### PR TITLE
feat(cli): alchemy login works without an alchemy.run.ts

### DIFF
--- a/packages/alchemy/src/Cli/commands/_shared.ts
+++ b/packages/alchemy/src/Cli/commands/_shared.ts
@@ -23,6 +23,12 @@ import {
   ALCHEMY_PROFILE,
   withProfileOverride,
 } from "../../Auth/Profile.ts";
+import { AwsAuth } from "../../AWS/AuthProvider.ts";
+import { AxiomAuth } from "../../Axiom/AuthProvider.ts";
+import { CloudflareAuth } from "../../Cloudflare/Auth/AuthProvider.ts";
+import { GitHubAuth } from "../../GitHub/AuthProvider.ts";
+import { NeonAuth } from "../../Neon/AuthProvider.ts";
+import { PlanetscaleAuth } from "../../Planetscale/AuthProvider.ts";
 import * as Stack from "../../Stack.ts";
 import { Stage } from "../../Stage.ts";
 import { recordCli } from "../../Telemetry/Metrics.ts";
@@ -440,3 +446,49 @@ export const buildStackProviders = Effect.fn("buildStackProviders")(function* (
   );
   return { authProviders, context, stackEffect };
 });
+
+/**
+ * The auth providers Alchemy ships with. Used as the baseline registry so
+ * `alchemy login` works from any folder (no `alchemy.run.ts` required) and
+ * `alchemy profile show` can pretty-print any provider a profile mentions,
+ * even one the current stack doesn't wire up.
+ */
+export const builtinAuth = Layer.mergeAll(
+  AwsAuth,
+  AxiomAuth,
+  CloudflareAuth,
+  GitHubAuth,
+  NeonAuth,
+  PlanetscaleAuth,
+);
+
+/**
+ * Build {@link builtinAuth} against `registry` so every built-in auth
+ * provider registers itself, without importing any stack entrypoint.
+ */
+export const buildBuiltinAuthProviders = Effect.fn("buildBuiltinAuthProviders")(
+  function* (options: {
+    envFile: Option.Option<string>;
+    profile: string;
+    /** Registry to populate. Defaults to a fresh empty registry. */
+    registry?: AuthProviders["Service"];
+  }) {
+    const authProviders = options.registry ?? {};
+    yield* Layer.build(
+      Layer.provide(
+        builtinAuth,
+        Layer.mergeAll(
+          Layer.succeed(AuthProviders, authProviders),
+          ConfigProvider.layer(
+            withProfileOverride(
+              yield* loadConfigProvider(options.envFile),
+              options.profile,
+            ),
+          ),
+          Logger.layer([fileLogger("out")], { mergeWithExisting: true }),
+        ),
+      ),
+    );
+    return authProviders;
+  },
+);

--- a/packages/alchemy/src/Cli/commands/login.ts
+++ b/packages/alchemy/src/Cli/commands/login.ts
@@ -9,6 +9,7 @@ import * as CliError from "effect/unstable/cli/CliError";
 
 import type { AuthProviders } from "../../Auth/AuthProvider.ts";
 import { AlchemyProfile } from "../../Auth/Profile.ts";
+import * as Clank from "../../Util/Clank.ts";
 
 import {
   buildBuiltinAuthProviders,
@@ -81,7 +82,12 @@ export const loginCommand = Command.make(
         );
       }
 
+      const profiles = yield* AlchemyProfile;
+      const ci = yield* Config.boolean("CI").pipe(Config.withDefault(false));
+
       let authProviders: AuthProviders["Service"];
+      // Providers to actually log in with; `undefined` means all registered.
+      let selected: string[] | undefined;
       if (mainExists) {
         // Build the user's providers() (+ state) layer to capture the auth
         // providers their stack wires up.
@@ -92,21 +98,38 @@ export const loginCommand = Command.make(
         }));
       } else {
         // No stack entrypoint — register every built-in auth provider so
-        // `alchemy login` works from any folder.
+        // `alchemy login` works from any folder. Interactively, let the
+        // user pick which ones to log in with; in CI, take them all.
         yield* Console.log(
-          "No alchemy.run.ts found — logging in with all built-in providers.",
+          "No alchemy.run.ts found — using Alchemy's built-in providers.",
         );
         authProviders = yield* buildBuiltinAuthProviders({ envFile, profile });
+        if (!ci) {
+          const existing = yield* profiles.getProfile(profile);
+          const names = Object.keys(authProviders).sort();
+          selected = yield* Clank.multiselect({
+            message: "Select providers to log in with",
+            options: names.map((name) => ({
+              value: name,
+              label: name,
+              hint: existing?.[name] != null ? "configured" : undefined,
+            })),
+            // Pre-select providers already in the profile so re-running
+            // login naturally refreshes/re-prints what's set up.
+            initialValues: names.filter((name) => existing?.[name] != null),
+          });
+        }
       }
 
