### PR TITLE
feat(planetscale): Persist PlanetScale branch replica intent

### DIFF
--- a/packages/alchemy/src/Planetscale/Branch.ts
+++ b/packages/alchemy/src/Planetscale/Branch.ts
@@ -14,6 +14,7 @@ import { ensureMySQLProductionBranchClusterSize } from "./MySQL/MySQLClusterSize
 import {
   ensurePostgresProductionBranchClusterSize,
   toPostgresClusterSku,
+  waitForPendingPostgresChanges,
 } from "./Postgres/PostgresClusterSize.ts";
 import {
   DEFAULT_MIGRATIONS_TABLE,
@@ -105,6 +106,16 @@ export interface BaseBranchAttributes {
   migrationsHashes: Record<string, string>;
   /** Content hashes for the last applied import files. */
   importHashes: Record<string, string>;
+  /**
+   * Desired total replica count requested by the resource input, when known.
+   * PlanetScale's branch read API exposes only boolean HA state, so this is
+   * persisted from Alchemy state rather than observed from live provider data.
+   */
+  desiredReplicas: number | undefined;
+  /** Whether the branch currently has HA replicas. */
+  hasReplicas: boolean | undefined;
+  /** Whether the branch currently has read-only replicas. */
+  hasReadOnlyReplicas: boolean | undefined;
 }
 
 // Runtime-resolved Database/Branch references. `news.database` can be a
@@ -230,6 +241,9 @@ export const makeBranchProvider = <R extends ResourceLike>(opts: {
                           migrationsTable: undefined,
                           migrationsHashes: {},
                           importHashes: {},
+                          desiredReplicas: undefined,
+                          hasReplicas: branch.has_replicas,
+                          hasReadOnlyReplicas: branch.has_read_only_replicas,
                         }) satisfies BaseBranchAttributes,
                     ),
                 ),
