### PR TITLE
fix(engine): stop persisting adopted state during plan construction

### DIFF
--- a/packages/alchemy/src/Plan.ts
+++ b/packages/alchemy/src/Plan.ts
@@ -698,21 +698,32 @@ export const make = <A>(
             //   - `Unowned(attrs)`   → exists but is *not* ours
             //
             // Routing:
-            //   - owned                          → persist `created` state
+            //   - owned                          → adopt the `created` state
             //                                      from attrs and continue
             //                                      through the normal diff
             //                                      path (so subsequent props
             //                                      drift produces an update).
-            //   - unowned + adopt enabled        → take over: persist `created`
-            //                                      state and let the next
-            //                                      update overwrite tags / etc.
+            //   - unowned + adopt enabled        → take over: adopt the
+            //                                      `created` state and let the
+            //                                      next update overwrite tags.
             //   - unowned + adopt disabled       → fail with
             //                                      `OwnedBySomeoneElse`.
+            //
+            // Plan construction is side-effect-free: the adopted `created`
+            // state is only held in-memory here (to drive the diff) and rides
+            // onto the plan node as `node.state`. Persisting it to the state
+            // store happens exclusively during APPLY of that node (the update
+            // lifecycle commits `updating` / `updated` carrying this state).
+            // If planning persisted here, a mere `alchemy plan` / `--dry-run`
+            // would claim ownership of an unowned cloud resource, arming a
+            // later unrelated deploy to orphan-delete it. See
+            // https://github.com/alchemy-run/alchemy-effect/issues/793.
+            //
             // After a cold-start adoption (engine just discovered an
             // existing cloud resource via `read`), force the engine's
             // normal `update` path so the provider can re-sync ownership
             // tags, configuration, etc. against the desired props.
-            // Adoption persists state with `props: news`, so the default
+            // Adoption carries state with `props: news`, so the default
             // diff sees no drift and would noop — which would leave any
             // foreign-owned tags / divergent config in place. Forcing
             // update keeps the deploy idempotent: if cloud state already
@@ -767,12 +778,13 @@ export const make = <A>(
                   downstream,
                   removalPolicy: resource.RemovalPolicy,
                 } satisfies CreatedResourceState;
-                yield* state.set({
-                  stack: stackName,
-                  stage: stage,
-                  fqn,
-                  value: adoptedState,
-                });
+                // In-memory only — do NOT persist here. Plan.make runs for
+                // `alchemy plan` / `deploy --dry-run` too, so a `state.set`
+                // would mutate persistent state during a read-only preview.
+                // The adopted state rides onto the plan node via `oldState`
+                // (→ `node.state`) and is persisted at APPLY time by the
+                // update lifecycle's `updating` / `updated` commits. See
+                // https://github.com/alchemy-run/alchemy-effect/issues/793.
                 oldState = adoptedState;
                 forceUpdateAfterAdoption = true;
               }

--- a/packages/alchemy/test/apply.test.ts
+++ b/packages/alchemy/test/apply.test.ts
@@ -1,3 +1,4 @@
+import { adopt, Unowned } from "@/AdoptPolicy";
 import { Cli } from "@/Cli/Cli";
 import * as Namespace from "@/Namespace.ts";
 import * as Output from "@/Output";
@@ -4961,4 +4962,69 @@ describe("type aliases", () => {
         }),
     );
   });
