### PR TITLE
fix(bundle): read vite build output after buildApp resolves

### DIFF
--- a/packages/alchemy/src/Bundle/Vite.ts
+++ b/packages/alchemy/src/Bundle/Vite.ts
@@ -1,6 +1,5 @@
 import type { NonEmptyArray } from "effect/Array";
 import * as Cause from "effect/Cause";
-import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
@@ -45,41 +44,24 @@ export const viteBuildOutputPlugin = Effect.fn(function* ({
     string,
     Effect.Effect<BundleFile, BundleError>
   >();
-  const deferred = yield* Deferred.make<ViteBuildOutput, BundleError>();
-  const isEnvironmentBuilt = new Map<string, boolean>();
-
-  // We used to detect a completed build using a `buildApp` hook. However, if the user's framework
-  // doesn't also provide a `buildApp` hook, ours may be called before the build is complete.
-  // As a workaround, we record each environment in `configResolved`, track when it's finished building
-  // by setting the value to `true` in `writeBundle`, and emitting the build output when all environments are built.
-  const onEnvironmentBuilt = (environment: string) => {
-    isEnvironmentBuilt.set(environment, true);
-    if (Array.from(isEnvironmentBuilt.values()).every(Boolean)) {
-      Deferred.doneUnsafe(
-        deferred,
-        Effect.succeed({
-          clientDirectory,
-          serverBundle: makeServerBundle(),
-        }),
-      );
-    }
-  };
 
   const plugin: vite.Plugin = {
     name: "alchemy:build-output",
     sharedDuringBuild: true,
-    async configResolved(config) {
-      for (const environment of Object.keys(config.environments)) {
-        isEnvironmentBuilt.set(environment, false);
-      }
-    },
+    // Collect the client output directory and server chunks as each
+    // environment writes its bundle. We deliberately do NOT resolve the build
+    // result from a `buildApp` hook: on Vite 8, when a project declares no
+    // `builder.buildApp` (e.g. a plain client-only SPA), `builder.buildApp()`
+    // runs post-order `buildApp` hooks *before* the default environment builds,
+    // so a hook fires while the output is still empty (issue #792). Instead,
+    // `viteBuild` reads `output` *after* `builder.buildApp()` resolves — by
+    // which point every environment that actually built has run `writeBundle`.
     async writeBundle(_, bundle) {
       if (this.environment.name === "client") {
         clientDirectory = path.resolve(
           this.environment.config.root,
           this.environment.config.build.outDir,
         );
-        onEnvironmentBuilt(this.environment.name);
         return;
       }
       const files = Object.values(bundle);
@@ -130,7 +112,6 @@ export const viteBuildOutputPlugin = Effect.fn(function* ({
           );
         }),
       );
-      onEnvironmentBuilt(this.environment.name);
     },
   };
 
@@ -212,6 +193,13 @@ export const viteBuildOutputPlugin = Effect.fn(function* ({
 
   return {
     plugin,
-    output: Deferred.await(deferred),
+    // Read lazily so callers observe the state collected during the build.
+    // Only safe to await *after* `builder.buildApp()` has resolved.
+    output: Effect.sync(
+      (): ViteBuildOutput => ({
+        clientDirectory,
+        serverBundle: makeServerBundle(),
+      }),
+    ),
   };
 });

--- a/packages/alchemy/src/Bundle/Vite.ts
+++ b/packages/alchemy/src/Bundle/Vite.ts
@@ -46,16 +46,40 @@ export const viteBuildOutputPlugin = Effect.fn(function* ({
     Effect.Effect<BundleFile, BundleError>
   >();
   const deferred = yield* Deferred.make<ViteBuildOutput, BundleError>();
+  const isEnvironmentBuilt = new Map<string, boolean>();
+
+  // We used to detect a completed build using a `buildApp` hook. However, if the user's framework
+  // doesn't also provide a `buildApp` hook, ours may be called before the build is complete.
+  // As a workaround, we record each environment in `configResolved`, track when it's finished building
+  // by setting the value to `true` in `writeBundle`, and emitting the build output when all environments are built.
+  const onEnvironmentBuilt = (environment: string) => {
+    isEnvironmentBuilt.set(environment, true);
+    if (Array.from(isEnvironmentBuilt.values()).every(Boolean)) {
+      Deferred.doneUnsafe(
+        deferred,
+        Effect.succeed({
+          clientDirectory,
+          serverBundle: makeServerBundle(),
+        }),
+      );
+    }
+  };
 
   const plugin: vite.Plugin = {
     name: "alchemy:build-output",
     sharedDuringBuild: true,
+    async configResolved(config) {
+      for (const environment of Object.keys(config.environments)) {
+        isEnvironmentBuilt.set(environment, false);
+      }
+    },
     async writeBundle(_, bundle) {
       if (this.environment.name === "client") {
         clientDirectory = path.resolve(
           this.environment.config.root,
           this.environment.config.build.outDir,
         );
+        onEnvironmentBuilt(this.environment.name);
         return;
       }
       const files = Object.values(bundle);
@@ -106,18 +130,7 @@ export const viteBuildOutputPlugin = Effect.fn(function* ({
           );
         }),
       );
-    },
-    buildApp: {
-      order: "post",
-      async handler() {
-        Deferred.doneUnsafe(
-          deferred,
-          Effect.succeed({
-            clientDirectory,
-            serverBundle: makeServerBundle(),
-          }),
-        );
-      },
+      onEnvironmentBuilt(this.environment.name);
     },
   };
 

--- a/packages/alchemy/test/Cloudflare/Website/Vite.test.ts
+++ b/packages/alchemy/test/Cloudflare/Website/Vite.test.ts
@@ -33,6 +33,7 @@ const logLevel = Effect.provideService(
 );
 
 const fixtureDir = pathe.resolve(import.meta.dirname, "vite-fixture");
+const spaFixtureDir = pathe.resolve(import.meta.dirname, "vite-spa-fixture");
 const doFixtureDir = pathe.resolve(import.meta.dirname, "vite-do-fixture");
 const reactRouterRscFixtureDir = pathe.resolve(
   import.meta.dirname,
@@ -119,6 +120,60 @@ test.provider(
 
       yield* stack.destroy();
       yield* waitForWorkerToBeDeleted(site1.workerName, accountId);
+    }).pipe(logLevel),
+  { timeout: 360_000 },
+);
+
+// Regression test for https://github.com/alchemy-run/alchemy-effect/issues/792.
+//
+// A pure client-only Vite project (no vite.config.ts, no plugins, no worker
+// entry) resolves as `appType: "spa"`, so the Cloudflare Vite plugin declares
+// no `builder.buildApp`. On Vite 8, `builder.buildApp()` then runs post-order
+// `buildApp` hooks *before* the default environment builds — which used to make
+// our build-output plugin resolve while the client output was still undefined,
+// so the deploy died with "Vite build produced neither assets nor server
+// output". Detecting completion in `writeBundle` (per environment) instead of a
+// post-order `buildApp` hook fixes it; this test proves the SPA path deploys.
+test.provider(
+  "Vite: client-only SPA (no config, no plugins) builds and serves assets",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* yield* CloudflareEnvironment;
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+
+      yield* stack.destroy();
+
+      const rootDir = yield* cloneFixture(spaFixtureDir, {
+        prefix: "alchemy-vite-spa-",
+        tempRoot,
+        entries: ["index.html", "package.json", "src"],
+      });
+      const indexPath = path.join(rootDir, "index.html");
+      const memoInclude = ["index.html", "src/**", "package.json"];
+
+      const marker = `vite-spa-${Date.now()}`;
+      yield* fs.writeFileString(indexPath, htmlPage(marker));
+
+      const site = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.Website.Vite(
+            "FixViteSpa",
+            viteProps(rootDir, memoInclude),
+          );
+        }),
+      );
+
+      expect(site.url).toBeDefined();
+      expect(site.hash?.input).toBeDefined();
+      yield* expectWorkerExists(site.workerName, accountId);
+      yield* expectUrlContains(`${site.url!}/`, marker, {
+        timeout: "120 seconds",
+        label: "spa marker",
+      });
+
+      yield* stack.destroy();
+      yield* waitForWorkerToBeDeleted(site.workerName, accountId);
     }).pipe(logLevel),
   { timeout: 360_000 },
 );

