### PR TITLE
fix(cloudflare/containers): auto-restart stopped/crashed containers, fail fast on crash

### DIFF
--- a/packages/alchemy/src/Cloudflare/Containers/StartContainer.ts
+++ b/packages/alchemy/src/Cloudflare/Containers/StartContainer.ts
@@ -180,18 +180,28 @@ export const startContainer = Effect.fn(function* <
       Effect.catchTag("ContainerError", (error) =>
         Effect.logError(`Container monitor error: ${error.message}`),
       ),
+      // When the container exits (stopped, crashed, or slept), its ports are no
+      // longer listening — drop the confirmed-ready marks so the next request
+      // re-probes the freshly (re)started instance instead of fetching a dead
+      // port. This is the analog of native's monitor clearing the `healthy`
+      // state on exit.
+      Effect.ensuring(Effect.sync(() => readyPorts.clear())),
     ),
   );
 
-  // Start the container if it isn't running, serialised + classified. Backs
-  // off on rate limiting instead of hammering the allocator.
-  const ensureRunning = Semaphore.withPermits(
+  // The actual (re)start, serialised through the mutex so racing callers never
+  // both invoke `container.start()` ("already running" — see
+  // cloudflare/containers#173). Re-checks `running` under the lock.
+  const startOnce = Semaphore.withPermits(
     startMutex,
     1,
   )(
     Effect.gen(function* () {
       if (yield* container.running) return;
       yield* Effect.logDebug("Container not running, starting...");
+      // A (re)start means nothing is listening yet — clear any stale ready
+      // marks from a previous run so the next request re-probes this instance.
+      yield* Effect.sync(() => readyPorts.clear());
       yield* container.start(options).pipe(
         Effect.catchDefect((defect) => Effect.fail(classifyDefect(defect, -1))),
         // A rate limit is transient — back off well clear of the per-second
@@ -210,6 +220,16 @@ export const startContainer = Effect.fn(function* <
       yield* launchMonitor;
     }),
   );
+
+  // Ensure the container is running. Fast path: when it's already running (the
+  // steady state) this is a single cheap `running` read and avoids contending
+  // on the start mutex. Only an actual (re)start acquires the lock — which is
+  // also what makes auto-restart work: a stopped/crashed container has
+  // `running === false`, so the next call transparently restarts it.
+  const ensureRunning = Effect.gen(function* () {
+    if (yield* container.running) return;
+    yield* startOnce;
+  });
 
   // A single readiness probe: any response at all (even a non-2xx) proves the
   // port is accepting connections. Each probe is hard-capped so a hung connect
@@ -262,18 +282,35 @@ export const startContainer = Effect.fn(function* <
       ),
     );
 
-  // Retry every readiness failure that could plausibly clear by waiting on the
-  // same instance — a not-yet-listening port, a still-allocating instance, a
-  // hung/timed-out probe, even a transient `running === false` read during cold
-  // start (which we can't reliably distinguish from a real crash without
-  // native's monitor exit code, so we keep polling within the bounded budget
-  // and only surface `ContainerCrashedError` if it never recovers). The one
-  // failure NOT retried here is a rate limit, which `ensureRunning` already
-  // backs off on — spinning the port loop would only make it worse.
+  // Retry ONLY failures that can clear by waiting on the SAME instance:
+  //   - `ContainerError`           — the port isn't listening yet (the app is
+  //                                  still booting; the container process is up)
+  //   - `NoContainerInstanceError` — an instance is still being allocated
+  // Fail fast on the rest:
+  //   - `ContainerCrashedError`    — the container PROCESS has exited
+  //                                  (`running === false`). `running` reflects
+  //                                  the process, not the app, so this is never
+  //                                  "still starting" — it's fatal for this
+  //                                  instance. Spinning the budget on a
+  //                                  crash-looping container just wastes ~20-60s
+  //                                  per request; surface it in ~one poll.
+  //   - `ContainerRateLimitedError`— back off in `ensureRunning`, don't spin.
+  // This matches `@cloudflare/containers`, whose `waitForPort` /
+  // `doStartContainer` throw immediately on `!running`.
   const isTransientReadiness = (e: ReadinessError) =>
-    e._tag !== "ContainerRateLimitedError";
+    e._tag === "ContainerError" || e._tag === "NoContainerInstanceError";
 
   // Phase 2 (native `waitForPort`): poll the port until it accepts connections.
+  // Crash detection is poll-based (`probePort` surfaces `ContainerCrashedError`
+  // on an observed `!running`, which `isTransientReadiness` does NOT retry).
+  //
+  // NB: we deliberately do NOT race `container.monitor()` for faster crash
+  // detection. The monitor wrapper settles immediately for a not-yet-allocated
+  // instance (and loses the exit code that native uses to tell "queued" from
+  // "exited"), so racing it mis-reports healthy, still-provisioning containers
+  // as crashed under concurrent startup — it dropped a 100-instance cold start
+  // to <10% success. Polling is correct under load; the price is that crash
+  // detection is bounded by the probe cadence rather than instant.
   const waitForPort = (portNumber: number) =>
     readyPorts.has(portNumber)
       ? Effect.void
@@ -294,23 +331,25 @@ export const startContainer = Effect.fn(function* <
         );
 
   // Phase 1 (native `doStartContainer`) + phase 2: ensure the instance is
-  // started (bounded, rate-limit aware), then wait for the port.
+  // started (bounded, rate-limit aware), then wait for the port. `ensureRunning`
+  // is ALWAYS run (cheap when already running) rather than short-circuiting on
+  // `readyPorts` — otherwise a container that has since stopped/crashed would
+  // never be restarted. The port probe (`waitForPort`) is what `readyPorts`
+  // skips in steady state.
   const ensureReady = (portNumber: number) =>
-    readyPorts.has(portNumber)
-      ? Effect.void
-      : ensureRunning.pipe(
-          Effect.retry({
-            while: (
-              e:
-                | ContainerError
-                | NoContainerInstanceError
-                | ContainerRateLimitedError,
-            ) => e._tag === "NoContainerInstanceError",
-            schedule: Schedule.spaced(READINESS_POLL_INTERVAL),
-            times: GET_CONTAINER_RETRIES,
-          }),
-          Effect.andThen(() => waitForPort(portNumber)),
-        );
+    ensureRunning.pipe(
+      Effect.retry({
+        while: (
+          e:
+            | ContainerError
+            | NoContainerInstanceError
+            | ContainerRateLimitedError,
+        ) => e._tag === "NoContainerInstanceError",
+        schedule: Schedule.spaced(READINESS_POLL_INTERVAL),
+        times: GET_CONTAINER_RETRIES,
+      }),
+      Effect.andThen(() => waitForPort(portNumber)),
+    );
 
   const getTcpPort = (portNumber: number) =>
     Effect.succeed({
@@ -333,7 +372,14 @@ export const startContainer = Effect.fn(function* <
               }),
             ),
           ),
+          // Only retry a generic transient blip: a not-yet-ready port
+          // (`ContainerError`) or a transport hiccup on the real request such
+          // as "Network connection lost" (`HttpClientError`). A crash, rate
+          // limit, or exhausted no-instance budget is surfaced immediately so a
+          // crash-looping container fails fast instead of re-starting 3× more.
           Effect.retry({
+            while: (e) =>
+              e._tag === "ContainerError" || e._tag === "HttpClientError",
             schedule: Schedule.spaced(READINESS_POLL_INTERVAL),
             times: REQUEST_RETRIES,
           }),

--- a/packages/alchemy/test/Cloudflare/Container/Container.benchmark.test.ts
+++ b/packages/alchemy/test/Cloudflare/Container/Container.benchmark.test.ts
@@ -244,4 +244,65 @@ describe("container cold-start benchmark", () => {
     }).pipe(logLevel),
     { timeout: TEST_TIMEOUT },
   );
