### PR TITLE
fix(cloudflare/worker): accept Effect props in Worker class form

### DIFF
--- a/packages/alchemy/src/AWS/Lambda/Function.ts
+++ b/packages/alchemy/src/AWS/Lambda/Function.ts
@@ -903,6 +903,7 @@ export const FunctionProvider = () =>
                 (importPath) => `
 import { layer as nodeServicesLayer } from "@effect/platform-node/NodeServices";
 import { Stack } from "alchemy/Stack";
+import { Stage } from "alchemy/Stage";
 import { makeEntrypointLayer, reifyBoundConfigProvider } from "alchemy/Runtime";
 import { registerLambdaExtension } from "alchemy/AWS/Lambda/RuntimeExtension";
 import * as Config from "effect/Config";
@@ -958,6 +959,9 @@ const stack = Layer.effect(
 
 const entryLayer = layer.pipe(
   Layer.provideMerge(stack),
+  // Effect-form props re-evaluate inside the deployed Function, so
+  // stage-dependent props need \`Stage\` at runtime just like at plan/deploy.
+  Layer.provideMerge(Layer.effect(Stage, Config.string("ALCHEMY_STAGE"))),
   Layer.provideMerge(Credentials.fromEnv()),
   Layer.provideMerge(Region.fromEnv()),
   Layer.provideMerge(platform),

--- a/packages/alchemy/src/AWS/Lambda/MicrovmBundle.ts
+++ b/packages/alchemy/src/AWS/Lambda/MicrovmBundle.ts
@@ -135,6 +135,7 @@ import { NodeHttpServer } from "alchemy/Http";
 const HttpServer = NodeHttpServer;`
 }
 import { Stack } from "alchemy/Stack";
+import { Stage } from "alchemy/Stage";
 import { makeEntrypointLayer } from "alchemy/Runtime";
 import * as Effect from "effect/Effect";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
