### PR TITLE
fix(aws/ecs): unwedge plan/deploy/destroy after a half-created Service

### DIFF
--- a/packages/alchemy/src/AWS/ECS/Service.ts
+++ b/packages/alchemy/src/AWS/ECS/Service.ts
@@ -381,10 +381,20 @@ export const ServiceProvider = () =>
   Provider.effect(
     Service,
     Effect.gen(function* () {
-      const clusterArnOf = (cluster: ServiceProps["cluster"] | ClusterArn) =>
+      // Derive the cluster ARN from either form of the `cluster` prop. May
+      // legitimately receive `undefined`: a `creating` state row persisted
+      // before upstream Outputs resolved can't round-trip an Output-valued
+      // `cluster` (it deserializes as `undefined`), and recovery paths hand
+      // those props back as `olds`.
+      const clusterArnOf = (
+        cluster: ServiceProps["cluster"] | ClusterArn | undefined,
+      ): ClusterArn | undefined =>
         typeof cluster === "string"
-          ? cluster
-          : (((cluster as any).clusterArn ?? cluster) as string);
+          ? (cluster as ClusterArn)
+          : typeof (cluster as { clusterArn?: unknown } | undefined)
+                ?.clusterArn === "string"
+            ? ((cluster as { clusterArn: string }).clusterArn as ClusterArn)
+            : undefined;
       const toEcsTags = (tags: Record<string, string>): ecs.Tag[] =>
         Object.entries(tags).map(([key, value]) => ({ key, value }));
 
@@ -555,8 +565,18 @@ export const ServiceProvider = () =>
           ) {
             return { action: "replace", deleteFirst: true } as const;
           }
-          // cluster change → replace (a service can't move clusters).
-          if (clusterArnOf(olds.cluster) !== clusterArnOf(news.cluster)) {
+          // cluster change → replace (a service can't move clusters). Only
+          // when both sides are known — a half-created state row may have
+          // lost an Output-valued `cluster` (see `clusterArnOf`), and an
+          // unknown old cluster must fall through to the create/update
+          // recovery path rather than force a replacement.
+          const oldClusterArn = clusterArnOf(olds.cluster);
+          const newClusterArn = clusterArnOf(news.cluster);
+          if (
+            oldClusterArn !== undefined &&
+            newClusterArn !== undefined &&
+            oldClusterArn !== newClusterArn
+          ) {
             return { action: "replace", deleteFirst: true } as const;
           }
           // Truly-immutable post-create fields. Everything else (desiredCount,
@@ -587,11 +607,20 @@ export const ServiceProvider = () =>
           }
         }),
         read: Effect.fn(function* ({ id, olds, output }) {
+          const clusterArn = output?.clusterArn ?? clusterArnOf(olds?.cluster);
+          if (clusterArn === undefined) {
+            // No attributes and no recoverable cluster from the persisted
+            // props (an Output-valued `cluster` doesn't survive a
+            // `creating`-state round-trip). We can't locate the service, so
+            // report "not found" — the engine re-drives the create and
+            // reconcile converges on any half-created service by name.
+            return undefined;
+          }
           const serviceName =
             output?.serviceName ?? (yield* toServiceName(id, olds ?? {}));
           const described = yield* ecs
             .describeServices({
-              cluster: output?.clusterArn ?? clusterArnOf(olds!.cluster),
+              cluster: clusterArn,
               services: [serviceName],
               include: ["TAGS"],
             })

--- a/packages/alchemy/test/AWS/ECS/Service.test.ts
+++ b/packages/alchemy/test/AWS/ECS/Service.test.ts
@@ -4,6 +4,7 @@ import { Vpc } from "@/AWS/EC2/Vpc.ts";
 import { Cluster } from "@/AWS/ECS/Cluster.ts";
 import { Service } from "@/AWS/ECS/Service.ts";
 import * as Provider from "@/Provider";
+import { isResourceState, State, type ResourceState } from "@/State";
 import * as Test from "@/Test/Vitest";
 import * as ec2 from "@distilled.cloud/aws/ec2";
 import * as ecs from "@distilled.cloud/aws/ecs";
@@ -444,6 +445,125 @@ test.provider(
       yield* elbv2
         .deleteTargetGroup({ TargetGroupArn: targetGroupArn })
         .pipe(Effect.catch(() => Effect.void));
+
+      yield* stack.destroy();
+      yield* ecs
+        .deregisterTaskDefinition({ taskDefinition: taskDefinitionArn })
+        .pipe(Effect.catchTag("ClientException", () => Effect.void));
+    }),
+  { timeout: 240_000 },
+);
+
+// Regression test for https://github.com/alchemy-run/alchemy-effect/issues/736.
+//
+// An interrupted first deploy persists the service as `status: "creating"`
+// with no attributes — and the Output-valued props (`cluster` passed as a
+// resource object, `task`, `vpcId`, `subnets`) do not survive the state
+// round-trip: they deserialize as `undefined`. Plan's recovery branch then
+// calls `provider.read` with those junk props, which crashed in
+// `clusterArnOf(undefined)` and wedged the stack (plan/deploy/destroy all
+// build a plan, so there was no CLI escape hatch).
+//
+// Simulate exactly that state row after a real deploy and assert the next
+// deploy recovers: `read` reports "not found", the engine re-drives the
+// create, and reconcile converges on the half-created service by name —
+// SAME serviceArn, no replacement.
+test.provider(
+  "recovers a half-created service whose creating-state lost Output-valued props (#736)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const registered = yield* ecs.registerTaskDefinition({
+        family: "alchemy-test-ecs-service-wedged",
+        networkMode: "awsvpc",
+        requiresCompatibilities: ["FARGATE"],
+        cpu: "256",
+        memory: "512",
+        containerDefinitions: [
+          {
+            name: "app",
+            image: "public.ecr.aws/nginx/nginx:stable",
+            essential: true,
+            portMappings: [{ containerPort: 80, protocol: "tcp" }],
+          },
+        ],
+      });
+      const taskDefinitionArn = registered.taskDefinition?.taskDefinitionArn!;
+      // Safety net: deregister the out-of-band task definition on scope close.
+      yield* Effect.addFinalizer(() =>
+        ecs
+          .deregisterTaskDefinition({ taskDefinition: taskDefinitionArn })
+          .pipe(Effect.ignore),
+      );
+
+      const deployService = () =>
+        stack.deploy(
+          Effect.gen(function* () {
+            const vpc = yield* Vpc("WedgedVpc", { cidrBlock: "10.74.0.0/16" });
+            const subnet = yield* Subnet("WedgedSubnet", {
+              vpcId: vpc.vpcId,
+              cidrBlock: "10.74.1.0/24",
+            });
+            const cluster = yield* Cluster("WedgedCluster", {
+              clusterName: "alchemy-test-ecs-service-wedged",
+            });
+            return yield* Service("WedgedService", {
+              // Whole resource object, NOT a string ARN — the #736 shape.
+              cluster,
+              task: { taskDefinitionArn, containerName: "app", port: 80 },
+              desiredCount: 0,
+              vpcId: vpc.vpcId,
+              subnets: [subnet.subnetId],
+            });
+          }),
+        );
+
+      const created = yield* deployService();
+
+      // Rewrite the service's persisted row into the wedged shape an
+      // interrupted deploy leaves behind: `creating`, no attributes, and
+      // every Output-valued prop lost in the round-trip.
+      const state = yield* yield* State;
+      const stage = "test"; // scratch stacks default to the "test" stage
+      const fqns = yield* state.list({ stack: stack.name, stage });
+      const rows = yield* Effect.forEach(fqns, (fqn) =>
+        state
+          .get({ stack: stack.name, stage, fqn })
+          .pipe(Effect.map((row) => ({ fqn, row }))),
+      );
+      const wedged = rows.find(
+        (r): r is { fqn: string; row: ResourceState } =>
+          isResourceState(r.row) && r.row.resourceType === "AWS.ECS.Service",
+      );
+      if (!wedged) {
+        return yield* Effect.die(
+          new Error("no AWS.ECS.Service state row found after deploy"),
+        );
+      }
+      yield* state.set({
+        stack: stack.name,
+        stage,
+        fqn: wedged.fqn,
+        value: {
+          ...wedged.row,
+          status: "creating",
+          attr: undefined,
+          props: {
+            ...wedged.row.props,
+            cluster: undefined,
+            task: undefined,
+            vpcId: undefined,
+            subnets: undefined,
+          },
+        },
+      });
+
+      // Before the fix this crashed in plan with
+      // `TypeError: undefined is not an object (evaluating 'cluster.clusterArn')`.
+      const recovered = yield* deployService();
+      expect(recovered.serviceArn).toEqual(created.serviceArn);
+      expect(recovered.clusterArn).toEqual(created.clusterArn);
 
       yield* stack.destroy();
       yield* ecs


