### PR TITLE
feat(drizzle): expose vanilla node-postgres client on Drizzle.postgres

### DIFF
--- a/packages/alchemy/src/Drizzle/Postgres.ts
+++ b/packages/alchemy/src/Drizzle/Postgres.ts
@@ -2,6 +2,10 @@ import * as PgClient from "@effect/sql-pg/PgClient";
 import type { AnyRelations, EmptyRelations } from "drizzle-orm";
 import type { EffectPgDatabase } from "drizzle-orm/effect-postgres";
 import * as PgDrizzle from "drizzle-orm/effect-postgres";
+import {
+  drizzle as nodePgDrizzle,
+  type NodePgDatabase,
+} from "drizzle-orm/node-postgres";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Redacted from "effect/Redacted";
@@ -39,9 +43,22 @@ import { proxyChain } from "../Util/proxy-chain.ts";
  * would fire there and every subsequent request would see "Cannot
  * use a pool after end".
  *
+ * The returned object also exposes a `.raw` Effect that resolves to a
+ * vanilla `drizzle-orm/node-postgres` instance backed by the same
+ * connection string. Use it for libraries that expect a regular
+ * promise-shaped drizzle (e.g. better-auth's `drizzleAdapter`):
+ *
+ * ```typescript
+ * const db = yield* Drizzle.postgres(hd.connectionString);
+ * const raw = yield* db.raw;
+ *
+ * const auth = betterAuth({
+ *   database: drizzleAdapter(raw, { provider: "pg", schema }),
+ * });
+ * ```
+ *
  * @binding
  */
-
 export const postgres = <
   TRelations extends AnyRelations = EmptyRelations,
   E = never,
@@ -51,28 +68,49 @@ export const postgres = <
   config?: PgDrizzle.EffectDrizzlePgConfig<TRelations>,
 ) =>
   Effect.sync(function () {
-    const symbol = Symbol();
+    const effectSymbol = Symbol();
+    const rawSymbol = Symbol();
 
-    return proxyChain<
+    const effectDb = proxyChain<
       EffectPgDatabase<TRelations> & {
         $client: PgClient.PgClient;
       }
     >(
       Effect.gen(function* () {
         const ctx = yield* ExecutionContext;
-        return yield* (ctx.cache[symbol] ??= yield* Effect.gen(function* () {
-          const pgCtx = yield* Layer.buildWithScope(
-            PgClient.layer({ url: yield* connectionString }),
-            ctx.scope,
-          );
-          return yield* PgDrizzle.makeWithDefaults(config).pipe(
-            Effect.provideContext(pgCtx),
-          );
-        }).pipe(Effect.cached));
+        return yield* (ctx.cache[effectSymbol] ??= yield* Effect.gen(
+          function* () {
+            const pgCtx = yield* Layer.buildWithScope(
+              PgClient.layer({ url: yield* connectionString }),
+              ctx.scope,
+            );
+            return yield* PgDrizzle.makeWithDefaults(config).pipe(
+              Effect.provideContext(pgCtx),
+            );
+          },
+        ).pipe(Effect.cached));
       }) as Effect.Effect<
         EffectPgDatabase<TRelations> & {
           $client: PgClient.PgClient;
         }
       >,
     );
+
+    const raw = Effect.gen(function* () {
+      const ctx = yield* ExecutionContext;
+      return yield* (ctx.cache[rawSymbol] ??= yield* Effect.gen(function* () {
+        const url = Redacted.value(yield* connectionString);
+        return nodePgDrizzle<TRelations>(url);
+      }).pipe(Effect.cached));
+    }) as Effect.Effect<NodePgDatabase<TRelations>, E, R | ExecutionContext>;
+
+    return new Proxy(effectDb as any, {
+      get(target, prop, receiver) {
+        if (prop === "raw") return raw;
+        return Reflect.get(target, prop, receiver);
+      },
+    }) as EffectPgDatabase<TRelations> & {
+      $client: PgClient.PgClient;
+      raw: Effect.Effect<NodePgDatabase<TRelations>, E, R | ExecutionContext>;
+    };
   });

--- a/packages/alchemy/src/Drizzle/Postgres.ts
+++ b/packages/alchemy/src/Drizzle/Postgres.ts
@@ -2,10 +2,6 @@ import * as PgClient from "@effect/sql-pg/PgClient";
 import type { AnyRelations, EmptyRelations } from "drizzle-orm";
 import type { EffectPgDatabase } from "drizzle-orm/effect-postgres";
 import * as PgDrizzle from "drizzle-orm/effect-postgres";
-import {
-  drizzle as nodePgDrizzle,
-  type NodePgDatabase,
-} from "drizzle-orm/node-postgres";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Redacted from "effect/Redacted";
@@ -43,22 +39,9 @@ import { proxyChain } from "../Util/proxy-chain.ts";
  * would fire there and every subsequent request would see "Cannot
  * use a pool after end".
  *
