### PR TITLE
feat(cloudflare/Worker): support for custom tld in `Vite` and `LocalWorkerProvider`

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -1,8 +1,8 @@
 import {
-  layerLocalProxy,
-  layerRuntime,
   Runtime,
   RuntimeError,
+  layerLocalProxy,
+  layerRuntime,
   type BindingHook,
   type BindingServices,
   type HyperdriveOrigin,
@@ -48,8 +48,9 @@ import type * as Bundle from "../../Bundle/Bundle.ts";
 import { InstanceId } from "../../InstanceId.ts";
 import * as RpcProvider from "../../Local/RpcProvider.ts";
 import type { ResourceBinding } from "../../Resource.ts";
-import { Stack } from "../../Stack.ts";
+import { Stack, type StackSpec } from "../../Stack.ts";
 import { Stage } from "../../Stage.ts";
+import { syncLocalHosts } from "../../Util/LocalHosts.ts";
 import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
 import type { WorkerAssetsConfig, WorkerProps } from "../Workers/Worker.ts";
 import { getCompatibility } from "./Compatibility.ts";
@@ -309,6 +310,18 @@ export const LocalWorkerProvider = () =>
 
       const rootScope = yield* Effect.scope;
       const workerdScopes = new Map<string, Scope.Closeable>();
+      const localHostnames = new Map<string, string>();
+      const localHostsMarker = `cloudflare:${stack.stage}:${stack.name}`;
+      const syncStackHosts = () =>
+        stack.localDomain === undefined
+          ? Effect.void
+          : syncLocalHosts(localHostsMarker, localHostnames.values());
+      if (stack.localDomain !== undefined) {
+        yield* Scope.addFinalizer(
+          rootScope,
+          syncLocalHosts(localHostsMarker, []),
+        );
+      }
 
       const context = yield* Effect.context<RuntimeServices>();
       const instances = new Map<
@@ -331,7 +344,13 @@ export const LocalWorkerProvider = () =>
       }) {
         const { id, props, bindings } = options;
         const config = yield* buildConfig(options);
-        const url = yield* localProxy.registerWorker(id);
+        const proxyUrl = yield* localProxy.registerWorker(id);
+        const url = toLocalWorkerUrl(id, proxyUrl, stack.localDomain);
+        const localHostname = new URL(url).hostname;
+        if (stack.localDomain !== undefined) {
+          localHostnames.set(id, localHostname);
+          yield* syncStackHosts();
+        }
         if (props.vite) {
           const devServer = yield* Vite.viteDev(
             props.vite.rootDir,
@@ -350,6 +369,9 @@ export const LocalWorkerProvider = () =>
               },
               context,
             },
+            stack.localDomain === undefined
+              ? undefined
+              : { allowedHosts: [localHostname] },
           );
           const localAddress = devServer.resolvedUrls!.local[0].slice(0, -1);
           yield* localProxy.setLocalAddress(id, localAddress);
@@ -425,6 +447,9 @@ export const LocalWorkerProvider = () =>
             yield* Fiber.interrupt(existing.fiber);
             yield* Scope.close(existing.scope, Exit.void);
             instances.delete(id);
+          }
+          if (localHostnames.delete(id)) {
+            yield* syncStackHosts();
           }
         }),
       };
@@ -528,6 +553,26 @@ const toRuntimeAssets = (
     serveDirectly: assets.config?.serveDirectly,
   };
 };
