### PR TITLE
fix(providers): guard read/diff recovery paths against lost Output-valued olds

### DIFF
--- a/packages/alchemy/src/AWS/ACM/Certificate.ts
+++ b/packages/alchemy/src/AWS/ACM/Certificate.ts
@@ -356,16 +356,27 @@ export const CertificateProvider = () =>
           }
         }),
         read: Effect.fn(function* ({ id, olds, output }) {
+          // `olds.domainName` may be `undefined` when a `creating` row was
+          // persisted before upstream Outputs resolved — without a domain
+          // there is nothing to search for, so report "not found" and let
+          // the engine re-drive the create (reconcile finds any managed
+          // certificate by tags before requesting a new one).
           const certificate = output?.certificateArn
             ? yield* describeCertificate(output.certificateArn)
-            : yield* findManagedCertificate(id, olds!);
+            : olds?.domainName !== undefined
+              ? yield* findManagedCertificate(id, olds)
+              : undefined;
 
           if (!certificate?.CertificateArn) {
             return undefined;
           }
 
           const tags = yield* listCertificateTags(certificate.CertificateArn);
-          return toAttrs(olds!, certificate, tags);
+          return toAttrs(
+            olds ?? { domainName: certificate.DomainName! },
+            certificate,
+            tags,
+          );
         }),
         reconcile: Effect.fn(function* ({
           id,

--- a/packages/alchemy/src/AWS/AutoScaling/AutoScalingGroup.ts
+++ b/packages/alchemy/src/AWS/AutoScaling/AutoScalingGroup.ts
@@ -111,14 +111,6 @@ export const AutoScalingGroup = Resource<AutoScalingGroup>(
   "AWS.AutoScaling.AutoScalingGroup",
 );
 
-const isLaunchTemplateResource = (
-  value: unknown,
-): value is LaunchTemplateResource =>
-  typeof value === "object" &&
-  value !== null &&
-  "Type" in value &&
-  (value as { Type?: string }).Type === "AWS.AutoScaling.LaunchTemplate";
-
 const sortStrings = (values: readonly string[] = []) =>
   [...values].sort((a, b) => a.localeCompare(b));
 
@@ -137,14 +129,28 @@ export const AutoScalingGroupProvider = () =>
       const toLaunchTemplateSpec = (
         input: AutoScalingGroupProps["launchTemplate"],
       ) => {
-        const spec = isLaunchTemplateResource(input)
-          ? {
-              launchTemplateId: input.launchTemplateId,
-              launchTemplateName: input.launchTemplateName,
-              version: input.defaultVersionNumber,
-            }
-          : ((input ?? {}) as LaunchTemplateReference);
+        // A whole-resource `launchTemplate: template` resolves to the
+        // LaunchTemplate's bare Attributes before reaching the provider —
+        // the resource `Type` marker does not survive resolution — so narrow
+        // on the attributes shape (`launchTemplateArn` exists only on
+        // attributes, never on a LaunchTemplateReference). Attributes carry
+        // BOTH id and name, and the API rejects a spec with both, so send
+        // the id alone.
+        const attrs = input as
+          | Partial<LaunchTemplateResource["Attributes"]>
+          | undefined;
+        if (typeof attrs?.launchTemplateArn === "string") {
+          return {
+            LaunchTemplateId: attrs.launchTemplateId as string | undefined,
+            LaunchTemplateName: undefined,
+            Version:
+              attrs.defaultVersionNumber === undefined
+                ? "$Default"
+                : String(attrs.defaultVersionNumber),
+          };
+        }
 
+        const spec = (input ?? {}) as LaunchTemplateReference;
         return {
           LaunchTemplateId: spec.launchTemplateId as string | undefined,
           LaunchTemplateName: spec.launchTemplateName as string | undefined,

--- a/packages/alchemy/src/AWS/AutoScaling/LaunchTemplate.ts
+++ b/packages/alchemy/src/AWS/AutoScaling/LaunchTemplate.ts
@@ -512,7 +512,12 @@ const isLaunchTemplateNotFound = (error: unknown) => {
     tag === "InvalidLaunchTemplateNameNotFoundException" ||
     tag === "InvalidLaunchTemplateIdNotFoundException" ||
     tag === "InvalidLaunchTemplateId.Malformed" ||
-    tag === "InvalidLaunchTemplateId.NotFound"
+    tag === "InvalidLaunchTemplateId.NotFound" ||
+    // Live `describeLaunchTemplates` surfaces the dot-form codes, which the
+    // ec2 SDK leaves untyped — a missing template on the read-before-create
+    // probe otherwise fails the whole plan.
+    tag === "InvalidLaunchTemplateName.NotFoundException" ||
+    tag === "InvalidLaunchTemplateId.NotFoundException"
   );
 };
 

--- a/packages/alchemy/src/AWS/AutoScaling/ScalingPolicy.ts
+++ b/packages/alchemy/src/AWS/AutoScaling/ScalingPolicy.ts
@@ -88,18 +88,24 @@ export const ScalingPolicyProvider = () =>
           ? Effect.succeed(props.policyName)
           : createPhysicalName({ id, maxLength: 255, lowercase: true });
 
+      // May receive `undefined`: an Output-valued `autoScalingGroup` doesn't
+      // survive a `creating`-state round-trip (it deserializes as
+      // `undefined`), and recovery paths hand those props back as `olds`.
       const toAutoScalingGroupName = (
-        input: ScalingPolicyProps["autoScalingGroup"],
+        input: ScalingPolicyProps["autoScalingGroup"] | undefined,
       ) =>
         isAutoScalingGroupResource(input)
           ? (input.autoScalingGroupName as unknown as string)
-          : (input as unknown as string);
+          : (input as unknown as string | undefined);
 
+      // `describePolicies` searches account-wide when no AutoScalingGroupName
+      // is given; policy names are unique physical names, so a name-only
+      // lookup still identifies our policy during state recovery.
       const describePolicy = ({
         autoScalingGroupName,
         policyName,
       }: {
-        autoScalingGroupName: string;
+        autoScalingGroupName: string | undefined;
         policyName: string;
       }) =>
         autoscaling
@@ -147,10 +153,17 @@ export const ScalingPolicyProvider = () =>
           const news = _news as typeof olds;
           const oldName = yield* toName(id, olds ?? {});
           const newName = yield* toName(id, news ?? {});
+          // ASG change → replace, but only when both sides are known — a
+          // half-created state row may have lost an Output-valued
+          // `autoScalingGroup`, and an unknown old ASG must fall through to
+          // the create/update recovery path rather than force a replacement.
+          const oldGroupName = toAutoScalingGroupName(olds.autoScalingGroup);
+          const newGroupName = toAutoScalingGroupName(news.autoScalingGroup);
           if (
             oldName !== newName ||
-            toAutoScalingGroupName(olds.autoScalingGroup) !==
-              toAutoScalingGroupName(news.autoScalingGroup)
+            (oldGroupName !== undefined &&
+              newGroupName !== undefined &&
+              oldGroupName !== newGroupName)
           ) {
             return { action: "replace" } as const;
           }
@@ -165,7 +178,7 @@ export const ScalingPolicyProvider = () =>
         read: Effect.fn(function* ({ id, olds, output }) {
           const autoScalingGroupName =
             output?.autoScalingGroupName ??
-            toAutoScalingGroupName(olds!.autoScalingGroup);
+            toAutoScalingGroupName(olds?.autoScalingGroup);
           const policyName =
             output?.policyName ?? (yield* toName(id, olds ?? {}));
           const policy = yield* describePolicy({

--- a/packages/alchemy/src/AWS/AutoScaling/ScalingPolicy.ts
+++ b/packages/alchemy/src/AWS/AutoScaling/ScalingPolicy.ts
@@ -71,14 +71,6 @@ export const ScalingPolicy = Resource<ScalingPolicy>(
   "AWS.AutoScaling.ScalingPolicy",
 );
 
-const isAutoScalingGroupResource = (
-  value: unknown,
-): value is AutoScalingGroupResource =>
-  typeof value === "object" &&
-  value !== null &&
-  "Type" in value &&
-  (value as { Type?: string }).Type === "AWS.AutoScaling.AutoScalingGroup";
-
 export const ScalingPolicyProvider = () =>
   Provider.effect(
     ScalingPolicy,
@@ -88,15 +80,24 @@ export const ScalingPolicyProvider = () =>
           ? Effect.succeed(props.policyName)
           : createPhysicalName({ id, maxLength: 255, lowercase: true });
 
-      // May receive `undefined`: an Output-valued `autoScalingGroup` doesn't
-      // survive a `creating`-state round-trip (it deserializes as
-      // `undefined`), and recovery paths hand those props back as `olds`.
+      // Derive the group name from either spelling of `autoScalingGroup`. A
+      // whole AutoScalingGroup resource resolves to its bare Attributes
+      // before reaching the provider — the resource `Type` marker does not
+      // survive resolution — so narrow on the attributes shape, never on
+      // `Type`. May also receive `undefined`: an Output-valued
+      // `autoScalingGroup` doesn't survive a `creating`-state round-trip
+      // (it deserializes as `undefined`), and recovery paths hand those
+      // props back as `olds`.
       const toAutoScalingGroupName = (
         input: ScalingPolicyProps["autoScalingGroup"] | undefined,
-      ) =>
-        isAutoScalingGroupResource(input)
-          ? (input.autoScalingGroupName as unknown as string)
-          : (input as unknown as string | undefined);
+      ): string | undefined =>
+        typeof input === "string"
+          ? input
+          : typeof (input as { autoScalingGroupName?: unknown } | undefined)
+                ?.autoScalingGroupName === "string"
+            ? (input as unknown as { autoScalingGroupName: string })
+                .autoScalingGroupName
+            : undefined;
 
       // `describePolicies` searches account-wide when no AutoScalingGroupName
       // is given; policy names are unique physical names, so a name-only

--- a/packages/alchemy/src/AWS/CloudFront/PublicKey.ts
+++ b/packages/alchemy/src/AWS/CloudFront/PublicKey.ts
@@ -171,7 +171,11 @@ export const PublicKeyProvider = () =>
           ) {
             return { action: "replace" } as const;
           }
+          // Compare only when the old key is known — an Output-valued
+          // `encodedKey` doesn't survive a `creating`-state round-trip (it
+          // deserializes as `undefined`).
           if (
+            olds.encodedKey !== undefined &&
             isResolved(olds.encodedKey) &&
             extractValue(olds.encodedKey) !== extractValue(news.encodedKey)
           ) {

--- a/packages/alchemy/src/AWS/DynamoDB/Table.ts
+++ b/packages/alchemy/src/AWS/DynamoDB/Table.ts
@@ -1015,7 +1015,7 @@ export const TableProvider = () =>
           ) {
             return { action: "replace" } as const;
           }
-          for (const [name, type] of Object.entries(olds.attributes)) {
+          for (const [name, type] of Object.entries(olds.attributes ?? {})) {
             if (news.attributes[name] !== type) {
               return { action: "replace" } as const;
             }

--- a/packages/alchemy/src/AWS/IAM/OpenIDConnectProvider.ts
+++ b/packages/alchemy/src/AWS/IAM/OpenIDConnectProvider.ts
@@ -147,7 +147,15 @@ export const OpenIDConnectProviderProvider = () =>
         read: Effect.fn(function* ({ olds, output }) {
           const providerArn =
             output?.openIDConnectProviderArn ??
-            (yield* oidcArnFromUrl(olds.url));
+            (olds?.url !== undefined
+              ? yield* oidcArnFromUrl(olds.url)
+              : undefined);
+          if (providerArn === undefined) {
+            // An Output-valued `url` doesn't survive a `creating`-state
+            // round-trip (it deserializes as `undefined`) — report "not
+            // found" so the engine re-drives the create.
+            return undefined;
+          }
           const provider = yield* readProvider(providerArn);
           if (!provider?.Url) {
             return undefined;

--- a/packages/alchemy/src/AWS/Organizations/DelegatedAdministrator.ts
+++ b/packages/alchemy/src/AWS/Organizations/DelegatedAdministrator.ts
@@ -56,10 +56,18 @@ export const DelegatedAdministratorProvider = () =>
           }
         }),
         read: Effect.fn(function* ({ olds, output }) {
+          const accountId = output?.accountId ?? olds?.accountId;
+          const servicePrincipal =
+            output?.servicePrincipal ?? olds?.servicePrincipal;
+          if (accountId === undefined || servicePrincipal === undefined) {
+            // Output-valued props don't survive a `creating`-state round-trip
+            // (they deserialize as `undefined`) — report "not found" so the
+            // engine re-drives the create.
+            return undefined;
+          }
           return yield* readDelegatedAdministrator({
-            accountId: output?.accountId ?? olds!.accountId,
-            servicePrincipal:
-              output?.servicePrincipal ?? olds!.servicePrincipal,
+            accountId,
+            servicePrincipal,
           });
         }),
         list: () =>

--- a/packages/alchemy/src/AWS/Organizations/PolicyAttachment.ts
+++ b/packages/alchemy/src/AWS/Organizations/PolicyAttachment.ts
@@ -55,10 +55,16 @@ export const PolicyAttachmentProvider = () =>
           }
         }),
         read: Effect.fn(function* ({ olds, output }) {
-          return yield* readAttachment({
-            policyId: output?.policyId ?? olds!.policyId,
-            targetId: output?.targetId ?? olds!.targetId,
-          });
+          const policyId = output?.policyId ?? olds?.policyId;
+          const targetId = output?.targetId ?? olds?.targetId;
+          if (policyId === undefined || targetId === undefined) {
+            // A `creating` row persisted before upstream Outputs resolved
+            // can't round-trip Output-valued ids — they deserialize as
+            // `undefined`. Report "not found" so the engine re-drives the
+            // create (reconcile observes before attaching).
+            return undefined;
+          }
+          return yield* readAttachment({ policyId, targetId });
         }),
         // Enumerate every (policy, target) attachment. There is no direct
         // "list attachments" API, so we fan out: for each policy type, list the

--- a/packages/alchemy/src/AWS/Organizations/RootPolicyType.ts
+++ b/packages/alchemy/src/AWS/Organizations/RootPolicyType.ts
@@ -54,10 +54,15 @@ export const RootPolicyTypeProvider = () =>
           }
         }),
         read: Effect.fn(function* ({ olds, output }) {
-          return yield* readRootPolicyType({
-            rootId: output?.rootId ?? olds!.rootId,
-            policyType: output?.policyType ?? olds!.policyType,
-          });
+          const rootId = output?.rootId ?? olds?.rootId;
+          const policyType = output?.policyType ?? olds?.policyType;
+          if (rootId === undefined || policyType === undefined) {
+            // Output-valued props don't survive a `creating`-state round-trip
+            // (they deserialize as `undefined`) — report "not found" so the
+            // engine re-drives the create.
+            return undefined;
+          }
+          return yield* readRootPolicyType({ rootId, policyType });
         }),
         // A RootPolicyType is the enable/disable state of one policy type on
         // one organization root. `listRoots` already returns each root's

--- a/packages/alchemy/src/AWS/Organizations/TrustedServiceAccess.ts
+++ b/packages/alchemy/src/AWS/Organizations/TrustedServiceAccess.ts
@@ -45,9 +45,15 @@ export const TrustedServiceAccessProvider = () =>
           }
         }),
         read: Effect.fn(function* ({ olds, output }) {
-          return yield* readTrustedServiceAccess(
-            output?.servicePrincipal ?? olds!.servicePrincipal,
-          );
+          const servicePrincipal =
+            output?.servicePrincipal ?? olds?.servicePrincipal;
+          if (servicePrincipal === undefined) {
+            // Output-valued props don't survive a `creating`-state round-trip
+            // (they deserialize as `undefined`) — report "not found" so the
+            // engine re-drives the create.
+            return undefined;
+          }
+          return yield* readTrustedServiceAccess(servicePrincipal);
         }),
         list: () =>
           Effect.gen(function* () {

--- a/packages/alchemy/src/AWS/Route53/HostedZone.ts
+++ b/packages/alchemy/src/AWS/Route53/HostedZone.ts
@@ -114,17 +114,22 @@ export const HostedZoneProvider = () =>
       // Poll `getChange` until the change reaches INSYNC. `getChange` is
       // eventually consistent and can briefly return `NoSuchChange` right after
       // submit, so coalesce that to a non-INSYNC status and keep polling.
+      // `ChangeInfo.Id` comes back as "/change/C..." but `getChange` only
+      // accepts the bare id — the prefixed form returns `NoSuchChange`
+      // forever, silently burning the full repeat cap on every change.
       const waitForChange = Effect.fn(function* (changeId: string) {
-        return yield* route53.getChange({ Id: changeId }).pipe(
-          Effect.map((r) => r.ChangeInfo.Status),
-          Effect.catchTag("NoSuchChange", () => Effect.succeed("PENDING")),
-          Effect.repeat({
-            schedule: Schedule.fixed("2 seconds").pipe(
-              Schedule.both(Schedule.recurs(60)),
-            ),
-            until: (status) => status === "INSYNC",
-          }),
-        );
+        return yield* route53
+          .getChange({ Id: changeId.replace(/^\/change\//, "") })
+          .pipe(
+            Effect.map((r) => r.ChangeInfo.Status),
+            Effect.catchTag("NoSuchChange", () => Effect.succeed("PENDING")),
+            Effect.repeat({
+              schedule: Schedule.fixed("2 seconds").pipe(
+                Schedule.both(Schedule.recurs(60)),
+              ),
+              until: (status) => status === "INSYNC",
+            }),
+          );
       });
 
       const findByName = Effect.fn(function* (name: string) {

--- a/packages/alchemy/src/AWS/Route53/HostedZone.ts
+++ b/packages/alchemy/src/AWS/Route53/HostedZone.ts
@@ -242,8 +242,13 @@ export const HostedZoneProvider = () =>
           ),
         diff: Effect.fn(function* ({ olds, news }) {
           if (!isResolved(news)) return undefined;
+          // Name change → replace, but only when the old name is known — a
+          // half-created state row can't round-trip an Output-valued `name`
+          // (it deserializes as `undefined`), and an unknown old name must
+          // fall through to the create/update recovery path.
           if (
-            normalizeName(olds.name) !== normalizeName(news.name) ||
+            (olds.name !== undefined &&
+              normalizeName(olds.name) !== normalizeName(news.name)) ||
             (olds.privateZone ?? false) !== (news.privateZone ?? false) ||
             olds.delegationSetId !== news.delegationSetId ||
             olds.vpc?.vpcId !== news.vpc?.vpcId
@@ -253,8 +258,15 @@ export const HostedZoneProvider = () =>
         }),
         read: Effect.fn(function* ({ olds, output }) {
           // Resolve the zone id: prefer the stored output, else look up by name
-          // (adoption / state-loss recovery).
-          const zoneId = output?.id ?? (yield* findByName(olds!.name))?.Id;
+          // (adoption / state-loss recovery). The persisted `name` may be
+          // `undefined` when a `creating` row was written before upstream
+          // Outputs resolved — report "not found" and let the engine
+          // re-drive the create.
+          const zoneId =
+            output?.id ??
+            (olds?.name !== undefined
+              ? (yield* findByName(olds.name))?.Id
+              : undefined);
           if (zoneId === undefined) {
             return undefined;
           }

--- a/packages/alchemy/src/AWS/Route53/Record.ts
+++ b/packages/alchemy/src/AWS/Route53/Record.ts
@@ -590,10 +590,16 @@ export const RecordProvider = () =>
           }),
         diff: Effect.fn(function* ({ olds, news }) {
           if (!isResolved(news)) return undefined;
+          // Identity change → replace, but only when the old value is known —
+          // a half-created state row can't round-trip Output-valued props
+          // (they deserialize as `undefined`), and an unknown old identity
+          // must fall through to the create/update recovery path.
           if (
-            normalizeHostedZoneId(olds.hostedZoneId) !==
-              normalizeHostedZoneId(news.hostedZoneId) ||
-            normalizeName(olds.name) !== normalizeName(news.name) ||
+            (olds.hostedZoneId !== undefined &&
+              normalizeHostedZoneId(olds.hostedZoneId) !==
+                normalizeHostedZoneId(news.hostedZoneId)) ||
+            (olds.name !== undefined &&
+              normalizeName(olds.name) !== normalizeName(news.name)) ||
             olds.type !== news.type ||
             olds.setIdentifier !== news.setIdentifier
           ) {
@@ -601,20 +607,31 @@ export const RecordProvider = () =>
           }
         }),
         read: Effect.fn(function* ({ olds, output }) {
-          const recordSet = yield* findRecord(
-            output?.hostedZoneId ?? olds!.hostedZoneId,
-            {
-              name: output?.name ?? olds!.name,
-              type: output?.type ?? olds!.type,
-              setIdentifier: output?.setIdentifier ?? olds!.setIdentifier,
-            },
-          );
+          const hostedZoneId = output?.hostedZoneId ?? olds?.hostedZoneId;
+          const name = output?.name ?? olds?.name;
+          const type = output?.type ?? olds?.type;
+          if (
+            hostedZoneId === undefined ||
+            name === undefined ||
+            type === undefined
+          ) {
+            // Output-valued props don't survive a `creating`-state round-trip
+            // — without the record's identity we can't look it up. Report
+            // "not found" so the engine re-drives the create (the UPSERT in
+            // reconcile converges on any half-created record).
+            return undefined;
+          }
+          const recordSet = yield* findRecord(hostedZoneId, {
+            name,
+            type,
+            setIdentifier: output?.setIdentifier ?? olds?.setIdentifier,
+          });
 
           if (!recordSet) {
             return undefined;
           }
 
-          return toAttrs(recordSet, output?.hostedZoneId ?? olds!.hostedZoneId);
+          return toAttrs(recordSet, hostedZoneId);
         }),
         reconcile: Effect.fn(function* ({ news, session }) {
           // Route 53 `changeResourceRecordSets` with `UPSERT` is naturally

--- a/packages/alchemy/src/AWS/Route53/Record.ts
+++ b/packages/alchemy/src/AWS/Route53/Record.ts
@@ -477,17 +477,22 @@ export const RecordProvider = () =>
       // Poll `getChange` until the change reaches INSYNC. `getChange` is
       // eventually consistent and can briefly return `NoSuchChange` right after
       // submit, so coalesce that to a non-INSYNC status and keep polling.
+      // `ChangeInfo.Id` comes back as "/change/C..." but `getChange` only
+      // accepts the bare id — the prefixed form returns `NoSuchChange`
+      // forever, silently burning the full repeat cap on every change.
       const waitForChange = Effect.fn(function* (changeId: string) {
-        return yield* route53.getChange({ Id: changeId }).pipe(
-          Effect.map((response) => response.ChangeInfo.Status),
-          Effect.catchTag("NoSuchChange", () => Effect.succeed("PENDING")),
-          Effect.repeat({
-            schedule: Schedule.fixed("2 seconds").pipe(
-              Schedule.both(Schedule.recurs(60)),
-            ),
-            until: (status) => status === "INSYNC",
-          }),
-        );
+        return yield* route53
+          .getChange({ Id: changeId.replace(/^\/change\//, "") })
+          .pipe(
+            Effect.map((response) => response.ChangeInfo.Status),
+            Effect.catchTag("NoSuchChange", () => Effect.succeed("PENDING")),
+            Effect.repeat({
+              schedule: Schedule.fixed("2 seconds").pipe(
+                Schedule.both(Schedule.recurs(60)),
+              ),
+              until: (status) => status === "INSYNC",
+            }),
+          );
       });
 
       const findRecord = Effect.fn(function* (

--- a/packages/alchemy/src/Cloudflare/Access/InfrastructureTarget.ts
+++ b/packages/alchemy/src/Cloudflare/Access/InfrastructureTarget.ts
@@ -178,7 +178,10 @@ export const InfrastructureTargetProvider = () =>
       // ownership markers, so gate adoption behind Unowned.
       const hostname = olds?.hostname ?? output?.hostname;
       if (!hostname) return undefined;
-      const desiredIp = olds ? resolvedIp(olds.ip) : output?.ip;
+      // `olds.ip` may be `undefined` when a `creating` row was persisted
+      // before upstream Outputs resolved — fall back to the output hint.
+      const desiredIp =
+        olds?.ip !== undefined ? resolvedIp(olds.ip) : output?.ip;
       const match = yield* findByIdentity(acct, hostname, desiredIp);
       if (match) return Unowned(toAttributes(match, acct));
       return undefined;

--- a/packages/alchemy/src/Cloudflare/Email/CatchAll.ts
+++ b/packages/alchemy/src/Cloudflare/Email/CatchAll.ts
@@ -180,7 +180,10 @@ export const CatchAllProvider = () =>
 
     read: Effect.fn(function* ({ output, olds }) {
       const zoneId =
-        output?.zoneId ?? (olds ? yield* resolve(olds.zone) : undefined);
+        // `olds.zone` may be `undefined` when a `creating` row was persisted
+        // before upstream Outputs resolved — report "not found" then.
+        output?.zoneId ??
+        (olds?.zone !== undefined ? yield* resolve(olds.zone) : undefined);
       if (!zoneId) return undefined;
       const observed = yield* emailRouting.getRuleCatchAll({ zoneId }).pipe(
         // Zone deleted out-of-band (or the token can no longer see it) —

--- a/packages/alchemy/src/Cloudflare/GoogleTagGateway/GoogleTagGateway.ts
+++ b/packages/alchemy/src/Cloudflare/GoogleTagGateway/GoogleTagGateway.ts
@@ -189,7 +189,10 @@ export const GoogleTagGatewayProvider = () =>
 
     read: Effect.fn(function* ({ output, olds }) {
       const zoneId =
-        output?.zoneId ?? (olds ? yield* resolve(olds.zone) : undefined);
+        // `olds.zone` may be `undefined` when a `creating` row was persisted
+        // before upstream Outputs resolved — report "not found" then.
+        output?.zoneId ??
+        (olds?.zone !== undefined ? yield* resolve(olds.zone) : undefined);
       if (!zoneId) return undefined;
       const observed = yield* googleTagGateway.getConfig({ zoneId }).pipe(
         // Zone deleted out-of-band — the config is gone with it.

--- a/packages/alchemy/src/Cloudflare/OriginCaCertificate/OriginCaCertificate.ts
+++ b/packages/alchemy/src/Cloudflare/OriginCaCertificate/OriginCaCertificate.ts
@@ -240,7 +240,10 @@ export const OriginCaCertificateProvider = () =>
       // adopt policy. Ambiguity (several live certs with the same
       // hostnames) means no identity at all — report missing and recreate
       // (certificates are free and revocation is harmless).
-      if (!olds?.hostnames?.length) return undefined;
+      // Output-valued hostname elements don't survive a `creating`-state
+      // round-trip (they deserialize as null/undefined) — without a concrete
+      // hostname there is no identity to search by.
+      if (typeof olds?.hostnames?.[0] !== "string") return undefined;
       const matches = yield* findByHostnames(olds.hostnames);
       if (matches.length !== 1) return undefined;
       const observed = yield* getCertificate(matches[0].id!);

--- a/packages/alchemy/src/Cloudflare/OriginTlsClientAuth/HostnameCertificate.ts
+++ b/packages/alchemy/src/Cloudflare/OriginTlsClientAuth/HostnameCertificate.ts
@@ -175,8 +175,12 @@ export const HostnameCertificateProvider = () =>
       ) {
         return { action: "replace" } as const;
       }
+      // Compare the certificate only when the old value is known — an
+      // Output-valued `certificate` doesn't survive a `creating`-state
+      // round-trip (it deserializes as `undefined`).
       if (
-        normalizePem(olds.certificate) !== normalizePem(news.certificate) ||
+        (olds.certificate !== undefined &&
+          normalizePem(olds.certificate) !== normalizePem(news.certificate)) ||
         unwrap(olds.privateKey) !== unwrap(news.privateKey)
       ) {
         // There is no update API for hostname client certificates — every

--- a/packages/alchemy/src/Cloudflare/Ruleset/Ruleset.ts
+++ b/packages/alchemy/src/Cloudflare/Ruleset/Ruleset.ts
@@ -257,8 +257,11 @@ export const toRulesetAttributes = (
 // type statically exposes it as an `Output`. During `diff` (plan time) the
 // zone can still be unresolved — e.g. when it's being created in the same
 // deploy — in which case `zoneId` is not yet a string. Callers must treat a
-// non-string result as "not resolved yet".
-const zoneIdOf = (zone: Zone): string | undefined => {
-  const zoneId = (zone as unknown as Partial<Attributes>).zoneId;
+// non-string result as "not resolved yet". May also receive `undefined`:
+// an Output-valued `zone` doesn't survive a `creating`-state round-trip
+// (it deserializes as `undefined`), and recovery paths hand those props
+// back as `olds`.
+const zoneIdOf = (zone: Zone | undefined): string | undefined => {
+  const zoneId = (zone as unknown as Partial<Attributes> | undefined)?.zoneId;
   return typeof zoneId === "string" ? zoneId : undefined;
 };

--- a/packages/alchemy/src/Cloudflare/Zaraz/Config.ts
+++ b/packages/alchemy/src/Cloudflare/Zaraz/Config.ts
@@ -253,7 +253,10 @@ export const ConfigProvider = () =>
     }),
     read: Effect.fn(function* ({ olds, output }) {
       const zoneId =
-        output?.zoneId ?? (olds ? yield* resolve(olds.zone) : undefined);
+        // `olds.zone` may be `undefined` when a `creating` row was persisted
+        // before upstream Outputs resolved — report "not found" then.
+        output?.zoneId ??
+        (olds?.zone !== undefined ? yield* resolve(olds.zone) : undefined);
       if (!zoneId) return undefined;
       return yield* observe(zoneId);
     }),

--- a/packages/alchemy/src/Docker/Container.ts
+++ b/packages/alchemy/src/Docker/Container.ts
@@ -243,9 +243,14 @@ export const ContainerProvider = () =>
               ),
             );
           if (!info) return undefined;
+          // `olds.image` may be `undefined` when a `creating` row was
+          // persisted before upstream Outputs resolved — fall back to the
+          // live container's actual image.
           const attrs = toContainerAttributes(
             info,
-            normalizeImageRef(olds.image),
+            olds.image !== undefined
+              ? normalizeImageRef(olds.image)
+              : info.Config.Image,
           );
           if (output) return attrs;
           // Without prior state, only adopt a container that carries our
@@ -258,6 +263,10 @@ export const ContainerProvider = () =>
         }),
         diff: Effect.fn(function* ({ id, instanceId, news, olds }) {
           if (!isResolved(news)) return undefined;
+          // An Output-valued `image` doesn't survive a `creating`-state
+          // round-trip (it deserializes as `undefined`) — without comparable
+          // prior create args, let the engine apply its default update logic.
+          if (olds.image === undefined) return undefined;
           const oldArgs = yield* makeCreateArgs(id, olds, instanceId);
           const newArgs = yield* makeCreateArgs(id, news, instanceId);
           if (!Equal.equals(oldArgs, newArgs)) {

--- a/packages/alchemy/src/Neon/Branch.ts
+++ b/packages/alchemy/src/Neon/Branch.ts
@@ -204,13 +204,20 @@ export const BranchProvider = () =>
       // planning engine resolves `news.project` to a plain object carrying that stable id (even when the project is being
       // updated in place). An unchanged project therefore resolves to the same string; a changed/replaced project resolves
       // to either a different string or an unresolved output, so `oldProjectId !== newProjectId` evaluates correctly.
+      // An Output-valued `project` doesn't survive a `creating`-state
+      // round-trip (it deserializes as `undefined`) — when the old project is
+      // unknown, fall through to the create/update recovery path rather than
+      // force a replacement.
       const oldProjectId =
-        output?.projectId ?? resolveProjectId(olds.project as BranchSource);
+        output?.projectId ??
+        (olds.project !== undefined
+          ? maybeResolveProjectId(olds.project as BranchSource)
+          : undefined);
       const newProjectId =
         "project" in news
           ? maybeResolveProjectId(news.project as BranchSource)
           : undefined;
-      if (oldProjectId !== newProjectId) {
+      if (oldProjectId !== undefined && oldProjectId !== newProjectId) {
         return { action: "replace" } as const;
       }
       if (!isResolved(news)) return undefined;
@@ -283,7 +290,12 @@ export const BranchProvider = () =>
         );
       }
       if (!olds?.project) return undefined;
-      const projectId = resolveProjectId(olds.project as BranchSource);
+      const projectId = maybeResolveProjectId(olds.project as BranchSource);
+      if (projectId === undefined) {
+        // The project reference survived as an object but its Output-valued
+        // `projectId` did not — there is nothing to look the branch up in.
+        return undefined;
+      }
       const name = yield* createBranchName(id, olds.name);
       const matches = yield* findBranchByName(projectId, name);
       const match = matches[0];

--- a/packages/alchemy/test/AWS/ACM/Certificate.test.ts
+++ b/packages/alchemy/test/AWS/ACM/Certificate.test.ts
@@ -2,12 +2,20 @@ import * as AWS from "@/AWS";
 import { Certificate, waitForRoute53Change } from "@/AWS/ACM/Certificate.ts";
 import { HostedZone } from "@/AWS/Route53";
 import * as Provider from "@/Provider";
+import { isResourceState, State, type ResourceState } from "@/State";
 import * as Test from "@/Test/Vitest";
+import { Region as AwsRegion } from "@distilled.cloud/aws/Region";
+import * as acm from "@distilled.cloud/aws/acm";
 import * as route53 from "@distilled.cloud/aws/route-53";
 import { expect } from "@effect/vitest";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";
+
+// ACM certificates for CloudFront are provider-pinned to us-east-1; every
+// out-of-band ACM call in this file must target the same region.
+const withUsEast1 = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+  effect.pipe(Effect.provideService(AwsRegion, Effect.succeed("us-east-1")));
 
 const { test } = Test.make({ providers: AWS.providers() });
 
@@ -101,3 +109,124 @@ test.provider.skipIf(!!process.env.FAST)(
 );
 
 class CertificateNotListed extends Data.TaggedError("CertificateNotListed") {}
+
+// Regression test for https://github.com/alchemy-run/alchemy-effect/issues/736.
+//
+// A `creating` state row persisted before upstream Outputs resolve cannot
+// round-trip Output-valued props (`domainName` from a HostedZone Output,
+// `hostedZoneId`) — they deserialize as `undefined`. In the worst case the
+// row's props are junk and the engine's deletion-planning branch (which every
+// `destroy` and every deploy that drops the resource runs) calls
+// `provider.read` with those junk `olds`. Before the fix, `read` dereferenced
+// `olds!` unconditionally (`findManagedCertificate` reads
+// `props.keyAlgorithm` / `props.domainName`), so planning crashed with a
+// TypeError and wedged the stack — plan/deploy/destroy all build a plan, so
+// there was no CLI escape hatch.
+//
+// Simulate exactly that row after a real deploy and assert the guarded `read`
+// reports "not found" instead of crashing: destroy succeeds (skipping the
+// physical delete, since no attr could be recovered), and a follow-up deploy
+// of the same program converges on the SAME leaked certificate (found by
+// domain + SAN + alchemy ownership tags) — no duplicate is requested.
+test.provider.skipIf(!!process.env.FAST)(
+  "recovers a wedged creating-state certificate whose props were lost (#736)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const domainName = "alchemy-acm-recovery-736.example.com";
+      const deployCertificate = () =>
+        stack.deploy(
+          Certificate("RecoveryCertificate", {
+            domainName,
+            // List the primary domain explicitly: ACM's DescribeCertificate
+            // reports it in SubjectAlternativeNames, and recovery-by-search
+            // (`findManagedCertificate`) compares that list against the
+            // props' SAN list — aligning them is what lets the redeploy
+            // below converge on the leaked certificate.
+            subjectAlternativeNames: [domainName],
+          }),
+        );
+
+      const created = yield* deployCertificate();
+      expect(created.certificateArn).toBeDefined();
+
+      // Safety net: reclaim the certificate on scope close even if the body
+      // fails mid-way (e.g. during the pre-fix crash verification).
+      yield* Effect.addFinalizer(() =>
+        withUsEast1(
+          acm.deleteCertificate({ CertificateArn: created.certificateArn }),
+        ).pipe(Effect.ignore),
+      );
+
+      // `ListCertificates` is eventually consistent; the recovery redeploy
+      // below finds the certificate through it, so wait (bounded) until the
+      // fresh ARN is visible before wedging the state.
+      yield* Effect.gen(function* () {
+        const listed = yield* withUsEast1(acm.listCertificates({}));
+        if (
+          !listed.CertificateSummaryList?.some(
+            (summary) => summary.CertificateArn === created.certificateArn,
+          )
+        ) {
+          return yield* Effect.fail(new CertificateNotListed());
+        }
+      }).pipe(
+        Effect.retry({
+          while: (e) => e._tag === "CertificateNotListed",
+          schedule: Schedule.fixed("3 seconds").pipe(
+            Schedule.both(Schedule.recurs(18)),
+          ),
+        }),
+      );
+
+      // Rewrite the certificate's persisted row into the wedged shape an
+      // interrupted deploy leaves behind: `creating`, no attributes, and the
+      // props lost in the Output round-trip.
+      const state = yield* yield* State;
+      const stage = "test"; // scratch stacks default to the "test" stage
+      const fqns = yield* state.list({ stack: stack.name, stage });
+      const rows = yield* Effect.forEach(fqns, (fqn) =>
+        state
+          .get({ stack: stack.name, stage, fqn })
+          .pipe(Effect.map((row) => ({ fqn, row }))),
+      );
+      const wedged = rows.find(
+        (r): r is { fqn: string; row: ResourceState } =>
+          isResourceState(r.row) &&
+          r.row.resourceType === "AWS.ACM.Certificate",
+      );
+      if (!wedged) {
+        return yield* Effect.die(
+          new Error("no AWS.ACM.Certificate state row found after deploy"),
+        );
+      }
+      yield* state.set({
+        stack: stack.name,
+        stage,
+        fqn: wedged.fqn,
+        value: {
+          ...wedged.row,
+          status: "creating",
+          attr: undefined,
+          props: undefined as never,
+        },
+      });
+
+      // Deletion planning reads the wedged row with `olds: undefined`.
+      // Before the fix this crashed with
+      // `TypeError: undefined is not an object (evaluating 'props.keyAlgorithm')`;
+      // after it, `read` reports "not found", the physical delete is skipped
+      // (no attr could be recovered) and the row is reaped.
+      yield* stack.destroy();
+
+      // The certificate itself leaked (the wedged row had no recoverable
+      // attr) — redeploying the same program must converge on it via
+      // domain + SAN + ownership tags instead of requesting a duplicate.
+      const recovered = yield* deployCertificate();
+      expect(recovered.certificateArn).toEqual(created.certificateArn);
+
+      yield* stack.destroy();
+    }),
+  { timeout: 240_000 },
+);

--- a/packages/alchemy/test/AWS/AutoScaling/AutoScalingGroup.test.ts
+++ b/packages/alchemy/test/AWS/AutoScaling/AutoScalingGroup.test.ts
@@ -1,8 +1,9 @@
 import * as AWS from "@/AWS";
-import { AutoScalingGroup } from "@/AWS/AutoScaling";
+import { AutoScalingGroup, LaunchTemplate } from "@/AWS/AutoScaling";
 import { amazonLinux2023, Subnet, Vpc } from "@/AWS/EC2";
 import * as Provider from "@/Provider";
 import * as Test from "@/Test/Vitest";
+import * as autoscaling from "@distilled.cloud/aws/auto-scaling";
 import * as ec2 from "@distilled.cloud/aws/ec2";
 import { expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
@@ -83,5 +84,91 @@ test.provider.skipIf(!process.env.AWS_TEST_AUTOSCALING)(
 
       yield* stack.destroy();
     }).pipe(Effect.ensuring(cleanupLaunchTemplate)),
+  { timeout: 240_000 },
+);
+
+// Whole-resource `launchTemplate: template` spelling. The engine resolves the
+// resource reference to its bare Attributes record before it reaches the
+// provider — no resource `Type` marker survives — so `toLaunchTemplateSpec`
+// must narrow on the attributes shape. Pre-fix it fell through to the
+// reference branch, which sent BOTH LaunchTemplateId and LaunchTemplateName
+// to `createAutoScalingGroup` (AWS rejects a spec carrying both) with the
+// version defaulted to `$Default` instead of the template's resolved default
+// version.
+//
+// The fleet is placed into a subnet of the account's default VPC (resolved
+// out-of-band) rather than a throwaway `Vpc` resource: a failed run loses its
+// in-memory scratch state, and orphaned VPCs quickly exhaust the 5-per-region
+// quota.
+const wholeAsgName = "alchemy-test-asg-whole-lt";
+const cleanupWholeAsg = autoscaling
+  .deleteAutoScalingGroup({
+    AutoScalingGroupName: wholeAsgName,
+    ForceDelete: true,
+  } as any)
+  .pipe(Effect.catch(() => Effect.void));
+
+test.provider(
+  "wires a whole LaunchTemplate resource by id and pinned default version",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* cleanupWholeAsg;
+      yield* stack.destroy();
+
+      // Launch templates do not validate the AMI at creation time; fall back
+      // to a syntactically valid id if the lookup returns nothing.
+      const imageId = (yield* amazonLinux2023()) ?? "ami-00000000000000000";
+
+      const subnets = yield* ec2.describeSubnets({
+        Filters: [{ Name: "default-for-az", Values: ["true"] }],
+      } as any);
+      const subnetId = subnets.Subnets?.[0]?.SubnetId;
+      if (!subnetId) {
+        return yield* Effect.die(
+          new Error("no default-VPC subnet available in this region"),
+        );
+      }
+
+      const deployed = yield* stack.deploy(
+        Effect.gen(function* () {
+          const template = yield* LaunchTemplate("WholeLtTemplate", {
+            imageId,
+            instanceType: "t3.micro",
+          });
+          const group = yield* AutoScalingGroup("WholeLtGroup", {
+            autoScalingGroupName: wholeAsgName,
+            // Whole resource — resolves to bare Attributes at deploy time.
+            launchTemplate: template,
+            subnetIds: [subnetId as `subnet-${string}`],
+            minSize: 0,
+            maxSize: 0,
+            desiredCapacity: 0,
+          });
+          return {
+            templateId: template.launchTemplateId.as<string>(),
+            templateDefaultVersion: template.defaultVersionNumber.as<number>(),
+            group,
+          };
+        }),
+      );
+
+      // The group is wired to the template by ID with the version pinned to
+      // the template's resolved default version (not "$Default").
+      expect(deployed.group.launchTemplateId).toEqual(deployed.templateId);
+      expect(deployed.group.launchTemplateVersion).toEqual(
+        String(deployed.templateDefaultVersion),
+      );
+
+      // Out-of-band: the live group carries the id-only spec.
+      const described = yield* autoscaling.describeAutoScalingGroups({
+        AutoScalingGroupNames: [wholeAsgName],
+      } as any);
+      const live = described.AutoScalingGroups?.[0];
+      expect(live?.LaunchTemplate?.LaunchTemplateId).toEqual(
+        deployed.templateId,
+      );
+
+      yield* stack.destroy();
+    }).pipe(Effect.ensuring(cleanupWholeAsg)),
   { timeout: 240_000 },
 );

--- a/packages/alchemy/test/AWS/AutoScaling/ScalingPolicy.test.ts
+++ b/packages/alchemy/test/AWS/AutoScaling/ScalingPolicy.test.ts
@@ -6,9 +6,13 @@ import {
 } from "@/AWS/AutoScaling";
 import { amazonLinux2023, Subnet, Vpc } from "@/AWS/EC2";
 import * as Provider from "@/Provider";
+import { isResourceState, State, type ResourceState } from "@/State";
 import * as Test from "@/Test/Vitest";
+import * as autoscaling from "@distilled.cloud/aws/auto-scaling";
+import * as ec2 from "@distilled.cloud/aws/ec2";
 import { expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
 
 const { test } = Test.make({ providers: AWS.providers() });
 
@@ -77,5 +81,196 @@ test.provider.skipIf(!process.env.AWS_TEST_SCALING_POLICY_LIST)(
 
       yield* stack.destroy();
     }),
+  { timeout: 240_000 },
+);
+
+// Regression test for https://github.com/alchemy-run/alchemy-effect/issues/736.
+//
+// An interrupted first deploy persists the scaling policy as
+// `status: "creating"` with no attributes — and the Output-valued
+// `autoScalingGroup` prop (a whole AutoScalingGroup resource object) does not
+// survive the state round-trip: it deserializes as `undefined`. Plan's
+// recovery branches then hand those junk props back to the provider as
+// `olds`:
+//
+// - `read` must tolerate `olds.autoScalingGroup === undefined` and fall back
+//   to an account-wide `describePolicies` lookup by (unique physical) policy
+//   name, so a half-created policy that DOES exist is recovered in place
+//   (same policyArn, no duplicate).
+// - `diff` must NOT treat "old ASG name unknown vs new ASG name known" as an
+//   ASG change: pre-fix it forced `action: "replace"`, which mints a new
+//   instanceId and therefore a NEW generated policy name instead of resuming
+//   the same create.
+//
+// The launch template is created out-of-band via distilled `ec2` (not the
+// `AWS.AutoScaling.LaunchTemplate` resource) to isolate this test from that
+// provider's unrelated untyped-NotFound read bug. The fleet is placed into a
+// subnet of the account's default VPC (resolved out-of-band) rather than a
+// throwaway `Vpc` resource: a failed run of this test loses its in-memory
+// scratch state, and orphaned VPCs quickly exhaust the 5-per-region quota.
+const recoveryLtName = "alchemy-test-scaling-policy-recovery-lt";
+const recoveryAsgName = "alchemy-test-scaling-policy-recovery-asg";
+const cleanupRecoveryLt = ec2
+  .deleteLaunchTemplate({ LaunchTemplateName: recoveryLtName } as any)
+  .pipe(Effect.catch(() => Effect.void));
+// Leftover-cleanup for interrupted/failed prior runs (the ASG name is
+// deterministic and account-unique; deleting it also deletes its policies).
+const cleanupRecoveryAsg = autoscaling
+  .deleteAutoScalingGroup({
+    AutoScalingGroupName: recoveryAsgName,
+    ForceDelete: true,
+  } as any)
+  .pipe(Effect.catch(() => Effect.void));
+
+test.provider(
+  "recovers a half-created scaling policy whose creating-state lost the Output-valued autoScalingGroup (#736)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* cleanupRecoveryAsg;
+      yield* cleanupRecoveryLt;
+      yield* stack.destroy();
+
+      // Launch templates do not validate the AMI at creation time; fall back
+      // to a syntactically valid id if the lookup returns nothing.
+      const imageId = (yield* amazonLinux2023()) ?? "ami-00000000000000000";
+      yield* ec2.createLaunchTemplate({
+        LaunchTemplateName: recoveryLtName,
+        LaunchTemplateData: { ImageId: imageId, InstanceType: "t3.micro" },
+      } as any);
+
+      const subnets = yield* ec2.describeSubnets({
+        Filters: [{ Name: "default-for-az", Values: ["true"] }],
+      } as any);
+      const subnetId = subnets.Subnets?.[0]?.SubnetId;
+      if (!subnetId) {
+        return yield* Effect.die(
+          new Error("no default-VPC subnet available in this region"),
+        );
+      }
+
+      const deployPolicy = () =>
+        stack.deploy(
+          Effect.gen(function* () {
+            const group = yield* AutoScalingGroup("RecoveryGroup", {
+              autoScalingGroupName: recoveryAsgName,
+              launchTemplate: { launchTemplateName: recoveryLtName },
+              subnetIds: [subnetId as `subnet-${string}`],
+              minSize: 0,
+              maxSize: 0,
+              desiredCapacity: 0,
+            });
+            return yield* ScalingPolicy("RecoveryScalingPolicy", {
+              // Whole-resource spelling — the #736 shape (an unresolved
+              // Output persisted at `creating` does not survive the state
+              // round-trip) AND coverage for the resolved-attributes
+              // narrowing: the engine resolves `group` to its bare
+              // Attributes record (no resource `Type` marker), which the
+              // provider must narrow by shape (`autoScalingGroupName`
+              // string field) to extract the group name.
+              // policyName intentionally omitted: the engine-generated
+              // physical name embeds the instanceId, so a wrongful
+              // `replace` (pre-fix diff) is observable as a changed name.
+              autoScalingGroup: group,
+              predefinedMetricType: "ASGAverageCPUUtilization",
+              targetValue: 50,
+            });
+          }),
+        );
+
+      const created = yield* deployPolicy();
+
+      // Rewrite the policy's persisted row into the wedged shape an
+      // interrupted deploy leaves behind: `creating`, no attributes, and the
+      // Output-valued `autoScalingGroup` lost in the round-trip.
+      const wedgeRow = Effect.gen(function* () {
+        const state = yield* yield* State;
+        const stage = "test"; // scratch stacks default to the "test" stage
+        const fqns = yield* state.list({ stack: stack.name, stage });
+        const rows = yield* Effect.forEach(fqns, (fqn) =>
+          state
+            .get({ stack: stack.name, stage, fqn })
+            .pipe(Effect.map((row) => ({ fqn, row }))),
+        );
+        const wedged = rows.find(
+          (r): r is { fqn: string; row: ResourceState } =>
+            isResourceState(r.row) &&
+            r.row.resourceType === "AWS.AutoScaling.ScalingPolicy",
+        );
+        if (!wedged) {
+          return yield* Effect.die(
+            new Error(
+              "no AWS.AutoScaling.ScalingPolicy state row found after deploy",
+            ),
+          );
+        }
+        yield* state.set({
+          stack: stack.name,
+          stage,
+          fqn: wedged.fqn,
+          value: {
+            ...wedged.row,
+            status: "creating",
+            attr: undefined,
+            props: {
+              ...wedged.row.props,
+              autoScalingGroup: undefined,
+            },
+          },
+        });
+      });
+
+      // Variant A — the half-created policy still exists in the cloud.
+      // `read` gets junk olds (no ASG name) and must find the policy via the
+      // account-wide name-only lookup: SAME policyArn, no duplicate.
+      yield* wedgeRow;
+      const recoveredInPlace = yield* deployPolicy();
+      expect(recoveredInPlace.policyArn).toEqual(created.policyArn);
+      expect(recoveredInPlace.policyName).toEqual(created.policyName);
+      expect(recoveredInPlace.autoScalingGroupName).toEqual(
+        created.autoScalingGroupName,
+      );
+
+      // Variant B — wedge again AND delete the policy out-of-band so the
+      // recovery `read` misses and `diff` runs with the junk olds. Pre-fix,
+      // diff saw `undefined !== <asg name>` and forced a replacement (new
+      // instanceId => new generated policy name). Post-fix it falls through
+      // to update, resumes the same create, and recreates under the SAME
+      // name.
+      yield* wedgeRow;
+      yield* autoscaling.deletePolicy({
+        AutoScalingGroupName: created.autoScalingGroupName,
+        PolicyName: created.policyName,
+      } as any);
+      const remaining = yield* autoscaling
+        .describePolicies({ PolicyNames: [created.policyName] })
+        .pipe(
+          Effect.map((result) => (result.ScalingPolicies ?? []).length),
+          Effect.repeat({
+            until: (count) => count === 0,
+            schedule: Schedule.spaced("2 seconds"),
+            times: 8,
+          }),
+        );
+      expect(remaining).toBe(0);
+
+      const recreated = yield* deployPolicy();
+      expect(recreated.policyName).toEqual(created.policyName);
+      expect(recreated.autoScalingGroupName).toEqual(
+        created.autoScalingGroupName,
+      );
+
+      // Out-of-band proof the policy is live again.
+      const after = yield* autoscaling.describePolicies({
+        PolicyNames: [created.policyName],
+      });
+      expect(
+        (after.ScalingPolicies ?? []).some(
+          (p) => p.PolicyName === created.policyName,
+        ),
+      ).toBe(true);
+
+      yield* stack.destroy();
+      yield* cleanupRecoveryLt;
+    }).pipe(Effect.ensuring(cleanupRecoveryLt)),
   { timeout: 240_000 },
 );

--- a/packages/alchemy/test/AWS/CloudFront/PublicKey.test.ts
+++ b/packages/alchemy/test/AWS/CloudFront/PublicKey.test.ts
@@ -1,6 +1,7 @@
 import * as AWS from "@/AWS";
 import { PublicKey } from "@/AWS/CloudFront";
 import * as Provider from "@/Provider";
+import { isResourceState, State, type ResourceState } from "@/State";
 import * as Test from "@/Test/Vitest";
 import * as cloudfront from "@distilled.cloud/aws/cloudfront";
 import { describe, expect } from "@effect/vitest";
@@ -43,8 +44,9 @@ describe("AWS.CloudFront.PublicKey", () => {
         });
         expect(initial.PublicKey?.Id).toEqual(created.publicKeyId);
         expect(initial.PublicKey?.PublicKeyConfig?.Comment).toEqual("initial");
-        expect(initial.PublicKey?.PublicKeyConfig?.EncodedKey).toEqual(
-          TEST_PUBLIC_KEY,
+        // CloudFront normalizes the stored key (trailing newline stripped).
+        expect(initial.PublicKey?.PublicKeyConfig?.EncodedKey?.trim()).toEqual(
+          TEST_PUBLIC_KEY.trim(),
         );
 
         const updated = yield* stack.deploy(
@@ -96,6 +98,97 @@ describe("AWS.CloudFront.PublicKey", () => {
         yield* assertPublicKeyDeleted(deployed.publicKeyId);
       }),
     { timeout: 300_000 },
+  );
+
+  test.provider.skipIf(!runLive)(
+    "recovers a wedged creating-state row that lost its Output-valued encodedKey (#736)",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const deployKey = () =>
+          stack.deploy(
+            Effect.gen(function* () {
+              return yield* PublicKey("WedgedKey", {
+                encodedKey: TEST_PUBLIC_KEY,
+                comment: "wedged recovery test",
+              });
+            }),
+          );
+
+        const created = yield* deployKey();
+
+        // Rewrite the persisted row into the wedged shape an interrupted
+        // deploy leaves behind: `creating`, no attributes, and the
+        // Output-valued `encodedKey` lost in the round-trip (#736).
+        const state = yield* yield* State;
+        const stage = "test"; // scratch stacks default to the "test" stage
+        const fqns = yield* state.list({ stack: stack.name, stage });
+        const rows = yield* Effect.forEach(fqns, (fqn) =>
+          state
+            .get({ stack: stack.name, stage, fqn })
+            .pipe(Effect.map((row) => ({ fqn, row }))),
+        );
+        const wedged = rows.find(
+          (r): r is { fqn: string; row: ResourceState } =>
+            isResourceState(r.row) &&
+            r.row.resourceType === "AWS.CloudFront.PublicKey",
+        );
+        if (!wedged) {
+          return yield* Effect.die(
+            new Error(
+              "no AWS.CloudFront.PublicKey state row found after deploy",
+            ),
+          );
+        }
+        yield* state.set({
+          stack: stack.name,
+          stage,
+          fqn: wedged.fqn,
+          value: {
+            ...wedged.row,
+            status: "creating",
+            attr: undefined,
+            props: {
+              ...wedged.row.props,
+              encodedKey: undefined,
+            },
+          },
+        });
+
+        // Delete the public key out-of-band so the recovery `read` misses
+        // and the engine falls through to `diff` with the junk olds.
+        const current = yield* cloudfront.getPublicKey({
+          Id: created.publicKeyId,
+        });
+        yield* cloudfront
+          .deletePublicKey({
+            Id: created.publicKeyId,
+            IfMatch: current.ETag,
+          })
+          .pipe(Effect.catchTag("NoSuchPublicKey", () => Effect.void));
+        yield* assertPublicKeyDeleted(created.publicKeyId);
+
+        // Before the fix this crashed in `diff`: `extractValue(undefined)`
+        // called `Redacted.value(undefined)` on the lost `olds.encodedKey`.
+        // After the fix, diff skips the comparison and the engine recreates
+        // the key cleanly.
+        const recovered = yield* deployKey();
+        expect(recovered.publicKeyId).not.toEqual(created.publicKeyId);
+
+        const after = yield* cloudfront.getPublicKey({
+          Id: recovered.publicKeyId,
+        });
+        expect(after.PublicKey?.Id).toEqual(recovered.publicKeyId);
+        // CloudFront normalizes the stored key (trailing newline stripped).
+        expect(after.PublicKey?.PublicKeyConfig?.EncodedKey?.trim()).toEqual(
+          TEST_PUBLIC_KEY.trim(),
+        );
+
+        yield* stack.destroy();
+        yield* assertPublicKeyDeleted(recovered.publicKeyId);
+      }),
+    { timeout: 240_000 },
   );
 });
 

--- a/packages/alchemy/test/AWS/DynamoDB/Table.test.ts
+++ b/packages/alchemy/test/AWS/DynamoDB/Table.test.ts
@@ -2,7 +2,7 @@ import { adopt } from "@/AdoptPolicy";
 import * as AWS from "@/AWS";
 import { Table } from "@/AWS/DynamoDB";
 import * as Provider from "@/Provider";
-import { State } from "@/State";
+import { isResourceState, State, type ResourceState } from "@/State";
 import * as Test from "@/Test/Vitest";
 import * as DynamoDB from "@distilled.cloud/aws/dynamodb";
 import { describe, expect } from "@effect/vitest";
@@ -709,6 +709,104 @@ describe.skipIf(!!process.env.FAST)("AWS.DynamoDB.Table", () => {
         yield* assertTableIsDeleted(tableName);
       }),
     { timeout: 360_000 },
+  );
+
+  // Regression test for https://github.com/alchemy-run/alchemy-effect/issues/736.
+  //
+  // An interrupted first deploy persists the table as `status: "creating"`
+  // with no attributes — and Output-valued props do not survive the state
+  // round-trip: they deserialize as `undefined`. Plan's recovery branch first
+  // calls `provider.read` with those junk olds; if read misses, it then calls
+  // `provider.diff` against the same junk olds, which crashed in
+  // `Object.entries(olds.attributes)` when `attributes` was lost.
+  //
+  // Simulate exactly that state row after a real deploy, then delete the
+  // table out-of-band so `read` cannot recover it by name (a live table would
+  // be recovered and `diff` would never run against the junk olds), and
+  // assert the next deploy falls through diff and recreates the table.
+  test.provider(
+    "recovers a creating-state row that lost its attributes prop (#736)",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const deployTable = () =>
+          stack.deploy(
+            Effect.gen(function* () {
+              return yield* Table("WedgedTable", {
+                partitionKey: "id",
+                attributes: { id: "S" },
+              });
+            }),
+          );
+
+        const created = yield* deployTable();
+
+        // Rewrite the table's persisted row into the wedged shape an
+        // interrupted deploy leaves behind: `creating`, no attributes, and
+        // the `attributes` prop lost in the state round-trip.
+        const state = yield* yield* State;
+        const stage = "test"; // scratch stacks default to the "test" stage
+        const fqns = yield* state.list({ stack: stack.name, stage });
+        const rows = yield* Effect.forEach(fqns, (fqn) =>
+          state
+            .get({ stack: stack.name, stage, fqn })
+            .pipe(Effect.map((row) => ({ fqn, row }))),
+        );
+        const wedged = rows.find(
+          (r): r is { fqn: string; row: ResourceState } =>
+            isResourceState(r.row) &&
+            r.row.resourceType === "AWS.DynamoDB.Table",
+        );
+        if (!wedged) {
+          return yield* Effect.die(
+            new Error("no AWS.DynamoDB.Table state row found after deploy"),
+          );
+        }
+        yield* state.set({
+          stack: stack.name,
+          stage,
+          fqn: wedged.fqn,
+          value: {
+            ...wedged.row,
+            status: "creating",
+            attr: undefined,
+            props: {
+              ...wedged.row.props,
+              attributes: undefined,
+            },
+          },
+        });
+
+        // Delete the table out-of-band so the recovery `read` misses.
+        yield* logTestStep(
+          `deleting ${created.tableName} out-of-band to force a read miss`,
+        );
+        yield* DynamoDB.deleteTable({ TableName: created.tableName }).pipe(
+          Effect.retry({
+            while: (e) => e._tag === "ResourceInUseException",
+            schedule: Schedule.fixed("2 seconds").pipe(
+              Schedule.both(Schedule.recurs(10)),
+            ),
+          }),
+          Effect.catchTag("ResourceNotFoundException", () => Effect.void),
+        );
+        yield* assertTableIsDeleted(created.tableName);
+
+        // Before the fix this crashed in plan's diff with
+        // `TypeError: undefined is not an object (evaluating 'olds.attributes')`.
+        const recovered = yield* deployTable();
+        expect(recovered.tableName).toEqual(created.tableName);
+
+        const actual = yield* DynamoDB.describeTable({
+          TableName: recovered.tableName,
+        });
+        expect(actual.Table?.TableArn).toEqual(recovered.tableArn);
+
+        yield* stack.destroy();
+        yield* assertTableIsDeleted(recovered.tableName);
+      }),
+    { timeout: 240_000 },
   );
 
   const assertTableIsDeleted = Effect.fn(function* (tableName: string) {

--- a/packages/alchemy/test/AWS/IAM/OpenIDConnectProvider.test.ts
+++ b/packages/alchemy/test/AWS/IAM/OpenIDConnectProvider.test.ts
@@ -1,12 +1,18 @@
 import * as AWS from "@/AWS";
 import { OpenIDConnectProvider } from "@/AWS/IAM";
 import * as Provider from "@/Provider";
+import { isResourceState, State, type ResourceState } from "@/State";
 import * as Test from "@/Test/Vitest";
 import { describe, expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import { testOidcListUrl, testOidcThumbprintA } from "./fixtures.ts";
 
 const { test } = Test.make({ providers: AWS.providers() });
+
+// A distinct issuer URL for the #736 recovery test — the OIDC provider ARN is
+// deterministic from the URL, so sharing a URL with another test would make
+// two tests provision (and tear down) the same physical provider.
+const testOidcWedgedUrl = "https://example.com/alchemy-oidc-wedged";
 
 describe("AWS.IAM.OpenIDConnectProvider", () => {
   test.provider(
@@ -47,5 +53,75 @@ describe("AWS.IAM.OpenIDConnectProvider", () => {
 
         yield* stack.destroy();
       }),
+  );
+
+  test.provider(
+    "recovers a half-created provider whose creating-state lost Output-valued props (#736)",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const deployProvider = () =>
+          stack.deploy(
+            Effect.gen(function* () {
+              return yield* OpenIDConnectProvider("WedgedOidcProvider", {
+                url: testOidcWedgedUrl,
+                clientIDList: ["sts.amazonaws.com"],
+                thumbprintList: [testOidcThumbprintA],
+              });
+            }),
+          );
+
+        const created = yield* deployProvider();
+
+        // Rewrite the provider's persisted row into the wedged shape an
+        // interrupted deploy leaves behind: `creating`, no attributes, and
+        // the Output-valued `url` prop lost in the round-trip.
+        const state = yield* yield* State;
+        const stage = "test"; // scratch stacks default to the "test" stage
+        const fqns = yield* state.list({ stack: stack.name, stage });
+        const rows = yield* Effect.forEach(fqns, (fqn) =>
+          state
+            .get({ stack: stack.name, stage, fqn })
+            .pipe(Effect.map((row) => ({ fqn, row }))),
+        );
+        const wedged = rows.find(
+          (r): r is { fqn: string; row: ResourceState } =>
+            isResourceState(r.row) &&
+            r.row.resourceType === "AWS.IAM.OpenIDConnectProvider",
+        );
+        if (!wedged) {
+          return yield* Effect.die(
+            new Error(
+              "no AWS.IAM.OpenIDConnectProvider state row found after deploy",
+            ),
+          );
+        }
+        yield* state.set({
+          stack: stack.name,
+          stage,
+          fqn: wedged.fqn,
+          value: {
+            ...wedged.row,
+            status: "creating",
+            attr: undefined,
+            props: {
+              ...wedged.row.props,
+              url: undefined,
+            },
+          },
+        });
+
+        // Before the fix this crashed in `read` with
+        // `TypeError: undefined is not an object (evaluating 'url.replace')`.
+        const recovered = yield* deployProvider();
+        expect(recovered.openIDConnectProviderArn).toEqual(
+          created.openIDConnectProviderArn,
+        );
+        expect(recovered.url).toEqual(created.url);
+
+        yield* stack.destroy();
+      }),
+    { timeout: 240_000 },
   );
 });

--- a/packages/alchemy/test/AWS/Organizations/DelegatedAdministrator.test.ts
+++ b/packages/alchemy/test/AWS/Organizations/DelegatedAdministrator.test.ts
@@ -1,6 +1,7 @@
 import * as AWS from "@/AWS";
 import { DelegatedAdministrator } from "@/AWS/Organizations";
 import * as Provider from "@/Provider";
+import { isResourceState, State, type ResourceState } from "@/State";
 import * as Test from "@/Test/Vitest";
 import { expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
@@ -71,4 +72,93 @@ test.provider.skipIf(!memberAccountId)(
 
       yield* stack.destroy();
     }),
+);
+
+// Regression test for https://github.com/alchemy-run/alchemy-effect/issues/736.
+//
+// An interrupted first deploy persists the registration as
+// `status: "creating"` with no attributes — and the Output-valued props
+// (`accountId` typically comes from an `Account` resource) do not survive
+// the state round-trip: they deserialize as `undefined`. Plan's
+// creating-recovery branch then calls `provider.read` with those junk olds,
+// which pre-fix crashed in
+// `listDelegatedServicesForAccount({ AccountId: undefined })`
+// (`ParseError: Expected string, got undefined`) and wedged the stack.
+//
+// Simulate exactly that state row after a real deploy and assert the next
+// deploy recovers: `read` reports "not found", the engine re-drives the
+// create, and reconcile observes the existing registration before
+// registering — SAME (accountId, servicePrincipal) identity, no duplicate.
+//
+// Same gating as the lifecycle test above: requires an org MANAGEMENT
+// account plus a member account to register (a management account cannot
+// delegate itself — `ConstraintViolationException`), so this is skipped
+// unless AWS_ORG_DELEGATED_ADMIN_ACCOUNT_ID is set.
+test.provider.skipIf(!memberAccountId)(
+  "recovers a half-created delegated administrator whose creating-state lost Output-valued props (#736)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const deployAdmin = () =>
+        stack.deploy(
+          Effect.gen(function* () {
+            return yield* DelegatedAdministrator("WedgedDelegatedAdmin", {
+              accountId: memberAccountId!,
+              servicePrincipal,
+            });
+          }),
+        );
+
+      const created = yield* deployAdmin();
+
+      // Rewrite the registration's persisted row into the wedged shape an
+      // interrupted deploy leaves behind: `creating`, no attributes, and
+      // every Output-valued prop lost in the round-trip.
+      const state = yield* yield* State;
+      const stage = "test"; // scratch stacks default to the "test" stage
+      const fqns = yield* state.list({ stack: stack.name, stage });
+      const rows = yield* Effect.forEach(fqns, (fqn) =>
+        state
+          .get({ stack: stack.name, stage, fqn })
+          .pipe(Effect.map((row) => ({ fqn, row }))),
+      );
+      const wedged = rows.find(
+        (r): r is { fqn: string; row: ResourceState } =>
+          isResourceState(r.row) &&
+          r.row.resourceType === "AWS.Organizations.DelegatedAdministrator",
+      );
+      if (!wedged) {
+        return yield* Effect.die(
+          new Error(
+            "no AWS.Organizations.DelegatedAdministrator state row found after deploy",
+          ),
+        );
+      }
+      yield* state.set({
+        stack: stack.name,
+        stage,
+        fqn: wedged.fqn,
+        value: {
+          ...wedged.row,
+          status: "creating",
+          attr: undefined,
+          props: {
+            ...wedged.row.props,
+            accountId: undefined,
+            servicePrincipal: undefined,
+          },
+        },
+      });
+
+      // Before the fix this failed in plan: `read` called
+      // `listDelegatedServicesForAccount({ AccountId: undefined })` with the
+      // junk olds.
+      const recovered = yield* deployAdmin();
+      expect(recovered.accountId).toEqual(created.accountId);
+      expect(recovered.servicePrincipal).toEqual(created.servicePrincipal);
+
+      yield* stack.destroy();
+    }),
+  { timeout: 240_000 },
 );

--- a/packages/alchemy/test/AWS/Organizations/PolicyAttachment.test.ts
+++ b/packages/alchemy/test/AWS/Organizations/PolicyAttachment.test.ts
@@ -1,9 +1,17 @@
 import * as AWS from "@/AWS";
-import { PolicyAttachment } from "@/AWS/Organizations";
+import {
+  Policy,
+  PolicyAttachment,
+  Root,
+  RootPolicyType,
+} from "@/AWS/Organizations";
 import * as Provider from "@/Provider";
+import { isResourceState, State, type ResourceState } from "@/State";
 import * as Test from "@/Test/Vitest";
+import * as organizations from "@distilled.cloud/aws/organizations";
 import { expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
 
 const { test } = Test.make({ providers: AWS.providers() });
 
@@ -25,4 +33,197 @@ test.provider("list enumerates policy attachments", () =>
       expect(typeof attachment.targetId).toBe("string");
     }
   }),
+);
+
+// Regression test for https://github.com/alchemy-run/alchemy-effect/issues/736.
+//
+// An interrupted first deploy persists the attachment as `status: "creating"`
+// with no attributes — and the Output-valued props (`policyId` from the Policy
+// resource, `targetId` from the RootPolicyType resource) do not survive the
+// state round-trip: they deserialize as `undefined`. Plan's creating-recovery
+// branch then calls `provider.read` with those junk props, which crashed in
+// `listTargetsForPolicy({ PolicyId: undefined })` and wedged the stack.
+//
+// Simulate exactly that state row after a real deploy and assert the next
+// deploy recovers: `read` reports "not found", the engine re-drives the
+// create, and reconcile observes the existing attachment before attaching —
+// SAME (policyId, targetId) identity, no duplicate attachment.
+//
+// Requires an org MANAGEMENT account (enablePolicyType / createPolicy /
+// attachPolicy all reject off one), so gate behind the same env var the other
+// Organizations lifecycle tests use.
+test.provider.skipIf(!process.env.AWS_ORG_MANAGEMENT_ACCOUNT)(
+  "recovers a half-created attachment whose creating-state lost Output-valued props (#736)",
+  (stack) =>
+    Effect.gen(function* () {
+      const policyName = "alchemy-test-736-attachment";
+
+      // A prior interrupted run may have left an (untagged, hence unowned)
+      // SCP with our deterministic name behind — the adoption probe would
+      // then fail the create with `OwnedBySomeoneElse`. Clean it up
+      // out-of-band before deploying, and again on scope close.
+      const cleanLeftoverPolicies = Effect.gen(function* () {
+        const policies = yield* organizations.listPolicies({
+          Filter: "SERVICE_CONTROL_POLICY",
+        });
+        const leftovers = (policies.Policies ?? []).filter(
+          (policy): policy is organizations.PolicySummary & { Id: string } =>
+            policy.Name === policyName && policy.Id != null,
+        );
+        for (const leftover of leftovers) {
+          const targets = yield* organizations
+            .listTargetsForPolicy({ PolicyId: leftover.Id })
+            .pipe(
+              Effect.catchTag("PolicyNotFoundException", () =>
+                Effect.succeed({ Targets: [] }),
+              ),
+            );
+          for (const target of targets.Targets ?? []) {
+            if (target.TargetId == null) continue;
+            yield* organizations
+              .detachPolicy({
+                PolicyId: leftover.Id,
+                TargetId: target.TargetId,
+              })
+              .pipe(
+                Effect.catchTag(
+                  [
+                    "PolicyNotAttachedException",
+                    "PolicyNotFoundException",
+                    "TargetNotFoundException",
+                  ],
+                  () => Effect.void,
+                ),
+              );
+          }
+          // The detach above can lag — retry the delete through the typed
+          // `PolicyInUseException` (bounded), and tolerate already-gone.
+          yield* organizations.deletePolicy({ PolicyId: leftover.Id }).pipe(
+            Effect.retry({
+              while: (error) => error._tag === "PolicyInUseException",
+              schedule: Schedule.spaced("3 seconds"),
+              times: 8,
+            }),
+            Effect.catchTag("PolicyNotFoundException", () => Effect.void),
+          );
+        }
+      });
+      yield* cleanLeftoverPolicies;
+      yield* Effect.addFinalizer(() =>
+        cleanLeftoverPolicies.pipe(Effect.ignore),
+      );
+
+      yield* stack.destroy();
+
+      const deployStack = (includeAttachment: boolean) =>
+        stack.deploy(
+          Effect.gen(function* () {
+            // Import-style resource — adopts the single organization root.
+            const root = yield* Root("WedgedRoot", {});
+            const scpType = yield* RootPolicyType("WedgedScpType", {
+              rootId: root.rootId,
+              policyType: "SERVICE_CONTROL_POLICY",
+            });
+            // Allow-all SCP — attaching it alongside the AWS-managed
+            // FullAWSAccess policy changes nothing about effective access.
+            const policy = yield* Policy("WedgedScp", {
+              name: policyName,
+              type: "SERVICE_CONTROL_POLICY",
+              document: {
+                Version: "2012-10-17",
+                Statement: [{ Effect: "Allow", Action: ["*"], Resource: "*" }],
+              },
+            });
+            if (!includeAttachment) {
+              return undefined;
+            }
+            return yield* PolicyAttachment("WedgedAttachment", {
+              // Both identity props are Output-valued — the #736 shape.
+              policyId: policy.policyId,
+              // Thread the RootPolicyType's output so the attachment plans
+              // after SERVICE_CONTROL_POLICY is enabled on the root.
+              targetId: scpType.rootId,
+            });
+          }),
+        );
+
+      // Stage 1: enable the policy type + create the SCP, WITHOUT the
+      // attachment. `enablePolicyType` completes asynchronously
+      // (PENDING_ENABLE), and `attachPolicy` rejects with the typed
+      // `PolicyTypeNotEnabledException` until it lands — so wait (bounded)
+      // for ENABLED before deploying the attachment.
+      yield* deployStack(false);
+      yield* organizations.listRoots({}).pipe(
+        Effect.map((page) =>
+          (page.Roots ?? []).some((root) =>
+            (root.PolicyTypes ?? []).some(
+              (summary) =>
+                summary.Type === "SERVICE_CONTROL_POLICY" &&
+                summary.Status === "ENABLED",
+            ),
+          ),
+        ),
+        Effect.repeat({
+          schedule: Schedule.spaced("3 seconds"),
+          until: (enabled) => enabled,
+          times: 10,
+        }),
+      );
+
+      // Stage 2: deploy the attachment itself.
+      const created = yield* deployStack(true);
+      if (created === undefined) {
+        return yield* Effect.die(
+          new Error("stage-2 deploy returned no attachment"),
+        );
+      }
+
+      // Rewrite the attachment's persisted row into the wedged shape an
+      // interrupted deploy leaves behind: `creating`, no attributes, and
+      // every Output-valued prop lost in the round-trip.
+      const state = yield* yield* State;
+      const stage = "test"; // scratch stacks default to the "test" stage
+      const fqns = yield* state.list({ stack: stack.name, stage });
+      const rows = yield* Effect.forEach(fqns, (fqn) =>
+        state
+          .get({ stack: stack.name, stage, fqn })
+          .pipe(Effect.map((row) => ({ fqn, row }))),
+      );
+      const wedged = rows.find(
+        (r): r is { fqn: string; row: ResourceState } =>
+          isResourceState(r.row) &&
+          r.row.resourceType === "AWS.Organizations.PolicyAttachment",
+      );
+      if (!wedged) {
+        return yield* Effect.die(
+          new Error(
+            "no AWS.Organizations.PolicyAttachment state row found after deploy",
+          ),
+        );
+      }
+      yield* state.set({
+        stack: stack.name,
+        stage,
+        fqn: wedged.fqn,
+        value: {
+          ...wedged.row,
+          status: "creating",
+          attr: undefined,
+          props: {
+            ...wedged.row.props,
+            policyId: undefined,
+            targetId: undefined,
+          },
+        },
+      });
+
+      // Before the fix this failed in plan: `read` called
+      // `listTargetsForPolicy({ PolicyId: undefined })` with the junk olds.
+      const recovered = yield* deployStack(true);
+      expect(recovered?.policyId).toEqual(created.policyId);
+      expect(recovered?.targetId).toEqual(created.targetId);
+
+      yield* stack.destroy();
+    }),
+  { timeout: 240_000 },
 );

