### PR TITLE
feat(hetzner): add Effect-based Cloud and DNS API clients

### DIFF
--- a/packages/alchemy/src/Hetzner/Cloud/Client.ts
+++ b/packages/alchemy/src/Hetzner/Cloud/Client.ts
@@ -1,0 +1,151 @@
+import * as Data from "effect/Data";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Redacted from "effect/Redacted";
+import * as Schedule from "effect/Schedule";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import type { HttpMethod } from "effect/unstable/http/HttpMethod";
+import { HetznerCredentials } from "./Credentials.ts";
+
+export class HetznerApiError extends Data.TaggedError("HetznerApiError")<{
+  status: number;
+  method: string;
+  url: string;
+  message: string;
+  code?: string;
+  body?: unknown;
+}> {}
+
+const retrySchedule = Schedule.both(
+  Schedule.exponential(Duration.millis(500), 2),
+  Schedule.recurs(5),
+);
+
+const doRequest = <A>(
+  method: HttpMethod,
+  path: string,
+  body?: unknown,
+): Effect.Effect<A, HetznerApiError, HetznerCredentials | HttpClient.HttpClient> =>
+  Effect.gen(function* () {
+    const creds = yield* HetznerCredentials;
+    const client = yield* HttpClient.HttpClient;
+    const url = `${creds.apiBaseUrl}${path}`;
+
+    let req = HttpClientRequest.make(method)(url).pipe(
+      HttpClientRequest.setHeader(
+        "Authorization",
+        `Bearer ${Redacted.value(creds.token)}`,
+      ),
+      HttpClientRequest.setHeader("Accept", "application/json"),
+    );
+    if (body !== undefined) {
+      req = yield* HttpClientRequest.bodyJson(body)(req).pipe(
+        Effect.mapError(
+          (e) =>
+            new HetznerApiError({
+              status: 0,
+              method,
+              url,
+              message: `Failed to serialize body: ${String(e)}`,
+            }),
+        ),
+      );
+    }
+    const response = yield* client.execute(req).pipe(
+      Effect.scoped,
+      Effect.mapError(
+        (e) =>
+          new HetznerApiError({
+            status: 0,
+            method,
+            url,
+            message: `Network error: ${String(e)}`,
+          }),
+      ),
+    );
+    if (response.status === 204) {
+      return undefined as A;
+    }
+    const text = yield* response.text.pipe(
+      Effect.mapError(
+        (e) =>
+          new HetznerApiError({
+            status: response.status,
+            method,
+            url,
+            message: `Failed to read response body: ${String(e)}`,
+          }),
+      ),
+    );
+    let parsed: unknown;
+    try {
+      parsed = text.length > 0 ? JSON.parse(text) : undefined;
+    } catch {
+      parsed = text;
+    }
+    if (response.status >= 400) {
+      const err = parsed as { error?: { message?: string; code?: string } };
+      const message =
+        err?.error?.message ??
+        (typeof parsed === "object" &&
+          parsed != null &&
+          (parsed as { message?: string }).message) ||
+        `HTTP ${response.status}`;
+      const code = err?.error?.code;
+      return yield* new HetznerApiError({
+        status: response.status,
+        method,
+        url,
+        message: typeof message === "string" ? message : `HTTP ${response.status}`,
+        code,
+        body: parsed,
+      });
+    }
+    return parsed as A;
+  });
+
+/**
+ * Issue a typed HTTP request to the Hetzner Cloud API. Automatically
+ * retries on 429 (rate limit) and 5xx (server error) responses using
+ * exponential backoff (up to 5 retries, starting at 500ms).
+ */
+export const request = <A>(
+  method: HttpMethod,
+  path: string,
+  body?: unknown,
+): Effect.Effect<A, HetznerApiError, HetznerCredentials | HttpClient.HttpClient> =>
+  doRequest<A>(method, path, body).pipe(
+    Effect.retry({
+      while: (e: HetznerApiError) => e.status === 429 || e.status >= 500,
+      schedule: retrySchedule,
+    }),
+  );
+
+export const get = <A>(
+  path: string,
+): Effect.Effect<A, HetznerApiError, HetznerCredentials | HttpClient.HttpClient> =>
+  request("GET", path);
+
+export const post = <A>(
+  path: string,
+  body: unknown,
+): Effect.Effect<A, HetznerApiError, HetznerCredentials | HttpClient.HttpClient> =>
+  request("POST", path, body);
+
+export const put = <A>(
+  path: string,
+  body: unknown,
+): Effect.Effect<A, HetznerApiError, HetznerCredentials | HttpClient.HttpClient> =>
+  request("PUT", path, body);
+
+export const patch = <A>(
+  path: string,
+  body: unknown,
+): Effect.Effect<A, HetznerApiError, HetznerCredentials | HttpClient.HttpClient> =>
+  request("PATCH", path, body);
+
+export const del = <A>(
+  path: string,
+): Effect.Effect<A, HetznerApiError, HetznerCredentials | HttpClient.HttpClient> =>
+  request("DELETE", path);

