### PR TITLE
docs(cloudflare): cloudflare foldkit example

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -525,6 +525,20 @@
         "effect": "catalog:",
       },
     },
+    "examples/cloudflare-foldkit": {
+      "name": "cloudflare-foldkit",
+      "version": "0.0.0",
+      "dependencies": {
+        "@effect/platform-browser": "4.0.0-beta.88",
+        "effect": "4.0.0-beta.88",
+        "foldkit": "^0.125.0",
+      },
+      "devDependencies": {
+        "@foldkit/vite-plugin": "^0.10.0",
+        "alchemy": "workspace:*",
+        "vite": "catalog:",
+      },
+    },
     "examples/cloudflare-git-artifacts": {
       "name": "cloudflare-git-artifacts",
       "version": "0.0.0",
@@ -1341,6 +1355,8 @@
 
     "@effect/language-service": ["@effect/language-service@0.77.0", "", { "bin": { "effect-language-service": "cli.js" } }, "sha512-QP2bri8DdcK7Eo+SqFS2yNeD0Ch9kKHYxq2jeE9CaPpBknevCNFb3+hT6qSsPt2P6yOkhNP83KMy5Uk7DGBXlg=="],
 
+    "@effect/platform-browser": ["@effect/platform-browser@4.0.0-beta.88", "", { "dependencies": { "multipasta": "^0.2.7" }, "peerDependencies": { "effect": "^4.0.0-beta.88" } }, "sha512-SwJ9KJ4g8dk1XDscxCy1NYJl4AJYqvxwQx43g4LV9OwipUisjdqKUZLrFo3PY3Rfkh2FCGpis55mrAXNklaKdg=="],
+
     "@effect/platform-bun": ["@effect/platform-bun@4.0.0-beta.93", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.93" }, "peerDependencies": { "effect": "^4.0.0-beta.93" } }, "sha512-pny29d1NhJ7XLv19as7A0pIZr+QFi5KejnwB/lLW1c8P63t+PDMPEn21toy2vx2yzl9xRTo8heyiXPXRsqPN5w=="],
 
     "@effect/platform-node": ["@effect/platform-node@4.0.0-beta.93", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.93", "mime": "^4.1.0", "undici": "^8.2.0" }, "peerDependencies": { "effect": "^4.0.0-beta.93", "ioredis": "^5.7.0" } }, "sha512-QagsCGR0ZOXaCQqS5qGR2mcDng4LiP2bYhiiX1D6UC8cT9vsusVVOHiJWn8CupeDx+yVnPcu81QmA/SDt6GM1w=="],
@@ -1462,6 +1478,8 @@
     "@expressive-code/plugin-text-markers": ["@expressive-code/plugin-text-markers@0.41.7", "", { "dependencies": { "@expressive-code/core": "^0.41.7" } }, "sha512-Ewpwuc5t6eFdZmWlFyeuy3e1PTQC0jFvw2Q+2bpcWXbOZhPLsT7+h8lsSIJxb5mS7wZko7cKyQ2RLYDyK6Fpmw=="],
 
     "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
+
+    "@foldkit/vite-plugin": ["@foldkit/vite-plugin@0.10.0", "", { "dependencies": { "ws": "^8.21.0" }, "peerDependencies": { "effect": "4.0.0-beta.88", "foldkit": "^0", "vite": "^7.0.0 || ^8.0.0" } }, "sha512-nCDb8GiIBG3va6sUKHHCw1w0fSFnAvjKEMi75nsRAnIxh0sSUi3hrZfMTVFnl991ZM9d7INmCa2y7DodYvXZKQ=="],
 
     "@fortawesome/fontawesome-free": ["@fortawesome/fontawesome-free@6.7.2", "", {}, "sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA=="],
 
@@ -2631,6 +2649,8 @@
 
     "cloudflare-email": ["cloudflare-email@workspace:examples/cloudflare-email"],
 
+    "cloudflare-foldkit": ["cloudflare-foldkit@workspace:examples/cloudflare-foldkit"],
+
     "cloudflare-git-artifacts": ["cloudflare-git-artifacts@workspace:examples/cloudflare-git-artifacts"],
 
     "cloudflare-neon-drizzle": ["cloudflare-neon-drizzle@workspace:examples/cloudflare-neon-drizzle"],
@@ -3054,6 +3074,8 @@
     "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
 
     "flattie": ["flattie@1.1.1", "", {}, "sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ=="],
+
+    "foldkit": ["foldkit@0.125.0", "", { "dependencies": { "snabbdom": "^3.6.3" }, "peerDependencies": { "@effect/platform-browser": "4.0.0-beta.88", "effect": "4.0.0-beta.88" } }, "sha512-XSkZlhLL+NmSRd7Bq7xBGyOlpEd1X/fgzIn4dH5BfLmv9NzH/Zq7Peeu99r83SOOZS3Y/2vCAYxtTAmpJtFJqw=="],
 
     "fontace": ["fontace@0.4.1", "", { "dependencies": { "fontkitten": "^1.0.2" } }, "sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw=="],
 
@@ -3979,6 +4001,8 @@
 
     "smol-toml": ["smol-toml@1.6.1", "", {}, "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg=="],
 
+    "snabbdom": ["snabbdom@3.6.4", "", {}, "sha512-VmxEfuw1/Y/eFj5VtMhYnukExpYiPkNzoo3+N3qwAOUDMl8wXgbli5ebR+j0knE3lZ/0eYskLxNcX64uy10N9w=="],
+
     "socks": ["socks@2.8.9", "", { "dependencies": { "ip-address": "^10.1.1", "smart-buffer": "^4.2.0" } }, "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw=="],
 
     "socks-proxy-agent": ["socks-proxy-agent@8.0.5", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "socks": "^2.8.3" } }, "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw=="],
@@ -4700,6 +4724,8 @@
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "cloudflare-foldkit/effect": ["effect@4.0.0-beta.88", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.8.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.1", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^14.0.0", "yaml": "^2.9.0" } }, "sha512-ml7Xr2BhU12RnNk5xX0lPqHv5pIXg7E161ooGlYncFd17Z5NKXL26DnfvwZsNBxYLS0ToGVMhb4Em7Z0A4dTDA=="],
 
     "cloudflare-solid-ssr/solid-js": ["solid-js@1.9.13", "", { "dependencies": { "csstype": "^3.1.0", "seroval": "~1.5.0", "seroval-plugins": "~1.5.0" } }, "sha512-6hJeJMOcEX8ktqjpDoJZEmld3ijvcvWBDtiXBm7f4332SiFN66QeAQI1REQshvyUoISsSeJ4PHDauKYbwao9JQ=="],
 