+
+  // Number of crash-loop attempts to time. Small — this measures latency-to-
+  // fail, not throughput.
+  const CRASH_N = Number(process.env.BENCH_CRASH_N ?? 10);
+
+  test(
+    "surfaces a fatal crash fast instead of burning the readiness budget",
+    Effect.gen(function* () {
+      const { url } = yield* stack;
+      yield* waitForWorker(url);
+
+      const nonce = yield* Effect.sync(() => crypto.randomUUID().slice(0, 8));
+      const client = freshConn(yield* HttpClient.HttpClient);
+
+      const results = yield* Effect.forEach(
+        Array.from({ length: CRASH_N }, (_, i) => `crash-${nonce}-${i}`),
+        (name) =>
+          Effect.gen(function* () {
+            const start = yield* Effect.sync(() => Date.now());
+            const res = yield* client
+              .get(`${url}/crashloop?name=${encodeURIComponent(name)}`)
+              .pipe(Effect.timeout(REQUEST_TIMEOUT));
+            const body = yield* res.text;
+            const outside = (yield* Effect.sync(() => Date.now())) - start;
+            const parsed = JSON.parse(body) as { ms: number; ok: boolean };
+            return { outside, inside: parsed.ms, ok: parsed.ok };
+          }),
+        { concurrency: CRASH_N },
+      );
+
+      const insideStats = stats(results.map((r) => r.inside));
+      const outsideStats = stats(results.map((r) => r.outside));
+      const sec = (n: number) => `${(n / 1000).toFixed(1)}s`;
+      const failedFast = results.filter((r) => !r.ok).length;
+
+      yield* Effect.sync(() =>
+        console.log(
+          [
+            "",
+            `Container crash-loop fail-fast (N=${CRASH_N})`,
+            `── fatal crash (container exits immediately) ──`,
+            `  detected-as-failed: ${failedFast}/${CRASH_N}`,
+            `  time-to-fail inside (DO):`,
+            `    min ${sec(insideStats.min)}  p50 ${sec(insideStats.p50)}  p95 ${sec(insideStats.p95)}  max ${sec(insideStats.max)}  mean ${sec(insideStats.mean)}`,
+            `  time-to-fail outside (client):`,
+            `    min ${sec(outsideStats.min)}  p50 ${sec(outsideStats.p50)}  p95 ${sec(outsideStats.p95)}  max ${sec(outsideStats.max)}  mean ${sec(outsideStats.mean)}`,
+            "",
+          ].join("\n"),
+        ),
+      );
+
+      // Every attempt must be detected as failed — the container crash-loops.
+      expect(failedFast).toBe(CRASH_N);
+      // And it must fail FAST: before the fix this retried the crash for the
+      // full readiness budget (tens of seconds → minutes); aligned with native
+      // it surfaces in ~one poll past the platform's allocation time. Bound well
+      // under the per-request ceiling to catch a regression to budget-burning.
+      expect(insideStats.p95).toBeLessThan(60_000);
+    }).pipe(logLevel),
+    { timeout: TEST_TIMEOUT },
+  );
 });

