### PR TITLE
feat(cloudflare/workers)!: Workers Cache support + Effect-native ExecutionContext

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/Cache.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Cache.ts
@@ -1,0 +1,102 @@
+import type * as cf from "@cloudflare/workers-types";
+import * as Effect from "effect/Effect";
+import * as Namespace from "../../Namespace.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
+import {
+  Worker,
+  WorkerExecutionContext,
+  type CachePurgeError,
+} from "./Worker.ts";
+
+export interface CacheOptions {
+  /**
+   * Whether Workers Cache checks the cache before invoking the Worker.
+   * @default true
+   */
+  enabled?: boolean;
+  /**
+   * Share cached responses across Worker versions. By default the cache is
+   * scoped to a single version, so every deploy starts cold.
+   * @default false
+   */
+  crossVersionCache?: boolean;
+}
+
+/**
+ * Runtime client for Workers Cache, returned by `yield* Cloudflare.cache()`.
+ */
+export interface CacheClient {
+  /**
+   * Purge cached responses by `Cache-Tag`, path prefix, or everything.
+   */
+  purge(
+    options: cf.CachePurgeOptions,
+  ): Effect.Effect<cf.CachePurgeResult, CachePurgeError, RuntimeContext>;
+}
+
+/**
+ * Enable [Workers Cache](https://blog.cloudflare.com/workers-cache/) on the
+ * surrounding Worker and get the runtime cache client.
+ *
+ * Yielding `cache()` in an Effect-native Worker's init phase turns the cache
+ * on at deploy time (the equivalent of setting `cache: { enabled: true }` on
+ * the Worker's props) and returns a client whose `purge` drives the runtime
+ * `ctx.cache` API from your handlers.
+ *
+ * What gets cached is controlled by standard response headers —
+ * `Cache-Control` (including `stale-while-revalidate`), `Cache-Tag` for
+ * tag-based purging, and `Vary` for content negotiation.
+ *
+ * For async (non-Effect) Workers, set the `cache` prop on the Worker
+ * instead.
+ *
+ * @binding
+ * @product Workers
+ * @category Workers & Compute
+ * @example
+ * ```typescript
+ * Effect.gen(function* () {
+ *   // init: enable Workers Cache on this Worker
+ *   const { purge } = yield* Cloudflare.cache();
+ *
+ *   return {
+ *     fetch: Effect.gen(function* () {
+ *       const request = yield* HttpServerRequest;
+ *       if (request.url.startsWith("/invalidate")) {
+ *         yield* purge({ tags: ["products"] });
+ *         return HttpServerResponse.text("purged");
+ *       }
+ *       return HttpServerResponse.text("hello", {
+ *         headers: {
+ *           "Cache-Control": "public, max-age=300",
+ *           "Cache-Tag": "products",
+ *         },
+ *       });
+ *     }),
+ *   };
+ * })
+ * ```
+ */
+export const cache = (
+  options?: CacheOptions,
+): Effect.Effect<CacheClient, never, Worker | WorkerExecutionContext> =>
+  Effect.gen(function* () {
+    const host = yield* Worker;
+    const exec = yield* WorkerExecutionContext;
+    if (!globalThis.__ALCHEMY_RUNTIME__) {
+      yield* Namespace.push(
+        host.LogicalId,
+        host.bind("Cache", {
+          cache: {
+            enabled: options?.enabled ?? true,
+            crossVersionCache: options?.crossVersionCache,
+          },
+        }),
+      );
+    }
+    return {
+      // `exec` is the init-phase deferred context; purge resolves the live
+      // per-event context from the calling handler's fiber.
+      purge: (purgeOptions) => exec.cache.purge(purgeOptions),
+    };
+  });

--- a/packages/alchemy/src/Cloudflare/Workers/DurableObject.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/DurableObject.ts
@@ -518,6 +518,41 @@ export class DurableObjectScope extends Context.Service<
  * const value = yield* state.storage.get("counter");
  * ```
  *
+ * @section Background Work & Scopes
+ * Every RPC call and fetch into a Durable Object gets its own Effect
+ * `Scope`. When the method finishes, the bridge closes that scope and
+ * registers the close promise with workerd's `state.waitUntil` — so
+ * finalizers added with `Effect.addFinalizer` inside a method run *after*
+ * the result is returned to the caller, without blocking it, and the
+ * object stays alive until they settle.
+ *
+ * For ad-hoc background work, `state.waitUntil(effect)` forks an Effect
+ * with the caller's full context and keeps the object alive until it
+ * settles.
+ *
+ * Attach cleanup to method scopes, not the constructor (init) closure —
+ * the constructor runs once per in-memory instance under
+ * `blockConcurrencyWhile`, and its scope is not tied to any call.
+ *
+ * @example Responding before finishing the work
+ * ```typescript
+ * return {
+ *   record: Effect.fn(function* (entry: string) {
+ *     // runs after `record` returns; the DO stays alive until it settles
+ *     yield* Effect.addFinalizer(() =>
+ *       state.storage.put(`audit:${entry}`, Date.now()).pipe(Effect.ignore),
+ *     );
+ *     return "accepted" as const;
+ *   }),
+ *
+ *   refresh: Effect.fn(function* () {
+ *     // same idea, explicit form
+ *     yield* state.waitUntil(recomputeExpensiveView());
+ *     return "scheduled" as const;
+ *   }),
+ * };
+ * ```
+ *
  * @section WebSocket Hibernation
  * Durable Objects support WebSocket hibernation — the runtime can
  * evict the object from memory while keeping connections open. Use

--- a/packages/alchemy/src/Cloudflare/Workers/DurableObjectState.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/DurableObjectState.ts
@@ -14,6 +14,19 @@ export class DurableObjectState extends Context.Service<
     readonly id: cf.DurableObjectId;
     readonly storage: DurableObjectStorage;
     container?: cf.Container;
+    /**
+     * Run an Effect in the background without blocking the current event,
+     * keeping the Durable Object alive until it settles. The Effect runs with
+     * the caller's full context (services, tracing), and the resulting
+     * promise is registered with workerd's `state.waitUntil`.
+     */
+    waitUntil<A, E, R>(
+      effect: Effect.Effect<A, E, R>,
+    ): Effect.Effect<void, never, R | RuntimeContext>;
+    /**
+     * The raw workerd DurableObjectState, for interop with async APIs.
+     */
+    readonly raw: cf.DurableObjectState;
     blockConcurrencyWhile<T>(
       callback: () => Effect.Effect<T, never, RuntimeContext>,
     ): Effect.Effect<T, never, RuntimeContext>;
@@ -54,6 +67,18 @@ export const fromDurableObjectState = (
   id: state.id,
   container: state.container,
   storage: fromDurableObjectStorage(state.storage),
+  raw: state,
+  waitUntil: <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+    Effect.gen(function* () {
+      const context = yield* Effect.context<R>();
+      // Register the promise with workerd un-awaited — waitUntil extends the
+      // event's lifetime without blocking the caller.
+      yield* Effect.sync(() =>
+        state.waitUntil(
+          Effect.runPromise(effect.pipe(Effect.provide(context))),
+        ),
+      );
+    }),
   blockConcurrencyWhile: <T>(callback: () => Effect.Effect<T>) =>
     Effect.tryPromise(() =>
       state.blockConcurrencyWhile(() => Effect.runPromise(callback())),

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -884,6 +884,52 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
  * }
  * ```
  *
