### PR TITLE
docs: fix stale API names in README and docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -748,7 +748,7 @@ export default class TestWorker extends Cloudflare.Worker<TestWorker>()(
     main: import.meta.url,
   },
   Effect.gen(function* () {
-    const aiGateway = yield* Cloudflare.AIbind(Gateway);
+    const aiGateway = yield* Cloudflare.AI.QueryGateway(Gateway);
 
     return {
       fetch: Effect.gen(function* () {
@@ -760,7 +760,7 @@ export default class TestWorker extends Cloudflare.Worker<TestWorker>()(
         return HttpServerResponse.text("ok");
       }),
     };
-  }).pipe(Effect.provide(Cloudflare.AI.GatewayBindingLive)),
+  }).pipe(Effect.provide(Cloudflare.AI.QueryGatewayBinding)),
 ) {}
 ```
 
@@ -845,7 +845,7 @@ Notes:
 
 ## Reference implementations
 
-- Cloudflare.AI.Gateway — [worker fixture](./packages/alchemy/test/Cloudflare.AI.Gateway/worker.ts) + [test](./packages/alchemy/test/Cloudflare.AI.Gateway/AiGateway.test.ts) (the deploy+fetch case lives at the bottom of the file)
+- Cloudflare.AI.Gateway — [worker fixture](./packages/alchemy/test/Cloudflare/AI/fixtures/TestWorker.ts) + [test](./packages/alchemy/test/Cloudflare/AI/Gateway.test.ts) (the deploy+fetch case lives at the bottom of the file)
 - Cloudflare D1Connection — [worker fixture](./packages/alchemy/test/Cloudflare/D1/d1-worker.ts) + [test](./packages/alchemy/test/Cloudflare/D1/D1Binding.test.ts)
 - Cloudflare Workflow — [workflow fixture](./packages/alchemy/test/Cloudflare/Workers/fixtures/test-workflow.ts) + [worker fixture](./packages/alchemy/test/Cloudflare/Workers/fixtures/workflow-worker.ts) + [test](./packages/alchemy/test/Cloudflare/Workers/Workflow.test.ts)
 - Cloudflare Cron Trigger — [worker + DO fixture](./packages/alchemy/test/Cloudflare/Workers/fixtures/cron-worker.ts) + [test](./packages/alchemy/test/Cloudflare/Workers/CronEventSource.test.ts) (cron handler writes to a DO; test polls a fetch route with `Effect.repeat` until the scheduled handler fires)

--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@
 A Worker bound to a R2 bucket and serving objects from it:
 
 ```typescript
-const Bucket = Cloudflare.R2Bucket("bucket");
+const Bucket = Cloudflare.R2.Bucket("bucket");
 
 export default Cloudflare.Worker(
   "api",
   { main: import.meta.url },
   Effect.gen(function* () {
-    const bucket = yield* Cloudflare.R2.ReadWrite(Bucket);
+    const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
     return {
       fetch: Effect.gen(function* () {
         const request = yield* HttpServerRequest;
@@ -35,11 +35,11 @@ export default Cloudflare.Worker(
         return HttpServerResponse.stream(object!.body);
       })
     };
-  }),
+  }).pipe(Effect.provide(Cloudflare.R2.ReadWriteBucketBinding)),
 );
 ```
 
-One `bind()` wires the binding, env var, and typed connection — at deploy time and at runtime.
+One `ReadWriteBucket(Bucket)` call wires the binding, env var, and typed client — at deploy time and at runtime.
 
 ---
 

--- a/website/src/content/docs/cloudflare/ai/effect-ai.mdx
+++ b/website/src/content/docs/cloudflare/ai/effect-ai.mdx
@@ -152,7 +152,7 @@ durable. Pick the one that matches your platform:
 
 | Platform | Backing |
 | --- | --- |
-| Cloudflare Worker + Durable Object | `Cloudflare.AIDurableObjectChatPersistence` — bytes live in `state.storage`, one DO instance per session |
+| Cloudflare Worker + Durable Object | `Cloudflare.AI.DurableObjectChatPersistence` — bytes live in `state.storage`, one DO instance per session |
 | Any platform, in-memory (tests) | `Persistence.layerBackingMemory` — lost on restart |
 | Anything else (KV, R2, DynamoDB, …) | Implement `BackingPersistence` against your store |
 

--- a/website/src/content/docs/cloudflare/compute/add-a-workflow.mdx
+++ b/website/src/content/docs/cloudflare/compute/add-a-workflow.mdx
@@ -247,13 +247,13 @@ sleep → broadcast → return — is durable end to end.
 ## Bind a secret
 
 Most real workflows need credentials — an upstream API key, a
-signing token, etc. `Alchemy.Secret` registers a `secret_text`
-binding on the workflow at plantime and hands back an accessor
-for use inside steps:
+signing token, etc. `Config.redacted` registers a `secret_text`
+binding on the workflow at plantime and hands back a
+`Redacted<string>` for use inside steps:
 
 ```diff lang="typescript"
