### PR TITLE
fix(auth): bail when configuring a missing profile non-interactively

### DIFF
--- a/packages/alchemy/src/Auth/Lock.ts
+++ b/packages/alchemy/src/Auth/Lock.ts
@@ -4,8 +4,6 @@ import * as fs from "node:fs/promises";
 import * as path from "pathe";
 import { rootDir } from "./Profile.ts";
 
-const lockDir = path.join(rootDir, "lock");
-
 /**
  * Serialise execution of `effect` so no two callers ever run inside the
  * critical section concurrently for the same `key`, both within this
@@ -20,6 +18,10 @@ export const withLock = <A, E, R>(
   key: string,
   effect: Effect.Effect<A, E, R>,
 ): Effect.Effect<A, E, R> => {
+  // Computed lazily (not at module-eval time) so that the
+  // `Profile -> AuthProvider -> Lock -> Profile` import cycle never reads
+  // `rootDir` before `Profile.ts` has finished initialising it.
+  const lockDir = path.join(rootDir, "lock");
   const lockPath = path.join(lockDir, `${key}.lock`);
   return Effect.acquireUseRelease(
     Effect.promise(async () => {

--- a/packages/alchemy/src/Auth/Profile.ts
+++ b/packages/alchemy/src/Auth/Profile.ts
@@ -7,11 +7,9 @@ import * as Layer from "effect/Layer";
 import type { PlatformError } from "effect/PlatformError";
 import os from "node:os";
 import path from "pathe";
-import type {
-  AuthError,
-  AuthProvider,
-  ConfigureContext,
-} from "./AuthProvider.ts";
+import { isNonInteractive } from "../Util/interactive.ts";
+import { AuthError } from "./AuthProvider.ts";
+import type { AuthProvider, ConfigureContext } from "./AuthProvider.ts";
 
 export const rootDir = path.join(os.homedir(), ".alchemy");
 export const configFilePath = path.join(rootDir, "profiles.json");
@@ -161,13 +159,37 @@ export const ProfileLive = Layer.effect(
       profileName: string,
       ctx: ConfigureContext,
     ) =>
-      Effect.flatMap(getProfile(profileName), (existing) =>
-        existing?.[auth.name]
-          ? Effect.succeed(existing[auth.name] as Config)
-          : Effect.tap(auth.configure(profileName, ctx), (config) =>
-              setProfile(profileName, { ...existing, [auth.name]: config }),
-            ),
-      );
+      Effect.flatMap(getProfile(profileName), (existing) => {
+        const stored = existing?.[auth.name];
+        if (stored) {
+          return Effect.succeed(stored as Config);
+        }
+        // No credentials are configured for this provider+profile. Driving
+        // `auth.configure` requires an interactive terminal (clack prompts,
+        // browser-based OAuth, ...). In a non-interactive, non-CI context
+        // (e.g. a `vitest` run or piped stdout) there is no TTY to drive
+        // those prompts, so bail *before* calling `auth.configure`.
+        //
+        // This matters beyond just avoiding a hang: `configure` is a locked
+        // method, so entering it acquires a cross-process auth lockfile. We
+        // must avoid creating that lock when we can't actually configure —
+        // for OAuth providers a refresh token is typically single-use, so a
+        // stray lock left by a doomed configure can wedge concurrent refreshes.
+        if (!ctx.ci && isNonInteractive()) {
+          return Effect.fail(
+            new AuthError({
+              message:
+                `No credentials configured for '${auth.name}' in profile '${profileName}', ` +
+                `and this process is non-interactive so it can't be configured interactively. ` +
+                `Run \`alchemy login --profile ${profileName}\` to configure it, ` +
+                `or set CI=1 to use environment-variable credentials.`,
+            }),
+          );
+        }
+        return Effect.tap(auth.configure(profileName, ctx), (config) =>
+          setProfile(profileName, { ...existing, [auth.name]: config }),
+        );
+      });
 
     return {
       readConfig,

--- a/packages/alchemy/src/Cli/selectCli.ts
+++ b/packages/alchemy/src/Cli/selectCli.ts
@@ -1,33 +1,10 @@
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import { isNonInteractive } from "../Util/interactive.ts";
 import type { Cli } from "./Cli.ts";
 import { LoggingCli } from "./LoggingCli.ts";
 
-/**
- * Returns true when the current process looks like it's being driven by a
- * coding agent, CI runner, or anything else that won't render an interactive
- * TUI well. The Ink renderer repaints the screen on every event, which floods
- * agent transcripts with redundant frames; LoggingCli emits one line per
- * status change instead.
- */
-export const isNonInteractive = (): boolean => {
-  const env = process.env;
-  if (env.ALCHEMY_PLAIN === "1" || env.ALCHEMY_NO_TUI === "1") return true;
-  if (env.ALCHEMY_TUI === "1") return false;
-  if (!process.stdout.isTTY) return true;
-  if (env.CI) return true;
-  // Known coding-agent env vars. These are best-effort — the isTTY check
-  // above already catches most cases since agents typically pipe stdout.
-  if (
-    env.CLAUDECODE ||
-    env.CLAUDE_CODE_ENTRYPOINT ||
-    env.CURSOR_AGENT ||
-    env.AIDER_MODEL ||
-    env.CODEX_CLI
-  )
-    return true;
-  return false;
-};
+export { isNonInteractive } from "../Util/interactive.ts";
 
 export const selectCli = (): Layer.Layer<Cli> =>
   isNonInteractive()

