### PR TITLE
fix(runtime): reify auto-bound Config markers at request time

### DIFF
--- a/packages/alchemy/src/AWS/EC2/hosted.ts
+++ b/packages/alchemy/src/AWS/EC2/hosted.ts
@@ -188,6 +188,7 @@ export const createEc2HostedSupport = ({
 import { BunServices } from "@effect/platform-bun";
 import { BunHttpServer } from "alchemy/Http";
 import { Stack } from "alchemy/Stack";
+import { reifyBoundConfigProvider } from "alchemy/Runtime";
 import * as Config from "effect/Config";
 import * as ConfigProvider from "effect/ConfigProvider";
 import * as Credentials from "@distilled.cloud/aws/Credentials";
@@ -233,7 +234,7 @@ const program = handler.pipe(
       Layer.provideMerge(
         Layer.succeed(
           ConfigProvider.ConfigProvider,
-          ConfigProvider.fromEnv()
+          reifyBoundConfigProvider(ConfigProvider.fromEnv(), process.env)
         )
       ),
     )

--- a/packages/alchemy/src/AWS/ECS/Task.ts
+++ b/packages/alchemy/src/AWS/ECS/Task.ts
@@ -585,6 +585,7 @@ export const TaskProvider = () =>
 import { BunServices } from "@effect/platform-bun";
 import { BunHttpServer } from "alchemy/Http";
 import { Stack } from "alchemy/Stack";
+import { reifyBoundConfigProvider } from "alchemy/Runtime";
 import * as Config from "effect/Config";
 import * as ConfigProvider from "effect/ConfigProvider";
 import * as Credentials from "@distilled.cloud/aws/Credentials";
@@ -630,7 +631,7 @@ const program = handler.pipe(
       Layer.provideMerge(
         Layer.succeed(
           ConfigProvider.ConfigProvider,
-          ConfigProvider.fromEnv()
+          reifyBoundConfigProvider(ConfigProvider.fromEnv(), process.env)
         )
       ),
     )

--- a/packages/alchemy/src/AWS/Lambda/Function.ts
+++ b/packages/alchemy/src/AWS/Lambda/Function.ts
@@ -940,7 +940,7 @@ export const FunctionProvider = () =>
                 (importPath) => `
 import { layer as nodeServicesLayer } from "@effect/platform-node/NodeServices";
 import { Stack } from "alchemy/Stack";
-import { makeEntrypointLayer } from "alchemy/Runtime";
+import { makeEntrypointLayer, reifyBoundConfigProvider } from "alchemy/Runtime";
 import { registerLambdaExtension } from "alchemy/AWS/Lambda/RuntimeExtension";
 import * as Config from "effect/Config";
 import * as ConfigProvider from "effect/ConfigProvider";
@@ -1001,7 +1001,10 @@ const entryLayer = layer.pipe(
   Layer.provideMerge(
     Layer.succeed(
       ConfigProvider.ConfigProvider,
-      ConfigProvider.fromEnv()
+      // Auto-bound \`Config\` values arrive in the env as
+      // \`{"_tag":"Redacted","value":...}\` markers; reify them so a \`Config\`
+      // re-read inside a handler decodes the raw source value.
+      reifyBoundConfigProvider(ConfigProvider.fromEnv(), process.env)
     )
   ),
   Layer.provideMerge(

--- a/packages/alchemy/src/AWS/Lambda/Function.ts
+++ b/packages/alchemy/src/AWS/Lambda/Function.ts
@@ -38,6 +38,7 @@ import { Platform, type Main, type PlatformProps } from "../../Platform.ts";
 import type { LogLine, LogsInput } from "../../Provider.ts";
 import * as Provider from "../../Provider.ts";
 import { Resource, type ResourceBinding } from "../../Resource.ts";
+import { packEnvValue, unpackEnvValue } from "../../RuntimeContext.ts";
 import { Self } from "../../Self.ts";
 import * as Serverless from "../../Serverless/index.ts";
 import { Stack } from "../../Stack.ts";
@@ -585,55 +586,17 @@ export const Function: Platform<
       set: (id: string, output: Output.Output) =>
         Effect.sync(() => {
           // Key is already canonical (see RuntimeContext.sanitizeKey); store it
-          // verbatim.
+          // verbatim. `packEnvValue` marker-packs Redacted values so they
+          // survive the Output → Lambda env var round-trip.
           const key = id;
-          // Preserve `Redacted`-ness across the Output → Lambda env var
-          // round-trip. `JSON.stringify(Redacted)` would emit the literal
-          // string `"<redacted>"` and lose the value, so secrets are
-          // serialized with a `{_tag: "Redacted", value: ...}` marker
-          // that the runtime `get` path detects and rebuilds.
-          env[key] = output.pipe(
-            Output.map((value) =>
-              Redacted.isRedacted(value)
-                ? JSON.stringify({
-                    _tag: "Redacted",
-                    value: Redacted.value(value),
-                  })
-                : JSON.stringify(value),
-            ),
-          );
+          env[key] = output.pipe(Output.map(packEnvValue));
           return key;
         }),
       get: <T>(key: string) =>
-        // Read the captured value straight from `process.env`. We must NOT
-        // resolve through `Config.string` here: at runtime the ambient
-        // `ConfigProvider` is the interceptor installed in `Platform.ts`,
-        // whose runtime branch calls back into `ctx.get(key)`. Going through
-        // `Config` would re-enter that interceptor for the same key and
-        // recurse forever, allocating until the Lambda init OOMs. The Worker
-        // runtime reads from `WorkerEnvironment` for the same reason.
-        Effect.sync(() => {
-          // Key is already canonical (see RuntimeContext.sanitizeKey).
-          const val = process.env[key];
-          if (val === undefined) {
-            return undefined;
-          }
-          try {
-            const value = JSON.parse(val);
-            if (
-              typeof value === "object" &&
-              value?._tag === "Redacted" &&
-              "value" in value
-            ) {
-              return Redacted.make(
-                (value as { value: unknown }).value,
-              ) as unknown as T;
-            }
-            return value as T;
-          } catch {
-            return val as unknown as T; // assume it's just a string
-          }
-        }),
+        // Key is already canonical (see RuntimeContext.sanitizeKey). Read
+        // straight from `process.env` — see `unpackEnvValue` for why this
+        // must never resolve through `Config.string`.
+        Effect.sync(() => unpackEnvValue<T>(process.env[key])),
       serve: (handler: HttpEffect) =>
         // @ts-ignore
         ctx.listen(makeFunctionHttpHandler(handler)),

--- a/packages/alchemy/src/AWS/Lambda/MicrovmRuntimeContext.ts
+++ b/packages/alchemy/src/AWS/Lambda/MicrovmRuntimeContext.ts
@@ -1,10 +1,12 @@
-import * as Config from "effect/Config";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
-import * as Redacted from "effect/Redacted";
 import { HttpServer, type HttpEffect } from "../../Http.ts";
 import * as Output from "../../Output.ts";
 import { serveRpc } from "../../Rpc.ts";
+import {
+  packEnvValueKeepRedacted,
+  unpackEnvValue,
+} from "../../RuntimeContext.ts";
 import * as Server from "../../Server/index.ts";
 
 export const MicrovmImageTypeId = "AWS.Lambda.MicrovmImage" as const;
@@ -49,45 +51,16 @@ export const makeMicrovmRuntimeContext = (
     set: (bindingId: string, output: Output.Output) =>
       Effect.sync(() => {
         const key = bindingId.replaceAll(/[^a-zA-Z0-9]/g, "_");
-        env[key] = output.pipe(
-          Output.map((value) =>
-            Redacted.isRedacted(value)
-              ? Redacted.make(
-                  JSON.stringify({
-                    _tag: "Redacted",
-                    value: Redacted.value(value),
-                  }),
-                )
-              : JSON.stringify(value),
-          ),
-        );
+        // `packEnvValueKeepRedacted` keeps the Redacted wrapper on the
+        // outside so deploy-time code can route secrets while the inner
+        // marker lets the runtime `get` accessor rebuild the wrapper.
+        env[key] = output.pipe(Output.map(packEnvValueKeepRedacted));
         return key;
       }),
     get: <T>(key: string) =>
-      Config.string(key).pipe(
-        Effect.flatMap((value) =>
-          Effect.try({
-            try: () => {
-              const parsed = JSON.parse(value) as T;
-              if (
-                typeof parsed === "object" &&
-                parsed !== null &&
-                (parsed as { _tag?: unknown })._tag === "Redacted" &&
-                "value" in parsed
-              ) {
-                return Redacted.make((parsed as { value: unknown }).value) as T;
-              }
-              return parsed;
-            },
-            catch: (error) => error as Error,
-          }),
-        ),
-        Effect.catch((cause) =>
-          Effect.die(
-            new Error(`Failed to get environment variable: ${key}`, { cause }),
-          ),
-        ),
-      ),
+      // Read straight from `process.env` — see `unpackEnvValue` for why
+      // this must never resolve through `Config.string`.
+      Effect.sync(() => unpackEnvValue<T>(process.env[key]) as T),
     run: ((effect: Effect.Effect<void, never, any>) =>
       Effect.sync(() => {
         runners.push(effect);

--- a/packages/alchemy/src/Cloudflare/Containers/ContainerBundle.ts
+++ b/packages/alchemy/src/Cloudflare/Containers/ContainerBundle.ts
@@ -199,8 +199,9 @@ const HttpServer = NodeHttpServer;
 `
 }
 import { Stack } from "alchemy/Stack";
-import { makeEntrypointLayer } from "alchemy/Runtime";
+import { makeEntrypointLayer, reifyBoundConfigProvider } from "alchemy/Runtime";
 import { CloudflareEnvironment } from "alchemy/Cloudflare";
+import * as ConfigProvider from "effect/ConfigProvider";
 import * as Effect from "effect/Effect";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import * as Layer from "effect/Layer";
@@ -249,6 +250,15 @@ const serverEffect = tag.pipe(
         )
       ),
       Layer.provideMerge(platform),
