### PR TITLE
feat(cloudflare/website): forward a custom worker entry (main) to the Vite plugin

### DIFF
--- a/packages/alchemy/src/Cloudflare/Website/Vite.ts
+++ b/packages/alchemy/src/Cloudflare/Website/Vite.ts
@@ -90,6 +90,25 @@ export interface ViteProps<Bindings extends WorkerBindingProps = {}>
  * });
  * ```
  *
+ * @section Custom Worker Entry
+ * By default the deployed Worker entry is the server bundle the
+ * framework produces. When the Worker must export more than the
+ * framework's fetch handler — Durable Object classes, additional
+ * handlers — point `main` at your own module that wraps the framework
+ * handler and re-exports the extras. `main` takes precedence over any
+ * entry configured in the Vite config.
+ *
+ * @example Custom entry hosting Durable Objects
+ * ```typescript
+ * const app = yield* Cloudflare.Website.Vite("App", {
+ *   main: "worker/index.ts",
+ *   viteEnvironments: {
+ *     entry: "rsc",
+ *     children: ["ssr"],
+ *   },
+ * });
+ * ```
+ *
  * @section Single-Page Applications
  * For SPAs (React, Vue, etc.), configure asset handling so all
  * routes fall back to `index.html`.
@@ -178,6 +197,7 @@ export const Vite: {
             ...props,
             main: undefined!,
             vite: {
+              main: props?.main,
               rootDir: props?.rootDir,
               memo: props?.memo,
               viteEnvironments: props?.viteEnvironments,

--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -328,6 +328,7 @@ export const LocalWorkerProvider = () =>
           compatibility,
           workerBindings,
           durableObjectNamespaces: Object.values(durableObjectNamespaces),
+          viteMain: props.vite?.main,
           viteEnvironments: props.vite?.viteEnvironments,
           hyperdrives,
           env: props.env,
@@ -418,6 +419,7 @@ export const LocalWorkerProvider = () =>
           rootDir,
           worker.env ?? {},
           {
+            main: worker.viteMain,
             compatibilityDate: worker.compatibility.date,
             compatibilityFlags: worker.compatibility.flags,
             viteEnvironments: worker.viteEnvironments,

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -557,6 +557,23 @@ export interface WorkerProps<
 
 export interface ViteOptions {
   /**
+   * Overrides the module that becomes the deployed Worker entry, forwarded
+   * to the Cloudflare Vite plugin's `main` option. Relative paths resolve
+   * from the Vite root (`rootDir`).
+   *
+   * By default the entry environment's own entry (the server bundle the
+   * framework produces) is deployed. Point `main` at a custom module when
+   * the deployed Worker must export more than the framework's fetch
+   * handler — e.g. Durable Object classes or additional handlers wrapping
+   * the framework handler.
+   *
+   * @example
+   * ```typescript
+   * vite: { main: "worker/index.ts" }
+   * ```
+   */
+  main?: string;
+  /**
    * Root directory passed to Vite's `root` option.
    * Defaults to the current working directory (`process.cwd()`).
    */

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -1055,6 +1055,7 @@ export const LiveWorkerProvider = () =>
             )).filter(([_, value]) => value !== undefined),
           ),
           {
+            main: props.vite?.main,
             compatibilityDate: compatibility.date,
             compatibilityFlags: compatibility.flags,
             viteEnvironments: props.vite?.viteEnvironments,

--- a/packages/alchemy/test/Cloudflare/Website/Vite.test.ts
+++ b/packages/alchemy/test/Cloudflare/Website/Vite.test.ts
@@ -397,6 +397,81 @@ test.provider(
 );
 
 test.provider(
+  "Vite: main overrides the worker entry from the Vite config",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const rootDir = yield* cloneFixture(doFixtureDir, {
+        prefix: "alchemy-vite-main-",
+        tempRoot,
+        entries: [
+          "alchemy.run.ts",
+          "index.html",
+          "package.json",
+          "vite.config.ts",
+          "src",
+        ],
+      });
+      const memoInclude = [
+        "index.html",
+        "src/**",
+        "package.json",
+        "vite.config.ts",
+      ];
+
+      // The fixture's vite.config.ts points the ssr environment at
+      // `src/worker.ts`. `main` must take precedence and deploy
+      // `src/worker-main.ts`, which re-exports the Durable Object and
+      // additionally answers `/api/entry`.
+      const site = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.Website.Vite("ViteMain", {
+            ...viteProps(rootDir, memoInclude),
+            main: "src/worker-main.ts",
+            compatibility: {
+              date: "2026-03-17",
+              flags: ["nodejs_compat"],
+            },
+            assets: {
+              runWorkerFirst: ["/api/*"],
+            },
+            env: {
+              Counter: Cloudflare.DurableObject<ViteDoCounter>("Counter", {
+                className: "Counter",
+              }),
+            },
+          });
+        }),
+      );
+
+      expect(site.url).toBeDefined();
+      yield* expectWorkerExists(site.workerName, accountId);
+
+      const entry = yield* fetchJsonReady<{ entry: string }>(
+        `${site.url!}/api/entry`,
+      );
+      expect(entry.entry).toBe("worker-main");
+
+      const reset = yield* fetchJsonReady<{ ok: boolean }>(
+        `${site.url!}/api/reset`,
+      );
+      expect(reset.ok).toBe(true);
+
+      const first = yield* fetchJsonReady<{ count: number }>(
+        `${site.url!}/api/count`,
+      );
+      expect(first.count).toBe(1);
+
+      yield* stack.destroy();
+      yield* waitForWorkerToBeDeleted(site.workerName, accountId);
+    }).pipe(logLevel),
+  { timeout: 360_000 },
+);
+
+test.provider(
   "Vite: React Router RSC deploys from a distilled manifest",
   (stack) =>
     Effect.gen(function* () {

--- a/packages/alchemy/test/Cloudflare/Website/vite-do-fixture/src/worker-main.ts
+++ b/packages/alchemy/test/Cloudflare/Website/vite-do-fixture/src/worker-main.ts
@@ -1,0 +1,24 @@
+import worker from "./worker.ts";
+
+export { Counter } from "./worker.ts";
+
+/**
+ * Alternate Worker entry used by the `main` override test. It hosts the
+ * same Durable Object but additionally answers `/api/entry`, so the test
+ * can prove the deployed entry came from the `main` option — not from the
+ * entry configured in `vite.config.ts` (which points at `worker.ts`).
+ */
+export default {
+  async fetch(
+    request: Request,
+    env: Parameters<typeof worker.fetch>[1],
+  ): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (url.pathname === "/api/entry") {
+      return Response.json({ entry: "worker-main" });
+    }
+
+    return worker.fetch(request, env);
+  },
+};


### PR DESCRIPTION
## Problem

`@distilled.cloud/cloudflare-vite-plugin` accepts a `main` option that overrides the entry environment's entry module, but `Website.Vite` provides no way to reach it: `ViteProps` omits `main` from `WorkerProps` and the wrapper hardcodes `main: undefined`, so the deployed Worker entry is always the framework's own server bundle.

That blocks Workers that must export more than the framework's fetch handler — most commonly Durable Object classes exported from a custom module that wraps the framework handler:

```ts
// worker/index.ts
import handler from "virtual:react-router/unstable_rsc/server"; // framework handler
export { MyDurableObject } from "./my-durable-object";
export default handler;
```

For single-environment builds the `vite-do-fixture` workaround (setting `environments.ssr.build.rollupOptions.input` in `vite.config.ts`) works, but React Server Components setups (e.g. React Router RSC) can't use it: the framework plugin owns the entry environment's input.

## Change

Adds `main?: string` to `ViteOptions` and threads it through both paths:

- **deploy**: `WorkerProvider` → `viteBuild` pluginOptions
- **dev**: `LocalWorkerProvider` worker config → `viteDev` pluginOptions

`Website.Vite` forwards its (previously omitted) flat `main` prop into `vite.main`, so usage reads like wrangler:

```ts
const app = yield* Cloudflare.Website.Vite("App", {
  main: "worker/index.ts",
  viteEnvironments: { entry: "rsc", children: ["ssr"] },
});
```

The plugin already gives `pluginOptions.main` precedence over config-derived entries for the entry environment (`cloudflare-rolldown-plugin` `plugins/options.ts`), so no plugin change is needed.

## Test

New live test `Vite: main overrides the worker entry from the Vite config": deploys the DO fixture with `main: "src/worker-main.ts"` — an alternate entry that re-exports the Durable Object and answers `/api/entry` — while the fixture's `vite.config.ts` still points at `src/worker.ts`. Asserts the deployed Worker serves the alternate entry and the DO binding still works.

`bun tsc -b` and `tsconfig.test.json` typecheck clean; touched files pass `oxfmt --check`.

## Context

This is the missing piece for driving a React Router RSC app that hosts Durable Objects entirely through stock alchemy + the stock Vite plugin, without maintaining a forked plugin to inject the entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)