### PR TITLE
fix(core): make diff.stables override provider.stables

### DIFF
--- a/packages/alchemy/src/Cloudflare/R2/R2Bucket.ts
+++ b/packages/alchemy/src/Cloudflare/R2/R2Bucket.ts
@@ -627,7 +627,11 @@ export const R2BucketProvider = () =>
           if (oldStorageClass !== (news.storageClass ?? "Standard")) {
             return {
               action: "update",
-              stables: oldName === name ? ["bucketName"] : undefined,
+              // `accountId` is always stable across an update (a name/account
+              // change is a `replace`); keep it now that `diff.stables`
+              // overrides `provider.stables` rather than merging with it.
+              stables:
+                oldName === name ? ["bucketName", "accountId"] : ["accountId"],
             } as const;
           }
           if (!deepEqual(olds.domains, news.domains)) {

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -1974,7 +1974,10 @@ export const LiveWorkerProvider = () =>
             cronsChanged ||
             (yield* hasChanged(id, news, output))
           ) {
-            const stables: string[] = [];
+            // `workerId` is always stable across an update; seed it so it
+            // survives now that `diff.stables` overrides `provider.stables`
+            // rather than being merged with it.
+            const stables: string[] = ["workerId"];
             if (oldWorkerName === workerName) {
               stables.push("workerName");
             }

--- a/packages/alchemy/src/Plan.ts
+++ b/packages/alchemy/src/Plan.ts
@@ -332,10 +332,11 @@ export const make = <A>(
                     .pipe(providePlanScope(resource.FQN, oldState.instanceId))
                 : Effect.succeed(undefined);
 
-              const stables: string[] = [
-                ...(provider.stables ?? []),
-                ...(diff?.stables ?? []),
-              ];
+              // A present `diff.stables` is authoritative for this update and
+              // overrides `provider.stables`. We only fall back to the
+              // provider-level "always stable" list when the diff does not
+              // return one (e.g. no diff fn, or a diff that omits `stables`).
+              const stables: string[] = diff?.stables ?? provider.stables ?? [];
 
               const withStables = (output: any) =>
                 stables.length > 0

--- a/packages/alchemy/test/plan.test.ts
+++ b/packages/alchemy/test/plan.test.ts
@@ -31,6 +31,7 @@ import {
   Function,
   KindStablesResource,
   NoPrecreateBindingTarget,
+  OverrideStablesResource,
   Queue,
   TestLayers,
   TestResource,
@@ -2232,6 +2233,100 @@ describe("stable properties should not cause downstream changes", () => {
         ),
       ),
     }),
+  );
+});
+
+describe("diff.stables overrides provider.stables", () => {
+  // `A` is an OverrideStablesResource: provider `stables` is
+  // ["providerStable", "sharedStable"], but its `diff` returns
+  // ["diffStable", "sharedStable"] on a `string` change. The two lists
+  // disagree, so this exercises the override (not merge) semantics.
+  const seedUpstreamAndDownstream = (downstreamOldString: string) =>
+    seed({
+      A: {
+        instanceId,
+        providerVersion: 0,
+        logicalId: "A",
+        fqn: "A",
+        namespace: undefined,
+        resourceType: "Test.OverrideStablesResource",
+        status: "created",
+        props: { string: "old" },
+        attr: {
+          string: "old",
+          providerStable: "provider-A",
+          diffStable: "diff-A",
+          sharedStable: "shared-A",
+        },
+        downstream: [],
+        bindings: [],
+      },
+      B: {
+        instanceId,
+        providerVersion: 0,
+        logicalId: "B",
+        fqn: "B",
+        namespace: undefined,
+        resourceType: "Test.TestResource",
+        status: "created",
+        props: { string: downstreamOldString },
+        attr: {
+          string: downstreamOldString,
+          stableString: "B",
+          stableArray: ["B"],
+        },
+        downstream: [],
+        bindings: [],
+      },
+    });
+
+  const subtest = (
+    description: string,
+    accessor: (A: OverrideStablesResource) => any,
+    downstreamOldString: string,
+    expectedBAction: "update" | "noop",
+  ) =>
+    test(
+      description,
+      Effect.gen(function* () {
+        yield* seedUpstreamAndDownstream(downstreamOldString);
+        const plan = yield* Effect.gen(function* () {
+          const A = yield* OverrideStablesResource("A", { string: "new" });
+          yield* TestResource("B", { string: accessor(A) });
+        }).pipe(makePlan);
+
+        // A always updates: its `string` prop changed.
+        expect(plan.resources.A!.action).toBe("update");
+        expect(plan.resources.B!.action).toBe(expectedBAction);
+      }),
+    );
+
+  // `providerStable` is in `provider.stables` but OMITTED from the
+  // `diff.stables` returned for this update. Because `diff.stables` now
+  // overrides `provider.stables`, it is treated as changed and the
+  // downstream re-plans (update). Under the old merge it would wrongly
+  // stay stable and the downstream would no-op.
+  subtest(
+    "provider-only stable omitted by diff is treated as changed downstream",
+    (A) => A.providerStable,
+    "provider-A",
+    "update",
+  );
+
+  // `diffStable` is only in `diff.stables` -> stays stable -> downstream no-op.
+  subtest(
+    "diff-only stable keeps downstream stable",
+    (A) => A.diffStable,
+    "diff-A",
+    "noop",
+  );
+
+  // `sharedStable` is in both lists -> stays stable -> downstream no-op.
+  subtest(
+    "shared stable keeps downstream stable",
+    (A) => A.sharedStable,
+    "shared-A",
+    "noop",
   );
 });
 

