### PR TITLE
chore(website): use R2.ReadWriteBucket bind alias in docs

### DIFF
--- a/website/src/content/docs/blog/2026-05-08-beta-35.md
+++ b/website/src/content/docs/blog/2026-05-08-beta-35.md
@@ -47,7 +47,7 @@ export default class Api extends Cloudflare.Worker<Api>()(
   "Api",
   { main: import.meta.filename },
   Effect.gen(function* () {
-    const bucket = yield* Cloudflare.R2.ReadWrite(Bucket);
+    const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
     const queueResource = yield* Queue;
     const queue = yield* Cloudflare.QueueBinding.bind(queueResource);
 

--- a/website/src/content/docs/blog/2026-05-12-beta-37.md
+++ b/website/src/content/docs/blog/2026-05-12-beta-37.md
@@ -237,7 +237,7 @@ export default class Backend extends Cloudflare.Worker<Backend>()(
   "Backend",
   { main: import.meta.filename },
   Effect.gen(function* () {
-    const bucket = yield* Cloudflare.R2.ReadWrite(Bucket);
+    const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
 
     return {
       // RPC method — callable via `backend.hello(key)` on the other side.

--- a/website/src/content/docs/blog/2026-05-20-beta-41.md
+++ b/website/src/content/docs/blog/2026-05-20-beta-41.md
@@ -105,7 +105,7 @@ export default Cloudflare.Worker(
   "Worker",
   { main: import.meta.filename },
   Effect.gen(function* () {
-    const tasks = yield* Cloudflare.R2.ReadWrite(Bucket);
+    const tasks = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
 
     const tasksGroup = HttpApiBuilder.group(TaskApi, "Tasks", (h) =>
       h.handle("getTask", ({ params }) =>
@@ -152,7 +152,7 @@ export default Cloudflare.Worker(
   "Worker",
   { main: import.meta.filename },
   Effect.gen(function* () {
-    const tasks = yield* Cloudflare.R2.ReadWrite(Bucket);
+    const tasks = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
 
     const handlersLayer = TaskRpcs.toLayer({
       getTask: ({ id }) => /* ... */,

--- a/website/src/content/docs/concepts/binding.mdx
+++ b/website/src/content/docs/concepts/binding.mdx
@@ -18,7 +18,7 @@ bindings fit into a Platform's runtime, see
 ## A binding in one line
 
 ```typescript
-const bucket = yield* Cloudflare.R2.ReadWrite(Bucket);
+const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
 
 // later, in fetch:
 yield* bucket.put("hello.txt", "world");
@@ -41,7 +41,7 @@ export default Cloudflare.Worker(
   "Worker",
   { main: import.meta.filename },
   Effect.gen(function* () {
-    const bucket = yield* Cloudflare.R2.ReadWrite(Bucket);
+    const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
     return {
       fetch: Effect.gen(function* () {
         const obj = yield* bucket.get("key");
@@ -118,7 +118,7 @@ On Cloudflare, the same call attaches a native Worker binding (R2,
 KV, D1, Durable Object…) instead of an IAM policy:
 
 ```typescript
-const bucket = yield* Cloudflare.R2.ReadWrite(Bucket);
+const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
 const kv = yield* Cloudflare.KV.ReadWriteNamespace(Sessions);
 ```
 

--- a/website/src/content/docs/concepts/phases.mdx
+++ b/website/src/content/docs/concepts/phases.mdx
@@ -30,7 +30,7 @@ Cloudflare.Worker(
   { main: import.meta.filename },
   Effect.gen(function* () {
     // ─── Init phase ───
-    const bucket = yield* Cloudflare.R2.ReadWrite(Bucket);
+    const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
 
     return {
       // ─── Runtime phase ───
@@ -157,7 +157,7 @@ The init/runtime split lets you write code that:
 ```typescript
 Effect.gen(function* () {
   // Init: runs once per cold start
-  const bucket = yield* Cloudflare.R2.ReadWrite(Bucket);
+  const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
   const kv = yield* Cloudflare.KV.ReadWriteNamespace(KV);
 
   return {

--- a/website/src/content/docs/concepts/platform.mdx
+++ b/website/src/content/docs/concepts/platform.mdx
@@ -30,7 +30,7 @@ export default Cloudflare.Worker(
   { main: import.meta.filename },
   Effect.gen(function* () {
     // Init: bind a resource. The binding is the typed SDK.
-    const bucket = yield* Cloudflare.R2.ReadWrite(Bucket);
+    const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
 
     return {
       // Runtime: per-request handler.
@@ -60,7 +60,7 @@ syntax `yield* SomeResource.bind(target)` does three things at once:
 3. Returns a typed handle you call at runtime
 
 ```typescript
-const bucket = yield* Cloudflare.R2.ReadWrite(Bucket);
+const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
 const kv = yield* Cloudflare.KV.ReadWriteNamespace(Sessions);
 
 // Inside fetch:
@@ -142,7 +142,7 @@ export default Cloudflare.Worker(
   "Worker",
   { main: import.meta.filename },
   Effect.gen(function* () {
-    const bucket = yield* Cloudflare.R2.ReadWrite(Bucket);
+    const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
     return {
       fetch: Effect.gen(function* () {
         /* ... */

--- a/website/src/content/docs/guides/effect-http-api.mdx
+++ b/website/src/content/docs/guides/effect-http-api.mdx
@@ -142,7 +142,7 @@ export default Cloudflare.Worker(
   "Worker",
   { main: import.meta.filename },
   Effect.gen(function* () {
-+   const tasks = yield* Cloudflare.R2.ReadWrite(Tasks);
++   const tasks = yield* Cloudflare.R2.ReadWriteBucket(Tasks);
 
     return {};
   }),
@@ -167,7 +167,7 @@ safe to call inside Init.
 ```typescript twoslash
 // @noErrors
   Effect.gen(function* () {
-    const tasks = yield* Cloudflare.R2.ReadWrite(Tasks);
+    const tasks = yield* Cloudflare.R2.ReadWriteBucket(Tasks);
 
 +   const tasksGroup = HttpApiBuilder.group(TaskApi, "Tasks", (handlers) =>
 +     handlers
@@ -283,7 +283,7 @@ export default Cloudflare.Worker(
   "Worker",
   { main: import.meta.filename },
   Effect.gen(function* () {
-    const tasks = yield* Cloudflare.R2.ReadWrite(Tasks);
+    const tasks = yield* Cloudflare.R2.ReadWriteBucket(Tasks);
 
     const tasksGroup = HttpApiBuilder.group(TaskApi, "Tasks", (handlers) =>
       handlers
@@ -513,7 +513,7 @@ under the hood:
 +import TasksObject, { TaskDOApi } from "./object.ts";
 
   Effect.gen(function* () {
-    const tasks = yield* Cloudflare.R2.ReadWrite(Tasks);
+    const tasks = yield* Cloudflare.R2.ReadWriteBucket(Tasks);
 +   const tasksDO = yield* TasksObject;
 +
 +   const getTaskDOClient = (id: string = "default") =>

--- a/website/src/content/docs/guides/effect-rpc.mdx
+++ b/website/src/content/docs/guides/effect-rpc.mdx
@@ -128,7 +128,7 @@ export default Cloudflare.Worker(
   "Worker",
   { main: import.meta.filename },
   Effect.gen(function* () {
-+   const tasks = yield* Cloudflare.R2.ReadWrite(Tasks);
++   const tasks = yield* Cloudflare.R2.ReadWriteBucket(Tasks);
 
     return {};
   }),
@@ -153,7 +153,7 @@ is pure construction — it builds a value, it doesn't run the server.
 ```typescript twoslash
 // @noErrors
   Effect.gen(function* () {
-    const tasks = yield* Cloudflare.R2.ReadWrite(Tasks);
+    const tasks = yield* Cloudflare.R2.ReadWriteBucket(Tasks);
 
 +   const handlersLayer = TaskRpcs.toLayer({
 +     getTask: ({ id }) =>
@@ -231,7 +231,7 @@ export default Cloudflare.Worker(
   "Worker",
   { main: import.meta.filename },
   Effect.gen(function* () {
-    const tasks = yield* Cloudflare.R2.ReadWrite(Tasks);
+    const tasks = yield* Cloudflare.R2.ReadWriteBucket(Tasks);
 
     const handlersLayer = TaskRpcs.toLayer({
       getTask: ({ id }) =>
@@ -480,7 +480,7 @@ export default Cloudflare.Worker(
   "Worker",
   { main: import.meta.filename },
   Effect.gen(function* () {
-    const tasks = yield* Cloudflare.R2.ReadWrite(Tasks);
+    const tasks = yield* Cloudflare.R2.ReadWriteBucket(Tasks);
     const tasksDO = yield* TasksObject;
 
     // A per-request typed RpcClient that short-circuits to the DO's

--- a/website/src/content/docs/guides/migrating-from-v1.mdx
+++ b/website/src/content/docs/guides/migrating-from-v1.mdx
@@ -155,7 +155,7 @@ import { Bucket } from "./bucket.ts";
 +export default Cloudflare.Worker("Worker",
 +  { main: import.meta.filename },
 +  Effect.gen(function* () {
-+    const bucket = yield* Cloudflare.R2.ReadWrite(Bucket);
++    const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
 +
 +    return {
 +      fetch: Effect.gen(function* () {

--- a/website/src/content/docs/tutorial/cloudflare/queue-consumer.mdx
+++ b/website/src/content/docs/tutorial/cloudflare/queue-consumer.mdx
@@ -61,7 +61,7 @@ export default Cloudflare.Worker(
   "Api",
   { main: import.meta.filename },
   Effect.gen(function* () {
-    const bucket = yield* Cloudflare.R2.ReadWrite(Bucket);
+    const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
     const queueResource = yield* Queue;
     const queue = yield* Cloudflare.Queues.WriteQueue(queueResource);
 
@@ -93,7 +93,7 @@ expected to return `Effect.Effect<void>`.
 +}
 
   Effect.gen(function* () {
-    const bucket = yield* Cloudflare.R2.ReadWrite(Bucket);
+    const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
     const queueResource = yield* Queue;
     const queue = yield* Cloudflare.Queues.WriteQueue(queueResource);
 

--- a/website/src/content/docs/tutorial/cloudflare/vite-spa.mdx
+++ b/website/src/content/docs/tutorial/cloudflare/vite-spa.mdx
@@ -492,7 +492,7 @@ concurrency), factor it into its own Worker:
 +  "Backend",
 +  { main: import.meta.filename },
 +  Effect.gen(function* () {
-+    const bucket = yield* Cloudflare.R2.ReadWrite(Bucket);
++    const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
 +
 +    return {
 +      hello: Effect.fn("Backend.hello")(function* (key: string) {

--- a/website/src/content/docs/tutorial/part-2.mdx
+++ b/website/src/content/docs/tutorial/part-2.mdx
@@ -119,7 +119,7 @@ export default Cloudflare.Worker(
     main: import.meta.filename,
   },
   Effect.gen(function* () {
-+   const bucket = yield* Cloudflare.R2.ReadWrite(Bucket);
++   const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
 
     return {
       fetch: Effect.gen(function* () {
@@ -151,7 +151,7 @@ export default Cloudflare.Worker(
   "Worker",
   { main: import.meta.filename },
   Effect.gen(function* () {
-    const bucket = yield* Cloudflare.R2.ReadWrite(Bucket);
+    const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
 
     return {
       fetch: Effect.gen(function* () {
@@ -189,7 +189,7 @@ export default Cloudflare.Worker(
   "Worker",
   { main: import.meta.filename },
   Effect.gen(function* () {
-    const bucket = yield* Cloudflare.R2.ReadWrite(Bucket);
+    const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
     return {
       fetch: Effect.gen(function* () {
 +       const request = yield* HttpServerRequest;
@@ -235,7 +235,7 @@ export default Cloudflare.Worker(
   "Worker",
   { main: import.meta.filename },
   Effect.gen(function* () {
-    const bucket = yield* Cloudflare.R2.ReadWrite(Bucket);
+    const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
     return {
       fetch: Effect.gen(function* () {
         const request = yield* HttpServerRequest;
@@ -287,7 +287,7 @@ export default Cloudflare.Worker(
   "Worker",
   { main: import.meta.filename },
   Effect.gen(function* () {
-    const bucket = yield* Cloudflare.R2.ReadWrite(Bucket);
+    const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
     return {
       fetch: Effect.gen(function* () {
         const request = yield* HttpServerRequest;

--- a/website/src/content/docs/what-is-alchemy.mdx
+++ b/website/src/content/docs/what-is-alchemy.mdx
@@ -52,7 +52,7 @@ export default Cloudflare.Worker(
   "Worker",
   { main: import.meta.filename },
   Effect.gen(function* () {
-    const bucket = yield* Cloudflare.R2.ReadWrite(Bucket);
+    const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
 
     return {
       fetch: Effect.gen(function* () {
@@ -122,7 +122,7 @@ export const Bucket = Cloudflare.R2Bucket("Bucket");
 ```typescript
 // src/worker.ts
 import { Bucket } from "./bucket.ts";
-const bucket = yield* Cloudflare.R2.ReadWrite(Bucket);
+const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
 ```
 
 ## Bindings
@@ -133,7 +133,7 @@ A **Binding** connects a resource to a Worker or Lambda. A single
 bindings that client needs:
 
 ```typescript
-const bucket = yield* Cloudflare.R2.ReadWrite(Bucket);
+const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
 
 // later, inside fetch:
 yield* bucket.put("hello.txt", "world");
@@ -219,7 +219,7 @@ export default Cloudflare.Worker(
   "Worker",
   { main: import.meta.filename },
   Effect.gen(function* () {
-    const bucket = yield* Cloudflare.R2.ReadWrite(Bucket);
+    const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
     return {
       fetch: Effect.gen(function* () {
         // Effect-native runtime code


### PR DESCRIPTION
The website deploy on `main` was failing because docs referenced `Cloudflare.R2.ReadWrite(...)`, but the R2 bind callable is `ReadWriteBucket`. Twoslash compiled the sample, hit a `2339` (`Property 'ReadWrite' does not exist`) instead of the expected `2345`, and the astro build aborted.

```diff
-const bucket = yield* Cloudflare.R2.ReadWrite(Bucket);
+const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
```

Applied across all docs that used the stale alias (tutorials, guides, concepts, blog posts). Full `astro build` now completes (581 pages).
