### PR TITLE
docs(website): document Container RPC in beta.58 blog

### DIFF
--- a/website/src/content/docs/blog/2026-06-24-beta-58.md
+++ b/website/src/content/docs/blog/2026-06-24-beta-58.md
@@ -217,10 +217,11 @@ with `Cloudflare.layerContainer` from the hosting Durable Object.
 
 ## RPC works in Containers
 
-A `Container` declares a typed runtime shape just like a Worker or
-Durable Object — and those methods are now callable over **RPC**. The
-container exposes Effect-returning methods alongside its `fetch`
-handler:
+Container RPC always existed on paper, but was never properly
+implemented or tested. As of beta.58 it actually works. A `Container`
+declares a typed runtime shape just like a Worker or Durable Object,
+and those methods are callable over **RPC** — the container exposes
+Effect-returning methods alongside its `fetch` handler:
 
 ```typescript
 export class MyContainer extends Cloudflare.Container<

--- a/website/src/content/docs/blog/2026-06-24-beta-58.md
+++ b/website/src/content/docs/blog/2026-06-24-beta-58.md
@@ -2,12 +2,13 @@
 title: 2.0.0-beta.58 - Platform Ergonomics
 date: 2026-06-24T22:00:00Z
 category: release
-excerpt: v2.0.0-beta.58 improves the ergonomics of Layers that contain Resources, so you can bundle infrastructure into a reusable service — like an agent tool — and provide it to a Worker, Container, or Durable Object. Plus Container RPC support.
+excerpt: v2.0.0-beta.58 improves the ergonomics of Layers that contain Resources, so you can bundle infrastructure into a reusable service — like an agent tool — and provide it to a Worker, Container, or Durable Object.
 ---
 
 beta.58 improves the ergonomics of Layers that contain Resources, so
 you can bundle infrastructure into a reusable service — like an agent
-tool — and provide it to a Worker, Container, or Durable Object.
+tool — and provide it to a Worker, Container, or Durable Object. It
+also makes RPC work in Containers.
 
 A few changes get us there. First, a Platform tag (e.g. a Worker or
 Container) becomes **pure identity**: its props and its runtime

--- a/website/src/content/docs/blog/2026-06-24-beta-58.md
+++ b/website/src/content/docs/blog/2026-06-24-beta-58.md
@@ -214,6 +214,50 @@ External and remote `Container` images (built from a `context` /
 `.make()` — declare their props inline on the tag and register them
 with `Cloudflare.layerContainer` from the hosting Durable Object.
 
+## RPC works in Containers
+
+A `Container` declares a typed runtime shape just like a Worker or
+Durable Object — and those methods are now callable over **RPC**. The
+container exposes Effect-returning methods alongside its `fetch`
+handler:
+
+```typescript
+export class MyContainer extends Cloudflare.Container<
+  MyContainer,
+  {
+    ping: () => Effect.Effect<string>;
+    readObject: (key: string) => Effect.Effect<string | null, never, RuntimeContext>;
+  }
+>()("MyContainer") {}
+
+export default MyContainer.make(
+  { main: import.meta.filename, dockerfile: "FROM oven/bun:latest" },
+  Effect.gen(function* () {
+    const bucket = yield* Cloudflare.R2.ReadWriteBucket(Storage);
+    return {
+      ping: () => Effect.succeed("pong"),
+      readObject: (key) => bucket.get(key).pipe(/* ... */),
+      fetch: Effect.gen(function* () {
+        /* ... */
+      }),
+    };
+  }).pipe(Effect.provide(Cloudflare.R2.ReadWriteBucketHttp)),
+);
+```
+
+From the host, `yield* MyContainer` gives the running container and
+its methods round-trip through Cloudflare's RPC machinery as typed
+Effects — no `fetch` plumbing, no manual serialization:
+
+```typescript
+const container = yield* MyContainer;
+const pong = yield* container.ping();           // RPC
+const body = yield* container.readObject("key"); // RPC
+```
+
+Use `container.getTcpPort(port)` when you do need a raw `fetch` into a
+server running inside the container process.
+
 ## `WorkerLoader`
 
 `DynamicWorkerLoader` is renamed to `WorkerLoader`, and `load(...)`

--- a/website/src/content/docs/blog/2026-06-24-beta-58.md
+++ b/website/src/content/docs/blog/2026-06-24-beta-58.md
@@ -7,8 +7,7 @@ excerpt: v2.0.0-beta.58 improves the ergonomics of Layers that contain Resources
 
 beta.58 improves the ergonomics of Layers that contain Resources, so
 you can bundle infrastructure into a reusable service — like an agent
-tool — and provide it to a Worker, Container, or Durable Object. It
-also makes RPC work in Containers.
+tool — and provide it to a Worker, Container, or Durable Object.
 
 A few changes get us there. First, a Platform tag (e.g. a Worker or
 Container) becomes **pure identity**: its props and its runtime

--- a/website/src/content/docs/blog/2026-06-24-beta-58.md
+++ b/website/src/content/docs/blog/2026-06-24-beta-58.md
@@ -2,7 +2,7 @@
 title: 2.0.0-beta.58 - Platform Ergonomics
 date: 2026-06-24T22:00:00Z
 category: release
-excerpt: v2.0.0-beta.58 improves the ergonomics of Layers that contain Resources, so you can bundle infrastructure into a reusable service — like an agent tool — and provide it to a Worker, Container, or Durable Object.
+excerpt: v2.0.0-beta.58 improves the ergonomics of Layers that contain Resources, so you can bundle infrastructure into a reusable service — like an agent tool — and provide it to a Worker, Container, or Durable Object. Plus Container RPC support.
 ---
 
 beta.58 improves the ergonomics of Layers that contain Resources, so


### PR DESCRIPTION
Follow-up to #689. Adds a section to the beta.58 post documenting that RPC now works in Containers.

A `Container` declares a typed runtime shape (Effect-returning methods alongside `fetch`), and the host calls those methods over RPC via `yield* MyContainer`:

```ts
const container = yield* MyContainer;
const pong = yield* container.ping();            // RPC
const body = yield* container.readObject("key"); // RPC
```

Modeled on the `effectful/container.ts` test fixture. `getTcpPort` is noted for raw `fetch` into the container process.
