### PR TITLE
fix(cloudflare): fold command + env into the memo hash for StaticSite

### DIFF
--- a/packages/alchemy/src/Command/Build.ts
+++ b/packages/alchemy/src/Command/Build.ts
@@ -2,9 +2,11 @@ import * as Effect from "effect/Effect";
 import * as Equal from "effect/Equal";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
+import * as Redacted from "effect/Redacted";
 import { havePropsChanged, isResolved } from "../Diff.ts";
 import * as Provider from "../Provider.ts";
 import { Resource } from "../Resource.ts";
+import { sha256Object } from "../Util/sha256.ts";
 import {
   CommandError,
   CommandExecutor,
@@ -109,6 +111,21 @@ export interface Build extends Resource<
  */
 export const Build = Resource<Build>("Command.Build");
 
+/**
+ * Resolves `Redacted` env values to their plain string so that a change in a
+ * secret's value still busts the memo hash (the hash is one-way, so the secret
+ * itself is never recoverable from state).
+ */
+const resolveEnv = (env: CommandProps["env"]) =>
+  env
+    ? Object.fromEntries(
+        Object.entries(env).map(([key, value]) => [
+          key,
+          Redacted.isRedacted(value) ? Redacted.value(value) : value,
+        ]),
+      )
+    : undefined;
+
 export const BuildProvider = () =>
   Provider.effect(
     Build,
@@ -135,10 +152,24 @@ export const BuildProvider = () =>
               ? { input: undefined, output: undefined }
               : yield* Effect.all(
                   {
+                    // Fold the resolved command + env into the input hash so
+                    // two builds that share the same source tree + `outdir`
+                    // but differ in their command or environment (e.g.
+                    // per-stage builds baking different `EXPO_PUBLIC_*` /
+                    // API ids) are never judged reusable. Without this the
+                    // second build silently reuses the first's stale output.
                     input: hashDirectory({
                       cwd,
                       memo: props.memo === true ? {} : props.memo,
-                    }),
+                    }).pipe(
+                      Effect.flatMap((files) =>
+                        sha256Object({
+                          files,
+                          command: props.command,
+                          env: resolveEnv(props.env),
+                        }),
+                      ),
+                    ),
                     output: hashDirectory({
                       cwd: outdir,
                       memo: {

--- a/packages/alchemy/test/Command/Build.test.ts
+++ b/packages/alchemy/test/Command/Build.test.ts
@@ -98,6 +98,43 @@ test.provider(
   { timeout: 60000 },
 );
 
+test.provider(
+  "input hash folds in the build command and env",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const fixture = yield* makeTemporaryFixture();
+
+      const deploy = (props: Partial<Command.BuildProps>) =>
+        stack.deploy(
+          Command.Build("test-build", {
+            command: "bash build.sh",
+            cwd: fixture.cwd,
+            outdir: "dist",
+            ...props,
+          }),
+        );
+
+      const withEnvA = yield* deploy({ env: { API_URL: "https://a.example" } });
+
+      // Same source tree + outdir, only the env differs: the build must not be
+      // judged reusable, so the input hash must change.
+      const withEnvB = yield* deploy({ env: { API_URL: "https://b.example" } });
+      expect(withEnvB.hash.input).not.toBe(withEnvA.hash.input);
+
+      // Likewise a change to the command string busts the input hash.
+      const withCommand = yield* deploy({
+        command: "bash build.sh dummy",
+        env: { API_URL: "https://b.example" },
+      });
+      expect(withCommand.hash.input).not.toBe(withEnvB.hash.input);
+
+      yield* stack.destroy();
+    }),
+  { timeout: 60000 },
+);
+
 test.provider("rebuilds memoized output if outdir is missing", (stack) =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;


### PR DESCRIPTION
`Command.Build` (and `StaticSite` built on it) keyed its memo/reuse hash only on a content hash of the input files plus `outdir`, ignoring the command string and environment. Two builds that share a source tree + `outdir` but differ only in `env` (e.g. per-stage builds baking different `EXPO_PUBLIC_*` / API ids) were wrongly judged reusable, so the second silently reused the first's stale output.

Fold the resolved command + env into the `input` hash so the memo is keyed on `files + command + env`:

```ts
input: hashDirectory({ cwd, memo }).pipe(
  Effect.flatMap((files) =>
    sha256Object({ files, command: props.command, env: resolveEnv(props.env) }),
  ),
),
```

`resolveEnv` unwraps `Redacted` values before hashing so a changed secret still busts the memo — the SHA-256 is one-way, so the secret is never recoverable from state.
