### PR TITLE
feat(cloudflare/containers): keep a container warm on a schedule, warm a DO pool ahead of first request

### DIFF
--- a/packages/alchemy/src/Cloudflare/Containers/Container.ts
+++ b/packages/alchemy/src/Cloudflare/Containers/Container.ts
@@ -435,6 +435,33 @@ export type Container<Id extends string = string> = Named<Id> & {
  * ) {}
  * ```
  *
+ * @example Keeping the container warm between requests
+ * ```typescript
+ * // Without `keepWarm`, a container Cloudflare put to sleep during an idle
+ * // stretch pays a full restart on the next real request. `keepWarm`
+ * // proactively re-checks it on a schedule instead, off the request's
+ * // critical path. This keeps *this* container warm — it is not a pool of
+ * // spares; see `Cloudflare.Containers.warmPool` to warm several
+ * // Durable Objects' containers ahead of their first real request.
+ * export default class Agent extends Cloudflare.DurableObject<Agent>()(
+ *   "Agents",
+ *   Effect.gen(function* () {
+ *     const sandbox = yield* Sandbox;
+ *     return Effect.gen(function* () {
+ *       return { exec: (cmd: string) => sandbox.exec(cmd) };
+ *     });
+ *   }).pipe(
+ *     Effect.provide(
+ *       Cloudflare.Containers.layer(Sandbox, {
+ *         keepWarm: Schedule.spaced(Duration.minutes(4)).pipe(
+ *           Schedule.upTo({ duration: Duration.hours(1) }),
+ *         ),
+ *       }),
+ *     ),
+ *   ),
+ * ) {}
+ * ```
+ *
  * @section HTTP Requests to Container Ports
  * Use `getTcpPort` on the running container instance to get a `fetch`
  * handle for a specific port. This lets you make HTTP requests to

--- a/packages/alchemy/src/Cloudflare/Containers/StartContainer.ts
+++ b/packages/alchemy/src/Cloudflare/Containers/StartContainer.ts
@@ -66,9 +66,55 @@ const getStartCoordination = (key: object) => {
   return coordination;
 };
 
+/**
+ * Options accepted by {@link layer} — Cloudflare's own container startup
+ * options plus Alchemy-only scheduling knobs layered on top.
+ */
+export interface ContainerLayerOptions extends ContainerStartupOptions {
+  /**
+   * Keep this Durable Object's container warm for its lifetime: after the
+   * initial eager start, periodically re-run the same readiness check that a
+   * real request would (restart the container and re-probe its default
+   * port if it has gone idle/cold) on this schedule — instead of waiting for
+   * the next real request to discover it needs a fresh boot.
+   *
+   * This keeps *one* container warm; it does not create a pool of spares.
+   * Cloudflare binds a container 1:1 to the Durable Object that owns it, so
+   * there is no such thing as a pre-warmed instance handed off to a
+   * different DO. To warm containers ahead of their first real request
+   * (across many DOs), see {@link warmPool} instead.
+   *
+   * A tick where the container is already warm costs a single local state
+   * read (no Cloudflare API round trip, no billing impact) plus a
+   * ready-port cache hit — both lock-free, so it never contends with real
+   * traffic. Only a container that has actually gone cold pays the restart
+   * + readiness cost, and it pays it on the schedule's cadence rather than
+   * on the critical path of the next real request.
+   *
+   * Typed `Schedule<unknown, void>` because only the schedule's *cadence* is
+   * used: its output is never consumed (`unknown` accepts any schedule the
+   * caller already has), and each tick is fed the ignored `void` result of
+   * the readiness check, so combinators like `Schedule.upTo` that inspect
+   * their input still compose.
+   *
+   * @example Keep warm every 4 minutes, bounded to a 1-hour session window
+   * ```typescript
+   * import * as Duration from "effect/Duration";
+   * import * as Schedule from "effect/Schedule";
+   *
+   * Cloudflare.Containers.layer(Sandbox, {
+   *   keepWarm: Schedule.spaced(Duration.minutes(4)).pipe(
+   *     Schedule.upTo({ duration: Duration.hours(1) }),
+   *   ),
+   * });
+   * ```
+   */
+  keepWarm?: Schedule.Schedule<unknown, void>;
+}
+
 export const layer = <Image extends Container.Decl.Any>(
   container: Image,
-  options?: ContainerStartupOptions,
+  options?: ContainerLayerOptions,
 ) => {
   const id = (container as any)["~alchemy/Id"] as string;
   // Provide the *started* instance under the same tag `yield* MyContainer`
@@ -84,7 +130,18 @@ export const layer = <Image extends Container.Decl.Any>(
  */
 export const startContainer = Effect.fn(function* <
   Image extends Container.Decl.Any,
->(containerEff: Image, options?: ContainerStartupOptions) {
+>(containerEff: Image, options?: ContainerLayerOptions) {
+  // `keepWarm` is an Alchemy-only scheduling knob layered on top of
+  // Cloudflare's real container startup options — split it off here so
+  // `container.start()` below only ever sees the keys Cloudflare declares,
+  // rather than relying on the runtime tolerating an unknown extra key.
+  const keepWarm = options?.keepWarm;
+  let startupOptions: ContainerStartupOptions | undefined;
+  if (options !== undefined) {
+    const { keepWarm: _stripped, ...rest } = options;
+    startupOptions = rest;
+  }
+
   const bindEff = (containerEff as any)["~alchemy/Container/Binding"] as
     | Effect.Effect<Effect.Effect<Container>, never, any>
     | undefined;
@@ -202,7 +259,7 @@ export const startContainer = Effect.fn(function* <
       // A (re)start means nothing is listening yet — clear any stale ready
       // marks from a previous run so the next request re-probes this instance.
       yield* Effect.sync(() => readyPorts.clear());
-      yield* container.start(options).pipe(
+      yield* container.start(startupOptions).pipe(
         Effect.catchDefect((defect) => Effect.fail(classifyDefect(defect, -1))),
         // A rate limit is transient — back off well clear of the per-second
         // window and try again a few times before surfacing it.
@@ -399,6 +456,30 @@ export const startContainer = Effect.fn(function* <
   if (phase === "runtime") {
     // erase the RuntimeContext color (we are applying it eagerly as an optimization only during runtime)
     yield* ensureRunning as Effect.Effect<void>;
+
+    if (keepWarm) {
+      // Proactively re-run the full readiness check (not just `ensureRunning`)
+      // on the given schedule, so a container that went idle/cold between
+      // real requests is already warm again by the time the next one
+      // arrives — port 3000 mirrors the same convention `base.fetch` below
+      // uses for the container's default RPC/fetch port. Forked into the
+      // layer's scope (the DO's runtime): the fiber outlives any single
+      // request but is interrupted with the runtime instead of leaking, and
+      // an erroring tick never fails the DO — the eager start above already
+      // covers the first run, so a transient failure here just means the
+      // next tick tries again. This loop is why the start can't simply be
+      // awaited: the initial start *is* awaited just above; the re-check
+      // repeats for the DO's whole life.
+      yield* Effect.forkScoped(
+        ensureReady(3000).pipe(
+          Effect.tapError((err) =>
+            Effect.logDebug(`keepWarm tick failed: ${err}`),
+          ),
+          Effect.ignore,
+          Effect.repeat(keepWarm),
+        ),
+      );
+    }
   }
 
   // The container exposes its non-`fetch` shape methods (declared on the

--- a/packages/alchemy/src/Cloudflare/Containers/WarmPool.ts
+++ b/packages/alchemy/src/Cloudflare/Containers/WarmPool.ts
@@ -1,0 +1,101 @@
+import * as Effect from "effect/Effect";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";
+import type { DurableObject } from "../Workers/DurableObject.ts";
+
+/**
+ * Options accepted by {@link warmPool}.
+ */
+export interface WarmPoolOptions {
+  /**
+   * The Durable Object names to warm on this pass. Alchemy has no way to
+   * know which DOs you expect traffic for — this is your own prediction,
+   * recent-activity list, or fixed roster. Pass a plain iterable when the
+   * list is already in hand, or an `Effect` to resolve it fresh on every
+   * pass (a KV read, a query, …).
+   */
+  names: Iterable<string> | Effect.Effect<Iterable<string>>;
+  /**
+   * Maximum number of DOs woken concurrently.
+   * @default 10
+   */
+  concurrency?: number;
+}
+
+/**
+ * Proactively wake a set of Durable Objects by name — one pass per call —
+ * so their containers start booting before the first real request arrives,
+ * instead of paying a cold start on that request's critical path.
+ *
+ * Cloudflare binds a container 1:1 to the Durable Object that owns it, so
+ * there is no platform concept of an anonymous, pre-warmed spare that could
+ * be handed to a *different* DO. `warmPool` doesn't try to invent one —
+ * it simply fires a lightweight `fetch` at each named DO's stub and waits
+ * for the fan-out to finish. Waking a DO this way is enough on its own: any
+ * inbound call forces the DO to construct if it isn't already resident in
+ * memory, which is exactly where `Cloudflare.Containers.layer(...)`'s
+ * existing eager start fires as a side effect. `warmPool` only needs to
+ * know how to wake a DO by name; it doesn't need to know anything about the
+ * container inside it.
+ *
+ * `warmPool` does **one pass and returns** — it has no schedule of its own.
+ * Call it from a recurring trigger (a Cron Trigger is the natural fit; its
+ * once-a-minute floor is plenty for pre-boot warming) rather than wrapping
+ * it in your own `Effect.repeat`: a self-repeating `warmPool` combined with
+ * a handler that's invoked repeatedly by its own trigger would fork one
+ * forever-running fan-out loop *per invocation*, piling up duplicate loops
+ * in any isolate that survives across fires.
+ *
+ * This complements {@link ContainerLayerOptions.keepWarm} rather than
+ * replacing it: `warmPool` gets a DO (and its container) booting *before*
+ * anyone has ever touched it; `keepWarm` keeps that same container warm
+ * for the rest of the DO's life once it has.
+ *
+ * @example Warm the last few active agents every minute from a Cron Trigger
+ * ```typescript
+ * import * as Cloudflare from "alchemy/Cloudflare";
+ * import * as Effect from "effect/Effect";
+ * import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+ *
+ * export default Cloudflare.Worker(
+ *   "PoolWorker",
+ *   { main: import.meta.url },
+ *   Effect.gen(function* () {
+ *     const agents = yield* Agent;
+ *
+ *     yield* Cloudflare.Workers.cron("* * * * *", () =>
+ *       Cloudflare.Containers.warmPool(agents, {
+ *         names: recentlyActiveAgentIds(), // your own prediction/heuristic
+ *         concurrency: 10,
+ *       }),
+ *     );
+ *
+ *     return {
+ *       fetch: Effect.succeed(HttpServerResponse.text("ok")),
+ *     };
+ *   }).pipe(Effect.provide(Cloudflare.Workers.CronEventSourceLive)),
+ * );
+ * ```
+ */
+export const warmPool = <Shape>(
+  namespace: DurableObject<Shape>,
+  options: WarmPoolOptions,
+) =>
+  Effect.gen(function* () {
+    const names = Effect.isEffect(options.names)
+      ? yield* options.names
+      : options.names;
+    yield* Effect.forEach(
+      names,
+      (name) =>
+        namespace
+          .getByName(name)
+          .fetch(
+            HttpServerRequest.fromClientRequest(
+              HttpClientRequest.get("http://warm-pool-ping"),
+            ),
+          )
+          .pipe(Effect.ignore),
+      { concurrency: options.concurrency ?? 10 },
+    );
+  });

--- a/packages/alchemy/src/Cloudflare/Containers/index.ts
+++ b/packages/alchemy/src/Cloudflare/Containers/index.ts
@@ -5,3 +5,4 @@ export * from "./ContainerPlatform.ts";
 export * from "./ContainerProvider.ts";
 export * from "./LocalContainerProvider.ts";
 export * from "./StartContainer.ts";
+export * from "./WarmPool.ts";

--- a/packages/alchemy/test/Cloudflare/Container/ContainerWarm.test.ts
+++ b/packages/alchemy/test/Cloudflare/Container/ContainerWarm.test.ts
@@ -1,6 +1,6 @@
 import * as Cloudflare from "@/Cloudflare";
-import * as Test from "@/Test/Vitest";
-import { describe, expect } from "@effect/vitest";
+import * as Test from "@/Test/Alchemy";
+import { describe, expect } from "alchemy-test";
 import * as Effect from "effect/Effect";
 import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
@@ -56,12 +56,24 @@ const fetchReady = (url: string, expected: string) =>
     );
   });
 
-// Fire a single GET and return its parsed JSON body.
+// GET a route and return its parsed JSON body, riding out a cold edge the same
+// way `fetchReady` does. Without the retry, a request that lands before the
+// deploy has propagated gets Cloudflare's own 404 HTML page and dies on
+// `JSON Parse error: Unrecognized token '<'` — a test failure that says
+// nothing about the code under test.
 const json = <T>(url: string) =>
   Effect.gen(function* () {
     const client = freshConn(yield* HttpClient.HttpClient);
-    const res = yield* client.get(url);
-    return (yield* res.json) as T;
+    return yield* client.get(url).pipe(
+      Effect.flatMap((res) =>
+        res.status !== 200
+          ? Effect.fail(new Error(`not ready: ${res.status}`))
+          : (res.json as Effect.Effect<unknown, unknown>),
+      ),
+      Effect.map((body) => body as T),
+      Effect.timeout("30 seconds"),
+      Effect.retry({ schedule: readinessSchedule, times: 40 }),
+    );
   });
 
 // Poll `/running` until the reported state matches `want`. Reading the flag
@@ -153,14 +165,21 @@ describe("container warming", () => {
         // Each DO recorded the wake itself, so the fan-out demonstrably
         // reached every name (not just the first, and not only the ones the
         // concurrency window admitted first).
-        const warmed = yield* json<{ count: number; runningAtWarm: boolean }>(
+        const warmed = yield* json<{ count: number }>(
           `${url}/warmed?name=${name}`,
         );
         expect(warmed.count).toBeGreaterThanOrEqual(1);
-        // And by the time the wake landed, waking the DO had already booted
-        // its container — which is the whole point of warming ahead of the
-        // first real request.
-        expect(warmed.runningAtWarm).toBe(true);
+
+        // ...and the wake set the container booting. This is polled, not read
+        // at wake time: `ensureRunning` calls `container.start()`, which asks
+        // for a boot rather than waiting one out, so `running` is still false
+        // while the wake handler itself is on the stack. Warming ahead of the
+        // first request only promises the boot is already under way by then —
+        // so that is what this asserts.
+        //
+        // `/running` only reads a flag; no request here ever touches the
+        // container.
+        expect(yield* waitRunning(url, name, true)).toBe(true);
       }
     }).pipe(logLevel),
     { timeout: TEST_TIMEOUT },

--- a/packages/alchemy/test/Cloudflare/Container/ContainerWarm.test.ts
+++ b/packages/alchemy/test/Cloudflare/Container/ContainerWarm.test.ts
@@ -1,0 +1,168 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as Test from "@/Test/Vitest";
+import { describe, expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+import * as Schedule from "effect/Schedule";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import WarmStack from "./fixtures/warm/stack.ts";
+
+const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
+  providers: Cloudflare.providers(),
+  state: Cloudflare.state(),
+});
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+// Image build + push + worker/DO deploy comfortably exceeds the default hook
+// budget; the warm tests then wait out a real keep-warm cadence on top.
+const HOOK_TIMEOUT = 600_000;
+const TEST_TIMEOUT = 300_000;
+
+const DEPLOY_PLACEHOLDER = "Alchemy worker is being deployed...";
+
+// Force `Connection: close` so each attempt opens a fresh connection and can
+// land on an edge that already has the new deploy / restarted container.
+const freshConn = HttpClient.mapRequest(
+  HttpClientRequest.setHeader("connection", "close"),
+);
+
+const readinessSchedule = Schedule.min([
+  Schedule.exponential("500 millis"),
+  Schedule.spaced("3 seconds"),
+]);
+
+// Retry a route until it answers 200 with a body containing `expected`,
+// rejecting transient non-200s and the pre-create deploy stub.
+const fetchReady = (url: string, expected: string) =>
+  Effect.gen(function* () {
+    const client = freshConn(yield* HttpClient.HttpClient);
+    return yield* client.get(url).pipe(
+      Effect.flatMap((r) =>
+        r.status !== 200
+          ? Effect.fail(new Error(`not ready: ${r.status}`))
+          : Effect.flatMap(r.text, (body) =>
+              body.includes(DEPLOY_PLACEHOLDER) || !body.includes(expected)
+                ? Effect.fail(new Error(`not ready: got ${body}`))
+                : Effect.succeed(body),
+            ),
+      ),
+      Effect.timeout("30 seconds"),
+      Effect.retry({ schedule: readinessSchedule, times: 40 }),
+    );
+  });
+
+// Fire a single GET and return its parsed JSON body.
+const json = <T>(url: string) =>
+  Effect.gen(function* () {
+    const client = freshConn(yield* HttpClient.HttpClient);
+    const res = yield* client.get(url);
+    return (yield* res.json) as T;
+  });
+
+// Poll `/running` until the reported state matches `want`. Reading the flag
+// never restarts the container, so a `false → true` transition observed here
+// with no other traffic in flight is attributable to `keepWarm` alone.
+const waitRunning = (baseUrl: string, name: string, want: boolean) =>
+  Effect.gen(function* () {
+    const client = freshConn(yield* HttpClient.HttpClient);
+    return yield* client
+      .get(`${baseUrl}/running?name=${encodeURIComponent(name)}`)
+      .pipe(
+        Effect.flatMap((r) =>
+          r.status !== 200
+            ? Effect.fail(new Error(`running not ready: ${r.status}`))
+            : Effect.flatMap(r.json, (body) => {
+                const running = (body as { running?: boolean }).running;
+                return running === want
+                  ? Effect.succeed(running)
+                  : Effect.fail(new Error(`running=${running}, want ${want}`));
+              }),
+        ),
+        Effect.timeout("15 seconds"),
+        Effect.retry({ schedule: readinessSchedule, times: 40 }),
+      );
+  });
+
+/**
+ * `keepWarm` (a container kept warm for the life of its DO) and `warmPool`
+ * (containers booted ahead of anyone's first request). The two are
+ * complementary, and the fixture wires both onto the same DO.
+ *
+ * The negative control lives in `ContainerRestart.test.ts`: its container
+ * carries no `keepWarm`, and its tests only ever pass once a stopped
+ * container *stays* stopped until the next real request. So "the container
+ * came back on its own" here is a property of `keepWarm`, not of the
+ * platform.
+ */
+describe("container warming", () => {
+  const stack = beforeAll(deploy(WarmStack), { timeout: HOOK_TIMEOUT });
+  afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(WarmStack), {
+    timeout: HOOK_TIMEOUT,
+  });
+
+  test(
+    "keepWarm restarts a stopped container with no requests in between",
+    Effect.gen(function* () {
+      const { url } = yield* stack;
+      const name = "keep-warm";
+
+      // Start + confirm up, and take the boot id of this container process.
+      expect(yield* fetchReady(`${url}/ping?name=${name}`, "pong")).toContain(
+        "pong",
+      );
+      const before = yield* json<{ boot: string }>(`${url}/boot?name=${name}`);
+
+      // Hard-stop it and confirm it is actually down. The keep-warm cadence is
+      // long relative to this probe, so the container is observably stopped
+      // before the schedule's next tick can act on it.
+      yield* fetchReady(`${url}/stop?name=${name}`, "stopped");
+      yield* waitRunning(url, name, false);
+
+      // The assertion: it comes back with ZERO requests touching the
+      // container. `/running` only reads a flag, so the only thing that can
+      // flip it back is the keepWarm schedule.
+      expect(yield* waitRunning(url, name, true)).toBe(true);
+
+      // ...and it is a genuinely new process, so the flag flipped because the
+      // container really restarted rather than never having gone down.
+      const after = yield* json<{ boot: string }>(`${url}/boot?name=${name}`);
+      expect(after.boot).not.toBe(before.boot);
+    }).pipe(logLevel),
+    { timeout: TEST_TIMEOUT },
+  );
+
+  test(
+    "warmPool wakes every named DO and boots its container",
+    Effect.gen(function* () {
+      const { url } = yield* stack;
+      // Names no test has ever addressed: nothing has constructed these DOs,
+      // so nothing has started their containers.
+      const names = ["pool-a", "pool-b", "pool-c"];
+
+      const result = yield* json<{ warmed: string[] }>(
+        `${url}/warm?names=${names.join(",")}&concurrency=2`,
+      );
+      expect(result.warmed).toEqual(names);
+
+      for (const name of names) {
+        // Each DO recorded the wake itself, so the fan-out demonstrably
+        // reached every name (not just the first, and not only the ones the
+        // concurrency window admitted first).
+        const warmed = yield* json<{ count: number; runningAtWarm: boolean }>(
+          `${url}/warmed?name=${name}`,
+        );
+        expect(warmed.count).toBeGreaterThanOrEqual(1);
+        // And by the time the wake landed, waking the DO had already booted
+        // its container — which is the whole point of warming ahead of the
+        // first real request.
+        expect(warmed.runningAtWarm).toBe(true);
+      }
+    }).pipe(logLevel),
+    { timeout: TEST_TIMEOUT },
+  );
+});

--- a/packages/alchemy/test/Cloudflare/Container/fixtures/warm/container.ts
+++ b/packages/alchemy/test/Cloudflare/Container/fixtures/warm/container.ts
@@ -17,7 +17,12 @@ export class WarmContainer extends Cloudflare.Container<
   }
 >()("WarmContainer") {}
 
-const bootId = crypto.randomUUID();
+// Minted on first ask rather than at module scope: this module is pulled into
+// the Worker bundle too, and workerd refuses to generate random values in
+// global scope ("Disallowed operation called within global scope") — which
+// fails the whole script at startup, not just this fixture. Either way the id
+// is per-process, which is all the test reads it for.
+let bootId: string | undefined;
 
 export default WarmContainer.make(
   {
@@ -27,7 +32,7 @@ export default WarmContainer.make(
   Effect.gen(function* () {
     return {
       ping: () => Effect.succeed("pong"),
-      boot: () => Effect.succeed(bootId),
+      boot: () => Effect.sync(() => (bootId ??= crypto.randomUUID())),
     };
   }),
 );

--- a/packages/alchemy/test/Cloudflare/Container/fixtures/warm/container.ts
+++ b/packages/alchemy/test/Cloudflare/Container/fixtures/warm/container.ts
@@ -1,0 +1,33 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as Dockerfile from "@/Docker/Dockerfile.ts";
+import * as Effect from "effect/Effect";
+
+/**
+ * Minimal effectful container for exercising `keepWarm` / `warmPool`.
+ *
+ * `boot` returns an id generated once per container *process*, so a test can
+ * tell a genuinely restarted container from one that never went down: the id
+ * changes if and only if the process was replaced.
+ */
+export class WarmContainer extends Cloudflare.Container<
+  WarmContainer,
+  {
+    ping: () => Effect.Effect<string>;
+    boot: () => Effect.Effect<string>;
+  }
+>()("WarmContainer") {}
+
+const bootId = crypto.randomUUID();
+
+export default WarmContainer.make(
+  {
+    main: import.meta.filename,
+    dockerfile: Dockerfile.inline`FROM oven/bun:latest`,
+  },
+  Effect.gen(function* () {
+    return {
+      ping: () => Effect.succeed("pong"),
+      boot: () => Effect.succeed(bootId),
+    };
+  }),
+);

--- a/packages/alchemy/test/Cloudflare/Container/fixtures/warm/object.ts
+++ b/packages/alchemy/test/Cloudflare/Container/fixtures/warm/object.ts
@@ -1,0 +1,71 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import { WarmContainer } from "./container.ts";
+
+/**
+ * How often the `keepWarm` schedule re-checks the container. Deliberately far
+ * longer than a poll round-trip so a test can still observe the container
+ * *down* right after killing it (a sub-second cadence would race the probe),
+ * yet short enough that the restart lands well inside the test timeout.
+ */
+const KEEP_WARM_INTERVAL = Duration.seconds(15);
+
+/**
+ * Durable Object backing one {@link WarmContainer}, exposing the levers the
+ * warm tests need:
+ *  - `ping` / `boot` — RPC into the container (also forces a start)
+ *  - `running`       — the raw `container.running` flag, which reading never
+ *                      itself restarts the container (so a `false → true`
+ *                      transition with no other traffic is attributable to
+ *                      `keepWarm` alone)
+ *  - `stop`          — hard stop from the DO side (`destroy` = SIGKILL)
+ *  - `warmed`        — what this DO observed when something woke it via its
+ *                      `fetch` handler, which is how `warmPool` reaches it
+ *
+ * The `fetch` handler records the wake in durable storage rather than in a
+ * closure variable, so the assertion survives the DO being evicted between
+ * the warm pass and the probe.
+ */
+export class WarmObject extends Cloudflare.DurableObject<WarmObject>()(
+  "WarmObject",
+  Effect.gen(function* () {
+    const state = yield* Cloudflare.DurableObjectState;
+    const container = yield* WarmContainer;
+
+    return Effect.gen(function* () {
+      return {
+        ping: () => container.ping(),
+        boot: () => container.boot(),
+        running: () => container.running,
+        stop: () => container.destroy(),
+        warmed: () =>
+          Effect.gen(function* () {
+            const count = (yield* state.storage.get<number>("warmed")) ?? 0;
+            const runningAtWarm =
+              (yield* state.storage.get<boolean>("runningAtWarm")) ?? false;
+            return { count, runningAtWarm };
+          }),
+        // Any inbound call constructs the DO if it isn't resident, which is
+        // where the container layer's eager start fires — this is exactly the
+        // path `warmPool` drives. Record that the wake arrived, and whether
+        // the container was up by the time it did.
+        fetch: Effect.gen(function* () {
+          const count = (yield* state.storage.get<number>("warmed")) ?? 0;
+          yield* state.storage.put("warmed", count + 1);
+          yield* state.storage.put("runningAtWarm", yield* container.running);
+          return HttpServerResponse.text("warmed");
+        }),
+      };
+    });
+  }).pipe(
+    Effect.provide(
+      Cloudflare.Containers.layer(WarmContainer, {
+        enableInternet: true,
+        keepWarm: Schedule.spaced(KEEP_WARM_INTERVAL),
+      }),
+    ),
+  ),
+) {}

--- a/packages/alchemy/test/Cloudflare/Container/fixtures/warm/object.ts
+++ b/packages/alchemy/test/Cloudflare/Container/fixtures/warm/object.ts
@@ -44,18 +44,16 @@ export class WarmObject extends Cloudflare.DurableObject<WarmObject>()(
         warmed: () =>
           Effect.gen(function* () {
             const count = (yield* state.storage.get<number>("warmed")) ?? 0;
-            const runningAtWarm =
-              (yield* state.storage.get<boolean>("runningAtWarm")) ?? false;
-            return { count, runningAtWarm };
+            return { count };
           }),
         // Any inbound call constructs the DO if it isn't resident, which is
         // where the container layer's eager start fires — this is exactly the
-        // path `warmPool` drives. Record that the wake arrived, and whether
-        // the container was up by the time it did.
+        // path `warmPool` drives. Record that the wake arrived; whether the
+        // container is up *yet* is not knowable here (the start has only just
+        // been asked for), so the test polls `running` separately.
         fetch: Effect.gen(function* () {
           const count = (yield* state.storage.get<number>("warmed")) ?? 0;
           yield* state.storage.put("warmed", count + 1);
-          yield* state.storage.put("runningAtWarm", yield* container.running);
           return HttpServerResponse.text("warmed");
         }),
       };

--- a/packages/alchemy/test/Cloudflare/Container/fixtures/warm/stack.ts
+++ b/packages/alchemy/test/Cloudflare/Container/fixtures/warm/stack.ts
@@ -1,0 +1,19 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as Alchemy from "@/index.ts";
+import * as Effect from "effect/Effect";
+import WarmContainerLive from "./container.ts";
+import Worker from "./worker.ts";
+
+export default Alchemy.Stack(
+  "WarmContainerStack",
+  {
+    providers: Cloudflare.providers(),
+    state: Cloudflare.state(),
+  },
+  Effect.gen(function* () {
+    const worker = yield* Worker;
+    return {
+      url: worker.url.as<string>(),
+    };
+  }).pipe(Effect.provide(WarmContainerLive)),
+);

--- a/packages/alchemy/test/Cloudflare/Container/fixtures/warm/worker.ts
+++ b/packages/alchemy/test/Cloudflare/Container/fixtures/warm/worker.ts
@@ -1,0 +1,80 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as Effect from "effect/Effect";
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import { WarmObject } from "./object.ts";
+
+/**
+ * Drives the warm scenarios over HTTP. Each request targets a named DO
+ * instance (`?name=`) so tests can isolate instances:
+ *  - `GET /ping`    → RPC ping (starts/restarts the container, returns "pong")
+ *  - `GET /boot`    → the container process's boot id
+ *  - `GET /running` → `{ running }` (never restarts the container)
+ *  - `GET /stop`    → destroy the container (SIGKILL)
+ *  - `GET /warmed`  → `{ count, runningAtWarm }` as observed by that DO
+ *  - `GET /warm`    → run one `warmPool` pass over `?names=a,b`
+ *
+ * `/warm` calls `warmPool` straight from the fetch handler rather than from a
+ * Cron Trigger (the cadence a real caller would use): the fan-out under test
+ * is one pass, and driving it directly keeps the test deterministic instead
+ * of waiting on cron's once-a-minute floor.
+ */
+export default Cloudflare.Worker(
+  "WarmWorker",
+  {
+    main: import.meta.filename,
+  },
+  Effect.gen(function* () {
+    const objects = yield* WarmObject;
+
+    return {
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        const url = new URL(request.url, "http://x");
+        const name = url.searchParams.get("name") ?? "default";
+
+        if (url.pathname === "/warm") {
+          const names = (url.searchParams.get("names") ?? "")
+            .split(",")
+            .filter((n) => n.length > 0);
+          yield* Cloudflare.Containers.warmPool(objects, {
+            names,
+            concurrency: Number(url.searchParams.get("concurrency") ?? 10),
+          });
+          return yield* HttpServerResponse.json({ warmed: names });
+        }
+
+        const object = objects.getByName(name);
+
+        if (url.pathname === "/ping") {
+          return HttpServerResponse.text(yield* object.ping());
+        }
+        if (url.pathname === "/boot") {
+          return yield* HttpServerResponse.json({ boot: yield* object.boot() });
+        }
+        if (url.pathname === "/running") {
+          return yield* HttpServerResponse.json({
+            running: yield* object.running(),
+          });
+        }
+        if (url.pathname === "/stop") {
+          yield* object.stop();
+          return HttpServerResponse.text("stopped");
+        }
+        if (url.pathname === "/warmed") {
+          return yield* HttpServerResponse.json(yield* object.warmed());
+        }
+
+        return HttpServerResponse.text("ok");
+      }).pipe(
+        // Surface failures as 5xx (not a thrown defect) so the test's readiness
+        // retry treats a mid-restart blip as retryable rather than fatal.
+        Effect.catchCause((cause) =>
+          Effect.succeed(
+            HttpServerResponse.text(String(cause), { status: 503 }),
+          ),
+        ),
+      ),
+    };
+  }),
+);

--- a/website/src/content/docs/cloudflare/compute/containers.mdx
+++ b/website/src/content/docs/cloudflare/compute/containers.mdx
@@ -106,6 +106,79 @@ it gets tree-shaken out of the DO's bundle. A Worker then binds
 `Agent` and calls `agents.getByName(name).ping()` like any other DO
 method.
 
+## Keep it warm between requests
+
+A container Cloudflare puts to sleep during an idle stretch pays a
+full restart on the next real request. Add `keepWarm` to re-check it
+on a schedule instead, so a cold container is caught and restarted
+off the critical path:
+
+```typescript
+import * as Duration from "effect/Duration";
+import * as Schedule from "effect/Schedule";
+
+Cloudflare.Containers.layer(Sandbox, {
+  keepWarm: Schedule.spaced(Duration.minutes(4)).pipe(
+    Schedule.upTo({ duration: Duration.hours(1) }),
+  ),
+});
+```
+
+A tick where the container is already warm costs a single local
+state read — no Cloudflare API call, no billing impact. Only a
+container that has actually gone cold pays the restart. This keeps
+*this* container warm for the life of its own Durable Object; it is
+not a pool of spares — Cloudflare binds a container 1:1 to the DO
+that owns it, so there's no such thing as a pre-warmed instance
+handed to a *different* DO. To warm containers **before** their
+first real request, across many DOs, see the next section.
+
+## Warm containers ahead of the first request
+
+`Cloudflare.Containers.warmPool` fans out a lightweight wake-up to a
+list of Durable Objects — one pass per call — so their containers
+start booting before anyone has actually asked for them. You supply
+which DOs to warm — Alchemy has no way to guess your traffic —
+typically from a Worker on a [Cron Trigger](/cloudflare/messaging/cron),
+which also supplies the recurring cadence: `warmPool` has no schedule
+of its own, so call it once per fire rather than wrapping it in your
+own repeat:
+
+```typescript
+// src/pool-worker.ts
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import { Agent } from "./Agent.ts";
+
+export default Cloudflare.Worker(
+  "PoolWorker",
+  { main: import.meta.url },
+  Effect.gen(function* () {
+    const agents = yield* Agent;
+
+    yield* Cloudflare.Workers.cron("* * * * *", () =>
+      Cloudflare.Containers.warmPool(agents, {
+        names: recentlyActiveAgentIds(), // your own prediction/heuristic
+        concurrency: 10,
+      }),
+    );
+
+    return {
+      fetch: Effect.succeed(HttpServerResponse.text("ok")),
+    };
+  }).pipe(Effect.provide(Cloudflare.Workers.CronEventSourceLive)),
+);
+```
+
+Waking a DO is enough on its own: any inbound call forces it to
+construct if it isn't already resident in memory, which is exactly
+where a container's eager start already fires as a side effect.
+`warmPool` only needs to know how to wake a DO by name — it doesn't
+need to know anything about the container inside it. Pair it with
+`keepWarm` above: `warmPool` gets a container booting before anyone
+has touched it, `keepWarm` keeps that same container warm afterward.
+
 ## Wire the runtime into the Stack
 
 The `.make()` default export is the side-effect that registers the
@@ -320,6 +393,8 @@ Related:
   is fronted by one.
 - [Workers](/cloudflare/compute/workers) — the entrypoint that reaches the
   DO (and through it, the container).
+- [Cron Triggers](/cloudflare/messaging/cron) — how `warmPool`'s scheduled
+  fan-out is typically wired up.
 
 Reference:
 

--- a/website/src/content/docs/cloudflare/compute/run-a-container.mdx
+++ b/website/src/content/docs/cloudflare/compute/run-a-container.mdx
@@ -478,6 +478,47 @@ if (request.url === "/sandbox/exec" && request.method === "POST") {
 method retries with backoff while the container is still booting,
 so you don't have to coordinate readiness yourself.
 
+## Bonus: keep the container warm between requests
+
+Right now, if Cloudflare puts the Sandbox container to sleep during
+an idle stretch, the next `exec`/`hello` call pays a full restart.
+Add `keepWarm` to the same layer call to re-check it on a schedule
+instead:
+
+```diff lang="typescript"
+// src/Agent.ts
+import * as Cloudflare from "alchemy/Cloudflare";
++import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
++import * as Schedule from "effect/Schedule";
+import { Sandbox } from "./Sandbox.ts";
+
+export default class Agent extends Cloudflare.DurableObject<Agent>()(
+  "Agents",
+  Effect.gen(function* () {
+    const sandbox = yield* Sandbox;
+    // ... unchanged ...
+  }).pipe(
+    Effect.provide(
+      Cloudflare.Containers.layer(Sandbox, {
+        enableInternet: true,
++        keepWarm: Schedule.spaced(Duration.minutes(4)).pipe(
++          Schedule.upTo({ duration: Duration.hours(1) }),
++        ),
+      }),
+    ),
+  ),
+) {}
+```
+
+A tick where the container is already warm costs a single local
+state read — no extra Cloudflare API calls, no billing impact — so
+this is safe to leave on for any container that expects bursty
+traffic. `keepWarm` only keeps *this* container warm for the life of
+its own Durable Object; to warm containers **before** their first
+real request, across many DOs, see
+[Warm containers ahead of the first request](/cloudflare/compute/containers#warm-containers-ahead-of-the-first-request).
+
 Next you'll [add a Workflow](/cloudflare/compute/workflows) to
 orchestrate multi-step durable work that the container or DOs can
 trigger — perfect for jobs that need to outlive any single request.


### PR DESCRIPTION
### Why

`Container.start()` already eagerly boots a container the instant its Durable Object constructs — so "warm on wake" already exists. What's missing is warmth *between* real requests within a long DO session (Cloudflare can put a container back to sleep during an idle stretch, and the next request pays a full restart), and warmth *before* a DO has ever been touched at all.

### What

- `keepWarm` on `Cloudflare.Containers.layer(Container, options)`: after the initial eager start, re-runs the existing readiness check on a schedule for the life of the DO. A tick where the container is already warm costs one local state read (no Cloudflare API call, no billing impact); only an actually cold container pays the restart, off the request's critical path. This keeps *one* container warm — not a pool of spares. A container is always bound 1:1 to the DO that owns it, so there's no platform concept of a pre-warmed instance handed to a *different* DO.
- `Cloudflare.Containers.warmPool(namespace, { names, concurrency })`: a generic one-pass fan-out that wakes a caller-supplied list of DO names (this repo can't know a caller's traffic prediction) by firing a lightweight `fetch` at each stub. Waking a DO is enough on its own — any inbound call forces it to construct if it isn't already resident, which is exactly where a container's eager start already fires as a side effect.
- Deliberately no schedule on `warmPool` itself — call it from a Cron Trigger's handler (which already supplies the recurring cadence) rather than wrapping it in `Effect.repeat`. A self-repeating fan-out invoked by something that's itself repeatedly invoked would fork one forever-running loop *per fire*.

### DX

**`keepWarm`** — one field on the layer you already write. No new call sites, no fibers to manage, no teardown; the schedule bounds itself.

```diff lang="typescript"
// src/Agent.ts
import * as Cloudflare from "alchemy/Cloudflare";
+import * as Duration from "effect/Duration";
import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
import { Sandbox } from "./Sandbox.ts";

