### PR TITLE
feat(planetscale): expose pooledOrigin on PostgresRole

### DIFF
--- a/packages/alchemy/src/Planetscale/Postgres/PostgresRole.ts
+++ b/packages/alchemy/src/Planetscale/Postgres/PostgresRole.ts
@@ -113,8 +113,10 @@ export interface PostgresRoleAttributes {
   database: string;
   /** The Postgres database name inside the branch. */
   databaseName: string;
-  /** Parsed connection components ready to feed into Cloudflare Hyperdrive. */
+  /** Parsed direct (port 5432) connection components ready to feed into Cloudflare Hyperdrive. */
   origin: PostgresOrigin;
+  /** Parsed pooled (PSBouncer, port 6432) connection components, e.g. for a Hyperdrive `dev` origin. */
+  pooledOrigin: PostgresOrigin;
   /** Direct connection URL for the database (Redacted). */
   connectionUrl: Redacted.Redacted<string>;
   /** Pooled connection URL via PSBouncer (port 6432, Redacted). */
@@ -528,6 +530,14 @@ const buildAttributes = (
       scheme: "postgres",
       host: role.access_host_url,
       port: 5432,
+      database: role.database_name,
+      user: role.username,
+      password,
+    },
+    pooledOrigin: {
+      scheme: "postgres",
+      host: role.access_host_url,
+      port: 6432,
       database: role.database_name,
       user: role.username,
       password,

--- a/packages/alchemy/test/Planetscale/Postgres/Hyperdrive.test.ts
+++ b/packages/alchemy/test/Planetscale/Postgres/Hyperdrive.test.ts
@@ -14,8 +14,18 @@ import HyperdriveWorker from "./fixtures/hyperdrive-worker.ts";
 import type { Widget } from "./fixtures/schema.ts";
 import { Hyperdrive, PlanetscaleDb } from "./fixtures/Stack.ts";
 
+const providers = Layer.mergeAll(
+  Cloudflare.providers(),
+  Planetscale.providers(),
+);
+
 const { test } = Test.make({
-  providers: Layer.mergeAll(Cloudflare.providers(), Planetscale.providers()),
+  providers,
+});
+
+const { test: devTest } = Test.make({
+  providers,
+  dev: true,
 });
 
 const logLevel = Effect.provideService(
@@ -28,7 +38,62 @@ class WorkerNotReady extends Data.TaggedError("WorkerNotReady")<{
   body: string;
 }> {}
 
-describe.skipIf(!process.env.PLANETSCALE_TEST).concurrent("Hyperdrive", () => {
+const fetchReady = (req: Effect.Effect<any, any, any>) =>
+  req.pipe(
+    Effect.flatMap((res: any) =>
+      res.status >= 200 && res.status < 300
+        ? res.text.pipe(Effect.as(res))
+        : res.text.pipe(
+            Effect.flatMap((body: string) =>
+              Effect.fail(new WorkerNotReady({ status: res.status, body })),
+            ),
+          ),
+    ),
+    Effect.retry({
+      while: (e: unknown): e is WorkerNotReady =>
+        e instanceof WorkerNotReady && e.status >= 400 && e.status < 600,
+      schedule: Schedule.exponential("500 millis").pipe(
+        Schedule.both(Schedule.recurs(20)),
+      ),
+    }),
+  ) as Effect.Effect<HttpClientResponse>;
+
+const expectWidgetRoundTrip = (baseUrl: string, widget: Widget) =>
+  Effect.gen(function* () {
+    const initial = yield* fetchReady(HttpClient.get(`${baseUrl}/widgets`));
+    expect(initial.status).toBe(200);
+    const initialBody = (yield* initial.json) as { widgets: Widget[] };
+    expect(Array.isArray(initialBody.widgets)).toBe(true);
+
+    const insertRes = yield* fetchReady(
+      HttpClient.execute(
+        HttpClientRequest.post(`${baseUrl}/widgets`).pipe(
+          HttpClientRequest.bodyJsonUnsafe(widget),
+        ),
+      ),
+    );
+    expect(insertRes.status).toBe(200);
+    const insertBody = (yield* insertRes.json) as { widget: Widget };
+    expect(insertBody.widget).toMatchObject(widget);
+
+    const after = yield* fetchReady(HttpClient.get(`${baseUrl}/widgets`));
+    expect(after.status).toBe(200);
+    const afterBody = (yield* after.json) as { widgets: Widget[] };
+    expect(afterBody.widgets.some((w) => w.id === widget.id)).toBe(true);
+
+    const deleteRes = yield* fetchReady(
+      HttpClient.execute(
+        HttpClientRequest.delete(`${baseUrl}/widgets/${widget.id}`),
+      ),
+    );
+    expect(deleteRes.status).toBe(200);
+
+    const final = yield* fetchReady(HttpClient.get(`${baseUrl}/widgets`));
+    const finalBody = (yield* final.json) as { widgets: Widget[] };
+    expect(finalBody.widgets.some((w) => w.id === widget.id)).toBe(false);
+  });
+
+describe.skipIf(!process.env.PLANETSCALE_TEST).sequential("Hyperdrive", () => {
   /**
    * End-to-end: deploy a {@link Planetscale.PostgresDatabase} + branch +
    * role, point a {@link Cloudflare.Hyperdrive.Connection} at the role's origin, and
@@ -46,74 +111,73 @@ describe.skipIf(!process.env.PLANETSCALE_TEST).concurrent("Hyperdrive", () => {
       Effect.gen(function* () {
         yield* stack.destroy();
 
-        const { worker } = yield* stack.deploy(
+        const { hyperdrive, worker } = yield* stack.deploy(
           Effect.gen(function* () {
             yield* PlanetscaleDb;
-            yield* Hyperdrive;
+            const hyperdrive = yield* Hyperdrive;
             const worker = yield* HyperdriveWorker;
-            return { worker };
+            return { hyperdrive, worker };
           }),
         );
 
         expect(worker.url).toBeTypeOf("string");
+        expect(hyperdrive.origin).toMatchObject({ port: 5432 });
+        expect(hyperdrive.dev).toMatchObject({ port: 6432 });
         const baseUrl = (worker.url as string).replace(/\/+$/, "");
+        yield* expectWidgetRoundTrip(baseUrl, { id: 1, name: "alpha" });
 
-        // workers.dev edge takes a few seconds to start serving; retry any
-        // request until we get a 2xx. Edge routing can flip mid-test as
-        // different POPs warm up, so apply to every call, not just the first.
-        const fetchReady = (req: Effect.Effect<any, any, any>) =>
-          req.pipe(
-            Effect.flatMap((res: any) =>
-              res.status >= 200 && res.status < 300
-                ? res.text.pipe(Effect.as(res))
-                : res.text.pipe(
-                    Effect.flatMap((body: string) =>
-                      Effect.fail(
-                        new WorkerNotReady({ status: res.status, body }),
-                      ),
-                    ),
-                  ),
-            ),
-            Effect.retry({
-              while: (e: unknown): e is WorkerNotReady =>
-                e instanceof WorkerNotReady &&
-                e.status >= 400 &&
-                e.status < 600,
-              schedule: Schedule.exponential("500 millis").pipe(
-                Schedule.both(Schedule.recurs(20)),
-              ),
-            }),
-          ) as Effect.Effect<HttpClientResponse>;
+        yield* stack.destroy();
+      }).pipe(logLevel),
+    { timeout: 600_000 },
+  );
 
-        const initial = yield* fetchReady(HttpClient.get(`${baseUrl}/widgets`));
-        expect(initial.status).toBe(200);
-        const initialBody = (yield* initial.json) as { widgets: Widget[] };
-        expect(Array.isArray(initialBody.widgets)).toBe(true);
+  /**
+   * End-to-end: deploy the same fixture in local-dev mode. Hyperdrive is
+   * bypassed in local dev, so `role.pooledOrigin` must provide a working
+   * direct connection for the Worker runtime binding.
+   */
+  devTest.provider(
+    "PostgresRole pooledOrigin works as the Hyperdrive dev origin",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
 
-        const insertRes = yield* fetchReady(
-          HttpClient.execute(
-            HttpClientRequest.post(`${baseUrl}/widgets`).pipe(
-              HttpClientRequest.bodyJsonUnsafe({ id: 1, name: "alpha" }),
-            ),
-          ),
+        const { hyperdrive, role, worker } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const { role } = yield* PlanetscaleDb;
+            const hyperdrive = yield* Hyperdrive;
+            const worker = yield* HyperdriveWorker;
+            return { hyperdrive, role, worker };
+          }),
         );
-        expect(insertRes.status).toBe(200);
-        const insertBody = (yield* insertRes.json) as { widget: Widget };
-        expect(insertBody.widget).toMatchObject({ id: 1, name: "alpha" });
 
-        const after = yield* fetchReady(HttpClient.get(`${baseUrl}/widgets`));
-        expect(after.status).toBe(200);
-        const afterBody = (yield* after.json) as { widgets: Widget[] };
-        expect(afterBody.widgets.some((w) => w.id === 1)).toBe(true);
+        expect(worker.url).toBeTypeOf("string");
+        expect(hyperdrive.origin).toMatchObject({ port: 5432 });
+        expect(hyperdrive.dev).toMatchObject({
+          host: role.pooledOrigin.host,
+          port: 6432,
+          database: role.pooledOrigin.database,
+          user: role.pooledOrigin.user,
+        });
 
-        const deleteRes = yield* fetchReady(
-          HttpClient.execute(HttpClientRequest.delete(`${baseUrl}/widgets/1`)),
+        const baseUrl = (worker.url as string).replace(/\/+$/, "");
+        const metadataRes = yield* fetchReady(
+          HttpClient.get(`${baseUrl}/hyperdrive`),
         );
-        expect(deleteRes.status).toBe(200);
+        const metadata = (yield* metadataRes.json) as {
+          host: string;
+          port: number;
+          database: string;
+          user: string;
+        };
+        expect(metadata).toMatchObject({
+          host: role.pooledOrigin.host,
+          port: 6432,
+          database: role.pooledOrigin.database,
+          user: role.pooledOrigin.user,
+        });
 
-        const final = yield* fetchReady(HttpClient.get(`${baseUrl}/widgets`));
-        const finalBody = (yield* final.json) as { widgets: Widget[] };
-        expect(finalBody.widgets.some((w) => w.id === 1)).toBe(false);
+        yield* expectWidgetRoundTrip(baseUrl, { id: 2, name: "beta" });
 
         yield* stack.destroy();
       }).pipe(logLevel),

--- a/packages/alchemy/test/Planetscale/Postgres/fixtures/Stack.ts
+++ b/packages/alchemy/test/Planetscale/Postgres/fixtures/Stack.ts
@@ -6,8 +6,9 @@ import * as Effect from "effect/Effect";
  * Shared Planetscale + Cloudflare wiring used by the Hyperdrive
  * fixture worker. A long-lived staging Postgres database (named
  * deterministically so reruns adopt the same resource) owns a feature
- * branch + role; Hyperdrive points at `role.origin` so the worker can
- * connect over Postgres-on-PSBouncer.
+ * branch + role. The live Hyperdrive config points at the direct
+ * `role.origin`; local dev bypasses Hyperdrive, so it uses
+ * `role.pooledOrigin` to avoid one direct connection per worker request.
  */
 export const PlanetscaleDb = Effect.gen(function* () {
   const database = yield* Planetscale.PostgresDatabase("HyperdriveTestDb", {
@@ -35,6 +36,7 @@ export const Hyperdrive = Effect.gen(function* () {
   const { role } = yield* PlanetscaleDb;
   return yield* Cloudflare.Hyperdrive.Connection("HyperdriveTestEdge", {
     origin: role.origin,
+    dev: role.pooledOrigin,
     // The test asserts read-your-writes across separate HTTP requests;
     // Hyperdrive's query cache (60s default) would serve stale SELECTs.
     caching: { disabled: true },

--- a/packages/alchemy/test/Planetscale/Postgres/fixtures/hyperdrive-worker.ts
+++ b/packages/alchemy/test/Planetscale/Postgres/fixtures/hyperdrive-worker.ts
@@ -29,6 +29,15 @@ export default class HyperdriveWorker extends Cloudflare.Worker<HyperdriveWorker
         const request = yield* HttpServerRequest;
         const url = new URL(request.url, "http://x");
 
+        if (request.method === "GET" && url.pathname === "/hyperdrive") {
+          return yield* HttpServerResponse.json({
+            host: yield* conn.host,
+            port: yield* conn.port,
+            user: yield* conn.user,
+            database: yield* conn.database,
+          });
+        }
+
         if (request.method === "GET" && url.pathname === "/widgets") {
           const widgets = yield* db.select().from(Widgets);
           return yield* HttpServerResponse.json({ widgets });


### PR DESCRIPTION
Closes #716.

### What

Add a `pooledOrigin: PostgresOrigin` attribute to `Planetscale.PostgresRole`, identical to the existing `origin` but on PSBouncer's pooled port (6432) instead of the direct port (5432).

```ts
const role = yield* Planetscale.PostgresRole("DbRole", { database, inheritedRoles: ["postgres"] })

const db = Cloudflare.Hyperdrive.Connection("db", {
  origin: role.origin,        // direct 5432 — Hyperdrive pools at the edge in prod
  dev: role.pooledOrigin,     // PSBouncer 6432 — pooled connection for local dev
})
```

### Why

`PostgresRole` already exposes a structured `origin` so role credentials drop straight into `Cloudflare.Hyperdrive.Connection`. The pooled endpoint is only available as the `connectionUrlPooled` **string** today, so anyone wanting the pooled components for a binding has to re-parse that URL.

The motivating case is the Hyperdrive `dev` origin. In dev Hyperdrive is bypassed and the worker connects to the origin directly; against a real per-stage PlanetScale branch that opens a fresh **direct** (5432) connection per invocation and quickly exhausts the direct-connection limit, taking the dev database down. Pointing `dev` at the pooled (6432) origin fixes it — but only if the resource hands back a structured pooled origin. See #716 for the full failure description.

### Change

- New `pooledOrigin: PostgresOrigin` field on `PostgresRoleAttributes`.
- Populated in the single `buildAttributes` helper (used by both create/update and `list`), mirroring the existing `origin` block with `port: 6432`. Pure derived field — no new API calls, no behavior change to existing attributes.

### Notes

- `PostgresOrigin` is unchanged; `pooledOrigin` reuses it.
- Existing `PostgresRole` tests use `toMatchObject`, so the added field doesn't disturb them. I couldn't run the full local suite from a standalone fork clone (the workspace resolves private `@distilled.cloud/*` packages), so CI here is the real gate — the change is a pure, type-trivial mirror of `origin`.
- Out of scope: `PostgresDefaultRole` currently exposes neither `origin` nor `pooledOrigin` (only URL strings) and could get the same treatment for symmetry — happy to follow up separately if wanted.