### PR TITLE
feat(aws/bedrock): add Bedrock Guardrail resource and runtime bindings

### DIFF
--- a/packages/alchemy/src/AWS/Bedrock/ApplyGuardrail.ts
+++ b/packages/alchemy/src/AWS/Bedrock/ApplyGuardrail.ts
@@ -1,0 +1,81 @@
+import * as bedrockRuntime from "@distilled.cloud/aws/bedrock-runtime";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Binding from "../../Binding.ts";
+import * as Output from "../../Output.ts";
+import { isFunction } from "../Lambda/Function.ts";
+import type { Guardrail } from "./Guardrail.ts";
+
+export interface ApplyGuardrailRequest extends Omit<
+  bedrockRuntime.ApplyGuardrailRequest,
+  "guardrailIdentifier" | "guardrailVersion"
+> {
+  /**
+   * Guardrail version to apply. Defaults to the `DRAFT` version managed by
+   * Alchemy. Pass a numbered version string (e.g. `"1"`) to apply a published
+   * version instead.
+   * @default "DRAFT"
+   */
+  guardrailVersion?: string;
+}
+
+export class ApplyGuardrail extends Binding.Service<
+  ApplyGuardrail,
+  (
+    guardrail: Guardrail,
+  ) => Effect.Effect<
+    (
+      request: ApplyGuardrailRequest,
+    ) => Effect.Effect<
+      bedrockRuntime.ApplyGuardrailResponse,
+      bedrockRuntime.ApplyGuardrailError
+    >
+  >
+>()("AWS.Bedrock.ApplyGuardrail") {}
+
+export const ApplyGuardrailLive = Layer.effect(
+  ApplyGuardrail,
+  Effect.gen(function* () {
+    const Policy = yield* ApplyGuardrailPolicy;
+    const applyGuardrail = yield* bedrockRuntime.applyGuardrail;
+
+    return Effect.fn(function* (guardrail: Guardrail) {
+      const GuardrailIdentifier = yield* guardrail.guardrailId;
+      yield* Policy(guardrail);
+      return Effect.fn(function* (request: ApplyGuardrailRequest) {
+        return yield* applyGuardrail({
+          ...request,
+          guardrailIdentifier: yield* GuardrailIdentifier,
+          guardrailVersion: request.guardrailVersion ?? "DRAFT",
+        });
+      });
+    });
+  }),
+);
+
+export class ApplyGuardrailPolicy extends Binding.Policy<
+  ApplyGuardrailPolicy,
+  (guardrail: Guardrail) => Effect.Effect<void>
+>()("AWS.Bedrock.ApplyGuardrail") {}
+
+export const ApplyGuardrailPolicyLive = ApplyGuardrailPolicy.layer.succeed(
+  Effect.fn(function* (host, guardrail) {
+    if (isFunction(host)) {
+      yield* host.bind`Allow(${host}, AWS.Bedrock.ApplyGuardrail(${guardrail}))`(
+        {
+          policyStatements: [
+            {
+              Effect: "Allow",
+              Action: ["bedrock:ApplyGuardrail"],
+              Resource: [Output.interpolate`${guardrail.guardrailArn}`],
+            },
+          ],
+        },
+      );
+    } else {
+      return yield* Effect.die(
+        `ApplyGuardrailPolicy does not support runtime '${host.Type}'`,
+      );
+    }
+  }),
+);

