### PR TITLE
fix(AWS): color runtime binding callables with Alchemy.RuntimeContext

### DIFF
--- a/examples/aws-lambda-httpapi/src/JobNotifications.ts
+++ b/examples/aws-lambda-httpapi/src/JobNotifications.ts
@@ -1,4 +1,5 @@
 import * as AWS from "alchemy/AWS";
+import type { RuntimeContext } from "alchemy/RuntimeContext";
 import * as Context from "effect/Context";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
@@ -20,7 +21,9 @@ type JobNotification = {
 export class JobNotifications extends Context.Service<
   JobNotifications,
   {
-    notifyJobCreated(job: Job): Effect.Effect<void, NotifyJobError>;
+    notifyJobCreated(
+      job: Job,
+    ): Effect.Effect<void, NotifyJobError, RuntimeContext>;
   }
 >()("JobNotifications") {}
 

--- a/examples/aws-lambda-httpapi/src/JobStorage.ts
+++ b/examples/aws-lambda-httpapi/src/JobStorage.ts
@@ -3,6 +3,7 @@ import * as Lambda from "alchemy/AWS/Lambda";
 import * as S3 from "alchemy/AWS/S3";
 import * as SQS from "alchemy/AWS/SQS";
 import * as RemovalPolicy from "alchemy/RemovalPolicy";
+import type { RuntimeContext } from "alchemy/RuntimeContext";
 import { Stack } from "alchemy/Stack";
 import * as Console from "effect/Console";
 import * as Context from "effect/Context";
@@ -26,8 +27,10 @@ export class GetJobError extends Data.TaggedError("GetJobError")<{
 export class JobStorage extends Context.Service<
   JobStorage,
   {
-    putJob(job: Job): Effect.Effect<Job, PutJobError>;
-    getJob(jobId: string): Effect.Effect<Job | undefined, GetJobError>;
+    putJob(job: Job): Effect.Effect<Job, PutJobError, RuntimeContext>;
+    getJob(
+      jobId: string,
+    ): Effect.Effect<Job | undefined, GetJobError, RuntimeContext>;
   }
 >()("JobStorage") {}
 

--- a/examples/aws-lambda-rpc/src/JobNotifications.ts
+++ b/examples/aws-lambda-rpc/src/JobNotifications.ts
@@ -1,4 +1,5 @@
 import * as AWS from "alchemy/AWS";
+import type { RuntimeContext } from "alchemy/RuntimeContext";
 import * as Context from "effect/Context";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
@@ -20,7 +21,9 @@ type JobNotification = {
 export class JobNotifications extends Context.Service<
   JobNotifications,
   {
-    notifyJobCreated(job: Job): Effect.Effect<void, NotifyJobError>;
+    notifyJobCreated(
+      job: Job,
+    ): Effect.Effect<void, NotifyJobError, RuntimeContext>;
   }
 >()("JobNotifications") {}
 

--- a/examples/aws-lambda-rpc/src/JobStorage.ts
+++ b/examples/aws-lambda-rpc/src/JobStorage.ts
@@ -3,6 +3,7 @@ import * as Lambda from "alchemy/AWS/Lambda";
 import * as S3 from "alchemy/AWS/S3";
 import * as SQS from "alchemy/AWS/SQS";
 import * as RemovalPolicy from "alchemy/RemovalPolicy";
+import type { RuntimeContext } from "alchemy/RuntimeContext";
 import { Stack } from "alchemy/Stack";
 import * as Console from "effect/Console";
 import * as Context from "effect/Context";
@@ -26,8 +27,10 @@ export class GetJobError extends Data.TaggedError("GetJobError")<{
 export class JobStorage extends Context.Service<
   JobStorage,
   {
-    putJob(job: Job): Effect.Effect<Job, PutJobError>;
-    getJob(jobId: string): Effect.Effect<Job | undefined, GetJobError>;
+    putJob(job: Job): Effect.Effect<Job, PutJobError, RuntimeContext>;
+    getJob(
+      jobId: string,
+    ): Effect.Effect<Job | undefined, GetJobError, RuntimeContext>;
   }
 >()("JobStorage") {}
 

--- a/examples/aws-lambda/src/JobNotifications.ts
+++ b/examples/aws-lambda/src/JobNotifications.ts
@@ -1,4 +1,5 @@
 import * as AWS from "alchemy/AWS";
+import type { RuntimeContext } from "alchemy/RuntimeContext";
 import * as Context from "effect/Context";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
@@ -20,7 +21,9 @@ type JobNotification = {
 export class JobNotifications extends Context.Service<
   JobNotifications,
   {
-    notifyJobCreated(job: Job): Effect.Effect<void, NotifyJobError>;
+    notifyJobCreated(
+      job: Job,
+    ): Effect.Effect<void, NotifyJobError, RuntimeContext>;
   }
 >()("JobNotifications") {}
 

--- a/examples/aws-lambda/src/JobStorage.ts
+++ b/examples/aws-lambda/src/JobStorage.ts
@@ -3,6 +3,7 @@ import * as Lambda from "alchemy/AWS/Lambda";
 import * as S3 from "alchemy/AWS/S3";
 import * as SQS from "alchemy/AWS/SQS";
 import * as RemovalPolicy from "alchemy/RemovalPolicy";
+import type { RuntimeContext } from "alchemy/RuntimeContext";
 import { Stack } from "alchemy/Stack";
 import * as Console from "effect/Console";
 import * as Context from "effect/Context";
@@ -26,8 +27,10 @@ export class GetJobError extends Data.TaggedError("GetJobError")<{
 export class JobStorage extends Context.Service<
   JobStorage,
   {
-    putJob(job: Job): Effect.Effect<Job, PutJobError>;
-    getJob(jobId: string): Effect.Effect<Job | undefined, GetJobError>;
+    putJob(job: Job): Effect.Effect<Job, PutJobError, RuntimeContext>;
+    getJob(
+      jobId: string,
+    ): Effect.Effect<Job | undefined, GetJobError, RuntimeContext>;
   }
 >()("JobStorage") {}
 

--- a/examples/aws-rds/src/Database.ts
+++ b/examples/aws-rds/src/Database.ts
@@ -1,4 +1,5 @@
 import * as AWS from "alchemy/AWS";
+import type { RuntimeContext } from "alchemy/RuntimeContext";
 import * as Context from "effect/Context";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
@@ -17,7 +18,7 @@ export class Database extends Context.Service<
     query<Row extends Record<string, unknown> = Record<string, unknown>>(
       statement: string,
       values?: ReadonlyArray<unknown>,
-    ): Effect.Effect<ReadonlyArray<Row>, SqlError>;
+    ): Effect.Effect<ReadonlyArray<Row>, SqlError, RuntimeContext>;
   }
 >()("Sql") {}
 
@@ -40,7 +41,7 @@ export const DatabaseAurora = Layer.effect(
       query: <Row extends Record<string, unknown>>(
         statement: string,
         values: ReadonlyArray<unknown> = [],
-      ): Effect.Effect<ReadonlyArray<Row>, SqlError> =>
+      ): Effect.Effect<ReadonlyArray<Row>, SqlError, RuntimeContext> =>
         connect.pipe(
           Effect.catch((cause) =>
             Effect.fail(

--- a/packages/alchemy/src/AWS/CloudWatch/DescribeAlarmContributors.ts
+++ b/packages/alchemy/src/AWS/CloudWatch/DescribeAlarmContributors.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { AlarmResource } from "./binding-common.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface DescribeAlarmContributorsRequest extends Omit<
   cloudwatch.DescribeAlarmContributorsInput,
@@ -22,7 +23,8 @@ export class DescribeAlarmContributors extends Binding.Service<
       request?: DescribeAlarmContributorsRequest,
     ) => Effect.Effect<
       cloudwatch.DescribeAlarmContributorsOutput,
-      cloudwatch.DescribeAlarmContributorsError
+      cloudwatch.DescribeAlarmContributorsError,
+      RuntimeContext
     >
   >
 >()("AWS.CloudWatch.DescribeAlarmContributors") {}

--- a/packages/alchemy/src/AWS/CloudWatch/DescribeAlarmHistory.ts
+++ b/packages/alchemy/src/AWS/CloudWatch/DescribeAlarmHistory.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface DescribeAlarmHistoryRequest
   extends cloudwatch.DescribeAlarmHistoryInput {}
@@ -17,7 +18,8 @@ export class DescribeAlarmHistory extends Binding.Service<
       request?: DescribeAlarmHistoryRequest,
     ) => Effect.Effect<
       cloudwatch.DescribeAlarmHistoryOutput,
-      cloudwatch.DescribeAlarmHistoryError
+      cloudwatch.DescribeAlarmHistoryError,
+      RuntimeContext
     >
   >
 >()("AWS.CloudWatch.DescribeAlarmHistory") {}

--- a/packages/alchemy/src/AWS/CloudWatch/DescribeAlarms.ts
+++ b/packages/alchemy/src/AWS/CloudWatch/DescribeAlarms.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import { type AlarmResource, sortAlarmResources } from "./binding-common.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface DescribeAlarmsRequest extends Omit<
   cloudwatch.DescribeAlarmsInput,
@@ -33,7 +34,7 @@ export class DescribeAlarms extends Binding.Service<
   ) => Effect.Effect<
     (
       request?: DescribeAlarmsRequest,
-    ) => Effect.Effect<cloudwatch.DescribeAlarmsOutput, any>
+    ) => Effect.Effect<cloudwatch.DescribeAlarmsOutput, any, RuntimeContext>
   >
 >()("AWS.CloudWatch.DescribeAlarms") {}
 

--- a/packages/alchemy/src/AWS/CloudWatch/DescribeAlarmsForMetric.ts
+++ b/packages/alchemy/src/AWS/CloudWatch/DescribeAlarmsForMetric.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface DescribeAlarmsForMetricRequest
   extends cloudwatch.DescribeAlarmsForMetricInput {}
@@ -17,7 +18,8 @@ export class DescribeAlarmsForMetric extends Binding.Service<
       request: DescribeAlarmsForMetricRequest,
     ) => Effect.Effect<
       cloudwatch.DescribeAlarmsForMetricOutput,
-      cloudwatch.DescribeAlarmsForMetricError
+      cloudwatch.DescribeAlarmsForMetricError,
+      RuntimeContext
     >
   >
 >()("AWS.CloudWatch.DescribeAlarmsForMetric") {}

--- a/packages/alchemy/src/AWS/CloudWatch/DescribeAnomalyDetectors.ts
+++ b/packages/alchemy/src/AWS/CloudWatch/DescribeAnomalyDetectors.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface DescribeAnomalyDetectorsRequest
   extends cloudwatch.DescribeAnomalyDetectorsInput {}
@@ -17,7 +18,8 @@ export class DescribeAnomalyDetectors extends Binding.Service<
       request?: DescribeAnomalyDetectorsRequest,
     ) => Effect.Effect<
       cloudwatch.DescribeAnomalyDetectorsOutput,
-      cloudwatch.DescribeAnomalyDetectorsError
+      cloudwatch.DescribeAnomalyDetectorsError,
+      RuntimeContext
     >
   >
 >()("AWS.CloudWatch.DescribeAnomalyDetectors") {}

--- a/packages/alchemy/src/AWS/CloudWatch/DescribeInsightRules.ts
+++ b/packages/alchemy/src/AWS/CloudWatch/DescribeInsightRules.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface DescribeInsightRulesRequest
   extends cloudwatch.DescribeInsightRulesInput {}
@@ -17,7 +18,8 @@ export class DescribeInsightRules extends Binding.Service<
       request?: DescribeInsightRulesRequest,
     ) => Effect.Effect<
       cloudwatch.DescribeInsightRulesOutput,
-      cloudwatch.DescribeInsightRulesError
+      cloudwatch.DescribeInsightRulesError,
+      RuntimeContext
     >
   >
 >()("AWS.CloudWatch.DescribeInsightRules") {}

--- a/packages/alchemy/src/AWS/CloudWatch/DisableAlarmActions.ts
+++ b/packages/alchemy/src/AWS/CloudWatch/DisableAlarmActions.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import { type AlarmResource, sortAlarmResources } from "./binding-common.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 type AlarmResources = [AlarmResource, ...AlarmResource[]];
 
@@ -15,7 +16,11 @@ export class DisableAlarmActions extends Binding.Service<
   (
     ...alarms: AlarmResources
   ) => Effect.Effect<
