### PR TITLE
feat(engine): thread resource fqn into provider handler inputs

### DIFF
--- a/packages/alchemy/src/Apply.ts
+++ b/packages/alchemy/src/Apply.ts
@@ -584,6 +584,7 @@ const executeNode = (
           attr = yield* node.provider
             .precreate({
               id: logicalId,
+              fqn,
               news: node.props,
               session: scopedSession,
               instanceId,
@@ -643,6 +644,7 @@ const executeNode = (
         attr = yield* node.provider
           .reconcile({
             id: logicalId,
+            fqn,
             news,
             instanceId,
             bindings: bindingOutputs,
@@ -765,6 +767,7 @@ const executeNode = (
         const attr = yield* node.provider
           .reconcile({
             id: logicalId,
+            fqn,
             news,
             instanceId,
             bindings: bindingOutputs,
@@ -887,6 +890,7 @@ const executeNode = (
               yield* node.provider
                 .delete({
                   id: logicalId,
+                  fqn,
                   instanceId: old.instanceId,
                   olds: old.props as never,
                   output: old.attr,
@@ -933,6 +937,7 @@ const executeNode = (
           attr = yield* node.provider
             .precreate({
               id: logicalId,
+              fqn,
               news: node.props,
               session: scopedSession,
               instanceId,
@@ -993,6 +998,7 @@ const executeNode = (
         attr = yield* node.provider
           .reconcile({
             id: logicalId,
+            fqn,
             news,
             instanceId,
             bindings: bindingOutputs,
@@ -1346,6 +1352,7 @@ const converge = Effect.fn(function* (
       const attr = yield* node.provider
         .reconcile({
           id: logicalId,
+          fqn,
           news: newProps,
           instanceId,
           bindings: newBindings,
@@ -1648,6 +1655,7 @@ const collectGarbage = Effect.fn(function* (
               yield* provider
                 .delete({
                   id: logicalId,
+                  fqn,
                   instanceId,
                   olds: props as never,
                   output: attr,

--- a/packages/alchemy/src/Cli/commands/logs.ts
+++ b/packages/alchemy/src/Cli/commands/logs.ts
@@ -126,6 +126,7 @@ export const logsCommand = Command.make(
 
             const lines = yield* provider.logs({
               id: resource.LogicalId,
+              fqn,
               instanceId: (resourceState as any).instanceId,
               props: (resourceState as any).props,
               output: (resourceState as any).attr,

--- a/packages/alchemy/src/Cli/commands/nuke.ts
+++ b/packages/alchemy/src/Cli/commands/nuke.ts
@@ -521,6 +521,9 @@ const nukeCommand = Command.make(
                 item.provider
                   .delete({
                     id: displayName(item.attr),
+                    // Enumerated straight from the cloud, so there is no
+                    // Alchemy namespace — an un-namespaced fqn is just the id.
+                    fqn: displayName(item.attr),
                     instanceId: "",
                     olds: item.attr as never,
                     output: item.attr as never,

--- a/packages/alchemy/src/Cli/commands/tail.ts
+++ b/packages/alchemy/src/Cli/commands/tail.ts
@@ -104,6 +104,7 @@ export const tailCommand = Command.make(
               logicalId: resource.LogicalId,
               stream: provider.tail({
                 id: resource.LogicalId,
+                fqn,
                 instanceId: (resourceState as any).instanceId,
                 props: (resourceState as any).props,
                 output: (resourceState as any).attr,

--- a/packages/alchemy/src/Plan.ts
+++ b/packages/alchemy/src/Plan.ts
@@ -324,6 +324,7 @@ export const make = <A>(
                 ? provider
                     .diff({
                       id: resource.LogicalId,
+                      fqn: resource.FQN,
                       olds: oldProps,
                       instanceId: oldState.instanceId,
                       news: props,
@@ -730,6 +731,7 @@ export const make = <A>(
               const readResult = yield* provider
                 .read({
                   id,
+                  fqn,
                   instanceId: adoptInstanceId,
                   olds: news,
                   output: undefined,
@@ -813,6 +815,7 @@ export const make = <A>(
                 const attr = yield* provider
                   .read({
                     id,
+                    fqn,
                     instanceId: oldState.instanceId,
                     olds: oldState.props,
                     output: oldState.attr,
@@ -837,6 +840,7 @@ export const make = <A>(
               provider
                 ?.diff?.({
                   id,
+                  fqn,
                   olds: oldProps,
                   instanceId: oldState.instanceId,
                   output: oldState.attr,
@@ -1232,6 +1236,7 @@ export const make = <A>(
                   attr = yield* provider
                     .read({
                       id: logicalId,
+                      fqn,
                       instanceId: oldState.instanceId,
                       olds: oldState.props as never,
                       output: oldState.attr as never,

--- a/packages/alchemy/src/Provider.ts
+++ b/packages/alchemy/src/Provider.ts
@@ -156,6 +156,11 @@ export interface ProviderService<
    */
   tail?(input: {
     id: string;
+    /**
+     * Fully-qualified name (namespace path + logical id, see `./FQN.ts`) —
+     * globally unique, so providers can stamp ownership metadata on cloud objects.
+     */
+    fqn: string;
     instanceId: string;
     props: Props<Res>;
     output: Res["Attributes"];
@@ -166,6 +171,11 @@ export interface ProviderService<
    */
   logs?(input: {
     id: string;
+    /**
+     * Fully-qualified name (namespace path + logical id, see `./FQN.ts`) —
+     * globally unique, so providers can stamp ownership metadata on cloud objects.
+     */
+    fqn: string;
     instanceId: string;
     props: Props<Res>;
     output: Res["Attributes"];
@@ -178,6 +188,11 @@ export interface ProviderService<
   // branch?() {}
   read?(input: {
     id: string;
+    /**
+     * Fully-qualified name (namespace path + logical id, see `./FQN.ts`) —
+     * globally unique, so providers can stamp ownership metadata on cloud objects.
+     */
+    fqn: string;
     instanceId: string;
     olds: Props<Res>;
     // what is the ARN?
@@ -189,6 +204,11 @@ export interface ProviderService<
   stables?: Extract<keyof Res["Attributes"], string>[];
   diff?(input: {
     id: string;
+    /**
+     * Fully-qualified name (namespace path + logical id, see `./FQN.ts`) —
+     * globally unique, so providers can stamp ownership metadata on cloud objects.
+     */
+    fqn: string;
     instanceId: string;
     olds: Props<Res>;
     // Note: we do not resolve (Res["Props"]) here because diff runs during plan
@@ -201,6 +221,11 @@ export interface ProviderService<
   // dev?:() => Effect.Effect<void, any, DevReq>;
   precreate?(input: {
     id: string;
+    /**
+     * Fully-qualified name (namespace path + logical id, see `./FQN.ts`) —
+     * globally unique, so providers can stamp ownership metadata on cloud objects.
+     */
+    fqn: string;
     news: Props<Res>;
     instanceId: string;
     session: ScopedPlanStatusSession;
@@ -230,6 +255,11 @@ export interface ProviderService<
    */
   reconcile(input: {
     id: string;
+    /**
+     * Fully-qualified name (namespace path + logical id, see `./FQN.ts`) —
+     * globally unique, so providers can stamp ownership metadata on cloud objects.
+     */
+    fqn: string;
     instanceId: string;
     news: Props<Res>;
     olds: Props<Res> | undefined;
@@ -239,6 +269,11 @@ export interface ProviderService<
   }): Effect.Effect<Res["Attributes"], any, ReconcileReq>;
   delete(input: {
     id: string;
+    /**
+     * Fully-qualified name (namespace path + logical id, see `./FQN.ts`) —
+     * globally unique, so providers can stamp ownership metadata on cloud objects.
+     */
+    fqn: string;
     instanceId: string;
     olds: Props<Res>;
     output: Res["Attributes"];

--- a/packages/alchemy/src/Sync.ts
+++ b/packages/alchemy/src/Sync.ts
@@ -203,6 +203,7 @@ export const sync = (
       const observed = yield* provider
         .read({
           id: logicalId,
+          fqn,
           instanceId,
           olds: old.props as never,
           output: old.attr as never,
@@ -220,6 +221,7 @@ export const sync = (
         const attr = yield* provider
           .reconcile({
             id: logicalId,
+            fqn,
             instanceId,
             news: old.props as never,
             olds: undefined,
@@ -273,6 +275,7 @@ export const sync = (
       const attr = yield* provider
         .reconcile({
           id: logicalId,
+          fqn,
           instanceId,
           news: old.props as never,
           olds: old.props as never,

--- a/packages/alchemy/test/AWS/RDS/DBCluster.test.ts
+++ b/packages/alchemy/test/AWS/RDS/DBCluster.test.ts
@@ -16,6 +16,7 @@ const callDiff = (olds: DBClusterProps, news: DBClusterProps) =>
     const provider = yield* Provider.findProvider(DBCluster);
     return yield* provider.diff!({
       id: "TestCluster",
+      fqn: "TestCluster",
       instanceId: "test-cluster",
       olds,
       news,

--- a/packages/alchemy/test/AWS/RDS/DBInstance.test.ts
+++ b/packages/alchemy/test/AWS/RDS/DBInstance.test.ts
@@ -19,6 +19,7 @@ const callDiff = (olds: DBInstanceProps, news: DBInstanceProps) =>
     const provider = yield* Provider.findProvider(DBInstance);
     return yield* provider.diff!({
       id: "TestInstance",
+      fqn: "TestInstance",
       instanceId: "test-instance",
       olds,
       news,

--- a/packages/alchemy/test/Command/Command.test.ts
+++ b/packages/alchemy/test/Command/Command.test.ts
@@ -130,6 +130,7 @@ test.provider(
       // diff() must return "update" because the output is stale.
       const refreshed = yield* provider.diff!({
         id: "test-build",
+        fqn: "test-build",
         instanceId: "legacy",
         olds: news,
         news,
@@ -142,6 +143,7 @@ test.provider(
       // reconcile() must rebuild and return a new output.
       const reconciled = yield* provider.reconcile({
         id: "test-build",
+        fqn: "test-build",
         instanceId: "legacy",
         news,
         olds: news,
@@ -161,6 +163,7 @@ test.provider(
       // delete() must resolve the absolute outdir and remove the directory.
       yield* provider.delete({
         id: "test-build",
+        fqn: "test-build",
         instanceId: "legacy",
         olds: news,
         output: legacyOutput,

--- a/packages/alchemy/test/Docker/Container.test.ts
+++ b/packages/alchemy/test/Docker/Container.test.ts
@@ -23,6 +23,7 @@ test.provider("diff replaces a container when its image changes", () =>
     const containerProvider = yield* Provider.findProvider(Docker.Container);
     const containerDiff = yield* containerProvider.diff!({
       id: "web",
+      fqn: "web",
       instanceId: "instance",
       olds: { name: "web", image: "nginx:alpine" },
       news: { name: "web", image: "nginx:1.27-alpine" },

--- a/packages/alchemy/test/Docker/Network.test.ts
+++ b/packages/alchemy/test/Docker/Network.test.ts
@@ -19,6 +19,7 @@ test.provider("diff replaces a network when labels change", () =>
     const networkProvider = yield* Provider.findProvider(Docker.Network);
     const networkDiff = yield* networkProvider.diff!({
       id: "app",
+      fqn: "app",
       instanceId: "instance",
       olds: { name: "app", labels: { usage: "old" } },
       news: { name: "app", labels: { usage: "new" } },

--- a/packages/alchemy/test/Docker/RemoteImage.test.ts
+++ b/packages/alchemy/test/Docker/RemoteImage.test.ts
@@ -28,6 +28,7 @@ test.provider("diff pulls again unless alwaysPull is disabled", () =>
 
     const pinned = yield* provider.diff!({
       id: "nginx",
+      fqn: "nginx",
       instanceId: "instance",
       olds: { name: "nginx", tag: "alpine", alwaysPull: false },
       news: { name: "nginx", tag: "alpine", alwaysPull: false },
@@ -39,6 +40,7 @@ test.provider("diff pulls again unless alwaysPull is disabled", () =>
 
     const refreshed = yield* provider.diff!({
       id: "nginx",
+      fqn: "nginx",
       instanceId: "instance",
       olds: { name: "nginx", tag: "alpine", alwaysPull: false },
       news: { name: "nginx", tag: "alpine" },

--- a/packages/alchemy/test/Docker/Volume.test.ts
+++ b/packages/alchemy/test/Docker/Volume.test.ts
@@ -18,6 +18,7 @@ test.provider("diff replaces a volume when labels change", () =>
     const volumeProvider = yield* Provider.findProvider(Docker.Volume);
     const volumeDiff = yield* volumeProvider.diff!({
       id: "data",
+      fqn: "data",
       instanceId: "instance",
       olds: { name: "data", labels: { usage: "old" } },
       news: { name: "data", labels: { usage: "new" } },

--- a/packages/alchemy/test/Local/RpcProvider.test.ts
+++ b/packages/alchemy/test/Local/RpcProvider.test.ts
@@ -43,6 +43,7 @@ describe("Local.RpcProvider.effect", () => {
         const [capture, result] = yield* useProvider((provider) =>
           provider.reconcile({
             id: "r",
+            fqn: "r",
             instanceId: "inst-from-arg",
             news: {},
             olds: undefined,
@@ -73,6 +74,7 @@ describe("Local.RpcProvider.effect", () => {
           provider
             .reconcile({
               id: "r",
+              fqn: "r",
               instanceId: "inst-from-arg",
               news: {},
               olds: undefined,
@@ -97,6 +99,7 @@ describe("Local.RpcProvider.effect", () => {
       const [capture, items] = yield* useProvider((provider) =>
         provider.tail!({
           id: "r",
+          fqn: "r",
           instanceId: "inst-from-arg",
           props: {},
           output: { ok: true, artifact: "artifact" },
@@ -115,6 +118,7 @@ describe("Local.RpcProvider.effect", () => {
         provider
           .reconcile({
             id: "r",
+            fqn: "r",
             news: {},
             olds: undefined,
             output: undefined,
@@ -136,6 +140,7 @@ describe("Local.RpcProvider.effect", () => {
       const [capture, result] = yield* useProvider((provider) =>
         provider.diff!({
           id: "r",
+          fqn: "r",
           news: {},
           olds: undefined,
           output: undefined,
@@ -147,6 +152,7 @@ describe("Local.RpcProvider.effect", () => {
             Effect.all({
               sameInstanceId: provider.reconcile({
                 id: "r",
+                fqn: "r",
                 instanceId: "inst-from-arg",
                 news: {},
                 olds: undefined,
@@ -156,6 +162,7 @@ describe("Local.RpcProvider.effect", () => {
               }),
               differentInstanceId: provider.reconcile({
                 id: "r",
+                fqn: "r",
                 instanceId: "inst-from-arg-2",
                 news: {},
                 olds: undefined,

--- a/packages/alchemy/test/Local/fixtures/rpc-spawner-devserver-parent.ts
+++ b/packages/alchemy/test/Local/fixtures/rpc-spawner-devserver-parent.ts
@@ -57,6 +57,7 @@ const program = Effect.gen(function* () {
 
   yield* provider.reconcile({
     id: "Dev",
+    fqn: "Dev",
     instanceId: "Dev",
     news: {
       command,

--- a/packages/alchemy/test/Planetscale/Branch.test.ts
+++ b/packages/alchemy/test/Planetscale/Branch.test.ts
@@ -47,6 +47,7 @@ test.provider("diff tracks Postgres branch replica intent", () =>
 
     const alreadyConvergedToNonHa = yield* provider.diff!({
       id: "Branch",
+      fqn: "Branch",
       instanceId: "instance",
       olds: props(0),
       news: props(0),
@@ -62,6 +63,7 @@ test.provider("diff tracks Postgres branch replica intent", () =>
 
     const exactHaCountChanged = yield* provider.diff!({
       id: "Branch",
+      fqn: "Branch",
       instanceId: "instance",
       olds: props(2),
       news: props(3),

--- a/packages/alchemy/test/apply.test.ts
+++ b/packages/alchemy/test/apply.test.ts
@@ -26,6 +26,7 @@ import {
   DeleteFirstResource,
   DeletedBindingRegressionTarget,
   DurationResource,
+  FqnProbe,
   Function,
   KindStablesResource,
   PhasedTarget,
@@ -4332,6 +4333,30 @@ describe("artifacts", () => {
         expect(updated.right.artifactValue).toEqual("right-v2");
         expect((yield* getState("Left/Shared"))?.status).toEqual("updated");
         expect((yield* getState("Right/Shared"))?.status).toEqual("updated");
+      }),
+  );
+});
+
+describe("resource identity (fqn) threading", () => {
+  test.provider(
+    "threads the resource's fully-qualified name into handler inputs, distinct from the logical id",
+    (stack) =>
+      Effect.gen(function* () {
+        // Deploy the probe under a namespace so its FQN ("Parent/leaf") is
+        // NOT its bare logical id ("leaf"). The provider echoes both the `id`
+        // and `fqn` it received back out as attributes.
+        const { probe } = yield* Effect.gen(function* () {
+          const probe = yield* Effect.gen(function* () {
+            return yield* FqnProbe("leaf", {});
+          }).pipe(Namespace.push("Parent"));
+          return { probe };
+        }).pipe(stack.deploy);
+
+        // The engine passes the leaf logical id as `id` and the full
+        // namespace-qualified name as `fqn`.
+        expect(probe.id).toEqual("leaf");
+        expect(probe.fqn).toEqual("Parent/leaf");
+        expect((yield* getState("Parent/leaf"))?.status).toEqual("created");
       }),
   );
 });

--- a/packages/alchemy/test/test.resources.ts
+++ b/packages/alchemy/test/test.resources.ts
@@ -1094,10 +1094,40 @@ export const aliasedWidgetProvider = () =>
     }),
   });
 
+// FqnProbe — echoes the identity the engine threads into each handler input
+// (`id` and `fqn`) back out as attributes. Lets a test assert that the engine
+// passes the resource's real fully-qualified name — namespace path + logical
+// id — which differs from the bare logical `id` for namespaced resources.
+
+export interface FqnProbe extends Resource<
+  "Test.FqnProbe",
+  {},
+  {
+    id: string;
+    fqn: string;
+  }
+> {}
+
+export const FqnProbe = Resource<FqnProbe>("Test.FqnProbe");
+
+export const fqnProbeProvider = () =>
+  Provider.succeed(FqnProbe, {
+    list: () => Effect.succeed([]),
+    diff: Effect.fn(function* ({ news }) {
+      if (!isResolved(news)) return undefined;
+      return undefined;
+    }),
+    reconcile: Effect.fn(function* ({ id, fqn }) {
+      return { id, fqn };
+    }),
+    delete: Effect.fn(function* () {}),
+  });
+
 // Layers
 export const TestLayers = () =>
   Layer.mergeAll(
     bucketProvider(),
+    fqnProbeProvider(),
     queueProvider(),
     functionProvider(),
     bindingTargetProvider(),


### PR DESCRIPTION
## Problem

Custom provider authors need a resource's stable, globally-unique identity inside lifecycle handlers — most importantly to stamp ownership metadata onto the cloud objects they manage (e.g. `alchemy_stack` / `alchemy_stage` / `alchemy_id` tags) so a provider never mutates or deletes an object owned by another stack, stage, or resource.

Today the handler inputs (`reconcile`, `delete`, `read`, `diff`, `precreate`, `tail`, `logs`) carry only `id` — the **leaf logical id**. That collides across namespaces: two resources with the same logical id under different constructs share an `id`, so it can't key ownership. The engine already treats the **fully-qualified name** (`fqn` = namespace path + logical id, see `FQN.ts`) as the resource's canonical identity — its telemetry spans log `alchemy.resource.fqn`, state is keyed by fqn, and artifact bags are already scoped by fqn — but handlers have no way to read it.

## Change

Adds `fqn: string` to every handler input object that already carries `id` (`reconcile`, `delete`, `read`, `diff`, `precreate`, `tail`, `logs`), documented with a short JSDoc. `list()` is unchanged — it enumerates rather than acting on a single resource.

The fqn is already computed at every call site, so this only threads the existing value through — no recomputation:

- **Apply**: `precreate` / `reconcile` / `delete` (the `fqn` already passed to `instrumentLifecycle`)
- **Plan**: `diff` / `read` (`resource.FQN` / the `fqn` already handed to `providePlanScope`)
- **Sync**: `read` / `reconcile`
- **CLI**: `tail` / `logs` (the loop's `fqn` key), and `nuke`'s `delete` (enumerated cloud objects have no Alchemy namespace, so their un-namespaced fqn is just the id)

This is purely additive: the input object gains a field, and providers that don't read it are unaffected.

## Tests

Adds a focused engine test (`apply.test.ts` → "resource identity (fqn) threading") deploying a new `FqnProbe` resource under a namespace, so its fqn (`Parent/leaf`) differs from its logical id (`leaf`). The provider echoes the `id` and `fqn` it received back out as attributes; the test asserts the engine threads `fqn = "Parent/leaf"` while `id = "leaf"`.

Existing provider-handler call sites in tests were updated to pass `fqn`. `bun tsc -b` and the affected suites pass.