+});
+
+// Regression coverage for
+// https://github.com/alchemy-run/alchemy-effect/issues/793
+//
+// `Plan.make` used to `state.set(...)` the adopted `created` state during plan
+// construction. Because `alchemy plan` / `deploy --dry-run` build a plan the
+// exact same way a real deploy does, a read-only preview silently claimed
+// ownership of an unowned cloud resource — arming a later, unrelated deploy to
+// orphan-delete it. Plan construction must be side-effect-free: reading the
+// cloud resource is fine (needed for an accurate diff), but persisting the
+// adopted state may only happen when the plan node is applied.
+describe("engine-level adoption persists at apply, not plan (issue #793)", () => {
+  // A pre-existing, foreign-owned cloud resource that `read` always discovers
+  // — the exact shape that triggers an `--adopt` takeover.
+  const ownedAttrs: TestResource["Attributes"] = {
+    string: "hello",
+    stringArray: [],
+    stableString: "Adopted",
+    stableArray: ["Adopted"],
+    replaceString: undefined,
+    redacted: undefined,
+    redactedArray: undefined,
+  };
+
+  const adoptHooks = Layer.succeed(TestResourceHooks, {
+    read: () => Effect.succeed(Unowned(ownedAttrs)),
+  });
+
+  test.provider(
+    "a dry-run plan writes nothing to the state store; applying persists",
+    (stack) =>
+      Effect.gen(function* () {
+        // ── dry-run: build a plan that adopts the unowned cloud resource ──
+        const plan = yield* TestResource("Adopted", { string: "hello" }).pipe(
+          adopt(true),
+          stack.plan,
+          Effect.provide(adoptHooks),
+        );
+
+        // The adopted state rides on the plan node as a forced update (so the
+        // provider re-syncs ownership tags / config) — it is not persisted.
+        expect(plan.resources.Adopted!.action).toBe("update");
+        expect(plan.resources.Adopted!.state?.status).toBe("created");
+
+        // The critical invariant of #793: planning persisted nothing, so a
+        // read-only `alchemy plan` / `--dry-run` cannot arm a later deploy to
+        // orphan-delete the live resource.
+        expect(yield* getState("Adopted")).toBeUndefined();
+        expect(yield* listState()).toEqual([]);
+
+        // ── apply: the same config now deploys. Because plan didn't persist,
+        // the resource is still adoptable here. ──
+        yield* TestResource("Adopted", { string: "hello" }).pipe(
+          adopt(true),
+          stack.deploy,
+          Effect.provide(adoptHooks),
+        );
+
+        // Applying DOES persist the adopted state.
+        const persisted = yield* getState("Adopted");
+        expect(["created", "updated"]).toContain(persisted?.status);
+        expect(yield* listState()).toEqual(["Adopted"]);
+      }),
+  );
 });

--- a/packages/alchemy/test/plan.test.ts
+++ b/packages/alchemy/test/plan.test.ts
@@ -2891,14 +2891,20 @@ describe("engine-level adoption", () => {
       // can't detect from `props` alone.
       expect(plan.resources.Adopted!.action).toBe("update");
 
+      // Planning no longer persists the adopted state (issue #793): it rides
+      // on the plan node and is only committed to the store at apply time.
+      const node = plan.resources.Adopted!;
+      expect(node.state?.status).toBe("created");
+      expect((node.state as any)?.attr).toMatchObject({ string: "hello" });
+
       const state = yield* yield* State;
-      const persisted = yield* state.get({
-        stack: TEST_STACK,
-        stage: TEST_STAGE,
-        fqn: "Adopted",
-      });
-      expect(persisted?.status).toBe("created");
-      expect((persisted as any)?.attr).toMatchObject({ string: "hello" });
+      expect(
+        yield* state.get({
+          stack: TEST_STACK,
+          stage: TEST_STAGE,
+          fqn: "Adopted",
+        }),
+      ).toBeUndefined();
     }),
   );
 
