### PR TITLE
feat(cli): `alchemy sync` — reconcile state drift via read+reconcile

### DIFF
--- a/packages/alchemy/src/Cli/commands/sync.ts
+++ b/packages/alchemy/src/Cli/commands/sync.ts
@@ -1,0 +1,96 @@
+import * as ConfigProvider from "effect/ConfigProvider";
+import * as Console from "effect/Console";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Logger from "effect/Logger";
+import * as Option from "effect/Option";
+import * as Command from "effect/unstable/cli/Command";
+import * as Flag from "effect/unstable/cli/Flag";
+
+import { AdoptPolicy } from "../../AdoptPolicy.ts";
+import { ArtifactStore, createArtifactStore } from "../../Artifacts.ts";
+import { AuthProviders } from "../../Auth/AuthProvider.ts";
+import { withProfileOverride } from "../../Auth/Profile.ts";
+import { Stage } from "../../Stage.ts";
+import * as Sync from "../../Sync.ts";
+import { loadConfigProvider } from "../../Util/ConfigProvider.ts";
+import { fileLogger } from "../../Util/FileLogger.ts";
+
+import {
+  envFile,
+  importStack,
+  instrumentCommand,
+  profile,
+  script,
+  stage,
+} from "./_shared.ts";
+
+const dryRunFlag = Flag.boolean("dry-run").pipe(
+  Flag.withDescription(
+    "Detect and report drift without repairing it (no reconcile, no state writes)",
+  ),
+  Flag.withDefault(false),
+);
+
+export interface SyncArgs {
+  main: string;
+  stage: string;
+  envFile: Option.Option<string>;
+  profile?: string;
+  dryRun?: boolean;
+}
+
+export const execSync = Effect.fn(function* ({
+  main,
+  stage,
+  envFile,
+  profile,
+  dryRun = false,
+}: SyncArgs) {
+  const stackEffect = yield* importStack(main);
+
+  const services = Layer.mergeAll(
+    Layer.succeed(AdoptPolicy, false),
+    Layer.succeed(ArtifactStore, createArtifactStore()),
+    Layer.succeed(
+      AuthProviders,
+      yield* Effect.serviceOption(AuthProviders).pipe(
+        Effect.map(Option.getOrElse(() => ({}))),
+      ),
+    ),
+    ConfigProvider.layer(
+      withProfileOverride(yield* loadConfigProvider(envFile), profile),
+    ),
+    Logger.layer([fileLogger("out")], { mergeWithExisting: true }),
+    Layer.succeed(Stage, stage),
+  );
+
+  yield* Effect.gen(function* () {
+    const stack = yield* stackEffect;
+
+    yield* Effect.gen(function* () {
+      const result = yield* Sync.sync(
+        { name: stack.name, stage: stack.stage },
+        { dryRun },
+      );
+      yield* Console.log(Sync.printSync(result));
+    }).pipe(Effect.provide(stack.services));
+  }).pipe(Effect.provide(services));
+});
+
+export const syncCommand = Command.make(
+  "sync",
+  {
+    dryRun: dryRunFlag,
+    main: script,
+    envFile,
+    stage,
+    profile,
+  },
+  instrumentCommand("sync", (args: SyncArgs) => ({
+    "alchemy.stage": args.stage,
+    "alchemy.profile": args.profile,
+    "alchemy.main": args.main,
+    "alchemy.dry_run": !!args.dryRun,
+  }))(execSync),
+);

--- a/packages/alchemy/src/Cli/commands/sync.ts
+++ b/packages/alchemy/src/Cli/commands/sync.ts
@@ -1,5 +1,4 @@
 import * as ConfigProvider from "effect/ConfigProvider";
-import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Logger from "effect/Logger";
@@ -11,6 +10,7 @@ import { AdoptPolicy } from "../../AdoptPolicy.ts";
 import { ArtifactStore, createArtifactStore } from "../../Artifacts.ts";
 import { AuthProviders } from "../../Auth/AuthProvider.ts";
 import { withProfileOverride } from "../../Auth/Profile.ts";
+import * as CLI from "../../Cli/Cli.ts";
 import { Stage } from "../../Stage.ts";
 import * as Sync from "../../Sync.ts";
 import { loadConfigProvider } from "../../Util/ConfigProvider.ts";
