### PR TITLE
fix(local): reuse cached provider RPC session in alchemy dev

### DIFF
--- a/packages/alchemy/src/Local/RpcProviderProxy.ts
+++ b/packages/alchemy/src/Local/RpcProviderProxy.ts
@@ -65,7 +65,7 @@ const make = Effect.fn(function* (spawnerUrl: string) {
 
   return RpcProviderProxy.of({
     get: Effect.fn(function* (mainUrl, providerName) {
-      const session = yield* cache.lookup(mainUrl);
+      const session = yield* Cache.get(cache, mainUrl);
       const provider = yield* Effect.promise(
         () =>
           session.getProvider(providerName) as ReturnType<


### PR DESCRIPTION
Reuse the memoized provider RPC session in `alchemy dev` instead of spawning a fresh WebSocket session on every provider access.

```diff
-const session = yield* cache.lookup(mainUrl);
+const session = yield* Cache.get(cache, mainUrl);
```

`cache.lookup` re-runs the lookup (spawning a new session) on every call; `Cache.get` returns the cached session for a given `mainUrl`.
