### PR TITLE
fix(cloudflare/state): bind cached state-store credentials to the account

### DIFF
--- a/packages/alchemy/src/AWS/AuthProvider.ts
+++ b/packages/alchemy/src/AWS/AuthProvider.ts
@@ -393,9 +393,6 @@ export const AwsAuth = AuthProviderLayer<
             );
           }),
         ),
-        Effect.catch((e) =>
-          Console.error(`  Failed to retrieve credentials: ${e}`),
-        ),
       );
 
     const logout = (profileName: string, config: AwsAuthConfig) =>

--- a/packages/alchemy/src/Axiom/AuthProvider.ts
+++ b/packages/alchemy/src/Axiom/AuthProvider.ts
@@ -328,9 +328,6 @@ export const AxiomAuth = AuthProviderLayer<
             Match.exhaustive,
           );
         }),
-        Effect.catch((e) =>
-          Console.error(`  Failed to retrieve credentials: ${e}`),
-        ),
       );
 
     return {

--- a/packages/alchemy/src/Cli/commands/_shared.ts
+++ b/packages/alchemy/src/Cli/commands/_shared.ts
@@ -1,8 +1,10 @@
 import * as Cause from "effect/Cause";
 import * as Config from "effect/Config";
+import * as ConfigProvider from "effect/ConfigProvider";
 import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Logger from "effect/Logger";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 import * as S from "effect/Schema";
@@ -16,10 +18,16 @@ import {
   AuthError,
   AuthProviders,
 } from "../../Auth/AuthProvider.ts";
-import type { AlchemyProfileProviders } from "../../Auth/Profile.ts";
-import type * as Stack from "../../Stack.ts";
+import {
+  type AlchemyProfileProviders,
+  withProfileOverride,
+} from "../../Auth/Profile.ts";
+import * as Stack from "../../Stack.ts";
+import { Stage } from "../../Stage.ts";
 import { recordCli } from "../../Telemetry/Metrics.ts";
 import { PromptCancelled } from "../../Util/Clank.ts";
+import { loadConfigProvider } from "../../Util/ConfigProvider.ts";
+import { fileLogger } from "../../Util/FileLogger.ts";
 
 export const USER = Config.string("USER").pipe(
   Config.orElse(() => Config.string("USERNAME")),
@@ -296,7 +304,19 @@ export const printProfile = Effect.fn(function* (
       }
       continue;
     }
-    yield* provider.prettyPrint(profile, cfg);
+    // A provider's `prettyPrint` catches its own credential-resolution
+    // failures, but some resolve paths `Effect.orDie` (e.g. AWS SSO with an
+    // expired token), which escapes as a defect. Contain it here — via
+    // `Console.log` so the message stays on stdout under this provider's
+    // header instead of interleaving on stderr — so one broken provider
+    // can't abort rendering the rest of the profile.
+    yield* provider.prettyPrint(profile, cfg).pipe(
+      Effect.catchCause((cause) => {
+        const error = Cause.squash(cause);
+        const message = error instanceof Error ? error.message : String(error);
+        return Console.log(`  Failed to retrieve credentials: ${message}`);
+      }),
+    );
   }
 });
 
