### PR TITLE
fix(aws/ecs): fix effectful ECS containers and add e2e smoke test that actually deploys

### DIFF
--- a/packages/alchemy/src/AWS/EC2/hosted.ts
+++ b/packages/alchemy/src/AWS/EC2/hosted.ts
@@ -1,17 +1,18 @@
 import * as iam from "@distilled.cloud/aws/iam";
 import * as s3 from "@distilled.cloud/aws/s3";
-import * as Config from "effect/Config";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import type * as rolldown from "rolldown";
 import * as Bundle from "../../Bundle/Bundle.ts";
 import { findCwdForBundle } from "../../Bundle/TempRoot.ts";
 import type { ScopedPlanStatusSession } from "../../Cli/Cli.ts";
-import * as Output from "../../Output.ts";
 import { createPhysicalName } from "../../PhysicalName.ts";
 import type { PlatformProps } from "../../Platform.ts";
 import type { ResourceBinding } from "../../Resource.ts";
-import type { ProcessContext } from "../../Server/Process.ts";
+import {
+  createHostRuntimeContext,
+  type HostRuntimeContext,
+} from "../../Server/Process.ts";
 import { createInternalTags, createTagsList, hasTags } from "../../Tags.ts";
 import { sha256 } from "../../Util/sha256.ts";
 import { zipCode } from "../../Util/zip.ts";
