### PR TITLE
fix(cloudflare): pack durable object metadata into a single script tag

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/DurableObject.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/DurableObject.ts
@@ -796,7 +796,8 @@ export class DurableObjectScope extends Context.Service<
  * a worker with no Alchemy ownership tags as `Unowned`.
  *
  * Alchemy normally tracks which class backs each binding through an
- * `alchemy:do:<logicalId>:<className>` tag it writes on the script. A
+ * `alchemy:dos:` metadata tag it writes on the script (mapping each
+ * binding's logical id to its class name). A
  * foreign worker has no such tag, so on the **adopting deploy** Alchemy
  * falls back to matching your binding to the live class **by binding
  * name**. The class is then reused in place — not recreated — so
@@ -807,7 +808,7 @@ export class DurableObjectScope extends Context.Service<
  * binding's `className` must match the class that already exists on the
  * worker.** You cannot rename the class in the same deploy that adopts
  * it. Once the deploy completes, Alchemy owns the worker and has written
- * the `alchemy:do:` tag, so subsequent renames are driven by logical id
+ * the `alchemy:dos:` tag, so subsequent renames are driven by logical id
  * and work normally.
  *
  * @example Adopting a worker whose `Counter` class already exists

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -1355,7 +1355,8 @@ export const LiveWorkerProvider = () =>
         const oldTags = Array.from(new Set(oldSettings?.tags ?? []));
         const oldBindings = oldSettings?.bindings ?? [];
 
-        // Parse alchemy:do:{logicalId}:{className} tags
+        // Parse the DO logical-id→class mapping from script tags (packed
+        // `alchemy:dos:` and legacy per-DO `alchemy:do:` formats)
         const oldDoClassNameByLogicalId = getDurableObjectTagMap(oldTags);
         const currentDoBindings = getDurableObjectBindings(bindings, name);
         const currentDoClassNameByLogicalId = Object.fromEntries(
@@ -1421,14 +1422,14 @@ export const LiveWorkerProvider = () =>
           let previousClassName: string | undefined =
             oldDoClassNameByLogicalId[binding.logicalId];
           if (!previousClassName) {
-            // No `alchemy:do:` tag maps this logical id to a class — the
+            // No DO metadata tag maps this logical id to a class — the
             // worker was created outside Alchemy (raw API / Wrangler) or
             // before these tags existed. Fall back to matching the observed
             // cloud binding by binding name so adoption reuses the existing
             // class instead of asking Cloudflare to create one that already
             // exists (which fails the migration). This is the "first deploy
             // must match the existing class name" path; once we write the
-            // `alchemy:do:` tag, subsequent renames are driven by logical id.
+            // `alchemy:dos:` tag, subsequent renames are driven by logical id.
             const observed = oldBindings.find(
               (old) =>
                 old.type === "durable_object_namespace" &&
@@ -1465,24 +1466,22 @@ export const LiveWorkerProvider = () =>
           )}`,
         );
 
-        // Build alchemy:do:{logicalId}:{className} tags for each DO binding
-        const alchemyDoTags: string[] = [];
-        for (const binding of currentDoBindings) {
-          alchemyDoTags.push(
-            `alchemy:do:${binding.logicalId}:${binding.className}`,
-          );
-        }
+        // Pack every DO logical-id→class mapping into as few `alchemy:dos:`
+        // tags as possible — one tag per DO blows Cloudflare's 10-tag limit
+        // at 7+ bindings (#811).
+        const alchemyDoTags = encodeDurableObjectTags(currentDoBindings);
 
+        const alchemyTags = [
+          ...createAlchemyWorkerTags(id),
+          ...alchemyDoTags,
+          ...(newMigrationTag
+            ? [`alchemy:migration-tag:${newMigrationTag}`]
+            : []),
+        ];
         const metadataTags = Array.from(
-          new Set([
-            ...createAlchemyWorkerTags(id),
-            ...alchemyDoTags,
-            ...(newMigrationTag
-              ? [`alchemy:migration-tag:${newMigrationTag}`]
-              : []),
-            ...(news.tags ?? []),
-          ]),
+          new Set([...alchemyTags, ...(news.tags ?? [])]),
         );
+        yield* validateWorkerTags(name, metadataTags, alchemyTags.length);
 
         const migrations = {
           oldTag: oldMigrationTag,
@@ -2025,17 +2024,15 @@ export const LiveWorkerProvider = () =>
               ),
             ),
           ).map((className) => ({ className }));
-          const alchemyDoTags = durableObjects.map(
-            ({ logicalId, className }) =>
-              `alchemy:do:${logicalId}:${className}`,
-          );
+          const alchemyDoTags = encodeDurableObjectTags(durableObjects);
+          const alchemyTags = [
+            ...createAlchemyWorkerTags(id),
+            ...alchemyDoTags,
+          ];
           const tags = Array.from(
-            new Set([
-              ...createAlchemyWorkerTags(id),
-              ...alchemyDoTags,
-              ...(news.tags ?? []),
-            ]),
+            new Set([...alchemyTags, ...(news.tags ?? [])]),
           );
+          yield* validateWorkerTags(name, tags, alchemyTags.length);
           yield* Effect.logInfo(
             `Cloudflare Worker precreate: starting ${name}`,
           );
@@ -2377,16 +2374,12 @@ export const LiveWorkerProvider = () =>
           );
           yield* Effect.logInfo(
             `Cloudflare Worker reconcile: existing durable object tags ${JSON.stringify(
-              (existingSettings?.tags ?? []).filter((tag) =>
-                tag.startsWith("alchemy:do:"),
-              ),
+              (existingSettings?.tags ?? []).filter(isDurableObjectTag),
             )}`,
           );
           yield* Effect.logInfo(
             `Cloudflare Worker reconcile: previous durable object tags ${JSON.stringify(
-              (output?.tags ?? []).filter((tag) =>
-                tag.startsWith("alchemy:do:"),
-              ),
+              (output?.tags ?? []).filter(isDurableObjectTag),
             )}`,
           );
 
@@ -2533,7 +2526,7 @@ function bumpMigrationTagVersion(
 /**
  * Merges a worker's export-derived and binding-derived Durable Object class
  * lists for the precreate placeholder, deduping by class name. The
- * binding-derived entry wins on a collision so the `alchemy:do:` tag keys off
+ * binding-derived entry wins on a collision so the `alchemy:dos:` tag keys off
  * the same logical id (the binding sid) that `reconcile` writes.
  */
 function mergeDurableObjectClasses(
@@ -2588,16 +2581,166 @@ function getDurableObjectBindings(
   );
 }
 
-function getDurableObjectTagMap(tags: ReadonlyArray<string>) {
-  return Object.fromEntries(
-    tags.flatMap((tag) => {
-      if (!tag.startsWith("alchemy:do:")) {
-        return [];
-      }
+/**
+ * Cloudflare Worker script-tag limits, verified empirically against the live
+ * API (2026-07):
+ *
+ * - at most **10 tags** per Worker (the 11th is rejected with `Forbidden`)
+ * - each tag is at most **1024 bytes** (`BadRequest: Tag is too large`)
+ * - tags may not contain `,` or `&`; everything else (`:`, `;`, `=`, `/`,
+ *   spaces, unicode) is accepted and round-trips intact
+ *
+ * Alchemy reserves 3 ownership tags (`alchemy:stack/stage/id`) and 1
+ * migration tag, so the Durable Object logical-id→class mapping must not
+ * spend one tag per DO (#811). Instead all mappings are packed into as few
+ * `alchemy:dos:` tags as possible.
+ */
+const MAX_TAGS_PER_WORKER = 10;
+const MAX_TAG_BYTES = 1024;
+const LEGACY_DO_TAG_PREFIX = "alchemy:do:";
+const PACKED_DO_TAG_PREFIX = "alchemy:dos:";
+
+class InvalidWorkerTags extends Data.TaggedError("InvalidWorkerTags")<{
+  scriptName: string;
+  reason: string;
+}> {}
+
+/**
+ * Pack Durable Object logical-id→class mappings into `alchemy:dos:` tags.
+ *
+ * Each mapping is encoded as `logicalId=className` — elided to just
+ * `className` when the two are equal (the common case for export-derived
+ * classes) — with both components `encodeURIComponent`-escaped so the `;`
+ * pair separator, the `=` delimiter, and Cloudflare's forbidden tag
+ * characters (`,`, `&`) can never collide with user identifiers. Pairs are
+ * sorted for deterministic output and greedily packed so each tag stays
+ * within Cloudflare's 1024-byte tag limit; workers with more DOs than fit in
+ * one tag spill into additional `alchemy:dos:` tags.
+ *
+ * `encodeURIComponent` output is pure ASCII, so `String.length` equals the
+ * tag's byte length.
+ *
+ * @internal exported for unit testing.
+ */
+export function encodeDurableObjectTags(
+  durableObjects: ReadonlyArray<{ logicalId: string; className: string }>,
+): string[] {
+  const pairs = [...durableObjects]
+    .sort((a, b) => a.logicalId.localeCompare(b.logicalId))
+    .map(({ logicalId, className }) =>
+      logicalId === className
+        ? encodeURIComponent(className)
+        : `${encodeURIComponent(logicalId)}=${encodeURIComponent(className)}`,
+    );
+  const tags: string[] = [];
+  let payload = "";
+  for (const pair of pairs) {
+    const appended = payload === "" ? pair : `${payload};${pair}`;
+    if (
+      PACKED_DO_TAG_PREFIX.length + appended.length > MAX_TAG_BYTES &&
+      payload !== ""
+    ) {
+      tags.push(`${PACKED_DO_TAG_PREFIX}${payload}`);
+      payload = pair;
+    } else {
+      payload = appended;
+    }
+  }
+  if (payload !== "") {
+    tags.push(`${PACKED_DO_TAG_PREFIX}${payload}`);
+  }
+  return tags;
+}
+
+/**
+ * Parse the Durable Object logical-id→class mapping from a worker's script
+ * tags. Reads both formats so workers deployed before the packed format roll
+ * forward transparently:
+ *
+ * - legacy: one `alchemy:do:{logicalId}:{className}` tag per DO
+ * - packed: `alchemy:dos:{pair};{pair};…` (see {@link encodeDurableObjectTags})
+ *
+ * A packed entry wins over a legacy entry for the same logical id.
+ *
+ * @internal exported for unit testing.
+ */
+export function getDurableObjectTagMap(tags: ReadonlyArray<string>) {
+  const map: Record<string, string> = {};
+  for (const tag of tags) {
+    if (tag.startsWith(LEGACY_DO_TAG_PREFIX)) {
       const parts = tag.split(":");
       const logicalId = parts[2];
       const className = parts.slice(3).join(":");
-      return logicalId && className ? [[logicalId, className]] : [];
-    }),
-  );
+      if (logicalId && className && !(logicalId in map)) {
+        map[logicalId] = className;
+      }
+    }
+  }
+  for (const tag of tags) {
+    if (tag.startsWith(PACKED_DO_TAG_PREFIX)) {
+      for (const pair of tag.slice(PACKED_DO_TAG_PREFIX.length).split(";")) {
+        if (pair === "") continue;
+        const eq = pair.indexOf("=");
+        const logicalId = decodeURIComponent(
+          eq === -1 ? pair : pair.slice(0, eq),
+        );
+        const className = decodeURIComponent(
+          eq === -1 ? pair : pair.slice(eq + 1),
+        );
+        if (logicalId && className) {
+          map[logicalId] = className;
+        }
+      }
+    }
+  }
+  return map;
 }
+
+const isDurableObjectTag = (tag: string) =>
+  tag.startsWith(LEGACY_DO_TAG_PREFIX) || tag.startsWith(PACKED_DO_TAG_PREFIX);
+
+/**
+ * Fail fast — before the script upload — when a worker's tag set violates
+ * Cloudflare's limits, instead of surfacing the raw `Forbidden`/`BadRequest`
+ * at PUT time (#811). `alchemyTagCount` is the number of tags alchemy itself
+ * generated (ownership + migration + packed DO tags) so the message can tell
+ * the user how much of the budget is theirs.
+ */
+const validateWorkerTags = (
+  scriptName: string,
+  tags: ReadonlyArray<string>,
+  alchemyTagCount: number,
+) =>
+  Effect.gen(function* () {
+    if (tags.length > MAX_TAGS_PER_WORKER) {
+      return yield* Effect.fail(
+        new InvalidWorkerTags({
+          scriptName,
+          reason:
+            `worker "${scriptName}" needs ${tags.length} script tags but Cloudflare allows at most ${MAX_TAGS_PER_WORKER}. ` +
+            `Alchemy reserves ${alchemyTagCount} (ownership, migration and durable-object metadata); ` +
+            `${tags.length - alchemyTagCount} user tags were passed via \`tags\`. Remove ${tags.length - MAX_TAGS_PER_WORKER} tag(s).`,
+        }),
+      );
+    }
+    const encoder = new TextEncoder();
+    for (const tag of tags) {
+      if (tag.includes(",") || tag.includes("&")) {
+        return yield* Effect.fail(
+          new InvalidWorkerTags({
+            scriptName,
+            reason: `worker "${scriptName}" tag ${JSON.stringify(tag)} contains ',' or '&', which Cloudflare rejects.`,
+          }),
+        );
+      }
+      const bytes = yield* Effect.sync(() => encoder.encode(tag).length);
+      if (bytes > MAX_TAG_BYTES) {
+        return yield* Effect.fail(
+          new InvalidWorkerTags({
+            scriptName,
+            reason: `worker "${scriptName}" tag ${JSON.stringify(tag.slice(0, 64))}… is ${bytes} bytes; Cloudflare allows at most ${MAX_TAG_BYTES}.`,
+          }),
+        );
+      }
+    }
+  });