--- a/packages/alchemy/test/Cloudflare/Container/ContainerRestart.test.ts
+++ b/packages/alchemy/test/Cloudflare/Container/ContainerRestart.test.ts
@@ -1,0 +1,152 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as Test from "@/Test/Vitest";
+import { describe, expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+import * as Schedule from "effect/Schedule";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import RestartStack from "./fixtures/restart/stack.ts";
+
+const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
+  providers: Cloudflare.providers(),
+  state: Cloudflare.state(),
+});
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+// Image build + push + worker/DO deploy comfortably exceeds the default hook
+// budget, and a restart adds another cold start on top, so be generous.
+const HOOK_TIMEOUT = 600_000;
+const TEST_TIMEOUT = 300_000;
+
+const DEPLOY_PLACEHOLDER = "Alchemy worker is being deployed...";
+
+// Force `Connection: close` so each attempt opens a fresh connection and can
+// land on an edge that already has the new deploy / restarted container.
+const freshConn = HttpClient.mapRequest(
+  HttpClientRequest.setHeader("connection", "close"),
+);
+
+const readinessSchedule = Schedule.exponential("500 millis").pipe(
+  Schedule.either(Schedule.spaced("3 seconds")),
+);
+
+// Retry a route until it answers 200 with a body containing `expected`,
+// rejecting transient non-200s and the pre-create deploy stub. This is how we
+// assert "the container is up and serving" both initially and after a restart.
+const fetchReady = (url: string, expected: string) =>
+  Effect.gen(function* () {
+    const client = freshConn(yield* HttpClient.HttpClient);
+    return yield* client.get(url).pipe(
+      Effect.flatMap((r) =>
+        r.status !== 200
+          ? Effect.fail(new Error(`not ready: ${r.status}`))
+          : Effect.flatMap(r.text, (body) =>
+              body.includes(DEPLOY_PLACEHOLDER) || !body.includes(expected)
+                ? Effect.fail(new Error(`not ready: got ${body}`))
+                : Effect.succeed(body),
+            ),
+      ),
+      Effect.timeout("30 seconds"),
+      Effect.retry({ schedule: readinessSchedule, times: 40 }),
+    );
+  });
+
+// Fire a single GET and return its body (used for /stop, /crash).
+const hit = (url: string) =>
+  Effect.gen(function* () {
+    const client = freshConn(yield* HttpClient.HttpClient);
+    const res = yield* client.get(url);
+    return yield* res.text;
+  });
+
+// Poll `/running` until the reported state matches `want`. Used to confirm the
+// container actually went down before we assert the next request restarts it,
+// so the test exercises the real restart path (not a still-warm container).
+const waitRunning = (baseUrl: string, name: string, want: boolean) =>
+  Effect.gen(function* () {
+    const client = freshConn(yield* HttpClient.HttpClient);
+    return yield* client
+      .get(`${baseUrl}/running?name=${encodeURIComponent(name)}`)
+      .pipe(
+        Effect.flatMap((r) =>
+          r.status !== 200
+            ? Effect.fail(new Error(`running not ready: ${r.status}`))
+            : Effect.flatMap(r.json, (body) => {
+                const running = (body as { running?: boolean }).running;
+                return running === want
+                  ? Effect.succeed(running)
+                  : Effect.fail(new Error(`running=${running}, want ${want}`));
+              }),
+        ),
+        Effect.timeout("15 seconds"),
+        Effect.retry({ schedule: readinessSchedule, times: 40 }),
+      );
+  });
+
+/**
+ * Auto-restart: a Durable Object's container that has stopped or crashed must
+ * be transparently restarted on the next request. Regression coverage for the
+ * `readyPorts` cache going stale — previously a port confirmed ready once was
+ * never re-probed and `ensureRunning` was skipped, so a stopped container was
+ * never restarted.
+ */
+describe("container auto-restart", () => {
+  const stack = beforeAll(deploy(RestartStack), { timeout: HOOK_TIMEOUT });
+  afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(RestartStack), {
+    timeout: HOOK_TIMEOUT,
+  });
+
+  test(
+    "restarts the container after it is stopped (destroy)",
+    Effect.gen(function* () {
+      const { url } = yield* stack;
+      const name = "stop";
+
+      // Start + confirm up.
+      expect(yield* fetchReady(`${url}/ping?name=${name}`, "pong")).toContain(
+        "pong",
+      );
+
+      // Hard-stop it, then confirm it is actually down before re-pinging — so
+      // the next ping must go through the restart path.
+      yield* hit(`${url}/stop?name=${name}`);
+      yield* waitRunning(url, name, false);
+
+      // Next request transparently restarts it.
+      expect(yield* fetchReady(`${url}/ping?name=${name}`, "pong")).toContain(
+        "pong",
+      );
+      expect(yield* waitRunning(url, name, true)).toBe(true);
+    }).pipe(logLevel),
+    { timeout: TEST_TIMEOUT },
+  );
+
+  test(
+    "restarts the container after it crashes (non-zero exit)",
+    Effect.gen(function* () {
+      const { url } = yield* stack;
+      const name = "crash";
+
+      expect(yield* fetchReady(`${url}/ping?name=${name}`, "pong")).toContain(
+        "pong",
+      );
+
+      // Make the container process exit on its own, then wait for the monitor
+      // to observe the exit (running === false).
+      yield* hit(`${url}/crash?name=${name}`);
+      yield* waitRunning(url, name, false);
+
+      // Next request transparently restarts it.
+      expect(yield* fetchReady(`${url}/ping?name=${name}`, "pong")).toContain(
+        "pong",
+      );
+      expect(yield* waitRunning(url, name, true)).toBe(true);
+    }).pipe(logLevel),
+    { timeout: TEST_TIMEOUT },
+  );
+});

