### PR TITLE
docs(website): add Command provider and WorkerLoader to beta.58 blog

### DIFF
--- a/website/src/content/docs/blog/2026-06-24-beta-58.md
+++ b/website/src/content/docs/blog/2026-06-24-beta-58.md
@@ -211,13 +211,11 @@ External and remote `Container` images (built from a `context` /
 `.make()` — declare their props inline on the tag and register them
 with `Cloudflare.layerContainer` from the hosting Durable Object.
 
-## A tool on `WorkerLoader`
+## `WorkerLoader`
 
-`DynamicWorkerLoader` is renamed to `WorkerLoader` and is now a
-first-class Effect service with a typed runtime client
-([#653](https://github.com/alchemy-run/alchemy-effect/pull/653)).
-`load(...)` returns an Effect, so you `yield*` it — the loader is the
-infrastructure an `Eval` tool captures to spin up code on demand:
+`DynamicWorkerLoader` is renamed to `WorkerLoader`, and `load(...)`
+now returns an Effect, so you `yield*` it
+([#653](https://github.com/alchemy-run/alchemy-effect/pull/653)):
 
 ```diff lang="typescript"
 - const loader = yield* Cloudflare.DynamicWorkerLoader("Loader");

--- a/website/src/content/docs/blog/2026-06-24-beta-58.md
+++ b/website/src/content/docs/blog/2026-06-24-beta-58.md
@@ -2,30 +2,44 @@
 title: 2.0.0-beta.58 - Platform Ergonomics
 date: 2026-06-24T22:00:00Z
 category: release
-excerpt: v2.0.0-beta.58 reworks how Platform classes are wired — resolve `DurableObjectState` in the outer init Effect, `yield*` a Container to get a running instance and configure it with `Cloudflare.layerContainer`, pass props to `.make()` instead of the tag so one tag can have many implementations, and bind resources with least-privilege capabilities (`Cloudflare.R2.ReadWriteBucket`) backed by a native binding or a scoped HTTP token.
+excerpt: v2.0.0-beta.58 makes a Platform tag pure identity — props and implementation move into a Layer — so you can resolve Durable Object state, a worker loader, or a running container at init and capture it in a Layer that implements a service. The canonical use is agent tools: Sql over DO storage, Eval over a WorkerLoader, Bash over a running Container.
 ---
 
-beta.58 reshapes how Platform classes are wired so that a single
-Layer can carry infrastructure and run the same way across Workers,
-Containers, and Durable Objects. The pattern throughout: `yield*` a
-tag to get a typed handle, and provide its implementation as a Layer.
+beta.58 makes a Platform tag **pure identity**: its props and its
+runtime implementation move out of the tag and into a Layer.
 
-```typescript
-// reference — a typed handle
-const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
+```diff lang="typescript"
+- export class WorkerB extends Cloudflare.Worker<WorkerB>()(
+-   "WorkerB",
+-   { main: import.meta.filename }, // props on the tag
+- ) {}
++ export class WorkerB extends Cloudflare.Worker<WorkerB>()("WorkerB") {}
 
-// implementation — provided separately as a Layer
-.pipe(Effect.provide(Cloudflare.R2.ReadWriteBucketBinding))
++ export default WorkerB.make(
++   { main: import.meta.filename }, // props on the Layer
++   Effect.gen(function* () {
++     /* ... */
++   }),
++ );
 ```
+
+The payoff: init is now the one place you resolve Platform
+infrastructure — Durable Object state, a worker loader, a running
+container — so you can capture it in a Layer that implements a
+service. The use case this was built for is **agent tools**: a `Sql`
+tool over a Durable Object's storage, an `Eval` tool over a
+`WorkerLoader`, a `Bash` tool over a running `Container`.
 
 :::caution
 **Breaking changes** — migration for each is below.
 
 - **Props move from the tag to `.make()`** on the Layer form of
   `Worker` / `Container`.
-- **Containers** replace `Cloudflare.Container.bind` /
-  `Cloudflare.start` with `yield*`-the-class + `Cloudflare.layerContainer`.
 - **`DurableObjectState`** is resolved in the **outer** init Effect.
+- **Containers** replace `Cloudflare.Container.bind` /
+  `Cloudflare.start` with `yield*`-the-class + `Cloudflare.layerContainer`,
+  and `yield*`-ing the tag now returns a **running container**, not the
+  `ContainerApplication` resource.
 - **Resource bindings** replace a resource's single `.bind` with
   namespaced, least-privilege capabilities (`Cloudflare.R2.ReadWriteBucket`).
 - **The `Build` module is removed** in favor of a new `Command`
@@ -34,13 +48,45 @@ const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
 - **`DynamicWorkerLoader` is renamed** to `WorkerLoader`.
 :::
 
-## Resolve `DurableObjectState` in the outer Effect
+## One tag, many implementations
+
+Because the tag is pure identity, one tag can have **many**
+implementations. `.make(propsA, implA)` and `.make(propsB, implB)`
+produce two Layers for the same tag — swap a real implementation for
+a stub in tests, or vary config per stage:
+
+```typescript
+export const SandboxProd = Sandbox.make(
+  { main: import.meta.filename, instanceType: "standard-1" },
+  realImpl,
+);
+
+export const SandboxTest = Sandbox.make(
+  { main: import.meta.filename, instanceType: "dev" },
+  fakeImpl,
+);
+```
+
+The inline form is unchanged — pass the implementation as a third
+argument and props stay inline:
+
+```typescript
+export default Cloudflare.Worker(
+  "Worker",
+  { main: import.meta.filename }, // still inline here
+  Effect.gen(function* () {
+    /* ... */
+  }),
+);
+```
+
+## A tool on Durable Object storage
 
 A Durable Object has two nested `Effect.gen` blocks: the **outer**
 init resolves shared dependencies, the **inner** runtime returns the
-public methods. `Cloudflare.DurableObjectState` is now resolved in
-the outer Effect — you yield the *reference* there, and call its
-storage methods from the inner Effect.
+public methods. `Cloudflare.DurableObjectState` now resolves in the
+outer Effect — you yield the *reference* there, but its storage I/O
+still runs in the inner Effect.
 
 ```diff lang="typescript"
   Effect.gen(function* () {
@@ -60,22 +106,22 @@ storage methods from the inner Effect.
   }),
 ```
 
-The reason is the [colored-function](/concepts/layers#runtime-as-a-colored-function)
-rule: `state`'s methods (`storage.get`, `storage.put`,
-`getWebSockets`, …) require `Alchemy.RuntimeContext`, which only
-exists inside the inner runtime closure. So the *reference* resolves
-in the outer init, but the *I/O* is type-checked into the inner
-Effect.
+You can yield the reference in the outer init, but you can't *use* it
+there — `state`'s methods (`storage.get`, `storage.put`, …) require
+`Alchemy.RuntimeContext`, which only exists inside the inner runtime
+closure (the [colored-function](/concepts/layers#runtime-as-a-colored-function)
+rule). So the reference resolves at init, but the I/O is type-checked
+into the inner Effect.
 
-The win is that init is now the one place you resolve references —
-`DurableObjectState`, bindings, other DOs — so you can hand them to
-a **Layer** that returns the runtime methods. Here's a service Layer
-that needs both the DO's storage and an R2 bucket:
+That split is what lets you capture the DO's storage in a **Layer**
+and expose it as a service — the shape a `Sql` tool takes. Resolve
+`state` (and anything else, like an R2 bucket) at init, return the
+runtime methods:
 
 ```typescript
 class Archive extends Context.Service<Archive, {
   save: (key: string, body: string) =>
-    Effect.Effect<void, never, Alchemy.RuntimeContext>; // <- note the RuntimeContext color
+    Effect.Effect<void, never, Alchemy.RuntimeContext>; // <- RuntimeContext-colored
 }>()("Archive") {}
 
 const ArchiveLive = Layer.effect(
@@ -99,16 +145,16 @@ const ArchiveLive = Layer.effect(
 
 Provide `ArchiveLive` on the DO's init and `yield* Archive` from the
 inner Effect. Neither `DurableObjectState` nor R2 leaks into
-`Archive`'s public type — consumers see only `RuntimeContext`, so
-the service stays cloud-agnostic.
+`Archive`'s public type — consumers see only `RuntimeContext`, so the
+service stays cloud-agnostic.
 
-## `yield*` a Container, configure it with a Layer
+## A tool on a running Container
 
-Containers used to be a three-step dance — `bind`, then `start`,
-then use. beta.58 collapses that: `yield*` the Container class to
-get a **running** instance, and provide
-`Cloudflare.layerContainer(Class, options)` to configure how it
-runs.
+Containers used to be a three-step dance — `bind`, then `start`, then
+use. beta.58 collapses that: `yield*` the Container tag to get the
+**running container instance** (not the `ContainerApplication`
+resource), and provide `Cloudflare.layerContainer(Class, options)` to
+configure how it runs.
 
 ```diff lang="typescript"
   Effect.gen(function* () {
@@ -133,100 +179,42 @@ runs.
 ```
 
 `layerContainer` binds, starts, and monitors the container, then
-satisfies the `Sandbox` tag with the running instance. Because it's
-a plain `Layer`, **any** Effect or Layer can `yield* Sandbox` and get
-a running container — no bind/start/use ceremony threaded through
-your code. That makes it straightforward to build a service Layer on
-top of a container:
+satisfies the `Sandbox` tag with the running instance. Because it's a
+plain `Layer`, **any** Effect or Layer can `yield* Sandbox` and get a
+running container — so a `Bash` tool is just a Layer that captures the
+container and shells out to it:
 
 ```typescript
-const SandboxClient = Layer.effect(
-  MyService,
+const Bash = Layer.effect(
+  BashTool,
   Effect.gen(function* () {
     const sandbox = yield* Sandbox; // running instance
-    return MyService.of({
+    return BashTool.of({
       run: (cmd: string) => sandbox.exec(cmd),
     });
   }),
 ).pipe(Layer.provide(Cloudflare.layerContainer(Sandbox)));
 ```
 
-## Props move from the tag to `.make()`
-
-For the **Layer form** of a tagged `Worker` or `Container` (class +
-separate `.make()`), props now go to `.make()` as its first
-argument, and the tag carries only the name (and typed shape):
-
-```diff lang="typescript"
-- export class WorkerB extends Cloudflare.Worker<WorkerB>()(
--   "WorkerB",
--   { main: import.meta.filename },
-- ) {}
-+ export class WorkerB extends Cloudflare.Worker<
-+   WorkerB,
-+   { greet: (name: string) => Effect.Effect<string> }
-+ >()("WorkerB") {}
-
-  export default WorkerB.make(
-+   { main: import.meta.filename },
-    Effect.gen(function* () {
-      /* ... */
-    }),
-  );
-```
-
-Same move for a `Container` with a runtime shape:
-
-```diff lang="typescript"
-  export class Sandbox extends Cloudflare.Container<
-    Sandbox,
-    { exec: (cmd: string) => Effect.Effect<ExecResult> }
-- >()("Sandbox", { main: import.meta.filename }) {}
-+ >()("Sandbox") {}
-
-  export default Sandbox.make(
-+   { main: import.meta.filename },
-    Effect.gen(function* () {
-      /* ... */
-    }),
-  );
-```
-
-The payoff: a tag is now pure identity, so one tag can have **many
-implementations**. `.make(propsA, implA)` and `.make(propsB, implB)`
-produce two Layers for the same `WorkerB` tag — handy for swapping a
-real implementation for a stub in tests, or varying config per stage:
-
-```typescript
-export const SandboxProd = Sandbox.make(
-  { main: import.meta.filename, instanceType: "standard-1" },
-  realImpl,
-);
-
-export const SandboxTest = Sandbox.make(
-  { main: import.meta.filename, instanceType: "dev" },
-  fakeImpl,
-);
-```
-
-The inline form is unchanged — when you pass the implementation as a
-third argument, props stay inline:
-
-```typescript
-export default Cloudflare.Worker(
-  "Worker",
-  { main: import.meta.filename }, // still inline here
-  Effect.gen(function* () {
-    /* ... */
-  }),
-);
-```
-
 External and remote `Container` images (built from a `context` /
-`dockerfile`, or pulled from a registry) have no runtime shape and
-no `.make()` — declare their props inline on the tag and register
-them with `Cloudflare.layerContainer` from the hosting Durable
-Object.
+`dockerfile`, or pulled from a registry) have no runtime shape and no
+`.make()` — declare their props inline on the tag and register them
+with `Cloudflare.layerContainer` from the hosting Durable Object.
+
+## A tool on `WorkerLoader`
+
+`DynamicWorkerLoader` is renamed to `WorkerLoader` and is now a
+first-class Effect service with a typed runtime client
+([#653](https://github.com/alchemy-run/alchemy-effect/pull/653)).
+`load(...)` returns an Effect, so you `yield*` it — the loader is the
+infrastructure an `Eval` tool captures to spin up code on demand:
+
+```diff lang="typescript"
+- const loader = yield* Cloudflare.DynamicWorkerLoader("Loader");
+- const worker = loader.load({ compatibilityDate, mainModule, modules });
++ const loader = yield* Cloudflare.WorkerLoader("Loader");
++ const worker = yield* loader.load({ compatibilityDate, mainModule, modules });
+```
 
 ## Bindings: least-privilege, native or HTTP
 
@@ -320,20 +308,6 @@ build and dev-serve through `Command`. Resource type IDs were
 renamed, so existing state referencing `Build.Command` /
 `Build.DevServer` won't match, and `Command.Build`'s output hash
 changed from `{ outdir, hash }` to `{ outdir, hash: { input, output } }`.
-
-## `WorkerLoader`: a typed, Effect-native loader
-
-`DynamicWorkerLoader` is renamed to `WorkerLoader` and is now a
-first-class Effect service with a typed runtime client
-([#653](https://github.com/alchemy-run/alchemy-effect/pull/653)).
-`load(...)` returns an Effect, so you `yield*` it:
-
-```diff lang="typescript"
-- const loader = yield* Cloudflare.DynamicWorkerLoader("Loader");
-- const worker = loader.load({ compatibilityDate, mainModule, modules });
-+ const loader = yield* Cloudflare.WorkerLoader("Loader");
-+ const worker = yield* loader.load({ compatibilityDate, mainModule, modules });
-```
 
 ## Where to go next
 

--- a/website/src/content/docs/blog/2026-06-24-beta-58.md
+++ b/website/src/content/docs/blog/2026-06-24-beta-58.md
@@ -5,8 +5,9 @@ category: release
 excerpt: v2.0.0-beta.58 makes a Platform tag pure identity — props and implementation move into a Layer — so you can capture Durable Object state, a worker loader, or a running container in a Layer that implements a service, like agent tools.
 ---
 
-beta.58 makes a Platform tag **pure identity**: its props and its
-runtime implementation move out of the tag and into a Layer.
+beta.58 makes a Platform tag (e.g. a Worker or Container) **pure
+identity**: its props and its runtime implementation move out of the
+tag and into a Layer.
 
 ```diff lang="typescript"
 - export class WorkerB extends Cloudflare.Worker<WorkerB>()(

--- a/website/src/content/docs/blog/2026-06-24-beta-58.md
+++ b/website/src/content/docs/blog/2026-06-24-beta-58.md
@@ -42,10 +42,9 @@ instead of having to be resolved inside the nested `Effect.gen`:
   }),
 ```
 
-Why it matters: that first closure — initialization — is where all
-resources, bindings, and layer dependencies are declared. So a Layer
-can itself contain infrastructure and be provided to the init Effect
-of a Worker, Durable Object, or Container without changing its shape.
+Initialization is where resources, bindings, and dependencies are
+declared, so a Layer can contain infrastructure and be provided to any
+Worker, Durable Object, or Container without changing its shape.
 
 :::caution
 **Breaking changes** — migration for each is below.

--- a/website/src/content/docs/blog/2026-06-24-beta-58.md
+++ b/website/src/content/docs/blog/2026-06-24-beta-58.md
@@ -331,21 +331,6 @@ first-class Effect service with a typed runtime client
 + const worker = yield* loader.load({ compatibilityDate, mainModule, modules });
 ```
 
-Because it's a `Context.Service`, you can require it as a tag and
-provide it via `WorkerLoader.layer(...)`, and the returned stub
-exposes typed RPC entrypoints:
-
-```typescript
-const api = worker.getEntrypoint<{
-  greet: (n: string) => Effect.Effect<string>;
-}>("api");
-const greeting = yield* api.greet("world");
-```
-
-`WorkerStub` / `WorkerEntrypoint<Shape>` wrap the raw Cloudflare stub
-with an Effect-native `fetch` + RPC, with sandboxing via
-`globalOutbound` and `tails` / `streamingTails`.
-
 ## Where to go next
 
 - [Run a Container](/tutorial/cloudflare/containers)

--- a/website/src/content/docs/blog/2026-06-24-beta-58.md
+++ b/website/src/content/docs/blog/2026-06-24-beta-58.md
@@ -126,9 +126,25 @@ const ArchiveLive = Layer.effect(
 ```
 
 Provide `ArchiveLive` on the DO's init and `yield* Archive` from the
-inner Effect. Neither `DurableObjectState` nor R2 leaks into
-`Archive`'s public type — consumers see only `RuntimeContext`, so the
-service stays cloud-agnostic.
+inner Effect:
+
+```typescript
+export class Doc extends Cloudflare.DurableObjectNamespace<Doc>()(
+  "Doc",
+  Effect.gen(function* () {
+    const archive = yield* Archive; // resolved at init
+    return Effect.gen(function* () {
+      return {
+        save: (key: string, body: string) => archive.save(key, body),
+      };
+    });
+  }).pipe(Effect.provide(ArchiveLive)),
+) {}
+```
+
+Neither `DurableObjectState` nor R2 leaks into `Archive`'s public
+type — consumers see only `RuntimeContext`, so the service stays
+cloud-agnostic.
 
 ## A tool on a running Container
 

--- a/website/src/content/docs/blog/2026-06-24-beta-58.md
+++ b/website/src/content/docs/blog/2026-06-24-beta-58.md
@@ -226,20 +226,19 @@ now returns an Effect, so you `yield*` it
 
 ## Bindings: least-privilege, native or HTTP
 
-Resource capabilities are now namespaced per **access level**, and
-each level ships two interchangeable implementations. The single
-`.bind` on a resource is gone:
+Bindings move to a **namespaced convention**: the single `.bind` on a
+resource is gone, replaced by a capability namespaced per **access
+level**.
 
 ```diff lang="typescript"
 - const bucket = yield* Cloudflare.R2Bucket.bind(Bucket);
-+ const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
++ const bucket = yield* Cloudflare.R2.ReadBucket(Bucket);      // get / head / list
++ const bucket = yield* Cloudflare.R2.WriteBucket(Bucket);     // put / delete / multipart
++ const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket); // both
 ```
 
-Pick the least privilege you need — `ReadBucket` exposes only
-`get` / `head` / `list`, `WriteBucket` only `put` / `delete` /
-multipart, and `ReadWriteBucket` composes both. Then provide an
-implementation Layer: the native Worker binding, or a scoped HTTP
-API token.
+Pick the least privilege you need, then provide an implementation
+Layer: the native Worker binding, or a scoped HTTP API token.
 
 ```typescript
 // native Worker binding (env.BUCKET)
@@ -280,7 +279,9 @@ manual token plumbing.
 
 The Read / Write / ReadWrite split and `*Binding` / `*Http`
 implementations follow the same convention across KV, Queues, and the
-other capability resources.
+other capability resources. This namespaced convention is the
+direction for all bindings — the full migration across AWS,
+Cloudflare, and the other providers lands in beta.59.
 
 ## `Command`: run shell commands as resources
 

--- a/website/src/content/docs/blog/2026-06-24-beta-58.md
+++ b/website/src/content/docs/blog/2026-06-24-beta-58.md
@@ -6,19 +6,26 @@ excerpt: v2.0.0-beta.58 reworks how Platform classes are wired — resolve `Dura
 ---
 
 :::caution
-**Breaking — `Cloudflare.Worker`, `Cloudflare.Container`,
+**Breaking changes.** beta.58 reshapes how Platform classes are wired
+so that a single Layer can carry infrastructure and run the same way
+across Workers, Containers, and Durable Objects. That meant ergonomic
+breaks to `Cloudflare.Worker`, `Cloudflare.Container`,
 `Cloudflare.DurableObjectNamespace`, resource bindings, the `Build`
-module, and `DynamicWorkerLoader`.** beta.58 moves props from the
-tag to `.make()`, replaces `Cloudflare.Container.bind` /
-`Cloudflare.start` with `yield*`-the-class +
-`Cloudflare.layerContainer`, standardizes resolving
-`DurableObjectState` in the **outer** init Effect, and replaces a
-resource's single `.bind` with namespaced, least-privilege
-capabilities (`Cloudflare.R2.ReadWriteBucket`). The `Build` module
-is removed in favor of a new `Command` module (`Build.Command` →
-`Command.Build`, `Build.DevServer` → `Command.Dev`), and
-`DynamicWorkerLoader` is renamed to `WorkerLoader`. Migration for
-each is below.
+module, and `DynamicWorkerLoader`:
+
+- **Props move from the tag to `.make()`** on the Layer form of
+  `Worker` / `Container`.
+- **Containers** replace `Cloudflare.Container.bind` /
+  `Cloudflare.start` with `yield*`-the-class + `Cloudflare.layerContainer`.
+- **`DurableObjectState`** is resolved in the **outer** init Effect.
+- **Resource bindings** replace a resource's single `.bind` with
+  namespaced, least-privilege capabilities (`Cloudflare.R2.ReadWriteBucket`).
+- **The `Build` module is removed** in favor of a new `Command`
+  module (`Build.Command` → `Command.Build`, `Build.DevServer` →
+  `Command.Dev`).
+- **`DynamicWorkerLoader` is renamed** to `WorkerLoader`.
+
+Migration for each is below.
 :::
 
 `v2.0.0-beta.58` is a Platform ergonomics release built around one

--- a/website/src/content/docs/blog/2026-06-24-beta-58.md
+++ b/website/src/content/docs/blog/2026-06-24-beta-58.md
@@ -23,12 +23,9 @@ runtime implementation move out of the tag and into a Layer.
 + );
 ```
 
-The payoff: init is now the one place you resolve Platform
-infrastructure — Durable Object state, a worker loader, a running
-container — so you can capture it in a Layer that implements a
-service. The use case this was built for is **agent tools**: a `Sql`
-tool over a Durable Object's storage, an `Eval` tool over a
-`WorkerLoader`, a `Bash` tool over a running `Container`.
+As part of this, `DurableObjectState` can now be yielded at the top
+level of a Worker, instead of having to be resolved inside the nested
+`Effect.gen`.
 
 :::caution
 **Breaking changes** — migration for each is below.

--- a/website/src/content/docs/blog/2026-06-24-beta-58.md
+++ b/website/src/content/docs/blog/2026-06-24-beta-58.md
@@ -2,7 +2,7 @@
 title: 2.0.0-beta.58 - Platform Ergonomics
 date: 2026-06-24T22:00:00Z
 category: release
-excerpt: v2.0.0-beta.58 makes a Platform tag pure identity — props and implementation move into a Layer — so you can resolve Durable Object state, a worker loader, or a running container at init and capture it in a Layer that implements a service. The canonical use is agent tools: Sql over DO storage, Eval over a WorkerLoader, Bash over a running Container.
+excerpt: v2.0.0-beta.58 makes a Platform tag pure identity — props and implementation move into a Layer — so you can capture Durable Object state, a worker loader, or a running container in a Layer that implements a service, like agent tools.
 ---
 
 beta.58 makes a Platform tag **pure identity**: its props and its

--- a/website/src/content/docs/blog/2026-06-24-beta-58.md
+++ b/website/src/content/docs/blog/2026-06-24-beta-58.md
@@ -5,13 +5,17 @@ category: release
 excerpt: v2.0.0-beta.58 reworks how Platform classes are wired — resolve `DurableObjectState` in the outer init Effect, `yield*` a Container to get a running instance and configure it with `Cloudflare.layerContainer`, pass props to `.make()` instead of the tag so one tag can have many implementations, and bind resources with least-privilege capabilities (`Cloudflare.R2.ReadWriteBucket`) backed by a native binding or a scoped HTTP token.
 ---
 
+beta.58 reshapes how Platform classes are wired so that a single
+Layer can carry infrastructure and run the same way across Workers,
+Containers, and Durable Objects. A tagged class or capability is a
+**reference** you `yield*` to get a typed handle; its *configuration*
+and *implementation* are provided separately as a Layer. That split
+is what lets you build a Layer on top of a running Container, give one
+Worker tag two implementations, or read an R2 bucket over a native
+binding in one place and a scoped HTTP token in another.
+
 :::caution
-**Breaking changes.** beta.58 reshapes how Platform classes are wired
-so that a single Layer can carry infrastructure and run the same way
-across Workers, Containers, and Durable Objects. That meant ergonomic
-breaks to `Cloudflare.Worker`, `Cloudflare.Container`,
-`Cloudflare.DurableObjectNamespace`, resource bindings, the `Build`
-module, and `DynamicWorkerLoader`:
+**Breaking changes** — migration for each is below.
 
 - **Props move from the tag to `.make()`** on the Layer form of
   `Worker` / `Container`.
@@ -24,18 +28,7 @@ module, and `DynamicWorkerLoader`:
   module (`Build.Command` → `Command.Build`, `Build.DevServer` →
   `Command.Dev`).
 - **`DynamicWorkerLoader` is renamed** to `WorkerLoader`.
-
-Migration for each is below.
 :::
-
-`v2.0.0-beta.58` is a Platform ergonomics release built around one
-idea: a tagged class or capability is a **reference** you `yield*`
-to get a typed handle, and the *configuration* and *implementation*
-are provided separately as a Layer. That split is what lets you
-build a Layer on top of a running Container, give one Worker tag two
-implementations, or read an R2 bucket over a native binding in one
-place and a scoped HTTP token in another — same code, different
-Layer.
 
 ## Resolve `DurableObjectState` in the outer Effect
 

--- a/website/src/content/docs/blog/2026-06-24-beta-58.md
+++ b/website/src/content/docs/blog/2026-06-24-beta-58.md
@@ -271,26 +271,44 @@ other capability resources.
 
 The `Build` module is gone, replaced by a unified `Command` module
 that models shell commands as first-class resources sharing one
-executor ([#673](https://github.com/alchemy-run/alchemy-effect/pull/673)):
+executor ([#673](https://github.com/alchemy-run/alchemy-effect/pull/673)).
 
-- **`Command.Build`** (was `Build.Command`) — runs a command that
-  produces an output asset (`outdir`). Inputs/outputs are
-  content-hashed (opt-in via `memo`) so unchanged projects skip the
-  rebuild.
-- **`Command.Exec`** — new. Runs a command purely for its side
-  effects — migrations, codegen, seeding. No output contract: it
-  succeeds as long as the command exits `0`, and `memo` re-runs it
-  only when inputs change.
-- **`Command.Dev`** (was `Build.DevServer`) — a long-lived dev
-  server scoped to the stack instance. Runs in the dev sidecar so it
-  survives user-code HMR, and surfaces the first `http(s)://` URL it
-  prints as its `url` output.
+`Command.Build` (was `Build.Command`) runs a command that produces an
+output asset and tracks `outdir` in state. Inputs and outputs are
+content-hashed (opt-in via `memo`) so an unchanged project skips the
+rebuild:
 
 ```typescript
-const migrate = yield* Command.Exec("migrate", {
-  command: "drizzle-kit migrate",
-  cwd: ".",
+const build = yield* Command.Build("vite-build", {
+  command: "npm run build",
+  cwd: "./frontend",
+  outdir: "dist",
 });
+yield* Console.log(build.outdir); // path to dist, relative to process.cwd()
+```
+
+`Command.Exec` is new. It runs a command purely for its side effects —
+migrations, codegen, seeding — with no output contract: it succeeds as
+long as the command exits `0`. `memo` re-runs it only when its inputs
+change:
+
+```typescript
+yield* Command.Exec("migrate", {
+  command: "npm run db:migrate",
+  cwd: "./packages/api",
+});
+```
+
+`Command.Dev` (was `Build.DevServer`) is a long-lived dev server scoped
+to the stack instance. It runs in the dev sidecar so it survives
+user-code HMR, and exposes the first `http(s)://` URL it prints as its
+`url` output. It's a no-op during `alchemy deploy`:
+
+```typescript
+const dev = yield* Command.Dev("Frontend", {
+  command: "npm run dev",
+});
+yield* Console.log(dev.url); // e.g. "http://localhost:5173"
 ```
 
 `StaticSite` (AWS + Cloudflare) and `Cloudflare.Workers.Worker` now

--- a/website/src/content/docs/blog/2026-06-24-beta-58.md
+++ b/website/src/content/docs/blog/2026-06-24-beta-58.md
@@ -2,7 +2,7 @@
 title: 2.0.0-beta.58 - Platform Ergonomics
 date: 2026-06-24T22:00:00Z
 category: release
-excerpt: v2.0.0-beta.58 makes a Platform tag pure identity — props and implementation move into a Layer — so you can capture Durable Object state, a worker loader, or a running container in a Layer that implements a service, like agent tools.
+excerpt: v2.0.0-beta.58 improves the ergonomics of Layers that contain Resources, so you can bundle infrastructure into a reusable service — like an agent tool — and provide it to a Worker, Container, or Durable Object.
 ---
 
 beta.58 makes a Platform tag (e.g. a Worker or Container) **pure

--- a/website/src/content/docs/blog/2026-06-24-beta-58.md
+++ b/website/src/content/docs/blog/2026-06-24-beta-58.md
@@ -5,9 +5,13 @@ category: release
 excerpt: v2.0.0-beta.58 improves the ergonomics of Layers that contain Resources, so you can bundle infrastructure into a reusable service — like an agent tool — and provide it to a Worker, Container, or Durable Object.
 ---
 
-beta.58 makes a Platform tag (e.g. a Worker or Container) **pure
-identity**: its props and its runtime implementation move out of the
-tag and into a Layer.
+beta.58 improves the ergonomics of Layers that contain Resources, so
+you can bundle infrastructure into a reusable service — like an agent
+tool — and provide it to a Worker, Container, or Durable Object.
+
+A few changes get us there. First, a Platform tag (e.g. a Worker or
+Container) becomes **pure identity**: its props and its runtime
+implementation move out of the tag and into a Layer.
 
 ```diff lang="typescript"
 - export class WorkerB extends Cloudflare.Worker<WorkerB>()(

--- a/website/src/content/docs/blog/2026-06-24-beta-58.md
+++ b/website/src/content/docs/blog/2026-06-24-beta-58.md
@@ -191,7 +191,19 @@ const Bash = Layer.effect(
       run: (cmd: string) => sandbox.exec(cmd),
     });
   }),
-).pipe(Layer.provide(Cloudflare.layerContainer(Sandbox)));
+);
+```
+
+The `Bash` Layer just *requires* `Sandbox` — `layerContainer` is
+provided once on the host's outermost init Effect, where it satisfies
+both `Bash` and anything else that needs the container:
+
+```typescript
+.pipe(
+  Effect.provide(
+    Layer.provideMerge(Bash, Cloudflare.layerContainer(Sandbox)),
+  ),
+)
 ```
 
 External and remote `Container` images (built from a `context` /

--- a/website/src/content/docs/blog/2026-06-24-beta-58.md
+++ b/website/src/content/docs/blog/2026-06-24-beta-58.md
@@ -23,8 +23,8 @@ runtime implementation move out of the tag and into a Layer.
 + );
 ```
 
-As part of this, `DurableObjectState` can now be yielded at the top
-level, instead of having to be resolved inside the nested `Effect.gen`:
+Also, `DurableObjectState` can now be yielded at the top level,
+instead of having to be resolved inside the nested `Effect.gen`:
 
 ```diff lang="typescript"
   Effect.gen(function* () {
@@ -37,11 +37,10 @@ level, instead of having to be resolved inside the nested `Effect.gen`:
   }),
 ```
 
-Why it matters: init is now the one place you resolve a DO's state,
-so you can capture it in a Layer and hand the runtime methods to a
-service — rather than re-resolving it inside every method. The I/O
-still runs in the nested Effect (it's `RuntimeContext`-colored), but
-the reference lives at the top.
+Why it matters: that first closure — initialization — is where all
+resources, bindings, and layer dependencies are declared. So a Layer
+can itself contain infrastructure and be provided to the init Effect
+of a Worker, Durable Object, or Container without changing its shape.
 
 :::caution
 **Breaking changes** — migration for each is below.

--- a/website/src/content/docs/blog/2026-06-24-beta-58.md
+++ b/website/src/content/docs/blog/2026-06-24-beta-58.md
@@ -7,14 +7,18 @@ excerpt: v2.0.0-beta.58 reworks how Platform classes are wired — resolve `Dura
 
 :::caution
 **Breaking — `Cloudflare.Worker`, `Cloudflare.Container`,
-`Cloudflare.DurableObjectNamespace`, and resource bindings.** beta.58
-moves props from the tag to `.make()`, replaces
-`Cloudflare.Container.bind` / `Cloudflare.start` with
-`yield*`-the-class + `Cloudflare.layerContainer`, standardizes
-resolving `DurableObjectState` in the **outer** init Effect, and
-replaces a resource's single `.bind` with namespaced,
-least-privilege capabilities (`Cloudflare.R2.ReadWriteBucket`).
-Migration for each is below.
+`Cloudflare.DurableObjectNamespace`, resource bindings, the `Build`
+module, and `DynamicWorkerLoader`.** beta.58 moves props from the
+tag to `.make()`, replaces `Cloudflare.Container.bind` /
+`Cloudflare.start` with `yield*`-the-class +
+`Cloudflare.layerContainer`, standardizes resolving
+`DurableObjectState` in the **outer** init Effect, and replaces a
+resource's single `.bind` with namespaced, least-privilege
+capabilities (`Cloudflare.R2.ReadWriteBucket`). The `Build` module
+is removed in favor of a new `Command` module (`Build.Command` →
+`Command.Build`, `Build.DevServer` → `Command.Dev`), and
+`DynamicWorkerLoader` is renamed to `WorkerLoader`. Migration for
+each is below.
 :::
 
 `v2.0.0-beta.58` is a Platform ergonomics release built around one
@@ -262,6 +266,67 @@ key, no manual token plumbing.
 The Read / Write / ReadWrite split and `*Binding` / `*Http`
 implementations follow the same convention across KV, Queues, and the
 other capability resources.
+
+## `Command`: run shell commands as resources
+
+The `Build` module is gone, replaced by a unified `Command` module
+that models shell commands as first-class resources sharing one
+executor ([#673](https://github.com/alchemy-run/alchemy-effect/pull/673)):
+
+- **`Command.Build`** (was `Build.Command`) — runs a command that
+  produces an output asset (`outdir`). Inputs/outputs are
+  content-hashed (opt-in via `memo`) so unchanged projects skip the
+  rebuild.
+- **`Command.Exec`** — new. Runs a command purely for its side
+  effects — migrations, codegen, seeding. No output contract: it
+  succeeds as long as the command exits `0`, and `memo` re-runs it
+  only when inputs change.
+- **`Command.Dev`** (was `Build.DevServer`) — a long-lived dev
+  server scoped to the stack instance. Runs in the dev sidecar so it
+  survives user-code HMR, and surfaces the first `http(s)://` URL it
+  prints as its `url` output.
+
+```typescript
+const migrate = yield* Command.Exec("migrate", {
+  command: "drizzle-kit migrate",
+  cwd: ".",
+});
+```
+
+`StaticSite` (AWS + Cloudflare) and `Cloudflare.Workers.Worker` now
+build and dev-serve through `Command`. Resource type IDs were
+renamed, so existing state referencing `Build.Command` /
+`Build.DevServer` won't match, and `Command.Build`'s output hash
+changed from `{ outdir, hash }` to `{ outdir, hash: { input, output } }`.
+
+## `WorkerLoader`: a typed, Effect-native loader
+
+`DynamicWorkerLoader` is renamed to `WorkerLoader` and is now a
+first-class Effect service with a typed runtime client
+([#653](https://github.com/alchemy-run/alchemy-effect/pull/653)).
+`load(...)` returns an Effect, so you `yield*` it:
+
+```diff lang="typescript"
+- const loader = yield* Cloudflare.DynamicWorkerLoader("Loader");
+- const worker = loader.load({ compatibilityDate, mainModule, modules });
++ const loader = yield* Cloudflare.WorkerLoader("Loader");
++ const worker = yield* loader.load({ compatibilityDate, mainModule, modules });
+```
+
+Because it's a `Context.Service`, you can require it as a tag and
+provide it via `WorkerLoader.layer(...)`, and the returned stub
+exposes typed RPC entrypoints:
+
+```typescript
+const api = worker.getEntrypoint<{
+  greet: (n: string) => Effect.Effect<string>;
+}>("api");
+const greeting = yield* api.greet("world");
+```
+
+`WorkerStub` / `WorkerEntrypoint<Shape>` wrap the raw Cloudflare stub
+with an Effect-native `fetch` + RPC, with sandboxing via
+`globalOutbound` and `tails` / `streamingTails`.
 
 ## Where to go next
 

--- a/website/src/content/docs/blog/2026-06-24-beta-58.md
+++ b/website/src/content/docs/blog/2026-06-24-beta-58.md
@@ -257,11 +257,26 @@ different Layer.
 
 The `*Http` Layer is what makes the same client work where there's
 no native binding — inside a **Container** process, for example.
-Providing it mints a scoped `AccountApiToken` with only the permission
-groups that access level needs and injects the token into the host's
-**secrets** — `secret_text` on a Worker, a secret on a Container. At
-runtime the client reads it and calls R2's REST API. No account-wide
-key, no manual token plumbing.
+Providing it mints a scoped `AccountApiToken` and binds a policy with
+only the permission groups that access level needs:
+
+```typescript
+const token = yield* AccountApiToken(`${self.LogicalId}Token`);
+yield* token.bind`${bucket.LogicalId}`({
+  policies: [
+    {
+      effect: "allow",
+      permissionGroups: options.permissionGroups, // e.g. R2 read-only
+      resources: { [`com.cloudflare.api.account.${accountId}`]: "*" },
+    },
+  ],
+});
+```
+
+The token's `value` is injected into the host's **secrets** —
+`secret_text` on a Worker, a secret on a Container. At runtime the
+client reads it and calls R2's REST API. No account-wide key, no
+manual token plumbing.
 
 The Read / Write / ReadWrite split and `*Binding` / `*Http`
 implementations follow the same convention across KV, Queues, and the

--- a/website/src/content/docs/blog/2026-06-24-beta-58.md
+++ b/website/src/content/docs/blog/2026-06-24-beta-58.md
@@ -7,12 +7,16 @@ excerpt: v2.0.0-beta.58 reworks how Platform classes are wired — resolve `Dura
 
 beta.58 reshapes how Platform classes are wired so that a single
 Layer can carry infrastructure and run the same way across Workers,
-Containers, and Durable Objects. A tagged class or capability is a
-**reference** you `yield*` to get a typed handle; its *configuration*
-and *implementation* are provided separately as a Layer. That split
-is what lets you build a Layer on top of a running Container, give one
-Worker tag two implementations, or read an R2 bucket over a native
-binding in one place and a scoped HTTP token in another.
+Containers, and Durable Objects. The pattern throughout: `yield*` a
+tag to get a typed handle, and provide its implementation as a Layer.
+
+```typescript
+// reference — a typed handle
+const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
+
+// implementation — provided separately as a Layer
+.pipe(Effect.provide(Cloudflare.R2.ReadWriteBucketBinding))
+```
 
 :::caution
 **Breaking changes** — migration for each is below.

--- a/website/src/content/docs/blog/2026-06-24-beta-58.md
+++ b/website/src/content/docs/blog/2026-06-24-beta-58.md
@@ -24,8 +24,24 @@ runtime implementation move out of the tag and into a Layer.
 ```
 
 As part of this, `DurableObjectState` can now be yielded at the top
-level of a Worker, instead of having to be resolved inside the nested
-`Effect.gen`.
+level, instead of having to be resolved inside the nested `Effect.gen`:
+
+```diff lang="typescript"
+  Effect.gen(function* () {
++   const state = yield* Cloudflare.DurableObjectState;
+    return Effect.gen(function* () {
+-     const state = yield* Cloudflare.DurableObjectState;
+      let count = (yield* state.storage.get<number>("count")) ?? 0;
+      /* ... */
+    });
+  }),
+```
+
+Why it matters: init is now the one place you resolve a DO's state,
+so you can capture it in a Layer and hand the runtime methods to a
+service — rather than re-resolving it inside every method. The I/O
+still runs in the nested Effect (it's `RuntimeContext`-colored), but
+the reference lives at the top.
 
 :::caution
 **Breaking changes** — migration for each is below.
@@ -79,41 +95,10 @@ export default Cloudflare.Worker(
 
 ## A tool on Durable Object storage
 
-A Durable Object has two nested `Effect.gen` blocks: the **outer**
-init resolves shared dependencies, the **inner** runtime returns the
-public methods. `Cloudflare.DurableObjectState` now resolves in the
-outer Effect — you yield the *reference* there, but its storage I/O
-still runs in the inner Effect.
-
-```diff lang="typescript"
-  Effect.gen(function* () {
-+   const state = yield* Cloudflare.DurableObjectState;
-    return Effect.gen(function* () {
--     const state = yield* Cloudflare.DurableObjectState;
-      let count = (yield* state.storage.get<number>("count")) ?? 0;
-      return {
-        increment: () =>
-          Effect.gen(function* () {
-            count += 1;
-            yield* state.storage.put("count", count);
-            return count;
-          }),
-      };
-    });
-  }),
-```
-
-You can yield the reference in the outer init, but you can't *use* it
-there — `state`'s methods (`storage.get`, `storage.put`, …) require
-`Alchemy.RuntimeContext`, which only exists inside the inner runtime
-closure (the [colored-function](/concepts/layers#runtime-as-a-colored-function)
-rule). So the reference resolves at init, but the I/O is type-checked
-into the inner Effect.
-
-That split is what lets you capture the DO's storage in a **Layer**
-and expose it as a service — the shape a `Sql` tool takes. Resolve
-`state` (and anything else, like an R2 bucket) at init, return the
-runtime methods:
+Resolving `DurableObjectState` at init is what lets you capture the
+DO's storage in a **Layer** and expose it as a service — the shape a
+`Sql` tool takes. Resolve `state` (and anything else, like an R2
+bucket) at init, return the runtime methods:
 
 ```typescript
 class Archive extends Context.Service<Archive, {


### PR DESCRIPTION
The beta.58 post only covered the Platform-ergonomics theme (#650). Adds the two other notable changes from the release and expands the breaking-change callout.

- New `## Command` section — the `Build` module is replaced by `Command` (`Command.Build`, new `Command.Exec`, `Command.Dev`), with the breaking state-ID and output-shape changes ([#673](https://github.com/alchemy-run/alchemy-effect/pull/673)).
- New `## WorkerLoader` section — `DynamicWorkerLoader` to `WorkerLoader`, now a `Context.Service` with an Effect-returning `load` and typed RPC entrypoints ([#653](https://github.com/alchemy-run/alchemy-effect/pull/653)).
- Caution callout now lists the `Build` removal and `WorkerLoader` rename.

Neon's breaking change and the Lambda features (arm64/memory/`build.install`) are intentionally left out.