--- a/packages/alchemy/test/AWS/Organizations/RootPolicyType.test.ts
+++ b/packages/alchemy/test/AWS/Organizations/RootPolicyType.test.ts
@@ -1,6 +1,7 @@
 import * as AWS from "@/AWS";
-import { RootPolicyType } from "@/AWS/Organizations";
+import { Root, RootPolicyType } from "@/AWS/Organizations";
 import * as Provider from "@/Provider";
+import { isResourceState, State, type ResourceState } from "@/State";
 import * as Test from "@/Test/Vitest";
 import { expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
@@ -31,4 +32,93 @@ test.provider("list enumerates root policy types", () =>
       }
     }
   }),
+);
+
+// Regression test for https://github.com/alchemy-run/alchemy-effect/issues/736.
+//
+// An interrupted first deploy persists the enablement as `status: "creating"`
+// with no attributes — and props that could not round-trip (the `rootId` is
+// Output-valued, coming from the `Root` resource). Plan's creating-recovery
+// branch then calls `provider.read` with those junk olds; pre-fix the
+// `olds!.rootId` dereference crashed the plan when the persisted row carried
+// no recoverable props at all (`BaseResourceState` declares `props?:` — a row
+// whose Output-valued props failed to round-trip can surface with none).
+//
+// Simulate exactly that state row after a real deploy and assert the next
+// deploy recovers: `read` reports "not found", the engine re-drives the
+// create, and reconcile observes the policy type already enabled on the root
+// — SAME rootId, no duplicate enablement.
+//
+// Requires an org MANAGEMENT account (`enablePolicyType` rejects off one), so
+// gate behind the same env var the other Organizations lifecycle tests use.
+test.provider.skipIf(!process.env.AWS_ORG_MANAGEMENT_ACCOUNT)(
+  "recovers a half-created root policy type whose creating-state lost its props (#736)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const deployPolicyType = () =>
+        stack.deploy(
+          Effect.gen(function* () {
+            // Import-style resource — adopts the single organization root,
+            // so `rootId` below is genuinely Output-valued (the #736 shape).
+            const root = yield* Root("WedgedRoot", {});
+            return yield* RootPolicyType("WedgedBackupType", {
+              rootId: root.rootId,
+              policyType: "BACKUP_POLICY",
+            });
+          }),
+        );
+
+      const created = yield* deployPolicyType();
+
+      // Rewrite the enablement's persisted row into the wedged shape an
+      // interrupted deploy leaves behind: `creating`, no attributes, and no
+      // recoverable props (the realistic field-level loss — `rootId:
+      // undefined` — is tolerated even pre-fix because `readRootPolicyType`
+      // is list-and-find; the crash this fix guards is the `olds!` deref on
+      // a row with no props at all).
+      const state = yield* yield* State;
+      const stage = "test"; // scratch stacks default to the "test" stage
+      const fqns = yield* state.list({ stack: stack.name, stage });
+      const rows = yield* Effect.forEach(fqns, (fqn) =>
+        state
+          .get({ stack: stack.name, stage, fqn })
+          .pipe(Effect.map((row) => ({ fqn, row }))),
+      );
+      const wedged = rows.find(
+        (r): r is { fqn: string; row: ResourceState } =>
+          isResourceState(r.row) &&
+          r.row.resourceType === "AWS.Organizations.RootPolicyType",
+      );
+      if (!wedged) {
+        return yield* Effect.die(
+          new Error(
+            "no AWS.Organizations.RootPolicyType state row found after deploy",
+          ),
+        );
+      }
+      yield* state.set({
+        stack: stack.name,
+        stage,
+        fqn: wedged.fqn,
+        value: {
+          ...wedged.row,
+          status: "creating",
+          attr: undefined,
+          props: undefined,
+          // `CreatingResourceState` requires `props`, but persisted rows may
+          // lack it (`BaseResourceState.props?:`) — simulate that corruption.
+        } as unknown as ResourceState,
+      });
+
+      // Before the fix this crashed in plan with
+      // `TypeError: undefined is not an object (evaluating 'olds.rootId')`.
+      const recovered = yield* deployPolicyType();
+      expect(recovered.rootId).toEqual(created.rootId);
+      expect(recovered.policyType).toEqual("BACKUP_POLICY");
+
+      yield* stack.destroy();
+    }),
+  { timeout: 240_000 },
 );

