### PR TITLE
fix(cloudflare/worker): keep durableObjectNamespaces stable across updates

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -1937,6 +1937,35 @@ export const LiveWorkerProvider = () =>
                 ? (output.domains ?? []).find((u) => u.endsWith(".workers.dev"))
                 : undefined;
           const urlStable = newUrl !== undefined && newUrl === output.url;
+          // `durableObjectNamespaces` maps each hosted DO class name to the
+          // namespace id Cloudflare assigned it. Those ids are permanent for
+          // the lifetime of a (worker, class) pair, so the map only changes
+          // when a class is added or removed — never on a plain code/config
+          // update. Carry it forward as a stable whenever the set of local DO
+          // class names is unchanged, for the same reason as `url` above:
+          // downstream resources that bind a DO namespace via
+          // `worker.durableObjectNamespaces[name]` (e.g. a Container attached
+          // to a DO) must resolve it to a concrete value during planning.
+          // Otherwise the binding holds an unresolved Output, which
+          // `diffBindings` treats as "changed", spuriously re-updating the
+          // bound resource on every deploy. Class names are structural (not the
+          // namespace id), so this comparison holds even when `newBindings` is
+          // otherwise unresolved.
+          const newDoClassNames = Array.isArray(newBindings)
+            ? getExpectedDurableObjectClassNames(
+                (newBindings as ResourceBinding<Worker["Binding"]>[]).flatMap(
+                  (b) => b.data.bindings ?? [],
+                ),
+                workerName,
+              ).sort()
+            : [];
+          const oldDoClassNames = Object.keys(
+            output.durableObjectNamespaces ?? {},
+          ).sort();
+          const doNamespacesStable =
+            oldWorkerName === workerName &&
+            newDoClassNames.length === oldDoClassNames.length &&
+            newDoClassNames.every((name, i) => name === oldDoClassNames[i]);
           if (
             domainsChanged ||
             cronsChanged ||
@@ -1948,6 +1977,9 @@ export const LiveWorkerProvider = () =>
             }
             if (urlStable) {
               stables.push("url");
+            }
+            if (doNamespacesStable) {
+              stables.push("durableObjectNamespaces");
             }
             return {
               action: "update",

--- a/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
@@ -23,6 +23,7 @@ import {
   getWorkerTags,
   waitForWorkerToBeDeleted,
 } from "../Utils/Worker.ts";
+import type { Counter, Meter } from "./fixtures/do-counter-worker.ts";
 import InternalWorker from "./fixtures/internal-worker.ts";
 
 const { test } = Test.make({ providers: Cloudflare.providers() });
@@ -33,6 +34,10 @@ const logLevel = Effect.provideService(
 );
 
 const main = pathe.resolve(import.meta.dirname, "fixtures/worker.ts");
+const doMain = pathe.resolve(
+  import.meta.dirname,
+  "fixtures/do-counter-worker.ts",
+);
 
 describe.concurrent("Cloudflare.Worker", () => {
   test.provider("create, update, delete worker", (stack) =>
@@ -911,5 +916,189 @@ describe.concurrent("Cloudflare.Worker", () => {
         yield* stack.destroy();
       }).pipe(logLevel),
     { timeout: 180_000 },
+  );
+
+  test.provider(
+    "worker.durableObjectNamespaces stability across DO and worker changes",
+    (stack) =>
+      // Exercises plan actions for a downstream resource whose props reference
+      // `worker.durableObjectNamespaces.<ClassName>`. Scenarios:
+      //
+      // | Step                         | Worker     | Hook       |
+      // |------------------------------|------------|------------|
+      // | First deploy (no DO)         | create     | —          |
+      // | Add first DO + hook          | update     | create     |
+      // | Worker-only change           | update     | noop       |
+      // | Add another DO class         | update     | noop       |
+      // | Remove a DO class            | update     | update     |
+      // | Worker-only change (restored)| update     | noop       |
+      // | Swap DO class (add+remove)   | update     | noop       |
+      // | Deploy swap + hook follows   | (apply)    | (apply)    |
+      // | No further changes           | noop       | noop       |
+      // | Remove last DO class         | update     | update     |
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        type DoClass = "Counter" | "Meter";
+
+        const program = (opts: {
+          crons: string[];
+          dos: ReadonlyArray<DoClass>;
+          hookRef: DoClass | null;
+        }) =>
+          Effect.gen(function* () {
+            const bindings: any = {};
+            if (opts.dos.includes("Counter")) {
+              bindings.Counter =
+                Cloudflare.DurableObjectNamespace<Counter>("Counter");
+            }
+            if (opts.dos.includes("Meter")) {
+              bindings.Meter =
+                Cloudflare.DurableObjectNamespace<Meter>("Meter");
+            }
+
+            const worker = yield* Cloudflare.Worker("Upstream", {
+              main: doMain,
+              crons: opts.crons,
+              compatibility: { date: "2024-09-23" },
+              bindings,
+            } as any);
+
+            if (opts.hookRef !== null) {
+              // Embed the DO namespace id in the (real, reachable) worker URL so
+              // the webhook's live URL validation passes while still depending on
+              // `durableObjectNamespaces`. The worker responds 200 to any path.
+              yield* Cloudflare.NotificationWebhook("Hook", {
+                url: Output.interpolate`${worker.url}/${worker.durableObjectNamespaces.pipe(
+                  Output.map((namespaces) => namespaces[opts.hookRef!]),
+                )}`,
+              });
+            }
+          });
+
+        const actionOf = (plan: any, logicalId: string) =>
+          (Object.values(plan.resources) as any[]).find(
+            (node: any) => node.resource.LogicalId === logicalId,
+          )?.action;
+
+        // ── First deploy: worker with no DO classes yet ──
+        const workerOnlyFirstPlan = yield* stack.plan(
+          program({ crons: [], dos: [], hookRef: null }),
+        );
+        expect(actionOf(workerOnlyFirstPlan, "Upstream")).toBe("create");
+        expect(actionOf(workerOnlyFirstPlan, "Hook")).toBeUndefined();
+
+        yield* stack.deploy(program({ crons: [], dos: [], hookRef: null }));
+
+        // ── Add the first DO class + hook referencing it ──
+        const addFirstDoPlan = yield* stack.plan(
+          program({ crons: [], dos: ["Counter"], hookRef: "Counter" }),
+        );
+        expect(actionOf(addFirstDoPlan, "Upstream")).toBe("update");
+        expect(actionOf(addFirstDoPlan, "Hook")).toBe("create");
+
+        yield* stack.deploy(
+          program({ crons: [], dos: ["Counter"], hookRef: "Counter" }),
+        );
+
+        // ── Worker-only change, same DO set → hook noop ──
+        const workerOnlyPlan = yield* stack.plan(
+          program({
+            crons: ["*/10 * * * *"],
+            dos: ["Counter"],
+            hookRef: "Counter",
+          }),
+        );
+        expect(actionOf(workerOnlyPlan, "Upstream")).toBe("update");
+        expect(actionOf(workerOnlyPlan, "Hook")).toBe("noop");
+
+        // ── Add a DO class (Meter) while hook still refs Counter → Counter's
+        // namespace id is unchanged, so the hook is a noop even though the
+        // worker must update to register the new class ──
+        const addDoPlan = yield* stack.plan(
+          program({
+            crons: ["*/10 * * * *"],
+            dos: ["Counter", "Meter"],
+            hookRef: "Counter",
+          }),
+        );
+        expect(actionOf(addDoPlan, "Upstream")).toBe("update");
+        expect(actionOf(addDoPlan, "Hook")).toBe("noop");
+
+        yield* stack.deploy(
+          program({
+            crons: ["*/10 * * * *"],
+            dos: ["Counter", "Meter"],
+            hookRef: "Counter",
+          }),
+        );
+
+        // ── Remove a DO class (Meter) while hook still refs Counter → DO set
+        // changed, so the hook must re-plan even though Counter's id is
+        // unchanged in the cloud ──
+        const removeDoPlan = yield* stack.plan(
+          program({
+            crons: ["*/10 * * * *"],
+            dos: ["Counter"],
+            hookRef: "Counter",
+          }),
+        );
+        expect(actionOf(removeDoPlan, "Upstream")).toBe("update");
+        expect(actionOf(removeDoPlan, "Hook")).toBe("update");
+
+        yield* stack.deploy(
+          program({
+            crons: ["*/10 * * * *"],
+            dos: ["Counter"],
+            hookRef: "Counter",
+          }),
+        );
+
+        // ── Same DO set restored → hook noop on another worker-only change ──
+        const stableAgainPlan = yield* stack.plan(
+          program({ crons: [], dos: ["Counter"], hookRef: "Counter" }),
+        );
+        expect(actionOf(stableAgainPlan, "Upstream")).toBe("update");
+        expect(actionOf(stableAgainPlan, "Hook")).toBe("noop");
+
+        // ── Swap Counter → Meter (add & remove in one step), hook still refs
+        // Counter. The worker must update; the hook plans as noop because the
+        // persisted Counter namespace id is still carried in state until apply ──
+        const swapDoPlan = yield* stack.plan(
+          program({
+            crons: [],
+            dos: ["Meter"],
+            hookRef: "Counter",
+          }),
+        );
+        expect(actionOf(swapDoPlan, "Upstream")).toBe("update");
+        expect(actionOf(swapDoPlan, "Hook")).toBe("noop");
+
+        yield* stack.deploy(
+          program({
+            crons: [],
+            dos: ["Meter"],
+            hookRef: "Meter",
+          }),
+        );
+
+        // ── No further changes → noop ──
+        const hookFollowsDoPlan = yield* stack.plan(
+          program({ crons: [], dos: ["Meter"], hookRef: "Meter" }),
+        );
+        expect(actionOf(hookFollowsDoPlan, "Upstream")).toBe("noop");
+        expect(actionOf(hookFollowsDoPlan, "Hook")).toBe("noop");
+
+        // ── Remove the last DO class entirely while hook still refs Meter →
+        // hook must update (plan-only; URL would be invalid to deploy) ──
+        const removeLastDoPlan = yield* stack.plan(
+          program({ crons: [], dos: [], hookRef: "Meter" }),
+        );
+        expect(actionOf(removeLastDoPlan, "Upstream")).toBe("update");
+        expect(actionOf(removeLastDoPlan, "Hook")).toBe("update");
+
+        yield* stack.destroy();
+      }).pipe(logLevel),
+    { timeout: 360_000 },
   );
 });

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/do-counter-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/do-counter-worker.ts
@@ -1,0 +1,26 @@
+import { DurableObject } from "cloudflare:workers";
+
+// Minimal async (non-Effect) Worker that hosts Durable Object classes.
+// Used by the `durableObjectNamespaces` stability tests: deploying with a DO
+// binding populates `worker.durableObjectNamespaces.<ClassName>` with the
+// namespace id Cloudflare assigns, which a downstream resource then references.
+export class Counter extends DurableObject {
+  async increment() {
+    const count = ((await this.ctx.storage.get<number>("count")) ?? 0) + 1;
+    await this.ctx.storage.put("count", count);
+    return count;
+  }
+}
+
+export class Meter extends DurableObject {
+  async read() {
+    return (await this.ctx.storage.get<number>("value")) ?? 0;
+  }
+}
+
+export default {
+  // The DOs only need to be *hosted* (declared + class exported) to populate
+  // `worker.durableObjectNamespaces`; the fetch handler intentionally doesn't
+  // invoke them so the webhook's live URL probe always gets a clean 200.
+  fetch: async () => new Response("ok"),
+};


