### PR TITLE
docs(cloudflare): correct static assets link and cf pages references

### DIFF
--- a/alchemy-web/src/content/docs/providers/cloudflare/assets.md
+++ b/alchemy-web/src/content/docs/providers/cloudflare/assets.md
@@ -3,7 +3,7 @@ title: Assets
 description: Learn how to deploy and manage static assets on Cloudflare using Alchemy for optimal performance and delivery.
 ---
 
-The Assets resource lets you add [static assets](https://developers.cloudflare.com/workers/configuration/sites/) to your Cloudflare Workers.
+The Assets resource lets you add [static assets](https://developers.cloudflare.com/workers/static-assets/) to your Cloudflare Workers.
 
 ## Minimal Example
 

--- a/alchemy-web/src/content/docs/providers/cloudflare/nuxt.md
+++ b/alchemy-web/src/content/docs/providers/cloudflare/nuxt.md
@@ -1,9 +1,9 @@
 ---
 title: Nuxt
-description: Learn how to deploy Nuxt.js applications to Cloudflare Pages/Workers using Alchemy for a seamless experience.
+description: Learn how to deploy Nuxt.js applications to Cloudflare Workers using Alchemy for a seamless experience.
 ---
 
-Deploy a [Nuxt](https://nuxt.com) application to Cloudflare Pages with automatically configured defaults.
+Deploy a [Nuxt](https://nuxt.com) application to Cloudflare Workers with automatically configured defaults.
 
 ## Minimal Example
 

--- a/alchemy-web/src/content/docs/providers/cloudflare/redwood.md
+++ b/alchemy-web/src/content/docs/providers/cloudflare/redwood.md
@@ -1,9 +1,9 @@
 ---
 title: Redwood
-description: Learn how to deploy RedwoodJS applications to Cloudflare Pages/Workers using Alchemy for full-stack serverless.
+description: Learn how to deploy RedwoodJS applications to Cloudflare Workers using Alchemy for full-stack serverless.
 ---
 
-Deploy a RedwoodJS application to Cloudflare Pages with automatically configured defaults. This resource handles the deployment of RedwoodJS applications with optimized settings for Cloudflare Workers.
+Deploy a RedwoodJS application to Cloudflare Workers with automatically configured defaults. This resource handles the deployment of RedwoodJS applications with optimized settings for Cloudflare Workers.
 
 ## Minimal Example
 

--- a/alchemy-web/src/content/docs/providers/cloudflare/tanstack-start.md
+++ b/alchemy-web/src/content/docs/providers/cloudflare/tanstack-start.md
@@ -1,9 +1,9 @@
 ---
 title: TanStackStart
-description: Learn how to deploy TanStack Start applications to Cloudflare Workers using Alchemy for modern web development.
+description: Learn how to deploy TanStack Start applications to Cloudflare Workers using Alchemy.
 ---
 
-Deploy a TanStack Start application to Cloudflare Pages with automatically configured defaults.
+Deploy a TanStack Start application to Cloudflare Workers with automatically configured defaults.
 
 ## Minimal Example
 

--- a/alchemy-web/src/content/docs/providers/cloudflare/vite.md
+++ b/alchemy-web/src/content/docs/providers/cloudflare/vite.md
@@ -1,6 +1,6 @@
 ---
 title: Vite
-description: Learn how to deploy Vite.js applications to Cloudflare Pages/Workers using Alchemy for fast and efficient builds.
+description: Learn how to deploy Vite.js applications to Cloudflare Workers using Alchemy.
 ---
 
 Deploy a [Vite](https://vitejs.dev/) application to Cloudflare Workers with automatic configuration.

--- a/alchemy-web/src/content/docs/providers/cloudflare/website.md
+++ b/alchemy-web/src/content/docs/providers/cloudflare/website.md
@@ -1,9 +1,9 @@
 ---
 title: Website
-description: Learn how to deploy and manage Cloudflare Pages websites using Alchemy for static and dynamic site hosting.
+description: Learn how to deploy static and dynamic websites to Cloudflare Workers using Alchemy.
 ---
 
-The Website resource deploys a static website to Cloudflare Pages with an optional Worker for server-side functionality.
+The Website resource deploys a static website to Cloudflare Workers with an optional Worker for server-side functionality.
 
 ## Minimal Example
 

--- a/alchemy/src/cloudflare/redwood/redwood.ts
+++ b/alchemy/src/cloudflare/redwood/redwood.ts
@@ -12,7 +12,7 @@ export type Redwood<B extends Bindings> = B extends { ASSETS: any }
   : Worker<B & { ASSETS: Assets }>;
 
 /**
- * Deploy a RedwoodJS application to Cloudflare Pages with automatically configured defaults.
+ * Deploy a RedwoodJS application to Cloudflare Workers with automatically configured defaults.
  *
  * This resource handles the deployment of RedwoodJS applications with optimized settings for
  * Cloudflare Workers, including proper build commands and compatibility flags.


### PR DESCRIPTION
- Removed references to Cloudflare Pages
- Corrected link to static assets page
- Removed preachy adjectives from TanStack and Vite description