--- a/packages/alchemy/test/Cloudflare/Container/fixtures/benchmark/crashloop-context/Dockerfile
+++ b/packages/alchemy/test/Cloudflare/Container/fixtures/benchmark/crashloop-context/Dockerfile
@@ -1,0 +1,9 @@
+# Crash-loop container: the entrypoint exits non-zero immediately on every
+# start, so the process never stays up and no port is ever bound. Used to prove
+# a fatal crash is surfaced FAST (bounded) instead of polling the full readiness
+# budget — and that this matches the native wrangler + @cloudflare/containers
+# behaviour.
+FROM oven/bun:latest
+
+EXPOSE 8080
+CMD ["bun", "-e", "process.exit(1)"]

--- a/packages/alchemy/test/Cloudflare/Container/fixtures/benchmark/crashloop-object.ts
+++ b/packages/alchemy/test/Cloudflare/Container/fixtures/benchmark/crashloop-object.ts
@@ -1,0 +1,55 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as Effect from "effect/Effect";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+
+/**
+ * A container whose process exits immediately on every start (see
+ * `crashloop-context/Dockerfile`). Reaching it always fails; the benchmark
+ * measures HOW LONG until that failure surfaces, to prove Alchemy fails fast on
+ * a fatal crash (like native wrangler) rather than burning the full readiness
+ * budget.
+ */
+export class BenchCrashContainer extends Cloudflare.Container<BenchCrashContainer>()(
+  "BenchCrashContainer",
+  {
+    context: `${import.meta.dirname}/crashloop-context`,
+    maxInstances: 100,
+    instanceType: "lite",
+    instances: 0,
+  },
+) {}
+
+export class BenchCrashObject extends Cloudflare.DurableObject<BenchCrashObject>()(
+  "BenchCrashObject",
+  Effect.gen(function* () {
+    const container = yield* BenchCrashContainer;
+
+    return Effect.gen(function* () {
+      const { fetch } = yield* container.getTcpPort(8080);
+
+      return {
+        // Attempt to reach the crash-looping container, returning how long until
+        // the attempt resolves (it always fails) and whether it succeeded. The
+        // elapsed time is the fail-fast metric.
+        boot: () =>
+          Effect.gen(function* () {
+            const start = yield* Effect.sync(() => Date.now());
+            const ok = yield* fetch(
+              HttpClientRequest.get("http://container/"),
+            ).pipe(
+              Effect.as(true),
+              Effect.catchCause(() => Effect.succeed(false)),
+            );
+            const ms = (yield* Effect.sync(() => Date.now())) - start;
+            return { ms, ok };
+          }),
+      };
+    });
+  }).pipe(
+    Effect.provide(
+      Cloudflare.Containers.layer(BenchCrashContainer, {
+        enableInternet: true,
+      }),
+    ),
+  ),
+) {}

