### PR TITLE
feat(test): guard RPC test transports against edge-transient HTML responses

### DIFF
--- a/packages/alchemy/src/Test/Bun.ts
+++ b/packages/alchemy/src/Test/Bun.ts
@@ -14,7 +14,11 @@ import * as Core from "./Core.ts";
 export {
   executeWhenReady,
   getWhenReady,
+  guardContentType,
+  guardedFetchLayer,
+  rpcClientLayer,
   WorkerNotReady,
+  type EdgeGuardOptions,
   type WhenReadyOptions,
 } from "./Http.ts";
 

--- a/packages/alchemy/src/Test/Http.ts
+++ b/packages/alchemy/src/Test/Http.ts
@@ -1,9 +1,17 @@
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
 import * as Schedule from "effect/Schedule";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import * as HttpClient from "effect/unstable/http/HttpClient";
+import {
+  DecodeError,
+  HttpClientError,
+} from "effect/unstable/http/HttpClientError";
 import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
 import type { HttpClientResponse } from "effect/unstable/http/HttpClientResponse";
+import * as RpcClient from "effect/unstable/rpc/RpcClient";
+import * as RpcSerialization from "effect/unstable/rpc/RpcSerialization";
 
 /**
  * A freshly-deployed Cloudflare Worker is not instantly reachable over HTTP.
@@ -72,3 +80,128 @@ export const getWhenReady = (
   options?: WhenReadyOptions,
 ): Effect.Effect<HttpClientResponse, unknown, HttpClient.HttpClient> =>
   executeWhenReady(HttpClientRequest.get(url), options);
+
+/**
+ * Options for the edge-transient response guard applied by
+ * {@link guardContentType} / {@link rpcClientLayer}. Pass per suite via
+ * `Test.make({ http: { ... } })` or per call site.
+ */
+export interface EdgeGuardOptions {
+  /**
+   * Retry schedule for edge-transient responses (and transport errors).
+   * Default: exponential from 500ms capped at 3s.
+   */
+  schedule?: Schedule.Schedule<unknown, unknown>;
+  /** Max transport-level retry attempts. Default `5`. */
+  times?: number;
+}
+
+const defaultGuardSchedule = Schedule.exponential("500 millis").pipe(
+  Schedule.either(Schedule.spaced("3 seconds")),
+);
+
+/**
+ * Guard an `HttpClient` against edge-generated bodies on a freshly deployed
+ * Worker URL.
+ *
+ * Protocol clients like effect RPC's `layerProtocolHttp` never inspect the
+ * response status or content-type — they pipe the raw body straight into the
+ * serialization parser, so every edge-generated HTML page (the workers.dev
+ * placeholder, which serves with HTTP **200**; 1101/1102 error pages;
+ * 429/1015 rate limits) surfaces as an opaque decode defect (e.g.
+ * `RpcClientDefect: Error decoding HTTP response`).
+ *
+ * This transform rejects any response whose `content-type` doesn't match the
+ * expected one as a typed `HttpClientError` that records the status + a body
+ * snippet — so a failure names its cause — and retries the request through a
+ * bounded schedule so callers ride out the cold-start window
+ * ({@link WorkerNotReady} documents why this belongs at the call site).
+ */
+export const guardContentType =
+  (contentType: string, options?: EdgeGuardOptions) =>
+  (client: HttpClient.HttpClient): HttpClient.HttpClient =>
+    client.pipe(
+      HttpClient.transform((effect, request) =>
+        Effect.flatMap(effect, (response) => {
+          const observed = response.headers["content-type"] ?? "";
+          if (observed.includes(contentType)) {
+            return Effect.succeed(response);
+          }
+          return response.text.pipe(
+            Effect.orElseSucceed(() => "<unreadable body>"),
+            Effect.flatMap((body) =>
+              Effect.fail(
+                new HttpClientError({
+                  reason: new DecodeError({
+                    request,
+                    response,
+                    description: `expected "${contentType}", got "${observed}" (status ${response.status}): ${body.slice(0, 200)}`,
+                  }),
+                }),
+              ),
+            ),
+          );
+        }),
+      ),
+      HttpClient.retry({
+        schedule: options?.schedule ?? defaultGuardSchedule,
+        times: options?.times ?? 5,
+      }),
+    );
+
+/**
+ * A fetch-backed `HttpClient` layer wrapped with {@link guardContentType}.
+ *
+ * Deliberately a standalone layer rather than a transform of the ambient
+ * test `HttpClient`: the ambient client also serves the engine's own cloud
+ * API calls during `deploy`/`destroy` and distilled SDK calls in
+ * `test.provider` bodies, which must NOT be subjected to this guard.
+ */
+export const guardedFetchLayer = (
+  contentType: string,
+  options?: EdgeGuardOptions,
+): Layer.Layer<HttpClient.HttpClient> =>
+  Layer.effect(HttpClient.HttpClient)(
+    Effect.gen(function* () {
+      const client = yield* HttpClient.HttpClient;
+      return guardContentType(contentType, options)(client);
+    }),
+  ).pipe(Layer.provide(FetchHttpClient.layer));
+
+/**
+ * Complete RPC-over-HTTP client transport for driving a deployed Worker:
+ * `RpcClient.layerProtocolHttp` + the given serialization (ndjson by
+ * default) + a {@link guardedFetchLayer} expecting that serialization's
+ * content-type.
+ *
+ * ```ts
+ * const client = yield* RpcClient.make(WorkerRpcs);
+ * // ...
+ * }).pipe(Effect.scoped, Effect.provide(Test.Http.rpcClientLayer(url)));
+ * ```
+ */
+export const rpcClientLayer = (
+  url: string,
+  options?: EdgeGuardOptions & {
+    /** RPC wire serialization. Default {@link RpcSerialization.ndjson}. */
+    serialization?: RpcSerialization.RpcSerialization["Service"];
+    /**
+     * Set `false` to skip the edge guard entirely and use a plain fetch
+     * transport — e.g. for a test that asserts on the raw edge behavior
+     * itself. Default `true`.
+     */
+    guard?: boolean;
+  },
+): Layer.Layer<RpcClient.Protocol> => {
+  const serialization = options?.serialization ?? RpcSerialization.ndjson;
+  return RpcClient.layerProtocolHttp({ url }).pipe(
+    Layer.provide(
+      options?.guard === false
+        ? FetchHttpClient.layer
+        : guardedFetchLayer(serialization.contentType, options),
+    ),
+    Layer.provide(
+      Layer.succeed(RpcSerialization.RpcSerialization, serialization),
+    ),
+  );
+};

