### PR TITLE
fix(pr-package): unwrap Redacted on both sides of bearer-token auth

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -702,6 +702,17 @@
         "effect": "catalog:",
       },
     },
+    "examples/cloudflare-worker-auth": {
+      "name": "cloudflare-worker-auth",
+      "version": "0.0.0",
+      "dependencies": {
+        "@cloudflare/workers-types": "catalog:",
+        "@effect/platform-bun": "catalog:",
+        "@effect/platform-node": "catalog:",
+        "alchemy": "workspace:*",
+        "effect": "catalog:",
+      },
+    },
     "examples/monorepo-multi-stack/backend": {
       "name": "@monorepo-multi-stack/backend",
       "version": "0.0.0",
@@ -2484,6 +2495,8 @@
     "cloudflare-worker": ["cloudflare-worker@workspace:examples/cloudflare-worker"],
 
     "cloudflare-worker-async": ["cloudflare-worker-async@workspace:examples/cloudflare-worker-async"],
+
+    "cloudflare-worker-auth": ["cloudflare-worker-auth@workspace:examples/cloudflare-worker-auth"],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
@@ -4471,6 +4484,8 @@
 
     "@vue/language-core/@vue/shared": ["@vue/shared@3.5.35", "", {}, "sha512-zSbjL7gRXwks2ZQLRGCajBtBXEOXW9Ddhn/HvSdrGkE2dqGnumzW8XtusRrxrE9LvqtiqDXQ+A60Hp6mvdYxfA=="],
 
+    "alchemy/@types/node": ["@types/node@25.9.3", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg=="],
+
     "ansi-align/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
@@ -4672,6 +4687,8 @@
     "string_decoder/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "svgo/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 
     "svgo/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 

--- a/examples/cloudflare-worker-auth/alchemy.run.ts
+++ b/examples/cloudflare-worker-auth/alchemy.run.ts
@@ -1,24 +1,27 @@
-import * as PrPackage from "@alchemy.run/pr-package";
 import * as Alchemy from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
 import * as Output from "alchemy/Output";
 import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
-import Api from "./pr-package/Api.ts";
+
+import Api from "./src/Api.ts";
+import { AuthTokenValue } from "./src/AuthToken.ts";
 
 export default Alchemy.Stack(
-  "PrPackage",
+  "CloudflareWorkerAuthExample",
   {
     providers: Cloudflare.providers(),
     state: Cloudflare.state(),
   },
   Effect.gen(function* () {
-    const authToken = yield* PrPackage.AuthTokenValue;
+    const authToken = yield* AuthTokenValue;
     const api = yield* Api;
+
     return {
       url: api.url.as<string>(),
-      // Unwrap the Redacted so the stack output emits the real token —
-      // otherwise it serializes to the literal string "<redacted>".
+      // `authToken.text` is an `Output<Redacted<string>>`. Map over the Output
+      // to unwrap the Redacted so the stack output emits the real token —
+      // otherwise it JSON-serializes to the literal string "<redacted>".
       authToken: authToken.text.pipe(Output.map(Redacted.value)),
     };
   }),

--- a/examples/cloudflare-worker-auth/package.json
+++ b/examples/cloudflare-worker-auth/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "cloudflare-worker-auth",
+  "version": "0.0.0",
+  "private": true,
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "directory": "examples/cloudflare-worker-auth"
+  },
+  "type": "module",
+  "scripts": {
+    "deploy": "alchemy deploy",
+    "dev": "alchemy dev",
+    "destroy": "alchemy destroy",
+    "logs": "alchemy logs",
+    "tail": "alchemy tail",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@cloudflare/workers-types": "catalog:",
+    "@effect/platform-bun": "catalog:",
+    "@effect/platform-node": "catalog:",
+    "alchemy": "workspace:*",
+    "effect": "catalog:"
+  }
+}

--- a/examples/cloudflare-worker-auth/src/Api.ts
+++ b/examples/cloudflare-worker-auth/src/Api.ts
@@ -1,0 +1,54 @@
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import * as Redacted from "effect/Redacted";
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import { AuthToken } from "./AuthToken.ts";
+
+/**
+ * A Worker with a single bearer-token protected route, mirroring the auth
+ * check in `@alchemy.run/pr-package`.
+ *
+ * `Cloudflare.Secret.bind(...)` resolves to `Redacted<string>`. The comparison
+ * MUST unwrap it with `Redacted.value(expected)` — coercing a `Redacted` to a
+ * string yields the literal `"<redacted>"`, so `Bearer ${expected}` would
+ * compare against `"Bearer <redacted>"` and silently accept the wrong token.
+ * See https://github.com/alchemy-run/alchemy-effect/pull/598.
+ */
+export default class Api extends Cloudflare.Worker<Api>()(
+  "Api",
+  {
+    main: import.meta.filename,
+  },
+  Effect.gen(function* () {
+    const authToken = yield* Cloudflare.Secret.bind(AuthToken);
+
+    return {
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+
+        if (request.url.startsWith("/protected")) {
+          const authHeader = request.headers.authorization;
+          const expected = yield* authToken;
+          if (
+            !authHeader ||
+            authHeader !== `Bearer ${Redacted.value(expected)}`
+          ) {
+            return HttpServerResponse.text("unauthorized", { status: 401 });
+          }
+          return HttpServerResponse.text("ok");
+        }
+
+        return HttpServerResponse.text("public");
+      }).pipe(
+        Effect.catchTag("SecretError", (err) =>
+          Effect.succeed(
+            HttpServerResponse.text(`failed to read secret: ${err.message}`, {
+              status: 500,
+            }),
+          ),
+        ),
+      ),
+    };
+  }).pipe(Effect.provide(Cloudflare.SecretBindingLive)),
+) {}

