### PR TITLE
feat(neon): expose pooled origin

### DIFF
--- a/packages/alchemy/src/Neon/Branch.ts
+++ b/packages/alchemy/src/Neon/Branch.ts
@@ -135,6 +135,11 @@ export type Branch = Resource<
      * when fronting Neon with another pooler like Hyperdrive.
      */
     origin: PostgresOrigin;
+    /**
+     * Parsed pooled connection components. Useful as a Hyperdrive `dev`
+     * origin when local workers bypass Hyperdrive and connect directly.
+     */
+    pooledOrigin: PostgresOrigin;
     migrationsDir: string | undefined;
     migrationsTable: string | undefined;
     migrationsHashes: Record<string, string>;
@@ -270,6 +275,9 @@ export const BranchProvider = () =>
             protected: branch.protected,
             default: branch.default,
             expiresAt: branch.expires_at,
+            pooledOrigin:
+              output.pooledOrigin ??
+              parsePostgresOrigin(output.pooledConnectionUri),
           })),
           Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
         );
@@ -311,6 +319,7 @@ export const BranchProvider = () =>
         connectionUri: conn.uri,
         pooledConnectionUri: conn.pooled,
         origin: parsePostgresOrigin(conn.uri),
+        pooledOrigin: parsePostgresOrigin(conn.pooled),
         migrationsDir: olds?.migrationsDir,
         migrationsTable: olds?.migrationsTable,
         migrationsHashes: {},
@@ -349,6 +358,9 @@ export const BranchProvider = () =>
               connectionUri: output.connectionUri,
               pooledConnectionUri: output.pooledConnectionUri,
               origin: output.origin,
+              pooledOrigin:
+                output.pooledOrigin ??
+                parsePostgresOrigin(output.pooledConnectionUri),
             })),
           )
         : yield* Effect.gen(function* () {
@@ -403,6 +415,7 @@ export const BranchProvider = () =>
               connectionUri: conn.uri,
               pooledConnectionUri: conn.pooled,
               origin: parsePostgresOrigin(conn.uri),
+              pooledOrigin: parsePostgresOrigin(conn.pooled),
             };
           });
 
