### PR TITLE
feat(cloudflare): add Turnstile widget resource

### DIFF
--- a/packages/alchemy/src/Cloudflare/Providers.ts
+++ b/packages/alchemy/src/Cloudflare/Providers.ts
@@ -29,6 +29,7 @@ import * as Queue from "./Queue/index.ts";
 import * as R2 from "./R2/index.ts";
 import * as SecretsStore from "./SecretsStore/index.ts";
 import * as Tunnel from "./Tunnel/index.ts";
+import * as Turnstile from "./Turnstile/index.ts";
 import * as VpcService from "./VpcService/index.ts";
 import * as Workers from "./Workers/index.ts";
 import * as Workflows from "./Workers/Workflow.ts";
@@ -78,6 +79,7 @@ export const providers = () =>
       SecretsStore.SecretsStore,
       SecretsStore.Secret,
       Tunnel.Tunnel,
+      Turnstile.TurnstileWidget,
       VpcService.VpcService,
       Random,
       Workers.BindWorkerPolicy,
@@ -118,6 +120,7 @@ export const providers = () =>
         SecretsStore.SecretsStoreProvider(),
         SecretsStore.StoreSecretProvider(),
         Tunnel.TunnelProvider(),
+        Turnstile.TurnstileWidgetProvider(),
         VpcService.VpcServiceProvider(),
         Workers.BindWorkerPolicyLive,
         Workers.CronEventSourcePolicyLive,

