### PR TITLE
feat(aws/lambda): support function URL config

### DIFF
--- a/packages/alchemy/src/AWS/Lambda/Function.ts
+++ b/packages/alchemy/src/AWS/Lambda/Function.ts
@@ -17,7 +17,7 @@ import type * as rolldown from "rolldown";
 import { Unowned } from "../../AdoptPolicy.ts";
 import * as Bundle from "../../Bundle/Bundle.ts";
 import * as TempRoot from "../../Bundle/TempRoot.ts";
-import { isResolved } from "../../Diff.ts";
+import { deepEqual, isResolved } from "../../Diff.ts";
 import type { HttpEffect } from "../../Http.ts";
 import * as Output from "../../Output.ts";
 import { createPhysicalName } from "../../PhysicalName.ts";
@@ -65,6 +65,24 @@ export interface FunctionBuildOptions {
   readonly output?: Partial<rolldown.OutputOptions>;
 }
 
+export interface FunctionUrlConfig {
+  /**
+   * Authentication type for the Lambda function URL.
+   * `NONE` creates a public endpoint. `AWS_IAM` requires SigV4-signed callers.
+   * @default "NONE"
+   */
+  authType?: Lambda.FunctionUrlAuthType;
+  /**
+   * Cross-origin resource sharing configuration for the function URL.
+   */
+  cors?: Lambda.Cors;
+  /**
+   * Invocation mode for the function URL.
+   * @default "BUFFERED"
+   */
+  invokeMode?: Lambda.InvokeMode;
+}
+
 export interface FunctionProps extends PlatformProps {
   /**
    * Entry module for the bundled Lambda function.
@@ -76,10 +94,12 @@ export interface FunctionProps extends PlatformProps {
    */
   handler?: string;
   /**
-   * Whether to create a public Lambda function URL.
-   * @default false
+   * Whether to create a Lambda function URL, or its configuration.
+   * `true` creates a public Function URL with `authType: "NONE"`.
+   * Set `false` to disable the Function URL.
+   * @default true
    */
-  url?: boolean;
+  url?: boolean | FunctionUrlConfig;
   functionName?: string;
   // TODO(sam): use a Layer instead so we can manage Effect platform?
   runtime?: "nodejs22.x" | "nodejs24.x";
@@ -156,6 +176,31 @@ export interface Function extends Resource<
 export type FunctionServices = Credentials | Region | AWSEnvironment;
 
 export type FunctionShape = Main<FunctionServices>;
+
+interface NormalizedFunctionUrlConfig {
+  authType: Lambda.FunctionUrlAuthType;
+  cors?: Lambda.Cors;
+  invokeMode: Lambda.InvokeMode;
+}
+
+const normalizeFunctionUrl = (
+  url: FunctionProps["url"] = true,
+): NormalizedFunctionUrlConfig | undefined => {
+  if (url === false) {
+    return undefined;
+  }
+  if (url === true || url === undefined) {
+    return {
+      authType: "NONE",
+      invokeMode: "BUFFERED",
+    };
+  }
+  return {
+    authType: url.authType ?? "NONE",
+    cors: url.cors,
+    invokeMode: url.invokeMode ?? "BUFFERED",
+  };
+};
 
 /**
  * An AWS Lambda host resource that combines code bundling, IAM role
@@ -237,6 +282,16 @@ export type FunctionShape = Main<FunctionServices>;
  * const func = yield* AWS.Lambda.Function("ApiFunction", {
  *   main: "./src/handler.ts",
  *   url: true,
+ * });
+ * ```
+ *
+ * @example Function URL with IAM auth
+ * ```typescript
+ * const func = yield* AWS.Lambda.Function("ApiFunction", {
+ *   main: "./src/handler.ts",
+ *   url: {
+ *     authType: "AWS_IAM",
+ *   },
  * });
  * ```
  *
@@ -1025,78 +1080,116 @@ export default await Effect.runPromise(handlerEffect)
         }
       });
 
+      const publicUrlAccessStatementId = "FunctionURLAllowPublicAccess";
+      const publicUrlInvokeStatementId = "FunctionURLAllowPublicInvoke";
+
+      const removePublicFunctionUrlPermissions = Effect.fnUntraced(function* (
+        functionName: string,
+      ) {
+        yield* Effect.all(
+          [
+            Lambda.removePermission({
+              FunctionName: functionName,
+              StatementId: publicUrlAccessStatementId,
+            }).pipe(
+              Effect.catchTag("ResourceNotFoundException", () => Effect.void),
+            ),
+            Lambda.removePermission({
+              FunctionName: functionName,
+              StatementId: publicUrlInvokeStatementId,
+            }).pipe(
+              Effect.catchTag("ResourceNotFoundException", () => Effect.void),
+            ),
+          ],
+          { concurrency: "unbounded" },
+        );
+      });
+
+      const upsertPermission = (permission: Lambda.AddPermissionRequest) =>
+        Lambda.addPermission(permission).pipe(
+          Effect.catchTag("ResourceConflictException", () =>
+            Effect.gen(function* () {
+              yield* Lambda.removePermission({
+                FunctionName: permission.FunctionName,
+                StatementId: permission.StatementId,
+              }).pipe(
+                Effect.catchTag("ResourceNotFoundException", () => Effect.void),
+              );
+              yield* Lambda.addPermission(permission);
+            }),
+          ),
+        );
+
+      const upsertPublicFunctionUrlPermissions = Effect.fnUntraced(function* (
+        functionName: string,
+      ) {
+        yield* Effect.all(
+          [
+            upsertPermission({
+              FunctionName: functionName,
+              StatementId: publicUrlAccessStatementId,
+              Action: "lambda:InvokeFunctionUrl",
+              Principal: "*",
+              FunctionUrlAuthType: "NONE",
+            }),
+            upsertPermission({
+              FunctionName: functionName,
+              StatementId: publicUrlInvokeStatementId,
+              Action: "lambda:InvokeFunction",
+              Principal: "*",
+              InvokedViaFunctionUrl: true,
+            }),
+          ],
+          { concurrency: "unbounded" },
+        );
+      });
+
       const createOrUpdateFunctionUrl = Effect.fnUntraced(function* ({
         functionName,
-        url = true,
+        url,
         oldUrl,
+        currentFunctionUrl,
       }: {
         functionName: string;
         url: FunctionProps["url"];
         oldUrl?: FunctionProps["url"];
+        currentFunctionUrl?: string;
       }) {
-        // TODO(sam): support AWS_IAM
-        const authType = "NONE";
-        yield* Effect.logDebug(`creating function url config ${functionName}`);
-        if (url) {
+        const desired = normalizeFunctionUrl(url);
+        const previous = normalizeFunctionUrl(oldUrl);
+        const hadFunctionUrl = previous !== undefined || !!currentFunctionUrl;
+
+        if (desired) {
+          yield* Effect.logDebug(
+            `creating function url config ${functionName}`,
+          );
+          const shouldClearCors =
+            desired.cors === undefined && previous?.cors !== undefined;
           const config = {
             FunctionName: functionName,
-            AuthType: authType, // | AWS_IAM
-            // Cors: {
-            //   AllowCredentials: true,
-            //   AllowHeaders: ["*"],
-            //   AllowMethods: ["*"],
-            //   AllowOrigins: ["*"],
-            //   ExposeHeaders: ["*"],
-            //   MaxAge: 86400,
-            // },
-            InvokeMode: "BUFFERED", // | RESPONSE_STREAM
-            // Qualifier: "$LATEST"
+            AuthType: desired.authType,
+            Cors: desired.cors ?? (shouldClearCors ? {} : undefined),
+            InvokeMode: desired.invokeMode,
           } satisfies
             | Lambda.CreateFunctionUrlConfigRequest
             | Lambda.UpdateFunctionUrlConfigRequest;
-          const urlPermission = {
-            FunctionName: functionName,
-            StatementId: "FunctionURLAllowPublicAccess",
-            Action: "lambda:InvokeFunctionUrl",
-            Principal: "*",
-            FunctionUrlAuthType: "NONE",
-          } as const;
-          const invokePermission = {
-            FunctionName: functionName,
-            StatementId: "FunctionURLAllowPublicInvoke",
-            Action: "lambda:InvokeFunction",
-            Principal: "*",
-            InvokedViaFunctionUrl: true,
-          } as const;
-          const upsertPermission = (permission: Lambda.AddPermissionRequest) =>
-            Lambda.addPermission(permission).pipe(
-              Effect.catchTag("ResourceConflictException", () =>
-                Effect.gen(function* () {
-                  yield* Lambda.removePermission({
-                    FunctionName: functionName,
-                    StatementId: permission.StatementId,
-                  });
-                  yield* Lambda.addPermission(permission);
-                }),
-              ),
-            );
-          const [{ FunctionUrl }] = yield* Effect.all([
-            Lambda.createFunctionUrlConfig(config).pipe(
-              Effect.catchTag("ResourceConflictException", () =>
-                Lambda.updateFunctionUrlConfig(config),
-              ),
+          const { FunctionUrl } = yield* Lambda.createFunctionUrlConfig(
+            config,
+          ).pipe(
+            Effect.catchTag("ResourceConflictException", () =>
+              Lambda.updateFunctionUrlConfig(config),
             ),
-            authType === "NONE"
-              ? Effect.all([
-                  upsertPermission(urlPermission),
-                  upsertPermission(invokePermission),
-                ])
-              : // TODO(sam): support AWS_IAM
-                Effect.void,
-          ]);
+          );
+
+          if (desired.authType === "NONE") {
+            yield* upsertPublicFunctionUrlPermissions(functionName);
+          } else {
+            yield* removePublicFunctionUrlPermissions(functionName);
+          }
+
           yield* Effect.logDebug(`created function url config ${functionName}`);
           return FunctionUrl;
-        } else if (oldUrl) {
+        } else if (hadFunctionUrl) {
           yield* Effect.logDebug(
             `deleting function url config ${functionName}`,
           );
@@ -1106,18 +1199,7 @@ export default await Effect.runPromise(handlerEffect)
             }).pipe(
               Effect.catchTag("ResourceNotFoundException", () => Effect.void),
             ),
-            Lambda.removePermission({
-              FunctionName: functionName,
-              StatementId: "FunctionURLAllowPublicAccess",
-            }).pipe(
-              Effect.catchTag("ResourceNotFoundException", () => Effect.void),
-            ),
-            Lambda.removePermission({
-              FunctionName: functionName,
-              StatementId: "FunctionURLAllowPublicInvoke",
-            }).pipe(
-              Effect.catchTag("ResourceNotFoundException", () => Effect.void),
-            ),
+            removePublicFunctionUrlPermissions(functionName),
           ]);
           yield* Effect.logDebug(`deleted function url config ${functionName}`);
         }
@@ -1144,11 +1226,17 @@ export default await Effect.runPromise(handlerEffect)
           if (
             // function name changed
             output.functionName !==
-              (yield* createFunctionName(id, news.functionName)) ||
-            // url changed
-            (olds.url ?? true) !== news.url
+            (yield* createFunctionName(id, news.functionName))
           ) {
             return { action: "replace" };
+          }
+          if (
+            !deepEqual(
+              normalizeFunctionUrl(olds.url),
+              normalizeFunctionUrl(news.url),
+            )
+          ) {
+            return { action: "update" };
           }
           if (
             output.code.hash !==
@@ -1310,6 +1398,7 @@ export default await Effect.runPromise(handlerEffect)
             functionName,
             url: news.url,
             oldUrl: olds?.url,
+            currentFunctionUrl: output?.functionUrl,
           });
 
           yield* session.note(summary({ code }));

--- a/packages/alchemy/src/AWS/Website/SsrSite.ts
+++ b/packages/alchemy/src/AWS/Website/SsrSite.ts
@@ -110,7 +110,7 @@ const serverUrlOf = (server: SsrSiteServerOrigin): Input<string> => {
       return Output.map((url: string | undefined) => {
         if (!url) {
           throw new Error(
-            "SsrSite lambda origins require a function created with `url: true`.",
+            "SsrSite lambda origins require a function created with `url` enabled.",
           );
         }
         return url;

--- a/packages/alchemy/test/AWS/Lambda/Function.test.ts
+++ b/packages/alchemy/test/AWS/Lambda/Function.test.ts
@@ -108,7 +108,133 @@ test.provider(
   { timeout: 360_000 },
 );
 
+test.provider(
+  "updates function URL auth to AWS_IAM",
+  (stack) =>
+    Effect.gen(function* () {
+      const initial = yield* stack.deploy(
+        AWS.Lambda.Function<{}>()("IamUrlFn", {
+          main: timeoutHandlerPath,
+          handler: "handler",
+          isExternal: true,
+          url: true,
+        }),
+      );
+
+      const invokePolicy = yield* getPolicyStatement(
+        initial.functionName,
+        "FunctionURLAllowPublicInvoke",
+      );
+      expect(invokePolicy.Condition).toEqual({
+        Bool: {
+          "lambda:InvokedViaFunctionUrl": "true",
+        },
+      });
+
+      const updated = yield* stack.deploy(
+        AWS.Lambda.Function<{}>()("IamUrlFn", {
+          main: timeoutHandlerPath,
+          handler: "handler",
+          isExternal: true,
+          url: {
+            authType: "AWS_IAM",
+            cors: {
+              AllowHeaders: ["authorization", "content-type"],
+              AllowMethods: ["GET", "POST"],
+              AllowOrigins: ["https://example.com"],
+              ExposeHeaders: ["x-request-id"],
+              MaxAge: 300,
+            },
+            invokeMode: "RESPONSE_STREAM",
+          },
+        }),
+      );
+
+      expect(updated.functionName).toBe(initial.functionName);
+      expect(updated.functionUrl).toBeTruthy();
+
+      const config = yield* getFunctionUrlConfigWithAuth(
+        updated.functionName,
+        "AWS_IAM",
+      );
+      expect(config.AuthType).toBe("AWS_IAM");
+      expect(config.InvokeMode).toBe("RESPONSE_STREAM");
+      expect(config.Cors).toEqual({
+        AllowHeaders: ["authorization", "content-type"],
+        AllowMethods: ["GET", "POST"],
+        AllowOrigins: ["https://example.com"],
+        ExposeHeaders: ["x-request-id"],
+        MaxAge: 300,
+      });
+
+      yield* waitForPolicyStatementAbsent(
+        updated.functionName,
+        "FunctionURLAllowPublicAccess",
+      );
+      yield* waitForPolicyStatementAbsent(
+        updated.functionName,
+        "FunctionURLAllowPublicInvoke",
+      );
+
+      const response = yield* HttpClient.get(updated.functionUrl!).pipe(
+        Effect.flatMap((response) =>
+          response.status === 403
+            ? Effect.succeed(response)
+            : Effect.fail(
+                new Error(`IAM Function URL returned ${response.status}`),
+              ),
+        ),
+        Effect.retry({
+          schedule: Schedule.exponential(500).pipe(
+            Schedule.both(Schedule.recurs(10)),
+          ),
+        }),
+      );
+      expect(response.status).toBe(403);
+    }).pipe(
+      Effect.tap(() => stack.destroy()),
+      Effect.onError(() => stack.destroy().pipe(Effect.ignore)),
+    ),
+  { timeout: 360_000 },
+);
+
 const getPolicyStatement = Effect.fn(function* (
+  functionName: string,
+  statementId: string,
+) {
+  return yield* findPolicyStatement(functionName, statementId).pipe(
+    Effect.flatMap((statement) =>
+      statement
+        ? Effect.succeed(statement)
+        : Effect.fail(new Error(`Policy statement ${statementId} not found`)),
+    ),
+    Effect.retry({
+      schedule: Schedule.exponential(500).pipe(
+        Schedule.both(Schedule.recurs(10)),
+      ),
+    }),
+  );
+});
+
+const waitForPolicyStatementAbsent = Effect.fn(function* (
+  functionName: string,
+  statementId: string,
+) {
+  yield* findPolicyStatement(functionName, statementId).pipe(
+    Effect.flatMap((statement) =>
+      statement
+        ? Effect.fail(new Error(`Policy statement ${statementId} still exists`))
+        : Effect.void,
+    ),
+    Effect.retry({
+      schedule: Schedule.exponential(500).pipe(
+        Schedule.both(Schedule.recurs(10)),
+      ),
+    }),
+  );
+});
+
+const findPolicyStatement = Effect.fn(function* (
   functionName: string,
   statementId: string,
 ) {
@@ -122,17 +248,30 @@ const getPolicyStatement = Effect.fn(function* (
               Condition?: unknown;
             }>;
           };
-          const statement = policy.Statement?.find(
+          return policy.Statement?.find(
             (statement) => statement.Sid === statementId,
           );
-          if (!statement) {
-            throw new Error(`Policy statement ${statementId} not found`);
-          }
-          return statement;
         },
         catch: (cause) =>
           cause instanceof Error ? cause : new Error(String(cause)),
       }),
+    ),
+    Effect.catchTag("ResourceNotFoundException", () =>
+      Effect.succeed(undefined),
+    ),
+  );
+});
+
+const getFunctionUrlConfigWithAuth = Effect.fn(function* (
+  functionName: string,
+  authType: Lambda.FunctionUrlAuthType,
+) {
+  return yield* Lambda.getFunctionUrlConfig({
+    FunctionName: functionName,
+  }).pipe(
+    Effect.filterOrFail(
+      (config) => config.AuthType === authType,
+      () => new Error("Function URL auth has not propagated yet"),
     ),
     Effect.retry({
       schedule: Schedule.exponential(500).pipe(


### PR DESCRIPTION
Allow Lambda function URLs to configure:

```ts
  url: {
    authType: "AWS_IAM",
    cors: {
      AllowOrigins: ["https://example.com"],
    },
    invokeMode: "RESPONSE_STREAM",
  }
  ```

`url: true` remains the public default. When `authType` is `AWS_IAM`, Alchemy removes the public Function URL permission statements.