--- a/packages/alchemy/src/AWS/Bedrock/Converse.ts
+++ b/packages/alchemy/src/AWS/Bedrock/Converse.ts
@@ -1,0 +1,72 @@
+import { Region } from "@distilled.cloud/aws/Region";
+import * as bedrockRuntime from "@distilled.cloud/aws/bedrock-runtime";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Binding from "../../Binding.ts";
+import { AWSEnvironment } from "../Environment.ts";
+import { isFunction } from "../Lambda/Function.ts";
+import { resolveModelArns } from "./ModelArn.ts";
+
+export interface ConverseRequest extends Omit<
+  bedrockRuntime.ConverseRequest,
+  "modelId"
+> {}
+
+export class Converse extends Binding.Service<
+  Converse,
+  (
+    modelId: string,
+  ) => Effect.Effect<
+    (
+      request: ConverseRequest,
+    ) => Effect.Effect<
+      bedrockRuntime.ConverseResponse,
+      bedrockRuntime.ConverseError
+    >
+  >
+>()("AWS.Bedrock.Converse") {}
+
+export const ConverseLive = Layer.effect(
+  Converse,
+  Effect.gen(function* () {
+    const Policy = yield* ConversePolicy;
+    const converse = yield* bedrockRuntime.converse;
+
+    return Effect.fn(function* (modelId: string) {
+      yield* Policy(modelId);
+      return Effect.fn(function* (request: ConverseRequest) {
+        return yield* converse({ ...request, modelId });
+      });
+    });
+  }),
+);
+
+export class ConversePolicy extends Binding.Policy<
+  ConversePolicy,
+  (modelId: string) => Effect.Effect<void>
+>()("AWS.Bedrock.Converse") {}
+
+export const ConversePolicyLive = ConversePolicy.layer.effect(
+  Effect.gen(function* () {
+    const region = yield* Region;
+    const { accountId } = yield* AWSEnvironment;
+
+    return Effect.fn(function* (host, modelId) {
+      if (isFunction(host)) {
+        yield* host.bind`Allow(${host}, AWS.Bedrock.Converse(${modelId}))`({
+          policyStatements: [
+            {
+              Effect: "Allow",
+              Action: ["bedrock:InvokeModel"],
+              Resource: resolveModelArns({ modelId, region, accountId }),
+            },
+          ],
+        });
+      } else {
+        return yield* Effect.die(
+          `ConversePolicy does not support runtime '${host.Type}'`,
+        );
+      }
+    });
+  }),
+);

--- a/packages/alchemy/src/AWS/Bedrock/ConverseStream.ts
+++ b/packages/alchemy/src/AWS/Bedrock/ConverseStream.ts
@@ -1,0 +1,74 @@
+import { Region } from "@distilled.cloud/aws/Region";
+import * as bedrockRuntime from "@distilled.cloud/aws/bedrock-runtime";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Binding from "../../Binding.ts";
+import { AWSEnvironment } from "../Environment.ts";
+import { isFunction } from "../Lambda/Function.ts";
+import { resolveModelArns } from "./ModelArn.ts";
+
+export interface ConverseStreamRequest extends Omit<
+  bedrockRuntime.ConverseStreamRequest,
+  "modelId"
+> {}
+
+export class ConverseStream extends Binding.Service<
+  ConverseStream,
+  (
+    modelId: string,
+  ) => Effect.Effect<
+    (
+      request: ConverseStreamRequest,
+    ) => Effect.Effect<
+      bedrockRuntime.ConverseStreamResponse,
+      bedrockRuntime.ConverseStreamError
+    >
+  >
+>()("AWS.Bedrock.ConverseStream") {}
+
+export const ConverseStreamLive = Layer.effect(
+  ConverseStream,
+  Effect.gen(function* () {
+    const Policy = yield* ConverseStreamPolicy;
+    const converseStream = yield* bedrockRuntime.converseStream;
+
+    return Effect.fn(function* (modelId: string) {
+      yield* Policy(modelId);
+      return Effect.fn(function* (request: ConverseStreamRequest) {
+        return yield* converseStream({ ...request, modelId });
+      });
+    });
+  }),
+);
+
+export class ConverseStreamPolicy extends Binding.Policy<
+  ConverseStreamPolicy,
+  (modelId: string) => Effect.Effect<void>
+>()("AWS.Bedrock.ConverseStream") {}
+
+export const ConverseStreamPolicyLive = ConverseStreamPolicy.layer.effect(
+  Effect.gen(function* () {
+    const region = yield* Region;
+    const { accountId } = yield* AWSEnvironment;
+
+    return Effect.fn(function* (host, modelId) {
+      if (isFunction(host)) {
+        yield* host.bind`Allow(${host}, AWS.Bedrock.ConverseStream(${modelId}))`(
+          {
+            policyStatements: [
+              {
+                Effect: "Allow",
+                Action: ["bedrock:InvokeModelWithResponseStream"],
+                Resource: resolveModelArns({ modelId, region, accountId }),
+              },
+            ],
+          },
+        );
+      } else {
+        return yield* Effect.die(
+          `ConverseStreamPolicy does not support runtime '${host.Type}'`,
+        );
+      }
+    });
+  }),
+);