--- a/packages/alchemy/src/Cloudflare/Turnstile/TurnstileWidget.ts
+++ b/packages/alchemy/src/Cloudflare/Turnstile/TurnstileWidget.ts
@@ -1,0 +1,375 @@
+import * as turnstile from "@distilled.cloud/cloudflare/turnstile";
+import * as Effect from "effect/Effect";
+import * as Redacted from "effect/Redacted";
+import { deepEqual, isResolved } from "../../Diff.ts";
+import { createPhysicalName } from "../../PhysicalName.ts";
+import * as Provider from "../../Provider.ts";
+import { Resource } from "../../Resource.ts";
+import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
+import type { Providers } from "../Providers.ts";
+
+export type TurnstileWidgetMode = turnstile.CreateWidgetRequest["mode"];
+export type TurnstileWidgetClearanceLevel =
+  turnstile.CreateWidgetRequest["clearanceLevel"];
+export type TurnstileWidgetRegion = turnstile.CreateWidgetRequest["region"];
+
+export interface TurnstileWidgetProps {
+  /**
+   * Existing widget sitekey to manage. Omit this to create a new widget.
+   *
+   * Cloudflare generates sitekeys and widget names are not unique, so Alchemy
+   * can only recover a widget after state loss when this is supplied.
+   */
+  sitekey?: string;
+  /**
+   * Human-readable widget name.
+   * @default ${app}-${stage}-${id}
+   */
+  name?: string;
+  /**
+   * Hostnames allowed to use this widget.
+   */
+  domains: string[];
+  /**
+   * Widget mode.
+   * @default "managed"
+   */
+  mode?: TurnstileWidgetMode;
+  /**
+   * Whether Cloudflare issues computationally expensive challenges to
+   * malicious bots. Enterprise-only.
+   * @default false
+   */
+  botFightMode?: boolean;
+  /**
+   * Clearance level granted when the widget is embedded on a Cloudflare site.
+   * @default "no_clearance"
+   */
+  clearanceLevel?: TurnstileWidgetClearanceLevel;
+  /**
+   * Whether the widget returns the Ephemeral ID in `/siteverify`.
+   * Enterprise-only.
+   * @default false
+   */
+  ephemeralId?: boolean;
+  /**
+   * Whether to hide Cloudflare branding on the widget. Enterprise-only.
+   * @default false
+   */
+  offlabel?: boolean;
+  /**
+   * Region where this widget can be used. Cloudflare does not allow changing
+   * the region after creation.
+   * @default "world"
+   */
+  region?: TurnstileWidgetRegion;
+  /**
+   * Cloudflare account id. Defaults to the configured Cloudflare account.
+   */
+  accountId?: string;
+}
+
+export type TurnstileWidget = Resource<
+  "Cloudflare.TurnstileWidget",
+  TurnstileWidgetProps,
+  {
+    /**
+     * Widget sitekey.
+     */
+    sitekey: string;
+    /**
+     * Human-readable widget name.
+     */
+    name: string;
+    /**
+     * Widget secret key.
+     */
+    secret: Redacted.Redacted<string>;
+    /**
+     * Hostnames allowed to use this widget.
+     */
+    domains: string[];
+    /**
+     * Widget mode.
+     */
+    mode: TurnstileWidgetMode;
+    /**
+     * Whether Bot Fight Mode is enabled for the widget.
+     */
+    botFightMode: boolean;
+    /**
+     * Clearance level granted by the widget.
+     */
+    clearanceLevel: NonNullable<TurnstileWidgetClearanceLevel>;
+    /**
+     * Whether the widget returns the Ephemeral ID in `/siteverify`.
+     */
+    ephemeralId: boolean;
+    /**
+     * Whether Cloudflare branding is hidden on the widget.
+     */
+    offlabel: boolean;
+    /**
+     * Widget region.
+     */
+    region: NonNullable<TurnstileWidgetRegion>;
+    /**
+     * Creation timestamp.
+     */
+    createdOn: string;
+    /**
+     * Last modification timestamp.
+     */
+    modifiedOn: string;
+    /**
+     * Cloudflare account id that owns the widget.
+     */
+    accountId: string;
+  },
+  never,
+  Providers
+>;
+
+/**
+ * A Cloudflare Turnstile widget.
+ *
+ * Turnstile widgets protect forms and other flows from automated abuse.
+ * Cloudflare generates the public sitekey and secret key when a widget is
+ * created; Alchemy stores both as resource attributes.
+ *
+ * Widget names are not unique in Cloudflare. If local state is lost, pass an
+ * existing `sitekey` to manage that widget explicitly.
+ *
+ * @section Creating Widgets
+ * @example Managed widget for one domain
+ * ```typescript
+ * const widget = yield* Cloudflare.TurnstileWidget("SignupChallenge", {
+ *   name: "signup",
+ *   domains: ["example.com"],
+ * });
+ * ```
+ *
+ * @section Existing Widgets
+ * @example Manage an existing widget
+ * ```typescript
+ * const widget = yield* Cloudflare.TurnstileWidget("ExistingChallenge", {
+ *   sitekey: "0x4AAAAAA...",
+ *   name: "signup",
+ *   domains: ["example.com"],
+ * });
+ * ```
+ */
+export const TurnstileWidget = Resource<TurnstileWidget>(
+  "Cloudflare.TurnstileWidget",
+);
+
+type WidgetResponse =
+  | turnstile.CreateWidgetResponse
+  | turnstile.GetWidgetResponse
+  | turnstile.UpdateWidgetResponse;
+
+const DEFAULT_MODE: TurnstileWidgetMode = "managed";
+const DEFAULT_CLEARANCE_LEVEL: NonNullable<TurnstileWidgetClearanceLevel> =
+  "no_clearance";
+const DEFAULT_REGION: NonNullable<TurnstileWidgetRegion> = "world";
+
+const resolveName = (id: string, name: string | undefined) =>
+  Effect.gen(function* () {
+    return name ?? (yield* createPhysicalName({ id }));
+  });
+
+const desiredConfig = (props: TurnstileWidgetProps, name: string) => ({
+  name,
+  domains: props.domains,
+  mode: props.mode ?? DEFAULT_MODE,
+  botFightMode: props.botFightMode ?? false,
+  clearanceLevel: props.clearanceLevel ?? DEFAULT_CLEARANCE_LEVEL,
+  ephemeralId: props.ephemeralId ?? false,
+  offlabel: props.offlabel ?? false,
+  region: props.region ?? DEFAULT_REGION,
+});
+
+type MutableWidgetConfig = {
+  name: string;
+  domains: string[];
+  mode: TurnstileWidgetMode;
+  botFightMode: boolean;
+  clearanceLevel: NonNullable<TurnstileWidgetClearanceLevel>;
+  ephemeralId: boolean;
+  offlabel: boolean;
+};
+
+const mutableConfig = (widget: MutableWidgetConfig) => ({
+  name: widget.name,
+  domains: [...widget.domains].sort(),
+  mode: widget.mode,
+  botFightMode: widget.botFightMode,
+  clearanceLevel: widget.clearanceLevel,
+  ephemeralId: widget.ephemeralId,
+  offlabel: widget.offlabel,
+});
+
+const toAttributes = (
+  accountId: string,
+  widget: WidgetResponse,
+): TurnstileWidget["Attributes"] => ({
+  sitekey: widget.sitekey,
+  name: widget.name,
+  secret: Redacted.make(widget.secret),
+  domains: widget.domains,
+  mode: widget.mode,
+  botFightMode: widget.botFightMode,
+  clearanceLevel: widget.clearanceLevel,
+  ephemeralId: widget.ephemeralId,
+  offlabel: widget.offlabel,
+  region: widget.region,
+  createdOn: widget.createdOn,
+  modifiedOn: widget.modifiedOn,
+  accountId,
+});
+
+export const TurnstileWidgetProvider = () =>
+  Provider.effect(
+    TurnstileWidget,
+    Effect.gen(function* () {
+      const { accountId: defaultAccountId } = yield* CloudflareEnvironment;
+      const createWidget = yield* turnstile.createWidget;
+      const getWidget = yield* turnstile.getWidget;
+      const updateWidget = yield* turnstile.updateWidget;
+      const deleteWidget = yield* turnstile.deleteWidget;
+
+      const observeBySitekey = (accountId: string, sitekey: string) =>
+        getWidget({ accountId, sitekey }).pipe(
+          Effect.map((widget) => toAttributes(accountId, widget)),
+          Effect.catchIf(isMissingTurnstileWidget, () =>
+            Effect.succeed(undefined),
+          ),
+        );
+
+      return {
+        stables: ["sitekey", "accountId"],
+        diff: Effect.fn(function* ({ id, olds, news, output }) {
+          if (!isResolved(news)) return undefined;
+          if (!olds && !output) return undefined;
+
+          const newAccountId = news.accountId ?? defaultAccountId;
+          const oldAccountId =
+            output?.accountId ?? olds?.accountId ?? defaultAccountId;
+          if (oldAccountId !== newAccountId) {
+            return { action: "replace" } as const;
+          }
+
+          // `sitekey` is generated by Cloudflare. Only compare explicit props
+          // here so removing `sitekey` switches from managing an existing
+          // widget to creating a replacement instead of reusing output.sitekey.
+          if (olds && olds.sitekey !== news.sitekey) {
+            return { action: "replace" } as const;
+          }
+
+          if (
+            !olds &&
+            output &&
+            news.sitekey &&
+            output.sitekey !== news.sitekey
+          ) {
+            return { action: "replace" } as const;
+          }
+
+          const oldRegion = output?.region ?? olds?.region ?? DEFAULT_REGION;
+          const newRegion = news.region ?? DEFAULT_REGION;
+          if (oldRegion !== newRegion) {
+            return { action: "replace" } as const;
+          }
+
+          const name = yield* resolveName(id, news.name);
+          const next = desiredConfig(news, name);
+          const previous =
+            output ??
+            (olds
+              ? {
+                  ...next,
+                  ...desiredConfig(olds, yield* resolveName(id, olds.name)),
+                }
+              : undefined);
+
+          if (
+            previous &&
+            !deepEqual(
+              mutableConfig(previous),
+              mutableConfig({ ...previous, ...next }),
+            )
+          ) {
+            return { action: "update" } as const;
+          }
+        }),
+        reconcile: Effect.fn(function* ({ id, news, output }) {
+          const accountId =
+            news.accountId ?? output?.accountId ?? defaultAccountId;
+          const name = yield* resolveName(id, news.name);
+          const desired = desiredConfig(news, name);
+          const sitekey = news.sitekey ?? output?.sitekey;
+          const observed = sitekey
+            ? yield* observeBySitekey(accountId, sitekey)
+            : undefined;
+
+          if (!observed) {
+            if (news.sitekey) {
+              return yield* Effect.fail(
+                new Error(
+                  `Cloudflare Turnstile widget "${news.sitekey}" was not found. Omit sitekey to create a new widget.`,
+                ),
+              );
+            }
+
+            return toAttributes(
+              accountId,
+              yield* createWidget({
+                accountId,
+                ...desired,
+              }),
+            );
+          }
+
+          if (
+            deepEqual(
+              mutableConfig(observed),
+              mutableConfig({ ...observed, ...desired }),
+            )
+          ) {
+            return observed;
+          }
+
+          return toAttributes(
+            accountId,
+            yield* updateWidget({
+              accountId,
+              sitekey: observed.sitekey,
+              ...desired,
+            }),
+          );
+        }),
+        delete: Effect.fn(function* ({ output }) {
+          yield* deleteWidget({
+            accountId: output.accountId,
+            sitekey: output.sitekey,
+          }).pipe(Effect.catchIf(isMissingTurnstileWidget, () => Effect.void));
+        }),
+        read: Effect.fn(function* ({ olds, output }) {
+          const accountId =
+            output?.accountId ?? olds?.accountId ?? defaultAccountId;
+          const sitekey = output?.sitekey ?? olds?.sitekey;
+          if (!sitekey) return undefined;
+          return yield* observeBySitekey(accountId, sitekey);
+        }),
+      };
+    }),
+  );
+
+const isMissingTurnstileWidget = (error: unknown): boolean =>
+  typeof error === "object" &&
+  error !== null &&
+  (("_tag" in error && (error as { _tag: unknown })._tag === "NotFound") ||
+    ("_tag" in error &&
+      (error as { _tag: unknown })._tag === "CloudflareHttpError" &&
+      "status" in error &&
+      (error as { status: unknown }).status === 404));

