### PR TITLE
docs(Cloudflare): add paired-DO container example reproducing #72

### DIFF
--- a/examples/cloudflare-worker-paired-do/README.md
+++ b/examples/cloudflare-worker-paired-do/README.md
@@ -1,0 +1,87 @@
+# cloudflare-worker-paired-do
+
+**Minimal repro for [issue #72](https://github.com/alchemy-run/alchemy-effect/issues/72) — Container app deploys without DO namespace linkage due to circular `Output<T>` dependency in `bindContainer`.**
+
+This example demonstrates the **paired-DO pattern** that real-world projects adopt when they need to:
+
+1. Put container runtime code in a **separate file** from the `Container` resource declaration (so the DO-side bundle doesn't pull in heavy runtime deps like `sharp`, `impit`, `playwright`).
+2. Declare the `DurableObjectNamespace` as a **separate, explicit alchemy resource** (so a different Worker / different resource graph can bind to it without re-declaring the Container).
+
+## Contrast with canonical `examples/cloudflare-worker` (Sandbox/Agent)
+
+The canonical example inlines container runtime + DO binding:
+
+```ts
+// Sandbox.ts — Container class AND runtime in same file
+class Sandbox extends Cloudflare.Container<Sandbox, {...}>()("Sandbox", {
+  main: import.meta.filename,   // self-reference
+  ...
+}) {}
+export default Sandbox.make(Effect.gen(function* () { return Sandbox.of({ ... }) }))
+
+// Agent.ts — DO binds Container directly in its body
+class Agent extends Cloudflare.DurableObjectNamespace<Agent>()("Agents",
+  Effect.gen(function* () {
+    const sandbox = yield* Cloudflare.Container.bind(Sandbox)
+    return Effect.gen(function* () { /* handler */ })
+  }),
+) {}
+```
+
+This example splits them:
+
+```ts
+// src/MyContainer.ts — Container class only, NO .make() here
+class MyContainer extends Cloudflare.Container<MyContainer>()("MyContainerApp", {
+  main: "./src/container-runtime/server.ts",   // separate file
+  ...
+}) {}
+
+// src/container-runtime/server.ts — runtime in dedicated file
+export default MyContainer.make(Effect.gen(function* () { ... }))
+
+// src/MyContainerDO.ts — paired DO resource with DIFFERENT LogicalId
+class MyContainerDO extends Cloudflare.DurableObjectNamespace<MyContainerDO>()("MyContainer",
+  Effect.gen(function* () {
+    const container = yield* Cloudflare.Container.bind(MyContainer)
+    /* handler */
+  }),
+) {}
+```
+
+## Why the LogicalIds differ
+
+`Container` and `DurableObjectNamespace` both call `worker.bind` internally during construction. `Diff.ts` deduplicates `ResourceBinding[]` by `sid` with **last-write-wins** semantics. If both use LogicalId `"MyContainer"`, the DO namespace binding gets silently clobbered by the Container's binding, and runtime errors with `DurableObjectNamespace 'MyContainer' not found`.
+
+The workaround: suffix the Container LogicalId with `App` (or any unique tag). The `className:` (= actual CF-side DO class name) remains `MyContainer` (comes from the class declaration), so runtime binding still resolves correctly — it's only the alchemy-internal `sid` that differs.
+
+## The bug (issue #72)
+
+When you deploy this example:
+
+- Deploy reports success for both `MyContainerApp` (Container) and `MyContainer` (DO namespace).
+- State file `.alchemy/state/<app>/<stage>/MyContainerApp.json` contains `durableObjects: null` (or `{}`) — the FK from the Container app to the DO namespace is silently missing.
+- At runtime, calling the DO method that triggers `container.start()` errors with: `Error: no container application assigned to this Durable Object namespace`.
+
+Root cause: circular `Output<T>` dependency between `Container.bind` (needs the DO's namespaceId) and the DO's own namespace (doesn't resolve until after the Container app references it).
+
+## Reproduce
+
+```bash
+bun install
+bun run deploy
+curl https://<worker>.workers.dev/hello   # triggers DO.fetch() → container.start() → ERROR
+```
+
+Inspect the state to confirm the missing linkage:
+
+```bash
+cat .alchemy/state/CloudflareWorkerPairedDOExample/<stage>/MyContainerApp.json | jq '.durableObjects'
+# Expected (for correct linkage): { "namespace_id": "...", ... }
+# Actual (with bug):               null
+```
+
+## Related
+
+- [Issue #72](https://github.com/alchemy-run/alchemy-effect/issues/72) — root bug report
+- [PR #73](https://github.com/alchemy-run/alchemy-effect/pull/73) — minimum-viable fix: convert silent failure → loud diagnostic via `Effect.die` when resolved `namespaceId` is missing/empty. Does NOT fix the underlying circular dependency; just surfaces it at deploy time.

--- a/examples/cloudflare-worker-paired-do/alchemy.run.ts
+++ b/examples/cloudflare-worker-paired-do/alchemy.run.ts
@@ -1,0 +1,19 @@
+import * as Alchemy from "alchemy";
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+
+import Api from "./src/Api.ts";
+
+export default Alchemy.Stack(
+  "CloudflareWorkerPairedDOExample",
+  {
+    providers: Cloudflare.providers(),
+  },
+  Effect.gen(function* () {
+    const api = yield* Api;
+
+    return {
+      url: api.url.as<string>(),
+    };
+  }),
+);

--- a/examples/cloudflare-worker-paired-do/package.json
+++ b/examples/cloudflare-worker-paired-do/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "cloudflare-worker-paired-do",
+  "version": "0.0.0",
+  "private": true,
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/alchemy-run/alchemy"
+  },
+  "type": "module",
+  "scripts": {
+    "deploy": "alchemy deploy",
+    "dev": "alchemy dev",
+    "destroy": "alchemy destroy",
+    "logs": "alchemy logs",
+    "tail": "alchemy tail"
+  },
+  "dependencies": {
+    "@effect/platform-bun": "catalog:",
+    "@effect/platform-node": "catalog:",
+    "alchemy": "workspace:*",
+    "effect": "catalog:"
+  }
+}

--- a/examples/cloudflare-worker-paired-do/src/Api.ts
+++ b/examples/cloudflare-worker-paired-do/src/Api.ts
@@ -1,0 +1,48 @@
+/**
+ * Api worker — calls the paired DO which tries to start the Container.
+ *
+ * The critical wiring is `const containers = yield* MyContainerDO;` which
+ * injects the DO stub. Invoking `containers.getByName(...).hello()` at runtime
+ * will hit the bug: the DO body's `Cloudflare.Container.bind(MyContainer)` is
+ * missing its FK linkage to the Container app because of the circular Output
+ * dependency documented in issue #72.
+ */
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import MyContainerDO from "./MyContainerDO.ts";
+
+export default class Api extends Cloudflare.Worker<Api>()(
+  "Api",
+  {
+    main: import.meta.path,
+    observability: {
+      enabled: true,
+    },
+  },
+  Effect.gen(function* () {
+    const containers = yield* MyContainerDO;
+
+    return {
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        const url = new URL(request.url, "http://localhost");
+
+        if (url.pathname === "/hello") {
+          const stub = containers.getByName("default");
+          const body = yield* stub.hello().pipe(Effect.orDie);
+          return HttpServerResponse.text(body);
+        }
+
+        if (url.pathname === "/health") {
+          const stub = containers.getByName("default");
+          const body = yield* stub.health().pipe(Effect.orDie);
+          return HttpServerResponse.text(body);
+        }
+
+        return HttpServerResponse.text("Not Found", { status: 404 });
+      }),
+    };
+  }),
+) {}

--- a/examples/cloudflare-worker-paired-do/src/MyContainer.ts
+++ b/examples/cloudflare-worker-paired-do/src/MyContainer.ts
@@ -1,0 +1,40 @@
+/**
+ * MyContainer — Container resource declaration ONLY.
+ *
+ * This file intentionally does NOT call `.make(Effect.gen(...))`. The runtime
+ * lives in `./container-runtime/server.ts`. This split is the whole point of
+ * the paired-DO pattern — real-world projects put heavy runtime deps (e.g.
+ * `sharp`, `impit`, `playwright`) in the dedicated runtime file so the DO-side
+ * bundle stays lean and the container bundle is built from a different entry.
+ *
+ * Note the LogicalId `"MyContainerApp"` — it differs from the DO's LogicalId
+ * `"MyContainer"` (see ./MyContainerDO.ts) to avoid a `sid` collision in
+ * `Diff.ts`'s last-write-wins binding dedup (see README.md "Why the LogicalIds
+ * differ" section). The `className:` is omitted; alchemy derives the actual
+ * CF-side DO class name from the TypeScript class name `MyContainer`.
+ */
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+
+export class MyContainer extends Cloudflare.Container<
+  MyContainer,
+  {
+    /**
+     * Tiny container-side effect: return a greeting.
+     * (Kept trivial on purpose — the whole point of this repro is the DO
+     * linkage, not the container's work.)
+     */
+    hello: () => Effect.Effect<string>;
+  }
+>()("MyContainerApp", {
+  // SPLIT RUNTIME: main points to a separate file, NOT `import.meta.filename`.
+  // This is the pattern real projects adopt when container runtime has heavy
+  // deps that shouldn't be pulled into the DO-side bundle.
+  main: "./src/container-runtime/server.ts",
+  instanceType: "dev",
+  observability: {
+    logs: {
+      enabled: true,
+    },
+  },
+}) {}

--- a/examples/cloudflare-worker-paired-do/src/MyContainerDO.ts
+++ b/examples/cloudflare-worker-paired-do/src/MyContainerDO.ts
@@ -1,0 +1,55 @@
+/**
+ * MyContainerDO — Paired DurableObjectNamespace resource.
+ *
+ * This is the pattern that triggers issue #72: a SEPARATE, EXPLICIT
+ * `DurableObjectNamespace` resource (not inlined into the Container class) with
+ * a DIFFERENT LogicalId ("MyContainer" here, vs "MyContainerApp" on the
+ * Container). The LogicalId mismatch is mandatory to avoid `sid` collision in
+ * `Diff.ts`'s last-write-wins binding dedup — see README.md.
+ *
+ * The DO body uses `Cloudflare.Container.bind(MyContainer)` to establish the
+ * FK linkage from Container app → DO namespace. THIS is where the bug fires:
+ * the `bindContainer` call graph pulls `namespaceId` as an `Output<T>`, but the
+ * DO's namespace hasn't resolved yet when Container tries to reference it,
+ * producing a circular Output dependency. Deploy silently succeeds with the
+ * linkage missing (`durableObjects: null` in state); runtime then errors
+ * `no container application assigned to this Durable Object namespace`.
+ */
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import { MyContainer } from "./MyContainer.ts";
+
+export default class MyContainerDO extends Cloudflare.DurableObjectNamespace<MyContainerDO>()(
+  // NOTE: LogicalId "MyContainer" differs from Container's "MyContainerApp".
+  // See README — this is the `sid` collision workaround.
+  "MyContainer",
+  Effect.gen(function* () {
+    const myContainer = yield* Cloudflare.Container.bind(MyContainer);
+
+    return Effect.gen(function* () {
+      const container = yield* Cloudflare.start(myContainer);
+
+      return {
+        hello: () => container.hello(),
+        health: () =>
+          Effect.gen(function* () {
+            const { fetch } = yield* container.getTcpPort(3000);
+            const response = yield* fetch(
+              HttpClientRequest.get("http://container/health"),
+            );
+            return yield* response.text;
+          }),
+        fetch: Effect.gen(function* () {
+          const { fetch } = yield* container.getTcpPort(3000);
+          const response = yield* fetch(
+            HttpClientRequest.get("http://container/"),
+          );
+          const body = yield* response.text;
+          return HttpServerResponse.text(body);
+        }),
+      };
+    });
+  }),
+) {}

--- a/examples/cloudflare-worker-paired-do/src/container-runtime/server.ts
+++ b/examples/cloudflare-worker-paired-do/src/container-runtime/server.ts
@@ -1,0 +1,35 @@
+/**
+ * Container runtime — default-exports `MyContainer.make(Effect.gen(...))`.
+ *
+ * This file is pointed-to by `MyContainer`'s `main:` option. Alchemy bundles it
+ * separately from the DO-side entry. In real projects this is where the heavy
+ * runtime deps live (sharp, impit, playwright) — deps that must be installed
+ * INSIDE the container image (via `external: [...]`) but never pulled into the
+ * worker/DO bundle.
+ */
+import * as Effect from "effect/Effect";
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import { MyContainer } from "../MyContainer.ts";
+
+export default MyContainer.make(
+  Effect.gen(function* () {
+    let counter = 0;
+
+    return MyContainer.of({
+      hello: () => Effect.succeed(`Hello from container (counter=${counter})`),
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        const url = new URL(request.url, "http://localhost");
+        if (url.pathname === "/health") {
+          return HttpServerResponse.jsonUnsafe({ status: "ok" });
+        }
+        if (url.pathname === "/increment") {
+          counter++;
+          return HttpServerResponse.jsonUnsafe({ counter });
+        }
+        return HttpServerResponse.text("Hello from paired-DO container!");
+      }),
+    });
+  }),
+);

--- a/examples/cloudflare-worker-paired-do/tsconfig.json
+++ b/examples/cloudflare-worker-paired-do/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["alchemy.run.ts", "src/**/*.ts", "test/**/*.ts"],
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "module": "Preserve",
+    "moduleResolution": "Bundler",
+    "target": "ESNext"
+  },
+  "references": [
+    {
+      "path": "../../packages/alchemy/tsconfig.json"
+    }
+  ]
+}


### PR DESCRIPTION
Minimal repro for #72.

Pattern: Container + paired `DurableObjectNamespace` as separate resources, container runtime in a split file (`container-runtime/server.ts` via `main:`). Deploy succeeds, state shows `durableObjects: null`, runtime: `no container application assigned to this Durable Object namespace`.

Also documents the mandatory LogicalId mismatch (`MyContainerApp` vs `MyContainer`) to dodge `Diff.ts` last-write-wins `sid` dedup.

Complements #73 (fail-loud via `Effect.die`). Does not fix the underlying circular `Output<T>`.

`tsc --noEmit` clean. Not deployed — README has the repro recipe.