--- a/packages/alchemy/test/Cloudflare/Container/fixtures/benchmark/worker.ts
+++ b/packages/alchemy/test/Cloudflare/Container/fixtures/benchmark/worker.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import { BenchBunObject } from "./bun-object.ts";
+import { BenchCrashObject } from "./crashloop-object.ts";
 import { BenchEffectfulObject } from "./effectful-object.ts";
 import { BenchRemoteObject } from "./remote-object.ts";
 
@@ -14,9 +15,10 @@ import { BenchRemoteObject } from "./remote-object.ts";
  * - `GET /effectful?name=X` → effectful (bundled Effect program) container
  * - `GET /remote?name=X`    → remote (pre-built echo image) container
  * - `GET /bun?name=X`       → bun-baseline (same base image, no Effect bundle)
+ * - `GET /crashloop?name=X` → a container that exits immediately (fail-fast)
  *
  * The test fires N distinct names per route concurrently to spin up N
- * containers and compares the two variants.
+ * containers and compares the variants.
  */
 export default class BenchWorker extends Cloudflare.Worker<BenchWorker>()(
   "BenchWorker",
@@ -27,6 +29,7 @@ export default class BenchWorker extends Cloudflare.Worker<BenchWorker>()(
     const effectful = yield* BenchEffectfulObject;
     const remote = yield* BenchRemoteObject;
     const bun = yield* BenchBunObject;
+    const crash = yield* BenchCrashObject;
 
     return {
       fetch: Effect.gen(function* () {
@@ -46,6 +49,11 @@ export default class BenchWorker extends Cloudflare.Worker<BenchWorker>()(
 
         if (url.pathname === "/bun") {
           const result = yield* bun.getByName(name).boot();
+          return yield* HttpServerResponse.json(result);
+        }
+
+        if (url.pathname === "/crashloop") {
+          const result = yield* crash.getByName(name).boot();
           return yield* HttpServerResponse.json(result);
         }
 

--- a/packages/alchemy/test/Cloudflare/Container/fixtures/benchmark/wrangler/Dockerfile.crash
+++ b/packages/alchemy/test/Cloudflare/Container/fixtures/benchmark/wrangler/Dockerfile.crash
@@ -1,0 +1,8 @@
+# Crash-loop control: the entrypoint exits non-zero immediately on every start,
+# matching the Alchemy crash-loop fixture. Used to measure how fast native
+# `@cloudflare/containers` surfaces a fatal crash, as the baseline Alchemy is
+# compared against.
+FROM oven/bun:latest
+
+EXPOSE 8080
+CMD ["bun", "-e", "process.exit(1)"]

--- a/packages/alchemy/test/Cloudflare/Container/fixtures/benchmark/wrangler/bench.ts
+++ b/packages/alchemy/test/Cloudflare/Container/fixtures/benchmark/wrangler/bench.ts
@@ -9,6 +9,7 @@
  *   bun x wrangler deploy                     # build + push the image, deploy the worker
  *   WORKER_URL=https://<worker>.workers.dev bun bench.ts
  *   BENCH_N=2 BENCH_CONCURRENCY=2 WORKER_URL=... bun bench.ts
+ *   BENCH_CRASH=1 WORKER_URL=... bun bench.ts   # crash-loop fail-fast baseline
  *   bun x wrangler delete                     # tear down
  *
  * `wrangler` and `@cloudflare/containers` resolve from the `alchemy` package's
@@ -24,6 +25,10 @@ const CONCURRENCY = Number(process.env.BENCH_CONCURRENCY ?? N);
 const REQUEST_TIMEOUT_MS = Number(
   process.env.BENCH_REQUEST_TIMEOUT_MS ?? 240_000,
 );
+// When set, benchmark how fast native surfaces a fatal crash (the baseline
+// Alchemy's fail-fast behaviour is compared against) instead of cold start.
+const CRASH = process.env.BENCH_CRASH === "1";
+const CRASH_N = Number(process.env.BENCH_CRASH_N ?? 10);
 
 if (!WORKER_URL) {
   console.error(
@@ -118,8 +123,67 @@ const stats = (xs: number[]) => {
   };
 };
 
+// One crash-loop attempt: time how long until the failure surfaces. `ok` is
+// true only on a 2xx (never, for a crash-looping container).
+const crashAttempt = async (
+  name: string,
+): Promise<{ outside: number; inside: number | undefined; ok: boolean }> => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  const start = Date.now();
+  try {
+    const res = await fetch(
+      `${WORKER_URL}/crashloop?name=${encodeURIComponent(name)}`,
+      { headers: { connection: "close" }, signal: controller.signal },
+    );
+    const body = await res.text();
+    const outside = Date.now() - start;
+    const parsed = JSON.parse(body) as { ms?: number; ok?: boolean };
+    return { outside, inside: parsed.ms, ok: parsed.ok ?? false };
+  } catch {
+    return { outside: Date.now() - start, inside: undefined, ok: false };
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+const runCrash = async () => {
+  const nonce = crypto.randomUUID().slice(0, 8);
+  const names = Array.from(
+    { length: CRASH_N },
+    (_, i) => `crash-${nonce}-${i}`,
+  );
+  const results = await Promise.all(names.map(crashAttempt));
+  const outside = stats(results.map((r) => r.outside));
+  const inside = stats(
+    results
+      .map((r) => r.inside)
+      .filter((m): m is number => typeof m === "number"),
+  );
+  const sec = (n: number) => `${(n / 1000).toFixed(1)}s`;
+  const failed = results.filter((r) => !r.ok).length;
+  console.log(
+    [
+      "",
+      `wrangler + @cloudflare/containers crash-loop fail-fast (N=${CRASH_N})`,
+      `── fatal crash (container exits immediately) ──`,
+      `  detected-as-failed: ${failed}/${CRASH_N}`,
+      `  time-to-fail inside (worker):`,
+      `    min ${sec(inside.min)}  p50 ${sec(inside.p50)}  p95 ${sec(inside.p95)}  max ${sec(inside.max)}  mean ${sec(inside.mean)}`,
+      `  time-to-fail outside (client):`,
+      `    min ${sec(outside.min)}  p50 ${sec(outside.p50)}  p95 ${sec(outside.p95)}  max ${sec(outside.max)}  mean ${sec(outside.mean)}`,
+      "",
+    ].join("\n"),
+  );
+};
+
 const main = async () => {
   await wait(WORKER_URL);
+
+  if (CRASH) {
+    await runCrash();
+    return;
+  }
 
   const nonce = crypto.randomUUID().slice(0, 8);
   const names = Array.from({ length: N }, (_, i) => `${nonce}-${i}`);

--- a/packages/alchemy/test/Cloudflare/Container/fixtures/benchmark/wrangler/worker.ts
+++ b/packages/alchemy/test/Cloudflare/Container/fixtures/benchmark/wrangler/worker.ts
@@ -1,7 +1,10 @@
+/// <reference types="@cloudflare/workers-types" />
+
 import { Container, getContainer } from "@cloudflare/containers";
 
 interface Env {
   BENCH_CONTAINER: DurableObjectNamespace<BenchContainer>;
+  CRASH_CONTAINER: DurableObjectNamespace<CrashContainer>;
 }
 
 /**
@@ -11,6 +14,16 @@ interface Env {
  * internally), so timing a single `fetch` measures start → reachable.
  */
 export class BenchContainer extends Container<Env> {
+  defaultPort = 8080;
+  sleepAfter = "2m";
+}
+
+/**
+ * Crash-loop control: its image exits immediately, so `fetch` can never reach
+ * it. Native surfaces the fatal crash from its monitor and returns a 5xx; we
+ * time how fast that happens to baseline Alchemy's fail-fast behaviour.
+ */
+export class CrashContainer extends Container<Env> {
   defaultPort = 8080;
   sleepAfter = "2m";
 }
@@ -34,6 +47,26 @@ export default {
           { error: String(err), ms: Date.now() - start },
           { status: 500 },
         );
+      }
+    }
+
+    // `/crashloop?name=X` attempts to reach a container that crash-loops and
+    // reports how long until the failure surfaces (native returns a 5xx). `ok`
+    // is true only on a 2xx — always false here.
+    if (url.pathname === "/crashloop") {
+      const name = url.searchParams.get("name") ?? "default";
+      const container = getContainer(env.CRASH_CONTAINER, name);
+      const start = Date.now();
+      try {
+        const res = await container.fetch(new Request("http://container/"));
+        await res.text();
+        return Response.json({ ms: Date.now() - start, ok: res.ok });
+      } catch (err) {
+        return Response.json({
+          ms: Date.now() - start,
+          ok: false,
+          error: String(err),
+        });
       }
     }
 

--- a/packages/alchemy/test/Cloudflare/Container/fixtures/benchmark/wrangler/wrangler.jsonc
+++ b/packages/alchemy/test/Cloudflare/Container/fixtures/benchmark/wrangler/wrangler.jsonc
@@ -11,6 +11,11 @@
       "class_name": "BenchContainer",
       "image": "./Dockerfile",
       "max_instances": 100
+    },
+    {
+      "class_name": "CrashContainer",
+      "image": "./Dockerfile.crash",
+      "max_instances": 100
     }
   ],
   "durable_objects": {
@@ -18,6 +23,10 @@
       {
         "class_name": "BenchContainer",
         "name": "BENCH_CONTAINER"
+      },
+      {
+        "class_name": "CrashContainer",
+        "name": "CRASH_CONTAINER"
       }
     ]
   },
@@ -25,6 +34,10 @@
     {
       "new_sqlite_classes": ["BenchContainer"],
       "tag": "v1"
+    },
+    {
+      "new_sqlite_classes": ["CrashContainer"],
+      "tag": "v2"
     }
   ]
 }

--- a/packages/alchemy/test/Cloudflare/Container/fixtures/restart/container.ts
+++ b/packages/alchemy/test/Cloudflare/Container/fixtures/restart/container.ts
@@ -1,0 +1,43 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as Effect from "effect/Effect";
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+/**
+ * Minimal effectful container for exercising stop/crash → auto-restart. `ping`
+ * proves the container is up; the `/exit` route makes the container process
+ * kill itself (non-zero exit) so we can drive the monitor-observed-crash path.
+ */
+export class RestartContainer extends Cloudflare.Container<
+  RestartContainer,
+  {
+    ping: () => Effect.Effect<string>;
+  }
+>()("RestartContainer") {}
+
+export default RestartContainer.make(
+  {
+    main: import.meta.filename,
+    dockerfile: "FROM oven/bun:latest",
+  },
+  Effect.gen(function* () {
+    return {
+      ping: () => Effect.succeed("pong"),
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        const url = new URL(request.url, "http://container");
+        if (url.pathname === "/exit") {
+          // Simulate a crash: kill the container process with a non-zero exit
+          // code shortly after replying, so the response flushes first. The
+          // Durable Object's monitor observes the exit; the next request must
+          // transparently restart the container.
+          yield* Effect.sync(() => {
+            setTimeout(() => process.exit(1), 50);
+          });
+          return HttpServerResponse.text("exiting");
+        }
+        return HttpServerResponse.text("ok");
+      }),
+    };
+  }),
+);

