### PR TITLE
fix(cloudflare): add Workers Observability write OAuth scope

### DIFF
--- a/packages/alchemy/src/Cloudflare/Auth/AuthProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Auth/AuthProvider.ts
@@ -664,6 +664,8 @@ export const ALL_SCOPES = {
     "See and change Cloudflare Workers KV Storage data such as keys and namespaces",
   "workers_observability:read":
     "Grants read access to Cloudflare Workers Observability",
+  "workers_observability:write":
+    "Grants read and write access to Cloudflare Workers Observability",
   "workers_observability_telemetry:write":
     "Grants write access to Cloudflare Workers Observability Telemetry API",
   "workers_routes:write":
@@ -694,6 +696,7 @@ export const DEFAULT_SCOPES = [
   "vectorize:write",
   "workers_kv:write",
   "workers_observability:read",
+  "workers_observability:write",
   "workers_observability_telemetry:write",
   "workers_routes:write",
   "workers_scripts:write",


### PR DESCRIPTION
Add the missing `workers_observability:write` Cloudflare OAuth scope.

`Cloudflare.Workers.ObservabilityDestination` manages account-level Workers Observability destinations, which requires write access to Workers Observability. The OAuth scope catalog currently includes read access and telemetry write access, but not destination-management write access.

This adds `workers_observability:write` to `ALL_SCOPES` and requests it in `DEFAULT_SCOPES`.

Fixes #659.

### Tests

- `bun run format:check`
