### PR TITLE
fix(planetscale): reconcile MySQL replicas without replacing database

### DIFF
--- a/packages/alchemy/src/Planetscale/Database.ts
+++ b/packages/alchemy/src/Planetscale/Database.ts
@@ -29,7 +29,8 @@ export interface BaseDatabaseProps {
 
   /**
    * Number of replicas for the database. `0` for non-HA, `2+` for HA.
-   * Create-only.
+   * Create-only for PostgreSQL databases; MySQL databases reconcile
+   * changes in place ({@link MySQLDatabaseProps.replicas}).
    */
   replicas?: number;
 

--- a/packages/alchemy/src/Planetscale/MySQL/MySQLClusterSize.ts
+++ b/packages/alchemy/src/Planetscale/MySQL/MySQLClusterSize.ts
@@ -1,6 +1,7 @@
 import * as ops from "@distilled.cloud/planetscale/Operations";
 import * as Effect from "effect/Effect";
-import { pollUntil } from "../Util.ts";
+import * as Schedule from "effect/Schedule";
+import { PlanetscaleConflict, pollUntil } from "../Util.ts";
 
 /**
  * Available PlanetScale MySQL (Vitess) cluster sizes.
@@ -55,15 +56,15 @@ export const waitForKeyspaceReady = Effect.fn(function* (
 });
 
 /**
- * Ensures the default keyspace of a MySQL production branch has the
- * expected cluster size, triggering a resize if it doesn't. Cluster sizes
- * can only be configured on production branches.
+ * Observes the default keyspace of a branch. The default keyspace usually
+ * shares the database's name, but a renamed database keeps its original
+ * keyspace name, so prefer the `default` flag and fall back to name
+ * matching.
  */
-export const ensureMySQLProductionBranchClusterSize = Effect.fn(function* (
+const observeDefaultKeyspace = Effect.fn(function* (
   organization: string,
   database: string,
   branch: string,
-  expectedClusterSize: MySQLClusterSize,
 ) {
   const keyspaces = yield* ops.listKeyspaces({
     organization,
@@ -72,31 +73,129 @@ export const ensureMySQLProductionBranchClusterSize = Effect.fn(function* (
     page: 1,
     per_page: 100,
   });
-  // Default keyspace is always the same name as the database.
-  const defaultKeyspace = keyspaces.data.find((x) => x.name === database);
-  if (!defaultKeyspace) {
+  return (
+    keyspaces.data.find((x) => x.default) ??
+    keyspaces.data.find((x) => x.name === database)
+  );
+});
+
+/**
+ * Observes the total replica count of a branch's default keyspace, or
+ * `undefined` when the branch or keyspace does not exist (yet).
+ */
+export const observeDefaultKeyspaceReplicas = Effect.fn(function* (
+  organization: string,
+  database: string,
+  branch: string,
+) {
+  return yield* observeDefaultKeyspace(organization, database, branch).pipe(
+    Effect.map((keyspace) => keyspace?.replicas),
+    Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
+  );
+});
+
+/**
+ * Ensures the default keyspace of a MySQL production branch has the
+ * expected cluster size and (optionally) total replica count, driving
+ * PlanetScale's in-place keyspace resize lifecycle when it doesn't.
+ * Cluster sizes can only be configured on production branches. Returns
+ * the final observed keyspace.
+ */
+export const ensureMySQLProductionBranchClusterSize = Effect.fn(function* (
+  organization: string,
+  database: string,
+  branch: string,
+  expectedClusterSize: MySQLClusterSize,
+  expectedReplicas?: number,
+) {
+  let keyspace = yield* observeDefaultKeyspace(organization, database, branch);
+  if (!keyspace) {
     return yield* Effect.die(`No default keyspace found for branch ${branch}`);
   }
 
-  yield* waitForKeyspaceReady(
-    organization,
-    database,
-    branch,
-    defaultKeyspace.name,
-  );
+  yield* waitForKeyspaceReady(organization, database, branch, keyspace.name);
 
-  if (defaultKeyspace.cluster_name !== expectedClusterSize) {
+  if (keyspace.cluster_name !== expectedClusterSize) {
     yield* ops.updateBranchClusterConfig({
       organization,
       database,
       branch,
       cluster_size: expectedClusterSize,
     });
-    yield* waitForKeyspaceReady(
-      organization,
-      database,
-      branch,
-      defaultKeyspace.name,
-    );
+    yield* waitForKeyspaceReady(organization, database, branch, keyspace.name);
+    // Re-observe so the replica sync below diffs against the post-resize
+    // keyspace state.
+    keyspace =
+      (yield* observeDefaultKeyspace(organization, database, branch)) ??
+      keyspace;
   }
+
+  // Sync replicas — MySQL databases cannot configure replicas at
+  // creation time (the API rejects the `replicas` param for mysql), so
+  // the desired total replica count is converged in place via a keyspace
+  // resize request.
+  if (
+    expectedReplicas !== undefined &&
+    keyspace.replicas !== expectedReplicas
+  ) {
+    // Each cluster size includes a fixed number of replicas (2 for
+    // production PS_* sizes); the resize API only accepts the count of
+    // additional replicas beyond that.
+    const includedReplicas = keyspace.replicas - keyspace.extra_replicas;
+    const extraReplicas = expectedReplicas - includedReplicas;
+    if (extraReplicas < 0) {
+      return yield* Effect.fail(
+        new PlanetscaleConflict({
+          message:
+            `Cannot set replicas to ${expectedReplicas} on keyspace "${keyspace.name}": ` +
+            `cluster size ${keyspace.cluster_name} always includes ${includedReplicas} replicas. ` +
+            `Set replicas to ${includedReplicas} or more (or omit it).`,
+        }),
+      );
+    }
+
+    const resize = yield* ops
+      .createKeyspaceResizeRequest({
+        organization,
+        database,
+        branch,
+        keyspace: keyspace.name,
+        extra_replicas: extraReplicas,
+      })
+      .pipe(
+        // A prior resize (e.g. the cluster-size change above) can still
+        // be finalizing after the keyspace reports `resizing: false`;
+        // PlanetScale rejects new resize requests during that window.
+        Effect.retry({
+          while: (e): boolean =>
+            e._tag === "UnprocessableEntity" &&
+            e.message.includes("resize in progress"),
+          schedule: Schedule.max([
+            Schedule.spaced("5 seconds"),
+            Schedule.recurs(120),
+          ]),
+        }),
+      );
+
+    yield* pollUntil(
+      `keyspace "${keyspace.name}" resize completed`,
+      ops.listKeyspaceResizeRequests({
+        organization,
+        database,
+        branch,
+        keyspace: keyspace.name,
+      }),
+      (page) => {
+        const request = page.data.find((r) => r.id === resize.id);
+        // If the request is missing, treat as settled (caller re-observes).
+        return request ? request.state === "completed" : true;
+      },
+    );
+
+    keyspace =
+      (yield* observeDefaultKeyspace(organization, database, branch)) ??
+      keyspace;
+  }
+
+  return keyspace;
 });

--- a/packages/alchemy/src/Planetscale/MySQL/MySQLDatabase.ts
+++ b/packages/alchemy/src/Planetscale/MySQL/MySQLDatabase.ts
@@ -18,6 +18,7 @@ import {
 } from "../Util.ts";
 import {
   ensureMySQLProductionBranchClusterSize,
+  observeDefaultKeyspaceReplicas,
   type MySQLClusterSize,
 } from "./MySQLClusterSize.ts";
 import { runMySQLImports, runMySQLMigrations } from "./MySQLMigrations.ts";
@@ -31,6 +32,16 @@ export interface MySQLDatabaseProps extends BaseDatabaseProps {
    * @see https://planetscale.com/docs/concepts/cluster-size
    */
   clusterSize: MySQLClusterSize;
+
+  /**
+   * Desired total number of replicas for the database's default keyspace.
+   * Each cluster size includes a fixed number of replicas (2 for
+   * production `PS_*` sizes); higher values add extra replicas. Changes
+   * are reconciled in place via PlanetScale's keyspace resize lifecycle —
+   * never by replacing the database.
+   * @see https://planetscale.com/docs/vitess/sharding/keyspaces
+   */
+  replicas?: number;
 
   /**
    * Whether to copy migration data to new branches and in deploy requests.
@@ -67,6 +78,12 @@ export interface MySQLDatabaseProps extends BaseDatabaseProps {
  * Output attributes of a deployed MySQL PlanetScale database.
  */
 export interface MySQLDatabaseAttributes extends BaseDatabaseAttributes {
+  /**
+   * Observed total replica count of the default keyspace on the default
+   * branch, or `undefined` while the keyspace is still provisioning.
+   */
+  replicas: number | undefined;
+
   /**
    * Whether to copy migration data to new branches and in deploy requests.
    */
@@ -168,8 +185,14 @@ export const MySQLDatabaseProvider = () =>
       ) {
         return { action: "replace" } as const;
       }
-      if (news.replicas !== olds.replicas) {
-        return { action: "replace" } as const;
+      // Replicas reconcile in place via a keyspace resize — never a
+      // replacement. Diff against the observed keyspace replica count so
+      // an adopted database whose live state already matches plans no-op.
+      if (
+        news.replicas !== undefined &&
+        news.replicas !== (output?.replicas ?? olds.replicas)
+      ) {
+        return { action: "update" } as const;
       }
       if (news.migrationsDir) {
         const newHashes = yield* hashMigrations(news.migrationsDir);
@@ -203,46 +226,57 @@ export const MySQLDatabaseProvider = () =>
           database: databaseName,
         })
         .pipe(
-          Effect.flatMap((data) => {
-            if (data.kind !== "mysql") {
-              return Effect.fail(
-                new PlanetscaleConflict({
-                  message:
-                    `Planetscale database "${data.name}" has kind "${data.kind}" but this resource ` +
-                    `is a MySQLDatabase. Use Planetscale.${data.kind === "postgresql" ? "PostgresDatabase" : data.kind}() instead, ` +
-                    `or delete the existing database and retry.`,
-                }),
+          Effect.flatMap(
+            Effect.fn(function* (data) {
+              if (data.kind !== "mysql") {
+                return yield* Effect.fail(
+                  new PlanetscaleConflict({
+                    message:
+                      `Planetscale database "${data.name}" has kind "${data.kind}" but this resource ` +
+                      `is a MySQLDatabase. Use Planetscale.${data.kind === "postgresql" ? "PostgresDatabase" : data.kind}() instead, ` +
+                      `or delete the existing database and retry.`,
+                  }),
+                );
+              }
+              // Observe the default keyspace's live replica configuration
+              // so adopted databases diff against reality.
+              const replicas = yield* observeDefaultKeyspaceReplicas(
+                organization,
+                data.name,
+                data.default_branch ?? "main",
               );
-            }
-            return Effect.succeed({
-              id: data.id,
-              name: data.name,
-              organization,
-              state: data.state,
-              defaultBranch: data.default_branch ?? "main",
-              plan: data.plan ?? "hobby",
-              createdAt: data.created_at,
-              updatedAt: data.updated_at,
-              htmlUrl: data.html_url,
-              region: { slug: data.region.slug },
-              migrationsDir: output?.migrationsDir ?? olds?.migrationsDir,
-              migrationsTable: output?.migrationsTable ?? olds?.migrationsTable,
-              migrationsHashes: output?.migrationsHashes ?? {},
-              importHashes: output?.importHashes ?? {},
-              clusterSize: output?.clusterSize ?? "",
-              requireApprovalForDeploy:
-                data.require_approval_for_deploy ?? false,
-              restrictBranchRegion: data.restrict_branch_region ?? false,
-              insightsRawQueries: data.insights_raw_queries ?? false,
-              productionBranchWebConsole:
-                data.production_branch_web_console ?? false,
-              automaticMigrations: data.automatic_migrations ?? false,
-              migrationFramework: data.migration_framework ?? undefined,
-              migrationTableName: data.migration_table_name ?? undefined,
-              allowDataBranching: data.allow_data_branching ?? false,
-              allowForeignKeyConstraints: data.foreign_keys_enabled ?? false,
-            });
-          }),
+              return {
+                id: data.id,
+                name: data.name,
+                organization,
+                state: data.state,
+                defaultBranch: data.default_branch ?? "main",
+                replicas,
+                plan: data.plan ?? "hobby",
+                createdAt: data.created_at,
+                updatedAt: data.updated_at,
+                htmlUrl: data.html_url,
+                region: { slug: data.region.slug },
+                migrationsDir: output?.migrationsDir ?? olds?.migrationsDir,
+                migrationsTable:
+                  output?.migrationsTable ?? olds?.migrationsTable,
+                migrationsHashes: output?.migrationsHashes ?? {},
+                importHashes: output?.importHashes ?? {},
+                clusterSize: output?.clusterSize ?? "",
+                requireApprovalForDeploy:
+                  data.require_approval_for_deploy ?? false,
+                restrictBranchRegion: data.restrict_branch_region ?? false,
+                insightsRawQueries: data.insights_raw_queries ?? false,
+                productionBranchWebConsole:
+                  data.production_branch_web_console ?? false,
+                automaticMigrations: data.automatic_migrations ?? false,
+                migrationFramework: data.migration_framework ?? undefined,
+                migrationTableName: data.migration_table_name ?? undefined,
+                allowDataBranching: data.allow_data_branching ?? false,
+                allowForeignKeyConstraints: data.foreign_keys_enabled ?? false,
+              };
+            }),
+          ),
           Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
         );
     }),
@@ -272,13 +306,14 @@ export const MySQLDatabaseProvider = () =>
       // Ensure — if missing, create.
       if (!observed) {
         yield* session.note("Creating database...");
+        // Note: the API rejects the `replicas` param for mysql databases;
+        // replicas are converged below via the keyspace resize lifecycle.
         observed = yield* planetscale.createDatabase({
           organization,
           name: newName,
           region: news.region?.slug,
           kind: "mysql",
           cluster_size: clusterSize,
-          replicas: news.replicas,
         });
       }
 
@@ -345,13 +380,16 @@ export const MySQLDatabaseProvider = () =>
         default_branch: news.defaultBranch,
       });
 
-      // Sync cluster size on the active default branch.
+      // Sync cluster size and replicas on the active default branch —
+      // both converge in place via PlanetScale's keyspace resize
+      // lifecycle, diffed against the observed default keyspace.
       const branch = news.defaultBranch ?? updated.default_branch ?? "main";
-      yield* ensureMySQLProductionBranchClusterSize(
+      const keyspace = yield* ensureMySQLProductionBranchClusterSize(
         organization,
         updated.name,
         branch,
         news.clusterSize,
+        news.replicas,
       );
 
       const migrationTarget = {
@@ -394,6 +432,7 @@ export const MySQLDatabaseProvider = () =>
         htmlUrl: updated.html_url,
         region: { slug: updated.region.slug },
         clusterSize,
+        replicas: keyspace.replicas,
         migrationsDir: news.migrationsDir,
         migrationsTable: news.migrationsDir ? migrationsTable : undefined,
         migrationsHashes,
@@ -445,6 +484,7 @@ export const MySQLDatabaseProvider = () =>
                 migrationsHashes: {},
                 importHashes: {},
                 clusterSize: "",
+                replicas: undefined,
                 requireApprovalForDeploy:
                   data.require_approval_for_deploy ?? false,
                 restrictBranchRegion: data.restrict_branch_region ?? false,

--- a/packages/alchemy/test/Planetscale/MySQL/MySQLDatabase.test.ts
+++ b/packages/alchemy/test/Planetscale/MySQL/MySQLDatabase.test.ts
@@ -235,6 +235,65 @@ describe
     );
 
     test.provider(
+      "reconciles replicas in place via keyspace resize",
+      (stack) =>
+        Effect.gen(function* () {
+          yield* stack.destroy();
+
+          const { database } = yield* stack.deploy(
+            Effect.gen(function* () {
+              const database = yield* Planetscale.MySQLDatabase(
+                "MySQLDatabaseReplicas",
+                {
+                  clusterSize: "PS_10",
+                  replicas: 3,
+                },
+              );
+              return { database };
+            }),
+          );
+
+          // PS_10 includes 2 replicas; the third is added in place via a
+          // keyspace resize request after creation.
+          expect(database.replicas).toEqual(3);
+
+          const keyspaces = yield* ops.listKeyspaces({
+            organization: database.organization,
+            database: database.name,
+            branch: "main",
+          });
+          const keyspace = keyspaces.data.find((x) => x.name === database.name);
+          expect(keyspace?.replicas).toEqual(3);
+          expect(keyspace?.extra_replicas).toEqual(1);
+
+          // Scale back down — must resize in place, never replace.
+          const { updatedDatabase } = yield* stack.deploy(
+            Effect.gen(function* () {
+              const updatedDatabase = yield* Planetscale.MySQLDatabase(
+                "MySQLDatabaseReplicas",
+                {
+                  clusterSize: "PS_10",
+                  replicas: 2,
+                },
+              );
+              return { updatedDatabase };
+            }),
+          );
+
+          expect(updatedDatabase.id).toEqual(database.id);
+          expect(updatedDatabase.replicas).toEqual(2);
+
+          yield* stack.destroy();
+
+          yield* waitForDatabaseToBeDeleted(
+            database.name,
+            database.organization,
+          );
+        }).pipe(logLevel),
+      5_000_000,
+    );
+
+    test.provider(
       "creates non-main default branch if specified",
       (stack) =>
         Effect.gen(function* () {


### PR DESCRIPTION
Reconcile `MySQLDatabase.replicas` in place through PlanetScale's keyspace resize lifecycle instead of replacing the database. Closes #814.

```diff
 diff: Effect.fn(function* ({ news, olds, output }) {
-  if (news.replicas !== olds.replicas) {
-    return { action: "replace" } as const;
-  }
+  // Replicas reconcile in place via a keyspace resize — never a
+  // replacement. Diff against the observed keyspace replica count so
+  // an adopted database whose live state already matches plans no-op.
+  if (
+    news.replicas !== undefined &&
+    news.replicas !== (output?.replicas ?? olds.replicas)
+  ) {
+    return { action: "update" } as const;
+  }
```

- `read` now observes the default keyspace's live replica count and exposes it as a new `replicas` attribute, so adopted databases diff against reality.
- `reconcile` no longer passes `replicas` to `createDatabase` — the API rejects it for mysql databases (422 `Replicas param is not supported for mysql databases`), so the previous replace-then-create path could never have applied it. Instead, `ensureMySQLProductionBranchClusterSize` now also converges the total replica count via `PUT .../keyspaces/{keyspace}/resizes` (`extra_replicas` = desired − included-by-cluster-size), retrying the resize-in-progress finalization window and polling the resize request until `completed`.
- Desired replicas below the cluster size's included count (2 for production `PS_*` sizes) fail with a typed `PlanetscaleConflict`.
- distilled: adds `createKeyspaceResizeRequest` / `listKeyspaceResizeRequests` / `cancelKeyspaceResizeRequest` (alchemy-run/distilled#376), shapes captured from live API responses.

Verified live: deploy with `replicas: 3` (create + in-place resize up), scale down to `replicas: 2`, database `id` stable across both — never replaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