--- a/examples/cloudflare-foldkit/.gitignore
+++ b/examples/cloudflare-foldkit/.gitignore
@@ -1,0 +1,14 @@
+logs
+*.log
+npm-debug.log*
+
+node_modules
+.DS_Store
+dist
+coverage
+*.local
+
+*.tsbuildinfo
+
+# Vite
+*.timestamp-*-*.mjs

--- a/examples/cloudflare-foldkit/README.md
+++ b/examples/cloudflare-foldkit/README.md
@@ -1,0 +1,39 @@
+# cloudflare-foldkit
+
+A minimal [Foldkit](https://foldkit.dev) single-page app deployed to Cloudflare Workers with Alchemy's `Cloudflare.Website.Vite` resource.
+
+Foldkit is an Elm-style frontend framework built on [Effect](https://effect.website): one immutable model, a closed union of messages, a single `update` fold, and a pure `view`. This example is the canonical counter — see [`src/main.ts`](./src/main.ts) for the whole architecture in one file.
+
+## Project setup
+
+```sh
+bun install
+```
+
+### Develop
+
+```sh
+bun dev
+```
+
+### Build
+
+```sh
+bun run build
+```
+
+### Deploy
+
+```sh
+bun run deploy
+```
+
+### Destroy
+
+```sh
+bun run destroy
+```
+
+## Notes
+
+- `effect` and `@effect/platform-browser` are pinned to `4.0.0-beta.88` — the exact peer version Foldkit is built against — instead of the workspace catalog. The app bundle resolves the pinned copy; the `alchemy` CLI keeps its own.

--- a/examples/cloudflare-foldkit/alchemy.run.ts
+++ b/examples/cloudflare-foldkit/alchemy.run.ts
@@ -1,0 +1,23 @@
+import * as Alchemy from "alchemy";
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+
+export default Alchemy.Stack(
+  "CloudflareFoldkitExample",
+  {
+    providers: Cloudflare.providers(),
+    state: Cloudflare.state(),
+  },
+  Effect.gen(function* () {
+    const website = yield* Cloudflare.Website.Vite("Foldkit", {
+      compatibility: {
+        flags: ["nodejs_compat"],
+      },
+      memo: {},
+    });
+
+    return {
+      url: website.url,
+    };
+  }),
+);

--- a/examples/cloudflare-foldkit/index.html
+++ b/examples/cloudflare-foldkit/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link href="/src/styles.css" rel="stylesheet" />
+    <title>Foldkit on Cloudflare</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./src/main.ts"></script>
+  </body>
+</html>

--- a/examples/cloudflare-foldkit/package.json
+++ b/examples/cloudflare-foldkit/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "cloudflare-foldkit-example",
+  "version": "0.0.0",
+  "private": true,
+  "license": "Apache-2.0",
+  "type": "module",
+  "scripts": {
+    "dev": "alchemy dev",
+    "build": "vite build",
+    "preview": "vite preview",
+    "deploy": "alchemy deploy",
+    "destroy": "alchemy destroy",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@effect/platform-browser": "4.0.0-beta.88",
+    "effect": "4.0.0-beta.88",
+    "foldkit": "^0.125.0"
+  },
+  "devDependencies": {
+    "@foldkit/vite-plugin": "^0.10.0",
+    "alchemy": "workspace:*",
+    "vite": "catalog:"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "directory": "examples/cloudflare-foldkit"
+  }
+}

--- a/examples/cloudflare-foldkit/src/main.ts
+++ b/examples/cloudflare-foldkit/src/main.ts
@@ -1,0 +1,86 @@
+import { Match, Schema } from "effect";
+import { Command, Runtime } from "foldkit";
+import type { Html } from "foldkit/html";
+import { html } from "foldkit/html";
+import { m } from "foldkit/message";
+
+// Foldkit is an Elm-style framework on Effect: one immutable Model, a closed
+// union of Messages, one `update` folding Messages into the next Model, and a
+// pure `view`. This example is the canonical counter.
+
+// MODEL
+
+const Model = Schema.Struct({
+  count: Schema.Number,
+});
+type Model = typeof Model.Type;
+
+// MESSAGE
+
+const Incremented = m("Incremented");
+const Decremented = m("Decremented");
+const Reset = m("Reset");
+
+const Message = Schema.Union([Incremented, Decremented, Reset]);
+type Message = typeof Message.Type;
+
+// UPDATE
+
+const init = (): readonly [Model, ReadonlyArray<Command.Command<Message>>] => [
+  { count: 0 },
+  [],
+];
+
+const update = (
+  model: Model,
+  message: Message,
+): readonly [Model, ReadonlyArray<Command.Command<Message>>] =>
+  Match.value(message).pipe(
+    Match.withReturnType<
+      readonly [Model, ReadonlyArray<Command.Command<Message>>]
+    >(),
+    Match.tagsExhaustive({
+      Incremented: () => [{ count: model.count + 1 }, []],
+      Decremented: () => [{ count: model.count - 1 }, []],
+      Reset: () => [{ count: 0 }, []],
+    }),
+  );
+
+// VIEW
+
+const h = html<Message>();
+
+const view = (model: Model): Html =>
+  h.main(
+    [h.Class("card")],
+    [
+      h.h1([], ["Foldkit on Cloudflare"]),
+      h.p([h.Class("count")], [String(model.count)]),
+      h.div(
+        [h.Class("row")],
+        [
+          h.button([h.OnClick(Decremented())], ["−1"]),
+          h.button([h.OnClick(Reset())], ["Reset"]),
+          h.button([h.OnClick(Incremented())], ["+1"]),
+        ],
+      ),
+      h.p(
+        [h.Class("hint")],
+        [
+          "An Elm-style counter: messages in, a fold over the model, a pure view out.",
+        ],
+      ),
+    ],
+  );
+
+// RUNTIME
+
+Runtime.run(
+  Runtime.makeElement({
+    Model,
+    init,
+    update,
+    view,
+    container: document.getElementById("root"),
+  }),
+);

--- a/examples/cloudflare-foldkit/src/styles.css
+++ b/examples/cloudflare-foldkit/src/styles.css
@@ -1,0 +1,62 @@
+:root {
+  color-scheme: light dark;
+  font-family:
+    system-ui,
+    -apple-system,
+    "Segoe UI",
+    Roboto,
+    sans-serif;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+}
+
+.card {
+  text-align: center;
+  padding: 3rem 4rem;
+  border: 1px solid color-mix(in srgb, currentColor 20%, transparent);
+  border-radius: 12px;
+}
+
+.card h1 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.count {
+  margin: 1.5rem 0;
+  font-size: 4rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.row {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+}
+
+.row button {
+  font: inherit;
+  padding: 0.5rem 1.25rem;
+  border: 1px solid color-mix(in srgb, currentColor 30%, transparent);
+  border-radius: 8px;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+
+.row button:hover {
+  background: color-mix(in srgb, currentColor 10%, transparent);
+}
+
+.hint {
+  margin: 2rem 0 0;
+  font-size: 0.875rem;
+  opacity: 0.6;
+  max-width: 32ch;
+}

--- a/examples/cloudflare-foldkit/tsconfig.json
+++ b/examples/cloudflare-foldkit/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["vite/client"],
+    "isolatedModules": true
+  },
+  "include": ["src/**/*", "vite.config.ts"]
+}

--- a/examples/cloudflare-foldkit/vite.config.ts
+++ b/examples/cloudflare-foldkit/vite.config.ts
@@ -1,0 +1,6 @@
+import { foldkit } from "@foldkit/vite-plugin";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [foldkit()],
+});

--- a/test/smoke.test.ts
+++ b/test/smoke.test.ts
@@ -35,6 +35,7 @@ const examples = [
   "aws-lambda",
   "aws-lambda-httpapi",
   "aws-lambda-rpc",
+  "cloudflare-foldkit",
   "cloudflare-git-artifacts",
   "cloudflare-neon-drizzle",
   "cloudflare-secrets-store",


### PR DESCRIPTION
Adds a minimal [Foldkit](https://foldkit.dev) example: an Elm-style counter SPA (single `src/main.ts`) deployed with `Cloudflare.Website.Vite`.

`effect` is pinned to `4.0.0-beta.88` — Foldkit's exact peer — instead of the catalog; noted in the README.