### PR TITLE
fix(engine): honor deleteFirst on replace

### DIFF
--- a/packages/alchemy/src/Apply.ts
+++ b/packages/alchemy/src/Apply.ts
@@ -38,6 +38,7 @@ import {
   type PersistedState,
   type RanActionState,
   type ReplacedResourceState,
+  type ReplacementOldResourceState,
   type ReplacingResourceState,
   type ResourceState,
   type RunningActionState,
@@ -854,6 +855,58 @@ const executeNode = (
           replState = node.state;
         }
 
+        // ── delete-first replacements ──
+        //
+        // By default a replacement is create-first: the new generation is
+        // created here and the old generation(s) are reclaimed afterwards by
+        // `collectGarbage` (Phase 2). That ordering keeps the old resource
+        // alive if the create fails, but it is wrong for resources whose
+        // replacement cannot coexist with the original — a fixed physical
+        // name, a singleton, etc. Those providers return
+        // `{ action: "replace", deleteFirst: true }`.
+        //
+        // When `deleteFirst` is set we tear the previous generation(s) down
+        // BEFORE creating the new one, and commit the result as a terminal
+        // `created` state (rather than `replaced`) so Phase 2 has no old chain
+        // left to drain. `delete` is required to be idempotent, so a re-run
+        // after an interrupted apply simply re-converges.
+        const deleteOldGenerations = (
+          old: ReplacementOldResourceState,
+        ): Effect.Effect<void, any, any> =>
+          Effect.gen(function* () {
+            const retain = node.resource.RemovalPolicy === "retain";
+            if (old.attr !== undefined && !retain) {
+              yield* node.provider
+                .delete({
+                  id: logicalId,
+                  instanceId: old.instanceId,
+                  olds: old.props as never,
+                  output: old.attr,
+                  session: scopedSession,
+                  bindings: [],
+                })
+                .pipe(
+                  instrumentLifecycle(
+                    "delete",
+                    fqn,
+                    node.resource.Type,
+                    logicalId,
+                    old.instanceId,
+                  ),
+                );
+            }
+            if (old.status === "replacing" || old.status === "replaced") {
+              yield* deleteOldGenerations(old.old);
+            }
+          });
+
+        if (node.deleteFirst) {
+          yield* scopedSession.note(
+            "Deleting previous resource before creating its replacement (deleteFirst)...",
+          );
+          yield* deleteOldGenerations(replState.old);
+        }
+
         let attr: any = replState.attr;
 
         if (attr !== undefined) {
@@ -949,25 +1002,44 @@ const executeNode = (
             ),
           );
 
-        yield* commit<ReplacedResourceState>({
-          // Creation of the new generation succeeded; from here on the only remaining
-          // work is draining the old chain via garbage collection.
-          status: "replaced",
-          fqn,
-          logicalId,
-          instanceId,
-          resourceType: node.resource.Type,
-          props: news,
-          attr,
-          providerVersion: node.provider.version ?? 0,
-          bindings: excludeDeletedBindings(node.bindings),
-          downstream: node.downstream,
-          // Preserve the remaining backlog exactly as-is. GC is responsible for
-          // popping one generation at a time until the chain is exhausted.
-          old: replState.old,
-          deleteFirst: node.deleteFirst,
-          removalPolicy: node.resource.RemovalPolicy,
-        });
+        if (node.deleteFirst) {
+          // The old generation(s) were already torn down above, so there is
+          // nothing left for `collectGarbage` to drain — collapse straight to
+          // the terminal `created` state.
+          yield* commit<CreatedResourceState>({
+            status: "created",
+            fqn,
+            logicalId,
+            instanceId,
+            resourceType: node.resource.Type,
+            props: news,
+            attr,
+            providerVersion: node.provider.version ?? 0,
+            bindings: excludeDeletedBindings(node.bindings),
+            downstream: node.downstream,
+            removalPolicy: node.resource.RemovalPolicy,
+          });
+        } else {
+          yield* commit<ReplacedResourceState>({
+            // Creation of the new generation succeeded; from here on the only remaining
+            // work is draining the old chain via garbage collection.
+            status: "replaced",
+            fqn,
+            logicalId,
+            instanceId,
+            resourceType: node.resource.Type,
+            props: news,
+            attr,
+            providerVersion: node.provider.version ?? 0,
+            bindings: excludeDeletedBindings(node.bindings),
+            downstream: node.downstream,
+            // Preserve the remaining backlog exactly as-is. GC is responsible for
+            // popping one generation at a time until the chain is exhausted.
+            old: replState.old,
+            deleteFirst: node.deleteFirst,
+            removalPolicy: node.resource.RemovalPolicy,
+          });
+        }
 
         tracker[fqn] = {
           output: attr,

--- a/packages/alchemy/test/apply.test.ts
+++ b/packages/alchemy/test/apply.test.ts
@@ -18,6 +18,8 @@ import * as Redacted from "effect/Redacted";
 import {
   ArtifactProbe,
   BindingTarget,
+  CollisionRegistry,
+  DeleteFirstResource,
   DeletedBindingRegressionTarget,
   DurationResource,
   Function,
@@ -518,6 +520,137 @@ describe("linear update propagation", () => {
         // sequence as long as no stale value leaked through.
         expect(sawByB.length).toBeGreaterThan(0);
         expect(sawByB.every((v) => v === "v2")).toBe(true);
+      }),
+  );
+});
+
+// Regression: `deleteFirst` on a `replace` diff was plumbed from the provider
+// all the way into persisted state but never *read* — every replacement was
+// create-first, with the old generation reclaimed afterwards by Phase-2 GC.
+// That silently broke any resource whose replacement can't coexist with the
+// original (fixed physical name, singleton): the create collided with the
+// not-yet-deleted original. These tests pin both orderings.
+describe("deleteFirst replacements", () => {
+  test.provider(
+    "deletes the old generation BEFORE creating the replacement",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* DeleteFirstResource("R", { replaceString: "v1" });
+          }),
+        );
+
+        const order: string[] = [];
+        const recordHooks = {
+          create: () =>
+            Effect.sync(() => {
+              order.push("create");
+            }),
+          update: () => Effect.succeed(undefined),
+          delete: () =>
+            Effect.sync(() => {
+              order.push("delete");
+            }),
+        };
+
+        yield* Effect.gen(function* () {
+          return yield* DeleteFirstResource("R", { replaceString: "v2" });
+        }).pipe(stack.deploy, hook(recordHooks));
+
+        // The whole point: delete-old precedes create-new.
+        expect(order).toEqual(["delete", "create"]);
+
+        // The resource collapses straight to a terminal `created` state with
+        // no leftover replacement chain for GC to drain.
+        const state = yield* getState("R");
+        expect(state?.status).toEqual("created");
+        expect((state as { old?: unknown }).old).toBeUndefined();
+        expect(yield* listState()).toHaveLength(1);
+      }),
+  );
+
+  test.provider(
+    "default (non-deleteFirst) replacement still creates BEFORE deleting",
+    (stack) =>
+      Effect.gen(function* () {
+        // `TestResource` returns a plain `{ action: "replace" }` (deleteFirst
+        // defaults to false), so the engine must stay create-first.
+        yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* TestResource("R", { replaceString: "v1" });
+          }),
+        );
+
+        const order: string[] = [];
+        yield* Effect.gen(function* () {
+          return yield* TestResource("R", { replaceString: "v2" });
+        }).pipe(
+          stack.deploy,
+          hook({
+            create: () =>
+              Effect.sync(() => {
+                order.push("create");
+              }),
+            update: () => Effect.succeed(undefined),
+            delete: () =>
+              Effect.sync(() => {
+                order.push("delete");
+              }),
+          }),
+        );
+
+        expect(order).toEqual(["create", "delete"]);
+      }),
+  );
+
+  test.provider(
+    "lets a same-identity replacement succeed where create-first would collide",
+    (stack) =>
+      Effect.gen(function* () {
+        // A shared registry of live physical names. The provider's create
+        // fails if the (fixed) name is still live — exactly the failure mode
+        // of a real fixed-name resource (Docker network "already exists",
+        // no-op `volume create`) when create runs before the old is deleted.
+        const registry = { live: new Set<string>() };
+        const withRegistry = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+          effect.pipe(
+            Effect.provide(Layer.succeed(CollisionRegistry, registry)),
+          );
+
+        yield* stack
+          .deploy(
+            Effect.gen(function* () {
+              return yield* DeleteFirstResource("R", {
+                name: "singleton",
+                replaceString: "v1",
+              });
+            }),
+          )
+          .pipe(withRegistry);
+        expect(registry.live.has("singleton")).toBe(true);
+
+        // Before the fix this deploy died with a CollisionError because the
+        // create of the new "singleton" ran while the old one was still live.
+        const result = yield* stack
+          .deploy(
+            Effect.gen(function* () {
+              return yield* DeleteFirstResource("R", {
+                name: "singleton",
+                replaceString: "v2",
+              });
+            }),
+          )
+          .pipe(withRegistry);
+
+        expect(result.name).toEqual("singleton");
+        expect(result.replaceString).toEqual("v2");
+        // Exactly one live instance remains (old torn down, new created).
+        expect(registry.live.size).toBe(1);
+        expect(registry.live.has("singleton")).toBe(true);
+
+        const state = yield* getState("R");
+        expect(state?.status).toEqual("created");
       }),
   );
 });

