### PR TITLE
fix(neon): project replaces unexpectedly due to default region mismatch

### DIFF
--- a/packages/alchemy/src/Neon/Project.ts
+++ b/packages/alchemy/src/Neon/Project.ts
@@ -236,9 +236,9 @@ export const ProjectProvider = () =>
         : yield* createProjectName(id, olds.name);
       if (
         oldName !== name ||
-        (news.region ?? DEFAULT_REGION) !==
+        (news.region ?? output?.region ?? DEFAULT_REGION) !==
           (output?.region ?? olds.region ?? DEFAULT_REGION) ||
-        (news.pgVersion ?? DEFAULT_PG_VERSION) !==
+        (news.pgVersion ?? output?.pgVersion ?? DEFAULT_PG_VERSION) !==
           (output?.pgVersion ?? olds.pgVersion ?? DEFAULT_PG_VERSION) ||
         (news.defaultBranchName ?? output?.defaultBranchName) !==
           output?.defaultBranchName

--- a/packages/alchemy/test/Neon/Project.test.ts
+++ b/packages/alchemy/test/Neon/Project.test.ts
@@ -37,6 +37,33 @@ test.provider("create and delete project with default props", (stack) =>
   }).pipe(logLevel),
 );
 
+test.provider("project with default props does not change on update", (stack) =>
+  Effect.gen(function* () {
+    yield* stack.destroy();
+
+    const deploy = stack.deploy(Neon.Project("DefaultProjectUpdate"));
+
+    const created = yield* deploy;
+
+    expect(created.projectId).toBeDefined();
+    expect(created.projectName).toBeDefined();
+    expect(created.defaultBranchId).toBeDefined();
+    expect(created.connectionUri).toContain("postgres");
+
+    const fetched = yield* getProject({ project_id: created.projectId });
+    expect(fetched.project.id).toEqual(created.projectId);
+
+    const updated = yield* deploy;
+
+    expect(updated.projectId).toEqual(created.projectId);
+    expect(updated.projectName).toEqual(created.projectName);
+    expect(updated.defaultBranchId).toEqual(created.defaultBranchId);
+    expect(updated.connectionUri).toEqual(created.connectionUri);
+
+    yield* stack.destroy();
+  }).pipe(logLevel),
+);
+
 test.provider("enable logical replication on update", (stack) =>
   Effect.gen(function* () {
     yield* stack.destroy();


### PR DESCRIPTION
If Neon gives you a different default region or Postgres version from the one we're expecting, and these props are not specified manually, this can cause your project to be replaced even if nothing has changed. This includes a quick fix for that, along with a test to verify.