-    () => Effect.Effect<cloudwatch.DisableAlarmActionsResponse, any>
+    () => Effect.Effect<
+      cloudwatch.DisableAlarmActionsResponse,
+      any,
+      RuntimeContext
+    >
   >
 >()("AWS.CloudWatch.DisableAlarmActions") {}
 

--- a/packages/alchemy/src/AWS/CloudWatch/DisableInsightRules.ts
+++ b/packages/alchemy/src/AWS/CloudWatch/DisableInsightRules.ts
@@ -7,6 +7,7 @@ import {
   sortInsightRuleResources,
   type InsightRuleResource,
 } from "./binding-common.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 type InsightRules = [InsightRuleResource, ...InsightRuleResource[]];
 
@@ -18,7 +19,11 @@ export class DisableInsightRules extends Binding.Service<
   (
     ...rules: InsightRules
   ) => Effect.Effect<
-    () => Effect.Effect<cloudwatch.DisableInsightRulesOutput, any>
+    () => Effect.Effect<
+      cloudwatch.DisableInsightRulesOutput,
+      any,
+      RuntimeContext
+    >
   >
 >()("AWS.CloudWatch.DisableInsightRules") {}
 

--- a/packages/alchemy/src/AWS/CloudWatch/EnableAlarmActions.ts
+++ b/packages/alchemy/src/AWS/CloudWatch/EnableAlarmActions.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import { type AlarmResource, sortAlarmResources } from "./binding-common.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 type AlarmResources = [AlarmResource, ...AlarmResource[]];
 
@@ -15,7 +16,11 @@ export class EnableAlarmActions extends Binding.Service<
   (
     ...alarms: AlarmResources
   ) => Effect.Effect<
-    () => Effect.Effect<cloudwatch.EnableAlarmActionsResponse, any>
+    () => Effect.Effect<
+      cloudwatch.EnableAlarmActionsResponse,
+      any,
+      RuntimeContext
+    >
   >
 >()("AWS.CloudWatch.EnableAlarmActions") {}
 

--- a/packages/alchemy/src/AWS/CloudWatch/GetAlarmMuteRule.ts
+++ b/packages/alchemy/src/AWS/CloudWatch/GetAlarmMuteRule.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { AlarmMuteRule } from "./AlarmMuteRule.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface GetAlarmMuteRuleRequest extends Omit<
   cloudwatch.GetAlarmMuteRuleInput,
@@ -22,7 +23,8 @@ export class GetAlarmMuteRule extends Binding.Service<
       request?: GetAlarmMuteRuleRequest,
     ) => Effect.Effect<
       cloudwatch.GetAlarmMuteRuleOutput,
-      cloudwatch.GetAlarmMuteRuleError
+      cloudwatch.GetAlarmMuteRuleError,
+      RuntimeContext
     >
   >
 >()("AWS.CloudWatch.GetAlarmMuteRule") {}

--- a/packages/alchemy/src/AWS/CloudWatch/GetDashboard.ts
+++ b/packages/alchemy/src/AWS/CloudWatch/GetDashboard.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Dashboard } from "./Dashboard.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface GetDashboardRequest extends Omit<
   cloudwatch.GetDashboardInput,
@@ -22,7 +23,8 @@ export class GetDashboard extends Binding.Service<
       request?: GetDashboardRequest,
     ) => Effect.Effect<
       cloudwatch.GetDashboardOutput,
-      cloudwatch.GetDashboardError
+      cloudwatch.GetDashboardError,
+      RuntimeContext
     >
   >
 >()("AWS.CloudWatch.GetDashboard") {}

--- a/packages/alchemy/src/AWS/CloudWatch/GetInsightRuleReport.ts
+++ b/packages/alchemy/src/AWS/CloudWatch/GetInsightRuleReport.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { InsightRule } from "./InsightRule.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface GetInsightRuleReportRequest extends Omit<
   cloudwatch.GetInsightRuleReportInput,
@@ -22,7 +23,8 @@ export class GetInsightRuleReport extends Binding.Service<
       request: GetInsightRuleReportRequest,
     ) => Effect.Effect<
       cloudwatch.GetInsightRuleReportOutput,
-      cloudwatch.GetInsightRuleReportError
+      cloudwatch.GetInsightRuleReportError,
+      RuntimeContext
     >
   >
 >()("AWS.CloudWatch.GetInsightRuleReport") {}

--- a/packages/alchemy/src/AWS/CloudWatch/GetMetricData.ts
+++ b/packages/alchemy/src/AWS/CloudWatch/GetMetricData.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface GetMetricDataRequest extends cloudwatch.GetMetricDataInput {}
 
@@ -16,7 +17,8 @@ export class GetMetricData extends Binding.Service<
       request: GetMetricDataRequest,
     ) => Effect.Effect<
       cloudwatch.GetMetricDataOutput,
-      cloudwatch.GetMetricDataError
+      cloudwatch.GetMetricDataError,
+      RuntimeContext
     >
   >
 >()("AWS.CloudWatch.GetMetricData") {}

--- a/packages/alchemy/src/AWS/CloudWatch/GetMetricStatistics.ts
+++ b/packages/alchemy/src/AWS/CloudWatch/GetMetricStatistics.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface GetMetricStatisticsRequest
   extends cloudwatch.GetMetricStatisticsInput {}
@@ -17,7 +18,8 @@ export class GetMetricStatistics extends Binding.Service<
       request: GetMetricStatisticsRequest,
     ) => Effect.Effect<
       cloudwatch.GetMetricStatisticsOutput,
-      cloudwatch.GetMetricStatisticsError
+      cloudwatch.GetMetricStatisticsError,
+      RuntimeContext
     >
   >
 >()("AWS.CloudWatch.GetMetricStatistics") {}

--- a/packages/alchemy/src/AWS/CloudWatch/GetMetricStream.ts
+++ b/packages/alchemy/src/AWS/CloudWatch/GetMetricStream.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { MetricStream } from "./MetricStream.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface GetMetricStreamRequest extends Omit<
   cloudwatch.GetMetricStreamInput,
@@ -22,7 +23,8 @@ export class GetMetricStream extends Binding.Service<
       request?: GetMetricStreamRequest,
     ) => Effect.Effect<
       cloudwatch.GetMetricStreamOutput,
-      cloudwatch.GetMetricStreamError
+      cloudwatch.GetMetricStreamError,
+      RuntimeContext
     >
   >
 >()("AWS.CloudWatch.GetMetricStream") {}

--- a/packages/alchemy/src/AWS/CloudWatch/GetMetricWidgetImage.ts
+++ b/packages/alchemy/src/AWS/CloudWatch/GetMetricWidgetImage.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface GetMetricWidgetImageRequest
   extends cloudwatch.GetMetricWidgetImageInput {}
@@ -17,7 +18,8 @@ export class GetMetricWidgetImage extends Binding.Service<
       request: GetMetricWidgetImageRequest,
     ) => Effect.Effect<
       cloudwatch.GetMetricWidgetImageOutput,
-      cloudwatch.GetMetricWidgetImageError
+      cloudwatch.GetMetricWidgetImageError,
+      RuntimeContext
     >
   >
 >()("AWS.CloudWatch.GetMetricWidgetImage") {}

--- a/packages/alchemy/src/AWS/CloudWatch/ListAlarmMuteRules.ts
+++ b/packages/alchemy/src/AWS/CloudWatch/ListAlarmMuteRules.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface ListAlarmMuteRulesRequest
   extends cloudwatch.ListAlarmMuteRulesInput {}
@@ -17,7 +18,8 @@ export class ListAlarmMuteRules extends Binding.Service<
       request?: ListAlarmMuteRulesRequest,
     ) => Effect.Effect<
       cloudwatch.ListAlarmMuteRulesOutput,
-      cloudwatch.ListAlarmMuteRulesError
+      cloudwatch.ListAlarmMuteRulesError,
+      RuntimeContext
     >
   >
 >()("AWS.CloudWatch.ListAlarmMuteRules") {}

--- a/packages/alchemy/src/AWS/CloudWatch/ListDashboards.ts
+++ b/packages/alchemy/src/AWS/CloudWatch/ListDashboards.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface ListDashboardsRequest extends cloudwatch.ListDashboardsInput {}
 
@@ -16,7 +17,8 @@ export class ListDashboards extends Binding.Service<
       request?: ListDashboardsRequest,
     ) => Effect.Effect<
       cloudwatch.ListDashboardsOutput,
-      cloudwatch.ListDashboardsError
+      cloudwatch.ListDashboardsError,
+      RuntimeContext
     >
   >
 >()("AWS.CloudWatch.ListDashboards") {}

--- a/packages/alchemy/src/AWS/CloudWatch/ListManagedInsightRules.ts
+++ b/packages/alchemy/src/AWS/CloudWatch/ListManagedInsightRules.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface ListManagedInsightRulesRequest
   extends cloudwatch.ListManagedInsightRulesInput {}
@@ -17,7 +18,8 @@ export class ListManagedInsightRules extends Binding.Service<
       request?: ListManagedInsightRulesRequest,
     ) => Effect.Effect<
       cloudwatch.ListManagedInsightRulesOutput,
-      cloudwatch.ListManagedInsightRulesError
+      cloudwatch.ListManagedInsightRulesError,
+      RuntimeContext
     >
   >
 >()("AWS.CloudWatch.ListManagedInsightRules") {}

--- a/packages/alchemy/src/AWS/CloudWatch/ListMetricStreams.ts
+++ b/packages/alchemy/src/AWS/CloudWatch/ListMetricStreams.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface ListMetricStreamsRequest
   extends cloudwatch.ListMetricStreamsInput {}
@@ -17,7 +18,8 @@ export class ListMetricStreams extends Binding.Service<
       request?: ListMetricStreamsRequest,
     ) => Effect.Effect<
       cloudwatch.ListMetricStreamsOutput,
-      cloudwatch.ListMetricStreamsError
+      cloudwatch.ListMetricStreamsError,
+      RuntimeContext
     >
   >
 >()("AWS.CloudWatch.ListMetricStreams") {}

--- a/packages/alchemy/src/AWS/CloudWatch/ListMetrics.ts
+++ b/packages/alchemy/src/AWS/CloudWatch/ListMetrics.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface ListMetricsRequest extends cloudwatch.ListMetricsInput {}
 
@@ -16,7 +17,8 @@ export class ListMetrics extends Binding.Service<
       request?: ListMetricsRequest,
     ) => Effect.Effect<
       cloudwatch.ListMetricsOutput,
-      cloudwatch.ListMetricsError
+      cloudwatch.ListMetricsError,
+      RuntimeContext
     >
   >
 >()("AWS.CloudWatch.ListMetrics") {}

--- a/packages/alchemy/src/AWS/CloudWatch/ListTagsForResource.ts
+++ b/packages/alchemy/src/AWS/CloudWatch/ListTagsForResource.ts
@@ -7,6 +7,7 @@ import {
   getTaggableResourceArn,
   type TaggableResource,
 } from "./binding-common.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface ListTagsForResourceRequest extends Omit<
   cloudwatch.ListTagsForResourceInput,
@@ -25,7 +26,8 @@ export class ListTagsForResource extends Binding.Service<
       request?: ListTagsForResourceRequest,
     ) => Effect.Effect<
       cloudwatch.ListTagsForResourceOutput,
-      cloudwatch.ListTagsForResourceError
+      cloudwatch.ListTagsForResourceError,
+      RuntimeContext
     >
   >
 >()("AWS.CloudWatch.ListTagsForResource") {}

--- a/packages/alchemy/src/AWS/CloudWatch/PutMetricData.ts
+++ b/packages/alchemy/src/AWS/CloudWatch/PutMetricData.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface PutMetricDataRequest extends cloudwatch.PutMetricDataInput {}
 
@@ -16,7 +17,8 @@ export class PutMetricData extends Binding.Service<
       request: PutMetricDataRequest,
     ) => Effect.Effect<
       cloudwatch.PutMetricDataResponse,
-      cloudwatch.PutMetricDataError
+      cloudwatch.PutMetricDataError,
+      RuntimeContext
     >
   >
 >()("AWS.CloudWatch.PutMetricData") {}

--- a/packages/alchemy/src/AWS/CloudWatch/SetAlarmState.ts
+++ b/packages/alchemy/src/AWS/CloudWatch/SetAlarmState.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { AlarmResource } from "./binding-common.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface SetAlarmStateRequest extends Omit<
   cloudwatch.SetAlarmStateInput,
