### PR TITLE
fix(command/dev): favor localhost/IP URLs in dev-URL detection

### DIFF
--- a/packages/alchemy/src/Command/Dev.ts
+++ b/packages/alchemy/src/Command/Dev.ts
@@ -162,7 +162,7 @@ export const DevProviderLocal = () =>
               duration: "5 seconds",
               // No localhost/IP URL appeared in time — fall back to any other
               // URL we saw (or `undefined` if the process stayed silent).
-              orElse: () => Effect.sync(() => fallbackUrl),
+              orElse: () => Effect.succeed(fallbackUrl),
             }),
           ),
           child.exitCode.pipe(

--- a/packages/alchemy/src/Command/Dev.ts
+++ b/packages/alchemy/src/Command/Dev.ts
@@ -22,8 +22,10 @@ export interface Dev extends Resource<
   DevProps,
   {
     /**
-     * URL extracted from the first matching stdout/stderr line. Best-effort:
-     * `undefined` if no URL appears within 5 seconds.
+     * URL extracted from stdout/stderr. A `localhost`/IP URL (the dev
+     * server's own address) is preferred over any other URL the command
+     * prints; a non-local URL is only used as a fallback if no local one
+     * appears. Best-effort: `undefined` if no URL appears within 5 seconds.
      */
     url: string | undefined;
   }
@@ -37,10 +39,11 @@ export interface Dev extends Resource<
  * The child process runs inside the dev sidecar (see `Command/Local.ts`) so it
  * survives user-code HMR — Alchemy's user process can restart without killing
  * your `npm run dev` server. Its stdout/stderr are mirrored to the terminal
- * (preserving colored output) and each line is scanned for the first
- * `http(s)://…` URL, which is exposed as the `url` output attribute — useful
- * for surfacing a dev server's local URL back out to whatever resource
- * declared this `Dev`.
+ * (preserving colored output) and scanned for an `http(s)://…` URL, favoring
+ * a `localhost`/IP URL (the dev server's own address) over any unrelated URL
+ * the command prints first. The result is exposed as the `url` output
+ * attribute — useful for surfacing a dev server's local URL back out to
+ * whatever resource declared this `Dev`.
  *
  * @resource
  *
@@ -119,6 +122,11 @@ export const DevProviderLocal = () =>
         const child = yield* spawn(props);
 
         let buffer = "";
+        // A non-local URL seen so far (docs link, error page, update notice,
+        // …). Held as a fallback so that if the dev server never prints a
+        // localhost/IP URL we still surface something, but a localhost URL
+        // always wins if one shows up. See issue #695.
+        let fallbackUrl: string | undefined;
         const deferred = yield* Deferred.make<string>();
 
         const mirror = (sink: "stdout" | "stderr") =>
@@ -132,8 +140,13 @@ export const DevProviderLocal = () =>
                 if (Deferred.isDoneUnsafe(deferred)) return;
                 buffer += text;
                 const url = extractUrl(buffer);
-                if (url) {
+                if (!url) return;
+                if (isLocalUrl(url)) {
+                  // The dev server's own address — resolve immediately.
                   Deferred.doneUnsafe(deferred, Effect.succeed(url));
+                } else {
+                  // Keep scanning: a localhost/IP URL may still appear.
+                  fallbackUrl = url;
                 }
               }),
             ),
@@ -147,7 +160,9 @@ export const DevProviderLocal = () =>
           Deferred.await(deferred).pipe(
             Effect.timeoutOrElse({
               duration: "5 seconds",
-              orElse: () => Effect.undefined,
+              // No localhost/IP URL appeared in time — fall back to any other
+              // URL we saw (or `undefined` if the process stayed silent).
+              orElse: () => Effect.sync(() => fallbackUrl),
             }),
           ),
           child.exitCode.pipe(
@@ -206,6 +221,13 @@ export const DevProviderLocal = () =>
     }),
   );
 