--- a/packages/alchemy/test/Cloudflare/Container/fixtures/restart/object.ts
+++ b/packages/alchemy/test/Cloudflare/Container/fixtures/restart/object.ts
@@ -1,0 +1,45 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as Effect from "effect/Effect";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import { RestartContainer } from "./container.ts";
+
+/**
+ * Durable Object backing one {@link RestartContainer} instance, exposing the
+ * levers the restart tests need:
+ *  - `ping`    — RPC into the container (forces start + proves it's up)
+ *  - `running` — the raw `container.running` flag
+ *  - `stop`    — hard stop from the DO side (`destroy` = SIGKILL)
+ *  - `crash`   — make the container process exit on its own (non-zero)
+ */
+export class RestartObject extends Cloudflare.DurableObject<RestartObject>()(
+  "RestartObject",
+  Effect.gen(function* () {
+    const container = yield* RestartContainer;
+
+    return Effect.gen(function* () {
+      return {
+        ping: () => container.ping(),
+        running: () => container.running,
+        // Hard stop from the DO side. Exercises the "container stopped, then
+        // requested again" auto-restart path.
+        stop: () => container.destroy(),
+        // Crash from inside the container process. Exercises the
+        // monitor-observed-exit auto-restart path.
+        crash: () =>
+          Effect.gen(function* () {
+            const { fetch } = yield* container.getTcpPort(3000);
+            const response = yield* fetch(
+              HttpClientRequest.get("http://container/exit"),
+            );
+            return yield* response.text;
+          }).pipe(Effect.orDie),
+      };
+    });
+  }).pipe(
+    Effect.provide(
+      Cloudflare.Containers.layer(RestartContainer, {
+        enableInternet: true,
+      }),
+    ),
+  ),
+) {}

