### PR TITLE
fix(cloudflare): signal plugin injection to app vite configs via ALCHEMY_CLOUDFLARE_VITE_INJECTED

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/Vite.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Vite.ts
@@ -9,6 +9,41 @@ import { pathToFileURL } from "node:url";
 import type * as vite from "vite";
 import { viteBuildOutputPlugin } from "../../Bundle/Vite.ts";
 
+/**
+ * Signals to the app's own Vite config that Alchemy is injecting its
+ * resource-aware Cloudflare plugin into this build/dev run.
+ *
+ * Apps that also build standalone (plain `vite build` in CI, no Alchemy)
+ * need the Cloudflare plugin in their `vite.config.ts`. Without a guard,
+ * an Alchemy-orchestrated run instantiates that config-file instance
+ * *alongside* the injected one: two same-named plugin stacks whose
+ * cross-plugin API lookups resolve by name, and — in dev — two workerd
+ * runtimes, only one of which carries the Worker's bindings. Guarding on
+ * this variable lets the config-file instance stand down:
+ *
+ * ```ts
+ * // vite.config.ts
+ * process.env.ALCHEMY_CLOUDFLARE_VITE_INJECTED === "1"
+ *   ? null
+ *   : cloudflare({ ... })
+ * ```
+ *
+ * The variable is set process-locally by `viteDev`/`viteBuild`, so it is
+ * correct regardless of which process hosts Vite (`alchemy dev` runs the
+ * dev server in the spawned local-provider host, not in the process that
+ * evaluates the user's alchemy.run.ts — an env variable set there never
+ * reaches the config).
+ *
+ * Contract: the value is `"1"` while the process is Alchemy-orchestrated;
+ * absence means not injected. It is deliberately never unset — Vite
+ * re-evaluates the app config on dev-server restarts long after
+ * `viteDev` returned, and concurrent `viteBuild`s in one process would
+ * race a save/restore. A process that ran an Alchemy build never also
+ * runs a standalone (non-Alchemy) Vite build, so the flag staying set is
+ * correct for the process lifetime.
+ */
+const ALCHEMY_CLOUDFLARE_VITE_INJECTED = "ALCHEMY_CLOUDFLARE_VITE_INJECTED";
+
 export const viteDev = (
   rootDir: string = process.cwd(),
   env: Record<string, unknown>,
@@ -17,6 +52,7 @@ export const viteDev = (
 ) =>
   Effect.acquireRelease(
     Effect.promise(async () => {
+      process.env[ALCHEMY_CLOUDFLARE_VITE_INJECTED] = "1";
       const vite = await loadVite(rootDir);
       const devServer = await vite.createServer({
         root: rootDir,
@@ -43,6 +79,7 @@ export const viteBuild = (
       entryEnvironment: pluginOptions.viteEnvironments?.entry ?? "ssr",
     });
     yield* Effect.promise(async () => {
+      process.env[ALCHEMY_CLOUDFLARE_VITE_INJECTED] = "1";
       const vite = await loadVite(rootDir);
       const builder = await vite.createBuilder(
         {


### PR DESCRIPTION
Closes the second half of #831 (see the corrected diagnosis in the last comment there).

## Problem

Apps that also build standalone (plain `vite build` in CI, no Alchemy) need `@distilled.cloud/cloudflare-vite-plugin` in their `vite.config.ts`. When Alchemy orchestrates a build or dev run, `viteDev`/`viteBuild` inject their own resource-aware instance inline — and the app has no supported way to know, so both instances run:

- Two same-named plugin stacks whose cross-plugin API lookups resolve by name (`resolvePluginApi(plugins, "distilled-cloudflare:options")`) — which instance's options win is resolution-order luck.
- In dev, each `distilled-cloudflare:dev` instance boots its own workerd runtime. The config-file instance has no `worker` options, so its runtime carries **zero user bindings** — and because Vite orders config-file plugins before inline ones, its catch-all middleware serves every request. The user Worker runs with a completely empty `env` (verified by capturing both spawned workerd config buffers on 2.0.0-beta.62).

Apps can't fix this themselves for dev: `alchemy dev` evaluates the user's `alchemy.run.ts` in the `--watch` exec child, but the vite server runs in the separately spawned local-provider host (`Cloudflare/Local.ts`, a sibling process spawned by the CLI) — an env variable set from the program is structurally invisible there. And the config evaluates during Vite's config *load*, before Alchemy's inline plugins or `define` merge, so process-global state is the only channel Alchemy has to signal it.

## Fix

`viteDev` and `viteBuild` set `ALCHEMY_CLOUDFLARE_VITE_INJECTED="1"` before creating the Vite server/builder, making this a documented contract for app configs:

```ts
// vite.config.ts
process.env.ALCHEMY_CLOUDFLARE_VITE_INJECTED === "1"
  ? null // Alchemy injects its resource-aware instance
  : cloudflare({ ... })
```

The variable is deliberately never unset:

- Dev re-evaluates the app config on `server.restart()` long after `viteDev` returned; a save/restore would resurrect the doubled runtime on the first restart.
- Concurrent `viteBuild`s in one process would race a boolean save/restore (one build's restore deletes the flag mid-way through another's config resolution).
- A process that ran an Alchemy build never also runs a standalone (non-Alchemy) Vite build, so the flag staying set is correct for the process lifetime.

Prior art: the (now retired) downstream fork of this repo shipped exactly this contract in its `Vite.ts` and it's what kept multi-mode apps working there. An alternative would be plugin-level dedupe in `@distilled.cloud/cloudflare-rolldown-plugin` (`optionsPlugin` detecting a same-named sibling in `configResolved`), but the plugin can't distinguish "the app's standalone fallback that should stand down" from a legitimately configured second instance, and both instances would still be constructed — the env-var contract means only one ever exists. Happy to add a docs section for the guard wherever you'd like it (the `Website.Vite` docstring seems like the natural place) or adjust naming.

Verified downstream on our monorepo (React Router 8 RSC + Effect worker routes + Hyperdrive/DO/R2 bindings): with the guard visible, `alchemy dev` serves the full app end to end on beta.62; without it, every dev request runs the Worker with `Object.keys(env).length === 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
