### PR TITLE
feat(core,state): versioned state store and deployment locking

### DIFF
--- a/packages/alchemy/scripts/upgrade-cf-state-store.ts
+++ b/packages/alchemy/scripts/upgrade-cf-state-store.ts
@@ -1,0 +1,58 @@
+/**
+ * One-off: resolve the Cloudflare State layer with `updateStateStore: true`
+ * so an out-of-date deployed state-store worker is upgraded in place to the
+ * current STATE_STORE_VERSION. Usage:
+ *
+ *   ALCHEMY_PROFILE=testing bun scripts/upgrade-cf-state-store.ts
+ */
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import { AlchemyContext } from "../src/AlchemyContext.ts";
+import { AuthProviders } from "../src/Auth/AuthProvider.ts";
+import { CredentialsStoreLive } from "../src/Auth/Credentials.ts";
+import { ProfileLive } from "../src/Auth/Profile.ts";
+import { LoggingCli } from "../src/Cli/LoggingCli.ts";
+import * as Cloudflare from "../src/Cloudflare/index.ts";
+import { State } from "../src/State/State.ts";
+import { PlatformServices } from "../src/Util/PlatformServices.ts";
+
+const platformLayer = Layer.mergeAll(
+  PlatformServices,
+  FetchHttpClient.layer,
+  Layer.provide(ProfileLive, PlatformServices),
+  Layer.provide(CredentialsStoreLive, PlatformServices),
+);
+
+const AutoUpgradeContext = Layer.effect(
+  AlchemyContext,
+  Effect.sync(() => ({
+    dotAlchemy: `${process.cwd()}/.alchemy`,
+    dev: false,
+    adopt: false,
+    updateStateStore: true,
+  })),
+);
+
+const main = Effect.gen(function* () {
+  const state = yield* yield* State;
+  const version = yield* state.getVersion();
+  yield* Effect.log(`state store serving at v${version}`);
+}).pipe(
+  Effect.provide(Cloudflare.state()),
+  Effect.provideService(AuthProviders, {}),
+  Effect.provide(
+    Layer.provideMerge(
+      Layer.mergeAll(LoggingCli, AutoUpgradeContext),
+      platformLayer,
+    ),
+  ),
+);
+
+Effect.runPromise(main as Effect.Effect<void>).then(
+  () => process.exit(0),
+  (error) => {
+    console.error(error);
+    process.exit(1);
+  },
+);

--- a/packages/alchemy/src/AWS/StateStore/Deployments.ts
+++ b/packages/alchemy/src/AWS/StateStore/Deployments.ts
@@ -1,0 +1,777 @@
+import type { Credentials } from "@distilled.cloud/aws/Credentials";
+import type { Region } from "@distilled.cloud/aws/Region";
+import * as s3 from "@distilled.cloud/aws/s3";
+import * as Clock from "effect/Clock";
+import type * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Stream from "effect/Stream";
+import type { HttpClient } from "effect/unstable/http/HttpClient";
+import {
+  ClosedVersionHint,
+  DEPLOYMENT_TTL_MILLIS,
+  DeploymentInProgress,
+  DeploymentNotFound,
+  DeploymentTokenInvalid,
+  endTransition,
+  shouldAbandonOpen,
+  maxSeqOf,
+  toPublicRecord,
+  type DeploymentEvent,
+  type DeploymentStore,
+  type StoredDeploymentRecord,
+} from "../../State/Deployment.ts";
+import { StateStoreError } from "../../State/State.ts";
+
+/**
+ * S3-backed {@link DeploymentStore}.
+ *
+ * Layout under the state store's stage prefix (`{prefix}{stack}/{stage}/`):
+ *
+ * ```
+ * .deployments/{version:08d}/record.json                 # lifecycle record (+ open token)
+ * .deployments/{version:08d}/events/{firstSeq:08d}.json  # one object per appended batch
+ * ```
+ *
+ * S3 has no append, so the journal is one object per batch; 8-digit
+ * zero-padded keys make lexicographic key order equal replay order.
+ *
+ * Request-efficiency invariants:
+ *
+ * - Version discovery LISTs with `Delimiter: "/"` and reads
+ *   `CommonPrefixes`, so event objects are never enumerated — one list
+ *   entry per version regardless of journal size.
+ * - Only the newest version can be open (a version is claimed only after
+ *   every prior open was observed closed or reconciled), so `begin`
+ *   decides liveness with a single GET of the newest record.
+ * - `appendEvents` caches the journal's high-water mark and the proven
+ *   token per `(stack, stage, version)` in the store instance, so
+ *   steady-state appends are a single PUT. The cold-cache path (fresh
+ *   process resuming a journal) pays one LIST + one GET to re-derive the
+ *   high-water mark from the lexicographically-last batch object.
+ * - `begin` has a blind-claim fast path: after our own `end` closed
+ *   version N, a conditional create of N+1 succeeding proves no newer
+ *   version — and therefore no live open — exists (versions are contiguous
+ *   and never deleted), so a warm-instance begin is a single PUT. Any
+ *   conflict falls back to the full observe → reconcile → claim loop.
+ *
+ * Version allocation uses S3 conditional writes as the claim primitive:
+ * `PutObject` of `record.json` with `If-None-Match: "*"` — exactly one of
+ * two racing begins can create the object, the loser observes the typed
+ * `PreconditionFailed` (or transient `ConditionalRequestConflict`),
+ * re-scans the open records, and either surfaces the live holder as
+ * {@link DeploymentInProgress} or retries at the next version.
+ *
+ * `heartbeat`/`end` are read-modify-write of `record.json` guarded with
+ * `If-Match` on the record's ETag so a concurrent `begin` reconciling the
+ * same record to `"abandoned"` is never silently clobbered — the loser of
+ * the OCC race re-reads and re-applies.
+ */
+
+/** Reserved directory name for deployment history under a stage prefix. */
+export const DEPLOYMENTS_DIR = ".deployments";
+
+/** Zero-pad to 8 digits so lexicographic key order equals numeric order. */
+export const pad8 = (n: number): string => n.toString().padStart(8, "0");
+
+/** `{stagePrefix}.deployments/` */
+export const deploymentsPrefix = (stagePrefix: string): string =>
+  `${stagePrefix}${DEPLOYMENTS_DIR}/`;
+
+/** `{stagePrefix}.deployments/{version:08d}/` */
+export const versionPrefix = (stagePrefix: string, version: number): string =>
+  `${deploymentsPrefix(stagePrefix)}${pad8(version)}/`;
+
+/** `{stagePrefix}.deployments/{version:08d}/record.json` */
+export const recordKey = (stagePrefix: string, version: number): string =>
+  `${versionPrefix(stagePrefix, version)}record.json`;
+
+/** `{stagePrefix}.deployments/{version:08d}/events/` */
+export const eventsPrefix = (stagePrefix: string, version: number): string =>
+  `${versionPrefix(stagePrefix, version)}events/`;
+
+/** `{stagePrefix}.deployments/{version:08d}/events/{firstSeq:08d}.json` */
+export const batchKey = (
+  stagePrefix: string,
+  version: number,
+  firstSeq: number,
+): string => `${eventsPrefix(stagePrefix, version)}${pad8(firstSeq)}.json`;
+
+const VERSION_PREFIX_RE = /^(\d{8})\/$/;
+
+/**
+ * Extract the version from a `CommonPrefixes` entry of a
+ * `Delimiter: "/"` list under the deployments prefix (e.g.
+ * `{deploymentsPrefix}00000003/`), or `undefined` for foreign prefixes.
+ */
+export const versionFromCommonPrefix = (
+  deploymentsKeyPrefix: string,
+  prefix: string,
+): number | undefined => {
+  if (!prefix.startsWith(deploymentsKeyPrefix)) {
+    return undefined;
+  }
+  const match = VERSION_PREFIX_RE.exec(
+    prefix.slice(deploymentsKeyPrefix.length),
+  );
+  return match === null ? undefined : Number.parseInt(match[1]!, 10);
+};
+
+export const encodeRecord = (record: StoredDeploymentRecord): string =>
+  JSON.stringify(record, null, 2);
+
+export const decodeRecord = (text: string): StoredDeploymentRecord =>
+  JSON.parse(text) as StoredDeploymentRecord;
+
+/**
+ * Dedupe an incoming batch against the journal's high-water mark.
+ *
+ * DEDUPE CHOICE: we read the highest stored seq from the lexicographically
+ * LAST batch object and drop incoming events whose seq is `<=` it (plus any
+ * same-seq repeats inside the batch itself — first occurrence wins). This is
+ * sound because every batch is filtered to seqs strictly above the previous
+ * high-water mark before it is written, so batch key order equals seq order
+ * and the global max seq always lives in the last batch object. The engine
+ * assigns contiguous seqs and retries whole batches, so a retried batch is
+ * always a suffix-overlap of what is already stored.
+ */
+export const dedupeBatch = (
+  events: readonly DeploymentEvent[],
+  maxStoredSeq: number,
+): { retained: DeploymentEvent[]; ackedSeq: number } => {
+  const bySeq = new Map<number, DeploymentEvent>();
+  for (const event of events) {
+    if (event.seq > maxStoredSeq && !bySeq.has(event.seq)) {
+      bySeq.set(event.seq, event);
+    }
+  }
+  const retained = Array.from(bySeq.values()).sort((a, b) => a.seq - b.seq);
+  return {
+    retained,
+    ackedSeq: Math.max(maxStoredSeq, maxSeqOf(retained)),
+  };
+};
+
+/** Context required by the distilled S3 operations. */
+type S3Deps = Credentials | HttpClient | Region;
+
+/** How many times `begin` retries the version claim after losing a race. */
+const CLAIM_ATTEMPTS = 8;
+
+/** How many times an If-Match read-modify-write retries after an OCC loss. */
+const UPDATE_ATTEMPTS = 4;
+
+/** Bounded fan-out for reading many record/batch objects. */
+const READ_CONCURRENCY = 8;
+
+export interface MakeS3DeploymentStoreOptions {
+  /**
+   * The cached ensure-bucket effect from the surrounding S3 state store —
+   * resolves the bucket name lazily on first use.
+   */
+  bucket: Effect.Effect<string, StateStoreError>;
+  /** Captured context that satisfies the distilled S3 operations. */
+  context: Context.Context<S3Deps>;
+  /** Builds `{prefix}{stack}/{stage}/` exactly like the state store does. */
+  stagePrefix: (ids: { stack: string; stage: string }) => string;
+}
+
+export const makeS3DeploymentStore = (
+  options: MakeS3DeploymentStoreOptions,
+): DeploymentStore => {
+  const { bucket, context, stagePrefix } = options;
+
+  const toError = (cause: unknown): StateStoreError =>
+    cause instanceof StateStoreError
+      ? cause
+      : new StateStoreError({
+          message:
+            cause instanceof Error
+              ? cause.message
+              : `S3 deployment store error: ${String(cause)}`,
+          cause: cause instanceof Error ? cause : undefined,
+        });
+
+  /** Run a distilled S3 effect with the captured context, keeping its typed errors. */
+  const withS3 = <A, E>(
+    f: (bucket: string) => Effect.Effect<A, E, S3Deps>,
+  ): Effect.Effect<A, E | StateStoreError> =>
+    bucket.pipe(
+      Effect.flatMap((bucket) =>
+        f(bucket).pipe(Effect.provideContext(context)),
+      ),
+    );
+
+  /** All object keys under `keyPrefix`, across pagination, ascending. */
+  const listKeys = (
+    keyPrefix: string,
+  ): Effect.Effect<string[], StateStoreError> =>
+    withS3((bucket) =>
+      s3.listObjectsV2.pages({ Bucket: bucket, Prefix: keyPrefix }).pipe(
+        Stream.flatMap((page) => Stream.fromIterable(page.Contents ?? [])),
+        Stream.map((object) => object.Key),
+        Stream.filter((key): key is string => key !== undefined),
+        Stream.runCollect,
+        Effect.map((keys) => Array.from(keys).sort()),
+      ),
+    ).pipe(Effect.mapError(toError));
+
+  const readText = (
+    key: string,
+  ): Effect.Effect<string | undefined, StateStoreError> =>
+    withS3((bucket) =>
+      s3.getObject({ Bucket: bucket, Key: key }).pipe(
+        Effect.flatMap((result) =>
+          result.Body === undefined
+            ? Effect.succeed(undefined)
+            : Stream.mkString(Stream.decodeText(result.Body)),
+        ),
+        Effect.catchTag("NoSuchKey", () => Effect.succeed(undefined)),
+      ),
+    ).pipe(Effect.mapError(toError));
+
+  interface ReadRecordResult {
+    record: StoredDeploymentRecord;
+    /** ETag of the object read — the If-Match guard for read-modify-write. */
+    etag: string | undefined;
+  }
+
+  // ---------------------------------------------------------------------
+  // Per-instance caches. The open token has exactly one holder (the engine
+  // process that called `begin`), so while our heartbeat is live nobody
+  // else writes this version's record and nobody else appends to its
+  // journal. That makes our own last read/write of `record.json` (plus its
+  // ETag) and our own high-water mark authoritative — steady-state
+  // heartbeat/end/append are each a single conditional PUT. Every cache is
+  // only an optimization: the If-Match guard still arbitrates, and a
+  // conflict (someone reconciled us to "abandoned") drops the cache and
+  // falls back to read-modify-write.
+  // ---------------------------------------------------------------------
+  const stageKey = (ids: { stack: string; stage: string }) =>
+    `${ids.stack}\u0000${ids.stage}`;
+  const versionKey = (ids: { stack: string; stage: string }, version: number) =>
+    `${stageKey(ids)}\u0000${version}`;
+  /** versionKey → the record + ETag from our own latest read or write. */
+  const recordCache = new Map<string, ReadRecordResult>();
+  /** versionKey → highest seq known stored in the journal. */
+  const highWaterMarks = new Map<string, number>();
+  /**
+   * Blind-claim fast-path hint — see {@link ClosedVersionHint} for the
+   * invariant and the shared single-shot / monotonic policy. Here the
+   * claim primitive is a conditional PUT (If-None-Match), turning a warm
+   * steady-state begin into a single PUT instead of LIST + GET + PUT.
+   */
+  const closedHint = new ClosedVersionHint();
+
+  const readRecord = (request: {
+    stack: string;
+    stage: string;
+    version: number;
+  }): Effect.Effect<ReadRecordResult | undefined, StateStoreError> =>
+    withS3((bucket) =>
+      s3
+        .getObject({
+          Bucket: bucket,
+          Key: recordKey(stagePrefix(request), request.version),
+        })
+        .pipe(
+          Effect.flatMap((result) =>
+            result.Body === undefined
+              ? Effect.succeed(undefined)
+              : Stream.mkString(Stream.decodeText(result.Body)).pipe(
+                  Effect.flatMap((text) =>
+                    Effect.try({
+                      try: (): ReadRecordResult => ({
+                        record: decodeRecord(text),
+                        etag: result.ETag,
+                      }),
+                      catch: toError,
+                    }),
+                  ),
+                ),
+          ),
+          Effect.catchTag("NoSuchKey", () => Effect.succeed(undefined)),
+        ),
+    ).pipe(Effect.mapError(toError));
+
+  /**
+   * Write `record.json`. `condition` selects the S3 conditional-write guard:
+   * `create` = If-None-Match: "*" (the version claim), `etag` = If-Match
+   * (read-modify-write). Returns "conflict" when the guard rejects the write
+   * so callers can re-observe instead of failing. On success, returns the
+   * written object's ETag — the If-Match guard for the NEXT write, so a
+   * writer that owns the latest write never needs to re-read the record.
+   */
+  const writeRecord = (
+    request: { stack: string; stage: string; version: number },
+    record: StoredDeploymentRecord,
+    condition: { create: true } | { etag: string | undefined },
+  ): Effect.Effect<
+    { etag: string | undefined } | "conflict",
+    StateStoreError
+  > =>
+    withS3((bucket) =>
+      s3
+        .putObject({
+          Bucket: bucket,
+          Key: recordKey(stagePrefix(request), request.version),
+          Body: encodeRecord(record),
+          ContentType: "application/json",
+          ...("create" in condition
+            ? { IfNoneMatch: "*" }
+            : condition.etag !== undefined
+              ? { IfMatch: condition.etag }
+              : {}),
+        })
+        .pipe(
+          Effect.map((result) => ({ etag: result.ETag })),
+          Effect.catchTag(
+            ["PreconditionFailed", "ConditionalRequestConflict"],
+            () => Effect.succeed("conflict" as const),
+          ),
+        ),
+    ).pipe(Effect.mapError(toError));
+
+  /** Read the record for a version and enforce the caller's token. */
+  const requireRecord = (request: {
+    stack: string;
+    stage: string;
+    version: number;
+    token: string;
+  }): Effect.Effect<
+    ReadRecordResult,
+    DeploymentNotFound | DeploymentTokenInvalid | StateStoreError
+  > =>
+    readRecord(request).pipe(
+      Effect.flatMap(
+        (
+          found,
+        ): Effect.Effect<
+          ReadRecordResult,
+          DeploymentNotFound | DeploymentTokenInvalid
+        > => {
+          if (found === undefined) {
+            return Effect.fail(
+              new DeploymentNotFound({
+                stack: request.stack,
+                stage: request.stage,
+                version: request.version,
+              }),
+            );
+          }
+          if (found.record.token !== request.token) {
+            return Effect.fail(
+              new DeploymentTokenInvalid({
+                stack: request.stack,
+                stage: request.stage,
+                version: request.version,
+              }),
+            );
+          }
+          return Effect.succeed(found);
+        },
+      ),
+    );
+
+  /**
+   * OCC read-modify-write of `record.json`, served from {@link recordCache}
+   * when warm: the token holder is this record's only writer while its
+   * heartbeat is live, so the record + ETag from our own last write are
+   * authoritative and the read is skipped — heartbeat/end become a single
+   * conditional PUT. An If-Match rejection (e.g. a concurrent `begin`
+   * reconciled this record to "abandoned" after our heartbeat went stale)
+   * invalidates the cache; the loop re-reads and re-applies. `update`
+   * returning `undefined` means "nothing to write" (idempotent no-op).
+   */
+  const updateRecord = (
+    request: { stack: string; stage: string; version: number; token: string },
+    update: (
+      record: StoredDeploymentRecord,
+    ) => StoredDeploymentRecord | undefined,
+  ): Effect.Effect<
+    void,
+    DeploymentNotFound | DeploymentTokenInvalid | StateStoreError
+  > =>
+    Effect.gen(function* () {
+      const cacheKey = versionKey(request, request.version);
+      for (let attempt = 0; attempt < UPDATE_ATTEMPTS; attempt++) {
+        let found = attempt === 0 ? recordCache.get(cacheKey) : undefined;
+        if (found === undefined) {
+          found = yield* requireRecord(request);
+        } else if (found.record.token !== request.token) {
+          // The token is immutable for a version's lifetime, so the cached
+          // copy is authoritative for rejection too.
+          return yield* Effect.fail(
+            new DeploymentTokenInvalid({
+              stack: request.stack,
+              stage: request.stage,
+              version: request.version,
+            }),
+          );
+        }
+        const next = update(found.record);
+        if (next === undefined) {
+          return;
+        }
+        const result = yield* writeRecord(request, next, {
+          etag: found.etag,
+        });
+        if (result !== "conflict") {
+          if (result.etag !== undefined) {
+            recordCache.set(cacheKey, { record: next, etag: result.etag });
+          }
+          return;
+        }
+        // Lost the OCC race — drop the cache, loop back, re-read, re-apply.
+        recordCache.delete(cacheKey);
+      }
+      return yield* Effect.fail(
+        toError(
+          new Error(
+            `deployment record update for ${request.stack}/${request.stage} v${request.version} kept conflicting`,
+          ),
+        ),
+      );
+    });
+
+  /**
+   * Version numbers under the deployments prefix, ascending.
+   *
+   * Lists with `Delimiter: "/"` so S3 rolls each version directory up into
+   * one `CommonPrefixes` entry — event batch objects are never enumerated,
+   * keeping this O(versions), not O(versions × batches).
+   */
+  const listVersions = (ids: {
+    stack: string;
+    stage: string;
+  }): Effect.Effect<number[], StateStoreError> => {
+    const keyPrefix = deploymentsPrefix(stagePrefix(ids));
+    return withS3((bucket) =>
+      s3.listObjectsV2
+        .pages({
+          Bucket: bucket,
+          Prefix: keyPrefix,
+          Delimiter: "/",
+        })
+        .pipe(
+          Stream.flatMap((page) =>
+            Stream.fromIterable(page.CommonPrefixes ?? []),
+          ),
+          Stream.map((common) =>
+            common.Prefix === undefined
+              ? undefined
+              : versionFromCommonPrefix(keyPrefix, common.Prefix),
+          ),
+          Stream.filter((version): version is number => version !== undefined),
+          Stream.runCollect,
+          Effect.map((versions) => Array.from(versions).sort((a, b) => a - b)),
+        ),
+    ).pipe(Effect.mapError(toError));
+  };
+
+  /** Read many records, preserving version order, skipping missing ones. */
+  const readRecords = (
+    ids: { stack: string; stage: string },
+    versions: readonly number[],
+  ): Effect.Effect<ReadRecordResult[], StateStoreError> =>
+    Effect.all(
+      versions.map((version) => readRecord({ ...ids, version })),
+      { concurrency: READ_CONCURRENCY },
+    ).pipe(
+      Effect.map((results) =>
+        results.filter(
+          (result): result is ReadRecordResult => result !== undefined,
+        ),
+      ),
+    );
+
+  /** Event batch object keys for a version, in replay (seq) order. */
+  const listBatchKeys = (request: {
+    stack: string;
+    stage: string;
+    version: number;
+  }): Effect.Effect<string[], StateStoreError> =>
+    listKeys(eventsPrefix(stagePrefix(request), request.version)).pipe(
+      Effect.map((keys) => keys.filter((key) => key.endsWith(".json"))),
+    );
+
+  const readBatch = (
+    key: string,
+  ): Effect.Effect<DeploymentEvent[], StateStoreError> =>
+    readText(key).pipe(
+      Effect.flatMap((text) =>
+        text === undefined
+          ? Effect.succeed([])
+          : Effect.try({
+              try: () => JSON.parse(text) as DeploymentEvent[],
+              catch: toError,
+            }),
+      ),
+    );
+
+  const writeBatch = (
+    request: { stack: string; stage: string; version: number },
+    events: readonly DeploymentEvent[],
+  ): Effect.Effect<void, StateStoreError> =>
+    withS3((bucket) =>
+      s3.putObject({
+        Bucket: bucket,
+        Key: batchKey(stagePrefix(request), request.version, events[0]!.seq),
+        // Compact — batches are the write hot path and only machine-read.
+        Body: JSON.stringify(events),
+        ContentType: "application/json",
+      }),
+    ).pipe(Effect.mapError(toError), Effect.asVoid);
+
+  const store: DeploymentStore = {
+    begin: Effect.fn(function* ({ stack, stage, meta, ttlMillis, supersede }) {
+      const ttl = ttlMillis ?? DEPLOYMENT_TTL_MILLIS;
+      const token = yield* Effect.sync(() => crypto.randomUUID());
+      const ids = { stack, stage };
+
+      const makeRecord = (
+        version: number,
+        now: number,
+      ): StoredDeploymentRecord => ({
+        stack,
+        stage,
+        version,
+        meta: structuredClone(meta),
+        startedAt: now,
+        heartbeatAt: now,
+        token,
+      });
+
+      const seedCaches = (
+        version: number,
+        stored: StoredDeploymentRecord,
+        etag: string | undefined,
+      ) => {
+        // We are now this version's sole writer, so the first
+        // heartbeat/append can skip the read entirely.
+        if (etag !== undefined) {
+          recordCache.set(versionKey(ids, version), { record: stored, etag });
+        }
+        highWaterMarks.set(versionKey(ids, version), 0);
+        // The newest version is now open — the fast path only applies
+        // after our own `end` closes it again.
+        closedHint.invalidate(ids);
+      };
+
+      // Blind-claim fast path: when our own `end` closed version N, a
+      // conditional create of N+1 succeeding proves no newer version (and
+      // therefore no live open) exists. `take` is single-shot, so any
+      // conflict falls through to the full observe loop below.
+      const known = supersede === undefined ? closedHint.take(ids) : undefined;
+      if (known !== undefined) {
+        const now = yield* Clock.currentTimeMillis;
+        const version = known + 1;
+        const stored = makeRecord(version, now);
+        const claim = yield* writeRecord({ stack, stage, version }, stored, {
+          create: true,
+        });
+        if (claim !== "conflict") {
+          seedCaches(version, stored, claim.etag);
+          return { version, token };
+        }
+      }
+
+      // Claim loop: observe → reconcile a stale open → claim next version
+      // with If-None-Match. A conflict means another begin claimed the same
+      // version concurrently — re-observe (the winner is now a live open)
+      // rather than blindly bumping. No sleeps: conflict resolution is
+      // deterministic, and the conformance suite runs under TestClock.
+      //
+      // Only the NEWEST version can be open: a version is claimed only
+      // after every prior open was observed closed or reconciled, and ends
+      // are permanent (heartbeat/end never reopen a closed record). So a
+      // single GET of the newest record decides liveness — no O(history)
+      // record scan.
+      for (let attempt = 0; attempt < CLAIM_ATTEMPTS; attempt++) {
+        const now = yield* Clock.currentTimeMillis;
+        const versions = yield* listVersions(ids);
+        const newestVersion =
+          versions.length === 0 ? undefined : versions[versions.length - 1]!;
+        const newest =
+          newestVersion === undefined
+            ? undefined
+            : yield* readRecord({ ...ids, version: newestVersion });
+
+        if (newest !== undefined && newest.record.endedAt === undefined) {
+          const { record, etag } = newest;
+          // Shared takeover semantics: stale heartbeat, or a targeted
+          // `supersede` of exactly this version. The If-Match reconcile
+          // below keeps even the takeover honest — if the "dead" holder
+          // races a heartbeat in, the write conflicts and we re-observe.
+          if (!shouldAbandonOpen(record, now, ttl, supersede)) {
+            return yield* Effect.fail(
+              new DeploymentInProgress({
+                stack,
+                stage,
+                holder: toPublicRecord(record),
+              }),
+            );
+          }
+          // Reconcile the lost deployment to "abandoned". If-Match keeps a
+          // racing heartbeat/begin from being clobbered; on conflict we
+          // re-observe from scratch on the next attempt.
+          const result = yield* writeRecord(
+            { stack, stage, version: record.version },
+            { ...record, endedAt: now, outcome: "abandoned" },
+            { etag },
+          );
+          if (result === "conflict") {
+            continue;
+          }
+        }
+
+        const version = (newestVersion ?? 0) + 1;
+        const stored = makeRecord(version, now);
+        const claim = yield* writeRecord({ stack, stage, version }, stored, {
+          create: true,
+        });
+        if (claim !== "conflict") {
+          seedCaches(version, stored, claim.etag);
+          return { version, token };
+        }
+        // Lost the claim race — loop back and re-observe: the winner's open
+        // record surfaces as DeploymentInProgress unless it is already
+        // stale/ended.
+      }
+      return yield* Effect.fail(
+        toError(
+          new Error(
+            `could not allocate a deployment version for ${stack}/${stage} after ${CLAIM_ATTEMPTS} claim conflicts`,
+          ),
+        ),
+      );
+    }),
+
+    appendEvents: Effect.fn(function* ({
+      stack,
+      stage,
+      version,
+      token,
+      events,
+    }) {
+      const cacheKey = versionKey({ stack, stage }, version);
+
+      // Token must match even after `end` — late flushes are accepted.
+      // The token is immutable for a version's lifetime, so a cached record
+      // (from our own begin/heartbeat/read) settles the check without a GET.
+      const cached = recordCache.get(cacheKey);
+      if (cached === undefined) {
+        recordCache.set(
+          cacheKey,
+          yield* requireRecord({ stack, stage, version, token }),
+        );
+      } else if (cached.record.token !== token) {
+        return yield* Effect.fail(
+          new DeploymentTokenInvalid({ stack, stage, version }),
+        );
+      }
+
+      // High-water mark: served from cache in the steady state. On a cold
+      // cache, the max stored seq always lives in the lexicographically-last
+      // batch object (see dedupeBatch's invariant), so one LIST + one GET
+      // re-derives it.
+      let maxStoredSeq = highWaterMarks.get(cacheKey);
+      if (maxStoredSeq === undefined) {
+        const batchKeys = yield* listBatchKeys({ stack, stage, version });
+        maxStoredSeq =
+          batchKeys.length === 0
+            ? 0
+            : maxSeqOf(yield* readBatch(batchKeys[batchKeys.length - 1]!));
+      }
+
+      const { retained, ackedSeq } = dedupeBatch(events, maxStoredSeq);
+      if (retained.length > 0) {
+        yield* writeBatch({ stack, stage, version }, retained);
+      }
+      highWaterMarks.set(cacheKey, ackedSeq);
+      return { ackedSeq };
+    }),
+
+    heartbeat: Effect.fn(function* ({ stack, stage, version, token }) {
+      const now = yield* Clock.currentTimeMillis;
+      yield* updateRecord({ stack, stage, version, token }, (record) =>
+        // Heartbeat against an ended deployment is a silent no-op.
+        record.endedAt === undefined
+          ? { ...record, heartbeatAt: now }
+          : undefined,
+      );
+    }),
+
+    end: Effect.fn(function* ({
+      stack,
+      stage,
+      version,
+      token,
+      outcome,
+      summary,
+    }) {
+      const now = yield* Clock.currentTimeMillis;
+      yield* updateRecord({ stack, stage, version, token }, (record) => {
+        // Shared close semantics: first outcome wins, ending an
+        // "abandoned" version records "completed-late".
+        const nextOutcome = endTransition(record, outcome);
+        if (nextOutcome === undefined) {
+          return undefined;
+        }
+        return {
+          ...record,
+          endedAt: now,
+          outcome: nextOutcome,
+          ...(summary !== undefined
+            ? { summary: structuredClone(summary) }
+            : {}),
+        };
+      });
+      // Feed the blind-claim fast path: this version is now known closed.
+      closedHint.noteClosed({ stack, stage }, version);
+    }),
+
+    list: Effect.fn(function* ({ stack, stage, before, limit }) {
+      const ids = { stack, stage };
+      let versions = (yield* listVersions(ids)).sort((a, b) => b - a);
+      if (before !== undefined) {
+        versions = versions.filter((version) => version < before);
+      }
+      if (limit !== undefined) {
+        versions = versions.slice(0, limit);
+      }
+      const records = yield* readRecords(ids, versions);
+      return records.map(({ record }) => toPublicRecord(record));
+    }),
+
+    get: Effect.fn(function* ({ stack, stage, version }) {
+      const found = yield* readRecord({ stack, stage, version });
+      return found === undefined ? undefined : toPublicRecord(found.record);
+    }),
+
+    readEvents: Effect.fn(function* ({ stack, stage, version, fromSeq }) {
+      // The existence check and the journal listing are independent — run
+      // them concurrently.
+      const [found, keys] = yield* Effect.all(
+        [
+          readRecord({ stack, stage, version }),
+          listBatchKeys({ stack, stage, version }),
+        ],
+        { concurrency: 2 },
+      );
+      if (found === undefined) {
+        return yield* Effect.fail(
+          new DeploymentNotFound({ stack, stage, version }),
+        );
+      }
+      const batches = yield* Effect.all(keys.map(readBatch), {
+        concurrency: READ_CONCURRENCY,
+      });
+      return batches
+        .flat()
+        .filter((event) => fromSeq === undefined || event.seq >= fromSeq)
+        .sort((a, b) => a.seq - b.seq);
+    }),
+  };
+
+  return store;
+};

--- a/packages/alchemy/src/AWS/StateStore/State.ts
+++ b/packages/alchemy/src/AWS/StateStore/State.ts
@@ -10,6 +10,7 @@ import { CredentialsStoreLive } from "../../Auth/Credentials.ts";
 import { decodeFqn, encodeFqn } from "../../FQN.ts";
 import { STATE_STORE_VERSION } from "../../State/HttpStateApi.ts";
 import {
+  fencedWriteRejected,
   State,
   StateStoreError,
   type PersistedState,
@@ -17,6 +18,7 @@ import {
 } from "../../State/State.ts";
 import { encodeState, reviveState } from "../../State/StateEncoding.ts";
 import { recordStateStoreInit } from "../../Telemetry/Metrics.ts";
+import { makeS3DeploymentStore, recordKey } from "./Deployments.ts";
 import { AwsAuth } from "../AuthProvider.ts";
 import * as AwsCredentials from "../Credentials.ts";
 import * as Endpoint from "../Endpoint.ts";
@@ -35,6 +37,26 @@ const OUTPUT_FILE = "__stack_output__.json";
 
 /** Maximum number of keys S3 accepts in a single DeleteObjects call. */
 const DELETE_BATCH_SIZE = 1000;
+
+/**
+ * Reduce raw stage-prefixed keys to committed resource state files.
+ * Excludes:
+ *  - the `__stack_output__.json` bookkeeping file — `decodeFqn` replaces
+ *    `__` with `/`, which would turn the literal name `__stack_output__`
+ *    into `/stack_output/` and slip past a bare-name filter, leaving the
+ *    engine to look up a non-existent resource;
+ *  - anything in a subdirectory — resource objects live flat under the
+ *    stage prefix, so any `/` marks bookkeeping such as the reserved
+ *    `.deployments/` history tree;
+ *  - any non-`.json` key.
+ */
+const resourceFiles = (keys: readonly string[], keyPrefix: string): string[] =>
+  keys
+    .map((key) => key.slice(keyPrefix.length))
+    .filter(
+      (file) =>
+        file !== OUTPUT_FILE && file.endsWith(".json") && !file.includes("/"),
+    );
 
 export interface S3StateOptions {
   /**
@@ -155,13 +177,15 @@ export const makeS3State = (options: S3StateOptions = {}) =>
       : "";
 
     const toError = (cause: unknown) =>
-      new StateStoreError({
-        message:
-          cause instanceof Error
-            ? cause.message
-            : `S3 state store error: ${String(cause)}`,
-        cause: cause instanceof Error ? cause : undefined,
-      });
+      cause instanceof StateStoreError
+        ? cause
+        : new StateStoreError({
+            message:
+              cause instanceof Error
+                ? cause.message
+                : `S3 state store error: ${String(cause)}`,
+            cause: cause instanceof Error ? cause : undefined,
+          });
 
     // Anything that touches AWS credentials must NOT run at layer
     // construction time. Resolving the environment (account/region),
@@ -282,6 +306,42 @@ export const makeS3State = (options: S3StateOptions = {}) =>
         }
       });
 
+    /**
+     * Fencing check (see StateWriteFence in State.ts): a write carrying
+     * `fence: F` is rejected once any deployment version > F exists.
+     * Versions are contiguous and never deleted, so "a version above F
+     * exists" is equivalent to "F+1's record.json exists" — one HEAD per
+     * fenced write, no LIST. Check-then-write (not atomic with the PUT),
+     * so fencing is best-effort on S3 — a zombie that lost its lease is
+     * caught by its next write.
+     */
+    const checkFence = (request: {
+      stack: string;
+      stage: string;
+      fence?: number;
+    }): Effect.Effect<void, StateStoreError> =>
+      request.fence === undefined
+        ? Effect.void
+        : run((bucket) =>
+            s3
+              .headObject({
+                Bucket: bucket,
+                Key: recordKey(stagePrefix(request), request.fence! + 1),
+              })
+              .pipe(
+                Effect.flatMap(() =>
+                  Effect.fail(
+                    fencedWriteRejected({
+                      stack: request.stack,
+                      stage: request.stage,
+                      fence: request.fence!,
+                    }),
+                  ),
+                ),
+                Effect.catchTag("NotFound", () => Effect.void),
+              ),
+          );
+
     const state: StateService = {
       id: "s3",
       getVersion: () => Effect.succeed(STATE_STORE_VERSION),
@@ -302,13 +362,23 @@ export const makeS3State = (options: S3StateOptions = {}) =>
         )).filter((r) => r?.status === "replaced");
       }),
       set: (request) =>
-        run((bucket) =>
-          writeJson(bucket, resourceKey(request), request.value),
-        ).pipe(Effect.map(() => request.value)),
+        checkFence(request).pipe(
+          Effect.flatMap(() =>
+            run((bucket) =>
+              writeJson(bucket, resourceKey(request), request.value),
+            ),
+          ),
+          Effect.map(() => request.value),
+        ),
       delete: (request) =>
-        run((bucket) =>
-          s3.deleteObject({ Bucket: bucket, Key: resourceKey(request) }),
-        ).pipe(Effect.asVoid),
+        checkFence(request).pipe(
+          Effect.flatMap(() =>
+            run((bucket) =>
+              s3.deleteObject({ Bucket: bucket, Key: resourceKey(request) }),
+            ),
+          ),
+          Effect.asVoid,
+        ),
       deleteStack: ({ stack, stage }) =>
         run((bucket) =>
           deleteAll(
@@ -321,23 +391,50 @@ export const makeS3State = (options: S3StateOptions = {}) =>
       list: (request) =>
         run((bucket) => listKeys(bucket, stagePrefix(request))).pipe(
           Effect.map((keys) =>
-            keys
-              .map((key) => key.slice(stagePrefix(request).length))
-              // Filter the bookkeeping file before decoding — `decodeFqn`
-              // replaces `__` with `/`, which would turn the literal name
-              // `__stack_output__` into `/stack_output/` and slip past
-              // the filter, leaving the engine to look up a non-existent
-              // resource.
-              .filter((file) => file !== OUTPUT_FILE && file.endsWith(".json"))
-              .map((file) => decodeFqn(file.replace(/\.json$/, ""))),
+            resourceFiles(keys, stagePrefix(request)).map((file) =>
+              decodeFqn(file.replace(/\.json$/, "")),
+            ),
           ),
         ),
+      getAll: (request) =>
+        run((bucket) =>
+          Effect.gen(function* () {
+            const keyPrefix = stagePrefix(request);
+            const files = resourceFiles(
+              yield* listKeys(bucket, keyPrefix),
+              keyPrefix,
+            );
+            const entries = yield* Effect.all(
+              files.map((file) =>
+                readJson<PersistedState>(bucket, `${keyPrefix}${file}`).pipe(
+                  Effect.map(
+                    (value) =>
+                      [decodeFqn(file.replace(/\.json$/, "")), value] as const,
+                  ),
+                ),
+              ),
+              { concurrency: 8 },
+            );
+            return new Map(
+              entries.filter(
+                (entry): entry is [string, PersistedState] =>
+                  entry[1] !== undefined,
+              ),
+            ) as ReadonlyMap<string, PersistedState>;
+          }),
+        ),
+      deployments: makeS3DeploymentStore({ bucket, context, stagePrefix }),
       getOutput: (request) =>
         run((bucket) => readJson(bucket, outputKey(request))),
       setOutput: (request) =>
-        run((bucket) =>
-          writeJson(bucket, outputKey(request), request.value),
-        ).pipe(Effect.map(() => request.value)),
+        checkFence(request).pipe(
+          Effect.flatMap(() =>
+            run((bucket) =>
+              writeJson(bucket, outputKey(request), request.value),
+            ),
+          ),
+          Effect.map(() => request.value),
+        ),
     };
     return state;
   });