--- a/packages/alchemy/test/AWS/Organizations/TrustedServiceAccess.test.ts
+++ b/packages/alchemy/test/AWS/Organizations/TrustedServiceAccess.test.ts
@@ -1,6 +1,7 @@
 import * as AWS from "@/AWS";
 import { TrustedServiceAccess } from "@/AWS/Organizations";
 import * as Provider from "@/Provider";
+import { isResourceState, State, type ResourceState } from "@/State";
 import * as Test from "@/Test/Vitest";
 import { expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
@@ -64,4 +65,89 @@ test.provider.skipIf(!process.env.AWS_ORG_MANAGEMENT_ACCOUNT)(
 
       yield* stack.destroy();
     }),
+);
+
+// Regression test for https://github.com/alchemy-run/alchemy-effect/issues/736.
+//
+// An interrupted first deploy persists the enablement as `status: "creating"`
+// with no attributes and props that could not round-trip. Plan's
+// creating-recovery branch then calls `provider.read` with those junk olds;
+// pre-fix the `olds!.servicePrincipal` dereference crashed the plan when the
+// persisted row carried no recoverable props at all (`BaseResourceState`
+// declares `props?:` — a row whose Output-valued props failed to round-trip
+// can surface with none).
+//
+// Simulate exactly that state row after a real deploy and assert the next
+// deploy recovers: `read` reports "not found", the engine re-drives the
+// create, and reconcile observes the access already enabled — SAME
+// servicePrincipal and SAME enablement date, no re-enable.
+test.provider.skipIf(!process.env.AWS_ORG_MANAGEMENT_ACCOUNT)(
+  "recovers a half-created trusted service access whose creating-state lost its props (#736)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const deployAccess = () =>
+        stack.deploy(
+          Effect.gen(function* () {
+            return yield* TrustedServiceAccess("WedgedTrustedAccess", {
+              servicePrincipal,
+            });
+          }),
+        );
+
+      const created = yield* deployAccess();
+
+      // Rewrite the persisted row into the wedged shape an interrupted
+      // deploy leaves behind: `creating`, no attributes, and no recoverable
+      // props (the realistic field-level loss — `servicePrincipal:
+      // undefined` — is tolerated even pre-fix because
+      // `readTrustedServiceAccess` is list-and-find; the crash this fix
+      // guards is the `olds!` deref on a row with no props at all).
+      const state = yield* yield* State;
+      const stage = "test"; // scratch stacks default to the "test" stage
+      const fqns = yield* state.list({ stack: stack.name, stage });
+      const rows = yield* Effect.forEach(fqns, (fqn) =>
+        state
+          .get({ stack: stack.name, stage, fqn })
+          .pipe(Effect.map((row) => ({ fqn, row }))),
+      );
+      const wedged = rows.find(
+        (r): r is { fqn: string; row: ResourceState } =>
+          isResourceState(r.row) &&
+          r.row.resourceType === "AWS.Organizations.TrustedServiceAccess",
+      );
+      if (!wedged) {
+        return yield* Effect.die(
+          new Error(
+            "no AWS.Organizations.TrustedServiceAccess state row found after deploy",
+          ),
+        );
+      }
+      yield* state.set({
+        stack: stack.name,
+        stage,
+        fqn: wedged.fqn,
+        value: {
+          ...wedged.row,
+          status: "creating",
+          attr: undefined,
+          props: undefined,
+          // `CreatingResourceState` requires `props`, but persisted rows may
+          // lack it (`BaseResourceState.props?:`) — simulate that corruption.
+        } as unknown as ResourceState,
+      });
+
+      // Before the fix this crashed in plan with
+      // `TypeError: undefined is not an object (evaluating 'olds.servicePrincipal')`.
+      const recovered = yield* deployAccess();
+      expect(recovered.servicePrincipal).toEqual(created.servicePrincipal);
+      // Same enablement observed — not disabled/re-enabled.
+      expect(recovered.dateEnabled?.getTime()).toEqual(
+        created.dateEnabled?.getTime(),
+      );
+
+      yield* stack.destroy();
+    }),
+  { timeout: 240_000 },
 );

