### PR TITLE
fix(cloudflare): cold-recovery read for Access Application

### DIFF
--- a/packages/alchemy/src/Cloudflare/Access/Application.ts
+++ b/packages/alchemy/src/Cloudflare/Access/Application.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
 
+import { Unowned } from "../../AdoptPolicy.ts";
 import { createPhysicalName } from "../../PhysicalName.ts";
 import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
@@ -312,25 +313,47 @@ export const ApplicationProvider = () =>
       }
     }),
 
-    read: Effect.fn(function* ({ output }) {
+    read: Effect.fn(function* ({ output, olds }) {
       const { accountId } = yield* yield* CloudflareEnvironment;
 
-      if (!output?.applicationId) return undefined;
-      const observed = yield* observeById(accountId, output.applicationId);
+      // Prefer the persisted physical id. After state loss there is no
+      // applicationId to probe, so fall back to matching an existing app
+      // by domain — without this the engine plans a blind `create`, and
+      // Cloudflare happily creates a second application on the same
+      // domain with a fresh `aud`, silently breaking existing JWT
+      // validation. Warp apps are excluded from the fallback: they are a
+      // per-account singleton that `reconcile` already recovers.
+      let observed: ObservedApp | undefined;
+      if (output?.applicationId) {
+        observed = yield* observeById(accountId, output.applicationId);
+      } else if (olds?.type !== "warp" && typeof olds?.domain === "string") {
+        observed = yield* findByDomain(accountId, olds.domain);
+      } else {
+        return undefined;
+      }
       if (!observed?.id || !observed.aud || !observed.type) {
         return undefined;
       }
-      return {
+      const domain = observed.domain ?? output?.domain ?? olds?.domain;
+      const name = observed.name ?? output?.name;
+      if (domain === undefined || name === undefined) {
+        return undefined;
+      }
+      const attrs = {
         applicationId: observed.id,
         aud: observed.aud,
-        domain: observed.domain ?? output.domain,
-        destinations: observed.destinations ?? output.destinations,
+        domain,
+        destinations: observed.destinations ?? output?.destinations,
         type: observed.type,
-        name: observed.name ?? output.name,
-        accountId: output.accountId,
-        createdAt: observed.createdAt ?? output.createdAt,
-        updatedAt: observed.updatedAt ?? output.updatedAt,
+        name,
+        accountId: output?.accountId ?? accountId,
+        createdAt: observed.createdAt ?? output?.createdAt,
+        updatedAt: observed.updatedAt ?? output?.updatedAt,
       } satisfies ApplicationAttributes;
+      // Recovered by id → positively ours. Recovered by domain scan →
+      // existence is certain but ownership is not (Access applications
+      // carry no alchemy marker), so gate takeover behind `--adopt`.
+      return output?.applicationId ? attrs : Unowned(attrs);
     }),
 
     reconcile: Effect.fn(function* ({ id, news, output }) {
@@ -535,6 +558,24 @@ const findWarpApp = (accountId: string) =>
     Effect.map((chunk) =>
       Array.from(chunk).find(
         (a) => (a as { type?: string | null }).type === "warp",
+      ),
+    ),
+    Effect.map((found) =>
+      found === undefined
+        ? undefined
+        : narrowApp(found as Parameters<typeof narrowApp>[0]),
+    ),
+  );
+
+// Cold-recovery scan for `read` when no applicationId was persisted:
+// match an existing application by its domain (unique per account for
+// non-warp app types).
+const findByDomain = (accountId: string, domain: string) =>
+  zeroTrust.listAccessApplicationsForAccount.items({ accountId }).pipe(
+    Stream.runCollect,
+    Effect.map((chunk) =>
+      Array.from(chunk).find(
+        (a) => (a as { domain?: string | null }).domain === domain,
       ),
     ),
     Effect.map((found) =>

--- a/packages/alchemy/test/Cloudflare/Access/Application.test.ts
+++ b/packages/alchemy/test/Cloudflare/Access/Application.test.ts
@@ -8,6 +8,8 @@ import { expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
+import * as Stream from "effect/Stream";
+import * as State from "@/State/State";
 
 const { test } = Test.make({ providers: Cloudflare.providers() });
 
@@ -234,6 +236,78 @@ test.provider(
         policies?: ReadonlyArray<unknown> | null;
       };
       expect(liveRecord.policies?.length ?? 0).toEqual(2);
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+);
+
+
+// Regression test for the cold-recovery `read` fallback: after state loss
+// (or a stage migration rebuilding state via the adoption probe) there is
+// no persisted `applicationId`. Without the domain-match fallback the
+// engine plans a blind `create` and Cloudflare accepts a DUPLICATE
+// application on the same domain with a fresh `aud`. With it, the app is
+// found by domain, surfaces as `Unowned`, and adopts cleanly under
+// `adopt(true)` — same applicationId/aud, no duplicate.
+test.provider(
+  "cold-recovery: read matches an existing app by domain after state loss",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const domain = `alchemy-test-cold-read.${zoneName}`;
+      const program = Effect.gen(function* () {
+        yield* Cloudflare.Zone.Zone("TestZone", {
+          name: zoneName,
+        }).pipe(AdoptPolicy.adopt(true));
+        const policy = yield* Cloudflare.Access.Policy("ColdReadAllow", {
+          name: "Allow example.com (cold read)",
+          decision: "allow",
+          include: [{ emailDomain: { domain: "example.com" } }],
+        });
+        return yield* Cloudflare.Access.Application("ColdReadApp", {
+          type: "self_hosted",
+          domain,
+          sessionDuration: "24h",
+          policies: [policy.policyId],
+        });
+      });
+
+      const first = yield* stack.deploy(program);
+      expect(first.applicationId).toBeDefined();
+      expect(first.aud.length).toBeGreaterThan(0);
+
+      // Simulate state loss for the application only: the app still
+      // exists in Cloudflare, but the engine has no applicationId.
+      const state = yield* yield* State.State;
+      yield* state.delete({
+        stack: stack.name,
+        stage: "test",
+        fqn: "ColdReadApp",
+      });
+
+      // Without adopt, the domain-matched app is Unowned — the engine
+      // must refuse the takeover rather than create a duplicate.
+      const refused = yield* stack.deploy(program).pipe(Effect.flip);
+      expect(refused).toBeInstanceOf(AdoptPolicy.OwnedBySomeoneElse);
+
+      // With adopt, the SAME app is adopted: identity is preserved and
+      // no duplicate application appears on the domain.
+      const readopted = yield* stack.deploy(
+        program.pipe(AdoptPolicy.adopt(true)),
+      );
+      expect(readopted.applicationId).toEqual(first.applicationId);
+      expect(readopted.aud).toEqual(first.aud);
+
+      const all = yield* zeroTrust.listAccessApplicationsForAccount
+        .items({ accountId })
+        .pipe(Stream.runCollect);
+      const onDomain = Array.from(all).filter(
+        (a) => (a as { domain?: string | null }).domain === domain,
+      );
+      expect(onDomain).toHaveLength(1);
 
       yield* stack.destroy();
     }).pipe(logLevel),


### PR DESCRIPTION
`AccessApplication.read` bails out when there is no persisted `applicationId`, so after state loss (or a stage migration rebuilding state via the adoption probe) the engine plans a blind `create`. Cloudflare accepts a second application on the same domain — with a fresh `aud` — which silently breaks JWT validation for anything pinned to the original application's audience.

Add a cold-recovery fallback: when no id is persisted, scan the account's applications and match by the desired `domain` (the probe passes resolved props as `olds`).

```ts
if (output?.applicationId) {
  observed = yield* observeById(accountId, output.applicationId);
} else if (olds?.type !== "warp" && typeof olds?.domain === "string") {
  observed = yield* findByDomain(accountId, olds.domain);
} else {
  return undefined;
}
```

- Recovered **by id** → plain attrs (positively ours, same as before).
- Recovered **by domain scan** → `Unowned(attrs)` — existence is certain but ownership is not (Access applications carry no alchemy marker), so takeover is gated behind `--adopt` per the AdoptPolicy contract.
- `warp` apps are excluded from the fallback: they are a per-account singleton that `reconcile` already recovers via `findWarpApp`.

Hit in production while rebuilding a ~100-resource stack's state under a new stage: three `self_hosted` apps planned as duplicate creates; with this fallback they adopt cleanly (verified live — plan converges to noop, applicationIds/AUDs preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