+ * @section Background Work & Scopes
+ * Each incoming event (fetch, RPC call, scheduled run) gets its own Effect
+ * `Scope`. When the handler finishes, the bridge closes that scope and
+ * registers the close promise with workerd's `ctx.waitUntil` — so
+ * finalizers added with `Effect.addFinalizer` inside a handler run *after*
+ * the response is sent, without blocking it, and the Worker stays alive
+ * until they settle. Streaming responses transfer the scope to the stream,
+ * so those finalizers run when the stream completes instead.
+ *
+ * For ad-hoc background work, `WorkerExecutionContext.waitUntil(effect)`
+ * forks an Effect with the caller's full context and keeps the invocation
+ * alive until it settles. The context can be yielded once in the init
+ * closure and used from any handler; its methods are `RuntimeContext`-
+ * colored, so they can only run inside a handler.
+ *
+ * The init closure itself is evaluated per event (its Layer is rebuilt for
+ * each event's runtime), so treat it as stateless setup: bind resources and
+ * build handlers there, but attach cleanup to handler scopes — a finalizer
+ * added in the init closure runs at the end of every event, not once per
+ * Worker.
+ *
+ * @example Post-response cleanup with a scope finalizer
+ * ```typescript
+ * return {
+ *   fetch: Effect.gen(function* () {
+ *     // runs after this response is sent, kept alive by waitUntil
+ *     yield* Effect.addFinalizer(() => flushMetrics().pipe(Effect.ignore));
+ *     return HttpServerResponse.text("ok");
+ *   }),
+ * };
+ * ```
+ *
+ * @example Background work with waitUntil
+ * ```typescript
+ * // init
+ * const exec = yield* Cloudflare.WorkerExecutionContext;
+ *
+ * return {
+ *   fetch: Effect.gen(function* () {
+ *     // respond now; the audit write completes in the background
+ *     yield* exec.waitUntil(writeAuditLog(event));
+ *     return HttpServerResponse.text("accepted", { status: 202 });
+ *   }),
+ * };
+ * ```
+ *
  * @section R2 Bucket
  * Bind an R2 bucket in the init phase with `Cloudflare.R2.ReadWriteBucket`.
  * The returned handle exposes `get`, `put`, `delete`, and `list`

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -3,6 +3,7 @@ import * as workers from "@distilled.cloud/cloudflare/workers";
 import type * as Config from "effect/Config";
 import type { ConfigError } from "effect/Config";
 import * as Context from "effect/Context";
+import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import type * as Layer from "effect/Layer";
 import * as Redacted from "effect/Redacted";
@@ -59,6 +60,25 @@ export class WorkerEnvironment extends Context.Service<
   Record<string, any>
 >()("Cloudflare.Workers.WorkerEnvironment") {}
 
+export class CachePurgeError extends Data.TaggedError("CachePurgeError")<{
+  message: string;
+  cause?: unknown;
+}> {}
+
+/**
+ * Effect-native view of the Workers Cache runtime API on the execution
+ * context (`ctx.cache`). Only available when the Worker has Workers Cache
+ * enabled (the `cache` prop or `yield* Cloudflare.cache()`).
+ */
+export interface WorkerExecutionContextCache {
+  /**
+   * Purge cached responses by `Cache-Tag`, path prefix, or everything.
+   */
+  purge(
+    options: cf.CachePurgeOptions,
+  ): Effect.Effect<cf.CachePurgeResult, CachePurgeError, RuntimeContext>;
+}
+
 export class WorkerExecutionContext extends Context.Service<
   WorkerExecutionContext,
   {
@@ -76,6 +96,10 @@ export class WorkerExecutionContext extends Context.Service<
      * exception, instead of returning an error page.
      */
     passThroughOnException(): Effect.Effect<void, never, RuntimeContext>;
+    /**
+     * The Workers Cache runtime API (`ctx.cache`).
+     */
+    readonly cache: WorkerExecutionContextCache;
     /**
      * The raw workerd ExecutionContext, for interop with async APIs.
      */
@@ -97,7 +121,72 @@ export const fromExecutionContext = (
       );
     }),
   passThroughOnException: () => Effect.sync(() => ctx.passThroughOnException()),
+  cache: {
+    purge: (options) =>
+      ctx.cache
+        ? Effect.tryPromise({
+            try: () => ctx.cache!.purge(options),
+            catch: (cause) =>
+              new CachePurgeError({
+                message:
+                  cause instanceof Error
+                    ? cause.message
+                    : "Unknown cache purge error",
+                cause,
+              }),
+          })
+        : Effect.fail(
+            new CachePurgeError({
+              message:
+                "ctx.cache is not available — enable Workers Cache on this " +
+                "Worker (the `cache` prop or `yield* Cloudflare.cache()`) " +
+                "and note it is not supported in local dev.",
+            }),
+          ),
+  },
 });
+
+/**
+ * A {@link WorkerExecutionContext} whose methods resolve the live per-event
+ * context from the calling fiber at call time. Provided during the Worker's
+ * init phase (plan and runtime module init) so the service can be yielded
+ * and closed over in the top-level closure; every method is colored with
+ * `RuntimeContext`, so it can only be *run* inside a handler, where the
+ * bridge provides the real per-event context that these methods defer to.
+ */
+export const deferredExecutionContext: WorkerExecutionContext["Service"] = {
+  get raw(): cf.ExecutionContext {
+    throw new Error(
+      "WorkerExecutionContext.raw is only available inside a request handler",
+    );
+  },
+  waitUntil: <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+    liveExecutionContext.pipe(
+      Effect.flatMap((live) => live.waitUntil(effect)),
+    ) as Effect.Effect<void, never, R | RuntimeContext>,
+  passThroughOnException: () =>
+    liveExecutionContext.pipe(
+      Effect.flatMap((live) => live.passThroughOnException()),
+    ) as Effect.Effect<void, never, RuntimeContext>,
+  cache: {
+    purge: (options) =>
+      liveExecutionContext.pipe(
+        Effect.flatMap((live) => live.cache.purge(options)),
+      ) as Effect.Effect<cf.CachePurgeResult, CachePurgeError, RuntimeContext>,
+  },
+};
+
+const liveExecutionContext = WorkerExecutionContext.pipe(
+  Effect.flatMap((live) =>
+    live === deferredExecutionContext
+      ? Effect.die(
+          new Error(
+            "WorkerExecutionContext can only be used inside a request handler",
+          ),
+        )
+      : Effect.succeed(live),
+  ),
+);
 
 export type WorkerEvent = Exclude<
   {
@@ -278,7 +367,10 @@ export interface WorkerProps<
    * versions (by default the cache is scoped to a single version, so every
    * deploy starts cold).
    *
-   * If omitted, Workers Cache is disabled.
+   * If omitted, Workers Cache is disabled — unless the Worker's init phase
+   * enables it via `yield* Cloudflare.cache()`, which is the preferred way
+   * for Effect-native Workers (and also returns the runtime purge client).
+   * When both are set, this prop takes precedence.
    *
    * @see https://blog.cloudflare.com/workers-cache/
    */
@@ -494,6 +586,12 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
   },
   {
     bindings?: WorkerBinding[];
+    /**
+     * Workers Cache settings contributed by `yield* Cloudflare.cache()`.
+     * Merged into the upload metadata's `cache_options`; an explicit
+     * `WorkerProps.cache` takes precedence.
+     */
+    cache?: WorkerCache;
     containers?: { className: string; dev: DevContainerImage | undefined }[];
     crons?: string[];
     hyperdrives?: Record<string, Required<DevOrigin>>;
@@ -740,7 +838,9 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
  * @section Workers Cache
  * Workers Cache puts a regionally tiered cache in front of the Worker —
  * cache hits are served from the edge without invoking the Worker (and
- * without billing CPU time). Enable it with the `cache` prop, then control
+ * without billing CPU time). In an Effect-native Worker, enable it by
+ * yielding `Cloudflare.cache()` in the init phase, which also returns the
+ * runtime purge client; async Workers use the `cache` prop instead. Control
  * what gets cached from your handlers via standard response headers:
  * `Cache-Control` (including `stale-while-revalidate`), `Cache-Tag` for
  * tag-based purging, and `Vary` for content negotiation.
@@ -749,29 +849,39 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
  * deploy starts cold. Set `crossVersionCache: true` to share cached
  * responses across versions.
  *
- * @example Enabling Workers Cache
+ * @example Enabling and purging the cache in an Effect Worker
+ * ```typescript
+ * Effect.gen(function* () {
+ *   // init: enable Workers Cache on this Worker
+ *   const { purge } = yield* Cloudflare.cache({ crossVersionCache: true });
+ *
+ *   return {
+ *     fetch: Effect.gen(function* () {
+ *       const request = yield* HttpServerRequest;
+ *       if (request.url.startsWith("/invalidate")) {
+ *         yield* purge({ tags: ["products"] });
+ *         return HttpServerResponse.text("purged");
+ *       }
+ *       return HttpServerResponse.text("hello", {
+ *         headers: {
+ *           "Cache-Control": "public, max-age=300, stale-while-revalidate=3600",
+ *           "Cache-Tag": "products,product:123",
+ *         },
+ *       });
+ *     }),
+ *   };
+ * })
+ * ```
+ *
+ * @example Enabling Workers Cache on an async Worker
  * ```typescript
  * {
- *   main: import.meta.url,
+ *   main: "./src/worker.ts",
  *   cache: {
  *     enabled: true,
  *     crossVersionCache: true,
  *   },
  * }
- * ```
- *
- * @example Caching responses from a handler
- * ```typescript
- * return {
- *   fetch: Effect.gen(function* () {
- *     return HttpServerResponse.text("hello", {
- *       headers: {
- *         "Cache-Control": "public, max-age=300, stale-while-revalidate=3600",
- *         "Cache-Tag": "products,product:123",
- *       },
- *     });
- *   }),
- * };
  * ```
  *
  * @section R2 Bucket

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -229,7 +229,7 @@ export interface WorkerLimits extends Exclude<
 > {}
 
 export interface WorkerCache extends Exclude<