--- a/packages/alchemy/src/AWS/Bedrock/Guardrail.ts
+++ b/packages/alchemy/src/AWS/Bedrock/Guardrail.ts
@@ -1,0 +1,391 @@
+import * as bedrock from "@distilled.cloud/aws/bedrock";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import * as Redacted from "effect/Redacted";
+import * as Schedule from "effect/Schedule";
+import { isResolved } from "../../Diff.ts";
+import { createPhysicalName } from "../../PhysicalName.ts";
+import * as Provider from "../../Provider.ts";
+import { Resource } from "../../Resource.ts";
+import { createInternalTags, diffTags } from "../../Tags.ts";
+import type { Providers } from "../Providers.ts";
+
+export type GuardrailId = string;
+export type GuardrailArn = string;
+
+export interface GuardrailProps {
+  /**
+   * Name of the guardrail. If omitted, a unique name is generated from the
+   * app, stage, and logical ID.
+   */
+  name?: string;
+  /**
+   * Description of the guardrail.
+   */
+  description?: string;
+  /**
+   * Message returned to the caller when the guardrail blocks an input.
+   * @default "Sorry, the input was blocked."
+   */
+  blockedInputMessaging?: string;
+  /**
+   * Message returned to the caller when the guardrail blocks the model's output.
+   * @default "Sorry, the model's response was blocked."
+   */
+  blockedOutputsMessaging?: string;
+  /**
+   * Topic policy — list of denied topics.
+   */
+  topicPolicyConfig?: bedrock.GuardrailTopicPolicyConfig;
+  /**
+   * Content policy — filters for harmful content categories such as hate,
+   * insults, sexual, violence, misconduct, and prompt-attack.
+   */
+  contentPolicyConfig?: bedrock.GuardrailContentPolicyConfig;
+  /**
+   * Word policy — list of denied words and managed word lists (e.g. profanity).
+   */
+  wordPolicyConfig?: bedrock.GuardrailWordPolicyConfig;
+  /**
+   * Sensitive information policy — PII entities and regex patterns to block
+   * or anonymize.
+   */
+  sensitiveInformationPolicyConfig?: bedrock.GuardrailSensitiveInformationPolicyConfig;
+  /**
+   * Contextual grounding policy — score-based filter that detects ungrounded
+   * or irrelevant model responses.
+   */
+  contextualGroundingPolicyConfig?: bedrock.GuardrailContextualGroundingPolicyConfig;
+  /**
+   * Automated reasoning policy — formal-logic checks for factual correctness.
+   */
+  automatedReasoningPolicyConfig?: bedrock.GuardrailAutomatedReasoningPolicyConfig;
+  /**
+   * Cross-region inference configuration.
+   */
+  crossRegionConfig?: bedrock.GuardrailCrossRegionConfig;
+  /**
+   * KMS key used to encrypt the guardrail.
+   */
+  kmsKeyId?: string;
+  /**
+   * User-defined tags for the guardrail.
+   */
+  tags?: Record<string, string>;
+}
+
+export interface Guardrail extends Resource<
+  "AWS.Bedrock.Guardrail",
+  GuardrailProps,
+  {
+    guardrailId: GuardrailId;
+    guardrailArn: GuardrailArn;
+    guardrailName: string;
+    version: string;
+    status: bedrock.GuardrailStatus;
+  },
+  never,
+  Providers
+> {}
+
+/**
+ * An Amazon Bedrock guardrail that filters user inputs and model responses
+ * against configured policies (topics, content filters, denied words, PII,
+ * grounding, and automated reasoning).
+ *
+ * The DRAFT version is managed by Alchemy. Publish numbered versions for
+ * production traffic via `createGuardrailVersion` from the AWS SDK.
+ *
+ * @section Creating a Guardrail
+ * @example Block harmful content
+ * ```typescript
+ * import * as Bedrock from "alchemy/AWS/Bedrock";
+ *
+ * const guardrail = yield* Bedrock.Guardrail("ContentGuardrail", {
+ *   contentPolicyConfig: {
+ *     filtersConfig: [
+ *       { type: "HATE", inputStrength: "HIGH", outputStrength: "HIGH" },
+ *       { type: "VIOLENCE", inputStrength: "HIGH", outputStrength: "HIGH" },
+ *     ],
+ *   },
+ * });
+ * ```
+ *
+ * @example Block sensitive PII
+ * ```typescript
+ * const guardrail = yield* Bedrock.Guardrail("PiiGuardrail", {
+ *   sensitiveInformationPolicyConfig: {
+ *     piiEntitiesConfig: [
+ *       { type: "EMAIL", action: "ANONYMIZE" },
+ *       { type: "US_SOCIAL_SECURITY_NUMBER", action: "BLOCK" },
+ *     ],
+ *   },
+ * });
+ * ```
+ *
+ * @section Applying a Guardrail at Runtime
+ * @example Apply guardrail to user content
+ * ```typescript
+ * // init
+ * const applyGuardrail = yield* Bedrock.ApplyGuardrail.bind(guardrail);
+ *
+ * // runtime
+ * const result = yield* applyGuardrail({
+ *   source: "INPUT",
+ *   content: [{ text: { text: userMessage } }],
+ * });
+ * if (result.action === "GUARDRAIL_INTERVENED") {
+ *   return HttpServerResponse.text("Blocked", { status: 400 });
+ * }
+ * ```
+ */
+export const Guardrail = Resource<Guardrail>("AWS.Bedrock.Guardrail");
+
+const DEFAULT_BLOCKED_INPUT = "Sorry, the input was blocked.";
+const DEFAULT_BLOCKED_OUTPUT = "Sorry, the model's response was blocked.";
+
+class GuardrailNotReady extends Data.TaggedError("GuardrailNotReady")<{
+  readonly status: bedrock.GuardrailStatus;
+}> {}
+
+const unredact = (
+  value: string | Redacted.Redacted<string> | undefined,
+): string | undefined =>
+  value === undefined
+    ? undefined
+    : typeof value === "string"
+      ? value
+      : Redacted.value(value);
+
+const toTagRecord = (tags: bedrock.Tag[] | undefined): Record<string, string> =>
+  Object.fromEntries((tags ?? []).map((tag) => [tag.key, tag.value]));
+
+export const GuardrailProvider = () =>
+  Provider.effect(
+    Guardrail,
+    Effect.gen(function* () {
+      const createGuardrailName = (id: string, props: GuardrailProps) =>
+        props.name
+          ? Effect.succeed(props.name)
+          : createPhysicalName({ id, maxLength: 50 });
+
+      const findGuardrailByName = Effect.fn(function* (name: string) {
+        let nextToken: string | undefined;
+        do {
+          const page = yield* bedrock.listGuardrails({
+            maxResults: 100,
+            nextToken,
+          });
+          const match = (page.guardrails ?? []).find(
+            (g) => unredact(g.name) === name,
+          );
+          if (match) return match;
+          nextToken = page.nextToken;
+        } while (nextToken);
+        return undefined;
+      });
+
+      const readGuardrail = Effect.fn(function* (guardrailIdentifier: string) {
+        return yield* bedrock
+          .getGuardrail({ guardrailIdentifier })
+          .pipe(
+            Effect.catchTag("ResourceNotFoundException", () =>
+              Effect.succeed(undefined),
+            ),
+          );
+      });
+
+      const readGuardrailTags = Effect.fn(function* (guardrailArn: string) {
+        return yield* bedrock
+          .listTagsForResource({ resourceARN: guardrailArn })
+          .pipe(
+            Effect.map((r) => toTagRecord(r.tags)),
+            Effect.catchTag("ResourceNotFoundException", () =>
+              Effect.succeed({} as Record<string, string>),
+            ),
+          );
+      });
+
+      const waitUntilReady = Effect.fn(function* (guardrailIdentifier: string) {
+        return yield* bedrock.getGuardrail({ guardrailIdentifier }).pipe(
+          Effect.flatMap((g) =>
+            g.status === "READY" || g.status === "FAILED"
+              ? Effect.succeed(g)
+              : Effect.fail(new GuardrailNotReady({ status: g.status })),
+          ),
+          Effect.retry({
+            while: (e) => "_tag" in e && e._tag === "GuardrailNotReady",
+            schedule: Schedule.fixed(1000).pipe(
+              Schedule.both(Schedule.recurs(60)),
+            ),
+          }),
+        );
+      });
+
+      return Guardrail.Provider.of({
+        stables: ["guardrailId", "guardrailArn", "guardrailName"],
+        diff: Effect.fn(function* ({ id, news = {}, olds = {} }) {
+          if (!isResolved(news)) return undefined;
+          const oldName = yield* createGuardrailName(id, olds);
+          const newName = yield* createGuardrailName(id, news);
+          if (oldName !== newName) {
+            return { action: "replace" } as const;
+          }
+        }),
+        read: Effect.fn(function* ({ id, olds, output }) {
+          const guardrailName =
+            output?.guardrailName ??
+            (yield* createGuardrailName(id, olds ?? {}));
+          const observed = output?.guardrailId
+            ? yield* readGuardrail(output.guardrailId)
+            : undefined;
+          let resolved = observed;
+          if (!resolved) {
+            const summary = yield* findGuardrailByName(guardrailName);
+            if (summary?.id) {
+              resolved = yield* readGuardrail(summary.id);
+            }
+          }
+          if (!resolved) return undefined;
+          return {
+            guardrailId: resolved.guardrailId,
+            guardrailArn: resolved.guardrailArn,
+            guardrailName: unredact(resolved.name) ?? guardrailName,
+            version: resolved.version,
+            status: resolved.status,
+          };
+        }),
+        reconcile: Effect.fn(function* ({ id, news, output, session }) {
+          const guardrailName =
+            output?.guardrailName ?? (yield* createGuardrailName(id, news));
+          const internalTags = yield* createInternalTags(id);
+          const desiredTags = { ...internalTags, ...news.tags };
+          const blockedInputMessaging =
+            news.blockedInputMessaging ?? DEFAULT_BLOCKED_INPUT;
+          const blockedOutputsMessaging =
+            news.blockedOutputsMessaging ?? DEFAULT_BLOCKED_OUTPUT;
+
+          // Observe — try by stored id first, then by name.
+          let observed = output?.guardrailId
+            ? yield* readGuardrail(output.guardrailId)
+            : undefined;
+          if (!observed) {
+            const summary = yield* findGuardrailByName(guardrailName);
+            if (summary?.id) {
+              observed = yield* readGuardrail(summary.id);
+            }
+          }
+
+          // Ensure — create if missing.
+          if (!observed) {
+            const created = yield* bedrock
+              .createGuardrail({
+                name: guardrailName,
+                description: news.description,
+                blockedInputMessaging,
+                blockedOutputsMessaging,
+                topicPolicyConfig: news.topicPolicyConfig,
+                contentPolicyConfig: news.contentPolicyConfig,
+                wordPolicyConfig: news.wordPolicyConfig,
+                sensitiveInformationPolicyConfig:
+                  news.sensitiveInformationPolicyConfig,
+                contextualGroundingPolicyConfig:
+                  news.contextualGroundingPolicyConfig,
+                automatedReasoningPolicyConfig:
+                  news.automatedReasoningPolicyConfig,
+                crossRegionConfig: news.crossRegionConfig,
+                kmsKeyId: news.kmsKeyId,
+                tags: Object.entries(desiredTags).map(([key, value]) => ({
+                  key,
+                  value,
+                })),
+              })
+              .pipe(
+                Effect.catchTag("ConflictException", () =>
+                  Effect.succeed(undefined),
+                ),
+              );
+            observed = created
+              ? yield* readGuardrail(created.guardrailId)
+              : undefined;
+            if (!observed) {
+              const summary = yield* findGuardrailByName(guardrailName);
+              if (summary?.id) {
+                observed = yield* readGuardrail(summary.id);
+              }
+            }
+          } else {
+            // Sync — update mutable fields. The DRAFT version is updated in
+            // place; published versions are immutable and managed via
+            // `createGuardrailVersion`.
+            yield* bedrock.updateGuardrail({
+              guardrailIdentifier: observed.guardrailId,
+              name: guardrailName,
+              description: news.description,
+              blockedInputMessaging,
+              blockedOutputsMessaging,
+              topicPolicyConfig: news.topicPolicyConfig,
+              contentPolicyConfig: news.contentPolicyConfig,
+              wordPolicyConfig: news.wordPolicyConfig,
+              sensitiveInformationPolicyConfig:
+                news.sensitiveInformationPolicyConfig,
+              contextualGroundingPolicyConfig:
+                news.contextualGroundingPolicyConfig,
+              automatedReasoningPolicyConfig:
+                news.automatedReasoningPolicyConfig,
+              crossRegionConfig: news.crossRegionConfig,
+              kmsKeyId: news.kmsKeyId,
+            });
+            observed = yield* readGuardrail(observed.guardrailId);
+          }
+
+          if (!observed) {
+            return yield* Effect.fail(
+              new Error(`Failed to create Guardrail '${guardrailName}'`),
+            );
+          }
+
+          const guardrailArn = observed.guardrailArn;
+
+          // Sync tags — diff observed cloud tags against desired.
+          const observedTags = yield* readGuardrailTags(guardrailArn);
+          const { removed, upsert } = diffTags(observedTags, desiredTags);
+          if (upsert.length > 0) {
+            yield* bedrock.tagResource({
+              resourceARN: guardrailArn,
+              tags: upsert.map(({ Key, Value }) => ({
+                key: Key,
+                value: Value,
+              })),
+            });
+          }
+          if (removed.length > 0) {
+            yield* bedrock.untagResource({
+              resourceARN: guardrailArn,
+              tagKeys: removed,
+            });
+          }
+
+          // Wait until the guardrail is in a stable state so that callers
+          // (e.g. `ApplyGuardrail`) see READY immediately.
+          const ready = yield* waitUntilReady(observed.guardrailId);
+
+          yield* session.note(guardrailArn);
+          return {
+            guardrailId: ready.guardrailId,
+            guardrailArn,
+            guardrailName,
+            version: ready.version,
+            status: ready.status,
+          };
+        }),
+        delete: Effect.fn(function* ({ output }) {
+          yield* bedrock
+            .deleteGuardrail({ guardrailIdentifier: output.guardrailId })
+            .pipe(
+              Effect.catchTag("ResourceNotFoundException", () => Effect.void),
+            );
+        }),
+      });
+    }),
+  );