--- a/packages/alchemy/src/Apply.ts
+++ b/packages/alchemy/src/Apply.ts
@@ -1,8 +1,12 @@
+import * as os from "node:os";
 import * as Cause from "effect/Cause";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Logger from "effect/Logger";
 import * as Option from "effect/Option";
 import type { Simplify } from "effect/Types";
+import packageJson from "../package.json" with { type: "json" };
 import {
   Artifacts,
   ArtifactStore,
@@ -15,7 +19,11 @@ import {
   type ScopedPlanStatusSession,
   Cli,
 } from "./Cli/Cli.ts";
-import type { ApplyStatus } from "./Cli/Event.ts";
+import {
+  type ApplyStatus,
+  type UnstampedApplyEvent,
+  stampApplyEvent,
+} from "./Cli/Event.ts";
 import { havePropsChanged } from "./Diff.ts";
 import type { Input } from "./Input.ts";
 import { generateInstanceId, InstanceId } from "./InstanceId.ts";
@@ -44,6 +52,10 @@ import {
   type RunningActionState,
   type UpdatedResourceState,
   type UpdatingReourceState,
+  type DeploymentInProgress,
+  type DeploymentRecord,
+  type StateService,
+  makeDeploymentSession,
   State,
   StateStoreError,
 } from "./State/index.ts";
@@ -110,11 +122,16 @@ const instrumentLifecycle =
     resourceType: string,
     logicalId: string,
     instanceId: string,
+    session?: PlanStatusSession,
+    phase?: "execute" | "gc" | "converge",
   ) =>
   <A, E, R>(
     effect: Effect.Effect<A, E, R>,
-  ): Effect.Effect<A, E, Exclude<R, InstanceId | Artifacts>> =>
-    effect.pipe(
+  ): Effect.Effect<A, E, Exclude<R, InstanceId | Artifacts>> => {
+    const instrumented = effect.pipe(
+      session
+        ? Effect.provide(resourceLogs(logicalId, session, fqn))
+        : (e) => e,
       provideLifecycleScope(fqn, instanceId),
       recordResourceOp(resourceType, op),
       Effect.withSpan(`provider.${op}`, {
@@ -127,83 +144,242 @@ const instrumentLifecycle =
         },
       }),
     );
+    if (session === undefined || op === "read") {
+      return instrumented;
+    }
+    // v2 op events: bracket the dispatch with op-start / op-end correlated by
+    // a per-op unique opId, so consumers (deployment journal, dashboard v2)
+    // get exact run segments. Additive — existing status-change emissions are
+    // untouched, and renderers that predate these kinds ignore them.
+    return Effect.gen(function* () {
+      const opId = yield* Effect.sync(() => crypto.randomUUID());
+      yield* emit(session, {
+        kind: "op-start",
+        id: logicalId,
+        fqn,
+        opId,
+        op,
+        ...(phase !== undefined ? { phase } : {}),
+      });
+      const exit = yield* Effect.exit(instrumented);
+      if (Exit.isSuccess(exit)) {
+        yield* emit(session, {
+          kind: "op-end",
+          id: logicalId,
+          fqn,
+          opId,
+          outcome: "ok",
+        });
+        return exit.value;
+      }
+      if (!Cause.hasInterruptsOnly(exit.cause)) {
+        yield* emit(session, {
+          kind: "op-end",
+          id: logicalId,
+          fqn,
+          opId,
+          outcome: "fail",
+          error: causeDigest(exit.cause),
+        });
+      }
+      return yield* Effect.failCause(exit.cause);
+    });
+  };
+
+/** Short, single-string digest of a failure cause for journal/op events. */
+const causeDigest = (cause: Cause.Cause<unknown>): string => {
+  const pretty = Cause.pretty(cause);
+  return pretty.length > 2_000 ? `${pretty.slice(0, 2_000)}…` : pretty;
+};
+
+/**
+ * Emit an apply event through the session with the v2 envelope stamped:
+ * `ts` is assigned at emission via the Effect `Clock` (never at receipt).
+ * `fqn` is included by the call site when it knows it.
+ */
+const emit = (session: PlanStatusSession, event: UnstampedApplyEvent) =>
+  Effect.flatMap(stampApplyEvent(event), session.emit);
+
+/**
+ * Capture `Effect.log*` emitted during a resource's lifecycle operation and
+ * route it through the apply session as a `log` event tagged with the
+ * resource's logical id, so UIs (the dashboard) can attribute logs to the
+ * resource being applied. Merged with existing loggers — terminal and file
+ * logging are unchanged.
+ */
+const resourceLogs = (
+  logicalId: string,
+  session: PlanStatusSession,
+  fqn?: string,
+) =>
+  Logger.layer(
+    [
+      Logger.make(({ logLevel, message }) => {
+        try {
+          const text = (Array.isArray(message) ? message : [message])
+            .map((m) =>
+              typeof m === "string" ? m : (JSON.stringify(m) ?? String(m)),
+            )
+            .join(" ");
+          Effect.runSync(
+            emit(session, {
+              kind: "log",
+              id: logicalId,
+              fqn,
+              level: logLevel,
+              message: text,
+            }),
+          );
+        } catch {
+          // log capture must never break an apply
+        }
+      }),
+    ],
+    { mergeWithExisting: true },
+  );
 
 export const apply = <P extends Plan>(
   plan: P,
+  options?: {
+    /**
+     * The engine command driving this apply — recorded on the deployment
+     * journal record. `destroy` is an apply of an emptied plan, so callers
+     * (CLI destroy, programmatic `Destroy`, test harness) pass it explicitly.
+     * @default "deploy"
+     */
+    command?: "deploy" | "destroy";
+  },
 ): Effect.Effect<
   Input.Resolve<P["output"]>,
-  Output.InvalidReferenceError | Output.MissingSourceError | StateStoreError,
+  | Output.InvalidReferenceError
+  | Output.MissingSourceError
+  | StateStoreError
+  | DeploymentInProgress,
   Cli | State | Stack | Stage
 > =>
