### PR TITLE
fix(cli): use the user's providers in `alchemy profile show`

### DIFF
--- a/packages/alchemy/src/AWS/AuthProvider.ts
+++ b/packages/alchemy/src/AWS/AuthProvider.ts
@@ -393,9 +393,6 @@ export const AwsAuth = AuthProviderLayer<
             );
           }),
         ),
-        Effect.catch((e) =>
-          Console.error(`  Failed to retrieve credentials: ${e}`),
-        ),
       );
 
     const logout = (profileName: string, config: AwsAuthConfig) =>

--- a/packages/alchemy/src/Axiom/AuthProvider.ts
+++ b/packages/alchemy/src/Axiom/AuthProvider.ts
@@ -328,9 +328,6 @@ export const AxiomAuth = AuthProviderLayer<
             Match.exhaustive,
           );
         }),
-        Effect.catch((e) =>
-          Console.error(`  Failed to retrieve credentials: ${e}`),
-        ),
       );
 
     return {

--- a/packages/alchemy/src/Cli/commands/_shared.ts
+++ b/packages/alchemy/src/Cli/commands/_shared.ts
@@ -296,7 +296,19 @@ export const printProfile = Effect.fn(function* (
       }
       continue;
     }
-    yield* provider.prettyPrint(profile, cfg);
+    // A provider's `prettyPrint` catches its own credential-resolution
+    // failures, but some resolve paths `Effect.orDie` (e.g. AWS SSO with an
+    // expired token), which escapes as a defect. Contain it here — via
+    // `Console.log` so the message stays on stdout under this provider's
+    // header instead of interleaving on stderr — so one broken provider
+    // can't abort rendering the rest of the profile.
+    yield* provider.prettyPrint(profile, cfg).pipe(
+      Effect.catchCause((cause) => {
+        const error = Cause.squash(cause);
+        const message = error instanceof Error ? error.message : String(error);
+        return Console.log(`  Failed to retrieve credentials: ${message}`);
+      }),
+    );
   }
 });
 

--- a/packages/alchemy/src/Cli/commands/_shared.ts
+++ b/packages/alchemy/src/Cli/commands/_shared.ts
@@ -1,8 +1,10 @@
 import * as Cause from "effect/Cause";
 import * as Config from "effect/Config";
+import * as ConfigProvider from "effect/ConfigProvider";
 import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Logger from "effect/Logger";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 import * as S from "effect/Schema";
@@ -16,10 +18,16 @@ import {
   AuthError,
   AuthProviders,
 } from "../../Auth/AuthProvider.ts";
-import type { AlchemyProfileProviders } from "../../Auth/Profile.ts";
-import type * as Stack from "../../Stack.ts";
+import {
+  type AlchemyProfileProviders,
+  withProfileOverride,
+} from "../../Auth/Profile.ts";
+import * as Stack from "../../Stack.ts";
+import { Stage } from "../../Stage.ts";
 import { recordCli } from "../../Telemetry/Metrics.ts";
 import { PromptCancelled } from "../../Util/Clank.ts";
