### PR TITLE
feat(cloudflare/workflows): add per-workflow step limits

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
@@ -152,6 +152,7 @@ export const bindWorkerAsyncBindings = Effect.fn(function* (
               workflowName,
               className,
               scriptName: resource.workerName,
+              limits: binding.limits,
             });
           }
         }

--- a/packages/alchemy/src/Cloudflare/Workflows/Workflow.ts
+++ b/packages/alchemy/src/Cloudflare/Workflows/Workflow.ts
@@ -288,6 +288,16 @@ export const isWorkflowExport = (value: unknown): value is WorkflowExport =>
   (value as any).kind === "workflow";
 
 /**
+ * Limits applied to the workflow on create or update.
+ */
+export interface WorkflowLimits {
+  /**
+   * Maximum number of steps a single workflow instance may execute.
+   */
+  steps?: number;
+}
+
+/**
  * Props for the reference (async) form of {@link Workflow}. Used when binding
  * a Workflow class to a plain async Worker (one without an Effect runtime) via
  * the Worker's `env`. Mirrors `DurableObjectProps`.
@@ -304,6 +314,23 @@ export interface WorkflowRefProps {
    * is hosted by the Worker that declares the binding.
    */
   scriptName?: Input<string>;
+  /**
+   * Limits applied to the workflow. Only applies when the workflow is hosted by
+   * the Worker that declares the binding; ignored when `scriptName` is set.
+   */
+  limits?: WorkflowLimits;
+}
+
+/**
+ * Props for the Effect-native form of {@link Workflow}
+ * (`Workflow(name, impl, props)`). Used when the workflow's implementation is
+ * defined inline by the hosting Worker.
+ */
+export interface WorkflowProps {
+  /**
+   * Limits applied to the workflow.
+   */
+  limits?: WorkflowLimits;
 }
 
 /**
@@ -321,6 +348,8 @@ export interface WorkflowLike<Params = unknown> {
   className?: string;
   /** @internal phantom */
   scriptName?: Input<string>;
+  /** @internal phantom */
+  limits?: WorkflowLimits;
   /** @internal phantom */
   Params?: Params;
 }
@@ -433,6 +462,7 @@ export interface WorkflowClass extends Effect.Effect<
     <Input = unknown, Result = unknown, InitReq = never>(
       name: string,
       impl: Effect.Effect<WorkflowImpl<Input, Result>, ConfigError, InitReq>,
+      props?: WorkflowProps,
     ): Effect.Effect<
       WorkflowHandle<Input, Result>,
       never,
@@ -448,6 +478,7 @@ export interface WorkflowClass extends Effect.Effect<
   <Input = unknown, Result = unknown, InitReq = never>(
     name: string,
     impl: Effect.Effect<WorkflowImpl<Input, Result>, ConfigError, InitReq>,
+    props?: WorkflowProps,
   ): Effect.Effect<
     WorkflowHandle<Input, Result>,
     never,
@@ -499,6 +530,19 @@ export class WorkflowScope extends Context.Service<
  *       return { received: input.name };
  *     });
  *   }),