--- a/packages/alchemy/src/Cloudflare/Turnstile/index.ts
+++ b/packages/alchemy/src/Cloudflare/Turnstile/index.ts
@@ -1,0 +1,1 @@
+export * from "./TurnstileWidget.ts";

--- a/packages/alchemy/src/Cloudflare/index.ts
+++ b/packages/alchemy/src/Cloudflare/index.ts
@@ -17,6 +17,7 @@ export * from "./R2/index.ts";
 export * from "./SecretsStore/index.ts";
 export * from "./StateStore/index.ts";
 export * from "./Tunnel/index.ts";
+export * from "./Turnstile/index.ts";
 export * from "./VpcService/index.ts";
 export * from "./Website/index.ts";
 export * from "./Workers/index.ts";

--- a/packages/alchemy/test/Cloudflare/Turnstile/TurnstileWidget.test.ts
+++ b/packages/alchemy/test/Cloudflare/Turnstile/TurnstileWidget.test.ts
@@ -1,0 +1,192 @@
+import * as Cloudflare from "@/Cloudflare";
+import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
+import * as Test from "@/Test/Vitest";
+import * as turnstile from "@distilled.cloud/cloudflare/turnstile";
+import { expect } from "@effect/vitest";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import * as Redacted from "effect/Redacted";
+import { MinimumLogLevel } from "effect/References";
+import * as Schedule from "effect/Schedule";
+
+const { test } = Test.make({ providers: Cloudflare.providers() });
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+test.provider(
+  "create, update, delete turnstile widget",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const widget = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.TurnstileWidget("TestWidget", {
+            name: "alchemy-test-turnstile-widget",
+            domains: ["example.com"],
+          });
+        }),
+      );
+
+      expect(widget.sitekey).toBeDefined();
+      expect(Redacted.value(widget.secret)).toBeDefined();
+      expect(widget.name).toEqual("alchemy-test-turnstile-widget");
+      expectDomains(widget.domains, ["example.com"]);
+      expect(widget.mode).toEqual("managed");
+      expect(widget.region).toEqual("world");
+
+      const actualWidget = yield* turnstile.getWidget({
+        accountId,
+        sitekey: widget.sitekey,
+      });
+      expect(actualWidget.sitekey).toEqual(widget.sitekey);
+      expect(actualWidget.name).toEqual(widget.name);
+
+      const updatedWidget = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.TurnstileWidget("TestWidget", {
+            name: "alchemy-test-turnstile-widget-updated",
+            domains: ["example.com", "www.example.com"],
+            mode: "invisible",
+          });
+        }),
+      );
+
+      expect(updatedWidget.sitekey).toEqual(widget.sitekey);
+      expect(updatedWidget.name).toEqual(
+        "alchemy-test-turnstile-widget-updated",
+      );
+      expectDomains(updatedWidget.domains, ["example.com", "www.example.com"]);
+      expect(updatedWidget.mode).toEqual("invisible");
+
+      const actualUpdatedWidget = yield* turnstile.getWidget({
+        accountId,
+        sitekey: updatedWidget.sitekey,
+      });
+      expect(actualUpdatedWidget.name).toEqual(updatedWidget.name);
+      expectDomains(actualUpdatedWidget.domains, updatedWidget.domains);
+      expect(actualUpdatedWidget.mode).toEqual(updatedWidget.mode);
+
+      const reorderedDomainsWidget = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.TurnstileWidget("TestWidget", {
+            name: "alchemy-test-turnstile-widget-updated",
+            domains: ["www.example.com", "example.com"],
+            mode: "invisible",
+          });
+        }),
+      );
+
+      expect(reorderedDomainsWidget.sitekey).toEqual(updatedWidget.sitekey);
+      expect(reorderedDomainsWidget.modifiedOn).toEqual(
+        updatedWidget.modifiedOn,
+      );
+      expectDomains(reorderedDomainsWidget.domains, updatedWidget.domains);
+
+      yield* stack.destroy();
+
+      yield* waitForWidgetToBeDeleted(widget.sitekey, accountId);
+    }).pipe(logLevel),
+  { timeout: 60_000 },
+);
+
+test.provider(
+  "manage existing turnstile widget by sitekey",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const external = yield* turnstile.createWidget({
+        accountId,
+        name: "alchemy-test-turnstile-existing",
+        domains: ["example.com"],
+        mode: "managed",
+      });
+
+      const managed = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.TurnstileWidget("ExistingWidget", {
+            sitekey: external.sitekey,
+            name: "alchemy-test-turnstile-existing-managed",
+            domains: ["example.com", "docs.example.com"],
+            mode: "non-interactive",
+          });
+        }),
+      );
+
+      expect(managed.sitekey).toEqual(external.sitekey);
+      expect(managed.name).toEqual("alchemy-test-turnstile-existing-managed");
+      expectDomains(managed.domains, ["example.com", "docs.example.com"]);
+      expect(managed.mode).toEqual("non-interactive");
+
+      const replacement = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.TurnstileWidget("ExistingWidget", {
+            name: "alchemy-test-turnstile-existing-replacement",
+            domains: ["example.com"],
+          });
+        }),
+      );
+
+      expect(replacement.sitekey).not.toEqual(external.sitekey);
+      expect(replacement.name).toEqual(
+        "alchemy-test-turnstile-existing-replacement",
+      );
+      expectDomains(replacement.domains, ["example.com"]);
+
+      yield* waitForWidgetToBeDeleted(external.sitekey, accountId);
+
+      yield* stack.destroy();
+
+      yield* waitForWidgetToBeDeleted(replacement.sitekey, accountId);
+    }).pipe(logLevel),
+  { timeout: 60_000 },
+);
+
+const waitForWidgetToBeDeleted = Effect.fn(function* (
+  sitekey: string,
+  accountId: string,
+) {
+  yield* turnstile
+    .getWidget({
+      accountId,
+      sitekey,
+    })
+    .pipe(
+      Effect.flatMap(() => Effect.fail(new WidgetStillExists())),
+      Effect.retry({
+        while: (e): e is WidgetStillExists => e instanceof WidgetStillExists,
+        schedule: Schedule.exponential(100).pipe(
+          Schedule.both(Schedule.recurs(8)),
+        ),
+      }),
+      Effect.catchTag("WidgetStillExists", () =>
+        Effect.die(
+          `Cloudflare Turnstile widget ${sitekey} was not deleted after retries`,
+        ),
+      ),
+      Effect.catchIf(isMissingTurnstileWidget, () => Effect.void),
+    );
+});
+
+class WidgetStillExists extends Data.TaggedError("WidgetStillExists") {}
+
+const isMissingTurnstileWidget = (error: unknown): boolean =>
+  typeof error === "object" &&
+  error !== null &&
+  (("_tag" in error && (error as { _tag: unknown })._tag === "NotFound") ||
+    ("_tag" in error &&
+      (error as { _tag: unknown })._tag === "CloudflareHttpError" &&
+      "status" in error &&
+      (error as { status: unknown }).status === 404));
+
+const expectDomains = (actual: string[], expected: string[]) => {
+  expect([...actual].sort()).toEqual([...expected].sort());
+};


### PR DESCRIPTION
### Summary

Adds `Cloudflare.TurnstileWidget` backed by distilled's Turnstile API, including create, update, read, delete, and explicit-sitekey adoption.

The provider is registered in `Cloudflare.providers()` and exported from `alchemy/Cloudflare`. The resource treats account changes, explicit sitekey changes/removal, and region changes as replacements, while mutable widget settings are updated in place. Domain comparison is order-insensitive because Cloudflare canonicalizes domain order in responses.

### Verification

- `bun tsc -p packages/alchemy/tsconfig.json --pretty false`
- `bun tsc -p packages/alchemy/tsconfig.test.json --pretty false`
- `bun vitest run packages/alchemy/test/Cloudflare/Turnstile/TurnstileWidget.test.ts`

The focused Turnstile test was run with a real Cloudflare API token/account. It covered create/update/delete, managing an existing widget by sitekey, replacing when `sitekey` is removed, the domain-order canonicalization regression, and verified no `alchemy-test-turnstile*` widgets were left behind.
