### PR TITLE
feat(cloudflare/r2): restore cors prop on Bucket

### DIFF
--- a/packages/alchemy/src/Cloudflare/R2/Bucket.ts
+++ b/packages/alchemy/src/Cloudflare/R2/Bucket.ts
@@ -99,6 +99,42 @@ export type BucketLifecycleRule = {
   }[];
 };
 
+export type BucketCorsRule = {
+  /**
+   * Identifier for this rule.
+   */
+  id?: string;
+  /**
+   * Allowed origins, methods and headers for this CORS rule.
+   */
+  allowed: {
+    /**
+     * HTTP methods browsers are allowed to use in cross-origin requests.
+     */
+    methods: ("GET" | "PUT" | "POST" | "DELETE" | "HEAD")[];
+    /**
+     * Origins allowed to make cross-origin requests, e.g.
+     * `"https://example.com"`. Use `"*"` to allow any origin.
+     */
+    origins: string[];
+    /**
+     * Request headers browsers are allowed to send, e.g. `"range"` for
+     * range reads. If omitted, only simple headers are allowed.
+     */
+    headers?: string[];
+  };
+  /**
+   * Response headers the browser is allowed to expose to the requesting
+   * JavaScript, e.g. `"etag"` or `"content-range"`.
+   */
+  exposeHeaders?: string[];
+  /**
+   * How long (in seconds) browsers may cache CORS preflight responses.
+   * Browsers may cap this at 2 hours or less, even if 86400 is specified.
+   */
+  maxAgeSeconds?: number;
+};
+
 export type BucketProps = {
   /**
    * Name of the bucket. If omitted, a unique name will be generated.
@@ -130,6 +166,13 @@ export type BucketProps = {
    * supported transitions.
    */
   lifecycleRules?: BucketLifecycleRule[];
+  /**
+   * CORS rules applied to the bucket, controlling which cross-origin
+   * browser requests are allowed against the bucket's public or S3 API
+   * endpoints. Pass an empty array (or omit) to remove the CORS
+   * configuration.
+   */
+  cors?: BucketCorsRule[];
 };
 
 export type Bucket = Resource<
@@ -143,6 +186,7 @@ export type Bucket = Resource<
     accountId: string;
     domains: Bucket.CustomDomain[];
     lifecycleRules: Bucket.LifecycleRule[];
+    cors: Bucket.CorsRule[];
   },
   never,
   Cloudflare.Providers