-  workers.PutScriptRequest["metadata"]["cacheOptions"],
+  workers.PutScriptRequest["metadata"]["cache"],
   undefined
 > {}
 

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -61,8 +61,43 @@ export class WorkerEnvironment extends Context.Service<
 
 export class WorkerExecutionContext extends Context.Service<
   WorkerExecutionContext,
-  cf.ExecutionContext
+  {
+    /**
+     * Run an Effect in the background without blocking the response, keeping
+     * the Worker alive until it settles. The Effect runs with the caller's
+     * full context (services, tracing), and the resulting promise is
+     * registered with workerd's `ctx.waitUntil`.
+     */
+    waitUntil<A, E, R>(
+      effect: Effect.Effect<A, E, R>,
+    ): Effect.Effect<void, never, R | RuntimeContext>;
+    /**
+     * Forward the request to the origin if the Worker throws an unhandled
+     * exception, instead of returning an error page.
+     */
+    passThroughOnException(): Effect.Effect<void, never, RuntimeContext>;
+    /**
+     * The raw workerd ExecutionContext, for interop with async APIs.
+     */
+    readonly raw: cf.ExecutionContext;
+  }
 >()("Cloudflare.Workers.WorkerExecutionContext") {}
+
+export const fromExecutionContext = (
+  ctx: cf.ExecutionContext,
+): WorkerExecutionContext["Service"] => ({
+  raw: ctx,
+  waitUntil: <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+    Effect.gen(function* () {
+      const context = yield* Effect.context<R>();
+      // Register the promise with workerd un-awaited — waitUntil extends the
+      // invocation's lifetime without blocking the response.
+      yield* Effect.sync(() =>
+        ctx.waitUntil(Effect.runPromise(effect.pipe(Effect.provide(context)))),
+      );
+    }),
+  passThroughOnException: () => Effect.sync(() => ctx.passThroughOnException()),
+});
 
 export type WorkerEvent = Exclude<
   {

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -103,6 +103,11 @@ export interface WorkerLimits extends Exclude<
   undefined
 > {}
 
+export interface WorkerCache extends Exclude<
+  workers.PutScriptRequest["metadata"]["cacheOptions"],
+  undefined
+> {}
+
 export type WorkerPlacement = Exclude<
   workers.PutScriptRequest["metadata"]["placement"],
   undefined
@@ -226,6 +231,23 @@ export interface WorkerProps<
    * `traces: { enabled: true, ... }`.
    */
   observability?: WorkerObservability;
+  /**
+   * Workers Cache settings. When `enabled` is `true`, Cloudflare checks a
+   * regionally tiered cache in front of the Worker on every HTTP request —
+   * cache hits are served from the edge without invoking the Worker at all.
+   * The Worker controls what gets cached via standard response headers
+   * (`Cache-Control`, `Cache-Tag`, `Vary`), including
+   * `stale-while-revalidate`.
+   *
+   * Set `crossVersionCache: true` to share cached responses across Worker
+   * versions (by default the cache is scoped to a single version, so every
+   * deploy starts cold).
+   *
+   * If omitted, Workers Cache is disabled.
+   *
+   * @see https://blog.cloudflare.com/workers-cache/
+   */
+  cache?: WorkerCache;
   tags?: string[];
   /**
    * Path to the Worker's entry module. Bundled with rolldown before
@@ -678,6 +700,43 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
  *     },
  *   },
  * }
+ * ```
+ *
+ * @section Workers Cache
+ * Workers Cache puts a regionally tiered cache in front of the Worker —
+ * cache hits are served from the edge without invoking the Worker (and
+ * without billing CPU time). Enable it with the `cache` prop, then control
+ * what gets cached from your handlers via standard response headers:
+ * `Cache-Control` (including `stale-while-revalidate`), `Cache-Tag` for
+ * tag-based purging, and `Vary` for content negotiation.
+ *
+ * The cache is scoped to a single Worker version by default, so every
+ * deploy starts cold. Set `crossVersionCache: true` to share cached
+ * responses across versions.
+ *
+ * @example Enabling Workers Cache
+ * ```typescript
+ * {
+ *   main: import.meta.url,
+ *   cache: {
+ *     enabled: true,
+ *     crossVersionCache: true,
+ *   },
+ * }
+ * ```
+ *
+ * @example Caching responses from a handler
+ * ```typescript
+ * return {
+ *   fetch: Effect.gen(function* () {
+ *     return HttpServerResponse.text("hello", {
+ *       headers: {
+ *         "Cache-Control": "public, max-age=300, stale-while-revalidate=3600",
+ *         "Cache-Tag": "products,product:123",
+ *       },
+ *     });
+ *   }),
+ * };
  * ```
  *
  * @section R2 Bucket

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
@@ -284,3 +284,21 @@ const toBinding = (
 export const getCronBindings = (
   bindings: ReadonlyArray<ResourceBinding<Worker["Binding"]>>,
 ) => Array.from(new Set(bindings.flatMap((b) => b.data.crons ?? [])));
+
+/**
+ * Merge the Workers Cache settings contributed by `yield* Cloudflare.cache()`
+ * bindings. Commutative: the cache is enabled (and cross-version) if any
+ * contributor asked for it.
+ */
+export const getCacheBinding = (
+  bindings: ReadonlyArray<ResourceBinding<Worker["Binding"]>>,
+) => {
+  const configs = bindings.flatMap((b) => (b.data.cache ? [b.data.cache] : []));
+  if (configs.length === 0) {
+    return undefined;
+  }
+  return {
+    enabled: configs.some((c) => c.enabled),
+    crossVersionCache: configs.some((c) => c.crossVersionCache) || undefined,
+  };
+};

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerBridge.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerBridge.ts
@@ -74,8 +74,11 @@ export const makeWorkerBridge = (
           eff.pipe(
             // Per-event services take precedence over the captured init
             // context: the init context carries the *deferred*
-            // WorkerExecutionContext (yieldable in the top-level closure),
-            // which must be shadowed by the real per-event one here.
+            // WorkerExecutionContext (yieldable in the top-level closure)
+            // and the isolate-lifetime instance Scope, both of which must
+            // be shadowed by the real per-event ones here so that
+            // `Effect.addFinalizer` in a handler attaches to the request
+            // scope (closed into `ctx.waitUntil` below).
             Effect.provide(
               Layer.mergeAll(
                 Layer.succeed(
@@ -86,14 +89,13 @@ export const makeWorkerBridge = (
                   scope,
                   cache: {},
                 }),
+                Layer.succeed(Scope.Scope, scope),
               ),
             ),
             Effect.provide(Layer.succeedContext(context)),
           ),
         ),
-        Effect.provide(
-          Layer.provideMerge(globalContext, Layer.succeed(Scope.Scope, scope)),
-        ),
+        Effect.provide(globalContext),
         Effect.runPromiseExit,
       )
       .finally(() =>
@@ -227,6 +229,16 @@ export const getWorkerExport = <Export = any>({
     Logger.layer([Logger.consolePretty()]),
   );
 
+  // Fallback Scope for init-phase code paths where the Layer machinery
+  // doesn't provide a build scope of its own. Never closed (workerd has no
+  // isolate-teardown hook). Note the entrypoint layer is rebuilt per event
+  // (each event runs in a fresh runtime with its own memo map), and a layer
+  // build provides its own scope to the init effect — so init-level
+  // finalizers actually attach to that build scope and fire at the end of
+  // each event, not here. Handlers get the request scope from
+  // `processEvent`, which closes into `ctx.waitUntil` after the response.
+  const instanceScope = Scope.makeUnsafe();
+
   const globalContext = Layer.unwrap(
     cloudflare_workers.pipe(
       Effect.map(({ env }) =>
@@ -274,6 +286,7 @@ export const getWorkerExport = <Export = any>({
               (env as any).DEBUG ? "Debug" : "Info",
             ),
           ),
+          Layer.provideMerge(Layer.succeed(Scope.Scope, instanceScope)),
         ),
       ),
     ),

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerBridge.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerBridge.ts
@@ -32,6 +32,7 @@ import {
   Worker,
   WorkerEnvironment,
   WorkerExecutionContext,
+  deferredExecutionContext,
   fromExecutionContext,
 } from "./Worker.ts";
 import type { WorkerRuntimeContext } from "./WorkerRuntimeContext.ts";
@@ -70,24 +71,24 @@ export const makeWorkerBridge = (
     return eff
       .pipe(
         Effect.flatMap(([eff, context]) =>
-          Effect.provide(
-            eff,
-            pipe(
-              Layer.succeedContext(context),
-              Layer.provideMerge(Layer.succeedContext(context)),
-              Layer.provideMerge(
+          eff.pipe(
+            // Per-event services take precedence over the captured init
+            // context: the init context carries the *deferred*
+            // WorkerExecutionContext (yieldable in the top-level closure),
+            // which must be shadowed by the real per-event one here.
+            Effect.provide(
+              Layer.mergeAll(
                 Layer.succeed(
                   WorkerExecutionContext,
                   fromExecutionContext(ctx),
                 ),
-              ),
-              Layer.provideMerge(
                 Layer.succeed(ExecutionContext, {
                   scope,
                   cache: {},
                 }),
               ),
             ),
+            Effect.provide(Layer.succeedContext(context)),
           ),
         ),
         Effect.provide(
@@ -250,6 +251,13 @@ export const getWorkerExport = <Export = any>({
             ),
           ),
           Layer.provideMerge(Layer.succeed(WorkerEnvironment, env)),
+          // Init-phase ExecutionContext: yieldable from the Worker's
+          // top-level closure (and Layers); its RuntimeContext-colored
+          // methods defer to the real per-event context provided by
+          // `processEvent`.
+          Layer.provideMerge(
+            Layer.succeed(WorkerExecutionContext, deferredExecutionContext),
+          ),
           Layer.provideMerge(
             Layer.succeed(
               CloudflareEnvironment,

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerBridge.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerBridge.ts
@@ -32,6 +32,7 @@ import {
   Worker,
   WorkerEnvironment,
   WorkerExecutionContext,
+  fromExecutionContext,
 } from "./Worker.ts";
 import type { WorkerRuntimeContext } from "./WorkerRuntimeContext.ts";
 
@@ -74,7 +75,12 @@ export const makeWorkerBridge = (
             pipe(
               Layer.succeedContext(context),
               Layer.provideMerge(Layer.succeedContext(context)),
-              Layer.provideMerge(Layer.succeed(WorkerExecutionContext, ctx)),
+              Layer.provideMerge(
+                Layer.succeed(
+                  WorkerExecutionContext,
+                  fromExecutionContext(ctx),
+                ),
+              ),
               Layer.provideMerge(
                 Layer.succeed(ExecutionContext, {
                   scope,

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -26,7 +26,7 @@ import { getCompatibility } from "./Compatibility.ts";
 import { isDurableObjectExport } from "./DurableObject.ts";
 import { LocalWorkerProvider } from "./LocalWorkerProvider.ts";
 import { Worker, type WorkerProps } from "./Worker.ts";
-import { getCronBindings } from "./WorkerAsyncBindings.ts";
+import { getCacheBinding, getCronBindings } from "./WorkerAsyncBindings.ts";
 import type { WorkerBinding, WorkerSettingsBinding } from "./WorkerBinding.ts";
 import { readPrebuiltWorkerBundle, WorkerBundle } from "./WorkerBundle.ts";
 import { isWorkerLoader } from "./WorkerLoader.ts";
@@ -1224,7 +1224,7 @@ export const LiveWorkerProvider = () =>
           assets: metadataAssets,
           bindings: metadataBindings,
           bodyPart: undefined,
-          cacheOptions: news.cache,
+          cacheOptions: news.cache ?? getCacheBinding(bindings),
           compatibilityDate: compatibility.date,
           compatibilityFlags: compatibility.flags,
           containers:

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -1242,7 +1242,7 @@ export const LiveWorkerProvider = () =>
           assets: metadataAssets,
           bindings: metadataBindings,
           bodyPart: undefined,
-          cacheOptions: news.cache ?? getCacheBinding(bindings),
+          cache: news.cache ?? getCacheBinding(bindings),
           compatibilityDate: compatibility.date,
           compatibilityFlags: compatibility.flags,
           containers:

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -244,8 +244,8 @@ const resolveMetadataHashValue = (
 /**
  * The deploy-time metadata surface of a Worker whose changes must trigger an
  * update but that never touch the bundle/vite/asset-content hashes:
- * compatibility, env literals, bindings, asset routing config, limits,
- * logpush, observability, placement, subdomain, and tags. See #745.
+ * compatibility, env literals, bindings, asset routing config, cache,
+ * limits, logpush, observability, placement, subdomain, and tags. See #745.
  */
 interface WorkerMetadataHashInput {
   readonly props: WorkerProps;
@@ -293,6 +293,7 @@ const resolveWorkerMetadataHash = ({
       data: binding.data,
     })),
     assets: workerAssetConfigForHash(props.assets),
+    cache: props.cache,
     limits: props.limits,
     logpush: props.logpush,
     observability: props.observability,
@@ -1223,6 +1224,7 @@ export const LiveWorkerProvider = () =>
           assets: metadataAssets,
           bindings: metadataBindings,
           bodyPart: undefined,
+          cacheOptions: news.cache,
           compatibilityDate: compatibility.date,
           compatibilityFlags: compatibility.flags,
           containers:

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerRuntimeContext.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerRuntimeContext.ts
@@ -11,7 +11,9 @@ import { makeRequestHandler } from "./HttpServer.ts";
 import {
   ExportedHandlerMethods,
   WorkerEnvironment,
+  WorkerExecutionContext,
   WorkerTypeId,
+  deferredExecutionContext,
   type WorkerEvent,
 } from "./Worker.ts";
 import type { WorkflowExport } from "../Workflows/Workflow.ts";
@@ -108,7 +110,13 @@ export const makeWorkerRuntimeContext = (id: string): WorkerRuntimeContext => {
       Effect.sync(() => {
         exports[name] = value;
       }),
-    planServices: Layer.succeed(WorkerEnvironment, {}),
+    planServices: Layer.mergeAll(
+      Layer.succeed(WorkerEnvironment, {}),
+      // Lets the init closure `yield*` WorkerExecutionContext during plan;
+      // its RuntimeContext-colored methods can't run until a real handler
+      // provides the live per-event context.
+      Layer.succeed(WorkerExecutionContext, deferredExecutionContext),
+    ),
     exports: Effect.gen(function* () {
       const handlers = yield* Effect.all(listeners, {
         concurrency: "unbounded",

--- a/packages/alchemy/src/Cloudflare/Workers/index.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/index.ts
@@ -2,6 +2,7 @@ export * from "./AccountSetting.ts";
 export * from "./Assets.ts";
 export * from "./Browser.ts";
 export * from "./BrowserBinding.ts";
+export * from "./Cache.ts";
 export * from "./ConfigProvider.ts";
 export * from "./CronEventSource.ts";
 export * from "./DurableObject.ts";

--- a/packages/alchemy/test/Cloudflare/Workers/RpcDurableObjectNamespace.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/RpcDurableObjectNamespace.test.ts
@@ -160,12 +160,25 @@ test(
     const delta = k("delta");
     const client = HttpClient.filterStatusOk(yield* HttpClient.HttpClient);
 
-    const res = yield* client
+    // The stream route commits a 200 before the DO stream produces data, so
+    // a transient `Worker not found.` during binding propagation dies AFTER
+    // the headers are sent and surfaces as a truncated/empty 200 body —
+    // invisible to status-based retries. `CountUpTo` is a pure stream, so
+    // retry on content until all four lines arrive.
+    const lines = yield* client
       .get(`${url}/counter/${delta}/stream?upto=4`)
-      .pipe(retryHttp);
-    expect(res.status).toBe(200);
-    const body = yield* res.text;
-    const lines = body.split("\n").filter((l) => l.length > 0);
+      .pipe(
+        Effect.flatMap((res) => res.text),
+        Effect.flatMap((body) => {
+          const lines = body.split("\n").filter((l) => l.length > 0);
+          return lines.length === 4
+            ? Effect.succeed(lines)
+            : Effect.fail(
+                new Error(`truncated stream body: ${JSON.stringify(lines)}`),
+              );
+        }),
+        retryHttp,
+      );
     expect(lines).toEqual(["1", "2", "3", "4"]);
   }).pipe(logLevel),
   { timeout: 30_000 },

--- a/packages/alchemy/test/Cloudflare/Workers/WaitUntil.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WaitUntil.test.ts
@@ -50,11 +50,16 @@ test(
 
     // Fire both background writes: one from the Worker's ExecutionContext,
     // one from inside the DO via DurableObjectState.waitUntil. Both routes
-    // respond before the journal entry is persisted.
-    const bg = yield* getText(client, `${url}/bg`);
-    expect(bg).toBe("scheduled");
-    const bgDo = yield* getText(client, `${url}/bg-do`);
-    expect(bgDo).toBe("scheduled");
+    // respond before the journal entry is persisted. Probed via
+    // expectUrlContains so transient placeholders/5xx during propagation
+    // are retried (a duplicate journal entry from a retry is harmless —
+    // the assertions below use `toContain`).
+    yield* expectUrlContains(`${url}/bg`, "bg-scheduled", {
+      label: "waitUntil /bg",
+    });
+    yield* expectUrlContains(`${url}/bg-do`, "bg-do-scheduled", {
+      label: "waitUntil /bg-do",
+    });
 
     // The entries only appear if waitUntil kept the invocations alive until
     // the delayed writes completed.
@@ -97,10 +102,15 @@ test(
     });
 
     // Both routes respond before their finalizers persist the entries.
-    const fin = yield* getText(client, `${url}/finalizer`);
-    expect(fin).toBe("ok");
-    const finDo = yield* getText(client, `${url}/finalizer-do`);
-    expect(finDo).toBe("scheduled");
+    // Probed via expectUrlContains so transient placeholders/5xx during
+    // propagation are retried (duplicate journal entries are harmless —
+    // the assertions below use `toContain`).
+    yield* expectUrlContains(`${url}/finalizer`, "finalizer-scheduled", {
+      label: "finalizer /finalizer",
+    });
+    yield* expectUrlContains(`${url}/finalizer-do`, "do-finalizer-scheduled", {
+      label: "finalizer /finalizer-do",
+    });
 
     const entries = yield* Effect.gen(function* () {
       const body = JSON.parse(yield* getText(client, `${url}/entries`)) as {

--- a/packages/alchemy/test/Cloudflare/Workers/WaitUntil.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WaitUntil.test.ts
@@ -5,6 +5,7 @@ import * as Effect from "effect/Effect";
 import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
 import * as HttpClient from "effect/unstable/http/HttpClient";
+import { expectUrlContains } from "../Utils/Http.ts";
 import Stack from "./fixtures/wait-until/stack.ts";
 
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
@@ -20,46 +21,47 @@ const logLevel = Effect.provideService(
 const stack = beforeAll(deploy(Stack));
 afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(Stack));
 
+// Cache-busting query param on every request: after destroy+recreate of the
+// same workers.dev subdomain the edge can serve a cached "nothing here yet"
+// placeholder (with a 200) for the bare URL even though busted requests
+// already reach the worker. Route matching uses `url.pathname`, so the
+// param is invisible to the fixture.
+let bust = 0;
+const getText = (
+  client: HttpClient.HttpClient,
+  url: string,
+): Effect.Effect<string, unknown> =>
+  client
+    .get(`${url}?cb=${Date.now()}-${bust++}`)
+    .pipe(Effect.flatMap((res) => res.text));
+
 test(
   "waitUntil runs background Effects past the response (worker ctx + DO state)",
   Effect.gen(function* () {
     const { url } = yield* stack;
     const client = yield* HttpClient.HttpClient;
 
-    // Readiness probe through workers.dev propagation; also asserts the raw
-    // escape hatch is the genuine workerd ExecutionContext.
-    const raw = yield* Effect.gen(function* () {
-      const res = yield* client.get(`${url}/raw`);
-      if (res.status !== 200) {
-        return yield* Effect.fail(new Error(`Worker not ready: ${res.status}`));
-      }
-      return yield* res.text;
-    }).pipe(
-      Effect.retry({
-        schedule: Schedule.exponential("500 millis"),
-        times: 10,
-      }),
-    );
-    expect(raw).toBe("ok");
+    // Content-based readiness through workers.dev propagation (the
+    // placeholder page serves 200s); also asserts the raw escape hatch is
+    // the genuine workerd ExecutionContext.
+    yield* expectUrlContains(`${url}/raw`, "ok", {
+      label: "wait-until worker propagation",
+    });
 
     // Fire both background writes: one from the Worker's ExecutionContext,
     // one from inside the DO via DurableObjectState.waitUntil. Both routes
     // respond before the journal entry is persisted.
-    const bg = yield* client
-      .get(`${url}/bg`)
-      .pipe(Effect.flatMap((res) => res.text));
+    const bg = yield* getText(client, `${url}/bg`);
     expect(bg).toBe("scheduled");
-    const bgDo = yield* client
-      .get(`${url}/bg-do`)
-      .pipe(Effect.flatMap((res) => res.text));
+    const bgDo = yield* getText(client, `${url}/bg-do`);
     expect(bgDo).toBe("scheduled");
 
     // The entries only appear if waitUntil kept the invocations alive until
     // the delayed writes completed.
     const entries = yield* Effect.gen(function* () {
-      const res = yield* client.get(`${url}/entries`);
-      if (res.status !== 200) return [];
-      const body = (yield* res.json) as { entries?: string[] };
+      const body = JSON.parse(yield* getText(client, `${url}/entries`)) as {
+        entries?: string[];
+      };
       return body.entries ?? [];
     }).pipe(
       Effect.catch(() => Effect.succeed([] as string[])),
@@ -74,6 +76,75 @@ test(
 
     expect(entries).toContain("from-worker-wait-until");
     expect(entries).toContain("from-do-wait-until");
+  }).pipe(logLevel),
+  { timeout: 180_000 },
+);
+
+// Scope finalizers piggyback on the same mechanism: the bridge closes the
+// per-event scope after the handler completes and registers the close
+// promise with waitUntil, so `Effect.addFinalizer` work lands after the
+// response without blocking it.
+test(
+  "Effect.addFinalizer runs after the response (request scope + DO call scope)",
+  Effect.gen(function* () {
+    const { url } = yield* stack;
+    const client = yield* HttpClient.HttpClient;
+
+    // Content-based readiness: a fresh workers.dev URL serves Cloudflare's
+    // placeholder page (with a 200) while the subdomain propagates.
+    yield* expectUrlContains(`${url}/raw`, "ok", {
+      label: "wait-until worker propagation",
+    });
+
+    // Both routes respond before their finalizers persist the entries.
+    const fin = yield* getText(client, `${url}/finalizer`);
+    expect(fin).toBe("ok");
+    const finDo = yield* getText(client, `${url}/finalizer-do`);
+    expect(finDo).toBe("scheduled");
+
+    const entries = yield* Effect.gen(function* () {
+      const body = JSON.parse(yield* getText(client, `${url}/entries`)) as {
+        entries?: string[];
+      };
+      return body.entries ?? [];
+    }).pipe(
+      Effect.catch(() => Effect.succeed([] as string[])),
+      Effect.repeat({
+        schedule: Schedule.spaced("1 second"),
+        until: (entries) =>
+          entries.includes("from-request-finalizer") &&
+          entries.includes("from-do-finalizer"),
+        times: 30,
+      }),
+    );
+
+    expect(entries).toContain("from-request-finalizer");
+    expect(entries).toContain("from-do-finalizer");
+
+    // Init-phase semantics (documented on the Worker resource): the init
+    // closure is re-evaluated per event — its Layer is rebuilt for each
+    // event's runtime — and the layer's build scope closes when the event
+    // ends, so a finalizer added in the init closure fires once per event.
+    // This pins that observable behavior: after the requests above, the
+    // per-isolate counters show multiple init runs with finalizers tracking
+    // them (finalized ≥ init - 1 on a single isolate; sampled loosely to
+    // tolerate isolate churn).
+    const observations: { init: number; finalized: number }[] = [];
+    yield* Effect.gen(function* () {
+      const init = Number(yield* getText(client, `${url}/init-runs`));
+      const finalized = Number(
+        yield* getText(client, `${url}/init-finalizer-runs`),
+      );
+      observations.push({ init, finalized });
+    }).pipe(
+      Effect.repeat({
+        schedule: Schedule.spaced("500 millis"),
+        times: 5,
+      }),
+    );
+    expect(observations.some((o) => o.init >= 2 && o.finalized >= 1)).toBe(
+      true,
+    );
   }).pipe(logLevel),
   { timeout: 180_000 },
 );

--- a/packages/alchemy/test/Cloudflare/Workers/WaitUntil.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WaitUntil.test.ts
@@ -1,0 +1,79 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as Test from "@/Test/Vitest";
+import { expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+import * as Schedule from "effect/Schedule";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import Stack from "./fixtures/wait-until/stack.ts";
+
+const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
+  providers: Cloudflare.providers(),
+  state: Cloudflare.state(),
+});
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+const stack = beforeAll(deploy(Stack));
+afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(Stack));
+
+test(
+  "waitUntil runs background Effects past the response (worker ctx + DO state)",
+  Effect.gen(function* () {
+    const { url } = yield* stack;
+    const client = yield* HttpClient.HttpClient;
+
+    // Readiness probe through workers.dev propagation; also asserts the raw
+    // escape hatch is the genuine workerd ExecutionContext.
+    const raw = yield* Effect.gen(function* () {
+      const res = yield* client.get(`${url}/raw`);
+      if (res.status !== 200) {
+        return yield* Effect.fail(new Error(`Worker not ready: ${res.status}`));
+      }
+      return yield* res.text;
+    }).pipe(
+      Effect.retry({
+        schedule: Schedule.exponential("500 millis"),
+        times: 10,
+      }),
+    );
+    expect(raw).toBe("ok");
+
+    // Fire both background writes: one from the Worker's ExecutionContext,
+    // one from inside the DO via DurableObjectState.waitUntil. Both routes
+    // respond before the journal entry is persisted.
+    const bg = yield* client
+      .get(`${url}/bg`)
+      .pipe(Effect.flatMap((res) => res.text));
+    expect(bg).toBe("scheduled");
+    const bgDo = yield* client
+      .get(`${url}/bg-do`)
+      .pipe(Effect.flatMap((res) => res.text));
+    expect(bgDo).toBe("scheduled");
+
+    // The entries only appear if waitUntil kept the invocations alive until
+    // the delayed writes completed.
+    const entries = yield* Effect.gen(function* () {
+      const res = yield* client.get(`${url}/entries`);
+      if (res.status !== 200) return [];
+      const body = (yield* res.json) as { entries?: string[] };
+      return body.entries ?? [];
+    }).pipe(
+      Effect.catch(() => Effect.succeed([] as string[])),
+      Effect.repeat({
+        schedule: Schedule.spaced("1 second"),
+        until: (entries) =>
+          entries.includes("from-worker-wait-until") &&
+          entries.includes("from-do-wait-until"),
+        times: 30,
+      }),
+    );
+
+    expect(entries).toContain("from-worker-wait-until");
+    expect(entries).toContain("from-do-wait-until");
+  }).pipe(logLevel),
+  { timeout: 180_000 },
+);

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerCache.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerCache.test.ts
@@ -5,6 +5,7 @@ import * as Effect from "effect/Effect";
 import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
 import { expectUrlContains } from "../Utils/Http.ts";
+import CacheTestWorker from "./fixtures/cache/cache-worker.ts";
 
 const { test } = Test.make({ providers: Cloudflare.providers() });
 
@@ -100,6 +101,70 @@ test.provider(
         }),
       );
       expect(disabled.worker.workerName).toEqual(worker.workerName);
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 240_000 },
+);
+
+// Effect-native path: `yield* Cloudflare.cache()` in the init phase enables
+// Workers Cache via the binding contract (no `cache` prop) and returns the
+// runtime purge client backed by `ctx.cache`.
+test.provider(
+  "Cloudflare.cache() enables the cache and purges by tag",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const { worker } = yield* stack.deploy(
+        Effect.gen(function* () {
+          return { worker: yield* CacheTestWorker };
+        }),
+      );
+      expect(worker.url).toBeDefined();
+
+      yield* expectUrlContains(`${worker.url}/item`, "id:", {
+        label: "cache worker propagation",
+      });
+
+      // Poll the same URL until a repeat body proves the binding actually
+      // enabled the cache.
+      const url = `${worker.url}/item`;
+      let previous: string | undefined;
+      const hit = yield* fetchCached(url).pipe(
+        Effect.map((res) => {
+          const isHit =
+            res.status === 200 &&
+            previous !== undefined &&
+            res.body === previous;
+          previous = res.body;
+          return { ...res, isHit };
+        }),
+        Effect.repeat({
+          schedule: Schedule.spaced("2 seconds"),
+          until: (res) => res.isHit,
+          times: 20,
+        }),
+      );
+      expect(hit.isHit).toBe(true);
+      const cachedBody = hit.body;
+
+      // Purge by Cache-Tag through the runtime client.
+      const purged = yield* fetchCached(`${worker.url}/purge`);
+      expect(purged.status).toBe(200);
+      expect((JSON.parse(purged.body) as { success: boolean }).success).toBe(
+        true,
+      );
+
+      // A fresh invocation id proves the tag purge evicted the entry.
+      const fresh = yield* fetchCached(url).pipe(
+        Effect.repeat({
+          schedule: Schedule.spaced("2 seconds"),
+          until: (res) => res.status === 200 && res.body !== cachedBody,
+          times: 20,
+        }),
+      );
+      expect(fresh.body).not.toBe(cachedBody);
 
       yield* stack.destroy();
     }).pipe(logLevel),

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerCache.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerCache.test.ts
@@ -37,6 +37,34 @@ const fetchCached = (url: string) =>
     };
   });
 
+// Poll `url` until two consecutive responses carry the same worker-stamped
+// body ("id:<uuid>"), proving the second was served from the Workers Cache
+// without invoking the worker. Only marker-carrying bodies participate:
+// workers.dev placeholder pages also serve identical 200 bodies, so an
+// unanchored comparison would count two placeholders as a false "hit".
+// Bounded so a broken cache fails fast instead of hitting the vitest
+// timeout.
+const pollForCacheHit = (url: string) => {
+  let previous: string | undefined;
+  return fetchCached(url).pipe(
+    Effect.map((res) => {
+      const isWorkerBody = res.status === 200 && res.body.startsWith("id:");
+      const isHit =
+        (isWorkerBody && previous !== undefined && res.body === previous) ||
+        res.cacheStatus === "HIT";
+      if (isWorkerBody) {
+        previous = res.body;
+      }
+      return { ...res, isHit };
+    }),
+    Effect.repeat({
+      schedule: Schedule.spaced("2 seconds"),
+      until: (res) => res.isHit,
+      times: 20,
+    }),
+  );
+};
+
 test.provider(
   "worker with Workers Cache enabled serves repeat requests from cache",
   (stack) =>
@@ -63,27 +91,7 @@ test.provider(
         label: "cached worker propagation",
       });
 
-      // Repeatedly fetch the same URL until two consecutive responses carry
-      // the same invocation id (i.e. the second was a cache hit). Bounded so
-      // a broken cache fails fast instead of running into the vitest timeout.
-      const url = `${worker.url}/cached`;
-      let previous: string | undefined;
-      const hit = yield* fetchCached(url).pipe(
-        Effect.map((res) => {
-          const isHit =
-            (res.status === 200 &&
-              previous !== undefined &&
-              res.body === previous) ||
-            res.cacheStatus === "HIT";
-          previous = res.body;
-          return { ...res, isHit };
-        }),
-        Effect.repeat({
-          schedule: Schedule.spaced("2 seconds"),
-          until: (res) => res.isHit,
-          times: 20,
-        }),
-      );
+      const hit = yield* pollForCacheHit(`${worker.url}/cached`);
       expect(hit.isHit).toBe(true);
 
       // Metadata-only update: same script, cache turned off. The metadata
@@ -130,41 +138,40 @@ test.provider(
       // Poll the same URL until a repeat body proves the binding actually
       // enabled the cache.
       const url = `${worker.url}/item`;
-      let previous: string | undefined;
-      const hit = yield* fetchCached(url).pipe(
-        Effect.map((res) => {
-          const isHit =
-            res.status === 200 &&
-            previous !== undefined &&
-            res.body === previous;
-          previous = res.body;
-          return { ...res, isHit };
-        }),
-        Effect.repeat({
-          schedule: Schedule.spaced("2 seconds"),
-          until: (res) => res.isHit,
-          times: 20,
-        }),
-      );
+      const hit = yield* pollForCacheHit(url);
       expect(hit.isHit).toBe(true);
       const cachedBody = hit.body;
 
-      // Purge by Cache-Tag through the runtime client.
-      const purged = yield* fetchCached(`${worker.url}/purge`);
-      expect(purged.status).toBe(200);
-      expect((JSON.parse(purged.body) as { success: boolean }).success).toBe(
-        true,
+      // Purge by Cache-Tag through the runtime client. Retried until the
+      // response parses as JSON — transient placeholders/5xx bodies throw
+      // and retry; a parsed `success: false` is a genuine failure and
+      // surfaces via the assertion.
+      const purged = yield* fetchCached(`${worker.url}/purge`).pipe(
+        Effect.flatMap((res) =>
+          Effect.try(() => JSON.parse(res.body) as { success: boolean }),
+        ),
+        Effect.retry({
+          schedule: Schedule.spaced("2 seconds"),
+          times: 10,
+        }),
       );
+      expect(purged.success).toBe(true);
 
-      // A fresh invocation id proves the tag purge evicted the entry.
+      // A fresh invocation id proves the tag purge evicted the entry. The
+      // marker check keeps a placeholder page (also ≠ cachedBody) from
+      // passing as "fresh".
       const fresh = yield* fetchCached(url).pipe(
         Effect.repeat({
           schedule: Schedule.spaced("2 seconds"),
-          until: (res) => res.status === 200 && res.body !== cachedBody,
+          until: (res) =>
+            res.status === 200 &&
+            res.body.startsWith("id:") &&
+            res.body !== cachedBody,
           times: 20,
         }),
       );
       expect(fresh.body).not.toBe(cachedBody);
+      expect(fresh.body.startsWith("id:")).toBe(true);
 
       yield* stack.destroy();
     }).pipe(logLevel),

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerCache.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerCache.test.ts
@@ -1,0 +1,107 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as Test from "@/Test/Vitest";
+import { expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+import * as Schedule from "effect/Schedule";
+import { expectUrlContains } from "../Utils/Http.ts";
+
+const { test } = Test.make({ providers: Cloudflare.providers() });
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+// The worker stamps every invocation with a fresh UUID, so two fetches of
+// the same URL returning the same body means the second response was served
+// from the Workers Cache without invoking the worker.
+const cachedScript = `export default {
+  async fetch() {
+    return new Response("id:" + crypto.randomUUID(), {
+      headers: { "Cache-Control": "public, max-age=300" },
+    });
+  },
+};
+`;
+
+const fetchCached = (url: string) =>
+  Effect.tryPromise(async (signal) => {
+    // NO cache-busting here — the whole point is hitting the same cache key.
+    const res = await fetch(url, { signal });
+    return {
+      status: res.status,
+      cacheStatus: res.headers.get("cf-cache-status"),
+      body: await res.text(),
+    };
+  });
+
+test.provider(
+  "worker with Workers Cache enabled serves repeat requests from cache",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const { worker } = yield* stack.deploy(
+        Effect.gen(function* () {
+          return {
+            worker: yield* Cloudflare.Worker("CachedWorker", {
+              script: cachedScript,
+              cache: {
+                enabled: true,
+                crossVersionCache: true,
+              },
+            }),
+          };
+        }),
+      );
+      expect(worker.url).toBeDefined();
+
+      // Ride out workers.dev propagation before probing cache behavior.
+      yield* expectUrlContains(worker.url!, "id:", {
+        label: "cached worker propagation",
+      });
+
+      // Repeatedly fetch the same URL until two consecutive responses carry
+      // the same invocation id (i.e. the second was a cache hit). Bounded so
+      // a broken cache fails fast instead of running into the vitest timeout.
+      const url = `${worker.url}/cached`;
+      let previous: string | undefined;
+      const hit = yield* fetchCached(url).pipe(
+        Effect.map((res) => {
+          const isHit =
+            (res.status === 200 &&
+              previous !== undefined &&
+              res.body === previous) ||
+            res.cacheStatus === "HIT";
+          previous = res.body;
+          return { ...res, isHit };
+        }),
+        Effect.repeat({
+          schedule: Schedule.spaced("2 seconds"),
+          until: (res) => res.isHit,
+          times: 20,
+        }),
+      );
+      expect(hit.isHit).toBe(true);
+
+      // Metadata-only update: same script, cache turned off. The metadata
+      // hash must register the change and the API must accept the update.
+      const disabled = yield* stack.deploy(
+        Effect.gen(function* () {
+          return {
+            worker: yield* Cloudflare.Worker("CachedWorker", {
+              script: cachedScript,
+              cache: {
+                enabled: false,
+              },
+            }),
+          };
+        }),
+      );
+      expect(disabled.worker.workerName).toEqual(worker.workerName);
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 240_000 },
+);

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/cache/cache-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/cache/cache-worker.ts
@@ -1,0 +1,49 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Effect from "effect/Effect";
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+/**
+ * Fixture worker for `WorkerCache.test.ts` (Effect-native path).
+ *
+ * `yield* Cloudflare.cache()` in the init phase enables Workers Cache on the
+ * Worker (no `cache` prop involved) and returns the runtime purge client.
+ * `/item` serves a per-invocation UUID tagged `items`, so a repeated body
+ * proves a cache hit and a fresh body after `/purge` proves the tag purge.
+ */
+export default class CacheTestWorker extends Cloudflare.Worker<CacheTestWorker>()(
+  "CacheTestWorker",
+  {
+    main: import.meta.url,
+  },
+  Effect.gen(function* () {
+    const { purge } = yield* Cloudflare.cache({ crossVersionCache: true });
+
+    return {
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        const url = new URL(request.url, "http://x");
+
+        if (url.pathname === "/item") {
+          return HttpServerResponse.text(`id:${crypto.randomUUID()}`, {
+            headers: {
+              "Cache-Control": "public, max-age=300",
+              "Cache-Tag": "items",
+            },
+          });
+        }
+
+        if (url.pathname === "/purge") {
+          const result = yield* purge({ tags: ["items"] }).pipe(
+            Effect.catchTag("CachePurgeError", (error) =>
+              Effect.succeed({ success: false, errors: [error.message] }),
+            ),
+          );
+          return yield* HttpServerResponse.json(result);
+        }
+
+        return HttpServerResponse.text("Not Found", { status: 404 });
+      }),
+    };
+  }),
+) {}

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/wait-until/stack.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/wait-until/stack.ts
@@ -1,0 +1,18 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as Alchemy from "@/index.ts";
+import * as Effect from "effect/Effect";
+import WaitUntilWorker from "./wait-until-worker.ts";
+
+export default Alchemy.Stack(
+  "WaitUntilStack",
+  {
+    providers: Cloudflare.providers(),
+    state: Cloudflare.state(),
+  },
+  Effect.gen(function* () {
+    const worker = yield* WaitUntilWorker;
+    return {
+      url: worker.url.as<string>(),
+    };
+  }),
+);

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/wait-until/wait-until-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/wait-until/wait-until-worker.ts
@@ -94,12 +94,12 @@ export default class WaitUntilWorker extends Cloudflare.Worker<WaitUntilWorker>(
               Effect.andThen(journal.record("from-worker-wait-until")),
             ),
           );
-          return HttpServerResponse.text("scheduled");
+          return HttpServerResponse.text("bg-scheduled");
         }
 
         if (url.pathname === "/bg-do") {
           return HttpServerResponse.text(
-            yield* journal.recordLater("from-do-wait-until"),
+            `bg-do-${yield* journal.recordLater("from-do-wait-until")}`,
           );
         }
 
@@ -113,12 +113,12 @@ export default class WaitUntilWorker extends Cloudflare.Worker<WaitUntilWorker>(
               Effect.ignore,
             ),
           );
-          return HttpServerResponse.text("ok");
+          return HttpServerResponse.text("finalizer-scheduled");
         }
 
         if (url.pathname === "/finalizer-do") {
           return HttpServerResponse.text(
-            yield* journal.recordOnClose("from-do-finalizer"),
+            `do-finalizer-${yield* journal.recordOnClose("from-do-finalizer")}`,
           );
         }
 

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/wait-until/wait-until-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/wait-until/wait-until-worker.ts
@@ -53,6 +53,9 @@ export default class WaitUntilWorker extends Cloudflare.Worker<WaitUntilWorker>(
   },
   Effect.gen(function* () {
     const journals = yield* Journal;
+    // Yielded from the init closure (deferred instance) — its methods
+    // resolve the live per-event context when invoked inside a handler.
+    const exec = yield* Cloudflare.WorkerExecutionContext;
 
     return {
       fetch: Effect.gen(function* () {
@@ -61,7 +64,6 @@ export default class WaitUntilWorker extends Cloudflare.Worker<WaitUntilWorker>(
         const journal = journals.getByName("default");
 
         if (url.pathname === "/bg") {
-          const exec = yield* Cloudflare.WorkerExecutionContext;
           yield* exec.waitUntil(
             Effect.sleep("100 millis").pipe(
               Effect.andThen(journal.record("from-worker-wait-until")),

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/wait-until/wait-until-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/wait-until/wait-until-worker.ts
@@ -28,6 +28,18 @@ export class Journal extends Cloudflare.DurableObject<Journal>()(
           );
           return "scheduled" as const;
         }),
+        // Scope finalizers added inside a DO method run after the method
+        // returns: the bridge closes the per-call scope and registers the
+        // close promise with `state.waitUntil`.
+        recordOnClose: Effect.fn(function* (entry: string) {
+          yield* Effect.addFinalizer(() =>
+            Effect.sleep("100 millis").pipe(
+              Effect.andThen(append(entry)),
+              Effect.ignore,
+            ),
+          );
+          return "scheduled" as const;
+        }),
         snapshot: Effect.fn(function* () {
           return {
             entries: (yield* state.storage.get<string[]>("entries")) ?? [],
@@ -56,6 +68,19 @@ export default class WaitUntilWorker extends Cloudflare.Worker<WaitUntilWorker>(
     // Yielded from the init closure (deferred instance) — its methods
     // resolve the live per-event context when invoked inside a handler.
     const exec = yield* Cloudflare.WorkerExecutionContext;
+    // Probes: observe how often the init closure itself runs and if/when a
+    // finalizer added in the init closure runs. Counted on globalThis and
+    // exposed via /init-runs and /init-finalizer-runs.
+    yield* Effect.sync(() => {
+      (globalThis as any).__initRuns =
+        ((globalThis as any).__initRuns ?? 0) + 1;
+    });
+    yield* Effect.addFinalizer(() =>
+      Effect.sync(() => {
+        (globalThis as any).__initFinalizerRuns =
+          ((globalThis as any).__initFinalizerRuns ?? 0) + 1;
+      }),
+    );
 
     return {
       fetch: Effect.gen(function* () {
@@ -78,8 +103,39 @@ export default class WaitUntilWorker extends Cloudflare.Worker<WaitUntilWorker>(
           );
         }
 
+        // Scope finalizers added in a fetch handler run after the response
+        // is sent: the bridge closes the request scope and registers the
+        // close promise with `ctx.waitUntil`.
+        if (url.pathname === "/finalizer") {
+          yield* Effect.addFinalizer(() =>
+            Effect.sleep("100 millis").pipe(
+              Effect.andThen(journal.record("from-request-finalizer")),
+              Effect.ignore,
+            ),
+          );
+          return HttpServerResponse.text("ok");
+        }
+
+        if (url.pathname === "/finalizer-do") {
+          return HttpServerResponse.text(
+            yield* journal.recordOnClose("from-do-finalizer"),
+          );
+        }
+
         if (url.pathname === "/entries") {
           return yield* HttpServerResponse.json(yield* journal.snapshot());
+        }
+
+        if (url.pathname === "/init-finalizer-runs") {
+          return HttpServerResponse.text(
+            String((globalThis as any).__initFinalizerRuns ?? 0),
+          );
+        }
+
+        if (url.pathname === "/init-runs") {
+          return HttpServerResponse.text(
+            String((globalThis as any).__initRuns ?? 0),
+          );
         }
 
         if (url.pathname === "/raw") {

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/wait-until/wait-until-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/wait-until/wait-until-worker.ts
@@ -1,0 +1,94 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Effect from "effect/Effect";
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+/**
+ * Durable Object journal for `WaitUntil.test.ts`.
+ *
+ * `record` persists an entry inline. `recordLater` returns before persisting
+ * and uses `DurableObjectState.waitUntil` to write the entry in the
+ * background — the test only sees the entry if waitUntil actually kept the
+ * DO alive past the RPC response.
+ */
+export class Journal extends Cloudflare.DurableObject<Journal>()(
+  "Journal",
+  Effect.gen(function* () {
+    const state = yield* Cloudflare.DurableObjectState;
+    return Effect.gen(function* () {
+      const append = Effect.fn(function* (entry: string) {
+        const entries = (yield* state.storage.get<string[]>("entries")) ?? [];
+        yield* state.storage.put("entries", [...entries, entry]);
+      });
+      return {
+        record: append,
+        recordLater: Effect.fn(function* (entry: string) {
+          yield* state.waitUntil(
+            Effect.sleep("100 millis").pipe(Effect.andThen(append(entry))),
+          );
+          return "scheduled" as const;
+        }),
+        snapshot: Effect.fn(function* () {
+          return {
+            entries: (yield* state.storage.get<string[]>("entries")) ?? [],
+          };
+        }),
+      };
+    });
+  }),
+) {}
+
+/**
+ * Fixture worker for `WaitUntil.test.ts`.
+ *
+ * `GET /bg` responds immediately and records a journal entry from a
+ * background Effect via `WorkerExecutionContext.waitUntil`. `GET /bg-do`
+ * exercises `DurableObjectState.waitUntil` inside the DO. The test polls
+ * `GET /entries` until both entries appear.
+ */
+export default class WaitUntilWorker extends Cloudflare.Worker<WaitUntilWorker>()(
+  "WaitUntilWorker",
+  {
+    main: import.meta.url,
+  },
+  Effect.gen(function* () {
+    const journals = yield* Journal;
+
+    return {
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        const url = new URL(request.url, "http://x");
+        const journal = journals.getByName("default");
+
+        if (url.pathname === "/bg") {
+          const exec = yield* Cloudflare.WorkerExecutionContext;
+          yield* exec.waitUntil(
+            Effect.sleep("100 millis").pipe(
+              Effect.andThen(journal.record("from-worker-wait-until")),
+            ),
+          );
+          return HttpServerResponse.text("scheduled");
+        }
+
+        if (url.pathname === "/bg-do") {
+          return HttpServerResponse.text(
+            yield* journal.recordLater("from-do-wait-until"),
+          );
+        }
+
+        if (url.pathname === "/entries") {
+          return yield* HttpServerResponse.json(yield* journal.snapshot());
+        }
+
+        if (url.pathname === "/raw") {
+          const exec = yield* Cloudflare.WorkerExecutionContext;
+          return HttpServerResponse.text(
+            typeof exec.raw.waitUntil === "function" ? "ok" : "missing",
+          );
+        }
+
+        return HttpServerResponse.text("Not Found", { status: 404 });
+      }),
+    };
+  }),
+) {}


### PR DESCRIPTION
Support [Workers Cache](https://blog.cloudflare.com/workers-cache/) — Cloudflare's regionally tiered cache in front of Worker entrypoints — as both a `cache` prop and an Effect-native `Cloudflare.cache()` binding, and make `WorkerExecutionContext` an Effect wrapper with `waitUntil` that is yieldable from the Worker's init closure.

### Workers Cache

Effect-native Workers enable the cache (and get the runtime purge client) with a binding:

```ts
Effect.gen(function* () {
  // init: enables Workers Cache on this Worker at deploy time
  const { purge } = yield* Cloudflare.cache({ crossVersionCache: true });

  return {
    fetch: Effect.gen(function* () {
      const request = yield* HttpServerRequest;
      if (request.url.startsWith("/invalidate")) {
        yield* purge({ tags: ["products"] }); // ctx.cache.purge, typed CachePurgeError
        return HttpServerResponse.text("purged");
      }
      return HttpServerResponse.text("hello", {
        headers: {
          "Cache-Control": "public, max-age=300, stale-while-revalidate=3600",
          "Cache-Tag": "products",
        },
      });
    }),
  };
})
```

Async Workers use the prop:

```ts
const worker = yield* Cloudflare.Worker("Api", {
  main: "./src/api.ts",
  cache: { enabled: true, crossVersionCache: true },
});
```

- Both paths map to the upload metadata's `cache_options` (typed via alchemy-run/distilled#364; submodule bumped here). The binding contributes through the Worker's binding contract (like `crons`); an explicit prop takes precedence.
- `cache` is part of the deploy-time metadata hash (#745), so a cache-only edit deploys instead of planning as a noop.
- The callable is lowercase `Cloudflare.cache` (matching `Cloudflare.Workers.cron`) — `Cloudflare.Cache` is already the zone-cache resource namespace.

### Effect-native ExecutionContext

`WorkerExecutionContext` was the raw `cf.ExecutionContext`; it's now an Effect wrapper — and it can be yielded from the Worker's **init closure** (or any Layer), like `DurableObjectState`:

```ts
Effect.gen(function* () {
  // init: deferred instance; methods resolve the live per-event context
  const exec = yield* Cloudflare.WorkerExecutionContext;

  return {
    fetch: Effect.gen(function* () {
      // respond now, finish work in the background
      yield* exec.waitUntil(journal.record(entry).pipe(Effect.delay("5 seconds")));
      return HttpServerResponse.text("ok");
    }),
  };
})
```

- `waitUntil(effect)` runs the Effect with the caller's full context and registers the promise with workerd un-awaited; `passThroughOnException()` and `cache.purge()` are wrapped too; `raw` is the escape hatch (init-time deferred `raw` throws — it only exists per event)
- Every method is colored with `RuntimeContext`, so nothing can *run* at the top level — plan mode works because the deferred instance is provided in `planServices`
- `DurableObjectState` gains the same `waitUntil` + `raw`

```diff
- const ctx = yield* Cloudflare.WorkerExecutionContext;
- ctx.waitUntil(somePromise);
+ const exec = yield* Cloudflare.WorkerExecutionContext;
+ exec.raw.waitUntil(somePromise);   // raw escape hatch
+ yield* exec.waitUntil(someEffect); // or Effect-native
```

Live tests: `WorkerCache.test.ts` observes real cache hits for both the prop and the binding path and verifies a `Cache-Tag` purge produces a fresh response; `WaitUntil.test.ts` proves both `exec.waitUntil` (yielded at init) and `state.waitUntil` persist background writes after the response is sent.


### Scope finalizers

`Effect.addFinalizer` in a handler behaves like `waitUntil`: the bridge closes the per-event scope after the handler completes and registers the close promise with `ctx.waitUntil` (Workers) / `state.waitUntil` (Durable Objects), so finalizer work lands after the response without blocking it. Streaming responses transfer the scope to the stream.

```ts
fetch: Effect.gen(function* () {
  // runs after this response is sent, kept alive by waitUntil
  yield* Effect.addFinalizer(() => flushMetrics().pipe(Effect.ignore));
  return HttpServerResponse.text("ok");
});
```

The live test also pins the init-phase semantics: the init closure is re-evaluated per event (its Layer is rebuilt for each event's runtime), so a finalizer added at init fires at the end of every event — cleanup belongs on handler scopes. Both are documented in new "Background Work & Scopes" sections on `Worker` and `DurableObject`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