@@ -22,7 +23,8 @@ export class SetAlarmState extends Binding.Service<
       request: SetAlarmStateRequest,
     ) => Effect.Effect<
       cloudwatch.SetAlarmStateResponse,
-      cloudwatch.SetAlarmStateError
+      cloudwatch.SetAlarmStateError,
+      RuntimeContext
     >
   >
 >()("AWS.CloudWatch.SetAlarmState") {}

--- a/packages/alchemy/src/AWS/DynamoDB/BatchExecuteStatement.ts
+++ b/packages/alchemy/src/AWS/DynamoDB/BatchExecuteStatement.ts
@@ -5,6 +5,7 @@ import * as Binding from "../../Binding.ts";
 import * as Output from "../../Output.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Table } from "./Table.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 type BatchExecuteStatementTables = [Table, ...Table[]];
 
@@ -53,7 +54,8 @@ export class BatchExecuteStatement extends Binding.Service<
       request: BatchExecuteStatementRequest,
     ) => Effect.Effect<
       DynamoDB.BatchExecuteStatementOutput,
-      DynamoDB.BatchExecuteStatementError
+      DynamoDB.BatchExecuteStatementError,
+      RuntimeContext
     >
   >
 >()("AWS.DynamoDB.BatchExecuteStatement") {}

--- a/packages/alchemy/src/AWS/DynamoDB/BatchGetItem.ts
+++ b/packages/alchemy/src/AWS/DynamoDB/BatchGetItem.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Table } from "./Table.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 type BatchGetItemTables = [Table, ...Table[]];
 
@@ -58,7 +59,11 @@ export class BatchGetItem extends Binding.Service<
   ) => Effect.Effect<
     (
       request: BatchGetItemRequest,
-    ) => Effect.Effect<DynamoDB.BatchGetItemOutput, DynamoDB.BatchGetItemError>
+    ) => Effect.Effect<
+      DynamoDB.BatchGetItemOutput,
+      DynamoDB.BatchGetItemError,
+      RuntimeContext
+    >
   >
 >()("AWS.DynamoDB.BatchGetItem") {}
 

--- a/packages/alchemy/src/AWS/DynamoDB/BatchWriteItem.ts
+++ b/packages/alchemy/src/AWS/DynamoDB/BatchWriteItem.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Table } from "./Table.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 type BatchWriteItemTables = [Table, ...Table[]];
 
@@ -63,7 +64,8 @@ export class BatchWriteItem extends Binding.Service<
       request: BatchWriteItemRequest,
     ) => Effect.Effect<
       DynamoDB.BatchWriteItemOutput,
-      DynamoDB.BatchWriteItemError
+      DynamoDB.BatchWriteItemError,
+      RuntimeContext
     >
   >
 >()("AWS.DynamoDB.BatchWriteItem") {}

--- a/packages/alchemy/src/AWS/DynamoDB/DeleteItem.ts
+++ b/packages/alchemy/src/AWS/DynamoDB/DeleteItem.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Table } from "./Table.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface DeleteItemRequest extends Omit<
   DynamoDB.DeleteItemInput,
@@ -17,7 +18,11 @@ export class DeleteItem extends Binding.Service<
   ) => Effect.Effect<
     (
       request: DeleteItemRequest,
-    ) => Effect.Effect<DynamoDB.DeleteItemOutput, DynamoDB.DeleteItemError>
+    ) => Effect.Effect<
+      DynamoDB.DeleteItemOutput,
+      DynamoDB.DeleteItemError,
+      RuntimeContext
+    >
   >
 >()("AWS.DynamoDB.DeleteItem") {}
 

--- a/packages/alchemy/src/AWS/DynamoDB/DescribeTable.ts
+++ b/packages/alchemy/src/AWS/DynamoDB/DescribeTable.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Table } from "./Table.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface DescribeTableRequest extends Omit<
   DynamoDB.DescribeTableInput,
@@ -19,7 +20,8 @@ export class DescribeTable extends Binding.Service<
       request?: DescribeTableRequest,
     ) => Effect.Effect<
       DynamoDB.DescribeTableOutput,
-      DynamoDB.DescribeTableError
+      DynamoDB.DescribeTableError,
+      RuntimeContext
     >
   >
 >()("AWS.DynamoDB.DescribeTable") {}

--- a/packages/alchemy/src/AWS/DynamoDB/DescribeTimeToLive.ts
+++ b/packages/alchemy/src/AWS/DynamoDB/DescribeTimeToLive.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Table } from "./Table.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface DescribeTimeToLiveRequest extends Omit<
   DynamoDB.DescribeTimeToLiveInput,
@@ -19,7 +20,8 @@ export class DescribeTimeToLive extends Binding.Service<
       request?: DescribeTimeToLiveRequest,
     ) => Effect.Effect<
       DynamoDB.DescribeTimeToLiveOutput,
-      DynamoDB.DescribeTimeToLiveError
+      DynamoDB.DescribeTimeToLiveError,
+      RuntimeContext
     >
   >
 >()("AWS.DynamoDB.DescribeTimeToLive") {}

--- a/packages/alchemy/src/AWS/DynamoDB/ExecuteStatement.ts
+++ b/packages/alchemy/src/AWS/DynamoDB/ExecuteStatement.ts
@@ -5,6 +5,7 @@ import * as Binding from "../../Binding.ts";
 import * as Output from "../../Output.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Table } from "./Table.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface ExecuteStatementRequest
   extends DynamoDB.ExecuteStatementInput {}
@@ -35,7 +36,8 @@ export class ExecuteStatement extends Binding.Service<
       request: ExecuteStatementRequest,
     ) => Effect.Effect<
       DynamoDB.ExecuteStatementOutput,
-      DynamoDB.ExecuteStatementError
+      DynamoDB.ExecuteStatementError,
+      RuntimeContext
     >
   >
 >()("AWS.DynamoDB.ExecuteStatement") {}

--- a/packages/alchemy/src/AWS/DynamoDB/ExecuteTransaction.ts
+++ b/packages/alchemy/src/AWS/DynamoDB/ExecuteTransaction.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Table } from "./Table.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface ExecuteTransactionRequest
   extends DynamoDB.ExecuteTransactionInput {}
@@ -19,7 +20,8 @@ export class ExecuteTransaction extends Binding.Service<
       request: ExecuteTransactionRequest,
     ) => Effect.Effect<
       DynamoDB.ExecuteTransactionOutput,
-      DynamoDB.ExecuteTransactionError
+      DynamoDB.ExecuteTransactionError,
+      RuntimeContext
     >
   >
 >()("AWS.DynamoDB.ExecuteTransaction") {}

--- a/packages/alchemy/src/AWS/DynamoDB/GetItem.ts
+++ b/packages/alchemy/src/AWS/DynamoDB/GetItem.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Table } from "./Table.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface GetItemRequest extends Omit<
   DynamoDB.GetItemInput,
@@ -35,7 +36,11 @@ export class GetItem extends Binding.Service<
   ) => Effect.Effect<
     (
       request: GetItemRequest,
-    ) => Effect.Effect<DynamoDB.GetItemOutput, DynamoDB.GetItemError>
+    ) => Effect.Effect<
+      DynamoDB.GetItemOutput,
+      DynamoDB.GetItemError,
+      RuntimeContext
+    >
   >
 >()("AWS.DynamoDB.GetItem") {}
 

--- a/packages/alchemy/src/AWS/DynamoDB/ListTables.ts
+++ b/packages/alchemy/src/AWS/DynamoDB/ListTables.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface ListTablesRequest extends DynamoDB.ListTablesInput {}
 
@@ -11,7 +12,11 @@ export class ListTables extends Binding.Service<
   () => Effect.Effect<
     (
       request?: ListTablesRequest,
-    ) => Effect.Effect<DynamoDB.ListTablesOutput, DynamoDB.ListTablesError>
+    ) => Effect.Effect<
+      DynamoDB.ListTablesOutput,
+      DynamoDB.ListTablesError,
+      RuntimeContext
+    >
   >
 >()("AWS.DynamoDB.ListTables") {}
 

--- a/packages/alchemy/src/AWS/DynamoDB/ListTagsOfResource.ts
+++ b/packages/alchemy/src/AWS/DynamoDB/ListTagsOfResource.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Table } from "./Table.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface ListTagsOfResourceRequest extends Omit<
   DynamoDB.ListTagsOfResourceInput,
@@ -19,7 +20,8 @@ export class ListTagsOfResource extends Binding.Service<
       request?: ListTagsOfResourceRequest,
     ) => Effect.Effect<
       DynamoDB.ListTagsOfResourceOutput,
-      DynamoDB.ListTagsOfResourceError
+      DynamoDB.ListTagsOfResourceError,
+      RuntimeContext
     >
   >
 >()("AWS.DynamoDB.ListTagsOfResource") {}

--- a/packages/alchemy/src/AWS/DynamoDB/PutItem.ts
+++ b/packages/alchemy/src/AWS/DynamoDB/PutItem.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Table } from "./Table.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface PutItemRequest extends Omit<
   DynamoDB.PutItemInput,
@@ -17,7 +18,11 @@ export class PutItem extends Binding.Service<
   ) => Effect.Effect<
     (
       request: PutItemRequest,
-    ) => Effect.Effect<DynamoDB.PutItemOutput, DynamoDB.PutItemError>
+    ) => Effect.Effect<
+      DynamoDB.PutItemOutput,
+      DynamoDB.PutItemError,
+      RuntimeContext
+    >
   >
 >()("AWS.DynamoDB.PutItem") {}
 

--- a/packages/alchemy/src/AWS/DynamoDB/Query.ts
+++ b/packages/alchemy/src/AWS/DynamoDB/Query.ts
@@ -5,6 +5,7 @@ import * as Binding from "../../Binding.ts";
 import * as Output from "../../Output.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Table } from "./Table.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface QueryRequest extends Omit<DynamoDB.QueryInput, "TableName"> {}
 
@@ -15,7 +16,11 @@ export class Query extends Binding.Service<
   ) => Effect.Effect<
     (
       request: QueryRequest,
-    ) => Effect.Effect<DynamoDB.QueryOutput, DynamoDB.QueryError>
+    ) => Effect.Effect<
+      DynamoDB.QueryOutput,
+      DynamoDB.QueryError,
+      RuntimeContext
+    >
   >
 >()("AWS.DynamoDB.Query") {}
 

--- a/packages/alchemy/src/AWS/DynamoDB/RestoreTableToPointInTime.ts
+++ b/packages/alchemy/src/AWS/DynamoDB/RestoreTableToPointInTime.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Table } from "./Table.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface RestoreTableToPointInTimeRequest extends Omit<
   DynamoDB.RestoreTableToPointInTimeInput,
@@ -20,7 +21,8 @@ export class RestoreTableToPointInTime extends Binding.Service<
       request: RestoreTableToPointInTimeRequest,
     ) => Effect.Effect<
       DynamoDB.RestoreTableToPointInTimeOutput,
-      DynamoDB.RestoreTableToPointInTimeError
+      DynamoDB.RestoreTableToPointInTimeError,
+      RuntimeContext
     >
   >
 >()("AWS.DynamoDB.RestoreTableToPointInTime") {}

--- a/packages/alchemy/src/AWS/DynamoDB/Scan.ts
+++ b/packages/alchemy/src/AWS/DynamoDB/Scan.ts
@@ -5,6 +5,7 @@ import * as Binding from "../../Binding.ts";
 import * as Output from "../../Output.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Table } from "./Table.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface ScanRequest extends Omit<DynamoDB.ScanInput, "TableName"> {}
 
@@ -15,7 +16,7 @@ export class Scan extends Binding.Service<
   ) => Effect.Effect<
     (
       request: ScanRequest,
-    ) => Effect.Effect<DynamoDB.ScanOutput, DynamoDB.ScanError>
+    ) => Effect.Effect<DynamoDB.ScanOutput, DynamoDB.ScanError, RuntimeContext>
   >
 >()("AWS.DynamoDB.Scan") {}
 

--- a/packages/alchemy/src/AWS/DynamoDB/TransactGetItems.ts
+++ b/packages/alchemy/src/AWS/DynamoDB/TransactGetItems.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Table } from "./Table.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 type TransactGetItemsTables = [Table, ...Table[]];
 
@@ -68,7 +69,8 @@ export class TransactGetItems extends Binding.Service<
       request: TransactGetItemsRequest,
     ) => Effect.Effect<
       DynamoDB.TransactGetItemsOutput,
-      DynamoDB.TransactGetItemsError
+      DynamoDB.TransactGetItemsError,
+      RuntimeContext
     >
   >
 >()("AWS.DynamoDB.TransactGetItems") {}