+ * ) {}
+ * ```
+ *
+ * @example Setting a step limit
+ * ```typescript
+ * export default class MyWorkflow extends Cloudflare.Workflow<MyWorkflow>()(
+ *   "MyWorkflow",
+ *   Effect.gen(function* () {
+ *     return Effect.fn(function* (input: { name: string }) {
+ *       return { received: input.name };
+ *     });
+ *   }),
+ *   { limits: { steps: 25000 } },
  * ) {}
  * ```
  *
@@ -747,23 +791,28 @@ export class WorkflowScope extends Context.Service<
 export const Workflow: WorkflowClass = taggedFunction(WorkflowScope, ((
   ...args:
     | []
-    | [name: string, impl: Effect.Effect<WorkflowImpl<any, any>>]
+    | [
+        name: string,
+        impl: Effect.Effect<WorkflowImpl<any, any>>,
+        props?: WorkflowProps,
+      ]
     | [name: string, props?: WorkflowRefProps]
 ) => {
   if (args.length === 0) {
     return Workflow;
   }
-  const [name, second] = args;
+  const [name, second, props] = args;
   if (!Effect.isEffect(second)) {
     // Props-only (async) reference form: returns a plain `WorkflowLike` that an
     // async Worker binds via `env`. `WorkerAsyncBindings` emits the `workflow`
     // binding and drives `putWorkflow` for locally-hosted workflows.
-    const props = second as WorkflowRefProps | undefined;
+    const refProps = second as WorkflowRefProps | undefined;
     return {
       kind: TypeId,
       name,
-      className: props?.className ?? name,
-      scriptName: props?.scriptName,
+      className: refProps?.className ?? name,
+      scriptName: refProps?.scriptName,
+      limits: refProps?.limits,
     } satisfies WorkflowLike;
   }
   const impl = second;
@@ -778,6 +827,7 @@ export const Workflow: WorkflowClass = taggedFunction(WorkflowScope, ((
         workflowName,
         className: name,
         scriptName: worker.workerName,
+        limits: props?.limits,
       });
 
       // Add the workflow binding to the Worker metadata
@@ -864,6 +914,7 @@ export interface WorkflowResourceProps {
   workflowName: string;
   className: string;
   scriptName: string;
+  limits?: WorkflowLimits;
 }
 
 export interface WorkflowResourceAttrs {
@@ -956,6 +1007,7 @@ export const ProviderLive = () =>
         workflowName,
         className: news.className,
         scriptName: news.scriptName,
+        limits: news.limits,
       });
       return {
         workflowId: result.id,

--- a/packages/alchemy/src/Cloudflare/Workflows/Workflow.ts
+++ b/packages/alchemy/src/Cloudflare/Workflows/Workflow.ts
@@ -323,7 +323,7 @@ export interface WorkflowRefProps {
 
 /**
  * Props for the Effect-native form of {@link Workflow}
- * (`Workflow(name, impl, props)`). Used when the workflow's implementation is
+ * (`Workflow(name, props, impl)`). Used when the workflow's implementation is
  * defined inline by the hosting Worker.
  */
 export interface WorkflowProps {
@@ -462,7 +462,17 @@ export interface WorkflowClass extends Effect.Effect<
     <Input = unknown, Result = unknown, InitReq = never>(
       name: string,
       impl: Effect.Effect<WorkflowImpl<Input, Result>, ConfigError, InitReq>,
-      props?: WorkflowProps,
+    ): Effect.Effect<
+      WorkflowHandle<Input, Result>,
+      never,
+      Worker | Exclude<InitReq, WorkflowServices>
+    > & {
+      new (_: never): WorkflowImpl<Input, Result>;
+    };
+    <Input = unknown, Result = unknown, InitReq = never>(
+      name: string,
+      props: WorkflowProps,
+      impl: Effect.Effect<WorkflowImpl<Input, Result>, ConfigError, InitReq>,
     ): Effect.Effect<
       WorkflowHandle<Input, Result>,
       never,
@@ -478,7 +488,15 @@ export interface WorkflowClass extends Effect.Effect<
   <Input = unknown, Result = unknown, InitReq = never>(
     name: string,
     impl: Effect.Effect<WorkflowImpl<Input, Result>, ConfigError, InitReq>,
-    props?: WorkflowProps,
+  ): Effect.Effect<
+    WorkflowHandle<Input, Result>,
+    never,
+    Worker | Exclude<InitReq, WorkflowServices>
+  >;
+  <Input = unknown, Result = unknown, InitReq = never>(
+    name: string,
+    props: WorkflowProps,
+    impl: Effect.Effect<WorkflowImpl<Input, Result>, ConfigError, InitReq>,
   ): Effect.Effect<
     WorkflowHandle<Input, Result>,
     never,
@@ -537,12 +555,12 @@ export class WorkflowScope extends Context.Service<
  * ```typescript
  * export default class MyWorkflow extends Cloudflare.Workflow<MyWorkflow>()(
  *   "MyWorkflow",
+ *   { limits: { steps: 25000 } },
  *   Effect.gen(function* () {
  *     return Effect.fn(function* (input: { name: string }) {
  *       return { received: input.name };
  *     });
  *   }),
- *   { limits: { steps: 25000 } },
  * ) {}
  * ```
  *
@@ -791,18 +809,24 @@ export class WorkflowScope extends Context.Service<
 export const Workflow: WorkflowClass = taggedFunction(WorkflowScope, ((
   ...args:
     | []
+    | [name: string, impl: Effect.Effect<WorkflowImpl<any, any>>]
     | [
         name: string,
+        props: WorkflowProps,
         impl: Effect.Effect<WorkflowImpl<any, any>>,
-        props?: WorkflowProps,
       ]
     | [name: string, props?: WorkflowRefProps]
 ) => {
   if (args.length === 0) {
     return Workflow;
   }
-  const [name, second, props] = args;
-  if (!Effect.isEffect(second)) {
+  const [name, second, third] = args;
+  const impl = Effect.isEffect(second)
+    ? second
+    : Effect.isEffect(third)
+      ? third
+      : undefined;
+  if (impl === undefined) {
     // Props-only (async) reference form: returns a plain `WorkflowLike` that an
     // async Worker binds via `env`. `WorkerAsyncBindings` emits the `workflow`
     // binding and drives `putWorkflow` for locally-hosted workflows.
@@ -815,7 +839,7 @@ export const Workflow: WorkflowClass = taggedFunction(WorkflowScope, ((
       limits: refProps?.limits,
     } satisfies WorkflowLike;
   }
-  const impl = second;
+  const props = Effect.isEffect(second) ? undefined : (second as WorkflowProps);
   return effectClass(
     Effect.gen(function* () {
       const worker = yield* Worker;

--- a/packages/alchemy/test/Cloudflare/Workers/Workflow.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/Workflow.test.ts
@@ -1,11 +1,17 @@
 import * as Cloudflare from "@/Cloudflare";
+import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
 import * as Provider from "@/Provider";
 import * as Test from "@/Test/Alchemy";
+import * as workers from "@distilled.cloud/cloudflare/workers";
+import * as workflows from "@distilled.cloud/cloudflare/workflows";
 import { expect } from "alchemy-test";
 import * as Effect from "effect/Effect";
 import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
+import * as Stream from "effect/Stream";
 import * as HttpClient from "effect/unstable/http/HttpClient";
+import LimitsWorkflowWorker from "./fixtures/workflow-limits/limits-worker.ts";
+import { STEP_LIMIT } from "./fixtures/workflow-limits/limits-workflow.ts";
 import Stack from "./fixtures/workflow/stack.ts";
 import WorkflowTestWorker from "./fixtures/workflow/workflow-worker.ts";
 
@@ -274,6 +280,71 @@ test.provider.skipIf(!process.env.CLOUDFLARE_TEST_WORKFLOW_LIST)(
       ).toBe(true);
 
       yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 120_000 },
+);
+
+// ---------------------------------------------------------------------------
+// Per-workflow limits: deploy a workflow declared with a step limit through the
+// Effect-native form, then read it back out-of-band from the versions API (the
+// only read that surfaces `limits`) to confirm it was applied.
+// ---------------------------------------------------------------------------
+
+// Physical workflow names are derived from the host Worker name and class, so
+// read the name off the deployed binding rather than assuming the class name.
+const readWorkflowName = (scriptName: string) =>
+  Effect.gen(function* () {
+    const { accountId } = yield* yield* CloudflareEnvironment;
+    const settings = yield* workers.getScriptScriptAndVersionSetting({
+      accountId,
+      scriptName,
+    });
+    const binding = (settings.bindings ?? []).find(
+      (b): b is Extract<typeof b, { type: "workflow" }> =>
+        b.type === "workflow",
+    );
+    return binding === undefined
+      ? yield* Effect.fail(new Error(`no workflow binding on '${scriptName}'`))
+      : binding.workflowName;
+  });
+
+// Read the applied step limit out-of-band via the versions API, retrying until
+// it propagates (bounded, so a missing limit fails fast).
+const waitForAppliedStepLimit = (workflowName: string, expected: number) =>
+  Effect.gen(function* () {
+    const { accountId } = yield* yield* CloudflareEnvironment;
+    const versions = yield* workflows.listVersions
+      .items({ accountId, workflowName })
+      .pipe(Stream.runCollect);
+    return Array.from(versions)
+      .map((v) => v.limits?.steps ?? undefined)
+      .find((steps) => steps !== undefined);
+  }).pipe(
+    Effect.flatMap((steps) =>
+      steps === expected
+        ? Effect.succeed(steps)
+        : Effect.fail(new Error(`steps limit not applied yet: ${steps}`)),
+    ),
+    Effect.retry({ schedule: Schedule.spaced("2 seconds"), times: 15 }),
+  );
+
+test.provider(
+  "effect-native workflow applies a per-workflow step limit",
+  (scratch) =>
+    Effect.gen(function* () {
+      yield* scratch.destroy();
+
+      const deployed = yield* scratch.deploy(
+        Effect.gen(function* () {
+          return { worker: yield* LimitsWorkflowWorker };
+        }),
+      );
+
+      const workflowName = yield* readWorkflowName(deployed.worker.workerName);
+      const applied = yield* waitForAppliedStepLimit(workflowName, STEP_LIMIT);
+      expect(applied).toBe(STEP_LIMIT);
+
+      yield* scratch.destroy();
     }).pipe(logLevel),
   { timeout: 120_000 },
 );

--- a/packages/alchemy/test/Cloudflare/Workers/WorkflowAsync.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkflowAsync.test.ts
@@ -1,9 +1,12 @@
 import * as Cloudflare from "@/Cloudflare";
+import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
 import * as Test from "@/Test/Alchemy";
+import * as workflows from "@distilled.cloud/cloudflare/workflows";
 import { expect } from "alchemy-test";
 import * as Effect from "effect/Effect";
 import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
+import * as Stream from "effect/Stream";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import Stack from "./fixtures/workflow-async/stack.ts";
 
@@ -233,6 +236,74 @@ test.provider(
       expect(lastStatus.status).toBe("complete");
       expect(lastStatus.error).toBeFalsy();
       expect(lastStatus.output?.greeting).toBe("Hello, world!");
+
+      yield* scratch.destroy();
+    }).pipe(logLevel),
+  { timeout: 120_000 },
+);
+
+// ---------------------------------------------------------------------------
+// Per-workflow limits: deploy a locally-hosted workflow declared with a step
+// limit, then read it back out-of-band from the versions API (the only read
+// that surfaces `limits`) to confirm it was applied.
+// ---------------------------------------------------------------------------
+
+const limitsWorkflowScript = `import { WorkflowEntrypoint } from "cloudflare:workers";
+export class LimitsWorkflow extends WorkflowEntrypoint {
+  async run(event, step) {
+    return await step.do("noop", async () => "ok");
+  }
+}
+export default {
+  async fetch() {
+    return new Response("ok");
+  },
+};
+`;
+
+// Read the applied step limit out-of-band via the versions API, retrying until
+// it propagates (bounded, so a missing limit fails fast).
+const waitForAppliedSteps = (workflowName: string, expected: number) =>
+  Effect.gen(function* () {
+    const { accountId } = yield* yield* CloudflareEnvironment;
+    const versions = yield* workflows.listVersions
+      .items({ accountId, workflowName })
+      .pipe(Stream.runCollect);
+    return Array.from(versions)
+      .map((v) => v.limits?.steps ?? undefined)
+      .find((steps) => steps !== undefined);
+  }).pipe(
+    Effect.flatMap((steps) =>
+      steps === expected
+        ? Effect.succeed(steps)
+        : Effect.fail(new Error(`steps limit not applied yet: ${steps}`)),
+    ),
+    Effect.retry({ schedule: Schedule.spaced("2 seconds"), times: 15 }),
+  );
+
+test.provider(
+  "async worker workflow binding applies a per-workflow step limit",
+  (scratch) =>
+    Effect.gen(function* () {
+      const steps = 100;
+
+      yield* scratch.deploy(
+        Effect.gen(function* () {
+          return {
+            worker: yield* Cloudflare.Worker("limits-workflow-worker", {
+              script: limitsWorkflowScript,
+              env: {
+                LIMITS_WORKFLOW: Cloudflare.Workflow("LimitsWorkflow", {
+                  limits: { steps },
+                }),
+              },
+            }),
+          };
+        }),
+      );
+
+      const applied = yield* waitForAppliedSteps("LimitsWorkflow", steps);
+      expect(applied).toBe(steps);
 
       yield* scratch.destroy();
     }).pipe(logLevel),

--- a/packages/alchemy/test/Cloudflare/Workers/WorkflowAsync.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkflowAsync.test.ts
@@ -1,6 +1,7 @@
 import * as Cloudflare from "@/Cloudflare";
 import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
 import * as Test from "@/Test/Alchemy";
+import * as workers from "@distilled.cloud/cloudflare/workers";
 import * as workflows from "@distilled.cloud/cloudflare/workflows";
 import { expect } from "alchemy-test";
 import * as Effect from "effect/Effect";
@@ -261,9 +262,27 @@ export default {
 };
 `;
 
