### PR TITLE
fix(cloudflare/workers): retry every binding-target-not-found error on script upload

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -105,10 +105,8 @@ const getScriptSettings = (
  * retrying converges, or a genuine misconfiguration that keeps
  * failing and surfaces as the typed error once the bounded budget is
  * exhausted.
- *
- * @internal exported for unit testing
  */
-export const isBindingTargetNotFound = (
+const isBindingTargetNotFound = (
   e:
     | Effect.Error<ReturnType<typeof workers.putScript>>
     | Effect.Error<ReturnType<typeof wfp.putDispatchNamespaceScript>>,

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -93,8 +93,46 @@ const getScriptSettings = (
   });
 
 /**
+ * Deploy-time binding validation rejects an upload whose bindings
+ * reference a resource Cloudflare can't see (each resource type has
+ * its own typed not-found error, verified against the live API).
+ * Every bound resource is provisioned before the Worker deploys —
+ * dependency order for KV/R2/D1/queues/etc., a pre-created stub
+ * (which exports the Durable Object classes) for circular
+ * Worker↔Worker references — so a not-found here is either
+ * propagation lag on a just-created resource (a Secrets Store secret
+ * still `pending`, a stub script not yet in the registry) that
+ * retrying converges, or a genuine misconfiguration that keeps
+ * failing and surfaces as the typed error once the bounded budget is
+ * exhausted.
+ *
+ * @internal exported for unit testing
+ */
+export const isBindingTargetNotFound = (
+  e:
+    | Effect.Error<ReturnType<typeof workers.putScript>>
+    | Effect.Error<ReturnType<typeof wfp.putDispatchNamespaceScript>>,
+): boolean =>
+  e._tag === "SecretsStoreBindingNotFound" ||
+  e._tag === "KVNamespaceNotFound" ||
+  e._tag === "R2BucketNotFound" ||
+  e._tag === "D1DatabaseNotFound" ||
+  e._tag === "QueueNotFound" ||
+  e._tag === "ServiceBindingNotFound" ||
+  e._tag === "DurableObjectClassNotFound" ||
+  e._tag === "HyperdriveConfigNotFound" ||
+  e._tag === "VectorizeIndexNotFound" ||
+  e._tag === "DispatchNamespaceNotFound" ||
+  e._tag === "MtlsCertificateNotFound";
+
+const bindingTargetNotFoundRetrySchedule = () =>
+  Schedule.fixed("2 seconds").pipe(Schedule.both(Schedule.recurs(10)));
+
+/**
  * Upsert a Worker script, routing to the dispatch-namespace endpoint when
- * `dispatchNamespace` is set. The metadata/files contract is identical.
+ * `dispatchNamespace` is set. The metadata/files contract is identical, and
+ * both endpoints run the same binding validation (see
+ * {@link isBindingTargetNotFound}), so both get the same bounded retry.
  *
  * @internal
  */
@@ -107,14 +145,21 @@ const putWorkerScript = (params: {
 }) =>
   Effect.gen(function* () {
     if (params.dispatchNamespace) {
-      return yield* wfp.putDispatchNamespaceScript({
-        accountId: params.accountId,
-        dispatchNamespace: params.dispatchNamespace,
-        scriptName: params.scriptName,
-        metadata:
-          params.metadata as unknown as wfp.PutDispatchNamespaceScriptRequest["metadata"],
-        files: params.files,
-      });
+      return yield* wfp
+        .putDispatchNamespaceScript({
+          accountId: params.accountId,
+          dispatchNamespace: params.dispatchNamespace,
+          scriptName: params.scriptName,
+          metadata:
+            params.metadata as unknown as wfp.PutDispatchNamespaceScriptRequest["metadata"],
+          files: params.files,
+        })
+        .pipe(
+          Effect.retry({
+            while: isBindingTargetNotFound,
+            schedule: bindingTargetNotFoundRetrySchedule(),
+          }),
+        );
     }
     return yield* workers
       .putScript({
@@ -125,14 +170,8 @@ const putWorkerScript = (params: {
       })
       .pipe(
         Effect.retry({
-          // A Secrets Store secret referenced by a binding can take a few
-          // seconds after creation before Cloudflare's deploy-time
-          // validation sees it; a genuinely missing secret keeps failing
-          // and surfaces after the (bounded) budget.
-          while: (e) => e._tag === "SecretsStoreBindingNotFound",
-          schedule: Schedule.fixed("2 seconds").pipe(
-            Schedule.both(Schedule.recurs(10)),
-          ),
+          while: isBindingTargetNotFound,
+          schedule: bindingTargetNotFoundRetrySchedule(),
         }),
       );
   });

--- a/packages/alchemy/test/Cloudflare/Workers/BindingTargetNotFound.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/BindingTargetNotFound.test.ts
@@ -1,8 +1,6 @@
 import * as Cloudflare from "@/Cloudflare/index.ts";
-import { isBindingTargetNotFound } from "@/Cloudflare/Workers/WorkerProvider.ts";
 import * as Test from "@/Test/Vitest";
-import * as workers from "@distilled.cloud/cloudflare/workers";
-import { describe, expect, it } from "@effect/vitest";
+import { expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 
 const { test } = Test.make({ providers: Cloudflare.providers() });
@@ -11,17 +9,18 @@ const script = `export default { fetch() { return new Response("ok"); } };`;
 
 /**
  * Deploy-time binding validation rejects a script upload whose bindings
- * reference a resource that doesn't exist.
+ * reference a resource that doesn't exist. The Durable Object
+ * cross-script binding is the one deterministic engine-level trigger:
+ * `scriptName` is a plain string, so a stack can name a script that was
+ * never deployed. (Every other binding type can only reference a
+ * resource declared in the stack, and its reconciler heals a missing
+ * target before the Worker deploys — those hit not-found only via
+ * propagation races, which `putWorkerScript`'s bounded retry rides
+ * out.)
  *
- * The Durable Object cross-script binding is the one deterministic
- * engine-level trigger: `scriptName` is a plain string, so a stack can
- * name a script that was never deployed. Every other binding type can
- * only reference a resource declared in the stack, and its reconciler
- * heals a missing target before the Worker deploys — those hit
- * not-found only through propagation races (a just-created target not
- * yet visible to validation), which is exactly what
- * `putWorkerScript`'s bounded retry exists for. The predicate matrix
- * below covers the full family hermetically.
+ * The deploy must fail with the resource-specific typed error after the
+ * bounded retry exhausts — not an UnknownCloudflareError, and not a
+ * success.
  */
 test.provider(
   "durable object binding to a script that doesn't exist surfaces the typed error",
@@ -45,90 +44,8 @@ test.provider(
         .pipe(Effect.flip);
 
       expect(error._tag).toEqual("DurableObjectClassNotFound");
-      expect(isBindingTargetNotFound(error)).toBe(true);
 
       yield* stack.destroy();
     }),
   { timeout: 240_000 },
 );
-
-/**
- * The retry predicate across the full family of typed
- * binding-target-not-found errors. Each code was captured verbatim
- * from the live API by uploading probe workers with bindings
- * referencing missing targets; the deploy above exercises one member
- * through a real stack.
- */
-describe("isBindingTargetNotFound", () => {
-  const notFound = [
-    new workers.KVNamespaceNotFound({
-      code: 10041,
-      message: "KV namespace '00000000000000000000000000000000' not found.",
-    }),
-    new workers.R2BucketNotFound({
-      code: 10085,
-      message: "R2 bucket 'missing-bucket' not found.",
-    }),
-    new workers.D1DatabaseNotFound({
-      code: 10181,
-      message:
-        "D1 binding 'DB' references database '00000000-0000-0000-0000-000000000000' which was not found.",
-    }),
-    new workers.QueueNotFound({
-      code: 11000,
-      message: "Queue 'missing-queue' not found.",
-    }),
-    new workers.ServiceBindingNotFound({
-      code: 10144,
-      message:
-        "Service binding 'SVC' references environment 'production' on Worker 'missing-worker' which was not found.",
-    }),
-    new workers.DurableObjectClassNotFound({
-      code: 10061,
-      message:
-        "Cannot create binding for class 'Foo' that is not exported by script 'some-script'.",
-    }),
-    new workers.HyperdriveConfigNotFound({
-      code: 10157,
-      message:
-        "Hyperdrive binding 'HD' references config '00000000000000000000000000000000' which was not found.",
-    }),
-    new workers.VectorizeIndexNotFound({
-      code: 10159,
-      message:
-        "Vectorize binding 'VEC' references index 'missing-index' which was not found.",
-    }),
-    new workers.DispatchNamespaceNotFound({
-      code: 100119,
-      message:
-        "The specified dispatch namespace does not exist on this account.",
-    }),
-    new workers.MtlsCertificateNotFound({
-      code: 100143,
-      message:
-        "mTLS certificate '00000000-0000-0000-0000-000000000000' not found.",
-    }),
-    new workers.SecretsStoreBindingNotFound({
-      code: 10182,
-      message:
-        "Secrets Store binding 'SECRET' references store '00000000000000000000000000000000' and secret 'missing' which were not found.",
-    }),
-  ];
-
-  for (const error of notFound) {
-    it(`retries ${error._tag}`, () => {
-      expect(isBindingTargetNotFound(error)).toBe(true);
-    });
-  }
-
-  it("does not retry non-binding upload failures", () => {
-    expect(
-      isBindingTargetNotFound(
-        new workers.InvalidWorkerScript({
-          code: 10068,
-          message: "Uncaught SyntaxError: Unexpected token",
-        }),
-      ),
-    ).toBe(false);
-  });
-});

--- a/packages/alchemy/test/Cloudflare/Workers/BindingTargetNotFound.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/BindingTargetNotFound.test.ts
@@ -1,182 +1,134 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
 import { isBindingTargetNotFound } from "@/Cloudflare/Workers/WorkerProvider.ts";
-import {
-  Credentials,
-  apiTokenCredentials,
-} from "@distilled.cloud/cloudflare/Credentials";
+import * as Test from "@/Test/Vitest";
 import * as workers from "@distilled.cloud/cloudflare/workers";
-import * as wfp from "@distilled.cloud/cloudflare/workers-for-platforms";
 import { describe, expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as HttpClient from "effect/unstable/http/HttpClient";
-import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
+
+const { test } = Test.make({ providers: Cloudflare.providers() });
+
+const script = `export default { fetch() { return new Response("ok"); } };`;
 
 /**
- * Every deploy-time "binding references a resource that doesn't exist"
- * rejection `putScript` / `putDispatchNamespaceScript` can produce must
- * decode to its resource-specific typed tag, and `putWorkerScript`'s
- * bounded retry must recognise all of them (a bound resource created
- * moments earlier can be invisible to Cloudflare's validation for a
- * few seconds).
+ * Deploy-time binding validation rejects a script upload whose bindings
+ * reference a resource that doesn't exist.
  *
- * Each `code` + message below was captured verbatim from the live API
- * by uploading a probe worker with a binding referencing a missing
- * target — the codes are resource-specific (not one shared
- * "binding not found" code), which is what makes the per-tag patches
- * sound.
+ * The Durable Object cross-script binding is the one deterministic
+ * engine-level trigger: `scriptName` is a plain string, so a stack can
+ * name a script that was never deployed. Every other binding type can
+ * only reference a resource declared in the stack, and its reconciler
+ * heals a missing target before the Worker deploys — those hit
+ * not-found only through propagation races (a just-created target not
+ * yet visible to validation), which is exactly what
+ * `putWorkerScript`'s bounded retry exists for. The predicate matrix
+ * below covers the full family hermetically.
  */
-const CASES: { tag: string; code: number; message: string }[] = [
-  {
-    tag: "KVNamespaceNotFound",
-    code: 10041,
-    message:
-      "KV namespace '00000000000000000000000000000000' not found. Verify the namespace exists in your account and that the namespace_id is correct.",
-  },
-  {
-    tag: "R2BucketNotFound",
-    code: 10085,
-    message:
-      "R2 bucket 'missing-bucket' not found. Verify the bucket exists in your account and that the bucket_name is correct.",
-  },
-  {
-    tag: "D1DatabaseNotFound",
-    code: 10181,
-    message:
-      "D1 binding 'DB' references database '00000000-0000-0000-0000-000000000000' which was not found.",
-  },
-  {
-    tag: "QueueNotFound",
-    code: 11000,
-    message:
-      "Queue 'missing-queue' not found. Please verify it exists and try again.",
-  },
-  {
-    tag: "ServiceBindingNotFound",
-    code: 10144,
-    message:
-      "Service binding 'SVC' references environment 'production' on Worker 'missing-worker' which was not found.",
-  },
-  {
-    tag: "DurableObjectClassNotFound",
-    code: 10061,
-    message:
-      "Cannot create binding for class 'Foo' that is not exported by script 'some-script'.",
-  },
-  {
-    tag: "HyperdriveConfigNotFound",
-    code: 10157,
-    message:
-      "Hyperdrive binding 'HD' references config '00000000000000000000000000000000' which was not found.",
-  },
-  {
-    tag: "VectorizeIndexNotFound",
-    code: 10159,
-    message:
-      "Vectorize binding 'VEC' references index 'missing-index' which was not found.",
-  },
-  {
-    tag: "DispatchNamespaceNotFound",
-    code: 100119,
-    message: "The specified dispatch namespace does not exist on this account.",
-  },
-  {
-    tag: "MtlsCertificateNotFound",
-    code: 100143,
-    message:
-      "mTLS certificate '00000000-0000-0000-0000-000000000000' not found.",
-  },
-  {
-    tag: "SecretsStoreBindingNotFound",
-    code: 10182,
-    message:
-      "Secrets Store binding 'SECRET' references store '00000000000000000000000000000000' and secret 'missing' which were not found.",
-  },
-];
+test.provider(
+  "durable object binding to a script that doesn't exist surfaces the typed error",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
 
-/** Serve the exact Cloudflare error envelope the live API returns. */
-const stubApi = (code: number, message: string) =>
-  Layer.mergeAll(
-    Layer.succeed(
-      HttpClient.HttpClient,
-      HttpClient.make((request) =>
-        Effect.sync(() =>
-          HttpClientResponse.fromWeb(
-            request,
-            new Response(
-              JSON.stringify({
-                success: false,
-                errors: [{ code, message }],
-                messages: [],
-                result: null,
-              }),
-              {
-                status: 400,
-                headers: { "content-type": "application/json" },
+      const error = yield* stack
+        .deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.Worker("do-consumer-worker", {
+              script,
+              env: {
+                Counter: Cloudflare.DurableObject("Counter", {
+                  scriptName: "alchemy-test-nonexistent-do-host",
+                }),
               },
-            ),
-          ),
-        ),
-      ),
-    ),
-    Layer.succeed(
-      Credentials,
-      Effect.succeed(apiTokenCredentials({ apiToken: "test-token" })),
-    ),
-  );
+            });
+          }),
+        )
+        .pipe(Effect.flip);
 
-const putScriptParams = {
-  accountId: "00000000000000000000000000000000",
-  scriptName: "binding-test",
-  metadata: { mainModule: "worker.js" },
-  files: [
-    new File(["export default {};"], "worker.js", {
-      type: "application/javascript+module",
+      expect(error._tag).toEqual("DurableObjectClassNotFound");
+      expect(isBindingTargetNotFound(error)).toBe(true);
+
+      yield* stack.destroy();
     }),
-  ],
-};
+  { timeout: 240_000 },
+);
 
-describe("putScript binding-target-not-found errors", () => {
-  for (const { tag, code, message } of CASES) {
-    it.effect(`decodes code ${code} as ${tag} and retries it`, () =>
-      Effect.gen(function* () {
-        const error = yield* workers
-          .putScript(putScriptParams)
-          .pipe(Effect.flip);
-        expect(error._tag).toBe(tag);
-        expect(isBindingTargetNotFound(error)).toBe(true);
-      }).pipe(Effect.provide(stubApi(code, message))),
-    );
+/**
+ * The retry predicate across the full family of typed
+ * binding-target-not-found errors. Each code was captured verbatim
+ * from the live API by uploading probe workers with bindings
+ * referencing missing targets; the deploy above exercises one member
+ * through a real stack.
+ */
+describe("isBindingTargetNotFound", () => {
+  const notFound = [
+    new workers.KVNamespaceNotFound({
+      code: 10041,
+      message: "KV namespace '00000000000000000000000000000000' not found.",
+    }),
+    new workers.R2BucketNotFound({
+      code: 10085,
+      message: "R2 bucket 'missing-bucket' not found.",
+    }),
+    new workers.D1DatabaseNotFound({
+      code: 10181,
+      message:
+        "D1 binding 'DB' references database '00000000-0000-0000-0000-000000000000' which was not found.",
+    }),
+    new workers.QueueNotFound({
+      code: 11000,
+      message: "Queue 'missing-queue' not found.",
+    }),
+    new workers.ServiceBindingNotFound({
+      code: 10144,
+      message:
+        "Service binding 'SVC' references environment 'production' on Worker 'missing-worker' which was not found.",
+    }),
+    new workers.DurableObjectClassNotFound({
+      code: 10061,
+      message:
+        "Cannot create binding for class 'Foo' that is not exported by script 'some-script'.",
+    }),
+    new workers.HyperdriveConfigNotFound({
+      code: 10157,
+      message:
+        "Hyperdrive binding 'HD' references config '00000000000000000000000000000000' which was not found.",
+    }),
+    new workers.VectorizeIndexNotFound({
+      code: 10159,
+      message:
+        "Vectorize binding 'VEC' references index 'missing-index' which was not found.",
+    }),
+    new workers.DispatchNamespaceNotFound({
+      code: 100119,
+      message:
+        "The specified dispatch namespace does not exist on this account.",
+    }),
+    new workers.MtlsCertificateNotFound({
+      code: 100143,
+      message:
+        "mTLS certificate '00000000-0000-0000-0000-000000000000' not found.",
+    }),
+    new workers.SecretsStoreBindingNotFound({
+      code: 10182,
+      message:
+        "Secrets Store binding 'SECRET' references store '00000000000000000000000000000000' and secret 'missing' which were not found.",
+    }),
+  ];
+
+  for (const error of notFound) {
+    it(`retries ${error._tag}`, () => {
+      expect(isBindingTargetNotFound(error)).toBe(true);
+    });
   }
 
-  it.effect(
-    "decodes the same envelope from the dispatch-namespace upload path",
-    () =>
-      Effect.gen(function* () {
-        const error = yield* wfp
-          .putDispatchNamespaceScript({
-            ...putScriptParams,
-            dispatchNamespace: "test-namespace",
-          })
-          .pipe(Effect.flip);
-        expect(error._tag).toBe("KVNamespaceNotFound");
-        expect(isBindingTargetNotFound(error)).toBe(true);
-      }).pipe(
-        Effect.provide(
-          stubApi(
-            10041,
-            "KV namespace '00000000000000000000000000000000' not found.",
-          ),
-        ),
+  it("does not retry non-binding upload failures", () => {
+    expect(
+      isBindingTargetNotFound(
+        new workers.InvalidWorkerScript({
+          code: 10068,
+          message: "Uncaught SyntaxError: Unexpected token",
+        }),
       ),
-  );
-
-  it.effect("does not retry non-binding upload failures", () =>
-    Effect.gen(function* () {
-      const error = yield* workers.putScript(putScriptParams).pipe(Effect.flip);
-      expect(error._tag).toBe("InvalidWorkerScript");
-      expect(isBindingTargetNotFound(error)).toBe(false);
-    }).pipe(
-      Effect.provide(stubApi(10068, "Uncaught SyntaxError: Unexpected token")),
-    ),
-  );
+    ).toBe(false);
+  });
 });

--- a/packages/alchemy/test/Cloudflare/Workers/BindingTargetNotFound.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/BindingTargetNotFound.test.ts
@@ -1,0 +1,182 @@
+import { isBindingTargetNotFound } from "@/Cloudflare/Workers/WorkerProvider.ts";
+import {
+  Credentials,
+  apiTokenCredentials,
+} from "@distilled.cloud/cloudflare/Credentials";
+import * as workers from "@distilled.cloud/cloudflare/workers";
+import * as wfp from "@distilled.cloud/cloudflare/workers-for-platforms";
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
+
+/**
+ * Every deploy-time "binding references a resource that doesn't exist"
+ * rejection `putScript` / `putDispatchNamespaceScript` can produce must
+ * decode to its resource-specific typed tag, and `putWorkerScript`'s
+ * bounded retry must recognise all of them (a bound resource created
+ * moments earlier can be invisible to Cloudflare's validation for a
+ * few seconds).
+ *
+ * Each `code` + message below was captured verbatim from the live API
+ * by uploading a probe worker with a binding referencing a missing
+ * target — the codes are resource-specific (not one shared
+ * "binding not found" code), which is what makes the per-tag patches
+ * sound.
+ */
+const CASES: { tag: string; code: number; message: string }[] = [
+  {
+    tag: "KVNamespaceNotFound",
+    code: 10041,
+    message:
+      "KV namespace '00000000000000000000000000000000' not found. Verify the namespace exists in your account and that the namespace_id is correct.",
+  },
+  {
+    tag: "R2BucketNotFound",
+    code: 10085,
+    message:
+      "R2 bucket 'missing-bucket' not found. Verify the bucket exists in your account and that the bucket_name is correct.",
+  },
+  {
+    tag: "D1DatabaseNotFound",
+    code: 10181,
+    message:
+      "D1 binding 'DB' references database '00000000-0000-0000-0000-000000000000' which was not found.",
+  },
+  {
+    tag: "QueueNotFound",
+    code: 11000,
+    message:
+      "Queue 'missing-queue' not found. Please verify it exists and try again.",
+  },
+  {
+    tag: "ServiceBindingNotFound",
+    code: 10144,
+    message:
+      "Service binding 'SVC' references environment 'production' on Worker 'missing-worker' which was not found.",
+  },
+  {
+    tag: "DurableObjectClassNotFound",
+    code: 10061,
+    message:
+      "Cannot create binding for class 'Foo' that is not exported by script 'some-script'.",
+  },
+  {
+    tag: "HyperdriveConfigNotFound",
+    code: 10157,
+    message:
+      "Hyperdrive binding 'HD' references config '00000000000000000000000000000000' which was not found.",
+  },
+  {
+    tag: "VectorizeIndexNotFound",
+    code: 10159,
+    message:
+      "Vectorize binding 'VEC' references index 'missing-index' which was not found.",
+  },
+  {
+    tag: "DispatchNamespaceNotFound",
+    code: 100119,
+    message: "The specified dispatch namespace does not exist on this account.",
+  },
+  {
+    tag: "MtlsCertificateNotFound",
+    code: 100143,
+    message:
+      "mTLS certificate '00000000-0000-0000-0000-000000000000' not found.",
+  },
+  {
+    tag: "SecretsStoreBindingNotFound",
+    code: 10182,
+    message:
+      "Secrets Store binding 'SECRET' references store '00000000000000000000000000000000' and secret 'missing' which were not found.",
+  },
+];
+
+/** Serve the exact Cloudflare error envelope the live API returns. */
+const stubApi = (code: number, message: string) =>
+  Layer.mergeAll(
+    Layer.succeed(
+      HttpClient.HttpClient,
+      HttpClient.make((request) =>
+        Effect.sync(() =>
+          HttpClientResponse.fromWeb(
+            request,
+            new Response(
+              JSON.stringify({
+                success: false,
+                errors: [{ code, message }],
+                messages: [],
+                result: null,
+              }),
+              {
+                status: 400,
+                headers: { "content-type": "application/json" },
+              },
+            ),
+          ),
+        ),
+      ),
+    ),
+    Layer.succeed(
+      Credentials,
+      Effect.succeed(apiTokenCredentials({ apiToken: "test-token" })),
+    ),
+  );
+
+const putScriptParams = {
+  accountId: "00000000000000000000000000000000",
+  scriptName: "binding-test",
+  metadata: { mainModule: "worker.js" },
+  files: [
+    new File(["export default {};"], "worker.js", {
+      type: "application/javascript+module",
+    }),
+  ],
+};
+
+describe("putScript binding-target-not-found errors", () => {
+  for (const { tag, code, message } of CASES) {
+    it.effect(`decodes code ${code} as ${tag} and retries it`, () =>
+      Effect.gen(function* () {
+        const error = yield* workers
+          .putScript(putScriptParams)
+          .pipe(Effect.flip);
+        expect(error._tag).toBe(tag);
+        expect(isBindingTargetNotFound(error)).toBe(true);
+      }).pipe(Effect.provide(stubApi(code, message))),
+    );
+  }
+
+  it.effect(
+    "decodes the same envelope from the dispatch-namespace upload path",
+    () =>
+      Effect.gen(function* () {
+        const error = yield* wfp
+          .putDispatchNamespaceScript({
+            ...putScriptParams,
+            dispatchNamespace: "test-namespace",
+          })
+          .pipe(Effect.flip);
+        expect(error._tag).toBe("KVNamespaceNotFound");
+        expect(isBindingTargetNotFound(error)).toBe(true);
+      }).pipe(
+        Effect.provide(
+          stubApi(
+            10041,
+            "KV namespace '00000000000000000000000000000000' not found.",
+          ),
+        ),
+      ),
+  );
+
+  it.effect("does not retry non-binding upload failures", () =>
+    Effect.gen(function* () {
+      const error = yield* workers.putScript(putScriptParams).pipe(Effect.flip);
+      expect(error._tag).toBe("InvalidWorkerScript");
+      expect(isBindingTargetNotFound(error)).toBe(false);
+    }).pipe(
+      Effect.provide(stubApi(10068, "Uncaught SyntaxError: Unexpected token")),
+    ),
+  );
+});


### PR DESCRIPTION
Extend `putWorkerScript`'s bounded not-found retry from just `SecretsStoreBindingNotFound` to every binding type whose target can be invisible to Cloudflare's deploy-time validation moments after creation. Every bound resource is provisioned before the Worker deploys (dependency order, or a pre-created stub that exports the DO classes for circular Worker↔Worker references), so a not-found at upload time is either propagation lag — the retry converges — or a genuine misconfiguration, which surfaces as the typed error after the ~20s budget.

```ts
export const isBindingTargetNotFound = (e) =>
  e._tag === "SecretsStoreBindingNotFound" ||
  e._tag === "KVNamespaceNotFound" ||        // 10041
  e._tag === "R2BucketNotFound" ||           // 10085
  e._tag === "D1DatabaseNotFound" ||         // 10181
  e._tag === "QueueNotFound" ||              // 11000
  e._tag === "ServiceBindingNotFound" ||     // 10144
  e._tag === "DurableObjectClassNotFound" || // 10061
  e._tag === "HyperdriveConfigNotFound" ||   // 10157
  e._tag === "VectorizeIndexNotFound" ||     // 10159
  e._tag === "DispatchNamespaceNotFound" ||  // 100119
  e._tag === "MtlsCertificateNotFound";      // 100143
```

- Every code was captured verbatim from the live API via probe uploads; the codes are resource-specific, so the typed tags can't mislabel another binding type (alchemy-run/distilled#365)
- The dispatch-namespace upload path (`putDispatchNamespaceScript`) runs the same validation (probed live) but previously had **no** retry — it now gets the same bounded one
- Workflow bindings are not validated at upload time (probe referencing a nonexistent workflow deployed fine), so they need no handling
- `test/Cloudflare/Workers/BindingTargetNotFound.test.ts` deploys a real stack through the engine (`test.provider`) whose Worker's DO binding names a script that doesn't exist, and asserts the typed `DurableObjectClassNotFound` surfaces through the failed deploy. The DO cross-script binding is the one deterministic engine-level trigger — every other binding type can only reference a resource declared in the stack, and its reconciler heals a missing target before the Worker deploys, so those hit not-found only via propagation races (which this retry exists for).

### Distilled dependency

The typed tags landed in alchemy-run/distilled#365; the pin on this branch (via the merge of main) already includes it.