--- a/packages/alchemy/test/Cloudflare/Workers/DurableObjectNamespace.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/DurableObjectNamespace.test.ts
@@ -11,6 +11,7 @@ import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import { getWorkerTags } from "../Utils/Worker.ts";
 import Stack from "./fixtures/do-rpc/stack.ts";
 
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
@@ -548,4 +549,166 @@ test.provider(
       yield* scratch.destroy();
     }).pipe(logLevel),
   { timeout: 120_000 },
+);
+
+// Reproduces #811: one script tag per DO binding blew Cloudflare's 10-tag
+// limit at 7+ Durable Objects (3 ownership tags + 1 migration tag + N DO
+// tags). The logical-id→class mapping is now packed into `alchemy:dos:`
+// tags, so a worker with 8 DOs deploys fine and the whole tag set stays
+// within the limit. The second deploy renames a class and drops another to
+// prove migrations are still driven by the packed mapping.
+test.provider(
+  "worker with 8 durable objects deploys within the 10-tag limit",
+  (scratch) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* yield* CloudflareEnvironment;
+      const ids = Array.from({ length: 8 }, (_, i) => `DO_${i}`);
+      const makeScript = (classes: string[], version: string) =>
+        `import { DurableObject } from "cloudflare:workers";
+${classes.map((c) => `export class ${c} extends DurableObject {}`).join("\n")}
+export default { async fetch() { return new Response("${version}"); } };
+`;
+
+      const v1 = yield* scratch.deploy(
+        Effect.gen(function* () {
+          return {
+            worker: yield* Cloudflare.Worker("worker", {
+              script: makeScript(
+                ids.map((_, i) => `Class${i}`),
+                "v1",
+              ),
+              env: Object.fromEntries(
+                ids.map((id, i) => [
+                  id,
+                  Cloudflare.DurableObject(id, { className: `Class${i}` }),
+                ]),
+              ),
+            }),
+          };
+        }),
+      );
+      expect(yield* fetchReady(v1.worker.url!, "v1")).toBe("v1");
+
+      const tags = yield* getWorkerTags(v1.worker.workerName, accountId);
+      expect(tags.length).toBeLessThanOrEqual(10);
+      expect(tags.filter((t) => t.startsWith("alchemy:dos:"))).toHaveLength(1);
+      expect(tags.filter((t) => t.startsWith("alchemy:do:"))).toHaveLength(0);
+
+      // Rename Class0 → Class0V2 (same binding id) and delete DO_7 — both
+      // migrations resolve their previous class through the packed tag.
+      const v2 = yield* scratch.deploy(
+        Effect.gen(function* () {
+          return {
+            worker: yield* Cloudflare.Worker("worker", {
+              script: makeScript(
+                ["Class0V2", ...ids.slice(1, 7).map((_, i) => `Class${i + 1}`)],
+                "v2",
+              ),
+              env: Object.fromEntries(
+                ids.slice(0, 7).map((id, i) => [
+                  id,
+                  Cloudflare.DurableObject(id, {
+                    className: i === 0 ? "Class0V2" : `Class${i}`,
+                  }),
+                ]),
+              ),
+            }),
+          };
+        }),
+      );
+      expect(yield* fetchReady(v2.worker.url!, "v2")).toBe("v2");
+
+      yield* scratch.destroy();
+    }).pipe(logLevel),
+  { timeout: 180_000 },
+);
+
+// Roll-forward from the legacy tag format: a worker last deployed by an
+// older alchemy carries one `alchemy:do:{logicalId}:{className}` tag per DO.
+// Simulate that by rewriting the live script tags to the legacy format
+// out-of-band, then redeploy with a class rename — reconcile must parse the
+// legacy tags to resolve the previous class, and the deploy rewrites the
+// mapping in the packed format.
+test.provider(
+  "rolls forward from legacy per-DO alchemy:do: tags",
+  (scratch) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* yield* CloudflareEnvironment;
+
+      const v1 = yield* scratch.deploy(
+        Effect.gen(function* () {
+          return {
+            worker: yield* Cloudflare.Worker("worker", {
+              script: `import { DurableObject } from "cloudflare:workers";
+export class CounterClass extends DurableObject {}
+export class MeterClass extends DurableObject {}
+export default { async fetch() { return new Response("v1"); } };
+`,
+              env: {
+                Counter: Cloudflare.DurableObject("Counter", {
+                  className: "CounterClass",
+                }),
+                Meter: Cloudflare.DurableObject("Meter", {
+                  className: "MeterClass",
+                }),
+              },
+            }),
+          };
+        }),
+      );
+      expect(yield* fetchReady(v1.worker.url!, "v1")).toBe("v1");
+      const scriptName = v1.worker.workerName;
+
+      // Rewrite the tags the way alchemy <= beta.62 wrote them: one
+      // `alchemy:do:` tag per binding, no packed tag.
+      const deployedTags = yield* getWorkerTags(scriptName, accountId);
+      yield* workers.patchScriptScriptAndVersionSetting({
+        accountId,
+        scriptName,
+        settings: {
+          tags: [
+            ...deployedTags.filter((t) => !t.startsWith("alchemy:dos:")),
+            "alchemy:do:Counter:CounterClass",
+            "alchemy:do:Meter:MeterClass",
+          ],
+        },
+      });
+
+      // Redeploy with a rename; the previous class must be resolved from the
+      // legacy tags for the migration to succeed.
+      const v2 = yield* scratch.deploy(
+        Effect.gen(function* () {
+          return {
+            worker: yield* Cloudflare.Worker("worker", {
+              script: `import { DurableObject } from "cloudflare:workers";
+export class CounterClassV2 extends DurableObject {}
+export class MeterClass extends DurableObject {}
+export default { async fetch() { return new Response("v2"); } };
+`,
+              env: {
+                Counter: Cloudflare.DurableObject("Counter", {
+                  className: "CounterClassV2",
+                }),
+                Meter: Cloudflare.DurableObject("Meter", {
+                  className: "MeterClass",
+                }),
+              },
+            }),
+          };
+        }),
+      );
+      expect(yield* fetchReady(v2.worker.url!, "v2")).toBe("v2");
+
+      // The deploy rewrote the mapping in the packed format.
+      const rolledForward = yield* getWorkerTags(scriptName, accountId);
+      expect(
+        rolledForward.filter((t) => t.startsWith("alchemy:dos:")),
+      ).toHaveLength(1);
+      expect(
+        rolledForward.filter((t) => t.startsWith("alchemy:do:")),
+      ).toHaveLength(0);
+
+      yield* scratch.destroy();
+    }).pipe(logLevel),
+  { timeout: 180_000 },
 );