--- a/packages/alchemy/test/AWS/Route53/HostedZone.test.ts
+++ b/packages/alchemy/test/AWS/Route53/HostedZone.test.ts
@@ -1,5 +1,6 @@
 import * as AWS from "@/AWS";
 import { HostedZone } from "@/AWS/Route53";
+import { isResourceState, State, type ResourceState } from "@/State";
 import * as Test from "@/Test/Vitest";
 import * as route53 from "@distilled.cloud/aws/route-53";
 import { expect } from "@effect/vitest";
@@ -140,6 +141,98 @@ test.provider(
       yield* assertZoneGone(zone.id);
     }),
   { timeout: 180_000 },
+);
+
+// Regression test for https://github.com/alchemy-run/alchemy-effect/issues/736.
+//
+// An interrupted first deploy persists the zone as `status: "creating"` with
+// no attributes — and an Output-valued `name` does not survive the state
+// round-trip: it deserializes as `undefined`. Plan's recovery branch then
+// calls `provider.read` with those junk props, which crashed in
+// `normalizeName(undefined)` (`undefined is not an object (evaluating
+// 'name.endsWith')`) and wedged the stack. When `read` reports "not found",
+// the same junk `olds` flow into `diff`, whose unguarded
+// `normalizeName(olds.name)` was the second crash site — so this one wedged
+// redeploy exercises both guards.
+//
+// Simulate exactly that state row after a real deploy and assert the next
+// deploy recovers: `read` returns undefined, `diff` falls through to the
+// create recovery path, and reconcile converges on the half-created zone via
+// its stable CallerReference (HostedZoneAlreadyExists → findByName) — SAME
+// zone id, no duplicate created.
+const recoveryZoneName = "pr770-recovery-hz.alchemy.";
+
+test.provider(
+  "recovers a half-created hosted zone whose creating-state lost Output-valued props (#736)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const deployZone = () =>
+        stack.deploy(
+          Effect.gen(function* () {
+            return yield* HostedZone("RecoveryZone", {
+              name: recoveryZoneName,
+              comment: "pr770 recovery",
+            });
+          }),
+        );
+
+      const created = yield* deployZone();
+      expect(created.id).toBeDefined();
+
+      // Safety net: if the recovery redeploy defects (the pre-fix crash), the
+      // zone would otherwise leak — a fresh zone only holds its SOA/NS records
+      // so it deletes cleanly; on the happy path it's already gone (ignored).
+      yield* Effect.addFinalizer(() =>
+        route53
+          .deleteHostedZone({ Id: normalizeId(created.id) })
+          .pipe(Effect.ignore),
+      );
+
+      // Rewrite the zone's persisted row into the wedged shape an interrupted
+      // deploy leaves behind: `creating`, no attributes, and the Output-valued
+      // `name` lost in the state round-trip.
+      const state = yield* yield* State;
+      const stage = "test"; // scratch stacks default to the "test" stage
+      const fqns = yield* state.list({ stack: stack.name, stage });
+      const rows = yield* Effect.forEach(fqns, (fqn) =>
+        state
+          .get({ stack: stack.name, stage, fqn })
+          .pipe(Effect.map((row) => ({ fqn, row }))),
+      );
+      const wedged = rows.find(
+        (r): r is { fqn: string; row: ResourceState } =>
+          isResourceState(r.row) &&
+          r.row.resourceType === "AWS.Route53.HostedZone",
+      );
+      if (!wedged) {
+        return yield* Effect.die(
+          new Error("no AWS.Route53.HostedZone state row found after deploy"),
+        );
+      }
+      yield* state.set({
+        stack: stack.name,
+        stage,
+        fqn: wedged.fqn,
+        value: {
+          ...wedged.row,
+          status: "creating",
+          attr: undefined,
+          props: { ...wedged.row.props, name: undefined },
+        },
+      });
+
+      // Before the fix this crashed in plan with
+      // `TypeError: undefined is not an object (evaluating 'name.endsWith')`.
+      const recovered = yield* deployZone();
+      expect(recovered.id).toEqual(created.id);
+      expect(recovered.name).toBe(recoveryZoneName);
+
+      yield* stack.destroy();
+      yield* assertZoneGone(created.id);
+    }),
+  { timeout: 240_000 },
 );
 
 test.provider(

--- a/packages/alchemy/test/AWS/Route53/Record.test.ts
+++ b/packages/alchemy/test/AWS/Route53/Record.test.ts
@@ -1,6 +1,7 @@
 import * as AWS from "@/AWS";
 import { Record } from "@/AWS/Route53";
 import * as Provider from "@/Provider";
+import { isResourceState, State, type ResourceState } from "@/State";
 import * as Test from "@/Test/Vitest";
 import * as route53 from "@distilled.cloud/aws/route-53";
 import { expect } from "@effect/vitest";
@@ -143,6 +144,141 @@ test.provider(
       yield* stack.destroy();
 
       expect(found).toBe(true);
+    }),
+  { timeout: 240_000 },
+);
+
+// Regression test for https://github.com/alchemy-run/alchemy-effect/issues/736.
+//
+// An interrupted first deploy persists the record as `status: "creating"`
+// with no attributes — and the Output-valued props (`hostedZoneId` flows from
+// the zone resource, `name` is typically derived from it) do not survive the
+// state round-trip: they deserialize as `undefined`. Plan's recovery branch
+// then calls `provider.read` with those junk props, which crashed in
+// `normalizeHostedZoneId(undefined)` (`undefined is not an object (evaluating
+// 'hostedZoneId.replace')`) and wedged the stack. When `read` reports "not
+// found", the same junk `olds` flow into `diff`, whose unguarded
+// `normalizeHostedZoneId(olds.hostedZoneId)` / `normalizeName(olds.name)`
+// were the next crash sites — so one wedged redeploy exercises all the guards.
+//
+// Deploy into the standing zone (see `ensureZone`), wedge the persisted row
+// into exactly that shape, and assert the next deploy recovers: `read`
+// returns undefined, `diff` falls through to the create recovery path, and
+// reconcile's UPSERT converges on the half-created record.
+const recoveryRecordName = `pr770-recovery.${zoneName}`;
+const recoveryRecordValue = '"pr770-recovery"';
+
+const deleteRecoveryRecord = (hostedZoneId: string) =>
+  route53
+    .changeResourceRecordSets({
+      HostedZoneId: hostedZoneId,
+      ChangeBatch: {
+        Comment: "pr770 recovery test cleanup",
+        Changes: [
+          {
+            Action: "DELETE",
+            ResourceRecordSet: {
+              Name: recoveryRecordName,
+              Type: "TXT",
+              TTL: 60,
+              ResourceRecords: [{ Value: recoveryRecordValue }],
+            },
+          },
+        ],
+      },
+    })
+    .pipe(Effect.ignore);
+
+test.provider(
+  "recovers a half-created record whose creating-state lost Output-valued props (#736)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const hostedZoneId = yield* ensureZone;
+
+      // Safety net: if the recovery redeploy defects (the pre-fix crash), the
+      // half-created record would otherwise leak into the standing zone; on
+      // the happy path the DELETE finds nothing (InvalidChangeBatch, ignored).
+      yield* Effect.addFinalizer(() => deleteRecoveryRecord(hostedZoneId));
+
+      const deployRecord = () =>
+        stack.deploy(
+          Effect.gen(function* () {
+            return yield* Record("RecoveryRecord", {
+              hostedZoneId,
+              name: recoveryRecordName,
+              type: "TXT",
+              ttl: 60,
+              records: [recoveryRecordValue],
+            });
+          }),
+        );
+
+      const created = yield* deployRecord();
+      expect(created.name).toBe(recoveryRecordName);
+
+      // Rewrite the record's persisted row into the wedged shape: `creating`,
+      // no attributes, and the Output-valued identity props lost in the
+      // state round-trip.
+      const state = yield* yield* State;
+      const stage = "test"; // scratch stacks default to the "test" stage
+      const fqns = yield* state.list({ stack: stack.name, stage });
+      const rows = yield* Effect.forEach(fqns, (fqn) =>
+        state
+          .get({ stack: stack.name, stage, fqn })
+          .pipe(Effect.map((row) => ({ fqn, row }))),
+      );
+      const wedged = rows.find(
+        (r): r is { fqn: string; row: ResourceState } =>
+          isResourceState(r.row) && r.row.resourceType === "AWS.Route53.Record",
+      );
+      if (!wedged) {
+        return yield* Effect.die(
+          new Error("no AWS.Route53.Record state row found after deploy"),
+        );
+      }
+      yield* state.set({
+        stack: stack.name,
+        stage,
+        fqn: wedged.fqn,
+        value: {
+          ...wedged.row,
+          status: "creating",
+          attr: undefined,
+          props: {
+            ...wedged.row.props,
+            hostedZoneId: undefined,
+            name: undefined,
+          },
+        },
+      });
+
+      // Before the fix this crashed in plan with
+      // `TypeError: undefined is not an object (evaluating 'hostedZoneId.replace')`.
+      const recovered = yield* deployRecord();
+      expect(normalizeId(recovered.hostedZoneId)).toBe(
+        normalizeId(hostedZoneId),
+      );
+      expect(recovered.name).toBe(recoveryRecordName);
+      expect(recovered.type).toBe("TXT");
+
+      // Verify out of band the record actually exists.
+      const observed = yield* route53.listResourceRecordSets({
+        HostedZoneId: hostedZoneId,
+        StartRecordName: recoveryRecordName,
+        StartRecordType: "TXT",
+        MaxItems: 1,
+      });
+      expect(
+        (observed.ResourceRecordSets ?? []).some(
+          (set) => set.Name === recoveryRecordName && set.Type === "TXT",
+        ),
+      ).toBe(true);
+
+      // The standing zone is left in place (see `ensureZone` — deleting it
+      // poisons the CallerReference); destroy() removes the record.
+      yield* stack.destroy();
     }),
   { timeout: 240_000 },
 );