@@ -167,6 +168,9 @@ const serverEffect = tag.pipe(
   Effect.provide(
     layer.pipe(
       Layer.provideMerge(stack),
+      // Effect-form props re-evaluate inside the running microVM, so
+      // stage-dependent props need Stage at runtime just like at plan/deploy.
+      Layer.provideMerge(Layer.succeed(Stage, ${JSON.stringify(stack.stage)})),
       Layer.provideMerge(HttpServer({ port: Number(process.env.PORT ?? ${port}) })),
       Layer.provideMerge(platform),
       Layer.provideMerge(

--- a/packages/alchemy/src/Cloudflare/Containers/ContainerBundle.ts
+++ b/packages/alchemy/src/Cloudflare/Containers/ContainerBundle.ts
@@ -199,6 +199,7 @@ const HttpServer = NodeHttpServer;
 `
 }
 import { Stack } from "alchemy/Stack";
+import { Stage } from "alchemy/Stage";
 import { makeEntrypointLayer, reifyBoundConfigProvider } from "alchemy/Runtime";
 import { CloudflareEnvironment } from "alchemy/Cloudflare";
 import * as ConfigProvider from "effect/ConfigProvider";
@@ -234,6 +235,9 @@ const serverEffect = tag.pipe(
   Effect.provide(
     layer.pipe(
       Layer.provideMerge(stack),
+      // Effect-form props re-evaluate inside the running container, so
+      // stage-dependent props need \`Stage\` at runtime just like at plan/deploy.
+      Layer.provideMerge(Layer.succeed(Stage, ${JSON.stringify(stack.stage)})),
       Layer.provideMerge(HttpServer()),
       // Capability bindings that talk to Cloudflare's HTTP API from inside the
       // container (e.g. R2/KV/Queue \`*Http\` bindings) resolve their account via

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -1181,6 +1181,7 @@ export const Worker: ResourceClassLike<Worker> &
             | Extract<Deps, Container.Application<any>>
             | Providers
             | Exclude<InitReq, Self | WorkerServices>
+            | Exclude<PropsReq, Self | WorkerServices | PlatformServices>
           >;
         };
     };
@@ -1193,14 +1194,19 @@ export const Worker: ResourceClassLike<Worker> &
           | Container.Application<any>
           | PlatformServices
           | Tag,
+        PropsReq = never,
       >(
         id: Id,
-        props: InputProps<WorkerProps>,
+        props:
+          | InputProps<WorkerProps>
+          | Effect.Effect<InputProps<WorkerProps>, ConfigError, PropsReq>,
         impl: Effect.Effect<Shape, ConfigError, Req>,
       ): Effect.Effect<
         Worker & Rpc<Self>,
         never,
-        Extract<Req, Container.Application<any>> | Providers
+        | Extract<Req, Container.Application<any>>
+        | Providers
+        | Exclude<PropsReq, WorkerServices | PlatformServices>
       > &
         Named<Id> & {
           new (): MakeShape<Shape, WorkerShape> & Named<Id> & Tag;
@@ -1237,14 +1243,19 @@ export const Worker: ResourceClassLike<Worker> &
         | WorkerServices
         | Container.Application<any>
         | PlatformServices,
+      PropsReq = never,
     >(
       id: string,
-      props: InputProps<WorkerProps>,
+      props:
+        | InputProps<WorkerProps>
+        | Effect.Effect<InputProps<WorkerProps>, ConfigError, PropsReq>,
       impl: Effect.Effect<Shape, ConfigError, Req>,
     ): Effect.Effect<
       Worker & Rpc<Shape>,
       never,
-      Extract<Req, Container.Application<any>> | Providers
+      | Extract<Req, Container.Application<any>>
+      | Providers
+      | Exclude<PropsReq, WorkerServices | PlatformServices>
     > &
       Named<Id>;
   } = Platform(WorkerTypeId, {

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerBridge.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerBridge.ts
@@ -19,6 +19,7 @@ import {
 } from "../../Runtime.ts";
 import { Self } from "../../Self.ts";
 import { Stack } from "../../Stack.ts";
+import { Stage } from "../../Stage.ts";
 import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
 import cloudflare_workers from "./cloudflare_workers.ts";
 import { isScopeEjected } from "./HttpServer.ts";
@@ -267,6 +268,11 @@ const getSharedBuild = (
               actions: {},
             }),
           ),
+          // Effect-form props (`Cloudflare.Worker<W>()(id, Effect.gen(...), impl)`)
+          // re-evaluate inside the deployed Worker, so stage-dependent props
+          // (e.g. deriving a domain from the Stage) need `Stage` at runtime
+          // just like they get it at plan/deploy.
+          Layer.provideMerge(Layer.succeed(Stage, stack.stage)),
           Layer.provideMerge(platform),
           Layer.provideMerge(
             Layer.succeed(

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerEffectProps.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerEffectProps.test.ts
@@ -1,0 +1,50 @@
+import * as Alchemy from "@/index.ts";
+import * as Cloudflare from "@/Cloudflare";
+import * as Test from "@/Test/Vitest";
+import * as Effect from "effect/Effect";
+import { expectUrlContains } from "../Utils/Http.ts";
+import EffectPropsWorker from "./fixtures/effect-props-worker.ts";
+
+const { beforeAll, afterAll, deploy, destroy, test } = Test.make({
+  providers: Cloudflare.providers(),
+});
+
+const Stack = Alchemy.Stack(
+  "WorkerEffectPropsTestStack",
+  { providers: Cloudflare.providers(), state: Cloudflare.state() },
+  Effect.gen(function* () {
+    const worker = yield* EffectPropsWorker;
+    return { url: worker.url.as<string>() };
+  }),
+);
+
+const stack = beforeAll(deploy(Stack));
+afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(Stack));
+
+/**
+ * The class form accepts an Effect of props (see
+ * WorkerEffectProps.types.ts for the compile-time contract). This test
+ * pins the runtime half: the props effect yields `Stage`, which the
+ * Worker bridge must provide inside the deployed isolate — the fixture
+ * echoes the props-derived value, so a missing `Stage` (init defect,
+ * every request 500s) or a dropped env binding fails the marker check.
+ */
+test(
+  "class-form worker with Stage-dependent Effect props deploys and serves",
+  Effect.gen(function* () {
+    const { url } = yield* stack;
+    const body = yield* expectUrlContains(url, "effect-props-stage:", {
+      label: "effect-props-worker",
+    });
+    // The stage suffix is the live value the props effect computed at
+    // runtime — assert it's non-empty rather than pinning the test
+    // runner's stage name.
+    const stage = body.split("effect-props-stage:")[1]?.trim();
+    if (!stage) {
+      return yield* Effect.die(
+        new Error(`props-derived stage missing from body: ${body}`),
+      );
+    }
+  }),
+  { timeout: 180_000 },
+);

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerEffectProps.types.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerEffectProps.types.ts
@@ -1,0 +1,88 @@
+/**
+ * Compile-only regression test: the Worker class form (and the named
+ * three-arg form) accept an `Effect` of props, not just a plain props
+ * object. Stage/Stack-dependent props (e.g. deriving a stage-specific
+ * domain) are the motivating case — see the props-only overload, which
+ * always supported this.
+ */
+import * as Cloudflare from "@/Cloudflare";
+import { Stack } from "@/Stack.ts";
+import { Stage } from "@/Stage.ts";
+import * as Effect from "effect/Effect";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+const domain = (domain: string) =>
+  Stage.pipe(
+    Effect.map((stage) =>
+      stage === "prod"
+        ? domain
+        : stage.startsWith("staging-")
+          ? `${stage}.${domain}`
+          : undefined,
+    ),
+  );
+
+const impl = Effect.gen(function* () {
+  return {
+    fetch: Effect.succeed(HttpServerResponse.text("ok")),
+  };
+});
+
+// Class form with an Effect of props that yields Stage.
+export default class StageDomainWorker extends Cloudflare.Worker<StageDomainWorker>()(
+  "StageDomainWorker",
+  Effect.gen(function* () {
+    return {
+      main: import.meta.url,
+      domain: yield* domain("facilitator.example.com"),
+      dev: {
+        host: "127.0.0.1",
+        port: 1337,
+        strictPort: true,
+      },
+    };
+  }),
+  impl,
+) {}
+
+// Same via Stack (also part of PlatformServices).
+export class StackDomainWorker extends Cloudflare.Worker<StackDomainWorker>()(
+  "StackDomainWorker",
+  Effect.gen(function* () {
+    const stack = yield* Stack;
+    return {
+      main: import.meta.url,
+      domain: stack.stage === "prod" ? "api.example.com" : undefined,
+    };
+  }),
+  impl,
+) {}
+
+// Named three-arg form (no class).
+export const NamedWorker = Cloudflare.Worker(
+  "NamedWorker",
+  Effect.gen(function* () {
+    return {
+      main: import.meta.url,
+      domain: yield* domain("named.example.com"),
+    };
+  }),
+  impl,
+);
+
+type RequirementsOf<T> =
+  T extends Effect.Effect<unknown, unknown, infer Req> ? Req : never;
+type Assert<T extends true> = T;
+
+// Stage/Stack are provided by the Stack at plan/deploy and by the runtime
+// bridges inside the deployed Worker, so they must not leak out of the
+// declaration's requirements.
+type _ClassFormDischargesStage = Assert<
+  Stage extends RequirementsOf<typeof StageDomainWorker> ? false : true
+>;
+type _ClassFormDischargesStack = Assert<
+  Stack extends RequirementsOf<typeof StackDomainWorker> ? false : true
+>;
+type _NamedFormDischargesStage = Assert<
+  Stage extends RequirementsOf<typeof NamedWorker> ? false : true
+>;

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/effect-props-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/effect-props-worker.ts
@@ -1,0 +1,31 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import { Stage } from "@/Stage.ts";
+import * as Effect from "effect/Effect";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+/**
+ * Class-form Worker whose props are an Effect that depends on `Stage` —
+ * the "stage-specific domain" pattern. The props effect re-evaluates
+ * inside the deployed Worker, so this fixture proves the runtime bridge
+ * provides `Stage` (a missing service would defect at init and 500
+ * every request). The stage value flows through props `env` so the
+ * handler can echo what the props effect actually computed.
+ */
+export default class EffectPropsWorker extends Cloudflare.Worker<EffectPropsWorker>()(
+  "EffectPropsWorker",
+  Effect.gen(function* () {
+    const stage = yield* Stage;
+    return {
+      main: import.meta.url,
+      env: { PROPS_STAGE: stage },
+    };
+  }),
+  Effect.gen(function* () {
+    const env = yield* Cloudflare.WorkerEnvironment;
+    return {
+      fetch: Effect.succeed(
+        HttpServerResponse.text(`effect-props-stage:${env.PROPS_STAGE}`),
+      ),
+    };
+  }),
+) {}


### PR DESCRIPTION
The Worker class form (and the named three-arg form) rejected an `Effect` of props even though the props-only overload — and the runtime — already support it. This is the type error reported in Discord for the stage-specific-domain pattern:

```ts
export default class FacilitatorWorker extends Cloudflare.Worker<FacilitatorWorker>()(
  "Facilitator",
  Effect.gen(function* () {
    return {
      main: import.meta.url,
      domain: yield* domain("facilitator.crosshatch.dev"), // yields Stage
    };
  }),
  impl,
) {}
// before: Type 'Effect<...>' has no properties in common with type 'InputProps<WorkerProps<...>>'
```

- `Worker`'s class-form and named-impl overloads now accept `Effect.Effect<InputProps<WorkerProps>, ConfigError, PropsReq>`, discharging `PropsReq` against `WorkerServices | PlatformServices` (matching the generic `Platform` interface); the `.make` overload threads its previously-dropped `PropsReq` the same way.
- Effect-form props re-evaluate inside the deployed artifact, so the runtime bridges now provide `Stage` alongside `Stack` (Worker bridge, Lambda entry, Container bundle, MicroVM bundle) — a props effect yielding `Stage` previously defected at init. The local RPC server environment already did this.
- `WorkerEffectProps.types.ts` pins the compile-time contract (reproduces the reported error verbatim without the fix); `WorkerEffectProps.test.ts` deploys a class-form Worker whose props derive from `Stage` and asserts the served body echoes the props-derived value (live-tested green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