--- a/packages/alchemy/src/AWS/DynamoDB/TransactWriteItems.ts
+++ b/packages/alchemy/src/AWS/DynamoDB/TransactWriteItems.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Table } from "./Table.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 type TransactWriteItemsTables = [Table, ...Table[]];
 
@@ -95,7 +96,8 @@ export class TransactWriteItems extends Binding.Service<
       request: TransactWriteItemsRequest,
     ) => Effect.Effect<
       DynamoDB.TransactWriteItemsOutput,
-      DynamoDB.TransactWriteItemsError
+      DynamoDB.TransactWriteItemsError,
+      RuntimeContext
     >
   >
 >()("AWS.DynamoDB.TransactWriteItems") {}

--- a/packages/alchemy/src/AWS/DynamoDB/UpdateItem.ts
+++ b/packages/alchemy/src/AWS/DynamoDB/UpdateItem.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Table } from "./Table.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface UpdateItemRequest extends Omit<
   DynamoDB.UpdateItemInput,
@@ -17,7 +18,11 @@ export class UpdateItem extends Binding.Service<
   ) => Effect.Effect<
     (
       request: UpdateItemRequest,
-    ) => Effect.Effect<DynamoDB.UpdateItemOutput, DynamoDB.UpdateItemError>
+    ) => Effect.Effect<
+      DynamoDB.UpdateItemOutput,
+      DynamoDB.UpdateItemError,
+      RuntimeContext
+    >
   >
 >()("AWS.DynamoDB.UpdateItem") {}
 

--- a/packages/alchemy/src/AWS/DynamoDB/UpdateTimeToLive.ts
+++ b/packages/alchemy/src/AWS/DynamoDB/UpdateTimeToLive.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Table } from "./Table.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface UpdateTimeToLiveRequest extends Omit<
   DynamoDB.UpdateTimeToLiveInput,
@@ -19,7 +20,8 @@ export class UpdateTimeToLive extends Binding.Service<
       request: UpdateTimeToLiveRequest,
     ) => Effect.Effect<
       DynamoDB.UpdateTimeToLiveOutput,
-      DynamoDB.UpdateTimeToLiveError
+      DynamoDB.UpdateTimeToLiveError,
+      RuntimeContext
     >
   >
 >()("AWS.DynamoDB.UpdateTimeToLive") {}

--- a/packages/alchemy/src/AWS/ECS/DescribeTasks.ts
+++ b/packages/alchemy/src/AWS/ECS/DescribeTasks.ts
@@ -5,6 +5,7 @@ import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import { isTask } from "./Task.ts";
 import type { Cluster } from "./Cluster.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface DescribeTasksRequest extends Omit<
   ECS.DescribeTasksRequest,
@@ -18,7 +19,11 @@ export class DescribeTasks extends Binding.Service<
   ) => Effect.Effect<
     (
       request: DescribeTasksRequest,
-    ) => Effect.Effect<ECS.DescribeTasksResponse, ECS.DescribeTasksError>
+    ) => Effect.Effect<
+      ECS.DescribeTasksResponse,
+      ECS.DescribeTasksError,
+      RuntimeContext
+    >
   >
 >()("AWS.ECS.DescribeTasks") {}
 

--- a/packages/alchemy/src/AWS/ECS/ListTasks.ts
+++ b/packages/alchemy/src/AWS/ECS/ListTasks.ts
@@ -5,6 +5,7 @@ import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import { isTask } from "./Task.ts";
 import type { Cluster } from "./Cluster.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface ListTasksRequest extends Omit<
   ECS.ListTasksRequest,
@@ -18,7 +19,11 @@ export class ListTasks extends Binding.Service<
   ) => Effect.Effect<
     (
       request: ListTasksRequest,
-    ) => Effect.Effect<ECS.ListTasksResponse, ECS.ListTasksError>
+    ) => Effect.Effect<
+      ECS.ListTasksResponse,
+      ECS.ListTasksError,
+      RuntimeContext
+    >
   >
 >()("AWS.ECS.ListTasks") {}
 

--- a/packages/alchemy/src/AWS/ECS/RunTask.ts
+++ b/packages/alchemy/src/AWS/ECS/RunTask.ts
@@ -5,6 +5,7 @@ import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import { Task, isTask } from "./Task.ts";
 import type { Cluster } from "./Cluster.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface RunTaskRequest extends Omit<
   ECS.RunTaskRequest,
@@ -19,7 +20,7 @@ export class RunTask extends Binding.Service<
   ) => Effect.Effect<
     (
       request: RunTaskRequest,
-    ) => Effect.Effect<ECS.RunTaskResponse, ECS.RunTaskError>
+    ) => Effect.Effect<ECS.RunTaskResponse, ECS.RunTaskError, RuntimeContext>
   >
 >()("AWS.ECS.RunTask") {}
 

--- a/packages/alchemy/src/AWS/ECS/StopTask.ts
+++ b/packages/alchemy/src/AWS/ECS/StopTask.ts
@@ -5,6 +5,7 @@ import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import { isTask } from "./Task.ts";
 import type { Cluster } from "./Cluster.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface StopTaskRequest extends Omit<ECS.StopTaskRequest, "cluster"> {}
 
@@ -15,7 +16,7 @@ export class StopTask extends Binding.Service<
   ) => Effect.Effect<
     (
       request: StopTaskRequest,
-    ) => Effect.Effect<ECS.StopTaskResponse, ECS.StopTaskError>
+    ) => Effect.Effect<ECS.StopTaskResponse, ECS.StopTaskError, RuntimeContext>
   >
 >()("AWS.ECS.StopTask") {}
 

--- a/packages/alchemy/src/AWS/EventBridge/DescribeEventBus.ts
+++ b/packages/alchemy/src/AWS/EventBridge/DescribeEventBus.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { EventBus } from "./EventBus.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface DescribeEventBusRequest extends Omit<
   eventbridge.DescribeEventBusRequest,
@@ -19,7 +20,8 @@ export class DescribeEventBus extends Binding.Service<
       request?: DescribeEventBusRequest,
     ) => Effect.Effect<
       eventbridge.DescribeEventBusResponse,
-      eventbridge.DescribeEventBusError
+      eventbridge.DescribeEventBusError,
+      RuntimeContext
     >
   >
 >()("AWS.EventBridge.DescribeEventBus") {}

--- a/packages/alchemy/src/AWS/EventBridge/DescribeRule.ts
+++ b/packages/alchemy/src/AWS/EventBridge/DescribeRule.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Rule } from "./Rule.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface DescribeRuleRequest extends Omit<
   eventbridge.DescribeRuleRequest,
@@ -19,7 +20,8 @@ export class DescribeRule extends Binding.Service<
       request?: DescribeRuleRequest,
     ) => Effect.Effect<
       eventbridge.DescribeRuleResponse,
-      eventbridge.DescribeRuleError
+      eventbridge.DescribeRuleError,
+      RuntimeContext
     >
   >
 >()("AWS.EventBridge.DescribeRule") {}

--- a/packages/alchemy/src/AWS/EventBridge/ListEventBuses.ts
+++ b/packages/alchemy/src/AWS/EventBridge/ListEventBuses.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface ListEventBusesRequest
   extends eventbridge.ListEventBusesRequest {}
@@ -14,7 +15,8 @@ export class ListEventBuses extends Binding.Service<
       request?: ListEventBusesRequest,
     ) => Effect.Effect<
       eventbridge.ListEventBusesResponse,
-      eventbridge.ListEventBusesError
+      eventbridge.ListEventBusesError,
+      RuntimeContext
     >
   >
 >()("AWS.EventBridge.ListEventBuses") {}

--- a/packages/alchemy/src/AWS/EventBridge/ListRules.ts
+++ b/packages/alchemy/src/AWS/EventBridge/ListRules.ts
@@ -7,6 +7,7 @@ import * as Output from "../../Output.ts";
 import { AWSEnvironment } from "../Environment.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { EventBus } from "./EventBus.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface ListRulesRequest extends Omit<
   eventbridge.ListRulesRequest,
@@ -22,7 +23,8 @@ export class ListRules extends Binding.Service<
       request?: ListRulesRequest,
     ) => Effect.Effect<
       eventbridge.ListRulesResponse,
-      eventbridge.ListRulesError
+      eventbridge.ListRulesError,
+      RuntimeContext
     >
   >
 >()("AWS.EventBridge.ListRules") {}

--- a/packages/alchemy/src/AWS/EventBridge/ListTargetsByRule.ts
+++ b/packages/alchemy/src/AWS/EventBridge/ListTargetsByRule.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Rule } from "./Rule.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface ListTargetsByRuleRequest extends Omit<
   eventbridge.ListTargetsByRuleRequest,
@@ -19,7 +20,8 @@ export class ListTargetsByRule extends Binding.Service<
       request?: ListTargetsByRuleRequest,
     ) => Effect.Effect<
       eventbridge.ListTargetsByRuleResponse,
-      eventbridge.ListTargetsByRuleError
+      eventbridge.ListTargetsByRuleError,
+      RuntimeContext
     >
   >
 >()("AWS.EventBridge.ListTargetsByRule") {}

--- a/packages/alchemy/src/AWS/EventBridge/PutEvents.ts
+++ b/packages/alchemy/src/AWS/EventBridge/PutEvents.ts
@@ -6,6 +6,7 @@ import * as Binding from "../../Binding.ts";
 import { AWSEnvironment } from "../Environment.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { EventBus } from "./EventBus.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface PutEventsRequest extends Omit<
   eventbridge.PutEventsRequest,
@@ -23,7 +24,8 @@ export class PutEvents extends Binding.Service<
       request: PutEventsRequest,
     ) => Effect.Effect<
       eventbridge.PutEventsResponse,
-      eventbridge.PutEventsError
+      eventbridge.PutEventsError,
+      RuntimeContext
     >
   >
 >()("AWS.EventBridge.PutEvents") {}

--- a/packages/alchemy/src/AWS/EventBridge/TestEventPattern.ts
+++ b/packages/alchemy/src/AWS/EventBridge/TestEventPattern.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface TestEventPatternRequest
   extends eventbridge.TestEventPatternRequest {}
@@ -14,7 +15,8 @@ export class TestEventPattern extends Binding.Service<
       request: TestEventPatternRequest,
     ) => Effect.Effect<
       eventbridge.TestEventPatternResponse,
-      eventbridge.TestEventPatternError
+      eventbridge.TestEventPatternError,
+      RuntimeContext
     >
   >
 >()("AWS.EventBridge.TestEventPattern") {}

--- a/packages/alchemy/src/AWS/Kinesis/DescribeAccountSettings.ts
+++ b/packages/alchemy/src/AWS/Kinesis/DescribeAccountSettings.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface DescribeAccountSettingsRequest
   extends Kinesis.DescribeAccountSettingsInput {}
@@ -14,7 +15,8 @@ export class DescribeAccountSettings extends Binding.Service<
       request?: DescribeAccountSettingsRequest,
     ) => Effect.Effect<
       Kinesis.DescribeAccountSettingsOutput,
-      Kinesis.DescribeAccountSettingsError
+      Kinesis.DescribeAccountSettingsError,
+      RuntimeContext
     >
   >
 >()("AWS.Kinesis.DescribeAccountSettings") {}

--- a/packages/alchemy/src/AWS/Kinesis/DescribeLimits.ts
+++ b/packages/alchemy/src/AWS/Kinesis/DescribeLimits.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface DescribeLimitsRequest extends Kinesis.DescribeLimitsInput {}
 
@@ -13,7 +14,8 @@ export class DescribeLimits extends Binding.Service<
       request?: DescribeLimitsRequest,
     ) => Effect.Effect<
       Kinesis.DescribeLimitsOutput,
-      Kinesis.DescribeLimitsError
+      Kinesis.DescribeLimitsError,
+      RuntimeContext
     >
   >
 >()("AWS.Kinesis.DescribeLimits") {}

--- a/packages/alchemy/src/AWS/Kinesis/DescribeStream.ts
+++ b/packages/alchemy/src/AWS/Kinesis/DescribeStream.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Stream } from "./Stream.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface DescribeStreamRequest extends Omit<
   Kinesis.DescribeStreamInput,
@@ -19,7 +20,8 @@ export class DescribeStream extends Binding.Service<
       request?: DescribeStreamRequest,
     ) => Effect.Effect<
       Kinesis.DescribeStreamOutput,