--- a/packages/alchemy/src/AWS/Bedrock/InvokeModel.ts
+++ b/packages/alchemy/src/AWS/Bedrock/InvokeModel.ts
@@ -1,0 +1,72 @@
+import { Region } from "@distilled.cloud/aws/Region";
+import * as bedrockRuntime from "@distilled.cloud/aws/bedrock-runtime";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Binding from "../../Binding.ts";
+import { AWSEnvironment } from "../Environment.ts";
+import { isFunction } from "../Lambda/Function.ts";
+import { resolveModelArns } from "./ModelArn.ts";
+
+export interface InvokeModelRequest extends Omit<
+  bedrockRuntime.InvokeModelRequest,
+  "modelId"
+> {}
+
+export class InvokeModel extends Binding.Service<
+  InvokeModel,
+  (
+    modelId: string,
+  ) => Effect.Effect<
+    (
+      request: InvokeModelRequest,
+    ) => Effect.Effect<
+      bedrockRuntime.InvokeModelResponse,
+      bedrockRuntime.InvokeModelError
+    >
+  >
+>()("AWS.Bedrock.InvokeModel") {}
+
+export const InvokeModelLive = Layer.effect(
+  InvokeModel,
+  Effect.gen(function* () {
+    const Policy = yield* InvokeModelPolicy;
+    const invokeModel = yield* bedrockRuntime.invokeModel;
+
+    return Effect.fn(function* (modelId: string) {
+      yield* Policy(modelId);
+      return Effect.fn(function* (request: InvokeModelRequest) {
+        return yield* invokeModel({ ...request, modelId });
+      });
+    });
+  }),
+);
+
+export class InvokeModelPolicy extends Binding.Policy<
+  InvokeModelPolicy,
+  (modelId: string) => Effect.Effect<void>
+>()("AWS.Bedrock.InvokeModel") {}
+
+export const InvokeModelPolicyLive = InvokeModelPolicy.layer.effect(
+  Effect.gen(function* () {
+    const region = yield* Region;
+    const { accountId } = yield* AWSEnvironment;
+
+    return Effect.fn(function* (host, modelId) {
+      if (isFunction(host)) {
+        yield* host.bind`Allow(${host}, AWS.Bedrock.InvokeModel(${modelId}))`({
+          policyStatements: [
+            {
+              Effect: "Allow",
+              Action: ["bedrock:InvokeModel"],
+              Resource: resolveModelArns({ modelId, region, accountId }),
+            },
+          ],
+        });
+      } else {
+        return yield* Effect.die(
+          `InvokeModelPolicy does not support runtime '${host.Type}'`,
+        );
+      }
+    });
+  }),
+);