--- a/packages/alchemy/src/Test/Vitest.ts
+++ b/packages/alchemy/src/Test/Vitest.ts
@@ -15,6 +15,17 @@ import type { CompiledStack } from "../Stack.ts";
 import type { Stage } from "../Stage.ts";
 import * as Core from "./Core.ts";
 
+export {
+  executeWhenReady,
+  getWhenReady,
+  guardContentType,
+  guardedFetchLayer,
+  rpcClientLayer,
+  WorkerNotReady,
+  type EdgeGuardOptions,
+  type WhenReadyOptions,
+} from "./Http.ts";
+
 export type MakeOptions<ROut = any> = Core.MakeOptions<ROut>;
 export type ScratchStack = Core.ScratchStack;
 export type TestEffect<A, R = never> = Core.TestEffect<A, R>;

--- a/packages/alchemy/test/Cloudflare/AI/ChatPersistenceRpc.test.ts
+++ b/packages/alchemy/test/Cloudflare/AI/ChatPersistenceRpc.test.ts
@@ -3,13 +3,10 @@ import * as Alchemy from "@/index.ts";
 import * as Test from "@/Test/Vitest";
 import { expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
 import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
-import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import * as RpcClient from "effect/unstable/rpc/RpcClient";
-import * as RpcSerialization from "effect/unstable/rpc/RpcSerialization";
 import ChatPersistenceRpcWorker from "./fixtures/ChatPersistenceRpcWorker.ts";
 import { ChatRpcs } from "./fixtures/ChatRpcs.ts";
 import { Gateway } from "./fixtures/Gateway.ts";
@@ -17,6 +14,13 @@ import { Gateway } from "./fixtures/Gateway.ts";
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Cloudflare.providers(),
 });