--- a/packages/alchemy/test/test.resources.ts
+++ b/packages/alchemy/test/test.resources.ts
@@ -845,6 +845,112 @@ export const durationResourceProvider = () =>
     delete: Effect.fn(function* () {}),
   });
 
+// DeleteFirstResource — exercises `{ action: "replace", deleteFirst: true }`.
+//
+// Models a resource whose replacement cannot coexist with the original (a
+// fixed physical name / singleton). When `replaceString` changes it asks the
+// engine to tear the old generation down BEFORE creating the new one.
+//
+// Two test affordances:
+//   - create/update/delete route through `TestResourceHooks` so a test can
+//     record the order the engine invokes them in.
+//   - if a `CollisionRegistry` is in context, create fails when an instance
+//     with the same physical `name` is still live. Under create-first ordering
+//     a same-name replacement would collide here (reproducing the real Docker
+//     "network already exists" / no-op `volume create` bug); under delete-first
+//     it succeeds.
+
+export class CollisionRegistry extends Context.Service<
+  CollisionRegistry,
+  { readonly live: Set<string> }
+>()("CollisionRegistry") {}
+
+export class CollisionError extends Data.TaggedError("CollisionError")<{
+  name: string;
+}> {}
+
+export type DeleteFirstResourceProps = {
+  string?: string;
+  replaceString?: string;
+  name?: string;
+};
+
+export interface DeleteFirstResource extends Resource<
+  "Test.DeleteFirstResource",
+  DeleteFirstResourceProps,
+  {
+    name: string;
+    string: string;
+    replaceString: DeleteFirstResourceProps["replaceString"];
+  }
+> {}
+
+export const DeleteFirstResource = Resource<DeleteFirstResource>(
+  "Test.DeleteFirstResource",
+);
+
+export const deleteFirstResourceProvider = () =>
+  Provider.succeed(DeleteFirstResource, {
+    list: () => Effect.succeed([]),
+    diff: Effect.fn(function* ({ news = {}, olds = {} }) {
+      if (!isResolved(news)) return undefined;
+      const n = news as DeleteFirstResourceProps;
+      const o = olds as DeleteFirstResourceProps;
+      if (n.replaceString !== o.replaceString) {
+        return { action: "replace", deleteFirst: true } as const;
+      }
+      if (n.string !== o.string) {
+        return { action: "update" } as const;
+      }
+      return undefined;
+    }),
+    reconcile: Effect.fn(function* ({ id, news = {}, olds }) {
+      const name = news.name ?? id;
+      const hooks = Option.getOrUndefined(
+        yield* Effect.serviceOption(TestResourceHooks),
+      );
+      const registry = Option.getOrUndefined(
+        yield* Effect.serviceOption(CollisionRegistry),
+      );
+      // `olds === undefined` ⇒ create (greenfield OR replacement-create); the
+      // engine clears `olds` when minting the new replacement generation.
+      if (olds === undefined) {
+        if (registry?.live.has(name)) {
+          return yield* Effect.fail(new CollisionError({ name }));
+        }
+        registry?.live.add(name);
+        if (hooks?.create) {
+          yield* hooks.create(id, {
+            string: news.string,
+            replaceString: news.replaceString,
+          });
+        }
+      } else if (hooks?.update) {
+        yield* hooks.update(id, {
+          string: news.string,
+          replaceString: news.replaceString,
+        });
+      }
+      return {
+        name,
+        string: news.string ?? id,
+        replaceString: news.replaceString,
+      };
+    }),
+    delete: Effect.fn(function* ({ id, output }) {
+      const hooks = Option.getOrUndefined(
+        yield* Effect.serviceOption(TestResourceHooks),
+      );
+      const registry = Option.getOrUndefined(
+        yield* Effect.serviceOption(CollisionRegistry),
+      );
+      registry?.live.delete(output.name);
+      if (hooks?.delete) {
+        yield* hooks.delete(id);
+      }
+    }),
+  });
+
 // Layers
 export const TestLayers = () =>
   Layer.mergeAll(
@@ -861,6 +967,7 @@ export const TestLayers = () =>
     phasedTargetProvider(),
     noPrecreateBindingTargetProvider(),
     durationResourceProvider(),
+    deleteFirstResourceProvider(),
   );
 
 export const InMemoryTestLayers = () =>