--- a/packages/alchemy/src/AWS/Bedrock/InvokeModelWithResponseStream.ts
+++ b/packages/alchemy/src/AWS/Bedrock/InvokeModelWithResponseStream.ts
@@ -1,0 +1,78 @@
+import { Region } from "@distilled.cloud/aws/Region";
+import * as bedrockRuntime from "@distilled.cloud/aws/bedrock-runtime";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Binding from "../../Binding.ts";
+import { AWSEnvironment } from "../Environment.ts";
+import { isFunction } from "../Lambda/Function.ts";
+import { resolveModelArns } from "./ModelArn.ts";
+
+export interface InvokeModelWithResponseStreamRequest extends Omit<
+  bedrockRuntime.InvokeModelWithResponseStreamRequest,
+  "modelId"
+> {}
+
+export class InvokeModelWithResponseStream extends Binding.Service<
+  InvokeModelWithResponseStream,
+  (
+    modelId: string,
+  ) => Effect.Effect<
+    (
+      request: InvokeModelWithResponseStreamRequest,
+    ) => Effect.Effect<
+      bedrockRuntime.InvokeModelWithResponseStreamResponse,
+      bedrockRuntime.InvokeModelWithResponseStreamError
+    >
+  >
+>()("AWS.Bedrock.InvokeModelWithResponseStream") {}
+
+export const InvokeModelWithResponseStreamLive = Layer.effect(
+  InvokeModelWithResponseStream,
+  Effect.gen(function* () {
+    const Policy = yield* InvokeModelWithResponseStreamPolicy;
+    const invokeModelWithResponseStream =
+      yield* bedrockRuntime.invokeModelWithResponseStream;
+
+    return Effect.fn(function* (modelId: string) {
+      yield* Policy(modelId);
+      return Effect.fn(function* (
+        request: InvokeModelWithResponseStreamRequest,
+      ) {
+        return yield* invokeModelWithResponseStream({ ...request, modelId });
+      });
+    });
+  }),
+);
+
+export class InvokeModelWithResponseStreamPolicy extends Binding.Policy<
+  InvokeModelWithResponseStreamPolicy,
+  (modelId: string) => Effect.Effect<void>
+>()("AWS.Bedrock.InvokeModelWithResponseStream") {}
+
+export const InvokeModelWithResponseStreamPolicyLive =
+  InvokeModelWithResponseStreamPolicy.layer.effect(
+    Effect.gen(function* () {
+      const region = yield* Region;
+      const { accountId } = yield* AWSEnvironment;
+
+      return Effect.fn(function* (host, modelId) {
+        if (isFunction(host)) {
+          yield* host.bind`Allow(${host}, AWS.Bedrock.InvokeModelWithResponseStream(${modelId}))`(
+            {
+              policyStatements: [
+                {
+                  Effect: "Allow",
+                  Action: ["bedrock:InvokeModelWithResponseStream"],
+                  Resource: resolveModelArns({ modelId, region, accountId }),
+                },
+              ],
+            },
+          );
+        } else {
+          return yield* Effect.die(
+            `InvokeModelWithResponseStreamPolicy does not support runtime '${host.Type}'`,
+          );
+        }
+      });
+    }),
+  );

