### PR TITLE
docs(website): collapse the tab-row height on mobile

### DIFF
--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -39,6 +39,20 @@
   }
 }
 
+/* Starlight shows the sticky "On this page" bar everywhere below 72rem —
+   including the 50–72rem range where the tab bar and left sidebar are
+   already up, which reads as stray mobile chrome on a desktop layout.
+   Align it with the rest of the chrome: mobile-only (< 50rem). The
+   right-rail TOC still appears from 72rem, as before. */
+@media (min-width: 50rem) {
+  :root {
+    --sl-mobile-toc-height: 0rem;
+  }
+  mobile-starlight-toc {
+    display: none;
+  }
+}
+
 /* Faint accent wash across the top of the whole docs page — sidebar,
    content, and TOC alike (bun.com-style), fading into the page background.
    The fixed sidebar goes transparent on desktop so the wash shows through

--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -28,6 +28,17 @@
   color-scheme: light;
 }
 
+/* The tab row is desktop-only (mobile navigation lives in the hamburger
+   drawer's product switcher), so collapse its reserved height on mobile —
+   otherwise the header keeps a dead 2.5rem band where the row used to be.
+   Everything offset by --sl-nav-height (sidebar pane, content top,
+   scroll-padding, menu-button centering) follows automatically. */
+@media (max-width: 50rem) {
+  :root {
+    --alc-tabs-height: 0rem;
+  }
+}
+
 /* Faint accent wash across the top of the whole docs page — sidebar,
    content, and TOC alike (bun.com-style), fading into the page background.
    The fixed sidebar goes transparent on desktop so the wash shows through


### PR DESCRIPTION
Remove the dead band in the mobile docs header left behind when the tab row became desktop-only.

`--sl-nav-height` was unconditionally two rows (`4rem` brand + `2.5rem` tabs), so mobile kept reserving the hidden tab row's height:

```css
@media (max-width: 50rem) {
  :root {
    --alc-tabs-height: 0rem;
  }
}
```

Everything offset by `--sl-nav-height` (sidebar drawer top, content padding, scroll-padding, menu-button centering) is calc'd from the token, so it all follows automatically — verified at 375px (header collapses to the single 64px brand row, drawer opens flush beneath it) and 1400px (desktop tab row unchanged).

Also gates Starlight's sticky "On this page" bar to true mobile (`< 50rem`): its default shows it everywhere below 72rem, including the 800–1152px range where the tab bar and left sidebar are already up — stray mobile chrome on a desktop layout. The right-rail TOC still appears from 72rem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
