### PR TITLE
fix(cloudflare): malformed request promoting queue consumer from dev

### DIFF
--- a/packages/alchemy/src/Cloudflare/Queue/QueueConsumer.ts
+++ b/packages/alchemy/src/Cloudflare/Queue/QueueConsumer.ts
@@ -236,7 +236,9 @@ export const QueueConsumerProviderLive = () =>
     reconcile: Effect.fn(function* ({ news, output }) {
       const { accountId } = yield* yield* CloudflareEnvironment;
       const acct = output?.accountId ?? accountId;
-      const queueId = output?.queueId ?? (news.queueId as unknown as string);
+      // Only use `output.queueId` if it's a live ID (i.e. no `dev:` prefix).
+      // Otherwise, the lookup will fail because the request is malformed.
+      const queueId = isLiveId(output?.queueId) ? output.queueId : news.queueId;
 
       // Observe — prefer the cached consumerId, then fall back to
       // listConsumers (paginated) to recover from out-of-band

--- a/packages/alchemy/test/Cloudflare/Queue/QueueConsumer.test.ts
+++ b/packages/alchemy/test/Cloudflare/Queue/QueueConsumer.test.ts
@@ -498,11 +498,12 @@ test.provider("promotes a dev consumer to a live consumer on deploy", (stack) =>
     expect(isLiveId(initial.consumer.consumerId)).toBe(true);
 
     // Rewrite the persisted consumerId back to a dev id, simulating a
-    // consumer that was minted in `alchemy dev`. The queueId stays live.
+    // consumer that was minted in `alchemy dev`.
+    const devQueueId = generateLocalId();
     const devConsumerId = generateLocalId();
     yield* Effect.gen(function* () {
       const state = yield* yield* State;
-      const current = (yield* state.get({
+      const currentConsumer = (yield* state.get({
         stack: stack.name,
         stage: "test",
         fqn: "Consumer",
@@ -512,8 +513,12 @@ test.provider("promotes a dev consumer to a live consumer on deploy", (stack) =>
         stage: "test",
         fqn: "Consumer",
         value: {
-          ...current,
-          attr: { ...current.attr, consumerId: devConsumerId },
+          ...currentConsumer,
+          attr: {
+            ...currentConsumer.attr,
+            queueId: devQueueId,
+            consumerId: devConsumerId,
+          },
         },
       });
     });
@@ -522,8 +527,10 @@ test.provider("promotes a dev consumer to a live consumer on deploy", (stack) =>
 
     // The dev id was promoted back to the real, live consumer id.
     expect(isLiveId(promoted.consumer.consumerId)).toBe(true);
+    expect(isLiveId(promoted.queue.queueId)).toBe(true);
     expect(promoted.consumer.consumerId).not.toEqual(devConsumerId);
     expect(promoted.consumer.consumerId).toEqual(initial.consumer.consumerId);
+    expect(promoted.queue.queueId).toEqual(initial.queue.queueId);
 
     const live = yield* queues.getConsumer({
       accountId,


### PR DESCRIPTION
When a queue consumer is first provisioned in dev mode and is then promoted to live, the provider detects the `dev:` prefix in the `consumerId` correctly to know that the live resource doesn't exist yet. However, the same detection is not applied to the `queueId`, so when we try to look up the consumer based on the `queueId`, the request fails because we're looking it up with the `dev:` ID, which isn't valid in CF.

We have a test for this dev-to-live flow, but it didn't modify the `queueId` correctly - only the `consumerId`. So I fixed that here to catch it.