### PR TITLE
test: protect the standing test zone and un-gate the worker routes test

### DIFF
--- a/packages/alchemy/test/Cloudflare/BotManagement/BotManagement.test.ts
+++ b/packages/alchemy/test/Cloudflare/BotManagement/BotManagement.test.ts
@@ -78,8 +78,16 @@ const restoreSbfm = (zoneId: string, original: ObservedConfig) =>
     yield* botManagement.putBotManagement({ zoneId, ...body });
   }).pipe(Effect.ignore);
 
+// Setting `sbfm_definitely_automated` to anything but "allow" makes the
+// standing zone answer every automated request (curl, fetch, vitest HTTP
+// assertions) with a managed challenge — breaking every live suite that
+// drives the zone over HTTP, and an interrupted run leaves the setting
+// behind. The mutating lifecycle tests are therefore opt-in; the adopt and
+// list tests below always run.
+const destructive = !!process.env.CLOUDFLARE_TEST_BOT_MANAGEMENT;
+
 describe.sequential("BotManagement", () => {
-  test.provider(
+  test.provider.skipIf(!destructive)(
     "manages SBFM settings on the zone singleton and restores them on destroy",
     (stack) =>
       Effect.gen(function* () {
@@ -197,7 +205,7 @@ describe.sequential("BotManagement", () => {
     { timeout: 240_000 },
   );
 
-  test.provider(
+  test.provider.skipIf(!destructive)(
     "toggles a boolean SBFM field and restores it on destroy",
     (stack) =>
       Effect.gen(function* () {

--- a/packages/alchemy/test/Cloudflare/Ssl/UniversalSsl.test.ts
+++ b/packages/alchemy/test/Cloudflare/Ssl/UniversalSsl.test.ts
@@ -65,8 +65,17 @@ const setBaseline = (zoneId: string, enabled: boolean) =>
     }),
   );
 
+// Toggling Universal SSL off DELETES the standing zone's universal edge
+// certificate; Cloudflare re-issues it minutes later on re-enable — and
+// sometimes not at all (`enabled: true` with zero certificate packs), which
+// breaks every TLS-dependent test on the shared zone (worker routes, R2
+// domains, Hyperdrive origins) until someone re-orders the cert by toggling
+// the setting off→on. The toggle lifecycle is therefore opt-in; the
+// read-only `list` test below always runs.
+const destructive = !!process.env.CLOUDFLARE_TEST_UNIVERSAL_SSL;
+
 describe.sequential("UniversalSsl", () => {
-  test.provider(
+  test.provider.skipIf(!destructive)(
     "disables Universal SSL and restores the original value on destroy",
     (stack) =>
       Effect.gen(function* () {
@@ -102,7 +111,7 @@ describe.sequential("UniversalSsl", () => {
     { timeout: 180_000 },
   );
 
-  test.provider(
+  test.provider.skipIf(!destructive)(
     "updates enabled in place and keeps the captured initial value",
     (stack) =>
       Effect.gen(function* () {
@@ -148,7 +157,7 @@ describe.sequential("UniversalSsl", () => {
     { timeout: 180_000 },
   );
 
-  test.provider(
+  test.provider.skipIf(!destructive)(
     "destroy restores a disabled baseline when managing from a disabled zone",
     (stack) =>
       Effect.gen(function* () {

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerRoutes.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerRoutes.test.ts
@@ -120,7 +120,7 @@ const T1_ADDED = `${zoneName}/${routeSuffix}/t1/other/*`;
 const T1_MATCH_URL = `https://${zoneName}/${routeSuffix}/t1/api/ping`;
 const T1_MISS_URL = `https://${zoneName}/${routeSuffix}/t1/unknown`;
 
-test.provider.skipIf(!zoneName || !!process.env.FAST)(
+test.provider.skipIf(!zoneName)(
   "creates, keeps, updates, and removes worker zone routes",
   (stack) =>
     Effect.gen(function* () {

--- a/scripts/nuke.sh
+++ b/scripts/nuke.sh
@@ -1,7 +1,8 @@
 bun alchemy unsafe nuke ./stacks/nuke.ts  \
   --exclude 'Cloudflare.Zone*' \
   --exclude 'Cloudflare.Account*' \
-  --exclude 'Cloudflare.Dns*' \
+  --exclude 'Cloudflare.DNS*' \
+  --exclude 'Cloudflare.Ssl.UniversalSsl' \
   --exclude 'Cloudflare.ApiToken.*' \
   --exclude 'Cloudflare.Secret*' \
   --exclude 'Cloudflare.Organization.*' \


### PR DESCRIPTION
Un-gate the worker-routes lifecycle test (FAST gate from 133e0cd12) and stop the recurring breakage of the standing test zone `alchemy-test-2.us` that made it slow/failing in the first place. The suite now passes in ~15s (was ~200s of HTTP timeouts).

Three independent saboteurs, each fixed:

- **`nuke.sh` deleted the zone's DNS records** — the exclude was `'Cloudflare.Dns*'` but provider ids are `Cloudflare.DNS.*` and picomatch is case-sensitive, so it matched nothing and every nuke removed the apex placeholder record that Workers routes need to serve.

  ```diff
  -  --exclude 'Cloudflare.Dns*' \
  +  --exclude 'Cloudflare.DNS*' \
  +  --exclude 'Cloudflare.Ssl.UniversalSsl' \
  ```

- **`UniversalSsl` tests deleted the zone's edge certificate** — toggling `enabled: false` deletes the universal cert pack, and Cloudflare sometimes never re-issues it on re-enable (`enabled: true` with zero packs → TLS handshake failure on every zone hostname). The toggle-lifecycle tests are now opt-in via `CLOUDFLARE_TEST_UNIVERSAL_SSL=1`; the read-only `list` test still runs.

- **`BotManagement` tests left the zone challenging all automated traffic** — the SBFM lifecycle test sets `sbfm_definitely_automated` to `managed_challenge`/`block`, so every curl/fetch (including the route test's HTTP assertions) got a 403 "Just a moment…" page instead of the Worker. The SBFM-mutating tests are now opt-in via `CLOUDFLARE_TEST_BOT_MANAGEMENT=1`; adopt/list tests still run.

The zone itself was repaired out-of-band (apex `AAAA 100::` proxied record restored, universal cert re-ordered, SBFM reset to `allow`), and `WorkerRoutes.test.ts` self-heals the apex record on future runs.
