### PR TITLE
refactor: use import.meta.url instead of import.meta.filename

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -738,7 +738,7 @@ import { Gateway } from "./gateway.ts";
 export default class TestWorker extends Cloudflare.Worker<TestWorker>()(
   "TestWorker",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const aiGateway = yield* Cloudflare.AIbind(Gateway);

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ const Bucket = Cloudflare.R2Bucket("bucket");
 
 export default Cloudflare.Worker(
   "api",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const bucket = yield* Cloudflare.R2.ReadWrite(Bucket);
     return {

--- a/examples/aws-ec2/src/Server.ts
+++ b/examples/aws-ec2/src/Server.ts
@@ -14,7 +14,7 @@ export default class Server extends AWS.EC2.Instance<Server>()(
     const network = yield* Network;
 
     return {
-      main: import.meta.filename,
+      main: import.meta.url,
       imageId,
       instanceType: "t3.small",
       subnetId: network.publicSubnetIds[0],

--- a/examples/aws-ecs/src/QueueConsumerTask.ts
+++ b/examples/aws-ecs/src/QueueConsumerTask.ts
@@ -8,7 +8,7 @@ import { JobsQueue, JobsQueueLive } from "./JobsQueue.ts";
 export default class QueueConsumerTask extends AWS.ECS.Task<QueueConsumerTask>()(
   "QueueConsumerTask",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
     cpu: 256,
     memory: 512,
     taskRoleManagedPolicyArns: ["arn:aws:iam::aws:policy/AmazonSQSFullAccess"],

--- a/examples/aws-ecs/src/Task.ts
+++ b/examples/aws-ecs/src/Task.ts
@@ -8,7 +8,7 @@ import { JobsQueue, JobsQueueLive } from "./JobsQueue.ts";
 export default class ApiTask extends AWS.ECS.Task<ApiTask>()(
   "ApiTask",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
     cpu: 512,
     memory: 1024,
     port: 3000,

--- a/examples/aws-lambda-httpapi/src/JobFunction.ts
+++ b/examples/aws-lambda-httpapi/src/JobFunction.ts
@@ -11,7 +11,7 @@ import { JobStorageDynamoDB } from "./JobStorage.ts";
 export default class JobFunction extends AWS.Lambda.Function<JobFunction>()(
   "JobFunction",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
     url: true,
   },
   HttpRouter.toHttpEffect(JobApiLive).pipe(

--- a/examples/aws-lambda-rpc/src/JobFunction.ts
+++ b/examples/aws-lambda-rpc/src/JobFunction.ts
@@ -8,7 +8,7 @@ import { JobStorageDynamoDB } from "./JobStorage.ts";
 export default class JobFunction extends AWS.Lambda.Function<JobFunction>()(
   "JobFunction",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
     url: true,
   },
   JobRpcHttpEffect.pipe(

--- a/examples/aws-lambda/src/JobFunction.ts
+++ b/examples/aws-lambda/src/JobFunction.ts
@@ -19,7 +19,7 @@ import {
 export default class JobFunction extends AWS.Lambda.Function<JobFunction>()(
   "JobFunction",
   Stack.useSync((stack) => ({
-    main: import.meta.filename,
+    main: import.meta.url,
     memory: stack.stage === "prod" ? 1024 : 512,
     url: true,
   })),

--- a/examples/aws-rds/src/ServiceFunction.ts
+++ b/examples/aws-rds/src/ServiceFunction.ts
@@ -10,7 +10,7 @@ import { NetworkLive } from "./Network.ts";
 export default class ServiceFunction extends AWS.Lambda.Function<ServiceFunction>()(
   "ServiceFunction",
   Stack.useSync((stack) => ({
-    main: import.meta.filename,
+    main: import.meta.url,
     memory: stack.stage === "prod" ? 1024 : 512,
     runtime: "nodejs24.x",
   })),

--- a/examples/aws-rest-api/src/JobFunction.ts
+++ b/examples/aws-rest-api/src/JobFunction.ts
@@ -2,7 +2,7 @@ import * as AWS from "alchemy/AWS";
 import * as Effect from "effect/Effect";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 
-const main = import.meta.filename;
+const main = import.meta.url;
 
 /**
  * Minimal Lambda for API Gateway `AWS_PROXY` — returns plain text.

--- a/examples/cloudflare-agent/src/DevBox.ts
+++ b/examples/cloudflare-agent/src/DevBox.ts
@@ -21,7 +21,7 @@ export class DevBox extends Cloudflare.Container<
 
 export default DevBox.make(
   {
-    main: import.meta.filename,
+    main: import.meta.url,
     dockerfile: `FROM oven/bun:1.3`,
   },
   Effect.gen(function* () {

--- a/examples/cloudflare-agent/src/ReleaseService.ts
+++ b/examples/cloudflare-agent/src/ReleaseService.ts
@@ -6,7 +6,7 @@ import { ReleaseVersion } from "./ReleaseVersion.ts";
 
 export default Cloudflare.Worker(
   "ReleaseService",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const versions = yield* ReleaseVersion;
 

--- a/examples/cloudflare-dev/src/EffectWorker.ts
+++ b/examples/cloudflare-dev/src/EffectWorker.ts
@@ -24,7 +24,7 @@ interface Message {
 export default class EffectWorker extends Cloudflare.Worker<EffectWorker>()(
   "EffectWorker",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
     dev: {
       port: Config.number("PORT").pipe(Config.withDefault(1338)),
     },

--- a/examples/cloudflare-dev/src/SandboxContainer.ts
+++ b/examples/cloudflare-dev/src/SandboxContainer.ts
@@ -9,7 +9,7 @@ export class SandboxContainer extends Cloudflare.Container<
 >()(
   "SandboxContainer",
   Stack.useSync((stack) => ({
-    main: import.meta.filename,
+    main: import.meta.url,
     instanceType: stack.stage === "prod" ? "standard-1" : "dev",
     observability: {
       logs: {

--- a/examples/cloudflare-email/src/Api.ts
+++ b/examples/cloudflare-email/src/Api.ts
@@ -16,7 +16,7 @@ import { DESTINATION, SendEmail, SENDER } from "./Email.ts";
 export default class Api extends Cloudflare.Worker<Api>()(
   "Api",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const email = yield* Cloudflare.Email.Send(SendEmail);

--- a/examples/cloudflare-git-artifacts/src/Worker.ts
+++ b/examples/cloudflare-git-artifacts/src/Worker.ts
@@ -29,7 +29,7 @@ const HttpPlatformStub = Layer.succeed(HttpPlatform.HttpPlatform, {
 export default class Worker extends Cloudflare.Worker<Worker>()(
   "Api",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
     observability: { enabled: true },
     compatibility: {
       flags: ["nodejs_compat"],

--- a/examples/cloudflare-neon-drizzle/src/Api.ts
+++ b/examples/cloudflare-neon-drizzle/src/Api.ts
@@ -11,7 +11,7 @@ import { relations, Users } from "./schema.ts";
 export default class Api extends Cloudflare.Worker<Api>()(
   "Api",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const conn = yield* Cloudflare.Hyperdrive.Connect(Hyperdrive);

--- a/examples/cloudflare-planetscale-mysql-drizzle/src/Api.ts
+++ b/examples/cloudflare-planetscale-mysql-drizzle/src/Api.ts
@@ -13,7 +13,7 @@ import { relations, Users } from "./schema.ts";
 export default class Api extends Cloudflare.Worker<Api>()(
   "Api",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
     compatibility: {
       date: "2026-03-17",
       flags: ["nodejs_compat"],

--- a/examples/cloudflare-planetscale-postgres-drizzle/src/Api.ts
+++ b/examples/cloudflare-planetscale-postgres-drizzle/src/Api.ts
@@ -11,7 +11,7 @@ import { relations, Users } from "./schema.ts";
 export default class Api extends Cloudflare.Worker<Api>()(
   "Api",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const conn = yield* Cloudflare.Hyperdrive.Connect(Hyperdrive);

--- a/examples/cloudflare-secrets-store/src/Api.ts
+++ b/examples/cloudflare-secrets-store/src/Api.ts
@@ -8,7 +8,7 @@ import { ApiKey } from "./ApiKey.ts";
 export default class Api extends Cloudflare.Worker<Api>()(
   "Api",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const apiKey = yield* Cloudflare.SecretsStore.ReadSecret(ApiKey);

--- a/examples/cloudflare-tanstack/src/backend.ts
+++ b/examples/cloudflare-tanstack/src/backend.ts
@@ -8,7 +8,7 @@ export const Bucket = Cloudflare.R2.Bucket("Bucket");
 export default class Backend extends Cloudflare.Worker<Backend>()(
   "Backend",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);

--- a/examples/cloudflare-worker-auth/src/Api.ts
+++ b/examples/cloudflare-worker-auth/src/Api.ts
@@ -18,7 +18,7 @@ import { AuthToken } from "./AuthToken.ts";
 export default class Api extends Cloudflare.Worker<Api>()(
   "Api",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const authToken = yield* Cloudflare.SecretsStore.ReadSecret(AuthToken);

--- a/examples/cloudflare-worker/src/Api.ts
+++ b/examples/cloudflare-worker/src/Api.ts
@@ -24,7 +24,7 @@ interface QueueMessageBody {
 export default class Api extends Cloudflare.Worker<Api>()(
   "Api",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
     observability: {
       enabled: true,
     },

--- a/examples/cloudflare-worker/src/Sandbox.ts
+++ b/examples/cloudflare-worker/src/Sandbox.ts
@@ -27,7 +27,7 @@ export class Sandbox extends Cloudflare.Container<
 
 export const SandboxLive = /* @__PURE__ */ Sandbox.make(
   Stack.useSync((stack) => ({
-    main: import.meta.filename,
+    main: import.meta.url,
     instanceType: stack.stage === "prod" ? "standard-1" : "dev",
     observability: {
       logs: {

--- a/examples/cloudflare-worker/src/SecondaryApi.ts
+++ b/examples/cloudflare-worker/src/SecondaryApi.ts
@@ -15,7 +15,7 @@ export class SecondaryApi extends Cloudflare.Worker<SecondaryApi, {}>()(
 
 export default SecondaryApi.make(
   {
-    main: import.meta.filename,
+    main: import.meta.url,
     observability: { enabled: true },
   },
   Effect.gen(function* () {

--- a/examples/cloudflare-worker/src/WorkerTag.ts
+++ b/examples/cloudflare-worker/src/WorkerTag.ts
@@ -11,7 +11,7 @@ export class WorkerTag extends Cloudflare.Worker<WorkerTag, {}>()(
 
 export default WorkerTag.make(
   {
-    main: import.meta.filename,
+    main: import.meta.url,
     compatibility: {
       flags: ["nodejs_compat"],
       date: "2026-04-26",

--- a/examples/monorepo-multi-stack/backend/src/Service.ts
+++ b/examples/monorepo-multi-stack/backend/src/Service.ts
@@ -10,7 +10,7 @@ import { BackendApi, Greeting } from "./Spec.ts";
 export default class Service extends Cloudflare.Worker<Service>()(
   "Service",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const helloGroup = HttpApiBuilder.group(BackendApi, "Hello", (handlers) =>

--- a/examples/monorepo-single-stack/backend/src/Service.ts
+++ b/examples/monorepo-single-stack/backend/src/Service.ts
@@ -10,7 +10,7 @@ import { BackendApi, Greeting } from "./Spec.ts";
 export default class Service extends Cloudflare.Worker<Service>()(
   "Service",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const helloGroup = HttpApiBuilder.group(BackendApi, "Hello", (handlers) =>

--- a/packages/alchemy/src/AWS/AutoScaling/LaunchTemplate.ts
+++ b/packages/alchemy/src/AWS/AutoScaling/LaunchTemplate.ts
@@ -147,7 +147,7 @@ export type LaunchTemplateRuntimeContext = Ec2HostRuntimeContext;
  *   yield* Http.serve(HttpServerResponse.json({ ok: true }));
  *
  *   return {
- *     main: import.meta.filename,
+ *     main: import.meta.url,
  *     imageId,
  *     instanceType: "t3.small",
  *     securityGroupIds: [securityGroup.groupId],

--- a/packages/alchemy/src/AWS/EC2/Instance.ts
+++ b/packages/alchemy/src/AWS/EC2/Instance.ts
@@ -290,7 +290,7 @@ export type InstanceRuntimeContext = Ec2HostRuntimeContext;
  *   );
  *
  *   return {
- *     main: import.meta.filename,
+ *     main: import.meta.url,
  *     imageId,
  *     instanceType: "t3.small",
  *     subnetId: subnet.subnetId,

--- a/packages/alchemy/src/AWS/ECS/Task.ts
+++ b/packages/alchemy/src/AWS/ECS/Task.ts
@@ -52,7 +52,7 @@ export class TaskEnvironment extends Context.Service<
 export interface TaskProps extends PlatformProps {
   /**
    * Module entrypoint for the bundled task program. This should typically be
-   * `import.meta.filename` from an inline Effect program.
+   * `import.meta.url` from an inline Effect program.
    */
   main: string;
   /**
@@ -250,7 +250,7 @@ export interface TaskRuntimeContext extends ProcessContext {
  * @example Basic Task
  * ```typescript
  * const task = yield* Task("ApiTask", {
- *   main: import.meta.filename,
+ *   main: import.meta.url,
  *   cpu: 256,
  *   memory: 512,
  *   port: 3000,
@@ -261,7 +261,7 @@ export interface TaskRuntimeContext extends ProcessContext {
  * @example Task with a Sidecar
  * ```typescript
  * const task = yield* Task("ApiTask", {
- *   main: import.meta.filename,
+ *   main: import.meta.url,
  *   port: 3000,
  *   sidecars: [
  *     {
@@ -278,7 +278,7 @@ export interface TaskRuntimeContext extends ProcessContext {
  * @example ARM64 with EFS Volume and Ephemeral Storage
  * ```typescript
  * const task = yield* Task("WorkerTask", {
- *   main: import.meta.filename,
+ *   main: import.meta.url,
  *   runtimePlatform: { cpuArchitecture: "ARM64", operatingSystemFamily: "LINUX" },
  *   ephemeralStorage: { sizeInGiB: 40 },
  *   volumes: [

--- a/packages/alchemy/src/AWS/Lambda/Function.ts
+++ b/packages/alchemy/src/AWS/Lambda/Function.ts
@@ -333,7 +333,7 @@ const matchesConfiguredExternal = (
  * ```typescript
  * export default class ApiFunction extends AWS.Lambda.Function<ApiFunction>()(
  *   "ApiFunction",
- *   { main: import.meta.filename, url: true },
+ *   { main: import.meta.url, url: true },
  *   Effect.gen(function* () {
  *     // init: bind resources
  *     const getItem = yield* AWS.DynamoDB.GetItem(table);

--- a/packages/alchemy/src/Cloudflare/AI/Gateway.ts
+++ b/packages/alchemy/src/Cloudflare/AI/Gateway.ts
@@ -360,7 +360,7 @@ export const isAiGateway = (value: unknown): value is Gateway =>
  *
  * export default class Api extends Cloudflare.Worker<Api>()(
  *   "Api",
- *   { main: import.meta.filename },
+ *   { main: import.meta.url },
  *   Effect.gen(function* () {
  *     const aiGateway = yield* Cloudflare.AI.QueryGateway(Gateway);
  *

--- a/packages/alchemy/src/Cloudflare/AI/Search.ts
+++ b/packages/alchemy/src/Cloudflare/AI/Search.ts
@@ -235,7 +235,7 @@ export type Search = SearchInstance & {
  *
  * export default class Api extends Cloudflare.Worker<Api>()(
  *   "api",
- *   { main: import.meta.filename },
+ *   { main: import.meta.url },
  *   Effect.gen(function* () {
  *     const bucket = yield* Cloudflare.R2.Bucket("docs");
  *     const aiSearch = yield* Cloudflare.AI.Search("docs-search", {

--- a/packages/alchemy/src/Cloudflare/AI/SearchInstance.ts
+++ b/packages/alchemy/src/Cloudflare/AI/SearchInstance.ts
@@ -508,7 +508,7 @@ export type SearchInstance = Resource<
  *
  * export default class Api extends Cloudflare.Worker<Api>()(
  *   "api",
- *   { main: import.meta.filename },
+ *   { main: import.meta.url },
  *   Effect.gen(function* () {
  *     const bucket = yield* Cloudflare.R2.Bucket("docs", {});
  *     const instance = yield* Cloudflare.AI.SearchInstance("docs-search", {

--- a/packages/alchemy/src/Cloudflare/AI/SearchNamespace.ts
+++ b/packages/alchemy/src/Cloudflare/AI/SearchNamespace.ts
@@ -131,7 +131,7 @@ export type SearchNamespace = Resource<
  *
  * export default class Api extends Cloudflare.Worker<Api>()(
  *   "api",
- *   { main: import.meta.filename },
+ *   { main: import.meta.url },
  *   Effect.gen(function* () {
  *     const ns = yield* Cloudflare.AI.QuerySearchNamespace(Docs);
  *

--- a/packages/alchemy/src/Cloudflare/Containers/Container.ts
+++ b/packages/alchemy/src/Cloudflare/Containers/Container.ts
@@ -50,7 +50,7 @@ export interface ContainerStartupOptions extends cf.ContainerStartupOptions {}
  * {@link main} and bakes it in as the container's entrypoint.
  */
 export interface EffectfulContainerProps extends ContainerApplicationProps {
-  /** Entrypoint file for the Effect program, typically `import.meta.filename`. */
+  /** Entrypoint file for the Effect program, typically `import.meta.url`. */
   main: string;
 }
 /**
@@ -154,7 +154,7 @@ export type Container<Id extends string = string> = Named<Id> & {
  * ```typescript
  * // src/Sandbox.runtime.ts — props are the first argument to `.make()`
  * export default Sandbox.make(
- *   { main: import.meta.filename },
+ *   { main: import.meta.url },
  *   Effect.gen(function* () {
  *     const cp = yield* ChildProcessSpawner;
  *
@@ -202,7 +202,7 @@ export type Container<Id extends string = string> = Named<Id> & {
  * >()("Sandbox") {}
  *
  * export default Sandbox.make(
- *   { main: import.meta.filename },
+ *   { main: import.meta.url },
  *   Effect.gen(function* () {
  *     return Sandbox.of({
  *       ping: () => Effect.succeed("pong"),
@@ -265,7 +265,7 @@ export type Container<Id extends string = string> = Named<Id> & {
  * ```typescript
  * export const SandboxLive = Sandbox.make(
  *   Stack.useSync((stack) => ({
- *     main: import.meta.filename,
+ *     main: import.meta.url,
  *     instanceType: stack.stage === "prod" ? "standard-1" : "dev",
  *     observability: { logs: { enabled: true } },
  *   })),

--- a/packages/alchemy/src/Cloudflare/Containers/ContainerApplication.ts
+++ b/packages/alchemy/src/Cloudflare/Containers/ContainerApplication.ts
@@ -285,7 +285,7 @@ export type ContainerShape = Main<ContainerServices>;
  * import * as Cloudflare from "alchemy/Cloudflare";
  *
  * export class Sandbox extends Cloudflare.Container<Sandbox>()("Sandbox", {
- *   main: import.meta.filename,
+ *   main: import.meta.url,
  * }) {}
  * ```
  *
@@ -297,7 +297,7 @@ export type ContainerShape = Main<ContainerServices>;
  * @example Named container with a non-default handler export
  * ```typescript
  * export class Worker extends Cloudflare.Container<Worker>()("Worker", {
- *   main: import.meta.filename,
+ *   main: import.meta.url,
  *   handler: "runWorker",
  *   name: "background-worker",
  * }) {}
@@ -346,7 +346,7 @@ export type ContainerShape = Main<ContainerServices>;
  * @example Node runtime with external native deps
  * ```typescript
  * export class ImageApi extends Cloudflare.Container<ImageApi>()("ImageApi", {
- *   main: import.meta.filename,
+ *   main: import.meta.url,
  *   runtime: "node",
  *   external: ["sharp"],
  *   autoInstallExternals: true,
@@ -360,7 +360,7 @@ export type ContainerShape = Main<ContainerServices>;
  * @example Custom Dockerfile base and registry
  * ```typescript
  * export class Custom extends Cloudflare.Container<Custom>()("Custom", {
- *   main: import.meta.filename,
+ *   main: import.meta.url,
  *   dockerfile: "FROM oven/bun:1\nRUN apt-get update && apt-get install -y ffmpeg",
  *   autoInstallExternals: false,
  *   registryId: "registry.cloudflare.com",
@@ -380,7 +380,7 @@ export type ContainerShape = Main<ContainerServices>;
  * @example Autoscaling with a larger instance type
  * ```typescript
  * export class Sandbox extends Cloudflare.Container<Sandbox>()("Sandbox", {
- *   main: import.meta.filename,
+ *   main: import.meta.url,
  *   instanceType: "standard-1",
  *   instances: 1,
  *   maxInstances: 5,
@@ -394,7 +394,7 @@ export type ContainerShape = Main<ContainerServices>;
  * @example Explicit CPU, memory, and disk overrides
  * ```typescript
  * export class Heavy extends Cloudflare.Container<Heavy>()("Heavy", {
- *   main: import.meta.filename,
+ *   main: import.meta.url,
  *   vcpu: 2,
  *   memory: "4GB",
  *   disk: { size: "10GB" },
@@ -413,7 +413,7 @@ export type ContainerShape = Main<ContainerServices>;
  * @example Environment variables, secrets, and a command override
  * ```typescript
  * export class Api extends Cloudflare.Container<Api>()("Api", {
- *   main: import.meta.filename,
+ *   main: import.meta.url,
  *   environmentVariables: [{ name: "LOG_LEVEL", value: "info" }],
  *   secrets: [{ name: "API_KEY", type: "env", secret: "my-stored-secret" }],
  *   command: ["bun", "run", "start"],
@@ -429,7 +429,7 @@ export type ContainerShape = Main<ContainerServices>;
  * @example Passing env and selecting runtime exports
  * ```typescript
  * export class Job extends Cloudflare.Container<Job>()("Job", {
- *   main: import.meta.filename,
+ *   main: import.meta.url,
  *   env: { REGION: "wnam", FEATURE_FLAG: "on" },
  *   exports: ["default"],
  * }) {}
@@ -446,7 +446,7 @@ export type ContainerShape = Main<ContainerServices>;
  * @example Ports, network mode, DNS, and a health check
  * ```typescript
  * export class Web extends Cloudflare.Container<Web>()("Web", {
- *   main: import.meta.filename,
+ *   main: import.meta.url,
  *   ports: [{ name: "http", port: 8080 }],
  *   network: { assignIpv4: "predefined", mode: "public" },
  *   dns: { servers: ["1.1.1.1"], searches: ["internal"] },
@@ -466,7 +466,7 @@ export type ContainerShape = Main<ContainerServices>;
  * @example Enable logs and grant SSH access
  * ```typescript
  * export class Api extends Cloudflare.Container<Api>()("Api", {
- *   main: import.meta.filename,
+ *   main: import.meta.url,
  *   observability: { logs: { enabled: true } },
  *   sshPublicKeyIds: ["ssh-key-id-123"],
  * }) {}
@@ -484,7 +484,7 @@ export type ContainerShape = Main<ContainerServices>;
  * @example Pin scheduling policy and placement
  * ```typescript
  * export class Edge extends Cloudflare.Container<Edge>()("Edge", {
- *   main: import.meta.filename,
+ *   main: import.meta.url,
  *   schedulingPolicy: "regional",
  *   constraints: { tier: 1 },
  *   affinities: { colocation: "datacenter" },
@@ -503,7 +503,7 @@ export type ContainerShape = Main<ContainerServices>;
  * @example Progressive rollout on update
  * ```typescript
  * export class Api extends Cloudflare.Container<Api>()("Api", {
- *   main: import.meta.filename,
+ *   main: import.meta.url,
  *   instances: 4,
  *   maxInstances: 4,
  *   rollout: { strategy: "rolling", stepPercentage: 25 },

--- a/packages/alchemy/src/Cloudflare/DNS/ReadDns.ts
+++ b/packages/alchemy/src/Cloudflare/DNS/ReadDns.ts
@@ -36,7 +36,7 @@ import type { Zone } from "../Zone/Zone.ts";
  *
  * export class ReadDnserWorker extends Cloudflare.Worker<ReadDnserWorker>()(
  *   "ReadDnserWorker",
- *   { main: import.meta.filename },
+ *   { main: import.meta.url },
  *   Effect.gen(function* () {
  *     // Init phase — bind the read client scoped to the zone.
  *     const dns = yield* Cloudflare.DNS.ReadDns(Zone);

--- a/packages/alchemy/src/Cloudflare/DNS/ReadWriteDns.ts
+++ b/packages/alchemy/src/Cloudflare/DNS/ReadWriteDns.ts
@@ -32,7 +32,7 @@ import { type WriteDnsClient } from "./WriteDns.ts";
  *
  * export class Worker extends Cloudflare.Worker<Worker>()(
  *   "Worker",
- *   { main: import.meta.filename },
+ *   { main: import.meta.url },
  *   Effect.gen(function* () {
  *     // Init phase — bind the full CRUD client scoped to the zone.
  *     const dns = yield* Cloudflare.DNS.ReadWriteDns(Zone);

--- a/packages/alchemy/src/Cloudflare/DNS/WriteDns.ts
+++ b/packages/alchemy/src/Cloudflare/DNS/WriteDns.ts
@@ -46,7 +46,7 @@ import type { Zone } from "../Zone/Zone.ts";
  *
  * export class WriteDnsrWorker extends Cloudflare.Worker<WriteDnsrWorker>()(
  *   "WriteDnsrWorker",
- *   { main: import.meta.filename },
+ *   { main: import.meta.url },
  *   Effect.gen(function* () {
  *     // Init phase — bind the write client scoped to the zone.
  *     const dns = yield* Cloudflare.DNS.WriteDns(Zone);

--- a/packages/alchemy/src/Cloudflare/Flagship/App.ts
+++ b/packages/alchemy/src/Cloudflare/Flagship/App.ts
@@ -97,7 +97,7 @@ export type App = Resource<TypeId, AppProps, AppAttributes, never, Providers>;
  *
  * Cloudflare.Worker(
  *   "FlagsWorker",
- *   { main: import.meta.filename },
+ *   { main: import.meta.url },
  *   Effect.gen(function* () {
  *     const flags = yield* Cloudflare.Flagship.ReadFlags(App);
  *     return {

--- a/packages/alchemy/src/Cloudflare/Images/Images.ts
+++ b/packages/alchemy/src/Cloudflare/Images/Images.ts
@@ -33,7 +33,7 @@ export class ImagesError extends Data.TaggedError("ImagesError")<{
  * ```typescript
  * import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
  *
- * Cloudflare.Worker("ImageWorker", { main: import.meta.filename },
+ * Cloudflare.Worker("ImageWorker", { main: import.meta.url },
  *   Effect.gen(function* () {
  *     const images = yield* Cloudflare.Images.Images("PIPELINE");
  *     return {

--- a/packages/alchemy/src/Cloudflare/Queues/Queue.ts
+++ b/packages/alchemy/src/Cloudflare/Queues/Queue.ts
@@ -82,7 +82,7 @@ export type Queue = Resource<
  *
  * export default Cloudflare.Worker(
  *   "Worker",
- *   { main: import.meta.filename },
+ *   { main: import.meta.url },
  *   Effect.gen(function* () {
  *     const queue = yield* Cloudflare.Queues.WriteQueue(Queue);
  *

--- a/packages/alchemy/src/Cloudflare/StateStore/Api.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/Api.ts
@@ -101,7 +101,7 @@ export default Worker(
   "Api",
   {
     name: STATE_STORE_SCRIPT_NAME,
-    main: import.meta.filename,
+    main: import.meta.url,
     url: true,
     compatibility: {
       flags: ["nodejs_compat"],

--- a/packages/alchemy/src/Cloudflare/Workers/Browser.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Browser.ts
@@ -136,7 +136,7 @@ export interface BrowserClient {
  *
  * Cloudflare.Worker(
  *   "BrowserWorker",
- *   { main: import.meta.filename },
+ *   { main: import.meta.url },
  *   Effect.gen(function* () {
  *     const browser = yield* Cloudflare.Browser("BROWSER");
  *

--- a/packages/alchemy/src/Cloudflare/Workers/DurableObject.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/DurableObject.ts
@@ -354,7 +354,7 @@ export class DurableObjectScope extends Context.Service<
  * //                                       ^^^^^^^ declared as part of WorkerA's public contract
  * export class WorkerA extends Cloudflare.Worker<WorkerA, {}, Counter>()(
  *   "WorkerA",
- *   { main: import.meta.filename },
+ *   { main: import.meta.url },
  * ) {}
  *
  * // WorkerA's Layer also provides the DO's Live implementation.
@@ -374,7 +374,7 @@ export class DurableObjectScope extends Context.Service<
  *
  * export default class WorkerB extends Cloudflare.Worker<WorkerB>()(
  *   "WorkerB",
- *   { main: import.meta.filename },
+ *   { main: import.meta.url },
  *   Effect.gen(function* () {
  *     //              ^^^^^^^^^^^^ scriptName-bound stub of WorkerA's Counter
  *     const counter = yield* Counter.from(WorkerA);
@@ -430,7 +430,7 @@ export class DurableObjectScope extends Context.Service<
  * // workerC.ts — another host of Counter, isolated from WorkerA
  * export class WorkerC extends Cloudflare.Worker<WorkerC, {}, Counter>()(
  *   "WorkerC",
- *   { main: import.meta.filename },
+ *   { main: import.meta.url },
  * ) {}
  *
  * export default WorkerC.make(

--- a/packages/alchemy/src/Cloudflare/Workers/RpcDurableObject.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/RpcDurableObject.ts
@@ -315,7 +315,7 @@ export interface RpcDurableObjectClass extends Effect.Effect<
  *
  * export class WorkerA extends Cloudflare.Worker<WorkerA, {}, Counter>()(
  *   "WorkerA",
- *   { main: import.meta.filename },
+ *   { main: import.meta.url },
  * ) {}
  *
  * export default WorkerA.make(
@@ -328,7 +328,7 @@ export interface RpcDurableObjectClass extends Effect.Effect<
  * // consumer worker (binds via .from)
  * export default class WorkerB extends Cloudflare.Worker<WorkerB>()(
  *   "WorkerB",
- *   { main: import.meta.filename },
+ *   { main: import.meta.url },
  *   Effect.gen(function* () {
  *     const counters = yield* Counter.from(WorkerA);
  *     return {
@@ -351,7 +351,7 @@ export interface RpcDurableObjectClass extends Effect.Effect<
  * ```typescript
  * export class WorkerC extends Cloudflare.Worker<WorkerC, {}, Counter>()(
  *   "WorkerC",
- *   { main: import.meta.filename },
+ *   { main: import.meta.url },
  * ) {}
  *
  * export default WorkerC.make(

--- a/packages/alchemy/src/Cloudflare/Workers/RpcWorker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/RpcWorker.ts
@@ -317,7 +317,7 @@ const bind = <Self, Rpcs extends Rpc.Any>(
  *
  * export default class Worker extends Cloudflare.RpcWorker<Worker>()(
  *   "Worker",
- *   { main: import.meta.filename, schema: TaskRpcs },
+ *   { main: import.meta.url, schema: TaskRpcs },
  *   Effect.gen(function* () {
  *     const handlers = TaskRpcs.toLayer({
  *       getTask: ({ id }) => Effect.succeed(`task-${id}`),
@@ -350,7 +350,7 @@ const bind = <Self, Rpcs extends Rpc.Any>(
  * ```typescript
  * export class TaskWorker extends Cloudflare.RpcWorker<TaskWorker>()(
  *   "TaskWorker",
- *   { main: import.meta.filename, schema: TaskRpcs },
+ *   { main: import.meta.url, schema: TaskRpcs },
  * ) {}
  *
  * // Only the host script imports this default export; consumers
@@ -379,7 +379,7 @@ const bind = <Self, Rpcs extends Rpc.Any>(
  *
  * export class TaskWorker extends Cloudflare.RpcWorker<TaskWorker, Counter>()(
  *   "TaskWorker",
- *   { main: import.meta.filename, schema: TaskRpcs },
+ *   { main: import.meta.url, schema: TaskRpcs },
  * ) {}
  * ```
  * See {@link RpcDurableObject} for the consumer side
@@ -399,7 +399,7 @@ const bind = <Self, Rpcs extends Rpc.Any>(
  *
  * export default class Caller extends Cloudflare.RpcWorker<Caller>()(
  *   "Caller",
- *   { main: import.meta.filename, schema: CallerRpcs },
+ *   { main: import.meta.url, schema: CallerRpcs },
  *   Effect.gen(function* () {
  *     // INIT: register binding, get the typed client
  *     const tasks = yield* Cloudflare.RpcWorker.bind(TaskWorker);

--- a/packages/alchemy/src/Cloudflare/Workers/VersionMetadata.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/VersionMetadata.ts
@@ -49,7 +49,7 @@ export type VersionMetadataAccessor = Effect.Effect<
  *
  * Cloudflare.Worker(
  *   "VersionWorker",
- *   { main: import.meta.filename },
+ *   { main: import.meta.url },
  *   Effect.gen(function* () {
  *     // Attaches the binding to this Worker AND returns a deferred accessor.
  *     const versionMetadata = yield* Cloudflare.Workers.VersionMetadata();

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -501,7 +501,7 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
  * ```typescript
  * export default class MyWorker extends Cloudflare.Worker<MyWorker>()(
  *   "MyWorker",
- *   { main: import.meta.filename },
+ *   { main: import.meta.url },
  *   Effect.gen(function* () {
  *     // init: bind resources
  *     const kv = yield* Cloudflare.KV.ReadWriteNamespace(MyKV);
@@ -541,7 +541,7 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
  * >()("WorkerB") {}
  *
  * export default WorkerB.make(
- *   { main: import.meta.filename },
+ *   { main: import.meta.url },
  *   Effect.gen(function* () {
  *     // init: bind resources
  *     const kv = yield* Cloudflare.KV.ReadWriteNamespace(MyKV);
@@ -565,7 +565,7 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
  *
  * export default class WorkerA extends Cloudflare.Worker<WorkerA>()(
  *   "WorkerA",
- *   { main: import.meta.filename },
+ *   { main: import.meta.url },
  *   Effect.gen(function* () {
  *     const b = yield* Cloudflare.Workers.bindWorker(WorkerB);
  *     return {
@@ -584,7 +584,7 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
  * @example Enabling Node.js compatibility
  * ```typescript
  * {
- *   main: import.meta.filename,
+ *   main: import.meta.url,
  *   compatibility: {
  *     flags: ["nodejs_compat"],
  *     date: "2026-03-17",
@@ -595,7 +595,7 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
  * @example Serving static assets
  * ```typescript
  * {
- *   main: import.meta.filename,
+ *   main: import.meta.url,
  *   assets: "./public",
  * }
  * ```
@@ -628,7 +628,7 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
  * @example Enabling logs and traces
  * ```typescript
  * {
- *   main: import.meta.filename,
+ *   main: import.meta.url,
  *   observability: {
  *     enabled: true,
  *     headSamplingRate: 1,

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerLoader.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerLoader.ts
@@ -118,7 +118,7 @@ export interface WorkerLoaderClass extends Context.Service<
  *
  * export default class EvalWorker extends Cloudflare.Worker<EvalWorker>()(
  *   "EvalWorker",
- *   { main: import.meta.filename },
+ *   { main: import.meta.url },
  *   Effect.gen(function* () {
  *     // Registers the `worker_loader` binding on this Worker
  *     const loader = yield* Cloudflare.WorkerLoader("LOADER");

--- a/packages/alchemy/test/AWS/DynamoDB/stream-handler.ts
+++ b/packages/alchemy/test/AWS/DynamoDB/stream-handler.ts
@@ -37,7 +37,7 @@ export const TableAndQueueLive = Layer.effect(
 
 export default DynamoDBStreamFunction.make(
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const { table, queue } = yield* TableAndQueue;

--- a/packages/alchemy/test/AWS/Kinesis/handler.ts
+++ b/packages/alchemy/test/AWS/Kinesis/handler.ts
@@ -48,7 +48,7 @@ export const StreamAndConsumerLive = Layer.effect(
 
 export const KinesisApiFunctionLive = KinesisApiFunction.make(
   {
-    main: import.meta.filename,
+    main: import.meta.url,
     url: true,
   },
   Effect.gen(function* () {

--- a/packages/alchemy/test/AWS/Kinesis/stream-handler.ts
+++ b/packages/alchemy/test/AWS/Kinesis/stream-handler.ts
@@ -34,7 +34,7 @@ export const StreamAndQueueLive = Layer.effect(
 );
 export default KinesisStreamFunction.make(
   {
-    main: import.meta.filename,
+    main: import.meta.url,
     url: true,
   },
   Effect.gen(function* () {

--- a/packages/alchemy/test/AWS/Lambda/fixtures/event-source-mapping-handler.ts
+++ b/packages/alchemy/test/AWS/Lambda/fixtures/event-source-mapping-handler.ts
@@ -16,7 +16,7 @@ export class EventSourceMappingFunction extends Lambda.Function<EventSourceMappi
 
 export default EventSourceMappingFunction.make(
   {
-    main: import.meta.filename,
+    main: import.meta.url,
     url: false,
   },
   Effect.gen(function* () {

--- a/packages/alchemy/test/AWS/Lambda/handler.ts
+++ b/packages/alchemy/test/AWS/Lambda/handler.ts
@@ -2,7 +2,7 @@ import * as Lambda from "@/AWS/Lambda";
 import * as Effect from "effect/Effect";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 
-const main = import.meta.filename;
+const main = import.meta.url;
 
 export class TestFunction extends Lambda.Function<Lambda.Function>()(
   "TestFunction",

--- a/packages/alchemy/test/AWS/S3/fixtures/event-source-handler.ts
+++ b/packages/alchemy/test/AWS/S3/fixtures/event-source-handler.ts
@@ -19,7 +19,7 @@ export class BucketEventSourceFunction extends Lambda.Function<BucketEventSource
 
 export default BucketEventSourceFunction.make(
   {
-    main: import.meta.filename,
+    main: import.meta.url,
     url: true,
   },
   Effect.gen(function* () {

--- a/packages/alchemy/test/Cloudflare/AI/fixtures/ChatPersistenceRpcWorker.ts
+++ b/packages/alchemy/test/Cloudflare/AI/fixtures/ChatPersistenceRpcWorker.ts
@@ -14,7 +14,7 @@ import { ChatRpcs } from "./ChatRpcs.ts";
 export default class ChatPersistenceRpcWorker extends Cloudflare.RpcWorker<ChatPersistenceRpcWorker>()(
   "ChatPersistenceRpcWorker",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
     schema: ChatRpcs,
   },
   Effect.gen(function* () {

--- a/packages/alchemy/test/Cloudflare/AI/fixtures/ChatPersistenceWorker.ts
+++ b/packages/alchemy/test/Cloudflare/AI/fixtures/ChatPersistenceWorker.ts
@@ -7,7 +7,7 @@ import ChatBackend from "./ChatBackend.ts";
 export default class ChatPersistenceTestWorker extends Cloudflare.Worker<ChatPersistenceTestWorker>()(
   "ChatPersistenceTestWorker",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     // Yielding the inline DO hosts it on this Worker and hands back the

--- a/packages/alchemy/test/Cloudflare/AI/fixtures/LanguageModelWorker.ts
+++ b/packages/alchemy/test/Cloudflare/AI/fixtures/LanguageModelWorker.ts
@@ -50,7 +50,7 @@ const WeatherToolkitLayer = WeatherToolkit.toLayer({
 export default class LanguageModelTestWorker extends Cloudflare.Worker<LanguageModelTestWorker>()(
   "LanguageModelTestWorker",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const aiGateway = yield* Cloudflare.AI.QueryGateway(Gateway);

--- a/packages/alchemy/test/Cloudflare/AI/fixtures/TestWorker.ts
+++ b/packages/alchemy/test/Cloudflare/AI/fixtures/TestWorker.ts
@@ -7,7 +7,7 @@ import { Gateway } from "./Gateway.ts";
 export default class TestWorker extends Cloudflare.Worker<TestWorker>()(
   "AiGatewayTestWorker",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const aiGateway = yield* Cloudflare.AI.QueryGateway(Gateway);

--- a/packages/alchemy/test/Cloudflare/AI/fixtures/crawl-target-worker.ts
+++ b/packages/alchemy/test/Cloudflare/AI/fixtures/crawl-target-worker.ts
@@ -25,7 +25,7 @@ const page = (title: string, body: string) =>
 export default class AiSearchCrawlTargetWorker extends Cloudflare.Worker<AiSearchCrawlTargetWorker>()(
   "AiSearchCrawlTargetWorker",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     return {

--- a/packages/alchemy/test/Cloudflare/AI/fixtures/effect-bindings-worker.ts
+++ b/packages/alchemy/test/Cloudflare/AI/fixtures/effect-bindings-worker.ts
@@ -21,7 +21,7 @@ import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 export default class AiSearchEffectBindingsWorker extends Cloudflare.Worker<AiSearchEffectBindingsWorker>()(
   "AiSearchEffectBindingsWorker",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const bucket = yield* Cloudflare.R2.Bucket("AiSearchEffectBindingBucket");

--- a/packages/alchemy/test/Cloudflare/AnalyticsEngine/fixtures/worker.ts
+++ b/packages/alchemy/test/Cloudflare/AnalyticsEngine/fixtures/worker.ts
@@ -7,7 +7,7 @@ import { Dataset } from "./dataset.ts";
 export default class AnalyticsEngineTestWorker extends Cloudflare.Worker<AnalyticsEngineTestWorker>()(
   "AnalyticsEngineTestWorker",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const analytics = yield* Cloudflare.AnalyticsEngine.WriteDataset(Dataset);

--- a/packages/alchemy/test/Cloudflare/Artifacts/fixtures/effect-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Artifacts/fixtures/effect-worker.ts
@@ -14,7 +14,7 @@ import { artifactsRoutes } from "./routes.ts";
  */
 export default class ArtifactsEffectWorker extends Cloudflare.Worker<ArtifactsEffectWorker>()(
   "ArtifactsEffectWorker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const repos = yield* Repos;
     const client = yield* Cloudflare.Artifacts.ReadWriteNamespace(repos);

--- a/packages/alchemy/test/Cloudflare/Browser/fixtures/effect-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Browser/fixtures/effect-worker.ts
@@ -17,7 +17,7 @@ const byteLength = <E, R>(stream: Stream.Stream<Uint8Array, E, R>) =>
 export default class BrowserEffectWorker extends Cloudflare.Worker<BrowserEffectWorker>()(
   "BrowserEffectWorker",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const browser = yield* Cloudflare.Browser("BROWSER");

--- a/packages/alchemy/test/Cloudflare/Container/fixtures/effectful/container.ts
+++ b/packages/alchemy/test/Cloudflare/Container/fixtures/effectful/container.ts
@@ -18,7 +18,7 @@ export class MyContainer extends Cloudflare.Container<
 
 export default MyContainer.make(
   {
-    main: import.meta.filename,
+    main: import.meta.url,
     dockerfile: "FROM oven/bun:latest",
   },
   Effect.gen(function* () {

--- a/packages/alchemy/test/Cloudflare/Container/fixtures/effectful/worker.ts
+++ b/packages/alchemy/test/Cloudflare/Container/fixtures/effectful/worker.ts
@@ -7,7 +7,7 @@ import { Object } from "./object.ts";
 export default Cloudflare.Worker(
   "Worker",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const objects = yield* Object;

--- a/packages/alchemy/test/Cloudflare/Container/fixtures/external/worker.ts
+++ b/packages/alchemy/test/Cloudflare/Container/fixtures/external/worker.ts
@@ -7,7 +7,7 @@ import { ExternalContainerObject } from "./object.ts";
 export default class ExternalContainerWorker extends Cloudflare.Worker<ExternalContainerWorker>()(
   "ExternalContainerWorker",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const objects = yield* ExternalContainerObject;

--- a/packages/alchemy/test/Cloudflare/Container/fixtures/remote/worker.ts
+++ b/packages/alchemy/test/Cloudflare/Container/fixtures/remote/worker.ts
@@ -7,7 +7,7 @@ import { RemoteContainerObject } from "./object.ts";
 export default class RemoteContainerWorker extends Cloudflare.Worker<RemoteContainerWorker>()(
   "RemoteContainerWorker",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const objects = yield* RemoteContainerObject;

--- a/packages/alchemy/test/Cloudflare/D1/fixtures/effect-worker.ts
+++ b/packages/alchemy/test/Cloudflare/D1/fixtures/effect-worker.ts
@@ -12,7 +12,7 @@ import { d1Routes } from "./routes.ts";
 export default class D1EffectWorker extends Cloudflare.Worker<D1EffectWorker>()(
   "D1EffectWorker",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const database = yield* TestDatabase;

--- a/packages/alchemy/test/Cloudflare/Dns/fixtures/effect.ts
+++ b/packages/alchemy/test/Cloudflare/Dns/fixtures/effect.ts
@@ -17,7 +17,7 @@ import { Zone } from "./zone.ts";
 export default class DnsEffectWorker extends Cloudflare.Worker<DnsEffectWorker>()(
   "DnsEffectWorker",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const dns = yield* Cloudflare.DNS.ReadWriteDns(Zone);

--- a/packages/alchemy/test/Cloudflare/Email/fixtures/worker.ts
+++ b/packages/alchemy/test/Cloudflare/Email/fixtures/worker.ts
@@ -7,7 +7,7 @@ import { Email } from "./sender.ts";
 export default class SendEmailWorker extends Cloudflare.Worker<SendEmailWorker>()(
   "SendEmailTestWorker",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const email = yield* Cloudflare.Email.Send(Email);

--- a/packages/alchemy/test/Cloudflare/Flagship/fixtures/effect-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Flagship/fixtures/effect-worker.ts
@@ -13,7 +13,7 @@ import { App } from "./app.ts";
 export default class FlagshipEffectWorker extends Cloudflare.Worker<FlagshipEffectWorker>()(
   "FlagshipEffectWorker",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const flags = yield* Cloudflare.Flagship.ReadFlags(App);

--- a/packages/alchemy/test/Cloudflare/Hyperdrive/fixtures/effect-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Hyperdrive/fixtures/effect-worker.ts
@@ -13,7 +13,7 @@ import { connectionRoutes } from "./routes.ts";
  */
 export default class HyperdriveEffectWorker extends Cloudflare.Worker<HyperdriveEffectWorker>()(
   "HyperdriveEffectWorker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const { connection } = yield* HyperdriveConnection;
     const hd = yield* Cloudflare.Hyperdrive.Connect(connection);

--- a/packages/alchemy/test/Cloudflare/Images/fixtures/effect-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Images/fixtures/effect-worker.ts
@@ -14,7 +14,7 @@ import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 export default class ImagesEffectWorker extends Cloudflare.Worker<ImagesEffectWorker>()(
   "ImagesEffectWorker",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const images = yield* Cloudflare.Images.Images("PIPELINE");

--- a/packages/alchemy/test/Cloudflare/KV/fixtures/read-binding.ts
+++ b/packages/alchemy/test/Cloudflare/KV/fixtures/read-binding.ts
@@ -8,7 +8,7 @@ import { readRoutes } from "./read-routes.ts";
 /** Read-only access via the native Worker binding (`ReadNamespaceBinding`). */
 export default class KVReadBindingWorker extends Cloudflare.Worker<KVReadBindingWorker>()(
   "KVReadBindingWorker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const namespace = yield* TestNamespace;
     const kv = yield* Cloudflare.KV.ReadNamespace(namespace);

--- a/packages/alchemy/test/Cloudflare/KV/fixtures/read-http.ts
+++ b/packages/alchemy/test/Cloudflare/KV/fixtures/read-http.ts
@@ -8,7 +8,7 @@ import { readRoutes } from "./read-routes.ts";
 /** Read-only access via a scoped HTTP API token (`ReadNamespaceHttp`). */
 export default class KVReadHttpWorker extends Cloudflare.Worker<KVReadHttpWorker>()(
   "KVReadHttpWorker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const namespace = yield* TestNamespace;
     const kv = yield* Cloudflare.KV.ReadNamespace(namespace);

--- a/packages/alchemy/test/Cloudflare/KV/fixtures/readwrite-binding.ts
+++ b/packages/alchemy/test/Cloudflare/KV/fixtures/readwrite-binding.ts
@@ -9,7 +9,7 @@ import { writeRoutes } from "./write-routes.ts";
 /** Read + write access via the native Worker binding (`ReadWriteNamespaceBinding`). */
 export default class KVReadWriteBindingWorker extends Cloudflare.Worker<KVReadWriteBindingWorker>()(
   "KVReadWriteBindingWorker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const namespace = yield* TestNamespace;
     const kv = yield* Cloudflare.KV.ReadWriteNamespace(namespace);

--- a/packages/alchemy/test/Cloudflare/KV/fixtures/readwrite-http.ts
+++ b/packages/alchemy/test/Cloudflare/KV/fixtures/readwrite-http.ts
@@ -9,7 +9,7 @@ import { writeRoutes } from "./write-routes.ts";
 /** Read + write access via a scoped HTTP API token (`ReadWriteNamespaceHttp`). */
 export default class KVReadWriteHttpWorker extends Cloudflare.Worker<KVReadWriteHttpWorker>()(
   "KVReadWriteHttpWorker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const namespace = yield* TestNamespace;
     const kv = yield* Cloudflare.KV.ReadWriteNamespace(namespace);

--- a/packages/alchemy/test/Cloudflare/KV/fixtures/write-binding.ts
+++ b/packages/alchemy/test/Cloudflare/KV/fixtures/write-binding.ts
@@ -8,7 +8,7 @@ import { writeRoutes } from "./write-routes.ts";
 /** Write-only access via the native Worker binding (`WriteNamespaceBinding`). */
 export default class KVWriteBindingWorker extends Cloudflare.Worker<KVWriteBindingWorker>()(
   "KVWriteBindingWorker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const namespace = yield* TestNamespace;
     const kv = yield* Cloudflare.KV.WriteNamespace(namespace);

--- a/packages/alchemy/test/Cloudflare/KV/fixtures/write-http.ts
+++ b/packages/alchemy/test/Cloudflare/KV/fixtures/write-http.ts
@@ -8,7 +8,7 @@ import { writeRoutes } from "./write-routes.ts";
 /** Write-only access via a scoped HTTP API token (`WriteNamespaceHttp`). */
 export default class KVWriteHttpWorker extends Cloudflare.Worker<KVWriteHttpWorker>()(
   "KVWriteHttpWorker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const namespace = yield* TestNamespace;
     const kv = yield* Cloudflare.KV.WriteNamespace(namespace);

--- a/packages/alchemy/test/Cloudflare/Queue/fixtures/write-binding.ts
+++ b/packages/alchemy/test/Cloudflare/Queue/fixtures/write-binding.ts
@@ -8,7 +8,7 @@ import { producerRoutes } from "./producer-routes.ts";
 /** Producer (send) access via the native Worker binding (`WriteQueueBinding`). */
 export default class QueueWriteBindingWorker extends Cloudflare.Worker<QueueWriteBindingWorker>()(
   "QueueWriteBindingWorker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const queue = yield* TestQueue;
     const producer = yield* Cloudflare.Queues.WriteQueue(queue);

--- a/packages/alchemy/test/Cloudflare/Queue/fixtures/write-http.ts
+++ b/packages/alchemy/test/Cloudflare/Queue/fixtures/write-http.ts
@@ -8,7 +8,7 @@ import { producerRoutes } from "./producer-routes.ts";
 /** Producer (send) access via a scoped HTTP API token (`WriteQueueHttp`). */
 export default class QueueWriteHttpWorker extends Cloudflare.Worker<QueueWriteHttpWorker>()(
   "QueueWriteHttpWorker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const queue = yield* TestQueue;
     const producer = yield* Cloudflare.Queues.WriteQueue(queue);

--- a/packages/alchemy/test/Cloudflare/Queue/round-trip-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Queue/round-trip-worker.ts
@@ -56,7 +56,7 @@ interface QueueMessageBody {
 export default class QueueWorker extends Cloudflare.Worker<QueueWorker>()(
   "QueueRoundTripWorker",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const counters = yield* Counter;

--- a/packages/alchemy/test/Cloudflare/R2/fixtures/read-binding.ts
+++ b/packages/alchemy/test/Cloudflare/R2/fixtures/read-binding.ts
@@ -8,7 +8,7 @@ import { readRoutes } from "./read-routes.ts";
 /** Read-only access via the native Worker binding (`ReadBucketBinding`). */
 export default class R2ReadBindingWorker extends Cloudflare.Worker<R2ReadBindingWorker>()(
   "R2ReadBindingWorker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const bucket = yield* TestBucket;
     const r2 = yield* Cloudflare.R2.ReadBucket(bucket);

--- a/packages/alchemy/test/Cloudflare/R2/fixtures/read-http.ts
+++ b/packages/alchemy/test/Cloudflare/R2/fixtures/read-http.ts
@@ -8,7 +8,7 @@ import { readRoutes } from "./read-routes.ts";
 /** Read-only access via a scoped HTTP API token (`ReadBucketHttp`). */
 export default class R2ReadHttpWorker extends Cloudflare.Worker<R2ReadHttpWorker>()(
   "R2ReadHttpWorker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const bucket = yield* TestBucket;
     const r2 = yield* Cloudflare.R2.ReadBucket(bucket);

--- a/packages/alchemy/test/Cloudflare/R2/fixtures/readwrite-binding.ts
+++ b/packages/alchemy/test/Cloudflare/R2/fixtures/readwrite-binding.ts
@@ -9,7 +9,7 @@ import { writeRoutes } from "./write-routes.ts";
 /** Read + write access via the native Worker binding (`ReadWriteBucketBinding`). */
 export default class R2ReadWriteBindingWorker extends Cloudflare.Worker<R2ReadWriteBindingWorker>()(
   "R2ReadWriteBindingWorker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const bucket = yield* TestBucket;
     const r2 = yield* Cloudflare.R2.ReadWriteBucket(bucket);

--- a/packages/alchemy/test/Cloudflare/R2/fixtures/readwrite-http.ts
+++ b/packages/alchemy/test/Cloudflare/R2/fixtures/readwrite-http.ts
@@ -9,7 +9,7 @@ import { writeRoutes } from "./write-routes.ts";
 /** Read + write access via a scoped HTTP API token (`ReadWriteBucketHttp`). */
 export default class R2ReadWriteHttpWorker extends Cloudflare.Worker<R2ReadWriteHttpWorker>()(
   "R2ReadWriteHttpWorker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const bucket = yield* TestBucket;
     const r2 = yield* Cloudflare.R2.ReadWriteBucket(bucket);

--- a/packages/alchemy/test/Cloudflare/R2/fixtures/write-binding.ts
+++ b/packages/alchemy/test/Cloudflare/R2/fixtures/write-binding.ts
@@ -8,7 +8,7 @@ import { writeRoutes } from "./write-routes.ts";
 /** Write-only access via the native Worker binding (`WriteBucketBinding`). */
 export default class R2WriteBindingWorker extends Cloudflare.Worker<R2WriteBindingWorker>()(
   "R2WriteBindingWorker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const bucket = yield* TestBucket;
     const r2 = yield* Cloudflare.R2.WriteBucket(bucket);

--- a/packages/alchemy/test/Cloudflare/R2/fixtures/write-http.ts
+++ b/packages/alchemy/test/Cloudflare/R2/fixtures/write-http.ts
@@ -8,7 +8,7 @@ import { writeRoutes } from "./write-routes.ts";
 /** Write-only access via a scoped HTTP API token (`WriteBucketHttp`). */
 export default class R2WriteHttpWorker extends Cloudflare.Worker<R2WriteHttpWorker>()(
   "R2WriteHttpWorker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const bucket = yield* TestBucket;
     const r2 = yield* Cloudflare.R2.WriteBucket(bucket);

--- a/packages/alchemy/test/Cloudflare/RateLimit/fixtures/effect.ts
+++ b/packages/alchemy/test/Cloudflare/RateLimit/fixtures/effect.ts
@@ -18,7 +18,7 @@ import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 export default class RateLimitEffectWorker extends Cloudflare.Worker<RateLimitEffectWorker>()(
   "RateLimitEffectWorker",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const throttle = yield* Cloudflare.RateLimit("THROTTLE", {

--- a/packages/alchemy/test/Cloudflare/Secret/fixtures/worker.ts
+++ b/packages/alchemy/test/Cloudflare/Secret/fixtures/worker.ts
@@ -23,7 +23,7 @@ export const OBJECT_VAR_VALUE = { host: "localhost", flags: { beta: true } };
 export default class SecretsTestWorker extends Cloudflare.Worker<SecretsTestWorker>()(
   "SecretsTestWorker",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
     subdomain: { enabled: true, previewsEnabled: false },
   },
   Effect.gen(function* () {

--- a/packages/alchemy/test/Cloudflare/SecretsStore/fixtures/async-worker.ts
+++ b/packages/alchemy/test/Cloudflare/SecretsStore/fixtures/async-worker.ts
@@ -17,7 +17,7 @@ import { ApiKey } from "./secret.ts";
 export default class AsyncSecretWorker extends Cloudflare.Worker<AsyncSecretWorker>()(
   "AsyncSecretBindingWorker",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
     subdomain: { enabled: true, previewsEnabled: false },
     env: {
       MY_SECRET: ApiKey,

--- a/packages/alchemy/test/Cloudflare/SecretsStore/fixtures/effect-worker.ts
+++ b/packages/alchemy/test/Cloudflare/SecretsStore/fixtures/effect-worker.ts
@@ -14,7 +14,7 @@ import { secretRoutes } from "./secret-routes.ts";
 export default class EffectSecretWorker extends Cloudflare.Worker<EffectSecretWorker>()(
   "EffectSecretBindingWorker",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
     subdomain: { enabled: true, previewsEnabled: false },
   },
   Effect.gen(function* () {

--- a/packages/alchemy/test/Cloudflare/Tunnel/fixtures/effect.ts
+++ b/packages/alchemy/test/Cloudflare/Tunnel/fixtures/effect.ts
@@ -19,7 +19,7 @@ import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 export default class TunnelEffectWorker extends Cloudflare.Worker<TunnelEffectWorker>()(
   "TunnelEffectWorker",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const read = yield* Cloudflare.Tunnel.ReadTunnel();

--- a/packages/alchemy/test/Cloudflare/Vectorize/fixtures/effect-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Vectorize/fixtures/effect-worker.ts
@@ -21,7 +21,7 @@ const LABEL = "effect";
 export default class VectorizeEffectWorker extends Cloudflare.Worker<VectorizeEffectWorker>()(
   "VectorizeEffectWorker",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const index = yield* TestIndex;

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/cron/cron-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/cron/cron-worker.ts
@@ -40,7 +40,7 @@ export class CronCounter extends Cloudflare.DurableObject<CronCounter>()(
 export default class CronTestWorker extends Cloudflare.Worker<CronTestWorker>()(
   "CronTestWorker",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const counters = yield* CronCounter;

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/do-rpc/worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/do-rpc/worker.ts
@@ -8,7 +8,7 @@ import { WorkerEnvironmentKVObject } from "./object.ts";
 export default class DurableObjectWorkerEnvironmentWorker extends Cloudflare.Worker<DurableObjectWorkerEnvironmentWorker>()(
   "DurableObjectWorkerEnvironmentWorker",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const objects = yield* WorkerEnvironmentKVObject;

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/drizzle-workflow/db.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/drizzle-workflow/db.ts
@@ -2,6 +2,7 @@ import * as Cloudflare from "@/Cloudflare/index.ts";
 import * as Neon from "@/Neon/index.ts";
 import * as Effect from "effect/Effect";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 /**
  * Neon + Cloudflare wiring for the Drizzle-in-Workflow regression test. A
@@ -11,9 +12,13 @@ import path from "node:path";
  */
 export const NeonDb = Effect.gen(function* () {
   // Resolved inside the effect (not at module scope) so it only runs at
-  // deploy time — `import.meta.filename` is undefined in the bundled worker.
+  // deploy time — `import.meta.url` is undefined in the bundled worker.
   const migrationsDir = yield* Effect.sync(() =>
-    path.join(import.meta.filename ?? ".", "..", "migrations"),
+    path.join(
+      import.meta.url ? fileURLToPath(import.meta.url) : ".",
+      "..",
+      "migrations",
+    ),
   );
 
   const project = yield* Neon.Project("DrizzleWorkflowProject", {

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/drizzle-workflow/worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/drizzle-workflow/worker.ts
@@ -14,7 +14,7 @@ import DrizzleWorkflow from "./workflow.ts";
 export default class DrizzleWorkflowWorker extends Cloudflare.Worker<DrizzleWorkflowWorker>()(
   "DrizzleWorkflowWorker",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const workflow = yield* DrizzleWorkflow;

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/dynamic-worker-loader/effect-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/dynamic-worker-loader/effect-worker.ts
@@ -13,7 +13,7 @@ import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
 export default class DynamicLoaderEffectWorker extends Cloudflare.Worker<DynamicLoaderEffectWorker>()(
   "DynamicLoaderEffectWorker",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const loader = yield* Cloudflare.WorkerLoader("LOADER");

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/env/effect.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/env/effect.ts
@@ -21,7 +21,7 @@ import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 export default class EnvEffectWorker extends Cloudflare.Worker<EnvEffectWorker>()(
   "EnvEffectWorker",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
     env: {
       STR: "hello",
       NUM: 42,

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/http-api/worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/http-api/worker.ts
@@ -27,7 +27,7 @@ const Bucket = Cloudflare.R2.Bucket("Tasks");
 export default class HttpApiTestWorker extends Cloudflare.Worker<HttpApiTestWorker>()(
   "HttpApiTestWorker",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const tasks = yield* Cloudflare.R2.ReadWriteBucket(Bucket);

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/internal-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/internal-worker.ts
@@ -5,7 +5,7 @@ import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 export default class InternalWorker extends Cloudflare.Worker<InternalWorker>()(
   "InternalWorker",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     return {

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/rpc-do-namespace-do-rpc/worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/rpc-do-namespace-do-rpc/worker.ts
@@ -18,7 +18,7 @@ import RpcCounterObject from "./object.ts";
 export default class RpcCounterWorker extends Cloudflare.Worker<RpcCounterWorker>()(
   "RpcCounterWorker",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const counters = yield* RpcCounterObject;

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/rpc-http/worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/rpc-http/worker.ts
@@ -15,7 +15,7 @@ let counter = 0;
 export default class RpcHttpTestWorker extends Cloudflare.Worker<RpcHttpTestWorker>()(
   "RpcHttpTestWorker",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const rpcDO = yield* RpcHttpTestObject;

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/rpc-worker-binding/caller-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/rpc-worker-binding/caller-worker.ts
@@ -17,7 +17,7 @@ import BindingTargetRpcWorker from "./target-worker.ts";
  */
 export default class BindingCallerRpcWorker extends Cloudflare.RpcWorker<BindingCallerRpcWorker>()(
   "BindingCallerRpcWorker",
-  { main: import.meta.filename, schema: CallerRpcs },
+  { main: import.meta.url, schema: CallerRpcs },
   Effect.gen(function* () {
     const target = yield* Cloudflare.RpcWorker.bind(BindingTargetRpcWorker);
 

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/rpc-worker-binding/target-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/rpc-worker-binding/target-worker.ts
@@ -13,7 +13,7 @@ import { TargetRpcs } from "./group.ts";
  */
 export default class BindingTargetRpcWorker extends Cloudflare.RpcWorker<BindingTargetRpcWorker>()(
   "BindingTargetRpcWorker",
-  { main: import.meta.filename, schema: TargetRpcs },
+  { main: import.meta.url, schema: TargetRpcs },
   Effect.gen(function* () {
     const handlers = TargetRpcs.toLayer({
       Greet: ({ name }) => Effect.succeed({ greeting: `hello ${name}` }),

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/rpc-worker-rpc-http/worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/rpc-worker-rpc-http/worker.ts
@@ -20,7 +20,7 @@ let counter = 0;
  */
 export default class RpcWorkerRpcHttpWorker extends Cloudflare.RpcWorker<RpcWorkerRpcHttpWorker>()(
   "RpcWorkerRpcHttpWorker",
-  { main: import.meta.filename, schema: WorkerRpcs },
+  { main: import.meta.url, schema: WorkerRpcs },
   Effect.gen(function* () {
     const objects = yield* RpcWorkerRpcHttpObject;
 

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/tagged-do/workerA.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/tagged-do/workerA.ts
@@ -13,7 +13,7 @@ export class WorkerA extends Cloudflare.Worker<WorkerA, {}, Counter>()(
 // Layer
 export default WorkerA.make(
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const counter = yield* Counter;

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/tagged-do/workerB.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/tagged-do/workerB.ts
@@ -9,7 +9,7 @@ import { WorkerA } from "./workerA.ts";
 export default class WorkerB extends Cloudflare.Worker<WorkerB>()(
   "WorkerB",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const counter = yield* Counter.from(WorkerA);

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/tagged-do/workerC.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/tagged-do/workerC.ts
@@ -18,7 +18,7 @@ export class WorkerC extends Cloudflare.Worker<WorkerC, {}, Counter>()(
 // extracted into a reusable Layer.
 export default WorkerC.make(
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const counter = yield* Counter.from(WorkerC);

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/tagged-rpc-do/workerA.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/tagged-rpc-do/workerA.ts
@@ -25,7 +25,7 @@ export class WorkerA extends Cloudflare.RpcWorker<WorkerA, Counter>()(
 // namespace (the `CounterLive` Layer below populates the tag).
 export default WorkerA.make(
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const counter = yield* Counter;

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/tagged-rpc-do/workerB.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/tagged-rpc-do/workerB.ts
@@ -13,7 +13,7 @@ import { WorkerA } from "./workerA.ts";
 export default class WorkerB extends Cloudflare.Worker<WorkerB>()(
   "WorkerB",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const counter = yield* Counter.from(WorkerA);

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/tagged-rpc-do/workerC.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/tagged-rpc-do/workerC.ts
@@ -19,7 +19,7 @@ export class WorkerC extends Cloudflare.Worker<WorkerC, {}, Counter>()(
 // extracted into a reusable Layer.
 export default WorkerC.make(
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const counter = yield* Counter.from(WorkerC);

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/worker-worker-binding/binding-effect-caller.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/worker-worker-binding/binding-effect-caller.ts
@@ -15,7 +15,7 @@ import BindingTargetWorker from "./binding-target-worker.ts";
 export default class BindingEffectCaller extends Cloudflare.Worker<BindingEffectCaller>()(
   "BindingEffectCaller",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const target = yield* Cloudflare.Workers.bindWorker(BindingTargetWorker);

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/worker-worker-binding/binding-target-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/worker-worker-binding/binding-target-worker.ts
@@ -9,7 +9,7 @@ import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 export default class BindingTargetWorker extends Cloudflare.Worker<BindingTargetWorker>()(
   "BindingTargetWorker",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     return {

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/workflow/workflow-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/workflow/workflow-worker.ts
@@ -7,7 +7,7 @@ import TestWorkflow from "./test-workflow.ts";
 export default class WorkflowTestWorker extends Cloudflare.Worker<WorkflowTestWorker>()(
   "WorkflowTestWorker",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const workflow = yield* TestWorkflow;

--- a/packages/alchemy/test/Planetscale/Postgres/fixtures/hyperdrive-worker.ts
+++ b/packages/alchemy/test/Planetscale/Postgres/fixtures/hyperdrive-worker.ts
@@ -18,7 +18,7 @@ import { relations, Widgets } from "./schema.ts";
 export default class HyperdriveWorker extends Cloudflare.Worker<HyperdriveWorker>()(
   "PlanetscaleHyperdriveWorker",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     const conn = yield* Cloudflare.Hyperdrive.Connect(Hyperdrive);

--- a/packages/alchemy/test/types/Api.ts
+++ b/packages/alchemy/test/types/Api.ts
@@ -8,7 +8,7 @@ import Agent from "./Agent.ts";
 export const Api2 = Cloudflare.Worker(
   "Api",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
     observability: {
       enabled: true,
     },
@@ -53,7 +53,7 @@ const _____ = Effect.gen(function* () {
 export default class Api extends Cloudflare.Worker<Api>()(
   "Api",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
     observability: {
       enabled: true,
     },
@@ -122,7 +122,7 @@ export class Api3 extends Cloudflare.Worker<
 
 export const Api3Live = Api3.make(
   {
-    main: import.meta.filename,
+    main: import.meta.url,
     observability: {
       enabled: true,
     },

--- a/packages/alchemy/test/types/Sandbox.ts
+++ b/packages/alchemy/test/types/Sandbox.ts
@@ -16,7 +16,7 @@ export class Sandbox extends Cloudflare.Container<
 
 export const SandboxLive = Sandbox.make(
   Stack.useSync((stack) => ({
-    main: import.meta.filename,
+    main: import.meta.url,
     // handler: "SandboxLive",
     instanceType: stack.stage === "prod" ? "standard-1" : "dev",
     dockerfile: `FROM alpine:latest`,

--- a/packages/pr-package/README.md
+++ b/packages/pr-package/README.md
@@ -24,7 +24,7 @@ The package exposes a `handler(options)` Effect that you wire into a `Cloudflare
 Two-file pattern, mirroring how `stacks/otel/Ingester.ts` is split out from `stacks/otel.ts`:
 
 ```ts
-// stacks/pr-package/Api.ts — the worker entry (main: import.meta.filename)
+// stacks/pr-package/Api.ts — the worker entry (main: import.meta.url)
 import * as PrPackage from "@alchemy.run/pr-package";
 import * as Cloudflare from "alchemy/Cloudflare";
 
@@ -41,7 +41,7 @@ const parseAliasUrl: PrPackage.ParseAliasUrl = (url) => {
 export default class Api extends Cloudflare.Worker<Api>()(
   "PrPackageWorker",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
     url: true,
     domain: ["pkg.example.com"],
     compatibility: { flags: ["nodejs_compat"], date: "2026-03-17" },

--- a/packages/pr-package/src/Worker.ts
+++ b/packages/pr-package/src/Worker.ts
@@ -34,7 +34,7 @@ const bindings = Layer.mergeAll(
  * Init effect for a pr-package worker. Pass as the third argument to
  * `Cloudflare.Worker<X>()(...)` in your stack file.
  *
- * The user's stack file must be the worker entry (`main: import.meta.filename`)
+ * The user's stack file must be the worker entry (`main: import.meta.url`)
  * because `parseAliasUrl` is a closure that has to live in the bundle.
  *
  * @example
@@ -43,7 +43,7 @@ const bindings = Layer.mergeAll(
  *
  * class Api extends Cloudflare.Worker<Api>()(
  *   "Api",
- *   { main: import.meta.filename, url: true, ... },
+ *   { main: import.meta.url, url: true, ... },
  *   PrPackage.handler({
  *     parseAliasUrl: (url) => ({ pkgName: "...", tag: "..." }),
  *   }),

--- a/stacks/otel/Ingester.ts
+++ b/stacks/otel/Ingester.ts
@@ -29,7 +29,7 @@ import { IngestToken } from "./IngestToken.ts";
 export default class Ingester extends Cloudflare.Worker<Ingester>()(
   "OtelWorker",
   Stack.useSync(({ stage }) => ({
-    main: import.meta.filename,
+    main: import.meta.url,
     observability: { enabled: true },
     domain:
       stage === "prod"

--- a/stacks/pr-package/Api.ts
+++ b/stacks/pr-package/Api.ts
@@ -42,7 +42,7 @@ const parseAliasUrl: PrPackage.ParseAliasUrl = (url) => {
 export default class Api extends Cloudflare.Worker<Api>()(
   "PrPackageWorker",
   Stack.useSync(({ stage }) => ({
-    main: import.meta.filename,
+    main: import.meta.url,
     url: true,
     domain:
       stage === "prod"

--- a/website/src/components/marketing-islands/EffectPilledShowcase.tsx
+++ b/website/src/components/marketing-islands/EffectPilledShowcase.tsx
@@ -88,7 +88,7 @@ const CONTAINER_CODE = `export class Sandbox extends Cloudflare.Container<Sandbo
 
 export const SandboxLive = Sandbox.make(
   Stack.useSync((stack) => ({
-    main: import.meta.filename,
+    main: import.meta.url,
     instanceType: stack.stage === "prod" ? "standard-1" : "dev",
   })),
   Effect.gen(function* () {

--- a/website/src/content/docs/concepts/binding.mdx
+++ b/website/src/content/docs/concepts/binding.mdx
@@ -39,7 +39,7 @@ handle:
 ```typescript
 export default Cloudflare.Worker(
   "Worker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
     return {

--- a/website/src/content/docs/concepts/layers.mdx
+++ b/website/src/content/docs/concepts/layers.mdx
@@ -30,7 +30,7 @@ import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 
 export default Cloudflare.Worker(
   "Api",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const kv = yield* Cloudflare.KV.ReadWriteNamespace(MyKV);
 
@@ -118,7 +118,7 @@ Layer to satisfy it:
 ```typescript
 export default Cloudflare.Worker(
   "Api",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const jobs = yield* JobService;
 
@@ -194,7 +194,7 @@ Bindings live in init; the actual cloud calls live in runtime:
 ```typescript
 Cloudflare.Worker(
   "Api",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     // ─── Init: declare dependencies ───
     const kv = yield* Cloudflare.KV.ReadWriteNamespace(MyKV);

--- a/website/src/content/docs/concepts/local-development.mdx
+++ b/website/src/content/docs/concepts/local-development.mdx
@@ -90,7 +90,7 @@ adjusts accordingly.
 
 ```typescript
 export default Cloudflare.Worker("Worker", {
-  main: import.meta.filename,
+  main: import.meta.url,
   dev: {
     port: 3000,
   },

--- a/website/src/content/docs/concepts/phases.mdx
+++ b/website/src/content/docs/concepts/phases.mdx
@@ -27,7 +27,7 @@ an Effect from inside an Effect**.
 ```typescript
 Cloudflare.Worker(
   "Worker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     // ─── Init phase ───
     const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);

--- a/website/src/content/docs/concepts/platform.mdx
+++ b/website/src/content/docs/concepts/platform.mdx
@@ -27,7 +27,7 @@ import { Bucket } from "./bucket.ts";
 
 export default Cloudflare.Worker(
   "Api",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     // Init: bind a resource. The binding is the typed SDK.
     const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
@@ -82,7 +82,7 @@ by hand:
 ```typescript
 export default AWS.Lambda.Function(
   "Api",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const getJob = yield* DynamoDB.GetItem(JobsTable);
     const enqueue = yield* SQS.SendMessage(JobQueue);
@@ -140,7 +140,7 @@ through Effect's context:
 ```typescript
 export default Cloudflare.Worker(
   "Worker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
     return {

--- a/website/src/content/docs/concepts/resource.mdx
+++ b/website/src/content/docs/concepts/resource.mdx
@@ -293,7 +293,7 @@ const Queue = yield* AWS.SQS.Queue("Queue", {
 });
 
 const Worker = yield* Cloudflare.Worker("Worker", {
-  main: import.meta.filename,
+  main: import.meta.url,
   env: { Bucket, Sessions, Queue },
 });
 ```
@@ -364,7 +364,7 @@ import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 
 // The class is the Tag — used as a typed identifier elsewhere.
 export class MyWorker extends Cloudflare.Worker<MyWorker>()("MyWorker", {
-  main: import.meta.filename,
+  main: import.meta.url,
 }) {}
 
 // The default export is the Layer — the runtime implementation.

--- a/website/src/content/docs/concepts/secrets.mdx
+++ b/website/src/content/docs/concepts/secrets.mdx
@@ -22,7 +22,7 @@ import * as Redacted from "effect/Redacted";
 
 export default Cloudflare.Worker(
   "Worker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const apiKey = yield* Config.redacted("API_KEY"); 
     // apiKey is Redacted<string> — usable here in Init AND captured as a binding
@@ -48,7 +48,7 @@ within the Init phase. For example, to initialize a client:
 ```typescript
 export default Cloudflare.Worker(
   "Worker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const apiKey = yield* Config.redacted("OPENAI_API_KEY");
     const client = createOpenAI(Redacted.value(apiKey));
@@ -93,7 +93,7 @@ because `fetch` does not run during deployment, so the engine never discovers it
 ```typescript
 export default Cloudflare.Worker(
   "Worker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     return {
       fetch: Effect.gen(function* () {

--- a/website/src/content/docs/concepts/stages.mdx
+++ b/website/src/content/docs/concepts/stages.mdx
@@ -94,7 +94,7 @@ For resources declared at module scope, use
 export class JobFunction extends AWS.Lambda.Function<JobFunction>()(
   "JobFunction",
   Stack.useSync((stack) => ({
-    main: import.meta.filename,
+    main: import.meta.url,
     memory: stack.stage === "prod" ? 1024 : 512,
   })),
 ) {}

--- a/website/src/content/docs/guides/circular-bindings.mdx
+++ b/website/src/content/docs/guides/circular-bindings.mdx
@@ -86,7 +86,7 @@ own `work` RPC method so B can call back into it.
   export class A extends Cloudflare.Worker<A, {}>()("A") {}
 
 + export default A.make(
-+   { main: import.meta.filename },
++   { main: import.meta.url },
 +   Effect.gen(function* () {
 +     const b = yield* Cloudflare.Workers.bindWorker(B);
 +     return {
@@ -120,7 +120,7 @@ binds it.
   export class B extends Cloudflare.Worker<B, {}>()("B") {}
 
 + export default B.make(
-+   { main: import.meta.filename },
++   { main: import.meta.url },
 +   Effect.gen(function* () {
 +     const a = yield* Cloudflare.Workers.bindWorker(A);
 +     return {
@@ -208,7 +208,7 @@ and implementation in one expression:
 ```typescript
 export default Cloudflare.Worker(
   "MyWorker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     /* ... */
   }),

--- a/website/src/content/docs/guides/effect-ai.mdx
+++ b/website/src/content/docs/guides/effect-ai.mdx
@@ -106,7 +106,7 @@ import { OpenAiClient, OpenAiLanguageModel } from "@effect/ai-openai";
 
 export default Cloudflare.Worker(
   "Worker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const apiKey = yield* Config.redacted("OPENAI_API_KEY");
 

--- a/website/src/content/docs/guides/effect-http-api.mdx
+++ b/website/src/content/docs/guides/effect-http-api.mdx
@@ -107,7 +107,7 @@ import * as Effect from "effect/Effect";
 
 export default Cloudflare.Worker(
   "Worker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     return {};
   }),
@@ -140,7 +140,7 @@ export const Tasks = Cloudflare.R2.Bucket("Tasks");
 
 export default Cloudflare.Worker(
   "Worker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
 +   const tasks = yield* Cloudflare.R2.ReadWriteBucket(Tasks);
 
@@ -281,7 +281,7 @@ import { Task, TaskNotFound } from "./task.ts";
 
 export default Cloudflare.Worker(
   "Worker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const tasks = yield* Cloudflare.R2.ReadWriteBucket(Tasks);
 

--- a/website/src/content/docs/guides/effect-rpc.mdx
+++ b/website/src/content/docs/guides/effect-rpc.mdx
@@ -94,7 +94,7 @@ import * as Effect from "effect/Effect";
 
 export default Cloudflare.Worker(
   "Worker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     return {};
   }),
@@ -126,7 +126,7 @@ export const Tasks = Cloudflare.R2.Bucket("Tasks");
 
 export default Cloudflare.Worker(
   "Worker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
 +   const tasks = yield* Cloudflare.R2.ReadWriteBucket(Tasks);
 
@@ -229,7 +229,7 @@ import { TaskRpcs } from "./rpcs.ts";
 
 export default Cloudflare.Worker(
   "Worker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const tasks = yield* Cloudflare.R2.ReadWriteBucket(Tasks);
 
@@ -478,7 +478,7 @@ whole Worker — the R2-backed handlers are unchanged, the new
 // src/worker.ts
 export default Cloudflare.Worker(
   "Worker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const tasks = yield* Cloudflare.R2.ReadWriteBucket(Tasks);
     const tasksDO = yield* TasksObject;
@@ -577,7 +577,7 @@ import { TaskRpcs } from "./rpcs.ts";
 
 export default class Worker extends Cloudflare.RpcWorker<Worker>()(
   "Worker",
-  { main: import.meta.filename, schema: TaskRpcs },
+  { main: import.meta.url, schema: TaskRpcs },
   Effect.gen(function* () {
     const handlers = TaskRpcs.toLayer({ getTask: /* ... */ });
     return RpcServer.toHttpEffect(TaskRpcs).pipe(
@@ -615,7 +615,7 @@ the host's runtime:
 // Modular: class declaration carries no impl.
 export class TaskWorker extends Cloudflare.RpcWorker<TaskWorker>()(
   "TaskWorker",
-  { main: import.meta.filename, schema: TaskRpcs },
+  { main: import.meta.url, schema: TaskRpcs },
 ) {}
 
 // Runtime lives in a separate Layer — only the host script imports it.

--- a/website/src/content/docs/guides/infrastructure-layers.mdx
+++ b/website/src/content/docs/guides/infrastructure-layers.mdx
@@ -144,7 +144,7 @@ import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 
 export default Cloudflare.Worker(
   "Api",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     return {
       fetch: Effect.gen(function* () {
@@ -168,7 +168,7 @@ call it from `fetch`:
 
  export default Cloudflare.Worker(
    "Api",
-   { main: import.meta.filename },
+   { main: import.meta.url },
    Effect.gen(function* () {
 +    const jobs = yield* JobService;
 +
@@ -202,7 +202,7 @@ KV namespace resource into the Stack:
 
  export default Cloudflare.Worker(
    "Api",
-   { main: import.meta.filename },
+   { main: import.meta.url },
    Effect.gen(function* () {
      // ...
 -  }),
@@ -241,7 +241,7 @@ has a stable logical id:
  // src/Admin.ts
  export default Cloudflare.Worker(
    "Admin",
-   { main: import.meta.filename },
+   { main: import.meta.url },
    Effect.gen(function* () {
      const jobs = yield* JobService;
      // ...

--- a/website/src/content/docs/guides/migrating-from-v1.mdx
+++ b/website/src/content/docs/guides/migrating-from-v1.mdx
@@ -153,7 +153,7 @@ import { Bucket } from "./bucket.ts";
 -  },
 -};
 +export default Cloudflare.Worker("Worker",
-+  { main: import.meta.filename },
++  { main: import.meta.url },
 +  Effect.gen(function* () {
 +    const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
 +
@@ -172,7 +172,7 @@ import { Bucket } from "./bucket.ts";
 ```
 
 The Worker resource declaration moves from `alchemy.run.ts` into the
-Worker file itself (using `import.meta.filename` as the `main`), and the
+Worker file itself (using `import.meta.url` as the `main`), and the
 Stack just `yield*`-s the imported Worker:
 
 ```typescript twoslash
@@ -208,7 +208,7 @@ export default Alchemy.Stack(
 | ------------ | ----------------------------- | ----------------------------- | ---------------------------------- |
 | Stack        | `await alchemy("name")`       | `Alchemy.Stack("name", ...)`  | `Alchemy.Stack("name", ...)`       |
 | Resources    | `await Bucket(...)`         | `Cloudflare.R2.Bucket(...)`    | `Cloudflare.R2.Bucket(...)`         |
-| Worker entry | `entrypoint`                  | `main`                        | `main: import.meta.filename`           |
+| Worker entry | `entrypoint`                  | `main`                        | `main: import.meta.url`           |
 | Bindings     | `bindings: { KEY: resource }` | `env: { Key: resource }`      | `yield* Binding(ref)`        |
 | Runtime code | `async fetch(req, env)`       | `async fetch(req, env)`       | `Effect.gen(function* () { ... })` |
 | Lifecycle    | `await app.finalize()`        | automatic                     | automatic                          |

--- a/website/src/content/docs/guides/monorepo.mdx
+++ b/website/src/content/docs/guides/monorepo.mdx
@@ -132,7 +132,7 @@ import { BackendApi, Greeting } from "./Spec.ts";
 
 export default class Service extends Cloudflare.Worker<Service>()(
   "Service",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const helloGroup = HttpApiBuilder.group(BackendApi, "Hello", (handlers) =>
       handlers.handle("hello", () =>

--- a/website/src/content/docs/guides/secrets.mdx
+++ b/website/src/content/docs/guides/secrets.mdx
@@ -30,7 +30,7 @@ OPENAI_API_KEY=sk-proj-...
 
  export default Cloudflare.Worker(
    "Worker",
-   { main: import.meta.filename },
+   { main: import.meta.url },
    Effect.gen(function* () {
 +    const apiKey = yield* Config.redacted("OPENAI_API_KEY");
 
@@ -65,7 +65,7 @@ the Init/Runtime hook-up works.
 
  export default Cloudflare.Worker(
    "Worker",
-   { main: import.meta.filename },
+   { main: import.meta.url },
    Effect.gen(function* () {
      const apiKey = yield* Config.redacted("OPENAI_API_KEY");
 

--- a/website/src/content/docs/tutorial/aws/kinesis.mdx
+++ b/website/src/content/docs/tutorial/aws/kinesis.mdx
@@ -109,7 +109,7 @@ import { Events } from "./stream.ts";
 
 export default class Audit extends AWS.Lambda.Function<Audit>()(
   "Audit",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const events = yield* Events;
     return {};
@@ -135,7 +135,7 @@ import { Events } from "./stream.ts";
 
 export default class Audit extends AWS.Lambda.Function<Audit>()(
   "Audit",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const events = yield* Events;
 +

--- a/website/src/content/docs/tutorial/aws/lambda.mdx
+++ b/website/src/content/docs/tutorial/aws/lambda.mdx
@@ -90,7 +90,7 @@ import * as Effect from "effect/Effect";
 
 export default class Api extends AWS.Lambda.Function<Api>()(
   "Api",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     return {};
   }),
@@ -102,7 +102,7 @@ of ceremony — it lets TypeScript reason about `Api` as a typed
 handle that other resources can later bind against. The rest of
 your code looks completely normal.
 
-`main: import.meta.filename` tells Alchemy this same file is the
+`main: import.meta.url` tells Alchemy this same file is the
 bundle entrypoint. At deploy time it'll be bundled with Rolldown
 into a zip and uploaded as the function's code.
 
@@ -121,7 +121,7 @@ import * as Effect from "effect/Effect";
 
 export default class Api extends AWS.Lambda.Function<Api>()(
   "Api",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
 -    return {};
 +    return {
@@ -145,8 +145,8 @@ Gateway, no auth, just a public HTTPS endpoint:
 ```diff lang="typescript"
 export default class Api extends AWS.Lambda.Function<Api>()(
   "Api",
--  { main: import.meta.filename },
-+  { main: import.meta.filename, url: true },
+-  { main: import.meta.url },
++  { main: import.meta.url, url: true },
   Effect.gen(function* () {
     return {
       fetch: Effect.succeed(HttpServerResponse.text("Hello from Lambda!")),
@@ -175,9 +175,9 @@ import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 
 export default class Api extends AWS.Lambda.Function<Api>()(
   "Api",
--  { main: import.meta.filename, url: true },
+-  { main: import.meta.url, url: true },
 +  Stack.useSync((stack) => ({
-+    main: import.meta.filename,
++    main: import.meta.url,
 +    url: true,
 +    memory: stack.stage === "prod" ? 1024 : 512,
 +  })),

--- a/website/src/content/docs/tutorial/aws/s3.mdx
+++ b/website/src/content/docs/tutorial/aws/s3.mdx
@@ -30,7 +30,7 @@ import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 export default class Api extends AWS.Lambda.Function<Api>()(
   "Api",
   Stack.useSync((stack) => ({
-    main: import.meta.filename,
+    main: import.meta.url,
     url: true,
     memory: stack.stage === "prod" ? 1024 : 512,
   })),

--- a/website/src/content/docs/tutorial/aws/sqs.mdx
+++ b/website/src/content/docs/tutorial/aws/sqs.mdx
@@ -101,7 +101,7 @@ import * as Effect from "effect/Effect";
 
 export default class Worker extends AWS.Lambda.Function<Worker>()(
   "JobsWorker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     return {};
   }),
@@ -148,7 +148,7 @@ import * as Effect from "effect/Effect";
 
 export default class Worker extends AWS.Lambda.Function<Worker>()(
   "JobsWorker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
 +    const queue = yield* Jobs;
     return {};
@@ -174,7 +174,7 @@ import { Jobs } from "./queue.ts";
 
 export default class Worker extends AWS.Lambda.Function<Worker>()(
   "JobsWorker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const queue = yield* Jobs;
 +

--- a/website/src/content/docs/tutorial/cloudflare/ai-gateway.mdx
+++ b/website/src/content/docs/tutorial/cloudflare/ai-gateway.mdx
@@ -78,7 +78,7 @@ the gateway endpoint, `getLog`/`patchLog` for the request log, and
 
  export default class Api extends Cloudflare.Worker<Api>()(
    "Api",
-   { main: import.meta.filename },
+   { main: import.meta.url },
    Effect.gen(function* () {
 +    const aiGateway = yield* Cloudflare.AI.QueryGateway(Gateway);
 

--- a/website/src/content/docs/tutorial/cloudflare/ai-search.mdx
+++ b/website/src/content/docs/tutorial/cloudflare/ai-search.mdx
@@ -200,7 +200,7 @@ Call it during the Worker's init phase.
 
  export default class Api extends Cloudflare.Worker<Api>()(
    "Api",
-   { main: import.meta.filename },
+   { main: import.meta.url },
    Effect.gen(function* () {
 +    const aiSearch = yield* Search;
 +    const search = yield* Cloudflare.AI.QuerySearch(aiSearch);

--- a/website/src/content/docs/tutorial/cloudflare/artifacts.mdx
+++ b/website/src/content/docs/tutorial/cloudflare/artifacts.mdx
@@ -41,7 +41,7 @@ import { Repos } from "./Repos.ts";
 export default class Worker extends Cloudflare.Worker<Worker>()(
   "Api",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
     compatibility: { flags: ["nodejs_compat"], date: "2026-03-17" },
   },
   Effect.gen(function* () {

--- a/website/src/content/docs/tutorial/cloudflare/containers.mdx
+++ b/website/src/content/docs/tutorial/cloudflare/containers.mdx
@@ -62,7 +62,7 @@ import * as Effect from "effect/Effect";
 import { Sandbox } from "./Sandbox.ts";
 
 export const SandboxLive = Sandbox.make(
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     return Sandbox.of({
       // exec + fetch will go here
@@ -92,9 +92,9 @@ import * as Effect from "effect/Effect";
 import { Sandbox } from "./Sandbox.ts";
 
 export const SandboxLive = Sandbox.make(
--  { main: import.meta.filename },
+-  { main: import.meta.url },
 +  Stack.useSync((stack) => ({
-+    main: import.meta.filename,
++    main: import.meta.url,
 +    instanceType: stack.stage === "prod" ? "standard-1" : "dev",
 +    observability: { logs: { enabled: true } },
 +  })),
@@ -132,7 +132,7 @@ import * as Effect from "effect/Effect";
 import { Sandbox } from "./Sandbox.ts";
 
 export const SandboxLive = Sandbox.make(
-  Stack.useSync((stack) => ({ main: import.meta.filename, /* ... */ })),
+  Stack.useSync((stack) => ({ main: import.meta.url, /* ... */ })),
   Effect.gen(function* () {
 +   const cp = yield* ChildProcessSpawner;
 
@@ -189,7 +189,7 @@ import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner
 import { Sandbox } from "./Sandbox.ts";
 
 export const SandboxLive = Sandbox.make(
-  Stack.useSync((stack) => ({ main: import.meta.filename, /* ... */ })),
+  Stack.useSync((stack) => ({ main: import.meta.url, /* ... */ })),
   Effect.gen(function* () {
     const cp = yield* ChildProcessSpawner;
 
@@ -336,7 +336,7 @@ import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 
 export default Cloudflare.Worker(
   "Worker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
 +    const agents = yield* Agent;
 

--- a/website/src/content/docs/tutorial/cloudflare/cross-worker-durable-object.mdx
+++ b/website/src/content/docs/tutorial/cloudflare/cross-worker-durable-object.mdx
@@ -137,7 +137,7 @@ WorkerA's bundle actually contains the DO class:
  ) {}
 
 +export default WorkerA.make(
-+  { main: import.meta.filename },
++  { main: import.meta.url },
 +  Effect.gen(function* () {
 +    const counters = yield* Counter;
 +    return {
@@ -173,7 +173,7 @@ import { WorkerA } from "./workerA.ts";
 
 export default class WorkerB extends Cloudflare.Worker<WorkerB>()(
   "WorkerB",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const counters = yield* Counter.from(WorkerA);
     return {
@@ -282,7 +282,7 @@ namespace as `yield* Counter`:
 ```diff lang="typescript"
 // src/workerA.ts
  export default WorkerA.make(
-   { main: import.meta.filename },
+   { main: import.meta.url },
    Effect.gen(function* () {
 -    const counters = yield* Counter;
 +    const counters = yield* Counter.from(WorkerA);

--- a/website/src/content/docs/tutorial/cloudflare/drizzle.mdx
+++ b/website/src/content/docs/tutorial/cloudflare/drizzle.mdx
@@ -165,7 +165,7 @@ import { Users } from "./schema.ts";
 export default class Api extends Cloudflare.Worker<Api>()(
   "Api",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
     compatibility: {
       // node-postgres needs Node.js APIs to run inside a Worker.
       flags: ["nodejs_compat"],

--- a/website/src/content/docs/tutorial/cloudflare/durable-objects.mdx
+++ b/website/src/content/docs/tutorial/cloudflare/durable-objects.mdx
@@ -118,7 +118,7 @@ import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 
 export default Cloudflare.Worker(
   "Worker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
 +    const counters = yield* Counter;
 
@@ -150,7 +150,7 @@ import Counter from "./counter.ts";
 
 export default Cloudflare.Worker(
   "Worker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const counters = yield* Counter;
 
@@ -282,7 +282,7 @@ import Counter from "./counter.ts";
 
 export default Cloudflare.Worker(
   "Worker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const counters = yield* Counter;
 

--- a/website/src/content/docs/tutorial/cloudflare/hibernatable-websockets.mdx
+++ b/website/src/content/docs/tutorial/cloudflare/hibernatable-websockets.mdx
@@ -256,7 +256,7 @@ import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 
 export default Cloudflare.Worker(
   "Worker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
 +    const rooms = yield* Room;
 

--- a/website/src/content/docs/tutorial/cloudflare/hyperdrive.mdx
+++ b/website/src/content/docs/tutorial/cloudflare/hyperdrive.mdx
@@ -413,7 +413,7 @@ import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 export default class Api extends Cloudflare.Worker<Api>()(
   "Api",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
 +    compatibility: {
 +      // node-postgres needs Node.js APIs to run inside a Worker.
 +      flags: ["nodejs_compat"],
@@ -458,7 +458,7 @@ import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 export default class Api extends Cloudflare.Worker<Api>()(
   "Api",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
 +    compatibility: {
 +      // node-postgres needs Node.js APIs to run inside a Worker.
 +      flags: ["nodejs_compat"],
@@ -503,7 +503,7 @@ import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 export default class Api extends Cloudflare.Worker<Api>()(
   "Api",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
 +    compatibility: {
 +      // mysql2 needs Node.js APIs to run inside a Worker.
 +      flags: ["nodejs_compat"],

--- a/website/src/content/docs/tutorial/cloudflare/queue-consumer.mdx
+++ b/website/src/content/docs/tutorial/cloudflare/queue-consumer.mdx
@@ -59,7 +59,7 @@ import { Queue } from "./Queue.ts";
 
 export default Cloudflare.Worker(
   "Api",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
     const queueResource = yield* Queue;

--- a/website/src/content/docs/tutorial/cloudflare/rpc-durable-object.mdx
+++ b/website/src/content/docs/tutorial/cloudflare/rpc-durable-object.mdx
@@ -174,7 +174,7 @@ import Counter from "./counter.ts";
 
 export default class Worker extends Cloudflare.Worker<Worker>()(
   "Worker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const counters = yield* Counter;
     return {
@@ -371,7 +371,7 @@ publishes for cross-script binding):
 
 -export default class Worker extends Cloudflare.Worker<Worker>()(
 -  "Worker",
--  { main: import.meta.filename },
+-  { main: import.meta.url },
 -  Effect.gen(function* () {
 -    const counters = yield* Counter;
 -    ...
@@ -395,7 +395,7 @@ actually ships in WorkerA's bundle:
 ```typescript
 // src/worker.ts
 export default WorkerA.make(
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const counters = yield* Counter;
     return {
@@ -436,7 +436,7 @@ import { WorkerA } from "./worker.ts";
 
 export default class WorkerB extends Cloudflare.Worker<WorkerB>()(
   "WorkerB",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const counters = yield* Counter.from(WorkerA);
     return {
@@ -472,7 +472,7 @@ export class WorkerC extends Cloudflare.Worker<WorkerC, {}, Counter>()(
 ) {}
 
 export default WorkerC.make(
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const counters = yield* Counter.from(WorkerC);
     // ... fetch handler ...

--- a/website/src/content/docs/tutorial/cloudflare/rpc-worker.mdx
+++ b/website/src/content/docs/tutorial/cloudflare/rpc-worker.mdx
@@ -76,7 +76,7 @@ import { TaskRpcs } from "./rpcs.ts";
 
 export default class Worker extends Cloudflare.RpcWorker<Worker>()(
   "Worker",
-  { main: import.meta.filename, schema: TaskRpcs },
+  { main: import.meta.url, schema: TaskRpcs },
   Effect.gen(function* () {
     return Effect.succeed(undefined as never);
   }),
@@ -96,7 +96,7 @@ which carries the `RpcGroup`.
 
  export default class Worker extends Cloudflare.RpcWorker<Worker>()(
    "Worker",
-   { main: import.meta.filename, schema: TaskRpcs },
+   { main: import.meta.url, schema: TaskRpcs },
    Effect.gen(function* () {
 -    return Effect.succeed(undefined as never);
 +    const handlers = TaskRpcs.toLayer({
@@ -121,7 +121,7 @@ and return type.
 
  export default class Worker extends Cloudflare.RpcWorker<Worker>()(
    "Worker",
-   { main: import.meta.filename, schema: TaskRpcs },
+   { main: import.meta.url, schema: TaskRpcs },
    Effect.gen(function* () {
      const handlers = TaskRpcs.toLayer({
        getTask: ({ id }) => Effect.succeed(`task-${id}`),
@@ -304,7 +304,7 @@ import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 
 export default class Caller extends Cloudflare.Worker<Caller>()(
   "Caller",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     return {
       fetch: Effect.gen(function* () {
@@ -327,7 +327,7 @@ A regular Worker — same shape as any other `Cloudflare.Worker`.
 
  export default class Caller extends Cloudflare.Worker<Caller>()(
    "Caller",
-   { main: import.meta.filename },
+   { main: import.meta.url },
    Effect.gen(function* () {
 +    const tasks = yield* Cloudflare.RpcWorker.bind(TaskWorker);
 +
@@ -381,7 +381,7 @@ runtime via `static make(impl)`:
 // src/worker.ts
 export class Worker extends Cloudflare.RpcWorker<Worker>()(
   "Worker",
-  { main: import.meta.filename, schema: TaskRpcs },
+  { main: import.meta.url, schema: TaskRpcs },
 ) {}
 
 export default Worker.make(
@@ -412,7 +412,7 @@ publishes for cross-script binding:
 -export class Worker extends Cloudflare.RpcWorker<Worker>()(
 +export class Worker extends Cloudflare.RpcWorker<Worker, Counter>()(
    "Worker",
-   { main: import.meta.filename, schema: TaskRpcs },
+   { main: import.meta.url, schema: TaskRpcs },
  ) {}
 ```
 

--- a/website/src/content/docs/tutorial/cloudflare/vite-spa.mdx
+++ b/website/src/content/docs/tutorial/cloudflare/vite-spa.mdx
@@ -490,7 +490,7 @@ concurrency), factor it into its own Worker:
 +
 +export default class Backend extends Cloudflare.Worker<Backend>()(
 +  "Backend",
-+  { main: import.meta.filename },
++  { main: import.meta.url },
 +  Effect.gen(function* () {
 +    const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
 +

--- a/website/src/content/docs/tutorial/cloudflare/workflows.mdx
+++ b/website/src/content/docs/tutorial/cloudflare/workflows.mdx
@@ -371,7 +371,7 @@ import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 
 export default Cloudflare.Worker(
   "Worker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
 +   const notifier = yield* NotifyWorkflow;
 

--- a/website/src/content/docs/tutorial/part-2.mdx
+++ b/website/src/content/docs/tutorial/part-2.mdx
@@ -27,7 +27,7 @@ import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 export default Cloudflare.Worker(
   "Worker",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
     return {
@@ -116,7 +116,7 @@ import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 export default Cloudflare.Worker(
   "Worker",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
   },
   Effect.gen(function* () {
 +   const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
@@ -149,7 +149,7 @@ import { Bucket } from "./bucket.ts";
 
 export default Cloudflare.Worker(
   "Worker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
 
@@ -187,7 +187,7 @@ import { Bucket } from "./bucket.ts";
 
 export default Cloudflare.Worker(
   "Worker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
     return {
@@ -233,7 +233,7 @@ import { Bucket } from "./bucket.ts";
 
 export default Cloudflare.Worker(
   "Worker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
     return {
@@ -285,7 +285,7 @@ import { Bucket } from "./bucket.ts";
 
 export default Cloudflare.Worker(
   "Worker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
     return {

--- a/website/src/content/docs/tutorial/part-4.mdx
+++ b/website/src/content/docs/tutorial/part-4.mdx
@@ -49,7 +49,7 @@ Set a custom port for your Worker:
 export default Cloudflare.Worker(
   "Worker",
   {
-    main: import.meta.filename,
+    main: import.meta.url,
 +   dev: {
 +     port: 3000,
 +   },

--- a/website/src/content/docs/what-is-alchemy.mdx
+++ b/website/src/content/docs/what-is-alchemy.mdx
@@ -50,7 +50,7 @@ import { Bucket } from "./bucket.ts";
 
 export default Cloudflare.Worker(
   "Worker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
 
@@ -217,7 +217,7 @@ composable retries, and bindings resolved through the Effect system:
 ```typescript
 export default Cloudflare.Worker(
   "Worker",
-  { main: import.meta.filename },
+  { main: import.meta.url },
   Effect.gen(function* () {
     const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
     return {


### PR DESCRIPTION
`import.meta.filename` is a Node/Bun extension; `import.meta.url` is the portable, HTML-defined form implemented across runtimes. Switch the documented Worker `main` idiom (plus docs, examples, stacks, and test fixtures) to it.

The drizzle-workflow fixture used the value as a filesystem path (`path.join`), so it now resolves via `fileURLToPath(import.meta.url)`.

Historical content (blog posts, CHANGELOG) is left untouched.