### PR TITLE
docs(github): add Repository examples for templates, rename, archive, secrets

### DIFF
--- a/packages/alchemy/src/GitHub/Repository.ts
+++ b/packages/alchemy/src/GitHub/Repository.ts
@@ -235,6 +235,20 @@ export interface Repository extends Resource<
  * });
  * ```
  *
+ * @example Initialize from Templates
+ * The `autoInit`, `gitignoreTemplate`, and `licenseTemplate` props seed the
+ * first commit. They are only honored at create time — changing them on a
+ * later deploy has no effect on an existing repository.
+ * ```typescript
+ * const repo = yield* GitHub.Repository("service", {
+ *   owner: "my-org",
+ *   name: "service",
+ *   autoInit: true,
+ *   gitignoreTemplate: "Node",
+ *   licenseTemplate: "mit",
+ * });
+ * ```
+ *
  * @section Topics and Merge Configuration
  * @example Repository with Topics and Merge Policy
  * ```typescript
@@ -246,6 +260,37 @@ export interface Repository extends Resource<
  *   allowRebaseMerge: false,
  *   allowSquashMerge: true,
  *   allowAutoMerge: true,
+ * });
+ * ```
+ *
+ * @section Renaming a Repository
+ * @example Rename in Place
+ * Keep the same logical ID and change `name` to rename the live repository
+ * instead of replacing it — the repository's history, issues, and pull
+ * requests are preserved. Only changing `owner` triggers a replacement.
+ * ```typescript
+ * // First deploy creates "api".
+ * const repo = yield* GitHub.Repository("api", {
+ *   owner: "my-org",
+ *   name: "api",
+ * });
+ *
+ * // A later deploy with the SAME logical ID ("api") renames it to "gateway".
+ * const repo = yield* GitHub.Repository("api", {
+ *   owner: "my-org",
+ *   name: "gateway",
+ * });
+ * ```
+ *
+ * @section Archiving a Repository
+ * @example Make a Repository Read-Only
+ * Archiving sets the repository to read-only. Set `archived` back to `false`
+ * on a later deploy to un-archive it.
+ * ```typescript
+ * yield* GitHub.Repository("legacy", {
+ *   owner: "my-org",
+ *   name: "legacy-service",
+ *   archived: true,
  * });
  * ```
  *
@@ -266,6 +311,24 @@ export interface Repository extends Resource<
  *   repository: repo.name!,
  *   name: "AWS_REGION",
  *   value: "us-east-1",
+ * });
+ * ```
+ *
+ * @example Store a Secret in the Repository
+ * ```typescript
+ * import * as Redacted from "effect/Redacted";
+ *
+ * const repo = yield* GitHub.Repository("api", {
+ *   owner: "my-org",
+ *   name: "api",
+ *   autoInit: true,
+ * });
+ *
+ * yield* GitHub.Secret("deploy-token", {
+ *   owner: "my-org",
+ *   repository: repo.name!,
+ *   name: "DEPLOY_TOKEN",
+ *   value: Redacted.make("my-secret-value"),
  * });
  * ```
  *


### PR DESCRIPTION
I don't feel strongly about adding this, but thought a few extra examples could be helpful. Looks like y'all haven't deployed the docs yet though so this doesn't show up on the live site anyway. Feel free to close if you think it's not useful or to edit it as you see fit. 

---

Add four new JSDoc examples to the GitHub `Repository` resource, documenting behavior the provider already implements but didn't previously show. Edits are on the source `.ts` (the generated provider markdown is gitignored and overwritten by `bun generate:api-reference`).

- **Initialize from Templates** — `autoInit` / `gitignoreTemplate` / `licenseTemplate` (create-time only)
- **Renaming a Repository** — same logical ID + changed `name` renames in place; only `owner` triggers replacement
- **Archiving a Repository** — `archived: true` for read-only, reversible
- **Store a Secret in the Repository** — `GitHub.Secret` wiring with `Redacted.make`

```typescript
// Rename in place: same logical ID ("api"), new name → renames, preserving history
const repo = yield* GitHub.Repository("api", {
  owner: "my-org",
  name: "gateway",
});
```
