### PR TITLE
feat(engine): resource type aliases for safe type renames

### DIFF
--- a/packages/alchemy/src/Apply.ts
+++ b/packages/alchemy/src/Apply.ts
@@ -465,7 +465,13 @@ const executeNode = (
     // ── noop ──
 
     if (node.action === "noop") {
-      // No work to do — the persisted attr is already stable.
+      // No work to do — the persisted attr is already stable. If the row was
+      // persisted under a legacy type name (the type was since renamed and
+      // carries the old name as an alias), migrate it to the canonical type
+      // so the state stops depending on the alias.
+      if (node.state.resourceType !== node.resource.Type) {
+        yield* commit({ ...node.state, resourceType: node.resource.Type });
+      }
       yield* signalReadyStable;
       yield* storeAndSignal({
         output: node.state.attr,

--- a/packages/alchemy/src/Cloudflare/AI/CustomTopics.ts
+++ b/packages/alchemy/src/Cloudflare/AI/CustomTopics.ts
@@ -101,7 +101,9 @@ export type CustomTopics = Resource<
  *
  * @see https://developers.cloudflare.com/waf/detections/firewall-for-ai/
  */
-export const CustomTopics = Resource<CustomTopics>(TypeId);
+export const CustomTopics = Resource<CustomTopics>(TypeId, {
+  aliases: ["Cloudflare.AiSecurity.CustomTopics"],
+});
 
 /**
  * Returns true if the given value is a CustomTopics resource.

--- a/packages/alchemy/src/Cloudflare/AI/Dataset.ts
+++ b/packages/alchemy/src/Cloudflare/AI/Dataset.ts
@@ -165,7 +165,9 @@ export type Dataset = Resource<
  *
  * @see https://developers.cloudflare.com/ai-gateway/evaluations/set-up-evaluations/
  */
-export const Dataset = Resource<Dataset>(TypeId);
+export const Dataset = Resource<Dataset>(TypeId, {
+  aliases: ["Cloudflare.AiGateway.Dataset"],
+});
 
 /**
  * Returns true if the given value is a Dataset resource.

--- a/packages/alchemy/src/Cloudflare/AI/Evaluation.ts
+++ b/packages/alchemy/src/Cloudflare/AI/Evaluation.ts
@@ -124,7 +124,9 @@ export type Evaluation = Resource<
  *
  * @see https://developers.cloudflare.com/ai-gateway/evaluations/
  */
-export const Evaluation = Resource<Evaluation>(TypeId);
+export const Evaluation = Resource<Evaluation>(TypeId, {
+  aliases: ["Cloudflare.AiGateway.Evaluation"],
+});
 
 /**
  * Returns true if the given value is an Evaluation resource.

--- a/packages/alchemy/src/Cloudflare/AI/Gateway.ts
+++ b/packages/alchemy/src/Cloudflare/AI/Gateway.ts
@@ -467,7 +467,9 @@ export const isAiGateway = (value: unknown): value is Gateway =>
  * });
  * ```
  */
-export const Gateway = Resource<Gateway>("Cloudflare.AI.Gateway");
+export const Gateway = Resource<Gateway>("Cloudflare.AI.Gateway", {
+  aliases: ["Cloudflare.AiGateway"],
+});
 
 export const GatewayResourceProvider = () =>
   Provider.succeed(Gateway, {

--- a/packages/alchemy/src/Cloudflare/AI/GatewayDynamicRouting.ts
+++ b/packages/alchemy/src/Cloudflare/AI/GatewayDynamicRouting.ts
@@ -302,7 +302,9 @@ export type GatewayDynamicRouting = Resource<
  *
  * @see https://developers.cloudflare.com/ai-gateway/features/dynamic-routing/
  */
-export const GatewayDynamicRouting = Resource<GatewayDynamicRouting>(TypeId);
+export const GatewayDynamicRouting = Resource<GatewayDynamicRouting>(TypeId, {
+  aliases: ["Cloudflare.AiGateway.DynamicRouting"],
+});
 
 /**
  * Returns true if the given value is a GatewayDynamicRouting resource.

--- a/packages/alchemy/src/Cloudflare/AI/GatewayProvider.ts
+++ b/packages/alchemy/src/Cloudflare/AI/GatewayProvider.ts
@@ -175,7 +175,9 @@ export type GatewayProvider = Resource<
  *
  * @see https://developers.cloudflare.com/ai-gateway/configuration/bring-your-own-keys/
  */
-export const GatewayProvider = Resource<GatewayProvider>(TypeId);
+export const GatewayProvider = Resource<GatewayProvider>(TypeId, {
+  aliases: ["Cloudflare.AiGateway.ProviderConfig"],
+});
 
 /**
  * Returns true if the given value is a GatewayProvider resource.

--- a/packages/alchemy/src/Cloudflare/AI/SearchInstance.ts
+++ b/packages/alchemy/src/Cloudflare/AI/SearchInstance.ts
@@ -556,7 +556,9 @@ export type SearchInstance = Resource<
  *
  * @see https://developers.cloudflare.com/ai-search/
  */
-export const SearchInstance = Resource<SearchInstance>(TypeId);
+export const SearchInstance = Resource<SearchInstance>(TypeId, {
+  aliases: ["Cloudflare.AiSearch.Instance"],
+});
 
 /**
  * Returns true if the given value is a SearchInstance resource.

--- a/packages/alchemy/src/Cloudflare/AI/SearchNamespace.ts
+++ b/packages/alchemy/src/Cloudflare/AI/SearchNamespace.ts
@@ -175,7 +175,9 @@ export type SearchNamespace = Resource<
  *
  * @see https://developers.cloudflare.com/ai-search/
  */
-export const SearchNamespace = Resource<SearchNamespace>(TypeId);
+export const SearchNamespace = Resource<SearchNamespace>(TypeId, {
+  aliases: ["Cloudflare.AiSearch.Namespace"],
+});
 
 /**
  * Returns true if the given value is a SearchNamespace resource.

--- a/packages/alchemy/src/Cloudflare/AI/SearchToken.ts
+++ b/packages/alchemy/src/Cloudflare/AI/SearchToken.ts
@@ -139,7 +139,9 @@ export type SearchToken = Resource<
  *
  * @see https://developers.cloudflare.com/ai-search/
  */
-export const SearchToken = Resource<SearchToken>(TypeId);
+export const SearchToken = Resource<SearchToken>(TypeId, {
+  aliases: ["Cloudflare.AiSearch.Token"],
+});
 
 /**
  * Returns true if the given value is a SearchToken resource.

--- a/packages/alchemy/src/Cloudflare/AI/SecuritySettings.ts
+++ b/packages/alchemy/src/Cloudflare/AI/SecuritySettings.ts
@@ -94,6 +94,9 @@ export type SecuritySettings = Resource<
  */
 export const SecuritySettings = Resource<SecuritySettings>(
   AiSecuritySettingsTypeId,
+  {
+    aliases: ["Cloudflare.AiSecurity.Settings"],
+  },
 );
 
 export const SecuritySettingsProvider = () =>

--- a/packages/alchemy/src/Cloudflare/Access/Organization.ts
+++ b/packages/alchemy/src/Cloudflare/Access/Organization.ts
@@ -188,6 +188,7 @@ export type Organization = Resource<
  */
 export const Organization = Resource<Organization>(
   "Cloudflare.Access.Organization",
+  { aliases: ["Cloudflare.AccessOrganization"] },
 );
 
 export const OrganizationProvider = () =>

--- a/packages/alchemy/src/Cloudflare/Access/Policy.ts
+++ b/packages/alchemy/src/Cloudflare/Access/Policy.ts
@@ -164,7 +164,9 @@ export type Policy = Resource<
  * });
  * ```
  */
-export const Policy = Resource<Policy>("Cloudflare.Access.Policy");
+export const Policy = Resource<Policy>("Cloudflare.Access.Policy", {
+  aliases: ["Cloudflare.AccessPolicy"],
+});
 
 export const PolicyProvider = () =>
   Provider.succeed(Policy, {

--- a/packages/alchemy/src/Cloudflare/Account/Account.ts
+++ b/packages/alchemy/src/Cloudflare/Account/Account.ts
@@ -145,7 +145,9 @@ export type Account = Resource<
  *
  * @see https://developers.cloudflare.com/tenant/how-to/manage-accounts/
  */
-export const Account = Resource<Account>(TypeId);
+export const Account = Resource<Account>(TypeId, {
+  aliases: ["Cloudflare.Account"],
+});
 
 /**
  * Returns true if the given value is an Account resource.

--- a/packages/alchemy/src/Cloudflare/ApiToken/AccountApiToken.ts
+++ b/packages/alchemy/src/Cloudflare/ApiToken/AccountApiToken.ts
@@ -116,6 +116,7 @@ export type AccountApiToken = Resource<
  */
 export const AccountApiToken = Resource<AccountApiToken>(
   "Cloudflare.ApiToken.AccountApiToken",
+  { aliases: ["Cloudflare.AccountApiToken"] },
 );
 
 type AccountApiTokenAttributes = AccountApiToken["Attributes"];

--- a/packages/alchemy/src/Cloudflare/ApiToken/UserApiToken.ts
+++ b/packages/alchemy/src/Cloudflare/ApiToken/UserApiToken.ts
@@ -104,6 +104,7 @@ export type UserApiToken = Resource<
  */
 export const UserApiToken = Resource<UserApiToken>(
   "Cloudflare.ApiToken.UserApiToken",
+  { aliases: ["Cloudflare.UserApiToken"] },
 );
 
 type UserApiTokenAttributes = UserApiToken["Attributes"];

--- a/packages/alchemy/src/Cloudflare/BotManagement/BotManagement.ts
+++ b/packages/alchemy/src/Cloudflare/BotManagement/BotManagement.ts
@@ -222,7 +222,9 @@ export type BotManagement = Resource<
  *
  * @see https://developers.cloudflare.com/bots/
  */
-export const BotManagement = Resource<BotManagement>(TypeId);
+export const BotManagement = Resource<BotManagement>(TypeId, {
+  aliases: ["Cloudflare.BotManagement"],
+});
 
 /**
  * Returns true if the given value is a BotManagement resource.

--- a/packages/alchemy/src/Cloudflare/Cache/Reserve.ts
+++ b/packages/alchemy/src/Cloudflare/Cache/Reserve.ts
@@ -111,7 +111,9 @@ export type Reserve = Resource<
  *
  * @see https://developers.cloudflare.com/cache/advanced-configuration/cache-reserve/
  */
-export const Reserve = Resource<Reserve>(TypeId);
+export const Reserve = Resource<Reserve>(TypeId, {
+  aliases: ["Cloudflare.Cache.CacheReserve"],
+});
 
 /**
  * Returns true if the given value is a Reserve resource.

--- a/packages/alchemy/src/Cloudflare/ClientCertificate/ClientCertificate.ts
+++ b/packages/alchemy/src/Cloudflare/ClientCertificate/ClientCertificate.ts
@@ -162,7 +162,9 @@ export type ClientCertificate = Resource<
  *
  * @see https://developers.cloudflare.com/ssl/client-certificates/
  */
-export const ClientCertificate = Resource<ClientCertificate>(TypeId);
+export const ClientCertificate = Resource<ClientCertificate>(TypeId, {
+  aliases: ["Cloudflare.ClientCertificate"],
+});
 
 /**
  * Returns true if the given value is a ClientCertificate resource.

--- a/packages/alchemy/src/Cloudflare/ContentScanning/ContentScanning.ts
+++ b/packages/alchemy/src/Cloudflare/ContentScanning/ContentScanning.ts
@@ -107,7 +107,9 @@ export type ContentScanning = Resource<
  *
  * @see https://developers.cloudflare.com/waf/detections/malicious-uploads/
  */
-export const ContentScanning = Resource<ContentScanning>(TypeId);
+export const ContentScanning = Resource<ContentScanning>(TypeId, {
+  aliases: ["Cloudflare.ContentScanning"],
+});
 
 /**
  * Returns true if the given value is a ContentScanning resource.

--- a/packages/alchemy/src/Cloudflare/CustomCertificate/CustomCertificate.ts
+++ b/packages/alchemy/src/Cloudflare/CustomCertificate/CustomCertificate.ts
@@ -244,7 +244,9 @@ export type CustomCertificate = Resource<
  *
  * @see https://developers.cloudflare.com/ssl/edge-certificates/custom-certificates/
  */
-export const CustomCertificate = Resource<CustomCertificate>(TypeId);
+export const CustomCertificate = Resource<CustomCertificate>(TypeId, {
+  aliases: ["Cloudflare.CustomCertificate"],
+});
 
 /**
  * Returns true if the given value is a CustomCertificate resource.

--- a/packages/alchemy/src/Cloudflare/CustomHostname/CustomHostname.ts
+++ b/packages/alchemy/src/Cloudflare/CustomHostname/CustomHostname.ts
@@ -280,6 +280,7 @@ export type CustomHostname = Resource<
  */
 export const CustomHostname = Resource<CustomHostname>(
   "Cloudflare.CustomHostname.CustomHostname",
+  { aliases: ["Cloudflare.CustomHostname"] },
 );
 
 export const isCustomHostname = (value: unknown): value is CustomHostname =>

--- a/packages/alchemy/src/Cloudflare/CustomHostname/FallbackOrigin.ts
+++ b/packages/alchemy/src/Cloudflare/CustomHostname/FallbackOrigin.ts
@@ -78,6 +78,7 @@ export type FallbackOrigin = Resource<
  */
 export const FallbackOrigin = Resource<FallbackOrigin>(
   "Cloudflare.CustomHostname.FallbackOrigin",
+  { aliases: ["Cloudflare.FallbackOrigin"] },
 );
 
 export const isFallbackOrigin = (value: unknown): value is FallbackOrigin =>

--- a/packages/alchemy/src/Cloudflare/CustomNameserver/CustomNameserver.ts
+++ b/packages/alchemy/src/Cloudflare/CustomNameserver/CustomNameserver.ts
@@ -132,7 +132,9 @@ export type CustomNameserver = Resource<
  *
  * @see https://developers.cloudflare.com/dns/nameservers/custom-nameservers/account-custom-nameservers/
  */
-export const CustomNameserver = Resource<CustomNameserver>(TypeId);
+export const CustomNameserver = Resource<CustomNameserver>(TypeId, {
+  aliases: ["Cloudflare.CustomNameserver"],
+});
 
 /**
  * Returns true if the given value is a CustomNameserver resource.

--- a/packages/alchemy/src/Cloudflare/DNS/AccountSettings.ts
+++ b/packages/alchemy/src/Cloudflare/DNS/AccountSettings.ts
@@ -228,7 +228,9 @@ export type AccountDnsSettings = Resource<
  * });
  * ```
  */
-export const AccountDnsSettings = Resource<AccountDnsSettings>(TypeId);
+export const AccountDnsSettings = Resource<AccountDnsSettings>(TypeId, {
+  aliases: ["Cloudflare.Dns.AccountSettings"],
+});
 
 /**
  * Returns true if the given value is an AccountDnsSettings resource.

--- a/packages/alchemy/src/Cloudflare/DNS/Dnssec.ts
+++ b/packages/alchemy/src/Cloudflare/DNS/Dnssec.ts
@@ -190,7 +190,9 @@ export type Dnssec = Resource<
  * });
  * ```
  */
-export const Dnssec = Resource<Dnssec>(TypeId);
+export const Dnssec = Resource<Dnssec>(TypeId, {
+  aliases: ["Cloudflare.Dns.Dnssec"],
+});
 
 /**
  * Returns true if the given value is a Dnssec resource.

--- a/packages/alchemy/src/Cloudflare/DNS/Firewall.ts
+++ b/packages/alchemy/src/Cloudflare/DNS/Firewall.ts
@@ -238,7 +238,9 @@ export type Firewall = Resource<
  *
  * @see https://developers.cloudflare.com/dns/dns-firewall/
  */
-export const Firewall = Resource<Firewall>(TypeId);
+export const Firewall = Resource<Firewall>(TypeId, {
+  aliases: ["Cloudflare.DnsFirewall"],
+});
 
 /**
  * Returns true if the given value is a DnsFirewall resource.

--- a/packages/alchemy/src/Cloudflare/DNS/Record.ts
+++ b/packages/alchemy/src/Cloudflare/DNS/Record.ts
@@ -163,7 +163,9 @@ export type Record = Resource<
  * });
  * ```
  */
-export const Record = Resource<Record>("Cloudflare.DNS.Record");
+export const Record = Resource<Record>("Cloudflare.DNS.Record", {
+  aliases: ["Cloudflare.Dns.Record"],
+});
 
 export const RecordProvider = () =>
   Provider.succeed(Record, {

--- a/packages/alchemy/src/Cloudflare/DNS/View.ts
+++ b/packages/alchemy/src/Cloudflare/DNS/View.ts
@@ -83,7 +83,9 @@ export type View = Resource<
  *
  * @see https://developers.cloudflare.com/dns/internal-dns/
  */
-export const View = Resource<View>(DnsViewTypeId);
+export const View = Resource<View>(DnsViewTypeId, {
+  aliases: ["Cloudflare.Dns.View"],
+});
 
 /**
  * Returns true if the given value is a View resource.

--- a/packages/alchemy/src/Cloudflare/DNS/ZoneSettings.ts
+++ b/packages/alchemy/src/Cloudflare/DNS/ZoneSettings.ts
@@ -252,7 +252,9 @@ export type ZoneDnsSettings = Resource<
  * });
  * ```
  */
-export const ZoneDnsSettings = Resource<ZoneDnsSettings>(TypeId);
+export const ZoneDnsSettings = Resource<ZoneDnsSettings>(TypeId, {
+  aliases: ["Cloudflare.Dns.ZoneSettings"],
+});
 
 /**
  * Returns true if the given value is a ZoneDnsSettings resource.

--- a/packages/alchemy/src/Cloudflare/DNS/ZoneTransferAcl.ts
+++ b/packages/alchemy/src/Cloudflare/DNS/ZoneTransferAcl.ts
@@ -84,7 +84,9 @@ export type ZoneTransferAcl = Resource<
  *
  * @see https://developers.cloudflare.com/dns/zone-setups/zone-transfers/
  */
-export const ZoneTransferAcl = Resource<ZoneTransferAcl>(TypeId);
+export const ZoneTransferAcl = Resource<ZoneTransferAcl>(TypeId, {
+  aliases: ["Cloudflare.Dns.ZoneTransferAcl"],
+});
 
 /**
  * Returns true if the given value is a ZoneTransferAcl resource.

--- a/packages/alchemy/src/Cloudflare/DNS/ZoneTransferIncoming.ts
+++ b/packages/alchemy/src/Cloudflare/DNS/ZoneTransferIncoming.ts
@@ -100,7 +100,9 @@ export type ZoneTransferIncoming = Resource<
  *
  * @see https://developers.cloudflare.com/dns/zone-setups/zone-transfers/setup/
  */
-export const ZoneTransferIncoming = Resource<ZoneTransferIncoming>(TypeId);
+export const ZoneTransferIncoming = Resource<ZoneTransferIncoming>(TypeId, {
+  aliases: ["Cloudflare.Dns.ZoneTransferIncoming"],
+});
 
 /**
  * Returns true if the given value is a ZoneTransferIncoming resource.

--- a/packages/alchemy/src/Cloudflare/DNS/ZoneTransferOutgoing.ts
+++ b/packages/alchemy/src/Cloudflare/DNS/ZoneTransferOutgoing.ts
@@ -112,7 +112,9 @@ export type ZoneTransferOutgoing = Resource<
  *
  * @see https://developers.cloudflare.com/dns/zone-setups/zone-transfers/setup/
  */
-export const ZoneTransferOutgoing = Resource<ZoneTransferOutgoing>(TypeId);
+export const ZoneTransferOutgoing = Resource<ZoneTransferOutgoing>(TypeId, {
+  aliases: ["Cloudflare.Dns.ZoneTransferOutgoing"],
+});
 
 /**
  * Returns true if the given value is a ZoneTransferOutgoing resource.

--- a/packages/alchemy/src/Cloudflare/DNS/ZoneTransferPeer.ts
+++ b/packages/alchemy/src/Cloudflare/DNS/ZoneTransferPeer.ts
@@ -119,7 +119,9 @@ export type ZoneTransferPeer = Resource<
  *
  * @see https://developers.cloudflare.com/dns/zone-setups/zone-transfers/
  */
-export const ZoneTransferPeer = Resource<ZoneTransferPeer>(TypeId);
+export const ZoneTransferPeer = Resource<ZoneTransferPeer>(TypeId, {
+  aliases: ["Cloudflare.Dns.ZoneTransferPeer"],
+});
 
 /**
  * Returns true if the given value is a ZoneTransferPeer resource.

--- a/packages/alchemy/src/Cloudflare/DNS/ZoneTransferTsig.ts
+++ b/packages/alchemy/src/Cloudflare/DNS/ZoneTransferTsig.ts
@@ -91,7 +91,9 @@ export type ZoneTransferTsig = Resource<
  *
  * @see https://developers.cloudflare.com/dns/zone-setups/zone-transfers/
  */
-export const ZoneTransferTsig = Resource<ZoneTransferTsig>(TypeId);
+export const ZoneTransferTsig = Resource<ZoneTransferTsig>(TypeId, {
+  aliases: ["Cloudflare.Dns.ZoneTransferTsig"],
+});
 
 /**
  * Returns true if the given value is a ZoneTransferTsig resource.

--- a/packages/alchemy/src/Cloudflare/Email/Address.ts
+++ b/packages/alchemy/src/Cloudflare/Email/Address.ts
@@ -55,7 +55,9 @@ export type Address = Resource<
  * Cloudflare sends a verification email when the address is first created.
  * The address must be verified before it can receive routed mail.
  */
-export const Address = Resource<Address>("Cloudflare.Email.Address");
+export const Address = Resource<Address>("Cloudflare.Email.Address", {
+  aliases: ["Cloudflare.EmailAddress"],
+});
 
 const toAttrs = (
   accountId: string,

--- a/packages/alchemy/src/Cloudflare/Email/AllowPolicy.ts
+++ b/packages/alchemy/src/Cloudflare/Email/AllowPolicy.ts
@@ -144,6 +144,7 @@ export type AllowPolicy = Resource<
  */
 export const AllowPolicy = Resource<AllowPolicy>(
   EmailSecurityAllowPolicyTypeId,
+  { aliases: ["Cloudflare.EmailSecurity.AllowPolicy"] },
 );
 
 /**

--- a/packages/alchemy/src/Cloudflare/Email/BlockSender.ts
+++ b/packages/alchemy/src/Cloudflare/Email/BlockSender.ts
@@ -104,6 +104,7 @@ export type BlockSender = Resource<
  */
 export const BlockSender = Resource<BlockSender>(
   EmailSecurityBlockSenderTypeId,
+  { aliases: ["Cloudflare.EmailSecurity.BlockSender"] },
 );
 
 /**

--- a/packages/alchemy/src/Cloudflare/Email/CatchAll.ts
+++ b/packages/alchemy/src/Cloudflare/Email/CatchAll.ts
@@ -124,7 +124,9 @@ export type CatchAll = Resource<
  * });
  * ```
  */
-export const CatchAll = Resource<CatchAll>(CatchAllTypeId);
+export const CatchAll = Resource<CatchAll>(CatchAllTypeId, {
+  aliases: ["Cloudflare.EmailCatchAll"],
+});
 
 /**
  * Returns true if the given value is an CatchAll resource.

--- a/packages/alchemy/src/Cloudflare/Email/Domain.ts
+++ b/packages/alchemy/src/Cloudflare/Email/Domain.ts
@@ -170,7 +170,9 @@ export type Domain = Resource<
  *
  * @see https://developers.cloudflare.com/cloudflare-one/email-security/
  */
-export const Domain = Resource<Domain>(EmailSecurityDomainTypeId);
+export const Domain = Resource<Domain>(EmailSecurityDomainTypeId, {
+  aliases: ["Cloudflare.EmailSecurity.Domain"],
+});
 
 /**
  * Returns true if the given value is an Domain resource.

--- a/packages/alchemy/src/Cloudflare/Email/ImpersonationRegistryEntry.ts
+++ b/packages/alchemy/src/Cloudflare/Email/ImpersonationRegistryEntry.ts
@@ -107,6 +107,7 @@ export type ImpersonationRegistryEntry = Resource<
  */
 export const ImpersonationRegistryEntry = Resource<ImpersonationRegistryEntry>(
   EmailSecurityImpersonationRegistryEntryTypeId,
+  { aliases: ["Cloudflare.EmailSecurity.ImpersonationRegistryEntry"] },
 );
 
 /**

--- a/packages/alchemy/src/Cloudflare/Email/Routing.ts
+++ b/packages/alchemy/src/Cloudflare/Email/Routing.ts
@@ -71,7 +71,9 @@ export type Routing = Resource<
  * });
  * ```
  */
-export const Routing = Resource<Routing>("Cloudflare.Email.Routing");
+export const Routing = Resource<Routing>("Cloudflare.Email.Routing", {
+  aliases: ["Cloudflare.EmailRouting"],
+});
 
 const resolve = Effect.fn(function* (zone: Reference) {
   const { accountId } = yield* yield* CloudflareEnvironment;

--- a/packages/alchemy/src/Cloudflare/Email/Rule.ts
+++ b/packages/alchemy/src/Cloudflare/Email/Rule.ts
@@ -84,7 +84,9 @@ export type Rule = Resource<
  * });
  * ```
  */
-export const Rule = Resource<Rule>("Cloudflare.Email.Rule");
+export const Rule = Resource<Rule>("Cloudflare.Email.Rule", {
+  aliases: ["Cloudflare.EmailRule"],
+});
 
 export const RuleProvider = () =>
   Provider.succeed(Rule, {

--- a/packages/alchemy/src/Cloudflare/Email/SendingSubdomain.ts
+++ b/packages/alchemy/src/Cloudflare/Email/SendingSubdomain.ts
@@ -113,6 +113,7 @@ export type SendingSubdomain = Resource<
  */
 export const SendingSubdomain = Resource<SendingSubdomain>(
   SendingSubdomainTypeId,
+  { aliases: ["Cloudflare.EmailSendingSubdomain"] },
 );
 
 /**

--- a/packages/alchemy/src/Cloudflare/Email/TrustedDomain.ts
+++ b/packages/alchemy/src/Cloudflare/Email/TrustedDomain.ts
@@ -106,6 +106,7 @@ export type TrustedDomain = Resource<
  */
 export const TrustedDomain = Resource<TrustedDomain>(
   EmailSecurityTrustedDomainTypeId,
+  { aliases: ["Cloudflare.EmailSecurity.TrustedDomain"] },
 );
 
 /**

--- a/packages/alchemy/src/Cloudflare/Fraud/DetectionSettings.ts
+++ b/packages/alchemy/src/Cloudflare/Fraud/DetectionSettings.ts
@@ -157,7 +157,9 @@ export type DetectionSettings = Resource<
  *
  * @see https://developers.cloudflare.com/bots/additional-configurations/fraud-detection/
  */
-export const DetectionSettings = Resource<DetectionSettings>(TypeId);
+export const DetectionSettings = Resource<DetectionSettings>(TypeId, {
+  aliases: ["Cloudflare.FraudDetectionSettings"],
+});
 
 /**
  * Returns true if the given value is a DetectionSettings resource.

--- a/packages/alchemy/src/Cloudflare/GoogleTagGateway/GoogleTagGateway.ts
+++ b/packages/alchemy/src/Cloudflare/GoogleTagGateway/GoogleTagGateway.ts
@@ -129,7 +129,9 @@ export type GoogleTagGateway = Resource<
  *
  * @see https://developers.cloudflare.com/google-tag-gateway/
  */
-export const GoogleTagGateway = Resource<GoogleTagGateway>(TypeId);
+export const GoogleTagGateway = Resource<GoogleTagGateway>(TypeId, {
+  aliases: ["Cloudflare.GoogleTagGateway"],
+});
 
 /**
  * Returns true if the given value is a GoogleTagGateway resource.

--- a/packages/alchemy/src/Cloudflare/Healthcheck/Healthcheck.ts
+++ b/packages/alchemy/src/Cloudflare/Healthcheck/Healthcheck.ts
@@ -293,7 +293,9 @@ export type Healthcheck = Resource<TypeId, Props, Attributes, never, Providers>;
  *
  * @see https://developers.cloudflare.com/health-checks/
  */
-export const Healthcheck = Resource<Healthcheck>(TypeId);
+export const Healthcheck = Resource<Healthcheck>(TypeId, {
+  aliases: ["Cloudflare.Healthcheck"],
+});
 
 /**
  * Returns true if the given value is a Healthcheck resource.

--- a/packages/alchemy/src/Cloudflare/HostnameTlsSetting/HostnameTlsSetting.ts
+++ b/packages/alchemy/src/Cloudflare/HostnameTlsSetting/HostnameTlsSetting.ts
@@ -150,7 +150,9 @@ export type HostnameTlsSetting = Resource<
  * @see https://developers.cloudflare.com/ssl/edge-certificates/additional-options/custom-metadata/
  * @see https://developers.cloudflare.com/api/resources/hostnames/subresources/settings/subresources/tls/
  */
-export const HostnameTlsSetting = Resource<HostnameTlsSetting>(TypeId);
+export const HostnameTlsSetting = Resource<HostnameTlsSetting>(TypeId, {
+  aliases: ["Cloudflare.HostnameTlsSetting"],
+});
 
 /**
  * Returns true if the given value is a HostnameTlsSetting resource.

--- a/packages/alchemy/src/Cloudflare/KV/Namespace.ts
+++ b/packages/alchemy/src/Cloudflare/KV/Namespace.ts
@@ -67,7 +67,9 @@ export type Namespace = Resource<
  * / `Cloudflare.KV.WriteNamespace` for least-privilege read- or
  * write-only access.
  */
-export const Namespace = Resource<Namespace>("Cloudflare.KV.Namespace");
+export const Namespace = Resource<Namespace>("Cloudflare.KV.Namespace", {
+  aliases: ["Cloudflare.KVNamespace"],
+});
 
 export const NamespaceProvider = () =>
   Provider.succeed(Namespace, {

--- a/packages/alchemy/src/Cloudflare/KeylessCertificate/KeylessCertificate.ts
+++ b/packages/alchemy/src/Cloudflare/KeylessCertificate/KeylessCertificate.ts
@@ -214,7 +214,9 @@ export type KeylessCertificate = Resource<
  *
  * @see https://developers.cloudflare.com/ssl/keyless-ssl/
  */
-export const KeylessCertificate = Resource<KeylessCertificate>(TypeId);
+export const KeylessCertificate = Resource<KeylessCertificate>(TypeId, {
+  aliases: ["Cloudflare.KeylessCertificate"],
+});
 
 /**
  * Returns true if the given value is a KeylessCertificate resource.

--- a/packages/alchemy/src/Cloudflare/LeakedCredentialCheck/LeakedCredentialCheck.ts
+++ b/packages/alchemy/src/Cloudflare/LeakedCredentialCheck/LeakedCredentialCheck.ts
@@ -91,7 +91,9 @@ export type LeakedCredentialCheck = Resource<
  *
  * @see https://developers.cloudflare.com/waf/detections/leaked-credentials/
  */
-export const LeakedCredentialCheck = Resource<LeakedCredentialCheck>(TypeId);
+export const LeakedCredentialCheck = Resource<LeakedCredentialCheck>(TypeId, {
+  aliases: ["Cloudflare.LeakedCredentialCheck"],
+});
 
 /**
  * Returns true if the given value is a LeakedCredentialCheck resource.

--- a/packages/alchemy/src/Cloudflare/LoadBalancer/LoadBalancer.ts
+++ b/packages/alchemy/src/Cloudflare/LoadBalancer/LoadBalancer.ts
@@ -239,7 +239,9 @@ export type LoadBalancer = Resource<
  *
  * @see https://developers.cloudflare.com/load-balancing/
  */
-export const LoadBalancer = Resource<LoadBalancer>(TypeId);
+export const LoadBalancer = Resource<LoadBalancer>(TypeId, {
+  aliases: ["Cloudflare.LoadBalancer"],
+});
 
 /**
  * Returns true if the given value is a LoadBalancer resource.

--- a/packages/alchemy/src/Cloudflare/ManagedTransforms/ManagedTransforms.ts
+++ b/packages/alchemy/src/Cloudflare/ManagedTransforms/ManagedTransforms.ts
@@ -172,7 +172,9 @@ export type ManagedTransforms = Resource<
  *
  * @see https://developers.cloudflare.com/rules/transform/managed-transforms/
  */
-export const ManagedTransforms = Resource<ManagedTransforms>(TypeId);
+export const ManagedTransforms = Resource<ManagedTransforms>(TypeId, {
+  aliases: ["Cloudflare.ManagedTransforms"],
+});
 
 /**
  * Returns true if the given value is a ManagedTransforms resource.

--- a/packages/alchemy/src/Cloudflare/MtlsCertificate/MtlsCertificate.ts
+++ b/packages/alchemy/src/Cloudflare/MtlsCertificate/MtlsCertificate.ts
@@ -167,7 +167,9 @@ export type MtlsCertificate = Resource<
  *
  * @see https://developers.cloudflare.com/ssl/client-certificates/
  */
-export const MtlsCertificate = Resource<MtlsCertificate>(TypeId);
+export const MtlsCertificate = Resource<MtlsCertificate>(TypeId, {
+  aliases: ["Cloudflare.MtlsCertificate"],
+});
 
 /**
  * Returns true if the given value is a MtlsCertificate resource.

--- a/packages/alchemy/src/Cloudflare/Organization/Organization.ts
+++ b/packages/alchemy/src/Cloudflare/Organization/Organization.ts
@@ -183,7 +183,9 @@ export type Organization = Resource<
  *
  * @see https://developers.cloudflare.com/fundamentals/setup/manage-organizations/
  */
-export const Organization = Resource<Organization>(TypeId);
+export const Organization = Resource<Organization>(TypeId, {
+  aliases: ["Cloudflare.Organization"],
+});
 
 /**
  * Returns true if the given value is an Organization resource.

--- a/packages/alchemy/src/Cloudflare/OriginCaCertificate/OriginCaCertificate.ts
+++ b/packages/alchemy/src/Cloudflare/OriginCaCertificate/OriginCaCertificate.ts
@@ -145,7 +145,9 @@ export type OriginCaCertificate = Resource<
  *
  * @see https://developers.cloudflare.com/ssl/origin-configuration/origin-ca/
  */
-export const OriginCaCertificate = Resource<OriginCaCertificate>(TypeId);
+export const OriginCaCertificate = Resource<OriginCaCertificate>(TypeId, {
+  aliases: ["Cloudflare.OriginCaCertificate"],
+});
 
 /**
  * Returns true if the given value is an OriginCaCertificate resource.

--- a/packages/alchemy/src/Cloudflare/OriginPostQuantumEncryption/OriginPostQuantumEncryption.ts
+++ b/packages/alchemy/src/Cloudflare/OriginPostQuantumEncryption/OriginPostQuantumEncryption.ts
@@ -113,7 +113,9 @@ export type OriginPostQuantumEncryption = Resource<
  * @see https://developers.cloudflare.com/ssl/origin-configuration/pqc-to-origin/
  */
 export const OriginPostQuantumEncryption =
-  Resource<OriginPostQuantumEncryption>(TypeId);
+  Resource<OriginPostQuantumEncryption>(TypeId, {
+    aliases: ["Cloudflare.OriginPostQuantumEncryption"],
+  });
 
 /**
  * Returns true if the given value is an OriginPostQuantumEncryption resource.

--- a/packages/alchemy/src/Cloudflare/PageRule/PageRule.ts
+++ b/packages/alchemy/src/Cloudflare/PageRule/PageRule.ts
@@ -170,7 +170,9 @@ export type PageRule = Resource<TypeId, Props, Attributes, never, Providers>;
  *
  * @see https://developers.cloudflare.com/rules/page-rules/
  */
-export const PageRule = Resource<PageRule>(TypeId);
+export const PageRule = Resource<PageRule>(TypeId, {
+  aliases: ["Cloudflare.PageRule"],
+});
 
 /**
  * Returns true if the given value is a PageRule resource.

--- a/packages/alchemy/src/Cloudflare/Queues/Consumer.ts
+++ b/packages/alchemy/src/Cloudflare/Queues/Consumer.ts
@@ -115,7 +115,9 @@ export type Consumer = Resource<
  * });
  * ```
  */
-export const Consumer = Resource<Consumer>("Cloudflare.Queues.Consumer");
+export const Consumer = Resource<Consumer>("Cloudflare.Queues.Consumer", {
+  aliases: ["Cloudflare.QueueConsumer"],
+});
 
 // Cloudflare allows a single Worker consumer per queue, so the
 // first match in the paginated stream is the only one. Using

--- a/packages/alchemy/src/Cloudflare/Queues/Queue.ts
+++ b/packages/alchemy/src/Cloudflare/Queues/Queue.ts
@@ -103,7 +103,9 @@ export type Queue = Resource<
  * );
  * ```
  */
-export const Queue = Resource<Queue>("Cloudflare.Queues.Queue");
+export const Queue = Resource<Queue>("Cloudflare.Queues.Queue", {
+  aliases: ["Cloudflare.Queue"],
+});
 
 export const ProviderLive = () =>
   Provider.succeed(Queue, {

--- a/packages/alchemy/src/Cloudflare/Queues/Subscription.ts
+++ b/packages/alchemy/src/Cloudflare/Queues/Subscription.ts
@@ -193,7 +193,9 @@ export type Subscription = Resource<
  *
  * @see https://developers.cloudflare.com/queues/event-subscriptions/
  */
-export const Subscription = Resource<Subscription>(TypeId);
+export const Subscription = Resource<Subscription>(TypeId, {
+  aliases: ["Cloudflare.Queue.Subscription"],
+});
 
 /**
  * Returns true if the given value is a Subscription resource.

--- a/packages/alchemy/src/Cloudflare/R2/Bucket.ts
+++ b/packages/alchemy/src/Cloudflare/R2/Bucket.ts
@@ -299,7 +299,9 @@ export type Bucket = Resource<
  * });
  * ```
  */
-export const Bucket = Resource<Bucket>("Cloudflare.R2.Bucket");
+export const Bucket = Resource<Bucket>("Cloudflare.R2.Bucket", {
+  aliases: ["Cloudflare.R2Bucket"],
+});
 
 export declare namespace Bucket {
   export type StorageClass = "Standard" | "InfrequentAccess";

--- a/packages/alchemy/src/Cloudflare/RegionalHostname/RegionalHostname.ts
+++ b/packages/alchemy/src/Cloudflare/RegionalHostname/RegionalHostname.ts
@@ -95,7 +95,9 @@ export type RegionalHostname = Resource<
  *
  * @see https://developers.cloudflare.com/data-localization/regional-services/
  */
-export const RegionalHostname = Resource<RegionalHostname>(TypeId);
+export const RegionalHostname = Resource<RegionalHostname>(TypeId, {
+  aliases: ["Cloudflare.RegionalHostname"],
+});
 
 /**
  * Returns true if the given value is a RegionalHostname resource.

--- a/packages/alchemy/src/Cloudflare/Ruleset/Ruleset.ts
+++ b/packages/alchemy/src/Cloudflare/Ruleset/Ruleset.ts
@@ -98,7 +98,9 @@ export type Ruleset = Resource<
  * });
  * ```
  */
-export const Ruleset = Resource<Ruleset>("Cloudflare.Ruleset.Ruleset")({});
+export const Ruleset = Resource<Ruleset>("Cloudflare.Ruleset.Ruleset", {
+  aliases: ["Cloudflare.Ruleset"],
+})({});
 
 export const RulesetProvider = () =>
   Provider.succeed(Ruleset, {

--- a/packages/alchemy/src/Cloudflare/SecurityTxt/SecurityTxt.ts
+++ b/packages/alchemy/src/Cloudflare/SecurityTxt/SecurityTxt.ts
@@ -150,7 +150,9 @@ export type SecurityTxt = Resource<TypeId, Props, Attributes, never, Providers>;
  *
  * @see https://developers.cloudflare.com/security-center/infrastructure/security-file/
  */
-export const SecurityTxt = Resource<SecurityTxt>(TypeId);
+export const SecurityTxt = Resource<SecurityTxt>(TypeId, {
+  aliases: ["Cloudflare.SecurityTxt"],
+});
 
 /**
  * Returns true if the given value is a SecurityTxt resource.

--- a/packages/alchemy/src/Cloudflare/Tunnel/Route.ts
+++ b/packages/alchemy/src/Cloudflare/Tunnel/Route.ts
@@ -114,7 +114,9 @@ export type Route = Resource<
  * });
  * ```
  */
-export const Route = Resource<Route>("Cloudflare.Tunnel.Route");
+export const Route = Resource<Route>("Cloudflare.Tunnel.Route", {
+  aliases: ["Cloudflare.TunnelRoute"],
+});
 
 export const RouteProvider = () =>
   Provider.succeed(Route, {

--- a/packages/alchemy/src/Cloudflare/Tunnel/Tunnel.ts
+++ b/packages/alchemy/src/Cloudflare/Tunnel/Tunnel.ts
@@ -150,7 +150,9 @@ export type Tunnel = Resource<
  * };
  * ```
  */
-export const Tunnel = Resource<Tunnel>("Cloudflare.Tunnel.Tunnel");
+export const Tunnel = Resource<Tunnel>("Cloudflare.Tunnel.Tunnel", {
+  aliases: ["Cloudflare.Tunnel"],
+});
 
 export const TunnelProvider = () =>
   Provider.succeed(Tunnel, {

--- a/packages/alchemy/src/Cloudflare/UrlNormalization/UrlNormalization.ts
+++ b/packages/alchemy/src/Cloudflare/UrlNormalization/UrlNormalization.ts
@@ -119,7 +119,9 @@ export type UrlNormalization = Resource<
  *
  * @see https://developers.cloudflare.com/rules/normalization/
  */
-export const UrlNormalization = Resource<UrlNormalization>(TypeId);
+export const UrlNormalization = Resource<UrlNormalization>(TypeId, {
+  aliases: ["Cloudflare.UrlNormalization"],
+});
 
 /**
  * Returns true if the given value is a UrlNormalization resource.

--- a/packages/alchemy/src/Cloudflare/VpcService/VpcService.ts
+++ b/packages/alchemy/src/Cloudflare/VpcService/VpcService.ts
@@ -122,6 +122,7 @@ export type VpcService = Resource<
  */
 export const VpcService = Resource<VpcService>(
   "Cloudflare.VpcService.VpcService",
+  { aliases: ["Cloudflare.VpcService"] },
 );
 
 const createServiceName = (id: string, name: string | undefined) =>

--- a/packages/alchemy/src/Cloudflare/WaitingRoom/WaitingRoom.ts
+++ b/packages/alchemy/src/Cloudflare/WaitingRoom/WaitingRoom.ts
@@ -290,7 +290,9 @@ export type WaitingRoom = Resource<TypeId, Props, Attributes, never, Providers>;
  *
  * @see https://developers.cloudflare.com/waiting-room/
  */
-export const WaitingRoom = Resource<WaitingRoom>(TypeId);
+export const WaitingRoom = Resource<WaitingRoom>(TypeId, {
+  aliases: ["Cloudflare.WaitingRoom"],
+});
 
 /**
  * Returns true if the given value is a WaitingRoom resource.

--- a/packages/alchemy/src/Cloudflare/Web3/ContentList.ts
+++ b/packages/alchemy/src/Cloudflare/Web3/ContentList.ts
@@ -136,7 +136,9 @@ export type HostnameContentList = Resource<
  *
  * @see https://developers.cloudflare.com/web3/
  */
-export const HostnameContentList = Resource<HostnameContentList>(TypeId);
+export const HostnameContentList = Resource<HostnameContentList>(TypeId, {
+  aliases: ["Cloudflare.Web3HostnameContentList"],
+});
 
 /**
  * Returns true if the given value is a HostnameContentList resource.

--- a/packages/alchemy/src/Cloudflare/Web3/Hostname.ts
+++ b/packages/alchemy/src/Cloudflare/Web3/Hostname.ts
@@ -143,7 +143,9 @@ export type Hostname = Resource<
  *
  * @see https://developers.cloudflare.com/web3/
  */
-export const Hostname = Resource<Hostname>(TypeId);
+export const Hostname = Resource<Hostname>(TypeId, {
+  aliases: ["Cloudflare.Web3Hostname"],
+});
 
 /**
  * Returns true if the given value is a Hostname resource.

--- a/packages/alchemy/src/Cloudflare/Zaraz/Config.ts
+++ b/packages/alchemy/src/Cloudflare/Zaraz/Config.ts
@@ -185,7 +185,9 @@ export type ConfigAttributes = {
  * ```
  */
 export const Config = Object.assign(
-  Resource<Config>("Cloudflare.Zaraz.Config"),
+  Resource<Config>("Cloudflare.Zaraz.Config", {
+    aliases: ["Cloudflare.ZarazConfig"],
+  }),
   {
     /**
      * Define a type-only contract for the events sent through this Zaraz config.

--- a/packages/alchemy/src/Cloudflare/Zone/Zone.ts
+++ b/packages/alchemy/src/Cloudflare/Zone/Zone.ts
@@ -190,6 +190,7 @@ export type Zone = Resource<
  */
 export const Zone = Resource<Zone>("Cloudflare.Zone.Zone", {
   defaultRemovalPolicy: "retain",
+  aliases: ["Cloudflare.Zone"],
 });
 
 export const ZoneProvider = () =>

--- a/packages/alchemy/src/Provider.ts
+++ b/packages/alchemy/src/Provider.ts
@@ -103,6 +103,14 @@ export interface ProviderService<
    */
   version?: number;
   /**
+   * Legacy type names this provider also answers to. Copied from the
+   * resource class's `aliases` option by {@link succeed}/{@link effect} so
+   * state persisted under a pre-rename type (e.g. `"Cloudflare.Queue"`
+   * before the `"Cloudflare.Queues.Queue"` rename) still resolves to this
+   * provider via {@link tryFindProviderByType}.
+   */
+  aliases?: readonly string[];
+  /**
    * Account-wide teardown (`alchemy unsafe nuke`) behaviour. Providers whose
    * resources can't meaningfully be deleted opt out here so nuke doesn't
    * report an endless "deleted but still there" loop. `read`/import are
@@ -275,8 +283,14 @@ export const effect = <
     LifecycleServices
   >
 > =>
-  // @ts-expect-error
-  Layer.effect(Provider(cls.Type), eff) as any;
+  Layer.effect(
+    // @ts-expect-error
+    Provider(cls.Type),
+    Effect.map(eff, (service) => ({
+      aliases: "Aliases" in cls ? cls.Aliases : undefined,
+      ...service,
+    })),
+  ) as any;
 
 export const succeed = <
   R extends ResourceLike,
@@ -310,7 +324,10 @@ export const succeed = <
   >
 > =>
   // @ts-expect-error
-  Layer.succeed(Provider(cls.Type), service);
+  Layer.succeed(Provider(cls.Type), {
+    aliases: "Aliases" in cls ? cls.Aliases : undefined,
+    ...service,
+  });
 
 export interface ProviderCollectionLike {
   kind: "ProviderCollection";
@@ -399,32 +416,18 @@ const isProviderCollectionService = (
 };
 
 /**
- * Legacy resource type names mapped to their canonical (current) type.
- *
- * Populated at module-load time by `Resource(type, { aliases })` — resource
- * classes are module-level constants, so every alias is registered before any
- * plan/apply runs. Lets state persisted under a renamed type (e.g.
- * `"Cloudflare.Queue"` from before the `"Cloudflare.Queues.Queue"` rename)
- * keep resolving to the provider registered under the canonical type.
+ * Structural check for a {@link ProviderService} living in the Effect
+ * context. Providers are keyed by their canonical resource type; when
+ * searching for a legacy alias, the tag key won't match, so lookup has to
+ * recognize provider services by shape.
  */
-const typeAliases = new Map<string, string>();
-
-/** @internal registers legacy type-name aliases for a canonical resource type. */
-export const registerTypeAliases = (
-  canonicalType: string,
-  aliases: readonly string[],
-) => {
-  for (const alias of aliases) {
-    typeAliases.set(alias, canonicalType);
-  }
-};
-
-/**
- * Resolves a possibly-legacy resource type name to its canonical type.
- * Returns the input unchanged when it is not a registered alias.
- */
-export const resolveTypeAlias = (resourceType: string): string =>
-  typeAliases.get(resourceType) ?? resourceType;
+const isProviderService = (value: unknown): value is ProviderService =>
+  typeof value === "object" &&
+  value !== null &&
+  "reconcile" in value &&
+  typeof (value as ProviderService).reconcile === "function" &&
+  "delete" in value &&
+  typeof (value as ProviderService).delete === "function";
 
 export const findProviderByType: {
   <R extends ResourceLike>(
@@ -458,38 +461,42 @@ export const tryFindProviderByType: {
     resourceType: R["Type"],
   ): Effect.Effect<Option.Option<ProviderService<R>>>;
 } = Effect.fn(function* <R extends ResourceLike>(resourceType: R["Type"]) {
-  const lookup = Effect.fn(function* (type: string) {
-    const Tag = Provider<R>(type) as unknown as Context.Service<
-      Provider<R>,
-      any
-    >;
-    const direct = yield* Effect.serviceOption(Tag);
-    if (Option.isSome(direct)) {
-      return direct;
-    }
+  const Tag = Provider<R>(resourceType) as unknown as Context.Service<
+    Provider<R>,
+    any
+  >;
+  const direct = yield* Effect.serviceOption(Tag);
+  if (Option.isSome(direct)) {
+    return direct;
+  }
 
-    const context = yield* Effect.context<never>();
-    for (const value of context.mapUnsafe.values()) {
-      if (isProviderCollectionService(value)) {
-        const provider = value.get(type);
-        if (provider) {
+  const context = yield* Effect.context<never>();
+  for (const value of context.mapUnsafe.values()) {
+    if (isProviderCollectionService(value)) {
+      const provider = value.get(resourceType);
+      if (provider) {
+        return Option.some(provider);
+      }
+    }
+  }
+
+  // State persisted before a type rename carries the legacy name, so no
+  // provider is keyed under it. Fall back to a provider that declares the
+  // name in its `aliases` — scanning both bare Provider layers and the
+  // members of every ProviderCollection.
+  for (const value of context.mapUnsafe.values()) {
+    if (isProviderCollectionService(value)) {
+      for (const provider of Object.values(value.providers)) {
+        if (provider.aliases?.includes(resourceType)) {
           return Option.some(provider);
         }
       }
+    } else if (
+      isProviderService(value) &&
+      value.aliases?.includes(resourceType)
+    ) {
+      return Option.some(value);
     }
-    return Option.none<ProviderService>();
-  });
-
-  const found = yield* lookup(resourceType);
-  if (Option.isSome(found)) {
-    return found;
-  }
-  // State persisted before a type rename carries the legacy name — fall back
-  // to the canonical type it aliases (works for both bare Provider layers and
-  // ProviderCollections, since both are retried by `lookup`).
-  const canonical = resolveTypeAlias(resourceType);
-  if (canonical !== resourceType) {
-    return yield* lookup(canonical);
   }
   return Option.none();
 }) as any;

--- a/packages/alchemy/src/Provider.ts
+++ b/packages/alchemy/src/Provider.ts
@@ -398,6 +398,34 @@ const isProviderCollectionService = (
   );
 };
 
+/**
+ * Legacy resource type names mapped to their canonical (current) type.
+ *
+ * Populated at module-load time by `Resource(type, { aliases })` — resource
+ * classes are module-level constants, so every alias is registered before any
+ * plan/apply runs. Lets state persisted under a renamed type (e.g.
+ * `"Cloudflare.Queue"` from before the `"Cloudflare.Queues.Queue"` rename)
+ * keep resolving to the provider registered under the canonical type.
+ */
+const typeAliases = new Map<string, string>();
+
+/** @internal registers legacy type-name aliases for a canonical resource type. */
+export const registerTypeAliases = (
+  canonicalType: string,
+  aliases: readonly string[],
+) => {
+  for (const alias of aliases) {
+    typeAliases.set(alias, canonicalType);
+  }
+};
+
+/**
+ * Resolves a possibly-legacy resource type name to its canonical type.
+ * Returns the input unchanged when it is not a registered alias.
+ */
+export const resolveTypeAlias = (resourceType: string): string =>
+  typeAliases.get(resourceType) ?? resourceType;
+
 export const findProviderByType: {
   <R extends ResourceLike>(
     resourceType: R["Type"],
@@ -430,23 +458,38 @@ export const tryFindProviderByType: {
     resourceType: R["Type"],
   ): Effect.Effect<Option.Option<ProviderService<R>>>;
 } = Effect.fn(function* <R extends ResourceLike>(resourceType: R["Type"]) {
-  const Tag = Provider<R>(resourceType) as unknown as Context.Service<
-    Provider<R>,
-    any
-  >;
-  const direct = yield* Effect.serviceOption(Tag);
-  if (Option.isSome(direct)) {
-    return direct;
-  }
+  const lookup = Effect.fn(function* (type: string) {
+    const Tag = Provider<R>(type) as unknown as Context.Service<
+      Provider<R>,
+      any
+    >;
+    const direct = yield* Effect.serviceOption(Tag);
+    if (Option.isSome(direct)) {
+      return direct;
+    }
 
-  const context = yield* Effect.context<never>();
-  for (const value of context.mapUnsafe.values()) {
-    if (isProviderCollectionService(value)) {
-      const provider = value.get(resourceType);
-      if (provider) {
-        return Option.some(provider);
+    const context = yield* Effect.context<never>();
+    for (const value of context.mapUnsafe.values()) {
+      if (isProviderCollectionService(value)) {
+        const provider = value.get(type);
+        if (provider) {
+          return Option.some(provider);
+        }
       }
     }
+    return Option.none<ProviderService>();
+  });
+
+  const found = yield* lookup(resourceType);
+  if (Option.isSome(found)) {
+    return found;
+  }
+  // State persisted before a type rename carries the legacy name — fall back
+  // to the canonical type it aliases (works for both bare Provider layers and
+  // ProviderCollections, since both are retried by `lookup`).
+  const canonical = resolveTypeAlias(resourceType);
+  if (canonical !== resourceType) {
+    return yield* lookup(canonical);
   }
   return Option.none();
 }) as any;

--- a/packages/alchemy/src/Resource.ts
+++ b/packages/alchemy/src/Resource.ts
@@ -8,7 +8,7 @@ import { toFqn } from "./FQN.ts";
 import type { Input, InputProps } from "./Input.ts";
 import { CurrentNamespace, type NamespaceNode } from "./Namespace.ts";
 import * as Output from "./Output.ts";
-import { Provider } from "./Provider.ts";
+import { Provider, registerTypeAliases } from "./Provider.ts";
 import { ref as makeRef } from "./Ref.ts";
 import { RemovalPolicy } from "./RemovalPolicy.ts";
 import { Self } from "./Self.ts";
@@ -184,6 +184,23 @@ export interface ResourceOptions {
    * @default "destroy"
    */
   defaultRemovalPolicy?: RemovalPolicy["Service"];
+  /**
+   * Legacy type names this resource was previously registered under.
+   *
+   * When a resource type is renamed (e.g. `"Cloudflare.Queue"` →
+   * `"Cloudflare.Queues.Queue"`), state persisted under the old name must
+   * still resolve to this resource's provider. Listing the old names here
+   * makes provider lookup fall back from the legacy name to this type, so
+   * existing stacks keep planning, updating, and deleting cleanly across
+   * the rename. The state row migrates to the new type on its next write.
+   *
+   * ```ts
+   * export const Queue = Resource<Queue>("Cloudflare.Queues.Queue", {
+   *   aliases: ["Cloudflare.Queue"],
+   * });
+   * ```
+   */
+  aliases?: string[];
 }
 
 /**
@@ -199,6 +216,9 @@ export function Resource<R extends ResourceLike>(
   options?: ResourceOptions,
 ): ResourceClass<R> {
   const defaultRemovalPolicy = options?.defaultRemovalPolicy ?? "destroy";
+  if (options?.aliases?.length) {
+    registerTypeAliases(type, options.aliases);
+  }
   type Props = Input<R["Props"]>;
   const self = Self<R>(type);
   const constructor = (

--- a/packages/alchemy/src/Resource.ts
+++ b/packages/alchemy/src/Resource.ts
@@ -8,7 +8,7 @@ import { toFqn } from "./FQN.ts";
 import type { Input, InputProps } from "./Input.ts";
 import { CurrentNamespace, type NamespaceNode } from "./Namespace.ts";
 import * as Output from "./Output.ts";
-import { Provider, registerTypeAliases } from "./Provider.ts";
+import { Provider } from "./Provider.ts";
 import { ref as makeRef } from "./Ref.ts";
 import { RemovalPolicy } from "./RemovalPolicy.ts";
 import { Self } from "./Self.ts";
@@ -45,6 +45,13 @@ export interface ResourceClassLike<R extends ResourceLike> {
   Props: R["Props"];
   Self: Self<R>;
   Provider: Provider<R>;
+  /**
+   * Legacy type names this resource was previously registered under
+   * (see {@link ResourceOptions.aliases}). Copied onto the
+   * `ProviderService` by `Provider.succeed`/`Provider.effect` so provider
+   * lookup can resolve state persisted under a pre-rename type.
+   */
+  Aliases?: readonly string[];
 }
 
 export type ResourceClass<R extends ResourceLike> = ResourceConstructor<
@@ -54,6 +61,7 @@ export type ResourceClass<R extends ResourceLike> = ResourceConstructor<
   Effect.Effect<ResourceConstructor<R>> & {
     Self: Self<R>;
     Provider: Provider<R>;
+    Aliases: readonly string[] | undefined;
     ref(
       id: string,
       options?: { stage?: string; stack?: string },
@@ -70,6 +78,7 @@ export type ResourceClassWithMethods<
   Effect.Effect<ResourceConstructor<R>> & {
     Self: Self<R>;
     Provider: Provider<R>;
+    Aliases: readonly string[] | undefined;
     ref(
       id: string,
       options?: { stage?: string; stack?: string },
@@ -216,9 +225,6 @@ export function Resource<R extends ResourceLike>(
   options?: ResourceOptions,
 ): ResourceClass<R> {
   const defaultRemovalPolicy = options?.defaultRemovalPolicy ?? "destroy";
-  if (options?.aliases?.length) {
-    registerTypeAliases(type, options.aliases);
-  }
   type Props = Input<R["Props"]>;
   const self = Self<R>(type);
   const constructor = (
@@ -359,6 +365,7 @@ export function Resource<R extends ResourceLike>(
     Type: type,
     Provider: ProviderTag,
     Self: self,
+    Aliases: options?.aliases,
   };
 
   const ResourceClass = Object.assign(

--- a/packages/alchemy/test/apply.test.ts
+++ b/packages/alchemy/test/apply.test.ts
@@ -1,6 +1,7 @@
 import { Cli } from "@/Cli/Cli";
 import * as Namespace from "@/Namespace.ts";
 import * as Output from "@/Output";
+import * as Provider from "@/Provider";
 import * as RemovalPolicy from "@/RemovalPolicy.ts";
 import { Stack } from "@/Stack";
 import {
@@ -16,6 +17,9 @@ import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import {
+  AliasedWidget,
+  aliasedWidgetDeletes,
+  aliasedWidgetProvider,
   ArtifactProbe,
   BindingTarget,
   CollisionRegistry,
@@ -4813,4 +4817,123 @@ describe("Duration round-trip through state", () => {
         expect(Duration.toMillis(persisted.attr.computedTimeout)).toBe(16_000);
       }),
   );
+});
+
+describe("type aliases", () => {
+  // Simulate state written before a type rename: rewrite the persisted row's
+  // resourceType to the legacy name ("Test.Widget") that the canonical type
+  // ("Test.Widgets.Widget") carries as an alias.
+  const rewriteTypeToLegacy = Effect.fn(function* (fqn: string) {
+    const state = yield* yield* State;
+    const stk = yield* Stack;
+    const row = (yield* state.get({
+      stack: stk.name,
+      stage: stk.stage,
+      fqn,
+    })) as ResourceState;
+    expect(row.resourceType).toEqual("Test.Widgets.Widget");
+    yield* state.set({
+      stack: stk.name,
+      stage: stk.stage,
+      fqn,
+      value: { ...row, resourceType: "Test.Widget" },
+    });
+  });
+
+  describe("bare provider layer", () => {
+    const { test } = Test.make({
+      providers: Layer.mergeAll(TestLayers(), aliasedWidgetProvider()),
+    });
+
+    test.provider(
+      "a noop deploy migrates legacy-typed state to the canonical type",
+      (stack) =>
+        Effect.gen(function* () {
+          yield* Effect.gen(function* () {
+            yield* AliasedWidget("W1", { name: "w1" });
+          }).pipe(stack.deploy);
+
+          yield* rewriteTypeToLegacy("W1");
+
+          // Unchanged props plan as a noop — Apply must still rewrite the
+          // state row to the canonical type name.
+          yield* Effect.gen(function* () {
+            yield* AliasedWidget("W1", { name: "w1" });
+          }).pipe(stack.deploy);
+
+          const row = yield* getState("W1");
+          expect(row.resourceType).toEqual("Test.Widgets.Widget");
+          expect(row.status).toEqual("created");
+          expect(row.attr).toEqual({ name: "w1" });
+        }),
+    );
+
+    test.provider(
+      "orphan persisted under a legacy type name is deleted via alias",
+      (stack) =>
+        Effect.gen(function* () {
+          yield* Effect.gen(function* () {
+            yield* AliasedWidget("W2", { name: "w2" });
+          }).pipe(stack.deploy);
+
+          yield* rewriteTypeToLegacy("W2");
+
+          // Remove the resource from the stack — the orphan-deletion path
+          // resolves the provider from the legacy type via its alias.
+          yield* Effect.void.pipe(stack.deploy);
+
+          expect(aliasedWidgetDeletes).toContain("W2");
+          expect(yield* getState("W2")).toBeUndefined();
+        }),
+    );
+
+    test.provider(
+      "destroy resolves the provider for legacy-typed state via alias",
+      (stack) =>
+        Effect.gen(function* () {
+          yield* Effect.gen(function* () {
+            yield* AliasedWidget("W3", { name: "w3" });
+          }).pipe(stack.deploy);
+
+          yield* rewriteTypeToLegacy("W3");
+
+          yield* stack.destroy();
+
+          expect(aliasedWidgetDeletes).toContain("W3");
+          expect(yield* getState("W3")).toBeUndefined();
+        }),
+    );
+  });
+
+  describe("provider collection", () => {
+    class AliasApplyProviders extends Provider.ProviderCollection<AliasApplyProviders>()(
+      "Test.AliasApplyProviders",
+    ) {}
+
+    // The bare provider layer is consumed while building the collection and
+    // is NOT exported — lookup can only succeed through the collection.
+    const { test } = Test.make({
+      providers: Layer.effect(
+        AliasApplyProviders,
+        Provider.collection([AliasedWidget]),
+      ).pipe(Layer.provide(aliasedWidgetProvider())),
+    });
+
+    test.provider(
+      "orphan persisted under a legacy type name is deleted via alias",
+      (stack) =>
+        Effect.gen(function* () {
+          yield* Effect.gen(function* () {
+            yield* AliasedWidget("W4", { name: "w4" });
+          }).pipe(stack.deploy);
+
+          yield* rewriteTypeToLegacy("W4");
+
+          yield* Effect.void.pipe(stack.deploy);
+
+          expect(aliasedWidgetDeletes).toContain("W4");
+          expect(yield* getState("W4")).toBeUndefined();
+        }),
+    );
+  });
 });

--- a/packages/alchemy/test/plan.test.ts
+++ b/packages/alchemy/test/plan.test.ts
@@ -4,6 +4,7 @@ import type { Input, InputProps } from "@/Input";
 import * as Namespace from "@/Namespace.ts";
 import * as Output from "@/Output";
 import * as Plan from "@/Plan";
+import * as Provider from "@/Provider";
 import { UnsatisfiedResourceCycle } from "@/Plan";
 import type { ResourceBinding } from "@/Resource";
 import * as Stack from "@/Stack";
@@ -25,6 +26,8 @@ import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Redacted from "effect/Redacted";
 import {
+  AliasedWidget,
+  aliasedWidgetProvider,
   ArtifactProbe,
   BindingTarget,
   Bucket,
@@ -3221,4 +3224,106 @@ describe("StackRefExpr resolution", () => {
       }
     }),
   );
+});
+
+describe("type aliases", () => {
+  // State rows persisted before a type rename carry the legacy name
+  // ("Test.Widget"). Provider lookup must fall back to the canonical type
+  // ("Test.Widgets.Widget") via the alias declared on the resource.
+  const legacyWidgetState = (fqn: string): ResourceState => ({
+    instanceId,
+    providerVersion: 0,
+    logicalId: fqn,
+    fqn,
+    namespace: undefined,
+    resourceType: "Test.Widget",
+    status: "created",
+    props: {
+      name: "widget",
+    },
+    attr: {
+      name: "widget",
+    },
+    bindings: [],
+    downstream: [],
+  });
+
+  test(
+    "orphan persisted under a legacy type name plans a delete via alias",
+    Effect.gen(function* () {
+      yield* seed({ LegacyOrphan: legacyWidgetState("LegacyOrphan") });
+      expect(
+        yield* makePlan(Effect.void).pipe(
+          Effect.provide(aliasedWidgetProvider()),
+        ),
+      ).toMatchObject({
+        deletions: {
+          LegacyOrphan: {
+            action: "delete",
+            resource: {
+              LogicalId: "LegacyOrphan",
+              Type: "Test.Widget",
+            },
+          },
+        },
+      });
+    }),
+  );
+
+  test(
+    "declared resource with legacy-typed state plans as a noop update",
+    Effect.gen(function* () {
+      yield* seed({ MyWidget: legacyWidgetState("MyWidget") });
+      const plan = yield* makePlan(
+        Effect.gen(function* () {
+          yield* AliasedWidget("MyWidget", { name: "widget" });
+        }),
+      ).pipe(Effect.provide(aliasedWidgetProvider()));
+      expect(plan).toMatchObject({
+        resources: {
+          MyWidget: {
+            action: "noop",
+            state: {
+              resourceType: "Test.Widget",
+            },
+          },
+        },
+      });
+      expect(Object.keys(plan.deletions)).toEqual([]);
+    }),
+  );
+
+  describe("via provider collection", () => {
+    class AliasPlanProviders extends Provider.ProviderCollection<AliasPlanProviders>()(
+      "Test.AliasPlanProviders",
+    ) {}
+
+    // The bare provider layer is consumed while building the collection and
+    // is NOT exported — lookup can only succeed through the collection.
+    const widgetCollection = () =>
+      Layer.effect(
+        AliasPlanProviders,
+        Provider.collection([AliasedWidget]),
+      ).pipe(Layer.provide(aliasedWidgetProvider()));
+
+    test(
+      "orphan persisted under a legacy type name plans a delete via alias",
+      Effect.gen(function* () {
+        yield* seed({ LegacyOrphan: legacyWidgetState("LegacyOrphan") });
+        expect(
+          yield* makePlan(Effect.void).pipe(Effect.provide(widgetCollection())),
+        ).toMatchObject({
+          deletions: {
+            LegacyOrphan: {
+              action: "delete",
+              resource: {
+                LogicalId: "LegacyOrphan",
+                Type: "Test.Widget",
+              },
+            },
+          },
+        });
+      }),
+    );
+  });
 });

--- a/packages/alchemy/test/test.resources.ts
+++ b/packages/alchemy/test/test.resources.ts
@@ -951,6 +951,38 @@ export const deleteFirstResourceProvider = () =>
     }),
   });
 
+// AliasedWidget — a resource whose type was "renamed" from `Test.Widget` to
+// `Test.Widgets.Widget`. The legacy name is carried as an alias so state
+// persisted under the old type still resolves to this provider. Its provider
+// is intentionally NOT part of `TestLayers` — alias tests provide it as a
+// bare layer or wrapped in a `ProviderCollection` to exercise both lookup
+// paths in isolation.
+export interface AliasedWidget extends Resource<
+  "Test.Widgets.Widget",
+  { name?: string },
+  {
+    name: string;
+  }
+> {}
+
+export const AliasedWidget = Resource<AliasedWidget>("Test.Widgets.Widget", {
+  aliases: ["Test.Widget"],
+});
+
+/** Logical IDs whose provider `delete` ran — proves deletion went through the provider. */
+export const aliasedWidgetDeletes: string[] = [];
+
+export const aliasedWidgetProvider = () =>
+  Provider.succeed(AliasedWidget, {
+    list: () => Effect.succeed([]),
+    reconcile: Effect.fn(function* ({ id, news }) {
+      return { name: news?.name ?? id };
+    }),
+    delete: Effect.fn(function* ({ id }) {
+      aliasedWidgetDeletes.push(id);
+    }),
+  });
+
 // Layers
 export const TestLayers = () =>
   Layer.mergeAll(


### PR DESCRIPTION
Renaming a resource's type string (e.g. the beta.59 `Cloudflare.Queue` → `Cloudflare.Queues.Queue` namespace alignment) used to strand state persisted under the old name — provider lookup would die on the legacy type. Resources can now declare their former names as aliases:

```ts
export const Queue = Resource<Queue>("Cloudflare.Queues.Queue", {
  aliases: ["Cloudflare.Queue"],
});
```

- Aliases live on the resource class (`Queue.Aliases`); `Provider.succeed`/`Provider.effect` copy them onto the `ProviderService` (`aliases?: readonly string[]`). No global state.
- `tryFindProviderByType` resolves a legacy name by scanning context providers that declare it in their `aliases` — both bare `Provider` layers and `ProviderCollection` members. Plan, Apply, `logs`, and `tail` all resolve through it, so orphan deletion, destroy, and replacement chains work against legacy-typed state.
- Apply migrates state rows to the canonical name: create/update/replace already persist `node.resource.Type`, and the `noop` branch now rewrites the row when the persisted `resourceType` differs, so state stops depending on the alias after the next deploy.
- All 74 resources whose type string changed in beta.59 are annotated with their pre-rename alias (extracted by diffing every `Resource<...>(...)` type string — literal, multi-line, and `TypeId`-const forms — between `v2.0.0-beta.58` and `v2.0.0-beta.59`, with each pairing confirmed by file correspondence).

Tests in `plan.test.ts` (legacy-typed orphan plans a delete via alias; declared resource with legacy-typed state plans as noop, not replace) and `apply.test.ts` (noop deploy migrates the type name; orphan delete and destroy resolve the provider via alias), each covering both bare layers and a collection-only provider environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
