### PR TITLE
fix(drizzle): forward Effect membership checks through proxyChain

### DIFF
--- a/packages/alchemy/src/Util/proxy-chain.ts
+++ b/packages/alchemy/src/Util/proxy-chain.ts
@@ -71,6 +71,9 @@ const chain = (
       }
       return chain(cached, [...ops, { kind: "get", prop }]);
     },
+    has(target, prop) {
+      return Reflect.has(target, prop) || Reflect.has(effect, prop);
+    },
     apply(_, __, args) {
       return chain(cached, [...ops, { kind: "call", args }]);
     },

--- a/packages/alchemy/test/Util/proxy-chain.test.ts
+++ b/packages/alchemy/test/Util/proxy-chain.test.ts
@@ -112,6 +112,26 @@ describe("proxyChain", () => {
     }),
   );
 
+  it.effect("is recognized by predicate-dispatched Effect operators", () =>
+    Effect.gen(function* () {
+      const api = proxyChain(
+        Effect.succeed({
+          transaction: () => Effect.fail({ _tag: "TestError" } as const),
+        }),
+      );
+
+      const transaction = api.transaction();
+
+      expect(Effect.isEffect(transaction)).toBe(true);
+
+      const result = yield* transaction.pipe(
+        Effect.catchTag("TestError", () => Effect.succeed("recovered")),
+      );
+
+      expect(result).toBe("recovered");
+    }),
+  );
+
   it.effect("a `.pipe`-d chain still composes inside Effect.all", () =>
     Effect.gen(function* () {
       const db = proxyChain<Db>(Effect.succeed(makeDb()));


### PR DESCRIPTION
`proxyChain` forwards property reads from its backing Effect, but `Effect.isEffect` checks `EffectTypeId` using the `in` operator.

Without a Proxy `has` trap, chained values expose Effect properties such as `pipe` and `Symbol.iterator` while still failing `Effect.isEffect`. Predicate-dispatched operators such as `Effect.catchTag` consequently return a curried function instead of an Effect.

This completes the Effect identity forwarding introduced in [#750](https://github.com/alchemy-run/alchemy-effect/pull/750).

```ts
has(target, prop) {
  return Reflect.has(target, prop) || Reflect.has(effect, prop)
}
```

Adds regression coverage for `Effect.isEffect` and `Effect.catchTag`.