+import { loadConfigProvider } from "../../Util/ConfigProvider.ts";
+import { fileLogger } from "../../Util/FileLogger.ts";
 
 export const USER = Config.string("USER").pipe(
   Config.orElse(() => Config.string("USERNAME")),
@@ -337,4 +345,85 @@ export const importStack = Effect.fn(function* (main: string) {
     providers: Layer.Layer<never>;
     state: Layer.Layer<never>;
   };
+});
+
+/**
+ * Placeholder {@link Stack.Stack} value used while building a stack's
+ * `providers()` layer out of band. No real resources exist yet — we only
+ * want the layer's provider/auth registrations and cloud-environment
+ * services, so `resources`/`bindings`/`actions` are empty and the stage is a
+ * sentinel.
+ */
+const placeholderStack = (name: string) => ({
+  actions: {},
+  bindings: {},
+  name,
+  resources: {},
+  stage: "placeholder",
+});
+
+export interface BuildStackProvidersOptions {
+  /** Stack entrypoint to import (e.g. `"alchemy.run.ts"`). */
+  main: string;
+  envFile: Option.Option<string>;
+  profile: string;
+  /**
+   * Registry to populate. Pass a pre-seeded registry (e.g. one that already
+   * has built-in providers) to layer the stack's providers on top of it,
+   * overriding by name. Defaults to a fresh empty registry.
+   */
+  registry?: AuthProviders["Service"];
+  /**
+   * Logger layer used during the build. Defaults to the file logger
+   * (`out`). `alchemy unsafe nuke` overrides this to log to the console in
+   * debug mode.
+   */
+  logger?: Layer.Layer<never, never, never>;
+  /**
+   * Extra layer merged into the placeholder scaffold — e.g.
+   * `Layer.succeed(MinimumLogLevel, ...)`, which sets a fiber-ref default
+   * and so contributes no context service (`Layer<never>`).
+   */
+  extra?: Layer.Layer<never, never, never>;
+}
+
+/**
+ * Import a stack entrypoint and build its `providers()` (+ `state()`) layer
+ * out of band against placeholder {@link Stack.Stack}/{@link Stage} services,
+ * so its `AuthProviderLayer` registrations land in an {@link AuthProviders}
+ * registry and the built context holds every resource provider plus the
+ * cloud-environment services their operations need.
+ *
+ * Shared by `alchemy login`, `alchemy profile show`, and `alchemy unsafe
+ * nuke`. The caller decides what to do with the result — use `authProviders`
+ * (login / profile show) or `context` (nuke) — and whether a missing/invalid
+ * entrypoint is fatal (login / nuke let it propagate) or best-effort
+ * (profile show wraps the call in `Effect.catchCause`).
+ */
+export const buildStackProviders = Effect.fn("buildStackProviders")(function* (
+  options: BuildStackProvidersOptions,
+) {
+  const authProviders = options.registry ?? {};
+  const stackEffect = yield* importStack(options.main);
+  const configProvider = withProfileOverride(
+    yield* loadConfigProvider(options.envFile),
+    options.profile,
+  );
+  const context = yield* Layer.build(
+    (stackEffect.providers ?? Layer.empty).pipe(
+      Layer.provideMerge(stackEffect.state ?? Layer.empty),
+      Layer.provideMerge(
+        Layer.mergeAll(
+          Layer.succeed(AuthProviders, authProviders),
+          ConfigProvider.layer(configProvider),
+          options.logger ??
+            Logger.layer([fileLogger("out")], { mergeWithExisting: true }),
+          Layer.succeed(Stage, "placeholder"),
+          Layer.succeed(Stack.Stack, placeholderStack(stackEffect.stackName)),
+          options.extra ?? Layer.empty,
+        ),
+      ),
+    ),
+  );
+  return { authProviders, context, stackEffect };
 });

--- a/packages/alchemy/src/Cli/commands/login.ts
+++ b/packages/alchemy/src/Cli/commands/login.ts
@@ -1,21 +1,13 @@
 import * as Config from "effect/Config";
-import * as ConfigProvider from "effect/ConfigProvider";
 import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as Logger from "effect/Logger";
 import { Command, Flag } from "effect/unstable/cli";
 
-import { AuthProviders } from "../../Auth/AuthProvider.ts";
-import { AlchemyProfile, withProfileOverride } from "../../Auth/Profile.ts";
-import { Stage } from "../../Stage.ts";
-import { loadConfigProvider } from "../../Util/ConfigProvider.ts";
-import { fileLogger } from "../../Util/FileLogger.ts";
+import { AlchemyProfile } from "../../Auth/Profile.ts";
 