@@ -23,6 +23,7 @@ import {
   profile,
   script,
   stage,
+  yes,
 } from "./_shared.ts";
 
 const dryRunFlag = Flag.boolean("dry-run").pipe(
@@ -38,6 +39,7 @@ export interface SyncArgs {
   envFile: Option.Option<string>;
   profile?: string;
   dryRun?: boolean;
+  yes?: boolean;
 }
 
 export const execSync = Effect.fn(function* ({
@@ -46,6 +48,7 @@ export const execSync = Effect.fn(function* ({
   envFile,
   profile,
   dryRun = false,
+  yes = false,
 }: SyncArgs) {
   const stackEffect = yield* importStack(main);
 
@@ -66,14 +69,37 @@ export const execSync = Effect.fn(function* ({
   );
 
   yield* Effect.gen(function* () {
+    const cli = yield* CLI.Cli;
     const stack = yield* stackEffect;
 
     yield* Effect.gen(function* () {
-      const result = yield* Sync.sync(
-        { name: stack.name, stage: stack.stage },
-        { dryRun },
+      // Detection pass: project the drift onto the engine's Plan shape so
+      // the CLI renders a sync exactly like a deploy plan (ink TUI when
+      // interactive, plain logging otherwise).
+      const { result, plan } = yield* Sync.plan({
+        name: stack.name,
+        stage: stack.stage,
+      });
+
+      if (dryRun) {
+        yield* cli.displayPlan(plan);
+        return;
+      }
+
+      const hasChanges = Object.values(result.resources).some(
+        (r) => r.action === "drifted" || r.action === "missing",
       );
-      yield* Console.log(Sync.printSync(result));
+      if (!yes && hasChanges) {
+        const approved = yield* cli.approvePlan(plan);
+        if (!approved) {
+          return;
+        }
+      }
+
+      // Repair pass: re-observes the cloud (rather than trusting the
+      // detection snapshot) and reports progress through the session.
+      const session = yield* cli.startApplySession(plan);
+      yield* Sync.sync({ name: stack.name, stage: stack.stage }, { session });
     }).pipe(Effect.provide(stack.services));
   }).pipe(Effect.provide(services));
 });
@@ -85,6 +111,7 @@ export const syncCommand = Command.make(
     main: script,
     envFile,
     stage,
+    yes,
     profile,
   },
   instrumentCommand("sync", (args: SyncArgs) => ({

--- a/packages/alchemy/src/Cli/main.ts
+++ b/packages/alchemy/src/Cli/main.ts
@@ -26,6 +26,7 @@ import { logsCommand } from "./commands/logs.ts";
 import { unsafeCommand } from "./commands/nuke.ts";
 import { profileCommand } from "./commands/profile.ts";
 import { stateCommand } from "./commands/state.ts";
+import { syncCommand } from "./commands/sync.ts";
 import { tailCommand } from "./commands/tail.ts";
 import { selectCli } from "./selectCli.ts";
 
@@ -42,6 +43,7 @@ const root = Command.make("alchemy", {}).pipe(
     loginCommand,
     profileCommand,
     stateCommand,
+    syncCommand,
     unsafeCommand,
   ]),
 );

--- a/packages/alchemy/src/Sync.ts
+++ b/packages/alchemy/src/Sync.ts
@@ -1,0 +1,465 @@
+/** @effect-diagnostics anyUnknownInErrorContext:off */
+import * as Cause from "effect/Cause";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import { stripUnowned } from "./AdoptPolicy.ts";
+import {
+  Artifacts,
+  ArtifactStore,
+  createArtifactStore,
+  ensureArtifactStore,
+  makeScopedArtifacts,
+} from "./Artifacts.ts";
+import type { PlanStatusSession, ScopedPlanStatusSession } from "./Cli/Cli.ts";
+import { deepEqual } from "./Diff.ts";
+import { InstanceId } from "./InstanceId.ts";
+import { findProviderByType } from "./Provider.ts";
+import {
+  isActionState,
+  State,
+  type CreatedResourceState,
+  type ResourceState,
+  type UpdatedResourceState,
+} from "./State/index.ts";
+import { type ResourceOp, recordResourceOp } from "./Telemetry/Metrics.ts";
+
+/**
+ * The outcome of syncing a single resource.
+ *
+ * - `unchanged` — the observed cloud state matches the persisted attributes.
+ * - `drifted`   — (dry-run only) the cloud state diverged from the persisted
+ *                 attributes; a non-dry-run sync would repair it.
+ * - `missing`   — (dry-run only) the resource no longer exists in the cloud;
+ *                 a non-dry-run sync would recreate it.
+ * - `repaired`  — drift was detected and the resource was reconciled back to
+ *                 its desired (last-deployed) state.
+ * - `recreated` — the resource was missing from the cloud and was reconciled
+ *                 from scratch, reusing the persisted instance id so
+ *                 deterministic physical names converge to the same values.
+ * - `skipped`   — the resource was not synced; see `reason` (provider has no
+ *                 `read`, or the persisted status is not stable).
+ */
+export type SyncAction =
+  | "unchanged"
+  | "drifted"
+  | "missing"
+  | "repaired"
+  | "recreated"
+  | "skipped";
+
+export interface SyncResourceResult {
+  fqn: string;
+  logicalId: string;
+  resourceType: string;
+  action: SyncAction;
+  /** Why the resource was skipped (only set when `action === "skipped"`). */
+  reason?: string;
+  /**
+   * The resource's attributes after the sync: the reconciled attributes for
+   * `repaired`/`recreated`, the observed cloud attributes for `drifted`, and
+   * the persisted attributes for `unchanged`. Unset for `missing`/`skipped`.
+   */
+  attr?: any;
+}
+
+export interface SyncResult {
+  resources: Record<string, SyncResourceResult>;
+}
+
+export interface SyncOptions {
+  /**
+   * Detect and report drift without repairing it. No provider `reconcile`
+   * runs and no state is persisted — resources report `drifted`/`missing`
+   * instead of `repaired`/`recreated`.
+   */
+  dryRun?: boolean;
+  /** Optional progress session (the CLI passes one; tests usually don't). */
+  session?: PlanStatusSession;
+}
+
+const noopSession: PlanStatusSession = {
+  emit: () => Effect.void,
+  done: () => Effect.void,
+};
+
+/**
+ * Reconcile state drift for every resource persisted under `stack`/`stage`.
+ *
+ * Unlike `deploy` (which converges the cloud to a *new* desired state
+ * computed from the stack program), `sync` converges the cloud back to the
+ * *last-deployed* desired state recorded in the state store. It needs no
+ * stack program — only the state store and the resource providers.
+ *
+ * The algorithm, per resource, is observe → compare → converge:
+ *
+ * 1. **Read** — call `provider.read` with the persisted props/attributes to
+ *    observe the live cloud state.
+ * 2. **Compare** — deep-compare the observed attributes against the
+ *    persisted attributes. Equal ⇒ `unchanged`.
+ * 3. **Reconcile** — on drift, call `provider.reconcile` with the persisted
+ *    props as the desired state (`news`) and the *observed* attributes as
+ *    `output`, so the provider diffs against reality rather than a stale
+ *    snapshot. When the resource is missing entirely, reconcile runs
+ *    greenfield (`olds`/`output` undefined) under the *same* instance id so
+ *    deterministic physical names regenerate identically.
+ * 4. **Persist** — write the fresh attributes back to the state store.
+ *
+ * Resources are synced concurrently and independently — persisted props are
+ * fully resolved values, so there are no upstream/downstream data edges to
+ * order by. A failure syncing one resource does not interrupt the others;
+ * all failures are aggregated into a single combined cause after every
+ * resource has been attempted.
+ *
+ * Resources that cannot be synced are reported as `skipped` rather than
+ * failing the run: providers without `read` (nothing to observe), and
+ * resources whose persisted status is not stable (`creating`, `updating`,
+ * `replacing`, `replaced`, `deleting`) — those represent an interrupted
+ * deploy and must be recovered by `deploy`, which owns replacement chains
+ * and dependency ordering. Action rows have no cloud state and are ignored.
+ */
+export const sync = (
+  stack: { name: string; stage: string },
+  options: SyncOptions = {},
+): Effect.Effect<SyncResult, any, State> =>
+  Effect.gen(function* () {
+    const state = yield* yield* State;
+    const session = options.session ?? noopSession;
+    const stackName = stack.name;
+    const stage = stack.stage;
+    const dryRun = options.dryRun ?? false;
+
+    const syncResource = Effect.fn("sync.resource")(function* (fqn: string) {
+      const persisted = yield* state.get({ stack: stackName, stage, fqn });
+      // Action rows have no cloud state to drift.
+      if (!persisted || isActionState(persisted)) {
+        return undefined;
+      }
+      const old = persisted as ResourceState;
+      const { logicalId, instanceId, resourceType, namespace } = old;
+
+      const result = (
+        partial: Pick<SyncResourceResult, "action" | "reason" | "attr">,
+      ): SyncResourceResult => ({
+        fqn,
+        logicalId,
+        resourceType,
+        ...partial,
+      });
+
+      if (old.status !== "created" && old.status !== "updated") {
+        // Anything mid-flight (or with a pending replacement chain) belongs
+        // to `deploy`'s recovery machinery — replacement generations and
+        // dependency ordering are not sync's to drive.
+        return result({
+          action: "skipped",
+          reason:
+            old.status === "replaced" || old.status === "replacing"
+              ? `resource has a pending replacement (status '${old.status}'); run deploy to finish it`
+              : `resource status '${old.status}' is not stable; run deploy to recover`,
+        });
+      }
+
+      const provider = yield* findProviderByType(resourceType);
+      if (!provider.read) {
+        return result({
+          action: "skipped",
+          reason: `provider '${resourceType}' does not implement read`,
+        });
+      }
+
+      const scopedSession = {
+        ...session,
+        note: (note: string) =>
+          session.emit({ id: logicalId, kind: "annotate", message: note }),
+      } satisfies ScopedPlanStatusSession;
+
+      const report = (
+        status: "updating" | "updated" | "creating" | "created",
+      ) =>
+        session.emit({
+          kind: "status-change",
+          id: logicalId,
+          type: resourceType,
+          status,
+        });
+
+      const commit = (value: Omit<ResourceState, "namespace">) =>
+        state.set({
+          stack: stackName,
+          stage,
+          fqn,
+          value: { ...value, namespace } as ResourceState,
+        });
+
+      const observed = yield* provider
+        .read({
+          id: logicalId,
+          instanceId,
+          olds: old.props as never,
+          output: old.attr as never,
+        })
+        .pipe(
+          instrumentLifecycle("read", fqn, resourceType, logicalId, instanceId),
+        );
+
+      // ── missing — recreate under the same instance id ──
+      if (observed === undefined) {
+        if (dryRun) {
+          return result({ action: "missing" });
+        }
+        yield* report("creating");
+        const attr = yield* provider
+          .reconcile({
+            id: logicalId,
+            instanceId,
+            news: old.props as never,
+            olds: undefined,
+            output: undefined,
+            session: scopedSession,
+            bindings: old.bindings as never,
+          })
+          .pipe(
+            instrumentLifecycle(
+              "create",
+              fqn,
+              resourceType,
+              logicalId,
+              instanceId,
+            ),
+          );
+        yield* commit({
+          status: "created",
+          fqn,
+          logicalId,
+          instanceId,
+          resourceType,
+          props: old.props!,
+          attr,
+          providerVersion: provider.version ?? 0,
+          bindings: old.bindings,
+          downstream: old.downstream,
+          removalPolicy: old.removalPolicy,
+        } satisfies Omit<CreatedResourceState, "namespace">);
+        yield* report("created");
+        return result({ action: "recreated", attr });
+      }
+
+      // `read` may brand the attributes as Unowned when ownership markers
+      // (tags) have drifted out from under us — the brand is a plan-time
+      // routing hint, never persisted, and here the state store already
+      // records the resource as ours. Tag drift then surfaces through the
+      // attribute comparison below and repairs like any other drift.
+      const live = stripUnowned(observed);
+
+      if (deepEqual(live, old.attr)) {
+        return result({ action: "unchanged", attr: old.attr });
+      }
+
+      if (dryRun) {
+        return result({ action: "drifted", attr: live });
+      }
+
+      // ── drifted — converge the cloud back to the last-deployed props ──
+      yield* report("updating");
+      const attr = yield* provider
+        .reconcile({
+          id: logicalId,
+          instanceId,
+          news: old.props as never,
+          olds: old.props as never,
+          // Hand reconcile the OBSERVED attributes, not the stale persisted
+          // snapshot, so its observed-vs-desired diffing works from reality.
+          output: live as never,
+          session: scopedSession,
+          bindings: old.bindings as never,
+        })
+        .pipe(
+          instrumentLifecycle(
+            "update",
+            fqn,
+            resourceType,
+            logicalId,
+            instanceId,
+          ),
+        );
+      yield* commit({
+        status: "updated",
+        fqn,
+        logicalId,
+        instanceId,
+        resourceType,
+        props: old.props!,
+        attr,
+        providerVersion: provider.version ?? 0,
+        bindings: old.bindings,
+        downstream: old.downstream,
+        removalPolicy: old.removalPolicy,
+      } satisfies Omit<UpdatedResourceState, "namespace">);
+      yield* report("updated");
+      return result({ action: "repaired", attr });
+    });
+
+    const fqns = yield* state.list({ stack: stackName, stage });
+
+    // Sync every resource even if some fail, then surface all failures as
+    // one combined cause (mirrors Apply's failure aggregation).
+    const failures: Cause.Cause<unknown>[] = [];
+    const results = yield* Effect.all(
+      fqns.map((fqn) =>
+        syncResource(fqn).pipe(
+          Effect.catchCause((cause) =>
+            Effect.gen(function* () {
+              failures.push(cause);
+              const persisted = yield* state
+                .get({ stack: stackName, stage, fqn })
+                .pipe(Effect.orElseSucceed(() => undefined));
+              if (persisted && !isActionState(persisted)) {
+                yield* session.emit({
+                  kind: "status-change",
+                  id: persisted.logicalId,
+                  type: persisted.resourceType,
+                  status: "fail",
+                });
+              }
+              return undefined;
+            }),
+          ),
+        ),
+      ),
+      { concurrency: "unbounded" },
+    );
+
+    yield* session.done();
+
+    if (failures.length > 0) {
+      return yield* Effect.failCause(
+        failures.reduce(Cause.combine) as Cause.Cause<never>,
+      );
+    }
+
+    return {
+      resources: Object.fromEntries(
+        results
+          .filter((r): r is SyncResourceResult => r !== undefined)
+          .map((r) => [r.fqn, r]),
+      ),
+    } satisfies SyncResult;
+  }).pipe(
+    ensureArtifactStore,
+    Effect.withSpan("sync", {
+      attributes: {
+        "alchemy.stack": stack.name,
+        "alchemy.stage": stack.stage,
+        "alchemy.dry_run": !!options.dryRun,
+      },
+    }),
+  );
+
+/**
+ * Same shape as Apply's lifecycle instrumentation: scoped artifacts +
+ * instance id, the resource op metrics, and a `provider.<op>` span.
+ */
+const instrumentLifecycle =
+  (
+    op: ResourceOp,
+    fqn: string,
+    resourceType: string,
+    logicalId: string,
+    instanceId: string,
+  ) =>
+  <A, E, R>(
+    effect: Effect.Effect<A, E, R>,
+  ): Effect.Effect<A, E, Exclude<R, InstanceId | Artifacts>> =>
+    Effect.serviceOption(ArtifactStore).pipe(
+      Effect.map(Option.getOrElse(createArtifactStore)),
+      Effect.flatMap((store) =>
+        effect.pipe(
+          Effect.provideService(Artifacts, makeScopedArtifacts(store, fqn)),
+          Effect.provideService(InstanceId, instanceId),
+        ),
+      ),
+      recordResourceOp(resourceType, op),
+      Effect.withSpan(`provider.${op}`, {
+        attributes: {
+          "alchemy.resource.fqn": fqn,
+          "alchemy.resource.type": resourceType,
+          "alchemy.resource.logical_id": logicalId,
+          "alchemy.resource.instance_id": instanceId,
+          "alchemy.resource.op": op,
+        },
+      }),
+    ) as Effect.Effect<A, E, Exclude<R, InstanceId | Artifacts>>;
+
+/**
+ * Print a sync result in a human-readable format.
+ */
+export const printSync = (result: SyncResult): string => {
+  const symbol = (action: SyncAction) => {
+    switch (action) {
+      case "unchanged":
+        return "=";
+      case "drifted":
+        return "!";
+      case "missing":
+        return "?";
+      case "repaired":
+        return "~";
+      case "recreated":
+        return "+";
+      case "skipped":
+        return "·";
+    }
+  };
+
+  const lines: string[] = [];
+  lines.push(
+    "┌─ Sync ─────────────────────────────────────────────────────────┐",
+  );
+  lines.push(
+    "│ Legend: = unchanged, ! drifted, ? missing, ~ repaired,         │",
+  );
+  lines.push(
+    "│         + recreated, · skipped                                 │",
+  );
+  lines.push(
+    "├────────────────────────────────────────────────────────────────┤",
+  );
+  const ids = Object.keys(result.resources).sort();
+  for (const id of ids) {
+    const r = result.resources[id];
+    const reason = r.reason ? ` — ${r.reason}` : "";
+    lines.push(
+      `│ [${symbol(r.action)}] ${id} (${r.resourceType}) ${r.action}${reason}`,
+    );
+  }
+  if (ids.length === 0) {
+    lines.push("│ (no resources)");
+  }
+  lines.push(
+    "└────────────────────────────────────────────────────────────────┘",
+  );
+
+  const counts = Object.values(result.resources).reduce(
+    (acc, r) => {
+      acc[r.action] = (acc[r.action] ?? 0) + 1;
+      return acc;
+    },
+    {} as Record<SyncAction, number>,
+  );
+  const summary = (
+    [
+      "unchanged",
+      "drifted",
+      "missing",
+      "repaired",
+      "recreated",
+      "skipped",
+    ] as const
+  )
+    .filter((a) => counts[a])
+    .map((a) => `${counts[a]} ${a}`)
+    .join(", ");
+  lines.push(summary === "" ? "Nothing to sync." : summary);
+
+  return lines.join("\n");
+};

--- a/packages/alchemy/src/Sync.ts
+++ b/packages/alchemy/src/Sync.ts
@@ -13,7 +13,9 @@ import {
 import type { PlanStatusSession, ScopedPlanStatusSession } from "./Cli/Cli.ts";
 import { deepEqual } from "./Diff.ts";
 import { InstanceId } from "./InstanceId.ts";
-import { findProviderByType } from "./Provider.ts";
+import type { Apply, Plan } from "./Plan.ts";
+import { findProviderByType, Provider } from "./Provider.ts";
+import type { ResourceLike } from "./Resource.ts";
 import {
   isActionState,
   State,
@@ -146,27 +148,6 @@ export const sync = (
         ...partial,
       });
 
-      if (old.status !== "created" && old.status !== "updated") {
-        // Anything mid-flight (or with a pending replacement chain) belongs
-        // to `deploy`'s recovery machinery — replacement generations and
-        // dependency ordering are not sync's to drive.
-        return result({
-          action: "skipped",
-          reason:
-            old.status === "replaced" || old.status === "replacing"
-              ? `resource has a pending replacement (status '${old.status}'); run deploy to finish it`
-              : `resource status '${old.status}' is not stable; run deploy to recover`,
-        });
-      }
-
-      const provider = yield* findProviderByType(resourceType);
-      if (!provider.read) {
-        return result({
-          action: "skipped",
-          reason: `provider '${resourceType}' does not implement read`,
-        });
-      }
-
       const scopedSession = {
         ...session,
         note: (note: string) =>
@@ -174,7 +155,7 @@ export const sync = (
       } satisfies ScopedPlanStatusSession;
 
       const report = (
-        status: "updating" | "updated" | "creating" | "created",
+        status: "updating" | "updated" | "creating" | "created" | "skipped",
       ) =>
         session.emit({
           kind: "status-change",
@@ -182,6 +163,34 @@ export const sync = (
           type: resourceType,
           status,
         });
+
+      // Surface the skip reason through the session (the TUI renders it as a
+      // note under the row; the logging CLI prints it) and settle the row
+      // with a terminal `skipped` status so it never shows as in-progress.
+      const skip = (reason: string) =>
+        Effect.gen(function* () {
+          yield* scopedSession.note(reason);
+          yield* report("skipped");
+          return result({ action: "skipped", reason });
+        });
+
+      if (old.status !== "created" && old.status !== "updated") {
+        // Anything mid-flight (or with a pending replacement chain) belongs
+        // to `deploy`'s recovery machinery — replacement generations and
+        // dependency ordering are not sync's to drive.
+        return yield* skip(
+          old.status === "replaced" || old.status === "replacing"
+            ? `resource has a pending replacement (status '${old.status}'); run deploy to finish it`
+            : `resource status '${old.status}' is not stable; run deploy to recover`,
+        );
+      }
+
+      const provider = yield* findProviderByType(resourceType);
+      if (!provider.read) {
+        return yield* skip(
+          `provider '${resourceType}' does not implement read`,
+        );
+      }
 
       const commit = (value: Omit<ResourceState, "namespace">) =>
         state.set({
@@ -390,76 +399,96 @@ const instrumentLifecycle =
       }),
     ) as Effect.Effect<A, E, Exclude<R, InstanceId | Artifacts>>;
 
+export interface SyncPlan {
+  /** Per-resource detection outcome (a dry-run {@link SyncResult}). */
+  result: SyncResult;
+  /**
+   * The detection outcome projected onto the engine's {@link Plan} shape so
+   * the CLI renders a sync exactly like a deploy plan (ink TUI when
+   * interactive, plain logging otherwise): `drifted` → `update`, `missing` →
+   * `create`, `unchanged`/`skipped` → `noop`.
+   */
+  plan: Plan;
+}
+
 /**
- * Print a sync result in a human-readable format.
+ * Run the drift-detection pass (a dry-run {@link sync}) and project the
+ * outcome onto a {@link Plan} for display/approval. The plan is a read-only
+ * view — repair happens by calling {@link sync} (without `dryRun`), which
+ * re-observes the cloud rather than trusting the detection snapshot.
  */
-export const printSync = (result: SyncResult): string => {
-  const symbol = (action: SyncAction) => {
-    switch (action) {
-      case "unchanged":
-        return "=";
-      case "drifted":
-        return "!";
-      case "missing":
-        return "?";
-      case "repaired":
-        return "~";
-      case "recreated":
-        return "+";
-      case "skipped":
-        return "·";
+export const plan = (stack: {
+  name: string;
+  stage: string;
+}): Effect.Effect<SyncPlan, any, State> =>
+  Effect.gen(function* () {
+    const result = yield* sync(stack, { dryRun: true });
+    const state = yield* yield* State;
+
+    const resources: Plan["resources"] = {};
+    for (const [fqn, r] of Object.entries(result.resources)) {
+      const persisted = yield* state.get({
+        stack: stack.name,
+        stage: stack.stage,
+        fqn,
+      });
+      if (!persisted || isActionState(persisted)) continue;
+      const provider = yield* findProviderByType(persisted.resourceType);
+      const action =
+        r.action === "drifted"
+          ? ("update" as const)
+          : r.action === "missing"
+            ? ("create" as const)
+            : ("noop" as const);
+      resources[fqn] = {
+        action,
+        props: persisted.props,
+        state: persisted,
+        provider,
+        // Synthetic ResourceLike reconstructed from persisted state, the
+        // same way Plan.make builds its deletion nodes.
+        resource: {
+          Namespace: persisted.namespace,
+          FQN: fqn,
+          LogicalId: persisted.logicalId,
+          Type: persisted.resourceType,
+          Attributes: persisted.attr,
+          Props: persisted.props,
+          Binding: undefined!,
+          Provider: Provider(persisted.resourceType),
+          RemovalPolicy: persisted.removalPolicy,
+          Adopt: undefined,
+          RuntimeContext: undefined!,
+          Providers: undefined,
+        } as ResourceLike,
+        // Sync repairs from the persisted bindings verbatim — surface them
+        // as noop rows so the renderer shows the binding topology without
+        // implying binding changes.
+        bindings: (persisted.bindings ?? []).map((binding) => ({
+          sid: binding.sid,
+          action: "noop" as const,
+          data: binding.data,
+        })),
+        downstream: persisted.downstream ?? [],
+      } as Apply;
     }
-  };
 
-  const lines: string[] = [];
-  lines.push(
-    "┌─ Sync ─────────────────────────────────────────────────────────┐",
+    return {
+      result,
+      plan: {
+        resources,
+        actions: {},
+        deletions: {},
+        actionDeletions: {},
+        output: undefined,
+        cycleMembers: new Set<string>(),
+      },
+    } satisfies SyncPlan;
+  }).pipe(
+    Effect.withSpan("sync.plan", {
+      attributes: {
+        "alchemy.stack": stack.name,
+        "alchemy.stage": stack.stage,
+      },
+    }),
   );
-  lines.push(
-    "│ Legend: = unchanged, ! drifted, ? missing, ~ repaired,         │",
-  );
-  lines.push(
-    "│         + recreated, · skipped                                 │",
-  );
-  lines.push(
-    "├────────────────────────────────────────────────────────────────┤",
-  );
-  const ids = Object.keys(result.resources).sort();
-  for (const id of ids) {
-    const r = result.resources[id];
-    const reason = r.reason ? ` — ${r.reason}` : "";
-    lines.push(
-      `│ [${symbol(r.action)}] ${id} (${r.resourceType}) ${r.action}${reason}`,
-    );
-  }
-  if (ids.length === 0) {
-    lines.push("│ (no resources)");
-  }
-  lines.push(
-    "└────────────────────────────────────────────────────────────────┘",
-  );
-
-  const counts = Object.values(result.resources).reduce(
-    (acc, r) => {
-      acc[r.action] = (acc[r.action] ?? 0) + 1;
-      return acc;
-    },
-    {} as Record<SyncAction, number>,
-  );
-  const summary = (
-    [
-      "unchanged",
-      "drifted",
-      "missing",
-      "repaired",
-      "recreated",
-      "skipped",
-    ] as const
-  )
-    .filter((a) => counts[a])
-    .map((a) => `${counts[a]} ${a}`)
-    .join(", ");
-  lines.push(summary === "" ? "Nothing to sync." : summary);
-
-  return lines.join("\n");
-};

--- a/packages/alchemy/src/index.ts
+++ b/packages/alchemy/src/index.ts
@@ -35,6 +35,7 @@ export * as Serverless from "./Serverless/index.ts";
 export { Stack } from "./Stack.ts";
 export * from "./Stage.ts";
 export { inMemoryState, localState } from "./State/index.ts";
+export * as Sync from "./Sync.ts";
 
 // Re-export internal types so they can be portably named in
 // downstream `.d.ts` emissions (fixes TS2883 in user files).

--- a/packages/alchemy/test/sync.test.ts
+++ b/packages/alchemy/test/sync.test.ts
@@ -1,0 +1,590 @@
+import { Unowned } from "@/AdoptPolicy";
+import { Stack } from "@/Stack";
+import { State, type ResourceState } from "@/State";
+import * as Sync from "@/Sync";
+import * as Test from "@/Test/Vitest";
+import { describe, expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Layer from "effect/Layer";
+import {
+  Bucket,
+  DriftResource,
+  makeTestCloud,
+  ResourceFailure,
+  TestCloud,
+  TestLayers,
+  TestResource,
+  TestResourceHooks,
+  failOn,
+  type TestCloudService,
+} from "./test.resources.ts";
+
+const { test } = Test.make({ providers: TestLayers() });
+
+const getState = Effect.fn(function* <S = ResourceState>(resourceId: string) {
+  const state = yield* yield* State;
+  const stk = yield* Stack;
+  return (yield* state.get({
+    stack: stk.name,
+    stage: stk.stage,
+    fqn: resourceId,
+  })) as S;
+});
+
+const seed = Effect.fn(function* (rows: Record<string, any>) {
+  const state = yield* yield* State;
+  const stk = yield* Stack;
+  for (const [fqn, value] of Object.entries(rows)) {
+    yield* state.set({ stack: stk.name, stage: stk.stage, fqn, value });
+  }
+});
+
+const runSync = (options?: Sync.SyncOptions) =>
+  Effect.gen(function* () {
+    const stk = yield* Stack;
+    return yield* Sync.sync({ name: stk.name, stage: stk.stage }, options);
+  });
+
+const withCloud =
+  (cloud: TestCloudService) =>
+  <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+    effect.pipe(Effect.provide(Layer.succeed(TestCloud, cloud)));
+
+const reconcileCalls = (cloud: TestCloudService) =>
+  cloud.calls.filter((c) => c.op === "reconcile").map((c) => c.id);
+
+const readCalls = (cloud: TestCloudService) =>
+  cloud.calls.filter((c) => c.op === "read").map((c) => c.id);
+
+const instanceId = "852f6ec2e19b66589825efe14dca2971";
+
+describe("drift detection and repair", () => {
+  test.provider(
+    "clean deployment: every resource is unchanged and reconcile is not invoked",
+    (stack) => {
+      const cloud = makeTestCloud();
+      return Effect.gen(function* () {
+        yield* stack.deploy(
+          Effect.gen(function* () {
+            yield* DriftResource("A", { value: "a" });
+            yield* DriftResource("B", { value: "b" });
+          }),
+        );
+
+        cloud.calls.length = 0;
+        const result = yield* runSync();
+
+        expect(result.resources).toMatchObject({
+          A: { action: "unchanged", resourceType: "Test.DriftResource" },
+          B: { action: "unchanged", resourceType: "Test.DriftResource" },
+        });
+        // sync observed both resources but touched neither
+        expect(readCalls(cloud).sort()).toEqual(["A", "B"]);
+        expect(reconcileCalls(cloud)).toEqual([]);
+        // cloud and state are untouched
+        expect(cloud.resources.get("A")).toMatchObject({ value: "a" });
+        expect((yield* getState("A"))?.status).toEqual("created");
+      }).pipe(withCloud(cloud));
+    },
+  );
+
+  test.provider(
+    "out-of-band value drift is repaired back to the desired state",
+    (stack) => {
+      const cloud = makeTestCloud();
+      return Effect.gen(function* () {
+        yield* stack.deploy(DriftResource("A", { value: "a" }));
+
+        // someone edits the resource in the console
+        cloud.resources.get("A")!.value = "hijacked";
+
+        cloud.calls.length = 0;
+        const result = yield* runSync();
+
+        expect(result.resources.A).toMatchObject({
+          action: "repaired",
+          attr: { value: "a" },
+        });
+        // cloud converged back to the last-deployed desired state
+        expect(cloud.resources.get("A")).toMatchObject({ value: "a" });
+        expect(reconcileCalls(cloud)).toEqual(["A"]);
+        // state refreshed with the reconciled attributes
+        expect(yield* getState("A")).toMatchObject({
+          status: "updated",
+          attr: { value: "a" },
+          props: { value: "a" },
+        });
+      }).pipe(withCloud(cloud));
+    },
+  );
+
+  test.provider("nested tag drift is detected and repaired", (stack) => {
+    const cloud = makeTestCloud();
+    return Effect.gen(function* () {
+      yield* stack.deploy(
+        DriftResource("A", { value: "a", tags: { team: "alchemy" } }),
+      );
+
+      // foreign tags appear and an owned tag is clobbered
+      cloud.resources.get("A")!.tags = { team: "intruder", extra: "tag" };
+
+      const result = yield* runSync();
+
+      expect(result.resources.A?.action).toEqual("repaired");
+      expect(cloud.resources.get("A")!.tags).toEqual({ team: "alchemy" });
+      expect((yield* getState("A"))?.attr?.tags).toEqual({ team: "alchemy" });
+    }).pipe(withCloud(cloud));
+  });
+
+  test.provider(
+    "a resource deleted out-of-band is recreated under the same instance id",
+    (stack) => {
+      const cloud = makeTestCloud();
+      return Effect.gen(function* () {
+        yield* stack.deploy(DriftResource("A", { value: "a" }));
+        const before = yield* getState("A");
+
+        // someone deletes the resource in the console
+        cloud.resources.delete("A");
+
+        const result = yield* runSync();
+
+        expect(result.resources.A).toMatchObject({
+          action: "recreated",
+          attr: { id: "A", value: "a" },
+        });
+        expect(cloud.resources.get("A")).toMatchObject({ value: "a" });
+        expect(yield* getState("A")).toMatchObject({
+          status: "created",
+          // same instance id so deterministic physical names converge
+          instanceId: before!.instanceId,
+          attr: { value: "a" },
+        });
+      }).pipe(withCloud(cloud));
+    },
+  );
+
+  test.provider("sync is idempotent", (stack) => {
+    const cloud = makeTestCloud();
+    return Effect.gen(function* () {
+      yield* stack.deploy(DriftResource("A", { value: "a" }));
+      cloud.resources.get("A")!.value = "hijacked";
+
+      const first = yield* runSync();
+      expect(first.resources.A?.action).toEqual("repaired");
+
+      cloud.calls.length = 0;
+      const second = yield* runSync();
+      expect(second.resources.A?.action).toEqual("unchanged");
+      expect(reconcileCalls(cloud)).toEqual([]);
+    }).pipe(withCloud(cloud));
+  });
+
+  test.provider(
+    "mixed fleet: only drifted and missing resources are reconciled",
+    (stack) => {
+      const cloud = makeTestCloud();
+      return Effect.gen(function* () {
+        yield* stack.deploy(
+          Effect.gen(function* () {
+            yield* DriftResource("Clean", { value: "clean" });
+            yield* DriftResource("Drifted", { value: "drifted" });
+            yield* DriftResource("Missing", { value: "missing" });
+          }),
+        );
+
+        cloud.resources.get("Drifted")!.value = "hijacked";
+        cloud.resources.delete("Missing");
+
+        cloud.calls.length = 0;
+        const result = yield* runSync();
+
+        expect(result.resources).toMatchObject({
+          Clean: { action: "unchanged" },
+          Drifted: { action: "repaired" },
+          Missing: { action: "recreated" },
+        });
+        expect(reconcileCalls(cloud).sort()).toEqual(["Drifted", "Missing"]);
+        expect(cloud.resources.get("Drifted")).toMatchObject({
+          value: "drifted",
+        });
+        expect(cloud.resources.get("Missing")).toMatchObject({
+          value: "missing",
+        });
+      }).pipe(withCloud(cloud));
+    },
+  );
+
+  test.provider("empty state: sync succeeds with no resources", () =>
+    Effect.gen(function* () {
+      const result = yield* runSync();
+      expect(result.resources).toEqual({});
+    }),
+  );
+
+  test.provider(
+    "a provider whose read reflects state back never drifts",
+    (stack) =>
+      Effect.gen(function* () {
+        // TestResource.read returns the persisted output when no hook is
+        // installed — the degenerate "cannot observe drift" case.
+        yield* stack.deploy(TestResource("A", { string: "test-string" }));
+        const result = yield* runSync();
+        expect(result.resources.A?.action).toEqual("unchanged");
+      }),
+  );
+});
+
+describe("dry run", () => {
+  test.provider(
+    "reports drift without repairing the cloud or touching state",
+    (stack) => {
+      const cloud = makeTestCloud();
+      return Effect.gen(function* () {
+        yield* stack.deploy(DriftResource("A", { value: "a" }));
+        cloud.resources.get("A")!.value = "hijacked";
+
+        cloud.calls.length = 0;
+        const result = yield* runSync({ dryRun: true });
+
+        expect(result.resources.A).toMatchObject({
+          action: "drifted",
+          // dry-run reports the OBSERVED (drifted) attributes
+          attr: { value: "hijacked" },
+        });
+        expect(reconcileCalls(cloud)).toEqual([]);
+        // neither the cloud nor the state store were touched
+        expect(cloud.resources.get("A")).toMatchObject({ value: "hijacked" });
+        expect(yield* getState("A")).toMatchObject({
+          status: "created",
+          attr: { value: "a" },
+        });
+      }).pipe(withCloud(cloud));
+    },
+  );
+
+  test.provider(
+    "reports missing resources without recreating them",
+    (stack) => {
+      const cloud = makeTestCloud();
+      return Effect.gen(function* () {
+        yield* stack.deploy(DriftResource("A", { value: "a" }));
+        cloud.resources.delete("A");
+
+        cloud.calls.length = 0;
+        const result = yield* runSync({ dryRun: true });
+
+        expect(result.resources.A?.action).toEqual("missing");
+        expect(reconcileCalls(cloud)).toEqual([]);
+        expect(cloud.resources.has("A")).toBe(false);
+        // state still remembers the last-deployed attributes
+        expect((yield* getState("A"))?.attr).toMatchObject({ value: "a" });
+      }).pipe(withCloud(cloud));
+    },
+  );
+
+  test.provider("reports unchanged resources as unchanged", (stack) => {
+    const cloud = makeTestCloud();
+    return Effect.gen(function* () {
+      yield* stack.deploy(DriftResource("A", { value: "a" }));
+      const result = yield* runSync({ dryRun: true });
+      expect(result.resources.A?.action).toEqual("unchanged");
+    }).pipe(withCloud(cloud));
+  });
+});
+
+describe("skipped resources", () => {
+  test.provider("a provider without read is skipped with a reason", (stack) =>
+    Effect.gen(function* () {
+      yield* stack.deploy(Bucket("MyBucket", { name: "test-bucket" }));
+
+      const result = yield* runSync();
+
+      expect(result.resources.MyBucket).toMatchObject({
+        action: "skipped",
+        resourceType: "Test.Bucket",
+      });
+      expect(result.resources.MyBucket?.reason).toContain("read");
+      // skipping is not destructive
+      expect((yield* getState("MyBucket"))?.status).toEqual("created");
+    }),
+  );
+
+  test.provider("resources stuck in a non-terminal status are skipped", () => {
+    const cloud = makeTestCloud();
+    return Effect.gen(function* () {
+      yield* seed({
+        Stuck: {
+          status: "creating",
+          fqn: "Stuck",
+          logicalId: "Stuck",
+          instanceId,
+          resourceType: "Test.DriftResource",
+          namespace: undefined,
+          providerVersion: 0,
+          props: { value: "v" },
+          bindings: [],
+          downstream: [],
+        },
+      });
+
+      const result = yield* runSync();
+
+      expect(result.resources.Stuck?.action).toEqual("skipped");
+      expect(result.resources.Stuck?.reason).toContain("creating");
+      // no lifecycle operation ran against the unstable resource
+      expect(cloud.calls).toEqual([]);
+    }).pipe(withCloud(cloud));
+  });
+
+  test.provider("resources with a pending replacement chain are skipped", () =>
+    Effect.gen(function* () {
+      const oldGeneration = {
+        status: "created",
+        fqn: "R",
+        logicalId: "R",
+        instanceId: "00000000000000000000000000000000",
+        resourceType: "Test.DriftResource",
+        namespace: undefined,
+        providerVersion: 0,
+        props: { value: "v1" },
+        attr: { id: "R", value: "v1", tags: {}, env: {} },
+        bindings: [],
+        downstream: [],
+      };
+      yield* seed({
+        R: {
+          status: "replaced",
+          fqn: "R",
+          logicalId: "R",
+          instanceId,
+          resourceType: "Test.DriftResource",
+          namespace: undefined,
+          providerVersion: 0,
+          props: { value: "v2" },
+          attr: { id: "R", value: "v2", tags: {}, env: {} },
+          bindings: [],
+          downstream: [],
+          deleteFirst: false,
+          old: oldGeneration,
+        },
+      });
+
+      const result = yield* runSync();
+
+      expect(result.resources.R?.action).toEqual("skipped");
+      expect(result.resources.R?.reason).toContain("replacement");
+    }),
+  );
+
+  test.provider("action state rows are ignored", (stack) => {
+    const cloud = makeTestCloud();
+    return Effect.gen(function* () {
+      yield* stack.deploy(DriftResource("A", { value: "a" }));
+      yield* seed({
+        MyTask: {
+          kind: "action",
+          status: "ran",
+          fqn: "MyTask",
+          logicalId: "MyTask",
+          actionType: "Test.Task",
+          namespace: undefined,
+          inputHash: "abc",
+          input: {},
+          output: { ok: true },
+          downstream: [],
+        },
+      });
+
+      const result = yield* runSync();
+
+      expect(result.resources.MyTask).toBeUndefined();
+      expect(result.resources.A?.action).toEqual("unchanged");
+      // the action row survives untouched
+      expect(yield* getState("MyTask")).toMatchObject({
+        kind: "action",
+        status: "ran",
+      });
+    }).pipe(withCloud(cloud));
+  });
+});
+
+describe("failures", () => {
+  test.provider(
+    "a failing repair does not prevent sibling repairs, and fails the sync",
+    (stack) => {
+      const cloud = makeTestCloud();
+      return Effect.gen(function* () {
+        yield* stack.deploy(
+          Effect.gen(function* () {
+            yield* DriftResource("A", { value: "a" });
+            yield* DriftResource("B", { value: "b" });
+          }),
+        );
+
+        cloud.resources.get("A")!.value = "hijacked-a";
+        cloud.resources.get("B")!.value = "hijacked-b";
+
+        // drift repair goes through the provider's update intent
+        const exit = yield* runSync().pipe(
+          Effect.provide(
+            Layer.succeed(TestResourceHooks, failOn("B", "update")),
+          ),
+          Effect.exit,
+        );
+
+        expect(Exit.isFailure(exit)).toBe(true);
+        // A was still repaired even though B failed
+        expect(cloud.resources.get("A")).toMatchObject({ value: "a" });
+        expect(yield* getState("A")).toMatchObject({
+          status: "updated",
+          attr: { value: "a" },
+        });
+        // B's cloud state is still drifted and its state row untouched
+        expect(cloud.resources.get("B")).toMatchObject({
+          value: "hijacked-b",
+        });
+        expect(yield* getState("B")).toMatchObject({
+          status: "created",
+          attr: { value: "b" },
+        });
+
+        // a follow-up sync (without the failure) converges B too
+        const result = yield* runSync();
+        expect(result.resources).toMatchObject({
+          A: { action: "unchanged" },
+          B: { action: "repaired" },
+        });
+        expect(cloud.resources.get("B")).toMatchObject({ value: "b" });
+      }).pipe(withCloud(cloud));
+    },
+  );
+
+  test.provider(
+    "a failing recreate goes through the provider's create intent",
+    (stack) => {
+      const cloud = makeTestCloud();
+      return Effect.gen(function* () {
+        yield* stack.deploy(DriftResource("A", { value: "a" }));
+        cloud.resources.delete("A");
+
+        const exit = yield* runSync().pipe(
+          Effect.provide(
+            Layer.succeed(TestResourceHooks, failOn("A", "create")),
+          ),
+          Effect.exit,
+        );
+
+        expect(Exit.isFailure(exit)).toBe(true);
+        expect(cloud.resources.has("A")).toBe(false);
+
+        // recovery: the next sync recreates it
+        const result = yield* runSync();
+        expect(result.resources.A?.action).toEqual("recreated");
+        expect(cloud.resources.get("A")).toMatchObject({ value: "a" });
+      }).pipe(withCloud(cloud));
+    },
+  );
+
+  test.provider("a failing read fails the sync", (stack) =>
+    Effect.gen(function* () {
+      yield* stack.deploy(TestResource("A", { string: "test-string" }));
+
+      const exit = yield* runSync().pipe(
+        Effect.provide(
+          Layer.succeed(TestResourceHooks, {
+            read: () => Effect.fail(new ResourceFailure("read exploded")),
+          }),
+        ),
+        Effect.exit,
+      );
+
+      expect(Exit.isFailure(exit)).toBe(true);
+      // state untouched by the failed observation
+      expect(yield* getState("A")).toMatchObject({
+        status: "created",
+        attr: { string: "test-string" },
+      });
+    }),
+  );
+});
+
+describe("ownership", () => {
+  test.provider(
+    "an unowned read result with matching attributes is unchanged",
+    (stack) => {
+      const cloud = makeTestCloud();
+      return Effect.gen(function* () {
+        yield* stack.deploy(DriftResource("A", { value: "a" }));
+
+        // ownership markers drifted but the attributes still match — the
+        // Unowned brand is a plan-time routing hint, not drift by itself
+        cloud.unowned.add("A");
+
+        cloud.calls.length = 0;
+        const result = yield* runSync();
+
+        expect(result.resources.A?.action).toEqual("unchanged");
+        expect(reconcileCalls(cloud)).toEqual([]);
+      }).pipe(withCloud(cloud));
+    },
+  );
+
+  test.provider(
+    "an unowned, drifted resource is repaired and the brand never persists",
+    (stack) => {
+      const cloud = makeTestCloud();
+      return Effect.gen(function* () {
+        yield* stack.deploy(DriftResource("A", { value: "a" }));
+
+        cloud.unowned.add("A");
+        cloud.resources.get("A")!.value = "hijacked";
+
+        const result = yield* runSync();
+
+        expect(result.resources.A?.action).toEqual("repaired");
+        expect(cloud.resources.get("A")).toMatchObject({ value: "a" });
+        const state = yield* getState("A");
+        expect(state).toMatchObject({
+          status: "updated",
+          attr: { value: "a" },
+        });
+        expect(Unowned.is(state!.attr)).toBe(false);
+      }).pipe(withCloud(cloud));
+    },
+  );
+});
+
+describe("bindings", () => {
+  test.provider(
+    "binding-derived attributes are repaired from the persisted bindings",
+    (stack) => {
+      const cloud = makeTestCloud();
+      return Effect.gen(function* () {
+        const created = yield* stack.deploy(
+          Effect.gen(function* () {
+            const a = yield* DriftResource("A", { value: "a" });
+            yield* a.bind("Env", {
+              env: { FEATURE_FLAG: "on" },
+            });
+            return a;
+          }),
+        );
+        expect(created.env).toEqual({ FEATURE_FLAG: "on" });
+
+        // the binding-derived env is wiped out-of-band
+        cloud.resources.get("A")!.env = {};
+
+        const result = yield* runSync();
+
+        expect(result.resources.A?.action).toEqual("repaired");
+        // reconcile received the persisted bindings and restored the env
+        expect(cloud.resources.get("A")!.env).toEqual({ FEATURE_FLAG: "on" });
+        expect((yield* getState("A"))?.attr?.env).toEqual({
+          FEATURE_FLAG: "on",
+        });
+      }).pipe(withCloud(cloud));
+    },
+  );
+});

--- a/packages/alchemy/test/sync.test.ts
+++ b/packages/alchemy/test/sync.test.ts
@@ -1,4 +1,6 @@
 import { Unowned } from "@/AdoptPolicy";
+import type { ApplyEvent } from "@/Cli/Event";
+import * as Namespace from "@/Namespace.ts";
 import { Stack } from "@/Stack";
 import { State, type ResourceState } from "@/State";
 import * as Sync from "@/Sync";
@@ -584,6 +586,189 @@ describe("bindings", () => {
         expect((yield* getState("A"))?.attr?.env).toEqual({
           FEATURE_FLAG: "on",
         });
+      }).pipe(withCloud(cloud));
+    },
+  );
+});
+
+describe("plan", () => {
+  test.provider(
+    "projects detection results onto plan node actions",
+    (stack) => {
+      const cloud = makeTestCloud();
+      return Effect.gen(function* () {
+        yield* stack.deploy(
+          Effect.gen(function* () {
+            yield* DriftResource("Clean", { value: "clean" });
+            yield* DriftResource("Drifted", { value: "drifted" });
+            yield* DriftResource("Missing", { value: "missing" });
+          }),
+        );
+
+        cloud.resources.get("Drifted")!.value = "hijacked";
+        cloud.resources.delete("Missing");
+
+        cloud.calls.length = 0;
+        const stk = yield* Stack;
+        const { result, plan } = yield* Sync.plan({
+          name: stk.name,
+          stage: stk.stage,
+        });
+
+        // drifted -> update, missing -> create, unchanged -> noop
+        expect(plan.resources.Clean?.action).toEqual("noop");
+        expect(plan.resources.Drifted?.action).toEqual("update");
+        expect(plan.resources.Missing?.action).toEqual("create");
+        // detection result rides along
+        expect(result.resources).toMatchObject({
+          Clean: { action: "unchanged" },
+          Drifted: { action: "drifted" },
+          Missing: { action: "missing" },
+        });
+        // the synthetic resource carries what the renderers need
+        expect(plan.resources.Drifted?.resource).toMatchObject({
+          FQN: "Drifted",
+          LogicalId: "Drifted",
+          Type: "Test.DriftResource",
+        });
+        // resource-only view: no deletions/actions in a sync plan
+        expect(plan.deletions).toEqual({});
+        expect(plan.actions).toEqual({});
+        expect(plan.actionDeletions).toEqual({});
+        // planning is detection-only: nothing was repaired
+        expect(cloud.resources.get("Drifted")).toMatchObject({
+          value: "hijacked",
+        });
+        expect(reconcileCalls(cloud)).toEqual([]);
+      }).pipe(withCloud(cloud));
+    },
+  );
+
+  test.provider(
+    "skipped resources render as noop nodes carrying persisted state",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.deploy(Bucket("MyBucket", { name: "test-bucket" }));
+
+        const stk = yield* Stack;
+        const { result, plan } = yield* Sync.plan({
+          name: stk.name,
+          stage: stk.stage,
+        });
+
+        expect(result.resources.MyBucket?.action).toEqual("skipped");
+        expect(plan.resources.MyBucket).toMatchObject({
+          action: "noop",
+          state: { status: "created" },
+          resource: { LogicalId: "MyBucket", Type: "Test.Bucket" },
+        });
+      }),
+  );
+
+  test.provider(
+    "namespaced resources keep their namespace, FQN and bindings",
+    (stack) => {
+      const cloud = makeTestCloud();
+      return Effect.gen(function* () {
+        const Site = (id: string) =>
+          Effect.gen(function* () {
+            const a = yield* DriftResource("A", { value: "a" });
+            yield* a.bind("Env", { env: { KEY: "on" } });
+            return a;
+          }).pipe(Namespace.push(id));
+
+        yield* stack.deploy(Site("Site"));
+
+        cloud.resources.get("A")!.value = "hijacked";
+
+        const stk = yield* Stack;
+        const { plan } = yield* Sync.plan({
+          name: stk.name,
+          stage: stk.stage,
+        });
+
+        const node = plan.resources["Site/A"];
+        expect(node?.action).toEqual("update");
+        expect(node?.resource).toMatchObject({
+          FQN: "Site/A",
+          LogicalId: "A",
+        });
+        expect(node?.resource.Namespace).toBeDefined();
+        // persisted bindings surface as noop rows (topology, not changes)
+        expect(node?.bindings).toMatchObject([{ sid: "Env", action: "noop" }]);
+      }).pipe(withCloud(cloud));
+    },
+  );
+});
+
+describe("session events", () => {
+  test.provider(
+    "repair reports progress through the provided session",
+    (stack) => {
+      const cloud = makeTestCloud();
+      const events: ApplyEvent[] = [];
+      const session = {
+        emit: (event: ApplyEvent) =>
+          Effect.sync(() => {
+            events.push(event);
+          }),
+        done: () => Effect.void,
+      };
+      return Effect.gen(function* () {
+        yield* stack.deploy(
+          Effect.gen(function* () {
+            yield* DriftResource("Drifted", { value: "drifted" });
+            yield* DriftResource("Missing", { value: "missing" });
+            yield* Bucket("MyBucket", { name: "test-bucket" });
+          }),
+        );
+
+        cloud.resources.get("Drifted")!.value = "hijacked";
+        cloud.resources.delete("Missing");
+
+        yield* runSync({ session });
+
+        // drift repair reports the update lifecycle
+        expect(events).toContainEqual({
+          kind: "status-change",
+          id: "Drifted",
+          type: "Test.DriftResource",
+          status: "updating",
+        });
+        expect(events).toContainEqual({
+          kind: "status-change",
+          id: "Drifted",
+          type: "Test.DriftResource",
+          status: "updated",
+        });
+        // recreation reports the create lifecycle
+        expect(events).toContainEqual({
+          kind: "status-change",
+          id: "Missing",
+          type: "Test.DriftResource",
+          status: "creating",
+        });
+        expect(events).toContainEqual({
+          kind: "status-change",
+          id: "Missing",
+          type: "Test.DriftResource",
+          status: "created",
+        });
+        // skipped resources settle with a terminal status and a reason note
+        expect(events).toContainEqual({
+          kind: "status-change",
+          id: "MyBucket",
+          type: "Test.Bucket",
+          status: "skipped",
+        });
+        expect(
+          events.some(
+            (e) =>
+              e.kind === "annotate" &&
+              e.id === "MyBucket" &&
+              e.message.includes("read"),
+          ),
+        ).toBe(true);
       }).pipe(withCloud(cloud));
     },
   );

--- a/packages/alchemy/test/test.resources.ts
+++ b/packages/alchemy/test/test.resources.ts
@@ -1,3 +1,4 @@
+import { Unowned } from "@/AdoptPolicy";
 import { Artifacts } from "@/Artifacts";
 import { isResolved } from "@/Diff.ts";
 import * as Provider from "@/Provider.ts";
@@ -951,6 +952,116 @@ export const deleteFirstResourceProvider = () =>
     }),
   });
 
+// ── DriftResource — exercises `alchemy sync` (read + reconcile drift repair).
+//
+// Models a cloud with an inspectable, mutable backing store (`TestCloud`):
+// `reconcile` upserts the resource into the cloud map, `read` observes it,
+// `delete` removes it. Tests mutate the map out-of-band to simulate drift
+// (or delete entries to simulate out-of-band deletion) and assert that
+// `sync` converges the cloud back to the last-deployed desired state.
+//
+// The map stores deep copies — the in-memory state store keeps references,
+// so aliasing the persisted `attr` would make out-of-band mutations
+// invisible to drift detection.
+
+export interface TestCloudService {
+  /** Live cloud state keyed by logical id. Mutate/delete to simulate drift. */
+  readonly resources: Map<string, Record<string, any>>;
+  /** Ids whose `read` result is branded {@link Unowned} (foreign tags). */
+  readonly unowned: Set<string>;
+  /** Lifecycle invocations, in order. Clear between phases to scope asserts. */
+  readonly calls: { op: "read" | "reconcile" | "delete"; id: string }[];
+}
+
+export class TestCloud extends Context.Service<TestCloud, TestCloudService>()(
+  "TestCloud",
+) {}
+
+export const makeTestCloud = (): TestCloudService => ({
+  resources: new Map(),
+  unowned: new Set(),
+  calls: [],
+});
+
+export type DriftResourceProps = {
+  value?: string;
+  tags?: Record<string, string>;
+};
+
+export interface DriftResource extends Resource<
+  "Test.DriftResource",
+  DriftResourceProps,
+  {
+    id: string;
+    value: string;
+    tags: Record<string, string>;
+    env: Record<string, string>;
+  },
+  {
+    env?: Record<string, string>;
+  }
+> {}
+
+export const DriftResource = Resource<DriftResource>("Test.DriftResource");
+
+export const driftResourceProvider = () =>
+  Provider.effect(
+    DriftResource,
+    Effect.gen(function* () {
+      const cloudOf = Effect.serviceOption(TestCloud).pipe(
+        Effect.map(Option.getOrUndefined),
+      );
+      const copy = (attrs: Record<string, any>) =>
+        JSON.parse(JSON.stringify(attrs)) as DriftResource["Attributes"];
+      return {
+        list: () => Effect.succeed([]),
+        read: Effect.fn(function* ({ id, output }) {
+          const cloud = yield* cloudOf;
+          // Without a TestCloud in context the resource behaves like
+          // TestResource: read reflects the persisted output back.
+          if (!cloud) return output;
+          cloud.calls.push({ op: "read", id });
+          const live = cloud.resources.get(id);
+          if (live === undefined) return undefined;
+          const attrs = copy(live);
+          return cloud.unowned.has(id) ? Unowned(attrs) : attrs;
+        }),
+        reconcile: Effect.fn(function* ({ id, news = {}, olds, bindings }) {
+          const cloud = yield* cloudOf;
+          cloud?.calls.push({ op: "reconcile", id });
+          const hooks = Option.getOrUndefined(
+            yield* Effect.serviceOption(TestResourceHooks),
+          );
+          if (olds === undefined) {
+            if (hooks?.create) {
+              yield* hooks.create(id, { string: news.value });
+            }
+          } else if (hooks?.update) {
+            yield* hooks.update(id, { string: news.value });
+          }
+          const attrs = {
+            id,
+            value: news.value ?? id,
+            tags: news.tags ?? {},
+            env: Object.assign(
+              {},
+              ...bindings.map(
+                (binding: any) => binding.env ?? binding.data?.env ?? {},
+              ),
+            ),
+          };
+          cloud?.resources.set(id, copy(attrs));
+          return attrs;
+        }),
+        delete: Effect.fn(function* ({ id }) {
+          const cloud = yield* cloudOf;
+          cloud?.calls.push({ op: "delete", id });
+          cloud?.resources.delete(id);
+        }),
+      };
+    }),
+  );
+
 // Layers
 export const TestLayers = () =>
   Layer.mergeAll(
@@ -968,6 +1079,7 @@ export const TestLayers = () =>
     noPrecreateBindingTargetProvider(),
     durationResourceProvider(),
     deleteFirstResourceProvider(),
+    driftResourceProvider(),
   );
 
 export const InMemoryTestLayers = () =>


### PR DESCRIPTION
Add `alchemy sync`: reconcile out-of-band cloud drift back to the last-deployed state recorded in the state store. Unlike `deploy`, it needs no re-plan of the stack program — per resource it runs observe → compare → converge:

1. `provider.read` observes the live cloud state
2. deep-compare observed vs. persisted attributes (equal ⇒ `unchanged`)
3. on drift, `provider.reconcile` runs with persisted props as `news` and the **observed** attributes as `output`; a missing resource reconciles greenfield under the **same instance id** so deterministic physical names regenerate identically
4. fresh attributes are persisted back to state

```sh
alchemy sync ./alchemy.run.ts --stage prod            # detect + repair
alchemy sync ./alchemy.run.ts --stage prod --dry-run  # detect only
```

```ts
const result = yield* Sync.sync({ name: stack.name, stage: stack.stage });
// result.resources: { [fqn]: { action: "unchanged" | "repaired" | "recreated" | "skipped" | ... } }
```

- Resources sync concurrently and independently (persisted props are fully resolved, so there are no data edges to order by); failures are aggregated into one combined cause after every resource is attempted, mirroring `apply`.
- Skipped (with a reason) instead of failed: providers without `read`, and rows in non-terminal statuses (`creating`, `replacing`, `replaced`, …) — those belong to `deploy`'s recovery machinery. Action rows are ignored.
- `Unowned`-branded reads are stripped and handled as ordinary tag drift; the brand never persists.
- Tests introduce a `DriftResource` + `TestCloud` fixture (an inspectable in-memory cloud) so suites mutate/delete live state out-of-band and assert convergence — 21 cases covering repair, recreation, dry-run, skip reasons, partial-failure isolation, ownership, and binding-derived attribute repair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
