### PR TITLE
fix(cli): report retained resources during destroy

### DIFF
--- a/packages/alchemy/src/Apply.ts
+++ b/packages/alchemy/src/Apply.ts
@@ -1607,7 +1607,7 @@ const collectGarbage = Effect.fn(function* (
                   stage,
                   fqn,
                 });
-                yield* report("deleted");
+                yield* report("retained");
                 return;
               }
               yield* commit<DeletingResourceState>({

--- a/packages/alchemy/src/Cli/Event.ts
+++ b/packages/alchemy/src/Cli/Event.ts
@@ -10,6 +10,7 @@ export type ApplyStatus =
   | "updated"
   | "deleting"
   | "deleted"
+  | "retained"
   | "replacing"
   | "replaced"
   // Action lifecycle (see {@link Action})

--- a/packages/alchemy/src/Cli/LoggingCli.ts
+++ b/packages/alchemy/src/Cli/LoggingCli.ts
@@ -35,6 +35,8 @@ const statusColor = (status: ApplyStatus): ((s: string) => string) => {
       return green;
     case "deleted":
       return dim;
+    case "retained":
+      return yellow;
     case "fail":
       return red;
     case "attaching":
@@ -51,6 +53,7 @@ const isTerminal = (status: ApplyStatus): boolean =>
   status === "created" ||
   status === "updated" ||
   status === "deleted" ||
+  status === "retained" ||
   status === "replaced" ||
   status === "fail";
 

--- a/packages/alchemy/src/Cli/LoggingCli.ts
+++ b/packages/alchemy/src/Cli/LoggingCli.ts
@@ -36,7 +36,7 @@ const statusColor = (status: ApplyStatus): ((s: string) => string) => {
     case "deleted":
       return dim;
     case "retained":
-      return yellow;
+      return dim;
     case "fail":
       return red;
     case "attaching":

--- a/packages/alchemy/src/Cli/tui/components/PlanProgress.tsx
+++ b/packages/alchemy/src/Cli/tui/components/PlanProgress.tsx
@@ -366,7 +366,7 @@ function statusColor(
     case "deleted":
       return "red";
     case "retained":
-      return "yellow";
+      return "gray";
     case "running":
     case "ran":
       return "cyan";

--- a/packages/alchemy/src/Cli/tui/components/PlanProgress.tsx
+++ b/packages/alchemy/src/Cli/tui/components/PlanProgress.tsx
@@ -270,8 +270,8 @@ export function PlanProgress(props: PlanProgressProps): JSX.Element {
           const icon = taskIcon(row.action, status, spinner);
           const label =
             row.action === "delete"
-              ? status === "deleted"
-                ? "deleted"
+              ? status === "deleted" || status === "retained"
+                ? status
                 : "drop"
               : status === "ran"
                 ? row.action === "noop"
@@ -365,6 +365,8 @@ function statusColor(
     case "deleting":
     case "deleted":
       return "red";
+    case "retained":
+      return "yellow";
     case "running":
     case "ran":
       return "cyan";
@@ -386,7 +388,7 @@ function taskIcon(
   if (status === "fail") return "✗";
   if (status === "skipped") return "•";
   if (status === "ran") return action === "noop" ? "•" : "✓";
-  if (status === "deleted") return "✓";
+  if (status === "deleted" || status === "retained") return "✓";
   if (action === "delete") return "-";
   if (action === "noop") return "•";
   return "λ";


### PR DESCRIPTION
Report retained resources as `retained` during stack destroy instead of `deleted`.

```ts
if (node.resource.RemovalPolicy === "retain") {
  yield* state.delete({ stack: stackName, stage, fqn });
  yield* report("retained");
  return;
}
```

The CLI and TUI treat `retained` as a terminal status and render it dim/gray so retained physical resources are not confused with deleted ones.

Closes alchemy-run/alchemy-effect#729.