--- a/packages/alchemy/src/Util/interactive.ts
+++ b/packages/alchemy/src/Util/interactive.ts
@@ -1,0 +1,32 @@
+/**
+ * Returns true when the current process looks like it's being driven by a
+ * coding agent, CI runner, test runner, or anything else that won't render an
+ * interactive TUI / prompt well.
+ *
+ * Two callers rely on this:
+ *  - `Cli/selectCli.ts` uses it to pick `LoggingCli` over the Ink TUI.
+ *  - `Auth/Profile.ts` uses it to refuse to launch an interactive credential
+ *    configure flow (and thus avoid acquiring an auth lockfile) when there's
+ *    no TTY to drive the prompts.
+ *
+ * Kept in `Util` (rather than `Cli`) so `Auth` can depend on it without
+ * pulling in the CLI layer.
+ */
+export const isNonInteractive = (): boolean => {
+  const env = process.env;
+  if (env.ALCHEMY_PLAIN === "1" || env.ALCHEMY_NO_TUI === "1") return true;
+  if (env.ALCHEMY_TUI === "1") return false;
+  if (!process.stdout.isTTY) return true;
+  if (env.CI) return true;
+  // Known coding-agent env vars. These are best-effort — the isTTY check
+  // above already catches most cases since agents typically pipe stdout.
+  if (
+    env.CLAUDECODE ||
+    env.CLAUDE_CODE_ENTRYPOINT ||
+    env.CURSOR_AGENT ||
+    env.AIDER_MODEL ||
+    env.CODEX_CLI
+  )
+    return true;
+  return false;
+};