+
+// `Test.rpcClientLayer` speaks `RpcSerialization.ndjson` (streaming
+// procedures require newline framing on the wire, matching the worker) and
+// guards the transport against edge-generated HTML bodies (workers.dev
+// placeholder, error pages) that the RPC protocol would otherwise surface as
+// an opaque `RpcClientDefect`; see Test/Http.ts.
+const clientLayer = Test.rpcClientLayer;
 
 const logLevel = Effect.provideService(
   MinimumLogLevel,
@@ -41,16 +45,6 @@ const Stack = Alchemy.Stack(
 
 const stack = beforeAll(deploy(Stack));
 afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(Stack));
-
-// Streaming procedures require newline framing on the wire, so both the
-// worker and this client use `RpcSerialization.ndjson`.
-const clientLayer = (url: string) =>
-  RpcClient.layerProtocolHttp({ url }).pipe(
-    Layer.provide(FetchHttpClient.layer),
-    Layer.provide(
-      Layer.succeed(RpcSerialization.RpcSerialization, RpcSerialization.ndjson),
-    ),
-  );
 
 // Cap exponential backoff at 3s so retries stay bounded when the CF edge is
 // slow (otherwise the geometric blow-up dominates wall time).

--- a/packages/alchemy/test/Cloudflare/Workers/RpcDurableObjectNamespace.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/RpcDurableObjectNamespace.test.ts
@@ -2,14 +2,11 @@ import * as Cloudflare from "@/Cloudflare";
 import * as Test from "@/Test/Vitest";
 import { expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
 import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
-import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as RpcClient from "effect/unstable/rpc/RpcClient";
-import * as RpcSerialization from "effect/unstable/rpc/RpcSerialization";
 import Stack from "./fixtures/rpc-do-namespace-do-rpc/stack.ts";
 import { WorkerRpcs as RpcWorkerWorkerRpcs } from "./fixtures/rpc-worker-rpc-http/group.ts";
 import RpcWorkerStack from "./fixtures/rpc-worker-rpc-http/stack.ts";
@@ -17,6 +14,11 @@ import RpcWorkerStack from "./fixtures/rpc-worker-rpc-http/stack.ts";
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Cloudflare.providers(),
 });
+
+// `Test.rpcClientLayer` guards the transport against edge-generated HTML
+// bodies (workers.dev placeholder, error pages) that the RPC protocol would
+// otherwise surface as an opaque `RpcClientDefect`; see Test/Http.ts.
+const rpcClientLayer = Test.rpcClientLayer;
 
 const logLevel = Effect.provideService(
   MinimumLogLevel,
@@ -48,14 +50,6 @@ const resetCounter = (url: string, id: string) =>
     const client = HttpClient.filterStatusOk(yield* HttpClient.HttpClient);
     yield* client.post(`${url}/counter/${id}/reset`).pipe(retryHttp);
   });
-
-const rpcClientLayer = (url: string) =>
-  RpcClient.layerProtocolHttp({ url }).pipe(
-    Layer.provide(FetchHttpClient.layer),
-    Layer.provide(
-      Layer.succeed(RpcSerialization.RpcSerialization, RpcSerialization.ndjson),
-    ),
-  );
 
 const readinessRetries = 15;
 

--- a/packages/alchemy/test/Cloudflare/Workers/RpcHttp.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/RpcHttp.test.ts
@@ -3,19 +3,26 @@ import * as Test from "@/Test/Vitest";
 import { expect } from "@effect/vitest";
 import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
 import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
