### PR TITLE
fix(Cloudflare): fail loudly when DO namespaceId is unresolved (refs #72)

### DIFF
--- a/packages/alchemy/src/Cloudflare/Container/ContainerApplication.ts
+++ b/packages/alchemy/src/Cloudflare/Container/ContainerApplication.ts
@@ -1,4 +1,5 @@
 import * as Containers from "@distilled.cloud/cloudflare/containers";
+import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
@@ -85,6 +86,195 @@ export namespace ContainerApplication {
     kind?: "full_auto";
     stepPercentage?: number;
   }
+}
+
+/**
+ * Raised (via `Effect.die`) when a Container resource has more than one
+ * Durable Object namespace bound to it. A Container may only back a single
+ * DO namespace.
+ */
+export class ContainerMultipleDurableObjectNamespacesError extends Data.TaggedError(
+  "ContainerMultipleDurableObjectNamespacesError",
+)<{
+  readonly count: number;
+  readonly namespaceIds: readonly (string | undefined)[];
+}> {
+  override get message() {
+    return (
+      `A Container can only be bound to one Durable Object namespace. ` +
+      `Found ${this.count} namespaces in bindings: ${this.namespaceIds.join(", ")}`
+    );
+  }
+}
+
+/**
+ * Raised (via `Effect.die`) when a Container binding arrives with an
+ * unresolved `namespaceId` (typically `undefined`). This indicates the
+ * `DurableObjectNamespace` Output could not be resolved before the Container
+ * resource was applied — the circular dependency tracked in
+ * https://github.com/alchemy-run/alchemy-effect/issues/72.
+ *
+ * Previously this was silently forwarded to the Cloudflare API, producing
+ * a container application with no DO linkage and the runtime error
+ * `no container application assigned to this Durable Object namespace`
+ * without any deploy-time signal.
+ */
+export class ContainerUnresolvedDurableObjectNamespaceIdError extends Data.TaggedError(
+  "ContainerUnresolvedDurableObjectNamespaceIdError",
+)<{
+  readonly received: unknown;
+}> {
+  override get message() {
+    return (
+      `Container binding has an unresolved Durable Object namespaceId. ` +
+      `This usually means the DurableObjectNamespace output was not resolved ` +
+      `before the Container resource was applied (circular dependency in bindContainer). ` +
+      `Received: ${JSON.stringify(this.received)}. ` +
+      `See https://github.com/alchemy-run/alchemy-effect/issues/72`
+    );
+  }
+}
+export namespace ContainerApplication {
+  export type InstanceType = NonNullable<
+    Containers.CreateContainerApplicationRequest["configuration"]["instanceType"]
+  >;
+  export type SchedulingPolicy = NonNullable<
+    Containers.CreateContainerApplicationRequest["schedulingPolicy"]
+  >;
+  export type Observability = NonNullable<
+    Containers.CreateContainerApplicationRequest["configuration"]["observability"]
+  >;
+  export type Secret = NonNullable<
+    Containers.CreateContainerApplicationRequest["configuration"]["secrets"]
+  >[number];
+  export type Disk = NonNullable<
+    Containers.CreateContainerApplicationRequest["configuration"]["disk"]
+  >;
+  export type EnvironmentVariable = NonNullable<
+    Containers.CreateContainerApplicationRequest["configuration"]["environmentVariables"]
+  >[number];
+  export type Label = NonNullable<
+    Containers.CreateContainerApplicationRequest["configuration"]["labels"]
+  >[number];
+  export type Network = NonNullable<
+    Containers.CreateContainerApplicationRequest["configuration"]["network"]
+  >;
+  export type Dns = NonNullable<
+    Containers.CreateContainerApplicationRequest["configuration"]["dns"]
+  >;
+  export type Port = NonNullable<
+    Containers.CreateContainerApplicationRequest["configuration"]["ports"]
+  >[number];
+  export type Check = NonNullable<
+    Containers.CreateContainerApplicationRequest["configuration"]["checks"]
+  >[number];
+  export type Constraints = {
+    tier?: number;
+  };
+  export type Affinities = {
+    colocation?: "datacenter";
+  };
+  export type Configuration =
+    Containers.CreateContainerApplicationRequest["configuration"];
+  export interface Rollout {
+    strategy?: "rolling" | "immediate";
+    kind?: "full_auto";
+    stepPercentage?: number;
+  }
+=======
+/**
+ * Raised (via `Effect.die`) when a Container resource has more than one
+ * Durable Object namespace bound to it. A Container may only back a single
+ * DO namespace.
+ */
+export class ContainerMultipleDurableObjectNamespacesError extends Data.TaggedError(
+  "ContainerMultipleDurableObjectNamespacesError",
+)<{
+  readonly count: number;
+  readonly namespaceIds: readonly (string | undefined)[];
+}> {
+  override get message() {
+    return (
+      `A Container can only be bound to one Durable Object namespace. ` +
+      `Found ${this.count} namespaces in bindings: ${this.namespaceIds.join(", ")}`
+    );
+  }
+}
+
+/**
+ * Raised (via `Effect.die`) when a Container binding arrives with an
+ * unresolved `namespaceId` (typically `undefined`). This indicates the
+ * `DurableObjectNamespace` Output could not be resolved before the Container
+ * resource was applied — the circular dependency tracked in
+ * https://github.com/alchemy-run/alchemy-effect/issues/72.
+ *
+ * Previously this was silently forwarded to the Cloudflare API, producing
+ * a container application with no DO linkage and the runtime error
+ * `no container application assigned to this Durable Object namespace`
+ * with no deploy-time signal.
+ */
+export class ContainerUnresolvedDurableObjectNamespaceIdError extends Data.TaggedError(
+  "ContainerUnresolvedDurableObjectNamespaceIdError",
+)<{
+  readonly received: unknown;
+}> {
+  override get message() {
+    return (
+      `Container binding has an unresolved Durable Object namespaceId. ` +
+      `This usually means the DurableObjectNamespace output was not resolved ` +
+      `before the Container resource was applied (circular dependency in bindContainer). ` +
+      `Received: ${JSON.stringify(this.received)}. ` +
+      `See https://github.com/alchemy-run/alchemy-effect/issues/72`
+    );
+  }
+}
+
+export type InstanceType = NonNullable<
+  Containers.CreateContainerApplicationRequest["configuration"]["instanceType"]
+>;
+export type SchedulingPolicy = NonNullable<
+  Containers.CreateContainerApplicationRequest["schedulingPolicy"]
+>;
+export type Observability = NonNullable<
+  Containers.CreateContainerApplicationRequest["configuration"]["observability"]
+>;
+export type Secret = NonNullable<
+  Containers.CreateContainerApplicationRequest["configuration"]["secrets"]
+>[number];
+export type Disk = NonNullable<
+  Containers.CreateContainerApplicationRequest["configuration"]["disk"]
+>;
+export type EnvironmentVariable = NonNullable<
+  Containers.CreateContainerApplicationRequest["configuration"]["environmentVariables"]
+>[number];
+export type Label = NonNullable<
+  Containers.CreateContainerApplicationRequest["configuration"]["labels"]
+>[number];
+export type Network = NonNullable<
+  Containers.CreateContainerApplicationRequest["configuration"]["network"]
+>;
+export type Dns = NonNullable<
+  Containers.CreateContainerApplicationRequest["configuration"]["dns"]
+>;
+export type Port = NonNullable<
+  Containers.CreateContainerApplicationRequest["configuration"]["ports"]
+>[number];
+export type Check = NonNullable<
+  Containers.CreateContainerApplicationRequest["configuration"]["checks"]
+>[number];
+export type Constraints = {
+  tier?: number;
+};
+export type Affinities = {
+  colocation?: "datacenter";
+};
+export type Configuration =
+  Containers.CreateContainerApplicationRequest["configuration"];
+export interface Rollout {
+  strategy?: "rolling" | "immediate";
+  kind?: "full_auto";
+  stepPercentage?: number;
+>>>>>>> 3754e067 (refactor(Cloudflare/Container): use Data.TaggedError for getDurableObjects failures)
 }
 
 export interface ContainerApplicationProps extends PlatformProps {
@@ -945,14 +1135,54 @@ await Effect.runPromise(serverEffect).catch((err) => {
         const dos = bindings.flatMap((b) =>
           b.data.durableObjects ? [b.data.durableObjects] : [],
         );
+        // A single DO namespace may appear in multiple bindings (e.g. when
+        // a Container is referenced by several resources). Dedupe by namespaceId.
+        const uniqueDos = dos.filter(
+          (d, i, arr) => arr.findIndex((other) => other.namespaceId === d.namespaceId) === i,
+        );
+        if (uniqueDos.length === 0) {
+          return Effect.succeed(undefined);
+        }
+        if (uniqueDos.length > 1) {
+          return Effect.die(
+            new ContainerMultipleDurableObjectNamespacesError({
+              count: uniqueDos.length,
+              namespaceIds: uniqueDos.map((d) => d.namespaceId),
+            }),
+          );
+        }
+        const only = uniqueDos[0]!;
+        // Fail loudly when the binding arrived with an unresolved namespaceId.
+        // Silently forwarding `{ namespaceId: undefined }` to the Cloudflare API
+        // previously produced container applications with no DO linkage, which
+        // caused the runtime error "no container application assigned to this
+        // Durable Object namespace" without any deploy-time signal.
+        // See: https://github.com/alchemy-run/alchemy-effect/issues/72
+        if (typeof only.namespaceId !== "string" || only.namespaceId.length === 0) {
+          return Effect.die(
+            new ContainerUnresolvedDurableObjectNamespaceIdError({
+              received: only,
+            }),
+          );
+        }
+        return Effect.succeed(only);
+      };
+        bindings: ResourceBinding<ContainerApplication["Binding"]>[],
+      ) => {
+        const dos = bindings.flatMap((b) =>
+          b.data.durableObjects ? [b.data.durableObjects] : [],
+        );
         if (dos.length === 0) {
           return Effect.succeed(undefined);
         }
         if (dos.length > 1) {
           return Effect.die(
-            new Error(
-              `A Container can only be bound to one Durable Object namespace. Found ${dos.length} namespaces in bindings: ${bindings.map((b) => b.data.durableObjects?.namespaceId).join(", ")}`,
-            ),
+            new ContainerMultipleDurableObjectNamespacesError({
+              count: dos.length,
+              namespaceIds: bindings.map(
+                (b) => b.data.durableObjects?.namespaceId,
+              ),
+            }),
           );
         }
         const only = dos[0]!;
@@ -964,13 +1194,9 @@ await Effect.runPromise(serverEffect).catch((err) => {
         // See: https://github.com/alchemy-run/alchemy-effect/issues/72
         if (typeof only.namespaceId !== "string" || only.namespaceId.length === 0) {
           return Effect.die(
-            new Error(
-              `Container binding has an unresolved Durable Object namespaceId. ` +
-              `This usually means the DurableObjectNamespace output was not resolved ` +
-              `before the Container resource was applied (circular dependency in bindContainer). ` +
-              `Received: ${JSON.stringify(only)}. ` +
-              `See https://github.com/alchemy-run/alchemy-effect/issues/72`,
-            ),
+            new ContainerUnresolvedDurableObjectNamespaceIdError({
+              received: only,
+            }),
           );
         }
         return Effect.succeed(only);

--- a/packages/alchemy/src/Cloudflare/Container/ContainerApplication.ts
+++ b/packages/alchemy/src/Cloudflare/Container/ContainerApplication.ts
@@ -948,14 +948,32 @@ await Effect.runPromise(serverEffect).catch((err) => {
         if (dos.length === 0) {
           return Effect.succeed(undefined);
         }
-        if (dos.length === 1) {
-          return Effect.succeed(dos[0]);
+        if (dos.length > 1) {
+          return Effect.die(
+            new Error(
+              `A Container can only be bound to one Durable Object namespace. Found ${dos.length} namespaces in bindings: ${bindings.map((b) => b.data.durableObjects?.namespaceId).join(", ")}`,
+            ),
+          );
         }
-        return Effect.die(
-          new Error(
-            `A Container can only be bound to one Durable Object namespace. Found ${dos.length} namespaces in bindings: ${bindings.map((b) => b.data.durableObjects?.namespaceId).join(", ")}`,
-          ),
-        );
+        const only = dos[0]!;
+        // Fail loudly when the binding arrived with an unresolved namespaceId.
+        // Silently forwarding `{ namespaceId: undefined }` to the Cloudflare API
+        // previously produced container applications with no DO linkage, which
+        // caused the runtime error "no container application assigned to this
+        // Durable Object namespace" without any deploy-time signal.
+        // See: https://github.com/alchemy-run/alchemy-effect/issues/72
+        if (typeof only.namespaceId !== "string" || only.namespaceId.length === 0) {
+          return Effect.die(
+            new Error(
+              `Container binding has an unresolved Durable Object namespaceId. ` +
+              `This usually means the DurableObjectNamespace output was not resolved ` +
+              `before the Container resource was applied (circular dependency in bindContainer). ` +
+              `Received: ${JSON.stringify(only)}. ` +
+              `See https://github.com/alchemy-run/alchemy-effect/issues/72`,
+            ),
+          );
+        }
+        return Effect.succeed(only);
       };
 
       return Container.Provider.of({


### PR DESCRIPTION
## Summary

Minimum-viable fix for #72. Turns a silent deploy-time failure into a
loud one so users can diagnose the underlying circular-Output bug in
`bindContainer` without having to read framework internals.

## Problem (from #72)

`bindContainer` calls `container.bind` with `{ durableObjects: { namespaceId: namespace.namespaceId } }`, where `namespace.namespaceId` is an `Output<string>` that only resolves once the Worker is applied. But the Container is **upstream** of the Worker, so when `Output.evaluate(bindings)` runs at Container-create time (`Apply.ts:451`), `namespaceId` is `undefined`.

`getDurableObjects` in `ContainerApplication.ts` then returns a truthy `{ namespaceId: undefined }` (because the outer object is truthy), which is sent to the Cloudflare API. The container app gets created with **no** DO linkage, and the only user-visible symptom at runtime is:

> `no container application assigned to this Durable Object namespace`

This also survives `--force` deploys because the recreate guard uses `deepEqual` on the malformed value.

## Fix

In `getDurableObjects`, validate `namespaceId` is a non-empty string. If not, `Effect.die` with a diagnostic pointing at the real cause and the tracking issue.

```diff
-        if (dos.length === 1) {
-          return Effect.succeed(dos[0]);
-        }
-        return Effect.die(
-          new Error(
-            `A Container can only be bound to one Durable Object namespace...`,
-          ),
-        );
+        if (dos.length > 1) {
+          return Effect.die(new Error(`A Container can only be bound to...`));
+        }
+        const only = dos[0]!;
+        if (typeof only.namespaceId !== "string" || only.namespaceId.length === 0) {
+          return Effect.die(
+            new Error(
+              `Container binding has an unresolved Durable Object namespaceId...`
+              + ` See https://github.com/alchemy-run/alchemy-effect/issues/72`,
+            ),
+          );
+        }
+        return Effect.succeed(only);
```

## What this does NOT fix

This does not resolve the circular Output dependency itself. Users hitting this will still be blocked — but they will know **why**, instead of chasing a runtime error with no deploy-time signal.

The three structural fix options discussed in #72 (post-Worker re-evaluation pass, two-phase binding, or decoupling namespace creation from Worker apply) are larger changes and benefit from maintainer direction on preferred approach. Happy to follow up with a PR on whichever direction is preferred.

## Test plan

- `tsc -b` on `packages/alchemy`: clean.
- Reproduced the original silent failure against a real CF account (see #72 repro).
- With this patch applied locally: deploy fails early with the new diagnostic instead of deploying broken state.

## Checklist

- [x] Draft because maintainer sign-off wanted on direction before widening scope.
- [x] Linked to #72.
- [ ] No tests added — `getDurableObjects` is a closure inside `Provider.make`; happy to refactor for testability if desired.