### PR TITLE
fix(cloudflare): preserve dev worker registration on reload

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -204,6 +204,13 @@ export const LocalWorkerProvider = () =>
         bundle: Bundle.BundleOutput,
         proxy: WorkerProxy.WorkerProxyInstance,
       ) {
+        const previous = workerdScopes.get(worker.id);
+        if (previous) {
+          // Both runtimes use the same registry key. Close the old scope first so
+          // its unregister finalizer cannot delete the replacement registration.
+          yield* Scope.close(previous, Exit.void);
+          workerdScopes.delete(worker.id);
+        }
         const scope = yield* Effect.scope.pipe(Effect.flatMap(Scope.fork));
         const url = yield* runtime
           .start({
@@ -218,10 +225,6 @@ export const LocalWorkerProvider = () =>
             assets: toRuntimeAssets(worker.assets),
           })
           .pipe(Scope.provide(scope));
-        const previous = workerdScopes.get(worker.id);
-        if (previous) {
-          yield* Effect.forkDetach(Scope.close(previous, Exit.void));
-        }
         workerdScopes.set(worker.id, scope);
         yield* proxy.set(url);
         return url;


### PR DESCRIPTION
hi! I'm getting Worker `"home-api-dev-utopy-ijmmtvj5spgzktlm" not found. Make sure the worker is running locally` in the rpc response whenever the backend code of my Api worker changes. It looks like a race condition.

Here's what the agent thinks is happpening:

1. API hot reload starts and registers the replacement worker.
2. Alchemy then asynchronously closes the previous worker scope in LocalWorkerProvider.ts:221-225.
3. The old scope finalizer deletes the registry file by worker name in Registry.ts:124-136.
4. Because both versions share the same name, it deletes the new worker’s registration.
5. The web worker’s service binding can no longer resolve the API and returns the reported 503.

This seems to have fixed it on my end, not sure if this is not a regression though