### PR TITLE
fix(bundle): avoid watching node_modules in alchemy dev

### DIFF
--- a/packages/alchemy/src/Bundle/Bundle.ts
+++ b/packages/alchemy/src/Bundle/Bundle.ts
@@ -161,6 +161,16 @@ export const watch = (
               },
             },
           ],
+          watch: {
+            // Watching the full module graph of an Effect worker (all of
+            // `effect`, `alchemy`, `@distilled.cloud/*`) registers thousands
+            // of OS watch handles *per worker*; with several Effect workers
+            // this exhausts the process fd table and the next `posix_spawn`
+            // (workerd / docker) fails with `spawn EBADF`. Workspace packages
+            // resolve to their real source paths (outside `node_modules`), so
+            // they stay watched and local HMR is unaffected.
+            exclude: ["**/node_modules/**"],
+          },
           output: outputOptions,
         });
         watcher.on("event", (event) => {


### PR DESCRIPTION
When we run `Bundle.watch`, Rolldown defaults to watching the entire module graph. This is particularly problematic for setups with multiple Effect-based workers: between `effect`, `alchemy`, and `@distilled.cloud/*`, this can result in thousands of OS watch handles being registered *per worker*.

`workerd` uses file descriptors to pass along configuration, so when the process fd table is exhausted, this causes either `EBADF` or more frustratingly anonymous errors (e.g. `SystemError` with no message) depending on your runtime. Either way, it bricks setups with multiple Effect workers.

To fix this, I added `exclude: ["**/node_modules/**"]` to Rolldown's watch configuration. Note that Rolldown resolves workspace packages to their real source paths before applying this pattern, so HMR will continue to work in monorepos.