### PR TITLE
docs: migrate from v1 via adoption instead of destroy/recreate

### DIFF
--- a/website/src/content/docs/migrating-from-v1.mdx
+++ b/website/src/content/docs/migrating-from-v1.mdx
@@ -110,18 +110,68 @@ This is the recommended migration path. Get your infrastructure on v2
 first, then optionally adopt Effect for runtime code later.
 :::
 
-## Step 3: Deploy
+## Step 3: Pin your physical names
 
-The CLI commands are the same:
+Your v1 state is not compatible with v2, so v2 starts from an empty
+state store. Without extra steps, the first deploy would create
+brand-new resources alongside your existing ones. Instead, you
+[adopt](/cli/adopting-resources) the resources v1 already deployed —
+no destroy, no downtime.
+
+Adoption works by physical name: when a resource has no prior state,
+the engine looks it up in the cloud by name and takes ownership of
+what it finds. v2 derives physical names from the stack, stage, and
+logical ID — which will not match what v1 deployed. So set the `name`
+prop on each resource to the **exact** name of the live v1 resource:
+
+```typescript
+export const Bucket = Cloudflare.R2.Bucket("Bucket", {
+  name: "my-app-bucket", // exact name of the bucket v1 created
+});
+
+export const Worker = Cloudflare.Worker("Worker", {
+  main: "./src/worker.ts",
+  name: "my-app-worker", // exact name of the worker v1 created
+  env: { Bucket },
+});
+```
+
+Find the deployed names in your v1 config (if you set `name`
+explicitly), your v1 state (`.alchemy/` by default), or the Cloudflare
+dashboard.
+
+## Step 4: Deploy with `--adopt`
+
+```sh
+alchemy deploy --adopt
+```
+
+For each resource, the engine finds the existing one by its physical
+name and adopts it into v2 state, then reconciles it to the declared
+config. `--adopt` tells the engine to take over resources it cannot
+prove it owns — which is exactly the situation for everything v1
+created. See [Adopting Resources](/cli/adopting-resources) for the
+full ownership rules.
+
+:::tip
+Try the migration on a non-production stage first: deploy your v1
+project to a fresh stage, then run the v2 adoption against it and
+verify everything reconciles cleanly before touching prod.
+:::
+
+:::caution
+After adopting, **do not run `destroy` in your v1 project** — its
+state still points at the same physical resources, so destroying the
+v1 stack would delete the resources v2 now manages. Delete the v1
+state files (the `.alchemy/` directory, or your remote state store
+entries) instead.
+:::
+
+From here on, deploys are normal:
 
 ```sh
 alchemy deploy
-alchemy destroy
 ```
-
-Your v1 state is not compatible with v2. On your first deploy, Alchemy
-creates new resources. You should destroy your v1 stack first, then
-deploy with v2.
 
 ## (Optional) Adopt Effect for runtime code
 
@@ -213,6 +263,8 @@ export default Alchemy.Stack(
 
 - Tutorial — build a full app on v2 from scratch, on
   [Cloudflare](/cloudflare/tutorial/part-1) or [AWS](/aws/tutorial/part-1)
+- [Adopting Resources](/cli/adopting-resources) — the full ownership
+  rules behind `--adopt`
 - [Bindings](/infrastructure-as-effects/binding) — what replaced v1 `bindings:`
 - [Cloudflare](/cloudflare) — the Cloudflare provider hub
 - [AWS](/aws) — the AWS provider hub

--- a/website/src/content/docs/migrating-from-v1.mdx
+++ b/website/src/content/docs/migrating-from-v1.mdx
@@ -120,25 +120,48 @@ no destroy, no downtime.
 
 Adoption works by physical name: when a resource has no prior state,
 the engine looks it up in the cloud by name and takes ownership of
-what it finds. v2 derives physical names from the stack, stage, and
-logical ID — which will not match what v1 deployed. So set the `name`
-prop on each resource to the **exact** name of the live v1 resource:
+what it finds. But v1 and v2 derive default names differently, so
+without pinning, v2 would look for names that don't exist.
+
+When you didn't set `name` explicitly, v1 derived it as:
+
+```
+{app}-{id}-{stage}
+```
+
+- `{app}` — the name you passed to `await alchemy("my-app")`
+- `{id}` — the resource's logical ID, e.g. `await Bucket("bucket")`
+- `{stage}` — the `--stage` value; defaults to `$ALCHEMY_STAGE`, then
+  your OS username (`$USER`), then `dev`
+
+So the v1 example at the top of this page, deployed with
+`--stage prod`, created a bucket named `my-app-bucket-prod` and a
+worker named `my-app-worker-prod`. (Resources created inside a nested
+scope get the scope names between `{app}` and `{id}`, and Worker names
+are lowercased.)
+
+Set the `name` prop on each v2 resource to that **exact** name:
 
 ```typescript
 export const Bucket = Cloudflare.R2.Bucket("Bucket", {
-  name: "my-app-bucket", // exact name of the bucket v1 created
+  name: "my-app-bucket-prod", // v1's {app}-{id}-{stage}
 });
 
 export const Worker = Cloudflare.Worker("Worker", {
   main: "./src/worker.ts",
-  name: "my-app-worker", // exact name of the worker v1 created
+  name: "my-app-worker-prod", // v1's {app}-{id}-{stage}
   env: { Bucket },
 });
 ```
 
-Find the deployed names in your v1 config (if you set `name`
-explicitly), your v1 state (`.alchemy/` by default), or the Cloudflare
-dashboard.
+If you did set `name` in v1, carry that value over unchanged. When in
+doubt, confirm the live names in your v1 state (`.alchemy/` by
+default) or the Cloudflare dashboard.
+
+Because v1 baked the stage into the name, each stage has different
+physical names. If you deploy several stages from the same config,
+compute the name from the stage (e.g. an environment variable your CI
+sets) instead of hardcoding one stage's suffix.
 
 ## Step 4: Deploy with `--adopt`
 


### PR DESCRIPTION
Replace the "destroy your v1 stack first" advice in the migration guide with the adoption workflow, so prod apps can migrate without recreating resources.

- New **Step 3: Pin your physical names** — v2 derives physical names from stack/stage/logical ID, so users must set `name` on each resource to the exact name v1 deployed:

  ```typescript
  export const Worker = Cloudflare.Worker("Worker", {
    main: "./src/worker.ts",
    name: "my-app-worker", // exact name of the worker v1 created
    env: { Bucket },
  });
  ```

- New **Step 4: Deploy with `--adopt`** — links to [Adopting Resources](https://alchemy.run/cli/adopting-resources), tips trying a non-prod stage first, and warns not to run `destroy` in the v1 project afterwards (delete the v1 state instead).
- Adds Adopting Resources to "Where next".

Prompted by user feedback that the guide's destroy-then-deploy flow "is not really an applicable workflow for most apps in prod".