@@ -298,6 +342,63 @@ export type Bucket = Resource<
  *   ],
  * });
  * ```
+ *
+ * @section CORS
+ *
+ * Configure CORS rules so browsers can make cross-origin requests against
+ * the bucket's public (custom domain / r2.dev) or S3 API endpoints. Pass an
+ * empty array (or omit) to remove the CORS configuration. See the
+ * [Cloudflare R2 docs](https://developers.cloudflare.com/r2/buckets/cors/)
+ * for details.
+ *
+ * @example Allow cross-origin reads from any origin
+ * ```typescript
+ * const bucket = yield* Cloudflare.R2.Bucket("MyBucket", {
+ *   cors: [
+ *     {
+ *       allowed: {
+ *         methods: ["GET", "HEAD"],
+ *         origins: ["*"],
+ *       },
+ *     },
+ *   ],
+ * });
+ * ```
+ *
+ * @example Browser range reads (e.g. PMTiles map tiles)
+ * ```typescript
+ * const bucket = yield* Cloudflare.R2.Bucket("MyBucket", {
+ *   domains: [{ name: "tiles.example.com" }],
+ *   cors: [
+ *     {
+ *       id: "range-reads",
+ *       allowed: {
+ *         methods: ["GET", "HEAD"],
+ *         origins: ["https://map.example.com"],
+ *         headers: ["range", "if-match"],
+ *       },
+ *       exposeHeaders: ["etag", "content-range"],
+ *       maxAgeSeconds: 3600,
+ *     },
+ *   ],
+ * });
+ * ```
+ *
+ * @example Allow uploads from a web app
+ * ```typescript
+ * const bucket = yield* Cloudflare.R2.Bucket("MyBucket", {
+ *   cors: [
+ *     {
+ *       allowed: {
+ *         methods: ["GET", "PUT", "POST"],
+ *         origins: ["https://app.example.com"],
+ *         headers: ["content-type"],
+ *       },
+ *       exposeHeaders: ["etag"],
+ *     },
+ *   ],
+ * });
+ * ```
  */
 export const Bucket = Resource<Bucket>("Cloudflare.R2.Bucket", {
   aliases: ["Cloudflare.R2Bucket"],
@@ -323,6 +424,16 @@ export declare namespace Bucket {
           storageClass: "InfrequentAccess";
         }[]
       | undefined;
+  };
+  export type CorsRule = {
+    id: string | undefined;
+    allowed: {
+      methods: ("GET" | "PUT" | "POST" | "DELETE" | "HEAD")[];
+      origins: string[];
+      headers: string[] | undefined;
+    };
+    exposeHeaders: string[] | undefined;
+    maxAgeSeconds: number | undefined;
   };
   export type CustomDomain = {
     domain: string;
@@ -659,6 +770,71 @@ export const BucketProvider = () =>
           return desiredRules;
         });
 
+      const reconcileCorsRules = (
+        bucketName: string,
+        jurisdiction: Bucket.Jurisdiction,
+        desired: BucketCorsRule[],
+      ) =>
+        Effect.gen(function* () {
+          const { accountId } = yield* yield* CloudflareEnvironment;
+          const observed = yield* r2
+            .getBucketCors({
+              accountId,
+              bucketName,
+              jurisdiction,
+            })
+            .pipe(
+              Effect.map((response) => (response.rules ?? []).map(toCorsRule)),
+              // A bucket with no CORS configuration is a typed error, not an
+              // empty rule list — normalize it to [] for the diff below.
+              Effect.catchTag("NoCorsConfiguration", () =>
+                Effect.succeed([] as Bucket.CorsRule[]),
+              ),
+              Effect.retry({
+                while: (e) => e._tag === "NoSuchBucket",
+                schedule: r2BucketEndpointConsistencySchedule,
+              }),
+            );
+
+          const desiredRules = desired.map(normalizeCorsRule);
+
+          if (deepEqual(observed, desiredRules)) {
+            return desiredRules;
+          }
+
+          if (desiredRules.length === 0) {
+            yield* r2
+              .deleteBucketCors({
+                accountId,
+                bucketName,
+                jurisdiction,
+              })
+              .pipe(
+                Effect.retry({
+                  while: (e) => e._tag === "NoSuchBucket",
+                  schedule: r2BucketEndpointConsistencySchedule,
+                }),
+              );
+            return desiredRules;
+          }
+
+          yield* r2
+            .putBucketCors({
+              accountId,
+              bucketName,
+              jurisdiction,
+              rules: desired,
+            })
+            .pipe(
+              Effect.retry({
+                while: (e) => e._tag === "NoSuchBucket",
+                schedule: r2BucketEndpointConsistencySchedule,
+              }),
+            );
+
+          return desiredRules;
+        });
+
       return {
         stables: ["bucketName", "accountId"],
         list: () =>
@@ -717,6 +893,21 @@ export const BucketProvider = () =>
                         Effect.succeed([] as Bucket.LifecycleRule[]),
                       ),
                     );
+                  const cors = yield* r2
+                    .getBucketCors({
+                      accountId,
+                      bucketName: bucket.name,
+                      jurisdiction: bucket.jurisdiction,
+                    })
+                    .pipe(
+                      Effect.map((observed) =>
+                        (observed.rules ?? []).map(toCorsRule),
+                      ),
+                      Effect.catchTag(
+                        ["NoSuchBucket", "NoCorsConfiguration"],
+                        () => Effect.succeed([] as Bucket.CorsRule[]),
+                      ),
+                    );
                   return {
                     bucketName: bucket.name,
                     storageClass: bucket.storageClass,
@@ -725,6 +916,7 @@ export const BucketProvider = () =>
                     accountId,
                     domains,
                     lifecycleRules,
+                    cors,
                   };
                 }).pipe(
                   // The custom-domain endpoint intermittently 500s ("Failed to
@@ -772,6 +964,9 @@ export const BucketProvider = () =>
             return { action: "update" } as const;
           }
           if (!deepEqual(olds.lifecycleRules, news.lifecycleRules)) {
+            return { action: "update" } as const;
+          }
+          if (!deepEqual(olds.cors, news.cors)) {
             return { action: "update" } as const;
           }
         }),
@@ -875,10 +1070,17 @@ export const BucketProvider = () =>
             news.lifecycleRules ?? [],
           );
 
+          const cors = yield* reconcileCorsRules(
+            attrs.bucketName,
+            attrs.jurisdiction,
+            news.cors ?? [],
+          );
+
           return {
             ...attrs,
             domains,
             lifecycleRules,
+            cors,
           };
         }),
         delete: Effect.fn(function* ({ output }) {
@@ -933,6 +1135,7 @@ export const BucketProvider = () =>
                 accountId: acct,
                 domains: output?.domains ?? [],
                 lifecycleRules: output?.lifecycleRules ?? [],
+                cors: output?.cors ?? [],
               })),
               Effect.catchTag("NoSuchBucket", () => Effect.succeed(undefined)),
             );
@@ -1021,6 +1224,31 @@ const normalizeLifecycleRule = (
     ? { condition: rule.deleteObjectsTransition.condition }
     : undefined,
   storageClassTransitions: rule.storageClassTransitions,
+});
+
+type CorsRuleResponse = NonNullable<r2.GetBucketCorsResponse["rules"]>[number];
+
+const toCorsRule = (rule: CorsRuleResponse): Bucket.CorsRule => ({
+  id: rule.id ?? undefined,
+  allowed: {
+    // Distilled widened generated string enums to open unions.
+    methods: rule.allowed.methods as Bucket.CorsRule["allowed"]["methods"],
+    origins: rule.allowed.origins,
+    headers: rule.allowed.headers ?? undefined,
+  },
+  exposeHeaders: rule.exposeHeaders ?? undefined,
+  maxAgeSeconds: rule.maxAgeSeconds ?? undefined,
+});
+
+const normalizeCorsRule = (rule: BucketCorsRule): Bucket.CorsRule => ({
+  id: rule.id,
+  allowed: {
+    methods: rule.allowed.methods,
+    origins: rule.allowed.origins,
+    headers: rule.allowed.headers,
+  },
+  exposeHeaders: rule.exposeHeaders,
+  maxAgeSeconds: rule.maxAgeSeconds,
 });
 
 const toLifecyclePutPayload = (

--- a/packages/alchemy/src/Cloudflare/R2/Bucket.ts
+++ b/packages/alchemy/src/Cloudflare/R2/Bucket.ts
@@ -101,28 +101,25 @@ export type BucketLifecycleRule = {
 
 export type BucketCorsRule = {
   /**
-   * Identifier for this rule.
+   * Optional label for this rule, shown in the Cloudflare dashboard. Not
+   * used to correlate rules across updates — the CORS configuration is
+   * always replaced as a whole.
    */
   id?: string;
   /**
-   * Allowed origins, methods and headers for this CORS rule.
+   * HTTP methods browsers are allowed to use in cross-origin requests.
    */
-  allowed: {
-    /**
-     * HTTP methods browsers are allowed to use in cross-origin requests.
-     */
-    methods: ("GET" | "PUT" | "POST" | "DELETE" | "HEAD")[];
-    /**
-     * Origins allowed to make cross-origin requests, e.g.
-     * `"https://example.com"`. Use `"*"` to allow any origin.
-     */
-    origins: string[];
-    /**
-     * Request headers browsers are allowed to send, e.g. `"range"` for
-     * range reads. If omitted, only simple headers are allowed.
-     */
-    headers?: string[];
-  };
+  allowedMethods: ("GET" | "PUT" | "POST" | "DELETE" | "HEAD")[];
+  /**
+   * Origins allowed to make cross-origin requests, e.g.
+   * `"https://example.com"`. Use `"*"` to allow any origin.
+   */
+  allowedOrigins: string[];
+  /**
+   * Request headers browsers are allowed to send, e.g. `"range"` for
+   * range reads. If omitted, only simple headers are allowed.
+   */
+  allowedHeaders?: string[];
   /**
    * Response headers the browser is allowed to expose to the requesting
    * JavaScript, e.g. `"etag"` or `"content-range"`.
@@ -356,10 +353,8 @@ export type Bucket = Resource<
  * const bucket = yield* Cloudflare.R2.Bucket("MyBucket", {
  *   cors: [
  *     {
- *       allowed: {
- *         methods: ["GET", "HEAD"],
- *         origins: ["*"],
- *       },
+ *       allowedMethods: ["GET", "HEAD"],
+ *       allowedOrigins: ["*"],
  *     },
  *   ],
  * });
@@ -371,12 +366,9 @@ export type Bucket = Resource<
  *   domains: [{ name: "tiles.example.com" }],
  *   cors: [
  *     {
- *       id: "range-reads",
- *       allowed: {
- *         methods: ["GET", "HEAD"],
- *         origins: ["https://map.example.com"],
- *         headers: ["range", "if-match"],
- *       },
+ *       allowedMethods: ["GET", "HEAD"],
+ *       allowedOrigins: ["https://map.example.com"],
+ *       allowedHeaders: ["range", "if-match"],
  *       exposeHeaders: ["etag", "content-range"],
  *       maxAgeSeconds: 3600,
  *     },
@@ -389,11 +381,9 @@ export type Bucket = Resource<
  * const bucket = yield* Cloudflare.R2.Bucket("MyBucket", {
  *   cors: [
  *     {
- *       allowed: {
- *         methods: ["GET", "PUT", "POST"],
- *         origins: ["https://app.example.com"],
- *         headers: ["content-type"],
- *       },
+ *       allowedMethods: ["GET", "PUT", "POST"],
+ *       allowedOrigins: ["https://app.example.com"],
+ *       allowedHeaders: ["content-type"],
  *       exposeHeaders: ["etag"],
  *     },
  *   ],
@@ -427,11 +417,9 @@ export declare namespace Bucket {
   };
   export type CorsRule = {
     id: string | undefined;
-    allowed: {
-      methods: ("GET" | "PUT" | "POST" | "DELETE" | "HEAD")[];
-      origins: string[];
-      headers: string[] | undefined;
-    };
+    allowedMethods: ("GET" | "PUT" | "POST" | "DELETE" | "HEAD")[];
+    allowedOrigins: string[];
+    allowedHeaders: string[] | undefined;
     exposeHeaders: string[] | undefined;
     maxAgeSeconds: number | undefined;
   };
@@ -823,7 +811,7 @@ export const BucketProvider = () =>
               accountId,
               bucketName,
               jurisdiction,
-              rules: desired,
+              rules: desired.map(toCorsPutPayload),
             })
             .pipe(
               Effect.retry({
@@ -1230,22 +1218,31 @@ type CorsRuleResponse = NonNullable<r2.GetBucketCorsResponse["rules"]>[number];
 
 const toCorsRule = (rule: CorsRuleResponse): Bucket.CorsRule => ({
   id: rule.id ?? undefined,
-  allowed: {
-    // Distilled widened generated string enums to open unions.
-    methods: rule.allowed.methods as Bucket.CorsRule["allowed"]["methods"],
-    origins: rule.allowed.origins,
-    headers: rule.allowed.headers ?? undefined,
-  },
+  // Distilled widened generated string enums to open unions.
+  allowedMethods: rule.allowed.methods as Bucket.CorsRule["allowedMethods"],
+  allowedOrigins: rule.allowed.origins,
+  allowedHeaders: rule.allowed.headers ?? undefined,
   exposeHeaders: rule.exposeHeaders ?? undefined,
   maxAgeSeconds: rule.maxAgeSeconds ?? undefined,
 });
 
 const normalizeCorsRule = (rule: BucketCorsRule): Bucket.CorsRule => ({
   id: rule.id,
+  allowedMethods: rule.allowedMethods,
+  allowedOrigins: rule.allowedOrigins,
+  allowedHeaders: rule.allowedHeaders,
+  exposeHeaders: rule.exposeHeaders,
+  maxAgeSeconds: rule.maxAgeSeconds,
+});
+
+const toCorsPutPayload = (
+  rule: BucketCorsRule,
+): NonNullable<r2.PutBucketCorsRequest["rules"]>[number] => ({
+  id: rule.id,
   allowed: {
-    methods: rule.allowed.methods,
-    origins: rule.allowed.origins,
-    headers: rule.allowed.headers,
+    methods: rule.allowedMethods,
+    origins: rule.allowedOrigins,
+    headers: rule.allowedHeaders,
   },
   exposeHeaders: rule.exposeHeaders,
   maxAgeSeconds: rule.maxAgeSeconds,

--- a/packages/alchemy/test/Cloudflare/R2/Bucket.test.ts
+++ b/packages/alchemy/test/Cloudflare/R2/Bucket.test.ts
@@ -294,6 +294,113 @@ test.provider("lifecycle rules are added, updated, and removed", (stack) =>
   }).pipe(logLevel),
 );
 
+test.provider("cors rules are added, updated, and removed", (stack) =>
+  Effect.gen(function* () {
+    const { accountId } = yield* yield* CloudflareEnvironment;
+
+    yield* stack.destroy();
+
+    // Create with one rule.
+    const initial = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* Cloudflare.R2.Bucket("CorsBucket", {
+          cors: [
+            {
+              id: "range-reads",
+              allowed: {
+                methods: ["GET", "HEAD"],
+                origins: ["https://map.example.com"],
+                headers: ["range"],
+              },
+              exposeHeaders: ["etag", "content-range"],
+              maxAgeSeconds: 3600,
+            },
+          ],
+        });
+      }),
+    );
+
+    expect(initial.cors).toHaveLength(1);
+
+    const initialCors = yield* r2.getBucketCors({
+      accountId,
+      bucketName: initial.bucketName,
+    });
+    expect(initialCors.rules).toHaveLength(1);
+    expect(initialCors.rules?.[0]?.id).toEqual("range-reads");
+    expect(initialCors.rules?.[0]?.allowed.methods).toEqual(["GET", "HEAD"]);
+    expect(initialCors.rules?.[0]?.allowed.origins).toEqual([
+      "https://map.example.com",
+    ]);
+    expect(initialCors.rules?.[0]?.exposeHeaders).toEqual([
+      "etag",
+      "content-range",
+    ]);
+    expect(initialCors.rules?.[0]?.maxAgeSeconds).toEqual(3600);
+
+    // Update: widen origins and add a second rule.
+    yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* Cloudflare.R2.Bucket("CorsBucket", {
+          cors: [
+            {
+              id: "range-reads",
+              allowed: {
+                methods: ["GET", "HEAD"],
+                origins: ["*"],
+                headers: ["range"],
+              },
+              exposeHeaders: ["etag", "content-range"],
+              maxAgeSeconds: 3600,
+            },
+            {
+              id: "uploads",
+              allowed: {
+                methods: ["PUT", "POST"],
+                origins: ["https://app.example.com"],
+                headers: ["content-type"],
+              },
+            },
+          ],
+        });
+      }),
+    );
+
+    const updatedCors = yield* r2.getBucketCors({
+      accountId,
+      bucketName: initial.bucketName,
+    });
+    expect(updatedCors.rules).toHaveLength(2);
+    expect(updatedCors.rules?.[0]?.allowed.origins).toEqual(["*"]);
+    expect(updatedCors.rules?.[1]?.id).toEqual("uploads");
+    expect(updatedCors.rules?.[1]?.allowed.methods).toEqual(["PUT", "POST"]);
+
+    // Clear all rules — the CORS configuration is deleted entirely, so the
+    // GET endpoint reports the typed NoCorsConfiguration error.
+    yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* Cloudflare.R2.Bucket("CorsBucket", {
+          cors: [],
+        });
+      }),
+    );
+
+    const cleared = yield* r2
+      .getBucketCors({
+        accountId,
+        bucketName: initial.bucketName,
+      })
+      .pipe(
+        Effect.map((response) => response.rules ?? []),
+        Effect.catchTag("NoCorsConfiguration", () => Effect.succeed([])),
+      );
+    expect(cleared).toEqual([]);
+
+    yield* stack.destroy();
+    yield* waitForBucketToBeDeleted(initial.bucketName, accountId);
+  }).pipe(logLevel),
+);
+
 // R2 bucket creates are eventually consistent — a read immediately after
 // deploy can briefly return NoSuchBucket until the bucket propagates.
 const getBucketWhenReady = Effect.fn(function* (

--- a/packages/alchemy/test/Cloudflare/R2/Bucket.test.ts
+++ b/packages/alchemy/test/Cloudflare/R2/Bucket.test.ts
@@ -307,11 +307,9 @@ test.provider("cors rules are added, updated, and removed", (stack) =>
           cors: [
             {
               id: "range-reads",
-              allowed: {
-                methods: ["GET", "HEAD"],
-                origins: ["https://map.example.com"],
-                headers: ["range"],
-              },
+              allowedMethods: ["GET", "HEAD"],
+              allowedOrigins: ["https://map.example.com"],
+              allowedHeaders: ["range"],
               exposeHeaders: ["etag", "content-range"],
               maxAgeSeconds: 3600,
             },
@@ -345,21 +343,17 @@ test.provider("cors rules are added, updated, and removed", (stack) =>
           cors: [
             {
               id: "range-reads",
-              allowed: {
-                methods: ["GET", "HEAD"],
-                origins: ["*"],
-                headers: ["range"],
-              },
+              allowedMethods: ["GET", "HEAD"],
+              allowedOrigins: ["*"],
+              allowedHeaders: ["range"],
               exposeHeaders: ["etag", "content-range"],
               maxAgeSeconds: 3600,
             },
             {
               id: "uploads",
-              allowed: {
-                methods: ["PUT", "POST"],
-                origins: ["https://app.example.com"],
-                headers: ["content-type"],
-              },
+              allowedMethods: ["PUT", "POST"],
+              allowedOrigins: ["https://app.example.com"],
+              allowedHeaders: ["content-type"],
             },
           ],
         });
@@ -410,11 +404,9 @@ test.provider("cors reconciliation converges drift and adoption", (stack) =>
     const bucketName = "alchemy-test-r2-cors-drift";
     const rangeReads = {
       id: "range-reads",
-      allowed: {
-        methods: ["GET", "HEAD"] as ("GET" | "HEAD")[],
-        origins: ["https://map.example.com"],
-        headers: ["range"],
-      },
+      allowedMethods: ["GET", "HEAD"] as ("GET" | "HEAD")[],
+      allowedOrigins: ["https://map.example.com"],
+      allowedHeaders: ["range"],
       exposeHeaders: ["etag"],
       maxAgeSeconds: 3600,
     };
@@ -510,11 +502,9 @@ test.provider("cors is applied to the new bucket on replacement", (stack) =>
     const cors = [
       {
         id: "range-reads",
-        allowed: {
-          methods: ["GET", "HEAD"] as ("GET" | "HEAD")[],
-          origins: ["https://map.example.com"],
-          headers: ["range"],
-        },
+        allowedMethods: ["GET", "HEAD"] as ("GET" | "HEAD")[],
+        allowedOrigins: ["https://map.example.com"],
+        allowedHeaders: ["range"],
         exposeHeaders: ["etag"],
         maxAgeSeconds: 3600,
       },

--- a/packages/alchemy/test/Cloudflare/R2/Bucket.test.ts
+++ b/packages/alchemy/test/Cloudflare/R2/Bucket.test.ts
@@ -499,6 +499,76 @@ test.provider("cors reconciliation converges drift and adoption", (stack) =>
   }).pipe(logLevel),
 );
 
+test.provider("cors is applied to the new bucket on replacement", (stack) =>
+  Effect.gen(function* () {
+    const { accountId } = yield* yield* CloudflareEnvironment;
+
+    yield* stack.destroy();
+
+    const oldName = "alchemy-test-r2-cors-replace-a";
+    const newName = "alchemy-test-r2-cors-replace-b";
+    const cors = [
+      {
+        id: "range-reads",
+        allowed: {
+          methods: ["GET", "HEAD"] as ("GET" | "HEAD")[],
+          origins: ["https://map.example.com"],
+          headers: ["range"],
+        },
+        exposeHeaders: ["etag"],
+        maxAgeSeconds: 3600,
+      },
+    ];
+
+    const initial = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* Cloudflare.R2.Bucket("ReplaceCorsBucket", {
+          name: oldName,
+          cors,
+        });
+      }),
+    );
+    expect(initial.bucketName).toEqual(oldName);
+
+    const initialCors = yield* r2.getBucketCors({
+      accountId,
+      bucketName: oldName,
+    });
+    expect(initialCors.rules).toHaveLength(1);
+
+    // Changing the name replaces the bucket: the new bucket is created
+    // (greenfield reconcile must apply the CORS config from scratch) and
+    // the old bucket is deleted afterwards.
+    const replaced = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* Cloudflare.R2.Bucket("ReplaceCorsBucket", {
+          name: newName,
+          cors,
+        });
+      }),
+    );
+    expect(replaced.bucketName).toEqual(newName);
+    expect(replaced.cors).toHaveLength(1);
+    expect(replaced.cors[0]?.id).toEqual("range-reads");
+
+    const replacedCors = yield* r2.getBucketCors({
+      accountId,
+      bucketName: newName,
+    });
+    expect(replacedCors.rules).toHaveLength(1);
+    expect(replacedCors.rules?.[0]?.id).toEqual("range-reads");
+    expect(replacedCors.rules?.[0]?.allowed.origins).toEqual([
+      "https://map.example.com",
+    ]);
+
+    // The replaced bucket is cleaned up.
+    yield* waitForBucketToBeDeleted(oldName, accountId);
+
+    yield* stack.destroy();
+    yield* waitForBucketToBeDeleted(newName, accountId);
+  }).pipe(logLevel),
+);
+
 // R2 bucket creates are eventually consistent — a read immediately after
 // deploy can briefly return NoSuchBucket until the bucket propagates.
 const getBucketWhenReady = Effect.fn(function* (

--- a/packages/alchemy/test/Cloudflare/R2/Bucket.test.ts
+++ b/packages/alchemy/test/Cloudflare/R2/Bucket.test.ts
@@ -401,6 +401,104 @@ test.provider("cors rules are added, updated, and removed", (stack) =>
   }).pipe(logLevel),
 );
 
+test.provider("cors reconciliation converges drift and adoption", (stack) =>
+  Effect.gen(function* () {
+    const { accountId } = yield* yield* CloudflareEnvironment;
+
+    yield* stack.destroy();
+
+    const bucketName = "alchemy-test-r2-cors-drift";
+    const rangeReads = {
+      id: "range-reads",
+      allowed: {
+        methods: ["GET", "HEAD"] as ("GET" | "HEAD")[],
+        origins: ["https://map.example.com"],
+        headers: ["range"],
+      },
+      exposeHeaders: ["etag"],
+      maxAgeSeconds: 3600,
+    };
+    const foreignRule = {
+      id: "foreign",
+      allowed: {
+        methods: ["DELETE" as const],
+        origins: ["https://other.example.com"],
+      },
+    };
+
+    const initial = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* Cloudflare.R2.Bucket("DriftCorsBucket", {
+          name: bucketName,
+          cors: [rangeReads],
+        });
+      }),
+    );
+
+    // Drift: overwrite the CORS configuration out-of-band.
+    yield* r2.putBucketCors({
+      accountId,
+      bucketName,
+      rules: [foreignRule],
+    });
+
+    // Re-deploy with a changed rule. Reconcile diffs desired against
+    // *observed* cloud state (not olds), so the foreign rule is replaced
+    // even though olds still describes the original rule.
+    yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* Cloudflare.R2.Bucket("DriftCorsBucket", {
+          name: bucketName,
+          cors: [{ ...rangeReads, maxAgeSeconds: 7200 }],
+        });
+      }),
+    );
+
+    const repaired = yield* r2.getBucketCors({ accountId, bucketName });
+    expect(repaired.rules).toHaveLength(1);
+    expect(repaired.rules?.[0]?.id).toEqual("range-reads");
+    expect(repaired.rules?.[0]?.maxAgeSeconds).toEqual(7200);
+
+    // Adoption: re-drift the CORS config, then wipe local state so the next
+    // deploy adopts via `read` (output defined, olds undefined).
+    yield* r2.putBucketCors({
+      accountId,
+      bucketName,
+      rules: [foreignRule],
+    });
+    yield* Effect.gen(function* () {
+      const state = yield* yield* State;
+      yield* state.delete({
+        stack: stack.name,
+        stage: "test",
+        fqn: "DriftCorsBucket",
+      });
+    }).pipe(Effect.provide(stack.state));
+
+    const adopted = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* Cloudflare.R2.Bucket("DriftCorsBucket", {
+          name: bucketName,
+          cors: [rangeReads],
+        });
+      }),
+    );
+    expect(adopted.bucketName).toEqual(bucketName);
+    expect(adopted.cors).toHaveLength(1);
+    expect(adopted.cors[0]?.id).toEqual("range-reads");
+
+    const converged = yield* r2.getBucketCors({ accountId, bucketName });
+    expect(converged.rules).toHaveLength(1);
+    expect(converged.rules?.[0]?.id).toEqual("range-reads");
+    expect(converged.rules?.[0]?.allowed.origins).toEqual([
+      "https://map.example.com",
+    ]);
+
+    yield* stack.destroy();
+    yield* waitForBucketToBeDeleted(bucketName, accountId);
+  }).pipe(logLevel),
+);
+
 // R2 bucket creates are eventually consistent — a read immediately after
 // deploy can briefly return NoSuchBucket until the bucket propagates.
 const getBucketWhenReady = Effect.fn(function* (


### PR DESCRIPTION
Restore the `cors` prop that `Cloudflare.R2.Bucket` had in v1 (0.93.12) and lost in the v2 rewrite. Public buckets serving browser range-reads (e.g. PMTiles) can once again declare CORS in the stack instead of out-of-band via dashboard/wrangler.

```ts
const bucket = yield* Cloudflare.R2.Bucket("Tiles", {
  domains: [{ name: "tiles.example.com" }],
  cors: [
    {
      allowedMethods: ["GET", "HEAD"],
      allowedOrigins: ["https://map.example.com"],
      allowedHeaders: ["range"],
      exposeHeaders: ["etag", "content-range"],
      maxAgeSeconds: 3600,
    },
  ],
});
```

- Rules use the flat S3-style shape (`allowedMethods` / `allowedOrigins` / `allowedHeaders` / `exposeHeaders` / `maxAgeSeconds`, optional `id` label) rather than Cloudflare's nested `allowed: {...}` envelope — matching S3/CloudFormation/CDK/Terraform-AWS and fixing the request-headers-inside / expose-headers-outside asymmetry. The provider maps to the wire format.
- Reconciled like `lifecycleRules`: observe via `getBucketCors` (typed `NoCorsConfiguration` → `[]`), diff against desired, then `putBucketCors` / `deleteBucketCors` (empty array or omit removes the configuration entirely).
- `cors` added to Attributes and hydrated in `list`; `diff` returns `update` on change.
- Live tests cover the full reconciliation matrix: greenfield create, update (widen origins, add rule), clear-to-empty (asserting the typed `NoCorsConfiguration`), out-of-band drift repair (reconcile diffs against observed state, not olds), adoption with foreign CORS config, and replacement (new bucket gets CORS applied, old bucket torn down).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