-import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import * as RpcClient from "effect/unstable/rpc/RpcClient";
-import * as RpcSerialization from "effect/unstable/rpc/RpcSerialization";
 import { WorkerRpcs } from "./fixtures/rpc-http/group.ts";
 import Stack from "./fixtures/rpc-http/stack.ts";
 
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Cloudflare.providers(),
 });
+
+// `Test.rpcClientLayer` guards the transport against edge-generated HTML
+// bodies (the workers.dev placeholder — which serves with HTTP 200 —
+// 1101/1102 error pages, 429/1015 rate limits): the effect RPC HTTP protocol
+// never inspects status or content-type, so those would otherwise surface as
+// an opaque `RpcClientDefect: Error decoding HTTP response`. Non-ndjson
+// responses fail typed (status + body snippet) and are retried at the
+// transport level, so every RPC call in this file rides out edge-propagation
+// windows with one shared budget.
+const clientLayer = Test.rpcClientLayer;
 
 const logLevel = Effect.provideService(
   MinimumLogLevel,
@@ -95,14 +102,6 @@ afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(Stack));
 // `RpcClient` constructed inside the Worker handler whose transport
 // is `Cloudflare.toHttpClient(rpcDO.getByName(...))`. This mirrors the
 // HttpApi fixture's `getTaskDO` pattern.
-const clientLayer = (url: string) =>
-  RpcClient.layerProtocolHttp({ url }).pipe(
-    Layer.provide(FetchHttpClient.layer),
-    Layer.provide(
-      Layer.succeed(RpcSerialization.RpcSerialization, RpcSerialization.ndjson),
-    ),
-  );
-
 test(
   "RpcServer.toHttpEffect: unary RPC response",
   Effect.gen(function* () {
@@ -192,9 +191,17 @@ test(
         (i) =>
           client.Ping({ message: `m-${i}` }).pipe(
             Effect.timeout("5 seconds"),
+            // 64-way fan-out opens many fresh connections, each of which can
+            // land on an edge host still serving an HTML page after the
+            // single-connection warmup succeeded. The transport guard retries
+            // those; this outer budget (matching the siblings' capped
+            // generosity) backstops timeouts and longer bursts — the previous
+            // uncapped `times: 3` (~3.5s window) was the flake.
             Effect.retry({
-              schedule: Schedule.exponential("500 millis"),
-              times: 3,
+              schedule: Schedule.exponential("500 millis").pipe(
+                Schedule.either(Schedule.spaced("2 seconds")),
+              ),
+              times: 10,
             }),
           ),
         { concurrency: 64 },
@@ -206,7 +213,7 @@ test(
       }
     }).pipe(Effect.scoped, Effect.provide(clientLayer(url)));
   }).pipe(logLevel),
-  { timeout: 30_000 },
+  { timeout: 60_000 },
 );
 
 test(

--- a/packages/alchemy/test/Cloudflare/Workers/RpcWorker.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/RpcWorker.test.ts
@@ -3,18 +3,20 @@ import * as Test from "@/Test/Vitest";
 import { expect } from "@effect/vitest";
 import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
 import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
-import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import * as RpcClient from "effect/unstable/rpc/RpcClient";
-import * as RpcSerialization from "effect/unstable/rpc/RpcSerialization";
 import { CallerRpcs, TargetRpcs } from "./fixtures/rpc-worker-binding/group.ts";
 import Stack from "./fixtures/rpc-worker-binding/stack.ts";
 
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Cloudflare.providers(),
 });
+
+// `Test.rpcClientLayer` guards the transport against edge-generated HTML
+// bodies (workers.dev placeholder, error pages) that the RPC protocol would
+// otherwise surface as an opaque `RpcClientDefect`; see Test/Http.ts.
+const clientLayer = Test.rpcClientLayer;
 
 const logLevel = Effect.provideService(
   MinimumLogLevel,
@@ -45,14 +47,6 @@ const retryReadyN =
 
 const stack = beforeAll(deploy(Stack));
 afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(Stack));