@@ -2921,22 +2927,29 @@ describe("engine-level adoption", () => {
       // foreign-owned to subsequent deploys).
       expect(plan.resources.Adopted!.action).toBe("update");
 
-      const state = yield* yield* State;
-      const persisted = yield* state.get({
-        stack: TEST_STACK,
-        stage: TEST_STAGE,
-        fqn: "Adopted",
-      });
-      expect(persisted?.status).toBe("created");
+      // The adopted state rides on the plan node, not the store (issue #793).
+      const node = plan.resources.Adopted!;
+      expect(node.state?.status).toBe("created");
 
       // The Unowned brand must be fully scrubbed from anything that
-      // reaches the state store — both via the public `Unowned.is`
-      // check *and* via direct symbol inspection (in case someone
-      // accidentally uses `Symbol.for` rather than `Unowned.is`).
-      const persistedAttr = (persisted as any)?.attr as object;
-      expect(Unowned.is(persistedAttr)).toBe(false);
-      expect(Object.getOwnPropertySymbols(persistedAttr).length).toBe(0);
-      expect(JSON.stringify(persistedAttr)).not.toContain("Unowned");
+      // reaches the plan node (and, at apply, the state store) — both via
+      // the public `Unowned.is` check *and* via direct symbol inspection
+      // (in case someone accidentally uses `Symbol.for` rather than
+      // `Unowned.is`).
+      const adoptedAttr = (node.state as any)?.attr as object;
+      expect(Unowned.is(adoptedAttr)).toBe(false);
+      expect(Object.getOwnPropertySymbols(adoptedAttr).length).toBe(0);
+      expect(JSON.stringify(adoptedAttr)).not.toContain("Unowned");
+
+      // Planning wrote nothing to the store.
+      const state = yield* yield* State;
+      expect(
+        yield* state.get({
+          stack: TEST_STACK,
+          stage: TEST_STAGE,
+          fqn: "Adopted",
+        }),
+      ).toBeUndefined();
     }),
   );
 
@@ -2993,13 +3006,19 @@ describe("engine-level adoption", () => {
 
       expect(plan.resources.Adopted!.action).toBe("update");
 
+      // Adopted state rides on the plan node; planning persists nothing
+      // (issue #793).
+      const node = plan.resources.Adopted!;
+      expect(node.state?.status).toBe("created");
+
       const state = yield* yield* State;
-      const persisted = yield* state.get({
-        stack: TEST_STACK,
-        stage: TEST_STAGE,
-        fqn: "Adopted",
-      });
-      expect(persisted?.status).toBe("created");
+      expect(
+        yield* state.get({
+          stack: TEST_STACK,
+          stage: TEST_STAGE,
+          fqn: "Adopted",
+        }),
+      ).toBeUndefined();
     }),
   );
 


### PR DESCRIPTION
Fixes #793

## Problem

`Plan.make`'s adoption probe persisted the adopted `created` state to the state store while the plan was being constructed. `alchemy plan` / `deploy --dry-run` build plans exactly like real deploys, so a read-only preview silently claimed ownership of an unowned cloud resource. From that moment, deploying any config that does not declare the resource orphan-deletes the live resource — a dry run plus an unrelated deploy destroys infrastructure neither declared they would touch. We hit this in production with a `WorkerRoute` on our apex domain (caught before damage because the baseline plan suddenly showed a `delete`).

## Change

Remove the plan-time `yield* state.set(...)` and keep the adopted state in-memory only. The probe still performs the cloud `read` (needed for an accurate diff); the adopted state rides on the plan node via `oldState` → `node.state`, and apply's update lifecycle persists it through its normal `updating` → `updated` commits (which are built from `node.state`, including `instanceId`/`attr`/`props`). Consequences:

- Plan construction is side-effect-free.
- No double-write: apply commits once through its existing lifecycle.
- Plan-then-deploy still adopts: since planning persists nothing, the deploy's fresh `Plan.make` re-reads and re-adopts.

One behavioral nuance: a downstream resource referencing an adopted upstream's attrs now shows them as unresolved in the plan *display* (like a create) instead of the read attrs, because resolution consults the store. Apply correctness is unaffected — apply re-evaluates against tracker outputs.

## Tests

- New round-trip regression test in `apply.test.ts` ("engine-level adoption persists at apply, not plan (issue #793)"): a dry-run plan for a config adopting an unowned existing resource performs the read and carries the adoption on the node but writes nothing to the store; deploying the same config adopts and persists.
- Updated the 3 existing engine-level-adoption tests in `plan.test.ts` that encoded the old plan-time persist; they now assert the adopted state on `node.state` and an empty store after planning.
- Mutation-checked: re-adding the removed `state.set` fails all 4 tests; with the fix they pass.
- `plan.test.ts` + `apply.test.ts`: 242/242 passing; `tsc -b tsconfig.test.json`, `oxfmt --check`, `oxlint` clean.

We run this patch in production via our fork.