### PR TITLE
docs(website): add --yes flag to tutorial CI deploy/destroy

### DIFF
--- a/website/src/content/docs/tutorial/part-5.mdx
+++ b/website/src/content/docs/tutorial/part-5.mdx
@@ -250,7 +250,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - run: bun install
       - name: Deploy
-        run: bun alchemy deploy --stage ${{ env.STAGE }}
+        run: bun alchemy deploy --stage ${{ env.STAGE }} --yes
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -275,7 +275,7 @@ jobs:
             exit 1
           fi
       - name: Destroy Preview
-        run: bun alchemy destroy --stage ${{ env.STAGE }}
+        run: bun alchemy destroy --stage ${{ env.STAGE }} --yes
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
The Part 5 CI workflow runs `alchemy deploy`/`destroy` in GitHub Actions, which is a non-interactive terminal. The CLI refuses to proceed there without `--yes` (see `LoggingCli.ts`), so as written both steps would hang waiting for approval.

```diff
- run: bun alchemy deploy --stage ${{ env.STAGE }}
+ run: bun alchemy deploy --stage ${{ env.STAGE }} --yes
```

```diff
- run: bun alchemy destroy --stage ${{ env.STAGE }}
+ run: bun alchemy destroy --stage ${{ env.STAGE }} --yes
```

Matches the existing CI examples in `concepts/stages.mdx` and `guides/cli.mdx`, which already pass `--yes` to both commands.
