### PR TITLE
feat(cloudflare/workers-for-platforms): dispatch namespace binding + deploy workers into namespaces

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/InferEnv.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/InferEnv.ts
@@ -21,6 +21,7 @@ import type * as ImagesNs from "../Images/index.ts";
 import type * as KV from "../KV/index.ts";
 import type * as Queues from "../Queues/index.ts";
 import type * as R2 from "../R2/index.ts";
+import type { DispatchNamespace as DispatchNamespaceResource } from "../WorkersForPlatforms/DispatchNamespace.ts";
 import type { Assets } from "./Assets.ts";
 import type { BrowserBinding } from "./BrowserBinding.ts";
 import type { DurableObjectLike } from "./DurableObject.ts";
@@ -54,43 +55,50 @@ export type GetBindingType<T> =
               ? R2Bucket
               : T extends KV.Namespace
                 ? KVNamespace
-                : T extends Queues.Queue
-                  ? Queue<unknown>
-                  : T extends AI.Gateway
-                    ? Ai
-                    : T extends AI.Search
-                      ? AiSearchInstance
-                      : T extends AI.SearchNamespace
-                        ? AiSearchNamespace
-                        : T extends Email.SendEmail
-                          ? SendEmail
-                          : T extends AnalyticsEngine.Dataset
-                            ? AnalyticsEngineDataset
-                            : T extends ArtifactsNs.Namespace
-                              ? Artifacts
-                              : T extends RateLimitBinding
-                                ? RateLimit
-                                : T extends ImagesNs.ImagesBinding
-                                  ? ImagesBinding
-                                  : T extends BrowserBinding
-                                    ? BrowserRun
-                                    : T extends HyperdriveNs.Connection
-                                      ? Hyperdrive
-                                      : T extends VersionMetadataBinding
-                                        ? WorkerVersionMetadata
-                                        : T extends WorkerLoaderResource
-                                          ? WorkerLoader
-                                          : T extends WorkflowLike<infer Params>
-                                            ? Workflow<Params>
-                                            : T extends DurableObjectLike
-                                              ? DurableObjectNamespace<
-                                                  Exclude<T["Shape"], undefined>
+                : T extends DispatchNamespaceResource
+                  ? DispatchNamespace
+                  : T extends Queues.Queue
+                    ? Queue<unknown>
+                    : T extends AI.Gateway
+                      ? Ai
+                      : T extends AI.Search
+                        ? AiSearchInstance
+                        : T extends AI.SearchNamespace
+                          ? AiSearchNamespace
+                          : T extends Email.SendEmail
+                            ? SendEmail
+                            : T extends AnalyticsEngine.Dataset
+                              ? AnalyticsEngineDataset
+                              : T extends ArtifactsNs.Namespace
+                                ? Artifacts
+                                : T extends RateLimitBinding
+                                  ? RateLimit
+                                  : T extends ImagesNs.ImagesBinding
+                                    ? ImagesBinding
+                                    : T extends BrowserBinding
+                                      ? BrowserRun
+                                      : T extends HyperdriveNs.Connection
+                                        ? Hyperdrive
+                                        : T extends VersionMetadataBinding
+                                          ? WorkerVersionMetadata
+                                          : T extends WorkerLoaderResource
+                                            ? WorkerLoader
+                                            : T extends WorkflowLike<
+                                                  infer Params
                                                 >
-                                              : T extends Redacted<any>
-                                                ? // redacteds are always stored as secret_text, so are always string
-                                                  // we JSON.stringify when not a Redacted<string>
-                                                  string
-                                                : T;
+                                              ? Workflow<Params>
+                                              : T extends DurableObjectLike
+                                                ? DurableObjectNamespace<
+                                                    Exclude<
+                                                      T["Shape"],
+                                                      undefined
+                                                    >
+                                                  >
+                                                : T extends Redacted<any>
+                                                  ? // redacteds are always stored as secret_text, so are always string
+                                                    // we JSON.stringify when not a Redacted<string>
+                                                    string
+                                                  : T;
 
 /**
  * Cloudflare service-binding wire shape for an Effect-native Worker.

--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -467,6 +467,7 @@ export const LocalWorkerProvider = () =>
         return {
           workerId: config.name,
           workerName: config.name,
+          namespace: undefined,
           logpush: undefined,
           url,
           tags: [],
@@ -538,6 +539,7 @@ export const LocalWorkerProvider = () =>
           return {
             workerId: name,
             workerName: name,
+            namespace: undefined,
             logpush: undefined,
             url,
             tags: [],
@@ -567,6 +569,7 @@ export const LocalWorkerProvider = () =>
             return {
               workerId: name,
               workerName: name,
+              namespace: undefined,
               logpush: undefined,
               url: news.dev.url,
               tags: [],

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -28,6 +28,7 @@ import type { Container } from "../Containers/Container.ts";
 import type { DevContainerImage } from "../Containers/ContainerApplication.ts";
 import type { DevOrigin } from "../Hyperdrive/Connection.ts";
 import type { Providers } from "../Providers.ts";
+import type { DispatchNamespace } from "../WorkersForPlatforms/DispatchNamespace.ts";
 import type { WorkflowExport } from "../Workflows/Workflow.ts";
 import { type Assets, type AssetsProps } from "./Assets.ts";
 import { type DurableObjectExport } from "./DurableObject.ts";
@@ -175,6 +176,27 @@ export interface WorkerProps<
    * name from the stack, stage, and logical ID.
    */
   name?: string;
+  /**
+   * Deploy this Worker into a Workers for Platforms dispatch namespace as a
+   * "user worker" — a customer Worker that a platform Worker dispatches to at
+   * runtime via a dynamic-dispatch binding — instead of as a regular
+   * account-level Worker.
+   *
+   * Accepts the namespace name or a {@link DispatchNamespace} resource. The
+   * Worker's put/read/delete switch from the account-level
+   * `/workers/scripts` endpoints to the dispatch-namespace
+   * `/workers/dispatch/namespaces/:namespace/scripts` endpoints.
+   *
+   * User workers are not directly routable: they have no `workers.dev`
+   * subdomain, custom domains, or cron triggers, so {@link url},
+   * {@link domain}, and {@link crons} are ignored when this is set. Changing
+   * the namespace (or moving a Worker in or out of one) replaces the Worker,
+   * since an account-level script and a dispatch-namespace script are
+   * distinct cloud resources.
+   *
+   * @see https://developers.cloudflare.com/cloudflare-for-platforms/workers-for-platforms/
+   */
+  namespace?: string | DispatchNamespace;
   /**
    * Whether to enable a workers.dev URL for this worker
    * @default true
@@ -389,6 +411,11 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
   {
     workerId: string;
     workerName: string;
+    /**
+     * The Workers for Platforms dispatch namespace this Worker was deployed
+     * into, or `undefined` for a regular account-level Worker.
+     */
+    namespace: string | undefined;
     logpush: boolean | undefined;
     url: string | undefined;
     tags: string[] | undefined;

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
@@ -21,6 +21,7 @@ import { isQueue } from "../Queues/Queue.ts";
 import { isBucket } from "../R2/Bucket.ts";
 import { isSecret } from "../SecretsStore/Secret.ts";
 import { isIndex } from "../Vectorize/VectorizeIndex.ts";
+import { isDispatchNamespace } from "../WorkersForPlatforms/DispatchNamespace.ts";
 import { isWorkflowLike, WorkflowResource } from "../Workflows/Workflow.ts";
 import { isAssets } from "./Assets.ts";
 import { isBrowser } from "./Browser.ts";