--- a/packages/alchemy/test/test.resources.ts
+++ b/packages/alchemy/test/test.resources.ts
@@ -598,6 +598,62 @@ export const kindStablesResourceProvider = () =>
     delete: Effect.fn(function* () {}),
   });
 
+// OverrideStablesResource — declares BOTH a provider-level `stables` list AND
+// a `diff` that returns its own `stables` list that DISAGREES with it. Used to
+// assert that a present `diff.stables` OVERRIDES `provider.stables` during plan
+// (rather than being merged with it):
+//   - `providerStable` is only in `provider.stables` (omitted by `diff.stables`)
+//   - `diffStable`     is only in `diff.stables`     (omitted by `provider.stables`)
+//   - `sharedStable`   is in both
+// Under override semantics, on a `string` change `providerStable` must be
+// treated as CHANGED (downstream re-plans) while `diffStable`/`sharedStable`
+// stay stable. Under the old merge, `providerStable` would wrongly stay stable.
+
+export type OverrideStablesResourceProps = {
+  string?: string;
+};
+
+export interface OverrideStablesResource extends Resource<
+  "Test.OverrideStablesResource",
+  OverrideStablesResourceProps,
+  {
+    string: string;
+    providerStable: string;
+    diffStable: string;
+    sharedStable: string;
+  }
+> {}
+
+export const OverrideStablesResource = Resource<OverrideStablesResource>(
+  "Test.OverrideStablesResource",
+);
+
+export const overrideStablesResourceProvider = () =>
+  Provider.succeed(OverrideStablesResource, {
+    stables: ["providerStable", "sharedStable"],
+    diff: Effect.fn(function* ({ news = {}, olds = {} }) {
+      if (!isResolved(news)) return undefined;
+      const n = news as OverrideStablesResourceProps;
+      const o = olds as OverrideStablesResourceProps;
+      if (n.string !== o.string) {
+        return {
+          action: "update",
+          stables: ["diffStable", "sharedStable"],
+        } as const;
+      }
+      return undefined;
+    }),
+    reconcile: Effect.fn(function* ({ id, news = {} }) {
+      return {
+        string: news.string ?? id,
+        providerStable: `provider-${id}`,
+        diffStable: `diff-${id}`,
+        sharedStable: `shared-${id}`,
+      };
+    }),
+    delete: Effect.fn(function* () {}),
+  });
+
 export type PhasedTargetProps = {
   desired: string;
   replaceKey?: string;
@@ -788,6 +844,7 @@ export const TestLayers = () =>
     testResourceProvider(),
     staticStablesResourceProvider(),
     kindStablesResourceProvider(),
+    overrideStablesResourceProvider(),
     phasedTargetProvider(),
     noPrecreateBindingTargetProvider(),
     durationResourceProvider(),


### PR DESCRIPTION
A present `diff.stables` (an `UpdateDiff`'s per-update list) is now authoritative and overrides `provider.stables`. Previously the two were concatenated, so a `diff` could never remove a provider-declared stable for a given update.

```diff
- const stables: string[] = [
-   ...(provider.stables ?? []),
-   ...(diff?.stables ?? []),
- ];
+ const stables: string[] = diff?.stables ?? provider.stables ?? [];
```

`provider.stables` remains the fallback when a diff omits `stables` (no diff fn, or a diff that returns no `stables`).

### Provider follow-ups

`Worker` and `R2Bucket` leaned on the old merge to inject an always-stable prop their `diff` omitted, so they now seed it into the diff result:

- `Cloudflare/Workers/Worker.ts`: seed the update branch with `["workerId"]`.
- `Cloudflare/R2/R2Bucket.ts`: include `accountId` in the storage-class update branch.

`EC2/Instance`, `LaunchTemplate`, `AutoScalingGroup`, and `ScalingPolicy` already return a `diff.stables` identical to their `provider.stables`, so they are unaffected.

### Tests

A new `OverrideStablesResource` test fixture (provider `["providerStable", "sharedStable"]` vs diff `["diffStable", "sharedStable"]`) drives a `plan.test.ts` block proving override semantics:

- `providerStable` (provider-only, omitted by diff) → downstream re-plans (`update`) — the regression guard; the old merge kept it `noop`.
- `diffStable` / `sharedStable` → downstream stays `noop`.
