### PR TITLE
feat(aws): support external packages in Lambda bundles

### DIFF
--- a/packages/alchemy/src/AWS/Lambda/Function.ts
+++ b/packages/alchemy/src/AWS/Lambda/Function.ts
@@ -13,9 +13,12 @@ import * as Option from "effect/Option";
 import * as Redacted from "effect/Redacted";
 import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
+import path from "node:path";
 import type * as rolldown from "rolldown";
 import { Unowned } from "../../AdoptPolicy.ts";
+import { AlchemyContext } from "../../AlchemyContext.ts";
 import * as Bundle from "../../Bundle/Bundle.ts";
+import * as ExternalPackages from "../../Bundle/ExternalPackages.ts";
 import * as TempRoot from "../../Bundle/TempRoot.ts";
 import { deepEqual, isResolved } from "../../Diff.ts";
 import type { HttpEffect } from "../../Http.ts";
@@ -63,6 +66,17 @@ export const isFunction = (value: any): value is Function => {
 export interface FunctionBuildOptions {
   readonly input?: Partial<rolldown.InputOptions>;
   readonly output?: Partial<rolldown.OutputOptions>;
+  /**
+   * Runtime packages to exclude from the Rolldown bundle and include under
+   * `node_modules` in the Lambda deployment package.
+   *
+   * Packages are installed in Docker for the function's Linux architecture
+   * using the nearest `bun.lock` or `package-lock.json`. Each package must be
+   * declared in this function package's dependencies or optionalDependencies.
+   *
+   * @default []
+   */
+  readonly externalPackages?: readonly string[];
 }
 
 export type FunctionArchitecture = "x86_64" | "arm64";
@@ -256,6 +270,18 @@ const normalizeFunctionUrl = (
  * const func = yield* AWS.Lambda.Function("ArmFunction", {
  *   main: "./src/handler.ts",
  *   architecture: "arm64",
+ * });
+ * ```
+ *
+ * @example Function with native dependencies
+ * ```typescript
+ * const func = yield* AWS.Lambda.Function("ImageProcessor", {
+ *   main: "./src/handler.ts",
+ *   runtime: "nodejs22.x",
+ *   architecture: "arm64",
+ *   build: {
+ *     externalPackages: ["sharp", "ffmpeg-static"],
+ *   },
  * });
  * ```
  *
@@ -578,6 +604,7 @@ export const FunctionProvider = () =>
     Function,
     Effect.gen(function* () {
       const stack = yield* Stack;
+      const { dotAlchemy } = yield* AlchemyContext;
 
       const fs = yield* FileSystem.FileSystem;
       const virtualEntryPlugin = yield* Bundle.virtualEntryPlugin;
@@ -740,12 +767,19 @@ export const FunctionProvider = () =>
       const bundleCode = Effect.fnUntraced(function* (
         id: string,
         props: FunctionProps,
+        session?: { note: (note: string) => Effect.Effect<void> },
       ) {
         const sourcemap = props.build?.output?.sourcemap ?? true;
         const uploadSourceMap = props.uploadSourceMap ?? true;
 
         const realMain = yield* fs.realPath(props.main);
         const cwd = yield* TempRoot.findCwdForBundle(realMain);
+        const externalPackages =
+          yield* ExternalPackages.normalizeExternalPackageNames(
+            props.build?.externalPackages ?? [],
+          );
+        const managedExternal =
+          ExternalPackages.externalPackagePredicate(externalPackages);
 
         const rolldownSourcemap = sourcemap;
 
@@ -753,15 +787,38 @@ export const FunctionProvider = () =>
           entry: string,
           plugins?: rolldown.RolldownPluginOption,
         ) {
+          const userExternal = props.build?.input?.external;
+          const defaultExternal: Array<string | RegExp> = [/^@aws-sdk\//];
+          const external: rolldown.ExternalOption =
+            typeof userExternal === "function"
+              ? (moduleId, parentId, isResolved) =>
+                  managedExternal(moduleId) ||
+                  defaultExternal.some((item) =>
+                    typeof item === "string"
+                      ? item === moduleId
+                      : item.test(moduleId),
+                  ) ||
+                  userExternal(moduleId, parentId, isResolved)
+              : [
+                  ...defaultExternal,
+                  ...externalPackages.map(
+                    (packageName) =>
+                      new RegExp(
+                        `^${packageName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(?:/|$)`,
+                      ),
+                  ),
+                  ...(Array.isArray(userExternal)
+                    ? userExternal
+                    : userExternal
+                      ? [userExternal]
+                      : []),
+                ];
           return yield* Bundle.build(
             {
               ...props.build?.input,
               input: entry,
               cwd,
-              external: [
-                /^@aws-sdk\//,
-                ...((props.build?.input?.external as string[]) ?? []),
-              ],
+              external,
               platform: "node",
               plugins: [props.build?.input?.plugins, plugins],
             },
@@ -863,7 +920,7 @@ export default await Effect.runPromise(handlerEffect)
         const includeSourceMaps =
           uploadSourceMap && (sourcemap === true || sourcemap === "hidden");
 
-        const extraFiles = bundleOutput.files
+        const bundledExtraFiles = bundleOutput.files
           .slice(1)
           .filter(
             (f: Bundle.BundleFile) =>
@@ -874,14 +931,58 @@ export default await Effect.runPromise(handlerEffect)
             content: f.content,
           }));
 
+        const external =
+          externalPackages.length > 0
+            ? yield* ExternalPackages.materializeExternalPackages({
+                packageRoot: cwd,
+                packages: externalPackages,
+                runtime: props.runtime ?? "nodejs22.x",
+                architecture: props.architecture ?? "x86_64",
+                cacheDirectory: path.join(
+                  dotAlchemy,
+                  "cache",
+                  "lambda-external-packages",
+                ),
+                bunVersion: process.versions.bun,
+                note: session?.note,
+              })
+            : undefined;
+        const extraFiles = [...bundledExtraFiles, ...(external?.files ?? [])];
+        const uncompressedSize =
+          code.byteLength +
+          extraFiles.reduce(
+            (total, file) =>
+              total +
+              (typeof file.content === "string"
+                ? new TextEncoder().encode(file.content).byteLength
+                : file.content.byteLength),
+            0,
+          );
+        yield* ExternalPackages.validateLambdaPackageSize({
+          uncompressedSize,
+          compressedSize: 0,
+          hasAssets: true,
+        });
+
         const archive = yield* zipCode(
           code,
           extraFiles.length > 0 ? extraFiles : undefined,
         );
+        const hash = ExternalPackages.hashLambdaDeploymentCode({
+          bundleHash: bundleOutput.hash,
+          externalHash: external?.hash,
+          runtime: props.runtime ?? "nodejs22.x",
+          architecture: props.architecture ?? "x86_64",
+        });
+        if (external && session) {
+          yield* session.note(
+            `Packaged ${externalPackages.join(", ")} (${(external.size / 1024 / 1024).toFixed(2)} MiB)`,
+          );
+        }
         return {
           archive,
           code,
-          hash: bundleOutput.hash,
+          hash,
         };
       });
 
@@ -1012,6 +1113,11 @@ export default await Effect.runPromise(handlerEffect)
         const assets = (yield* Effect.serviceOption(Assets)).pipe(
           Option.getOrUndefined,
         );
+        yield* ExternalPackages.validateLambdaPackageSize({
+          uncompressedSize: 0,
+          compressedSize: archive.byteLength,
+          hasAssets: assets !== undefined,
+        });
 
         const codeLocation = yield* Effect.gen(function* () {
           if (assets) {
@@ -1324,6 +1430,9 @@ export default await Effect.runPromise(handlerEffect)
             (yield* bundleCode(id, {
               main: news.main,
               handler: news.handler,
+              isExternal: news.isExternal,
+              runtime: news.runtime,
+              architecture: news.architecture,
               build: news.build,
               uploadSourceMap: news.uploadSourceMap,
             })).hash
@@ -1523,7 +1632,7 @@ export default await Effect.runPromise(handlerEffect)
             bindings,
           });
 
-          const { archive, code, hash } = yield* bundleCode(id, news);
+          const { archive, code, hash } = yield* bundleCode(id, news, session);
 
           yield* createOrUpdateFunction({
             id,

--- a/packages/alchemy/src/Bundle/ExternalPackages.ts
+++ b/packages/alchemy/src/Bundle/ExternalPackages.ts
@@ -1,4 +1,5 @@
 import * as Data from "effect/Data";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import fg from "fast-glob";
 import { execFile } from "node:child_process";
@@ -14,6 +15,7 @@ import {
   realpath,
   rename,
   rm,
+  stat,
   writeFile,
 } from "node:fs/promises";
 import path from "node:path";
@@ -426,6 +428,106 @@ export const collectExternalPackageFiles = (
           }),
   });
 
+export const renderExternalPackageCollector = (packages: readonly string[]) =>
+  `import { cp, mkdir, readFile, realpath } from "node:fs/promises";
+import path from "node:path";
+
+const selectedPackages = ${JSON.stringify([...packages].sort())};
+const installRoot = await realpath(path.resolve(process.argv[2]));
+const outputRoot = path.resolve(process.argv[3]);
+const nodeModulesRoot = path.join(installRoot, "node_modules");
+const visitedPackages = new Set();
+
+function isWithin(root, candidate) {
+  const relative = path.relative(root, candidate);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+async function packageExists(directory) {
+  try {
+    await readFile(path.join(directory, "package.json"));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function findInstalledPackage(fromPackage, packageName) {
+  let current = fromPackage;
+  while (isWithin(installRoot, current)) {
+    const candidate = path.join(current, "node_modules", packageName);
+    if (await packageExists(candidate)) return candidate;
+    if (current === installRoot) break;
+    current = path.dirname(current);
+  }
+  return undefined;
+}
+
+async function copyPackage(packageDirectory) {
+  const canonical = await realpath(packageDirectory);
+  if (!isWithin(installRoot, canonical)) {
+    throw new Error("Package resolves outside install root: " + packageDirectory);
+  }
+  if (visitedPackages.has(canonical)) return;
+  visitedPackages.add(canonical);
+
+  const relative = path.relative(installRoot, packageDirectory);
+  const destination = path.join(outputRoot, relative);
+  await mkdir(path.dirname(destination), { recursive: true });
+  await cp(packageDirectory, destination, {
+    recursive: true,
+    dereference: true,
+    filter: async (source) => {
+      if (source !== packageDirectory && path.basename(source) === "node_modules") {
+        return false;
+      }
+      const canonicalSource = await realpath(source);
+      if (!isWithin(installRoot, canonicalSource)) {
+        throw new Error("Package path resolves outside install root: " + source);
+      }
+      return true;
+    },
+  });
+
+  const manifest = JSON.parse(await readFile(path.join(packageDirectory, "package.json"), "utf8"));
+  const bundled = Array.isArray(manifest.bundledDependencies)
+    ? manifest.bundledDependencies
+    : Array.isArray(manifest.bundleDependencies)
+      ? manifest.bundleDependencies
+      : [];
+  const required = new Set([
+    ...Object.keys(manifest.dependencies ?? {}),
+    ...Object.keys(manifest.peerDependencies ?? {}).filter(
+      (name) => !manifest.peerDependenciesMeta?.[name]?.optional,
+    ),
+    ...bundled,
+  ]);
+  const optional = new Set([
+    ...Object.keys(manifest.optionalDependencies ?? {}),
+    ...Object.keys(manifest.peerDependencies ?? {}).filter(
+      (name) => manifest.peerDependenciesMeta?.[name]?.optional,
+    ),
+  ]);
+
+  for (const dependency of [...required, ...optional].sort()) {
+    const installed = await findInstalledPackage(packageDirectory, dependency);
+    if (installed) await copyPackage(installed);
+    else if (required.has(dependency)) {
+      throw new Error("Required dependency is missing: " + dependency);
+    }
+  }
+}
+
+await mkdir(outputRoot, { recursive: true });
+for (const packageName of selectedPackages) {
+  const packageDirectory = path.join(nodeModulesRoot, packageName);
+  if (!(await packageExists(packageDirectory))) {
+    throw new Error("Selected package is missing: " + packageName);
+  }
+  await copyPackage(packageDirectory);
+}
+`;
+
 export const renderExternalPackageDockerfile = (options: {
   readonly manager: "bun" | "npm";
   readonly runtime: "nodejs22.x" | "nodejs24.x";
@@ -461,9 +563,10 @@ export const renderExternalPackageDockerfile = (options: {
     "WORKDIR /workspace",
     "COPY . .",
     ...install,
+    "RUN node /workspace/alchemy-external-package-collector.mjs /workspace /workspace/.alchemy-external",
     "",
     "FROM scratch AS export",
-    "COPY --from=dependencies /workspace/node_modules /node_modules",
+    "COPY --from=dependencies /workspace/.alchemy-external/node_modules /node_modules",
     "",
   ].join("\n");
 };
@@ -531,13 +634,22 @@ export const prepareExternalPackageBuildContext = (options: {
       const canonicalLockRoot = await realpath(options.project.lockRoot);
 
       await mkdir(options.directory, { recursive: true });
+      const collector = renderExternalPackageCollector(packages);
+      const dockerfile = renderExternalPackageDockerfile({
+        manager: options.project.manager,
+        runtime: options.runtime,
+        packages,
+        bunVersion: options.bunVersion,
+      });
       const fingerprintInputs: Array<string | Uint8Array> = [
-        "lambda-external-packages-v1",
+        "lambda-external-packages-v2",
         options.project.manager,
         options.runtime,
         options.architecture,
         options.bunVersion,
         JSON.stringify(packages),
+        collector,
+        dockerfile,
       ];
       for (const relative of manifestRelatives) {
         const source = path.resolve(options.project.lockRoot, relative);
@@ -573,14 +685,10 @@ export const prepareExternalPackageBuildContext = (options: {
         lockContent,
       );
       await writeFile(
-        path.join(options.directory, "Dockerfile"),
-        renderExternalPackageDockerfile({
-          manager: options.project.manager,
-          runtime: options.runtime,
-          packages,
-          bunVersion: options.bunVersion,
-        }),
+        path.join(options.directory, "alchemy-external-package-collector.mjs"),
+        collector,
       );
+      await writeFile(path.join(options.directory, "Dockerfile"), dockerfile);
 
       return {
         fingerprint: digest(fingerprintInputs),
@@ -685,6 +793,17 @@ export interface MaterializedExternalPackages {
   readonly cacheHit: boolean;
 }
 
+export interface ExternalPackageBuildRequest {
+  readonly platform: string;
+  readonly contextDirectory: string;
+  readonly outputDirectory: string;
+}
+
+const inFlightMaterializations = new Map<
+  string,
+  Deferred.Deferred<MaterializedExternalPackages, ExternalPackageError>
+>();
+
 const installedBunVersion = Effect.tryPromise({
   try: () =>
     new Promise<string>((resolve, reject) => {
@@ -701,6 +820,42 @@ const installedBunVersion = Effect.tryPromise({
 });
 
 const bunVersionPattern = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/;
+const staleBuildAgeMs = 10 * 60 * 1000;
+
+const processIsRunning = (pid: number) => {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (cause) {
+    return (cause as NodeJS.ErrnoException).code !== "ESRCH";
+  }
+};
+
+const cleanupStaleBuildDirectories = async (cacheDirectory: string) => {
+  for (const entry of await readdir(cacheDirectory, { withFileTypes: true })) {
+    if (!entry.isDirectory() || !entry.name.startsWith("build-")) continue;
+    try {
+      const directory = path.join(cacheDirectory, entry.name);
+      let ownerIsRunning = false;
+      try {
+        const owner = JSON.parse(
+          await readFile(path.join(directory, "owner.json"), "utf8"),
+        ) as { readonly pid?: number };
+        ownerIsRunning =
+          typeof owner.pid === "number" && processIsRunning(owner.pid);
+      } catch {
+        const info = await stat(directory);
+        if (Date.now() - info.mtimeMs < staleBuildAgeMs) continue;
+      }
+      if (!ownerIsRunning) {
+        await rm(directory, { recursive: true, force: true });
+      }
+    } catch {
+      // Cleanup is best-effort: another planner may have removed the same
+      // abandoned directory after we listed it.
+    }
+  }
+};
 
 export const materializeExternalPackages = Effect.fnUntraced(
   function* (options: {
@@ -711,6 +866,9 @@ export const materializeExternalPackages = Effect.fnUntraced(
     readonly cacheDirectory: string;
     readonly bunVersion: string | undefined;
     readonly note?: (message: string) => Effect.Effect<void>;
+    readonly build?: (
+      request: ExternalPackageBuildRequest,
+    ) => Effect.Effect<void, ExternalPackageError>;
   }) {
     const packages = yield* normalizeExternalPackageNames(options.packages);
     const project = yield* discoverExternalPackageProject(
@@ -734,7 +892,10 @@ export const materializeExternalPackages = Effect.fnUntraced(
     bunVersion ??= "not-used";
 
     yield* Effect.tryPromise({
-      try: () => mkdir(options.cacheDirectory, { recursive: true }),
+      try: async () => {
+        await mkdir(options.cacheDirectory, { recursive: true });
+        await cleanupStaleBuildDirectories(options.cacheDirectory);
+      },
       catch: (cause) =>
         new ExternalPackageError({
           message: `Failed to create external package cache ${options.cacheDirectory}`,
@@ -744,7 +905,16 @@ export const materializeExternalPackages = Effect.fnUntraced(
 
     return yield* Effect.acquireUseRelease(
       Effect.tryPromise({
-        try: () => mkdtemp(path.join(options.cacheDirectory, "build-")),
+        try: async () => {
+          const directory = await mkdtemp(
+            path.join(options.cacheDirectory, "build-"),
+          );
+          await writeFile(
+            path.join(directory, "owner.json"),
+            `${JSON.stringify({ pid: process.pid, startedAt: Date.now() })}\n`,
+          );
+          return directory;
+        },
         catch: (cause) =>
           new ExternalPackageError({
             message: "Failed to create external package build directory.",
@@ -780,98 +950,130 @@ export const materializeExternalPackages = Effect.fnUntraced(
             return { ...cached, cacheHit: true };
           }
 
-          yield* Effect.tryPromise({
-            try: () => rm(cacheDirectory, { recursive: true, force: true }),
-            catch: (cause) =>
-              new ExternalPackageError({
-                message: "Failed to remove an invalid Lambda package cache.",
-                cause,
-              }),
-          });
-
-          if (options.note) {
-            yield* options.note(
-              `Installing Lambda packages for ${prepared.platform}: ${packages.join(", ")}`,
-            );
+          const inFlight = inFlightMaterializations.get(cacheDirectory);
+          if (inFlight) {
+            return yield* Deferred.await(inFlight);
           }
-          const outputDirectory = path.join(temporaryDirectory, "output");
-          yield* Effect.tryPromise({
-            try: () => mkdir(outputDirectory, { recursive: true }),
-            catch: (cause) =>
-              new ExternalPackageError({
-                message: "Failed to create Docker package output directory.",
-                cause,
-              }),
-          });
-          yield* runDockerCommand(
-            [
-              "build",
-              "--platform",
-              prepared.platform,
-              "--target",
-              "export",
-              "--output",
-              `type=local,dest=${outputDirectory}`,
-              contextDirectory,
-            ],
-            { env: { DOCKER_BUILDKIT: "1" } },
-          ).pipe(
-            Effect.mapError(
-              (cause) =>
+          const deferred = Deferred.makeUnsafe<
+            MaterializedExternalPackages,
+            ExternalPackageError
+          >();
+          inFlightMaterializations.set(cacheDirectory, deferred);
+
+          return yield* Effect.gen(function* () {
+            yield* Effect.tryPromise({
+              try: () => rm(cacheDirectory, { recursive: true, force: true }),
+              catch: (cause) =>
                 new ExternalPackageError({
-                  message:
-                    "Failed to build external Lambda packages with Docker. Ensure Docker with BuildKit and the target architecture emulator are available.",
+                  message: "Failed to remove an invalid Lambda package cache.",
                   cause,
                 }),
-            ),
-            Effect.tapError((error) =>
-              options.note
-                ? options.note(
-                    `Lambda package installation failed: ${error.message}`,
-                  )
-                : Effect.void,
-            ),
-          );
+            });
 
-          const files = yield* collectExternalPackageFiles(
-            path.join(outputDirectory, "node_modules"),
-            packages,
-          );
-          const stagingCache = path.join(
-            options.cacheDirectory,
-            `.staging-${prepared.fingerprint}-${randomUUID()}`,
-          );
-          const manifest = yield* Effect.tryPromise({
-            try: () => writeExternalPackageCache(stagingCache, files),
-            catch: (cause) =>
-              new ExternalPackageError({
-                message: "Failed to write external Lambda package cache.",
-                cause,
-              }),
-          });
-          yield* Effect.tryPromise({
-            try: async () => {
-              try {
-                await rename(stagingCache, cacheDirectory);
-              } catch (cause) {
-                if (!(await exists(cacheDirectory))) {
-                  throw cause;
+            if (options.note) {
+              yield* options.note(
+                `Installing Lambda packages for ${prepared.platform}: ${packages.join(", ")}`,
+              );
+            }
+            const outputDirectory = path.join(temporaryDirectory, "output");
+            yield* Effect.tryPromise({
+              try: () => mkdir(outputDirectory, { recursive: true }),
+              catch: (cause) =>
+                new ExternalPackageError({
+                  message: "Failed to create Docker package output directory.",
+                  cause,
+                }),
+            });
+            const buildRequest = {
+              platform: prepared.platform,
+              contextDirectory,
+              outputDirectory,
+            } satisfies ExternalPackageBuildRequest;
+            yield* (
+              options.build
+                ? options.build(buildRequest)
+                : runDockerCommand(
+                    [
+                      "build",
+                      "--platform",
+                      buildRequest.platform,
+                      "--target",
+                      "export",
+                      "--output",
+                      `type=local,dest=${buildRequest.outputDirectory}`,
+                      buildRequest.contextDirectory,
+                    ],
+                    { env: { DOCKER_BUILDKIT: "1" } },
+                  ).pipe(
+                    Effect.asVoid,
+                    Effect.mapError(
+                      (cause) =>
+                        new ExternalPackageError({
+                          message:
+                            "Failed to build external Lambda packages with Docker. Ensure Docker with BuildKit and the target architecture emulator are available.",
+                          cause,
+                        }),
+                    ),
+                  )
+            ).pipe(
+              Effect.tapError((error) =>
+                options.note
+                  ? options.note(
+                      `Lambda package installation failed: ${error.message}`,
+                    )
+                  : Effect.void,
+              ),
+            );
+
+            const files = yield* collectExternalPackageFiles(
+              path.join(outputDirectory, "node_modules"),
+              packages,
+            );
+            const stagingCache = path.join(
+              options.cacheDirectory,
+              `.staging-${prepared.fingerprint}-${randomUUID()}`,
+            );
+            const manifest = yield* Effect.tryPromise({
+              try: () => writeExternalPackageCache(stagingCache, files),
+              catch: (cause) =>
+                new ExternalPackageError({
+                  message: "Failed to write external Lambda package cache.",
+                  cause,
+                }),
+            });
+            yield* Effect.tryPromise({
+              try: async () => {
+                try {
+                  await rename(stagingCache, cacheDirectory);
+                } catch (cause) {
+                  if (!(await exists(cacheDirectory))) {
+                    throw cause;
+                  }
+                  await rm(stagingCache, { recursive: true, force: true });
                 }
-                await rm(stagingCache, { recursive: true, force: true });
-              }
-            },
-            catch: (cause) =>
-              new ExternalPackageError({
-                message: "Failed to publish external Lambda package cache.",
-                cause,
+              },
+              catch: (cause) =>
+                new ExternalPackageError({
+                  message: "Failed to publish external Lambda package cache.",
+                  cause,
+                }),
+            });
+            return {
+              files,
+              hash: manifest.hash,
+              size: manifest.size,
+              cacheHit: false,
+            } satisfies MaterializedExternalPackages;
+          }).pipe(
+            Effect.onExit((exit) => Deferred.done(deferred, exit)),
+            Effect.ensuring(
+              Effect.sync(() => {
+                if (inFlightMaterializations.get(cacheDirectory) === deferred) {
+                  inFlightMaterializations.delete(cacheDirectory);
+                }
               }),
-          });
-          return {
-            files,
-            hash: manifest.hash,
-            size: manifest.size,
-            cacheHit: false,
-          } satisfies MaterializedExternalPackages;
+            ),
+          );
         }),
       (temporaryDirectory) =>
         Effect.tryPromise(() =>

--- a/packages/alchemy/src/Bundle/ExternalPackages.ts
+++ b/packages/alchemy/src/Bundle/ExternalPackages.ts
@@ -1,0 +1,882 @@
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import fg from "fast-glob";
+import { execFile } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import {
+  access,
+  chmod,
+  lstat,
+  mkdtemp,
+  mkdir,
+  readdir,
+  readFile,
+  realpath,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import path from "node:path";
+import { runDockerCommand } from "./Docker.ts";
+
+export class ExternalPackageError extends Data.TaggedError(
+  "ExternalPackageError",
+)<{
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+const packageNamePattern =
+  /^(?:@[a-z0-9][a-z0-9._~-]*\/)?[a-z0-9][a-z0-9._~-]*$/;
+
+export const normalizeExternalPackageNames = (
+  packages: readonly string[],
+): Effect.Effect<string[], ExternalPackageError> =>
+  Effect.gen(function* () {
+    for (const packageName of packages) {
+      if (!packageNamePattern.test(packageName)) {
+        return yield* new ExternalPackageError({
+          message: `Invalid external package name ${JSON.stringify(packageName)}. Use a package root such as "sharp" or "@scope/package".`,
+        });
+      }
+    }
+    return Array.from(new Set(packages)).sort();
+  });
+
+export const externalPackagePredicate = (packages: readonly string[]) => {
+  const roots = new Set(packages);
+  return (id: string) => {
+    if (roots.has(id)) return true;
+    for (const root of roots) {
+      if (id.startsWith(`${root}/`)) return true;
+    }
+    return false;
+  };
+};
+
+export interface ExternalPackageProject {
+  readonly manager: "bun" | "npm";
+  readonly packageRoot: string;
+  readonly lockRoot: string;
+  readonly lockfile: string;
+  readonly bunVersion: string | undefined;
+}
+
+interface PackageManifest {
+  readonly [key: string]: unknown;
+  readonly packageManager?: string;
+  readonly dependencies?: Record<string, string>;
+  readonly optionalDependencies?: Record<string, string>;
+  readonly peerDependencies?: Record<string, string>;
+  readonly peerDependenciesMeta?: Record<string, { optional?: boolean }>;
+  readonly bundledDependencies?: readonly string[];
+  readonly workspaces?:
+    | readonly string[]
+    | { readonly packages?: readonly string[] };
+}
+
+const exists = (file: string) =>
+  access(file).then(
+    () => true,
+    () => false,
+  );
+
+const readManifest = async (file: string): Promise<PackageManifest> => {
+  try {
+    return JSON.parse(await readFile(file, "utf8")) as PackageManifest;
+  } catch (cause) {
+    throw new ExternalPackageError({
+      message: `Failed to read package manifest ${file}`,
+      cause,
+    });
+  }
+};
+
+const unsupportedDependencyProtocol =
+  /^(?:workspace:|file:|link:|git(?:\+[^:]+)?:|github:|https?:)/;
+
+const validateNpmRegistryPackages = async (
+  lockfile: string,
+  packages: readonly string[],
+) => {
+  const lock = JSON.parse(await readFile(lockfile, "utf8")) as {
+    readonly packages?: Record<string, { readonly resolved?: string }>;
+  };
+  for (const packageName of packages) {
+    const resolved = lock.packages?.[`node_modules/${packageName}`]?.resolved;
+    if (resolved === undefined) continue;
+    const host = new URL(resolved).hostname;
+    if (host !== "registry.npmjs.org" && host !== "registry.yarnpkg.com") {
+      throw new ExternalPackageError({
+        message: `External package ${JSON.stringify(packageName)} resolves through unsupported registry ${host}. Version 1 supports the public npm registry only.`,
+      });
+    }
+  }
+};
+
+export const discoverExternalPackageProject = (
+  packageRoot: string,
+  packages: readonly string[],
+): Effect.Effect<ExternalPackageProject, ExternalPackageError> =>
+  Effect.tryPromise({
+    try: async () => {
+      const normalized = await Effect.runPromise(
+        normalizeExternalPackageNames(packages),
+      );
+      const packageManifestFile = path.join(packageRoot, "package.json");
+      const packageManifest = await readManifest(packageManifestFile);
+
+      for (const packageName of normalized) {
+        const spec =
+          packageManifest.dependencies?.[packageName] ??
+          packageManifest.optionalDependencies?.[packageName];
+        if (spec === undefined) {
+          throw new ExternalPackageError({
+            message: `External package ${JSON.stringify(packageName)} must be declared in dependencies or optionalDependencies of ${packageManifestFile}.`,
+          });
+        }
+        if (unsupportedDependencyProtocol.test(spec)) {
+          throw new ExternalPackageError({
+            message: `External package ${JSON.stringify(packageName)} uses unsupported dependency specifier ${JSON.stringify(spec)}. Version 1 supports public registry packages only.`,
+          });
+        }
+      }
+
+      let current = path.resolve(packageRoot);
+      while (true) {
+        const bunLock = path.join(current, "bun.lock");
+        const npmLock = path.join(current, "package-lock.json");
+        const [hasBunLock, hasNpmLock] = await Promise.all([
+          exists(bunLock),
+          exists(npmLock),
+        ]);
+        if (hasBunLock || hasNpmLock) {
+          const rootManifest = await readManifest(
+            path.join(current, "package.json"),
+          );
+          let manager: "bun" | "npm";
+          if (hasBunLock && hasNpmLock) {
+            if (rootManifest.packageManager?.startsWith("bun@")) {
+              manager = "bun";
+            } else if (rootManifest.packageManager?.startsWith("npm@")) {
+              manager = "npm";
+            } else {
+              throw new ExternalPackageError({
+                message: `Both bun.lock and package-lock.json exist in ${current}; set packageManager to "bun@..." or "npm@...".`,
+              });
+            }
+          } else {
+            manager = hasBunLock ? "bun" : "npm";
+          }
+          if (manager === "npm") {
+            await validateNpmRegistryPackages(npmLock, normalized);
+          }
+          return {
+            manager,
+            packageRoot: path.resolve(packageRoot),
+            lockRoot: current,
+            lockfile: manager === "bun" ? bunLock : npmLock,
+            bunVersion: rootManifest.packageManager?.startsWith("bun@")
+              ? rootManifest.packageManager.slice("bun@".length)
+              : undefined,
+          };
+        }
+        const parent = path.dirname(current);
+        if (parent === current) break;
+        current = parent;
+      }
+
+      throw new ExternalPackageError({
+        message: `No bun.lock or package-lock.json found above ${packageRoot}. External Lambda packages require a frozen lockfile.`,
+      });
+    },
+    catch: (cause) =>
+      cause instanceof ExternalPackageError
+        ? cause
+        : new ExternalPackageError({
+            message: `Failed to discover external package project for ${packageRoot}`,
+            cause,
+          }),
+  });
+
+export interface ExternalPackageFile {
+  readonly path: string;
+  readonly content: Uint8Array<ArrayBufferLike>;
+  readonly mode: number;
+}
+
+export const hashExternalPackageFiles = (
+  files: readonly ExternalPackageFile[],
+) =>
+  digest(
+    [...files]
+      .sort((a, b) => a.path.localeCompare(b.path))
+      .flatMap((file) => [
+        file.path,
+        file.mode.toString(8),
+        digest([file.content]),
+      ]),
+  );
+
+export const hashLambdaDeploymentCode = (options: {
+  readonly bundleHash: string;
+  readonly externalHash: string | undefined;
+  readonly runtime: "nodejs22.x" | "nodejs24.x";
+  readonly architecture: "x86_64" | "arm64";
+}) => {
+  if (options.externalHash === undefined) return options.bundleHash;
+  return digest([
+    "lambda-external-deployment-code-v1",
+    options.bundleHash,
+    options.externalHash,
+    options.runtime,
+    options.architecture,
+  ]);
+};
+
+export const validateLambdaPackageSize = (options: {
+  readonly uncompressedSize: number;
+  readonly compressedSize: number;
+  readonly hasAssets: boolean;
+}): Effect.Effect<void, ExternalPackageError> => {
+  if (options.uncompressedSize > 250 * 1024 * 1024) {
+    return Effect.fail(
+      new ExternalPackageError({
+        message: `Lambda deployment package is ${(options.uncompressedSize / 1024 / 1024).toFixed(2)} MiB uncompressed; AWS Lambda allows at most 250 MiB including dependencies.`,
+      }),
+    );
+  }
+  if (!options.hasAssets && options.compressedSize > 50 * 1024 * 1024) {
+    return Effect.fail(
+      new ExternalPackageError({
+        message: `Lambda deployment package is ${(options.compressedSize / 1024 / 1024).toFixed(2)} MiB compressed and cannot be uploaded inline. Run "alchemy aws bootstrap" to configure the Assets bucket for S3 uploads.`,
+      }),
+    );
+  }
+  return Effect.void;
+};
+
+const isWithin = (root: string, candidate: string) => {
+  const relative = path.relative(root, candidate);
+  return (
+    relative === "" ||
+    (!relative.startsWith("..") && !path.isAbsolute(relative))
+  );
+};
+
+const findInstalledPackage = async (
+  installRoot: string,
+  fromPackage: string,
+  packageName: string,
+) => {
+  let current = fromPackage;
+  while (isWithin(installRoot, current)) {
+    const candidate = path.join(current, "node_modules", packageName);
+    if (await exists(path.join(candidate, "package.json"))) {
+      return candidate;
+    }
+    if (current === installRoot) break;
+    current = path.dirname(current);
+  }
+  return undefined;
+};
+
+export const collectExternalPackageFiles = (
+  nodeModulesRoot: string,
+  packages: readonly string[],
+): Effect.Effect<ExternalPackageFile[], ExternalPackageError> =>
+  Effect.tryPromise({
+    try: async () => {
+      const normalized = await Effect.runPromise(
+        normalizeExternalPackageNames(packages),
+      );
+      const installRoot = await realpath(
+        path.dirname(path.resolve(nodeModulesRoot)),
+      );
+      const resolvedNodeModulesRoot = path.join(installRoot, "node_modules");
+      const collected = new Map<string, ExternalPackageFile>();
+      const visitedPackages = new Set<string>();
+
+      const collectDirectory = async (
+        source: string,
+        destination: string,
+        seenDirectories: Set<string>,
+      ): Promise<void> => {
+        const canonical = await realpath(source);
+        if (!isWithin(installRoot, canonical)) {
+          throw new ExternalPackageError({
+            message: `External package path ${source} resolves outside the target install root.`,
+          });
+        }
+        if (seenDirectories.has(canonical)) return;
+        seenDirectories.add(canonical);
+        for (const entry of await readdir(source, { withFileTypes: true })) {
+          if (entry.name === "node_modules") continue;
+          const sourcePath = path.join(source, entry.name);
+          const destinationPath = path.posix.join(destination, entry.name);
+          const info = await lstat(sourcePath);
+          if (info.isSymbolicLink()) {
+            const target = await realpath(sourcePath);
+            if (!isWithin(installRoot, target)) {
+              throw new ExternalPackageError({
+                message: `External package symlink ${sourcePath} resolves outside the target install root.`,
+              });
+            }
+            const targetInfo = await lstat(target);
+            if (targetInfo.isDirectory()) {
+              await collectDirectory(target, destinationPath, seenDirectories);
+            } else if (targetInfo.isFile()) {
+              collected.set(destinationPath, {
+                path: destinationPath,
+                content: await readFile(target),
+                mode: targetInfo.mode & 0o111 ? 0o755 : 0o644,
+              });
+            }
+          } else if (info.isDirectory()) {
+            await collectDirectory(
+              sourcePath,
+              destinationPath,
+              seenDirectories,
+            );
+          } else if (info.isFile()) {
+            collected.set(destinationPath, {
+              path: destinationPath,
+              content: await readFile(sourcePath),
+              mode: info.mode & 0o111 ? 0o755 : 0o644,
+            });
+          }
+        }
+      };
+
+      const collectPackage = async (
+        packageDirectory: string,
+      ): Promise<void> => {
+        const canonical = await realpath(packageDirectory);
+        if (!isWithin(installRoot, canonical)) {
+          throw new ExternalPackageError({
+            message: `External package ${packageDirectory} resolves outside the target install root.`,
+          });
+        }
+        if (visitedPackages.has(canonical)) return;
+        visitedPackages.add(canonical);
+
+        const relative = path.relative(installRoot, packageDirectory);
+        await collectDirectory(
+          packageDirectory,
+          relative.split(path.sep).join(path.posix.sep),
+          new Set(),
+        );
+
+        const manifest = await readManifest(
+          path.join(packageDirectory, "package.json"),
+        );
+        const required = new Set([
+          ...Object.keys(manifest.dependencies ?? {}),
+          ...Object.keys(manifest.peerDependencies ?? {}).filter(
+            (name) => !manifest.peerDependenciesMeta?.[name]?.optional,
+          ),
+          ...(manifest.bundledDependencies ?? []),
+        ]);
+        const optional = new Set([
+          ...Object.keys(manifest.optionalDependencies ?? {}),
+          ...Object.keys(manifest.peerDependencies ?? {}).filter(
+            (name) => manifest.peerDependenciesMeta?.[name]?.optional,
+          ),
+        ]);
+
+        for (const dependency of [...required, ...optional].sort()) {
+          const installed = await findInstalledPackage(
+            installRoot,
+            packageDirectory,
+            dependency,
+          );
+          if (installed) {
+            await collectPackage(installed);
+          } else if (required.has(dependency)) {
+            throw new ExternalPackageError({
+              message: `Required dependency ${JSON.stringify(dependency)} of ${packageDirectory} is missing from the target install.`,
+            });
+          }
+        }
+      };
+
+      for (const packageName of normalized) {
+        const packageDirectory = path.join(
+          resolvedNodeModulesRoot,
+          packageName,
+        );
+        if (!(await exists(path.join(packageDirectory, "package.json")))) {
+          throw new ExternalPackageError({
+            message: `External package ${JSON.stringify(packageName)} was not installed for the Lambda target.`,
+          });
+        }
+        await collectPackage(packageDirectory);
+      }
+
+      return Array.from(collected.values()).sort((a, b) =>
+        a.path.localeCompare(b.path),
+      );
+    },
+    catch: (cause) =>
+      cause instanceof ExternalPackageError
+        ? cause
+        : new ExternalPackageError({
+            message: "Failed to collect external Lambda package files.",
+            cause,
+          }),
+  });
+
+export const renderExternalPackageDockerfile = (options: {
+  readonly manager: "bun" | "npm";
+  readonly runtime: "nodejs22.x" | "nodejs24.x";
+  readonly packages: readonly string[];
+  readonly bunVersion: string;
+}) => {
+  const runtimeVersion = options.runtime === "nodejs24.x" ? "24" : "22";
+  const packageNames = [...options.packages].sort().join(" ");
+  const bunStage =
+    options.manager === "bun"
+      ? [
+          `FROM --platform=$TARGETPLATFORM oven/bun:${options.bunVersion} AS bun`,
+          "",
+        ]
+      : [];
+  const install =
+    options.manager === "bun"
+      ? [
+          "COPY --from=bun /usr/local/bin/bun /usr/local/bin/bun",
+          "RUN bun install --frozen-lockfile --production --ignore-scripts --linker=hoisted",
+          // `bun pm trust` cannot discover scripts after an `--ignore-scripts`
+          // install, while npm can rebuild an existing Bun-installed package.
+          `RUN npm rebuild --foreground-scripts ${packageNames}`,
+        ]
+      : [
+          "RUN npm ci --omit=dev --ignore-scripts",
+          `RUN npm rebuild --foreground-scripts ${packageNames}`,
+        ];
+  return [
+    "# syntax=docker/dockerfile:1",
+    ...bunStage,
+    `FROM --platform=$TARGETPLATFORM public.ecr.aws/sam/build-nodejs${runtimeVersion}.x:latest AS dependencies`,
+    "WORKDIR /workspace",
+    "COPY . .",
+    ...install,
+    "",
+    "FROM scratch AS export",
+    "COPY --from=dependencies /workspace/node_modules /node_modules",
+    "",
+  ].join("\n");
+};
+
+const digest = (values: readonly (string | Uint8Array)[]) => {
+  const hash = createHash("sha256");
+  for (const value of values) {
+    hash.update(value);
+    hash.update("\0");
+  }
+  return hash.digest("hex");
+};
+
+const workspacePatterns = (manifest: PackageManifest): readonly string[] => {
+  const workspaces = manifest.workspaces;
+  if (workspaces === undefined) return [];
+  if (Array.isArray(workspaces)) return workspaces;
+  return (
+    (workspaces as { readonly packages?: readonly string[] }).packages ?? []
+  );
+};
+
+export const prepareExternalPackageBuildContext = (options: {
+  readonly project: ExternalPackageProject;
+  readonly packages: readonly string[];
+  readonly runtime: "nodejs22.x" | "nodejs24.x";
+  readonly architecture: "x86_64" | "arm64";
+  readonly bunVersion: string;
+  readonly directory: string;
+}): Effect.Effect<
+  { readonly fingerprint: string; readonly platform: string },
+  ExternalPackageError
+> =>
+  Effect.tryPromise({
+    try: async () => {
+      const packages = await Effect.runPromise(
+        normalizeExternalPackageNames(options.packages),
+      );
+      const rootManifestFile = path.join(
+        options.project.lockRoot,
+        "package.json",
+      );
+      const rootManifest = await readManifest(rootManifestFile);
+      const patterns = workspacePatterns(rootManifest).map((pattern) =>
+        path.posix.join(pattern.replaceAll("\\", "/"), "package.json"),
+      );
+      const workspaceManifests = patterns.length
+        ? await fg(patterns, {
+            cwd: options.project.lockRoot,
+            onlyFiles: true,
+            dot: true,
+          })
+        : [];
+      const packageManifestRelative = path.relative(
+        options.project.lockRoot,
+        path.join(options.project.packageRoot, "package.json"),
+      );
+      const manifestRelatives = Array.from(
+        new Set([
+          "package.json",
+          packageManifestRelative,
+          ...workspaceManifests,
+        ]),
+      ).sort();
+      const canonicalLockRoot = await realpath(options.project.lockRoot);
+
+      await mkdir(options.directory, { recursive: true });
+      const fingerprintInputs: Array<string | Uint8Array> = [
+        "lambda-external-packages-v1",
+        options.project.manager,
+        options.runtime,
+        options.architecture,
+        options.bunVersion,
+        JSON.stringify(packages),
+      ];
+      for (const relative of manifestRelatives) {
+        const source = path.resolve(options.project.lockRoot, relative);
+        const canonicalSource = await realpath(source);
+        if (
+          !isWithin(options.project.lockRoot, source) ||
+          !isWithin(canonicalLockRoot, canonicalSource)
+        ) {
+          throw new ExternalPackageError({
+            message: `Workspace manifest ${source} resolves outside the lockfile root.`,
+          });
+        }
+        const raw = await readFile(source);
+        fingerprintInputs.push(relative, raw);
+        const manifest = JSON.parse(raw.toString("utf8")) as Record<
+          string,
+          unknown
+        >;
+        delete manifest.scripts;
+        delete manifest.trustedDependencies;
+        const target = path.join(options.directory, relative);
+        await mkdir(path.dirname(target), { recursive: true });
+        await writeFile(target, `${JSON.stringify(manifest, null, 2)}\n`);
+      }
+
+      const lockContent = await readFile(options.project.lockfile);
+      fingerprintInputs.push(
+        path.basename(options.project.lockfile),
+        lockContent,
+      );
+      await writeFile(
+        path.join(options.directory, path.basename(options.project.lockfile)),
+        lockContent,
+      );
+      await writeFile(
+        path.join(options.directory, "Dockerfile"),
+        renderExternalPackageDockerfile({
+          manager: options.project.manager,
+          runtime: options.runtime,
+          packages,
+          bunVersion: options.bunVersion,
+        }),
+      );
+
+      return {
+        fingerprint: digest(fingerprintInputs),
+        platform:
+          options.architecture === "arm64" ? "linux/arm64" : "linux/amd64",
+      };
+    },
+    catch: (cause) =>
+      cause instanceof ExternalPackageError
+        ? cause
+        : new ExternalPackageError({
+            message: "Failed to prepare external Lambda package build context.",
+            cause,
+          }),
+  });
+
+interface ExternalPackageCacheManifest {
+  readonly hash: string;
+  readonly size: number;
+  readonly files: ReadonlyArray<{
+    readonly path: string;
+    readonly mode: number;
+    readonly hash: string;
+    readonly size: number;
+  }>;
+}
+
+const readCachedExternalPackages = async (
+  cacheDirectory: string,
+): Promise<{
+  files: ExternalPackageFile[];
+  hash: string;
+  size: number;
+}> => {
+  const manifest = JSON.parse(
+    await readFile(path.join(cacheDirectory, "manifest.json"), "utf8"),
+  ) as ExternalPackageCacheManifest;
+  const files: ExternalPackageFile[] = [];
+  const paths = new Set<string>();
+  let size = 0;
+  for (const entry of manifest.files) {
+    if (
+      !entry.path.startsWith("node_modules/") ||
+      path.posix.normalize(entry.path) !== entry.path ||
+      entry.path.includes("\\") ||
+      paths.has(entry.path) ||
+      (entry.mode !== 0o644 && entry.mode !== 0o755)
+    ) {
+      throw new Error(`Unsafe cached external package path ${entry.path}`);
+    }
+    paths.add(entry.path);
+    const content = await readFile(
+      path.join(cacheDirectory, "files", ...entry.path.split("/")),
+    );
+    if (digest([content]) !== entry.hash) {
+      throw new Error(`Corrupt cached external package file ${entry.path}`);
+    }
+    files.push({ path: entry.path, content, mode: entry.mode });
+    size += content.byteLength;
+  }
+  files.sort((a, b) => a.path.localeCompare(b.path));
+  if (hashExternalPackageFiles(files) !== manifest.hash) {
+    throw new Error("Corrupt external package cache manifest");
+  }
+  if (size !== manifest.size) {
+    throw new Error("Corrupt external package cache size");
+  }
+  return { files, hash: manifest.hash, size };
+};
+
+const writeExternalPackageCache = async (
+  cacheDirectory: string,
+  files: readonly ExternalPackageFile[],
+) => {
+  const manifest: ExternalPackageCacheManifest = {
+    hash: hashExternalPackageFiles(files),
+    size: files.reduce((total, file) => total + file.content.byteLength, 0),
+    files: files.map((file) => ({
+      path: file.path,
+      mode: file.mode,
+      hash: digest([file.content]),
+      size: file.content.byteLength,
+    })),
+  };
+  for (const file of files) {
+    const target = path.join(cacheDirectory, "files", ...file.path.split("/"));
+    await mkdir(path.dirname(target), { recursive: true });
+    await writeFile(target, file.content);
+    await chmod(target, file.mode);
+  }
+  await writeFile(
+    path.join(cacheDirectory, "manifest.json"),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
+  return manifest;
+};
+
+export interface MaterializedExternalPackages {
+  readonly files: ExternalPackageFile[];
+  readonly hash: string;
+  readonly size: number;
+  readonly cacheHit: boolean;
+}
+
+const installedBunVersion = Effect.tryPromise({
+  try: () =>
+    new Promise<string>((resolve, reject) => {
+      execFile("bun", ["--version"], (error, stdout) => {
+        if (error) reject(error);
+        else resolve(stdout.trim());
+      });
+    }),
+  catch: (cause) =>
+    new ExternalPackageError({
+      message: "Failed to determine the installed Bun version.",
+      cause,
+    }),
+});
+
+const bunVersionPattern = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/;
+
+export const materializeExternalPackages = Effect.fnUntraced(
+  function* (options: {
+    readonly packageRoot: string;
+    readonly packages: readonly string[];
+    readonly runtime: "nodejs22.x" | "nodejs24.x";
+    readonly architecture: "x86_64" | "arm64";
+    readonly cacheDirectory: string;
+    readonly bunVersion: string | undefined;
+    readonly note?: (message: string) => Effect.Effect<void>;
+  }) {
+    const packages = yield* normalizeExternalPackageNames(options.packages);
+    const project = yield* discoverExternalPackageProject(
+      options.packageRoot,
+      packages,
+    );
+    let bunVersion = options.bunVersion;
+    if (project.manager === "bun" && bunVersion === undefined) {
+      bunVersion = yield* installedBunVersion.pipe(
+        Effect.catch(() => Effect.succeed(project.bunVersion)),
+      );
+    }
+    if (
+      project.manager === "bun" &&
+      (bunVersion === undefined || !bunVersionPattern.test(bunVersion))
+    ) {
+      return yield* new ExternalPackageError({
+        message: `Unable to select a safe Bun version for Lambda dependency packaging${bunVersion ? `: ${JSON.stringify(bunVersion)}` : "."}`,
+      });
+    }
+    bunVersion ??= "not-used";
+
+    yield* Effect.tryPromise({
+      try: () => mkdir(options.cacheDirectory, { recursive: true }),
+      catch: (cause) =>
+        new ExternalPackageError({
+          message: `Failed to create external package cache ${options.cacheDirectory}`,
+          cause,
+        }),
+    });
+
+    return yield* Effect.acquireUseRelease(
+      Effect.tryPromise({
+        try: () => mkdtemp(path.join(options.cacheDirectory, "build-")),
+        catch: (cause) =>
+          new ExternalPackageError({
+            message: "Failed to create external package build directory.",
+            cause,
+          }),
+      }),
+      (temporaryDirectory) =>
+        Effect.gen(function* () {
+          const contextDirectory = path.join(temporaryDirectory, "context");
+          const prepared = yield* prepareExternalPackageBuildContext({
+            project,
+            packages,
+            runtime: options.runtime,
+            architecture: options.architecture,
+            bunVersion,
+            directory: contextDirectory,
+          });
+          const cacheDirectory = path.join(
+            options.cacheDirectory,
+            prepared.fingerprint,
+          );
+
+          const cached = yield* Effect.tryPromise({
+            try: () => readCachedExternalPackages(cacheDirectory),
+            catch: (cause) => cause,
+          }).pipe(Effect.catch(() => Effect.succeed(undefined)));
+          if (cached) {
+            if (options.note) {
+              yield* options.note(
+                `Using cached Lambda packages: ${packages.join(", ")}`,
+              );
+            }
+            return { ...cached, cacheHit: true };
+          }
+
+          yield* Effect.tryPromise({
+            try: () => rm(cacheDirectory, { recursive: true, force: true }),
+            catch: (cause) =>
+              new ExternalPackageError({
+                message: "Failed to remove an invalid Lambda package cache.",
+                cause,
+              }),
+          });
+
+          if (options.note) {
+            yield* options.note(
+              `Installing Lambda packages for ${prepared.platform}: ${packages.join(", ")}`,
+            );
+          }
+          const outputDirectory = path.join(temporaryDirectory, "output");
+          yield* Effect.tryPromise({
+            try: () => mkdir(outputDirectory, { recursive: true }),
+            catch: (cause) =>
+              new ExternalPackageError({
+                message: "Failed to create Docker package output directory.",
+                cause,
+              }),
+          });
+          yield* runDockerCommand(
+            [
+              "build",
+              "--platform",
+              prepared.platform,
+              "--target",
+              "export",
+              "--output",
+              `type=local,dest=${outputDirectory}`,
+              contextDirectory,
+            ],
+            { env: { DOCKER_BUILDKIT: "1" } },
+          ).pipe(
+            Effect.mapError(
+              (cause) =>
+                new ExternalPackageError({
+                  message:
+                    "Failed to build external Lambda packages with Docker. Ensure Docker with BuildKit and the target architecture emulator are available.",
+                  cause,
+                }),
+            ),
+            Effect.tapError((error) =>
+              options.note
+                ? options.note(
+                    `Lambda package installation failed: ${error.message}`,
+                  )
+                : Effect.void,
+            ),
+          );
+
+          const files = yield* collectExternalPackageFiles(
+            path.join(outputDirectory, "node_modules"),
+            packages,
+          );
+          const stagingCache = path.join(
+            options.cacheDirectory,
+            `.staging-${prepared.fingerprint}-${randomUUID()}`,
+          );
+          const manifest = yield* Effect.tryPromise({
+            try: () => writeExternalPackageCache(stagingCache, files),
+            catch: (cause) =>
+              new ExternalPackageError({
+                message: "Failed to write external Lambda package cache.",
+                cause,
+              }),
+          });
+          yield* Effect.tryPromise({
+            try: async () => {
+              try {
+                await rename(stagingCache, cacheDirectory);
+              } catch (cause) {
+                if (!(await exists(cacheDirectory))) {
+                  throw cause;
+                }
+                await rm(stagingCache, { recursive: true, force: true });
+              }
+            },
+            catch: (cause) =>
+              new ExternalPackageError({
+                message: "Failed to publish external Lambda package cache.",
+                cause,
+              }),
+          });
+          return {
+            files,
+            hash: manifest.hash,
+            size: manifest.size,
+            cacheHit: false,
+          } satisfies MaterializedExternalPackages;
+        }),
+      (temporaryDirectory) =>
+        Effect.tryPromise(() =>
+          rm(temporaryDirectory, { recursive: true, force: true }),
+        ).pipe(Effect.ignore),
+    );
+  },
+);

--- a/packages/alchemy/src/Bundle/index.ts
+++ b/packages/alchemy/src/Bundle/index.ts
@@ -1,6 +1,7 @@
 export * from "./Bundle.ts";
 export * from "./BundleAnalyzerPlugin.ts";
 export * from "./Docker.ts";
+export * from "./ExternalPackages.ts";
 export * from "./PurePlugin.ts";
 export * from "./RawPlugin.ts";
 export * from "./TempRoot.ts";

--- a/packages/alchemy/src/Util/zip.ts
+++ b/packages/alchemy/src/Util/zip.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 export interface ZipFile {
   path: string;
   content: string | Uint8Array<ArrayBufferLike>;
+  mode?: number;
 }
 
 export const zipCode = Effect.fn(function* (
@@ -14,7 +15,10 @@ export const zipCode = Effect.fn(function* (
   const date = new Date("1980-01-01T00:00:00.000Z");
   zip.file("index.mjs", content, { date });
   for (const file of files ?? []) {
-    zip.file(file.path, file.content, { date });
+    zip.file(file.path, file.content, {
+      date,
+      unixPermissions: file.mode,
+    });
   }
 
   return yield* Effect.promise(() =>

--- a/packages/alchemy/test/AWS/Lambda/Function.test.ts
+++ b/packages/alchemy/test/AWS/Lambda/Function.test.ts
@@ -7,10 +7,17 @@ import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";
 import * as HttpClient from "effect/unstable/http/HttpClient";
+import { fileURLToPath } from "node:url";
 import { TestFunction, TestFunctionLive } from "./handler.ts";
 
 const timeoutHandlerPath = new URL("./timeout-handler.ts", import.meta.url)
   .pathname;
+const nativePackagesHandlerPath = fileURLToPath(
+  new URL(
+    "../../Bundle/fixtures/external-packages-bun/handler.mjs",
+    import.meta.url,
+  ),
+);
 
 const { test } = Test.make({ providers: AWS.providers() });
 
@@ -143,6 +150,57 @@ test.provider(
       Effect.onError(() => stack.destroy().pipe(Effect.ignore)),
     ),
   { timeout: 360_000 },
+);
+
+test.provider.skipIf(process.env.ALCHEMY_TEST_LAMBDA_EXTERNAL_PACKAGES !== "1")(
+  "runs Sharp and FFmpeg in an ARM64 Lambda",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const fn = yield* stack.deploy(
+        AWS.Lambda.Function<{}>()("NativePackagesArm64Fn", {
+          main: nativePackagesHandlerPath,
+          handler: "handler",
+          isExternal: true,
+          url: true,
+          runtime: "nodejs22.x",
+          architecture: "arm64",
+          build: {
+            externalPackages: ["sharp", "ffmpeg-static"],
+          },
+        }),
+      );
+
+      const response = yield* HttpClient.get(fn.functionUrl!).pipe(
+        Effect.flatMap((response) =>
+          response.status === 200
+            ? Effect.succeed(response)
+            : Effect.fail(
+                new Error(`Function URL returned ${response.status}`),
+              ),
+        ),
+        Effect.retry({
+          schedule: Schedule.exponential(500).pipe(
+            Schedule.both(Schedule.recurs(8)),
+          ),
+        }),
+      );
+      const result = JSON.parse(yield* response.text) as {
+        architecture: string;
+        imageBytes: number;
+        ffmpegStatus: number;
+        ffmpegVersion: string;
+      };
+      expect(result.architecture).toBe("arm64");
+      expect(result.imageBytes).toBeGreaterThan(0);
+      expect(result.ffmpegStatus).toBe(0);
+      expect(result.ffmpegVersion).toContain("ffmpeg version");
+    }).pipe(
+      Effect.tap(() => stack.destroy()),
+      Effect.onError(() => stack.destroy().pipe(Effect.ignore)),
+    ),
+  { timeout: 120_000 },
 );
 
 test.provider(

--- a/packages/alchemy/test/Bundle/ExternalPackages.test.ts
+++ b/packages/alchemy/test/Bundle/ExternalPackages.test.ts
@@ -8,6 +8,7 @@ import {
   materializeExternalPackages,
   normalizeExternalPackageNames,
   prepareExternalPackageBuildContext,
+  renderExternalPackageCollector,
   renderExternalPackageDockerfile,
   validateLambdaPackageSize,
 } from "@/Bundle/ExternalPackages";
@@ -16,6 +17,7 @@ import * as Effect from "effect/Effect";
 import * as Result from "effect/Result";
 import { spawnSync } from "node:child_process";
 import {
+  access,
   chmod,
   mkdtemp,
   mkdir,
@@ -23,6 +25,7 @@ import {
   rm,
   symlink,
   unlink,
+  utimes,
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -250,6 +253,65 @@ describe("external Lambda packages", () => {
     }
   });
 
+  it("prunes a hoisted install to the selected runtime closure before export", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "alchemy-external-prune-"));
+    try {
+      const nodeModules = path.join(root, "node_modules");
+      const output = path.join(root, "output");
+      const selected = path.join(nodeModules, "selected");
+      const runtime = path.join(nodeModules, "runtime");
+      const devOnly = path.join(nodeModules, "dev-only");
+      const unrelated = path.join(nodeModules, "unrelated");
+      await Promise.all(
+        [selected, runtime, devOnly, unrelated].map((directory) =>
+          mkdir(directory, { recursive: true }),
+        ),
+      );
+      await writeFile(
+        path.join(selected, "package.json"),
+        JSON.stringify({
+          dependencies: { runtime: "1.0.0" },
+          devDependencies: { "dev-only": "1.0.0" },
+        }),
+      );
+      await writeFile(path.join(selected, "index.js"), "selected");
+      await writeFile(path.join(runtime, "package.json"), "{}");
+      await writeFile(path.join(runtime, "index.js"), "runtime");
+      await writeFile(path.join(devOnly, "package.json"), "{}");
+      await writeFile(path.join(unrelated, "package.json"), "{}");
+      await writeFile(path.join(unrelated, "large.bin"), new Uint8Array(1024));
+
+      const collector = path.join(root, "collector.mjs");
+      await writeFile(collector, renderExternalPackageCollector(["selected"]));
+      const result = spawnSync(process.execPath, [collector, root, output], {
+        encoding: "utf8",
+      });
+
+      expect(result.stderr).toBe("");
+      expect(result.status).toBe(0);
+      expect(
+        await readFile(
+          path.join(output, "node_modules/selected/index.js"),
+          "utf8",
+        ),
+      ).toBe("selected");
+      expect(
+        await readFile(
+          path.join(output, "node_modules/runtime/index.js"),
+          "utf8",
+        ),
+      ).toBe("runtime");
+      await expect(
+        access(path.join(output, "node_modules/dev-only")),
+      ).rejects.toThrow();
+      await expect(
+        access(path.join(output, "node_modules/unrelated")),
+      ).rejects.toThrow();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("rejects package symlinks that escape the install root", async () => {
     const root = await mkdtemp(path.join(tmpdir(), "alchemy-external-link-"));
     const outside = await mkdtemp(
@@ -364,6 +426,103 @@ describe("external Lambda packages", () => {
       await expect(readFile(path.join(context, ".npmrc"))).rejects.toThrow();
       expect(prepared.platform).toBe("linux/arm64");
       expect(prepared.fingerprint).toHaveLength(64);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("coalesces concurrent materializations for the same cache key", async () => {
+    const root = await mkdtemp(
+      path.join(tmpdir(), "alchemy-external-concurrent-"),
+    );
+    try {
+      await writeFile(
+        path.join(root, "package.json"),
+        JSON.stringify({ dependencies: { selected: "1.0.0" } }),
+      );
+      await writeFile(path.join(root, "bun.lock"), "{}\n");
+      let builds = 0;
+      const options = {
+        packageRoot: root,
+        packages: ["selected"],
+        runtime: "nodejs22.x" as const,
+        architecture: "arm64" as const,
+        cacheDirectory: path.join(root, "cache"),
+        bunVersion: "1.3.14",
+        build: ({ outputDirectory }: { outputDirectory: string }) =>
+          Effect.promise(async () => {
+            builds += 1;
+            await new Promise((resolve) => setTimeout(resolve, 50));
+            const selected = path.join(
+              outputDirectory,
+              "node_modules/selected",
+            );
+            await mkdir(selected, { recursive: true });
+            await writeFile(path.join(selected, "package.json"), "{}");
+            await writeFile(path.join(selected, "index.js"), "selected");
+          }),
+      };
+
+      const [first, second] = await Effect.runPromise(
+        Effect.all(
+          [
+            materializeExternalPackages(options),
+            materializeExternalPackages(options),
+          ],
+          { concurrency: "unbounded" },
+        ).pipe(Effect.provide(NodeServices.layer), Effect.scoped),
+      );
+      expect(builds).toBe(1);
+      expect(first.hash).toBe(second.hash);
+
+      const cached = await Effect.runPromise(
+        materializeExternalPackages(options).pipe(
+          Effect.provide(NodeServices.layer),
+          Effect.scoped,
+        ),
+      );
+      expect(builds).toBe(1);
+      expect(cached.cacheHit).toBe(true);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("removes abandoned external-package build directories", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "alchemy-external-stale-"));
+    try {
+      const cacheDirectory = path.join(root, "cache");
+      const abandoned = path.join(cacheDirectory, "build-abandoned");
+      await mkdir(abandoned, { recursive: true });
+      const old = new Date(Date.now() - 60 * 60 * 1000);
+      await utimes(abandoned, old, old);
+      await writeFile(
+        path.join(root, "package.json"),
+        JSON.stringify({ dependencies: { selected: "1.0.0" } }),
+      );
+      await writeFile(path.join(root, "bun.lock"), "{}\n");
+
+      await Effect.runPromise(
+        materializeExternalPackages({
+          packageRoot: root,
+          packages: ["selected"],
+          runtime: "nodejs22.x",
+          architecture: "arm64",
+          cacheDirectory,
+          bunVersion: "1.3.14",
+          build: ({ outputDirectory }) =>
+            Effect.promise(async () => {
+              const selected = path.join(
+                outputDirectory,
+                "node_modules/selected",
+              );
+              await mkdir(selected, { recursive: true });
+              await writeFile(path.join(selected, "package.json"), "{}");
+            }),
+        }).pipe(Effect.provide(NodeServices.layer), Effect.scoped),
+      );
+
+      await expect(access(abandoned)).rejects.toThrow();
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/packages/alchemy/test/Bundle/ExternalPackages.test.ts
+++ b/packages/alchemy/test/Bundle/ExternalPackages.test.ts
@@ -1,0 +1,538 @@
+import { runDockerCommand } from "@/Bundle/Docker";
+import {
+  collectExternalPackageFiles,
+  discoverExternalPackageProject,
+  externalPackagePredicate,
+  hashExternalPackageFiles,
+  hashLambdaDeploymentCode,
+  materializeExternalPackages,
+  normalizeExternalPackageNames,
+  prepareExternalPackageBuildContext,
+  renderExternalPackageDockerfile,
+  validateLambdaPackageSize,
+} from "@/Bundle/ExternalPackages";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import * as Effect from "effect/Effect";
+import * as Result from "effect/Result";
+import { spawnSync } from "node:child_process";
+import {
+  chmod,
+  mkdtemp,
+  mkdir,
+  readFile,
+  rm,
+  symlink,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const dockerIntegrationEnabled =
+  process.env.ALCHEMY_TEST_LAMBDA_EXTERNAL_PACKAGES === "1" &&
+  spawnSync("docker", ["info"], { stdio: "ignore" }).status === 0;
+const fixtureRoot = fileURLToPath(new URL("./fixtures", import.meta.url));
+
+describe("external Lambda packages", () => {
+  it("accepts package roots, removes duplicates, and externalizes subpaths", async () => {
+    const packages = await Effect.runPromise(
+      normalizeExternalPackageNames(["sharp", "@img/tool", "sharp"]),
+    );
+
+    expect(packages).toEqual(["@img/tool", "sharp"]);
+
+    const isExternal = externalPackagePredicate(packages);
+    expect(isExternal("sharp")).toBe(true);
+    expect(isExternal("sharp/lib/index.js")).toBe(true);
+    expect(isExternal("@img/tool/subpath")).toBe(true);
+    expect(isExternal("sharpish")).toBe(false);
+  });
+
+  it("rejects versions and package subpaths", async () => {
+    for (const name of ["sharp@1.0.0", "sharp/lib", "@img/tool/subpath"]) {
+      const result = await Effect.runPromise(
+        Effect.result(normalizeExternalPackageNames([name])),
+      );
+      expect(Result.isFailure(result)).toBe(true);
+    }
+  });
+
+  it("discovers a Bun workspace and validates runtime dependencies", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "alchemy-external-"));
+    try {
+      const workspace = path.join(root, "packages", "app");
+      await mkdir(workspace, { recursive: true });
+      await writeFile(
+        path.join(root, "package.json"),
+        JSON.stringify({
+          workspaces: ["packages/*"],
+          packageManager: "bun@1.3.14",
+        }),
+      );
+      await writeFile(path.join(root, "bun.lock"), "{}\n");
+      await writeFile(
+        path.join(root, ".npmrc"),
+        "//registry.npmjs.org/:_authToken=secret\n",
+      );
+      await writeFile(
+        path.join(workspace, "package.json"),
+        JSON.stringify({ dependencies: { sharp: "0.34.5" } }),
+      );
+
+      const project = await Effect.runPromise(
+        discoverExternalPackageProject(workspace, ["sharp"]),
+      );
+      expect(project.manager).toBe("bun");
+      expect(project.lockRoot).toBe(root);
+      expect(project.packageRoot).toBe(workspace);
+
+      const missing = await Effect.runPromise(
+        Effect.result(
+          discoverExternalPackageProject(workspace, ["ffmpeg-static"]),
+        ),
+      );
+      expect(Result.isFailure(missing)).toBe(true);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves ambiguous locks with packageManager and rejects remote specs", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "alchemy-external-locks-"));
+    try {
+      await writeFile(
+        path.join(root, "package.json"),
+        JSON.stringify({ dependencies: { sharp: "0.34.5" } }),
+      );
+      await writeFile(path.join(root, "bun.lock"), "{}\n");
+      await writeFile(path.join(root, "package-lock.json"), "{}\n");
+
+      const ambiguous = await Effect.runPromise(
+        Effect.result(discoverExternalPackageProject(root, ["sharp"])),
+      );
+      expect(Result.isFailure(ambiguous)).toBe(true);
+
+      await writeFile(
+        path.join(root, "package.json"),
+        JSON.stringify({
+          packageManager: "npm@11.0.0",
+          dependencies: { sharp: "0.34.5" },
+        }),
+      );
+      const npmProject = await Effect.runPromise(
+        discoverExternalPackageProject(root, ["sharp"]),
+      );
+      expect(npmProject.manager).toBe("npm");
+
+      await writeFile(
+        path.join(root, "package.json"),
+        JSON.stringify({
+          packageManager: "npm@11.0.0",
+          dependencies: { sharp: "https://registry.example.com/sharp.tgz" },
+        }),
+      );
+      const remote = await Effect.runPromise(
+        Effect.result(discoverExternalPackageProject(root, ["sharp"])),
+      );
+      expect(Result.isFailure(remote)).toBe(true);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("discovers npm workspaces, rejects private registries, and requires a lock", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "alchemy-external-npm-"));
+    try {
+      const workspace = path.join(root, "packages", "app");
+      await mkdir(workspace, { recursive: true });
+      await writeFile(
+        path.join(root, "package.json"),
+        JSON.stringify({ workspaces: ["packages/*"] }),
+      );
+      await writeFile(
+        path.join(workspace, "package.json"),
+        JSON.stringify({ dependencies: { sharp: "0.34.5" } }),
+      );
+      await writeFile(
+        path.join(root, "package-lock.json"),
+        JSON.stringify({
+          lockfileVersion: 3,
+          packages: {
+            "node_modules/sharp": {
+              resolved: "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+            },
+          },
+        }),
+      );
+
+      const project = await Effect.runPromise(
+        discoverExternalPackageProject(workspace, ["sharp"]),
+      );
+      expect(project.manager).toBe("npm");
+      expect(project.lockRoot).toBe(root);
+
+      await writeFile(
+        path.join(root, "package-lock.json"),
+        JSON.stringify({
+          lockfileVersion: 3,
+          packages: {
+            "node_modules/sharp": {
+              resolved: "https://npm.internal.example/sharp.tgz",
+            },
+          },
+        }),
+      );
+      const privateRegistry = await Effect.runPromise(
+        Effect.result(discoverExternalPackageProject(workspace, ["sharp"])),
+      );
+      expect(Result.isFailure(privateRegistry)).toBe(true);
+
+      await unlink(path.join(root, "package-lock.json"));
+      const missingLock = await Effect.runPromise(
+        Effect.result(discoverExternalPackageProject(workspace, ["sharp"])),
+      );
+      expect(Result.isFailure(missingLock)).toBe(true);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("collects runtime dependency closures and preserves executables", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "alchemy-external-files-"));
+    try {
+      const nodeModules = path.join(root, "node_modules");
+      const sharp = path.join(nodeModules, "sharp");
+      const runtimeDep = path.join(nodeModules, "runtime-dep");
+      const runtimePeer = path.join(nodeModules, "runtime-peer");
+      const installedOptional = path.join(nodeModules, "installed-optional");
+      await mkdir(path.join(sharp, "bin"), { recursive: true });
+      await mkdir(runtimeDep, { recursive: true });
+      await mkdir(runtimePeer, { recursive: true });
+      await mkdir(installedOptional, { recursive: true });
+      await writeFile(
+        path.join(sharp, "package.json"),
+        JSON.stringify({
+          dependencies: { "runtime-dep": "1.0.0" },
+          optionalDependencies: {
+            "installed-optional": "1.0.0",
+            "missing-optional": "1.0.0",
+          },
+          peerDependencies: { "runtime-peer": "1.0.0" },
+          devDependencies: { "dev-only": "1.0.0" },
+        }),
+      );
+      await writeFile(path.join(runtimeDep, "package.json"), "{}");
+      await writeFile(path.join(runtimeDep, "index.js"), "export default 1");
+      await writeFile(path.join(runtimePeer, "package.json"), "{}");
+      await writeFile(path.join(installedOptional, "package.json"), "{}");
+      const executable = path.join(sharp, "bin", "sharp-tool");
+      await writeFile(executable, "#!/bin/sh\n");
+      await chmod(executable, 0o755);
+
+      const files = await Effect.runPromise(
+        collectExternalPackageFiles(nodeModules, ["sharp"]),
+      );
+      expect(files.map((file) => file.path)).toEqual([
+        "node_modules/installed-optional/package.json",
+        "node_modules/runtime-dep/index.js",
+        "node_modules/runtime-dep/package.json",
+        "node_modules/runtime-peer/package.json",
+        "node_modules/sharp/bin/sharp-tool",
+        "node_modules/sharp/package.json",
+      ]);
+      expect(files.find((file) => file.path.endsWith("sharp-tool"))?.mode).toBe(
+        0o755,
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects package symlinks that escape the install root", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "alchemy-external-link-"));
+    const outside = await mkdtemp(
+      path.join(tmpdir(), "alchemy-external-outside-"),
+    );
+    try {
+      const sharp = path.join(root, "node_modules", "sharp");
+      await mkdir(sharp, { recursive: true });
+      await writeFile(path.join(sharp, "package.json"), "{}");
+      const outsideFile = path.join(outside, "secret.txt");
+      await writeFile(outsideFile, "outside");
+      await symlink(outsideFile, path.join(sharp, "escape"));
+
+      const result = await Effect.runPromise(
+        Effect.result(
+          collectExternalPackageFiles(path.join(root, "node_modules"), [
+            "sharp",
+          ]),
+        ),
+      );
+      expect(Result.isFailure(result)).toBe(true);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+
+  it("renders target installs with scripts limited to selected packages", () => {
+    const bunDockerfile = renderExternalPackageDockerfile({
+      manager: "bun",
+      runtime: "nodejs22.x",
+      packages: ["ffmpeg-static", "sharp"],
+      bunVersion: "1.3.14",
+    });
+    expect(bunDockerfile).toContain(
+      "FROM --platform=$TARGETPLATFORM public.ecr.aws/sam/build-nodejs22.x:latest AS dependencies",
+    );
+    expect(bunDockerfile).toContain(
+      "bun install --frozen-lockfile --production --ignore-scripts --linker=hoisted",
+    );
+    expect(bunDockerfile).toContain(
+      "npm rebuild --foreground-scripts ffmpeg-static sharp",
+    );
+    expect(bunDockerfile).not.toContain("bun pm trust");
+
+    const npmDockerfile = renderExternalPackageDockerfile({
+      manager: "npm",
+      runtime: "nodejs24.x",
+      packages: ["sharp"],
+      bunVersion: "unused",
+    });
+    expect(npmDockerfile).toContain(
+      "FROM --platform=$TARGETPLATFORM public.ecr.aws/sam/build-nodejs24.x:latest AS dependencies",
+    );
+    expect(npmDockerfile).toContain("npm ci --omit=dev --ignore-scripts");
+    expect(npmDockerfile).toContain("npm rebuild --foreground-scripts sharp");
+  });
+
+  it("creates a manifest-only Docker context without project scripts", async () => {
+    const root = await mkdtemp(
+      path.join(tmpdir(), "alchemy-external-context-"),
+    );
+    try {
+      const workspace = path.join(root, "packages", "app");
+      const context = path.join(root, "context");
+      await mkdir(workspace, { recursive: true });
+      await writeFile(
+        path.join(root, "package.json"),
+        JSON.stringify({
+          workspaces: ["packages/*"],
+          packageManager: "bun@1.3.14",
+          scripts: { prepare: "should-not-run" },
+        }),
+      );
+      await writeFile(path.join(root, "bun.lock"), "{}\n");
+      await writeFile(
+        path.join(workspace, "package.json"),
+        JSON.stringify({
+          dependencies: { sharp: "0.34.5" },
+          scripts: { postinstall: "should-not-run" },
+        }),
+      );
+      const project = await Effect.runPromise(
+        discoverExternalPackageProject(workspace, ["sharp"]),
+      );
+
+      const prepared = await Effect.runPromise(
+        prepareExternalPackageBuildContext({
+          project,
+          packages: ["sharp"],
+          runtime: "nodejs22.x",
+          architecture: "arm64",
+          bunVersion: "1.3.14",
+          directory: context,
+        }),
+      );
+
+      const copiedRoot = JSON.parse(
+        await readFile(path.join(context, "package.json"), "utf8"),
+      );
+      const copiedWorkspace = JSON.parse(
+        await readFile(
+          path.join(context, "packages", "app", "package.json"),
+          "utf8",
+        ),
+      );
+      expect(copiedRoot.scripts).toBeUndefined();
+      expect(copiedWorkspace.scripts).toBeUndefined();
+      expect(await readFile(path.join(context, "bun.lock"), "utf8")).toBe(
+        "{}\n",
+      );
+      await expect(readFile(path.join(context, ".npmrc"))).rejects.toThrow();
+      expect(prepared.platform).toBe("linux/arm64");
+      expect(prepared.fingerprint).toHaveLength(64);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("hashes external package contents and executable modes", () => {
+    const base = [
+      {
+        path: "node_modules/tool/bin/tool",
+        content: new Uint8Array([1, 2, 3]),
+        mode: 0o755,
+      },
+    ];
+    expect(hashExternalPackageFiles(base)).toBe(
+      hashExternalPackageFiles([...base]),
+    );
+    expect(hashExternalPackageFiles(base)).not.toBe(
+      hashExternalPackageFiles([{ ...base[0], mode: 0o644 }]),
+    );
+    expect(hashExternalPackageFiles(base)).not.toBe(
+      hashExternalPackageFiles([
+        { ...base[0], content: new Uint8Array([1, 2, 4]) },
+      ]),
+    );
+  });
+
+  it("includes runtime and architecture in dependency deployment hashes", () => {
+    const hash = (
+      runtime: "nodejs22.x" | "nodejs24.x",
+      architecture: "x86_64" | "arm64",
+    ) =>
+      hashLambdaDeploymentCode({
+        bundleHash: "bundle",
+        externalHash: "external",
+        runtime,
+        architecture,
+      });
+
+    expect(hash("nodejs22.x", "arm64")).not.toBe(hash("nodejs22.x", "x86_64"));
+    expect(hash("nodejs22.x", "arm64")).not.toBe(hash("nodejs24.x", "arm64"));
+    expect(
+      hashLambdaDeploymentCode({
+        bundleHash: "original-bundle-hash",
+        externalHash: undefined,
+        runtime: "nodejs24.x",
+        architecture: "arm64",
+      }),
+    ).toBe("original-bundle-hash");
+  });
+
+  it("enforces Lambda zip size limits before upload", async () => {
+    const tooLargeUnpacked = await Effect.runPromise(
+      Effect.result(
+        validateLambdaPackageSize({
+          uncompressedSize: 250 * 1024 * 1024 + 1,
+          compressedSize: 1,
+          hasAssets: true,
+        }),
+      ),
+    );
+    expect(Result.isFailure(tooLargeUnpacked)).toBe(true);
+
+    const needsAssets = await Effect.runPromise(
+      Effect.result(
+        validateLambdaPackageSize({
+          uncompressedSize: 100 * 1024 * 1024,
+          compressedSize: 50 * 1024 * 1024 + 1,
+          hasAssets: false,
+        }),
+      ),
+    );
+    expect(Result.isFailure(needsAssets)).toBe(true);
+
+    await expect(
+      Effect.runPromise(
+        validateLambdaPackageSize({
+          uncompressedSize: 100 * 1024 * 1024,
+          compressedSize: 50 * 1024 * 1024 + 1,
+          hasAssets: true,
+        }),
+      ),
+    ).resolves.toBeUndefined();
+  });
+});
+
+const verifyNativeFixture = async (manager: "bun" | "npm") => {
+  const root = await mkdtemp(path.join(tmpdir(), `alchemy-${manager}-native-`));
+  try {
+    const taskDirectory = path.join(root, "task");
+    const materialized = await Effect.runPromise(
+      materializeExternalPackages({
+        packageRoot: path.join(fixtureRoot, `external-packages-${manager}`),
+        packages: ["sharp", "ffmpeg-static"],
+        runtime: "nodejs22.x",
+        architecture: "arm64",
+        cacheDirectory: path.join(root, "cache"),
+        bunVersion: process.versions.bun,
+      }).pipe(Effect.provide(NodeServices.layer), Effect.scoped),
+    );
+
+    expect(
+      materialized.files.some(
+        (file) =>
+          file.path.includes("sharp-linux-arm64") &&
+          file.path.endsWith(".node"),
+      ),
+    ).toBe(true);
+    expect(
+      materialized.files.find(
+        (file) => file.path === "node_modules/ffmpeg-static/ffmpeg",
+      )?.mode,
+    ).toBe(0o755);
+
+    for (const file of materialized.files) {
+      const target = path.join(taskDirectory, ...file.path.split("/"));
+      await mkdir(path.dirname(target), { recursive: true });
+      await writeFile(target, file.content);
+      await chmod(target, file.mode);
+    }
+    await writeFile(
+      path.join(taskDirectory, "handler.mjs"),
+      await readFile(
+        path.join(fixtureRoot, "external-packages-bun", "handler.mjs"),
+      ),
+    );
+
+    const { stdout } = await Effect.runPromise(
+      runDockerCommand([
+        "run",
+        "--rm",
+        "--platform",
+        "linux/arm64",
+        "--entrypoint",
+        "node",
+        "-v",
+        `${taskDirectory}:/var/task:ro`,
+        "-w",
+        "/var/task",
+        "public.ecr.aws/lambda/nodejs:22",
+        "--input-type=module",
+        "-e",
+        "import('/var/task/handler.mjs').then(async ({ verifyNativePackages }) => console.log(JSON.stringify(await verifyNativePackages())))",
+      ]).pipe(Effect.provide(NodeServices.layer), Effect.scoped),
+    );
+    const result = JSON.parse(stdout.trim().split("\n").at(-1)!) as {
+      architecture: string;
+      imageBytes: number;
+      ffmpegStatus: number;
+      ffmpegVersion: string;
+    };
+    expect(result.architecture).toBe("arm64");
+    expect(result.imageBytes).toBeGreaterThan(0);
+    expect(result.ffmpegStatus).toBe(0);
+    expect(result.ffmpegVersion).toContain("ffmpeg version");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+};
+
+describe("external Lambda package Docker integration", () => {
+  it.skipIf(!dockerIntegrationEnabled)(
+    "runs Bun-locked Sharp and FFmpeg in the ARM64 Lambda runtime",
+    () => verifyNativeFixture("bun"),
+    120_000,
+  );
+
+  it.skipIf(!dockerIntegrationEnabled)(
+    "runs npm-locked Sharp and FFmpeg in the ARM64 Lambda runtime",
+    () => verifyNativeFixture("npm"),
+    120_000,
+  );
+});

--- a/packages/alchemy/test/Bundle/fixtures/external-packages-bun/bun.lock
+++ b/packages/alchemy/test/Bundle/fixtures/external-packages-bun/bun.lock
@@ -1,0 +1,114 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "external-packages-bun-fixture",
+      "dependencies": {
+        "ffmpeg-static": "5.3.0",
+        "sharp": "0.34.5",
+      },
+    },
+  },
+  "packages": {
+    "@derhuerst/http-basic": ["@derhuerst/http-basic@8.2.4", "", { "dependencies": { "caseless": "^0.12.0", "concat-stream": "^2.0.0", "http-response-object": "^3.0.1", "parse-cache-control": "^1.0.1" } }, "sha512-F9rL9k9Xjf5blCz8HsJRO4diy111cayL2vkY2XE4r4t3n0yPXVYy3KD3nJ1qbrSn9743UWSXH4IwuCa/HWlGFw=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
+
+    "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
+
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+
+    "@types/node": ["@types/node@10.17.60", "", {}, "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="],
+
+    "agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
+
+    "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "caseless": ["caseless@0.12.0", "", {}, "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="],
+
+    "concat-stream": ["concat-stream@2.0.0", "", { "dependencies": { "buffer-from": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.0.2", "typedarray": "^0.0.6" } }, "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
+
+    "ffmpeg-static": ["ffmpeg-static@5.3.0", "", { "dependencies": { "@derhuerst/http-basic": "^8.2.0", "env-paths": "^2.2.0", "https-proxy-agent": "^5.0.0", "progress": "^2.0.3" } }, "sha512-H+K6sW6TiIX6VGend0KQwthe+kaceeH/luE8dIZyOP35ik7ahYojDuqlTV1bOrtEwl01sy2HFNGQfi5IDJvotg=="],
+
+    "http-response-object": ["http-response-object@3.0.2", "", { "dependencies": { "@types/node": "^10.0.3" } }, "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA=="],
+
+    "https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "parse-cache-control": ["parse-cache-control@1.0.1", "", {}, "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg=="],
+
+    "progress": ["progress@2.0.3", "", {}, "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="],
+
+    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
+
+    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "typedarray": ["typedarray@0.0.6", "", {}, "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="],
+
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+  }
+}

--- a/packages/alchemy/test/Bundle/fixtures/external-packages-bun/handler.mjs
+++ b/packages/alchemy/test/Bundle/fixtures/external-packages-bun/handler.mjs
@@ -1,0 +1,31 @@
+import ffmpegPath from "ffmpeg-static";
+import { spawnSync } from "node:child_process";
+import sharp from "sharp";
+
+export const verifyNativePackages = async () => {
+  const image = await sharp({
+    create: {
+      width: 1,
+      height: 1,
+      channels: 4,
+      background: { r: 255, g: 0, b: 0, alpha: 1 },
+    },
+  })
+    .png()
+    .toBuffer();
+  const ffmpeg = spawnSync(ffmpegPath, ["-version"], { encoding: "utf8" });
+  return {
+    architecture: process.arch,
+    imageBytes: image.byteLength,
+    ffmpegStatus: ffmpeg.status,
+    ffmpegVersion: ffmpeg.stdout.split("\n")[0],
+  };
+};
+
+export const handler = async () => ({
+  statusCode: 200,
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify(await verifyNativePackages()),
+});
+
+export default handler;

--- a/packages/alchemy/test/Bundle/fixtures/external-packages-bun/package.json
+++ b/packages/alchemy/test/Bundle/fixtures/external-packages-bun/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "external-packages-bun-fixture",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "ffmpeg-static": "5.3.0",
+    "sharp": "0.34.5"
+  }
+}

--- a/packages/alchemy/test/Bundle/fixtures/external-packages-npm/package-lock.json
+++ b/packages/alchemy/test/Bundle/fixtures/external-packages-npm/package-lock.json
@@ -1,0 +1,814 @@
+{
+  "name": "external-packages-npm-fixture",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "external-packages-npm-fixture",
+      "dependencies": {
+        "ffmpeg-static": "5.3.0",
+        "sharp": "0.34.5"
+      }
+    },
+    "node_modules/@derhuerst/http-basic": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/@derhuerst/http-basic/-/http-basic-8.2.4.tgz",
+      "integrity": "sha512-F9rL9k9Xjf5blCz8HsJRO4diy111cayL2vkY2XE4r4t3n0yPXVYy3KD3nJ1qbrSn9743UWSXH4IwuCa/HWlGFw==",
+      "license": "MIT",
+      "dependencies": {
+        "caseless": "^0.12.0",
+        "concat-stream": "^2.0.0",
+        "http-response-object": "^3.0.1",
+        "parse-cache-control": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "10.17.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
+      "license": "MIT"
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ffmpeg-static": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ffmpeg-static/-/ffmpeg-static-5.3.0.tgz",
+      "integrity": "sha512-H+K6sW6TiIX6VGend0KQwthe+kaceeH/luE8dIZyOP35ik7ahYojDuqlTV1bOrtEwl01sy2HFNGQfi5IDJvotg==",
+      "hasInstallScript": true,
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@derhuerst/http-basic": "^8.2.0",
+        "env-paths": "^2.2.0",
+        "https-proxy-agent": "^5.0.0",
+        "progress": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/http-response-object": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz",
+      "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^10.0.3"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/parse-cache-control": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+      "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg=="
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    }
+  }
+}

--- a/packages/alchemy/test/Bundle/fixtures/external-packages-npm/package.json
+++ b/packages/alchemy/test/Bundle/fixtures/external-packages-npm/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "external-packages-npm-fixture",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "ffmpeg-static": "5.3.0",
+    "sharp": "0.34.5"
+  }
+}

--- a/packages/alchemy/test/zip.test.ts
+++ b/packages/alchemy/test/zip.test.ts
@@ -1,6 +1,7 @@
 import { sha256 } from "@/Util/sha256";
 import { zipCode } from "@/Util/zip";
 import * as Effect from "effect/Effect";
+import JSZip from "jszip";
 import { expect, test } from "vitest";
 
 test("zipCode is deterministic for identical inputs", async () => {
@@ -20,4 +21,19 @@ test("zipCode is deterministic for identical inputs", async () => {
   const first = await hash();
   await new Promise((resolve) => setTimeout(resolve, 1100));
   expect(await hash()).toBe(first);
+});
+
+test("zipCode preserves executable file permissions", async () => {
+  const archive = await Effect.runPromise(
+    zipCode("export default 1", [
+      {
+        path: "bin/ffmpeg",
+        content: new Uint8Array([1, 2, 3]),
+        mode: 0o755,
+      },
+    ]),
+  );
+
+  const zip = await JSZip.loadAsync(archive);
+  expect(Number(zip.file("bin/ffmpeg")?.unixPermissions) & 0o777).toBe(0o755);
 });


### PR DESCRIPTION
## Summary

- add `build.externalPackages` to Lambda functions
- exclude selected dependencies from Rolldown and materialize them under `node_modules` in the deployment package
- install dependencies from Bun or npm lockfiles inside Docker for the Lambda runtime architecture
- preserve executable permissions for packaged binaries
- cache materialized packages and include their contents, runtime, and architecture in deployment hashes
- enforce Lambda compressed and uncompressed package-size limits

## Why

Some Lambda dependencies cannot be bundled into a single JavaScript artifact. Native modules such as `sharp`, and packages that ship executables such as `ffmpeg-static`, need their platform-specific files and binaries available alongside the Lambda code.

This change lets users declare those dependencies explicitly while Alchemy builds them for Lambda Linux and packages their complete runtime dependency trees into the function ZIP.

## Example

```ts
const fn = yield* AWS.Lambda.Function("ImageProcessor", {
  main: "./src/handler.ts",
  runtime: "nodejs22.x",
  architecture: "arm64",
  build: {
    externalPackages: ["sharp", "ffmpeg-static"],
  },
});
```

## Validation

- `timeout 240 bun vitest run test/Bundle/ExternalPackages.test.ts test/zip.test.ts` — 17 passed, 2 Docker integration tests skipped behind `ALCHEMY_TEST_LAMBDA_EXTERNAL_PACKAGES=1`
- formatting check across changed TypeScript, JavaScript, and JSON files
- `git diff --check main...HEAD`