-      Kinesis.DescribeStreamError
+      Kinesis.DescribeStreamError,
+      RuntimeContext
     >
   >
 >()("AWS.Kinesis.DescribeStream") {}

--- a/packages/alchemy/src/AWS/Kinesis/DescribeStreamConsumer.ts
+++ b/packages/alchemy/src/AWS/Kinesis/DescribeStreamConsumer.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { StreamConsumer } from "./StreamConsumer.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface DescribeStreamConsumerRequest extends Omit<
   Kinesis.DescribeStreamConsumerInput,
@@ -19,7 +20,8 @@ export class DescribeStreamConsumer extends Binding.Service<
       request?: DescribeStreamConsumerRequest,
     ) => Effect.Effect<
       Kinesis.DescribeStreamConsumerOutput,
-      Kinesis.DescribeStreamConsumerError
+      Kinesis.DescribeStreamConsumerError,
+      RuntimeContext
     >
   >
 >()("AWS.Kinesis.DescribeStreamConsumer") {}

--- a/packages/alchemy/src/AWS/Kinesis/DescribeStreamSummary.ts
+++ b/packages/alchemy/src/AWS/Kinesis/DescribeStreamSummary.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Stream } from "./Stream.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface DescribeStreamSummaryRequest extends Omit<
   Kinesis.DescribeStreamSummaryInput,
@@ -19,7 +20,8 @@ export class DescribeStreamSummary extends Binding.Service<
       request?: DescribeStreamSummaryRequest,
     ) => Effect.Effect<
       Kinesis.DescribeStreamSummaryOutput,
-      Kinesis.DescribeStreamSummaryError
+      Kinesis.DescribeStreamSummaryError,
+      RuntimeContext
     >
   >
 >()("AWS.Kinesis.DescribeStreamSummary") {}

--- a/packages/alchemy/src/AWS/Kinesis/GetRecords.ts
+++ b/packages/alchemy/src/AWS/Kinesis/GetRecords.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Stream } from "./Stream.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface GetRecordsRequest extends Kinesis.GetRecordsInput {}
 
@@ -14,7 +15,11 @@ export class GetRecords extends Binding.Service<
   ) => Effect.Effect<
     (
       request: GetRecordsRequest,
-    ) => Effect.Effect<Kinesis.GetRecordsOutput, Kinesis.GetRecordsError>
+    ) => Effect.Effect<
+      Kinesis.GetRecordsOutput,
+      Kinesis.GetRecordsError,
+      RuntimeContext
+    >
   >
 >()("AWS.Kinesis.GetRecords") {}
 

--- a/packages/alchemy/src/AWS/Kinesis/GetResourcePolicy.ts
+++ b/packages/alchemy/src/AWS/Kinesis/GetResourcePolicy.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Stream } from "./Stream.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface GetResourcePolicyRequest extends Omit<
   Kinesis.GetResourcePolicyInput,
@@ -19,7 +20,8 @@ export class GetResourcePolicy extends Binding.Service<
       request?: GetResourcePolicyRequest,
     ) => Effect.Effect<
       Kinesis.GetResourcePolicyOutput,
-      Kinesis.GetResourcePolicyError
+      Kinesis.GetResourcePolicyError,
+      RuntimeContext
     >
   >
 >()("AWS.Kinesis.GetResourcePolicy") {}

--- a/packages/alchemy/src/AWS/Kinesis/GetShardIterator.ts
+++ b/packages/alchemy/src/AWS/Kinesis/GetShardIterator.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Stream } from "./Stream.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface GetShardIteratorRequest extends Omit<
   Kinesis.GetShardIteratorInput,
@@ -19,7 +20,8 @@ export class GetShardIterator extends Binding.Service<
       request: GetShardIteratorRequest,
     ) => Effect.Effect<
       Kinesis.GetShardIteratorOutput,
-      Kinesis.GetShardIteratorError
+      Kinesis.GetShardIteratorError,
+      RuntimeContext
     >
   >
 >()("AWS.Kinesis.GetShardIterator") {}

--- a/packages/alchemy/src/AWS/Kinesis/ListShards.ts
+++ b/packages/alchemy/src/AWS/Kinesis/ListShards.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Stream } from "./Stream.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface ListShardsRequest extends Omit<
   Kinesis.ListShardsInput,
@@ -17,7 +18,11 @@ export class ListShards extends Binding.Service<
   ) => Effect.Effect<
     (
       request?: ListShardsRequest,
-    ) => Effect.Effect<Kinesis.ListShardsOutput, Kinesis.ListShardsError>
+    ) => Effect.Effect<
+      Kinesis.ListShardsOutput,
+      Kinesis.ListShardsError,
+      RuntimeContext
+    >
   >
 >()("AWS.Kinesis.ListShards") {}
 

--- a/packages/alchemy/src/AWS/Kinesis/ListStreamConsumers.ts
+++ b/packages/alchemy/src/AWS/Kinesis/ListStreamConsumers.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Stream } from "./Stream.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface ListStreamConsumersRequest extends Omit<
   Kinesis.ListStreamConsumersInput,
@@ -19,7 +20,8 @@ export class ListStreamConsumers extends Binding.Service<
       request?: ListStreamConsumersRequest,
     ) => Effect.Effect<
       Kinesis.ListStreamConsumersOutput,
-      Kinesis.ListStreamConsumersError
+      Kinesis.ListStreamConsumersError,
+      RuntimeContext
     >
   >
 >()("AWS.Kinesis.ListStreamConsumers") {}

--- a/packages/alchemy/src/AWS/Kinesis/ListStreams.ts
+++ b/packages/alchemy/src/AWS/Kinesis/ListStreams.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface ListStreamsRequest extends Kinesis.ListStreamsInput {}
 
@@ -11,7 +12,11 @@ export class ListStreams extends Binding.Service<
   () => Effect.Effect<
     (
       request?: ListStreamsRequest,
-    ) => Effect.Effect<Kinesis.ListStreamsOutput, Kinesis.ListStreamsError>
+    ) => Effect.Effect<
+      Kinesis.ListStreamsOutput,
+      Kinesis.ListStreamsError,
+      RuntimeContext
+    >
   >
 >()("AWS.Kinesis.ListStreams") {}
 

--- a/packages/alchemy/src/AWS/Kinesis/ListTagsForResource.ts
+++ b/packages/alchemy/src/AWS/Kinesis/ListTagsForResource.ts
@@ -5,6 +5,7 @@ import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Stream } from "./Stream.ts";
 import type { StreamConsumer } from "./StreamConsumer.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 type TaggableResource = Stream | StreamConsumer;
 
@@ -22,7 +23,8 @@ export class ListTagsForResource extends Binding.Service<
       request?: ListTagsForResourceRequest,
     ) => Effect.Effect<
       Kinesis.ListTagsForResourceOutput,
-      Kinesis.ListTagsForResourceError
+      Kinesis.ListTagsForResourceError,
+      RuntimeContext
     >
   >
 >()("AWS.Kinesis.ListTagsForResource") {}

--- a/packages/alchemy/src/AWS/Kinesis/PutRecord.ts
+++ b/packages/alchemy/src/AWS/Kinesis/PutRecord.ts
@@ -5,6 +5,7 @@ import * as Binding from "../../Binding.ts";
 import * as Output from "../../Output.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Stream } from "./Stream.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface PutRecordRequest extends Omit<
   Kinesis.PutRecordInput,
@@ -18,7 +19,11 @@ export class PutRecord extends Binding.Service<
   ) => Effect.Effect<
     (
       request: PutRecordRequest,
-    ) => Effect.Effect<Kinesis.PutRecordOutput, Kinesis.PutRecordError>
+    ) => Effect.Effect<
+      Kinesis.PutRecordOutput,
+      Kinesis.PutRecordError,
+      RuntimeContext
+    >
   >
 >()("AWS.Kinesis.PutRecord") {}
 

--- a/packages/alchemy/src/AWS/Kinesis/PutRecords.ts
+++ b/packages/alchemy/src/AWS/Kinesis/PutRecords.ts
@@ -5,6 +5,7 @@ import * as Binding from "../../Binding.ts";
 import * as Output from "../../Output.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Stream } from "./Stream.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface PutRecordsRequest extends Omit<
   Kinesis.PutRecordsInput,
@@ -18,7 +19,11 @@ export class PutRecords extends Binding.Service<
   ) => Effect.Effect<
     (
       request: PutRecordsRequest,
-    ) => Effect.Effect<Kinesis.PutRecordsOutput, Kinesis.PutRecordsError>
+    ) => Effect.Effect<
+      Kinesis.PutRecordsOutput,
+      Kinesis.PutRecordsError,
+      RuntimeContext
+    >
   >
 >()("AWS.Kinesis.PutRecords") {}
 

--- a/packages/alchemy/src/AWS/Kinesis/StreamSink.ts
+++ b/packages/alchemy/src/AWS/Kinesis/StreamSink.ts
@@ -6,6 +6,7 @@ import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import { PutRecords } from "./PutRecords.ts";
 import type { Stream } from "./Stream.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export type StreamSinkRecord = Kinesis.PutRecordsRequestEntry;
 
@@ -14,7 +15,13 @@ export class StreamSink extends Binding.Service<
   (
     stream: Stream,
   ) => Effect.Effect<
-    Sink.Sink<void, StreamSinkRecord, readonly StreamSinkRecord[], never>
+    Sink.Sink<
+      void,
+      StreamSinkRecord,
+      readonly StreamSinkRecord[],
+      never,
+      RuntimeContext
+    >
   >
 >()("AWS.Kinesis.StreamSink") {}
 

--- a/packages/alchemy/src/AWS/Kinesis/SubscribeToShard.ts
+++ b/packages/alchemy/src/AWS/Kinesis/SubscribeToShard.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { StreamConsumer } from "./StreamConsumer.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface SubscribeToShardRequest extends Omit<
   Kinesis.SubscribeToShardInput,
@@ -19,7 +20,8 @@ export class SubscribeToShard extends Binding.Service<
       request: SubscribeToShardRequest,
     ) => Effect.Effect<
       Kinesis.SubscribeToShardOutput,
-      Kinesis.SubscribeToShardError
+      Kinesis.SubscribeToShardError,
+      RuntimeContext
     >
   >
 >()("AWS.Kinesis.SubscribeToShard") {}

--- a/packages/alchemy/src/AWS/Lambda/InvokeFunction.ts
+++ b/packages/alchemy/src/AWS/Lambda/InvokeFunction.ts
@@ -5,6 +5,7 @@ import * as Binding from "../../Binding.ts";
 import * as Output from "../../Output.ts";
 import type { Function } from "./Function.ts";
 import { isFunction } from "./Function.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface InvokeFunctionRequest extends Omit<
   Lambda.InvocationRequest,
@@ -18,7 +19,11 @@ export class InvokeFunction extends Binding.Service<
   ) => Effect.Effect<
     (
       request: InvokeFunctionRequest,
-    ) => Effect.Effect<Lambda.InvocationResponse, Lambda.InvokeError>
+    ) => Effect.Effect<
+      Lambda.InvocationResponse,
+      Lambda.InvokeError,
+      RuntimeContext
+    >
   >
 >()("AWS.Lambda.InvokeFunction") {}
 

--- a/packages/alchemy/src/AWS/RDS/Connect.ts
+++ b/packages/alchemy/src/AWS/RDS/Connect.ts
@@ -11,6 +11,7 @@ import type { Secret } from "../SecretsManager/Secret.ts";
 import type { DBCluster } from "./DBCluster.ts";
 import type { DBProxy } from "./DBProxy.ts";
 import type { DBProxyEndpoint } from "./DBProxyEndpoint.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 type ConnectResource = DBCluster | DBProxy | DBProxyEndpoint;
 
@@ -42,7 +43,11 @@ export class Connect extends Binding.Service<
     resource: ConnectResource,
     options: ConnectOptions,
   ) => Effect.Effect<
-    Effect.Effect<ConnectionInfo, secretsmanager.GetSecretValueError>
+    Effect.Effect<
+      ConnectionInfo,
+      secretsmanager.GetSecretValueError,
+      RuntimeContext
+    >
   >
 >()("AWS.RDS.Connect") {}
 

--- a/packages/alchemy/src/AWS/RDSData/BatchExecuteStatement.ts
+++ b/packages/alchemy/src/AWS/RDSData/BatchExecuteStatement.ts
@@ -5,6 +5,7 @@ import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { DBCluster } from "../RDS/DBCluster.ts";
 import type { Secret } from "../SecretsManager/Secret.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface BatchExecuteStatementOptions {
   secret: Secret;
