### PR TITLE
feat(cloudflare): add logpush support to worker metadata and configuration

### DIFF
--- a/alchemy-web/src/content/docs/providers/cloudflare/worker.mdx
+++ b/alchemy-web/src/content/docs/providers/cloudflare/worker.mdx
@@ -818,6 +818,40 @@ only generate wrangler.json when you need to integrate with existing Wrangler-ba
 Alchemy's declarative approach eliminates the need for most wrangler.json configurations.
 :::
 
+### LogPush Configuration
+
+Enable Workers LogPush to send trace events to configured destinations:
+
+```ts
+const worker = await Worker("api", {
+  entrypoint: "./src/api.ts",
+  logpush: true,
+});
+```
+
+**Important**: Setting `logpush: true` only enables trace event collection. You must separately create a LogPush job using the Cloudflare API to specify where logs should be sent.
+
+#### Creating a LogPush Job
+
+LogPush jobs are created via the Cloudflare API. Here's an example using R2:
+
+```bash
+curl -X POST "https://api.cloudflare.com/client/v4/accounts/{account_id}/logpush/jobs" \
+  -H "Authorization: Bearer {api_token}" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "name": "workers-logpush",
+    "dataset": "workers_trace_events",
+    "destination_conf": "r2://{bucket}?account-id={account_id}&access-key-id={key}&secret-access-key={secret}",
+    "output_options": {
+      "field_names": ["Event", "EventTimestampMs", "Outcome", "ScriptName", "Logs"]
+    },
+    "enabled": true
+  }'
+```
+
+For more information, see the [Cloudflare LogPush documentation](https://developers.cloudflare.com/workers/observability/logging/logpush/).
+
 ## Troubleshooting (common issues)
 
 **Binding Resolution Errors:** Ensure bindings are configured in Worker definition.

--- a/alchemy/src/cloudflare/worker-metadata.ts
+++ b/alchemy/src/cloudflare/worker-metadata.ts
@@ -183,6 +183,7 @@ export interface WorkerMetadata {
   observability: {
     enabled: boolean;
   };
+  logpush?: boolean;
   migrations?: SingleStepMigration;
   main_module?: string;
   body_part?: string;
@@ -325,6 +326,7 @@ export async function prepareWorkerMetadata(
     observability: {
       enabled: props.observability?.enabled !== false,
     },
+    logpush: props.logpush ?? false,
     // TODO(sam): base64 encode instead? 0 collision risk vs readability.
     tags: [
       // encode a mapping table of Durable Object stable ID -> binding name

--- a/alchemy/src/cloudflare/worker.ts
+++ b/alchemy/src/cloudflare/worker.ts
@@ -180,6 +180,13 @@ export interface BaseWorkerProps<
   };
 
   /**
+   * Enable Workers LogPush for trace event export.
+   * Requires separate LogPush job configuration via Cloudflare API.
+   * @default false
+   */
+  logpush?: boolean;
+
+  /**
    * Whether to adopt the Worker if it already exists when creating
    */
   adopt?: boolean;

--- a/alchemy/src/cloudflare/wrangler.json.ts
+++ b/alchemy/src/cloudflare/wrangler.json.ts
@@ -162,6 +162,7 @@ export async function WranglerJson(
       : undefined,
     placement: worker.placement,
     limits: worker.limits,
+    logpush: worker.logpush,
   };
 
   // Process bindings if they exist
@@ -274,6 +275,15 @@ export interface WranglerJsonSpec {
   limits?: {
     cpu_ms?: number;
   };
+
+  /**
+   * Send Trace Events from this Worker to Workers Logpush.
+   *
+   * This will not configure a corresponding Logpush job automatically.
+   *
+   * @default false
+   */
+  logpush?: boolean;
 
   /**
    * Whether to enable a workers.dev URL for this worker

--- a/alchemy/test/cloudflare/worker-logpush.test.ts
+++ b/alchemy/test/cloudflare/worker-logpush.test.ts
@@ -1,0 +1,106 @@
+import { beforeAll, describe, expect } from "vitest";
+import { alchemy } from "../../src/alchemy.ts";
+import { createCloudflareApi } from "../../src/cloudflare/api.ts";
+import type { WorkerScriptMetadata } from "../../src/cloudflare/worker-metadata.ts";
+import { Worker } from "../../src/cloudflare/worker.ts";
+import { WranglerJson } from "../../src/cloudflare/wrangler.json.ts";
+import { destroy } from "../../src/destroy.ts";
+import "../../src/test/vitest.ts";
+import { BRANCH_PREFIX, waitFor } from "../util.ts";
+
+const test = alchemy.test(import.meta, {
+  prefix: BRANCH_PREFIX,
+});
+
+describe("Worker LogPush", () => {
+  const prefix = `${BRANCH_PREFIX}-lp`;
+  let api: Awaited<ReturnType<typeof createCloudflareApi>>;
+
+  beforeAll(async () => {
+    api = await createCloudflareApi();
+  });
+
+  const name = (s: string) => `${prefix}-${s}`;
+
+  async function makeWorker(suffix: string, opts: { logpush?: boolean } = {}) {
+    return Worker(name(suffix), {
+      entrypoint: "./alchemy/test/cloudflare/test-handlers/basic-fetch.ts",
+      logpush: opts.logpush,
+      url: false,
+      adopt: true,
+    });
+  }
+
+  async function serviceLogpush(workerName: string) {
+    const res = await api.get(
+      `/accounts/${api.accountId}/workers/services/${workerName}`,
+    );
+    if (!res.ok)
+      throw new Error(`Failed to fetch worker metadata: ${res.statusText}`);
+    const json = (await res.json()) as { result: WorkerScriptMetadata };
+    return json.result.default_environment?.script?.logpush;
+  }
+
+  test("enable-logpush-updates-cloudflare-metadata", async (scope) => {
+    let worker: Worker | undefined;
+    try {
+      worker = await makeWorker("metadata", { logpush: true });
+      expect(worker.logpush).toBe(true);
+
+      await waitFor(
+        async () => (await serviceLogpush(worker!.name)) === true,
+        (v) => v === true,
+        { timeoutMs: 10000, intervalMs: 500 },
+      );
+
+      worker = await makeWorker("metadata", { logpush: false });
+      expect(worker.logpush).toBe(false);
+
+      await waitFor(
+        async () => (await serviceLogpush(worker!.name)) === false,
+        (v) => v === true,
+        { timeoutMs: 10000, intervalMs: 500 },
+      );
+    } finally {
+      await destroy(scope);
+      if (worker?.name) {
+        const res = await api.get(
+          `/accounts/${api.accountId}/workers/services/${worker.name}`,
+        );
+        expect(res.status).toBe(404);
+      }
+    }
+  });
+
+  test("wrangler-json-logpush-field", async (scope) => {
+    try {
+      const worker = await makeWorker("wrangler-enabled", { logpush: true });
+      const wr = await WranglerJson({ worker, path: "./test-output" });
+      expect(wr.spec.logpush).toBe(true);
+    } finally {
+      await destroy(scope);
+    }
+  });
+
+  test("wrangler-json-default-unset", async (scope) => {
+    try {
+      const worker = await makeWorker("wrangler-default");
+      const wr = await WranglerJson({ worker, path: "./test-output" });
+      expect(wr.spec.logpush).toBeUndefined();
+    } finally {
+      await destroy(scope);
+    }
+  });
+
+  test("props-defaults", async (scope) => {
+    try {
+      const on = await makeWorker("enabled", { logpush: true });
+      expect(on.logpush).toBe(true);
+
+      const off = await makeWorker("default");
+      expect(off.logpush).toBeUndefined();
+    } finally {
+      await destroy(scope);
+    }
+  });
+});


### PR DESCRIPTION
**What changed:**
- `logpush` property now available in `WorkerMetadata` and `BaseWorkerProps`
- `prepareWorkerMetadata` handles Logpush config passthrough
- Tests cover Worker creation + Wrangler JSON output with Logpush enabled
- Docs updated with Logpush setup and gotchas

**Why:**
Lets you define Logpush destinations directly in Worker config instead of stitching it together post-deploy.

**How to use:**
```ts
// In your Worker props
const worker = new Worker(this, 'my-worker', {
  logpush: {
    destination: 'r2://my-bucket/logs',
    // ...
  },
});
```

**Test plan:**
- Unit tests for metadata prep + serialization
- Wrangler JSON output validated with snapshots
