### PR TITLE
fix(docker): unit-suffix Container healthcheck durations

### DIFF
--- a/packages/alchemy/src/Docker/Container.ts
+++ b/packages/alchemy/src/Docker/Container.ts
@@ -418,5 +418,8 @@ const normalizeDuration = (
 ): string | undefined => {
   if (!input) return undefined;
   const duration = Duration.fromInputUnsafe(input);
-  return Duration.toNanosUnsafe(duration).toString();
+  // Docker parses `--health-*` durations with Go's `time.ParseDuration`, which
+  // requires a unit suffix — a bare nanosecond count is rejected with "missing
+  // unit in duration". `ns` is the lossless Go-duration rendering of the nanos.
+  return `${Duration.toNanosUnsafe(duration).toString()}ns`;
 };

--- a/packages/alchemy/test/Docker/Container.test.ts
+++ b/packages/alchemy/test/Docker/Container.test.ts
@@ -251,4 +251,38 @@ describe("Docker.Container", { concurrent: false }, () => {
       }),
     { timeout: 240_000 },
   );
+
+  test.provider.skipIf(!isDockerReady)(
+    "applies a healthcheck with unit-suffixed durations",
+    (stack) =>
+      Effect.gen(function* () {
+        const docker = yield* Docker.Docker;
+        // `normalizeDuration` used to emit a bare nanosecond count (e.g.
+        // `1000000000`), which `docker container create` rejects with "missing
+        // unit in duration" — so this deploy would fail outright before the fix.
+        const container = yield* stack.deploy(
+          Docker.Container("healthcheck-container", {
+            image: "nginx:alpine",
+            healthcheck: {
+              cmd: "true",
+              interval: "1 second",
+              timeout: "2 seconds",
+              retries: 3,
+              startPeriod: "1 second",
+            },
+            start: true,
+          }),
+        );
+        expect(container.status).toBe("running");
+
+        // Docker reports the configured durations back in nanoseconds — assert
+        // they round-tripped rather than being dropped or truncated.
+        const info = yield* docker.container.inspect(container.name);
+        const health = info?.Config.Healthcheck;
+        expect(health?.Interval).toBe(1_000_000_000);
+        expect(health?.Timeout).toBe(2_000_000_000);
+        expect(health?.Retries).toBe(3);
+        expect(health?.StartPeriod).toBe(1_000_000_000);
+      }),
+  );
 });


### PR DESCRIPTION
## Problem

Any `Docker.Container` with a `healthcheck` fails to create. `normalizeDuration` renders durations as a bare nanosecond count:

```ts
// Docker/Container.ts
return Duration.toNanosUnsafe(duration).toString();   // "1000000000"
```

Docker parses `--health-interval` / `--health-timeout` / `--health-start-period` / `--health-start-interval` with Go's `time.ParseDuration`, which **requires a unit suffix**, so `docker container create` rejects the bare number:

```
invalid argument "1000000000" for "--health-interval" flag:
time: missing unit in duration "1000000000"
```

Repro:

```ts
Docker.Container("pg", {
  image: "postgres:17-alpine",
  healthcheck: { cmd: "pg_isready", interval: "5 seconds" },
  start: true,
});
// → deploy fails: docker container create ... missing unit in duration
```

## Fix

Append `ns` — the lossless Go-duration rendering of the nanosecond count. `Duration` keeps nanosecond precision, and Docker accepts `1000000000ns`.

```ts
return `${Duration.toNanosUnsafe(duration).toString()}ns`;
```

`normalizeDuration` is used only for the four `--health-*` duration flags, so this covers the whole surface.

## Test

Adds a docker-gated regression test (`test.provider.skipIf(!isDockerReady)`) that deploys an `nginx:alpine` container with a healthcheck and asserts the durations round-trip through `docker inspect`:

```
Config.Healthcheck = { Interval: 1000000000, Timeout: 2000000000, StartPeriod: 1000000000, Retries: 3 }
```

Before the fix the deploy throws on `container create`; after, it succeeds and the values match.

## Verification

I couldn't run the full workspace test suite in my environment (the `@distilled.cloud/*` workspace packages don't resolve without the private submodule/registry). I validated the fix directly against a real Docker daemon (29.6.1):

- `docker create --health-interval 1000000000` → `missing unit in duration` (the current bug).
- `docker create --health-interval 1000000000ns` → accepted; `docker inspect .Config.Healthcheck` returns exactly the values the new test asserts.

Found this while adopting the new `Docker` namespace (beta.61) to manage a local-dev Postgres — a `healthcheck` block made every `db:up` fail until I dropped it.

Co-authored-by: Claude <noreply@anthropic.com>