+// Matches an http(s) URL whose host is `localhost`, an IPv4 address, or a
+// bracketed IPv6 address — i.e. the shape a dev server prints for its own
+// local address. Preferred over any other URL a command might print first
+// (docs links, error pages, update notices). See issue #695.
+const LOCAL_URL_REGEX =
+  /https?:\/\/(?:localhost|\[[0-9a-fA-F:]+\]|(?:\d{1,3}\.){3}\d{1,3})(?::\d+)?[^\s)\],"'`]*/;
+
 // Matches the first plain http(s) URL. Stops at whitespace and at a small
 // set of punctuation typically used to wrap URLs in log output.
 const URL_REGEX = /https?:\/\/[^\s)\],"'`]+/;
@@ -215,5 +237,15 @@ const URL_REGEX = /https?:\/\/[^\s)\],"'`]+/;
 // eslint-disable-next-line no-control-regex
 const ANSI_REGEX = /\x1b\[[0-9;]*m/g;
 
-const extractUrl = (text: string) =>
-  text.replaceAll(ANSI_REGEX, "").match(URL_REGEX)?.[0];
+/**
+ * Extract a URL from `text`, favoring a localhost/IP URL (the dev server's
+ * own address) over any other URL. Returns the first localhost/IP URL if one
+ * is present, otherwise the first plain http(s) URL, otherwise `undefined`.
+ * @internal
+ */
+export const extractUrl = (text: string) => {
+  const clean = text.replaceAll(ANSI_REGEX, "");
+  return clean.match(LOCAL_URL_REGEX)?.[0] ?? clean.match(URL_REGEX)?.[0];
+};
+
+const isLocalUrl = (url: string) => LOCAL_URL_REGEX.test(url);

--- a/packages/alchemy/test/Command/Dev.test.ts
+++ b/packages/alchemy/test/Command/Dev.test.ts
@@ -1,7 +1,7 @@
 import * as Command from "@/Command/index.ts";
 import * as Provider from "@/Provider.ts";
 import * as Test from "@/Test/Vitest";
-import { assert, expect } from "@effect/vitest";
+import { assert, describe, expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Schedule from "effect/Schedule";
@@ -29,6 +29,46 @@ if (fixtureScript.includes(" ") || urlServerScript.includes(" ")) {
       `argv split cannot represent: ${fixtureScript} / ${urlServerScript}`,
   );
 }
+
+describe("extractUrl", () => {
+  it("returns a plain URL when it is the only match", () => {
+    expect(Command.extractUrl("Local: http://localhost:5173/")).toBe(
+      "http://localhost:5173/",
+    );
+  });
+
+  it("favors a localhost URL over an unrelated URL printed first", () => {
+    // Astro prints a docs link on a content error before the dev server
+    // prints its own localhost URL. See issue #695.
+    const buffer =
+      "see https://docs.astro.build/en/guides/content-collections/\n" +
+      "  ➜  Local:   http://localhost:5001/\n";
+    expect(Command.extractUrl(buffer)).toBe("http://localhost:5001/");
+  });
+
+  it("favors an IP URL over an unrelated URL printed first", () => {
+    const buffer =
+      "update available https://example.com/release\n" +
+      "ready - started server on http://127.0.0.1:3000\n";
+    expect(Command.extractUrl(buffer)).toBe("http://127.0.0.1:3000");
+  });
+
+  it("falls back to a non-local URL when no local URL is present", () => {
+    expect(
+      Command.extractUrl("docs https://docs.astro.build/en/guides/x/"),
+    ).toBe("https://docs.astro.build/en/guides/x/");
+  });
+
+  it("strips ANSI escapes before matching", () => {
+    expect(Command.extractUrl("\x1b[36mhttp://localhost:5173/\x1b[0m")).toBe(
+      "http://localhost:5173/",
+    );
+  });
+
+  it("returns undefined when there is no URL", () => {
+    expect(Command.extractUrl("no url here")).toBeUndefined();
+  });
+});
 
 const isAlive = (pid: number) =>
   Effect.sync(() => {
@@ -309,6 +349,69 @@ test.provider(
       expect(output.url).toBe("http://localhost:5173/");
 
       const { pid } = yield* waitForPidFile(pidFile, "url-ansi");
+      yield* stack.destroy();
+      yield* waitForDeath(pid);
+    }),
+  { timeout: 30_000 },
+);
+
+test.provider(
+  "favors a localhost URL over an unrelated URL printed first (#695)",
+  (stack) =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const tmp = yield* fs.makeTempDirectoryScoped({ prefix: "devcmd-" });
+      const pidFile = pathe.join(tmp, "pid.json");
+
+      const output = yield* stack.deploy(
+        Command.Dev("Dev", {
+          command: `node ${urlServerScript}`,
+          env: {
+            PID_FILE: pidFile,
+            MARKER: "url-favor-local",
+            // A docs link is printed first (as Astro does on a content
+            // error), then the dev server prints its own localhost URL.
+            URL_LINE: "https://docs.astro.build/en/guides/content-collections/",
+            URL_LINE_2: "  ➜  Local:   http://localhost:5001/",
+            URL_DELAY_2_MS: "300",
+          },
+        }),
+      );
+
+      expect(output.url).toBe("http://localhost:5001/");
+
+      const { pid } = yield* waitForPidFile(pidFile, "url-favor-local");
+      yield* stack.destroy();
+      yield* waitForDeath(pid);
+    }),
+  { timeout: 30_000 },
+);
+
+test.provider(
+  "falls back to a non-local URL when no localhost URL appears (#695)",
+  (stack) =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const tmp = yield* fs.makeTempDirectoryScoped({ prefix: "devcmd-" });
+      const pidFile = pathe.join(tmp, "pid.json");
+
+      const output = yield* stack.deploy(
+        Command.Dev("Dev", {
+          command: `node ${urlServerScript}`,
+          env: {
+            PID_FILE: pidFile,
+            MARKER: "url-fallback",
+            // Only a non-local URL is ever printed — it should still surface.
+            URL_LINE: "https://docs.astro.build/en/guides/content-collections/",
+          },
+        }),
+      );
+
+      expect(output.url).toBe(
+        "https://docs.astro.build/en/guides/content-collections/",
+      );
+
+      const { pid } = yield* waitForPidFile(pidFile, "url-fallback");
       yield* stack.destroy();
       yield* waitForDeath(pid);
     }),

