### PR TITLE
fix(cli): suppress bun's benign tsconfig-override fd warning in dev

### DIFF
--- a/packages/alchemy/bin/cli.js
+++ b/packages/alchemy/bin/cli.js
@@ -89,7 +89,15 @@ process.on("uncaughtException", (error) => {
 
 // Substring match (not regex) — bun may wrap the line in ANSI color codes
 // when stderr is piped to a TTY-aware parent, so anchored regex is fragile.
+//
+// "directory mismatch for directory" is bun's known-benign internal warning
+// triggered by --tsconfig-override (oven-sh/bun#25730): the resolver openat()s
+// the tsconfig basename against a cached dir fd that isn't its parent, falls
+// back to an absolute open, and logs. Bun's own tsconfig-override tests
+// tolerate the same line. Only our dev path passes --tsconfig-override, which
+// is why published installs never see it.
 foregroundChild(runtime, args, {
   stderrFilter: (line) =>
-    !line.includes("is not in the project directory and will not be watched"),
+    !line.includes("is not in the project directory and will not be watched") &&
+    !line.includes("directory mismatch for directory"),
 });


### PR DESCRIPTION
Running the CLI from a checkout (`bun alchemy ...` in any example) printed on every invocation:

```
Internal error: directory mismatch for directory ".../packages/alchemy/tsconfig.json", fd 3. You don't need to do anything, but this indicates a bug.
```

This is a known benign bun bug ([oven-sh/bun#25730](https://github.com/oven-sh/bun/issues/25730)) triggered by `--tsconfig-override`, which only the dev launcher path passes — published installs never see it. Bun's resolver `openat()`s the tsconfig basename against a cached dir fd that isn't its parent, falls back to an absolute open, and logs. Bun's own `tsconfig-override.test.ts` tolerates the same stderr line, so an upgrade won't remove it.

The launcher already owns the child's stderr to drop bun's un-silenceable watcher warning; this extends the same filter:

```diff
   stderrFilter: (line) =>
-    !line.includes("is not in the project directory and will not be watched"),
+    !line.includes("is not in the project directory and will not be watched") &&
+    !line.includes("directory mismatch for directory"),
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
