### PR TITLE
fix(cloudflare): StaticSite precreate fails in alchemy dev

### DIFF
--- a/packages/alchemy/src/Cloudflare/Website/StaticSite.ts
+++ b/packages/alchemy/src/Cloudflare/Website/StaticSite.ts
@@ -236,7 +236,7 @@ const makeStaticSite = <
           }).pipe(
             Effect.map((d) =>
               Output.map(d.url, (url) => ({
-                url: url ?? props.dev?.url ?? (false as const),
+                url: url ?? props.dev?.url,
               })),
             ),
           )
@@ -272,7 +272,7 @@ const makeStaticSite = <
       // Opt out of the local Worker in dev when the external DevCommand
       // is serving the content. The Worker resource still exists in
       // state with a stub Attributes shape.
-      dev: dev ? dev.url : undefined,
+      dev: dev ? { mode: "external", url: dev.url } : undefined,
       script: fallbackScript ?? props.script,
     });
   }).pipe(Namespace.push(id));

--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -72,7 +72,7 @@ import { WorkerBundle, type WorkerBundleOptions } from "./WorkerBundle.ts";
 import { createWorkerName } from "./WorkerName.ts";
 
 type WorkerPropsWithDev = Omit<WorkerProps, "dev"> & {
-  dev: Exclude<WorkerProps["dev"], false | string>;
+  dev: Extract<WorkerProps["dev"], { mode?: "worker" }>;
 };
 
 export class WorkerValidationError extends Schema.TaggedErrorClass<WorkerValidationError>()(
@@ -528,14 +528,13 @@ export const LocalWorkerProvider = () =>
           }
           const { accountId } = yield* yield* CloudflareEnvironment;
           const url =
-            news.dev === false
-              ? undefined
-              : typeof news.dev === "string"
-                ? news.dev
-                : yield* maybeStartProxy(id, {
-                    ...news.dev,
-                    port: news.dev?.port ?? 1337,
-                  }).pipe(Effect.map((proxy) => proxy.url.toString()));
+            news.dev?.mode === "external"
+              ? // news.dev.url may be an unresolved output; avoid trying to resolve it here.
+                undefined
+              : yield* maybeStartProxy(id, {
+                  ...news.dev,
+                  port: news.dev?.port ?? 1337,
+                }).pipe(Effect.map((proxy) => proxy.url.toString()));
           return {
             workerId: name,
             workerName: name,
@@ -556,7 +555,7 @@ export const LocalWorkerProvider = () =>
           // serving requests. Tear down any prior instance and return a
           // stub Attributes; the resource exists in state but has no
           // running workerd / proxy behind it.
-          if (news.dev === false || typeof news.dev === "string") {
+          if (news.dev?.mode === "external") {
             const { accountId } = yield* yield* CloudflareEnvironment;
             const existing = instances.get(id);
             if (existing) {
@@ -569,7 +568,7 @@ export const LocalWorkerProvider = () =>
               workerId: name,
               workerName: name,
               logpush: undefined,
-              url: news.dev || undefined,
+              url: news.dev.url,
               tags: [],
               durableObjectNamespaces: {},
               accountId,

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -355,9 +355,7 @@ export interface WorkerProps<
       }
     | {
         /**
-         * Don't start a local Worker; an external dev server is serving this
-         * content instead. Distinguished from `"worker"` mode by a literal
-         * tag so it can be matched without interpolating Worker outputs.
+         * Don't start a local Worker; an external dev server is running instead.
          */
         mode: "external";
         /**

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -324,14 +324,17 @@ export interface WorkerProps<
    * Options for the local dev server that runs this Worker under `alchemy dev`.
    * Each Worker is served on its own port.
    *
-   * Set to `false` to skip starting a local Worker entirely — useful when an
-   * external dev server (e.g. one spawned via `Build.DevCommand`) is
-   * serving the content this Worker would otherwise host.
+   * Use `{ mode: "external" }` to skip starting a local Worker entirely —
+   * useful when an external dev server (e.g. one spawned via `Build.DevServer`)
+   * is serving the content this Worker would otherwise host.
    */
   dev?:
-    | false
-    | string
     | {
+        /**
+         * Run this Worker in `workerd` locally (the default).
+         * @default "worker"
+         */
+        mode?: "worker";
         /**
          * Host the local dev server binds to.
          * @default "localhost"
@@ -349,6 +352,19 @@ export interface WorkerProps<
          * @default false
          */
         strictPort?: boolean;
+      }
+    | {
+        /**
+         * Don't start a local Worker; an external dev server is serving this
+         * content instead. Distinguished from `"worker"` mode by a literal
+         * tag so it can be matched without interpolating Worker outputs.
+         */
+        mode: "external";
+        /**
+         * URL the external dev server is reachable at, if applicable.
+         * This will be returned as the `url` attribute of the Worker resource.
+         */
+        url?: string;
       };
 }
 


### PR DESCRIPTION
Closes #668.

StaticSite was failing during `precreate` because `props.dev` was an output, which wasn't being interpreted correctly, causing an error whereby we try to read `props.dev.port` where none exists, which fails with an output interpolation error. I changed `props.dev` into a union type with a literal discriminator to fix this.