@@ -271,6 +285,20 @@ export const makeBranchProvider = <R extends ResourceLike>(opts: {
         news.region.slug !== output.region.slug
       ) {
         return { action: "replace" } as const;
+      }
+
+      if (news.replicas !== undefined) {
+        if (output?.desiredReplicas !== news.replicas) {
+          return { action: "update" } as const;
+        }
+
+        const desiredHasReplicas = news.replicas > 0;
+        if (
+          output?.hasReplicas !== undefined &&
+          output.hasReplicas !== desiredHasReplicas
+        ) {
+          return { action: "update" } as const;
+        }
       }
 
       if (news.migrationsDir) {
@@ -336,6 +364,12 @@ export const makeBranchProvider = <R extends ResourceLike>(opts: {
               migrationsTable: output?.migrationsTable ?? olds?.migrationsTable,
               migrationsHashes: output?.migrationsHashes ?? {},
               importHashes: output?.importHashes ?? {},
+              desiredReplicas:
+                output?.desiredReplicas ??
+                olds?.desiredReplicas ??
+                olds?.replicas,
+              hasReplicas: data.has_replicas,
+              hasReadOnlyReplicas: data.has_read_only_replicas,
             } satisfies BaseBranchAttributes;
 
             return output ? attrs : Unowned(attrs);
@@ -493,6 +527,39 @@ export const makeBranchProvider = <R extends ResourceLike>(opts: {
         }
       }
 
+      if (opts.expectedKind === "postgresql" && news.replicas !== undefined) {
+        const desiredReplicas = news.replicas;
+        const desiredHasReplicas = desiredReplicas > 0;
+        const shouldApplyReplicaChange =
+          current.has_replicas !== desiredHasReplicas ||
+          (desiredHasReplicas && output?.desiredReplicas !== desiredReplicas);
+
+        if (shouldApplyReplicaChange) {
+          yield* waitForPendingPostgresChanges(
+            organization,
+            databaseName,
+            branchName,
+          );
+          const change = yield* planetscale.updateBranchChangeRequest({
+            organization,
+            database: databaseName,
+            branch: branchName,
+            replicas: desiredReplicas,
+          });
+          yield* waitForPendingPostgresChanges(
+            organization,
+            databaseName,
+            branchName,
+            change.id,
+          );
+          current = yield* planetscale.getBranch({
+            organization,
+            database: databaseName,
+            branch: branchName,
+          });
+        }
+      }
+
       // Sync clusterSize — only meaningful on production branches.
       if (news.clusterSize) {
         if (current.kind === "postgresql") {
@@ -559,6 +626,9 @@ export const makeBranchProvider = <R extends ResourceLike>(opts: {
         migrationsTable: news.migrationsDir ? migrationsTable : undefined,
         migrationsHashes,
         importHashes,
+        desiredReplicas: news.replicas ?? output?.desiredReplicas,
+        hasReplicas: updated.has_replicas,
+        hasReadOnlyReplicas: updated.has_read_only_replicas,
       } satisfies BaseBranchAttributes;
     }),
 

--- a/packages/alchemy/src/Planetscale/Postgres/PostgresBranch.ts
+++ b/packages/alchemy/src/Planetscale/Postgres/PostgresBranch.ts
@@ -29,6 +29,12 @@ export interface PostgresBranchProps extends BaseBranchProps {
   clusterSize?: PostgresClusterSize;
 
   /**
+   * Total number of replicas for the branch. `0` creates or converges the
+   * branch to non-HA/single-node; `2+` enables HA.
+   */
+  replicas?: number;
+
+  /**
    * Parent branch — either a string name or another {@link PostgresBranch}.
    * @default "main"
    */

--- a/packages/alchemy/test/Planetscale/Branch.test.ts
+++ b/packages/alchemy/test/Planetscale/Branch.test.ts
@@ -86,7 +86,7 @@ describe.skipIf(!process.env.PLANETSCALE_TEST)("Branch", () => {
     (stack) =>
       Effect.gen(function* () {
         const dbName = process.env.PLANETSCALE_BRANCH_REPLICA_DATABASE!;
-        const branchName = "replica-target";
+        const branchName = `replica-target-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
         const { organization } = yield* yield* Planetscale.Credentials;
 
         yield* Effect.gen(function* () {

--- a/packages/alchemy/test/Planetscale/Branch.test.ts
+++ b/packages/alchemy/test/Planetscale/Branch.test.ts
@@ -78,60 +78,63 @@ test.provider("diff tracks Postgres branch replica intent", () =>
 );
 
 describe.skipIf(!process.env.PLANETSCALE_TEST)("Branch", () => {
-  test.provider.skipIf(!process.env.PLANETSCALE_BRANCH_REPLICA_TEST)(
+  test.provider.skipIf(
+    !process.env.PLANETSCALE_BRANCH_REPLICA_TEST ||
+      !process.env.PLANETSCALE_BRANCH_REPLICA_DATABASE,
+  )(
     "Postgres branch persists replica intent and plans no-op once converged",
     (stack) =>
       Effect.gen(function* () {
-        const dbName = "alchemy-pg-branch-replicas";
+        const dbName = process.env.PLANETSCALE_BRANCH_REPLICA_DATABASE!;
         const branchName = "replica-target";
+        const { organization } = yield* yield* Planetscale.Credentials;
 
-        yield* stack.destroy();
+        yield* Effect.gen(function* () {
+          yield* stack.destroy();
+          yield* deleteBranchIfExists(dbName, branchName, organization);
 
-        const program = Effect.gen(function* () {
-          const database = yield* Planetscale.PostgresDatabase("ReplicaDb", {
-            name: dbName,
-            region: { slug: "us-east" },
-            clusterSize: "PS_10",
-            replicas: 0,
-            arch: "arm",
+          const program = Effect.gen(function* () {
+            const branch = yield* Planetscale.PostgresBranch("ReplicaBranch", {
+              name: branchName,
+              database: dbName,
+              parentBranch: "main",
+              replicas: 0,
+            });
+
+            return { branch };
           });
-          const branch = yield* Planetscale.PostgresBranch("ReplicaBranch", {
+
+          const { branch } = yield* stack.deploy(program);
+
+          expect(branch).toMatchObject({
             name: branchName,
-            database,
-            parentBranch: "main",
-            clusterSize: "PS_10",
-            replicas: 0,
+            database: dbName,
+            desiredReplicas: 0,
+            hasReplicas: false,
+            hasReadOnlyReplicas: false,
           });
 
-          return { database, branch };
-        });
+          const live = yield* ops.getBranch({
+            organization,
+            database: dbName,
+            branch: branchName,
+          });
 
-        const { database, branch } = yield* stack.deploy(program);
+          expect(live.has_replicas).toBe(false);
+          expect(live.has_read_only_replicas).toBe(false);
 
-        expect(branch).toMatchObject({
-          name: branchName,
-          database: dbName,
-          desiredReplicas: 0,
-          hasReplicas: false,
-          hasReadOnlyReplicas: false,
-        });
+          const plan = yield* stack.plan(program);
+          expect(plan.resources.ReplicaBranch).toMatchObject({
+            action: "noop",
+          });
 
-        const live = yield* ops.getBranch({
-          organization: database.organization,
-          database: dbName,
-          branch: branchName,
-        });
-
-        expect(live.has_replicas).toBe(false);
-        expect(live.has_read_only_replicas).toBe(false);
-
-        const plan = yield* stack.plan(program);
-        expect(plan.resources.ReplicaBranch).toMatchObject({
-          action: "noop",
-        });
-
-        yield* stack.destroy();
-        yield* waitForDatabaseToBeDeleted(dbName, database.organization);
+          yield* stack.destroy();
+          yield* waitForBranchToBeDeleted(dbName, branchName, organization);
+        }).pipe(
+          Effect.ensuring(
+            deleteBranchIfExists(dbName, branchName, organization),
+          ),
+        );
       }).pipe(logLevel),
     5_000_000,
   );
@@ -224,4 +227,39 @@ const waitForDatabaseToBeDeleted = Effect.fn(function* (
     );
 });
 
+const waitForBranchToBeDeleted = Effect.fn(function* (
+  database: string,
+  branch: string,
+  organization: string,
+) {
+  yield* ops
+    .getBranch({
+      organization,
+      database,
+      branch,
+    })
+    .pipe(
+      Effect.flatMap(() => Effect.fail(new BranchStillExists())),
+      Effect.retry({
+        while: (e): e is BranchStillExists => e instanceof BranchStillExists,
+        schedule: Schedule.exponential(100),
+      }),
+      Effect.catchTag("NotFound", () => Effect.void),
+    );
+});
+
+const deleteBranchIfExists = (
+  database: string,
+  branch: string,
+  organization: string,
+) =>
+  ops.deleteBranch({ organization, database, branch }).pipe(
+    Effect.catchTag("NotFound", () => Effect.void),
+    Effect.flatMap(() =>
+      waitForBranchToBeDeleted(database, branch, organization),
+    ),
+    Effect.ignore,
+  );
+
+class BranchStillExists extends Data.TaggedError("BranchStillExists") {}
 class DatabaseStillExists extends Data.TaggedError("DatabaseStillExists") {}

--- a/packages/alchemy/test/Planetscale/Branch.test.ts
+++ b/packages/alchemy/test/Planetscale/Branch.test.ts
@@ -78,6 +78,64 @@ test.provider("diff tracks Postgres branch replica intent", () =>
 );
 
 describe.skipIf(!process.env.PLANETSCALE_TEST)("Branch", () => {
+  test.provider.skipIf(!process.env.PLANETSCALE_BRANCH_REPLICA_TEST)(
+    "Postgres branch persists replica intent and plans no-op once converged",
+    (stack) =>
+      Effect.gen(function* () {
+        const dbName = "alchemy-pg-branch-replicas";
+        const branchName = "replica-target";
+
+        yield* stack.destroy();
+
+        const program = Effect.gen(function* () {
+          const database = yield* Planetscale.PostgresDatabase("ReplicaDb", {
+            name: dbName,
+            region: { slug: "us-east" },
+            clusterSize: "PS_10",
+            replicas: 0,
+            arch: "arm",
+          });
+          const branch = yield* Planetscale.PostgresBranch("ReplicaBranch", {
+            name: branchName,
+            database,
+            parentBranch: "main",
+            clusterSize: "PS_10",
+            replicas: 0,
+          });
+
+          return { database, branch };
+        });
+
+        const { database, branch } = yield* stack.deploy(program);
+
+        expect(branch).toMatchObject({
+          name: branchName,
+          database: dbName,
+          desiredReplicas: 0,
+          hasReplicas: false,
+          hasReadOnlyReplicas: false,
+        });
+
+        const live = yield* ops.getBranch({
+          organization: database.organization,
+          database: dbName,
+          branch: branchName,
+        });
+
+        expect(live.has_replicas).toBe(false);
+        expect(live.has_read_only_replicas).toBe(false);
+
+        const plan = yield* stack.plan(program);
+        expect(plan.resources.ReplicaBranch).toMatchObject({
+          action: "noop",
+        });
+
+        yield* stack.destroy();
+        yield* waitForDatabaseToBeDeleted(dbName, database.organization);
+      }).pipe(logLevel),
+    5_000_000,
+  );
+
   // Canonical `list()` test (PARENT FAN-OUT): branches live under a database
   // within the credentialed organization. `list()` enumerates every database
   // in the org, lists each database's branches, and keeps only the engine's

--- a/packages/alchemy/test/Planetscale/Branch.test.ts
+++ b/packages/alchemy/test/Planetscale/Branch.test.ts
@@ -14,6 +14,69 @@ const logLevel = Effect.provideService(
   process.env.DEBUG ? "Debug" : "Info",
 );
 
+const branchOutput = (
+  overrides: Partial<Planetscale.PostgresBranchAttributes> = {},
+): Planetscale.PostgresBranchAttributes => ({
+  name: "branch",
+  organization: "org",
+  database: "database",
+  parentBranch: "main",
+  production: false,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+  htmlUrl: "https://planetscale.com/org/database/branch/branch",
+  region: { slug: "us-east" },
+  migrationsDir: undefined,
+  migrationsTable: undefined,
+  migrationsHashes: {},
+  importHashes: {},
+  desiredReplicas: undefined,
+  hasReplicas: undefined,
+  hasReadOnlyReplicas: undefined,
+  ...overrides,
+});
+
+test.provider("diff tracks Postgres branch replica intent", () =>
+  Effect.gen(function* () {
+    const provider = yield* Provider.findProvider(Planetscale.PostgresBranch);
+    const props = (replicas: number): Planetscale.PostgresBranchProps => ({
+      database: "database",
+      parentBranch: "main",
+      replicas,
+    });
+
+    const alreadyConvergedToNonHa = yield* provider.diff!({
+      id: "Branch",
+      instanceId: "instance",
+      olds: props(0),
+      news: props(0),
+      oldBindings: [],
+      newBindings: [],
+      output: branchOutput({
+        desiredReplicas: 0,
+        hasReplicas: false,
+        hasReadOnlyReplicas: false,
+      }),
+    });
+    expect(alreadyConvergedToNonHa).toBeUndefined();
+
+    const exactHaCountChanged = yield* provider.diff!({
+      id: "Branch",
+      instanceId: "instance",
+      olds: props(2),
+      news: props(3),
+      oldBindings: [],
+      newBindings: [],
+      output: branchOutput({
+        desiredReplicas: 2,
+        hasReplicas: true,
+        hasReadOnlyReplicas: false,
+      }),
+    });
+    expect(exactHaCountChanged).toEqual({ action: "update" });
+  }),
+);
+
 describe.skipIf(!process.env.PLANETSCALE_TEST)("Branch", () => {
   // Canonical `list()` test (PARENT FAN-OUT): branches live under a database
   // within the credentialed organization. `list()` enumerates every database


### PR DESCRIPTION
## Summary

Adds Postgres branch replica support that persists the requested replica count as `desiredReplicas` instead of inferring an exact count from PlanetScale branch read/list responses. PlanetScale exposes only `has_replicas` / `has_read_only_replicas` on branch reads, while `updateBranchChangeRequest` accepts a numeric `replicas` value.

This keeps observed provider state separate from desired intent so:

- `replicas: 0` on an already non-HA branch can converge after state records `desiredReplicas: 0`
- positive count changes such as `2 -> 3` still plan an update even though both live reads only report `has_replicas: true`

## Tests

- `bun vitest run test/Planetscale/Branch.test.ts`
- `bun oxfmt --check packages/alchemy/src/Planetscale/Branch.ts packages/alchemy/src/Planetscale/Postgres/PostgresBranch.ts packages/alchemy/test/Planetscale/Branch.test.ts`
- `git diff --check`
- `bun run --filter alchemy build`

Note: the bundle step emits the existing `cloudflare:workers` unresolved-import warning and exits successfully.

## Live validation

The equivalent Oddlynew fork change was validated against real PlanetScale with `STAGE=alex bun nx deploy vermittelbar-database`: the branch converged with `desiredReplicas: 0`, `hasReplicas: false`, and `hasReadOnlyReplicas: false`, then a follow-up plan returned all no-ops.

This PR also adds an opt-in upstream live fixture guarded by `PLANETSCALE_TEST`, `PLANETSCALE_BRANCH_REPLICA_TEST`, and `PLANETSCALE_BRANCH_REPLICA_DATABASE`. The fixture reuses the explicitly supplied Postgres database, creates and deletes a uniquely named temporary branch inside it, asserts `replicas: 0` persists desired intent and live non-HA state, then asserts the follow-up plan for the branch is `noop`. The fixture is intentionally not part of ordinary CI or the default PlanetScale live suite.

Additional live fixture runs performed from an Oddlynew dev config only:

- `doppler run --project vermittelbar --config dev -- env PLANETSCALE_TEST=1 PLANETSCALE_BRANCH_REPLICA_TEST=1 PLANETSCALE_BRANCH_REPLICA_DATABASE=vermittelbar-staging bun vitest run test/Planetscale/Branch.test.ts -t "Postgres branch persists replica intent"`

After the latest run, `vermittelbar-staging` was verified to have no leftover `replica-target-*` branches.