-  Effect.gen(function* () {
-    const cli = yield* Cli;
-    const session = yield* cli.startApplySession(plan);
-    const state = yield* yield* State;
-    const stack = yield* Stack;
-    const stage = yield* Stage;
-    const stackName = stack.name;
+  Effect.scoped(
+    Effect.gen(function* () {
+      const cli = yield* Cli;
+      const store = yield* yield* State;
+      const stack = yield* Stack;
+      const stage = yield* Stage;
+      const stackName = stack.name;
 
-    const tracker: Record<string, ResourceTracker> = {};
-    const terminalStatuses = new Map<
-      string,
-      {
-        id: string;
-        type: string;
-        status: Extract<ApplyStatus, "created" | "updated" | "ran" | "skipped">;
+      // ── deployment journal ──────────────────────────────────────────────
+      // Open one deployment version per apply (the single choke point every
+      // deploy/destroy funnels through: CLI, programmatic, test harness).
+      // The session's `state` facade journals every engine state write; its
+      // `emit` tees apply events into the journal. Stores without
+      // `deployments` support yield a no-op session. `begin` is fail-closed:
+      // DeploymentInProgress AND StateStoreError abort the apply — we never
+      // proceed without the mutual-exclusion lock.
+      const deployment = yield* openDeploymentSession({
+        store,
+        stack: stackName,
+        stage,
+        command: options?.command ?? "deploy",
+      });
+      const state = deployment.state;
+
+      const inner = yield* cli.startApplySession(plan);
+      // Tee every event that flows to the TUI/dashboard into the journal.
+      // Decorated at session creation (like withDashboardReporter) so ALL
+      // emitters — status changes, notes, logs, op events — are covered.
+      const session: PlanStatusSession = {
+        emit: (event) =>
+          inner.emit(event).pipe(Effect.andThen(deployment.emit(event))),
+        done: inner.done,
+      };
+
+      const run = Effect.gen(function* () {
+        const tracker: Record<string, ResourceTracker> = {};
+        const terminalStatuses = new Map<
+          string,
+          {
+            id: string;
+            type: string;
+            status: Extract<
+              ApplyStatus,
+              "created" | "updated" | "ran" | "skipped"
+            >;
+          }
+        >();
+
+        yield* executePlan(
+          plan,
+          tracker,
+          terminalStatuses,
+          session,
+          state,
+          stackName,
+          stage,
+        );
+
+        // TODO(sam): support roll back to previous state if errors occur during expansion
+        // -> RISK: some UPDATEs may not be reversible (i.e. trigger replacements)
+        // TODO(sam): should pivot be done separately? E.g shift traffic?
+
+        // collectGarbage re-resolves State from context — re-provide the
+        // journaling facade so its deletes/commits journal like every other
+        // engine write.
+        yield* collectGarbage(plan, session).pipe(
+          Effect.provideService(State, State.of(Effect.succeed(state))),
+        );
+
+        yield* converge(
+          plan,
+          tracker,
+          terminalStatuses,
+          session,
+          state,
+          stackName,
+          stage,
+        );
+
+        yield* Effect.forEach(
+          Array.from(terminalStatuses.entries()),
+          ([fqn, { id, type, status }]) =>
+            emit(session, { kind: "status-change", id, fqn, type, status }),
+          { concurrency: "unbounded" },
+        );
+
+        yield* session.done();
+
+        if (!plan.output) {
+          return undefined;
+        }
+
+        const outputs = Object.fromEntries(
+          Object.entries(tracker).map(([fqn, t]) => [fqn, t.output]),
+        );
+        const resolved = yield* Output.evaluate(plan.output, outputs);
+
+        // Persist the stack's evaluated outputs so cross-stack references
+        // (`yield* OtherStack` / `OtherStack.stage.<name>` / `Output.stackRef`)
+        // can read them back out of the state store.
+        yield* state.setOutput({ stack: stackName, stage, value: resolved });
+
+        return resolved;
+      });
+
+      // Map the run's exit onto the deployment record. Interruption is left
+      // to the session's scope-finalizer backstop (which closes the version
+      // as "interrupted"), covering Ctrl-C and dev-mode teardown uniformly.
+      const exit = yield* Effect.exit(run);
+      const counts = planActionCounts(plan);
+      if (Exit.isSuccess(exit)) {
+        yield* deployment.end("succeeded", { counts });
+        return exit.value;
       }
-    >();
-
-    yield* executePlan(
-      plan,
-      tracker,
-      terminalStatuses,
-      session,
-      state,
-      stackName,
-      stage,
-    );
-
-    // TODO(sam): support roll back to previous state if errors occur during expansion
-    // -> RISK: some UPDATEs may not be reversible (i.e. trigger replacements)
-    // TODO(sam): should pivot be done separately? E.g shift traffic?
-
-    yield* collectGarbage(plan, session);
-
-    yield* converge(
-      plan,
-      tracker,
-      terminalStatuses,
-      session,
-      state,
-      stackName,
-      stage,
-    );
-
-    yield* Effect.forEach(
-      Array.from(terminalStatuses.values()),
-      ({ id, type, status }) =>
-        session.emit({ kind: "status-change", id, type, status }),
-      { concurrency: "unbounded" },
-    );
-
-    yield* session.done();
-
-    if (!plan.output) {
-      return undefined;
-    }
-
-    const outputs = Object.fromEntries(
-      Object.entries(tracker).map(([fqn, t]) => [fqn, t.output]),
-    );
-    const resolved = yield* Output.evaluate(plan.output, outputs);
-
-    // Persist the stack's evaluated outputs so cross-stack references
-    // (`yield* OtherStack` / `OtherStack.stage.<name>` / `Output.stackRef`)
-    // can read them back out of the state store.
-    yield* state.setOutput({ stack: stackName, stage, value: resolved });
-
-    return resolved;
-  }).pipe(
+      if (!Cause.hasInterruptsOnly(exit.cause)) {
+        yield* deployment.end("failed", {
+          counts,
+          error: causeDigest(exit.cause),
+        });
+      }
+      return yield* Effect.failCause(exit.cause);
+    }),
+  ).pipe(
     ensureArtifactStore,
     Effect.withSpan("apply", {
       attributes: {
@@ -212,6 +388,139 @@ export const apply = <P extends Plan>(
       },
     }),
   );
+
+/**
+ * Per-action counts for the deployment summary, derived from the plan:
+ * resource actions (create/update/replace/noop), action runs, and deletions.
+ */
+const planActionCounts = (plan: Plan): Record<string, number> => {
+  const counts: Record<string, number> = {};
+  const bump = (key: string, by = 1) => {
+    if (by > 0) {
+      counts[key] = (counts[key] ?? 0) + by;
+    }
+  };
+  for (const node of Object.values(plan.resources)) {
+    bump(node.action);
+  }
+  for (const node of Object.values(plan.actions ?? {})) {
+    bump(node.action === "run" ? "run" : "noop");
+  }
+  bump(
+    "delete",
+    Object.values(plan.deletions ?? {}).filter((d) => d !== undefined).length +
+      Object.values(plan.actionDeletions ?? {}).filter((d) => d !== undefined)
+        .length,
+  );
+  return counts;
+};
+
+/**
+ * `true` when a process with `pid` is currently running on THIS host.
+ * Signal 0 performs the existence check without delivering anything;
+ * `EPERM` means "alive but owned by another user", `ESRCH` means gone.
+ */
+export const isProcessAlive = (pid: number): boolean => {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+};
+
+/**
+ * Same-host dead-pid takeover predicate: the holder of a live open
+ * deployment can be superseded iff it was started on THIS host by a
+ * process that no longer exists. We only trust the pid check when the
+ * holder's recorded host matches ours — a pid from another machine is
+ * meaningless locally.
+ *
+ * A recycled pid (dead holder, new unrelated process with the same pid)
+ * makes this return `false` — conservative: the deploy waits for the TTL
+ * reconciliation path instead of taking over.
+ */
+export const canTakeOverDeployment = (
+  holder: DeploymentRecord,
+  self: { host?: string; pid?: number },
+  isAlive: (pid: number) => boolean = isProcessAlive,
+): boolean => {
+  const initiator = holder.meta.initiator;
+  return (
+    initiator?.host !== undefined &&
+    initiator.host === self.host &&
+    initiator.pid !== undefined &&
+    initiator.pid !== self.pid &&
+    !isAlive(initiator.pid)
+  );
+};
+
+/**
+ * Open a {@link DeploymentSession} for this apply.
+ *
+ * `begin` is the mutual-exclusion gate for the whole apply, so every failure
+ * is fail-closed: `DeploymentInProgress` (a live holder exists) and
+ * `StateStoreError` (the store could not prove exclusivity — unreachable,
+ * unauthorized, or claim contention) both abort the deploy. Proceeding
+ * without the lock is never an option: the apply is one big transaction and
+ * a deploy that cannot claim its version must not mutate anything.
+ *
+ * One exception softens `DeploymentInProgress`: when the live holder was
+ * started on THIS host by a process that is provably gone (crashed CLI,
+ * killed terminal — see {@link canTakeOverDeployment}), waiting out the
+ * 60s heartbeat TTL just punishes the user for the crash. We retry `begin`
+ * once with `supersede: holder.version` — a targeted takeover that abandons
+ * exactly that version. If any OTHER deploy claimed the stage in between,
+ * the versions no longer match and the retry fails `DeploymentInProgress`
+ * like any other begin, so the takeover can never race a legitimate deploy.
+ *
+ * Stores without `deployments` support yield a no-op session inside
+ * {@link makeDeploymentSession} — that is a declared capability gap, not a
+ * failure.
+ */
+const openDeploymentSession = Effect.fn("openDeploymentSession")(function* ({
+  store,
+  stack,
+  stage,
+  command,
+}: {
+  store: StateService;
+  stack: string;
+  stage: string;
+  command: "deploy" | "destroy";
+}) {
+  const initiator = yield* Effect.sync(() => ({
+    user: process.env.USER,
+    host: os.hostname(),
+    pid: process.pid,
+  }));
+  const open = (supersede?: number) =>
+    makeDeploymentSession({
+      store,
+      stack,
+      stage,
+      meta: {
+        command,
+        initiator,
+        alchemyVersion: packageJson.version,
+      },
+      supersede,
+    });
+  return yield* open().pipe(
+    Effect.catchTag("DeploymentInProgress", (error) =>
+      Effect.sync(() => canTakeOverDeployment(error.holder, initiator)).pipe(
+        Effect.flatMap((takeover) =>
+          takeover
+            ? Effect.logWarning(
+                `alchemy: taking over deployment v${error.holder.version} of ${stack}/${stage} — ` +
+                  `its holder (pid ${error.holder.meta.initiator?.pid} on this host) is no longer running`,
+              ).pipe(Effect.flatMap(() => open(error.holder.version)))
+            : Effect.fail(error),
+        ),
+      ),
+    ),
+  );
+});
 
 // ── Phase 1: concurrent initial execution ──────────────────────────────────
 //
@@ -411,13 +720,14 @@ const executeNode = (
     const scopedSession = {
       ...session,
       note: (note: string) =>
-        session.emit({ id: logicalId, kind: "annotate", message: note }),
+        emit(session, { id: logicalId, fqn, kind: "annotate", message: note }),
     } satisfies ScopedPlanStatusSession;
 
     const report = (status: ApplyStatus) =>
-      session.emit({
+      emit(session, {
         kind: "status-change",
         id: logicalId,
+        fqn,
         type: node.resource.Type,
         status,
       });
@@ -442,9 +752,10 @@ const executeNode = (
         // terminal status is known. Their final status is flushed from
         // `terminalStatuses` after `converge` completes.
         if (inCycle) return;
-        yield* session.emit({
+        yield* emit(session, {
           kind: "status-change",
           id: logicalId,
+          fqn,
           type: node.resource.Type,
           status,
         });
@@ -590,6 +901,8 @@ const executeNode = (
                 node.resource.Type,
                 logicalId,
                 instanceId,
+                session,
+                "execute",
               ),
             );
           yield* commit<CreatingResourceState>({
@@ -651,6 +964,8 @@ const executeNode = (
               node.resource.Type,
               logicalId,
               instanceId,
+              session,
+              "execute",
             ),
           );
 
@@ -773,6 +1088,8 @@ const executeNode = (
               node.resource.Type,
               logicalId,
               instanceId,
+              session,
+              "execute",
             ),
           );
 
@@ -894,6 +1211,8 @@ const executeNode = (
                     node.resource.Type,
                     logicalId,
                     old.instanceId,
+                    session,
+                    "execute",
                   ),
                 );
             }
@@ -939,6 +1258,8 @@ const executeNode = (
                 node.resource.Type,
                 logicalId,
                 instanceId,
+                session,
+                "execute",
               ),
             );
           yield* commit<ReplacingResourceState>({
@@ -1001,6 +1322,8 @@ const executeNode = (
               node.resource.Type,
               logicalId,
               instanceId,
+              session,
+              "execute",
             ),
           );
 
@@ -1080,9 +1403,10 @@ const executeNode = (
           readyStable[fqn],
           cause as Cause.Cause<never>,
         );
-        yield* session.emit({
+        yield* emit(session, {
           kind: "status-change",
           id: node.resource.LogicalId,
+          fqn,
           type: node.resource.Type,
           status: "fail",
         });
@@ -1148,9 +1472,10 @@ const executeActionNode = (
       });
 
     const report = (status: ApplyStatus) =>
-      session.emit({
+      emit(session, {
         kind: "status-change",
         id: logicalId,
+        fqn,
         type: task.Type,
         status,
       });
@@ -1246,9 +1571,10 @@ const executeActionNode = (
           readyStable[fqn],
           cause as Cause.Cause<never>,
         );
-        yield* session.emit({
+        yield* emit(session, {
           kind: "status-change",
           id: node.def.LogicalId,
+          fqn,
           type: node.def.Type,
           status: "fail",
         });
@@ -1334,7 +1660,12 @@ const converge = Effect.fn(function* (
       const scopedSession = {
         ...session,
         note: (note: string) =>
-          session.emit({ id: logicalId, kind: "annotate", message: note }),
+          emit(session, {
+            id: logicalId,
+            fqn,
+            kind: "annotate",
+            message: note,
+          }),
       } satisfies ScopedPlanStatusSession;
 
       const attr = yield* node.provider
@@ -1354,6 +1685,8 @@ const converge = Effect.fn(function* (
             node.resource.Type,
             logicalId,
             instanceId,
+            session,
+            "converge",
           ),
         );
 
@@ -1483,16 +1816,18 @@ const collectGarbage = Effect.fn(function* (
       node === undefined
         ? Effect.void
         : Effect.gen(function* () {
-            yield* session.emit({
+            yield* emit(session, {
               kind: "status-change",
               id: node.def.LogicalId,
+              fqn,
               type: node.def.Type,
               status: "deleting",
             });
             yield* state.delete({ stack: stackName, stage, fqn });
-            yield* session.emit({
+            yield* emit(session, {
               kind: "status-change",
               id: node.def.LogicalId,
+              fqn,
               type: node.def.Type,
               status: "deleted",
             });
@@ -1568,9 +1903,10 @@ const collectGarbage = Effect.fn(function* (
           });
 
         const report = (status: ApplyStatus) =>
-          session.emit({
+          emit(session, {
             kind: "status-change",
             id: logicalId,
+            fqn,
             type: resourceType,
             status,
           });
@@ -1578,8 +1914,9 @@ const collectGarbage = Effect.fn(function* (
         const scopedSession = {
           ...session,
           note: (note: string) =>
-            session.emit({
+            emit(session, {
               id: logicalId,
+              fqn,
               kind: "annotate",
               message: note,
             }),
@@ -1655,6 +1992,8 @@ const collectGarbage = Effect.fn(function* (
                     resourceType,
                     logicalId,
                     instanceId,
+                    session,
+                    "gc",
                   ),
                 );
             }

--- a/packages/alchemy/src/Cli/Event.ts
+++ b/packages/alchemy/src/Cli/Event.ts
@@ -1,3 +1,6 @@
+import * as Clock from "effect/Clock";
+import * as Effect from "effect/Effect";
+
 export type ApplyStatus =
   | "attaching"
   | "post-attach"
@@ -18,15 +21,57 @@ export type ApplyStatus =
   | "skipped"
   | "fail";
 
-export type ApplyEvent = AnnotateEvent | StatusChangeEvent;
+export type ApplyEvent =
+  | AnnotateEvent
+  | StatusChangeEvent
+  | LogEvent
+  | OpStartEvent
+  | OpEndEvent
+  | AnnotationEvent;
 
-export interface AnnotateEvent {
+/**
+ * The v2 event envelope: fields stamped by the engine on EVERY apply event.
+ *
+ * Consumers that predate these fields (LoggingCli, the TUI, the v1
+ * dashboard) ignore them safely; new consumers (the deployment journal,
+ * dashboard v2) rely on them for durable, time-ordered history.
+ */
+export interface ApplyEventBase {
+  /**
+   * Epoch millis at emission (not receipt). Stamped by the engine via
+   * `Clock.currentTimeMillis` — see {@link stampApplyEvent}.
+   */
+  ts: number;
+  /**
+   * Fully-qualified resource name — the primary identity for v2 consumers
+   * (`id`/logicalId is not unique across namespaces). Optional: emit sites
+   * that don't know the fqn leave it undefined; renderers keying by fqn
+   * must fall back to `id`.
+   */
+  fqn?: string;
+}
+
+export interface AnnotateEvent extends ApplyEventBase {
   kind: "annotate";
   id: string;
   message: string;
 }
 
-export interface StatusChangeEvent {
+/**
+ * A log line (`Effect.log*`) captured during a resource's lifecycle
+ * operation, attributed to the resource being applied. Emitted by the
+ * per-resource logger `apply()` injects around each lifecycle call —
+ * renderers that don't care (LoggingCli, TUI) ignore these; the dashboard
+ * shows them per-resource.
+ */
+export interface LogEvent extends ApplyEventBase {
+  kind: "log";
+  id: string;
+  level: string;
+  message: string;
+}
+
+export interface StatusChangeEvent extends ApplyEventBase {
   kind: "status-change";
   id: string; // resource id (e.g. "messages", "api")
   type: string; // resource type (e.g. "AWS::Lambda::Function", "Cloudflare::Worker")
@@ -34,3 +79,60 @@ export interface StatusChangeEvent {
   message?: string; // optional details
   bindingId?: string; // if this event is for a binding
 }
+
+/**
+ * A provider lifecycle operation began. Emitted from `instrumentLifecycle`
+ * (the single dispatch choke point), paired with {@link OpEndEvent} by
+ * `opId` — the ts pair is exactly the Waterfall view's run segment.
+ */
+export interface OpStartEvent extends ApplyEventBase {
+  kind: "op-start";
+  id: string;
+  /** Correlates this start with its {@link OpEndEvent}. */
+  opId: string;
+  op: "precreate" | "create" | "update" | "delete" | "run";
+  /** Engine phase dispatching the op (e.g. "execute", "gc", "converge"). */
+  phase?: string;
+}
+
+/** A provider lifecycle operation finished. See {@link OpStartEvent}. */
+export interface OpEndEvent extends ApplyEventBase {
+  kind: "op-end";
+  id: string;
+  opId: string;
+  outcome: "ok" | "fail";
+  error?: string;
+}
+
+/**
+ * A deployment-scoped rich-markdown annotation (Buildkite semantics:
+ * upsert by `context`). Distinct from per-resource {@link AnnotateEvent}
+ * notes — `id`/`fqn` are optional and only set for resource-scoped
+ * annotations.
+ */
+export interface AnnotationEvent extends ApplyEventBase {
+  kind: "annotation";
+  id?: string;
+  /** Upsert key: emitting the same context again replaces the annotation. */
+  context: string;
+  style: "success" | "info" | "warning" | "error";
+  markdown: string;
+}
+
+type DistributiveOmit<T, K extends keyof any> = T extends any
+  ? Omit<T, K>
+  : never;
+
+/** An {@link ApplyEvent} before the engine stamps `ts` at emission. */
+export type UnstampedApplyEvent = DistributiveOmit<ApplyEvent, "ts">;
+
+/**
+ * Stamp `ts` (epoch millis, via the Effect `Clock`) onto an event at
+ * emission time. Every engine emit site routes through this so event
+ * timestamps reflect when things happened, not when a renderer received
+ * them.
+ */
+export const stampApplyEvent = (
+  event: UnstampedApplyEvent,
+): Effect.Effect<ApplyEvent> =>
+  Effect.map(Clock.currentTimeMillis, (ts) => ({ ...event, ts }) as ApplyEvent);

--- a/packages/alchemy/src/Cli/LoggingCli.ts
+++ b/packages/alchemy/src/Cli/LoggingCli.ts
@@ -112,20 +112,31 @@ export const LoggingCli = Layer.succeed(
         return {
           emit: (event: ApplyEvent) =>
             Effect.sync(() => {
+              if (event.kind === "log") {
+                // captured Effect.log* lines already reach the terminal via
+                // the merged default logger — don't double-print
+                return;
+              }
               if (event.kind === "annotate") {
                 console.log(`${tag(event.id)} ${blue(event.message)}`);
                 return;
               }
-              const id = event.bindingId
-                ? `${event.id}/${event.bindingId}`
-                : event.id;
-              const status = statusColor(event.status)(event.status);
-              const msg = event.message ? ` ${dim("—")} ${event.message}` : "";
-              console.log(`${tag(id)} ${status}${msg}`);
-              if (isTerminal(event.status)) {
-                if (event.status === "fail") counts.fail++;
-                else counts.ok++;
+              if (event.kind === "status-change") {
+                const id = event.bindingId
+                  ? `${event.id}/${event.bindingId}`
+                  : event.id;
+                const status = statusColor(event.status)(event.status);
+                const msg = event.message
+                  ? ` ${dim("—")} ${event.message}`
+                  : "";
+                console.log(`${tag(id)} ${status}${msg}`);
+                if (isTerminal(event.status)) {
+                  if (event.status === "fail") counts.fail++;
+                  else counts.ok++;
+                }
               }
+              // other kinds (op-start / op-end / annotation / future events)
+              // are dashboard/journal detail — ignore them here
             }),
           done: () =>
             Console.log(

--- a/packages/alchemy/src/Cli/tui/components/PlanProgress.tsx
+++ b/packages/alchemy/src/Cli/tui/components/PlanProgress.tsx
@@ -204,9 +204,9 @@ export function PlanProgress(props: PlanProgressProps): JSX.Element {
     unsubscribeRef.current = source.subscribe((event) => {
       setTasks((prev) => {
         const next = new Map(prev);
-        const keys = logicalIdIndex.get(event.id) ?? [];
 
         if (event.kind === "status-change") {
+          const keys = logicalIdIndex.get(event.id) ?? [];
           if (!event.bindingId) {
             for (const key of keys) {
               const current = next.get(key);
@@ -220,7 +220,8 @@ export function PlanProgress(props: PlanProgressProps): JSX.Element {
               });
             }
           }
-        } else {
+        } else if (event.kind === "annotate") {
+          const keys = logicalIdIndex.get(event.id) ?? [];
           for (const key of keys) {
             const current = next.get(key);
             if (!current) continue;
@@ -231,6 +232,9 @@ export function PlanProgress(props: PlanProgressProps): JSX.Element {
             });
           }
         }
+        // "log" events are dashboard-only (the terminal already shows them
+        // through the merged default logger); op-start/op-end/annotation and
+        // any future kinds are journal/dashboard detail — ignored here
 
         return next;
       });

--- a/packages/alchemy/src/Cloudflare/StateStore/Api.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/Api.ts
@@ -13,6 +13,12 @@ import {
   BearerTokenValidator,
   StateApi,
   StateAuthLive,
+  type DeploymentCorruptWire,
+  type DeploymentEventWire,
+  type DeploymentInProgressWire,
+  type DeploymentNotFoundWire,
+  type DeploymentTokenInvalidWire,
+  type StateWriteFencedWire,
 } from "../../State/HttpStateApi.ts";
 import { ReadSecret } from "../SecretsStore/ReadSecret.ts";
 import { ReadSecretBinding } from "../SecretsStore/ReadSecretBinding.ts";
@@ -31,7 +37,7 @@ export const STATE_STORE_SCRIPT_NAME = "alchemy-state-store" as const;
  * compare against this constant; a mismatch (or 404) triggers a
  * forced redeploy via the bootstrap flow.
  */
-export const STATE_STORE_VERSION = 7 as const;
+export const STATE_STORE_VERSION = 10 as const;
 
 /**
  * Hard-coded OTLP/HTTP endpoints. Point at the public ingest relay
@@ -193,12 +199,22 @@ export default Worker(
               }),
             );
         })
-        .handle("setState", ({ params, payload }) => {
+        .handle("setState", ({ params, payload, query }) => {
           const fqn = decodeURIComponent(params.fqn);
           return store
             .getByName(params.stack)
-            .set({ stage: params.stage, fqn, value: payload as any })
+            .set({
+              stage: params.stage,
+              fqn,
+              value: payload as any,
+              fence: query.fence,
+            })
             .pipe(
+              Effect.flatMap((result) =>
+                result._tag === "ok"
+                  ? Effect.succeed(result.value)
+                  : failStateWriteFenced(params, query.fence!),
+              ),
               Effect.tap(() =>
                 store
                   .getByName(Store.ROOT_DO_NAME)
@@ -214,15 +230,19 @@ export default Worker(
               }),
             );
         })
-        .handle("deleteState", ({ params }) => {
+        .handle("deleteState", ({ params, query }) => {
           const fqn = decodeURIComponent(params.fqn);
           // The DO method is `remove`, not `delete` — `delete` is
           // reserved by Cloudflare's RPC stub proxy.
           return store
             .getByName(params.stack)
-            .remove({ stage: params.stage, fqn })
+            .remove({ stage: params.stage, fqn, fence: query.fence })
             .pipe(
-              Effect.asVoid,
+              Effect.flatMap((result) =>
+                result._tag === "ok"
+                  ? Effect.void
+                  : failStateWriteFenced(params, query.fence!),
+              ),
               Effect.withSpan("state_store.deleteState", {
                 attributes: {
                   "alchemy.state_store.op": "deleteState",
@@ -261,11 +281,20 @@ export default Worker(
               }),
             ),
         )
-        .handle("setStackOutput", ({ params, payload }) =>
+        .handle("setStackOutput", ({ params, payload, query }) =>
           store
             .getByName(params.stack)
-            .setOutput({ stage: params.stage, value: payload as any })
+            .setOutput({
+              stage: params.stage,
+              value: payload as any,
+              fence: query.fence,
+            })
             .pipe(
+              Effect.flatMap((result) =>
+                result._tag === "ok"
+                  ? Effect.succeed(result.value)
+                  : failStateWriteFenced(params, query.fence!),
+              ),
               Effect.tap(() =>
                 store
                   .getByName(Store.ROOT_DO_NAME)
@@ -276,6 +305,254 @@ export default Worker(
                   "alchemy.state_store.op": "setStackOutput",
                   "alchemy.state_store.stack": params.stack,
                   "alchemy.state_store.stage": params.stage,
+                },
+              }),
+            ),
+        )
+        .handle("getAllStates", ({ params }) =>
+          store
+            .getByName(params.stack)
+            .getAll({ stage: params.stage })
+            .pipe(
+              Effect.withSpan("state_store.getAllStates", {
+                attributes: {
+                  "alchemy.state_store.op": "getAllStates",
+                  "alchemy.state_store.stack": params.stack,
+                  "alchemy.state_store.stage": params.stage,
+                },
+              }),
+            ),
+        )
+        .handle("beginDeployment", ({ params, payload }) =>
+          store
+            .getByName(params.stack)
+            .deploymentBegin({
+              stack: params.stack,
+              stage: params.stage,
+              meta: payload.meta,
+              ttlMillis: payload.ttlMillis,
+              supersede: payload.supersede,
+            })
+            .pipe(
+              Effect.flatMap(
+                (
+                  result,
+                ): Effect.Effect<
+                  { version: number; token: string },
+                  | typeof DeploymentInProgressWire.Type
+                  | typeof DeploymentCorruptWire.Type
+                > =>
+                  result._tag === "ok"
+                    ? Effect.succeed({
+                        version: result.version,
+                        token: result.token,
+                      })
+                    : result._tag === "in-progress"
+                      ? Effect.fail({
+                          _tag: "DeploymentInProgress",
+                          stack: params.stack,
+                          stage: params.stage,
+                          holder: result.holder,
+                        } as const)
+                      : Effect.fail({
+                          _tag: "DeploymentCorrupt",
+                          message: result.message,
+                        } as const),
+              ),
+              Effect.withSpan("state_store.beginDeployment", {
+                attributes: {
+                  "alchemy.state_store.op": "beginDeployment",
+                  "alchemy.state_store.stack": params.stack,
+                  "alchemy.state_store.stage": params.stage,
+                },
+              }),
+            ),
+        )
+        .handle("appendDeploymentEvents", ({ params, payload }) =>
+          store
+            .getByName(params.stack)
+            .deploymentAppendEvents({
+              stage: params.stage,
+              version: params.version,
+              token: payload.token,
+              events: payload.events,
+            })
+            .pipe(
+              Effect.flatMap(
+                (
+                  result,
+                ): Effect.Effect<
+                  { ackedSeq: number },
+                  | typeof DeploymentTokenInvalidWire.Type
+                  | typeof DeploymentNotFoundWire.Type
+                > =>
+                  result._tag === "ok"
+                    ? Effect.succeed({ ackedSeq: result.ackedSeq })
+                    : failDeploymentMutation(result._tag, params),
+              ),
+              Effect.withSpan("state_store.appendDeploymentEvents", {
+                attributes: {
+                  "alchemy.state_store.op": "appendDeploymentEvents",
+                  "alchemy.state_store.stack": params.stack,
+                  "alchemy.state_store.stage": params.stage,
+                  "alchemy.state_store.deployment_version": params.version,
+                },
+              }),
+            ),
+        )
+        .handle("heartbeatDeployment", ({ params, payload }) =>
+          store
+            .getByName(params.stack)
+            .deploymentHeartbeat({
+              stage: params.stage,
+              version: params.version,
+              token: payload.token,
+            })
+            .pipe(
+              Effect.flatMap(
+                (
+                  result,
+                ): Effect.Effect<
+                  void,
+                  | typeof DeploymentTokenInvalidWire.Type
+                  | typeof DeploymentNotFoundWire.Type
+                > =>
+                  result._tag === "ok"
+                    ? Effect.void
+                    : failDeploymentMutation(result._tag, params),
+              ),
+              Effect.withSpan("state_store.heartbeatDeployment", {
+                attributes: {
+                  "alchemy.state_store.op": "heartbeatDeployment",
+                  "alchemy.state_store.stack": params.stack,
+                  "alchemy.state_store.stage": params.stage,
+                  "alchemy.state_store.deployment_version": params.version,
+                },
+              }),
+            ),
+        )
+        .handle("endDeployment", ({ params, payload }) =>
+          store
+            .getByName(params.stack)
+            .deploymentEnd({
+              stage: params.stage,
+              version: params.version,
+              token: payload.token,
+              outcome: payload.outcome,
+              summary: payload.summary,
+            })
+            .pipe(
+              Effect.flatMap(
+                (
+                  result,
+                ): Effect.Effect<
+                  void,
+                  | typeof DeploymentTokenInvalidWire.Type
+                  | typeof DeploymentNotFoundWire.Type
+                > =>
+                  result._tag === "ok"
+                    ? Effect.void
+                    : failDeploymentMutation(result._tag, params),
+              ),
+              Effect.withSpan("state_store.endDeployment", {
+                attributes: {
+                  "alchemy.state_store.op": "endDeployment",
+                  "alchemy.state_store.stack": params.stack,
+                  "alchemy.state_store.stage": params.stage,
+                  "alchemy.state_store.deployment_version": params.version,
+                },
+              }),
+            ),
+        )
+        .handle("listDeployments", ({ params, query }) =>
+          store
+            .getByName(params.stack)
+            .deploymentList({
+              stage: params.stage,
+              before: query.before,
+              limit: query.limit,
+            })
+            .pipe(
+              Effect.flatMap((result) =>
+                result._tag === "ok"
+                  ? Effect.succeed(result.records)
+                  : Effect.fail({
+                      _tag: "DeploymentCorrupt",
+                      message: result.message,
+                    } as const),
+              ),
+              Effect.withSpan("state_store.listDeployments", {
+                attributes: {
+                  "alchemy.state_store.op": "listDeployments",
+                  "alchemy.state_store.stack": params.stack,
+                  "alchemy.state_store.stage": params.stage,
+                },
+              }),
+            ),
+        )
+        .handle("getDeployment", ({ params }) =>
+          store
+            .getByName(params.stack)
+            .deploymentGet({
+              stage: params.stage,
+              version: params.version,
+            })
+            .pipe(
+              Effect.flatMap((result) =>
+                result._tag === "ok"
+                  ? Effect.succeed(result.record)
+                  : Effect.fail({
+                      _tag: "DeploymentCorrupt",
+                      message: result.message,
+                    } as const),
+              ),
+              Effect.withSpan("state_store.getDeployment", {
+                attributes: {
+                  "alchemy.state_store.op": "getDeployment",
+                  "alchemy.state_store.stack": params.stack,
+                  "alchemy.state_store.stage": params.stage,
+                  "alchemy.state_store.deployment_version": params.version,
+                },
+              }),
+            ),
+        )
+        .handle("readDeploymentEvents", ({ params, query }) =>
+          store
+            .getByName(params.stack)
+            .deploymentReadEvents({
+              stage: params.stage,
+              version: params.version,
+              fromSeq: query.fromSeq,
+            })
+            .pipe(
+              Effect.flatMap(
+                (
+                  result,
+                ): Effect.Effect<
+                  readonly (typeof DeploymentEventWire.Type)[],
+                  | typeof DeploymentNotFoundWire.Type
+                  | typeof DeploymentCorruptWire.Type
+                > =>
+                  result._tag === "ok"
+                    ? Effect.succeed(result.events)
+                    : result._tag === "not-found"
+                      ? Effect.fail({
+                          _tag: "DeploymentNotFound",
+                          stack: params.stack,
+                          stage: params.stage,
+                          version: params.version,
+                        } as const)
+                      : Effect.fail({
+                          _tag: "DeploymentCorrupt",
+                          message: result.message,
+                        } as const),
+              ),
+              Effect.withSpan("state_store.readDeploymentEvents", {
+                attributes: {
+                  "alchemy.state_store.op": "readDeploymentEvents",
+                  "alchemy.state_store.stack": params.stack,
+                  "alchemy.state_store.stage": params.stage,
+                  "alchemy.state_store.deployment_version": params.version,
                 },
               }),
             ),
@@ -323,6 +600,50 @@ export default Worker(
     };
   }).pipe(Effect.provide(Layer.mergeAll(ReadSecretBinding))),
 );
+
+/**
+ * Map the stack DO's fenced-write refusal onto the schema-typed 412
+ * wire error. Like the deployment mutations, the DO surfaces the
+ * refusal as a discriminated result value (its RPC stub serializes
+ * thrown errors lossily); the worker is where it becomes typed HTTP.
+ */
+const failStateWriteFenced = (
+  params: { stack: string; stage: string },
+  fence: number,
+): Effect.Effect<never, typeof StateWriteFencedWire.Type> =>
+  Effect.fail({
+    _tag: "StateWriteFenced",
+    stack: params.stack,
+    stage: params.stage,
+    fence,
+  } as const);
+
+/**
+ * Map the stack DO's deployment mutation failures onto the schema-typed
+ * wire errors declared in `HttpStateApi.ts`. The DO returns discriminated
+ * result values (its RPC stub serializes thrown errors lossily); the worker
+ * is where they become typed HTTP failures.
+ */
+const failDeploymentMutation = (
+  tag: "not-found" | "invalid-token",
+  params: { stack: string; stage: string; version: number },
+): Effect.Effect<
+  never,
+  typeof DeploymentNotFoundWire.Type | typeof DeploymentTokenInvalidWire.Type
+> =>
+  tag === "not-found"
+    ? Effect.fail({
+        _tag: "DeploymentNotFound",
+        stack: params.stack,
+        stage: params.stage,
+        version: params.version,
+      } as const)
+    : Effect.fail({
+        _tag: "DeploymentTokenInvalid",
+        stack: params.stack,
+        stage: params.stage,
+        version: params.version,
+      } as const);
 
 /**
  * Stub `HttpPlatform` for the worker. The state-store API never

--- a/packages/alchemy/src/Cloudflare/StateStore/Deployments.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/Deployments.ts
@@ -1,0 +1,211 @@
+import type {
+  DeploymentEvent,
+  DeploymentMeta,
+  DeploymentOutcome,
+  DeploymentRecord,
+  DeploymentSummary,
+} from "../../State/Deployment.ts";
+
+/**
+ * Pure scaffolding for the Cloudflare Durable Object deployment store:
+ * reserved key builders, the stored record shapes, and the SQLite
+ * statements backing the event journal. Encryption uses the same shared
+ * AES-CTR helpers (`Util/aes-ctr.ts`) as resource rows.
+ *
+ * Shared between `Store.ts` (the stack DO) and its unit tests. Not exported
+ * from the `StateStore` index — internal scaffolding only.
+ */
+
+/** NUL byte separator — matches `Store.ts`'s composite-key convention. */
+const SEP = "\x00";
+
+/**
+ * Reserved key prefixes inside a *stack DO*. Deliberately disjoint from the
+ * existing `r\x00` (resources), `o\x00` (stack outputs) and `s:` (root stack
+ * index) prefixes so deployment history never mixes with resource rows.
+ */
+export const DEPLOYMENT_RECORD_PREFIX = `d${SEP}`;
+/** Open-deployment marker per stage — at most one live open per stage. */
+export const DEPLOYMENT_OPEN_PREFIX = `dl${SEP}`;
+/** Monotonic per-stage version counter. */
+export const DEPLOYMENT_COUNTER_PREFIX = `dc${SEP}`;
+
+/**
+ * Zero-pad versions so record keys sort lexicographically in version order,
+ * letting `storage.list({ prefix, reverse, end, limit })` implement
+ * newest-first pagination without decrypting anything.
+ */
+const VERSION_PAD = 12;
+export const padVersion = (version: number): string =>
+  String(version).padStart(VERSION_PAD, "0");
+
+/** Prefix matching every deployment record of a specific stage. */
+export const deploymentStagePrefix = (stage: string): string =>
+  `${DEPLOYMENT_RECORD_PREFIX}${stage}${SEP}`;
+
+/** Key of one deployment record inside a stack DO. */
+export const deploymentRecordKey = (stage: string, version: number): string =>
+  `${deploymentStagePrefix(stage)}${padVersion(version)}`;
+
+/** Key of the open-deployment marker for a stage. */
+export const deploymentOpenKey = (stage: string): string =>
+  `${DEPLOYMENT_OPEN_PREFIX}${stage}`;
+
+/** Key of the per-stage version counter. */
+export const deploymentCounterKey = (stage: string): string =>
+  `${DEPLOYMENT_COUNTER_PREFIX}${stage}`;
+
+/** Parse an open-marker key back to its stage, or undefined. */
+export const parseDeploymentOpenKey = (key: string): string | undefined =>
+  key.startsWith(DEPLOYMENT_OPEN_PREFIX)
+    ? key.slice(DEPLOYMENT_OPEN_PREFIX.length)
+    : undefined;
+
+/** Parse a record key back into `(stage, version)`, or undefined. */
+export const parseDeploymentRecordKey = (
+  key: string,
+): { stage: string; version: number } | undefined => {
+  if (!key.startsWith(DEPLOYMENT_RECORD_PREFIX)) return undefined;
+  const rest = key.slice(DEPLOYMENT_RECORD_PREFIX.length);
+  const sep = rest.lastIndexOf(SEP);
+  if (sep < 0) return undefined;
+  const version = Number(rest.slice(sep + 1));
+  if (!Number.isInteger(version) || version < 1) return undefined;
+  return { stage: rest.slice(0, sep), version };
+};
+
+// ---------------------------------------------------------------------------
+// Stored shapes
+// ---------------------------------------------------------------------------
+
+/**
+ * The KV value stored under {@link deploymentRecordKey}. Lifecycle /
+ * liveness fields stay plaintext so `begin`, `heartbeat` and the alarm can
+ * arbitrate without any crypto inside the storage transaction (non-storage
+ * awaits there would open the DO input gate mid-claim); the identity-bearing
+ * `meta`/`summary` are encrypted with the store's AES-CTR key; the bearer
+ * token is stored only as a SHA-256 hash so a storage dump can never mint a
+ * valid capability.
+ */
+export interface StoredDeploymentRecord {
+  v: 1;
+  stack: string;
+  stage: string;
+  version: number;
+  startedAt: number;
+  heartbeatAt: number;
+  /** TTL supplied at `begin`, used by the alarm's stale-open detection. */
+  ttlMillis: number;
+  endedAt?: number;
+  outcome?: DeploymentOutcome;
+  /** SHA-256 hex of the bearer token — validates ops without decryption. */
+  tokenHash: string;
+  /** Encrypted {@link DeploymentMeta} (`base64(nonce || ciphertext)`). */
+  meta: string;
+  /** Encrypted {@link DeploymentSummary}, present once `end` supplied one. */
+  summary?: string;
+}
+
+/** The KV value stored under {@link deploymentOpenKey}. */
+export interface DeploymentOpenMarker {
+  version: number;
+  /** `heartbeatAt + ttlMillis` at the time of the last write. */
+  deadline: number;
+}
+
+/**
+ * Assemble the public {@link DeploymentRecord} from a stored record and its
+ * decrypted meta/summary. Never leaks the token hash, TTL or ciphertext.
+ */
+export const toPublicDeploymentRecord = (
+  stored: StoredDeploymentRecord,
+  meta: DeploymentMeta,
+  summary?: DeploymentSummary,
+): DeploymentRecord => {
+  const record: DeploymentRecord = {
+    stack: stored.stack,
+    stage: stored.stage,
+    version: stored.version,
+    meta,
+    startedAt: stored.startedAt,
+    heartbeatAt: stored.heartbeatAt,
+  };
+  if (stored.endedAt !== undefined) record.endedAt = stored.endedAt;
+  if (stored.outcome !== undefined) record.outcome = stored.outcome;
+  if (summary !== undefined) record.summary = summary;
+  return record;
+};
+
+// ---------------------------------------------------------------------------
+// DO method result unions
+//
+// Deployment failures cross the Durable Object RPC boundary as plain
+// discriminated values (not thrown tagged errors) — Cloudflare's RPC stub
+// serializes thrown errors lossily, so the worker re-raises them as the
+// schema-typed HTTP errors instead.
+// ---------------------------------------------------------------------------
+
+export type DeploymentBeginResult =
+  | { _tag: "ok"; version: number; token: string }
+  | { _tag: "in-progress"; holder: DeploymentRecord }
+  | { _tag: "corrupt"; message: string };
+
+export type DeploymentMutateResult =
+  | { _tag: "ok" }
+  | { _tag: "not-found" }
+  | { _tag: "invalid-token" };
+
+export type DeploymentAppendResult =
+  | { _tag: "ok"; ackedSeq: number }
+  | { _tag: "not-found" }
+  | { _tag: "invalid-token" };
+
+export type DeploymentGetResult =
+  | { _tag: "ok"; record: DeploymentRecord | undefined }
+  | { _tag: "corrupt"; message: string };
+
+export type DeploymentListResult =
+  | { _tag: "ok"; records: DeploymentRecord[] }
+  | { _tag: "corrupt"; message: string };
+
+export type DeploymentReadEventsResult =
+  | { _tag: "ok"; events: DeploymentEvent[] }
+  | { _tag: "not-found" }
+  | { _tag: "corrupt"; message: string };
+
+// ---------------------------------------------------------------------------
+// Event journal SQL (storage.sql / SQLite)
+//
+// Rows escape the 128 KiB per-value KV cap and give indexed range reads.
+// `INSERT OR IGNORE` against the composite primary key makes appends
+// seq-idempotent for free, so crash-retried batches never duplicate.
+// ---------------------------------------------------------------------------
+
+export const CREATE_DEPLOYMENT_EVENTS_TABLE = `CREATE TABLE IF NOT EXISTS deployment_events (
+  stage TEXT NOT NULL,
+  version INTEGER NOT NULL,
+  seq INTEGER NOT NULL,
+  ts INTEGER NOT NULL,
+  fqn TEXT,
+  payload TEXT NOT NULL,
+  PRIMARY KEY (stage, version, seq)
+)`;
+
+export const INSERT_DEPLOYMENT_EVENT = `INSERT OR IGNORE INTO deployment_events (stage, version, seq, ts, fqn, payload) VALUES (?, ?, ?, ?, ?, ?)`;
+
+export const SELECT_DEPLOYMENT_MAX_SEQ = `SELECT COALESCE(MAX(seq), 0) AS ackedSeq FROM deployment_events WHERE stage = ? AND version = ?`;
+
+export const selectDeploymentEventsSql = (hasFromSeq: boolean): string =>
+  `SELECT seq, ts, fqn, payload FROM deployment_events WHERE stage = ? AND version = ?${hasFromSeq ? " AND seq >= ?" : ""} ORDER BY seq ASC`;
+
+/** Row shape of the `deployment_events` table. */
+export interface DeploymentEventRow extends Record<
+  string,
+  string | number | null
+> {
+  seq: number;
+  ts: number;
+  fqn: string | null;
+  /** Encrypted event payload (`base64(nonce || ciphertext)`). */
+  payload: string;
+}

--- a/packages/alchemy/src/Cloudflare/StateStore/State.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/State.ts
@@ -345,8 +345,15 @@ const deployStateStore = ({
 }) =>
   Effect.gen(function* () {
     yield* annotateAccountHash();
+    // The state-store deploy is self-referential: when upgrading, `state`
+    // IS the (outdated) deployed store. Journaling this deploy against it
+    // would make `begin` — which is fail-closed — depend on the very
+    // contract version we are upgrading away from (a v7 store has no
+    // deployments API at all, bricking the upgrade). Strip `deployments`
+    // so the deploy runs with a declared no-op session instead.
+    const bootstrapState: StateService = { ...state, deployments: undefined };
     // deploy it with local state (which we will then hoist into the Cloudflare state store)
-    const stateLayer = Layer.succeed(State, Effect.succeed(state));
+    const stateLayer = Layer.succeed(State, Effect.succeed(bootstrapState));
     const { url, authToken } = yield* deploy({
       // use the script name as the stage name (so the user can have multiple state stores)
       stage,

--- a/packages/alchemy/src/Cloudflare/StateStore/Store.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/Store.ts
@@ -1,15 +1,56 @@
+import * as Clock from "effect/Clock";
 import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
+import * as Result from "effect/Result";
 
 import { pipe } from "effect/Function";
+import { RuntimeContext } from "../../RuntimeContext.ts";
+import {
+  DEPLOYMENT_TTL_MILLIS,
+  endTransition,
+  isStaleOpen,
+  shouldAbandonOpen,
+  type DeploymentEvent,
+  type DeploymentMeta,
+  type DeploymentRecord,
+  type DeploymentSummary,
+} from "../../State/Deployment.ts";
 import type {
   ReplacedResourceState,
   ResourceState,
 } from "../../State/ResourceState.ts";
 import { encodeState } from "../../State/StateEncoding.ts";
+import {
+  aesCtrDecryptJson,
+  aesCtrEncryptJson,
+  importAesCtrKey,
+} from "../../Util/aes-ctr.ts";
+import { sha256 } from "../../Util/sha256.ts";
 import * as Secret from "../SecretsStore/index.ts";
 import { DurableObject } from "../Workers/DurableObject.ts";
 import { DurableObjectState } from "../Workers/DurableObjectState.ts";
+import {
+  CREATE_DEPLOYMENT_EVENTS_TABLE,
+  DEPLOYMENT_OPEN_PREFIX,
+  deploymentCounterKey,
+  deploymentOpenKey,
+  deploymentRecordKey,
+  deploymentStagePrefix,
+  INSERT_DEPLOYMENT_EVENT,
+  parseDeploymentOpenKey,
+  SELECT_DEPLOYMENT_MAX_SEQ,
+  selectDeploymentEventsSql,
+  toPublicDeploymentRecord,
+  type DeploymentAppendResult,
+  type DeploymentBeginResult,
+  type DeploymentEventRow,
+  type DeploymentGetResult,
+  type DeploymentListResult,
+  type DeploymentMutateResult,
+  type DeploymentOpenMarker,
+  type DeploymentReadEventsResult,
+  type StoredDeploymentRecord,
+} from "./Deployments.ts";
 import { EncryptionKey } from "./Token.ts";
 
 export default class Store extends DurableObject<Store>()(
@@ -26,59 +67,121 @@ export default class Store extends DurableObject<Store>()(
       const keyHex = yield* encryptionSecret
         .get()
         .pipe(Effect.map(Redacted.value), Effect.orDie);
-      const cryptoKey = yield* Effect.tryPromise(() =>
-        crypto.subtle.importKey(
-          "raw",
-          Buffer.from(keyHex, "hex"),
-          { name: "AES-CTR" },
-          false,
-          ["encrypt", "decrypt"],
-        ),
-      ).pipe(Effect.orDie);
+      const cryptoKey = yield* importAesCtrKey(keyHex);
 
       const encryptValue = (value: unknown) =>
-        Effect.tryPromise(async () => {
-          const plaintext = new TextEncoder().encode(
-            JSON.stringify(encodeState(value)),
-          );
-          const counter = crypto.getRandomValues(allocBytes(NONCE_BYTES));
-          const ct = new Uint8Array(
-            await crypto.subtle.encrypt(
-              { name: "AES-CTR", counter, length: 64 },
-              cryptoKey,
-              plaintext,
-            ),
-          );
-          // Frame as a single base64 string: nonce || ciphertext.
-          return Buffer.concat([counter, ct]).toString("base64");
-        }).pipe(Effect.orDie);
+        aesCtrEncryptJson(cryptoKey, encodeState(value));
 
-      const decryptEntry = (entry: string) =>
-        Effect.tryPromise(async () => {
-          const framed = Buffer.from(entry, "base64");
-          const counter = framed.subarray(0, NONCE_BYTES);
-          const ciphertext = framed.subarray(NONCE_BYTES);
-          let pt;
-          try {
-            pt = await crypto.subtle.decrypt(
-              { name: "AES-CTR", counter, length: 64 },
-              cryptoKey,
-              ciphertext,
-            );
-          } catch (error) {
-            // We return undefined here because in 2.0.0-beta.45, we rotated encryption keys unnecessarily.
-            // So, we catch a decryption error here and return undefined instead.
-            // The engine should reconcile, hopefully, but users may lose some data
-            console.error(
-              "Error decrypting entry. Returning undefined instead.",
-              error,
-            );
-            return undefined;
-          }
-          return JSON.parse(new TextDecoder().decode(pt)) as ResourceState;
-        }).pipe(Effect.orDie);
+      const decryptEntry = (
+        entry: string,
+      ): Effect.Effect<ResourceState | undefined> =>
+        aesCtrDecryptJson<ResourceState>(cryptoKey, entry).pipe(
+          Effect.catchTag("AesCtrDecryptError", (error) =>
+            Effect.sync(() => {
+              // We return undefined here because in 2.0.0-beta.45, we rotated encryption keys unnecessarily.
+              // So, we catch a decryption error here and return undefined instead.
+              // The engine should reconcile, hopefully, but users may lose some data
+              console.error(
+                "Error decrypting entry. Returning undefined instead.",
+                error,
+              );
+              return undefined;
+            }),
+          ),
+        );
+
+      // -- Deployment history (DeploymentStore backing) --------------
+      //
+      // Records live in KV under reserved `d\x00`/`dl\x00`/`dc\x00`
+      // prefixes; the event journal lives in `storage.sql` rows. Meta /
+      // summary / payloads are encrypted with the same AES-CTR key as
+      // resource rows. Unlike resource rows (which swallow decryption
+      // failures so the engine can reconcile), deployment history is
+      // read-only evidence — an unreadable record surfaces as a typed
+      // "corrupt" result instead of silently vanishing.
+      const ensureEventsTable = storage.sql
+        .exec(CREATE_DEPLOYMENT_EVENTS_TABLE)
+        .pipe(Effect.asVoid);
+
+      const readStoredDeployment = (stage: string, version: number) =>
+        storage.get<StoredDeploymentRecord>(
+          deploymentRecordKey(stage, version),
+        );
+
+      /**
+       * Fencing check (see StateWriteFence in State.ts): a head-state
+       * write carrying `fence: F` is rejected once any deployment
+       * version > F has been begun. The per-stage counter IS the newest
+       * allocated version, so the check is one hot storage-cache read.
+       * The DO input gate stays closed across the check and the write
+       * that follows, so fencing here is perfectly atomic.
+       */
+      const fenceViolated = (stage: string, fence: number | undefined) =>
+        fence === undefined
+          ? Effect.succeed(false)
+          : storage
+              .get<number>(deploymentCounterKey(stage))
+              .pipe(Effect.map((newest) => (newest ?? 0) > fence));
+
+      /** Decrypt meta/summary and strip internal fields. */
+      const toPublicDeployment = (stored: StoredDeploymentRecord) =>
+        Effect.gen(function* () {
+          const meta = yield* aesCtrDecryptJson<DeploymentMeta>(
+            cryptoKey,
+            stored.meta,
+          );
+          const summary =
+            stored.summary === undefined
+              ? undefined
+              : yield* aesCtrDecryptJson<DeploymentSummary>(
+                  cryptoKey,
+                  stored.summary,
+                );
+          return toPublicDeploymentRecord(stored, meta, summary);
+        });
 
       return {
+        /**
+         * (Both DOs) Reconcile TTL-expired open deployments to
+         * "abandoned" server-side. `begin` arms the alarm at the open's
+         * deadline; the handler closes stale opens across every stage
+         * and re-arms itself at the earliest remaining deadline.
+         */
+        alarm: () =>
+          Effect.gen(function* () {
+            const now = yield* Clock.currentTimeMillis;
+            const markers = yield* storage.list<DeploymentOpenMarker>({
+              prefix: DEPLOYMENT_OPEN_PREFIX,
+            });
+            let next: number | undefined;
+            for (const [key, marker] of markers) {
+              const stage = parseDeploymentOpenKey(key);
+              if (stage === undefined) continue;
+              const stored = yield* storage.get<StoredDeploymentRecord>(
+                deploymentRecordKey(stage, marker.version),
+              );
+              if (stored === undefined || stored.endedAt !== undefined) {
+                // Orphaned marker (record gone or already closed).
+                yield* storage.delete(key);
+                continue;
+              }
+              if (isStaleOpen(stored, now, stored.ttlMillis)) {
+                yield* storage.put(deploymentRecordKey(stage, marker.version), {
+                  ...stored,
+                  endedAt: now,
+                  outcome: "abandoned",
+                } satisfies StoredDeploymentRecord);
+                yield* storage.delete(key);
+              } else {
+                const deadline = stored.heartbeatAt + stored.ttlMillis;
+                next = next === undefined ? deadline : Math.min(next, deadline);
+              }
+            }
+            if (next !== undefined) {
+              yield* storage.setAlarm(next);
+            }
+          }).pipe(Effect.provide(RuntimeContext.phantom)),
+
         // -- Root DO methods -----------------------------------------
 
         /**
@@ -158,26 +261,33 @@ export default class Store extends DurableObject<Store>()(
             ),
 
         /**
-         * (Stack DO only) Persist a resource. Returns the stored
-         * value unchanged.
+         * (Stack DO only) Persist a resource. Returns the stored value,
+         * or a `fenced` result when the caller's lease is superseded —
+         * a discriminated value (not a thrown error) because the DO RPC
+         * stub serializes thrown errors lossily.
          */
-        set: ({
+        set: Effect.fn(function* ({
           stage,
           fqn,
           value,
+          fence,
         }: {
           stage: string;
           fqn: string;
           value: ResourceState;
-        }) =>
-          encryptValue(value).pipe(
-            Effect.flatMap((encrypted) =>
-              storage
-                .put<string>(resourceKey(stage, fqn), encrypted)
-                .pipe(Effect.asVoid),
-            ),
-            Effect.map(() => value),
-          ),
+          fence?: number;
+        }) {
+          // Encrypt BEFORE the fence check: crypto is a non-storage
+          // await that opens the DO input gate, so it must not sit
+          // between the check and the put (which are both storage ops
+          // and therefore atomic under the closed gate).
+          const encrypted = yield* encryptValue(value);
+          if (yield* fenceViolated(stage, fence)) {
+            return { _tag: "fenced" as const };
+          }
+          yield* storage.put<string>(resourceKey(stage, fqn), encrypted);
+          return { _tag: "ok" as const, value };
+        }),
 
         /**
          * (Stack DO only) Delete a resource. Idempotent.
@@ -187,8 +297,21 @@ export default class Store extends DurableObject<Store>()(
          * proxy the call, surfacing as "RPC receiver does not
          * implement the method 'delete'".
          */
-        remove: ({ stage, fqn }: { stage: string; fqn: string }) =>
-          storage.delete(resourceKey(stage, fqn)),
+        remove: Effect.fn(function* ({
+          stage,
+          fqn,
+          fence,
+        }: {
+          stage: string;
+          fqn: string;
+          fence?: number;
+        }) {
+          if (yield* fenceViolated(stage, fence)) {
+            return { _tag: "fenced" as const };
+          }
+          yield* storage.delete(resourceKey(stage, fqn));
+          return { _tag: "ok" as const };
+        }),
 
         /**
          * (Stack DO only) Delete every resource in this stack, or every
@@ -219,17 +342,26 @@ export default class Store extends DurableObject<Store>()(
 
         /**
          * (Stack DO only) Persist the resolved stack output for
-         * `stage`. Returns the stored value unchanged.
+         * `stage`. Returns the stored value, or a `fenced` result when
+         * the caller's lease is superseded (see `set`).
          */
-        setOutput: ({ stage, value }: { stage: string; value: any }) =>
-          encryptValue(value).pipe(
-            Effect.flatMap((encrypted) =>
-              storage
-                .put<string>(stackOutputKey(stage), encrypted)
-                .pipe(Effect.asVoid),
-            ),
-            Effect.map(() => value),
-          ),
+        setOutput: Effect.fn(function* ({
+          stage,
+          value,
+          fence,
+        }: {
+          stage: string;
+          value: any;
+          fence?: number;
+        }) {
+          // Encrypt before the fence check — see `set`.
+          const encrypted = yield* encryptValue(value);
+          if (yield* fenceViolated(stage, fence)) {
+            return { _tag: "fenced" as const };
+          }
+          yield* storage.put<string>(stackOutputKey(stage), encrypted);
+          return { _tag: "ok" as const, value };
+        }),
 
         /**
          * (Stack DO only) Return every resource in a stage whose
@@ -251,6 +383,481 @@ export default class Store extends DurableObject<Store>()(
               ),
             ),
           ),
+
+        /**
+         * (Stack DO only) Read every resource in a stage in one call —
+         * `fqn -> ResourceState`. Batch reader for the dashboard; kills
+         * the N+1 `listResources` + per-fqn `get` pattern.
+         */
+        getAll: ({ stage }: { stage: string }) =>
+          pipe(
+            storage.list<string>({ prefix: stagePrefix(stage) }),
+            Effect.flatMap((entries) =>
+              Effect.forEach(
+                [...entries.entries()],
+                ([key, entry]) =>
+                  (entry == null
+                    ? Effect.succeed(undefined)
+                    : decryptEntry(entry)
+                  ).pipe(
+                    Effect.map(
+                      (state) => [parseResourceKey(key)?.fqn, state] as const,
+                    ),
+                  ),
+                { concurrency: "unbounded" },
+              ),
+            ),
+            Effect.map((pairs) => {
+              const all: Record<string, ResourceState> = {};
+              for (const [fqn, state] of pairs) {
+                if (fqn !== undefined && state !== undefined) {
+                  all[fqn] = state;
+                }
+              }
+              return all;
+            }),
+          ),
+
+        // -- Stack DO deployment history -------------------------------
+        //
+        // Failures travel back as discriminated result values (not thrown
+        // tagged errors): Cloudflare's DO RPC stub serializes thrown
+        // errors lossily, so the worker maps these onto the schema-typed
+        // HTTP errors instead.
+
+        /**
+         * (Stack DO only) Allocate the next version for `(stack, stage)`
+         * and open it. Stale opens are reconciled to "abandoned" first;
+         * a live open loses the claim and is surfaced as `in-progress`.
+         */
+        deploymentBegin: Effect.fn(function* ({
+          stack,
+          stage,
+          meta,
+          ttlMillis,
+          supersede,
+        }: {
+          stack: string;
+          stage: string;
+          meta: DeploymentMeta;
+          ttlMillis?: number;
+          /**
+           * Targeted takeover: abandon exactly this open version even with
+           * a fresh heartbeat (the caller proved the holder is dead); any
+           * other live open still loses the claim.
+           */
+          supersede?: number;
+        }) {
+          const now = yield* Clock.currentTimeMillis;
+          const ttl = ttlMillis ?? DEPLOYMENT_TTL_MILLIS;
+          const token = yield* Effect.sync(() => crypto.randomUUID());
+          // Pre-compute ALL crypto outside the transaction: a non-storage
+          // await inside it would open the DO input gate mid-claim.
+          const tokenHash = yield* sha256(token);
+          const encryptedMeta = yield* aesCtrEncryptJson(cryptoKey, meta);
+
+          // The version-claim primitive: the DO is single-threaded per
+          // stack and `storage.transaction` makes the read-marker /
+          // bump-counter / write-record step atomic even across the
+          // storage await points, so two racing begins can never both
+          // allocate. (No blind-claim fast path here — begin is already a
+          // single client round trip; the marker/counter reads are hot
+          // in-DO storage-cache hits.)
+          const claim = yield* storage.transaction((txn) =>
+            Effect.gen(function* () {
+              const open = yield* txn.get<DeploymentOpenMarker>(
+                deploymentOpenKey(stage),
+              );
+              if (open !== undefined) {
+                const holder = yield* txn.get<StoredDeploymentRecord>(
+                  deploymentRecordKey(stage, open.version),
+                );
+                // Shared takeover semantics: stale heartbeat, or a targeted
+                // `supersede` of exactly this version.
+                if (
+                  holder !== undefined &&
+                  holder.endedAt === undefined &&
+                  !shouldAbandonOpen(holder, now, ttl, supersede)
+                ) {
+                  // Live open — the loser re-checks and fails in-progress.
+                  return {
+                    _tag: "conflict" as const,
+                    version: open.version,
+                  };
+                }
+                if (holder !== undefined && holder.endedAt === undefined) {
+                  // Stale open: reconcile to "abandoned" before allocating.
+                  yield* txn.put(deploymentRecordKey(stage, open.version), {
+                    ...holder,
+                    endedAt: now,
+                    outcome: "abandoned",
+                  } satisfies StoredDeploymentRecord);
+                }
+                yield* txn.delete(deploymentOpenKey(stage));
+              }
+              const version =
+                ((yield* txn.get<number>(deploymentCounterKey(stage))) ?? 0) +
+                1;
+              yield* txn.put(deploymentCounterKey(stage), version);
+              yield* txn.put(deploymentRecordKey(stage, version), {
+                v: 1,
+                stack,
+                stage,
+                version,
+                startedAt: now,
+                heartbeatAt: now,
+                ttlMillis: ttl,
+                tokenHash,
+                meta: encryptedMeta,
+              } satisfies StoredDeploymentRecord);
+              yield* txn.put(deploymentOpenKey(stage), {
+                version,
+                deadline: now + ttl,
+              } satisfies DeploymentOpenMarker);
+              // Server-side stale-open detection: fire at (or before)
+              // this open's deadline; the handler reconciles + re-arms.
+              const existingAlarm = yield* txn.getAlarm();
+              if (existingAlarm === null || existingAlarm > now + ttl) {
+                yield* txn.setAlarm(now + ttl);
+              }
+              return { _tag: "allocated" as const, version };
+            }),
+          );
+
+          if (claim._tag === "allocated") {
+            const ok: DeploymentBeginResult = {
+              _tag: "ok",
+              version: claim.version,
+              token,
+            };
+            return ok;
+          }
+          // Lost the claim: surface who holds the stage (sans token).
+          const holder = yield* readStoredDeployment(stage, claim.version);
+          if (holder === undefined) {
+            const corrupt: DeploymentBeginResult = {
+              _tag: "corrupt",
+              message: `open deployment v${claim.version} has no record`,
+            };
+            return corrupt;
+          }
+          const pub = yield* Effect.result(toPublicDeployment(holder));
+          const result: DeploymentBeginResult = Result.isSuccess(pub)
+            ? { _tag: "in-progress", holder: pub.success }
+            : { _tag: "corrupt", message: pub.failure.message };
+          return result;
+        }),
+
+        /**
+         * (Stack DO only) Append a batch of events to a deployment's
+         * journal. Idempotent per `seq` via `INSERT OR IGNORE`; appends
+         * after `end` are accepted (the token must still match).
+         */
+        deploymentAppendEvents: Effect.fn(function* ({
+          stage,
+          version,
+          token,
+          events,
+        }: {
+          stage: string;
+          version: number;
+          token: string;
+          events: readonly DeploymentEvent[];
+        }) {
+          const tokenHash = yield* sha256(token);
+          const rows = yield* Effect.forEach(events, (event) =>
+            aesCtrEncryptJson(cryptoKey, event.payload ?? null).pipe(
+              Effect.map((payload) => ({
+                seq: event.seq,
+                ts: event.ts,
+                fqn: event.fqn ?? null,
+                payload,
+              })),
+            ),
+          );
+          const stored = yield* readStoredDeployment(stage, version);
+          if (stored === undefined) {
+            const notFound: DeploymentAppendResult = { _tag: "not-found" };
+            return notFound;
+          }
+          if (stored.tokenHash !== tokenHash) {
+            const invalid: DeploymentAppendResult = { _tag: "invalid-token" };
+            return invalid;
+          }
+          yield* ensureEventsTable;
+          for (const row of rows) {
+            yield* storage.sql.exec(
+              INSERT_DEPLOYMENT_EVENT,
+              stage,
+              version,
+              row.seq,
+              row.ts,
+              row.fqn,
+              row.payload,
+            );
+          }
+          const cursor = yield* storage.sql.exec<{ ackedSeq: number }>(
+            SELECT_DEPLOYMENT_MAX_SEQ,
+            stage,
+            version,
+          );
+          const acked = yield* cursor.one();
+          const ok: DeploymentAppendResult = {
+            _tag: "ok",
+            ackedSeq: acked.ackedSeq,
+          };
+          return ok;
+        }),
+
+        /**
+         * (Stack DO only) Refresh the open marker's heartbeat. Silent
+         * no-op once the deployment has ended.
+         */
+        deploymentHeartbeat: Effect.fn(function* ({
+          stage,
+          version,
+          token,
+        }: {
+          stage: string;
+          version: number;
+          token: string;
+        }) {
+          const now = yield* Clock.currentTimeMillis;
+          const tokenHash = yield* sha256(token);
+          return yield* storage.transaction((txn) =>
+            Effect.gen(function* () {
+              const stored = yield* txn.get<StoredDeploymentRecord>(
+                deploymentRecordKey(stage, version),
+              );
+              if (stored === undefined) {
+                const notFound: DeploymentMutateResult = { _tag: "not-found" };
+                return notFound;
+              }
+              if (stored.tokenHash !== tokenHash) {
+                const invalid: DeploymentMutateResult = {
+                  _tag: "invalid-token",
+                };
+                return invalid;
+              }
+              const ok: DeploymentMutateResult = { _tag: "ok" };
+              if (stored.endedAt !== undefined) {
+                // Ended (possibly reconciled to "abandoned"): no-op.
+                return ok;
+              }
+              yield* txn.put(deploymentRecordKey(stage, version), {
+                ...stored,
+                heartbeatAt: now,
+              } satisfies StoredDeploymentRecord);
+              const open = yield* txn.get<DeploymentOpenMarker>(
+                deploymentOpenKey(stage),
+              );
+              if (open?.version === version) {
+                yield* txn.put(deploymentOpenKey(stage), {
+                  version,
+                  deadline: now + stored.ttlMillis,
+                } satisfies DeploymentOpenMarker);
+              }
+              return ok;
+            }),
+          );
+        }),
+
+        /**
+         * (Stack DO only) Close a deployment. Idempotent — the first
+         * outcome wins; ending an "abandoned" version records
+         * "completed-late".
+         */
+        deploymentEnd: Effect.fn(function* ({
+          stage,
+          version,
+          token,
+          outcome,
+          summary,
+        }: {
+          stage: string;
+          version: number;
+          token: string;
+          outcome: "succeeded" | "failed" | "interrupted";
+          // Readonly-friendly DeploymentSummary: the worker hands us the
+          // wire-decoded payload, whose record fields carry readonly
+          // index signatures.
+          summary?: {
+            readonly counts?: Readonly<Record<string, number>>;
+            readonly error?: string;
+          };
+        }) {
+          const now = yield* Clock.currentTimeMillis;
+          const tokenHash = yield* sha256(token);
+          const encryptedSummary =
+            summary === undefined
+              ? undefined
+              : yield* aesCtrEncryptJson(cryptoKey, summary);
+          return yield* storage.transaction((txn) =>
+            Effect.gen(function* () {
+              const stored = yield* txn.get<StoredDeploymentRecord>(
+                deploymentRecordKey(stage, version),
+              );
+              if (stored === undefined) {
+                const notFound: DeploymentMutateResult = { _tag: "not-found" };
+                return notFound;
+              }
+              if (stored.tokenHash !== tokenHash) {
+                const invalid: DeploymentMutateResult = {
+                  _tag: "invalid-token",
+                };
+                return invalid;
+              }
+              const ok: DeploymentMutateResult = { _tag: "ok" };
+              // Shared close semantics: first outcome wins, ending an
+              // "abandoned" version records "completed-late".
+              const wasOpen = stored.endedAt === undefined;
+              const nextOutcome = endTransition(stored, outcome);
+              if (nextOutcome === undefined) {
+                // Already ended with a real outcome: idempotent no-op.
+                return ok;
+              }
+              const next: StoredDeploymentRecord = {
+                ...stored,
+                endedAt: now,
+                outcome: nextOutcome,
+              };
+              if (encryptedSummary !== undefined) {
+                next.summary = encryptedSummary;
+              }
+              yield* txn.put(deploymentRecordKey(stage, version), next);
+              if (wasOpen) {
+                const open = yield* txn.get<DeploymentOpenMarker>(
+                  deploymentOpenKey(stage),
+                );
+                if (open?.version === version) {
+                  yield* txn.delete(deploymentOpenKey(stage));
+                }
+              }
+              return ok;
+            }),
+          );
+        }),
+
+        /**
+         * (Stack DO only) List deployment records newest-first with
+         * strictly-less-than `before` cursor pagination.
+         */
+        deploymentList: Effect.fn(function* ({
+          stage,
+          before,
+          limit,
+        }: {
+          stage: string;
+          before?: number;
+          limit?: number;
+        }) {
+          const entries = yield* storage.list<StoredDeploymentRecord>({
+            prefix: deploymentStagePrefix(stage),
+            reverse: true,
+            // `end` is exclusive, so this is exactly `version < before`.
+            ...(before !== undefined
+              ? { end: deploymentRecordKey(stage, before) }
+              : {}),
+            ...(limit !== undefined ? { limit } : {}),
+          });
+          const records: DeploymentRecord[] = [];
+          for (const stored of entries.values()) {
+            const pub = yield* Effect.result(toPublicDeployment(stored));
+            if (Result.isFailure(pub)) {
+              const corrupt: DeploymentListResult = {
+                _tag: "corrupt",
+                message: pub.failure.message,
+              };
+              return corrupt;
+            }
+            records.push(pub.success);
+          }
+          const ok: DeploymentListResult = { _tag: "ok", records };
+          return ok;
+        }),
+
+        /**
+         * (Stack DO only) Read one deployment record, or undefined.
+         */
+        deploymentGet: Effect.fn(function* ({
+          stage,
+          version,
+        }: {
+          stage: string;
+          version: number;
+        }) {
+          const stored = yield* readStoredDeployment(stage, version);
+          if (stored === undefined) {
+            const missing: DeploymentGetResult = {
+              _tag: "ok",
+              record: undefined,
+            };
+            return missing;
+          }
+          const pub = yield* Effect.result(toPublicDeployment(stored));
+          const result: DeploymentGetResult = Result.isSuccess(pub)
+            ? { _tag: "ok", record: pub.success }
+            : { _tag: "corrupt", message: pub.failure.message };
+          return result;
+        }),
+
+        /**
+         * (Stack DO only) Read a deployment's journal, seq-ascending,
+         * `fromSeq` inclusive.
+         */
+        deploymentReadEvents: Effect.fn(function* ({
+          stage,
+          version,
+          fromSeq,
+        }: {
+          stage: string;
+          version: number;
+          fromSeq?: number;
+        }) {
+          const stored = yield* readStoredDeployment(stage, version);
+          if (stored === undefined) {
+            const notFound: DeploymentReadEventsResult = { _tag: "not-found" };
+            return notFound;
+          }
+          yield* ensureEventsTable;
+          const cursor = yield* fromSeq === undefined
+            ? storage.sql.exec<DeploymentEventRow>(
+                selectDeploymentEventsSql(false),
+                stage,
+                version,
+              )
+            : storage.sql.exec<DeploymentEventRow>(
+                selectDeploymentEventsSql(true),
+                stage,
+                version,
+                fromSeq,
+              );
+          const rows = yield* cursor.toArray();
+          const events: DeploymentEvent[] = [];
+          for (const row of rows) {
+            const payload = yield* Effect.result(
+              aesCtrDecryptJson<unknown>(cryptoKey, row.payload),
+            );
+            if (Result.isFailure(payload)) {
+              const corrupt: DeploymentReadEventsResult = {
+                _tag: "corrupt",
+                message: payload.failure.message,
+              };
+              return corrupt;
+            }
+            const event: DeploymentEvent = {
+              seq: row.seq,
+              ts: row.ts,
+              payload: payload.success,
+            };
+            if (row.fqn !== null) {
+              event.fqn = row.fqn;
+            }
+            events.push(event);
+          }
+          const ok: DeploymentReadEventsResult = { _tag: "ok", events };
+          return ok;
+        }),
       };
     });
   }).pipe(Effect.provide(Secret.ReadSecretBinding)),
@@ -275,9 +882,6 @@ const STACK_OUTPUT_PREFIX = `o${SEP}`;
 /** Key prefix for stack-index entries in the root DO. */
 const STACK_INDEX_PREFIX = "s:";
 
-/** AES-CTR counter block length. */
-const NONCE_BYTES = 16;
-
 /** Build the resource key inside a *stack DO*. */
 const resourceKey = (stage: string, fqn: string) =>
   `${RESOURCE_PREFIX}${stage}${SEP}${fqn}`;
@@ -301,11 +905,3 @@ const parseResourceKey = (
   if (sep < 0) return undefined;
   return { stage: rest.slice(0, sep), fqn: rest.slice(sep + 1) };
 };
-
-/**
- * Allocate a `Uint8Array` over a fresh `ArrayBuffer` (not shared) so
- * the resulting buffer satisfies Web Crypto's `BufferSource` type
- * constraint under strict DOM typings.
- */
-const allocBytes = (size: number): Uint8Array<ArrayBuffer> =>
-  new Uint8Array(new ArrayBuffer(size));

--- a/packages/alchemy/src/Destroy.ts
+++ b/packages/alchemy/src/Destroy.ts
@@ -31,6 +31,8 @@ export const destroy = ({
         bindings: {},
         actions: {},
         output: {},
-      }).pipe(Effect.flatMap(Apply.apply)),
+      }).pipe(
+        Effect.flatMap((plan) => Apply.apply(plan, { command: "destroy" })),
+      ),
     { stage, dev, scope },
   );

--- a/packages/alchemy/src/State/Deployment.ts
+++ b/packages/alchemy/src/State/Deployment.ts
@@ -1,0 +1,397 @@
+import * as Data from "effect/Data";
+import type * as Effect from "effect/Effect";
+import type { StateStoreError } from "./State.ts";
+
+/**
+ * Deployment history — the durable spine of the dashboard (and any other
+ * frontend: TUI, native app). A state store that implements
+ * {@link DeploymentStore} records every deployment of a `(stack, stage)` as
+ * a monotonically-versioned, append-only journal of events plus an
+ * open/closed lifecycle record.
+ *
+ * Design invariants (the conformance suite in
+ * `test/State/deploymentStoreConformance.ts` enforces these against every
+ * backend):
+ *
+ * - **Versions are monotonic per `(stack, stage)`**, allocated atomically at
+ *   {@link DeploymentStore.begin}. Two racing `begin` calls never receive the
+ *   same version.
+ * - **At most one live deployment per `(stack, stage)`**: `begin` fails with
+ *   {@link DeploymentInProgress} while an open version's heartbeat is fresh.
+ *   Opens whose heartbeat is older than `ttlMillis` are reconciled to
+ *   `"abandoned"` by the next `begin`.
+ * - **Idempotent writes**: `appendEvents` dedupes by `seq` (retrying a batch
+ *   after a crash never duplicates events); `end` tolerates repeat calls and
+ *   already-abandoned versions (recorded as `"completed-late"`).
+ * - **Crash-safe without `end`**: the open marker carries a heartbeat; a
+ *   deploy that dies without calling `end` is detected and closed as
+ *   `"abandoned"` by the next `begin`.
+ */
+export interface DeploymentStore {
+  /**
+   * Allocate the next version for `(stack, stage)` and open it.
+   *
+   * Reconciles stale opens (heartbeat older than `ttlMillis`) as
+   * `"abandoned"` before allocating. Fails with {@link DeploymentInProgress}
+   * when a live open version exists.
+   */
+  begin(request: {
+    stack: string;
+    stage: string;
+    meta: DeploymentMeta;
+    /**
+     * Age in milliseconds after which an open deployment with no heartbeat
+     * is considered abandoned.
+     * @default 60_000
+     */
+    ttlMillis?: number;
+    /**
+     * Take over one specific open version: when the live open version is
+     * exactly `supersede`, it is reconciled to `"abandoned"` regardless of
+     * heartbeat freshness and the claim proceeds. Any OTHER live open still
+     * fails {@link DeploymentInProgress}.
+     *
+     * This is the targeted takeover primitive for the engine's same-host
+     * dead-pid recovery: the caller first observed `DeploymentInProgress`,
+     * proved the holder cannot be alive (same host, pid gone), and retries
+     * with the holder's version. Pinning the version (instead of a blanket
+     * `ttlMillis: 0`) makes the takeover race-free — if a different deploy
+     * claimed the stage in between, the versions no longer match and the
+     * retry fails {@link DeploymentInProgress} like any other begin.
+     */
+    supersede?: number;
+  }): Effect.Effect<
+    { version: number; token: string },
+    DeploymentInProgress | StateStoreError
+  >;
+
+  /**
+   * Append a batch of events to an open deployment's journal.
+   *
+   * Idempotent per `seq`: events whose `seq` has already been stored are
+   * ignored, so a crashed/retried batch never duplicates. Returns the
+   * highest stored `seq`. Appends to an ended deployment are accepted
+   * (journal completeness beats strictness — a deploy that lost its
+   * heartbeat may still be flushing), but the token must match.
+   */
+  appendEvents(request: {
+    stack: string;
+    stage: string;
+    version: number;
+    token: string;
+    events: readonly DeploymentEvent[];
+  }): Effect.Effect<
+    { ackedSeq: number },
+    DeploymentTokenInvalid | DeploymentNotFound | StateStoreError
+  >;
+
+  /**
+   * Refresh the open marker's heartbeat (liveness for concurrency control
+   * and crash detection). A heartbeat against an already-ended deployment
+   * is a silent no-op.
+   */
+  heartbeat(request: {
+    stack: string;
+    stage: string;
+    version: number;
+    token: string;
+  }): Effect.Effect<
+    void,
+    DeploymentTokenInvalid | DeploymentNotFound | StateStoreError
+  >;
+
+  /**
+   * Close a deployment. Idempotent: repeat calls with the same outcome are
+   * no-ops; ending a version that was already reconciled to `"abandoned"`
+   * records `"completed-late"` (preserving that the heartbeat was lost)
+   * rather than failing.
+   */
+  end(request: {
+    stack: string;
+    stage: string;
+    version: number;
+    token: string;
+    outcome: DeploymentEndOutcome;
+    summary?: DeploymentSummary;
+  }): Effect.Effect<
+    void,
+    DeploymentTokenInvalid | DeploymentNotFound | StateStoreError
+  >;
+
+  /**
+   * List deployment records for `(stack, stage)`, newest first. When
+   * `before` is given, only versions strictly less than it are returned
+   * (cursor pagination: pass the last record's version).
+   */
+  list(request: {
+    stack: string;
+    stage: string;
+    before?: number;
+    limit?: number;
+  }): Effect.Effect<readonly DeploymentRecord[], StateStoreError>;
+
+  /**
+   * Read a single deployment record, or `undefined` when the version does
+   * not exist.
+   */
+  get(request: {
+    stack: string;
+    stage: string;
+    version: number;
+  }): Effect.Effect<DeploymentRecord | undefined, StateStoreError>;
+
+  /**
+   * Read a deployment's journal ordered by `seq` ascending. `fromSeq` is
+   * inclusive; omit to read from the start.
+   */
+  readEvents(request: {
+    stack: string;
+    stage: string;
+    version: number;
+    fromSeq?: number;
+  }): Effect.Effect<
+    readonly DeploymentEvent[],
+    DeploymentNotFound | StateStoreError
+  >;
+}
+
+/**
+ * Who/what started a deployment — recorded at `begin`, immutable for the
+ * deployment's lifetime.
+ */
+export interface DeploymentMeta {
+  /** The engine command driving this deployment. */
+  command: "deploy" | "destroy";
+  /** Initiator identity for the Summary view's "who" column. */
+  initiator?: {
+    user?: string;
+    host?: string;
+    pid?: number;
+  };
+  /** Version of alchemy that ran the deployment. */
+  alchemyVersion?: string;
+  /** Git commit of the app repo, when resolvable. */
+  gitCommit?: string;
+}
+
+/**
+ * Terminal outcome supplied by the engine at {@link DeploymentStore.end}.
+ * Stores add `"abandoned"` (stale-open reconciliation) and
+ * `"completed-late"` (`end` after abandonment) on their own.
+ */
+export type DeploymentEndOutcome = "succeeded" | "failed" | "interrupted";
+
+export type DeploymentOutcome =
+  | DeploymentEndOutcome
+  | "abandoned"
+  | "completed-late";
+
+/** Optional rollup recorded at `end`, denormalized for cheap list views. */
+export interface DeploymentSummary {
+  /** Count per apply action, e.g. `{ create: 3, update: 1, delete: 0 }`. */
+  counts?: Record<string, number>;
+  /** Short digest of the failure, when `outcome` is `"failed"`. */
+  error?: string;
+}
+
+/**
+ * A deployment's lifecycle record. `endedAt`/`outcome` are absent while the
+ * deployment is open.
+ */
+export interface DeploymentRecord {
+  stack: string;
+  stage: string;
+  version: number;
+  meta: DeploymentMeta;
+  /** Epoch millis at `begin`. */
+  startedAt: number;
+  /** Epoch millis of the most recent heartbeat (or `begin`). */
+  heartbeatAt: number;
+  /** Epoch millis at close (engine `end` or store reconciliation). */
+  endedAt?: number;
+  outcome?: DeploymentOutcome;
+  summary?: DeploymentSummary;
+}
+
+/**
+ * One journaled event. The engine assigns `seq` (contiguous from 1 within a
+ * deployment) and stamps `ts` at emission. `fqn` identifies the resource for
+ * resource-scoped events and is absent for deployment-scoped ones
+ * (deployment-start/end, annotations).
+ *
+ * The `payload` is deliberately open at the storage layer: stores persist
+ * and return it verbatim. The engine-side event schema (op-start/op-end,
+ * status, note, log, annotation) is layered on top and versioned
+ * independently, so the storage contract never churns when the event
+ * vocabulary grows.
+ */
+export interface DeploymentEvent {
+  seq: number;
+  /** Epoch millis at emission (not receipt). */
+  ts: number;
+  fqn?: string;
+  payload: unknown;
+}
+
+/**
+ * A live deployment already holds `(stack, stage)`. Carries the holder's
+ * record so callers can render who is deploying and since when.
+ */
+export class DeploymentInProgress extends Data.TaggedError(
+  "DeploymentInProgress",
+)<{
+  stack: string;
+  stage: string;
+  holder: DeploymentRecord;
+}> {}
+
+/** The supplied token does not match the deployment's open token. */
+export class DeploymentTokenInvalid extends Data.TaggedError(
+  "DeploymentTokenInvalid",
+)<{
+  stack: string;
+  stage: string;
+  version: number;
+}> {}
+
+/** The referenced deployment version does not exist. */
+export class DeploymentNotFound extends Data.TaggedError("DeploymentNotFound")<{
+  stack: string;
+  stage: string;
+  version: number;
+}> {}
+
+/** Default heartbeat TTL for stale-open reconciliation. */
+export const DEPLOYMENT_TTL_MILLIS = 60_000;
+
+// ---------------------------------------------------------------------------
+// Shared implementation helpers
+//
+// Every DeploymentStore backend (in-memory, local FS, S3, Cloudflare DO)
+// enforces the same lifecycle semantics. The pure pieces of those semantics
+// live here so the backends only implement storage mechanics.
+// ---------------------------------------------------------------------------
+
+/**
+ * Internal record shape used by plaintext backends: the public record plus
+ * the open bearer token. Backends that store the token differently (e.g.
+ * the Cloudflare DO stores only a hash) define their own stored shape.
+ */
+export interface StoredDeploymentRecord extends DeploymentRecord {
+  token: string;
+}
+
+/** Strip the token and deep-copy so callers never alias internal state. */
+export const toPublicRecord = (
+  record: StoredDeploymentRecord,
+): DeploymentRecord => {
+  const { token: _token, ...rest } = record;
+  return structuredClone(rest);
+};
+
+/**
+ * An open record whose heartbeat is at least `ttlMillis` old is stale and
+ * gets reconciled to `"abandoned"` (by the next `begin`, or server-side
+ * where the backend supports it). `ttlMillis: 0` therefore means "always
+ * stale"; an ended record is never stale.
+ */
+export const isStaleOpen = (
+  record: Pick<DeploymentRecord, "endedAt" | "heartbeatAt">,
+  now: number,
+  ttlMillis: number,
+): boolean =>
+  record.endedAt === undefined && now - record.heartbeatAt >= ttlMillis;
+
+/**
+ * May a `begin` abandon this open holder and claim the next version?
+ *
+ * Yes when the holder is stale ({@link isStaleOpen} — its heartbeat
+ * lapsed), OR when the caller passed `supersede` naming exactly this
+ * version: a targeted takeover where the caller proved out-of-band that
+ * the holder is dead (e.g. same-host pid check), so even a fresh
+ * heartbeat does not protect it. Any other live open wins and the begin
+ * fails `DeploymentInProgress`.
+ *
+ * Every store MUST use this predicate (inside whatever atomic claim
+ * primitive it has) so takeover semantics never drift between backends.
+ */
+export const shouldAbandonOpen = (
+  record: Pick<DeploymentRecord, "endedAt" | "heartbeatAt" | "version">,
+  now: number,
+  ttlMillis: number,
+  supersede: number | undefined,
+): boolean =>
+  isStaleOpen(record, now, ttlMillis) || record.version === supersede;
+
+/**
+ * The shared `end` transition: which outcome (if any) to record when the
+ * engine closes a deployment.
+ *
+ * - Still open — record the engine's outcome.
+ * - Already reconciled to `"abandoned"` — the engine finished after the
+ *   store gave up on its heartbeat; preserve that fact as
+ *   `"completed-late"`.
+ * - Already ended with a real outcome — idempotent no-op (`undefined`),
+ *   the first outcome wins.
+ */
+export const endTransition = (
+  record: Pick<DeploymentRecord, "endedAt" | "outcome">,
+  outcome: DeploymentEndOutcome,
+): DeploymentOutcome | undefined =>
+  record.endedAt === undefined
+    ? outcome
+    : record.outcome === "abandoned"
+      ? "completed-late"
+      : undefined;
+
+/** Highest seq in a batch (0 for an empty batch). */
+export const maxSeqOf = (events: readonly DeploymentEvent[]): number =>
+  events.reduce((max, event) => (event.seq > max ? event.seq : max), 0);
+
+/**
+ * Per-instance hint cache powering the blind-claim fast path in `begin`
+ * (S3 and local FS; single-arbiter stores don't need it).
+ *
+ * The invariant it encodes: versions are allocated contiguously and never
+ * deleted, so if this instance's own `end` closed version N, an atomic
+ * exclusive-create of N+1 succeeding PROVES no newer version — and
+ * therefore no live open — exists, skipping the full observe loop.
+ *
+ * Policy (identical across stores, so decided once here):
+ * - the hint is **single-shot**: `take` consumes it, so a failed claim can
+ *   never be retried blindly — the caller falls back to the observe loop,
+ *   which re-seeds nothing until the next `end`;
+ * - `noteClosed` only advances: a late `end` of an old abandoned version
+ *   never rolls the stage's high-water mark backwards;
+ * - `invalidate` clears the hint when a version is observed OPEN (the
+ *   fast path only applies after our own `end` closes it again).
+ */
+export class ClosedVersionHint {
+  private readonly newest = new Map<string, number>();
+
+  private key(ids: { stack: string; stage: string }): string {
+    return `${ids.stack}\u0000${ids.stage}`;
+  }
+
+  /** Consume the hint for `(stack, stage)` — single-shot. */
+  take(ids: { stack: string; stage: string }): number | undefined {
+    const key = this.key(ids);
+    const version = this.newest.get(key);
+    this.newest.delete(key);
+    return version;
+  }
+
+  /** Record that `version` is closed. Never rolls backwards. */
+  noteClosed(ids: { stack: string; stage: string }, version: number): void {
+    const key = this.key(ids);
+    const prev = this.newest.get(key);
+    if (prev === undefined || version > prev) {
+      this.newest.set(key, version);
+    }
+  }
+
+  /** Drop the hint — a version was observed open. */
+  invalidate(ids: { stack: string; stage: string }): void {
+    this.newest.delete(this.key(ids));
+  }
+}

--- a/packages/alchemy/src/State/DeploymentSession.ts
+++ b/packages/alchemy/src/State/DeploymentSession.ts
@@ -1,0 +1,376 @@
+import * as Clock from "effect/Clock";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as Schedule from "effect/Schedule";
+import type * as Scope from "effect/Scope";
+import type { ApplyEvent } from "../Cli/Event.ts";
+import type {
+  DeploymentEndOutcome,
+  DeploymentEvent,
+  DeploymentInProgress,
+  DeploymentMeta,
+  DeploymentSummary,
+} from "./Deployment.ts";
+import type { PersistedState, StateService, StateStoreError } from "./State.ts";
+
+/**
+ * The engine-side composition over {@link DeploymentStore}: one open
+ * deployment version, a batched journal tee for apply events, a heartbeat
+ * keeping the open marker live, and a {@link StateService} facade that
+ * journals every engine state write alongside the head-state write.
+ *
+ * Robustness invariants:
+ * - **`begin` is fail-closed.** It is the mutual-exclusion gate for the
+ *   apply, so every failure aborts the deploy: {@link DeploymentInProgress}
+ *   (a live holder exists) and `StateStoreError` (the store could not prove
+ *   exclusivity) both propagate. A deploy never proceeds without the lock.
+ * - **Once open, journaling must never fail or stall the deploy**: journal
+ *   writes (append/heartbeat/end) are fire-and-forget with bounded retry;
+ *   store errors are logged (`Effect.logWarning`) and swallowed. Losing the
+ *   journal mid-flight loses observability, not correctness — the version
+ *   was already claimed.
+ * - Stores without `deployments` support (older/third-party) yield a no-op
+ *   session: `version` is `undefined`, `state` is the store itself, and
+ *   `emit`/`end` do nothing.
+ * - The session is Scope-owned: if the scope closes before {@link end} was
+ *   called (crash/interrupt path), the deployment is closed as
+ *   `"interrupted"` by a finalizer backstop.
+ */
+export interface DeploymentSession {
+  /**
+   * The deployment version allocated by `begin`, or `undefined` when the
+   * store has no deployments support (no-op session).
+   */
+  readonly version: number | undefined;
+  /**
+   * A {@link StateService} facade over the real store: `set`/`delete`/
+   * `setOutput` for this session's `(stack, stage)` additionally journal a
+   * status-level record (see {@link DeploymentStateSetPayload}); everything
+   * else delegates untouched. For no-op sessions this IS the underlying
+   * store.
+   */
+  readonly state: StateService;
+  /**
+   * Journal an apply event. Stamps the next `seq`, buffers, and flushes in
+   * batches (every {@link FLUSH_INTERVAL} or {@link FLUSH_MAX_EVENTS}
+   * events, whichever comes first). Never fails; events emitted after
+   * {@link end} are dropped.
+   */
+  emit(event: ApplyEvent): Effect.Effect<void>;
+  /**
+   * Close the deployment: journals a `deployment-end` event, flushes the
+   * remaining buffer (bounded ~3s), stops the heartbeat, and records the
+   * outcome via `deployments.end`. Idempotent — the first call wins and
+   * subsequent calls are no-ops. Never fails.
+   */
+  end(
+    outcome: DeploymentEndOutcome,
+    summary?: DeploymentSummary,
+  ): Effect.Effect<void>;
+}
+
+/** Journal payload for the session-lifecycle bookends. */
+export interface DeploymentStartPayload {
+  kind: "deployment-start";
+  command: DeploymentMeta["command"];
+}
+
+export interface DeploymentEndPayload {
+  kind: "deployment-end";
+  outcome: DeploymentEndOutcome;
+  summary?: DeploymentSummary;
+}
+
+/**
+ * Journal payload for an engine state write teed by the facade. Carries
+ * ONLY status-level info (never full props/attr bodies — those live in head
+ * state) plus a `before` snapshot of the prior status when a row existed.
+ */
+export interface DeploymentStateSetPayload {
+  kind: "state-set";
+  fqn: string;
+  status: string;
+  before?: { status: string };
+}
+
+export interface DeploymentStateDeletePayload {
+  kind: "state-delete";
+  fqn: string;
+  before?: { status: string };
+}
+
+export interface DeploymentOutputSetPayload {
+  kind: "output-set";
+}
+
+/**
+ * Everything a {@link DeploymentSession} writes into the journal. Apply
+ * events are journaled verbatim as payloads (the envelope duplicates their
+ * `ts`/`fqn` for cheap store-side filtering).
+ */
+export type DeploymentSessionPayload =
+  | DeploymentStartPayload
+  | DeploymentEndPayload
+  | DeploymentStateSetPayload
+  | DeploymentStateDeletePayload
+  | DeploymentOutputSetPayload
+  | ApplyEvent;
+
+/** Flush the journal buffer at least this often. */
+const FLUSH_INTERVAL = "1 second";
+/** ... or as soon as this many events are buffered, whichever comes first. */
+const FLUSH_MAX_EVENTS = 50;
+/** Heartbeat cadence for the open marker (TTL default is 60s). */
+const HEARTBEAT_INTERVAL = "10 seconds";
+/** How long `end` waits for the final flush before giving up on it. */
+const END_FLUSH_BUDGET = "3 seconds";
+
+/**
+ * Open a {@link DeploymentSession} for `(stack, stage)` against `store`.
+ *
+ * Feature-detects `store.deployments`: absent → a no-op session (version
+ * `undefined`, `state === store`, `emit`/`end` are `Effect.void`). Present →
+ * `begin`s a new version ({@link DeploymentInProgress} propagates — that is
+ * the concurrent-deploy protection), journals a `deployment-start` event as
+ * seq 1, forks a Scope-owned heartbeat and interval flusher, and registers a
+ * finalizer that closes the deployment as `"interrupted"` if the scope ends
+ * before {@link DeploymentSession.end} was called.
+ */
+export const makeDeploymentSession: (options: {
+  store: StateService;
+  stack: string;
+  stage: string;
+  meta: DeploymentMeta;
+  /**
+   * Targeted takeover — passed through to `deployments.begin`. Abandons
+   * exactly this open version (the caller proved the holder is dead)
+   * before claiming; any other live open still fails
+   * {@link DeploymentInProgress}.
+   */
+  supersede?: number;
+}) => Effect.Effect<
+  DeploymentSession,
+  DeploymentInProgress | StateStoreError,
+  Scope.Scope
+> = Effect.fn("makeDeploymentSession")(function* (options: {
+  store: StateService;
+  stack: string;
+  stage: string;
+  meta: DeploymentMeta;
+  supersede?: number;
+}) {
+  const { store, stack, stage, meta, supersede } = options;
+  const deployments = store.deployments;
+
+  if (deployments === undefined) {
+    // Third-party / older store: journaling is a total no-op.
+    const noop: DeploymentSession = {
+      version: undefined,
+      state: store,
+      emit: () => Effect.void,
+      end: () => Effect.void,
+    };
+    return noop;
+  }
+
+  const { version, token } = yield* deployments.begin({
+    stack,
+    stage,
+    meta,
+    supersede,
+  });
+
+  const warn = (what: string) => (cause: unknown) =>
+    Effect.logWarning(
+      `alchemy: deployment journal ${what} failed for ${stack}/${stage} v${version} (deploy unaffected)`,
+      cause,
+    );
+
+  // ── journal buffer ──────────────────────────────────────────────────────
+  // seq is a monotonic in-session counter starting at 1 (deployment-start).
+  // The buffer is drained by the interval flusher, the size threshold, and
+  // `end`. Batches are disjoint (the splice below is synchronous), and
+  // `appendEvents` is idempotent per seq, so overlapping flushes are safe.
+  let nextSeq = 1;
+  let buffer: DeploymentEvent[] = [];
+  let ended = false;
+
+  const flush: Effect.Effect<void> = Effect.suspend(() => {
+    if (buffer.length === 0) {
+      return Effect.void;
+    }
+    const batch = buffer;
+    buffer = [];
+    return deployments
+      .appendEvents({ stack, stage, version, token, events: batch })
+      .pipe(
+        Effect.retry({ times: 2 }),
+        Effect.asVoid,
+        Effect.catchCause(warn("append")),
+      );
+  });
+
+  /** Buffer one journal event (fire-and-forget; dropped after `end`). */
+  const enqueue = (event: Omit<DeploymentEvent, "seq">) =>
+    Effect.suspend(() => {
+      if (ended) {
+        return Effect.void;
+      }
+      buffer.push({ seq: nextSeq++, ...event });
+      return buffer.length >= FLUSH_MAX_EVENTS ? flush : Effect.void;
+    });
+
+  /** Journal a session/state payload, stamping `ts` at enqueue time. */
+  const journal = (payload: DeploymentSessionPayload, fqn?: string) =>
+    Effect.flatMap(Clock.currentTimeMillis, (ts) =>
+      enqueue({ ts, fqn, payload }),
+    );
+
+  // seq 1: the deployment-start bookend.
+  yield* journal({ kind: "deployment-start", command: meta.command });
+
+  const emit = (event: ApplyEvent) =>
+    // Apply events already carry their emission ts — mirror it onto the
+    // journal envelope instead of re-stamping at enqueue time.
+    typeof event.ts === "number"
+      ? enqueue({ ts: event.ts, fqn: event.fqn, payload: event })
+      : journal(event, event.fqn);
+
+  const end = (
+    outcome: DeploymentEndOutcome,
+    summary?: DeploymentSummary,
+  ): Effect.Effect<void> =>
+    Effect.gen(function* () {
+      if (ended) {
+        return;
+      }
+      // Latch synchronously so a concurrent end() (or the scope finalizer
+      // racing an explicit call) can never double-close.
+      ended = true;
+      const ts = yield* Clock.currentTimeMillis;
+      buffer.push({
+        seq: nextSeq++,
+        ts,
+        payload: {
+          kind: "deployment-end",
+          outcome,
+          ...(summary !== undefined ? { summary } : {}),
+        } satisfies DeploymentEndPayload,
+      });
+      yield* Fiber.interrupt(heartbeatFiber);
+      yield* flush.pipe(
+        Effect.timeout(END_FLUSH_BUDGET),
+        Effect.catchCause(warn("final flush")),
+      );
+      yield* deployments
+        .end({ stack, stage, version, token, outcome, summary })
+        .pipe(Effect.catchCause(warn("end")));
+    });
+
+  // Backstop: a scope that closes without end() (crash, interrupt, dev-mode
+  // swallowed failure) still closes the deployment record. Registered BEFORE
+  // the fibers are forked so it runs AFTER they are interrupted (finalizers
+  // are LIFO) — the final flush never races the interval flusher.
+  yield* Effect.addFinalizer(() => end("interrupted"));
+
+  const heartbeatFiber = yield* Effect.forkScoped(
+    deployments
+      .heartbeat({ stack, stage, version, token })
+      .pipe(
+        Effect.catchCause(warn("heartbeat")),
+        Effect.repeat(Schedule.spaced(HEARTBEAT_INTERVAL)),
+      ),
+  );
+
+  yield* Effect.forkScoped(
+    Effect.gen(function* () {
+      for (;;) {
+        yield* Effect.sleep(FLUSH_INTERVAL);
+        yield* flush;
+      }
+    }),
+  );
+
+  // ── the state facade ────────────────────────────────────────────────────
+  // Same StateService, but engine writes for THIS (stack, stage) also leave
+  // a status-level journal record AND carry the session's version as a
+  // fencing token (see StateWriteFence in State.ts): if a newer deployment
+  // has begun — this session is a zombie whose lease lapsed — the store
+  // rejects the write and the failure aborts the stale apply. The
+  // before-image read is best-effort: journaling must never fail (or
+  // reorder) the head write.
+  const priorStatus = (request: {
+    stack: string;
+    stage: string;
+    fqn: string;
+  }) =>
+    store.get(request).pipe(
+      Effect.map((prior) =>
+        prior === undefined ? undefined : { status: String(prior.status) },
+      ),
+      Effect.orElseSucceed(() => undefined),
+    );
+
+  const mine = (request: { stack: string; stage: string }) =>
+    request.stack === stack && request.stage === stage && !ended;
+
+  const facade: StateService = {
+    ...store,
+    set: <V extends PersistedState>(request: {
+      stack: string;
+      stage: string;
+      fqn: string;
+      value: V;
+    }) =>
+      Effect.gen(function* () {
+        if (!mine(request)) {
+          return yield* store.set(request);
+        }
+        const before = yield* priorStatus(request);
+        const value = yield* store.set({ ...request, fence: version });
+        yield* journal(
+          {
+            kind: "state-set",
+            fqn: request.fqn,
+            status: String(request.value.status),
+            ...(before !== undefined ? { before } : {}),
+          },
+          request.fqn,
+        );
+        return value;
+      }),
+    delete: (request) =>
+      Effect.gen(function* () {
+        if (!mine(request)) {
+          return yield* store.delete(request);
+        }
+        const before = yield* priorStatus(request);
+        yield* store.delete({ ...request, fence: version });
+        yield* journal(
+          {
+            kind: "state-delete",
+            fqn: request.fqn,
+            ...(before !== undefined ? { before } : {}),
+          },
+          request.fqn,
+        );
+      }),
+    setOutput: (request) =>
+      Effect.gen(function* () {
+        if (!mine(request)) {
+          return yield* store.setOutput(request);
+        }
+        const value = yield* store.setOutput({ ...request, fence: version });
+        yield* journal({ kind: "output-set" });
+        return value;
+      }),
+  };
+
+  const session: DeploymentSession = {
+    version,
+    state: facade,
+    emit,
+    end,
+  };
+  return session;
+});

--- a/packages/alchemy/src/State/HttpStateApi.ts
+++ b/packages/alchemy/src/State/HttpStateApi.ts
@@ -86,6 +86,28 @@ const ResourceKey = Schema.Struct({
   fqn: Schema.String,
 });
 
+/**
+ * Optional fencing token on head-state writes — the deployment version
+ * whose lease authorizes the write (see `StateWriteFence` in State.ts).
+ * Travels as a query param because the write payloads are the raw
+ * state values themselves.
+ */
+const FenceQuery = Schema.Struct({
+  fence: Schema.optional(Schema.Number),
+});
+
+/**
+ * A fenced head-state write lost its lease: a deployment newer than
+ * `fence` has been begun. 412 Precondition Failed — decoded by the
+ * client into the `fencedWriteRejected` StateStoreError. Never
+ * retryable: the writer's lease is gone for good.
+ */
+export const StateWriteFencedWire = Schema.TaggedStruct("StateWriteFenced", {
+  stack: Schema.String,
+  stage: Schema.String,
+  fence: Schema.Number,
+}).pipe(HttpApiSchema.status(412));
+
 export const ListStacks = HttpApiEndpoint.get("listStacks", "/state/stacks", {
   success: Schema.Array(Schema.String),
 });
@@ -122,8 +144,10 @@ export const SetState = HttpApiEndpoint.put(
   "/state/stacks/:stack/stages/:stage/resources/:fqn",
   {
     params: ResourceKey,
+    query: FenceQuery,
     payload: ResourceStateSchema,
     success: ResourceStateSchema,
+    error: StateWriteFencedWire,
   },
 );
 
@@ -132,7 +156,9 @@ export const DeleteState = HttpApiEndpoint.delete(
   "/state/stacks/:stack/stages/:stage/resources/:fqn",
   {
     params: ResourceKey,
+    query: FenceQuery,
     success: HttpApiSchema.NoContent,
+    error: StateWriteFencedWire,
   },
 );
 
@@ -169,7 +195,235 @@ export const SetStackOutput = HttpApiEndpoint.put(
   "/state/stacks/:stack/stages/:stage/output",
   {
     params: StackStage,
+    query: FenceQuery,
     payload: ResourceStateSchema,
+    success: ResourceStateSchema,
+    error: StateWriteFencedWire,
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Deployment history (DeploymentStore) wire contract
+// ---------------------------------------------------------------------------
+
+/** Wire shape of {@link DeploymentMeta}. */
+export const DeploymentMetaWire = Schema.Struct({
+  command: Schema.Literals(["deploy", "destroy"]),
+  initiator: Schema.optional(
+    Schema.Struct({
+      user: Schema.optional(Schema.String),
+      host: Schema.optional(Schema.String),
+      pid: Schema.optional(Schema.Number),
+    }),
+  ),
+  alchemyVersion: Schema.optional(Schema.String),
+  gitCommit: Schema.optional(Schema.String),
+});
+
+/** Wire shape of {@link DeploymentSummary}. */
+export const DeploymentSummaryWire = Schema.Struct({
+  counts: Schema.optional(Schema.Record(Schema.String, Schema.Number)),
+  error: Schema.optional(Schema.String),
+});
+
+/**
+ * Wire shape of {@link DeploymentRecord}. Deliberately excludes the bearer
+ * token: records returned by list/get/read (and the `holder` carried by
+ * `DeploymentInProgress`) must never expose another deploy's capability.
+ */
+export const DeploymentRecordWire = Schema.Struct({
+  stack: Schema.String,
+  stage: Schema.String,
+  version: Schema.Number,
+  meta: DeploymentMetaWire,
+  startedAt: Schema.Number,
+  heartbeatAt: Schema.Number,
+  endedAt: Schema.optional(Schema.Number),
+  outcome: Schema.optional(
+    Schema.Literals([
+      "succeeded",
+      "failed",
+      "interrupted",
+      "abandoned",
+      "completed-late",
+    ]),
+  ),
+  summary: Schema.optional(DeploymentSummaryWire),
+});
+
+/** Wire shape of {@link DeploymentEvent} — the payload travels verbatim. */
+export const DeploymentEventWire = Schema.Struct({
+  seq: Schema.Number,
+  ts: Schema.Number,
+  fqn: Schema.optional(Schema.String),
+  payload: Schema.Unknown,
+});
+
+/**
+ * `begin` conflict: a live deployment already holds `(stack, stage)`.
+ * 409 Conflict — decoded by the client into the typed
+ * `DeploymentInProgress` error and passed through untouched (it must never
+ * be retried as if it were a transport blip).
+ */
+export const DeploymentInProgressWire = Schema.TaggedStruct(
+  "DeploymentInProgress",
+  {
+    stack: Schema.String,
+    stage: Schema.String,
+    holder: DeploymentRecordWire,
+  },
+).pipe(HttpApiSchema.status(409));
+
+/** The supplied token does not match the deployment's open token. 403. */
+export const DeploymentTokenInvalidWire = Schema.TaggedStruct(
+  "DeploymentTokenInvalid",
+  {
+    stack: Schema.String,
+    stage: Schema.String,
+    version: Schema.Number,
+  },
+).pipe(HttpApiSchema.status(403));
+
+/**
+ * The referenced deployment version does not exist. 410 Gone — deliberately
+ * NOT 404, so a real missing-version error can never be confused with the
+ * transient 404s a freshly-deployed worker serves while its route
+ * propagates (those must stay retryable at the transport layer).
+ */
+export const DeploymentNotFoundWire = Schema.TaggedStruct(
+  "DeploymentNotFound",
+  {
+    stack: Schema.String,
+    stage: Schema.String,
+    version: Schema.Number,
+  },
+).pipe(HttpApiSchema.status(410));
+
+/**
+ * Deployment data at rest failed to decrypt (wrong key or corrupt data).
+ * 422 (not 5xx) so corrupt-at-rest data fails fast instead of being
+ * retried as a transient server error; the client folds it into
+ * `StateStoreError`.
+ */
+export const DeploymentCorruptWire = Schema.TaggedStruct("DeploymentCorrupt", {
+  message: Schema.String,
+}).pipe(HttpApiSchema.status(422));
+
+/** `(stack, stage, version)` path segments for a single deployment. */
+const DeploymentKey = Schema.Struct({
+  stack: Schema.String,
+  stage: Schema.String,
+  version: Schema.Number,
+});
+
+export const BeginDeployment = HttpApiEndpoint.post(
+  "beginDeployment",
+  "/state/stacks/:stack/stages/:stage/deployments",
+  {
+    params: StackStage,
+    payload: Schema.Struct({
+      meta: DeploymentMetaWire,
+      ttlMillis: Schema.optional(Schema.Number),
+      supersede: Schema.optional(Schema.Number),
+    }).pipe(HttpApiSchema.asJson()),
+    success: Schema.Struct({
+      version: Schema.Number,
+      token: Schema.String,
+    }),
+    error: [DeploymentInProgressWire, DeploymentCorruptWire],
+  },
+);
+
+export const AppendDeploymentEvents = HttpApiEndpoint.post(
+  "appendDeploymentEvents",
+  "/state/stacks/:stack/stages/:stage/deployments/:version/events",
+  {
+    params: DeploymentKey,
+    payload: Schema.Struct({
+      token: Schema.String,
+      events: Schema.Array(DeploymentEventWire),
+    }).pipe(HttpApiSchema.asJson()),
+    success: Schema.Struct({ ackedSeq: Schema.Number }),
+    error: [DeploymentTokenInvalidWire, DeploymentNotFoundWire],
+  },
+);
+
+export const HeartbeatDeployment = HttpApiEndpoint.post(
+  "heartbeatDeployment",
+  "/state/stacks/:stack/stages/:stage/deployments/:version/heartbeat",
+  {
+    params: DeploymentKey,
+    payload: Schema.Struct({ token: Schema.String }).pipe(
+      HttpApiSchema.asJson(),
+    ),
+    success: HttpApiSchema.NoContent,
+    error: [DeploymentTokenInvalidWire, DeploymentNotFoundWire],
+  },
+);
+
+export const EndDeployment = HttpApiEndpoint.post(
+  "endDeployment",
+  "/state/stacks/:stack/stages/:stage/deployments/:version/end",
+  {
+    params: DeploymentKey,
+    payload: Schema.Struct({
+      token: Schema.String,
+      outcome: Schema.Literals(["succeeded", "failed", "interrupted"]),
+      summary: Schema.optional(DeploymentSummaryWire),
+    }).pipe(HttpApiSchema.asJson()),
+    success: HttpApiSchema.NoContent,
+    error: [DeploymentTokenInvalidWire, DeploymentNotFoundWire],
+  },
+);
+
+export const ListDeployments = HttpApiEndpoint.get(
+  "listDeployments",
+  "/state/stacks/:stack/stages/:stage/deployments",
+  {
+    params: StackStage,
+    query: Schema.Struct({
+      before: Schema.optional(Schema.Number),
+      limit: Schema.optional(Schema.Number),
+    }),
+    success: Schema.Array(DeploymentRecordWire),
+    error: DeploymentCorruptWire,
+  },
+);
+
+export const GetDeployment = HttpApiEndpoint.get(
+  "getDeployment",
+  "/state/stacks/:stack/stages/:stage/deployments/:version",
+  {
+    params: DeploymentKey,
+    success: Schema.UndefinedOr(DeploymentRecordWire),
+    error: DeploymentCorruptWire,
+  },
+);
+
+export const ReadDeploymentEvents = HttpApiEndpoint.get(
+  "readDeploymentEvents",
+  "/state/stacks/:stack/stages/:stage/deployments/:version/events",
+  {
+    params: DeploymentKey,
+    query: Schema.Struct({
+      fromSeq: Schema.optional(Schema.Number),
+    }),
+    success: Schema.Array(DeploymentEventWire),
+    error: [DeploymentNotFoundWire, DeploymentCorruptWire],
+  },
+);
+
+/**
+ * Batch read of every resource in a stage — `fqn -> PersistedState`.
+ * Kills the N+1 `list` + per-fqn `get` pattern for dashboard readers.
+ * Lives under `/all` (not `/resources/:fqn`) so it can never be shadowed
+ * by an fqn literally named "all".
+ */
+export const GetAllStates = HttpApiEndpoint.get(
+  "getAllStates",
+  "/state/stacks/:stack/stages/:stage/all",
+  {
+    params: StackStage,
     success: ResourceStateSchema,
   },
 );
@@ -183,7 +437,7 @@ export const SetStackOutput = HttpApiEndpoint.put(
  * compare against this constant; a mismatch (or 404) triggers a
  * forced redeploy via the bootstrap flow.
  */
-export const STATE_STORE_VERSION = 5 as const;
+export const STATE_STORE_VERSION = 6 as const;
 
 /** Response shape for the unauthenticated `/version` probe. */
 export const VersionResponse = Schema.Struct({
@@ -211,6 +465,14 @@ export class StateGroup extends HttpApiGroup.make("state")
   .add(DeleteStack)
   .add(GetStackOutput)
   .add(SetStackOutput)
+  .add(GetAllStates)
+  .add(BeginDeployment)
+  .add(AppendDeploymentEvents)
+  .add(HeartbeatDeployment)
+  .add(EndDeployment)
+  .add(ListDeployments)
+  .add(GetDeployment)
+  .add(ReadDeploymentEvents)
   .middleware(StateAuth) {}
 
 export class VersionGroup extends HttpApiGroup.make("version").add(

--- a/packages/alchemy/src/State/HttpStateStore.ts
+++ b/packages/alchemy/src/State/HttpStateStore.ts
@@ -4,10 +4,23 @@ import * as Schedule from "effect/Schedule";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
 import * as HttpApiClient from "effect/unstable/httpapi/HttpApiClient";
-import { StateApi } from "./HttpStateApi.ts";
+import {
+  DeploymentInProgress,
+  DeploymentNotFound,
+  DeploymentTokenInvalid,
+  type DeploymentEvent,
+  type DeploymentRecord,
+  type DeploymentStore,
+} from "./Deployment.ts";
+import {
+  StateApi,
+  type DeploymentEventWire,
+  type DeploymentRecordWire,
+} from "./HttpStateApi.ts";
 
 import type { ReplacedResourceState, ResourceState } from "./ResourceState.ts";
 import {
+  fencedWriteRejected,
   StateStoreError,
   type PersistedState,
   type StateService,
@@ -132,6 +145,7 @@ export const makeHttpStateStore = ({
         stage: string;
         fqn: string;
         value: V;
+        fence?: number;
       }) =>
         state
           .setState({
@@ -140,6 +154,7 @@ export const makeHttpStateStore = ({
               stage: request.stage,
               fqn: encodeURIComponent(request.fqn),
             },
+            query: { fence: request.fence },
             payload: encodeState(request.value),
           })
           .pipe(
@@ -147,6 +162,7 @@ export const makeHttpStateStore = ({
             // has the canonical object (including any Redacted<T>
             // instances); returning the input avoids a lossy round-trip.
             Effect.map(() => request.value),
+            failFenced(request),
             mapStateStoreError,
           ),
       delete: (request) =>
@@ -157,8 +173,9 @@ export const makeHttpStateStore = ({
               stage: request.stage,
               fqn: encodeURIComponent(request.fqn),
             },
+            query: { fence: request.fence },
           })
-          .pipe(Effect.asVoid, mapStateStoreError),
+          .pipe(Effect.asVoid, failFenced(request), mapStateStoreError),
       deleteStack: (request) =>
         state
           .deleteStack({
@@ -181,15 +198,344 @@ export const makeHttpStateStore = ({
         state
           .setStackOutput({
             params: { stack: request.stack, stage: request.stage },
+            query: { fence: request.fence },
             payload: encodeState(request.value as any),
           })
           .pipe(
             Effect.map(() => request.value),
+            failFenced(request),
             mapStateStoreError,
           ),
+      getAll: (request) =>
+        state
+          .getAllStates({
+            params: { stack: request.stack, stage: request.stage },
+          })
+          .pipe(
+            Effect.map((all) => {
+              const map = new Map<string, PersistedState>();
+              for (const [fqn, value] of Object.entries(
+                (all ?? {}) as Record<string, unknown>,
+              )) {
+                map.set(fqn, reviveStateRecursive(value) as ResourceState);
+              }
+              return map as ReadonlyMap<string, PersistedState>;
+            }),
+            mapStateStoreError,
+          ),
+      // Deployment history. Every op goes through `retryTransient`, which
+      // blindly retries transport errors, 404s (worker route propagation)
+      // and 5xx. That blanket policy is safe here ONLY because:
+      //   - `appendEvents` is seq-idempotent server-side (INSERT OR
+      //     IGNORE), so a replayed batch never double-appends;
+      //   - `end` / `heartbeat` are idempotent by contract;
+      //   - `begin` failing DeploymentInProgress decodes to a *typed*
+      //     (non-HttpClientError) failure, so `isTransient` never retries
+      //     it — it passes through to the engine untouched;
+      //   - a real DeploymentNotFound travels as 410 (not 404), so it is
+      //     never mistaken for a propagation blip.
+      deployments: {
+        begin: (request) =>
+          state
+            .beginDeployment({
+              params: { stack: request.stack, stage: request.stage },
+              payload: {
+                meta: request.meta,
+                ttlMillis: request.ttlMillis,
+                supersede: request.supersede,
+              },
+            })
+            .pipe(
+              retryTransient,
+              Effect.map((r) => ({ version: r.version, token: r.token })),
+              Effect.catch(
+                (
+                  error,
+                ): Effect.Effect<
+                  never,
+                  DeploymentInProgress | StateStoreError
+                > =>
+                  error._tag === "DeploymentInProgress"
+                    ? Effect.fail(
+                        new DeploymentInProgress({
+                          stack: request.stack,
+                          stage: request.stage,
+                          holder: reviveDeploymentRecord(error.holder),
+                        }),
+                      )
+                    : failStateStore(error),
+              ),
+            ),
+        appendEvents: (request) =>
+          state
+            .appendDeploymentEvents({
+              params: {
+                stack: request.stack,
+                stage: request.stage,
+                version: request.version,
+              },
+              payload: { token: request.token, events: request.events },
+            })
+            .pipe(
+              retryTransient,
+              Effect.map((r) => ({ ackedSeq: r.ackedSeq })),
+              Effect.catch(
+                (
+                  error,
+                ): Effect.Effect<
+                  never,
+                  DeploymentTokenInvalid | DeploymentNotFound | StateStoreError
+                > =>
+                  error._tag === "DeploymentTokenInvalid"
+                    ? Effect.fail(
+                        new DeploymentTokenInvalid({
+                          stack: error.stack,
+                          stage: error.stage,
+                          version: error.version,
+                        }),
+                      )
+                    : error._tag === "DeploymentNotFound"
+                      ? Effect.fail(
+                          new DeploymentNotFound({
+                            stack: error.stack,
+                            stage: error.stage,
+                            version: error.version,
+                          }),
+                        )
+                      : failStateStore(error),
+              ),
+            ),
+        heartbeat: (request) =>
+          state
+            .heartbeatDeployment({
+              params: {
+                stack: request.stack,
+                stage: request.stage,
+                version: request.version,
+              },
+              payload: { token: request.token },
+            })
+            .pipe(
+              retryTransient,
+              Effect.asVoid,
+              Effect.catch(
+                (
+                  error,
+                ): Effect.Effect<
+                  never,
+                  DeploymentTokenInvalid | DeploymentNotFound | StateStoreError
+                > =>
+                  error._tag === "DeploymentTokenInvalid"
+                    ? Effect.fail(
+                        new DeploymentTokenInvalid({
+                          stack: error.stack,
+                          stage: error.stage,
+                          version: error.version,
+                        }),
+                      )
+                    : error._tag === "DeploymentNotFound"
+                      ? Effect.fail(
+                          new DeploymentNotFound({
+                            stack: error.stack,
+                            stage: error.stage,
+                            version: error.version,
+                          }),
+                        )
+                      : failStateStore(error),
+              ),
+            ),
+        end: (request) =>
+          state
+            .endDeployment({
+              params: {
+                stack: request.stack,
+                stage: request.stage,
+                version: request.version,
+              },
+              payload: {
+                token: request.token,
+                outcome: request.outcome,
+                summary: request.summary,
+              },
+            })
+            .pipe(
+              retryTransient,
+              Effect.asVoid,
+              Effect.catch(
+                (
+                  error,
+                ): Effect.Effect<
+                  never,
+                  DeploymentTokenInvalid | DeploymentNotFound | StateStoreError
+                > =>
+                  error._tag === "DeploymentTokenInvalid"
+                    ? Effect.fail(
+                        new DeploymentTokenInvalid({
+                          stack: error.stack,
+                          stage: error.stage,
+                          version: error.version,
+                        }),
+                      )
+                    : error._tag === "DeploymentNotFound"
+                      ? Effect.fail(
+                          new DeploymentNotFound({
+                            stack: error.stack,
+                            stage: error.stage,
+                            version: error.version,
+                          }),
+                        )
+                      : failStateStore(error),
+              ),
+            ),
+        list: (request) =>
+          state
+            .listDeployments({
+              params: { stack: request.stack, stage: request.stage },
+              query: { before: request.before, limit: request.limit },
+            })
+            .pipe(
+              retryTransient,
+              Effect.map((records) => records.map(reviveDeploymentRecord)),
+              Effect.catch((error) => failStateStore(error)),
+            ),
+        get: (request) =>
+          state
+            .getDeployment({
+              params: {
+                stack: request.stack,
+                stage: request.stage,
+                version: request.version,
+              },
+            })
+            .pipe(
+              retryTransient,
+              Effect.map((record) =>
+                record == null ? undefined : reviveDeploymentRecord(record),
+              ),
+              Effect.catch((error) => failStateStore(error)),
+            ),
+        readEvents: (request) =>
+          state
+            .readDeploymentEvents({
+              params: {
+                stack: request.stack,
+                stage: request.stage,
+                version: request.version,
+              },
+              query: { fromSeq: request.fromSeq },
+            })
+            .pipe(
+              retryTransient,
+              Effect.map((events) => events.map(reviveDeploymentEvent)),
+              Effect.catch(
+                (
+                  error,
+                ): Effect.Effect<never, DeploymentNotFound | StateStoreError> =>
+                  error._tag === "DeploymentNotFound"
+                    ? Effect.fail(
+                        new DeploymentNotFound({
+                          stack: error.stack,
+                          stage: error.stage,
+                          version: error.version,
+                        }),
+                      )
+                    : failStateStore(error),
+              ),
+            ),
+      } satisfies DeploymentStore,
     };
     return service;
   });
+
+/**
+ * Decode the server's 412 `StateWriteFenced` wire error into the
+ * canonical {@link fencedWriteRejected} StateStoreError. Applied before
+ * {@link mapStateStoreError} so the fence refusal keeps its precise
+ * message (and is never retried — 412 isn't in the transient set).
+ */
+const failFenced =
+  (request: { stack: string; stage: string; fence?: number }) =>
+  <A, E extends { _tag: string }, R>(eff: Effect.Effect<A, E, R>) =>
+    eff.pipe(
+      Effect.catchIf(
+        (e): e is E & { _tag: "StateWriteFenced" } =>
+          e._tag === "StateWriteFenced",
+        () =>
+          Effect.fail(
+            fencedWriteRejected({
+              stack: request.stack,
+              stage: request.stage,
+              fence: request.fence ?? 0,
+            }),
+          ),
+      ),
+    );
+
+/** Fold any residual client failure into a {@link StateStoreError}. */
+const failStateStore = (e: unknown) =>
+  Effect.fail(
+    new StateStoreError({
+      message:
+        e instanceof Error
+          ? e.message
+          : typeof e === "object" && e !== null && "_tag" in e
+            ? `${(e as { _tag: string })._tag}${
+                "message" in e ? `: ${(e as { message: unknown }).message}` : ""
+              }`
+            : String(e),
+      cause: e instanceof Error ? e : undefined,
+    }),
+  );
+
+/** Rebuild a mutable {@link DeploymentRecord} from its wire shape. */
+const reviveDeploymentRecord = (
+  wire: typeof DeploymentRecordWire.Type,
+): DeploymentRecord => {
+  const record: DeploymentRecord = {
+    stack: wire.stack,
+    stage: wire.stage,
+    version: wire.version,
+    meta: {
+      command: wire.meta.command,
+    },
+    startedAt: wire.startedAt,
+    heartbeatAt: wire.heartbeatAt,
+  };
+  if (wire.meta.initiator !== undefined) {
+    record.meta.initiator = { ...wire.meta.initiator };
+  }
+  if (wire.meta.alchemyVersion !== undefined) {
+    record.meta.alchemyVersion = wire.meta.alchemyVersion;
+  }
+  if (wire.meta.gitCommit !== undefined) {
+    record.meta.gitCommit = wire.meta.gitCommit;
+  }
+  if (wire.endedAt !== undefined) record.endedAt = wire.endedAt;
+  if (wire.outcome !== undefined) record.outcome = wire.outcome;
+  if (wire.summary !== undefined) {
+    record.summary = {};
+    if (wire.summary.counts !== undefined) {
+      record.summary.counts = { ...wire.summary.counts };
+    }
+    if (wire.summary.error !== undefined) {
+      record.summary.error = wire.summary.error;
+    }
+  }
+  return record;
+};
+
+/** Rebuild a mutable {@link DeploymentEvent} from its wire shape. */
+const reviveDeploymentEvent = (
+  wire: typeof DeploymentEventWire.Type,
+): DeploymentEvent => {
+  const event: DeploymentEvent = {
+    seq: wire.seq,
+    ts: wire.ts,
+    payload: wire.payload,
+  };
+  if (wire.fqn !== undefined) event.fqn = wire.fqn;
+  return event;
+};
 
 /**
  * Predicate over an `HttpClientError`-shaped failure that returns `true`
@@ -233,10 +579,12 @@ const mapStateStoreError = <A, E, R>(eff: Effect.Effect<A, E, R>) =>
     Effect.tapError(Effect.log),
     Effect.catch((e: E) =>
       Effect.fail(
-        new StateStoreError({
-          message: e instanceof Error ? e.message : String(e),
-          cause: e instanceof Error ? e : undefined,
-        }),
+        e instanceof StateStoreError
+          ? e
+          : new StateStoreError({
+              message: e instanceof Error ? e.message : String(e),
+              cause: e instanceof Error ? e : undefined,
+            }),
       ),
     ),
   ) as Effect.Effect<A, StateStoreError, R>;

--- a/packages/alchemy/src/State/InMemoryState.ts
+++ b/packages/alchemy/src/State/InMemoryState.ts
@@ -1,13 +1,41 @@
+import * as Clock from "effect/Clock";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import { recordStateStoreInit } from "../Telemetry/Metrics.ts";
+import {
+  DEPLOYMENT_TTL_MILLIS,
+  DeploymentInProgress,
+  DeploymentNotFound,
+  DeploymentTokenInvalid,
+  endTransition,
+  shouldAbandonOpen,
+  maxSeqOf,
+  toPublicRecord,
+  type DeploymentEvent,
+  type DeploymentStore,
+  type StoredDeploymentRecord,
+} from "./Deployment.ts";
 import { STATE_STORE_VERSION } from "./HttpStateApi.ts";
 import type { ResourceState } from "./ResourceState.ts";
-import { State, type PersistedState } from "./State.ts";
+import {
+  fencedWriteRejected,
+  State,
+  type PersistedState,
+  type StateStoreError,
+} from "./State.ts";
 
 type StackId = string;
 type StageId = string;
 type Fqn = string;
+
+/** Per-(stack, stage) deployment history for one in-memory instance. */
+interface StageDeployments {
+  /** Highest version ever allocated (versions start at 1). */
+  counter: number;
+  records: Map<number, StoredDeploymentRecord>;
+  /** Journal per version, keyed by `seq` for idempotent appends. */
+  events: Map<number, Map<number, DeploymentEvent>>;
+}
 
 export const inMemoryState = (
   initialState: Record<
@@ -26,8 +54,210 @@ export const inMemoryState = (
 export const InMemoryService = (
   state: Record<StackId, Record<StageId, Record<Fqn, ResourceState>>> = {},
   outputs: Record<StackId, Record<StageId, unknown>> = {},
-) =>
-  State.of(
+) => {
+  // Per-instance deployment history, keyed by `${stack}\u0000${stage}`.
+  const deploymentState = new Map<string, StageDeployments>();
+
+  const stageKey = (stack: string, stage: string) => `${stack}\u0000${stage}`;
+
+  const stageDeployments = (stack: string, stage: string): StageDeployments => {
+    const key = stageKey(stack, stage);
+    let existing = deploymentState.get(key);
+    if (existing === undefined) {
+      existing = { counter: 0, records: new Map(), events: new Map() };
+      deploymentState.set(key, existing);
+    }
+    return existing;
+  };
+
+  /**
+   * Fencing check (see StateWriteFence in State.ts): a write carrying
+   * `fence: F` is rejected once any deployment version > F was begun for
+   * the stage. Returns the rejection error, or `undefined` when the write
+   * may proceed. Synchronous against the same map `begin` mutates and
+   * evaluated in the same step as the write — perfect fencing.
+   */
+  const fenceViolation = (request: {
+    stack: string;
+    stage: string;
+    fence?: number;
+  }): StateStoreError | undefined => {
+    if (request.fence === undefined) {
+      return undefined;
+    }
+    const newest =
+      deploymentState.get(stageKey(request.stack, request.stage))?.counter ?? 0;
+    return newest > request.fence
+      ? fencedWriteRejected({
+          stack: request.stack,
+          stage: request.stage,
+          fence: request.fence,
+        })
+      : undefined;
+  };
+
+  /** Look up an open-or-ended version and enforce the token. */
+  const resolveRecord = (
+    stack: string,
+    stage: string,
+    version: number,
+    token: string,
+  ) =>
+    Effect.suspend(
+      (): Effect.Effect<
+        StoredDeploymentRecord,
+        DeploymentNotFound | DeploymentTokenInvalid
+      > => {
+        const record = deploymentState
+          .get(stageKey(stack, stage))
+          ?.records.get(version);
+        if (record === undefined) {
+          return Effect.fail(new DeploymentNotFound({ stack, stage, version }));
+        }
+        if (record.token !== token) {
+          return Effect.fail(
+            new DeploymentTokenInvalid({ stack, stage, version }),
+          );
+        }
+        return Effect.succeed(record);
+      },
+    );
+
+  const deployments: DeploymentStore = {
+    begin: ({ stack, stage, meta, ttlMillis, supersede }) =>
+      Effect.gen(function* () {
+        const now = yield* Clock.currentTimeMillis;
+        const token = yield* Effect.sync(() => crypto.randomUUID());
+        const ttl = ttlMillis ?? DEPLOYMENT_TTL_MILLIS;
+        // Reconcile + live-check + allocate in one synchronous step so two
+        // racing begins can never both succeed. (No blind-claim fast path
+        // here — there is no I/O to skip; the scan IS the fast path.)
+        return yield* Effect.suspend(() => {
+          const ns = stageDeployments(stack, stage);
+          for (const record of ns.records.values()) {
+            if (record.endedAt === undefined) {
+              // Shared takeover semantics: stale heartbeat, or a targeted
+              // `supersede` of exactly this version.
+              if (shouldAbandonOpen(record, now, ttl, supersede)) {
+                record.endedAt = now;
+                record.outcome = "abandoned";
+              } else {
+                return Effect.fail(
+                  new DeploymentInProgress({
+                    stack,
+                    stage,
+                    holder: toPublicRecord(record),
+                  }),
+                );
+              }
+            }
+          }
+          const version = ++ns.counter;
+          ns.records.set(version, {
+            stack,
+            stage,
+            version,
+            meta: structuredClone(meta),
+            startedAt: now,
+            heartbeatAt: now,
+            token,
+          });
+          ns.events.set(version, new Map());
+          return Effect.succeed({ version, token });
+        });
+      }),
+    appendEvents: ({ stack, stage, version, token, events }) =>
+      Effect.gen(function* () {
+        yield* resolveRecord(stack, stage, version, token);
+        return yield* Effect.sync(() => {
+          const ns = stageDeployments(stack, stage);
+          let journal = ns.events.get(version);
+          if (journal === undefined) {
+            journal = new Map();
+            ns.events.set(version, journal);
+          }
+          for (const event of events) {
+            // Idempotent per seq: first write wins, retries are ignored.
+            if (!journal.has(event.seq)) {
+              journal.set(event.seq, structuredClone(event));
+            }
+          }
+          return { ackedSeq: maxSeqOf([...journal.values()]) };
+        });
+      }),
+    heartbeat: ({ stack, stage, version, token }) =>
+      Effect.gen(function* () {
+        const now = yield* Clock.currentTimeMillis;
+        const record = yield* resolveRecord(stack, stage, version, token);
+        yield* Effect.sync(() => {
+          // Heartbeat against an ended deployment is a silent no-op.
+          if (record.endedAt === undefined) {
+            record.heartbeatAt = now;
+          }
+        });
+      }),
+    end: ({ stack, stage, version, token, outcome, summary }) =>
+      Effect.gen(function* () {
+        const now = yield* Clock.currentTimeMillis;
+        const record = yield* resolveRecord(stack, stage, version, token);
+        yield* Effect.sync(() => {
+          // Shared close semantics: first outcome wins, ending an
+          // "abandoned" version records "completed-late".
+          const nextOutcome = endTransition(record, outcome);
+          if (nextOutcome !== undefined) {
+            record.endedAt = now;
+            record.outcome = nextOutcome;
+            if (summary !== undefined) {
+              record.summary = structuredClone(summary);
+            }
+          }
+        });
+      }),
+    list: ({ stack, stage, before, limit }) =>
+      Effect.sync(() => {
+        const ns = deploymentState.get(stageKey(stack, stage));
+        if (ns === undefined) {
+          return [];
+        }
+        let versions = Array.from(ns.records.keys()).sort((a, b) => b - a);
+        if (before !== undefined) {
+          versions = versions.filter((version) => version < before);
+        }
+        if (limit !== undefined) {
+          versions = versions.slice(0, limit);
+        }
+        return versions.map((version) =>
+          toPublicRecord(ns.records.get(version)!),
+        );
+      }),
+    get: ({ stack, stage, version }) =>
+      Effect.sync(() => {
+        const record = deploymentState
+          .get(stageKey(stack, stage))
+          ?.records.get(version);
+        return record === undefined ? undefined : toPublicRecord(record);
+      }),
+    readEvents: ({ stack, stage, version, fromSeq }) =>
+      Effect.suspend(() => {
+        const ns = deploymentState.get(stageKey(stack, stage));
+        if (ns?.records.get(version) === undefined) {
+          return Effect.fail(new DeploymentNotFound({ stack, stage, version }));
+        }
+        const journal = ns.events.get(version);
+        const events =
+          journal === undefined
+            ? []
+            : Array.from(journal.values())
+                .filter((event) =>
+                  fromSeq === undefined ? true : event.seq >= fromSeq,
+                )
+                .sort((a, b) => a.seq - b.seq)
+                .map((event) => structuredClone(event));
+        return Effect.succeed<readonly DeploymentEvent[]>(events);
+      }),
+  };
+
+  return State.of(
     Effect.succeed({
       id: "inmemory",
       getVersion: () => Effect.succeed(STATE_STORE_VERSION),
@@ -62,27 +292,43 @@ export const InMemoryService = (
         stage,
         fqn,
         value,
+        fence,
       }: {
         stack: string;
         stage: string;
         fqn: string;
         value: V;
+        fence?: number;
       }) =>
-        Effect.sync(() => {
+        Effect.suspend(() => {
+          const violation = fenceViolation({ stack, stage, fence });
+          if (violation !== undefined) {
+            return Effect.fail(violation);
+          }
           const stackState = (state[stack] ??= {});
           const stageState = (stackState[stage] ??= {});
           stageState[fqn] = value as ResourceState;
-          return value;
+          return Effect.succeed(value);
         }),
       delete: ({
         stack,
         stage,
         fqn,
+        fence,
       }: {
         stack: string;
         stage: string;
         fqn: string;
-      }) => Effect.sync(() => delete state[stack]?.[stage]?.[fqn]),
+        fence?: number;
+      }) =>
+        Effect.suspend(() => {
+          const violation = fenceViolation({ stack, stage, fence });
+          if (violation !== undefined) {
+            return Effect.fail(violation);
+          }
+          delete state[stack]?.[stage]?.[fqn];
+          return Effect.void;
+        }),
       deleteStack: ({ stack, stage }: { stack: string; stage?: string }) =>
         Effect.sync(() => {
           if (stage === undefined) {
@@ -101,15 +347,28 @@ export const InMemoryService = (
         stack,
         stage,
         value,
+        fence,
       }: {
         stack: string;
         stage: string;
         value: unknown;
+        fence?: number;
       }) =>
-        Effect.sync(() => {
+        Effect.suspend(() => {
+          const violation = fenceViolation({ stack, stage, fence });
+          if (violation !== undefined) {
+            return Effect.fail(violation);
+          }
           const stackOutputs = (outputs[stack] ??= {});
           stackOutputs[stage] = value;
-          return value;
+          return Effect.succeed(value);
         }),
+      getAll: ({ stack, stage }: { stack: string; stage: string }) =>
+        Effect.sync(
+          (): ReadonlyMap<string, PersistedState> =>
+            new Map(Object.entries(state[stack]?.[stage] ?? {})),
+        ),
+      deployments,
     }),
   );
+};

--- a/packages/alchemy/src/State/LocalState.ts
+++ b/packages/alchemy/src/State/LocalState.ts
@@ -1,3 +1,4 @@
+import * as Clock from "effect/Clock";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
@@ -5,11 +6,38 @@ import * as Path from "effect/Path";
 import type { PlatformError } from "effect/PlatformError";
 import { decodeFqn, encodeFqn } from "../FQN.ts";
 import { recordStateStoreInit } from "../Telemetry/Metrics.ts";
+import {
+  ClosedVersionHint,
+  DEPLOYMENT_TTL_MILLIS,
+  DeploymentInProgress,
+  DeploymentNotFound,
+  DeploymentTokenInvalid,
+  endTransition,
+  shouldAbandonOpen,
+  toPublicRecord,
+  type DeploymentEvent,
+  type DeploymentStore,
+  type StoredDeploymentRecord,
+} from "./Deployment.ts";
 import { STATE_STORE_VERSION } from "./HttpStateApi.ts";
-import { State, StateStoreError, type StateService } from "./State.ts";
+import {
+  fencedWriteRejected,
+  State,
+  StateStoreError,
+  type PersistedState,
+  type StateService,
+} from "./State.ts";
 import { encodeState, reviveState } from "./StateEncoding.ts";
 
-export const localState = () =>
+export interface LocalStateOptions {
+  /**
+   * Directory the `.alchemy` state root is created under.
+   * @default process.cwd()
+   */
+  rootDir?: string;
+}
+
+export const localState = (options?: LocalStateOptions) =>
   Layer.effect(
     State,
     Effect.gen(function* () {
@@ -17,7 +45,7 @@ export const localState = () =>
         FileSystem.FileSystem | Path.Path
       >();
 
-      const make = makeLocalState().pipe(
+      const make = makeLocalState(options).pipe(
         recordStateStoreInit,
         Effect.provideContext(context),
       );
@@ -26,11 +54,13 @@ export const localState = () =>
     }),
   );
 
-export const makeLocalState = () =>
+export const makeLocalState = (options?: LocalStateOptions) =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
-    const dotAlchemy = path.join(process.cwd(), ".alchemy");
+    const rootDir =
+      options?.rootDir ?? (yield* Effect.sync(() => process.cwd()));
+    const dotAlchemy = path.join(rootDir, ".alchemy");
     const stateDir = path.join(dotAlchemy, "state");
 
     const fail = (err: PlatformError) =>
@@ -100,6 +130,409 @@ export const makeLocalState = () =>
             .makeDirectory(dir, { recursive: true })
             .pipe(Effect.tap(() => Effect.sync(() => created.add(dir))));
 
+    // ---------------------------------------------------------------------
+    // Deployment history (DeploymentStore)
+    //
+    // Layout (reserved `.deployments` dir inside the stage dir — `list()`
+    // filters stage entries to `*.json` files, so it never shows up as a
+    // resource):
+    //
+    //   {stage}/.deployments/{version}.record.json   — DeploymentRecord + token
+    //   {stage}/.deployments/{version}.events.jsonl  — one JSON event per line
+    //
+    // The record file doubles as BOTH the version marker and the atomic
+    // version-claim: `begin` creates it with the exclusive flag (`wx`), so
+    // two racing begins can never claim the same version (rename overwrites
+    // on POSIX and can NOT arbitrate). Keeping it flat (no per-version dir)
+    // closes the window where a version directory exists before its record
+    // does. After the claim, all record rewrites go through `writeAtomic`
+    // (temp + rename), so readers never see a torn update.
+    // ---------------------------------------------------------------------
+
+    type Loc = { stack: string; stage: string };
+
+    const deploymentsDir = (loc: Loc) =>
+      path.join(stageDir(loc), ".deployments");
+
+    /**
+     * Blind-claim fast-path hint — see {@link ClosedVersionHint} for the
+     * invariant and the shared single-shot / monotonic policy. Here the
+     * claim primitive is an exclusive-create (`wx`) of N+1's record,
+     * skipping the O(history) record scan.
+     */
+    const closedHint = new ClosedVersionHint();
+
+    const recordFile = (loc: Loc, version: number) =>
+      path.join(deploymentsDir(loc), `${version}.record.json`);
+
+    const eventsFile = (loc: Loc, version: number) =>
+      path.join(deploymentsDir(loc), `${version}.events.jsonl`);
+
+    /** Read a file's contents, mapping NotFound to `undefined`. */
+    const readOptional = (file: string) =>
+      fs
+        .readFileString(file)
+        .pipe(
+          Effect.catchTag("PlatformError", (e) =>
+            e.reason._tag === "NotFound" ? Effect.succeed(undefined) : fail(e),
+          ),
+        );
+
+    /** Version numbers present for `(stack, stage)`, unsorted. */
+    const listVersions = (loc: Loc) =>
+      fs.readDirectory(deploymentsDir(loc)).pipe(
+        Effect.catchTag("PlatformError", (e) =>
+          e.reason._tag === "NotFound"
+            ? Effect.succeed([] as string[])
+            : fail(e),
+        ),
+        Effect.map((entries) =>
+          entries
+            .map((entry) => /^(\d+)\.record\.json$/.exec(entry)?.[1])
+            .filter((version): version is string => version !== undefined)
+            .map(Number),
+        ),
+      );
+
+    /**
+     * Read a stored deployment record. `undefined` means the version does
+     * not exist (the record file IS the version marker).
+     *
+     * The initial `wx` claim write is not atomic w.r.t. content — a
+     * concurrent reader can observe the file existing but still empty for a
+     * tick. Yield and re-read a bounded number of times; a permanently
+     * empty/torn record (crash between open and write of the claim) is
+     * treated as garbage after the budget — safe, because `begin` never
+     * returned that version to anyone.
+     */
+    const readStoredRecord = Effect.fn(function* (loc: Loc, version: number) {
+      for (let attempt = 0; attempt < 25; attempt++) {
+        const contents = yield* readOptional(recordFile(loc, version));
+        if (contents === undefined) {
+          return undefined;
+        }
+        const parsed = yield* Effect.sync(() => {
+          try {
+            return JSON.parse(contents) as StoredDeploymentRecord;
+          } catch {
+            return undefined;
+          }
+        });
+        if (parsed !== undefined) {
+          return parsed;
+        }
+        yield* Effect.yieldNow;
+      }
+      return undefined;
+    });
+
+    /** Look up a version and enforce the caller's token. */
+    const resolveStored = Effect.fn(function* (
+      loc: Loc,
+      version: number,
+      token: string,
+    ) {
+      const stored = yield* readStoredRecord(loc, version);
+      if (stored === undefined) {
+        return yield* Effect.fail(new DeploymentNotFound({ ...loc, version }));
+      }
+      if (stored.token !== token) {
+        return yield* Effect.fail(
+          new DeploymentTokenInvalid({ ...loc, version }),
+        );
+      }
+      return stored;
+    });
+
+    const writeRecord = (
+      loc: Loc,
+      version: number,
+      record: StoredDeploymentRecord,
+    ) =>
+      writeAtomic(
+        recordFile(loc, version),
+        JSON.stringify(record, null, 2),
+      ).pipe(Effect.catchTag("PlatformError", fail));
+
+    /**
+     * Parse an events.jsonl body. Skips blank and unparseable lines (a
+     * crash mid-append can leave a torn trailing line — it must not poison
+     * history) and dedupes by seq (first write wins).
+     */
+    const parseEventLines = (raw: string): DeploymentEvent[] => {
+      const events: DeploymentEvent[] = [];
+      const seen = new Set<number>();
+      for (const line of raw.split("\n")) {
+        if (line.trim().length === 0) {
+          continue;
+        }
+        let event: DeploymentEvent;
+        try {
+          event = JSON.parse(line) as DeploymentEvent;
+        } catch {
+          continue;
+        }
+        if (!seen.has(event.seq)) {
+          seen.add(event.seq);
+          events.push(event);
+        }
+      }
+      return events;
+    };
+
+    const deployments: DeploymentStore = {
+      begin: ({ stack, stage, meta, ttlMillis, supersede }) =>
+        Effect.gen(function* () {
+          const loc: Loc = { stack, stage };
+          const now = yield* Clock.currentTimeMillis;
+          const token = yield* Effect.sync(() => crypto.randomUUID());
+          const ttl = ttlMillis ?? DEPLOYMENT_TTL_MILLIS;
+          yield* fs
+            .makeDirectory(deploymentsDir(loc), { recursive: true })
+            .pipe(Effect.catchTag("PlatformError", fail));
+
+          const makeRecord = (version: number): StoredDeploymentRecord => ({
+            stack,
+            stage,
+            version,
+            meta,
+            startedAt: now,
+            heartbeatAt: now,
+            token,
+          });
+
+          // Blind-claim fast path: our own `end` closed version `known`,
+          // so an exclusive-create of known+1 succeeding proves no newer
+          // version (and no live open) exists — skip the record scan.
+          // `take` is single-shot: a conflict falls through to the loop.
+          const known =
+            supersede === undefined ? closedHint.take(loc) : undefined;
+          if (known !== undefined) {
+            const version = known + 1;
+            const claimed = yield* fs
+              .writeFileString(
+                recordFile(loc, version),
+                JSON.stringify(makeRecord(version), null, 2),
+                { flag: "wx" },
+              )
+              .pipe(
+                Effect.map(() => true),
+                Effect.catchTag("PlatformError", (e) =>
+                  e.reason._tag === "AlreadyExists"
+                    ? Effect.succeed(false)
+                    : fail(e),
+                ),
+              );
+            if (claimed) {
+              return { version, token };
+            }
+            // Someone else claimed known+1 — fall through to the full loop.
+          }
+
+          const attempt = (
+            remaining: number,
+          ): Effect.Effect<
+            { version: number; token: string },
+            DeploymentInProgress | StateStoreError
+          > =>
+            Effect.gen(function* () {
+              if (remaining <= 0) {
+                return yield* Effect.fail(
+                  new StateStoreError({
+                    message: `unable to claim a deployment version for ${stack}/${stage}`,
+                  }),
+                );
+              }
+              // Observe: scan existing versions, reconcile stale opens,
+              // fail on a live open, derive the next version.
+              const versions = yield* listVersions(loc);
+              let next = 1;
+              for (const version of versions) {
+                if (version >= next) {
+                  next = version + 1;
+                }
+                const stored = yield* readStoredRecord(loc, version);
+                if (stored === undefined || stored.endedAt !== undefined) {
+                  continue;
+                }
+                // Shared takeover semantics: stale heartbeat, or a targeted
+                // `supersede` of exactly this version.
+                if (shouldAbandonOpen(stored, now, ttl, supersede)) {
+                  stored.endedAt = now;
+                  stored.outcome = "abandoned";
+                  yield* writeRecord(loc, version, stored);
+                } else {
+                  return yield* Effect.fail(
+                    new DeploymentInProgress({
+                      stack,
+                      stage,
+                      holder: toPublicRecord(stored),
+                    }),
+                  );
+                }
+              }
+              // Claim: exclusive-create of the record file arbitrates the
+              // race. The loser re-scans — it either finds the winner's
+              // live open (DeploymentInProgress) or claims next + 1.
+              return yield* fs
+                .writeFileString(
+                  recordFile(loc, next),
+                  JSON.stringify(makeRecord(next), null, 2),
+                  { flag: "wx" },
+                )
+                .pipe(
+                  Effect.map(() => ({ version: next, token })),
+                  Effect.catchTag("PlatformError", (e) =>
+                    e.reason._tag === "AlreadyExists"
+                      ? attempt(remaining - 1)
+                      : fail(e),
+                  ),
+                );
+            });
+
+          return yield* attempt(16);
+        }),
+      appendEvents: ({ stack, stage, version, token, events }) =>
+        Effect.gen(function* () {
+          const loc: Loc = { stack, stage };
+          yield* resolveStored(loc, version, token);
+          // Single writer per version (enforced by the token), so
+          // read-dedupe-append is safe without a lock.
+          const raw = yield* readOptional(eventsFile(loc, version));
+          const existing = yield* Effect.sync(() => parseEventLines(raw ?? ""));
+          const seqs = new Set(existing.map((event) => event.seq));
+          const fresh: DeploymentEvent[] = [];
+          for (const event of events) {
+            if (!seqs.has(event.seq)) {
+              seqs.add(event.seq);
+              fresh.push(event);
+            }
+          }
+          if (fresh.length > 0) {
+            // If a crash left a torn trailing line (no newline), start on a
+            // fresh line so the new events stay parseable.
+            const needsLeadingNewline =
+              raw !== undefined && raw.length > 0 && !raw.endsWith("\n");
+            const chunk =
+              (needsLeadingNewline ? "\n" : "") +
+              fresh.map((event) => JSON.stringify(event)).join("\n") +
+              "\n";
+            yield* fs
+              .writeFileString(eventsFile(loc, version), chunk, { flag: "a" })
+              .pipe(Effect.catchTag("PlatformError", fail));
+          }
+          let ackedSeq = 0;
+          for (const seq of seqs) {
+            if (seq > ackedSeq) {
+              ackedSeq = seq;
+            }
+          }
+          return { ackedSeq };
+        }),
+      heartbeat: ({ stack, stage, version, token }) =>
+        Effect.gen(function* () {
+          const loc: Loc = { stack, stage };
+          const now = yield* Clock.currentTimeMillis;
+          const stored = yield* resolveStored(loc, version, token);
+          // Heartbeat against an ended deployment is a silent no-op.
+          if (stored.endedAt === undefined) {
+            stored.heartbeatAt = now;
+            yield* writeRecord(loc, version, stored);
+          }
+        }),
+      end: ({ stack, stage, version, token, outcome, summary }) =>
+        Effect.gen(function* () {
+          const loc: Loc = { stack, stage };
+          const now = yield* Clock.currentTimeMillis;
+          const stored = yield* resolveStored(loc, version, token);
+          // Shared close semantics: first outcome wins, ending an
+          // "abandoned" version records "completed-late".
+          const nextOutcome = endTransition(stored, outcome);
+          if (nextOutcome !== undefined) {
+            stored.endedAt = now;
+            stored.outcome = nextOutcome;
+            if (summary !== undefined) {
+              stored.summary = summary;
+            }
+            yield* writeRecord(loc, version, stored);
+          }
+          // Feed the blind-claim fast path: this version is known closed.
+          closedHint.noteClosed(loc, version);
+        }),
+      list: ({ stack, stage, before, limit }) =>
+        Effect.gen(function* () {
+          const loc: Loc = { stack, stage };
+          let versions = (yield* listVersions(loc)).sort((a, b) => b - a);
+          if (before !== undefined) {
+            versions = versions.filter((version) => version < before);
+          }
+          if (limit !== undefined) {
+            versions = versions.slice(0, limit);
+          }
+          const records = yield* Effect.all(
+            versions.map((version) => readStoredRecord(loc, version)),
+            { concurrency: 8 },
+          );
+          return records.flatMap((record) =>
+            record === undefined ? [] : [toPublicRecord(record)],
+          );
+        }),
+      get: ({ stack, stage, version }) =>
+        Effect.gen(function* () {
+          const stored = yield* readStoredRecord({ stack, stage }, version);
+          return stored === undefined ? undefined : toPublicRecord(stored);
+        }),
+      readEvents: ({ stack, stage, version, fromSeq }) =>
+        Effect.gen(function* () {
+          const loc: Loc = { stack, stage };
+          const stored = yield* readStoredRecord(loc, version);
+          if (stored === undefined) {
+            return yield* Effect.fail(
+              new DeploymentNotFound({ stack, stage, version }),
+            );
+          }
+          const raw = yield* readOptional(eventsFile(loc, version));
+          const events = yield* Effect.sync(() => parseEventLines(raw ?? ""));
+          return events
+            .filter((event) =>
+              fromSeq === undefined ? true : event.seq >= fromSeq,
+            )
+            .sort((a, b) => a.seq - b.seq);
+        }),
+    };
+
+    /**
+     * Fencing check (see StateWriteFence in State.ts): reject a write
+     * carrying `fence: F` once any deployment version > F exists for the
+     * stage. The version directory read is cheap locally. Check-then-write
+     * (not atomic with the write), so fencing is best-effort here — a
+     * zombie that lost its lease is caught by its next write.
+     */
+    const checkFence = (request: {
+      stack: string;
+      stage: string;
+      fence?: number;
+    }): Effect.Effect<void, StateStoreError> =>
+      Effect.gen(function* () {
+        if (request.fence === undefined) {
+          return;
+        }
+        const versions = yield* listVersions({
+          stack: request.stack,
+          stage: request.stage,
+        });
+        const newest = versions.reduce((max, v) => (v > max ? v : max), 0);
+        if (newest > request.fence) {
+          return yield* Effect.fail(
+            fencedWriteRejected({
+              stack: request.stack,
+              stage: request.stage,
+              fence: request.fence,
+            }),
+          );
+        }
+      });
+
     const state: StateService = {
       id: "local",
       getVersion: () => Effect.succeed(STATE_STORE_VERSION),
@@ -130,17 +563,25 @@ export const makeLocalState = () =>
         )).filter((r) => r?.status === "replaced");
       }),
       set: (request) =>
-        ensure(stageDir(request)).pipe(
+        checkFence(request).pipe(
           Effect.flatMap(() =>
-            writeAtomic(
-              resource(request),
-              JSON.stringify(encodeState(request.value), null, 2),
+            ensure(stageDir(request)).pipe(
+              Effect.flatMap(() =>
+                writeAtomic(
+                  resource(request),
+                  JSON.stringify(encodeState(request.value), null, 2),
+                ),
+              ),
+              recover,
             ),
           ),
-          recover,
           Effect.map(() => request.value),
         ),
-      delete: (request) => fs.remove(resource(request)).pipe(recover),
+      delete: (request) =>
+        checkFence(request).pipe(
+          Effect.flatMap(() => fs.remove(resource(request)).pipe(recover)),
+          Effect.asVoid,
+        ),
       deleteStack: ({ stack, stage }) =>
         fs
           .remove(
@@ -175,16 +616,40 @@ export const makeLocalState = () =>
           recover,
         ),
       setOutput: (request) =>
-        ensure(stageDir(request)).pipe(
+        checkFence(request).pipe(
           Effect.flatMap(() =>
-            writeAtomic(
-              outputFile(request),
-              JSON.stringify(encodeState(request.value as any), null, 2),
+            ensure(stageDir(request)).pipe(
+              Effect.flatMap(() =>
+                writeAtomic(
+                  outputFile(request),
+                  JSON.stringify(encodeState(request.value as any), null, 2),
+                ),
+              ),
+              recover,
             ),
           ),
-          recover,
           Effect.map(() => request.value),
         ),
+      getAll: (request) =>
+        Effect.gen(function* () {
+          const fqns = yield* state.list(request);
+          const entries = yield* Effect.all(
+            fqns.map((fqn) =>
+              state
+                .get({ ...request, fqn })
+                .pipe(Effect.map((value) => [fqn, value] as const)),
+            ),
+            { concurrency: 8 },
+          );
+          const all = new Map<string, PersistedState>();
+          for (const [fqn, value] of entries) {
+            if (value !== undefined) {
+              all.set(fqn, value);
+            }
+          }
+          return all;
+        }),
+      deployments,
     };
     return state;
   });

--- a/packages/alchemy/src/State/State.ts
+++ b/packages/alchemy/src/State/State.ts
@@ -2,6 +2,7 @@ import * as Context from "effect/Context";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import type { ActionState } from "./ActionState.ts";
+import type { DeploymentStore } from "./Deployment.ts";
 import type { ReplacedResourceState, ResourceState } from "./ResourceState.ts";
 
 /**
@@ -22,6 +23,49 @@ export class StateStoreError extends Data.TaggedError("StateStoreError")<{
   message: string;
   cause?: Error;
 }> {}
+
+/**
+ * # StateWriteFence
+ *
+ * The optional `fence` on {@link StateService.set} / `delete` /
+ * `setOutput` is a fencing token guarding head state against zombie
+ * writers — the classic lease problem: a deploy pauses (GC, laptop lid,
+ * network partition), its heartbeat lapses, a new deploy takes over the
+ * stage, and then the old deploy wakes up and keeps writing.
+ *
+ * The token is the deployment version, which every backend already
+ * allocates monotonically per `(stack, stage)` at `deployments.begin`.
+ * A write carrying `fence: F` must be REJECTED once any version `> F`
+ * has been begun — the newer begin supersedes the older lease, and
+ * versions are never re-used, so the check is a plain comparison
+ * against the newest allocated version.
+ *
+ * Enforcement strength is per backend:
+ * - in-memory and the Cloudflare Durable Object check atomically with
+ *   the write (single-threaded arbiter) — perfect fencing;
+ * - local FS and S3 check the newest version immediately before the
+ *   write — a small check-then-write window remains, so fencing is
+ *   best-effort there (still a categorical improvement: a zombie that
+ *   lost its lease minutes ago is caught by the very next write).
+ *
+ * A rejected write fails with a {@link StateStoreError} built by
+ * {@link fencedWriteRejected}; the engine treats it like any other
+ * fatal state write failure and aborts the zombie deploy.
+ *
+ * Writes WITHOUT `fence` (dashboards, CLIs, repair tooling, stores
+ * that predate fencing) bypass the check — the fence protects against
+ * *stale deploy sessions*, not against explicit operator writes.
+ */
+export const fencedWriteRejected = (request: {
+  stack: string;
+  stage: string;
+  fence: number;
+}): StateStoreError =>
+  new StateStoreError({
+    message:
+      `fenced write rejected: deployment v${request.fence} of ` +
+      `${request.stack}/${request.stage} has been superseded by a newer deployment`,
+  });
 
 export class State extends Context.Service<
   State,
@@ -82,20 +126,27 @@ export interface StateService {
   >;
   /**
    * Set a resource by its FQN (namespace-qualified key).
+   *
+   * `fence` (optional, feature-detected): the deployment version whose
+   * lease authorizes this write — see {@link StateWriteFence}.
    */
   set<V extends PersistedState>(request: {
     stack: string;
     stage: string;
     fqn: string;
     value: V;
+    fence?: number;
   }): Effect.Effect<V, StateStoreError, never>;
   /**
    * Delete a resource by its FQN (namespace-qualified key).
+   *
+   * `fence` (optional): see {@link StateWriteFence}.
    */
   delete(request: {
     stack: string;
     stage: string;
     fqn: string;
+    fence?: number;
   }): Effect.Effect<void, StateStoreError, never>;
   /**
    * Delete an entire stack, or a single stage when `stage` is provided.
@@ -126,10 +177,37 @@ export interface StateService {
   }): Effect.Effect<unknown, StateStoreError, never>;
   /**
    * Persist the resolved stack output for `(stack, stage)`.
+   *
+   * `fence` (optional): see {@link StateWriteFence}.
    */
   setOutput(request: {
     stack: string;
     stage: string;
     value: unknown;
+    fence?: number;
   }): Effect.Effect<unknown, StateStoreError, never>;
+  /**
+   * Read every resource in a stack/stage in one call.
+   *
+   * Optional (feature-detected): the dashboard and other batch readers use
+   * this to avoid the N+1 `list` + per-fqn `get` pattern; when absent,
+   * callers fall back to that pattern. All in-repo backends implement it.
+   */
+  getAll?(request: {
+    stack: string;
+    stage: string;
+  }): Effect.Effect<
+    ReadonlyMap<string, PersistedState>,
+    StateStoreError,
+    never
+  >;
+  /**
+   * Deployment history (versioned journal of every deploy/destroy).
+   *
+   * Optional (feature-detected): older or third-party state stores may not
+   * implement it, in which case the engine skips journaling and the
+   * dashboard's history views are unavailable. See {@link DeploymentStore}
+   * for the semantics every implementation must uphold.
+   */
+  deployments?: DeploymentStore;
 }

--- a/packages/alchemy/src/State/index.ts
+++ b/packages/alchemy/src/State/index.ts
@@ -1,3 +1,5 @@
+export * from "./Deployment.ts";
+export * from "./DeploymentSession.ts";
 export * from "./HttpStateApi.ts";
 export * from "./HttpStateStore.ts";
 export * from "./InMemoryState.ts";

--- a/packages/alchemy/src/Test/Core.ts
+++ b/packages/alchemy/src/Test/Core.ts
@@ -296,7 +296,7 @@ export const scratchStack = <ROut>(
         actions: {},
         output: {},
       }).pipe(
-        Effect.flatMap(apply),
+        Effect.flatMap((plan) => apply(plan, { command: "destroy" })),
         Effect.asVoid,
         Effect.provide(stateLayer),
         Effect.provide(options.providers as Layer.Layer<any, never, any>),

--- a/packages/alchemy/src/Util/aes-ctr.ts
+++ b/packages/alchemy/src/Util/aes-ctr.ts
@@ -1,0 +1,117 @@
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+
+/**
+ * Web Crypto AES-CTR helpers over a compact wire format: every payload is
+ * framed as `base64(nonce || ciphertext)` with a random 16-byte counter
+ * block per encryption, so a single string round-trips through JSON/KV
+ * storage without extra bookkeeping.
+ */
+
+/** AES-CTR counter block length. */
+const NONCE_BYTES = 16;
+
+/**
+ * Allocate a `Uint8Array` over a fresh `ArrayBuffer` (not shared) so the
+ * buffer satisfies Web Crypto's `BufferSource` under strict DOM typings.
+ */
+const allocBytes = (size: number): Uint8Array<ArrayBuffer> =>
+  new Uint8Array(new ArrayBuffer(size));
+
+/** Copy arbitrary bytes into a fresh non-shared buffer for Web Crypto. */
+const toBufferSource = (bytes: Uint8Array): Uint8Array<ArrayBuffer> => {
+  const copy = allocBytes(bytes.byteLength);
+  copy.set(bytes);
+  return copy;
+};
+
+/** Decryption failed — wrong key, truncated frame, or corrupt ciphertext. */
+export class AesCtrDecryptError extends Data.TaggedError("AesCtrDecryptError")<{
+  message: string;
+  cause?: unknown;
+}> {}
+
+/** Import a hex-encoded 256-bit key as an AES-CTR `CryptoKey`. */
+export const importAesCtrKey = (keyHex: string): Effect.Effect<CryptoKey> =>
+  Effect.promise(() =>
+    crypto.subtle.importKey(
+      "raw",
+      Buffer.from(keyHex, "hex"),
+      { name: "AES-CTR" },
+      false,
+      ["encrypt", "decrypt"],
+    ),
+  );
+
+/** Encrypt raw bytes; returns `base64(nonce || ciphertext)`. */
+export const aesCtrEncrypt = (
+  key: CryptoKey,
+  plaintext: Uint8Array,
+): Effect.Effect<string> =>
+  Effect.promise(async () => {
+    const counter = crypto.getRandomValues(allocBytes(NONCE_BYTES));
+    const ciphertext = new Uint8Array(
+      await crypto.subtle.encrypt(
+        { name: "AES-CTR", counter, length: 64 },
+        key,
+        toBufferSource(plaintext),
+      ),
+    );
+    return Buffer.concat([counter, ciphertext]).toString("base64");
+  });
+
+/** Decrypt a `base64(nonce || ciphertext)` frame back to raw bytes. */
+export const aesCtrDecrypt = (
+  key: CryptoKey,
+  framedBase64: string,
+): Effect.Effect<Uint8Array, AesCtrDecryptError> =>
+  Effect.tryPromise({
+    try: async () => {
+      const framed = Buffer.from(framedBase64, "base64");
+      const counter = toBufferSource(framed.subarray(0, NONCE_BYTES));
+      const ciphertext = toBufferSource(framed.subarray(NONCE_BYTES));
+      const decrypted = await crypto.subtle.decrypt(
+        { name: "AES-CTR", counter, length: 64 },
+        key,
+        ciphertext,
+      );
+      return new Uint8Array(decrypted);
+    },
+    catch: (cause) =>
+      new AesCtrDecryptError({
+        message: `AES-CTR decryption failed: ${String(cause)}`,
+        cause,
+      }),
+  });
+
+/** Encrypt a JSON-serializable value; returns `base64(nonce || ciphertext)`. */
+export const aesCtrEncryptJson = (
+  key: CryptoKey,
+  value: unknown,
+): Effect.Effect<string> =>
+  Effect.suspend(() =>
+    aesCtrEncrypt(key, new TextEncoder().encode(JSON.stringify(value))),
+  );
+
+/**
+ * Decrypt a `base64(nonce || ciphertext)` frame and parse the plaintext as
+ * JSON. AES-CTR decryption with the wrong key "succeeds" with garbage
+ * bytes, so an unparseable plaintext is reported as the same typed error.
+ */
+export const aesCtrDecryptJson = <T>(
+  key: CryptoKey,
+  framedBase64: string,
+): Effect.Effect<T, AesCtrDecryptError> =>
+  aesCtrDecrypt(key, framedBase64).pipe(
+    Effect.flatMap((plaintext) =>
+      Effect.try({
+        try: () => JSON.parse(new TextDecoder().decode(plaintext)) as T,
+        catch: (cause) =>
+          new AesCtrDecryptError({
+            message:
+              "decrypted payload is not valid JSON (wrong key or corrupt data)",
+            cause,
+          }),
+      }),
+    ),
+  );

--- a/packages/alchemy/src/Util/index.ts
+++ b/packages/alchemy/src/Util/index.ts
@@ -1,3 +1,4 @@
+export * from "./aes-ctr.ts";
 export * from "./base32.ts";
 export * from "./camel.ts";
 export * from "./data.ts";

--- a/packages/alchemy/test/AWS/StateStore/S3Deployments.test.ts
+++ b/packages/alchemy/test/AWS/StateStore/S3Deployments.test.ts
@@ -1,0 +1,235 @@
+import * as AWS from "@/AWS";
+import {
+  DEPLOYMENTS_DIR,
+  batchKey,
+  dedupeBatch,
+  decodeRecord,
+  deploymentsPrefix,
+  encodeRecord,
+  eventsPrefix,
+  pad8,
+  recordKey,
+  versionFromCommonPrefix,
+  versionPrefix,
+} from "@/AWS/StateStore/Deployments.ts";
+import { State, type DeploymentEvent } from "@/State";
+import {
+  isStaleOpen,
+  maxSeqOf,
+  toPublicRecord,
+  type StoredDeploymentRecord,
+} from "@/State/Deployment.ts";
+import * as Core from "@/Test/Core.ts";
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import { beforeAll } from "vitest";
+import { deploymentStoreConformance } from "../../State/deploymentStoreConformance.ts";
+
+// ---------------------------------------------------------------------------
+// Ungated unit tests for the pure helpers the S3 deployment store is built on.
+// These run everywhere; no AWS account is touched.
+// ---------------------------------------------------------------------------
+
+const stagePrefix = "alchemy/my-stack/dev/";
+
+const event = (seq: number, payload?: unknown): DeploymentEvent => ({
+  seq,
+  ts: seq * 10,
+  payload: payload ?? { kind: "note", seq },
+});
+
+const stored = (
+  overrides: Partial<StoredDeploymentRecord> = {},
+): StoredDeploymentRecord => ({
+  stack: "my-stack",
+  stage: "dev",
+  version: 1,
+  meta: { command: "deploy", initiator: { user: "tester" } },
+  startedAt: 100,
+  heartbeatAt: 100,
+  token: "secret-token",
+  ...overrides,
+});
+
+describe("S3 deployment store key layout", () => {
+  it("pads versions and seqs to 8 digits so key order equals numeric order", () => {
+    expect(pad8(1)).toBe("00000001");
+    expect(pad8(42)).toBe("00000042");
+    expect(pad8(12345678)).toBe("12345678");
+    // lexicographic order must match numeric order
+    expect(pad8(2) < pad8(10)).toBe(true);
+    expect(pad8(9) < pad8(11)).toBe(true);
+  });
+
+  it("builds the documented key layout under the stage prefix", () => {
+    expect(deploymentsPrefix(stagePrefix)).toBe(
+      `alchemy/my-stack/dev/${DEPLOYMENTS_DIR}/`,
+    );
+    expect(recordKey(stagePrefix, 3)).toBe(
+      "alchemy/my-stack/dev/.deployments/00000003/record.json",
+    );
+    expect(eventsPrefix(stagePrefix, 3)).toBe(
+      "alchemy/my-stack/dev/.deployments/00000003/events/",
+    );
+    expect(batchKey(stagePrefix, 3, 17)).toBe(
+      "alchemy/my-stack/dev/.deployments/00000003/events/00000017.json",
+    );
+  });
+
+  it("parses the version back out of a delimiter-list common prefix", () => {
+    const prefix = deploymentsPrefix(stagePrefix);
+    expect(versionFromCommonPrefix(prefix, versionPrefix(stagePrefix, 1))).toBe(
+      1,
+    );
+    expect(
+      versionFromCommonPrefix(prefix, versionPrefix(stagePrefix, 12345678)),
+    ).toBe(12345678);
+    // object keys (records, batches) are not version prefixes
+    expect(
+      versionFromCommonPrefix(prefix, recordKey(stagePrefix, 1)),
+    ).toBeUndefined();
+    expect(
+      versionFromCommonPrefix(prefix, batchKey(stagePrefix, 1, 1)),
+    ).toBeUndefined();
+    // foreign prefixes are ignored
+    expect(
+      versionFromCommonPrefix(prefix, `${stagePrefix}other/`),
+    ).toBeUndefined();
+    expect(
+      versionFromCommonPrefix(prefix, `${prefix}not-a-version/`),
+    ).toBeUndefined();
+  });
+});
+
+describe("S3 deployment store stale-open predicate", () => {
+  it("an ended record is never stale", () => {
+    expect(
+      isStaleOpen(stored({ endedAt: 100, outcome: "succeeded" }), 1e9, 0),
+    ).toBe(false);
+  });
+
+  it("an open record within the ttl is live", () => {
+    expect(isStaleOpen(stored({ heartbeatAt: 100 }), 150, 60_000)).toBe(false);
+  });
+
+  it("an open record whose heartbeat is older than the ttl is stale", () => {
+    expect(isStaleOpen(stored({ heartbeatAt: 100 }), 60_100, 60_000)).toBe(
+      true,
+    );
+    // boundary: now - heartbeatAt >= ttl
+    expect(isStaleOpen(stored({ heartbeatAt: 100 }), 60_100, 60_001)).toBe(
+      false,
+    );
+  });
+
+  it("ttl 0 marks any open record stale", () => {
+    expect(isStaleOpen(stored({ heartbeatAt: 100 }), 100, 0)).toBe(true);
+  });
+});
+
+describe("S3 deployment store batch dedupe", () => {
+  it("keeps everything on an empty journal and acks the highest seq", () => {
+    const { retained, ackedSeq } = dedupeBatch(
+      [event(2), event(1), event(3)],
+      0,
+    );
+    expect(retained.map((e) => e.seq)).toEqual([1, 2, 3]);
+    expect(ackedSeq).toBe(3);
+  });
+
+  it("drops events at or below the journal high-water mark", () => {
+    const { retained, ackedSeq } = dedupeBatch(
+      [event(2), event(3), event(4)],
+      3,
+    );
+    expect(retained.map((e) => e.seq)).toEqual([4]);
+    expect(ackedSeq).toBe(4);
+  });
+
+  it("acks the high-water mark when every event is a duplicate", () => {
+    const { retained, ackedSeq } = dedupeBatch([event(1), event(2)], 5);
+    expect(retained).toEqual([]);
+    expect(ackedSeq).toBe(5);
+  });
+
+  it("dedupes repeats inside a single batch, first write wins", () => {
+    const { retained } = dedupeBatch(
+      [event(1, { first: true }), event(1, { first: false }), event(2)],
+      0,
+    );
+    expect(retained.map((e) => e.seq)).toEqual([1, 2]);
+    expect(retained[0]?.payload).toEqual({ first: true });
+  });
+
+  it("maxSeqOf finds the highest seq in a batch", () => {
+    expect(maxSeqOf([])).toBe(0);
+    expect(maxSeqOf([event(3), event(1), event(2)])).toBe(3);
+  });
+});
+
+describe("S3 deployment store record codec", () => {
+  it("round-trips a record through JSON", () => {
+    const record = stored({
+      endedAt: 200,
+      outcome: "failed",
+      summary: { counts: { create: 1 }, error: "boom" },
+    });
+    expect(decodeRecord(encodeRecord(record))).toEqual(record);
+  });
+
+  it("drops absent optional fields instead of persisting undefined", () => {
+    const decoded = decodeRecord(encodeRecord(stored()));
+    expect("endedAt" in decoded).toBe(false);
+    expect("outcome" in decoded).toBe(false);
+    expect("summary" in decoded).toBe(false);
+  });
+
+  it("toPublicRecord strips the token and does not alias the stored record", () => {
+    const record = stored();
+    const publicRecord = toPublicRecord(record);
+    expect("token" in publicRecord).toBe(false);
+    expect(publicRecord.version).toBe(1);
+    publicRecord.meta.initiator!.user = "intruder";
+    expect(record.meta.initiator?.user).toBe("tester");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Full conformance suite against real S3.
+// ---------------------------------------------------------------------------
+
+describe("S3 DeploymentStore (live)", () => {
+  // Each `make` builds a fresh StateService over the same bucket + prefix,
+  // mirroring the CLI runtime composition (`Core.toEffect` is what
+  // `Test.make` uses under the hood) so credentials/region resolution
+  // matches `alchemy deploy`.
+  const make = () =>
+    Core.toEffect(
+      Effect.gen(function* () {
+        return yield* yield* State;
+      }),
+      {
+        providers: AWS.providers(),
+        state: AWS.state({ prefix: "test-deployments" }),
+      },
+    );
+
+  // The conformance suite assumes a fresh backend (versions start at 1),
+  // but the S3 bucket persists across runs — wipe the conformance stack
+  // (its slug is derived from the label below) before running.
+  beforeAll(async () => {
+    await Effect.runPromise(
+      make().pipe(
+        Effect.flatMap((state) =>
+          state.deleteStack({ stack: "s3-deploymentstore-conformance" }),
+        ),
+      ),
+    );
+  }, 120_000);
+
+  deploymentStoreConformance({
+    label: "S3 DeploymentStore",
+    make,
+    persistent: true,
+  });
+});

--- a/packages/alchemy/test/Cloudflare/StateStore/CfDeployments.test.ts
+++ b/packages/alchemy/test/Cloudflare/StateStore/CfDeployments.test.ts
@@ -1,0 +1,445 @@
+import {
+  CREATE_DEPLOYMENT_EVENTS_TABLE,
+  DEPLOYMENT_COUNTER_PREFIX,
+  DEPLOYMENT_OPEN_PREFIX,
+  DEPLOYMENT_RECORD_PREFIX,
+  deploymentCounterKey,
+  deploymentOpenKey,
+  deploymentRecordKey,
+  deploymentStagePrefix,
+  INSERT_DEPLOYMENT_EVENT,
+  parseDeploymentOpenKey,
+  parseDeploymentRecordKey,
+  SELECT_DEPLOYMENT_MAX_SEQ,
+  selectDeploymentEventsSql,
+  toPublicDeploymentRecord,
+  type StoredDeploymentRecord,
+} from "@/Cloudflare/StateStore/Deployments.ts";
+import { isStaleOpen } from "@/State/Deployment.ts";
+import {
+  aesCtrDecryptJson,
+  aesCtrEncryptJson,
+  importAesCtrKey,
+} from "@/Util/aes-ctr.ts";
+import { sha256 } from "@/Util/sha256.ts";
+import { AlchemyContextLive } from "@/AlchemyContext.ts";
+import { AuthProviders } from "@/Auth/AuthProvider.ts";
+import { CredentialsStoreLive } from "@/Auth/Credentials.ts";
+import { ProfileLive } from "@/Auth/Profile.ts";
+import { LoggingCli } from "@/Cli/LoggingCli.ts";
+import * as Cloudflare from "@/Cloudflare";
+import {
+  DeploymentEventWire,
+  DeploymentInProgressWire,
+  DeploymentNotFoundWire,
+  DeploymentRecordWire,
+  DeploymentTokenInvalidWire,
+} from "@/State/HttpStateApi.ts";
+import { State } from "@/State/State.ts";
+import { PlatformServices } from "@/Util/PlatformServices.ts";
+import { describe, expect, it } from "@effect/vitest";
+import { beforeAll } from "vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Result from "effect/Result";
+import * as Schema from "effect/Schema";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import { deploymentStoreConformance } from "../../State/deploymentStoreConformance.ts";
+
+// ---------------------------------------------------------------------------
+// Ungated unit tests for the pure pieces of the Cloudflare DO deployment
+// store: key builders, the stale-open predicate, the shared AES-CTR JSON
+// codec and the SQL statement builders.
+// ---------------------------------------------------------------------------
+
+describe("Cloudflare deployment keys", () => {
+  it("record keys are lexicographically ordered by version", () => {
+    const k1 = deploymentRecordKey("dev", 1);
+    const k2 = deploymentRecordKey("dev", 2);
+    const k10 = deploymentRecordKey("dev", 10);
+    const k100000 = deploymentRecordKey("dev", 100000);
+    expect(k1 < k2).toBe(true);
+    expect(k2 < k10).toBe(true);
+    expect(k10 < k100000).toBe(true);
+  });
+
+  it("record keys live under the stage prefix", () => {
+    const key = deploymentRecordKey("dev", 42);
+    expect(key.startsWith(deploymentStagePrefix("dev"))).toBe(true);
+    expect(key.startsWith(DEPLOYMENT_RECORD_PREFIX)).toBe(true);
+  });
+
+  it("a stage prefix never matches another stage that shares a name prefix", () => {
+    const key = deploymentRecordKey("dev-extra", 1);
+    expect(key.startsWith(deploymentStagePrefix("dev"))).toBe(false);
+  });
+
+  it("record/open/counter prefixes are disjoint from each other and from resource keys", () => {
+    const record = deploymentRecordKey("dev", 1);
+    const open = deploymentOpenKey("dev");
+    const counter = deploymentCounterKey("dev");
+    expect(record.startsWith(DEPLOYMENT_OPEN_PREFIX)).toBe(false);
+    expect(record.startsWith(DEPLOYMENT_COUNTER_PREFIX)).toBe(false);
+    expect(open.startsWith(DEPLOYMENT_RECORD_PREFIX)).toBe(false);
+    expect(counter.startsWith(DEPLOYMENT_RECORD_PREFIX)).toBe(false);
+    // resource keys in the stack DO use the `r\x00` prefix, outputs `o\x00`,
+    // the root stack index `s:` — none of the deployment keys may collide.
+    for (const key of [record, open, counter]) {
+      expect(key.startsWith("r\x00")).toBe(false);
+      expect(key.startsWith("o\x00")).toBe(false);
+      expect(key.startsWith("s:")).toBe(false);
+    }
+  });
+
+  it("parseDeploymentRecordKey round-trips", () => {
+    expect(
+      parseDeploymentRecordKey(deploymentRecordKey("my-stage", 7)),
+    ).toEqual({ stage: "my-stage", version: 7 });
+    expect(parseDeploymentRecordKey("r\x00dev\x00fqn")).toBeUndefined();
+    expect(parseDeploymentRecordKey(deploymentOpenKey("dev"))).toBeUndefined();
+  });
+
+  it("parseDeploymentOpenKey round-trips", () => {
+    expect(parseDeploymentOpenKey(deploymentOpenKey("my-stage"))).toBe(
+      "my-stage",
+    );
+    expect(
+      parseDeploymentOpenKey(deploymentRecordKey("dev", 1)),
+    ).toBeUndefined();
+    expect(parseDeploymentOpenKey(deploymentCounterKey("dev"))).toBeUndefined();
+  });
+});
+
+describe("Cloudflare deployment stale-open predicate", () => {
+  it("is stale exactly at the ttl boundary (>=)", () => {
+    expect(isStaleOpen({ heartbeatAt: 1_000 }, 61_000, 60_000)).toBe(true);
+    expect(isStaleOpen({ heartbeatAt: 1_000 }, 60_999, 60_000)).toBe(false);
+  });
+
+  it("ttl 0 means always stale", () => {
+    expect(isStaleOpen({ heartbeatAt: 5 }, 5, 0)).toBe(true);
+  });
+
+  it("a fresh heartbeat under the default ttl is live", () => {
+    expect(isStaleOpen({ heartbeatAt: 10_000 }, 10_001, 60_000)).toBe(false);
+  });
+});
+
+describe("Cloudflare deployment record codec", () => {
+  // 32-byte AES-CTR key, hex-encoded — same shape as the deployed store's
+  // Secrets-Store-backed encryption key.
+  const KEY_HEX =
+    "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+  const OTHER_KEY_HEX =
+    "ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100";
+
+  it.effect("sha256 matches a known vector", () =>
+    Effect.gen(function* () {
+      const empty = yield* sha256("");
+      expect(empty).toBe(
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      );
+    }),
+  );
+
+  it.effect("encrypt/decrypt round-trips and never stores plaintext", () =>
+    Effect.gen(function* () {
+      const key = yield* importAesCtrKey(KEY_HEX);
+      const value = {
+        command: "deploy",
+        initiator: { user: "sam" },
+        nested: [1, 2, { deep: true }],
+      };
+      const data = yield* aesCtrEncryptJson(key, value);
+      expect(data).not.toContain("sam");
+      const opened = yield* aesCtrDecryptJson<typeof value>(key, data);
+      expect(opened).toEqual(value);
+      // fresh object every decrypt — no aliasing
+      const again = yield* aesCtrDecryptJson<typeof value>(key, data);
+      expect(again).not.toBe(opened);
+    }),
+  );
+
+  it.effect("two encryptions of the same value use distinct nonces", () =>
+    Effect.gen(function* () {
+      const key = yield* importAesCtrKey(KEY_HEX);
+      const a = yield* aesCtrEncryptJson(key, { v: 1 });
+      const b = yield* aesCtrEncryptJson(key, { v: 1 });
+      expect(a).not.toBe(b);
+      expect(yield* aesCtrDecryptJson(key, a)).toEqual({ v: 1 });
+      expect(yield* aesCtrDecryptJson(key, b)).toEqual({ v: 1 });
+    }),
+  );
+
+  it.effect(
+    "decrypting with the wrong key fails typed instead of returning garbage",
+    () =>
+      Effect.gen(function* () {
+        const key = yield* importAesCtrKey(KEY_HEX);
+        const wrongKey = yield* importAesCtrKey(OTHER_KEY_HEX);
+        const data = yield* aesCtrEncryptJson(key, { secret: "value" });
+        const result = yield* Effect.result(aesCtrDecryptJson(wrongKey, data));
+        expect(Result.isFailure(result)).toBe(true);
+        if (Result.isFailure(result)) {
+          expect(result.failure._tag).toBe("AesCtrDecryptError");
+        }
+      }),
+  );
+});
+
+describe("Cloudflare deployment public-record assembly", () => {
+  const stored: StoredDeploymentRecord = {
+    v: 1,
+    stack: "my-stack",
+    stage: "dev",
+    version: 3,
+    startedAt: 100,
+    heartbeatAt: 200,
+    ttlMillis: 60_000,
+    tokenHash: "abc123",
+    meta: "base64-ciphertext",
+  };
+
+  it("never exposes the token hash or ciphertext", () => {
+    const record = toPublicDeploymentRecord(stored, { command: "deploy" });
+    expect("token" in record).toBe(false);
+    expect("tokenHash" in record).toBe(false);
+    expect("ttlMillis" in record).toBe(false);
+    expect(Object.values(record)).not.toContain("abc123");
+    expect(record).toEqual({
+      stack: "my-stack",
+      stage: "dev",
+      version: 3,
+      meta: { command: "deploy" },
+      startedAt: 100,
+      heartbeatAt: 200,
+    });
+  });
+
+  it("omits endedAt/outcome/summary while open, includes them when closed", () => {
+    const open = toPublicDeploymentRecord(stored, { command: "deploy" });
+    expect("endedAt" in open).toBe(false);
+    expect("outcome" in open).toBe(false);
+    expect("summary" in open).toBe(false);
+
+    const closed = toPublicDeploymentRecord(
+      { ...stored, endedAt: 300, outcome: "failed" },
+      { command: "deploy" },
+      { counts: { create: 1 }, error: "boom" },
+    );
+    expect(closed.endedAt).toBe(300);
+    expect(closed.outcome).toBe("failed");
+    expect(closed.summary).toEqual({ counts: { create: 1 }, error: "boom" });
+  });
+});
+
+describe("Cloudflare deployment SQL statements", () => {
+  it("event inserts are idempotent per (stage, version, seq)", () => {
+    expect(CREATE_DEPLOYMENT_EVENTS_TABLE).toContain(
+      "CREATE TABLE IF NOT EXISTS deployment_events",
+    );
+    expect(CREATE_DEPLOYMENT_EVENTS_TABLE).toContain(
+      "PRIMARY KEY (stage, version, seq)",
+    );
+    expect(INSERT_DEPLOYMENT_EVENT).toContain("INSERT OR IGNORE");
+  });
+
+  it("max-seq query coalesces the empty journal to 0", () => {
+    expect(SELECT_DEPLOYMENT_MAX_SEQ).toContain("COALESCE(MAX(seq), 0)");
+  });
+
+  it("event reads are seq-ascending with an optional inclusive fromSeq", () => {
+    const all = selectDeploymentEventsSql(false);
+    const from = selectDeploymentEventsSql(true);
+    expect(all).toContain("ORDER BY seq ASC");
+    expect(all).not.toContain("seq >=");
+    expect(from).toContain("seq >= ?");
+    expect(from).toContain("ORDER BY seq ASC");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wire-schema tests for the HTTP contract in State/HttpStateApi.ts.
+// ---------------------------------------------------------------------------
+
+describe("Deployment wire schemas", () => {
+  const decodeRecord = Schema.decodeUnknownEffect(DeploymentRecordWire);
+  const decodeEvent = Schema.decodeUnknownEffect(DeploymentEventWire);
+
+  it.effect("decodes an open record (no endedAt/outcome/summary)", () =>
+    Effect.gen(function* () {
+      const record = yield* decodeRecord({
+        stack: "s",
+        stage: "dev",
+        version: 1,
+        meta: { command: "deploy", initiator: { user: "sam", pid: 42 } },
+        startedAt: 1,
+        heartbeatAt: 2,
+      });
+      expect(record.version).toBe(1);
+      expect(record.meta.command).toBe("deploy");
+      expect(record.endedAt).toBeUndefined();
+    }),
+  );
+
+  it.effect("decodes a closed record including store-added outcomes", () =>
+    Effect.gen(function* () {
+      const record = yield* decodeRecord({
+        stack: "s",
+        stage: "dev",
+        version: 2,
+        meta: { command: "destroy" },
+        startedAt: 1,
+        heartbeatAt: 2,
+        endedAt: 3,
+        outcome: "completed-late",
+        summary: { counts: { create: 1, delete: 2 }, error: "boom" },
+      });
+      expect(record.outcome).toBe("completed-late");
+      expect(record.summary?.counts).toEqual({ create: 1, delete: 2 });
+    }),
+  );
+
+  it.effect("rejects an unknown outcome", () =>
+    Effect.gen(function* () {
+      const result = yield* Effect.result(
+        decodeRecord({
+          stack: "s",
+          stage: "dev",
+          version: 2,
+          meta: { command: "deploy" },
+          startedAt: 1,
+          heartbeatAt: 2,
+          outcome: "exploded",
+        }),
+      );
+      expect(Result.isFailure(result)).toBe(true);
+    }),
+  );
+
+  it.effect("events carry payloads verbatim and fqn optionally", () =>
+    Effect.gen(function* () {
+      const event = yield* decodeEvent({
+        seq: 1,
+        ts: 10,
+        payload: { kind: "note", nested: [1, 2, 3] },
+      });
+      expect(event.fqn).toBeUndefined();
+      expect(event.payload).toEqual({ kind: "note", nested: [1, 2, 3] });
+
+      const scoped = yield* decodeEvent({
+        seq: 2,
+        ts: 20,
+        fqn: "stack/resource",
+        payload: null,
+      });
+      expect(scoped.fqn).toBe("stack/resource");
+    }),
+  );
+
+  it.effect("wire error schemas decode with the Deployment.ts tags", () =>
+    Effect.gen(function* () {
+      const inProgress = yield* Schema.decodeUnknownEffect(
+        DeploymentInProgressWire,
+      )({
+        _tag: "DeploymentInProgress",
+        stack: "s",
+        stage: "dev",
+        holder: {
+          stack: "s",
+          stage: "dev",
+          version: 1,
+          meta: { command: "deploy" },
+          startedAt: 1,
+          heartbeatAt: 2,
+        },
+      });
+      expect(inProgress._tag).toBe("DeploymentInProgress");
+      expect(inProgress.holder.version).toBe(1);
+
+      const tokenInvalid = yield* Schema.decodeUnknownEffect(
+        DeploymentTokenInvalidWire,
+      )({
+        _tag: "DeploymentTokenInvalid",
+        stack: "s",
+        stage: "dev",
+        version: 1,
+      });
+      expect(tokenInvalid._tag).toBe("DeploymentTokenInvalid");
+
+      const notFound = yield* Schema.decodeUnknownEffect(
+        DeploymentNotFoundWire,
+      )({ _tag: "DeploymentNotFound", stack: "s", stage: "dev", version: 9 });
+      expect(notFound._tag).toBe("DeploymentNotFound");
+    }),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Live conformance run against the DEPLOYED Cloudflare state store.
+//
+// Gated behind ALCHEMY_TEST_STATE_CF because it talks to the real
+// `alchemy-state-store` worker on the configured profile's account. The
+// operator must have bootstrapped the store at STATE_STORE_VERSION >= 8
+// (`alchemy bootstrap cloudflare`) before running:
+//
+//   ALCHEMY_TEST_STATE_CF=1 ALCHEMY_PROFILE=testing \
+//     bun vitest run test/Cloudflare/StateStore/CfDeployments.test.ts
+//
+// NOTE: the shared conformance suite runs under `it.effect`'s TestClock, so
+// only *server-side* time advances — which is exactly what the deployment
+// semantics key off (heartbeats, TTLs and timestamps are all stamped by the
+// Durable Object's real clock). Client-side retry schedules will not tick
+// under the TestClock, so the store must already be healthy and serving.
+// ---------------------------------------------------------------------------
+
+const platformLayer = Layer.mergeAll(
+  PlatformServices,
+  FetchHttpClient.layer,
+  Layer.provide(ProfileLive, PlatformServices),
+  Layer.provide(CredentialsStoreLive, PlatformServices),
+);
+
+/**
+ * Build a fresh `StateService` over the deployed store — mirrors the layer
+ * composition in `Test/Core.ts`'s `toEffect`, minus the stack/deploy
+ * machinery the conformance suite doesn't need.
+ */
+const makeLiveState = () =>
+  Effect.gen(function* () {
+    return yield* yield* State;
+  }).pipe(
+    Effect.provide(Cloudflare.state()),
+    Effect.provideService(AuthProviders, {}),
+    Effect.provide(
+      Layer.provideMerge(
+        Layer.mergeAll(LoggingCli, AlchemyContextLive),
+        platformLayer,
+      ),
+    ),
+  );
+
+describe("Cloudflare state store (live)", () => {
+  // The conformance suite assumes a fresh backend (versions start at 1),
+  // but the Durable Object persists across runs — wipe the conformance
+  // stack (its slug is derived from the label below) first. The DO's
+  // deleteAll clears both KV (records, counters, open markers) and SQL
+  // (the events table).
+  beforeAll(async () => {
+    await Effect.runPromise(
+      makeLiveState().pipe(
+        Effect.flatMap((state) =>
+          state.deleteStack({
+            stack: "cloudflare-deploymentstore-conformance",
+          }),
+        ),
+      ) as Effect.Effect<void, unknown, never>,
+    );
+  }, 120_000);
+
+  deploymentStoreConformance({
+    label: "Cloudflare DeploymentStore",
+    make: makeLiveState,
+    persistent: true,
+  });
+});

--- a/packages/alchemy/test/State/DeploymentSession.test.ts
+++ b/packages/alchemy/test/State/DeploymentSession.test.ts
@@ -1,0 +1,526 @@
+import type { ApplyEvent } from "@/Cli/Event.ts";
+import {
+  InMemoryService,
+  makeDeploymentSession,
+  makeLocalState,
+  StateStoreError,
+  type DeploymentEvent,
+  type ResourceState,
+  type StateService,
+} from "@/State";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as FileSystem from "effect/FileSystem";
+import * as Result from "effect/Result";
+import * as Scope from "effect/Scope";
+import * as TestClock from "effect/testing/TestClock";
+
+const resource = (fqn: string, status: "created" | "updating" = "created") =>
+  ({
+    resourceType: "test:resource",
+    namespace: undefined,
+    fqn,
+    logicalId: fqn,
+    instanceId: `instance-${fqn}`,
+    providerVersion: 1,
+    status,
+    downstream: [],
+    bindings: [],
+    props: {},
+    attr: {},
+  }) as ResourceState;
+
+const applyEvent = (n: number): ApplyEvent => ({
+  kind: "status-change",
+  id: `res-${n}`,
+  fqn: `ns/res-${n}`,
+  type: "test:resource",
+  status: "creating",
+  ts: n,
+});
+
+const meta = { command: "deploy" as const, initiator: { user: "test" } };
+
+/** Unique (stack, stage) per case so cases never interfere. */
+const ids = (name: string) => ({ stack: "deployment-session", stage: name });
+
+describe("DeploymentSession", () => {
+  it.effect("no-deployments store → no-op session, passthrough works", () =>
+    Effect.gen(function* () {
+      const { stack, stage } = ids("no-deployments");
+      const full = yield* InMemoryService();
+      // A third-party store without deployment history support.
+      const store: StateService = { ...full, deployments: undefined };
+
+      yield* Effect.scoped(
+        Effect.gen(function* () {
+          const session = yield* makeDeploymentSession({
+            store,
+            stack,
+            stage,
+            meta,
+          });
+          expect(session.version).toBeUndefined();
+          expect(session.state).toBe(store);
+
+          // journaling is a total no-op, never an error
+          yield* session.emit(applyEvent(1));
+
+          // state passthrough still works
+          const value = resource("res-a");
+          yield* session.state.set({ stack, stage, fqn: value.fqn, value });
+          expect(yield* store.get({ stack, stage, fqn: value.fqn })).toEqual(
+            value,
+          );
+
+          yield* session.end("succeeded");
+        }),
+      );
+    }),
+  );
+
+  it.effect(
+    "journals deployment-start + emits + deployment-end with contiguous seq",
+    () =>
+      Effect.gen(function* () {
+        const { stack, stage } = ids("journal");
+        const store = yield* InMemoryService();
+
+        yield* Effect.scoped(
+          Effect.gen(function* () {
+            const session = yield* makeDeploymentSession({
+              store,
+              stack,
+              stage,
+              meta,
+            });
+            expect(session.version).toBe(1);
+            yield* session.emit(applyEvent(1));
+            yield* session.emit(applyEvent(2));
+            yield* session.emit(applyEvent(3));
+            yield* session.end("succeeded", { counts: { create: 3 } });
+          }),
+        );
+
+        const record = yield* store.deployments!.get({
+          stack,
+          stage,
+          version: 1,
+        });
+        expect(record?.outcome).toBe("succeeded");
+        expect(record?.summary).toEqual({ counts: { create: 3 } });
+
+        const events = yield* store.deployments!.readEvents({
+          stack,
+          stage,
+          version: 1,
+        });
+        expect(events.map((e) => e.seq)).toEqual([1, 2, 3, 4, 5]);
+        for (const e of events) {
+          expect(typeof e.ts).toBe("number");
+        }
+        expect(events[0].payload).toEqual({
+          kind: "deployment-start",
+          command: "deploy",
+        });
+        expect((events[1].payload as ApplyEvent).kind).toBe("status-change");
+        expect(events[1].fqn).toBe("ns/res-1");
+        // journal envelope ts mirrors the ApplyEvent's emission ts
+        expect(events[1].ts).toBe(1);
+        expect(events[4].payload).toEqual({
+          kind: "deployment-end",
+          outcome: "succeeded",
+          summary: { counts: { create: 3 } },
+        });
+      }),
+  );
+
+  it.effect("facade set/delete journal state events AND write head state", () =>
+    Effect.gen(function* () {
+      const { stack, stage } = ids("facade");
+      const store = yield* InMemoryService();
+
+      yield* Effect.scoped(
+        Effect.gen(function* () {
+          const session = yield* makeDeploymentSession({
+            store,
+            stack,
+            stage,
+            meta,
+          });
+          const first = resource("res-a", "created");
+          yield* session.state.set({
+            stack,
+            stage,
+            fqn: first.fqn,
+            value: first,
+          });
+          const second = resource("res-a", "updating");
+          yield* session.state.set({
+            stack,
+            stage,
+            fqn: second.fqn,
+            value: second,
+          });
+          // head state is written through to the real store
+          expect(
+            (yield* store.get({ stack, stage, fqn: "res-a" }))?.status,
+          ).toBe("updating");
+
+          yield* session.state.delete({ stack, stage, fqn: "res-a" });
+          expect(
+            yield* store.get({ stack, stage, fqn: "res-a" }),
+          ).toBeUndefined();
+
+          yield* session.state.setOutput({ stack, stage, value: { a: 1 } });
+          expect(yield* store.getOutput({ stack, stage })).toEqual({ a: 1 });
+
+          yield* session.end("succeeded");
+        }),
+      );
+
+      const events = yield* store.deployments!.readEvents({
+        stack,
+        stage,
+        version: 1,
+      });
+      const payloads = events.map((e) => e.payload) as {
+        kind: string;
+        [k: string]: unknown;
+      }[];
+      expect(payloads.map((p) => p.kind)).toEqual([
+        "deployment-start",
+        "state-set",
+        "state-set",
+        "state-delete",
+        "output-set",
+        "deployment-end",
+      ]);
+      // first write: greenfield, no before image
+      expect(payloads[1]).toEqual({
+        kind: "state-set",
+        fqn: "res-a",
+        status: "created",
+      });
+      // second write carries a status-only before image, never full bodies
+      expect(payloads[2]).toEqual({
+        kind: "state-set",
+        fqn: "res-a",
+        status: "updating",
+        before: { status: "created" },
+      });
+      expect(payloads[3]).toEqual({
+        kind: "state-delete",
+        fqn: "res-a",
+        before: { status: "updating" },
+      });
+      expect(payloads[4]).toEqual({ kind: "output-set" });
+      // envelope fqn is stamped for state events
+      expect(events[1].fqn).toBe("res-a");
+      expect(events[3].fqn).toBe("res-a");
+    }),
+  );
+
+  it.effect("end is idempotent (first outcome wins, one deployment-end)", () =>
+    Effect.gen(function* () {
+      const { stack, stage } = ids("end-idempotent");
+      const store = yield* InMemoryService();
+
+      yield* Effect.scoped(
+        Effect.gen(function* () {
+          const session = yield* makeDeploymentSession({
+            store,
+            stack,
+            stage,
+            meta,
+          });
+          yield* session.end("failed", { error: "boom" });
+          yield* session.end("succeeded");
+          // post-end emits are dropped, not errors
+          yield* session.emit(applyEvent(9));
+        }),
+      );
+
+      const record = yield* store.deployments!.get({
+        stack,
+        stage,
+        version: 1,
+      });
+      expect(record?.outcome).toBe("failed");
+      expect(record?.summary).toEqual({ error: "boom" });
+
+      const events = yield* store.deployments!.readEvents({
+        stack,
+        stage,
+        version: 1,
+      });
+      const kinds = events.map((e) => (e.payload as { kind: string }).kind);
+      expect(kinds).toEqual(["deployment-start", "deployment-end"]);
+    }),
+  );
+
+  it.effect("scope close without end → record outcome interrupted", () =>
+    Effect.gen(function* () {
+      const { stack, stage } = ids("interrupted");
+      const store = yield* InMemoryService();
+
+      const scope = yield* Scope.make();
+      const session = yield* Scope.provide(
+        makeDeploymentSession({ store, stack, stage, meta }),
+        scope,
+      );
+      yield* session.emit(applyEvent(1));
+      // no end() — the crash/interrupt path
+      yield* Scope.close(scope, Exit.void);
+
+      const record = yield* store.deployments!.get({
+        stack,
+        stage,
+        version: 1,
+      });
+      expect(record?.outcome).toBe("interrupted");
+
+      const events = yield* store.deployments!.readEvents({
+        stack,
+        stage,
+        version: 1,
+      });
+      const kinds = events.map((e) => (e.payload as { kind: string }).kind);
+      expect(kinds).toEqual([
+        "deployment-start",
+        "status-change",
+        "deployment-end",
+      ]);
+      expect(events.at(-1)?.payload).toEqual({
+        kind: "deployment-end",
+        outcome: "interrupted",
+      });
+    }),
+  );
+
+  it.effect("second concurrent session fails with DeploymentInProgress", () =>
+    Effect.gen(function* () {
+      const { stack, stage } = ids("conflict");
+      const store = yield* InMemoryService();
+
+      yield* Effect.scoped(
+        Effect.gen(function* () {
+          const session = yield* makeDeploymentSession({
+            store,
+            stack,
+            stage,
+            meta,
+          });
+          expect(session.version).toBe(1);
+
+          const result = yield* Effect.result(
+            Effect.scoped(makeDeploymentSession({ store, stack, stage, meta })),
+          );
+          expect(Result.isFailure(result)).toBe(true);
+          if (Result.isFailure(result)) {
+            expect(result.failure._tag).toBe("DeploymentInProgress");
+          }
+          yield* session.end("succeeded");
+        }),
+      );
+    }),
+  );
+
+  it.effect("size threshold flushes without time passing or end()", () =>
+    Effect.gen(function* () {
+      const { stack, stage } = ids("threshold");
+      const store = yield* InMemoryService();
+
+      yield* Effect.scoped(
+        Effect.gen(function* () {
+          const session = yield* makeDeploymentSession({
+            store,
+            stack,
+            stage,
+            meta,
+          });
+          // deployment-start (seq 1) + 49 emits = 50 buffered → flush
+          for (let n = 1; n <= 49; n++) {
+            yield* session.emit(applyEvent(n));
+          }
+          const events = yield* store.deployments!.readEvents({
+            stack,
+            stage,
+            version: 1,
+          });
+          expect(events.length).toBe(50);
+          yield* session.end("succeeded");
+        }),
+      );
+    }),
+  );
+
+  it.effect("interval flusher drains the buffer under TestClock", () =>
+    Effect.gen(function* () {
+      const { stack, stage } = ids("interval");
+      const store = yield* InMemoryService();
+
+      yield* Effect.scoped(
+        Effect.gen(function* () {
+          const session = yield* makeDeploymentSession({
+            store,
+            stack,
+            stage,
+            meta,
+          });
+          yield* session.emit(applyEvent(1));
+
+          // nothing flushed yet (below the size threshold, no time passed)
+          expect(
+            (yield* store.deployments!.readEvents({
+              stack,
+              stage,
+              version: 1,
+            })).length,
+          ).toBe(0);
+
+          yield* TestClock.adjust("1 second");
+
+          const events = yield* store.deployments!.readEvents({
+            stack,
+            stage,
+            version: 1,
+          });
+          expect(events.map((e) => e.seq)).toEqual([1, 2]);
+          yield* session.end("succeeded");
+        }),
+      );
+    }),
+  );
+
+  it.effect("heartbeat fiber refreshes the open marker", () =>
+    Effect.gen(function* () {
+      const { stack, stage } = ids("heartbeat");
+      const store = yield* InMemoryService();
+
+      yield* Effect.scoped(
+        Effect.gen(function* () {
+          const session = yield* makeDeploymentSession({
+            store,
+            stack,
+            stage,
+            meta,
+          });
+          expect(session.version).toBe(1);
+          const before = yield* store.deployments!.get({
+            stack,
+            stage,
+            version: 1,
+          });
+          yield* TestClock.adjust("10 seconds");
+          const after = yield* store.deployments!.get({
+            stack,
+            stage,
+            version: 1,
+          });
+          expect(after!.heartbeatAt).toBeGreaterThan(before!.heartbeatAt);
+          yield* session.end("succeeded");
+        }),
+      );
+    }),
+  );
+
+  it.effect("journal append failures never fail deploy-visible effects", () =>
+    Effect.gen(function* () {
+      const { stack, stage } = ids("append-fails");
+      const store = yield* InMemoryService();
+      const failing: StateService = {
+        ...store,
+        deployments: {
+          ...store.deployments!,
+          appendEvents: () =>
+            Effect.fail(new StateStoreError({ message: "journal down" })),
+        },
+      };
+
+      yield* Effect.scoped(
+        Effect.gen(function* () {
+          const session = yield* makeDeploymentSession({
+            store: failing,
+            stack,
+            stage,
+            meta,
+          });
+          // emits (including the threshold-triggered flush) succeed
+          for (let n = 1; n <= 60; n++) {
+            yield* session.emit(applyEvent(n));
+          }
+          // facade writes still succeed and hit head state
+          const value = resource("res-a");
+          yield* session.state.set({ stack, stage, fqn: value.fqn, value });
+          expect(
+            yield* store.get({ stack, stage, fqn: "res-a" }),
+          ).toBeDefined();
+          yield* session.end("succeeded");
+        }),
+      );
+
+      const record = yield* store.deployments!.get({
+        stack,
+        stage,
+        version: 1,
+      });
+      expect(record?.outcome).toBe("succeeded");
+      // nothing was journaled — and nothing failed because of it
+      const events = yield* store.deployments!.readEvents({
+        stack,
+        stage,
+        version: 1,
+      });
+      expect(events.length).toBe(0);
+    }),
+  );
+
+  it.effect("facade tee works over the local FS store", () =>
+    Effect.gen(function* () {
+      const { stack, stage } = ids("local-fs");
+      const fs = yield* FileSystem.FileSystem;
+      const root = yield* fs.makeTempDirectory({
+        prefix: "alchemy-deployment-session-",
+      });
+      const store = yield* makeLocalState({ rootDir: root });
+
+      yield* Effect.scoped(
+        Effect.gen(function* () {
+          const session = yield* makeDeploymentSession({
+            store,
+            stack,
+            stage,
+            meta,
+          });
+          expect(session.version).toBe(1);
+          const value = resource("res-a");
+          yield* session.state.set({ stack, stage, fqn: value.fqn, value });
+          yield* session.emit(applyEvent(1));
+          yield* session.end("succeeded");
+        }),
+      );
+
+      // head row written
+      expect(yield* store.get({ stack, stage, fqn: "res-a" })).toBeDefined();
+      // journal persisted
+      const record = yield* store.deployments!.get({
+        stack,
+        stage,
+        version: 1,
+      });
+      expect(record?.outcome).toBe("succeeded");
+      const events: readonly DeploymentEvent[] =
+        yield* store.deployments!.readEvents({ stack, stage, version: 1 });
+      const kinds = events.map((e) => (e.payload as { kind: string }).kind);
+      expect(kinds).toEqual([
+        "deployment-start",
+        "state-set",
+        "status-change",
+        "deployment-end",
+      ]);
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+});

--- a/packages/alchemy/test/State/EngineJournal.test.ts
+++ b/packages/alchemy/test/State/EngineJournal.test.ts
@@ -1,0 +1,591 @@
+/**
+ * Engine ⇄ deployment-journal integration: every deploy/destroy driven
+ * through `apply()` opens a DeploymentSession against the state store's
+ * `deployments` API, tees all apply events into the journal, journals every
+ * engine state write, and closes the version with the run's outcome.
+ */
+import { spawnSync } from "node:child_process";
+import * as os from "node:os";
+import { apply, canTakeOverDeployment, isProcessAlive } from "@/Apply";
+import { provideFreshArtifactStore } from "@/Artifacts";
+import * as Plan from "@/Plan";
+import { make as makeStack } from "@/Stack";
+import { Stage } from "@/Stage";
+import {
+  InMemoryService,
+  localState,
+  State,
+  StateStoreError,
+  type DeploymentEvent,
+  type StateService,
+} from "@/State";
+import * as Test from "@/Test/Vitest";
+import { describe, expect } from "@effect/vitest";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+import * as Ref from "effect/Ref";
+import * as Result from "effect/Result";
+import {
+  TestLayers,
+  TestResource,
+  TestResourceHooks,
+} from "../test.resources.ts";
+
+const { test } = Test.make({ providers: TestLayers() });
+
+class JournalTestFailure extends Data.TaggedError("JournalTestFailure")<{
+  message: string;
+}> {}
+
+const kindsOf = (events: readonly DeploymentEvent[]) =>
+  events.map((e) => (e.payload as { kind: string }).kind);
+
+const payloadsOf = <T = Record<string, unknown>>(
+  events: readonly DeploymentEvent[],
+  kind: string,
+): T[] =>
+  events
+    .map((e) => e.payload as { kind: string })
+    .filter((p) => p.kind === kind) as T[];
+
+/** The scratch's own in-memory store (shared with the deploys). */
+const getStore = Effect.gen(function* () {
+  const store = yield* yield* State;
+  expect(store.deployments).toBeDefined();
+  return store;
+});
+
+describe("engine deployment journaling", () => {
+  test.provider("deploy journals version 1 with a full event trail", (stack) =>
+    Effect.gen(function* () {
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          const A = yield* TestResource("A", { string: "a" });
+          const B = yield* TestResource("B", { string: A.string });
+          return { A, B };
+        }),
+      );
+
+      const store = yield* getStore;
+      const list = yield* store.deployments!.list({
+        stack: stack.name,
+        stage: "test",
+      });
+      expect(list).toHaveLength(1);
+      expect(list[0].version).toBe(1);
+      expect(list[0].outcome).toBe("succeeded");
+      expect(list[0].meta.command).toBe("deploy");
+      expect(list[0].meta.initiator?.pid).toBe(process.pid);
+      expect(typeof list[0].meta.initiator?.host).toBe("string");
+      expect(typeof list[0].meta.alchemyVersion).toBe("string");
+      expect(list[0].summary?.counts).toMatchObject({ create: 2 });
+
+      const events = yield* store.deployments!.readEvents({
+        stack: stack.name,
+        stage: "test",
+        version: 1,
+      });
+
+      // seq is contiguous from 1 and every event carries an emission ts
+      expect(events.map((e) => e.seq)).toEqual(events.map((_, i) => i + 1));
+      for (const e of events) {
+        expect(typeof e.ts).toBe("number");
+      }
+
+      const kinds = kindsOf(events);
+      expect(kinds[0]).toBe("deployment-start");
+      expect(kinds.at(-1)).toBe("deployment-end");
+      expect(kinds).toContain("status-change");
+      expect(kinds).toContain("state-set");
+      expect(kinds).toContain("output-set");
+
+      // one create op-start/op-end pair per resource, correlated by opId
+      const starts = payloadsOf<{
+        opId: string;
+        op: string;
+        id: string;
+        fqn?: string;
+      }>(events, "op-start");
+      const ends = payloadsOf<{ opId: string; outcome: string }>(
+        events,
+        "op-end",
+      );
+      const creates = starts.filter((s) => s.op === "create");
+      expect(creates).toHaveLength(2);
+      expect(new Set(creates.map((s) => s.fqn))).toEqual(new Set(["A", "B"]));
+      for (const start of starts) {
+        const end = ends.find((e) => e.opId === start.opId);
+        expect(end).toBeDefined();
+        expect(end!.outcome).toBe("ok");
+      }
+
+      const endPayload = payloadsOf<{
+        outcome: string;
+        summary?: { counts?: Record<string, number> };
+      }>(events, "deployment-end")[0];
+      expect(endPayload.outcome).toBe("succeeded");
+    }),
+  );
+
+  test.provider("second deploy allocates version 2", (stack) =>
+    Effect.gen(function* () {
+      yield* stack.deploy(TestResource("A", { string: "v1" }));
+      yield* stack.deploy(TestResource("A", { string: "v2" }));
+
+      const store = yield* getStore;
+      const list = yield* store.deployments!.list({
+        stack: stack.name,
+        stage: "test",
+      });
+      // newest first
+      expect(list.map((r) => r.version)).toEqual([2, 1]);
+      expect(list[0].outcome).toBe("succeeded");
+      expect(list[0].summary?.counts).toMatchObject({ update: 1 });
+
+      const events = yield* store.deployments!.readEvents({
+        stack: stack.name,
+        stage: "test",
+        version: 2,
+      });
+      const updates = payloadsOf<{ op: string }>(events, "op-start").filter(
+        (s) => s.op === "update",
+      );
+      expect(updates.length).toBeGreaterThanOrEqual(1);
+    }),
+  );
+
+  test.provider("destroy journals a destroy-command version", (stack) =>
+    Effect.gen(function* () {
+      yield* stack.deploy(TestResource("A", { string: "a" }));
+      yield* stack.destroy();
+
+      const store = yield* getStore;
+      const list = yield* store.deployments!.list({
+        stack: stack.name,
+        stage: "test",
+      });
+      expect(list.map((r) => r.version)).toEqual([2, 1]);
+      expect(list[0].meta.command).toBe("destroy");
+      expect(list[0].outcome).toBe("succeeded");
+
+      const events = yield* store.deployments!.readEvents({
+        stack: stack.name,
+        stage: "test",
+        version: 2,
+      });
+      const kinds = kindsOf(events);
+      expect(kinds[0]).toBe("deployment-start");
+      expect(kinds.at(-1)).toBe("deployment-end");
+      expect(kinds).toContain("state-delete");
+      const deletes = payloadsOf<{ op: string; opId: string }>(
+        events,
+        "op-start",
+      ).filter((s) => s.op === "delete");
+      expect(deletes).toHaveLength(1);
+      const ends = payloadsOf<{ opId: string; outcome: string }>(
+        events,
+        "op-end",
+      );
+      expect(ends.find((e) => e.opId === deletes[0].opId)?.outcome).toBe("ok");
+      expect(
+        payloadsOf<{ command: string }>(events, "deployment-start")[0].command,
+      ).toBe("destroy");
+    }),
+  );
+
+  test.provider(
+    "failed deploy records outcome failed with an error digest",
+    (stack) =>
+      Effect.gen(function* () {
+        const result = yield* Effect.result(
+          stack.deploy(TestResource("A", { string: "a" })).pipe(
+            Effect.provide(
+              Layer.succeed(TestResourceHooks, {
+                create: () =>
+                  Effect.fail(
+                    new JournalTestFailure({ message: "create exploded" }),
+                  ),
+              }),
+            ),
+          ),
+        );
+        expect(Result.isFailure(result)).toBe(true);
+
+        const store = yield* getStore;
+        const record = yield* store.deployments!.get({
+          stack: stack.name,
+          stage: "test",
+          version: 1,
+        });
+        expect(record?.outcome).toBe("failed");
+        expect(record?.summary?.error).toContain("JournalTestFailure");
+
+        const events = yield* store.deployments!.readEvents({
+          stack: stack.name,
+          stage: "test",
+          version: 1,
+        });
+        const ends = payloadsOf<{ outcome: string; error?: string }>(
+          events,
+          "op-end",
+        );
+        const failed = ends.filter((e) => e.outcome === "fail");
+        expect(failed).toHaveLength(1);
+        expect(failed[0].error).toContain("JournalTestFailure");
+        const endPayload = payloadsOf<{ outcome: string }>(
+          events,
+          "deployment-end",
+        )[0];
+        expect(endPayload.outcome).toBe("failed");
+      }),
+  );
+
+  test.provider(
+    "a live open deployment blocks a second deploy with DeploymentInProgress",
+    (stack) =>
+      Effect.gen(function* () {
+        const store = yield* getStore;
+        const held = yield* store.deployments!.begin({
+          stack: stack.name,
+          stage: "test",
+          meta: { command: "deploy", initiator: { user: "other" } },
+        });
+
+        const result = yield* Effect.result(
+          stack.deploy(TestResource("A", { string: "a" })),
+        );
+        expect(Result.isFailure(result)).toBe(true);
+        if (Result.isFailure(result)) {
+          expect((result.failure as { _tag?: string })._tag).toBe(
+            "DeploymentInProgress",
+          );
+        }
+
+        // the blocked attempt never allocated a version
+        const list = yield* store.deployments!.list({
+          stack: stack.name,
+          stage: "test",
+        });
+        expect(list).toHaveLength(1);
+        expect(list[0].version).toBe(held.version);
+
+        // release the lease so the harness teardown destroy can run
+        yield* store.deployments!.end({
+          stack: stack.name,
+          stage: "test",
+          version: held.version,
+          token: held.token,
+          outcome: "succeeded",
+        });
+
+        // with the lease released the deploy goes through and journals v2
+        yield* stack.deploy(TestResource("A", { string: "a" }));
+        const after = yield* store.deployments!.list({
+          stack: stack.name,
+          stage: "test",
+        });
+        expect(after.map((r) => r.version)).toEqual([2, 1]);
+        expect(after[0].outcome).toBe("succeeded");
+      }),
+  );
+
+  test.provider(
+    "a live open held by a dead same-host process is taken over (supersede)",
+    (stack) =>
+      Effect.gen(function* () {
+        const store = yield* getStore;
+
+        // A pid that provably existed on this host and is now gone: spawn
+        // a short-lived child and wait for it to exit.
+        const deadPid = yield* Effect.sync(
+          () => spawnSync(process.execPath, ["--version"]).pid,
+        );
+        expect(typeof deadPid).toBe("number");
+
+        const held = yield* store.deployments!.begin({
+          stack: stack.name,
+          stage: "test",
+          meta: {
+            command: "deploy",
+            initiator: {
+              user: "crashed-cli",
+              host: os.hostname(),
+              pid: deadPid,
+            },
+          },
+        });
+
+        // The holder's heartbeat is fresh, but its process is dead on THIS
+        // host — the deploy takes over instead of failing.
+        yield* stack.deploy(TestResource("A", { string: "a" }));
+
+        const list = yield* store.deployments!.list({
+          stack: stack.name,
+          stage: "test",
+        });
+        expect(list.map((r) => r.version)).toEqual([
+          held.version + 1,
+          held.version,
+        ]);
+        expect(list[0].outcome).toBe("succeeded");
+        // The dead holder's version was reconciled to abandoned.
+        expect(list[1].outcome).toBe("abandoned");
+      }),
+  );
+
+  test(
+    "takeover predicate: only same-host dead pids qualify",
+    Effect.gen(function* () {
+      const holder = (initiator?: {
+        user?: string;
+        host?: string;
+        pid?: number;
+      }) => ({
+        stack: "s",
+        stage: "t",
+        version: 1,
+        meta: { command: "deploy" as const, initiator },
+        startedAt: 0,
+        heartbeatAt: 0,
+      });
+      const self = { host: "this-host", pid: 100 };
+      const dead = () => false;
+      const alive = () => true;
+
+      // same host + dead pid → takeover
+      expect(
+        canTakeOverDeployment(
+          holder({ host: "this-host", pid: 7 }),
+          self,
+          dead,
+        ),
+      ).toBe(true);
+      // same host + live pid → no
+      expect(
+        canTakeOverDeployment(
+          holder({ host: "this-host", pid: 7 }),
+          self,
+          alive,
+        ),
+      ).toBe(false);
+      // different host → never (the pid check is meaningless there)
+      expect(
+        canTakeOverDeployment(
+          holder({ host: "other-host", pid: 7 }),
+          self,
+          dead,
+        ),
+      ).toBe(false);
+      // missing host or pid → never
+      expect(canTakeOverDeployment(holder({ pid: 7 }), self, dead)).toBe(false);
+      expect(
+        canTakeOverDeployment(holder({ host: "this-host" }), self, dead),
+      ).toBe(false);
+      expect(canTakeOverDeployment(holder(undefined), self, dead)).toBe(false);
+      // our own pid → never (we cannot supersede ourselves)
+      expect(
+        canTakeOverDeployment(
+          holder({ host: "this-host", pid: 100 }),
+          self,
+          dead,
+        ),
+      ).toBe(false);
+
+      // the real liveness check recognizes our own process as alive
+      expect(isProcessAlive(process.pid)).toBe(true);
+    }),
+  );
+
+  test.provider(
+    "a deploy superseded mid-flight is fenced on its next state write",
+    (stack) =>
+      Effect.gen(function* () {
+        const store = yield* getStore;
+        const usurper = yield* Ref.make<
+          { version: number; token: string } | undefined
+        >(undefined);
+
+        // The create hook plays the usurper: while the deploy (v1) is
+        // mid-operation, a second deployment begins with supersede: 1 —
+        // exactly what a same-host takeover of a "dead" holder does. The
+        // deploy's own post-create state write carries fence: 1, sees
+        // that v2 exists, and MUST be rejected, failing the zombie apply.
+        const result = yield* Effect.result(
+          stack.deploy(TestResource("A", { string: "a" })).pipe(
+            Effect.provide(
+              Layer.succeed(TestResourceHooks, {
+                create: () =>
+                  store
+                    .deployments!.begin({
+                      stack: stack.name,
+                      stage: "test",
+                      meta: {
+                        command: "deploy",
+                        initiator: { user: "usurper" },
+                      },
+                      supersede: 1,
+                    })
+                    .pipe(
+                      Effect.flatMap((held) => Ref.set(usurper, held)),
+                      Effect.orDie,
+                    ),
+              }),
+            ),
+          ),
+        );
+
+        expect(Result.isFailure(result)).toBe(true);
+        if (Result.isFailure(result)) {
+          const failure = result.failure as { _tag?: string; message?: string };
+          expect(failure._tag).toBe("StateStoreError");
+          expect(String(failure.message)).toContain("fenced");
+        }
+
+        // The zombie's write never landed: A is not in "created" state.
+        const state = yield* store.get({
+          stack: stack.name,
+          stage: "test",
+          fqn: "A",
+        });
+        expect((state as { status?: string } | undefined)?.status).not.toBe(
+          "created",
+        );
+
+        // v1 was reconciled to abandoned by the takeover; v2 is the
+        // usurper's live open.
+        const list = yield* store.deployments!.list({
+          stack: stack.name,
+          stage: "test",
+        });
+        expect(list.map((r) => r.version)).toEqual([2, 1]);
+        expect(["abandoned", "completed-late", "failed"]).toContain(
+          list[1].outcome,
+        );
+
+        // Close the usurper's lease so the harness teardown destroy can run.
+        const held = yield* Ref.get(usurper);
+        expect(held).toBeDefined();
+        yield* store.deployments!.end({
+          stack: stack.name,
+          stage: "test",
+          version: held!.version,
+          token: held!.token,
+          outcome: "succeeded",
+        });
+      }),
+  );
+
+  test(
+    "a StateStoreError from begin fails the deploy (fail-closed: no lock, no mutation)",
+    Effect.gen(function* () {
+      const store = yield* InMemoryService();
+      const failing: StateService = {
+        ...store,
+        deployments: {
+          ...store.deployments!,
+          begin: () =>
+            Effect.fail(
+              new StateStoreError({ message: "journal store unreachable" }),
+            ),
+        },
+      };
+
+      const stackName = "engine-journal-fail-closed";
+      const result = yield* Effect.result(
+        TestResource("A", { string: "a" }).pipe(
+          makeStack({
+            name: stackName,
+            providers: TestLayers(),
+            state: Layer.succeed(State, Effect.succeed(failing)),
+          } as any) as any,
+          Effect.flatMap((compiled: any) =>
+            Plan.make(compiled).pipe(
+              Effect.flatMap((plan) => apply(plan)),
+              Effect.provide(compiled.services),
+            ),
+          ),
+          Effect.provide(Layer.succeed(Stage, "test")),
+          provideFreshArtifactStore,
+        ) as unknown as Effect.Effect<unknown, unknown>,
+      );
+
+      // begin is the mutual-exclusion gate — its failure aborts the apply.
+      expect(Result.isFailure(result)).toBe(true);
+      if (Result.isFailure(result)) {
+        expect((result.failure as { _tag?: string })._tag).toBe(
+          "StateStoreError",
+        );
+      }
+
+      // Fail-closed: nothing was deployed and no version was allocated.
+      expect(
+        yield* store.get({ stack: stackName, stage: "test", fqn: "A" }),
+      ).toBeUndefined();
+      expect(
+        yield* store.deployments!.list({ stack: stackName, stage: "test" }),
+      ).toHaveLength(0);
+    }),
+  );
+
+  test(
+    "local-fs deploy persists .deployments record + events.jsonl on disk",
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fs.makeTempDirectory({
+        prefix: "alchemy-engine-journal-",
+      });
+
+      const stackName = "engine-journal-local";
+      yield* TestResource("A", { string: "a" }).pipe(
+        makeStack({
+          name: stackName,
+          providers: TestLayers(),
+          state: localState({ rootDir: root }),
+        } as any) as any,
+        Effect.flatMap((compiled: any) =>
+          Plan.make(compiled).pipe(
+            Effect.flatMap((plan) => apply(plan)),
+            Effect.provide(compiled.services),
+          ),
+        ),
+        Effect.provide(Layer.succeed(Stage, "test")),
+        provideFreshArtifactStore,
+      ) as unknown as Effect.Effect<void>;
+
+      const dir = path.join(
+        root,
+        ".alchemy",
+        "state",
+        stackName,
+        "test",
+        ".deployments",
+      );
+      const recordPath = path.join(dir, "1.record.json");
+      const eventsPath = path.join(dir, "1.events.jsonl");
+      expect(yield* fs.exists(recordPath)).toBe(true);
+      expect(yield* fs.exists(eventsPath)).toBe(true);
+
+      const record = JSON.parse(yield* fs.readFileString(recordPath));
+      expect(record.version).toBe(1);
+      expect(record.outcome).toBe("succeeded");
+      expect(record.meta.command).toBe("deploy");
+
+      const lines = (yield* fs.readFileString(eventsPath))
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as DeploymentEvent);
+      expect(lines.map((e) => e.seq)).toEqual(lines.map((_, i) => i + 1));
+      const kinds = kindsOf(lines);
+      expect(kinds[0]).toBe("deployment-start");
+      expect(kinds.at(-1)).toBe("deployment-end");
+      expect(kinds).toContain("op-start");
+      expect(kinds).toContain("op-end");
+      expect(kinds).toContain("state-set");
+    }),
+    { timeout: 30_000 },
+  );
+});

--- a/packages/alchemy/test/State/InMemoryDeployments.test.ts
+++ b/packages/alchemy/test/State/InMemoryDeployments.test.ts
@@ -1,0 +1,13 @@
+import { InMemoryService } from "@/State";
+import { deploymentStoreConformance } from "./deploymentStoreConformance.ts";
+
+// One shared underlying store for the whole file: the conformance suite
+// keys every case by a unique (stack, stage) pair, so cases never interfere
+// even though `make` always resolves the same instance.
+const service = InMemoryService();
+
+deploymentStoreConformance({
+  label: "InMemory DeploymentStore",
+  make: () => service,
+  persistent: false,
+});

--- a/packages/alchemy/test/State/LocalDeployments.test.ts
+++ b/packages/alchemy/test/State/LocalDeployments.test.ts
@@ -1,0 +1,76 @@
+import { makeLocalState, type ResourceState } from "@/State";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import { deploymentStoreConformance } from "./deploymentStoreConformance.ts";
+
+// One temp root shared by every `make()` call so the persistence case's two
+// store instances observe the same underlying storage. Never the repo's
+// `.alchemy` — this is a throwaway directory in the OS temp location.
+let root: string | undefined;
+
+const make = () =>
+  Effect.gen(function* () {
+    if (root === undefined) {
+      const fs = yield* FileSystem.FileSystem;
+      root = yield* fs.makeTempDirectory({
+        prefix: "alchemy-local-deployments-",
+      });
+    }
+    return yield* makeLocalState({ rootDir: root });
+  }).pipe(Effect.provide(NodeServices.layer));
+
+deploymentStoreConformance({
+  label: "Local DeploymentStore",
+  make,
+  persistent: true,
+});
+
+describe("Local DeploymentStore isolation", () => {
+  const resource = (fqn: string): ResourceState => ({
+    resourceType: "test:resource",
+    namespace: undefined,
+    fqn,
+    logicalId: fqn,
+    instanceId: `instance-${fqn}`,
+    providerVersion: 1,
+    status: "created",
+    downstream: [],
+    bindings: [],
+    props: {},
+    attr: {},
+  });
+
+  it.effect(
+    "resource list()/getAll()/listStages() ignore the .deployments directory",
+    () =>
+      Effect.gen(function* () {
+        const state = yield* make();
+        const stack = "local-deployments-isolation";
+        const stage = "main";
+
+        const a = resource("resource-a");
+        yield* state.set({ stack, stage, fqn: a.fqn, value: a });
+
+        const { version, token } = yield* state.deployments!.begin({
+          stack,
+          stage,
+          meta: { command: "deploy" },
+        });
+        yield* state.deployments!.appendEvents({
+          stack,
+          stage,
+          version,
+          token,
+          events: [{ seq: 1, ts: 10, payload: { kind: "note" } }],
+        });
+
+        // Resource-facing reads must not see the reserved `.deployments` dir.
+        expect(yield* state.list({ stack, stage })).toEqual(["resource-a"]);
+        const all = yield* state.getAll!({ stack, stage });
+        expect(Array.from(all.keys())).toEqual(["resource-a"]);
+        expect(yield* state.listStages(stack)).toEqual([stage]);
+      }),
+  );
+});

--- a/packages/alchemy/test/State/deploymentStoreConformance.ts
+++ b/packages/alchemy/test/State/deploymentStoreConformance.ts
@@ -1,0 +1,927 @@
+import type {
+  DeploymentEvent,
+  DeploymentMeta,
+  ResourceState,
+  StateService,
+} from "@/State";
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Result from "effect/Result";
+
+export interface DeploymentStoreConformanceOptions {
+  /** Label for the describe block, e.g. "InMemory deployments". */
+  label: string;
+  /**
+   * Build a fresh {@link StateService} over the SAME underlying storage.
+   * Called multiple times by persistence cases, so two invocations must
+   * observe each other's writes when `persistent` is true.
+   *
+   * Requirements must be pre-provided by the caller (e.g. via
+   * `Effect.provide`) so the returned effect runs in the plain test runtime.
+   */
+  make: () => Effect.Effect<StateService, unknown, unknown>;
+  /** Whether data must survive re-`make` (true for FS-backed stores). */
+  persistent: boolean;
+}
+
+/**
+ * Shared conformance suite for {@link DeploymentStore} implementations.
+ *
+ * Every case uses its own unique `(stack, stage)` pair so the suite is safe
+ * against shared/non-resettable backends and vitest's concurrent sequencing.
+ *
+ * NOTE: runs under `it.effect`'s TestClock — `Clock.currentTimeMillis` is 0
+ * and does not advance. Stale-open behavior is exercised via `ttlMillis: 0`
+ * (always stale) vs. the default TTL (always live).
+ */
+export const deploymentStoreConformance = (
+  options: DeploymentStoreConformanceOptions,
+): void => {
+  const slug = options.label.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+
+  // Callers pre-provide requirements; erase the (unknown) R for it.effect.
+  const makeState = () =>
+    options.make() as Effect.Effect<StateService, unknown, never>;
+
+  const makeStore = Effect.fn(function* () {
+    const state = yield* makeState();
+    const deployments = state.deployments;
+    if (deployments === undefined) {
+      return yield* Effect.die(
+        `state store '${options.label}' does not implement deployments`,
+      );
+    }
+    return { state, deployments };
+  });
+
+  /** Unique (stack, stage) per case so cases never interfere. */
+  const ids = (name: string) => ({
+    stack: `${slug}-conformance`,
+    stage: name,
+  });
+
+  const meta = (user = "conformance"): DeploymentMeta => ({
+    command: "deploy",
+    initiator: { user },
+  });
+
+  const event = (seq: number, payload?: unknown): DeploymentEvent => ({
+    seq,
+    ts: seq * 10,
+    payload: payload ?? { kind: "note", seq },
+  });
+
+  const resource = (fqn: string): ResourceState => ({
+    resourceType: "test:resource",
+    namespace: undefined,
+    fqn,
+    logicalId: fqn,
+    instanceId: `instance-${fqn}`,
+    providerVersion: 1,
+    status: "created",
+    downstream: [],
+    bindings: [],
+    props: {},
+    attr: {},
+  });
+
+  describe(options.label, () => {
+    it.effect("begin allocates version 1, then 2 after end (monotonic)", () =>
+      Effect.gen(function* () {
+        const { deployments } = yield* makeStore();
+        const { stack, stage } = ids("monotonic");
+
+        const first = yield* deployments.begin({ stack, stage, meta: meta() });
+        expect(first.version).toBe(1);
+        expect(typeof first.token).toBe("string");
+        expect(first.token.length).toBeGreaterThan(0);
+
+        yield* deployments.end({
+          stack,
+          stage,
+          version: first.version,
+          token: first.token,
+          outcome: "succeeded",
+        });
+
+        const second = yield* deployments.begin({ stack, stage, meta: meta() });
+        expect(second.version).toBe(2);
+        expect(second.token).not.toBe(first.token);
+      }),
+    );
+
+    it.effect(
+      "begin fails DeploymentInProgress with the holder record while a live open exists",
+      () =>
+        Effect.gen(function* () {
+          const { deployments } = yield* makeStore();
+          const { stack, stage } = ids("in-progress");
+
+          const first = yield* deployments.begin({
+            stack,
+            stage,
+            meta: meta("first-deployer"),
+          });
+
+          const result = yield* Effect.result(
+            deployments.begin({ stack, stage, meta: meta("second-deployer") }),
+          );
+          expect(Result.isFailure(result)).toBe(true);
+          if (Result.isFailure(result)) {
+            const failure = result.failure;
+            expect(failure._tag).toBe("DeploymentInProgress");
+            if (failure._tag === "DeploymentInProgress") {
+              expect(failure.stack).toBe(stack);
+              expect(failure.stage).toBe(stage);
+              expect(failure.holder.version).toBe(first.version);
+              expect(failure.holder.meta.initiator?.user).toBe(
+                "first-deployer",
+              );
+              expect(failure.holder.outcome).toBeUndefined();
+              expect("token" in failure.holder).toBe(false);
+            }
+          }
+        }),
+    );
+
+    it.effect(
+      "begin with ttlMillis: 0 reconciles the stale open to abandoned and allocates the next version",
+      () =>
+        Effect.gen(function* () {
+          const { deployments } = yield* makeStore();
+          const { stack, stage } = ids("stale-reconcile");
+
+          const first = yield* deployments.begin({
+            stack,
+            stage,
+            meta: meta(),
+          });
+          expect(first.version).toBe(1);
+
+          const second = yield* deployments.begin({
+            stack,
+            stage,
+            meta: meta(),
+            ttlMillis: 0,
+          });
+          expect(second.version).toBe(2);
+
+          const abandoned = yield* deployments.get({
+            stack,
+            stage,
+            version: 1,
+          });
+          expect(abandoned?.outcome).toBe("abandoned");
+          expect(abandoned?.endedAt).not.toBeUndefined();
+        }),
+    );
+
+    it.effect(
+      "begin with supersede matching the live open abandons it and allocates the next version",
+      () =>
+        Effect.gen(function* () {
+          const { deployments } = yield* makeStore();
+          const { stack, stage } = ids("supersede-match");
+
+          const first = yield* deployments.begin({
+            stack,
+            stage,
+            meta: meta("dead-holder"),
+          });
+          expect(first.version).toBe(1);
+
+          // Heartbeat is fresh (TestClock never advances), so without
+          // supersede this would fail DeploymentInProgress.
+          const second = yield* deployments.begin({
+            stack,
+            stage,
+            meta: meta("takeover"),
+            supersede: first.version,
+          });
+          expect(second.version).toBe(2);
+
+          const abandoned = yield* deployments.get({
+            stack,
+            stage,
+            version: first.version,
+          });
+          expect(abandoned?.outcome).toBe("abandoned");
+          expect(abandoned?.endedAt).not.toBeUndefined();
+        }),
+    );
+
+    it.effect(
+      "begin with a non-matching supersede still fails DeploymentInProgress",
+      () =>
+        Effect.gen(function* () {
+          const { deployments } = yield* makeStore();
+          const { stack, stage } = ids("supersede-mismatch");
+
+          const first = yield* deployments.begin({
+            stack,
+            stage,
+            meta: meta("live-holder"),
+          });
+
+          // The takeover was aimed at a version that is no longer the open
+          // one (e.g. a legitimate deploy claimed the stage in between) —
+          // it must lose like any other begin.
+          const result = yield* Effect.result(
+            deployments.begin({
+              stack,
+              stage,
+              meta: meta("stale-takeover"),
+              supersede: first.version + 41,
+            }),
+          );
+          expect(Result.isFailure(result)).toBe(true);
+          if (Result.isFailure(result)) {
+            expect(result.failure._tag).toBe("DeploymentInProgress");
+          }
+
+          // The live holder was untouched.
+          const holder = yield* deployments.get({
+            stack,
+            stage,
+            version: first.version,
+          });
+          expect(holder?.outcome).toBeUndefined();
+          expect(holder?.endedAt).toBeUndefined();
+        }),
+    );
+
+    it.effect(
+      "end sets outcome/endedAt/summary; repeat end is a no-op preserving the first outcome",
+      () =>
+        Effect.gen(function* () {
+          const { deployments } = yield* makeStore();
+          const { stack, stage } = ids("end-idempotent");
+
+          const { version, token } = yield* deployments.begin({
+            stack,
+            stage,
+            meta: meta(),
+          });
+
+          yield* deployments.end({
+            stack,
+            stage,
+            version,
+            token,
+            outcome: "failed",
+            summary: { counts: { create: 1 }, error: "boom" },
+          });
+
+          const ended = yield* deployments.get({ stack, stage, version });
+          expect(ended?.outcome).toBe("failed");
+          expect(ended?.endedAt).not.toBeUndefined();
+          expect(ended?.summary).toEqual({
+            counts: { create: 1 },
+            error: "boom",
+          });
+
+          // Repeat end (even with a different outcome/summary) is a no-op.
+          yield* deployments.end({
+            stack,
+            stage,
+            version,
+            token,
+            outcome: "succeeded",
+            summary: { counts: { update: 9 } },
+          });
+
+          const after = yield* deployments.get({ stack, stage, version });
+          expect(after?.outcome).toBe("failed");
+          expect(after?.summary).toEqual({
+            counts: { create: 1 },
+            error: "boom",
+          });
+        }),
+    );
+
+    it.effect("end after abandonment records completed-late", () =>
+      Effect.gen(function* () {
+        const { deployments } = yield* makeStore();
+        const { stack, stage } = ids("completed-late");
+
+        const first = yield* deployments.begin({ stack, stage, meta: meta() });
+        // Reconcile the first open to "abandoned".
+        yield* deployments.begin({ stack, stage, meta: meta(), ttlMillis: 0 });
+
+        yield* deployments.end({
+          stack,
+          stage,
+          version: first.version,
+          token: first.token,
+          outcome: "succeeded",
+        });
+
+        const record = yield* deployments.get({
+          stack,
+          stage,
+          version: first.version,
+        });
+        expect(record?.outcome).toBe("completed-late");
+        expect(record?.endedAt).not.toBeUndefined();
+      }),
+    );
+
+    it.effect(
+      "appendEvents acks the highest stored seq; readEvents is seq-ascending with inclusive fromSeq",
+      () =>
+        Effect.gen(function* () {
+          const { deployments } = yield* makeStore();
+          const { stack, stage } = ids("append-read");
+
+          const { version, token } = yield* deployments.begin({
+            stack,
+            stage,
+            meta: meta(),
+          });
+
+          const { ackedSeq } = yield* deployments.appendEvents({
+            stack,
+            stage,
+            version,
+            token,
+            events: [event(2), event(1), event(3)],
+          });
+          expect(ackedSeq).toBe(3);
+
+          const all = yield* deployments.readEvents({ stack, stage, version });
+          expect(all.map((e) => e.seq)).toEqual([1, 2, 3]);
+
+          const fromTwo = yield* deployments.readEvents({
+            stack,
+            stage,
+            version,
+            fromSeq: 2,
+          });
+          expect(fromTwo.map((e) => e.seq)).toEqual([2, 3]);
+        }),
+    );
+
+    it.effect("retrying an overlapping batch does not duplicate events", () =>
+      Effect.gen(function* () {
+        const { deployments } = yield* makeStore();
+        const { stack, stage } = ids("dedupe");
+
+        const { version, token } = yield* deployments.begin({
+          stack,
+          stage,
+          meta: meta(),
+        });
+
+        yield* deployments.appendEvents({
+          stack,
+          stage,
+          version,
+          token,
+          events: [
+            event(1, { first: true }),
+            event(2, { first: true }),
+            event(3, { first: true }),
+          ],
+        });
+
+        // Crash-retry: the batch overlaps seqs 2 and 3, plus a new seq 4.
+        const retried = yield* deployments.appendEvents({
+          stack,
+          stage,
+          version,
+          token,
+          events: [
+            event(2, { first: false }),
+            event(3, { first: false }),
+            event(4, { first: false }),
+          ],
+        });
+        expect(retried.ackedSeq).toBe(4);
+
+        const all = yield* deployments.readEvents({ stack, stage, version });
+        expect(all.map((e) => e.seq)).toEqual([1, 2, 3, 4]);
+        // First write wins — the retried duplicates were ignored.
+        expect(all[1]?.payload).toEqual({ first: true });
+        expect(all[2]?.payload).toEqual({ first: true });
+        expect(all[3]?.payload).toEqual({ first: false });
+      }),
+    );
+
+    it.effect(
+      "wrong token fails DeploymentTokenInvalid for append, heartbeat and end",
+      () =>
+        Effect.gen(function* () {
+          const { deployments } = yield* makeStore();
+          const { stack, stage } = ids("wrong-token");
+
+          const { version } = yield* deployments.begin({
+            stack,
+            stage,
+            meta: meta(),
+          });
+          const wrong = "not-the-token";
+
+          const append = yield* Effect.result(
+            deployments.appendEvents({
+              stack,
+              stage,
+              version,
+              token: wrong,
+              events: [event(1)],
+            }),
+          );
+          expect(Result.isFailure(append)).toBe(true);
+          if (Result.isFailure(append)) {
+            expect(append.failure._tag).toBe("DeploymentTokenInvalid");
+          }
+
+          const heartbeat = yield* Effect.result(
+            deployments.heartbeat({ stack, stage, version, token: wrong }),
+          );
+          expect(Result.isFailure(heartbeat)).toBe(true);
+          if (Result.isFailure(heartbeat)) {
+            expect(heartbeat.failure._tag).toBe("DeploymentTokenInvalid");
+          }
+
+          const end = yield* Effect.result(
+            deployments.end({
+              stack,
+              stage,
+              version,
+              token: wrong,
+              outcome: "succeeded",
+            }),
+          );
+          expect(Result.isFailure(end)).toBe(true);
+          if (Result.isFailure(end)) {
+            expect(end.failure._tag).toBe("DeploymentTokenInvalid");
+          }
+        }),
+    );
+
+    it.effect(
+      "unknown version fails DeploymentNotFound for append, heartbeat, end and readEvents",
+      () =>
+        Effect.gen(function* () {
+          const { deployments } = yield* makeStore();
+          const { stack, stage } = ids("not-found");
+
+          // Ensure the (stack, stage) exists but version 999 does not.
+          const { token } = yield* deployments.begin({
+            stack,
+            stage,
+            meta: meta(),
+          });
+          const version = 999;
+
+          const append = yield* Effect.result(
+            deployments.appendEvents({
+              stack,
+              stage,
+              version,
+              token,
+              events: [event(1)],
+            }),
+          );
+          expect(Result.isFailure(append)).toBe(true);
+          if (Result.isFailure(append)) {
+            expect(append.failure._tag).toBe("DeploymentNotFound");
+          }
+
+          const heartbeat = yield* Effect.result(
+            deployments.heartbeat({ stack, stage, version, token }),
+          );
+          expect(Result.isFailure(heartbeat)).toBe(true);
+          if (Result.isFailure(heartbeat)) {
+            expect(heartbeat.failure._tag).toBe("DeploymentNotFound");
+          }
+
+          const end = yield* Effect.result(
+            deployments.end({
+              stack,
+              stage,
+              version,
+              token,
+              outcome: "succeeded",
+            }),
+          );
+          expect(Result.isFailure(end)).toBe(true);
+          if (Result.isFailure(end)) {
+            expect(end.failure._tag).toBe("DeploymentNotFound");
+          }
+
+          const read = yield* Effect.result(
+            deployments.readEvents({ stack, stage, version }),
+          );
+          expect(Result.isFailure(read)).toBe(true);
+          if (Result.isFailure(read)) {
+            expect(read.failure._tag).toBe("DeploymentNotFound");
+          }
+        }),
+    );
+
+    it.effect(
+      "append after end is accepted with a matching token; heartbeat after end is a silent no-op",
+      () =>
+        Effect.gen(function* () {
+          const { deployments } = yield* makeStore();
+          const { stack, stage } = ids("after-end");
+
+          const { version, token } = yield* deployments.begin({
+            stack,
+            stage,
+            meta: meta(),
+          });
+          yield* deployments.appendEvents({
+            stack,
+            stage,
+            version,
+            token,
+            events: [event(1)],
+          });
+          yield* deployments.end({
+            stack,
+            stage,
+            version,
+            token,
+            outcome: "succeeded",
+          });
+
+          // Late flush after end: accepted, token still enforced.
+          const late = yield* deployments.appendEvents({
+            stack,
+            stage,
+            version,
+            token,
+            events: [event(2)],
+          });
+          expect(late.ackedSeq).toBe(2);
+          const all = yield* deployments.readEvents({ stack, stage, version });
+          expect(all.map((e) => e.seq)).toEqual([1, 2]);
+
+          // Heartbeat after end: silent no-op, outcome untouched.
+          yield* deployments.heartbeat({ stack, stage, version, token });
+          const record = yield* deployments.get({ stack, stage, version });
+          expect(record?.outcome).toBe("succeeded");
+          expect(record?.endedAt).not.toBeUndefined();
+        }),
+    );
+
+    it.effect("list is newest-first and honors before/limit", () =>
+      Effect.gen(function* () {
+        const { deployments } = yield* makeStore();
+        const { stack, stage } = ids("list");
+
+        for (let i = 0; i < 3; i++) {
+          const { version, token } = yield* deployments.begin({
+            stack,
+            stage,
+            meta: meta(),
+          });
+          yield* deployments.end({
+            stack,
+            stage,
+            version,
+            token,
+            outcome: "succeeded",
+          });
+        }
+
+        const all = yield* deployments.list({ stack, stage });
+        expect(all.map((r) => r.version)).toEqual([3, 2, 1]);
+
+        const limited = yield* deployments.list({ stack, stage, limit: 2 });
+        expect(limited.map((r) => r.version)).toEqual([3, 2]);
+
+        // `before` is a strictly-less-than cursor.
+        const beforeThree = yield* deployments.list({
+          stack,
+          stage,
+          before: 3,
+        });
+        expect(beforeThree.map((r) => r.version)).toEqual([2, 1]);
+
+        const page = yield* deployments.list({
+          stack,
+          stage,
+          before: 3,
+          limit: 1,
+        });
+        expect(page.map((r) => r.version)).toEqual([2]);
+      }),
+    );
+
+    it.effect("get of an unknown version returns undefined", () =>
+      Effect.gen(function* () {
+        const { deployments } = yield* makeStore();
+        const { stack, stage } = ids("get-unknown");
+        const record = yield* deployments.get({ stack, stage, version: 42 });
+        expect(record).toBeUndefined();
+      }),
+    );
+
+    it.effect(
+      "returned records and events do not expose the token or alias internal state",
+      () =>
+        Effect.gen(function* () {
+          const { deployments } = yield* makeStore();
+          const { stack, stage } = ids("no-alias");
+
+          const { version, token } = yield* deployments.begin({
+            stack,
+            stage,
+            meta: meta("owner"),
+          });
+          yield* deployments.appendEvents({
+            stack,
+            stage,
+            version,
+            token,
+            events: [event(1, { value: "original" })],
+          });
+
+          const record = yield* deployments.get({ stack, stage, version });
+          expect(record).toBeDefined();
+          expect("token" in record!).toBe(false);
+
+          // Mutating the returned record must not leak into the store.
+          record!.meta.initiator!.user = "intruder";
+          (record as { outcome?: string }).outcome = "succeeded";
+          const reread = yield* deployments.get({ stack, stage, version });
+          expect(reread?.meta.initiator?.user).toBe("owner");
+          expect(reread?.outcome).toBeUndefined();
+
+          // Same for events.
+          const events = yield* deployments.readEvents({
+            stack,
+            stage,
+            version,
+          });
+          (events[0]!.payload as { value: string }).value = "mutated";
+          const rereadEvents = yield* deployments.readEvents({
+            stack,
+            stage,
+            version,
+          });
+          expect(rereadEvents[0]?.payload).toEqual({ value: "original" });
+
+          // The listing view must not expose tokens either.
+          const listed = yield* deployments.list({ stack, stage });
+          expect("token" in listed[0]!).toBe(false);
+        }),
+    );
+
+    it.effect("two concurrent begins produce exactly one success", () =>
+      Effect.gen(function* () {
+        const { deployments } = yield* makeStore();
+        const { stack, stage } = ids("concurrent-begin");
+
+        const results = yield* Effect.all(
+          [
+            Effect.result(
+              deployments.begin({ stack, stage, meta: meta("racer-a") }),
+            ),
+            Effect.result(
+              deployments.begin({ stack, stage, meta: meta("racer-b") }),
+            ),
+          ],
+          { concurrency: "unbounded" },
+        );
+
+        const successes = results.filter(Result.isSuccess);
+        const failures = results.filter(Result.isFailure);
+        expect(successes).toHaveLength(1);
+        expect(failures).toHaveLength(1);
+        expect(successes[0]!.success.version).toBe(1);
+        expect(failures[0]!.failure._tag).toBe("DeploymentInProgress");
+      }),
+    );
+
+    (options.persistent ? it.effect : it.effect.skip)(
+      "a foreign claim after our own end still wins over a warm re-begin",
+      () =>
+        Effect.gen(function* () {
+          // Exercises the blind-claim fast path (S3 / local FS): instance A
+          // ends v1 and caches "1 is closed"; instance B claims v2; A's next
+          // begin must observe B's live open — the stale fast-path claim of
+          // v2 conflicts and falls back to the full observe loop.
+          const a = yield* makeStore();
+          const b = yield* makeStore();
+          const { stack, stage } = ids("fast-path-fallback");
+
+          const first = yield* a.deployments.begin({
+            stack,
+            stage,
+            meta: meta("instance-a"),
+          });
+          yield* a.deployments.end({
+            stack,
+            stage,
+            version: first.version,
+            token: first.token,
+            outcome: "succeeded",
+          });
+
+          const second = yield* b.deployments.begin({
+            stack,
+            stage,
+            meta: meta("instance-b"),
+          });
+          expect(second.version).toBe(2);
+
+          const blocked = yield* Effect.result(
+            a.deployments.begin({ stack, stage, meta: meta("instance-a") }),
+          );
+          expect(Result.isFailure(blocked)).toBe(true);
+          if (Result.isFailure(blocked)) {
+            expect(blocked.failure._tag).toBe("DeploymentInProgress");
+            if (blocked.failure._tag === "DeploymentInProgress") {
+              expect(blocked.failure.holder.version).toBe(2);
+            }
+          }
+
+          yield* b.deployments.end({
+            stack,
+            stage,
+            version: second.version,
+            token: second.token,
+            outcome: "succeeded",
+          });
+
+          const third = yield* a.deployments.begin({
+            stack,
+            stage,
+            meta: meta("instance-a"),
+          });
+          expect(third.version).toBe(3);
+        }),
+    );
+
+    (options.persistent ? it.effect : it.effect.skip)(
+      "persists records and events across re-instantiation",
+      () =>
+        Effect.gen(function* () {
+          const first = yield* makeStore();
+          const { stack, stage } = ids("persistence");
+
+          const { version, token } = yield* first.deployments.begin({
+            stack,
+            stage,
+            meta: meta("persisted-user"),
+          });
+          yield* first.deployments.appendEvents({
+            stack,
+            stage,
+            version,
+            token,
+            events: [event(1), event(2)],
+          });
+          yield* first.deployments.end({
+            stack,
+            stage,
+            version,
+            token,
+            outcome: "succeeded",
+            summary: { counts: { create: 2 } },
+          });
+
+          // A brand-new store over the same underlying storage sees it all.
+          const second = yield* makeStore();
+          const listed = yield* second.deployments.list({ stack, stage });
+          expect(listed.map((r) => r.version)).toEqual([version]);
+
+          const record = yield* second.deployments.get({
+            stack,
+            stage,
+            version,
+          });
+          expect(record?.outcome).toBe("succeeded");
+          expect(record?.meta.initiator?.user).toBe("persisted-user");
+          expect(record?.summary).toEqual({ counts: { create: 2 } });
+
+          const events = yield* second.deployments.readEvents({
+            stack,
+            stage,
+            version,
+          });
+          expect(events.map((e) => e.seq)).toEqual([1, 2]);
+        }),
+    );
+
+    it.effect(
+      "a fenced write from a superseded deployment is rejected; the current holder's writes pass",
+      () =>
+        Effect.gen(function* () {
+          const { state, deployments } = yield* makeStore();
+          const { stack, stage } = ids("fencing");
+          const value = resource("fenced-resource");
+
+          // v1 opens, then is treated as stale (claimer passes ttl 0) and
+          // superseded by v2 — the classic zombie: v1 still believes it
+          // holds the lease.
+          const v1 = yield* deployments.begin({
+            stack,
+            stage,
+            meta: meta("zombie"),
+          });
+          const v2 = yield* deployments.begin({
+            stack,
+            stage,
+            meta: meta("current"),
+            ttlMillis: 0,
+          });
+          expect(v2.version).toBe(v1.version + 1);
+
+          // The zombie's fenced writes are all rejected.
+          const fencedSet = yield* Effect.result(
+            state.set({
+              stack,
+              stage,
+              fqn: value.fqn,
+              value,
+              fence: v1.version,
+            }),
+          );
+          expect(Result.isFailure(fencedSet)).toBe(true);
+          if (Result.isFailure(fencedSet)) {
+            expect(fencedSet.failure._tag).toBe("StateStoreError");
+            expect(String(fencedSet.failure.message)).toContain("fenced");
+          }
+          const fencedDelete = yield* Effect.result(
+            state.delete({ stack, stage, fqn: value.fqn, fence: v1.version }),
+          );
+          expect(Result.isFailure(fencedDelete)).toBe(true);
+          const fencedOutput = yield* Effect.result(
+            state.setOutput({
+              stack,
+              stage,
+              value: { ok: false },
+              fence: v1.version,
+            }),
+          );
+          expect(Result.isFailure(fencedOutput)).toBe(true);
+
+          // The rejected set must not have landed.
+          const afterFenced = yield* state.get({
+            stack,
+            stage,
+            fqn: value.fqn,
+          });
+          expect(afterFenced).toBeUndefined();
+
+          // The current holder's fence (== newest version) passes.
+          yield* state.set({
+            stack,
+            stage,
+            fqn: value.fqn,
+            value,
+            fence: v2.version,
+          });
+          expect(
+            yield* state.get({ stack, stage, fqn: value.fqn }),
+          ).toBeDefined();
+          yield* state.setOutput({
+            stack,
+            stage,
+            value: { ok: true },
+            fence: v2.version,
+          });
+          yield* state.delete({
+            stack,
+            stage,
+            fqn: value.fqn,
+            fence: v2.version,
+          });
+
+          // Unfenced writes (operator tooling) always bypass the check.
+          yield* state.set({ stack, stage, fqn: value.fqn, value });
+          yield* state.delete({ stack, stage, fqn: value.fqn });
+        }),
+    );
+
+    it.effect("getAll returns every resource in the stage", () =>
+      Effect.gen(function* () {
+        const { state } = yield* makeStore();
+        const { stack, stage } = ids("get-all");
+
+        expect(state.getAll).toBeDefined();
+
+        const a = resource("resource-a");
+        const b = resource("resource-b");
+        yield* state.set({ stack, stage, fqn: a.fqn, value: a });
+        yield* state.set({ stack, stage, fqn: b.fqn, value: b });
+
+        const all = yield* state.getAll!({ stack, stage });
+        expect(all.size).toBe(2);
+        expect(all.get("resource-a")).toEqual(a);
+        expect(all.get("resource-b")).toEqual(b);
+
+        const empty = yield* state.getAll!({
+          stack,
+          stage: `${stage}-empty`,
+        });
+        expect(empty.size).toBe(0);
+      }),
+    );
+  });
+};


### PR DESCRIPTION
Every deploy/destroy is now journaled as a versioned deployment in the state store, guarded by a fail-closed lease with dead-pid takeover and fencing tokens. Implemented on all four backends (in-memory, local FS, S3, Cloudflare DO) behind one `deployments` sub-interface.

```ts
interface DeploymentStore {
  begin(request): Effect<OpenDeployment, DeploymentInProgress | StateStoreError>;
  appendEvents(request): Effect<void>;   // seq-idempotent
  heartbeat(request): Effect<void>;      // every 10s while applying
  end(request): Effect<void>;            // exit-mapped: succeeded/failed/interrupted
  list / get / readEvents;
}
```

### Mutual exclusion (fail-closed)

- `begin` atomically allocates the next per-(stack,stage) version: `O_EXCL` create (local), `If-None-Match: "*"` PUT (S3, typed 412 via a distilled patch), `storage.transaction` (Cloudflare DO)
- a live open blocks concurrent deploys with typed `DeploymentInProgress` carrying the holder; a `begin` failure aborts the apply — no lock, no mutation
- crash-safe without `end()`: heartbeated open markers; the next `begin` reconciles TTL-expired opens as `abandoned`

### Same-host dead-pid takeover

A fresh-heartbeat lease whose holder is a dead process on this host (crashed CLI) is superseded instead of blocking for the TTL:

```ts
// Apply.ts — on DeploymentInProgress:
canTakeOverDeployment(holder, self, isProcessAlive)  // same host + dead pid only
  && retry begin({ supersede: holder.version })
```

### Fencing tokens

Head-state writes from a deployment session carry `fence: version`. Once a newer version has begun, the store rejects the zombie's write:

```ts
// a superseded deploy's next state write fails the apply
StateStoreError: state write fenced: stack=.. stage=.. fence=1
```

Enforced natively per backend (synchronous check in-memory, directory scan local, DO transaction on Cloudflare, observed-version check on S3) and wired through the HTTP API as a 412 `StateWriteFenced`.

### Also

- ApplyEvent envelope v2: `ts` stamped at emission, `fqn` on every event, new `op-start`/`op-end`/`log` kinds; renderers tolerate unknown kinds
- blind-claim fast path (S3/local): re-begin after a clean `end` claims version N+1 directly, skipping the observation scan
- Cloudflare store: events as SQLite rows, alarm-based stale-open expiry, AES-CTR + SHA-256 integrity, tokens stored as hashes, `DeploymentNotFound` as HTTP 410
- shared conformance suite runs against in-memory, local FS, live S3, and live Cloudflare; engine integration tests cover the journal trail, blocking, takeover, fail-closed begin, and the fenced-zombie apply
