### PR TITLE
test(cloudflare): reproduce numeric D1 local bind failure

### DIFF
--- a/packages/alchemy/test/Cloudflare/D1/QueryDatabaseLocal.test.ts
+++ b/packages/alchemy/test/Cloudflare/D1/QueryDatabaseLocal.test.ts
@@ -61,10 +61,16 @@ test.provider(
                   .bind("1")
                   .first<string>("name");
 
+                const numericBind = yield* db
+                  .prepare("SELECT ? AS value")
+                  .bind(42)
+                  .first<number>("value");
+
                 return {
                   databaseId: yield* databaseId,
                   users: rows.results,
                   first,
+                  numericBind,
                 };
               });
             }).pipe(Effect.provide(Cloudflare.D1.QueryDatabaseLocal)),
@@ -80,6 +86,7 @@ test.provider(
         { id: "2", name: "Grace" },
       ]);
       expect(out.first).toBe("Ada");
+      expect(out.numericBind).toBe(42);
 
       yield* stack.destroy();
     }).pipe(logLevel),

--- a/packages/alchemy/test/Cloudflare/D1/QueryDatabaseLocal.test.ts
+++ b/packages/alchemy/test/Cloudflare/D1/QueryDatabaseLocal.test.ts
@@ -86,7 +86,8 @@ test.provider(
   { timeout: 120_000 },
 );
 
-// Expected to fail until D1 request parameters support numeric values.
+// Expected to fail before reaching D1: Distilled validates params as string[],
+// so .bind(42) throws "Expected string, got 42" during request encoding.
 test.provider(
   "QueryDatabaseLocal: binds numeric prepared-statement parameters",
   (stack) =>
@@ -97,14 +98,13 @@ test.provider(
         Effect.gen(function* () {
           const database = yield* Cloudflare.D1.Database("NumericBindDatabase");
 
-          // Exercise the Local binding inside an Action, matching its intended use.
           const Query = Action(
             "QueryNumericBind",
             Effect.gen(function* () {
               const db = yield* Cloudflare.D1.QueryDatabase(database);
 
               return Effect.fn(function* () {
-                // Select the parameter directly to isolate binding from table schema.
+                // Selecting the parameter directly rules out table schema or seed behavior.
                 return yield* db
                   .prepare("SELECT ? AS value")
                   .bind(42)

--- a/packages/alchemy/test/Cloudflare/D1/QueryDatabaseLocal.test.ts
+++ b/packages/alchemy/test/Cloudflare/D1/QueryDatabaseLocal.test.ts
@@ -97,12 +97,14 @@ test.provider(
         Effect.gen(function* () {
           const database = yield* Cloudflare.D1.Database("NumericBindDatabase");
 
+          // Exercise the Local binding inside an Action, matching its intended use.
           const Query = Action(
             "QueryNumericBind",
             Effect.gen(function* () {
               const db = yield* Cloudflare.D1.QueryDatabase(database);
 
               return Effect.fn(function* () {
+                // Select the parameter directly to isolate binding from table schema.
                 return yield* db
                   .prepare("SELECT ? AS value")
                   .bind(42)

--- a/packages/alchemy/test/Cloudflare/D1/QueryDatabaseLocal.test.ts
+++ b/packages/alchemy/test/Cloudflare/D1/QueryDatabaseLocal.test.ts
@@ -61,16 +61,10 @@ test.provider(
                   .bind("1")
                   .first<string>("name");
 
-                const numericBind = yield* db
-                  .prepare("SELECT ? AS value")
-                  .bind(42)
-                  .first<number>("value");
-
                 return {
                   databaseId: yield* databaseId,
                   users: rows.results,
                   first,
-                  numericBind,
                 };
               });
             }).pipe(Effect.provide(Cloudflare.D1.QueryDatabaseLocal)),
@@ -86,7 +80,42 @@ test.provider(
         { id: "2", name: "Grace" },
       ]);
       expect(out.first).toBe("Ada");
-      expect(out.numericBind).toBe(42);
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 120_000 },
+);
+
+// Expected to fail until D1 request parameters support numeric values.
+test.provider(
+  "QueryDatabaseLocal: binds numeric prepared-statement parameters",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const out = yield* stack.deploy(
+        Effect.gen(function* () {
+          const database = yield* Cloudflare.D1.Database("NumericBindDatabase");
+
+          const Query = Action(
+            "QueryNumericBind",
+            Effect.gen(function* () {
+              const db = yield* Cloudflare.D1.QueryDatabase(database);
+
+              return Effect.fn(function* () {
+                return yield* db
+                  .prepare("SELECT ? AS value")
+                  .bind(42)
+                  .first<number>("value");
+              });
+            }).pipe(Effect.provide(Cloudflare.D1.QueryDatabaseLocal)),
+          );
+
+          return yield* Query({});
+        }),
+      );
+
+      expect(out).toBe(42);
 
       yield* stack.destroy();
     }).pipe(logLevel),


### PR DESCRIPTION
## Summary

- add a dedicated provider test for numeric prepared-statement parameters in `QueryDatabaseLocal`
- use `SELECT ? AS value` so the failure is isolated from table schema and seed behavior

## Expected failure

This draft intentionally fails against the current PR #807 implementation:

```text
SchemaError: Expected string, got 42
  at ["params"][0]
```

`PreparedStatement.bind` accepts native D1 values, but the pinned Distilled D1 request schema models both single and batch `params` as `string[]`. The failure occurs during request encoding, before the query reaches Cloudflare.

## Verification

```sh
timeout 240s bun vitest run test/Cloudflare/D1/QueryDatabaseLocal.test.ts
```

The existing string-parameter test passes. The dedicated numeric-parameter test creates its temporary D1 database, reaches the Action, fails on `.bind(42)` as expected, and deletes the database during cleanup.

This PR is stacked on #807 as an executable reproduction; it should become green when the Distilled D1 parameter schema and Local normalization support native D1 values.