@@ -72,55 +73,12 @@ export interface Ec2HostedCleanupState {
 
 /**
  * Deploy-time / plan-time host context for EC2-backed platforms that bundle a
- * long-lived program (`exports.program`) and collect background work via `run`.
+ * long-lived program (`exports.program`) and collect background work via `run`
+ * / HTTP handlers via `serve`. Alias of the shared {@link HostRuntimeContext}.
  */
-export interface Ec2HostRuntimeContext extends ProcessContext {
-  exports: Effect.Effect<{
-    readonly program: Effect.Effect<void, never, any>;
-  }>;
-}
+export type Ec2HostRuntimeContext = HostRuntimeContext;
 
-export const createEc2HostRuntimeContext =
-  (type: string) =>
-  (id: string): Ec2HostRuntimeContext => {
-    const runners: Effect.Effect<void, never, any>[] = [];
-    const env: Record<string, any> = {};
-
-    return {
-      Type: type,
-      id,
-      env,
-      set: (bindingId: string, output: Output.Output) =>
-        Effect.sync(() => {
-          const key = bindingId.replaceAll(/[^a-zA-Z0-9]/g, "_");
-          env[key] = output.pipe(Output.map((value) => JSON.stringify(value)));
-          return key;
-        }),
-      get: <T>(key: string) =>
-        Config.string(key).pipe(
-          Effect.flatMap((value) =>
-            Effect.try({
-              try: () => JSON.parse(value) as T,
-              catch: (error) => error as Error,
-            }),
-          ),
-          Effect.catch((cause) =>
-            Effect.die(
-              new Error(`Failed to get environment variable: ${key}`, {
-                cause,
-              }),
-            ),
-          ),
-        ),
-      run: (effect: Effect.Effect<void, never, any>) =>
-        Effect.sync(() => {
-          runners.push(effect);
-        }),
-      exports: Effect.sync(() => ({
-        program: Effect.all(runners, { concurrency: "unbounded" }),
-      })),
-    } satisfies Ec2HostRuntimeContext;
-  };
+export const createEc2HostRuntimeContext = createHostRuntimeContext;
 
 export const createEc2HostedSupport = ({
   stackName,
@@ -235,7 +193,8 @@ const platform = Layer.mergeAll(
 );
 
 const program = handler.pipe(
-  Effect.flatMap((instance) => instance.RuntimeContext.exports.program),
+  Effect.flatMap((instance) => instance.RuntimeContext.exports),
+  Effect.flatMap((exports) => exports.program),
   Effect.provide(
     Layer.effect(
       Stack,

--- a/packages/alchemy/src/AWS/EC2/hosted.ts
+++ b/packages/alchemy/src/AWS/EC2/hosted.ts
@@ -155,14 +155,26 @@ export const createEc2HostedSupport = ({
           input: entry,
           cwd,
           platform: "node",
+          // The hosted process runs under `bun` (installed by the user-data);
+          // keep `bun`/`bun:*` external and resolve the `bun` export condition
+          // so `@effect/platform-bun` picks its Bun implementations.
+          external: [
+            "bun",
+            "bun:*",
+            ...((props.build?.input?.external as string[] | undefined) ?? []),
+          ],
+          resolve: {
+            conditionNames: ["bun", "import", "module", "default"],
+            ...props.build?.input?.resolve,
+          },
           plugins: [props.build?.input?.plugins, plugins],
         },
         {
           ...props.build?.output,
           format: "esm",
           sourcemap: props.build?.output?.sourcemap ?? false,
-          minify: props.build?.output?.minify ?? true,
-          entryFileNames: "index.js",
+          minify: props.build?.output?.minify ?? false,
+          entryFileNames: "index.mjs",
         },
       );
     });
@@ -173,7 +185,8 @@ export const createEc2HostedSupport = ({
           realMain,
           virtualEntryPlugin(
             (importPath) => `
-import { NodeServices } from "@effect/platform-node";
+import { BunServices } from "@effect/platform-bun";
+import { BunHttpServer } from "alchemy/Http";
 import { Stack } from "alchemy/Stack";
 import * as Config from "effect/Config";
 import * as ConfigProvider from "effect/ConfigProvider";
@@ -187,11 +200,14 @@ import * as Region from "@distilled.cloud/aws/Region";
 import { ${handler} as handler } from ${JSON.stringify(importPath)};
 
 const platform = Layer.mergeAll(
-  NodeServices.layer,
+  BunServices.layer,
   FetchHttpClient.layer,
   Logger.layer([Logger.consolePretty()]),
 );
 
+// Resolve the bundled program (the runners registered via host.run / serve)
+// and run it with a Bun HTTP server bound to PORT, so a returned { fetch }
+// handler is actually served and host.run loops stay alive.
 const program = handler.pipe(
   Effect.flatMap((instance) => instance.RuntimeContext.exports),
   Effect.flatMap((exports) => exports.program),
@@ -212,6 +228,7 @@ const program = handler.pipe(
     ).pipe(
       Layer.provideMerge(Credentials.fromEnv()),
       Layer.provideMerge(Region.fromEnv()),
+      Layer.provideMerge(BunHttpServer()),
       Layer.provideMerge(platform),
       Layer.provideMerge(
         Layer.succeed(
@@ -224,18 +241,28 @@ const program = handler.pipe(
   Effect.scoped
 );
 
-await Effect.runPromise(program);
+console.log("Instance bootstrap starting...");
+await Effect.runPromise(program).catch((err) => {
+  console.error("Instance bootstrap failed:", err);
+  process.exit(1);
+});
 `,
           ),
         );
 
-    const mainFile = bundleOutput.files[0];
-    const code =
-      typeof mainFile.content === "string"
-        ? new TextEncoder().encode(mainFile.content)
-        : mainFile.content;
-
-    const archive = yield* zipCode(code);
+    // Zip every emitted file: the entry becomes `index.mjs` (what the systemd
+    // unit runs) and shared chunks keep their `*.js` names so the entry's
+    // relative imports resolve. Dropping a chunk crashes the process at start.
+    const toBytes = (content: string | Uint8Array<ArrayBufferLike>) =>
+      typeof content === "string" ? new TextEncoder().encode(content) : content;
+    const [entryFile, ...chunkFiles] = bundleOutput.files;
+    const archive = yield* zipCode(
+      toBytes(entryFile.content),
+      chunkFiles.map((file) => ({
+        path: file.path,
+        content: toBytes(file.content),
+      })),
+    );
     return { archive, hash: bundleOutput.hash };
   });
 

--- a/packages/alchemy/src/AWS/EC2/hosted.ts
+++ b/packages/alchemy/src/AWS/EC2/hosted.ts
@@ -155,26 +155,14 @@ export const createEc2HostedSupport = ({
           input: entry,
           cwd,
           platform: "node",
-          // The hosted process runs under `bun` (installed by the user-data);
-          // keep `bun`/`bun:*` external and resolve the `bun` export condition
-          // so `@effect/platform-bun` picks its Bun implementations.
-          external: [
-            "bun",
-            "bun:*",
-            ...((props.build?.input?.external as string[] | undefined) ?? []),
-          ],
-          resolve: {
-            conditionNames: ["bun", "import", "module", "default"],
-            ...props.build?.input?.resolve,
-          },
           plugins: [props.build?.input?.plugins, plugins],
         },
         {
           ...props.build?.output,
           format: "esm",
           sourcemap: props.build?.output?.sourcemap ?? false,
-          minify: props.build?.output?.minify ?? false,
-          entryFileNames: "index.mjs",
+          minify: props.build?.output?.minify ?? true,
+          entryFileNames: "index.js",
         },
       );
     });
@@ -185,8 +173,7 @@ export const createEc2HostedSupport = ({
           realMain,
           virtualEntryPlugin(
             (importPath) => `
-import { BunServices } from "@effect/platform-bun";
-import { BunHttpServer } from "alchemy/Http";
+import { NodeServices } from "@effect/platform-node";
 import { Stack } from "alchemy/Stack";
 import * as Config from "effect/Config";
 import * as ConfigProvider from "effect/ConfigProvider";
@@ -200,14 +187,11 @@ import * as Region from "@distilled.cloud/aws/Region";
 import { ${handler} as handler } from ${JSON.stringify(importPath)};
 
 const platform = Layer.mergeAll(
-  BunServices.layer,
+  NodeServices.layer,
   FetchHttpClient.layer,
   Logger.layer([Logger.consolePretty()]),
 );
 
-// Resolve the bundled program (the runners registered via host.run / serve)
-// and run it with a Bun HTTP server bound to PORT, so a returned { fetch }
-// handler is actually served and host.run loops stay alive.
 const program = handler.pipe(
   Effect.flatMap((instance) => instance.RuntimeContext.exports),
   Effect.flatMap((exports) => exports.program),
@@ -228,7 +212,6 @@ const program = handler.pipe(
     ).pipe(
       Layer.provideMerge(Credentials.fromEnv()),
       Layer.provideMerge(Region.fromEnv()),
-      Layer.provideMerge(BunHttpServer()),
       Layer.provideMerge(platform),
       Layer.provideMerge(
         Layer.succeed(
@@ -241,28 +224,18 @@ const program = handler.pipe(
   Effect.scoped
 );
 
-console.log("Instance bootstrap starting...");
-await Effect.runPromise(program).catch((err) => {
-  console.error("Instance bootstrap failed:", err);
-  process.exit(1);
-});
+await Effect.runPromise(program);
 `,
           ),
         );
 
-    // Zip every emitted file: the entry becomes `index.mjs` (what the systemd
-    // unit runs) and shared chunks keep their `*.js` names so the entry's
-    // relative imports resolve. Dropping a chunk crashes the process at start.
-    const toBytes = (content: string | Uint8Array<ArrayBufferLike>) =>
-      typeof content === "string" ? new TextEncoder().encode(content) : content;
-    const [entryFile, ...chunkFiles] = bundleOutput.files;
-    const archive = yield* zipCode(
-      toBytes(entryFile.content),
-      chunkFiles.map((file) => ({
-        path: file.path,
-        content: toBytes(file.content),
-      })),
-    );
+    const mainFile = bundleOutput.files[0];
+    const code =
+      typeof mainFile.content === "string"
+        ? new TextEncoder().encode(mainFile.content)
+        : mainFile.content;
+
+    const archive = yield* zipCode(code);
     return { archive, hash: bundleOutput.hash };
   });
 

--- a/packages/alchemy/src/AWS/ECS/Task.ts
+++ b/packages/alchemy/src/AWS/ECS/Task.ts
@@ -552,14 +552,27 @@ export const TaskProvider = () =>
               input: entry,
               cwd,
               platform: "node",