@@ -325,4 +345,85 @@ export const importStack = Effect.fn(function* (main: string) {
     providers: Layer.Layer<never>;
     state: Layer.Layer<never>;
   };
+});
+
+/**
+ * Placeholder {@link Stack.Stack} value used while building a stack's
+ * `providers()` layer out of band. No real resources exist yet — we only
+ * want the layer's provider/auth registrations and cloud-environment
+ * services, so `resources`/`bindings`/`actions` are empty and the stage is a
+ * sentinel.
+ */
+const placeholderStack = (name: string) => ({
+  actions: {},
+  bindings: {},
+  name,
+  resources: {},
+  stage: "placeholder",
+});
+
+export interface BuildStackProvidersOptions {
+  /** Stack entrypoint to import (e.g. `"alchemy.run.ts"`). */
+  main: string;
+  envFile: Option.Option<string>;
+  profile: string;
+  /**
+   * Registry to populate. Pass a pre-seeded registry (e.g. one that already
+   * has built-in providers) to layer the stack's providers on top of it,
+   * overriding by name. Defaults to a fresh empty registry.
+   */
+  registry?: AuthProviders["Service"];
+  /**
+   * Logger layer used during the build. Defaults to the file logger
+   * (`out`). `alchemy unsafe nuke` overrides this to log to the console in
+   * debug mode.
+   */
+  logger?: Layer.Layer<never, never, never>;
+  /**
+   * Extra layer merged into the placeholder scaffold — e.g.
+   * `Layer.succeed(MinimumLogLevel, ...)`, which sets a fiber-ref default
+   * and so contributes no context service (`Layer<never>`).
+   */
+  extra?: Layer.Layer<never, never, never>;
+}
+
+/**
+ * Import a stack entrypoint and build its `providers()` (+ `state()`) layer
+ * out of band against placeholder {@link Stack.Stack}/{@link Stage} services,
+ * so its `AuthProviderLayer` registrations land in an {@link AuthProviders}
+ * registry and the built context holds every resource provider plus the
+ * cloud-environment services their operations need.
+ *
+ * Shared by `alchemy login`, `alchemy profile show`, and `alchemy unsafe
+ * nuke`. The caller decides what to do with the result — use `authProviders`
+ * (login / profile show) or `context` (nuke) — and whether a missing/invalid
+ * entrypoint is fatal (login / nuke let it propagate) or best-effort
+ * (profile show wraps the call in `Effect.catchCause`).
+ */
+export const buildStackProviders = Effect.fn("buildStackProviders")(function* (
+  options: BuildStackProvidersOptions,
+) {
+  const authProviders = options.registry ?? {};
+  const stackEffect = yield* importStack(options.main);
+  const configProvider = withProfileOverride(
+    yield* loadConfigProvider(options.envFile),
+    options.profile,
+  );
+  const context = yield* Layer.build(
+    (stackEffect.providers ?? Layer.empty).pipe(
+      Layer.provideMerge(stackEffect.state ?? Layer.empty),
+      Layer.provideMerge(
+        Layer.mergeAll(
+          Layer.succeed(AuthProviders, authProviders),
+          ConfigProvider.layer(configProvider),
+          options.logger ??
+            Logger.layer([fileLogger("out")], { mergeWithExisting: true }),
+          Layer.succeed(Stage, "placeholder"),
+          Layer.succeed(Stack.Stack, placeholderStack(stackEffect.stackName)),
+          options.extra ?? Layer.empty,
+        ),
+      ),
+    ),
+  );
+  return { authProviders, context, stackEffect };
 });

--- a/packages/alchemy/src/Cli/commands/login.ts
+++ b/packages/alchemy/src/Cli/commands/login.ts
@@ -1,21 +1,13 @@
 import * as Config from "effect/Config";
-import * as ConfigProvider from "effect/ConfigProvider";
 import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as Logger from "effect/Logger";
 import { Command, Flag } from "effect/unstable/cli";
 
-import { AuthProviders } from "../../Auth/AuthProvider.ts";
-import { AlchemyProfile, withProfileOverride } from "../../Auth/Profile.ts";
-import { Stage } from "../../Stage.ts";
-import { loadConfigProvider } from "../../Util/ConfigProvider.ts";
-import { fileLogger } from "../../Util/FileLogger.ts";
+import { AlchemyProfile } from "../../Auth/Profile.ts";
 