-+import * as Alchemy from "alchemy";
  import * as Cloudflare from "alchemy/Cloudflare";
++import * as Config from "effect/Config";
  import * as Effect from "effect/Effect";
  import Room from "./room.ts";
 
@@ -261,10 +261,10 @@ for use inside steps:
    "Notifier",
    Effect.gen(function* () {
      const rooms = yield* Room;
-+    const apiKey = yield* Alchemy.Secret("API_KEY");
++    const apiKey = yield* Config.redacted("API_KEY");
 ```
 
-`Alchemy.Secret("API_KEY")` reads `API_KEY` from the active
+`Config.redacted("API_KEY")` reads `API_KEY` from the active
 `Config` provider (env vars, `.env`, …) at plantime and binds it
 into the workflow as `secret_text`. Set it in your local `.env`:
 
@@ -278,8 +278,8 @@ input shapes (literals, `Effect`, `Config`, …).
 
 ## Use the secret in a task
 
-The accessor returned in init is yielded inside the Runtime phase to resolve a
-`Redacted<string>`. Unwrap with `Redacted.value` only at the call
+The `Redacted<string>` resolved in init is captured by the Runtime
+body. Unwrap with `Redacted.value` only at the call
 site that needs it (here, an `Authorization` header):
 
 ```diff lang="typescript"
@@ -291,7 +291,7 @@ site that needs it (here, an `Authorization` header):
    "Notifier",
    Effect.gen(function* () {
      const rooms = yield* Room;
-     const apiKey = yield* Alchemy.Secret("API_KEY");
+     const apiKey = yield* Config.redacted("API_KEY");
 
      return Effect.gen(function* () {
        const env = yield* Cloudflare.Workers.WorkerEnvironment;
@@ -309,11 +309,10 @@ site that needs it (here, an `Authorization` header):
          room.broadcast(`[workflow] ${stored}`),
        );
 
-+      const key = yield* apiKey;
 +      yield* Cloudflare.Workflows.task(
 +        "fetch-with-auth",
 +        HttpClientRequest.get("https://example.com/data").pipe(
-+          HttpClientRequest.bearerToken(Redacted.value(key)),
++          HttpClientRequest.bearerToken(Redacted.value(apiKey)),
 +          HttpClient.execute,
 +          Effect.flatMap((r) => r.text),
 +        ),
@@ -325,8 +324,7 @@ site that needs it (here, an `Authorization` header):
  ) {}
 ```
 
-`yield* apiKey` lives inside the body Effect — the Runtime phase —
-not at module scope. `HttpClient.execute` runs inside
+`HttpClient.execute` runs inside
 `Cloudflare.Workflows.task`, so the response is checkpointed and the
 request only fires once across replays. `Redacted.value` is
 called at the single header site that needs the cleartext;

--- a/website/src/content/docs/infrastructure-as-code/outputs.mdx
+++ b/website/src/content/docs/infrastructure-as-code/outputs.mdx
@@ -193,7 +193,7 @@ You rarely call this directly because resources already act like
 `Output`s, but it's how the conversion happens internally:
 
 ```typescript
-const bucketOut = Output.of(bucket);          // Output<R2BucketAttrs>
+const bucketOut = Output.of(bucket);          // Output<Bucket>
 const refOut    = Output.of(Ref({ id: "B" })); // for cross-stack refs
 ```
 


### PR DESCRIPTION
Fix stale API names in the README and docs, found by validating every dotted `Cloudflare.*` / `AWS.*` / `Alchemy.*` reference in non-blog docs against the package's actual exports.

- README hero snippet used two nonexistent names and skipped the binding layer:

  ```diff
  -const Bucket = Cloudflare.R2Bucket("bucket");
  +const Bucket = Cloudflare.R2.Bucket("bucket");
  ...
  -    const bucket = yield* Cloudflare.R2.ReadWrite(Bucket);
  +    const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
  ...
  -  }),
  +  }).pipe(Effect.provide(Cloudflare.R2.ReadWriteBucketBinding)),
  ```

- `add-a-workflow.mdx`: the "Bind a secret" section used a nonexistent `Alchemy.Secret("API_KEY")` accessor API; replaced with `Config.redacted("API_KEY")`, which yields the `Redacted<string>` directly at init (matches `examples/cloudflare-worker/src/NotifyWorkflow.ts` and the secrets concept doc).
- `effect-ai.mdx`: `Cloudflare.AIDurableObjectChatPersistence` → `Cloudflare.AI.DurableObjectChatPersistence` (missing dot).
- `outputs.mdx`: stale `Output<R2BucketAttrs>` comment → `Output<Bucket>`.
- `AGENTS.md`: AI Gateway fixture example used pre-beta-59 names (`Cloudflare.AIbind`, `GatewayBindingLive`) and dead fixture paths; now `Cloudflare.AI.QueryGateway` / `QueryGatewayBinding` and `test/Cloudflare/AI/...`.

Blog posts are untouched — beta-59 is the rename announcement, so its old names are intentional migration diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