+              // The container runs on `bun`; keep `bun`/`bun:*` external (the
+              // runtime provides them) and resolve the `bun` export condition
+              // so `@effect/platform-bun` picks its Bun implementations.
+              external: [
+                "bun",
+                "bun:*",
+                ...((props.build?.input?.external as string[] | undefined) ??
+                  []),
+              ],
+              resolve: {
+                conditionNames: ["bun", "import", "module", "default"],
+                ...props.build?.input?.resolve,
+              },
               plugins: [props.build?.input?.plugins, plugins],
             },
             {
               ...props.build?.output,
               format: "esm",
               sourcemap: props.build?.output?.sourcemap ?? false,
-              minify: props.build?.output?.minify ?? true,
-              entryFileNames: "index.js",
+              minify: props.build?.output?.minify ?? false,
+              entryFileNames: "index.mjs",
             },
           );
         });
@@ -570,7 +583,8 @@ export const TaskProvider = () =>
               realMain,
               virtualEntryPlugin(
                 (importPath) => `
-import { NodeServices } from "@effect/platform-node";
+import { BunServices } from "@effect/platform-bun";
+import { BunHttpServer } from "alchemy/Http";
 import { Stack } from "alchemy/Stack";
 import * as Config from "effect/Config";
 import * as ConfigProvider from "effect/ConfigProvider";
@@ -584,11 +598,14 @@ import * as Region from "@distilled.cloud/aws/Region";
 import { ${handler} as handler } from ${JSON.stringify(importPath)};
 
 const platform = Layer.mergeAll(
-  NodeServices.layer,
+  BunServices.layer,
   FetchHttpClient.layer,
   Logger.layer([Logger.consolePretty()]),
 );
 
+// Resolve the bundled program (the runners registered via host.run / serve)
+// and run it with a Bun HTTP server bound to PORT, so a returned { fetch }
+// handler is actually served and host.run loops stay alive.
 const program = handler.pipe(
   Effect.flatMap((task) => task.RuntimeContext.exports),
   Effect.flatMap((exports) => exports.program),
@@ -609,6 +626,7 @@ const program = handler.pipe(
     ).pipe(
       Layer.provideMerge(Credentials.fromEnv()),
       Layer.provideMerge(Region.fromEnv()),
+      Layer.provideMerge(BunHttpServer()),
       Layer.provideMerge(platform),
       Layer.provideMerge(
         Layer.succeed(
@@ -621,31 +639,40 @@ const program = handler.pipe(
   Effect.scoped
 );
 
-await Effect.runPromise(program);
+console.log("Task bootstrap starting...");
+await Effect.runPromise(program).catch((err) => {
+  console.error("Task bootstrap failed:", err);
+  process.exit(1);
+});
 `,
               ),
             );
 
-        const mainFile = bundleOutput.files[0];
-        const code =
-          typeof mainFile.content === "string"
-            ? new TextEncoder().encode(mainFile.content)
-            : mainFile.content;
+        // Return every emitted file (entry + shared chunks). Dynamic imports in
+        // the Bun HTTP server / AWS SDK split into chunks; dropping any of them
+        // crashes the container with `Cannot find module './chunk-XXX.js'`.
+        const files = bundleOutput.files.map((file) => ({
+          path: file.path,
+          content:
+            typeof file.content === "string"
+              ? new TextEncoder().encode(file.content)
+              : file.content,
+        }));
 