+      Layer.provideMerge(
+        Layer.succeed(
+          ConfigProvider.ConfigProvider,
+          // Auto-bound \`Config\` values arrive in the env as
+          // \`{"_tag":"Redacted","value":...}\` markers; reify them so a
+          // \`Config\` re-read inside a handler decodes the raw source value.
+          reifyBoundConfigProvider(ConfigProvider.fromEnv(), process.env)
+        )
+      ),
       Layer.provideMerge(
         Layer.succeed(
           MinimumLogLevel,

--- a/packages/alchemy/src/Cloudflare/Containers/ContainerPlatform.ts
+++ b/packages/alchemy/src/Cloudflare/Containers/ContainerPlatform.ts
@@ -1,4 +1,3 @@
-import * as Config from "effect/Config";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Redacted from "effect/Redacted";
@@ -91,38 +90,40 @@ export const ContainerPlatform: Platform<
             return key;
           }),
         get: <T>(key: string) =>
-          Config.string(key).pipe(
-            Effect.flatMap((value) =>
-              Effect.try({
-                try: () => {
-                  const parsed = JSON.parse(value) as T;
-                  // The `set` path serializes Redacted values as
-                  // `{_tag: "Redacted", value: ...}`. After JSON.parse the
-                  // result is a plain object — detect the marker shape and
-                  // rebuild the Redacted wrapper. Plain values pass through.
-                  if (
-                    typeof parsed === "object" &&
-                    parsed !== null &&
-                    (parsed as { _tag?: unknown })._tag === "Redacted" &&
-                    "value" in parsed
-                  ) {
-                    return Redacted.make(
-                      (parsed as { value: unknown }).value,
-                    ) as T;
-                  }
-                  return parsed;
-                },
-                catch: (error) => error as Error,
-              }),
-            ),
-            Effect.catch((cause) =>
-              Effect.die(
-                new Error(`Failed to get environment variable: ${key}`, {
-                  cause,
-                }),
-              ),
-            ),
-          ),
+          // Read the captured value straight from `process.env`. We must NOT
+          // resolve through `Config.string` here: the ambient
+          // `ConfigProvider` at runtime reifies bound values (unwrapping the
+          // `Redacted` marker before we could detect it), and during init it
+          // is the interceptor installed in `Platform.ts`, whose runtime
+          // branch calls back into `ctx.get(key)` — going through `Config`
+          // would re-enter it for the same key and recurse forever. Mirrors
+          // the Lambda and Worker contexts.
+          Effect.sync(() => {
+            const val = process.env[key];
+            if (val === undefined) {
+              return undefined as T;
+            }
+            try {
+              const parsed = JSON.parse(val);
+              // The `set` path serializes Redacted values as
+              // `{_tag: "Redacted", value: ...}`. After JSON.parse the
+              // result is a plain object — detect the marker shape and
+              // rebuild the Redacted wrapper. Plain values pass through.
+              if (
+                typeof parsed === "object" &&
+                parsed !== null &&
+                (parsed as { _tag?: unknown })._tag === "Redacted" &&
+                "value" in parsed
+              ) {
+                return Redacted.make(
+                  (parsed as { value: unknown }).value,
+                ) as unknown as T;
+              }
+              return parsed as T;
+            } catch {
+              return val as unknown as T; // assume it's just a string
+            }
+          }),
         run: ((effect: Effect.Effect<void, never, any>) =>
           Effect.sync(() => {
             runners.push(effect);

--- a/packages/alchemy/src/Cloudflare/Containers/ContainerPlatform.ts
+++ b/packages/alchemy/src/Cloudflare/Containers/ContainerPlatform.ts
@@ -1,10 +1,13 @@
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
-import * as Redacted from "effect/Redacted";
 import { HttpServer, type HttpEffect } from "../../Http.ts";
 import * as Output from "../../Output.ts";
 import { Platform } from "../../Platform.ts";
 import { serveRpc, type Rpc } from "../../Rpc.ts";
+import {
+  packEnvValueKeepRedacted,
+  unpackEnvValue,
+} from "../../RuntimeContext.ts";
 import * as Server from "../../Server/index.ts";
 import type { Fetcher } from "../Fetcher.ts";
 import { fromCloudflareFetcher, toCloudflareFetcher } from "../Fetcher.ts";
@@ -68,62 +71,20 @@ export const ContainerPlatform: Platform<
         set: (bindingId: string, output: Output.Output) =>
           Effect.sync(() => {
             const key = bindingId.replaceAll(/[^a-zA-Z0-9]/g, "_");
-            // Preserve `Redacted`-ness across the Output → env → Cloudflare
-            // boundary so the provider can deploy secrets through the
+            // `packEnvValueKeepRedacted` keeps the Redacted wrapper on the
+            // outside so the provider can deploy secrets through the
             // Secrets Store (referenced via `secrets`) instead of leaking
-            // them as plain `environmentVariables`. The JSON payload carries
-            // a `{_tag: "Redacted", …}` marker so the runtime `get` accessor
-            // can rebuild the wrapper after Cloudflare hands the value back
-            // as a plain env-var string. Mirrors `makeWorkerRuntimeContext`.
-            env[key] = output.pipe(
-              Output.map((value) =>
-                Redacted.isRedacted(value)
-                  ? Redacted.make(
-                      JSON.stringify({
-                        _tag: "Redacted",
-                        value: Redacted.value(value),
-                      }),
-                    )
-                  : JSON.stringify(value),
-              ),
-            );
+            // them as plain `environmentVariables`, while the inner marker
+            // lets the runtime `get` accessor rebuild the wrapper after
+            // Cloudflare hands the value back as a plain env-var string.
+            // Mirrors `makeWorkerRuntimeContext`.
+            env[key] = output.pipe(Output.map(packEnvValueKeepRedacted));
             return key;
           }),
         get: <T>(key: string) =>
-          // Read the captured value straight from `process.env`. We must NOT
-          // resolve through `Config.string` here: the ambient
-          // `ConfigProvider` at runtime reifies bound values (unwrapping the
-          // `Redacted` marker before we could detect it), and during init it
-          // is the interceptor installed in `Platform.ts`, whose runtime
-          // branch calls back into `ctx.get(key)` — going through `Config`
-          // would re-enter it for the same key and recurse forever. Mirrors
-          // the Lambda and Worker contexts.
-          Effect.sync(() => {
-            const val = process.env[key];
-            if (val === undefined) {
-              return undefined as T;
-            }
-            try {
-              const parsed = JSON.parse(val);
-              // The `set` path serializes Redacted values as
-              // `{_tag: "Redacted", value: ...}`. After JSON.parse the
-              // result is a plain object — detect the marker shape and
-              // rebuild the Redacted wrapper. Plain values pass through.
-              if (
-                typeof parsed === "object" &&
-                parsed !== null &&
-                (parsed as { _tag?: unknown })._tag === "Redacted" &&
-                "value" in parsed
-              ) {
-                return Redacted.make(
-                  (parsed as { value: unknown }).value,
-                ) as unknown as T;
-              }
-              return parsed as T;
-            } catch {
-              return val as unknown as T; // assume it's just a string
-            }
-          }),
+          // Read straight from `process.env` — see `unpackEnvValue` for why
+          // this must never resolve through `Config.string`.
+          Effect.sync(() => unpackEnvValue<T>(process.env[key]) as T),
         run: ((effect: Effect.Effect<void, never, any>) =>
           Effect.sync(() => {
             runners.push(effect);

--- a/packages/alchemy/src/Cloudflare/Workers/ConfigProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/ConfigProvider.ts
@@ -1,9 +1,23 @@
 import * as ConfigProvider from "effect/ConfigProvider";
 import * as Effect from "effect/Effect";
 
+import { reifyBoundConfigProvider } from "../../Runtime.ts";
 import cloudflare_workers from "./cloudflare_workers.ts";
 
+/**
+ * A `ConfigProvider` backed by the running Worker's environment.
+ *
+ * Values that were auto-bound by the deploy-time `Config` interceptor
+ * arrive in the env as `{"_tag":"Redacted","value":...}` markers; they are
+ * reified back to their raw source value before `Config` schemas decode
+ * them, matching the provider the Worker bridge installs by default.
+ */
 export const WorkerConfigProvider = () =>
   cloudflare_workers.pipe(
-    Effect.map(({ env }) => ConfigProvider.fromUnknown(env)),
+    Effect.map(({ env }) =>
+      reifyBoundConfigProvider(
+        ConfigProvider.fromUnknown(env),
+        env as Record<string, unknown>,
+      ),
+    ),
   );

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerBridge.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerBridge.ts
@@ -13,7 +13,10 @@ import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import * as EffectHttp from "effect/unstable/http/HttpEffect";
-import { makeEntrypointLayer } from "../../Runtime.ts";
+import {
+  makeEntrypointLayer,
+  reifyBoundConfigProvider,
+} from "../../Runtime.ts";
 import { Self } from "../../Self.ts";
 import { Stack } from "../../Stack.ts";
 import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
@@ -270,7 +273,14 @@ const getSharedBuild = (
               ConfigProvider.ConfigProvider,
               ConfigProvider.orElse(
                 ConfigProvider.fromUnknown({ ALCHEMY_PHASE: "runtime" }),
-                ConfigProvider.fromUnknown(env),
+                // Auto-bound `Config` values arrive in `env` as
+                // `{"_tag":"Redacted","value":...}` markers; reify them so a
+                // `Config` re-read inside a request handler decodes the raw
+                // source value instead of the marker JSON.
+                reifyBoundConfigProvider(
+                  ConfigProvider.fromUnknown(env),
+                  env as Record<string, unknown>,
+                ),
               ),
             ),
           ),

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerRuntimeContext.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerRuntimeContext.ts
@@ -2,9 +2,12 @@ import type * as cf from "@cloudflare/workers-types";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
-import * as Redacted from "effect/Redacted";
 import type { HttpEffect } from "../../Http.ts";
 import * as Output from "../../Output.ts";
+import {
+  packEnvValueKeepRedacted,
+  unpackEnvValue,
+} from "../../RuntimeContext.ts";
 import type * as Serverless from "../../Serverless/index.ts";
 import type { DurableObjectExport } from "./DurableObject.ts";
 import { makeRequestHandler } from "./HttpServer.ts";
@@ -37,53 +40,19 @@ export const makeWorkerRuntimeContext = (id: string): WorkerRuntimeContext => {
     get: (key: string) =>
       Effect.serviceOption(WorkerEnvironment).pipe(
         Effect.map(Option.getOrUndefined),
-        // Key is already canonical (see RuntimeContext.sanitizeKey).
-        Effect.map((env) => env?.[key]),
-        Effect.map((json) => {
-          if (json === undefined) {
-            return undefined;
-          }
-          try {
-            const value = JSON.parse(json);
-            // The `set` path serializes Redacted values as
-            // `{_tag: "Redacted", value: ...}`. After JSON.parse the
-            // result is a plain object — `Redacted.isRedacted` would
-            // always return `false` on it — so detect the marker shape
-            // and rebuild the Redacted wrapper. Plain values pass
-            // through unchanged.
-            if (
-              typeof value === "object" &&
-              value?._tag === "Redacted" &&
-              "value" in value
-            ) {
-              return Redacted.make((value as { value: unknown }).value);
-            }
-            return value;
-          } catch {
-            return json;
-          }
-        }),
+        // Key is already canonical (see RuntimeContext.sanitizeKey). Read
+        // straight from `WorkerEnvironment` — see `unpackEnvValue` for why
+        // this must never resolve through `Config.string`.
+        Effect.map((env) => unpackEnvValue(env?.[key])),
       ) as any,
     set: (key: string, output: Output.Output) =>
       Effect.sync(() => {
-        // Preserve `Redacted`-ness across the Output → env → Cloudflare
-        // binding boundary so the put-worker loop can deploy secrets via
-        // `secret_text` instead of leaking them as `plain_text`. The JSON
-        // payload still carries the `{_tag: "Redacted", …}` marker so the
-        // runtime `get` accessor can rebuild the wrapper after Cloudflare
-        // hands the binding back as a plain string.
-        env[key] = output.pipe(
-          Output.map((value) =>
-            Redacted.isRedacted(value)
-              ? Redacted.make(
-                  JSON.stringify({
-                    _tag: "Redacted",
-                    value: Redacted.value(value),
-                  }),
-                )
-              : JSON.stringify(value),
-          ),
-        );
+        // `packEnvValueKeepRedacted` keeps the Redacted wrapper on the
+        // outside so the put-worker loop can deploy secrets via
+        // `secret_text` instead of leaking them as `plain_text`, while the
+        // inner marker lets the runtime `get` accessor rebuild the wrapper
+        // after Cloudflare hands the binding back as a plain string.
+        env[key] = output.pipe(Output.map(packEnvValueKeepRedacted));
         return key;
       }),
     serve: <Req = never>(

--- a/packages/alchemy/src/Local/RpcSerialization.ts
+++ b/packages/alchemy/src/Local/RpcSerialization.ts
@@ -7,6 +7,7 @@ import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 import * as NodeUtil from "node:util";
 import * as Output from "../Output.ts";
+import { isRedactedMarker, type RedactedMarker } from "../RuntimeContext.ts";
 
 type RpcEffectHandler<Args extends Array<any>, Success, Error> = (
   ...args: Args
@@ -173,7 +174,10 @@ const unwrapRpcStreamHandler = <Args extends Array<any>, Success, Error>(
 
 const serializeRpcArgs = (value: unknown): unknown => {
   if (Redacted.isRedacted(value)) {
-    return { _tag: "Redacted", value: Redacted.value(value) };
+    return {
+      _tag: "Redacted",
+      value: Redacted.value(value),
+    } satisfies RedactedMarker;
   }
   if (Output.isOutput(value)) {
     return {
@@ -204,7 +208,7 @@ const deserializeRpcArgs = (value: unknown): unknown => {
   } else if (typeof value === "object" && value !== null) {
     // These values are serialized as `{_tag: "Redacted", value: ...}` and `{_tag: "Output", description: ...}`,
     // so we need to detect them manually - Redacted.isRedacted and Output.isOutput do not work.
-    if ("_tag" in value && value._tag === "Redacted" && "value" in value) {
+    if (isRedactedMarker(value)) {
       return Redacted.make(value.value);
     } else if (
       "_tag" in value &&

--- a/packages/alchemy/src/Runtime.ts
+++ b/packages/alchemy/src/Runtime.ts
@@ -6,7 +6,10 @@
  * surface tiny and dependency-light.
  */
 
+import * as ConfigProvider from "effect/ConfigProvider";
+import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import { sanitizeKey } from "./RuntimeContext.ts";
 import { asEffect } from "./Util/types.ts";
 
 /**
@@ -32,3 +35,96 @@ export const makeEntrypointLayer = (
   }
   return Layer.effect(tag, asEffect(entrypoint));
 };
+
+/**
+ * Unwrap the `{"_tag":"Redacted","value":...}` marker that the deploy-time
+ * `Config` interceptor (see `Platform.ts`) and `RuntimeContext.set` use to
+ * preserve `Redacted`-ness across the env-var boundary. Returns the inner
+ * source value as a string, or `undefined` when `raw` is not a marker.
+ */
+const parseRedactedMarker = (raw: string): string | undefined => {
+  if (!raw.startsWith("{")) {
+    return undefined;
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      (parsed as { _tag?: unknown })._tag === "Redacted" &&
+      "value" in parsed
+    ) {
+      const value = (parsed as { value: unknown }).value;
+      return typeof value === "string" ? value : JSON.stringify(value);
+    }
+  } catch {
+    // not JSON — plain env value, fall through
+  }
+  return undefined;
+};
+
+/**
+ * Reify an env-var string the way `RuntimeContext.get` does: unwrap the
+ * `Redacted` marker, unquote a JSON-stringified string, and pass anything
+ * else through verbatim.
+ */
+const reifyEnvString = (raw: string): string => {
+  const marker = parseRedactedMarker(raw);
+  if (marker !== undefined) {
+    return marker;
+  }
+  if (raw.startsWith('"')) {
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      if (typeof parsed === "string") {
+        return parsed;
+      }
+    } catch {
+      // not JSON — plain env value, fall through
+    }
+  }
+  return raw;
+};
+
+/**
+ * Wrap a runtime's env-backed `ConfigProvider` so values that were
+ * auto-bound by the deploy-time `Config` interceptor decode transparently.
+ *
+ * The engine can't know which config values are sensitive, so the
+ * interceptor binds every `Config` read during Init onto the deploy target
+ * as a secret, serialized as a `{"_tag":"Redacted","value":<source>}`
+ * marker. The interceptor's runtime branch reifies those markers for reads
+ * during Init, but effects that run later (request handlers, nested
+ * layers) resolve `Config` against the raw env-backed provider — without
+ * this wrapper, `Config.number("PORT")` inside a handler sees the marker
+ * JSON instead of the source value and fails with a schema error.
+ *
+ * Two behaviors:
+ * - Leaf values that carry the marker are unwrapped to the raw source
+ *   string before `Config` schemas decode them; everything else passes
+ *   through untouched.
+ * - On a miss, falls back to the flat `sanitizeKey`-canonicalized key
+ *   (`my.key` → `my_key`) that the interceptor bound the value under, so
+ *   config names with non-alphanumeric characters resolve at runtime too.
+ */
+export const reifyBoundConfigProvider = (
+  base: ConfigProvider.ConfigProvider,
+  env: Record<string, unknown>,
+): ConfigProvider.ConfigProvider =>
+  ConfigProvider.make((path) =>
+    base.load(path).pipe(
+      Effect.map((node) => {
+        if (node?._tag === "Value") {
+          const value = parseRedactedMarker(node.value);
+          return value === undefined ? node : ConfigProvider.makeValue(value);
+        }
+        if (node === undefined) {
+          const raw = env[sanitizeKey(path.map((p) => p.toString()).join("_"))];
+          if (typeof raw === "string") {
+            return ConfigProvider.makeValue(reifyEnvString(raw));
+          }
+        }
+        return node;
+      }),
+    ),
+  );

--- a/packages/alchemy/src/Runtime.ts
+++ b/packages/alchemy/src/Runtime.ts
@@ -9,7 +9,7 @@
 import * as ConfigProvider from "effect/ConfigProvider";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
-import { sanitizeKey } from "./RuntimeContext.ts";
+import { isRedactedMarker, sanitizeKey } from "./RuntimeContext.ts";
 import { asEffect } from "./Util/types.ts";
 
 /**
@@ -48,14 +48,10 @@ const parseRedactedMarker = (raw: string): string | undefined => {
   }
   try {
     const parsed: unknown = JSON.parse(raw);
-    if (
-      typeof parsed === "object" &&
-      parsed !== null &&
-      (parsed as { _tag?: unknown })._tag === "Redacted" &&
-      "value" in parsed
-    ) {
-      const value = (parsed as { value: unknown }).value;
-      return typeof value === "string" ? value : JSON.stringify(value);
+    if (isRedactedMarker(parsed)) {
+      return typeof parsed.value === "string"
+        ? parsed.value
+        : JSON.stringify(parsed.value);
     }
   } catch {
     // not JSON — plain env value, fall through

--- a/packages/alchemy/src/RuntimeContext.ts
+++ b/packages/alchemy/src/RuntimeContext.ts
@@ -2,6 +2,7 @@ import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as Redacted from "effect/Redacted";
 import type { HttpEffect } from "./Http.ts";
 import type { Output } from "./Output.ts";
 
@@ -42,6 +43,84 @@ export interface BaseRuntimeContext {
  */
 export const sanitizeKey = (key: string): string =>
   key.replaceAll(/[^a-zA-Z0-9]/g, "_");
+
+/**
+ * The wire format `RuntimeContext.set`/`get` use to carry a `Redacted` value
+ * through an environment variable. `JSON.stringify(Redacted)` emits the
+ * literal string `"<redacted>"` and loses the value, so secrets are
+ * serialized as this marker and the runtime `get` path rebuilds the wrapper.
+ */
+export interface RedactedMarker {
+  readonly _tag: "Redacted";
+  readonly value: unknown;
+}
+
+/**
+ * Detect the (already JSON-parsed) {@link RedactedMarker} shape. After
+ * `JSON.parse` the marker is a plain object — `Redacted.isRedacted` is
+ * always `false` on it — so detection is structural.
+ */
+export const isRedactedMarker = (value: unknown): value is RedactedMarker =>
+  typeof value === "object" &&
+  value !== null &&
+  (value as { _tag?: unknown })._tag === "Redacted" &&
+  "value" in value;
+
+/**
+ * Serialize a binding value for an env var: `Redacted` values are packed as
+ * a {@link RedactedMarker}, everything else is plain `JSON.stringify`.
+ */
+export const packEnvValue = (value: unknown): string =>
+  Redacted.isRedacted(value)
+    ? JSON.stringify({
+        _tag: "Redacted",
+        value: Redacted.value(value),
+      } satisfies RedactedMarker)
+    : JSON.stringify(value);
+
+/**
+ * Like {@link packEnvValue}, but a `Redacted` input keeps its `Redacted`
+ * wrapper on the *outside* of the packed string, so deploy-time code can
+ * route secrets through a dedicated channel (Cloudflare `secret_text`,
+ * Secrets Store) instead of leaking them as plain env vars. The inner
+ * payload still carries the marker for the runtime `get` accessor.
+ */
+export const packEnvValueKeepRedacted = (
+  value: unknown,
+): string | Redacted.Redacted<string> =>
+  Redacted.isRedacted(value)
+    ? Redacted.make(packEnvValue(value))
+    : packEnvValue(value);
+
+/**
+ * Parse an env-var string produced by {@link packEnvValue} back into its
+ * value: rebuild `Redacted` from the marker, return other JSON values
+ * as-is, and fall back to the raw string for non-JSON input (e.g. an env
+ * var the user set directly). `undefined` passes through.
+ *
+ * Runtime `get` accessors MUST feed this from the raw environment
+ * (`process.env[key]` / the platform env object) — never through
+ * `Config.string`: the ambient runtime `ConfigProvider` reifies bound
+ * values (unwrapping the marker before it could be detected here), and
+ * during init the ambient provider is the interceptor installed in
+ * `Platform.ts`, whose runtime branch calls back into `ctx.get(key)` —
+ * resolving through `Config` would re-enter it for the same key and
+ * recurse forever.
+ */
+export const unpackEnvValue = <T>(raw: string | undefined): T | undefined => {
+  if (raw === undefined) {
+    return undefined;
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (isRedactedMarker(parsed)) {
+      return Redacted.make(parsed.value) as unknown as T;
+    }
+    return parsed as T;
+  } catch {
+    return raw as unknown as T; // assume it's just a string
+  }
+};
 
 /**
  * Context of the runtime environment.

--- a/packages/alchemy/src/Server/Process.ts
+++ b/packages/alchemy/src/Server/Process.ts
@@ -1,6 +1,6 @@
-import * as Config from "effect/Config";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
+import * as Redacted from "effect/Redacted";
 import { FileSystem } from "effect/FileSystem";
 import type { Path } from "effect/Path";
 import type { Stdio } from "effect/Stdio";
@@ -74,25 +74,52 @@ export const createHostRuntimeContext =
       set: (bindingId: string, output: Output.Output) =>
         Effect.sync(() => {
           const key = bindingId.replaceAll(/[^a-zA-Z0-9]/g, "_");
-          env[key] = output.pipe(Output.map((value) => JSON.stringify(value)));
+          // Preserve `Redacted`-ness across the Output → env round-trip.
+          // `JSON.stringify(Redacted)` would emit the literal string
+          // `"<redacted>"` and lose the value, so secrets are serialized
+          // with a `{_tag: "Redacted", value: ...}` marker that the runtime
+          // `get` path detects and rebuilds. Mirrors the Lambda context.
+          env[key] = output.pipe(
+            Output.map((value) =>
+              Redacted.isRedacted(value)
+                ? JSON.stringify({
+                    _tag: "Redacted",
+                    value: Redacted.value(value),
+                  })
+                : JSON.stringify(value),
+            ),
+          );
           return key;
         }),
       get: <T>(key: string) =>
-        Config.string(key).pipe(
-          Effect.flatMap((value) =>
-            Effect.try({
-              try: () => JSON.parse(value) as T,
-              catch: (error) => error as Error,
-            }),
-          ),
-          Effect.catch((cause) =>
-            Effect.die(
-              new Error(`Failed to get environment variable: ${key}`, {
-                cause,
-              }),
-            ),
-          ),
-        ),
+        // Read the captured value straight from `process.env`. We must NOT
+        // resolve through `Config.string` here: the ambient `ConfigProvider`
+        // at runtime reifies bound values (and during init it is the
+        // interceptor installed in `Platform.ts`, whose runtime branch calls
+        // back into `ctx.get(key)` — going through `Config` would re-enter
+        // it for the same key and recurse forever). Mirrors the Lambda and
+        // Worker contexts.
+        Effect.sync(() => {
+          const val = process.env[key];
+          if (val === undefined) {
+            return undefined as T;
+          }
+          try {
+            const value = JSON.parse(val);
+            if (
+              typeof value === "object" &&
+              value?._tag === "Redacted" &&
+              "value" in value
+            ) {
+              return Redacted.make(
+                (value as { value: unknown }).value,
+              ) as unknown as T;
+            }
+            return value as T;
+          } catch {
+            return val as unknown as T; // assume it's just a string
+          }
+        }),
       run: (effect: Effect.Effect<void, never, any>) =>
         Effect.sync(() => {
           runners.push(effect);

--- a/packages/alchemy/src/Server/Process.ts
+++ b/packages/alchemy/src/Server/Process.ts
@@ -1,6 +1,5 @@
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
-import * as Redacted from "effect/Redacted";
 import { FileSystem } from "effect/FileSystem";
 import type { Path } from "effect/Path";
 import type { Stdio } from "effect/Stdio";
@@ -9,7 +8,11 @@ import type { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSp
 import type { HttpEffect } from "../Http.ts";
 import * as Http from "../Http.ts";
 import * as Output from "../Output.ts";
-import type { BaseRuntimeContext } from "../RuntimeContext.ts";
+import {
+  packEnvValue,
+  unpackEnvValue,
+  type BaseRuntimeContext,
+} from "../RuntimeContext.ts";
 
 export type ProcessServices =
   | ChildProcessSpawner
@@ -74,52 +77,15 @@ export const createHostRuntimeContext =
       set: (bindingId: string, output: Output.Output) =>
         Effect.sync(() => {
           const key = bindingId.replaceAll(/[^a-zA-Z0-9]/g, "_");
-          // Preserve `Redacted`-ness across the Output → env round-trip.
-          // `JSON.stringify(Redacted)` would emit the literal string
-          // `"<redacted>"` and lose the value, so secrets are serialized
-          // with a `{_tag: "Redacted", value: ...}` marker that the runtime
-          // `get` path detects and rebuilds. Mirrors the Lambda context.
-          env[key] = output.pipe(
-            Output.map((value) =>
-              Redacted.isRedacted(value)
-                ? JSON.stringify({
-                    _tag: "Redacted",
-                    value: Redacted.value(value),
-                  })
-                : JSON.stringify(value),
-            ),
-          );
+          // `packEnvValue` marker-packs Redacted values so they survive the
+          // Output → env round-trip.
+          env[key] = output.pipe(Output.map(packEnvValue));
           return key;
         }),
       get: <T>(key: string) =>
-        // Read the captured value straight from `process.env`. We must NOT
-        // resolve through `Config.string` here: the ambient `ConfigProvider`
-        // at runtime reifies bound values (and during init it is the
-        // interceptor installed in `Platform.ts`, whose runtime branch calls
-        // back into `ctx.get(key)` — going through `Config` would re-enter
-        // it for the same key and recurse forever). Mirrors the Lambda and
-        // Worker contexts.
-        Effect.sync(() => {
-          const val = process.env[key];
-          if (val === undefined) {
-            return undefined as T;
-          }
-          try {
-            const value = JSON.parse(val);
-            if (
-              typeof value === "object" &&
-              value?._tag === "Redacted" &&
-              "value" in value
-            ) {
-              return Redacted.make(
-                (value as { value: unknown }).value,
-              ) as unknown as T;
-            }
-            return value as T;
-          } catch {
-            return val as unknown as T; // assume it's just a string
-          }
-        }),
+        // Read straight from `process.env` — see `unpackEnvValue` for why
+        // this must never resolve through `Config.string`.
+        Effect.sync(() => unpackEnvValue<T>(process.env[key]) as T),
       run: (effect: Effect.Effect<void, never, any>) =>
         Effect.sync(() => {
           runners.push(effect);

--- a/packages/alchemy/test/Cloudflare/Workers/TaggedRpcDO.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/TaggedRpcDO.test.ts
@@ -35,13 +35,15 @@ const requestTimeout = "5 seconds";
 // status codes, so we explicitly `Effect.fail` non-2xx responses to force a
 // retry through `readinessRetry`.
 // Cap exponential backoff at 3s so cold-start retries stay bounded when
-// CF edge propagation is slow.
+// CF edge propagation is slow. Fresh `*.workers.dev` subdomains routinely
+// take over a minute to stop serving the placeholder page, so the budget
+// must comfortably exceed that (~2 minutes here).
 const readinessRetry = {
   schedule: Schedule.min([
     Schedule.exponential("500 millis"),
     Schedule.spaced("3 seconds"),
   ]),
-  times: 15,
+  times: 40,
 } as const;
 
 const requestUntilReady = (
@@ -202,6 +204,9 @@ const stack = beforeAll(
     // just give it some extra time to propagate
     Effect.tap(Effect.sleep("5 seconds")),
   ),
+  // deploy + the ~2-minute warmup retry budget can exceed the default
+  // 120s hook timeout when workers.dev propagation is slow
+  { timeout: 300_000 },
 );
 afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(Stack));
 

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerEnv.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerEnv.test.ts
@@ -14,6 +14,10 @@ const CONFIG_REDACTED_VALUE = (process.env.CONFIG_REDACTED =
   "config-redacted-value");
 const CONFIG_REDACTED_INIT_VALUE = (process.env.CONFIG_REDACTED_INIT =
   "config-redacted-init-value");
+// Read via `Config.string("HOST").pipe(Config.nested("CONFIG_NESTED"))` —
+// binds under the flattened `CONFIG_NESTED_HOST` key.
+const CONFIG_NESTED_HOST_VALUE = (process.env.CONFIG_NESTED_HOST =
+  "config-nested-host-value");
 
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Cloudflare.providers(),
@@ -103,6 +107,35 @@ describe.concurrent("Cloudflare.Worker env bindings", () => {
   );
 
   test(
+    "effect worker re-resolves Config.xxx at request time inside a nested effect",
+    Effect.gen(function* () {
+      const { effectUrl } = yield* stack;
+
+      const body = yield* expectUrlContains(
+        `${effectUrl}/config-runtime`,
+        '"CONFIG_STR"',
+        { timeout: "60 seconds", label: "effect env-worker /config-runtime" },
+      );
+      expect(JSON.parse(body)).toEqual({
+        CONFIG_STR: CONFIG_STR_VALUE,
+        CONFIG_NUM: Number(CONFIG_NUM_VALUE),
+        CONFIG_NUM_WITH_DEFAULT: Number(CONFIG_NUM_VALUE),
+        CONFIG_UNSET_WITH_DEFAULT: 3000,
+        CONFIG_REDACTED_INIT: CONFIG_REDACTED_INIT_VALUE,
+        CONFIG_REDACTED_INIT_IS_REDACTED: true,
+        CONFIG_ALL_OBJ: {
+          str: CONFIG_STR_VALUE,
+          num: Number(CONFIG_NUM_VALUE),
+          redacted: CONFIG_REDACTED_INIT_VALUE,
+          redactedIsRedacted: true,
+        },
+        CONFIG_ALL_TUPLE: [CONFIG_STR_VALUE, Number(CONFIG_NUM_VALUE)],
+        CONFIG_NESTED_HOST: CONFIG_NESTED_HOST_VALUE,
+      });
+    }).pipe(logLevel),
+  );
+
+  test(
     "effect worker round-trips Config.xxx bindings captured in Init",
     Effect.gen(function* () {
       const { effectUrl } = yield* stack;
@@ -118,6 +151,14 @@ describe.concurrent("Cloudflare.Worker env bindings", () => {
         CONFIG_REDACTED: CONFIG_REDACTED_VALUE,
         CONFIG_REDACTED_INIT: CONFIG_REDACTED_INIT_VALUE,
         CONFIG_REDACTED_INIT_IS_REDACTED: true,
+        CONFIG_ALL_OBJ: {
+          str: CONFIG_STR_VALUE,
+          num: Number(CONFIG_NUM_VALUE),
+          redacted: CONFIG_REDACTED_INIT_VALUE,
+          redactedIsRedacted: true,
+        },
+        CONFIG_ALL_TUPLE: [CONFIG_STR_VALUE, Number(CONFIG_NUM_VALUE)],
+        CONFIG_NESTED_HOST: CONFIG_NESTED_HOST_VALUE,
       });
     }).pipe(logLevel),
   );

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/env/effect.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/env/effect.ts
@@ -43,6 +43,21 @@ export default class EnvEffectWorker extends Cloudflare.Worker<EnvEffectWorker>(
     const configStr = yield* Config.string("CONFIG_STR");
     const configNum = yield* Config.number("CONFIG_NUM");
     const configRedactedInit = yield* Config.redacted("CONFIG_REDACTED_INIT");
+    // Composite forms — each member is bound individually, so the whole
+    // shape must survive the deploy → runtime round-trip.
+    const configAllObj = yield* Config.all({
+      str: Config.string("CONFIG_STR"),
+      num: Config.number("CONFIG_NUM"),
+      redacted: Config.redacted("CONFIG_REDACTED_INIT"),
+    });
+    const configAllTuple = yield* Config.all([
+      Config.string("CONFIG_STR"),
+      Config.number("CONFIG_NUM"),
+    ]);
+    // Nested prefix — bound under the flattened `CONFIG_NESTED_HOST` key.
+    const configNested = yield* Config.string("HOST").pipe(
+      Config.nested("CONFIG_NESTED"),
+    );
 
     // Yieldable binding form — attaches the `version_metadata` binding to
     // this Worker and returns a deferred accessor resolved at runtime.
@@ -84,11 +99,72 @@ export default class EnvEffectWorker extends Cloudflare.Worker<EnvEffectWorker>(
             CONFIG_REDACTED_INIT: Redacted.value(configRedactedInit),
             CONFIG_REDACTED_INIT_IS_REDACTED:
               Redacted.isRedacted(configRedactedInit),
+            CONFIG_ALL_OBJ: {
+              str: configAllObj.str,
+              num: configAllObj.num,
+              redacted: Redacted.value(configAllObj.redacted),
+              redactedIsRedacted: Redacted.isRedacted(configAllObj.redacted),
+            },
+            CONFIG_ALL_TUPLE: configAllTuple,
+            CONFIG_NESTED_HOST: configNested,
+          });
+        }
+
+        if (pathname === "/config-runtime") {
+          // Re-resolve the same Configs captured during Init — this time at
+          // request time, deep inside a nested effect, where the env-backed
+          // runtime ConfigProvider (not the Init interceptor) answers the
+          // read. The bound values arrive in `env` as
+          // `{"_tag":"Redacted","value":...}` markers and must be reified
+          // transparently: `Config.number` must decode the raw source value,
+          // not the marker JSON.
+          const nested = yield* Effect.gen(function* () {
+            const allObj = yield* Config.all({
+              str: Config.string("CONFIG_STR"),
+              num: Config.number("CONFIG_NUM"),
+              redacted: Config.redacted("CONFIG_REDACTED_INIT"),
+            });
+            return {
+              CONFIG_STR: yield* Config.string("CONFIG_STR"),
+              CONFIG_NUM: yield* Config.number("CONFIG_NUM"),
+              // Combinators re-apply at runtime against the bound source.
+              CONFIG_NUM_WITH_DEFAULT: yield* Config.number("CONFIG_NUM").pipe(
+                Config.withDefault(999),
+              ),
+              // Never read during Init, so never bound — the default applies.
+              CONFIG_UNSET_WITH_DEFAULT: yield* Config.number(
+                "CONFIG_UNSET",
+              ).pipe(Config.withDefault(3000)),
+              CONFIG_ALL_OBJ: {
+                str: allObj.str,
+                num: allObj.num,
+                redacted: Redacted.value(allObj.redacted),
+                redactedIsRedacted: Redacted.isRedacted(allObj.redacted),
+              },
+              CONFIG_ALL_TUPLE: yield* Config.all([
+                Config.string("CONFIG_STR"),
+                Config.number("CONFIG_NUM"),
+              ]),
+              CONFIG_NESTED_HOST: yield* Config.string("HOST").pipe(
+                Config.nested("CONFIG_NESTED"),
+              ),
+            };
+          });
+          const redactedAtRuntime = yield* Config.redacted(
+            "CONFIG_REDACTED_INIT",
+          );
+          return yield* HttpServerResponse.json({
+            ...nested,
+            CONFIG_REDACTED_INIT: Redacted.value(redactedAtRuntime),
+            CONFIG_REDACTED_INIT_IS_REDACTED:
+              Redacted.isRedacted(redactedAtRuntime),
           });
         }
 
         return HttpServerResponse.text("ok");
-      }),
+        // The request-time Config reads carry ConfigError; a failed read is
+        // a test bug, so die (surfaces as a 500 the test assertions catch).
+      }).pipe(Effect.orDie),
     };
   }).pipe(Effect.provide(Cloudflare.Workers.VersionMetadataBinding)),
 ) {}

--- a/website/src/content/docs/environments/secrets.mdx
+++ b/website/src/content/docs/environments/secrets.mdx
@@ -123,6 +123,11 @@ Effect.gen(function* () {
 });
 ```
 
+Once a `Config` has been resolved during Init, re-yielding the same
+`Config` anywhere at runtime — inside `fetch`, deep in a nested
+effect, or in a service layer — resolves it from the binding and
+produces the same value.
+
 ## Async Workers — bind via `env`
 
 Async (non-Effect) Workers don't have an Init `Effect.gen` to


### PR DESCRIPTION
Auto-bound `Config` values are serialized into the target's env as `{"_tag":"Redacted","value":...}` markers (the engine can't know what's sensitive, so it binds everything as a secret). The deploy-time interceptor reified those markers for reads during Init, but request handlers resolve `Config` against the raw env-backed provider — so re-yielding a `Config` inside a handler decoded the marker JSON instead of the source value:

```
SchemaError: Expected a string representing a finite number, got "{\"_tag\":\"Redacted\",\"value\":\"4321\"}"
```

`Config.redacted` didn't error but silently wrapped the marker JSON as the secret value.

New `reifyBoundConfigProvider` in `alchemy/Runtime` wraps the runtime's env-backed provider:

```ts
ConfigProvider.orElse(
  ConfigProvider.fromUnknown({ ALCHEMY_PHASE: "runtime" }),
  reifyBoundConfigProvider(ConfigProvider.fromUnknown(env), env),
)
```

- unwraps the `Redacted` marker on leaf values before `Config` schemas decode them; everything else passes through untouched
- on a miss, falls back to the flat `sanitizeKey`-canonicalized key the interceptor bound the value under, so `Config.nested("CONFIG_NESTED")` resolves `CONFIG_NESTED_HOST` at runtime

Wired into every runtime bridge: Cloudflare `WorkerBridge` (Workers, DOs, Workflows via the shared build), the Lambda entry template, ECS Task, EC2 hosted, and `ContainerBundle` (which previously had no explicit provider at all).

Live coverage in `WorkerEnv.test.ts`: a `/config-runtime` fixture route re-yields the same Configs inside `fetch`, deep in a nested effect — `Config.string`/`number`/`redacted`, `Config.all` (object form with a redacted member + tuple form), `Config.nested`, and `withDefault` on both a bound and an unbound key. The test fails on the pre-fix code with the reported error and is green with the fix; init-phase assertions cover the same composite forms.

Also documents in `secrets.mdx` that re-yielding an Init-resolved `Config` anywhere at runtime resolves from the binding.


### Companion fix: host/container `ctx.get` accessors

`ContainerPlatform.get` and the shared ECS/EC2 host context resolved env values through `Config.string` + `JSON.parse`, dying on parse failure — incompatible with the reifying provider (which hands them the already-unwrapped secret) and a latent init-recursion hazard. Both now read `process.env` directly with marker detection and a raw-string fallback, mirroring the Lambda/Worker contexts. The host context's `set` also marker-packs `Redacted` values — bare `JSON.stringify(Redacted)` emitted the literal `"<redacted>"` and destroyed the secret on ECS/EC2.

Live verification: Cloudflare Workers directory 30/30 suites, `WorkerEnv` 5/5 (incl. `Config.all` object/tuple, `Config.nested`, request-time re-reads), Container directory 16/16 (including the previously-failing effectful `dev: true` variants), Lambda 4 suites, ECS Task smoke, EC2 Instance smoke.

### Shared marker helpers

The `{"_tag":"Redacted","value":...}` env wire format was hand-rolled in five runtime contexts. It now lives in `RuntimeContext.ts` next to the `set`/`get` contract it implements:

```ts
packEnvValue(value)             // marker-pack Redacted, JSON.stringify otherwise
packEnvValueKeepRedacted(value) // keeps Redacted outside for secret_text / Secrets Store routing
unpackEnvValue(raw)             // rebuild Redacted from the marker, raw-string fallback
isRedactedMarker(value)
```

This also fixed `MicrovmRuntimeContext.get`, which still resolved through `Config.string` and died on parse failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
