### PR TITLE
feat(core): per-resource credential metadata + scope-aware login/create-token

### DIFF
--- a/packages/alchemy/src/AWS/ACM/Certificate.ts
+++ b/packages/alchemy/src/AWS/ACM/Certificate.ts
@@ -288,6 +288,27 @@ export const CertificateProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "acm:RequestCertificate",
+                "acm:DeleteCertificate",
+                "acm:AddTagsToCertificate",
+                "acm:RemoveTagsFromCertificate",
+                "route53:ChangeResourceRecordSets",
+                "route53:GetChange",
+              ],
+              readActions: [
+                "acm:ListCertificates",
+                "acm:DescribeCertificate",
+                "acm:ListTagsForCertificate",
+              ],
+              notes:
+                "ACM calls are pinned to us-east-1. route53:ChangeResourceRecordSets/GetChange are needed only when hostedZoneId is set for automatic DNS validation. RequestCertificate with inline Tags requires acm:AddTagsToCertificate.",
+            },
+          },
+        },
         stables: ["certificateArn"],
         list: () =>
           Effect.gen(function* () {

--- a/packages/alchemy/src/AWS/ApiGateway/Account.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/Account.ts
@@ -50,6 +50,16 @@ export const AccountProvider = () =>
     AccountResource,
     Effect.gen(function* () {
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: ["apigateway:PATCH", "iam:PassRole"],
+              readActions: ["apigateway:GET"],
+              notes:
+                "updateAccount authorizes as apigateway:PATCH on arn:aws:apigateway:{region}::/account. iam:PassRole is required on the CloudWatch logging role whenever `cloudwatchRoleArn` is set (API Gateway assumes that role to push logs). Delete also PATCHes (removes the role) when the stack managed it.",
+            },
+          },
+        },
         diff: Effect.fn(function* ({ news: newsIn, olds, output }) {
           if (!isResolved(newsIn)) return;
           const news = newsIn as AccountProps;

--- a/packages/alchemy/src/AWS/ApiGateway/ApiKey.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/ApiKey.ts
@@ -112,6 +112,21 @@ export const ApiKeyProvider = () =>
     ApiKeyResource,
     Effect.gen(function* () {
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "apigateway:POST",
+                "apigateway:PATCH",
+                "apigateway:PUT",
+                "apigateway:DELETE",
+              ],
+              readActions: ["apigateway:GET"],
+              notes:
+                "Verb-based: createApiKey (POST), updateApiKey (PATCH), deleteApiKey (DELETE), tagResource (PUT) / untagResource (DELETE), getApiKey/getApiKeys reads (GET). Key values are never read back (includeValue(s): false throughout).",
+            },
+          },
+        },
         stables: ["id"] as const,
         diff: Effect.fn(function* ({ news: newsIn, olds }) {
           if (!isResolved(newsIn)) return;

--- a/packages/alchemy/src/AWS/ApiGateway/Authorizer.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/Authorizer.ts
@@ -100,6 +100,21 @@ export const AuthorizerProvider = () =>
     AuthorizerResource,
     Effect.gen(function* () {
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "apigateway:POST",
+                "apigateway:PATCH",
+                "apigateway:DELETE",
+                "iam:PassRole",
+              ],
+              readActions: ["apigateway:GET"],
+              notes:
+                "Verb-based: createAuthorizer (POST), updateAuthorizer (PATCH), deleteAuthorizer (DELETE), get* reads (GET). iam:PassRole is required on the invocation role only when `authorizerCredentials` carries an IAM role ARN (create and the /authorizerCredentials PATCH path).",
+            },
+          },
+        },
         stables: ["authorizerId", "restApiId"] as const,
         diff: Effect.fn(function* ({ news: newsIn, olds }) {
           if (!isResolved(newsIn)) return;

--- a/packages/alchemy/src/AWS/ApiGateway/BasePathMapping.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/BasePathMapping.ts
@@ -60,6 +60,20 @@ export const BasePathMappingProvider = () =>
     BasePathMappingResource,
     Effect.gen(function* () {
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "apigateway:POST",
+                "apigateway:PATCH",
+                "apigateway:DELETE",
+              ],
+              readActions: ["apigateway:GET"],
+              notes:
+                "Verb-based: createBasePathMapping (POST), updateBasePathMapping (PATCH), deleteBasePathMapping (DELETE), get* reads (GET). No tagging surface.",
+            },
+          },
+        },
         stables: ["domainName", "domainNameId", "basePath"] as const,
         diff: Effect.fn(function* ({ news: newsIn, olds }) {
           if (!isResolved(newsIn)) return;

--- a/packages/alchemy/src/AWS/ApiGateway/Deployment.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/Deployment.ts
@@ -205,6 +205,20 @@ export const DeploymentProvider = () =>
     DeploymentResource,
     Effect.gen(function* () {
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "apigateway:POST",
+                "apigateway:PATCH",
+                "apigateway:DELETE",
+              ],
+              readActions: ["apigateway:GET"],
+              notes:
+                "Verb-based: createDeployment (POST), updateDeployment (PATCH), deleteDeployment (DELETE), get* reads (GET). createDeployment with stageName can implicitly create/update a stage; still authorized as POST on /restapis/{id}/deployments.",
+            },
+          },
+        },
         stables: ["deploymentId", "restApiId"] as const,
         // Deployments are sub-resources keyed by `restApiId`. Enumerate every
         // RestApi in the account/region, then page every deployment under each

--- a/packages/alchemy/src/AWS/ApiGateway/DomainName.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/DomainName.ts
@@ -76,6 +76,24 @@ export const DomainNameProvider = () =>
     DomainNameResource,
     Effect.gen(function* () {
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "apigateway:POST",
+                "apigateway:PATCH",
+                "apigateway:PUT",
+                "apigateway:DELETE",
+                "apigateway:AddCertificateToDomain",
+                "apigateway:RemoveCertificateFromDomain",
+                "iam:CreateServiceLinkedRole",
+              ],
+              readActions: ["apigateway:GET"],
+              notes:
+                "Verb-based: createDomainName (POST), updateDomainName (PATCH), deleteDomainName (DELETE), tagResource (PUT) / untagResource (DELETE), get* reads (GET). apigateway:AddCertificateToDomain / RemoveCertificateFromDomain are permission-only actions evaluated when certificateArn/regionalCertificateArn is attached, changed, or removed. iam:CreateServiceLinkedRole (ops.apigateway.amazonaws.com) may fire on the account's first custom domain.",
+            },
+          },
+        },
         stables: ["domainName"] as const,
         diff: Effect.fn(function* ({ news: newsIn, olds }) {
           if (!isResolved(newsIn)) return;

--- a/packages/alchemy/src/AWS/ApiGateway/GatewayResource.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/GatewayResource.ts
@@ -128,6 +128,20 @@ export const ResourceProvider = () =>
     GatewayResource,
     Effect.gen(function* () {
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "apigateway:POST",
+                "apigateway:PATCH",
+                "apigateway:DELETE",
+              ],
+              readActions: ["apigateway:GET"],
+              notes:
+                "API Gateway IAM is verb-based; these map to createResource (POST), updateResource (PATCH), deleteResource (DELETE), and get* reads (GET). No tagging API for path resources.",
+            },
+          },
+        },
         stables: ["resourceId", "restApiId", "parentId"] as const,
         diff: Effect.fn(function* ({ news: newsIn, olds }) {
           if (!isResolved(newsIn)) return;

--- a/packages/alchemy/src/AWS/ApiGateway/GatewayResponse.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/GatewayResponse.ts
@@ -53,6 +53,16 @@ export const GatewayResponseProvider = () =>
     GatewayResponseResource,
     Effect.gen(function* () {
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: ["apigateway:PUT", "apigateway:DELETE"],
+              readActions: ["apigateway:GET"],
+              notes:
+                "Verb-based: putGatewayResponse is a pure upsert (PUT), deleteGatewayResponse (DELETE), get* reads (GET). Reconcile performs no GET — the PUT is unconditional.",
+            },
+          },
+        },
         stables: ["restApiId", "responseType"] as const,
         diff: Effect.fn(function* ({ news: newsIn, olds }) {
           if (!isResolved(newsIn)) return;

--- a/packages/alchemy/src/AWS/ApiGateway/Method.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/Method.ts
@@ -365,6 +365,21 @@ export const MethodProvider = () =>
     MethodResource,
     Effect.gen(function* () {
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "apigateway:PUT",
+                "apigateway:PATCH",
+                "apigateway:DELETE",
+                "iam:PassRole",
+              ],
+              readActions: ["apigateway:GET"],
+              notes:
+                "PUT covers putMethod/putIntegration; PATCH covers updateMethod; DELETE covers deleteMethod/deleteIntegration (reconcile recreates by delete+put when non-patchable fields drift). iam:PassRole is required on the integration credentials role only when `integration.credentials` carries an IAM role ARN.",
+            },
+          },
+        },
         stables: ["restApiId", "resourceId", "httpMethod"] as const,
         diff: Effect.fn(function* ({ news: newsIn, olds }) {
           if (!isResolved(newsIn)) return;

--- a/packages/alchemy/src/AWS/ApiGateway/RestApi.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/RestApi.ts
@@ -301,6 +301,23 @@ export const RestApiProvider = () =>
     RestApi,
     Effect.gen(function* () {
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "apigateway:POST",
+                "apigateway:PATCH",
+                "apigateway:PUT",
+                "apigateway:DELETE",
+                "apigateway:UpdateRestApiPolicy",
+                "iam:CreateServiceLinkedRole",
+              ],
+              readActions: ["apigateway:GET"],
+              notes:
+                "API Gateway IAM is verb-based (GET/POST/PATCH/PUT/DELETE on apigateway ARNs), not per-operation. apigateway:UpdateRestApiPolicy is additionally evaluated whenever the `policy` prop is set (createRestApi with a policy, or a PATCH touching /policy). iam:CreateServiceLinkedRole (ops.apigateway.amazonaws.com) may fire on the account's first API. PUT/DELETE cover tagResource/untagResource.",
+            },
+          },
+        },
         stables: ["restApiId", "rootResourceId"] as const,
         diff: Effect.fn(function* ({ news: newsIn, olds }) {
           if (!isResolved(newsIn)) return;

--- a/packages/alchemy/src/AWS/ApiGateway/Stage.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/Stage.ts
@@ -529,6 +529,22 @@ export const StageProvider = () =>
     StageResource,
     Effect.gen(function* () {
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "apigateway:POST",
+                "apigateway:PATCH",
+                "apigateway:PUT",
+                "apigateway:DELETE",
+                "apigateway:SetWebACL",
+              ],
+              readActions: ["apigateway:GET"],
+              notes:
+                "Verb-based: createStage (POST), updateStage (PATCH), deleteStage (DELETE), tagResource (PUT) / untagResource (DELETE), get* reads (GET). apigateway:SetWebACL is additionally evaluated only when the `webAclArn` prop drives an updateStage PATCH on /webAclArn. Stage access logging requires the account-level CloudWatch role (see AWS.ApiGateway.Account), not extra caller permissions.",
+            },
+          },
+        },
         stables: ["restApiId", "stageName"] as const,
         diff: Effect.fn(function* ({ news: newsIn, olds }) {
           if (!isResolved(newsIn)) return;

--- a/packages/alchemy/src/AWS/ApiGateway/UsagePlan.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/UsagePlan.ts
@@ -237,6 +237,21 @@ export const UsagePlanProvider = () =>
     UsagePlanResource,
     Effect.gen(function* () {
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "apigateway:POST",
+                "apigateway:PATCH",
+                "apigateway:PUT",
+                "apigateway:DELETE",
+              ],
+              readActions: ["apigateway:GET"],
+              notes:
+                "Verb-based: createUsagePlan (POST), updateUsagePlan (PATCH), deleteUsagePlan (DELETE), tagResource (PUT) / untagResource (DELETE), get* reads (GET). Attaching apiStages authorizes as PATCH on the usage plan; no extra per-stage action.",
+            },
+          },
+        },
         stables: ["id"] as const,
         diff: Effect.fn(function* ({ news: newsIn, olds }) {
           if (!isResolved(newsIn)) return;

--- a/packages/alchemy/src/AWS/ApiGateway/UsagePlanKey.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/UsagePlanKey.ts
@@ -53,6 +53,16 @@ export const UsagePlanKeyProvider = () =>
     UsagePlanKeyResource,
     Effect.gen(function* () {
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: ["apigateway:POST", "apigateway:DELETE"],
+              readActions: ["apigateway:GET"],
+              notes:
+                "Verb-based: createUsagePlanKey (POST), deleteUsagePlanKey (DELETE), get* reads (GET). Pure association — no PATCH/PUT paths.",
+            },
+          },
+        },
         stables: ["usagePlanId", "keyId"] as const,
         diff: Effect.fn(function* ({ news: newsIn, olds }) {
           if (!isResolved(newsIn)) return;

--- a/packages/alchemy/src/AWS/ApiGateway/VpcLink.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/VpcLink.ts
@@ -99,6 +99,22 @@ export const VpcLinkProvider = () =>
     VpcLinkResource,
     Effect.gen(function* () {
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "apigateway:POST",
+                "apigateway:PATCH",
+                "apigateway:PUT",
+                "apigateway:DELETE",
+                "iam:CreateServiceLinkedRole",
+              ],
+              readActions: ["apigateway:GET"],
+              notes:
+                "Verb-based: createVpcLink (POST), updateVpcLink (PATCH), deleteVpcLink (DELETE), tagResource (PUT) / untagResource (DELETE), get* reads (GET). iam:CreateServiceLinkedRole (ops.apigateway.amazonaws.com) may fire on the account's first VPC link — API Gateway manages the NLB attachment through its service-linked role, so no elasticloadbalancing:* caller permission is needed.",
+            },
+          },
+        },
         stables: ["vpcLinkId"] as const,
         diff: Effect.fn(function* ({ news: newsIn, olds }) {
           if (!isResolved(newsIn)) return;

--- a/packages/alchemy/src/AWS/AutoScaling/AutoScalingGroup.ts
+++ b/packages/alchemy/src/AWS/AutoScaling/AutoScalingGroup.ts
@@ -262,6 +262,24 @@ export const AutoScalingGroupProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "autoscaling:CreateAutoScalingGroup",
+                "autoscaling:UpdateAutoScalingGroup",
+                "autoscaling:DeleteAutoScalingGroup",
+                "autoscaling:AttachLoadBalancerTargetGroups",
+                "autoscaling:DetachLoadBalancerTargetGroups",
+                "autoscaling:CreateOrUpdateTags",
+                "autoscaling:DeleteTags",
+              ],
+              readActions: ["autoscaling:DescribeAutoScalingGroups"],
+              notes:
+                "First ASG in an account requires iam:CreateServiceLinkedRole (AWSServiceRoleForAutoScaling). When the referenced launch template specifies an instance profile (always true for hosted LaunchTemplates), CreateAutoScalingGroup/UpdateAutoScalingGroup validation additionally requires iam:PassRole on the instance role and ec2:RunInstances on the template.",
+            },
+          },
+        },
         stables: ["autoScalingGroupArn", "autoScalingGroupName"],
         list: () =>
           // `describeAutoScalingGroups` is paginated; collect every page and

--- a/packages/alchemy/src/AWS/AutoScaling/LaunchTemplate.ts
+++ b/packages/alchemy/src/AWS/AutoScaling/LaunchTemplate.ts
@@ -329,6 +329,40 @@ export const LaunchTemplateProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "ec2:CreateLaunchTemplate",
+                "ec2:CreateLaunchTemplateVersion",
+                "ec2:ModifyLaunchTemplate",
+                "ec2:DeleteLaunchTemplate",
+                "ec2:CreateTags",
+                "ec2:DeleteTags",
+                // hosted mode (props.main set): managed instance role/profile
+                "iam:CreateRole",
+                "iam:GetRole",
+                "iam:ListAttachedRolePolicies",
+                "iam:AttachRolePolicy",
+                "iam:DetachRolePolicy",
+                "iam:PutRolePolicy",
+                "iam:DeleteRolePolicy",
+                "iam:CreateInstanceProfile",
+                "iam:GetInstanceProfile",
+                "iam:AddRoleToInstanceProfile",
+                "iam:RemoveRoleFromInstanceProfile",
+                "iam:DeleteInstanceProfile",
+                "iam:DeleteRole",
+                // hosted mode: bundle assets in the shared Assets bucket
+                "s3:PutObject",
+                "s3:DeleteObject",
+              ],
+              readActions: ["ec2:DescribeLaunchTemplates"],
+              notes:
+                "All iam:* and s3:* actions apply only in hosted mode (props.main set), where the provider manages an instance role + instance profile and uploads the bundled program to the shared Assets S3 bucket (s3:CopyObject is covered by s3:PutObject on the destination + s3:GetObject on the source key). The launch-template data embeds an IamInstanceProfile, so consumers launching instances from it (ASG, RunInstances) need iam:PassRole on the managed role.",
+            },
+          },
+        },
         stables: [
           "launchTemplateId",
           "launchTemplateArn",

--- a/packages/alchemy/src/AWS/AutoScaling/ScalingPolicy.ts
+++ b/packages/alchemy/src/AWS/AutoScaling/ScalingPolicy.ts
@@ -129,6 +129,19 @@ export const ScalingPolicyProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "autoscaling:PutScalingPolicy",
+                "autoscaling:DeletePolicy",
+              ],
+              readActions: ["autoscaling:DescribePolicies"],
+              notes:
+                "Target-tracking policies have their CloudWatch alarms created and deleted by the Auto Scaling service itself — no cloudwatch:* actions are needed by the caller.",
+            },
+          },
+        },
         stables: ["policyArn", "policyName", "autoScalingGroupName"],
         // `describePolicies` enumerates every scaling policy across all Auto
         // Scaling Groups in the account/region when no AutoScalingGroupName

--- a/packages/alchemy/src/AWS/CloudFront/CachePolicy.ts
+++ b/packages/alchemy/src/AWS/CloudFront/CachePolicy.ts
@@ -175,6 +175,21 @@ export const CachePolicyProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "cloudfront:CreateCachePolicy",
+                "cloudfront:UpdateCachePolicy",
+                "cloudfront:DeleteCachePolicy",
+              ],
+              readActions: [
+                "cloudfront:GetCachePolicyConfig",
+                "cloudfront:ListCachePolicies",
+              ],
+            },
+          },
+        },
         stables: ["cachePolicyId"],
         diff: Effect.fn(function* ({ id, news, olds }) {
           if (!isResolved(news)) return undefined;

--- a/packages/alchemy/src/AWS/CloudFront/Distribution.ts
+++ b/packages/alchemy/src/AWS/CloudFront/Distribution.ts
@@ -609,6 +609,28 @@ export const DistributionProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "cloudfront:CreateDistributionWithTags",
+                "cloudfront:CreateDistribution",
+                "cloudfront:UpdateDistribution",
+                "cloudfront:DeleteDistribution",
+                "cloudfront:TagResource",
+                "cloudfront:UntagResource",
+              ],
+              readActions: [
+                "cloudfront:GetDistribution",
+                "cloudfront:GetDistributionConfig",
+                "cloudfront:ListDistributions",
+                "cloudfront:ListTagsForResource",
+              ],
+              notes:
+                "CreateDistributionWithTags requires cloudfront:TagResource as a dependent action; the provider falls back to CreateDistribution + TagResource when the WithTags call is AccessDenied, so grant all three.",
+            },
+          },
+        },
         stables: [
           "distributionId",
           "distributionArn",

--- a/packages/alchemy/src/AWS/CloudFront/Function.ts
+++ b/packages/alchemy/src/AWS/CloudFront/Function.ts
@@ -152,6 +152,22 @@ export const FunctionProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "cloudfront:CreateFunction",
+                "cloudfront:UpdateFunction",
+                "cloudfront:PublishFunction",
+                "cloudfront:DeleteFunction",
+              ],
+              readActions: [
+                "cloudfront:DescribeFunction",
+                "cloudfront:ListFunctions",
+              ],
+            },
+          },
+        },
         stables: ["functionArn", "functionName"],
         // CloudFront is global; listFunctions enumerates every function in the
         // account. It is non-paginated in distilled but uses Marker/NextMarker,

--- a/packages/alchemy/src/AWS/CloudFront/Invalidation.ts
+++ b/packages/alchemy/src/AWS/CloudFront/Invalidation.ts
@@ -154,6 +154,16 @@ export const InvalidationProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: ["cloudfront:CreateInvalidation"],
+              readActions: ["cloudfront:GetInvalidation"],
+              notes:
+                "delete is a no-op — invalidations are immutable ledger entries. GetInvalidation is only used for the optional wait-for-completion poll inside reconcile, but it is purely descriptive so it sits in readActions.",
+            },
+          },
+        },
         stables: ["distributionId", "version"],
         // Non-listable: an Invalidation is an ephemeral, immutable ledger entry
         // keyed by {distributionId, invalidationId}. It completes on its own and

--- a/packages/alchemy/src/AWS/CloudFront/KeyGroup.ts
+++ b/packages/alchemy/src/AWS/CloudFront/KeyGroup.ts
@@ -131,6 +131,21 @@ export const KeyGroupProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "cloudfront:CreateKeyGroup",
+                "cloudfront:UpdateKeyGroup",
+                "cloudfront:DeleteKeyGroup",
+              ],
+              readActions: [
+                "cloudfront:GetKeyGroupConfig",
+                "cloudfront:ListKeyGroups",
+              ],
+            },
+          },
+        },
         stables: ["keyGroupId"],
         list: () =>
           Effect.gen(function* () {

--- a/packages/alchemy/src/AWS/CloudFront/KeyValueStore.ts
+++ b/packages/alchemy/src/AWS/CloudFront/KeyValueStore.ts
@@ -95,6 +95,21 @@ export const KeyValueStoreProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "cloudfront:CreateKeyValueStore",
+                "cloudfront:UpdateKeyValueStore",
+                "cloudfront:DeleteKeyValueStore",
+              ],
+              readActions: [
+                "cloudfront:DescribeKeyValueStore",
+                "cloudfront:ListKeyValueStores",
+              ],
+            },
+          },
+        },
         stables: ["keyValueStoreId", "keyValueStoreArn", "keyValueStoreName"],
         diff: Effect.fn(function* ({ id, olds, news: _news }) {
           if (!isResolved(_news)) return undefined;

--- a/packages/alchemy/src/AWS/CloudFront/KvEntries.ts
+++ b/packages/alchemy/src/AWS/CloudFront/KvEntries.ts
@@ -195,6 +195,22 @@ export const KvEntriesProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "cloudfront-keyvaluestore:DescribeKeyValueStore",
+                "cloudfront-keyvaluestore:ListKeys",
+                "cloudfront-keyvaluestore:UpdateKeys",
+                "cloudfront-keyvaluestore:PutKey",
+                "cloudfront-keyvaluestore:DeleteKey",
+              ],
+              readActions: [],
+              notes:
+                "UpdateKeys has dependent actions cloudfront-keyvaluestore:PutKey and cloudfront-keyvaluestore:DeleteKey (batch writes are authorized per key). read/list make no cloud calls, hence empty readActions. Data-plane requests are signed for us-east-1.",
+            },
+          },
+        },
         // Non-listable: a KvEntries resource is a logical group of key/value
         // data keyed entirely by its parent store ARN + namespace (both chosen
         // by the user). There is no account-wide API to enumerate these groups,

--- a/packages/alchemy/src/AWS/CloudFront/KvRoutesUpdate.ts
+++ b/packages/alchemy/src/AWS/CloudFront/KvRoutesUpdate.ts
@@ -226,6 +226,22 @@ export const KvRoutesUpdateProvider = () =>
         );
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "cloudfront-keyvaluestore:DescribeKeyValueStore",
+                "cloudfront-keyvaluestore:GetKey",
+                "cloudfront-keyvaluestore:UpdateKeys",
+                "cloudfront-keyvaluestore:PutKey",
+                "cloudfront-keyvaluestore:DeleteKey",
+              ],
+              readActions: [],
+              notes:
+                "UpdateKeys has dependent actions PutKey and DeleteKey. GetKey/DescribeKeyValueStore are only invoked from reconcile/delete (read/list make no cloud calls). Data-plane requests are signed for us-east-1.",
+            },
+          },
+        },
         // Non-listable: this resource is an update operation that manages a
         // single route entry inside a JSON array stored at a KV store key. It is
         // keyed entirely by {store, namespace, key, entry}; there is no API that

--- a/packages/alchemy/src/AWS/CloudFront/OriginAccessControl.ts
+++ b/packages/alchemy/src/AWS/CloudFront/OriginAccessControl.ts
@@ -142,6 +142,21 @@ export const OriginAccessControlProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "cloudfront:CreateOriginAccessControl",
+                "cloudfront:UpdateOriginAccessControl",
+                "cloudfront:DeleteOriginAccessControl",
+              ],
+              readActions: [
+                "cloudfront:GetOriginAccessControlConfig",
+                "cloudfront:ListOriginAccessControls",
+              ],
+            },
+          },
+        },
         stables: ["originAccessControlId"],
         list: () =>
           Effect.gen(function* () {

--- a/packages/alchemy/src/AWS/CloudFront/OriginRequestPolicy.ts
+++ b/packages/alchemy/src/AWS/CloudFront/OriginRequestPolicy.ts
@@ -154,6 +154,21 @@ export const OriginRequestPolicyProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "cloudfront:CreateOriginRequestPolicy",
+                "cloudfront:UpdateOriginRequestPolicy",
+                "cloudfront:DeleteOriginRequestPolicy",
+              ],
+              readActions: [
+                "cloudfront:GetOriginRequestPolicyConfig",
+                "cloudfront:ListOriginRequestPolicies",
+              ],
+            },
+          },
+        },
         stables: ["originRequestPolicyId"],
         diff: Effect.fn(function* ({ id, news, olds }) {
           if (!isResolved(news)) return undefined;

--- a/packages/alchemy/src/AWS/CloudFront/PublicKey.ts
+++ b/packages/alchemy/src/AWS/CloudFront/PublicKey.ts
@@ -135,6 +135,21 @@ export const PublicKeyProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "cloudfront:CreatePublicKey",
+                "cloudfront:UpdatePublicKey",
+                "cloudfront:DeletePublicKey",
+              ],
+              readActions: [
+                "cloudfront:GetPublicKeyConfig",
+                "cloudfront:ListPublicKeys",
+              ],
+            },
+          },
+        },
         stables: ["publicKeyId", "callerReference"],
         list: () =>
           Effect.gen(function* () {

--- a/packages/alchemy/src/AWS/CloudFront/ResponseHeadersPolicy.ts
+++ b/packages/alchemy/src/AWS/CloudFront/ResponseHeadersPolicy.ts
@@ -200,6 +200,21 @@ export const ResponseHeadersPolicyProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "cloudfront:CreateResponseHeadersPolicy",
+                "cloudfront:UpdateResponseHeadersPolicy",
+                "cloudfront:DeleteResponseHeadersPolicy",
+              ],
+              readActions: [
+                "cloudfront:GetResponseHeadersPolicyConfig",
+                "cloudfront:ListResponseHeadersPolicies",
+              ],
+            },
+          },
+        },
         stables: ["responseHeadersPolicyId"],
         diff: Effect.fn(function* ({ id, news, olds }) {
           if (!isResolved(news)) return undefined;

--- a/packages/alchemy/src/AWS/CloudFront/VpcOrigin.ts
+++ b/packages/alchemy/src/AWS/CloudFront/VpcOrigin.ts
@@ -257,6 +257,27 @@ export const VpcOriginProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "cloudfront:CreateVpcOrigin",
+                "cloudfront:UpdateVpcOrigin",
+                "cloudfront:DeleteVpcOrigin",
+                "cloudfront:TagResource",
+                "cloudfront:UntagResource",
+                "iam:CreateServiceLinkedRole",
+              ],
+              readActions: [
+                "cloudfront:GetVpcOrigin",
+                "cloudfront:ListVpcOrigins",
+                "cloudfront:ListTagsForResource",
+              ],
+              notes:
+                "First CreateVpcOrigin in an account auto-creates the AWSServiceRoleForCloudFrontVPCOrigin service-linked role (iam:CreateServiceLinkedRole). CloudFront's SLR then manages the ENIs in the target VPC; the caller does not need ec2:* directly from this provider's code.",
+            },
+          },
+        },
         stables: ["vpcOriginId", "vpcOriginArn"],
         list: () =>
           Effect.gen(function* () {

--- a/packages/alchemy/src/AWS/CloudWatch/Alarm.ts
+++ b/packages/alchemy/src/AWS/CloudWatch/Alarm.ts
@@ -114,6 +114,22 @@ export const AlarmProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "cloudwatch:PutMetricAlarm",
+                "cloudwatch:DeleteAlarms",
+                "cloudwatch:TagResource",
+                "cloudwatch:UntagResource",
+              ],
+              readActions: [
+                "cloudwatch:DescribeAlarms",
+                "cloudwatch:ListTagsForResource",
+              ],
+            },
+          },
+        },
         stables: ["alarmName", "alarmArn"],
         diff: Effect.fn(function* ({ id, olds = {}, news = {} }) {
           if (!isResolved(news)) return undefined;

--- a/packages/alchemy/src/AWS/CloudWatch/AlarmMuteRule.ts
+++ b/packages/alchemy/src/AWS/CloudWatch/AlarmMuteRule.ts
@@ -103,6 +103,23 @@ export const AlarmMuteRuleProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "cloudwatch:PutAlarmMuteRule",
+                "cloudwatch:DeleteAlarmMuteRule",
+                "cloudwatch:TagResource",
+              ],
+              readActions: [
+                "cloudwatch:GetAlarmMuteRule",
+                "cloudwatch:ListAlarmMuteRules",
+              ],
+              notes:
+                "Tags are passed inline on PutAlarmMuteRule; CloudWatch authorizes tag-on-create as cloudwatch:TagResource.",
+            },
+          },
+        },
         stables: ["alarmMuteRuleName", "alarmMuteRuleArn"],
         diff: Effect.fn(function* ({ id, olds = {}, news = {} }) {
           if (!isResolved(news)) return undefined;

--- a/packages/alchemy/src/AWS/CloudWatch/AnomalyDetector.ts
+++ b/packages/alchemy/src/AWS/CloudWatch/AnomalyDetector.ts
@@ -143,6 +143,17 @@ const describeDetector = Effect.fn(function* (
 
 export const AnomalyDetectorProvider = () =>
   Provider.succeed(AnomalyDetector, {
+    metadata: {
+      aws: {
+        iam: {
+          actions: [
+            "cloudwatch:PutAnomalyDetector",
+            "cloudwatch:DeleteAnomalyDetector",
+          ],
+          readActions: ["cloudwatch:DescribeAnomalyDetectors"],
+        },
+      },
+    },
     stables: ["detectorId"],
     list: () =>
       // `describeAnomalyDetectors` is paginated and account/region-scoped;

--- a/packages/alchemy/src/AWS/CloudWatch/CompositeAlarm.ts
+++ b/packages/alchemy/src/AWS/CloudWatch/CompositeAlarm.ts
@@ -107,6 +107,22 @@ export const CompositeAlarmProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "cloudwatch:PutCompositeAlarm",
+                "cloudwatch:DeleteAlarms",
+                "cloudwatch:TagResource",
+                "cloudwatch:UntagResource",
+              ],
+              readActions: [
+                "cloudwatch:DescribeAlarms",
+                "cloudwatch:ListTagsForResource",
+              ],
+            },
+          },
+        },
         stables: ["alarmName", "alarmArn"],
         diff: Effect.fn(function* ({ id, olds = {}, news = {} }) {
           if (!isResolved(news)) return undefined;

--- a/packages/alchemy/src/AWS/CloudWatch/Dashboard.ts
+++ b/packages/alchemy/src/AWS/CloudWatch/Dashboard.ts
@@ -199,6 +199,20 @@ export const DashboardProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "cloudwatch:PutDashboard",
+                "cloudwatch:DeleteDashboards",
+              ],
+              readActions: [
+                "cloudwatch:GetDashboard",
+                "cloudwatch:ListDashboards",
+              ],
+            },
+          },
+        },
         stables: ["dashboardName", "dashboardArn"],
         diff: Effect.fn(function* ({
           id,

--- a/packages/alchemy/src/AWS/CloudWatch/InsightRule.ts
+++ b/packages/alchemy/src/AWS/CloudWatch/InsightRule.ts
@@ -168,6 +168,22 @@ export const InsightRuleProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "cloudwatch:PutInsightRule",
+                "cloudwatch:DeleteInsightRules",
+                "cloudwatch:TagResource",
+                "cloudwatch:UntagResource",
+              ],
+              readActions: [
+                "cloudwatch:DescribeInsightRules",
+                "cloudwatch:ListTagsForResource",
+              ],
+            },
+          },
+        },
         stables: ["ruleName", "ruleArn"],
         diff: Effect.fn(function* ({
           id,

--- a/packages/alchemy/src/AWS/CloudWatch/MetricStream.ts
+++ b/packages/alchemy/src/AWS/CloudWatch/MetricStream.ts
@@ -148,6 +148,28 @@ export const MetricStreamProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "cloudwatch:PutMetricStream",
+                "cloudwatch:StartMetricStreams",
+                "cloudwatch:StopMetricStreams",
+                "cloudwatch:DeleteMetricStream",
+                "cloudwatch:TagResource",
+                "cloudwatch:UntagResource",
+                "iam:PassRole",
+              ],
+              readActions: [
+                "cloudwatch:GetMetricStream",
+                "cloudwatch:ListMetricStreams",
+                "cloudwatch:ListTagsForResource",
+              ],
+              notes:
+                "iam:PassRole on the Firehose delivery role passed as RoleArn to PutMetricStream.",
+            },
+          },
+        },
         stables: ["metricStreamName", "metricStreamArn"],
         diff: Effect.fn(function* ({
           id,

--- a/packages/alchemy/src/AWS/DynamoDB/Table.ts
+++ b/packages/alchemy/src/AWS/DynamoDB/Table.ts
@@ -945,6 +945,30 @@ export const TableProvider = () =>
       };
 
       return Table.Provider.of({
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "dynamodb:CreateTable",
+                "dynamodb:UpdateTable",
+                "dynamodb:DeleteTable",
+                "dynamodb:UpdateTimeToLive",
+                "dynamodb:UpdateContinuousBackups",
+                "dynamodb:TagResource",
+                "dynamodb:UntagResource",
+              ],
+              readActions: [
+                "dynamodb:ListTables",
+                "dynamodb:DescribeTable",
+                "dynamodb:ListTagsOfResource",
+                "dynamodb:DescribeContinuousBackups",
+                "dynamodb:DescribeTimeToLive",
+              ],
+              notes:
+                "CreateTable with Tags additionally authorizes dynamodb:TagResource. When sseSpecification uses a customer-managed KMS key, the caller and the table need the usual kms:* grants on that key (not issued by this provider directly).",
+            },
+          },
+        },
         stables: ["tableName", "tableId", "tableArn"],
         // Enumerate every table in the ambient account/region. `listTables`
         // returns only names, so each is hydrated to the full Attributes shape

--- a/packages/alchemy/src/AWS/EC2/EIP.ts
+++ b/packages/alchemy/src/AWS/EC2/EIP.ts
@@ -184,6 +184,19 @@ export const EIPProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "ec2:AllocateAddress",
+                "ec2:CreateTags",
+                "ec2:DeleteTags",
+                "ec2:ReleaseAddress",
+              ],
+              readActions: ["ec2:DescribeAddresses"],
+            },
+          },
+        },
         stables: ["allocationId", "eipArn", "publicIp"],
 
         list: () =>

--- a/packages/alchemy/src/AWS/EC2/EgressOnlyInternetGateway.ts
+++ b/packages/alchemy/src/AWS/EC2/EgressOnlyInternetGateway.ts
@@ -180,6 +180,22 @@ export const EgressOnlyInternetGatewayProvider = () =>
         );
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "ec2:CreateEgressOnlyInternetGateway",
+                "ec2:CreateTags",
+                "ec2:DeleteTags",
+                "ec2:DeleteEgressOnlyInternetGateway",
+              ],
+              readActions: [
+                "ec2:DescribeEgressOnlyInternetGateways",
+                "ec2:DescribeTags",
+              ],
+            },
+          },
+        },
         stables: [
           "egressOnlyInternetGatewayId",
           "egressOnlyInternetGatewayArn",

--- a/packages/alchemy/src/AWS/EC2/Instance.ts
+++ b/packages/alchemy/src/AWS/EC2/Instance.ts
@@ -572,6 +572,43 @@ export const InstanceProvider = () =>
       };
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "ec2:RunInstances",
+                "ec2:ModifyInstanceAttribute",
+                "ec2:StopInstances",
+                "ec2:StartInstances",
+                "ec2:RebootInstances",
+                "ec2:TerminateInstances",
+                "ec2:CreateTags",
+                "ec2:DeleteTags",
+                // host mode (props.main set) — managed role/profile + asset upload
+                "iam:CreateRole",
+                "iam:GetRole",
+                "iam:DeleteRole",
+                "iam:PutRolePolicy",
+                "iam:DeleteRolePolicy",
+                "iam:AttachRolePolicy",
+                "iam:DetachRolePolicy",
+                "iam:ListAttachedRolePolicies",
+                "iam:CreateInstanceProfile",
+                "iam:GetInstanceProfile",
+                "iam:DeleteInstanceProfile",
+                "iam:AddRoleToInstanceProfile",
+                "iam:RemoveRoleFromInstanceProfile",
+                "iam:PassRole",
+                "s3:PutObject",
+                "s3:CopyObject",
+                "s3:DeleteObject",
+              ],
+              readActions: ["ec2:DescribeInstances", "ec2:DescribeImages"],
+              notes:
+                "iam:PassRole is required because RunInstances launches with an instance profile in host mode. iam:*/s3:* actions apply only when `main` is set (hosted runtime); s3 objects live under the alchemy Assets bucket prefix `ec2/{unit}/*`. ec2:DescribeImages is used by the Image.ts AMI-lookup helpers (amazonLinux2023() etc.) commonly passed as `imageId`.",
+            },
+          },
+        },
         stables: ["instanceId", "instanceArn", "vpcId", "subnetId"],
         list: () =>
           Effect.gen(function* () {

--- a/packages/alchemy/src/AWS/EC2/InternetGateway.ts
+++ b/packages/alchemy/src/AWS/EC2/InternetGateway.ts
@@ -142,6 +142,21 @@ export const InternetGatewayProvider = () =>
     InternetGateway,
     Effect.gen(function* () {
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "ec2:CreateInternetGateway",
+                "ec2:AttachInternetGateway",
+                "ec2:DetachInternetGateway",
+                "ec2:CreateTags",
+                "ec2:DeleteTags",
+                "ec2:DeleteInternetGateway",
+              ],
+              readActions: ["ec2:DescribeInternetGateways"],
+            },
+          },
+        },
         stables: ["internetGatewayId", "internetGatewayArn", "ownerId"],
 
         list: () =>

--- a/packages/alchemy/src/AWS/EC2/KeyPair.ts
+++ b/packages/alchemy/src/AWS/EC2/KeyPair.ts
@@ -133,6 +133,20 @@ export const KeyPairProvider = () =>
         );
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "ec2:CreateKeyPair",
+                "ec2:ImportKeyPair",
+                "ec2:CreateTags",
+                "ec2:DeleteTags",
+                "ec2:DeleteKeyPair",
+              ],
+              readActions: ["ec2:DescribeKeyPairs"],
+            },
+          },
+        },
         stables: ["keyPairId", "keyName", "keyType"],
 
         // Generated key pairs are immutable except for tags. A changed name /

--- a/packages/alchemy/src/AWS/EC2/NatGateway.ts
+++ b/packages/alchemy/src/AWS/EC2/NatGateway.ts
@@ -312,6 +312,19 @@ export const NatGatewayProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "ec2:CreateNatGateway",
+                "ec2:CreateTags",
+                "ec2:DeleteTags",
+                "ec2:DeleteNatGateway",
+              ],
+              readActions: ["ec2:DescribeNatGateways", "ec2:DescribeTags"],
+            },
+          },
+        },
         stables: ["natGatewayId", "natGatewayArn", "vpcId"],
 
         read: Effect.fn(function* ({ id, output }) {

--- a/packages/alchemy/src/AWS/EC2/NetworkAcl.ts
+++ b/packages/alchemy/src/AWS/EC2/NetworkAcl.ts
@@ -218,6 +218,19 @@ export const NetworkAclProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "ec2:CreateNetworkAcl",
+                "ec2:CreateTags",
+                "ec2:DeleteTags",
+                "ec2:DeleteNetworkAcl",
+              ],
+              readActions: ["ec2:DescribeNetworkAcls"],
+            },
+          },
+        },
         stables: ["networkAclId", "networkAclArn", "ownerId", "isDefault"],
 
         read: Effect.fn(function* ({ output }) {

--- a/packages/alchemy/src/AWS/EC2/NetworkAclAssociation.ts
+++ b/packages/alchemy/src/AWS/EC2/NetworkAclAssociation.ts
@@ -104,6 +104,14 @@ export const NetworkAclAssociationProvider = () =>
           );
 
       return NetworkAclAssociation.Provider.of({
+        metadata: {
+          aws: {
+            iam: {
+              actions: ["ec2:ReplaceNetworkAclAssociation"],
+              readActions: ["ec2:DescribeNetworkAcls", "ec2:DescribeSubnets"],
+            },
+          },
+        },
         stables: ["subnetId"],
 
         // NACL associations are embedded in describeNetworkAcls. Each NetworkAcl

--- a/packages/alchemy/src/AWS/EC2/NetworkAclEntry.ts
+++ b/packages/alchemy/src/AWS/EC2/NetworkAclEntry.ts
@@ -251,6 +251,18 @@ export const NetworkAclEntryProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "ec2:CreateNetworkAclEntry",
+                "ec2:ReplaceNetworkAclEntry",
+                "ec2:DeleteNetworkAclEntry",
+              ],
+              readActions: ["ec2:DescribeNetworkAcls"],
+            },
+          },
+        },
         stables: [],
 
         // Entries are embedded in describeNetworkAcls (each NetworkAcl owns an

--- a/packages/alchemy/src/AWS/EC2/Route.ts
+++ b/packages/alchemy/src/AWS/EC2/Route.ts
@@ -305,6 +305,18 @@ export const RouteProvider = () =>
     Route,
     Effect.gen(function* () {
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "ec2:CreateRoute",
+                "ec2:ReplaceRoute",
+                "ec2:DeleteRoute",
+              ],
+              readActions: ["ec2:DescribeRouteTables"],
+            },
+          },
+        },
         diff: Effect.fn(function* ({ news, olds }) {
           if (!isResolved(news)) return;
           // Route table change requires replacement

--- a/packages/alchemy/src/AWS/EC2/RouteTable.ts
+++ b/packages/alchemy/src/AWS/EC2/RouteTable.ts
@@ -249,6 +249,19 @@ export const RouteTableProvider = () =>
     RouteTable,
     Effect.gen(function* () {
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "ec2:CreateRouteTable",
+                "ec2:CreateTags",
+                "ec2:DeleteTags",
+                "ec2:DeleteRouteTable",
+              ],
+              readActions: ["ec2:DescribeRouteTables"],
+            },
+          },
+        },
         stables: ["routeTableId", "ownerId", "routeTableArn", "vpcId"],
 
         list: () =>

--- a/packages/alchemy/src/AWS/EC2/RouteTableAssociation.ts
+++ b/packages/alchemy/src/AWS/EC2/RouteTableAssociation.ts
@@ -144,6 +144,18 @@ export const RouteTableAssociationProvider = () =>
     RouteTableAssociation,
     Effect.gen(function* () {
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "ec2:AssociateRouteTable",
+                "ec2:ReplaceRouteTableAssociation",
+                "ec2:DisassociateRouteTable",
+              ],
+              readActions: ["ec2:DescribeRouteTables"],
+            },
+          },
+        },
         stables: ["associationId", "subnetId", "gatewayId"],
 
         // Associations are embedded in describeRouteTables — each RouteTable

--- a/packages/alchemy/src/AWS/EC2/SecurityGroup.ts
+++ b/packages/alchemy/src/AWS/EC2/SecurityGroup.ts
@@ -459,6 +459,26 @@ export const SecurityGroupProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "ec2:CreateSecurityGroup",
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:AuthorizeSecurityGroupEgress",
+                "ec2:RevokeSecurityGroupIngress",
+                "ec2:RevokeSecurityGroupEgress",
+                "ec2:CreateTags",
+                "ec2:DeleteTags",
+                "ec2:DeleteSecurityGroup",
+              ],
+              readActions: [
+                "ec2:DescribeSecurityGroups",
+                "ec2:DescribeSecurityGroupRules",
+              ],
+            },
+          },
+        },
         stables: ["groupId", "groupArn", "ownerId"],
 
         read: Effect.fn(function* ({ output }) {

--- a/packages/alchemy/src/AWS/EC2/SecurityGroupRule.ts
+++ b/packages/alchemy/src/AWS/EC2/SecurityGroupRule.ts
@@ -338,6 +338,22 @@ export const SecurityGroupRuleProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:AuthorizeSecurityGroupEgress",
+                "ec2:ModifySecurityGroupRules",
+                "ec2:RevokeSecurityGroupIngress",
+                "ec2:RevokeSecurityGroupEgress",
+                "ec2:CreateTags",
+                "ec2:DeleteTags",
+              ],
+              readActions: ["ec2:DescribeSecurityGroupRules"],
+            },
+          },
+        },
         stables: ["securityGroupRuleId", "groupOwnerId"],
 
         read: Effect.fn(function* ({ output }) {

--- a/packages/alchemy/src/AWS/EC2/Subnet.ts
+++ b/packages/alchemy/src/AWS/EC2/Subnet.ts
@@ -355,6 +355,20 @@ export const SubnetProvider = () =>
     Subnet,
     Effect.gen(function* () {
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "ec2:CreateSubnet",
+                "ec2:ModifySubnetAttribute",
+                "ec2:CreateTags",
+                "ec2:DeleteTags",
+                "ec2:DeleteSubnet",
+              ],
+              readActions: ["ec2:DescribeSubnets"],
+            },
+          },
+        },
         stables: ["subnetId", "subnetArn", "ownerId", "vpcId"],
         diff: Effect.fn(function* ({ news, olds }) {
           if (!isResolved(news)) return;

--- a/packages/alchemy/src/AWS/EC2/Vpc.ts
+++ b/packages/alchemy/src/AWS/EC2/Vpc.ts
@@ -370,6 +370,20 @@ export const VpcProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "ec2:CreateVpc",
+                "ec2:ModifyVpcAttribute",
+                "ec2:CreateTags",
+                "ec2:DeleteTags",
+                "ec2:DeleteVpc",
+              ],
+              readActions: ["ec2:DescribeVpcs", "ec2:DescribeVpcAttribute"],
+            },
+          },
+        },
         stables: ["vpcId", "vpcArn", "ownerId", "isDefault"],
         diff: Effect.fn(function* ({ news, olds }) {
           if (!isResolved(news)) return;

--- a/packages/alchemy/src/AWS/EC2/VpcEndpoint.ts
+++ b/packages/alchemy/src/AWS/EC2/VpcEndpoint.ts
@@ -375,6 +375,20 @@ export const VpcEndpointProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "ec2:CreateVpcEndpoint",
+                "ec2:ModifyVpcEndpoint",
+                "ec2:CreateTags",
+                "ec2:DeleteTags",
+                "ec2:DeleteVpcEndpoints",
+              ],
+              readActions: ["ec2:DescribeVpcEndpoints"],
+            },
+          },
+        },
         stables: ["vpcEndpointId", "vpcEndpointArn", "ownerId"],
 
         read: Effect.fn(function* ({ output }) {

--- a/packages/alchemy/src/AWS/ECR/Repository.ts
+++ b/packages/alchemy/src/AWS/ECR/Repository.ts
@@ -87,6 +87,26 @@ export const RepositoryProvider = () =>
             });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "ecr:CreateRepository",
+                "ecr:PutLifecyclePolicy",
+                "ecr:TagResource",
+                "ecr:UntagResource",
+                "ecr:DeleteRepository",
+              ],
+              readActions: [
+                "ecr:DescribeRepositories",
+                "ecr:ListTagsForResource",
+                "ecr:GetLifecyclePolicy",
+              ],
+              notes:
+                "delete uses force:true, which removes all images in the repository via ecr:DeleteRepository alone (no per-image ecr:BatchDeleteImage needed).",
+            },
+          },
+        },
         stables: [
           "repositoryArn",
           "repositoryName",

--- a/packages/alchemy/src/AWS/ECS/CapacityProvider.ts
+++ b/packages/alchemy/src/AWS/ECS/CapacityProvider.ts
@@ -158,6 +158,23 @@ export const CapacityProviderProvider = () =>
           );
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "ecs:CreateCapacityProvider",
+                "ecs:UpdateCapacityProvider",
+                "ecs:TagResource",
+                "ecs:UntagResource",
+                "ecs:DeleteCapacityProvider",
+                "iam:CreateServiceLinkedRole",
+              ],
+              readActions: ["ecs:DescribeCapacityProviders"],
+              notes:
+                "The referenced Auto Scaling Group is user-supplied (autoScalingGroupArn prop) — no autoscaling:* actions are called by this provider. iam:CreateServiceLinkedRole covers the AWSServiceRoleForECS SLR that createCapacityProvider requires on first use.",
+            },
+          },
+        },
         stables: ["capacityProviderArn", "name"],
 
         diff: Effect.fn(function* ({ id, news, olds }) {

--- a/packages/alchemy/src/AWS/ECS/Cluster.ts
+++ b/packages/alchemy/src/AWS/ECS/Cluster.ts
@@ -115,6 +115,24 @@ export const ClusterProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "ecs:CreateCluster",
+                "ecs:UpdateCluster",
+                "ecs:PutClusterCapacityProviders",
+                "ecs:TagResource",
+                "ecs:UntagResource",
+                "ecs:DeleteCluster",
+                "iam:CreateServiceLinkedRole",
+              ],
+              readActions: ["ecs:DescribeClusters", "ecs:ListClusters"],
+              notes:
+                "iam:CreateServiceLinkedRole is required the first time ecs:CreateCluster runs in an account (AWS auto-creates AWSServiceRoleForECS).",
+            },
+          },
+        },
         stables: ["clusterArn", "clusterName"],
         diff: Effect.fn(function* ({ id, olds, news }) {
           if (!isResolved(news)) return;

--- a/packages/alchemy/src/AWS/ECS/Service.ts
+++ b/packages/alchemy/src/AWS/ECS/Service.ts
@@ -545,6 +545,35 @@ export const ServiceProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "ecs:CreateService",
+                "ecs:UpdateService",
+                "ecs:DeleteService",
+                "ecs:TagResource",
+                "ecs:UntagResource",
+                "elasticloadbalancing:CreateLoadBalancer",
+                "elasticloadbalancing:CreateTargetGroup",
+                "elasticloadbalancing:CreateListener",
+                "elasticloadbalancing:AddTags",
+                "elasticloadbalancing:DeleteListener",
+                "elasticloadbalancing:DeleteTargetGroup",
+                "elasticloadbalancing:DeleteLoadBalancer",
+                "iam:CreateServiceLinkedRole",
+                "iam:PassRole",
+              ],
+              readActions: [
+                "ecs:DescribeServices",
+                "ecs:ListServices",
+                "ecs:ListClusters",
+              ],
+              notes:
+                "elasticloadbalancing:* actions are only exercised when `public: true` (Alchemy-managed ALB); elasticloadbalancing:AddTags is required because CreateLoadBalancer/CreateTargetGroup are called with Tags. iam:CreateServiceLinkedRole covers both AWSServiceRoleForECS and AWSServiceRoleForElasticLoadBalancing on first use. iam:PassRole is required on the task/execution roles referenced by the deployed task definition (checked by ecs:CreateService/UpdateService) and on the `role` prop when set (CLB path).",
+            },
+          },
+        },
         stables: ["serviceArn", "serviceName", "clusterArn"],
         diff: Effect.fn(function* ({ id, olds, news }) {
           if (!isResolved(news)) return;

--- a/packages/alchemy/src/AWS/ECS/Task.ts
+++ b/packages/alchemy/src/AWS/ECS/Task.ts
@@ -883,6 +883,49 @@ await Effect.runPromise(program).catch((err) => {
       };
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "ecs:RegisterTaskDefinition",
+                "ecs:DeregisterTaskDefinition",
+                "ecs:TagResource",
+                "ecs:UntagResource",
+                "ecr:CreateRepository",
+                "ecr:DeleteRepository",
+                "ecr:GetAuthorizationToken",
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:InitiateLayerUpload",
+                "ecr:UploadLayerPart",
+                "ecr:CompleteLayerUpload",
+                "ecr:PutImage",
+                "ecr:BatchGetImage",
+                "logs:CreateLogGroup",
+                "logs:TagResource",
+                "logs:DeleteLogGroup",
+                "iam:CreateRole",
+                "iam:TagRole",
+                "iam:GetRole",
+                "iam:AttachRolePolicy",
+                "iam:DetachRolePolicy",
+                "iam:PutRolePolicy",
+                "iam:DeleteRolePolicy",
+                "iam:ListRolePolicies",
+                "iam:ListAttachedRolePolicies",
+                "iam:DeleteRole",
+                "iam:PassRole",
+              ],
+              readActions: [
+                "ecs:DescribeTaskDefinition",
+                "ecs:ListTaskDefinitions",
+                "ecs:ListTagsForResource",
+                "ecr:DescribeRepositories",
+              ],
+              notes:
+                "Bundling and the Docker image build are local-only; the push to ECR is authorized by ecr:GetAuthorizationToken plus the layer-upload/PutImage actions (the token inherits the caller's IAM permissions). iam:TagRole is needed because createRole is called with Tags; logs:TagResource because createLogGroup is called with tags. iam:PassRole on the created task/execution roles is required for ecs:RegisterTaskDefinition consumers (RunTask/CreateService) and is commonly enforced at registration by org policies — grant it on the roles this provider creates. iam:ListRolePolicies/ListAttachedRolePolicies are List* but are used only by delete, so they stay in actions.",
+            },
+          },
+        },
         stables: [
           "repositoryName",
           "repositoryUri",

--- a/packages/alchemy/src/AWS/EKS/AccessEntry.ts
+++ b/packages/alchemy/src/AWS/EKS/AccessEntry.ts
@@ -97,6 +97,29 @@ export const AccessEntry = Resource<AccessEntry>("AWS.EKS.AccessEntry");
 
 export const AccessEntryProvider = () =>
   Provider.succeed(AccessEntry, {
+    metadata: {
+      aws: {
+        iam: {
+          actions: [
+            "eks:CreateAccessEntry",
+            "eks:UpdateAccessEntry",
+            "eks:DeleteAccessEntry",
+            "eks:AssociateAccessPolicy",
+            "eks:DisassociateAccessPolicy",
+            "eks:TagResource",
+            "eks:UntagResource",
+          ],
+          readActions: [
+            "eks:DescribeAccessEntry",
+            "eks:ListAccessEntries",
+            "eks:ListAssociatedAccessPolicies",
+            "eks:ListClusters",
+          ],
+          notes:
+            "The principalArn is referenced (not assumed or passed as an execution role), so no iam:PassRole is needed. This resource grants Kubernetes access — treat write actions as privilege-escalating.",
+        },
+      },
+    },
     stables: ["accessEntryArn"],
     diff: Effect.fn(function* ({ olds, news }) {
       if (!isResolved(news)) return;

--- a/packages/alchemy/src/AWS/EKS/Addon.ts
+++ b/packages/alchemy/src/AWS/EKS/Addon.ts
@@ -166,6 +166,27 @@ export const AddonProvider = () =>
         });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "eks:CreateAddon",
+                "eks:UpdateAddon",
+                "eks:DeleteAddon",
+                "eks:TagResource",
+                "eks:UntagResource",
+                "iam:PassRole",
+              ],
+              readActions: [
+                "eks:DescribeAddon",
+                "eks:ListAddons",
+                "eks:ListClusters",
+              ],
+              notes:
+                "iam:PassRole is only exercised when serviceAccountRoleArn (IRSA) or podIdentityAssociations (which pass role ARNs) are set on create/update.",
+            },
+          },
+        },
         stables: ["addonArn"],
         // Add-ons are keyed by (clusterName, addonName) and `listAddons`
         // requires a cluster. Enumerate every cluster, list its add-ons,

--- a/packages/alchemy/src/AWS/EKS/Cluster.ts
+++ b/packages/alchemy/src/AWS/EKS/Cluster.ts
@@ -399,6 +399,30 @@ export const ClusterProvider = () =>
           );
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "eks:CreateCluster",
+                "eks:UpdateClusterConfig",
+                "eks:UpdateClusterVersion",
+                "eks:DescribeUpdate",
+                "eks:TagResource",
+                "eks:UntagResource",
+                "eks:DeleteCluster",
+                "iam:PassRole",
+                "iam:CreateServiceLinkedRole",
+              ],
+              readActions: [
+                "eks:DescribeCluster",
+                "eks:ListClusters",
+                "eks:ListTagsForResource",
+              ],
+              notes:
+                "iam:PassRole is required on the cluster role (roleArn) and, for Auto Mode, the node role (computeConfig.nodeRoleArn). iam:CreateServiceLinkedRole covers the AWSServiceRoleForAmazonEKS SLR auto-created on first CreateCluster. Kubernetes-object bindings are applied over the cluster's Kubernetes API using an STS-presigned GetCallerIdentity token (sts:GetCallerIdentity is implicitly allowed for any principal) — the *deploying* principal must additionally have Kubernetes RBAC on the cluster (e.g. via an AccessEntry or bootstrapClusterCreatorAdminPermissions), which is not an IAM action. eks:DescribeUpdate is listed under actions (not readActions) because it is only exercised by reconcile/delete update-polling.",
+            },
+          },
+        },
         stables: ["clusterArn", "clusterName"],
         // Enumerate every cluster in the ambient account/region. `listClusters`
         // returns only names, so we paginate it exhaustively then hydrate each

--- a/packages/alchemy/src/AWS/EKS/PodIdentityAssociation.ts
+++ b/packages/alchemy/src/AWS/EKS/PodIdentityAssociation.ts
@@ -99,6 +99,27 @@ export const PodIdentityAssociationProvider = () =>
         });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "eks:CreatePodIdentityAssociation",
+                "eks:UpdatePodIdentityAssociation",
+                "eks:DeletePodIdentityAssociation",
+                "eks:TagResource",
+                "eks:UntagResource",
+                "iam:PassRole",
+              ],
+              readActions: [
+                "eks:DescribePodIdentityAssociation",
+                "eks:ListPodIdentityAssociations",
+                "eks:ListClusters",
+              ],
+              notes:
+                "iam:PassRole is required on roleArn (and targetRoleArn when set) for Create/UpdatePodIdentityAssociation. The role's trust policy must allow pods.eks.amazonaws.com, but establishing that trust is the role resource's concern, not this provider's.",
+            },
+          },
+        },
         stables: ["associationArn", "associationId"],
         // `list()` enumerates every pod identity association across the
         // account/region. The list op is cluster-scoped, so first enumerate all

--- a/packages/alchemy/src/AWS/ELBv2/Listener.ts
+++ b/packages/alchemy/src/AWS/ELBv2/Listener.ts
@@ -222,6 +222,24 @@ const desiredMutualAuth = (
 
 export const ListenerProvider = () =>
   Provider.succeed(Listener, {
+    metadata: {
+      aws: {
+        iam: {
+          actions: [
+            "elasticloadbalancing:CreateListener",
+            "elasticloadbalancing:ModifyListener",
+            "elasticloadbalancing:AddListenerCertificates",
+            "elasticloadbalancing:RemoveListenerCertificates",
+            "elasticloadbalancing:DeleteListener",
+          ],
+          readActions: [
+            "elasticloadbalancing:DescribeListeners",
+            "elasticloadbalancing:DescribeLoadBalancers",
+            "elasticloadbalancing:DescribeListenerCertificates",
+          ],
+        },
+      },
+    },
     stables: ["listenerArn", "loadBalancerArn"],
     diff: Effect.fn(function* ({ olds, news }) {
       if (!isResolved(news)) return;

--- a/packages/alchemy/src/AWS/ELBv2/ListenerRule.ts
+++ b/packages/alchemy/src/AWS/ELBv2/ListenerRule.ts
@@ -98,6 +98,26 @@ export const ListenerRule = Resource<ListenerRule>("AWS.ELBv2.ListenerRule");
 
 export const ListenerRuleProvider = () =>
   Provider.succeed(ListenerRule, {
+    metadata: {
+      aws: {
+        iam: {
+          actions: [
+            "elasticloadbalancing:CreateRule",
+            "elasticloadbalancing:ModifyRule",
+            "elasticloadbalancing:SetRulePriorities",
+            "elasticloadbalancing:AddTags",
+            "elasticloadbalancing:RemoveTags",
+            "elasticloadbalancing:DeleteRule",
+          ],
+          readActions: [
+            "elasticloadbalancing:DescribeRules",
+            "elasticloadbalancing:DescribeListeners",
+            "elasticloadbalancing:DescribeLoadBalancers",
+            "elasticloadbalancing:DescribeTags",
+          ],
+        },
+      },
+    },
     stables: ["ruleArn", "listenerArn"],
     diff: Effect.fn(function* ({ olds, news }) {
       if (!isResolved(news)) return;

--- a/packages/alchemy/src/AWS/ELBv2/LoadBalancer.ts
+++ b/packages/alchemy/src/AWS/ELBv2/LoadBalancer.ts
@@ -140,6 +140,28 @@ export const LoadBalancerProvider = () =>
           : createPhysicalName({ id, maxLength: 32, lowercase: true });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "elasticloadbalancing:CreateLoadBalancer",
+                "elasticloadbalancing:SetSubnets",
+                "elasticloadbalancing:SetSecurityGroups",
+                "elasticloadbalancing:SetIpAddressType",
+                "elasticloadbalancing:ModifyLoadBalancerAttributes",
+                "elasticloadbalancing:AddTags",
+                "elasticloadbalancing:RemoveTags",
+                "elasticloadbalancing:DeleteLoadBalancer",
+              ],
+              readActions: [
+                "elasticloadbalancing:DescribeLoadBalancers",
+                "elasticloadbalancing:DescribeTags",
+              ],
+              notes:
+                "First load balancer in an account requires iam:CreateServiceLinkedRole (AWSServiceRoleForElasticLoadBalancing).",
+            },
+          },
+        },
         stables: [
           "loadBalancerArn",
           "loadBalancerName",

--- a/packages/alchemy/src/AWS/ELBv2/TargetGroup.ts
+++ b/packages/alchemy/src/AWS/ELBv2/TargetGroup.ts
@@ -133,6 +133,24 @@ export const TargetGroupProvider = () =>
           : createPhysicalName({ id, maxLength: 32, lowercase: true });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "elasticloadbalancing:CreateTargetGroup",
+                "elasticloadbalancing:ModifyTargetGroup",
+                "elasticloadbalancing:ModifyTargetGroupAttributes",
+                "elasticloadbalancing:AddTags",
+                "elasticloadbalancing:RemoveTags",
+                "elasticloadbalancing:DeleteTargetGroup",
+              ],
+              readActions: [
+                "elasticloadbalancing:DescribeTargetGroups",
+                "elasticloadbalancing:DescribeTags",
+              ],
+            },
+          },
+        },
         stables: ["targetGroupArn", "targetGroupName", "vpcId"],
         diff: Effect.fn(function* ({ id, olds, news }) {
           if (!isResolved(news)) return;

--- a/packages/alchemy/src/AWS/ELBv2/TrustStore.ts
+++ b/packages/alchemy/src/AWS/ELBv2/TrustStore.ts
@@ -99,6 +99,26 @@ export const TrustStoreProvider = () =>
         });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "elasticloadbalancing:CreateTrustStore",
+                "elasticloadbalancing:ModifyTrustStore",
+                "elasticloadbalancing:AddTags",
+                "elasticloadbalancing:RemoveTags",
+                "elasticloadbalancing:DeleteTrustStore",
+                "s3:GetObject",
+              ],
+              readActions: [
+                "elasticloadbalancing:DescribeTrustStores",
+                "elasticloadbalancing:DescribeTags",
+              ],
+              notes:
+                "CreateTrustStore/ModifyTrustStore read the CA bundle from S3 using the caller's permissions: s3:GetObject on the bundle object (plus s3:GetObjectVersion when caCertificatesBundleS3ObjectVersion is set).",
+            },
+          },
+        },
         stables: ["trustStoreArn", "name"],
         diff: Effect.fn(function* ({ id, olds, news }) {
           if (!isResolved(news)) return;

--- a/packages/alchemy/src/AWS/EventBridge/EventBus.ts
+++ b/packages/alchemy/src/AWS/EventBridge/EventBus.ts
@@ -132,6 +132,26 @@ export const EventBusProvider = () =>
         });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "events:CreateEventBus",
+                "events:UpdateEventBus",
+                "events:TagResource",
+                "events:UntagResource",
+                "events:DeleteEventBus",
+              ],
+              readActions: [
+                "events:DescribeEventBus",
+                "events:ListEventBuses",
+                "events:ListTagsForResource",
+              ],
+              notes:
+                "events:UpdateEventBus runs on every reconcile (unconditional full-PUT sync). When kmsKeyIdentifier is set, the caller needs kms:DescribeKey (and the key policy must allow EventBridge) per AWS docs — not called directly by this provider.",
+            },
+          },
+        },
         stables: ["eventBusName", "eventBusArn"],
         diff: Effect.fn(function* ({ id, news, olds }) {
           if (!isResolved(news)) return;

--- a/packages/alchemy/src/AWS/EventBridge/Permission.ts
+++ b/packages/alchemy/src/AWS/EventBridge/Permission.ts
@@ -74,6 +74,14 @@ export const PermissionProvider = () =>
       type PermissionAttrs = { statementId: string; eventBusName: string };
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: ["events:PutPermission", "events:RemovePermission"],
+              readActions: ["events:ListEventBuses", "events:DescribeEventBus"],
+            },
+          },
+        },
         stables: ["statementId", "eventBusName"],
         list: () =>
           Effect.gen(function* () {

--- a/packages/alchemy/src/AWS/EventBridge/Rule.ts
+++ b/packages/alchemy/src/AWS/EventBridge/Rule.ts
@@ -283,6 +283,30 @@ export const RuleProvider = () =>
       };
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "events:PutRule",
+                "events:PutTargets",
+                "events:RemoveTargets",
+                "events:TagResource",
+                "events:UntagResource",
+                "events:DeleteRule",
+                "iam:PassRole",
+              ],
+              readActions: [
+                "events:DescribeRule",
+                "events:ListRules",
+                "events:ListEventBuses",
+                "events:ListTargetsByRule",
+                "events:ListTagsForResource",
+              ],
+              notes:
+                "iam:PassRole is needed when props.roleArn is set on the rule or when any target specifies RoleArn (e.g. ECS task targets); pattern-matched Lambda/SQS targets that authorize via resource policy don't need it.",
+            },
+          },
+        },
         stables: ["ruleName", "ruleArn", "eventBusName"],
         diff: Effect.fn(function* ({ id, news, olds }) {
           if (!isResolved(news)) return;

--- a/packages/alchemy/src/AWS/IAM/AccessKey.ts
+++ b/packages/alchemy/src/AWS/IAM/AccessKey.ts
@@ -61,6 +61,22 @@ export const AccessKey = Resource<AccessKey>("AWS.IAM.AccessKey");
 
 export const AccessKeyProvider = () =>
   Provider.succeed(AccessKey, {
+    metadata: {
+      aws: {
+        iam: {
+          actions: [
+            "iam:CreateAccessKey",
+            "iam:UpdateAccessKey",
+            "iam:DeleteAccessKey",
+          ],
+          readActions: [
+            "iam:ListAccessKeys",
+            "iam:GetAccessKeyLastUsed",
+            "iam:ListUsers",
+          ],
+        },
+      },
+    },
     stables: ["accessKeyId"],
     diff: Effect.fn(function* ({ olds, news }) {
       if (!isResolved(news)) return;

--- a/packages/alchemy/src/AWS/IAM/AccountAlias.ts
+++ b/packages/alchemy/src/AWS/IAM/AccountAlias.ts
@@ -45,6 +45,14 @@ const readAccountAlias = Effect.gen(function* () {
 
 export const AccountAliasProvider = () =>
   Provider.succeed(AccountAlias, {
+    metadata: {
+      aws: {
+        iam: {
+          actions: ["iam:CreateAccountAlias", "iam:DeleteAccountAlias"],
+          readActions: ["iam:ListAccountAliases"],
+        },
+      },
+    },
     stables: ["accountAlias"],
     diff: Effect.fn(function* ({ olds, news }) {
       if (!isResolved(news)) return;

--- a/packages/alchemy/src/AWS/IAM/AccountPasswordPolicy.ts
+++ b/packages/alchemy/src/AWS/IAM/AccountPasswordPolicy.ts
@@ -40,6 +40,17 @@ export const AccountPasswordPolicy = Resource<AccountPasswordPolicy>(
 
 export const AccountPasswordPolicyProvider = () =>
   Provider.succeed(AccountPasswordPolicy, {
+    metadata: {
+      aws: {
+        iam: {
+          actions: [
+            "iam:UpdateAccountPasswordPolicy",
+            "iam:DeleteAccountPasswordPolicy",
+          ],
+          readActions: ["iam:GetAccountPasswordPolicy"],
+        },
+      },
+    },
     read: Effect.fn(function* () {
       const response = yield* iam
         .getAccountPasswordPolicy({})

--- a/packages/alchemy/src/AWS/IAM/Group.ts
+++ b/packages/alchemy/src/AWS/IAM/Group.ts
@@ -192,6 +192,28 @@ export const GroupProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "iam:CreateGroup",
+                "iam:AttachGroupPolicy",
+                "iam:DetachGroupPolicy",
+                "iam:PutGroupPolicy",
+                "iam:DeleteGroupPolicy",
+                "iam:RemoveUserFromGroup",
+                "iam:DeleteGroup",
+              ],
+              readActions: [
+                "iam:GetGroup",
+                "iam:ListGroups",
+                "iam:ListGroupPolicies",
+                "iam:GetGroupPolicy",
+                "iam:ListAttachedGroupPolicies",
+              ],
+            },
+          },
+        },
         stables: ["groupArn", "groupName", "groupId"],
         // IAM is global (no region). Enumerate every group via the paginated
         // `listGroups`, then hydrate each into the full `read` Attributes shape

--- a/packages/alchemy/src/AWS/IAM/GroupMembership.ts
+++ b/packages/alchemy/src/AWS/IAM/GroupMembership.ts
@@ -62,6 +62,14 @@ export const GroupMembership = Resource<GroupMembership>(
 
 export const GroupMembershipProvider = () =>
   Provider.succeed(GroupMembership, {
+    metadata: {
+      aws: {
+        iam: {
+          actions: ["iam:AddUserToGroup", "iam:RemoveUserFromGroup"],
+          readActions: ["iam:GetGroup", "iam:ListGroups"],
+        },
+      },
+    },
     stables: ["groupName"],
     diff: Effect.fn(function* ({ olds, news }) {
       if (!isResolved(news)) return;

--- a/packages/alchemy/src/AWS/IAM/InstanceProfile.ts
+++ b/packages/alchemy/src/AWS/IAM/InstanceProfile.ts
@@ -127,6 +127,27 @@ export const InstanceProfileProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "iam:CreateInstanceProfile",
+                "iam:AddRoleToInstanceProfile",
+                "iam:RemoveRoleFromInstanceProfile",
+                "iam:TagInstanceProfile",
+                "iam:UntagInstanceProfile",
+                "iam:DeleteInstanceProfile",
+                "iam:PassRole",
+              ],
+              readActions: [
+                "iam:GetInstanceProfile",
+                "iam:ListInstanceProfiles",
+              ],
+              notes:
+                "iam:PassRole on the attached role is required by AddRoleToInstanceProfile (the API reference states the caller must hold PassRole on the role).",
+            },
+          },
+        },
         stables: [
           "instanceProfileArn",
           "instanceProfileName",

--- a/packages/alchemy/src/AWS/IAM/LoginProfile.ts
+++ b/packages/alchemy/src/AWS/IAM/LoginProfile.ts
@@ -59,6 +59,18 @@ export const LoginProfile = Resource<LoginProfile>("AWS.IAM.LoginProfile");
 
 export const LoginProfileProvider = () =>
   Provider.succeed(LoginProfile, {
+    metadata: {
+      aws: {
+        iam: {
+          actions: [
+            "iam:CreateLoginProfile",
+            "iam:UpdateLoginProfile",
+            "iam:DeleteLoginProfile",
+          ],
+          readActions: ["iam:GetLoginProfile", "iam:ListUsers"],
+        },
+      },
+    },
     stables: ["userName"],
     diff: Effect.fn(function* ({ olds, news }) {
       if (!isResolved(news)) return;

--- a/packages/alchemy/src/AWS/IAM/OpenIDConnectProvider.ts
+++ b/packages/alchemy/src/AWS/IAM/OpenIDConnectProvider.ts
@@ -120,6 +120,26 @@ export const OpenIDConnectProviderProvider = () =>
         );
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "iam:CreateOpenIDConnectProvider",
+                "iam:AddClientIDToOpenIDConnectProvider",
+                "iam:RemoveClientIDFromOpenIDConnectProvider",
+                "iam:UpdateOpenIDConnectProviderThumbprint",
+                "iam:TagOpenIDConnectProvider",
+                "iam:UntagOpenIDConnectProvider",
+                "iam:DeleteOpenIDConnectProvider",
+              ],
+              readActions: [
+                "iam:GetOpenIDConnectProvider",
+                "iam:ListOpenIDConnectProviders",
+                "iam:ListOpenIDConnectProviderTags",
+              ],
+            },
+          },
+        },
         stables: ["openIDConnectProviderArn"],
         // IAM is global; `listOpenIDConnectProviders` returns ARNs only, so
         // hydrate each into the full Attributes shape `read` produces.

--- a/packages/alchemy/src/AWS/IAM/Policy.ts
+++ b/packages/alchemy/src/AWS/IAM/Policy.ts
@@ -181,6 +181,28 @@ export const PolicyProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "iam:CreatePolicy",
+                "iam:CreatePolicyVersion",
+                "iam:DeletePolicyVersion",
+                "iam:SetDefaultPolicyVersion",
+                "iam:TagPolicy",
+                "iam:UntagPolicy",
+                "iam:DeletePolicy",
+              ],
+              readActions: [
+                "iam:GetPolicy",
+                "iam:GetPolicyVersion",
+                "iam:ListPolicies",
+                "iam:ListPolicyVersions",
+                "iam:ListPolicyTags",
+              ],
+            },
+          },
+        },
         stables: ["policyArn", "policyName", "policyId"],
         list: () =>
           Effect.gen(function* () {

--- a/packages/alchemy/src/AWS/IAM/Role.ts
+++ b/packages/alchemy/src/AWS/IAM/Role.ts
@@ -298,6 +298,34 @@ export const RoleProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "iam:CreateRole",
+                "iam:UpdateRole",
+                "iam:UpdateAssumeRolePolicy",
+                "iam:PutRolePermissionsBoundary",
+                "iam:DeleteRolePermissionsBoundary",
+                "iam:AttachRolePolicy",
+                "iam:DetachRolePolicy",
+                "iam:PutRolePolicy",
+                "iam:DeleteRolePolicy",
+                "iam:TagRole",
+                "iam:UntagRole",
+                "iam:DeleteRole",
+              ],
+              readActions: [
+                "iam:GetRole",
+                "iam:ListRoles",
+                "iam:ListRolePolicies",
+                "iam:GetRolePolicy",
+                "iam:ListAttachedRolePolicies",
+                "iam:ListRoleTags",
+              ],
+            },
+          },
+        },
         stables: ["roleArn", "roleName"],
         list: () =>
           Effect.gen(function* () {

--- a/packages/alchemy/src/AWS/IAM/SAMLProvider.ts
+++ b/packages/alchemy/src/AWS/IAM/SAMLProvider.ts
@@ -83,6 +83,24 @@ const isTransientWriteError = (error: {
 
 export const SAMLProviderProvider = () =>
   Provider.succeed(SAMLProvider, {
+    metadata: {
+      aws: {
+        iam: {
+          actions: [
+            "iam:CreateSAMLProvider",
+            "iam:UpdateSAMLProvider",
+            "iam:TagSAMLProvider",
+            "iam:UntagSAMLProvider",
+            "iam:DeleteSAMLProvider",
+          ],
+          readActions: [
+            "iam:GetSAMLProvider",
+            "iam:ListSAMLProviders",
+            "iam:ListSAMLProviderTags",
+          ],
+        },
+      },
+    },
     stables: ["samlProviderArn"],
     diff: Effect.fn(function* ({ olds, news }) {
       if (!isResolved(news)) return;

--- a/packages/alchemy/src/AWS/IAM/SSHPublicKey.ts
+++ b/packages/alchemy/src/AWS/IAM/SSHPublicKey.ts
@@ -60,6 +60,22 @@ export const SSHPublicKey = Resource<SSHPublicKey>("AWS.IAM.SSHPublicKey");
 
 export const SSHPublicKeyProvider = () =>
   Provider.succeed(SSHPublicKey, {
+    metadata: {
+      aws: {
+        iam: {
+          actions: [
+            "iam:UploadSSHPublicKey",
+            "iam:UpdateSSHPublicKey",
+            "iam:DeleteSSHPublicKey",
+          ],
+          readActions: [
+            "iam:GetSSHPublicKey",
+            "iam:ListSSHPublicKeys",
+            "iam:ListUsers",
+          ],
+        },
+      },
+    },
     stables: ["sshPublicKeyId"],
     diff: Effect.fn(function* ({ olds, news }) {
       if (!isResolved(news)) return;

--- a/packages/alchemy/src/AWS/IAM/ServerCertificate.ts
+++ b/packages/alchemy/src/AWS/IAM/ServerCertificate.ts
@@ -107,6 +107,23 @@ export const ServerCertificateProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "iam:UploadServerCertificate",
+                "iam:TagServerCertificate",
+                "iam:UntagServerCertificate",
+                "iam:DeleteServerCertificate",
+              ],
+              readActions: [
+                "iam:GetServerCertificate",
+                "iam:ListServerCertificates",
+                "iam:ListServerCertificateTags",
+              ],
+            },
+          },
+        },
         stables: [
           "serverCertificateArn",
           "serverCertificateName",

--- a/packages/alchemy/src/AWS/IAM/ServiceSpecificCredential.ts
+++ b/packages/alchemy/src/AWS/IAM/ServiceSpecificCredential.ts
@@ -74,6 +74,18 @@ export const ServiceSpecificCredential = Resource<ServiceSpecificCredential>(
 
 export const ServiceSpecificCredentialProvider = () =>
   Provider.succeed(ServiceSpecificCredential, {
+    metadata: {
+      aws: {
+        iam: {
+          actions: [
+            "iam:CreateServiceSpecificCredential",
+            "iam:UpdateServiceSpecificCredential",
+            "iam:DeleteServiceSpecificCredential",
+          ],
+          readActions: ["iam:ListServiceSpecificCredentials", "iam:ListUsers"],
+        },
+      },
+    },
     stables: ["serviceSpecificCredentialId"],
     list: Effect.fn(function* () {
       // Service-specific credentials are owned per IAM user and IAM is a

--- a/packages/alchemy/src/AWS/IAM/SigningCertificate.ts
+++ b/packages/alchemy/src/AWS/IAM/SigningCertificate.ts
@@ -61,6 +61,18 @@ export const SigningCertificate = Resource<SigningCertificate>(
 
 export const SigningCertificateProvider = () =>
   Provider.succeed(SigningCertificate, {
+    metadata: {
+      aws: {
+        iam: {
+          actions: [
+            "iam:UploadSigningCertificate",
+            "iam:UpdateSigningCertificate",
+            "iam:DeleteSigningCertificate",
+          ],
+          readActions: ["iam:ListSigningCertificates", "iam:ListUsers"],
+        },
+      },
+    },
     stables: ["certificateId"],
     // IAM is a global service. `listSigningCertificates` requires a `UserName`,
     // so we enumerate every IAM user first (paginated) and then list each

--- a/packages/alchemy/src/AWS/IAM/User.ts
+++ b/packages/alchemy/src/AWS/IAM/User.ts
@@ -212,6 +212,32 @@ export const UserProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "iam:CreateUser",
+                "iam:PutUserPermissionsBoundary",
+                "iam:DeleteUserPermissionsBoundary",
+                "iam:AttachUserPolicy",
+                "iam:DetachUserPolicy",
+                "iam:PutUserPolicy",
+                "iam:DeleteUserPolicy",
+                "iam:TagUser",
+                "iam:UntagUser",
+                "iam:DeleteUser",
+              ],
+              readActions: [
+                "iam:GetUser",
+                "iam:ListUsers",
+                "iam:ListUserPolicies",
+                "iam:GetUserPolicy",
+                "iam:ListAttachedUserPolicies",
+                "iam:ListUserTags",
+              ],
+            },
+          },
+        },
         stables: ["userArn", "userName", "userId"],
         list: () =>
           Effect.gen(function* () {

--- a/packages/alchemy/src/AWS/IAM/VirtualMFADevice.ts
+++ b/packages/alchemy/src/AWS/IAM/VirtualMFADevice.ts
@@ -124,6 +124,25 @@ export const VirtualMFADeviceProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "iam:CreateVirtualMFADevice",
+                "iam:EnableMFADevice",
+                "iam:DeactivateMFADevice",
+                "iam:TagMFADevice",
+                "iam:UntagMFADevice",
+                "iam:DeleteVirtualMFADevice",
+              ],
+              readActions: [
+                "iam:GetMFADevice",
+                "iam:ListVirtualMFADevices",
+                "iam:ListMFADeviceTags",
+              ],
+            },
+          },
+        },
         stables: ["serialNumber"],
         list: () =>
           Effect.gen(function* () {

--- a/packages/alchemy/src/AWS/IdentityCenter/AccountAssignment.ts
+++ b/packages/alchemy/src/AWS/IdentityCenter/AccountAssignment.ts
@@ -75,6 +75,26 @@ export const AccountAssignmentProvider = () =>
     AccountAssignment,
     Effect.gen(function* () {
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "sso:CreateAccountAssignment",
+                "sso:DeleteAccountAssignment",
+                "sso:DescribeAccountAssignmentCreationStatus",
+                "sso:DescribeAccountAssignmentDeletionStatus",
+              ],
+              readActions: [
+                "sso:ListInstances",
+                "sso:ListPermissionSets",
+                "sso:ListAccountsForProvisionedPermissionSet",
+                "sso:ListAccountAssignments",
+              ],
+              notes:
+                "The two Describe*Status actions are only used by reconcile/delete async polling, so they are classified as full-lifecycle actions. Creating an assignment causes Identity Center to provision the permission set into the target account via its own service-linked role; no extra IAM actions are needed on the deploying principal.",
+            },
+          },
+        },
         stables: [
           "instanceArn",
           "permissionSetArn",

--- a/packages/alchemy/src/AWS/IdentityCenter/Group.ts
+++ b/packages/alchemy/src/AWS/IdentityCenter/Group.ts
@@ -64,6 +64,22 @@ export const GroupProvider = () =>
     Group,
     Effect.gen(function* () {
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "identitystore:CreateGroup",
+                "identitystore:UpdateGroup",
+                "identitystore:DeleteGroup",
+              ],
+              readActions: [
+                "sso:ListInstances",
+                "identitystore:ListGroups",
+                "identitystore:DescribeGroup",
+              ],
+            },
+          },
+        },
         stables: ["identityStoreId", "groupId"],
         list: () =>
           Effect.gen(function* () {

--- a/packages/alchemy/src/AWS/IdentityCenter/Instance.ts
+++ b/packages/alchemy/src/AWS/IdentityCenter/Instance.ts
@@ -84,6 +84,20 @@ export const InstanceProvider = () =>
     Instance,
     Effect.gen(function* () {
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "sso:CreateInstance",
+                "sso:DeleteInstance",
+                "iam:CreateServiceLinkedRole",
+              ],
+              readActions: ["sso:ListInstances"],
+              notes:
+                "CreateInstance/DeleteInstance are only invoked in mode: 'account'; mode: 'existing' (the default) is adopt-only and needs just sso:ListInstances. Enabling an Identity Center instance implicitly creates the AWSServiceRoleForSSO service-linked role (iam:CreateServiceLinkedRole for sso.amazonaws.com). Organization instances cannot be created via API and must be enabled manually in the management account.",
+            },
+          },
+        },
         stables: ["instanceArn", "identityStoreId", "ownerAccountId", "mode"],
         // Enumerate every Identity Center instance visible to the calling
         // account (organization + account instances). `ListInstances` is

--- a/packages/alchemy/src/AWS/IdentityCenter/PermissionSet.ts
+++ b/packages/alchemy/src/AWS/IdentityCenter/PermissionSet.ts
@@ -69,6 +69,22 @@ export const PermissionSetProvider = () =>
     PermissionSet,
     Effect.gen(function* () {
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "sso:CreatePermissionSet",
+                "sso:UpdatePermissionSet",
+                "sso:DeletePermissionSet",
+              ],
+              readActions: [
+                "sso:ListInstances",
+                "sso:ListPermissionSets",
+                "sso:DescribePermissionSet",
+              ],
+            },
+          },
+        },
         stables: ["permissionSetArn", "instanceArn"],
         list: () =>
           Effect.gen(function* () {

--- a/packages/alchemy/src/AWS/KMS/Alias.ts
+++ b/packages/alchemy/src/AWS/KMS/Alias.ts
@@ -57,6 +57,21 @@ export const Alias = Resource<Alias>("AWS.KMS.Alias");
 
 export const AliasProvider = () =>
   Provider.succeed(Alias, {
+    metadata: {
+      aws: {
+        iam: {
+          actions: [
+            "kms:CreateAlias",
+            "kms:UpdateAlias",
+            "kms:DeleteAlias",
+            "kms:DescribeKey",
+          ],
+          readActions: ["kms:ListAliases"],
+          notes:
+            "kms:DescribeKey is called during reconcile to canonicalize the target key ID, so it is classified as a full-lifecycle action. CreateAlias/UpdateAlias/DeleteAlias must be allowed on BOTH the alias and the target KMS key resource in ARN-scoped policies.",
+        },
+      },
+    },
     stables: ["aliasName", "aliasArn"],
     list: () =>
       Effect.gen(function* () {

--- a/packages/alchemy/src/AWS/KMS/Key.ts
+++ b/packages/alchemy/src/AWS/KMS/Key.ts
@@ -132,6 +132,34 @@ const defaultDeletionWindowInDays = 30;
 
 export const KeyProvider = () =>
   Provider.succeed(Key, {
+    metadata: {
+      aws: {
+        iam: {
+          actions: [
+            "kms:CreateKey",
+            "kms:CancelKeyDeletion",
+            "kms:UpdateKeyDescription",
+            "kms:EnableKey",
+            "kms:DisableKey",
+            "kms:PutKeyPolicy",
+            "kms:EnableKeyRotation",
+            "kms:DisableKeyRotation",
+            "kms:TagResource",
+            "kms:UntagResource",
+            "kms:ScheduleKeyDeletion",
+          ],
+          readActions: [
+            "kms:ListKeys",
+            "kms:DescribeKey",
+            "kms:ListResourceTags",
+            "kms:GetKeyRotationStatus",
+            "kms:GetKeyPolicy",
+          ],
+          notes:
+            "Delete only schedules deletion (ScheduleKeyDeletion with the configured waiting period); the key is not destroyed immediately. PutKeyPolicy with bypassPolicyLockoutSafetyCheck can lock the caller out — the default key policy path needs no extra actions.",
+        },
+      },
+    },
     stables: ["keyId", "keyArn"],
     list: () =>
       Effect.gen(function* () {

--- a/packages/alchemy/src/AWS/Kinesis/Stream.ts
+++ b/packages/alchemy/src/AWS/Kinesis/Stream.ts
@@ -442,6 +442,38 @@ export const StreamProvider = () =>
     Stream,
     Effect.gen(function* () {
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "kinesis:CreateStream",
+                "kinesis:UpdateStreamMode",
+                "kinesis:UpdateShardCount",
+                "kinesis:IncreaseStreamRetentionPeriod",
+                "kinesis:DecreaseStreamRetentionPeriod",
+                "kinesis:StartStreamEncryption",
+                "kinesis:StopStreamEncryption",
+                "kinesis:EnableEnhancedMonitoring",
+                "kinesis:DisableEnhancedMonitoring",
+                "kinesis:UpdateStreamWarmThroughput",
+                "kinesis:UpdateMaxRecordSize",
+                "kinesis:AddTagsToStream",
+                "kinesis:RemoveTagsFromStream",
+                "kinesis:PutResourcePolicy",
+                "kinesis:DeleteResourcePolicy",
+                "kinesis:DeleteStream",
+              ],
+              readActions: [
+                "kinesis:ListStreams",
+                "kinesis:DescribeStreamSummary",
+                "kinesis:ListTagsForResource",
+                "kinesis:GetResourcePolicy",
+              ],
+              notes:
+                "StartStreamEncryption defaults to alias/aws/kinesis; a customer-managed key additionally requires kms grants (kms:DescribeKey, kms:CreateGrant on the key) for the caller per AWS docs. deleteStream sets EnforceConsumerDeletion, which also tears down registered consumers.",
+            },
+          },
+        },
         stables: ["streamName", "streamArn"],
         // Enumerate every stream in the ambient account/region. `listStreams`
         // is paginated; collect every page exhaustively, then hydrate each

--- a/packages/alchemy/src/AWS/Kinesis/StreamConsumer.ts
+++ b/packages/alchemy/src/AWS/Kinesis/StreamConsumer.ts
@@ -235,6 +235,24 @@ const waitForConsumerDeleted = (consumerArn: string) =>
 
 export const StreamConsumerProvider = () =>
   Provider.succeed(StreamConsumer, {
+    metadata: {
+      aws: {
+        iam: {
+          actions: [
+            "kinesis:RegisterStreamConsumer",
+            "kinesis:DeregisterStreamConsumer",
+            "kinesis:TagResource",
+            "kinesis:UntagResource",
+          ],
+          readActions: [
+            "kinesis:DescribeStreamConsumer",
+            "kinesis:ListStreamConsumers",
+            "kinesis:ListStreams",
+            "kinesis:ListTagsForResource",
+          ],
+        },
+      },
+    },
     stables: ["consumerArn", "consumerName"],
     read: Effect.fn(function* ({ id, olds, output }) {
       const consumerName =

--- a/packages/alchemy/src/AWS/Lambda/Alias.ts
+++ b/packages/alchemy/src/AWS/Lambda/Alias.ts
@@ -163,6 +163,22 @@ export const AliasProvider = () =>
       };
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "lambda:CreateAlias",
+                "lambda:UpdateAlias",
+                "lambda:DeleteAlias",
+              ],
+              readActions: [
+                "lambda:GetAlias",
+                "lambda:ListAliases",
+                "lambda:ListFunctions",
+              ],
+            },
+          },
+        },
         stables: ["aliasArn", "aliasName", "functionName"],
         diff: Effect.fn(function* ({ id, olds, news }) {
           if (!isResolved(news)) return;

--- a/packages/alchemy/src/AWS/Lambda/EventSourceMapping.ts
+++ b/packages/alchemy/src/AWS/Lambda/EventSourceMapping.ts
@@ -576,6 +576,26 @@ export const EventSourceMappingProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "lambda:CreateEventSourceMapping",
+                "lambda:UpdateEventSourceMapping",
+                "lambda:DeleteEventSourceMapping",
+                "lambda:TagResource",
+                "lambda:UntagResource",
+              ],
+              readActions: [
+                "lambda:GetEventSourceMapping",
+                "lambda:ListEventSourceMappings",
+                "lambda:ListTags",
+              ],
+              notes:
+                "Read access to the event source (SQS/Kinesis/DynamoDB Streams) is granted to the function's execution role, not the deployer. The provider retries IAM-propagation errors until the role can poll the source.",
+            },
+          },
+        },
         stables: ["uuid", "eventSourceMappingArn"],
         diff: Effect.fn(function* ({ news, olds }) {
           if (!isResolved(news)) return;

--- a/packages/alchemy/src/AWS/Lambda/Function.ts
+++ b/packages/alchemy/src/AWS/Lambda/Function.ts
@@ -1425,6 +1425,50 @@ export default await Effect.runPromise(handlerEffect)
         }`;
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "lambda:CreateFunction",
+                "lambda:UpdateFunctionCode",
+                "lambda:UpdateFunctionConfiguration",
+                "lambda:DeleteFunction",
+                "lambda:TagResource",
+                "lambda:CreateFunctionUrlConfig",
+                "lambda:UpdateFunctionUrlConfig",
+                "lambda:DeleteFunctionUrlConfig",
+                "lambda:AddPermission",
+                "lambda:RemovePermission",
+                "lambda:PutFunctionConcurrency",
+                "lambda:DeleteFunctionConcurrency",
+                "iam:CreateRole",
+                "iam:TagRole",
+                "iam:AttachRolePolicy",
+                "iam:DetachRolePolicy",
+                "iam:PutRolePolicy",
+                "iam:DeleteRolePolicy",
+                "iam:DeleteRole",
+                "iam:PassRole",
+                "s3:GetObject",
+                "s3:PutObject",
+              ],
+              readActions: [
+                "lambda:GetFunction",
+                "lambda:ListFunctions",
+                "lambda:ListTags",
+                "lambda:GetFunctionUrlConfig",
+                "lambda:GetFunctionConcurrency",
+                "iam:GetRole",
+                "iam:ListRolePolicies",
+                "iam:ListAttachedRolePolicies",
+                "logs:StartLiveTail",
+                "logs:FilterLogEvents",
+              ],
+              notes:
+                "Creates/owns the execution role: requires iam:PassRole on the generated role. s3:GetObject/PutObject are only used to upload the code archive when the Assets bucket service is provided (falls back to inline ZipFile otherwise). CreateFunction with Tags additionally authorizes lambda:TagResource.",
+            },
+          },
+        },
         stables: ["functionArn", "functionName", "roleName"],
         diff: Effect.fn(function* ({ id, olds, news, output }) {
           if (!isResolved(news)) return;

--- a/packages/alchemy/src/AWS/Lambda/MicrovmProvider.ts
+++ b/packages/alchemy/src/AWS/Lambda/MicrovmProvider.ts
@@ -313,6 +313,33 @@ const syncTags = Effect.fn(function* (
 
 export const MicrovmImageProvider = () =>
   Provider.succeed(MicrovmImage, {
+    metadata: {
+      aws: {
+        iam: {
+          actions: [
+            "lambda:CreateMicrovmImage",
+            "lambda:UpdateMicrovmImage",
+            "lambda:DeleteMicrovmImage",
+            "lambda:TagResource",
+            "lambda:UntagResource",
+            "lambda:TerminateMicrovm",
+            "iam:PassRole",
+            "s3:GetObject",
+            "s3:PutObject",
+          ],
+          readActions: [
+            "lambda:GetMicrovmImage",
+            "lambda:ListMicrovmImages",
+            "lambda:ListManagedMicrovmImages",
+            "lambda:GetMicrovmImageVersion",
+            "lambda:ListMicrovmImageBuilds",
+            "lambda:ListMicrovms",
+          ],
+          notes:
+            "iam:PassRole on the buildRole ARN (required for create/update builds). The code artifact is uploaded to the Assets S3 bucket (HeadObject + PutObject), which is mandatory for main/context-based images. MicroVM IAM action names assumed to mirror the new API operation names under the lambda: prefix.",
+        },
+      },
+    },
     stables: ["imageArn", "name"],
 
     diff: Effect.fn(function* ({ id, olds, news }) {

--- a/packages/alchemy/src/AWS/Lambda/NetworkConnector.ts
+++ b/packages/alchemy/src/AWS/Lambda/NetworkConnector.ts
@@ -166,6 +166,24 @@ export const NetworkConnector = Resource<NetworkConnector>(
 
 export const NetworkConnectorProvider = () =>
   Provider.succeed(NetworkConnector, {
+    metadata: {
+      aws: {
+        iam: {
+          actions: [
+            "lambda:CreateNetworkConnector",
+            "lambda:UpdateNetworkConnector",
+            "lambda:DeleteNetworkConnector",
+            "iam:PassRole",
+          ],
+          readActions: [
+            "lambda:GetNetworkConnector",
+            "lambda:ListNetworkConnectors",
+          ],
+          notes:
+            "iam:PassRole on the operatorRole ARN when one is configured (Lambda assumes it to manage ENIs). Tags are only settable at creation (the API exposes no tagging operations). IAM action names assumed to mirror the new NetworkConnector API operation names under the lambda: prefix.",
+        },
+      },
+    },
     stables: ["networkConnectorArn", "networkConnectorId", "name"],
 
     diff: Effect.fn(function* ({ id, olds, news }) {

--- a/packages/alchemy/src/AWS/Lambda/Permission.ts
+++ b/packages/alchemy/src/AWS/Lambda/Permission.ts
@@ -130,6 +130,14 @@ export const PermissionProvider = () =>
       type PermissionAttrs = { statementId: string; functionName: string };
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: ["lambda:AddPermission", "lambda:RemovePermission"],
+              readActions: ["lambda:ListFunctions", "lambda:GetPolicy"],
+            },
+          },
+        },
         stables: ["statementId", "functionName"],
         list: () =>
           Effect.gen(function* () {

--- a/packages/alchemy/src/AWS/Logs/LogGroup.ts
+++ b/packages/alchemy/src/AWS/Logs/LogGroup.ts
@@ -91,6 +91,29 @@ export const LogGroupProvider = () =>
       ): LogGroupClass => props.logGroupClass ?? "STANDARD";
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "logs:CreateLogGroup",
+                "logs:DeleteLogGroup",
+                "logs:PutRetentionPolicy",
+                "logs:DeleteRetentionPolicy",
+                "logs:AssociateKmsKey",
+                "logs:DisassociateKmsKey",
+                "logs:PutLogGroupDeletionProtection",
+                "logs:TagResource",
+                "logs:UntagResource",
+              ],
+              readActions: [
+                "logs:DescribeLogGroups",
+                "logs:ListTagsForResource",
+              ],
+              notes:
+                "createLogGroup with tags requires logs:TagResource. Using kmsKeyId additionally requires the KMS key policy to grant CloudWatch Logs use of the key (kms:Encrypt*/Decrypt* via the key policy, not caller IAM).",
+            },
+          },
+        },
         stables: ["logGroupArn", "logGroupName"],
         // AWS account/region collection: paginate `describeLogGroups`
         // exhaustively, then hydrate each group's tags via

--- a/packages/alchemy/src/AWS/Organizations/Account.ts
+++ b/packages/alchemy/src/AWS/Organizations/Account.ts
@@ -75,6 +75,29 @@ export const AccountProvider = () =>
     Account,
     Effect.gen(function* () {
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "organizations:CreateAccount",
+                "organizations:DescribeCreateAccountStatus",
+                "organizations:MoveAccount",
+                "organizations:RemoveAccountFromOrganization",
+                "organizations:TagResource",
+                "organizations:UntagResource",
+                "account:PutAccountName",
+              ],
+              readActions: [
+                "organizations:DescribeAccount",
+                "organizations:ListAccounts",
+                "organizations:ListParents",
+                "organizations:ListTagsForResource",
+              ],
+              notes:
+                "Account name sync uses the AWS Account Management API (account:PutAccountName), not Organizations. DescribeCreateAccountStatus is only invoked from reconcile's async-create poll, so it is classified as a full-lifecycle action.",
+            },
+          },
+        },
         stables: ["accountId", "accountArn", "joinedMethod", "joinedTimestamp"],
         diff: Effect.fn(function* ({ olds, news }) {
           if (!isResolved(news)) return;

--- a/packages/alchemy/src/AWS/Organizations/DelegatedAdministrator.ts
+++ b/packages/alchemy/src/AWS/Organizations/DelegatedAdministrator.ts
@@ -45,6 +45,20 @@ export const DelegatedAdministratorProvider = () =>
     DelegatedAdministrator,
     Effect.gen(function* () {
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "organizations:RegisterDelegatedAdministrator",
+                "organizations:DeregisterDelegatedAdministrator",
+              ],
+              readActions: [
+                "organizations:ListDelegatedAdministrators",
+                "organizations:ListDelegatedServicesForAccount",
+              ],
+            },
+          },
+        },
         stables: ["accountId", "servicePrincipal"],
         diff: Effect.fn(function* ({ olds, news }) {
           if (!isResolved(news)) return;

--- a/packages/alchemy/src/AWS/Organizations/Organization.ts
+++ b/packages/alchemy/src/AWS/Organizations/Organization.ts
@@ -58,6 +58,21 @@ export const OrganizationProvider = () =>
     Organization,
     Effect.gen(function* () {
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "organizations:CreateOrganization",
+                "organizations:EnableAllFeatures",
+                "organizations:DeleteOrganization",
+                "iam:CreateServiceLinkedRole",
+              ],
+              readActions: ["organizations:DescribeOrganization"],
+              notes:
+                "CreateOrganization implicitly creates the AWSServiceRoleForOrganizations service-linked role, so the caller needs iam:CreateServiceLinkedRole for organizations.amazonaws.com. Must run in the management account.",
+            },
+          },
+        },
         stables: ["organizationId", "organizationArn", "managementAccountId"],
         diff: Effect.fn(function* () {}),
         read: Effect.fn(function* () {

--- a/packages/alchemy/src/AWS/Organizations/OrganizationResourcePolicy.ts
+++ b/packages/alchemy/src/AWS/Organizations/OrganizationResourcePolicy.ts
@@ -58,6 +58,17 @@ export const OrganizationResourcePolicyProvider = () =>
     OrganizationResourcePolicy,
     Effect.gen(function* () {
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "organizations:PutResourcePolicy",
+                "organizations:DeleteResourcePolicy",
+              ],
+              readActions: ["organizations:DescribeResourcePolicy"],
+            },
+          },
+        },
         stables: ["resourcePolicyId", "resourcePolicyArn"],
         diff: Effect.fn(function* () {}),
         read: Effect.fn(function* () {

--- a/packages/alchemy/src/AWS/Organizations/OrganizationalUnit.ts
+++ b/packages/alchemy/src/AWS/Organizations/OrganizationalUnit.ts
@@ -67,6 +67,26 @@ export const OrganizationalUnitProvider = () =>
     OrganizationalUnit,
     Effect.gen(function* () {
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "organizations:CreateOrganizationalUnit",
+                "organizations:UpdateOrganizationalUnit",
+                "organizations:DeleteOrganizationalUnit",
+                "organizations:TagResource",
+                "organizations:UntagResource",
+              ],
+              readActions: [
+                "organizations:DescribeOrganizationalUnit",
+                "organizations:ListOrganizationalUnitsForParent",
+                "organizations:ListRoots",
+                "organizations:ListParents",
+                "organizations:ListTagsForResource",
+              ],
+            },
+          },
+        },
         stables: ["ouId", "ouArn"],
         diff: Effect.fn(function* ({ id, olds, news }) {
           if (!isResolved(news)) return;

--- a/packages/alchemy/src/AWS/Organizations/Policy.ts
+++ b/packages/alchemy/src/AWS/Organizations/Policy.ts
@@ -70,6 +70,24 @@ export const PolicyProvider = () =>
     Policy,
     Effect.gen(function* () {
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "organizations:CreatePolicy",
+                "organizations:UpdatePolicy",
+                "organizations:DeletePolicy",
+                "organizations:TagResource",
+                "organizations:UntagResource",
+              ],
+              readActions: [
+                "organizations:DescribePolicy",
+                "organizations:ListPolicies",
+                "organizations:ListTagsForResource",
+              ],
+            },
+          },
+        },
         stables: ["policyId", "policyArn"],
         diff: Effect.fn(function* ({ id, olds, news }) {
           if (!isResolved(news)) return;

--- a/packages/alchemy/src/AWS/Organizations/PolicyAttachment.ts
+++ b/packages/alchemy/src/AWS/Organizations/PolicyAttachment.ts
@@ -44,6 +44,20 @@ export const PolicyAttachmentProvider = () =>
     PolicyAttachment,
     Effect.gen(function* () {
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "organizations:AttachPolicy",
+                "organizations:DetachPolicy",
+              ],
+              readActions: [
+                "organizations:ListPolicies",
+                "organizations:ListTargetsForPolicy",
+              ],
+            },
+          },
+        },
         stables: ["policyId", "targetId"],
         diff: Effect.fn(function* ({ olds, news }) {
           if (!isResolved(news)) return;

--- a/packages/alchemy/src/AWS/Organizations/Root.ts
+++ b/packages/alchemy/src/AWS/Organizations/Root.ts
@@ -59,6 +59,22 @@ export const RootProvider = () =>
     Root,
     Effect.gen(function* () {
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "organizations:TagResource",
+                "organizations:UntagResource",
+              ],
+              readActions: [
+                "organizations:ListRoots",
+                "organizations:ListTagsForResource",
+              ],
+              notes:
+                "Import-style resource: the root is created/deleted by AWS with the organization; Alchemy only discovers it and reconciles tags. delete is a no-op.",
+            },
+          },
+        },
         stables: ["rootId", "rootArn"],
         // Enumerate every organization root via `listRoots` (paginated) and
         // hydrate each into the exact `read` Attributes shape, fetching tags

--- a/packages/alchemy/src/AWS/Organizations/RootPolicyType.ts
+++ b/packages/alchemy/src/AWS/Organizations/RootPolicyType.ts
@@ -43,6 +43,17 @@ export const RootPolicyTypeProvider = () =>
     RootPolicyType,
     Effect.gen(function* () {
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "organizations:EnablePolicyType",
+                "organizations:DisablePolicyType",
+              ],
+              readActions: ["organizations:ListRoots"],
+            },
+          },
+        },
         stables: ["rootId", "rootArn", "policyType"],
         diff: Effect.fn(function* ({ olds, news }) {
           if (!isResolved(news)) return;

--- a/packages/alchemy/src/AWS/Organizations/TrustedServiceAccess.ts
+++ b/packages/alchemy/src/AWS/Organizations/TrustedServiceAccess.ts
@@ -37,6 +37,21 @@ export const TrustedServiceAccessProvider = () =>
     TrustedServiceAccess,
     Effect.gen(function* () {
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "organizations:EnableAWSServiceAccess",
+                "organizations:DisableAWSServiceAccess",
+              ],
+              readActions: [
+                "organizations:ListAWSServiceAccessForOrganization",
+              ],
+              notes:
+                "For some AWS services, enabling trusted access causes the service to create service-linked roles in member accounts; AWS may require iam:CreateServiceLinkedRole on the caller depending on the service principal.",
+            },
+          },
+        },
         stables: ["servicePrincipal"],
         diff: Effect.fn(function* ({ olds, news }) {
           if (!isResolved(news)) return;

--- a/packages/alchemy/src/AWS/ProviderMetadata.ts
+++ b/packages/alchemy/src/AWS/ProviderMetadata.ts
@@ -1,0 +1,35 @@
+/**
+ * Credential requirements an AWS resource provider declares via
+ * `metadata.aws`. Consumed by deploy-time preflight (rendering the required
+ * actions on authorization failures), a future `alchemy aws create-policy`
+ * (least-privilege deploy-role policy generation), and generated docs. See
+ * `processes/ProviderMetadata/DESIGN.md`.
+ *
+ * Values must be plain literals — no `Output`s, Effects, or environment reads.
+ */
+export interface AwsProviderMetadata {
+  iam?: {
+    /**
+     * IAM actions the full lifecycle (precreate/reconcile/delete) may call,
+     * e.g. `"s3:CreateBucket"`. Derived from the operations the provider's
+     * lifecycle code actually invokes.
+     */
+    actions?: string[];
+    /**
+     * Narrower set sufficient for read/list/diff/logs/tail (plan-only).
+     * @default actions
+     */
+    readActions?: string[];
+    /**
+     * Free-form caveats surfaced in docs and preflight output — e.g.
+     * "requires iam:PassRole on the function role".
+     */
+    notes?: string;
+  };
+}
+
+declare module "../Provider.ts" {
+  interface AlchemyProviderMetadata {
+    aws?: AwsProviderMetadata;
+  }
+}

--- a/packages/alchemy/src/AWS/RDS/DBCluster.ts
+++ b/packages/alchemy/src/AWS/RDS/DBCluster.ts
@@ -480,6 +480,23 @@ export const DBClusterProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "rds:CreateDBCluster",
+                "rds:ModifyDBCluster",
+                "rds:DeleteDBCluster",
+                "rds:AddTagsToResource",
+                "rds:RemoveTagsFromResource",
+                "secretsmanager:GetSecretValue",
+              ],
+              readActions: ["rds:DescribeDBClusters"],
+              notes:
+                "secretsmanager:GetSecretValue only when masterUserSecretArn is set. iam:PassRole on monitoringRoleArn when enhanced monitoring is configured. First cluster in an account may require iam:CreateServiceLinkedRole (AWSServiceRoleForRDS). kms:* grants are delegated to the key policy when kmsKeyId / performanceInsightsKMSKeyId / masterUserSecretKmsKeyId are set.",
+            },
+          },
+        },
         stables: ["dbClusterArn", "dbClusterIdentifier"],
         // AWS account/region collection (pattern a): exhaustively paginate
         // `describeDBClusters` and map each cluster to the exact `read`

--- a/packages/alchemy/src/AWS/RDS/DBClusterEndpoint.ts
+++ b/packages/alchemy/src/AWS/RDS/DBClusterEndpoint.ts
@@ -104,6 +104,20 @@ export const DBClusterEndpointProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "rds:CreateDBClusterEndpoint",
+                "rds:ModifyDBClusterEndpoint",
+                "rds:DeleteDBClusterEndpoint",
+                "rds:AddTagsToResource",
+                "rds:RemoveTagsFromResource",
+              ],
+              readActions: ["rds:DescribeDBClusterEndpoints"],
+            },
+          },
+        },
         stables: ["dbClusterEndpointArn", "dbClusterEndpointIdentifier"],
         // Enumerate every custom cluster endpoint in the account/region.
         // `describeDBClusterEndpoints` with no filter returns custom endpoints

--- a/packages/alchemy/src/AWS/RDS/DBClusterParameterGroup.ts
+++ b/packages/alchemy/src/AWS/RDS/DBClusterParameterGroup.ts
@@ -72,6 +72,19 @@ export const DBClusterParameterGroupProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "rds:CreateDBClusterParameterGroup",
+                "rds:DeleteDBClusterParameterGroup",
+                "rds:AddTagsToResource",
+                "rds:RemoveTagsFromResource",
+              ],
+              readActions: ["rds:DescribeDBClusterParameterGroups"],
+            },
+          },
+        },
         stables: ["dbClusterParameterGroupArn", "dbClusterParameterGroupName"],
         list: () =>
           // AWS account/region collection (pattern (a)): exhaustively paginate

--- a/packages/alchemy/src/AWS/RDS/DBInstance.ts
+++ b/packages/alchemy/src/AWS/RDS/DBInstance.ts
@@ -453,6 +453,22 @@ export const DBInstanceProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "rds:CreateDBInstance",
+                "rds:ModifyDBInstance",
+                "rds:DeleteDBInstance",
+                "rds:AddTagsToResource",
+                "rds:RemoveTagsFromResource",
+              ],
+              readActions: ["rds:DescribeDBInstances"],
+              notes:
+                "iam:PassRole on monitoringRoleArn when enhanced monitoring is configured. First instance in an account may require iam:CreateServiceLinkedRole (AWSServiceRoleForRDS). KMS grants come from the key policy when kmsKeyId / performanceInsightsKMSKeyId / masterUserSecretKmsKeyId are set.",
+            },
+          },
+        },
         stables: ["dbInstanceArn", "dbInstanceIdentifier"],
         // Pattern (a) AWS account/region collection: `describeDBInstances` is
         // paginated (items: "DBInstances") and returns each instance's

--- a/packages/alchemy/src/AWS/RDS/DBParameterGroup.ts
+++ b/packages/alchemy/src/AWS/RDS/DBParameterGroup.ts
@@ -72,6 +72,19 @@ export const DBParameterGroupProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "rds:CreateDBParameterGroup",
+                "rds:DeleteDBParameterGroup",
+                "rds:AddTagsToResource",
+                "rds:RemoveTagsFromResource",
+              ],
+              readActions: ["rds:DescribeDBParameterGroups"],
+            },
+          },
+        },
         stables: ["dbParameterGroupArn", "dbParameterGroupName"],
         diff: Effect.fn(function* ({ id, olds, news }) {
           if (!isResolved(news)) return undefined;

--- a/packages/alchemy/src/AWS/RDS/DBProxy.ts
+++ b/packages/alchemy/src/AWS/RDS/DBProxy.ts
@@ -147,6 +147,23 @@ export const DBProxyProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "rds:CreateDBProxy",
+                "rds:ModifyDBProxy",
+                "rds:DeleteDBProxy",
+                "rds:AddTagsToResource",
+                "rds:RemoveTagsFromResource",
+                "iam:PassRole",
+              ],
+              readActions: ["rds:DescribeDBProxies", "rds:ListTagsForResource"],
+              notes:
+                "iam:PassRole is required on the proxy auth role (props.roleArn) passed as RoleArn to CreateDBProxy/ModifyDBProxy.",
+            },
+          },
+        },
         stables: ["dbProxyArn", "dbProxyName"],
         // Enumerate every DB proxy in the account/region via the paginated
         // `describeDBProxies`, then hydrate each proxy's tags via

--- a/packages/alchemy/src/AWS/RDS/DBProxyEndpoint.ts
+++ b/packages/alchemy/src/AWS/RDS/DBProxyEndpoint.ts
@@ -137,6 +137,23 @@ export const DBProxyEndpointProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "rds:CreateDBProxyEndpoint",
+                "rds:ModifyDBProxyEndpoint",
+                "rds:DeleteDBProxyEndpoint",
+                "rds:AddTagsToResource",
+                "rds:RemoveTagsFromResource",
+              ],
+              readActions: [
+                "rds:DescribeDBProxyEndpoints",
+                "rds:DescribeDBProxies",
+              ],
+            },
+          },
+        },
         stables: ["dbProxyEndpointArn", "dbProxyEndpointName"],
         list: () =>
           Effect.gen(function* () {

--- a/packages/alchemy/src/AWS/RDS/DBProxyTargetGroup.ts
+++ b/packages/alchemy/src/AWS/RDS/DBProxyTargetGroup.ts
@@ -139,6 +139,22 @@ export const DBProxyTargetGroupProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "rds:ModifyDBProxyTargetGroup",
+                "rds:RegisterDBProxyTargets",
+                "rds:DeregisterDBProxyTargets",
+              ],
+              readActions: [
+                "rds:DescribeDBProxyTargetGroups",
+                "rds:DescribeDBProxyTargets",
+                "rds:DescribeDBProxies",
+              ],
+            },
+          },
+        },
         stables: ["dbProxyName", "targetGroupArn", "targetGroupName"],
         // Target groups are proxy-scoped: `describeDBProxyTargetGroups`
         // requires a `DBProxyName`, so there is no account-wide enumeration.

--- a/packages/alchemy/src/AWS/RDS/DBSubnetGroup.ts
+++ b/packages/alchemy/src/AWS/RDS/DBSubnetGroup.ts
@@ -74,6 +74,20 @@ export const DBSubnetGroupProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "rds:CreateDBSubnetGroup",
+                "rds:ModifyDBSubnetGroup",
+                "rds:DeleteDBSubnetGroup",
+                "rds:AddTagsToResource",
+                "rds:RemoveTagsFromResource",
+              ],
+              readActions: ["rds:DescribeDBSubnetGroups"],
+            },
+          },
+        },
         stables: ["dbSubnetGroupArn", "dbSubnetGroupName", "vpcId"],
         diff: Effect.fn(function* ({ id, olds, news }) {
           if (!isResolved(news)) return undefined;

--- a/packages/alchemy/src/AWS/Requirements.ts
+++ b/packages/alchemy/src/AWS/Requirements.ts
@@ -1,0 +1,91 @@
+import type {
+  ProviderMetadataIndex,
+  StackProviderMetadata,
+} from "../Provider.ts";
+
+/**
+ * Cloud-specific analysis of {@link StackProviderMetadata} for AWS — the
+ * union of IAM actions the stack's resources require. Consumed by the future
+ * `alchemy aws create-policy` (least-privilege deploy-role generation) and by
+ * error rendering on authorization failures.
+ *
+ * Every action carries the resource types that demanded it so output can
+ * explain *why* a grant is needed.
+ */
+export interface AwsRequirements {
+  /** IAM action → resource types requiring it (full lifecycle). */
+  actions: Map<string, string[]>;
+  /** IAM action → resource types requiring it (read/list/diff only). */
+  readActions: Map<string, string[]>;
+  /** Per-resource caveats from `iam.notes` (e.g. PassRole conditions). */
+  notes: { resourceType: string; note: string }[];
+}
+
+const push = (
+  map: Map<string, string[]>,
+  key: string,
+  resourceType: string,
+) => {
+  const list = map.get(key);
+  if (list) list.push(resourceType);
+  else map.set(key, [resourceType]);
+};
+
+/**
+ * Union the `aws` metadata namespaces across the given index. Prefers the
+ * exact-mode `used` subset; falls back to `all` (whole-cloud — over-asks)
+ * when the stack couldn't be compiled.
+ */
+export const collectAwsRequirements = (
+  metadata: StackProviderMetadata,
+): AwsRequirements => {
+  const index: ProviderMetadataIndex = metadata.used ?? metadata.all;
+  const requirements: AwsRequirements = {
+    actions: new Map(),
+    readActions: new Map(),
+    notes: [],
+  };
+  for (const [resourceType, entry] of index) {
+    const iam = entry.aws?.iam;
+    if (iam === undefined) continue;
+    for (const action of iam.actions ?? []) {
+      push(requirements.actions, action, resourceType);
+    }
+    for (const action of iam.readActions ?? []) {
+      push(requirements.readActions, action, resourceType);
+    }
+    if (iam.notes) {
+      requirements.notes.push({ resourceType, note: iam.notes });
+    }
+  }
+  return requirements;
+};
+
+/**
+ * Render the requirements as an IAM policy document (statements with
+ * `Resource: "*"` — ARN-level least privilege is future work). `planOnly`
+ * emits just the read tier.
+ */
+export const toPolicyDocument = (
+  requirements: AwsRequirements,
+  options?: { planOnly?: boolean },
+) => ({
+  Version: "2012-10-17" as const,
+  Statement: [
+    {
+      Sid: options?.planOnly ? "AlchemyPlan" : "AlchemyDeploy",
+      Effect: "Allow" as const,
+      Action: [
+        ...new Set(
+          options?.planOnly
+            ? requirements.readActions.keys()
+            : [
+                ...requirements.actions.keys(),
+                ...requirements.readActions.keys(),
+              ],
+        ),
+      ].sort(),
+      Resource: "*" as const,
+    },
+  ],
+});

--- a/packages/alchemy/src/AWS/Route53/HealthCheck.ts
+++ b/packages/alchemy/src/AWS/Route53/HealthCheck.ts
@@ -223,6 +223,23 @@ export const HealthCheckProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "route53:CreateHealthCheck",
+                "route53:UpdateHealthCheck",
+                "route53:DeleteHealthCheck",
+                "route53:ListTagsForResource",
+                "route53:ChangeTagsForResource",
+              ],
+              readActions: [
+                "route53:GetHealthCheck",
+                "route53:ListHealthChecks",
+              ],
+            },
+          },
+        },
         stables: ["id", "healthCheckId"],
         list: () =>
           route53.listHealthChecks.pages({}).pipe(

--- a/packages/alchemy/src/AWS/Route53/HostedZone.ts
+++ b/packages/alchemy/src/AWS/Route53/HostedZone.ts
@@ -225,6 +225,30 @@ export const HostedZoneProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "route53:CreateHostedZone",
+                "route53:DeleteHostedZone",
+                "route53:UpdateHostedZoneComment",
+                "route53:ListTagsForResource",
+                "route53:ChangeTagsForResource",
+                "route53:ListResourceRecordSets",
+                "route53:ChangeResourceRecordSets",
+                "route53:GetChange",
+                "ec2:DescribeVpcs",
+              ],
+              readActions: [
+                "route53:ListHostedZones",
+                "route53:ListHostedZonesByName",
+                "route53:GetHostedZone",
+              ],
+              notes:
+                "ListResourceRecordSets/ChangeResourceRecordSets/GetChange are needed only for forceDestroy record purge. ec2:DescribeVpcs is required by AWS only when creating a private hosted zone (props.vpc); public-zone-only stacks can drop it.",
+            },
+          },
+        },
         stables: ["id", "name"],
         list: () =>
           route53.listHostedZones.pages({}).pipe(

--- a/packages/alchemy/src/AWS/Route53/Record.ts
+++ b/packages/alchemy/src/AWS/Route53/Record.ts
@@ -559,6 +559,20 @@ export const RecordProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "route53:ChangeResourceRecordSets",
+                "route53:GetChange",
+              ],
+              readActions: [
+                "route53:ListResourceRecordSets",
+                "route53:ListHostedZones",
+              ],
+            },
+          },
+        },
         stables: ["hostedZoneId", "name", "type", "setIdentifier"],
         list: () =>
           Effect.gen(function* () {

--- a/packages/alchemy/src/AWS/S3/Bucket.ts
+++ b/packages/alchemy/src/AWS/S3/Bucket.ts
@@ -1304,6 +1304,57 @@ export const BucketProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "s3:CreateBucket",
+                "s3:DeleteBucket",
+                "s3:GetBucketTagging",
+                "s3:PutBucketTagging",
+                "s3:GetBucketOwnershipControls",
+                "s3:PutBucketOwnershipControls",
+                "s3:GetBucketPublicAccessBlock",
+                "s3:PutBucketPublicAccessBlock",
+                "s3:GetBucketVersioning",
+                "s3:PutBucketVersioning",
+                "s3:GetEncryptionConfiguration",
+                "s3:PutEncryptionConfiguration",
+                "s3:GetBucketCORS",
+                "s3:PutBucketCORS",
+                "s3:GetLifecycleConfiguration",
+                "s3:PutLifecycleConfiguration",
+                "s3:GetBucketLogging",
+                "s3:PutBucketLogging",
+                "s3:GetAccelerateConfiguration",
+                "s3:PutAccelerateConfiguration",
+                "s3:GetBucketRequestPayment",
+                "s3:PutBucketRequestPayment",
+                "s3:GetBucketWebsite",
+                "s3:PutBucketWebsite",
+                "s3:GetReplicationConfiguration",
+                "s3:PutReplicationConfiguration",
+                "s3:GetIntelligentTieringConfiguration",
+                "s3:PutIntelligentTieringConfiguration",
+                "s3:GetBucketObjectLockConfiguration",
+                "s3:PutBucketObjectLockConfiguration",
+                "s3:PutBucketAcl",
+                "s3:GetBucketPolicy",
+                "s3:PutBucketPolicy",
+                "s3:DeleteBucketPolicy",
+                "s3:GetBucketNotification",
+                "s3:PutBucketNotification",
+                "s3:ListBucketVersions",
+                "s3:DeleteObject",
+                "s3:DeleteObjectVersion",
+                "iam:PassRole",
+              ],
+              readActions: ["s3:ListAllMyBuckets", "s3:ListBucket"],
+              notes:
+                "headBucket authorizes as s3:ListBucket. ListBucketVersions/DeleteObject/DeleteObjectVersion are needed only for forceDestroy. iam:PassRole on the replication role is required only when props.replication is set. Creating with objectLockEnabled also requires s3:PutBucketObjectLockConfiguration and s3:PutBucketVersioning (already listed).",
+            },
+          },
+        },
         stables: ["bucketName", "bucketArn", "region", "accountId"],
         // S3 bucket names are globally unique. `headBucket` succeeds only when
         // the bucket exists in our account, so a successful response is itself

--- a/packages/alchemy/src/AWS/SNS/Subscription.ts
+++ b/packages/alchemy/src/AWS/SNS/Subscription.ts
@@ -70,6 +70,24 @@ export const Subscription = Resource<Subscription>("AWS.SNS.Subscription");
 
 export const SubscriptionProvider = () =>
   Provider.succeed(Subscription, {
+    metadata: {
+      aws: {
+        iam: {
+          actions: [
+            "sns:Subscribe",
+            "sns:SetSubscriptionAttributes",
+            "sns:Unsubscribe",
+          ],
+          readActions: [
+            "sns:ListSubscriptions",
+            "sns:ListSubscriptionsByTopic",
+            "sns:GetSubscriptionAttributes",
+          ],
+          notes:
+            "SNS subscriptions are not taggable; ownership cannot be tag-verified. Lambda-protocol subscriptions additionally need a Lambda Permission (lambda:AddPermission via AWS.Lambda.Permission) so SNS can invoke the function — handled by the separate Permission resource, not this provider.",
+        },
+      },
+    },
     read: Effect.fn(function* ({ olds, output }) {
       return yield* readSubscription({
         subscriptionArn: output?.subscriptionArn,

--- a/packages/alchemy/src/AWS/SNS/Topic.ts
+++ b/packages/alchemy/src/AWS/SNS/Topic.ts
@@ -135,6 +135,28 @@ export const Topic = Resource<Topic>("AWS.SNS.Topic");
 
 export const TopicProvider = () =>
   Provider.succeed(Topic, {
+    metadata: {
+      aws: {
+        iam: {
+          actions: [
+            "sns:CreateTopic",
+            "sns:SetTopicAttributes",
+            "sns:TagResource",
+            "sns:UntagResource",
+            "sns:PutDataProtectionPolicy",
+            "sns:DeleteTopic",
+          ],
+          readActions: [
+            "sns:ListTopics",
+            "sns:GetTopicAttributes",
+            "sns:ListTagsForResource",
+            "sns:GetDataProtectionPolicy",
+          ],
+          notes:
+            "sns:CreateTopic is required on every deploy (reconcile uses idempotent createTopic as the observe/ensure step). KMS-encrypted topics (KmsMasterKeyId attribute) need kms grants on the key for publishers, not the deployer.",
+        },
+      },
+    },
     // AWS account/region collection: `listTopics` enumerates every topic ARN
     // in the ambient account+region (paginated, ARN-only), then each ARN is
     // hydrated via `readTopic` into the exact `read` Attributes shape

--- a/packages/alchemy/src/AWS/SQS/Queue.ts
+++ b/packages/alchemy/src/AWS/SQS/Queue.ts
@@ -384,6 +384,27 @@ export const QueueProvider = () =>
         return baseAttributes;
       };
       return Queue.Provider.of({
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "sqs:CreateQueue",
+                "sqs:SetQueueAttributes",
+                "sqs:TagQueue",
+                "sqs:UntagQueue",
+                "sqs:DeleteQueue",
+              ],
+              readActions: [
+                "sqs:ListQueues",
+                "sqs:GetQueueUrl",
+                "sqs:GetQueueAttributes",
+                "sqs:ListQueueTags",
+              ],
+              notes:
+                "CreateQueue with the tags parameter additionally authorizes sqs:TagQueue. SSE with a customer-managed KMS key (kmsMasterKeyId) needs the usual kms grants on that key for producers/consumers, not the deployer.",
+            },
+          },
+        },
         stables: ["queueName", "queueUrl", "queueArn"],
         // Enumerate every queue in the ambient account/region. `listQueues`
         // returns queue URLs (paginated), which we hydrate into the exact `read`

--- a/packages/alchemy/src/AWS/Scheduler/Schedule.ts
+++ b/packages/alchemy/src/AWS/Scheduler/Schedule.ts
@@ -127,6 +127,21 @@ export const ScheduleProvider = () =>
           : createPhysicalName({ id, maxLength: 64 });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "scheduler:CreateSchedule",
+                "scheduler:UpdateSchedule",
+                "scheduler:DeleteSchedule",
+                "iam:PassRole",
+              ],
+              readActions: ["scheduler:GetSchedule", "scheduler:ListSchedules"],
+              notes:
+                "iam:PassRole on the Target.RoleArn (every schedule target requires a role Scheduler assumes to invoke it). Schedules are not taggable (only schedule groups are), so ownership cannot be tag-verified.",
+            },
+          },
+        },
         stables: ["scheduleArn", "scheduleName", "groupName"],
         diff: Effect.fn(function* ({ id, olds, news }) {
           if (!isResolved(news)) return undefined;

--- a/packages/alchemy/src/AWS/Scheduler/ScheduleGroup.ts
+++ b/packages/alchemy/src/AWS/Scheduler/ScheduleGroup.ts
@@ -66,6 +66,23 @@ export const ScheduleGroupProvider = () =>
           : createPhysicalName({ id, maxLength: 64 });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "scheduler:CreateScheduleGroup",
+                "scheduler:TagResource",
+                "scheduler:UntagResource",
+                "scheduler:DeleteScheduleGroup",
+              ],
+              readActions: [
+                "scheduler:GetScheduleGroup",
+                "scheduler:ListScheduleGroups",
+                "scheduler:ListTagsForResource",
+              ],
+            },
+          },
+        },
         stables: ["scheduleGroupArn", "scheduleGroupName"],
         diff: Effect.fn(function* ({ id, olds, news }) {
           if (!isResolved(news)) return undefined;

--- a/packages/alchemy/src/AWS/SecretsManager/Secret.ts
+++ b/packages/alchemy/src/AWS/SecretsManager/Secret.ts
@@ -170,6 +170,26 @@ export const SecretProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: [
+                "secretsmanager:CreateSecret",
+                "secretsmanager:UpdateSecret",
+                "secretsmanager:DeleteSecret",
+                "secretsmanager:TagResource",
+                "secretsmanager:UntagResource",
+                "secretsmanager:GetRandomPassword",
+              ],
+              readActions: [
+                "secretsmanager:DescribeSecret",
+                "secretsmanager:ListSecrets",
+              ],
+              notes:
+                "GetRandomPassword is only called when props.generateSecretString is set. When props.kmsKeyId points at a customer managed KMS key, AWS additionally requires kms:GenerateDataKey and kms:Decrypt on that key for CreateSecret/UpdateSecret (not needed for the default aws/secretsmanager key). Delete uses ForceDeleteWithoutRecovery (no recovery window).",
+            },
+          },
+        },
         stables: ["secretArn", "secretName"],
         diff: Effect.fn(function* ({ id, olds, news }) {
           if (!isResolved(news)) return undefined;

--- a/packages/alchemy/src/AWS/Website/AssetDeployment.ts
+++ b/packages/alchemy/src/AWS/Website/AssetDeployment.ts
@@ -174,6 +174,16 @@ export const AssetDeploymentProvider = () =>
       });
 
       return {
+        metadata: {
+          aws: {
+            iam: {
+              actions: ["s3:ListBucket", "s3:PutObject", "s3:DeleteObject"],
+              readActions: [],
+              notes:
+                "Object-level actions on the destination bucket only (listObjectsV2 authorizes as s3:ListBucket). read/list/diff make no AWS calls, hence readActions: []. s3:DeleteObject is needed only when purge: true.",
+            },
+          },
+        },
         // Non-listable: an AssetDeployment is an action (uploading a local
         // directory into a bucket under a prefix), keyed by {bucketName,
         // prefix}, not a standalone cloud resource. There is no AWS API that

--- a/packages/alchemy/src/AWS/index.ts
+++ b/packages/alchemy/src/AWS/index.ts
@@ -2,6 +2,7 @@ export * from "./Arn.ts";
 export * from "./Assets.ts";
 export * from "./Bootstrap.ts";
 export * from "./Environment.ts";
+export type { AwsProviderMetadata } from "./ProviderMetadata.ts";
 export * from "./Providers.ts";
 export * from "./StateStore/index.ts";
 

--- a/packages/alchemy/src/Auth/AuthProvider.ts
+++ b/packages/alchemy/src/Auth/AuthProvider.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Schema from "effect/Schema";
 import * as Semaphore from "effect/Semaphore";
+import type { StackProviderMetadata } from "../Provider.ts";
 import { withLock } from "./Lock.ts";
 
 /**
@@ -55,6 +56,29 @@ export interface ConfigureContext {
    * `{ method: "env" }`) so unattended runs work.
    */
   readonly ci: boolean;
+  /**
+   * Metadata of the resource providers registered by the stack being
+   * configured. Core passes this through opaquely — each auth provider runs
+   * its own cloud-specific analysis (e.g. Cloudflare derives the OAuth
+   * scopes to request from `metadata.cloudflare` across the used resources).
+   * Undefined when the stack couldn't be compiled at configure time.
+   */
+  readonly providerMetadata?: StackProviderMetadata;
+}
+
+/**
+ * A single required-vs-granted mismatch reported by
+ * {@link AuthProviderImpl.preflight}. Core renders findings before a
+ * deploy/plan runs; it never interprets them.
+ */
+export interface PreflightFinding {
+  readonly severity: "error" | "warning";
+  /** What is missing, e.g. `queues:write` or `Vectorize Write (9247…)`. */
+  readonly missing: string;
+  /** Resource types that require the missing grant. */
+  readonly resourceTypes: readonly string[];
+  /** How to fix it, e.g. "Run `alchemy login --configure`". */
+  readonly remediation: string;
 }
 
 export interface AuthProviderImpl<
@@ -90,6 +114,21 @@ export interface AuthProviderImpl<
     profileName: string,
     config: Config,
   ): Effect.Effect<Credentials, AuthError, ReadReq>;
+
+  /**
+   * Compare what the stack requires (from provider metadata) against what
+   * this profile's credentials grant, returning renderable findings. Core
+   * prints them before deploy/plan; Clank consumes them for guided
+   * remediation. Optional — providers with no grant model omit it.
+   *
+   * Shares `ReadReq` with {@link read}: preflight inspects the same stored
+   * credentials/config that `read` resolves.
+   */
+  preflight?(
+    profileName: string,
+    config: Config,
+    metadata: StackProviderMetadata,
+  ): Effect.Effect<PreflightFinding[], AuthError, ReadReq>;
 }
 
 export interface AuthProvider<

--- a/packages/alchemy/src/Auth/Preflight.ts
+++ b/packages/alchemy/src/Auth/Preflight.ts
@@ -1,0 +1,78 @@
+import * as Console from "effect/Console";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+
+import { collectProviderMetadata } from "../Provider.ts";
+import type { CompiledStack } from "../Stack.ts";
+import { AuthProviders, type PreflightFinding } from "./AuthProvider.ts";
+import { ALCHEMY_PROFILE, AlchemyProfile } from "./Profile.ts";
+
+/**
+ * Required-vs-granted credential preflight, run before deploy/plan/destroy.
+ *
+ * Collects the compiled stack's provider metadata (exact mode — only the
+ * resource types the stack declares), then asks each registered auth provider
+ * to diff its own cloud's requirements against the active profile's grants
+ * (see `AuthProviderImpl.preflight`). Findings are rendered as warnings; the
+ * run proceeds — a stale grant analysis must never block a deploy that would
+ * have succeeded.
+ *
+ * Never fails: any error in the analysis is logged at debug level and
+ * swallowed.
+ */
+export const preflightStack = (
+  stack: CompiledStack,
+): Effect.Effect<void, never, AlchemyProfile> =>
+  Effect.gen(function* () {
+    const metadata = collectProviderMetadata(
+      stack.services,
+      Object.values(stack.resources).map((r) => r.Type),
+    );
+    if (metadata.used === undefined || metadata.used.size === 0) {
+      return;
+    }
+
+    const registry = yield* Effect.serviceOption(AuthProviders);
+    if (Option.isNone(registry)) {
+      return;
+    }
+
+    const profileName = yield* ALCHEMY_PROFILE;
+    const profiles = yield* AlchemyProfile;
+    const entry = yield* profiles.getProfile(profileName);
+    if (entry == null) {
+      return;
+    }
+
+    const findings: { provider: string; finding: PreflightFinding }[] = [];
+    for (const provider of Object.values(registry.value)) {
+      const config = entry[provider.name];
+      if (config == null || provider.preflight == null) {
+        continue;
+      }
+      const results = yield* provider.preflight(profileName, config, metadata);
+      for (const finding of results) {
+        findings.push({ provider: provider.name, finding });
+      }
+    }
+
+    if (findings.length === 0) {
+      return;
+    }
+
+    const lines = findings.map(
+      ({ provider, finding }) =>
+        `  - [${provider}] missing ${finding.missing} (needed by ${finding.resourceTypes.join(", ")})`,
+    );
+    const remediations = [
+      ...new Set(findings.map(({ finding }) => finding.remediation)),
+    ].map((r) => `  → ${r}`);
+    yield* Console.warn(
+      `⚠ Profile "${profileName}" may be missing grants required by this stack:\n` +
+        `${lines.join("\n")}\n${remediations.join("\n")}`,
+    );
+  }).pipe(
+    Effect.catchCause((cause) =>
+      Effect.logDebug("credential preflight skipped", cause),
+    ),
+  );

--- a/packages/alchemy/src/Cli/commands/cloudflare.ts
+++ b/packages/alchemy/src/Cli/commands/cloudflare.ts
@@ -8,6 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Logger from "effect/Logger";
 import * as Option from "effect/Option";
+import * as Result from "effect/Result";
 import * as Stream from "effect/Stream";
 import { Command, Flag } from "effect/unstable/cli";
 import * as HttpClient from "effect/unstable/http/HttpClient";
@@ -16,11 +17,14 @@ import { AuthProviders } from "../../Auth/AuthProvider.ts";
 import { withProfileOverride } from "../../Auth/Profile.ts";
 import * as CloudflareAccess from "../../Cloudflare/Access.ts";
 import { CloudflareAuth } from "../../Cloudflare/Auth/AuthProvider.ts";
+import { collectCloudflareRequirements } from "../../Cloudflare/Auth/Requirements.ts";
 import * as CloudflareEnvironment from "../../Cloudflare/CloudflareEnvironment.ts";
 import * as CloudflareCredentials from "../../Cloudflare/Credentials.ts";
 import { CloudflareLogs } from "../../Cloudflare/Logs.ts";
 import { STATE_STORE_SCRIPT_NAME } from "../../Cloudflare/StateStore/Api.ts";
 import { bootstrap as bootstrapCloudflare } from "../../Cloudflare/StateStore/State.ts";
+import * as Provider from "../../Provider.ts";
+import { Stage } from "../../Stage.ts";
 import * as Clank from "../../Util/Clank.ts";
 import { loadConfigProvider } from "../../Util/ConfigProvider.ts";
 import { fileLogger } from "../../Util/FileLogger.ts";
@@ -28,6 +32,7 @@ import { fileLogger } from "../../Util/FileLogger.ts";
 import {
   envFile,
   formatLocalTimestamp,
+  importStack,
   instrumentCommand,
   parseSince,
   profile,
@@ -238,6 +243,16 @@ const tokenNameFlag = Flag.string("name").pipe(
   Flag.map(Option.getOrUndefined),
 );
 
+const fromStackFlag = Flag.string("from-stack").pipe(
+  Flag.withDescription(
+    "Derive the permission groups from a stack file's resources (via provider " +
+      "metadata) instead of prompting — e.g. --from-stack alchemy.run.ts. " +
+      "Mints a least-privilege token covering exactly what the stack manages.",
+  ),
+  Flag.optional,
+  Flag.map(Option.getOrUndefined),
+);
+
 const tokenAccountIdFlag = Flag.string("account-id").pipe(
   Flag.withDescription(
     "Cloudflare account ID(s) to scope the token to (comma-separated for " +
@@ -283,19 +298,73 @@ const createTokenCommand = Command.make(
     allPermissions: allPermissionsFlag,
     name: tokenNameFlag,
     accountId: tokenAccountIdFlag,
+    fromStack: fromStackFlag,
   },
   instrumentCommand(
     "cloudflare.create-token",
-    (a: { allPermissions: boolean }) => ({
+    (a: { allPermissions: boolean; fromStack: string | undefined }) => ({
       "alchemy.all_permissions": a.allPermissions,
+      "alchemy.from_stack": a.fromStack ?? "",
     }),
   )(
-    Effect.fn(function* ({ envFile, allPermissions, name, accountId }) {
+    Effect.fn(function* ({
+      envFile,
+      allPermissions,
+      name,
+      accountId,
+      fromStack,
+    }) {
       const configProvider = ConfigProvider.layer(
         yield* loadConfigProvider(envFile),
       );
 
       yield* Effect.gen(function* () {
+        // --from-stack: compile the stack (no cloud calls — resource
+        // constructors only register nodes) and derive the required
+        // permission groups from the providers' metadata. Fail fast, before
+        // prompting for the Global API Key.
+        let requiredGroups:
+          | Map<string, { name: string; resourceTypes: string[] }>
+          | undefined;
+        if (fromStack !== undefined) {
+          if (allPermissions) {
+            return yield* Effect.die(
+              "--from-stack and --all-permissions are mutually exclusive.",
+            );
+          }
+          const stackEffect = yield* importStack(fromStack);
+          const compiled = yield* stackEffect.pipe(
+            Effect.provide(
+              Layer.mergeAll(
+                Layer.succeed(AuthProviders, {}),
+                Layer.succeed(Stage, "placeholder"),
+              ),
+            ),
+            Effect.result,
+          );
+          if (Result.isFailure(compiled)) {
+            return yield* Effect.die(
+              `Could not compile stack "${fromStack}" to derive its permission requirements:\n${compiled.failure}`,
+            );
+          }
+          const stack = compiled.success;
+          const metadata = Provider.collectProviderMetadata(
+            stack.services,
+            Object.values(stack.resources).map((r: { Type: string }) => r.Type),
+          );
+          const requirements = collectCloudflareRequirements(metadata);
+          if (requirements.permissionGroups.size === 0) {
+            return yield* Effect.die(
+              `Stack "${fromStack}" declares no Cloudflare resources with token requirements; nothing to mint.`,
+            );
+          }
+          requiredGroups = requirements.permissionGroups;
+          yield* Clank.info(
+            `Derived ${requiredGroups.size} permission group(s) from ${
+              metadata.used?.size ?? 0
+            } resource type(s) in ${fromStack}.`,
+          );
+        }
         // The Global API Key is a dashboard-only secret — there is no API to
         // fetch it — so read it from the environment or prompt for it. It is
         // used only to create the token and is never stored.
@@ -379,6 +448,33 @@ const createTokenCommand = Command.make(
         let selected: typeof liveGroups;
         if (allPermissions) {
           selected = liveGroups;
+        } else if (requiredGroups !== undefined) {
+          // Resolve the stack's required groups against the live list —
+          // Cloudflare silently ignores unknown permission-group ids, so a
+          // stale catalog id must not produce a token that's quietly missing
+          // a grant. Match by id first, then fall back to the (unique) name.
+          const byId = new Map(liveGroups.map((g) => [g.id, g]));
+          const byName = new Map(liveGroups.map((g) => [g.name, g]));
+          selected = [];
+          const missing: string[] = [];
+          for (const [id, info] of requiredGroups) {
+            const live = byId.get(id) ?? byName.get(info.name);
+            if (live) {
+              selected.push(live);
+            } else {
+              missing.push(
+                `${info.name} (${id}) — needed by ${info.resourceTypes.join(", ")}`,
+              );
+            }
+          }
+          if (missing.length > 0) {
+            yield* Clank.warn(
+              "Some permission groups from the stack's metadata are not available " +
+                `to this credential and will be omitted:\n${missing
+                  .map((m) => `  - ${m}`)
+                  .join("\n")}`,
+            );
+          }
         } else {
           // Only groups whose scope maps to one of the three policy buckets
           // can actually become a policy (see `buildTokenPolicies`); offering

--- a/packages/alchemy/src/Cli/commands/cloudflare.ts
+++ b/packages/alchemy/src/Cli/commands/cloudflare.ts
@@ -1,6 +1,5 @@
 import * as cfAccounts from "@distilled.cloud/cloudflare/accounts";
 import { apiKeyCredentials } from "@distilled.cloud/cloudflare/Credentials";
-import * as user from "@distilled.cloud/cloudflare/user";
 import * as Config from "effect/Config";
 import * as ConfigProvider from "effect/ConfigProvider";
 import * as Console from "effect/Console";
@@ -11,12 +10,18 @@ import * as Option from "effect/Option";
 import * as Result from "effect/Result";
 import * as Stream from "effect/Stream";
 import { Command, Flag } from "effect/unstable/cli";
-import * as HttpClient from "effect/unstable/http/HttpClient";
 
 import { AuthProviders } from "../../Auth/AuthProvider.ts";
 import { withProfileOverride } from "../../Auth/Profile.ts";
 import * as CloudflareAccess from "../../Cloudflare/Access.ts";
 import { CloudflareAuth } from "../../Cloudflare/Auth/AuthProvider.ts";
+import {
+  buildTokenPolicies,
+  fetchLivePermissionGroups,
+  mintToken,
+  resolveRequiredGroups,
+  SELECTABLE_SCOPE_LABELS,
+} from "../../Cloudflare/Auth/CreateToken.ts";
 import { collectCloudflareRequirements } from "../../Cloudflare/Auth/Requirements.ts";
 import * as CloudflareEnvironment from "../../Cloudflare/CloudflareEnvironment.ts";
 import * as CloudflareCredentials from "../../Cloudflare/Credentials.ts";
@@ -120,74 +125,6 @@ const bootstrapCommand = Command.make(
     }),
   ),
 );
-
-/**
- * A single resolved Cloudflare token policy in the shape expected by
- * `POST /user/tokens`.
- */
-type CreateTokenPolicy = {
-  effect: "allow";
-  permissionGroups: { id: string }[];
-  resources: Record<string, unknown>;
-};
-
-/**
- * Cloudflare scopes that `buildTokenPolicies` knows how to turn into a policy,
- * mapped to a short human label shown as a hint in the selection prompt.
- * Groups with any other scope cannot be expressed as a policy and are omitted
- * from the prompt.
- */
-const SELECTABLE_SCOPE_LABELS: Record<string, string> = {
-  "com.cloudflare.api.account": "account",
-  "com.cloudflare.api.account.zone": "zone",
-  "com.cloudflare.edge.r2.bucket": "r2",
-};
-
-/**
- * Group permission groups by their Cloudflare scope and produce one policy
- * per scope, wiring up the right resource selector for each:
- *
- * - `com.cloudflare.api.account` → scoped to each selected account ID
- * - `com.cloudflare.api.account.zone` → all zones (`*`)
- * - `com.cloudflare.edge.r2.bucket` → all buckets (`*`)
- *
- * Mirrors the upstream `alchemy` "god token" policy shape. Groups with an
- * unrecognized scope are skipped, and empty policies are dropped. When more
- * than one account is selected, the account-scoped policy lists every chosen
- * account in its `resources` map so the token spans all of them.
- */
-const buildTokenPolicies = (
-  accountIds: readonly string[],
-  groups: readonly { id: string; scopes: readonly string[] }[],
-): CreateTokenPolicy[] => {
-  const buckets: Record<string, CreateTokenPolicy> = {
-    "com.cloudflare.api.account": {
-      effect: "allow",
-      permissionGroups: [],
-      resources: Object.fromEntries(
-        accountIds.map((id) => [`com.cloudflare.api.account.${id}`, "*"]),
-      ),
-    },
-    "com.cloudflare.api.account.zone": {
-      effect: "allow",
-      permissionGroups: [],
-      resources: { "com.cloudflare.api.account.zone.*": "*" },
-    },
-    "com.cloudflare.edge.r2.bucket": {
-      effect: "allow",
-      permissionGroups: [],
-      resources: { "com.cloudflare.edge.r2.bucket.*": "*" },
-    },
-  };
-  const seen = new Set<string>();
-  for (const group of groups) {
-    const bucket = buckets[group.scopes[0]!];
-    if (!bucket || seen.has(group.id)) continue;
-    seen.add(group.id);
-    bucket.permissionGroups.push({ id: group.id });
-  }
-  return Object.values(buckets).filter((p) => p.permissionGroups.length > 0);
-};
 
 /**
  * Let the user pick which Cloudflare account(s) the token is scoped to. Lists
@@ -414,63 +351,18 @@ const createTokenCommand = Command.make(
               v.trim().length === 0 ? "Token name is required" : undefined,
           }));
 
-        // Resolve permission groups live from Cloudflare instead of a static
-        // catalog. Cloudflare silently ignores permission-group IDs it doesn't
-        // recognize, so a stale local list yields a token with zero
-        // permissions. `/user/tokens/permission_groups` returns exactly the
-        // groups (and IDs) valid for this credential.
-        //
-        // We hit the endpoint with a raw GET rather than the typed distilled
-        // client: the client hard-codes the set of valid `scopes` literals,
-        // and Cloudflare keeps adding new ones (e.g. `com.cloudflare.edge.
-        // worker.script`), which makes the strict schema reject the whole
-        // response. Parsing leniently keeps us forward-compatible.
-        const http = yield* HttpClient.HttpClient;
-        const pgResponse = yield* http.get(
-          "https://api.cloudflare.com/client/v4/user/tokens/permission_groups",
-          {
-            headers: {
-              "X-Auth-Key": apiKey,
-              "X-Auth-Email": email,
-              Accept: "application/json",
-            },
-          },
-        );
-        const pgBody = (yield* pgResponse.json) as {
-          result?: { id?: string; name?: string; scopes?: string[] }[];
-        };
-        const liveGroups = (pgBody.result ?? []).flatMap((g) =>
-          g.id && g.scopes && g.scopes.length > 0
-            ? [{ id: g.id, name: g.name ?? "", scopes: g.scopes }]
-            : [],
-        );
+        const liveGroups = yield* fetchLivePermissionGroups({ apiKey, email });
 
         let selected: typeof liveGroups;
         if (allPermissions) {
           selected = liveGroups;
         } else if (requiredGroups !== undefined) {
-          // Resolve the stack's required groups against the live list —
-          // Cloudflare silently ignores unknown permission-group ids, so a
-          // stale catalog id must not produce a token that's quietly missing
-          // a grant. Match by id first, then fall back to the (unique) name.
-          const byId = new Map(liveGroups.map((g) => [g.id, g]));
-          const byName = new Map(liveGroups.map((g) => [g.name, g]));
-          selected = [];
-          const missing: string[] = [];
-          for (const [id, info] of requiredGroups) {
-            const live = byId.get(id) ?? byName.get(info.name);
-            if (live) {
-              selected.push(live);
-            } else {
-              missing.push(
-                `${info.name} (${id}) — needed by ${info.resourceTypes.join(", ")}`,
-              );
-            }
-          }
-          if (missing.length > 0) {
+          const resolved = resolveRequiredGroups(requiredGroups, liveGroups);
+          selected = resolved.selected;
+          if (resolved.missing.length > 0) {
             yield* Clank.warn(
               "Some permission groups from the stack's metadata are not available " +
-                `to this credential and will be omitted:\n${missing
+                `to this credential and will be omitted:\n${resolved.missing
                   .map((m) => `  - ${m}`)
                   .join("\n")}`,
             );
@@ -521,56 +413,29 @@ const createTokenCommand = Command.make(
           }
         }
 
-        const result = yield* withCreds(
-          user.createToken({ name: tokenName, policies }),
-        );
+        const minted = yield* mintToken({
+          auth: { apiKey, email },
+          name: tokenName,
+          policies,
+        });
 
-        if (!result.value) {
+        if (!minted.value) {
           return yield* Effect.die(
             "Cloudflare did not return a token value. Try again.",
           );
         }
-
-        // Cloudflare echoes back the policies it actually accepted. It silently
-        // drops permission groups the authenticating user isn't allowed to
-        // grant — so a token can come back with zero permissions even though
-        // the request was well-formed. Count what was granted and warn loudly
-        // if it's empty (almost always an account-role problem, not a bug).
-        const granted = (result.policies ?? []).reduce(
-          (n, p) => n + (p.permissionGroups?.length ?? 0),
-          0,
-        );
-
-        // Verify the freshly minted token actually authenticates. The
-        // Cloudflare dashboard has a long-standing rendering bug where
-        // API-created tokens show a blank permission summary (and a disabled
-        // "View"), which makes a perfectly good token look empty. A live
-        // `/user/tokens/verify` is the source of truth.
-        const status = yield* http
-          .get("https://api.cloudflare.com/client/v4/user/tokens/verify", {
-            headers: {
-              Authorization: `Bearer ${result.value}`,
-              Accept: "application/json",
-            },
-          })
-          .pipe(
-            Effect.flatMap((r) => r.json),
-            Effect.map(
-              (b) => (b as { result?: { status?: string } }).result?.status,
-            ),
-            Effect.catch(() => Effect.succeed(undefined)),
-          );
+        const granted = minted.granted;
 
         yield* Console.log("");
         yield* Console.log(
-          `Created Cloudflare API token "${result.name ?? tokenName}" (${result.id ?? "unknown id"}).`,
+          `Created Cloudflare API token "${minted.name ?? tokenName}" (${minted.id ?? "unknown id"}).`,
         );
         yield* Console.log(
-          `Granted ${granted} permission group(s) across ${result.policies?.length ?? 0} policy(ies)` +
-            (status ? `; token status: ${status}.` : "."),
+          `Granted ${granted} permission group(s) across ${minted.policiesCount} policy(ies)` +
+            (minted.status ? `; token status: ${minted.status}.` : "."),
         );
         yield* Console.log("");
-        yield* Console.log(result.value);
+        yield* Console.log(minted.value);
         yield* Console.log("");
         yield* Console.log(
           "Store this value now — Cloudflare only shows it once. " +

--- a/packages/alchemy/src/Cli/commands/deploy.ts
+++ b/packages/alchemy/src/Cli/commands/deploy.ts
@@ -14,6 +14,7 @@ import { AlchemyContext } from "../../AlchemyContext.ts";
 import { apply } from "../../Apply.ts";
 import { ArtifactStore, createArtifactStore } from "../../Artifacts.ts";
 import { AuthProviders } from "../../Auth/AuthProvider.ts";
+import { preflightStack } from "../../Auth/Preflight.ts";
 import { withProfileOverride } from "../../Auth/Profile.ts";
 import * as CLI from "../../Cli/Cli.ts";
 import * as Plan from "../../Plan.ts";
@@ -118,6 +119,10 @@ export const execStack = Effect.fn(function* ({
     const stack = yield* stackEffect;
 
     yield* Effect.gen(function* () {
+      // Warn (never block) when the active profile is missing grants the
+      // stack's resources declare via provider metadata.
+      yield* preflightStack(stack);
+
       const updatePlan = yield* Plan.make(
         destroy
           ? {

--- a/packages/alchemy/src/Cli/commands/login.ts
+++ b/packages/alchemy/src/Cli/commands/login.ts
@@ -4,10 +4,12 @@ import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Logger from "effect/Logger";
+import * as Result from "effect/Result";
 import { Command, Flag } from "effect/unstable/cli";
 
 import { AuthProviders } from "../../Auth/AuthProvider.ts";
 import { AlchemyProfile, withProfileOverride } from "../../Auth/Profile.ts";
+import * as Provider from "../../Provider.ts";
 import { Stage } from "../../Stage.ts";
 import { loadConfigProvider } from "../../Util/ConfigProvider.ts";
 import { fileLogger } from "../../Util/FileLogger.ts";
@@ -50,32 +52,56 @@ export const loginCommand = Command.make(
 
       const authProviders: AuthProviders["Service"] = {};
 
-      // build the state + providers layer to capture the Auth Providers
-      yield* Layer.build(
-        (stackEffect.providers ?? Layer.empty).pipe(
-          Layer.provideMerge(stackEffect.state ?? Layer.empty),
-          Layer.provideMerge(
-            Layer.mergeAll(
-              Layer.succeed(AuthProviders, authProviders),
-              ConfigProvider.layer(
-                withProfileOverride(
-                  yield* loadConfigProvider(envFile),
-                  profile,
-                ),
+      const baseLayer = Layer.mergeAll(
+        Layer.succeed(AuthProviders, authProviders),
+        ConfigProvider.layer(
+          withProfileOverride(yield* loadConfigProvider(envFile), profile),
+        ),
+        Logger.layer([fileLogger("out")], { mergeWithExisting: true }),
+        Layer.succeed(Stage, "placeholder"),
+      );
+
+      // Compile the stack (runs the user's program with a placeholder stage —
+      // resource constructors only register nodes, no cloud calls) so we know
+      // exactly which resource types it uses. That powers exact-mode provider
+      // metadata: providers' configure steps can then suggest exactly the
+      // scopes this stack needs. Registers the Auth Providers as a side
+      // effect of building the stack's services.
+      const compiled = yield* stackEffect.pipe(
+        Effect.provide(baseLayer),
+        Effect.result,
+      );
+
+      let providerMetadata: Provider.StackProviderMetadata | undefined;
+      if (Result.isSuccess(compiled)) {
+        const stack = compiled.success;
+        providerMetadata = Provider.collectProviderMetadata(
+          stack.services,
+          Object.values(stack.resources).map((r: { Type: string }) => r.Type),
+        );
+      } else {
+        // The stack program failed to compile (e.g. it needs env/config that
+        // isn't available before login). Fall back to building just the
+        // state + providers layer to capture the Auth Providers; configure
+        // steps then use their generic defaults.
+        yield* Layer.build(
+          (stackEffect.providers ?? Layer.empty).pipe(
+            Layer.provideMerge(stackEffect.state ?? Layer.empty),
+            Layer.provideMerge(
+              Layer.mergeAll(
+                baseLayer,
+                Layer.succeed(Stack, {
+                  actions: {},
+                  bindings: {},
+                  name: stackEffect.stackName,
+                  resources: {},
+                  stage: "placeholder",
+                }),
               ),
-              Logger.layer([fileLogger("out")], { mergeWithExisting: true }),
-              Layer.succeed(Stage, "placeholder"),
-              Layer.succeed(Stack, {
-                actions: {},
-                bindings: {},
-                name: stackEffect.stackName,
-                resources: {},
-                stage: "placeholder",
-              }),
             ),
           ),
-        ),
-      );
+        );
+      }
 
       const profiles = yield* AlchemyProfile;
 
@@ -100,7 +126,10 @@ export const loginCommand = Command.make(
 
             let cfg: { method: string };
             if (stored == null) {
-              cfg = yield* provider.configure(profile, { ci });
+              cfg = yield* provider.configure(profile, {
+                ci,
+                providerMetadata,
+              });
               yield* profiles.setProfile(profile, {
                 ...existing,
                 [provider.name]: cfg,

--- a/packages/alchemy/src/Cloudflare/AI/CustomTopics.ts
+++ b/packages/alchemy/src/Cloudflare/AI/CustomTopics.ts
@@ -111,6 +111,30 @@ export const isCustomTopics = (value: unknown): value is CustomTopics =>
 
 export const CustomTopicsProvider = () =>
   Provider.succeed(CustomTopics, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "5af6a2f284144e95a89840408439adef",
+                name: "Firewall for AI Write",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+            readPermissionGroups: [
+              {
+                id: "a2c61201f92a4e06a901f156795388a9",
+                name: "Firewall for AI Read",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+          },
+        },
+      },
+    },
     stables: ["zoneId", "initialTopics"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/AI/Dataset.ts
+++ b/packages/alchemy/src/Cloudflare/AI/Dataset.ts
@@ -175,6 +175,31 @@ export const isDataset = (value: unknown): value is Dataset =>
 
 export const DatasetProvider = () =>
   Provider.succeed(Dataset, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["aig:write"],
+            readScopes: ["aig:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "6c8a3737f07f46369c1ea1f22138daaf",
+                name: "AI Gateway Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "4dc8917b4b40457d88d3035d5dadb054",
+                name: "AI Gateway Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["datasetId", "accountId", "gatewayId", "createdAt"],
     diff: Effect.fn(function* ({ olds, news, output }) {
       if (!isResolved(news)) return undefined;

--- a/packages/alchemy/src/Cloudflare/AI/Evaluation.ts
+++ b/packages/alchemy/src/Cloudflare/AI/Evaluation.ts
@@ -144,6 +144,31 @@ export const listEvaluationTypes = (accountId: string) =>
 
 export const EvaluationProvider = () =>
   Provider.succeed(Evaluation, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["aig:write"],
+            readScopes: ["aig:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "6c8a3737f07f46369c1ea1f22138daaf",
+                name: "AI Gateway Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "4dc8917b4b40457d88d3035d5dadb054",
+                name: "AI Gateway Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["evaluationId", "accountId", "gatewayId", "createdAt"],
     diff: Effect.fn(function* ({ id, news, output }) {
       if (!isResolved(news)) return undefined;

--- a/packages/alchemy/src/Cloudflare/AI/Gateway.ts
+++ b/packages/alchemy/src/Cloudflare/AI/Gateway.ts
@@ -474,6 +474,31 @@ export const Gateway = Resource<Gateway>("Cloudflare.AI.Gateway");
 
 export const GatewayResourceProvider = () =>
   Provider.succeed(Gateway, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["aig:write"],
+            readScopes: ["aig:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "6c8a3737f07f46369c1ea1f22138daaf",
+                name: "AI Gateway Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "4dc8917b4b40457d88d3035d5dadb054",
+                name: "AI Gateway Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["gatewayId", "accountId"],
     diff: Effect.fn(function* ({ id, olds = {}, news = {}, output }) {
       if (!isResolved(news)) return undefined;

--- a/packages/alchemy/src/Cloudflare/AI/GatewayDynamicRouting.ts
+++ b/packages/alchemy/src/Cloudflare/AI/GatewayDynamicRouting.ts
@@ -314,6 +314,31 @@ export const isDynamicRouting = (
 
 export const DynamicRoutingProvider = () =>
   Provider.succeed(GatewayDynamicRouting, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["aig:write"],
+            readScopes: ["aig:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "6c8a3737f07f46369c1ea1f22138daaf",
+                name: "AI Gateway Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "4dc8917b4b40457d88d3035d5dadb054",
+                name: "AI Gateway Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["routeId", "accountId", "gatewayId", "createdAt"],
     diff: Effect.fn(function* ({ olds, news, output }) {
       if (!isResolved(news)) return undefined;

--- a/packages/alchemy/src/Cloudflare/AI/GatewayProvider.ts
+++ b/packages/alchemy/src/Cloudflare/AI/GatewayProvider.ts
@@ -185,6 +185,31 @@ export const isGatewayProvider = (value: unknown): value is GatewayProvider =>
 
 export const GatewayProviderProvider = () =>
   Provider.succeed(GatewayProvider, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["aig:write"],
+            readScopes: ["aig:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "6c8a3737f07f46369c1ea1f22138daaf",
+                name: "AI Gateway Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "4dc8917b4b40457d88d3035d5dadb054",
+                name: "AI Gateway Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["providerConfigId", "accountId", "gatewayId"],
     diff: Effect.fn(function* ({ id, news, output }) {
       if (!isResolved(news)) return undefined;

--- a/packages/alchemy/src/Cloudflare/AI/SearchInstance.ts
+++ b/packages/alchemy/src/Cloudflare/AI/SearchInstance.ts
@@ -567,6 +567,32 @@ export const isSearchInstance = (value: unknown): value is SearchInstance =>
 
 export const SearchInstanceProvider = () =>
   Provider.succeed(SearchInstance, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["ai-search:write", "ai-search:run"],
+            readScopes: ["ai-search:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "7fb8d27511b34d02994d005b520b679f",
+                name: "Auto Rag Write",
+              },
+              {
+                id: "234108c786084936a381bb19b7f4ea65",
+                name: "Auto Rag Write Run Engine",
+              },
+            ],
+            readPermissionGroups: [
+              { id: "d7887c7a417e4cf2a69f1d01c1a1dc3b", name: "Auto Rag Read" },
+            ],
+          },
+        },
+      },
+    },
     stables: [
       "instanceId",
       "accountId",

--- a/packages/alchemy/src/Cloudflare/AI/SearchNamespace.ts
+++ b/packages/alchemy/src/Cloudflare/AI/SearchNamespace.ts
@@ -186,6 +186,28 @@ export const isSearchNamespace = (value: unknown): value is SearchNamespace =>
 
 export const SearchNamespaceProvider = () =>
   Provider.succeed(SearchNamespace, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["ai-search:write"],
+            readScopes: ["ai-search:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "7fb8d27511b34d02994d005b520b679f",
+                name: "Auto Rag Write",
+              },
+            ],
+            readPermissionGroups: [
+              { id: "d7887c7a417e4cf2a69f1d01c1a1dc3b", name: "Auto Rag Read" },
+            ],
+          },
+        },
+      },
+    },
     stables: ["name", "accountId", "createdAt"],
     diff: Effect.fn(function* ({ id, olds, news, output }) {
       const { accountId } = yield* yield* CloudflareEnvironment;

--- a/packages/alchemy/src/Cloudflare/AI/SearchToken.ts
+++ b/packages/alchemy/src/Cloudflare/AI/SearchToken.ts
@@ -149,6 +149,28 @@ export const isSearchToken = (value: unknown): value is SearchToken =>
 
 export const SearchTokenProvider = () =>
   Provider.succeed(SearchToken, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["ai-search:write"],
+            readScopes: ["ai-search:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "7fb8d27511b34d02994d005b520b679f",
+                name: "Auto Rag Write",
+              },
+            ],
+            readPermissionGroups: [
+              { id: "d7887c7a417e4cf2a69f1d01c1a1dc3b", name: "Auto Rag Read" },
+            ],
+          },
+        },
+      },
+    },
     stables: ["id", "accountId", "createdAt", "createdBy"],
     diff: Effect.fn(function* ({ news, output }) {
       const { accountId } = yield* yield* CloudflareEnvironment;

--- a/packages/alchemy/src/Cloudflare/AI/SecuritySettings.ts
+++ b/packages/alchemy/src/Cloudflare/AI/SecuritySettings.ts
@@ -98,6 +98,30 @@ export const SecuritySettings = Resource<SecuritySettings>(
 
 export const SecuritySettingsProvider = () =>
   Provider.succeed(SecuritySettings, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "5af6a2f284144e95a89840408439adef",
+                name: "Firewall for AI Write",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+            readPermissionGroups: [
+              {
+                id: "a2c61201f92a4e06a901f156795388a9",
+                name: "Firewall for AI Read",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+          },
+        },
+      },
+    },
     stables: ["zoneId", "initialEnabled"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/Access/Application.ts
+++ b/packages/alchemy/src/Cloudflare/Access/Application.ts
@@ -300,6 +300,34 @@ const retryTransientAccessError = <A, E extends { _tag: string }, R>(
 
 export const ApplicationProvider = () =>
   Provider.succeed(Application, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["access:write"],
+            readScopes: ["access:read"],
+          },
+          token: {
+            // "Access: Apps and Policies Write" exists at account AND zone scope —
+            // account id form (this resource is account-scoped).
+            permissionGroups: [
+              {
+                id: "1e13c5124ca64b72b1969a67e8829049",
+                name: "Access: Apps and Policies Write",
+              },
+            ],
+            // "Access: Apps and Policies Read" (account form).
+            readPermissionGroups: [
+              {
+                id: "7ea222f6d5064cfa89ea366d7c1fee89",
+                name: "Access: Apps and Policies Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["applicationId", "aud", "type", "accountId"],
 
     diff: Effect.fn(function* ({ olds = {}, news }) {

--- a/packages/alchemy/src/Cloudflare/Access/Bookmark.ts
+++ b/packages/alchemy/src/Cloudflare/Access/Bookmark.ts
@@ -107,6 +107,33 @@ export const isBookmark = (value: unknown): value is Bookmark =>
 
 export const BookmarkProvider = () =>
   Provider.succeed(Bookmark, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["access:write"],
+            readScopes: ["access:read"],
+          },
+          token: {
+            // Bookmarks are legacy bookmark-type Access applications — governed by
+            // the account-scoped Apps and Policies groups.
+            permissionGroups: [
+              {
+                id: "1e13c5124ca64b72b1969a67e8829049",
+                name: "Access: Apps and Policies Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "7ea222f6d5064cfa89ea366d7c1fee89",
+                name: "Access: Apps and Policies Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["bookmarkId", "accountId"],
     diff: Effect.fn(function* ({ news, output }) {
       const { accountId } = yield* yield* CloudflareEnvironment;

--- a/packages/alchemy/src/Cloudflare/Access/Certificate.ts
+++ b/packages/alchemy/src/Cloudflare/Access/Certificate.ts
@@ -107,6 +107,31 @@ export const isCertificate = (value: unknown): value is Certificate =>
 
 export const CertificateProvider = () =>
   Provider.succeed(Certificate, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["access:write"],
+            readScopes: ["access:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "29d3afbfd4054af9accdd1118815ed05",
+                name: "Access: Mutual TLS Certificates Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "4f3196a5c95747b6ad82e34e1d0a694f",
+                name: "Access: Mutual TLS Certificates Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["certificateId", "accountId", "fingerprint"],
     // Account-scoped collection (pattern b). Cloudflare never returns the
     // certificate PEM body, so the persisted `certificate` field is empty for

--- a/packages/alchemy/src/Cloudflare/Access/CustomPage.ts
+++ b/packages/alchemy/src/Cloudflare/Access/CustomPage.ts
@@ -93,6 +93,33 @@ export const isCustomPage = (value: unknown): value is CustomPage =>
 
 export const CustomPageProvider = () =>
   Provider.succeed(CustomPage, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["access:write"],
+            readScopes: ["access:read"],
+          },
+          token: {
+            // "Access: Custom Pages …" — distinct from the account-level
+            // "Account Custom Pages …" groups; unique names, account scope.
+            permissionGroups: [
+              {
+                id: "4e5fd8ac327b4a358e48c66fcbeb856d",
+                name: "Access: Custom Pages Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "08e61dabe81a422dab0dea6fdef1a98a",
+                name: "Access: Custom Pages Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["customPageId", "accountId", "type"],
     // Account-scoped collection (pattern b). The list response items already
     // carry every Attribute field (uid/name/type) — read's Attributes don't

--- a/packages/alchemy/src/Cloudflare/Access/Group.ts
+++ b/packages/alchemy/src/Cloudflare/Access/Group.ts
@@ -119,6 +119,31 @@ export const isGroup = (value: unknown): value is Group =>
 
 export const GroupProvider = () =>
   Provider.succeed(Group, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["access:write"],
+            readScopes: ["access:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "bfe0d8686a584fa680f4c53b5eb0de6d",
+                name: "Access: Organizations, Identity Providers, and Groups Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "26bc23f853634eb4bff59983b9064fde",
+                name: "Access: Organizations, Identity Providers, and Groups Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["groupId", "accountId"],
     diff: Effect.fn(function* ({ news, output }) {
       const { accountId } = yield* yield* CloudflareEnvironment;

--- a/packages/alchemy/src/Cloudflare/Access/IdentityProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Access/IdentityProvider.ts
@@ -188,6 +188,31 @@ export const isIdentityProvider = (value: unknown): value is IdentityProvider =>
 
 export const IdentityProviderProvider = () =>
   Provider.succeed(IdentityProvider, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["access:write"],
+            readScopes: ["access:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "bfe0d8686a584fa680f4c53b5eb0de6d",
+                name: "Access: Organizations, Identity Providers, and Groups Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "26bc23f853634eb4bff59983b9064fde",
+                name: "Access: Organizations, Identity Providers, and Groups Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["identityProviderId", "accountId", "type"],
 
     diff: Effect.fn(function* ({ olds = {}, news, output }) {

--- a/packages/alchemy/src/Cloudflare/Access/InfrastructureTarget.ts
+++ b/packages/alchemy/src/Cloudflare/Access/InfrastructureTarget.ts
@@ -138,6 +138,34 @@ export const isInfrastructureTarget = (
 
 export const InfrastructureTargetProvider = () =>
   Provider.succeed(InfrastructureTarget, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["access:write"],
+            readScopes: ["access:read"],
+          },
+          token: {
+            // "Access: Apps and Policies Write" exists at account AND zone
+            // scope — account id form (infrastructure targets are
+            // account-scoped Zero Trust resources).
+            permissionGroups: [
+              {
+                id: "1e13c5124ca64b72b1969a67e8829049",
+                name: "Access: Apps and Policies Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "7ea222f6d5064cfa89ea366d7c1fee89",
+                name: "Access: Apps and Policies Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["targetId", "accountId", "createdAt"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/Access/KeyConfiguration.ts
+++ b/packages/alchemy/src/Cloudflare/Access/KeyConfiguration.ts
@@ -86,6 +86,31 @@ export const isKeyConfiguration = (value: unknown): value is KeyConfiguration =>
 
 export const KeyConfigurationProvider = () =>
   Provider.succeed(KeyConfiguration, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["access:write"],
+            readScopes: ["access:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "bfe0d8686a584fa680f4c53b5eb0de6d",
+                name: "Access: Organizations, Identity Providers, and Groups Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "26bc23f853634eb4bff59983b9064fde",
+                name: "Access: Organizations, Identity Providers, and Groups Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     nuke: { singleton: true },
     stables: ["accountId", "initialKeyRotationIntervalDays"],
 

--- a/packages/alchemy/src/Cloudflare/Access/McpPortal.ts
+++ b/packages/alchemy/src/Cloudflare/Access/McpPortal.ts
@@ -117,6 +117,32 @@ export const isMcpPortal = (value: unknown): value is McpPortal =>
 
 export const McpPortalProvider = () =>
   Provider.succeed(McpPortal, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            // No OAuth scope covers AI Controls MCP portals (not in ALL_SCOPES,
+            // and outside access:read/write's described surface).
+            supported: false,
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "db3d398df73946acb755c05b69edfc30",
+                name: "MCP Portals Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "b84a912ebb4a418888fec65f65c8ff3b",
+                name: "MCP Portals Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["portalId", "accountId", "createdAt"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/Access/Organization.ts
+++ b/packages/alchemy/src/Cloudflare/Access/Organization.ts
@@ -192,6 +192,31 @@ export const Organization = Resource<Organization>(
 
 export const OrganizationProvider = () =>
   Provider.succeed(Organization, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["access:write"],
+            readScopes: ["access:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "bfe0d8686a584fa680f4c53b5eb0de6d",
+                name: "Access: Organizations, Identity Providers, and Groups Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "26bc23f853634eb4bff59983b9064fde",
+                name: "Access: Organizations, Identity Providers, and Groups Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     nuke: { singleton: true },
     stables: ["accountId", "authDomain"],
     reconcile: Effect.fn(function* ({ news }) {

--- a/packages/alchemy/src/Cloudflare/Access/Policy.ts
+++ b/packages/alchemy/src/Cloudflare/Access/Policy.ts
@@ -168,6 +168,32 @@ export const Policy = Resource<Policy>("Cloudflare.Access.Policy");
 
 export const PolicyProvider = () =>
   Provider.succeed(Policy, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["access:write"],
+            readScopes: ["access:read"],
+          },
+          token: {
+            // Account-scoped "Access: Apps and Policies Write" (name collides with zone form).
+            permissionGroups: [
+              {
+                id: "1e13c5124ca64b72b1969a67e8829049",
+                name: "Access: Apps and Policies Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "7ea222f6d5064cfa89ea366d7c1fee89",
+                name: "Access: Apps and Policies Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["policyId", "accountId", "decision"],
     diff: Effect.fn(function* ({ id, olds = {}, news, output }) {
       const { accountId } = yield* yield* CloudflareEnvironment;

--- a/packages/alchemy/src/Cloudflare/Access/ServiceToken.ts
+++ b/packages/alchemy/src/Cloudflare/Access/ServiceToken.ts
@@ -127,6 +127,31 @@ export const isServiceToken = (value: unknown): value is ServiceToken =>
 
 export const ServiceTokenProvider = () =>
   Provider.succeed(ServiceToken, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["access:write"],
+            readScopes: ["access:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "a1c0fec57cf94af79479a6d827fa518c",
+                name: "Access: Service Tokens Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "91f7ce32fa614d73b7e1fc8f0e78582b",
+                name: "Access: Service Tokens Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["serviceTokenId", "accountId", "clientId"],
     list: Effect.fn(function* () {
       const { accountId } = yield* yield* CloudflareEnvironment;

--- a/packages/alchemy/src/Cloudflare/Access/Tag.ts
+++ b/packages/alchemy/src/Cloudflare/Access/Tag.ts
@@ -77,6 +77,33 @@ export const isTag = (value: unknown): value is Tag =>
 
 export const TagProvider = () =>
   Provider.succeed(Tag, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["access:write"],
+            readScopes: ["access:read"],
+          },
+          token: {
+            // Tags live under /access/tags and attach to Access applications —
+            // governed by the account-scoped Apps and Policies groups.
+            permissionGroups: [
+              {
+                id: "1e13c5124ca64b72b1969a67e8829049",
+                name: "Access: Apps and Policies Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "7ea222f6d5064cfa89ea366d7c1fee89",
+                name: "Access: Apps and Policies Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["name", "accountId"],
     list: Effect.fn(function* () {
       const { accountId } = yield* yield* CloudflareEnvironment;

--- a/packages/alchemy/src/Cloudflare/Account/Account.ts
+++ b/packages/alchemy/src/Cloudflare/Account/Account.ts
@@ -155,6 +155,28 @@ export const isAccount = (value: unknown): value is Account =>
 
 export const AccountProvider = () =>
   Provider.succeed(Account, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false, readScopes: ["account:read"] },
+          token: {
+            permissionGroups: [
+              {
+                id: "1af1fa2adc104452b74a9a3364202f20",
+                name: "Account Settings Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "c1fde68c7bcc44588cbb6ddbc16d6480",
+                name: "Account Settings Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["accountId", "type", "createdOn", "parentOrgId", "parentOrgName"],
 
     diff: Effect.fn(function* ({ olds, news, output }) {

--- a/packages/alchemy/src/Cloudflare/Account/Member.ts
+++ b/packages/alchemy/src/Cloudflare/Account/Member.ts
@@ -180,6 +180,28 @@ export const isMember = (value: unknown): value is Member =>
 
 export const MemberProvider = () =>
   Provider.succeed(Member, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false, readScopes: ["account:read"] },
+          token: {
+            permissionGroups: [
+              {
+                id: "1af1fa2adc104452b74a9a3364202f20",
+                name: "Account Settings Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "c1fde68c7bcc44588cbb6ddbc16d6480",
+                name: "Account Settings Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["memberId", "accountId", "email", "userId"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/Acm/CustomTrustStore.ts
+++ b/packages/alchemy/src/Cloudflare/Acm/CustomTrustStore.ts
@@ -125,6 +125,30 @@ export const isCustomTrustStore = (value: unknown): value is CustomTrustStore =>
 
 export const CustomTrustStoreProvider = () =>
   Provider.succeed(CustomTrustStore, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "c03055bc037c4ea9afb9a9f104b7b721",
+                name: "SSL and Certificates Write",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+            readPermissionGroups: [
+              {
+                id: "7b7216b327b04b8fbc8f524e1f9b7531",
+                name: "SSL and Certificates Read",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+          },
+        },
+      },
+    },
     stables: ["id", "zoneId", "issuer", "signature", "uploadedOn"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/Acm/TotalTls.ts
+++ b/packages/alchemy/src/Cloudflare/Acm/TotalTls.ts
@@ -133,6 +133,30 @@ export const isTotalTls = (value: unknown): value is TotalTls =>
 
 export const TotalTlsProvider = () =>
   Provider.succeed(TotalTls, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "c03055bc037c4ea9afb9a9f104b7b721",
+                name: "SSL and Certificates Write",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+            readPermissionGroups: [
+              {
+                id: "7b7216b327b04b8fbc8f524e1f9b7531",
+                name: "SSL and Certificates Read",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+          },
+        },
+      },
+    },
     nuke: { singleton: true },
     stables: ["zoneId", "initialEnabled", "initialCertificateAuthority"],
 

--- a/packages/alchemy/src/Cloudflare/Addressing/AddressMap.ts
+++ b/packages/alchemy/src/Cloudflare/Addressing/AddressMap.ts
@@ -152,6 +152,28 @@ export const isAddressMap = (value: unknown): value is AddressMap =>
 
 export const AddressMapProvider = () =>
   Provider.succeed(AddressMap, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "6ffe7f4299db4d4cb54f64e0eb12a456",
+                name: "Address Maps Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "d07270cea5484b08ad6440c985af2148",
+                name: "Address Maps Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: [
       "addressMapId",
       "accountId",

--- a/packages/alchemy/src/Cloudflare/Addressing/BgpPrefix.ts
+++ b/packages/alchemy/src/Cloudflare/Addressing/BgpPrefix.ts
@@ -127,6 +127,36 @@ export const isBgpPrefix = (value: unknown): value is BgpPrefix =>
 
 export const BgpPrefixProvider = () =>
   Provider.succeed(BgpPrefix, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "2ae23e4939d54074b7d252d27ce75a77",
+                name: "IP Prefixes: BGP On Demand Write",
+              },
+              {
+                id: "27beb7f8333b41e2b946f0e23cd8091e",
+                name: "IP Prefixes: Read",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "e763fae6ee95443b8f56f19213c5f2a5",
+                name: "IP Prefixes: BGP On Demand Read",
+              },
+              {
+                id: "27beb7f8333b41e2b946f0e23cd8091e",
+                name: "IP Prefixes: Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["bgpPrefixId", "prefixId", "accountId", "cidr", "createdAt"],
 
     diff: Effect.fn(function* ({ olds, news, output }) {

--- a/packages/alchemy/src/Cloudflare/Addressing/Prefix.ts
+++ b/packages/alchemy/src/Cloudflare/Addressing/Prefix.ts
@@ -133,6 +133,28 @@ export const isPrefix = (value: unknown): value is Prefix =>
 
 export const PrefixProvider = () =>
   Provider.succeed(Prefix, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "92b8234e99f64e05bbbc59e1dc0f76b6",
+                name: "IP Prefixes: Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "27beb7f8333b41e2b946f0e23cd8091e",
+                name: "IP Prefixes: Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: [
       "prefixId",
       "accountId",

--- a/packages/alchemy/src/Cloudflare/Addressing/PrefixDelegation.ts
+++ b/packages/alchemy/src/Cloudflare/Addressing/PrefixDelegation.ts
@@ -85,6 +85,28 @@ export const isPrefixDelegation = (value: unknown): value is PrefixDelegation =>
 
 export const PrefixDelegationProvider = () =>
   Provider.succeed(PrefixDelegation, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "92b8234e99f64e05bbbc59e1dc0f76b6",
+                name: "IP Prefixes: Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "27beb7f8333b41e2b946f0e23cd8091e",
+                name: "IP Prefixes: Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: [
       "delegationId",
       "prefixId",

--- a/packages/alchemy/src/Cloudflare/Addressing/ServiceBinding.ts
+++ b/packages/alchemy/src/Cloudflare/Addressing/ServiceBinding.ts
@@ -93,6 +93,28 @@ export const isServiceBinding = (value: unknown): value is ServiceBinding =>
 
 export const ServiceBindingProvider = () =>
   Provider.succeed(ServiceBinding, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "92b8234e99f64e05bbbc59e1dc0f76b6",
+                name: "IP Prefixes: Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "27beb7f8333b41e2b946f0e23cd8091e",
+                name: "IP Prefixes: Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["bindingId", "prefixId", "accountId", "cidr", "serviceId"],
 
     diff: Effect.fn(function* ({ olds, news, output }) {

--- a/packages/alchemy/src/Cloudflare/Alerting/NotificationPolicy.ts
+++ b/packages/alchemy/src/Cloudflare/Alerting/NotificationPolicy.ts
@@ -174,6 +174,31 @@ export const isNotificationPolicy = (
 
 export const NotificationPolicyProvider = () =>
   Provider.succeed(NotificationPolicy, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["notification:write"],
+            readScopes: ["notification:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "c3c847c5802d4ce3ba00e3e97b3c8555",
+                name: "Notifications Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "ce18edbdcebf465e9d6d1d2fc80ffd42",
+                name: "Notifications Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["policyId", "accountId", "alertType"],
 
     // Account-scoped collection: exhaustively paginate the account's

--- a/packages/alchemy/src/Cloudflare/Alerting/Silence.ts
+++ b/packages/alchemy/src/Cloudflare/Alerting/Silence.ts
@@ -116,6 +116,31 @@ export const isSilence = (value: unknown): value is Silence =>
 
 export const SilenceProvider = () =>
   Provider.succeed(Silence, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["notification:write"],
+            readScopes: ["notification:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "c3c847c5802d4ce3ba00e3e97b3c8555",
+                name: "Notifications Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "ce18edbdcebf465e9d6d1d2fc80ffd42",
+                name: "Notifications Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["silenceId", "accountId", "policyId", "createdAt"],
 
     // Silences are account-scoped; listSilences enumerates every silence in

--- a/packages/alchemy/src/Cloudflare/Alerting/Webhook.ts
+++ b/packages/alchemy/src/Cloudflare/Alerting/Webhook.ts
@@ -129,6 +129,31 @@ export const isNotificationWebhook = (
 
 export const NotificationWebhookProvider = () =>
   Provider.succeed(NotificationWebhook, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["notification:write"],
+            readScopes: ["notification:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "c3c847c5802d4ce3ba00e3e97b3c8555",
+                name: "Notifications Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "ce18edbdcebf465e9d6d1d2fc80ffd42",
+                name: "Notifications Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["webhookId", "accountId"],
 
     // Account collection (pattern b): enumerate every webhook destination in

--- a/packages/alchemy/src/Cloudflare/ApiShield/Configuration.ts
+++ b/packages/alchemy/src/Cloudflare/ApiShield/Configuration.ts
@@ -119,6 +119,30 @@ export const isConfiguration = (value: unknown): value is Configuration =>
 
 export const ConfigurationProvider = () =>
   Provider.succeed(Configuration, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "f0235726de25444a84f704b7c93afadf",
+                name: "Domain API Gateway",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+            readPermissionGroups: [
+              {
+                id: "6ced5d0d69b1422396909a62c38ab41b",
+                name: "Domain API Gateway Read",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+          },
+        },
+      },
+    },
     stables: ["zoneId", "initialAuthIdCharacteristics"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/ApiShield/Label.ts
+++ b/packages/alchemy/src/Cloudflare/ApiShield/Label.ts
@@ -105,6 +105,30 @@ export const Label = Resource<Label>(TypeId);
 
 export const LabelProvider = () =>
   Provider.succeed(Label, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "f0235726de25444a84f704b7c93afadf",
+                name: "Domain API Gateway",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+            readPermissionGroups: [
+              {
+                id: "6ced5d0d69b1422396909a62c38ab41b",
+                name: "Domain API Gateway Read",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+          },
+        },
+      },
+    },
     stables: ["zoneId", "name", "source", "createdAt"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/ApiShield/Operation.ts
+++ b/packages/alchemy/src/Cloudflare/ApiShield/Operation.ts
@@ -136,6 +136,30 @@ export const isOperation = (value: unknown): value is Operation =>
 
 export const OperationProvider = () =>
   Provider.succeed(Operation, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "f0235726de25444a84f704b7c93afadf",
+                name: "Domain API Gateway",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+            readPermissionGroups: [
+              {
+                id: "6ced5d0d69b1422396909a62c38ab41b",
+                name: "Domain API Gateway Read",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+          },
+        },
+      },
+    },
     // An operation has no mutable aspect — every attribute except the
     // last-updated timestamp survives any non-replacing deploy.
     stables: ["operationId", "zoneId", "method", "host", "endpoint"],

--- a/packages/alchemy/src/Cloudflare/ApiShield/UserSchema.ts
+++ b/packages/alchemy/src/Cloudflare/ApiShield/UserSchema.ts
@@ -121,6 +121,30 @@ export const isUserSchema = (value: unknown): value is UserSchema =>
 
 export const UserSchemaProvider = () =>
   Provider.succeed(UserSchema, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "f0235726de25444a84f704b7c93afadf",
+                name: "Domain API Gateway",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+            readPermissionGroups: [
+              {
+                id: "6ced5d0d69b1422396909a62c38ab41b",
+                name: "Domain API Gateway Read",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+          },
+        },
+      },
+    },
     stables: ["zoneId", "name", "kind"],
 
     diff: Effect.fn(function* ({ id, olds, news, output }) {

--- a/packages/alchemy/src/Cloudflare/ApiToken/AccountApiToken.ts
+++ b/packages/alchemy/src/Cloudflare/ApiToken/AccountApiToken.ts
@@ -144,6 +144,28 @@ const buildAttributes = (
 
 export const AccountApiTokenProvider = () =>
   Provider.succeed(AccountApiToken, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "5bc3f8b21c554832afc660159ab75fa4",
+                name: "Account API Tokens Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "eb56a6953c034b9d97dd838155666f06",
+                name: "Account API Tokens Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["tokenId", "accountId"],
     diff: Effect.fn(function* ({ id, olds, news = {}, output }) {
       if (!isResolved(news)) return undefined;

--- a/packages/alchemy/src/Cloudflare/ApiToken/UserApiToken.ts
+++ b/packages/alchemy/src/Cloudflare/ApiToken/UserApiToken.ts
@@ -110,6 +110,14 @@ type UserApiTokenAttributes = UserApiToken["Attributes"];
 
 export const UserApiTokenProvider = () =>
   Provider.succeed(UserApiToken, {
+    metadata: {
+      cloudflare: {
+        scope: "user",
+        auth: {
+          oauth: { supported: false },
+        },
+      },
+    },
     stables: ["tokenId"],
     diff: Effect.fn(function* ({ id, olds, news = {}, output }) {
       if (!isResolved(news)) return undefined;

--- a/packages/alchemy/src/Cloudflare/Argo/SmartRouting.ts
+++ b/packages/alchemy/src/Cloudflare/Argo/SmartRouting.ts
@@ -105,6 +105,36 @@ export const isSmartRouting = (value: unknown): value is SmartRouting =>
 
 export const SmartRoutingProvider = () =>
   Provider.succeed(SmartRouting, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "3030687196b94b638145a3953da2b699",
+                name: "Zone Settings Write",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "517b21aee92c4d89936c976ba6e4be55",
+                name: "Zone Settings Read",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["zoneId", "initialValue"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/Argo/TieredCaching.ts
+++ b/packages/alchemy/src/Cloudflare/Argo/TieredCaching.ts
@@ -106,6 +106,36 @@ export const isTieredCaching = (value: unknown): value is TieredCaching =>
 
 export const TieredCachingProvider = () =>
   Provider.succeed(TieredCaching, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "3030687196b94b638145a3953da2b699",
+                name: "Zone Settings Write",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "517b21aee92c4d89936c976ba6e4be55",
+                name: "Zone Settings Read",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     nuke: { singleton: true },
     stables: ["zoneId", "initialValue"],
 

--- a/packages/alchemy/src/Cloudflare/Auth/AuthProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Auth/AuthProvider.ts
@@ -12,6 +12,7 @@ import {
   AuthError,
   AuthProviderLayer,
   type ConfigureContext,
+  type PreflightFinding,
 } from "../../Auth/AuthProvider.ts";
 import { CredentialsStore, displayRedacted } from "../../Auth/Credentials.ts";
 import {
@@ -20,8 +21,13 @@ import {
   getEnvRequired,
   retryOnce,
 } from "../../Auth/Env.ts";
+import type { StackProviderMetadata } from "../../Provider.ts";
 import * as Clank from "../../Util/Clank.ts";
 import * as OAuthClient from "./OAuthClient.ts";
+import {
+  collectCloudflareRequirements,
+  suggestOAuthScopes,
+} from "./Requirements.ts";
 
 const options: Array<{
   value: CloudflareAuthConfig["method"];
@@ -137,29 +143,57 @@ const promptAccountId = () =>
     ),
   );
 
-const promptOAuthScopes = () =>
-  Clank.confirm({
-    message: "Customize OAuth scopes? (default covers typical use cases)",
-    initialValue: false,
-  }).pipe(
-    retryOnce,
-    Effect.flatMap((customize) => {
-      if (!customize) return Effect.succeed([...DEFAULT_SCOPES]);
-      return Clank.multiselect({
-        message: "Select OAuth scopes",
-        initialValues: DEFAULT_SCOPES as string[],
-        options: Object.entries(ALL_SCOPES).map(([value, hint]) => ({
-          value: value as string,
-          label: value,
-          hint,
-        })),
-        required: true,
-      }).pipe(
-        Effect.map((s) => s as string[]),
-        retryOnce,
+const promptOAuthScopes = (ctx: ConfigureContext) =>
+  Effect.gen(function* () {
+    // Only trust the analysis in exact mode (the stack compiled and we know
+    // which resource types it uses) — the whole-cloud fallback would suggest
+    // nearly every scope in the catalog.
+    const requirements =
+      ctx.providerMetadata?.used !== undefined
+        ? collectCloudflareRequirements(ctx.providerMetadata)
+        : undefined;
+    const suggested: string[] = requirements
+      ? suggestOAuthScopes(requirements)
+      : [...DEFAULT_SCOPES];
+
+    if (requirements && requirements.oauthUnsupported.length > 0) {
+      const list = requirements.oauthUnsupported;
+      const shown = list
+        .slice(0, 8)
+        .map((t) => `  - ${t}`)
+        .join("\n");
+      const more = list.length > 8 ? `\n  … and ${list.length - 8} more` : "";
+      yield* Clank.warn(
+        `Cloudflare: ${list.length} resource type(s) in this stack cannot be fully managed with an OAuth user token:\n${shown}${more}\n` +
+          "Consider API Token auth instead, or mint a scoped token with: alchemy cloudflare create-token --from-stack",
       );
-    }),
-  );
+    }
+
+    return yield* Clank.confirm({
+      message: requirements
+        ? `Customize OAuth scopes? (default: ${suggested.length} scopes derived from this stack's resources)`
+        : "Customize OAuth scopes? (default covers typical use cases)",
+      initialValue: false,
+    }).pipe(
+      retryOnce,
+      Effect.flatMap((customize) => {
+        if (!customize) return Effect.succeed(suggested);
+        return Clank.multiselect({
+          message: "Select OAuth scopes",
+          initialValues: suggested,
+          options: Object.entries(ALL_SCOPES).map(([value, hint]) => ({
+            value: value as string,
+            label: value,
+            hint,
+          })),
+          required: true,
+        }).pipe(
+          Effect.map((s) => s as string[]),
+          retryOnce,
+        );
+      }),
+    );
+  });
 
 /**
  * Layer that registers the Cloudflare {@link AuthProvider} into the
@@ -263,8 +297,11 @@ export const CloudflareAuth = AuthProviderLayer<
       );
     });
 
-    const configureOAuth = Effect.fn(function* (profileName: string) {
-      const scopes = yield* promptOAuthScopes();
+    const configureOAuth = Effect.fn(function* (
+      profileName: string,
+      ctx: ConfigureContext,
+    ) {
+      const scopes = yield* promptOAuthScopes(ctx);
 
       const oauthCreds = yield* oauthLogin(profileName, scopes);
 
@@ -285,7 +322,7 @@ export const CloudflareAuth = AuthProviderLayer<
       };
     });
 
-    const configureInteractive = (profileName: string) =>
+    const configureInteractive = (profileName: string, ctx: ConfigureContext) =>
       Clank.select({
         message: "Cloudflare authentication method",
         options,
@@ -293,7 +330,7 @@ export const CloudflareAuth = AuthProviderLayer<
         Effect.flatMap((method) =>
           Match.value(method).pipe(
             Match.when("env", () => Effect.succeed({ method: "env" as const })),
-            Match.when("oauth", () => configureOAuth(profileName)),
+            Match.when("oauth", () => configureOAuth(profileName, ctx)),
             Match.when("stored", () => loginStored(profileName)),
             Match.exhaustive,
           ),
@@ -305,7 +342,7 @@ export const CloudflareAuth = AuthProviderLayer<
         if (ctx.ci) {
           return { method: "env" as const };
         }
-        return yield* configureInteractive(profileName);
+        return yield* configureInteractive(profileName, ctx);
       }).pipe(
         Effect.mapError(
           (e) =>
@@ -563,15 +600,62 @@ export const CloudflareAuth = AuthProviderLayer<
         ),
       );
 
+    const preflight = (
+      _profileName: string,
+      config: CloudflareAuthConfig,
+      metadata: StackProviderMetadata,
+    ) =>
+      Effect.sync(() => {
+        const findings: PreflightFinding[] = [];
+        // Only exact mode is actionable — the whole-cloud fallback would
+        // flag a grant for every resource type alchemy supports.
+        if (metadata.used === undefined) return findings;
+        const requirements = collectCloudflareRequirements(metadata);
+        if (config.method === "oauth") {
+          const granted = new Set(config.scopes);
+          for (const [scope, resourceTypes] of requirements.oauthScopes) {
+            if (!granted.has(scope)) {
+              findings.push({
+                severity: "warning",
+                missing: scope,
+                resourceTypes,
+                remediation:
+                  "Run `alchemy login --configure` to re-authorize with the missing scopes",
+              });
+            }
+          }
+          for (const resourceType of requirements.oauthUnsupported) {
+            findings.push({
+              severity: "warning",
+              missing: "no OAuth scope exists for this product",
+              resourceTypes: [resourceType],
+              remediation:
+                "Use an API token: alchemy cloudflare create-token --from-stack",
+            });
+          }
+        }
+        // Token/env methods: we don't know the token's grants (until
+        // create-token --from-stack records them), so nothing to diff yet.
+        return findings;
+      });
+
     return {
       configure: configureCredentials,
       logout,
       login,
       prettyPrint,
       read: resolveCredentials,
+      preflight,
     };
   }),
 );
+
+/**
+ * An OAuth scope Cloudflare's dashboard OAuth flow can grant — the keys of
+ * {@link ALL_SCOPES}. Used by provider metadata to declare which scopes a
+ * resource's lifecycle requires.
+ */
+export type OAuthScope = keyof typeof ALL_SCOPES;
 
 export const ALL_SCOPES = {
   "access:read":

--- a/packages/alchemy/src/Cloudflare/Auth/AuthProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Auth/AuthProvider.ts
@@ -23,10 +23,18 @@ import {
 } from "../../Auth/Env.ts";
 import type { StackProviderMetadata } from "../../Provider.ts";
 import * as Clank from "../../Util/Clank.ts";
+import * as CloudflareCredentials from "../Credentials.ts";
+import {
+  buildTokenPolicies,
+  fetchLivePermissionGroups,
+  mintToken,
+  resolveRequiredGroups,
+} from "./CreateToken.ts";
 import * as OAuthClient from "./OAuthClient.ts";
 import {
   collectCloudflareRequirements,
   suggestOAuthScopes,
+  type CloudflareRequirements,
 } from "./Requirements.ts";
 
 const options: Array<{
@@ -53,7 +61,17 @@ const options: Array<{
 
 export type CloudflareAuthConfig =
   | { method: "env" }
-  | { method: "stored"; credentialType: "apiToken" }
+  | {
+      method: "stored";
+      credentialType: "apiToken";
+      /**
+       * Permission-group ids the token was minted with (present when the
+       * token was created via `alchemy login --configure`'s scoped-token
+       * flow). Lets deploy preflight diff required-vs-granted for API-token
+       * profiles the same way it does for OAuth scopes.
+       */
+      permissionGroupIds?: string[];
+    }
   | { method: "stored"; credentialType: "apiKey" }
   | { method: "oauth"; scopes: string[]; accountId: string };
 
@@ -131,6 +149,43 @@ const selectAccount = (accessToken: string) =>
       })),
     }).pipe(retryOnce);
   }).pipe((e) => withOAuthCredentials(accessToken, e));
+
+/**
+ * List accounts with Global API Key credentials and pick one — the mint flow
+ * analogue of {@link selectAccount} (which authenticates with an OAuth token).
+ */
+const selectAccountWithApiKey = (auth: { apiKey: string; email: string }) =>
+  Effect.gen(function* () {
+    const list = yield* cfAccounts.listAccounts;
+    const response = yield* list({});
+    const accounts = response.result;
+    if (accounts.length === 0) {
+      return yield* new AuthError({
+        message: "Cloudflare: no accounts found for this credential.",
+      });
+    }
+    if (accounts.length === 1) {
+      const account = accounts[0]!;
+      yield* Clank.info(
+        `Cloudflare: using account: ${account.name} (${account.id})`,
+      );
+      return account.id;
+    }
+    return yield* Clank.select({
+      message: "Select a Cloudflare account",
+      options: accounts.map((a) => ({
+        value: a.id,
+        label: a.name,
+        hint: a.id,
+      })),
+    }).pipe(retryOnce);
+  }).pipe(
+    Effect.provideService(
+      CloudflareCredentials.Credentials,
+      Effect.succeed(CfCredentialsModule.apiKeyCredentials(auth)),
+    ),
+    Effect.provide(FetchHttpClient.layer),
+  );
 
 const promptAccountId = () =>
   getEnv("CLOUDFLARE_ACCOUNT_ID").pipe(
@@ -234,7 +289,110 @@ export const CloudflareAuth = AuthProviderLayer<
         return credentials;
       });
 
-    const loginStored = Effect.fn(function* (profileName: string) {
+    /**
+     * Mint a token scoped to exactly the permission groups the stack's
+     * resources require (from provider metadata) and store it as the
+     * profile's API-token credential. Authenticates the mint with the
+     * account's Global API Key — Cloudflare only mints a token whose
+     * permissions the authenticating credential can grant, and OAuth/scoped
+     * tokens silently produce a token with zero permissions. The key is used
+     * only for the mint and is never stored.
+     */
+    const mintStackToken = Effect.fn(function* (
+      profileName: string,
+      requirements: CloudflareRequirements,
+    ) {
+      yield* Clank.info(
+        "Minting uses your Global API Key (bottom of " +
+          "https://dash.cloudflare.com/profile/api-tokens). It is only used " +
+          "to create the token and is never stored.",
+      );
+      const envApiKey = yield* getEnv("CLOUDFLARE_API_KEY");
+      const apiKey =
+        envApiKey ??
+        (yield* Clank.password({
+          message: "Cloudflare Global API Key",
+          validate: (v) => (v.trim().length === 0 ? "Required" : undefined),
+        }).pipe(retryOnce));
+      const envEmail = yield* getEnv("CLOUDFLARE_EMAIL");
+      const email =
+        envEmail ??
+        (yield* Clank.text({
+          message: "Cloudflare account email",
+          validate: (v) => (v.trim().length === 0 ? "Required" : undefined),
+        }).pipe(retryOnce));
+
+      const accountId = yield* selectAccountWithApiKey({ apiKey, email });
+
+      const tokenName = yield* Clank.text({
+        message: "Token name",
+        placeholder: "alchemy",
+        defaultValue: "alchemy",
+      }).pipe(retryOnce);
+
+      const liveGroups = yield* fetchLivePermissionGroups({
+        apiKey,
+        email,
+      }).pipe(Effect.provide(FetchHttpClient.layer));
+      const { selected, missing } = resolveRequiredGroups(
+        requirements.permissionGroups,
+        liveGroups,
+      );
+      if (missing.length > 0) {
+        yield* Clank.warn(
+          "Some permission groups from the stack's metadata are not " +
+            `available to this credential and will be omitted:\n${missing
+              .map((m) => `  - ${m}`)
+              .join("\n")}`,
+        );
+      }
+      const policies = buildTokenPolicies([accountId], selected);
+      if (policies.length === 0) {
+        return yield* new AuthError({
+          message:
+            "Cloudflare: no permission groups resolved for this stack; cannot create a token.",
+        });
+      }
+
+      const minted = yield* mintToken({
+        auth: { apiKey, email },
+        name: tokenName,
+        policies,
+      }).pipe(Effect.provide(FetchHttpClient.layer));
+      if (!minted.value) {
+        return yield* new AuthError({
+          message: "Cloudflare did not return a token value. Try again.",
+        });
+      }
+      if (minted.granted === 0) {
+        yield* Clank.warn(
+          "Cloudflare granted 0 permissions. A token can only carry " +
+            "permissions the authenticating user already holds — check that " +
+            "the Global API Key's user is a Super Administrator on the " +
+            "selected account.",
+        );
+      }
+
+      yield* store.write<CloudflareStoredCredentials>(
+        profileName,
+        "cf-stored",
+        { type: "apiToken", apiToken: minted.value, accountId },
+      );
+      yield* Clank.success(
+        `Cloudflare: created token "${minted.name ?? tokenName}" with ` +
+          `${minted.granted} permission group(s) and saved credentials.`,
+      );
+      return {
+        method: "stored" as const,
+        credentialType: "apiToken" as const,
+        permissionGroupIds: selected.map((g) => g.id),
+      };
+    });
+
+    const loginStored = Effect.fn(function* (
+      profileName: string,
+      ctx: ConfigureContext,
+    ) {
       const credentialType = yield* Clank.select({
         message: "Cloudflare credential type",
         options: [
@@ -250,6 +408,34 @@ export const CloudflareAuth = AuthProviderLayer<
       return yield* Match.value(credentialType).pipe(
         Match.when("apiToken", () =>
           Effect.gen(function* () {
+            // When the stack compiled at configure time we know exactly which
+            // permission groups it needs — offer to mint that token here
+            // instead of making the user click through the dashboard.
+            if (ctx.providerMetadata?.used !== undefined) {
+              const requirements = collectCloudflareRequirements(
+                ctx.providerMetadata,
+              );
+              if (requirements.permissionGroups.size > 0) {
+                const source = yield* Clank.select({
+                  message: "Cloudflare API Token",
+                  options: [
+                    {
+                      value: "create" as const,
+                      label: `Create a token scoped to this stack (${requirements.permissionGroups.size} permission groups)`,
+                      hint: "mints with your Global API Key; only the token is stored",
+                    },
+                    {
+                      value: "paste" as const,
+                      label: "Paste an existing token",
+                    },
+                  ],
+                }).pipe(retryOnce);
+                if (source === "create") {
+                  return yield* mintStackToken(profileName, requirements);
+                }
+              }
+            }
+
             const apiToken = yield* Clank.password({
               message: "Cloudflare API Token",
               validate: (v) => (v.length === 0 ? "Required" : undefined),
@@ -331,7 +517,7 @@ export const CloudflareAuth = AuthProviderLayer<
           Match.value(method).pipe(
             Match.when("env", () => Effect.succeed({ method: "env" as const })),
             Match.when("oauth", () => configureOAuth(profileName, ctx)),
-            Match.when("stored", () => loginStored(profileName)),
+            Match.when("stored", () => loginStored(profileName, ctx)),
             Match.exhaustive,
           ),
         ),
@@ -511,7 +697,12 @@ export const CloudflareAuth = AuthProviderLayer<
               .read<CloudflareStoredCredentials>(profileName, "cf-stored")
               .pipe(
                 Effect.flatMap((creds) =>
-                  creds == null ? loginStored(profileName) : Effect.void,
+                  // `login` re-collects a missing credential outside the
+                  // configure flow — no stack metadata available, so the
+                  // create-token option is not offered here.
+                  creds == null
+                    ? loginStored(profileName, { ci: false })
+                    : Effect.void,
                 ),
               ),
           ),
@@ -634,8 +825,29 @@ export const CloudflareAuth = AuthProviderLayer<
             });
           }
         }
-        // Token/env methods: we don't know the token's grants (until
-        // create-token --from-stack records them), so nothing to diff yet.
+        if (
+          config.method === "stored" &&
+          config.credentialType === "apiToken" &&
+          config.permissionGroupIds !== undefined
+        ) {
+          // The token was minted by the scoped-token login flow, which
+          // recorded its permission-group ids — diff against what the stack
+          // now requires.
+          const granted = new Set(config.permissionGroupIds);
+          for (const [id, info] of requirements.permissionGroups) {
+            if (!granted.has(id)) {
+              findings.push({
+                severity: "warning",
+                missing: `${info.name} (${id})`,
+                resourceTypes: info.resourceTypes,
+                remediation:
+                  "Re-run `alchemy login --configure` to mint a token with the missing permission groups",
+              });
+            }
+          }
+        }
+        // Other token/env configs: the token's grants are unknown, so
+        // nothing to diff.
         return findings;
       });
 

--- a/packages/alchemy/src/Cloudflare/Auth/CreateToken.ts
+++ b/packages/alchemy/src/Cloudflare/Auth/CreateToken.ts
@@ -1,0 +1,228 @@
+import { apiKeyCredentials } from "@distilled.cloud/cloudflare/Credentials";
+import * as user from "@distilled.cloud/cloudflare/user";
+import * as Effect from "effect/Effect";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as CloudflareCredentials from "../Credentials.ts";
+
+/**
+ * Shared machinery for minting Cloudflare API tokens (`POST /user/tokens`),
+ * used by both `alchemy cloudflare create-token` and the token-creation path
+ * inside `alchemy login --configure`.
+ *
+ * Minting always authenticates with the account's **Global API Key**:
+ * Cloudflare only mints a token whose permissions the authenticating
+ * credential is allowed to grant, and OAuth/scoped tokens silently produce a
+ * token with zero permissions. The key is used only to create the token and
+ * is never stored.
+ */
+
+export interface GlobalKeyAuth {
+  apiKey: string;
+  email: string;
+}
+
+export interface LivePermissionGroup {
+  id: string;
+  name: string;
+  scopes: string[];
+}
+
+/**
+ * A single resolved Cloudflare token policy in the shape expected by
+ * `POST /user/tokens`.
+ */
+export type CreateTokenPolicy = {
+  effect: "allow";
+  permissionGroups: { id: string }[];
+  resources: Record<string, unknown>;
+};
+
+/**
+ * Cloudflare scopes that {@link buildTokenPolicies} knows how to turn into a
+ * policy, mapped to a short human label shown as a hint in selection prompts.
+ * Groups with any other scope cannot be expressed as a policy.
+ */
+export const SELECTABLE_SCOPE_LABELS: Record<string, string> = {
+  "com.cloudflare.api.account": "account",
+  "com.cloudflare.api.account.zone": "zone",
+  "com.cloudflare.edge.r2.bucket": "r2",
+};
+
+/**
+ * Resolve permission groups live from Cloudflare instead of a static catalog.
+ * Cloudflare silently ignores permission-group IDs it doesn't recognize, so a
+ * stale local list yields a token with zero permissions.
+ * `/user/tokens/permission_groups` returns exactly the groups (and IDs) valid
+ * for this credential.
+ *
+ * Hits the endpoint with a raw GET rather than the typed distilled client:
+ * the client hard-codes the set of valid `scopes` literals, and Cloudflare
+ * keeps adding new ones (e.g. `com.cloudflare.edge.worker.script`), which
+ * makes the strict schema reject the whole response. Parsing leniently keeps
+ * us forward-compatible.
+ */
+export const fetchLivePermissionGroups = (auth: GlobalKeyAuth) =>
+  Effect.gen(function* () {
+    const http = yield* HttpClient.HttpClient;
+    const response = yield* http.get(
+      "https://api.cloudflare.com/client/v4/user/tokens/permission_groups",
+      {
+        headers: {
+          "X-Auth-Key": auth.apiKey,
+          "X-Auth-Email": auth.email,
+          Accept: "application/json",
+        },
+      },
+    );
+    const body = (yield* response.json) as {
+      result?: { id?: string; name?: string; scopes?: string[] }[];
+    };
+    return (body.result ?? []).flatMap((g) =>
+      g.id && g.scopes && g.scopes.length > 0
+        ? [{ id: g.id, name: g.name ?? "", scopes: g.scopes }]
+        : [],
+    );
+  });
+
+/**
+ * Group permission groups by their Cloudflare scope and produce one policy
+ * per scope, wiring up the right resource selector for each:
+ *
+ * - `com.cloudflare.api.account` → scoped to each selected account ID
+ * - `com.cloudflare.api.account.zone` → all zones (`*`)
+ * - `com.cloudflare.edge.r2.bucket` → all buckets (`*`)
+ *
+ * Mirrors the upstream `alchemy` "god token" policy shape. Groups with an
+ * unrecognized scope are skipped, and empty policies are dropped. When more
+ * than one account is selected, the account-scoped policy lists every chosen
+ * account in its `resources` map so the token spans all of them.
+ */
+export const buildTokenPolicies = (
+  accountIds: readonly string[],
+  groups: readonly { id: string; scopes: readonly string[] }[],
+): CreateTokenPolicy[] => {
+  const buckets: Record<string, CreateTokenPolicy> = {
+    "com.cloudflare.api.account": {
+      effect: "allow",
+      permissionGroups: [],
+      resources: Object.fromEntries(
+        accountIds.map((id) => [`com.cloudflare.api.account.${id}`, "*"]),
+      ),
+    },
+    "com.cloudflare.api.account.zone": {
+      effect: "allow",
+      permissionGroups: [],
+      resources: { "com.cloudflare.api.account.zone.*": "*" },
+    },
+    "com.cloudflare.edge.r2.bucket": {
+      effect: "allow",
+      permissionGroups: [],
+      resources: { "com.cloudflare.edge.r2.bucket.*": "*" },
+    },
+  };
+  const seen = new Set<string>();
+  for (const group of groups) {
+    const bucket = buckets[group.scopes[0]!];
+    if (!bucket || seen.has(group.id)) continue;
+    seen.add(group.id);
+    bucket.permissionGroups.push({ id: group.id });
+  }
+  return Object.values(buckets).filter((p) => p.permissionGroups.length > 0);
+};
+
+/**
+ * Resolve the permission groups a stack requires (from provider metadata)
+ * against the live list — by id first, then by (unique) name as a fallback
+ * for retired/renamed ids. Anything unresolvable is reported in `missing`
+ * rather than silently dropped.
+ */
+export const resolveRequiredGroups = (
+  required: ReadonlyMap<string, { name: string; resourceTypes: string[] }>,
+  live: LivePermissionGroup[],
+): { selected: LivePermissionGroup[]; missing: string[] } => {
+  const byId = new Map(live.map((g) => [g.id, g]));
+  const byName = new Map(live.map((g) => [g.name, g]));
+  const selected: LivePermissionGroup[] = [];
+  const missing: string[] = [];
+  for (const [id, info] of required) {
+    const match = byId.get(id) ?? byName.get(info.name);
+    if (match) {
+      selected.push(match);
+    } else {
+      missing.push(
+        `${info.name} (${id}) — needed by ${info.resourceTypes.join(", ")}`,
+      );
+    }
+  }
+  return { selected, missing };
+};
+
+export interface MintedToken {
+  /** The token secret. Cloudflare only returns it once. */
+  value: string | undefined;
+  id: string | undefined;
+  name: string | undefined;
+  /**
+   * Permission groups Cloudflare actually granted. It silently drops groups
+   * the authenticating user isn't allowed to grant, so a token can come back
+   * with zero permissions even though the request was well-formed (almost
+   * always an account-role problem).
+   */
+  granted: number;
+  policiesCount: number;
+  /** Live `/user/tokens/verify` status of the minted token, if reachable. */
+  status: string | undefined;
+}
+
+/**
+ * Create the token and verify it authenticates. The Cloudflare dashboard has
+ * a long-standing rendering bug where API-created tokens show a blank
+ * permission summary, so a live `/user/tokens/verify` is the source of truth.
+ */
+export const mintToken = (options: {
+  auth: GlobalKeyAuth;
+  name: string;
+  policies: CreateTokenPolicy[];
+}) =>
+  Effect.gen(function* () {
+    const result = yield* user
+      .createToken({ name: options.name, policies: options.policies })
+      .pipe(
+        Effect.provideService(
+          CloudflareCredentials.Credentials,
+          Effect.succeed(apiKeyCredentials(options.auth)),
+        ),
+      );
+
+    const granted = (result.policies ?? []).reduce(
+      (n, p) => n + (p.permissionGroups?.length ?? 0),
+      0,
+    );
+
+    const http = yield* HttpClient.HttpClient;
+    const status = result.value
+      ? yield* http
+          .get("https://api.cloudflare.com/client/v4/user/tokens/verify", {
+            headers: {
+              Authorization: `Bearer ${result.value}`,
+              Accept: "application/json",
+            },
+          })
+          .pipe(
+            Effect.flatMap((r) => r.json),
+            Effect.map(
+              (b) => (b as { result?: { status?: string } }).result?.status,
+            ),
+            Effect.catch(() => Effect.succeed(undefined)),
+          )
+      : undefined;
+
+    return {
+      value: result.value ?? undefined,
+      id: result.id ?? undefined,
+      name: result.name ?? undefined,
+      granted,
+      policiesCount: result.policies?.length ?? 0,
+      status,
+    } satisfies MintedToken;
+  });

--- a/packages/alchemy/src/Cloudflare/Auth/Requirements.ts
+++ b/packages/alchemy/src/Cloudflare/Auth/Requirements.ts
@@ -1,0 +1,97 @@
+import type {
+  ProviderMetadataIndex,
+  StackProviderMetadata,
+} from "../../Provider.ts";
+import type { OAuthScope } from "./AuthProvider.ts";
+
+/**
+ * Cloud-specific analysis of {@link StackProviderMetadata} for Cloudflare —
+ * the union of what the stack's Cloudflare resources require from a
+ * credential. Consumed by `alchemy login` (OAuth scope preselection),
+ * `alchemy cloudflare create-token --from-stack` (least-privilege token
+ * minting), and the deploy preflight.
+ *
+ * Every entry carries the resource types that demanded it so prompts and
+ * warnings can explain *why* a grant is needed.
+ */
+export interface CloudflareRequirements {
+  /** OAuth scope → resource types requiring it (full lifecycle). */
+  oauthScopes: Map<OAuthScope, string[]>;
+  /**
+   * Resource types whose full lifecycle cannot run on an OAuth user token
+   * (`metadata.cloudflare.auth.oauth.supported === false`) — they need an
+   * API token.
+   */
+  oauthUnsupported: string[];
+  /** Permission-group id → name + resource types requiring it. */
+  permissionGroups: Map<string, { name: string; resourceTypes: string[] }>;
+  /** True when any zone-scoped resource is present. */
+  hasZoneScoped: boolean;
+}
+
+const push = <K>(map: Map<K, string[]>, key: K, resourceType: string) => {
+  const list = map.get(key);
+  if (list) list.push(resourceType);
+  else map.set(key, [resourceType]);
+};
+
+/**
+ * Union the `cloudflare` metadata namespaces across the given index. Prefers
+ * the exact-mode `used` subset; falls back to `all` (whole-cloud — over-asks)
+ * when the stack couldn't be compiled.
+ */
+export const collectCloudflareRequirements = (
+  metadata: StackProviderMetadata,
+): CloudflareRequirements => {
+  const index: ProviderMetadataIndex = metadata.used ?? metadata.all;
+  const requirements: CloudflareRequirements = {
+    oauthScopes: new Map(),
+    oauthUnsupported: [],
+    permissionGroups: new Map(),
+    hasZoneScoped: false,
+  };
+  for (const [resourceType, entry] of index) {
+    const cloudflare = entry.cloudflare;
+    if (cloudflare === undefined) continue;
+    if (cloudflare.scope === "zone") {
+      requirements.hasZoneScoped = true;
+    }
+    const oauth = cloudflare.auth?.oauth;
+    if (oauth?.supported === false) {
+      requirements.oauthUnsupported.push(resourceType);
+    }
+    for (const scope of oauth?.scopes ?? []) {
+      push(requirements.oauthScopes, scope, resourceType);
+    }
+    const token = cloudflare.auth?.token;
+    for (const group of token?.permissionGroups ?? []) {
+      const existing = requirements.permissionGroups.get(group.id);
+      if (existing) existing.resourceTypes.push(resourceType);
+      else
+        requirements.permissionGroups.set(group.id, {
+          name: group.name,
+          resourceTypes: [resourceType],
+        });
+    }
+  }
+  requirements.oauthUnsupported.sort();
+  return requirements;
+};
+
+/**
+ * Base scopes every profile needs regardless of resources: account/user
+ * enumeration for configure, plus zone listing when zone-scoped resources
+ * are present.
+ */
+export const suggestOAuthScopes = (
+  requirements: CloudflareRequirements,
+): OAuthScope[] => {
+  const scopes = new Set<OAuthScope>(["account:read", "user:read"]);
+  if (requirements.hasZoneScoped) {
+    scopes.add("zone:read");
+  }
+  for (const scope of requirements.oauthScopes.keys()) {
+    scopes.add(scope);
+  }
+  return [...scopes].sort();
+};

--- a/packages/alchemy/src/Cloudflare/BotManagement/BotManagement.ts
+++ b/packages/alchemy/src/Cloudflare/BotManagement/BotManagement.ts
@@ -256,6 +256,36 @@ type SettingsKey = (typeof SETTINGS_KEYS)[number];
 
 export const BotManagementProvider = () =>
   Provider.succeed(BotManagement, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "3b94c49258ec4573b06d51d99b6416c0",
+                name: "Bot Management Write",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "07bea2220b2343fa9fae15656c0d8e88",
+                name: "Bot Management Read",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     nuke: { singleton: true },
     stables: ["zoneId", "initialSettings"],
 

--- a/packages/alchemy/src/Cloudflare/Cache/OriginCloudRegion.ts
+++ b/packages/alchemy/src/Cloudflare/Cache/OriginCloudRegion.ts
@@ -141,6 +141,36 @@ const sameIp = (a: string, b: string): boolean =>
 
 export const OriginCloudRegionProvider = () =>
   Provider.succeed(OriginCloudRegion, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "9ff81cbbe65c400b97d92c3c1033cab6",
+                name: "Cache Settings Write",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "3245da1cf36c45c3847bb9b483c62f97",
+                name: "Cache Settings Read",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["zoneId", "originIp"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/Cache/RegionalTieredCache.ts
+++ b/packages/alchemy/src/Cloudflare/Cache/RegionalTieredCache.ts
@@ -121,6 +121,36 @@ const transientAuthRetrySchedule = Schedule.exponential("500 millis").pipe(
 
 export const RegionalTieredCacheProvider = () =>
   Provider.succeed(RegionalTieredCache, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "9ff81cbbe65c400b97d92c3c1033cab6",
+                name: "Cache Settings Write",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "3245da1cf36c45c3847bb9b483c62f97",
+                name: "Cache Settings Read",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["zoneId", "initialValue"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/Cache/Reserve.ts
+++ b/packages/alchemy/src/Cloudflare/Cache/Reserve.ts
@@ -124,6 +124,36 @@ const desiredValue = (props: ReserveProps): "on" | "off" =>
 
 export const ReserveProvider = () =>
   Provider.succeed(Reserve, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "9ff81cbbe65c400b97d92c3c1033cab6",
+                name: "Cache Settings Write",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "3245da1cf36c45c3847bb9b483c62f97",
+                name: "Cache Settings Read",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["zoneId", "initialValue"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/Cache/SmartTieredCache.ts
+++ b/packages/alchemy/src/Cloudflare/Cache/SmartTieredCache.ts
@@ -104,6 +104,36 @@ const desiredValue = (props: SmartTieredCacheProps): "on" | "off" =>
 
 export const SmartTieredCacheProvider = () =>
   Provider.succeed(SmartTieredCache, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "9ff81cbbe65c400b97d92c3c1033cab6",
+                name: "Cache Settings Write",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "3245da1cf36c45c3847bb9b483c62f97",
+                name: "Cache Settings Read",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     nuke: { singleton: true },
     stables: ["zoneId", "initialValue"],
 

--- a/packages/alchemy/src/Cloudflare/Cache/Variants.ts
+++ b/packages/alchemy/src/Cloudflare/Cache/Variants.ts
@@ -182,6 +182,36 @@ const valuesEqual = (a: VariantsValue, b: VariantsValue): boolean =>
 
 export const VariantsProvider = () =>
   Provider.succeed(Variants, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "9ff81cbbe65c400b97d92c3c1033cab6",
+                name: "Cache Settings Write",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "3245da1cf36c45c3847bb9b483c62f97",
+                name: "Cache Settings Read",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["zoneId"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/Calls/App.ts
+++ b/packages/alchemy/src/Cloudflare/Calls/App.ts
@@ -102,6 +102,22 @@ export const isApp = (value: unknown): value is App =>
 
 export const AppProvider = () =>
   Provider.succeed(App, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              { id: "b711942448db4b0aace44d1312f9fdb0", name: "Calls Write" },
+            ],
+            readPermissionGroups: [
+              { id: "686ab9a8b3854f25a1474f302d14b68d", name: "Calls Read" },
+            ],
+          },
+        },
+      },
+    },
     stables: ["appId", "accountId", "secret", "created"],
     list: Effect.fn(function* () {
       const { accountId } = yield* yield* CloudflareEnvironment;

--- a/packages/alchemy/src/Cloudflare/Calls/TurnKey.ts
+++ b/packages/alchemy/src/Cloudflare/Calls/TurnKey.ts
@@ -109,6 +109,22 @@ export const isTurnKey = (value: unknown): value is TurnKey =>
 
 export const TurnKeyProvider = () =>
   Provider.succeed(TurnKey, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              { id: "b711942448db4b0aace44d1312f9fdb0", name: "Calls Write" },
+            ],
+            readPermissionGroups: [
+              { id: "686ab9a8b3854f25a1474f302d14b68d", name: "Calls Read" },
+            ],
+          },
+        },
+      },
+    },
     stables: ["keyId", "accountId", "key", "created"],
     diff: Effect.fn(function* ({ output }) {
       const { accountId } = yield* yield* CloudflareEnvironment;

--- a/packages/alchemy/src/Cloudflare/CertificateAuthorities/HostnameAssociation.ts
+++ b/packages/alchemy/src/Cloudflare/CertificateAuthorities/HostnameAssociation.ts
@@ -121,6 +121,30 @@ export const isHostnameAssociation = (
 
 export const HostnameAssociationProvider = () =>
   Provider.succeed(HostnameAssociation, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "c03055bc037c4ea9afb9a9f104b7b721",
+                name: "SSL and Certificates Write",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+            readPermissionGroups: [
+              {
+                id: "7b7216b327b04b8fbc8f524e1f9b7531",
+                name: "SSL and Certificates Read",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+          },
+        },
+      },
+    },
     stables: ["zoneId", "mtlsCertificateId"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/ClientCertificate/ClientCertificate.ts
+++ b/packages/alchemy/src/Cloudflare/ClientCertificate/ClientCertificate.ts
@@ -174,6 +174,30 @@ export const isClientCertificate = (
 
 export const ClientCertificateProvider = () =>
   Provider.succeed(ClientCertificate, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "c03055bc037c4ea9afb9a9f104b7b721",
+                name: "SSL and Certificates Write",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+            readPermissionGroups: [
+              {
+                id: "7b7216b327b04b8fbc8f524e1f9b7531",
+                name: "SSL and Certificates Read",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+          },
+        },
+      },
+    },
     // Everything Cloudflare returns at issuance is fixed for the lifetime of
     // the certificate — only `status` changes (revocation/reactivation).
     stables: [

--- a/packages/alchemy/src/Cloudflare/CloudConnector/Rules.ts
+++ b/packages/alchemy/src/Cloudflare/CloudConnector/Rules.ts
@@ -168,6 +168,36 @@ export const isRules = (value: unknown): value is Rules =>
 
 export const RulesProvider = () =>
   Provider.succeed(Rules, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "eafd71286d0e4fdca404a7b4d203c5c9",
+                name: "Cloud Connector Write",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "0661ff47aa3a4786beab3b8128e0cd24",
+                name: "Cloud Connector Read",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["zoneId"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/CloudforceOne/ScanConfig.ts
+++ b/packages/alchemy/src/Cloudflare/CloudforceOne/ScanConfig.ts
@@ -117,6 +117,31 @@ export const isScanConfig = (value: unknown): value is ScanConfig =>
 
 export const ScanConfigProvider = () =>
   Provider.succeed(ScanConfig, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["cfone:write"],
+            readScopes: ["cfone:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "677767156f294485b497a8f103172e7d",
+                name: "Cloudforce One Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "cf9353ed7978436e8fb20c03fce26449",
+                name: "Cloudforce One Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["configId", "accountId"],
     diff: Effect.fn(function* ({ news, output }) {
       const { accountId } = yield* yield* CloudflareEnvironment;

--- a/packages/alchemy/src/Cloudflare/Connectivity/DirectoryService.ts
+++ b/packages/alchemy/src/Cloudflare/Connectivity/DirectoryService.ts
@@ -291,6 +291,31 @@ export const isDirectoryService = (value: unknown): value is DirectoryService =>
 
 export const DirectoryServiceProvider = () =>
   Provider.succeed(DirectoryService, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["connectivity:admin"],
+            readScopes: ["connectivity:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "77efc2c0724d4c4eb94bfd9656247130",
+                name: "Connectivity Directory Admin",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "8764961c1edb4274be129d630b0b2671",
+                name: "Connectivity Directory Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["serviceId", "accountId", "createdAt"],
     diff: Effect.fn(function* ({ news, output }) {
       const { accountId } = yield* yield* CloudflareEnvironment;

--- a/packages/alchemy/src/Cloudflare/Containers/ContainerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Containers/ContainerProvider.ts
@@ -618,6 +618,51 @@ export const LiveContainerProvider = () =>
       };
 
       return ContainerPlatform.Provider.of({
+        metadata: {
+          cloudflare: {
+            scope: "account",
+            auth: {
+              oauth: {
+                scopes: [
+                  "containers:write",
+                  "cloudchamber:write",
+                  "workers_observability:read",
+                  "workers_tail:read",
+                ],
+              },
+              token: {
+                permissionGroups: [
+                  {
+                    id: "bdbcd690c763475a985e8641dddc09f7",
+                    name: "Workers Containers Write",
+                  },
+                  {
+                    id: "26ce6c7d18a346528e7b905d5e269866",
+                    name: "Cloudchamber Write",
+                  },
+                  {
+                    id: "66c1ed49f4ed46098b75696a6d4ee3c9",
+                    name: "Workers Observability Read",
+                  },
+                  {
+                    id: "05880cd1bdc24d8bae0be2136972816b",
+                    name: "Workers Tail Read",
+                  },
+                ],
+                readPermissionGroups: [
+                  {
+                    id: "cfd39eebc07c4e3ea849e4b3d2644637",
+                    name: "Workers Containers Read",
+                  },
+                  {
+                    id: "65ec50cbde3d4c838bbe7500024d5745",
+                    name: "Cloudchamber Read",
+                  },
+                ],
+              },
+            },
+          },
+        },
         stables: ["accountId", "applicationId"],
         diff: Effect.fn(function* ({
           id,

--- a/packages/alchemy/src/Cloudflare/Containers/LocalContainerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Containers/LocalContainerProvider.ts
@@ -156,6 +156,7 @@ export const LocalContainerProvider = () =>
       });
 
       return {
+        metadata: {},
         // No HMR for containers (yet): bundle once on first reconcile, then
         // treat the resource as a no-op so subsequent reconciles don't
         // re-bundle on every change.

--- a/packages/alchemy/src/Cloudflare/ContentScanning/ContentScanning.ts
+++ b/packages/alchemy/src/Cloudflare/ContentScanning/ContentScanning.ts
@@ -117,6 +117,27 @@ export const isContentScanning = (value: unknown): value is ContentScanning =>
 
 export const ContentScanningProvider = () =>
   Provider.succeed(ContentScanning, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "fb6778dc191143babbfaa57993f1d275",
+                name: "Zone WAF Write",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+            readPermissionGroups: [
+              { id: "dbc512b354774852af2b5a5f4ba3d470", name: "Zone WAF Read" },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+          },
+        },
+      },
+    },
     nuke: { singleton: true },
     stables: ["zoneId", "initialValue"],
 

--- a/packages/alchemy/src/Cloudflare/ContentScanning/Expression.ts
+++ b/packages/alchemy/src/Cloudflare/ContentScanning/Expression.ts
@@ -111,6 +111,27 @@ export class ExpressionCreateAnomaly extends Data.TaggedError(
 
 export const ExpressionProvider = () =>
   Provider.succeed(Expression, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "fb6778dc191143babbfaa57993f1d275",
+                name: "Zone WAF Write",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+            readPermissionGroups: [
+              { id: "dbc512b354774852af2b5a5f4ba3d470", name: "Zone WAF Read" },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+          },
+        },
+      },
+    },
     stables: ["expressionId", "zoneId", "payload"],
 
     // Custom scan expressions are a zone-scoped Content Scanning feature. Fan

--- a/packages/alchemy/src/Cloudflare/CustomCertificate/CustomCertificate.ts
+++ b/packages/alchemy/src/Cloudflare/CustomCertificate/CustomCertificate.ts
@@ -256,6 +256,30 @@ export const isCustomCertificate = (
 
 export const CustomCertificateProvider = () =>
   Provider.succeed(CustomCertificate, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "c03055bc037c4ea9afb9a9f104b7b721",
+                name: "SSL and Certificates Write",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+            readPermissionGroups: [
+              {
+                id: "7b7216b327b04b8fbc8f524e1f9b7531",
+                name: "SSL and Certificates Read",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+          },
+        },
+      },
+    },
     stables: ["certificateId", "zoneId", "type", "uploadedOn"],
 
     // Zone-scoped collection: fan out over every zone and exhaustively

--- a/packages/alchemy/src/Cloudflare/CustomHostname/CustomHostname.ts
+++ b/packages/alchemy/src/Cloudflare/CustomHostname/CustomHostname.ts
@@ -288,6 +288,36 @@ export const isCustomHostname = (value: unknown): value is CustomHostname =>
 
 export const CustomHostnameProvider = () =>
   Provider.succeed(CustomHostname, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "c03055bc037c4ea9afb9a9f104b7b721",
+                name: "SSL and Certificates Write",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "7b7216b327b04b8fbc8f524e1f9b7531",
+                name: "SSL and Certificates Read",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["customHostnameId", "zoneId", "hostname"],
 
     // Custom hostnames are a zone-scoped Cloudflare for SaaS feature. Fan out

--- a/packages/alchemy/src/Cloudflare/CustomHostname/FallbackOrigin.ts
+++ b/packages/alchemy/src/Cloudflare/CustomHostname/FallbackOrigin.ts
@@ -86,6 +86,36 @@ export const isFallbackOrigin = (value: unknown): value is FallbackOrigin =>
 
 export const FallbackOriginProvider = () =>
   Provider.succeed(FallbackOrigin, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "c03055bc037c4ea9afb9a9f104b7b721",
+                name: "SSL and Certificates Write",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "7b7216b327b04b8fbc8f524e1f9b7531",
+                name: "SSL and Certificates Read",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["zoneId"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/CustomNameserver/CustomNameserver.ts
+++ b/packages/alchemy/src/Cloudflare/CustomNameserver/CustomNameserver.ts
@@ -142,6 +142,17 @@ export const isCustomNameserver = (value: unknown): value is CustomNameserver =>
 
 export const CustomNameserverProvider = () =>
   Provider.succeed(CustomNameserver, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          // token: CATALOG GAP — no account custom-nameservers permission
+          // group exists in the static PERMISSION_GROUPS catalog yet
+        },
+      },
+    },
+
     stables: ["nsName", "accountId", "nsSet", "zoneTag"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/D1/Database.ts
+++ b/packages/alchemy/src/Cloudflare/D1/Database.ts
@@ -251,6 +251,24 @@ export const Database = Resource<Database>("Cloudflare.D1Database");
 
 export const DatabaseProvider = () =>
   Provider.succeed(Database, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["d1:write"],
+          },
+          token: {
+            permissionGroups: [
+              { id: "09b2857d1c31407795e75e3fed8617a1", name: "D1 Write" },
+            ],
+            readPermissionGroups: [
+              { id: "192192df92ee43ac90f2aeeffce67e35", name: "D1 Read" },
+            ],
+          },
+        },
+      },
+    },
     stables: ["databaseId", "accountId"],
     diff: Effect.fn(function* ({ id, olds = {}, news = {}, output }) {
       const { accountId } = yield* yield* CloudflareEnvironment;

--- a/packages/alchemy/src/Cloudflare/DNS/AccountSettings.ts
+++ b/packages/alchemy/src/Cloudflare/DNS/AccountSettings.ts
@@ -240,6 +240,32 @@ export const isAccountDnsSettings = (
 
 export const AccountDnsSettingsProvider = () =>
   Provider.succeed(AccountDnsSettings, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            supported: false,
+            readScopes: ["dns_settings:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "dc44f27f48ab405392a5f69fe822bd01",
+                name: "Account DNS Settings Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "cfa964bcdafc4ab39704e7476154e41b",
+                name: "Account DNS Settings Read",
+              },
+            ],
+          },
+        },
+      },
+    },
+
     stables: ["accountId", "initialSettings", "managedKeys"],
 
     // Account singleton — the DNS settings object always exists for the

--- a/packages/alchemy/src/Cloudflare/DNS/Dnssec.ts
+++ b/packages/alchemy/src/Cloudflare/DNS/Dnssec.ts
@@ -200,6 +200,25 @@ export const issec = (value: unknown): value is Dnssec =>
 
 export const DnssecProvider = () =>
   Provider.succeed(Dnssec, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              { id: "4755a26eedb94da69e1066d98aa820be", name: "DNS Write" },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+            readPermissionGroups: [
+              { id: "82e64a83756745bbbb1c9c2701bf816b", name: "DNS Read" },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+          },
+        },
+      },
+    },
+
     stables: [
       "zoneId",
       "initialStatus",

--- a/packages/alchemy/src/Cloudflare/DNS/Firewall.ts
+++ b/packages/alchemy/src/Cloudflare/DNS/Firewall.ts
@@ -248,6 +248,29 @@ export const isFirewall = (value: unknown): value is Firewall =>
 
 export const FirewallProvider = () =>
   Provider.succeed(Firewall, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "da6d2d6f2ec8442eaadda60d13f42bca",
+                name: "DNS Firewall Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "5f48a472240a4b489a21d43bd19a06e1",
+                name: "DNS Firewall Read",
+              },
+            ],
+          },
+        },
+      },
+    },
+
     stables: ["dnsFirewallId", "accountId", "dnsFirewallIps"],
     diff: Effect.fn(function* ({ id, olds, news, output }) {
       const { accountId } = yield* yield* CloudflareEnvironment;

--- a/packages/alchemy/src/Cloudflare/DNS/Record.ts
+++ b/packages/alchemy/src/Cloudflare/DNS/Record.ts
@@ -167,6 +167,28 @@ export const Record = Resource<Record>("Cloudflare.DNS.Record");
 
 export const RecordProvider = () =>
   Provider.succeed(Record, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: {
+            scopes: ["dns_records:edit", "zone:read"],
+            readScopes: ["dns_records:read", "zone:read"],
+          },
+          token: {
+            permissionGroups: [
+              { id: "4755a26eedb94da69e1066d98aa820be", name: "DNS Write" },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+            readPermissionGroups: [
+              { id: "82e64a83756745bbbb1c9c2701bf816b", name: "DNS Read" },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+          },
+        },
+      },
+    },
+
     stables: ["recordId", "zoneId", "type", "name"],
 
     // Zone-scoped collection: DNS records live under `/zones/{id}/dns_records`

--- a/packages/alchemy/src/Cloudflare/DNS/View.ts
+++ b/packages/alchemy/src/Cloudflare/DNS/View.ts
@@ -93,6 +93,26 @@ export const isView = (value: unknown): value is View =>
 
 export const ViewProvider = () =>
   Provider.succeed(View, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "5b7aedd821a548b9bf5a2acabbce98c7",
+                name: "DNS View Write",
+              },
+            ],
+            readPermissionGroups: [
+              { id: "95d69e8d6d5144bfb0923667355d9f11", name: "DNS View Read" },
+            ],
+          },
+        },
+      },
+    },
+
     stables: ["viewId", "accountId", "createdTime"],
 
     // Account collection — internal DNS views are enumerated per account

--- a/packages/alchemy/src/Cloudflare/DNS/ZoneSettings.ts
+++ b/packages/alchemy/src/Cloudflare/DNS/ZoneSettings.ts
@@ -262,6 +262,34 @@ export const isZoneDnsSettings = (value: unknown): value is ZoneDnsSettings =>
 
 export const ZoneDnsSettingsProvider = () =>
   Provider.succeed(ZoneDnsSettings, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: {
+            supported: false,
+            readScopes: ["dns_settings:read", "zone:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "c4df38be41c247b3b4b7702e76eadae0",
+                name: "Zone DNS Settings Write",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+            readPermissionGroups: [
+              {
+                id: "0a6cfe8cd3ed445e918579e2fb13087b",
+                name: "Zone DNS Settings Read",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+          },
+        },
+      },
+    },
+
     stables: ["zoneId", "initialSettings", "managedKeys"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/DNS/ZoneTransferAcl.ts
+++ b/packages/alchemy/src/Cloudflare/DNS/ZoneTransferAcl.ts
@@ -94,6 +94,17 @@ export const isZoneTransferAcl = (value: unknown): value is ZoneTransferAcl =>
 
 export const ZoneTransferAclProvider = () =>
   Provider.succeed(ZoneTransferAcl, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          // token: CATALOG GAP — no Secondary DNS permission group exists in
+          // the static PERMISSION_GROUPS catalog yet
+        },
+      },
+    },
+
     stables: ["aclId", "accountId"],
 
     // Account-scoped collection: enumerate every ACL in the ambient

--- a/packages/alchemy/src/Cloudflare/DNS/ZoneTransferIncoming.ts
+++ b/packages/alchemy/src/Cloudflare/DNS/ZoneTransferIncoming.ts
@@ -112,6 +112,18 @@ export const isZoneTransferIncoming = (
 
 export const ZoneTransferIncomingProvider = () =>
   Provider.succeed(ZoneTransferIncoming, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          // token: CATALOG GAP — no Secondary DNS permission group exists in
+          // the static PERMISSION_GROUPS catalog yet; "Zone Read" is
+          // additionally required by list's zone fan-out
+        },
+      },
+    },
+
     stables: ["zoneId", "id", "createdTime"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/DNS/ZoneTransferOutgoing.ts
+++ b/packages/alchemy/src/Cloudflare/DNS/ZoneTransferOutgoing.ts
@@ -124,6 +124,18 @@ export const isZoneTransferOutgoing = (
 
 export const ZoneTransferOutgoingProvider = () =>
   Provider.succeed(ZoneTransferOutgoing, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          // token: CATALOG GAP — no Secondary DNS permission group exists in
+          // the static PERMISSION_GROUPS catalog yet; "Zone Read" is
+          // additionally required by list's zone fan-out
+        },
+      },
+    },
+
     stables: ["zoneId", "id", "createdTime"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/DNS/ZoneTransferPeer.ts
+++ b/packages/alchemy/src/Cloudflare/DNS/ZoneTransferPeer.ts
@@ -129,6 +129,17 @@ export const isZoneTransferPeer = (value: unknown): value is ZoneTransferPeer =>
 
 export const ZoneTransferPeerProvider = () =>
   Provider.succeed(ZoneTransferPeer, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          // token: CATALOG GAP — no Secondary DNS permission group exists in
+          // the static PERMISSION_GROUPS catalog yet
+        },
+      },
+    },
+
     stables: ["peerId", "accountId"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/DNS/ZoneTransferTsig.ts
+++ b/packages/alchemy/src/Cloudflare/DNS/ZoneTransferTsig.ts
@@ -101,6 +101,17 @@ export const isZoneTransferTsig = (value: unknown): value is ZoneTransferTsig =>
 
 export const ZoneTransferTsigProvider = () =>
   Provider.succeed(ZoneTransferTsig, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          // token: CATALOG GAP — no Secondary DNS permission group exists in
+          // the static PERMISSION_GROUPS catalog yet
+        },
+      },
+    },
+
     stables: ["tsigId", "accountId"],
 
     diff: Effect.fn(function* ({ output }) {

--- a/packages/alchemy/src/Cloudflare/DdosProtection/AllowlistEntry.ts
+++ b/packages/alchemy/src/Cloudflare/DdosProtection/AllowlistEntry.ts
@@ -114,6 +114,28 @@ export const isDdosAllowlistEntry = (
 
 export const DdosAllowlistEntryProvider = () =>
   Provider.succeed(DdosAllowlistEntry, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "0bc09a3cd4b54605990df4e307f138e1",
+                name: "Magic Transit Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "967ecf860a244dd1911a0331a0af582a",
+                name: "Magic Transit Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["allowlistId", "accountId", "prefix", "createdOn"],
 
     diff: Effect.fn(function* ({ olds, news }) {

--- a/packages/alchemy/src/Cloudflare/DdosProtection/SynProtectionFilter.ts
+++ b/packages/alchemy/src/Cloudflare/DdosProtection/SynProtectionFilter.ts
@@ -105,6 +105,28 @@ export const isSynProtectionFilter = (
 
 export const SynProtectionFilterProvider = () =>
   Provider.succeed(SynProtectionFilter, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "0bc09a3cd4b54605990df4e307f138e1",
+                name: "Magic Transit Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "967ecf860a244dd1911a0331a0af582a",
+                name: "Magic Transit Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["filterId", "accountId", "createdOn"],
 
     // Account-scoped collection: paginate every filter in the ambient

--- a/packages/alchemy/src/Cloudflare/DdosProtection/SynProtectionRule.ts
+++ b/packages/alchemy/src/Cloudflare/DdosProtection/SynProtectionRule.ts
@@ -159,6 +159,28 @@ export const isSynProtectionRule = (
 
 export const SynProtectionRuleProvider = () =>
   Provider.succeed(SynProtectionRule, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "0bc09a3cd4b54605990df4e307f138e1",
+                name: "Magic Transit Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "967ecf860a244dd1911a0331a0af582a",
+                name: "Magic Transit Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["ruleId", "accountId", "scope", "name", "createdOn"],
 
     // Account-scoped collection: paginate every rule in the ambient

--- a/packages/alchemy/src/Cloudflare/DdosProtection/TcpFlowProtectionFilter.ts
+++ b/packages/alchemy/src/Cloudflare/DdosProtection/TcpFlowProtectionFilter.ts
@@ -106,6 +106,28 @@ export const isTcpFlowProtectionFilter = (
 
 export const TcpFlowProtectionFilterProvider = () =>
   Provider.succeed(TcpFlowProtectionFilter, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "0bc09a3cd4b54605990df4e307f138e1",
+                name: "Magic Transit Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "967ecf860a244dd1911a0331a0af582a",
+                name: "Magic Transit Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["filterId", "accountId", "createdOn"],
 
     read: Effect.fn(function* ({ output, olds }) {

--- a/packages/alchemy/src/Cloudflare/DdosProtection/TcpFlowProtectionRule.ts
+++ b/packages/alchemy/src/Cloudflare/DdosProtection/TcpFlowProtectionRule.ts
@@ -145,6 +145,28 @@ export const isTcpFlowProtectionRule = (
 
 export const TcpFlowProtectionRuleProvider = () =>
   Provider.succeed(TcpFlowProtectionRule, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "0bc09a3cd4b54605990df4e307f138e1",
+                name: "Magic Transit Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "967ecf860a244dd1911a0331a0af582a",
+                name: "Magic Transit Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["ruleId", "accountId", "scope", "name", "createdOn"],
 
     diff: Effect.fn(function* ({ olds, news }) {

--- a/packages/alchemy/src/Cloudflare/Devices/CustomProfile.ts
+++ b/packages/alchemy/src/Cloudflare/Devices/CustomProfile.ts
@@ -259,6 +259,31 @@ export const isDeviceCustomProfile = (
 
 export const DeviceCustomProfileProvider = () =>
   Provider.succeed(DeviceCustomProfile, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["teams:write"],
+            readScopes: ["teams:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "b33f02c6f7284e05a6f20741c0bb0567",
+                name: "Zero Trust Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "3f376c8e6f764a938b848bd01c8995c4",
+                name: "Zero Trust Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["policyId", "accountId", "default"],
 
     read: Effect.fn(function* ({ id, output, olds }) {

--- a/packages/alchemy/src/Cloudflare/Devices/DefaultProfile.ts
+++ b/packages/alchemy/src/Cloudflare/Devices/DefaultProfile.ts
@@ -268,6 +268,31 @@ export const DeviceDefaultProfile = Resource<DeviceDefaultProfile>(
  */
 export const DeviceDefaultProfileProvider = () =>
   Provider.succeed(DeviceDefaultProfile, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["teams:write"],
+            readScopes: ["teams:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "b33f02c6f7284e05a6f20741c0bb0567",
+                name: "Zero Trust Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "3f376c8e6f764a938b848bd01c8995c4",
+                name: "Zero Trust Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     nuke: { singleton: true },
     stables: ["accountId"],
     reconcile: Effect.fn(function* ({ news = {} }) {

--- a/packages/alchemy/src/Cloudflare/Devices/DexTest.ts
+++ b/packages/alchemy/src/Cloudflare/Devices/DexTest.ts
@@ -142,6 +142,31 @@ export const isDeviceDexTest = (value: unknown): value is DeviceDexTest =>
 
 export const DeviceDexTestProvider = () =>
   Provider.succeed(DeviceDexTest, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["dex:write"],
+            readScopes: ["dex:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "92c8dcd551cc42a6a57a54e8f8d3f3e3",
+                name: "Cloudflare DEX Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "3b376e0aa52c41cbb6afc9cab945afa8",
+                name: "Cloudflare DEX Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["testId", "accountId"],
 
     // Account-scoped collection: paginate the DEX tests list and hydrate each

--- a/packages/alchemy/src/Cloudflare/Devices/ManagedNetwork.ts
+++ b/packages/alchemy/src/Cloudflare/Devices/ManagedNetwork.ts
@@ -114,6 +114,31 @@ export const isDeviceManagedNetwork = (
 
 export const DeviceManagedNetworkProvider = () =>
   Provider.succeed(DeviceManagedNetwork, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["teams:write"],
+            readScopes: ["teams:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "b33f02c6f7284e05a6f20741c0bb0567",
+                name: "Zero Trust Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "3f376c8e6f764a938b848bd01c8995c4",
+                name: "Zero Trust Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["networkId", "accountId", "type"],
 
     // Account collection: managed networks are account-scoped and the

--- a/packages/alchemy/src/Cloudflare/Devices/PostureIntegration.ts
+++ b/packages/alchemy/src/Cloudflare/Devices/PostureIntegration.ts
@@ -183,6 +183,31 @@ export const isDevicePostureIntegration = (
 
 export const DevicePostureIntegrationProvider = () =>
   Provider.succeed(DevicePostureIntegration, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["access:write"],
+            readScopes: ["access:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "2fc1072ee6b743828db668fcb3f9dee7",
+                name: "Access: Device Posture Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "0f4841f80adb4bada5a09493300e7f8d",
+                name: "Access: Device Posture Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["integrationId", "accountId", "type"],
 
     // Account collection — enumerate every posture integration in the

--- a/packages/alchemy/src/Cloudflare/Devices/PostureRule.ts
+++ b/packages/alchemy/src/Cloudflare/Devices/PostureRule.ts
@@ -168,6 +168,31 @@ export const isDevicePostureRule = (
 
 export const DevicePostureRuleProvider = () =>
   Provider.succeed(DevicePostureRule, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["access:write"],
+            readScopes: ["access:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "2fc1072ee6b743828db668fcb3f9dee7",
+                name: "Access: Device Posture Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "0f4841f80adb4bada5a09493300e7f8d",
+                name: "Access: Device Posture Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["postureRuleId", "accountId", "type"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/Devices/Settings.ts
+++ b/packages/alchemy/src/Cloudflare/Devices/Settings.ts
@@ -142,6 +142,31 @@ export const isDeviceSettings = (value: unknown): value is DeviceSettings =>
 
 export const DeviceSettingsProvider = () =>
   Provider.succeed(DeviceSettings, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["teams:write"],
+            readScopes: ["teams:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "b33f02c6f7284e05a6f20741c0bb0567",
+                name: "Zero Trust Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "3f376c8e6f764a938b848bd01c8995c4",
+                name: "Zero Trust Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     nuke: { singleton: true },
     stables: ["accountId", "initialSettings"],
 

--- a/packages/alchemy/src/Cloudflare/Diagnostics/EndpointHealthcheck.ts
+++ b/packages/alchemy/src/Cloudflare/Diagnostics/EndpointHealthcheck.ts
@@ -113,6 +113,30 @@ export const isEndpointHealthcheck = (
 
 export const EndpointHealthcheckProvider = () =>
   Provider.succeed(EndpointHealthcheck, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            supported: false,
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "0bc09a3cd4b54605990df4e307f138e1",
+                name: "Magic Transit Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "967ecf860a244dd1911a0331a0af582a",
+                name: "Magic Transit Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["healthcheckId", "accountId"],
 
     diff: Effect.fn(function* ({ id, news, output }) {

--- a/packages/alchemy/src/Cloudflare/Dlp/Entry.ts
+++ b/packages/alchemy/src/Cloudflare/Dlp/Entry.ts
@@ -108,6 +108,30 @@ export const isEntry = (value: unknown): value is Entry =>
 
 export const EntryProvider = () =>
   Provider.succeed(Entry, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            supported: false,
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "b33f02c6f7284e05a6f20741c0bb0567",
+                name: "Zero Trust Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "3f376c8e6f764a938b848bd01c8995c4",
+                name: "Zero Trust Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["entryId", "accountId", "profileId"],
 
     diff: Effect.fn(function* ({ olds, news, output }) {

--- a/packages/alchemy/src/Cloudflare/Dlp/Profile.ts
+++ b/packages/alchemy/src/Cloudflare/Dlp/Profile.ts
@@ -142,6 +142,30 @@ export const isProfile = (value: unknown): value is Profile =>
 
 export const ProfileProvider = () =>
   Provider.succeed(Profile, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            supported: false,
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "b33f02c6f7284e05a6f20741c0bb0567",
+                name: "Zero Trust Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "3f376c8e6f764a938b848bd01c8995c4",
+                name: "Zero Trust Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["profileId", "accountId"],
 
     read: Effect.fn(function* ({ output }) {

--- a/packages/alchemy/src/Cloudflare/Email/Address.ts
+++ b/packages/alchemy/src/Cloudflare/Email/Address.ts
@@ -93,6 +93,28 @@ const findByEmail = (accountId: string, email: string) =>
 
 export const AddressProvider = () =>
   Provider.succeed(Address, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "e4589eb09e63436686cd64252a3aebeb",
+                name: "Email Routing Addresses Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "5272e56105d04b5897466995b9bd4643",
+                name: "Email Routing Addresses Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["addressId", "accountId", "email"],
     // Account collection: destination addresses are enumerable account-wide.
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/Email/AllowPolicy.ts
+++ b/packages/alchemy/src/Cloudflare/Email/AllowPolicy.ts
@@ -155,6 +155,28 @@ export const isAllowPolicy = (value: unknown): value is AllowPolicy =>
 
 export const AllowPolicyProvider = () =>
   Provider.succeed(AllowPolicy, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "a3567c13e074447fb101babac3463566",
+                name: "Cloud Email Security: Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "9e5a9912439940fca5898b5b8dc6d1a5",
+                name: "Cloud Email Security: Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["policyId", "accountId", "createdAt"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/Email/BlockSender.ts
+++ b/packages/alchemy/src/Cloudflare/Email/BlockSender.ts
@@ -115,6 +115,28 @@ export const isBlockSender = (value: unknown): value is BlockSender =>
 
 export const BlockSenderProvider = () =>
   Provider.succeed(BlockSender, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "a3567c13e074447fb101babac3463566",
+                name: "Cloud Email Security: Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "9e5a9912439940fca5898b5b8dc6d1a5",
+                name: "Cloud Email Security: Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["blockSenderId", "accountId", "createdAt"],
 
     read: Effect.fn(function* ({ output, olds }) {

--- a/packages/alchemy/src/Cloudflare/Email/CatchAll.ts
+++ b/packages/alchemy/src/Cloudflare/Email/CatchAll.ts
@@ -134,6 +134,36 @@ export const isCatchAll = (value: unknown): value is CatchAll =>
 
 export const CatchAllProvider = () =>
   Provider.succeed(CatchAll, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "79b3ec0d10ce4148a8f8bdc0cc5f97f2",
+                name: "Email Routing Rules Write",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "1b600d9d8062443e986a973f097e728a",
+                name: "Email Routing Rules Read",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     nuke: { singleton: true },
     stables: [
       "ruleId",

--- a/packages/alchemy/src/Cloudflare/Email/Domain.ts
+++ b/packages/alchemy/src/Cloudflare/Email/Domain.ts
@@ -181,6 +181,28 @@ export const isDomain = (value: unknown): value is Domain =>
 
 export const DomainProvider = () =>
   Provider.succeed(Domain, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "a3567c13e074447fb101babac3463566",
+                name: "Cloud Email Security: Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "9e5a9912439940fca5898b5b8dc6d1a5",
+                name: "Cloud Email Security: Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["domainId", "accountId", "domain", "o365TenantId", "createdAt"],
 
     diff: Effect.fn(function* ({ olds, news, output }) {

--- a/packages/alchemy/src/Cloudflare/Email/ImpersonationRegistryEntry.ts
+++ b/packages/alchemy/src/Cloudflare/Email/ImpersonationRegistryEntry.ts
@@ -121,6 +121,28 @@ export const isImpersonationRegistryEntry = (
 
 export const ImpersonationRegistryEntryProvider = () =>
   Provider.succeed(ImpersonationRegistryEntry, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "a3567c13e074447fb101babac3463566",
+                name: "Cloud Email Security: Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "9e5a9912439940fca5898b5b8dc6d1a5",
+                name: "Cloud Email Security: Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["entryId", "accountId", "createdAt"],
 
     // Account collection: exhaustively paginate the account-scoped registry

--- a/packages/alchemy/src/Cloudflare/Email/Routing.ts
+++ b/packages/alchemy/src/Cloudflare/Email/Routing.ts
@@ -84,6 +84,36 @@ const resolve = Effect.fn(function* (zone: Reference) {
 
 export const RoutingProvider = () =>
   Provider.succeed(Routing, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "79b3ec0d10ce4148a8f8bdc0cc5f97f2",
+                name: "Email Routing Rules Write",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "1b600d9d8062443e986a973f097e728a",
+                name: "Email Routing Rules Read",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     nuke: { singleton: true },
     stables: ["zoneId", "routingId"],
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/Email/Rule.ts
+++ b/packages/alchemy/src/Cloudflare/Email/Rule.ts
@@ -88,6 +88,36 @@ export const Rule = Resource<Rule>("Cloudflare.Email.Rule");
 
 export const RuleProvider = () =>
   Provider.succeed(Rule, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "79b3ec0d10ce4148a8f8bdc0cc5f97f2",
+                name: "Email Routing Rules Write",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "1b600d9d8062443e986a973f097e728a",
+                name: "Email Routing Rules Read",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["ruleId", "zoneId"],
     list: Effect.fn(function* () {
       const { accountId } = yield* yield* CloudflareEnvironment;

--- a/packages/alchemy/src/Cloudflare/Email/SendingSubdomain.ts
+++ b/packages/alchemy/src/Cloudflare/Email/SendingSubdomain.ts
@@ -123,6 +123,36 @@ export const isSendingSubdomain = (value: unknown): value is SendingSubdomain =>
 
 export const SendingSubdomainProvider = () =>
   Provider.succeed(SendingSubdomain, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "5df633d6b41c42bcaf5b4a62b9d14b64",
+                name: "Email Sending Write",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "2d5b4b1f6c89487bb7184c2c1dcd3bf1",
+                name: "Email Sending Read",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     // No update API exists — every attribute is stable across updates.
     stables: [
       "subdomainId",

--- a/packages/alchemy/src/Cloudflare/Email/TrustedDomain.ts
+++ b/packages/alchemy/src/Cloudflare/Email/TrustedDomain.ts
@@ -117,6 +117,28 @@ export const isTrustedDomain = (value: unknown): value is TrustedDomain =>
 
 export const TrustedDomainProvider = () =>
   Provider.succeed(TrustedDomain, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "a3567c13e074447fb101babac3463566",
+                name: "Cloud Email Security: Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "9e5a9912439940fca5898b5b8dc6d1a5",
+                name: "Cloud Email Security: Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["trustedDomainId", "accountId", "createdAt"],
 
     // Account-scoped collection. Exhaustively paginate the account's trusted

--- a/packages/alchemy/src/Cloudflare/Firewall/AccessRule.ts
+++ b/packages/alchemy/src/Cloudflare/Firewall/AccessRule.ts
@@ -180,6 +180,44 @@ export const isAccessRule = (value: unknown): value is AccessRule =>
 
 export const AccessRuleProvider = () =>
   Provider.succeed(AccessRule, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "a416acf9ef5a4af19fb11ed3b96b1fe6",
+                name: "Account Firewall Access Rules Write",
+              },
+              {
+                id: "43137f8d07884d3198dc0ee77ca6e79b",
+                name: "Firewall Services Write",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "de7a688cc47d43bd9ea700b467a09c96",
+                name: "Account Firewall Access Rules Read",
+              },
+              {
+                id: "4ec32dfcb35641c5bb32d5ef1ab963b4",
+                name: "Firewall Services Read",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["ruleId", "zoneId", "accountId", "allowedModes", "createdOn"],
 
     diff: Effect.fn(function* ({ olds = {}, news }) {

--- a/packages/alchemy/src/Cloudflare/Firewall/Lockdown.ts
+++ b/packages/alchemy/src/Cloudflare/Firewall/Lockdown.ts
@@ -173,6 +173,36 @@ export const isLockdown = (value: unknown): value is Lockdown =>
 
 export const LockdownProvider = () =>
   Provider.succeed(Lockdown, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "43137f8d07884d3198dc0ee77ca6e79b",
+                name: "Firewall Services Write",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "4ec32dfcb35641c5bb32d5ef1ab963b4",
+                name: "Firewall Services Read",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["lockdownId", "zoneId", "createdOn"],
 
     diff: Effect.fn(function* ({ olds = {}, news }) {

--- a/packages/alchemy/src/Cloudflare/Firewall/UaRule.ts
+++ b/packages/alchemy/src/Cloudflare/Firewall/UaRule.ts
@@ -142,6 +142,36 @@ export const isUaRule = (value: unknown): value is UaRule =>
 
 export const UaRuleProvider = () =>
   Provider.succeed(UaRule, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "43137f8d07884d3198dc0ee77ca6e79b",
+                name: "Firewall Services Write",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "4ec32dfcb35641c5bb32d5ef1ab963b4",
+                name: "Firewall Services Read",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["uaRuleId", "zoneId"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/Flagship/App.ts
+++ b/packages/alchemy/src/Cloudflare/Flagship/App.ts
@@ -154,6 +154,16 @@ export const isApp = (value: unknown): value is App =>
 
 export const AppProvider = () =>
   Provider.succeed(App, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            supported: false,
+          },
+        },
+      },
+    },
     stables: ["appId", "accountId", "createdAt"],
     diff: Effect.fn(function* ({ output }) {
       const { accountId } = yield* yield* CloudflareEnvironment;

--- a/packages/alchemy/src/Cloudflare/Flagship/Flag.ts
+++ b/packages/alchemy/src/Cloudflare/Flagship/Flag.ts
@@ -302,6 +302,16 @@ export const isFlag = (value: unknown): value is Flag =>
 
 export const FlagProvider = () =>
   Provider.succeed(Flag, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            supported: false,
+          },
+        },
+      },
+    },
     stables: ["appId", "accountId", "key"],
     diff: Effect.fn(function* ({ olds, news, output }) {
       if (!isResolved(news)) return undefined;

--- a/packages/alchemy/src/Cloudflare/Fraud/DetectionSettings.ts
+++ b/packages/alchemy/src/Cloudflare/Fraud/DetectionSettings.ts
@@ -181,6 +181,32 @@ type SettingsKey = (typeof SETTINGS_KEYS)[number];
 
 export const DetectionSettingsProvider = () =>
   Provider.succeed(DetectionSettings, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: {
+            supported: false,
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "685f9605fd4e44ec937b6a0db658e629",
+                name: "Fraud Detection Write",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+            readPermissionGroups: [
+              {
+                id: "0d24e472a9654642a97df736e8b0d980",
+                name: "Fraud Detection Read",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+          },
+        },
+      },
+    },
     nuke: { singleton: true },
     stables: ["zoneId", "initialSettings"],
 

--- a/packages/alchemy/src/Cloudflare/Gateway/Certificate.ts
+++ b/packages/alchemy/src/Cloudflare/Gateway/Certificate.ts
@@ -132,6 +132,31 @@ export const isCertificate = (value: unknown): value is Certificate =>
 
 export const CertificateProvider = () =>
   Provider.succeed(Certificate, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["teams:write"],
+            readScopes: ["teams:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "b33f02c6f7284e05a6f20741c0bb0567",
+                name: "Zero Trust Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "3f376c8e6f764a938b848bd01c8995c4",
+                name: "Zero Trust Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: [
       "certificateId",
       "accountId",

--- a/packages/alchemy/src/Cloudflare/Gateway/Configuration.ts
+++ b/packages/alchemy/src/Cloudflare/Gateway/Configuration.ts
@@ -199,6 +199,31 @@ export const isConfiguration = (value: unknown): value is Configuration =>
 
 export const ConfigurationProvider = () =>
   Provider.succeed(Configuration, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["teams:write"],
+            readScopes: ["teams:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "b33f02c6f7284e05a6f20741c0bb0567",
+                name: "Zero Trust Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "3f376c8e6f764a938b848bd01c8995c4",
+                name: "Zero Trust Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     nuke: { singleton: true },
     stables: ["accountId", "initialSettings", "createdAt"],
 

--- a/packages/alchemy/src/Cloudflare/Gateway/List.ts
+++ b/packages/alchemy/src/Cloudflare/Gateway/List.ts
@@ -159,6 +159,31 @@ export const isList = (value: unknown): value is List =>
 
 export const ListProvider = () =>
   Provider.succeed(List, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["teams:write"],
+            readScopes: ["teams:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "b33f02c6f7284e05a6f20741c0bb0567",
+                name: "Zero Trust Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "3f376c8e6f764a938b848bd01c8995c4",
+                name: "Zero Trust Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["listId", "accountId", "type", "createdAt"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/Gateway/Location.ts
+++ b/packages/alchemy/src/Cloudflare/Gateway/Location.ts
@@ -185,6 +185,31 @@ const isTransientFeatureAccessBlip = (e: {
 
 export const LocationProvider = () =>
   Provider.succeed(Location, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["teams:write"],
+            readScopes: ["teams:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "b33f02c6f7284e05a6f20741c0bb0567",
+                name: "Zero Trust Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "3f376c8e6f764a938b848bd01c8995c4",
+                name: "Zero Trust Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["locationId", "accountId", "dohSubdomain", "ip", "createdAt"],
 
     // Account-scoped collection: enumerate every Gateway location in the

--- a/packages/alchemy/src/Cloudflare/Gateway/Logging.ts
+++ b/packages/alchemy/src/Cloudflare/Gateway/Logging.ts
@@ -123,6 +123,31 @@ export const isLogging = (value: unknown): value is Logging =>
 
 export const LoggingProvider = () =>
   Provider.succeed(Logging, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["teams:write"],
+            readScopes: ["teams:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "b33f02c6f7284e05a6f20741c0bb0567",
+                name: "Zero Trust Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "3f376c8e6f764a938b848bd01c8995c4",
+                name: "Zero Trust Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     nuke: { singleton: true },
     stables: ["accountId", "initialSettings"],
 

--- a/packages/alchemy/src/Cloudflare/Gateway/ProxyEndpoint.ts
+++ b/packages/alchemy/src/Cloudflare/Gateway/ProxyEndpoint.ts
@@ -123,6 +123,31 @@ export const isProxyEndpoint = (value: unknown): value is ProxyEndpoint =>
 
 export const ProxyEndpointProvider = () =>
   Provider.succeed(ProxyEndpoint, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["teams:write"],
+            readScopes: ["teams:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "b33f02c6f7284e05a6f20741c0bb0567",
+                name: "Zero Trust Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "3f376c8e6f764a938b848bd01c8995c4",
+                name: "Zero Trust Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["proxyEndpointId", "accountId", "kind", "subdomain", "createdAt"],
 
     diff: Effect.fn(function* ({ olds = {}, news, output }) {

--- a/packages/alchemy/src/Cloudflare/Gateway/Rule.ts
+++ b/packages/alchemy/src/Cloudflare/Gateway/Rule.ts
@@ -254,6 +254,31 @@ export const RuleProvider = () =>
         });
 
       return {
+        metadata: {
+          cloudflare: {
+            scope: "account",
+            auth: {
+              oauth: {
+                scopes: ["teams:write"],
+                readScopes: ["teams:read"],
+              },
+              token: {
+                permissionGroups: [
+                  {
+                    id: "b33f02c6f7284e05a6f20741c0bb0567",
+                    name: "Zero Trust Write",
+                  },
+                ],
+                readPermissionGroups: [
+                  {
+                    id: "3f376c8e6f764a938b848bd01c8995c4",
+                    name: "Zero Trust Read",
+                  },
+                ],
+              },
+            },
+          },
+        },
         stables: ["ruleId", "action", "accountId"],
 
         // Account collection (pattern b): Gateway rules are account-scoped

--- a/packages/alchemy/src/Cloudflare/GoogleTagGateway/GoogleTagGateway.ts
+++ b/packages/alchemy/src/Cloudflare/GoogleTagGateway/GoogleTagGateway.ts
@@ -139,6 +139,32 @@ export const isGoogleTagGateway = (value: unknown): value is GoogleTagGateway =>
 
 export const GoogleTagGatewayProvider = () =>
   Provider.succeed(GoogleTagGateway, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: {
+            scopes: ["firstpartytags:write", "zone:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "3030687196b94b638145a3953da2b699",
+                name: "Zone Settings Write",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+            readPermissionGroups: [
+              {
+                id: "517b21aee92c4d89936c976ba6e4be55",
+                name: "Zone Settings Read",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+          },
+        },
+      },
+    },
     nuke: { singleton: true },
     stables: ["zoneId", "initialConfig"],
 

--- a/packages/alchemy/src/Cloudflare/Healthcheck/Healthcheck.ts
+++ b/packages/alchemy/src/Cloudflare/Healthcheck/Healthcheck.ts
@@ -303,6 +303,36 @@ export const isHealthcheck = (value: unknown): value is Healthcheck =>
 
 export const HealthcheckProvider = () =>
   Provider.succeed(Healthcheck, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "e0dc25a0fbdf4286b1ea100e3256b0e3",
+                name: "Health Checks Write",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "fac65912d42144aa86b7dd33281bf79e",
+                name: "Health Checks Read",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["healthcheckId", "zoneId", "createdOn"],
 
     diff: Effect.fn(function* ({ olds = {}, news }) {

--- a/packages/alchemy/src/Cloudflare/HostnameTlsSetting/HostnameTlsSetting.ts
+++ b/packages/alchemy/src/Cloudflare/HostnameTlsSetting/HostnameTlsSetting.ts
@@ -162,6 +162,36 @@ export const isHostnameTlsSetting = (
 
 export const HostnameTlsSettingProvider = () =>
   Provider.succeed(HostnameTlsSetting, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "c03055bc037c4ea9afb9a9f104b7b721",
+                name: "SSL and Certificates Write",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "7b7216b327b04b8fbc8f524e1f9b7531",
+                name: "SSL and Certificates Read",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["zoneId", "settingId", "hostname", "createdAt"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/Hyperdrive/Connection.ts
+++ b/packages/alchemy/src/Cloudflare/Hyperdrive/Connection.ts
@@ -165,6 +165,30 @@ export const isHyperdriveConnection = (value: unknown): value is Connection =>
 
 export const ConnectionProvider = () =>
   Provider.succeed(Connection, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["query_cache:write"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "721b2f51fba74871bd361de65aeb7e03",
+                name: "Hyperdrive Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "4d62ccf834df44808bc9283d65c4e4e9",
+                name: "Hyperdrive Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     // The `hyperdriveId` is not marked as stable because if you start in dev mode, the ID will change on first deploy.
     stables: ["accountId"],
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/Iam/ResourceGroup.ts
+++ b/packages/alchemy/src/Cloudflare/Iam/ResourceGroup.ts
@@ -139,6 +139,14 @@ export const isResourceGroup = (value: unknown): value is ResourceGroup =>
 
 export const ResourceGroupProvider = () =>
   Provider.succeed(ResourceGroup, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+        },
+      },
+    },
     stables: ["resourceGroupId", "accountId"],
 
     read: Effect.fn(function* ({ id, output, olds }) {

--- a/packages/alchemy/src/Cloudflare/Iam/UserGroup.ts
+++ b/packages/alchemy/src/Cloudflare/Iam/UserGroup.ts
@@ -146,6 +146,14 @@ export const isUserGroup = (value: unknown): value is UserGroup =>
 
 export const UserGroupProvider = () =>
   Provider.succeed(UserGroup, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+        },
+      },
+    },
     stables: ["userGroupId", "accountId", "createdOn"],
 
     // Account-scoped collection: exhaustively paginate the account's

--- a/packages/alchemy/src/Cloudflare/Iam/UserGroupMembership.ts
+++ b/packages/alchemy/src/Cloudflare/Iam/UserGroupMembership.ts
@@ -88,6 +88,14 @@ export const isUserGroupMembership = (
 
 export const UserGroupMembershipProvider = () =>
   Provider.succeed(UserGroupMembership, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+        },
+      },
+    },
     stables: ["userGroupId", "memberId", "accountId"],
 
     // Parent fan-out: memberships are keyed by (user group, member) and

--- a/packages/alchemy/src/Cloudflare/Images/SigningKey.ts
+++ b/packages/alchemy/src/Cloudflare/Images/SigningKey.ts
@@ -94,6 +94,22 @@ export const isSigningKey = (value: unknown): value is SigningKey =>
 
 export const SigningKeyProvider = () =>
   Provider.succeed(SigningKey, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              { id: "618ec6c64a3a42f8b08bdcb147ded4e4", name: "Images Write" },
+            ],
+            readPermissionGroups: [
+              { id: "0cf6473ad41449e7b7b743d14fc20c60", name: "Images Read" },
+            ],
+          },
+        },
+      },
+    },
     stables: ["keyName", "accountId", "value"],
 
     diff: Effect.fn(function* ({ olds, news, output }) {

--- a/packages/alchemy/src/Cloudflare/Images/Variant.ts
+++ b/packages/alchemy/src/Cloudflare/Images/Variant.ts
@@ -154,6 +154,22 @@ export const isVariant = (value: unknown): value is Variant =>
 
 export const VariantProvider = () =>
   Provider.succeed(Variant, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              { id: "618ec6c64a3a42f8b08bdcb147ded4e4", name: "Images Write" },
+            ],
+            readPermissionGroups: [
+              { id: "0cf6473ad41449e7b7b743d14fc20c60", name: "Images Read" },
+            ],
+          },
+        },
+      },
+    },
     stables: ["variantName", "accountId"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/Intel/IndicatorFeed.ts
+++ b/packages/alchemy/src/Cloudflare/Intel/IndicatorFeed.ts
@@ -163,6 +163,24 @@ export const isIndicatorFeed = (value: unknown): value is IndicatorFeed =>
 
 export const IndicatorFeedProvider = () =>
   Provider.succeed(IndicatorFeed, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            supported: false,
+          },
+          token: {
+            permissionGroups: [
+              { id: "92209474242d459690e2cdb1985eaa6c", name: "Intel Write" },
+            ],
+            readPermissionGroups: [
+              { id: "df1577df30ee46268f9470952d7b0cdf", name: "Intel Read" },
+            ],
+          },
+        },
+      },
+    },
     stables: ["feedId", "accountId", "createdOn"],
 
     // Account collection — enumerate every indicator feed owned by the

--- a/packages/alchemy/src/Cloudflare/Intel/IndicatorFeedPermission.ts
+++ b/packages/alchemy/src/Cloudflare/Intel/IndicatorFeedPermission.ts
@@ -84,6 +84,22 @@ export const isIndicatorFeedPermission = (
 
 export const IndicatorFeedPermissionProvider = () =>
   Provider.succeed(IndicatorFeedPermission, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            supported: false,
+          },
+          token: {
+            permissionGroups: [
+              { id: "92209474242d459690e2cdb1985eaa6c", name: "Intel Write" },
+            ],
+            readPermissionGroups: [],
+          },
+        },
+      },
+    },
     stables: ["feedId", "accountTag", "accountId"],
 
     // Non-listable: a grant is keyed by {feedId, accountTag} from the

--- a/packages/alchemy/src/Cloudflare/KV/Namespace.ts
+++ b/packages/alchemy/src/Cloudflare/KV/Namespace.ts
@@ -72,6 +72,31 @@ export const Namespace = Resource<Namespace>("Cloudflare.KV.Namespace");
 
 export const NamespaceProvider = () =>
   Provider.succeed(Namespace, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["workers_kv:write"],
+            readScopes: ["workers:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "f7f0eda5697f475c90846e879bab8666",
+                name: "Workers KV Storage Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "8b47d2786a534c08a1f94ee8f9f599ef",
+                name: "Workers KV Storage Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["namespaceId", "accountId"],
     diff: Effect.fn(function* ({ id, olds = {}, news = {}, output }) {
       const { accountId } = yield* yield* CloudflareEnvironment;

--- a/packages/alchemy/src/Cloudflare/KeylessCertificate/KeylessCertificate.ts
+++ b/packages/alchemy/src/Cloudflare/KeylessCertificate/KeylessCertificate.ts
@@ -226,6 +226,30 @@ export const isKeylessCertificate = (
 
 export const KeylessCertificateProvider = () =>
   Provider.succeed(KeylessCertificate, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "c03055bc037c4ea9afb9a9f104b7b721",
+                name: "SSL and Certificates Write",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+            readPermissionGroups: [
+              {
+                id: "7b7216b327b04b8fbc8f524e1f9b7531",
+                name: "SSL and Certificates Read",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+          },
+        },
+      },
+    },
     stables: ["keylessCertificateId", "zoneId", "createdOn"],
 
     // Keyless SSL is zone-scoped (`/zones/{id}/keyless_certificates`) with no

--- a/packages/alchemy/src/Cloudflare/LeakedCredentialCheck/Detection.ts
+++ b/packages/alchemy/src/Cloudflare/LeakedCredentialCheck/Detection.ts
@@ -112,6 +112,27 @@ export const isLeakedCredentialDetection = (
 
 export const LeakedCredentialDetectionProvider = () =>
   Provider.succeed(LeakedCredentialDetection, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "fb6778dc191143babbfaa57993f1d275",
+                name: "Zone WAF Write",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+            readPermissionGroups: [
+              { id: "dbc512b354774852af2b5a5f4ba3d470", name: "Zone WAF Read" },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+          },
+        },
+      },
+    },
     stables: ["detectionId", "zoneId"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/LeakedCredentialCheck/LeakedCredentialCheck.ts
+++ b/packages/alchemy/src/Cloudflare/LeakedCredentialCheck/LeakedCredentialCheck.ts
@@ -105,6 +105,27 @@ const desiredEnabled = (props: Props): boolean => props.enabled ?? true;
 
 export const LeakedCredentialCheckProvider = () =>
   Provider.succeed(LeakedCredentialCheck, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "fb6778dc191143babbfaa57993f1d275",
+                name: "Zone WAF Write",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+            readPermissionGroups: [
+              { id: "dbc512b354774852af2b5a5f4ba3d470", name: "Zone WAF Read" },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+          },
+        },
+      },
+    },
     nuke: { singleton: true },
     stables: ["zoneId", "initialEnabled"],
 

--- a/packages/alchemy/src/Cloudflare/LoadBalancer/LoadBalancer.ts
+++ b/packages/alchemy/src/Cloudflare/LoadBalancer/LoadBalancer.ts
@@ -249,6 +249,39 @@ export const isLoadBalancer = (value: unknown): value is LoadBalancer =>
 
 export const LoadBalancerProvider = () =>
   Provider.succeed(LoadBalancer, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: {
+            scopes: ["lb:edit"],
+            readScopes: ["lb:read", "zone:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "6d7f2f5f5b1d4a0e9081fdc98d432fd1",
+                name: "Load Balancers Write",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "e9a975f628014f1d85b723993116f7d5",
+                name: "Load Balancers Read",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["loadBalancerId", "zoneId", "createdOn"],
 
     diff: Effect.fn(function* ({ olds, news }) {

--- a/packages/alchemy/src/Cloudflare/LoadBalancer/Monitor.ts
+++ b/packages/alchemy/src/Cloudflare/LoadBalancer/Monitor.ts
@@ -194,6 +194,31 @@ export const isMonitor = (value: unknown): value is Monitor =>
 
 export const MonitorProvider = () =>
   Provider.succeed(Monitor, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["lb:edit"],
+            readScopes: ["lb:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "d2a1802cc9a34e30852f8b33869b2f3c",
+                name: "Load Balancing: Monitors and Pools Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "9d24387c6e8544e2bc4024a03991339f",
+                name: "Load Balancing: Monitors and Pools Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["monitorId", "accountId", "createdOn"],
 
     // Account-scoped collection: monitors are enumerated by the account-wide

--- a/packages/alchemy/src/Cloudflare/LoadBalancer/MonitorGroup.ts
+++ b/packages/alchemy/src/Cloudflare/LoadBalancer/MonitorGroup.ts
@@ -119,6 +119,31 @@ export const isMonitorGroup = (value: unknown): value is MonitorGroup =>
 
 export const MonitorGroupProvider = () =>
   Provider.succeed(MonitorGroup, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["lb:edit"],
+            readScopes: ["lb:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "d2a1802cc9a34e30852f8b33869b2f3c",
+                name: "Load Balancing: Monitors and Pools Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "9d24387c6e8544e2bc4024a03991339f",
+                name: "Load Balancing: Monitors and Pools Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["monitorGroupId", "accountId", "createdOn"],
 
     diff: Effect.fn(function* ({ output }) {

--- a/packages/alchemy/src/Cloudflare/LoadBalancer/Pool.ts
+++ b/packages/alchemy/src/Cloudflare/LoadBalancer/Pool.ts
@@ -239,6 +239,31 @@ export const isPool = (value: unknown): value is Pool =>
 
 export const PoolProvider = () =>
   Provider.succeed(Pool, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["lb:edit"],
+            readScopes: ["lb:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "d2a1802cc9a34e30852f8b33869b2f3c",
+                name: "Load Balancing: Monitors and Pools Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "9d24387c6e8544e2bc4024a03991339f",
+                name: "Load Balancing: Monitors and Pools Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["poolId", "accountId", "createdOn"],
 
     diff: Effect.fn(function* ({ output }) {

--- a/packages/alchemy/src/Cloudflare/Logpush/Job.ts
+++ b/packages/alchemy/src/Cloudflare/Logpush/Job.ts
@@ -270,6 +270,33 @@ export const isJob = (value: unknown): value is Job =>
 
 export const JobProvider = () =>
   Provider.succeed(Job, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["logpush:write", "zone:read"],
+            readScopes: ["logpush:read", "zone:read"],
+          },
+          token: {
+            permissionGroups: [
+              { id: "96163bd1b0784f62b3e44ed8c2ab1eb6", name: "Logs Write" },
+              // Logs Write (account)
+              { id: "3e0b5820118e47f3922f7c989e673882", name: "Logs Write" },
+              // Logs Write (zone)
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+            readPermissionGroups: [
+              { id: "6a315a56f18441e59ed03352369ae956", name: "Logs Read" },
+              // Logs Read (account)
+              { id: "c4a30cd58c5d42619c86a3c36c441e2d", name: "Logs Read" },
+              // Logs Read (zone)
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+          },
+        },
+      },
+    },
     stables: ["jobId", "accountId", "zoneId", "dataset", "kind"],
 
     diff: Effect.fn(function* ({ olds = {}, news, output }) {

--- a/packages/alchemy/src/Cloudflare/LogsControl/CmbConfig.ts
+++ b/packages/alchemy/src/Cloudflare/LogsControl/CmbConfig.ts
@@ -101,6 +101,22 @@ export const isCmbConfig = (value: unknown): value is CmbConfig =>
 
 export const CmbConfigProvider = () =>
   Provider.succeed(CmbConfig, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              { id: "96163bd1b0784f62b3e44ed8c2ab1eb6", name: "Logs Write" },
+            ], // Logs Write (account)
+            readPermissionGroups: [
+              { id: "6a315a56f18441e59ed03352369ae956", name: "Logs Read" },
+            ], // Logs Read (account)
+          },
+        },
+      },
+    },
     stables: ["accountId"],
 
     diff: Effect.fn(function* ({ news, output }) {

--- a/packages/alchemy/src/Cloudflare/LogsControl/RetentionFlag.ts
+++ b/packages/alchemy/src/Cloudflare/LogsControl/RetentionFlag.ts
@@ -95,6 +95,26 @@ export const isLogsRetentionFlag = (
 
 export const LogsRetentionFlagProvider = () =>
   Provider.succeed(LogsRetentionFlag, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              { id: "3e0b5820118e47f3922f7c989e673882", name: "Logs Write" },
+              // Logs Write (zone)
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+            readPermissionGroups: [
+              { id: "c4a30cd58c5d42619c86a3c36c441e2d", name: "Logs Read" },
+              // Logs Read (zone)
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+          },
+        },
+      },
+    },
     stables: ["zoneId", "initialFlag"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/MagicCloudNetworking/CatalogSync.ts
+++ b/packages/alchemy/src/Cloudflare/MagicCloudNetworking/CatalogSync.ts
@@ -152,6 +152,17 @@ export const isCatalogSync = (value: unknown): value is CatalogSync =>
 
 export const CatalogSyncProvider = () =>
   Provider.succeed(CatalogSync, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          // No Magic Cloud Networking permission group exists in the static
+          // token catalog — resolve by { id } against the live
+          // GET /user/tokens/permission_groups list at implementation time.
+        },
+      },
+    },
     stables: ["syncId", "accountId", "destinationType", "destinationId"],
 
     diff: Effect.fn(function* ({ olds, news, output }) {

--- a/packages/alchemy/src/Cloudflare/MagicCloudNetworking/CloudIntegration.ts
+++ b/packages/alchemy/src/Cloudflare/MagicCloudNetworking/CloudIntegration.ts
@@ -179,6 +179,17 @@ export const isCloudIntegration = (value: unknown): value is CloudIntegration =>
 
 export const CloudIntegrationProvider = () =>
   Provider.succeed(CloudIntegration, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          // No Magic Cloud Networking permission group exists in the static
+          // token catalog — resolve by { id } against the live
+          // GET /user/tokens/permission_groups list at implementation time.
+        },
+      },
+    },
     stables: ["integrationId", "accountId", "cloudType"],
 
     diff: Effect.fn(function* ({ olds, news, output }) {

--- a/packages/alchemy/src/Cloudflare/MagicCloudNetworking/OnRamp.ts
+++ b/packages/alchemy/src/Cloudflare/MagicCloudNetworking/OnRamp.ts
@@ -251,6 +251,17 @@ export const isOnRamp = (value: unknown): value is OnRamp =>
 
 export const OnRampProvider = () =>
   Provider.succeed(OnRamp, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          // No Magic Cloud Networking permission group exists in the static
+          // token catalog — resolve by { id } against the live
+          // GET /user/tokens/permission_groups list at implementation time.
+        },
+      },
+    },
     stables: [
       "onRampId",
       "accountId",

--- a/packages/alchemy/src/Cloudflare/MagicNetworkMonitoring/Config.ts
+++ b/packages/alchemy/src/Cloudflare/MagicNetworkMonitoring/Config.ts
@@ -138,6 +138,28 @@ export const isConfig = (value: unknown): value is Config =>
 
 export const ConfigProvider = () =>
   Provider.succeed(Config, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "8e6ed1ef6e864ad0ae477ceffa5aa5eb",
+                name: "Magic Network Monitoring Admin",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "3d85e9514f944bb4912c5871d92e5af5",
+                name: "Magic Network Monitoring Config Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["accountId"],
 
     diff: Effect.fn(function* ({ output }) {

--- a/packages/alchemy/src/Cloudflare/MagicNetworkMonitoring/Rule.ts
+++ b/packages/alchemy/src/Cloudflare/MagicNetworkMonitoring/Rule.ts
@@ -196,6 +196,28 @@ export const isRule = (value: unknown): value is Rule =>
 
 export const RuleProvider = () =>
   Provider.succeed(Rule, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "09c77baecb6341a2b1ca2c62b658d290",
+                name: "Magic Network Monitoring Config Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "3d85e9514f944bb4912c5871d92e5af5",
+                name: "Magic Network Monitoring Config Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["ruleId", "accountId"],
 
     diff: Effect.fn(function* ({ olds, news, output }) {

--- a/packages/alchemy/src/Cloudflare/MagicTransit/App.ts
+++ b/packages/alchemy/src/Cloudflare/MagicTransit/App.ts
@@ -98,6 +98,28 @@ export const isMagicApp = (value: unknown): value is MagicApp =>
 
 export const MagicAppProvider = () =>
   Provider.succeed(MagicApp, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "a1a7389ba7e441dba95852e10970fcc3",
+                name: "Magic WAN Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "17fc856c4ebe49d4bb70f8e4744398cf",
+                name: "Magic WAN Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["appId", "accountId"],
 
     read: Effect.fn(function* ({ output, olds }) {

--- a/packages/alchemy/src/Cloudflare/MagicTransit/GreTunnel.ts
+++ b/packages/alchemy/src/Cloudflare/MagicTransit/GreTunnel.ts
@@ -215,6 +215,28 @@ export const isGreTunnel = (value: unknown): value is GreTunnel =>
 
 export const GreTunnelProvider = () =>
   Provider.succeed(GreTunnel, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "0bc09a3cd4b54605990df4e307f138e1",
+                name: "Magic Transit Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "967ecf860a244dd1911a0331a0af582a",
+                name: "Magic Transit Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["tunnelId", "accountId", "createdOn"],
 
     diff: Effect.fn(function* ({ olds, news }) {

--- a/packages/alchemy/src/Cloudflare/MagicTransit/IpsecTunnel.ts
+++ b/packages/alchemy/src/Cloudflare/MagicTransit/IpsecTunnel.ts
@@ -167,6 +167,28 @@ export const isIpsecTunnel = (value: unknown): value is IpsecTunnel =>
 
 export const IpsecTunnelProvider = () =>
   Provider.succeed(IpsecTunnel, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "0bc09a3cd4b54605990df4e307f138e1",
+                name: "Magic Transit Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "967ecf860a244dd1911a0331a0af582a",
+                name: "Magic Transit Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["tunnelId", "accountId", "createdOn"],
 
     diff: Effect.fn(function* ({ olds, news }) {

--- a/packages/alchemy/src/Cloudflare/MagicTransit/Site.ts
+++ b/packages/alchemy/src/Cloudflare/MagicTransit/Site.ts
@@ -134,6 +134,28 @@ export const isMagicSite = (value: unknown): value is MagicSite =>
 
 export const MagicSiteProvider = () =>
   Provider.succeed(MagicSite, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "a1a7389ba7e441dba95852e10970fcc3",
+                name: "Magic WAN Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "17fc856c4ebe49d4bb70f8e4744398cf",
+                name: "Magic WAN Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["siteId", "accountId", "haMode"],
 
     // Account collection — Magic WAN sites are account-scoped and enumerated

--- a/packages/alchemy/src/Cloudflare/MagicTransit/SiteAcl.ts
+++ b/packages/alchemy/src/Cloudflare/MagicTransit/SiteAcl.ts
@@ -150,6 +150,28 @@ export const isMagicSiteAcl = (value: unknown): value is MagicSiteAcl =>
 
 export const MagicSiteAclProvider = () =>
   Provider.succeed(MagicSiteAcl, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "a1a7389ba7e441dba95852e10970fcc3",
+                name: "Magic WAN Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "17fc856c4ebe49d4bb70f8e4744398cf",
+                name: "Magic WAN Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["aclId", "siteId", "accountId"],
 
     diff: Effect.fn(function* ({ olds, news }) {

--- a/packages/alchemy/src/Cloudflare/MagicTransit/SiteLan.ts
+++ b/packages/alchemy/src/Cloudflare/MagicTransit/SiteLan.ts
@@ -191,6 +191,28 @@ export const isMagicSiteLan = (value: unknown): value is MagicSiteLan =>
 
 export const MagicSiteLanProvider = () =>
   Provider.succeed(MagicSiteLan, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "a1a7389ba7e441dba95852e10970fcc3",
+                name: "Magic WAN Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "17fc856c4ebe49d4bb70f8e4744398cf",
+                name: "Magic WAN Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["lanId", "siteId", "accountId"],
 
     diff: Effect.fn(function* ({ olds, news }) {

--- a/packages/alchemy/src/Cloudflare/MagicTransit/SiteWan.ts
+++ b/packages/alchemy/src/Cloudflare/MagicTransit/SiteWan.ts
@@ -132,6 +132,28 @@ export const isMagicSiteWan = (value: unknown): value is MagicSiteWan =>
 
 export const MagicSiteWanProvider = () =>
   Provider.succeed(MagicSiteWan, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "a1a7389ba7e441dba95852e10970fcc3",
+                name: "Magic WAN Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "17fc856c4ebe49d4bb70f8e4744398cf",
+                name: "Magic WAN Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["wanId", "siteId", "accountId"],
 
     diff: Effect.fn(function* ({ olds, news }) {

--- a/packages/alchemy/src/Cloudflare/MagicTransit/StaticRoute.ts
+++ b/packages/alchemy/src/Cloudflare/MagicTransit/StaticRoute.ts
@@ -140,6 +140,28 @@ const DEFAULT_PRIORITY = 100;
 
 export const MagicStaticRouteProvider = () =>
   Provider.succeed(MagicStaticRoute, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "0bc09a3cd4b54605990df4e307f138e1",
+                name: "Magic Transit Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "967ecf860a244dd1911a0331a0af582a",
+                name: "Magic Transit Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["routeId", "accountId", "createdOn"],
 
     read: Effect.fn(function* ({ output, olds }) {

--- a/packages/alchemy/src/Cloudflare/ManagedTransforms/ManagedTransforms.ts
+++ b/packages/alchemy/src/Cloudflare/ManagedTransforms/ManagedTransforms.ts
@@ -184,6 +184,36 @@ export const isManagedTransforms = (
 
 export const ManagedTransformsProvider = () =>
   Provider.succeed(ManagedTransforms, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "0ac90a90249747bca6b047d97f0803e9",
+                name: "Zone Transform Rules Write",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "211a4c0feb3e43b3a2d41f1443a433e7",
+                name: "Zone Transform Rules Read",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     nuke: { singleton: true },
     stables: ["zoneId", "initialRequestHeaders", "initialResponseHeaders"],
 

--- a/packages/alchemy/src/Cloudflare/MtlsCertificate/MtlsCertificate.ts
+++ b/packages/alchemy/src/Cloudflare/MtlsCertificate/MtlsCertificate.ts
@@ -177,6 +177,30 @@ export const isMtlsCertificate = (value: unknown): value is MtlsCertificate =>
 
 export const MtlsCertificateProvider = () =>
   Provider.succeed(MtlsCertificate, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["ssl_certs:write"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "db37e5f1cb1a4e1aabaef8deaea43575",
+                name: "Account: SSL and Certificates Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "a7a233f9604845c787d4c8c39ac09c21",
+                name: "Account: SSL and Certificates Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["mtlsCertificateId", "accountId"],
     diff: Effect.fn(function* ({ id, olds, news, output }) {
       const { accountId } = yield* yield* CloudflareEnvironment;

--- a/packages/alchemy/src/Cloudflare/NetworkInterconnects/Settings.ts
+++ b/packages/alchemy/src/Cloudflare/NetworkInterconnects/Settings.ts
@@ -88,6 +88,30 @@ export const isNetworkInterconnectSettings = (
 
 export const NetworkInterconnectSettingsProvider = () =>
   Provider.succeed(NetworkInterconnectSettings, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            supported: false,
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "0bc09a3cd4b54605990df4e307f138e1",
+                name: "Magic Transit Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "967ecf860a244dd1911a0331a0af582a",
+                name: "Magic Transit Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     nuke: { singleton: true },
     stables: ["accountId", "initialDefaultAsn"],
 

--- a/packages/alchemy/src/Cloudflare/Organization/Organization.ts
+++ b/packages/alchemy/src/Cloudflare/Organization/Organization.ts
@@ -193,6 +193,14 @@ export const isOrganization = (value: unknown): value is Organization =>
 
 export const OrganizationProvider = () =>
   Provider.succeed(Organization, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+        },
+      },
+    },
     stables: ["organizationId", "createTime"],
 
     // Enumerate every organization reachable by the credentials. Cloudflare's

--- a/packages/alchemy/src/Cloudflare/OriginCaCertificate/OriginCaCertificate.ts
+++ b/packages/alchemy/src/Cloudflare/OriginCaCertificate/OriginCaCertificate.ts
@@ -157,6 +157,36 @@ export const isOriginCaCertificate = (
 
 export const OriginCaCertificateProvider = () =>
   Provider.succeed(OriginCaCertificate, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "c03055bc037c4ea9afb9a9f104b7b721",
+                name: "SSL and Certificates Write",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "7b7216b327b04b8fbc8f524e1f9b7531",
+                name: "SSL and Certificates Read",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     // Every prop change is a replacement, so all attributes are stable
     // across (non-existent) updates.
     stables: [

--- a/packages/alchemy/src/Cloudflare/OriginPostQuantumEncryption/OriginPostQuantumEncryption.ts
+++ b/packages/alchemy/src/Cloudflare/OriginPostQuantumEncryption/OriginPostQuantumEncryption.ts
@@ -125,6 +125,36 @@ export const isOriginPostQuantumEncryption = (
 
 export const OriginPostQuantumEncryptionProvider = () =>
   Provider.succeed(OriginPostQuantumEncryption, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "3030687196b94b638145a3953da2b699",
+                name: "Zone Settings Write",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "517b21aee92c4d89936c976ba6e4be55",
+                name: "Zone Settings Read",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     nuke: { singleton: true },
     stables: ["zoneId", "initialValue"],
 

--- a/packages/alchemy/src/Cloudflare/OriginTlsClientAuth/Certificate.ts
+++ b/packages/alchemy/src/Cloudflare/OriginTlsClientAuth/Certificate.ts
@@ -130,6 +130,36 @@ export const isCertificate = (value: unknown): value is Certificate =>
 
 export const CertificateProvider = () =>
   Provider.succeed(Certificate, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "c03055bc037c4ea9afb9a9f104b7b721",
+                name: "SSL and Certificates Write",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "7b7216b327b04b8fbc8f524e1f9b7531",
+                name: "SSL and Certificates Read",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["certificateId", "zoneId"],
 
     diff: Effect.fn(function* ({ olds = {}, news }) {

--- a/packages/alchemy/src/Cloudflare/OriginTlsClientAuth/HostnameAssociation.ts
+++ b/packages/alchemy/src/Cloudflare/OriginTlsClientAuth/HostnameAssociation.ts
@@ -135,6 +135,28 @@ export const isHostnameAssociation = (
 
 export const HostnameAssociationProvider = () =>
   Provider.succeed(HostnameAssociation, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "c03055bc037c4ea9afb9a9f104b7b721",
+                name: "SSL and Certificates Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "7b7216b327b04b8fbc8f524e1f9b7531",
+                name: "SSL and Certificates Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["zoneId", "hostname"],
 
     // Non-listable: an association is keyed entirely by {zoneId, hostname}

--- a/packages/alchemy/src/Cloudflare/OriginTlsClientAuth/HostnameCertificate.ts
+++ b/packages/alchemy/src/Cloudflare/OriginTlsClientAuth/HostnameCertificate.ts
@@ -136,6 +136,36 @@ export const isHostnameCertificate = (
 
 export const HostnameCertificateProvider = () =>
   Provider.succeed(HostnameCertificate, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "c03055bc037c4ea9afb9a9f104b7b721",
+                name: "SSL and Certificates Write",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "7b7216b327b04b8fbc8f524e1f9b7531",
+                name: "SSL and Certificates Read",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["certificateId", "zoneId"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/OriginTlsClientAuth/Setting.ts
+++ b/packages/alchemy/src/Cloudflare/OriginTlsClientAuth/Setting.ts
@@ -102,6 +102,36 @@ export const isSetting = (value: unknown): value is Setting =>
 
 export const SettingProvider = () =>
   Provider.succeed(Setting, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "c03055bc037c4ea9afb9a9f104b7b721",
+                name: "SSL and Certificates Write",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "7b7216b327b04b8fbc8f524e1f9b7531",
+                name: "SSL and Certificates Read",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     nuke: { singleton: true },
     stables: ["zoneId", "initialEnabled"],
 

--- a/packages/alchemy/src/Cloudflare/PageRule/PageRule.ts
+++ b/packages/alchemy/src/Cloudflare/PageRule/PageRule.ts
@@ -180,6 +180,36 @@ export const isPageRule = (value: unknown): value is PageRule =>
 
 export const PageRuleProvider = () =>
   Provider.succeed(PageRule, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "ed07f6c337da4195b4e72a1fb2c6bcae",
+                name: "Page Rules Write",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "b415b70a4fd1412886f164451f20405c",
+                name: "Page Rules Read",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["pageRuleId", "zoneId", "createdOn"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/PageShield/Policy.ts
+++ b/packages/alchemy/src/Cloudflare/PageShield/Policy.ts
@@ -142,6 +142,30 @@ export const isPolicy = (value: unknown): value is Policy =>
 
 export const PolicyProvider = () =>
   Provider.succeed(Policy, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "6134079371904d8ebd77931c8ca07e50",
+                name: "Domain Page Shield",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+            readPermissionGroups: [
+              {
+                id: "945315185a8f40518bf3e9e6d0bee126",
+                name: "Domain Page Shield Read",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+          },
+        },
+      },
+    },
     stables: ["policyId", "zoneId"],
 
     diff: Effect.fn(function* ({ news, output }) {

--- a/packages/alchemy/src/Cloudflare/PageShield/Settings.ts
+++ b/packages/alchemy/src/Cloudflare/PageShield/Settings.ts
@@ -158,6 +158,30 @@ const desiredSettings = (props: SettingsProps): DesiredSettings => ({
 
 export const SettingsProvider = () =>
   Provider.succeed(Settings, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "6134079371904d8ebd77931c8ca07e50",
+                name: "Domain Page Shield",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+            readPermissionGroups: [
+              {
+                id: "945315185a8f40518bf3e9e6d0bee126",
+                name: "Domain Page Shield Read",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+          },
+        },
+      },
+    },
     nuke: { singleton: true },
     stables: [
       "zoneId",

--- a/packages/alchemy/src/Cloudflare/Pages/Deployment.ts
+++ b/packages/alchemy/src/Cloudflare/Pages/Deployment.ts
@@ -152,6 +152,25 @@ export const isDeployment = (value: unknown): value is Deployment =>
 
 export const DeploymentProvider = () =>
   Provider.succeed(Deployment, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["pages:write"],
+            readScopes: ["pages:read"],
+          },
+          token: {
+            permissionGroups: [
+              { id: "8d28297797f24fb8a0c332fe0866ec89", name: "Pages Write" },
+            ],
+            readPermissionGroups: [
+              { id: "e247aedd66bd41cc9193af0213416666", name: "Pages Read" },
+            ],
+          },
+        },
+      },
+    },
     stables: [
       "deploymentId",
       "shortId",

--- a/packages/alchemy/src/Cloudflare/Pages/Domain.ts
+++ b/packages/alchemy/src/Cloudflare/Pages/Domain.ts
@@ -148,6 +148,25 @@ export const isDomain = (value: unknown): value is Domain =>
 
 export const DomainProvider = () =>
   Provider.succeed(Domain, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["pages:write"],
+            readScopes: ["pages:read"],
+          },
+          token: {
+            permissionGroups: [
+              { id: "8d28297797f24fb8a0c332fe0866ec89", name: "Pages Write" },
+            ],
+            readPermissionGroups: [
+              { id: "e247aedd66bd41cc9193af0213416666", name: "Pages Read" },
+            ],
+          },
+        },
+      },
+    },
     stables: [
       "domainId",
       "accountId",

--- a/packages/alchemy/src/Cloudflare/Pages/Project.ts
+++ b/packages/alchemy/src/Cloudflare/Pages/Project.ts
@@ -255,6 +255,25 @@ export const isProject = (value: unknown): value is Project =>
 
 export const ProjectProvider = () =>
   Provider.succeed(Project, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["pages:write"],
+            readScopes: ["pages:read"],
+          },
+          token: {
+            permissionGroups: [
+              { id: "8d28297797f24fb8a0c332fe0866ec89", name: "Pages Write" },
+            ],
+            readPermissionGroups: [
+              { id: "e247aedd66bd41cc9193af0213416666", name: "Pages Read" },
+            ],
+          },
+        },
+      },
+    },
     stables: ["projectId", "accountId", "name", "subdomain", "createdOn"],
     diff: Effect.fn(function* ({ id, olds, news, output }) {
       const { accountId } = yield* yield* CloudflareEnvironment;

--- a/packages/alchemy/src/Cloudflare/Pipelines/LegacyPipeline.ts
+++ b/packages/alchemy/src/Cloudflare/Pipelines/LegacyPipeline.ts
@@ -217,6 +217,31 @@ export const isLegacyPipeline = (value: unknown): value is LegacyPipeline =>
 
 export const LegacyPipelineProvider = () =>
   Provider.succeed(LegacyPipeline, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["pipelines:write"],
+            readScopes: ["pipelines:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "e34111af393449539859485aa5ddd5bd",
+                name: "Pipelines Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "14b9cf2f410f4c0c9a16bb10a81c0e0b",
+                name: "Pipelines Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["pipelineId", "accountId", "name", "endpoint"],
 
     diff: Effect.fn(function* ({ id, olds, news, output }) {

--- a/packages/alchemy/src/Cloudflare/Pipelines/Pipeline.ts
+++ b/packages/alchemy/src/Cloudflare/Pipelines/Pipeline.ts
@@ -108,6 +108,31 @@ export const isPipeline = (value: unknown): value is Pipeline =>
 
 export const PipelineProvider = () =>
   Provider.succeed(Pipeline, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["pipelines:write"],
+            readScopes: ["pipelines:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "e34111af393449539859485aa5ddd5bd",
+                name: "Pipelines Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "14b9cf2f410f4c0c9a16bb10a81c0e0b",
+                name: "Pipelines Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["pipelineId", "accountId", "name", "createdAt"],
 
     diff: Effect.fn(function* ({ id, olds, news, output }) {

--- a/packages/alchemy/src/Cloudflare/Pipelines/Sink.ts
+++ b/packages/alchemy/src/Cloudflare/Pipelines/Sink.ts
@@ -282,6 +282,31 @@ export const isSink = (value: unknown): value is Sink =>
 
 export const SinkProvider = () =>
   Provider.succeed(Sink, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["pipelines:write"],
+            readScopes: ["pipelines:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "e34111af393449539859485aa5ddd5bd",
+                name: "Pipelines Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "14b9cf2f410f4c0c9a16bb10a81c0e0b",
+                name: "Pipelines Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["sinkId", "accountId", "name", "type", "createdAt"],
 
     diff: Effect.fn(function* ({ id, olds, news, output }) {

--- a/packages/alchemy/src/Cloudflare/Pipelines/Stream.ts
+++ b/packages/alchemy/src/Cloudflare/Pipelines/Stream.ts
@@ -240,6 +240,31 @@ export const isStream = (value: unknown): value is Stream =>
 
 export const StreamProvider = () =>
   Provider.succeed(Stream, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["pipelines:write"],
+            readScopes: ["pipelines:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "e34111af393449539859485aa5ddd5bd",
+                name: "Pipelines Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "14b9cf2f410f4c0c9a16bb10a81c0e0b",
+                name: "Pipelines Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["streamId", "accountId", "name", "createdAt"],
 
     diff: Effect.fn(function* ({ id, olds, news, output }) {

--- a/packages/alchemy/src/Cloudflare/ProviderMetadata.ts
+++ b/packages/alchemy/src/Cloudflare/ProviderMetadata.ts
@@ -1,0 +1,76 @@
+import type { PermissionGroupName } from "./ApiToken/PermissionGroups.ts";
+import type { OAuthScope } from "./Auth/AuthProvider.ts";
+
+/**
+ * A permission-group requirement. The `id` is authoritative — it is what token
+ * policies actually consume, and it disambiguates names that exist at both
+ * account and zone scope (e.g. "Logs Read"). The `name` is carried for
+ * docs/UX and typed against the static catalog in
+ * `ApiToken/PermissionGroups.ts` — if Cloudflare ships a group the catalog
+ * doesn't know yet, add it to the catalog first.
+ */
+export interface PermissionGroupRequirement {
+  id: string;
+  name: PermissionGroupName;
+}
+
+/**
+ * Credential requirements a Cloudflare resource provider declares via
+ * `metadata.cloudflare`. Consumed by `alchemy login` (OAuth scope
+ * preselection), `alchemy cloudflare create-token` (minting a least-privilege
+ * API token for a stack), and deploy-time preflight (required-vs-granted
+ * diffing). See `processes/ProviderMetadata/DESIGN.md`.
+ *
+ * Values must be plain literals — no `Output`s, Effects, or environment reads.
+ */
+export interface CloudflareProviderMetadata {
+  /**
+   * The scope the resource lives at. Drives the token policy resource clause
+   * (`com.cloudflare.api.account.*` vs `...account.zone.*`) and is surfaced
+   * in generated docs.
+   */
+  scope?: "account" | "zone" | "user";
+  auth?: {
+    /**
+     * Requirements when authenticating with an OAuth user token
+     * (`alchemy login` → dash.cloudflare.com OAuth flow).
+     */
+    oauth?: {
+      /**
+       * Whether the full lifecycle (reconcile/delete) is possible with an
+       * OAuth user token at all. Many products (most zone-level settings,
+       * Magic Transit, Registrar, …) have no OAuth scope — set `false` and
+       * `alchemy login` will steer the user to an API token.
+       * @default true
+       */
+      supported?: boolean;
+      /** OAuth scopes required for the full lifecycle, e.g. `"workers:write"`. */
+      scopes?: OAuthScope[];
+      /**
+       * Narrower set sufficient for read/list/diff (plan-only sessions).
+       * @default scopes
+       */
+      readScopes?: OAuthScope[];
+    };
+    /**
+     * Requirements when authenticating with a Cloudflare API token, expressed
+     * as permission groups. Each entry carries both the catalog `id`
+     * (authoritative, consumed by token policies) and the human `name`.
+     */
+    token?: {
+      /** Permission groups required for the full lifecycle. */
+      permissionGroups?: PermissionGroupRequirement[];
+      /**
+       * Narrower set sufficient for read/list/diff.
+       * @default permissionGroups
+       */
+      readPermissionGroups?: PermissionGroupRequirement[];
+    };
+  };
+}
+
+declare module "../Provider.ts" {
+  interface AlchemyProviderMetadata {
+    cloudflare?: CloudflareProviderMetadata;
+  }
+}

--- a/packages/alchemy/src/Cloudflare/Queues/Consumer.ts
+++ b/packages/alchemy/src/Cloudflare/Queues/Consumer.ts
@@ -137,6 +137,24 @@ const findWorkerConsumer = (acct: string, queueId: string) =>
 
 export const ConsumerProviderLive = () =>
   Provider.succeed(Consumer, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["queues:write"],
+          },
+          token: {
+            permissionGroups: [
+              { id: "366f57075ffc42689627bcf8242a1b6d", name: "Queues Write" },
+            ],
+            readPermissionGroups: [
+              { id: "84a7755d54c646ca87cd50682a34bf7c", name: "Queues Read" },
+            ],
+          },
+        },
+      },
+    },
     // The `consumerId` is not marked as stable because if you start in dev mode, the ID will change on first deploy.
     stables: ["accountId"],
     // Queue consumers are sub-resources of a queue with no account-wide
@@ -570,6 +588,7 @@ export const ConsumerProviderLocal = () =>
     Effect.gen(function* () {
       const localRuntimeState = yield* LocalRuntimeState;
       return {
+        metadata: {},
         list: () =>
           Effect.sync(() =>
             Array.from(MutableHashMap.values(localRuntimeState.queueConsumers)),

--- a/packages/alchemy/src/Cloudflare/Queues/Queue.ts
+++ b/packages/alchemy/src/Cloudflare/Queues/Queue.ts
@@ -108,6 +108,24 @@ export const Queue = Resource<Queue>("Cloudflare.Queues.Queue");
 
 export const ProviderLive = () =>
   Provider.succeed(Queue, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["queues:write"],
+          },
+          token: {
+            permissionGroups: [
+              { id: "366f57075ffc42689627bcf8242a1b6d", name: "Queues Write" },
+            ],
+            readPermissionGroups: [
+              { id: "84a7755d54c646ca87cd50682a34bf7c", name: "Queues Read" },
+            ],
+          },
+        },
+      },
+    },
     // The `queueId` is not marked as stable because if you start in dev mode, the ID will change on first deploy.
     stables: ["accountId"],
     diff: Effect.fn(function* ({ id, olds = {}, news = {}, output }) {
@@ -294,6 +312,7 @@ export const ProviderLocal = () =>
     Effect.gen(function* () {
       const localRuntimeState = yield* LocalRuntimeState;
       return {
+        metadata: {},
         stables: ["accountId"],
         diff: Effect.fn(function* ({ id, olds = {}, news = {}, output }) {
           const { accountId } = yield* yield* CloudflareEnvironment;

--- a/packages/alchemy/src/Cloudflare/Queues/Subscription.ts
+++ b/packages/alchemy/src/Cloudflare/Queues/Subscription.ts
@@ -203,6 +203,24 @@ export const isSubscription = (value: unknown): value is Subscription =>
 
 export const SubscriptionProvider = () =>
   Provider.succeed(Subscription, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["queues:write"],
+          },
+          token: {
+            permissionGroups: [
+              { id: "366f57075ffc42689627bcf8242a1b6d", name: "Queues Write" },
+            ],
+            readPermissionGroups: [
+              { id: "84a7755d54c646ca87cd50682a34bf7c", name: "Queues Read" },
+            ],
+          },
+        },
+      },
+    },
     stables: ["subscriptionId", "accountId", "source", "createdAt"],
     diff: Effect.fn(function* ({ olds, news, output }) {
       const { accountId } = yield* yield* CloudflareEnvironment;

--- a/packages/alchemy/src/Cloudflare/R2/Bucket.ts
+++ b/packages/alchemy/src/Cloudflare/R2/Bucket.ts
@@ -658,6 +658,35 @@ export const BucketProvider = () =>
         });
 
       return {
+        metadata: {
+          cloudflare: {
+            scope: "account",
+            auth: {
+              oauth: {
+                scopes: ["workers:write", "zone:read"],
+                readScopes: ["workers:read"],
+              },
+              token: {
+                permissionGroups: [
+                  {
+                    id: "bf7481a1826f439697cb59a20b22293e",
+                    name: "Workers R2 Storage Write",
+                  },
+                  {
+                    id: "c8fed203ed3043cba015a93ad1616f1f",
+                    name: "Zone Read",
+                  },
+                ],
+                readPermissionGroups: [
+                  {
+                    id: "b4992e1108244f5d8bfbd5744320c2e1",
+                    name: "Workers R2 Storage Read",
+                  },
+                ],
+              },
+            },
+          },
+        },
         stables: ["bucketName", "accountId"],
         list: () =>
           Effect.gen(function* () {

--- a/packages/alchemy/src/Cloudflare/R2/BucketEventNotification.ts
+++ b/packages/alchemy/src/Cloudflare/R2/BucketEventNotification.ts
@@ -204,6 +204,39 @@ export const isBucketEventNotification = (
 
 export const BucketEventNotificationProvider = () =>
   Provider.succeed(BucketEventNotification, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["workers:write", "queues:write"],
+            readScopes: ["workers:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "bf7481a1826f439697cb59a20b22293e",
+                name: "Workers R2 Storage Write",
+              },
+              {
+                id: "366f57075ffc42689627bcf8242a1b6d",
+                name: "Queues Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "b4992e1108244f5d8bfbd5744320c2e1",
+                name: "Workers R2 Storage Read",
+              },
+              {
+                id: "84a7755d54c646ca87cd50682a34bf7c",
+                name: "Queues Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["bucketName", "queueId", "accountId", "jurisdiction"],
 
     diff: Effect.fn(function* ({ olds = {}, news }) {

--- a/packages/alchemy/src/Cloudflare/R2/BucketSippy.ts
+++ b/packages/alchemy/src/Cloudflare/R2/BucketSippy.ts
@@ -224,6 +224,31 @@ export const isBucketSippy = (value: unknown): value is BucketSippy =>
 
 export const BucketSippyProvider = () =>
   Provider.succeed(BucketSippy, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["workers:write"],
+            readScopes: ["workers:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "bf7481a1826f439697cb59a20b22293e",
+                name: "Workers R2 Storage Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "b4992e1108244f5d8bfbd5744320c2e1",
+                name: "Workers R2 Storage Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["bucketName", "accountId", "jurisdiction"],
 
     diff: Effect.fn(function* ({ olds, news }) {

--- a/packages/alchemy/src/Cloudflare/R2/DataCatalog.ts
+++ b/packages/alchemy/src/Cloudflare/R2/DataCatalog.ts
@@ -207,6 +207,30 @@ export const isDataCatalog = (value: unknown): value is DataCatalog =>
 
 export const DataCatalogProvider = () =>
   Provider.succeed(DataCatalog, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["r2_catalog:write"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "d229766a2f7f4d299f20eaa8c9b1fde9",
+                name: "Workers R2 Data Catalog Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "45db74139a62490b9b60eb7c4f34994b",
+                name: "Workers R2 Data Catalog Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["catalogId", "name", "accountId", "bucketName", "catalogUri"],
     diff: Effect.fn(function* ({ olds, news, output }) {
       const { accountId } = yield* yield* CloudflareEnvironment;

--- a/packages/alchemy/src/Cloudflare/RealtimeKit/App.ts
+++ b/packages/alchemy/src/Cloudflare/RealtimeKit/App.ts
@@ -93,6 +93,25 @@ export const isApp = (value: unknown): value is App =>
 
 export const AppProvider = () =>
   Provider.succeed(App, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "ba6ce7d23a9544ccad0816691ba38e21",
+                name: "Realtime Admin",
+              },
+            ],
+            readPermissionGroups: [
+              { id: "de62b15d79cc4d8d9c7b443c656eadbd", name: "Realtime" },
+            ],
+          },
+        },
+      },
+    },
     stables: ["appId", "accountId", "name", "createdAt"],
     diff: Effect.fn(function* ({ olds, news, output }) {
       const { accountId } = yield* yield* CloudflareEnvironment;

--- a/packages/alchemy/src/Cloudflare/RealtimeKit/Preset.ts
+++ b/packages/alchemy/src/Cloudflare/RealtimeKit/Preset.ts
@@ -399,6 +399,25 @@ export const defaultRealtimeKitPresetPermissions = (): PresetPermissions => ({
 
 export const PresetProvider = () =>
   Provider.succeed(Preset, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "ba6ce7d23a9544ccad0816691ba38e21",
+                name: "Realtime Admin",
+              },
+            ],
+            readPermissionGroups: [
+              { id: "de62b15d79cc4d8d9c7b443c656eadbd", name: "Realtime" },
+            ],
+          },
+        },
+      },
+    },
     stables: ["presetId", "accountId", "appId"],
     diff: Effect.fn(function* ({ olds, news, output }) {
       if (!isResolved(news)) return undefined;

--- a/packages/alchemy/src/Cloudflare/RealtimeKit/Webhook.ts
+++ b/packages/alchemy/src/Cloudflare/RealtimeKit/Webhook.ts
@@ -153,6 +153,25 @@ export const isWebhook = (value: unknown): value is Webhook =>
 
 export const WebhookProvider = () =>
   Provider.succeed(Webhook, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "ba6ce7d23a9544ccad0816691ba38e21",
+                name: "Realtime Admin",
+              },
+            ],
+            readPermissionGroups: [
+              { id: "de62b15d79cc4d8d9c7b443c656eadbd", name: "Realtime" },
+            ],
+          },
+        },
+      },
+    },
     stables: ["webhookId", "accountId", "appId", "createdAt"],
     diff: Effect.fn(function* ({ olds, news, output }) {
       if (!isResolved(news)) return undefined;

--- a/packages/alchemy/src/Cloudflare/RegionalHostname/RegionalHostname.ts
+++ b/packages/alchemy/src/Cloudflare/RegionalHostname/RegionalHostname.ts
@@ -105,6 +105,18 @@ export const isRegionalHostname = (value: unknown): value is RegionalHostname =>
 
 export const RegionalHostnameProvider = () =>
   Provider.succeed(RegionalHostname, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          // token: CATALOG GAP — no zone-scoped regional-hostnames permission
+          // group exists in the static PERMISSION_GROUPS catalog yet; "Zone
+          // Read" is additionally required by list's zone fan-out
+        },
+      },
+    },
+
     stables: ["zoneId", "hostname", "createdOn"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/Registrar/Domain.ts
+++ b/packages/alchemy/src/Cloudflare/Registrar/Domain.ts
@@ -169,6 +169,22 @@ export const isDomain = (value: unknown): value is Domain =>
 
 export const DomainProvider = () =>
   Provider.succeed(Domain, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            readPermissionGroups: [
+              {
+                id: "9bb90620717647a39679e1d951f140d6",
+                name: "Registrar Domains Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     // `delete` never releases the registration (it only restores settings), so
     // a domain can never be removed by teardown and would re-appear on every
     // `nuke` scan. Skip it in account-wide teardown.

--- a/packages/alchemy/src/Cloudflare/ResourceSharing/Share.ts
+++ b/packages/alchemy/src/Cloudflare/ResourceSharing/Share.ts
@@ -194,6 +194,14 @@ export const isShare = (value: unknown): value is Share =>
 
 export const ShareProvider = () =>
   Provider.succeed(Share, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+        },
+      },
+    },
     stables: ["shareId", "accountId", "organizationId", "created"],
     // Account collection — enumerate every share this account sends
     // (the ones we own and can delete), exhaustively paginated, mapped

--- a/packages/alchemy/src/Cloudflare/ResourceSharing/ShareRecipient.ts
+++ b/packages/alchemy/src/Cloudflare/ResourceSharing/ShareRecipient.ts
@@ -120,6 +120,14 @@ export const isShareRecipient = (value: unknown): value is ShareRecipient =>
 
 export const ShareRecipientProvider = () =>
   Provider.succeed(ShareRecipient, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+        },
+      },
+    },
     stables: [
       "recipientId",
       "accountId",

--- a/packages/alchemy/src/Cloudflare/ResourceSharing/ShareResource.ts
+++ b/packages/alchemy/src/Cloudflare/ResourceSharing/ShareResource.ts
@@ -143,6 +143,14 @@ export const isShareResource = (value: unknown): value is ShareResource =>
 
 export const ShareResourceProvider = () =>
   Provider.succeed(ShareResource, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+        },
+      },
+    },
     stables: [
       "shareResourceId",
       "accountId",

--- a/packages/alchemy/src/Cloudflare/RiskScoring/Integration.ts
+++ b/packages/alchemy/src/Cloudflare/RiskScoring/Integration.ts
@@ -107,6 +107,30 @@ export const isIntegration = (value: unknown): value is Integration =>
 
 export const IntegrationProvider = () =>
   Provider.succeed(Integration, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            supported: false,
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "b33f02c6f7284e05a6f20741c0bb0567",
+                name: "Zero Trust Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "3f376c8e6f764a938b848bd01c8995c4",
+                name: "Zero Trust Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["integrationId", "accountId", "integrationType", "createdAt"],
 
     read: Effect.fn(function* ({ output, olds }) {

--- a/packages/alchemy/src/Cloudflare/Rules/List.ts
+++ b/packages/alchemy/src/Cloudflare/Rules/List.ts
@@ -299,6 +299,28 @@ export class ListBulkOperationError extends Data.TaggedError(
 
 export const ListProvider = () =>
   Provider.succeed(List, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "2edbf20661fd4661b0fe10e9e12f485c",
+                name: "Account Rule Lists Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "4f1071168de8466e9808de86febfc516",
+                name: "Account Rule Lists Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["listId", "accountId", "name", "kind", "createdOn"],
     list: Effect.fn(function* () {
       const { accountId } = yield* yield* CloudflareEnvironment;

--- a/packages/alchemy/src/Cloudflare/Ruleset/AccountEntrypoint.ts
+++ b/packages/alchemy/src/Cloudflare/Ruleset/AccountEntrypoint.ts
@@ -135,6 +135,28 @@ export const isAccountEntrypoint = (
 
 export const AccountEntrypointProvider = () =>
   Provider.succeed(AccountEntrypoint, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "56907406c3d548ed902070ec4df0e328",
+                name: "Account Rulesets Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "fb39996ee9044d2a8725921e02744b39",
+                name: "Account Rulesets Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["rulesetId", "accountId", "kind", "phase"],
 
     diff: Effect.fn(function* ({ id, olds, news, output }) {

--- a/packages/alchemy/src/Cloudflare/Ruleset/CustomRuleset.ts
+++ b/packages/alchemy/src/Cloudflare/Ruleset/CustomRuleset.ts
@@ -148,6 +148,28 @@ export const isCustomRuleset = (value: unknown): value is CustomRuleset =>
 
 export const CustomRulesetProvider = () =>
   Provider.succeed(CustomRuleset, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "56907406c3d548ed902070ec4df0e328",
+                name: "Account Rulesets Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "fb39996ee9044d2a8725921e02744b39",
+                name: "Account Rulesets Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["rulesetId", "accountId", "kind", "phase"],
 
     diff: Effect.fn(function* ({ id, olds, news, output }) {

--- a/packages/alchemy/src/Cloudflare/Ruleset/Ruleset.ts
+++ b/packages/alchemy/src/Cloudflare/Ruleset/Ruleset.ts
@@ -102,6 +102,36 @@ export const Ruleset = Resource<Ruleset>("Cloudflare.Ruleset.Ruleset")({});
 
 export const RulesetProvider = () =>
   Provider.succeed(Ruleset, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "fb6778dc191143babbfaa57993f1d275",
+                name: "Zone WAF Write",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "dbc512b354774852af2b5a5f4ba3d470",
+                name: "Zone WAF Read",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["zoneId", "phase"],
     diff: Effect.fn(function* ({ id, olds, news, output }) {
       if (!isResolved(news)) return undefined;

--- a/packages/alchemy/src/Cloudflare/Rum/Rule.ts
+++ b/packages/alchemy/src/Cloudflare/Rum/Rule.ts
@@ -147,6 +147,14 @@ export const isRule = (value: unknown): value is Rule =>
 
 export const RuleProvider = () =>
   Provider.succeed(Rule, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+        },
+      },
+    },
     stables: ["id", "rulesetId", "accountId", "created"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/Rum/Site.ts
+++ b/packages/alchemy/src/Cloudflare/Rum/Site.ts
@@ -157,6 +157,14 @@ export const isSite = (value: unknown): value is Site =>
 
 export const SiteProvider = () =>
   Provider.succeed(Site, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+        },
+      },
+    },
     stables: ["siteTag", "siteToken", "accountId", "rulesetId", "created"],
 
     diff: Effect.fn(function* ({ olds = {}, news, output }) {

--- a/packages/alchemy/src/Cloudflare/SchemaValidation/OperationSetting.ts
+++ b/packages/alchemy/src/Cloudflare/SchemaValidation/OperationSetting.ts
@@ -113,6 +113,30 @@ export const isOperationSetting = (value: unknown): value is OperationSetting =>
 
 export const OperationSettingProvider = () =>
   Provider.succeed(OperationSetting, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "f0235726de25444a84f704b7c93afadf",
+                name: "Domain API Gateway",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+            readPermissionGroups: [
+              {
+                id: "6ced5d0d69b1422396909a62c38ab41b",
+                name: "Domain API Gateway Read",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+          },
+        },
+      },
+    },
     stables: ["zoneId", "operationId"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/SchemaValidation/Schema.ts
+++ b/packages/alchemy/src/Cloudflare/SchemaValidation/Schema.ts
@@ -152,6 +152,30 @@ export const isSchema = (value: unknown): value is SchemaValidationSchema =>
 
 export const SchemaProvider = () =>
   Provider.succeed(SchemaValidationSchema, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "f0235726de25444a84f704b7c93afadf",
+                name: "Domain API Gateway",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+            readPermissionGroups: [
+              {
+                id: "6ced5d0d69b1422396909a62c38ab41b",
+                name: "Domain API Gateway Read",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+          },
+        },
+      },
+    },
     stables: ["schemaId", "zoneId", "name", "kind", "source", "createdAt"],
 
     diff: Effect.fn(function* ({ olds, news, output }) {

--- a/packages/alchemy/src/Cloudflare/SchemaValidation/Settings.ts
+++ b/packages/alchemy/src/Cloudflare/SchemaValidation/Settings.ts
@@ -114,6 +114,30 @@ export const isSettings = (value: unknown): value is Settings =>
 
 export const SettingsProvider = () =>
   Provider.succeed(Settings, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "f0235726de25444a84f704b7c93afadf",
+                name: "Domain API Gateway",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+            readPermissionGroups: [
+              {
+                id: "6ced5d0d69b1422396909a62c38ab41b",
+                name: "Domain API Gateway Read",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+          },
+        },
+      },
+    },
     nuke: { singleton: true },
     stables: [
       "zoneId",

--- a/packages/alchemy/src/Cloudflare/SecretsStore/Secret.ts
+++ b/packages/alchemy/src/Cloudflare/SecretsStore/Secret.ts
@@ -98,6 +98,31 @@ export const Secret = Resource<Secret>("Cloudflare.SecretsStore.Secret");
 
 export const StoreSecretProvider = () =>
   Provider.succeed(Secret, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["secrets_store:write"],
+            readScopes: ["secrets_store:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "adc8fa2bc6124928a8b3314dc63a1235",
+                name: "Secrets Store Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "5e33b7d77788455c9fdf18cbd38ee5a0",
+                name: "Secrets Store Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["secretId", "secretName", "storeId", "accountId"],
     diff: Effect.fn(function* ({ id, olds = {} as any, news, output }) {
       if (!isResolved(news)) return undefined;

--- a/packages/alchemy/src/Cloudflare/SecretsStore/SecretsStore.ts
+++ b/packages/alchemy/src/Cloudflare/SecretsStore/SecretsStore.ts
@@ -51,6 +51,31 @@ export const Store = Resource<Store>("Cloudflare.SecretsStore");
 
 export const SecretsStoreProvider = () =>
   Provider.succeed(Store, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["secrets_store:write"],
+            readScopes: ["secrets_store:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "adc8fa2bc6124928a8b3314dc63a1235",
+                name: "Secrets Store Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "5e33b7d77788455c9fdf18cbd38ee5a0",
+                name: "Secrets Store Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["storeId", "storeName", "accountId"],
     // The engine calls `read` whenever there's no prior state. Cloudflare
     // allows exactly one Secrets Store per account, so any account that's

--- a/packages/alchemy/src/Cloudflare/SecurityTxt/SecurityTxt.ts
+++ b/packages/alchemy/src/Cloudflare/SecurityTxt/SecurityTxt.ts
@@ -160,6 +160,14 @@ export const isSecurityTxt = (value: unknown): value is SecurityTxt =>
 
 export const SecurityTxtProvider = () =>
   Provider.succeed(SecurityTxt, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+        },
+      },
+    },
     stables: ["zoneId"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/Snippets/Snippet.ts
+++ b/packages/alchemy/src/Cloudflare/Snippets/Snippet.ts
@@ -125,6 +125,36 @@ const DEFAULT_MAIN_MODULE = "snippet.js";
 
 export const SnippetProvider = () =>
   Provider.succeed(Snippet, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "dadeaf3abdf14126a77a35e0c92fc36e",
+                name: "Snippets Write",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "74c654eb4aac40e28d6c6caa4c5aeb3d",
+                name: "Snippets Read",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["name", "zoneId", "createdOn"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/Snippets/SnippetRules.ts
+++ b/packages/alchemy/src/Cloudflare/Snippets/SnippetRules.ts
@@ -121,6 +121,36 @@ export const isSnippetRules = (value: unknown): value is SnippetRules =>
 
 export const SnippetRulesProvider = () =>
   Provider.succeed(SnippetRules, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "dadeaf3abdf14126a77a35e0c92fc36e",
+                name: "Snippets Write",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "74c654eb4aac40e28d6c6caa4c5aeb3d",
+                name: "Snippets Read",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["zoneId"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/Spectrum/Application.ts
+++ b/packages/alchemy/src/Cloudflare/Spectrum/Application.ts
@@ -273,6 +273,28 @@ export const isApplication = (value: unknown): value is Application =>
 
 export const ApplicationProvider = () =>
   Provider.succeed(Application, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["appId", "zoneId", "createdOn"],
 
     diff: Effect.fn(function* ({ olds, news }) {

--- a/packages/alchemy/src/Cloudflare/Speed/TestSchedule.ts
+++ b/packages/alchemy/src/Cloudflare/Speed/TestSchedule.ts
@@ -166,6 +166,36 @@ const normalizeUrl = (url: string): string => {
 
 export const TestScheduleProvider = () =>
   Provider.succeed(TestSchedule, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "3030687196b94b638145a3953da2b699",
+                name: "Zone Settings Write",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "517b21aee92c4d89936c976ba6e4be55",
+                name: "Zone Settings Read",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["zoneId", "url", "region"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/Ssl/CertificatePack.ts
+++ b/packages/alchemy/src/Cloudflare/Ssl/CertificatePack.ts
@@ -239,6 +239,30 @@ export const isCertificatePack = (value: unknown): value is CertificatePack =>
 
 export const CertificatePackProvider = () =>
   Provider.succeed(CertificatePack, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "c03055bc037c4ea9afb9a9f104b7b721",
+                name: "SSL and Certificates Write",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+            readPermissionGroups: [
+              {
+                id: "7b7216b327b04b8fbc8f524e1f9b7531",
+                name: "SSL and Certificates Read",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+          },
+        },
+      },
+    },
     stables: ["certificatePackId", "zoneId"],
 
     diff: Effect.fn(function* ({ olds, news, output }) {

--- a/packages/alchemy/src/Cloudflare/Ssl/UniversalSsl.ts
+++ b/packages/alchemy/src/Cloudflare/Ssl/UniversalSsl.ts
@@ -117,6 +117,30 @@ const patchUniversal = (input: { zoneId: string; enabled: boolean }) =>
 
 export const UniversalSslProvider = () =>
   Provider.succeed(UniversalSsl, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "c03055bc037c4ea9afb9a9f104b7b721",
+                name: "SSL and Certificates Write",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+            readPermissionGroups: [
+              {
+                id: "7b7216b327b04b8fbc8f524e1f9b7531",
+                name: "SSL and Certificates Read",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+          },
+        },
+      },
+    },
     nuke: { singleton: true },
     stables: ["zoneId", "initialEnabled"],
 

--- a/packages/alchemy/src/Cloudflare/Stream/LiveInput.ts
+++ b/packages/alchemy/src/Cloudflare/Stream/LiveInput.ts
@@ -170,6 +170,23 @@ export const isLiveInput = (value: unknown): value is LiveInput =>
 
 export const LiveInputProvider = () =>
   Provider.succeed(LiveInput, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              { id: "714f9c13a5684c2885a793f5edb36f59", name: "Stream Write" },
+            ],
+            readPermissionGroups: [
+              { id: "de21485a24744b76a004aa153898f7fe", name: "Stream Read" },
+            ],
+          },
+        },
+      },
+    },
+
     stables: ["liveInputId", "accountId", "created"],
 
     diff: Effect.fn(function* ({ output }) {

--- a/packages/alchemy/src/Cloudflare/Stream/LiveInputOutput.ts
+++ b/packages/alchemy/src/Cloudflare/Stream/LiveInputOutput.ts
@@ -131,6 +131,23 @@ export const isLiveInputOutput = (value: unknown): value is LiveInputOutput =>
 
 export const LiveInputOutputProvider = () =>
   Provider.succeed(LiveInputOutput, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              { id: "714f9c13a5684c2885a793f5edb36f59", name: "Stream Write" },
+            ],
+            readPermissionGroups: [
+              { id: "de21485a24744b76a004aa153898f7fe", name: "Stream Read" },
+            ],
+          },
+        },
+      },
+    },
+
     stables: ["outputId", "liveInputId", "accountId", "url", "streamKey"],
 
     diff: Effect.fn(function* ({ olds, news, output }) {

--- a/packages/alchemy/src/Cloudflare/Stream/SigningKey.ts
+++ b/packages/alchemy/src/Cloudflare/Stream/SigningKey.ts
@@ -84,6 +84,23 @@ export const isSigningKey = (value: unknown): value is SigningKey =>
 
 export const SigningKeyProvider = () =>
   Provider.succeed(SigningKey, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              { id: "714f9c13a5684c2885a793f5edb36f59", name: "Stream Write" },
+            ],
+            readPermissionGroups: [
+              { id: "de21485a24744b76a004aa153898f7fe", name: "Stream Read" },
+            ],
+          },
+        },
+      },
+    },
+
     stables: ["keyId", "accountId", "created", "pem", "jwk"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/Stream/Watermark.ts
+++ b/packages/alchemy/src/Cloudflare/Stream/Watermark.ts
@@ -169,6 +169,23 @@ export const isWatermark = (value: unknown): value is Watermark =>
 
 export const WatermarkProvider = () =>
   Provider.succeed(Watermark, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              { id: "714f9c13a5684c2885a793f5edb36f59", name: "Stream Write" },
+            ],
+            readPermissionGroups: [
+              { id: "de21485a24744b76a004aa153898f7fe", name: "Stream Read" },
+            ],
+          },
+        },
+      },
+    },
+
     stables: [
       "watermarkId",
       "accountId",

--- a/packages/alchemy/src/Cloudflare/Stream/Webhook.ts
+++ b/packages/alchemy/src/Cloudflare/Stream/Webhook.ts
@@ -86,6 +86,23 @@ export const isWebhook = (value: unknown): value is Webhook =>
 
 export const WebhookProvider = () =>
   Provider.succeed(Webhook, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              { id: "714f9c13a5684c2885a793f5edb36f59", name: "Stream Write" },
+            ],
+            readPermissionGroups: [
+              { id: "de21485a24744b76a004aa153898f7fe", name: "Stream Read" },
+            ],
+          },
+        },
+      },
+    },
+
     stables: ["accountId"],
 
     diff: Effect.fn(function* ({ output }) {

--- a/packages/alchemy/src/Cloudflare/Tags/AccountResourceTags.ts
+++ b/packages/alchemy/src/Cloudflare/Tags/AccountResourceTags.ts
@@ -152,6 +152,14 @@ export const isAccountResourceTags = (
 
 export const AccountResourceTagsProvider = () =>
   Provider.succeed(AccountResourceTags, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+        },
+      },
+    },
     stables: ["accountId", "resourceType", "resourceId", "workerId"],
 
     // Account-wide enumeration: `GET /accounts/{id}/tags/resources` returns

--- a/packages/alchemy/src/Cloudflare/Tags/ZoneResourceTags.ts
+++ b/packages/alchemy/src/Cloudflare/Tags/ZoneResourceTags.ts
@@ -161,6 +161,14 @@ export const isZoneResourceTags = (value: unknown): value is ZoneResourceTags =>
 
 export const ZoneResourceTagsProvider = () =>
   Provider.succeed(ZoneResourceTags, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+        },
+      },
+    },
     stables: ["zoneId", "resourceType", "resourceId", "accessApplicationId"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/TokenValidation/Configuration.ts
+++ b/packages/alchemy/src/Cloudflare/TokenValidation/Configuration.ts
@@ -201,6 +201,30 @@ export const isTokenConfiguration = (
 
 export const TokenConfigurationProvider = () =>
   Provider.succeed(TokenConfiguration, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "f0235726de25444a84f704b7c93afadf",
+                name: "Domain API Gateway",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+            readPermissionGroups: [
+              {
+                id: "6ced5d0d69b1422396909a62c38ab41b",
+                name: "Domain API Gateway Read",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+          },
+        },
+      },
+    },
     stables: ["configId", "zoneId", "tokenType", "createdAt"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/TokenValidation/Rule.ts
+++ b/packages/alchemy/src/Cloudflare/TokenValidation/Rule.ts
@@ -196,6 +196,30 @@ export const isRule = (value: unknown): value is Rule =>
 
 export const RuleProvider = () =>
   Provider.succeed(Rule, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "f0235726de25444a84f704b7c93afadf",
+                name: "Domain API Gateway",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+            readPermissionGroups: [
+              {
+                id: "6ced5d0d69b1422396909a62c38ab41b",
+                name: "Domain API Gateway Read",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+          },
+        },
+      },
+    },
     stables: ["ruleId", "zoneId", "createdAt"],
 
     diff: Effect.fn(function* ({ olds, news, output }) {

--- a/packages/alchemy/src/Cloudflare/Tunnel/Configuration.ts
+++ b/packages/alchemy/src/Cloudflare/Tunnel/Configuration.ts
@@ -289,6 +289,31 @@ export const ConfigurationProvider = () =>
         });
 
       return {
+        metadata: {
+          cloudflare: {
+            scope: "account",
+            auth: {
+              oauth: {
+                scopes: ["teams:write"],
+                readScopes: ["teams:read"],
+              },
+              token: {
+                permissionGroups: [
+                  {
+                    id: "c07321b023e944ff818fec44d8203567",
+                    name: "Cloudflare Tunnel Write",
+                  },
+                ],
+                readPermissionGroups: [
+                  {
+                    id: "efea2ab8357b47888938f101ae5e053f",
+                    name: "Cloudflare Tunnel Read",
+                  },
+                ],
+              },
+            },
+          },
+        },
         stables: ["tunnelId", "accountId"],
 
         diff: Effect.fn(function* ({ olds = {}, news }) {

--- a/packages/alchemy/src/Cloudflare/Tunnel/HostnameRoute.ts
+++ b/packages/alchemy/src/Cloudflare/Tunnel/HostnameRoute.ts
@@ -94,6 +94,31 @@ export const isHostnameRoute = (value: unknown): value is HostnameRoute =>
 
 export const HostnameRouteProvider = () =>
   Provider.succeed(HostnameRoute, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["teams:write"],
+            readScopes: ["teams:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "e2980d9241cf4939bbbd74fdc43b9651",
+                name: "Cloudflare One Networks Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "4f1276d1e7e34c32a5012bbe02ece86d",
+                name: "Cloudflare One Networks Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["hostnameRouteId", "accountId"],
 
     read: Effect.fn(function* ({ output, olds }) {

--- a/packages/alchemy/src/Cloudflare/Tunnel/Route.ts
+++ b/packages/alchemy/src/Cloudflare/Tunnel/Route.ts
@@ -118,6 +118,31 @@ export const Route = Resource<Route>("Cloudflare.Tunnel.Route");
 
 export const RouteProvider = () =>
   Provider.succeed(Route, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["teams:write"],
+            readScopes: ["teams:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "e2980d9241cf4939bbbd74fdc43b9651",
+                name: "Cloudflare One Networks Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "4f1276d1e7e34c32a5012bbe02ece86d",
+                name: "Cloudflare One Networks Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: [
       "routeId",
       "accountId",

--- a/packages/alchemy/src/Cloudflare/Tunnel/Tunnel.ts
+++ b/packages/alchemy/src/Cloudflare/Tunnel/Tunnel.ts
@@ -154,6 +154,31 @@ export const Tunnel = Resource<Tunnel>("Cloudflare.Tunnel.Tunnel");
 
 export const TunnelProvider = () =>
   Provider.succeed(Tunnel, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["teams:write"],
+            readScopes: ["teams:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "c07321b023e944ff818fec44d8203567",
+                name: "Cloudflare Tunnel Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "efea2ab8357b47888938f101ae5e053f",
+                name: "Cloudflare Tunnel Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["tunnelId", "accountTag", "accountId"],
     // Account collection: enumerate every cfd_tunnel in the account, skip
     // deleted tunnels (match `read`/`findTunnelByName`), exhaustively

--- a/packages/alchemy/src/Cloudflare/Tunnel/VirtualNetwork.ts
+++ b/packages/alchemy/src/Cloudflare/Tunnel/VirtualNetwork.ts
@@ -119,6 +119,31 @@ export const isVirtualNetwork = (value: unknown): value is VirtualNetwork =>
 
 export const VirtualNetworkProvider = () =>
   Provider.succeed(VirtualNetwork, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["teams:write"],
+            readScopes: ["teams:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "e2980d9241cf4939bbbd74fdc43b9651",
+                name: "Cloudflare One Networks Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "4f1276d1e7e34c32a5012bbe02ece86d",
+                name: "Cloudflare One Networks Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["virtualNetworkId", "accountId", "createdAt"],
 
     diff: Effect.fn(function* ({ output }) {

--- a/packages/alchemy/src/Cloudflare/Tunnel/WarpConnector.ts
+++ b/packages/alchemy/src/Cloudflare/Tunnel/WarpConnector.ts
@@ -105,6 +105,31 @@ export const isWarpConnector = (value: unknown): value is WarpConnector =>
 
 export const WarpConnectorProvider = () =>
   Provider.succeed(WarpConnector, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["teams:write"],
+            readScopes: ["teams:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "5b5c774a5d174ca88d046c8889648b3f",
+                name: "Cloudflare One Connector: WARP Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "1cd960c063a0448481343372c963d8c7",
+                name: "Cloudflare One Connector: WARP Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["tunnelId", "accountId", "createdAt"],
 
     diff: Effect.fn(function* ({ output }) {

--- a/packages/alchemy/src/Cloudflare/Turnstile/Widget.ts
+++ b/packages/alchemy/src/Cloudflare/Turnstile/Widget.ts
@@ -196,6 +196,28 @@ export const isWidget = (value: unknown): value is Widget =>
 
 export const WidgetProvider = () =>
   Provider.succeed(Widget, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "755c05aa014b4f9ab263aa80b8167bd8",
+                name: "Turnstile Sites Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "5d78fd7895974fd0bdbbbb079482721b",
+                name: "Turnstile Sites Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["sitekey", "accountId", "region", "createdOn"],
     diff: Effect.fn(function* ({ olds, news, output }) {
       const { accountId } = yield* yield* CloudflareEnvironment;

--- a/packages/alchemy/src/Cloudflare/UrlNormalization/UrlNormalization.ts
+++ b/packages/alchemy/src/Cloudflare/UrlNormalization/UrlNormalization.ts
@@ -134,6 +134,36 @@ const DEFAULT_TYPE: Type = "cloudflare";
 
 export const UrlNormalizationProvider = () =>
   Provider.succeed(UrlNormalization, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "0ac90a90249747bca6b047d97f0803e9",
+                name: "Zone Transform Rules Write",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "211a4c0feb3e43b3a2d41f1443a433e7",
+                name: "Zone Transform Rules Read",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     nuke: { singleton: true },
     stables: ["zoneId"],
 

--- a/packages/alchemy/src/Cloudflare/Vectorize/VectorizeIndex.ts
+++ b/packages/alchemy/src/Cloudflare/Vectorize/VectorizeIndex.ts
@@ -141,6 +141,30 @@ export const isIndex = (value: unknown): value is Index =>
 
 export const IndexProvider = () =>
   Provider.succeed(Index, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["vectorize:write"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "64156ba5be47441096c83c7fc17c488b",
+                name: "Vectorize Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "1799edaae5db489294430e20d9b519e0",
+                name: "Vectorize Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["indexName", "accountId"],
     diff: Effect.fn(function* ({ id, olds = {}, news = {}, output }) {
       const { accountId } = yield* yield* CloudflareEnvironment;

--- a/packages/alchemy/src/Cloudflare/Vectorize/VectorizeMetadataIndex.ts
+++ b/packages/alchemy/src/Cloudflare/Vectorize/VectorizeMetadataIndex.ts
@@ -91,6 +91,30 @@ export const MetadataIndex = Resource<MetadataIndex>(
 
 export const MetadataIndexProvider = () =>
   Provider.succeed(MetadataIndex, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["vectorize:write"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "64156ba5be47441096c83c7fc17c488b",
+                name: "Vectorize Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "1799edaae5db489294430e20d9b519e0",
+                name: "Vectorize Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["propertyName", "indexName", "accountId"],
     diff: Effect.fn(function* ({ olds, news, output }) {
       const { accountId } = yield* yield* CloudflareEnvironment;

--- a/packages/alchemy/src/Cloudflare/VpcService/VpcService.ts
+++ b/packages/alchemy/src/Cloudflare/VpcService/VpcService.ts
@@ -145,6 +145,31 @@ const findServiceByName = Effect.fn(function* (name: string) {
 
 export const VpcServiceProvider = () =>
   Provider.succeed(VpcService, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["connectivity:admin"],
+            readScopes: ["connectivity:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "77efc2c0724d4c4eb94bfd9656247130",
+                name: "Connectivity Directory Admin",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "8764961c1edb4274be129d630b0b2671",
+                name: "Connectivity Directory Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["serviceId", "accountId"],
     list: Effect.fn(function* () {
       const { accountId } = yield* yield* CloudflareEnvironment;

--- a/packages/alchemy/src/Cloudflare/VulnerabilityScanner/Credential.ts
+++ b/packages/alchemy/src/Cloudflare/VulnerabilityScanner/Credential.ts
@@ -138,6 +138,19 @@ export const isVulnScannerCredential = (
 
 export const VulnScannerCredentialProvider = () =>
   Provider.succeed(VulnScannerCredential, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            supported: false,
+          },
+          // token: no matching permission group exists in the static catalog
+          // (ApiToken/PermissionGroups.ts) for the `/vuln_scanner/*` API family —
+          // resolve against the live permission-group list before implementing.
+        },
+      },
+    },
     stables: ["credentialId", "credentialSetId", "accountId"],
 
     // Credentials are sub-resources of a credential set and there is no

--- a/packages/alchemy/src/Cloudflare/VulnerabilityScanner/CredentialSet.ts
+++ b/packages/alchemy/src/Cloudflare/VulnerabilityScanner/CredentialSet.ts
@@ -89,6 +89,19 @@ export const isVulnScannerCredentialSet = (
 
 export const VulnScannerCredentialSetProvider = () =>
   Provider.succeed(VulnScannerCredentialSet, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            supported: false,
+          },
+          // token: no matching permission group exists in the static catalog
+          // (ApiToken/PermissionGroups.ts) for the `/vuln_scanner/*` API family —
+          // resolve against the live permission-group list before implementing.
+        },
+      },
+    },
     stables: ["credentialSetId", "accountId"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/VulnerabilityScanner/TargetEnvironment.ts
+++ b/packages/alchemy/src/Cloudflare/VulnerabilityScanner/TargetEnvironment.ts
@@ -99,6 +99,19 @@ export const isVulnScannerTargetEnvironment = (
 
 export const VulnScannerTargetEnvironmentProvider = () =>
   Provider.succeed(VulnScannerTargetEnvironment, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            supported: false,
+          },
+          // token: no matching permission group exists in the static catalog
+          // (ApiToken/PermissionGroups.ts) for the `/vuln_scanner/*` API family —
+          // resolve against the live permission-group list before implementing.
+        },
+      },
+    },
     stables: ["targetEnvironmentId", "accountId"],
 
     // Account collection: exhaustively paginate the account-scoped target

--- a/packages/alchemy/src/Cloudflare/WaitingRoom/Settings.ts
+++ b/packages/alchemy/src/Cloudflare/WaitingRoom/Settings.ts
@@ -95,6 +95,36 @@ export const isSettings = (value: unknown): value is Settings =>
 
 export const SettingsProvider = () =>
   Provider.succeed(Settings, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "24fc124dc8254e0db468e60bf410c800",
+                name: "Waiting Rooms Write",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "cab5202d07ef47beae788e6bc95cb6fe",
+                name: "Waiting Rooms Read",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     nuke: { singleton: true },
     stables: ["zoneId", "initialSearchEngineCrawlerBypass"],
 

--- a/packages/alchemy/src/Cloudflare/WaitingRoom/WaitingRoom.ts
+++ b/packages/alchemy/src/Cloudflare/WaitingRoom/WaitingRoom.ts
@@ -300,6 +300,36 @@ export const isWaitingRoom = (value: unknown): value is WaitingRoom =>
 
 export const WaitingRoomProvider = () =>
   Provider.succeed(WaitingRoom, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "24fc124dc8254e0db468e60bf410c800",
+                name: "Waiting Rooms Write",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "cab5202d07ef47beae788e6bc95cb6fe",
+                name: "Waiting Rooms Read",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["waitingRoomId", "zoneId", "createdOn"],
 
     diff: Effect.fn(function* ({ olds = {}, news, output }) {

--- a/packages/alchemy/src/Cloudflare/Web3/ContentList.ts
+++ b/packages/alchemy/src/Cloudflare/Web3/ContentList.ts
@@ -148,6 +148,31 @@ export const isHostnameContentList = (
 
 export const HostnameContentListProvider = () =>
   Provider.succeed(HostnameContentList, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "5ea6da42edb34811a78d1b007557c0ca",
+                name: "Web3 Hostnames Write",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+            readPermissionGroups: [
+              {
+                id: "8e31f574901c42e8ad89140b28d42112",
+                name: "Web3 Hostnames Read",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+          },
+        },
+      },
+    },
+
     stables: ["zoneId", "hostnameId"],
 
     list: Effect.fn(function* () {
@@ -332,6 +357,8 @@ const sameContentList = (
 
 const serializeEntries = (entries: ContentListEntry[]) =>
   entries
-    .map((entry) => `${entry.type} ${entry.content} ${entry.description ?? ""}`)
+    .map(
+      (entry) => `${entry.type}\0${entry.content}\0${entry.description ?? ""}`,
+    )
     .sort()
     .join("");

--- a/packages/alchemy/src/Cloudflare/Web3/Hostname.ts
+++ b/packages/alchemy/src/Cloudflare/Web3/Hostname.ts
@@ -153,6 +153,31 @@ export const isHostname = (value: unknown): value is Hostname =>
 
 export const HostnameProvider = () =>
   Provider.succeed(Hostname, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "5ea6da42edb34811a78d1b007557c0ca",
+                name: "Web3 Hostnames Write",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+            readPermissionGroups: [
+              {
+                id: "8e31f574901c42e8ad89140b28d42112",
+                name: "Web3 Hostnames Read",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+          },
+        },
+      },
+    },
+
     stables: ["hostnameId", "zoneId", "name", "target", "createdOn"],
 
     // Web3 hostnames live inside a zone (`/zones/{id}/web3/hostnames`) with no

--- a/packages/alchemy/src/Cloudflare/Workers/AccountSetting.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/AccountSetting.ts
@@ -102,6 +102,31 @@ export const isAccountSetting = (value: unknown): value is AccountSetting =>
 
 export const AccountSettingProvider = () =>
   Provider.succeed(AccountSetting, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["workers_scripts:write"],
+            readScopes: ["workers:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "e086da7e2179491d91ee5f35b3ca210a",
+                name: "Workers Scripts Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "1a71c399035b4950a1bd1466bbe4f420",
+                name: "Workers Scripts Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     nuke: { singleton: true },
     stables: ["accountId", "initialDefaultUsageModel", "initialGreenCompute"],
 

--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -486,6 +486,7 @@ export const LocalWorkerProvider = () =>
       });
 
       return {
+        metadata: {},
         // Local dev provider: there is no cloud enumeration API. The set of
         // locally running Workers is the in-memory `instances` map; each
         // instance's fiber resolves to the Worker Attributes once it has

--- a/packages/alchemy/src/Cloudflare/Workers/ObservabilityDestination.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/ObservabilityDestination.ts
@@ -181,6 +181,31 @@ export const isObservabilityDestination = (
 
 export const ObservabilityDestinationProvider = () =>
   Provider.succeed(ObservabilityDestination, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["workers_observability:write"],
+            readScopes: ["workers_observability:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "82c075da3f4647a2a03becd0fe240f8a",
+                name: "Workers Observability Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "66c1ed49f4ed46098b75696a6d4ee3c9",
+                name: "Workers Observability Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["slug", "accountId", "name", "logpushDataset"],
 
     diff: Effect.fn(function* ({ id, olds, news, output }) {

--- a/packages/alchemy/src/Cloudflare/Workers/Route.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Route.ts
@@ -115,6 +115,39 @@ export const isWorkerRoute = (value: unknown): value is WorkerRoute =>
 
 export const WorkerRouteProvider = () =>
   Provider.succeed(WorkerRoute, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: {
+            scopes: ["workers_routes:write", "zone:read"],
+            readScopes: ["workers:read", "zone:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "28f4b596e7d643029c524985477ae49a",
+                name: "Workers Routes Write",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "2072033d694d415a936eaeb94e6405b8",
+                name: "Workers Routes Read",
+              },
+              {
+                id: "c8fed203ed3043cba015a93ad1616f1f",
+                name: "Zone Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["routeId", "zoneId"],
 
     diff: Effect.fn(function* ({ olds = {}, news }) {

--- a/packages/alchemy/src/Cloudflare/Workers/Subdomain.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Subdomain.ts
@@ -88,6 +88,31 @@ export const isSubdomain = (value: unknown): value is Subdomain =>
 
 export const SubdomainProvider = () =>
   Provider.succeed(Subdomain, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["workers_scripts:write"],
+            readScopes: ["workers:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "e086da7e2179491d91ee5f35b3ca210a",
+                name: "Workers Scripts Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "1a71c399035b4950a1bd1466bbe4f420",
+                name: "Workers Scripts Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     nuke: { singleton: true },
     stables: ["accountId", "initialSubdomain"],
 

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -1314,6 +1314,51 @@ export const LiveWorkerProvider = () =>
       });
 
       return Worker.Provider.of({
+        metadata: {
+          cloudflare: {
+            scope: "account",
+            auth: {
+              oauth: {
+                // zone:read is only exercised when the `domain` prop triggers
+                // zone inference; observability/tail scopes only by logs/tail.
+                scopes: [
+                  "workers:write",
+                  "workers_scripts:write",
+                  "zone:read",
+                  "workers_observability:read",
+                  "workers_tail:read",
+                ],
+                readScopes: ["workers:read"],
+              },
+              token: {
+                permissionGroups: [
+                  {
+                    id: "e086da7e2179491d91ee5f35b3ca210a",
+                    name: "Workers Scripts Write",
+                  },
+                  {
+                    id: "c8fed203ed3043cba015a93ad1616f1f",
+                    name: "Zone Read",
+                  },
+                  {
+                    id: "66c1ed49f4ed46098b75696a6d4ee3c9",
+                    name: "Workers Observability Read",
+                  },
+                  {
+                    id: "05880cd1bdc24d8bae0be2136972816b",
+                    name: "Workers Tail Read",
+                  },
+                ],
+                readPermissionGroups: [
+                  {
+                    id: "1a71c399035b4950a1bd1466bbe4f420",
+                    name: "Workers Scripts Read",
+                  },
+                ],
+              },
+            },
+          },
+        },
         stables: ["workerId", "workerName"],
         list: () =>
           Effect.gen(function* () {

--- a/packages/alchemy/src/Cloudflare/WorkersForPlatforms/DispatchNamespace.ts
+++ b/packages/alchemy/src/Cloudflare/WorkersForPlatforms/DispatchNamespace.ts
@@ -157,6 +157,31 @@ export const isDispatchNamespace = (
 
 export const DispatchNamespaceProvider = () =>
   Provider.succeed(DispatchNamespace, {
+    metadata: {
+      cloudflare: {
+        scope: "account",
+        auth: {
+          oauth: {
+            scopes: ["workers:write", "workers_scripts:write"],
+            readScopes: ["workers:read"],
+          },
+          token: {
+            permissionGroups: [
+              {
+                id: "e086da7e2179491d91ee5f35b3ca210a",
+                name: "Workers Scripts Write",
+              },
+            ],
+            readPermissionGroups: [
+              {
+                id: "1a71c399035b4950a1bd1466bbe4f420",
+                name: "Workers Scripts Read",
+              },
+            ],
+          },
+        },
+      },
+    },
     stables: ["namespaceId", "name", "accountId", "createdOn"],
     diff: Effect.fn(function* ({ olds, news, output }) {
       const { accountId } = yield* yield* CloudflareEnvironment;

--- a/packages/alchemy/src/Cloudflare/Workflows/Workflow.ts
+++ b/packages/alchemy/src/Cloudflare/Workflows/Workflow.ts
@@ -633,6 +633,31 @@ export const WorkflowProvider = () =>
       const ctx = yield* AlchemyContext;
 
       return WorkflowResource.Provider.of({
+        metadata: {
+          cloudflare: {
+            scope: "account",
+            auth: {
+              oauth: {
+                scopes: ["workers:write", "workers_scripts:write"],
+                readScopes: ["workers:read"],
+              },
+              token: {
+                permissionGroups: [
+                  {
+                    id: "e086da7e2179491d91ee5f35b3ca210a",
+                    name: "Workers Scripts Write",
+                  },
+                ],
+                readPermissionGroups: [
+                  {
+                    id: "1a71c399035b4950a1bd1466bbe4f420",
+                    name: "Workers Scripts Read",
+                  },
+                ],
+              },
+            },
+          },
+        },
         // The `workflowId` is no longer marked as stable because if you start in dev mode, the ID will change on first deploy.
         stables: ["accountId"],
         // Workflows are account-scoped. Enumerate every workflow in the account

--- a/packages/alchemy/src/Cloudflare/Zaraz/Config.ts
+++ b/packages/alchemy/src/Cloudflare/Zaraz/Config.ts
@@ -199,6 +199,24 @@ export const Config = Object.assign(
 
 export const ConfigProvider = () =>
   Provider.succeed(Config, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              { id: "cdeb15b336e640a2965df8c65052f1e0", name: "Zaraz Admin" },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+            readPermissionGroups: [
+              { id: "5bdbde7e76144204a244274eac3eb0eb", name: "Zaraz Read" },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+          },
+        },
+      },
+    },
     nuke: { singleton: true },
     stables: ["zoneId"],
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/Zone/CustomNameservers.ts
+++ b/packages/alchemy/src/Cloudflare/Zone/CustomNameservers.ts
@@ -123,6 +123,23 @@ export const isCustomNameservers = (
 
 export const CustomNameserversProvider = () =>
   Provider.succeed(CustomNameservers, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false, readScopes: ["zone:read"] },
+          token: {
+            permissionGroups: [
+              { id: "e6d2666161e84845a636613608cee8d5", name: "Zone Write" },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+            readPermissionGroups: [
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+          },
+        },
+      },
+    },
     stables: ["zoneId", "initialEnabled", "initialNsSet"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/Zone/Hold.ts
+++ b/packages/alchemy/src/Cloudflare/Zone/Hold.ts
@@ -116,6 +116,23 @@ const forbiddenRetrySchedule = Schedule.exponential("500 millis").pipe(
 
 export const HoldProvider = () =>
   Provider.succeed(Hold, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false, readScopes: ["zone:read"] },
+          token: {
+            permissionGroups: [
+              { id: "e6d2666161e84845a636613608cee8d5", name: "Zone Write" },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+            readPermissionGroups: [
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+          },
+        },
+      },
+    },
     stables: ["zoneId"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/Zone/Setting.ts
+++ b/packages/alchemy/src/Cloudflare/Zone/Setting.ts
@@ -279,6 +279,30 @@ export const isSetting = (value: unknown): value is Setting =>
 
 export const SettingProvider = () =>
   Provider.succeed(Setting, {
+    metadata: {
+      cloudflare: {
+        scope: "zone",
+        auth: {
+          oauth: { supported: false },
+          token: {
+            permissionGroups: [
+              {
+                id: "3030687196b94b638145a3953da2b699",
+                name: "Zone Settings Write",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+            readPermissionGroups: [
+              {
+                id: "517b21aee92c4d89936c976ba6e4be55",
+                name: "Zone Settings Read",
+              },
+              { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+            ],
+          },
+        },
+      },
+    },
     stables: ["zoneId", "settingId", "initialValue"],
 
     diff: Effect.fn(function* ({ olds = {}, news, output }) {

--- a/packages/alchemy/src/Cloudflare/Zone/Zone.ts
+++ b/packages/alchemy/src/Cloudflare/Zone/Zone.ts
@@ -202,6 +202,25 @@ export const ZoneProvider = () =>
       // const del = yield* zones.deleteZone;
 
       return {
+        metadata: {
+          cloudflare: {
+            scope: "account",
+            auth: {
+              oauth: { supported: false, readScopes: ["zone:read"] },
+              token: {
+                permissionGroups: [
+                  {
+                    id: "e6d2666161e84845a636613608cee8d5",
+                    name: "Zone Write",
+                  },
+                ],
+                readPermissionGroups: [
+                  { id: "c8fed203ed3043cba015a93ad1616f1f", name: "Zone Read" },
+                ],
+              },
+            },
+          },
+        },
         stables: ["name", "zoneId", "accountId"],
         diff: Effect.fn(function* ({ news, output }) {
           if (!output) return undefined;

--- a/packages/alchemy/src/Cloudflare/index.ts
+++ b/packages/alchemy/src/Cloudflare/index.ts
@@ -2,6 +2,10 @@
 export * from "./CloudflareEnvironment.ts";
 export * from "./EdgeSession.ts";
 export * from "./Fetcher.ts";
+export type {
+  CloudflareProviderMetadata,
+  PermissionGroupRequirement,
+} from "./ProviderMetadata.ts";
 export * from "./Providers.ts";
 export * from "./StateStore/index.ts";
 export * from "./Workers/RpcAsync.ts";

--- a/packages/alchemy/src/Provider.ts
+++ b/packages/alchemy/src/Provider.ts
@@ -75,6 +75,24 @@ type Props<Res extends ResourceLike> = keyof Res["Props"] extends never
   ? Res["Props"] | undefined
   : Res["Props"];
 
+/**
+ * Metadata a resource provider declares about itself — most importantly the
+ * credentials/permissions its lifecycle operations require.
+ *
+ * This interface is intentionally empty in core. Each cloud package augments
+ * it with its own optional namespace via declaration merging (see
+ * `Cloudflare/ProviderMetadata.ts`, `AWS/ProviderMetadata.ts`), so third-party
+ * providers can contribute their own namespaces without touching core. Core
+ * never interprets the contents — cloud-specific analyses (e.g. computing the
+ * OAuth scopes an `alchemy login` should request) live with each cloud's auth
+ * provider.
+ *
+ * Values must be plain literals: no `Output`s, no Effects, no environment
+ * reads. Metadata is read by the CLI without running any lifecycle code and
+ * may be serialized into profiles.
+ */
+export interface AlchemyProviderMetadata {}
+
 export interface LogLine {
   timestamp: Date;
   message: string;
@@ -126,6 +144,14 @@ export interface ProviderService<
      */
     skip?: boolean;
   };
+  /**
+   * Declarative metadata about this provider — most importantly the
+   * credentials/permissions its lifecycle operations require (see
+   * {@link AlchemyProviderMetadata}). Local-only providers that make no cloud
+   * API calls declare an empty object (`metadata: {}`) to signal "annotated,
+   * nothing required" as distinct from "not yet annotated".
+   */
+  metadata?: AlchemyProviderMetadata;
   /**
    * Enumerates every existing resource of this type in the ambient scope
    * (account / region / zone resolved from the environment services), and
@@ -396,6 +422,63 @@ const isProviderCollectionService = (
     "kind" in value &&
     value.kind === "ProviderCollection"
   );
+};
+
+/**
+ * Provider metadata keyed by resource type (e.g. `"Cloudflare.Worker"`).
+ */
+export type ProviderMetadataIndex = ReadonlyMap<
+  string,
+  AlchemyProviderMetadata
+>;
+
+/**
+ * The provider metadata visible to a stack. Core only aggregates this —
+ * interpreting the per-cloud namespaces is the job of each cloud's auth
+ * provider (e.g. `Cloudflare/Auth/Requirements.ts`).
+ */
+export interface StackProviderMetadata {
+  /** Metadata of every provider registered in the stack's services. */
+  all: ProviderMetadataIndex;
+  /**
+   * Subset for the resource types the stack program actually declares
+   * (exact mode). Undefined when the stack couldn't be compiled — consumers
+   * should then fall back to {@link all} (whole-cloud mode, which over-asks).
+   */
+  used?: ProviderMetadataIndex;
+}
+
+/**
+ * Collect provider metadata from a built services context by walking every
+ * registered {@link ProviderCollection}. Pass the resource types a stack
+ * declares (`Object.values(stack.resources).map((r) => r.Type)`) to also get
+ * the exact-mode `used` subset.
+ */
+export const collectProviderMetadata = (
+  context: Context.Context<any>,
+  usedTypes?: Iterable<string>,
+): StackProviderMetadata => {
+  const all = new Map<string, AlchemyProviderMetadata>();
+  for (const value of context.mapUnsafe.values()) {
+    if (isProviderCollectionService(value)) {
+      for (const [type, provider] of Object.entries(value.providers)) {
+        if (provider?.metadata !== undefined) {
+          all.set(type, provider.metadata);
+        }
+      }
+    }
+  }
+  if (usedTypes === undefined) {
+    return { all };
+  }
+  const used = new Map<string, AlchemyProviderMetadata>();
+  for (const type of usedTypes) {
+    const metadata = all.get(type);
+    if (metadata !== undefined) {
+      used.set(type, metadata);
+    }
+  }
+  return { all, used };
 };
 
 export const findProviderByType: {

--- a/packages/alchemy/src/index.ts
+++ b/packages/alchemy/src/index.ts
@@ -44,7 +44,12 @@ export type { Dependencies } from "./Dependencies.ts";
 export type { Named } from "./Named.ts";
 export type * from "./Platform.ts";
 export { Platform } from "./Platform.ts";
-export type { ProviderCollectionLike } from "./Provider.ts";
+export type {
+  AlchemyProviderMetadata,
+  ProviderCollectionLike,
+  ProviderMetadataIndex,
+  StackProviderMetadata,
+} from "./Provider.ts";
 export type * from "./Rpc.ts";
 export {
   RuntimeContext,

--- a/packages/alchemy/test/Auth/Requirements.test.ts
+++ b/packages/alchemy/test/Auth/Requirements.test.ts
@@ -1,0 +1,142 @@
+import {
+  collectAwsRequirements,
+  toPolicyDocument,
+} from "@/AWS/Requirements.ts";
+import {
+  collectCloudflareRequirements,
+  suggestOAuthScopes,
+} from "@/Cloudflare/Auth/Requirements.ts";
+import type {
+  AlchemyProviderMetadata,
+  StackProviderMetadata,
+} from "@/index.ts";
+import { describe, expect, it } from "@effect/vitest";
+
+const metadata = (
+  entries: Record<string, AlchemyProviderMetadata>,
+  used?: string[],
+): StackProviderMetadata => {
+  const all = new Map(Object.entries(entries));
+  return used === undefined
+    ? { all }
+    : {
+        all,
+        used: new Map(used.map((type) => [type, all.get(type)!])),
+      };
+};
+
+const worker: AlchemyProviderMetadata = {
+  cloudflare: {
+    scope: "account",
+    auth: {
+      oauth: { scopes: ["workers:write", "workers_scripts:write"] },
+      token: {
+        permissionGroups: [
+          {
+            id: "e086da7e2179491d91ee5f35b3ca210a",
+            name: "Workers Scripts Write",
+          },
+        ],
+      },
+    },
+  },
+};
+
+const zoneSetting: AlchemyProviderMetadata = {
+  cloudflare: {
+    scope: "zone",
+    auth: {
+      oauth: { supported: false },
+      token: {
+        permissionGroups: [
+          {
+            id: "9ff81cbbe65c400b97d92c3c1033cab6",
+            name: "Cache Settings Write",
+          },
+        ],
+      },
+    },
+  },
+};
+
+const bucket: AlchemyProviderMetadata = {
+  aws: {
+    iam: {
+      actions: ["s3:CreateBucket", "s3:DeleteBucket"],
+      readActions: ["s3:ListAllMyBuckets"],
+      notes: "headBucket authorizes as s3:ListBucket.",
+    },
+  },
+};
+
+describe("Cloudflare Requirements", () => {
+  it("unions scopes and permission groups over the used subset", () => {
+    const requirements = collectCloudflareRequirements(
+      metadata(
+        { "CF.Worker": worker, "CF.Cache": zoneSetting, "AWS.Bucket": bucket },
+        ["CF.Worker", "CF.Cache"],
+      ),
+    );
+    expect([...requirements.oauthScopes.keys()].sort()).toEqual([
+      "workers:write",
+      "workers_scripts:write",
+    ]);
+    expect(requirements.oauthScopes.get("workers:write")).toEqual([
+      "CF.Worker",
+    ]);
+    expect(requirements.oauthUnsupported).toEqual(["CF.Cache"]);
+    expect(requirements.hasZoneScoped).toBe(true);
+    expect(
+      requirements.permissionGroups.get("e086da7e2179491d91ee5f35b3ca210a"),
+    ).toEqual({ name: "Workers Scripts Write", resourceTypes: ["CF.Worker"] });
+    expect(requirements.permissionGroups.size).toBe(2);
+  });
+
+  it("falls back to `all` when no used subset exists", () => {
+    const requirements = collectCloudflareRequirements(
+      metadata({ "CF.Worker": worker }),
+    );
+    expect(requirements.oauthScopes.size).toBe(2);
+  });
+
+  it("suggests base scopes plus required scopes, zone:read only when zone-scoped", () => {
+    const withZone = collectCloudflareRequirements(
+      metadata({ "CF.Worker": worker, "CF.Cache": zoneSetting }),
+    );
+    expect(suggestOAuthScopes(withZone)).toEqual([
+      "account:read",
+      "user:read",
+      "workers:write",
+      "workers_scripts:write",
+      "zone:read",
+    ]);
+    const accountOnly = collectCloudflareRequirements(
+      metadata({ "CF.Worker": worker }),
+    );
+    expect(suggestOAuthScopes(accountOnly)).not.toContain("zone:read");
+  });
+});
+
+describe("AWS Requirements", () => {
+  it("unions actions with resource attribution and renders a policy document", () => {
+    const requirements = collectAwsRequirements(
+      metadata({ "AWS.Bucket": bucket, "CF.Worker": worker }),
+    );
+    expect(requirements.actions.get("s3:CreateBucket")).toEqual(["AWS.Bucket"]);
+    expect(requirements.notes).toEqual([
+      {
+        resourceType: "AWS.Bucket",
+        note: "headBucket authorizes as s3:ListBucket.",
+      },
+    ]);
+
+    const policy = toPolicyDocument(requirements);
+    expect(policy.Statement[0]!.Action).toEqual([
+      "s3:CreateBucket",
+      "s3:DeleteBucket",
+      "s3:ListAllMyBuckets",
+    ]);
+    const planOnly = toPolicyDocument(requirements, { planOnly: true });
+    expect(planOnly.Statement[0]!.Action).toEqual(["s3:ListAllMyBuckets"]);
+  });
+});

--- a/packages/alchemy/test/ProviderMetadata.test.ts
+++ b/packages/alchemy/test/ProviderMetadata.test.ts
@@ -1,0 +1,60 @@
+import { PlatformServices } from "@/Util/PlatformServices.ts";
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+
+/**
+ * Enforcement for provider metadata (see processes/ProviderMetadata/DESIGN.md
+ * §6): every resource provider under src/AWS and src/Cloudflare must declare a
+ * `metadata` field — local-only providers declare `metadata: {}` — so the
+ * credential-requirements catalog can't rot as new resources are added.
+ *
+ * Static source scan (counting `Provider.effect(`/`Provider.succeed(` sites
+ * vs `metadata: {` keys per file) rather than constructing the provider
+ * layers, which would require cloud environment services in a unit test.
+ */
+
+const PROVIDER_CALL = /\bProvider\.(effect|succeed)\(/g;
+const METADATA_KEY = /\bmetadata: \{/g;
+
+const scan = Effect.gen(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const root = path.join(import.meta.dirname, "..", "src");
+
+  const offenders: string[] = [];
+  for (const cloud of ["AWS", "Cloudflare"]) {
+    const files = yield* fs.readDirectory(path.join(root, cloud), {
+      recursive: true,
+    });
+    for (const file of files) {
+      if (!file.endsWith(".ts")) continue;
+      const source = yield* fs.readFileString(path.join(root, cloud, file));
+      const providers = source.match(PROVIDER_CALL)?.length ?? 0;
+      if (providers === 0) continue;
+      const metadata = source.match(METADATA_KEY)?.length ?? 0;
+      if (metadata < providers) {
+        offenders.push(
+          `${cloud}/${file} (${providers} provider(s), ${metadata} metadata key(s))`,
+        );
+      }
+    }
+  }
+  return offenders;
+});
+
+describe("ProviderMetadata", () => {
+  it.effect(
+    "every AWS and Cloudflare resource provider declares metadata",
+    () =>
+      Effect.gen(function* () {
+        const offenders = yield* scan;
+        expect(
+          offenders,
+          "providers missing a metadata field — annotate them per processes/ProviderMetadata/DESIGN.md " +
+            "(local-only providers declare `metadata: {}`)",
+        ).toEqual([]);
+      }).pipe(Effect.provide(PlatformServices)),
+  );
+});

--- a/scripts/generate-api-reference.ts
+++ b/scripts/generate-api-reference.ts
@@ -526,21 +526,53 @@ function renderPermissionsSection(
       parts.push(`Scope: **${cf.scope}**`);
     }
     const oauth = cf.auth?.oauth;
+    const token = cf.auth?.token;
+    const oauthUnsupported = oauth?.supported === false;
+    const hasTokenGroups =
+      (token?.permissionGroups?.length ?? 0) > 0 ||
+      (token?.readPermissionGroups?.length ?? 0) > 0;
+    if (oauthUnsupported && hasTokenGroups) {
+      parts.push(
+        [
+          ":::caution",
+          "This resource cannot be managed with an OAuth user token (`alchemy login`). " +
+            "Use an API token carrying the permission groups below — e.g. " +
+            "`alchemy cloudflare create-token --from-stack alchemy.run.ts`.",
+          ":::",
+        ].join("\n"),
+      );
+    } else if (oauthUnsupported) {
+      parts.push(
+        [
+          ":::caution",
+          "This resource cannot be managed with an OAuth user token, and Cloudflare " +
+            "does not publish an API-token permission group for it yet. Managing it " +
+            "requires Global API Key credentials.",
+          ":::",
+        ].join("\n"),
+      );
+    } else if (!hasTokenGroups && (oauth?.scopes?.length ?? 0) > 0) {
+      parts.push(
+        [
+          ":::caution",
+          "No API-token permission group is cataloged for this resource — manage it " +
+            "with an OAuth user token (`alchemy login`) using the scopes below.",
+          ":::",
+        ].join("\n"),
+      );
+    }
     if (oauth) {
-      if (oauth.supported === false) {
-        parts.push(
-          "**OAuth:** not manageable via OAuth user tokens — use an API token.",
-        );
-      } else if (oauth.scopes && oauth.scopes.length > 0) {
+      if (!oauthUnsupported && oauth.scopes && oauth.scopes.length > 0) {
         parts.push(`**OAuth scopes:** ${inlineCodes(oauth.scopes)}`);
       }
+      // Rendered even when full management is OAuth-unsupported: read-only
+      // scopes still enable plan-only sessions.
       if (oauth.readScopes && oauth.readScopes.length > 0) {
         parts.push(
           `**Plan-only (read) OAuth scopes:** ${inlineCodes(oauth.readScopes)}`,
         );
       }
     }
-    const token = cf.auth?.token;
     if (token?.permissionGroups && token.permissionGroups.length > 0) {
       parts.push(
         [

--- a/scripts/generate-api-reference.ts
+++ b/scripts/generate-api-reference.ts
@@ -1,7 +1,12 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 
-import { Node, Project, type SourceFile } from "ts-morph";
+import {
+  Node,
+  type ObjectLiteralExpression,
+  Project,
+  type SourceFile,
+} from "ts-morph";
 
 const websiteRoot = path.join(import.meta.dir, "../website");
 
@@ -32,6 +37,8 @@ interface PageDoc {
   relativePath: string;
   summary: string;
   sections: ExampleSection[];
+  /** Rendered "Required permissions" markdown (from provider `metadata`). */
+  permissions?: string;
 }
 
 const normalizeSlashes = (value: string) => value.split(path.sep).join("/");
@@ -319,6 +326,264 @@ function findTaggedPrimary(sourceFile: SourceFile): Primary | undefined {
   return undefined;
 }
 
+// ---------------------------------------------------------------------------
+// Required permissions — statically extracted from the provider's `metadata`
+// declaration (see AlchemyProviderMetadata in packages/alchemy/src/Provider.ts).
+// ---------------------------------------------------------------------------
+
+/** The cloud keys `AlchemyProviderMetadata` is augmented with. */
+const METADATA_CLOUD_KEYS = new Set(["aws", "cloudflare"]);
+
+interface ParsedPermissionGroup {
+  id?: string;
+  name?: string;
+}
+
+interface ParsedProviderMetadata {
+  aws?: {
+    iam?: { actions?: string[]; readActions?: string[]; notes?: string };
+  };
+  cloudflare?: {
+    scope?: string;
+    auth?: {
+      oauth?: { supported?: boolean; scopes?: string[]; readScopes?: string[] };
+      token?: {
+        permissionGroups?: ParsedPermissionGroup[];
+        readPermissionGroups?: ParsedPermissionGroup[];
+      };
+    };
+  };
+}
+
+/**
+ * Statically evaluate a plain-literal expression into data. Provider metadata
+ * is documented as "plain literals — no `Output`s, Effects, or environment
+ * reads", so anything else throws (and the resource is reported, not guessed).
+ */
+function literalToData(node: Node): unknown {
+  if (
+    Node.isParenthesizedExpression(node) ||
+    Node.isAsExpression(node) ||
+    Node.isSatisfiesExpression(node)
+  ) {
+    return literalToData(node.getExpression());
+  }
+  if (Node.isStringLiteral(node) || Node.isNoSubstitutionTemplateLiteral(node)) {
+    return node.getLiteralValue();
+  }
+  if (Node.isNumericLiteral(node)) return node.getLiteralValue();
+  if (Node.isTrueLiteral(node)) return true;
+  if (Node.isFalseLiteral(node)) return false;
+  if (Node.isNullLiteral(node)) return null;
+  if (Node.isArrayLiteralExpression(node)) {
+    return node.getElements().map(literalToData);
+  }
+  if (Node.isObjectLiteralExpression(node)) {
+    const out: Record<string, unknown> = {};
+    for (const prop of node.getProperties()) {
+      if (!Node.isPropertyAssignment(prop)) {
+        throw new Error(`non-literal property: ${prop.getText().slice(0, 60)}`);
+      }
+      const key = prop.getName().replace(/^["']|["']$/g, "");
+      out[key] = literalToData(prop.getInitializerOrThrow());
+    }
+    return out;
+  }
+  throw new Error(`non-literal expression: ${node.getText().slice(0, 60)}`);
+}
+
+/**
+ * Find `metadata: { ... }` object literals that look like provider metadata:
+ * a `metadata` property whose object-literal value has only cloud keys
+ * (`aws` / `cloudflare`) — or is empty (`metadata: {}` = local-only). The key
+ * filter rejects the many other `metadata:` properties in provider code
+ * (Worker script metadata, Kubernetes object metadata, …).
+ */
+function findMetadataCandidates(
+  sourceFile: SourceFile,
+): ObjectLiteralExpression[] {
+  const results: ObjectLiteralExpression[] = [];
+  sourceFile.forEachDescendant((node) => {
+    if (!Node.isPropertyAssignment(node)) return;
+    if (node.getName() !== "metadata") return;
+    const init = node.getInitializer();
+    if (!init || !Node.isObjectLiteralExpression(init)) return;
+    const names = init.getProperties().map((p) =>
+      Node.isPropertyAssignment(p) || Node.isShorthandPropertyAssignment(p)
+        ? p.getName().replace(/^["']|["']$/g, "")
+        : undefined,
+    );
+    if (names.some((n) => n === undefined || !METADATA_CLOUD_KEYS.has(n))) {
+      return;
+    }
+    results.push(init);
+  });
+  return results;
+}
+
+/**
+ * True when the metadata literal sits inside the provider registration for
+ * `resourceName` — `Provider.succeed(Name, {...})` or `Name.Provider.of({...})`.
+ * Used to attribute metadata found in a sibling `*Provider.ts` file.
+ */
+function belongsToProvider(
+  meta: ObjectLiteralExpression,
+  resourceName: string,
+): boolean {
+  let current: Node | undefined = meta;
+  while (current) {
+    if (Node.isCallExpression(current)) {
+      const callee = current.getExpression().getText();
+      if (callee === `${resourceName}.Provider.of`) return true;
+      if (callee === "Provider.succeed" || callee.endsWith(".Provider.succeed")) {
+        if (current.getArguments()[0]?.getText() === resourceName) return true;
+      }
+    }
+    current = current.getParent();
+  }
+  return false;
+}
+
+/**
+ * Locate the provider `metadata` declaration for a resource: first in the
+ * resource's own file, then in sibling `*Provider.ts` files (e.g.
+ * Workers/Worker.ts's provider lives in Workers/WorkerProvider.ts). Returns
+ * the rendered section, or undefined for local-only (`metadata: {}`) and
+ * un-annotated providers. Parse failures are pushed onto `issues`.
+ */
+async function extractPermissionsSection(
+  project: Project,
+  sourceFile: SourceFile,
+  entry: FileEntry,
+  resourceName: string,
+  issues: string[],
+): Promise<string | undefined> {
+  const candidates = findMetadataCandidates(sourceFile);
+
+  if (candidates.length === 0) {
+    const dir = path.dirname(entry.absolutePath);
+    let siblings: string[] = [];
+    try {
+      siblings = await fs.readdir(dir);
+    } catch {
+      // ignore
+    }
+    for (const sibling of siblings) {
+      if (!sibling.endsWith("Provider.ts")) continue;
+      const siblingPath = path.join(dir, sibling);
+      if (siblingPath === entry.absolutePath) continue;
+      const siblingFile = project.getSourceFile(siblingPath);
+      if (!siblingFile) continue;
+      candidates.push(
+        ...findMetadataCandidates(siblingFile).filter((c) =>
+          belongsToProvider(c, resourceName),
+        ),
+      );
+    }
+  }
+
+  if (candidates.length === 0) return undefined;
+
+  // Prefer the cloud provider's metadata over a local provider's `metadata: {}`.
+  const nonEmpty = candidates.filter((c) => c.getProperties().length > 0);
+  if (nonEmpty.length === 0) return undefined; // local-only
+  let pick = nonEmpty;
+  if (pick.length > 1) {
+    const owned = pick.filter((c) => belongsToProvider(c, resourceName));
+    if (owned.length > 0) pick = owned;
+    if (pick.length > 1) {
+      console.warn(
+        `  multiple metadata declarations for ${resourceName} (${entry.relativePath}); using the first`,
+      );
+    }
+  }
+
+  try {
+    const meta = literalToData(pick[0]) as ParsedProviderMetadata;
+    return renderPermissionsSection(meta);
+  } catch (error) {
+    issues.push(
+      `${entry.relativePath} (${resourceName}): ${(error as Error).message}`,
+    );
+    return undefined;
+  }
+}
+
+const inlineCodes = (values: string[]) =>
+  values.map((v) => `\`${v}\``).join(", ");
+
+const permissionGroupItem = (pg: ParsedPermissionGroup) =>
+  `- ${pg.name ?? "Unknown"} (\`${pg.id ?? "?"}\`)`;
+
+function renderPermissionsSection(
+  meta: ParsedProviderMetadata,
+): string | undefined {
+  const parts: string[] = [];
+
+  const cf = meta.cloudflare;
+  if (cf) {
+    if (cf.scope) {
+      parts.push(`Scope: **${cf.scope}**`);
+    }
+    const oauth = cf.auth?.oauth;
+    if (oauth) {
+      if (oauth.supported === false) {
+        parts.push(
+          "**OAuth:** not manageable via OAuth user tokens — use an API token.",
+        );
+      } else if (oauth.scopes && oauth.scopes.length > 0) {
+        parts.push(`**OAuth scopes:** ${inlineCodes(oauth.scopes)}`);
+      }
+      if (oauth.readScopes && oauth.readScopes.length > 0) {
+        parts.push(
+          `**Plan-only (read) OAuth scopes:** ${inlineCodes(oauth.readScopes)}`,
+        );
+      }
+    }
+    const token = cf.auth?.token;
+    if (token?.permissionGroups && token.permissionGroups.length > 0) {
+      parts.push(
+        [
+          "**API token permission groups:**",
+          "",
+          ...token.permissionGroups.map(permissionGroupItem),
+        ].join("\n"),
+      );
+    }
+    if (token?.readPermissionGroups && token.readPermissionGroups.length > 0) {
+      parts.push(
+        [
+          "**Plan-only (read) permission groups:**",
+          "",
+          ...token.readPermissionGroups.map(permissionGroupItem),
+        ].join("\n"),
+      );
+    }
+  }
+
+  const iam = meta.aws?.iam;
+  if (iam) {
+    if (iam.actions && iam.actions.length > 0) {
+      parts.push(
+        ["**IAM actions:**", "", ...iam.actions.map((a) => `- \`${a}\``)].join(
+          "\n",
+        ),
+      );
+    }
+    if (iam.readActions && iam.readActions.length > 0) {
+      parts.push(
+        `**Plan-only (read) IAM actions:** ${inlineCodes(iam.readActions)}`,
+      );
+    }
+    if (iam.notes) {
+      parts.push(iam.notes);
+    }
+  }
+
+  if (parts.length === 0) return undefined;
+  return ["## Required permissions", ...parts].join("\n\n");
+}
+
 function yamlString(value: string): string {
   if (/[\n:"{}[\],&*?|>!%@`#]/.test(value) || value.trim() !== value) {
     return JSON.stringify(value);
@@ -351,6 +616,10 @@ function renderPageBody(doc: PageDoc): string {
       secParts.push(example.body);
     }
     parts.push(secParts.join("\n\n"));
+  }
+
+  if (doc.permissions) {
+    parts.push(doc.permissions);
   }
 
   return parts.join("\n\n");
@@ -492,6 +761,7 @@ async function main() {
 
   const seen = new Map<string, string>();
   const pageEntries: PageEntry[] = [];
+  const metadataIssues: string[] = [];
   let written = 0;
   let skipped = 0;
 
@@ -534,6 +804,13 @@ async function main() {
       relativePath: entry.relativePath,
       summary: primary.doc.summary,
       sections: primary.doc.sections,
+      permissions: await extractPermissionsSection(
+        project,
+        sourceFile,
+        entry,
+        primary.name,
+        metadataIssues,
+      ),
     };
 
     const outputPath = path.join(config.outRoot, outputRelative);
@@ -565,6 +842,15 @@ async function main() {
     `${JSON.stringify(sidebar, null, 2)}\n`,
     "utf8",
   );
+
+  if (metadataIssues.length > 0) {
+    console.warn(
+      `Provider metadata could not be statically parsed for ${metadataIssues.length} resource(s):`,
+    );
+    for (const issue of metadataIssues) {
+      console.warn(`  ${issue}`);
+    }
+  }
 
   console.log(
     `Done. Wrote ${written} resource pages (skipped ${skipped} untagged) to ${normalizeSlashes(


### PR DESCRIPTION
Providers now declare the credentials their lifecycle operations require via a `metadata` field on `ProviderService`, and the CLI uses it to request or mint exactly the grants a stack needs.

```ts
// core: empty AlchemyProviderMetadata interface, augmented per cloud
metadata: {
  cloudflare: {
    scope: "account",
    auth: {
      oauth: { scopes: ["workers:write", "workers_scripts:write"], readScopes: ["workers:read"] },
      token: {
        permissionGroups: [
          { id: "e086da7e2179491d91ee5f35b3ca210a", name: "Workers Scripts Write" },
        ],
      },
    },
  },
}
// AWS: metadata: { aws: { iam: { actions, readActions, notes } } }
```

- All 380 AWS + Cloudflare resource providers annotated (per-resource lifecycle→API mapping researched from the provider source; 878 permission-group `{id, name}` pairs validated against the static catalog). A static test fails CI when a new provider lands without metadata (`metadata: {}` marks local-only providers).
- `collectProviderMetadata(context, usedTypes)` keeps core cloud-agnostic; compiling the stack (`yield* stackEffect` — no cloud calls, no credentials) yields the exact resource types in use. Cloud-specific analysis lives with each auth provider (`Cloudflare/Auth/Requirements.ts`, `AWS/Requirements.ts`).
- `alchemy login`: the Cloudflare OAuth prompt preselects exactly the scopes the stack's resources need (9 instead of the 26 `DEFAULT_SCOPES` for `examples/cloudflare-worker-async`) and warns up front when resources can't be managed over OAuth at all (158 of 238 Cloudflare resources are API-token-only).
- `alchemy cloudflare create-token --from-stack alchemy.run.ts`: mints a least-privilege token from the stack's permission groups, id-resolved against the live `/user/tokens/permission_groups` endpoint with a name fallback and a loud warning for anything unresolvable.
- Deploy preflight (`Auth/Preflight.ts`): before `Plan.make`, each registered auth provider diffs required-vs-granted for the active profile and renders warnings with resource attribution. It never blocks the run.
- `AWS/Requirements.ts` includes `toPolicyDocument` (deploy or plan-only tiers) for a future `alchemy aws create-policy`.
- `bun docs:gen` now emits a "Required permissions" section per resource page (372 pages): OAuth scopes, token permission groups with ids, IAM actions, and plan-only tiers.

Also replaces two raw NUL bytes in `Cloudflare/Web3/ContentList.ts` with `\0` escapes (same semantics; the file was being treated as binary by search tools).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
