### PR TITLE
fix(cloudflare/worker): tolerate legacy custom-domain state in Worker diff (#546)

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -37,6 +37,27 @@ class MissingDurableObjectNamespaces extends Data.TaggedError(
   expected: string[];
 }> {}
 
+/**
+ * Normalize a Worker's persisted `domains` state to `https://<hostname>`
+ * strings. Alchemy <= beta.44 stored each custom domain as a
+ * `{ id, hostname, zoneId }` object; beta.45+ stores `https://<hostname>`
+ * strings and the diff path calls string methods on each entry. Older state is
+ * coerced back to strings so `.endsWith` does not throw `u.endsWith is not a
+ * function` (#546). Entries that are neither a string nor an object with a
+ * string `hostname` are dropped rather than turned into a bogus `https://`
+ * value that would skew the diff.
+ *
+ * @internal exported for unit testing.
+ */
+export const normalizeStateDomains = (
+  domains: readonly unknown[] | undefined,
+): string[] =>
+  (domains ?? []).flatMap((u) => {
+    if (typeof u === "string") return [u];
+    const hostname = (u as { hostname?: unknown } | null)?.hostname;
+    return typeof hostname === "string" ? [`https://${hostname}`] : [];
+  });
+
 export const WorkerProvider = () =>
   ProviderLayer.select({
     live: () => LiveWorkerProvider(),
@@ -1205,7 +1226,7 @@ export const LiveWorkerProvider = () =>
           const newDomains = normalizeDomains(news.domain)
             .map((h) => `https://${h}`)
             .sort();
-          const oldDomains = (output?.domains ?? [])
+          const oldDomains = normalizeStateDomains(output?.domains)
             .filter((u) => !u.endsWith(".workers.dev"))
             .sort();
           const domainsChanged =
@@ -1240,7 +1261,9 @@ export const LiveWorkerProvider = () =>
             newCustomDomains.length > 0
               ? `https://${newCustomDomains[0]}`
               : news.url !== false
-                ? (output.domains ?? []).find((u) => u.endsWith(".workers.dev"))
+                ? normalizeStateDomains(output.domains).find((u) =>
+                    u.endsWith(".workers.dev"),
+                  )
                 : undefined;
           const urlStable = newUrl !== undefined && newUrl === output.url;
           // `durableObjectNamespaces` maps each hosted DO class name to the

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerProvider.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerProvider.test.ts
@@ -1,0 +1,62 @@
+import { normalizeStateDomains } from "@/Cloudflare/Workers/WorkerProvider";
+import { describe, expect, test } from "@effect/vitest";
+
+describe("WorkerProvider", () => {
+  describe("normalizeStateDomains", () => {
+    // Worker state written by Alchemy <= beta.44 stored each custom domain as a
+    // `{ id, hostname, zoneId }` object; beta.45+ stores `https://<hostname>`
+    // strings. The diff path then called `.endsWith` directly on each entry and
+    // threw `u.endsWith is not a function` when reading the older object state
+    // (#546).
+    test("coerces legacy domain objects to https:// strings", () => {
+      expect(
+        normalizeStateDomains([
+          { id: "abc", hostname: "metrics.example.com", zoneId: "z1" },
+        ]),
+      ).toEqual(["https://metrics.example.com"]);
+    });
+
+    test("leaves modern string entries untouched", () => {
+      expect(
+        normalizeStateDomains([
+          "https://app.example.com",
+          "https://my-worker.acct.workers.dev",
+        ]),
+      ).toEqual([
+        "https://app.example.com",
+        "https://my-worker.acct.workers.dev",
+      ]);
+    });
+
+    test("keeps the diff filter and workers.dev lookup working after normalization", () => {
+      const normalized = normalizeStateDomains([
+        { id: "abc", hostname: "app.example.com", zoneId: "z1" },
+        "https://my-worker.acct.workers.dev",
+      ]);
+      // custom domains used by the domainsChanged diff (workers.dev excluded)
+      expect(normalized.filter((u) => !u.endsWith(".workers.dev"))).toEqual([
+        "https://app.example.com",
+      ]);
+      // the workers.dev url stays findable for the `newUrl` computation
+      expect(normalized.find((u) => u.endsWith(".workers.dev"))).toBe(
+        "https://my-worker.acct.workers.dev",
+      );
+    });
+
+    test("drops entries that are neither strings nor objects with a string hostname", () => {
+      expect(
+        normalizeStateDomains([
+          "https://keep.example.com",
+          { id: "no-hostname" },
+          { hostname: 123 },
+          null,
+          42,
+        ]),
+      ).toEqual(["https://keep.example.com"]);
+    });
+
+    test("returns an empty array for undefined state", () => {
+      expect(normalizeStateDomains(undefined)).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
Closes #546.

## Problem

Upgrading a Worker that has custom domains from an older Alchemy version crashes during plan/diff:

```
TypeError: u.endsWith is not a function
    at Cloudflare/Workers/WorkerProvider.ts (Worker diff)
```

Worker state written by Alchemy **≤ beta.44** stored each custom domain as a `{ id, hostname, zoneId }` object; **beta.45+** stores `https://<hostname>` strings and the diff path calls string methods directly on each persisted entry:

```ts
const oldDomains = (output?.domains ?? [])
  .filter((u) => !u.endsWith(".workers.dev"))   // u is an object in ≤ beta.44 state
```

So the first deploy after crossing the beta.44 → beta.45 boundary reads the legacy objects and throws. It aborts during planning (before apply), so nothing is mutated — but the deploy can never proceed. (Bisected: beta.44 has no `.endsWith` on `domains`; it appears in beta.45.)

## Fix

Add a `normalizeStateDomains` helper that coerces legacy `{ hostname }` objects back to `https://<hostname>` strings — matching the format the write path already produces (`https://${d.hostname}`) — before the diff reads them. Applied at both `output.domains` read sites: the `oldDomains` diff and the `newUrl` workers.dev lookup. Entries that are neither strings nor `{ hostname: string }` objects are dropped rather than coerced into a bogus `https://` value that would skew the diff.

Transitional by nature: once a deploy succeeds, state is rewritten in the string format and the helper is a no-op for that resource.

## Test

Adds `test/Cloudflare/Workers/WorkerProvider.test.ts` (unit, `@effect/vitest`, no live CF) covering: legacy object → string, modern strings untouched, the diff-filter + workers.dev lookup still working after normalization, junk entries dropped, and `undefined → []`.