@@ -30,7 +31,8 @@ export class BatchExecuteStatement extends Binding.Service<
       request: BatchExecuteStatementRequest,
     ) => Effect.Effect<
       rdsdata.BatchExecuteStatementResponse,
-      rdsdata.BatchExecuteStatementError
+      rdsdata.BatchExecuteStatementError,
+      RuntimeContext
     >
   >
 >()("AWS.RDSData.BatchExecuteStatement") {}

--- a/packages/alchemy/src/AWS/RDSData/BeginTransaction.ts
+++ b/packages/alchemy/src/AWS/RDSData/BeginTransaction.ts
@@ -5,6 +5,7 @@ import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { DBCluster } from "../RDS/DBCluster.ts";
 import type { Secret } from "../SecretsManager/Secret.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface BeginTransactionOptions {
   secret: Secret;
@@ -23,7 +24,8 @@ export class BeginTransaction extends Binding.Service<
   ) => Effect.Effect<
     () => Effect.Effect<
       rdsdata.BeginTransactionResponse,
-      rdsdata.BeginTransactionError
+      rdsdata.BeginTransactionError,
+      RuntimeContext
     >
   >
 >()("AWS.RDSData.BeginTransaction") {}

--- a/packages/alchemy/src/AWS/RDSData/CommitTransaction.ts
+++ b/packages/alchemy/src/AWS/RDSData/CommitTransaction.ts
@@ -5,6 +5,7 @@ import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { DBCluster } from "../RDS/DBCluster.ts";
 import type { Secret } from "../SecretsManager/Secret.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface CommitTransactionOptions {
   secret: Secret;
@@ -28,7 +29,8 @@ export class CommitTransaction extends Binding.Service<
       request: CommitTransactionRequest,
     ) => Effect.Effect<
       rdsdata.CommitTransactionResponse,
-      rdsdata.CommitTransactionError
+      rdsdata.CommitTransactionError,
+      RuntimeContext
     >
   >
 >()("AWS.RDSData.CommitTransaction") {}

--- a/packages/alchemy/src/AWS/RDSData/ExecuteSql.ts
+++ b/packages/alchemy/src/AWS/RDSData/ExecuteSql.ts
@@ -5,6 +5,7 @@ import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { DBCluster } from "../RDS/DBCluster.ts";
 import type { Secret } from "../SecretsManager/Secret.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface ExecuteSqlOptions {
   secret: Secret;
@@ -28,7 +29,11 @@ export class ExecuteSql extends Binding.Service<
   ) => Effect.Effect<
     (
       request: ExecuteSqlRequest,
-    ) => Effect.Effect<rdsdata.ExecuteSqlResponse, rdsdata.ExecuteSqlError>
+    ) => Effect.Effect<
+      rdsdata.ExecuteSqlResponse,
+      rdsdata.ExecuteSqlError,
+      RuntimeContext
+    >
   >
 >()("AWS.RDSData.ExecuteSql") {}
 

--- a/packages/alchemy/src/AWS/RDSData/ExecuteStatement.ts
+++ b/packages/alchemy/src/AWS/RDSData/ExecuteStatement.ts
@@ -5,6 +5,7 @@ import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { DBCluster } from "../RDS/DBCluster.ts";
 import type { Secret } from "../SecretsManager/Secret.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface ExecuteStatementOptions {
   secret: Secret;
@@ -30,7 +31,8 @@ export class ExecuteStatement extends Binding.Service<
       request: ExecuteStatementRequest,
     ) => Effect.Effect<
       rdsdata.ExecuteStatementResponse,
-      rdsdata.ExecuteStatementError
+      rdsdata.ExecuteStatementError,
+      RuntimeContext
     >
   >
 >()("AWS.RDSData.ExecuteStatement") {}

--- a/packages/alchemy/src/AWS/RDSData/RollbackTransaction.ts
+++ b/packages/alchemy/src/AWS/RDSData/RollbackTransaction.ts
@@ -5,6 +5,7 @@ import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { DBCluster } from "../RDS/DBCluster.ts";
 import type { Secret } from "../SecretsManager/Secret.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface RollbackTransactionOptions {
   secret: Secret;
@@ -28,7 +29,8 @@ export class RollbackTransaction extends Binding.Service<
       request: RollbackTransactionRequest,
     ) => Effect.Effect<
       rdsdata.RollbackTransactionResponse,
-      rdsdata.RollbackTransactionError
+      rdsdata.RollbackTransactionError,
+      RuntimeContext
     >
   >
 >()("AWS.RDSData.RollbackTransaction") {}

--- a/packages/alchemy/src/AWS/S3/AbortMultipartUpload.ts
+++ b/packages/alchemy/src/AWS/S3/AbortMultipartUpload.ts
@@ -5,6 +5,7 @@ import * as Binding from "../../Binding.ts";
 import * as Output from "../../Output.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Bucket } from "./Bucket.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface AbortMultipartUploadRequest extends Omit<
   S3.AbortMultipartUploadRequest,
@@ -20,7 +21,8 @@ export class AbortMultipartUpload extends Binding.Service<
       request: AbortMultipartUploadRequest,
     ) => Effect.Effect<
       S3.AbortMultipartUploadOutput,
-      S3.AbortMultipartUploadError
+      S3.AbortMultipartUploadError,
+      RuntimeContext
     >
   >
 >()("AWS.S3.AbortMultipartUpload") {}

--- a/packages/alchemy/src/AWS/S3/CompleteMultipartUpload.ts
+++ b/packages/alchemy/src/AWS/S3/CompleteMultipartUpload.ts
@@ -5,6 +5,7 @@ import * as Binding from "../../Binding.ts";
 import * as Output from "../../Output.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Bucket } from "./Bucket.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface CompleteMultipartUploadRequest extends Omit<
   S3.CompleteMultipartUploadRequest,
@@ -20,7 +21,8 @@ export class CompleteMultipartUpload extends Binding.Service<
       request: CompleteMultipartUploadRequest,
     ) => Effect.Effect<
       S3.CompleteMultipartUploadOutput,
-      S3.CompleteMultipartUploadError
+      S3.CompleteMultipartUploadError,
+      RuntimeContext
     >
   >
 >()("AWS.S3.CompleteMultipartUpload") {}

--- a/packages/alchemy/src/AWS/S3/CopyObject.ts
+++ b/packages/alchemy/src/AWS/S3/CopyObject.ts
@@ -6,6 +6,7 @@ import * as Binding from "../../Binding.ts";
 import * as Output from "../../Output.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Bucket } from "./Bucket.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface CopyObjectRequest extends Omit<
   S3.CopyObjectRequest,
@@ -19,7 +20,7 @@ export class CopyObject extends Binding.Service<
   ) => Effect.Effect<
     (
       request: CopyObjectRequest,
-    ) => Effect.Effect<S3.CopyObjectOutput, S3.CopyObjectError>
+    ) => Effect.Effect<S3.CopyObjectOutput, S3.CopyObjectError, RuntimeContext>
   >
 >()("AWS.S3.CopyObject") {}
 

--- a/packages/alchemy/src/AWS/S3/CreateMultipartUpload.ts
+++ b/packages/alchemy/src/AWS/S3/CreateMultipartUpload.ts
@@ -5,6 +5,7 @@ import * as Binding from "../../Binding.ts";
 import * as Output from "../../Output.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Bucket } from "./Bucket.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface CreateMultipartUploadRequest extends Omit<
   S3.CreateMultipartUploadRequest,
@@ -20,7 +21,8 @@ export class CreateMultipartUpload extends Binding.Service<
       request: CreateMultipartUploadRequest,
     ) => Effect.Effect<
       S3.CreateMultipartUploadOutput,
-      S3.CreateMultipartUploadError
+      S3.CreateMultipartUploadError,
+      RuntimeContext
     >
   >
 >()("AWS.S3.CreateMultipartUpload") {}

--- a/packages/alchemy/src/AWS/S3/DeleteObject.ts
+++ b/packages/alchemy/src/AWS/S3/DeleteObject.ts
@@ -5,6 +5,7 @@ import * as Binding from "../../Binding.ts";
 import * as Output from "../../Output.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Bucket } from "./Bucket.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface DeleteObjectRequest extends Omit<
   S3.DeleteObjectRequest,
@@ -18,7 +19,11 @@ export class DeleteObject extends Binding.Service<
   ) => Effect.Effect<
     (
       request: DeleteObjectRequest,
-    ) => Effect.Effect<S3.DeleteObjectOutput, S3.DeleteObjectError>
+    ) => Effect.Effect<
+      S3.DeleteObjectOutput,
+      S3.DeleteObjectError,
+      RuntimeContext
+    >
   >
 >()("AWS.S3.DeleteObject") {}
 

--- a/packages/alchemy/src/AWS/S3/GetObject.ts
+++ b/packages/alchemy/src/AWS/S3/GetObject.ts
@@ -5,6 +5,7 @@ import * as Binding from "../../Binding.ts";
 import * as Output from "../../Output.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Bucket } from "./Bucket.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface GetObjectRequest extends Omit<S3.GetObjectRequest, "Bucket"> {}
 
@@ -15,7 +16,7 @@ export class GetObject extends Binding.Service<
   ) => Effect.Effect<
     (
       request: GetObjectRequest,
-    ) => Effect.Effect<S3.GetObjectOutput, S3.GetObjectError>
+    ) => Effect.Effect<S3.GetObjectOutput, S3.GetObjectError, RuntimeContext>
   >
 >()("AWS.S3.GetObject") {}
 

--- a/packages/alchemy/src/AWS/S3/HeadObject.ts
+++ b/packages/alchemy/src/AWS/S3/HeadObject.ts
@@ -5,6 +5,7 @@ import * as Binding from "../../Binding.ts";
 import * as Output from "../../Output.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Bucket } from "./Bucket.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface HeadObjectRequest extends Omit<
   S3.HeadObjectRequest,
@@ -18,7 +19,7 @@ export class HeadObject extends Binding.Service<
   ) => Effect.Effect<
     (
       request: HeadObjectRequest,
-    ) => Effect.Effect<S3.HeadObjectOutput, S3.HeadObjectError>
+    ) => Effect.Effect<S3.HeadObjectOutput, S3.HeadObjectError, RuntimeContext>
   >
 >()("AWS.S3.HeadObject") {}
 

--- a/packages/alchemy/src/AWS/S3/ListObjectsV2.ts
+++ b/packages/alchemy/src/AWS/S3/ListObjectsV2.ts
@@ -5,6 +5,7 @@ import * as Binding from "../../Binding.ts";
 import * as Output from "../../Output.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Bucket } from "./Bucket.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface ListObjectsV2Request extends Omit<
   S3.ListObjectsV2Request,
@@ -18,7 +19,11 @@ export class ListObjectsV2 extends Binding.Service<
   ) => Effect.Effect<
     (
       request?: ListObjectsV2Request,
-    ) => Effect.Effect<S3.ListObjectsV2Output, S3.ListObjectsV2Error>
+    ) => Effect.Effect<
+      S3.ListObjectsV2Output,
+      S3.ListObjectsV2Error,
+      RuntimeContext
+    >
   >
 >()("AWS.S3.ListObjectsV2") {}
 

--- a/packages/alchemy/src/AWS/S3/PutObject.ts
+++ b/packages/alchemy/src/AWS/S3/PutObject.ts
@@ -1,6 +1,7 @@
 import * as S3 from "@distilled.cloud/aws/s3";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 import * as Binding from "../../Binding.ts";
 import * as Output from "../../Output.ts";
@@ -34,7 +35,7 @@ export class PutObject extends Binding.Service<
   ) => Effect.Effect<
     (
       request: PutObjectRequest,
-    ) => Effect.Effect<S3.PutObjectOutput, S3.PutObjectError>
+    ) => Effect.Effect<S3.PutObjectOutput, S3.PutObjectError, RuntimeContext>
   >
 >()("AWS.S3.PutObject") {}
 

--- a/packages/alchemy/src/AWS/S3/UploadPart.ts
+++ b/packages/alchemy/src/AWS/S3/UploadPart.ts
@@ -5,6 +5,7 @@ import * as Binding from "../../Binding.ts";
 import * as Output from "../../Output.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Bucket } from "./Bucket.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface UploadPartRequest extends Omit<
   S3.UploadPartRequest,