-        return { code, hash: bundleOutput.hash };
+        return { files, hash: bundleOutput.hash };
       });
 
       const buildAndPushImage = Effect.fn(function* ({
         id,
         repositoryUri,
         hash,
-        code,
+        files,
         props,
       }: {
         id: string;
         repositoryUri: string;
         hash: string;
-        code: Uint8Array<ArrayBufferLike>;
+        files: { path: string; content: Uint8Array<ArrayBufferLike> }[];
         props: TaskProps;
       }) {
         const realMain = yield* fs.realPath(props.main);
@@ -663,6 +690,10 @@ await Effect.runPromise(program);
             `FROM ${base}`,
             `WORKDIR /app`,
             `COPY index.mjs /app/index.mjs`,
+            // Copy any additional rolldown chunks (`chunk-XXX.js`,
+            // `BunServices-YYY.js`, …). Non-trivial bundles always emit at
+            // least one; minimal bundles emit none and the COPY no-ops.
+            `COPY *.js /app/`,
           ];
           if (props.port !== undefined) {
             lines.push(
@@ -691,11 +722,26 @@ await Effect.runPromise(program);
         yield* docker.materialize({
           context: contextDir,
           dockerfile: dockerfile,
-          files: [{ path: "index.mjs", content: code }],
+          // Entry chunk becomes `index.mjs`; all other chunks keep their
+          // emitted `*.js` names so the entry's relative imports resolve.
+          files: files.map((file, index) => ({
+            path: index === 0 ? "index.mjs" : file.path,
+            content: file.content,
+          })),
         });
+        // Build for the architecture the task definition declares (Fargate
+        // defaults to X86_64 when `runtimePlatform` is unset). Without this, an
+        // image built on an ARM64 host (e.g. Apple Silicon) is rejected at task
+        // start with `image Manifest does not contain descriptor matching
+        // platform 'linux/amd64'`.
+        const buildPlatform =
+          props.runtimePlatform?.cpuArchitecture === "ARM64"
+            ? "linux/arm64"
+            : "linux/amd64";
         yield* docker.image.build({
           tag: imageUri,
           context: contextDir,
+          platform: buildPlatform,
         });
         yield* docker.image.push(imageUri, {
           username: "AWS",
@@ -964,12 +1010,12 @@ await Effect.runPromise(program);
           // definitions are versioned in AWS, so registering a new revision
           // is the unit of "update" — the prior revision is deregistered
           // only on `delete` of the resource.
-          const { code, hash } = yield* bundleProgram(id, news);
+          const { files, hash } = yield* bundleProgram(id, news);
           const imageUri = yield* buildAndPushImage({
             id,
             repositoryUri,
             hash,
-            code,
+            files,
             props: {
               ...news,
               env: {
@@ -1123,6 +1169,11 @@ await Effect.runPromise(program);
               RoleName: output.taskRoleName,
             })
             .pipe(
+              // The role may already be gone (delete re-run / race) — treat a
+              // missing role as "no policies to delete" so delete is idempotent.
+              Effect.catchTag("NoSuchEntityException", () =>
+                Effect.succeed({ PolicyNames: [] as string[] }),
+              ),
               Effect.flatMap((policies) =>
                 Effect.all(
                   (policies.PolicyNames ?? []).map((policyName) =>
@@ -1151,6 +1202,9 @@ await Effect.runPromise(program);
                 RoleName: roleName,
               })
               .pipe(
+                Effect.catchTag("NoSuchEntityException", () =>
+                  Effect.succeed({ AttachedPolicies: [] }),
+                ),
                 Effect.flatMap((policies) =>
                   Effect.all(
                     (policies.AttachedPolicies ?? []).map((policy) =>

--- a/packages/alchemy/src/AWS/ECS/Task.ts
+++ b/packages/alchemy/src/AWS/ECS/Task.ts
@@ -3,7 +3,6 @@ import * as ecr from "@distilled.cloud/aws/ecr";
 import * as ecs from "@distilled.cloud/aws/ecs";
 import * as iam from "@distilled.cloud/aws/iam";
 import { Region } from "@distilled.cloud/aws/Region";
-import * as Config from "effect/Config";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
@@ -17,12 +16,15 @@ import {
 } from "../../Bundle/TempRoot.ts";
 import { isResolved } from "../../Diff.ts";
 import { Docker } from "../../Docker/Docker.ts";
-import * as Output from "../../Output.ts";
 import { createPhysicalName } from "../../PhysicalName.ts";
 import { Platform, type Main, type PlatformProps } from "../../Platform.ts";
 import * as Provider from "../../Provider.ts";
 import { Resource, type ResourceBinding } from "../../Resource.ts";
-import type { ProcessContext, ServerHost } from "../../Server/Process.ts";
+import {
+  createHostRuntimeContext,
+  type HostRuntimeContext,
+  type ServerHost,
+} from "../../Server/Process.ts";
 import { Stack } from "../../Stack.ts";
 import {
   createInternalTags,
@@ -230,7 +232,7 @@ export type TaskServices = Credentials | Region | ServerHost | AWSEnvironment;
 
 export type TaskShape = Main<TaskServices>;
 
-export interface TaskRuntimeContext extends ProcessContext {
+export interface TaskRuntimeContext extends HostRuntimeContext {
   readonly Type: "AWS.ECS.Task";
 }
 
@@ -295,44 +297,9 @@ export interface TaskRuntimeContext extends ProcessContext {
  */
 export const Task: Platform<Task, TaskServices, TaskShape, TaskRuntimeContext> =
   Platform("AWS.ECS.Task", {
-    createRuntimeContext: (id): TaskRuntimeContext => {
-      const runners: Effect.Effect<void, never, any>[] = [];
-      const env: Record<string, any> = {};
-
-      return {
-        Type: "AWS.ECS.Task",
-        id,
-        env,
-        set: (bindingId: string, output: Output.Output) =>
-          Effect.sync(() => {
-            const key = bindingId.replaceAll(/[^a-zA-Z0-9]/g, "_");
-            env[key] = output.pipe(
-              Output.map((value) => JSON.stringify(value)),
-            );
-            return key;
-          }),
-        get: <T>(key: string) =>
-          Config.string(key).pipe(
-            Effect.flatMap((value) =>
-              Effect.try({
-                try: () => JSON.parse(value) as T,
-                catch: (error) => error as Error,
-              }),
-            ),
-            Effect.catch((cause) =>
-              Effect.die(
-                new Error(`Failed to get environment variable: ${key}`, {
-                  cause,
-                }),
-              ),
-            ),
-          ),
-        run: (effect: Effect.Effect<void, never, any>) =>
-          Effect.sync(() => {
-            runners.push(effect);
-          }),
-      };
-    },
+    createRuntimeContext: createHostRuntimeContext("AWS.ECS.Task") as (
+      id: string,
+    ) => TaskRuntimeContext,
   });
 
 export const TaskProvider = () =>
@@ -623,7 +590,8 @@ const platform = Layer.mergeAll(
 );
 
 const program = handler.pipe(
-  Effect.flatMap((task) => task.RuntimeContext.exports.program),
+  Effect.flatMap((task) => task.RuntimeContext.exports),
+  Effect.flatMap((exports) => exports.program),
   Effect.provide(
     Layer.effect(
       Stack,

--- a/packages/alchemy/src/Platform.ts
+++ b/packages/alchemy/src/Platform.ts
@@ -21,6 +21,7 @@ import { ALCHEMY_PHASE } from "./Phase.ts";
 import type { Provider, ProviderCollectionLike } from "./Provider.ts";
 import { Resource, type ResourceLike } from "./Resource.ts";
 import type { Rpc } from "./Rpc.ts";
+import { ServerHost, type ProcessContext } from "./Server/Process.ts";
 import {
   CurrentRuntimeContext,
   RuntimeContext,
@@ -437,6 +438,18 @@ export const Platform = <
                         Layer.succeed(Platform.Platform, runtimeContext),
                         Layer.succeed(PlatformContext, runtimeContext),
                         Layer.succeed(RuntimeContext, runtimeContext),
+                        // Host contexts (EC2 instances, ECS tasks, processes)
+                        // carry a `run` for registering long-running loops.
+                        // Expose it as `ServerHost` so an inline program can
+                        // `yield* ServerHost` during plan/deploy without the
+                        // caller providing the layer itself.
+                        "run" in runtimeContext &&
+                          typeof (runtimeContext as { run?: unknown }).run ===
+                            "function"
+                          ? Layer.succeed(ServerHost, {
+                              run: (runtimeContext as ProcessContext).run,
+                            })
+                          : Layer.empty,
                         Layer.succeed(resource.Self, instance),
                         Layer.succeed(Platform.Self, instance),
                         Layer.succeed(Self, instance),

--- a/packages/alchemy/src/Server/Process.ts
+++ b/packages/alchemy/src/Server/Process.ts
@@ -1,3 +1,4 @@
+import * as Config from "effect/Config";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import { FileSystem } from "effect/FileSystem";
@@ -5,6 +6,9 @@ import type { Path } from "effect/Path";
 import type { Stdio } from "effect/Stdio";
 import type { Terminal } from "effect/Terminal";
 import type { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner";
+import type { HttpEffect } from "../Http.ts";
+import * as Http from "../Http.ts";
+import * as Output from "../Output.ts";
 import type { BaseRuntimeContext } from "../RuntimeContext.ts";
 
 export type ProcessServices =
@@ -22,9 +26,86 @@ export interface ProcessContext extends BaseRuntimeContext {
 
 /**
  * Long-running host loop registration (`run`). Provided by `Platform` when the
- * execution context implements {@link ProcessContext}.
+ * execution context implements {@link ProcessContext} (i.e. carries `run`).
+ *
+ * `Platform` wires this automatically for every host runtime context that
+ * implements `run` (EC2 instances, ECS tasks, processes), so an inline program
+ * can `yield* ServerHost` and call `host.run(...)` during plan/deploy without
+ * the caller providing the layer itself.
  */
 export class ServerHost extends Context.Service<
   ServerHost,
   Pick<ProcessContext, "run">
 >()("Alchemy::ServerHost") {}
+
+/**
+ * Deploy-time / plan-time host context for platforms that bundle a long-lived
+ * program. It collects background work registered via `run` and HTTP handlers
+ * registered via `serve` into a single `exports.program` effect that the
+ * generated container/instance entrypoint runs.
+ */
+export interface HostRuntimeContext extends ProcessContext {
+  serve: <Req = never>(
+    handler: HttpEffect<Req> | Effect.Effect<HttpEffect<Req>>,
+    options?: { shape?: Record<string, unknown> },
+  ) => Effect.Effect<void, never, Req>;
+  exports: Effect.Effect<{
+    readonly program: Effect.Effect<void, never, any>;
+  }>;
+}
+
+/**
+ * Build a {@link HostRuntimeContext} for a hosted platform of the given
+ * resource `type`. Both `run` (background loops) and `serve` (HTTP handlers)
+ * append to a single list of runners; `exports.program` runs them all
+ * concurrently. This is the shared host context used by `AWS.EC2.Instance` and
+ * `AWS.ECS.Task`.
+ */
+export const createHostRuntimeContext =
+  (type: string) =>
+  (id: string): HostRuntimeContext => {
+    const runners: Effect.Effect<void, never, any>[] = [];
+    const env: Record<string, any> = {};
+
+    return {
+      Type: type,
+      id,
+      env,
+      set: (bindingId: string, output: Output.Output) =>
+        Effect.sync(() => {
+          const key = bindingId.replaceAll(/[^a-zA-Z0-9]/g, "_");
+          env[key] = output.pipe(Output.map((value) => JSON.stringify(value)));
+          return key;
+        }),
+      get: <T>(key: string) =>
+        Config.string(key).pipe(
+          Effect.flatMap((value) =>
+            Effect.try({
+              try: () => JSON.parse(value) as T,
+              catch: (error) => error as Error,
+            }),
+          ),
+          Effect.catch((cause) =>
+            Effect.die(
+              new Error(`Failed to get environment variable: ${key}`, {
+                cause,
+              }),
+            ),
+          ),
+        ),
+      run: (effect: Effect.Effect<void, never, any>) =>
+        Effect.sync(() => {
+          runners.push(effect);
+        }),
+      serve: ((handler) =>
+        Effect.sync(() => {
+          // Register the HTTP handler as a runner. At container runtime the
+          // ambient `HttpServer` (if provided) serves it; `Http.serve` is a
+          // no-op when no server is bound, so this never crashes plan/deploy.
+          runners.push(Http.serve(handler as HttpEffect<any>));
+        })) as HostRuntimeContext["serve"],
+      exports: Effect.sync(() => ({
+        program: Effect.all(runners, { concurrency: "unbounded" }),
+      })),
+    } satisfies HostRuntimeContext;
+  };

--- a/packages/alchemy/test/AWS/ECS/Task.smoke.test.ts
+++ b/packages/alchemy/test/AWS/ECS/Task.smoke.test.ts
@@ -1,0 +1,200 @@
+import * as AWS from "@/AWS";
+import {
+  InternetGateway,
+  Route,
+  RouteTable,
+  RouteTableAssociation,
+  SecurityGroup,
+  Subnet,
+  Vpc,
+} from "@/AWS/EC2";
+import { Cluster } from "@/AWS/ECS/Cluster.ts";
+import { Service } from "@/AWS/ECS/Service.ts";
+import * as Test from "@/Test/Vitest";
+import * as ec2 from "@distilled.cloud/aws/ec2";
+import * as elbv2 from "@distilled.cloud/aws/elastic-load-balancing-v2";
+import { expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import TestTask from "./fixtures/task.ts";
+
+const { test } = Test.make({ providers: AWS.providers() });
+
+// Full end-to-end: build + push the bundled Task image, run it on Fargate
+// behind an Alchemy-managed public ALB, and prove over HTTP that (a) the
+// `{ fetch }` handler is served and (b) the `ServerHost.run` background loop is
+// actually executing inside the deployed container (`/ticks` keeps climbing).
+//
+// This is the real-deploy regression for #706. It is heavy (Docker build + ECR
+// push + Fargate placement + ALB health), so it is skipped under `FAST=1`.
+test.provider.skipIf(!!process.env.FAST)(
+  "deploys a real Fargate task that serves HTTP and runs a background loop",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const azResult = yield* ec2.describeAvailabilityZones({});
+      const available = (azResult.AvailabilityZones ?? []).filter(
+        (az) => az.State === "available",
+      );
+      const az1 = available[0]?.ZoneName!;
+      const az2 = available[1]?.ZoneName!;
+
+      const { url, targetGroupArn } = yield* stack.deploy(
+        Effect.gen(function* () {
+          // Public networking: VPC + IGW + 2 public subnets (ALB needs ≥2 AZs)
+          // + route to the IGW + a security group that admits the ALB (80) and
+          // the container traffic port (3000).
+          const vpc = yield* Vpc("EcsE2EVpc", {
+            cidrBlock: "10.80.0.0/16",
+            enableDnsSupport: true,
+            enableDnsHostnames: true,
+          });
+          const igw = yield* InternetGateway("EcsE2EIgw", {
+            vpcId: vpc.vpcId,
+          });
+          const subnetA = yield* Subnet("EcsE2ESubnetA", {
+            vpcId: vpc.vpcId,
+            cidrBlock: "10.80.1.0/24",
+            availabilityZone: az1,
+            mapPublicIpOnLaunch: true,
+          });
+          const subnetB = yield* Subnet("EcsE2ESubnetB", {
+            vpcId: vpc.vpcId,
+            cidrBlock: "10.80.2.0/24",
+            availabilityZone: az2,
+            mapPublicIpOnLaunch: true,
+          });
+          const routeTable = yield* RouteTable("EcsE2ERouteTable", {
+            vpcId: vpc.vpcId,
+          });
+          yield* Route("EcsE2ERoute", {
+            routeTableId: routeTable.routeTableId,
+            destinationCidrBlock: "0.0.0.0/0",
+            gatewayId: igw.internetGatewayId,
+          });
+          yield* RouteTableAssociation("EcsE2EAssocA", {
+            routeTableId: routeTable.routeTableId,
+            subnetId: subnetA.subnetId,
+          });
+          yield* RouteTableAssociation("EcsE2EAssocB", {
+            routeTableId: routeTable.routeTableId,
+            subnetId: subnetB.subnetId,
+          });
+          const securityGroup = yield* SecurityGroup("EcsE2ESg", {
+            vpcId: vpc.vpcId,
+            description: "alchemy ecs task e2e",
+            ingress: [
+              {
+                ipProtocol: "tcp",
+                fromPort: 80,
+                toPort: 80,
+                cidrIpv4: "0.0.0.0/0",
+                description: "ALB ingress",
+              },
+              {
+                ipProtocol: "tcp",
+                fromPort: 3000,
+                toPort: 3000,
+                cidrIpv4: "0.0.0.0/0",
+                description: "container traffic",
+              },
+            ],
+            egress: [
+              {
+                ipProtocol: "-1",
+                cidrIpv4: "0.0.0.0/0",
+                description: "all outbound",
+              },
+            ],
+          });
+
+          const cluster = yield* Cluster("EcsE2ECluster", {
+            clusterName: "alchemy-test-ecs-task-e2e",
+          });
+
+          // The bundled long-running Task (builds + pushes the image).
+          const task = yield* TestTask;
+
+          const service = yield* Service("EcsE2EService", {
+            cluster,
+            task: {
+              taskDefinitionArn: task.taskDefinitionArn,
+              containerName: task.containerName,
+              port: task.port,
+            },
+            desiredCount: 1,
+            public: true,
+            listenerPort: 80,
+            healthCheckPath: "/health",
+            vpcId: vpc.vpcId,
+            subnets: [subnetA.subnetId, subnetB.subnetId],
+            securityGroups: [securityGroup.groupId],
+            assignPublicIp: true,
+          });
+
+          return {
+            url: service.url,
+            targetGroupArn: service.targetGroupArn,
+          };
+        }),
+      );
+
+      expect(url).toBeTruthy();
+      expect(targetGroupArn).toBeTruthy();
+
+      // Gate on target health via the ELBv2 API (no DNS): wait until the task
+      // is placed, the image pulled, and the ALB health check on `/health`
+      // passes. Polling via the API — rather than HTTP — avoids looking up the
+      // freshly-created ALB hostname before its DNS record exists (a premature
+      // lookup gets NXDOMAIN negatively cached by the resolver for minutes).
+      yield* elbv2
+        .describeTargetHealth({ TargetGroupArn: targetGroupArn! })
+        .pipe(
+          Effect.flatMap((result) => {
+            const states = (result.TargetHealthDescriptions ?? []).map(
+              (t) => t.TargetHealth?.State,
+            );
+            return states.includes("healthy")
+              ? Effect.void
+              : Effect.fail(
+                  new Error(`no healthy target yet: [${states.join(", ")}]`),
+                );
+          }),
+          Effect.tapError((error) => Effect.logError(error)),
+          // ~12 min budget: image pull + container boot + the ALB health check
+          // ramp (default 5 × 30s consecutive successes) can take several
+          // minutes for a cold Fargate task.
+          Effect.retry({ schedule: Schedule.spaced("12 seconds"), times: 60 }),
+        );
+
+      // The ALB has been active for a while now, so its DNS resolves. Probe the
+      // public endpoint (still retry through edge/DNS propagation).
+      const health = yield* HttpClient.get(`${url}/health`).pipe(
+        Effect.flatMap((res) =>
+          res.status === 200
+            ? Effect.succeed(res)
+            : Effect.fail(new Error(`/health returned ${res.status}`)),
+        ),
+        Effect.tapError((error) => Effect.logError(error)),
+        Effect.retry({ schedule: Schedule.spaced("6 seconds"), times: 30 }),
+      );
+      expect(health.status).toBe(200);
+      expect(yield* health.json).toEqual({ ok: true });
+
+      // Prove the ServerHost.run background loop is executing in-container:
+      // the tick counter climbs between two reads.
+      const readTicks = HttpClient.get(`${url}/ticks`).pipe(
+        Effect.flatMap((res) => res.json),
+        Effect.map((body) => (body as { ticks: number }).ticks),
+      );
+      const first = yield* readTicks;
+      yield* Effect.sleep("3 seconds");
+      const second = yield* readTicks;
+      expect(second).toBeGreaterThan(first);
+
+      yield* stack.destroy();
+    }),
+  { timeout: 1_200_000 },
+);

--- a/packages/alchemy/test/AWS/ECS/fixtures/task.ts
+++ b/packages/alchemy/test/AWS/ECS/fixtures/task.ts
@@ -1,0 +1,63 @@
+import * as AWS from "@/AWS";
+import { ServerHost } from "@/Server/Process.ts";
+import * as Effect from "effect/Effect";
+import * as Ref from "effect/Ref";
+import * as Schedule from "effect/Schedule";
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+/**
+ * End-to-end fixture for `AWS.ECS.Task`: a long-running server.
+ *
+ * - `yield* ServerHost` + `host.run(...)` registers a background loop that
+ *   increments a counter once a second (this is the pattern from issue #706).
+ * - the returned `{ fetch }` handler is served over HTTP by the container's Bun
+ *   HTTP server. `/ticks` reports the counter so the test can prove the
+ *   background loop is actually running inside the deployed Fargate task.
+ */
+export default class TestTask extends AWS.ECS.Task<TestTask>()(
+  "EcsE2ETask",
+  {
+    main: import.meta.filename,
+    cpu: 256,
+    memory: 512,
+    port: 3000,
+    // Build/run on ARM64 so the image built on an Apple Silicon host matches
+    // the Fargate runtime architecture (Graviton).
+    runtimePlatform: {
+      cpuArchitecture: "ARM64",
+      operatingSystemFamily: "LINUX",
+    },
+    // Docker Hub's `oven/bun` image; the public.ecr.aws default mirror
+    // aggressively rate-limits anonymous pulls (429) during local builds.
+    docker: { base: "oven/bun:1" },
+  },
+  Effect.gen(function* () {
+    const host = yield* ServerHost;
+    const ticks = yield* Ref.make(0);
+
+    // Long-running background loop (the `host.run` pattern from #706).
+    yield* host.run(
+      Ref.update(ticks, (n) => n + 1).pipe(
+        Effect.repeat(Schedule.spaced("1 second")),
+        Effect.asVoid,
+      ),
+    );
+
+    return {
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        const url = new URL(request.url, "http://task");
+        if (url.pathname === "/health") {
+          return yield* HttpServerResponse.json({ ok: true });
+        }
+        if (url.pathname === "/ticks") {
+          return yield* HttpServerResponse.json({
+            ticks: yield* Ref.get(ticks),
+          });
+        }
+        return HttpServerResponse.text("hello from ecs task");
+      }),
+    };
+  }),
+) {}

--- a/packages/alchemy/test/Server/Process.test.ts
+++ b/packages/alchemy/test/Server/Process.test.ts
@@ -1,6 +1,6 @@
 import { isResolved } from "@/Diff.ts";
 import * as Plan from "@/Plan";
-import { Platform, type Main } from "@/Platform.ts";
+import { Platform, type Main, type PlatformProps } from "@/Platform.ts";
 import * as Provider from "@/Provider.ts";
 import { Resource } from "@/Resource";
 import {
@@ -21,11 +21,11 @@ import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 // A minimal hosted Platform (like AWS.ECS.Task / AWS.EC2.Instance) whose
 // runtime context is built by the shared `createHostRuntimeContext`. Its
 // provider is a no-op so the plan never touches the cloud.
-interface Host extends Resource<
-  "Test.Host",
-  { main?: string },
-  { ok: boolean }
-> {}
+interface HostProps extends PlatformProps {
+  main?: string;
+}
+
+interface Host extends Resource<"Test.Host", HostProps, { ok: boolean }> {}
 
 type HostServices = ServerHost;
 type HostShape = Main<HostServices>;
@@ -55,9 +55,8 @@ const { test } = Test.make({
 const makePlan = <A, Err, Req>(
   effect: Effect.Effect<A, Err, Req>,
 ): Effect.Effect<Plan.Plan<A>, Err, State> =>
-  // @ts-expect-error - Stack.make's typing erases R unsoundly here
   effect.pipe(
-    // @ts-expect-error
+    // @ts-expect-error - Stack.make's typing erases R unsoundly here
     Stack.make({
       name: "test",
       providers: Layer.empty,

--- a/packages/alchemy/test/Server/Process.test.ts
+++ b/packages/alchemy/test/Server/Process.test.ts
@@ -1,0 +1,143 @@
+import { isResolved } from "@/Diff.ts";
+import * as Plan from "@/Plan";
+import { Platform, type Main } from "@/Platform.ts";
+import * as Provider from "@/Provider.ts";
+import { Resource } from "@/Resource";
+import {
+  createHostRuntimeContext,
+  type HostRuntimeContext,
+  ServerHost,
+} from "@/Server/Process.ts";
+import * as Stack from "@/Stack";
+import { Stage } from "@/Stage";
+import { inMemoryState, State } from "@/State";
+import * as Test from "@/Test/Vitest";
+import { expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Ref from "effect/Ref";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+// A minimal hosted Platform (like AWS.ECS.Task / AWS.EC2.Instance) whose
+// runtime context is built by the shared `createHostRuntimeContext`. Its
+// provider is a no-op so the plan never touches the cloud.
+interface Host extends Resource<
+  "Test.Host",
+  { main?: string },
+  { ok: boolean }
+> {}
+
+type HostServices = ServerHost;
+type HostShape = Main<HostServices>;
+
+const Host: Platform<Host, HostServices, HostShape, HostRuntimeContext> =
+  Platform("Test.Host", {
+    createRuntimeContext: createHostRuntimeContext("Test.Host"),
+  });
+
+const hostProvider = () =>
+  Provider.succeed(Host, {
+    list: () => Effect.succeed([]),
+    diff: Effect.fn(function* ({ news }) {
+      if (!isResolved(news)) return undefined;
+    }),
+    reconcile: Effect.fn(function* ({ output }) {
+      return output ?? { ok: true };
+    }),
+    delete: Effect.fn(function* () {}),
+  });
+
+const { test } = Test.make({
+  providers: hostProvider(),
+  state: inMemoryState(),
+});
+
+const makePlan = <A, Err, Req>(
+  effect: Effect.Effect<A, Err, Req>,
+): Effect.Effect<Plan.Plan<A>, Err, State> =>
+  // @ts-expect-error - Stack.make's typing erases R unsoundly here
+  effect.pipe(
+    // @ts-expect-error
+    Stack.make({
+      name: "test",
+      providers: Layer.empty,
+      state: inMemoryState(),
+    }),
+    Effect.provideService(Stage, "test"),
+    Effect.flatMap((stackSpec: any) => Plan.make(stackSpec)),
+    Effect.provide(hostProvider()),
+  );
+
+// Unit-level: the shared host context exposes run / serve / exports and folds
+// both run-registered loops and serve-registered handlers into a single
+// `exports.program` that the generated container/instance entry runs.
+test(
+  "createHostRuntimeContext collects run + serve into exports.program",
+  Effect.gen(function* () {
+    const ctx = createHostRuntimeContext("Test.Host")("my-host");
+
+    expect(ctx.Type).toBe("Test.Host");
+    expect(typeof ctx.run).toBe("function");
+    expect(typeof ctx.serve).toBe("function");
+    expect(typeof ctx.get).toBe("function");
+    expect(typeof ctx.set).toBe("function");
+
+    const ran = yield* Ref.make<string[]>([]);
+    yield* ctx.run(Ref.update(ran, (xs) => [...xs, "loop"]));
+    // serve registers an HTTP handler runner; with no HttpServer bound it is a
+    // harmless no-op, so the program completes without crashing.
+    yield* ctx.serve(Effect.succeed(HttpServerResponse.text("ok")));
+
+    const { program } = yield* ctx.exports;
+    yield* program;
+
+    expect(yield* Ref.get(ran)).toEqual(["loop"]);
+  }),
+);
+
+// Regression for #706: the generated container/instance entrypoint resolves the
+// long-running program via `RuntimeContext.exports` (an Effect) and then runs
+// `.program`. `exports` is an Effect, so the entry MUST flat-map it before
+// touching `.program` — reaching for `exports.program` directly yields
+// `undefined`. This asserts both the (wrong) direct access and the (correct)
+// resolved access, mirroring the entry's `flatMap(exports) → flatMap(.program)`.
+test(
+  "exports must be resolved before reading .program (generated-entry contract)",
+  Effect.gen(function* () {
+    const ran = yield* Ref.make(false);
+    const ctx = createHostRuntimeContext("Test.Host")("entry");
+    yield* ctx.run(Ref.set(ran, true));
+
+    // Direct access — what the broken entry did — is undefined.
+    expect((ctx.exports as { program?: unknown }).program).toBeUndefined();
+
+    // Correct access: resolve the Effect, then run the program.
+    const { program } = yield* ctx.exports;
+    yield* program;
+    expect(yield* Ref.get(ran)).toBe(true);
+  }),
+);
+
+// Regression for #706: a hosted Platform program can `yield* ServerHost` and
+// call `host.run(...)` during plan. Before the fix this died with
+// "Service not found: Alchemy::ServerHost". Returning `{ fetch }` additionally
+// exercises the host `serve` path (previously "No serve handler").
+test(
+  "Platform provides ServerHost to a hosted program during plan",
+  Effect.gen(function* () {
+    const plan = yield* Host(
+      "MyHost",
+      { main: "index.ts" },
+      Effect.gen(function* () {
+        const host = yield* ServerHost;
+        // The long-running loop — only registered during plan, never run.
+        yield* host.run(Effect.void);
+        return {
+          fetch: Effect.succeed(HttpServerResponse.text("ok")),
+        };
+      }),
+    ).pipe(makePlan);
+
+    expect(plan.resources["MyHost"]?.action).toBe("create");
+  }),
+);


### PR DESCRIPTION
Fixes #706. `AWS.ECS.Task` (and `AWS.EC2.Instance`) long-running programs that yield `ServerHost` failed during `plan`/`deploy` with `Service not found: Alchemy::ServerHost`, and the Task container could not actually serve HTTP. This makes the `ServerHost` + `host.run` + `{ fetch }` pattern work end to end.

### Plan/deploy fix

- `Platform` provides `ServerHost` whenever the runtime context carries `run` (covers ECS Task, EC2 Instance, processes; Workers unaffected).
- One shared host runtime context (`createHostRuntimeContext`: `run` + `serve` + `exports.program`) backs both `AWS.EC2.Instance` and `AWS.ECS.Task`.
- The generated container/instance entry resolves the `exports` Effect before reading `.program` (it was reading `.program` off an Effect → `undefined`).

```diff
- Effect.flatMap((task) => task.RuntimeContext.exports.program),
+ Effect.flatMap((task) => task.RuntimeContext.exports),
+ Effect.flatMap((exports) => exports.program),
```

### Container runtime (so a `{ fetch }` Task actually serves)

- Bundle the entry with a Bun HTTP server (`BunServices` + `BunHttpServer`) and ship **every** rolldown chunk into the image (was: first chunk only — dynamic imports crashed the container with `Cannot find module './chunk-*.js'`).
- Build the image for the architecture `runtimePlatform` declares (default `linux/amd64`); an image built on an ARM64 host was rejected by Fargate (`image Manifest does not contain descriptor matching platform 'linux/amd64'`).
- Guard the role-deletion `list*` calls against `NoSuchEntityException` so Task `delete` is idempotent.

The same Bun HTTP server + multi-chunk bundling is mirrored into the shared EC2 hosted runtime.

### Tests

- `test/Server/Process.test.ts` (deterministic, no cloud): the host context folds `run` + `serve` into `exports.program`; the generated-entry resolution contract; and a regression that a hosted program can `yield* ServerHost` + `host.run(...)` + return `{ fetch }` during plan (reproduces the exact `Service not found` error when the `Platform` fix is reverted).
- `test/AWS/ECS/Task.smoke.test.ts` (real deploy, skipped under `FAST=1`): builds + pushes the bundled image, runs the Task on Fargate behind a managed ALB, and asserts over HTTP that `/health` is served and the `ServerHost.run` background loop is executing in-container (`/ticks` climbs). Verified green against AWS (deploys, serves, self-cleans).