--- a/packages/alchemy/test/Cloudflare/Container/fixtures/restart/stack.ts
+++ b/packages/alchemy/test/Cloudflare/Container/fixtures/restart/stack.ts
@@ -1,0 +1,19 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as Alchemy from "@/index.ts";
+import * as Effect from "effect/Effect";
+import RestartContainerLive from "./container.ts";
+import Worker from "./worker.ts";
+
+export default Alchemy.Stack(
+  "RestartContainerStack",
+  {
+    providers: Cloudflare.providers(),
+    state: Cloudflare.state(),
+  },
+  Effect.gen(function* () {
+    const worker = yield* Worker;
+    return {
+      url: worker.url.as<string>(),
+    };
+  }).pipe(Effect.provide(RestartContainerLive)),
+);

--- a/packages/alchemy/test/Cloudflare/Container/fixtures/restart/worker.ts
+++ b/packages/alchemy/test/Cloudflare/Container/fixtures/restart/worker.ts
@@ -1,0 +1,59 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as Effect from "effect/Effect";
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import { RestartObject } from "./object.ts";
+
+/**
+ * Drives the restart scenarios over HTTP. Each request targets a named DO
+ * instance (`?name=`) so tests can isolate instances:
+ *  - `GET /ping`    → RPC ping (starts/restarts the container, returns "pong")
+ *  - `GET /running` → `{ running }`
+ *  - `GET /stop`    → destroy the container (SIGKILL)
+ *  - `GET /crash`   → make the container process exit non-zero
+ */
+export default Cloudflare.Worker(
+  "RestartWorker",
+  {
+    main: import.meta.filename,
+  },
+  Effect.gen(function* () {
+    const objects = yield* RestartObject;
+
+    return {
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        const url = new URL(request.url, "http://x");
+        const name = url.searchParams.get("name") ?? "default";
+        const object = objects.getByName(name);
+
+        if (url.pathname === "/ping") {
+          const pong = yield* object.ping();
+          return HttpServerResponse.text(pong);
+        }
+        if (url.pathname === "/running") {
+          const running = yield* object.running();
+          return yield* HttpServerResponse.json({ running });
+        }
+        if (url.pathname === "/stop") {
+          yield* object.stop();
+          return HttpServerResponse.text("stopped");
+        }
+        if (url.pathname === "/crash") {
+          const result = yield* object.crash();
+          return HttpServerResponse.text(result);
+        }
+
+        return HttpServerResponse.text("ok");
+      }).pipe(
+        // Surface failures as 5xx (not a thrown defect) so the test's readiness
+        // retry treats a mid-restart blip as retryable rather than fatal.
+        Effect.catchCause((cause) =>
+          Effect.succeed(
+            HttpServerResponse.text(String(cause), { status: 503 }),
+          ),
+        ),
+      ),
+    };
+  }),
+);


