### PR TITLE
refactor(cloudflare): use named workers.Binding/SettingsBinding from distilled

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -767,7 +767,7 @@ export const toRuntimeBinding = Effect.fn(function* (b: WorkerBinding) {
       return DurableObjectNamespace.local({
         binding: b.name,
         className: b.className,
-        scriptName: b.scriptName,
+        scriptName: b.scriptName ?? undefined,
         uniqueKey:
           b.namespaceId ??
           encodeURIComponent(`${b.scriptName!}-${b.className}`),
@@ -796,7 +796,7 @@ export const toRuntimeBinding = Effect.fn(function* (b: WorkerBinding) {
         queueName: b.queueName,
       });
     case "r2_bucket":
-      return R2Bucket.remote(b.name, b.bucketName, b.jurisdiction);
+      return R2Bucket.remote(b.name, b.bucketName, b.jurisdiction ?? undefined);
     case "ratelimit":
       return RateLimit.local({
         binding: b.name,
@@ -812,15 +812,15 @@ export const toRuntimeBinding = Effect.fn(function* (b: WorkerBinding) {
     case "send_email":
       return SendEmail.remote({
         binding: b.name,
-        destinationAddress: b.destinationAddress,
-        allowedDestinationAddresses: b.allowedDestinationAddresses,
-        allowedSenderAddresses: b.allowedSenderAddresses,
+        destinationAddress: b.destinationAddress ?? undefined,
+        allowedDestinationAddresses: b.allowedDestinationAddresses ?? undefined,
+        allowedSenderAddresses: b.allowedSenderAddresses ?? undefined,
       });
     case "service":
       return Service.local({
         binding: b.name,
         scriptName: b.service,
-        entrypoint: b.entrypoint,
+        entrypoint: b.entrypoint ?? undefined,
       });
     case "text_blob":
       return Data.local(b.name, Buffer.from(b.part));
@@ -837,7 +837,7 @@ export const toRuntimeBinding = Effect.fn(function* (b: WorkerBinding) {
         binding: b.name,
         workflowName: b.workflowName,
         className: b.className,
-        scriptName: b.scriptName,
+        scriptName: b.scriptName ?? undefined,
       });
     default:
       return yield* unsupported();

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
@@ -1,4 +1,4 @@
-import type { PutScriptRequest } from "@distilled.cloud/cloudflare/workers";
+import type { Binding } from "@distilled.cloud/cloudflare/workers";
 import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import type { InputProps } from "../../Input.ts";
@@ -98,9 +98,7 @@ export const bindWorkerAsyncBindings = Effect.fn(function* (
   }
 });
 
-type BindingSpec = InputProps<
-  Exclude<PutScriptRequest["metadata"]["bindings"], undefined>[number]
->;
+type BindingSpec = InputProps<Binding>;
 
 const toBinding = (
   bindingName: string,

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerBinding.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerBinding.ts
@@ -31,15 +31,9 @@ import type { VersionMetadataBinding } from "./VersionMetadataBinding.ts";
 import { Worker, WorkerEnvironment } from "./Worker.ts";
 import type { WorkerLoader } from "./WorkerLoader.ts";
 
-export type WorkerBinding = Exclude<
-  workers.PutScriptRequest["metadata"]["bindings"],
-  undefined
->[number];
+export type WorkerBinding = workers.Binding;
 
-export type WorkerSettingsBinding = Exclude<
-  workers.GetScriptScriptAndVersionSettingResponse["bindings"],
-  null | undefined
->[number];
+export type WorkerSettingsBinding = workers.SettingsBinding;
 
 export type WorkerBindingResource =
   // Config values


### PR DESCRIPTION
distilled now exports the Workers script-upload binding union as named type aliases (alchemy-run/distilled#381), so the `Exclude<...>[number]` digs go away:

```diff
-export type WorkerBinding = Exclude<
-  workers.PutScriptRequest["metadata"]["bindings"],
-  undefined
->[number];
+export type WorkerBinding = workers.Binding;

-export type WorkerSettingsBinding = Exclude<
-  workers.GetScriptScriptAndVersionSettingResponse["bindings"],
-  null | undefined
->[number];
+export type WorkerSettingsBinding = workers.SettingsBinding;
```

- Bumps the distilled submodule to pick up the named aliases (and one exported interface per variant, e.g. `workers.WorkersBindingKindDurableObjectNamespace2`).
- Optional variant props are now honestly nullable (matching what the runtime schema accepts/decodes), so `toRuntimeBinding` in `LocalWorkerProvider` coalesces `null` to `undefined` where local-mode helpers expect `string | undefined`.

Verified with `bun tsc -b` and live `WorkerEnv` / `WorkerBinding` suites against real Cloudflare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