--- a/packages/alchemy/test/AWS/Route53/Record.test.ts
+++ b/packages/alchemy/test/AWS/Route53/Record.test.ts
@@ -282,18 +282,3 @@ test.provider(
     }),
   { timeout: 240_000 },
 );
-
-// NOTE — distilled patch needed (do not apply here; reported to coordinator):
-//   service: route-53
-//   structures.ListResourceRecordSetsResponse.members.ResourceRecordSets.optional: true
-//
-// Route53 omits the `<ResourceRecordSets>` element entirely when a
-// `ListResourceRecordSets` page is empty (e.g. when `StartRecordName` points
-// past the last record — exactly what the provider's `read`/`findRecord`
-// adoption probe does for a brand-new record). distilled currently marks the
-// member required, so the response fails to parse with:
-//   SchemaError: Missing key at ["ResourceRecordSets"]
-// This blocks deploying any record through the Alchemy engine (the greenfield
-// adoption probe in Plan.ts), so this test seeds the record out of band. Once
-// the member is optional, `findRecord` should also coalesce
-// `response.ResourceRecordSets ?? []`.

--- a/packages/alchemy/test/Cloudflare/Access/InfrastructureTarget.test.ts
+++ b/packages/alchemy/test/Cloudflare/Access/InfrastructureTarget.test.ts
@@ -1,9 +1,12 @@
 import * as Cloudflare from "@/Cloudflare";
 import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
 import * as Provider from "@/Provider";
