### PR TITLE
fix(cloudflare/worker): keep url stable across updates

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -1917,15 +1917,41 @@ export const LiveWorkerProvider = () =>
           const cronsChanged =
             newCrons.length !== oldCrons.length ||
             newCrons.some((cron, index) => cron !== oldCrons[index]);
+          // `url` is `domains[0]`: the first custom domain in user order if
+          // any, otherwise the workers.dev URL (derived from the stable
+          // worker name + account subdomain). It's stable across this update
+          // exactly when that first domain is unchanged — which is NOT the
+          // same as "the domain set is unchanged": adding a second custom
+          // domain leaves `url` put, while reordering changes it even though
+          // the set is equal. Compute the resulting `url` and carry it
+          // forward as a stable only when it matches the old one, so
+          // downstream resources that reference `worker.url` (e.g. a GitHub
+          // Webhook delivery URL built via `Output.interpolate`) resolve it
+          // to a concrete value during planning instead of an unresolved
+          // Output — otherwise every worker update spuriously re-updates them.
+          const newCustomDomains = normalizeDomains(news.domain);
+          const newUrl =
+            newCustomDomains.length > 0
+              ? `https://${newCustomDomains[0]}`
+              : news.url !== false
+                ? (output.domains ?? []).find((u) => u.endsWith(".workers.dev"))
+                : undefined;
+          const urlStable = newUrl !== undefined && newUrl === output.url;
           if (
             domainsChanged ||
             cronsChanged ||
             (yield* hasChanged(id, news, output))
           ) {
+            const stables: string[] = [];
+            if (oldWorkerName === workerName) {
+              stables.push("workerName");
+            }
+            if (urlStable) {
+              stables.push("url");
+            }
             return {
               action: "update",
-              stables:
-                oldWorkerName === workerName ? ["workerName"] : undefined,
+              stables: stables.length > 0 ? stables : undefined,
             };
           }
         }),

--- a/packages/alchemy/src/Test/Core.ts
+++ b/packages/alchemy/src/Test/Core.ts
@@ -207,6 +207,17 @@ export interface ScratchStack<ROut = any> {
   deploy<A, E, R>(
     effect: Effect.Effect<A, E, R>,
   ): Effect.Effect<Input.Resolve<A>, any, Exclude<R, ROut | StackServices>>;
+  /**
+   * Build a plan against the scratch's shared state WITHOUT applying it.
+   *
+   * Use this to assert on the planned action for a resource (e.g. that a
+   * downstream dependency stays `noop` when only an upstream resource
+   * changes) without mutating the cloud. Plans run against whatever state
+   * prior `deploy(...)` calls persisted.
+   */
+  plan<A, E, R>(
+    effect: Effect.Effect<A, E, R>,
+  ): Effect.Effect<Plan.Plan<A>, any, Exclude<R, ROut | StackServices>>;
   destroy(): Effect.Effect<void, any, never>;
 }
 
@@ -250,11 +261,27 @@ export const scratchStack = <ROut>(
       provideFreshArtifactStore,
     );
 