+// Physical workflow names are derived from the host Worker name and class, so
+// read the name off the deployed binding rather than assuming the class name.
+const readWorkflowName = (scriptName: string) =>
+  Effect.gen(function* () {
+    const { accountId } = yield* yield* CloudflareEnvironment;
+    const settings = yield* workers.getScriptScriptAndVersionSetting({
+      accountId,
+      scriptName,
+    });
+    const binding = (settings.bindings ?? []).find(
+      (b): b is Extract<typeof b, { type: "workflow" }> =>
+        b.type === "workflow",
+    );
+    return binding === undefined
+      ? yield* Effect.fail(new Error(`no workflow binding on '${scriptName}'`))
+      : binding.workflowName;
+  });
+
 // Read the applied step limit out-of-band via the versions API, retrying until
 // it propagates (bounded, so a missing limit fails fast).
-const waitForAppliedSteps = (workflowName: string, expected: number) =>
+const waitForAppliedStepLimit = (workflowName: string, expected: number) =>
   Effect.gen(function* () {
     const { accountId } = yield* yield* CloudflareEnvironment;
     const versions = yield* workflows.listVersions
@@ -287,7 +306,7 @@ test.provider(
     Effect.gen(function* () {
       const steps = 100;
 
-      yield* scratch.deploy(
+      const deployed = yield* scratch.deploy(
         Effect.gen(function* () {
           return {
             worker: yield* Cloudflare.Worker("limits-workflow-worker", {
@@ -302,7 +321,8 @@ test.provider(
         }),
       );
 
-      const applied = yield* waitForAppliedSteps("LimitsWorkflow", steps);
+      const workflowName = yield* readWorkflowName(deployed.worker.workerName);
+      const applied = yield* waitForAppliedStepLimit(workflowName, steps);
       expect(applied).toBe(steps);
 
       yield* scratch.destroy();

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/workflow-limits/limits-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/workflow-limits/limits-worker.ts
@@ -1,0 +1,21 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as Effect from "effect/Effect";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import LimitsWorkflow from "./limits-workflow.ts";
+
+export default class LimitsWorkflowWorker extends Cloudflare.Worker<LimitsWorkflowWorker>()(
+  "LimitsWorkflowWorker",
+  {
+    main: import.meta.url,
+  },
+  Effect.gen(function* () {
+    // Registering the workflow is what drives `putWorkflow` with the limit.
+    yield* LimitsWorkflow;
+
+    return {
+      fetch: Effect.gen(function* () {
+        return HttpServerResponse.text("ok");
+      }),
+    };
+  }),
+) {}

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/workflow-limits/limits-workflow.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/workflow-limits/limits-workflow.ts
@@ -1,0 +1,22 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as Effect from "effect/Effect";
+
+/** Step limit declared on {@link LimitsWorkflow}. */
+export const STEP_LIMIT = 250;
+
+/**
+ * Fixture workflow used by `Workflow.test.ts`. Declares a per-workflow step
+ * limit through the Effect-native form's third argument.
+ */
+export default class LimitsWorkflow extends Cloudflare.Workflow<LimitsWorkflow>()(
+  "LimitsWorkflow",
+  Effect.gen(function* () {
+    return Effect.fn(function* (input: { value: string }) {
+      return yield* Cloudflare.Workflows.task(
+        "greet",
+        Effect.succeed({ greeting: `Hello, ${input.value}!` }),
+      );
+    });
+  }),
+  { limits: { steps: STEP_LIMIT } },
+) {}

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/workflow-limits/limits-workflow.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/workflow-limits/limits-workflow.ts
@@ -6,10 +6,11 @@ export const STEP_LIMIT = 250;
 
 /**
  * Fixture workflow used by `Workflow.test.ts`. Declares a per-workflow step
- * limit through the Effect-native form's third argument.
+ * limit through the Effect-native form's props argument.
  */
 export default class LimitsWorkflow extends Cloudflare.Workflow<LimitsWorkflow>()(
   "LimitsWorkflow",
+  { limits: { steps: STEP_LIMIT } },
   Effect.gen(function* () {
     return Effect.fn(function* (input: { value: string }) {
       return yield* Cloudflare.Workflows.task(
@@ -18,5 +19,4 @@ export default class LimitsWorkflow extends Cloudflare.Workflow<LimitsWorkflow>(
       );
     });
   }),
-  { limits: { steps: STEP_LIMIT } },
 ) {}


### PR DESCRIPTION
Thread an optional `limits: { steps }` through both Workflow forms — the async ref form (`Workflow(name, { limits })` in a Worker `env`) and the Effect-native form (`Workflow(name, { limits }, impl)`) — down to the Workflows definition API (`putWorkflow`). Omitting `limits` is unchanged.

```ts
// async ref form
env: {
  LIMITS_WORKFLOW: Cloudflare.Workflow("LimitsWorkflow", { limits: { steps: 100 } }),
}

// effect-native form (props second, impl third — consistent with Worker/DurableObject)
export default class LimitsWorkflow extends Cloudflare.Workflow<LimitsWorkflow>()(
  "LimitsWorkflow",
  { limits: { steps: 250 } },
  Effect.gen(function* () { ... }),
) {}
```

Verified live: the limit is applied on deploy and read back from the Workflows versions API. Both forms are covered by tests that deploy a workflow with a step limit and assert the applied limit via the versions API.