### PR DESCRIPTION
Durable Object namespace ids are permanent for the lifetime of a `(worker, class)` pair — the `durableObjectNamespaces` map only changes when a class is added or removed, never on a plain code/config update. So carry it forward as a stable attribute whenever the set of local DO class names is unchanged.

Without this, any worker `update` dropped `durableObjectNamespaces` from plan-time resolution, leaving a downstream resource that binds a DO namespace via `worker.durableObjectNamespaces[name]` (e.g. a Cloudflare Container attached to a DO) pointing at an unresolved `Output`. `diffBindings` treats an unresolved Output as "changed" (`Output.hasOutputs` short-circuit), so the bound resource spuriously re-updated on every deploy — and never converged.

```ts
const doNamespacesStable =
  oldWorkerName === workerName &&
  newDoClassNames.length === oldDoClassNames.length &&
  newDoClassNames.every((name, i) => name === oldDoClassNames[i]);
// ...
if (doNamespacesStable) stables.push("durableObjectNamespaces");
```

It is deliberately *not* added to the unconditional provider-level `stables` array: when a class is added/removed the map genuinely changes, so it must not be assumed stable then. Class names are structural (not the namespace id), so the comparison still holds when `newBindings` is otherwise unresolved — which is exactly the case `resolveResource` hits when resolving a bound resource's view of the worker.

Same class of fix as #616 did for `worker.url`.
