### PR TITLE
fix(core): use persisted FQN when deleting resources

### DIFF
--- a/packages/alchemy/src/Apply.ts
+++ b/packages/alchemy/src/Apply.ts
@@ -17,7 +17,6 @@ import {
 } from "./Cli/Cli.ts";
 import type { ApplyStatus } from "./Cli/Event.ts";
 import { havePropsChanged } from "./Diff.ts";
-import { toFqn } from "./FQN.ts";
 import type { Input } from "./Input.ts";
 import { generateInstanceId, InstanceId } from "./InstanceId.ts";
 import * as Output from "./Output.ts";
@@ -1445,6 +1444,7 @@ const collectGarbage = Effect.fnUntraced(function* (
         ): node is Delete => "action" in node;
 
         const {
+          fqn,
           logicalId,
           namespace,
           resourceType,
@@ -1455,6 +1455,13 @@ const collectGarbage = Effect.fnUntraced(function* (
           provider,
         } = isDeleteNode(node)
           ? {
+              // Use the persisted FQN verbatim — never recompute it from
+              // `toFqn(namespace, logicalId)`. A logical ID may legitimately
+              // contain the FQN separator (`/`), in which case `parseFqn`
+              // truncated it and a recomputed key would miss the real state
+              // row (the row would then resurface as an orphan on every
+              // subsequent destroy, never getting deleted).
+              fqn: node.resource.FQN,
               logicalId: node.resource.LogicalId,
               namespace: node.resource.Namespace,
               resourceType: node.resource.Type,
@@ -1465,6 +1472,7 @@ const collectGarbage = Effect.fnUntraced(function* (
               provider: node.provider,
             }
           : {
+              fqn: node.fqn,
               logicalId: node.logicalId,
               namespace: node.namespace,
               resourceType: node.old.resourceType,
@@ -1475,7 +1483,6 @@ const collectGarbage = Effect.fnUntraced(function* (
               provider: yield* findProviderByType(node.old.resourceType),
             };
 
-        const fqn = toFqn(namespace, logicalId);
         const nextAncestors = new Set(ancestors).add(fqn);
 
         const commit = <S extends ResourceState>(value: Omit<S, "namespace">) =>
@@ -1663,7 +1670,9 @@ const collectGarbage = Effect.fnUntraced(function* (
       ...(first ? plan.deletions : {}),
       ...Object.fromEntries(
         remainingReplacedResources.map((replaced) => [
-          toFqn(replaced.namespace, replaced.logicalId),
+          // Key by the persisted FQN (not a recomputed one) so logical IDs
+          // containing the FQN separator round-trip correctly.
+          replaced.fqn,
           replaced,
         ]),
       ),

--- a/packages/alchemy/test/apply.test.ts
+++ b/packages/alchemy/test/apply.test.ts
@@ -404,6 +404,74 @@ describe("basic operations", () => {
   );
 });
 
+// Regression: a logical ID may legitimately contain the FQN separator ("/").
+// The GitHub event source registers a webhook keyed by `${owner}/${repository}`
+// (e.g. "alchemy-run/alchemy-effect"). During destroy the deletion path used to
+// recompute the state key via `toFqn(namespace, logicalId)`, but `logicalId`
+// came from `parseFqn` which splits on "/" and keeps only the last segment
+// ("alchemy-effect"). The recomputed key missed the real state row, so the
+// resource was deleted from the cloud yet never removed from state — resurfacing
+// as an orphan deletion on every subsequent destroy, forever.
+describe("FQN separator in logical ID", () => {
+  test.provider(
+    "destroy clears state for a top-level logical ID containing '/'",
+    (stack) =>
+      Effect.gen(function* () {
+        const fqn = "alchemy-run/alchemy-effect";
+
+        yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* TestResource(fqn, { string: "v1" });
+          }),
+        );
+
+        // The row is persisted under the full FQN (separator and all).
+        expect((yield* getState(fqn))?.status).toEqual("created");
+
+        const deleted: string[] = [];
+        yield* stack.destroy().pipe(
+          hook({
+            delete: (id: string) =>
+              Effect.sync(() => {
+                deleted.push(id);
+              }),
+          }),
+        );
+
+        // provider.delete ran exactly once, AND the state row was removed
+        // (the pre-fix bug deleted the cloud resource but missed the row).
+        expect(deleted).toHaveLength(1);
+        expect(yield* getState(fqn)).toBeUndefined();
+        expect(yield* listState()).toEqual([]);
+      }),
+  );
+
+  test.provider(
+    "destroy clears state for a namespaced logical ID containing '/'",
+    (stack) =>
+      Effect.gen(function* () {
+        // Mirrors the GitHub webhook: a host construct (the Worker) whose
+        // child resource's logical ID is "owner/repo".
+        const fqn = "ReleaseService/alchemy-run/alchemy-effect";
+
+        const Host = Construct.fn(function* (_id: string, _props: {}) {
+          return yield* TestResource("alchemy-run/alchemy-effect", {
+            string: "v1",
+          });
+        });
+
+        yield* stack.deploy(Host("ReleaseService", {}));
+
+        expect((yield* getState(fqn))?.status).toEqual("created");
+
+        yield* stack.destroy();
+
+        expect(yield* getState(fqn)).toBeUndefined();
+        expect(yield* listState()).toEqual([]);
+      }),
+  );
+});
+
 describe("linear update propagation", () => {
   // Regression: in a linear chain (A -> B with no cycle), an update to A
   // followed by an update to B must let B see A's *post-update* attr, never


### PR DESCRIPTION
A logical ID may legitimately contain the FQN separator (`/`) — e.g. the GitHub event source registers a webhook keyed by `${owner}/${repository}` like `alchemy-run/alchemy-effect`. On destroy, the garbage-collection path recomputed the state key instead of using the persisted one:

```ts
// logicalId here came from parseFqn(fqn), which splits on "/" and keeps
// only the LAST segment -> "alchemy-effect"
const fqn = toFqn(namespace, logicalId); // -> "Host/alchemy-effect" (wrong)
```

So `provider.delete` ran with the correct attrs (the cloud resource was deleted), but `state.delete` targeted the wrong key and the real row survived — resurfacing as an orphan deletion on every subsequent destroy, forever.

Fix: use the persisted FQN verbatim rather than recomputing it.

```diff
-              logicalId: node.resource.LogicalId,
+              fqn: node.resource.FQN,        // orphan deletes
+              logicalId: node.resource.LogicalId,
...
-        const fqn = toFqn(namespace, logicalId);
```

```diff
-          toFqn(replaced.namespace, replaced.logicalId),
+          replaced.fqn,                      // replacement-chain cleanup
```

Added two regression tests in `apply.test.ts` (top-level and namespaced logical IDs containing `/`) that deploy, destroy, and assert the state row is gone. Both fail before the fix and pass after.