@@ -206,6 +207,12 @@ const toBinding = (
       type: "queue",
       name: bindingName,
       queueName: binding.queueName,
+    };
+  } else if (isDispatchNamespace(binding)) {
+    return {
+      type: "dispatch_namespace",
+      name: bindingName,
+      namespace: binding.name,
     };
   } else if (isAiGateway(binding)) {
     return {

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerBinding.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerBinding.ts
@@ -20,6 +20,7 @@ import type { Queue } from "../Queues/Queue.ts";
 import type { Bucket } from "../R2/Bucket.ts";
 import type { Secret } from "../SecretsStore/Secret.ts";
 import type { Index as VectorizeIndex } from "../Vectorize/VectorizeIndex.ts";
+import type { DispatchNamespace } from "../WorkersForPlatforms/DispatchNamespace.ts";
 import type { WorkflowLike } from "../Workflows/Workflow.ts";
 import type { Assets } from "./Assets.ts";
 import type { BrowserBinding } from "./BrowserBinding.ts";
@@ -67,6 +68,7 @@ export type WorkerBindingResource =
   | Worker
   | WorkerLoader
   | VersionMetadataBinding
+  | DispatchNamespace
   | DurableObjectLike<any>
   | WorkflowLike<any>;
 

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -1,4 +1,5 @@
 import * as workers from "@distilled.cloud/cloudflare/workers";
+import * as wfp from "@distilled.cloud/cloudflare/workers-for-platforms";
 import * as zones from "@distilled.cloud/cloudflare/zones";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
@@ -34,6 +35,117 @@ class MissingDurableObjects extends Data.TaggedError("MissingDurableObjects")<{
   scriptName: string;
   expected: string[];
 }> {}
+
+/**
+ * Resolve the Workers for Platforms dispatch-namespace *name* from a resolved
+ * `namespace` prop or persisted attribute. The engine resolves a passed
+ * {@link DispatchNamespace} resource to its Attributes object (see
+ * `Input.Resolve` / Plan.ts), so the value is either the namespace name
+ * string, that attributes object, or `undefined` for a regular Worker.
+ *
+ * @internal
+ */
+export const resolveNamespaceName = (
+  namespace: unknown,
+): string | undefined => {
+  if (namespace == null) return undefined;
+  if (typeof namespace === "string") return namespace;
+  return (namespace as { name?: string }).name;
+};
+
+// Workers for Platforms "user workers" live inside a dispatch namespace and
+// use a parallel family of script endpoints (`/workers/dispatch/namespaces/
+// :namespace/scripts/...`). The request/response shapes are identical to the
+// account-level Workers API for everything the provider touches, so these
+// helpers route by `dispatchNamespace` and the call sites stay agnostic.
+
+/**
+ * Read a script's combined settings, routing to the dispatch-namespace
+ * endpoint when `dispatchNamespace` is set. The two response shapes are
+ * structurally identical for the fields the provider consumes (`bindings`,
+ * `tags`, `logpush`), so the WFP response is surfaced as the workers shape.
+ *
+ * @internal
+ */
+const getScriptSettings = (
+  accountId: string,
+  scriptName: string,
+  dispatchNamespace: string | undefined,
+) =>
+  // `Effect.gen` (rather than a ternary) so the two branches unify into a
+  // single `Effect<Settings, WorkersErr | WfpErr>` instead of a *union* of
+  // Effects, which `.pipe`/`catchTag` at the call sites can't consume.
+  Effect.gen(function* () {
+    if (dispatchNamespace) {
+      const settings = yield* wfp.getDispatchNamespaceScriptSetting({
+        accountId,
+        dispatchNamespace,
+        scriptName,
+      });
+      // The dispatch-namespace settings response is structurally identical to
+      // the account-level one for the fields the provider reads.
+      return settings as unknown as workers.GetScriptScriptAndVersionSettingResponse;
+    }
+    return yield* workers.getScriptScriptAndVersionSetting({
+      accountId,
+      scriptName,
+    });
+  });
+
+/**
+ * Upsert a Worker script, routing to the dispatch-namespace endpoint when
+ * `dispatchNamespace` is set. The metadata/files contract is identical.
+ *
+ * @internal
+ */
+const putWorkerScript = (params: {
+  accountId: string;
+  scriptName: string;
+  dispatchNamespace: string | undefined;
+  metadata: workers.PutScriptRequest["metadata"];
+  files: workers.PutScriptRequest["files"];
+}) =>
+  Effect.gen(function* () {
+    if (params.dispatchNamespace) {
+      return yield* wfp.putDispatchNamespaceScript({
+        accountId: params.accountId,
+        dispatchNamespace: params.dispatchNamespace,
+        scriptName: params.scriptName,
+        metadata:
+          params.metadata as unknown as wfp.PutDispatchNamespaceScriptRequest["metadata"],
+        files: params.files,
+      });
+    }
+    return yield* workers.putScript({
+      accountId: params.accountId,
+      scriptName: params.scriptName,
+      metadata: params.metadata,
+      files: params.files,
+    });
+  });
+
+/**
+ * Delete a Worker script, routing to the dispatch-namespace endpoint when
+ * `dispatchNamespace` is set.
+ *
+ * @internal
+ */
+const deleteWorkerScript = (
+  accountId: string,
+  scriptName: string,
+  dispatchNamespace: string | undefined,
+) =>
+  Effect.gen(function* () {
+    if (dispatchNamespace) {
+      return yield* wfp.deleteDispatchNamespaceScript({
+        accountId,
+        dispatchNamespace,
+        scriptName,
+        force: true,
+      });
+    }
+    return yield* workers.deleteScript({ accountId, scriptName, force: true });
+  });
 
 /**
  * Normalize a Worker's persisted `domains` state to `https://<hostname>`
@@ -404,50 +516,52 @@ export const LiveWorkerProvider = () =>
       const getWorkerSettingsWithDurableObjects = Effect.fn(function* (
         scriptName: string,
         expectedClassNames: readonly string[],
+        dispatchNamespace?: string,
       ) {
         const { accountId } = yield* yield* CloudflareEnvironment;
-        return yield* workers
-          .getScriptScriptAndVersionSetting({
-            accountId,
-            scriptName,
-          })
-          .pipe(
-            Effect.map((settings) => {
-              const namespaces = getDurableObjects(settings.bindings);
-              const missing = expectedClassNames.filter(
-                (className) => !namespaces[className],
+        return yield* getScriptSettings(
+          accountId,
+          scriptName,
+          dispatchNamespace,
+        ).pipe(
+          Effect.map((settings) => {
+            const namespaces = getDurableObjects(settings.bindings);
+            const missing = expectedClassNames.filter(
+              (className) => !namespaces[className],
+            );
+            if (missing.length > 0) {
+              return Effect.fail(
+                new MissingDurableObjects({
+                  scriptName,
+                  expected: missing,
+                }),
               );
-              if (missing.length > 0) {
-                return Effect.fail(
-                  new MissingDurableObjects({
-                    scriptName,
-                    expected: missing,
-                  }),
-                );
-              }
-              return Effect.succeed({
-                settings,
-                durableObjectNamespaces: namespaces,
-              });
-            }),
-            Effect.flatten,
-            Effect.retry({
-              // `MissingDurableObjects`: the DO bindings haven't
-              // surfaced in the version settings yet. `WorkerHasNoVersions` /
-              // `WorkerNotFound`: right after the first `putScript`, the
-              // version-settings read can race the script registry — under a
-              // busy account this read can briefly 404 with "has no versions"
-              // (or the worker itself as not-yet-found) before the upload
-              // propagates. All three are eventual-consistency blips.
-              while: (error) =>
-                error._tag === "MissingDurableObjects" ||
-                error._tag === "WorkerHasNoVersions" ||
-                error._tag === "WorkerNotFound",
-              schedule: Schedule.exponential(100).pipe(
-                Schedule.both(Schedule.recurs(20)),
-              ),
-            }),
-          );
+            }
+            return Effect.succeed({
+              settings,
+              durableObjectNamespaces: namespaces,
+            });
+          }),
+          Effect.flatten,
+          Effect.retry({
+            // `MissingDurableObjects`: the DO bindings haven't
+            // surfaced in the version settings yet. `WorkerHasNoVersions` /
+            // `WorkerNotFound`: right after the first `putScript`, the
+            // version-settings read can race the script registry — under a
+            // busy account this read can briefly 404 with "has no versions"
+            // (or the worker itself as not-yet-found) before the upload
+            // propagates. All three are eventual-consistency blips.
+            while: (error) =>
+              error._tag === "MissingDurableObjects" ||
+              error._tag === "WorkerHasNoVersions" ||
+              error._tag === "WorkerNotFound" ||
+              error._tag === "DispatchNamespaceScriptNotFound" ||
+              error._tag === "DispatchNamespaceNotFound",
+            schedule: Schedule.exponential(100).pipe(
+              Schedule.both(Schedule.recurs(20)),
+            ),
+          }),
+        );
       });
 
       const prepareAssets = Effect.fn(function* (
@@ -654,6 +768,11 @@ export const LiveWorkerProvider = () =>
       ) {
         const { accountId } = yield* yield* CloudflareEnvironment;
         const name = yield* createWorkerName(id, news.name);
+        // When set, this Worker is a Workers for Platforms "user worker"
+        // uploaded into a dispatch namespace rather than a routable
+        // account-level script. The put/settings calls switch endpoints and
+        // the subdomain / custom-domain / cron reconciliation is skipped.
+        const dispatchNamespace = resolveNamespaceName(news.namespace);
         yield* Effect.logInfo(
           `Cloudflare Worker ${olds ? "update" : "create"}: preparing bundle for ${name}`,
         );
@@ -965,51 +1084,70 @@ export const LiveWorkerProvider = () =>
           tailConsumers: undefined,
           usageModel: undefined,
         };
-        const worker = yield* workers
-          .putScript({
-            accountId,
-            scriptName: name,
-            metadata,
-            files: bundle.files,
-          })
-          .pipe(
-            Effect.catch((err) => {
-              // When adopting a Worker managed by Wrangler (or after a previous
-              // deploy with mismatched migrations), the old_tag precondition
-              // fails. The only way to discover the actual tag is through the
-              // error message — getScriptSettings is meant to return it but
-              // doesn't at runtime.
-              const msg = String(
-                typeof err === "object" && err !== null && "message" in err
-                  ? err.message
-                  : err,
-              );
-              const expectedTag = msg.match(
-                /when expected tag is ['"]?([^'"]+)['"]?/,
-              )?.[1];
-              if (expectedTag) {
-                return workers.putScript({
-                  accountId,
-                  scriptName: name,
-                  metadata: {
-                    ...metadata,
-                    migrations: {
-                      ...migrations,
-                      oldTag: expectedTag,
-                      newTag: bumpMigrationTagVersion(expectedTag),
-                    },
+        const worker = yield* putWorkerScript({
+          accountId,
+          scriptName: name,
+          dispatchNamespace,
+          metadata,
+          files: bundle.files,
+        }).pipe(
+          Effect.catch((err) => {
+            // When adopting a Worker managed by Wrangler (or after a previous
+            // deploy with mismatched migrations), the old_tag precondition
+            // fails. The only way to discover the actual tag is through the
+            // error message — getScriptSettings is meant to return it but
+            // doesn't at runtime.
+            const msg = String(
+              typeof err === "object" && err !== null && "message" in err
+                ? err.message
+                : err,
+            );
+            const expectedTag = msg.match(
+              /when expected tag is ['"]?([^'"]+)['"]?/,
+            )?.[1];
+            if (expectedTag) {
+              return putWorkerScript({
+                accountId,
+                scriptName: name,
+                dispatchNamespace,
+                metadata: {
+                  ...metadata,
+                  migrations: {
+                    ...migrations,
+                    oldTag: expectedTag,
+                    newTag: bumpMigrationTagVersion(expectedTag),
                   },
-                  files: bundle.files,
-                });
-              }
-              return Effect.fail(err as any);
-            }),
-          );
+                },
+                files: bundle.files,
+              });
+            }
+            return Effect.fail(err as any);
+          }),
+        );
         const { settings, durableObjectNamespaces } =
           yield* getWorkerSettingsWithDurableObjects(
             name,
             expectedDurableObjectClassNames,
+            dispatchNamespace,
           );
+        // Workers for Platforms user workers are invoked via dynamic dispatch,
+        // never routed directly — they have no workers.dev subdomain, custom
+        // domains, or cron triggers. Skip all of that reconciliation.
+        if (dispatchNamespace) {
+          return {
+            workerId: worker.id ?? name,
+            workerName: name,
+            namespace: dispatchNamespace,
+            logpush: worker.logpush ?? undefined,
+            url: undefined,
+            tags: settings.tags ?? metadata.tags,
+            durableObjectNamespaces,
+            accountId,
+            domains: [],
+            crons: [],
+            hash,
+          } satisfies Worker["Attributes"];
+        }
         // Reconcile workers.dev subdomain against observed cloud state.
         // We can't diff `news.url` against `olds.url` here because both
         // default to `undefined` (meaning "enable") — that comparison
@@ -1081,6 +1219,7 @@ export const LiveWorkerProvider = () =>
         return {
           workerId: worker.id ?? name,
           workerName: name,
+          namespace: undefined,
           logpush: worker.logpush ?? undefined,
           url: domains[0],
           tags: settings.tags ?? metadata.tags,
@@ -1192,6 +1331,7 @@ export const LiveWorkerProvider = () =>
                               accountId,
                               workerId: script.id,
                               workerName: script.id,
+                              namespace: undefined,
                               logpush: script.logpush ?? undefined,
                               url: undefined,
                               tags: script.tags ?? undefined,
@@ -1210,6 +1350,15 @@ export const LiveWorkerProvider = () =>
           const { accountId } = yield* yield* CloudflareEnvironment;
           if (!isResolved(news)) return undefined;
           if ((output?.accountId ?? accountId) !== accountId) {
+            return { action: "replace" };
+          }
+          // An account-level script and a dispatch-namespace ("user worker")
+          // script are distinct cloud resources; moving a Worker into, out of,
+          // or between namespaces requires a replacement.
+          const newNamespace = resolveNamespaceName(news.namespace);
+          const oldNamespace =
+            output?.namespace ?? resolveNamespaceName(olds?.namespace);
+          if (newNamespace !== oldNamespace) {
             return { action: "replace" };
           }
           const workerName = yield* createWorkerName(id, news.name);
@@ -1321,6 +1470,33 @@ export const LiveWorkerProvider = () =>
         precreate: Effect.fn(function* ({ id, news, session }) {
           const { accountId } = yield* yield* CloudflareEnvironment;
           const name = yield* createWorkerName(id, news.name);
+          // A Workers for Platforms user worker can't be pre-created: precreate
+          // runs on raw, *unresolved* props (so resources in a dependency cycle
+          // can signal early), meaning a `namespace` that references the
+          // namespace resource is still an unresolved Output here, and the
+          // namespace itself may not be deployed yet. There's also nothing to
+          // pre-create — a user worker is dispatched to by name, never bound to
+          // circularly. Return a stub; `reconcile` performs the real upload
+          // once props resolve and the namespace exists.
+          if (news.namespace != null) {
+            yield* Effect.logInfo(
+              `Cloudflare Worker precreate: skipping stub for dispatch-namespace worker ${name}`,
+            );
+            return {
+              workerId: name,
+              workerName: name,
+              namespace:
+                typeof news.namespace === "string" ? news.namespace : undefined,
+              logpush: undefined,
+              url: undefined,
+              tags: undefined,
+              durableObjectNamespaces: {},
+              accountId,
+              domains: [],
+              crons: [],
+            } satisfies Worker["Attributes"];
+          }
+          const dispatchNamespace = resolveNamespaceName(news.namespace);
           const exportMap = news.exports ?? {};
           const durableObjects = Object.keys(exportMap)
             .filter((logicalId) => isDurableObjectExport(exportMap[logicalId]))
@@ -1349,22 +1525,28 @@ export const LiveWorkerProvider = () =>
               durableObjects,
             )}`,
           );
-          const existingSettings = yield* workers
-            .getScriptScriptAndVersionSetting({
-              accountId,
-              scriptName: name,
-            })
-            .pipe(
-              // A freshly pre-created stub can briefly report "has no
-              // versions" before its first version registers — treat it the
-              // same as a missing worker (nothing to adopt yet).
-              Effect.catchTag("WorkerNotFound", () =>
-                Effect.succeed(undefined),
-              ),
-              Effect.catchTag("WorkerHasNoVersions", () =>
-                Effect.succeed(undefined),
-              ),
-            );
+          const existingSettings = yield* getScriptSettings(
+            accountId,
+            name,
+            dispatchNamespace,
+          ).pipe(
+            // A freshly pre-created stub can briefly report "has no
+            // versions" before its first version registers — treat it the
+            // same as a missing worker (nothing to adopt yet). For a user
+            // worker the dispatch-namespace endpoints report a missing
+            // script as `DispatchNamespaceScriptNotFound` (and a missing
+            // namespace as `DispatchNamespaceNotFound`).
+            Effect.catchTag("WorkerNotFound", () => Effect.succeed(undefined)),
+            Effect.catchTag("WorkerHasNoVersions", () =>
+              Effect.succeed(undefined),
+            ),
+            Effect.catchTag("DispatchNamespaceScriptNotFound", () =>
+              Effect.succeed(undefined),
+            ),
+            Effect.catchTag("DispatchNamespaceNotFound", () =>
+              Effect.succeed(undefined),
+            ),
+          );
           let durableObjectNamespaces = getDurableObjects(
             existingSettings?.bindings,
           );
@@ -1385,80 +1567,88 @@ export const LiveWorkerProvider = () =>
                   `export class ${className} extends DurableObject {}`,
               )
               .join("\n")}`;
-            yield* workers
-              .putScript({
-                accountId,
-                scriptName: name,
-                metadata: {
-                  mainModule,
-                  bindings:
-                    doClasses.length > 0
-                      ? doClasses.map((className) => ({
-                          type: "durable_object_namespace" as const,
-                          name: className,
-                          className,
-                        }))
-                      : undefined,
-                  ...getCompatibility(news),
-                  containers,
-                  migrations:
-                    doClasses.length > 0
-                      ? {
-                          oldTag: undefined,
-                          newTag: undefined,
-                          newClasses: [],
-                          deletedClasses: [],
-                          renamedClasses: [],
-                          transferredClasses: [],
-                          newSqliteClasses: doClasses,
-                        }
-                      : undefined,
-                  observability: news.observability ?? {
+            yield* putWorkerScript({
+              accountId,
+              scriptName: name,
+              dispatchNamespace,
+              metadata: {
+                mainModule,
+                bindings:
+                  doClasses.length > 0
+                    ? doClasses.map((className) => ({
+                        type: "durable_object_namespace" as const,
+                        name: className,
+                        className,
+                      }))
+                    : undefined,
+                ...getCompatibility(news),
+                containers,
+                migrations:
+                  doClasses.length > 0
+                    ? {
+                        oldTag: undefined,
+                        newTag: undefined,
+                        newClasses: [],
+                        deletedClasses: [],
+                        renamedClasses: [],
+                        transferredClasses: [],
+                        newSqliteClasses: doClasses,
+                      }
+                    : undefined,
+                observability: news.observability ?? {
+                  enabled: true,
+                  logs: {
                     enabled: true,
-                    logs: {
-                      enabled: true,
-                      invocationLogs: true,
-                    },
+                    invocationLogs: true,
                   },
-                  tags,
                 },
-                files: [
-                  new File([placeholderScript], mainModule, {
-                    type: "application/javascript+module",
-                  }),
-                ],
-              })
-              .pipe(
-                // Cloudflare's PUT /workers/scripts/{name} intermittently
-                // returns code 10002 / "An unknown error has occurred" on the
-                // first put for a fresh worker name. Surfaced as the shared
-                // `InternalServerError` upstream (alchemy-run/distilled#290).
-                // Also match `UnknownCloudflareError` for older
-                // @distilled.cloud/cloudflare versions that haven't picked
-                // up the patch yet.
-                Effect.retry({
-                  while: (e) =>
-                    e._tag === "InternalServerError" ||
-                    e._tag === "UnknownCloudflareError",
-                  schedule: Schedule.exponential(1000).pipe(
-                    Schedule.both(Schedule.recurs(5)),
-                  ),
+                tags,
+              },
+              files: [
+                new File([placeholderScript], mainModule, {
+                  type: "application/javascript+module",
                 }),
-              );
+              ],
+            }).pipe(
+              // Cloudflare's PUT /workers/scripts/{name} intermittently
+              // returns code 10002 / "An unknown error has occurred" on the
+              // first put for a fresh worker name. Surfaced as the shared
+              // `InternalServerError` upstream (alchemy-run/distilled#290).
+              // Also match `UnknownCloudflareError` for older
+              // @distilled.cloud/cloudflare versions that haven't picked
+              // up the patch yet.
+              Effect.retry({
+                while: (e) =>
+                  e._tag === "InternalServerError" ||
+                  e._tag === "UnknownCloudflareError",
+                schedule: Schedule.exponential(1000).pipe(
+                  Schedule.both(Schedule.recurs(5)),
+                ),
+              }),
+            );
             if (doClasses.length > 0) {
               ({ durableObjectNamespaces } =
-                yield* getWorkerSettingsWithDurableObjects(name, doClasses));
+                yield* getWorkerSettingsWithDurableObjects(
+                  name,
+                  doClasses,
+                  dispatchNamespace,
+                ));
             }
           }
 
           if (existingSettings && doClasses.length > 0) {
             ({ durableObjectNamespaces } =
-              yield* getWorkerSettingsWithDurableObjects(name, doClasses));
+              yield* getWorkerSettingsWithDurableObjects(
+                name,
+                doClasses,
+                dispatchNamespace,
+              ));
           }
 
           return {
             workerId: name,
             workerName: name,
+            namespace: dispatchNamespace,
             logpush: existingSettings?.logpush ?? undefined,
             url: undefined,
             tags: existingSettings?.tags ?? tags,
@@ -1473,9 +1663,41 @@ export const LiveWorkerProvider = () =>
             const { accountId } = yield* yield* CloudflareEnvironment;
             const workerName =
               output?.workerName ?? (yield* createWorkerName(id, olds?.name));
+            const dispatchNamespace =
+              output?.namespace ?? resolveNamespaceName(olds?.namespace);
             yield* Effect.logInfo(
               `Cloudflare Worker read: checking ${workerName}`,
             );
+
+            // Workers for Platforms user workers have no subdomain, custom
+            // domains, or cron triggers — read only the script settings from
+            // the dispatch-namespace endpoint.
+            if (dispatchNamespace) {
+              const settings = yield* getScriptSettings(
+                accountId,
+                workerName,
+                dispatchNamespace,
+              );
+              yield* Effect.logInfo(
+                `Cloudflare Worker read: found ${workerName} in dispatch namespace ${dispatchNamespace}`,
+              );
+              const attrs = {
+                accountId,
+                workerId: workerName,
+                workerName,
+                namespace: dispatchNamespace,
+                logpush: settings.logpush ?? undefined,
+                url: undefined,
+                tags: settings.tags ?? undefined,
+                durableObjectNamespaces: getDurableObjects(settings.bindings),
+                domains: [],
+                crons: [],
+              } satisfies Worker["Attributes"];
+              return hasAlchemyWorkerTags(id, settings.tags ?? [])
+                ? attrs
+                : Unowned(attrs);
+            }
+
             // We deliberately don't call `listScripts({ accountId })` here:
             // it pulls every Worker on the account back through a strict
             // schema decode, and a single existing Worker the schema doesn't
@@ -1532,6 +1754,7 @@ export const LiveWorkerProvider = () =>
               accountId,
               workerId: workerName,
               workerName,
+              namespace: undefined,
               logpush: settings.logpush ?? undefined,
               url: domains[0],
               tags: settings.tags ?? undefined,
@@ -1554,10 +1777,18 @@ export const LiveWorkerProvider = () =>
             effect.pipe(
               // A worker that exists but hasn't registered a version yet reads
               // as "not deployed" — fall through to (re)create like NotFound.
+              // The dispatch-namespace endpoints report the same conditions as
+              // `DispatchNamespaceScriptNotFound` / `DispatchNamespaceNotFound`.
               Effect.catchTag("WorkerNotFound", () =>
                 Effect.succeed(undefined),
               ),
               Effect.catchTag("WorkerHasNoVersions", () =>
+                Effect.succeed(undefined),
+              ),
+              Effect.catchTag("DispatchNamespaceScriptNotFound", () =>
+                Effect.succeed(undefined),
+              ),
+              Effect.catchTag("DispatchNamespaceNotFound", () =>
                 Effect.succeed(undefined),
               ),
             ),
@@ -1588,28 +1819,34 @@ export const LiveWorkerProvider = () =>
             )}`,
           );
 
+          const dispatchNamespace = resolveNamespaceName(news.namespace);
           // Observe — fetch the script's current settings if it already exists.
           // `putWorker` is a true upsert against the Cloudflare API; the
           // existing settings inform asset/migration decisions and let the
           // reconciler converge whether the worker is brand-new, adopted, or
           // an in-place update.
-          const existingSettings = yield* workers
-            .getScriptScriptAndVersionSetting({
-              accountId,
-              scriptName: name,
-            })
-            .pipe(
-              // After a pre-create stub (or under a busy account right after
-              // the first upload) the settings read can race the script
-              // registry and 404 with "has no versions". Treat it as "no
-              // existing settings" so reconcile proceeds to upload/converge.
-              Effect.catchTag("WorkerNotFound", () =>
-                Effect.succeed(undefined),
-              ),
-              Effect.catchTag("WorkerHasNoVersions", () =>
-                Effect.succeed(undefined),
-              ),
-            );
+          const existingSettings = yield* getScriptSettings(
+            accountId,
+            name,
+            dispatchNamespace,
+          ).pipe(
+            // After a pre-create stub (or under a busy account right after
+            // the first upload) the settings read can race the script
+            // registry and 404 with "has no versions". Treat it as "no
+            // existing settings" so reconcile proceeds to upload/converge.
+            // The dispatch-namespace endpoints raise
+            // `DispatchNamespaceScriptNotFound` / `DispatchNamespaceNotFound`.
+            Effect.catchTag("WorkerNotFound", () => Effect.succeed(undefined)),
+            Effect.catchTag("WorkerHasNoVersions", () =>
+              Effect.succeed(undefined),
+            ),
+            Effect.catchTag("DispatchNamespaceScriptNotFound", () =>
+              Effect.succeed(undefined),
+            ),
+            Effect.catchTag("DispatchNamespaceNotFound", () =>
+              Effect.succeed(undefined),
+            ),
+          );
           yield* Effect.logInfo(
             `Cloudflare Worker reconcile: existing durable object tags ${JSON.stringify(
               (existingSettings?.tags ?? []).filter((tag) =>
@@ -1638,6 +1875,24 @@ export const LiveWorkerProvider = () =>
           yield* Effect.logInfo(
             `Cloudflare Worker delete: deleting ${output.workerName}`,
           );
+          // Workers for Platforms user workers have no custom domains; delete
+          // the script straight out of its dispatch namespace.
+          if (output.namespace) {
+            yield* deleteWorkerScript(
+              output.accountId,
+              output.workerName,
+              output.namespace,
+            ).pipe(
+              Effect.catchTag(
+                [
+                  "DispatchNamespaceScriptNotFound",
+                  "DispatchNamespaceNotFound",
+                ],
+                () => Effect.void,
+              ),
+            );
+            return;
+          }
           // Look up live domain IDs rather than trusting persisted state.
           // We no longer track `{ id, zoneId }` on the output; fetching
           // straight from Cloudflare handles both the normal case and
@@ -1670,18 +1925,11 @@ export const LiveWorkerProvider = () =>
               { concurrency: "unbounded" },
             );
           }
-          yield* workers
-            .deleteScript({
-              accountId: output.accountId,
-              scriptName: output.workerName,
-              // Force teardown of queue consumers, durable object classes, and
-              // service bindings hanging off this worker. Without `force`, those
-              // conditions raise QueueConsumerConflict / ServiceBindingConflict
-              // and leave the script in CF. Alchemy is the source of truth for
-              // the worker, so we want a hard delete on teardown.
-              force: true,
-            })
-            .pipe(Effect.catchTag("WorkerNotFound", () => Effect.void));
+          yield* deleteWorkerScript(
+            output.accountId,
+            output.workerName,
+            undefined,
+          ).pipe(Effect.catchTag("WorkerNotFound", () => Effect.void));
         }),
         tail: ({ output }) =>
           telemetry.tailScript({

--- a/packages/alchemy/src/Cloudflare/WorkersForPlatforms/DispatchNamespace.ts
+++ b/packages/alchemy/src/Cloudflare/WorkersForPlatforms/DispatchNamespace.ts
@@ -93,12 +93,54 @@ export type DispatchNamespace = Resource<
  * ```
  *
  * @section Uploading user Workers
- * @example Upload a customer script into the namespace
+ * @example Upload a customer Worker into the namespace
+ * A {@link Cloudflare.Worker} deploys into the namespace as a "user worker"
+ * (rather than as a routable account-level script) when its `namespace` prop is
+ * set. Reference the namespace by its `name` output so it deploys first.
  * ```typescript
- * const script = yield* Cloudflare.DispatchNamespaceScript("CustomerA", {
+ * const namespace = yield* Cloudflare.WorkersForPlatforms.DispatchNamespace("Customers", {});
+ *
+ * const customerA = yield* Cloudflare.Worker("CustomerA", {
  *   namespace: namespace.name,
  *   script: `export default { fetch() { return new Response("hi"); } }`,
  * });
+ * ```
+ *
+ * @section Dispatching from a platform Worker
+ * @example Effect-native binding via `Get`
+ * `Cloudflare.WorkersForPlatforms.Get(namespace)` binds the namespace and
+ * returns an Effect-native client; `get(name)` resolves a user Worker by script
+ * name. Provide {@link GetBinding} on the Worker's runtime layer.
+ * ```typescript
+ * const dispatch = yield* Cloudflare.WorkersForPlatforms.Get(namespace);
+ *
+ * return {
+ *   fetch: Effect.gen(function* () {
+ *     const request = yield* HttpServerRequest;
+ *     const userWorker = yield* dispatch.get("CustomerA");
+ *     return yield* Effect.promise(() => userWorker.fetch(request));
+ *   }),
+ * };
+ * ```
+ *
+ * @example Async binding via `env` + `InferEnv`
+ * Passing the namespace on a Worker's `env` binds it as a native
+ * `dispatch_namespace` binding; `Cloudflare.InferEnv` types `env.DISPATCH` as
+ * the runtime `DispatchNamespace`, so the async handler calls `.get(name)`
+ * directly.
+ * ```typescript
+ * const platform = Cloudflare.Worker("Platform", {
+ *   main: "./handler.ts",
+ *   env: { DISPATCH: namespace },
+ * });
+ * type Env = Cloudflare.InferEnv<typeof platform>;
+ *
+ * // handler.ts
+ * export default {
+ *   async fetch(request: Request, env: Env) {
+ *     return env.DISPATCH.get("CustomerA").fetch(request);
+ *   },
+ * };
  * ```
  *
  * @see https://developers.cloudflare.com/cloudflare-for-platforms/workers-for-platforms/

--- a/packages/alchemy/src/Cloudflare/WorkersForPlatforms/Get.ts
+++ b/packages/alchemy/src/Cloudflare/WorkersForPlatforms/Get.ts
@@ -1,0 +1,87 @@
+/// <reference types="@cloudflare/workers-types" />
+
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import * as Binding from "../../Binding.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
+import type { DispatchNamespace as DispatchNamespaceResource } from "./DispatchNamespace.ts";
+
+/**
+ * Bind a {@link DispatchNamespace} to a Worker and obtain the Effect-native
+ * dynamic-dispatch client (`get`).
+ *
+ * `Get` is a single identifier that is simultaneously the binding's Context
+ * tag, its type, and the callable —
+ * `yield* Cloudflare.WorkersForPlatforms.Get(namespace)`.
+ *
+ * Provide {@link GetBinding} on the Worker's runtime layer to resolve the
+ * underlying `dispatch_namespace` binding at request time.
+ *
+ * @binding
+ * @product Workers for Platforms
+ * @category Workers & Compute
+ *
+ * @section Dispatching to user Workers
+ * @example Dispatch a request to a customer Worker
+ * Bind the namespace during the Worker's init phase, then look up and forward
+ * to a user Worker from a request handler.
+ * ```typescript
+ * const dispatch = yield* Cloudflare.WorkersForPlatforms.Get(namespace);
+ *
+ * return {
+ *   fetch: Effect.gen(function* () {
+ *     const request = yield* HttpServerRequest;
+ *     const userWorker = yield* dispatch.get("customer-a");
+ *     return yield* Effect.promise(() => userWorker.fetch(request));
+ *   }),
+ * };
+ * ```
+ *
+ * @see https://developers.cloudflare.com/cloudflare-for-platforms/workers-for-platforms/get-started/dynamic-dispatch/
+ */
+export interface Get extends Binding.Service<
+  Get,
+  "Cloudflare.WorkersForPlatforms.Get",
+  (
+    namespace: DispatchNamespaceResource,
+  ) => Effect.Effect<DispatchNamespaceClient>
+> {}
+
+export const Get = Binding.Service<Get>("Cloudflare.WorkersForPlatforms.Get");
+
+/** Error raised by dynamic-dispatch runtime operations. */
+export class DispatchNamespaceError extends Data.TaggedError(
+  "DispatchNamespaceError",
+)<{
+  /** Human-readable runtime error message. */
+  message: string;
+  /** Original error thrown by the Cloudflare runtime binding. */
+  cause: unknown;
+}> {}
+
+/**
+ * Effect-native client for a Workers for Platforms dispatch-namespace Worker
+ * binding.
+ *
+ * Wraps the runtime `DispatchNamespace` binding so the lookup returns an
+ * Effect tagged with {@link DispatchNamespaceError}. Use
+ * `Cloudflare.WorkersForPlatforms.Get(namespace)` inside a Worker's init
+ * phase.
+ */
+export interface DispatchNamespaceClient {
+  /** Effect resolving to the raw dispatch-namespace runtime binding. */
+  raw: Effect.Effect<DispatchNamespace, never, RuntimeContext>;
+  /**
+   * Look up a user Worker in the dispatch namespace by script name and obtain
+   * a `Fetcher` to send it requests.
+   *
+   * @param name Name of the user Worker script.
+   * @param args Arguments passed to the user Worker script.
+   * @param options Options for the dynamic-dispatch invocation.
+   */
+  get(
+    name: string,
+    args?: { [key: string]: any },
+    options?: DynamicDispatchOptions,
+  ): Effect.Effect<Fetcher, DispatchNamespaceError, RuntimeContext>;
+}

--- a/packages/alchemy/src/Cloudflare/WorkersForPlatforms/GetBinding.ts
+++ b/packages/alchemy/src/Cloudflare/WorkersForPlatforms/GetBinding.ts
@@ -1,0 +1,63 @@
+/// <reference types="@cloudflare/workers-types" />
+
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { Worker, WorkerEnvironment } from "../Workers/Worker.ts";
+import type { DispatchNamespace as DispatchNamespaceResource } from "./DispatchNamespace.ts";
+import {
+  type DispatchNamespaceClient,
+  DispatchNamespaceError,
+  Get,
+} from "./Get.ts";
+
+/**
+ * Implementation of the {@link Get} binding that uses a native
+ * `dispatch_namespace` Worker binding.
+ */
+export const GetBinding = Layer.effect(
+  Get,
+  Effect.gen(function* () {
+    const env = yield* WorkerEnvironment;
+    const host = yield* Worker;
+
+    return Effect.fn(function* (namespace: DispatchNamespaceResource) {
+      if (!globalThis.__ALCHEMY_RUNTIME__) {
+        yield* host.bind`${namespace}`({
+          bindings: [
+            {
+              type: "dispatch_namespace",
+              name: namespace.LogicalId,
+              namespace: namespace.name,
+            },
+          ],
+        });
+      }
+
+      const raw = Effect.sync(
+        // Lazy — the WorkerEnvironment binding is not populated until runtime.
+        () => (env as Record<string, DispatchNamespace>)[namespace.LogicalId]!,
+      );
+
+      const self: DispatchNamespaceClient = {
+        raw,
+        get: (name, args, options) =>
+          raw.pipe(
+            Effect.flatMap((ns) =>
+              Effect.try({
+                try: () => ns.get(name, args, options),
+                catch: (error) =>
+                  new DispatchNamespaceError({
+                    message:
+                      error instanceof Error
+                        ? error.message
+                        : "Unknown dispatch namespace runtime error",
+                    cause: error,
+                  }),
+              }),
+            ),
+          ),
+      };
+      return self;
+    });
+  }),
+);

--- a/packages/alchemy/src/Cloudflare/WorkersForPlatforms/index.ts
+++ b/packages/alchemy/src/Cloudflare/WorkersForPlatforms/index.ts
@@ -1,1 +1,3 @@
 export * from "./DispatchNamespace.ts";
+export * from "./Get.ts";
+export * from "./GetBinding.ts";

--- a/packages/alchemy/test/Cloudflare/WorkersForPlatforms/DispatchBinding.test.ts
+++ b/packages/alchemy/test/Cloudflare/WorkersForPlatforms/DispatchBinding.test.ts
@@ -9,7 +9,11 @@ import * as Schedule from "effect/Schedule";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import type * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
 import WfpPlatformWorker from "./fixtures/platform-worker.ts";
-import { DispatchNs, userWorkerScript } from "./fixtures/shared.ts";
+import {
+  AsyncPlatformWorker,
+  DispatchNs,
+  userWorkerScript,
+} from "./fixtures/shared.ts";
 
 /**
  * End-to-end test for the Workers for Platforms dynamic-dispatch binding
@@ -50,8 +54,10 @@ const Stack = Alchemy.Stack(
       script: userWorkerScript,
     });
     const platformWorker = yield* WfpPlatformWorker;
+    const asyncPlatformWorker = yield* AsyncPlatformWorker;
     return {
       platformUrl: platformWorker.url.as<string>(),
+      asyncPlatformUrl: asyncPlatformWorker.url.as<string>(),
       userWorkerName: userWorker.workerName.as<string>(),
     };
   }),
@@ -89,21 +95,25 @@ const untilOk = <E, R>(
 const stack = beforeAll(
   WFP_ENABLED
     ? deploy(Stack)
-    : Effect.succeed({ platformUrl: "", userWorkerName: "" }),
+    : Effect.succeed({
+        platformUrl: "",
+        asyncPlatformUrl: "",
+        userWorkerName: "",
+      }),
   { timeout: HOOK_TIMEOUT },
 );
 afterAll.skipIf(!WFP_ENABLED || !!process.env.NO_DESTROY)(destroy(Stack), {
   timeout: HOOK_TIMEOUT,
 });
 
-test.skipIf(!WFP_ENABLED)(
-  "platform worker dispatches to a user worker in the namespace",
+// Drive one platform worker base URL: dispatch to `scriptName`, assert the
+// request reached the dispatched user worker (not the platform worker's own
+// fallback) and that the path + header were forwarded.
+const assertDispatch = (base: string, scriptName: string) =>
   Effect.gen(function* () {
-    const { platformUrl, userWorkerName } = yield* stack;
     const client = yield* HttpClient.HttpClient;
-
     const res = yield* untilOk(
-      client.get(`${platformUrl}/dispatch/${userWorkerName}/hello`, {
+      client.get(`${base}/dispatch/${scriptName}/hello`, {
         headers: { "x-custom": "ping" },
       }),
     );
@@ -114,11 +124,27 @@ test.skipIf(!WFP_ENABLED)(
       path: string;
       customHeader: string;
     };
-    // Proves the request reached the dispatched user worker — not the platform
-    // worker's own fallback route.
     expect(body.handledBy).toBe("user-worker");
     expect(body.path).toBe("/hello");
     expect(body.customHeader).toBe("ping");
+  });
+
+// Effect-native platform worker: binds the namespace via `Get`.
+test.skipIf(!WFP_ENABLED)(
+  "Get binding dispatches to a user worker in the namespace",
+  Effect.gen(function* () {
+    const { platformUrl, userWorkerName } = yield* stack;
+    yield* assertDispatch(platformUrl, userWorkerName);
+  }).pipe(logLevel),
+  { timeout: TEST_TIMEOUT },
+);
+
+// Async platform worker: binds the namespace via `env: { DISPATCH }` + InferEnv.
+test.skipIf(!WFP_ENABLED)(
+  "env binding (InferEnv) dispatches to a user worker in the namespace",
+  Effect.gen(function* () {
+    const { asyncPlatformUrl, userWorkerName } = yield* stack;
+    yield* assertDispatch(asyncPlatformUrl, userWorkerName);
   }).pipe(logLevel),
   { timeout: TEST_TIMEOUT },
 );

--- a/packages/alchemy/test/Cloudflare/WorkersForPlatforms/DispatchBinding.test.ts
+++ b/packages/alchemy/test/Cloudflare/WorkersForPlatforms/DispatchBinding.test.ts
@@ -1,0 +1,147 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as Alchemy from "@/index.ts";
+import * as Test from "@/Test/Vitest";
+import { expect } from "@effect/vitest";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+import * as Schedule from "effect/Schedule";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import type * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
+import WfpPlatformWorker from "./fixtures/platform-worker.ts";
+import { DispatchNs, userWorkerScript } from "./fixtures/shared.ts";
+
+/**
+ * End-to-end test for the Workers for Platforms dynamic-dispatch binding
+ * (`Cloudflare.WorkersForPlatforms.Get`). Deploys a dispatch namespace, a user
+ * Worker uploaded *into* it (via the Worker `namespace` prop), and a platform
+ * Worker that binds the namespace and forwards requests to the user Worker by
+ * script name. The platform Worker is then driven over HTTP.
+ *
+ * Workers for Platforms is a paid add-on. The standing test account is
+ * entitled, so this runs live by default; set `CLOUDFLARE_TEST_WFP=0` to skip
+ * the suite skip-clean on a non-entitled account.
+ */
+const WFP_ENABLED = process.env.CLOUDFLARE_TEST_WFP !== "0";
+
+const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
+  providers: Cloudflare.providers(),
+  state: Cloudflare.state(),
+});
+
+const HOOK_TIMEOUT = 300_000;
+const TEST_TIMEOUT = 180_000;
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+const Stack = Alchemy.Stack(
+  "WfpDispatchBindingStack",
+  { providers: Cloudflare.providers(), state: Cloudflare.state() },
+  Effect.gen(function* () {
+    // Reference the namespace by its `name` output: resolves to the namespace
+    // name string and establishes the dependency edge so the namespace is
+    // created before the user Worker is uploaded into it.
+    const ns = yield* DispatchNs;
+    const userWorker = yield* Cloudflare.Worker("WfpBindingUserWorker", {
+      namespace: ns.name,
+      script: userWorkerScript,
+    });
+    const platformWorker = yield* WfpPlatformWorker;
+    return {
+      platformUrl: platformWorker.url.as<string>(),
+      userWorkerName: userWorker.workerName.as<string>(),
+    };
+  }),
+);
+
+class NotReady extends Data.TaggedError("NotReady")<{
+  status: number;
+  body: string;
+}> {}
+
+// Fresh workers.dev URLs take a few seconds to start serving 200s; ride out
+// cold-start non-200s with a bounded spaced schedule so a real failure
+// surfaces fast instead of running to the vitest timeout.
+const untilOk = <E, R>(
+  eff: Effect.Effect<HttpClientResponse.HttpClientResponse, E, R>,
+) =>
+  eff.pipe(
+    Effect.flatMap((res) =>
+      res.status === 200
+        ? Effect.succeed(res)
+        : res.text.pipe(
+            Effect.flatMap((body) =>
+              Effect.fail(new NotReady({ status: res.status, body })),
+            ),
+          ),
+    ),
+    Effect.retry({
+      while: (e): e is NotReady => e instanceof NotReady,
+      schedule: Schedule.spaced("2 seconds").pipe(
+        Schedule.both(Schedule.recurs(30)),
+      ),
+    }),
+  );
+
+const stack = beforeAll(
+  WFP_ENABLED
+    ? deploy(Stack)
+    : Effect.succeed({ platformUrl: "", userWorkerName: "" }),
+  { timeout: HOOK_TIMEOUT },
+);
+afterAll.skipIf(!WFP_ENABLED || !!process.env.NO_DESTROY)(destroy(Stack), {
+  timeout: HOOK_TIMEOUT,
+});
+
+test.skipIf(!WFP_ENABLED)(
+  "platform worker dispatches to a user worker in the namespace",
+  Effect.gen(function* () {
+    const { platformUrl, userWorkerName } = yield* stack;
+    const client = yield* HttpClient.HttpClient;
+
+    const res = yield* untilOk(
+      client.get(`${platformUrl}/dispatch/${userWorkerName}/hello`, {
+        headers: { "x-custom": "ping" },
+      }),
+    );
+    expect(res.status).toBe(200);
+
+    const body = (yield* res.json) as {
+      handledBy: string;
+      path: string;
+      customHeader: string;
+    };
+    // Proves the request reached the dispatched user worker — not the platform
+    // worker's own fallback route.
+    expect(body.handledBy).toBe("user-worker");
+    expect(body.path).toBe("/hello");
+    expect(body.customHeader).toBe("ping");
+  }).pipe(logLevel),
+  { timeout: TEST_TIMEOUT },
+);
+
+test.skipIf(!WFP_ENABLED)(
+  "dispatching an unknown script does not reach a user worker",
+  Effect.gen(function* () {
+    const { platformUrl } = yield* stack;
+    const client = yield* HttpClient.HttpClient;
+
+    // A script that doesn't exist in the namespace can't be dispatched to:
+    // the forwarded fetch surfaces as a 404 from the edge rather than a
+    // dispatched 200. Either way it must be an error status, never a real
+    // user-worker response.
+    const res = yield* client
+      .get(`${platformUrl}/dispatch/this-script-does-not-exist/x`)
+      .pipe(
+        Effect.retry({
+          schedule: Schedule.exponential("500 millis"),
+          times: 8,
+        }),
+      );
+    expect(res.status).toBeGreaterThanOrEqual(400);
+  }).pipe(logLevel),
+  { timeout: TEST_TIMEOUT },
+);