+import { isResourceState, State, type ResourceState } from "@/State";
 import * as Test from "@/Test/Vitest";
+import * as zeroTrust from "@distilled.cloud/cloudflare/zero-trust";
 import { expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as Stream from "effect/Stream";
 
 const { test } = Test.make({
   providers: Cloudflare.providers(),
@@ -38,4 +41,95 @@ test.provider("list enumerates the deployed infrastructure target", (stack) =>
 
     yield* stack.destroy();
   }),
+);
+
+test.provider(
+  "recovers a half-created target whose creating-state lost Output-valued props (#736)",
+  (stack) =>
+    Effect.gen(function* () {
+      const hostname = "wedged-recovery.bastion.internal";
+
+      yield* stack.destroy();
+
+      // Safety net: a previously crashed run leaves an orphaned cloud
+      // target (its state row is wedged attr-less, so destroy can't reach
+      // it) which would fail the fresh deploy with OwnedBySomeoneElse.
+      // Sweep any target with our deterministic hostname out-of-band.
+      const { accountId } = yield* yield* CloudflareEnvironment;
+      const orphans = yield* zeroTrust.listAccessInfrastructureTargets
+        .items({ accountId, hostname })
+        .pipe(
+          Stream.filter((t) => t.hostname === hostname),
+          Stream.runCollect,
+        );
+      yield* Effect.forEach(Array.from(orphans), (t) =>
+        zeroTrust
+          .deleteAccessInfrastructureTarget({ accountId, targetId: t.id })
+          .pipe(Effect.catchTag("TargetNotFound", () => Effect.void)),
+      );
+
+      const deployTarget = () =>
+        stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.Access.InfrastructureTarget(
+              "WedgedTarget",
+              {
+                hostname,
+                ip: { ipv4: { ipAddr: "10.7.0.99" } },
+              },
+            );
+          }),
+        );
+
+      const created = yield* deployTarget();
+
+      // Rewrite the target's persisted row into the wedged shape an
+      // interrupted deploy leaves behind: `creating`, no attributes, and
+      // the Output-valued `ip` prop lost in the round-trip. `hostname`
+      // survives so the cold-read identity path runs.
+      const state = yield* yield* State;
+      const stage = "test"; // scratch stacks default to the "test" stage
+      const fqns = yield* state.list({ stack: stack.name, stage });
+      const rows = yield* Effect.forEach(fqns, (fqn) =>
+        state
+          .get({ stack: stack.name, stage, fqn })
+          .pipe(Effect.map((row) => ({ fqn, row }))),
+      );
+      const wedged = rows.find(
+        (r): r is { fqn: string; row: ResourceState } =>
+          isResourceState(r.row) &&
+          r.row.resourceType === "Cloudflare.Access.InfrastructureTarget",
+      );
+      if (!wedged) {
+        return yield* Effect.die(
+          new Error(
+            "no Cloudflare.Access.InfrastructureTarget state row found after deploy",
+          ),
+        );
+      }
+      yield* state.set({
+        stack: stack.name,
+        stage,
+        fqn: wedged.fqn,
+        value: {
+          ...wedged.row,
+          status: "creating",
+          attr: undefined,
+          props: { ...wedged.row.props, ip: undefined },
+        },
+      });
+
+      // Before the fix, `read` crashed here with
+      // `TypeError: undefined is not an object (evaluating 'ip.ipv4')`
+      // (resolvedIp(olds.ip) with olds.ip === undefined). After the fix,
+      // read falls back to the output hint, matches by hostname, and the
+      // engine converges onto the same target — no duplicate created.
+      const recovered = yield* deployTarget();
+      expect(recovered.targetId).toEqual(created.targetId);
+      expect(recovered.hostname).toEqual(created.hostname);
+      expect(recovered.ip.ipv4?.ipAddr).toEqual("10.7.0.99");
+
+      yield* stack.destroy();
+    }),
+  { timeout: 240_000 },
 );

--- a/packages/alchemy/test/Cloudflare/Email/EmailCatchAll.test.ts
+++ b/packages/alchemy/test/Cloudflare/Email/EmailCatchAll.test.ts
@@ -2,6 +2,7 @@ import * as Cloudflare from "@/Cloudflare";
 import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
 import { findZoneByName } from "@/Cloudflare/Zone/lookup";
 import * as Provider from "@/Provider";
+import { isResourceState, State, type ResourceState } from "@/State";
 import * as Test from "@/Test/Vitest";
 import * as emailRouting from "@distilled.cloud/cloudflare/email-routing";
 import { expect } from "@effect/vitest";
@@ -180,6 +181,99 @@ describe.sequential("EmailCatchAll", () => {
         expect(restored.name ?? "").toEqual("");
         expect(restored.actions).toEqual([{ type: "drop" }]);
       }).pipe(logLevel),
+  );
+
+  test.provider(
+    "recovers a half-created catch-all whose creating-state lost Output-valued props (#736)",
+    (stack) =>
+      Effect.gen(function* () {
+        const zoneId = yield* resolveZoneId;
+
+        yield* stack.destroy();
+        yield* setBaseline(zoneId);
+        // Safety net: normalize the zone singleton back to the Cloudflare
+        // default even if the test dies mid-way.
+        yield* Effect.addFinalizer(() =>
+          setBaseline(zoneId).pipe(Effect.ignore),
+        );
+
+        const deployCatchAll = () =>
+          stack.deploy(
+            Effect.gen(function* () {
+              const routing = yield* Cloudflare.Email.Routing("Routing", {
+                zone: zoneName,
+              });
+              return yield* Cloudflare.Email.CatchAll("CatchAll", {
+                // Output-valued zone reference — the #736 shape.
+                zone: { zoneId: routing.zoneId },
+                name: "alchemy recovery test",
+                actions: [{ type: "drop" }],
+              });
+            }),
+          );
+
+        const created = yield* deployCatchAll();
+        expect(created.zoneId).toEqual(zoneId);
+        expect(created.ruleId).not.toEqual("");
+
+        // Rewrite the persisted row into the wedged shape an interrupted
+        // deploy leaves behind: `creating`, no attributes, and the
+        // Output-valued `zone` prop lost in the round-trip.
+        const state = yield* yield* State;
+        const stage = "test"; // scratch stacks default to the "test" stage
+        const fqns = yield* state.list({ stack: stack.name, stage });
+        const rows = yield* Effect.forEach(fqns, (fqn) =>
+          state
+            .get({ stack: stack.name, stage, fqn })
+            .pipe(Effect.map((row) => ({ fqn, row }))),
+        );
+        const wedged = rows.find(
+          (r): r is { fqn: string; row: ResourceState } =>
+            isResourceState(r.row) &&
+            r.row.resourceType === "Cloudflare.Email.CatchAll",
+        );
+        if (!wedged) {
+          return yield* Effect.die(
+            new Error(
+              "no Cloudflare.Email.CatchAll state row found after deploy",
+            ),
+          );
+        }
+        yield* state.set({
+          stack: stack.name,
+          stage,
+          fqn: wedged.fqn,
+          value: {
+            ...wedged.row,
+            status: "creating",
+            attr: undefined,
+            props: { ...wedged.row.props, zone: undefined },
+          },
+        });
+
+        // Before the fix `read` crashed resolving `olds.zone === undefined`
+        // (TypeError reading `name` of undefined inside `resolve`). After
+        // the fix it reports "not found" and reconcile converges on the
+        // same zone singleton — same rule, no duplicate.
+        const recovered = yield* deployCatchAll();
+        expect(recovered.zoneId).toEqual(zoneId);
+        expect(recovered.ruleId).toEqual(created.ruleId);
+        expect(recovered.name).toEqual("alchemy recovery test");
+        expect(recovered.enabled).toEqual(true);
+        expect(recovered.actions).toEqual([{ type: "drop" }]);
+
+        // Out-of-band verification against the live API.
+        const live = yield* getCatchAll(zoneId);
+        expect(live.enabled).toEqual(true);
+        expect(live.name).toEqual("alchemy recovery test");
+
+        yield* stack.destroy();
+        // The recovery re-adopted the singleton with the managed state as
+        // its restore baseline, so destroy restores that state — normalize
+        // the zone back to the Cloudflare default for subsequent tests.
+        yield* setBaseline(zoneId);
+      }).pipe(logLevel),
+    { timeout: 240_000 },
   );
 
   // Canonical `list()` test (zone-scoped singleton): there is no account-wide

--- a/packages/alchemy/test/Cloudflare/GoogleTagGateway/GoogleTagGateway.test.ts
+++ b/packages/alchemy/test/Cloudflare/GoogleTagGateway/GoogleTagGateway.test.ts
@@ -2,6 +2,7 @@ import * as Cloudflare from "@/Cloudflare";
 import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
 import { findZoneByName } from "@/Cloudflare/Zone/lookup";
 import * as Provider from "@/Provider";
+import { isResourceState, State, type ResourceState } from "@/State";
 import * as Test from "@/Test/Vitest";
 import * as googleTagGateway from "@distilled.cloud/cloudflare/google-tag-gateway";
 import { expect } from "@effect/vitest";
@@ -191,6 +192,96 @@ describe.sequential("GoogleTagGateway", () => {
           const stillRestored = yield* getConfig(zoneId);
           expect(stillRestored).toEqual(baseline);
         }).pipe(Effect.ensuring(setBaseline(zoneId).pipe(Effect.ignore)));
