### PR TITLE
chore(cloudflare): make PermissionGroups a function & improve error handling

### DIFF
--- a/alchemy/src/cloudflare/account-api-token.ts
+++ b/alchemy/src/cloudflare/account-api-token.ts
@@ -282,10 +282,7 @@ export const AccountApiToken = Resource(
       return this.destroy();
     }
 
-    const permissionGroups = await PermissionGroups(
-      "cloudflare-permission-groups",
-      props,
-    );
+    const permissionGroups = await PermissionGroups(props);
 
     // Transform our properties to API format
     const apiPayload = {

--- a/alchemy/test/cloudflare/permission-groups.test.ts
+++ b/alchemy/test/cloudflare/permission-groups.test.ts
@@ -10,12 +10,10 @@ const test = alchemy.test(import.meta, {
 });
 
 describe("PermissionGroups Resource", () => {
-  const testId = `${BRANCH_PREFIX}-permission-groups`;
-
   test("fetch and verify well-known permission groups", async (scope) => {
     try {
       // Fetch all permission groups
-      const permissionGroups = await PermissionGroups(testId);
+      const permissionGroups = await PermissionGroups();
 
       // Verify the resource has expected properties
       expect(permissionGroups).toBeTruthy();


### PR DESCRIPTION
`PermissionGroups` is a resource, but it should probably just be a function. It also doesn't log the full error message when there's a problem. Here's a quick fix.