### PR TITLE
feat(aws): add Lambda function memory size

### DIFF
--- a/packages/alchemy/src/AWS/Lambda/Function.ts
+++ b/packages/alchemy/src/AWS/Lambda/Function.ts
@@ -111,6 +111,7 @@ export interface FunctionProps extends PlatformProps {
    * @default "x86_64"
    */
   architecture?: FunctionArchitecture;
+  memorySize?: number;
   build?: FunctionBuildOptions;
   uploadSourceMap?: boolean;
   env?: Record<string, any>;
@@ -1036,6 +1037,7 @@ export default await Effect.runPromise(handlerEffect)
           Code: codeLocation,
           Runtime: news.runtime ?? "nodejs22.x",
           Architectures: [news.architecture ?? "x86_64"],
+          MemorySize: news.memorySize,
           Environment: runtimeEnv
             ? {
                 Variables: {


### PR DESCRIPTION
## Summary

- expose `memorySize` on Lambda `FunctionProps`
- pass the configured value through to the AWS Lambda create request

## Why

Lambda functions currently use the AWS default memory allocation because the resource contract does not expose `MemorySize` during creation.

## Impact

Users can configure a Lambda function memory allocation through Alchemy. The existing update path also propagates the value from the shared create request.

## Validation

- `bunx oxfmt --check packages/alchemy/src/AWS/Lambda/Function.ts`
- `git diff --check`