--- a/packages/alchemy/src/AWS/Bedrock/ModelArn.ts
+++ b/packages/alchemy/src/AWS/Bedrock/ModelArn.ts
@@ -1,0 +1,39 @@
+import type { AccountID, RegionID } from "../Environment.ts";
+
+/**
+ * Resolve a Bedrock model identifier into the full set of IAM Resource ARNs
+ * required to invoke it.
+ *
+ * Accepted shapes:
+ *
+ * - `arn:aws:bedrock:...` — used verbatim
+ * - `us.anthropic.claude-3-5-sonnet-20240620-v1:0` (cross-region inference
+ *   profile id with a two-letter geographic prefix) — expanded to both an
+ *   `inference-profile/` ARN in the caller's account AND a wildcard
+ *   `foundation-model/` ARN for the underlying model (Bedrock requires
+ *   permission on both when invoking via an inference profile)
+ * - any other string — treated as a foundation-model id and expanded to
+ *   `arn:aws:bedrock:${region}::foundation-model/${modelId}`
+ */
+export const resolveModelArns = ({
+  modelId,
+  region,
+  accountId,
+}: {
+  modelId: string;
+  region: RegionID;
+  accountId: AccountID;
+}): string[] => {
+  if (modelId.startsWith("arn:")) return [modelId];
+  const inferenceProfilePrefix = /^(us|eu|apac|us-gov|ap)\.[^.]+\./.exec(
+    modelId,
+  );
+  if (inferenceProfilePrefix) {
+    const foundationModelId = modelId.substring(modelId.indexOf(".") + 1);
+    return [
+      `arn:aws:bedrock:${region}:${accountId}:inference-profile/${modelId}`,
+      `arn:aws:bedrock:*::foundation-model/${foundationModelId}`,
+    ];
+  }
+  return [`arn:aws:bedrock:${region}::foundation-model/${modelId}`];
+};