--- a/packages/alchemy/test/Cloudflare/WorkersForPlatforms/fixtures/async-platform-handler.ts
+++ b/packages/alchemy/test/Cloudflare/WorkersForPlatforms/fixtures/async-platform-handler.ts
@@ -1,0 +1,30 @@
+/// <reference types="@cloudflare/workers-types" />
+
+import type { AsyncPlatformWorkerEnv } from "./shared.ts";
+
+/**
+ * Async (non-Effect) platform Worker handler. The dispatch namespace is bound
+ * via `env: { DISPATCH }` (see `shared.ts`); `InferEnv` types `env.DISPATCH` as
+ * the native `cf.DispatchNamespace`, so `env.DISPATCH.get(name)` returns a
+ * `Fetcher` for the user Worker. Mirrors the Effect-native `platform-worker.ts`
+ * routes so the test can drive both styles identically.
+ */
+export default {
+  async fetch(
+    request: Request,
+    env: AsyncPlatformWorkerEnv,
+  ): Promise<Response> {
+    const url = new URL(request.url);
+    const match = url.pathname.match(/^\/dispatch\/([^/]+)(\/.*)?$/);
+    if (!match) {
+      return new Response("async-platform-worker ok");
+    }
+    const [, scriptName, rest] = match;
+    const userWorker = env.DISPATCH.get(scriptName);
+    return userWorker.fetch(
+      new Request(`https://user-worker${rest ?? "/"}`, {
+        headers: { "x-custom": request.headers.get("x-custom") ?? "" },
+      }),
+    );
+  },
+};

