### PR TITLE
fix(engine): never persist unresolved Output exprs in resource state

### DIFF
--- a/packages/alchemy/src/Apply.ts
+++ b/packages/alchemy/src/Apply.ts
@@ -16,7 +16,7 @@ import {
   Cli,
 } from "./Cli/Cli.ts";
 import type { ApplyStatus } from "./Cli/Event.ts";
-import { havePropsChanged } from "./Diff.ts";
+import { havePropsChanged, stripUnresolved } from "./Diff.ts";
 import type { Input } from "./Input.ts";
 import { generateInstanceId, InstanceId } from "./InstanceId.ts";
 import * as Output from "./Output.ts";
@@ -405,7 +405,14 @@ const executeNode = (
         stack: stackName,
         stage,
         fqn,
-        value: { ...value, namespace } as S,
+        // Early commits (`creating`/`replacing`) persist plan props that may
+        // still hold unresolved Output exprs; strip them so state stores only
+        // plain data (see stripUnresolved in Diff.ts).
+        value: {
+          ...value,
+          props: stripUnresolved(value.props),
+          namespace,
+        } as S,
       });
 
     const scopedSession = {
@@ -1577,7 +1584,13 @@ const collectGarbage = Effect.fn(function* (
             stack: stackName,
             stage,
             fqn,
-            value: { ...value, namespace } as S,
+            // Same rule as the lifecycle commit above: state only stores
+            // plain data, never unresolved Output exprs.
+            value: {
+              ...value,
+              props: stripUnresolved(value.props),
+              namespace,
+            } as S,
           });
 
         const report = (status: ApplyStatus) =>

--- a/packages/alchemy/src/Diff.ts
+++ b/packages/alchemy/src/Diff.ts
@@ -1,3 +1,4 @@
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import type { Input } from "./Input.ts";
@@ -51,6 +52,38 @@ const _hasUnresolved = (value: unknown): boolean => {
     return Object.values(value as Record<string, unknown>).some(_hasUnresolved);
   }
   return false;
+};
+
+/**
+ * Deeply replace every unresolved plan-time expression (an `Output`/`Expr`
+ * or an un-evaluated `Effect`) with `undefined`, leaving resolved values
+ * (including opaque `Redacted`/`Duration` instances) intact.
+ *
+ * Persisted resource state must only ever hold plain data. Durable (JSON)
+ * state stores already enforce this implicitly — Output proxies are
+ * function-typed, so `JSON.stringify` silently drops them — but the
+ * in-memory store used by tests retains live proxies, which would later be
+ * fed back into provider lifecycle operations as `olds` after an
+ * interrupted apply (e.g. `read` during a destroy plan) and blow up on
+ * first string coercion. Sanitizing at the commit boundary keeps both
+ * store kinds consistent with the provider contract that `olds` is
+ * resolved `Props`.
+ */
+export const stripUnresolved = <T>(value: T): T => _stripUnresolved(value) as T;
+
+const _stripUnresolved = (value: unknown): unknown => {
+  if (value == null || isPrimitive(value)) return value;
+  if (Output.isExpr(value) || Effect.isEffect(value)) return undefined;
+  // Opaque resolved values — rebuilding them structurally would strip
+  // their prototype (see resolveInput in Plan.ts for the same rule).
+  if (Redacted.isRedacted(value) || Duration.isDuration(value)) return value;
+  if (Array.isArray(value)) return value.map(_stripUnresolved);
+  if (typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [key, _stripUnresolved(item)]),
+    );
+  }
+  return value;
 };
 
 export const somePropsAreDifferent = <Props extends Record<string, any>>(

--- a/packages/alchemy/test/Planetscale/Postgres/fixtures/Stack.ts
+++ b/packages/alchemy/test/Planetscale/Postgres/fixtures/Stack.ts
@@ -1,6 +1,8 @@
 import * as Cloudflare from "@/Cloudflare/index.ts";
 import * as Planetscale from "@/Planetscale/index.ts";
 import * as Effect from "effect/Effect";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 /**
  * Shared Planetscale + Cloudflare wiring used by the Hyperdrive
@@ -11,6 +13,16 @@ import * as Effect from "effect/Effect";
  * `role.pooledOrigin` to avoid one direct connection per worker request.
  */
 export const PlanetscaleDb = Effect.gen(function* () {
+  // Resolved inside the effect (not at module scope) so it only runs at
+  // deploy time — `import.meta.url` is undefined in the bundled worker.
+  const migrationsDir = yield* Effect.sync(() =>
+    path.join(
+      import.meta.url ? fileURLToPath(import.meta.url) : ".",
+      "..",
+      "migrations",
+    ),
+  );
+
   const database = yield* Planetscale.PostgresDatabase("HyperdriveTestDb", {
     name: "alchemy-postgres-hyperdrive",
     region: { slug: "us-east" },
@@ -19,8 +31,7 @@ export const PlanetscaleDb = Effect.gen(function* () {
 
   const branch = yield* Planetscale.PostgresBranch("HyperdriveTestBranch", {
     database,
-    migrationsDir:
-      "./packages/alchemy/test/Planetscale/Postgres/fixtures/migrations",
+    migrationsDir,
   });
 
   const role = yield* Planetscale.PostgresRole("HyperdriveTestRole", {

--- a/packages/alchemy/test/Planetscale/Postgres/fixtures/Stack.ts
+++ b/packages/alchemy/test/Planetscale/Postgres/fixtures/Stack.ts
@@ -12,17 +12,15 @@ import { fileURLToPath } from "node:url";
  * `role.origin`; local dev bypasses Hyperdrive, so it uses
  * `role.pooledOrigin` to avoid one direct connection per worker request.
  */
-export const PlanetscaleDb = Effect.gen(function* () {
-  // Resolved inside the effect (not at module scope) so it only runs at
-  // deploy time — `import.meta.url` is undefined in the bundled worker.
-  const migrationsDir = yield* Effect.sync(() =>
-    path.join(
-      import.meta.url ? fileURLToPath(import.meta.url) : ".",
-      "..",
-      "migrations",
-    ),
-  );
+// This module is bundled into the worker (hyperdrive-worker.ts imports it),
+// so this also evaluates at worker startup, where the bundler leaves
+// `import.meta.url` undefined. The fallback is never read there — resource
+// props are only consumed at deploy time.
+const migrationsDir = import.meta.url
+  ? path.join(fileURLToPath(import.meta.url), "..", "migrations")
+  : ".";
 
+export const PlanetscaleDb = Effect.gen(function* () {
   const database = yield* Planetscale.PostgresDatabase("HyperdriveTestDb", {
     name: "alchemy-postgres-hyperdrive",
     region: { slug: "us-east" },

--- a/packages/alchemy/test/apply.test.ts
+++ b/packages/alchemy/test/apply.test.ts
@@ -5028,3 +5028,35 @@ describe("engine-level adoption persists at apply, not plan (issue #793)", () =>
       }),
   );
 });
+
+describe("interrupted create persists no unresolved Output exprs", () => {
+  test.provider(
+    "creating-state props are plain data and destroy converges",
+    (stack) =>
+      Effect.gen(function* () {
+        const program = Effect.gen(function* () {
+          const a = yield* TestResource("A", { string: "a-value" });
+          const b = yield* TestResource("B", { string: a.string });
+          return { a, b };
+        });
+
+        // B's reconcile fails AFTER the engine committed its `creating`
+        // state, which snapshots the plan props — where `string` is still
+        // an unresolved PropExpr referencing A's output.
+        yield* program.pipe(stack.deploy, hook(failOn("B", "create")));
+
+        const b = yield* getState("B");
+        expect(b?.status).toEqual("creating");
+        // State only holds plain data: the unresolved expr must be
+        // stripped, never persisted as a live proxy. A later destroy plan
+        // hands these props back to `provider.read` as `olds`; a live
+        // proxy explodes on first string coercion (e.g. inside a distilled
+        // path-parameter builder).
+        expect((b?.props as TestResourceProps).string).toBeUndefined();
+
+        yield* stack.destroy();
+        expect(yield* getState("B")).toBeUndefined();
+        expect(yield* listState()).toEqual([]);
+      }),
+  );
+});


### PR DESCRIPTION
Both `test/Planetscale/Postgres/Hyperdrive.test.ts` tests died with a defect thrown from distilled's path-parameter builder:

```
Cannot coerce Output<HyperdriveTestDb.organization> to a string via JS coercion
    at buildRequestParts (distilled/packages/core/src/traits.ts:783)
    at GET /organizations/{organization}/databases/{database}/branches/{branch}
    at Plan.ts:1249 (plan.diff.deletion) → Planetscale/Branch.ts read
```

Two bugs stacked:

### 1. Engine: interrupted creates persisted live Output proxies

The first `creating`/`replacing` commits snapshot **plan** props, where upstream references are still live `ResourceExpr`/`PropExpr` proxies. Durable JSON stores drop them silently (proxies are function-typed), but the in-memory scratch store used by `test.provider` kept them. After a mid-deploy failure, the destroy plan handed those props back to `provider.read` as `olds`, and `resolveDatabase(olds.database).organization` reached `getBranch` as an unresolved proxy — the defect above, which also masked the real deploy error (the destroy runs inside `Effect.ensuring`, and defects escape `Effect.ignore`).

Fix: strip unresolved exprs at the state-commit boundary, keeping both store kinds consistent with the provider contract that `olds` is resolved `Props`:

```ts
// Apply.ts — both ResourceState commit helpers
value: { ...value, props: stripUnresolved(value.props), namespace } as S
```

`stripUnresolved` (Diff.ts) deep-replaces `Expr`/`Effect` leaves with `undefined`, preserving `Redacted`/`Duration`. Regression test in `apply.test.ts` covers interrupted-create → state hygiene → destroy convergence.

### 2. Fixture: `migrationsDir` was repo-root-relative

The masked failure: `ENOENT: FileSystem.readDirectory('./packages/alchemy/test/...')`. Tests run from `packages/alchemy`, so the branch reconcile failed right after the branch became ready and cascaded every dependent to `fail`. Now resolved cwd-independently:

```ts
const migrationsDir = yield* Effect.sync(() =>
  path.join(import.meta.url ? fileURLToPath(import.meta.url) : ".", "..", "migrations"),
);
```

Note: with destroy actually working now, each test really deletes and recreates the fixed-name `alchemy-postgres-hyperdrive` database — it previously survived only because the destroy plan died before deleting anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
