### PR TITLE
fix(cli): load the stack entry via a file:// URL so the CLI works on Windows

### DIFF
--- a/packages/alchemy/src/Cli/commands/_shared.ts
+++ b/packages/alchemy/src/Cli/commands/_shared.ts
@@ -9,6 +9,7 @@ import * as S from "effect/Schema";
 import * as Argument from "effect/unstable/cli/Argument";
 import * as CliError from "effect/unstable/cli/CliError";
 import * as Flag from "effect/unstable/cli/Flag";
+import { pathToFileURL } from "node:url";
 
 import {
   type AuthProvider,
@@ -301,7 +302,12 @@ export const printProfile = Effect.fn(function* (
 
 export const importStack = Effect.fn(function* (main: string) {
   const path = yield* Path.Path;
-  const url = import.meta.resolve(path.resolve(main));
+  // Build a `file://` URL from the absolute path. `import.meta.resolve` expects a
+  // module specifier / URL, not a raw filesystem path: on Windows an absolute
+  // path like `D:\stack.ts` is not a valid specifier and fails to resolve, so the
+  // CLI cannot load the user's stack. `pathToFileURL` produces a valid URL on
+  // every platform.
+  const url = pathToFileURL(path.resolve(main)).href;
   const module = yield* Effect.promise(() => import(url));
   const stackEffect = module.default as ReturnType<
     ReturnType<typeof Stack.make>


### PR DESCRIPTION
`alchemy deploy` / `alchemy dev` cannot load the stack entry on Windows. `importStack` passes a raw absolute path to `import.meta.resolve`, which expects a module specifier or URL — on Windows an absolute path like `D:\stack.ts` is not a valid specifier, so resolution fails and the CLI never imports the user's stack.

Convert the resolved path to a `file://` URL first, matching the existing `pathToFileURL` usage in `Cloudflare/Workers/Vite.ts`:

```diff
-  const url = import.meta.resolve(path.resolve(main));
+  const url = pathToFileURL(path.resolve(main)).href;
```

`pathToFileURL` produces a valid `file://` URL on every platform, so POSIX is unaffected.
