### PR TITLE
fix(cloudflare/workers): preserve cron handler requirements

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/CronEventSource.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/CronEventSource.ts
@@ -198,25 +198,20 @@ import { isWorkerEvent, Worker } from "./Worker.ts";
  *
  * @see https://developers.cloudflare.com/workers/configuration/cron-triggers/
  */
-type CronEventSourceRequirements<Req> = Exclude<Req, RuntimeContext>;
-
 export const cron = <Req = never>(
   expression: string,
   process: (
     controller: cf.ScheduledController,
   ) => Effect.Effect<void, unknown, Req>,
-): Effect.Effect<
-  void,
-  never,
-  CronEventSource | CronEventSourceRequirements<Req>
-> => CronEventSource.use((source) => source(expression, process));
+): Effect.Effect<void, never, CronEventSource | Exclude<Req, RuntimeContext>> =>
+  CronEventSource.use((source) => source(expression, process));
 
 export type CronEventSourceService = <Req = never>(
   expression: string,
   process: (
     controller: cf.ScheduledController,
   ) => Effect.Effect<void, unknown, Req>,
-) => Effect.Effect<void, never, CronEventSourceRequirements<Req>>;
+) => Effect.Effect<void, never, Exclude<Req, RuntimeContext>>;
 
 export class CronEventSource extends Context.Service<
   CronEventSource,

--- a/packages/alchemy/src/Cloudflare/Workers/CronEventSource.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/CronEventSource.ts
@@ -198,19 +198,25 @@ import { isWorkerEvent, Worker } from "./Worker.ts";
  *
  * @see https://developers.cloudflare.com/workers/configuration/cron-triggers/
  */
+type CronEventSourceRequirements<Req> = Exclude<Req, RuntimeContext>;
+
 export const cron = <Req = never>(
   expression: string,
   process: (
     controller: cf.ScheduledController,
   ) => Effect.Effect<void, unknown, Req>,
-) => CronEventSource.use((source) => source(expression, process));
+): Effect.Effect<
+  void,
+  never,
+  CronEventSource | CronEventSourceRequirements<Req>
+> => CronEventSource.use((source) => source(expression, process));
 
 export type CronEventSourceService = <Req = never>(
   expression: string,
   process: (
     controller: cf.ScheduledController,
   ) => Effect.Effect<void, unknown, Req>,
-) => Effect.Effect<void, never, never>;
+) => Effect.Effect<void, never, CronEventSourceRequirements<Req>>;
 
 export class CronEventSource extends Context.Service<
   CronEventSource,

--- a/packages/alchemy/test/Cloudflare/Workers/CronEventSource.types.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/CronEventSource.types.ts
@@ -1,0 +1,45 @@
+import * as Cloudflare from "@/Cloudflare";
+import type { RuntimeContext } from "@/RuntimeContext.ts";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+
+class ScheduledTask extends Context.Service<
+  ScheduledTask,
+  { run: Effect.Effect<void, never, RuntimeContext> }
+>()("test/ScheduledTask") {}
+
+const ScheduleExpression = "* * * * *";
+
+const runScheduledTask = Effect.fn("ScheduledWorker.runTask")(function* () {
+  const task = yield* ScheduledTask;
+  yield* task.run;
+});
+
+export const ScheduledTaskCronBinding = Cloudflare.Workers.cron(
+  ScheduleExpression,
+  Effect.fn("ScheduledWorker.cron")(function* () {
+    yield* runScheduledTask();
+  }),
+);
+
+type RequirementsOf<T> =
+  T extends Effect.Effect<unknown, unknown, infer Req> ? Req : never;
+type Assert<T extends true> = T;
+
+type _PreservesUserRequirement = Assert<
+  ScheduledTask extends RequirementsOf<typeof ScheduledTaskCronBinding>
+    ? true
+    : false
+>;
+type _StillRequiresCronEventSource = Assert<
+  Cloudflare.Workers.CronEventSource extends RequirementsOf<
+    typeof ScheduledTaskCronBinding
+  >
+    ? true
+    : false
+>;
+type _HidesRuntimeContext = Assert<
+  RuntimeContext extends RequirementsOf<typeof ScheduledTaskCronBinding>
+    ? false
+    : true
+>;


### PR DESCRIPTION
Preserve app-level requirements from `Cloudflare.Workers.cron` handlers while keeping `RuntimeContext` hidden behind the Worker runtime bridge.

```ts
type CronEventSourceRequirements<Req> = Exclude<Req, RuntimeContext>;
```

A type-only fixture asserts scheduled handler services remain required and runtime context does not leak into the Worker init effect.