-
-const clientLayer = (url: string) =>
-  RpcClient.layerProtocolHttp({ url }).pipe(
-    Layer.provide(FetchHttpClient.layer),
-    Layer.provide(
-      Layer.succeed(RpcSerialization.RpcSerialization, RpcSerialization.ndjson),
-    ),
-  );
 
 test(
   "RpcWorker: target worker exposes Greet",

--- a/packages/alchemy/test/Cloudflare/Workers/TaggedRpcDO.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/TaggedRpcDO.test.ts
@@ -4,11 +4,9 @@ import { poll } from "@/Util/poll.ts";
 import { expect } from "@effect/vitest";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
 import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
 import type * as Scope from "effect/Scope";
-import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
 import type { HttpClientResponse } from "effect/unstable/http/HttpClientResponse";
@@ -128,16 +126,11 @@ const rpcUntilReady = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
 const withCounterKey = (key: string) =>
   HttpClient.mapRequest(HttpClientRequest.setHeader("x-counter-key", key));
 
-// Build a typed `RpcClient<CounterRpcs>` against WorkerA's URL.
-// Every call rides through the same JSON edge as the worker.dev URL,
-// so we share the readiness retry below at the test layer.
-const rpcClientLayer = (url: string) =>
-  RpcClient.layerProtocolHttp({ url }).pipe(
-    Layer.provide(FetchHttpClient.layer),
-    Layer.provide(
-      Layer.succeed(RpcSerialization.RpcSerialization, RpcSerialization.ndjson),
-    ),
-  );
+// WorkerA's typed RPC transport is `Test.rpcClientLayer` (see Test/Http.ts).
+// Its transport-level retry fires only on non-ndjson responses — edge pages
+// that prove the handler never ran (see `isEdgeNotReadyRpc` above) — so it
+// is safe for the non-idempotent increment bodies below.
+const rpcClientLayer = Test.rpcClientLayer;
 
 // Drive a typed `RpcClient<CounterRpcs>` body against WorkerA's URL.
 // Each call gets its own scope (so the client is freed promptly).


### PR DESCRIPTION
Root-causes and fixes the `RpcHttp.test.ts` "200 concurrent unary calls do not hang" full-suite flake.

The effect RPC HTTP protocol never inspects response status or content-type — it pipes the raw body straight into the ndjson parser. Any Cloudflare edge-generated HTML page (the workers.dev placeholder, which serves with HTTP **200**; 1101/1102 error pages; 429/1015 rate limits) therefore surfaced as an opaque `RpcClientDefect: Error decoding HTTP response`. The failing test was also the only one in its file still on an uncapped `times: 3` retry (~3.5s window), shorter than a typical edge bad-window burst under full-suite load.

### `Test.rpcClientLayer`

New shared transport in `Test/Http.ts` (re-exported from `Test/Vitest` and `Test/Bun`, next to the existing `getWhenReady` cold-start helpers). Its fetch client rejects any response whose content-type doesn't match the RPC serialization as a typed `HttpClientError` carrying the status + a body snippet — so the next flake names its cause — and retries at the transport level through a capped schedule.

```ts
import * as Test from "@/Test/Vitest";

const clientLayer = Test.rpcClientLayer;           // guarded ndjson transport
// Test.rpcClientLayer(url, { guard: false })       // plain transport
// Test.rpcClientLayer(url, { times: 0 })           // typed check, no retries
```

Suites opt in by importing the layer — `Test.make` and the ambient `HttpClient` (which also serves the engine's own cloud API calls and distilled SDK calls) are untouched.

- Replaces the identical hand-rolled `layerProtocolHttp` + `FetchHttpClient` + ndjson block in `RpcHttp`, `RpcWorker`, `TaggedRpcDO`, `RpcDurableObjectNamespace`, and `ChatPersistenceRpc` tests
- `TaggedRpcDO`'s non-idempotent increment bodies stay safe: the transport retry fires only on non-ndjson responses, which prove the handler never ran (the file's own `isEdgeNotReadyRpc` invariant)
- Aligns the flaky test's retry budget with its siblings (capped backoff, `times: 10`, 60s timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