@@ -18,7 +19,7 @@ export class UploadPart extends Binding.Service<
   ) => Effect.Effect<
     (
       request: UploadPartRequest,
-    ) => Effect.Effect<S3.UploadPartOutput, S3.UploadPartError>
+    ) => Effect.Effect<S3.UploadPartOutput, S3.UploadPartError, RuntimeContext>
   >
 >()("AWS.S3.UploadPart") {}
 

--- a/packages/alchemy/src/AWS/SNS/AddPermission.ts
+++ b/packages/alchemy/src/AWS/SNS/AddPermission.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Topic } from "./Topic.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface AddPermissionRequest extends Omit<
   sns.AddPermissionInput,
@@ -17,7 +18,11 @@ export class AddPermission extends Binding.Service<
   ) => Effect.Effect<
     (
       request: AddPermissionRequest,
-    ) => Effect.Effect<sns.AddPermissionResponse, sns.AddPermissionError>
+    ) => Effect.Effect<
+      sns.AddPermissionResponse,
+      sns.AddPermissionError,
+      RuntimeContext
+    >
   >
 >()("AWS.SNS.AddPermission") {}
 

--- a/packages/alchemy/src/AWS/SNS/ConfirmSubscription.ts
+++ b/packages/alchemy/src/AWS/SNS/ConfirmSubscription.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Subscription } from "./Subscription.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface ConfirmSubscriptionRequest extends Omit<
   sns.ConfirmSubscriptionInput,
@@ -19,7 +20,8 @@ export class ConfirmSubscription extends Binding.Service<
       request: ConfirmSubscriptionRequest,
     ) => Effect.Effect<
       sns.ConfirmSubscriptionResponse,
-      sns.ConfirmSubscriptionError
+      sns.ConfirmSubscriptionError,
+      RuntimeContext
     >
   >
 >()("AWS.SNS.ConfirmSubscription") {}

--- a/packages/alchemy/src/AWS/SNS/GetDataProtectionPolicy.ts
+++ b/packages/alchemy/src/AWS/SNS/GetDataProtectionPolicy.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Topic } from "./Topic.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface GetDataProtectionPolicyRequest extends Omit<
   sns.GetDataProtectionPolicyInput,
@@ -19,7 +20,8 @@ export class GetDataProtectionPolicy extends Binding.Service<
       request?: GetDataProtectionPolicyRequest,
     ) => Effect.Effect<
       sns.GetDataProtectionPolicyResponse,
-      sns.GetDataProtectionPolicyError
+      sns.GetDataProtectionPolicyError,
+      RuntimeContext
     >
   >
 >()("AWS.SNS.GetDataProtectionPolicy") {}

--- a/packages/alchemy/src/AWS/SNS/GetSubscriptionAttributes.ts
+++ b/packages/alchemy/src/AWS/SNS/GetSubscriptionAttributes.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Subscription } from "./Subscription.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface GetSubscriptionAttributesRequest extends Omit<
   sns.GetSubscriptionAttributesInput,
@@ -19,7 +20,8 @@ export class GetSubscriptionAttributes extends Binding.Service<
       request?: GetSubscriptionAttributesRequest,
     ) => Effect.Effect<
       sns.GetSubscriptionAttributesResponse,
-      sns.GetSubscriptionAttributesError
+      sns.GetSubscriptionAttributesError,
+      RuntimeContext
     >
   >
 >()("AWS.SNS.GetSubscriptionAttributes") {}

--- a/packages/alchemy/src/AWS/SNS/GetTopicAttributes.ts
+++ b/packages/alchemy/src/AWS/SNS/GetTopicAttributes.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Topic } from "./Topic.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface GetTopicAttributesRequest extends Omit<
   sns.GetTopicAttributesInput,
@@ -19,7 +20,8 @@ export class GetTopicAttributes extends Binding.Service<
       request?: GetTopicAttributesRequest,
     ) => Effect.Effect<
       sns.GetTopicAttributesResponse,
-      sns.GetTopicAttributesError
+      sns.GetTopicAttributesError,
+      RuntimeContext
     >
   >
 >()("AWS.SNS.GetTopicAttributes") {}

--- a/packages/alchemy/src/AWS/SNS/ListSubscriptions.ts
+++ b/packages/alchemy/src/AWS/SNS/ListSubscriptions.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface ListSubscriptionsRequest extends sns.ListSubscriptionsInput {}
 
@@ -13,7 +14,8 @@ export class ListSubscriptions extends Binding.Service<
       request?: ListSubscriptionsRequest,
     ) => Effect.Effect<
       sns.ListSubscriptionsResponse,
-      sns.ListSubscriptionsError
+      sns.ListSubscriptionsError,
+      RuntimeContext
     >
   >
 >()("AWS.SNS.ListSubscriptions") {}

--- a/packages/alchemy/src/AWS/SNS/ListSubscriptionsByTopic.ts
+++ b/packages/alchemy/src/AWS/SNS/ListSubscriptionsByTopic.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Topic } from "./Topic.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface ListSubscriptionsByTopicRequest extends Omit<
   sns.ListSubscriptionsByTopicInput,
@@ -19,7 +20,8 @@ export class ListSubscriptionsByTopic extends Binding.Service<
       request?: ListSubscriptionsByTopicRequest,
     ) => Effect.Effect<
       sns.ListSubscriptionsByTopicResponse,
-      sns.ListSubscriptionsByTopicError
+      sns.ListSubscriptionsByTopicError,
+      RuntimeContext
     >
   >
 >()("AWS.SNS.ListSubscriptionsByTopic") {}

--- a/packages/alchemy/src/AWS/SNS/ListTagsForResource.ts
+++ b/packages/alchemy/src/AWS/SNS/ListTagsForResource.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Topic } from "./Topic.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface ListTagsForResourceRequest extends Omit<
   sns.ListTagsForResourceRequest,
@@ -19,7 +20,8 @@ export class ListTagsForResource extends Binding.Service<
       request?: ListTagsForResourceRequest,
     ) => Effect.Effect<
       sns.ListTagsForResourceResponse,
-      sns.ListTagsForResourceError
+      sns.ListTagsForResourceError,
+      RuntimeContext
     >
   >
 >()("AWS.SNS.ListTagsForResource") {}

--- a/packages/alchemy/src/AWS/SNS/ListTopics.ts
+++ b/packages/alchemy/src/AWS/SNS/ListTopics.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface ListTopicsRequest extends sns.ListTopicsInput {}
 
@@ -11,7 +12,11 @@ export class ListTopics extends Binding.Service<
   () => Effect.Effect<
     (
       request?: ListTopicsRequest,
-    ) => Effect.Effect<sns.ListTopicsResponse, sns.ListTopicsError>
+    ) => Effect.Effect<
+      sns.ListTopicsResponse,
+      sns.ListTopicsError,
+      RuntimeContext
+    >
   >
 >()("AWS.SNS.ListTopics") {}
 

--- a/packages/alchemy/src/AWS/SNS/Publish.ts
+++ b/packages/alchemy/src/AWS/SNS/Publish.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Topic } from "./Topic.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface PublishRequest extends Omit<
   sns.PublishInput,
@@ -17,7 +18,7 @@ export class Publish extends Binding.Service<
   ) => Effect.Effect<
     (
       request: PublishRequest,
-    ) => Effect.Effect<sns.PublishResponse, sns.PublishError>
+    ) => Effect.Effect<sns.PublishResponse, sns.PublishError, RuntimeContext>
   >
 >()("AWS.SNS.Publish") {}
 

--- a/packages/alchemy/src/AWS/SNS/PublishBatch.ts
+++ b/packages/alchemy/src/AWS/SNS/PublishBatch.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Topic } from "./Topic.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface PublishBatchRequest extends Omit<
   sns.PublishBatchInput,
@@ -17,7 +18,11 @@ export class PublishBatch extends Binding.Service<
   ) => Effect.Effect<
     (
       request: PublishBatchRequest,
-    ) => Effect.Effect<sns.PublishBatchResponse, sns.PublishBatchError>
+    ) => Effect.Effect<
+      sns.PublishBatchResponse,
+      sns.PublishBatchError,
+      RuntimeContext
+    >
   >
 >()("AWS.SNS.PublishBatch") {}
 

--- a/packages/alchemy/src/AWS/SNS/PutDataProtectionPolicy.ts
+++ b/packages/alchemy/src/AWS/SNS/PutDataProtectionPolicy.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Topic } from "./Topic.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface PutDataProtectionPolicyRequest extends Omit<
   sns.PutDataProtectionPolicyInput,
@@ -19,7 +20,8 @@ export class PutDataProtectionPolicy extends Binding.Service<
       request: PutDataProtectionPolicyRequest,
     ) => Effect.Effect<
       sns.PutDataProtectionPolicyResponse,
-      sns.PutDataProtectionPolicyError
+      sns.PutDataProtectionPolicyError,
+      RuntimeContext
     >
   >
 >()("AWS.SNS.PutDataProtectionPolicy") {}

--- a/packages/alchemy/src/AWS/SNS/RemovePermission.ts
+++ b/packages/alchemy/src/AWS/SNS/RemovePermission.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Topic } from "./Topic.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface RemovePermissionRequest extends Omit<
   sns.RemovePermissionInput,
@@ -17,7 +18,11 @@ export class RemovePermission extends Binding.Service<
   ) => Effect.Effect<
     (
       request: RemovePermissionRequest,
-    ) => Effect.Effect<sns.RemovePermissionResponse, sns.RemovePermissionError>
+    ) => Effect.Effect<
+      sns.RemovePermissionResponse,
+      sns.RemovePermissionError,
+      RuntimeContext
+    >
   >
 >()("AWS.SNS.RemovePermission") {}
 

--- a/packages/alchemy/src/AWS/SNS/SetSubscriptionAttributes.ts
+++ b/packages/alchemy/src/AWS/SNS/SetSubscriptionAttributes.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Subscription } from "./Subscription.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface SetSubscriptionAttributesRequest extends Omit<
   sns.SetSubscriptionAttributesInput,
@@ -19,7 +20,8 @@ export class SetSubscriptionAttributes extends Binding.Service<
       request: SetSubscriptionAttributesRequest,
     ) => Effect.Effect<
       sns.SetSubscriptionAttributesResponse,
-      sns.SetSubscriptionAttributesError
+      sns.SetSubscriptionAttributesError,
+      RuntimeContext
     >
   >
 >()("AWS.SNS.SetSubscriptionAttributes") {}

--- a/packages/alchemy/src/AWS/SNS/SetTopicAttributes.ts
+++ b/packages/alchemy/src/AWS/SNS/SetTopicAttributes.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Topic } from "./Topic.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface SetTopicAttributesRequest extends Omit<
   sns.SetTopicAttributesInput,
@@ -19,7 +20,8 @@ export class SetTopicAttributes extends Binding.Service<
       request: SetTopicAttributesRequest,
     ) => Effect.Effect<
       sns.SetTopicAttributesResponse,
-      sns.SetTopicAttributesError
+      sns.SetTopicAttributesError,
+      RuntimeContext
     >
   >
 >()("AWS.SNS.SetTopicAttributes") {}

--- a/packages/alchemy/src/AWS/SNS/TagResource.ts
+++ b/packages/alchemy/src/AWS/SNS/TagResource.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Topic } from "./Topic.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface TagResourceRequest extends Omit<
   sns.TagResourceRequest,
@@ -17,7 +18,11 @@ export class TagResource extends Binding.Service<
   ) => Effect.Effect<
     (
       request: TagResourceRequest,
-    ) => Effect.Effect<sns.TagResourceResponse, sns.TagResourceError>
+    ) => Effect.Effect<
+      sns.TagResourceResponse,
+      sns.TagResourceError,
+      RuntimeContext
+    >
   >
 >()("AWS.SNS.TagResource") {}
 

--- a/packages/alchemy/src/AWS/SNS/TopicSink.ts
+++ b/packages/alchemy/src/AWS/SNS/TopicSink.ts
@@ -5,12 +5,15 @@ import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import { PublishBatch } from "./PublishBatch.ts";
 import type { Topic } from "./Topic.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export class TopicSink extends Binding.Service<
   TopicSink,
   (
     topic: Topic,
-  ) => Effect.Effect<Sink.Sink<void, string, readonly string[], never>>
+  ) => Effect.Effect<
+    Sink.Sink<void, string, readonly string[], never, RuntimeContext>
+  >
 >()("AWS.SNS.TopicSink") {}
 
 export const TopicSinkLive = Layer.effect(

--- a/packages/alchemy/src/AWS/SNS/UntagResource.ts
+++ b/packages/alchemy/src/AWS/SNS/UntagResource.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Topic } from "./Topic.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface UntagResourceRequest extends Omit<
   sns.UntagResourceRequest,
