### PR TITLE
feat(cloudflare): run DO-attached containers in alchemy dev

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -214,7 +214,27 @@ export const LocalWorkerProvider = () =>
             hyperdrives: worker.hyperdrives,
             durableObjectNamespaces: toRuntimeDurableObjectNamespaces(
               worker.durableObjectNamespaces,
+              worker.containerImages,
             ),
+            // Local containers: hand workerd the docker socket whenever a
+            // namespace has an attached image, mirroring `wrangler dev`.
+            // The egress-interceptor default is the image miniflare pins;
+            // ALCHEMY_CONTAINER_EGRESS_IMAGE overrides it (e.g. to work
+            // around cloudflare/workerd#6792 on hosts where TPROXY
+            // intercepts bridge-local traffic and hangs the sidecar
+            // readiness probe).
+            ...(Object.keys(worker.containerImages).length > 0
+              ? {
+                  containerEngine: {
+                    localDocker: {
+                      socketPath: "unix:///var/run/docker.sock",
+                      containerEgressInterceptorImage:
+                        process.env.ALCHEMY_CONTAINER_EGRESS_IMAGE ??
+                        "cloudflare/proxy-everything:3cb1195@sha256:0ef6716c52430096900b150d84a3302057d6cd2319dae7987128c85d0733e3c8",
+                    },
+                  },
+                }
+              : {}),
             queueConsumers: yield* getQueueConsumers(worker.name),
             modules: yield* toRuntimeModules(bundle),
             assets: toRuntimeAssets(worker.assets),
@@ -296,12 +316,26 @@ export const LocalWorkerProvider = () =>
             }
           }
         }
+        // Container-backed DO classes: map className to a local image from
+        // binding data (`containers: [{ className, imageName }]`). Only
+        // entries that carry an `imageName` participate locally; a
+        // remote-only attachment (no image) is ignored by the local
+        // runtime and `ctx.container` stays absent.
+        const containerImages: Record<string, string> = {};
+        for (const { data } of bindings) {
+          for (const container of data.containers ?? []) {
+            if (container.imageName) {
+              containerImages[container.className] = container.imageName;
+            }
+          }
+        }
         return {
           id,
           name,
           compatibility,
           workerBindings,
           durableObjectNamespaces,
+          containerImages,
           hyperdrives,
           env: props.env,
           bundleOptions: {
@@ -395,6 +429,7 @@ export const LocalWorkerProvider = () =>
               bindings: worker.workerBindings,
               durableObjectNamespaces: toRuntimeDurableObjectNamespaces(
                 worker.durableObjectNamespaces,
+                worker.containerImages,
               ),
               hyperdrives: worker.hyperdrives,
               queueConsumers: yield* getQueueConsumers(worker.name),
@@ -674,11 +709,15 @@ const toRuntimeAssets = (
 
 const toRuntimeDurableObjectNamespaces = (
   namespaces: Record<string, string>,
+  containerImages: Record<string, string> = {},
 ): RuntimeDurableObjectNamespace[] => {
   return Object.entries(namespaces).map(([className, namespaceId]) => ({
     className,
     uniqueKey: namespaceId,
     sql: true,
+    ...(containerImages[className]
+      ? { container: { imageName: containerImages[className] } }
+      : {}),
   }));
 };
 

--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -316,19 +316,9 @@ export const LocalWorkerProvider = () =>
             }
           }
         }
-        // Container-backed DO classes: map className to a local image from
-        // binding data (`containers: [{ className, imageName }]`). Only
-        // entries that carry an `imageName` participate locally; a
-        // remote-only attachment (no image) is ignored by the local
-        // runtime and `ctx.container` stays absent.
-        const containerImages: Record<string, string> = {};
-        for (const { data } of bindings) {
-          for (const container of data.containers ?? []) {
-            if (container.imageName) {
-              containerImages[container.className] = container.imageName;
-            }
-          }
-        }
+        // Container-backed DO classes: className -> local image name from
+        // binding data (see `collectContainerImages`).
+        const containerImages = collectContainerImages(bindings);
         return {
           id,
           name,
@@ -707,7 +697,32 @@ const toRuntimeAssets = (
   };
 };
 