--- a/packages/alchemy/src/AWS/Bedrock/index.ts
+++ b/packages/alchemy/src/AWS/Bedrock/index.ts
@@ -1,0 +1,7 @@
+export * from "./ApplyGuardrail.ts";
+export * from "./Converse.ts";
+export * from "./ConverseStream.ts";
+export * from "./Guardrail.ts";
+export * from "./InvokeModel.ts";
+export * from "./InvokeModelWithResponseStream.ts";
+export * from "./ModelArn.ts";

--- a/packages/alchemy/src/AWS/Providers.ts
+++ b/packages/alchemy/src/AWS/Providers.ts
@@ -25,6 +25,7 @@ import * as ApiGateway from "./ApiGateway/index.ts";
 import * as Assets from "./Assets.ts";
 import { AwsAuth } from "./AuthProvider.ts";
 import * as AutoScaling from "./AutoScaling/index.ts";
+import * as Bedrock from "./Bedrock/index.ts";
 import * as CloudFront from "./CloudFront/index.ts";
 import * as CloudWatch from "./CloudWatch/index.ts";
 import * as Credentials from "./Credentials.ts";
@@ -82,6 +83,12 @@ export const providers = () =>
       AutoScaling.AutoScalingGroup,
       AutoScaling.LaunchTemplate,
       AutoScaling.ScalingPolicy,
