### PR TITLE
chore(examples): correct container syntax in cloudflare-dev example

### DIFF
--- a/examples/cloudflare-dev/alchemy.run.ts
+++ b/examples/cloudflare-dev/alchemy.run.ts
@@ -5,6 +5,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import type { Counter, QueueMessages } from "./src/AsyncWorker.ts";
 import EffectWorker from "./src/EffectWorker.ts";
+import { SandboxLive } from "./src/SandboxContainer.ts";
 
 export type AsyncWorkerEnv = Cloudflare.InferEnv<typeof AsyncWorker>;
 
@@ -51,5 +52,5 @@ export default Alchemy.Stack(
       asyncWorker: asyncWorker.url,
       effectWorker: effectWorker.url,
     };
-  }),
+  }).pipe(Effect.provide(SandboxLive)),
 );

--- a/examples/cloudflare-dev/src/EffectWorker.ts
+++ b/examples/cloudflare-dev/src/EffectWorker.ts
@@ -32,18 +32,20 @@ export default class EffectWorker extends Cloudflare.Worker<EffectWorker>()(
   Effect.gen(function* () {
     const kv = yield* Cloudflare.KV.ReadWriteNamespace(KV);
     const queue = yield* Cloudflare.Queues.Queue("EffectWorkerQueue");
-    const queueBinding = yield* Cloudflare.Queues.Queue(queue);
+    const queueBinding = yield* Cloudflare.Queues.WriteQueue(queue);
     const sandbox = yield* SandboxDO;
     const queueMessages = yield* QueueMessages;
     const workflow = yield* NotifyWorkflow;
 
-    yield* Cloudflare.Queues.consumeQueueMessages<Message["body"]>(queue, (stream) =>
-      Stream.runForEach(stream, (msg) =>
-        queueMessages
-          .getByName("global")
-          .put({ id: msg.id, body: msg.body })
-          .pipe(Effect.asVoid),
-      ),
+    yield* Cloudflare.Queues.consumeQueueMessages<Message["body"]>(
+      queue,
+      (stream) =>
+        Stream.runForEach(stream, (msg) =>
+          queueMessages
+            .getByName("global")
+            .put({ id: msg.id, body: msg.body })
+            .pipe(Effect.asVoid),
+        ),
     );
 
     return {

--- a/examples/cloudflare-dev/src/SandboxContainer.ts
+++ b/examples/cloudflare-dev/src/SandboxContainer.ts
@@ -6,25 +6,30 @@ import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 export class SandboxContainer extends Cloudflare.Container<
   SandboxContainer,
   {}
->()(
-  "SandboxContainer",
+>()("SandboxContainer") {}
+
+export const SandboxLive = /* @__PURE__ */ SandboxContainer.make(
   Stack.useSync((stack) => ({
     main: import.meta.url,
     instanceType: stack.stage === "prod" ? "standard-1" : "dev",
+    env: {
+      GREETING: "hello-from-env",
+    },
     observability: {
       logs: {
         enabled: true,
       },
     },
   })),
-) {}
-
-export default SandboxContainer.make(
   Effect.gen(function* () {
     return SandboxContainer.of({
-      fetch: Effect.succeed(
-        HttpServerResponse.text("Hello from Sandbox container!"),
+      fetch: Effect.sync(() =>
+        HttpServerResponse.text(
+          `Hello from Sandbox container! GREETING=${process.env.GREETING}`,
+        ),
       ),
     });
   }),
 );
+
+export default SandboxLive;

--- a/examples/cloudflare-dev/src/SandboxContainer.ts
+++ b/examples/cloudflare-dev/src/SandboxContainer.ts
@@ -23,10 +23,8 @@ export const SandboxLive = /* @__PURE__ */ SandboxContainer.make(
   })),
   Effect.gen(function* () {
     return SandboxContainer.of({
-      fetch: Effect.sync(() =>
-        HttpServerResponse.text(
-          `Hello from Sandbox container! GREETING=${process.env.GREETING}`,
-        ),
+      fetch: Effect.succeed(
+        HttpServerResponse.text("Hello from Sandbox container!"),
       ),
     });
   }),

--- a/examples/cloudflare-dev/src/SandboxContainer.ts
+++ b/examples/cloudflare-dev/src/SandboxContainer.ts
@@ -12,9 +12,6 @@ export const SandboxLive = /* @__PURE__ */ SandboxContainer.make(
   Stack.useSync((stack) => ({
     main: import.meta.url,
     instanceType: stack.stage === "prod" ? "standard-1" : "dev",
-    env: {
-      GREETING: "hello-from-env",
-    },
     observability: {
       logs: {
         enabled: true,
@@ -23,8 +20,10 @@ export const SandboxLive = /* @__PURE__ */ SandboxContainer.make(
   })),
   Effect.gen(function* () {
     return SandboxContainer.of({
-      fetch: Effect.succeed(
-        HttpServerResponse.text("Hello from Sandbox container!"),
+      fetch: Effect.sync(() =>
+        HttpServerResponse.text(
+          `Hello from Sandbox container! GREETING=${process.env.GREETING}`,
+        ),
       ),
     });
   }),

--- a/examples/cloudflare-dev/src/SandboxContainer.ts
+++ b/examples/cloudflare-dev/src/SandboxContainer.ts
@@ -20,10 +20,8 @@ export const SandboxLive = /* @__PURE__ */ SandboxContainer.make(
   })),
   Effect.gen(function* () {
     return SandboxContainer.of({
-      fetch: Effect.sync(() =>
-        HttpServerResponse.text(
-          `Hello from Sandbox container! GREETING=${process.env.GREETING}`,
-        ),
+      fetch: Effect.succeed(
+        HttpServerResponse.text("Hello from Sandbox container!"),
       ),
     });
   }),

--- a/examples/cloudflare-dev/src/SandboxDO.ts
+++ b/examples/cloudflare-dev/src/SandboxDO.ts
@@ -6,13 +6,9 @@ import { SandboxContainer } from "./SandboxContainer.ts";
 export default class SandboxDO extends Cloudflare.DurableObject<SandboxDO>()(
   "SandboxDO",
   Effect.gen(function* () {
-    const sandbox = yield* Cloudflare.Container(SandboxContainer);
+    const container = yield* SandboxContainer;
 
     return Effect.gen(function* () {
-      const container = yield* Cloudflare.start(sandbox, {
-        enableInternet: true,
-      });
-
       return {
         fetch: Effect.gen(function* () {
           const { fetch } = yield* container.getTcpPort(3000);
@@ -26,5 +22,11 @@ export default class SandboxDO extends Cloudflare.DurableObject<SandboxDO>()(
         }),
       };
     });
-  }),
+  }).pipe(
+    Effect.provide(
+      Cloudflare.Containers.layer(SandboxContainer, {
+        enableInternet: true,
+      }),
+    ),
+  ),
 ) {}


### PR DESCRIPTION
The `cloudflare-dev` example wasn't updated to use the new container syntax. Here's a quick fix for that.