### PR TITLE
feat(cloudflare): pin the state-store account via state({ accountId })

### DIFF
--- a/packages/alchemy/src/Cloudflare/StateStore/State.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/State.ts
@@ -56,7 +56,54 @@ const CI = Config.boolean("CI").pipe(Config.withDefault(false));
 /** Filename used for stored credentials under the profile directory. */
 const CREDENTIALS_FILE = "cloudflare-state-store";
 
-export const state = () =>
+export interface StateOptions {
+  /**
+   * Pin the Cloudflare account this stack's state store must live in.
+   *
+   * The account is otherwise decided implicitly by the auth profile —
+   * a `login` against the wrong account (easy for users who belong to
+   * several) resolves an **empty** state store, so the engine
+   * cold-probes live cloud resources and fails with confusing
+   * `OwnedBySomeoneElse` errors (or, with `--adopt`, silently forks
+   * state into the wrong account). When set, the layer asserts the
+   * profile-resolved accountId matches before reading, bootstrapping,
+   * or upgrading anything, and fails with re-login instructions
+   * instead.
+   */
+  accountId?: string;
+}
+
+/**
+ * Fail loudly when the auth profile resolves a different Cloudflare
+ * account than the one the stack pins via {@link StateOptions.accountId}.
+ * No-op when no pin is configured.
+ */
+const assertAccountId = (
+  expected: string | undefined,
+  profileName: string,
+): Effect.Effect<
+  void,
+  never,
+  CloudflareEnvironment.CloudflareEnvironment
+> =>
+  Effect.gen(function* () {
+    if (expected === undefined) return;
+    const { accountId } =
+      yield* yield* CloudflareEnvironment.CloudflareEnvironment;
+    if (accountId !== expected) {
+      return yield* Effect.die(
+        new AuthError({
+          message:
+            `Cloudflare account mismatch: profile '${profileName}' resolves ` +
+            `account ${accountId}, but this stack pins its state store to ` +
+            `account ${expected}. Re-run 'alchemy login --profile ${profileName}' ` +
+            `and select the expected account.`,
+        }),
+      );
+    }
+  });
+
+export const state = (options: StateOptions = {}) =>
   Layer.effect(
     State,
     Effect.gen(function* () {
@@ -74,6 +121,11 @@ export const state = () =>
       const context = yield* Effect.context<Effect.Services<typeof init>>();
 
       const init = Effect.gen(function* () {
+        // Guard the account BEFORE any state is read or bootstrapped —
+        // an account mismatch must not be able to reach the "State
+        // Store not available. Do you want to deploy it?" prompt.
+        yield* assertAccountId(options.accountId, profileName);
+
         if (yield* hasLocalStack(localStage)) {
           // if there's still a local stack, then we need to finish the bootstrap
           // TODO(sam): what if the local stack was
@@ -233,6 +285,11 @@ export interface BootstrapOptions {
   force?: boolean;
   /** @default "default" */
   profile?: string;
+  /**
+   * Require the profile to resolve this Cloudflare account before
+   * deploying anything. See {@link StateOptions.accountId}.
+   */
+  accountId?: string;
 }
 
 export const bootstrap = (options: BootstrapOptions = {}) =>
@@ -242,6 +299,7 @@ export const bootstrap = (options: BootstrapOptions = {}) =>
     const scriptName = options.workerName ?? STATE_STORE_SCRIPT_NAME;
     const force = options.force ?? false;
     const localStage = `${profileName}_${scriptName}`;
+    yield* assertAccountId(options.accountId, profileName);
     yield* Effect.annotateCurrentSpan({
       "alchemy.state_store.script_name": scriptName,
       "alchemy.state_store.profile": profileName,


### PR DESCRIPTION
The Cloudflare account hosting a stack's state store is decided implicitly by the auth profile. A `login` against the wrong account — easy for users who belong to several — resolves an **empty** state store: the engine then cold-probes live cloud resources and fails with confusing `OwnedBySomeoneElse` errors on the first plan, or (worse) `--adopt` silently forks the stack's state into the wrong account, arming a `destroy` that can delete live infra. We hit exactly this onboarding a new team member this week.

Let stacks pin the account:

```ts
Alchemy.Stack("my-stack", {
  providers: ...,
  state: Cloudflare.state({ accountId: "c8eeff0e..." }),
}, ...)
```

- `StateOptions.accountId` (and the same on `BootstrapOptions`) is asserted against the profile-resolved account **before** anything is read, bootstrapped, or upgraded — an account mismatch can no longer reach the "State Store not available. Do you want to deploy it?" prompt.
- On mismatch it dies with an `AuthError` naming both accounts and the fix:

```
Cloudflare account mismatch: profile 'default' resolves account <actual>, but this
stack pins its state store to account <expected>. Re-run 'alchemy login --profile
default' and select the expected account.
```

- No pin → no behavior change (`state()` remains zero-config).

The `assertAccountId` helper carries an explicit return type — letting it infer joins the self-referential `typeof init` context inference inside `state()` and breaks the `deployStateStore` providers-layer type downstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
