### PR TITLE
fix: vite dev server hangs

### DIFF
--- a/alchemy/src/util/idempotent-spawn.ts
+++ b/alchemy/src/util/idempotent-spawn.ts
@@ -112,7 +112,7 @@ export async function idempotentSpawn({
     const child = spawn(cmd, {
       shell: true,
       cwd,
-      stdio: ["ignore", out.fd, out.fd], // stdout/stderr -> files (OS-level)
+      stdio: ["inherit", out.fd, out.fd], // stdout/stderr -> files (OS-level)
       env,
       detached: false,
     });


### PR DESCRIPTION
The TanStack Start dev server was getting stuck. Upon further inspection, I found that no logs were being recorded in our file. Running the vite dev server directly worked. Running within Alchemy without `idempotentSpawn` worked. So I kept removing things from `idempotentSpawn` until I narrowed it down to this.

I don't quite understand why this works but it does.