### PR TITLE
docs(website): fix empty provider directory in production builds

### DIFF
--- a/website/src/components/ProviderDirectory.astro
+++ b/website/src/components/ProviderDirectory.astro
@@ -6,8 +6,6 @@
  * sidebar (`bun run build:reference`); the directory renders without
  * counts if it hasn't been generated yet.
  */
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
 import { sidebarGroupIcon } from "../docs-icons";
 
 interface SidebarNode {
@@ -16,19 +14,20 @@ interface SidebarNode {
   items?: SidebarNode[];
 }
 
+/**
+ * Resolved at BUILD time via Vite's eager glob — a runtime fs read
+ * relative to import.meta.url breaks once this component is bundled
+ * into dist/ (the production /providers page rendered zero cards).
+ * The glob stays graceful when the file hasn't been generated yet
+ * (fresh `astro dev` before `bun run build:reference`).
+ */
+const generatedModules = import.meta.glob<{ default: SidebarNode[] }>(
+  "../generated/providers-sidebar.json",
+  { eager: true },
+);
+
 function generatedSidebar(): SidebarNode[] | undefined {
-  try {
-    return JSON.parse(
-      readFileSync(
-        fileURLToPath(
-          new URL("../generated/providers-sidebar.json", import.meta.url),
-        ),
-        "utf8",
-      ),
-    );
-  } catch {
-    return undefined;
-  }
+  return Object.values(generatedModules)[0]?.default;
 }
 
 const countLinks = (nodes: SidebarNode[]): number =>


### PR DESCRIPTION
Fix the empty API Reference directory on the live site (https://v2.alchemy.run/providers/).

`ProviderDirectory.astro` read the generated `providers-sidebar.json` at runtime, path-relative to `import.meta.url`:

```ts
// works in astro dev (component served from src/), dangles in the
// production bundle (component relocated into dist/chunks/):
readFileSync(new URL("../generated/providers-sidebar.json", import.meta.url))
```

The graceful missing-file fallback turned the dangling path into an invisible empty card grid. Now the JSON is bound at build time:

```ts
const generatedModules = import.meta.glob("../generated/providers-sidebar.json", { eager: true });
```

Verified against the production build output: `dist/providers/index.html` renders all ten cards with live resource counts. The eager glob still resolves to nothing (instead of crashing) on a fresh checkout before `bun run build:reference`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