+
+const toLocalWorkerUrl = (
+  id: string,
+  proxyUrl: string,
+  localDomain: StackSpec["localDomain"],
+): string => {
+  if (localDomain === undefined) {
+    return proxyUrl;
+  }
+  const url = new URL(proxyUrl);
+  url.hostname = `${toDnsLabel(id)}.${localDomain.domain}.${localDomain.tld}`;
+  return url.toString().replace(/\/$/, "");
+};
+
+const toDnsLabel = (value: string): string =>
+  value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
 
 const toRuntimeDurableObjectNamespaces = (
   namespaces: Record<string, string>,

--- a/packages/alchemy/src/Cloudflare/Workers/Vite.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Vite.ts
@@ -12,6 +12,9 @@ export const viteDev = (
   rootDir: string = process.cwd(),
   env: Record<string, unknown>,
   pluginOptions: CloudflareVitePluginOptions,
+  options?: {
+    allowedHosts?: string[];
+  },
 ) =>
   Effect.acquireRelease(
     Effect.promise(async () => {
@@ -19,6 +22,9 @@ export const viteDev = (
       const devServer = await vite.createServer({
         root: rootDir,
         define: getDefine(env),
+        server: {
+          allowedHosts: options?.allowedHosts,
+        },
         plugins: [cloudflare(pluginOptions)],
       });
       await devServer.listen();

--- a/packages/alchemy/src/Local/RpcProviderProxy.ts
+++ b/packages/alchemy/src/Local/RpcProviderProxy.ts
@@ -36,7 +36,11 @@ const make = Effect.fnUntraced(function* (spawnerUrl: string) {
       const payload: RpcSpawnPayload = {
         serverEntryUrl,
         alchemyContext,
-        stack: { name: stack.name, stage: stack.stage },
+        stack: {
+          name: stack.name,
+          stage: stack.stage,
+          localDomain: stack.localDomain,
+        },
       };
       const response = yield* client.post(spawnerUrl, {
         body: yield* HttpBody.json(payload),

--- a/packages/alchemy/src/Local/RpcServerEnvironment.ts
+++ b/packages/alchemy/src/Local/RpcServerEnvironment.ts
@@ -18,6 +18,10 @@ export interface RpcServerEnvironment {
   stack: {
     name: string;
     stage: string;
+    localDomain?: {
+      domain: string;
+      tld: string;
+    };
   };
 }
 
@@ -37,6 +41,7 @@ export const layer = (environment: RpcServerEnvironment) =>
     Layer.succeed(Stack, {
       name: environment.stack.name,
       stage: environment.stack.stage,
+      localDomain: environment.stack.localDomain,
       resources: {},
       bindings: {},
       actions: {},

--- a/packages/alchemy/src/Stack.ts
+++ b/packages/alchemy/src/Stack.ts
@@ -64,6 +64,28 @@ export type Stack = Context.ServiceClass.Shape<
 export interface StackProps<Req> {
   providers: Layer.Layer<NoInfer<Req>, never, StackServices>;
   state: Layer.Layer<State, never, StackServices>;
+  /**
+   * Opt-in local development top-level domain.
+   *
+   * When set, local Cloudflare workers are exposed as
+   * `<worker>.<stack-name>.<customTld>` instead of `<worker>.localhost`.
+   * Alchemy will best-effort sync concrete hostnames to `/etc/hosts`.
+   *
+   * @example
+   * ```ts
+   * Alchemy.Stack("myapp", {
+   *   providers: Cloudflare.providers(),
+   *   state: Cloudflare.state(),
+   *   customTld: "test",
+   * }, ...)
+   * ```
+   */
+  customTld?: string;
+  /**
+   * Optional local development domain label. Defaults to a DNS-safe slug of
+   * the stack name.
+   */
+  customDomain?: string;
 }
 
 export const Stack: Context.ServiceClass<
@@ -158,6 +180,10 @@ const createStageProxy = (stackName: string) =>
 export interface StackSpec<Output = any> {
   name: string;
   stage: string;
+  localDomain?: {
+    domain: string;
+    tld: string;
+  };
   // @internal
   resources: {
     [logicalId: string]: ResourceLike;
@@ -185,6 +211,8 @@ export interface MakeStackProps<ROut = never> {
   name: string;
   providers: Layer.Layer<ROut, never, StackServices>;
   state: Layer.Layer<State, never, StackServices>;
+  customTld?: string;
+  customDomain?: string;
   /** @internal */
   stack?: StackSpec;
 }
@@ -232,6 +260,15 @@ export const make =
                     options.stack ?? {
                       name: options.name,
                       stage,
+                      localDomain:
+                        options.customTld === undefined
+                          ? undefined
+                          : {
+                              domain:
+                                options.customDomain ??
+                                toDnsLabel(options.name),
+                              tld: toDnsLabel(options.customTld),
+                            },
                       resources: {},
                       bindings: {},
                       actions: {},
@@ -334,3 +371,10 @@ export const evalStack = <A, B, Err, Req>(
     ? Effect.scoped(body)
     : Scope.provide(body, options.scope);
 };
+
+const toDnsLabel = (value: string): string =>
+  value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/^-+|-+$/g, "");

--- a/packages/alchemy/src/Util/LocalHosts.ts
+++ b/packages/alchemy/src/Util/LocalHosts.ts
@@ -1,0 +1,75 @@
+import * as Effect from "effect/Effect";
+import * as fs from "node:fs/promises";
+
+const HOSTS_PATH = "/etc/hosts";
+
+export const syncLocalHosts = (
+  marker: string,
+  hostnames: Iterable<string>,
+): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    const uniqueHosts = [...new Set(hostnames)].sort();
+    const nextBlock = formatBlock(marker, uniqueHosts);
+
+    const previous = yield* Effect.tryPromise(() =>
+      fs.readFile(HOSTS_PATH, "utf8"),
+    ).pipe(
+      Effect.catch((error) =>
+        Effect.logWarning(
+          `Alchemy could not read ${HOSTS_PATH} for local dev domains: ${String(error)}`,
+        ).pipe(Effect.as("")),
+      ),
+    );
+    if (previous === "") {
+      return;
+    }
+    const next = replaceBlock(previous, marker, nextBlock);
+    if (next === previous) {
+      return;
+    }
+
+    yield* Effect.tryPromise(() => fs.writeFile(HOSTS_PATH, next, "utf8")).pipe(
+      Effect.catch((error) =>
+        Effect.logWarning(
+          [
+            `Alchemy could not update ${HOSTS_PATH} for local dev domains.`,
+            `Add this block manually or rerun with permission to edit ${HOSTS_PATH}:`,
+            nextBlock.trimEnd(),
+            `Cause: ${String(error)}`,
+          ].join("\n"),
+        ),
+      ),
+    );
+  });
+
+const formatBlock = (marker: string, hostnames: readonly string[]): string => {
+  if (hostnames.length === 0) {
+    return "";
+  }
+  return [
+    `# alchemy:${marker}:start`,
+    ...hostnames.map((hostname) => `127.0.0.1 ${hostname}`),
+    `# alchemy:${marker}:end`,
+    "",
+  ].join("\n");
+};
+
+const replaceBlock = (
+  hosts: string,
+  marker: string,
+  nextBlock: string,
+): string => {
+  const start = `# alchemy:${marker}:start`;
+  const end = `# alchemy:${marker}:end`;
+  const block = new RegExp(
+    `\\n?${escapeRegExp(start)}[\\s\\S]*?${escapeRegExp(end)}\\n?`,
+  );
+  const withoutBlock = hosts.replace(block, "\n").replace(/\n{3,}/g, "\n\n");
+  if (nextBlock === "") {
+    return withoutBlock;
+  }
+  return `${withoutBlock.replace(/\s*$/, "\n\n")}${nextBlock}`;
+};
+
+const escapeRegExp = (value: string): string =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");


### PR DESCRIPTION
this is just a proof of concept, far from production grade

todo
- [ ] handle missing permissions (modifying /etc/hosts probably requires sudo)
- [ ] support windows hosts path