-      const profiles = yield* AlchemyProfile;
-
-      const ci = yield* Config.boolean("CI").pipe(Config.withDefault(false));
-      const providers = Object.values(authProviders);
+      const providers = Object.values(authProviders).filter(
+        (provider) => selected == null || selected.includes(provider.name),
+      );
 
       if (providers.length === 0) {
         yield* Console.log(
-          "No AuthProviders registered. Make sure the stack's providers() layer includes AuthProviderLayer entries.",
+          selected != null
+            ? "No providers selected."
+            : "No AuthProviders registered. Make sure the stack's providers() layer includes AuthProviderLayer entries.",
         );
         return;
       }

--- a/packages/alchemy/src/Cli/commands/login.ts
+++ b/packages/alchemy/src/Cli/commands/login.ts
@@ -1,17 +1,22 @@
 import * as Config from "effect/Config";
 import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Option from "effect/Option";
 import { Command, Flag } from "effect/unstable/cli";
+import * as Argument from "effect/unstable/cli/Argument";
+import * as CliError from "effect/unstable/cli/CliError";
 
+import type { AuthProviders } from "../../Auth/AuthProvider.ts";
 import { AlchemyProfile } from "../../Auth/Profile.ts";
 
 import {
+  buildBuiltinAuthProviders,
   buildStackProviders,
   envFile,
   instrumentCommand,
   printProfile,
   profile,
-  script,
 } from "./_shared.ts";
 
 const loginConfigure = Flag.boolean("configure").pipe(
@@ -21,30 +26,78 @@ const loginConfigure = Flag.boolean("configure").pipe(
   Flag.withDefault(false),
 );
 
+/**
+ * Stack entrypoint whose `providers()` layer selects which auth providers
+ * to log in with. Optional: when omitted and no `alchemy.run.ts` exists in
+ * the current folder, `alchemy login` falls back to every built-in auth
+ * provider, so logging in (and refreshing credentials) works from any
+ * folder.
+ */
+const loginMain = Argument.file("main").pipe(
+  Argument.withDescription(
+    "Stack entrypoint whose providers() to log in with, defaults to alchemy.run.ts (falls back to all built-in providers when absent)",
+  ),
+  Argument.optional,
+);
+
 export const loginCommand = Command.make(
   "login",
   {
-    main: script,
+    main: loginMain,
     envFile,
     profile,
     configure: loginConfigure,
   },
   instrumentCommand(
     "login",
-    (a: { main: string; profile: string; configure: boolean }) => ({
+    (a: {
+      main: Option.Option<string>;
+      profile: string;
+      configure: boolean;
+    }) => ({
       "alchemy.profile": a.profile,
-      "alchemy.main": a.main,
+      "alchemy.main": Option.getOrElse(a.main, () => "alchemy.run.ts"),
       "alchemy.configure": a.configure,
     }),
   )(
     Effect.fn(function* ({ main, envFile, profile, configure }) {
-      // Build the user's providers() (+ state) layer to capture the auth
-      // providers their stack wires up.
-      const { authProviders } = yield* buildStackProviders({
-        main,
-        envFile,
-        profile,
-      });
+      const fs = yield* FileSystem.FileSystem;
+      const explicitMain = Option.getOrUndefined(main);
+      const mainPath = explicitMain ?? "alchemy.run.ts";
+      const mainExists = yield* fs
+        .exists(mainPath)
+        .pipe(Effect.catch(() => Effect.succeed(false)));
+
+      // An explicitly-passed entrypoint must exist; only the default may
+      // fall back to the built-in providers.
+      if (explicitMain != null && !mainExists) {
+        return yield* Effect.fail(
+          new CliError.InvalidValue({
+            option: "main",
+            value: explicitMain,
+            expected: "an existing stack entrypoint file",
+            kind: "argument",
+          }),
+        );
+      }
+
+      let authProviders: AuthProviders["Service"];
+      if (mainExists) {
+        // Build the user's providers() (+ state) layer to capture the auth
+        // providers their stack wires up.
+        ({ authProviders } = yield* buildStackProviders({
+          main: mainPath,
+          envFile,
+          profile,
+        }));
+      } else {
+        // No stack entrypoint — register every built-in auth provider so
+        // `alchemy login` works from any folder.
+        yield* Console.log(
+          "No alchemy.run.ts found — logging in with all built-in providers.",
+        );
+        authProviders = yield* buildBuiltinAuthProviders({ envFile, profile });
+      }
 
       const profiles = yield* AlchemyProfile;
 

--- a/packages/alchemy/src/Cli/commands/profile.ts
+++ b/packages/alchemy/src/Cli/commands/profile.ts
@@ -1,45 +1,21 @@
-import * as ConfigProvider from "effect/ConfigProvider";
 import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as Logger from "effect/Logger";
 import * as Option from "effect/Option";
 import { Command } from "effect/unstable/cli";
 import * as Argument from "effect/unstable/cli/Argument";
 
 import { AuthProviders } from "../../Auth/AuthProvider.ts";
 import { CredentialsStore } from "../../Auth/Credentials.ts";
-import { AlchemyProfile, withProfileOverride } from "../../Auth/Profile.ts";
-import { AwsAuth } from "../../AWS/AuthProvider.ts";
-import { AxiomAuth } from "../../Axiom/AuthProvider.ts";
-import { CloudflareAuth } from "../../Cloudflare/Auth/AuthProvider.ts";
-import { GitHubAuth } from "../../GitHub/AuthProvider.ts";
-import { NeonAuth } from "../../Neon/AuthProvider.ts";
-import { PlanetscaleAuth } from "../../Planetscale/AuthProvider.ts";
-import { loadConfigProvider } from "../../Util/ConfigProvider.ts";
-import { fileLogger } from "../../Util/FileLogger.ts";
+import { AlchemyProfile } from "../../Auth/Profile.ts";
 
 import {
+  buildBuiltinAuthProviders,
   buildStackProviders,
   envFile,
   instrumentCommand,
   printProfile,
   profile,
 } from "./_shared.ts";
-
-/**
- * The auth providers Alchemy ships with. Built into the registry as a
- * baseline so `profile show` can pretty-print any provider a profile
- * mentions, even one the current stack doesn't wire up.
- */
-const builtinAuth = Layer.mergeAll(
-  AwsAuth,
-  AxiomAuth,
-  CloudflareAuth,
-  GitHubAuth,
-  NeonAuth,
-  PlanetscaleAuth,
-);
 
 /**
  * Entrypoint whose `providers()` layer contributes the user's own auth
@@ -73,21 +49,11 @@ export const collectAuthProviders = Effect.fn("collectAuthProviders")(
     const authProviders: AuthProviders["Service"] = {};
 
     // 1. Built-in providers first (baseline).
-    yield* Layer.build(
-      Layer.provide(
-        builtinAuth,
-        Layer.mergeAll(
-          Layer.succeed(AuthProviders, authProviders),
-          ConfigProvider.layer(
-            withProfileOverride(
-              yield* loadConfigProvider(options.envFile),
-              options.profile,
-            ),
-          ),
-          Logger.layer([fileLogger("out")], { mergeWithExisting: true }),
-        ),
-      ),
-    );
+    yield* buildBuiltinAuthProviders({
+      envFile: options.envFile,
+      profile: options.profile,
+      registry: authProviders,
+    });
 
     // 2. The user's own providers() layer on top — building into the same
     //    registry overrides the built-ins by name. Best-effort: swallow


### PR DESCRIPTION
`alchemy login` no longer requires an `alchemy.run.ts`. When the default entrypoint is absent, it registers every built-in auth provider (AWS, Axiom, Cloudflare, GitHub, Neon, Planetscale) and prompts a multi-select of which ones to log in with, so credentials can be set up and refreshed from any folder.

```
$ cd /some/empty/dir && alchemy login
No alchemy.run.ts found — using Alchemy's built-in providers.
◆  Select providers to log in with
│  ◻ AWS
│  ◻ Axiom
│  ◻ Cloudflare
│  ◼ GitHub (configured)
│  ◻ Neon
│  ◻ Planetscale
```

- Providers already in the profile are pre-selected and hinted as `configured`; only the selected providers run their configure step.
- In CI the prompt is skipped and all built-ins are configured non-interactively.
- With an `alchemy.run.ts` present, behavior is unchanged: only the stack's `providers()` auth providers are configured, with no prompt.
- An explicitly passed `main` argument must still exist; a missing path fails with `CliError.InvalidValue` instead of silently falling back.
- The built-in provider registry moved from `profile.ts` into `_shared.ts` (`builtinAuth` + `buildBuiltinAuthProviders`) and is shared by `alchemy login` and `alchemy profile show`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