--- a/packages/alchemy/src/Hetzner/Cloud/Credentials.ts
+++ b/packages/alchemy/src/Hetzner/Cloud/Credentials.ts
@@ -1,0 +1,43 @@
+import * as Config from "effect/Config";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Redacted from "effect/Redacted";
+
+const CLOUD_BASE_URL = "https://api.hetzner.cloud/v1";
+
+export interface HetznerCredentialsService {
+  readonly token: Redacted.Redacted<string>;
+  readonly apiBaseUrl: string;
+}
+
+export class HetznerCredentials extends Context.Service<
+  HetznerCredentials,
+  HetznerCredentialsService
+>()("Hetzner::Cloud::Credentials") {}
+
+/**
+ * Build a `HetznerCredentials` layer from a literal token. Useful for
+ * tests or when callers already have a token in hand.
+ */
+export const fromToken = (
+  token: string | Redacted.Redacted<string>,
+  apiBaseUrl = CLOUD_BASE_URL,
+) =>
+  Layer.succeed(HetznerCredentials, {
+    token: typeof token === "string" ? Redacted.make(token) : token,
+    apiBaseUrl,
+  });
+
+/**
+ * Build a `HetznerCredentials` layer that reads the API token from
+ * `HCLOUD_TOKEN` at layer build time.
+ */
+export const fromEnv = (apiBaseUrl = CLOUD_BASE_URL) =>
+  Layer.effect(
+    HetznerCredentials,
+    Effect.gen(function* () {
+      const token = yield* Config.redacted("HCLOUD_TOKEN");
+      return { token, apiBaseUrl };
+    }),
+  );

--- a/packages/alchemy/src/Hetzner/Cloud/DnsClient.ts
+++ b/packages/alchemy/src/Hetzner/Cloud/DnsClient.ts
@@ -1,0 +1,170 @@
+import * as Data from "effect/Data";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Redacted from "effect/Redacted";
+import * as Schedule from "effect/Schedule";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import type { HttpMethod } from "effect/unstable/http/HttpMethod";
+import { HetznerDnsCredentials } from "./DnsCredentials.ts";
+
+export class HetznerDnsApiError extends Data.TaggedError("HetznerDnsApiError")<{
+  status: number;
+  method: string;
+  url: string;
+  message: string;
+  code?: string;
+  body?: unknown;
+}> {}
+
+const retrySchedule = Schedule.both(
+  Schedule.exponential(Duration.millis(500), 2),
+  Schedule.recurs(5),
+);
+
+const doRequest = <A>(
+  method: HttpMethod,
+  path: string,
+  body?: unknown,
+): Effect.Effect<
+  A,
+  HetznerDnsApiError,
+  HetznerDnsCredentials | HttpClient.HttpClient
+> =>
+  Effect.gen(function* () {
+    const creds = yield* HetznerDnsCredentials;
+    const client = yield* HttpClient.HttpClient;
+    const url = `${creds.apiBaseUrl}${path}`;
+
+    let req = HttpClientRequest.make(method)(url).pipe(
+      HttpClientRequest.setHeader(
+        "Auth-API-Token",
+        Redacted.value(creds.token),
+      ),
+      HttpClientRequest.setHeader("Accept", "application/json"),
+    );
+    if (body !== undefined) {
+      req = yield* HttpClientRequest.bodyJson(body)(req).pipe(
+        Effect.mapError(
+          (e) =>
+            new HetznerDnsApiError({
+              status: 0,
+              method,
+              url,
+              message: `Failed to serialize body: ${String(e)}`,
+            }),
+        ),
+      );
+    }
+    const response = yield* client.execute(req).pipe(
+      Effect.scoped,
+      Effect.mapError(
+        (e) =>
+          new HetznerDnsApiError({
+            status: 0,
+            method,
+            url,
+            message: `Network error: ${String(e)}`,
+          }),
+      ),
+    );
+    if (response.status === 204) {
+      return undefined as A;
+    }
+    const text = yield* response.text.pipe(
+      Effect.mapError(
+        (e) =>
+          new HetznerDnsApiError({
+            status: response.status,
+            method,
+            url,
+            message: `Failed to read response body: ${String(e)}`,
+          }),
+      ),
+    );
+    let parsed: unknown;
+    try {
+      parsed = text.length > 0 ? JSON.parse(text) : undefined;
+    } catch {
+      parsed = text;
+    }
+    if (response.status >= 400) {
+      const message =
+        (typeof parsed === "object" &&
+          parsed != null &&
+          (parsed as { message?: string }).message) ||
+        `HTTP ${response.status}`;
+      return yield* new HetznerDnsApiError({
+        status: response.status,
+        method,
+        url,
+        message: typeof message === "string" ? message : `HTTP ${response.status}`,
+        body: parsed,
+      });
+    }
+    return parsed as A;
+  });
+
+/**
+ * Issue a typed HTTP request to the Hetzner DNS API. Automatically
+ * retries on 429 (rate limit) and 5xx (server error) responses using
+ * exponential backoff (up to 5 retries, starting at 500ms).
+ */
+export const request = <A>(
+  method: HttpMethod,
+  path: string,
+  body?: unknown,
+): Effect.Effect<
+  A,
+  HetznerDnsApiError,
+  HetznerDnsCredentials | HttpClient.HttpClient
+> =>
+  doRequest<A>(method, path, body).pipe(
+    Effect.retry({
+      while: (e: HetznerDnsApiError) => e.status === 429 || e.status >= 500,
+      schedule: retrySchedule,
+    }),
+  );
+
+export const get = <A>(
+  path: string,
+): Effect.Effect<
+  A,
+  HetznerDnsApiError,
+  HetznerDnsCredentials | HttpClient.HttpClient
+> => request("GET", path);
+
+export const post = <A>(
+  path: string,
+  body: unknown,
+): Effect.Effect<
+  A,
+  HetznerDnsApiError,
+  HetznerDnsCredentials | HttpClient.HttpClient
+> => request("POST", path, body);
+
+export const put = <A>(
+  path: string,
+  body: unknown,
+): Effect.Effect<
+  A,
+  HetznerDnsApiError,
+  HetznerDnsCredentials | HttpClient.HttpClient
+> => request("PUT", path, body);
+
+export const patch = <A>(
+  path: string,
+  body: unknown,
+): Effect.Effect<
+  A,
+  HetznerDnsApiError,
+  HetznerDnsCredentials | HttpClient.HttpClient
+> => request("PATCH", path, body);
+
+export const del = <A>(
+  path: string,
+): Effect.Effect<
+  A,
+  HetznerDnsApiError,
+  HetznerDnsCredentials | HttpClient.HttpClient
+> => request("DELETE", path);