-import { Stack } from "../../Stack.ts";
 import {
+  buildStackProviders,
   envFile,
-  importStack,
   instrumentCommand,
   printProfile,
   profile,
@@ -46,36 +38,13 @@ export const loginCommand = Command.make(
     }),
   )(
     Effect.fn(function* ({ main, envFile, profile, configure }) {
-      const stackEffect = yield* importStack(main);
-
-      const authProviders: AuthProviders["Service"] = {};
-
-      // build the state + providers layer to capture the Auth Providers
-      yield* Layer.build(
-        (stackEffect.providers ?? Layer.empty).pipe(
-          Layer.provideMerge(stackEffect.state ?? Layer.empty),
-          Layer.provideMerge(
-            Layer.mergeAll(
-              Layer.succeed(AuthProviders, authProviders),
-              ConfigProvider.layer(
-                withProfileOverride(
-                  yield* loadConfigProvider(envFile),
-                  profile,
-                ),
-              ),
-              Logger.layer([fileLogger("out")], { mergeWithExisting: true }),
-              Layer.succeed(Stage, "placeholder"),
-              Layer.succeed(Stack, {
-                actions: {},
-                bindings: {},
-                name: stackEffect.stackName,
-                resources: {},
-                stage: "placeholder",
-              }),
-            ),
-          ),
-        ),
-      );
+      // Build the user's providers() (+ state) layer to capture the auth
+      // providers their stack wires up.
+      const { authProviders } = yield* buildStackProviders({
+        main,
+        envFile,
+        profile,
+      });
 
       const profiles = yield* AlchemyProfile;
 

--- a/packages/alchemy/src/Cli/commands/nuke.ts
+++ b/packages/alchemy/src/Cli/commands/nuke.ts
@@ -1,4 +1,3 @@
-import * as ConfigProvider from "effect/ConfigProvider";
 import * as Console from "effect/Console";
 import type * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
@@ -8,22 +7,16 @@ import { MinimumLogLevel } from "effect/References";
 import { Command, Flag } from "effect/unstable/cli";
 import picomatch from "picomatch";
 
-import { AuthProviders } from "../../Auth/AuthProvider.ts";
-import { withProfileOverride } from "../../Auth/Profile.ts";
 import type { ProviderService } from "../../Provider.ts";
-import { Stack } from "../../Stack.ts";
-import { Stage } from "../../Stage.ts";
 import * as Clank from "../../Util/Clank.ts";
-import { loadConfigProvider } from "../../Util/ConfigProvider.ts";
-import { fileLogger } from "../../Util/FileLogger.ts";
 import type { ScopedPlanStatusSession } from "../Cli.ts";
 import { isNonInteractive } from "../selectCli.ts";
 import * as NukeUI from "../tui/components/Nuke.tsx";
 
 import {
+  buildStackProviders,
   dryRun,
   envFile,
-  importStack,
   instrumentCommand,
   profile,
   script,
@@ -311,42 +304,18 @@ const nukeCommand = Command.make(
       // log stream isn't clobbered by the progress renderer.
       const debug = !!process.env.DEBUG;
       const interactive = !isNonInteractive() && !debug;
-      const stackEffect = yield* importStack(main);
-      const authProviders: AuthProviders["Service"] = {};
 
-      // Build the state + providers layer (same wiring as `alchemy login`) so
-      // that the resulting context holds every resource provider plus the
-      // cloud-environment services their `list`/`delete` need at call time.
-      const context = yield* Layer.build(
-        (stackEffect.providers ?? Layer.empty).pipe(
-          Layer.provideMerge(stackEffect.state ?? Layer.empty),
-          Layer.provideMerge(
-            Layer.mergeAll(
-              Layer.succeed(AuthProviders, authProviders),
-              ConfigProvider.layer(
-                withProfileOverride(
-                  yield* loadConfigProvider(envFile),
-                  profile,
-                ),
-              ),
-              debug
-                ? Logger.layer([Logger.defaultLogger])
-                : Logger.layer([fileLogger("out")], {
-                    mergeWithExisting: true,
-                  }),
-              Layer.succeed(MinimumLogLevel, debug ? "Debug" : "Info"),
-              Layer.succeed(Stage, "placeholder"),
-              Layer.succeed(Stack, {
-                actions: {},
-                bindings: {},
-                name: stackEffect.stackName,
-                resources: {},
-                stage: "placeholder",
-              }),
-            ),
-          ),
-        ),
-      );
+      // Build the user's providers() (+ state) layer so the resulting context
+      // holds every resource provider plus the cloud-environment services
+      // their `list`/`delete` need at call time. DEBUG=1 routes provider logs
+      // to the console at Debug level instead of the .alchemy/log/out file.
+      const { context } = yield* buildStackProviders({
+        main,
+        envFile,
+        profile,
+        logger: debug ? Logger.layer([Logger.defaultLogger]) : undefined,
+        extra: Layer.succeed(MinimumLogLevel, debug ? "Debug" : "Info"),
+      });
 
       const discovered = discoverProviders(context as Context.Context<never>);
 

--- a/packages/alchemy/src/Cli/commands/profile.ts
+++ b/packages/alchemy/src/Cli/commands/profile.ts
@@ -3,7 +3,9 @@ import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Logger from "effect/Logger";
+import * as Option from "effect/Option";
 import { Command } from "effect/unstable/cli";
+import * as Argument from "effect/unstable/cli/Argument";
 
 import { AuthProviders } from "../../Auth/AuthProvider.ts";
 import { CredentialsStore } from "../../Auth/Credentials.ts";
@@ -14,23 +16,119 @@ import { CloudflareAuth } from "../../Cloudflare/Auth/AuthProvider.ts";
 import { GitHubAuth } from "../../GitHub/AuthProvider.ts";
 import { NeonAuth } from "../../Neon/AuthProvider.ts";
 import { PlanetscaleAuth } from "../../Planetscale/AuthProvider.ts";
+import { Stack } from "../../Stack.ts";
+import { Stage } from "../../Stage.ts";
 import { loadConfigProvider } from "../../Util/ConfigProvider.ts";
 import { fileLogger } from "../../Util/FileLogger.ts";
 
 import {
   envFile,
+  importStack,
   instrumentCommand,
   printProfile,
   profile,
 } from "./_shared.ts";
 
+/**
+ * The auth providers Alchemy ships with. Built into the registry as a
+ * baseline so `profile show` can pretty-print any provider a profile
+ * mentions, even one the current stack doesn't wire up.
+ */
+const builtinAuth = Layer.mergeAll(
+  AwsAuth,
+  AxiomAuth,
+  CloudflareAuth,
+  GitHubAuth,
+  NeonAuth,
+  PlanetscaleAuth,
+);
+
+/**
+ * Entrypoint whose `providers()` layer contributes the user's own auth
+ * providers. Optional and best-effort — if it's missing or fails to load,
+ * `profile show` still renders the built-in providers.
+ */
+const mainFile = Argument.file("main").pipe(
+  Argument.withDescription(
+    "Stack entrypoint whose providers() should be used, defaults to alchemy.run.ts",
+  ),
+  Argument.withDefault("alchemy.run.ts"),
+);
+
+/**
+ * Populate an {@link AuthProviders} registry for display: the built-in
+ * providers first, then the user's stack `providers()` layer on top so a
+ * customized provider (same name) overrides the built-in one. Loading the
+ * user's stack is best-effort — a missing or invalid entrypoint leaves the
+ * built-ins in place.
+ *
+ * Registration happens as a side effect of building each layer (see
+ * `AuthProviderLayer`), and later builds overwrite earlier entries by name,
+ * so build order is what gives the user's providers precedence.
+ */
+export const collectAuthProviders = Effect.fn("collectAuthProviders")(
+  function* (options: {
+    main: string;
+    envFile: Option.Option<string>;
+    profile: string;
+  }) {
+    const authProviders: AuthProviders["Service"] = {};
+    const base = Layer.mergeAll(
+      Layer.succeed(AuthProviders, authProviders),
+      ConfigProvider.layer(
+        withProfileOverride(
+          yield* loadConfigProvider(options.envFile),
+          options.profile,
+        ),
+      ),
+      Logger.layer([fileLogger("out")], { mergeWithExisting: true }),
+    );
+
+    // 1. Built-in providers first (baseline).
+    yield* Layer.build(Layer.provide(builtinAuth, base));
+
+    // 2. The user's own providers() layer on top — same-named providers
+    //    override the built-ins. Best-effort: swallow load/build failures
+    //    (including a missing entrypoint) so display still works.
+    yield* Effect.gen(function* () {
+      const stackEffect = yield* importStack(options.main);
+      yield* Layer.build(
+        (stackEffect.providers ?? Layer.empty).pipe(
+          Layer.provideMerge(stackEffect.state ?? Layer.empty),
+          Layer.provideMerge(
+            Layer.mergeAll(
+              base,
+              Layer.succeed(Stage, "placeholder"),
+              Layer.succeed(Stack, {
+                actions: {},
+                bindings: {},
+                name: stackEffect.stackName,
+                resources: {},
+                stage: "placeholder",
+              }),
+            ),
+          ),
+        ),
+      );
+    }).pipe(
+      Effect.catchCause((cause) =>
+        Effect.logDebug("profile show: could not load user stack providers", {
+          cause,
+        }),
+      ),
+    );
+
+    return authProviders;
+  },
+);
+
 const showCommand = Command.make(
   "show",
-  { profile, envFile },
+  { profile, envFile, main: mainFile },
   instrumentCommand("profile.show", (a: { profile: string }) => ({
     "alchemy.profile": a.profile,
   }))(
-    Effect.fn(function* ({ profile, envFile }) {
+    Effect.fn(function* ({ profile, envFile, main }) {
       const profiles = yield* AlchemyProfile;
       const stored = yield* profiles.getProfile(profile);
       if (stored == null) {
@@ -45,32 +143,13 @@ const showCommand = Command.make(
         return;
       }
 
-      const authProviders: AuthProviders["Service"] = {};
-      const authRegistry = Layer.succeed(AuthProviders, authProviders);
-      const services = Layer.mergeAll(
-        authRegistry,
-        ConfigProvider.layer(
-          withProfileOverride(yield* loadConfigProvider(envFile), profile),
-        ),
-        Logger.layer([fileLogger("out")], { mergeWithExisting: true }),
-        // Building these layers triggers their AuthProviderLayer effect, which
-        // registers the provider into the shared `authProviders` registry.
-        Layer.provide(
-          Layer.mergeAll(
-            AwsAuth,
-            AxiomAuth,
-            CloudflareAuth,
-            GitHubAuth,
-            NeonAuth,
-            PlanetscaleAuth,
-          ),
-          authRegistry,
-        ),
-      );
+      const authProviders = yield* collectAuthProviders({
+        main,
+        envFile,
+        profile,
+      });
 
-      yield* printProfile(profile, stored, authProviders).pipe(
-        Effect.provide(services),
-      );
+      yield* printProfile(profile, stored, authProviders);
     }),
   ),
 );

--- a/packages/alchemy/src/Cli/commands/profile.ts
+++ b/packages/alchemy/src/Cli/commands/profile.ts
@@ -16,14 +16,12 @@ import { CloudflareAuth } from "../../Cloudflare/Auth/AuthProvider.ts";
 import { GitHubAuth } from "../../GitHub/AuthProvider.ts";
 import { NeonAuth } from "../../Neon/AuthProvider.ts";
 import { PlanetscaleAuth } from "../../Planetscale/AuthProvider.ts";
-import { Stack } from "../../Stack.ts";
-import { Stage } from "../../Stage.ts";
 import { loadConfigProvider } from "../../Util/ConfigProvider.ts";
 import { fileLogger } from "../../Util/FileLogger.ts";
 
 import {
+  buildStackProviders,
   envFile,
-  importStack,
   instrumentCommand,
   printProfile,
   profile,
@@ -73,44 +71,29 @@ export const collectAuthProviders = Effect.fn("collectAuthProviders")(
     profile: string;
   }) {
     const authProviders: AuthProviders["Service"] = {};
-    const base = Layer.mergeAll(
-      Layer.succeed(AuthProviders, authProviders),
-      ConfigProvider.layer(
-        withProfileOverride(
-          yield* loadConfigProvider(options.envFile),
-          options.profile,
-        ),
-      ),
-      Logger.layer([fileLogger("out")], { mergeWithExisting: true }),
-    );
 
     // 1. Built-in providers first (baseline).
-    yield* Layer.build(Layer.provide(builtinAuth, base));
-
-    // 2. The user's own providers() layer on top — same-named providers
-    //    override the built-ins. Best-effort: swallow load/build failures
-    //    (including a missing entrypoint) so display still works.
-    yield* Effect.gen(function* () {
-      const stackEffect = yield* importStack(options.main);
-      yield* Layer.build(
-        (stackEffect.providers ?? Layer.empty).pipe(
-          Layer.provideMerge(stackEffect.state ?? Layer.empty),
-          Layer.provideMerge(
-            Layer.mergeAll(
-              base,
-              Layer.succeed(Stage, "placeholder"),
-              Layer.succeed(Stack, {
-                actions: {},
-                bindings: {},
-                name: stackEffect.stackName,
-                resources: {},
-                stage: "placeholder",
-              }),
+    yield* Layer.build(
+      Layer.provide(
+        builtinAuth,
+        Layer.mergeAll(
+          Layer.succeed(AuthProviders, authProviders),
+          ConfigProvider.layer(
+            withProfileOverride(
+              yield* loadConfigProvider(options.envFile),
+              options.profile,
             ),
           ),
+          Logger.layer([fileLogger("out")], { mergeWithExisting: true }),
         ),
-      );
-    }).pipe(
+      ),
+    );
+
+    // 2. The user's own providers() layer on top — building into the same
+    //    registry overrides the built-ins by name. Best-effort: swallow
+    //    load/build failures (including a missing entrypoint) so display
+    //    still works with just the built-ins.
+    yield* buildStackProviders({ ...options, registry: authProviders }).pipe(
       Effect.catchCause((cause) =>
         Effect.logDebug("profile show: could not load user stack providers", {
           cause,

--- a/packages/alchemy/src/Cloudflare/Auth/AuthProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Auth/AuthProvider.ts
@@ -638,9 +638,6 @@ export const CloudflareAuth = AuthProviderLayer<
             Match.exhaustive,
           );
         }),
-        Effect.catch((e) =>
-          Console.error(`  Failed to retrieve credentials: ${e}`),
-        ),
       );
 
     return {

--- a/packages/alchemy/src/GitHub/AuthProvider.ts
+++ b/packages/alchemy/src/GitHub/AuthProvider.ts
@@ -297,9 +297,6 @@ export const GitHubAuth = AuthProviderLayer<
             Console.log(`  source: ${sourceStr}`),
           ]);
         }),
-        Effect.catch((e) =>
-          Console.error(`  Failed to retrieve credentials: ${e}`),
-        ),
       );
 
     return {

--- a/packages/alchemy/src/Neon/AuthProvider.ts
+++ b/packages/alchemy/src/Neon/AuthProvider.ts
@@ -207,9 +207,6 @@ export const NeonAuth = AuthProviderLayer<
             Console.log(`  source: ${sourceStr}`),
           ]);
         }),
-        Effect.catch((e) =>
-          Console.error(`  Failed to retrieve credentials: ${e}`),
-        ),
       );
 
     return {

--- a/packages/alchemy/src/Planetscale/AuthProvider.ts
+++ b/packages/alchemy/src/Planetscale/AuthProvider.ts
@@ -269,9 +269,6 @@ export const PlanetscaleAuth = AuthProviderLayer<
             Console.log(`  source: ${sourceStr}`),
           ]);
         }),
-        Effect.catch((e) =>
-          Console.error(`  Failed to retrieve credentials: ${e}`),
-        ),
       );
 
     return {


### PR DESCRIPTION
Stacked on #760.

`alchemy profile show` registered only a hardcoded list of built-in auth providers, while `alchemy login` builds the providers from the user's own stack. So the two commands could disagree: a provider the user's stack wires up (or customizes) was shown with the raw JSON fallback in `profile show`, and providers the stack doesn't use were still probed. This is the mismatch behind the confusing `profile show` output in the original report.

### Change

Build the built-in providers first, then overlay the user's stack `providers()` layer, so same-named providers override the built-ins while the built-ins stay as a baseline for anything the stack doesn't wire up. Registration is a build-time side effect (`AuthProviderLayer`), so build order is what gives the user's providers precedence.

```ts
// 1. built-in providers (baseline)
yield* Layer.build(Layer.provide(builtinAuth, base));

// 2. the user's stack providers() on top — same-named providers win
yield* Effect.gen(function* () {
  const stackEffect = yield* importStack(options.main);
  yield* Layer.build(/* stackEffect.providers over base + Stage/Stack placeholders */);
}).pipe(Effect.catchCause(/* best-effort: missing/invalid entrypoint keeps built-ins */));
```

- The stack entrypoint (defaults to `alchemy.run.ts`) is loaded best-effort — a missing or invalid file just renders the built-ins.
- `login` is intentionally left provider-user-only (it iterates registered providers to log in; pulling in built-ins would prompt logins for providers the user doesn't use). Built-ins-as-baseline is specific to read-only display.

Also makes `printProfile` defect-safe. A provider whose `prettyPrint` resolution `Effect.orDie`s (e.g. AWS SSO with an expired token) previously escaped its own `Effect.catch` and dumped a stack trace, aborting the rest of the render. It now degrades to one line on stdout under that provider's header:

```
── Axiom ──
  Failed to retrieve credentials: AuthError: Axiom env credentials not found. Set AXIOM_TOKEN (or AXIOM_API_KEY).
```