--- a/packages/alchemy/test/Cloudflare/WorkersForPlatforms/fixtures/platform-worker.ts
+++ b/packages/alchemy/test/Cloudflare/WorkersForPlatforms/fixtures/platform-worker.ts
@@ -1,0 +1,43 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Effect from "effect/Effect";
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import { DispatchNs } from "./shared.ts";
+
+/**
+ * Effect-native platform Worker that binds the dispatch namespace via
+ * `Cloudflare.WorkersForPlatforms.Get(DispatchNs)` and forwards requests to a
+ * user Worker by script name.
+ *
+ * `GET /dispatch/:scriptName/...` looks up `:scriptName` in the namespace and
+ * forwards the trailing path (plus the `x-custom` header) to the user Worker's
+ * `Fetcher`, returning its response verbatim.
+ */
+export default class WfpPlatformWorker extends Cloudflare.Worker<WfpPlatformWorker>()(
+  "WfpBindingPlatformWorker",
+  { main: import.meta.filename, url: true },
+  Effect.gen(function* () {
+    const dispatch = yield* Cloudflare.WorkersForPlatforms.Get(DispatchNs);
+
+    return {
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        const url = new URL(request.url, "http://placeholder");
+        const match = url.pathname.match(/^\/dispatch\/([^/]+)(\/.*)?$/);
+        if (!match) {
+          return HttpServerResponse.text("platform-worker ok");
+        }
+        const [, scriptName, rest] = match;
+        const userWorker = yield* dispatch.get(scriptName).pipe(Effect.orDie);
+        const response = yield* Effect.promise(() =>
+          userWorker.fetch(
+            new Request(`https://user-worker${rest ?? "/"}`, {
+              headers: { "x-custom": request.headers["x-custom"] ?? "" },
+            }),
+          ),
+        );
+        return HttpServerResponse.fromWeb(response);
+      }),
+    };
+  }).pipe(Effect.provide(Cloudflare.WorkersForPlatforms.GetBinding)),
+) {}

