### PR TITLE
fix(cloudflare): hash workspace dependency closure for Vite worker diffs

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -579,9 +579,15 @@ export interface ViteOptions {
    */
   rootDir?: string;
   /**
-   * Controls which files are hashed to decide whether a rebuild is needed.
-   * By default every non-gitignored file in `cwd` is hashed, plus the nearest
-   * lockfile. Provide explicit globs to narrow the scope.
+   * Controls which files under `rootDir` are hashed to decide whether a
+   * rebuild is needed. By default every non-gitignored file in `rootDir` is
+   * hashed, plus the nearest lockfile. Provide explicit globs to narrow the
+   * scope.
+   *
+   * The workspace packages `rootDir` depends on are always hashed in addition
+   * to this — changing an imported monorepo package triggers a rebuild even
+   * when nothing under `rootDir` changed. These options only scope the
+   * `rootDir` portion of the hash.
    *
    * @see {@link MemoOptions}
    */

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -12,7 +12,7 @@ import * as crypto from "node:crypto";
 import { Unowned } from "../../AdoptPolicy.ts";
 import * as Artifacts from "../../Artifacts.ts";
 import type { ScopedPlanStatusSession } from "../../Cli/Cli.ts";
-import { hashDirectory } from "../../Command/Memo.ts";
+import { hashViteBuildInputs } from "../../Command/Memo.ts";
 import { isResolved } from "../../Diff.ts";
 import * as ProviderLayer from "../../Local/ProviderLayer.ts";
 import * as Provider from "../../Provider.ts";
@@ -1118,14 +1118,13 @@ export const LiveWorkerProvider = () =>
             const [{ assets, bundle }, input] = yield* Effect.all(
               [
                 viteBuild(props),
-                // hashDirectory expects `{ cwd, memo }`. The vite props
-                // store the project root under `rootDir`, so map it
-                // here. Without this, `cwd` falls back to
-                // `process.cwd()` and the input hash is computed over
-                // the wrong directory tree (often the entire monorepo
-                // root), making it both slow and unable to detect
-                // changes scoped to the actual Vite project.
-                hashDirectory({
+                // Hashes the Vite root (`rootDir`) plus the workspace
+                // packages it depends on. Without `rootDir`, `cwd` would
+                // fall back to `process.cwd()` and hash the wrong tree
+                // (often the whole monorepo); without the workspace
+                // closure, changes to imported packages outside `rootDir`
+                // would look like a no-op and silently skip the deploy.
+                hashViteBuildInputs({
                   cwd: props.vite.rootDir,
                   memo: props.vite.memo,
                 }),
@@ -1732,7 +1731,7 @@ export const LiveWorkerProvider = () =>
           return assetsHash !== output.hash?.assets;
         }
         if (props.vite) {
-          const input = yield* hashDirectory({
+          const input = yield* hashViteBuildInputs({
             cwd: props.vite.rootDir,
             memo: props.vite.memo,
           });

--- a/packages/alchemy/src/Command/Memo.ts
+++ b/packages/alchemy/src/Command/Memo.ts
@@ -3,6 +3,7 @@ import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
 import type { PlatformError } from "effect/PlatformError";
 import fg from "fast-glob";
+import { parse as parseYaml } from "yaml";
 import { gitignoreRulesToGlobs } from "../Util/gitignore-rules-to-globs.ts";
 import { sha256, sha256Object } from "../Util/sha256.ts";
 
@@ -44,6 +45,58 @@ interface ResolvedMemoOptions {
   exclude: string[];
   lockfile: boolean;
 }
+
+/** A workspace package reachable from the build root. */
+export interface WorkspacePackage {
+  /** The package's `name` field, used as a machine-independent hash key. */
+  readonly name: string;
+  /** Absolute path to the package directory. */
+  readonly dir: string;
+}
+
+/** The subset of a `package.json` we read to resolve the workspace closure. */
+interface PackageManifest {
+  readonly name?: string;
+  readonly dependencies?: Record<string, string>;
+  readonly devDependencies?: Record<string, string>;
+  readonly optionalDependencies?: Record<string, string>;
+  readonly peerDependencies?: Record<string, string>;
+  readonly workspaces?: string[] | { packages?: string[] };
+}
+
+/** The subset of `pnpm-workspace.yaml` we read for workspace globs. */
+interface PnpmWorkspace {
+  readonly packages?: string[];
+}
+
+/**
+ * Collects the dependency names to follow when walking the workspace graph.
+ * At the build root we also follow `devDependencies` (Vite plugins and shared
+ * config packages that shape the build live there); deeper in the graph we
+ * follow only the runtime edges a consumer actually pulls in, so the closure
+ * stays scoped to what the app bundles instead of the whole monorepo.
+ */
+const dependencyNames = (
+  manifest: PackageManifest,
+  includeDev: boolean,
+): string[] => [
+  ...Object.keys(manifest.dependencies ?? {}),
+  ...(includeDev ? Object.keys(manifest.devDependencies ?? {}) : []),
+  ...Object.keys(manifest.optionalDependencies ?? {}),
+  ...Object.keys(manifest.peerDependencies ?? {}),
+];
+
+const workspaceGlobs = (
+  manifest: PackageManifest | undefined,
+  pnpm: PnpmWorkspace | undefined,
+): string[] => {
+  const workspaces = manifest?.workspaces;
+  if (Array.isArray(workspaces)) return workspaces;
+  if (workspaces && Array.isArray(workspaces.packages))
+    return workspaces.packages;
+  if (pnpm && Array.isArray(pnpm.packages)) return pnpm.packages;
+  return [];
+};
 
 /**
  * Internal service that resolves memo options, lists matching files, and
@@ -160,10 +213,160 @@ const Memo = Effect.gen(function* () {
     return yield* sha256Object(hashes);
   });
 
+  const readJsonFile = Effect.fn(function* <T>(
+    file: string,
+    parse: (content: string) => T,
+  ): Effect.fn.Return<T | undefined, PlatformError> {
+    const content = yield* fs.readFileString(file).pipe(
+      Effect.catchIf(
+        (error) =>
+          error._tag === "PlatformError" && error.reason._tag === "NotFound",
+        () => Effect.succeed(undefined),
+      ),
+    );
+    if (content === undefined) {
+      return undefined;
+    }
+    // Malformed manifests must not crash a deploy hash; a package we can't
+    // parse simply drops out of the workspace closure.
+    return yield* Effect.sync(() => {
+      try {
+        return parse(content);
+      } catch {
+        return undefined;
+      }
+    });
+  });
+
+  const readManifest = (dir: string) =>
+    readJsonFile(
+      path.join(dir, "package.json"),
+      (content) => JSON.parse(content) as PackageManifest,
+    );
+
+  const readPnpmWorkspace = (dir: string) =>
+    readJsonFile(
+      path.join(dir, "pnpm-workspace.yaml"),
+      (content) => parseYaml(content) as PnpmWorkspace,
+    );
+
+  // Walk up from `cwd` to the nearest ancestor that declares a package
+  // workspace (bun/npm/yarn `workspaces`, or `pnpm-workspace.yaml`).
+  const findWorkspaceRoot = Effect.fn(function* (
+    cwd: string,
+  ): Effect.fn.Return<
+    { root: string; globs: string[] } | undefined,
+    PlatformError
+  > {
+    let dir = cwd;
+    while (true) {
+      const [manifest, pnpm] = yield* Effect.all(
+        [readManifest(dir), readPnpmWorkspace(dir)],
+        { concurrency: "unbounded" },
+      );
+      const globs = workspaceGlobs(manifest, pnpm);
+      if (globs.length > 0) {
+        return { root: dir, globs };
+      }
+      const parent = path.dirname(dir);
+      if (parent === dir) {
+        return undefined;
+      }
+      dir = parent;
+    }
+  });
+
+  // Expand the workspace globs to a name → { dir, manifest } map. Reads each
+  // package.json once so the closure walk never re-reads a manifest.
+  const listWorkspacePackages = Effect.fn(function* (
+    root: string,
+    globs: string[],
+  ): Effect.fn.Return<
+    Map<string, { dir: string; manifest: PackageManifest }>,
+    PlatformError
+  > {
+    const packageJsonPaths = yield* Effect.promise(() =>
+      fg.glob(
+        globs.map((glob) => `${glob.replace(/\/+$/, "")}/package.json`),
+        {
+          cwd: root,
+          ignore: ["**/node_modules/**"],
+          onlyFiles: true,
+          absolute: true,
+        },
+      ),
+    );
+    const entries = yield* Effect.forEach(
+      packageJsonPaths,
+      (packageJsonPath) =>
+        Effect.gen(function* () {
+          const dir = path.dirname(packageJsonPath);
+          const manifest = yield* readManifest(dir);
+          if (!manifest?.name) {
+            return undefined;
+          }
+          return [manifest.name, { dir, manifest }] as const;
+        }),
+      { concurrency: "unbounded" },
+    );
+    const packages = new Map<
+      string,
+      { dir: string; manifest: PackageManifest }
+    >();
+    for (const entry of entries) {
+      if (entry) {
+        packages.set(entry[0], entry[1]);
+      }
+    }
+    return packages;
+  });
+
+  // The set of workspace packages `cwd` transitively depends on, excluding
+  // `cwd` itself. Empty when `cwd` is not inside a package workspace or its
+  // dependency graph reaches no sibling packages.
+  const resolveWorkspaceClosure = Effect.fn(function* (
+    cwd: string,
+  ): Effect.fn.Return<WorkspacePackage[], PlatformError> {
+    const rootDir = path.resolve(cwd);
+    const [rootManifest, workspace] = yield* Effect.all(
+      [readManifest(rootDir), findWorkspaceRoot(rootDir)],
+      { concurrency: "unbounded" },
+    );
+    if (!rootManifest || !workspace) {
+      return [];
+    }
+    const packages = yield* listWorkspacePackages(
+      workspace.root,
+      workspace.globs,
+    );
+    const visited = new Set<string>();
+    if (rootManifest.name) {
+      visited.add(rootManifest.name);
+    }
+    const closure: WorkspacePackage[] = [];
+    const queue = dependencyNames(rootManifest, true);
+    while (queue.length > 0) {
+      const name = queue.shift()!;
+      if (visited.has(name)) {
+        continue;
+      }
+      visited.add(name);
+      const pkg = packages.get(name);
+      if (!pkg || path.resolve(pkg.dir) === rootDir) {
+        continue;
+      }
+      closure.push({ name, dir: pkg.dir });
+      queue.push(...dependencyNames(pkg.manifest, false));
+    }
+    closure.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+    return closure;
+  });
+
   return {
     resolveMemoOptions,
     listFiles,
     hashFiles,
+    resolveWorkspaceClosure,
   };
 });
 
@@ -184,4 +387,63 @@ export const hashDirectory = Effect.fn(function* (props: {
   const files = yield* service.listFiles(resolvedOptions);
   const hash = yield* service.hashFiles(resolvedOptions.cwd, files);
   return hash;
+});
+
+/**
+ * Resolves the workspace packages that the project at `cwd` transitively
+ * depends on. Walks up to the workspace root (bun/npm/yarn `workspaces` or
+ * `pnpm-workspace.yaml`), matches `cwd`'s dependency graph against the
+ * workspace's own packages, and follows workspace edges to a cycle-safe
+ * closure. Returns an empty array when `cwd` is not inside a workspace.
+ */
+export const resolveWorkspaceClosure = Effect.fn(function* (
+  cwd: string,
+): Effect.fn.Return<
+  WorkspacePackage[],
+  PlatformError,
+  FileSystem.FileSystem | Path.Path
+> {
+  const service = yield* Memo;
+  return yield* service.resolveWorkspaceClosure(cwd);
+});
+
+/**
+ * Hashes the inputs that determine whether a Vite-built Worker must rebuild:
+ * the project directory (`cwd`, honoring `memo`) plus every workspace package
+ * it transitively depends on. In a monorepo the app at `cwd` imports packages
+ * that live outside it; hashing `cwd` alone makes changes to those packages
+ * look like a no-op and silently skips the deploy. Each workspace package is
+ * hashed with the same gitignore-respecting semantics as `cwd` (keyed by
+ * package name so the hash is machine-independent), and folded into the
+ * result. With no workspace dependencies the hash is identical to
+ * {@link hashDirectory} of `cwd`, so non-monorepo Workers are unaffected.
+ */
+export const hashViteBuildInputs = Effect.fn(function* (props: {
+  cwd?: string;
+  memo?: MemoOptions;
+}): Effect.fn.Return<string, PlatformError, FileSystem.FileSystem | Path.Path> {
+  const service = yield* Memo;
+  const path = yield* Path.Path;
+  const rootDir = props.cwd ? path.resolve(props.cwd) : process.cwd();
+  const [rootHash, closure] = yield* Effect.all(
+    [
+      hashDirectory({ cwd: rootDir, memo: props.memo }),
+      service.resolveWorkspaceClosure(rootDir),
+    ],
+    { concurrency: "unbounded" },
+  );
+  if (closure.length === 0) {
+    return rootHash;
+  }
+  // The root hash already folds in the nearest lockfile; skip it per package
+  // so a shared monorepo lockfile isn't re-hashed once per closure member.
+  const workspaceHashes = yield* Effect.forEach(
+    closure,
+    ({ name, dir }) =>
+      hashDirectory({ cwd: dir, memo: { lockfile: false } }).pipe(
+        Effect.map((hash) => `${name}:${hash}`),
+      ),
+    { concurrency: "unbounded" },
+  );
+  return yield* sha256Object({ root: rootHash, workspace: workspaceHashes });
 });

--- a/packages/alchemy/test/Command/Memo.test.ts
+++ b/packages/alchemy/test/Command/Memo.test.ts
@@ -1,0 +1,196 @@
+import {
+  hashDirectory,
+  hashViteBuildInputs,
+  resolveWorkspaceClosure,
+} from "@/Command/Memo";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+
+// Builds a small monorepo under a temp dir:
+//
+//   root/                 workspaces: ["packages/*"]
+//   packages/app          -> depends on @scope/lib-a
+//   packages/lib-a        -> depends on @scope/lib-b (and back on lib-a: cycle)
+//   packages/lib-b        -> depends on @scope/lib-a (cycle)
+//   packages/lib-c        -> unrelated, nothing depends on it
+//
+// The app's workspace closure is therefore {@scope/lib-a, @scope/lib-b}.
+const makeWorkspace = Effect.fn(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const root = yield* fs.makeTempDirectoryScoped({ prefix: "alchemy-memo-" });
+
+  const write = (relativePath: string, content: string) =>
+    Effect.gen(function* () {
+      const absolute = path.join(root, relativePath);
+      yield* fs.makeDirectory(path.dirname(absolute), { recursive: true });
+      yield* fs.writeFileString(absolute, content);
+    });
+
+  yield* write(
+    "package.json",
+    JSON.stringify({ name: "root", private: true, workspaces: ["packages/*"] }),
+  );
+  yield* write("bun.lock", "{}");
+
+  yield* write(
+    "packages/app/package.json",
+    JSON.stringify({
+      name: "app",
+      dependencies: { "@scope/lib-a": "workspace:*" },
+    }),
+  );
+  yield* write("packages/app/src/index.ts", "export const app = 1;\n");
+  yield* write("packages/app/ignored.txt", "not part of src\n");
+
+  yield* write(
+    "packages/lib-a/package.json",
+    JSON.stringify({
+      name: "@scope/lib-a",
+      dependencies: { "@scope/lib-b": "workspace:*" },
+    }),
+  );
+  yield* write("packages/lib-a/src/a.ts", "export const a = 1;\n");
+
+  yield* write(
+    "packages/lib-b/package.json",
+    JSON.stringify({
+      name: "@scope/lib-b",
+      // Cycle back to lib-a to exercise cycle-safety of the closure walk.
+      dependencies: { "@scope/lib-a": "workspace:*" },
+    }),
+  );
+  yield* write("packages/lib-b/src/b.ts", "export const b = 1;\n");
+
+  yield* write(
+    "packages/lib-c/package.json",
+    JSON.stringify({ name: "@scope/lib-c" }),
+  );
+  yield* write("packages/lib-c/src/c.ts", "export const c = 1;\n");
+
+  return {
+    root,
+    appDir: path.join(root, "packages", "app"),
+    edit: (relativePath: string, content: string) =>
+      write(relativePath, content),
+  };
+});
+
+describe("resolveWorkspaceClosure", () => {
+  it.effect("resolves the transitive workspace dependency closure", () =>
+    Effect.gen(function* () {
+      const path = yield* Path.Path;
+      const workspace = yield* makeWorkspace();
+
+      const closure = yield* resolveWorkspaceClosure(workspace.appDir);
+
+      // Sorted by name, excludes the app itself and the unrelated lib-c,
+      // and terminates despite the lib-a <-> lib-b cycle.
+      expect(closure.map((pkg) => pkg.name)).toEqual([
+        "@scope/lib-a",
+        "@scope/lib-b",
+      ]);
+      expect(closure.map((pkg) => path.resolve(pkg.dir))).toEqual([
+        path.resolve(path.join(workspace.root, "packages", "lib-a")),
+        path.resolve(path.join(workspace.root, "packages", "lib-b")),
+      ]);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("returns an empty closure outside a workspace", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const dir = yield* fs.makeTempDirectoryScoped({
+        prefix: "alchemy-memo-solo-",
+      });
+      yield* fs.writeFileString(
+        path.join(dir, "package.json"),
+        JSON.stringify({ name: "solo", dependencies: { effect: "^4" } }),
+      );
+
+      expect(yield* resolveWorkspaceClosure(dir)).toEqual([]);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+});
+
+describe("hashViteBuildInputs", () => {
+  it.effect("changes when a transitive workspace dependency changes", () =>
+    Effect.gen(function* () {
+      const workspace = yield* makeWorkspace();
+
+      const before = yield* hashViteBuildInputs({ cwd: workspace.appDir });
+      yield* workspace.edit("packages/lib-b/src/b.ts", "export const b = 2;\n");
+      const after = yield* hashViteBuildInputs({ cwd: workspace.appDir });
+
+      expect(after).not.toBe(before);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("is unchanged when an unrelated workspace package changes", () =>
+    Effect.gen(function* () {
+      const workspace = yield* makeWorkspace();
+
+      const before = yield* hashViteBuildInputs({ cwd: workspace.appDir });
+      // lib-c is a workspace package but not in the app's closure.
+      yield* workspace.edit("packages/lib-c/src/c.ts", "export const c = 2;\n");
+      const after = yield* hashViteBuildInputs({ cwd: workspace.appDir });
+
+      expect(after).toBe(before);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect(
+    "narrows the rootDir scope via memo.include while still tracking the closure",
+    () =>
+      Effect.gen(function* () {
+        const workspace = yield* makeWorkspace();
+        const memo = { include: ["src/**"] };
+
+        const before = yield* hashViteBuildInputs({
+          cwd: workspace.appDir,
+          memo,
+        });
+
+        // A rootDir file outside `include` must not affect the hash.
+        yield* workspace.edit(
+          "packages/app/ignored.txt",
+          "changed but excluded\n",
+        );
+        expect(
+          yield* hashViteBuildInputs({ cwd: workspace.appDir, memo }),
+        ).toBe(before);
+
+        // The workspace closure is still hashed regardless of `memo`.
+        yield* workspace.edit(
+          "packages/lib-a/src/a.ts",
+          "export const a = 2;\n",
+        );
+        expect(
+          yield* hashViteBuildInputs({ cwd: workspace.appDir, memo }),
+        ).not.toBe(before);
+      }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("equals hashDirectory of rootDir when there is no closure", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const dir = yield* fs.makeTempDirectoryScoped({
+        prefix: "alchemy-memo-nodep-",
+      });
+      yield* fs.writeFileString(
+        path.join(dir, "package.json"),
+        JSON.stringify({ name: "solo", dependencies: { effect: "^4" } }),
+      );
+      yield* fs.writeFileString(path.join(dir, "index.ts"), "export {};\n");
+
+      expect(yield* hashViteBuildInputs({ cwd: dir })).toBe(
+        yield* hashDirectory({ cwd: dir }),
+      );
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+});


### PR DESCRIPTION
Fixes #744.

## Problem

The Vite worker's rebuild diff hashes only the files under `props.vite.rootDir`. In a monorepo, the app at `rootDir` imports workspace packages that live outside it — changing only those packages produces a "noop" plan and the deploy silently ships nothing (`Done: 0 succeeded`, exit 0, worker unchanged; this bit us in production). The `memo.include` workaround can't actually cover it either: those globs are relative to `rootDir` and can never reach packages outside it.

## Fix

`hashViteBuildInputs({ cwd, memo })` replaces `hashDirectory` at both Vite hash sites (apply + `hasChanged`). It hashes `rootDir` exactly as before (still scoped by `memo`) and additionally folds in the app's **workspace-dependency closure**:

- Walks up from `rootDir` to the nearest ancestor declaring a workspace (bun/npm/yarn `workspaces` — array or `{ packages }` — or `pnpm-workspace.yaml`), expands the globs once, and reads each `package.json` once.
- Resolves the closure from `rootDir`'s manifest: the root follows `dependencies` + `devDependencies` + `optionalDependencies` + `peerDependencies` (Vite plugins and shared config live in devDeps); transitive steps follow runtime edges only, so the closure stays scoped to what the app bundles rather than ballooning to the whole monorepo. Cycle-safe; matched by package *name* against the workspace's own package map, so `workspace:*` vs hoisted-semver specifiers don't matter.
- Each closure package directory is hashed with the same gitignore-respecting semantics as `rootDir` (`lockfile: false` per package — the root hash already folds in the shared lockfile), keyed by package **name** so the stored `hash.input` stays machine-independent.

With no workspace dependencies the result is byte-identical to the previous `hashDirectory(rootDir)` — non-monorepo workers see zero hash churn. Monorepo workers take one expected redeploy on upgrade.

## Measured on the monorepo that hit the bug

An app depending on **55 workspace packages**: closure resolution 15ms; input hash 137ms → 391ms (+254ms per plan). Both hash sites had this same shape before (the patch widens each call, it doesn't add one); if that cost ever matters, the closure hash is a natural candidate for `Artifacts.cached`-style memoization within a plan run — happy to follow up.

## Deliberate choices (flagging for your call)

- **Closure is always unioned; `memo` scopes only the `rootDir` portion.** Over-inclusion errs toward a spurious rebuild, never a missed deploy — the right bias for a rebuild detector. An opt-out could be added if someone needs it.
- **A malformed sibling `package.json` drops out of the closure instead of failing the plan** (matches the file's existing NotFound-tolerant convention; non-NotFound IO errors still propagate). Say the word if you'd rather fail loud.
- Scoped strictly to the two `WorkerProvider` Vite sites the issue names; non-Vite workers untouched.

Tests: 6 new unit tests in `test/Command/Memo.test.ts` (closure resolution incl. cycles and self-exclusion, hash sensitivity to transitive dep changes, insensitivity to unrelated packages, `memo.include` still respected, empty-closure identity with `hashDirectory`); `WorkerProvider.test.ts` 15/15 green; `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
