### PR TITLE
feat(cli): export ALCHEMY_DEV config and fix ALCHEMY_PHASE docs

### DIFF
--- a/packages/alchemy/src/Cli/commands/dev.ts
+++ b/packages/alchemy/src/Cli/commands/dev.ts
@@ -56,6 +56,7 @@ export const devCommand = Command.make(
         stderr: "inherit",
         env: {
           ALCHEMY_EXEC_OPTIONS: JSON.stringify(options),
+          ALCHEMY_DEV: "true",
           [SPAWNER_URL_ENV_KEY]: spawner.url,
         },
         extendEnv: true,

--- a/packages/alchemy/src/Phase.ts
+++ b/packages/alchemy/src/Phase.ts
@@ -29,3 +29,28 @@ export const ALCHEMY_PHASE = Config.string("ALCHEMY_PHASE").pipe(
   }),
   Effect.orDie,
 );
+
+/**
+ * Whether the program is running under `alchemy dev` (local development with
+ * hot reload), exposed as the `ALCHEMY_DEV` environment variable / config key.
+ *
+ * The `alchemy dev` CLI command sets `ALCHEMY_DEV=true` on the spawned process;
+ * every other entrypoint (`deploy`, `plan`, deployed runtime) leaves it unset,
+ * so it defaults to `false`. Accepts the usual truthy strings (`true`, `1`,
+ * `yes`, `on`).
+ *
+ * Read it from user code to branch on dev mode:
+ *
+ * ```typescript
+ * import { ALCHEMY_DEV } from "alchemy";
+ *
+ * Effect.gen(function* () {
+ *   if (yield* ALCHEMY_DEV) {
+ *     // local-dev-only behavior
+ *   }
+ * });
+ * ```
+ */
+export const ALCHEMY_DEV = Config.boolean("ALCHEMY_DEV").pipe(
+  Config.withDefault(false),
+);

--- a/packages/alchemy/src/index.ts
+++ b/packages/alchemy/src/index.ts
@@ -24,6 +24,7 @@ export * from "./KeyPair.ts";
 export * from "./Namespace.ts";
 export { stackRef } from "./Output.ts";
 export type { Output } from "./Output.ts";
+export { ALCHEMY_DEV, ALCHEMY_PHASE, type AlchemyPhase } from "./Phase.ts";
 export * from "./PhysicalName.ts";
 export * as Plan from "./Plan.ts";
 export { Provider, ProviderCollection } from "./Provider.ts";

--- a/website/src/content/docs/concepts/phases.mdx
+++ b/website/src/content/docs/concepts/phases.mdx
@@ -95,15 +95,33 @@ rejects it everywhere else. See
 The current phase is exposed as the `ALCHEMY_PHASE` environment
 variable / config key:
 
-| Value     | Context                                                    |
-| --------- | ---------------------------------------------------------- |
-| `plan`    | Default. Running `alchemy deploy` or `alchemy plan`.       |
-| `dev`     | Running `alchemy dev` (local development with hot reload). |
-| `runtime` | Running inside a deployed Worker or Lambda Function.       |
+| Value     | Context                                                              |
+| --------- | ------------------------------------------------------------------- |
+| `plan`    | Default. Running `alchemy deploy`, `alchemy plan`, or `alchemy dev`. |
+| `runtime` | Running inside a deployed Worker or Lambda Function.                 |
 
 Most user code never reads this directly — but providers and
 [bindings](/concepts/binding) use it internally to behave
 differently across phases.
+
+## `ALCHEMY_DEV`
+
+`alchemy dev` is a plantime phase, so `ALCHEMY_PHASE` is `plan`
+during local development just like a regular deploy. To tell whether
+you're running under `alchemy dev` specifically, read the
+`ALCHEMY_DEV` config key. The CLI sets `ALCHEMY_DEV=true` on the dev
+process; every other entrypoint leaves it unset, so it defaults to
+`false`.
+
+```typescript
+import { ALCHEMY_DEV } from "alchemy";
+
+Effect.gen(function* () {
+  if (yield* ALCHEMY_DEV) {
+    // local-dev-only behavior
+  }
+});
+```
 
 ## `Binding.Service` vs `Binding.Policy`
 


### PR DESCRIPTION
Exposes a config key for detecting `alchemy dev`, and corrects the `ALCHEMY_PHASE` docs (which listed a `dev` value that the implementation never sets).

`alchemy dev` is itself a *plantime* phase, so `ALCHEMY_PHASE` stays `plan` during local development. To branch on dev mode, read the new `ALCHEMY_DEV` config:

```ts
import { ALCHEMY_DEV } from "alchemy";

Effect.gen(function* () {
  if (yield* ALCHEMY_DEV) {
    // local-dev-only behavior
  }
});
```

- `ALCHEMY_DEV` is a `Config<boolean>` defaulting to `false`, exported from the package root.
- The `alchemy dev` CLI command sets `ALCHEMY_DEV=true` on the spawned process; every other entrypoint leaves it unset.
- Docs: `ALCHEMY_PHASE` is now documented as `plan | runtime` only, with a dedicated `ALCHEMY_DEV` section.

Closes #683
