### PR TITLE
fix(drizzle): make proxyChain a real Effect so it composes with combinators

### DIFF
--- a/packages/alchemy/src/Util/proxy-chain.ts
+++ b/packages/alchemy/src/Util/proxy-chain.ts
@@ -59,19 +59,15 @@ export const proxyChain = <T>(cached: Effect.Effect<T, any, any>): T =>
 const chain = (
   cached: Effect.Effect<unknown, any, any>,
   ops: ReadonlyArray<Op> = [],
-): unknown =>
-  new Proxy(function () {} as any, {
+): unknown => {
+  const effect = Effect.flatMap(
+    cached,
+    (root) => replay(root, ops) as Effect.Effect<unknown, unknown, unknown>,
+  );
+  return new Proxy(function () {}, {
     get(_, prop) {
-      if (prop === Symbol.iterator) {
-        // `yield* proxy` — produce the resolved Effect's iterator.
-        return function () {
-          const eff = Effect.flatMap(
-            cached,
-            (root) =>
-              replay(root, ops) as Effect.Effect<unknown, unknown, unknown>,
-          );
-          return (eff as any)[Symbol.iterator]();
-        };
+      if (Reflect.has(effect, prop)) {
+        return Reflect.get(effect, prop);
       }
       return chain(cached, [...ops, { kind: "get", prop }]);
     },
@@ -79,3 +75,4 @@ const chain = (
       return chain(cached, [...ops, { kind: "call", args }]);
     },
   });
+};

--- a/packages/alchemy/test/Util/proxy-chain.test.ts
+++ b/packages/alchemy/test/Util/proxy-chain.test.ts
@@ -1,0 +1,149 @@
+import { proxyChain } from "@/Util/proxy-chain.ts";
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+
+const TIMEOUT = 5_000;
+
+/**
+ * A fake drizzle-like db. `select()` and `echo()` are real methods that
+ * read `this` — so replaying them with the wrong receiver would throw,
+ * which is how we assert `this`-binding is preserved through the proxy.
+ */
+const makeDb = () => ({
+  greeting: "hi",
+  echo(n: number) {
+    return Effect.succeed(`${this.greeting}:${n}`);
+  },
+  select() {
+    const greeting = this.greeting;
+    return {
+      from: (table: string) => Effect.succeed([`${greeting}/${table}`]),
+    };
+  },
+});
+
+type Db = ReturnType<typeof makeDb>;
+
+describe("proxyChain", () => {
+  it.effect("replays a property-read + call chain when yielded", () =>
+    Effect.gen(function* () {
+      const db = proxyChain<Db>(Effect.succeed(makeDb()));
+      const rows = yield* db.select().from("users");
+      expect(rows).toEqual(["hi/users"]);
+    }),
+  );
+
+  it.effect("binds `this` to the receiver for method calls", () =>
+    Effect.gen(function* () {
+      const db = proxyChain<Db>(Effect.succeed(makeDb()));
+      // `echo` reads `this.greeting`; a dropped receiver would throw.
+      const result = yield* db.echo(7);
+      expect(result).toBe("hi:7");
+    }),
+  );
+
+  it.effect(
+    "is lazy — does not resolve the underlying effect until yielded",
+    () =>
+      Effect.gen(function* () {
+        let built = 0;
+        const db = proxyChain<Db>(
+          Effect.sync(() => {
+            built++;
+            return makeDb();
+          }),
+        );
+
+        // Building the op chain must not touch the underlying effect.
+        const query = db.select().from("users");
+        expect(built).toBe(0);
+
+        yield* query;
+        expect(built).toBe(1);
+      }),
+  );
+
+  it.effect(
+    "works as an Effect inside Effect.all (regression: used to hang)",
+    () =>
+      Effect.gen(function* () {
+        const db = proxyChain<Db>(Effect.succeed(makeDb()));
+        const results = yield* Effect.all([
+          db.select().from("users"),
+          db.select().from("posts"),
+        ]);
+        expect(results).toEqual([["hi/users"], ["hi/posts"]]);
+      }),
+  );
+
+  it.effect("works inside Effect.forEach", () =>
+    Effect.gen(function* () {
+      const db = proxyChain<Db>(Effect.succeed(makeDb()));
+      const results = yield* Effect.forEach(
+        ["users", "posts", "comments"],
+        (table) => db.select().from(table),
+      );
+      expect(results).toEqual([["hi/users"], ["hi/posts"], ["hi/comments"]]);
+    }),
+  );
+
+  it.effect(
+    "supports `.pipe` on a chain (forwarded to the resolved effect)",
+    () =>
+      Effect.gen(function* () {
+        const db = proxyChain<Db>(Effect.succeed(makeDb()));
+        const rows = yield* db
+          .select()
+          .from("users")
+          .pipe(Effect.map((rows) => rows.map((r) => r.toUpperCase())));
+        expect(rows).toEqual(["HI/USERS"]);
+      }),
+  );
+
+  it.effect("supports `.pipe` recovering a failure", () =>
+    Effect.gen(function* () {
+      const db = proxyChain<{ boom: () => Effect.Effect<string, string> }>(
+        Effect.succeed({ boom: () => Effect.fail("nope") }),
+      );
+      const result = yield* db
+        .boom()
+        .pipe(Effect.catch((e) => Effect.succeed(`recovered:${e}`)));
+      expect(result).toBe("recovered:nope");
+    }),
+  );
+
+  it.effect("a `.pipe`-d chain still composes inside Effect.all", () =>
+    Effect.gen(function* () {
+      const db = proxyChain<Db>(Effect.succeed(makeDb()));
+      const results = yield* Effect.all([
+        db
+          .select()
+          .from("users")
+          .pipe(Effect.map((r) => r.length)),
+        db
+          .select()
+          .from("posts")
+          .pipe(Effect.map((r) => r.length)),
+      ]);
+      expect(results).toEqual([1, 1]);
+    }),
+  );
+
+  it.effect("propagates failures from the resolved effect", () =>
+    Effect.gen(function* () {
+      const db = proxyChain<{ boom: () => Effect.Effect<never, string> }>(
+        Effect.succeed({ boom: () => Effect.fail("nope") }),
+      );
+      const error = yield* Effect.flip(db.boom());
+      expect(error).toBe("nope");
+    }),
+  );
+
+  it.effect("propagates failures from the underlying (cached) effect", () =>
+    Effect.gen(function* () {
+      const db = proxyChain<Db>(Effect.fail("connect failed"));
+      const error = yield* Effect.flip(db.select().from("users"));
+      expect(error).toBe("connect failed");
+    }),
+  );
+}, 5000);


### PR DESCRIPTION
`Drizzle.postgres` returns a `proxyChain` over the resolved db. The proxy only answered `Symbol.iterator`, so `yield* db.select()…` worked but the proxy was **not** recognized as an `Effect`. Passing chains to `Effect.all` made the fiber probe each proxy for internal Effect fields, get a truthy proxy back for every probe, and spin the run loop: seconds of pure CPU, no SQL ever issued, spans never exported, canceled once the caller timed out. It only reproduced when the array held real query chains; tokenless paths put `Effect.void` in the array and sailed through.

Fix: build the resolved `Effect` once per chain node and forward any property it already carries to it; record everything else as an op.

```ts
const effect = Effect.flatMap(cached, (root) => replay(root, ops) as Effect.Effect<...>);
return new Proxy(function () {}, {
  get(_, prop) {
    if (Reflect.has(effect, prop)) return Reflect.get(effect, prop);
    return chain(cached, [...ops, { kind: "get", prop }]);
  },
  apply(_, __, args) {
    return chain(cached, [...ops, { kind: "call", args }]);
  },
});
```

The proxy now exposes `EffectTypeId`, `[evaluate]`, `Symbol.iterator`, `pipe`, … so it is a genuine `Effect`.

Adds `test/Util/proxy-chain.test.ts` covering replay, `this`-binding, laziness, failure propagation, and composition via `Effect.all` / `Effect.forEach` / `.pipe` (the regression cases).
