### PR TITLE
fix(planetscale): compare inherited roles by membership

### DIFF
--- a/packages/alchemy/src/Planetscale/Postgres/PostgresRole.ts
+++ b/packages/alchemy/src/Planetscale/Postgres/PostgresRole.ts
@@ -199,8 +199,8 @@ export const PostgresRoleProvider = () =>
       if (newBranch !== oldBranch) {
         return { action: "replace" } as const;
       }
-      const newRoles = resolveInheritedRoles(news.inheritedRoles);
-      const oldRoles = output?.inheritedRoles ?? [];
+      const newRoles = [...resolveInheritedRoles(news.inheritedRoles)].sort();
+      const oldRoles = [...(output?.inheritedRoles ?? [])].sort();
       if (!deepEqual(newRoles, oldRoles)) {
         return { action: "replace" } as const;
       }


### PR DESCRIPTION
Fixes #563.

Compare `PostgresRole` inherited roles as a membership set so API-returned ordering does not force replacement.

```ts
const newRoles = [...resolveInheritedRoles(news.inheritedRoles)].sort();
const oldRoles = [...(output?.inheritedRoles ?? [])].sort();

if (!deepEqual(newRoles, oldRoles)) {
  return { action: "replace" } as const;
}
```

I first thought of using sets and `symmetricDifference` but those are not supported for the target ES version