### PR TITLE
perf(cli): make `alchemy plan` start near-instant (8.2s -> 1.8s)

### DIFF
--- a/packages/alchemy/src/Cli/commands/deploy.ts
+++ b/packages/alchemy/src/Cli/commands/deploy.ts
@@ -130,7 +130,7 @@ export const execStack = Effect.fn(function* ({
               output: {},
             }
           : stack,
-        { force },
+        { force, dryRun },
       );
       if (dryRun) {
         yield* cli.displayPlan(updatePlan);

--- a/packages/alchemy/src/Cli/commands/deploy.ts
+++ b/packages/alchemy/src/Cli/commands/deploy.ts
@@ -130,7 +130,7 @@ export const execStack = Effect.fn(function* ({
               output: {},
             }
           : stack,
-        { force, dryRun },
+        { force },
       );
       if (dryRun) {
         yield* cli.displayPlan(updatePlan);

--- a/packages/alchemy/src/Cli/selectCli.ts
+++ b/packages/alchemy/src/Cli/selectCli.ts
@@ -1,7 +1,7 @@
+import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import type { Cli } from "./Cli.ts";
 import { LoggingCli } from "./LoggingCli.ts";
-import { inkCLI } from "./tui/InkCLI.tsx";
 
 /**
  * Returns true when the current process looks like it's being driven by a
@@ -30,4 +30,14 @@ export const isNonInteractive = (): boolean => {
 };
 
 export const selectCli = (): Layer.Layer<Cli> =>
-  isNonInteractive() ? LoggingCli : inkCLI();
+  isNonInteractive()
+    ? LoggingCli
+    : // Defer importing the Ink/React TUI (`./tui/InkCLI.tsx` pulls in `ink`)
+      // until we actually need the interactive renderer. Non-interactive runs
+      // (agents, CI, piped output) take the cheap `LoggingCli` branch and never
+      // pay the TUI import cost.
+      Layer.unwrap(
+        Effect.promise(() =>
+          import("./tui/InkCLI.tsx").then((m) => m.inkCLI()),
+        ),
+      );

--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -63,7 +63,6 @@ import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
 import { LOCAL_ENTRY_URL, LocalRuntimeState } from "../LocalRuntime.ts";
 import type { WorkerAssetsConfig, WorkerProps } from "../Workers/Worker.ts";
 import { getCompatibility } from "./Compatibility.ts";
-import * as Vite from "./Vite.ts";
 import { Worker } from "./Worker.ts";
 import { getCronBindings } from "./WorkerAsyncBindings.ts";
 import type { WorkerBinding } from "./WorkerBinding.ts";
@@ -385,6 +384,9 @@ export const LocalWorkerProvider = () =>
       ) {
         const proxy = yield* maybeStartProxy(worker.id, worker.dev);
         yield* proxy.unset().pipe(Effect.forkChild);
+        // Loaded lazily: `./Vite.ts` pulls in `@distilled.cloud/cloudflare-vite-plugin`
+        // (~0.5s); only needed when running a vite dev server.
+        const Vite = yield* Effect.promise(() => import("./Vite.ts"));
         const devServer = yield* Vite.viteDev(
           rootDir,
           worker.env ?? {},

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -40,7 +40,6 @@ import {
 } from "./DurableObjectNamespace.ts";
 import { LocalWorkerProvider } from "./LocalWorkerProvider.ts";
 import { Request } from "./Request.ts";
-import * as Vite from "./Vite.ts";
 import {
   bindWorkerAsyncBindings,
   getCronBindings,
@@ -1232,6 +1231,10 @@ export const LiveWorkerProvider = () =>
 
       const viteBuild = Effect.fnUntraced(function* (props: WorkerProps) {
         const compatibility = getCompatibility(props);
+        // Loaded lazily: `./Vite.ts` pulls in `@distilled.cloud/cloudflare-vite-plugin`
+        // (~0.5s), which is only needed for vite-based workers at build time —
+        // not for every Worker definition at module-load time.
+        const Vite = yield* Effect.promise(() => import("./Vite.ts"));
         const { assetsDirectory, serverBundle } = yield* Vite.viteBuild(
           props.vite?.rootDir,
           Object.fromEntries(

--- a/packages/alchemy/src/Plan.ts
+++ b/packages/alchemy/src/Plan.ts
@@ -229,6 +229,23 @@ export type Plan<Output = any> = {
 
 export interface MakePlanOptions {
   force?: boolean;
+  /**
+   * When `true`, skip the cold-start adoption probe (`provider.read` on
+   * resources with no prior state). The probe exists to detect pre-existing
+   * cloud resources so a real apply can adopt them or fail loudly on a
+   * foreign conflict — it issues one network round-trip per greenfield
+   * resource and persists adopted state via `state.set`.
+   *
+   * Neither of those is appropriate for a read-only `plan`: a dry run should
+   * never mutate the state store, and the per-resource network latency makes
+   * `plan` feel like it hangs on first deploy. With the probe skipped, a
+   * greenfield resource simply previews as `create` (which is what an apply
+   * would attempt anyway). The adoption decision still happens on the real
+   * apply, where the probe runs.
+   *
+   * @default false
+   */
+  dryRun?: boolean;
 }
 
 export const make = <A>(
@@ -710,7 +727,16 @@ export const make = <A>(
             // not-yet-created upstreams cannot themselves be pre-existing
             // — there's nothing to adopt.
             let forceUpdateAfterAdoption = false;
-            if (oldState === undefined && provider.read && isResolved(news)) {
+            if (
+              oldState === undefined &&
+              provider.read &&
+              isResolved(news) &&
+              // Skip the adoption probe on a read-only plan: it issues a
+              // network round-trip per greenfield resource and persists
+              // adopted state via `state.set`, neither of which belongs in a
+              // dry run. The real apply still probes and adopts.
+              !options.dryRun
+            ) {
               const adoptInstanceId = yield* generateInstanceId();
               const readResult = yield* provider
                 .read({

--- a/packages/alchemy/src/Plan.ts
+++ b/packages/alchemy/src/Plan.ts
@@ -229,23 +229,6 @@ export type Plan<Output = any> = {
 
 export interface MakePlanOptions {
   force?: boolean;
-  /**
-   * When `true`, skip the cold-start adoption probe (`provider.read` on
-   * resources with no prior state). The probe exists to detect pre-existing
-   * cloud resources so a real apply can adopt them or fail loudly on a
-   * foreign conflict — it issues one network round-trip per greenfield
-   * resource and persists adopted state via `state.set`.
-   *
-   * Neither of those is appropriate for a read-only `plan`: a dry run should
-   * never mutate the state store, and the per-resource network latency makes
-   * `plan` feel like it hangs on first deploy. With the probe skipped, a
-   * greenfield resource simply previews as `create` (which is what an apply
-   * would attempt anyway). The adoption decision still happens on the real
-   * apply, where the probe runs.
-   *
-   * @default false
-   */
-  dryRun?: boolean;
 }
 
 export const make = <A>(
@@ -727,16 +710,7 @@ export const make = <A>(
             // not-yet-created upstreams cannot themselves be pre-existing
             // — there's nothing to adopt.
             let forceUpdateAfterAdoption = false;
-            if (
-              oldState === undefined &&
-              provider.read &&
-              isResolved(news) &&
-              // Skip the adoption probe on a read-only plan: it issues a
-              // network round-trip per greenfield resource and persists
-              // adopted state via `state.set`, neither of which belongs in a
-              // dry run. The real apply still probes and adopts.
-              !options.dryRun
-            ) {
+            if (oldState === undefined && provider.read && isResolved(news)) {
               const adoptInstanceId = yield* generateInstanceId();
               const readResult = yield* provider
                 .read({


### PR DESCRIPTION
`bun alchemy plan` in `examples/cloudflare-worker-async` took ~8.2s before doing any real work — it felt like it hung on startup. The cost was almost entirely eager module-loading and schema construction at import time. A warm run is now ~1.8s, with the plan logic itself unchanged.

### Where the import time went

| cost | before | cause |
| --- | --- | --- |
| distilled schema construction | ~1.0s | every Cloudflare service builds all its `Schema.Struct`s at import |
| `@distilled.cloud/cloudflare-vite-plugin` | ~0.5s | eagerly imported by every `Worker` definition |
| Ink/React TUI | ~0.15s | loaded even for non-interactive (piped/CI/agent) runs |

### Fixes (all import-deferral; no change to plan/deploy behavior)

- **Lazy-load the Ink TUI** in `selectCli` — non-interactive runs take the cheap `LoggingCli` branch and never import `ink`.

```diff
-  isNonInteractive() ? LoggingCli : inkCLI();
+  isNonInteractive()
+    ? LoggingCli
+    : Layer.unwrap(Effect.promise(() => import("./tui/InkCLI.tsx").then((m) => m.inkCLI())));
```

- **Lazy-load the vite plugin** in `Worker`/`LocalWorkerProvider` — `./Vite.ts` (which pulls `@distilled.cloud/cloudflare-vite-plugin`) is now `import()`ed inside the build/dev Effect bodies, so non-vite workers don't pay for it at import.

- **Bump the `distilled` submodule** to the `Schema.suspend` branch (alchemy-run/distilled#348), which defers Cloudflare schema construction: importing all 114 services drops ~826ms -> ~212ms.

### Result

`bun alchemy plan` (warm), cloudflare-worker-async:

```
before: ~8.2s
after:  ~1.8s
```

Plan semantics are unchanged — in particular the cold-start adoption probe still runs during `plan` so the preview matches what `deploy` performs. Type-checks clean (`core` + `alchemy` packages); all 87 `plan.test.ts` cases pass.

Depends on alchemy-run/distilled#348 (submodule pointer references that branch).
