### PR TITLE
fix(aws): provide Region to STS GetCallerIdentity during login

### DIFF
--- a/packages/alchemy/src/AWS/AuthProvider.ts
+++ b/packages/alchemy/src/AWS/AuthProvider.ts
@@ -17,6 +17,7 @@ import {
   type ConfigureContext,
 } from "../Auth/AuthProvider.ts";
 import { CredentialsStore, displayRedacted } from "../Auth/Credentials.ts";
+import * as Region from "./Region.ts";
 import {
   getEnv,
   getEnvRedacted,
@@ -94,20 +95,25 @@ export const AwsAuth = AuthProviderLayer<
       accessKeyId,
       secretAccessKey,
       sessionToken,
+      region,
     }: {
       accessKeyId: Redacted.Redacted<string>;
       secretAccessKey: Redacted.Redacted<string>;
       sessionToken?: Redacted.Redacted<string>;
+      region: string;
     }) =>
       STS.getCallerIdentity({}).pipe(
         Effect.provide(
-          Layer.succeed(
-            Credentials,
-            Effect.succeed({
-              accessKeyId,
-              secretAccessKey,
-              sessionToken,
-            }),
+          Layer.mergeAll(
+            Layer.succeed(
+              Credentials,
+              Effect.succeed({
+                accessKeyId,
+                secretAccessKey,
+                sessionToken,
+              }),
+            ),
+            Region.of(region),
           ),
         ),
         Effect.flatMap((self) =>
@@ -143,6 +149,7 @@ export const AwsAuth = AuthProviderLayer<
         accessKeyId: Redacted.make(accessKeyId),
         secretAccessKey: Redacted.make(secretAccessKey),
         sessionToken: sessionToken ? Redacted.make(sessionToken) : undefined,
+        region,
       });
 
       yield* store.write<AwsStoredCredentials>(profileName, "aws", {
@@ -234,7 +241,12 @@ export const AwsAuth = AuthProviderLayer<
               }
               const accountId = yield* getEnvRequired("AWS_ACCOUNT_ID").pipe(
                 Effect.catch(() =>
-                  getAccountId({ accessKeyId, secretAccessKey, sessionToken }),
+                  getAccountId({
+                    accessKeyId,
+                    secretAccessKey,
+                    sessionToken,
+                    region,
+                  }),
                 ),
               );
               return {
@@ -277,11 +289,12 @@ export const AwsAuth = AuthProviderLayer<
                 creds.accountId
                   ? Effect.succeed(creds)
                   : creds.credentials.pipe(
-                      Effect.flatMap((creds) =>
+                      Effect.flatMap((resolved) =>
                         getAccountId({
-                          accessKeyId: creds.accessKeyId,
-                          secretAccessKey: creds.secretAccessKey,
-                          sessionToken: creds.sessionToken,
+                          accessKeyId: resolved.accessKeyId,
+                          secretAccessKey: resolved.secretAccessKey,
+                          sessionToken: resolved.sessionToken,
+                          region: creds.region,
                         }),
                       ),
                       Effect.map(


### PR DESCRIPTION
`alchemy login --configure` with the **Stored** method died immediately after entering the region:

```
Error: Service not found: AWS::Region
    (defined at @distilled.cloud/aws/src/region.ts:6:37)
```

`getAccountId` validates the entered keys via STS `GetCallerIdentity`, but only provided a `Credentials` layer — every distilled AWS client also requires the `AWS::Region` service. The `login` command runs `configure` with no `Region` in scope (`Region.fromEnvironment` only exists inside `AWS.providers()`), so the call had nothing to satisfy the requirement.

Fix at the root: thread the region (already in scope at every call site) into `getAccountId` and provide it via `Region.of`.

```diff
 STS.getCallerIdentity({}).pipe(
   Effect.provide(
-    Layer.succeed(Credentials, Effect.succeed({ accessKeyId, secretAccessKey, sessionToken })),
+    Layer.mergeAll(
+      Layer.succeed(Credentials, Effect.succeed({ accessKeyId, secretAccessKey, sessionToken })),
+      Region.of(region),
+    ),
   ),
```

This covers all three callers — the Stored prompt flow, the `env` resolver, and the legacy account-id backfill — rather than only the path the bug report hit.

Closes #705