+      Bedrock.ApplyGuardrailPolicy,
+      Bedrock.ConversePolicy,
+      Bedrock.ConverseStreamPolicy,
+      Bedrock.Guardrail,
+      Bedrock.InvokeModelPolicy,
+      Bedrock.InvokeModelWithResponseStreamPolicy,
       CloudFront.CachePolicy,
       CloudFront.Distribution,
       CloudFront.Function,
@@ -335,6 +342,12 @@ export const providers = () =>
         AutoScaling.AutoScalingGroupProvider(),
         AutoScaling.LaunchTemplateProvider(),
         AutoScaling.ScalingPolicyProvider(),
+        Bedrock.ApplyGuardrailPolicyLive,
+        Bedrock.ConversePolicyLive,
+        Bedrock.ConverseStreamPolicyLive,
+        Bedrock.GuardrailProvider(),
+        Bedrock.InvokeModelPolicyLive,
+        Bedrock.InvokeModelWithResponseStreamPolicyLive,
         CloudFront.CachePolicyProvider(),
         CloudFront.DistributionProvider(),
         CloudFront.FunctionProvider(),

--- a/packages/alchemy/src/AWS/index.ts
+++ b/packages/alchemy/src/AWS/index.ts
@@ -10,6 +10,7 @@ export { Region } from "@distilled.cloud/aws/Region";
 export * as ACM from "./ACM/index.ts";
 export * as ApiGateway from "./ApiGateway/index.ts";
 export * as AutoScaling from "./AutoScaling/index.ts";
+export * as Bedrock from "./Bedrock/index.ts";
 export * as CloudFront from "./CloudFront/index.ts";
 export * as CloudWatch from "./CloudWatch/index.ts";
 export * as DynamoDB from "./DynamoDB/index.ts";


### PR DESCRIPTION
First-class AWS Bedrock support: a `Guardrail` resource and runtime bindings for `InvokeModel`, `Converse` (+ streaming variants), and `ApplyGuardrail`.

### Define a Guardrail

```ts
import * as Bedrock from "alchemy/AWS/Bedrock";

const guardrail = yield* Bedrock.Guardrail("ContentGuardrail", {
  contentPolicyConfig: {
    filtersConfig: [
      { type: "HATE", inputStrength: "HIGH", outputStrength: "HIGH" },
      { type: "VIOLENCE", inputStrength: "HIGH", outputStrength: "HIGH" },
    ],
  },
});
```

### Invoke a model from a Lambda

```ts
// init
const converse = yield* Bedrock.Converse.bind(
  "us.anthropic.claude-3-5-sonnet-20240620-v1:0",
);

return {
  fetch: Effect.gen(function* () {
    // runtime
    const res = yield* converse({
      messages: [{ role: "user", content: [{ text: "hello" }] }],
    });
    return HttpServerResponse.json(res.output);
  }),
};
```

The policy auto-expands cross-region inference profile ids to both ARNs Bedrock requires:

```jsonc
{
  "Action": ["bedrock:InvokeModel"],
  "Resource": [
    "arn:aws:bedrock:us-east-1:123:inference-profile/us.anthropic.claude-3-5-sonnet-20240620-v1:0",
    "arn:aws:bedrock:*::foundation-model/anthropic.claude-3-5-sonnet-20240620-v1:0",
  ],
}
```

### Apply a guardrail before forwarding to the model

```ts
const applyGuardrail = yield* Bedrock.ApplyGuardrail.bind(guardrail);

const result = yield* applyGuardrail({
  source: "INPUT",
  content: [{ text: { text: userMessage } }],
});
if (result.action === "GUARDRAIL_INTERVENED") {
  return HttpServerResponse.text("Blocked", { status: 400 });
}
```