+  const buildPlan = (effect: Effect.Effect<any, any, any>) =>
+    (effect as Effect.Effect<any, any, never>).pipe(
+      makeStack({
+        name: stackName,
+        providers: options.providers,
+        state: stateLayer,
+      } as any) as any,
+      Effect.flatMap((compiled: any) =>
+        Plan.make(compiled).pipe(Effect.provide(compiled.services)),
+      ),
+      Effect.provide(Layer.succeed(Stage, stage)),
+      provideFreshArtifactStore,
+    );
+
   return {
     name: stackName,
     state: stateLayer,
     deploy: ((effect: Effect.Effect<any, any, any>) =>
       buildAndApply(effect)) as ScratchStack<ROut>["deploy"],
+    plan: ((effect: Effect.Effect<any, any, any>) =>
+      buildPlan(effect)) as ScratchStack<ROut>["plan"],
     destroy: () =>
       Plan.make({
         name: stackName,

--- a/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
@@ -2,6 +2,7 @@ import { adopt } from "@/AdoptPolicy";
 import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
 import * as Cloudflare from "@/Cloudflare/index.ts";
 import * as R2 from "@/Cloudflare/R2";
+import * as Output from "@/Output";
 import { Stack } from "@/Stack";
 import { State } from "@/State";
 import * as Test from "@/Test/Vitest";
@@ -859,5 +860,56 @@ describe.concurrent("Cloudflare.Worker", () => {
         yield* stack.destroy();
         yield* waitForWorkerToBeDeleted(worker.workerName, accountId);
       }).pipe(logLevel),
+  );
+
+  test.provider(
+    "downstream referencing worker.url is not re-updated when the worker changes",
+    (stack) =>
+      // Regression: a downstream resource that references `worker.url` as a
+      // plain prop (e.g. a GitHub Webhook delivery URL built via
+      // `Output.interpolate`) must not spuriously re-update every time the
+      // upstream worker changes. The worker's url is stable across a
+      // code/config change, so the planner must resolve `worker.url` to a
+      // concrete value (rather than an unresolved Output, which would make
+      // `havePropsChanged` short-circuit on `Output.hasOutputs` and force a
+      // phantom update) and plan the downstream as a no-op.
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        // A worker plus a notification webhook whose `url` prop points at the
+        // worker (a plain prop dependency, exactly like a GitHub webhook's
+        // delivery URL). `crons` is the only thing that varies between the
+        // deploy and the re-plan — it forces the worker to plan as an
+        // `update` while leaving its url untouched.
+        const program = (crons: string[]) =>
+          Effect.gen(function* () {
+            const worker = yield* Cloudflare.Worker("Upstream", {
+              main,
+              crons,
+              compatibility: { date: "2024-01-01" },
+            });
+            yield* Cloudflare.NotificationWebhook("Hook", {
+              url: Output.interpolate`${worker.url}`,
+            });
+          });
+
+        yield* stack.deploy(program([]));
+
+        // Re-plan with the worker changed (a new cron forces an update) but
+        // the webhook identical. The plan is never applied, so the cron is
+        // never actually deployed.
+        const plan = yield* stack.plan(program(["*/10 * * * *"]));
+
+        const actionOf = (logicalId: string) =>
+          Object.values(plan.resources).find(
+            (node) => node.resource.LogicalId === logicalId,
+          )?.action;
+
+        expect(actionOf("Upstream")).toBe("update");
+        expect(actionOf("Hook")).toBe("noop");
+
+        yield* stack.destroy();
+      }).pipe(logLevel),
+    { timeout: 180_000 },
   );
 });


### PR DESCRIPTION
A downstream resource that references `worker.url` (e.g. a `GitHub.Webhook` delivery URL built via `Output.interpolate`) spuriously re-updated on every worker deploy.

`worker.url` is `domains[0]`, which was not a stable attribute. During planning, an updating resource only carries its **stable** attributes forward, so `worker.url` resolved to an unresolved `Output` whenever the worker updated — making `havePropsChanged` short-circuit on `Output.hasOutputs(news)` and force a phantom update on the downstream.

The worker `diff` now carries `url` forward as a stable attribute, but only when it is genuinely unchanged. `url` is the first custom domain in user order, else the workers.dev URL, so it's stable iff that first domain is unchanged — not merely when the domain set is unchanged:

```ts
const newCustomDomains = normalizeDomains(news.domain);
const newUrl =
  newCustomDomains.length > 0
    ? `https://${newCustomDomains[0]}`
    : news.url !== false
      ? (output.domains ?? []).find((u) => u.endsWith(".workers.dev"))
      : undefined;
const urlStable = newUrl !== undefined && newUrl === output.url;
// ...
if (urlStable) stables.push("url");
```

- adding a second custom domain keeps `url` (the first) stable
- reordering domains changes `url` → not stable
- disabling the workers.dev subdomain drops `url` → not stable

Also exposes `ScratchStack.plan(...)` so tests can assert planned actions without applying, used by a new regression test that deploys a Worker + a `NotificationWebhook` pointing at it and asserts the webhook stays `noop` when only the worker changes.