--- a/packages/alchemy/test/Cloudflare/WorkersForPlatforms/fixtures/shared.ts
+++ b/packages/alchemy/test/Cloudflare/WorkersForPlatforms/fixtures/shared.ts
@@ -1,0 +1,29 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+
+/**
+ * Dispatch namespace shared by the platform Worker (which binds it via `Get`)
+ * and the user Worker (which is uploaded *into* it via the Worker `namespace`
+ * prop). Deterministic, constant name per the test conventions.
+ */
+export const DispatchNs = Cloudflare.WorkersForPlatforms.DispatchNamespace(
+  "WfpBindingNs",
+  { name: "alchemy-wfp-binding-test-ns" },
+);
+
+/**
+ * Raw ESM source for a trivial "user worker" uploaded into {@link DispatchNs}.
+ * Using the `script` form keeps it a plain module (no Effect runtime), which is
+ * all we need to prove dynamic dispatch forwards the request: it echoes its
+ * path and the `x-custom` header back as JSON so the test can assert the
+ * platform Worker reached it.
+ */
+export const userWorkerScript = `export default {
+  async fetch(request) {
+    const url = new URL(request.url);
+    return Response.json({
+      handledBy: "user-worker",
+      path: url.pathname,
+      customHeader: request.headers.get("x-custom"),
+    });
+  },
+};`;