-const toRuntimeDurableObjectNamespaces = (
+/**
+ * Map each container-backed DO `className` to its local image name from worker
+ * binding data. Only `containers` entries that carry an `imageName` participate
+ * locally; a remote-only attachment (no image) is skipped, so `ctx.container`
+ * stays absent for it under `alchemy dev`. Later entries win on a className
+ * collision.
+ */
+export const collectContainerImages = (
+  bindings: ReadonlyArray<{
+    data: {
+      containers?: ReadonlyArray<{ className: string; imageName?: string }>;
+    };
+  }>,
+): Record<string, string> => {
+  const containerImages: Record<string, string> = {};
+  for (const { data } of bindings) {
+    for (const container of data.containers ?? []) {
+      if (container.imageName) {
+        containerImages[container.className] = container.imageName;
+      }
+    }
+  }
+  return containerImages;
+};
+
+export const toRuntimeDurableObjectNamespaces = (
   namespaces: Record<string, string>,
   containerImages: Record<string, string> = {},
 ): RuntimeDurableObjectNamespace[] => {

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -325,7 +325,7 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
   },
   {
     bindings?: WorkerBinding[];
-    containers?: { className: string }[];
+    containers?: { className: string; imageName?: string }[];
     crons?: string[];
     hyperdrives?: Record<string, Required<HyperdriveDevOrigin>>;
   },

--- a/packages/alchemy/test/Cloudflare/Workers/LocalWorkerProvider.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/LocalWorkerProvider.test.ts
@@ -1,0 +1,68 @@
+import {
+  collectContainerImages,
+  toRuntimeDurableObjectNamespaces,
+} from "@/Cloudflare/Workers/LocalWorkerProvider";
+import { describe, expect, test } from "vitest";
+
+const binding = (containers?: { className: string; imageName?: string }[]) => ({
+  data: { containers },
+});
+
+describe("collectContainerImages", () => {
+  test("maps className to imageName for entries that carry an image", () => {
+    expect(
+      collectContainerImages([
+        binding([{ className: "SheetDo", imageName: "sql:dev" }]),
+      ]),
+    ).toEqual({ SheetDo: "sql:dev" });
+  });
+
+  test("skips remote-only attachments (no imageName)", () => {
+    expect(
+      collectContainerImages([
+        binding([
+          { className: "WithImage", imageName: "img:dev" },
+          { className: "RemoteOnly" },
+        ]),
+      ]),
+    ).toEqual({ WithImage: "img:dev" });
+  });
+
+  test("tolerates bindings with no containers and empty input", () => {
+    expect(collectContainerImages([])).toEqual({});
+    expect(collectContainerImages([binding(), binding([])])).toEqual({});
+  });
+
+  test("last entry wins on a className collision", () => {
+    expect(
+      collectContainerImages([
+        binding([{ className: "Dup", imageName: "first:dev" }]),
+        binding([{ className: "Dup", imageName: "second:dev" }]),
+      ]),
+    ).toEqual({ Dup: "second:dev" });
+  });
+});
+
+describe("toRuntimeDurableObjectNamespaces", () => {
+  test("emits sql-backed namespaces with no container by default", () => {
+    expect(toRuntimeDurableObjectNamespaces({ Counter: "uniq-1" })).toEqual([
+      { className: "Counter", uniqueKey: "uniq-1", sql: true },
+    ]);
+  });
+
+  test("attaches container only to namespaces with a mapped image", () => {
+    const result = toRuntimeDurableObjectNamespaces(
+      { SheetDo: "uniq-1", Plain: "uniq-2" },
+      { SheetDo: "sql:dev" },
+    );
+    expect(result).toEqual([
+      {
+        className: "SheetDo",
+        uniqueKey: "uniq-1",
+        sql: true,
+        container: { imageName: "sql:dev" },
+      },
+      { className: "Plain", uniqueKey: "uniq-2", sql: true },
+    ]);
+  });
+});


### PR DESCRIPTION
Run Durable-Object-attached containers under `alchemy dev`, using workerd's native container support against the local Docker daemon (what `wrangler dev` / miniflare do).

A worker binds a container class to a DO namespace with an image name; locally that image is started per DO instance and exposed as `ctx.container`:

```ts
yield* worker.bind`my-container`({
  containers: [{ className: "MyDo", imageName: "my-image:dev" }],
});
```

- `containers` binding data gains an optional `imageName`; entries without one are remote-only attachments and are ignored locally (`ctx.container` stays absent)
- `LocalWorkerProvider` maps `className -> imageName` from binding data, attaches `container: { imageName }` to the matching workerd DO namespace, and configures a `localDocker` container engine (socket `unix:///var/run/docker.sock`)
- The egress-interceptor sidecar image defaults to the same pinned `cloudflare/proxy-everything` miniflare uses; `ALCHEMY_CONTAINER_EGRESS_IMAGE` overrides it (e.g. to work around cloudflare/workerd#6792 on hosts where TPROXY intercepts bridge-local traffic and hangs the sidecar readiness probe)

Draft because it activates only once `@distilled.cloud/cloudflare-runtime` threads the container config through to workerd: alchemy-run/cloudflare-tools#46, then a catalog bump here. The new fields typecheck against 0.10.12 and are dropped by its config assembly, so behavior is unchanged until that lands.

Validated end-to-end on the cloudflare-tools#46 runtime: a Rust DataFusion container attached to a DO class under `alchemy dev` cold-starts on first request, serves proxied traffic, and is destroyed by the DO's idle alarm.
