### PR TITLE
fix(cloudflare): register non-fetch ExportedHandler methods from Worker shape

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/RpcAsync.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/RpcAsync.ts
@@ -2,9 +2,17 @@ import type * as Effect from "effect/Effect";
 import type * as Stream from "effect/Stream";
 import type { Rpc } from "../../Rpc.ts";
 import { isRpcErrorEnvelope, isRpcStreamEnvelope } from "../Bridge.ts";
+import {
+  ExportedHandlerMethods,
+  type ExportedHandlerMethod,
+} from "./Worker.ts";
+
+const handlerMethodSet = new Set<string>(ExportedHandlerMethods);
 
 export type RpcAsync<Shape> = {
-  [K in keyof Shape as K extends "fetch" ? never : K]: Shape[K] extends (
+  [K in keyof Shape as K extends ExportedHandlerMethod
+    ? never
+    : K]: Shape[K] extends (
     ...args: infer A
   ) => Effect.Effect<infer T, any, any>
     ? (...args: A) => Promise<T>
@@ -79,7 +87,11 @@ export const toRpcAsync = <W>(stub: any): RpcAsync<Rpc.Shape<W>> & Service =>
     get: (target, prop) => {
       // `Service` methods (fetch/connect) and any non-string keys (Symbol.dispose, etc.)
       // pass through to the underlying Cloudflare binding unchanged.
-      if (typeof prop !== "string" || prop === "fetch" || prop === "connect") {
+      if (
+        typeof prop !== "string" ||
+        prop === "connect" ||
+        handlerMethodSet.has(prop)
+      ) {
         const value = (target as any)[prop];
         return typeof value === "function" ? value.bind(target) : value;
       }

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -138,6 +138,8 @@ export const ExportedHandlerMethods = [
   "queue",
 ] as const satisfies (keyof cf.ExportedHandler)[];
 
+export type ExportedHandlerMethod = (typeof ExportedHandlerMethods)[number];
+
 export type WorkerServices =
   | Worker
   | Request

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerBinding.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerBinding.ts
@@ -16,7 +16,12 @@ import type { R2Bucket } from "../R2/R2Bucket.ts";
 import type { Assets } from "./Assets.ts";
 import type { DurableObjectNamespaceLike } from "./DurableObjectNamespace.ts";
 import { makeRpcStub } from "./Rpc.ts";
-import { isWorker, Worker, WorkerEnvironment } from "./Worker.ts";
+import {
+  isWorker,
+  Worker,
+  WorkerEnvironment,
+  type ExportedHandlerMethod,
+} from "./Worker.ts";
 
 export type WorkerBinding = Exclude<
   workers.PutScriptRequest["metadata"]["bindings"],
@@ -74,7 +79,7 @@ export const bindWorker = Effect.fnUntraced(function* <Shape, Req = never>(
   const stubEff = WorkerEnvironment.pipe(
     Effect.map((env) => (env as Record<string, unknown>)[worker.LogicalId]),
   );
-  return makeRpcStub<Shape>(stubEff);
+  return makeRpcStub<Omit<Shape, ExportedHandlerMethod>>(stubEff);
 });
 
 export class BindWorkerPolicy extends Binding.Policy<

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerRuntimeContext.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerRuntimeContext.ts
@@ -9,6 +9,7 @@ import type * as Serverless from "../../Serverless/index.ts";
 import { makeRequestHandler } from "./HttpServer.ts";
 import {
   ExportedHandlerMethods,
+  isWorkerEvent,
   WorkerEnvironment,
   WorkerTypeId,
   type WorkerEvent,
@@ -93,11 +94,27 @@ export const makeWorkerRuntimeContext = (id: string): WorkerRuntimeContext => {
       handler: HttpEffect<Req> | Effect.Effect<HttpEffect<Req>>,
       options?: { shape?: Record<string, unknown> },
     ) => {
-      // Capture the user's full default-export shape so `exports` can
-      // expose any non-handler methods on it as RPC methods on the
-      // deployed `WorkerEntrypoint` subclass — see `__rpc__` below.
       if (options?.shape) userShape = options.shape;
-      return ctx.listen(makeRequestHandler(handler));
+      const registerFetch = ctx.listen(makeRequestHandler(handler));
+
+      const nonFetchMethods = ExportedHandlerMethods.filter(
+        (m) => m !== "fetch" && options?.shape?.[m] != null,
+      );
+      if (nonFetchMethods.length === 0) return registerFetch;
+
+      return Effect.all(
+        [
+          registerFetch,
+          ...nonFetchMethods.map((method) =>
+            ctx.listen((event: any) => {
+              if (!isWorkerEvent(event) || event.type !== method) return;
+              const handler = (options!.shape as any)[method];
+              return (handler as Function)(event.input) as Effect.Effect<any>;
+            }),
+          ),
+        ],
+        { discard: true },
+      );
     },
     listen: ((
       handler:


### PR DESCRIPTION
## Summary

- When a Worker returns non-fetch `ExportedHandler` methods (`email`, `queue`, `scheduled`, etc.) on its shape, `serve()` now registers event listeners for them alongside the fetch handler.
- Previously only the fetch listener was registered via `makeRequestHandler`, so email and other event types caused `"No event handler found for event type 'email'"` errors at runtime.
- The fix filters `ExportedHandlerMethods` for any non-fetch methods present on the user's shape and registers a listener for each that dispatches `event.input` to the corresponding handler function.

Closes #414

## Test plan

- [ ] Deploy a Worker with an `email` handler on the shape
- [ ] Send an inbound email and verify it's dispatched to the handler instead of erroring
- [ ] Verify fetch requests still work as before
- [ ] Verify Workers without non-fetch handlers are unaffected (`nonFetchMethods.length === 0` early return)