-import { Stack } from "../../Stack.ts";
 import {
+  buildStackProviders,
   envFile,
-  importStack,
   instrumentCommand,
   printProfile,
   profile,
@@ -46,36 +38,13 @@ export const loginCommand = Command.make(
     }),
   )(
     Effect.fn(function* ({ main, envFile, profile, configure }) {
-      const stackEffect = yield* importStack(main);
-
-      const authProviders: AuthProviders["Service"] = {};
-
-      // build the state + providers layer to capture the Auth Providers
-      yield* Layer.build(
-        (stackEffect.providers ?? Layer.empty).pipe(
-          Layer.provideMerge(stackEffect.state ?? Layer.empty),
-          Layer.provideMerge(
-            Layer.mergeAll(
-              Layer.succeed(AuthProviders, authProviders),
-              ConfigProvider.layer(
-                withProfileOverride(
-                  yield* loadConfigProvider(envFile),
-                  profile,
-                ),
-              ),
-              Logger.layer([fileLogger("out")], { mergeWithExisting: true }),
-              Layer.succeed(Stage, "placeholder"),
-              Layer.succeed(Stack, {
-                actions: {},
-                bindings: {},
-                name: stackEffect.stackName,
-                resources: {},
-                stage: "placeholder",
-              }),
-            ),
-          ),
-        ),
-      );
+      // Build the user's providers() (+ state) layer to capture the auth
+      // providers their stack wires up.
+      const { authProviders } = yield* buildStackProviders({
+        main,
+        envFile,
+        profile,
+      });
 
       const profiles = yield* AlchemyProfile;
 

--- a/packages/alchemy/src/Cli/commands/nuke.ts
+++ b/packages/alchemy/src/Cli/commands/nuke.ts
@@ -1,4 +1,3 @@
-import * as ConfigProvider from "effect/ConfigProvider";
 import * as Console from "effect/Console";
 import type * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
@@ -8,22 +7,16 @@ import { MinimumLogLevel } from "effect/References";
 import { Command, Flag } from "effect/unstable/cli";
 import picomatch from "picomatch";
 
-import { AuthProviders } from "../../Auth/AuthProvider.ts";
-import { withProfileOverride } from "../../Auth/Profile.ts";
 import type { ProviderService } from "../../Provider.ts";
-import { Stack } from "../../Stack.ts";
-import { Stage } from "../../Stage.ts";
 import * as Clank from "../../Util/Clank.ts";
-import { loadConfigProvider } from "../../Util/ConfigProvider.ts";
-import { fileLogger } from "../../Util/FileLogger.ts";
 import type { ScopedPlanStatusSession } from "../Cli.ts";
 import { isNonInteractive } from "../selectCli.ts";
 import * as NukeUI from "../tui/components/Nuke.tsx";
 
 import {
+  buildStackProviders,
   dryRun,
   envFile,
-  importStack,
   instrumentCommand,
   profile,
   script,
@@ -311,42 +304,18 @@ const nukeCommand = Command.make(
       // log stream isn't clobbered by the progress renderer.
       const debug = !!process.env.DEBUG;
       const interactive = !isNonInteractive() && !debug;
-      const stackEffect = yield* importStack(main);
-      const authProviders: AuthProviders["Service"] = {};
 
-      // Build the state + providers layer (same wiring as `alchemy login`) so
-      // that the resulting context holds every resource provider plus the
-      // cloud-environment services their `list`/`delete` need at call time.
-      const context = yield* Layer.build(
-        (stackEffect.providers ?? Layer.empty).pipe(
-          Layer.provideMerge(stackEffect.state ?? Layer.empty),
-          Layer.provideMerge(
-            Layer.mergeAll(
-              Layer.succeed(AuthProviders, authProviders),
-              ConfigProvider.layer(
-                withProfileOverride(
-                  yield* loadConfigProvider(envFile),
-                  profile,
-                ),
-              ),
-              debug
-                ? Logger.layer([Logger.defaultLogger])
-                : Logger.layer([fileLogger("out")], {
-                    mergeWithExisting: true,
-                  }),
-              Layer.succeed(MinimumLogLevel, debug ? "Debug" : "Info"),
-              Layer.succeed(Stage, "placeholder"),
-              Layer.succeed(Stack, {
-                actions: {},
-                bindings: {},
-                name: stackEffect.stackName,
-                resources: {},
-                stage: "placeholder",
-              }),
-            ),
-          ),
-        ),
-      );
+      // Build the user's providers() (+ state) layer so the resulting context
+      // holds every resource provider plus the cloud-environment services
+      // their `list`/`delete` need at call time. DEBUG=1 routes provider logs
+      // to the console at Debug level instead of the .alchemy/log/out file.
+      const { context } = yield* buildStackProviders({
+        main,
+        envFile,
+        profile,
+        logger: debug ? Logger.layer([Logger.defaultLogger]) : undefined,
+        extra: Layer.succeed(MinimumLogLevel, debug ? "Debug" : "Info"),
+      });
 
       const discovered = discoverProviders(context as Context.Context<never>);
 

--- a/packages/alchemy/src/Cli/commands/profile.ts
+++ b/packages/alchemy/src/Cli/commands/profile.ts
@@ -3,7 +3,9 @@ import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Logger from "effect/Logger";
+import * as Option from "effect/Option";
 import { Command } from "effect/unstable/cli";
+import * as Argument from "effect/unstable/cli/Argument";
 
 import { AuthProviders } from "../../Auth/AuthProvider.ts";
 import { CredentialsStore } from "../../Auth/Credentials.ts";
@@ -18,19 +20,98 @@ import { loadConfigProvider } from "../../Util/ConfigProvider.ts";
 import { fileLogger } from "../../Util/FileLogger.ts";
 
 import {
+  buildStackProviders,
   envFile,
   instrumentCommand,
   printProfile,
   profile,
 } from "./_shared.ts";
 
+/**
+ * The auth providers Alchemy ships with. Built into the registry as a
+ * baseline so `profile show` can pretty-print any provider a profile
+ * mentions, even one the current stack doesn't wire up.
+ */
+const builtinAuth = Layer.mergeAll(
+  AwsAuth,
+  AxiomAuth,
+  CloudflareAuth,
+  GitHubAuth,
+  NeonAuth,
+  PlanetscaleAuth,
+);
+
+/**
+ * Entrypoint whose `providers()` layer contributes the user's own auth
+ * providers. Optional and best-effort — if it's missing or fails to load,
+ * `profile show` still renders the built-in providers.
+ */
+const mainFile = Argument.file("main").pipe(
+  Argument.withDescription(
+    "Stack entrypoint whose providers() should be used, defaults to alchemy.run.ts",
+  ),
+  Argument.withDefault("alchemy.run.ts"),
+);
+
+/**
+ * Populate an {@link AuthProviders} registry for display: the built-in
+ * providers first, then the user's stack `providers()` layer on top so a
+ * customized provider (same name) overrides the built-in one. Loading the
+ * user's stack is best-effort — a missing or invalid entrypoint leaves the
+ * built-ins in place.
+ *
+ * Registration happens as a side effect of building each layer (see
+ * `AuthProviderLayer`), and later builds overwrite earlier entries by name,
+ * so build order is what gives the user's providers precedence.
+ */
+export const collectAuthProviders = Effect.fn("collectAuthProviders")(
+  function* (options: {
+    main: string;
+    envFile: Option.Option<string>;
+    profile: string;
+  }) {
+    const authProviders: AuthProviders["Service"] = {};
+
+    // 1. Built-in providers first (baseline).
+    yield* Layer.build(
+      Layer.provide(
+        builtinAuth,
+        Layer.mergeAll(
+          Layer.succeed(AuthProviders, authProviders),
+          ConfigProvider.layer(
+            withProfileOverride(
+              yield* loadConfigProvider(options.envFile),
+              options.profile,
+            ),
+          ),
+          Logger.layer([fileLogger("out")], { mergeWithExisting: true }),
+        ),
+      ),
+    );
+
+    // 2. The user's own providers() layer on top — building into the same
+    //    registry overrides the built-ins by name. Best-effort: swallow
+    //    load/build failures (including a missing entrypoint) so display
+    //    still works with just the built-ins.
+    yield* buildStackProviders({ ...options, registry: authProviders }).pipe(
+      Effect.catchCause((cause) =>
+        Effect.logDebug("profile show: could not load user stack providers", {
+          cause,
+        }),
+      ),
+    );
+
+    return authProviders;
+  },
+);
+
 const showCommand = Command.make(
   "show",
-  { profile, envFile },
+  { profile, envFile, main: mainFile },
   instrumentCommand("profile.show", (a: { profile: string }) => ({
     "alchemy.profile": a.profile,
   }))(
-    Effect.fn(function* ({ profile, envFile }) {
+    Effect.fn(function* ({ profile, envFile, main }) {
       const profiles = yield* AlchemyProfile;
       const stored = yield* profiles.getProfile(profile);
       if (stored == null) {
@@ -45,32 +126,13 @@ const showCommand = Command.make(
         return;
       }
 
-      const authProviders: AuthProviders["Service"] = {};
-      const authRegistry = Layer.succeed(AuthProviders, authProviders);
-      const services = Layer.mergeAll(
-        authRegistry,
-        ConfigProvider.layer(
-          withProfileOverride(yield* loadConfigProvider(envFile), profile),
-        ),
-        Logger.layer([fileLogger("out")], { mergeWithExisting: true }),
-        // Building these layers triggers their AuthProviderLayer effect, which
-        // registers the provider into the shared `authProviders` registry.
-        Layer.provide(
-          Layer.mergeAll(
-            AwsAuth,
-            AxiomAuth,
-            CloudflareAuth,
-            GitHubAuth,
-            NeonAuth,
-            PlanetscaleAuth,
-          ),
-          authRegistry,
-        ),
-      );
+      const authProviders = yield* collectAuthProviders({
+        main,
+        envFile,
+        profile,
+      });
 
-      yield* printProfile(profile, stored, authProviders).pipe(
-        Effect.provide(services),
-      );
+      yield* printProfile(profile, stored, authProviders);
     }),
   ),
 );

--- a/packages/alchemy/src/Cloudflare/Auth/AuthProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Auth/AuthProvider.ts
@@ -638,9 +638,6 @@ export const CloudflareAuth = AuthProviderLayer<
             Match.exhaustive,
           );
         }),
-        Effect.catch((e) =>
-          Console.error(`  Failed to retrieve credentials: ${e}`),
-        ),
       );
 
     return {

--- a/packages/alchemy/src/Cloudflare/Auth/AuthProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Auth/AuthProvider.ts
@@ -21,6 +21,7 @@ import {
   retryOnce,
 } from "../../Auth/Env.ts";
 import * as Clank from "../../Util/Clank.ts";
+import { CREDENTIALS_FILE as STATE_STORE_CREDENTIALS_FILE } from "../StateStore/CredentialsFile.ts";
 import * as OAuthClient from "./OAuthClient.ts";
 
 const options: Array<{
@@ -343,10 +344,18 @@ export const CloudflareAuth = AuthProviderLayer<
 
     const configureCredentials = (profileName: string, ctx: ConfigureContext) =>
       Effect.gen(function* () {
-        if (ctx.ci) {
-          return { method: "env" as const };
-        }
-        return yield* configureInteractive(profileName);
+        const config = ctx.ci
+          ? { method: "env" as const }
+          : yield* configureInteractive(profileName);
+        // Re-configuring auth may point this profile at a different
+        // Cloudflare account. The cached state-store credentials
+        // (`~/.alchemy/credentials/{profile}/cloudflare-state-store.json`)
+        // are minted per-account, so drop them here; the next deploy
+        // re-derives them against the freshly-configured account.
+        yield* store
+          .delete(profileName, STATE_STORE_CREDENTIALS_FILE)
+          .pipe(Effect.ignore);
+        return config;
       }).pipe(
         Effect.mapError(
           (e) =>
@@ -491,40 +500,50 @@ export const CloudflareAuth = AuthProviderLayer<
       );
 
     const logout = (profileName: string, config: CloudflareAuthConfig) =>
-      Match.value(config).pipe(
-        Match.when({ method: "env" }, () => Effect.void),
-        Match.when({ method: "stored" }, () =>
-          store
-            .delete(profileName, "cf-stored")
-            .pipe(
-              Effect.andThen(
-                Clank.success("Cloudflare: stored credentials removed"),
+      Match.value(config)
+        .pipe(
+          Match.when({ method: "env" }, () => Effect.void),
+          Match.when({ method: "stored" }, () =>
+            store
+              .delete(profileName, "cf-stored")
+              .pipe(
+                Effect.andThen(
+                  Clank.success("Cloudflare: stored credentials removed"),
+                ),
               ),
-            ),
-        ),
-        Match.when({ method: "oauth" }, () =>
-          store
-            .read<OAuthClient.OAuthCredentials>(profileName, "cf-oauth")
-            .pipe(
-              Effect.tap((creds) =>
-                creds?.type === "oauth"
-                  ? OAuthClient.revoke(creds).pipe(
-                      Effect.catchTag("OAuthError", (err) =>
-                        Clank.warn(
-                          `Cloudflare: could not revoke OAuth token: ${err.errorDescription}`,
+          ),
+          Match.when({ method: "oauth" }, () =>
+            store
+              .read<OAuthClient.OAuthCredentials>(profileName, "cf-oauth")
+              .pipe(
+                Effect.tap((creds) =>
+                  creds?.type === "oauth"
+                    ? OAuthClient.revoke(creds).pipe(
+                        Effect.catchTag("OAuthError", (err) =>
+                          Clank.warn(
+                            `Cloudflare: could not revoke OAuth token: ${err.errorDescription}`,
+                          ),
                         ),
-                      ),
-                    )
-                  : Effect.void,
+                      )
+                    : Effect.void,
+                ),
+                Effect.andThen(store.delete(profileName, "cf-oauth")),
+                Effect.andThen(
+                  Clank.success("Cloudflare: OAuth credentials removed."),
+                ),
               ),
-              Effect.andThen(store.delete(profileName, "cf-oauth")),
-              Effect.andThen(
-                Clank.success("Cloudflare: OAuth credentials removed."),
-              ),
-            ),
-        ),
-        Match.exhaustive,
-      );
+          ),
+          Match.exhaustive,
+        )
+        // The cached state-store credentials are derived from the account we
+        // just logged out of, so drop them regardless of auth method.
+        .pipe(
+          Effect.andThen(
+            store
+              .delete(profileName, STATE_STORE_CREDENTIALS_FILE)
+              .pipe(Effect.ignore),
+          ),
+        );
 
     const login = (profileName: string, config: CloudflareAuthConfig) =>
       Match.value(config)

--- a/packages/alchemy/src/Cloudflare/StateStore/CredentialsFile.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/CredentialsFile.ts
@@ -1,0 +1,48 @@
+import type { HttpStateStoreCredentials } from "../../State/HttpStateStore.ts";
+
+/**
+ * Filename (under `~/.alchemy/credentials/{profile}/`) used to cache the
+ * Cloudflare-deployed HTTP state store's endpoint + bearer token.
+ *
+ * Kept in this leaf module (rather than `StateStore/State.ts`) so the
+ * Cloudflare auth provider can invalidate the cache on
+ * `login --configure` / `logout` without importing the heavy state-store
+ * module and creating an import cycle
+ * (`StateStore/State.ts` -> `Providers.ts` -> `Auth/AuthProvider.ts`).
+ */
+export const CREDENTIALS_FILE = "cloudflare-state-store";
+
+/**
+ * On-disk shape of the cached Cloudflare state-store credentials.
+ *
+ * Extends the generic {@link HttpStateStoreCredentials} (`{ url, authToken }`)
+ * with the `accountId` the credentials were minted against. The `url` already
+ * encodes the account (via the `*.workers.dev` subdomain), so a cache written
+ * while logged into account A keeps pointing at account A's state store even
+ * after the user re-authenticates against account B. Persisting `accountId`
+ * lets `state()` detect that mismatch and re-derive.
+ *
+ * `accountId` is optional so legacy files written before this field existed
+ * still parse — they are treated as stale (see
+ * {@link isStateStoreCredentialsStale}) and re-derived on next use.
+ */
+export interface StoredStateStoreCredentials extends HttpStateStoreCredentials {
+  /** Cloudflare account ID the `url`/`authToken` were minted against. */
+  accountId?: string;
+}
+
+/**
+ * `true` when cached state-store credentials must not be trusted for the
+ * current account:
+ *
+ * - the file predates the `accountId` field (legacy cache — exactly the
+ *   artifact that caused deploys to silently target the wrong account), or
+ * - it was minted against a different account than the one now in use.
+ *
+ * A stale cache is discarded and re-derived from the current account.
+ */
+export const isStateStoreCredentialsStale = (
+  credentials: StoredStateStoreCredentials,
+  currentAccountId: string,
+): boolean =>
+  credentials.accountId == null || credentials.accountId !== currentAccountId;

--- a/packages/alchemy/src/Cloudflare/StateStore/State.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/State.ts
@@ -40,6 +40,11 @@ import * as CloudflareEnvironment from "../CloudflareEnvironment.ts";
 import { EdgeSessionError, createEdgeSession } from "../EdgeSession.ts";
 import Api, { STATE_STORE_SCRIPT_NAME, STATE_STORE_VERSION } from "./Api.ts";
 import {
+  CREDENTIALS_FILE,
+  type StoredStateStoreCredentials,
+  isStateStoreCredentialsStale,
+} from "./CredentialsFile.ts";
+import {
   AuthToken,
   AuthTokenSecretName,
   EncryptionKeySecretName,
@@ -47,9 +52,6 @@ import {
 } from "./Token.ts";
 
 const CI = Config.boolean("CI").pipe(Config.withDefault(false));
-
-/** Filename used for stored credentials under the profile directory. */
-const CREDENTIALS_FILE = "cloudflare-state-store";
 
 export const state = () =>
   Layer.effect(
@@ -173,15 +175,32 @@ export const state = () =>
             return yield* makeCloudflareStateStore(credentials);
           });
 
-        const credentials = yield* credStore.read<HttpStateStoreCredentials>(
+        const { accountId } =
+          yield* yield* CloudflareEnvironment.CloudflareEnvironment;
+
+        const credentials = yield* credStore.read<StoredStateStoreCredentials>(
           profileName,
           CREDENTIALS_FILE,
         );
         if (credentials) {
-          return yield* ensureLatest(credentials);
+          // The cached `url`/`authToken` are minted per-account (the `url`
+          // encodes the account via its workers.dev subdomain). If the
+          // active account changed since they were written — or the file
+          // predates the `accountId` field — trusting the cache would
+          // silently read/write state in the wrong account, so discard it
+          // and fall through to re-derivation from the current account.
+          if (isStateStoreCredentialsStale(credentials, accountId)) {
+            yield* Clank.info(
+              `Cloudflare State Store credentials were minted for a different ` +
+                `Cloudflare account; re-deriving for the current account.`,
+            );
+            yield* credStore
+              .delete(profileName, CREDENTIALS_FILE)
+              .pipe(Effect.ignore);
+          } else {
+            return yield* ensureLatest(credentials);
+          }
         }
-        const { accountId } =
-          yield* yield* CloudflareEnvironment.CloudflareEnvironment;
         if (yield* isStateStoreServing(accountId)) {
           return yield* ensureLatest(
             yield* loginWithCloudflare(profileName, false),
@@ -283,7 +302,7 @@ export const bootstrap = (options: BootstrapOptions = {}) =>
       if (!isCI) {
         // we don't write credentials in CI because the file system is ephemeral
         const store = yield* CredentialsStore;
-        yield* store.write<HttpStateStoreCredentials>(
+        yield* store.write<StoredStateStoreCredentials>(
           profileName,
           CREDENTIALS_FILE,
           credentials,
@@ -703,11 +722,17 @@ export const loginWithCloudflare = (profileName: string, force: boolean) =>
 
     if (!force) {
       // try and read from the cached credentials first if not forcing (force will always refresh)
-      const credentials = yield* credStore.read<HttpStateStoreCredentials>(
+      const credentials = yield* credStore.read<StoredStateStoreCredentials>(
         profileName,
         CREDENTIALS_FILE,
       );
-      if (credentials) {
+      // Ignore a cache minted for a different account (or a legacy file with
+      // no `accountId`) — reusing it would hand back the wrong account's
+      // state-store URL. Fall through to re-derive against `accountId`.
+      if (
+        credentials &&
+        !isStateStoreCredentialsStale(credentials, accountId)
+      ) {
         return credentials;
       }
     }
@@ -751,9 +776,10 @@ export const loginWithCloudflare = (profileName: string, force: boolean) =>
       // 4. Persist credentials. The profile entry is managed by
       //    `loadOrConfigure` when this is invoked through `configure`.
       yield* credStore
-        .write<HttpStateStoreCredentials>(profileName, CREDENTIALS_FILE, {
+        .write<StoredStateStoreCredentials>(profileName, CREDENTIALS_FILE, {
           url,
           authToken: authToken.trim(),
+          accountId,
         })
         .pipe(
           Effect.mapError(
@@ -774,6 +800,7 @@ export const loginWithCloudflare = (profileName: string, force: boolean) =>
     return {
       url,
       authToken: authToken.trim(),
+      accountId,
     };
   }).pipe(
     Effect.catchTag("EdgeSessionError", (e) =>
@@ -1022,12 +1049,15 @@ const writeCredentials = (url: string, authToken: string) =>
   Effect.gen(function* () {
     const profileName = yield* ALCHEMY_PROFILE;
     const credStore = yield* CredentialsStore;
-    yield* credStore.write<HttpStateStoreCredentials>(
+    const { accountId } =
+      yield* yield* CloudflareEnvironment.CloudflareEnvironment;
+    yield* credStore.write<StoredStateStoreCredentials>(
       profileName,
       CREDENTIALS_FILE,
       {
         url,
         authToken,
+        accountId,
       },
     );
   });

--- a/packages/alchemy/src/GitHub/AuthProvider.ts
+++ b/packages/alchemy/src/GitHub/AuthProvider.ts
@@ -297,9 +297,6 @@ export const GitHubAuth = AuthProviderLayer<
             Console.log(`  source: ${sourceStr}`),
           ]);
         }),
-        Effect.catch((e) =>
-          Console.error(`  Failed to retrieve credentials: ${e}`),
-        ),
       );
 
     return {

--- a/packages/alchemy/src/Neon/AuthProvider.ts
+++ b/packages/alchemy/src/Neon/AuthProvider.ts
@@ -207,9 +207,6 @@ export const NeonAuth = AuthProviderLayer<
             Console.log(`  source: ${sourceStr}`),
           ]);
         }),
-        Effect.catch((e) =>
-          Console.error(`  Failed to retrieve credentials: ${e}`),
-        ),
       );
 
     return {

--- a/packages/alchemy/src/Planetscale/AuthProvider.ts
+++ b/packages/alchemy/src/Planetscale/AuthProvider.ts
@@ -269,9 +269,6 @@ export const PlanetscaleAuth = AuthProviderLayer<
             Console.log(`  source: ${sourceStr}`),
           ]);
         }),
-        Effect.catch((e) =>
-          Console.error(`  Failed to retrieve credentials: ${e}`),
-        ),
       );
 
     return {

--- a/packages/alchemy/test/Cloudflare/StateStore/CredentialsFile.test.ts
+++ b/packages/alchemy/test/Cloudflare/StateStore/CredentialsFile.test.ts
@@ -1,0 +1,41 @@
+import { isStateStoreCredentialsStale } from "@/Cloudflare/StateStore/CredentialsFile.ts";
+import { describe, expect, it } from "@effect/vitest";
+
+const ACCOUNT_A = "c8eeff0e4f5ebeeedc8d9af2013d7997";
+const ACCOUNT_B = "a1b2c3d4e5f60718293a4b5c6d7e8f90";
+
+/**
+ * The cached Cloudflare state-store credentials encode an account (the `url`
+ * is a `*.workers.dev` subdomain). {@link isStateStoreCredentialsStale} guards
+ * against trusting a cache minted for a different account than the one now in
+ * use — the bug where deploys silently read/write state in a previously
+ * logged-in account.
+ */
+describe("isStateStoreCredentialsStale", () => {
+  it("is fresh when the cached account matches the current account", () => {
+    expect(
+      isStateStoreCredentialsStale(
+        { url: "https://s.workers.dev", authToken: "t", accountId: ACCOUNT_A },
+        ACCOUNT_A,
+      ),
+    ).toBe(false);
+  });
+
+  it("is stale when the cached account differs from the current account", () => {
+    expect(
+      isStateStoreCredentialsStale(
+        { url: "https://s.workers.dev", authToken: "t", accountId: ACCOUNT_A },
+        ACCOUNT_B,
+      ),
+    ).toBe(true);
+  });
+
+  it("is stale for a legacy cache with no accountId", () => {
+    expect(
+      isStateStoreCredentialsStale(
+        { url: "https://s.workers.dev", authToken: "t" },
+        ACCOUNT_A,
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
The Cloudflare state-store credentials cache (`~/.alchemy/credentials/{profile}/cloudflare-state-store.json`) stores a per-account `{ url, authToken }` — the `url` encodes the account via its `*.workers.dev` subdomain. `state()` short-circuited on that cache before ever consulting the current account, and `alchemy login --configure` re-selected the account without invalidating it. So after re-authenticating against a different account, deploys wrote resources to the new account while state reads/writes silently kept going to the old account's store.

### Fix

Bind the cached credentials to the account they were minted against and stop trusting a cache that doesn't match the current account.

```ts
export interface StoredStateStoreCredentials extends HttpStateStoreCredentials {
  accountId?: string; // optional so legacy files still parse (treated as stale)
}

export const isStateStoreCredentialsStale = (
  credentials: StoredStateStoreCredentials,
  currentAccountId: string,
): boolean =>
  credentials.accountId == null || credentials.accountId !== currentAccountId;
```

- `state()` init resolves the current `accountId` first, then discards a stale/legacy cache and falls through to re-derivation:

```ts
if (isStateStoreCredentialsStale(credentials, accountId)) {
  yield* Clank.info("...minted for a different Cloudflare account; re-deriving...");
  yield* credStore.delete(profileName, CREDENTIALS_FILE).pipe(Effect.ignore);
} else {
  return yield* ensureLatest(credentials);
}
```

- `accountId` is now persisted at every mint site (`loginWithCloudflare`, `bootstrap`, `writeCredentials`), and `loginWithCloudflare` applies the same staleness check to its own cache read.
- The Cloudflare auth provider deletes the state-store cache on `configure` (i.e. `login --configure`) and `logout`, since both may change the account. The `"cloudflare-state-store"` filename moved to a leaf module (`StateStore/CredentialsFile.ts`) to avoid an import cycle.

Legacy caches with no `accountId` are treated as stale, so existing users self-heal on the next deploy without running anything (verified live: the state-store suite re-derived a legacy cache and passed 18/18).

### Not included

Follow-up for the separate `profile show` diagnosability bugs surfaced in the same investigation (hardcoded provider registry, AWS read errors mislabeled `login failed`, `Console.error` interleaving under the wrong header).