--- a/examples/cloudflare-worker-auth/src/AuthToken.ts
+++ b/examples/cloudflare-worker-auth/src/AuthToken.ts
@@ -1,0 +1,25 @@
+import { Random } from "alchemy";
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+
+/** Secrets Store backing the bearer token. */
+export const Store = Cloudflare.SecretsStore("AuthSecrets");
+
+/**
+ * Random-generated bearer token. `Random` persists its value in state, so the
+ * token is stable across deploys (only regenerated on replacement).
+ *
+ * `yield* AuthTokenValue` resolves to `{ text: Output<Redacted<string>> }` —
+ * yield it in the stack to read `.text` for the `authToken` output.
+ */
+export const AuthTokenValue = Random("AuthTokenValue");
+
+/** Cloudflare Secret bound to the Worker. Internal — yielded by `Api`. */
+export const AuthToken = Effect.gen(function* () {
+  const store = yield* Store;
+  const value = yield* AuthTokenValue;
+  return yield* Cloudflare.Secret("AuthToken", {
+    store,
+    value: value.text,
+  });
+});

--- a/examples/cloudflare-worker-auth/test/integ.test.ts
+++ b/examples/cloudflare-worker-auth/test/integ.test.ts
@@ -1,0 +1,101 @@
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Test from "alchemy/Test/Bun";
+import { expect } from "bun:test";
+import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import Stack from "../alchemy.run.ts";
+
+const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
+  providers: Cloudflare.providers(),
+  state: Cloudflare.state(),
+  stage: "test",
+});
+
+const stack = beforeAll(deploy(Stack), { timeout: 180_000 });
+
+afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(Stack), {
+  timeout: 180_000,
+});
+
+/**
+ * Regression guard for https://github.com/alchemy-run/alchemy-effect/pull/598
+ *
+ * The bearer token is symmetric:
+ *
+ *  - Stack output: `authToken.text` is an `Output<Redacted<string>>`. It must
+ *    be unwrapped via `Output.map(Redacted.value)` before being returned —
+ *    otherwise it JSON-serializes to the literal string "<redacted>".
+ *  - Worker check: `Cloudflare.Secret.bind(...)` resolves to `Redacted<string>`.
+ *    The comparison must unwrap with `Redacted.value(expected)` — otherwise it
+ *    compares against "Bearer <redacted>".
+ *
+ * Two bugs that cancelled: a publisher reading the broken `<redacted>` output
+ * would send `Bearer <redacted>`, which the broken worker check also produced,
+ * so they matched. This suite breaks that camouflage:
+ *
+ *  - The output must be the real token, not "<redacted>".
+ *  - A request carrying the literal "<redacted>" must be rejected.
+ */
+test(
+  "stack output emits the real token, not the literal <redacted>",
+  Effect.gen(function* () {
+    const { authToken } = yield* stack;
+    expect(authToken).toBeString();
+    expect(authToken).not.toBe("<redacted>");
+    // Random defaults to 32 bytes -> 64 hex chars.
+    expect(authToken).toMatch(/^[0-9a-f]{64}$/);
+  }),
+);
+
+test(
+  "valid token is accepted; invalid / missing / <redacted> are rejected",
+  Effect.gen(function* () {
+    const { url, authToken } = yield* stack;
+    const client = yield* HttpClient.HttpClient;
+
+    const protectedUrl = `${url}/protected`;
+    const get = (req: HttpClientRequest.HttpClientRequest) =>
+      client.execute(req);
+
+    // Warm up through edge propagation — fresh workers.dev URLs take a few
+    // seconds to start serving. The public route needs no auth.
+    yield* client.get(url).pipe(
+      Effect.retry({
+        schedule: Schedule.exponential("500 millis"),
+        times: 10,
+      }),
+    );
+
+    // Valid token -> 200
+    const ok = yield* get(
+      HttpClientRequest.get(protectedUrl).pipe(
+        HttpClientRequest.bearerToken(authToken),
+      ),
+    );
+    expect(ok.status).toBe(200);
+
+    // Invalid token -> 401
+    const bad = yield* get(
+      HttpClientRequest.get(protectedUrl).pipe(
+        HttpClientRequest.bearerToken("not-the-token"),
+      ),
+    );
+    expect(bad.status).toBe(401);
+
+    // No Authorization header -> 401
+    const none = yield* get(HttpClientRequest.get(protectedUrl));
+    expect(none.status).toBe(401);
+
+    // The literal "<redacted>" (what both old bugs produced) -> 401.
+    // Pre-fix this matched and returned 200.
+    const redacted = yield* get(
+      HttpClientRequest.get(protectedUrl).pipe(
+        HttpClientRequest.bearerToken("<redacted>"),
+      ),
+    );
+    expect(redacted.status).toBe(401);
+  }),
+  { timeout: 120_000 },
+);

