### PR TITLE
fix(aws): break Region/AWSEnvironment layer cycle in env auth account-id lookup

### DIFF
--- a/packages/alchemy/src/AWS/AuthProvider.ts
+++ b/packages/alchemy/src/AWS/AuthProvider.ts
@@ -1,5 +1,6 @@
 import * as DistilledAuth from "@distilled.cloud/aws/Auth";
 import { Credentials } from "@distilled.cloud/aws/Credentials";
+import { Region } from "@distilled.cloud/aws/Region";
 import * as STS from "@distilled.cloud/aws/sts";
 import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
@@ -94,20 +95,29 @@ export const AwsAuth = AuthProviderLayer<
       accessKeyId,
       secretAccessKey,
       sessionToken,
+      region,
     }: {
       accessKeyId: Redacted.Redacted<string>;
       secretAccessKey: Redacted.Redacted<string>;
       sessionToken?: Redacted.Redacted<string>;
+      region: string;
     }) =>
       STS.getCallerIdentity({}).pipe(
         Effect.provide(
-          Layer.succeed(
-            Credentials,
-            Effect.succeed({
-              accessKeyId,
-              secretAccessKey,
-              sessionToken,
-            }),
+          Layer.mergeAll(
+            Layer.succeed(
+              Credentials,
+              Effect.succeed({
+                accessKeyId,
+                secretAccessKey,
+                sessionToken,
+              }),
+            ),
+            // Provide Region directly from the resolved inputs. Relying on the
+            // ambient Region provider (Region.fromEnvironment) here would
+            // deadlock: it derives the region from AWSEnvironment, which is the
+            // very service still being constructed by this STS call.
+            Layer.succeed(Region, Effect.succeed(region)),
           ),
         ),
         Effect.flatMap((self) =>
@@ -143,6 +153,7 @@ export const AwsAuth = AuthProviderLayer<
         accessKeyId: Redacted.make(accessKeyId),
         secretAccessKey: Redacted.make(secretAccessKey),
         sessionToken: sessionToken ? Redacted.make(sessionToken) : undefined,
+        region,
       });
 
       yield* store.write<AwsStoredCredentials>(profileName, "aws", {
@@ -234,7 +245,12 @@ export const AwsAuth = AuthProviderLayer<
               }
               const accountId = yield* getEnvRequired("AWS_ACCOUNT_ID").pipe(
                 Effect.catch(() =>
-                  getAccountId({ accessKeyId, secretAccessKey, sessionToken }),
+                  getAccountId({
+                    accessKeyId,
+                    secretAccessKey,
+                    sessionToken,
+                    region,
+                  }),
                 ),
               );
               return {
@@ -277,11 +293,12 @@ export const AwsAuth = AuthProviderLayer<
                 creds.accountId
                   ? Effect.succeed(creds)
                   : creds.credentials.pipe(
-                      Effect.flatMap((creds) =>
+                      Effect.flatMap((resolved) =>
                         getAccountId({
-                          accessKeyId: creds.accessKeyId,
-                          secretAccessKey: creds.secretAccessKey,
-                          sessionToken: creds.sessionToken,
+                          accessKeyId: resolved.accessKeyId,
+                          secretAccessKey: resolved.secretAccessKey,
+                          sessionToken: resolved.sessionToken,
+                          region: creds.region,
                         }),
                       ),
                       Effect.map(

--- a/packages/alchemy/src/AWS/Region.ts
+++ b/packages/alchemy/src/AWS/Region.ts
@@ -21,8 +21,15 @@ export const fromEnvOrElse = (region: string) =>
     Effect.succeed(process.env.AWS_REGION ?? region),
   );
 
-export const CurrentRegion = AWSEnvironment.use((env) =>
-  Effect.flatMap(env, ({ region }) => Effect.succeed(region)),
+// Deferred with `Effect.suspend` so it does not dereference `AWSEnvironment`
+// during module evaluation. `Region.ts` and `Environment.ts` are part of an
+// import cycle (AuthProvider → Region → Environment → AuthProvider); touching
+// `AWSEnvironment` eagerly at top level hits a temporal-dead-zone error when
+// this module is evaluated mid-cycle.
+export const CurrentRegion = Effect.suspend(() =>
+  AWSEnvironment.use((env) =>
+    Effect.flatMap(env, ({ region }) => Effect.succeed(region)),
+  ),
 );
 
 /**


### PR DESCRIPTION
Fixes #704 — `plan`/`deploy` hung forever under `{ "method": "env" }` AWS auth when `AWS_ACCOUNT_ID` was unset.

`getAccountId` resolves the account via STS `GetCallerIdentity` but only provided `Credentials`, so the STS client fell back to the ambient `Region` provider — `Region.fromEnvironment` — which derives the region from `AWSEnvironment`, the very service still being constructed. STS waited on `AWSEnvironment`; `AWSEnvironment` waited on STS → deadlock.

Provide `Region` directly to the STS call from the already-resolved region inputs, so the account-id lookup never touches `AWSEnvironment`:

```diff
 STS.getCallerIdentity({}).pipe(
   Effect.provide(
-    Layer.succeed(Credentials, Effect.succeed({ accessKeyId, secretAccessKey, sessionToken })),
+    Layer.mergeAll(
+      Layer.succeed(Credentials, Effect.succeed({ accessKeyId, secretAccessKey, sessionToken })),
+      Layer.succeed(Region, Effect.succeed(region)),
+    ),
   ),
 )
```

The region is already in scope at all three call sites (`env` branch, interactive `loginStored`, and the stored-credentials account-id backfill), so each passes it in.

### Note

No automated test — reproducing the deadlock needs live AWS credentials and an STS round-trip; the cycle only manifests inside the real deploy graph, which doesn't fit the unit-test harness.