@@ -17,7 +18,11 @@ export class UntagResource extends Binding.Service<
   ) => Effect.Effect<
     (
       request: UntagResourceRequest,
-    ) => Effect.Effect<sns.UntagResourceResponse, sns.UntagResourceError>
+    ) => Effect.Effect<
+      sns.UntagResourceResponse,
+      sns.UntagResourceError,
+      RuntimeContext
+    >
   >
 >()("AWS.SNS.UntagResource") {}
 

--- a/packages/alchemy/src/AWS/SQS/DeleteMessage.ts
+++ b/packages/alchemy/src/AWS/SQS/DeleteMessage.ts
@@ -5,6 +5,7 @@ import * as Binding from "../../Binding.ts";
 import * as Output from "../../Output.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Queue } from "./Queue.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface DeleteMessageRequest extends Omit<
   sqs.DeleteMessageRequest,
@@ -18,7 +19,11 @@ export class DeleteMessage extends Binding.Service<
   ) => Effect.Effect<
     (
       request: DeleteMessageRequest,
-    ) => Effect.Effect<sqs.DeleteMessageResponse, sqs.DeleteMessageError>
+    ) => Effect.Effect<
+      sqs.DeleteMessageResponse,
+      sqs.DeleteMessageError,
+      RuntimeContext
+    >
   >
 >()("AWS.SQS.DeleteMessage") {}
 

--- a/packages/alchemy/src/AWS/SQS/DeleteMessageBatch.ts
+++ b/packages/alchemy/src/AWS/SQS/DeleteMessageBatch.ts
@@ -6,6 +6,7 @@ import * as Output from "../../Output.ts";
 import { isInstance } from "../EC2/Instance.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Queue } from "./Queue.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface DeleteMessageBatchRequest extends Omit<
   sqs.DeleteMessageBatchRequest,
@@ -21,7 +22,8 @@ export class DeleteMessageBatch extends Binding.Service<
       request: DeleteMessageBatchRequest,
     ) => Effect.Effect<
       sqs.DeleteMessageBatchResult,
-      sqs.DeleteMessageBatchError
+      sqs.DeleteMessageBatchError,
+      RuntimeContext
     >
   >
 >()("AWS.SQS.DeleteMessageBatch") {}

--- a/packages/alchemy/src/AWS/SQS/QueueSink.ts
+++ b/packages/alchemy/src/AWS/SQS/QueueSink.ts
@@ -6,12 +6,15 @@ import * as Output from "../../Output.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Queue } from "./Queue.ts";
 import { SendMessageBatch } from "./SendMessageBatch.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export class QueueSink extends Binding.Service<
   QueueSink,
   (
     queue: Queue,
-  ) => Effect.Effect<Sink.Sink<void, string, readonly string[], never>>
+  ) => Effect.Effect<
+    Sink.Sink<void, string, readonly string[], never, RuntimeContext>
+  >
 >()("AWS.SQS.QueueSink") {}
 
 export const QueueSinkLive = Layer.effect(

--- a/packages/alchemy/src/AWS/SQS/ReceiveMessage.ts
+++ b/packages/alchemy/src/AWS/SQS/ReceiveMessage.ts
@@ -6,6 +6,7 @@ import * as Output from "../../Output.ts";
 import { isInstance } from "../EC2/Instance.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Queue } from "./Queue.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface ReceiveMessageRequest extends Omit<
   sqs.ReceiveMessageRequest,
@@ -19,7 +20,11 @@ export class ReceiveMessage extends Binding.Service<
   ) => Effect.Effect<
     (
       request: ReceiveMessageRequest,
-    ) => Effect.Effect<sqs.ReceiveMessageResult, sqs.ReceiveMessageError>
+    ) => Effect.Effect<
+      sqs.ReceiveMessageResult,
+      sqs.ReceiveMessageError,
+      RuntimeContext
+    >
   >
 >()("AWS.SQS.ReceiveMessage") {}
 

--- a/packages/alchemy/src/AWS/SQS/SendMessage.ts
+++ b/packages/alchemy/src/AWS/SQS/SendMessage.ts
@@ -6,6 +6,7 @@ import * as Output from "../../Output.ts";
 import { isInstance } from "../EC2/Instance.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Queue } from "./Queue.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface SendMessageRequest extends Omit<
   sqs.SendMessageRequest,
@@ -19,7 +20,11 @@ export class SendMessage extends Binding.Service<
   ) => Effect.Effect<
     (
       request: SendMessageRequest,
-    ) => Effect.Effect<sqs.SendMessageResult, sqs.SendMessageError>
+    ) => Effect.Effect<
+      sqs.SendMessageResult,
+      sqs.SendMessageError,
+      RuntimeContext
+    >
   >
 >()("AWS.SQS.SendMessage") {}
 

--- a/packages/alchemy/src/AWS/SQS/SendMessageBatch.ts
+++ b/packages/alchemy/src/AWS/SQS/SendMessageBatch.ts
@@ -5,6 +5,7 @@ import * as Binding from "../../Binding.ts";
 import * as Output from "../../Output.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Queue } from "./Queue.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface SendMessageBatchRequest extends Omit<
   sqs.SendMessageBatchRequest,
@@ -18,7 +19,11 @@ export class SendMessageBatch extends Binding.Service<
   ) => Effect.Effect<
     (
       request: SendMessageBatchRequest,
-    ) => Effect.Effect<sqs.SendMessageBatchResult, sqs.SendMessageBatchError>
+    ) => Effect.Effect<
+      sqs.SendMessageBatchResult,
+      sqs.SendMessageBatchError,
+      RuntimeContext
+    >
   >
 >()("AWS.SQS.SendMessageBatch") {}
 

--- a/packages/alchemy/src/AWS/SecretsManager/DescribeSecret.ts
+++ b/packages/alchemy/src/AWS/SecretsManager/DescribeSecret.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Secret } from "./Secret.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 /**
  * Runtime binding for `secretsmanager:DescribeSecret`.
@@ -15,7 +16,8 @@ export class DescribeSecret extends Binding.Service<
   ) => Effect.Effect<
     () => Effect.Effect<
       secretsmanager.DescribeSecretResponse,
-      secretsmanager.DescribeSecretError
+      secretsmanager.DescribeSecretError,
+      RuntimeContext
     >
   >
 >()("AWS.SecretsManager.DescribeSecret") {}

--- a/packages/alchemy/src/AWS/SecretsManager/GetRandomPassword.ts
+++ b/packages/alchemy/src/AWS/SecretsManager/GetRandomPassword.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 /**
  * Runtime binding for `secretsmanager:GetRandomPassword`.
@@ -14,7 +15,8 @@ export class GetRandomPassword extends Binding.Service<
       request?: secretsmanager.GetRandomPasswordRequest,
     ) => Effect.Effect<
       secretsmanager.GetRandomPasswordResponse,
-      secretsmanager.GetRandomPasswordError
+      secretsmanager.GetRandomPasswordError,
+      RuntimeContext
     >
   >
 >()("AWS.SecretsManager.GetRandomPassword") {}

--- a/packages/alchemy/src/AWS/SecretsManager/GetSecretValue.ts
+++ b/packages/alchemy/src/AWS/SecretsManager/GetSecretValue.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Secret } from "./Secret.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface GetSecretValueRequest extends Omit<
   secretsmanager.GetSecretValueRequest,
@@ -22,7 +23,8 @@ export class GetSecretValue extends Binding.Service<
       request?: GetSecretValueRequest,
     ) => Effect.Effect<
       secretsmanager.GetSecretValueResponse,
-      secretsmanager.GetSecretValueError
+      secretsmanager.GetSecretValueError,
+      RuntimeContext
     >
   >
 >()("AWS.SecretsManager.GetSecretValue") {}

--- a/packages/alchemy/src/AWS/SecretsManager/ListSecrets.ts
+++ b/packages/alchemy/src/AWS/SecretsManager/ListSecrets.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 /**
  * Runtime binding for `secretsmanager:ListSecrets`.
@@ -14,7 +15,8 @@ export class ListSecrets extends Binding.Service<
       request?: secretsmanager.ListSecretsRequest,
     ) => Effect.Effect<
       secretsmanager.ListSecretsResponse,
-      secretsmanager.ListSecretsError
+      secretsmanager.ListSecretsError,
+      RuntimeContext
     >
   >
 >()("AWS.SecretsManager.ListSecrets") {}

--- a/packages/alchemy/src/AWS/SecretsManager/PutSecretValue.ts
+++ b/packages/alchemy/src/AWS/SecretsManager/PutSecretValue.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import { isFunction } from "../Lambda/Function.ts";
 import type { Secret } from "./Secret.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 
 export interface PutSecretValueRequest extends Omit<
   secretsmanager.PutSecretValueRequest,
@@ -22,7 +23,8 @@ export class PutSecretValue extends Binding.Service<
       request: PutSecretValueRequest,
     ) => Effect.Effect<
       secretsmanager.PutSecretValueResponse,
-      secretsmanager.PutSecretValueError
+      secretsmanager.PutSecretValueError,
+      RuntimeContext
     >
   >
 >()("AWS.SecretsManager.PutSecretValue") {}

--- a/packages/alchemy/test/AWS/Kinesis/handler.ts
+++ b/packages/alchemy/test/AWS/Kinesis/handler.ts
@@ -1,4 +1,5 @@
 import * as AWS from "@/AWS";
+import type { RuntimeContext } from "@/RuntimeContext.ts";
 import * as Kinesis from "@distilled.cloud/aws/kinesis";
 import * as Context from "effect/Context";
 import * as Data from "effect/Data";
@@ -324,7 +325,11 @@ class RecordsNotReady extends Data.TaggedError("RecordsNotReady") {}
 const waitForRecords = (
   getRecords: (
     request: Kinesis.GetRecordsInput,
-  ) => Effect.Effect<Kinesis.GetRecordsOutput, Kinesis.GetRecordsError>,
+  ) => Effect.Effect<
+    Kinesis.GetRecordsOutput,
+    Kinesis.GetRecordsError,
+    RuntimeContext
+  >,
   shardIterator: string,
 ) =>
   getRecords({


### PR DESCRIPTION
Continues the work from #383: every `Binding.Service` runtime callable now declares `Alchemy.RuntimeContext` as a requirement, so consumers can wrap them in cloud-agnostic Layers without leaking `Lambda.FunctionEnvironment` / `WorkerEnvironment` into the service interface.

### What changed

```diff lang="typescript"
 export class GetItem extends Binding.Service<
   GetItem,
   <T extends Table>(
     table: T,
   ) => Effect.Effect<
     (
       request: GetItemRequest,
-    ) => Effect.Effect<DynamoDB.GetItemOutput, DynamoDB.GetItemError>
+    ) => Effect.Effect<DynamoDB.GetItemOutput, DynamoDB.GetItemError, RuntimeContext>
   >
 >()("AWS.DynamoDB.GetItem") {}
```

Applied to:

- **117 AWS binding files** — CloudWatch, DynamoDB, EventBridge, ECS, Kinesis, Lambda, RDS, RDSData, S3, SNS, SQS, SecretsManager
- **3 sink files** (`QueueSink`, `TopicSink`, `StreamSink`) — `RuntimeContext` goes in the 5th `Sink.Sink<A, In, L, E, R>` slot
- **Downstream consumers** (`examples/aws-lambda*`, `examples/aws-rds`, `test/AWS/Kinesis/handler.ts`) — service contracts updated to thread the new requirement through

### What's left alone

`EventSource` files (`BucketEventSource`, `DynamoDB/Stream`, `StreamEventSource`, `TopicEventSource`) — their `Binding.Service` is deploy-time wiring (`Effect<void, never, never>`) with no inner runtime callable. The actual runtime work happens inside the user-supplied `process` callback's generic `Req`.

`Binding.Policy` classes — untouched (already runs at deploy time only).

### Why

See the [Layers concept](https://github.com/alchemy-run/alchemy-effect/blob/main/website/src/content/docs/concepts/layers.mdx) and the new ["Runtime-only methods" section in AGENTS.md](https://github.com/alchemy-run/alchemy-effect/blob/main/AGENTS.md). TL;DR: a function with `WorkerEnvironment` in its requirements is structurally pinned to a Cloudflare Worker; with `RuntimeContext` instead, it just says "runs inside *some* deployed runtime" — which is what callers want.
