### PR TITLE
fix(website): move v2.alchemy.run redirect into the Worker

### DIFF
--- a/website/alchemy.run.ts
+++ b/website/alchemy.run.ts
@@ -21,8 +21,8 @@ const Website = Cloudflare.Website.StaticSite(
     main: "./src/worker.ts",
     outdir: "dist",
     // `alchemy.run` first: the Worker's `url` output is `domains[0]`.
-    // `v2.alchemy.run` stays attached (DNS + cert) but is 301-redirected
-    // to `alchemy.run` by the redirect Ruleset below.
+    // `v2.alchemy.run` stays attached (DNS + cert); the Worker 301s it
+    // to `alchemy.run` (see `redirectLegacyHost` in src/worker.ts).
     domain:
       stack.stage === "prod" ? ["alchemy.run", "v2.alchemy.run"] : undefined,
     memo: {
@@ -58,35 +58,15 @@ export default Alchemy.Stack(
 
     if (stage === "prod") {
       // The `alchemy.run` zone predates this stack (the v1 website created
-      // it), so adopt it — and never delete it on destroy.
-      const zone = yield* Cloudflare.Zone.Zone("Zone", {
+      // it), so adopt it — and never delete it on destroy. The
+      // `v2.alchemy.run` → `alchemy.run` redirect is handled by the Worker
+      // itself (`redirectLegacyHost` in src/worker.ts) rather than a
+      // `http_request_dynamic_redirect` Ruleset: the prod deploy token has
+      // no zone-ruleset permissions (PUT .../rulesets/phases/.../entrypoint
+      // returns 403), and the Worker already runs first on every request.
+      yield* Cloudflare.Zone.Zone("Zone", {
         name: "alchemy.run",
       }).pipe(AdoptPolicy.adopt(true), RemovalPolicy.retain());
-
-      // Single Redirects run at the edge before Workers, so requests to
-      // `v2.alchemy.run` never reach the Worker — they 301 to `alchemy.run`
-      // with path and query preserved.
-      yield* Cloudflare.Ruleset.Ruleset("V2Redirect", {
-        zone,
-        phase: "http_request_dynamic_redirect",
-        rules: [
-          {
-            description: "Redirect v2.alchemy.run to alchemy.run",
-            expression: 'http.host eq "v2.alchemy.run"',
-            action: "redirect",
-            actionParameters: {
-              fromValue: {
-                targetUrl: {
-                  expression:
-                    'concat("https://alchemy.run", http.request.uri.path)',
-                },
-                preserveQueryString: true,
-                statusCode: 301,
-              },
-            },
-          },
-        ],
-      });
     }
 
     if (stage.startsWith("pr-")) {

--- a/website/src/worker.ts
+++ b/website/src/worker.ts
@@ -221,6 +221,8 @@ const resolveRedirect = (url: URL): string | undefined => {
 
 export default {
   fetch: async (request: Request, env: WorkerEnv) => {
+    const legacyRedirect = redirectLegacyHost(request);
+    if (legacyRedirect !== undefined) return legacyRedirect;
     const redirect = resolveRedirect(new URL(request.url));
     if (redirect !== undefined) {
       return Response.redirect(new URL(redirect, request.url), 301);
@@ -239,6 +241,22 @@ export default {
       await rewriteLlmsTxtOrigin(request, rewriteCanonicalHost(request, res)),
     );
   },
+};
+
+/**
+ * The site moved from `v2.alchemy.run` to the apex. The legacy hostname
+ * stays attached to this Worker (DNS + cert) and every request to it is
+ * 301-redirected to `alchemy.run`, path and query preserved. Done here
+ * rather than with a `http_request_dynamic_redirect` Ruleset because the
+ * prod deploy token has no zone-ruleset permissions, and assets are
+ * configured with `runWorkerFirst` so the Worker sees every request.
+ */
+const LEGACY_HOST = "v2.alchemy.run";
+const redirectLegacyHost = (request: Request): Response | undefined => {
+  const url = new URL(request.url);
+  if (url.host !== LEGACY_HOST) return undefined;
+  url.host = CANONICAL_HOST;
+  return Response.redirect(url.toString(), 301);
 };
 
 /**


### PR DESCRIPTION
The prod deploy of #806 failed creating the `V2Redirect` Ruleset — the deploy token has no zone-ruleset permissions:

```
ERROR: Forbidden: request is not authorized
  at PUT /zones/{zone_id}/rulesets/phases/http_request_dynamic_redirect/entrypoint
```

Everything else landed: the Worker deployed and both custom domains attached, so `alchemy.run` is already serving the new site. This PR replaces the Ruleset with a redirect in the Worker itself, which needs no extra token permissions — assets run `runWorkerFirst`, so the Worker sees every request:

```ts
const LEGACY_HOST = "v2.alchemy.run";
const redirectLegacyHost = (request: Request): Response | undefined => {
  const url = new URL(request.url);
  if (url.host !== LEGACY_HOST) return undefined;
  url.host = CANONICAL_HOST;
  return Response.redirect(url.toString(), 301);
};
```

- The adopted `Zone` stays declared (`adopt` + `retain`).
- The failed Ruleset never created anything, so removing it is a state-only cleanup (no delete API call — its state has no attributes).

If the prod token is later re-minted with zone-ruleset permissions, this can move back to a `http_request_dynamic_redirect` Ruleset so redirects short-circuit at the edge without invoking the Worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