--- a/packages/alchemy/test/Cloudflare/Website/vite-spa-fixture/.gitignore
+++ b/packages/alchemy/test/Cloudflare/Website/vite-spa-fixture/.gitignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/packages/alchemy/test/Cloudflare/Website/vite-spa-fixture/index.html
+++ b/packages/alchemy/test/Cloudflare/Website/vite-spa-fixture/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Vite SPA fixture</title>
+  </head>
+  <body>
+    <div id="app">Vite SPA fixture</div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/packages/alchemy/test/Cloudflare/Website/vite-spa-fixture/package.json
+++ b/packages/alchemy/test/Cloudflare/Website/vite-spa-fixture/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "alchemy-vite-spa-fixture",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/packages/alchemy/test/Cloudflare/Website/vite-spa-fixture/src/main.ts
+++ b/packages/alchemy/test/Cloudflare/Website/vite-spa-fixture/src/main.ts
@@ -1,0 +1,10 @@
+// The entire fixture: a single client module referenced by index.html.
+// There is no vite.config.ts and no plugins, so the Cloudflare Vite plugin
+// resolves the project as `appType: "spa"` with no worker entry — which means
+// it declares no `builder.buildApp`. On Vite 8 that is the code path where a
+// post-order `buildApp` hook fires before the client environment builds, so
+// this fixture is the minimal reproduction for issue #792.
+const el = document.getElementById("app");
+if (el) {
+  el.textContent = `${el.textContent} (hydrated)`;
+}


