### PR TITLE
chore: give claude workflow AWS OIDC + Cloudflare credentials

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -52,4 +52,4 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
             --model claude-fable-5
-            --allowedTools "Bash(aws:*)"
+            --allowedTools "Bash(aws:*),WebFetch,WebSearch"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,8 +30,26 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Configure AWS credentials
+        id: aws
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+          output-credentials: true
+
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
+        env:
+          AWS_ACCESS_KEY_ID: ${{ steps.aws.outputs.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.aws.outputs.aws-secret-access-key }}
+          AWS_SESSION_TOKEN: ${{ steps.aws.outputs.aws-session-token }}
+          AWS_REGION: us-east-1
+          AWS_DEFAULT_REGION: us-east-1
+          CLOUDFLARE_API_TOKEN: ${{ secrets.TEST_CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.TEST_CLOUDFLARE_ACCOUNT_ID }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: "--model claude-fable-5"
+          claude_args: |
+            --model claude-fable-5
+            --allowedTools "Bash(aws:*)"


### PR DESCRIPTION
Give the `@claude` workflow AWS and Cloudflare access so Claude can run `aws` commands and drive the Cloudflare API from CI.

```yaml
- name: Configure AWS credentials
  id: aws
  uses: aws-actions/configure-aws-credentials@v6
  with:
    role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
    aws-region: us-east-1
    output-credentials: true

- name: Run Claude Code
  uses: anthropics/claude-code-action@v1
  env:
    AWS_ACCESS_KEY_ID: ${{ steps.aws.outputs.aws-access-key-id }}
    AWS_SECRET_ACCESS_KEY: ${{ steps.aws.outputs.aws-secret-access-key }}
    AWS_SESSION_TOKEN: ${{ steps.aws.outputs.aws-session-token }}
    CLOUDFLARE_API_TOKEN: ${{ secrets.TEST_CLOUDFLARE_API_TOKEN }}
    CLOUDFLARE_ACCOUNT_ID: ${{ secrets.TEST_CLOUDFLARE_ACCOUNT_ID }}
```

- AWS credentials come from assuming `AWS_ROLE_ARN` over OIDC (the job already had `id-token: write`)
- `--allowedTools "Bash(aws:*),WebFetch,WebSearch"` added to `claude_args` so Claude may invoke the AWS CLI and fetch/search the web
- `TEST_CLOUDFLARE_*` secrets were re-synced from Doppler `alchemy-v2` (dev); note `website.yml` also reads `TEST_CLOUDFLARE_API_TOKEN` for non-prod deploys
- Requires the `AWS_ROLE_ARN` repo secret plus an IAM role trusting GitHub's OIDC provider for `repo:alchemy-run/alchemy-effect:*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
