### PR TITLE
chore: update repo references to alchemy-run/alchemy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       # distilled submodule, so consumer checkouts must fetch it.
       submodules: "true"
       version: ${{ inputs.version }}
-      repo: alchemy-run/alchemy-effect
+      repo: alchemy-run/alchemy
       current-version: "2.0.0"
       # Each package builds in its own publish job: the tsc build pulls
       # in the alchemy -> distilled project-reference chain (distilled/aws

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,45 +3,45 @@
 ### &nbsp;&nbsp;&nbsp;🚨 Breaking Changes
 
 - **cloudflare**:
-  - **workers**: Build layers once per isolate, scope resources per event &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/774 [<samp>(25ed5)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/25ed5171)
+  - **workers**: Build layers once per isolate, scope resources per event &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/774 [<samp>(25ed5)</samp>](https://github.com/alchemy-run/alchemy/commit/25ed5171)
 
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
-- Add alchemy action and gh env helper &nbsp;-&nbsp; by **Harry Solovay** in https://github.com/alchemy-run/alchemy-effect/issues/699 [<samp>(80753)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/807535ba)
+- Add alchemy action and gh env helper &nbsp;-&nbsp; by **Harry Solovay** in https://github.com/alchemy-run/alchemy/issues/699 [<samp>(80753)</samp>](https://github.com/alchemy-run/alchemy/commit/807535ba)
 - **cloudflare**:
-  - **website**: Forward a custom worker entry (main) to the Vite plugin &nbsp;-&nbsp; by **Daniel Gangl** in https://github.com/alchemy-run/alchemy-effect/issues/779 [<samp>(c7de7)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/c7de74c5)
+  - **website**: Forward a custom worker entry (main) to the Vite plugin &nbsp;-&nbsp; by **Daniel Gangl** in https://github.com/alchemy-run/alchemy/issues/779 [<samp>(c7de7)</samp>](https://github.com/alchemy-run/alchemy/commit/c7de74c5)
 - **engine**:
-  - Thread resource fqn into provider handler inputs &nbsp;-&nbsp; by **Daniel Gangl** in https://github.com/alchemy-run/alchemy-effect/issues/783 [<samp>(20ed8)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/20ed8d24)
+  - Thread resource fqn into provider handler inputs &nbsp;-&nbsp; by **Daniel Gangl** in https://github.com/alchemy-run/alchemy/issues/783 [<samp>(20ed8)</samp>](https://github.com/alchemy-run/alchemy/commit/20ed8d24)
 - **planetscale**:
-  - OAuth login + shared landing pages &nbsp;-&nbsp; by **Michael (Pear)** in https://github.com/alchemy-run/alchemy-effect/issues/467 [<samp>(5a0be)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/5a0beb1d)
+  - OAuth login + shared landing pages &nbsp;-&nbsp; by **Michael (Pear)** in https://github.com/alchemy-run/alchemy/issues/467 [<samp>(5a0be)</samp>](https://github.com/alchemy-run/alchemy/commit/5a0beb1d)
 - **website**:
-  - OAuth landing pages &nbsp;-&nbsp; by **Michael (Pear)** in https://github.com/alchemy-run/alchemy-effect/issues/780 [<samp>(1e9d0)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/1e9d0c11)
+  - OAuth landing pages &nbsp;-&nbsp; by **Michael (Pear)** in https://github.com/alchemy-run/alchemy/issues/780 [<samp>(1e9d0)</samp>](https://github.com/alchemy-run/alchemy/commit/1e9d0c11)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- Upgrade effect to 4.0.0-beta.97 and migrate removed Schedule APIs &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/801 [<samp>(89f2d)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/89f2dff1)
-- Update dependencies to support effect 4.0.0-beta.97 &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/813 [<samp>(a644c)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/a644c854)
+- Upgrade effect to 4.0.0-beta.97 and migrate removed Schedule APIs &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/801 [<samp>(89f2d)</samp>](https://github.com/alchemy-run/alchemy/commit/89f2dff1)
+- Update dependencies to support effect 4.0.0-beta.97 &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/813 [<samp>(a644c)</samp>](https://github.com/alchemy-run/alchemy/commit/a644c854)
 - **bundle**:
-  - Read vite build output after buildApp resolves &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/795 [<samp>(87244)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/87244a57)
+  - Read vite build output after buildApp resolves &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/795 [<samp>(87244)</samp>](https://github.com/alchemy-run/alchemy/commit/87244a57)
 - **cli**:
-  - Respect ALCHEMY_PROFILE in alchemy state clear &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(ba705)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/ba70585f)
+  - Respect ALCHEMY_PROFILE in alchemy state clear &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(ba705)</samp>](https://github.com/alchemy-run/alchemy/commit/ba70585f)
 - **cloudflare**:
-  - Support container environment variables in alchemy dev &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/785 [<samp>(ae68c)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/ae68cff7)
-  - Persist dev image for containers &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/727 [<samp>(d92af)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/d92af2a8)
-  - Preserve dev worker registration on reload &nbsp;-&nbsp; by **utopy** in https://github.com/alchemy-run/alchemy-effect/issues/812 [<samp>(9864c)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/9864c8de)
-  - Support remote images and external Dockerfiles in LocalContainerProvider &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/790 [<samp>(c9996)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/c999680e)
-  - **state**: Bind cached state-store credentials to the account &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/760 [<samp>(726cf)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/726cf9f0)
-  - **workers**: Preserve cron handler requirements &nbsp;-&nbsp; by **Jack Bisceglia** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/791 [<samp>(68b35)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/68b359b6)
+  - Support container environment variables in alchemy dev &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/785 [<samp>(ae68c)</samp>](https://github.com/alchemy-run/alchemy/commit/ae68cff7)
+  - Persist dev image for containers &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/727 [<samp>(d92af)</samp>](https://github.com/alchemy-run/alchemy/commit/d92af2a8)
+  - Preserve dev worker registration on reload &nbsp;-&nbsp; by **utopy** in https://github.com/alchemy-run/alchemy/issues/812 [<samp>(9864c)</samp>](https://github.com/alchemy-run/alchemy/commit/9864c8de)
+  - Support remote images and external Dockerfiles in LocalContainerProvider &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/790 [<samp>(c9996)</samp>](https://github.com/alchemy-run/alchemy/commit/c999680e)
+  - **state**: Bind cached state-store credentials to the account &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/760 [<samp>(726cf)</samp>](https://github.com/alchemy-run/alchemy/commit/726cf9f0)
+  - **workers**: Preserve cron handler requirements &nbsp;-&nbsp; by **Jack Bisceglia** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/791 [<samp>(68b35)</samp>](https://github.com/alchemy-run/alchemy/commit/68b359b6)
 - **command**:
-  - **dev**: Favor localhost/IP URLs in dev-URL detection &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/787 [<samp>(788f4)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/788f4a41)
+  - **dev**: Favor localhost/IP URLs in dev-URL detection &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/787 [<samp>(788f4)</samp>](https://github.com/alchemy-run/alchemy/commit/788f4a41)
 - **docker**:
-  - Unit-suffix Container healthcheck durations &nbsp;-&nbsp; by **Matthew Aylward** in https://github.com/alchemy-run/alchemy-effect/issues/778 [<samp>(fa2c2)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/fa2c206d)
+  - Unit-suffix Container healthcheck durations &nbsp;-&nbsp; by **Matthew Aylward** in https://github.com/alchemy-run/alchemy/issues/778 [<samp>(fa2c2)</samp>](https://github.com/alchemy-run/alchemy/commit/fa2c206d)
 - **engine**:
-  - Stop persisting adopted state during plan construction &nbsp;-&nbsp; by **Daniel Gangl** in https://github.com/alchemy-run/alchemy-effect/issues/794 [<samp>(011d5)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/011d526e)
+  - Stop persisting adopted state during plan construction &nbsp;-&nbsp; by **Daniel Gangl** in https://github.com/alchemy-run/alchemy/issues/794 [<samp>(011d5)</samp>](https://github.com/alchemy-run/alchemy/commit/011d526e)
 - **local**:
-  - Reuse cached provider RPC session in alchemy dev &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/789 [<samp>(819a8)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/819a831a)
+  - Reuse cached provider RPC session in alchemy dev &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/789 [<samp>(819a8)</samp>](https://github.com/alchemy-run/alchemy/commit/819a831a)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.61...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.61...HEAD)
 
 ---
 
@@ -50,48 +50,48 @@
 ### &nbsp;&nbsp;&nbsp;🚨 Breaking Changes
 
 - **cloudflare**:
-  - Expand workflows api &nbsp;-&nbsp; by **Gerben Mulder**, **Sam Goodwin** and **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/611 [<samp>(4b0c5)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/4b0c527b)
-  - **workers**: Workers Cache support + Effect-native ExecutionContext &nbsp;-&nbsp; by **Sam Goodwin** and **Claude Fable 5** in https://github.com/alchemy-run/alchemy-effect/issues/752 [<samp>(ff81b)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/ff81bee4)
+  - Expand workflows api &nbsp;-&nbsp; by **Gerben Mulder**, **Sam Goodwin** and **John Royal** in https://github.com/alchemy-run/alchemy/issues/611 [<samp>(4b0c5)</samp>](https://github.com/alchemy-run/alchemy/commit/4b0c527b)
+  - **workers**: Workers Cache support + Effect-native ExecutionContext &nbsp;-&nbsp; by **Sam Goodwin** and **Claude Fable 5** in https://github.com/alchemy-run/alchemy/issues/752 [<samp>(ff81b)</samp>](https://github.com/alchemy-run/alchemy/commit/ff81bee4)
 
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
 - **aws**:
-  - **lambda**: Add event invoke config &nbsp;-&nbsp; by **José Netto** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/627 [<samp>(74754)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/74754b7a)
+  - **lambda**: Add event invoke config &nbsp;-&nbsp; by **José Netto** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/627 [<samp>(74754)</samp>](https://github.com/alchemy-run/alchemy/commit/74754b7a)
 - **cli**:
-  - `alchemy sync` — reconcile state drift via read+reconcile &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/766 [<samp>(dcafc)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/dcafc26a)
+  - `alchemy sync` — reconcile state drift via read+reconcile &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/766 [<samp>(dcafc)</samp>](https://github.com/alchemy-run/alchemy/commit/dcafc26a)
 - **cloudflare**:
-  - **Worker**: Add Zone Routes &nbsp;-&nbsp; by **utopy** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/438 [<samp>(dc871)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/dc8717c9)
-  - **ai**: Add AI.ProviderKey BYOK composition helper &nbsp;-&nbsp; by **Alex** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/586 [<samp>(8c9bf)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/8c9bfe78)
-  - **r2**: Restore cors prop on Bucket &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/771 [<samp>(14409)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/144090f8)
+  - **Worker**: Add Zone Routes &nbsp;-&nbsp; by **utopy** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/438 [<samp>(dc871)</samp>](https://github.com/alchemy-run/alchemy/commit/dc8717c9)
+  - **ai**: Add AI.ProviderKey BYOK composition helper &nbsp;-&nbsp; by **Alex** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/586 [<samp>(8c9bf)</samp>](https://github.com/alchemy-run/alchemy/commit/8c9bfe78)
+  - **r2**: Restore cors prop on Bucket &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/771 [<samp>(14409)</samp>](https://github.com/alchemy-run/alchemy/commit/144090f8)
 - **engine**:
-  - Resource type aliases for safe type renames &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/765 [<samp>(27138)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/27138721)
+  - Resource type aliases for safe type renames &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/765 [<samp>(27138)</samp>](https://github.com/alchemy-run/alchemy/commit/27138721)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- Require effect >=4.0.0-beta.93 and migrate UrlParams.makeUrl to Url.make &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/748 [<samp>(94451)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/944510ca)
-- Guard read/diff recovery paths against lost Output-valued olds &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/770 [<samp>(29df0)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/29df03eb)
+- Require effect >=4.0.0-beta.93 and migrate UrlParams.makeUrl to Url.make &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/748 [<samp>(94451)</samp>](https://github.com/alchemy-run/alchemy/commit/944510ca)
+- Guard read/diff recovery paths against lost Output-valued olds &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/770 [<samp>(29df0)</samp>](https://github.com/alchemy-run/alchemy/commit/29df03eb)
 - **aws**:
-  - **ecs**: Unwedge plan/deploy/destroy after a half-created Service &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/767 [<samp>(70037)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/70037fe1)
+  - **ecs**: Unwedge plan/deploy/destroy after a half-created Service &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/767 [<samp>(70037)</samp>](https://github.com/alchemy-run/alchemy/commit/70037fe1)
 - **cli**:
-  - Suppress bun's benign tsconfig-override fd warning in dev &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/768 [<samp>(82692)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/826923a3)
+  - Suppress bun's benign tsconfig-override fd warning in dev &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/768 [<samp>(82692)</samp>](https://github.com/alchemy-run/alchemy/commit/826923a3)
 - **cloudflare**:
-  - Include worker metadata in the update diff &nbsp;-&nbsp; by **Alex** in https://github.com/alchemy-run/alchemy-effect/issues/747 [<samp>(26221)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/26221009)
-  - Fix state-store errors &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy-effect/issues/737 [<samp>(6c9b6)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/6c9b67c5)
-  - Preserve explicit globalOutbound: null in WorkerLoader &nbsp;-&nbsp; by **Alex** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/746 [<samp>(52be6)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/52be64e2)
-  - Classify Resource.ref values as native Worker env bindings &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/756 [<samp>(01b4a)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/01b4ae32)
-  - Dispatch for multiple queue consumers &nbsp;-&nbsp; by **Leonardo E. Dominguez** in https://github.com/alchemy-run/alchemy-effect/issues/466 [<samp>(a2367)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/a2367665)
+  - Include worker metadata in the update diff &nbsp;-&nbsp; by **Alex** in https://github.com/alchemy-run/alchemy/issues/747 [<samp>(26221)</samp>](https://github.com/alchemy-run/alchemy/commit/26221009)
+  - Fix state-store errors &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy/issues/737 [<samp>(6c9b6)</samp>](https://github.com/alchemy-run/alchemy/commit/6c9b67c5)
+  - Preserve explicit globalOutbound: null in WorkerLoader &nbsp;-&nbsp; by **Alex** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/746 [<samp>(52be6)</samp>](https://github.com/alchemy-run/alchemy/commit/52be64e2)
+  - Classify Resource.ref values as native Worker env bindings &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/756 [<samp>(01b4a)</samp>](https://github.com/alchemy-run/alchemy/commit/01b4ae32)
+  - Dispatch for multiple queue consumers &nbsp;-&nbsp; by **Leonardo E. Dominguez** in https://github.com/alchemy-run/alchemy/issues/466 [<samp>(a2367)</samp>](https://github.com/alchemy-run/alchemy/commit/a2367665)
   - **workers**:
-    - Retry every binding-target-not-found error on script upload &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/753 [<samp>(958b9)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/958b9294)
-    - Declare binding-hosted DO classes in the worker precreate stub &nbsp;-&nbsp; by **Daniel Gangl** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/764 [<samp>(93952)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/93952191)
+    - Retry every binding-target-not-found error on script upload &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/753 [<samp>(958b9)</samp>](https://github.com/alchemy-run/alchemy/commit/958b9294)
+    - Declare binding-hosted DO classes in the worker precreate stub &nbsp;-&nbsp; by **Daniel Gangl** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/764 [<samp>(93952)</samp>](https://github.com/alchemy-run/alchemy/commit/93952191)
 - **drizzle**:
-  - Make proxyChain a real Effect so it composes with combinators &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/750 [<samp>(8015f)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/8015f610)
+  - Make proxyChain a real Effect so it composes with combinators &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/750 [<samp>(8015f)</samp>](https://github.com/alchemy-run/alchemy/commit/8015f610)
 - **planetscale**:
-  - Compare inherited roles by membership &nbsp;-&nbsp; by **Gerben Mulder** in https://github.com/alchemy-run/alchemy-effect/issues/761 [<samp>(6ce15)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/6ce15030)
+  - Compare inherited roles by membership &nbsp;-&nbsp; by **Gerben Mulder** in https://github.com/alchemy-run/alchemy/issues/761 [<samp>(6ce15)</samp>](https://github.com/alchemy-run/alchemy/commit/6ce15030)
 - **test**:
-  - Make the test suite pass on Windows &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy-effect/issues/735 [<samp>(3c050)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/3c050fe2)
-  - Guard RPC test transports against edge-transient HTML responses &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/773 [<samp>(a8570)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/a85708dc)
+  - Make the test suite pass on Windows &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy/issues/735 [<samp>(3c050)</samp>](https://github.com/alchemy-run/alchemy/commit/3c050fe2)
+  - Guard RPC test transports against edge-transient HTML responses &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/773 [<samp>(a8570)</samp>](https://github.com/alchemy-run/alchemy/commit/a85708dc)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.60...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.60...HEAD)
 
 ---
 
@@ -100,46 +100,46 @@
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
 - **aws**:
-  - **ec2**: KeyPair resource + hosted Instance HTTP serving &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/714 [<samp>(62f05)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/62f05d39)
-  - **lambda**: MicroVM images and CF vs AWS container benchmarks &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/712 [<samp>(7f238)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/7f238498)
+  - **ec2**: KeyPair resource + hosted Instance HTTP serving &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/714 [<samp>(62f05)</samp>](https://github.com/alchemy-run/alchemy/commit/62f05d39)
+  - **lambda**: MicroVM images and CF vs AWS container benchmarks &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/712 [<samp>(7f238)</samp>](https://github.com/alchemy-run/alchemy/commit/7f238498)
 - **cli**:
-  - --yes auto-upgrades the Cloudflare state store &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy-effect/issues/728 [<samp>(c0ced)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/c0cedf76)
+  - --yes auto-upgrades the Cloudflare state store &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy/issues/728 [<samp>(c0ced)</samp>](https://github.com/alchemy-run/alchemy/commit/c0cedf76)
 - **cloudflare**:
-  - Custom vite environments and rsc &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/685 [<samp>(7b866)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/7b866200)
-  - Bind Workflows to async Workers &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/707 [<samp>(9c7b8)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/9c7b8232)
-  - **workers-for-platforms**: Dispatch namespace binding + deploy workers into namespaces &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/715 [<samp>(c9f89)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/c9f8961d)
+  - Custom vite environments and rsc &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/685 [<samp>(7b866)</samp>](https://github.com/alchemy-run/alchemy/commit/7b866200)
+  - Bind Workflows to async Workers &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/707 [<samp>(9c7b8)</samp>](https://github.com/alchemy-run/alchemy/commit/9c7b8232)
+  - **workers-for-platforms**: Dispatch namespace binding + deploy workers into namespaces &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/715 [<samp>(c9f89)</samp>](https://github.com/alchemy-run/alchemy/commit/c9f8961d)
 - **docker**:
-  - Add Docker resources &nbsp;-&nbsp; by **Austin** and **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/649 [<samp>(968bb)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/968bb10f)
+  - Add Docker resources &nbsp;-&nbsp; by **Austin** and **John Royal** in https://github.com/alchemy-run/alchemy/issues/649 [<samp>(968bb)</samp>](https://github.com/alchemy-run/alchemy/commit/968bb10f)
 - **neon**:
-  - Expose pooled origin &nbsp;-&nbsp; by **Alex** in https://github.com/alchemy-run/alchemy-effect/issues/718 [<samp>(0b60c)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/0b60c38a)
+  - Expose pooled origin &nbsp;-&nbsp; by **Alex** in https://github.com/alchemy-run/alchemy/issues/718 [<samp>(0b60c)</samp>](https://github.com/alchemy-run/alchemy/commit/0b60c38a)
 - **planetscale**:
-  - Expose pooledOrigin on PostgresRole &nbsp;-&nbsp; by **Alex** in https://github.com/alchemy-run/alchemy-effect/issues/717 [<samp>(9641b)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/9641be02)
-  - Persist PlanetScale branch replica intent &nbsp;-&nbsp; by **Alex** in https://github.com/alchemy-run/alchemy-effect/issues/719 [<samp>(cfb72)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/cfb72d01)
+  - Expose pooledOrigin on PostgresRole &nbsp;-&nbsp; by **Alex** in https://github.com/alchemy-run/alchemy/issues/717 [<samp>(9641b)</samp>](https://github.com/alchemy-run/alchemy/commit/9641be02)
+  - Persist PlanetScale branch replica intent &nbsp;-&nbsp; by **Alex** in https://github.com/alchemy-run/alchemy/issues/719 [<samp>(cfb72)</samp>](https://github.com/alchemy-run/alchemy/commit/cfb72d01)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
 - **aws**:
-  - Remove dead DashboardsNotFound invalid tag handling code &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(86b04)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/86b04fe1)
-  - Provide Region to STS GetCallerIdentity during login &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/709 [<samp>(3c3e8)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/3c3e852b)
-  - Break Region/AWSEnvironment layer cycle in env auth account-id lookup &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/710 [<samp>(351c3)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/351c3f56)
-  - **ecs**: Fix effectful ECS containers and add e2e smoke test that actually deploys &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/713 [<samp>(8cd7a)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/8cd7a2e5)
+  - Remove dead DashboardsNotFound invalid tag handling code &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(86b04)</samp>](https://github.com/alchemy-run/alchemy/commit/86b04fe1)
+  - Provide Region to STS GetCallerIdentity during login &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/709 [<samp>(3c3e8)</samp>](https://github.com/alchemy-run/alchemy/commit/3c3e852b)
+  - Break Region/AWSEnvironment layer cycle in env auth account-id lookup &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/710 [<samp>(351c3)</samp>](https://github.com/alchemy-run/alchemy/commit/351c3f56)
+  - **ecs**: Fix effectful ECS containers and add e2e smoke test that actually deploys &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/713 [<samp>(8cd7a)</samp>](https://github.com/alchemy-run/alchemy/commit/8cd7a2e5)
 - **cli**:
-  - Load the stack entry via a file:// URL so the CLI works on Windows &nbsp;-&nbsp; by **d3lay** in https://github.com/alchemy-run/alchemy-effect/issues/696 [<samp>(2ced8)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/2ced8e0c)
-  - Report retained resources during destroy &nbsp;-&nbsp; by **bjorntechTobbe** in https://github.com/alchemy-run/alchemy-effect/issues/739 [<samp>(48021)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/48021c42)
+  - Load the stack entry via a file:// URL so the CLI works on Windows &nbsp;-&nbsp; by **d3lay** in https://github.com/alchemy-run/alchemy/issues/696 [<samp>(2ced8)</samp>](https://github.com/alchemy-run/alchemy/commit/2ced8e0c)
+  - Report retained resources during destroy &nbsp;-&nbsp; by **bjorntechTobbe** in https://github.com/alchemy-run/alchemy/issues/739 [<samp>(48021)</samp>](https://github.com/alchemy-run/alchemy/commit/48021c42)
 - **cloudflare**:
-  - Detect and recover cf state store partial deploy &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy-effect/issues/700 [<samp>(37584)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/3758460f)
-  - Adopt durable object classes created outside alchemy &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/495 [<samp>(3d063)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/3d06359e)
-  - Fold command + env into the memo hash for StaticSite &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy-effect/issues/738 [<samp>(36b49)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/36b494dd)
-  - Cold-recovery read for Access Application &nbsp;-&nbsp; by **Andy Jefferson** in https://github.com/alchemy-run/alchemy-effect/issues/742 [<samp>(ed44f)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/ed44f238)
+  - Detect and recover cf state store partial deploy &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy/issues/700 [<samp>(37584)</samp>](https://github.com/alchemy-run/alchemy/commit/3758460f)
+  - Adopt durable object classes created outside alchemy &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/495 [<samp>(3d063)</samp>](https://github.com/alchemy-run/alchemy/commit/3d06359e)
+  - Fold command + env into the memo hash for StaticSite &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy/issues/738 [<samp>(36b49)</samp>](https://github.com/alchemy-run/alchemy/commit/36b494dd)
+  - Cold-recovery read for Access Application &nbsp;-&nbsp; by **Andy Jefferson** in https://github.com/alchemy-run/alchemy/issues/742 [<samp>(ed44f)</samp>](https://github.com/alchemy-run/alchemy/commit/ed44f238)
   - **containers**:
-    - Wrangler-parity defaults and readiness for fast, reliable starts &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/708 [<samp>(c740f)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/c740f0fb)
-    - Auto-restart stopped/crashed containers, fail fast on crash &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/711 [<samp>(c1906)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/c1906298)
+    - Wrangler-parity defaults and readiness for fast, reliable starts &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/708 [<samp>(c740f)</samp>](https://github.com/alchemy-run/alchemy/commit/c740f0fb)
+    - Auto-restart stopped/crashed containers, fail fast on crash &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/711 [<samp>(c1906)</samp>](https://github.com/alchemy-run/alchemy/commit/c1906298)
 - **test**:
-  - Deflake live test suite and harden Cloudflare providers &nbsp;-&nbsp; by **Sam Goodwin** and **Cursor** [<samp>(6965b)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/6965bf7e)
+  - Deflake live test suite and harden Cloudflare providers &nbsp;-&nbsp; by **Sam Goodwin** and **Cursor** [<samp>(6965b)</samp>](https://github.com/alchemy-run/alchemy/commit/6965bf7e)
 - **website**:
-  - Collapse the tab-row height on mobile &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/734 [<samp>(c85e2)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/c85e2342)
+  - Collapse the tab-row height on mobile &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/734 [<samp>(c85e2)</samp>](https://github.com/alchemy-run/alchemy/commit/c85e2342)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.59...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.59...HEAD)
 
 ---
 
@@ -147,20 +147,20 @@
 
 ### &nbsp;&nbsp;&nbsp;🚨 Breaking Changes
 
-- **bindings**: Remove Binding.Policy and align all bindings to a single convention &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/690 [<samp>(35b04)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/35b04361)
+- **bindings**: Remove Binding.Policy and align all bindings to a single convention &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/690 [<samp>(35b04)</samp>](https://github.com/alchemy-run/alchemy/commit/35b04361)
 
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
-- **cli**: Export ALCHEMY_DEV config and fix ALCHEMY_PHASE docs &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/684 [<samp>(5c606)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/5c60600f)
+- **cli**: Export ALCHEMY_DEV config and fix ALCHEMY_PHASE docs &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/684 [<samp>(5c606)</samp>](https://github.com/alchemy-run/alchemy/commit/5c60600f)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
 - **cloudflare**:
-  - **worker**: Tolerate legacy custom-domain state in Worker diff &nbsp;-&nbsp; by **Nicolas Fléron** in https://github.com/alchemy-run/alchemy-effect/issues/546 and https://github.com/alchemy-run/alchemy-effect/issues/694 [<samp>(f17fa)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/f17fab02)
+  - **worker**: Tolerate legacy custom-domain state in Worker diff &nbsp;-&nbsp; by **Nicolas Fléron** in https://github.com/alchemy-run/alchemy/issues/546 and https://github.com/alchemy-run/alchemy/issues/694 [<samp>(f17fa)</samp>](https://github.com/alchemy-run/alchemy/commit/f17fab02)
 - **engine**:
-  - Honor deleteFirst on replace &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/692 [<samp>(ef6f8)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/ef6f8e4d)
+  - Honor deleteFirst on replace &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/692 [<samp>(ef6f8)</samp>](https://github.com/alchemy-run/alchemy/commit/ef6f8e4d)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.58...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.58...HEAD)
 
 ---
 
@@ -168,48 +168,48 @@
 
 ### &nbsp;&nbsp;&nbsp;🚨 Breaking Changes
 
-- Command provider &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/673 [<samp>(e7127)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/e7127f2e)
-- **neon**: Replace branch when project changes &nbsp;-&nbsp; by **Harry Solovay** and **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/654 [<samp>(b21d2)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/b21d2129)
+- Command provider &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/673 [<samp>(e7127)</samp>](https://github.com/alchemy-run/alchemy/commit/e7127f2e)
+- **neon**: Replace branch when project changes &nbsp;-&nbsp; by **Harry Solovay** and **John Royal** in https://github.com/alchemy-run/alchemy/issues/654 [<samp>(b21d2)</samp>](https://github.com/alchemy-run/alchemy/commit/b21d2129)
 
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
 - **aws**:
-  - Add Lambda function memory size &nbsp;-&nbsp; by **Joaquín Pérez** in https://github.com/alchemy-run/alchemy-effect/issues/676 [<samp>(57ce8)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/57ce8300)
+  - Add Lambda function memory size &nbsp;-&nbsp; by **Joaquín Pérez** in https://github.com/alchemy-run/alchemy/issues/676 [<samp>(57ce8)</samp>](https://github.com/alchemy-run/alchemy/commit/57ce8300)
   - **lambda**:
-    - Support AWS Lambda function architecture &nbsp;-&nbsp; by **Joaquín Pérez** in https://github.com/alchemy-run/alchemy-effect/issues/662 [<samp>(bfa21)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/bfa2181a)
-    - Add build.install for native packages &nbsp;-&nbsp; by **Joaquín Pérez** in https://github.com/alchemy-run/alchemy-effect/issues/682 [<samp>(46e48)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/46e484fd)
+    - Support AWS Lambda function architecture &nbsp;-&nbsp; by **Joaquín Pérez** in https://github.com/alchemy-run/alchemy/issues/662 [<samp>(bfa21)</samp>](https://github.com/alchemy-run/alchemy/commit/bfa2181a)
+    - Add build.install for native packages &nbsp;-&nbsp; by **Joaquín Pérez** in https://github.com/alchemy-run/alchemy/issues/682 [<samp>(46e48)</samp>](https://github.com/alchemy-run/alchemy/commit/46e484fd)
 - **cloudflare**:
-  - Allow DurableObjectState and other DO dependencies at plan level, move Tag Props to Layer &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/650 [<samp>(c0ecf)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/c0ecfbe8)
-  - **workers**: Rename DynamicWorkerLoader to WorkerLoader + service tag, layer, typed client &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/653 [<samp>(ef336)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/ef336146)
+  - Allow DurableObjectState and other DO dependencies at plan level, move Tag Props to Layer &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/650 [<samp>(c0ecf)</samp>](https://github.com/alchemy-run/alchemy/commit/c0ecfbe8)
+  - **workers**: Rename DynamicWorkerLoader to WorkerLoader + service tag, layer, typed client &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/653 [<samp>(ef336)</samp>](https://github.com/alchemy-run/alchemy/commit/ef336146)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
 - **all**:
-  - Use Effect.fn instead of Effect.fnUntraced for better stack traces &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(b9676)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/b9676c58)
+  - Use Effect.fn instead of Effect.fnUntraced for better stack traces &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(b9676)</samp>](https://github.com/alchemy-run/alchemy/commit/b9676c58)
 - **auth**:
-  - Bail when configuring a missing profile non-interactively &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/663 [<samp>(3d2cb)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/3d2cbbe4)
+  - Bail when configuring a missing profile non-interactively &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/663 [<samp>(3d2cb)</samp>](https://github.com/alchemy-run/alchemy/commit/3d2cbbe4)
 - **aws**:
-  - Route53 change ID normalization &nbsp;-&nbsp; by **Joaquín Pérez** in https://github.com/alchemy-run/alchemy-effect/issues/675 [<samp>(acf5f)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/acf5fc3d)
+  - Route53 change ID normalization &nbsp;-&nbsp; by **Joaquín Pérez** in https://github.com/alchemy-run/alchemy/issues/675 [<samp>(acf5f)</samp>](https://github.com/alchemy-run/alchemy/commit/acf5fc3d)
 - **build**:
-  - Key DevServer instances by instanceId, not logical id &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/665 [<samp>(c33f3)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/c33f3b84)
-  - Set dev server process to `detached: false` &nbsp;-&nbsp; by **Harry Solovay** in https://github.com/alchemy-run/alchemy-effect/issues/655 [<samp>(c5500)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/c5500e2b)
+  - Key DevServer instances by instanceId, not logical id &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/665 [<samp>(c33f3)</samp>](https://github.com/alchemy-run/alchemy/commit/c33f3b84)
+  - Set dev server process to `detached: false` &nbsp;-&nbsp; by **Harry Solovay** in https://github.com/alchemy-run/alchemy/issues/655 [<samp>(c5500)</samp>](https://github.com/alchemy-run/alchemy/commit/c5500e2b)
 - **cloudflare**:
-  - Re-export dev container image type &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/666 [<samp>(60c56)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/60c56e15)
-  - Update workerd to fix dev container bug &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/664 [<samp>(e8630)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/e8630490)
-  - Add Workers Observability write OAuth scope &nbsp;-&nbsp; by **Leonardo Trapani** in https://github.com/alchemy-run/alchemy-effect/issues/660 [<samp>(87ed4)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/87ed4a47)
-  - StaticSite precreate fails in alchemy dev &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/671 [<samp>(884eb)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/884eb3fd)
-  - Retry InvalidRoute when checking if state store available &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(34a07)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/34a0767f)
+  - Re-export dev container image type &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/666 [<samp>(60c56)</samp>](https://github.com/alchemy-run/alchemy/commit/60c56e15)
+  - Update workerd to fix dev container bug &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/664 [<samp>(e8630)</samp>](https://github.com/alchemy-run/alchemy/commit/e8630490)
+  - Add Workers Observability write OAuth scope &nbsp;-&nbsp; by **Leonardo Trapani** in https://github.com/alchemy-run/alchemy/issues/660 [<samp>(87ed4)</samp>](https://github.com/alchemy-run/alchemy/commit/87ed4a47)
+  - StaticSite precreate fails in alchemy dev &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/671 [<samp>(884eb)</samp>](https://github.com/alchemy-run/alchemy/commit/884eb3fd)
+  - Retry InvalidRoute when checking if state store available &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(34a07)</samp>](https://github.com/alchemy-run/alchemy/commit/34a0767f)
 - **core**:
-  - Use persisted FQN when deleting resources &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/669 [<samp>(5ef57)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/5ef57925)
-  - Resolve stable attributes of whole-resource references &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/670 [<samp>(933d2)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/933d2a09)
+  - Use persisted FQN when deleting resources &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/669 [<samp>(5ef57)</samp>](https://github.com/alchemy-run/alchemy/commit/5ef57925)
+  - Resolve stable attributes of whole-resource references &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/670 [<samp>(933d2)</samp>](https://github.com/alchemy-run/alchemy/commit/933d2a09)
 - **drizzle**:
-  - Fall back to drizzle-kit CLI &nbsp;-&nbsp; by **utopy** in https://github.com/alchemy-run/alchemy-effect/issues/632 [<samp>(27262)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/27262f5d)
+  - Fall back to drizzle-kit CLI &nbsp;-&nbsp; by **utopy** in https://github.com/alchemy-run/alchemy/issues/632 [<samp>(27262)</samp>](https://github.com/alchemy-run/alchemy/commit/27262f5d)
 - **github**:
-  - Resolve lazy secret values &nbsp;-&nbsp; by **Harry Solovay** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/652 [<samp>(351b9)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/351b9a8d)
+  - Resolve lazy secret values &nbsp;-&nbsp; by **Harry Solovay** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/652 [<samp>(351b9)</samp>](https://github.com/alchemy-run/alchemy/commit/351b9a8d)
 - **neon**:
-  - Project replaces unexpectedly due to default region mismatch &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/667 [<samp>(55597)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/55597d41)
+  - Project replaces unexpectedly due to default region mismatch &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/667 [<samp>(55597)</samp>](https://github.com/alchemy-run/alchemy/commit/55597d41)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.57...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.57...HEAD)
 
 ---
 
@@ -218,49 +218,49 @@
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
 - **aws**:
-  - VpcOrigin, ListenerRule, TrustStore, HostedZone, HealthCheck &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/631 [<samp>(6f952)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/6f9528ac)
+  - VpcOrigin, ListenerRule, TrustStore, HostedZone, HealthCheck &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/631 [<samp>(6f952)</samp>](https://github.com/alchemy-run/alchemy/commit/6f9528ac)
   - **kms**:
-    - Add key and alias resources &nbsp;-&nbsp; by **José Netto** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/641 [<samp>(28f7d)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/28f7d3d0)
+    - Add key and alias resources &nbsp;-&nbsp; by **José Netto** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/641 [<samp>(28f7d)</samp>](https://github.com/alchemy-run/alchemy/commit/28f7d3d0)
   - **lambda**:
-    - Add alias resource &nbsp;-&nbsp; by **José Netto** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/625 [<samp>(a9e1c)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/a9e1cc53)
-    - Support function concurrency &nbsp;-&nbsp; by **José Netto** in https://github.com/alchemy-run/alchemy-effect/issues/628 [<samp>(6857a)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/6857a3ee)
+    - Add alias resource &nbsp;-&nbsp; by **José Netto** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/625 [<samp>(a9e1c)</samp>](https://github.com/alchemy-run/alchemy/commit/a9e1cc53)
+    - Support function concurrency &nbsp;-&nbsp; by **José Netto** in https://github.com/alchemy-run/alchemy/issues/628 [<samp>(6857a)</samp>](https://github.com/alchemy-run/alchemy/commit/6857a3ee)
   - **logs**:
-    - Support log group config &nbsp;-&nbsp; by **José Netto** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/630 [<samp>(63172)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/63172cb1)
+    - Support log group config &nbsp;-&nbsp; by **José Netto** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/630 [<samp>(63172)</samp>](https://github.com/alchemy-run/alchemy/commit/63172cb1)
 - **cli**:
-  - Support creating user api tokens &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(5d226)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/5d226b30)
+  - Support creating user api tokens &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(5d226)</samp>](https://github.com/alchemy-run/alchemy/commit/5d226b30)
 - **cloudflare**:
-  - Containers in alchemy dev &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/636 [<samp>(f3bf2)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/f3bf27c1)
-  - **ai-search**: AiSearch, AiSearchInstance and AiSearchNamespace &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/639 [<samp>(6831d)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/6831d0b1)
+  - Containers in alchemy dev &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/636 [<samp>(f3bf2)</samp>](https://github.com/alchemy-run/alchemy/commit/f3bf27c1)
+  - **ai-search**: AiSearch, AiSearchInstance and AiSearchNamespace &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/639 [<samp>(6831d)</samp>](https://github.com/alchemy-run/alchemy/commit/6831d0b1)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- Upgrade to effect beta.84 and fix ConfigProvider.get -> .load &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(340e4)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/340e4109)
-- Upgrade effect beta 84 &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(06a6f)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/06a6fffc)
+- Upgrade to effect beta.84 and fix ConfigProvider.get -> .load &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(340e4)</samp>](https://github.com/alchemy-run/alchemy/commit/340e4109)
+- Upgrade effect beta 84 &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(06a6f)</samp>](https://github.com/alchemy-run/alchemy/commit/06a6fffc)
 - **aws**:
-  - Fix Scheduler everntual consistency durability &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(763d1)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/763d1b71)
-  - Harden Distribution, Table, SecurityGrouip, Rule OIDCConnectionProvider, Policu, SAMLProvider, StreamConsumer and StateStore &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(affe6)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/affe67e3)
-  - Harden SQS Queue tests, SNS Topic, Provider network error retries, ELB Target Group tests &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(83b4a)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/83b4a407)
-  - Harden SQS QUeue against DLQ eventual consistency &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(b2814)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/b2814e7e)
+  - Fix Scheduler everntual consistency durability &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(763d1)</samp>](https://github.com/alchemy-run/alchemy/commit/763d1b71)
+  - Harden Distribution, Table, SecurityGrouip, Rule OIDCConnectionProvider, Policu, SAMLProvider, StreamConsumer and StateStore &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(affe6)</samp>](https://github.com/alchemy-run/alchemy/commit/affe67e3)
+  - Harden SQS Queue tests, SNS Topic, Provider network error retries, ELB Target Group tests &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(83b4a)</samp>](https://github.com/alchemy-run/alchemy/commit/83b4a407)
+  - Harden SQS QUeue against DLQ eventual consistency &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(b2814)</samp>](https://github.com/alchemy-run/alchemy/commit/b2814e7e)
 - **build**:
-  - Handle relative and absolute paths in Build.Command &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(fd3c0)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/fd3c071e)
+  - Handle relative and absolute paths in Build.Command &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(fd3c0)</samp>](https://github.com/alchemy-run/alchemy/commit/fd3c071e)
 - **bundle**:
-  - Avoid watching node_modules in alchemy dev &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/646 [<samp>(1d72a)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/1d72aa44)
+  - Avoid watching node_modules in alchemy dev &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/646 [<samp>(1d72a)</samp>](https://github.com/alchemy-run/alchemy/commit/1d72aa44)
 - **cli**:
-  - Cloudflare create-token supports selecting permissions &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(1674d)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/1674d2cd)
+  - Cloudflare create-token supports selecting permissions &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(1674d)</samp>](https://github.com/alchemy-run/alchemy/commit/1674d2cd)
 - **cloudflare**:
-  - Malformed request promoting queue consumer from dev &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/647 [<samp>(a2787)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/a278763b)
-  - Harden PageRule, SchemaValidation SChema, Images Variant, OiriginPostQuantum, HostnameAssociation, Pages Project &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(e8e6f)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/e8e6f059)
-  - Remove DispatchNamespaceScript &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(20371)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/20371abb)
-  - Retry MnnConfigMissing in MagicNetworkMonitoring Rule &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(75832)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/75832278)
+  - Malformed request promoting queue consumer from dev &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/647 [<samp>(a2787)</samp>](https://github.com/alchemy-run/alchemy/commit/a278763b)
+  - Harden PageRule, SchemaValidation SChema, Images Variant, OiriginPostQuantum, HostnameAssociation, Pages Project &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(e8e6f)</samp>](https://github.com/alchemy-run/alchemy/commit/e8e6f059)
+  - Remove DispatchNamespaceScript &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(20371)</samp>](https://github.com/alchemy-run/alchemy/commit/20371abb)
+  - Retry MnnConfigMissing in MagicNetworkMonitoring Rule &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(75832)</samp>](https://github.com/alchemy-run/alchemy/commit/75832278)
   - **workers**:
-    - Support local AI Search bindings &nbsp;-&nbsp; by **Jonathan Beckman** in https://github.com/alchemy-run/alchemy-effect/issues/642 [<samp>(3ee0f)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/3ee0fd3d)
-    - Preserve local service entrypoints &nbsp;-&nbsp; by **Jonathan Beckman** in https://github.com/alchemy-run/alchemy-effect/issues/643 [<samp>(6bbcb)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/6bbcb4b4)
+    - Support local AI Search bindings &nbsp;-&nbsp; by **Jonathan Beckman** in https://github.com/alchemy-run/alchemy/issues/642 [<samp>(3ee0f)</samp>](https://github.com/alchemy-run/alchemy/commit/3ee0fd3d)
+    - Preserve local service entrypoints &nbsp;-&nbsp; by **Jonathan Beckman** in https://github.com/alchemy-run/alchemy/issues/643 [<samp>(6bbcb)</samp>](https://github.com/alchemy-run/alchemy/commit/6bbcb4b4)
 - **core**:
-  - Make diff.stables override provider.stables &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/635 [<samp>(470a5)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/470a5658)
+  - Make diff.stables override provider.stables &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/635 [<samp>(470a5)</samp>](https://github.com/alchemy-run/alchemy/commit/470a5658)
 - **state**:
-  - Make writes in LocalState atomic &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(1c596)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/1c596afb)
+  - Make writes in LocalState atomic &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(1c596)</samp>](https://github.com/alchemy-run/alchemy/commit/1c596afb)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.56...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.56...HEAD)
 
 ---
 
@@ -269,47 +269,47 @@
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
 - **aws**:
-  - S3-backed state store (AWS.state()) &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/585 [<samp>(1d664)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/1d6642b1)
-  - **lambda**: Support function URL config &nbsp;-&nbsp; by **José Netto** in https://github.com/alchemy-run/alchemy-effect/issues/614 [<samp>(33da7)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/33da7a32)
+  - S3-backed state store (AWS.state()) &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/585 [<samp>(1d664)</samp>](https://github.com/alchemy-run/alchemy/commit/1d6642b1)
+  - **lambda**: Support function URL config &nbsp;-&nbsp; by **José Netto** in https://github.com/alchemy-run/alchemy/issues/614 [<samp>(33da7)</samp>](https://github.com/alchemy-run/alchemy/commit/33da7a32)
 - **cloudflare**:
-  - DnsRecord and Zero Trust resources (TunnelRoute, Access apps/policies/org, Device profile) &nbsp;-&nbsp; by **Andy Jefferson** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/570 [<samp>(e9af0)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/e9af082d)
-  - Forward dev.env to the StaticSite dev server &nbsp;-&nbsp; by **Alex** in https://github.com/alchemy-run/alchemy-effect/issues/587 [<samp>(f5110)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/f5110e55)
-  - Generate all missing Cloudflare resources &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/601 [<samp>(89bbb)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/89bbb2d6)
-  - Flagship feature flags — resources + worker binding &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/602 [<samp>(f7e1c)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/f7e1c4d3)
-  - **worker**: Bundle: false — deploy prebuilt workers without re-bundling &nbsp;-&nbsp; by **Alex** in https://github.com/alchemy-run/alchemy-effect/issues/592 [<samp>(76fc7)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/76fc7ad2)
+  - DnsRecord and Zero Trust resources (TunnelRoute, Access apps/policies/org, Device profile) &nbsp;-&nbsp; by **Andy Jefferson** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/570 [<samp>(e9af0)</samp>](https://github.com/alchemy-run/alchemy/commit/e9af082d)
+  - Forward dev.env to the StaticSite dev server &nbsp;-&nbsp; by **Alex** in https://github.com/alchemy-run/alchemy/issues/587 [<samp>(f5110)</samp>](https://github.com/alchemy-run/alchemy/commit/f5110e55)
+  - Generate all missing Cloudflare resources &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/601 [<samp>(89bbb)</samp>](https://github.com/alchemy-run/alchemy/commit/89bbb2d6)
+  - Flagship feature flags — resources + worker binding &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/602 [<samp>(f7e1c)</samp>](https://github.com/alchemy-run/alchemy/commit/f7e1c4d3)
+  - **worker**: Bundle: false — deploy prebuilt workers without re-bundling &nbsp;-&nbsp; by **Alex** in https://github.com/alchemy-run/alchemy/issues/592 [<samp>(76fc7)</samp>](https://github.com/alchemy-run/alchemy/commit/76fc7ad2)
 - **core**:
-  - Provider.list &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/620 [<samp>(b9360)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/b9360147)
-  - Alchemy unsafe nuke &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/624 [<samp>(9b052)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/9b052778)
+  - Provider.list &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/620 [<samp>(b9360)</samp>](https://github.com/alchemy-run/alchemy/commit/b9360147)
+  - Alchemy unsafe nuke &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/624 [<samp>(9b052)</samp>](https://github.com/alchemy-run/alchemy/commit/9b052778)
 - **github**:
-  - Add GitHub Repository resource &nbsp;-&nbsp; by **Justin Bennett** in https://github.com/alchemy-run/alchemy-effect/issues/607 [<samp>(1a48e)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/1a48ef4e)
-  - Repository event source for Cloudflare Workers &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/619 [<samp>(5ba26)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/5ba26aed)
+  - Add GitHub Repository resource &nbsp;-&nbsp; by **Justin Bennett** in https://github.com/alchemy-run/alchemy/issues/607 [<samp>(1a48e)</samp>](https://github.com/alchemy-run/alchemy/commit/1a48ef4e)
+  - Repository event source for Cloudflare Workers &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/619 [<samp>(5ba26)</samp>](https://github.com/alchemy-run/alchemy/commit/5ba26aed)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
 - **cli**:
-  - Keep alchemy dev alive when an apply fails &nbsp;-&nbsp; by **Matthew Aylward** in https://github.com/alchemy-run/alchemy-effect/issues/582 [<samp>(c2f63)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/c2f635a6)
-  - Run state clear in parallel &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(81b9d)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/81b9d8f7)
-  - Support different entrypoint file in alchemy state clear command &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(7d7f3)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/7d7f33d4)
-  - Hide nuke command &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(2d57d)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/2d57df42)
+  - Keep alchemy dev alive when an apply fails &nbsp;-&nbsp; by **Matthew Aylward** in https://github.com/alchemy-run/alchemy/issues/582 [<samp>(c2f63)</samp>](https://github.com/alchemy-run/alchemy/commit/c2f635a6)
+  - Run state clear in parallel &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(81b9d)</samp>](https://github.com/alchemy-run/alchemy/commit/81b9d8f7)
+  - Support different entrypoint file in alchemy state clear command &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(7d7f3)</samp>](https://github.com/alchemy-run/alchemy/commit/7d7f33d4)
+  - Hide nuke command &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(2d57d)</samp>](https://github.com/alchemy-run/alchemy/commit/2d57df42)
 - **cloudflare**:
-  - Migrate resources to regenerated SDK after spec update &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(a8e4e)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/a8e4e8f2)
-  - Local assets binding throws 500 error &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/613 [<samp>(dfea3)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/dfea32a1)
-  - Broad improvements to new resources and tests &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(17dd2)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/17dd2cc7)
+  - Migrate resources to regenerated SDK after spec update &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(a8e4e)</samp>](https://github.com/alchemy-run/alchemy/commit/a8e4e8f2)
+  - Local assets binding throws 500 error &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/613 [<samp>(dfea3)</samp>](https://github.com/alchemy-run/alchemy/commit/dfea32a1)
+  - Broad improvements to new resources and tests &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(17dd2)</samp>](https://github.com/alchemy-run/alchemy/commit/17dd2cc7)
   - **worker**:
-    - Keep url stable across updates &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/616 [<samp>(03e71)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/03e71f03)
-    - Keep durableObjectNamespaces stable across updates &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/617 [<samp>(f7fcb)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/f7fcb9e0)
+    - Keep url stable across updates &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/616 [<samp>(03e71)</samp>](https://github.com/alchemy-run/alchemy/commit/03e71f03)
+    - Keep durableObjectNamespaces stable across updates &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/617 [<samp>(f7fcb)</samp>](https://github.com/alchemy-run/alchemy/commit/f7fcb9e0)
 - **drizzle**:
-  - Cache detectDrift so interactive prompt only runs once &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/597 [<samp>(957a6)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/957a63c3)
+  - Cache detectDrift so interactive prompt only runs once &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/597 [<samp>(957a6)</samp>](https://github.com/alchemy-run/alchemy/commit/957a63c3)
 - **github**:
-  - Implement Webhook Provider.list &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(2915a)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/2915a1d5)
+  - Implement Webhook Provider.list &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(2915a)</samp>](https://github.com/alchemy-run/alchemy/commit/2915a1d5)
 - **pr-package**:
-  - Unwrap Redacted on both sides of bearer-token auth &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy-effect/issues/598 [<samp>(f9314)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/f9314d0a)
+  - Unwrap Redacted on both sides of bearer-token auth &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy/issues/598 [<samp>(f9314)</samp>](https://github.com/alchemy-run/alchemy/commit/f9314d0a)
 
 ### &nbsp;&nbsp;&nbsp;🏎 Performance
 
-- **cli**: Make `alchemy plan` start near-instant (8.2s -> 1.8s) &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/618 [<samp>(89ccc)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/89ccc11f)
+- **cli**: Make `alchemy plan` start near-instant (8.2s -> 1.8s) &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/618 [<samp>(89ccc)</samp>](https://github.com/alchemy-run/alchemy/commit/89ccc11f)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.55...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.55...HEAD)
 
 ---
 
@@ -318,14 +318,14 @@
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
 - **cloudflare**:
-  - **ai-gateway**: Add AiGatewaySpendingLimit (account-level spend cap) &nbsp;-&nbsp; by **Matthew Aylward** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/569 [<samp>(3c550)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/3c550b58)
+  - **ai-gateway**: Add AiGatewaySpendingLimit (account-level spend cap) &nbsp;-&nbsp; by **Matthew Aylward** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/569 [<samp>(3c550)</samp>](https://github.com/alchemy-run/alchemy/commit/3c550b58)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- Dangling process on alchemy deploy/destroy &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/580 [<samp>(67bcc)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/67bcca0f)
-- **cloudflare**: Export fetcher utils from alchemy/Cloudflare/Bridge &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/581 [<samp>(77777)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/77777c6a)
+- Dangling process on alchemy deploy/destroy &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/580 [<samp>(67bcc)</samp>](https://github.com/alchemy-run/alchemy/commit/67bcca0f)
+- **cloudflare**: Export fetcher utils from alchemy/Cloudflare/Bridge &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/581 [<samp>(77777)</samp>](https://github.com/alchemy-run/alchemy/commit/77777c6a)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.54...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.54...HEAD)
 
 ---
 
@@ -333,13 +333,13 @@
 
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
-- **cloudflare**: Queue consumers in alchemy dev &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/571 [<samp>(ecb63)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/ecb63322)
+- **cloudflare**: Queue consumers in alchemy dev &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/571 [<samp>(ecb63)</samp>](https://github.com/alchemy-run/alchemy/commit/ecb63322)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- **cloudflare**: Support lazy credentials in dev &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/578 [<samp>(b9781)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/b9781c5e)
+- **cloudflare**: Support lazy credentials in dev &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/578 [<samp>(b9781)</samp>](https://github.com/alchemy-run/alchemy/commit/b9781c5e)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.53...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.53...HEAD)
 
 ---
 
@@ -347,22 +347,22 @@
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- Lazily evaluate auth providers &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/567 [<samp>(390a6)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/390a6db4)
+- Lazily evaluate auth providers &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/567 [<samp>(390a6)</samp>](https://github.com/alchemy-run/alchemy/commit/390a6db4)
 - **aws**:
-  - Actually use AWS Auth provider &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/574 [<samp>(73e62)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/73e62cc1)
-  - **s3**: Narrow bucket tag requirements &nbsp;-&nbsp; by **Kilian Cirera Sant** in https://github.com/alchemy-run/alchemy-effect/issues/555 [<samp>(26796)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/26796939)
+  - Actually use AWS Auth provider &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/574 [<samp>(73e62)</samp>](https://github.com/alchemy-run/alchemy/commit/73e62cc1)
+  - **s3**: Narrow bucket tag requirements &nbsp;-&nbsp; by **Kilian Cirera Sant** in https://github.com/alchemy-run/alchemy/issues/555 [<samp>(26796)</samp>](https://github.com/alchemy-run/alchemy/commit/26796939)
 - **cli**:
-  - Always refresh credentials on alchemy login &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/575 [<samp>(75f04)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/75f04495)
-  - Avoid login after configure &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(8ee28)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/8ee2837b)
+  - Always refresh credentials on alchemy login &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/575 [<samp>(75f04)</samp>](https://github.com/alchemy-run/alchemy/commit/75f04495)
+  - Avoid login after configure &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(8ee28)</samp>](https://github.com/alchemy-run/alchemy/commit/8ee2837b)
 - **cloudflare**:
-  - Vite handles require of node built-ins incorrectly &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/556 [<samp>(1010a)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/1010a5c3)
-  - Use named import for @alchemy.run/node-utils/ignore &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/572 [<samp>(e2926)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/e29265c3)
-  - Race condition with >1 workflow in alchemy dev &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/573 [<samp>(6cc94)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/6cc9429d)
-  - Handle NoSuchBucket eventual consistency when updating bucket domain &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(448ba)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/448ba756)
+  - Vite handles require of node built-ins incorrectly &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/556 [<samp>(1010a)</samp>](https://github.com/alchemy-run/alchemy/commit/1010a5c3)
+  - Use named import for @alchemy.run/node-utils/ignore &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/572 [<samp>(e2926)</samp>](https://github.com/alchemy-run/alchemy/commit/e29265c3)
+  - Race condition with >1 workflow in alchemy dev &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/573 [<samp>(6cc94)</samp>](https://github.com/alchemy-run/alchemy/commit/6cc9429d)
+  - Handle NoSuchBucket eventual consistency when updating bucket domain &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(448ba)</samp>](https://github.com/alchemy-run/alchemy/commit/448ba756)
 - **core**:
-  - Resolve Config values in input props &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/566 [<samp>(aa584)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/aa5844f5)
+  - Resolve Config values in input props &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/566 [<samp>(aa584)</samp>](https://github.com/alchemy-run/alchemy/commit/aa5844f5)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.52...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.52...HEAD)
 
 ---
 
@@ -370,35 +370,35 @@
 
 ### &nbsp;&nbsp;&nbsp;🚨 Breaking Changes
 
-- Bump effect to 4.0.0-beta.78 &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/542 [<samp>(80d50)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/80d50a7e)
-- **cloudflare**: Consistent `props.assets` type for Worker, StaticSite, & Vite &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/534 [<samp>(e1ad3)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/e1ad34ad)
+- Bump effect to 4.0.0-beta.78 &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/542 [<samp>(80d50)</samp>](https://github.com/alchemy-run/alchemy/commit/80d50a7e)
+- **cloudflare**: Consistent `props.assets` type for Worker, StaticSite, & Vite &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/534 [<samp>(e1ad3)</samp>](https://github.com/alchemy-run/alchemy/commit/e1ad34ad)
 
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
 - **cloudflare**:
-  - Effect wrapper for Browser quick actions &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/525 [<samp>(e734a)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/e734a2f4)
-  - Add Version Metadata binding &nbsp;-&nbsp; by **Alex** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/524 [<samp>(77937)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/77937935)
-  - Class form for Vite and StaticSite &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/527 [<samp>(a195c)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/a195c93d)
-  - Provide ExecutionContext to Workflow runs &nbsp;-&nbsp; by **Saatvik Arya** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/515 [<samp>(159b9)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/159b9779)
-  - Build.DevServer resource used in Cloudflare.StaticSite &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy-effect/issues/537 [<samp>(81415)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/81415133)
+  - Effect wrapper for Browser quick actions &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/525 [<samp>(e734a)</samp>](https://github.com/alchemy-run/alchemy/commit/e734a2f4)
+  - Add Version Metadata binding &nbsp;-&nbsp; by **Alex** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/524 [<samp>(77937)</samp>](https://github.com/alchemy-run/alchemy/commit/77937935)
+  - Class form for Vite and StaticSite &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/527 [<samp>(a195c)</samp>](https://github.com/alchemy-run/alchemy/commit/a195c93d)
+  - Provide ExecutionContext to Workflow runs &nbsp;-&nbsp; by **Saatvik Arya** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/515 [<samp>(159b9)</samp>](https://github.com/alchemy-run/alchemy/commit/159b9779)
+  - Build.DevServer resource used in Cloudflare.StaticSite &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy/issues/537 [<samp>(81415)</samp>](https://github.com/alchemy-run/alchemy/commit/81415133)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- Bump @distilled.cloud/* to 0.23.1 &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy-effect/issues/539 [<samp>(d0afc)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/d0afc986)
+- Bump @distilled.cloud/* to 0.23.1 &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy/issues/539 [<samp>(d0afc)</samp>](https://github.com/alchemy-run/alchemy/commit/d0afc986)
 - **cloudflare**:
-  - Cloudflare.Providers requirement type was any &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(4b0ca)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/4b0caa8d)
-  - Allow ConfigError in RpcWorker and RpcDurableObjectNamespace &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(4e8f4)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/4e8f4e55)
+  - Cloudflare.Providers requirement type was any &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(4b0ca)</samp>](https://github.com/alchemy-run/alchemy/commit/4b0caa8d)
+  - Allow ConfigError in RpcWorker and RpcDurableObjectNamespace &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(4e8f4)</samp>](https://github.com/alchemy-run/alchemy/commit/4e8f4e55)
   - **dev**:
-    - Improve multi-worker reliability in bun &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/535 [<samp>(cd1af)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/cd1aff7a)
-    - Cross-script durable object bindings not working &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/540 [<samp>(40f36)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/40f36355)
-    - Populate assets binding for vite websites &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/547 [<samp>(b1504)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/b1504d9d)
+    - Improve multi-worker reliability in bun &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/535 [<samp>(cd1af)</samp>](https://github.com/alchemy-run/alchemy/commit/cd1aff7a)
+    - Cross-script durable object bindings not working &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/540 [<samp>(40f36)</samp>](https://github.com/alchemy-run/alchemy/commit/40f36355)
+    - Populate assets binding for vite websites &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/547 [<samp>(b1504)</samp>](https://github.com/alchemy-run/alchemy/commit/b1504d9d)
 - **core**:
-  - Trigger updates when a Redacted config/secret value changes &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/549 [<samp>(8b9c2)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/8b9c2415)
-  - Honor retain removal policy on replace &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/548 [<samp>(5ac2f)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/5ac2f158)
+  - Trigger updates when a Redacted config/secret value changes &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/549 [<samp>(8b9c2)</samp>](https://github.com/alchemy-run/alchemy/commit/8b9c2415)
+  - Honor retain removal policy on replace &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/548 [<samp>(5ac2f)</samp>](https://github.com/alchemy-run/alchemy/commit/5ac2f158)
 - **drizzle**:
-  - Expose Schema `out` as a cwd-relative path &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/551 [<samp>(0cf52)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/0cf52bb6)
+  - Expose Schema `out` as a cwd-relative path &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/551 [<samp>(0cf52)</samp>](https://github.com/alchemy-run/alchemy/commit/0cf52bb6)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.51...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.51...HEAD)
 
 ---
 
@@ -407,21 +407,21 @@
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
 - **cloudflare**:
-  - Add Ruleset resource &nbsp;-&nbsp; by **Alex** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/240 [<samp>(93d1c)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/93d1cdea)
-  - **ai**: Add DurableObjectChatPersistence layer &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/390 [<samp>(f53a2)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/f53a26ff)
+  - Add Ruleset resource &nbsp;-&nbsp; by **Alex** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/240 [<samp>(93d1c)</samp>](https://github.com/alchemy-run/alchemy/commit/93d1cdea)
+  - **ai**: Add DurableObjectChatPersistence layer &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/390 [<samp>(f53a2)</samp>](https://github.com/alchemy-run/alchemy/commit/f53a26ff)
 - **core**:
-  - Allow ConfigError on Alchemy.Stack, Worker and Platform effects &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/487 [<samp>(ce201)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/ce201070)
+  - Allow ConfigError on Alchemy.Stack, Worker and Platform effects &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/487 [<samp>(ce201)</samp>](https://github.com/alchemy-run/alchemy/commit/ce201070)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- Honor resource-scoped adopt(...) in the planner &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/521 [<samp>(5736f)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/5736f1c0)
-- **aws**: Deliver S3 bucket notifications to Lambda event sources &nbsp;-&nbsp; by **Andrey Konopkov** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/470 [<samp>(04459)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/04459ee4)
-- **cloudflare**: Support SecretsStore Secret as async binding &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/475 [<samp>(46010)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/46010c82)
-- **core**: Use ExprSymbol to identify Outputs in core to avoid collisions with user data &nbsp;-&nbsp; by **Julius Marminge** in https://github.com/alchemy-run/alchemy-effect/issues/517 [<samp>(c0a6b)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/c0a6bd86)
-- **drizzle**: Preserve snapshot lineage &nbsp;-&nbsp; by **Julius Marminge** in https://github.com/alchemy-run/alchemy-effect/issues/519 [<samp>(86d18)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/86d186d8)
-- **planetscale**: Remove kind attribute that collides with output proxy discriminator &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy-effect/issues/518 [<samp>(bd12d)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/bd12d1c1)
+- Honor resource-scoped adopt(...) in the planner &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/521 [<samp>(5736f)</samp>](https://github.com/alchemy-run/alchemy/commit/5736f1c0)
+- **aws**: Deliver S3 bucket notifications to Lambda event sources &nbsp;-&nbsp; by **Andrey Konopkov** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/470 [<samp>(04459)</samp>](https://github.com/alchemy-run/alchemy/commit/04459ee4)
+- **cloudflare**: Support SecretsStore Secret as async binding &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/475 [<samp>(46010)</samp>](https://github.com/alchemy-run/alchemy/commit/46010c82)
+- **core**: Use ExprSymbol to identify Outputs in core to avoid collisions with user data &nbsp;-&nbsp; by **Julius Marminge** in https://github.com/alchemy-run/alchemy/issues/517 [<samp>(c0a6b)</samp>](https://github.com/alchemy-run/alchemy/commit/c0a6bd86)
+- **drizzle**: Preserve snapshot lineage &nbsp;-&nbsp; by **Julius Marminge** in https://github.com/alchemy-run/alchemy/issues/519 [<samp>(86d18)</samp>](https://github.com/alchemy-run/alchemy/commit/86d186d8)
+- **planetscale**: Remove kind attribute that collides with output proxy discriminator &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy/issues/518 [<samp>(bd12d)</samp>](https://github.com/alchemy-run/alchemy/commit/bd12d1c1)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.50...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.50...HEAD)
 
 ---
 
@@ -430,10 +430,10 @@
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
 - **cloudflare**:
-  - Worker/vite port conflict in dev &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/513 [<samp>(f7b9e)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/f7b9ecc5)
-  - `RuntimeContext` dependency when binding output values &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/514 [<samp>(d136f)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/d136fb54)
+  - Worker/vite port conflict in dev &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/513 [<samp>(f7b9e)</samp>](https://github.com/alchemy-run/alchemy/commit/f7b9ecc5)
+  - `RuntimeContext` dependency when binding output values &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/514 [<samp>(d136f)</samp>](https://github.com/alchemy-run/alchemy/commit/d136fb54)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.49...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.49...HEAD)
 
 ---
 
@@ -441,15 +441,15 @@
 
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
-- **cloudflare**: DNS record bindings &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/511 [<samp>(fafc9)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/fafc9e9c)
-- **output**: Add flatMap and method-style combinators &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/512 [<samp>(00234)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/002343f0)
+- **cloudflare**: DNS record bindings &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/511 [<samp>(fafc9)</samp>](https://github.com/alchemy-run/alchemy/commit/fafc9e9c)
+- **output**: Add flatMap and method-style combinators &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/512 [<samp>(00234)</samp>](https://github.com/alchemy-run/alchemy/commit/002343f0)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- Don't unwrap unredacted values &nbsp;-&nbsp; by **sam** [<samp>(f4ef0)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/f4ef0381)
-- **cloudflare**: Ensure all yielded Config in a Worker to use secret_text &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/510 [<samp>(38c62)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/38c62b6b)
+- Don't unwrap unredacted values &nbsp;-&nbsp; by **sam** [<samp>(f4ef0)</samp>](https://github.com/alchemy-run/alchemy/commit/f4ef0381)
+- **cloudflare**: Ensure all yielded Config in a Worker to use secret_text &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/510 [<samp>(38c62)</samp>](https://github.com/alchemy-run/alchemy/commit/38c62b6b)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.48...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.48...HEAD)
 
 ---
 
@@ -458,24 +458,24 @@
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
 - **cli**:
-  - Add cloudflare create-token command &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/496 [<samp>(ab886)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/ab8864fe)
+  - Add cloudflare create-token command &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/496 [<samp>(ab886)</samp>](https://github.com/alchemy-run/alchemy/commit/ab8864fe)
 - **cloudflare**:
-  - Zone &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/493 [<samp>(38b2f)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/38b2f0a8)
-  - Rename BrowserRendering to Browser &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/503 [<samp>(1a62d)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/1a62d247)
-  - Tunnel Bindings &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/508 [<samp>(86bcf)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/86bcf260)
-  - **browser**: Yieldable BrowserRendering marker &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/498 [<samp>(05283)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/052832a8)
-  - **images**: Yieldable Images binding &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/501 [<samp>(46c15)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/46c158a6)
-  - **ratelimit**: Add RateLimit binding &nbsp;-&nbsp; by **Alex** and **sam** in https://github.com/alchemy-run/alchemy-effect/issues/238 [<samp>(eb8f5)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/eb8f5efc)
-  - **workers**: Yieldable DynamicWorkerLoader marker &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/505 [<samp>(362fc)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/362fcdff)
+  - Zone &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/493 [<samp>(38b2f)</samp>](https://github.com/alchemy-run/alchemy/commit/38b2f0a8)
+  - Rename BrowserRendering to Browser &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/503 [<samp>(1a62d)</samp>](https://github.com/alchemy-run/alchemy/commit/1a62d247)
+  - Tunnel Bindings &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/508 [<samp>(86bcf)</samp>](https://github.com/alchemy-run/alchemy/commit/86bcf260)
+  - **browser**: Yieldable BrowserRendering marker &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/498 [<samp>(05283)</samp>](https://github.com/alchemy-run/alchemy/commit/052832a8)
+  - **images**: Yieldable Images binding &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/501 [<samp>(46c15)</samp>](https://github.com/alchemy-run/alchemy/commit/46c158a6)
+  - **ratelimit**: Add RateLimit binding &nbsp;-&nbsp; by **Alex** and **sam** in https://github.com/alchemy-run/alchemy/issues/238 [<samp>(eb8f5)</samp>](https://github.com/alchemy-run/alchemy/commit/eb8f5efc)
+  - **workers**: Yieldable DynamicWorkerLoader marker &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/505 [<samp>(362fc)</samp>](https://github.com/alchemy-run/alchemy/commit/362fcdff)
 - **docs**:
-  - Add Bindings section and refocus Providers on lifecycle interface &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/502 [<samp>(a5fc3)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/a5fc3412)
+  - Add Bindings section and refocus Providers on lifecycle interface &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/502 [<samp>(a5fc3)</samp>](https://github.com/alchemy-run/alchemy/commit/a5fc3412)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
 - **cloudflare**:
-  - **zone**: Use ZoneAlreadyExists tag; bump distilled 0.22.3 &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/507 [<samp>(d948f)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/d948f304)
+  - **zone**: Use ZoneAlreadyExists tag; bump distilled 0.22.3 &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/507 [<samp>(d948f)</samp>](https://github.com/alchemy-run/alchemy/commit/d948f304)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.47...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.47...HEAD)
 
 ---
 
@@ -484,17 +484,17 @@
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
 - **cloudflare**:
-  - **ai-gateway**: Add LanguageModel + AI Gateway client surface &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/389 [<samp>(51150)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/51150a8c)
+  - **ai-gateway**: Add LanguageModel + AI Gateway client surface &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/389 [<samp>(51150)</samp>](https://github.com/alchemy-run/alchemy/commit/51150a8c)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
 - **cli**:
-  - Skip evalStack in login and defer State store init to runtime &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/492 [<samp>(949b3)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/949b3079)
+  - Skip evalStack in login and defer State store init to runtime &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/492 [<samp>(949b3)</samp>](https://github.com/alchemy-run/alchemy/commit/949b3079)
 - **cloudflare**:
-  - Handle props.env in local workers &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/473 [<samp>(0b779)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/0b779dfe)
-  - Stream RPC return values across durable object boundary &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/478 [<samp>(6811d)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/6811de57)
+  - Handle props.env in local workers &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/473 [<samp>(0b779)</samp>](https://github.com/alchemy-run/alchemy/commit/0b779dfe)
+  - Stream RPC return values across durable object boundary &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/478 [<samp>(6811d)</samp>](https://github.com/alchemy-run/alchemy/commit/6811de57)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.46...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.46...HEAD)
 
 ---
 
@@ -503,13 +503,13 @@
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
 - **cloudflare**:
-  - **vectorize**: Add Vectorize index as a bindable resource &nbsp;-&nbsp; by **David J. Felix** and **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/407 [<samp>(2089d)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/2089dbf7)
+  - **vectorize**: Add Vectorize index as a bindable resource &nbsp;-&nbsp; by **David J. Felix** and **John Royal** in https://github.com/alchemy-run/alchemy/issues/407 [<samp>(2089d)</samp>](https://github.com/alchemy-run/alchemy/commit/2089dbf7)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- **cloudflare**: Use remote state when updating Cloudflare State Store &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/477 [<samp>(a1a81)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/a1a811e1)
+- **cloudflare**: Use remote state when updating Cloudflare State Store &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/477 [<samp>(a1a81)</samp>](https://github.com/alchemy-run/alchemy/commit/a1a811e1)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.45...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.45...HEAD)
 
 ---
 
@@ -518,50 +518,50 @@
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
 - **Random**:
-  - Add KeyPair resource &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/441 [<samp>(aa776)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/aa776a6d)
+  - Add KeyPair resource &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/441 [<samp>(aa776)</samp>](https://github.com/alchemy-run/alchemy/commit/aa776a6d)
 - **aws**:
-  - **lambda**: Add timeout to FunctionProps &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/440 [<samp>(38a32)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/38a32704)
+  - **lambda**: Add timeout to FunctionProps &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/440 [<samp>(38a32)</samp>](https://github.com/alchemy-run/alchemy/commit/38a32704)
 - **cloudflare**:
-  - Add Browser Rendering binding &nbsp;-&nbsp; by **Alex** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/372 [<samp>(88e95)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/88e95867)
-  - Cross-script durable object binding &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/435 [<samp>(438fb)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/438fbfe1)
-  - RpcWorker &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/387 [<samp>(d15f0)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/d15f0a9f)
-  - Add RpcDurableObjectNamespace + modular RpcWorker/DO &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/388 [<samp>(c801d)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/c801dfd3)
-  - Workflows in `alchemy dev` &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/449 [<samp>(0351d)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/0351d715)
-  - Worker.url now tries to infer canonical url & domain order is preserved &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy-effect/issues/432 [<samp>(ae0a1)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/ae0a19a6)
-  - AnalyticsEngine and SendEmail bindings in alchemy dev &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/460 [<samp>(aa890)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/aa890310)
-  - Custom ports in alchemy dev &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/469 [<samp>(68ef9)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/68ef90fe)
-  - **queue**: Accept Duration.Input for messages() time props &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/443 [<samp>(f15c0)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/f15c0c50)
-  - **workers**: Collapse WorkerProps.bindings into WorkerProps.env &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/446 [<samp>(a0358)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/a0358684)
+  - Add Browser Rendering binding &nbsp;-&nbsp; by **Alex** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/372 [<samp>(88e95)</samp>](https://github.com/alchemy-run/alchemy/commit/88e95867)
+  - Cross-script durable object binding &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/435 [<samp>(438fb)</samp>](https://github.com/alchemy-run/alchemy/commit/438fbfe1)
+  - RpcWorker &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/387 [<samp>(d15f0)</samp>](https://github.com/alchemy-run/alchemy/commit/d15f0a9f)
+  - Add RpcDurableObjectNamespace + modular RpcWorker/DO &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/388 [<samp>(c801d)</samp>](https://github.com/alchemy-run/alchemy/commit/c801dfd3)
+  - Workflows in `alchemy dev` &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/449 [<samp>(0351d)</samp>](https://github.com/alchemy-run/alchemy/commit/0351d715)
+  - Worker.url now tries to infer canonical url & domain order is preserved &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy/issues/432 [<samp>(ae0a1)</samp>](https://github.com/alchemy-run/alchemy/commit/ae0a19a6)
+  - AnalyticsEngine and SendEmail bindings in alchemy dev &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/460 [<samp>(aa890)</samp>](https://github.com/alchemy-run/alchemy/commit/aa890310)
+  - Custom ports in alchemy dev &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/469 [<samp>(68ef9)</samp>](https://github.com/alchemy-run/alchemy/commit/68ef90fe)
+  - **queue**: Accept Duration.Input for messages() time props &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/443 [<samp>(f15c0)</samp>](https://github.com/alchemy-run/alchemy/commit/f15c0c50)
+  - **workers**: Collapse WorkerProps.bindings into WorkerProps.env &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/446 [<samp>(a0358)</samp>](https://github.com/alchemy-run/alchemy/commit/a0358684)
 - **core**:
-  - Replace Alchemy.Secret and Alchemy.Variable with effect/Config &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/445 [<samp>(53e7b)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/53e7b9c5)
+  - Replace Alchemy.Secret and Alchemy.Variable with effect/Config &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/445 [<samp>(53e7b)</samp>](https://github.com/alchemy-run/alchemy/commit/53e7b9c5)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
 - **Cloudflare**:
-  - Update Secrets reconcilation logic to update the Secret and update distilled &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(5d2d8)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/5d2d8daf)
-  - Wait for queue consumer to be bound &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(c74a8)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/c74a871b)
+  - Update Secrets reconcilation logic to update the Secret and update distilled &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(5d2d8)</samp>](https://github.com/alchemy-run/alchemy/commit/5d2d8daf)
+  - Wait for queue consumer to be bound &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(c74a8)</samp>](https://github.com/alchemy-run/alchemy/commit/c74a871b)
 - **better-auth**:
-  - Better auth as peer dep &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy-effect/issues/434 [<samp>(08244)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/08244a13)
+  - Better auth as peer dep &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy/issues/434 [<samp>(08244)</samp>](https://github.com/alchemy-run/alchemy/commit/08244a13)
 - **cli**:
-  - Disable --experimental-transform-types on node.js 26 &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/458 [<samp>(70359)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/703591ba)
-  - Import stack via file URL on Windows &nbsp;-&nbsp; by **d3lay** in https://github.com/alchemy-run/alchemy-effect/issues/426 [<samp>(51f6f)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/51f6f9e4)
-  - Ensure auth providers don't run in parallel and only run once &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy-effect/issues/461 [<samp>(2421c)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/2421cfe4)
+  - Disable --experimental-transform-types on node.js 26 &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/458 [<samp>(70359)</samp>](https://github.com/alchemy-run/alchemy/commit/703591ba)
+  - Import stack via file URL on Windows &nbsp;-&nbsp; by **d3lay** in https://github.com/alchemy-run/alchemy/issues/426 [<samp>(51f6f)</samp>](https://github.com/alchemy-run/alchemy/commit/51f6f9e4)
+  - Ensure auth providers don't run in parallel and only run once &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy/issues/461 [<samp>(2421c)</samp>](https://github.com/alchemy-run/alchemy/commit/2421cfe4)
 - **cloudflare**:
-  - Dev hyperdrive binding fails for vite/async workers &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/423 [<samp>(c83ce)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/c83ce2d8)
-  - Pass DO scriptName through async bindings &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/437 [<samp>(3a8da)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/3a8daa3d)
-  - Handle external require calls in vite dev &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/452 [<samp>(87cc9)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/87cc9f0c)
-  - Cloudflare.providers() has `any` in requirements &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/456 [<samp>(81814)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/818147f8)
-  - Reconcile Worker preview subdomain state &nbsp;-&nbsp; by **Dawson** and **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/285 [<samp>(dbd04)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/dbd042e2)
-  - Handle websocket upgrade in vite dev &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/457 [<samp>(67b57)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/67b57f81)
-  - Run HttpServer pre-response handlers correctly &nbsp;-&nbsp; by **Lucas Thevenet**, **Sam Goodwin** and **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/404 [<samp>(2e3d1)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/2e3d176f)
-  - Only close Scope if it's not transferred to a Stream &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(bb970)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/bb970abd)
-  - Trim bearer token to workaround effect beta.73 regression &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/468 [<samp>(2d08b)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/2d08bcf5)
-  - Reduce unnecessary updates in alchemy dev &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/455 [<samp>(ab7e7)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/ab7e718b)
-  - **worker**: Normalize bundle entry path on windows &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy-effect/issues/453 [<samp>(5cd26)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/5cd26234)
+  - Dev hyperdrive binding fails for vite/async workers &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/423 [<samp>(c83ce)</samp>](https://github.com/alchemy-run/alchemy/commit/c83ce2d8)
+  - Pass DO scriptName through async bindings &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/437 [<samp>(3a8da)</samp>](https://github.com/alchemy-run/alchemy/commit/3a8daa3d)
+  - Handle external require calls in vite dev &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/452 [<samp>(87cc9)</samp>](https://github.com/alchemy-run/alchemy/commit/87cc9f0c)
+  - Cloudflare.providers() has `any` in requirements &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/456 [<samp>(81814)</samp>](https://github.com/alchemy-run/alchemy/commit/818147f8)
+  - Reconcile Worker preview subdomain state &nbsp;-&nbsp; by **Dawson** and **John Royal** in https://github.com/alchemy-run/alchemy/issues/285 [<samp>(dbd04)</samp>](https://github.com/alchemy-run/alchemy/commit/dbd042e2)
+  - Handle websocket upgrade in vite dev &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/457 [<samp>(67b57)</samp>](https://github.com/alchemy-run/alchemy/commit/67b57f81)
+  - Run HttpServer pre-response handlers correctly &nbsp;-&nbsp; by **Lucas Thevenet**, **Sam Goodwin** and **John Royal** in https://github.com/alchemy-run/alchemy/issues/404 [<samp>(2e3d1)</samp>](https://github.com/alchemy-run/alchemy/commit/2e3d176f)
+  - Only close Scope if it's not transferred to a Stream &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(bb970)</samp>](https://github.com/alchemy-run/alchemy/commit/bb970abd)
+  - Trim bearer token to workaround effect beta.73 regression &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/468 [<samp>(2d08b)</samp>](https://github.com/alchemy-run/alchemy/commit/2d08bcf5)
+  - Reduce unnecessary updates in alchemy dev &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/455 [<samp>(ab7e7)</samp>](https://github.com/alchemy-run/alchemy/commit/ab7e718b)
+  - **worker**: Normalize bundle entry path on windows &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy/issues/453 [<samp>(5cd26)</samp>](https://github.com/alchemy-run/alchemy/commit/5cd26234)
 - **core**:
-  - Interrupt deployments when upstream non-cylic dependency fails &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(e22ee)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/e22ee4bf)
+  - Interrupt deployments when upstream non-cylic dependency fails &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(e22ee)</samp>](https://github.com/alchemy-run/alchemy/commit/e22ee4bf)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.44...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.44...HEAD)
 
 ---
 
@@ -569,30 +569,30 @@
 
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
-- Bundle analyzer plugin &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/405 [<samp>(28b8c)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/28b8c7a4)
+- Bundle analyzer plugin &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/405 [<samp>(28b8c)</samp>](https://github.com/alchemy-run/alchemy/commit/28b8c7a4)
 - **cloudflare**:
-  - Support Artifacts binding in dev &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/419 [<samp>(3917e)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/3917ef3a)
-  - **zaraz**: Add ZarazConfig resource &nbsp;-&nbsp; by **Alex** in https://github.com/alchemy-run/alchemy-effect/issues/371 [<samp>(7a232)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/7a232990)
+  - Support Artifacts binding in dev &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/419 [<samp>(3917e)</samp>](https://github.com/alchemy-run/alchemy/commit/3917ef3a)
+  - **zaraz**: Add ZarazConfig resource &nbsp;-&nbsp; by **Alex** in https://github.com/alchemy-run/alchemy/issues/371 [<samp>(7a232)</samp>](https://github.com/alchemy-run/alchemy/commit/7a232990)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- Node.js import resolution error from @alchemy.run/node-utils &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/406 [<samp>(4820d)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/4820da51)
+- Node.js import resolution error from @alchemy.run/node-utils &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/406 [<samp>(4820d)</samp>](https://github.com/alchemy-run/alchemy/commit/4820da51)
 - **bundle**:
-  - Support Vite-style ?raw imports &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/411 [<samp>(0e989)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/0e98917c)
+  - Support Vite-style ?raw imports &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/411 [<samp>(0e989)</samp>](https://github.com/alchemy-run/alchemy/commit/0e98917c)
 - **cli**:
-  - Filter bun's "not in project directory" watcher warning &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy-effect/issues/124 [<samp>(67370)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/673701e6)
+  - Filter bun's "not in project directory" watcher warning &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy/issues/124 [<samp>(67370)</samp>](https://github.com/alchemy-run/alchemy/commit/673701e6)
 - **cloudflare**:
-  - Update cloudflare-tools to 0.6.1 &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/403 [<samp>(cb68e)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/cb68ef48)
-  - Remove extraneous logs &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/410 [<samp>(7bb5d)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/7bb5d132)
-  - Harden local durable object handling &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/408 [<samp>(19e80)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/19e80aa2)
-  - Update cloudflare-tools to 0.6.3 &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/418 [<samp>(60826)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/60826480)
-  - Optimize WorkerBridge imports and silence warning &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/420 [<samp>(aa9ee)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/aa9ee151)
+  - Update cloudflare-tools to 0.6.1 &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/403 [<samp>(cb68e)</samp>](https://github.com/alchemy-run/alchemy/commit/cb68ef48)
+  - Remove extraneous logs &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/410 [<samp>(7bb5d)</samp>](https://github.com/alchemy-run/alchemy/commit/7bb5d132)
+  - Harden local durable object handling &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/408 [<samp>(19e80)</samp>](https://github.com/alchemy-run/alchemy/commit/19e80aa2)
+  - Update cloudflare-tools to 0.6.3 &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/418 [<samp>(60826)</samp>](https://github.com/alchemy-run/alchemy/commit/60826480)
+  - Optimize WorkerBridge imports and silence warning &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/420 [<samp>(aa9ee)</samp>](https://github.com/alchemy-run/alchemy/commit/aa9ee151)
 - **dev**:
-  - Dangling processes after dev server exits &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/382 [<samp>(6a8a0)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/6a8a0258)
+  - Dangling processes after dev server exits &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/382 [<samp>(6a8a0)</samp>](https://github.com/alchemy-run/alchemy/commit/6a8a0258)
 - **website**:
-  - Extract privacy.mdx style block to css file &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/398 [<samp>(fd72a)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/fd72a9de)
+  - Extract privacy.mdx style block to css file &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/398 [<samp>(fd72a)</samp>](https://github.com/alchemy-run/alchemy/commit/fd72a9de)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.43...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.43...HEAD)
 
 ---
 
@@ -600,19 +600,19 @@
 
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
-- **planetscale**: Add planetscale resources &nbsp;-&nbsp; by **Lucas Thevenet** and **Michael K** in https://github.com/alchemy-run/alchemy-effect/issues/113 [<samp>(ce5ea)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/ce5eabbf)
+- **planetscale**: Add planetscale resources &nbsp;-&nbsp; by **Lucas Thevenet** and **Michael K** in https://github.com/alchemy-run/alchemy/issues/113 [<samp>(ce5ea)</samp>](https://github.com/alchemy-run/alchemy/commit/ce5eabbf)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
 - **Cloudflare**:
-  - Move WorkerEnvironment requirement to the Layer instead of the binding API call &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/383 [<samp>(ab3a0)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/ab3a0268)
-  - Allow Outputs as input to Cloudflare.Worker &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/394 [<samp>(b9ea9)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/b9ea9315)
+  - Move WorkerEnvironment requirement to the Layer instead of the binding API call &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/383 [<samp>(ab3a0)</samp>](https://github.com/alchemy-run/alchemy/commit/ab3a0268)
+  - Allow Outputs as input to Cloudflare.Worker &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/394 [<samp>(b9ea9)</samp>](https://github.com/alchemy-run/alchemy/commit/b9ea9315)
 - **core**:
-  - Remove actions when destroying &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(d8551)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/d8551e21)
+  - Remove actions when destroying &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(d8551)</samp>](https://github.com/alchemy-run/alchemy/commit/d8551e21)
 - **docker**:
-  - Proper docker command on windows &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy-effect/issues/377 [<samp>(d1c42)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/d1c421af)
+  - Proper docker command on windows &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy/issues/377 [<samp>(d1c42)</samp>](https://github.com/alchemy-run/alchemy/commit/d1c421af)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.42...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.42...HEAD)
 
 ---
 
@@ -621,9 +621,9 @@
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
 - **Cloudflare**:
-  - **Worker**: Defer Platform hook bindings to avoid TDZ from npm &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/378 [<samp>(1b498)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/1b498227)
+  - **Worker**: Defer Platform hook bindings to avoid TDZ from npm &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/378 [<samp>(1b498)</samp>](https://github.com/alchemy-run/alchemy/commit/1b498227)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.41...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.41...HEAD)
 
 ---
 
@@ -631,25 +631,25 @@
 
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
-- **Cloudflare**: Include WorkerProps.env in InferEnv &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/351 [<samp>(f157e)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/f157ed89)
+- **Cloudflare**: Include WorkerProps.env in InferEnv &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/351 [<samp>(f157e)</samp>](https://github.com/alchemy-run/alchemy/commit/f157ed89)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
 - **Cloudflare**:
-  - Fix RPC and HTTP APIs by scoping runtime effects per request &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/374 [<samp>(b7cdc)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/b7cdca09)
+  - Fix RPC and HTTP APIs by scoping runtime effects per request &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/374 [<samp>(b7cdc)</samp>](https://github.com/alchemy-run/alchemy/commit/b7cdca09)
 - **cloudflare**:
-  - Externalize lightningcss + fsevents in worker bundler &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy-effect/issues/363 [<samp>(5dc95)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/5dc95a0e)
-  - Provide worker env to do methods &nbsp;-&nbsp; by **Dillon Mulroy** in https://github.com/alchemy-run/alchemy-effect/issues/369 [<samp>(7b5be)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/7b5be8be)
-  - Add WorkerExecutionContext and ExecutionContext to worker fetch types &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy-effect/issues/358 [<samp>(d2d0f)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/d2d0fa8d)
-  - **worker**: Force delete scripts on teardown &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/348 [<samp>(f37d0)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/f37d06cf)
+  - Externalize lightningcss + fsevents in worker bundler &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy/issues/363 [<samp>(5dc95)</samp>](https://github.com/alchemy-run/alchemy/commit/5dc95a0e)
+  - Provide worker env to do methods &nbsp;-&nbsp; by **Dillon Mulroy** in https://github.com/alchemy-run/alchemy/issues/369 [<samp>(7b5be)</samp>](https://github.com/alchemy-run/alchemy/commit/7b5be8be)
+  - Add WorkerExecutionContext and ExecutionContext to worker fetch types &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy/issues/358 [<samp>(d2d0f)</samp>](https://github.com/alchemy-run/alchemy/commit/d2d0fa8d)
+  - **worker**: Force delete scripts on teardown &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/348 [<samp>(f37d0)</samp>](https://github.com/alchemy-run/alchemy/commit/f37d06cf)
 - **core**:
-  - Eager terminal status events + pending while waiting on deps &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy-effect/issues/376 [<samp>(b307e)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/b307ee5a)
+  - Eager terminal status events + pending while waiting on deps &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy/issues/376 [<samp>(b307e)</samp>](https://github.com/alchemy-run/alchemy/commit/b307ee5a)
 - **sidecar**:
-  - Preserve Redacted values across RPC serialization &nbsp;-&nbsp; by **Juliaan** in https://github.com/alchemy-run/alchemy-effect/issues/356 [<samp>(b2334)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/b2334c5e)
+  - Preserve Redacted values across RPC serialization &nbsp;-&nbsp; by **Juliaan** in https://github.com/alchemy-run/alchemy/issues/356 [<samp>(b2334)</samp>](https://github.com/alchemy-run/alchemy/commit/b2334c5e)
 - **state**:
-  - Remove that one log we don't want, if you know you know &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy-effect/issues/347 [<samp>(ab648)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/ab648e16)
+  - Remove that one log we don't want, if you know you know &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy/issues/347 [<samp>(ab648)</samp>](https://github.com/alchemy-run/alchemy/commit/ab648e16)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.40...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.40...HEAD)
 
 ---
 
@@ -657,27 +657,27 @@
 
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
-- **axiom**: Smartfilter chart subtype &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy-effect/issues/339 [<samp>(f2650)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/f2650d05)
-- **cloudflare**: Vite dev &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/331 [<samp>(1913a)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/1913aafb)
+- **axiom**: Smartfilter chart subtype &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy/issues/339 [<samp>(f2650)</samp>](https://github.com/alchemy-run/alchemy/commit/f2650d05)
+- **cloudflare**: Vite dev &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/331 [<samp>(1913a)</samp>](https://github.com/alchemy-run/alchemy/commit/1913aafb)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
 - **Cloudflare**:
-  - Revert scopeTransferToStream which is causing 415 &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(fe354)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/fe354905)
-  - Bump state store version to 5 &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(baddd)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/baddd845)
+  - Revert scopeTransferToStream which is causing 415 &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(fe354)</samp>](https://github.com/alchemy-run/alchemy/commit/fe354905)
+  - Bump state store version to 5 &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(baddd)</samp>](https://github.com/alchemy-run/alchemy/commit/baddd845)
   - **AiGateway**:
-    - Stop reporting update on every deploy &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/332 [<samp>(2a1f7)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/2a1f7232)
-    - Align desired-state defaults with API defaults &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/334 [<samp>(0e3dc)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/0e3dcd3b)
+    - Stop reporting update on every deploy &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/332 [<samp>(2a1f7)</samp>](https://github.com/alchemy-run/alchemy/commit/2a1f7232)
+    - Align desired-state defaults with API defaults &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/334 [<samp>(0e3dc)</samp>](https://github.com/alchemy-run/alchemy/commit/0e3dcd3b)
   - **Container**:
-    - Forward startup options through Cloudflare.start &nbsp;-&nbsp; by **Christopher Yovanovitch** in https://github.com/alchemy-run/alchemy-effect/issues/341 [<samp>(1c72b)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/1c72b9c0)
+    - Forward startup options through Cloudflare.start &nbsp;-&nbsp; by **Christopher Yovanovitch** in https://github.com/alchemy-run/alchemy/issues/341 [<samp>(1c72b)</samp>](https://github.com/alchemy-run/alchemy/commit/1c72b9c0)
   - **Worker**:
-    - Log full Cause server-side, return generic 500 to client &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/336 [<samp>(ebdbc)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/ebdbc0d5)
+    - Log full Cause server-side, return generic 500 to client &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/336 [<samp>(ebdbc)</samp>](https://github.com/alchemy-run/alchemy/commit/ebdbc0d5)
 - **aws,cloudflare**:
-  - Sanitize entrypoint urls &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy-effect/issues/353 [<samp>(4cf38)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/4cf3856c)
+  - Sanitize entrypoint urls &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy/issues/353 [<samp>(4cf38)</samp>](https://github.com/alchemy-run/alchemy/commit/4cf3856c)
 - **dev**:
-  - Use @alchemy.run/node-utils lockfile &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/345 [<samp>(acc8b)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/acc8b885)
+  - Use @alchemy.run/node-utils lockfile &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/345 [<samp>(acc8b)</samp>](https://github.com/alchemy-run/alchemy/commit/acc8b885)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.39...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.39...HEAD)
 
 ---
 
@@ -687,12 +687,12 @@
 
 - **Cloudflare**:
   - **Vite**:
-    - Inline `env` props as `import.meta.env.*` in the bundle &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/330 [<samp>(c22a1)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/c22a1c7a)
+    - Inline `env` props as `import.meta.env.*` in the bundle &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/330 [<samp>(c22a1)</samp>](https://github.com/alchemy-run/alchemy/commit/c22a1c7a)
   - **Worker**:
-    - Cloudflare Worker HTTP effect lifecycle &nbsp;-&nbsp; by **Will King** in https://github.com/alchemy-run/alchemy-effect/issues/328 [<samp>(a1032)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/a1032c34)
-    - Add missing SendEmail worker binding type and meta &nbsp;-&nbsp; by **Gerben Mulder** in https://github.com/alchemy-run/alchemy-effect/issues/326 [<samp>(a7fbb)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/a7fbba51)
+    - Cloudflare Worker HTTP effect lifecycle &nbsp;-&nbsp; by **Will King** in https://github.com/alchemy-run/alchemy/issues/328 [<samp>(a1032)</samp>](https://github.com/alchemy-run/alchemy/commit/a1032c34)
+    - Add missing SendEmail worker binding type and meta &nbsp;-&nbsp; by **Gerben Mulder** in https://github.com/alchemy-run/alchemy/issues/326 [<samp>(a7fbb)</samp>](https://github.com/alchemy-run/alchemy/commit/a7fbba51)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.38...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.38...HEAD)
 
 ---
 
@@ -700,16 +700,16 @@
 
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
-- **cloudflare**: Add Email Routing resources and SendEmail Worker binding &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/314 [<samp>(06dab)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/06dab7c5)
-- **core**: Action plan node type (functions that run as part of apply) &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/315 [<samp>(8a66a)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/8a66a896)
+- **cloudflare**: Add Email Routing resources and SendEmail Worker binding &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/314 [<samp>(06dab)</samp>](https://github.com/alchemy-run/alchemy/commit/06dab7c5)
+- **core**: Action plan node type (functions that run as part of apply) &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/315 [<samp>(8a66a)</samp>](https://github.com/alchemy-run/alchemy/commit/8a66a896)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- Move to effect@4.0.0-beta.66 &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/321 [<samp>(b57f7)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/b57f78cf)
-- Improve transport error fault tolerance &nbsp;-&nbsp; by **sam** [<samp>(6d67c)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/6d67c24f)
-- **Neon**: Use @distilled.cloud/neon SDK instead of hand-rolled API &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/270 [<samp>(1b9d4)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/1b9d4372)
+- Move to effect@4.0.0-beta.66 &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/321 [<samp>(b57f7)</samp>](https://github.com/alchemy-run/alchemy/commit/b57f78cf)
+- Improve transport error fault tolerance &nbsp;-&nbsp; by **sam** [<samp>(6d67c)</samp>](https://github.com/alchemy-run/alchemy/commit/6d67c24f)
+- **Neon**: Use @distilled.cloud/neon SDK instead of hand-rolled API &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/270 [<samp>(1b9d4)</samp>](https://github.com/alchemy-run/alchemy/commit/1b9d4372)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.37...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.37...HEAD)
 
 ---
 
@@ -717,28 +717,28 @@
 
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
-- Cross-stack and cross-stage references &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/300 [<samp>(94ea3)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/94ea3129)
+- Cross-stack and cross-stage references &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/300 [<samp>(94ea3)</samp>](https://github.com/alchemy-run/alchemy/commit/94ea3129)
 - **Cloudflare**:
-  - Empty r2 bucket on destroy &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy-effect/issues/276 [<samp>(2412a)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/2412a3c2)
-  - Worker to worker binding types and tanstack start bridge example and docs &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/310 [<samp>(30dd9)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/30dd99c9)
-  - **Workflow**: Type workflow input and output &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/304 [<samp>(1dafd)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/1dafd77c)
+  - Empty r2 bucket on destroy &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy/issues/276 [<samp>(2412a)</samp>](https://github.com/alchemy-run/alchemy/commit/2412a3c2)
+  - Worker to worker binding types and tanstack start bridge example and docs &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/310 [<samp>(30dd9)</samp>](https://github.com/alchemy-run/alchemy/commit/30dd99c9)
+  - **Workflow**: Type workflow input and output &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/304 [<samp>(1dafd)</samp>](https://github.com/alchemy-run/alchemy/commit/1dafd77c)
 - **cloudflare**:
-  - Add Worker cron triggers &nbsp;-&nbsp; by **Dawson** and **sam** in https://github.com/alchemy-run/alchemy-effect/issues/288 [<samp>(cae20)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/cae20c98)
-  - Add Analytics Engine binding &nbsp;-&nbsp; by **Dawson** and **sam** in https://github.com/alchemy-run/alchemy-effect/issues/286 [<samp>(ba8b3)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/ba8b3a16)
+  - Add Worker cron triggers &nbsp;-&nbsp; by **Dawson** and **sam** in https://github.com/alchemy-run/alchemy/issues/288 [<samp>(cae20)</samp>](https://github.com/alchemy-run/alchemy/commit/cae20c98)
+  - Add Analytics Engine binding &nbsp;-&nbsp; by **Dawson** and **sam** in https://github.com/alchemy-run/alchemy/issues/286 [<samp>(ba8b3)</samp>](https://github.com/alchemy-run/alchemy/commit/ba8b3a16)
 - **core**:
-  - Add Alchemy.Secret and Alchemy.Variable &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/290 [<samp>(88611)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/88611eac)
+  - Add Alchemy.Secret and Alchemy.Variable &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/290 [<samp>(88611)</samp>](https://github.com/alchemy-run/alchemy/commit/88611eac)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- Remove deprecated libsodium wrapper types &nbsp;-&nbsp; by **齐天大圣** in https://github.com/alchemy-run/alchemy-effect/issues/311 [<samp>(f3f70)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/f3f7079a)
+- Remove deprecated libsodium wrapper types &nbsp;-&nbsp; by **齐天大圣** in https://github.com/alchemy-run/alchemy/issues/311 [<samp>(f3f70)</samp>](https://github.com/alchemy-run/alchemy/commit/f3f7079a)
 - **Cloudflare**:
-  - **D1**: Make prepare/bind synchronous &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/299 [<samp>(6e58d)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/6e58da04)
+  - **D1**: Make prepare/bind synchronous &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/299 [<samp>(6e58d)</samp>](https://github.com/alchemy-run/alchemy/commit/6e58da04)
 - **cloudflare**:
-  - Include wasm modules in local sidecar bundle &nbsp;-&nbsp; by **Baptiste Arnaud** and **sam** in https://github.com/alchemy-run/alchemy-effect/issues/305 [<samp>(1926d)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/1926d580)
+  - Include wasm modules in local sidecar bundle &nbsp;-&nbsp; by **Baptiste Arnaud** and **sam** in https://github.com/alchemy-run/alchemy/issues/305 [<samp>(1926d)</samp>](https://github.com/alchemy-run/alchemy/commit/1926d580)
 - **core**:
-  - Throw on JS string-coercion of unresolved Outputs &nbsp;-&nbsp; by **Zé Yuri** in https://github.com/alchemy-run/alchemy-effect/issues/306 [<samp>(d1b12)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/d1b12ac7)
+  - Throw on JS string-coercion of unresolved Outputs &nbsp;-&nbsp; by **Zé Yuri** in https://github.com/alchemy-run/alchemy/issues/306 [<samp>(d1b12)</samp>](https://github.com/alchemy-run/alchemy/commit/d1b12ac7)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.36...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.36...HEAD)
 
 ---
 
@@ -747,20 +747,20 @@
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
 - **Cloudflare**:
-  - **Images**: Add Images binding &nbsp;-&nbsp; by **Alex** in https://github.com/alchemy-run/alchemy-effect/issues/237 [<samp>(b19c3)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/b19c3562)
+  - **Images**: Add Images binding &nbsp;-&nbsp; by **Alex** in https://github.com/alchemy-run/alchemy/issues/237 [<samp>(b19c3)</samp>](https://github.com/alchemy-run/alchemy/commit/b19c3562)
 - **cloudflare**:
-  - Support Hyperdrive in Worker bindings &nbsp;-&nbsp; by **Baptiste Arnaud** in https://github.com/alchemy-run/alchemy-effect/issues/282 [<samp>(48381)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/48381a01)
-  - **r2**: Add lifecycleRules option to R2Bucket &nbsp;-&nbsp; by **Baptiste Arnaud** in https://github.com/alchemy-run/alchemy-effect/issues/284 [<samp>(ed905)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/ed905d44)
+  - Support Hyperdrive in Worker bindings &nbsp;-&nbsp; by **Baptiste Arnaud** in https://github.com/alchemy-run/alchemy/issues/282 [<samp>(48381)</samp>](https://github.com/alchemy-run/alchemy/commit/48381a01)
+  - **r2**: Add lifecycleRules option to R2Bucket &nbsp;-&nbsp; by **Baptiste Arnaud** in https://github.com/alchemy-run/alchemy/issues/284 [<samp>(ed905)</samp>](https://github.com/alchemy-run/alchemy/commit/ed905d44)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- **Dev**: Resolve *.localhost via undici dispatcher &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/289 [<samp>(ae6de)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/ae6de171)
+- **Dev**: Resolve *.localhost via undici dispatcher &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/289 [<samp>(ae6de)</samp>](https://github.com/alchemy-run/alchemy/commit/ae6de171)
 
 ### &nbsp;&nbsp;&nbsp;🏎 Performance
 
-- **smoke**: Batch canary install at the workspace root &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/291 [<samp>(90918)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/9091856e)
+- **smoke**: Batch canary install at the workspace root &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/291 [<samp>(90918)</samp>](https://github.com/alchemy-run/alchemy/commit/9091856e)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.35...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.35...HEAD)
 
 ---
 
@@ -769,31 +769,31 @@
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
 - **Cloudflare**:
-  - **R2**: Add bucket custom domains &nbsp;-&nbsp; by **Alex** and **sam** in https://github.com/alchemy-run/alchemy-effect/issues/241 [<samp>(a782a)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/a782a449)
+  - **R2**: Add bucket custom domains &nbsp;-&nbsp; by **Alex** and **sam** in https://github.com/alchemy-run/alchemy/issues/241 [<samp>(a782a)</samp>](https://github.com/alchemy-run/alchemy/commit/a782a449)
 - **Neon**:
-  - **Project**: Add enableLogicalReplication option &nbsp;-&nbsp; by **Baptiste Arnaud** in https://github.com/alchemy-run/alchemy-effect/issues/268 [<samp>(c4945)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/c49451c6)
+  - **Project**: Add enableLogicalReplication option &nbsp;-&nbsp; by **Baptiste Arnaud** in https://github.com/alchemy-run/alchemy/issues/268 [<samp>(c4945)</samp>](https://github.com/alchemy-run/alchemy/commit/c49451c6)
 - **cli**:
-  - Warn when a newer alchemy version is on npm &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/253 [<samp>(7e701)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/7e701205)
-  - Use plain-text renderer in non-interactive terminals &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/258 [<samp>(16485)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/16485403)
-  - Cloudflare/aws namespaces + cloudflare state logs &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/256 [<samp>(335ab)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/335ab26c)
+  - Warn when a newer alchemy version is on npm &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/253 [<samp>(7e701)</samp>](https://github.com/alchemy-run/alchemy/commit/7e701205)
+  - Use plain-text renderer in non-interactive terminals &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/258 [<samp>(16485)</samp>](https://github.com/alchemy-run/alchemy/commit/16485403)
+  - Cloudflare/aws namespaces + cloudflare state logs &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/256 [<samp>(335ab)</samp>](https://github.com/alchemy-run/alchemy/commit/335ab26c)
 - **cloudflare**:
-  - Worker support non-string env bindings &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy-effect/issues/269 [<samp>(220c3)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/220c358c)
-  - **queue**: Cloudflare.messages(queue).subscribe(...) Effect consumer API &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/260 [<samp>(59c01)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/59c01867)
+  - Worker support non-string env bindings &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy/issues/269 [<samp>(220c3)</samp>](https://github.com/alchemy-run/alchemy/commit/220c358c)
+  - **queue**: Cloudflare.messages(queue).subscribe(...) Effect consumer API &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/260 [<samp>(59c01)</samp>](https://github.com/alchemy-run/alchemy/commit/59c01867)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- Move Auth Providers into layers to keep requirements never &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/271 [<samp>(38319)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/38319fa0)
-- Dev mode node compatibility and profiles &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/273 [<samp>(9f402)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/9f4026b6)
+- Move Auth Providers into layers to keep requirements never &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/271 [<samp>(38319)</samp>](https://github.com/alchemy-run/alchemy/commit/38319fa0)
+- Dev mode node compatibility and profiles &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/273 [<samp>(9f402)</samp>](https://github.com/alchemy-run/alchemy/commit/9f4026b6)
 - **Cloudflare**:
-  - **QueueConsumer**: Paginate listConsumers, surface conflicts clearly &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/257 [<samp>(11d06)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/11d06201)
-  - **R2**: Simplify r2 custom domain interface to just an array &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/259 [<samp>(8953d)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/8953dfc2)
+  - **QueueConsumer**: Paginate listConsumers, surface conflicts clearly &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/257 [<samp>(11d06)</samp>](https://github.com/alchemy-run/alchemy/commit/11d06201)
+  - **R2**: Simplify r2 custom domain interface to just an array &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/259 [<samp>(8953d)</samp>](https://github.com/alchemy-run/alchemy/commit/8953dfc2)
 - **Drizzle**:
-  - Only flag Schema as updated when migrations actually drift &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/261 [<samp>(8f2e3)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/8f2e33e7)
+  - Only flag Schema as updated when migrations actually drift &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/261 [<samp>(8f2e3)</samp>](https://github.com/alchemy-run/alchemy/commit/8f2e33e7)
 - **cloudflare**:
-  - Disable builder.sharedConfigBuild for vite build &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/176 [<samp>(2fb34)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/2fb34c2b)
-  - Update runtime to 0.3.1 &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/278 [<samp>(426e8)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/426e83f6)
+  - Disable builder.sharedConfigBuild for vite build &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/176 [<samp>(2fb34)</samp>](https://github.com/alchemy-run/alchemy/commit/2fb34c2b)
+  - Update runtime to 0.3.1 &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/278 [<samp>(426e8)</samp>](https://github.com/alchemy-run/alchemy/commit/426e83f6)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.34...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.34...HEAD)
 
 ---
 
@@ -801,10 +801,10 @@
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- Upgrade to distilled 0.17.0 consistently &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(d681f)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/d681f72f)
-- **cli**: Correct args for dev command in node &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/250 [<samp>(4859d)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/4859dc95)
+- Upgrade to distilled 0.17.0 consistently &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(d681f)</samp>](https://github.com/alchemy-run/alchemy/commit/d681f72f)
+- **cli**: Correct args for dev command in node &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/250 [<samp>(4859d)</samp>](https://github.com/alchemy-run/alchemy/commit/4859dc95)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.33...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.33...HEAD)
 
 ---
 
@@ -812,9 +812,9 @@
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- **Cloudflare**: Fix I/O error in state store &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/251 [<samp>(ec430)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/ec430ad2)
+- **Cloudflare**: Fix I/O error in state store &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/251 [<samp>(ec430)</samp>](https://github.com/alchemy-run/alchemy/commit/ec430ad2)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.32...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.32...HEAD)
 
 ---
 
@@ -822,13 +822,13 @@
 
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
-- **cloudflare**: Log cf state store version mismatch &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy-effect/issues/245 [<samp>(75f52)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/75f5220d)
+- **cloudflare**: Log cf state store version mismatch &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy/issues/245 [<samp>(75f52)</samp>](https://github.com/alchemy-run/alchemy/commit/75f5220d)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- **cloudflare**: Remove debug log statements &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(64414)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/64414547)
+- **cloudflare**: Remove debug log statements &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(64414)</samp>](https://github.com/alchemy-run/alchemy/commit/64414547)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.31...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.31...HEAD)
 
 ---
 
@@ -837,38 +837,38 @@
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
 - **Cloudflare**:
-  - **StateStore**: Wire OTLP traces, metrics, and logs &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/181 [<samp>(14b8a)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/14b8ab8c)
+  - **StateStore**: Wire OTLP traces, metrics, and logs &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/181 [<samp>(14b8a)</samp>](https://github.com/alchemy-run/alchemy/commit/14b8ab8c)
 - **aws**:
-  - Harden ApiGateway REST resources (bindings, retries, stage patches) &nbsp;-&nbsp; by **Sam Goodwin** and **Adrian Witaszak** in https://github.com/alchemy-run/alchemy-effect/issues/169 [<samp>(e4b84)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/e4b84a51)
+  - Harden ApiGateway REST resources (bindings, retries, stage patches) &nbsp;-&nbsp; by **Sam Goodwin** and **Adrian Witaszak** in https://github.com/alchemy-run/alchemy/issues/169 [<samp>(e4b84)</samp>](https://github.com/alchemy-run/alchemy/commit/e4b84a51)
 - **cloudflare**:
-  - Add Tunnel, VpcService, and VpcServiceRef &nbsp;-&nbsp; by **Kotkoroid** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/123 [<samp>(090c1)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/090c14db)
-  - Expose raw durable object sql storage &nbsp;-&nbsp; by **m@s** in https://github.com/alchemy-run/alchemy-effect/issues/188 [<samp>(20c03)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/20c0301b)
-  - Add Hyperdrive resource with dev-mode local DB support &nbsp;-&nbsp; by **Julian Archila** in https://github.com/alchemy-run/alchemy-effect/issues/158 [<samp>(8e651)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/8e651091)
-  - Workers observability traces &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy-effect/issues/244 [<samp>(ae531)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/ae5319cd)
+  - Add Tunnel, VpcService, and VpcServiceRef &nbsp;-&nbsp; by **Kotkoroid** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/123 [<samp>(090c1)</samp>](https://github.com/alchemy-run/alchemy/commit/090c14db)
+  - Expose raw durable object sql storage &nbsp;-&nbsp; by **m@s** in https://github.com/alchemy-run/alchemy/issues/188 [<samp>(20c03)</samp>](https://github.com/alchemy-run/alchemy/commit/20c0301b)
+  - Add Hyperdrive resource with dev-mode local DB support &nbsp;-&nbsp; by **Julian Archila** in https://github.com/alchemy-run/alchemy/issues/158 [<samp>(8e651)</samp>](https://github.com/alchemy-run/alchemy/commit/8e651091)
+  - Workers observability traces &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy/issues/244 [<samp>(ae531)</samp>](https://github.com/alchemy-run/alchemy/commit/ae5319cd)
 - **core**:
-  - Support for adoption in the core engine (using read) &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/167 [<samp>(9914e)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/9914ec03)
-  - Replace create+update with one `reconcile` function &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/179 [<samp>(bfd4f)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/bfd4f386)
+  - Support for adoption in the core engine (using read) &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/167 [<samp>(9914e)</samp>](https://github.com/alchemy-run/alchemy/commit/9914ec03)
+  - Replace create+update with one `reconcile` function &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/179 [<samp>(bfd4f)</samp>](https://github.com/alchemy-run/alchemy/commit/bfd4f386)
 - **neon**:
-  - Add Neon serverless Postgres provider &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/134 [<samp>(3b5e8)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/3b5e88a8)
+  - Add Neon serverless Postgres provider &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/134 [<samp>(3b5e8)</samp>](https://github.com/alchemy-run/alchemy/commit/3b5e88a8)
 - **test**:
-  - Add dev flag to test harness, toggleable via ALCHEMY_DEV &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/183 [<samp>(7856a)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/7856afbb)
+  - Add dev flag to test harness, toggleable via ALCHEMY_DEV &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/183 [<samp>(7856a)</samp>](https://github.com/alchemy-run/alchemy/commit/7856afbb)
 - **website**:
-  - Generate llms.txt from page frontmatter &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/170 [<samp>(9ad47)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/9ad47381)
+  - Generate llms.txt from page frontmatter &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/170 [<samp>(9ad47)</samp>](https://github.com/alchemy-run/alchemy/commit/9ad47381)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
 - **Cloudflare**:
-  - Dedupe Container DO bindings by namespaceId &nbsp;-&nbsp; by **Christopher Yovanovitch** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/172 [<samp>(a2c54)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/a2c54999)
-  - **SecretsStore**: Adoption opt-in by default &nbsp;-&nbsp; by **Stibbs** in https://github.com/alchemy-run/alchemy-effect/issues/163 [<samp>(d9f22)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/d9f22752)
+  - Dedupe Container DO bindings by namespaceId &nbsp;-&nbsp; by **Christopher Yovanovitch** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/172 [<samp>(a2c54)</samp>](https://github.com/alchemy-run/alchemy/commit/a2c54999)
+  - **SecretsStore**: Adoption opt-in by default &nbsp;-&nbsp; by **Stibbs** in https://github.com/alchemy-run/alchemy/issues/163 [<samp>(d9f22)</samp>](https://github.com/alchemy-run/alchemy/commit/d9f22752)
 - **aws**:
   - **lambda**:
-    - Scope public url invokes &nbsp;-&nbsp; by **José Netto** in https://github.com/alchemy-run/alchemy-effect/issues/162 [<samp>(1e092)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/1e092912)
-    - Pass invoked via url permission &nbsp;-&nbsp; by **José Netto** in https://github.com/alchemy-run/alchemy-effect/issues/161 [<samp>(3e978)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/3e978ff7)
+    - Scope public url invokes &nbsp;-&nbsp; by **José Netto** in https://github.com/alchemy-run/alchemy/issues/162 [<samp>(1e092)</samp>](https://github.com/alchemy-run/alchemy/commit/1e092912)
+    - Pass invoked via url permission &nbsp;-&nbsp; by **José Netto** in https://github.com/alchemy-run/alchemy/issues/161 [<samp>(3e978)</samp>](https://github.com/alchemy-run/alchemy/commit/3e978ff7)
 - **cloudflare**:
-  - Enable hyperdrive in dev mode &nbsp;-&nbsp; by **John Royal** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/242 [<samp>(86623)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/8662373d)
-  - **worker**: Make asset hash path-independent and reuse manifest when unchanged &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/165 [<samp>(e1669)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/e1669a77)
+  - Enable hyperdrive in dev mode &nbsp;-&nbsp; by **John Royal** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/242 [<samp>(86623)</samp>](https://github.com/alchemy-run/alchemy/commit/8662373d)
+  - **worker**: Make asset hash path-independent and reuse manifest when unchanged &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/165 [<samp>(e1669)</samp>](https://github.com/alchemy-run/alchemy/commit/e1669a77)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.30...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.30...HEAD)
 
 ---
 
@@ -876,9 +876,9 @@
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- **Cloudflare**: Apply Cloudflare Access headers to HTTP requests &nbsp;-&nbsp; by **jacobiajohnson** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/160 [<samp>(fd329)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/fd329e7)
+- **Cloudflare**: Apply Cloudflare Access headers to HTTP requests &nbsp;-&nbsp; by **jacobiajohnson** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/160 [<samp>(fd329)</samp>](https://github.com/alchemy-run/alchemy/commit/fd329e7)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.29...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.29...HEAD)
 
 ---
 
@@ -886,22 +886,22 @@
 
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
-- **Cloudflare**: Add AiGateway resource &nbsp;-&nbsp; by **Jan Henning** in https://github.com/alchemy-run/alchemy-effect/issues/130 [<samp>(b0361)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/b036165)
-- **cloudflare/state-store**: Version-gate the deployed worker &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/156 [<samp>(bdc37)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/bdc37df)
+- **Cloudflare**: Add AiGateway resource &nbsp;-&nbsp; by **Jan Henning** in https://github.com/alchemy-run/alchemy/issues/130 [<samp>(b0361)</samp>](https://github.com/alchemy-run/alchemy/commit/b036165)
+- **cloudflare/state-store**: Version-gate the deployed worker &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/156 [<samp>(bdc37)</samp>](https://github.com/alchemy-run/alchemy/commit/bdc37df)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
 - **Cloudflare**:
-  - Don't run update out of order for strict DAGs &nbsp;-&nbsp; by **sam** and **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/144 [<samp>(fcae5)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/fcae571)
-  - Run state-store secret probe under the deployed script name &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/150 [<samp>(061f8)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/061f86b)
+  - Don't run update out of order for strict DAGs &nbsp;-&nbsp; by **sam** and **John Royal** in https://github.com/alchemy-run/alchemy/issues/144 [<samp>(fcae5)</samp>](https://github.com/alchemy-run/alchemy/commit/fcae571)
+  - Run state-store secret probe under the deployed script name &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/150 [<samp>(061f8)</samp>](https://github.com/alchemy-run/alchemy/commit/061f86b)
 - **cloudflare**:
-  - Handle cloudflare access for edge preview workers &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/155 [<samp>(09d01)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/09d0130)
+  - Handle cloudflare access for edge preview workers &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/155 [<samp>(09d01)</samp>](https://github.com/alchemy-run/alchemy/commit/09d0130)
 - **core**:
-  - Handle failed resource gracefully &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/119 [<samp>(94d4b)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/94d4b3f)
+  - Handle failed resource gracefully &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/119 [<samp>(94d4b)</samp>](https://github.com/alchemy-run/alchemy/commit/94d4b3f)
 - **website**:
-  - Mobile dark hero, theme reactivity, brighter beta badge, OG host &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy-effect/issues/146 [<samp>(05eae)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/05eae4d)
+  - Mobile dark hero, theme reactivity, brighter beta badge, OG host &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy/issues/146 [<samp>(05eae)</samp>](https://github.com/alchemy-run/alchemy/commit/05eae4d)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.28...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.28...HEAD)
 
 ---
 
@@ -909,9 +909,9 @@
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- Remove PlatformServices from Util barrel &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/137 [<samp>(f85dd)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/f85ddfe)
+- Remove PlatformServices from Util barrel &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/137 [<samp>(f85dd)</samp>](https://github.com/alchemy-run/alchemy/commit/f85ddfe)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.27...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.27...HEAD)
 
 ---
 
@@ -919,10 +919,10 @@
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- **Cloudflare**: Don't bundle CLI with tsdown because it messes with import.meta.filename &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/135 [<samp>(2796c)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/2796c33)
-- **pr-package**: Use `bun add <name>@<url>` to dodge bun DependencyLoop bug &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/132 [<samp>(989e2)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/989e254)
+- **Cloudflare**: Don't bundle CLI with tsdown because it messes with import.meta.filename &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/135 [<samp>(2796c)</samp>](https://github.com/alchemy-run/alchemy/commit/2796c33)
+- **pr-package**: Use `bun add <name>@<url>` to dodge bun DependencyLoop bug &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/132 [<samp>(989e2)</samp>](https://github.com/alchemy-run/alchemy/commit/989e254)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.26...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.26...HEAD)
 
 ---
 
@@ -930,21 +930,21 @@
 
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
-- **test**: Align vitest and bun test helpers and integrate with profiles &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/129 [<samp>(07e83)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/07e83f3)
+- **test**: Align vitest and bun test helpers and integrate with profiles &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/129 [<samp>(07e83)</samp>](https://github.com/alchemy-run/alchemy/commit/07e83f3)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- Export types as lib/.d.ts &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/121 [<samp>(a000c)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/a000c26)
-- Resolve bin/exec.ts via package name so devs modes bundled CLI works &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy-effect/issues/128 [<samp>(303da)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/303daeb)
+- Export types as lib/.d.ts &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/121 [<samp>(a000c)</samp>](https://github.com/alchemy-run/alchemy/commit/a000c26)
+- Resolve bin/exec.ts via package name so devs modes bundled CLI works &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy/issues/128 [<samp>(303da)</samp>](https://github.com/alchemy-run/alchemy/commit/303daeb)
 - **cli**:
-  - Parallelize alchemy state tree &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/126 [<samp>(f3e8f)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/f3e8fef)
+  - Parallelize alchemy state tree &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/126 [<samp>(f3e8f)</samp>](https://github.com/alchemy-run/alchemy/commit/f3e8fef)
 - **cloudflare**:
-  - Bootstrap regressions in SecretsStore and StateStore &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/131 [<samp>(37db0)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/37db01a)
+  - Bootstrap regressions in SecretsStore and StateStore &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/131 [<samp>(37db0)</samp>](https://github.com/alchemy-run/alchemy/commit/37db01a)
 - **core**:
-  - Fix broken url in error message and add state store guide &nbsp;-&nbsp; by **sam** [<samp>(4b991)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/4b991e7)
-  - Treat raw Resource refs as upstream dependencies &nbsp;-&nbsp; by **Mathieu Post** and **sam** in https://github.com/alchemy-run/alchemy-effect/issues/122 [<samp>(416f1)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/416f19c)
+  - Fix broken url in error message and add state store guide &nbsp;-&nbsp; by **sam** [<samp>(4b991)</samp>](https://github.com/alchemy-run/alchemy/commit/4b991e7)
+  - Treat raw Resource refs as upstream dependencies &nbsp;-&nbsp; by **Mathieu Post** and **sam** in https://github.com/alchemy-run/alchemy/issues/122 [<samp>(416f1)</samp>](https://github.com/alchemy-run/alchemy/commit/416f19c)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.25...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.25...HEAD)
 
 ---
 
@@ -952,9 +952,9 @@
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- **Cloudflare**: Remove broken keepAssets optimization &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(845a7)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/845a7b7)
+- **Cloudflare**: Remove broken keepAssets optimization &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(845a7)</samp>](https://github.com/alchemy-run/alchemy/commit/845a7b7)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.24...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.24...HEAD)
 
 ---
 
@@ -962,17 +962,17 @@
 
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
-- Dev mode for cloudflare workers &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/88 [<samp>(5a0d7)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/5a0d779)
-- **core**: --adopt &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(2af88)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/2af8851)
+- Dev mode for cloudflare workers &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/88 [<samp>(5a0d7)</samp>](https://github.com/alchemy-run/alchemy/commit/5a0d779)
+- **core**: --adopt &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(2af88)</samp>](https://github.com/alchemy-run/alchemy/commit/2af8851)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
 - **Cloudflare**:
-  - Add bootstrap command and harden bootstrap process of cloudflare &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/118 [<samp>(0858d)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/0858dd8)
-  - Hoist stack non-destructively &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(c9621)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/c9621d1)
-  - Don't fail on broken paths in state &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(05f16)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/05f16c8)
+  - Add bootstrap command and harden bootstrap process of cloudflare &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/118 [<samp>(0858d)</samp>](https://github.com/alchemy-run/alchemy/commit/0858dd8)
+  - Hoist stack non-destructively &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(c9621)</samp>](https://github.com/alchemy-run/alchemy/commit/c9621d1)
+  - Don't fail on broken paths in state &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(05f16)</samp>](https://github.com/alchemy-run/alchemy/commit/05f16c8)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.23...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.23...HEAD)
 
 ---
 
@@ -980,10 +980,10 @@
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- **AWS**: Various bugs in Lambda Function &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(92611)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/92611cd)
-- **cli**: Logs and tail command read state from right place &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/114 [<samp>(00163)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/0016361)
+- **AWS**: Various bugs in Lambda Function &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(92611)</samp>](https://github.com/alchemy-run/alchemy/commit/92611cd)
+- **cli**: Logs and tail command read state from right place &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/114 [<samp>(00163)</samp>](https://github.com/alchemy-run/alchemy/commit/0016361)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.22...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.22...HEAD)
 
 ---
 
@@ -991,9 +991,9 @@
 
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
-- **Cloudflare**: D1Database migrationsDir, importFiles, and clone &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/111 [<samp>(555e8)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/555e8ff)
+- **Cloudflare**: D1Database migrationsDir, importFiles, and clone &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/111 [<samp>(555e8)</samp>](https://github.com/alchemy-run/alchemy/commit/555e8ff)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.21...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.21...HEAD)
 
 ---
 
@@ -1001,13 +1001,13 @@
 
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
-- **pr-pkg**: Pr-package package &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy-effect/issues/110 [<samp>(9442d)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/9442d42)
+- **pr-pkg**: Pr-package package &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy/issues/110 [<samp>(9442d)</samp>](https://github.com/alchemy-run/alchemy/commit/9442d42)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- Update to distilled 0.13.1 &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(b0407)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/b040783)
+- Update to distilled 0.13.1 &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(b0407)</samp>](https://github.com/alchemy-run/alchemy/commit/b040783)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.20...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.20...HEAD)
 
 ---
 
@@ -1015,9 +1015,9 @@
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- Update to effect beta.58 & distilled 0.13 &nbsp;-&nbsp; by **Michael (Pear)** [<samp>(d6f4e)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/d6f4e53)
+- Update to effect beta.58 & distilled 0.13 &nbsp;-&nbsp; by **Michael (Pear)** [<samp>(d6f4e)</samp>](https://github.com/alchemy-run/alchemy/commit/d6f4e53)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.19...HEAD)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.19...HEAD)
 
 ---
 
@@ -1026,20 +1026,20 @@
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
 - **Axiom**:
-  - Axiom resources &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(f2ffd)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/f2ffde1)
-  - Type-safe dashboard charts &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(46f05)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/46f051d)
+  - Axiom resources &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(f2ffd)</samp>](https://github.com/alchemy-run/alchemy/commit/f2ffde1)
+  - Type-safe dashboard charts &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(46f05)</samp>](https://github.com/alchemy-run/alchemy/commit/46f051d)
 - **Bundle**:
-  - Auto-detect entry package for pure annotations &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(ce5f3)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/ce5f35b)
+  - Auto-detect entry package for pure annotations &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(ce5f3)</samp>](https://github.com/alchemy-run/alchemy/commit/ce5f35b)
 - **core**:
-  - Annotate pure calls to optimize tree shaking &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(e21a6)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/e21a605)
+  - Annotate pure calls to optimize tree shaking &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(e21a6)</samp>](https://github.com/alchemy-run/alchemy/commit/e21a605)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
 - **Axiom**:
-  - Ensure token is always present and handle missing token error in ApiTokenProvider &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(da86a)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/da86abb)
-  - Don't replace token when props don't cange &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(ac655)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/ac65581)
+  - Ensure token is always present and handle missing token error in ApiTokenProvider &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(da86a)</samp>](https://github.com/alchemy-run/alchemy/commit/da86abb)
+  - Don't replace token when props don't cange &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(ac655)</samp>](https://github.com/alchemy-run/alchemy/commit/ac65581)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.18...v2.0.0-beta.19)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.18...v2.0.0-beta.19)
 
 ---
 
@@ -1047,10 +1047,10 @@
 
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
-- **CloudFront**: CachePolicy, OriginRequestPolicy, ResponseHeadersPolicy, PublicKey, KeyGroup &nbsp;-&nbsp; by **Jordan** and **Claude Opus 4.7** in https://github.com/alchemy-run/alchemy-effect/issues/106 [<samp>(70201)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/7020108)
-- **GitHub**: Secrets helper for creating many secrets &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(7be53)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/7be536a)
+- **CloudFront**: CachePolicy, OriginRequestPolicy, ResponseHeadersPolicy, PublicKey, KeyGroup &nbsp;-&nbsp; by **Jordan** and **Claude Opus 4.7** in https://github.com/alchemy-run/alchemy/issues/106 [<samp>(70201)</samp>](https://github.com/alchemy-run/alchemy/commit/7020108)
+- **GitHub**: Secrets helper for creating many secrets &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(7be53)</samp>](https://github.com/alchemy-run/alchemy/commit/7be536a)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.17...v2.0.0-beta.18)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.17...v2.0.0-beta.18)
 
 ---
 
@@ -1059,22 +1059,22 @@
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
 - **ECS**:
-  - Add CapacityProvider resource &nbsp;-&nbsp; by **Jordan** in https://github.com/alchemy-run/alchemy-effect/issues/103 [<samp>(cb218)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/cb2183e)
+  - Add CapacityProvider resource &nbsp;-&nbsp; by **Jordan** in https://github.com/alchemy-run/alchemy/issues/103 [<samp>(cb218)</samp>](https://github.com/alchemy-run/alchemy/commit/cb2183e)
 - **cli**:
-  - Add alchemy profile clear command &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/104 [<samp>(9dde9)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/9dde996)
-  - Add `alchemy state clear` command &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/105 [<samp>(26bf5)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/26bf5e4)
+  - Add alchemy profile clear command &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/104 [<samp>(9dde9)</samp>](https://github.com/alchemy-run/alchemy/commit/9dde996)
+  - Add `alchemy state clear` command &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/105 [<samp>(26bf5)</samp>](https://github.com/alchemy-run/alchemy/commit/26bf5e4)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
 - **Cloudflare**:
-  - Don't modify ApiToken policies, let user write explicitly. &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/102 [<samp>(5c31b)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/5c31b1f)
+  - Don't modify ApiToken policies, let user write explicitly. &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/102 [<samp>(5c31b)</samp>](https://github.com/alchemy-run/alchemy/commit/5c31b1f)
 - **GitHub**:
-  - Place Comment in the GitHub.Providers collection &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(3ad95)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/3ad95cb)
+  - Place Comment in the GitHub.Providers collection &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(3ad95)</samp>](https://github.com/alchemy-run/alchemy/commit/3ad95cb)
 - **cli**:
-  - Don't prompt for approval if plan has no changes &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(891cf)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/891cf1c)
-  - Dont print undefined outputs &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(31ade)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/31ade04)
+  - Don't prompt for approval if plan has no changes &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(891cf)</samp>](https://github.com/alchemy-run/alchemy/commit/891cf1c)
+  - Dont print undefined outputs &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(31ade)</samp>](https://github.com/alchemy-run/alchemy/commit/31ade04)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.16...v2.0.0-beta.17)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.16...v2.0.0-beta.17)
 
 ---
 
@@ -1083,19 +1083,19 @@
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
 - **Cloudflare**:
-  - Artifacts Store &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(e531f)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/e531fbe)
-  - Allow account ID to be passed into AccountApiToken and UserApiToken &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(0f8ac)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/0f8ac88)
+  - Artifacts Store &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(e531f)</samp>](https://github.com/alchemy-run/alchemy/commit/e531fbe)
+  - Allow account ID to be passed into AccountApiToken and UserApiToken &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(0f8ac)</samp>](https://github.com/alchemy-run/alchemy/commit/0f8ac88)
 - **GitHub**:
-  - Auth provider for github supporting env, PAT and gh cli &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(1de51)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/1de5180)
+  - Auth provider for github supporting env, PAT and gh cli &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(1de51)</samp>](https://github.com/alchemy-run/alchemy/commit/1de5180)
 - **cli**:
-  - Alchemy profile show &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(f83e2)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/f83e216)
+  - Alchemy profile show &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(f83e2)</samp>](https://github.com/alchemy-run/alchemy/commit/f83e216)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- **Cloudflare**: Remove InstanceId from Artifact store requirement &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(de489)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/de489c7)
-- **cli**: Don't fail on broken profiles when logging in &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(d8296)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/d829616)
+- **Cloudflare**: Remove InstanceId from Artifact store requirement &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(de489)</samp>](https://github.com/alchemy-run/alchemy/commit/de489c7)
+- **cli**: Don't fail on broken profiles when logging in &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(d8296)</samp>](https://github.com/alchemy-run/alchemy/commit/d829616)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.15...v2.0.0-beta.16)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.15...v2.0.0-beta.16)
 
 ---
 
@@ -1103,20 +1103,20 @@
 
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
-- **Cloudflare**: UserApiToken and AccountApiToken &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(56e0f)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/56e0f79)
-- **GitHub**: Export a providers() Layer &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(e5cd4)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/e5cd471)
+- **Cloudflare**: UserApiToken and AccountApiToken &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(56e0f)</samp>](https://github.com/alchemy-run/alchemy/commit/56e0f79)
+- **GitHub**: Export a providers() Layer &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(e5cd4)</samp>](https://github.com/alchemy-run/alchemy/commit/e5cd471)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- Properly handle redacted outputs &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy-effect/issues/101 [<samp>(0d049)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/0d049aa)
+- Properly handle redacted outputs &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy/issues/101 [<samp>(0d049)</samp>](https://github.com/alchemy-run/alchemy/commit/0d049aa)
 - **Cloudflare**:
-  - Prefix State Store secrets with Alchemy &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(e2533)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/e25338e)
+  - Prefix State Store secrets with Alchemy &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(e2533)</samp>](https://github.com/alchemy-run/alchemy/commit/e25338e)
 - **core**:
-  - Clearer error when Stack is missing state or providers &nbsp;-&nbsp; by **Michael K** [<samp>(52cf4)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/52cf431)
-  - Core no longer requires cli &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy-effect/issues/100 [<samp>(aba0e)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/aba0ea4)
-  - Handle Redacted values in Plan &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(4fc48)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/4fc4874)
+  - Clearer error when Stack is missing state or providers &nbsp;-&nbsp; by **Michael K** [<samp>(52cf4)</samp>](https://github.com/alchemy-run/alchemy/commit/52cf431)
+  - Core no longer requires cli &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy/issues/100 [<samp>(aba0e)</samp>](https://github.com/alchemy-run/alchemy/commit/aba0ea4)
+  - Handle Redacted values in Plan &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(4fc48)</samp>](https://github.com/alchemy-run/alchemy/commit/4fc4874)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.14...v2.0.0-beta.15)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.14...v2.0.0-beta.15)
 
 ---
 
@@ -1124,16 +1124,16 @@
 
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
-- **Cloudflare**: Cloudflare State Store &nbsp;-&nbsp; by **Sam Goodwin** and **Michael (Pear)** in https://github.com/alchemy-run/alchemy-effect/issues/94 [<samp>(d3b12)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/d3b1298)
-- **cli**: Alchemy state command &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(b4a1d)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/b4a1d94)
+- **Cloudflare**: Cloudflare State Store &nbsp;-&nbsp; by **Sam Goodwin** and **Michael (Pear)** in https://github.com/alchemy-run/alchemy/issues/94 [<samp>(d3b12)</samp>](https://github.com/alchemy-run/alchemy/commit/d3b1298)
+- **cli**: Alchemy state command &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(b4a1d)</samp>](https://github.com/alchemy-run/alchemy/commit/b4a1d94)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- **Cloudflare**: Set rolldown resolve.conditionNames for bun/node in container bundle &nbsp;-&nbsp; by **Christopher Yovanovitch** in https://github.com/alchemy-run/alchemy-effect/issues/86 [<samp>(779bb)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/779bbd1)
-- **cli**: Use a cli.js shim to support node/bun and make effect a non-optional peer &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/92 [<samp>(9b69b)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/9b69ba3)
-- **core**: Harden HttpStateStore to transient errors &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(4071e)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/4071e8a)
+- **Cloudflare**: Set rolldown resolve.conditionNames for bun/node in container bundle &nbsp;-&nbsp; by **Christopher Yovanovitch** in https://github.com/alchemy-run/alchemy/issues/86 [<samp>(779bb)</samp>](https://github.com/alchemy-run/alchemy/commit/779bbd1)
+- **cli**: Use a cli.js shim to support node/bun and make effect a non-optional peer &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/92 [<samp>(9b69b)</samp>](https://github.com/alchemy-run/alchemy/commit/9b69ba3)
+- **core**: Harden HttpStateStore to transient errors &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(4071e)</samp>](https://github.com/alchemy-run/alchemy/commit/4071e8a)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.13...v2.0.0-beta.14)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.13...v2.0.0-beta.14)
 
 ---
 
@@ -1141,9 +1141,9 @@
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- **cli**: Cli ships correct platform versions &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy-effect/issues/91 [<samp>(e3597)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/e3597ab)
+- **cli**: Cli ships correct platform versions &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy/issues/91 [<samp>(e3597)</samp>](https://github.com/alchemy-run/alchemy/commit/e3597ab)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.12...v2.0.0-beta.13)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.12...v2.0.0-beta.13)
 
 ---
 
@@ -1151,19 +1151,19 @@
 
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
-- **AWS**: Use account-regional S3 bucket names for assets &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(6ab3f)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/6ab3fba)
-- **cloudflare**: Secret store resources &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy-effect/issues/64 [<samp>(9b107)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/9b10769)
+- **AWS**: Use account-regional S3 bucket names for assets &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(6ab3f)</samp>](https://github.com/alchemy-run/alchemy/commit/6ab3fba)
+- **cloudflare**: Secret store resources &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy/issues/64 [<samp>(9b107)</samp>](https://github.com/alchemy-run/alchemy/commit/9b10769)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- Providers not inheriting parent scope &nbsp;-&nbsp; by **John Royal** [<samp>(8317b)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/8317bcc)
-- Include WebSocketConstructor in PlatformServices &nbsp;-&nbsp; by **John Royal** [<samp>(2dfb0)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/2dfb06e)
+- Providers not inheriting parent scope &nbsp;-&nbsp; by **John Royal** [<samp>(8317b)</samp>](https://github.com/alchemy-run/alchemy/commit/8317bcc)
+- Include WebSocketConstructor in PlatformServices &nbsp;-&nbsp; by **John Royal** [<samp>(2dfb0)</samp>](https://github.com/alchemy-run/alchemy/commit/2dfb06e)
 
 ### &nbsp;&nbsp;&nbsp;🏎 Performance
 
-- Use subpath imports for PlatformServices &nbsp;-&nbsp; by **John Royal** [<samp>(1867a)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/1867a42)
+- Use subpath imports for PlatformServices &nbsp;-&nbsp; by **John Royal** [<samp>(1867a)</samp>](https://github.com/alchemy-run/alchemy/commit/1867a42)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.11...v2.0.0-beta.12)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.11...v2.0.0-beta.12)
 
 ---
 
@@ -1171,20 +1171,20 @@
 
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
-- Support vite 7 &nbsp;-&nbsp; by **John Royal** and **Michael (Pear)** in https://github.com/alchemy-run/alchemy-effect/issues/68 [<samp>(28d0e)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/28d0ef2)
+- Support vite 7 &nbsp;-&nbsp; by **John Royal** and **Michael (Pear)** in https://github.com/alchemy-run/alchemy/issues/68 [<samp>(28d0e)</samp>](https://github.com/alchemy-run/alchemy/commit/28d0ef2)
 - **Cloudflare**:
-  - Install external deps in container Dockerfile &nbsp;-&nbsp; by **Christopher Yovanovitch** and **Sisyphus** in https://github.com/alchemy-run/alchemy-effect/issues/75 [<samp>(f8493)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/f84934f)
-  - Add Queue, QueueBinding, and QueueConsumer resources &nbsp;-&nbsp; by **Christopher Yovanovitch** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/69 [<samp>(09e97)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/09e971b)
+  - Install external deps in container Dockerfile &nbsp;-&nbsp; by **Christopher Yovanovitch** and **Sisyphus** in https://github.com/alchemy-run/alchemy/issues/75 [<samp>(f8493)</samp>](https://github.com/alchemy-run/alchemy/commit/f84934f)
+  - Add Queue, QueueBinding, and QueueConsumer resources &nbsp;-&nbsp; by **Christopher Yovanovitch** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/69 [<samp>(09e97)</samp>](https://github.com/alchemy-run/alchemy/commit/09e971b)
 - **cli**:
-  - Alchemy login &nbsp;-&nbsp; by **Sam Goodwin** and **Michael (Pear)** in https://github.com/alchemy-run/alchemy-effect/issues/67 [<samp>(fc57d)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/fc57db8)
+  - Alchemy login &nbsp;-&nbsp; by **Sam Goodwin** and **Michael (Pear)** in https://github.com/alchemy-run/alchemy/issues/67 [<samp>(fc57d)</samp>](https://github.com/alchemy-run/alchemy/commit/fc57db8)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
 - **Cloudflare**:
-  - Provide WorkerEnvironment to Workflow body, not wrapper &nbsp;-&nbsp; by **Christopher Yovanovitch** in https://github.com/alchemy-run/alchemy-effect/issues/71 [<samp>(a0ae1)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/a0ae1d6)
-  - Write all bundle chunks to container image context &nbsp;-&nbsp; by **Christopher Yovanovitch** in https://github.com/alchemy-run/alchemy-effect/issues/78 [<samp>(03306)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/0330605)
+  - Provide WorkerEnvironment to Workflow body, not wrapper &nbsp;-&nbsp; by **Christopher Yovanovitch** in https://github.com/alchemy-run/alchemy/issues/71 [<samp>(a0ae1)</samp>](https://github.com/alchemy-run/alchemy/commit/a0ae1d6)
+  - Write all bundle chunks to container image context &nbsp;-&nbsp; by **Christopher Yovanovitch** in https://github.com/alchemy-run/alchemy/issues/78 [<samp>(03306)</samp>](https://github.com/alchemy-run/alchemy/commit/0330605)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.10...v2.0.0-beta.11)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.10...v2.0.0-beta.11)
 
 ---
 
@@ -1193,10 +1193,10 @@
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
 - **Cloudflare**:
-  - Reduce readiness retry schedule from 104s to 30s &nbsp;-&nbsp; by **Christopher Yovanovitch** and **Sisyphus** in https://github.com/alchemy-run/alchemy-effect/issues/76 [<samp>(bb2bf)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/bb2bff2)
-  - Await monitor() Promise instead of discarding it &nbsp;-&nbsp; by **Christopher Yovanovitch** and **Sisyphus** in https://github.com/alchemy-run/alchemy-effect/issues/74 [<samp>(d75e6)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/d75e6dd)
+  - Reduce readiness retry schedule from 104s to 30s &nbsp;-&nbsp; by **Christopher Yovanovitch** and **Sisyphus** in https://github.com/alchemy-run/alchemy/issues/76 [<samp>(bb2bf)</samp>](https://github.com/alchemy-run/alchemy/commit/bb2bff2)
+  - Await monitor() Promise instead of discarding it &nbsp;-&nbsp; by **Christopher Yovanovitch** and **Sisyphus** in https://github.com/alchemy-run/alchemy/issues/74 [<samp>(d75e6)</samp>](https://github.com/alchemy-run/alchemy/commit/d75e6dd)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.9...v2.0.0-beta.10)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.9...v2.0.0-beta.10)
 
 ---
 
@@ -1204,9 +1204,9 @@
 
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
-- CLI packages &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy-effect/issues/66 [<samp>(73e2a)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/73e2a45)
+- CLI packages &nbsp;-&nbsp; by **Michael K** in https://github.com/alchemy-run/alchemy/issues/66 [<samp>(73e2a)</samp>](https://github.com/alchemy-run/alchemy/commit/73e2a45)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.8...v2.0.0-beta.9)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.8...v2.0.0-beta.9)
 
 ---
 
@@ -1214,9 +1214,9 @@
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- Add stack export to package.json &nbsp;-&nbsp; by **John Royal** [<samp>(0ede2)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/0ede2c3)
+- Add stack export to package.json &nbsp;-&nbsp; by **John Royal** [<samp>(0ede2)</samp>](https://github.com/alchemy-run/alchemy/commit/0ede2c3)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.7...v2.0.0-beta.8)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.7...v2.0.0-beta.8)
 
 ---
 
@@ -1224,9 +1224,9 @@
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- **cloudflare**: Use consistent comaptibility date and flags in Worker &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(deda3)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/deda381)
+- **cloudflare**: Use consistent comaptibility date and flags in Worker &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(deda3)</samp>](https://github.com/alchemy-run/alchemy/commit/deda381)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.6...v2.0.0-beta.7)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.6...v2.0.0-beta.7)
 
 ---
 
@@ -1234,9 +1234,9 @@
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- **cloudflare**: Set nodejs_compat by default for Effect Workers &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(ff780)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/ff780f3)
+- **cloudflare**: Set nodejs_compat by default for Effect Workers &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(ff780)</samp>](https://github.com/alchemy-run/alchemy/commit/ff780f3)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.5...v2.0.0-beta.6)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.5...v2.0.0-beta.6)
 
 ---
 
@@ -1244,10 +1244,10 @@
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- Running with bun no longer runs unbundled alchemy bin &nbsp;-&nbsp; by **Michael (Pear)** [<samp>(61198)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/61198ca)
-- **core**: Use Provider collection as requirements &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(f81cc)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/f81cccb)
+- Running with bun no longer runs unbundled alchemy bin &nbsp;-&nbsp; by **Michael (Pear)** [<samp>(61198)</samp>](https://github.com/alchemy-run/alchemy/commit/61198ca)
+- **core**: Use Provider collection as requirements &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(f81cc)</samp>](https://github.com/alchemy-run/alchemy/commit/f81cccb)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.4...v2.0.0-beta.5)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.4...v2.0.0-beta.5)
 
 ---
 
@@ -1255,23 +1255,23 @@
 
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
-- Pr-package service &nbsp;-&nbsp; by **Michael (Pear)** in https://github.com/alchemy-run/alchemy-effect/issues/54 [<samp>(6edd8)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/6edd8dd)
+- Pr-package service &nbsp;-&nbsp; by **Michael (Pear)** in https://github.com/alchemy-run/alchemy/issues/54 [<samp>(6edd8)</samp>](https://github.com/alchemy-run/alchemy/commit/6edd8dd)
 - **cloudflare**:
-  - Async DurableObjetNamespace binding &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(25b90)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/25b9012)
-  - Async Assets binding &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(f1a3c)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/f1a3c6f)
-  - Alarms and ScheduledEvents &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(1f183)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/1f183c0)
-  - Worker Custom Domains &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(670c5)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/670c575)
+  - Async DurableObjetNamespace binding &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(25b90)</samp>](https://github.com/alchemy-run/alchemy/commit/25b9012)
+  - Async Assets binding &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(f1a3c)</samp>](https://github.com/alchemy-run/alchemy/commit/f1a3c6f)
+  - Alarms and ScheduledEvents &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(1f183)</samp>](https://github.com/alchemy-run/alchemy/commit/1f183c0)
+  - Worker Custom Domains &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(670c5)</samp>](https://github.com/alchemy-run/alchemy/commit/670c575)
 - **core**:
-  - AuthProvider &nbsp;-&nbsp; by **Michael (Pear)** in https://github.com/alchemy-run/alchemy-effect/issues/61 [<samp>(bac01)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/bac01b7)
+  - AuthProvider &nbsp;-&nbsp; by **Michael (Pear)** in https://github.com/alchemy-run/alchemy/issues/61 [<samp>(bac01)</samp>](https://github.com/alchemy-run/alchemy/commit/bac01b7)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- Rename cli binary from "alchemy-effect" to "alchemy" &nbsp;-&nbsp; by **John Royal** [<samp>(b8b3a)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/b8b3a8c)
-- Fix exports &nbsp;-&nbsp; by **Michael (Pear)** in https://github.com/alchemy-run/alchemy-effect/issues/62 [<samp>(903c2)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/903c262)
-- **aws**: Fix VpcEndpoint resource bad state checks &nbsp;-&nbsp; by **Michael (Pear)** and **Marc MacLeod** in https://github.com/alchemy-run/alchemy-effect/issues/63 [<samp>(f1fd2)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/f1fd20b)
-- **core**: Use platform-bun when running in bun, otherwise platform-node &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(3b0d6)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/3b0d6b0)
+- Rename cli binary from "alchemy-effect" to "alchemy" &nbsp;-&nbsp; by **John Royal** [<samp>(b8b3a)</samp>](https://github.com/alchemy-run/alchemy/commit/b8b3a8c)
+- Fix exports &nbsp;-&nbsp; by **Michael (Pear)** in https://github.com/alchemy-run/alchemy/issues/62 [<samp>(903c2)</samp>](https://github.com/alchemy-run/alchemy/commit/903c262)
+- **aws**: Fix VpcEndpoint resource bad state checks &nbsp;-&nbsp; by **Michael (Pear)** and **Marc MacLeod** in https://github.com/alchemy-run/alchemy/issues/63 [<samp>(f1fd2)</samp>](https://github.com/alchemy-run/alchemy/commit/f1fd20b)
+- **core**: Use platform-bun when running in bun, otherwise platform-node &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(3b0d6)</samp>](https://github.com/alchemy-run/alchemy/commit/3b0d6b0)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.3...v2.0.0-beta.4)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.3...v2.0.0-beta.4)
 
 ---
 
@@ -1279,7 +1279,7 @@
 
 _No significant changes_
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.test-export-fix-3...v2.0.0-beta.test-export-fix-4)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.test-export-fix-3...v2.0.0-beta.test-export-fix-4)
 
 ---
 
@@ -1287,7 +1287,7 @@ _No significant changes_
 
 _No significant changes_
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.test-export-fix-2...v2.0.0-beta.test-export-fix-3)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.test-export-fix-2...v2.0.0-beta.test-export-fix-3)
 
 ---
 
@@ -1295,7 +1295,7 @@ _No significant changes_
 
 _No significant changes_
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.test-export-fix...v2.0.0-beta.test-export-fix-2)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.test-export-fix...v2.0.0-beta.test-export-fix-2)
 
 ---
 
@@ -1303,19 +1303,19 @@ _No significant changes_
 
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
-- Pr-package service &nbsp;-&nbsp; by **Michael (Pear)** in https://github.com/alchemy-run/alchemy-effect/issues/54 [<samp>(6edd8)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/6edd8dd)
+- Pr-package service &nbsp;-&nbsp; by **Michael (Pear)** in https://github.com/alchemy-run/alchemy/issues/54 [<samp>(6edd8)</samp>](https://github.com/alchemy-run/alchemy/commit/6edd8dd)
 - **cloudflare**:
-  - Async DurableObjetNamespace binding &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(25b90)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/25b9012)
-  - Async Assets binding &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(f1a3c)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/f1a3c6f)
-  - Alarms and ScheduledEvents &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(1f183)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/1f183c0)
+  - Async DurableObjetNamespace binding &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(25b90)</samp>](https://github.com/alchemy-run/alchemy/commit/25b9012)
+  - Async Assets binding &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(f1a3c)</samp>](https://github.com/alchemy-run/alchemy/commit/f1a3c6f)
+  - Alarms and ScheduledEvents &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(1f183)</samp>](https://github.com/alchemy-run/alchemy/commit/1f183c0)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- Rename cli binary from "alchemy-effect" to "alchemy" &nbsp;-&nbsp; by **John Royal** [<samp>(b8b3a)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/b8b3a8c)
-- Fix export order &nbsp;-&nbsp; by **Michael (Pear)** [<samp>(7bea9)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/7bea945)
-- **core**: Use platform-bun when running in bun, otherwise platform-node &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(3b0d6)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/3b0d6b0)
+- Rename cli binary from "alchemy-effect" to "alchemy" &nbsp;-&nbsp; by **John Royal** [<samp>(b8b3a)</samp>](https://github.com/alchemy-run/alchemy/commit/b8b3a8c)
+- Fix export order &nbsp;-&nbsp; by **Michael (Pear)** [<samp>(7bea9)</samp>](https://github.com/alchemy-run/alchemy/commit/7bea945)
+- **core**: Use platform-bun when running in bun, otherwise platform-node &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(3b0d6)</samp>](https://github.com/alchemy-run/alchemy/commit/3b0d6b0)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.3...v2.0.0-beta.test-export-fix)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.3...v2.0.0-beta.test-export-fix)
 
 ---
 
@@ -1324,14 +1324,14 @@ _No significant changes_
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
 - **GitHub**:
-  - Comment Resource and CI guide &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(5e938)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/5e93857)
-  - Secret and Variable &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(0f620)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/0f620bd)
+  - Comment Resource and CI guide &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(5e938)</samp>](https://github.com/alchemy-run/alchemy/commit/5e93857)
+  - Secret and Variable &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(0f620)</samp>](https://github.com/alchemy-run/alchemy/commit/0f620bd)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- **core**: Fix undefined Provider in plan &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(e0143)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/e01431f)
+- **core**: Fix undefined Provider in plan &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(e0143)</samp>](https://github.com/alchemy-run/alchemy/commit/e01431f)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.2...v2.0.0-beta.3)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.2...v2.0.0-beta.3)
 
 ---
 
@@ -1339,9 +1339,9 @@ _No significant changes_
 
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
-- ProviderCollections reduce number of Provider types polluting user's types &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(9f76b)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/9f76b91)
+- ProviderCollections reduce number of Provider types polluting user's types &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(9f76b)</samp>](https://github.com/alchemy-run/alchemy/commit/9f76b91)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.1...v2.0.0-beta.2)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.1...v2.0.0-beta.2)
 
 ---
 
@@ -1349,20 +1349,20 @@ _No significant changes_
 
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
-- Migrate to effect@4.0.0-beta.48 &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(8674e)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/8674e8f)
-- **cloudflare**: Support R2Bucket.bind instead of R2BucketBinding.bind for all CF resources &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(12b50)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/12b50d3)
-- **core**: Alchemy.Stack &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(68e66)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/68e6622)
+- Migrate to effect@4.0.0-beta.48 &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(8674e)</samp>](https://github.com/alchemy-run/alchemy/commit/8674e8f)
+- **cloudflare**: Support R2Bucket.bind instead of R2BucketBinding.bind for all CF resources &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(12b50)</samp>](https://github.com/alchemy-run/alchemy/commit/12b50d3)
+- **core**: Alchemy.Stack &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(68e66)</samp>](https://github.com/alchemy-run/alchemy/commit/68e6622)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- Release to alchemy package &nbsp;-&nbsp; by **Michael (Pear)** in https://github.com/alchemy-run/alchemy-effect/issues/55 [<samp>(217c5)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/217c5c9)
+- Release to alchemy package &nbsp;-&nbsp; by **Michael (Pear)** in https://github.com/alchemy-run/alchemy/issues/55 [<samp>(217c5)</samp>](https://github.com/alchemy-run/alchemy/commit/217c5c9)
 - **cloudflare**:
-  - Require Content Length in R2.put and use raw ReadableStream if available &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(1cd6b)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/1cd6bda)
-  - Bundle properly formats windows paths &nbsp;-&nbsp; by **Michael (Pear)** [<samp>(5156c)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/5156c6c)
+  - Require Content Length in R2.put and use raw ReadableStream if available &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(1cd6b)</samp>](https://github.com/alchemy-run/alchemy/commit/1cd6bda)
+  - Bundle properly formats windows paths &nbsp;-&nbsp; by **Michael (Pear)** [<samp>(5156c)</samp>](https://github.com/alchemy-run/alchemy/commit/5156c6c)
 - **test**:
-  - Infer and resolve Output types in Test/Bun &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(9853d)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/9853d92)
+  - Infer and resolve Output types in Test/Bun &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(9853d)</samp>](https://github.com/alchemy-run/alchemy/commit/9853d92)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v0.11.0...v2.0.0-beta.1)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v0.11.0...v2.0.0-beta.1)
 
 ---
 
@@ -1370,15 +1370,15 @@ _No significant changes_
 
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
-- **test**: Add skipIf to bun testing harness &nbsp;-&nbsp; by **Michael (Pear)** [<samp>(6021c)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/6021c3d)
+- **test**: Add skipIf to bun testing harness &nbsp;-&nbsp; by **Michael (Pear)** [<samp>(6021c)</samp>](https://github.com/alchemy-run/alchemy/commit/6021c3d)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- **Http**: Lazy-import platform-node to avoid crash on Bun &nbsp;-&nbsp; by **Christopher Yovanovitch** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/48 [<samp>(85224)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/852243b)
-- **cloudflare**: Bindings resolve Effect<Resource> and remove KV per-operation bindings &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(61e02)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/61e0244)
-- **core**: Migrate to Provider.effect so that providers are tree-shakable &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/53 [<samp>(73029)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/7302911)
+- **Http**: Lazy-import platform-node to avoid crash on Bun &nbsp;-&nbsp; by **Christopher Yovanovitch** and **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/48 [<samp>(85224)</samp>](https://github.com/alchemy-run/alchemy/commit/852243b)
+- **cloudflare**: Bindings resolve Effect<Resource> and remove KV per-operation bindings &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(61e02)</samp>](https://github.com/alchemy-run/alchemy/commit/61e0244)
+- **core**: Migrate to Provider.effect so that providers are tree-shakable &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/53 [<samp>(73029)</samp>](https://github.com/alchemy-run/alchemy/commit/7302911)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v0.10.0...v0.11.0)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v0.10.0...v0.11.0)
 
 ---
 
@@ -1387,11 +1387,11 @@ _No significant changes_
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
 - **cloudflare**:
-  - Accept Output<T> in Worker env + Vite props &nbsp;-&nbsp; by **cooper** in https://github.com/alchemy-run/alchemy-effect/issues/51 [<samp>(9560b)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/9560bed)
-  - Allow bindings to be undefined &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(15c8c)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/15c8c6e)
-  - Rename DynamicWorker to DynamicWorkerLoader &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(39f89)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/39f89d5)
+  - Accept Output<T> in Worker env + Vite props &nbsp;-&nbsp; by **cooper** in https://github.com/alchemy-run/alchemy/issues/51 [<samp>(9560b)</samp>](https://github.com/alchemy-run/alchemy/commit/9560bed)
+  - Allow bindings to be undefined &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(15c8c)</samp>](https://github.com/alchemy-run/alchemy/commit/15c8c6e)
+  - Rename DynamicWorker to DynamicWorkerLoader &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(39f89)</samp>](https://github.com/alchemy-run/alchemy/commit/39f89d5)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v0.9.1...v0.10.0)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v0.9.1...v0.10.0)
 
 ---
 
@@ -1399,9 +1399,9 @@ _No significant changes_
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- **cloudflare**: Environment variables silently dropped &nbsp;-&nbsp; by **cooper** in https://github.com/alchemy-run/alchemy-effect/issues/49 [<samp>(847f0)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/847f0c2)
+- **cloudflare**: Environment variables silently dropped &nbsp;-&nbsp; by **cooper** in https://github.com/alchemy-run/alchemy/issues/49 [<samp>(847f0)</samp>](https://github.com/alchemy-run/alchemy/commit/847f0c2)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v0.9.0...v0.9.1)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v0.9.0...v0.9.1)
 
 ---
 
@@ -1409,25 +1409,25 @@ _No significant changes_
 
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
-- **core**: Bun test helpers &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(40af3)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/40af3f4)
+- **core**: Bun test helpers &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(40af3)</samp>](https://github.com/alchemy-run/alchemy/commit/40af3f4)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
 - **cloudflare**:
-  - Delay WorkerEnvironment resolution for R2Bucket binding until inside Worker &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(b41b1)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/b41b1c3)
-  - Precreate Worker with tags and resolve DO namespace IDs as Worker output attributes &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(c6b2a)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/c6b2add)
-  - Retry eventually consistent ContainerApplicationNotFound error &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(90d75)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/90d7524)
-  - Resolve Durable Object namespace IDs in precreate &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(cd1e2)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/cd1e25d)
-  - Use Sonda to generate bundle report &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(a7a9c)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/a7a9c5f)
-  - Recover from partial ContainerApplication failure &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(04890)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/04890d3)
+  - Delay WorkerEnvironment resolution for R2Bucket binding until inside Worker &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(b41b1)</samp>](https://github.com/alchemy-run/alchemy/commit/b41b1c3)
+  - Precreate Worker with tags and resolve DO namespace IDs as Worker output attributes &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(c6b2a)</samp>](https://github.com/alchemy-run/alchemy/commit/c6b2add)
+  - Retry eventually consistent ContainerApplicationNotFound error &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(90d75)</samp>](https://github.com/alchemy-run/alchemy/commit/90d7524)
+  - Resolve Durable Object namespace IDs in precreate &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(cd1e2)</samp>](https://github.com/alchemy-run/alchemy/commit/cd1e25d)
+  - Use Sonda to generate bundle report &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(a7a9c)</samp>](https://github.com/alchemy-run/alchemy/commit/a7a9c5f)
+  - Recover from partial ContainerApplication failure &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(04890)</samp>](https://github.com/alchemy-run/alchemy/commit/04890d3)
 - **core**:
-  - Use a Deferred to support parallel caching &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(ca693)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/ca693b5)
-  - Exclude Artifacts from provider requirements &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(a0aec)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/a0aec34)
-  - Resolve Effects in Binding.Sevice.bind &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(b82f2)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/b82f262)
+  - Use a Deferred to support parallel caching &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(ca693)</samp>](https://github.com/alchemy-run/alchemy/commit/ca693b5)
+  - Exclude Artifacts from provider requirements &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(a0aec)</samp>](https://github.com/alchemy-run/alchemy/commit/a0aec34)
+  - Resolve Effects in Binding.Sevice.bind &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(b82f2)</samp>](https://github.com/alchemy-run/alchemy/commit/b82f262)
 - **test**:
-  - Return output of deploying stack in a test &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(6d354)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/6d354a1)
+  - Return output of deploying stack in a test &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(6d354)</samp>](https://github.com/alchemy-run/alchemy/commit/6d354a1)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v0.8.0...v0.9.0)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v0.8.0...v0.9.0)
 
 ---
 
@@ -1435,9 +1435,9 @@ _No significant changes_
 
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
-- **cloudflare**: Async-alchemy style bindings and R2 wrapper &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(4c4ca)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/4c4ca91)
+- **cloudflare**: Async-alchemy style bindings and R2 wrapper &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(4c4ca)</samp>](https://github.com/alchemy-run/alchemy/commit/4c4ca91)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v0.7.1...v0.8.0)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v0.7.1...v0.8.0)
 
 ---
 
@@ -1445,9 +1445,9 @@ _No significant changes_
 
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
-- **core**: Support deploy --force &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy-effect/issues/43 [<samp>(06b88)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/06b881a)
+- **core**: Support deploy --force &nbsp;-&nbsp; by **sam** in https://github.com/alchemy-run/alchemy/issues/43 [<samp>(06b88)</samp>](https://github.com/alchemy-run/alchemy/commit/06b881a)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v0.7.0...v0.7.1)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v0.7.0...v0.7.1)
 
 ---
 
@@ -1456,12 +1456,12 @@ _No significant changes_
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
 - **cloudflare**:
-  - Vite integration &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/41 [<samp>(e3c16)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/e3c160c)
+  - Vite integration &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/41 [<samp>(e3c16)</samp>](https://github.com/alchemy-run/alchemy/commit/e3c160c)
 - **core**:
-  - Add Output.as<T>() &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(33186)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/33186ef)
-  - Artifact service for caching build artifacts across plan and apply &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(dc60e)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/dc60e9e)
+  - Add Output.as<T>() &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(33186)</samp>](https://github.com/alchemy-run/alchemy/commit/33186ef)
+  - Artifact service for caching build artifacts across plan and apply &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(dc60e)</samp>](https://github.com/alchemy-run/alchemy/commit/dc60e9e)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v0.6.4...v0.7.0)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v0.6.4...v0.7.0)
 
 ---
 
@@ -1469,7 +1469,7 @@ _No significant changes_
 
 _No significant changes_
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v0.6.3...v0.6.4)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v0.6.3...v0.6.4)
 
 ---
 
@@ -1478,26 +1478,26 @@ _No significant changes_
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
 - **better-auth**:
-  - Add @alchemy.run/better-auth packag with D1 support &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(9dc0f)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/9dc0ff6)
+  - Add @alchemy.run/better-auth packag with D1 support &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(9dc0f)</samp>](https://github.com/alchemy-run/alchemy/commit/9dc0ff6)
 - **cloudflare**:
-  - D1Database resource &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(48fd4)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/48fd499)
-  - Expose raw Cloudflare.Request as a Tag &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(67998)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/67998cd)
+  - D1Database resource &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(48fd4)</samp>](https://github.com/alchemy-run/alchemy/commit/48fd499)
+  - Expose raw Cloudflare.Request as a Tag &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(67998)</samp>](https://github.com/alchemy-run/alchemy/commit/67998cd)
 - **core**:
-  - Random resource &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(71527)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/715278e)
+  - Random resource &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(71527)</samp>](https://github.com/alchemy-run/alchemy/commit/715278e)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- Replace Schedule.compose with Schedule.both &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(46195)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/461951d)
+- Replace Schedule.compose with Schedule.both &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(46195)</samp>](https://github.com/alchemy-run/alchemy/commit/461951d)
 - **cli**:
-  - Simplify logs query to latest hour &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(b4a47)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/b4a4733)
-  - Used TaggedError in Daemon &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(77a78)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/77a788a)
+  - Simplify logs query to latest hour &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(b4a47)</samp>](https://github.com/alchemy-run/alchemy/commit/b4a4733)
+  - Used TaggedError in Daemon &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(77a78)</samp>](https://github.com/alchemy-run/alchemy/commit/77a788a)
 - **cloudflare**:
-  - Export D1 resources and bindings &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(d9e94)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/d9e9447)
-  - Export D1 resources and bindings &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(bcd43)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/bcd436d)
+  - Export D1 resources and bindings &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(d9e94)</samp>](https://github.com/alchemy-run/alchemy/commit/d9e9447)
+  - Export D1 resources and bindings &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(bcd43)</samp>](https://github.com/alchemy-run/alchemy/commit/bcd436d)
 - **core**:
-  - Support updating downstream to unlink and delete a binding &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(6bdf8)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/6bdf8e9)
+  - Support updating downstream to unlink and delete a binding &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(6bdf8)</samp>](https://github.com/alchemy-run/alchemy/commit/6bdf8e9)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v0.6.2...v0.6.3)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v0.6.2...v0.6.3)
 
 ---
 
@@ -1505,7 +1505,7 @@ _No significant changes_
 
 _No significant changes_
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v0.6.1...v0.6.2)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v0.6.1...v0.6.2)
 
 ---
 
@@ -1513,145 +1513,145 @@ _No significant changes_
 
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
-- Move to distilled-aws &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(e12f2)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/e12f2a6)
-- Add S3 data plane APIs &nbsp;-&nbsp; by **Sam Goodwin** and **Claude Haiku 4.5** in https://github.com/alchemy-run/alchemy-effect/issues/34 [<samp>(f2986)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/f2986ab)
-- Bootstrap CLI command &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(3a79a)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/3a79a04)
-- Lambda.consumeTable &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(420c1)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/420c124)
-- Remove ExecutionContext from Policy requirements &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(867ef)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/867ef28)
-- Implement HttpServer for Lambda and Cloudflare &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(655df)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/655dfd1)
-- Namespaces &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(46050)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/4605092)
-- Implement Host, Self and make Lambda entrypoint &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(1d9a2)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/1d9a218)
-- Generalize bundler and end to end deployment working &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(65353)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/65353fc)
-- Namespace tree for organizing Resources and Bindings &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(3b937)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/3b93785)
-- Default AWS StageConfig &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(45152)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/4515245)
-- Bind Outputs to environment variables &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(9ff75)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/9ff7587)
-- End-to-end bundling, bindings and IAM policies &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(d2fef)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/d2fef7a)
-- Migrate to @distilled.cloud (v2) &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(75151)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/75151e7)
-- Support external platforms &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(7ed9f)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/7ed9ffb)
+- Move to distilled-aws &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(e12f2)</samp>](https://github.com/alchemy-run/alchemy/commit/e12f2a6)
+- Add S3 data plane APIs &nbsp;-&nbsp; by **Sam Goodwin** and **Claude Haiku 4.5** in https://github.com/alchemy-run/alchemy/issues/34 [<samp>(f2986)</samp>](https://github.com/alchemy-run/alchemy/commit/f2986ab)
+- Bootstrap CLI command &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(3a79a)</samp>](https://github.com/alchemy-run/alchemy/commit/3a79a04)
+- Lambda.consumeTable &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(420c1)</samp>](https://github.com/alchemy-run/alchemy/commit/420c124)
+- Remove ExecutionContext from Policy requirements &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(867ef)</samp>](https://github.com/alchemy-run/alchemy/commit/867ef28)
+- Implement HttpServer for Lambda and Cloudflare &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(655df)</samp>](https://github.com/alchemy-run/alchemy/commit/655dfd1)
+- Namespaces &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(46050)</samp>](https://github.com/alchemy-run/alchemy/commit/4605092)
+- Implement Host, Self and make Lambda entrypoint &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(1d9a2)</samp>](https://github.com/alchemy-run/alchemy/commit/1d9a218)
+- Generalize bundler and end to end deployment working &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(65353)</samp>](https://github.com/alchemy-run/alchemy/commit/65353fc)
+- Namespace tree for organizing Resources and Bindings &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(3b937)</samp>](https://github.com/alchemy-run/alchemy/commit/3b93785)
+- Default AWS StageConfig &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(45152)</samp>](https://github.com/alchemy-run/alchemy/commit/4515245)
+- Bind Outputs to environment variables &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(9ff75)</samp>](https://github.com/alchemy-run/alchemy/commit/9ff7587)
+- End-to-end bundling, bindings and IAM policies &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(d2fef)</samp>](https://github.com/alchemy-run/alchemy/commit/d2fef7a)
+- Migrate to @distilled.cloud (v2) &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(75151)</samp>](https://github.com/alchemy-run/alchemy/commit/75151e7)
+- Support external platforms &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(7ed9f)</samp>](https://github.com/alchemy-run/alchemy/commit/7ed9ffb)
 - **aws**:
-  - DynamoDB Bindings and an AI process for implementing an aws service &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(cdfd4)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/cdfd45b)
-  - DynamoDB Table Stream &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(ec61a)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/ec61a6d)
-  - SNS Topic, Subscription, TopicSink and EventSource &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(4d3af)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/4d3af74)
-  - Cloudwatch Resources &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(30544)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/3054413)
-  - Add logs and tail for Lambda Functions &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(8403c)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/8403cda)
+  - DynamoDB Bindings and an AI process for implementing an aws service &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(cdfd4)</samp>](https://github.com/alchemy-run/alchemy/commit/cdfd45b)
+  - DynamoDB Table Stream &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(ec61a)</samp>](https://github.com/alchemy-run/alchemy/commit/ec61a6d)
+  - SNS Topic, Subscription, TopicSink and EventSource &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(4d3af)</samp>](https://github.com/alchemy-run/alchemy/commit/4d3af74)
+  - Cloudwatch Resources &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(30544)</samp>](https://github.com/alchemy-run/alchemy/commit/3054413)
+  - Add logs and tail for Lambda Functions &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(8403c)</samp>](https://github.com/alchemy-run/alchemy/commit/8403cda)
 - **aws, dynamodb**:
-  - Add Batch and Transact Operations &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(73a01)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/73a0134)
+  - Add Batch and Transact Operations &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(73a01)</samp>](https://github.com/alchemy-run/alchemy/commit/73a0134)
 - **aws, eventbridge**:
-  - EventBrdige Resources &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(4809c)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/4809c8e)
+  - EventBrdige Resources &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(4809c)</samp>](https://github.com/alchemy-run/alchemy/commit/4809c8e)
 - **aws,acm**:
-  - Certificate &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(c082f)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/c082f83)
+  - Certificate &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(c082f)</samp>](https://github.com/alchemy-run/alchemy/commit/c082f83)
 - **aws,autoscaling**:
-  - AutoScalingGroup, LaunchTemplate, ScalingPolicy &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(d7878)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/d787847)
+  - AutoScalingGroup, LaunchTemplate, ScalingPolicy &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(d7878)</samp>](https://github.com/alchemy-run/alchemy/commit/d787847)
 - **aws,cloudfront**:
-  - Distribution, Function, Invalidation, KeyValueStore, OriginAccessControl &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(2d2e5)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/2d2e528)
+  - Distribution, Function, Invalidation, KeyValueStore, OriginAccessControl &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(2d2e5)</samp>](https://github.com/alchemy-run/alchemy/commit/2d2e528)
 - **aws,ec2**:
-  - EC2 Network and Instance &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(8e686)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/8e686d7)
-  - Share Hsot logic across EC2 Instance and LaunchTemplate &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(691e2)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/691e20b)
+  - EC2 Network and Instance &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(8e686)</samp>](https://github.com/alchemy-run/alchemy/commit/8e686d7)
+  - Share Hsot logic across EC2 Instance and LaunchTemplate &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(691e2)</samp>](https://github.com/alchemy-run/alchemy/commit/691e20b)
 - **aws,ecr**:
-  - Repository Resource &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(0af1e)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/0af1ec1)
+  - Repository Resource &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(0af1e)</samp>](https://github.com/alchemy-run/alchemy/commit/0af1ec1)
 - **aws,ecs**:
-  - ECS Cluster, Task and Service Resources &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(11c74)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/11c7438)
+  - ECS Cluster, Task and Service Resources &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(11c74)</samp>](https://github.com/alchemy-run/alchemy/commit/11c7438)
 - **aws,eks**:
-  - AWS Auto EKS Cluster resoruces &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(9b4f9)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/9b4f96f)
+  - AWS Auto EKS Cluster resoruces &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(9b4f9)</samp>](https://github.com/alchemy-run/alchemy/commit/9b4f96f)
 - **aws,elbv2**:
-  - Listener, LoadBalancer, TargetGroup &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(8486e)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/8486e65)
-  - Support TCP protocol in Listener, LoadBalancer &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(b5128)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/b5128d7)
+  - Listener, LoadBalancer, TargetGroup &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(8486e)</samp>](https://github.com/alchemy-run/alchemy/commit/8486e65)
+  - Support TCP protocol in Listener, LoadBalancer &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(b5128)</samp>](https://github.com/alchemy-run/alchemy/commit/b5128d7)
 - **aws,http**:
-  - Handle unrecoverable Http errors, fix GetObject IAM policy &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(39e5c)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/39e5c6c)
+  - Handle unrecoverable Http errors, fix GetObject IAM policy &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(39e5c)</samp>](https://github.com/alchemy-run/alchemy/commit/39e5c6c)
 - **aws,iam**:
-  - AWS IAM Resources, Operations and Tests &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(8638a)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/8638abe)
+  - AWS IAM Resources, Operations and Tests &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(8638a)</samp>](https://github.com/alchemy-run/alchemy/commit/8638abe)
 - **aws,iamidentitycenter**:
-  - AccountAssignment, Group, Instance, PermissionSet &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(3f864)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/3f86467)
+  - AccountAssignment, Group, Instance, PermissionSet &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(3f864)</samp>](https://github.com/alchemy-run/alchemy/commit/3f86467)
 - **aws,kinesiss**:
-  - Operations for Kinesis Streams, including EventSource and Sinks &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(8b40c)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/8b40c72)
+  - Operations for Kinesis Streams, including EventSource and Sinks &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(8b40c)</samp>](https://github.com/alchemy-run/alchemy/commit/8b40c72)
 - **aws,lambda**:
-  - EventBridge and Stream Event Sources &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(311a0)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/311a04b)
+  - EventBridge and Stream Event Sources &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(311a0)</samp>](https://github.com/alchemy-run/alchemy/commit/311a04b)
 - **aws,logs**:
-  - LogGroup Resource &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(ff7e2)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/ff7e2de)
+  - LogGroup Resource &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(ff7e2)</samp>](https://github.com/alchemy-run/alchemy/commit/ff7e2de)
 - **aws,organizations**:
-  - Account, DelegatedAdministrator, Organization, OrganizationalUnit, OrganizationResourcePolicy, Policy, PolicyAttachment, Root, RootPolicyType, TrustedServiceAccess &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(ed86a)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/ed86a76)
-  - TenantRoot &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(b6f7b)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/b6f7b21)
+  - Account, DelegatedAdministrator, Organization, OrganizationalUnit, OrganizationResourcePolicy, Policy, PolicyAttachment, Root, RootPolicyType, TrustedServiceAccess &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(ed86a)</samp>](https://github.com/alchemy-run/alchemy/commit/ed86a76)
+  - TenantRoot &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(b6f7b)</samp>](https://github.com/alchemy-run/alchemy/commit/b6f7b21)
 - **aws,pipes**:
-  - Pipe resources &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(38af3)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/38af3e0)
+  - Pipe resources &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(38af3)</samp>](https://github.com/alchemy-run/alchemy/commit/38af3e0)
 - **aws,rds**:
-  - DB\* Resources, Aurora, Connect and RDSData &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(9742b)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/9742b8c)
+  - DB\* Resources, Aurora, Connect and RDSData &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(9742b)</samp>](https://github.com/alchemy-run/alchemy/commit/9742b8c)
 - **aws,route53**:
-  - Record &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(71d88)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/71d88cd)
+  - Record &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(71d88)</samp>](https://github.com/alchemy-run/alchemy/commit/71d88cd)
 - **aws,scheduler**:
-  - Schedule, ScheduleGroup resources &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(3be73)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/3be73bd)
+  - Schedule, ScheduleGroup resources &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(3be73)</samp>](https://github.com/alchemy-run/alchemy/commit/3be73bd)
 - **aws,secretsmanager**:
-  - Secret Resource and Bindings &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(a8a39)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/a8a39bd)
+  - Secret Resource and Bindings &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(a8a39)</samp>](https://github.com/alchemy-run/alchemy/commit/a8a39bd)
 - **aws,sqs**:
-  - Allow DeleteMessageBatch, ReceiveMessage and SendMessage on EC2 &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(bddb4)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/bddb4bb)
+  - Allow DeleteMessageBatch, ReceiveMessage and SendMessage on EC2 &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(bddb4)</samp>](https://github.com/alchemy-run/alchemy/commit/bddb4bb)
 - **aws,website**:
-  - SsrSite, StaticSite, Router &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(d4f14)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/d4f14c3)
-  - Bring StaticSite up to par with SST &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(6aaac)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/6aaace9)
+  - SsrSite, StaticSite, Router &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(d4f14)</samp>](https://github.com/alchemy-run/alchemy/commit/d4f14c3)
+  - Bring StaticSite up to par with SST &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(6aaac)</samp>](https://github.com/alchemy-run/alchemy/commit/6aaace9)
 - **build**:
-  - Docker commands &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(d12cf)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/d12cf9f)
+  - Docker commands &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(d12cf)</samp>](https://github.com/alchemy-run/alchemy/commit/d12cf9f)
 - **cli**:
-  - Tail and logs &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(b0a06)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/b0a061e)
-  - Filter logs and tail by resource ID &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(a6514)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/a6514c7)
-  - Process Manager daemon &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(c0fd1)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/c0fd148)
+  - Tail and logs &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(b0a06)</samp>](https://github.com/alchemy-run/alchemy/commit/b0a061e)
+  - Filter logs and tail by resource ID &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(a6514)</samp>](https://github.com/alchemy-run/alchemy/commit/a6514c7)
+  - Process Manager daemon &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(c0fd1)</samp>](https://github.com/alchemy-run/alchemy/commit/c0fd148)
 - **cloudflare**:
-  - Durable Objects and Worker entrypoint/exports &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(aa6d3)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/aa6d3a0)
-  - Durable Objects and Containers &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/37 [<samp>(ccade)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/ccade21)
-  - DynamicWorker &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(8c5d2)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/8c5d205)
-  - Workflows &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(874cc)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/874cc9a)
+  - Durable Objects and Worker entrypoint/exports &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(aa6d3)</samp>](https://github.com/alchemy-run/alchemy/commit/aa6d3a0)
+  - Durable Objects and Containers &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/37 [<samp>(ccade)</samp>](https://github.com/alchemy-run/alchemy/commit/ccade21)
+  - DynamicWorker &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(8c5d2)</samp>](https://github.com/alchemy-run/alchemy/commit/8c5d205)
+  - Workflows &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(874cc)</samp>](https://github.com/alchemy-run/alchemy/commit/874cc9a)
 - **core**:
-  - Handle circular binding cycles &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(6d843)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/6d843c4)
-  - Construct.fn and two-phase apply &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(7c8bd)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/7c8bd2b)
-  - Enhance convrergence of circularity in alchemy &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(fbfbf)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/fbfbf2a)
-  - Allow replace on top of a partially replaced resurce &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(3c630)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/3c63096)
+  - Handle circular binding cycles &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(6d843)</samp>](https://github.com/alchemy-run/alchemy/commit/6d843c4)
+  - Construct.fn and two-phase apply &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(7c8bd)</samp>](https://github.com/alchemy-run/alchemy/commit/7c8bd2b)
+  - Enhance convrergence of circularity in alchemy &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(fbfbf)</samp>](https://github.com/alchemy-run/alchemy/commit/fbfbf2a)
+  - Allow replace on top of a partially replaced resurce &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(3c630)</samp>](https://github.com/alchemy-run/alchemy/commit/3c63096)
 - **k8s**:
-  - Kubernetes Manifest, Service, ServiceAccount, etc. &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(8d2d1)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/8d2d133)
+  - Kubernetes Manifest, Service, ServiceAccount, etc. &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(8d2d1)</samp>](https://github.com/alchemy-run/alchemy/commit/8d2d133)
 - **kinesis**:
-  - Add AWS Kinesis Stream resource and capabilities &nbsp;-&nbsp; by **Sam Goodwin** and **Claude Haiku 4.5** in https://github.com/alchemy-run/alchemy-effect/issues/30 [<samp>(3f30b)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/3f30b79)
+  - Add AWS Kinesis Stream resource and capabilities &nbsp;-&nbsp; by **Sam Goodwin** and **Claude Haiku 4.5** in https://github.com/alchemy-run/alchemy/issues/30 [<samp>(3f30b)</samp>](https://github.com/alchemy-run/alchemy/commit/3f30b79)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- Improve deletion of ec2 resources &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(c5bf6)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/c5bf62f)
-- Stack.make to capture providers and re-implement binding diffs in Plan &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(94e40)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/94e401c)
-- Use error.\_tag instead of error.name &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(87cbf)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/87cbfa3)
-- Handle undefined props &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(63f08)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/63f0869)
-- Write bundle temp files to .alchemy/tmp &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(0b491)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/0b49156)
-- Write temporary bundle file inside .alchemy within the correct module &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(6d678)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/6d678c8)
-- Resource Service inherits call-site Context &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(07511)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/0751195)
+- Improve deletion of ec2 resources &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(c5bf6)</samp>](https://github.com/alchemy-run/alchemy/commit/c5bf62f)
+- Stack.make to capture providers and re-implement binding diffs in Plan &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(94e40)</samp>](https://github.com/alchemy-run/alchemy/commit/94e401c)
+- Use error.\_tag instead of error.name &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(87cbf)</samp>](https://github.com/alchemy-run/alchemy/commit/87cbfa3)
+- Handle undefined props &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(63f08)</samp>](https://github.com/alchemy-run/alchemy/commit/63f0869)
+- Write bundle temp files to .alchemy/tmp &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(0b491)</samp>](https://github.com/alchemy-run/alchemy/commit/0b49156)
+- Write temporary bundle file inside .alchemy within the correct module &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(6d678)</samp>](https://github.com/alchemy-run/alchemy/commit/6d678c8)
+- Resource Service inherits call-site Context &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(07511)</samp>](https://github.com/alchemy-run/alchemy/commit/0751195)
 - **aws**:
-  - Provide stack, stage and phase at runtime &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(befb4)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/befb4ff)
-  - Add missing Provider and Binding layers &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(f41c1)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/f41c13b)
-  - Add missing Providers &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(82f51)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/82f51ef)
-  - Bootstrap command creates and tags the bucket &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(5a36f)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/5a36fab)
-  - EC2 and LaunchTemplate host now provide ExecutionContext.Server &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(e2f01)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/e2f0100)
-  - Avoid redundant updates when source map changes &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(48fe5)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/48fe5cd)
+  - Provide stack, stage and phase at runtime &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(befb4)</samp>](https://github.com/alchemy-run/alchemy/commit/befb4ff)
+  - Add missing Provider and Binding layers &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(f41c1)</samp>](https://github.com/alchemy-run/alchemy/commit/f41c13b)
+  - Add missing Providers &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(82f51)</samp>](https://github.com/alchemy-run/alchemy/commit/82f51ef)
+  - Bootstrap command creates and tags the bucket &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(5a36f)</samp>](https://github.com/alchemy-run/alchemy/commit/5a36fab)
+  - EC2 and LaunchTemplate host now provide ExecutionContext.Server &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(e2f01)</samp>](https://github.com/alchemy-run/alchemy/commit/e2f0100)
+  - Avoid redundant updates when source map changes &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(48fe5)</samp>](https://github.com/alchemy-run/alchemy/commit/48fe5cd)
 - **aws,cloudflare**:
-  - Fix AnomalyDetector and bindings &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(2d47e)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/2d47e71)
+  - Fix AnomalyDetector and bindings &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(2d47e)</samp>](https://github.com/alchemy-run/alchemy/commit/2d47e71)
 - **aws,sns**:
-  - ReadSubscription returns undefined if topicArn is unknown &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(4e25c)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/4e25c3d)
+  - ReadSubscription returns undefined if topicArn is unknown &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(4e25c)</samp>](https://github.com/alchemy-run/alchemy/commit/4e25c3d)
 - **aws,website**:
-  - Include stack, stage and FQN in kv namespace &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(e971c)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/e971ca7)
-  - End-to-end deployment of StaticSite &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(1dea3)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/1dea3ec)
+  - Include stack, stage and FQN in kv namespace &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(e971c)</samp>](https://github.com/alchemy-run/alchemy/commit/e971ca7)
+  - End-to-end deployment of StaticSite &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(1dea3)</samp>](https://github.com/alchemy-run/alchemy/commit/1dea3ec)
 - **cli**:
-  - Support running in node and load .env with ConfigProvider &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(9b15b)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/9b15b39)
-  - Support node and bun for globs &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(2bcb6)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/2bcb6d0)
-  - Respect caller's node runtime &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(6396c)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/6396cd6)
+  - Support running in node and load .env with ConfigProvider &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(9b15b)</samp>](https://github.com/alchemy-run/alchemy/commit/9b15b39)
+  - Support node and bun for globs &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(2bcb6)</samp>](https://github.com/alchemy-run/alchemy/commit/2bcb6d0)
+  - Respect caller's node runtime &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(6396c)</samp>](https://github.com/alchemy-run/alchemy/commit/6396cd6)
 - **cloudflare**:
-  - Migrate to distilled-cloudflare and rolldown &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(a4184)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/a4184ec)
-  - Distilled 0.4.0 pagination apis &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(4bffe)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/4bffe41)
-  - Hard-code all exported handler methods instead of Proxy &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(289b9)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/289b92f)
-  - Detect changes to Container and Bundle &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(924ff)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/924ffb5)
-  - Pass assetsConfig in TanstackStart and StaticSite &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(42832)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/428329f)
-  - Get HTTP server plumbing working for containers &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(cf058)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/cf05888)
+  - Migrate to distilled-cloudflare and rolldown &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(a4184)</samp>](https://github.com/alchemy-run/alchemy/commit/a4184ec)
+  - Distilled 0.4.0 pagination apis &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(4bffe)</samp>](https://github.com/alchemy-run/alchemy/commit/4bffe41)
+  - Hard-code all exported handler methods instead of Proxy &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(289b9)</samp>](https://github.com/alchemy-run/alchemy/commit/289b92f)
+  - Detect changes to Container and Bundle &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(924ff)</samp>](https://github.com/alchemy-run/alchemy/commit/924ffb5)
+  - Pass assetsConfig in TanstackStart and StaticSite &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(42832)</samp>](https://github.com/alchemy-run/alchemy/commit/428329f)
+  - Get HTTP server plumbing working for containers &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(cf058)</samp>](https://github.com/alchemy-run/alchemy/commit/cf05888)
 - **cloudflare,assets**:
-  - Pass jwtToken to createAssetUpload &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(26228)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/262289d)
+  - Pass jwtToken to createAssetUpload &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(26228)</samp>](https://github.com/alchemy-run/alchemy/commit/262289d)
 - **core**:
-  - Accept Input<T> in Host props &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(09edc)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/09edccf)
-  - Add asEffect to Output &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(5ec8d)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/5ec8d27)
+  - Accept Input<T> in Host props &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(09edc)</samp>](https://github.com/alchemy-run/alchemy/commit/09edccf)
+  - Add asEffect to Output &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(5ec8d)</samp>](https://github.com/alchemy-run/alchemy/commit/5ec8d27)
 - **ec2**:
-  - Query attachments when deleting IGW &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(ced7f)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/ced7f85)
+  - Query attachments when deleting IGW &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(ced7f)</samp>](https://github.com/alchemy-run/alchemy/commit/ced7f85)
 - **process**:
-  - Export Process module &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(1600d)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/1600d3c)
+  - Export Process module &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(1600d)</samp>](https://github.com/alchemy-run/alchemy/commit/1600d3c)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v0.6.0...v0.6.1)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v0.6.0...v0.6.1)
 
 ---
 
@@ -1659,9 +1659,9 @@ _No significant changes_
 
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
-- **ec2**: NAT Gateway, EIP, Egress IGW, SecurityGroups &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/24 [<samp>(ff04d)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/ff04d57)
+- **ec2**: NAT Gateway, EIP, Egress IGW, SecurityGroups &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/24 [<samp>(ff04d)</samp>](https://github.com/alchemy-run/alchemy/commit/ff04d57)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v0.5.0...v0.6.0)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v0.5.0...v0.6.0)
 
 ---
 
@@ -1669,12 +1669,12 @@ _No significant changes_
 
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
-- Standardize physical name generation &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(91199)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/9119967)
+- Standardize physical name generation &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(91199)</samp>](https://github.com/alchemy-run/alchemy/commit/9119967)
 - **cloudflare**:
-  - Rename worker.id and name workerId and workerName &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(273cb)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/273cb26)
-  - Rename Bucket.name to Bucket.bucketName and constraint name length &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(a0733)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/a0733a6)
+  - Rename worker.id and name workerId and workerName &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(273cb)</samp>](https://github.com/alchemy-run/alchemy/commit/273cb26)
+  - Rename Bucket.name to Bucket.bucketName and constraint name length &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(a0733)</samp>](https://github.com/alchemy-run/alchemy/commit/a0733a6)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v0.4.0...v0.5.0)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v0.4.0...v0.5.0)
 
 ---
 
@@ -1682,9 +1682,9 @@ _No significant changes_
 
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
-- **ec2**: Add IGW, Route, Route Table, Route Table Assoication &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/23 [<samp>(0eeb6)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/0eeb613)
+- **ec2**: Add IGW, Route, Route Table, Route Table Assoication &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/23 [<samp>(0eeb6)</samp>](https://github.com/alchemy-run/alchemy/commit/0eeb613)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v0.3.0...v0.4.0)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v0.3.0...v0.4.0)
 
 ---
 
@@ -1693,14 +1693,14 @@ _No significant changes_
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
 - **core**:
-  - Inputs and Outputs &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/19 [<samp>(fa8b8)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/fa8b893)
-  - DefineStack, defineStages and alchemy CLI &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/21 [<samp>(d30da)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/d30da72)
+  - Inputs and Outputs &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/19 [<samp>(fa8b8)</samp>](https://github.com/alchemy-run/alchemy/commit/fa8b893)
+  - DefineStack, defineStages and alchemy CLI &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/21 [<samp>(d30da)</samp>](https://github.com/alchemy-run/alchemy/commit/d30da72)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- **cloudflare**: Make props optional in KV Namespace and R2 Bucket &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(dbfbe)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/dbfbe40)
+- **cloudflare**: Make props optional in KV Namespace and R2 Bucket &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(dbfbe)</samp>](https://github.com/alchemy-run/alchemy/commit/dbfbe40)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v0.2.0...v0.3.0)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v0.2.0...v0.3.0)
 
 ---
 
@@ -1708,21 +1708,21 @@ _No significant changes_
 
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
-- Diff bindings + Queue Event Source &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/12 [<samp>(f0ba8)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/f0ba897)
+- Diff bindings + Queue Event Source &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/12 [<samp>(f0ba8)</samp>](https://github.com/alchemy-run/alchemy/commit/f0ba897)
 - **aws**:
-  - DynamoDB Table and getItem &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/10 [<samp>(877ba)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/877ba8f)
-  - VPC &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/16 [<samp>(cda86)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/cda86ce)
+  - DynamoDB Table and getItem &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/10 [<samp>(877ba)</samp>](https://github.com/alchemy-run/alchemy/commit/877ba8f)
+  - VPC &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/16 [<samp>(cda86)</samp>](https://github.com/alchemy-run/alchemy/commit/cda86ce)
 - **cloudflare**:
-  - Worker, Assets, R2, KV &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/13 [<samp>(6e5b1)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/6e5b107)
+  - Worker, Assets, R2, KV &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/13 [<samp>(6e5b1)</samp>](https://github.com/alchemy-run/alchemy/commit/6e5b107)
 - **test**:
-  - Add test utility &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy-effect/issues/15 [<samp>(7a9e1)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/7a9e10f)
+  - Add test utility &nbsp;-&nbsp; by **Sam Goodwin** in https://github.com/alchemy-run/alchemy/issues/15 [<samp>(7a9e1)</samp>](https://github.com/alchemy-run/alchemy/commit/7a9e10f)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- Properly type the Resource Provider Layers and use Layer.merge &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(77d69)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/77d69be)
-- **core**: Exclude bindings from props diff and include attributes in no-op bind &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy-effect/issues/17 [<samp>(6408d)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/6408d2b)
+- Properly type the Resource Provider Layers and use Layer.merge &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(77d69)</samp>](https://github.com/alchemy-run/alchemy/commit/77d69be)
+- **core**: Exclude bindings from props diff and include attributes in no-op bind &nbsp;-&nbsp; by **John Royal** in https://github.com/alchemy-run/alchemy/issues/17 [<samp>(6408d)</samp>](https://github.com/alchemy-run/alchemy/commit/6408d2b)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/v0.1.0...v0.2.0)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/v0.1.0...v0.2.0)
 
 ---
 
@@ -1730,32 +1730,32 @@ _No significant changes_
 
 ### &nbsp;&nbsp;&nbsp;🚀 Features
 
-- Adopt currying pattern across codebase to deal with NoInfer and Extract limitations &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(9a319)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/9a3193c)
-- Remove HKTs from capability and resource &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(88a59)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/88a594a)
-- Use triples in Policy to support overriden tags for bindings &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(9e8fc)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/9e8fc77)
-- Introduce BindingTag to map Binding -> BindingService &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(c59b7)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/c59b76c)
-- Capture Capability ID in Binding declaration &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(742c2)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/742c205)
-- Standardize .provider builder pattern and add 'binding' integration contract type to Runtime &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(6afdd)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/6afdd33)
-- Include Phase in the Plan and properly type the output of Apply &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(1eade)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/1eade78)
-- Add provider: { effect, succeed } to Resources &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(c4233)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/c42336f)
-- Thread BindNode through state and fix the planner &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(c1bb3)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/c1bb313)
-- Apply bindings in the generic apply functions instead of each provider &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(f0f34)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/f0f348a)
+- Adopt currying pattern across codebase to deal with NoInfer and Extract limitations &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(9a319)</samp>](https://github.com/alchemy-run/alchemy/commit/9a3193c)
+- Remove HKTs from capability and resource &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(88a59)</samp>](https://github.com/alchemy-run/alchemy/commit/88a594a)
+- Use triples in Policy to support overriden tags for bindings &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(9e8fc)</samp>](https://github.com/alchemy-run/alchemy/commit/9e8fc77)
+- Introduce BindingTag to map Binding -> BindingService &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(c59b7)</samp>](https://github.com/alchemy-run/alchemy/commit/c59b76c)
+- Capture Capability ID in Binding declaration &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(742c2)</samp>](https://github.com/alchemy-run/alchemy/commit/742c205)
+- Standardize .provider builder pattern and add 'binding' integration contract type to Runtime &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(6afdd)</samp>](https://github.com/alchemy-run/alchemy/commit/6afdd33)
+- Include Phase in the Plan and properly type the output of Apply &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(1eade)</samp>](https://github.com/alchemy-run/alchemy/commit/1eade78)
+- Add provider: { effect, succeed } to Resources &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(c4233)</samp>](https://github.com/alchemy-run/alchemy/commit/c42336f)
+- Thread BindNode through state and fix the planner &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(c1bb3)</samp>](https://github.com/alchemy-run/alchemy/commit/c1bb313)
+- Apply bindings in the generic apply functions instead of each provider &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(f0f34)</samp>](https://github.com/alchemy-run/alchemy/commit/f0f348a)
 
 ### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes
 
-- Bind types &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(d11c7)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/d11c774)
-- Update Instance<T> to handle the resource types like Queue &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(6adca)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/6adca3c)
-- Re-work simpler types for plan and apply &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(1d08d)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/1d08d19)
-- Instance<Queue> maps to Queue instead of Resource<..> &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(aa18f)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/aa18f3a)
-- Pass-through of the Props and Bindings to the Service type &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(9784e)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/9784eca)
-- Remove Resource from Binding tag construction and implement layer builders &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(ada7c)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/ada7cba)
-- Plumb through new Plan structure to apply and CLI &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(8c057)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/8c0570b)
-- Missing props in Capability, Bindingm, Resource and Service &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(aaec3)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/aaec377)
-- Include bindings in the plan, fix papercuts, remove node:util usage &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(0a5f4)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/0a5f4d3)
-- Log message when SSO token has expired &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(8a7a7)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/8a7a72f)
-- Infer return type of Resource.provider.effect &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(2093f)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/2093f17)
-- Serialize classes properly and rename packages &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(2bf72)</samp>](https://github.com/alchemy-run/alchemy-effect/commit/2bf7290)
+- Bind types &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(d11c7)</samp>](https://github.com/alchemy-run/alchemy/commit/d11c774)
+- Update Instance<T> to handle the resource types like Queue &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(6adca)</samp>](https://github.com/alchemy-run/alchemy/commit/6adca3c)
+- Re-work simpler types for plan and apply &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(1d08d)</samp>](https://github.com/alchemy-run/alchemy/commit/1d08d19)
+- Instance<Queue> maps to Queue instead of Resource<..> &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(aa18f)</samp>](https://github.com/alchemy-run/alchemy/commit/aa18f3a)
+- Pass-through of the Props and Bindings to the Service type &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(9784e)</samp>](https://github.com/alchemy-run/alchemy/commit/9784eca)
+- Remove Resource from Binding tag construction and implement layer builders &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(ada7c)</samp>](https://github.com/alchemy-run/alchemy/commit/ada7cba)
+- Plumb through new Plan structure to apply and CLI &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(8c057)</samp>](https://github.com/alchemy-run/alchemy/commit/8c0570b)
+- Missing props in Capability, Bindingm, Resource and Service &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(aaec3)</samp>](https://github.com/alchemy-run/alchemy/commit/aaec377)
+- Include bindings in the plan, fix papercuts, remove node:util usage &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(0a5f4)</samp>](https://github.com/alchemy-run/alchemy/commit/0a5f4d3)
+- Log message when SSO token has expired &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(8a7a7)</samp>](https://github.com/alchemy-run/alchemy/commit/8a7a72f)
+- Infer return type of Resource.provider.effect &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(2093f)</samp>](https://github.com/alchemy-run/alchemy/commit/2093f17)
+- Serialize classes properly and rename packages &nbsp;-&nbsp; by **Sam Goodwin** [<samp>(2bf72)</samp>](https://github.com/alchemy-run/alchemy/commit/2bf7290)
 
-##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy-effect/compare/c46b447ca0d46a9e4dbf08a6789770a420d90be5...v0.1.0)
+##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/alchemy-run/alchemy/compare/c46b447ca0d46a9e4dbf08a6789770a420d90be5...v0.1.0)
 
 ---

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Use the root action to deploy `prod` from `main`, deploy PR previews as
 `staging-{number}`, and destroy PR previews when the PR closes:
 
 ```yaml
-- uses: alchemy-run/alchemy-effect@v1
+- uses: alchemy-run/alchemy@v1
   env:
     CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
     CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/benchmark/container/package.json
+++ b/benchmark/container/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
     "directory": "benchmark/container"
   },
   "type": "module",

--- a/examples/aws-ec2/package.json
+++ b/examples/aws-ec2/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
     "directory": "examples/aws-ec2"
   },
   "scripts": {

--- a/examples/aws-ecs/package.json
+++ b/examples/aws-ecs/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
     "directory": "examples/aws-ecs"
   },
   "scripts": {

--- a/examples/aws-eks/package.json
+++ b/examples/aws-eks/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
     "directory": "examples/aws-eks"
   },
   "scripts": {

--- a/examples/aws-lambda-httpapi/package.json
+++ b/examples/aws-lambda-httpapi/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
     "directory": "examples/aws-lambda-httpapi"
   },
   "scripts": {

--- a/examples/aws-lambda-rpc/package.json
+++ b/examples/aws-lambda-rpc/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
     "directory": "examples/aws-lambda-rpc"
   },
   "scripts": {

--- a/examples/aws-lambda/package.json
+++ b/examples/aws-lambda/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
     "directory": "examples/aws-lambda"
   },
   "scripts": {

--- a/examples/aws-rds/package.json
+++ b/examples/aws-rds/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
     "directory": "examples/aws-rds"
   },
   "scripts": {

--- a/examples/aws-rest-api/package.json
+++ b/examples/aws-rest-api/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
     "directory": "examples/aws-rest-api"
   },
   "scripts": {

--- a/examples/aws-static-site/package.json
+++ b/examples/aws-static-site/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
     "directory": "examples/aws-static-site"
   },
   "type": "module",

--- a/examples/aws-static-site/site/index.html
+++ b/examples/aws-static-site/site/index.html
@@ -16,7 +16,7 @@
       </p>
       <div class="actions">
         <a href="/docs/">Read the docs page</a>
-        <a href="https://github.com/alchemy-run/alchemy-effect"
+        <a href="https://github.com/alchemy-run/alchemy"
           >View the repo</a
         >
       </div>

--- a/examples/aws-vite/package.json
+++ b/examples/aws-vite/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
     "directory": "examples/aws-vite"
   },
   "type": "module",

--- a/examples/cloudflare-agent/package.json
+++ b/examples/cloudflare-agent/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
     "directory": "examples/cloudflare-worker"
   },
   "type": "module",

--- a/examples/cloudflare-agent/src/ReleaseService.ts
+++ b/examples/cloudflare-agent/src/ReleaseService.ts
@@ -13,7 +13,7 @@ export default Cloudflare.Worker(
     yield* Github.consumeRepositoryEvents(
       {
         owner: "alchemy-run",
-        repository: "alchemy-effect",
+        repository: "alchemy",
         events: ["push"],
       },
       (event) => {

--- a/examples/cloudflare-dev/package.json
+++ b/examples/cloudflare-dev/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
     "directory": "examples/cloudflare-dev"
   },
   "type": "module",

--- a/examples/cloudflare-dev/src/NotifyWorkflow.ts
+++ b/examples/cloudflare-dev/src/NotifyWorkflow.ts
@@ -19,7 +19,7 @@ export default class NotifyWorkflow extends Cloudflare.Workflow<NotifyWorkflow>(
     const secret = yield* Config.redacted("WORKFLOW_SECRET").pipe(
       Config.withDefault(Redacted.make(WORKFLOW_SECRET_VALUE)),
     );
-    // Regression guard for https://github.com/alchemy-run/alchemy-effect/pull/71
+    // Regression guard for https://github.com/alchemy-run/alchemy/pull/71
     //
     // The kv binding internally yields `Cloudflare.Workers.WorkerEnvironment` —
     // before that PR, accessing `WorkerEnvironment` inside a workflow body

--- a/examples/cloudflare-email/package.json
+++ b/examples/cloudflare-email/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/alchemy-run/alchemy-effect"
+    "url": "https://github.com/alchemy-run/alchemy"
   },
   "type": "module",
   "scripts": {

--- a/examples/cloudflare-git-artifacts/package.json
+++ b/examples/cloudflare-git-artifacts/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
     "directory": "examples/cloudflare-git-artifacts"
   },
   "type": "module",

--- a/examples/cloudflare-neon-drizzle/package.json
+++ b/examples/cloudflare-neon-drizzle/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
     "directory": "examples/cloudflare-neon-drizzle"
   },
   "type": "module",

--- a/examples/cloudflare-planetscale-mysql-drizzle/package.json
+++ b/examples/cloudflare-planetscale-mysql-drizzle/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
     "directory": "examples/cloudflare-planetscale-mysql-drizzle"
   },
   "type": "module",

--- a/examples/cloudflare-planetscale-postgres-drizzle/package.json
+++ b/examples/cloudflare-planetscale-postgres-drizzle/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
     "directory": "examples/cloudflare-planetscale-postgres-drizzle"
   },
   "type": "module",

--- a/examples/cloudflare-pr-package/package.json
+++ b/examples/cloudflare-pr-package/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
     "directory": "examples/cloudflare-pr-package"
   },
   "type": "module",

--- a/examples/cloudflare-pr-package/src/Api.ts
+++ b/examples/cloudflare-pr-package/src/Api.ts
@@ -8,7 +8,7 @@ import * as Cloudflare from "alchemy/Cloudflare";
  * `main: import.meta.url`.
  *
  * The handler's bearer-token check is the worker side of the bug fixed in
- * https://github.com/alchemy-run/alchemy-effect/pull/598.
+ * https://github.com/alchemy-run/alchemy/pull/598.
  */
 export default class Api extends Cloudflare.Worker<Api>()(
   "Api",

--- a/examples/cloudflare-pr-package/test/integ.test.ts
+++ b/examples/cloudflare-pr-package/test/integ.test.ts
@@ -92,7 +92,7 @@ const pollUntilStatus = <A extends { readonly status: number }, E, R>(
   );
 
 /**
- * Regression guard for https://github.com/alchemy-run/alchemy-effect/pull/598
+ * Regression guard for https://github.com/alchemy-run/alchemy/pull/598
  *
  * Exercises the real `@alchemy.run/pr-package` Worker. The bearer token is
  * symmetric:

--- a/examples/cloudflare-secrets-store/package.json
+++ b/examples/cloudflare-secrets-store/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
     "directory": "examples/cloudflare-secrets-store"
   },
   "type": "module",

--- a/examples/cloudflare-solidjs-ssr/package.json
+++ b/examples/cloudflare-solidjs-ssr/package.json
@@ -27,7 +27,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
     "directory": "examples/cloudflare-solidjs-ssr"
   }
 }

--- a/examples/cloudflare-solidstart/package.json
+++ b/examples/cloudflare-solidstart/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {},
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
     "directory": "examples/cloudflare-solidstart"
   }
 }

--- a/examples/cloudflare-static-site/package.json
+++ b/examples/cloudflare-static-site/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
     "directory": "examples/cloudflare-static-site"
   },
   "type": "module",

--- a/examples/cloudflare-tanstack-rpc-drizzle/package.json
+++ b/examples/cloudflare-tanstack-rpc-drizzle/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
     "directory": "examples/cloudflare-tanstack-rpc-drizzle"
   },
   "type": "module",

--- a/examples/cloudflare-tanstack-start-solid/package.json
+++ b/examples/cloudflare-tanstack-start-solid/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
     "directory": "examples/cloudflare-tanstack-start-solid"
   },
   "type": "module",

--- a/examples/cloudflare-tanstack/package.json
+++ b/examples/cloudflare-tanstack/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
     "directory": "examples/cloudflare-tanstack"
   },
   "type": "module",

--- a/examples/cloudflare-vue/package.json
+++ b/examples/cloudflare-vue/package.json
@@ -48,7 +48,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
     "directory": "examples/cloudflare-vue"
   }
 }

--- a/examples/cloudflare-worker-async/package.json
+++ b/examples/cloudflare-worker-async/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
     "directory": "examples/cloudflare-worker-async"
   },
   "type": "module",

--- a/examples/cloudflare-worker/package.json
+++ b/examples/cloudflare-worker/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
     "directory": "examples/cloudflare-worker"
   },
   "type": "module",

--- a/examples/cloudflare-worker/test/integ.test.ts
+++ b/examples/cloudflare-worker/test/integ.test.ts
@@ -39,7 +39,7 @@ test(
 );
 
 /**
- * Regression guard for https://github.com/alchemy-run/alchemy-effect/pull/172
+ * Regression guard for https://github.com/alchemy-run/alchemy/pull/172
  *
  * The stack now includes two Workers (`Api` and `SecondaryApi`) that both
  * bind the same `Agent` Durable Object, which in turn binds the `Sandbox`
@@ -67,7 +67,7 @@ test(
 );
 
 /**
- * Regression guard for https://github.com/alchemy-run/alchemy-effect/pull/71
+ * Regression guard for https://github.com/alchemy-run/alchemy/pull/71
  *
  * `NotifyWorkflow` accesses `Cloudflare.Workers.WorkerEnvironment` inside its body and
  * performs a KV roundtrip via `env.KV.put` / `env.KV.get`. If the fix from #71

--- a/examples/docker-postgres/package.json
+++ b/examples/docker-postgres/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
     "directory": "examples/docker-postgres"
   },
   "type": "module",

--- a/examples/monorepo-multi-stack/_package.json
+++ b/examples/monorepo-multi-stack/_package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/alchemy-run/alchemy-effect"
+    "url": "https://github.com/alchemy-run/alchemy"
   },
   "type": "module",
   "scripts": {

--- a/examples/monorepo-multi-stack/backend/package.json
+++ b/examples/monorepo-multi-stack/backend/package.json
@@ -7,7 +7,7 @@
   "sideEffects": false,
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
     "directory": "examples/monorepo-multi-stack/backend"
   },
   "dependencies": {

--- a/examples/monorepo-multi-stack/frontend/package.json
+++ b/examples/monorepo-multi-stack/frontend/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
     "directory": "examples/monorepo-multi-stack/frontend"
   },
   "dependencies": {

--- a/examples/monorepo-single-stack/_package.json
+++ b/examples/monorepo-single-stack/_package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/alchemy-run/alchemy-effect"
+    "url": "https://github.com/alchemy-run/alchemy"
   },
   "type": "module",
   "scripts": {

--- a/examples/monorepo-single-stack/backend/package.json
+++ b/examples/monorepo-single-stack/backend/package.json
@@ -7,7 +7,7 @@
   "sideEffects": false,
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
     "directory": "examples/monorepo-single-stack/backend"
   },
   "dependencies": {

--- a/examples/monorepo-single-stack/frontend/package.json
+++ b/examples/monorepo-single-stack/frontend/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
     "directory": "examples/monorepo-single-stack/frontend"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/alchemy-run/alchemy-effect"
+    "url": "https://github.com/alchemy-run/alchemy"
   },
   "type": "module",
   "module": "./lib/index.js",

--- a/packages/alchemy/package.json
+++ b/packages/alchemy/package.json
@@ -6,7 +6,7 @@
   "author": "Sam Goodwin <sam@alchemy.run>",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
     "directory": "packages/alchemy"
   },
   "bin": {

--- a/packages/alchemy/src/AWS/AuthProvider.ts
+++ b/packages/alchemy/src/AWS/AuthProvider.ts
@@ -272,7 +272,7 @@ export const AwsAuth = AuthProviderLayer<
                   ? Effect.fail(
                       new AuthError({
                         message:
-                          "AWS stored credentials not found. Run: alchemy-effect login --configure",
+                          "AWS stored credentials not found. Run: alchemy login --configure",
                       }),
                     )
                   : Effect.succeed({

--- a/packages/alchemy/src/Cloudflare/Auth/AuthProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Auth/AuthProvider.ts
@@ -416,7 +416,7 @@ export const CloudflareAuth = AuthProviderLayer<
                   ? Effect.fail(
                       new AuthError({
                         message:
-                          "Cloudflare stored credentials not found. Run: alchemy-effect login --configure",
+                          "Cloudflare stored credentials not found. Run: alchemy login --configure",
                       }),
                     )
                   : Effect.gen(function* () {

--- a/packages/alchemy/src/GitHub/Secrets.ts
+++ b/packages/alchemy/src/GitHub/Secrets.ts
@@ -41,7 +41,7 @@ export interface SecretsProps {
  * ```ts
  * yield* GitHub.Secrets({
  *   owner: "alchemy-run",
- *   repository: "alchemy-effect",
+ *   repository: "alchemy",
  *   secrets: {
  *     AXIOM_INGEST_TOKEN: tokenValue,
  *     AXIOM_DATASET_TRACES: traces.name,

--- a/packages/alchemy/src/GitHub/Variables.ts
+++ b/packages/alchemy/src/GitHub/Variables.ts
@@ -33,7 +33,7 @@ export interface VariablesProps {
  * ```ts
  * yield* GitHub.Variables({
  *   owner: "alchemy-run",
- *   repository: "alchemy-effect",
+ *   repository: "alchemy",
  *   variables: {
  *     AWS_ROLE_ARN: role.roleArn,
  *     AWS_REGION: region,

--- a/packages/alchemy/src/Neon/AuthProvider.ts
+++ b/packages/alchemy/src/Neon/AuthProvider.ts
@@ -129,7 +129,7 @@ export const NeonAuth = AuthProviderLayer<
                 ? Effect.fail(
                     new AuthError({
                       message:
-                        "Neon stored credentials not found. Run: alchemy-effect login --configure",
+                        "Neon stored credentials not found. Run: alchemy login --configure",
                     }),
                   )
                 : Effect.succeed({

--- a/packages/alchemy/src/Plan.ts
+++ b/packages/alchemy/src/Plan.ts
@@ -717,7 +717,7 @@ export const make = <A>(
             // If planning persisted here, a mere `alchemy plan` / `--dry-run`
             // would claim ownership of an unowned cloud resource, arming a
             // later unrelated deploy to orphan-delete it. See
-            // https://github.com/alchemy-run/alchemy-effect/issues/793.
+            // https://github.com/alchemy-run/alchemy/issues/793.
             //
             // After a cold-start adoption (engine just discovered an
             // existing cloud resource via `read`), force the engine's
@@ -784,7 +784,7 @@ export const make = <A>(
                 // The adopted state rides onto the plan node via `oldState`
                 // (→ `node.state`) and is persisted at APPLY time by the
                 // update lifecycle's `updating` / `updated` commits. See
-                // https://github.com/alchemy-run/alchemy-effect/issues/793.
+                // https://github.com/alchemy-run/alchemy/issues/793.
                 oldState = adoptedState;
                 forceUpdateAfterAdoption = true;
               }

--- a/packages/alchemy/test/AWS/ACM/Certificate.test.ts
+++ b/packages/alchemy/test/AWS/ACM/Certificate.test.ts
@@ -111,7 +111,7 @@ test.provider.skipIf(!!process.env.FAST)(
 
 class CertificateNotListed extends Data.TaggedError("CertificateNotListed") {}
 
-// Regression test for https://github.com/alchemy-run/alchemy-effect/issues/736.
+// Regression test for https://github.com/alchemy-run/alchemy/issues/736.
 //
 // A `creating` state row persisted before upstream Outputs resolve cannot
 // round-trip Output-valued props (`domainName` from a HostedZone Output,

--- a/packages/alchemy/test/AWS/AutoScaling/ScalingPolicy.test.ts
+++ b/packages/alchemy/test/AWS/AutoScaling/ScalingPolicy.test.ts
@@ -84,7 +84,7 @@ test.provider.skipIf(!process.env.AWS_TEST_SCALING_POLICY_LIST)(
   { timeout: 240_000 },
 );
 
-// Regression test for https://github.com/alchemy-run/alchemy-effect/issues/736.
+// Regression test for https://github.com/alchemy-run/alchemy/issues/736.
 //
 // An interrupted first deploy persists the scaling policy as
 // `status: "creating"` with no attributes — and the Output-valued

--- a/packages/alchemy/test/AWS/DynamoDB/Table.test.ts
+++ b/packages/alchemy/test/AWS/DynamoDB/Table.test.ts
@@ -713,7 +713,7 @@ describe.skipIf(!!process.env.FAST)("AWS.DynamoDB.Table", () => {
     { timeout: 360_000 },
   );
 
-  // Regression test for https://github.com/alchemy-run/alchemy-effect/issues/736.
+  // Regression test for https://github.com/alchemy-run/alchemy/issues/736.
   //
   // An interrupted first deploy persists the table as `status: "creating"`
   // with no attributes — and Output-valued props do not survive the state

--- a/packages/alchemy/test/AWS/ECS/Service.test.ts
+++ b/packages/alchemy/test/AWS/ECS/Service.test.ts
@@ -455,7 +455,7 @@ test.provider(
   { timeout: 240_000 },
 );
 
-// Regression test for https://github.com/alchemy-run/alchemy-effect/issues/736.
+// Regression test for https://github.com/alchemy-run/alchemy/issues/736.
 //
 // An interrupted first deploy persists the service as `status: "creating"`
 // with no attributes — and the Output-valued props (`cluster` passed as a

--- a/packages/alchemy/test/AWS/Organizations/DelegatedAdministrator.test.ts
+++ b/packages/alchemy/test/AWS/Organizations/DelegatedAdministrator.test.ts
@@ -74,7 +74,7 @@ test.provider.skipIf(!memberAccountId)(
     }),
 );
 
-// Regression test for https://github.com/alchemy-run/alchemy-effect/issues/736.
+// Regression test for https://github.com/alchemy-run/alchemy/issues/736.
 //
 // An interrupted first deploy persists the registration as
 // `status: "creating"` with no attributes — and the Output-valued props

--- a/packages/alchemy/test/AWS/Organizations/PolicyAttachment.test.ts
+++ b/packages/alchemy/test/AWS/Organizations/PolicyAttachment.test.ts
@@ -35,7 +35,7 @@ test.provider("list enumerates policy attachments", () =>
   }),
 );
 
-// Regression test for https://github.com/alchemy-run/alchemy-effect/issues/736.
+// Regression test for https://github.com/alchemy-run/alchemy/issues/736.
 //
 // An interrupted first deploy persists the attachment as `status: "creating"`
 // with no attributes — and the Output-valued props (`policyId` from the Policy

--- a/packages/alchemy/test/AWS/Organizations/RootPolicyType.test.ts
+++ b/packages/alchemy/test/AWS/Organizations/RootPolicyType.test.ts
@@ -34,7 +34,7 @@ test.provider("list enumerates root policy types", () =>
   }),
 );
 
-// Regression test for https://github.com/alchemy-run/alchemy-effect/issues/736.
+// Regression test for https://github.com/alchemy-run/alchemy/issues/736.
 //
 // An interrupted first deploy persists the enablement as `status: "creating"`
 // with no attributes — and props that could not round-trip (the `rootId` is

--- a/packages/alchemy/test/AWS/Organizations/TrustedServiceAccess.test.ts
+++ b/packages/alchemy/test/AWS/Organizations/TrustedServiceAccess.test.ts
@@ -67,7 +67,7 @@ test.provider.skipIf(!process.env.AWS_ORG_MANAGEMENT_ACCOUNT)(
     }),
 );
 
-// Regression test for https://github.com/alchemy-run/alchemy-effect/issues/736.
+// Regression test for https://github.com/alchemy-run/alchemy/issues/736.
 //
 // An interrupted first deploy persists the enablement as `status: "creating"`
 // with no attributes and props that could not round-trip. Plan's

--- a/packages/alchemy/test/AWS/Route53/HostedZone.test.ts
+++ b/packages/alchemy/test/AWS/Route53/HostedZone.test.ts
@@ -144,7 +144,7 @@ test.provider(
   { timeout: 180_000 },
 );
 
-// Regression test for https://github.com/alchemy-run/alchemy-effect/issues/736.
+// Regression test for https://github.com/alchemy-run/alchemy/issues/736.
 //
 // An interrupted first deploy persists the zone as `status: "creating"` with
 // no attributes — and an Output-valued `name` does not survive the state

--- a/packages/alchemy/test/AWS/Route53/Record.test.ts
+++ b/packages/alchemy/test/AWS/Route53/Record.test.ts
@@ -149,7 +149,7 @@ test.provider(
   { timeout: 240_000 },
 );
 
-// Regression test for https://github.com/alchemy-run/alchemy-effect/issues/736.
+// Regression test for https://github.com/alchemy-run/alchemy/issues/736.
 //
 // An interrupted first deploy persists the record as `status: "creating"`
 // with no attributes — and the Output-valued props (`hostedZoneId` flows from

--- a/packages/alchemy/test/Cloudflare/Website/Vite.test.ts
+++ b/packages/alchemy/test/Cloudflare/Website/Vite.test.ts
@@ -124,7 +124,7 @@ test.provider(
   { timeout: 360_000 },
 );
 
-// Regression test for https://github.com/alchemy-run/alchemy-effect/issues/792.
+// Regression test for https://github.com/alchemy-run/alchemy/issues/792.
 //
 // A pure client-only Vite project (no vite.config.ts, no plugins, no worker
 // entry) resolves as `appType: "spa"`, so the Cloudflare Vite plugin declares

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/drizzle-workflow/workflow.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/drizzle-workflow/workflow.ts
@@ -8,7 +8,7 @@ import { relations, Widgets } from "./schema.ts";
 
 /**
  * Regression guard for the ExecutionContext-in-Workflow fix
- * (https://github.com/alchemy-run/alchemy-effect/pull/515).
+ * (https://github.com/alchemy-run/alchemy/pull/515).
  *
  * `Drizzle.postgres` resolves its pool through `ExecutionContext`, which
  * `WorkflowBridge.run` now provides per run and `task` threads into each

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/workflow/test-workflow.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/workflow/test-workflow.ts
@@ -9,7 +9,7 @@ import * as Effect from "effect/Effect";
  *  - `Cloudflare.Workflows.sleep` between steps
  *  - `Cloudflare.Workflows.waitForEvent` external event delivery
  *  - `Cloudflare.Workers.WorkerEnvironment` access from inside the body — regression
- *    guard for https://github.com/alchemy-run/alchemy-effect/pull/71
+ *    guard for https://github.com/alchemy-run/alchemy/pull/71
  */
 export default class TestWorkflow extends Cloudflare.Workflow<TestWorkflow>()(
   "TestWorkflow",

--- a/packages/alchemy/test/Stack.test.ts
+++ b/packages/alchemy/test/Stack.test.ts
@@ -8,7 +8,7 @@ import * as Layer from "effect/Layer";
 // These tests are compile-time assertions: they verify that the
 // `Alchemy.Stack` effect permits a `ConfigError` in its body without
 // forcing the user to `Effect.orDie`. See
-// https://github.com/alchemy-run/alchemy-effect/issues/479
+// https://github.com/alchemy-run/alchemy/issues/479
 describe("Alchemy.Stack error channel", () => {
   it("allows ConfigError in the stack body", () => {
     // A stack body that reads from `effect/Config` fails with `ConfigError`.

--- a/packages/alchemy/test/apply.test.ts
+++ b/packages/alchemy/test/apply.test.ts
@@ -415,10 +415,10 @@ describe("basic operations", () => {
 
 // Regression: a logical ID may legitimately contain the FQN separator ("/").
 // The GitHub event source registers a webhook keyed by `${owner}/${repository}`
-// (e.g. "alchemy-run/alchemy-effect"). During destroy the deletion path used to
+// (e.g. "alchemy-run/alchemy"). During destroy the deletion path used to
 // recompute the state key via `toFqn(namespace, logicalId)`, but `logicalId`
 // came from `parseFqn` which splits on "/" and keeps only the last segment
-// ("alchemy-effect"). The recomputed key missed the real state row, so the
+// ("alchemy"). The recomputed key missed the real state row, so the
 // resource was deleted from the cloud yet never removed from state — resurfacing
 // as an orphan deletion on every subsequent destroy, forever.
 describe("FQN separator in logical ID", () => {
@@ -426,7 +426,7 @@ describe("FQN separator in logical ID", () => {
     "destroy clears state for a top-level logical ID containing '/'",
     (stack) =>
       Effect.gen(function* () {
-        const fqn = "alchemy-run/alchemy-effect";
+        const fqn = "alchemy-run/alchemy";
 
         yield* stack.deploy(
           Effect.gen(function* () {
@@ -461,11 +461,11 @@ describe("FQN separator in logical ID", () => {
       Effect.gen(function* () {
         // Mirrors the GitHub webhook: a host construct (the Worker) whose
         // child resource's logical ID is "owner/repo".
-        const fqn = "ReleaseService/alchemy-run/alchemy-effect";
+        const fqn = "ReleaseService/alchemy-run/alchemy";
 
         yield* stack.deploy(
           Effect.gen(function* () {
-            return yield* TestResource("alchemy-run/alchemy-effect", {
+            return yield* TestResource("alchemy-run/alchemy", {
               string: "v1",
             });
           }).pipe(Namespace.push("ReleaseService")),
@@ -4965,7 +4965,7 @@ describe("type aliases", () => {
 });
 
 // Regression coverage for
-// https://github.com/alchemy-run/alchemy-effect/issues/793
+// https://github.com/alchemy-run/alchemy/issues/793
 //
 // `Plan.make` used to `state.set(...)` the adopted `created` state during plan
 // construction. Because `alchemy plan` / `deploy --dry-run` build a plan the

--- a/packages/better-auth/package.json
+++ b/packages/better-auth/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
     "directory": "packages/better-auth"
   },
   "files": [

--- a/packages/pr-package/package.json
+++ b/packages/pr-package/package.json
@@ -6,7 +6,7 @@
   "sideEffects": false,
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
     "directory": "packages/pr-package"
   },
   "files": [

--- a/stacks/github.ts
+++ b/stacks/github.ts
@@ -9,7 +9,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Redacted from "effect/Redacted";
 
-const REPO = { owner: "alchemy-run", repository: "alchemy-effect" } as const;
+const REPO = { owner: "alchemy-run", repository: "alchemy" } as const;
 
 export default Alchemy.Stack(
   "AlchemyGitHubSecrets",

--- a/stacks/otel.ts
+++ b/stacks/otel.ts
@@ -83,7 +83,7 @@ export default Alchemy.Stack(
     if (process.env.SYNC_GITHUB_SECRETS === "1") {
       yield* GitHub.Secrets({
         owner: "alchemy-run",
-        repository: "alchemy-effect",
+        repository: "alchemy",
         secrets: {
           AXIOM_DATASET_TRACES: traces.name,
           AXIOM_DATASET_LOGS: logs.name,

--- a/website/alchemy.run.ts
+++ b/website/alchemy.run.ts
@@ -92,7 +92,7 @@ export default Alchemy.Stack(
     if (stage.startsWith("pr-")) {
       yield* GitHub.Comment("preview-comment", {
         owner: "alchemy-run",
-        repository: "alchemy-effect",
+        repository: "alchemy",
         issueNumber: Number(process.env.PULL_REQUEST),
         body: Output.interpolate`
           ## Website Preview Deployed
@@ -106,7 +106,7 @@ export default Alchemy.Stack(
             // commit on `pull_request` events, which is not what
             // anyone wants to see in the comment.
             process.env.BUILD_SHA
-              ? `[\`${process.env.BUILD_SHA.slice(0, 7)}\`](https://github.com/alchemy-run/alchemy-effect/commit/${process.env.BUILD_SHA})`
+              ? `[\`${process.env.BUILD_SHA.slice(0, 7)}\`](https://github.com/alchemy-run/alchemy/commit/${process.env.BUILD_SHA})`
               : "unknown"
           }.
 

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -261,7 +261,7 @@ export default defineConfig({
         {
           icon: "github",
           label: "GitHub",
-          href: "https://github.com/alchemy-run/alchemy-effect",
+          href: "https://github.com/alchemy-run/alchemy",
         },
         {
           icon: "discord",
@@ -270,8 +270,7 @@ export default defineConfig({
         },
       ],
       editLink: {
-        baseUrl:
-          "https://github.com/alchemy-run/alchemy-effect/edit/main/website",
+        baseUrl: "https://github.com/alchemy-run/alchemy/edit/main/website",
       },
       // One top-level group per docs tab (see src/docs-tabs.ts). The
       // docs-tabs-sidebar middleware swaps in the active tab's group, so

--- a/website/design-system/README.md
+++ b/website/design-system/README.md
@@ -18,14 +18,14 @@ Alchemy — without re-inventing tokens each time.
 
 ## Sources
 
-- **Repo:** `github.com/alchemy-run/alchemy-effect` — website (Astro +
+- **Repo:** `github.com/alchemy-run/alchemy` — website (Astro +
   Starlight), README, docs content, raw sketch PNGs under `images/`.
 - **Live docs:** https://alchemy.run
 - **Docs styling:** `website/src/styles/custom.css` — the ground truth for
   color tokens, spacing, dark-only theme.
-- **Hero diagrams:** `website/images/alchemy-effect-*.png` — hand-drawn
+- **Hero diagrams:** `images/alchemy-effect-*.png` — hand-drawn
   Function → Binding → Resource triple, layers, terminal screenshots.
-- **Sibling repos** (same brand): `alchemy-run/alchemy` (core),
+- **Sibling repos** (same brand):
   `alchemy-run/distilled` (Effect-native cloud SDKs).
 
 ---

--- a/website/package.json
+++ b/website/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
     "directory": "website"
   },
   "type": "module",

--- a/website/src/components/marketing/CTA.astro
+++ b/website/src/components/marketing/CTA.astro
@@ -14,7 +14,7 @@ const { heading } = Astro.props;
     <div class="alc-cta__buttons">
       <Button variant="primary" icon="arrow" href="/getting-started">Start the tutorial</Button>
       <Button variant="secondary" href="/">Read the docs</Button>
-      <Button variant="ghost" icon="github" href="https://github.com/alchemy-run/alchemy-effect">GitHub</Button>
+      <Button variant="ghost" icon="github" href="https://github.com/alchemy-run/alchemy">GitHub</Button>
     </div>
   </div>
 </Section>

--- a/website/src/components/marketing/Footer.astro
+++ b/website/src/components/marketing/Footer.astro
@@ -32,7 +32,7 @@ const cols: FooterCol[] = [
     h: "Community",
     links: [
       { label: "Discord", href: "https://discord.gg/jwKw8dBJdN" },
-      { label: "GitHub", href: "https://github.com/alchemy-run/alchemy-effect" },
+      { label: "GitHub", href: "https://github.com/alchemy-run/alchemy" },
       { label: "X / Twitter", href: "https://x.com/alchemy_run" },
       { label: "Blog", href: "/blog" },
       { label: "Privacy", href: "/privacy" },

--- a/website/src/components/marketing/Nav.astro
+++ b/website/src/components/marketing/Nav.astro
@@ -29,7 +29,7 @@ const { marketing = false } = Astro.props;
   <a href="/getting-started" class="alc-nav__link">Docs</a>
   <a href="/blog" class="alc-nav__link">Blog</a>
   <a
-    href="https://github.com/alchemy-run/alchemy-effect"
+    href="https://github.com/alchemy-run/alchemy"
     class="alc-nav__link alc-nav__link--icon"
     aria-label="GitHub"
   >

--- a/website/src/content/docs/aws/apis/effect-http-api.mdx
+++ b/website/src/content/docs/aws/apis/effect-http-api.mdx
@@ -41,7 +41,7 @@ The mental model:
 4. **Deploy** and call the API from a fully typed test.
 
 A complete, runnable version of this app lives at
-[`examples/aws-lambda-httpapi`](https://github.com/alchemy-run/alchemy-effect/tree/main/examples/aws-lambda-httpapi).
+[`examples/aws-lambda-httpapi`](https://github.com/alchemy-run/alchemy/tree/main/examples/aws-lambda-httpapi).
 
 ## 1. Define the schema
 
@@ -459,7 +459,7 @@ branch is a real typed value you can pattern-match on (here via
 ## Go further
 
 The full
-[`examples/aws-lambda-httpapi`](https://github.com/alchemy-run/alchemy-effect/tree/main/examples/aws-lambda-httpapi)
+[`examples/aws-lambda-httpapi`](https://github.com/alchemy-run/alchemy/tree/main/examples/aws-lambda-httpapi)
 example grows this app in a few directions: it hides DynamoDB behind
 a cloud-agnostic `JobStorage` service (with a drop-in S3
 implementation), publishes job-created notifications to SNS, fans

--- a/website/src/content/docs/aws/apis/effect-rpc.mdx
+++ b/website/src/content/docs/aws/apis/effect-rpc.mdx
@@ -37,7 +37,7 @@ wiring story is identical to the HTTP API guide:
    shares the exact same `RpcGroup` value.
 
 A complete, runnable version of this app lives at
-[`examples/aws-lambda-rpc`](https://github.com/alchemy-run/alchemy-effect/tree/main/examples/aws-lambda-rpc).
+[`examples/aws-lambda-rpc`](https://github.com/alchemy-run/alchemy/tree/main/examples/aws-lambda-rpc).
 
 ## 1. Define the schemas
 
@@ -403,7 +403,7 @@ explicitly.
 ## Go further
 
 The full
-[`examples/aws-lambda-rpc`](https://github.com/alchemy-run/alchemy-effect/tree/main/examples/aws-lambda-rpc)
+[`examples/aws-lambda-rpc`](https://github.com/alchemy-run/alchemy/tree/main/examples/aws-lambda-rpc)
 example grows this app in a few directions: it hides DynamoDB behind
 a cloud-agnostic `JobStorage` service (with a drop-in S3
 implementation), publishes job-created notifications to SNS, fans

--- a/website/src/content/docs/aws/data/rds.mdx
+++ b/website/src/content/docs/aws/data/rds.mdx
@@ -209,7 +209,7 @@ init phase and returns an inner Effect; each `yield*` of that
 inner Effect at runtime resolves fresh `ConnectionInfo` from the
 secret. `Network` here is the same network from the prerequisite
 section, wrapped in its own layer (see the
-[`examples/aws-rds`](https://github.com/alchemy-run/alchemy-effect/tree/main/examples/aws-rds)
+[`examples/aws-rds`](https://github.com/alchemy-run/alchemy/tree/main/examples/aws-rds)
 for the full three-file layout).
 
 The Lambda function provides both layers plus the

--- a/website/src/content/docs/aws/frontend/static-site.mdx
+++ b/website/src/content/docs/aws/frontend/static-site.mdx
@@ -52,7 +52,7 @@ bun alchemy deploy
 ```
 
 The deployed example lives at
-[`examples/aws-static-site`](https://github.com/alchemy-run/alchemy-effect/tree/main/examples/aws-static-site)
+[`examples/aws-static-site`](https://github.com/alchemy-run/alchemy/tree/main/examples/aws-static-site)
 if you want a runnable starting point.
 
 ## Run a build step first

--- a/website/src/content/docs/blog/2026-04-25-circular-references.md
+++ b/website/src/content/docs/blog/2026-04-25-circular-references.md
@@ -54,7 +54,7 @@ needing the other side?* If the provider implements
 `precreate`, the answer is yes.
 
 Here's the Cloudflare `Worker` provider's `precreate`
-(abbreviated from [`Worker.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/Cloudflare/Workers/Worker.ts)):
+(abbreviated from [`Worker.ts`](https://github.com/alchemy-run/alchemy/blob/main/packages/alchemy/src/Cloudflare/Workers/Worker.ts)):
 
 ```typescript
 precreate: Effect.fn(function* ({ id, news, session }) {
@@ -92,7 +92,7 @@ planner detects the cycle, calls `precreate` on the
 participating resources first, and then runs `reconcile` on
 all of them with the cross-references resolved.
 
-For [`AWS/S3/Bucket.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/AWS/S3/Bucket.ts)
+For [`AWS/S3/Bucket.ts`](https://github.com/alchemy-run/alchemy/blob/main/packages/alchemy/src/AWS/S3/Bucket.ts)
 the `precreate` is even shorter — it just calls
 `ensureBucketExists`, since for the BucketPolicy → Lambda
 cycle all the other side needs is the bucket ARN, which is
@@ -293,8 +293,8 @@ only invokes it when a cycle is actually present.
 
 - [Guides › Circular Bindings](/infrastructure-as-effects/circular-bindings) —
   the step-by-step Worker A ↔ Worker B walkthrough.
-- [`Cloudflare/Workers/Worker.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/Cloudflare/Workers/Worker.ts)
+- [`Cloudflare/Workers/Worker.ts`](https://github.com/alchemy-run/alchemy/blob/main/packages/alchemy/src/Cloudflare/Workers/Worker.ts)
   — the canonical `precreate` reference, including Durable
   Object namespace reservation.
-- [`AWS/S3/Bucket.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/AWS/S3/Bucket.ts)
+- [`AWS/S3/Bucket.ts`](https://github.com/alchemy-run/alchemy/blob/main/packages/alchemy/src/AWS/S3/Bucket.ts)
   — `precreate` for the BucketPolicy ↔ Lambda Role cycle.

--- a/website/src/content/docs/blog/2026-04-30-bindings.md
+++ b/website/src/content/docs/blog/2026-04-30-bindings.md
@@ -111,7 +111,7 @@ because the framework resolves it via
 `Effect.serviceOption` — it's *optional* at the type level.
 
 The relevant snippet is the comment right in
-[`Binding.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/Binding.ts):
+[`Binding.ts`](https://github.com/alchemy-run/alchemy/blob/main/packages/alchemy/src/Binding.ts):
 
 ```typescript
 // we use a service option because at runtime (e.g. in a Lambda
@@ -300,9 +300,9 @@ mixing the two phases' code together.
 
 ## Where to go next
 
-- [`Binding.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/Binding.ts)
+- [`Binding.ts`](https://github.com/alchemy-run/alchemy/blob/main/packages/alchemy/src/Binding.ts)
   — the `Binding.Service` / `Binding.Policy` machinery.
-- [`AWS/S3/GetObject.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/AWS/S3/GetObject.ts)
+- [`AWS/S3/GetObject.ts`](https://github.com/alchemy-run/alchemy/blob/main/packages/alchemy/src/AWS/S3/GetObject.ts)
   — a canonical capability: runtime layer + policy layer
   in one file.
 - [Circular references, without the deadlock](/blog/2026-04-25-circular-references)

--- a/website/src/content/docs/blog/2026-05-04-reconcile.md
+++ b/website/src/content/docs/blog/2026-05-04-reconcile.md
@@ -257,7 +257,7 @@ authoritative is what the cloud says right now.
 Once `create` and `update` have both grown an "observe live
 state, then converge per-aspect" prefix, the split is
 purely cosmetic. This is the actual reconciler in
-[`AWS/DynamoDB/Table.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/AWS/DynamoDB/Table.ts),
+[`AWS/DynamoDB/Table.ts`](https://github.com/alchemy-run/alchemy/blob/main/packages/alchemy/src/AWS/DynamoDB/Table.ts),
 which collapses both into one flow:
 
 ```typescript
@@ -313,7 +313,7 @@ your `create` body is *already* a reconciler. It's reading
 observed state and applying deltas. It just happens to be
 named `create`.
 
-[`Cloudflare/Workers/Worker.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/Cloudflare/Workers/Worker.ts)
+[`Cloudflare/Workers/Worker.ts`](https://github.com/alchemy-run/alchemy/blob/main/packages/alchemy/src/Cloudflare/Workers/Worker.ts)
 makes the reconciler explicit. `putWorker` is a true upsert;
 `reconcileDomains` queries the live domain list and computes
 attach/detach deltas. There's no "first time" path. Crash
@@ -380,7 +380,7 @@ The provider surface is now three operations:
 
 `read` is called first whenever there's no prior state. If
 it finds a resource, the engine checks the
-[`AdoptPolicy`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/AdoptPolicy.ts)
+[`AdoptPolicy`](https://github.com/alchemy-run/alchemy/blob/main/packages/alchemy/src/AdoptPolicy.ts)
 — set globally with `--adopt`, or per-scope with
 `.pipe(adopt(true))`. If adoption is allowed (or the
 resource carries our ownership tags), the engine seeds state
@@ -421,7 +421,7 @@ we just deleted.
 ## Plan didn't change
 
 This is important: the *plan* still talks about create and
-update. Open [`Plan.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/Plan.ts)
+update. Open [`Plan.ts`](https://github.com/alchemy-run/alchemy/blob/main/packages/alchemy/src/Plan.ts)
 and you'll find an `action` field on every node, with the
 same values as before:
 
@@ -457,11 +457,11 @@ the ground truth, and the apply/plan integration tests as
 the safety net for the engine changes themselves.
 
 - [Part 2 — Migrating 50+ providers in an afternoon](/blog/2026-05-06-reconcile-ai-migration)
-- [`AdoptPolicy`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/AdoptPolicy.ts)
+- [`AdoptPolicy`](https://github.com/alchemy-run/alchemy/blob/main/packages/alchemy/src/AdoptPolicy.ts)
   — the engine-side spec for `read` → `Unowned` → adopt/fail routing.
 - Canonical reconcilers:
-  [`AWS/S3/Bucket.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/AWS/S3/Bucket.ts),
-  [`AWS/Kinesis/Stream.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/AWS/Kinesis/Stream.ts),
-  [`AWS/DynamoDB/Table.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/AWS/DynamoDB/Table.ts).
-- [PR #179](https://github.com/alchemy-run/alchemy-effect/issues/179)
+  [`AWS/S3/Bucket.ts`](https://github.com/alchemy-run/alchemy/blob/main/packages/alchemy/src/AWS/S3/Bucket.ts),
+  [`AWS/Kinesis/Stream.ts`](https://github.com/alchemy-run/alchemy/blob/main/packages/alchemy/src/AWS/Kinesis/Stream.ts),
+  [`AWS/DynamoDB/Table.ts`](https://github.com/alchemy-run/alchemy/blob/main/packages/alchemy/src/AWS/DynamoDB/Table.ts).
+- [PR #179](https://github.com/alchemy-run/alchemy/issues/179)
   — the migration itself, every provider in one diff.

--- a/website/src/content/docs/blog/2026-05-06-reconcile-ai-migration.md
+++ b/website/src/content/docs/blog/2026-05-06-reconcile-ai-migration.md
@@ -10,7 +10,7 @@ excerpt: One prompt, fifty resources, run in parallel. Tests were the ground tru
 This post is about the part that surprised us: how
 unreasonably fast it was to actually do the migration.
 
-Alchemy has 50+ provider files in [`packages/alchemy/src/`](https://github.com/alchemy-run/alchemy-effect/tree/main/packages/alchemy/src).
+Alchemy has 50+ provider files in [`packages/alchemy/src/`](https://github.com/alchemy-run/alchemy/tree/main/packages/alchemy/src).
 The old shape was two functions per resource — `create` and
 `update` — both written defensively against each other's
 edge cases. The new shape is one function. Rewriting every
@@ -60,8 +60,8 @@ or what the other one already did. There is no other one.
 ## Tests were the ground truth
 
 Every provider already had test coverage:
-[`test/AWS/S3/Bucket.test.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/test/AWS/S3/Bucket.test.ts),
-[`test/AWS/DynamoDB/Table.test.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/test/AWS/DynamoDB/Table.test.ts),
+[`test/AWS/S3/Bucket.test.ts`](https://github.com/alchemy-run/alchemy/blob/main/packages/alchemy/test/AWS/S3/Bucket.test.ts),
+[`test/AWS/DynamoDB/Table.test.ts`](https://github.com/alchemy-run/alchemy/blob/main/packages/alchemy/test/AWS/DynamoDB/Table.test.ts),
 and so on. These weren't unit tests with mocked SDKs — they
 hit the real cloud, run through the full apply path, and
 assert on the actual state of the resource.
@@ -87,8 +87,8 @@ as an executable spec for the gap.
 ## The engine got the same treatment
 
 The provider-side change was the visible half. The other
-half was inside the engine — [`Plan.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/Plan.ts)
-and [`Apply.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/Apply.ts) —
+half was inside the engine — [`Plan.ts`](https://github.com/alchemy-run/alchemy/blob/main/packages/alchemy/src/Plan.ts)
+and [`Apply.ts`](https://github.com/alchemy-run/alchemy/blob/main/packages/alchemy/src/Apply.ts) —
 which decide *which* provider function to call and route
 the lifecycle.
 
@@ -141,8 +141,8 @@ your head.
 ## Where to go next
 
 - [Part 1 — One reconcile, no create vs. update](/blog/2026-05-04-reconcile)
-- [PR #179](https://github.com/alchemy-run/alchemy-effect/issues/179)
+- [PR #179](https://github.com/alchemy-run/alchemy/issues/179)
   — the migration in one diff.
 - Per-resource test conventions:
-  [`test/AWS/DynamoDB/Table.test.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/test/AWS/DynamoDB/Table.test.ts),
-  [`test/Cloudflare/Workers/Worker.test.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts).
+  [`test/AWS/DynamoDB/Table.test.ts`](https://github.com/alchemy-run/alchemy/blob/main/packages/alchemy/test/AWS/DynamoDB/Table.test.ts),
+  [`test/Cloudflare/Workers/Worker.test.ts`](https://github.com/alchemy-run/alchemy/blob/main/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts).

--- a/website/src/content/docs/blog/2026-05-08-beta-35.md
+++ b/website/src/content/docs/blog/2026-05-08-beta-35.md
@@ -97,7 +97,7 @@ export default class Api extends Cloudflare.Worker<Api>()(
 ```
 
 The full round-trip lives in
-[`examples/cloudflare-worker/src/Api.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/examples/cloudflare-worker/src/Api.ts).
+[`examples/cloudflare-worker/src/Api.ts`](https://github.com/alchemy-run/alchemy/blob/main/examples/cloudflare-worker/src/Api.ts).
 [Tutorial › Queue consumer](/cloudflare/messaging/queues)
 
 ## R2 bucket custom domains
@@ -120,7 +120,7 @@ Each domain points at the bucket's public origin; pair
 with a Cloudflare `Zone` if you want the DNS record
 provisioned in the same stack.
 
-— *Thanks to **Alex** ([#241](https://github.com/alchemy-run/alchemy-effect/pull/241))
+— *Thanks to **Alex** ([#241](https://github.com/alchemy-run/alchemy/pull/241))
 for the contribution.*
 
 ## Non-string env bindings on Workers
@@ -151,7 +151,7 @@ the binding site and `JSON.parse` on the runtime side
 with an `as` cast for typing. Now it's just `env.MAX_ITEMS`.
 
 — *Thanks to **Michael K**
-([#269](https://github.com/alchemy-run/alchemy-effect/pull/269))
+([#269](https://github.com/alchemy-run/alchemy/pull/269))
 for the contribution.*
 
 ## Neon logical replication
@@ -171,7 +171,7 @@ Toggling the flag on an existing project applies in place —
 no replacement needed.
 
 — *Thanks to **Baptiste Arnaud**
-([#268](https://github.com/alchemy-run/alchemy-effect/pull/268))
+([#268](https://github.com/alchemy-run/alchemy/pull/268))
 for the contribution.*
 
 ## CLI: version-on-npm warning
@@ -232,11 +232,11 @@ alchemy aws state get <key>     # read a state entry
 
 Big thank-you to everyone who shipped code in this beta:
 
-- **Alex** — R2 bucket custom domains ([#241](https://github.com/alchemy-run/alchemy-effect/pull/241))
-- **Michael K** — non-string env bindings on Workers ([#269](https://github.com/alchemy-run/alchemy-effect/pull/269))
-- **Baptiste Arnaud** — Neon `enableLogicalReplication` ([#268](https://github.com/alchemy-run/alchemy-effect/pull/268))
+- **Alex** — R2 bucket custom domains ([#241](https://github.com/alchemy-run/alchemy/pull/241))
+- **Michael K** — non-string env bindings on Workers ([#269](https://github.com/alchemy-run/alchemy/pull/269))
+- **Baptiste Arnaud** — Neon `enableLogicalReplication` ([#268](https://github.com/alchemy-run/alchemy/pull/268))
 
 ## Where to go next
 
-- [CHANGELOG](https://github.com/alchemy-run/alchemy-effect/blob/main/CHANGELOG.md#v200-beta35)
-- [Compare v2.0.0-beta.34 → v2.0.0-beta.35](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.34...v2.0.0-beta.35)
+- [CHANGELOG](https://github.com/alchemy-run/alchemy/blob/main/CHANGELOG.md#v200-beta35)
+- [Compare v2.0.0-beta.34 → v2.0.0-beta.35](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.34...v2.0.0-beta.35)

--- a/website/src/content/docs/blog/2026-05-09-beta-36.md
+++ b/website/src/content/docs/blog/2026-05-09-beta-36.md
@@ -52,9 +52,9 @@ export default class ImageWorker extends Cloudflare.Worker<ImageWorker>()(
 ) {}
 ```
 
-— *Thanks to **Alex** ([#237](https://github.com/alchemy-run/alchemy-effect/pull/237))
+— *Thanks to **Alex** ([#237](https://github.com/alchemy-run/alchemy/pull/237))
 for the contribution.*
-[`Images.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/Cloudflare/Images/Images.ts)
+[`Images.ts`](https://github.com/alchemy-run/alchemy/blob/main/packages/alchemy/src/Cloudflare/Images/Images.ts)
 
 ## Hyperdrive in Worker bindings
 
@@ -128,7 +128,7 @@ export default class Api extends Cloudflare.Worker<Api>()(
 ```
 
 — *Thanks to **Baptiste Arnaud**
-([#282](https://github.com/alchemy-run/alchemy-effect/pull/282))
+([#282](https://github.com/alchemy-run/alchemy/pull/282))
 for the contribution.*
 [Tutorial › Hyperdrive](/cloudflare/data/hyperdrive)
 
@@ -170,7 +170,7 @@ Each entry is reconciled in place — edit the array and the
 next deploy applies the delta against R2's live policy.
 
 — *Thanks to **Baptiste Arnaud**
-([#284](https://github.com/alchemy-run/alchemy-effect/pull/284))
+([#284](https://github.com/alchemy-run/alchemy/pull/284))
 for the contribution.* See [Cloudflare R2 docs › Object
 lifecycles](https://developers.cloudflare.com/r2/buckets/object-lifecycles/)
 for the underlying behavior.
@@ -193,11 +193,11 @@ for the underlying behavior.
 
 Big thank-you to everyone who shipped code in this beta:
 
-- **Alex** — Cloudflare Images binding ([#237](https://github.com/alchemy-run/alchemy-effect/pull/237))
-- **Baptiste Arnaud** — Hyperdrive in Worker bindings ([#282](https://github.com/alchemy-run/alchemy-effect/pull/282))
-- **Baptiste Arnaud** — R2 lifecycle rules ([#284](https://github.com/alchemy-run/alchemy-effect/pull/284))
+- **Alex** — Cloudflare Images binding ([#237](https://github.com/alchemy-run/alchemy/pull/237))
+- **Baptiste Arnaud** — Hyperdrive in Worker bindings ([#282](https://github.com/alchemy-run/alchemy/pull/282))
+- **Baptiste Arnaud** — R2 lifecycle rules ([#284](https://github.com/alchemy-run/alchemy/pull/284))
 
 ## Where to go next
 
-- [CHANGELOG](https://github.com/alchemy-run/alchemy-effect/blob/main/CHANGELOG.md#v200-beta36)
-- [Compare v2.0.0-beta.35 → v2.0.0-beta.36](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.35...v2.0.0-beta.36)
+- [CHANGELOG](https://github.com/alchemy-run/alchemy/blob/main/CHANGELOG.md#v200-beta36)
+- [Compare v2.0.0-beta.35 → v2.0.0-beta.36](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.35...v2.0.0-beta.36)

--- a/website/src/content/docs/blog/2026-05-12-beta-37.md
+++ b/website/src/content/docs/blog/2026-05-12-beta-37.md
@@ -90,7 +90,7 @@ alchemy deploy --stage pr-147         # references it, creates only the branch
 ```
 
 The full file lives in
-[`examples/cloudflare-neon-drizzle/src/Db.ts`](https://github.com/alchemy-run/alchemy-effect/tree/main/examples/cloudflare-neon-drizzle/src/Db.ts);
+[`examples/cloudflare-neon-drizzle/src/Db.ts`](https://github.com/alchemy-run/alchemy/tree/main/examples/cloudflare-neon-drizzle/src/Db.ts);
 the guide is at
 [Guides › Shared database across stages](/cloudflare/data/shared-database).
 
@@ -219,7 +219,7 @@ deployment.
 The example: a `Backend` Worker exposing both an RPC method
 and an HTTP route, plus a TanStack Start frontend calling
 it three different ways. (This is the
-[`examples/cloudflare-tanstack`](https://github.com/alchemy-run/alchemy-effect/tree/main/examples/cloudflare-tanstack)
+[`examples/cloudflare-tanstack`](https://github.com/alchemy-run/alchemy/tree/main/examples/cloudflare-tanstack)
 project — cut down to the relevant pieces.)
 
 The backend Worker:
@@ -311,7 +311,7 @@ streaming bodies; the RPC option (#3) is the right one
 when you want typed method calls.
 
 [Tutorial › Vite SPA + Worker bridge](/cloudflare/frontend/vite-spa) ·
-[Example › `cloudflare-tanstack`](https://github.com/alchemy-run/alchemy-effect/tree/main/examples/cloudflare-tanstack)
+[Example › `cloudflare-tanstack`](https://github.com/alchemy-run/alchemy/tree/main/examples/cloudflare-tanstack)
 
 ## Workflows with typed input and output
 
@@ -427,7 +427,7 @@ Multiple `cron("…")` calls register multiple schedules on
 the same Worker; the cheapest cron granularity Cloudflare
 offers is one minute (`* * * * *`).
 
-— *Thanks to **Dawson** ([#288](https://github.com/alchemy-run/alchemy-effect/pull/288))
+— *Thanks to **Dawson** ([#288](https://github.com/alchemy-run/alchemy/pull/288))
 for the contribution.*
 
 ## Analytics Engine binding
@@ -464,7 +464,7 @@ export default Cloudflare.Worker("Api",
 );
 ```
 
-— *Thanks to **Dawson** ([#286](https://github.com/alchemy-run/alchemy-effect/pull/286))
+— *Thanks to **Dawson** ([#286](https://github.com/alchemy-run/alchemy/pull/286))
 for the contribution.*
 
 ## R2 buckets empty themselves on destroy
@@ -486,7 +486,7 @@ production guards, opt out per-bucket:
 const Photos = Cloudflare.R2.Bucket("Photos", { emptyOnDestroy: false });
 ```
 
-— *Thanks to **Michael K** ([#276](https://github.com/alchemy-run/alchemy-effect/pull/276))
+— *Thanks to **Michael K** ([#276](https://github.com/alchemy-run/alchemy/pull/276))
 for the contribution.*
 
 ## Fixes worth knowing about
@@ -499,31 +499,31 @@ for the contribution.*
   sidecar, fixing a class of "module not found" errors for
   Workers that depend on WASM. *Thanks to **Baptiste
   Arnaud**
-  ([#305](https://github.com/alchemy-run/alchemy-effect/pull/305)).*
+  ([#305](https://github.com/alchemy-run/alchemy/pull/305)).*
 - **Unresolved `Output` JS-coercion throws.** Accidentally
   using an unresolved `Output<string>` in a template
   literal (e.g. `` `${bucket.bucketName}` `` outside an
   Effect) previously coerced to `"[object Output]"` and
   shipped garbage to the cloud. It now throws. *Thanks to
   **Zé Yuri**
-  ([#306](https://github.com/alchemy-run/alchemy-effect/pull/306)).*
+  ([#306](https://github.com/alchemy-run/alchemy/pull/306)).*
 - **Deprecated libsodium wrapper types removed.** No public
   API impact; if you were importing internal types they're
   gone. *Thanks to **齐天大圣**
-  ([#311](https://github.com/alchemy-run/alchemy-effect/pull/311)).*
+  ([#311](https://github.com/alchemy-run/alchemy/pull/311)).*
 
 ## Contributors
 
 Big thank-you to everyone who shipped code in this beta:
 
-- **Michael K** — R2 empty-on-destroy ([#276](https://github.com/alchemy-run/alchemy-effect/pull/276))
-- **Dawson** — Worker cron triggers ([#288](https://github.com/alchemy-run/alchemy-effect/pull/288))
-- **Dawson** — Analytics Engine binding ([#286](https://github.com/alchemy-run/alchemy-effect/pull/286))
-- **Baptiste Arnaud** — WASM in local sidecar bundle ([#305](https://github.com/alchemy-run/alchemy-effect/pull/305))
-- **Zé Yuri** — throw on unresolved `Output` JS-coercion ([#306](https://github.com/alchemy-run/alchemy-effect/pull/306))
-- **齐天大圣** — remove deprecated libsodium wrapper types ([#311](https://github.com/alchemy-run/alchemy-effect/pull/311))
+- **Michael K** — R2 empty-on-destroy ([#276](https://github.com/alchemy-run/alchemy/pull/276))
+- **Dawson** — Worker cron triggers ([#288](https://github.com/alchemy-run/alchemy/pull/288))
+- **Dawson** — Analytics Engine binding ([#286](https://github.com/alchemy-run/alchemy/pull/286))
+- **Baptiste Arnaud** — WASM in local sidecar bundle ([#305](https://github.com/alchemy-run/alchemy/pull/305))
+- **Zé Yuri** — throw on unresolved `Output` JS-coercion ([#306](https://github.com/alchemy-run/alchemy/pull/306))
+- **齐天大圣** — remove deprecated libsodium wrapper types ([#311](https://github.com/alchemy-run/alchemy/pull/311))
 
 ## Where to go next
 
-- [CHANGELOG](https://github.com/alchemy-run/alchemy-effect/blob/main/CHANGELOG.md#v200-beta37)
-- [Compare v2.0.0-beta.36 → v2.0.0-beta.37](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.36...v2.0.0-beta.37)
+- [CHANGELOG](https://github.com/alchemy-run/alchemy/blob/main/CHANGELOG.md#v200-beta37)
+- [Compare v2.0.0-beta.36 → v2.0.0-beta.37](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.36...v2.0.0-beta.37)

--- a/website/src/content/docs/blog/2026-05-13-actions.md
+++ b/website/src/content/docs/blog/2026-05-13-actions.md
@@ -309,7 +309,7 @@ among the others.
 - [Concepts › Action](/infrastructure-as-code/action) — the full reference
   for the inline, init-effect, and tagged forms, plus the
   state model and lifecycle table.
-- [`packages/alchemy/src/Action.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/Action.ts)
+- [`packages/alchemy/src/Action.ts`](https://github.com/alchemy-run/alchemy/blob/main/packages/alchemy/src/Action.ts)
   — the source. Around 270 lines including JSDoc.
 - [Bindings — one line, two phases](/blog/2026-04-30-bindings) —
   the deploy-vs-runtime split that Actions also follow at

--- a/website/src/content/docs/blog/2026-05-13-beta-38.md
+++ b/website/src/content/docs/blog/2026-05-13-beta-38.md
@@ -209,5 +209,5 @@ backs off, reconnects, and resumes.
 
 ## Where to go next
 
-- [CHANGELOG](https://github.com/alchemy-run/alchemy-effect/blob/main/CHANGELOG.md#v200-beta38)
-- [Compare v2.0.0-beta.37 → v2.0.0-beta.38](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.37...v2.0.0-beta.38)
+- [CHANGELOG](https://github.com/alchemy-run/alchemy/blob/main/CHANGELOG.md#v200-beta38)
+- [Compare v2.0.0-beta.37 → v2.0.0-beta.38](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.37...v2.0.0-beta.38)

--- a/website/src/content/docs/blog/2026-05-13-beta-39.md
+++ b/website/src/content/docs/blog/2026-05-13-beta-39.md
@@ -73,9 +73,9 @@ under `Cloudflare.Worker` too. `RpcServer.toHttpEffect`,
 in particular, is unblocked.
 
 — *Thanks to **[Will King](https://github.com/wking-io)**
-([#328](https://github.com/alchemy-run/alchemy-effect/pull/328))
+([#328](https://github.com/alchemy-run/alchemy/pull/328))
 for the fix.* Fixes
-[#327](https://github.com/alchemy-run/alchemy-effect/issues/327).
+[#327](https://github.com/alchemy-run/alchemy/issues/327).
 
 ## `SendEmail` binding type inference
 
@@ -92,17 +92,17 @@ the right runtime type, and Cloudflare receives the
 expected `send_email` binding metadata at deploy time.
 
 — *Thanks to **[Gerben Mulder](https://github.com/Gerbuuun)**
-([#326](https://github.com/alchemy-run/alchemy-effect/pull/326))
+([#326](https://github.com/alchemy-run/alchemy/pull/326))
 for catching this.*
 
 ## Contributors
 
 Big thank-you to everyone who shipped code in this beta:
 
-- **[Will King](https://github.com/wking-io)** — Cloudflare Worker HTTP effect lifecycle ([#328](https://github.com/alchemy-run/alchemy-effect/pull/328))
-- **[Gerben Mulder](https://github.com/Gerbuuun)** — `SendEmail` Worker binding type and meta ([#326](https://github.com/alchemy-run/alchemy-effect/pull/326))
+- **[Will King](https://github.com/wking-io)** — Cloudflare Worker HTTP effect lifecycle ([#328](https://github.com/alchemy-run/alchemy/pull/328))
+- **[Gerben Mulder](https://github.com/Gerbuuun)** — `SendEmail` Worker binding type and meta ([#326](https://github.com/alchemy-run/alchemy/pull/326))
 
 ## Where to go next
 
-- [CHANGELOG](https://github.com/alchemy-run/alchemy-effect/blob/main/CHANGELOG.md#v200-beta39)
-- [Compare v2.0.0-beta.38 → v2.0.0-beta.39](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.38...v2.0.0-beta.39)
+- [CHANGELOG](https://github.com/alchemy-run/alchemy/blob/main/CHANGELOG.md#v200-beta39)
+- [Compare v2.0.0-beta.38 → v2.0.0-beta.39](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.38...v2.0.0-beta.39)

--- a/website/src/content/docs/blog/2026-05-15-beta-40.md
+++ b/website/src/content/docs/blog/2026-05-15-beta-40.md
@@ -71,8 +71,8 @@ and `Diff.ts` gained the helpers needed to compare
 observed-vs-desired correctly. Deploys are quiet again
 unless something genuinely changed.
 
-Fixes [#332](https://github.com/alchemy-run/alchemy-effect/issues/332)
-and [#334](https://github.com/alchemy-run/alchemy-effect/issues/334).
+Fixes [#332](https://github.com/alchemy-run/alchemy/issues/332)
+and [#334](https://github.com/alchemy-run/alchemy/issues/334).
 
 ## Worker HTTP: log full Cause server-side, return generic 500
 
@@ -87,7 +87,7 @@ under `Cloudflare.Worker`.
 This pairs with the beta.39 lifecycle adapter fix and
 finishes the cleanup of the Worker HTTP path.
 
-Fixes [#336](https://github.com/alchemy-run/alchemy-effect/pull/336).
+Fixes [#336](https://github.com/alchemy-run/alchemy/pull/336).
 
 ## Sanitize entrypoint URLs in generated code
 
@@ -112,10 +112,10 @@ codegen site.
   options were silently dropped before they reached the
   container runtime. Thanks
   **[Christopher Yovanovitch](https://github.com/yovanoc)**
-  ([#341](https://github.com/alchemy-run/alchemy-effect/pull/341)).
+  ([#341](https://github.com/alchemy-run/alchemy/pull/341)).
 - **`bun alchemy dev` lockfile** moves to
   `@alchemy.run/node-utils` and the legacy `Sidecar/Lock.ts`
-  is gone ([#345](https://github.com/alchemy-run/alchemy-effect/pull/345)).
+  is gone ([#345](https://github.com/alchemy-run/alchemy/pull/345)).
 - **Cloudflare state store version bumped to 5** — clients
   pinned to older versions will refuse to load mismatched
   state and prompt you to upgrade.
@@ -125,15 +125,15 @@ codegen site.
 - **Axiom `smartfilter` chart subtype** — used by the
   internal otel dashboard; available now if you build
   your own Axiom charts via `Axiom.Chart`
-  ([#339](https://github.com/alchemy-run/alchemy-effect/pull/339)).
+  ([#339](https://github.com/alchemy-run/alchemy/pull/339)).
 
 ## Contributors
 
 Big thank-you to everyone who shipped code in this beta:
 
-- **[Christopher Yovanovitch](https://github.com/yovanoc)** — `Cloudflare.start` options forwarding ([#341](https://github.com/alchemy-run/alchemy-effect/pull/341))
+- **[Christopher Yovanovitch](https://github.com/yovanoc)** — `Cloudflare.start` options forwarding ([#341](https://github.com/alchemy-run/alchemy/pull/341))
 
 ## Where to go next
 
-- [CHANGELOG](https://github.com/alchemy-run/alchemy-effect/blob/main/CHANGELOG.md#v200-beta40)
-- [Compare v2.0.0-beta.39 → v2.0.0-beta.40](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.39...v2.0.0-beta.40)
+- [CHANGELOG](https://github.com/alchemy-run/alchemy/blob/main/CHANGELOG.md#v200-beta40)
+- [Compare v2.0.0-beta.39 → v2.0.0-beta.40](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.39...v2.0.0-beta.40)

--- a/website/src/content/docs/blog/2026-05-20-beta-41.md
+++ b/website/src/content/docs/blog/2026-05-20-beta-41.md
@@ -12,7 +12,7 @@ runtime across requests, which caused intermittent 500s, hung
 `fetch` calls under load, and "promise resolved on the wrong I/O
 context" errors from workerd. beta.41 scopes everything per
 request — the failure modes documented in
-[#374](https://github.com/alchemy-run/alchemy-effect/pull/374)
+[#374](https://github.com/alchemy-run/alchemy/pull/374)
 no longer reproduce.
 :::
 
@@ -49,7 +49,7 @@ request. Three things went wrong in production:
    then captured stale state from a previous request.
 
 beta.41 refactors the entrypoint into
-[`WorkerBridge.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/Cloudflare/Workers/WorkerBridge.ts).
+[`WorkerBridge.ts`](https://github.com/alchemy-run/alchemy/blob/main/packages/alchemy/src/Cloudflare/Workers/WorkerBridge.ts).
 The generated entrypoint is now thin — it just instantiates the
 bridge class. Everything else is type-checked TypeScript in the
 package. Scoping is linear: one `Scope.makeUnsafe()` per request,
@@ -65,7 +65,7 @@ against the request's own scope.
 > safe to cache (anything that doesn't capture a promise) — for
 > now, correctness first.
 
-[#374](https://github.com/alchemy-run/alchemy-effect/pull/374)
+[#374](https://github.com/alchemy-run/alchemy/pull/374)
 
 ### The schema-driven pattern, end to end
 
@@ -225,7 +225,7 @@ The guides walk through the full thing:
 - **`WorkerProps.env` flows into `InferEnv`** — typing
   `worker.env.MY_VAR` now picks up keys you declared in
   `env: { ... }` on the Worker, not just bindings
-  ([#351](https://github.com/alchemy-run/alchemy-effect/pull/351)).
+  ([#351](https://github.com/alchemy-run/alchemy/pull/351)).
 - **`WorkerExecutionContext` + `ExecutionContext` in fetch types** —
   the Worker fetch handler now exposes both the Effect-side
   `ExecutionContext` (with the request scope) and the raw
@@ -233,44 +233,44 @@ The guides walk through the full thing:
   friends are reachable from inside the handler without an
   extra cast. Thanks
   **[Michael K](https://github.com/michaelkleene)**
-  ([#358](https://github.com/alchemy-run/alchemy-effect/pull/358)).
+  ([#358](https://github.com/alchemy-run/alchemy/pull/358)).
 - **DO methods receive the Worker env** — previously, RPC methods
   on a `DurableObject` were running with an empty `env`
   context, breaking any binding the DO needed to call into. Thanks
   **[Dillon Mulroy](https://github.com/dmmulroy)**
-  ([#369](https://github.com/alchemy-run/alchemy-effect/pull/369)).
+  ([#369](https://github.com/alchemy-run/alchemy/pull/369)).
 - **`Redacted` survives sidecar RPC serialization** — sidecar
   was unwrapping `Redacted` values during JSON round-trips,
   leaking secrets in dev logs. They're now preserved end to end.
   Thanks **[Juliaan](https://github.com/Juliaan)**
-  ([#356](https://github.com/alchemy-run/alchemy-effect/pull/356)).
+  ([#356](https://github.com/alchemy-run/alchemy/pull/356)).
 - **`lightningcss` + `fsevents` externalized in the Worker
   bundler** — both are platform-specific native deps that don't
   belong in the Worker bundle. Thanks
   **[Michael K](https://github.com/michaelkleene)**
-  ([#363](https://github.com/alchemy-run/alchemy-effect/pull/363)).
+  ([#363](https://github.com/alchemy-run/alchemy/pull/363)).
 - **Worker teardown force-deletes scripts** — if a Worker had
   stuck Durable Object migrations from a previous failed deploy,
   `destroy` would hang. It now force-deletes the script and
-  proceeds ([#348](https://github.com/alchemy-run/alchemy-effect/pull/348)).
+  proceeds ([#348](https://github.com/alchemy-run/alchemy/pull/348)).
 - **Eager terminal status events while waiting on deps** — the
   CLI now shows `pending` for resources blocked on dependencies
   and emits terminal status (created/updated/failed) as soon as
   the resource's own reconcile finishes, rather than batching at
   the end. Thanks **[Michael K](https://github.com/michaelkleene)**
-  ([#376](https://github.com/alchemy-run/alchemy-effect/pull/376)).
+  ([#376](https://github.com/alchemy-run/alchemy/pull/376)).
 
 ## Contributors
 
 Big thank-you to everyone who shipped code in this beta:
 
-- **[Michael K](https://github.com/michaelkleene)** — Worker fetch type fix ([#358](https://github.com/alchemy-run/alchemy-effect/pull/358)), `lightningcss`/`fsevents` externalization ([#363](https://github.com/alchemy-run/alchemy-effect/pull/363)), eager terminal status events ([#376](https://github.com/alchemy-run/alchemy-effect/pull/376))
-- **[Dillon Mulroy](https://github.com/dmmulroy)** — DO methods receive Worker env ([#369](https://github.com/alchemy-run/alchemy-effect/pull/369))
-- **[Juliaan](https://github.com/Juliaan)** — `Redacted` across sidecar RPC ([#356](https://github.com/alchemy-run/alchemy-effect/pull/356))
+- **[Michael K](https://github.com/michaelkleene)** — Worker fetch type fix ([#358](https://github.com/alchemy-run/alchemy/pull/358)), `lightningcss`/`fsevents` externalization ([#363](https://github.com/alchemy-run/alchemy/pull/363)), eager terminal status events ([#376](https://github.com/alchemy-run/alchemy/pull/376))
+- **[Dillon Mulroy](https://github.com/dmmulroy)** — DO methods receive Worker env ([#369](https://github.com/alchemy-run/alchemy/pull/369))
+- **[Juliaan](https://github.com/Juliaan)** — `Redacted` across sidecar RPC ([#356](https://github.com/alchemy-run/alchemy/pull/356))
 
 ## Where to go next
 
 - [Effect HTTP API guide](/cloudflare/apis/effect-http-api)
 - [Effect RPC guide](/cloudflare/apis/effect-rpc)
-- [CHANGELOG](https://github.com/alchemy-run/alchemy-effect/blob/main/CHANGELOG.md#v200-beta41)
-- [Compare v2.0.0-beta.40 → v2.0.0-beta.41](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.40...v2.0.0-beta.41)
+- [CHANGELOG](https://github.com/alchemy-run/alchemy/blob/main/CHANGELOG.md#v200-beta41)
+- [Compare v2.0.0-beta.40 → v2.0.0-beta.41](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.40...v2.0.0-beta.41)

--- a/website/src/content/docs/blog/2026-05-21-beta-43.md
+++ b/website/src/content/docs/blog/2026-05-21-beta-43.md
@@ -14,7 +14,7 @@ The headline is **PlanetScale** — typed `MySQLDatabase` and
 Drizzle integration that plugs straight into Cloudflare
 Hyperdrive, the same way every other Alchemy provider plugs
 into the rest of the graph.
-([#113](https://github.com/alchemy-run/alchemy-effect/pull/113))
+([#113](https://github.com/alchemy-run/alchemy/pull/113))
 
 We'll walk it end-to-end against Postgres. The MySQL deltas are
 noted along the way — the shape is one-for-one.
@@ -236,14 +236,14 @@ A `JobService` wrapping KV can now expose
 mentioning Cloudflare at all. See
 [Concepts › Layers](/infrastructure-as-effects/layers) for
 the underlying model.
-([#383](https://github.com/alchemy-run/alchemy-effect/pull/383),
-[#386](https://github.com/alchemy-run/alchemy-effect/pull/386))
+([#383](https://github.com/alchemy-run/alchemy/pull/383),
+[#386](https://github.com/alchemy-run/alchemy/pull/386))
 
 ## Where to go next
 
 - [Hyperdrive tutorial](/cloudflare/data/hyperdrive) — PlanetScale Postgres and MySQL tabs alongside Neon
 - [Drizzle tutorial](/cloudflare/data/drizzle) — `Drizzle.Schema` and deploy-driven migrations
 - [Branch from a shared database](/cloudflare/data/branch-from-shared-database) — `.ref()` as a guided tutorial
-- [PlanetScale Postgres + Drizzle example](https://github.com/alchemy-run/alchemy-effect/tree/main/examples/cloudflare-planetscale-postgres-drizzle)
-- [PlanetScale MySQL + Drizzle example](https://github.com/alchemy-run/alchemy-effect/tree/main/examples/cloudflare-planetscale-mysql-drizzle)
-- [CHANGELOG](https://github.com/alchemy-run/alchemy-effect/blob/main/CHANGELOG.md) · [v2.0.0-beta.42 → v2.0.0-beta.43](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.42...v2.0.0-beta.43)
+- [PlanetScale Postgres + Drizzle example](https://github.com/alchemy-run/alchemy/tree/main/examples/cloudflare-planetscale-postgres-drizzle)
+- [PlanetScale MySQL + Drizzle example](https://github.com/alchemy-run/alchemy/tree/main/examples/cloudflare-planetscale-mysql-drizzle)
+- [CHANGELOG](https://github.com/alchemy-run/alchemy/blob/main/CHANGELOG.md) · [v2.0.0-beta.42 → v2.0.0-beta.43](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.42...v2.0.0-beta.43)

--- a/website/src/content/docs/blog/2026-05-22-beta-44.md
+++ b/website/src/content/docs/blog/2026-05-22-beta-44.md
@@ -42,7 +42,7 @@ A couple of design notes worth knowing:
 
 Thanks **[Alex](https://github.com/agcty)** for the
 contribution.
-([#371](https://github.com/alchemy-run/alchemy-effect/pull/371))
+([#371](https://github.com/alchemy-run/alchemy/pull/371))
 
 ## Bundle analyzer for Workers
 
@@ -76,7 +76,7 @@ build: {
 Under the hood it wraps rolldown's experimental
 `bundleAnalyzerPlugin`, exported as `Bundle.bundleAnalyzerPlugin`
 for anyone composing their own bundles.
-([#405](https://github.com/alchemy-run/alchemy-effect/pull/405))
+([#405](https://github.com/alchemy-run/alchemy/pull/405))
 
 This replaces the previous `build.metafile` option, which is now removed.
 
@@ -86,7 +86,7 @@ The `Cloudflare.Artifacts.Artifacts` binding now works under
 `bun alchemy dev` — previously it was only wired up in deployed
 Workers. No code change required; existing artifact bindings
 light up locally on upgrade.
-([#419](https://github.com/alchemy-run/alchemy-effect/pull/419))
+([#419](https://github.com/alchemy-run/alchemy/pull/419))
 
 ## `RpcProvider` for more reliable local development
 
@@ -131,42 +131,42 @@ export const LocalWorkerProvider = () =>
 - **Vite-style `?raw` imports in the Worker bundler** —
   `import sql from "./schema.sql?raw"` now works, matching the
   Vite convention for inlining a file as a string
-  ([#411](https://github.com/alchemy-run/alchemy-effect/pull/411)).
+  ([#411](https://github.com/alchemy-run/alchemy/pull/411)).
 - **Local Durable Objects hardened** — fixes swapped
   `className`/`namespaceId` in the local provider output, makes
   the local `namespaceId` deterministic and independent of the
   binding name, and stops DOs declared on other Workers in the
   stack from being registered against the current Worker
-  ([#408](https://github.com/alchemy-run/alchemy-effect/pull/408)).
+  ([#408](https://github.com/alchemy-run/alchemy/pull/408)).
 - **`alchemy dev` now honors your Workers `assets` config** —
   the configured asset behavior was previously ignored in local
   dev
-  ([#403](https://github.com/alchemy-run/alchemy-effect/pull/403)).
+  ([#403](https://github.com/alchemy-run/alchemy/pull/403)).
 - **`mysql2` no longer errors at bundle time** in the Worker
   bundler
-  ([#403](https://github.com/alchemy-run/alchemy-effect/pull/403)).
+  ([#403](https://github.com/alchemy-run/alchemy/pull/403)).
 - **`x-forwarded-for` and `x-forwarded-proto` headers** are now
   forwarded on incoming requests in `alchemy dev`
-  ([#403](https://github.com/alchemy-run/alchemy-effect/pull/403)).
+  ([#403](https://github.com/alchemy-run/alchemy/pull/403)).
 - **Rolldown bumped to 1.0.1 stable** — out of pre-release
-  ([#409](https://github.com/alchemy-run/alchemy-effect/pull/409)).
+  ([#409](https://github.com/alchemy-run/alchemy/pull/409)).
 - **`@alchemy.run/node-utils` import resolution fix** — resolves
   an ESM resolution error on Node
-  ([#406](https://github.com/alchemy-run/alchemy-effect/pull/406)).
+  ([#406](https://github.com/alchemy-run/alchemy/pull/406)).
 - **CLI filters Bun's "not in project directory" watcher warning** —
   no more spurious warnings during dev. Thanks
   **[Michael K](https://github.com/michaelkleene)**
-  ([#124](https://github.com/alchemy-run/alchemy-effect/pull/124)).
+  ([#124](https://github.com/alchemy-run/alchemy/pull/124)).
 
 ## Contributors
 
 Thanks to everyone who shipped code in this beta:
 
-- **[Alex](https://github.com/agcty)** — `Cloudflare.Zaraz.Config` ([#371](https://github.com/alchemy-run/alchemy-effect/pull/371))
-- **[Michael K](https://github.com/michaelkleene)** — CLI watcher warning filter ([#124](https://github.com/alchemy-run/alchemy-effect/pull/124))
-- **[sam](https://github.com/samgoodwin)** — privacy page styling cleanup ([#398](https://github.com/alchemy-run/alchemy-effect/pull/398))
+- **[Alex](https://github.com/agcty)** — `Cloudflare.Zaraz.Config` ([#371](https://github.com/alchemy-run/alchemy/pull/371))
+- **[Michael K](https://github.com/michaelkleene)** — CLI watcher warning filter ([#124](https://github.com/alchemy-run/alchemy/pull/124))
+- **[sam](https://github.com/samgoodwin)** — privacy page styling cleanup ([#398](https://github.com/alchemy-run/alchemy/pull/398))
 
 ## Where to go next
 
-- [CHANGELOG](https://github.com/alchemy-run/alchemy-effect/blob/main/CHANGELOG.md#v200-beta44)
-- [Compare v2.0.0-beta.43 → v2.0.0-beta.44](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.43...v2.0.0-beta.44)
+- [CHANGELOG](https://github.com/alchemy-run/alchemy/blob/main/CHANGELOG.md#v200-beta44)
+- [Compare v2.0.0-beta.43 → v2.0.0-beta.44](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.43...v2.0.0-beta.44)

--- a/website/src/content/docs/blog/2026-05-29-beta-45.md
+++ b/website/src/content/docs/blog/2026-05-29-beta-45.md
@@ -66,7 +66,7 @@ One footgun to internalize: a `Config` only `yield*`ed inside
 `fetch` is **never bound**, because `fetch` doesn't run during
 deploy. Always resolve it in the outer Init `Effect.gen` and
 capture it in a `const`.
-([#445](https://github.com/alchemy-run/alchemy-effect/pull/445))
+([#445](https://github.com/alchemy-run/alchemy/pull/445))
 
 Relatedly, **`WorkerProps.bindings` collapses into
 `WorkerProps.env`** — there's now one place to declare a Worker's
@@ -95,7 +95,7 @@ export const Worker = Cloudflare.Worker("Worker", {
 });
 ```
 
-([#446](https://github.com/alchemy-run/alchemy-effect/pull/446))
+([#446](https://github.com/alchemy-run/alchemy/pull/446))
 
 ## `Cloudflare.RpcWorker`
 
@@ -164,7 +164,7 @@ The full walkthrough — schema, handlers, deploy, integration
 test, cross-Worker binding, and the modular `Class.make(impl)`
 form — lives in the new
 [RpcWorker tutorial](/cloudflare/compute/workers#schemaless-rpc).
-([#387](https://github.com/alchemy-run/alchemy-effect/pull/387))
+([#387](https://github.com/alchemy-run/alchemy/pull/387))
 
 ## `Cloudflare.RpcDurableObject`
 
@@ -235,35 +235,35 @@ caller's bundle.
 The [RpcDurableObject tutorial](/cloudflare/compute/durable-objects#schemaless-rpc)
 covers the single-DO flow, the modular split, and cross-script
 binding.
-([#388](https://github.com/alchemy-run/alchemy-effect/pull/388))
+([#388](https://github.com/alchemy-run/alchemy/pull/388))
 
 ## Also in this release
 
 - **`Cloudflare` Browser Rendering binding** — bind headless
   Chrome to a Worker. Thanks
   **[Alex](https://github.com/agcty)**
-  ([#372](https://github.com/alchemy-run/alchemy-effect/pull/372)).
+  ([#372](https://github.com/alchemy-run/alchemy/pull/372)).
 - **Cross-script Durable Object binding** — the primitive under
   `RpcDurableObject`'s `Class.from(Worker)`
-  ([#435](https://github.com/alchemy-run/alchemy-effect/pull/435)).
+  ([#435](https://github.com/alchemy-run/alchemy/pull/435)).
 - **`Random.KeyPair` resource** — a managed public/private key
   pair
-  ([#441](https://github.com/alchemy-run/alchemy-effect/pull/441)).
+  ([#441](https://github.com/alchemy-run/alchemy/pull/441)).
 - **`timeout` on `FunctionProps`** — set AWS Lambda timeout
   declaratively
-  ([#440](https://github.com/alchemy-run/alchemy-effect/pull/440)).
+  ([#440](https://github.com/alchemy-run/alchemy/pull/440)).
 - **`Cloudflare.Queues.Queue` accepts `Duration.Input`** for time props
   on `messages()` — `"30 seconds"` instead of raw seconds
-  ([#443](https://github.com/alchemy-run/alchemy-effect/pull/443)).
+  ([#443](https://github.com/alchemy-run/alchemy/pull/443)).
 - **Workflows, AnalyticsEngine + SendEmail, and custom ports in
   `alchemy dev`** — more bindings light up locally. Thanks
   **[John Royal](https://github.com/jdrydn)**
-  ([#449](https://github.com/alchemy-run/alchemy-effect/pull/449),
-  [#460](https://github.com/alchemy-run/alchemy-effect/pull/460),
-  [#469](https://github.com/alchemy-run/alchemy-effect/pull/469)).
+  ([#449](https://github.com/alchemy-run/alchemy/pull/449),
+  [#460](https://github.com/alchemy-run/alchemy/pull/460),
+  [#469](https://github.com/alchemy-run/alchemy/pull/469)).
 - **`Worker.url` infers the canonical URL** and preserves domain
   order. Thanks **[Michael K](https://github.com/michaelkleene)**
-  ([#432](https://github.com/alchemy-run/alchemy-effect/pull/432)).
+  ([#432](https://github.com/alchemy-run/alchemy/pull/432)).
 
 A batch of dev-server and bundler fixes also landed — reconciling
 the Worker preview subdomain, websocket upgrades in vite dev,
@@ -276,5 +276,5 @@ types. See the changelog for the full list.
 - [RpcWorker tutorial](/cloudflare/compute/workers#schemaless-rpc)
 - [RpcDurableObject tutorial](/cloudflare/compute/durable-objects#schemaless-rpc)
 - [Effect RPC guide](/cloudflare/apis/effect-rpc)
-- [CHANGELOG](https://github.com/alchemy-run/alchemy-effect/blob/main/CHANGELOG.md#v200-beta45)
-- [Compare v2.0.0-beta.44 → v2.0.0-beta.45](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.44...v2.0.0-beta.45)
+- [CHANGELOG](https://github.com/alchemy-run/alchemy/blob/main/CHANGELOG.md#v200-beta45)
+- [Compare v2.0.0-beta.44 → v2.0.0-beta.45](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.44...v2.0.0-beta.45)

--- a/website/src/content/docs/blog/2026-05-31-beta-46.md
+++ b/website/src/content/docs/blog/2026-05-31-beta-46.md
@@ -100,7 +100,7 @@ type, or parent index replaces them.
 Thanks **[David J. Felix](https://github.com/DavidJFelix)** and
 **[John Royal](https://github.com/jdrydn)** for the
 contribution.
-([#407](https://github.com/alchemy-run/alchemy-effect/pull/407))
+([#407](https://github.com/alchemy-run/alchemy/pull/407))
 
 ## Fix: state-store bootstrap no longer rotates your keys
 
@@ -134,10 +134,10 @@ The same change hardens a few adjacent failure modes:
 - **Missing store recovers** — if the profile thinks the state
   store exists but it's actually gone, it's recreated.
 
-([#477](https://github.com/alchemy-run/alchemy-effect/pull/477))
+([#477](https://github.com/alchemy-run/alchemy/pull/477))
 
 ## Where to go next
 
 - [Vectorize on Cloudflare](https://developers.cloudflare.com/vectorize/)
-- [CHANGELOG](https://github.com/alchemy-run/alchemy-effect/blob/main/CHANGELOG.md#v200-beta46)
-- [Compare v2.0.0-beta.45 → v2.0.0-beta.46](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.45...v2.0.0-beta.46)
+- [CHANGELOG](https://github.com/alchemy-run/alchemy/blob/main/CHANGELOG.md#v200-beta46)
+- [Compare v2.0.0-beta.45 → v2.0.0-beta.46](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.45...v2.0.0-beta.46)

--- a/website/src/content/docs/blog/2026-06-01-beta-47.md
+++ b/website/src/content/docs/blog/2026-06-01-beta-47.md
@@ -71,7 +71,7 @@ The [Effect AI guide](/cloudflare/ai/effect-ai) covers the provider
 pattern (reading keys with `Config.redacted`, chat persistence),
 and the [AI Gateway tutorial](/cloudflare/ai/ai-gateway)
 walks the gateway end to end including streaming.
-([#389](https://github.com/alchemy-run/alchemy-effect/pull/389))
+([#389](https://github.com/alchemy-run/alchemy/pull/389))
 
 ## Implicit Worker and Durable Object RPC can return a `Stream`
 
@@ -128,7 +128,7 @@ and crashed with `Fiber.runLoop: Not a valid effect`; the fix
 lifts it into the success channel in both `WorkerBridge` and
 `DurableObjectBridge`.
 
-([#478](https://github.com/alchemy-run/alchemy-effect/pull/478))
+([#478](https://github.com/alchemy-run/alchemy/pull/478))
 
 ## Also in this release
 
@@ -137,16 +137,16 @@ lifts it into the success channel in both `WorkerBridge` and
   `Config` or build the state store before auth was configured,
   bricking the flow). Providers/state are now read statically and
   state-store init is deferred until actually used
-  ([#492](https://github.com/alchemy-run/alchemy-effect/pull/492)).
+  ([#492](https://github.com/alchemy-run/alchemy/pull/492)).
 - **`props.env` works in local Workers** — `Config` values
   declared via `env` weren't being wired into the local Worker
   provider under `alchemy dev`. Thanks
   **[John Royal](https://github.com/jdrydn)**
-  ([#473](https://github.com/alchemy-run/alchemy-effect/pull/473)).
+  ([#473](https://github.com/alchemy-run/alchemy/pull/473)).
 
 ## Where to go next
 
 - [Effect AI guide](/cloudflare/ai/effect-ai)
 - [AI Gateway tutorial](/cloudflare/ai/ai-gateway)
-- [CHANGELOG](https://github.com/alchemy-run/alchemy-effect/blob/main/CHANGELOG.md#v200-beta47)
-- [Compare v2.0.0-beta.46 → v2.0.0-beta.47](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.46...v2.0.0-beta.47)
+- [CHANGELOG](https://github.com/alchemy-run/alchemy/blob/main/CHANGELOG.md#v200-beta47)
+- [Compare v2.0.0-beta.46 → v2.0.0-beta.47](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.46...v2.0.0-beta.47)

--- a/website/src/content/docs/blog/2026-06-01-beta-48.md
+++ b/website/src/content/docs/blog/2026-06-01-beta-48.md
@@ -48,7 +48,7 @@ This also adds `Resource(type, { defaultRemovalPolicy })` so a
 resource type can flip the engine's destroy-by-default (`Zone`
 uses `"retain"`), and `destroy()` / `retain()` now default to
 `true` when called with no argument.
-([#493](https://github.com/alchemy-run/alchemy-effect/pull/493))
+([#493](https://github.com/alchemy-run/alchemy/pull/493))
 
 ## Tunnel bindings
 
@@ -150,7 +150,7 @@ export const Worker = Cloudflare.Worker("Worker", {
 
 Thanks **[Alex](https://github.com/agcty)** for the
 contribution.
-([#238](https://github.com/alchemy-run/alchemy-effect/pull/238))
+([#238](https://github.com/alchemy-run/alchemy/pull/238))
 
 ## `alchemy cloudflare create-token`
 
@@ -173,32 +173,32 @@ the authenticating credential holds, it authenticates with the
 account's Global API Key (`CLOUDFLARE_API_KEY` / `CLOUDFLARE_EMAIL`,
 or prompted). See the
 [CLI guide](/cli/cloudflare) for the full command.
-([#496](https://github.com/alchemy-run/alchemy-effect/pull/496))
+([#496](https://github.com/alchemy-run/alchemy/pull/496))
 
 ## Also in this release
 
 - **`Cloudflare.BrowserRendering` renamed to `Cloudflare.Browser`** —
   along with the matching binding/client/error exports
-  ([#503](https://github.com/alchemy-run/alchemy-effect/pull/503)).
+  ([#503](https://github.com/alchemy-run/alchemy/pull/503)).
 - **Yieldable binding markers** — `Browser`, `Images`, and
   `DynamicWorkerLoader` can be `yield*`ed directly inside an
   effect-native Worker to attach the binding and get the client in
   one step
-  ([#498](https://github.com/alchemy-run/alchemy-effect/pull/498),
-  [#501](https://github.com/alchemy-run/alchemy-effect/pull/501),
-  [#505](https://github.com/alchemy-run/alchemy-effect/pull/505)).
+  ([#498](https://github.com/alchemy-run/alchemy/pull/498),
+  [#501](https://github.com/alchemy-run/alchemy/pull/501),
+  [#505](https://github.com/alchemy-run/alchemy/pull/505)).
 - **Providers docs refocused** — a new Bindings section and the
   Providers page now centers on the lifecycle interface
-  ([#502](https://github.com/alchemy-run/alchemy-effect/pull/502)).
+  ([#502](https://github.com/alchemy-run/alchemy/pull/502)).
 - **`Zone` leans on error tags** — distilled bumped to `0.22.3`
   for the `ZoneAlreadyExists` tag, replacing brittle
   error-message matching; the same distilled bump widened
   generated enums to open unions, narrowed back at the API
   boundary across several providers
-  ([#507](https://github.com/alchemy-run/alchemy-effect/pull/507)).
+  ([#507](https://github.com/alchemy-run/alchemy/pull/507)).
 
 ## Where to go next
 
 - [CLI guide](/cli)
-- [CHANGELOG](https://github.com/alchemy-run/alchemy-effect/blob/main/CHANGELOG.md#v200-beta48)
-- [Compare v2.0.0-beta.47 → v2.0.0-beta.48](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.47...v2.0.0-beta.48)
+- [CHANGELOG](https://github.com/alchemy-run/alchemy/blob/main/CHANGELOG.md#v200-beta48)
+- [Compare v2.0.0-beta.47 → v2.0.0-beta.48](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.47...v2.0.0-beta.48)

--- a/website/src/content/docs/blog/2026-06-01-beta-49.md
+++ b/website/src/content/docs/blog/2026-06-01-beta-49.md
@@ -71,7 +71,7 @@ resources: {
 ```
 :::
 
-([#511](https://github.com/alchemy-run/alchemy-effect/pull/511))
+([#511](https://github.com/alchemy-run/alchemy/pull/511))
 
 ## `Output.flatMap`
 
@@ -98,7 +98,7 @@ output.flatMap(fn); // FlatMapExpr
 
 Like the other combinators, `flatMap` short-circuits while its
 source is unresolved, so it composes cleanly in the deploy graph.
-([#512](https://github.com/alchemy-run/alchemy-effect/pull/512))
+([#512](https://github.com/alchemy-run/alchemy/pull/512))
 
 ## The `secret_text` fix in detail
 
@@ -107,7 +107,7 @@ Two related changes land the fix:
 - **Yielded `Config` always binds as `secret_text`** — the
   Worker now records every `Config` resolved in Init as a secret
   binding, so a value can't slip through as plain text
-  ([#510](https://github.com/alchemy-run/alchemy-effect/pull/510)).
+  ([#510](https://github.com/alchemy-run/alchemy/pull/510)).
 - **Don't unwrap non-redacted values** — when reading a bound
   value back at runtime, Alchemy now only calls `Redacted.value`
   on values that are actually `Redacted`, leaving plain values
@@ -117,5 +117,5 @@ Two related changes land the fix:
 
 - [Concepts › Secrets and Config](/environments/secrets)
 - [beta.48 — Tunnel bindings](/blog/2026-06-01-beta-48)
-- [CHANGELOG](https://github.com/alchemy-run/alchemy-effect/blob/main/CHANGELOG.md#v200-beta49)
-- [Compare v2.0.0-beta.48 → v2.0.0-beta.49](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.48...v2.0.0-beta.49)
+- [CHANGELOG](https://github.com/alchemy-run/alchemy/blob/main/CHANGELOG.md#v200-beta49)
+- [Compare v2.0.0-beta.48 → v2.0.0-beta.49](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.48...v2.0.0-beta.49)

--- a/website/src/content/docs/blog/2026-06-01-beta-50.md
+++ b/website/src/content/docs/blog/2026-06-01-beta-50.md
@@ -17,7 +17,7 @@ a random port and places a `WorkerProxy` in front of it, so ports
 are assigned deterministically and conflicts are actually
 detected. The conflict detection and `WorkerProxy` implementation
 in `cloudflare-runtime` were both tightened up along the way.
-([#513](https://github.com/alchemy-run/alchemy-effect/pull/513))
+([#513](https://github.com/alchemy-run/alchemy/pull/513))
 
 ## Binding an `Output` into a Worker's `env`
 
@@ -41,9 +41,9 @@ const website = yield* Cloudflare.Website.Vite("Website", {
 `RuntimeContext`, which doesn't exist at deploy time. beta.50
 checks whether the value is an `Output` before yielding, so
 output references thread through to runtime as intended.
-([#514](https://github.com/alchemy-run/alchemy-effect/pull/514))
+([#514](https://github.com/alchemy-run/alchemy/pull/514))
 
 ## Where to go next
 
-- [CHANGELOG](https://github.com/alchemy-run/alchemy-effect/blob/main/CHANGELOG.md#v200-beta50)
-- [Compare v2.0.0-beta.49 → v2.0.0-beta.50](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.49...v2.0.0-beta.50)
+- [CHANGELOG](https://github.com/alchemy-run/alchemy/blob/main/CHANGELOG.md#v200-beta50)
+- [Compare v2.0.0-beta.49 → v2.0.0-beta.50](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.49...v2.0.0-beta.50)

--- a/website/src/content/docs/blog/2026-06-02-beta-51.md
+++ b/website/src/content/docs/blog/2026-06-02-beta-51.md
@@ -17,7 +17,7 @@ custom rules, redirects, or any of Cloudflare's ruleset phases.
 Pass a `Zone`, a `phase`, and the rules; the resource reconciles
 the entire phase entrypoint. Thanks
 **[Alex](https://github.com/agcty)**
-([#240](https://github.com/alchemy-run/alchemy-effect/pull/240)).
+([#240](https://github.com/alchemy-run/alchemy/pull/240)).
 
 ```typescript
 const zone = yield* Cloudflare.Zone("MyZone", { name: "example.com" });
@@ -49,7 +49,7 @@ Durable Object's `state.storage`. Drop it under
 `Chat.makePersisted({ storeId })` and chat history lives in the
 DO's SQLite store — surviving hibernation and eviction — with
 `${storeId}:` key namespacing so multiple stores coexist in one DO
-([#390](https://github.com/alchemy-run/alchemy-effect/pull/390)).
+([#390](https://github.com/alchemy-run/alchemy/pull/390)).
 
 One DO instance == one persisted conversation thread:
 
@@ -99,7 +99,7 @@ Lambda permission used the invalid action string
 are fixed, and the notification props gained `prefix` / `suffix`
 key filters (mapped to S3 `FilterRules`). Thanks
 **[Andrey Konopkov](https://github.com/konopkov)**
-([#470](https://github.com/alchemy-run/alchemy-effect/pull/470)).
+([#470](https://github.com/alchemy-run/alchemy/pull/470)).
 
 ```typescript
 yield* S3.notifications(bucket, {
@@ -130,7 +130,7 @@ requiring `never`. Reading configuration with `Config.string` in a
 stack body previously forced an `Effect.orDie` wrapper; now it
 type-checks directly and the `ConfigError` surfaces on the
 resulting effect
-([#487](https://github.com/alchemy-run/alchemy-effect/pull/487)).
+([#487](https://github.com/alchemy-run/alchemy/pull/487)).
 
 ```diff lang="typescript"
  const stack = Alchemy.Stack(
@@ -149,27 +149,27 @@ resulting effect
 - **Resource-scoped `adopt(...)` is honored by the planner** —
   `.pipe(adopt(true))` on a resource overrides the stack/CLI-wide
   adopt default, in both directions
-  ([#521](https://github.com/alchemy-run/alchemy-effect/pull/521)).
+  ([#521](https://github.com/alchemy-run/alchemy/pull/521)).
 - **`Cloudflare.SecretsStore.Secret` works in a Worker's `env`** —
   the provider maps it to a native `secrets_store_secret` binding,
   so the runtime sees a real `SecretsStoreSecret` with `.get()`
-  ([#475](https://github.com/alchemy-run/alchemy-effect/pull/475)).
+  ([#475](https://github.com/alchemy-run/alchemy/pull/475)).
 - **Drizzle `Schema` preserves snapshot lineage** — the previous
   snapshot id is passed to `generateDrizzleJson` when generating
   migrations. Thanks
   **[Julius Marminge](https://github.com/juliusmarminge)**
-  ([#519](https://github.com/alchemy-run/alchemy-effect/pull/519)).
+  ([#519](https://github.com/alchemy-run/alchemy/pull/519)).
 - **Outputs are identified by symbol, not a duck-typed `kind`
   property** — user data containing a `kind` field is no longer
   misclassified as an Output expression. Thanks
   **[Julius Marminge](https://github.com/juliusmarminge)**
-  ([#517](https://github.com/alchemy-run/alchemy-effect/pull/517)).
+  ([#517](https://github.com/alchemy-run/alchemy/pull/517)).
 - **PlanetScale MySQL/Postgres Database outputs drop the `kind`
   attribute** that collided with the output proxy discriminator
-  ([#518](https://github.com/alchemy-run/alchemy-effect/pull/518)).
+  ([#518](https://github.com/alchemy-run/alchemy/pull/518)).
 - **Website: the theme toggle no longer collides with the mobile
   hamburger menu**
-  ([#499](https://github.com/alchemy-run/alchemy-effect/pull/499)).
+  ([#499](https://github.com/alchemy-run/alchemy/pull/499)).
 
 ## Where to go next
 
@@ -177,5 +177,5 @@ resulting effect
 - [AI Gateway tutorial](/cloudflare/ai/ai-gateway)
 - [S3 Events tutorial](/aws/messaging/s3-events)
 - [Concepts › Stack](/infrastructure-as-code/stack)
-- [CHANGELOG](https://github.com/alchemy-run/alchemy-effect/blob/main/CHANGELOG.md#v200-beta51)
-- [Compare v2.0.0-beta.50 → v2.0.0-beta.51](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.50...v2.0.0-beta.51)
+- [CHANGELOG](https://github.com/alchemy-run/alchemy/blob/main/CHANGELOG.md#v200-beta51)
+- [Compare v2.0.0-beta.50 → v2.0.0-beta.51](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.50...v2.0.0-beta.51)

--- a/website/src/content/docs/blog/2026-06-05-beta-52.md
+++ b/website/src/content/docs/blog/2026-06-05-beta-52.md
@@ -16,14 +16,14 @@ Effects, and `Vite` / `StaticSite` gain the same class form as
 **Breaking changes:**
 
 - **`props.assets` is one flat shape** across `Worker`, `StaticSite`,
-  and `Vite` ([#534](https://github.com/alchemy-run/alchemy-effect/pull/534)).
+  and `Vite` ([#534](https://github.com/alchemy-run/alchemy/pull/534)).
   Asset-routing options move up a level: `assets.config.runWorkerFirst`
   becomes `assets.runWorkerFirst`, StaticSite's `assetsConfig` prop is
   renamed to `assets`, and the prebuilt form `{ path, hash, config }`
   becomes `{ directory, hash, ...config }`. Migration is a one-level
   un-nesting — see the diff below.
 - **effect peer dependency bumped to `4.0.0-beta.78`**
-  ([#542](https://github.com/alchemy-run/alchemy-effect/pull/542)) —
+  ([#542](https://github.com/alchemy-run/alchemy/pull/542)) —
   update your project's `effect` version to match.
 :::
 
@@ -68,7 +68,7 @@ console.log(dev.url); // e.g. "http://localhost:5173"
 
 For servers that don't print a URL, StaticSite's `dev.url` prop sets
 it explicitly.
-([#537](https://github.com/alchemy-run/alchemy-effect/pull/537))
+([#537](https://github.com/alchemy-run/alchemy/pull/537))
 
 ## One `assets` shape everywhere
 
@@ -93,7 +93,7 @@ routing options like `runWorkerFirst`, `htmlHandling`, and
 ```
 
 For `StaticSite`, rename the `assetsConfig:` key to `assets:`.
-([#534](https://github.com/alchemy-run/alchemy-effect/pull/534))
+([#534](https://github.com/alchemy-run/alchemy/pull/534))
 
 ## Effect-native Browser quick actions
 
@@ -120,7 +120,7 @@ const png = yield* browser.screenshot({ url }).pipe(Stream.runCollect);
 Provide `Cloudflare.BrowserBindingLive` on the Worker's init Effect.
 `raw` and `fetch` remain as escape hatches for promise-based
 libraries like `@cloudflare/puppeteer`.
-([#525](https://github.com/alchemy-run/alchemy-effect/pull/525))
+([#525](https://github.com/alchemy-run/alchemy/pull/525))
 
 ## Class form for Vite and StaticSite
 
@@ -147,7 +147,7 @@ const site = yield* Website;
 ```
 
 The `cloudflare-tanstack` example uses it.
-([#527](https://github.com/alchemy-run/alchemy-effect/pull/527))
+([#527](https://github.com/alchemy-run/alchemy/pull/527))
 
 ## Also in this release
 
@@ -156,36 +156,36 @@ The `cloudflare-tanstack` example uses it.
   accessor for the deployed version's `id`, `tag`, and `timestamp`;
   also declarable on `env`. Thanks
   **[Alex](https://github.com/agcty)**
-  ([#524](https://github.com/alchemy-run/alchemy-effect/pull/524)).
+  ([#524](https://github.com/alchemy-run/alchemy/pull/524)).
 - **Workflow runs get a per-invocation `ExecutionContext`** (scope +
   cache), so binding helpers like `Drizzle.postgres` resolve inside
   workflow steps just like in a fetch or queue handler. Thanks
   **[Saatvik Arya](https://github.com/aryasaatvik)**
-  ([#515](https://github.com/alchemy-run/alchemy-effect/pull/515)).
+  ([#515](https://github.com/alchemy-run/alchemy/pull/515)).
 - **`retain` removal policy is honored on replace** — the old
   generation of a replaced resource is retained, not just orphan
-  deletes ([#548](https://github.com/alchemy-run/alchemy-effect/pull/548)).
+  deletes ([#548](https://github.com/alchemy-run/alchemy/pull/548)).
 - **Changing a `Redacted` config/secret value now triggers an
   update** — redacted wrappers are unwrapped during diffing
-  ([#549](https://github.com/alchemy-run/alchemy-effect/pull/549)).
+  ([#549](https://github.com/alchemy-run/alchemy/pull/549)).
 - **Local dev fixes** — the assets binding is populated for Vite
-  websites ([#547](https://github.com/alchemy-run/alchemy-effect/pull/547)),
+  websites ([#547](https://github.com/alchemy-run/alchemy/pull/547)),
   cross-script Durable Object bindings work
-  ([#540](https://github.com/alchemy-run/alchemy-effect/pull/540)),
+  ([#540](https://github.com/alchemy-run/alchemy/pull/540)),
   and multi-worker dev is more reliable in bun
-  ([#535](https://github.com/alchemy-run/alchemy-effect/pull/535)).
+  ([#535](https://github.com/alchemy-run/alchemy/pull/535)).
 - **Drizzle `Schema` exposes `out` as a cwd-relative path** so
   drizzle-kit resolves migrations regardless of where alchemy runs
-  ([#551](https://github.com/alchemy-run/alchemy-effect/pull/551)).
+  ([#551](https://github.com/alchemy-run/alchemy/pull/551)).
 - **The Vite SPA tutorial documents the local dev workflow**
-  ([#526](https://github.com/alchemy-run/alchemy-effect/pull/526)).
+  ([#526](https://github.com/alchemy-run/alchemy/pull/526)).
 - **`@distilled.cloud/*` bumped to 0.23.1**
-  ([#539](https://github.com/alchemy-run/alchemy-effect/pull/539)).
+  ([#539](https://github.com/alchemy-run/alchemy/pull/539)).
 
 ## Where to go next
 
 - [Vite SPA tutorial](/cloudflare/frontend/vite-spa)
 - [Workflows tutorial](/cloudflare/compute/add-a-workflow)
 - [Concepts › Local Development](/environments/local-development)
-- [CHANGELOG](https://github.com/alchemy-run/alchemy-effect/blob/main/CHANGELOG.md#v200-beta52)
-- [Compare v2.0.0-beta.51 → v2.0.0-beta.52](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.51...v2.0.0-beta.52)
+- [CHANGELOG](https://github.com/alchemy-run/alchemy/blob/main/CHANGELOG.md#v200-beta52)
+- [Compare v2.0.0-beta.51 → v2.0.0-beta.52](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.51...v2.0.0-beta.52)

--- a/website/src/content/docs/blog/2026-06-10-beta-53.md
+++ b/website/src/content/docs/blog/2026-06-10-beta-53.md
@@ -22,12 +22,12 @@ prop too.
   Environment Variables, or Stored. Under CI the Environment
   Variables method is selected automatically, so
   `aws-actions/configure-aws-credentials` pipelines keep working
-  ([#574](https://github.com/alchemy-run/alchemy-effect/pull/574)).
+  ([#574](https://github.com/alchemy-run/alchemy/pull/574)).
 - **`AWSEnvironment` is now lazy.** The service holds an
   `Effect<AWSEnvironmentShape>` — read it with
   `yield* AWSEnvironment.current` instead of `yield* AWSEnvironment`.
   `AWSEnvironment.makeEnvironment` and `loadDefault` are removed
-  ([#567](https://github.com/alchemy-run/alchemy-effect/pull/567)).
+  ([#567](https://github.com/alchemy-run/alchemy/pull/567)).
 :::
 
 ## AWS auth through `alchemy login`
@@ -47,10 +47,10 @@ Your AWS account ID is captured automatically via
 `STS.GetCallerIdentity` and saved on the profile — the Stored method
 detects it from the keys you paste, and the Environment Variables
 method falls back to STS when `AWS_ACCOUNT_ID` isn't exported
-([#574](https://github.com/alchemy-run/alchemy-effect/pull/574)).
+([#574](https://github.com/alchemy-run/alchemy/pull/574)).
 
 Auth providers are also evaluated **lazily** now
-([#567](https://github.com/alchemy-run/alchemy-effect/pull/567)).
+([#567](https://github.com/alchemy-run/alchemy/pull/567)).
 Credentials resolve the first time a resource actually needs them —
 a stack that touches no AWS resources never prompts for AWS auth.
 Inside lifecycle operations, the environment is read through the new
@@ -66,7 +66,7 @@ reconcile: Effect.fn(function* ({ id, news }) {
 
 Rounding it out, `alchemy login` always refreshes credentials instead
 of short-circuiting on a non-expired cache
-([#575](https://github.com/alchemy-run/alchemy-effect/pull/575)), and
+([#575](https://github.com/alchemy-run/alchemy/pull/575)), and
 `--configure` no longer runs a redundant login pass after the
 interactive setup completes.
 
@@ -76,7 +76,7 @@ interactive setup completes.
 read secrets and variables inside a Worker's init. beta.53 completes
 the picture: `Config` values are resolved in **resource input props**
 — at the top level or nested anywhere inside objects and arrays
-([#566](https://github.com/alchemy-run/alchemy-effect/pull/566)).
+([#566](https://github.com/alchemy-run/alchemy/pull/566)).
 
 ```typescript
 export default class EffectWorker extends Cloudflare.Worker<EffectWorker>()(
@@ -105,27 +105,27 @@ stays wrapped end to end, preserving the secrecy boundary. See
 Two dev-server fixes land via `@distilled.cloud/cloudflare-runtime`
 bumps (0.10.5 → 0.10.11): a race condition when a stack runs more
 than one Workflow in `alchemy dev`
-([#573](https://github.com/alchemy-run/alchemy-effect/pull/573)), and
+([#573](https://github.com/alchemy-run/alchemy/pull/573)), and
 incorrect Vite handling of `require()` of Node built-ins in Worker
-code ([#556](https://github.com/alchemy-run/alchemy-effect/pull/556)).
+code ([#556](https://github.com/alchemy-run/alchemy/pull/556)).
 
 ## Also in this release
 
 - **R2 custom-domain updates ride out `NoSuchBucket`** during R2's
   endpoint eventual-consistency window — including when a create
   loses a race and the winning bucket isn't readable yet
-  ([448ba756](https://github.com/alchemy-run/alchemy-effect/commit/448ba756)).
+  ([448ba756](https://github.com/alchemy-run/alchemy/commit/448ba756)).
 - **Narrowed S3 bucket tag-fetch requirements** to
   `Credentials | HttpClient | Region`. Thanks
   **[Kilian Cirera Sant](https://github.com/kiliancs)**
-  ([#555](https://github.com/alchemy-run/alchemy-effect/pull/555)).
+  ([#555](https://github.com/alchemy-run/alchemy/pull/555)).
 - **Fixed Worker static-assets bundling** by switching to a named
   import of `@alchemy.run/node-utils/ignore`
-  ([#572](https://github.com/alchemy-run/alchemy-effect/pull/572)).
+  ([#572](https://github.com/alchemy-run/alchemy/pull/572)).
 - **Added a missing permission to
   [Tutorial Part 5](/cloudflare/tutorial/part-5)**. Thanks
   **[David J. Felix](https://github.com/DavidJFelix)**
-  ([#560](https://github.com/alchemy-run/alchemy-effect/pull/560)).
+  ([#560](https://github.com/alchemy-run/alchemy/pull/560)).
 
 ## Where to go next
 
@@ -133,5 +133,5 @@ code ([#556](https://github.com/alchemy-run/alchemy-effect/pull/556)).
 - [Concepts › Secrets and Config](/environments/secrets)
 - [Concepts › Local Development](/environments/local-development)
 - [Guides › CLI](/cli)
-- [CHANGELOG](https://github.com/alchemy-run/alchemy-effect/blob/main/CHANGELOG.md#v200-beta53)
-- [Compare v2.0.0-beta.52 → v2.0.0-beta.53](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.52...v2.0.0-beta.53)
+- [CHANGELOG](https://github.com/alchemy-run/alchemy/blob/main/CHANGELOG.md#v200-beta53)
+- [Compare v2.0.0-beta.52 → v2.0.0-beta.53](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.52...v2.0.0-beta.53)

--- a/website/src/content/docs/blog/2026-06-10-beta-54.md
+++ b/website/src/content/docs/blog/2026-06-10-beta-54.md
@@ -15,7 +15,7 @@ consumer handler fires locally, no Cloudflare round-trip.
 
 One Worker, both halves: `Cloudflare.Queue.bind` gives you the
 producer, `Cloudflare.messages(queue).subscribe` registers the
-consumer ([#571](https://github.com/alchemy-run/alchemy-effect/pull/571)):
+consumer ([#571](https://github.com/alchemy-run/alchemy/pull/571)):
 
 ```typescript
 export default class MyWorker extends Cloudflare.Worker<MyWorker>()(
@@ -67,18 +67,18 @@ config reconciles like everything else.
 - **`alchemy dev` no longer requires Cloudflare credentials at
   startup** — the local runtime resolves the account ID lazily, only
   when a live API call actually needs it
-  ([#578](https://github.com/alchemy-run/alchemy-effect/pull/578)).
+  ([#578](https://github.com/alchemy-run/alchemy/pull/578)).
 - **PlanetScale providers are more resilient to live API timing** —
   branch promote/demote retries while a cluster resize is still
   finalizing, Postgres resizes wait for the branch to finish
   provisioning first, and polling budgets grew from 10 to 30 minutes
   (60 for Postgres cluster-size changes)
-  ([#576](https://github.com/alchemy-run/alchemy-effect/pull/576)).
+  ([#576](https://github.com/alchemy-run/alchemy/pull/576)).
 
 ## Where to go next
 
 - [Tutorial Part 4: Local Dev](/cloudflare/tutorial/part-4)
 - [Consume from a Queue](/cloudflare/messaging/queues)
 - [CLI reference](/cli)
-- [CHANGELOG](https://github.com/alchemy-run/alchemy-effect/blob/main/CHANGELOG.md#v200-beta54)
-- [Compare v2.0.0-beta.53 → v2.0.0-beta.54](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.53...v2.0.0-beta.54)
+- [CHANGELOG](https://github.com/alchemy-run/alchemy/blob/main/CHANGELOG.md#v200-beta54)
+- [Compare v2.0.0-beta.53 → v2.0.0-beta.54](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.53...v2.0.0-beta.54)

--- a/website/src/content/docs/blog/2026-06-11-beta-55.md
+++ b/website/src/content/docs/blog/2026-06-11-beta-55.md
@@ -58,7 +58,7 @@ bootstrap only.
 One caveat: Cloudflare stores a **single limit per account**, so this
 resource is a per-account singleton — declare exactly one. Thanks
 **[Matthew Aylward](https://github.com/Butch78)**
-([#569](https://github.com/alchemy-run/alchemy-effect/pull/569)).
+([#569](https://github.com/alchemy-run/alchemy/pull/569)).
 
 ## Fetcher utils on `alchemy/Cloudflare/Bridge`
 
@@ -67,7 +67,7 @@ The fetcher/socket interop helpers — `fromCloudflareFetcher`,
 exported from the `alchemy/Cloudflare/Bridge` entrypoint, and
 `fromCloudflareFetcher` / `fromCloudflareSocket` accept the global
 `Fetcher` / `Socket` types directly
-([#581](https://github.com/alchemy-run/alchemy-effect/pull/581)).
+([#581](https://github.com/alchemy-run/alchemy/pull/581)).
 
 That combination matters inside a framework worker (TanStack Start,
 Astro, …), where your Effect backend arrives as a plain service binding
@@ -100,11 +100,11 @@ the service binding's `fetch`, typed RPC (`toRpcAsync`), and this
   from exiting** — local `RpcProvider` service layers (`providerServices` /
   `providerServicesEffect`) now only construct when `AlchemyContext.dev`
   is set, so one-shot CLI runs no longer spin up the local dev provider
-  machinery ([#580](https://github.com/alchemy-run/alchemy-effect/pull/580))
+  machinery ([#580](https://github.com/alchemy-run/alchemy/pull/580))
 
 ## Where to go next
 
 - [Add an AI Gateway](/cloudflare/ai/ai-gateway)
 - [Frontend frameworks](/cloudflare/frontend/frontends)
-- [CHANGELOG](https://github.com/alchemy-run/alchemy-effect/blob/main/CHANGELOG.md#v200-beta55)
-- [Compare v2.0.0-beta.54 → v2.0.0-beta.55](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.54...v2.0.0-beta.55)
+- [CHANGELOG](https://github.com/alchemy-run/alchemy/blob/main/CHANGELOG.md#v200-beta55)
+- [Compare v2.0.0-beta.54 → v2.0.0-beta.55](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.54...v2.0.0-beta.55)

--- a/website/src/content/docs/blog/2026-06-17-beta-56.md
+++ b/website/src/content/docs/blog/2026-06-17-beta-56.md
@@ -6,7 +6,7 @@ excerpt: v2.0.0-beta.56 grows the Cloudflare provider from 22 resources to 230, 
 ---
 
 The Cloudflare provider grows from **22 resources to 230** in this
-release. A single PR ([#601](https://github.com/alchemy-run/alchemy-effect/pull/601))
+release. A single PR ([#601](https://github.com/alchemy-run/alchemy/pull/601))
 lands +101k lines across 542 files — 189 new live-test suites, every
 one run against a real Cloudflare account — bringing coverage to over
 a hundred Cloudflare services: Zero Trust (Access, Tunnels, Devices,
@@ -20,7 +20,7 @@ That means an entire Zero Trust deployment — tunnel, private network
 route, identity-gated application, WARP device profile — is now a
 single Effect (Zero Trust resources contributed by
 **[Andy Jefferson](https://github.com/microagi-andy)** in
-[#570](https://github.com/alchemy-run/alchemy-effect/pull/570)):
+[#570](https://github.com/alchemy-run/alchemy/pull/570)):
 
 ```typescript
 // a private network reachable only through WARP + Access
@@ -89,7 +89,7 @@ them — is in
 
 Cloudflare's Flagship feature flags land as full resources with an
 Effect-native Worker binding
-([#602](https://github.com/alchemy-run/alchemy-effect/pull/602)).
+([#602](https://github.com/alchemy-run/alchemy/pull/602)).
 Declare the app and its flags:
 
 ```typescript
@@ -135,12 +135,12 @@ raw binding.
 Providers can now implement a `list()` lifecycle operation that
 enumerates every live resource of their type in the ambient
 account/zone
-([#620](https://github.com/alchemy-run/alchemy-effect/pull/620)) —
+([#620](https://github.com/alchemy-run/alchemy/pull/620)) —
 each item returned in the same `Attributes` shape `read` produces, so
 it's directly deletable.
 
 Built on top of it: `alchemy unsafe nuke`
-([#624](https://github.com/alchemy-run/alchemy-effect/pull/624))
+([#624](https://github.com/alchemy-run/alchemy/pull/624))
 enumerates everything a profile's providers can see and deletes it
 all. With 230 resource types now enumerable, a burned test account is
 a one-liner to clean:
@@ -162,7 +162,7 @@ hidden from `--help`; it deletes real infrastructure.
 
 **[Justin Bennett](https://github.com/just-be-dev)** contributed
 `GitHub.Repository`
-([#607](https://github.com/alchemy-run/alchemy-effect/pull/607)) —
+([#607](https://github.com/alchemy-run/alchemy/pull/607)) —
 full repository lifecycle with a converging reconciler that reads by
 stable numeric id, so renaming a repo out from under the stack doesn't
 corrupt state:
@@ -178,7 +178,7 @@ const repo = yield* GitHub.Repository("internal-tools", {
 
 On top of it, `GitHub.events` turns a repository into an **event
 source** for Cloudflare Workers
-([#619](https://github.com/alchemy-run/alchemy-effect/pull/619)).
+([#619](https://github.com/alchemy-run/alchemy/pull/619)).
 Subscribing in a Worker's init provisions a `GitHub.Webhook` pointed
 at the Worker's URL; at runtime, deliveries are verified with a
 constant-time HMAC-SHA256 signature check and handed to your handler
@@ -202,7 +202,7 @@ yield* GitHub.events({
 
 AWS stacks get a first-class remote state backend, mirroring
 `Cloudflare.state()`
-([#585](https://github.com/alchemy-run/alchemy-effect/pull/585)):
+([#585](https://github.com/alchemy-run/alchemy/pull/585)):
 
 ```typescript
 const Stack = Alchemy.Stack(
@@ -228,37 +228,37 @@ layer construction.
   `rules` selecting additional modules. The working path for OpenNext
   and other externally-bundled outputs. Thanks
   **[Alex](https://github.com/agcty)**
-  ([#592](https://github.com/alchemy-run/alchemy-effect/pull/592)).
+  ([#592](https://github.com/alchemy-run/alchemy/pull/592)).
 - **`alchemy plan` starts near-instant** — 8.2s → 1.8s warm, via
   lazy-loading the TUI and vite plugin and deferring distilled schema
   construction
-  ([#618](https://github.com/alchemy-run/alchemy-effect/pull/618)).
+  ([#618](https://github.com/alchemy-run/alchemy/pull/618)).
 - **`worker.url` is stable across deploys** when the first domain is
   unchanged, so downstream resources referencing it (e.g. webhook
   delivery URLs) stop phantom-updating
-  ([#616](https://github.com/alchemy-run/alchemy-effect/pull/616));
+  ([#616](https://github.com/alchemy-run/alchemy/pull/616));
   same for `worker.durableObjectNamespaces` when the DO class set is
   unchanged
-  ([#617](https://github.com/alchemy-run/alchemy-effect/pull/617)).
+  ([#617](https://github.com/alchemy-run/alchemy/pull/617)).
 - **Lambda function URLs accept full config** —
   `url: { authType: "AWS_IAM", cors, invokeMode: "RESPONSE_STREAM" }`;
   IAM-auth URLs drop the public permission statement. Thanks
   **[José Netto](https://github.com/mineiro)**
-  ([#614](https://github.com/alchemy-run/alchemy-effect/pull/614)).
+  ([#614](https://github.com/alchemy-run/alchemy/pull/614)).
 - **`alchemy dev` stays alive when an apply fails**, logging the full
   cause instead of silently exiting. Thanks
   **[Matthew Aylward](https://github.com/Butch78)**
-  ([#582](https://github.com/alchemy-run/alchemy-effect/pull/582)).
+  ([#582](https://github.com/alchemy-run/alchemy/pull/582)).
 - **StaticSite forwards `dev.env`** (including Redacted secrets) to
   the external dev-server command. Thanks
   **[Alex](https://github.com/agcty)**
-  ([#587](https://github.com/alchemy-run/alchemy-effect/pull/587)).
+  ([#587](https://github.com/alchemy-run/alchemy/pull/587)).
 - **Local assets binding no longer 500s** in `alchemy dev`
-  ([#613](https://github.com/alchemy-run/alchemy-effect/pull/613)).
+  ([#613](https://github.com/alchemy-run/alchemy/pull/613)).
 - **Drizzle drift detection is cached** per plan/apply cycle, so
   drizzle-kit's interactive rename prompt appears once instead of
   hanging `alchemy dev`
-  ([#597](https://github.com/alchemy-run/alchemy-effect/pull/597)).
+  ([#597](https://github.com/alchemy-run/alchemy/pull/597)).
 
 ## Where to go next
 
@@ -267,5 +267,5 @@ layer construction.
 - [Concepts › State Store](/state-store)
 - [CLI guide](/cli)
 - [Deploy a Lambda Function](/aws/compute/lambda)
-- [CHANGELOG](https://github.com/alchemy-run/alchemy-effect/blob/main/CHANGELOG.md#v200-beta56)
-- [Compare v2.0.0-beta.55 → v2.0.0-beta.56](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.55...v2.0.0-beta.56)
+- [CHANGELOG](https://github.com/alchemy-run/alchemy/blob/main/CHANGELOG.md#v200-beta56)
+- [Compare v2.0.0-beta.55 → v2.0.0-beta.56](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.55...v2.0.0-beta.56)

--- a/website/src/content/docs/blog/2026-06-19-beta-57.md
+++ b/website/src/content/docs/blog/2026-06-19-beta-57.md
@@ -89,7 +89,7 @@ curl http://localhost:1338/sandbox
 Dev-created containers carry a `dev:<uuid>` application id, so a
 subsequent `alchemy deploy` knows to promote them to a real
 `ContainerApplication`
-([#636](https://github.com/alchemy-run/alchemy-effect/pull/636)).
+([#636](https://github.com/alchemy-run/alchemy/pull/636)).
 
 ## Cloudflare AI Search (AutoRAG)
 
@@ -150,12 +150,12 @@ citations come for free. The binding also works in `alchemy dev`. The
 new [AI Search tutorial](/cloudflare/ai/ai-search) walks through
 the whole pipeline, including dropping down to the underlying
 `AiSearchInstance` / `AiSearchNamespace` / `AiSearchToken` resources
-([#639](https://github.com/alchemy-run/alchemy-effect/pull/639)).
+([#639](https://github.com/alchemy-run/alchemy/pull/639)).
 
 ## An AWS coverage wave
 
 Five new resources land in one PR
-([#631](https://github.com/alchemy-run/alchemy-effect/pull/631)):
+([#631](https://github.com/alchemy-run/alchemy/pull/631)):
 CloudFront **`VpcOrigin`**, ELBv2 **`ListenerRule`** and
 **`TrustStore`** (mTLS), and Route53 **`HostedZone`** and
 **`HealthCheck`** — each with live tests.
@@ -191,14 +191,14 @@ and SQS props all deepen — about 8,700 lines in total.
 
 Thanks **José Netto** for a run of AWS contributions: new
 `AWS.KMS.Key` and `AWS.KMS.Alias` resources
-([#641](https://github.com/alchemy-run/alchemy-effect/pull/641)),
+([#641](https://github.com/alchemy-run/alchemy/pull/641)),
 a Lambda `Alias` resource
-([#625](https://github.com/alchemy-run/alchemy-effect/pull/625)),
+([#625](https://github.com/alchemy-run/alchemy/pull/625)),
 `reservedConcurrentExecutions` on Lambda `Function`
-([#628](https://github.com/alchemy-run/alchemy-effect/pull/628)),
+([#628](https://github.com/alchemy-run/alchemy/pull/628)),
 and `LogGroup` configuration — retention, KMS encryption, log class,
 and deletion protection
-([#630](https://github.com/alchemy-run/alchemy-effect/pull/630)).
+([#630](https://github.com/alchemy-run/alchemy/pull/630)).
 
 ```typescript
 const key = yield* KMS.Key("AppKey", {
@@ -251,28 +251,28 @@ account runs the full suite unchanged.
 
 - **`diff.stables` overrides `provider.stables`** — a provider's diff
   can now narrow stability per-update, fixing spurious replacements
-  ([#635](https://github.com/alchemy-run/alchemy-effect/pull/635)).
+  ([#635](https://github.com/alchemy-run/alchemy/pull/635)).
 - **Atomic local state writes** — `LocalState` writes to a temp file
   and renames, so a crash mid-write can't corrupt state.
 - **`alchemy dev` no longer watches `node_modules`**, cutting
   file-watcher churn on large projects
-  ([#646](https://github.com/alchemy-run/alchemy-effect/pull/646)).
+  ([#646](https://github.com/alchemy-run/alchemy/pull/646)).
 - **Queue consumers created in dev promote cleanly** to a real deploy
-  ([#647](https://github.com/alchemy-run/alchemy-effect/pull/647)).
+  ([#647](https://github.com/alchemy-run/alchemy/pull/647)).
 - **Local service bindings preserve their entrypoints** in dev. Thanks
   **Jonathan Beckman**
-  ([#643](https://github.com/alchemy-run/alchemy-effect/pull/643)).
+  ([#643](https://github.com/alchemy-run/alchemy/pull/643)).
 - **AI Search bindings work in local dev**. Thanks
   **Jonathan Beckman**
-  ([#642](https://github.com/alchemy-run/alchemy-effect/pull/642)).
+  ([#642](https://github.com/alchemy-run/alchemy/pull/642)).
 - **`alchemy cloudflare create-token`** can now mint user API tokens
   and interactively select permissions.
 - **`Build.Command`** handles both relative and absolute paths.
 - **`Artifacts.cached`** is allowed in the local `RpcProvider`
-  ([#648](https://github.com/alchemy-run/alchemy-effect/pull/648)).
+  ([#648](https://github.com/alchemy-run/alchemy/pull/648)).
 - **GitHub `Repository` docs** — examples for templates, rename,
   archive, and secrets. Thanks **Justin Bennett**
-  ([#629](https://github.com/alchemy-run/alchemy-effect/pull/629)).
+  ([#629](https://github.com/alchemy-run/alchemy/pull/629)).
 - **AWS lifecycle hardening** — Scheduler, SQS DLQ wiring, SNS Topic,
   CloudFront, DynamoDB, EC2, IAM, and Kinesis operations retry
   eventual consistency and throttling more robustly.
@@ -284,5 +284,5 @@ account runs the full suite unchanged.
 - [Add AI Search (AutoRAG)](/cloudflare/ai/ai-search)
 - [Run a Container](/cloudflare/compute/run-a-container)
 - [Add a Durable Object](/cloudflare/compute/durable-objects)
-- [CHANGELOG](https://github.com/alchemy-run/alchemy-effect/blob/main/CHANGELOG.md#v200-beta57)
-- [Compare v2.0.0-beta.56 → v2.0.0-beta.57](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.56...v2.0.0-beta.57)
+- [CHANGELOG](https://github.com/alchemy-run/alchemy/blob/main/CHANGELOG.md#v200-beta57)
+- [Compare v2.0.0-beta.56 → v2.0.0-beta.57](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.56...v2.0.0-beta.57)

--- a/website/src/content/docs/blog/2026-06-24-beta-58.md
+++ b/website/src/content/docs/blog/2026-06-24-beta-58.md
@@ -263,7 +263,7 @@ server running inside the container process.
 
 `DynamicWorkerLoader` is renamed to `WorkerLoader`, and `load(...)`
 now returns an Effect, so you `yield*` it
-([#653](https://github.com/alchemy-run/alchemy-effect/pull/653)):
+([#653](https://github.com/alchemy-run/alchemy/pull/653)):
 
 ```diff lang="typescript"
 - const loader = yield* Cloudflare.DynamicWorkerLoader("Loader");
@@ -335,7 +335,7 @@ Cloudflare, and the other providers lands in beta.59.
 
 The `Build` module is gone, replaced by a unified `Command` module
 that models shell commands as first-class resources sharing one
-executor ([#673](https://github.com/alchemy-run/alchemy-effect/pull/673)).
+executor ([#673](https://github.com/alchemy-run/alchemy/pull/673)).
 
 `Command.Build` (was `Build.Command`) runs a command that produces an
 output asset and tracks `outdir` in state. Inputs and outputs are
@@ -387,5 +387,5 @@ changed from `{ outdir, hash }` to `{ outdir, hash: { input, output } }`.
 - [Add a Durable Object](/cloudflare/compute/durable-objects)
 - [Cross-Worker Durable Objects](/cloudflare/compute/cross-worker-durable-object)
 - [Runtime as a colored function](/infrastructure-as-effects/layers#runtime-as-a-colored-function)
-- [CHANGELOG](https://github.com/alchemy-run/alchemy-effect/blob/main/CHANGELOG.md#v200-beta58)
-- [Compare v2.0.0-beta.57 → v2.0.0-beta.58](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.57...v2.0.0-beta.58)
+- [CHANGELOG](https://github.com/alchemy-run/alchemy/blob/main/CHANGELOG.md#v200-beta58)
+- [Compare v2.0.0-beta.57 → v2.0.0-beta.58](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.57...v2.0.0-beta.58)

--- a/website/src/content/docs/blog/2026-06-27-beta-59.md
+++ b/website/src/content/docs/blog/2026-06-27-beta-59.md
@@ -10,7 +10,7 @@ almost entirely renames: every Cloudflare service is now a real
 namespace, every binding across AWS **and** Cloudflare follows one
 `{Verb}{Resource}` convention, and the two-layer `Binding.Policy`
 split is gone — folded into a single runtime-guarded `Layer`
-([#690](https://github.com/alchemy-run/alchemy-effect/pull/690)).
+([#690](https://github.com/alchemy-run/alchemy/pull/690)).
 
 There's almost no new behavior here. It's a coordinated rename across
 ~900 symbols and ~1200 files so the API reads the same everywhere —
@@ -321,7 +321,7 @@ inference.
 Two fixes shipped alongside the rename:
 
 - **`deleteFirst` is honored on replace**
-  ([#692](https://github.com/alchemy-run/alchemy-effect/pull/692)) — a
+  ([#692](https://github.com/alchemy-run/alchemy/pull/692)) — a
   replacement defaults to create-first (stand up the new generation,
   then tear down the old), but some resources can't coexist with their
   previous self (a fixed physical name, a singleton). `deleteFirst` is
@@ -330,13 +330,13 @@ Two fixes shipped alongside the rename:
   instead of leaking an old chain into the next phase. Thanks
   **John Royal**.
 - **Worker diff tolerates legacy custom-domain state**
-  ([#694](https://github.com/alchemy-run/alchemy-effect/pull/694)) —
+  ([#694](https://github.com/alchemy-run/alchemy/pull/694)) —
   Alchemy ≤ beta.44 stored each Worker custom domain as a
   `{ id, hostname, zoneId }` object; beta.45+ stores
   `https://<hostname>` strings and the diff path calls string methods
   on each entry. Older state now gets coerced back to strings so a
   Worker deploy no longer throws `u.endsWith is not a function`
-  ([#546](https://github.com/alchemy-run/alchemy-effect/issues/546)).
+  ([#546](https://github.com/alchemy-run/alchemy/issues/546)).
   Thanks **Nicolas Fléron**.
 
 ## Where to go next
@@ -344,5 +344,5 @@ Two fixes shipped alongside the rename:
 - [Binding](/infrastructure-as-effects/binding)
 - [Plantime and Runtime › The `__ALCHEMY_RUNTIME__` guard](/infrastructure-as-effects/phases#the-__alchemy_runtime__-guard)
 - [Queue Consumer](/cloudflare/messaging/queues)
-- [CHANGELOG](https://github.com/alchemy-run/alchemy-effect/blob/main/CHANGELOG.md#v200-beta59)
-- [Compare v2.0.0-beta.58 → v2.0.0-beta.59](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.58...v2.0.0-beta.59)
+- [CHANGELOG](https://github.com/alchemy-run/alchemy/blob/main/CHANGELOG.md#v200-beta59)
+- [Compare v2.0.0-beta.58 → v2.0.0-beta.59](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.58...v2.0.0-beta.59)

--- a/website/src/content/docs/blog/2026-07-01-microvm-cold-starts.md
+++ b/website/src/content/docs/blog/2026-07-01-microvm-cold-starts.md
@@ -138,7 +138,7 @@ the last user as well as the first.
 
 (The full 16-variant matrix — a Python image, the Node
 baselines, the remaining Worker-driven rows — lives in the
-[full report](https://github.com/alchemy-run/alchemy-effect/tree/main/benchmark/container).)
+[full report](https://github.com/alchemy-run/alchemy/tree/main/benchmark/container).)
 
 Which shape you want depends on what you're building. If a slow
 boot retries invisibly in the background, take the faster
@@ -168,7 +168,7 @@ distributing a freshly pushed image isn't mixed into the numbers.
 ## The images under test
 
 The benchmark is an ordinary Alchemy app
-([`benchmark/container`](https://github.com/alchemy-run/alchemy-effect/tree/main/benchmark/container)).
+([`benchmark/container`](https://github.com/alchemy-run/alchemy/tree/main/benchmark/container)).
 Each variant is an image resource, and the variants are chosen
 to isolate one question each.
 

--- a/website/src/content/docs/blog/2026-07-02-cloudflare-resource-factory.mdx
+++ b/website/src/content/docs/blog/2026-07-02-cloudflare-resource-factory.mdx
@@ -28,7 +28,7 @@ loop grew Alchemy's Cloudflare provider from **22 resources to
 230** between June 11 and June 17, producing 288 test files
 with roughly 700 tests and **720 SDK patches**. Most of it
 landed in a single PR
-([#601](https://github.com/alchemy-run/alchemy-effect/pull/601))
+([#601](https://github.com/alchemy-run/alchemy/pull/601))
 that added 101,178 lines across 542 files and was open for 22
 hours. The PR description, in its entirety:
 
@@ -159,7 +159,7 @@ returns.
 Two choices kept the loop fast. distilled is a git submodule
 inside alchemy's bun workspace, so an agent patches the SDK
 and the resource that consumes it in one working tree, and a
-wave lands as two PRs, one to alchemy-effect and one to
+wave lands as two PRs, one to alchemy and one to
 distilled. And vitest resolves distilled from its TypeScript
 source, so a regenerated service is visible to the very next
 test run. The loop's cycle time is the test's runtime.
@@ -174,6 +174,6 @@ Cloudflare run was the proof, and it shipped in
 [2.0.0-beta.56](/blog/2026-06-17-beta-56).
 
 - [2.0.0-beta.56 — the release these resources shipped in](/blog/2026-06-17-beta-56)
-- [PR #601 — the generation wave](https://github.com/alchemy-run/alchemy-effect/pull/601)
+- [PR #601 — the generation wave](https://github.com/alchemy-run/alchemy/pull/601)
 - [distilled — the generated, patchable SDK](https://github.com/alchemy-run/distilled)
 - [Cloudflare provider reference](/providers/cloudflare)

--- a/website/src/content/docs/blog/2026-07-06-beta-60.md
+++ b/website/src/content/docs/blog/2026-07-06-beta-60.md
@@ -15,7 +15,7 @@ ground-up overhaul of the docs. No breaking changes this release.
 
 `alchemy/Docker` brings `Image`, `RemoteImage`, `Container`,
 `Volume`, and `Network` as Stack resources
-([#649](https://github.com/alchemy-run/alchemy-effect/pull/649)).
+([#649](https://github.com/alchemy-run/alchemy/pull/649)).
 They drive the `docker` CLI's active context — Docker Desktop, a
 remote/SSH context, a CI daemon — and live in the same Stack as
 your cloud resources. Thanks **Austin**!
@@ -47,7 +47,7 @@ alchemy follow the standard adoption rules. See the new
 ## AWS Lambda MicroVMs
 
 `AWS.Lambda.MicrovmImage` is a new Platform for snapshot-booted
-microVMs ([#712](https://github.com/alchemy-run/alchemy-effect/pull/712)).
+microVMs ([#712](https://github.com/alchemy-run/alchemy/pull/712)).
 Author the in-VM server in TypeScript — alchemy bundles it,
 generates the Dockerfile, and builds the snapshot server-side — or
 bring your own Dockerfile or a prebuilt artifact:
@@ -92,7 +92,7 @@ Docs: [MicroVMs](/aws/compute/microvms).
 ## Workers for Platforms
 
 Deploy user Workers into a dispatch namespace and route to them
-dynamically ([#715](https://github.com/alchemy-run/alchemy-effect/pull/715)).
+dynamically ([#715](https://github.com/alchemy-run/alchemy/pull/715)).
 A Worker deploys *into* a namespace with the new `namespace` prop —
 no duplicate resource type:
 
@@ -129,7 +129,7 @@ Docs: [Workers for Platforms](/cloudflare/compute/workers-for-platforms).
 
 `Cloudflare.Vite` now supports builds that emit more than one
 server environment — most notably RSC
-([#685](https://github.com/alchemy-run/alchemy-effect/pull/685)).
+([#685](https://github.com/alchemy-run/alchemy/pull/685)).
 `viteEnvironments` selects which environment produces the deployed
 Worker entry and which additional server environments are bundled
 alongside it:
@@ -152,7 +152,7 @@ signature, so config changes are never silently missed. Docs:
 
 Class-based Cloudflare Workflows now bind to async (non-Effect)
 Workers via `env`, mirroring class-based Durable Objects
-([#707](https://github.com/alchemy-run/alchemy-effect/pull/707)):
+([#707](https://github.com/alchemy-run/alchemy/pull/707)):
 
 ```typescript
 export const AsyncWorker = Cloudflare.Worker("Async", {
@@ -177,7 +177,7 @@ Docs: [Workflows](/cloudflare/compute/workflows).
 Cloudflare Containers deployed with alchemy behaved much worse
 than the same image deployed with wrangler — at 100 concurrent
 cold starts, ~2/100 succeeded. Two root causes, both fixed
-([#708](https://github.com/alchemy-run/alchemy-effect/pull/708)):
+([#708](https://github.com/alchemy-run/alchemy/pull/708)):
 
 - **Wrangler-parity defaults** — `maxInstances` defaulted to `1`,
   serializing every Durable Object through one container slot. Now
@@ -191,14 +191,14 @@ Result: 100/100 cold starts, on par with wrangler. And a container
 that stops or crashes is now transparently restarted on the next
 request, while a crash-looping container fails fast instead of
 burning the readiness budget
-([#711](https://github.com/alchemy-run/alchemy-effect/pull/711)).
+([#711](https://github.com/alchemy-run/alchemy/pull/711)).
 Docs: [Containers](/cloudflare/compute/containers).
 
 ## Effectful compute on ECS and EC2
 
 The `ServerHost` + `{ fetch }` pattern now works end to end on
 `AWS.ECS.Task`
-([#713](https://github.com/alchemy-run/alchemy-effect/pull/713)):
+([#713](https://github.com/alchemy-run/alchemy/pull/713)):
 the container entry bundles a Bun HTTP server, ships every chunk
 into the image, and builds for the architecture the task declares
 — verified by a smoke test that deploys a real Fargate service
@@ -206,7 +206,7 @@ behind an ALB.
 
 The hosted `AWS.EC2.Instance` serves HTTP the same way, with a
 reboot-safe systemd unit that self-heals transient boot failures
-([#714](https://github.com/alchemy-run/alchemy-effect/pull/714)).
+([#714](https://github.com/alchemy-run/alchemy/pull/714)).
 And there's a new `AWS.EC2.KeyPair` resource — the generated
 private key is captured once as a `Redacted` secret:
 
@@ -221,7 +221,7 @@ const keyPair = yield* AWS.EC2.KeyPair("DeployKey", { keyType: "ed25519" });
 The website is restructured into per-provider hubs behind a
 horizontal tab bar — `Core · CLI · Cloudflare · AWS · PlanetScale ·
 Neon · More ▾` — with ~100 new or reworked pages
-([#721](https://github.com/alchemy-run/alchemy-effect/pull/721)):
+([#721](https://github.com/alchemy-run/alchemy/pull/721)):
 
 - **Core** — Infrastructure as Code, Infrastructure as Effects,
   APIs, Environments, State Store, Project structure, Testing.
@@ -238,48 +238,48 @@ Start at [the docs](/) and pick your provider.
 ## Also in this release
 
 - **`--yes` is fully non-interactive**
-  ([#728](https://github.com/alchemy-run/alchemy-effect/pull/728)) —
+  ([#728](https://github.com/alchemy-run/alchemy/pull/728)) —
   `alchemy deploy --yes` now auto-accepts the Cloudflare state
   store upgrade and deploy prompts instead of hanging on a non-TTY,
   so CI needs no workarounds.
 - **Partial state-store deploys are detected and recovered**
-  ([#700](https://github.com/alchemy-run/alchemy-effect/pull/700)) —
+  ([#700](https://github.com/alchemy-run/alchemy/pull/700)) —
   the store health check now verifies a real store is serving, not
   just that a pre-create stub exists.
 - **`Command.Build` memo includes command + env**
-  ([#738](https://github.com/alchemy-run/alchemy-effect/pull/738)) —
+  ([#738](https://github.com/alchemy-run/alchemy/pull/738)) —
   two `StaticSite` builds differing only in env (per-stage
   `EXPO_PUBLIC_*`, API ids) no longer reuse each other's output.
 - **Retained resources report as `retained`**
-  ([#739](https://github.com/alchemy-run/alchemy-effect/pull/739)) —
+  ([#739](https://github.com/alchemy-run/alchemy/pull/739)) —
   destroy no longer lists `RemovalPolicy: "retain"` resources as
   deleted. Thanks **bjorntechTobbe**!
 - **The CLI works on Windows**
-  ([#696](https://github.com/alchemy-run/alchemy-effect/pull/696)) —
+  ([#696](https://github.com/alchemy-run/alchemy/pull/696)) —
   the stack entry loads via a `file://` URL. Thanks **d3lay**!
 - **Durable Object classes created outside alchemy adopt cleanly**
-  ([#495](https://github.com/alchemy-run/alchemy-effect/pull/495)) —
+  ([#495](https://github.com/alchemy-run/alchemy/pull/495)) —
   class migrations fall back to matching the observed binding, so
   adopting a wrangler/dashboard Worker reuses its DO classes
   instead of failing to re-create them.
 - **Access Application survives state loss**
-  ([#742](https://github.com/alchemy-run/alchemy-effect/pull/742)) —
+  ([#742](https://github.com/alchemy-run/alchemy/pull/742)) —
   `read` falls back to a domain scan and gates takeover behind
   `--adopt`, instead of blindly creating a duplicate app with a
   fresh `aud`. Thanks **Andy Jefferson**!
 - **Pooled connection origins** — Neon `Project`/`Branch`
-  ([#718](https://github.com/alchemy-run/alchemy-effect/pull/718))
+  ([#718](https://github.com/alchemy-run/alchemy/pull/718))
   and PlanetScale `PostgresRole`
-  ([#717](https://github.com/alchemy-run/alchemy-effect/pull/717))
+  ([#717](https://github.com/alchemy-run/alchemy/pull/717))
   expose `pooledOrigin`, and PlanetScale branch replica intent
   persists so `replicas: 0` converges
-  ([#719](https://github.com/alchemy-run/alchemy-effect/pull/719)).
+  ([#719](https://github.com/alchemy-run/alchemy/pull/719)).
   Thanks **Alex**!
 - **AWS env-auth fixes** — `Region` is provided to STS during login
-  ([#709](https://github.com/alchemy-run/alchemy-effect/pull/709))
+  ([#709](https://github.com/alchemy-run/alchemy/pull/709))
   and the `Region`/`AWSEnvironment` layer cycle in the account-id
   lookup is broken
-  ([#710](https://github.com/alchemy-run/alchemy-effect/pull/710)).
+  ([#710](https://github.com/alchemy-run/alchemy/pull/710)).
 
 ## Where to go next
 
@@ -288,5 +288,5 @@ Start at [the docs](/) and pick your provider.
 - [Workers for Platforms](/cloudflare/compute/workers-for-platforms)
 - [Workflows](/cloudflare/compute/workflows)
 - [Benchmarking Cloudflare Containers vs AWS MicroVMs](/blog/2026-07-01-microvm-cold-starts)
-- [CHANGELOG](https://github.com/alchemy-run/alchemy-effect/blob/main/CHANGELOG.md#v200-beta60)
-- [Compare v2.0.0-beta.59 → v2.0.0-beta.60](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.59...v2.0.0-beta.60)
+- [CHANGELOG](https://github.com/alchemy-run/alchemy/blob/main/CHANGELOG.md#v200-beta60)
+- [Compare v2.0.0-beta.59 → v2.0.0-beta.60](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.59...v2.0.0-beta.60)

--- a/website/src/content/docs/blog/2026-07-08-beta-61.md
+++ b/website/src/content/docs/blog/2026-07-08-beta-61.md
@@ -17,15 +17,15 @@ reliability fixes.
 
 - **`workflow.create` takes the native options object** —
   `create(input)` → `create({ params: input })`
-  ([#611](https://github.com/alchemy-run/alchemy-effect/pull/611)).
+  ([#611](https://github.com/alchemy-run/alchemy/pull/611)).
 - **`WorkerExecutionContext` is now an Effect wrapper** — it's no
   longer the raw `cf.ExecutionContext`; `waitUntil` takes an
   `Effect` and is `yield*`-ed
-  ([#752](https://github.com/alchemy-run/alchemy-effect/pull/752)).
+  ([#752](https://github.com/alchemy-run/alchemy/pull/752)).
 - **effect `>=4.0.0-beta.93` is required** — effect moved
   `UrlParams.makeUrl` to `Url.make`; the peer range floor is raised
   to match
-  ([#748](https://github.com/alchemy-run/alchemy-effect/pull/748)).
+  ([#748](https://github.com/alchemy-run/alchemy/pull/748)).
 :::
 
 ## Workers Cache
@@ -33,7 +33,7 @@ reliability fixes.
 [Workers Cache](https://blog.cloudflare.com/workers-cache/) —
 Cloudflare's regionally tiered cache in front of Worker
 entrypoints — lands as both a binding and a prop
-([#752](https://github.com/alchemy-run/alchemy-effect/pull/752)).
+([#752](https://github.com/alchemy-run/alchemy/pull/752)).
 Effect-native Workers enable it with `Cloudflare.cache()`, which
 also returns the typed purge client:
 
@@ -98,7 +98,7 @@ Migrating is mechanical — `ctx.waitUntil(promise)` becomes
 
 `Cloudflare.Worker` accepts Wrangler-style zone routes via a new
 `routes` prop
-([#438](https://github.com/alchemy-run/alchemy-effect/pull/438)).
+([#438](https://github.com/alchemy-run/alchemy/pull/438)).
 Thanks **utopy**!
 
 ```typescript
@@ -122,7 +122,7 @@ Cloud state drifts: someone edits a resource in the dashboard, a
 bucket gets deleted, tags get mangled. `alchemy sync` converges it
 back to the last-deployed state — without re-running your stack
 program
-([#766](https://github.com/alchemy-run/alchemy-effect/pull/766)):
+([#766](https://github.com/alchemy-run/alchemy/pull/766)):
 
 ```sh
 alchemy sync ./alchemy.run.ts --stage prod            # detect + repair
@@ -142,7 +142,7 @@ aggregated after every resource has been attempted.
 
 The Effect-native Workflow wrapper now covers the full Workers API
 surface, 1:1 with the native binding
-([#611](https://github.com/alchemy-run/alchemy-effect/pull/611)).
+([#611](https://github.com/alchemy-run/alchemy/pull/611)).
 Thanks **Gerben Mulder**!
 
 `create` takes the native options object — the breaking change
@@ -196,7 +196,7 @@ metadata round out the surface. Docs:
 Renaming a resource's type string used to strand state persisted
 under the old name — provider lookup died on the legacy type.
 Resources now declare their former names
-([#765](https://github.com/alchemy-run/alchemy-effect/pull/765)):
+([#765](https://github.com/alchemy-run/alchemy/pull/765)):
 
 ```typescript
 export const Queue = Resource<Queue>("Cloudflare.Queues.Queue", {
@@ -218,7 +218,7 @@ resources — a Secrets Store `Secret` with an exact
 `{gatewayId}_{providerSlug}_{alias}` name, and a `GatewayProvider`
 that references it. `Cloudflare.AI.ProviderKey` owns that contract
 as one resource
-([#586](https://github.com/alchemy-run/alchemy-effect/pull/586)).
+([#586](https://github.com/alchemy-run/alchemy/pull/586)).
 Thanks **Alex**!
 
 ```typescript
@@ -237,7 +237,7 @@ Docs: [AI Gateway](/cloudflare/ai/ai-gateway).
 Lambda's asynchronous invocation settings — retries, event age,
 success/failure destinations — land as an `eventInvokeConfig` prop
 on `Function` and `Alias`
-([#627](https://github.com/alchemy-run/alchemy-effect/pull/627)).
+([#627](https://github.com/alchemy-run/alchemy/pull/627)).
 Thanks **José Netto**!
 
 ```typescript
@@ -256,7 +256,7 @@ const fn = yield* AWS.Lambda.Function("AsyncFn", {
 ## R2 Bucket `cors`
 
 The `cors` prop that `Cloudflare.R2.Bucket` had in v1 is restored
-([#771](https://github.com/alchemy-run/alchemy-effect/pull/771)) —
+([#771](https://github.com/alchemy-run/alchemy/pull/771)) —
 public buckets serving browser range-reads (e.g. PMTiles) declare
 CORS in the stack again instead of out-of-band:
 
@@ -282,66 +282,66 @@ adoption converge correctly.
 ## Also in this release
 
 - **Worker metadata-only changes now deploy**
-  ([#747](https://github.com/alchemy-run/alchemy-effect/pull/747)) —
+  ([#747](https://github.com/alchemy-run/alchemy/pull/747)) —
   compatibility flags/date, observability, placement, limits, and
   binding changes are folded into the update diff via a metadata
   hash; previously they planned as noops and silently never
   shipped. The first deploy after upgrading plans a one-time update
   per Worker to backfill the hash. Thanks **Alex**!
 - **Wedged stacks recover**
-  ([#767](https://github.com/alchemy-run/alchemy-effect/pull/767),
-  [#770](https://github.com/alchemy-run/alchemy-effect/pull/770)) —
+  ([#767](https://github.com/alchemy-run/alchemy/pull/767),
+  [#770](https://github.com/alchemy-run/alchemy/pull/770)) —
   a deploy interrupted mid-create used to persist a state row whose
   Output-valued props can't round-trip, crashing every subsequent
   `plan`/`deploy`/`destroy`. Every provider's `read`/`diff` is
   audited so the engine re-drives the create and reconcile
   converges on the half-created resource.
 - **Script uploads retry every binding-target-not-found error**
-  ([#753](https://github.com/alchemy-run/alchemy-effect/pull/753)) —
+  ([#753](https://github.com/alchemy-run/alchemy/pull/753)) —
   KV, R2, D1, Queues, DO classes, Hyperdrive, Vectorize, and more,
   covering Cloudflare's deploy-time propagation lag.
 - **`Resource.ref` values bind natively in Worker `env`**
-  ([#756](https://github.com/alchemy-run/alchemy-effect/pull/756)) —
+  ([#756](https://github.com/alchemy-run/alchemy/pull/756)) —
   a ref passed as an env binding used to degrade to a plain JSON
   env var and break at runtime; refs now classify exactly like
   locally-declared resources.
 - **Multiple queue consumers on one Worker**
-  ([#466](https://github.com/alchemy-run/alchemy-effect/pull/466)) —
+  ([#466](https://github.com/alchemy-run/alchemy/pull/466)) —
   event dispatch runs every listener for an event type instead of
   letting the first queue subscription swallow the rest. Thanks
   **Leonardo E. Dominguez**!
 - **State-store errors are actionable**
-  ([#737](https://github.com/alchemy-run/alchemy-effect/pull/737)) —
+  ([#737](https://github.com/alchemy-run/alchemy/pull/737)) —
   30 days of production traces triaged; empty `StateStoreError:`
   messages, opaque decode errors, and JSON-parse crashes now
   surface real messages (an unauthorized store tells you to run
   `alchemy login`).
 - **The test suite passes on Windows**
-  ([#735](https://github.com/alchemy-run/alchemy-effect/pull/735)) —
+  ([#735](https://github.com/alchemy-run/alchemy/pull/735)) —
   including two real product fixes: `Drizzle.Schema` passed
   OS-native paths to drizzle-kit (backslashes are glob escapes),
   and `Bundle.PurePlugin` could be hijacked by a stray
   `package.json` above `node_modules`.
 - **Drizzle query chains are real Effects**
-  ([#750](https://github.com/alchemy-run/alchemy-effect/pull/750)) —
+  ([#750](https://github.com/alchemy-run/alchemy/pull/750)) —
   `db.select()...` chains now expose the full Effect protocol, so
   they compose with `Effect.all` and friends instead of spinning
   the run loop.
 - **PlanetScale inherited roles compare by membership**
-  ([#761](https://github.com/alchemy-run/alchemy-effect/pull/761)) —
+  ([#761](https://github.com/alchemy-run/alchemy/pull/761)) —
   API-returned ordering no longer forces a `PostgresRole`
   replacement. Thanks **Gerben Mulder**!
 - **`globalOutbound: null` is preserved in `WorkerLoader`**
-  ([#746](https://github.com/alchemy-run/alchemy-effect/pull/746)) —
+  ([#746](https://github.com/alchemy-run/alchemy/pull/746)) —
   the documented "block all outbound network access" signal no
   longer silently coerces to default access. Thanks **Alex**!
 - **Binding-hosted DO classes join the precreate stub**
-  ([#764](https://github.com/alchemy-run/alchemy-effect/pull/764)) —
+  ([#764](https://github.com/alchemy-run/alchemy/pull/764)) —
   fixes `Worker did not expose Durable Object namespace` on fresh
   deploys of worker↔container cycles. Thanks **Daniel Gangl**!
 - **`alchemy dev` no longer prints bun's benign tsconfig fd
   warning**
-  ([#768](https://github.com/alchemy-run/alchemy-effect/pull/768)).
+  ([#768](https://github.com/alchemy-run/alchemy/pull/768)).
 
 ## Where to go next
 
@@ -349,5 +349,5 @@ adoption converge correctly.
 - [Workers](/cloudflare/compute/workers)
 - [Custom Domains & Routes](/cloudflare/networking/custom-domains)
 - [AI Gateway](/cloudflare/ai/ai-gateway)
-- [CHANGELOG](https://github.com/alchemy-run/alchemy-effect/blob/main/CHANGELOG.md#v200-beta61)
-- [Compare v2.0.0-beta.60 → v2.0.0-beta.61](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.60...v2.0.0-beta.61)
+- [CHANGELOG](https://github.com/alchemy-run/alchemy/blob/main/CHANGELOG.md#v200-beta61)
+- [Compare v2.0.0-beta.60 → v2.0.0-beta.61](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.60...v2.0.0-beta.61)

--- a/website/src/content/docs/cloudflare/ai/release-agent.mdx
+++ b/website/src/content/docs/cloudflare/ai/release-agent.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 27
 ---
 
-The [`cloudflare-agent` example](https://github.com/alchemy-run/alchemy-effect/tree/main/examples/cloudflare-agent)
+The [`cloudflare-agent` example](https://github.com/alchemy-run/alchemy/tree/main/examples/cloudflare-agent)
 is an autonomous release pipeline: a push lands on `main`, a Worker
 filters for release commits, and each one is handed to a Durable
 Object that drives an AI agent to write the release blog post — with
@@ -29,7 +29,7 @@ and filters for release commits on `main` in ordinary handler code:
 ```typescript
 // src/ReleaseService.ts
 yield* Github.consumeRepositoryEvents(
-  { owner: "alchemy-run", repository: "alchemy-effect", events: ["push"] },
+  { owner: "alchemy-run", repository: "alchemy", events: ["push"] },
   (event) => {
     const title = event.payload.head_commit?.message.split("\n")[0] ?? "";
     const isRelease =

--- a/website/src/content/docs/cloudflare/data/branch-from-shared-database.mdx
+++ b/website/src/content/docs/cloudflare/data/branch-from-shared-database.mdx
@@ -355,9 +355,9 @@ export const Hyperdrive = Effect.gen(function* () {
 ```
 
 The full working projects live at
-[`cloudflare-planetscale-postgres-drizzle`](https://github.com/alchemy-run/alchemy-effect/tree/main/examples/cloudflare-planetscale-postgres-drizzle)
+[`cloudflare-planetscale-postgres-drizzle`](https://github.com/alchemy-run/alchemy/tree/main/examples/cloudflare-planetscale-postgres-drizzle)
 and
-[`cloudflare-planetscale-mysql-drizzle`](https://github.com/alchemy-run/alchemy-effect/tree/main/examples/cloudflare-planetscale-mysql-drizzle).
+[`cloudflare-planetscale-mysql-drizzle`](https://github.com/alchemy-run/alchemy/tree/main/examples/cloudflare-planetscale-mysql-drizzle).
 
 ## Where to from here
 

--- a/website/src/content/docs/cloudflare/data/shared-database.mdx
+++ b/website/src/content/docs/cloudflare/data/shared-database.mdx
@@ -19,7 +19,7 @@ resolved at plan time against the persisted state store. See
 The example we'll build: a Neon Postgres project that's owned by
 `staging`, with PR-preview stages (`pr-*`) referencing it instead
 of creating their own. The full file lives in
-[`examples/cloudflare-neon-drizzle/src/Db.ts`](https://github.com/alchemy-run/alchemy-effect/tree/main/examples/cloudflare-neon-drizzle/src/Db.ts).
+[`examples/cloudflare-neon-drizzle/src/Db.ts`](https://github.com/alchemy-run/alchemy/tree/main/examples/cloudflare-neon-drizzle/src/Db.ts).
 
 ## Start with the unconditional version
 
@@ -218,9 +218,9 @@ database across all PRs, use `stage: "staging"` exactly as above.
 
 The MySQL family works identically — `MySQLDatabase.ref`,
 `MySQLBranch`, `MySQLPassword`. Full files:
-[`cloudflare-planetscale-postgres-drizzle`](https://github.com/alchemy-run/alchemy-effect/tree/main/examples/cloudflare-planetscale-postgres-drizzle/src/Db.ts)
+[`cloudflare-planetscale-postgres-drizzle`](https://github.com/alchemy-run/alchemy/tree/main/examples/cloudflare-planetscale-postgres-drizzle/src/Db.ts)
 and
-[`cloudflare-planetscale-mysql-drizzle`](https://github.com/alchemy-run/alchemy-effect/tree/main/examples/cloudflare-planetscale-mysql-drizzle/src/Db.ts).
+[`cloudflare-planetscale-mysql-drizzle`](https://github.com/alchemy-run/alchemy/tree/main/examples/cloudflare-planetscale-mysql-drizzle/src/Db.ts).
 
 ## Cross-stack too
 

--- a/website/src/content/docs/cloudflare/frontend/full-stack-tanstack-rpc-drizzle.mdx
+++ b/website/src/content/docs/cloudflare/frontend/full-stack-tanstack-rpc-drizzle.mdx
@@ -18,7 +18,7 @@ This guide ties four pieces into one deployable app:
   mutations in the browser.
 
 The full project lives in
-[`examples/cloudflare-tanstack-rpc-drizzle`](https://github.com/alchemy-run/alchemy-effect/tree/main/examples/cloudflare-tanstack-rpc-drizzle).
+[`examples/cloudflare-tanstack-rpc-drizzle`](https://github.com/alchemy-run/alchemy/tree/main/examples/cloudflare-tanstack-rpc-drizzle).
 We'll build a Todo app and follow a single value — a `Todo` — from the
 Postgres row all the way to a checkbox in the browser.
 

--- a/website/src/content/docs/cloudflare/frontend/solidstart.mdx
+++ b/website/src/content/docs/cloudflare/frontend/solidstart.mdx
@@ -14,7 +14,7 @@ entrypoint.
 
 :::note[Verified version line]
 The checked-in example
-([examples/cloudflare-solidstart](https://github.com/alchemy-run/alchemy-effect/tree/main/examples/cloudflare-solidstart))
+([examples/cloudflare-solidstart](https://github.com/alchemy-run/alchemy/tree/main/examples/cloudflare-solidstart))
 pins `@solidjs/start` **2.0.0-alpha.2** with
 `@solidjs/vite-plugin-nitro-2` — the Vite-native alpha line where
 `solidStart()` is a plain Vite plugin. That is the version line
@@ -83,7 +83,7 @@ fails to start.
 ## Hand-rolled SolidJS SSR
 
 You don't need SolidStart to server-render Solid. The
-[examples/cloudflare-solidjs-ssr](https://github.com/alchemy-run/alchemy-effect/tree/main/examples/cloudflare-solidjs-ssr)
+[examples/cloudflare-solidjs-ssr](https://github.com/alchemy-run/alchemy/tree/main/examples/cloudflare-solidjs-ssr)
 example uses plain `vite-plugin-solid` with SSR enabled and declares
 an `ssr` environment whose input is a hand-written server entry:
 

--- a/website/src/content/docs/cloudflare/frontend/static-site.mdx
+++ b/website/src/content/docs/cloudflare/frontend/static-site.mdx
@@ -63,7 +63,7 @@ export default Alchemy.Stack(
 `alchemy deploy` runs `zola build`, hashes `public/`, and uploads it as the
 Worker's static assets; `notFoundHandling: "404-page"` serves Zola's
 generated 404 page for unmatched paths. The runnable version lives at
-[`examples/cloudflare-static-site`](https://github.com/alchemy-run/alchemy-effect/tree/main/examples/cloudflare-static-site).
+[`examples/cloudflare-static-site`](https://github.com/alchemy-run/alchemy/tree/main/examples/cloudflare-static-site).
 
 ## Props
 

--- a/website/src/content/docs/cloudflare/frontend/tanstack-start.mdx
+++ b/website/src/content/docs/cloudflare/frontend/tanstack-start.mdx
@@ -10,7 +10,7 @@ ordinary plugins in `vite.config.ts`, so
 [`Cloudflare.Website.Vite`](/cloudflare/frontend/vite) builds the client
 assets and the SSR server bundle in a single `vite build` pass, no
 adapter or Wrangler config required. Support is verified: the
-[examples/cloudflare-tanstack](https://github.com/alchemy-run/alchemy-effect/tree/main/examples/cloudflare-tanstack)
+[examples/cloudflare-tanstack](https://github.com/alchemy-run/alchemy/tree/main/examples/cloudflare-tanstack)
 example is checked in, and a live test deploys it in dev mode with real
 Alchemy-managed R2 bindings.
 
@@ -152,7 +152,7 @@ hits the same bucket in dev as in production.
 
 TanStack Start's Solid flavor works the same way — swap the plugins in
 `vite.config.ts` and keep the identical `alchemy.run.ts` shape (see
-[examples/cloudflare-tanstack-start-solid](https://github.com/alchemy-run/alchemy-effect/tree/main/examples/cloudflare-tanstack-start-solid)):
+[examples/cloudflare-tanstack-start-solid](https://github.com/alchemy-run/alchemy/tree/main/examples/cloudflare-tanstack-start-solid)):
 
 ```typescript
 // vite.config.ts

--- a/website/src/content/docs/cloudflare/frontend/vue.mdx
+++ b/website/src/content/docs/cloudflare/frontend/vue.mdx
@@ -31,7 +31,7 @@ aliases, and the rest of your setup are preserved as-is.
 ## Deploy it from a Stack
 
 Yield the Vite resource from your Stack — this is
-[examples/cloudflare-vue](https://github.com/alchemy-run/alchemy-effect/tree/main/examples/cloudflare-vue)
+[examples/cloudflare-vue](https://github.com/alchemy-run/alchemy/tree/main/examples/cloudflare-vue)
 verbatim:
 
 ```typescript

--- a/website/src/content/docs/cloudflare/messaging/github-events.mdx
+++ b/website/src/content/docs/cloudflare/messaging/github-events.mdx
@@ -198,7 +198,7 @@ every GitHub event name.
 
 ## Case study: a release-blogging agent
 
-The [`cloudflare-agent` example](https://github.com/alchemy-run/alchemy-effect/tree/main/examples/cloudflare-agent)
+The [`cloudflare-agent` example](https://github.com/alchemy-run/alchemy/tree/main/examples/cloudflare-agent)
 uses this event source as the front door of an autonomous pipeline:
 a Worker consumes push events on the alchemy repo, filters for
 release commits on `main`, and hands each one to a Durable Object
@@ -211,7 +211,7 @@ The filter is ordinary handler code over the typed `push` payload:
 yield* GitHub.consumeRepositoryEvents(
   {
     owner: "alchemy-run",
-    repository: "alchemy-effect",
+    repository: "alchemy",
     events: ["push"],
   },
   (event) => {

--- a/website/src/content/docs/cloudflare/messaging/queues.mdx
+++ b/website/src/content/docs/cloudflare/messaging/queues.mdx
@@ -225,7 +225,7 @@ if (request.url.startsWith("/queue/result/") && request.method === "GET") {
 
 Cloudflare's runtime delivers queue events to a `queue(batch, env)`
 export on the worker module. You can write that directly — see
-[`examples/cloudflare-worker-async`](https://github.com/alchemy-run/alchemy-effect/blob/main/examples/cloudflare-worker-async)
+[`examples/cloudflare-worker-async`](https://github.com/alchemy-run/alchemy/blob/main/examples/cloudflare-worker-async)
 for the plain async-handler shape:
 
 ```typescript

--- a/website/src/content/docs/docker/local-services.mdx
+++ b/website/src/content/docs/docker/local-services.mdx
@@ -15,7 +15,7 @@ it all down.
 You'll need a Docker daemon reachable from your CLI and the provider
 registered — see [Setup](/docker/setup) and the
 [Docker overview](/docker). The full program below is the checked-in
-[`examples/docker-postgres`](https://github.com/alchemy-run/alchemy-effect/tree/main/examples/docker-postgres).
+[`examples/docker-postgres`](https://github.com/alchemy-run/alchemy/tree/main/examples/docker-postgres).
 
 ## Pin the image
 

--- a/website/src/content/docs/environments/custom-auth-provider.mdx
+++ b/website/src/content/docs/environments/custom-auth-provider.mdx
@@ -9,7 +9,7 @@ builds the credentials side properly: a lazy `StripeCredentials` service backed
 by an Auth Provider, so the key comes from the configured
 [Profile](/environments/profiles), from env vars in CI, or from a refreshable
 session — never from props or hardcoded config. The steps below mirror the
-in-repo [Neon Auth Provider](https://github.com/sam-goodwin/alchemy-effect/blob/main/packages/alchemy/src/Neon/AuthProvider.ts),
+in-repo [Neon Auth Provider](https://github.com/alchemy-run/alchemy/blob/main/packages/alchemy/src/Neon/AuthProvider.ts),
 the smallest real implementation.
 
 For what an Auth Provider *is* — the five-method contract, the registry, lazy
@@ -352,7 +352,7 @@ Every built-in bridge — Neon, Planetscale, Cloudflare — has this exact shape
 
 Merge the auth machinery into the same `providers()` Layer that carries the
 resource providers, mirroring
-[`Neon/Providers.ts`](https://github.com/sam-goodwin/alchemy-effect/blob/main/packages/alchemy/src/Neon/Providers.ts):
+[`Neon/Providers.ts`](https://github.com/alchemy-run/alchemy/blob/main/packages/alchemy/src/Neon/Providers.ts):
 
 ```typescript
 // src/stripe/Providers.ts

--- a/website/src/content/docs/infrastructure-as-code/custom-provider.mdx
+++ b/website/src/content/docs/infrastructure-as-code/custom-provider.mdx
@@ -595,8 +595,8 @@ field your `diff` flags as `replace`) and assert that
 
 If you'd rather start from a real provider:
 
-- [`Axiom/VirtualField.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/Axiom/VirtualField.ts) — minimal CRUD with `diff` and `read`
-- [`Cloudflare/R2/Bucket.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/Cloudflare/R2/Bucket.ts) — production provider with bindings and replace semantics
+- [`Axiom/VirtualField.ts`](https://github.com/alchemy-run/alchemy/blob/main/packages/alchemy/src/Axiom/VirtualField.ts) — minimal CRUD with `diff` and `read`
+- [`Cloudflare/R2/Bucket.ts`](https://github.com/alchemy-run/alchemy/blob/main/packages/alchemy/src/Cloudflare/R2/Bucket.ts) — production provider with bindings and replace semantics
 
 ## Where next
 

--- a/website/src/content/docs/infrastructure-as-effects/custom-runtime.mdx
+++ b/website/src/content/docs/infrastructure-as-effects/custom-runtime.mdx
@@ -10,7 +10,7 @@ model to a new compute target. A custom runtime is a
 the compute infrastructure, and bundle + upload the runtime Effect.
 
 The running reference is `AWS.ECS.Task`
-([`AWS/ECS/Task.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/AWS/ECS/Task.ts))
+([`AWS/ECS/Task.ts`](https://github.com/alchemy-run/alchemy/blob/main/packages/alchemy/src/AWS/ECS/Task.ts))
 — it bundles an inline Effect program, builds a Docker image, and
 registers a Fargate task definition. Every built-in runtime —
 `Cloudflare.Worker`, `AWS.Lambda.Function`, `AWS.EC2.Instance` —
@@ -135,7 +135,7 @@ export interface BaseRuntimeContext {
 
 Server-style platforms don't write this from scratch —
 `createHostRuntimeContext` in
-[`Server/Process.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/Server/Process.ts)
+[`Server/Process.ts`](https://github.com/alchemy-run/alchemy/blob/main/packages/alchemy/src/Server/Process.ts)
 is the shared implementation used by `AWS.ECS.Task` and
 `AWS.EC2.Instance`. It folds `run` (background loops) and `serve`
 (HTTP handlers) into one list of runners:

--- a/website/src/content/docs/kubernetes/setup.mdx
+++ b/website/src/content/docs/kubernetes/setup.mdx
@@ -28,7 +28,7 @@ export default Alchemy.Stack(
 ```
 
 This is the exact shape of
-[examples/aws-eks](https://github.com/alchemy-run/alchemy-effect/tree/main/examples/aws-eks) —
+[examples/aws-eks](https://github.com/alchemy-run/alchemy/tree/main/examples/aws-eks) —
 `import * as Kubernetes from "alchemy/Kubernetes"` brings in the object
 helpers, and `AWS.providers()` covers everything they need.
 

--- a/website/src/content/docs/planetscale/data/mysql.mdx
+++ b/website/src/content/docs/planetscale/data/mysql.mdx
@@ -119,7 +119,7 @@ const hyperdrive = yield* Cloudflare.Hyperdrive.Connection("app-hyperdrive", {
 ```
 
 See the full example —
-[cloudflare-planetscale-mysql-drizzle](https://github.com/alchemy-run/alchemy-effect/tree/main/examples/cloudflare-planetscale-mysql-drizzle)
+[cloudflare-planetscale-mysql-drizzle](https://github.com/alchemy-run/alchemy/tree/main/examples/cloudflare-planetscale-mysql-drizzle)
 — for a Worker querying the branch through Hyperdrive with Drizzle.
 
 ## Apply migrations

--- a/website/src/content/docs/planetscale/guides/drizzle.mdx
+++ b/website/src/content/docs/planetscale/guides/drizzle.mdx
@@ -174,9 +174,9 @@ Everything above runs at deploy time. Querying from your application
 [Add Drizzle ORM](/cloudflare/data/drizzle) walkthrough.
 
 Complete working projects:
-[`cloudflare-planetscale-postgres-drizzle`](https://github.com/alchemy-run/alchemy-effect/tree/main/examples/cloudflare-planetscale-postgres-drizzle)
+[`cloudflare-planetscale-postgres-drizzle`](https://github.com/alchemy-run/alchemy/tree/main/examples/cloudflare-planetscale-postgres-drizzle)
 and
-[`cloudflare-planetscale-mysql-drizzle`](https://github.com/alchemy-run/alchemy-effect/tree/main/examples/cloudflare-planetscale-mysql-drizzle).
+[`cloudflare-planetscale-mysql-drizzle`](https://github.com/alchemy-run/alchemy/tree/main/examples/cloudflare-planetscale-mysql-drizzle).
 
 ## Where next
 

--- a/website/src/content/docs/planetscale/guides/preview-branches.mdx
+++ b/website/src/content/docs/planetscale/guides/preview-branches.mdx
@@ -171,9 +171,9 @@ runtime-specific:
   `Cloudflare.Hyperdrive.Connection`.
 
 Complete working projects:
-[`cloudflare-planetscale-postgres-drizzle`](https://github.com/alchemy-run/alchemy-effect/tree/main/examples/cloudflare-planetscale-postgres-drizzle)
+[`cloudflare-planetscale-postgres-drizzle`](https://github.com/alchemy-run/alchemy/tree/main/examples/cloudflare-planetscale-postgres-drizzle)
 and
-[`cloudflare-planetscale-mysql-drizzle`](https://github.com/alchemy-run/alchemy-effect/tree/main/examples/cloudflare-planetscale-mysql-drizzle).
+[`cloudflare-planetscale-mysql-drizzle`](https://github.com/alchemy-run/alchemy/tree/main/examples/cloudflare-planetscale-mysql-drizzle).
 
 ## Where next
 

--- a/website/src/content/docs/project-structure/file-layout.mdx
+++ b/website/src/content/docs/project-structure/file-layout.mdx
@@ -3,7 +3,7 @@ title: File layout
 description: How to organize an Alchemy project — one file per Resource or Layer, group Resources that travel together by concern, and keep alchemy.run.ts as the composition root.
 ---
 
-A typical alchemy app ([`examples/cloudflare-neon-drizzle`](https://github.com/alchemy-run/alchemy-effect/tree/main/examples/cloudflare-neon-drizzle)):
+A typical alchemy app ([`examples/cloudflare-neon-drizzle`](https://github.com/alchemy-run/alchemy/tree/main/examples/cloudflare-neon-drizzle)):
 
 ```sh
 .

--- a/website/src/content/docs/project-structure/monorepo-multi-stack.mdx
+++ b/website/src/content/docs/project-structure/monorepo-multi-stack.mdx
@@ -4,7 +4,7 @@ description: Each package owns its own alchemy.run.ts — the frontend reads the
 ---
 
 Each package owns its own `alchemy.run.ts`
-([`examples/monorepo-multi-stack`](https://github.com/alchemy-run/alchemy-effect/tree/main/examples/monorepo-multi-stack)):
+([`examples/monorepo-multi-stack`](https://github.com/alchemy-run/alchemy/tree/main/examples/monorepo-multi-stack)):
 
 ```sh
 .

--- a/website/src/content/docs/project-structure/monorepo-single-stack.mdx
+++ b/website/src/content/docs/project-structure/monorepo-single-stack.mdx
@@ -4,7 +4,7 @@ description: One alchemy.run.ts at the workspace root deploys the backend Worker
 ---
 
 One `alchemy.run.ts` at the workspace root deploys both packages
-([`examples/monorepo-single-stack`](https://github.com/alchemy-run/alchemy-effect/tree/main/examples/monorepo-single-stack)):
+([`examples/monorepo-single-stack`](https://github.com/alchemy-run/alchemy/tree/main/examples/monorepo-single-stack)):
 
 ```sh
 .

--- a/website/src/content/docs/state-store/custom-state-store.mdx
+++ b/website/src/content/docs/state-store/custom-state-store.mdx
@@ -433,6 +433,6 @@ production:
 
 If you'd rather start from one of the built-ins:
 
-- [`LocalState.ts`](https://github.com/sam-goodwin/alchemy-effect/blob/main/packages/alchemy/src/State/LocalState.ts) — filesystem-backed, the simplest end-to-end example
-- [`HttpStateStore.ts`](https://github.com/sam-goodwin/alchemy-effect/blob/main/packages/alchemy/src/State/HttpStateStore.ts) — HTTP client against the Alchemy state API
-- [`InMemoryState.ts`](https://github.com/sam-goodwin/alchemy-effect/blob/main/packages/alchemy/src/State/InMemoryState.ts) — minimal in-process map, useful as a template
+- [`LocalState.ts`](https://github.com/alchemy-run/alchemy/blob/main/packages/alchemy/src/State/LocalState.ts) — filesystem-backed, the simplest end-to-end example
+- [`HttpStateStore.ts`](https://github.com/alchemy-run/alchemy/blob/main/packages/alchemy/src/State/HttpStateStore.ts) — HTTP client against the Alchemy state API
+- [`InMemoryState.ts`](https://github.com/alchemy-run/alchemy/blob/main/packages/alchemy/src/State/InMemoryState.ts) — minimal in-process map, useful as a template

--- a/website/src/pages/index.mdx
+++ b/website/src/pages/index.mdx
@@ -378,7 +378,7 @@ between the two files with a short caption explaining each step. */}
       <Button
         variant="ghost"
         icon="github"
-        href="https://github.com/alchemy-run/alchemy-effect"
+        href="https://github.com/alchemy-run/alchemy"
       >
         GitHub
       </Button>

--- a/website/src/pages/privacy.mdx
+++ b/website/src/pages/privacy.mdx
@@ -17,8 +17,8 @@ features people actually use.
 
 This page documents exactly what is collected, what is not, where
 it goes, and how to opt out. Source of truth is the code:
-[`Telemetry/Attributes.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/Telemetry/Attributes.ts)
-and [`Cloudflare/StateStore/Api.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/Cloudflare/StateStore/Api.ts).
+[`Telemetry/Attributes.ts`](https://github.com/alchemy-run/alchemy/blob/main/packages/alchemy/src/Telemetry/Attributes.ts)
+and [`Cloudflare/StateStore/Api.ts`](https://github.com/alchemy-run/alchemy/blob/main/packages/alchemy/src/Cloudflare/StateStore/Api.ts).
 
 ## What we collect
 
@@ -87,7 +87,7 @@ hash to count distinct deployments without identifying anyone.
 standard OTLP/HTTP at `/v1/traces`, `/v1/logs`, and `/v1/metrics`,
 attaches an Axiom ingest token server-side, and forwards to our
 Axiom workspace. Source for the relay lives at
-[`stacks/otel/Ingester.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/stacks/otel/Ingester.ts).
+[`stacks/otel/Ingester.ts`](https://github.com/alchemy-run/alchemy/blob/main/stacks/otel/Ingester.ts).
 
 We do not share or sell the data. Aggregated stats may appear in
 public talks, posts, or dashboards.
@@ -151,6 +151,6 @@ custom HTTP state store via [/state-store/custom-state-store](/state-store/custo
 ## Questions
 
 Email [sam@alchemy.run](mailto:sam@alchemy.run) or open an issue at
-[alchemy-run/alchemy-effect](https://github.com/alchemy-run/alchemy-effect/issues).
+[alchemy-run/alchemy](https://github.com/alchemy-run/alchemy/issues).
 
 </div>


### PR DESCRIPTION
The repository moved from `alchemy-run/alchemy-effect` to `alchemy-run/alchemy`. This updates every in-repo reference to the old path.

- `repository.url` in every `package.json` (root, `packages/*`, `website`, all examples, benchmark)

```diff
-    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
```

- Live repo references where `owner: "alchemy-run"` is paired with the repo name (`stacks/github.ts`, `stacks/otel.ts`, `website/alchemy.run.ts`, `examples/cloudflare-agent`, GitHub capability JSDoc)

```diff
-const REPO = { owner: "alchemy-run", repository: "alchemy-effect" } as const;
+const REPO = { owner: "alchemy-run", repository: "alchemy" } as const;
```

- `.github/workflows/release.yml` `repo:` input, all docs/blog/CHANGELOG/README links, `astro.config.mjs` nav + edit-page URLs
- Stale `sam-goodwin/alchemy-effect` doc links now point to `alchemy-run/alchemy`
- Stale CLI hints in three auth providers: `alchemy-effect login --configure` → `alchemy login --configure`

Intentionally untouched: CHANGELOG entries quoting the old binary name, GitHub live-test fixture names, and the `images/alchemy-effect-*.png` asset filenames (real files referenced by README).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