+      }).pipe(logLevel),
+    { timeout: 120_000 },
+  );
+
+  test.provider(
+    "recovers a creating-state row whose Output-valued zone prop was lost (#736)",
+    (stack) =>
+      Effect.gen(function* () {
+        const zoneId = yield* resolveZoneId;
+
+        yield* stack.destroy();
+        yield* setBaseline(zoneId);
+
+        yield* Effect.gen(function* () {
+          const deployGateway = () =>
+            stack.deploy(
+              Effect.gen(function* () {
+                return yield* Cloudflare.GoogleTagGateway.GoogleTagGateway(
+                  "GtgWedged",
+                  {
+                    zone: { zoneId, name: zoneName },
+                    enabled: true,
+                    endpoint: "/wedged",
+                    measurementId: "G-WEDGED0001",
+                    hideOriginalIp: true,
+                    setUpTag: false,
+                  },
+                );
+              }),
+            );
+
+          const created = yield* deployGateway();
+          expect(created.zoneId).toEqual(zoneId);
+
+          // Rewrite the persisted row into the wedged shape an interrupted
+          // deploy leaves behind: `creating`, no attributes, and the
+          // Output-valued `zone` prop lost in the state round-trip (#736).
+          const state = yield* yield* State;
+          const stage = "test"; // scratch stacks default to the "test" stage
+          const fqns = yield* state.list({ stack: stack.name, stage });
+          const rows = yield* Effect.forEach(fqns, (fqn) =>
+            state
+              .get({ stack: stack.name, stage, fqn })
+              .pipe(Effect.map((row) => ({ fqn, row }))),
+          );
+          const wedged = rows.find(
+            (r): r is { fqn: string; row: ResourceState } =>
+              isResourceState(r.row) &&
+              r.row.resourceType ===
+                "Cloudflare.GoogleTagGateway.GoogleTagGateway",
+          );
+          if (!wedged) {
+            return yield* Effect.die(
+              new Error("no GoogleTagGateway state row found after deploy"),
+            );
+          }
+          yield* state.set({
+            stack: stack.name,
+            stage,
+            fqn: wedged.fqn,
+            value: {
+              ...wedged.row,
+              status: "creating",
+              attr: undefined,
+              props: { ...wedged.row.props, zone: undefined },
+            },
+          });
+
+          // Before the fix this crashed in `read` with
+          // `TypeError: undefined is not an object (evaluating 'zone.name')`
+          // (resolve(olds.zone) with a lost `zone`). After the fix, read
+          // reports "not found" and reconcile converges on the same zone
+          // singleton — no drift, same identity.
+          const recovered = yield* deployGateway();
+          expect(recovered.zoneId).toEqual(created.zoneId);
+          expect(recovered.enabled).toEqual(true);
+          expect(recovered.endpoint).toEqual("/wedged");
+          expect(recovered.measurementId).toEqual("G-WEDGED0001");
+          expect(recovered.hideOriginalIp).toEqual(true);
+
+          // The live singleton still matches — converged, not duplicated.
+          const live = yield* getConfig(zoneId);
+          expect(live?.endpoint).toEqual("/wedged");
+          expect(live?.measurementId).toEqual("G-WEDGED0001");
+
+          yield* stack.destroy();
+        }).pipe(
+          // Leave the zone in the disabled baseline even if the test fails.
+          Effect.ensuring(setBaseline(zoneId).pipe(Effect.ignore)),
+        );
       }).pipe(logLevel),
     { timeout: 120_000 },
   );

--- a/packages/alchemy/test/Cloudflare/OriginCaCertificate/OriginCaCertificate.test.ts
+++ b/packages/alchemy/test/Cloudflare/OriginCaCertificate/OriginCaCertificate.test.ts
@@ -1,6 +1,7 @@
 import { adopt } from "@/AdoptPolicy";
 import * as Cloudflare from "@/Cloudflare";
 import * as Provider from "@/Provider";
+import { isResourceState, State, type ResourceState } from "@/State";
 import * as Test from "@/Test/Vitest";
 import * as originCa from "@distilled.cloud/cloudflare/origin-ca-certificates";
 import { expect } from "@effect/vitest";
@@ -139,6 +140,127 @@ test.provider("list enumerates issued certificates", (stack) =>
     yield* stack.destroy();
     yield* expectRevoked(cert.certificateId);
   }).pipe(logLevel),
+);
+
+// Explicit revoke for certificates the wedged-state recovery orphans out of
+// engine state (their rows lose `attr`, so `stack.destroy()` can't reclaim
+// them). Revoked/absent both count as cleaned up.
+const revokeQuietly = (certificateId: string) =>
+  originCa.deleteOriginCaCertificate({ certificateId }).pipe(
+    Effect.retry({
+      while: (e) => e._tag === "Forbidden",
+      schedule: Schedule.exponential("500 millis"),
+      times: 8,
+    }),
+    Effect.catchTag("CertificateNotFound", () => Effect.void),
+    Effect.catchTag("CertificateAlreadyRevoked", () => Effect.void),
+  );
+
+test.provider(
+  "recovers a creating-state row whose Output-valued hostnames were lost (#736)",
+  (stack) =>
+    Effect.gen(function* () {
+      const hostname = `originwedged.${zoneName}`;
+      yield* stack.destroy();
+
+      const deployCert = () =>
+        stack.deploy(
+          Cloudflare.OriginCaCertificate.OriginCaCertificate("WedgedCert", {
+            csr: TEST_CSR,
+            hostnames: [hostname],
+            requestType: "origin-rsa",
+            requestedValidity: 90,
+          }).pipe(adopt(true)),
+        );
+
+      const created = yield* deployCert();
+      expect(created.certificateId).toBeTruthy();
+
+      // Rewrite the certificate's persisted row into the wedged shape an
+      // interrupted deploy leaves behind: `creating`, no attributes, and the
+      // Output-valued props lost in the state round-trip (#736).
+      const state = yield* yield* State;
+      const stage = "test"; // scratch stacks default to the "test" stage
+      const wedgeRow = (junk: Record<string, unknown>) =>
+        Effect.gen(function* () {
+          const fqns = yield* state.list({ stack: stack.name, stage });
+          const rows = yield* Effect.forEach(fqns, (fqn) =>
+            state
+              .get({ stack: stack.name, stage, fqn })
+              .pipe(Effect.map((row) => ({ fqn, row }))),
+          );
+          const wedged = rows.find(
+            (r): r is { fqn: string; row: ResourceState } =>
+              isResourceState(r.row) &&
+              r.row.resourceType ===
+                "Cloudflare.OriginCaCertificate.OriginCaCertificate",
+          );
+          if (!wedged) {
+            return yield* Effect.die(
+              new Error("no OriginCaCertificate state row found after deploy"),
+            );
+          }
+          yield* state.set({
+            stack: stack.name,
+            stage,
+            fqn: wedged.fqn,
+            value: {
+              ...wedged.row,
+              status: "creating",
+              attr: undefined,
+              props: { ...wedged.row.props, ...junk },
+            },
+          });
+        });
+
+      // The wedge orphans the previous certificate out of engine state, so
+      // destroy can never reclaim it — revoke it explicitly on scope close
+      // even if the body fails mid-way.
+      yield* Effect.addFinalizer(() =>
+        revokeQuietly(created.certificateId).pipe(Effect.ignore),
+      );
+
+      // Wedge 1 — the #736 shape: the hostnames array survives serialization
+      // but its Output-valued ELEMENT deserializes as undefined. Before the
+      // fix, read's cold path only checked `hostnames?.length`, passed the
+      // truthy-length junk array into `findByHostnames`, and crashed on
+      // `hostnames[0].replace(...)`. After the fix, read reports "missing"
+      // and the engine re-creates.
+      yield* wedgeRow({ hostnames: [undefined] });
+      const recovered = yield* deployCert();
+      expect(recovered.certificateId).toBeTruthy();
+      expect(recovered.hostnames).toEqual([hostname]);
+      const live = yield* getCertificate(recovered.certificateId);
+      expect(live.hostnames).toEqual([hostname]);
+      expect(live.revokedAt ?? null).toBeNull();
+
+      yield* Effect.addFinalizer(() =>
+        revokeQuietly(recovered.certificateId).pipe(Effect.ignore),
+      );
+
+      // Wedge 2 — every Output-valued prop lost wholesale (`undefined`, not
+      // `[undefined]`): the whole hostnames array AND the csr. Guarded both
+      // before and after the fix in `read`; csr must be wedged too because
+      // `diff` keys its "no prior props" guard off `olds.csr`. Recovery is
+      // the same: read reports missing, the engine re-creates.
+      yield* wedgeRow({ hostnames: undefined, csr: undefined });
+      const recovered2 = yield* deployCert();
+      expect(recovered2.certificateId).toBeTruthy();
+      expect(recovered2.hostnames).toEqual([hostname]);
+      const live2 = yield* getCertificate(recovered2.certificateId);
+      expect(live2.hostnames).toEqual([hostname]);
+      expect(live2.revokedAt ?? null).toBeNull();
+
+      yield* stack.destroy();
+      yield* expectRevoked(recovered2.certificateId);
+
+      // Explicitly reclaim the certificates the wedges orphaned.
+      yield* revokeQuietly(created.certificateId);
+      yield* revokeQuietly(recovered.certificateId);
+      yield* expectRevoked(created.certificateId);
+      yield* expectRevoked(recovered.certificateId);
+    }).pipe(logLevel),
+  { timeout: 240_000 },
 );
 
 test.provider("replacement on requestedValidity change", (stack) =>

--- a/packages/alchemy/test/Cloudflare/OriginTlsClientAuth/HostnameCertificate.test.ts
+++ b/packages/alchemy/test/Cloudflare/OriginTlsClientAuth/HostnameCertificate.test.ts
@@ -2,6 +2,7 @@ import * as Cloudflare from "@/Cloudflare";
 import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
 import { findZoneByName } from "@/Cloudflare/Zone/lookup";
 import * as Provider from "@/Provider";
+import { isResourceState, State, type ResourceState } from "@/State";
 import * as Test from "@/Test/Vitest";
 import * as originTls from "@distilled.cloud/cloudflare/origin-tls-client-auth";
 import { expect } from "@effect/vitest";
@@ -10,10 +11,12 @@ import * as Redacted from "effect/Redacted";
 import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
 import {
+  CERT_2,
   CERT_3,
   CERT_4,
   CERT_8,
   CERT_9,
+  KEY_2,
   KEY_3,
   KEY_4,
   KEY_8,
@@ -209,6 +212,79 @@ test.provider(
       yield* stack.destroy();
 
       yield* waitForGone(zoneId, replaced.certificateId);
+    }).pipe(Effect.ensuring(stack.destroy().pipe(Effect.ignore)), logLevel),
+  { timeout: 120_000 },
+);
+
+test.provider(
+  "recovers a creating-state row whose Output-valued certificate was lost (#736)",
+  (stack) =>
+    Effect.gen(function* () {
+      const zoneId = yield* resolveZoneId;
+
+      // Dedicated PEM (CERT_2): the other hostname-certificate tests own
+      // CERT_3/4/8/9; CERT_2 is otherwise only used by the *zone-level*
+      // Certificate suite, which is a separate Cloudflare collection.
+      yield* stack.destroy();
+      yield* purgeCertificates(zoneId, [CERT_2]);
+
+      const deployCert = () =>
+        stack.deploy(
+          Cloudflare.OriginTlsClientAuth.HostnameCertificate("WedgedHostCert", {
+            zoneId,
+            certificate: CERT_2,
+            privateKey: Redacted.make(KEY_2),
+          }),
+        );
+
+      const created = yield* deployCert();
+      expect(created.certificateId).toBeDefined();
+
+      // Rewrite the persisted row into the wedged shape an interrupted deploy
+      // leaves behind when `certificate` was Output-valued: `creating`, no
+      // attributes, and the certificate lost in the round-trip (#736).
+      const state = yield* yield* State;
+      const stage = "test"; // scratch stacks default to the "test" stage
+      const fqns = yield* state.list({ stack: stack.name, stage });
+      const rows = yield* Effect.forEach(fqns, (fqn) =>
+        state
+          .get({ stack: stack.name, stage, fqn })
+          .pipe(Effect.map((row) => ({ fqn, row }))),
+      );
+      const wedged = rows.find(
+        (r): r is { fqn: string; row: ResourceState } =>
+          isResourceState(r.row) &&
+          r.row.resourceType ===
+            "Cloudflare.OriginTlsClientAuth.HostnameCertificate",
+      );
+      if (!wedged) {
+        return yield* Effect.die(
+          new Error("no HostnameCertificate state row found after deploy"),
+        );
+      }
+      yield* state.set({
+        stack: stack.name,
+        stage,
+        fqn: wedged.fqn,
+        value: {
+          ...wedged.row,
+          status: "creating",
+          attr: undefined,
+          props: { ...wedged.row.props, certificate: undefined },
+        },
+      });
+
+      // `read` cannot content-match without `olds.certificate`, so planning
+      // falls through to `diff` with the junk olds. Before the fix this
+      // crashed with `TypeError: undefined is not an object (evaluating
+      // 'pem.trim')` in normalizePem; after it, diff falls through and
+      // reconcile re-adopts the live certificate by PEM content.
+      const recovered = yield* deployCert();
+      expect(recovered.certificateId).toEqual(created.certificateId);
+
+      yield* stack.destroy();
+
+      yield* waitForGone(zoneId, recovered.certificateId);
     }).pipe(Effect.ensuring(stack.destroy().pipe(Effect.ignore)), logLevel),
   { timeout: 120_000 },
 );

--- a/packages/alchemy/test/Cloudflare/Ruleset/Ruleset.test.ts
+++ b/packages/alchemy/test/Cloudflare/Ruleset/Ruleset.test.ts
@@ -4,6 +4,7 @@ import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
 import { findZoneByName } from "@/Cloudflare/Zone/lookup";
 import * as Provider from "@/Provider";
 import * as RemovalPolicy from "@/RemovalPolicy";
+import { isResourceState, State, type ResourceState } from "@/State";
 import * as Test from "@/Test/Vitest";
 import * as rulesets from "@distilled.cloud/cloudflare/rulesets";
 import { expect } from "@effect/vitest";
@@ -230,6 +231,96 @@ describe.sequential("Ruleset", () => {
         });
         expect(zoneAfter).toBeUndefined();
       }).pipe(softSkipWhenZoneCreationBlocked, logLevel),
+  );
+
+  // A `creating` state row persisted before upstream Outputs resolve cannot
+  // round-trip Output-valued props — the `zone` prop deserializes as
+  // `undefined`. The engine's creating-with-no-attr recovery path then calls
+  // `read` with those junk props as `olds` and `output: undefined`. Before the
+  // #770 guard, `zoneIdOf(olds.zone)` dereferenced `.zoneId` on `undefined`
+  // and crashed the deploy; after it, `read` returns "not found" and
+  // `reconcile` re-converges the phase entrypoint from the resolved news.
+  test.provider(
+    "recovers a half-created ruleset whose creating-state lost the Output-valued zone (#736)",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const deployRuleset = () =>
+          stack.deploy(
+            Effect.gen(function* () {
+              const zone = yield* Cloudflare.Zone.Zone("TestZone", {
+                name: zoneName,
+              }).pipe(AdoptPolicy.adopt(true));
+              return yield* Cloudflare.Ruleset.Ruleset("WedgedRuleset", {
+                zone,
+                phase,
+                rules: [
+                  {
+                    description: "Alchemy wedged recovery rule",
+                    expression:
+                      'http.request.uri.path eq "/__alchemy_ruleset_wedged__"',
+                    action: "block",
+                  },
+                ],
+              });
+            }),
+          );
+
+        const created = yield* deployRuleset();
+
+        // Rewrite the ruleset's persisted row into the wedged shape an
+        // interrupted deploy leaves behind: `creating`, no attributes, and the
+        // Output-valued `zone` prop lost in the round-trip.
+        const state = yield* yield* State;
+        const stage = "test"; // scratch stacks default to the "test" stage
+        const fqns = yield* state.list({ stack: stack.name, stage });
+        const rows = yield* Effect.forEach(fqns, (fqn) =>
+          state
+            .get({ stack: stack.name, stage, fqn })
+            .pipe(Effect.map((row) => ({ fqn, row }))),
+        );
+        const wedged = rows.find(
+          (r): r is { fqn: string; row: ResourceState } =>
+            isResourceState(r.row) &&
+            r.row.resourceType === "Cloudflare.Ruleset.Ruleset",
+        );
+        if (!wedged) {
+          return yield* Effect.die(
+            new Error(
+              "no Cloudflare.Ruleset.Ruleset state row found after deploy",
+            ),
+          );
+        }
+        yield* state.set({
+          stack: stack.name,
+          stage,
+          fqn: wedged.fqn,
+          value: {
+            ...wedged.row,
+            status: "creating",
+            attr: undefined,
+            props: { ...wedged.row.props, zone: undefined },
+          },
+        });
+
+        // Before the fix this crashed in `read` with
+        // `TypeError: undefined is not an object (evaluating 'zone.zoneId')`.
+        const recovered = yield* deployRuleset();
+        expect(recovered.rulesetId).toEqual(created.rulesetId);
+        expect(recovered.zoneId).toEqual(created.zoneId);
+
+        // The recovered entrypoint converged to the desired rules.
+        const recoveredRules = yield* getPhaseRules(recovered.zoneId, phase);
+        expect(recoveredRules).toHaveLength(1);
+        expect(recoveredRules[0]).toMatchObject({
+          description: "Alchemy wedged recovery rule",
+          action: "block",
+        });
+
+        yield* stack.destroy();
+      }).pipe(logLevel),
+    { timeout: 240_000 },
   );
 
   // Canonical `list()` test (zone-scoped collection): enumerate every zone via

--- a/packages/alchemy/test/Cloudflare/Zaraz/ZarazConfig.test.ts
+++ b/packages/alchemy/test/Cloudflare/Zaraz/ZarazConfig.test.ts
@@ -1,7 +1,9 @@
 import * as Cloudflare from "@/Cloudflare";
 import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
 import { findZoneByName } from "@/Cloudflare/Zone/lookup";
+import { deepEqual } from "@/Diff";
 import * as Provider from "@/Provider";
+import { isResourceState, State, type ResourceState } from "@/State";
 import * as Test from "@/Test/Vitest";
 import { stripNullFields, stripUndefinedFields } from "@/Util/data";
 import * as zaraz from "@distilled.cloud/cloudflare/zaraz";
@@ -202,6 +204,102 @@ describe.sequential("Config", () => {
         yield* stack.destroy();
       }).pipe(logLevel),
     { timeout: 120_000 },
