### PR TITLE
fix(aws): Route53 change ID normalization

### DIFF
--- a/packages/alchemy/src/AWS/ACM/Certificate.ts
+++ b/packages/alchemy/src/AWS/ACM/Certificate.ts
@@ -255,22 +255,26 @@ export const CertificateProvider = () =>
       });
 
       const waitForChange = Effect.fn(function* (changeId: string) {
-        return yield* route53.getChange({ Id: changeId }).pipe(
-          Effect.map((response) => response.ChangeInfo),
-          Effect.flatMap((changeInfo) =>
-            changeInfo.Status === "INSYNC"
-              ? Effect.succeed(changeInfo)
-              : Effect.fail(new Error("Route53ChangePending")),
-          ),
-          Effect.retry({
-            while: (error) =>
-              error instanceof Error &&
-              error.message === "Route53ChangePending",
-            schedule: Schedule.fixed("2 seconds").pipe(
-              Schedule.both(Schedule.recurs(60)),
+        return yield* route53
+          .getChange({
+            Id: changeId.replace(/^\/change\//, ""),
+          })
+          .pipe(
+            Effect.map((response) => response.ChangeInfo),
+            Effect.flatMap((changeInfo) =>
+              changeInfo.Status === "INSYNC"
+                ? Effect.succeed(changeInfo)
+                : Effect.fail(new Error("Route53ChangePending")),
             ),
-          }),
-        );
+            Effect.retry({
+              while: (error) =>
+                error instanceof Error &&
+                error.message === "Route53ChangePending",
+              schedule: Schedule.fixed("2 seconds").pipe(
+                Schedule.both(Schedule.recurs(60)),
+              ),
+            }),
+          );
       });
 
       const upsertValidationRecords = Effect.fn(function* (

--- a/packages/alchemy/src/AWS/ACM/Certificate.ts
+++ b/packages/alchemy/src/AWS/ACM/Certificate.ts
@@ -131,6 +131,29 @@ export interface Certificate extends Resource<
  */
 export const Certificate = Resource<Certificate>("AWS.ACM.Certificate");
 
+/** @internal */
+export const waitForRoute53Change = Effect.fn(function* (changeId: string) {
+  return yield* route53
+    .getChange({
+      Id: changeId.replace(/^\/change\//, ""),
+    })
+    .pipe(
+      Effect.map((response) => response.ChangeInfo),
+      Effect.flatMap((changeInfo) =>
+        changeInfo.Status === "INSYNC"
+          ? Effect.succeed(changeInfo)
+          : Effect.fail(new Error("Route53ChangePending")),
+      ),
+      Effect.retry({
+        while: (error) =>
+          error instanceof Error && error.message === "Route53ChangePending",
+        schedule: Schedule.fixed("2 seconds").pipe(
+          Schedule.both(Schedule.recurs(60)),
+        ),
+      }),
+    );
+});
+
 export const CertificateProvider = () =>
   Provider.effect(
     Certificate,
@@ -254,29 +277,6 @@ export const CertificateProvider = () =>
         );
       });
 
-      const waitForChange = Effect.fn(function* (changeId: string) {
-        return yield* route53
-          .getChange({
-            Id: changeId.replace(/^\/change\//, ""),
-          })
-          .pipe(
-            Effect.map((response) => response.ChangeInfo),
-            Effect.flatMap((changeInfo) =>
-              changeInfo.Status === "INSYNC"
-                ? Effect.succeed(changeInfo)
-                : Effect.fail(new Error("Route53ChangePending")),
-            ),
-            Effect.retry({
-              while: (error) =>
-                error instanceof Error &&
-                error.message === "Route53ChangePending",
-              schedule: Schedule.fixed("2 seconds").pipe(
-                Schedule.both(Schedule.recurs(60)),
-              ),
-            }),
-          );
-      });
-
       const upsertValidationRecords = Effect.fn(function* (
         hostedZoneId: string,
         certificate: acm.CertificateDetail,
@@ -307,7 +307,7 @@ export const CertificateProvider = () =>
           },
         });
 
-        yield* waitForChange(response.ChangeInfo.Id);
+        yield* waitForRoute53Change(response.ChangeInfo.Id);
       });
 
       return {

--- a/packages/alchemy/test/AWS/ACM/Certificate.test.ts
+++ b/packages/alchemy/test/AWS/ACM/Certificate.test.ts
@@ -1,13 +1,55 @@
 import * as AWS from "@/AWS";
-import { Certificate } from "@/AWS/ACM/Certificate.ts";
+import { Certificate, waitForRoute53Change } from "@/AWS/ACM/Certificate.ts";
+import { HostedZone } from "@/AWS/Route53";
 import * as Provider from "@/Provider";
 import * as Test from "@/Test/Vitest";
+import * as route53 from "@distilled.cloud/aws/route-53";
 import { expect } from "@effect/vitest";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";
 
 const { test } = Test.make({ providers: AWS.providers() });
+
+test.provider(
+  "polls Route53 validation changes returned with resource-path IDs",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const zone = yield* stack.deploy(
+        HostedZone("CertificateValidationZone", {
+          name: "alchemy-certificate-change-id.alchemy.",
+          forceDestroy: true,
+        }),
+      );
+
+      const change = yield* route53.changeResourceRecordSets({
+        HostedZoneId: zone.id.replace(/^\/hostedzone\//, ""),
+        ChangeBatch: {
+          Comment: "ACM Route53 change ID regression test",
+          Changes: [
+            {
+              Action: "UPSERT",
+              ResourceRecordSet: {
+                Name: `_validation.${zone.name}`,
+                Type: "TXT",
+                TTL: 60,
+                ResourceRecords: [{ Value: '"alchemy"' }],
+              },
+            },
+          ],
+        },
+      });
+
+      expect(change.ChangeInfo.Id).toMatch(/^\/change\//);
+      const completed = yield* waitForRoute53Change(change.ChangeInfo.Id);
+      expect(completed.Status).toBe("INSYNC");
+
+      yield* stack.destroy();
+    }),
+  { timeout: 180_000 },
+);
 
 // Canonical `list()` test (AWS account/region-scoped collection): request a
 // real ACM certificate (no DNS validation, stays PENDING_VALIDATION), resolve


### PR DESCRIPTION
## Summary

- normalize Route53 change IDs before polling `GetChange`
- strip the `/change/` resource prefix returned by Route53 APIs

## Why

Route53 mutation responses can return change IDs in resource-path form, while `GetChange` expects the bare identifier. This mirrors the normalization discussed in [aws/aws-sdk-go-v2#1838](https://github.com/aws/aws-sdk-go-v2/issues/1838) and implemented in [aws/aws-sdk-go-v2#1852](https://github.com/aws/aws-sdk-go-v2/pull/1852).

## Impact

ACM DNS validation can reliably poll Route53 changes without sending a prefixed ID.

## Validation

- `bunx oxfmt --check packages/alchemy/src/AWS/ACM/Certificate.ts`
- `git diff --check`