--- a/examples/cloudflare-worker-auth/tsconfig.json
+++ b/examples/cloudflare-worker-auth/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["alchemy.run.ts", "src/**/*.ts", "test/**/*.ts"],
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "module": "Preserve",
+    "moduleResolution": "Bundler",
+    "target": "ESNext"
+  },
+  "references": [
+    {
+      "path": "../../packages/alchemy/tsconfig.json"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "sync:submodules": "git submodule sync --recursive && git submodule update --init --recursive",
     "test:benchmark": "bun run --filter alchemy test:benchmark",
     "test:canary": "SMOKE_CANARY=1 bun test --only-failures ./test/smoke.test.ts",
-    "test:examples": "bun run --filter ./examples/cloudflare-worker --filter ./examples/cloudflare-worker-async --filter ./examples/cloudflare-tanstack --filter ./examples/cloudflare-tanstack-start-solid --filter ./examples/aws-lambda test && bun format",
+    "test:examples": "bun run --filter ./examples/cloudflare-worker --filter ./examples/cloudflare-worker-auth --filter ./examples/cloudflare-worker-async --filter ./examples/cloudflare-tanstack --filter ./examples/cloudflare-tanstack-start-solid --filter ./examples/aws-lambda test && bun format",
     "test:fast": "NO_SLOW_TESTS=1 FAST=1 bun run test:live",
     "test:live": "bun ./scripts/test.ts",
     "test:local": "LOCAL=1 bun ./scripts/test.ts",

--- a/packages/alchemy/test/Output.test.ts
+++ b/packages/alchemy/test/Output.test.ts
@@ -840,6 +840,56 @@ describe("Output coercion guard", () => {
   });
 });
 