--- a/packages/alchemy/test/Cloudflare/WorkersForPlatforms/fixtures/shared.ts
+++ b/packages/alchemy/test/Cloudflare/WorkersForPlatforms/fixtures/shared.ts
@@ -1,4 +1,5 @@
 import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as pathe from "pathe";
 
 /**
  * Dispatch namespace shared by the platform Worker (which binds it via `Get`)
@@ -9,6 +10,24 @@ export const DispatchNs = Cloudflare.WorkersForPlatforms.DispatchNamespace(
   "WfpBindingNs",
   { name: "alchemy-wfp-binding-test-ns" },
 );
+
+/**
+ * Async (non-Effect) platform Worker that declares the dispatch namespace on
+ * its `env`. `InferEnv` resolves `DISPATCH` to the native `cf.DispatchNamespace`
+ * runtime binding, so the handler calls `env.DISPATCH.get(name)` directly — the
+ * `env`-binding counterpart to the Effect-native `Get` platform worker.
+ */
+export const AsyncPlatformWorker = Cloudflare.Worker("WfpAsyncPlatformWorker", {
+  main: pathe.resolve(import.meta.dirname, "async-platform-handler.ts"),
+  url: true,
+  env: {
+    DISPATCH: DispatchNs,
+  },
+});
+
+export type AsyncPlatformWorkerEnv = Cloudflare.InferEnv<
+  typeof AsyncPlatformWorker
+>;
 
 /**
  * Raw ESM source for a trivial "user worker" uploaded into {@link DispatchNs}.


### PR DESCRIPTION
Add the Workers for Platforms dynamic-dispatch binding and let a Worker deploy *into* a dispatch namespace as a "user worker" — no duplicate Worker resource.

### Bind a dispatch namespace to a platform Worker

Two interchangeable styles, both emitting the native `dispatch_namespace` binding:

```ts
// Effect-native — yield the binding, get a typed client
const dispatch = yield* Cloudflare.WorkersForPlatforms.Get(namespace);
const userWorker = yield* dispatch.get("customer-a"); // Effect<Fetcher, DispatchNamespaceError, RuntimeContext>
```

```ts
// Async / InferEnv — pass the namespace on env, call it directly
const platform = Cloudflare.Worker("Platform", {
  main: "./handler.ts",
  env: { DISPATCH: namespace },          // DispatchNamespace is now a valid env binding
});
type Env = Cloudflare.InferEnv<typeof platform>; // env.DISPATCH : cf.DispatchNamespace

// handler.ts
export default {
  async fetch(request: Request, env: Env) {
    return env.DISPATCH.get("customer-a").fetch(request);
  },
};
```

Provide `Cloudflare.WorkersForPlatforms.GetBinding` on the Worker's runtime layer for the Effect-native path.

### Worker `namespace` prop — deploy into a namespace

```ts
const ns = yield* Cloudflare.WorkersForPlatforms.DispatchNamespace("Customers", {});
const userWorker = yield* Cloudflare.Worker("CustomerA", {
  namespace: ns.name, // string | DispatchNamespace
  script: `export default { fetch() { return new Response("hi") } }`,
});
```

The provider switches its put/read/delete/settings calls to the `dispatch/namespaces/:ns/scripts` endpoints when `namespace` is set, skips the (inapplicable) subdomain / custom-domain / workers.dev / cron reconciliation and the precreate placeholder, and replaces the Worker if it moves into/out of/between namespaces. Reference the namespace via `ns.name` (an Output) so it resolves and orders correctly.

### Tests

`DispatchBinding.test.ts` deploys a namespace + a user worker in it + two platform workers (Effect-native `Get` and async `env`/`InferEnv`), then drives each over `HttpClient` (forwards by script name, asserts the dispatched response + header pass-through), plus an unknown-script negative case. Verified live: fresh deploy → dispatch round-trip for both styles → destroy.

### Depends on

distilled patch [alchemy-run/distilled#361](https://github.com/alchemy-run/distilled/pull/361) (typed errors + a placement-union fix for `getDispatchNamespaceScriptSetting` (append the omitted response variant)); the submodule pointer is bumped to it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