### PR DESCRIPTION
`deleteFirst` was plumbed from a provider's replace diff into persisted state but the apply engine never read it — every replacement was create-first, with the old generation reclaimed afterwards by Phase-2 GC. That silently broke any resource whose replacement can't coexist with the original (fixed physical name, singleton): the new create collided with the not-yet-deleted original (Docker `network ... already exists`, no-op `volume create`, etc.).

When a provider returns:

```ts
diff: () => ({ action: "replace", deleteFirst: true })
```

the engine now tears the previous generation(s) down **before** creating the replacement, then commits a terminal `created` state so Phase-2 GC has no old chain left to drain:

```diff
+if (node.deleteFirst) {
+  yield* deleteOldGenerations(replState.old); // walk + delete the old chain
+}
 // ...create the new generation...
-yield* commit<ReplacedResourceState>({ status: "replaced", old: replState.old, ... });
+yield* commit<CreatedResourceState>({ status: "created", ... }); // deleteFirst path
```

`delete` is already required to be idempotent, so an interrupted apply re-converges on re-run.

### Tests

Three cases in `apply.test.ts`, backed by a new `DeleteFirstResource` + `CollisionRegistry` fixture:

- `deleteFirst` replacement deletes-then-creates (asserts hook order `["delete", "create"]`) and lands in terminal `created` with no leftover chain.
- default replacement is unchanged — still create-first (`["create", "delete"]`).
- regression: a same-identity (`name: "singleton"`) replacement now succeeds where create-first previously died with a collision.