### PR DESCRIPTION
Closes #736.

A first deploy interrupted mid-create persists the `AWS.ECS.Service` row as `status: "creating"` with no attributes — and Output-valued props (a `cluster` passed as a resource object, `task`, `vpcId`, `subnets`) do not survive the state round-trip: they deserialize as `undefined`. Plan's recovery branch then calls `read` with those props and crashed:

```
TypeError: undefined is not an object (evaluating 'cluster.clusterArn')
    at clusterArnOf (src/AWS/ECS/Service.ts:387)
```

Since `plan`, `deploy`, and `destroy` all build a plan, the stack was wedged with no CLI escape hatch.

- `clusterArnOf` now returns `ClusterArn | undefined` instead of dereferencing `undefined`
- `read` reports "not found" when no cluster ARN is recoverable from `output` or `olds`; the engine re-drives the create and reconcile (observe-ensure-sync) converges on the half-created service by name — same `serviceArn`, no replacement
- `diff` only forces a cluster-change replacement when **both** old and new cluster ARNs are known

```ts
// read
const clusterArn = output?.clusterArn ?? clusterArnOf(olds?.cluster);
if (clusterArn === undefined) return undefined; // engine re-drives create

// diff — unknown old cluster falls through to the create/update recovery path
if (oldClusterArn !== undefined && newClusterArn !== undefined && oldClusterArn !== newClusterArn) {
  return { action: "replace", deleteFirst: true } as const;
}
```

The regression test deploys a real service with `cluster` as a resource object, rewrites its state row into the exact wedged shape (`creating`, no attr, Output-valued props `undefined`), and asserts the next deploy recovers the same `serviceArn`. Verified it reproduces the issue's `TypeError` on the unfixed provider.
