### PR TITLE
chore(posthog): remove legacy posthog service

### DIFF
--- a/alchemy-web/alchemy.run.ts
+++ b/alchemy-web/alchemy.run.ts
@@ -34,14 +34,6 @@ if (stage === "prod") {
   await Zone("alchemy-run", {
     name: "alchemy.run",
   });
-
-  await Worker("posthog-proxy", {
-    adopt: true,
-    name: "alchemy-posthog-proxy",
-    entrypoint: "src/proxy.ts",
-    domains: [POSTHOG_PROXY_HOST],
-    bindings: proxyBindings,
-  });
 }
 
 export const website = await Astro("website", {

--- a/alchemy-web/alchemy.run.ts
+++ b/alchemy-web/alchemy.run.ts
@@ -1,5 +1,5 @@
 import alchemy from "alchemy";
-import { Astro, Worker, Zone } from "alchemy/cloudflare";
+import { Astro, Zone } from "alchemy/cloudflare";
 import { GitHubComment } from "alchemy/github";
 import { CloudflareStateStore } from "alchemy/state";
 


### PR DESCRIPTION
now managed by https://github.com/alchemy-run/telemetry