+describe("Redacted stack-output serialization (regression #598)", () => {
+  // A resource whose attribute is a `Redacted<string>` — e.g. `Random.text`,
+  // which pr-package's AuthTokenValue exposes. When such an attribute flows
+  // into a Stack output it is JSON-serialized for persistence to state /
+  // Doppler / GH secrets. `JSON.stringify(Redacted)` returns the literal
+  // string "<redacted>", so a publisher reading the output would send
+  // `Bearer <redacted>` instead of the real token. The fix is to unwrap with
+  // `Output.map(Redacted.value)` before returning it from the stack.
+  const SECRET = "1486c434bd35732a185d1712c587ddfafd9e1c8d7a94fb15cf6ece51128";
+  const redactedResource = () => {
+    const src = fakeResource<
+      "Alchemy.Random",
+      { text: Redacted.Redacted<string> }
+    >("Alchemy.Random", "AuthTokenValue");
+    return (Output.of(src) as any).text as Output.Output<
+      Redacted.Redacted<string>
+    >;
+  };
+  const env = { AuthTokenValue: { text: Redacted.make(SECRET) } };
+
+  it.effect(
+    'a raw Redacted output serializes to the literal "<redacted>" (the bug)',
+    () =>
+      provideState(
+        Effect.gen(function* () {
+          const result = yield* Output.evaluate(redactedResource(), env);
+          // The evaluated value is still a Redacted, and persisting it as a
+          // stack output (JSON) loses the real token.
+          expect(Redacted.isRedacted(result)).toBe(true);
+          expect(JSON.stringify({ authToken: result })).toBe(
+            '{"authToken":"<redacted>"}',
+          );
+        }),
+      ),
+  );
+
+  it.effect("Output.map(Redacted.value) emits the real token (the fix)", () =>
+    provideState(
+      Effect.gen(function* () {
+        const expr = redactedResource().pipe(Output.map(Redacted.value));
+        const result = yield* Output.evaluate(expr, env);
+        expect(result).toBe(SECRET);
+        expect(JSON.stringify({ authToken: result })).toBe(
+          `{"authToken":"${SECRET}"}`,
+        );
+      }),
+    ),
+  );
+});
+
 describe("Output.isOutput / isExpr", () => {
   it("identifies Output expressions", () => {
     expect(Output.isOutput(Output.literal(1))).toBe(true);

--- a/packages/pr-package/README.md
+++ b/packages/pr-package/README.md
@@ -55,6 +55,7 @@ export default class Api extends Cloudflare.Worker<Api>()(
 import * as PrPackage from "@alchemy.run/pr-package";
 import * as Alchemy from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
+import * as Output from "alchemy/Output";
 import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import Api from "./pr-package/Api.ts";
@@ -69,7 +70,7 @@ export default Alchemy.Stack(
       url: api.url.as<string>(),
       // Unwrap the Redacted so the stack output emits the real token —
       // otherwise it serializes to the literal string "<redacted>".
-      authToken: Redacted.value(authToken.text),
+      authToken: authToken.text.pipe(Output.map(Redacted.value)),
     };
   }),
 );

--- a/packages/pr-package/README.md
+++ b/packages/pr-package/README.md
@@ -56,6 +56,7 @@ import * as PrPackage from "@alchemy.run/pr-package";
 import * as Alchemy from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
+import * as Redacted from "effect/Redacted";
 import Api from "./pr-package/Api.ts";
 
 export default Alchemy.Stack(
@@ -66,7 +67,9 @@ export default Alchemy.Stack(
     const api = yield* Api;
     return {
       url: api.url.as<string>(),
-      authToken: authToken.text, // Redacted bearer token for uploads
+      // Unwrap the Redacted so the stack output emits the real token —
+      // otherwise it serializes to the literal string "<redacted>".
+      authToken: Redacted.value(authToken.text),
     };
   }),
 );

--- a/packages/pr-package/src/Worker.ts
+++ b/packages/pr-package/src/Worker.ts
@@ -2,6 +2,7 @@ import * as Cloudflare from "alchemy/Cloudflare";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Redacted from "effect/Redacted";
 import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import {
@@ -70,7 +71,10 @@ export const handler = (options: HandlerOptions = {}) =>
         const requireAuth = Effect.gen(function* () {
           const authHeader = request.headers.authorization;
           const expected = yield* authToken;
-          if (!authHeader || authHeader !== `Bearer ${expected}`) {
+          if (
+            !authHeader ||
+            authHeader !== `Bearer ${Redacted.value(expected)}`
+          ) {
             return yield* Effect.fail(new Unauthorized());
           }
         });

--- a/stacks/pr-package.ts
+++ b/stacks/pr-package.ts
@@ -2,6 +2,7 @@ import * as PrPackage from "@alchemy.run/pr-package";
 import * as Alchemy from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
+import * as Redacted from "effect/Redacted";
 import Api from "./pr-package/Api.ts";
 
 export default Alchemy.Stack(
@@ -15,7 +16,7 @@ export default Alchemy.Stack(
     const api = yield* Api;
     return {
       url: api.url.as<string>(),
-      authToken: authToken.text,
+      authToken: Redacted.value(authToken.text),
     };
   }),
 );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -64,6 +64,9 @@
       "path": "./examples/cloudflare-worker/tsconfig.json"
     },
     {
+      "path": "./examples/cloudflare-worker-auth/tsconfig.json"
+    },
+    {
       "path": "./examples/cloudflare-email/tsconfig.json"
     },
     {


### PR DESCRIPTION
Supersedes [#568](https://github.com/alchemy-run/alchemy-effect/pull/568). That PR fixes the worker side of the auth check, but the bug is symmetric — fixing only one side breaks every existing publisher.

### The symmetric bug

`Cloudflare.Secret.bind(...)` resolves to `Redacted<string>`. `Redacted.toString()` returns the literal string `"<redacted>"`, and `toJSON()` delegates to `toString()`.

Worker side (in `packages/pr-package/src/Worker.ts`):

```ts
const expected = yield* authToken;            // Redacted<string>
if (authHeader !== `Bearer ${expected}`) {... // compares against "Bearer <redacted>"
```

Stack-output side (in `stacks/pr-package.ts`):

```ts
return {
  authToken: authToken.text,  // Redacted<string> — JSON-serializes to "<redacted>"
};
```

When that stack output is persisted to state and pulled into Doppler / `PR_PACKAGE_TOKEN`, the env var ends up as the literal string `<redacted>`. The publisher then sends `Authorization: Bearer <redacted>`, and the worker's broken check also produces `"Bearer <redacted>"`. They match. Two bugs cancelling — which is why this "worked" in prod.

### Fix

Unwrap on both sides.

```diff
// packages/pr-package/src/Worker.ts
-  if (!authHeader || authHeader !== `Bearer ${expected}`) {
+  if (!authHeader || authHeader !== `Bearer ${Redacted.value(expected)}`) {
```

```diff
// stacks/pr-package.ts
-    authToken: authToken.text,
+    authToken: Redacted.value(authToken.text),
```

README example updated to match.

### Rollout note

The currently-distributed `PR_PACKAGE_TOKEN` is the literal string `<redacted>`. After this lands, re-deploy the stack and re-publish the new `authToken` output to Doppler / GH Actions secrets so publishers send the real token.