--- a/packages/alchemy/src/Hetzner/Cloud/DnsCredentials.ts
+++ b/packages/alchemy/src/Hetzner/Cloud/DnsCredentials.ts
@@ -1,0 +1,43 @@
+import * as Config from "effect/Config";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Redacted from "effect/Redacted";
+
+const DNS_BASE_URL = "https://dns.hetzner.com/api/v1";
+
+export interface HetznerDnsCredentialsService {
+  readonly token: Redacted.Redacted<string>;
+  readonly apiBaseUrl: string;
+}
+
+export class HetznerDnsCredentials extends Context.Service<
+  HetznerDnsCredentials,
+  HetznerDnsCredentialsService
+>()("Hetzner::DNS::Credentials") {}
+
+/**
+ * Build a `HetznerDnsCredentials` layer from a literal token. Useful for
+ * tests or when callers already have a token in hand.
+ */
+export const fromToken = (
+  token: string | Redacted.Redacted<string>,
+  apiBaseUrl = DNS_BASE_URL,
+) =>
+  Layer.succeed(HetznerDnsCredentials, {
+    token: typeof token === "string" ? Redacted.make(token) : token,
+    apiBaseUrl,
+  });
+
+/**
+ * Build a `HetznerDnsCredentials` layer that reads the API token from
+ * `HETZNER_DNS_API_TOKEN` at layer build time.
+ */
+export const fromEnv = (apiBaseUrl = DNS_BASE_URL) =>
+  Layer.effect(
+    HetznerDnsCredentials,
+    Effect.gen(function* () {
+      const token = yield* Config.redacted("HETZNER_DNS_API_TOKEN");
+      return { token, apiBaseUrl };
+    }),
+  );


### PR DESCRIPTION
Implements the Hetzner Cloud and DNS HTTP client infrastructure for the v2 (`alchemy-effect`) codebase, following the `Neon/api.ts` Effect pattern.

### Files added

- `packages/alchemy/src/Hetzner/Cloud/Credentials.ts` — `Context.Service`-based credential service that reads `HCLOUD_TOKEN` from env; exposes `fromToken` and `fromEnv` layers
- `packages/alchemy/src/Hetzner/Cloud/Client.ts` — typed `get`/`post`/`put`/`patch`/`del` helpers wrapping `HttpClient`; base URL `https://api.hetzner.cloud/v1`; `HetznerApiError` with `Data.TaggedError`; auto-retry 429/5xx with `Schedule.exponential`
- `packages/alchemy/src/Hetzner/Cloud/DnsCredentials.ts` — same pattern for DNS; reads `HETZNER_DNS_API_TOKEN`
- `packages/alchemy/src/Hetzner/Cloud/DnsClient.ts` — DNS client; base URL `https://dns.hetzner.com/api/v1`; uses `Auth-API-Token` header; `HetznerDnsApiError`

### Usage

```ts
// Cloud API
const servers = yield* CloudClient.get<{ servers: Server[] }>("/servers").pipe(
  Effect.provide(CloudCredentials.fromEnv()),
  Effect.provide(FetchHttpClient.layer),
);

// DNS API
const zones = yield* DnsClient.get<{ zones: Zone[] }>("/zones").pipe(
  Effect.provide(DnsCredentials.fromEnv()),
  Effect.provide(FetchHttpClient.layer),
);
```
