### PR TITLE
fix(cloudflare): re-export dev container image type

### DIFF
--- a/packages/alchemy/src/Cloudflare/Container/ContainerApplication.ts
+++ b/packages/alchemy/src/Cloudflare/Container/ContainerApplication.ts
@@ -543,7 +543,7 @@ export interface ContainerApplication<Shape = unknown> extends Resource<
     hash?: {
       image: string;
     };
-    dev: ContainerImage | undefined;
+    dev: DevContainerImage | undefined;
   },
   {
     /**
@@ -562,6 +562,8 @@ export interface ContainerApplication<Shape = unknown> extends Resource<
   /** @internal phantom */
   Shape: Shape;
 }
+
+export type DevContainerImage = ContainerImage;
 
 const resolveDurableObjectApplicationRecovery = ({
   namespaceId,

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -1,5 +1,4 @@
 import type * as cf from "@cloudflare/workers-types";
-import type { ContainerImage } from "@distilled.cloud/cloudflare-runtime/Docker";
 import * as workers from "@distilled.cloud/cloudflare/workers";
 import * as zones from "@distilled.cloud/cloudflare/zones";
 import type * as Config from "effect/Config";
@@ -26,6 +25,7 @@ import * as Provider from "../../Provider.ts";
 import { Resource, type ResourceBinding } from "../../Resource.ts";
 import { Stack } from "../../Stack.ts";
 import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
+import type { DevContainerImage } from "../Container/ContainerApplication.ts";
 import type { HyperdriveDevOrigin } from "../Hyperdrive/Hyperdrive.ts";
 import { CloudflareLogs } from "../Logs.ts";
 import type { Providers } from "../Providers.ts";
@@ -373,7 +373,7 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
   },
   {
     bindings?: WorkerBinding[];
-    containers?: { className: string; dev: ContainerImage | undefined }[];
+    containers?: { className: string; dev: DevContainerImage | undefined }[];
     crons?: string[];
     hyperdrives?: Record<string, Required<HyperdriveDevOrigin>>;
   },


### PR DESCRIPTION
Closes #651.

Re-exports the type of `ContainerImage` from `cloudflare-runtime` to fix this error:

```
src/worker.ts(10,22): error TS2883: The inferred type of 'Worker' cannot be named without a
reference to 'ContainerImage' from
'.bun/@distilled.cloud+cloudflare-runtime@0.11.2+<hash>/node_modules/@distilled.cloud/cloudflare-runtime/Docker'.
This is likely not portable. A type annotation is necessary.
```