### PR TITLE
feat(cloudflare/workers): add cache config for Workers Cache

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -108,6 +108,11 @@ export type WorkerPlacement = Exclude<
   undefined
 >;
 
+export type WorkerCache = Exclude<
+  workers.PutScriptRequest["metadata"]["cache"],
+  undefined
+>;
+
 export const ExportedHandlerMethods = [
   "fetch",
   "tail",
@@ -246,6 +251,18 @@ export interface WorkerProps<
   };
   limits?: WorkerLimits;
   placement?: WorkerPlacement;
+  /**
+   * Cloudflare Workers Cache settings. Runs the Worker behind a regional
+   * tiered cache so cacheable responses are served without invoking the
+   * Worker. `enabled` turns the feature on; `crossVersionCache` keeps cache
+   * entries valid across Worker versions.
+   *
+   * Requires responses to set `Cache-Control` (and optionally `Cache-Tag`)
+   * headers to be cacheable. Off unless set.
+   *
+   * @see https://developers.cloudflare.com/workers/cache/
+   */
+  cache?: WorkerCache;
   /**
    * Tracks Durable Object and Workflow exports for Effect-native Workers only.
    * Populated automatically from bindings; do not set manually.

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -1099,6 +1099,7 @@ export const LiveWorkerProvider = () =>
             },
           },
           placement: news.placement,
+          cache: news.cache,
           tags: metadataTags,
           tailConsumers: undefined,
           usageModel: undefined,

--- a/packages/alchemy/test/Cloudflare/Workers/Cache.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/Cache.test.ts
@@ -1,0 +1,69 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
+import * as Test from "@/Test/Vitest";
+import { describe, expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+import * as pathe from "pathe";
+import {
+  expectWorkerExists,
+  findWorker,
+  waitForWorkerToBeDeleted,
+} from "../Utils/Worker.ts";
+
+const { test } = Test.make({ providers: Cloudflare.providers() });
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+const main = pathe.resolve(import.meta.dirname, "fixtures/worker.ts");
+
+// Workers Cache (https://developers.cloudflare.com/workers/cache/) is set
+// through the script-upload metadata (`cache: { enabled, cross_version_cache }`).
+// The settings API has no typed read-back for it, so this suite asserts the
+// full deploy -> update -> destroy lifecycle is accepted by Cloudflare with the
+// cache metadata present on the upload.
+describe.concurrent("Cloudflare.Worker cache", () => {
+  test.provider(
+    "deploys a worker with cache enabled",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+
+        yield* stack.destroy();
+
+        const worker = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.Worker("CacheWorker", {
+              main,
+              compatibility: { date: "2024-01-01" },
+              cache: { enabled: true, crossVersionCache: true },
+            });
+          }),
+        );
+
+        const deployed = yield* findWorker(worker.workerName, accountId);
+        expect(deployed?.scriptName).toEqual(worker.workerName);
+        yield* expectWorkerExists(worker.workerName, accountId);
+
+        // Update path: toggling a cache field re-puts the metadata and must
+        // still be accepted.
+        yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.Worker("CacheWorker", {
+              main,
+              compatibility: { date: "2024-01-01" },
+              cache: { enabled: true, crossVersionCache: false },
+            });
+          }),
+        );
+        yield* expectWorkerExists(worker.workerName, accountId);
+
+        yield* stack.destroy();
+        yield* waitForWorkerToBeDeleted(worker.workerName, accountId);
+      }).pipe(logLevel),
+    { timeout: 120_000 },
+  );
+});


### PR DESCRIPTION
Expose Cloudflare [Workers Cache](https://developers.cloudflare.com/workers/cache/) (announced 2026-07-03) on the `Worker` resource. The setting rides in the script-upload metadata as `cache: { enabled, cross_version_cache }`.

```ts
Cloudflare.Worker("api", {
  main,
  cache: { enabled: true, crossVersionCache: true },
});
```

`cache` is typed off `workers.PutScriptRequest["metadata"]["cache"]` (same pattern as `placement`/`limits`/`observability`) and threaded into the deploy metadata PUT.

### Depends on

The metadata field must be typed in distilled first: alchemy-run/distilled#366. Draft until that merges and the `distilled` submodule is bumped to include it (this branch omits the submodule bump). Verified locally against a real account with the submodule pointed at the distilled branch — `test/Cloudflare/Workers/Cache.test.ts` deploys, updates, and destroys a worker with cache enabled.
