### PR TITLE
docs(blog): back-fill beta.42 and beta.62 release posts

### DIFF
--- a/website/src/content/docs/blog/2026-05-20-beta-42.md
+++ b/website/src/content/docs/blog/2026-05-20-beta-42.md
@@ -1,0 +1,40 @@
+---
+title: 2.0.0-beta.42 - npm Install Hotfix
+date: 2026-05-20T23:30:00Z
+category: release
+excerpt: v2.0.0-beta.42 is a one-fix hotfix for a `ReferenceError` crash that only reproduced when alchemy was installed from npm — a module-load-order TDZ in the Cloudflare Worker's Platform hooks.
+---
+
+`v2.0.0-beta.42` is a one-fix hotfix for a crash that only
+reproduced when alchemy was installed from npm:
+
+```
+ReferenceError: Cannot access 'bindWorkerAsyncBindings' before initialization
+  at node_modules/alchemy/src/Cloudflare/Workers/Worker.ts:684:13
+```
+
+`Worker.ts` forms import cycles with `WorkerAsyncBindings.ts` and
+`WorkerRuntimeContext.ts`, and it passed their exports directly
+into `Platform(...)` — reading them at module-load time. When Bun
+enters the cycle from the other side (which happens with the npm
+package layout, but not in the local workspace), those references
+are still in their temporal dead zone and the import crashes.
+
+beta.42 wraps both hook arguments in arrows so they resolve at
+call time instead of module-load time
+([#378](https://github.com/alchemy-run/alchemy-effect/pull/378)):
+
+```diff lang="typescript"
+  } = Platform(WorkerTypeId, {
+-   onCreate: bindWorkerAsyncBindings,
+-   createRuntimeContext: makeWorkerRuntimeContext,
++   onCreate: (resource, props) =>
++     bindWorkerAsyncBindings(resource as Worker, props),
++   createRuntimeContext: (id) => makeWorkerRuntimeContext(id),
+  });
+```
+
+## Where to go next
+
+- [CHANGELOG](https://github.com/alchemy-run/alchemy-effect/blob/main/CHANGELOG.md#v200-beta42)
+- [Compare v2.0.0-beta.41 → v2.0.0-beta.42](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.41...v2.0.0-beta.42)

--- a/website/src/content/docs/blog/2026-07-14-beta-62.md
+++ b/website/src/content/docs/blog/2026-07-14-beta-62.md
@@ -100,28 +100,47 @@ Effect.gen(function* () {
 ```
 
 Under the hood the handle is a `proxyChain`. It records the method
-chain and replays it when yielded. Yielding resolves the current
-event's `Scope` and builds the pool at most once per event with
-`Effect.cached`:
+chain and replays it when yielded. You can write your own:
 
 ```typescript
-proxyChain<EffectPgDatabase>(
-  Effect.gen(function* () {
-    const scope = yield* Effect.scope; // this event's Scope
-    let memo = cacheFor(scope).get(key);
-    if (memo === undefined) {
-      // allocates the memo cell; the pool builds on first evaluation
-      memo = yield* Effect.cached(buildPool(scope));
-      cacheFor(scope).set(key, memo);
-    }
-    return yield* memo;
-  }),
-);
+import { proxyChain } from "alchemy/Util/proxy-chain";
+import * as Effect from "effect/Effect";
+import * as Scope from "effect/Scope";
+
+// per-event memos, keyed on the event's Scope and GC'd with it
+const caches = new WeakMap<
+  Scope.Scope,
+  Map<symbol, Effect.Effect<any, any, any>>
+>();
+
+// declare in init; builds on first use, at most once per event
+export const perEvent = <A>(build: Effect.Effect<A, any, Scope.Scope>): A => {
+  const key = Symbol();
+  return proxyChain<A>(
+    Effect.gen(function* () {
+      const scope = yield* Effect.scope; // this event's Scope
+      let cache = caches.get(scope);
+      if (cache === undefined) {
+        caches.set(scope, (cache = new Map()));
+      }
+      let memo = cache.get(key);
+      if (memo === undefined) {
+        // allocates the memo cell; the build runs on first evaluation,
+        // and a concurrent first use joins it instead of building twice
+        memo = yield* Effect.cached(Scope.provide(build, scope));
+        cache.set(key, memo);
+      }
+      return yield* memo;
+    }),
+  );
+};
 ```
 
-The pool is built against the event's `Scope`, so it closes when
-the event settles. This is also why `Drizzle.postgres` now works
-inside Durable Object methods.
+Declare `const pool = perEvent(acquirePool)` in init and call it in
+handlers. The build runs against the event's `Scope`, so finalizers
+run when the event settles. The chain you yield must end in an
+Effect, like drizzle's query builders. This pattern is also why
+`Drizzle.postgres` now works inside Durable Object methods.
 
 Lambda gets a real shutdown from the same change. The generated
 entry registers an internal extension, so the instance receives

--- a/website/src/content/docs/blog/2026-07-14-beta-62.md
+++ b/website/src/content/docs/blog/2026-07-14-beta-62.md
@@ -83,30 +83,50 @@ An Effect is only a description, so declaring one in init acquires
 nothing:
 
 ```typescript
-import postgres from "postgres";
+import * as PgClient from "@effect/sql-pg/PgClient";
 
 Effect.gen(function* () {
-  // init: declare the acquisition. Nothing connects yet.
-  const acquire = Effect.acquireRelease(
-    Effect.sync(() => postgres(url)),
-    (sql) => Effect.promise(() => sql.end()),
-  );
+  // init: declare the client. Nothing connects yet.
+  const client = PgClient.make({ url });
 
   return {
     fetch: Effect.gen(function* () {
       // handler: connects on this event's Scope
-      const sql = yield* acquire;
-      const rows = yield* Effect.promise(() => sql`select * from users`);
+      const sql = yield* client;
+      const rows = yield* sql`select * from users`;
       return yield* HttpServerResponse.json(rows);
     }),
   };
 })
 ```
 
-The handler runs the description, so the pool is acquired on the
-event's `Scope` and released when the event settles.
+The pool is acquired on the event's `Scope` and released when the
+event settles.
 
-`Drizzle.postgres` packages this pattern up:
+`proxyChain` removes the extra `yield*`. It wraps the deferred
+client in a chainable handle. Yielding a query resolves the client
+on the current event's `Scope`, then replays the chain against it:
+
+```typescript
+import { proxyChain } from "alchemy/Util/proxy-chain";
+
+Effect.gen(function* () {
+  // init: a chainable handle over the deferred client
+  const sql = proxyChain(PgClient.make({ url }));
+
+  return {
+    fetch: Effect.gen(function* () {
+      const rows = yield* sql`select * from users`;
+      return yield* HttpServerResponse.json(rows);
+    }),
+  };
+})
+```
+
+`Drizzle.postgres` is this pattern plus `Effect.cached` to memoize
+the acquisition per event. The first query opens the pool, every
+later query in the same event reuses it, and the pool closes when
+the event settles:
 
 ```typescript
 Effect.gen(function* () {
@@ -123,14 +143,10 @@ Effect.gen(function* () {
 })
 ```
 
-The handle is a chainable proxy. It records your query chain and
-replays it on first use, and `Effect.cached` memoizes the
-acquisition per event. The first query opens the pool, every later
-query in the same event reuses it, and the pool closes when the
-event settles. See
+See
 [Postgres.ts](https://github.com/alchemy-run/alchemy/blob/main/packages/alchemy/src/Drizzle/Postgres.ts)
-for the full pattern. It is also why `Drizzle.postgres` now works
-inside Durable Object methods.
+for the full implementation. It is also why `Drizzle.postgres` now
+works inside Durable Object methods.
 
 Lambda gets a real shutdown from the same change. The generated
 entry registers an internal extension, so the instance receives

--- a/website/src/content/docs/blog/2026-07-14-beta-62.md
+++ b/website/src/content/docs/blog/2026-07-14-beta-62.md
@@ -41,7 +41,7 @@ Effect.gen(function* () {
   return {
     fetch: Effect.gen(function* () {
       // handler: runs per event, reusing the cached config
-      return HttpServerResponse.json(config);
+      return yield* HttpServerResponse.json(config);
     }),
   };
 })
@@ -97,7 +97,7 @@ Effect.gen(function* () {
       // handler: connects on this event's Scope
       const sql = yield* acquire;
       const rows = yield* Effect.promise(() => sql`select * from users`);
-      return HttpServerResponse.json(rows);
+      return yield* HttpServerResponse.json(rows);
     }),
   };
 })
@@ -117,7 +117,7 @@ Effect.gen(function* () {
     fetch: Effect.gen(function* () {
       // first query builds the pool, memoized on this event's Scope
       const rows = yield* db.select().from(users);
-      return HttpServerResponse.json(rows);
+      return yield* HttpServerResponse.json(rows);
     }),
   };
 })

--- a/website/src/content/docs/blog/2026-07-14-beta-62.md
+++ b/website/src/content/docs/blog/2026-07-14-beta-62.md
@@ -79,9 +79,49 @@ fetch: Effect.gen(function* () {
 }),
 ```
 
-`Drizzle.postgres` already follows this model. It opens one pool
-per event on the first query and closes it when the event settles.
-It also now works inside Durable Object methods.
+You can still declare the resource in init and use it at runtime.
+Declare a lazy handle in init. The first use in a handler acquires
+the real thing against that event's `Scope`. `Drizzle.postgres`
+ships this pattern:
+
+```typescript
+Effect.gen(function* () {
+  // init: declares the handle. No connection is made.
+  const db = yield* Drizzle.postgres(hyperdrive.connectionString);
+
+  return {
+    fetch: Effect.gen(function* () {
+      // first query builds the pool, memoized on this event's Scope
+      const rows = yield* db.select().from(users);
+      return HttpServerResponse.json(rows);
+    }),
+  };
+})
+```
+
+Under the hood the handle is a `proxyChain`. It records the method
+chain and replays it when yielded. Yielding resolves the current
+event's `Scope` and builds the pool at most once per event with
+`Effect.cached`:
+
+```typescript
+proxyChain<EffectPgDatabase>(
+  Effect.gen(function* () {
+    const scope = yield* Effect.scope; // this event's Scope
+    let memo = cacheFor(scope).get(key);
+    if (memo === undefined) {
+      // allocates the memo cell; the pool builds on first evaluation
+      memo = yield* Effect.cached(buildPool(scope));
+      cacheFor(scope).set(key, memo);
+    }
+    return yield* memo;
+  }),
+);
+```
+
+The pool is built against the event's `Scope`, so it closes when
+the event settles. This is also why `Drizzle.postgres` now works
+inside Durable Object methods.
 
 Lambda gets a real shutdown from the same change. The generated
 entry registers an internal extension, so the instance receives

--- a/website/src/content/docs/blog/2026-07-14-beta-62.md
+++ b/website/src/content/docs/blog/2026-07-14-beta-62.md
@@ -34,15 +34,14 @@ event. Every later event reuses them
 ```typescript
 Effect.gen(function* () {
   // init: runs once per isolate. beta.61 ran this on every request.
-  const jwks = yield* fetchJwks(issuer);
-  const verifier = makeVerifier(jwks);
+  const client = yield* HttpClient.HttpClient;
+  const response = yield* client.get("https://example.com/config.json");
+  const config = yield* response.json;
 
   return {
     fetch: Effect.gen(function* () {
-      // handler: gets a fresh request Scope per event
-      yield* verifier.verify(yield* HttpServerRequest);
-      yield* Effect.addFinalizer(() => flushMetrics().pipe(Effect.ignore));
-      return HttpServerResponse.text("ok");
+      // handler: runs per event, reusing the cached config
+      return HttpServerResponse.json(config);
     }),
   };
 })

--- a/website/src/content/docs/blog/2026-07-14-beta-62.md
+++ b/website/src/content/docs/blog/2026-07-14-beta-62.md
@@ -2,81 +2,89 @@
 title: 2.0.0-beta.62 - Build-Once Workers & GitHub Action
 date: 2026-07-14T06:00:00Z
 category: release
-excerpt: v2.0.0-beta.62 rebuilds the Worker runtime around a build-once layer model (layers build once per isolate, resources scope per event), adds an official GitHub Action for deploy/destroy-per-PR pipelines, PlanetScale OAuth login, a custom Worker entry for Vite websites, and a batch of `alchemy dev` reliability fixes.
+excerpt: v2.0.0-beta.62 makes Workers build their layer stack once per isolate instead of on every request — init cost is paid once at cold start — and adds an official GitHub Action, PlanetScale OAuth login, a custom Worker entry for Vite websites, and a batch of `alchemy dev` fixes.
 ---
 
-beta.62 rebuilds the Worker runtime around a **build-once layer
-model** — layers build once per isolate, resources scope per
-event — and adds an official **GitHub Action** for
-deploy/destroy-per-PR pipelines, **PlanetScale OAuth login**, a
-**custom Worker entry** for Vite websites, and a batch of
-`alchemy dev` reliability fixes.
+beta.62 makes Workers build their layer stack **once per isolate**
+instead of on every request, and adds an official **GitHub
+Action**, **PlanetScale OAuth login**, a **custom Worker entry**
+for Vite websites, and a batch of `alchemy dev` fixes.
 
 :::caution
 **Breaking changes** — migration for each is below.
 
 - **Worker layers build once per isolate, not once per request**
-  ([#774](https://github.com/alchemy-run/alchemy-effect/pull/774)).
-  Init code that acquired per-request resources (connections,
-  pools, anything with a finalizer) must move that acquisition
-  into the handler, where a fresh request `Scope` is provided per
-  event. See below.
+  ([#774](https://github.com/alchemy-run/alchemy-effect/pull/774)) —
+  disposables (connections, pools) move from init to the handler.
 - **effect `>=4.0.0-beta.97` is required**
   ([#801](https://github.com/alchemy-run/alchemy-effect/pull/801),
   [#813](https://github.com/alchemy-run/alchemy-effect/pull/813)) —
   effect removed several `Schedule` APIs; alchemy is migrated and
-  the peer range floor is raised to match.
+  the peer floor is raised to match.
 :::
 
 ## Layers build once per isolate
 
 The Worker bridge used to rebuild your entire layer stack on
-every request. Layers now build **once per instance** (on the
-first event), and each event runs against the built context with
-a fresh request `Scope`
+**every request** — every `Layer.effect`, config decode, and
+client constructor re-ran per event. Layers now build once, on the
+first event, and every later event — fetch, RPC, cron, queue —
+reuses them
 ([#774](https://github.com/alchemy-run/alchemy-effect/pull/774)):
 
+```typescript
+Effect.gen(function* () {
+  // init — runs ONCE per isolate (beta.61 ran this on every request)
+  const jwks = yield* fetchJwks(issuer); // one-shot I/O, cached
+  const verifier = makeVerifier(jwks);
+
+  return {
+    fetch: Effect.gen(function* () {
+      // handler — fresh request Scope per event
+      yield* verifier.verify(yield* HttpServerRequest);
+      yield* Effect.addFinalizer(() => flushMetrics().pipe(Effect.ignore));
+      return HttpServerResponse.text("ok");
+    }),
+  };
+})
 ```
-instance scope:  layer build (once, first event) — assembly + one-shot I/O
-request scope:   fresh Scope.Scope per event — disposables, finalizers,
-                 per-request memoization
+
+Init cost is paid once at cold start; steady-state requests jump
+straight to the handler. Durable Objects get the same win — the
+bridge shares one layer build across activations instead of
+building per activation.
+
+The one migration: anything **disposable** moves out of init and
+into the handler, where the per-event `Scope` runs its finalizers
+after the response:
+
+```typescript
+// ❌ init — workerd has no isolate teardown; this finalizer never runs
+const pool = yield* acquirePool();
+
+// ✅ handler — acquired per event, released when the event settles
+fetch: Effect.gen(function* () {
+  const conn = yield* acquireConn();
+  // ...
+}),
 ```
 
-The split is:
+`Drizzle.postgres` follows the model out of the box — one pool per
+event, opened on the first query, closed when the event settles —
+and now works inside Durable Object methods too.
 
-- **Init (layer build) may** resolve services and config,
-  register bindings and listeners, assemble clients, and perform
-  one-shot I/O that caches a plain value — fetch a secret once
-  per isolate instead of once per request.
-- **Init must not** acquire disposables (connections, pools,
-  streams) or retain I/O-backed objects across events — workerd
-  pins them to the creating request and there is no isolate
-  teardown to run their finalizers.
-- **Handlers get a fresh `Scope` per event.**
-  `Effect.addFinalizer` in a handler runs after the response
-  (via `ctx.waitUntil`). Per-request work that needs cleanup
-  acquires lazily, per call.
-
-`Drizzle.postgres` follows the model out of the box: the client
-is assembled at init, and the pool is acquired and memoized per
-request scope — which also means it now works inside Durable
-Object methods. The DO bridge shares the isolate's layer build
-across activations instead of rebuilding per activation.
-
-The same change gives Lambda a real shutdown phase: the generated
-entry registers an internal extension, so the instance gets
-SIGTERM plus a ~500 ms window in which the instance scope closes
-and init-level finalizers run.
+The same change gives Lambda a real shutdown: the generated entry
+registers an internal extension, so the instance gets SIGTERM plus
+a ~500 ms window in which init-level finalizers run.
 
 Docs: [Instance scope vs request
-scope](/infrastructure-as-effects/functions-and-servers#instance-scope-vs-request-scope)
-and [Workers](/cloudflare/compute/workers#isolate-scope-vs-request-scope).
+scope](/infrastructure-as-effects/functions-and-servers#instance-scope-vs-request-scope).
 
 ## Deploy from GitHub Actions
 
-An official composite action resolves the Alchemy lifecycle from
-the GitHub event — deploy a `staging-{pr}` stage on PR open/sync,
-destroy it on close, deploy `prod` on push to main
+One step resolves the Alchemy lifecycle from the GitHub event —
+deploy `staging-{pr}` on PR open/sync, destroy it on close, deploy
+`prod` on push to main
 ([#699](https://github.com/alchemy-run/alchemy-effect/pull/699)).
 Thanks **Harry Solovay**!
 
@@ -84,10 +92,9 @@ Thanks **Harry Solovay**!
 - uses: alchemy-run/alchemy-effect@v1
 ```
 
-It also exports the PR number, and a new `GitHub.GitHubEnv`
-config surfaces the Actions metadata to your stack, so stacks can
-create resources conditionally — like a preview comment on the
-PR:
+A new `GitHub.GitHubEnv` config surfaces the Actions metadata to
+your stack — `undefined` outside CI, so the same stack runs
+unchanged locally:
 
 ```typescript
 import * as GitHub from "alchemy/GitHub";
@@ -104,39 +111,32 @@ if (github?.pr) {
 }
 ```
 
-`GitHubEnv` resolves to `undefined` outside GitHub Actions, so
-the same stack runs unchanged locally. Docs:
-[CI](/environments/ci).
+Docs: [CI](/environments/ci).
 
 ## PlanetScale OAuth login
 
 `alchemy login` now offers browser-based OAuth for PlanetScale,
-mirroring the Cloudflare flow — authorize in the browser, the CLI
-catches the callback on a localhost loopback, exchanges and
-stores the token, and refreshes it proactively
-([#467](https://github.com/alchemy-run/alchemy-effect/pull/467)).
-Env vars and service tokens keep working; OAuth is one more
-option.
+mirroring the Cloudflare flow
+([#467](https://github.com/alchemy-run/alchemy-effect/pull/467)):
 
-Both flows now land on shared, provider-agnostic `/auth/success`
-and `/auth/error` pages on the website
+```sh
+alchemy login
+# authorize in the browser → token stored, refreshed proactively
+```
+
+Env vars and service tokens keep working. Both providers' flows
+now land on shared `/auth/success` and `/auth/error` pages
 ([#780](https://github.com/alchemy-run/alchemy-effect/pull/780)).
 
 ## Custom Worker entry for Vite websites
 
 `Cloudflare.Website.Vite` accepts a `main` prop that forwards a
-custom Worker entry to the Vite plugin — in dev and deploy
+custom Worker entry to the Vite plugin, in dev and deploy
 ([#779](https://github.com/alchemy-run/alchemy-effect/pull/779)).
 Thanks **Daniel Gangl**!
 
-This unblocks Workers that must export more than the framework's
-fetch handler — most commonly Durable Object classes wrapped
-around a React Router / RSC handler, where the framework plugin
-owns the entry and the old `rollupOptions.input` workaround can't
-apply:
-
 ```typescript
-// worker/index.ts
+// worker/index.ts — export more than the framework's fetch handler
 import handler from "virtual:react-router/unstable_rsc/server";
 export { MyDurableObject } from "./my-durable-object";
 export default handler;
@@ -149,21 +149,21 @@ yield* Cloudflare.Website.Vite("Site", {
 });
 ```
 
-## `alchemy dev` reliability
+This unblocks React Router / RSC setups, where the framework
+plugin owns the entry and the old `rollupOptions.input`
+workaround can't apply.
 
-A batch of fixes to local dev, mostly around containers and hot
-reload:
+## `alchemy dev` reliability
 
 - **Hot reload no longer kills service bindings**
   ([#812](https://github.com/alchemy-run/alchemy-effect/pull/812)) —
   the old worker's scope finalizer raced the replacement's
-  registration and deleted it, so RPC calls failed with `Worker
-  not found` after every backend change. Thanks **utopy**!
+  registration, so RPC calls failed with `Worker not found` after
+  every backend change. Thanks **utopy**!
 - **Container environment variables work in dev**
   ([#785](https://github.com/alchemy-run/alchemy-effect/pull/785)).
-- **Dev container images persist**
-  ([#727](https://github.com/alchemy-run/alchemy-effect/pull/727)) —
-  no more rebuild on every restart.
+- **Dev container images persist** — no rebuild on every restart
+  ([#727](https://github.com/alchemy-run/alchemy-effect/pull/727)).
 - **Remote images and external Dockerfiles work in
   `LocalContainerProvider`**
   ([#790](https://github.com/alchemy-run/alchemy-effect/pull/790)).
@@ -176,26 +176,22 @@ reload:
 
 - **`plan` no longer claims ownership of adopted resources**
   ([#794](https://github.com/alchemy-run/alchemy-effect/pull/794)) —
-  the adoption probe persisted state during plan construction, so
   a read-only dry run could silently adopt an unowned cloud
-  resource and a later unrelated deploy would orphan-delete it.
+  resource, and a later unrelated deploy would orphan-delete it.
   Thanks **Daniel Gangl**!
 - **State-store credentials are bound to the account**
   ([#760](https://github.com/alchemy-run/alchemy-effect/pull/760)) —
-  after `alchemy login --configure` switched accounts, the cached
-  state-store credentials kept reading/writing the old account's
-  store while deploys targeted the new one.
+  after `alchemy login --configure` switched accounts, state
+  reads/writes silently kept going to the old account's store.
 - **Provider handlers receive the resource `fqn`**
   ([#783](https://github.com/alchemy-run/alchemy-effect/pull/783)) —
-  the fully-qualified name joins `id` in `reconcile`, `delete`,
-  `read`, `diff`, `precreate`, `tail`, and `logs`, so custom
-  providers can stamp collision-free ownership metadata. Thanks
-  **Daniel Gangl**!
+  the fully-qualified name joins `id` in every lifecycle handler,
+  so custom providers can stamp collision-free ownership metadata.
+  Thanks **Daniel Gangl**!
 - **Cron handlers keep their requirements**
   ([#791](https://github.com/alchemy-run/alchemy-effect/pull/791)) —
   services required by a `Workers.cron` handler surface on the
-  Worker's init effect again instead of being swallowed with
-  `RuntimeContext`. Thanks **Jack Bisceglia**!
+  Worker's init effect again. Thanks **Jack Bisceglia**!
 - **Vite build output is read after the build resolves**
   ([#795](https://github.com/alchemy-run/alchemy-effect/pull/795)) —
   fixes a bundling race in `Website` deploys.
@@ -205,9 +201,7 @@ reload:
 - **`alchemy state clear` respects `ALCHEMY_PROFILE`**
   ([ba705](https://github.com/alchemy-run/alchemy-effect/commit/ba70585f)).
 - **TypeScript 7 (stable) toolchain**
-  ([#804](https://github.com/alchemy-run/alchemy-effect/pull/804)) —
-  the repo builds on `typescript@7`, replacing the tsgo
-  native-preview.
+  ([#804](https://github.com/alchemy-run/alchemy-effect/pull/804)).
 - **New guides**: [Worker Loader](/cloudflare/compute/worker-loader),
   [Rate limiting](/cloudflare/compute/rate-limiting), and
   [Workers Cache](/cloudflare/compute/cache)

--- a/website/src/content/docs/blog/2026-07-14-beta-62.md
+++ b/website/src/content/docs/blog/2026-07-14-beta-62.md
@@ -1,0 +1,225 @@
+---
+title: 2.0.0-beta.62 - Build-Once Workers & GitHub Action
+date: 2026-07-14T06:00:00Z
+category: release
+excerpt: v2.0.0-beta.62 rebuilds the Worker runtime around a build-once layer model (layers build once per isolate, resources scope per event), adds an official GitHub Action for deploy/destroy-per-PR pipelines, PlanetScale OAuth login, a custom Worker entry for Vite websites, and a batch of `alchemy dev` reliability fixes.
+---
+
+beta.62 rebuilds the Worker runtime around a **build-once layer
+model** — layers build once per isolate, resources scope per
+event — and adds an official **GitHub Action** for
+deploy/destroy-per-PR pipelines, **PlanetScale OAuth login**, a
+**custom Worker entry** for Vite websites, and a batch of
+`alchemy dev` reliability fixes.
+
+:::caution
+**Breaking changes** — migration for each is below.
+
+- **Worker layers build once per isolate, not once per request**
+  ([#774](https://github.com/alchemy-run/alchemy-effect/pull/774)).
+  Init code that acquired per-request resources (connections,
+  pools, anything with a finalizer) must move that acquisition
+  into the handler, where a fresh request `Scope` is provided per
+  event. See below.
+- **effect `>=4.0.0-beta.97` is required**
+  ([#801](https://github.com/alchemy-run/alchemy-effect/pull/801),
+  [#813](https://github.com/alchemy-run/alchemy-effect/pull/813)) —
+  effect removed several `Schedule` APIs; alchemy is migrated and
+  the peer range floor is raised to match.
+:::
+
+## Layers build once per isolate
+
+The Worker bridge used to rebuild your entire layer stack on
+every request. Layers now build **once per instance** (on the
+first event), and each event runs against the built context with
+a fresh request `Scope`
+([#774](https://github.com/alchemy-run/alchemy-effect/pull/774)):
+
+```
+instance scope:  layer build (once, first event) — assembly + one-shot I/O
+request scope:   fresh Scope.Scope per event — disposables, finalizers,
+                 per-request memoization
+```
+
+The split is:
+
+- **Init (layer build) may** resolve services and config,
+  register bindings and listeners, assemble clients, and perform
+  one-shot I/O that caches a plain value — fetch a secret once
+  per isolate instead of once per request.
+- **Init must not** acquire disposables (connections, pools,
+  streams) or retain I/O-backed objects across events — workerd
+  pins them to the creating request and there is no isolate
+  teardown to run their finalizers.
+- **Handlers get a fresh `Scope` per event.**
+  `Effect.addFinalizer` in a handler runs after the response
+  (via `ctx.waitUntil`). Per-request work that needs cleanup
+  acquires lazily, per call.
+
+`Drizzle.postgres` follows the model out of the box: the client
+is assembled at init, and the pool is acquired and memoized per
+request scope — which also means it now works inside Durable
+Object methods. The DO bridge shares the isolate's layer build
+across activations instead of rebuilding per activation.
+
+The same change gives Lambda a real shutdown phase: the generated
+entry registers an internal extension, so the instance gets
+SIGTERM plus a ~500 ms window in which the instance scope closes
+and init-level finalizers run.
+
+Docs: [Instance scope vs request
+scope](/infrastructure-as-effects/functions-and-servers#instance-scope-vs-request-scope)
+and [Workers](/cloudflare/compute/workers#isolate-scope-vs-request-scope).
+
+## Deploy from GitHub Actions
+
+An official composite action resolves the Alchemy lifecycle from
+the GitHub event — deploy a `staging-{pr}` stage on PR open/sync,
+destroy it on close, deploy `prod` on push to main
+([#699](https://github.com/alchemy-run/alchemy-effect/pull/699)).
+Thanks **Harry Solovay**!
+
+```yml
+- uses: alchemy-run/alchemy-effect@v1
+```
+
+It also exports the PR number, and a new `GitHub.GitHubEnv`
+config surfaces the Actions metadata to your stack, so stacks can
+create resources conditionally — like a preview comment on the
+PR:
+
+```typescript
+import * as GitHub from "alchemy/GitHub";
+
+const github = yield* GitHub.GitHubEnv;
+
+if (github?.pr) {
+  yield* GitHub.Comment("preview-comment", {
+    owner: github.owner,
+    repository: github.repository,
+    issueNumber: github.pr,
+    body: `Preview for ${github.sha}`,
+  });
+}
+```
+
+`GitHubEnv` resolves to `undefined` outside GitHub Actions, so
+the same stack runs unchanged locally. Docs:
+[CI](/environments/ci).
+
+## PlanetScale OAuth login
+
+`alchemy login` now offers browser-based OAuth for PlanetScale,
+mirroring the Cloudflare flow — authorize in the browser, the CLI
+catches the callback on a localhost loopback, exchanges and
+stores the token, and refreshes it proactively
+([#467](https://github.com/alchemy-run/alchemy-effect/pull/467)).
+Env vars and service tokens keep working; OAuth is one more
+option.
+
+Both flows now land on shared, provider-agnostic `/auth/success`
+and `/auth/error` pages on the website
+([#780](https://github.com/alchemy-run/alchemy-effect/pull/780)).
+
+## Custom Worker entry for Vite websites
+
+`Cloudflare.Website.Vite` accepts a `main` prop that forwards a
+custom Worker entry to the Vite plugin — in dev and deploy
+([#779](https://github.com/alchemy-run/alchemy-effect/pull/779)).
+Thanks **Daniel Gangl**!
+
+This unblocks Workers that must export more than the framework's
+fetch handler — most commonly Durable Object classes wrapped
+around a React Router / RSC handler, where the framework plugin
+owns the entry and the old `rollupOptions.input` workaround can't
+apply:
+
+```typescript
+// worker/index.ts
+import handler from "virtual:react-router/unstable_rsc/server";
+export { MyDurableObject } from "./my-durable-object";
+export default handler;
+```
+
+```typescript
+yield* Cloudflare.Website.Vite("Site", {
+  rootDir: "./site",
+  main: "./site/worker/index.ts",
+});
+```
+
+## `alchemy dev` reliability
+
+A batch of fixes to local dev, mostly around containers and hot
+reload:
+
+- **Hot reload no longer kills service bindings**
+  ([#812](https://github.com/alchemy-run/alchemy-effect/pull/812)) —
+  the old worker's scope finalizer raced the replacement's
+  registration and deleted it, so RPC calls failed with `Worker
+  not found` after every backend change. Thanks **utopy**!
+- **Container environment variables work in dev**
+  ([#785](https://github.com/alchemy-run/alchemy-effect/pull/785)).
+- **Dev container images persist**
+  ([#727](https://github.com/alchemy-run/alchemy-effect/pull/727)) —
+  no more rebuild on every restart.
+- **Remote images and external Dockerfiles work in
+  `LocalContainerProvider`**
+  ([#790](https://github.com/alchemy-run/alchemy-effect/pull/790)).
+- **The provider RPC session is cached and reused**
+  ([#789](https://github.com/alchemy-run/alchemy-effect/pull/789)).
+- **Dev-URL detection favors localhost/IP URLs**
+  ([#787](https://github.com/alchemy-run/alchemy-effect/pull/787)).
+
+## Also in this release
+
+- **`plan` no longer claims ownership of adopted resources**
+  ([#794](https://github.com/alchemy-run/alchemy-effect/pull/794)) —
+  the adoption probe persisted state during plan construction, so
+  a read-only dry run could silently adopt an unowned cloud
+  resource and a later unrelated deploy would orphan-delete it.
+  Thanks **Daniel Gangl**!
+- **State-store credentials are bound to the account**
+  ([#760](https://github.com/alchemy-run/alchemy-effect/pull/760)) —
+  after `alchemy login --configure` switched accounts, the cached
+  state-store credentials kept reading/writing the old account's
+  store while deploys targeted the new one.
+- **Provider handlers receive the resource `fqn`**
+  ([#783](https://github.com/alchemy-run/alchemy-effect/pull/783)) —
+  the fully-qualified name joins `id` in `reconcile`, `delete`,
+  `read`, `diff`, `precreate`, `tail`, and `logs`, so custom
+  providers can stamp collision-free ownership metadata. Thanks
+  **Daniel Gangl**!
+- **Cron handlers keep their requirements**
+  ([#791](https://github.com/alchemy-run/alchemy-effect/pull/791)) —
+  services required by a `Workers.cron` handler surface on the
+  Worker's init effect again instead of being swallowed with
+  `RuntimeContext`. Thanks **Jack Bisceglia**!
+- **Vite build output is read after the build resolves**
+  ([#795](https://github.com/alchemy-run/alchemy-effect/pull/795)) —
+  fixes a bundling race in `Website` deploys.
+- **Container healthcheck durations are unit-suffixed**
+  ([#778](https://github.com/alchemy-run/alchemy-effect/pull/778)) —
+  Docker rejects bare numbers. Thanks **Matthew Aylward**!
+- **`alchemy state clear` respects `ALCHEMY_PROFILE`**
+  ([ba705](https://github.com/alchemy-run/alchemy-effect/commit/ba70585f)).
+- **TypeScript 7 (stable) toolchain**
+  ([#804](https://github.com/alchemy-run/alchemy-effect/pull/804)) —
+  the repo builds on `typescript@7`, replacing the tsgo
+  native-preview.
+- **New guides**: [Worker Loader](/cloudflare/compute/worker-loader),
+  [Rate limiting](/cloudflare/compute/rate-limiting), and
+  [Workers Cache](/cloudflare/compute/cache)
+  ([#805](https://github.com/alchemy-run/alchemy-effect/pull/805)),
+  plus a TanStack + Atom RPC + Drizzle example
+  ([#634](https://github.com/alchemy-run/alchemy-effect/pull/634)).
+
+## Where to go next
+
+- [Instance scope vs request scope](/infrastructure-as-effects/functions-and-servers#instance-scope-vs-request-scope)
+- [CI](/environments/ci)
+- [Workers](/cloudflare/compute/workers)
+- [Workers Cache](/cloudflare/compute/cache)
+- [CHANGELOG](https://github.com/alchemy-run/alchemy-effect/blob/main/CHANGELOG.md#v200-beta62)
+- [Compare v2.0.0-beta.61 → v2.0.0-beta.62](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.61...v2.0.0-beta.62)

--- a/website/src/content/docs/blog/2026-07-14-beta-62.md
+++ b/website/src/content/docs/blog/2026-07-14-beta-62.md
@@ -79,9 +79,34 @@ fetch: Effect.gen(function* () {
 ```
 
 You can still declare the resource in init and use it at runtime.
-Declare a lazy handle in init. The first use in a handler acquires
-the real thing against that event's `Scope`. `Drizzle.postgres`
-ships this pattern:
+An Effect is only a description, so declaring one in init acquires
+nothing:
+
+```typescript
+import postgres from "postgres";
+
+Effect.gen(function* () {
+  // init: declare the acquisition. Nothing connects yet.
+  const acquire = Effect.acquireRelease(
+    Effect.sync(() => postgres(url)),
+    (sql) => Effect.promise(() => sql.end()),
+  );
+
+  return {
+    fetch: Effect.gen(function* () {
+      // handler: connects on this event's Scope
+      const sql = yield* acquire;
+      const rows = yield* Effect.promise(() => sql`select * from users`);
+      return HttpServerResponse.json(rows);
+    }),
+  };
+})
+```
+
+The handler runs the description, so the pool is acquired on the
+event's `Scope` and released when the event settles.
+
+`Drizzle.postgres` packages this pattern up:
 
 ```typescript
 Effect.gen(function* () {
@@ -98,48 +123,14 @@ Effect.gen(function* () {
 })
 ```
 
-Under the hood the handle is a `proxyChain`. It records the method
-chain and replays it when yielded. You can write your own:
-
-```typescript
-import { proxyChain } from "alchemy/Util/proxy-chain";
-import * as Effect from "effect/Effect";
-import * as Scope from "effect/Scope";
-
-// per-event memos, keyed on the event's Scope and GC'd with it
-const caches = new WeakMap<
-  Scope.Scope,
-  Map<symbol, Effect.Effect<any, any, any>>
->();
-
-// declare in init; builds on first use, at most once per event
-export const perEvent = <A>(build: Effect.Effect<A, any, Scope.Scope>): A => {
-  const key = Symbol();
-  return proxyChain<A>(
-    Effect.gen(function* () {
-      const scope = yield* Effect.scope; // this event's Scope
-      let cache = caches.get(scope);
-      if (cache === undefined) {
-        caches.set(scope, (cache = new Map()));
-      }
-      let memo = cache.get(key);
-      if (memo === undefined) {
-        // allocates the memo cell; the build runs on first evaluation,
-        // and a concurrent first use joins it instead of building twice
-        memo = yield* Effect.cached(Scope.provide(build, scope));
-        cache.set(key, memo);
-      }
-      return yield* memo;
-    }),
-  );
-};
-```
-
-Declare `const pool = perEvent(acquirePool)` in init and call it in
-handlers. The build runs against the event's `Scope`, so finalizers
-run when the event settles. The chain you yield must end in an
-Effect, like drizzle's query builders. This pattern is also why
-`Drizzle.postgres` now works inside Durable Object methods.
+The handle is a chainable proxy. It records your query chain and
+replays it on first use, and `Effect.cached` memoizes the
+acquisition per event. The first query opens the pool, every later
+query in the same event reuses it, and the pool closes when the
+event settles. See
+[Postgres.ts](https://github.com/alchemy-run/alchemy/blob/main/packages/alchemy/src/Drizzle/Postgres.ts)
+for the full pattern. It is also why `Drizzle.postgres` now works
+inside Durable Object methods.
 
 Lambda gets a real shutdown from the same change. The generated
 entry registers an internal extension, so the instance receives

--- a/website/src/content/docs/blog/2026-07-14-beta-62.md
+++ b/website/src/content/docs/blog/2026-07-14-beta-62.md
@@ -54,6 +54,19 @@ straight to the handler. Durable Objects get the same win — the
 bridge shares one layer build across activations instead of
 building per activation.
 
+Sharing one build across events depends on cross-request async —
+a concurrent event awaiting the layer build another event started —
+which workerd normally forbids: a promise created in one request
+context can't be resolved from another. Alchemy enables the
+[`handle_cross_request_promise_resolution`](https://developers.cloudflare.com/workers/configuration/compatibility-flags/#handle-cross-request-promise-resolution-correctly)
+compatibility flag automatically for Workers pinned to a
+compatibility date before 2024-10-14 (later dates default it on),
+and each awaiting event pins the in-flight build with
+`ctx.waitUntil` so workerd can't drop the continuation when the
+originating request ends. Opting out with
+`no_handle_cross_request_promise_resolution` is a deploy-time
+error.
+
 The one migration: anything **disposable** moves out of init and
 into the handler, where the per-event `Scope` runs its finalizers
 after the response:

--- a/website/src/content/docs/blog/2026-07-14-beta-62.md
+++ b/website/src/content/docs/blog/2026-07-14-beta-62.md
@@ -2,11 +2,11 @@
 title: 2.0.0-beta.62 - Build-Once Workers & GitHub Action
 date: 2026-07-14T06:00:00Z
 category: release
-excerpt: v2.0.0-beta.62 makes Workers build their layer stack once per isolate instead of on every request — init cost is paid once at cold start — and adds an official GitHub Action, PlanetScale OAuth login, a custom Worker entry for Vite websites, and a batch of `alchemy dev` fixes.
+excerpt: v2.0.0-beta.62 makes Workers build their layer stack once per isolate instead of on every request. It also adds an official GitHub Action, PlanetScale OAuth login, a custom Worker entry for Vite websites, and a batch of `alchemy dev` fixes.
 ---
 
 beta.62 makes Workers build their layer stack **once per isolate**
-instead of on every request, and adds an official **GitHub
+instead of on every request. It also adds an official **GitHub
 Action**, **PlanetScale OAuth login**, a **custom Worker entry**
 for Vite websites, and a batch of `alchemy dev` fixes.
 
@@ -14,33 +14,32 @@ for Vite websites, and a batch of `alchemy dev` fixes.
 **Breaking changes** — migration for each is below.
 
 - **Worker layers build once per isolate, not once per request**
-  ([#774](https://github.com/alchemy-run/alchemy-effect/pull/774)) —
-  disposables (connections, pools) move from init to the handler.
+  ([#774](https://github.com/alchemy-run/alchemy-effect/pull/774)).
+  Connections and pools move from init to the handler.
 - **effect `>=4.0.0-beta.97` is required**
   ([#801](https://github.com/alchemy-run/alchemy-effect/pull/801),
-  [#813](https://github.com/alchemy-run/alchemy-effect/pull/813)) —
-  effect removed several `Schedule` APIs; alchemy is migrated and
+  [#813](https://github.com/alchemy-run/alchemy-effect/pull/813)).
+  effect removed several `Schedule` APIs. Alchemy is migrated and
   the peer floor is raised to match.
 :::
 
 ## Layers build once per isolate
 
 The Worker bridge used to rebuild your entire layer stack on
-**every request** — every `Layer.effect`, config decode, and
-client constructor re-ran per event. Layers now build once, on the
-first event, and every later event — fetch, RPC, cron, queue —
-reuses them
+**every request**. Every `Layer.effect`, config decode, and client
+constructor re-ran per event. Now layers build once, on the first
+event. Every later event reuses them
 ([#774](https://github.com/alchemy-run/alchemy-effect/pull/774)):
 
 ```typescript
 Effect.gen(function* () {
-  // init — runs ONCE per isolate (beta.61 ran this on every request)
-  const jwks = yield* fetchJwks(issuer); // one-shot I/O, cached
+  // init: runs once per isolate. beta.61 ran this on every request.
+  const jwks = yield* fetchJwks(issuer);
   const verifier = makeVerifier(jwks);
 
   return {
     fetch: Effect.gen(function* () {
-      // handler — fresh request Scope per event
+      // handler: gets a fresh request Scope per event
       yield* verifier.verify(yield* HttpServerRequest);
       yield* Effect.addFinalizer(() => flushMetrics().pipe(Effect.ignore));
       return HttpServerResponse.text("ok");
@@ -49,55 +48,53 @@ Effect.gen(function* () {
 })
 ```
 
-Init cost is paid once at cold start; steady-state requests jump
-straight to the handler. Durable Objects get the same win — the
-bridge shares one layer build across activations instead of
-building per activation.
+Init cost is paid once at cold start. After that, every request
+goes straight to the handler. Durable Objects get the same win:
+one layer build shared across activations.
 
-Sharing one build across events depends on cross-request async —
-a concurrent event awaiting the layer build another event started —
-which workerd normally forbids: a promise created in one request
-context can't be resolved from another. Alchemy enables the
+Sharing one build across events needs cross-request async. One
+event awaits a layer build that another event started. workerd
+normally forbids this: a promise created in one request context
+can't be resolved from another. So alchemy enables the
 [`handle_cross_request_promise_resolution`](https://developers.cloudflare.com/workers/configuration/compatibility-flags/#handle-cross-request-promise-resolution-correctly)
-compatibility flag automatically for Workers pinned to a
-compatibility date before 2024-10-14 (later dates default it on),
-and each awaiting event pins the in-flight build with
-`ctx.waitUntil` so workerd can't drop the continuation when the
-originating request ends. Opting out with
-`no_handle_cross_request_promise_resolution` is a deploy-time
-error.
+compatibility flag automatically for Workers with a compatibility
+date before 2024-10-14. Later dates enable it by default. Each
+awaiting event also pins the in-flight build with `ctx.waitUntil`,
+so workerd doesn't drop the continuation when the original request
+ends. Opting out with `no_handle_cross_request_promise_resolution`
+is a deploy-time error.
 
-The one migration: anything **disposable** moves out of init and
-into the handler, where the per-event `Scope` runs its finalizers
-after the response:
+There is one migration. Anything **disposable** moves out of init
+and into the handler. The handler's per-event `Scope` runs its
+finalizers after the response:
 
 ```typescript
-// ❌ init — workerd has no isolate teardown; this finalizer never runs
+// ❌ init: workerd has no isolate teardown, so this finalizer never runs
 const pool = yield* acquirePool();
 
-// ✅ handler — acquired per event, released when the event settles
+// ✅ handler: acquired per event, released when the event settles
 fetch: Effect.gen(function* () {
   const conn = yield* acquireConn();
   // ...
 }),
 ```
 
-`Drizzle.postgres` follows the model out of the box — one pool per
-event, opened on the first query, closed when the event settles —
-and now works inside Durable Object methods too.
+`Drizzle.postgres` already follows this model. It opens one pool
+per event on the first query and closes it when the event settles.
+It also now works inside Durable Object methods.
 
-The same change gives Lambda a real shutdown: the generated entry
-registers an internal extension, so the instance gets SIGTERM plus
-a ~500 ms window in which init-level finalizers run.
+Lambda gets a real shutdown from the same change. The generated
+entry registers an internal extension, so the instance receives
+SIGTERM and a ~500 ms window to run init-level finalizers.
 
 Docs: [Instance scope vs request
 scope](/infrastructure-as-effects/functions-and-servers#instance-scope-vs-request-scope).
 
 ## Deploy from GitHub Actions
 
-One step resolves the Alchemy lifecycle from the GitHub event —
-deploy `staging-{pr}` on PR open/sync, destroy it on close, deploy
-`prod` on push to main
+One step resolves the Alchemy lifecycle from the GitHub event.
+Opening a PR deploys a `staging-{pr}` stage, closing it destroys
+the stage, and pushing to main deploys `prod`
 ([#699](https://github.com/alchemy-run/alchemy-effect/pull/699)).
 Thanks **Harry Solovay**!
 
@@ -105,9 +102,9 @@ Thanks **Harry Solovay**!
 - uses: alchemy-run/alchemy-effect@v1
 ```
 
-A new `GitHub.GitHubEnv` config surfaces the Actions metadata to
-your stack — `undefined` outside CI, so the same stack runs
-unchanged locally:
+A new `GitHub.GitHubEnv` config exposes the Actions metadata to
+your stack. It resolves to `undefined` outside CI, so the same
+stack runs unchanged locally:
 
 ```typescript
 import * as GitHub from "alchemy/GitHub";
@@ -129,7 +126,7 @@ Docs: [CI](/environments/ci).
 ## PlanetScale OAuth login
 
 `alchemy login` now offers browser-based OAuth for PlanetScale,
-mirroring the Cloudflare flow
+the same flow as Cloudflare
 ([#467](https://github.com/alchemy-run/alchemy-effect/pull/467)):
 
 ```sh
@@ -137,8 +134,8 @@ alchemy login
 # authorize in the browser → token stored, refreshed proactively
 ```
 
-Env vars and service tokens keep working. Both providers' flows
-now land on shared `/auth/success` and `/auth/error` pages
+Env vars and service tokens keep working. Both providers now land
+on shared `/auth/success` and `/auth/error` pages
 ([#780](https://github.com/alchemy-run/alchemy-effect/pull/780)).
 
 ## Custom Worker entry for Vite websites
@@ -149,7 +146,7 @@ custom Worker entry to the Vite plugin, in dev and deploy
 Thanks **Daniel Gangl**!
 
 ```typescript
-// worker/index.ts — export more than the framework's fetch handler
+// worker/index.ts: export more than the framework's fetch handler
 import handler from "virtual:react-router/unstable_rsc/server";
 export { MyDurableObject } from "./my-durable-object";
 export default handler;
@@ -162,20 +159,19 @@ yield* Cloudflare.Website.Vite("Site", {
 });
 ```
 
-This unblocks React Router / RSC setups, where the framework
-plugin owns the entry and the old `rollupOptions.input`
-workaround can't apply.
+React Router / RSC setups need this. The framework plugin owns the
+entry, so the old `rollupOptions.input` workaround doesn't apply.
 
 ## `alchemy dev` reliability
 
 - **Hot reload no longer kills service bindings**
   ([#812](https://github.com/alchemy-run/alchemy-effect/pull/812)) —
-  the old worker's scope finalizer raced the replacement's
-  registration, so RPC calls failed with `Worker not found` after
-  every backend change. Thanks **utopy**!
+  reloading a worker used to delete its replacement's registration,
+  so RPC calls failed with `Worker not found` after every backend
+  change. Thanks **utopy**!
 - **Container environment variables work in dev**
   ([#785](https://github.com/alchemy-run/alchemy-effect/pull/785)).
-- **Dev container images persist** — no rebuild on every restart
+- **Dev container images persist across restarts**
   ([#727](https://github.com/alchemy-run/alchemy-effect/pull/727)).
 - **Remote images and external Dockerfiles work in
   `LocalContainerProvider`**


### PR DESCRIPTION
Back-fill the two missing release posts — every other `chore(release)` on main already has one.

- **beta.42** (2026-05-20) — short hotfix post for the npm-only TDZ crash in the Worker's `Platform` hooks ([#378](https://github.com/alchemy-run/alchemy-effect/pull/378)).
- **beta.62** (2026-07-14) — full post: build-once layer model ([#774](https://github.com/alchemy-run/alchemy-effect/pull/774)) and the effect `>=4.0.0-beta.97` floor in the breaking callout; dedicated sections for the GitHub Action ([#699](https://github.com/alchemy-run/alchemy-effect/pull/699)), PlanetScale OAuth login ([#467](https://github.com/alchemy-run/alchemy-effect/pull/467)), the custom Worker entry for Vite websites ([#779](https://github.com/alchemy-run/alchemy-effect/pull/779)), and the grouped `alchemy dev` fixes; long tail in the also-list. External contributors thanked (Harry Solovay, Daniel Gangl, utopy, Jack Bisceglia, Matthew Aylward).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
