### PR TITLE
feat(aws/lambda): support AWS Lambda function architecture

### DIFF
--- a/packages/alchemy/src/AWS/Lambda/Function.ts
+++ b/packages/alchemy/src/AWS/Lambda/Function.ts
@@ -65,6 +65,8 @@ export interface FunctionBuildOptions {
   readonly output?: Partial<rolldown.OutputOptions>;
 }
 
+export type FunctionArchitecture = "x86_64" | "arm64";
+
 export interface FunctionUrlConfig {
   /**
    * Authentication type for the Lambda function URL.
@@ -103,6 +105,12 @@ export interface FunctionProps extends PlatformProps {
   functionName?: string;
   // TODO(sam): use a Layer instead so we can manage Effect platform?
   runtime?: "nodejs22.x" | "nodejs24.x";
+  /**
+   * Instruction set architecture for the Lambda function.
+   *
+   * @default "x86_64"
+   */
+  architecture?: FunctionArchitecture;
   build?: FunctionBuildOptions;
   uploadSourceMap?: boolean;
   env?: Record<string, any>;
@@ -240,6 +248,14 @@ const normalizeFunctionUrl = (
  * const func = yield* AWS.Lambda.Function("ApiFunction", {
  *   main: "./src/handler.ts",
  *   url: true,
+ * });
+ * ```
+ *
+ * @example Function using ARM64
+ * ```typescript
+ * const func = yield* AWS.Lambda.Function("ArmFunction", {
+ *   main: "./src/handler.ts",
+ *   architecture: "arm64",
  * });
  * ```
  *
@@ -1019,6 +1035,7 @@ export default await Effect.runPromise(handlerEffect)
           Role: roleArn,
           Code: codeLocation,
           Runtime: news.runtime ?? "nodejs22.x",
+          Architectures: [news.architecture ?? "x86_64"],
           Environment: runtimeEnv
             ? {
                 Variables: {
@@ -1316,6 +1333,11 @@ export default await Effect.runPromise(handlerEffect)
           }
           if (
             toTimeoutSeconds(olds.timeout) !== toTimeoutSeconds(news.timeout)
+          ) {
+            return { action: "update" };
+          }
+          if (
+            (olds.architecture ?? "x86_64") !== (news.architecture ?? "x86_64")
           ) {
             return { action: "update" };
           }

--- a/packages/alchemy/test/AWS/Lambda/Function.test.ts
+++ b/packages/alchemy/test/AWS/Lambda/Function.test.ts
@@ -110,6 +110,42 @@ test.provider(
 );
 
 test.provider(
+  "applies and updates the Lambda architecture",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const initial = yield* stack.deploy(
+        AWS.Lambda.Function<{}>()("ArchitectureFn", {
+          main: timeoutHandlerPath,
+          handler: "handler",
+          isExternal: true,
+          url: false,
+          architecture: "arm64",
+        }),
+      );
+
+      yield* waitForArchitecture(initial.functionName, "arm64");
+
+      const updated = yield* stack.deploy(
+        AWS.Lambda.Function<{}>()("ArchitectureFn", {
+          main: timeoutHandlerPath,
+          handler: "handler",
+          isExternal: true,
+          url: false,
+        }),
+      );
+
+      expect(updated.functionName).toBe(initial.functionName);
+      yield* waitForArchitecture(updated.functionName, "x86_64");
+    }).pipe(
+      Effect.tap(() => stack.destroy()),
+      Effect.onError(() => stack.destroy().pipe(Effect.ignore)),
+    ),
+  { timeout: 360_000 },
+);
+
+test.provider(
   "applies, updates, and removes reserved concurrency",
   (stack) =>
     Effect.gen(function* () {
@@ -379,6 +415,24 @@ const waitForReservedConcurrency = Effect.fn(function* (
     Effect.filterOrFail(
       (actual) => actual === expected,
       () => new Error("Reserved concurrency update has not propagated yet"),
+    ),
+    Effect.retry({
+      schedule: Schedule.exponential(500).pipe(
+        Schedule.both(Schedule.recurs(10)),
+      ),
+    }),
+  );
+});
+
+const waitForArchitecture = Effect.fn(function* (
+  functionName: string,
+  expected: AWS.Lambda.FunctionArchitecture,
+) {
+  return yield* Lambda.getFunction({ FunctionName: functionName }).pipe(
+    Effect.map((result) => result.Configuration?.Architectures),
+    Effect.filterOrFail(
+      (architectures) => architectures?.[0] === expected,
+      () => new Error("Lambda architecture update has not propagated yet"),
     ),
     Effect.retry({
       schedule: Schedule.exponential(500).pipe(


### PR DESCRIPTION
## Summary

- add a typed `architecture` property to `AWS.Lambda.Function`
- default functions to `x86_64` and pass the selected architecture to Lambda create/code-update operations
- detect architecture changes during planning so existing functions update in place
- document ARM64 usage and add lifecycle coverage for switching from `arm64` back to the default architecture

## Why

Lambda supports both `x86_64` and `arm64`, but Alchemy did not expose the architecture on `FunctionProps`. Users can now select Graviton-backed Lambda functions while retaining the existing x86 default.

## Validation

- `bun oxfmt --check packages/alchemy/src/AWS/Lambda/Function.ts packages/alchemy/test/AWS/Lambda/Function.test.ts`
- `bun oxlint packages/alchemy/src/AWS/Lambda/Function.ts packages/alchemy/test/AWS/Lambda/Function.test.ts`
- `bun tsgo -b packages/alchemy/tsconfig.json --verbose`
- `bun tsgo -b packages/alchemy/tsconfig.test.json --verbose`
- `bun docs:gen`

The focused live AWS lifecycle test was not run because the local testing profile requires interactive AWS authentication.