--- a/packages/alchemy/test/Command/Dev.test.ts
+++ b/packages/alchemy/test/Command/Dev.test.ts
@@ -30,46 +30,6 @@ if (fixtureScript.includes(" ") || urlServerScript.includes(" ")) {
   );
 }
 
-describe("extractUrl", () => {
-  it("returns a plain URL when it is the only match", () => {
-    expect(Command.extractUrl("Local: http://localhost:5173/")).toBe(
-      "http://localhost:5173/",
-    );
-  });
-
-  it("favors a localhost URL over an unrelated URL printed first", () => {
-    // Astro prints a docs link on a content error before the dev server
-    // prints its own localhost URL. See issue #695.
-    const buffer =
-      "see https://docs.astro.build/en/guides/content-collections/\n" +
-      "  ➜  Local:   http://localhost:5001/\n";
-    expect(Command.extractUrl(buffer)).toBe("http://localhost:5001/");
-  });
-
-  it("favors an IP URL over an unrelated URL printed first", () => {
-    const buffer =
-      "update available https://example.com/release\n" +
-      "ready - started server on http://127.0.0.1:3000\n";
-    expect(Command.extractUrl(buffer)).toBe("http://127.0.0.1:3000");
-  });
-
-  it("falls back to a non-local URL when no local URL is present", () => {
-    expect(
-      Command.extractUrl("docs https://docs.astro.build/en/guides/x/"),
-    ).toBe("https://docs.astro.build/en/guides/x/");
-  });
-
-  it("strips ANSI escapes before matching", () => {
-    expect(Command.extractUrl("\x1b[36mhttp://localhost:5173/\x1b[0m")).toBe(
-      "http://localhost:5173/",
-    );
-  });
-
-  it("returns undefined when there is no URL", () => {
-    expect(Command.extractUrl("no url here")).toBeUndefined();
-  });
-});
-
 const isAlive = (pid: number) =>
   Effect.sync(() => {
     try {
@@ -488,3 +448,43 @@ test.provider("errors when the command fails in first 5 seconds", (stack) =>
     expect(error.reason.stderr).toContain("I'm not feeling it...");
   }),
 );
+
+describe("extractUrl", () => {
+  it("returns a plain URL when it is the only match", () => {
+    expect(Command.extractUrl("Local: http://localhost:5173/")).toBe(
+      "http://localhost:5173/",
+    );
+  });
+
+  it("favors a localhost URL over an unrelated URL printed first", () => {
+    // Astro prints a docs link on a content error before the dev server
+    // prints its own localhost URL. See issue #695.
+    const buffer =
+      "see https://docs.astro.build/en/guides/content-collections/\n" +
+      "  ➜  Local:   http://localhost:5001/\n";
+    expect(Command.extractUrl(buffer)).toBe("http://localhost:5001/");
+  });
+
+  it("favors an IP URL over an unrelated URL printed first", () => {
+    const buffer =
+      "update available https://example.com/release\n" +
+      "ready - started server on http://127.0.0.1:3000\n";
+    expect(Command.extractUrl(buffer)).toBe("http://127.0.0.1:3000");
+  });
+
+  it("falls back to a non-local URL when no local URL is present", () => {
+    expect(
+      Command.extractUrl("docs https://docs.astro.build/en/guides/x/"),
+    ).toBe("https://docs.astro.build/en/guides/x/");
+  });
+
+  it("strips ANSI escapes before matching", () => {
+    expect(Command.extractUrl("\x1b[36mhttp://localhost:5173/\x1b[0m")).toBe(
+      "http://localhost:5173/",
+    );
+  });
+
+  it("returns undefined when there is no URL", () => {
+    expect(Command.extractUrl("no url here")).toBeUndefined();
+  });
+});

--- a/packages/alchemy/test/Command/fixture/url-server.cjs
+++ b/packages/alchemy/test/Command/fixture/url-server.cjs
@@ -6,13 +6,13 @@
 // `URL_STREAM` -> "stdout" (default) or "stderr".
 // `URL_DELAY_MS` -> how long to wait before printing (default 0). Lets the
 //   test exercise extraction that happens after reconcile starts awaiting.
+// `URL_LINE_2` / `URL_STREAM_2` / `URL_DELAY_2_MS` -> an optional second line
+//   printed independently. Lets a test print an unrelated URL first and the
+//   real dev-server URL later (issue #695).
 const fs = require("node:fs");
 
 const pidFile = process.env.PID_FILE;
 const marker = process.env.MARKER ?? "default";
-const urlLine = process.env.URL_LINE;
-const urlStream = process.env.URL_STREAM === "stderr" ? "stderr" : "stdout";
-const urlDelayMs = Number(process.env.URL_DELAY_MS ?? 0);
 
 if (!pidFile) {
   console.error("url-server.cjs: PID_FILE env var is required");
@@ -21,10 +21,16 @@ if (!pidFile) {
 
 fs.writeFileSync(pidFile, JSON.stringify({ pid: process.pid, marker }));
 
-if (urlLine) {
+const printLine = (line, streamEnv, delayEnv) => {
+  if (!line) return;
+  const stream = process.env[streamEnv] === "stderr" ? "stderr" : "stdout";
+  const delayMs = Number(process.env[delayEnv] ?? 0);
   setTimeout(() => {
-    process[urlStream].write(`${urlLine}\n`);
-  }, urlDelayMs);
-}
+    process[stream].write(`${line}\n`);
+  }, delayMs);
+};
+
+printLine(process.env.URL_LINE, "URL_STREAM", "URL_DELAY_MS");
+printLine(process.env.URL_LINE_2, "URL_STREAM_2", "URL_DELAY_2_MS");
 
 setInterval(() => {}, 60_000);


### PR DESCRIPTION
`alchemy dev` resolved a resource's `url` to the **first** `http(s)://` URL seen on stdout/stderr, so any unrelated link a command prints first (a docs link, an error page, an "update available" notice) would win over the dev server's own address.

Now a `localhost`/IP URL (the shape a dev server prints for itself) is preferred; a non-local URL is only used as a fallback if no local one appears within the timeout.

```ts
// favors localhost / IPv4 / bracketed-IPv6 hosts, else first http(s) URL
extractUrl("see https://docs.astro.build/…\n  ➜  Local: http://localhost:5001/")
// -> "http://localhost:5001/"   (was: the docs link)

extractUrl("docs https://docs.astro.build/…")
// -> "https://docs.astro.build/…"   (fallback: no local URL present)
```

The stream scan resolves immediately on a localhost/IP URL and otherwise keeps a non-local URL as a fallback for the timeout branch.

Fixes #695
