### PR TITLE
docs(cloudflare/workers): expand cron typedoc with Effect and async Worker examples

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/CronEventSource.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/CronEventSource.ts
@@ -10,19 +10,121 @@ import { isWorkerEvent, Worker } from "./Worker.ts";
 /**
  * Subscribe to Cloudflare Cron Triggers with an Effect handler.
  *
- * This wires both pieces of a scheduled Worker:
+ * A single call wires both pieces of a scheduled Worker:
  *
- * - **Runtime**: registers a `scheduled` listener on the Worker.
- * - **Deploy-time**: attaches the cron expression to the host Worker.
+ * - **Deploy-time**: attaches the cron expression to the host Worker's
+ *   Cron Triggers.
+ * - **Runtime**: registers a `scheduled` listener that runs your Effect on
+ *   each fire. The handler receives Cloudflare's `ScheduledController` —
+ *   `controller.scheduledTime` is the fire time and `controller.cron` is
+ *   the expression that fired.
+ *
+ * Requires `CronEventSourceLive` provided on the Worker's Effect.
+ * A failing handler won't crash the Worker — the event source catches the
+ * failure and moves on; log or report errors inside the handler if you
+ * need visibility into failed runs.
+ *
+ * Async (non-Effect) Workers don't use `cron` — they attach schedules with
+ * the Worker's `crons` prop and export their own `scheduled` handler from
+ * the entry module (see the Async Worker section below). Pass `crons: []`
+ * to remove all Cron Triggers from a Worker.
+ *
  * @binding
  * @product Workers
  * @category Workers & Compute
- * @example
+ *
+ * @section Effect-native Worker (recommended)
+ * @example Run an Effect on a schedule
  * ```typescript
- * yield* Cloudflare.Workers.cron("0 12 * * *", (controller) =>
- *   Effect.log(`scheduled at ${controller.scheduledTime}`),
+ * import * as Cloudflare from "alchemy/Cloudflare";
+ * import * as Effect from "effect/Effect";
+ * import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+ *
+ * export default Cloudflare.Worker(
+ *   "Worker",
+ *   { main: import.meta.url },
+ *   Effect.gen(function* () {
+ *     yield* Cloudflare.Workers.cron("0 12 * * *", (controller) =>
+ *       Effect.log(`scheduled at ${controller.scheduledTime}`),
+ *     );
+ *
+ *     return {
+ *       fetch: Effect.succeed(HttpServerResponse.text("ok")),
+ *     };
+ *   }).pipe(Effect.provide(Cloudflare.Workers.CronEventSourceLive)),
  * );
  * ```
+ *
+ * @example Multiple schedules
+ * ```typescript
+ * // Each handler only runs for fires of its own expression — the listener
+ * // checks controller.cron, so a midnight fire never runs the hourly handler.
+ * yield* Cloudflare.Workers.cron("0 * * * *", () => syncFeeds);
+ * yield* Cloudflare.Workers.cron("0 0 * * *", () => purgeExpired);
+ * ```
+ *
+ * @example Record each fire on a Durable Object
+ * ```typescript
+ * export default class Worker extends Cloudflare.Worker<Worker>()(
+ *   "Worker",
+ *   { main: import.meta.url },
+ *   Effect.gen(function* () {
+ *     const counters = yield* CronCounter;
+ *
+ *     yield* Cloudflare.Workers.cron("0 * * * *", (controller) =>
+ *       counters.getByName("default").record(controller.scheduledTime),
+ *     );
+ *
+ *     return {
+ *       fetch: Effect.gen(function* () {
+ *         const { times } = yield* counters.getByName("default").snapshot();
+ *         return yield* HttpServerResponse.json({ times });
+ *       }),
+ *     };
+ *   }).pipe(Effect.provide(Cloudflare.Workers.CronEventSourceLive)),
+ * ) {}
+ * ```
+ *
+ * @section Async Worker
+ * @example Attach schedules with the `crons` prop and export `scheduled`
+ * ```typescript
+ * // alchemy.run.ts — attach the cron expressions at deploy time
+ * export const Worker = Cloudflare.Worker("Worker", {
+ *   main: "./src/worker.ts",
+ *   crons: ["0 12 * * *"],
+ * });
+ *
+ * // src/worker.ts — the entry module handles the fires itself
+ * export default {
+ *   async scheduled(controller: ScheduledController) {
+ *     console.log(`scheduled at ${controller.scheduledTime}`);
+ *   },
+ * };
+ * ```
+ *
+ * @example Dispatch multiple schedules on `controller.cron`
+ * ```typescript
+ * export const Worker = Cloudflare.Worker("Worker", {
+ *   main: "./src/worker.ts",
+ *   crons: ["0 * * * *", "0 0 * * *"],
+ * });
+ *
+ * // src/worker.ts — one scheduled handler receives every fire
+ * export default {
+ *   async scheduled(controller: ScheduledController) {
+ *     switch (controller.cron) {
+ *       case "0 * * * *":
+ *         await syncFeeds();
+ *         break;
+ *       case "0 0 * * *":
+ *         await purgeExpired();
+ *         break;
+ *     }
+ *   },
+ * };
+ * ```
+ *
+ * @see https://developers.cloudflare.com/workers/configuration/cron-triggers/
  */
 export const cron = <Req = never>(
   expression: string,

--- a/packages/alchemy/src/Cloudflare/Workers/CronEventSource.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/CronEventSource.ts
@@ -22,7 +22,10 @@ import { isWorkerEvent, Worker } from "./Worker.ts";
  *   - `controller.cron` — the cron expression that fired.
  *   - `controller.noRetry()` — opts the invocation out of Cloudflare's
  *     retry-on-failure. Only meaningful when the scheduled invocation can
- *     actually fail — see the retry note below.
+ *     actually fail — see the failure & retry section below.
+ *
+ *   Each member has its own section below with an Effect example first and
+ *   an async example second.
  *
  * Requires `CronEventSourceLive` provided on the Worker's Effect.
  *
@@ -38,15 +41,15 @@ import { isWorkerEvent, Worker } from "./Worker.ts";
  *
  * Async (non-Effect) Workers don't use `cron` — they attach schedules with
  * the Worker's `crons` prop and export their own `scheduled` handler from
- * the entry module (see the Async Worker section below). Pass `crons: []`
- * to remove all Cron Triggers from a Worker.
+ * the entry module (each section below includes the async variant). Pass
+ * `crons: []` to remove all Cron Triggers from a Worker.
  *
  * @binding
  * @product Workers
  * @category Workers & Compute
  *
- * @section Effect-native Worker (recommended)
- * @example Run an Effect on a schedule
+ * @section Declare a schedule
+ * @example Effect-native Worker (recommended)
  * ```typescript
  * import * as Cloudflare from "alchemy/Cloudflare";
  * import * as Effect from "effect/Effect";
@@ -56,8 +59,8 @@ import { isWorkerEvent, Worker } from "./Worker.ts";
  *   "Worker",
  *   { main: import.meta.url },
  *   Effect.gen(function* () {
- *     yield* Cloudflare.Workers.cron("0 12 * * *", (controller) =>
- *       Effect.log(`scheduled at ${controller.scheduledTime}`),
+ *     yield* Cloudflare.Workers.cron("0 12 * * *", () =>
+ *       Effect.log("cron fired"),
  *     );
  *
  *     return {
@@ -67,15 +70,24 @@ import { isWorkerEvent, Worker } from "./Worker.ts";
  * );
  * ```
  *
- * @example Multiple schedules
+ * @example Async Worker — `crons` prop + exported `scheduled` handler
  * ```typescript
- * // Each handler only runs for fires of its own expression — the listener
- * // checks controller.cron, so a midnight fire never runs the hourly handler.
- * yield* Cloudflare.Workers.cron("0 * * * *", () => syncFeeds);
- * yield* Cloudflare.Workers.cron("0 0 * * *", () => purgeExpired);
+ * // alchemy.run.ts — attach the cron expressions at deploy time
+ * export const Worker = Cloudflare.Worker("Worker", {
+ *   main: "./src/worker.ts",
+ *   crons: ["0 12 * * *"],
+ * });
+ *
+ * // src/worker.ts — the entry module handles the fires itself
+ * export default {
+ *   async scheduled(controller: ScheduledController) {
+ *     console.log("cron fired");
+ *   },
+ * };
  * ```
  *
- * @example Record each fire on a Durable Object
+ * @section `controller.scheduledTime` — the fire time
+ * @example Effect: record each fire on a Durable Object
  * ```typescript
  * export default class Worker extends Cloudflare.Worker<Worker>()(
  *   "Worker",
@@ -97,24 +109,31 @@ import { isWorkerEvent, Worker } from "./Worker.ts";
  * ) {}
  * ```
  *
- * @section Async Worker
- * @example Attach schedules with the `crons` prop and export `scheduled`
+ * @example Async: use the fire time as an idempotency key
  * ```typescript
- * // alchemy.run.ts — attach the cron expressions at deploy time
- * export const Worker = Cloudflare.Worker("Worker", {
- *   main: "./src/worker.ts",
- *   crons: ["0 12 * * *"],
- * });
- *
- * // src/worker.ts — the entry module handles the fires itself
+ * // scheduledTime is the time the fire was *scheduled* for (not when it
+ * // ran), so it is stable across retries of the same fire — a natural
+ * // idempotency key for at-most-once side effects.
  * export default {
- *   async scheduled(controller: ScheduledController) {
- *     console.log(`scheduled at ${controller.scheduledTime}`);
+ *   async scheduled(controller: ScheduledController, env: WorkerEnv) {
+ *     const key = `run:${controller.scheduledTime}`;
+ *     if (await env.RUNS.get(key)) return;
+ *     await syncFeeds();
+ *     await env.RUNS.put(key, "done");
  *   },
  * };
  * ```
  *
- * @example Dispatch multiple schedules on `controller.cron`
+ * @section `controller.cron` — dispatch multiple schedules
+ * @example Effect: one handler per expression
+ * ```typescript
+ * // Each handler only runs for fires of its own expression — the listener
+ * // checks controller.cron, so a midnight fire never runs the hourly handler.
+ * yield* Cloudflare.Workers.cron("0 * * * *", () => syncFeeds);
+ * yield* Cloudflare.Workers.cron("0 0 * * *", () => purgeExpired);
+ * ```
+ *
+ * @example Async: switch on `controller.cron`
  * ```typescript
  * export const Worker = Cloudflare.Worker("Worker", {
  *   main: "./src/worker.ts",
@@ -136,7 +155,30 @@ import { isWorkerEvent, Worker } from "./Worker.ts";
  * };
  * ```
  *
- * @example Suppress retry for permanent failures with `controller.noRetry()`
+ * @section `controller.noRetry()` — failure & retry control
+ * @example Effect: bound retries with `Effect.retry`
+ * ```typescript
+ * import * as Schedule from "effect/Schedule";
+ *
+ * // The event source reports the invocation as successful even when the
+ * // handler fails, so Cloudflare's platform retry rarely engages for Effect
+ * // handlers — Effect.retry is the primary retry control. Calling
+ * // controller.noRetry() once retries are exhausted defensively covers
+ * // anything that can still mark the invocation failed (e.g. a failing
+ * // waitUntil task).
+ * yield* Cloudflare.Workers.cron("0 * * * *", (controller) =>
+ *   syncFeeds.pipe(
+ *     Effect.retry({ schedule: Schedule.exponential("1 second"), times: 3 }),
+ *     Effect.tapError((error) =>
+ *       Effect.logError("syncFeeds failed permanently", error).pipe(
+ *         Effect.andThen(Effect.sync(() => controller.noRetry())),
+ *       ),
+ *     ),
+ *   ),
+ * );
+ * ```
+ *
+ * @example Async: suppress retry for permanent failures
  * ```typescript
  * // src/worker.ts — a thrown error marks the invocation failed and
  * // Cloudflare may retry it; noRetry() opts this fire out of that.

--- a/packages/alchemy/src/Cloudflare/Workers/CronEventSource.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/CronEventSource.ts
@@ -15,14 +15,26 @@ import { isWorkerEvent, Worker } from "./Worker.ts";
  * - **Deploy-time**: attaches the cron expression to the host Worker's
  *   Cron Triggers.
  * - **Runtime**: registers a `scheduled` listener that runs your Effect on
- *   each fire. The handler receives Cloudflare's `ScheduledController` —
- *   `controller.scheduledTime` is the fire time and `controller.cron` is
- *   the expression that fired.
+ *   each fire. The handler receives Cloudflare's `ScheduledController`,
+ *   which has three members:
+ *   - `controller.scheduledTime` — the fire time in milliseconds since the
+ *     Unix epoch.
+ *   - `controller.cron` — the cron expression that fired.
+ *   - `controller.noRetry()` — opts the invocation out of Cloudflare's
+ *     retry-on-failure. Only meaningful when the scheduled invocation can
+ *     actually fail — see the retry note below.
  *
  * Requires `CronEventSourceLive` provided on the Worker's Effect.
- * A failing handler won't crash the Worker — the event source catches the
- * failure and moves on; log or report errors inside the handler if you
- * need visibility into failed runs.
+ *
+ * **Failure & retry semantics**: a failing handler won't crash the Worker —
+ * the event source catches the failure and moves on. That also means
+ * Cloudflare never observes a failed invocation, so its platform-level
+ * retry (and `controller.noRetry()`) never comes into play here. Express
+ * retry declaratively with `Effect.retry` inside the handler, and log or
+ * report errors if you need visibility into failed runs. In async Workers
+ * the opposite holds: a `scheduled` handler that throws (or rejects) marks
+ * the invocation failed and Cloudflare may retry it — call
+ * `controller.noRetry()` before rethrowing to suppress that.
  *
  * Async (non-Effect) Workers don't use `cron` — they attach schedules with
  * the Worker's `crons` prop and export their own `scheduled` handler from
@@ -119,6 +131,24 @@ import { isWorkerEvent, Worker } from "./Worker.ts";
  *       case "0 0 * * *":
  *         await purgeExpired();
  *         break;
+ *     }
+ *   },
+ * };
+ * ```
+ *
+ * @example Suppress retry for permanent failures with `controller.noRetry()`
+ * ```typescript
+ * // src/worker.ts — a thrown error marks the invocation failed and
+ * // Cloudflare may retry it; noRetry() opts this fire out of that.
+ * export default {
+ *   async scheduled(controller: ScheduledController) {
+ *     try {
+ *       await syncFeeds();
+ *     } catch (error) {
+ *       if (isPermanentFailure(error)) {
+ *         controller.noRetry();
+ *       }
+ *       throw error; // still recorded as a failed invocation
  *     }
  *   },
  * };

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -425,6 +425,13 @@ export interface WorkerProps<
   /**
    * Cron expressions that trigger the Worker's scheduled handler.
    *
+   * This is how async (non-Effect) Workers configure Cron Triggers — the
+   * entry module exports its own `scheduled` handler and this prop attaches
+   * the schedules at deploy time. Effect-native Workers usually skip this
+   * prop and call `Cloudflare.Workers.cron(expression, handler)` in the Init
+   * phase instead, which attaches the expression and registers the runtime
+   * listener in one step.
+   *
    * Pass an empty array to remove all Cron Triggers.
    */
   crons?: string[];


### PR DESCRIPTION
Expand the `Cloudflare.Workers.cron` typedoc to cover both ways of configuring Cron Triggers — Effect-native first, async second — organized as `@section`/`@example` blocks so the generated API reference gets a full Quick Reference.

**Effect-native Worker (recommended)** — `cron(expression, handler)` + `CronEventSourceLive`:

```ts
yield* Cloudflare.Workers.cron("0 12 * * *", (controller) =>
  Effect.log(`scheduled at ${controller.scheduledTime}`),
);
```

with examples for multiple schedules and recording fires on a Durable Object.

**Async Worker** — `crons` prop + exported `scheduled` handler:

```ts
export const Worker = Cloudflare.Worker("Worker", {
  main: "./src/worker.ts",
  crons: ["0 12 * * *"],
});

// src/worker.ts
export default {
  async scheduled(controller: ScheduledController) { ... },
};
```

with a second example dispatching multiple schedules on `controller.cron`.

Also cross-references the two entry points: the `crons` prop JSDoc on `WorkerProps` now explains it is the async-Worker path and points Effect-native Workers at `Workers.cron`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