--- a/packages/alchemy/test/Cloudflare/Workers/DurableObjectNamespace.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/DurableObjectNamespace.test.ts
@@ -554,15 +554,16 @@ test.provider(
 // Reproduces #811: one script tag per DO binding blew Cloudflare's 10-tag
 // limit at 7+ Durable Objects (3 ownership tags + 1 migration tag + N DO
 // tags). The logical-id→class mapping is now packed into `alchemy:dos:`
-// tags, so a worker with 8 DOs deploys fine and the whole tag set stays
-// within the limit. The second deploy renames a class and drops another to
-// prove migrations are still driven by the packed mapping.
+// tags, so a worker with 20 DOs — double the count that used to consume the
+// entire tag budget — deploys fine and the whole tag set stays within the
+// limit. The second deploy renames a class and drops another to prove
+// migrations are still driven by the packed mapping.
 test.provider(
-  "worker with 8 durable objects deploys within the 10-tag limit",
+  "worker with 20 durable objects deploys within the 10-tag limit",
   (scratch) =>
     Effect.gen(function* () {
       const { accountId } = yield* yield* CloudflareEnvironment;
-      const ids = Array.from({ length: 8 }, (_, i) => `DO_${i}`);
+      const ids = Array.from({ length: 20 }, (_, i) => `DO_${i}`);
       const makeScript = (classes: string[], version: string) =>
         `import { DurableObject } from "cloudflare:workers";
 ${classes.map((c) => `export class ${c} extends DurableObject {}`).join("\n")}
@@ -594,18 +595,21 @@ export default { async fetch() { return new Response("${version}"); } };
       expect(tags.filter((t) => t.startsWith("alchemy:dos:"))).toHaveLength(1);
       expect(tags.filter((t) => t.startsWith("alchemy:do:"))).toHaveLength(0);
 
-      // Rename Class0 → Class0V2 (same binding id) and delete DO_7 — both
+      // Rename Class0 → Class0V2 (same binding id) and delete DO_19 — both
       // migrations resolve their previous class through the packed tag.
       const v2 = yield* scratch.deploy(
         Effect.gen(function* () {
           return {
             worker: yield* Cloudflare.Worker("worker", {
               script: makeScript(
-                ["Class0V2", ...ids.slice(1, 7).map((_, i) => `Class${i + 1}`)],
+                [
+                  "Class0V2",
+                  ...ids.slice(1, 19).map((_, i) => `Class${i + 1}`),
+                ],
                 "v2",
               ),
               env: Object.fromEntries(
-                ids.slice(0, 7).map((id, i) => [
+                ids.slice(0, 19).map((id, i) => [
                   id,
                   Cloudflare.DurableObject(id, {
                     className: i === 0 ? "Class0V2" : `Class${i}`,

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerProvider.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerProvider.test.ts
@@ -1,4 +1,8 @@
-import { normalizeStateDomains } from "@/Cloudflare/Workers/WorkerProvider";
+import {
+  encodeDurableObjectTags,
+  getDurableObjectTagMap,
+  normalizeStateDomains,
+} from "@/Cloudflare/Workers/WorkerProvider";
 import { describe, expect, test } from "@effect/vitest";
 
 describe("WorkerProvider", () => {
@@ -57,6 +61,129 @@ describe("WorkerProvider", () => {
 
     test("returns an empty array for undefined state", () => {
       expect(normalizeStateDomains(undefined)).toEqual([]);
+    });
+  });
+
+  // Cloudflare allows at most 10 tags per worker and 1024 bytes per tag, so
+  // the DO logical-id→class mapping is packed into `alchemy:dos:` tags
+  // instead of one `alchemy:do:` tag per binding (#811).
+  describe("durable object tags", () => {
+    test("packs all mappings into a single tag", () => {
+      expect(
+        encodeDurableObjectTags([
+          { logicalId: "Counter", className: "Counter" },
+          { logicalId: "Meter", className: "MeterV2" },
+        ]),
+      ).toEqual(["alchemy:dos:Counter;Meter=MeterV2"]);
+    });
+
+    test("elides the class name when it equals the logical id", () => {
+      expect(
+        encodeDurableObjectTags([{ logicalId: "A", className: "A" }]),
+      ).toEqual(["alchemy:dos:A"]);
+    });
+
+    test("output is deterministic regardless of input order", () => {
+      const forward = encodeDurableObjectTags([
+        { logicalId: "A", className: "A1" },
+        { logicalId: "B", className: "B1" },
+      ]);
+      const reverse = encodeDurableObjectTags([
+        { logicalId: "B", className: "B1" },
+        { logicalId: "A", className: "A1" },
+      ]);
+      expect(forward).toEqual(reverse);
+    });
+
+    test("round-trips through the parser", () => {
+      const mappings = Array.from({ length: 25 }, (_, i) => ({
+        logicalId: `binding-${i}`,
+        className: `ClassName${i}`,
+      }));
+      expect(getDurableObjectTagMap(encodeDurableObjectTags(mappings))).toEqual(
+        Object.fromEntries(
+          mappings.map(({ logicalId, className }) => [logicalId, className]),
+        ),
+      );
+    });
+
+    test("escapes separators and Cloudflare-forbidden characters", () => {
+      const mappings = [
+        { logicalId: "a;b", className: "C1" },
+        { logicalId: "a=b", className: "C2" },
+        { logicalId: "a,b&c", className: "C3" },
+        { logicalId: "a:b", className: "C4" },
+      ];
+      const tags = encodeDurableObjectTags(mappings);
+      for (const tag of tags) {
+        expect(tag).not.toContain(",");
+        expect(tag).not.toContain("&");
+      }
+      expect(getDurableObjectTagMap(tags)).toEqual({
+        "a;b": "C1",
+        "a=b": "C2",
+        "a,b&c": "C3",
+        "a:b": "C4",
+      });
+    });
+
+    test("splits into multiple tags at the 1024-byte limit", () => {
+      const mappings = Array.from({ length: 100 }, (_, i) => ({
+        logicalId: `some-durable-object-binding-${i}`,
+        className: `SomeDurableObjectClassName${i}`,
+      }));
+      const tags = encodeDurableObjectTags(mappings);
+      expect(tags.length).toBeGreaterThan(1);
+      for (const tag of tags) {
+        expect(tag.length).toBeLessThanOrEqual(1024);
+        expect(tag.startsWith("alchemy:dos:")).toBe(true);
+      }
+      expect(getDurableObjectTagMap(tags)).toEqual(
+        Object.fromEntries(
+          mappings.map(({ logicalId, className }) => [logicalId, className]),
+        ),
+      );
+    });
+
+    test("unicode identifiers stay within the byte limit", () => {
+      const mappings = Array.from({ length: 40 }, (_, i) => ({
+        logicalId: `对象-${i}`,
+        className: `Class_${i}`,
+      }));
+      const tags = encodeDurableObjectTags(mappings);
+      const encoder = new TextEncoder();
+      for (const tag of tags) {
+        expect(encoder.encode(tag).length).toBeLessThanOrEqual(1024);
+      }
+      expect(getDurableObjectTagMap(tags)).toEqual(
+        Object.fromEntries(
+          mappings.map(({ logicalId, className }) => [logicalId, className]),
+        ),
+      );
+    });
+
+    test("parses legacy per-DO alchemy:do: tags", () => {
+      expect(
+        getDurableObjectTagMap([
+          "alchemy:stack:app",
+          "alchemy:do:Counter:CounterV2",
+          "alchemy:do:Meter:Meter",
+          "user-tag",
+        ]),
+      ).toEqual({ Counter: "CounterV2", Meter: "Meter" });
+    });
+
+    test("packed entries win over legacy entries for the same logical id", () => {
+      expect(
+        getDurableObjectTagMap([
+          "alchemy:do:Counter:OldClass",
+          "alchemy:dos:Counter=NewClass",
+        ]),
+      ).toEqual({ Counter: "NewClass" });
+    });
+
+    test("returns an empty map when no DO tags are present", () => {
+      expect(getDurableObjectTagMap(["alchemy:stack:app", "user"])).toEqual({});
     });
   });
 });


### PR DESCRIPTION
Fixes #811. One script tag per Durable Object binding blew Cloudflare's 10-tag-per-Worker limit at 7+ DOs. All logical-id→class mappings are now packed into a single `alchemy:dos:` tag.

```diff
- alchemy:do:Counter:Counter
- alchemy:do:Meter:MeterV2
- alchemy:do:Session:Session
+ alchemy:dos:Counter;Meter=MeterV2;Session
```

Pairs are `logicalId=className`, elided to just the name when equal (the common case), `encodeURIComponent`-escaped so the `;`/`=` separators and Cloudflare's forbidden tag characters can never collide with identifiers, sorted for determinism, and greedily split into additional `alchemy:dos:` tags at the byte limit.

### Empirical limits (probed against the live API)

- **10 tags** per Worker — the 11th is rejected with `Forbidden`
- **1024 bytes** per tag — `BadRequest: Tag is too large` at 1025
- only `,` and `&` are forbidden characters; `:` `;` `=` `/` spaces and unicode round-trip intact

With 4 reserved tags (3 ownership + 1 migration) and zero user tags, that leaves 6 slots × 1012 payload bytes ≈ **~290–350 DOs** with typical class names — beyond Cloudflare's own [500 DO classes per account](https://developers.cloudflare.com/durable-objects/platform/limits/) ceiling, versus the previous cap of 6.

### Roll-forward

`getDurableObjectTagMap` parses both formats (packed entries win per logical id), so workers last deployed with per-DO tags reconcile correctly and get rewritten in the packed format on their next deploy. Verified live: deploy → rewrite tags to the legacy format out-of-band → redeploy with a class rename succeeds and repacks.

### Fail fast

Tag sets that still violate the limits (e.g. too many user `tags`) now fail before upload with a typed `InvalidWorkerTags` error explaining the budget, instead of Cloudflare's raw `Forbidden` at PUT time.

### Tests

- unit: encode/parse round-trip, elision, determinism, escaping, byte-limit splitting, unicode, legacy parsing, precedence
- live: a Worker with 8 DO bindings deploys, renames a class, and deletes another (previously failed with `exceeded the limit of 10 tags`); legacy-tag roll-forward with a class rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)
