### PR TITLE
fix(cloudflare): tolerate KV eventual consistency in workflow testy

### DIFF
--- a/examples/cloudflare-worker/src/NotifyWorkflow.ts
+++ b/examples/cloudflare-worker/src/NotifyWorkflow.ts
@@ -2,6 +2,7 @@ import * as Cloudflare from "alchemy/Cloudflare";
 import { Config } from "effect";
 import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
+import * as Schedule from "effect/Schedule";
 import { KV } from "./KV.ts";
 import Room from "./Room.ts";
 
@@ -30,7 +31,16 @@ export default class NotifyWorkflow extends Cloudflare.Workflow<NotifyWorkflow>(
         Effect.gen(function* () {
           const key = `workflow:smoke:${roomId}`;
           yield* kv.put(key, message);
-          const got = yield* kv.get(key);
+          // KV is eventually consistent: a read immediately after a write can
+          // briefly miss or return stale data. Re-read until it reflects the
+          // write (bounded, so a genuine failure still surfaces below).
+          const got = yield* kv.get(key).pipe(
+            Effect.repeat({
+              schedule: Schedule.spaced("500 millis"),
+              until: (value) => value === message,
+              times: 10,
+            }),
+          );
           if (got !== message) {
             return yield* Effect.die(
               new Error(


### PR DESCRIPTION
The `cloudflare-worker` integ test flaked intermittently: the workflow instance came back `errored` on one run and `complete` on the next, identical code.

Root cause is the `kv-roundtrip` workflow step — it writes a key then reads it back immediately and `Effect.die`s on mismatch. KV is eventually consistent, so a read right after a write can briefly miss or return stale data, killing the step and erroring the instance.

The read now re-reads with a bounded `Effect.repeat` until KV reflects the write. A genuine failure still surfaces via the existing `Effect.die` after the bound.

```diff
  yield* kv.put(key, message);
- const got = yield* kv.get(key);
+ const got = yield* kv.get(key).pipe(
+   Effect.repeat({
+     schedule: Schedule.spaced("500 millis"),
+     until: (value) => value === message,
+     times: 10,
+   }),
+ );
  if (got !== message) {
    return yield* Effect.die(/* … */);
  }
```

Verified against `alchemy-testing`: `bun test` is green 4/4 with the worker redeployed.