+  );
+
+  // Ungated like the `list()` test: the deploy passes NO mutable props, so
+  // reconcile observes the zone config, computes an identical desired config,
+  // and skips putConfig/putZaraz entirely — the standing zone's singleton is
+  // never mutated (capture-and-restore below is just a safety net).
+  test.provider(
+    "recovers a half-created config whose creating-state lost Output-valued props (#736)",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const { accountId } = yield* yield* CloudflareEnvironment;
+        const zone = yield* findZoneByName({ accountId, name: zoneName });
+        if (!zone) {
+          return yield* Effect.die(
+            new Error(`zone "${zoneName}" not found in account`),
+          );
+        }
+
+        const original = yield* zaraz.getConfig({ zoneId: zone.id });
+
+        yield* Effect.gen(function* () {
+          const deployConfig = () =>
+            stack.deploy(
+              Effect.gen(function* () {
+                // No mutable props: reconcile is a pure observe (no put).
+                return yield* Cloudflare.Zaraz.Config("Config", {
+                  zone: { zoneId: zone.id, name: zoneName },
+                });
+              }),
+            );
+
+          const created = yield* deployConfig();
+          expect(created.zoneId).toEqual(zone.id);
+
+          // Rewrite the persisted row into the wedged shape an interrupted
+          // deploy leaves behind: `creating`, no attributes, and the
+          // Output-valued `zone` prop lost in the round-trip (#736).
+          const state = yield* yield* State;
+          const stage = "test"; // scratch stacks default to the "test" stage
+          const fqns = yield* state.list({ stack: stack.name, stage });
+          const rows = yield* Effect.forEach(fqns, (fqn) =>
+            state
+              .get({ stack: stack.name, stage, fqn })
+              .pipe(Effect.map((row) => ({ fqn, row }))),
+          );
+          const wedged = rows.find(
+            (r): r is { fqn: string; row: ResourceState } =>
+              isResourceState(r.row) &&
+              r.row.resourceType === "Cloudflare.Zaraz.Config",
+          );
+          if (!wedged) {
+            return yield* Effect.die(
+              new Error(
+                "no Cloudflare.Zaraz.Config state row found after deploy",
+              ),
+            );
+          }
+          yield* state.set({
+            stack: stack.name,
+            stage,
+            fqn: wedged.fqn,
+            value: {
+              ...wedged.row,
+              status: "creating",
+              attr: undefined,
+              props: {
+                ...wedged.row.props,
+                zone: undefined,
+              },
+            },
+          });
+
+          // Before the fix this crashed in read's recovery path with
+          // `TypeError: undefined is not an object (evaluating 'zone.name')`.
+          const recovered = yield* deployConfig();
+          expect(recovered.zoneId).toEqual(created.zoneId);
+          expect(recovered.dataLayer).toEqual(created.dataLayer);
+          expect(recovered.workflow).toEqual(created.workflow);
+
+          yield* stack.destroy();
+        }).pipe(
+          Effect.ensuring(
+            // Safety net: restore only if something actually changed, so the
+            // happy path leaves the standing zone's singleton untouched.
+            Effect.gen(function* () {
+              const current = yield* zaraz.getConfig({ zoneId: zone.id });
+              if (!deepEqual(current, original)) {
+                yield* zaraz.putConfig(toPutConfig(zone.id, original));
+              }
+            }).pipe(Effect.ignore),
+          ),
+        );
+      }).pipe(logLevel),
+    { timeout: 240_000 },
   );
 });
 

--- a/packages/alchemy/test/Docker/Container.test.ts
+++ b/packages/alchemy/test/Docker/Container.test.ts
@@ -1,6 +1,11 @@
 import * as Docker from "@/Docker";
 import * as Provider from "@/Provider";
-import { inMemoryState } from "@/State";
+import {
+  inMemoryState,
+  isResourceState,
+  State,
+  type ResourceState,
+} from "@/State";
 import * as Test from "@/Test/Vitest";
 import { expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
@@ -134,5 +139,116 @@ describe("Docker.Container", { concurrent: false }, () => {
         expect(second.id).not.toBe(first.id);
         expect(second.ports["80/tcp"]).toBe(secondPort);
       }),
+  );
+
+  // Rewrite the container's persisted row into the wedged shape an
+  // interrupted deploy leaves behind: `creating`, no attributes, and the
+  // Output-valued `image` prop lost in the round-trip (#736).
+  const wedgeContainerRow = (stack: { readonly name: string }) =>
+    Effect.gen(function* () {
+      const state = yield* yield* State;
+      const stage = "test"; // scratch stacks default to the "test" stage
+      const fqns = yield* state.list({ stack: stack.name, stage });
+      const rows = yield* Effect.forEach(fqns, (fqn) =>
+        state
+          .get({ stack: stack.name, stage, fqn })
+          .pipe(Effect.map((row) => ({ fqn, row }))),
+      );
+      const wedged = rows.find(
+        (r): r is { fqn: string; row: ResourceState } =>
+          isResourceState(r.row) && r.row.resourceType === "Docker.Container",
+      );
+      if (!wedged) {
+        return yield* Effect.die(
+          new Error("no Docker.Container state row found after deploy"),
+        );
+      }
+      yield* state.set({
+        stack: stack.name,
+        stage,
+        fqn: wedged.fqn,
+        value: {
+          ...wedged.row,
+          status: "creating",
+          attr: undefined,
+          props: { ...wedged.row.props, image: undefined },
+        },
+      });
+    });
+
+  test.provider.skipIf(!isDockerReady)(
+    "read recovers a creating-state container whose image prop was lost (#736)",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+        const docker = yield* Docker.Docker;
+
+        const deployContainer = () =>
+          stack.deploy(
+            // No explicit name: the engine-generated physical name is stable
+            // across both deploys, so `read` can find the live container.
+            Docker.Container("read-recovery-container", {
+              image: "nginx:alpine",
+              start: false,
+            }),
+          );
+
+        const created = yield* deployContainer();
+        // Safety net: remove the container if the test dies mid-way.
+        yield* Effect.addFinalizer(() =>
+          docker.container.remove(created.name, true).pipe(Effect.ignore),
+        );
+
+        yield* wedgeContainerRow(stack);
+
+        // Before the fix this crashed in `read` with
+        // `TypeError: undefined is not an object (evaluating 'image.imageRef')`.
+        const recovered = yield* deployContainer();
+        // Same container id — read/reconcile converged on the existing
+        // container instead of creating a duplicate.
+        expect(recovered.id).toBe(created.id);
+        expect(recovered.imageRef).toBe("nginx:alpine");
+
+        yield* stack.destroy();
+      }),
+    { timeout: 240_000 },
+  );
+
+  test.provider.skipIf(!isDockerReady)(
+    "diff recreates a creating-state container that vanished after its image prop was lost (#736)",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+        const docker = yield* Docker.Docker;
+
+        const deployContainer = () =>
+          stack.deploy(
+            Docker.Container("diff-recovery-container", {
+              image: "nginx:alpine",
+              start: false,
+            }),
+          );
+
+        const created = yield* deployContainer();
+        // Safety net: remove the container if the test dies mid-way.
+        yield* Effect.addFinalizer(() =>
+          docker.container.remove(created.name, true).pipe(Effect.ignore),
+        );
+
+        yield* wedgeContainerRow(stack);
+        // Remove the container out-of-band so recovery `read` misses and the
+        // engine falls through to `diff` with the junk creating-row props.
+        yield* docker.container.remove(created.name, true);
+
+        // Before the fix this crashed in `diff` with
+        // `TypeError: undefined is not an object (evaluating 'image.imageRef')`.
+        const recovered = yield* deployContainer();
+        expect(recovered.id).not.toBe(created.id);
+        expect(recovered.imageRef).toBe("nginx:alpine");
+        expect(recovered.status).toBe("created");
+
+        yield* stack.destroy();
+      }),
+    { timeout: 240_000 },
   );
 });

--- a/packages/alchemy/test/Neon/Branch.test.ts
+++ b/packages/alchemy/test/Neon/Branch.test.ts
@@ -1,10 +1,12 @@
 import * as Neon from "@/Neon";
 import * as Provider from "@/Provider";
+import { isResourceState, State, type ResourceState } from "@/State";
 import * as Test from "@/Test/Vitest";
-import { getProjectBranch } from "@distilled.cloud/neon";
+import { deleteProjectBranch, getProjectBranch } from "@distilled.cloud/neon";
 import { expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import { MinimumLogLevel } from "effect/References";
+import * as Schedule from "effect/Schedule";
 
 const { test } = Test.make({ providers: Neon.providers() });
 
@@ -201,4 +203,172 @@ test.provider("replaces branch when project is replaced", (stack) =>
 
     yield* stack.destroy();
   }).pipe(logLevel),
+);
+
+// #736 regression tests: a `creating`-state row persisted before upstream
+// Outputs resolve cannot round-trip Output-valued props — they deserialize as
+// `undefined`. The engine's recovery paths hand those junk props back to the
+// provider as `olds` (Plan.ts calls `read` and then `diff` with
+// `olds: oldState.props` for a creating row with no attributes). The provider
+// must fall through to the create path instead of crashing in
+// `resolveProjectId`.
+//
+// Shared shape (Variant B): deploy a project + branch, rewrite the branch's
+// persisted row into the wedged creating-state shape, delete the branch
+// out-of-band so recovery must recreate it, redeploy, and assert convergence.
+
+/** Rewrite the deployed branch's state row into a wedged `creating` row. */
+const wedgeBranchRow = (stack: { name: string }, project: unknown) =>
+  Effect.gen(function* () {
+    const state = yield* yield* State;
+    const stage = "test"; // scratch stacks default to the "test" stage
+    const fqns = yield* state.list({ stack: stack.name, stage });
+    const rows = yield* Effect.forEach(fqns, (fqn) =>
+      state
+        .get({ stack: stack.name, stage, fqn })
+        .pipe(Effect.map((row) => ({ fqn, row }))),
+    );
+    const wedged = rows.find(
+      (r): r is { fqn: string; row: ResourceState } =>
+        isResourceState(r.row) && r.row.resourceType === "Neon.Branch",
+    );
+    if (!wedged) {
+      return yield* Effect.die(
+        new Error("no Neon.Branch state row found after deploy"),
+      );
+    }
+    yield* state.set({
+      stack: stack.name,
+      stage,
+      fqn: wedged.fqn,
+      value: {
+        ...wedged.row,
+        status: "creating",
+        attr: undefined,
+        props: {
+          ...wedged.row.props,
+          project,
+        },
+      },
+    });
+  });
+
+/** Delete the branch out-of-band and wait (bounded) until it is gone. */
+const deleteBranchOutOfBand = (projectId: string, branchId: string) =>
+  Effect.gen(function* () {
+    yield* deleteProjectBranch({
+      project_id: projectId,
+      branch_id: branchId,
+    }).pipe(Effect.catchTag("NotFound", () => Effect.void));
+    const gone = yield* getProjectBranch({
+      project_id: projectId,
+      branch_id: branchId,
+    }).pipe(
+      Effect.as("found" as const),
+      Effect.catchTag("NotFound", () => Effect.succeed("gone" as const)),
+      Effect.repeat({
+        schedule: Schedule.spaced("2 seconds"),
+        until: (s) => s === "gone",
+        times: 10,
+      }),
+    );
+    expect(gone).toEqual("gone");
+  });
+
+// `read` guard: the project reference survived the creating-state round-trip
+// as an object, but its Output-valued `projectId` did not. Pre-fix, `read`
+// crashed with `Error: Invalid Neon project source: must be a Project or
+// { projectId }` (thrown by `resolveProjectId`); post-fix it returns
+// `undefined` and recovery recreates the branch.
+test.provider(
+  "recovers a creating-state branch whose project lost its Output-valued projectId (#736)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const deployBranch = () =>
+        stack.deploy(
+          Effect.gen(function* () {
+            const project = yield* Neon.Project("WedgedReadProject");
+            const branch = yield* Neon.Branch("WedgedReadBranch", { project });
+            return { project, branch };
+          }),
+        );
+
+      const initial = yield* deployBranch();
+
+      // The #736 shape for the `read` guard: the object survived but the
+      // Output-valued `projectId` inside it deserialized as `undefined`.
+      yield* wedgeBranchRow(stack, { projectId: undefined });
+
+      // Delete the branch out-of-band so recovery must recreate it (a
+      // recovery `read` returning attributes would skip the create path).
+      yield* deleteBranchOutOfBand(
+        initial.project.projectId,
+        initial.branch.branchId,
+      );
+
+      const recovered = yield* deployBranch();
+      expect(recovered.branch.branchId).toBeDefined();
+      expect(recovered.branch.branchId).not.toEqual(initial.branch.branchId);
+      expect(recovered.branch.projectId).toEqual(recovered.project.projectId);
+      expect(recovered.branch.branchName).toEqual(initial.branch.branchName);
+
+      const fetched = yield* getProjectBranch({
+        project_id: recovered.project.projectId,
+        branch_id: recovered.branch.branchId,
+      });
+      expect(fetched.branch.id).toEqual(recovered.branch.branchId);
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 240_000 },
+);
+
+// `diff` guard: the whole `project` prop deserialized as `undefined`. `read`
+// falls through on `!olds?.project` (both pre- and post-fix), so the engine
+// then calls `diff` with the junk olds. Pre-fix, `diff` crashed in
+// `resolveProjectId(undefined)`; post-fix the unknown old project id falls
+// through to the create/update recovery path (no forced replacement).
+test.provider(
+  "recovers a creating-state branch whose project prop was lost entirely (#736)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const deployBranch = () =>
+        stack.deploy(
+          Effect.gen(function* () {
+            const project = yield* Neon.Project("WedgedDiffProject");
+            const branch = yield* Neon.Branch("WedgedDiffBranch", { project });
+            return { project, branch };
+          }),
+        );
+
+      const initial = yield* deployBranch();
+
+      // The #736 shape for the `diff` guard: the entire Output-valued
+      // `project` prop deserialized as `undefined`.
+      yield* wedgeBranchRow(stack, undefined);
+
+      yield* deleteBranchOutOfBand(
+        initial.project.projectId,
+        initial.branch.branchId,
+      );
+
+      const recovered = yield* deployBranch();
+      expect(recovered.branch.branchId).toBeDefined();
+      expect(recovered.branch.branchId).not.toEqual(initial.branch.branchId);
+      expect(recovered.branch.projectId).toEqual(recovered.project.projectId);
+      expect(recovered.branch.branchName).toEqual(initial.branch.branchName);
+
+      const fetched = yield* getProjectBranch({
+        project_id: recovered.project.projectId,
+        branch_id: recovered.branch.branchId,
+      });
+      expect(fetched.branch.id).toEqual(recovered.branch.branchId);
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 240_000 },
 );


### PR DESCRIPTION
Follow-up to #767 (issue #736). A `creating` state row persisted before upstream Outputs resolve cannot round-trip Output-valued props — they deserialize as `undefined` — and Plan's recovery and deletion-planning branches hand those props back to `read`/`diff` as `olds`. Any provider that dereferences such a field crashes the plan and wedges the stack for `plan`/`deploy`/`destroy` alike (the ECS Service shape from #736).

This audits every provider's `read`/`diff` for that crash shape and applies the #767 pattern: when the identifying value can't be recovered from `output` or `olds`, `read` reports "not found" so the engine re-drives the create and the reconciler converges; `diff` only treats identity as changed when the old value is known.

```ts
// the recurring shape, e.g. IAM OpenIDConnectProvider read
const providerArn =
  output?.openIDConnectProviderArn ??
  (olds?.url !== undefined ? yield* oidcArnFromUrl(olds.url) : undefined);
if (providerArn === undefined) return undefined; // engine re-drives create
```

Fixed crash sites:

- **AWS Organizations** PolicyAttachment, RootPolicyType, TrustedServiceAccess, DelegatedAdministrator — `read` bails without identity props
- **AWS** ScalingPolicy (unknown old ASG → name-only `describePolicies` in `read`, known-both guard in `diff`), Route53 HostedZone + Record (`normalizeName`/`normalizeHostedZoneId` on undefined), ACM Certificate, CloudFront PublicKey, DynamoDB Table, IAM OpenIDConnectProvider
- **Cloudflare** Ruleset (`zoneIdOf` widened), Zaraz Config, Email CatchAll, GoogleTagGateway, Access InfrastructureTarget, OriginTlsClientAuth HostnameCertificate, OriginCaCertificate (lost hostname array elements)
- **Docker** Container (`read` falls back to the live container's image; `diff` skips create-args comparison without a comparable old image)
- **Neon** Branch (`resolveProjectId` threw; now falls through on an unknown old project)

Verified-already-guarded and left unchanged: Cloudflare Tunnel, KeylessCertificate, CustomCertificate, SecretsStore Secret, MtlsCertificate; Planetscale Branch/roles/passwords; GitHub Repository.

### Test coverage

Every fix now has a live wedged-state recovery regression test following the canonical ECS #736 pattern — deploy, rewrite the persisted row to `status: "creating"` / `attr: undefined` with the Output-valued props set to `undefined`, redeploy, assert convergence (plus an out-of-band delete variant where the fix is in `diff`, since a successful recovery `read` skips `diff`). 21 new tests across 19 files; **each was verified to fail against the pre-fix provider before its green live run** (`ALCHEMY_PROFILE=testing`, run individually under a hard timeout).

```ts
// the recurring wedge, from any of the new tests
yield* state.set({ stack: stack.name, stage, fqn, value: {
  ...row, status: "creating", attr: undefined,
  props: { ...row.props, hostedZoneId: undefined, name: undefined },
}});
const recovered = yield* deployRecord(); // pre-fix: TypeError in plan
```

Platform-gated lifecycles keep their directories' existing skipIf gates (Organizations management-account vars, Zaraz zone mutation, GoogleTagGateway list) and were verified skip-clean; everything else ran live.

### Additional fixes surfaced by writing the tests

- **AWS Route53**: `waitForChange` polled `getChange` with the raw prefixed `ChangeInfo.Id` (`"/change/C..."`), which returns `NoSuchChange` forever — every record/zone change silently burned the full ~121s bounded-repeat cap without ever observing INSYNC. Stripped the prefix (as ACM already did); changes now reach INSYNC in 0.1–3s.
- **AWS AutoScaling**: whole-resource props (`autoScalingGroup: group`, `launchTemplate: template`) never worked — the providers narrowed on a resource `Type` marker that doesn't survive Output resolution, so ScalingPolicy sent the entire attributes object as `AutoScalingGroupName` (ParseError) and AutoScalingGroup sent both `LaunchTemplateId` and `LaunchTemplateName` (AWS rejects both). Both now narrow on the resolved-attributes shape, with live whole-resource tests.
- **AWS AutoScaling**: `isLaunchTemplateNotFound` now recognizes the dot-form codes live AWS returns (`InvalidLaunchTemplateName.NotFoundException`), un-breaking the LaunchTemplate resource's read-before-create probe.
