### PR TITLE
chore(website): remove duplicate build step from ci

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -75,17 +75,6 @@ jobs:
       - name: Install dependencies
         run: bun install
 
-      # Build the website ahead of `alchemy deploy`. The
-      # Cloudflare.StaticSite resource declares the same `bun run build`
-      # in its config and runs it as part of the create lifecycle, but
-      # on update plans alchemy reads `dist/` during plan.diff before
-      # the embedded Build resource gets a chance to (re)run, causing
-      # a NotFound on a fresh CI checkout. Building here makes the
-      # workflow correct under both create and update plans.
-      - name: Build website
-        working-directory: website
-        run: bun run build
-
       # Secrets (Cloudflare credentials, etc.) are injected by
       # `doppler run` from the `alchemy-v2` project — `prod` config on
       # main, `dev` config everywhere else.


### PR DESCRIPTION
We were building our website twice in CI, which doubles how long the job takes. This was a workaround for #538, which #673 solved, so this is no longer necessary.