### PR TITLE
fix(cloudflare): classify Resource.ref values as native Worker env bindings

### DIFF
--- a/packages/alchemy/src/Cloudflare/AI/Gateway.ts
+++ b/packages/alchemy/src/Cloudflare/AI/Gateway.ts
@@ -5,7 +5,7 @@ import * as Stream from "effect/Stream";
 import { deepEqual, isResolved } from "../../Diff.ts";
 import { createPhysicalName } from "../../PhysicalName.ts";
 import * as Provider from "../../Provider.ts";
-import { Resource } from "../../Resource.ts";
+import { isResourceOfType, Resource } from "../../Resource.ts";
 import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
 import type { Providers } from "../Providers.ts";
 
@@ -302,10 +302,7 @@ const nullIfZero = (value: number | null | undefined): number | null =>
   value == null || value === 0 ? null : value;
 
 export const isAiGateway = (value: unknown): value is Gateway =>
-  typeof value === "object" &&
-  value !== null &&
-  "Type" in value &&
-  (value as Gateway).Type === "Cloudflare.AI.Gateway";
+  isResourceOfType(value, "Cloudflare.AI.Gateway");
 
 /**
  * A Cloudflare.AI. Gateway for observability, caching, rate limiting, and

--- a/packages/alchemy/src/Cloudflare/AI/SearchInstance.ts
+++ b/packages/alchemy/src/Cloudflare/AI/SearchInstance.ts
@@ -1,13 +1,12 @@
 import * as aisearch from "@distilled.cloud/cloudflare/aisearch";
 import * as Effect from "effect/Effect";
-import * as Predicate from "effect/Predicate";
 import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
 
 import { deepEqual, isResolved } from "../../Diff.ts";
 import { createPhysicalName } from "../../PhysicalName.ts";
 import * as Provider from "../../Provider.ts";
-import { Resource } from "../../Resource.ts";
+import { isResourceOfType, Resource } from "../../Resource.ts";
 import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
 import type { Providers } from "../Providers.ts";
 
@@ -563,7 +562,7 @@ export const SearchInstance = Resource<SearchInstance>(TypeId);
  * Returns true if the given value is a SearchInstance resource.
  */
 export const isSearchInstance = (value: unknown): value is SearchInstance =>