@@ -542,6 +555,7 @@ const hydrateBranch = (
       connectionUri: conn.uri,
       pooledConnectionUri: conn.pooled,
       origin: parsePostgresOrigin(conn.uri),
+      pooledOrigin: parsePostgresOrigin(conn.pooled),
       migrationsDir: undefined,
       migrationsTable: undefined,
       migrationsHashes: {},

--- a/packages/alchemy/src/Neon/Project.ts
+++ b/packages/alchemy/src/Neon/Project.ts
@@ -147,6 +147,11 @@ export type Project = Resource<
      * when fronting Neon with another pooler like Hyperdrive.
      */
     origin: PostgresOrigin;
+    /**
+     * Parsed pooled connection components. Useful as a Hyperdrive `dev`
+     * origin when local workers bypass Hyperdrive and connect directly.
+     */
+    pooledOrigin: PostgresOrigin;
     historyRetentionSeconds: number;
     enableLogicalReplication: boolean;
     migrationsDir: string | undefined;
@@ -283,6 +288,9 @@ export const ProjectProvider = () =>
           Effect.map(({ project }) => ({
             ...output,
             projectName: project.name,
+            pooledOrigin:
+              output.pooledOrigin ??
+              parsePostgresOrigin(output.pooledConnectionUri),
             historyRetentionSeconds: project.history_retention_seconds,
             enableLogicalReplication:
               project.settings?.enable_logical_replication === true,
@@ -332,6 +340,9 @@ export const ProjectProvider = () =>
               connectionUri: output.connectionUri,
               pooledConnectionUri: output.pooledConnectionUri,
               origin: output.origin,
+              pooledOrigin:
+                output.pooledOrigin ??
+                parsePostgresOrigin(output.pooledConnectionUri),
               historyRetentionSeconds:
                 r.project.history_retention_seconds ??
                 output.historyRetentionSeconds,
@@ -381,6 +392,7 @@ export const ProjectProvider = () =>
               connectionUri: conn.uri,
               pooledConnectionUri: conn.pooled,
               origin: parsePostgresOrigin(conn.uri),
+              pooledOrigin: parsePostgresOrigin(conn.pooled),
               historyRetentionSeconds:
                 created.project.history_retention_seconds ?? 86400,
               enableLogicalReplication:
@@ -664,6 +676,7 @@ const hydrateProjectAttributes = (
       connectionUri: conn.uri,
       pooledConnectionUri: conn.pooled,
       origin: parsePostgresOrigin(conn.uri),
+      pooledOrigin: parsePostgresOrigin(conn.pooled),
       historyRetentionSeconds: project.history_retention_seconds ?? 86400,
       enableLogicalReplication:
         project.settings?.enable_logical_replication === true,

--- a/packages/alchemy/test/Neon/Branch.test.ts
+++ b/packages/alchemy/test/Neon/Branch.test.ts
@@ -13,6 +13,21 @@ const logLevel = Effect.provideService(
   process.env.DEBUG ? "Debug" : "Info",
 );
 
+const expectPooledOrigin = (branch: {
+  pooledConnectionUri: string;
+  pooledOrigin: Neon.PostgresOrigin;
+}) => {
+  const uri = new URL(branch.pooledConnectionUri);
+  expect(branch.pooledOrigin).toMatchObject({
+    scheme: uri.protocol === "postgresql:" ? "postgresql" : "postgres",
+    host: uri.hostname,
+    port: uri.port ? Number(uri.port) : 5432,
+    database: uri.pathname.replace(/^\//, ""),
+    user: decodeURIComponent(uri.username),
+  });
+  expect(branch.pooledOrigin.password).toBeDefined();
+};
+
 // Canonical `list()` test (parent fan-out): branches are scoped to a project
 // and there is no account-wide branch enumeration API, so `list()` enumerates
 // every project and lists+hydrates the branches of each. Deploy a project +
@@ -37,6 +52,8 @@ test.provider("list enumerates the deployed branch", (stack) =>
     expect(found?.projectId).toEqual(project.projectId);
     expect(found?.branchName).toEqual(branch.branchName);
     expect(found?.connectionUri).toContain("postgres");
+    expectPooledOrigin(branch);
+    expectPooledOrigin(found!);
 
     yield* stack.destroy();
   }).pipe(logLevel),
@@ -74,6 +91,7 @@ test.provider(
 
       expect(updated.branch.projectId).toEqual(updated.project.projectId);
       expect(updated.branch.branchId).toEqual(initial.branch.branchId);
+      expectPooledOrigin(updated.branch);
 
       yield* stack.destroy();
     }).pipe(logLevel),

--- a/packages/alchemy/test/Neon/Project.test.ts
+++ b/packages/alchemy/test/Neon/Project.test.ts
@@ -15,6 +15,21 @@ const logLevel = Effect.provideService(
   process.env.DEBUG ? "Debug" : "Info",
 );
 
+const expectPooledOrigin = (project: {
+  pooledConnectionUri: string;
+  pooledOrigin: Neon.PostgresOrigin;
+}) => {
+  const uri = new URL(project.pooledConnectionUri);
+  expect(project.pooledOrigin).toMatchObject({
+    scheme: uri.protocol === "postgresql:" ? "postgresql" : "postgres",
+    host: uri.hostname,
+    port: uri.port ? Number(uri.port) : 5432,
+    database: uri.pathname.replace(/^\//, ""),
+    user: decodeURIComponent(uri.username),
+  });
+  expect(project.pooledOrigin.password).toBeDefined();
+};
+
 test.provider("create and delete project with default props", (stack) =>
   Effect.gen(function* () {
     yield* stack.destroy();
@@ -29,6 +44,8 @@ test.provider("create and delete project with default props", (stack) =>
     expect(project.projectName).toBeDefined();
     expect(project.defaultBranchId).toBeDefined();
     expect(project.connectionUri).toContain("postgres");
+    expect(project.pooledConnectionUri).toContain("postgres");
+    expectPooledOrigin(project);
 
     const fetched = yield* getProject({ project_id: project.projectId });
     expect(fetched.project.id).toEqual(project.projectId);
@@ -49,6 +66,7 @@ test.provider("project with default props does not change on update", (stack) =>
     expect(created.projectName).toBeDefined();
     expect(created.defaultBranchId).toBeDefined();
     expect(created.connectionUri).toContain("postgres");
+    expectPooledOrigin(created);
 
     const fetched = yield* getProject({ project_id: created.projectId });
     expect(fetched.project.id).toEqual(created.projectId);
@@ -59,6 +77,7 @@ test.provider("project with default props does not change on update", (stack) =>
     expect(updated.projectName).toEqual(created.projectName);
     expect(updated.defaultBranchId).toEqual(created.defaultBranchId);
     expect(updated.connectionUri).toEqual(created.connectionUri);
+    expectPooledOrigin(updated);
 
     yield* stack.destroy();
   }).pipe(logLevel),
@@ -112,7 +131,9 @@ test.provider("list enumerates the deployed project", (stack) =>
     const provider = yield* Provider.findProvider(Neon.Project);
     const all = yield* provider.list();
 
-    expect(all.some((p) => p.projectId === deployed.projectId)).toBe(true);
+    const found = all.find((p) => p.projectId === deployed.projectId);
+    expect(found).toBeDefined();
+    expectPooledOrigin(found!);
 
     yield* stack.destroy();
   }).pipe(logLevel),


### PR DESCRIPTION
## Summary
- add parsed `pooledOrigin` attributes to `Neon.Project` and `Neon.Branch`
- derive `pooledOrigin` from the existing pooled connection URI on create, read/adopt, list hydration, and update preservation paths
- extend Neon Project/Branch tests to compare `pooledOrigin` against `pooledConnectionUri`

## Validation
- `bun oxfmt --check packages/alchemy/src/Neon/Project.ts packages/alchemy/src/Neon/Branch.ts packages/alchemy/test/Neon/Project.test.ts packages/alchemy/test/Neon/Branch.test.ts`
- `bun oxlint packages/alchemy/src/Neon/Project.ts packages/alchemy/src/Neon/Branch.ts packages/alchemy/test/Neon/Project.test.ts packages/alchemy/test/Neon/Branch.test.ts`
- `bun -e 'await import("./packages/alchemy/src/Neon/Project.ts"); await import("./packages/alchemy/src/Neon/Branch.ts"); console.log("ok")'`\n\nFocused live tests were attempted with `ALCHEMY_PROFILE=testing bun vitest run test/Neon/Project.test.ts test/Neon/Branch.test.ts`, but this local machine has no Neon credentials configured for the `testing` profile, so the suites fail before exercising the provider code.