### PR TITLE
docs(queues): use worker.workerName in Consumer examples

### DIFF
--- a/packages/alchemy/src/Cloudflare/Queues/Consumer.ts
+++ b/packages/alchemy/src/Cloudflare/Queues/Consumer.ts
@@ -98,7 +98,7 @@ export type Consumer = Resource<
  *
  * yield* Cloudflare.Queues.Consumer("MyConsumer", {
  *   queueId: queue.queueId,
- *   scriptName: "my-worker",
+ *   scriptName: worker.workerName,
  * });
  * ```
  *
@@ -106,7 +106,7 @@ export type Consumer = Resource<
  * ```typescript
  * yield* Cloudflare.Queues.Consumer("MyConsumer", {
  *   queueId: queue.queueId,
- *   scriptName: "my-worker",
+ *   scriptName: worker.workerName,
  *   settings: {
  *     batchSize: 50,
  *     maxRetries: 5,


### PR DESCRIPTION
The "Registering a Consumer" examples hardcoded `scriptName: "my-worker"` while a `Worker` resource was already in scope. Reference `worker.workerName` instead, matching the convention used elsewhere (`Workflow`, `EventSource`, the `DurableObject` docs, and the `examples/` stacks).