- * The returned object also exposes a `.raw` Effect that resolves to a
- * vanilla `drizzle-orm/node-postgres` instance backed by the same
- * connection string. Use it for libraries that expect a regular
- * promise-shaped drizzle (e.g. better-auth's `drizzleAdapter`):
- *
- * ```typescript
- * const db = yield* Drizzle.postgres(hd.connectionString);
- * const raw = yield* db.raw;
- *
- * const auth = betterAuth({
- *   database: drizzleAdapter(raw, { provider: "pg", schema }),
- * });
- * ```
- *
  * @binding
  */
+
 export const postgres = <
   TRelations extends AnyRelations = EmptyRelations,
   E = never,
@@ -68,49 +51,28 @@ export const postgres = <
   config?: PgDrizzle.EffectDrizzlePgConfig<TRelations>,
 ) =>
   Effect.sync(function () {
-    const effectSymbol = Symbol();
-    const rawSymbol = Symbol();
+    const symbol = Symbol();
 
-    const effectDb = proxyChain<
+    return proxyChain<
       EffectPgDatabase<TRelations> & {
         $client: PgClient.PgClient;
       }
     >(
       Effect.gen(function* () {
         const ctx = yield* ExecutionContext;
-        return yield* (ctx.cache[effectSymbol] ??= yield* Effect.gen(
-          function* () {
-            const pgCtx = yield* Layer.buildWithScope(
-              PgClient.layer({ url: yield* connectionString }),
-              ctx.scope,
-            );
-            return yield* PgDrizzle.makeWithDefaults(config).pipe(
-              Effect.provideContext(pgCtx),
-            );
-          },
-        ).pipe(Effect.cached));
+        return yield* (ctx.cache[symbol] ??= yield* Effect.gen(function* () {
+          const pgCtx = yield* Layer.buildWithScope(
+            PgClient.layer({ url: yield* connectionString }),
+            ctx.scope,
+          );
+          return yield* PgDrizzle.makeWithDefaults(config).pipe(
+            Effect.provideContext(pgCtx),
+          );
+        }).pipe(Effect.cached));
       }) as Effect.Effect<
         EffectPgDatabase<TRelations> & {
           $client: PgClient.PgClient;
         }
       >,
     );
-
-    const raw = Effect.gen(function* () {
-      const ctx = yield* ExecutionContext;
-      return yield* (ctx.cache[rawSymbol] ??= yield* Effect.gen(function* () {
-        const url = Redacted.value(yield* connectionString);
-        return nodePgDrizzle<TRelations>(url);
-      }).pipe(Effect.cached));
-    }) as Effect.Effect<NodePgDatabase<TRelations>, E, R | ExecutionContext>;
-
-    return new Proxy(effectDb as any, {
-      get(target, prop, receiver) {
-        if (prop === "raw") return raw;
-        return Reflect.get(target, prop, receiver);
-      },
-    }) as EffectPgDatabase<TRelations> & {
-      $client: PgClient.PgClient;
-      raw: Effect.Effect<NodePgDatabase<TRelations>, E, R | ExecutionContext>;
-    };
   });

--- a/packages/alchemy/src/Drizzle/PostgresRaw.ts
+++ b/packages/alchemy/src/Drizzle/PostgresRaw.ts
@@ -1,0 +1,48 @@
+import type { AnyRelations, EmptyRelations } from "drizzle-orm";
+import {
+  drizzle as nodePgDrizzle,
+  type NodePgDatabase,
+} from "drizzle-orm/node-postgres";
+import * as Effect from "effect/Effect";
+import * as Redacted from "effect/Redacted";
+import { ExecutionContext } from "../ExecutionContext.ts";
+
+/**
+ * Open a vanilla `drizzle-orm/node-postgres` database from a connection
+ * URL. Returns a regular promise-shaped drizzle client — use this for
+ * libraries that expect that shape (e.g. better-auth's `drizzleAdapter`):
+ *
+ * ```typescript
+ * const raw = yield* Drizzle.postgresRaw(hd.connectionString);
+ *
+ * const auth = betterAuth({
+ *   database: drizzleAdapter(raw, { provider: "pg", schema }),
+ * });
+ * ```
+ *
+ * For the Effect-flavored client (chainable, integrates with the
+ * Effect runtime), use `Drizzle.postgres` instead. The two live in
+ * separate modules so apps that only need one don't pay the bundle
+ * cost of the other.
+ *
+ * The drizzle client is cached per-`ExecutionContext` — the pool is
+ * built at most once per request.
+ *
+ * @binding
+ */
+export const postgresRaw = <
+  TRelations extends AnyRelations = EmptyRelations,
+  E = never,
+  R = never,
+>(
+  connectionString: Effect.Effect<Redacted.Redacted<string>, E, R>,
+) => {
+  const symbol = Symbol();
+  return Effect.gen(function* () {
+    const ctx = yield* ExecutionContext;
+    return yield* (ctx.cache[symbol] ??= yield* Effect.gen(function* () {
+      const url = Redacted.value(yield* connectionString);
+      return nodePgDrizzle<TRelations>(url);
+    }).pipe(Effect.cached));
+  }) as Effect.Effect<NodePgDatabase<TRelations>, E, R | ExecutionContext>;
+};

--- a/packages/alchemy/src/Drizzle/index.ts
+++ b/packages/alchemy/src/Drizzle/index.ts
@@ -1,3 +1,4 @@
 export * from "./Postgres.ts";
+export * from "./PostgresRaw.ts";
 export * from "./Providers.ts";
 export * from "./Schema.ts";


### PR DESCRIPTION
Refs #274 — building block for a `BetterAuth.DrizzlePostgres` layer (separate PR).

Adds `Drizzle.postgresRaw(...)` — a vanilla `drizzle-orm/node-postgres` client for libraries that need a regular promise-shaped drizzle (e.g. better-auth's `drizzleAdapter`).

```ts
const raw = yield* Drizzle.postgresRaw(hd.connectionString);

const auth = betterAuth({
  database: drizzleAdapter(raw, { provider: "pg", schema }),
});
```

Lives in its own module so apps using only the Effect-flavored `Drizzle.postgres` don't pull `drizzle-orm/node-postgres` into the bundle. The drizzle client is cached per-`ExecutionContext` — the pool is built at most once per request.