### PR DESCRIPTION
On Vite 8, `builder.buildApp()` runs post-order `buildApp` hooks *before* the default environment builds when a project declares no `builder.buildApp` (e.g. a plain client-only SPA, which resolves as `appType: "spa"`). Our `alchemy:build-output` plugin resolved the build output from a post-order `buildApp` hook, so it fired while the client/server output was still empty and `viteBuild` died with "neither assets nor server output" (#792).

`viteBuild` already awaits `builder.buildApp()` before reading `output`, so instead of resolving from a plugin hook, the plugin just collects state in `writeBundle` and exposes `output` as a lazy read. By the time `viteBuild` awaits it, every environment that actually built has run `writeBundle`.

```diff
-    buildApp: {
-      order: "post",
-      async handler() {
-        Deferred.doneUnsafe(deferred, Effect.succeed({ clientDirectory, serverBundle: makeServerBundle() }));
-      },
-    },
+    async writeBundle(_, bundle) {
+      // ...record clientDirectory / server chunks...
+    },
```

```diff
   return {
     plugin,
-    output: Deferred.await(deferred),
+    // Only safe to await *after* `builder.buildApp()` has resolved.
+    output: Effect.sync((): ViteBuildOutput => ({
+      clientDirectory,
+      serverBundle: makeServerBundle(),
+    })),
   };
```

This also avoids the trap of tracking "all registered environments built": a client-only SPA falls back to Vite's legacy single-environment builder, which only builds the `client` environment — the registered `ssr` environment never builds, so waiting on its `writeBundle` would hang forever.

### Test

Adds the world's simplest Vite fixture (`vite-spa-fixture`: a client-only app, no config, no plugins) and a deploy test exercising the `appType: "spa"` path from #792.

Fixes #792