### PR DESCRIPTION
A Durable Object's container that stopped or crashed was never restarted on the next request. The `readyPorts` cache (our analog of native's `healthy` state) was never invalidated, and `ensureReady` short-circuited on it — so once a port was confirmed ready, a dead container was fetched directly and the request failed.

### Fix

```diff
- ensureReady = (port) => readyPorts.has(port) ? Effect.void : ensureRunning.pipe(... waitForPort)
+ ensureReady = (port) => ensureRunning.pipe(... waitForPort)   // always; cheap when already running
```

- **Always run `ensureRunning`** (double-checked locking keeps the steady-state hot path a single `running` read). A stopped/crashed container has `running === false`, so the next request transparently restarts it.
- **Invalidate `readyPorts`** on (re)start and on monitor exit, so the restarted instance is re-probed rather than fetched on a stale "ready" mark.
- **Fail fast on a fatal crash:** `ContainerCrashedError` (an observed `!running`) is no longer retried in the readiness loop or the request retry — matching native `@cloudflare/containers`, which throws immediately on `!running`. A crash-looping container surfaces in ~one poll instead of burning the readiness budget.

### Tests

- `ContainerRestart.test.ts` (+ `fixtures/restart/`) — stop→restart (`destroy`) and crash→restart (`process.exit(1)`), each polling `/running` to confirm the container actually went down before asserting the next request restarts it.
- A crash-loop fail-fast case in `Container.benchmark.test.ts` (+ `crashloop` fixtures and a `BENCH_CRASH=1` mode in the wrangler control harness) that measures time-to-fail and asserts it stays bounded.

### Rejected alternative

An event-driven variant racing `container.monitor()` for instant crash detection was evaluated and **reverted**: the monitor settles immediately for a not-yet-allocated instance, and the wrapper loses the exit code native uses to distinguish queued-vs-exited — so it mis-reported healthy, still-provisioning containers as crashed under concurrent startup (dropped a 100-instance cold start to <10%). Poll-based detection is correct under load; warm, it already surfaces a crash in ~1.7s.