-  Predicate.hasProperty(value, "Type") && value.Type === TypeId;
+  isResourceOfType(value, TypeId);
 
 export const SearchInstanceProvider = () =>
   Provider.succeed(SearchInstance, {

--- a/packages/alchemy/src/Cloudflare/AI/SearchNamespace.ts
+++ b/packages/alchemy/src/Cloudflare/AI/SearchNamespace.ts
@@ -1,12 +1,11 @@
 import * as aisearch from "@distilled.cloud/cloudflare/aisearch";
 import * as Effect from "effect/Effect";
-import * as Predicate from "effect/Predicate";
 import * as Stream from "effect/Stream";
 
 import { isResolved } from "../../Diff.ts";
 import { createPhysicalName } from "../../PhysicalName.ts";
 import * as Provider from "../../Provider.ts";
-import { Resource } from "../../Resource.ts";
+import { isResourceOfType, Resource } from "../../Resource.ts";
 import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
 import type { Providers } from "../Providers.ts";
 
@@ -182,7 +181,7 @@ export const SearchNamespace = Resource<SearchNamespace>(TypeId);
  * Returns true if the given value is a SearchNamespace resource.
  */
 export const isSearchNamespace = (value: unknown): value is SearchNamespace =>
-  Predicate.hasProperty(value, "Type") && value.Type === TypeId;
+  isResourceOfType(value, TypeId);
 
 export const SearchNamespaceProvider = () =>
   Provider.succeed(SearchNamespace, {

--- a/packages/alchemy/src/Cloudflare/D1/Database.ts
+++ b/packages/alchemy/src/Cloudflare/D1/Database.ts
@@ -6,7 +6,7 @@ import type { HttpClient } from "effect/unstable/http/HttpClient";
 import { isResolved } from "../../Diff.ts";
 import { createPhysicalName } from "../../PhysicalName.ts";
 import * as Provider from "../../Provider.ts";
-import { Resource } from "../../Resource.ts";
+import { isResourceOfType, Resource } from "../../Resource.ts";
 import { listSqlFiles, readSqlFile } from "../../Sql/SqlFile.ts";
 import { recordsEqual } from "../../Util/equal.ts";
 import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
@@ -17,7 +17,7 @@ import { cloneDatabase } from "./CloneDatabase.ts";
 import { importD1Database } from "./ImportDatabase.ts";
 
 export const isDatabase = (value: unknown): value is Database =>
-  typeof value === "object" && (value as any)?.Type === "Cloudflare.D1Database";
+  isResourceOfType(value, "Cloudflare.D1Database");
 
 export type Jurisdiction = "default" | "eu" | "fedramp";
 export type PrimaryLocationHint =

--- a/packages/alchemy/src/Cloudflare/Flagship/App.ts
+++ b/packages/alchemy/src/Cloudflare/Flagship/App.ts
@@ -1,10 +1,9 @@
 import * as flagship from "@distilled.cloud/cloudflare/flagship";
 import * as Effect from "effect/Effect";
-import * as Predicate from "effect/Predicate";
 import * as Stream from "effect/Stream";
 import { createPhysicalName } from "../../PhysicalName.ts";
 import * as Provider from "../../Provider.ts";
-import { Resource } from "../../Resource.ts";
+import { isResourceOfType, Resource } from "../../Resource.ts";
 import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
 import type { Providers } from "../Providers.ts";
 
@@ -150,7 +149,7 @@ export const App = Resource<App>(TypeId);
  * Returns true if the given value is a Flagship App resource.
  */
 export const isApp = (value: unknown): value is App =>
-  Predicate.hasProperty(value, "Type") && value.Type === TypeId;
+  isResourceOfType(value, TypeId);
 
 export const AppProvider = () =>
   Provider.succeed(App, {

--- a/packages/alchemy/src/Cloudflare/Hyperdrive/Connection.ts
+++ b/packages/alchemy/src/Cloudflare/Hyperdrive/Connection.ts
@@ -1,6 +1,5 @@
 import * as hyperdrive from "@distilled.cloud/cloudflare/hyperdrive";
 import * as Effect from "effect/Effect";
-import * as Predicate from "effect/Predicate";
 import * as Redacted from "effect/Redacted";
 import * as Stream from "effect/Stream";
 
@@ -8,7 +7,7 @@ import { AlchemyContext } from "../../AlchemyContext.ts";
 import { isResolved } from "../../Diff.ts";
 import { createPhysicalName } from "../../PhysicalName.ts";
 import * as Provider from "../../Provider.ts";
-import { Resource } from "../../Resource.ts";
+import { isResourceOfType, Resource } from "../../Resource.ts";
 import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
 import { generateLocalId, isLiveId } from "../LocalRuntime.ts";
 import type { Providers } from "../Providers.ts";
@@ -160,8 +159,7 @@ export type Connection = Resource<
 export const Connection = Resource<Connection>("Cloudflare.Hyperdrive");
 
 export const isHyperdriveConnection = (value: unknown): value is Connection =>
-  Predicate.hasProperty(value, "Type") &&
-  value.Type === "Cloudflare.Hyperdrive";
+  isResourceOfType(value, "Cloudflare.Hyperdrive");
 
 export const ConnectionProvider = () =>
   Provider.succeed(Connection, {

--- a/packages/alchemy/src/Cloudflare/KV/Namespace.ts
+++ b/packages/alchemy/src/Cloudflare/KV/Namespace.ts
@@ -5,13 +5,12 @@ import * as Stream from "effect/Stream";
 import { isResolved } from "../../Diff.ts";
 import { createPhysicalName } from "../../PhysicalName.ts";
 import * as Provider from "../../Provider.ts";
-import { Resource } from "../../Resource.ts";
+import { isResourceOfType, Resource } from "../../Resource.ts";
 import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
 import type { Providers } from "../Providers.ts";
 
 export const isNamespace = (value: unknown): value is Namespace =>
-  typeof value === "object" &&
-  (value as any)?.Type === "Cloudflare.KV.Namespace";
+  isResourceOfType(value, "Cloudflare.KV.Namespace");
 
 export type NamespaceProps = {
   /**

--- a/packages/alchemy/src/Cloudflare/Queues/Queue.ts
+++ b/packages/alchemy/src/Cloudflare/Queues/Queue.ts
@@ -9,7 +9,7 @@ import * as ProviderLayer from "../../Local/ProviderLayer.ts";
 import * as RpcProvider from "../../Local/RpcProvider.ts";
 import { createPhysicalName } from "../../PhysicalName.ts";
 import * as Provider from "../../Provider.ts";
-import { Resource } from "../../Resource.ts";
+import { isResourceOfType, Resource } from "../../Resource.ts";
 import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
 import {
   generateLocalId,
@@ -20,8 +20,7 @@ import {
 import type { Providers } from "../Providers.ts";
 
 export const isQueue = (value: unknown): value is Queue =>
-  typeof value === "object" &&
-  (value as any)?.Type === "Cloudflare.Queues.Queue";
+  isResourceOfType(value, "Cloudflare.Queues.Queue");
 
 export type QueueProps = {
   /**

--- a/packages/alchemy/src/Cloudflare/R2/Bucket.ts
+++ b/packages/alchemy/src/Cloudflare/R2/Bucket.ts
@@ -6,13 +6,13 @@ import * as Stream from "effect/Stream";
 import { deepEqual, isResolved } from "../../Diff.ts";
 import { createPhysicalName } from "../../PhysicalName.ts";
 import * as Provider from "../../Provider.ts";
-import { Resource } from "../../Resource.ts";
+import { isResourceOfType, Resource } from "../../Resource.ts";
 import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
 import type * as Cloudflare from "../Providers.ts";
 import * as Zone from "../Zone/index.ts";
 
 export const isBucket = (value: any): value is Bucket =>
-  typeof value === "object" && (value as any)?.Type === "Cloudflare.R2.Bucket";
+  isResourceOfType(value, "Cloudflare.R2.Bucket");
 
 export type BucketName = string;
 

--- a/packages/alchemy/src/Cloudflare/SecretsStore/Secret.ts
+++ b/packages/alchemy/src/Cloudflare/SecretsStore/Secret.ts
@@ -8,7 +8,7 @@ import * as Stream from "effect/Stream";
 import { Unowned } from "../../AdoptPolicy.ts";
 import { isResolved } from "../../Diff.ts";
 import * as Provider from "../../Provider.ts";
-import { Resource } from "../../Resource.ts";
+import { isResourceOfType, Resource } from "../../Resource.ts";
 import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
 import type { Providers } from "../Providers.ts";
 
@@ -57,8 +57,7 @@ export type Secret = Resource<
 >;
 
 export const isSecret = (value: unknown): value is Secret =>
-  typeof value === "object" &&
-  (value as any)?.Type === "Cloudflare.SecretsStore.Secret";
+  isResourceOfType(value, "Cloudflare.SecretsStore.Secret");
 
 export type SecretStatus = "pending" | "active" | "deleted";
 

--- a/packages/alchemy/src/Cloudflare/Vectorize/VectorizeIndex.ts
+++ b/packages/alchemy/src/Cloudflare/Vectorize/VectorizeIndex.ts
@@ -1,12 +1,11 @@
 import * as vectorize from "@distilled.cloud/cloudflare/vectorize";
 import * as Effect from "effect/Effect";
-import * as Predicate from "effect/Predicate";
 import * as Stream from "effect/Stream";
 
 import { isResolved } from "../../Diff.ts";
 import { createPhysicalName } from "../../PhysicalName.ts";
 import * as Provider from "../../Provider.ts";
-import { Resource } from "../../Resource.ts";
+import { isResourceOfType, Resource } from "../../Resource.ts";
 import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
 import type { Providers } from "../Providers.ts";
 
@@ -137,7 +136,7 @@ export const Index = Resource<Index>(TypeId);
  * Returns true if the given value is a Vectorize Index resource.
  */
 export const isIndex = (value: unknown): value is Index =>
-  Predicate.hasProperty(value, "Type") && value.Type === TypeId;
+  isResourceOfType(value, TypeId);
 
 export const IndexProvider = () =>
   Provider.succeed(Index, {

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -19,7 +19,11 @@ import {
   type PlatformProps,
   type PlatformServices,
 } from "../../Platform.ts";
-import { Resource, type ResourceClassLike } from "../../Resource.ts";
+import {
+  isResourceOfType,
+  Resource,
+  type ResourceClassLike,
+} from "../../Resource.ts";
 import type { Rpc } from "../../Rpc.ts";
 import type { RuntimeContext } from "../../RuntimeContext.ts";
 import type { Self } from "../../Self.ts";
@@ -49,10 +53,7 @@ export const WorkerTypeId = "Cloudflare.Worker";
 export type WorkerTypeId = typeof WorkerTypeId;
 
 export const isWorker = <T>(value: T): value is T & Worker =>
-  typeof value === "object" &&
-  value !== null &&
-  "Type" in value &&
-  value.Type === WorkerTypeId;
+  isResourceOfType(value, WorkerTypeId);
 
 export class WorkerEnvironment extends Context.Service<
   WorkerEnvironment,

--- a/packages/alchemy/src/Cloudflare/WorkersForPlatforms/DispatchNamespace.ts
+++ b/packages/alchemy/src/Cloudflare/WorkersForPlatforms/DispatchNamespace.ts
@@ -1,12 +1,11 @@
 import * as wfp from "@distilled.cloud/cloudflare/workers-for-platforms";
 import * as Effect from "effect/Effect";
-import * as Predicate from "effect/Predicate";
 import * as Stream from "effect/Stream";
 
 import { isResolved } from "../../Diff.ts";
 import { createPhysicalName } from "../../PhysicalName.ts";
 import * as Provider from "../../Provider.ts";
-import { Resource } from "../../Resource.ts";
+import { isResourceOfType, Resource } from "../../Resource.ts";
 import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
 import type { Providers } from "../Providers.ts";
 
@@ -152,8 +151,7 @@ export const DispatchNamespace = Resource<DispatchNamespace>(TypeId);
  */
 export const isDispatchNamespace = (
   value: unknown,
-): value is DispatchNamespace =>
-  Predicate.hasProperty(value, "Type") && value.Type === TypeId;
+): value is DispatchNamespace => isResourceOfType(value, TypeId);
 
 export const DispatchNamespaceProvider = () =>
   Provider.succeed(DispatchNamespace, {

--- a/packages/alchemy/src/Output.ts
+++ b/packages/alchemy/src/Output.ts
@@ -23,7 +23,15 @@ export const of = <R extends ResourceLike>(
   : RefExpr<R["Attributes"]> => {
   if (isRef(resource)) {
     const metadata = getRefMetadata(resource);
-    return new RefExpr(metadata.stack, metadata.stage, metadata.id) as any;
+    return new RefExpr(
+      metadata.stack,
+      metadata.stage,
+      metadata.id,
+      // Surface the target's resource type as a statically-known
+      // property so duck-typing classifiers (Worker env bindings)
+      // identify the ref exactly like a locally-declared resource.
+      metadata.type !== undefined ? { Type: metadata.type } : undefined,
+    ) as any;
   }
   return new ResourceExpr(resource) as any;
 };
@@ -377,6 +385,12 @@ export class RefExpr<A> extends BaseExpr<A, never> {
     public readonly stack: string | undefined,
     public readonly stage: string | undefined,
     public readonly resourceId: string,
+    /**
+     * Statically-known properties of the ref's target (currently its
+     * resource `Type`), served as literals by the proxy instead of
+     * `PropExpr`s — mirrors {@link ResourceExpr}'s `stables`.
+     */
+    readonly stables?: Record<string, any>,
   ) {
     super();
     return proxy(this);
@@ -502,7 +516,9 @@ function proxy(self: any): any {
           ? self
           : prop === inspect
             ? target[inspect]
-            : isResourceExpr(self) && self.stables && prop in self.stables
+            : (isResourceExpr(self) || isRefExpr(self)) &&
+                self.stables &&
+                prop in self.stables
               ? self.stables[prop as keyof typeof self.stables]
               : prop in self
                 ? typeof self[prop as keyof typeof self] === "function" &&

--- a/packages/alchemy/src/Ref.ts
+++ b/packages/alchemy/src/Ref.ts
@@ -20,6 +20,14 @@ export interface RefMetadata<R extends ResourceLike> {
   id: R["LogicalId"];
   stack?: string;
   stage?: string;
+  /**
+   * The resource type of the ref's target (e.g.
+   * `"Cloudflare.KV.Namespace"`). Known statically — `MyResource.ref`
+   * carries its own type — so duck-typing classifiers (Worker env
+   * bindings, capability helpers) that read `.Type` can identify a ref
+   * exactly like a locally-declared resource.
+   */
+  type?: string;
 }
 
 export const ref = <R extends ResourceLike>(
@@ -31,6 +39,7 @@ export const ref = <R extends ResourceLike>(
     stack?: string;
     stage?: string;
   } = {},
+  type?: string,
 ): Ref<R> => {
   const ref = new Proxy(
     {},
@@ -41,6 +50,7 @@ export const ref = <R extends ResourceLike>(
             stack,
             stage,
             id,
+            type,
           } satisfies RefMetadata<R>;
         }
         return (Output.of(ref) as any)[prop];

--- a/packages/alchemy/src/Resource.ts
+++ b/packages/alchemy/src/Resource.ts
@@ -133,6 +133,28 @@ export const isResource = (value: any): value is ResourceLike => {
   return typeof value === "object" && value !== null && "Type" in value;
 };
 
+/**
+ * Does `value` reference an instance of the resource type `type` —
+ * either a locally-declared resource or a `Resource.ref(...)` to one?
+ *
+ * Two constraints that ad-hoc guards get wrong for refs, which resolve
+ * to Output-expression proxies:
+ *
+ * - Read `.Type` via property access (never `in`): the proxy answers
+ *   property reads with statically-known values but deliberately does
+ *   not report key existence (so {@link isResource} keeps routing refs
+ *   through Output resolution instead of the upstream-node lookup).
+ * - Accept `typeof value === "function"`: the proxy's target is
+ *   callable (it needs an `apply` trap), so refs are not `"object"`.
+ *
+ * Either mistake silently rejects refs — in a Worker `env` that
+ * degrades the binding to a plain JSON var.
+ */
+export const isResourceOfType = (value: unknown, type: string): boolean =>
+  (typeof value === "object" || typeof value === "function") &&
+  value !== null &&
+  (value as { Type?: unknown }).Type === type;
+
 export type Resource<
   Type extends string = any,
   Props extends object | undefined = any,
@@ -312,7 +334,7 @@ export function Resource<R extends ResourceLike>(
       id: string,
       options?: { stage?: string; stack?: string },
     ): Effect.Effect<R> =>
-      Effect.succeed(Output.of(makeRef<R>(id, options)) as unknown as R),
+      Effect.succeed(Output.of(makeRef<R>(id, options, type)) as unknown as R),
 
     Type: type,
     Provider: ProviderTag,

--- a/packages/alchemy/test/Cloudflare/Workers/RefEnvBinding.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/RefEnvBinding.test.ts
@@ -1,0 +1,102 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import { isHyperdriveConnection } from "@/Cloudflare/Hyperdrive/Connection.ts";
+import { isNamespace } from "@/Cloudflare/KV/Namespace.ts";
+import { isIndex } from "@/Cloudflare/Vectorize/VectorizeIndex.ts";
+import * as Output from "@/Output.ts";
+import { isResource } from "@/Resource.ts";
+import * as Test from "@/Test/Vitest";
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import { expectUrlContains } from "../Utils/Http.ts";
+
+const { test } = Test.make({ providers: Cloudflare.providers() });
+
+/**
+ * `Resource.ref(...)` values must classify exactly like locally-declared
+ * resources wherever code duck-types on `.Type` — most importantly the
+ * Worker `env` binding classifiers. A ref used to answer `.Type` with an
+ * Output expression, so the guard failed and the ref silently degraded
+ * to a plain JSON env var instead of the native binding.
+ */
+describe("ref classification", () => {
+  it("a ref answers .Type with the target's literal resource type", () => {
+    const ref = Effect.runSync(Cloudflare.KV.Namespace.ref("SomeNamespace"));
+    expect(ref.Type).toBe("Cloudflare.KV.Namespace");
+    expect(isNamespace(ref)).toBe(true);
+  });
+
+  it("previously `in`-based guards accept refs too", () => {
+    expect(
+      isHyperdriveConnection(
+        Effect.runSync(Cloudflare.Hyperdrive.Connection.ref("SomeConnection")),
+      ),
+    ).toBe(true);
+    expect(
+      isIndex(Effect.runSync(Cloudflare.Vectorize.Index.ref("SomeIndex"))),
+    ).toBe(true);
+  });
+
+  it("guards still reject refs to other resource types", () => {
+    const ref = Effect.runSync(Cloudflare.Hyperdrive.Connection.ref("Conn"));
+    expect(isNamespace(ref)).toBe(false);
+  });
+
+  it("a ref still routes through Output resolution, not upstream lookup", () => {
+    const ref = Effect.runSync(Cloudflare.KV.Namespace.ref("SomeNamespace"));
+    // `isResource` uses `"Type" in value`, which must stay false for
+    // refs — otherwise `evaluate` would treat them as locally-declared
+    // resources and fail with MissingSourceError.
+    expect(isResource(ref)).toBe(false);
+    // Attributes are still deploy-time Outputs, not literals.
+    expect(Output.isOutput(ref.namespaceId)).toBe(true);
+  });
+});
+
+const script = `export default {
+  async fetch(request, env) {
+    await env.KV.put("ref-binding-key", "bound-through-ref");
+    const value = await env.KV.get("ref-binding-key");
+    return new Response(value ?? "missing");
+  },
+};`;
+
+test.provider(
+  "a KV namespace ref in worker env produces a working native binding",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      // Phase 1: the target must already be in state for the ref to
+      // resolve (a ghost ref fails the plan).
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.KV.Namespace("RefNamespace");
+        }),
+      );
+
+      // Phase 2: bind the namespace via `Namespace.ref(...)`. If the
+      // ref misclassifies, no kv_namespace binding is emitted, the
+      // worker still deploys, and `env.KV.put` throws at runtime — so
+      // a live KV roundtrip is the airtight assertion.
+      const deployed = yield* stack.deploy(
+        Effect.gen(function* () {
+          const namespace = yield* Cloudflare.KV.Namespace("RefNamespace");
+          const worker = yield* Cloudflare.Worker("ref-binding-worker", {
+            script,
+            subdomain: { enabled: true },
+            env: {
+              KV: yield* Cloudflare.KV.Namespace.ref("RefNamespace"),
+            },
+          });
+          return { namespace, worker };
+        }),
+      );
+
+      yield* expectUrlContains(deployed.worker.url!, "bound-through-ref", {
+        label: "ref-bound KV worker",
+      });
+
+      yield* stack.destroy();
+    }),
+  { timeout: 240_000 },
+);


### PR DESCRIPTION
A `Resource.ref(...)` passed as a Worker `env` binding silently degraded to a plain JSON env var — the worker deployed "successfully" with a broken binding (`env.KV.put is not a function` at runtime). A ref resolves to an Output-expression proxy that every env classifier rejected, three different ways:

- guards reading `.Type` got a `PropExpr` instead of the literal type string
- guards using `"Type" in value` / `Predicate.hasProperty` got `false` (the proxy doesn't report key existence)
- all guards gated on `typeof value === "object"`, but the proxy target is callable so refs are `"function"`

The fix makes refs classify exactly like locally-declared resources:

- Ref metadata carries the target's resource type (`MyResource.ref` knows its own `Type`), surfaced through `RefExpr` via the same `stables` mechanism `ResourceExpr` already uses. `ref.Type` answers the literal while `"Type" in ref` deliberately stays `false`, so `isResource` keeps routing refs through Output resolution instead of the upstream-node lookup.

```ts
// Output.of(ref)
return new RefExpr(metadata.stack, metadata.stage, metadata.id,
  metadata.type !== undefined ? { Type: metadata.type } : undefined);
```

- A shared guard encodes both constraints, and all thirteen resource-backed env classifiers (KV, R2, D1, Queue, Secret, AI Gateway, Search instance/namespace, Flagship, Vectorize, Hyperdrive, DispatchNamespace, Worker) now use it:

```ts
export const isResourceOfType = (value: unknown, type: string): boolean =>
  (typeof value === "object" || typeof value === "function") &&
  value !== null &&
  (value as { Type?: unknown }).Type === type;
```

Tests (`test/Cloudflare/Workers/RefEnvBinding.test.ts`): hermetic classification units (get-path guards, previously-`in`-path guards, cross-type rejection, and the `isResource(ref) === false` invariant), plus a live `test.provider` deploy that binds a KV namespace via `Namespace.ref(...)` and proves the native binding with a runtime KV roundtrip through the worker.