export default class Agent extends Cloudflare.DurableObject<Agent>()(
  "Agents",
  Effect.gen(function* () {
    const sandbox = yield* Sandbox;
    // ... unchanged ...
  }).pipe(
    Effect.provide(
      Cloudflare.Containers.layer(Sandbox, {
        enableInternet: true,
+       keepWarm: Schedule.spaced(Duration.minutes(4)).pipe(
+         Schedule.upTo({ duration: Duration.hours(1) }),
+       ),
      }),
    ),
  ),
) {}
```

**`warmPool`** — one call from a Cron Trigger handler. You supply the names (your own recent-activity list or prediction); it fans out and returns. No schedule to own — the trigger *is* the cadence.

```typescript
export default Cloudflare.Worker(
  "PoolWorker",
  { main: import.meta.url },
  Effect.gen(function* () {
    const agents = yield* Agent;

    yield* Cloudflare.Workers.cron("* * * * *", () =>
      Cloudflare.Containers.warmPool(agents, {
        names: recentlyActiveAgentIds(), // your own prediction/heuristic
        concurrency: 10,
      }),
    );

    return { fetch: Effect.succeed(HttpServerResponse.text("ok")) };
  }).pipe(Effect.provide(Cloudflare.Workers.CronEventSourceLive)),
);
```

The two compose: `warmPool` gets a DO (and its container) booting *before* anyone touches it; `keepWarm` keeps that same container warm for the rest of the DO's life once it has.

### Tests

Per @sam-goodwin's ask. `ContainerWarm.test.ts` + a `fixtures/warm` stack, modelled on `ContainerRestart.test.ts` — same fixture shape, same readiness-retry helpers, same live-deploy style. Now **run live** against a real Cloudflare account (not this repo's test account — I still don't have creds for that one):

| Test | With this PR | Feature disabled |
|---|---|---|
| `keepWarm restarts a stopped container with no requests in between` | ✓ pass (29.8s) | ✗ **fail** — `running=false, want true`, container stays down for the whole 400s poll |
| `warmPool wakes every named DO and boots its container` | ✓ pass (46.9s) | — |

**`keepWarm`**: start the container, hard-stop it, confirm it's observably down, then assert it comes back with **zero** requests touching it. `/running` only reads a flag, so the schedule is the only thing that can flip it back; a per-process boot id then proves it really restarted rather than never having gone down. The right-hand column is the point — with the `keepWarm` fork disabled, the container never comes back, so the test is testing the feature and not the platform. (`ContainerRestart`'s keepWarm-less container is the standing negative control for the same claim.)

**`warmPool`**: fans out to three DO names nothing has ever addressed. Each records its own wake in durable storage, so the pass demonstrably reached every name — not just the first, and not only what the concurrency window admitted first. The test drives `warmPool` from a fetch route rather than a Cron Trigger: the unit under test is one pass, and this keeps it deterministic instead of waiting out cron's once-a-minute floor.

### What the live run caught

Worth recording, since three real bugs only showed up under a real deploy — all in my test code, none in the feature:

1. **`crypto.randomUUID()` at module scope failed the entire Worker at startup** — this fixture module is pulled into the Worker bundle, and workerd forbids generating random values in global scope (`Disallowed operation called within global scope`). Now minted on first ask.
2. **No readiness retry on the JSON helper** — a request landing before the deploy propagated got Cloudflare's 404 HTML page and died on `Unrecognized token '<'`.
3. **The `warmPool` assertion overclaimed.** It demanded the container be *already running* at the instant the wake handler ran. It isn't: `ensureRunning` calls `container.start()`, which asks for a boot rather than waiting one out, so `running` is still false while the wake handler is on the stack. Warming ahead of the first request only promises the boot is *under way* by then — so the test now polls `running` instead. Worth being precise about in the docs too, and it's why `warmPool` pairs with a cron cadence rather than being called inline before traffic.

Also rebased onto current main and migrated to the `alchemy-test` harness, which the container tests moved to while this branch sat behind.

### Docs

Added a `keepWarm` example + bonus section to the container guides, and a new "Warm containers ahead of the first request" section covering `warmPool`.