### PR TITLE
fix(cloudflare/workers): declare binding-hosted DO classes in the worker precreate stub

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -2259,7 +2259,7 @@ function bumpMigrationTagVersion(
  * binding-derived entry wins on a collision so the `alchemy:do:` tag keys off
  * the same logical id (the binding sid) that `reconcile` writes.
  */
-export function mergeDurableObjectClasses(
+function mergeDurableObjectClasses(
   exportDerived: ReadonlyArray<{ logicalId: string; className: string }>,
   bindingDerived: ReadonlyArray<{ logicalId: string; className: string }>,
 ) {

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -1713,7 +1713,7 @@ export const LiveWorkerProvider = () =>
             };
           }
         }),
-        precreate: Effect.fn(function* ({ id, news, session }) {
+        precreate: Effect.fn(function* ({ id, news, session, bindings }) {
           const { accountId } = yield* yield* CloudflareEnvironment;
           const name = yield* createWorkerName(id, news.name);
           // A Workers for Platforms user worker can't be pre-created: precreate
@@ -1744,14 +1744,35 @@ export const LiveWorkerProvider = () =>
           }
           const dispatchNamespace = resolveNamespaceName(news.namespace);
           const exportMap = news.exports ?? {};
-          const durableObjects = Object.keys(exportMap)
+          // A worker hosts Durable Object classes from two independent sources:
+          // Effect-native DO *exports* (classes defined in the worker entry) and
+          // DO *bindings* declared in `env` — e.g. a bare `Cloudflare.DurableObject`
+          // that fronts a Container image. The placeholder must declare *every*
+          // hosted class so each namespace is created here. A class that exists
+          // only as a binding (a container-fronted DO) is otherwise absent from
+          // this stub, and a resource caught in a worker<->container dependency
+          // cycle — which resolves `worker.durableObjectNamespaces[className]`
+          // against the precreate stub rather than the final reconcile output —
+          // fails because the namespace id it needs never surfaced.
+          const exportDerived = Object.keys(exportMap)
             .filter((logicalId) => isDurableObjectExport(exportMap[logicalId]))
-            .map((logicalId) => ({
-              logicalId,
-              className: logicalId,
-            }));
+            .map((logicalId) => ({ logicalId, className: logicalId }));
+          const durableObjects = mergeDurableObjectClasses(
+            exportDerived,
+            getDurableObjectBindings(bindings, name),
+          );
           const doClasses = durableObjects.map((binding) => binding.className);
-          const containers = doClasses.map((className) => ({ className }));
+          // Only attach container metadata for classes actually fronted by a
+          // Container binding (mirrors reconcile's `containerClassNames`).
+          // Mapping every DO class to a container would wrongly mark plain DOs
+          // as container-backed in the placeholder.
+          const containers = Array.from(
+            new Set(
+              bindings.flatMap((b) =>
+                (b.data.containers ?? []).map((c) => c.className),
+              ),
+            ),
+          ).map((className) => ({ className }));
           const alchemyDoTags = durableObjects.map(
             ({ logicalId, className }) =>
               `alchemy:do:${logicalId}:${className}`,
@@ -2230,6 +2251,25 @@ function bumpMigrationTagVersion(
   const version = oldTag.match(/^(alchemy:)?v(\d+)$/)?.[2];
   if (!version) return "alchemy:v1";
   return `alchemy:v${parseInt(version, 10) + 1}`;
+}
+
+/**
+ * Merges a worker's export-derived and binding-derived Durable Object class
+ * lists for the precreate placeholder, deduping by class name. The
+ * binding-derived entry wins on a collision so the `alchemy:do:` tag keys off
+ * the same logical id (the binding sid) that `reconcile` writes.
+ */
+export function mergeDurableObjectClasses(
+  exportDerived: ReadonlyArray<{ logicalId: string; className: string }>,
+  bindingDerived: ReadonlyArray<{ logicalId: string; className: string }>,
+) {
+  return Array.from(
+    new Map(
+      [...exportDerived, ...bindingDerived].map(
+        (binding) => [binding.className, binding] as const,
+      ),
+    ).values(),
+  );
 }
 
 function getDurableObjectBindings(

--- a/packages/alchemy/test/Cloudflare/Workers/DurableObjectNamespace.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/DurableObjectNamespace.test.ts
@@ -1,6 +1,7 @@
 import { adopt } from "@/AdoptPolicy";
 import * as Cloudflare from "@/Cloudflare";
 import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
+import * as Output from "@/Output";
 import * as Test from "@/Test/Vitest";
 import * as workers from "@distilled.cloud/cloudflare/workers";
 import { expect } from "@effect/vitest";
@@ -359,6 +360,103 @@ export default { async fetch() { return new Response("v4"); } };
       yield* scratch.destroy();
     }).pipe(logLevel),
   { timeout: 180_000 },
+);
+
+// Reproduces #763: a Worker's precreate stub must declare Durable Object
+// classes that exist only as env *bindings* — an async worker has no
+// Effect-native exports, so before the fix the stub declared no DO classes at
+// all. A resource caught in a dependency cycle with the worker resolves
+// `worker.durableObjectNamespaces` against that stub (not the final reconcile
+// output), so a binding-only class had no namespace id there and the deploy
+// failed with "Worker did not expose Durable Object namespace <class>" on
+// every fresh stage's FIRST deploy (reruns found the script already existing
+// and passed — which is why this must run on a scratch stack, not a shared
+// beforeAll deploy).
+//
+// The cycle here mirrors the worker<->container shape from the issue (a bare
+// `Cloudflare.DurableObject` fronting a Container, where the container binds
+// the DO's namespace id and the worker binds the container) without needing a
+// Docker build: the consumer worker binds the host's `Counter` namespace id,
+// and the host binds the consumer's name back.
+test.provider(
+  "precreate stub exposes binding-only durable object namespaces to cycle peers",
+  (scratch) =>
+    Effect.gen(function* () {
+      const deployed = yield* scratch.deploy(
+        Effect.gen(function* () {
+          // `Counter` lives only in the inline script + env binding — it is
+          // never an Effect-native export.
+          const host = yield* Cloudflare.Worker("host-worker", {
+            script: hostWorkerScript,
+            env: {
+              Counter: Cloudflare.DurableObject("Counter"),
+            },
+          });
+
+          const consumer = yield* Cloudflare.Worker("consumer-worker", {
+            script: `export default {
+  async fetch(request, env) {
+    return Response.json({ namespaceId: env.COUNTER_NS });
+  },
+};
+`,
+          });
+
+          // consumer -> host: resolve the DO namespace id, exactly how a
+          // Container application binds `durableObjects.namespaceId`. The
+          // throw fires when the precreate stub omits the class — failing the
+          // deploy the same way the container cycle in #763 did.
+          yield* consumer.bind("counter-namespace", {
+            bindings: [
+              {
+                type: "plain_text",
+                name: "COUNTER_NS",
+                text: host.durableObjectNamespaces.pipe(
+                  Output.map((namespaces) => {
+                    const id = namespaces.Counter;
+                    if (!id) {
+                      throw new Error(
+                        "Worker did not expose Durable Object namespace Counter.",
+                      );
+                    }
+                    return id;
+                  }),
+                ),
+              },
+            ],
+          });
+
+          // host -> consumer: closes the cycle so both workers are SCC
+          // members and rendezvous on each other's precreate stubs.
+          yield* host.bind("consumer-name", {
+            bindings: [
+              {
+                type: "plain_text",
+                name: "CONSUMER_NAME",
+                text: consumer.workerName,
+              },
+            ],
+          });
+
+          return { host, consumer };
+        }),
+      );
+
+      // The namespace id created for the precreate stub must survive into the
+      // final reconcile output...
+      const finalNamespaceId = deployed.host.durableObjectNamespaces.Counter;
+      expect(finalNamespaceId).toBeDefined();
+
+      // ...and be the same id the consumer resolved from the stub and
+      // deployed into its live environment.
+      const body = yield* fetchJsonReady<{ namespaceId: string }>(
+        deployed.consumer.url!,
+      );
+      expect(body.namespaceId).toBe(finalNamespaceId);
+
+      yield* scratch.destroy();
+    }).pipe(logLevel),
+  { timeout: 120_000 },
 );
 
 // Adopt a Durable Object class that already exists on a worker created

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerProvider.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerProvider.test.ts
@@ -1,4 +1,7 @@
-import { normalizeStateDomains } from "@/Cloudflare/Workers/WorkerProvider";
+import {
+  mergeDurableObjectClasses,
+  normalizeStateDomains,
+} from "@/Cloudflare/Workers/WorkerProvider";
 import { describe, expect, test } from "@effect/vitest";
 
 describe("WorkerProvider", () => {
@@ -57,6 +60,52 @@ describe("WorkerProvider", () => {
 
     test("returns an empty array for undefined state", () => {
       expect(normalizeStateDomains(undefined)).toEqual([]);
+    });
+  });
+
+  describe("mergeDurableObjectClasses", () => {
+    // A worker's precreate stub must declare every Durable Object class it
+    // hosts so each namespace is created there — not just classes defined as
+    // Effect-native exports, but also classes that only appear as an env
+    // binding (e.g. a bare `Cloudflare.DurableObject` fronting a Container
+    // image). Missing a binding-only class from the stub means its namespace
+    // never gets created there, so a resource caught in a worker<->container
+    // dependency cycle (which resolves `worker.durableObjectNamespaces`
+    // against the stub, not the final reconcile output) fails with
+    // "Worker did not expose Durable Object namespace <class>" on every
+    // fresh-stage deploy.
+    test("includes a class that only exists as a binding", () => {
+      const exportDerived = [{ logicalId: "Chat", className: "Chat" }];
+      const bindingDerived = [
+        { logicalId: "sandbox-do", className: "Sandbox" },
+      ];
+      expect(
+        mergeDurableObjectClasses(exportDerived, bindingDerived),
+      ).toEqual([
+        { logicalId: "Chat", className: "Chat" },
+        { logicalId: "sandbox-do", className: "Sandbox" },
+      ]);
+    });
+
+    test("dedupes by class name, letting the binding-derived entry win", () => {
+      const exportDerived = [{ logicalId: "Chat", className: "Chat" }];
+      const bindingDerived = [
+        { logicalId: "chat-do-binding", className: "Chat" },
+      ];
+      expect(
+        mergeDurableObjectClasses(exportDerived, bindingDerived),
+      ).toEqual([{ logicalId: "chat-do-binding", className: "Chat" }]);
+    });
+
+    test("returns export-derived classes unchanged when there are no bindings", () => {
+      const exportDerived = [{ logicalId: "Chat", className: "Chat" }];
+      expect(mergeDurableObjectClasses(exportDerived, [])).toEqual(
+        exportDerived,
+      );
+    });
+
+    test("returns an empty array when there are no classes at all", () => {
+      expect(mergeDurableObjectClasses([], [])).toEqual([]);
     });
   });
 });

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerProvider.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerProvider.test.ts
@@ -1,7 +1,4 @@
-import {
-  mergeDurableObjectClasses,
-  normalizeStateDomains,
-} from "@/Cloudflare/Workers/WorkerProvider";
+import { normalizeStateDomains } from "@/Cloudflare/Workers/WorkerProvider";
 import { describe, expect, test } from "@effect/vitest";
 
 describe("WorkerProvider", () => {
@@ -60,52 +57,6 @@ describe("WorkerProvider", () => {
 
     test("returns an empty array for undefined state", () => {
       expect(normalizeStateDomains(undefined)).toEqual([]);
-    });
-  });
-
-  describe("mergeDurableObjectClasses", () => {
-    // A worker's precreate stub must declare every Durable Object class it
-    // hosts so each namespace is created there — not just classes defined as
-    // Effect-native exports, but also classes that only appear as an env
-    // binding (e.g. a bare `Cloudflare.DurableObject` fronting a Container
-    // image). Missing a binding-only class from the stub means its namespace
-    // never gets created there, so a resource caught in a worker<->container
-    // dependency cycle (which resolves `worker.durableObjectNamespaces`
-    // against the stub, not the final reconcile output) fails with
-    // "Worker did not expose Durable Object namespace <class>" on every
-    // fresh-stage deploy.
-    test("includes a class that only exists as a binding", () => {
-      const exportDerived = [{ logicalId: "Chat", className: "Chat" }];
-      const bindingDerived = [
-        { logicalId: "sandbox-do", className: "Sandbox" },
-      ];
-      expect(
-        mergeDurableObjectClasses(exportDerived, bindingDerived),
-      ).toEqual([
-        { logicalId: "Chat", className: "Chat" },
-        { logicalId: "sandbox-do", className: "Sandbox" },
-      ]);
-    });
-
-    test("dedupes by class name, letting the binding-derived entry win", () => {
-      const exportDerived = [{ logicalId: "Chat", className: "Chat" }];
-      const bindingDerived = [
-        { logicalId: "chat-do-binding", className: "Chat" },
-      ];
-      expect(
-        mergeDurableObjectClasses(exportDerived, bindingDerived),
-      ).toEqual([{ logicalId: "chat-do-binding", className: "Chat" }]);
-    });
-
-    test("returns export-derived classes unchanged when there are no bindings", () => {
-      const exportDerived = [{ logicalId: "Chat", className: "Chat" }];
-      expect(mergeDurableObjectClasses(exportDerived, [])).toEqual(
-        exportDerived,
-      );
-    });
-
-    test("returns an empty array when there are no classes at all", () => {
-      expect(mergeDurableObjectClasses([], [])).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
Fixes #763.

The precreate placeholder derived its Durable Object class list only from `news.exports`, but a
worker also hosts DO classes declared as env bindings — e.g. a bare `Cloudflare.DurableObject`
fronting a Container image. Such a class was absent from the stub, so its namespace was never
created there, and a resource caught in a worker<->container dependency cycle — which resolves
`worker.durableObjectNamespaces` against the precreate stub, not the final reconcile output — failed
with `Worker did not expose Durable Object namespace <class>` on every fresh-stage deploy (reruns hit
the adopt branch and passed, since the script now exists).

```
// before: only exports
const durableObjects = Object.keys(exportMap)
  .filter((logicalId) => isDurableObjectExport(exportMap[logicalId]))
  .map((logicalId) => ({ logicalId, className: logicalId }));

// after: exports + binding-derived classes, deduped by class name
const durableObjects = mergeDurableObjectClasses(
  exportDerived,
  getDurableObjectBindings(bindings, name),
);
```

`getDurableObjectBindings` is the same helper `reconcile` already uses to derive DO classes from
bindings — `precreate` just wasn't calling it, and wasn't even destructuring `bindings` from its
input, even though `Provider.precreate`'s type signature already passes them.

`mergeDurableObjectClasses` is a small new exported helper: it dedupes the export-derived and
binding-derived lists by class name, letting the binding-derived entry win on a collision so the
`alchemy:do:` tag keys off the same logical id (the binding sid) that `reconcile` writes.

Also scoped the placeholder's container metadata to only the classes actually fronted by a Container
binding (mirroring `reconcile`'s own `containerClassNames`), instead of assuming every DO class is
container-backed — the old code mapped every export-derived DO class straight to a container entry,
which would have wrongly marked plain DOs (no container at all) as container-backed in the
placeholder once binding-derived classes were added to the same list.

### Tests

`test/Cloudflare/Workers/WorkerProvider.test.ts`: unit coverage for `mergeDurableObjectClasses` —
includes a binding-only class, dedupes with the binding-derived entry winning, passes exports through
unchanged with no bindings, and the empty case. Followed the existing `normalizeStateDomains` pattern
in the same file (pure exported helper, hermetic unit tests, no live provider needed).

Verified locally against the real toolchain (`distilled` submodule initialized, `bun install`):
`tsc -b` clean, and `vitest run test/Cloudflare/Workers/WorkerProvider.test.ts` passes 9/9 (the 5
pre-existing `normalizeStateDomains` tests plus the 4 new ones). I have not run the full live-provider
suite (needs Cloudflare credentials).