--- a/packages/alchemy/test/Auth/Profile.test.ts
+++ b/packages/alchemy/test/Auth/Profile.test.ts
@@ -1,0 +1,67 @@
+import {
+  AuthError,
+  AuthProviderLayer,
+  AuthProviders,
+  getAuthProvider,
+} from "@/Auth/AuthProvider.ts";
+import { AlchemyProfile, ProfileLive } from "@/Auth/Profile.ts";
+import { NodeServices } from "@effect/platform-node";
+import { expect, it } from "@effect/vitest";
+import * as ConfigProvider from "effect/ConfigProvider";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { v4 as uuidv4 } from "uuid";
+
+const FAKE_PROVIDER = "FakeAuthProvider";
+
+// Records whether the lock-wrapped `configure` was ever entered. The
+// non-interactive bail in `loadOrConfigure` must short-circuit *before* this
+// runs — otherwise it would acquire an auth lockfile (which we must avoid for
+// single-use OAuth refresh tokens).
+const state = { configureCalls: 0 };
+
+const FakeAuth = AuthProviderLayer<{ method: "env" }, undefined>()(
+  FAKE_PROVIDER,
+  {
+    configure: () =>
+      Effect.sync(() => {
+        state.configureCalls += 1;
+        return { method: "env" as const };
+      }),
+    login: () => Effect.void,
+    logout: () => Effect.void,
+    prettyPrint: () => Effect.void,
+    read: () => Effect.succeed(undefined),
+  },
+);
+
+const TestLayer = Layer.mergeAll(ProfileLive, FakeAuth).pipe(
+  Layer.provideMerge(
+    Layer.mergeAll(
+      Layer.succeed(AuthProviders, {}),
+      ConfigProvider.layer(ConfigProvider.fromUnknown({})),
+      NodeServices.layer,
+    ),
+  ),
+);
+
+it.live(
+  "loadOrConfigure bails (without configuring) for a missing profile when non-interactive",
+  () =>
+    Effect.gen(function* () {
+      state.configureCalls = 0;
+      const profile = yield* AlchemyProfile;
+      const auth = yield* getAuthProvider<{ method: "env" }, undefined>(
+        FAKE_PROVIDER,
+      );
+
+      const error = yield* profile
+        .loadOrConfigure(auth, `non-existent-${uuidv4()}`, { ci: false })
+        .pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(AuthError);
+      expect((error as AuthError).message).toContain("non-interactive");
+      // The lock-wrapped `configure` must never run, so no lockfile is created.
+      expect(state.configureCalls).toBe(0);
+    }).pipe(Effect.provide(TestLayer)),
+);


### PR DESCRIPTION
Resolving credentials for a profile with no entry for a given provider called `auth.configure`, which is a locked method — so the provider wrapper acquired a cross-process auth lockfile *before* running the interactive clack prompts. In a non-TTY context (a `vitest` run, piped stdout) there's no terminal to drive those prompts, so the flow hung instead of bailing, leaving a lockfile behind. For OAuth providers a refresh token is typically single-use, so a stray lock can wedge concurrent refreshes.

`loadOrConfigure` now bails *before* `auth.configure` runs (and thus before any lock is acquired) when there's no stored config, the process is non-interactive, and we're not in CI:

```ts
if (!ctx.ci && isNonInteractive()) {
  return Effect.fail(
    new AuthError({
      message:
        `No credentials configured for '${auth.name}' in profile '${profileName}', ` +
        `and this process is non-interactive so it can't be configured interactively. ` +
        `Run \`alchemy login --profile ${profileName}\` to configure it, ` +
        `or set CI=1 to use environment-variable credentials.`,
    }),
  );
}
```

CI is preserved: `ctx.ci` still short-circuits `configure` to the env-credential default.

### Supporting changes

- Extracted `isNonInteractive()` into `Util/interactive.ts` so `Auth` can use it without depending on `Cli`; `Cli/selectCli.ts` re-exports it (existing importers unaffected).
- Importing `AuthError` as a value into `Profile.ts` introduced a runtime import cycle `Profile -> AuthProvider -> Lock -> Profile`, so `Lock.ts` now computes `lockDir` lazily inside `withLock` instead of at module-eval time (avoids a `rootDir` TDZ error).
- Added `test/Auth/Profile.test.ts` asserting a missing profile resolved non-interactively fails with `AuthError` and the lock-wrapped `configure` is never entered (no lockfile created).

### Note

`alchemy login` calls `provider.configure` directly (not via `loadOrConfigure`), so it isn't affected by this guard — intentional, since it's an explicit interactive command. Making `login` also refuse in a non-interactive shell would be a small follow-up.
