### PR TITLE
feat(github): GitHub Enterprise support + Environment resource

### DIFF
--- a/packages/alchemy/src/GitHub/AuthProvider.ts
+++ b/packages/alchemy/src/GitHub/AuthProvider.ts
@@ -13,6 +13,11 @@ import {
 import { CredentialsStore, displayRedacted } from "../Auth/Credentials.ts";
 import { getEnvRedacted, retryOnce } from "../Auth/Env.ts";
 import * as Clank from "../Util/Clank.ts";
+import {
+  githubHostname,
+  normalizeGitHubBaseUrl,
+  resolveGitHubBaseUrlFromEnv,
+} from "./BaseUrl.ts";
 
 const options: Array<{
   value: GitHubAuthConfig["method"];
@@ -37,9 +42,9 @@ const options: Array<{
 ];
 
 export type GitHubAuthConfig =
-  | { method: "env" }
-  | { method: "stored" }
-  | { method: "gh-cli" };
+  | { method: "env"; baseUrl?: string }
+  | { method: "stored"; baseUrl?: string }
+  | { method: "gh-cli"; baseUrl?: string };
 
 export interface GitHubStoredCredentials {
   type: "pat";
@@ -49,6 +54,12 @@ export interface GitHubStoredCredentials {
 export interface GitHubResolvedCredentials {
   type: "token";
   token: Redacted.Redacted<string>;
+  /**
+   * Normalized REST API base URL for GitHub Enterprise (e.g.
+   * `https://github.example.com/api/v3` or `https://api.acme.ghe.com`).
+   * `undefined` means github.com.
+   */
+  baseUrl?: string;
   source: { type: GitHubAuthConfig["method"]; details?: string };
 }
 
@@ -59,14 +70,59 @@ class GhCliError extends Error {
 }
 
 /**
+ * Read GitHub credentials from the environment. The base URL comes from the
+ * stored config when set, otherwise from `GITHUB_BASE_URL`, `GITHUB_API_URL`,
+ * or `GH_HOST`. When it resolves to a GitHub Enterprise host, the gh CLI's
+ * enterprise token variables (`GH_ENTERPRISE_TOKEN`, `GITHUB_ENTERPRISE_TOKEN`)
+ * are checked before the standard `GITHUB_ACCESS_TOKEN` / `GITHUB_TOKEN`.
+ */
+export const readEnvCredentials = (
+  configBaseUrl?: string,
+): Effect.Effect<GitHubResolvedCredentials, AuthError> =>
+  Effect.gen(function* () {
+    const baseUrl = configBaseUrl ?? (yield* resolveGitHubBaseUrlFromEnv);
+    const candidates =
+      baseUrl !== undefined
+        ? [
+            "GH_ENTERPRISE_TOKEN",
+            "GITHUB_ENTERPRISE_TOKEN",
+            "GITHUB_ACCESS_TOKEN",
+            "GITHUB_TOKEN",
+          ]
+        : ["GITHUB_ACCESS_TOKEN", "GITHUB_TOKEN"];
+    for (const key of candidates) {
+      const token = yield* getEnvRedacted(key);
+      if (token) {
+        return {
+          type: "token" as const,
+          token,
+          baseUrl,
+          source: { type: "env" as const, details: key },
+        };
+      }
+    }
+    return yield* new AuthError({
+      message: `GitHub env credentials not found. Set ${candidates.join(", ")}.`,
+    });
+  });
+
+/**
  * Layer that registers the GitHub {@link AuthProvider} into the
  * {@link AuthProviders} registry when built. Include this in the GitHub
  * `providers()` layer so `alchemy login` can discover it.
  *
  * Supported methods:
  * - `gh-cli`: shells out to `gh auth token` (recommended).
- * - `env`: reads `GITHUB_ACCESS_TOKEN` or `GITHUB_TOKEN`.
+ * - `env`: reads `GITHUB_ACCESS_TOKEN` or `GITHUB_TOKEN` (plus
+ *   `GH_ENTERPRISE_TOKEN` / `GITHUB_ENTERPRISE_TOKEN` on enterprise hosts).
  * - `stored`: prompts for a PAT and writes it to `~/.alchemy/credentials`.
+ *
+ * GitHub Enterprise (Server or Cloud with data residency) is supported by
+ * every method: `alchemy login --configure` prompts for the host, or set
+ * `GITHUB_BASE_URL` / `GITHUB_API_URL` / `GH_HOST` in the environment. The
+ * host is normalized into the REST API base URL passed to Octokit, and
+ * `gh auth token` is invoked with `--hostname` so the CLI returns the token
+ * for the right host.
  *
  * Browser/device OAuth is intentionally not implemented: GitHub's
  * OAuth App flow requires a `client_secret` we cannot ship, and
@@ -81,10 +137,18 @@ export const GitHubAuth = AuthProviderLayer<
     const store = yield* CredentialsStore;
     const cp = yield* ChildProcessSpawner;
 
-    const ghCliToken = (): Effect.Effect<string, AuthError> =>
+    const ghCliToken = (hostname?: string): Effect.Effect<string, AuthError> =>
       Effect.gen(function* () {
         const handle = yield* cp.spawn(
-          ChildProcess.make("gh", ["auth", "token"], { shell: false }),
+          ChildProcess.make(
+            "gh",
+            [
+              "auth",
+              "token",
+              ...(hostname !== undefined ? ["--hostname", hostname] : []),
+            ],
+            { shell: false },
+          ),
         );
         const [exitCode, stdout, stderr] = yield* Effect.all(
           [
@@ -121,7 +185,10 @@ export const GitHubAuth = AuthProviderLayer<
         ),
       );
 
-    const loginStored = Effect.fn(function* (profileName: string) {
+    const loginStored = Effect.fn(function* (
+      profileName: string,
+      baseUrl?: string,
+    ) {
       const token = yield* Clank.password({
         message:
           "GitHub Personal Access Token (needs `repo` scope; `workflow` for Actions)",
@@ -133,34 +200,56 @@ export const GitHubAuth = AuthProviderLayer<
         token,
       });
       yield* Clank.success("GitHub: credentials saved.");
-      return { method: "stored" as const };
+      return { method: "stored" as const, baseUrl };
     });
 
+    // Optional GitHub Enterprise host. Blank means github.com; anything else
+    // is normalized into the REST API base URL (GHES gets `/api/v3`
+    // appended, data-residency hosts get the `api.` prefix).
+    const promptBaseUrl = Clank.text({
+      message:
+        "GitHub host (leave blank for github.com; e.g. github.example.com for GitHub Enterprise)",
+      placeholder: "github.com",
+      defaultValue: "",
+    }).pipe(
+      retryOnce,
+      Effect.flatMap((input) => {
+        const trimmed = (input ?? "").trim();
+        return trimmed === ""
+          ? Effect.succeed(undefined)
+          : normalizeGitHubBaseUrl(trimmed);
+      }),
+    );
+
     const configureInteractive = (profileName: string) =>
-      Clank.select({
-        message: "GitHub authentication method",
-        options,
-      }).pipe(
-        Effect.flatMap((method) =>
-          Match.value(method).pipe(
-            Match.when("env", () => Effect.succeed({ method: "env" as const })),
-            Match.when("gh-cli", () =>
-              ghCliToken().pipe(
-                Effect.as({ method: "gh-cli" as const }),
-                Effect.mapError(
-                  (e) =>
-                    new AuthError({
-                      message: `gh CLI not available: ${e.message}`,
-                      cause: e,
-                    }),
-                ),
+      Effect.gen(function* () {
+        const method = yield* Clank.select({
+          message: "GitHub authentication method",
+          options,
+        });
+        const baseUrl = yield* promptBaseUrl;
+        return yield* Match.value(method).pipe(
+          Match.when("env", () =>
+            Effect.succeed({ method: "env" as const, baseUrl }),
+          ),
+          Match.when("gh-cli", () =>
+            ghCliToken(
+              baseUrl !== undefined ? githubHostname(baseUrl) : undefined,
+            ).pipe(
+              Effect.as({ method: "gh-cli" as const, baseUrl }),
+              Effect.mapError(
+                (e) =>
+                  new AuthError({
+                    message: `gh CLI not available: ${e.message}`,
+                    cause: e,
+                  }),
               ),
             ),
-            Match.when("stored", () => loginStored(profileName)),
-            Match.exhaustive,
           ),
-        ),
-      );
+          Match.when("stored", () => loginStored(profileName, baseUrl)),
+          Match.exhaustive,
+        );
+      });
 
     const configureCredentials = (profileName: string, ctx: ConfigureContext) =>
       Effect.gen(function* () {
@@ -183,60 +272,43 @@ export const GitHubAuth = AuthProviderLayer<
       config: GitHubAuthConfig,
     ): Effect.Effect<GitHubResolvedCredentials, AuthError> =>
       Match.value(config).pipe(
+        Match.when({ method: "env" }, (c) => readEnvCredentials(c.baseUrl)),
         Match.when(
-          { method: "env" },
-          Effect.fn(function* () {
-            const access = yield* getEnvRedacted("GITHUB_ACCESS_TOKEN");
-            if (access) {
-              return {
-                type: "token" as const,
-                token: access,
-                source: {
-                  type: "env" as const,
-                  details: "GITHUB_ACCESS_TOKEN",
-                },
-              };
+          { method: "stored" },
+          Effect.fn(function* (c) {
+            const baseUrl = c.baseUrl ?? (yield* resolveGitHubBaseUrlFromEnv);
+            const creds = yield* store.read<GitHubStoredCredentials>(
+              profileName,
+              "gh-stored",
+            );
+            if (creds == null) {
+              return yield* new AuthError({
+                message:
+                  "GitHub stored credentials not found. Run: alchemy login --configure",
+              });
             }
-            const token = yield* getEnvRedacted("GITHUB_TOKEN");
-            if (token) {
-              return {
-                type: "token" as const,
-                token,
-                source: { type: "env" as const, details: "GITHUB_TOKEN" },
-              };
-            }
-            return yield* new AuthError({
-              message:
-                "GitHub env credentials not found. Set GITHUB_ACCESS_TOKEN or GITHUB_TOKEN.",
-            });
+            return {
+              type: "token" as const,
+              token: Redacted.make(creds.token),
+              baseUrl,
+              source: { type: "stored" as const },
+            };
           }),
         ),
-        Match.when({ method: "stored" }, () =>
-          store.read<GitHubStoredCredentials>(profileName, "gh-stored").pipe(
-            Effect.flatMap((creds) =>
-              creds == null
-                ? Effect.fail(
-                    new AuthError({
-                      message:
-                        "GitHub stored credentials not found. Run: alchemy login --configure",
-                    }),
-                  )
-                : Effect.succeed({
-                    type: "token" as const,
-                    token: Redacted.make(creds.token),
-                    source: { type: "stored" as const },
-                  }),
-            ),
-          ),
-        ),
-        Match.when({ method: "gh-cli" }, () =>
-          ghCliToken().pipe(
-            Effect.map((token) => ({
+        Match.when(
+          { method: "gh-cli" },
+          Effect.fn(function* (c) {
+            const baseUrl = c.baseUrl ?? (yield* resolveGitHubBaseUrlFromEnv);
+            const token = yield* ghCliToken(
+              baseUrl !== undefined ? githubHostname(baseUrl) : undefined,
+            );
+            return {
               type: "token" as const,
               token: Redacted.make(token),
+              baseUrl,
               source: { type: "gh-cli" as const },
-            })),
-          ),
+            };
+          }),
         ),
         Match.exhaustive,
       );
@@ -261,20 +333,24 @@ export const GitHubAuth = AuthProviderLayer<
       Match.value(config)
         .pipe(
           Match.when({ method: "env" }, () => Effect.void),
-          Match.when({ method: "gh-cli" }, () =>
-            ghCliToken().pipe(
+          Match.when({ method: "gh-cli" }, (c) =>
+            ghCliToken(
+              c.baseUrl !== undefined ? githubHostname(c.baseUrl) : undefined,
+            ).pipe(
               Effect.tap(() =>
                 Clank.success("GitHub: gh CLI authentication available."),
               ),
               Effect.asVoid,
             ),
           ),
-          Match.when({ method: "stored" }, () =>
+          Match.when({ method: "stored" }, (c) =>
             store
               .read<GitHubStoredCredentials>(profileName, "gh-stored")
               .pipe(
                 Effect.flatMap((creds) =>
-                  creds == null ? loginStored(profileName) : Effect.void,
+                  creds == null
+                    ? loginStored(profileName, c.baseUrl)
+                    : Effect.void,
                 ),
               ),
           ),
@@ -295,6 +371,9 @@ export const GitHubAuth = AuthProviderLayer<
           return Effect.all([
             Console.log(`  token: ${displayRedacted(creds.token, 6)}`),
             Console.log(`  source: ${sourceStr}`),
+            ...(creds.baseUrl !== undefined
+              ? [Console.log(`  baseUrl: ${creds.baseUrl}`)]
+              : []),
           ]);
         }),
       );

--- a/packages/alchemy/src/GitHub/AuthProvider.ts
+++ b/packages/alchemy/src/GitHub/AuthProvider.ts
@@ -70,17 +70,15 @@ class GhCliError extends Error {
 }
 
 /**
- * Read GitHub credentials from the environment. The base URL comes from the
- * stored config when set, otherwise from `GITHUB_BASE_URL`, `GITHUB_API_URL`,
- * or `GH_HOST`. When it resolves to a GitHub Enterprise host, the gh CLI's
- * enterprise token variables (`GH_ENTERPRISE_TOKEN`, `GITHUB_ENTERPRISE_TOKEN`)
- * are checked before the standard `GITHUB_ACCESS_TOKEN` / `GITHUB_TOKEN`.
+ * Read a token from the environment for the given (already-resolved) base
+ * URL. On a GitHub Enterprise host, the gh CLI's enterprise token variables
+ * (`GH_ENTERPRISE_TOKEN`, `GITHUB_ENTERPRISE_TOKEN`) are checked before the
+ * standard `GITHUB_ACCESS_TOKEN` / `GITHUB_TOKEN`.
  */
-export const readEnvCredentials = (
-  configBaseUrl?: string,
+const readEnvTokenFor = (
+  baseUrl: string | undefined,
 ): Effect.Effect<GitHubResolvedCredentials, AuthError> =>
   Effect.gen(function* () {
-    const baseUrl = configBaseUrl ?? (yield* resolveGitHubBaseUrlFromEnv);
     const candidates =
       baseUrl !== undefined
         ? [
@@ -107,9 +105,22 @@ export const readEnvCredentials = (
   });
 
 /**
- * Layer that registers the GitHub {@link AuthProvider} into the
- * {@link AuthProviders} registry when built. Include this in the GitHub
- * `providers()` layer so `alchemy login` can discover it.
+ * Read GitHub credentials from the environment. The base URL comes from the
+ * stored config when set, otherwise from `GITHUB_BASE_URL`, `GITHUB_API_URL`,
+ * or `GH_HOST`.
+ */
+export const readEnvCredentials = (
+  configBaseUrl?: string,
+): Effect.Effect<GitHubResolvedCredentials, AuthError> =>
+  Effect.gen(function* () {
+    const baseUrl = configBaseUrl ?? (yield* resolveGitHubBaseUrlFromEnv);
+    return yield* readEnvTokenFor(baseUrl);
+  });
+
+/**
+ * Build the Layer that registers the GitHub {@link AuthProvider} into the
+ * {@link AuthProviders} registry. Included in the GitHub `providers()` layer
+ * so `alchemy login` can discover it.
  *
  * Supported methods:
  * - `gh-cli`: shells out to `gh auth token` (recommended).
@@ -128,262 +139,320 @@ export const readEnvCredentials = (
  * OAuth App flow requires a `client_secret` we cannot ship, and
  * device flow is exactly what `gh auth login` already does.
  */
-export const GitHubAuth = AuthProviderLayer<
-  GitHubAuthConfig,
-  GitHubResolvedCredentials
->()(
-  GITHUB_AUTH_PROVIDER_NAME,
-  Effect.gen(function* () {
-    const store = yield* CredentialsStore;
-    const cp = yield* ChildProcessSpawner;
+export interface GitHubAuthOptions {
+  /**
+   * Hard-code the GitHub host or API base URL (e.g. `github.example.com`
+   * or `https://github.example.com/api/v3`). When set, it takes precedence
+   * over the profile's configured host and the environment for every auth
+   * method, `alchemy login` stops prompting for a host, and the `gh` CLI
+   * method authenticates against this host. `GitHub.providers({ baseUrl })`
+   * threads its option here.
+   */
+  readonly baseUrl?: string;
+}
 
-    const ghCliToken = (hostname?: string): Effect.Effect<string, AuthError> =>
-      Effect.gen(function* () {
-        const handle = yield* cp.spawn(
-          ChildProcess.make(
-            "gh",
-            [
-              "auth",
-              "token",
-              ...(hostname !== undefined ? ["--hostname", hostname] : []),
-            ],
-            { shell: false },
-          ),
-        );
-        const [exitCode, stdout, stderr] = yield* Effect.all(
-          [
-            handle.exitCode,
-            Stream.mkString(Stream.decodeText(handle.stdout)),
-            Stream.mkString(Stream.decodeText(handle.stderr)),
-          ],
-          { concurrency: 3 },
-        );
-        if (exitCode !== 0) {
-          return yield* Effect.fail(
-            new GhCliError(
-              `gh auth token exited with ${exitCode}: ${stderr.trim() || stdout.trim()}`,
+export const makeGitHubAuth = (authOptions?: GitHubAuthOptions) =>
+  AuthProviderLayer<GitHubAuthConfig, GitHubResolvedCredentials>()(
+    GITHUB_AUTH_PROVIDER_NAME,
+    Effect.gen(function* () {
+      const store = yield* CredentialsStore;
+      const cp = yield* ChildProcessSpawner;
+
+      // Hard-coded host from `providers({ baseUrl })`, resolved once at layer
+      // build. Kept as an object so "no option" (undefined) is distinct from
+      // "option normalized to the github.com default" ({ baseUrl: undefined })
+      // — both matter: the latter still pins the host and mutes the prompt.
+      const fixed =
+        authOptions?.baseUrl !== undefined
+          ? {
+              baseUrl: yield* normalizeGitHubBaseUrl(authOptions.baseUrl).pipe(
+                Effect.orDie,
+              ),
+            }
+          : undefined;
+
+      // The host every method authenticates against: the hard-coded value
+      // wins, then the profile's configured host, then the environment.
+      const effectiveBaseUrl = (
+        config: GitHubAuthConfig,
+      ): Effect.Effect<string | undefined, AuthError> =>
+        fixed !== undefined
+          ? Effect.succeed(fixed.baseUrl)
+          : config.baseUrl !== undefined
+            ? Effect.succeed(config.baseUrl)
+            : resolveGitHubBaseUrlFromEnv;
+
+      const ghCliToken = (
+        hostname?: string,
+      ): Effect.Effect<string, AuthError> =>
+        Effect.gen(function* () {
+          const handle = yield* cp.spawn(
+            ChildProcess.make(
+              "gh",
+              [
+                "auth",
+                "token",
+                ...(hostname !== undefined ? ["--hostname", hostname] : []),
+              ],
+              { shell: false },
             ),
           );
-        }
-        const token = stdout.trim();
-        if (!token) {
-          return yield* Effect.fail(
-            new GhCliError("gh auth token returned empty output"),
+          const [exitCode, stdout, stderr] = yield* Effect.all(
+            [
+              handle.exitCode,
+              Stream.mkString(Stream.decodeText(handle.stdout)),
+              Stream.mkString(Stream.decodeText(handle.stderr)),
+            ],
+            { concurrency: 3 },
           );
-        }
-        return token;
+          if (exitCode !== 0) {
+            return yield* Effect.fail(
+              new GhCliError(
+                `gh auth token exited with ${exitCode}: ${stderr.trim() || stdout.trim()}`,
+              ),
+            );
+          }
+          const token = stdout.trim();
+          if (!token) {
+            return yield* Effect.fail(
+              new GhCliError("gh auth token returned empty output"),
+            );
+          }
+          return token;
+        }).pipe(
+          Effect.scoped,
+          Effect.mapError((e) =>
+            e instanceof GhCliError
+              ? new AuthError({ message: e.message, cause: e })
+              : new AuthError({
+                  message:
+                    "Could not invoke `gh`. Install GitHub CLI from https://cli.github.com/ and run `gh auth login`.",
+                  cause: e,
+                }),
+          ),
+        );
+
+      const loginStored = Effect.fn(function* (
+        profileName: string,
+        baseUrl?: string,
+      ) {
+        const token = yield* Clank.password({
+          message:
+            "GitHub Personal Access Token (needs `repo` scope; `workflow` for Actions)",
+          validate: (v) => (v.length === 0 ? "Required" : undefined),
+        }).pipe(retryOnce);
+
+        yield* store.write<GitHubStoredCredentials>(profileName, "gh-stored", {
+          type: "pat",
+          token,
+        });
+        yield* Clank.success("GitHub: credentials saved.");
+        return { method: "stored" as const, baseUrl };
+      });
+
+      // Optional GitHub Enterprise host. Blank means github.com; anything else
+      // is normalized into the REST API base URL (GHES gets `/api/v3`
+      // appended, data-residency hosts get the `api.` prefix).
+      const promptBaseUrl = Clank.text({
+        message:
+          "GitHub host (leave blank for github.com; e.g. github.example.com for GitHub Enterprise)",
+        placeholder: "github.com",
+        defaultValue: "",
       }).pipe(
-        Effect.scoped,
-        Effect.mapError((e) =>
-          e instanceof GhCliError
-            ? new AuthError({ message: e.message, cause: e })
-            : new AuthError({
-                message:
-                  "Could not invoke `gh`. Install GitHub CLI from https://cli.github.com/ and run `gh auth login`.",
+        retryOnce,
+        Effect.flatMap((input) => {
+          const trimmed = (input ?? "").trim();
+          return trimmed === ""
+            ? Effect.succeed(undefined)
+            : normalizeGitHubBaseUrl(trimmed);
+        }),
+      );
+
+      const configureInteractive = (profileName: string) =>
+        Effect.gen(function* () {
+          const method = yield* Clank.select({
+            message: "GitHub authentication method",
+            options,
+          });
+          // The host prompt is skipped when providers({ baseUrl }) pinned it —
+          // nothing is stored in the profile config; `read` re-applies the
+          // pinned value from code on every resolution.
+          const baseUrl =
+            fixed !== undefined ? undefined : yield* promptBaseUrl;
+          const verifyHost = fixed !== undefined ? fixed.baseUrl : baseUrl;
+          return yield* Match.value(method).pipe(
+            Match.when("env", () =>
+              Effect.succeed({ method: "env" as const, baseUrl }),
+            ),
+            Match.when("gh-cli", () =>
+              ghCliToken(
+                verifyHost !== undefined
+                  ? githubHostname(verifyHost)
+                  : undefined,
+              ).pipe(
+                Effect.as({ method: "gh-cli" as const, baseUrl }),
+                Effect.mapError(
+                  (e) =>
+                    new AuthError({
+                      message: `gh CLI not available: ${e.message}`,
+                      cause: e,
+                    }),
+                ),
+              ),
+            ),
+            Match.when("stored", () => loginStored(profileName, baseUrl)),
+            Match.exhaustive,
+          );
+        });
+
+      const configureCredentials = (
+        profileName: string,
+        ctx: ConfigureContext,
+      ) =>
+        Effect.gen(function* () {
+          if (ctx.ci) {
+            return { method: "env" as const };
+          }
+          return yield* configureInteractive(profileName);
+        }).pipe(
+          Effect.mapError(
+            (e) =>
+              new AuthError({
+                message: "failed to configure credentials",
                 cause: e,
               }),
-        ),
-      );
-
-    const loginStored = Effect.fn(function* (
-      profileName: string,
-      baseUrl?: string,
-    ) {
-      const token = yield* Clank.password({
-        message:
-          "GitHub Personal Access Token (needs `repo` scope; `workflow` for Actions)",
-        validate: (v) => (v.length === 0 ? "Required" : undefined),
-      }).pipe(retryOnce);
-
-      yield* store.write<GitHubStoredCredentials>(profileName, "gh-stored", {
-        type: "pat",
-        token,
-      });
-      yield* Clank.success("GitHub: credentials saved.");
-      return { method: "stored" as const, baseUrl };
-    });
-
-    // Optional GitHub Enterprise host. Blank means github.com; anything else
-    // is normalized into the REST API base URL (GHES gets `/api/v3`
-    // appended, data-residency hosts get the `api.` prefix).
-    const promptBaseUrl = Clank.text({
-      message:
-        "GitHub host (leave blank for github.com; e.g. github.example.com for GitHub Enterprise)",
-      placeholder: "github.com",
-      defaultValue: "",
-    }).pipe(
-      retryOnce,
-      Effect.flatMap((input) => {
-        const trimmed = (input ?? "").trim();
-        return trimmed === ""
-          ? Effect.succeed(undefined)
-          : normalizeGitHubBaseUrl(trimmed);
-      }),
-    );
-
-    const configureInteractive = (profileName: string) =>
-      Effect.gen(function* () {
-        const method = yield* Clank.select({
-          message: "GitHub authentication method",
-          options,
-        });
-        const baseUrl = yield* promptBaseUrl;
-        return yield* Match.value(method).pipe(
-          Match.when("env", () =>
-            Effect.succeed({ method: "env" as const, baseUrl }),
           ),
-          Match.when("gh-cli", () =>
-            ghCliToken(
-              baseUrl !== undefined ? githubHostname(baseUrl) : undefined,
-            ).pipe(
-              Effect.as({ method: "gh-cli" as const, baseUrl }),
-              Effect.mapError(
-                (e) =>
-                  new AuthError({
-                    message: `gh CLI not available: ${e.message}`,
-                    cause: e,
-                  }),
-              ),
-            ),
+        );
+
+      const resolveCredentials = (
+        profileName: string,
+        config: GitHubAuthConfig,
+      ): Effect.Effect<GitHubResolvedCredentials, AuthError> =>
+        Match.value(config).pipe(
+          Match.when({ method: "env" }, (c) =>
+            effectiveBaseUrl(c).pipe(Effect.flatMap(readEnvTokenFor)),
           ),
-          Match.when("stored", () => loginStored(profileName, baseUrl)),
+          Match.when(
+            { method: "stored" },
+            Effect.fn(function* (c) {
+              const baseUrl = yield* effectiveBaseUrl(c);
+              const creds = yield* store.read<GitHubStoredCredentials>(
+                profileName,
+                "gh-stored",
+              );
+              if (creds == null) {
+                return yield* new AuthError({
+                  message:
+                    "GitHub stored credentials not found. Run: alchemy login --configure",
+                });
+              }
+              return {
+                type: "token" as const,
+                token: Redacted.make(creds.token),
+                baseUrl,
+                source: { type: "stored" as const },
+              };
+            }),
+          ),
+          Match.when(
+            { method: "gh-cli" },
+            Effect.fn(function* (c) {
+              const baseUrl = yield* effectiveBaseUrl(c);
+              const token = yield* ghCliToken(
+                baseUrl !== undefined ? githubHostname(baseUrl) : undefined,
+              );
+              return {
+                type: "token" as const,
+                token: Redacted.make(token),
+                baseUrl,
+                source: { type: "gh-cli" as const },
+              };
+            }),
+          ),
           Match.exhaustive,
         );
-      });
 
-    const configureCredentials = (profileName: string, ctx: ConfigureContext) =>
-      Effect.gen(function* () {
-        if (ctx.ci) {
-          return { method: "env" as const };
-        }
-        return yield* configureInteractive(profileName);
-      }).pipe(
-        Effect.mapError(
-          (e) =>
-            new AuthError({
-              message: "failed to configure credentials",
-              cause: e,
-            }),
-        ),
-      );
-
-    const resolveCredentials = (
-      profileName: string,
-      config: GitHubAuthConfig,
-    ): Effect.Effect<GitHubResolvedCredentials, AuthError> =>
-      Match.value(config).pipe(
-        Match.when({ method: "env" }, (c) => readEnvCredentials(c.baseUrl)),
-        Match.when(
-          { method: "stored" },
-          Effect.fn(function* (c) {
-            const baseUrl = c.baseUrl ?? (yield* resolveGitHubBaseUrlFromEnv);
-            const creds = yield* store.read<GitHubStoredCredentials>(
-              profileName,
-              "gh-stored",
-            );
-            if (creds == null) {
-              return yield* new AuthError({
-                message:
-                  "GitHub stored credentials not found. Run: alchemy login --configure",
-              });
-            }
-            return {
-              type: "token" as const,
-              token: Redacted.make(creds.token),
-              baseUrl,
-              source: { type: "stored" as const },
-            };
-          }),
-        ),
-        Match.when(
-          { method: "gh-cli" },
-          Effect.fn(function* (c) {
-            const baseUrl = c.baseUrl ?? (yield* resolveGitHubBaseUrlFromEnv);
-            const token = yield* ghCliToken(
-              baseUrl !== undefined ? githubHostname(baseUrl) : undefined,
-            );
-            return {
-              type: "token" as const,
-              token: Redacted.make(token),
-              baseUrl,
-              source: { type: "gh-cli" as const },
-            };
-          }),
-        ),
-        Match.exhaustive,
-      );
-
-    const logout = (profileName: string, config: GitHubAuthConfig) =>
-      Match.value(config).pipe(
-        Match.when({ method: "env" }, () => Effect.void),
-        Match.when({ method: "gh-cli" }, () => Effect.void),
-        Match.when({ method: "stored" }, () =>
-          store
-            .delete(profileName, "gh-stored")
-            .pipe(
-              Effect.andThen(
-                Clank.success("GitHub: stored credentials removed"),
-              ),
-            ),
-        ),
-        Match.exhaustive,
-      );
-
-    const login = (profileName: string, config: GitHubAuthConfig) =>
-      Match.value(config)
-        .pipe(
+      const logout = (profileName: string, config: GitHubAuthConfig) =>
+        Match.value(config).pipe(
           Match.when({ method: "env" }, () => Effect.void),
-          Match.when({ method: "gh-cli" }, (c) =>
-            ghCliToken(
-              c.baseUrl !== undefined ? githubHostname(c.baseUrl) : undefined,
-            ).pipe(
-              Effect.tap(() =>
-                Clank.success("GitHub: gh CLI authentication available."),
-              ),
-              Effect.asVoid,
-            ),
-          ),
-          Match.when({ method: "stored" }, (c) =>
+          Match.when({ method: "gh-cli" }, () => Effect.void),
+          Match.when({ method: "stored" }, () =>
             store
-              .read<GitHubStoredCredentials>(profileName, "gh-stored")
+              .delete(profileName, "gh-stored")
               .pipe(
-                Effect.flatMap((creds) =>
-                  creds == null
-                    ? loginStored(profileName, c.baseUrl)
-                    : Effect.void,
+                Effect.andThen(
+                  Clank.success("GitHub: stored credentials removed"),
                 ),
               ),
           ),
           Match.exhaustive,
-        )
-        .pipe(
-          Effect.mapError(
-            (e) => new AuthError({ message: "login failed", cause: e }),
-          ),
         );
 
-    const prettyPrint = (profileName: string, config: GitHubAuthConfig) =>
-      resolveCredentials(profileName, config).pipe(
-        Effect.tap((creds) => {
-          const sourceStr = creds.source.details
-            ? `${creds.source.type} - ${creds.source.details}`
-            : creds.source.type;
-          return Effect.all([
-            Console.log(`  token: ${displayRedacted(creds.token, 6)}`),
-            Console.log(`  source: ${sourceStr}`),
-            ...(creds.baseUrl !== undefined
-              ? [Console.log(`  baseUrl: ${creds.baseUrl}`)]
-              : []),
-          ]);
-        }),
-      );
+      const login = (profileName: string, config: GitHubAuthConfig) =>
+        Match.value(config)
+          .pipe(
+            Match.when({ method: "env" }, () => Effect.void),
+            Match.when({ method: "gh-cli" }, (c) =>
+              effectiveBaseUrl(c).pipe(
+                Effect.flatMap((baseUrl) =>
+                  ghCliToken(
+                    baseUrl !== undefined ? githubHostname(baseUrl) : undefined,
+                  ),
+                ),
+                Effect.tap(() =>
+                  Clank.success("GitHub: gh CLI authentication available."),
+                ),
+                Effect.asVoid,
+              ),
+            ),
+            Match.when({ method: "stored" }, (c) =>
+              store
+                .read<GitHubStoredCredentials>(profileName, "gh-stored")
+                .pipe(
+                  Effect.flatMap((creds) =>
+                    creds == null
+                      ? loginStored(profileName, c.baseUrl)
+                      : Effect.void,
+                  ),
+                ),
+            ),
+            Match.exhaustive,
+          )
+          .pipe(
+            Effect.mapError(
+              (e) => new AuthError({ message: "login failed", cause: e }),
+            ),
+          );
 
-    return {
-      configure: configureCredentials,
-      logout,
-      login,
-      prettyPrint,
-      read: resolveCredentials,
-    };
-  }),
-);
+      const prettyPrint = (profileName: string, config: GitHubAuthConfig) =>
+        resolveCredentials(profileName, config).pipe(
+          Effect.tap((creds) => {
+            const sourceStr = creds.source.details
+              ? `${creds.source.type} - ${creds.source.details}`
+              : creds.source.type;
+            return Effect.all([
+              Console.log(`  token: ${displayRedacted(creds.token, 6)}`),
+              Console.log(`  source: ${sourceStr}`),
+              ...(creds.baseUrl !== undefined
+                ? [Console.log(`  baseUrl: ${creds.baseUrl}`)]
+                : []),
+            ]);
+          }),
+        );
+
+      return {
+        configure: configureCredentials,
+        logout,
+        login,
+        prettyPrint,
+        read: resolveCredentials,
+      };
+    }),
+  );
+
+/**
+ * The default GitHub AuthProvider layer — {@link makeGitHubAuth} with no
+ * hard-coded host. Use `GitHub.providers({ baseUrl })` (or
+ * `makeGitHubAuth({ baseUrl })` directly) to pin a GitHub Enterprise host.
+ */
+export const GitHubAuth = makeGitHubAuth();

--- a/packages/alchemy/src/GitHub/BaseUrl.ts
+++ b/packages/alchemy/src/GitHub/BaseUrl.ts
@@ -1,0 +1,77 @@
+import * as Effect from "effect/Effect";
+import { AuthError } from "../Auth/AuthProvider.ts";
+import { getEnv } from "../Auth/Env.ts";
+
+/**
+ * Normalize a user-supplied GitHub host or URL into the REST API base URL
+ * Octokit expects, following the same conventions as the `gh` CLI and the
+ * Terraform GitHub provider:
+ *
+ * - `github.com` / `api.github.com` → `undefined` (Octokit's default)
+ * - GitHub Enterprise Cloud with data residency (`acme.ghe.com` or
+ *   `api.acme.ghe.com`) → `https://api.acme.ghe.com`
+ * - GitHub Enterprise Server (`github.example.com`) → `https://github.example.com/api/v3`;
+ *   an explicit path (e.g. an already-complete `/api/v3` URL) is honored as-is.
+ *
+ * Accepts a bare hostname or a full URL.
+ */
+export const normalizeGitHubBaseUrl = (
+  input: string,
+): Effect.Effect<string | undefined, AuthError> =>
+  Effect.try({
+    try: () => {
+      const trimmed = input.trim();
+      const url = new URL(
+        trimmed.includes("://") ? trimmed : `https://${trimmed}`,
+      );
+      const host = url.hostname.toLowerCase();
+      if (
+        host === "github.com" ||
+        host === "www.github.com" ||
+        host === "api.github.com"
+      ) {
+        return undefined;
+      }
+      if (host.endsWith(".ghe.com")) {
+        return `https://${host.startsWith("api.") ? host : `api.${host}`}`;
+      }
+      const path = url.pathname.replace(/\/+$/, "");
+      return `${url.protocol}//${url.host}${path === "" ? "/api/v3" : path}`;
+    },
+    catch: () =>
+      new AuthError({
+        message: `Invalid GitHub base URL: '${input}'. Provide a hostname (github.example.com) or URL (https://github.example.com/api/v3).`,
+      }),
+  });
+
+/**
+ * The hostname `gh auth token --hostname` expects for a normalized API base
+ * URL — the plain host for GitHub Enterprise Server, and the `api.`-less
+ * host for GitHub Enterprise Cloud with data residency.
+ */
+export const githubHostname = (baseUrl: string): string => {
+  const host = new URL(baseUrl).hostname;
+  return host.startsWith("api.") && host.endsWith(".ghe.com")
+    ? host.slice("api.".length)
+    : host;
+};
+
+/**
+ * Resolve the GitHub API base URL from the environment:
+ * `GITHUB_BASE_URL` (Terraform convention), then `GITHUB_API_URL` (set by
+ * GitHub Actions runners), then `GH_HOST` (gh CLI convention, a bare
+ * hostname). Returns `undefined` when unset or when the value points at
+ * github.com.
+ */
+export const resolveGitHubBaseUrlFromEnv: Effect.Effect<
+  string | undefined,
+  AuthError
+> = Effect.gen(function* () {
+  for (const key of ["GITHUB_BASE_URL", "GITHUB_API_URL", "GH_HOST"]) {
+    const value = yield* getEnv(key);
+    if (value !== undefined && value.trim() !== "") {
+      return yield* normalizeGitHubBaseUrl(value);
+    }
+  }
+  return undefined;
+});

--- a/packages/alchemy/src/GitHub/BaseUrl.ts
+++ b/packages/alchemy/src/GitHub/BaseUrl.ts
@@ -45,34 +45,6 @@ export const normalizeGitHubBaseUrl = (
   });
 
 /**
- * {@link normalizeGitHubBaseUrl} lifted over `undefined` — used to compare
- * `baseUrl` props in `diff`, where either side may be unset.
- */
-export const normalizeOptionalGitHubBaseUrl = (
-  input: string | undefined,
-): Effect.Effect<string | undefined, AuthError> =>
-  input === undefined
-    ? Effect.succeed(undefined)
-    : normalizeGitHubBaseUrl(input);
-
-/**
- * Whether a resource's `baseUrl` prop changed between deploys, compared on
- * the normalized API base URL so cosmetic rewrites (`github.example.com` →
- * `https://github.example.com/api/v3`) don't trigger a replacement. Used by
- * resource `diff` implementations — a resource with the same name on a
- * different GitHub instance is a different physical resource.
- */
-export const gitHubBaseUrlChanged = (
-  olds: { baseUrl?: string },
-  news: { baseUrl?: string },
-): Effect.Effect<boolean, AuthError> =>
-  Effect.gen(function* () {
-    const oldUrl = yield* normalizeOptionalGitHubBaseUrl(olds.baseUrl);
-    const newUrl = yield* normalizeOptionalGitHubBaseUrl(news.baseUrl);
-    return oldUrl !== newUrl;
-  });
-
-/**
  * The hostname `gh auth token --hostname` expects for a normalized API base
  * URL — the plain host for GitHub Enterprise Server, and the `api.`-less
  * host for GitHub Enterprise Cloud with data residency.

--- a/packages/alchemy/src/GitHub/BaseUrl.ts
+++ b/packages/alchemy/src/GitHub/BaseUrl.ts
@@ -45,6 +45,34 @@ export const normalizeGitHubBaseUrl = (
   });
 
 /**
+ * {@link normalizeGitHubBaseUrl} lifted over `undefined` — used to compare
+ * `baseUrl` props in `diff`, where either side may be unset.
+ */
+export const normalizeOptionalGitHubBaseUrl = (
+  input: string | undefined,
+): Effect.Effect<string | undefined, AuthError> =>
+  input === undefined
+    ? Effect.succeed(undefined)
+    : normalizeGitHubBaseUrl(input);
+
+/**
+ * Whether a resource's `baseUrl` prop changed between deploys, compared on
+ * the normalized API base URL so cosmetic rewrites (`github.example.com` →
+ * `https://github.example.com/api/v3`) don't trigger a replacement. Used by
+ * resource `diff` implementations — a resource with the same name on a
+ * different GitHub instance is a different physical resource.
+ */
+export const gitHubBaseUrlChanged = (
+  olds: { baseUrl?: string },
+  news: { baseUrl?: string },
+): Effect.Effect<boolean, AuthError> =>
+  Effect.gen(function* () {
+    const oldUrl = yield* normalizeOptionalGitHubBaseUrl(olds.baseUrl);
+    const newUrl = yield* normalizeOptionalGitHubBaseUrl(news.baseUrl);
+    return oldUrl !== newUrl;
+  });
+
+/**
  * The hostname `gh auth token --hostname` expects for a normalized API base
  * URL — the plain host for GitHub Enterprise Server, and the `api.`-less
  * host for GitHub Enterprise Cloud with data residency.

--- a/packages/alchemy/src/GitHub/Comment.ts
+++ b/packages/alchemy/src/GitHub/Comment.ts
@@ -1,8 +1,10 @@
 import * as Effect from "effect/Effect";
+import { isResolved } from "../Diff.ts";
 import * as Provider from "../Provider.ts";
 import { Resource } from "../Resource.ts";
 import { dedent } from "../Util/dedent.ts";
-import { Octokit } from "./Octokit.ts";
+import { gitHubBaseUrlChanged } from "./BaseUrl.ts";
+import { octokitFor } from "./Octokit.ts";
 import * as GitHub from "./Providers.ts";
 
 export interface CommentProps {
@@ -37,6 +39,15 @@ export interface CommentProps {
    * @default false
    */
   allowDelete?: boolean;
+
+  /**
+   * Override the GitHub host or API base URL for this resource only (e.g.
+   * `github.example.com` for GitHub Enterprise). Falls back to
+   * `GitHub.providers({ baseUrl })`, then to the host resolved by the auth
+   * provider. Changing it replaces the resource — the same name on a
+   * different GitHub instance is a different physical resource.
+   */
+  baseUrl?: string;
 }
 
 export interface Comment extends Resource<
@@ -153,8 +164,18 @@ export const CommentProvider = () =>
     // enumerate every comment without first knowing the issue/PR. With no
     // ambient scope to enumerate from, this collapses to the empty list.
     list: () => Effect.succeed([]),
+
+    // The only structural change is the host: the same comment on a
+    // different GitHub instance is a different physical comment.
+    diff: Effect.fn(function* ({ news, olds }) {
+      if (!isResolved(news)) return;
+      if (olds !== undefined && (yield* gitHubBaseUrlChanged(olds, news))) {
+        return { action: "replace" };
+      }
+    }),
+
     reconcile: Effect.fn(function* ({ news, output }) {
-      const octokit = yield* Octokit;
+      const octokit = yield* octokitFor(news.baseUrl);
       const body = dedent(news.body);
 
       // Observe — GitHub assigns `comment_id` server-side. Probe for live
@@ -220,7 +241,7 @@ export const CommentProvider = () =>
         return;
       }
 
-      const octokit = yield* Octokit;
+      const octokit = yield* octokitFor(olds.baseUrl);
 
       yield* Effect.tryPromise(async () => {
         try {

--- a/packages/alchemy/src/GitHub/Comment.ts
+++ b/packages/alchemy/src/GitHub/Comment.ts
@@ -165,11 +165,20 @@ export const CommentProvider = () =>
     // ambient scope to enumerate from, this collapses to the empty list.
     list: () => Effect.succeed([]),
 
-    // The only structural change is the host: the same comment on a
-    // different GitHub instance is a different physical comment.
+    // A comment belongs to (host, owner, repository, issueNumber) — its
+    // server-assigned id is meaningless anywhere else, so moving it replaces
+    // the resource: a fresh comment is posted on the new issue, and the old
+    // one is deleted only when `allowDelete` is set (the provider's `delete`
+    // no-ops otherwise, preserving discussion history — the default).
     diff: Effect.fn(function* ({ news, olds }) {
       if (!isResolved(news)) return;
-      if (olds !== undefined && (yield* gitHubBaseUrlChanged(olds, news))) {
+      if (olds === undefined) return;
+      if (
+        news.owner !== olds.owner ||
+        news.repository !== olds.repository ||
+        news.issueNumber !== olds.issueNumber ||
+        (yield* gitHubBaseUrlChanged(olds, news))
+      ) {
         return { action: "replace" };
       }
     }),

--- a/packages/alchemy/src/GitHub/Comment.ts
+++ b/packages/alchemy/src/GitHub/Comment.ts
@@ -3,8 +3,7 @@ import { isResolved } from "../Diff.ts";
 import * as Provider from "../Provider.ts";
 import { Resource } from "../Resource.ts";
 import { dedent } from "../Util/dedent.ts";
-import { gitHubBaseUrlChanged } from "./BaseUrl.ts";
-import { octokitFor } from "./Octokit.ts";
+import { gitHubBaseUrlChanged, octokitFor } from "./Octokit.ts";
 import * as GitHub from "./Providers.ts";
 
 export interface CommentProps {

--- a/packages/alchemy/src/GitHub/Credentials.ts
+++ b/packages/alchemy/src/GitHub/Credentials.ts
@@ -10,10 +10,19 @@ import {
   GITHUB_AUTH_PROVIDER_NAME,
   type GitHubAuthConfig,
   type GitHubResolvedCredentials,
+  readEnvCredentials,
 } from "./AuthProvider.ts";
+import { normalizeGitHubBaseUrl } from "./BaseUrl.ts";
 
 export interface GitHubCredentialsService {
   readonly token: Redacted.Redacted<string>;
+  /**
+   * REST API base URL for GitHub Enterprise (e.g.
+   * `https://github.example.com/api/v3` for GitHub Enterprise Server, or
+   * `https://api.acme.ghe.com` for GitHub Enterprise Cloud with data
+   * residency). `undefined` targets github.com.
+   */
+  readonly baseUrl?: string;
   readonly octokit: () => Octokit;
 }
 
@@ -22,49 +31,62 @@ export class GitHubCredentials extends Context.Service<
   Effect.Effect<GitHubCredentialsService>
 >()("GitHub::Credentials") {}
 
-const make = (token: Redacted.Redacted<string>): GitHubCredentialsService => ({
+const make = (
+  token: Redacted.Redacted<string>,
+  baseUrl?: string,
+): GitHubCredentialsService => ({
   token,
-  octokit: () => new Octokit({ auth: Redacted.value(token) }),
+  baseUrl,
+  octokit: () =>
+    new Octokit({
+      auth: Redacted.value(token),
+      ...(baseUrl !== undefined ? { baseUrl } : {}),
+    }),
 });
 
 /**
  * Build a `GitHubCredentials` layer from a literal token. Useful for
  * tests or when callers already have a PAT in hand.
+ *
+ * Pass `baseUrl` to target a GitHub Enterprise instance. It accepts a
+ * hostname or URL and is normalized into the REST API base URL — a GitHub
+ * Enterprise Server host gets `/api/v3` appended, a `*.ghe.com`
+ * data-residency host gets the `api.` prefix.
  */
-export const fromToken = (token: string | Redacted.Redacted<string>) =>
+export const fromToken = (
+  token: string | Redacted.Redacted<string>,
+  options?: { readonly baseUrl?: string },
+) =>
   Layer.succeed(
     GitHubCredentials,
-    Effect.succeed(
-      make(typeof token === "string" ? Redacted.make(token) : token),
-    ),
+    Effect.gen(function* () {
+      const baseUrl =
+        options?.baseUrl !== undefined
+          ? yield* normalizeGitHubBaseUrl(options.baseUrl)
+          : undefined;
+      return make(
+        typeof token === "string" ? Redacted.make(token) : token,
+        baseUrl,
+      );
+    }).pipe(Effect.orDie),
   );
 
 /**
  * Build a `GitHubCredentials` layer that reads the token from
  * `GITHUB_ACCESS_TOKEN` or `GITHUB_TOKEN` at layer build time.
+ *
+ * GitHub Enterprise is resolved from the environment too: `GITHUB_BASE_URL`,
+ * `GITHUB_API_URL` (set by GitHub Actions runners), or `GH_HOST` select the
+ * host, and on an enterprise host `GH_ENTERPRISE_TOKEN` /
+ * `GITHUB_ENTERPRISE_TOKEN` are checked before the standard token variables.
  */
 export const fromEnv = () =>
   Layer.succeed(
     GitHubCredentials,
-    Effect.gen(function* () {
-      const access = yield* Config.redacted("GITHUB_ACCESS_TOKEN").pipe(
-        Config.option,
-      );
-      const token = yield* Config.redacted("GITHUB_TOKEN").pipe(Config.option);
-      const value =
-        access._tag === "Some"
-          ? access.value
-          : token._tag === "Some"
-            ? token.value
-            : undefined;
-      if (value == null) {
-        return yield* new AuthError({
-          message:
-            "GitHub credentials not found. Set GITHUB_ACCESS_TOKEN or GITHUB_TOKEN.",
-        });
-      }
-      return make(value);
-    }).pipe(Effect.orDie),
+    readEnvCredentials().pipe(
+      Effect.map((creds) => make(creds.token, creds.baseUrl)),
+      Effect.orDie,
+    ),
   );
 
 /**
@@ -88,7 +110,7 @@ export const fromAuthProvider = () =>
         Effect.flatMap((config) =>
           auth.read(profileName, config as GitHubAuthConfig),
         ),
-        Effect.map((creds) => make(creds.token)),
+        Effect.map((creds) => make(creds.token, creds.baseUrl)),
         Effect.mapError(
           (e) =>
             new AuthError({

--- a/packages/alchemy/src/GitHub/Credentials.ts
+++ b/packages/alchemy/src/GitHub/Credentials.ts
@@ -23,7 +23,14 @@ export interface GitHubCredentialsService {
    * residency). `undefined` targets github.com.
    */
   readonly baseUrl?: string;
-  readonly octokit: () => Octokit;
+  /**
+   * Construct an Octokit for these credentials. Pass `override` to target a
+   * different host than the credentials' own `baseUrl` — `override.baseUrl`
+   * is used verbatim, including `undefined` for github.com (which is why the
+   * override is an object rather than an optional string: it distinguishes
+   * "no override" from "override to the github.com default").
+   */
+  readonly octokit: (override?: { baseUrl: string | undefined }) => Octokit;
 }
 
 export class GitHubCredentials extends Context.Service<
@@ -37,11 +44,13 @@ const make = (
 ): GitHubCredentialsService => ({
   token,
   baseUrl,
-  octokit: () =>
-    new Octokit({
+  octokit: (override) => {
+    const url = override !== undefined ? override.baseUrl : baseUrl;
+    return new Octokit({
       auth: Redacted.value(token),
-      ...(baseUrl !== undefined ? { baseUrl } : {}),
-    }),
+      ...(url !== undefined ? { baseUrl: url } : {}),
+    });
+  },
 });
 
 /**
@@ -93,11 +102,19 @@ export const fromEnv = () =>
  * Build a `GitHubCredentials` layer that resolves a token via the
  * Alchemy AuthProvider for the configured profile (defaults to
  * `default`, overridable with `ALCHEMY_PROFILE`).
+ *
+ * Pass `baseUrl` to hard-code the GitHub host — it takes precedence over
+ * whatever host the auth provider resolved from the profile config or
+ * environment. `GitHub.providers({ baseUrl })` threads its option here.
  */
-export const fromAuthProvider = () =>
+export const fromAuthProvider = (options?: { readonly baseUrl?: string }) =>
   Layer.effect(
     GitHubCredentials,
     Effect.gen(function* () {
+      const fixedBaseUrl =
+        options?.baseUrl !== undefined
+          ? { baseUrl: yield* normalizeGitHubBaseUrl(options.baseUrl) }
+          : undefined;
       const profile = yield* AlchemyProfile;
       const auth = yield* getAuthProvider<
         GitHubAuthConfig,
@@ -110,7 +127,12 @@ export const fromAuthProvider = () =>
         Effect.flatMap((config) =>
           auth.read(profileName, config as GitHubAuthConfig),
         ),
-        Effect.map((creds) => make(creds.token, creds.baseUrl)),
+        Effect.map((creds) =>
+          make(
+            creds.token,
+            fixedBaseUrl !== undefined ? fixedBaseUrl.baseUrl : creds.baseUrl,
+          ),
+        ),
         Effect.mapError(
           (e) =>
             new AuthError({

--- a/packages/alchemy/src/GitHub/Environment.ts
+++ b/packages/alchemy/src/GitHub/Environment.ts
@@ -2,8 +2,7 @@ import * as Effect from "effect/Effect";
 import { isResolved } from "../Diff.ts";
 import * as Provider from "../Provider.ts";
 import { Resource } from "../Resource.ts";
-import { gitHubBaseUrlChanged } from "./BaseUrl.ts";
-import { Octokit, octokitFor } from "./Octokit.ts";
+import { gitHubBaseUrlChanged, Octokit, octokitFor } from "./Octokit.ts";
 import type * as GitHub from "./Providers.ts";
 
 export interface EnvironmentProps {

--- a/packages/alchemy/src/GitHub/Environment.ts
+++ b/packages/alchemy/src/GitHub/Environment.ts
@@ -1,0 +1,419 @@
+import * as Effect from "effect/Effect";
+import { isResolved } from "../Diff.ts";
+import * as Provider from "../Provider.ts";
+import { Resource } from "../Resource.ts";
+import { Octokit } from "./Octokit.ts";
+import type * as GitHub from "./Providers.ts";
+
+export interface EnvironmentProps {
+  /**
+   * Repository owner (user or organization).
+   */
+  owner: string;
+
+  /**
+   * Repository name.
+   */
+  repository: string;
+
+  /**
+   * Environment name (e.g. `production`, `staging`). The name is the
+   * environment's identity — changing it replaces the environment.
+   */
+  name: string;
+
+  /**
+   * Minutes to wait before allowing deployments to proceed (0–43200,
+   * i.e. up to 30 days). Requires a plan that supports environment
+   * protection rules on the repository.
+   * @default 0
+   */
+  waitTimer?: number;
+
+  /**
+   * Whether users who created or pushed the deployment are prevented
+   * from approving their own deployment.
+   * @default false
+   */
+  preventSelfReview?: boolean;
+
+  /**
+   * The people or teams that must review deployments to this environment.
+   * Up to six users or teams in total; reviewers must have at least read
+   * access to the repository. Users are referenced by login, teams by
+   * slug (teams are only valid for organization-owned repositories).
+   */
+  reviewers?: {
+    /**
+     * User logins allowed to review deployments.
+     */
+    users?: string[];
+
+    /**
+     * Team slugs (within the owning organization) allowed to review
+     * deployments.
+     */
+    teams?: string[];
+  };
+
+  /**
+   * Which branches can deploy to this environment. Omit to allow all
+   * branches. Set `protectedBranches: true` to restrict deployments to
+   * branches with branch protection rules, or `customBranchPolicies` to a
+   * list of branch name patterns (e.g. `["main", "release/*"]`).
+   */
+  deploymentBranchPolicy?:
+    | { protectedBranches: true }
+    | { customBranchPolicies: string[] };
+}
+
+export interface Environment extends Resource<
+  "GitHub.Environment",
+  EnvironmentProps,
+  {
+    /**
+     * Numeric GitHub environment ID.
+     */
+    environmentId: number;
+
+    /**
+     * GraphQL node ID of the environment.
+     */
+    nodeId: string;
+
+    /**
+     * The environment name.
+     */
+    name: string;
+
+    /**
+     * URL to view the environment in a browser.
+     */
+    htmlUrl: string;
+
+    /**
+     * ISO-8601 timestamp of when the environment was created.
+     */
+    createdAt: string;
+
+    /**
+     * ISO-8601 timestamp of the last update.
+     */
+    updatedAt: string;
+  },
+  never,
+  GitHub.Providers
+> {}
+
+/**
+ * A GitHub Actions deployment environment.
+ *
+ * `Environment` manages a repository's deployment environment (e.g.
+ * `production`, `staging`) along with its protection rules: required
+ * reviewers, wait timers, self-review prevention, and deployment branch
+ * policies. Pair it with `GitHub.Secret` and `GitHub.Variable` (both accept
+ * an `environment` prop) to scope configuration to the environment.
+ *
+ * Environments are available on public repositories on every plan; private
+ * repositories require GitHub Pro, Team, or Enterprise, and protection
+ * rules on private repositories require Team or Enterprise.
+ *
+ * Authentication is resolved via the `GitHubCredentials` service supplied
+ * by `GitHub.providers()` (env, stored PAT, `gh` CLI, or OAuth). The token
+ * needs `repo` scope.
+ * @resource
+ * @section Creating an Environment
+ * @example Basic Environment
+ * ```typescript
+ * const production = yield* GitHub.Environment("production", {
+ *   owner: "my-org",
+ *   repository: "my-repo",
+ *   name: "production",
+ * });
+ * ```
+ *
+ * @example Environment with Protection Rules
+ * ```typescript
+ * yield* GitHub.Environment("production", {
+ *   owner: "my-org",
+ *   repository: "my-repo",
+ *   name: "production",
+ *   waitTimer: 30,
+ *   preventSelfReview: true,
+ *   reviewers: {
+ *     users: ["release-manager"],
+ *     teams: ["platform"],
+ *   },
+ * });
+ * ```
+ *
+ * @section Deployment Branch Policies
+ * @example Restrict to Protected Branches
+ * ```typescript
+ * yield* GitHub.Environment("production", {
+ *   owner: "my-org",
+ *   repository: "my-repo",
+ *   name: "production",
+ *   deploymentBranchPolicy: { protectedBranches: true },
+ * });
+ * ```
+ *
+ * @example Restrict to Branch Name Patterns
+ * ```typescript
+ * yield* GitHub.Environment("production", {
+ *   owner: "my-org",
+ *   repository: "my-repo",
+ *   name: "production",
+ *   deploymentBranchPolicy: {
+ *     customBranchPolicies: ["main", "release/*"],
+ *   },
+ * });
+ * ```
+ *
+ * @section Environment Secrets and Variables
+ * @example Scope Secrets and Variables to the Environment
+ * ```typescript
+ * const env = yield* GitHub.Environment("production", {
+ *   owner: "my-org",
+ *   repository: "my-repo",
+ *   name: "production",
+ * });
+ *
+ * yield* GitHub.Secret("deploy-key", {
+ *   owner: "my-org",
+ *   repository: "my-repo",
+ *   environment: env.name!,
+ *   name: "DEPLOY_KEY",
+ *   value: Redacted.make("my-secret-value"),
+ * });
+ *
+ * yield* GitHub.Variable("region", {
+ *   owner: "my-org",
+ *   repository: "my-repo",
+ *   environment: env.name!,
+ *   name: "AWS_REGION",
+ *   value: "us-east-1",
+ * });
+ * ```
+ */
+export const Environment = Resource<Environment>("GitHub.Environment");
+
+export const EnvironmentProvider = () =>
+  Provider.succeed(Environment, {
+    stables: ["environmentId", "nodeId"],
+
+    // The environment name is its path identity — GitHub has no rename, so
+    // changing owner, repository, or name replaces the resource.
+    diff: Effect.fn(function* ({ news, olds }) {
+      if (!isResolved(news)) return;
+      if (
+        olds !== undefined &&
+        (news.owner !== olds.owner ||
+          news.repository !== olds.repository ||
+          news.name !== olds.name)
+      ) {
+        return { action: "replace" };
+      }
+    }),
+
+    reconcile: Effect.fn(function* ({ news }) {
+      const octokit = yield* Octokit;
+
+      // Resolve reviewer logins/slugs to the numeric IDs the API expects.
+      const reviewers = yield* Effect.tryPromise({
+        try: async () => {
+          if (news.reviewers === undefined) return null;
+          const users = await Promise.all(
+            (news.reviewers.users ?? []).map(async (username) => {
+              const { data } = await octokit.rest.users.getByUsername({
+                username,
+              });
+              return { type: "User" as const, id: data.id };
+            }),
+          );
+          const teams = await Promise.all(
+            (news.reviewers.teams ?? []).map(async (team_slug) => {
+              const { data } = await octokit.rest.teams.getByName({
+                org: news.owner,
+                team_slug,
+              });
+              return { type: "Team" as const, id: data.id };
+            }),
+          );
+          return [...users, ...teams];
+        },
+        catch: (e) => e as Error,
+      });
+
+      // Ensure & Sync — the PUT is a full upsert of the environment's
+      // protection configuration; send explicit values (not omissions) so
+      // removed props converge back to their defaults.
+      const environment = yield* Effect.tryPromise({
+        try: async () => {
+          const { data } = await octokit.rest.repos.createOrUpdateEnvironment({
+            owner: news.owner,
+            repo: news.repository,
+            environment_name: news.name,
+            wait_timer: news.waitTimer ?? 0,
+            prevent_self_review: news.preventSelfReview ?? false,
+            reviewers:
+              reviewers === null || reviewers.length === 0 ? null : reviewers,
+            deployment_branch_policy:
+              news.deploymentBranchPolicy === undefined
+                ? null
+                : "protectedBranches" in news.deploymentBranchPolicy
+                  ? { protected_branches: true, custom_branch_policies: false }
+                  : { protected_branches: false, custom_branch_policies: true },
+          });
+          return data;
+        },
+        catch: (e) => e as Error,
+      });
+
+      // Sync — custom branch policies live behind dedicated endpoints. Diff
+      // the observed patterns against the desired list; create the missing
+      // ones and delete the extras. Skipped entirely unless the policy mode
+      // is custom (GitHub drops the policies itself when the mode changes).
+      if (
+        news.deploymentBranchPolicy !== undefined &&
+        "customBranchPolicies" in news.deploymentBranchPolicy
+      ) {
+        const desired = news.deploymentBranchPolicy.customBranchPolicies;
+        yield* Effect.tryPromise({
+          try: async () => {
+            const observed = await octokit.paginate(
+              octokit.rest.repos.listDeploymentBranchPolicies,
+              {
+                owner: news.owner,
+                repo: news.repository,
+                environment_name: news.name,
+                per_page: 100,
+              },
+            );
+            const observedNames = new Set(
+              observed.map((policy) => policy.name),
+            );
+            for (const name of desired) {
+              if (!observedNames.has(name)) {
+                await octokit.rest.repos.createDeploymentBranchPolicy({
+                  owner: news.owner,
+                  repo: news.repository,
+                  environment_name: news.name,
+                  name,
+                  type: "branch",
+                });
+              }
+            }
+            for (const policy of observed) {
+              if (
+                policy.id !== undefined &&
+                policy.name !== undefined &&
+                !desired.includes(policy.name)
+              ) {
+                await octokit.rest.repos.deleteDeploymentBranchPolicy({
+                  owner: news.owner,
+                  repo: news.repository,
+                  environment_name: news.name,
+                  branch_policy_id: policy.id,
+                });
+              }
+            }
+          },
+          catch: (e) => e as Error,
+        });
+      }
+
+      return {
+        environmentId: environment.id,
+        nodeId: environment.node_id,
+        name: environment.name,
+        htmlUrl: environment.html_url,
+        createdAt: environment.created_at,
+        updatedAt: environment.updated_at,
+      };
+    }),
+
+    // Enumerate every environment across the repositories the token can see —
+    // environments are keyed by {owner, repository, name} with no account-wide
+    // list endpoint, so walk the repos like the Variable provider does.
+    list: Effect.fn(function* () {
+      const octokit = yield* Octokit;
+
+      const repos = yield* Effect.tryPromise({
+        try: () =>
+          octokit.paginate(octokit.rest.repos.listForAuthenticatedUser, {
+            per_page: 100,
+          }),
+        catch: (e) => e as Error,
+      });
+
+      const perRepo = yield* Effect.forEach(
+        repos,
+        (repo) =>
+          Effect.tryPromise({
+            try: async () => {
+              try {
+                // `octokit.paginate` can't flatten this endpoint's
+                // `{ total_count, environments }` envelope, so page manually
+                // until a short page signals the end.
+                const environments = [];
+                for (let page = 1; ; page++) {
+                  const { data } = await octokit.rest.repos.getAllEnvironments({
+                    owner: repo.owner.login,
+                    repo: repo.name,
+                    per_page: 100,
+                    page,
+                  });
+                  const batch = data.environments ?? [];
+                  environments.push(
+                    ...batch.map((environment) => ({
+                      environmentId: environment.id,
+                      nodeId: environment.node_id,
+                      name: environment.name,
+                      htmlUrl: environment.html_url,
+                      createdAt: environment.created_at,
+                      updatedAt: environment.updated_at,
+                    })),
+                  );
+                  if (batch.length < 100) break;
+                }
+                return environments;
+              } catch (error: any) {
+                // Repos without environments support (plan limits) or where
+                // the token lacks access reject with 403/404 — skip them
+                // rather than failing the whole enumeration.
+                if (error.status === 403 || error.status === 404) {
+                  return [];
+                }
+                throw error;
+              }
+            },
+            catch: (e) => e as Error,
+          }),
+        { concurrency: 10 },
+      );
+
+      return perRepo.flat();
+    }),
+
+    delete: Effect.fn(function* ({ olds }) {
+      const octokit = yield* Octokit;
+
+      yield* Effect.tryPromise({
+        try: async () => {
+          try {
+            await octokit.rest.repos.deleteAnEnvironment({
+              owner: olds.owner,
+              repo: olds.repository,
+              environment_name: olds.name,
+            });
+          } catch (error: any) {
+            if (error.status !== 404) {
+              throw error;
+            }
+          }
+        },
+        catch: (e) => e as Error,
+      });
+    }),
+  });

--- a/packages/alchemy/src/GitHub/Environment.ts
+++ b/packages/alchemy/src/GitHub/Environment.ts
@@ -182,7 +182,7 @@ export interface Environment extends Resource<
  * yield* GitHub.Secret("deploy-key", {
  *   owner: "my-org",
  *   repository: "my-repo",
- *   environment: env.name!,
+ *   environment: env,
  *   name: "DEPLOY_KEY",
  *   value: Redacted.make("my-secret-value"),
  * });
@@ -190,13 +190,29 @@ export interface Environment extends Resource<
  * yield* GitHub.Variable("region", {
  *   owner: "my-org",
  *   repository: "my-repo",
- *   environment: env.name!,
+ *   environment: env,
  *   name: "AWS_REGION",
  *   value: "us-east-1",
  * });
  * ```
  */
 export const Environment = Resource<Environment>("GitHub.Environment");
+
+// At runtime, Resource references in props are resolved to their full
+// attributes — so an `Environment` passed to another resource's
+// `environment` prop arrives as `{ name: string; ... }` rather than the
+// statically-typed Resource (whose attributes are `Output<...>`). We cast
+// through the structural shape here.
+export const resolveEnvironmentName = (
+  environment: string | Environment | undefined,
+): string | undefined => {
+  const ref = environment as unknown as string | { name: string } | undefined;
+  return ref === undefined
+    ? undefined
+    : typeof ref === "string"
+      ? ref
+      : ref.name;
+};
 
 export const EnvironmentProvider = () =>
   Provider.succeed(Environment, {

--- a/packages/alchemy/src/GitHub/Environment.ts
+++ b/packages/alchemy/src/GitHub/Environment.ts
@@ -2,7 +2,8 @@ import * as Effect from "effect/Effect";
 import { isResolved } from "../Diff.ts";
 import * as Provider from "../Provider.ts";
 import { Resource } from "../Resource.ts";
-import { Octokit } from "./Octokit.ts";
+import { gitHubBaseUrlChanged } from "./BaseUrl.ts";
+import { Octokit, octokitFor } from "./Octokit.ts";
 import type * as GitHub from "./Providers.ts";
 
 export interface EnvironmentProps {
@@ -65,6 +66,15 @@ export interface EnvironmentProps {
   deploymentBranchPolicy?:
     | { protectedBranches: true }
     | { customBranchPolicies: string[] };
+
+  /**
+   * Override the GitHub host or API base URL for this resource only (e.g.
+   * `github.example.com` for GitHub Enterprise). Falls back to
+   * `GitHub.providers({ baseUrl })`, then to the host resolved by the auth
+   * provider. Changing it replaces the resource — the same name on a
+   * different GitHub instance is a different physical resource.
+   */
+  baseUrl?: string;
 }
 
 export interface Environment extends Resource<
@@ -219,21 +229,22 @@ export const EnvironmentProvider = () =>
     stables: ["environmentId", "nodeId"],
 
     // The environment name is its path identity — GitHub has no rename, so
-    // changing owner, repository, or name replaces the resource.
+    // changing owner, repository, name, or the host replaces the resource.
     diff: Effect.fn(function* ({ news, olds }) {
       if (!isResolved(news)) return;
+      if (olds === undefined) return;
       if (
-        olds !== undefined &&
-        (news.owner !== olds.owner ||
-          news.repository !== olds.repository ||
-          news.name !== olds.name)
+        news.owner !== olds.owner ||
+        news.repository !== olds.repository ||
+        news.name !== olds.name ||
+        (yield* gitHubBaseUrlChanged(olds, news))
       ) {
         return { action: "replace" };
       }
     }),
 
     reconcile: Effect.fn(function* ({ news }) {
-      const octokit = yield* Octokit;
+      const octokit = yield* octokitFor(news.baseUrl);
 
       // Resolve reviewer logins/slugs to the numeric IDs the API expects.
       const reviewers = yield* Effect.tryPromise({
@@ -413,7 +424,7 @@ export const EnvironmentProvider = () =>
     }),
 
     delete: Effect.fn(function* ({ olds }) {
-      const octokit = yield* Octokit;
+      const octokit = yield* octokitFor(olds.baseUrl);
 
       yield* Effect.tryPromise({
         try: async () => {

--- a/packages/alchemy/src/GitHub/Octokit.ts
+++ b/packages/alchemy/src/GitHub/Octokit.ts
@@ -27,3 +27,43 @@ export const octokitFor = (
       ? creds.octokit()
       : creds.octokit({ baseUrl: yield* normalizeGitHubBaseUrl(baseUrl) });
   });
+
+/**
+ * The host a resource's `baseUrl` prop actually resolves to: the normalized
+ * prop when set, otherwise the credentials' host — which already reflects
+ * `GitHub.providers({ baseUrl })` or the auth provider's resolved host.
+ */
+export const effectiveGitHubBaseUrl = (
+  baseUrl: string | undefined,
+): Effect.Effect<string | undefined, AuthError, GitHubCredentials> =>
+  Effect.gen(function* () {
+    if (baseUrl !== undefined) {
+      return yield* normalizeGitHubBaseUrl(baseUrl);
+    }
+    const creds = yield* yield* GitHubCredentials;
+    return creds.baseUrl;
+  });
+
+/**
+ * Whether a resource's EFFECTIVE GitHub host changed between deploys — used
+ * by resource `diff` implementations to decide replacement (a resource with
+ * the same name on a different GitHub instance is a different physical
+ * resource).
+ *
+ * Each side is resolved through the full fallback chain (explicit prop →
+ * `providers({ baseUrl })` → auth provider host) and normalized before
+ * comparing, so neither a cosmetic rewrite (`github.example.com` →
+ * `https://github.example.com/api/v3`) nor making the ambient default
+ * explicit (prop `undefined` → prop equal to the credentials' host) triggers
+ * a replacement — and dropping back to github.com from an enterprise-wide
+ * credential host is correctly detected as a change.
+ */
+export const gitHubBaseUrlChanged = (
+  olds: { baseUrl?: string },
+  news: { baseUrl?: string },
+): Effect.Effect<boolean, AuthError, GitHubCredentials> =>
+  Effect.gen(function* () {
+    const oldUrl = yield* effectiveGitHubBaseUrl(olds.baseUrl);
+    const newUrl = yield* effectiveGitHubBaseUrl(news.baseUrl);
+    return oldUrl !== newUrl;
+  });

--- a/packages/alchemy/src/GitHub/Octokit.ts
+++ b/packages/alchemy/src/GitHub/Octokit.ts
@@ -1,9 +1,29 @@
 import type { Octokit as _Octokit } from "@octokit/rest";
 import * as Effect from "effect/Effect";
+import type { AuthError } from "../Auth/AuthProvider.ts";
+import { normalizeGitHubBaseUrl } from "./BaseUrl.ts";
 import { GitHubCredentials } from "./Credentials.ts";
 
 export const Octokit: Effect.Effect<_Octokit, never, GitHubCredentials> =
   Effect.gen(function* () {
     const creds = yield* yield* GitHubCredentials;
     return creds.octokit();
+  });
+
+/**
+ * An Octokit honoring a per-resource `baseUrl` prop. When `baseUrl` is set,
+ * it is normalized and used for this Octokit only (including an explicit
+ * `"github.com"`, which overrides an enterprise-wide credential host back to
+ * the default). When unset, falls back to the credentials' host — the
+ * `GitHub.providers({ baseUrl })` hard-code or the auth provider's resolved
+ * host.
+ */
+export const octokitFor = (
+  baseUrl: string | undefined,
+): Effect.Effect<_Octokit, AuthError, GitHubCredentials> =>
+  Effect.gen(function* () {
+    const creds = yield* yield* GitHubCredentials;
+    return baseUrl === undefined
+      ? creds.octokit()
+      : creds.octokit({ baseUrl: yield* normalizeGitHubBaseUrl(baseUrl) });
   });

--- a/packages/alchemy/src/GitHub/Providers.ts
+++ b/packages/alchemy/src/GitHub/Providers.ts
@@ -2,7 +2,7 @@ import * as Layer from "effect/Layer";
 import { CredentialsStoreLive } from "../Auth/Credentials.ts";
 import { ProfileLive } from "../Auth/Profile.ts";
 import * as Provider from "../Provider.ts";
-import { GitHubAuth } from "./AuthProvider.ts";
+import { type GitHubAuthOptions, makeGitHubAuth } from "./AuthProvider.ts";
 import { Comment, CommentProvider } from "./Comment.ts";
 import * as Credentials from "./Credentials.ts";
 import { Environment, EnvironmentProvider } from "./Environment.ts";
@@ -19,11 +19,25 @@ export class Providers extends Provider.ProviderCollection<Providers>()(
 
 export type ProviderRequirements = Layer.Services<ReturnType<typeof providers>>;
 
+export interface ProvidersOptions extends GitHubAuthOptions {}
+
 /**
  * GitHub providers (Comment, Environment, Repository, Secret, Variable,
  * Webhook) plus the GitHub AuthProvider that `alchemy login` discovers.
+ *
+ * Pass `baseUrl` to pin every GitHub resource to a GitHub Enterprise host
+ * without relying on the auth provider's configuration:
+ *
+ * ```typescript
+ * providers: GitHub.providers({ baseUrl: "github.example.com" })
+ * ```
+ *
+ * The auth provider receives the same value, so `alchemy login` skips the
+ * host prompt and authenticates against the pinned host (`gh auth token
+ * --hostname`, enterprise token env vars). Individual resources can still
+ * override the host per-resource via their own `baseUrl` prop.
  */
-export const providers = () =>
+export const providers = (options?: ProvidersOptions) =>
   Layer.effect(
     Providers,
     Provider.collection([
@@ -45,8 +59,8 @@ export const providers = () =>
         WebhookProvider(),
       ),
     ),
-    Layer.provideMerge(Credentials.fromAuthProvider()),
-    Layer.provideMerge(GitHubAuth),
+    Layer.provideMerge(Credentials.fromAuthProvider(options)),
+    Layer.provideMerge(makeGitHubAuth(options)),
     Layer.provideMerge(ProfileLive),
     Layer.provideMerge(CredentialsStoreLive),
     Layer.orDie,

--- a/packages/alchemy/src/GitHub/Providers.ts
+++ b/packages/alchemy/src/GitHub/Providers.ts
@@ -5,6 +5,7 @@ import * as Provider from "../Provider.ts";
 import { GitHubAuth } from "./AuthProvider.ts";
 import { Comment, CommentProvider } from "./Comment.ts";
 import * as Credentials from "./Credentials.ts";
+import { Environment, EnvironmentProvider } from "./Environment.ts";
 import { Repository, RepositoryProvider } from "./Repository.ts";
 import { Secret, SecretProvider } from "./Secret.ts";
 import { Variable, VariableProvider } from "./Variable.ts";
@@ -19,17 +20,25 @@ export class Providers extends Provider.ProviderCollection<Providers>()(
 export type ProviderRequirements = Layer.Services<ReturnType<typeof providers>>;
 
 /**
- * GitHub providers (Comment, Repository, Secret, Variable) plus the GitHub
- * AuthProvider that `alchemy login` discovers.
+ * GitHub providers (Comment, Environment, Repository, Secret, Variable,
+ * Webhook) plus the GitHub AuthProvider that `alchemy login` discovers.
  */
 export const providers = () =>
   Layer.effect(
     Providers,
-    Provider.collection([Comment, Repository, Secret, Variable, Webhook]),
+    Provider.collection([
+      Comment,
+      Environment,
+      Repository,
+      Secret,
+      Variable,
+      Webhook,
+    ]),
   ).pipe(
     Layer.provide(
       Layer.mergeAll(
         CommentProvider(),
+        EnvironmentProvider(),
         RepositoryProvider(),
         SecretProvider(),
         VariableProvider(),

--- a/packages/alchemy/src/GitHub/Repository.ts
+++ b/packages/alchemy/src/GitHub/Repository.ts
@@ -2,7 +2,8 @@ import * as Effect from "effect/Effect";
 import { isResolved } from "../Diff.ts";
 import * as Provider from "../Provider.ts";
 import { Resource } from "../Resource.ts";
-import { Octokit } from "./Octokit.ts";
+import { gitHubBaseUrlChanged } from "./BaseUrl.ts";
+import { Octokit, octokitFor } from "./Octokit.ts";
 import type * as GitHub from "./Providers.ts";
 
 export interface RepositoryProps {
@@ -135,6 +136,15 @@ export interface RepositoryProps {
    * Only used at create time.
    */
   licenseTemplate?: string;
+
+  /**
+   * Override the GitHub host or API base URL for this resource only (e.g.
+   * `github.example.com` for GitHub Enterprise). Falls back to
+   * `GitHub.providers({ baseUrl })`, then to the host resolved by the auth
+   * provider. Changing it replaces the resource — the same name on a
+   * different GitHub instance is a different physical resource.
+   */
+  baseUrl?: string;
 }
 
 export interface Repository extends Resource<
@@ -351,18 +361,23 @@ export const RepositoryProvider = () =>
   Provider.succeed(Repository, {
     stables: ["repoId", "nodeId"],
 
-    // The only structural change is the owner: a repository cannot be moved
-    // between owners by an update, so changing it replaces the resource.
-    // A `name` change is a rename, handled in `reconcile`, not a replacement.
+    // Structural changes are the owner (a repository cannot be moved between
+    // owners by an update) and the host (the same repo name on a different
+    // GitHub instance is a different repository). A `name` change is a
+    // rename, handled in `reconcile`, not a replacement.
     diff: Effect.fn(function* ({ news, olds }) {
       if (!isResolved(news)) return;
-      if (olds !== undefined && news.owner !== olds.owner) {
+      if (olds === undefined) return;
+      if (
+        news.owner !== olds.owner ||
+        (yield* gitHubBaseUrlChanged(olds, news))
+      ) {
         return { action: "replace" };
       }
     }),
 
     reconcile: Effect.fn(function* ({ news, olds }) {
-      const octokit = yield* Octokit;
+      const octokit = yield* octokitFor(news.baseUrl);
 
       const getRepo = (repo: string) =>
         Effect.tryPromise({
@@ -597,12 +612,12 @@ export const RepositoryProvider = () =>
     // refreshes the output attributes (including the current name) so that a
     // subsequent delete targets the live repository even when a prior rename's
     // state persistence failed.
-    read: Effect.fn(function* ({ output }) {
+    read: Effect.fn(function* ({ olds, output }) {
       if (output === undefined) {
         return undefined;
       }
 
-      const octokit = yield* Octokit;
+      const octokit = yield* octokitFor(olds.baseUrl);
 
       return yield* Effect.tryPromise({
         try: async () => {
@@ -621,7 +636,7 @@ export const RepositoryProvider = () =>
     }),
 
     delete: Effect.fn(function* ({ olds, output }) {
-      const octokit = yield* Octokit;
+      const octokit = yield* octokitFor(olds.baseUrl);
 
       // Resolve the current repository name via the stable numeric ID. A rename
       // whose state persistence failed leaves `olds.name` stale; deleting by

--- a/packages/alchemy/src/GitHub/Repository.ts
+++ b/packages/alchemy/src/GitHub/Repository.ts
@@ -10,8 +10,13 @@ export interface RepositoryProps {
   /**
    * Repository owner — a user or organization login.
    *
-   * Changing the owner replaces the repository (the old one is deleted and a
-   * new one created under the new owner).
+   * Changing the owner replaces the repository: a NEW, EMPTY repository is
+   * created under the new owner — history, issues, and pull requests are
+   * not carried over. The old repository is retained on GitHub under the
+   * default `retain` removal policy; it is only deleted when the resource
+   * opted into deletion via `destroy()`. To actually move a repository
+   * between owners with its history, transfer it in the GitHub UI/API
+   * first, then update `owner` here and deploy with `--adopt`.
    */
   owner: string;
 
@@ -361,10 +366,16 @@ export const RepositoryProvider = () =>
   Provider.succeed(Repository, {
     stables: ["repoId", "nodeId"],
 
-    // Structural changes are the owner (a repository cannot be moved between
-    // owners by an update) and the host (the same repo name on a different
-    // GitHub instance is a different repository). A `name` change is a
-    // rename, handled in `reconcile`, not a replacement.
+    // Structural changes are the owner (we deliberately do NOT call GitHub's
+    // transfer API — user-to-user transfers require out-of-band acceptance
+    // and cannot converge deterministically) and the host (the same repo
+    // name on a different GitHub instance is a different repository). A
+    // `name` change is a rename, handled in `reconcile`, not a replacement.
+    //
+    // Replacement is guarded by the resource's default `retain` removal
+    // policy: the engine creates the new repository and RETAINS the old one
+    // on GitHub (Apply honors `retain` for the replaced old generation), so
+    // history is never destroyed unless the user opted into `destroy()`.
     diff: Effect.fn(function* ({ news, olds }) {
       if (!isResolved(news)) return;
       if (olds === undefined) return;

--- a/packages/alchemy/src/GitHub/Repository.ts
+++ b/packages/alchemy/src/GitHub/Repository.ts
@@ -2,8 +2,7 @@ import * as Effect from "effect/Effect";
 import { isResolved } from "../Diff.ts";
 import * as Provider from "../Provider.ts";
 import { Resource } from "../Resource.ts";
-import { gitHubBaseUrlChanged } from "./BaseUrl.ts";
-import { Octokit, octokitFor } from "./Octokit.ts";
+import { gitHubBaseUrlChanged, Octokit, octokitFor } from "./Octokit.ts";
 import type * as GitHub from "./Providers.ts";
 
 export interface RepositoryProps {

--- a/packages/alchemy/src/GitHub/Secret.ts
+++ b/packages/alchemy/src/GitHub/Secret.ts
@@ -2,6 +2,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Provider from "../Provider.ts";
 import { Resource } from "../Resource.ts";
+import { type Environment, resolveEnvironmentName } from "./Environment.ts";
 import { Octokit } from "./Octokit.ts";
 import type * as GitHub from "./Providers.ts";
 
@@ -28,10 +29,11 @@ export interface SecretProps {
   value: Redacted.Redacted;
 
   /**
-   * Optional environment name. When set the secret is scoped to that
-   * GitHub Actions environment instead of the whole repository.
+   * Optional environment. When set the secret is scoped to that GitHub
+   * Actions environment instead of the whole repository. Accepts an
+   * environment name or a `GitHub.Environment` resource.
    */
-  environment?: string;
+  environment?: string | Environment;
 }
 
 export interface Secret extends Resource<
@@ -160,12 +162,12 @@ export const SecretProvider = () =>
       // If the location changed, the previous secret is orphaned: delete
       // it before upserting the new one, otherwise it stays in GitHub as
       // dead state.
-      if (olds !== undefined) {
-        const wasEnv = !!olds.environment;
-        const isEnv = !!news.environment;
-        if (wasEnv !== isEnv || olds.environment !== news.environment) {
-          yield* deleteSecret(olds);
-        }
+      if (
+        olds !== undefined &&
+        resolveEnvironmentName(olds.environment) !==
+          resolveEnvironmentName(news.environment)
+      ) {
+        yield* deleteSecret(olds);
       }
 
       // Ensure & Sync — `createOrUpdate*Secret` is upsert-style: it
@@ -185,14 +187,14 @@ export const SecretProvider = () =>
 const upsertSecret = Effect.fn(function* (props: SecretProps) {
   const octokit = yield* Octokit;
   const plaintext = Redacted.value(props.value);
-  const isEnv = !!props.environment;
+  const environment = resolveEnvironmentName(props.environment);
 
   const publicKey = yield* Effect.tryPromise(async () => {
-    if (isEnv) {
+    if (environment !== undefined) {
       const { data } = await octokit.rest.actions.getEnvironmentPublicKey({
         owner: props.owner,
         repo: props.repository,
-        environment_name: props.environment!,
+        environment_name: environment,
       });
       return data;
     }
@@ -208,11 +210,11 @@ const upsertSecret = Effect.fn(function* (props: SecretProps) {
   );
 
   yield* Effect.tryPromise(async () => {
-    if (isEnv) {
+    if (environment !== undefined) {
       await octokit.rest.actions.createOrUpdateEnvironmentSecret({
         owner: props.owner,
         repo: props.repository,
-        environment_name: props.environment!,
+        environment_name: environment,
         secret_name: props.name,
         encrypted_value: encrypted,
         key_id: publicKey.key_id,
@@ -231,13 +233,14 @@ const upsertSecret = Effect.fn(function* (props: SecretProps) {
 
 const deleteSecret = Effect.fn(function* (props: SecretProps) {
   const octokit = yield* Octokit;
+  const environment = resolveEnvironmentName(props.environment);
   yield* Effect.tryPromise(async () => {
     try {
-      if (props.environment) {
+      if (environment !== undefined) {
         await octokit.rest.actions.deleteEnvironmentSecret({
           owner: props.owner,
           repo: props.repository,
-          environment_name: props.environment,
+          environment_name: environment,
           secret_name: props.name,
         });
       } else {

--- a/packages/alchemy/src/GitHub/Secret.ts
+++ b/packages/alchemy/src/GitHub/Secret.ts
@@ -159,11 +159,23 @@ async function encryptValue(
 
 export const SecretProvider = () =>
   Provider.succeed(Secret, {
-    // The only structural change is the host: the same secret name on a
-    // different GitHub instance is a different physical secret.
+    // A secret's entire identity is (host, owner, repository, environment,
+    // name) — GitHub has no rename/move API for secrets, so changing any of
+    // them replaces the resource: the engine upserts the new secret first,
+    // then `delete` removes the old one from its old location. Replacement
+    // is safe here — a secret is declarative config that is fully
+    // re-creatable from props.
     diff: Effect.fn(function* ({ news, olds }) {
       if (!isResolved(news)) return;
-      if (olds !== undefined && (yield* gitHubBaseUrlChanged(olds, news))) {
+      if (olds === undefined) return;
+      if (
+        news.owner !== olds.owner ||
+        news.repository !== olds.repository ||
+        news.name !== olds.name ||
+        resolveEnvironmentName(news.environment) !==
+          resolveEnvironmentName(olds.environment) ||
+        (yield* gitHubBaseUrlChanged(olds, news))
+      ) {
         return { action: "replace" };
       }
     }),
@@ -179,9 +191,10 @@ export const SecretProvider = () =>
     reconcile: Effect.fn(function* ({ news, olds }) {
       // Observe — there's no API to read a secret's value back, so we can
       // only observe its location (repo vs. environment, environment name).
-      // If the location changed, the previous secret is orphaned: delete
-      // it before upserting the new one, otherwise it stays in GitHub as
-      // dead state.
+      // A location change normally arrives as a replacement (see `diff`);
+      // this guard is the safety net for the plan-time path where `news`
+      // contained unresolved outputs and diff could not compare — delete the
+      // orphaned secret from its old location before upserting the new one.
       if (
         olds !== undefined &&
         resolveEnvironmentName(olds.environment) !==

--- a/packages/alchemy/src/GitHub/Secret.ts
+++ b/packages/alchemy/src/GitHub/Secret.ts
@@ -1,9 +1,11 @@
 import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
+import { isResolved } from "../Diff.ts";
 import * as Provider from "../Provider.ts";
 import { Resource } from "../Resource.ts";
+import { gitHubBaseUrlChanged } from "./BaseUrl.ts";
 import { type Environment, resolveEnvironmentName } from "./Environment.ts";
-import { Octokit } from "./Octokit.ts";
+import { octokitFor } from "./Octokit.ts";
 import type * as GitHub from "./Providers.ts";
 
 export interface SecretProps {
@@ -34,6 +36,15 @@ export interface SecretProps {
    * environment name or a `GitHub.Environment` resource.
    */
   environment?: string | Environment;
+
+  /**
+   * Override the GitHub host or API base URL for this resource only (e.g.
+   * `github.example.com` for GitHub Enterprise). Falls back to
+   * `GitHub.providers({ baseUrl })`, then to the host resolved by the auth
+   * provider. Changing it replaces the resource — the same name on a
+   * different GitHub instance is a different physical resource.
+   */
+  baseUrl?: string;
 }
 
 export interface Secret extends Resource<
@@ -148,6 +159,15 @@ async function encryptValue(
 
 export const SecretProvider = () =>
   Provider.succeed(Secret, {
+    // The only structural change is the host: the same secret name on a
+    // different GitHub instance is a different physical secret.
+    diff: Effect.fn(function* ({ news, olds }) {
+      if (!isResolved(news)) return;
+      if (olds !== undefined && (yield* gitHubBaseUrlChanged(olds, news))) {
+        return { action: "replace" };
+      }
+    }),
+
     // Non-listable: a GitHub Actions secret is keyed entirely by its parent
     // (owner, repository[, environment], name) which arrive as props — there is
     // no ambient owner/repo scope to enumerate from, `list()` takes no input,
@@ -185,7 +205,7 @@ export const SecretProvider = () =>
   });
 
 const upsertSecret = Effect.fn(function* (props: SecretProps) {
-  const octokit = yield* Octokit;
+  const octokit = yield* octokitFor(props.baseUrl);
   const plaintext = Redacted.value(props.value);
   const environment = resolveEnvironmentName(props.environment);
 
@@ -232,7 +252,7 @@ const upsertSecret = Effect.fn(function* (props: SecretProps) {
 });
 
 const deleteSecret = Effect.fn(function* (props: SecretProps) {
-  const octokit = yield* Octokit;
+  const octokit = yield* octokitFor(props.baseUrl);
   const environment = resolveEnvironmentName(props.environment);
   yield* Effect.tryPromise(async () => {
     try {

--- a/packages/alchemy/src/GitHub/Secret.ts
+++ b/packages/alchemy/src/GitHub/Secret.ts
@@ -3,9 +3,8 @@ import * as Redacted from "effect/Redacted";
 import { isResolved } from "../Diff.ts";
 import * as Provider from "../Provider.ts";
 import { Resource } from "../Resource.ts";
-import { gitHubBaseUrlChanged } from "./BaseUrl.ts";
 import { type Environment, resolveEnvironmentName } from "./Environment.ts";
-import { octokitFor } from "./Octokit.ts";
+import { gitHubBaseUrlChanged, octokitFor } from "./Octokit.ts";
 import type * as GitHub from "./Providers.ts";
 
 export interface SecretProps {

--- a/packages/alchemy/src/GitHub/Secrets.ts
+++ b/packages/alchemy/src/GitHub/Secrets.ts
@@ -4,6 +4,7 @@ import * as Redacted from "effect/Redacted";
 
 import type { Input } from "../Input.ts";
 import * as Output from "../Output.ts";
+import type { Environment } from "./Environment.ts";
 import { Secret } from "./Secret.ts";
 
 export interface SecretsProps {
@@ -18,10 +19,11 @@ export interface SecretsProps {
   repository: string;
 
   /**
-   * Optional environment name. When set every secret is scoped to that
-   * GitHub Actions environment instead of the whole repository.
+   * Optional environment. When set every secret is scoped to that GitHub
+   * Actions environment instead of the whole repository. Accepts an
+   * environment name or a `GitHub.Environment` resource.
    */
-  environment?: string;
+  environment?: string | Environment;
 
   /**
    * Map of secret name to value. Plain strings are wrapped with

--- a/packages/alchemy/src/GitHub/Secrets.ts
+++ b/packages/alchemy/src/GitHub/Secrets.ts
@@ -42,8 +42,8 @@ export interface SecretsProps {
  * @example
  * ```ts
  * yield* GitHub.Secrets({
- *   owner: "alchemy-run",
- *   repository: "alchemy",
+ *   owner: "my-org",
+ *   repository: "my-repo",
  *   secrets: {
  *     AXIOM_INGEST_TOKEN: tokenValue,
  *     AXIOM_DATASET_TRACES: traces.name,

--- a/packages/alchemy/src/GitHub/Variable.ts
+++ b/packages/alchemy/src/GitHub/Variable.ts
@@ -24,6 +24,12 @@ export interface VariableProps {
    * Variable value.
    */
   value: string;
+
+  /**
+   * Optional environment name. When set the variable is scoped to that
+   * GitHub Actions environment instead of the whole repository.
+   */
+  environment?: string;
 }
 
 export interface Variable extends Resource<
@@ -67,6 +73,22 @@ export interface Variable extends Resource<
  * });
  * ```
  *
+ * @section Environment Variables
+ * Scope a variable to a specific GitHub Actions environment (e.g.
+ * `production`, `staging`). Use `GitHub.Environment` to manage the
+ * environment itself.
+ *
+ * @example Create an Environment Variable
+ * ```typescript
+ * yield* GitHub.Variable("region", {
+ *   owner: "my-org",
+ *   repository: "my-repo",
+ *   environment: "production",
+ *   name: "AWS_REGION",
+ *   value: "us-east-1",
+ * });
+ * ```
+ *
  * @section Wiring with Other Resources
  * Pass output attributes from other resources into GitHub variables so
  * that CI workflows can reference them.
@@ -104,54 +126,32 @@ export const Variable = Resource<Variable>("GitHub.Variable");
 
 export const VariableProvider = () =>
   Provider.succeed(Variable, {
-    reconcile: Effect.fn(function* ({ news }) {
-      const octokit = yield* Octokit;
+    reconcile: Effect.fn(function* ({ news, olds }) {
+      // A variable is keyed by its location (repo vs. environment). When the
+      // location changed, the previous variable is orphaned: delete it before
+      // converging the new one, otherwise it stays in GitHub as dead state.
+      if (
+        olds !== undefined &&
+        (olds.environment ?? undefined) !== (news.environment ?? undefined)
+      ) {
+        yield* deleteVariable(olds);
+      }
 
-      // Observe — `name` is the path identifier for repo variables; ask
-      // GitHub directly for the live row. A 404 means it doesn't exist
-      // (deleted out-of-band, or never created), so we converge by
-      // creating it; otherwise we PATCH the value.
-      const observed = yield* Effect.tryPromise({
-        try: async () => {
-          try {
-            const { data } = await octokit.rest.actions.getRepoVariable({
-              owner: news.owner,
-              repo: news.repository,
-              name: news.name,
-            });
-            return data;
-          } catch (error: any) {
-            if (error.status === 404) return undefined;
-            throw error;
-          }
-        },
-        catch: (e) => e as Error,
-      });
+      // Observe — `name` is the path identifier; ask GitHub directly for the
+      // live row. A 404 means it doesn't exist (deleted out-of-band, or never
+      // created), so we converge by creating it; otherwise we PATCH the value.
+      const observed = yield* getVariable(news);
 
       // Ensure — POST creates the variable.
       if (observed === undefined) {
-        yield* Effect.tryPromise(() =>
-          octokit.rest.actions.createRepoVariable({
-            owner: news.owner,
-            repo: news.repository,
-            name: news.name,
-            value: news.value,
-          }),
-        );
+        yield* createVariable(news);
         return { updatedAt: new Date().toISOString() };
       }
 
       // Sync — PATCH the value if it drifted; skip the call when the
       // observed value already matches to keep the API quiet.
       if (observed.value !== news.value) {
-        yield* Effect.tryPromise(() =>
-          octokit.rest.actions.updateRepoVariable({
-            owner: news.owner,
-            repo: news.repository,
-            name: news.name,
-            value: news.value,
-          }),
-        );
+        yield* updateVariable(news);
       }
       return { updatedAt: new Date().toISOString() };
     }),
@@ -211,20 +211,105 @@ export const VariableProvider = () =>
     }),
 
     delete: Effect.fn(function* ({ olds }) {
-      const octokit = yield* Octokit;
-
-      yield* Effect.tryPromise(async () => {
-        try {
-          await octokit.rest.actions.deleteRepoVariable({
-            owner: olds.owner,
-            repo: olds.repository,
-            name: olds.name,
-          });
-        } catch (error: any) {
-          if (error.status !== 404) {
-            throw error;
-          }
-        }
-      });
+      yield* deleteVariable(olds);
     }),
   });
+
+const getVariable = Effect.fn(function* (props: VariableProps) {
+  const octokit = yield* Octokit;
+  return yield* Effect.tryPromise({
+    try: async () => {
+      try {
+        if (props.environment) {
+          const { data } = await octokit.rest.actions.getEnvironmentVariable({
+            owner: props.owner,
+            repo: props.repository,
+            environment_name: props.environment,
+            name: props.name,
+          });
+          return data;
+        }
+        const { data } = await octokit.rest.actions.getRepoVariable({
+          owner: props.owner,
+          repo: props.repository,
+          name: props.name,
+        });
+        return data;
+      } catch (error: any) {
+        if (error.status === 404) return undefined;
+        throw error;
+      }
+    },
+    catch: (e) => e as Error,
+  });
+});
+
+const createVariable = Effect.fn(function* (props: VariableProps) {
+  const octokit = yield* Octokit;
+  yield* Effect.tryPromise(async () => {
+    if (props.environment) {
+      await octokit.rest.actions.createEnvironmentVariable({
+        owner: props.owner,
+        repo: props.repository,
+        environment_name: props.environment,
+        name: props.name,
+        value: props.value,
+      });
+    } else {
+      await octokit.rest.actions.createRepoVariable({
+        owner: props.owner,
+        repo: props.repository,
+        name: props.name,
+        value: props.value,
+      });
+    }
+  });
+});
+
+const updateVariable = Effect.fn(function* (props: VariableProps) {
+  const octokit = yield* Octokit;
+  yield* Effect.tryPromise(async () => {
+    if (props.environment) {
+      await octokit.rest.actions.updateEnvironmentVariable({
+        owner: props.owner,
+        repo: props.repository,
+        environment_name: props.environment,
+        name: props.name,
+        value: props.value,
+      });
+    } else {
+      await octokit.rest.actions.updateRepoVariable({
+        owner: props.owner,
+        repo: props.repository,
+        name: props.name,
+        value: props.value,
+      });
+    }
+  });
+});
+
+const deleteVariable = Effect.fn(function* (props: VariableProps) {
+  const octokit = yield* Octokit;
+  yield* Effect.tryPromise(async () => {
+    try {
+      if (props.environment) {
+        await octokit.rest.actions.deleteEnvironmentVariable({
+          owner: props.owner,
+          repo: props.repository,
+          environment_name: props.environment,
+          name: props.name,
+        });
+      } else {
+        await octokit.rest.actions.deleteRepoVariable({
+          owner: props.owner,
+          repo: props.repository,
+          name: props.name,
+        });
+      }
+    } catch (error: any) {
+      if (error.status !== 404) {
+        throw error;
+      }
+    }
+  });
+});

--- a/packages/alchemy/src/GitHub/Variable.ts
+++ b/packages/alchemy/src/GitHub/Variable.ts
@@ -139,19 +139,33 @@ export const Variable = Resource<Variable>("GitHub.Variable");
 
 export const VariableProvider = () =>
   Provider.succeed(Variable, {
-    // The only structural change is the host: the same variable name on a
-    // different GitHub instance is a different physical variable.
+    // A variable's entire identity is (host, owner, repository, environment,
+    // name) — GitHub has no rename/move API for variables, so changing any
+    // of them replaces the resource: the engine creates the new variable
+    // first, then `delete` removes the old one from its old location.
+    // Replacement is safe here — a variable is declarative config that is
+    // fully re-creatable from props.
     diff: Effect.fn(function* ({ news, olds }) {
       if (!isResolved(news)) return;
-      if (olds !== undefined && (yield* gitHubBaseUrlChanged(olds, news))) {
+      if (olds === undefined) return;
+      if (
+        news.owner !== olds.owner ||
+        news.repository !== olds.repository ||
+        news.name !== olds.name ||
+        resolveEnvironmentName(news.environment) !==
+          resolveEnvironmentName(olds.environment) ||
+        (yield* gitHubBaseUrlChanged(olds, news))
+      ) {
         return { action: "replace" };
       }
     }),
 
     reconcile: Effect.fn(function* ({ news, olds }) {
-      // A variable is keyed by its location (repo vs. environment). When the
-      // location changed, the previous variable is orphaned: delete it before
-      // converging the new one, otherwise it stays in GitHub as dead state.
+      // A variable is keyed by its location (repo vs. environment). A
+      // location change normally arrives as a replacement (see `diff`); this
+      // guard is the safety net for the plan-time path where `news` contained
+      // unresolved outputs and diff could not compare — delete the orphaned
+      // variable from its old location before converging the new one.
       if (
         olds !== undefined &&
         resolveEnvironmentName(olds.environment) !==

--- a/packages/alchemy/src/GitHub/Variable.ts
+++ b/packages/alchemy/src/GitHub/Variable.ts
@@ -2,9 +2,8 @@ import * as Effect from "effect/Effect";
 import { isResolved } from "../Diff.ts";
 import * as Provider from "../Provider.ts";
 import { Resource } from "../Resource.ts";
-import { gitHubBaseUrlChanged } from "./BaseUrl.ts";
 import { type Environment, resolveEnvironmentName } from "./Environment.ts";
-import { Octokit, octokitFor } from "./Octokit.ts";
+import { gitHubBaseUrlChanged, Octokit, octokitFor } from "./Octokit.ts";
 import type * as GitHub from "./Providers.ts";
 
 export interface VariableProps {

--- a/packages/alchemy/src/GitHub/Variable.ts
+++ b/packages/alchemy/src/GitHub/Variable.ts
@@ -1,8 +1,10 @@
 import * as Effect from "effect/Effect";
+import { isResolved } from "../Diff.ts";
 import * as Provider from "../Provider.ts";
 import { Resource } from "../Resource.ts";
+import { gitHubBaseUrlChanged } from "./BaseUrl.ts";
 import { type Environment, resolveEnvironmentName } from "./Environment.ts";
-import { Octokit } from "./Octokit.ts";
+import { Octokit, octokitFor } from "./Octokit.ts";
 import type * as GitHub from "./Providers.ts";
 
 export interface VariableProps {
@@ -32,6 +34,15 @@ export interface VariableProps {
    * environment name or a `GitHub.Environment` resource.
    */
   environment?: string | Environment;
+
+  /**
+   * Override the GitHub host or API base URL for this resource only (e.g.
+   * `github.example.com` for GitHub Enterprise). Falls back to
+   * `GitHub.providers({ baseUrl })`, then to the host resolved by the auth
+   * provider. Changing it replaces the resource — the same name on a
+   * different GitHub instance is a different physical resource.
+   */
+  baseUrl?: string;
 }
 
 export interface Variable extends Resource<
@@ -128,6 +139,15 @@ export const Variable = Resource<Variable>("GitHub.Variable");
 
 export const VariableProvider = () =>
   Provider.succeed(Variable, {
+    // The only structural change is the host: the same variable name on a
+    // different GitHub instance is a different physical variable.
+    diff: Effect.fn(function* ({ news, olds }) {
+      if (!isResolved(news)) return;
+      if (olds !== undefined && (yield* gitHubBaseUrlChanged(olds, news))) {
+        return { action: "replace" };
+      }
+    }),
+
     reconcile: Effect.fn(function* ({ news, olds }) {
       // A variable is keyed by its location (repo vs. environment). When the
       // location changed, the previous variable is orphaned: delete it before
@@ -219,7 +239,7 @@ export const VariableProvider = () =>
   });
 
 const getVariable = Effect.fn(function* (props: VariableProps) {
-  const octokit = yield* Octokit;
+  const octokit = yield* octokitFor(props.baseUrl);
   const environment = resolveEnvironmentName(props.environment);
   return yield* Effect.tryPromise({
     try: async () => {
@@ -249,7 +269,7 @@ const getVariable = Effect.fn(function* (props: VariableProps) {
 });
 
 const createVariable = Effect.fn(function* (props: VariableProps) {
-  const octokit = yield* Octokit;
+  const octokit = yield* octokitFor(props.baseUrl);
   const environment = resolveEnvironmentName(props.environment);
   yield* Effect.tryPromise(async () => {
     if (environment !== undefined) {
@@ -272,7 +292,7 @@ const createVariable = Effect.fn(function* (props: VariableProps) {
 });
 
 const updateVariable = Effect.fn(function* (props: VariableProps) {
-  const octokit = yield* Octokit;
+  const octokit = yield* octokitFor(props.baseUrl);
   const environment = resolveEnvironmentName(props.environment);
   yield* Effect.tryPromise(async () => {
     if (environment !== undefined) {
@@ -295,7 +315,7 @@ const updateVariable = Effect.fn(function* (props: VariableProps) {
 });
 
 const deleteVariable = Effect.fn(function* (props: VariableProps) {
-  const octokit = yield* Octokit;
+  const octokit = yield* octokitFor(props.baseUrl);
   const environment = resolveEnvironmentName(props.environment);
   yield* Effect.tryPromise(async () => {
     try {

--- a/packages/alchemy/src/GitHub/Variable.ts
+++ b/packages/alchemy/src/GitHub/Variable.ts
@@ -1,6 +1,7 @@
 import * as Effect from "effect/Effect";
 import * as Provider from "../Provider.ts";
 import { Resource } from "../Resource.ts";
+import { type Environment, resolveEnvironmentName } from "./Environment.ts";
 import { Octokit } from "./Octokit.ts";
 import type * as GitHub from "./Providers.ts";
 
@@ -26,10 +27,11 @@ export interface VariableProps {
   value: string;
 
   /**
-   * Optional environment name. When set the variable is scoped to that
-   * GitHub Actions environment instead of the whole repository.
+   * Optional environment. When set the variable is scoped to that GitHub
+   * Actions environment instead of the whole repository. Accepts an
+   * environment name or a `GitHub.Environment` resource.
    */
-  environment?: string;
+  environment?: string | Environment;
 }
 
 export interface Variable extends Resource<
@@ -132,7 +134,8 @@ export const VariableProvider = () =>
       // converging the new one, otherwise it stays in GitHub as dead state.
       if (
         olds !== undefined &&
-        (olds.environment ?? undefined) !== (news.environment ?? undefined)
+        resolveEnvironmentName(olds.environment) !==
+          resolveEnvironmentName(news.environment)
       ) {
         yield* deleteVariable(olds);
       }
@@ -217,14 +220,15 @@ export const VariableProvider = () =>
 
 const getVariable = Effect.fn(function* (props: VariableProps) {
   const octokit = yield* Octokit;
+  const environment = resolveEnvironmentName(props.environment);
   return yield* Effect.tryPromise({
     try: async () => {
       try {
-        if (props.environment) {
+        if (environment !== undefined) {
           const { data } = await octokit.rest.actions.getEnvironmentVariable({
             owner: props.owner,
             repo: props.repository,
-            environment_name: props.environment,
+            environment_name: environment,
             name: props.name,
           });
           return data;
@@ -246,12 +250,13 @@ const getVariable = Effect.fn(function* (props: VariableProps) {
 
 const createVariable = Effect.fn(function* (props: VariableProps) {
   const octokit = yield* Octokit;
+  const environment = resolveEnvironmentName(props.environment);
   yield* Effect.tryPromise(async () => {
-    if (props.environment) {
+    if (environment !== undefined) {
       await octokit.rest.actions.createEnvironmentVariable({
         owner: props.owner,
         repo: props.repository,
-        environment_name: props.environment,
+        environment_name: environment,
         name: props.name,
         value: props.value,
       });
@@ -268,12 +273,13 @@ const createVariable = Effect.fn(function* (props: VariableProps) {
 
 const updateVariable = Effect.fn(function* (props: VariableProps) {
   const octokit = yield* Octokit;
+  const environment = resolveEnvironmentName(props.environment);
   yield* Effect.tryPromise(async () => {
-    if (props.environment) {
+    if (environment !== undefined) {
       await octokit.rest.actions.updateEnvironmentVariable({
         owner: props.owner,
         repo: props.repository,
-        environment_name: props.environment,
+        environment_name: environment,
         name: props.name,
         value: props.value,
       });
@@ -290,13 +296,14 @@ const updateVariable = Effect.fn(function* (props: VariableProps) {
 
 const deleteVariable = Effect.fn(function* (props: VariableProps) {
   const octokit = yield* Octokit;
+  const environment = resolveEnvironmentName(props.environment);
   yield* Effect.tryPromise(async () => {
     try {
-      if (props.environment) {
+      if (environment !== undefined) {
         await octokit.rest.actions.deleteEnvironmentVariable({
           owner: props.owner,
           repo: props.repository,
-          environment_name: props.environment,
+          environment_name: environment,
           name: props.name,
         });
       } else {

--- a/packages/alchemy/src/GitHub/Variables.ts
+++ b/packages/alchemy/src/GitHub/Variables.ts
@@ -15,6 +15,12 @@ export interface VariablesProps {
   repository: string;
 
   /**
+   * Optional environment name. When set every variable is scoped to that
+   * GitHub Actions environment instead of the whole repository.
+   */
+  environment?: string;
+
+  /**
    * Map of variable name to value. Each entry becomes one
    * `GitHub.Variable` resource, using the map key as both the alchemy
    * logical id and the variable name.
@@ -41,12 +47,18 @@ export interface VariablesProps {
  * });
  * ```
  */
-export const Variables = ({ owner, repository, variables }: VariablesProps) =>
+export const Variables = ({
+  owner,
+  repository,
+  environment,
+  variables,
+}: VariablesProps) =>
   Effect.all(
     Object.entries(variables).map(([name, value]) =>
       Variable(name, {
         owner,
         repository,
+        environment,
         name,
         value,
       }),

--- a/packages/alchemy/src/GitHub/Variables.ts
+++ b/packages/alchemy/src/GitHub/Variables.ts
@@ -40,8 +40,8 @@ export interface VariablesProps {
  * @example
  * ```ts
  * yield* GitHub.Variables({
- *   owner: "alchemy-run",
- *   repository: "alchemy",
+ *   owner: "my-org",
+ *   repository: "my-repo",
  *   variables: {
  *     AWS_ROLE_ARN: role.roleArn,
  *     AWS_REGION: region,

--- a/packages/alchemy/src/GitHub/Variables.ts
+++ b/packages/alchemy/src/GitHub/Variables.ts
@@ -1,6 +1,7 @@
 import * as Effect from "effect/Effect";
 
 import type { Input } from "../Input.ts";
+import type { Environment } from "./Environment.ts";
 import { Variable } from "./Variable.ts";
 
 export interface VariablesProps {
@@ -15,10 +16,11 @@ export interface VariablesProps {
   repository: string;
 
   /**
-   * Optional environment name. When set every variable is scoped to that
-   * GitHub Actions environment instead of the whole repository.
+   * Optional environment. When set every variable is scoped to that GitHub
+   * Actions environment instead of the whole repository. Accepts an
+   * environment name or a `GitHub.Environment` resource.
    */
-  environment?: string;
+  environment?: string | Environment;
 
   /**
    * Map of variable name to value. Each entry becomes one

--- a/packages/alchemy/src/GitHub/Webhook.ts
+++ b/packages/alchemy/src/GitHub/Webhook.ts
@@ -1,9 +1,11 @@
 import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import type { Input } from "../Input.ts";
+import { isResolved } from "../Diff.ts";
 import * as Provider from "../Provider.ts";
 import { Resource } from "../Resource.ts";
-import { Octokit } from "./Octokit.ts";
+import { gitHubBaseUrlChanged } from "./BaseUrl.ts";
+import { Octokit, octokitFor } from "./Octokit.ts";
 import type * as GitHub from "./Providers.ts";
 import type { WebhookEventName } from "./RepositoryEventSource.ts";
 
@@ -58,6 +60,15 @@ export interface WebhookProps {
    * @default false
    */
   insecureSsl?: boolean;
+
+  /**
+   * Override the GitHub host or API base URL for this resource only (e.g.
+   * `github.example.com` for GitHub Enterprise). Falls back to
+   * `GitHub.providers({ baseUrl })`, then to the host resolved by the auth
+   * provider. Changing it replaces the resource — the same name on a
+   * different GitHub instance is a different physical resource.
+   */
+  baseUrl?: string;
 }
 
 export interface Webhook extends Resource<
@@ -140,8 +151,17 @@ export const WebhookProvider = () =>
   Provider.succeed(Webhook, {
     stables: ["webhookId"],
 
+    // The only structural change is the host: the same webhook on a
+    // different GitHub instance is a different physical webhook.
+    diff: Effect.fn(function* ({ news, olds }) {
+      if (!isResolved(news)) return;
+      if (olds !== undefined && (yield* gitHubBaseUrlChanged(olds, news))) {
+        return { action: "replace" };
+      }
+    }),
+
     reconcile: Effect.fn(function* ({ news, output }) {
-      const octokit = yield* Octokit;
+      const octokit = yield* octokitFor(news.baseUrl);
 
       const config = {
         url: news.url as string,
@@ -254,7 +274,7 @@ export const WebhookProvider = () =>
     }),
 
     delete: Effect.fn(function* ({ olds, output }) {
-      const octokit = yield* Octokit;
+      const octokit = yield* octokitFor(olds.baseUrl);
 
       yield* Effect.tryPromise(async () => {
         try {

--- a/packages/alchemy/src/GitHub/Webhook.ts
+++ b/packages/alchemy/src/GitHub/Webhook.ts
@@ -4,8 +4,7 @@ import type { Input } from "../Input.ts";
 import { isResolved } from "../Diff.ts";
 import * as Provider from "../Provider.ts";
 import { Resource } from "../Resource.ts";
-import { gitHubBaseUrlChanged } from "./BaseUrl.ts";
-import { Octokit, octokitFor } from "./Octokit.ts";
+import { gitHubBaseUrlChanged, Octokit, octokitFor } from "./Octokit.ts";
 import type * as GitHub from "./Providers.ts";
 import type { WebhookEventName } from "./RepositoryEventSource.ts";
 

--- a/packages/alchemy/src/GitHub/Webhook.ts
+++ b/packages/alchemy/src/GitHub/Webhook.ts
@@ -151,11 +151,21 @@ export const WebhookProvider = () =>
   Provider.succeed(Webhook, {
     stables: ["webhookId"],
 
-    // The only structural change is the host: the same webhook on a
-    // different GitHub instance is a different physical webhook.
+    // A webhook belongs to (host, owner, repository) — its server-assigned
+    // id is meaningless in any other repo, so moving it replaces the
+    // resource: the engine creates the new webhook first, then `delete`
+    // removes the old one from the old repo. Everything else (url, events,
+    // secret, active) is mutated in place by `reconcile`. Replacement is
+    // safe here — a webhook is declarative config that is fully
+    // re-creatable from props.
     diff: Effect.fn(function* ({ news, olds }) {
       if (!isResolved(news)) return;
-      if (olds !== undefined && (yield* gitHubBaseUrlChanged(olds, news))) {
+      if (olds === undefined) return;
+      if (
+        news.owner !== olds.owner ||
+        news.repository !== olds.repository ||
+        (yield* gitHubBaseUrlChanged(olds, news))
+      ) {
         return { action: "replace" };
       }
     }),

--- a/packages/alchemy/src/GitHub/index.ts
+++ b/packages/alchemy/src/GitHub/index.ts
@@ -2,6 +2,7 @@ export * as Auth from "./AuthProvider.ts";
 export * from "./Comment.ts";
 export { GitHubCredentials, fromEnv, fromToken } from "./Credentials.ts";
 export * from "./Env.ts";
+export * from "./Environment.ts";
 export * from "./Providers.ts";
 export * from "./Repository.ts";
 export * from "./RepositoryEventSource.ts";

--- a/packages/alchemy/test/GitHub/BaseUrl.test.ts
+++ b/packages/alchemy/test/GitHub/BaseUrl.test.ts
@@ -1,10 +1,12 @@
 import { readEnvCredentials } from "@/GitHub/AuthProvider";
 import { GitHubCredentials, fromToken } from "@/GitHub/Credentials";
 import {
+  gitHubBaseUrlChanged,
   githubHostname,
   normalizeGitHubBaseUrl,
   resolveGitHubBaseUrlFromEnv,
 } from "@/GitHub/BaseUrl";
+import { octokitFor } from "@/GitHub/Octokit";
 import * as ConfigProvider from "effect/ConfigProvider";
 import * as Effect from "effect/Effect";
 import * as Result from "effect/Result";
@@ -169,6 +171,63 @@ describe("readEnvCredentials", () => {
       ),
     );
     expect(Result.isFailure(result)).toBe(true);
+  });
+});
+
+describe("gitHubBaseUrlChanged", () => {
+  const changed = (a: string | undefined, b: string | undefined) =>
+    Effect.runSync(gitHubBaseUrlChanged({ baseUrl: a }, { baseUrl: b }));
+
+  test("cosmetic rewrites of the same host do not count as a change", () => {
+    expect(
+      changed("github.example.com", "https://github.example.com/api/v3"),
+    ).toBe(false);
+    expect(changed(undefined, "github.com")).toBe(false);
+    expect(changed("acme.ghe.com", "https://api.acme.ghe.com")).toBe(false);
+  });
+
+  test("moving between hosts counts as a change", () => {
+    expect(changed(undefined, "github.example.com")).toBe(true);
+    expect(changed("github.example.com", undefined)).toBe(true);
+    expect(changed("github.example.com", "other.example.com")).toBe(true);
+  });
+});
+
+describe("octokitFor", () => {
+  const octokitOf = (
+    credsBaseUrl: string | undefined,
+    resourceBaseUrl: string | undefined,
+  ) =>
+    Effect.runSync(
+      octokitFor(resourceBaseUrl).pipe(
+        Effect.provide(
+          fromToken(
+            "test-token",
+            credsBaseUrl !== undefined ? { baseUrl: credsBaseUrl } : undefined,
+          ),
+        ),
+      ),
+    );
+
+  test("falls back to the credentials' host when no override is given", () => {
+    const octokit = octokitOf("github.example.com", undefined);
+    expect(octokit.request.endpoint.DEFAULTS.baseUrl).toBe(
+      "https://github.example.com/api/v3",
+    );
+  });
+
+  test("a per-resource baseUrl overrides the credentials' host", () => {
+    const octokit = octokitOf("github.example.com", "other.example.com");
+    expect(octokit.request.endpoint.DEFAULTS.baseUrl).toBe(
+      "https://other.example.com/api/v3",
+    );
+  });
+
+  test("an explicit github.com override wins over an enterprise credential host", () => {
+    const octokit = octokitOf("github.example.com", "github.com");
+    expect(octokit.request.endpoint.DEFAULTS.baseUrl).toBe(
+      "https://api.github.com",
+    );
   });
 });
 

--- a/packages/alchemy/test/GitHub/BaseUrl.test.ts
+++ b/packages/alchemy/test/GitHub/BaseUrl.test.ts
@@ -1,0 +1,197 @@
+import { readEnvCredentials } from "@/GitHub/AuthProvider";
+import { GitHubCredentials, fromToken } from "@/GitHub/Credentials";
+import {
+  githubHostname,
+  normalizeGitHubBaseUrl,
+  resolveGitHubBaseUrlFromEnv,
+} from "@/GitHub/BaseUrl";
+import * as ConfigProvider from "effect/ConfigProvider";
+import * as Effect from "effect/Effect";
+import * as Result from "effect/Result";
+import { describe, expect, test } from "vitest";
+
+const normalize = (input: string) =>
+  Effect.runSync(normalizeGitHubBaseUrl(input));
+
+describe("normalizeGitHubBaseUrl", () => {
+  test("github.com hosts normalize to undefined (Octokit default)", () => {
+    expect(normalize("github.com")).toBeUndefined();
+    expect(normalize("https://github.com")).toBeUndefined();
+    expect(normalize("https://www.github.com/")).toBeUndefined();
+    expect(normalize("https://api.github.com")).toBeUndefined();
+  });
+
+  test("GitHub Enterprise Server hosts get /api/v3 appended", () => {
+    expect(normalize("github.example.com")).toBe(
+      "https://github.example.com/api/v3",
+    );
+    expect(normalize("https://github.example.com")).toBe(
+      "https://github.example.com/api/v3",
+    );
+    expect(normalize("https://github.example.com/")).toBe(
+      "https://github.example.com/api/v3",
+    );
+  });
+
+  test("an explicit API path is honored as-is", () => {
+    expect(normalize("https://github.example.com/api/v3")).toBe(
+      "https://github.example.com/api/v3",
+    );
+    expect(normalize("https://github.example.com/api/v3/")).toBe(
+      "https://github.example.com/api/v3",
+    );
+  });
+
+  test("non-default ports and http protocol are preserved", () => {
+    expect(normalize("http://github.example.com:8080")).toBe(
+      "http://github.example.com:8080/api/v3",
+    );
+  });
+
+  test("data-residency ghe.com hosts get the api. prefix", () => {
+    expect(normalize("acme.ghe.com")).toBe("https://api.acme.ghe.com");
+    expect(normalize("https://acme.ghe.com")).toBe("https://api.acme.ghe.com");
+    expect(normalize("https://api.acme.ghe.com")).toBe(
+      "https://api.acme.ghe.com",
+    );
+  });
+
+  test("invalid input fails with AuthError", () => {
+    const result = Effect.runSync(
+      Effect.result(normalizeGitHubBaseUrl("https://")),
+    );
+    expect(Result.isFailure(result)).toBe(true);
+  });
+});
+
+describe("githubHostname", () => {
+  test("GHES base URL yields the plain host", () => {
+    expect(githubHostname("https://github.example.com/api/v3")).toBe(
+      "github.example.com",
+    );
+  });
+
+  test("data-residency base URL drops the api. prefix", () => {
+    expect(githubHostname("https://api.acme.ghe.com")).toBe("acme.ghe.com");
+  });
+});
+
+describe("resolveGitHubBaseUrlFromEnv", () => {
+  // The default ConfigProvider snapshots process.env, so tests inject their
+  // environment via a ConfigProvider layer instead of mutating process.env.
+  const resolveWith = (env: Record<string, string>) =>
+    Effect.runSync(
+      resolveGitHubBaseUrlFromEnv.pipe(
+        Effect.provideService(
+          ConfigProvider.ConfigProvider,
+          ConfigProvider.fromEnv({ env }),
+        ),
+      ),
+    );
+
+  test("GITHUB_BASE_URL wins over GITHUB_API_URL", () => {
+    expect(
+      resolveWith({
+        GITHUB_BASE_URL: "https://github.example.com",
+        GITHUB_API_URL: "https://api.github.com",
+      }),
+    ).toBe("https://github.example.com/api/v3");
+  });
+
+  test("GITHUB_API_URL pointing at github.com resolves to undefined", () => {
+    expect(
+      resolveWith({ GITHUB_API_URL: "https://api.github.com" }),
+    ).toBeUndefined();
+  });
+
+  test("GH_HOST resolves as a bare hostname", () => {
+    expect(resolveWith({ GH_HOST: "github.example.com" })).toBe(
+      "https://github.example.com/api/v3",
+    );
+  });
+
+  test("resolves to undefined when nothing is set", () => {
+    expect(resolveWith({})).toBeUndefined();
+  });
+});
+
+describe("readEnvCredentials", () => {
+  const readWith = (env: Record<string, string>, configBaseUrl?: string) =>
+    Effect.runSync(
+      readEnvCredentials(configBaseUrl).pipe(
+        Effect.provideService(
+          ConfigProvider.ConfigProvider,
+          ConfigProvider.fromEnv({ env }),
+        ),
+      ),
+    );
+
+  test("enterprise token variables win on an enterprise host", () => {
+    const creds = readWith({
+      GITHUB_BASE_URL: "https://github.example.com",
+      GH_ENTERPRISE_TOKEN: "enterprise-token",
+      GITHUB_TOKEN: "standard-token",
+    });
+    expect(creds.baseUrl).toBe("https://github.example.com/api/v3");
+    expect(creds.source.details).toBe("GH_ENTERPRISE_TOKEN");
+  });
+
+  test("enterprise token variables are ignored on github.com", () => {
+    const creds = readWith({
+      GH_ENTERPRISE_TOKEN: "enterprise-token",
+      GITHUB_TOKEN: "standard-token",
+    });
+    expect(creds.baseUrl).toBeUndefined();
+    expect(creds.source.details).toBe("GITHUB_TOKEN");
+  });
+
+  test("an explicit config baseUrl wins over the environment", () => {
+    const creds = readWith(
+      {
+        GITHUB_BASE_URL: "https://other.example.com",
+        GITHUB_ACCESS_TOKEN: "token",
+      },
+      "https://github.example.com/api/v3",
+    );
+    expect(creds.baseUrl).toBe("https://github.example.com/api/v3");
+    expect(creds.source.details).toBe("GITHUB_ACCESS_TOKEN");
+  });
+
+  test("fails with AuthError when no token variable is set", () => {
+    const result = Effect.runSync(
+      Effect.result(
+        readEnvCredentials().pipe(
+          Effect.provideService(
+            ConfigProvider.ConfigProvider,
+            ConfigProvider.fromEnv({ env: {} }),
+          ),
+        ),
+      ),
+    );
+    expect(Result.isFailure(result)).toBe(true);
+  });
+});
+
+describe("fromToken", () => {
+  const octokitOf = (options?: { baseUrl?: string }) =>
+    Effect.runSync(
+      Effect.gen(function* () {
+        const creds = yield* yield* GitHubCredentials;
+        return creds.octokit();
+      }).pipe(Effect.provide(fromToken("test-token", options))),
+    );
+
+  test("defaults to api.github.com", () => {
+    const octokit = octokitOf();
+    expect(octokit.request.endpoint.DEFAULTS.baseUrl).toBe(
+      "https://api.github.com",
+    );
+  });
+
+  test("passes the normalized enterprise base URL to Octokit", () => {
+    const octokit = octokitOf({ baseUrl: "github.example.com" });
+    expect(octokit.request.endpoint.DEFAULTS.baseUrl).toBe(
+      "https://github.example.com/api/v3",
+    );
+  });
+});

--- a/packages/alchemy/test/GitHub/BaseUrl.test.ts
+++ b/packages/alchemy/test/GitHub/BaseUrl.test.ts
@@ -1,12 +1,11 @@
 import { readEnvCredentials } from "@/GitHub/AuthProvider";
 import { GitHubCredentials, fromToken } from "@/GitHub/Credentials";
 import {
-  gitHubBaseUrlChanged,
   githubHostname,
   normalizeGitHubBaseUrl,
   resolveGitHubBaseUrlFromEnv,
 } from "@/GitHub/BaseUrl";
-import { octokitFor } from "@/GitHub/Octokit";
+import { gitHubBaseUrlChanged, octokitFor } from "@/GitHub/Octokit";
 import * as ConfigProvider from "effect/ConfigProvider";
 import * as Effect from "effect/Effect";
 import * as Result from "effect/Result";
@@ -175,8 +174,24 @@ describe("readEnvCredentials", () => {
 });
 
 describe("gitHubBaseUrlChanged", () => {
-  const changed = (a: string | undefined, b: string | undefined) =>
-    Effect.runSync(gitHubBaseUrlChanged({ baseUrl: a }, { baseUrl: b }));
+  // The comparison resolves each side through the full fallback chain, so it
+  // needs the ambient credentials host — `undefined` in props means "use the
+  // credentials' host", not "github.com".
+  const changed = (
+    a: string | undefined,
+    b: string | undefined,
+    credsBaseUrl?: string,
+  ) =>
+    Effect.runSync(
+      gitHubBaseUrlChanged({ baseUrl: a }, { baseUrl: b }).pipe(
+        Effect.provide(
+          fromToken(
+            "test-token",
+            credsBaseUrl !== undefined ? { baseUrl: credsBaseUrl } : undefined,
+          ),
+        ),
+      ),
+    );
 
   test("cosmetic rewrites of the same host do not count as a change", () => {
     expect(
@@ -190,6 +205,36 @@ describe("gitHubBaseUrlChanged", () => {
     expect(changed(undefined, "github.example.com")).toBe(true);
     expect(changed("github.example.com", undefined)).toBe(true);
     expect(changed("github.example.com", "other.example.com")).toBe(true);
+  });
+
+  test("making the ambient enterprise host explicit is not a change", () => {
+    // providers({ baseUrl: "github.example.com" }): prop undefined and prop
+    // "github.example.com" resolve to the same effective host.
+    expect(changed(undefined, "github.example.com", "github.example.com")).toBe(
+      false,
+    );
+    expect(changed("github.example.com", undefined, "github.example.com")).toBe(
+      false,
+    );
+    expect(
+      changed(
+        undefined,
+        "https://github.example.com/api/v3",
+        "github.example.com",
+      ),
+    ).toBe(false);
+  });
+
+  test("explicit github.com under an ambient enterprise host IS a change", () => {
+    // prop undefined resolves to the enterprise host; prop "github.com"
+    // pins the resource back to github.com — different physical instance.
+    expect(changed(undefined, "github.com", "github.example.com")).toBe(true);
+    expect(changed("github.com", undefined, "github.example.com")).toBe(true);
+  });
+
+  test("undefined on both sides is never a change", () => {
+    expect(changed(undefined, undefined)).toBe(false);
+    expect(changed(undefined, undefined, "github.example.com")).toBe(false);
   });
 });
 

--- a/packages/alchemy/test/GitHub/Environment.test.ts
+++ b/packages/alchemy/test/GitHub/Environment.test.ts
@@ -15,10 +15,11 @@ const logLevel = Effect.provideService(
 );
 
 // These tests create, mutate, and delete a real deployment environment, so
-// they require an owner (user login or org) the token can write to. Skip
-// when unset. The host repository is public because environments (and their
-// protection rules) on private repositories are plan-gated.
-const owner = process.env.GITHUB_TEST_OWNER ?? "";
+// they run against the dedicated test org (never a real one). Set
+// GITHUB_TEST_OWNER="" to skip. The host repository is public because
+// environments (and their protection rules) on private repositories are
+// plan-gated.
+const owner = process.env.GITHUB_TEST_OWNER ?? "alchemy-run-test";
 const repo =
   process.env.GITHUB_TEST_ENVIRONMENT_REPOSITORY ??
   "alchemy-effect-environment-test";

--- a/packages/alchemy/test/GitHub/Environment.test.ts
+++ b/packages/alchemy/test/GitHub/Environment.test.ts
@@ -213,10 +213,12 @@ test.provider.skipIf(!owner)(
               name,
             }).pipe(destroy());
 
+            // Pass the Environment resource itself — the `environment` prop
+            // accepts `string | Environment` and resolves the name.
             return yield* GitHub.Variable("Variable", {
               owner,
               repository: repoName(repository),
-              environment: environment.name,
+              environment,
               name: "ALCHEMY_ENV_TEST",
               value,
             }).pipe(destroy());

--- a/packages/alchemy/test/GitHub/Environment.test.ts
+++ b/packages/alchemy/test/GitHub/Environment.test.ts
@@ -1,0 +1,264 @@
+import * as GitHub from "@/GitHub";
+import { Octokit } from "@/GitHub/Octokit.ts";
+import * as Output from "@/Output";
+import { destroy } from "@/RemovalPolicy";
+import * as Test from "@/Test/Vitest";
+import { expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+
+const { test } = Test.make({ providers: GitHub.providers() });
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+// These tests create, mutate, and delete a real deployment environment, so
+// they require an owner (user login or org) the token can write to. Skip
+// when unset. The host repository is public because environments (and their
+// protection rules) on private repositories are plan-gated.
+const owner = process.env.GITHUB_TEST_OWNER ?? "";
+const repo =
+  process.env.GITHUB_TEST_ENVIRONMENT_REPOSITORY ??
+  "alchemy-effect-environment-test";
+
+// Derive the repository name from the `fullName` output — referencing an
+// output (rather than the `repo` constant) makes the engine order dependent
+// resources after the repository exists.
+const repoName = (repository: GitHub.Repository) =>
+  Output.map(repository.fullName, (fullName) => fullName.split("/")[1]!);
+
+const getEnvironment = (name: string) =>
+  Effect.gen(function* () {
+    const octokit = yield* Octokit;
+    return yield* Effect.tryPromise({
+      try: async () => {
+        try {
+          const { data } = await octokit.rest.repos.getEnvironment({
+            owner,
+            repo,
+            environment_name: name,
+          });
+          return data;
+        } catch (error: any) {
+          if (error.status === 404) return undefined;
+          throw error;
+        }
+      },
+      catch: (e) => e as Error,
+    });
+  });
+
+const listBranchPolicies = (name: string) =>
+  Effect.gen(function* () {
+    const octokit = yield* Octokit;
+    return yield* Effect.tryPromise({
+      try: async () => {
+        const { data } = await octokit.rest.repos.listDeploymentBranchPolicies({
+          owner,
+          repo,
+          environment_name: name,
+          per_page: 100,
+        });
+        return (data.branch_policies ?? []).map((policy) => policy.name);
+      },
+      catch: (e) => e as Error,
+    });
+  });
+
+test.provider.skipIf(!owner)(
+  "create, update, and delete an environment with protection rules",
+  (stack) =>
+    Effect.gen(function* () {
+      const name = "alchemy-test-production";
+
+      // Clean up any leftovers from a previous run before deploying.
+      yield* stack.destroy();
+
+      // Create — environment with a wait timer and custom branch patterns.
+      // `Repository` defaults to `retain`, so the host repo is created once
+      // and reused across runs (reconcile is idempotent).
+      const created = yield* stack.deploy(
+        Effect.gen(function* () {
+          const repository = yield* GitHub.Repository("Repo", {
+            owner,
+            name: repo,
+            description: "alchemy-effect environment test",
+            visibility: "public",
+            autoInit: true,
+          });
+
+          return yield* GitHub.Environment("Env", {
+            owner,
+            // Derive the repo name from a repository output so the engine
+            // orders the environment after the repository exists.
+            repository: repoName(repository),
+            name,
+            waitTimer: 5,
+            preventSelfReview: true,
+            deploymentBranchPolicy: {
+              customBranchPolicies: ["main", "release/*"],
+            },
+          }).pipe(destroy());
+        }),
+      );
+
+      expect(created.environmentId).toBeGreaterThan(0);
+      expect(created.name).toEqual(name);
+      expect(created.htmlUrl).toContain(repo);
+
+      const fetched = yield* getEnvironment(name);
+      expect(fetched?.id).toEqual(created.environmentId);
+      expect(fetched?.deployment_branch_policy?.custom_branch_policies).toBe(
+        true,
+      );
+      const waitRule = fetched?.protection_rules?.find(
+        (rule) => rule.type === "wait_timer",
+      );
+      expect(
+        waitRule !== undefined && "wait_timer" in waitRule
+          ? waitRule.wait_timer
+          : undefined,
+      ).toEqual(5);
+
+      const patterns = yield* listBranchPolicies(name);
+      expect(patterns.sort()).toEqual(["main", "release/*"]);
+
+      // Update — drop the wait timer, converge the pattern list, same
+      // logical ID → same environmentId (update in place, not replace).
+      const updated = yield* stack.deploy(
+        Effect.gen(function* () {
+          const repository = yield* GitHub.Repository("Repo", {
+            owner,
+            name: repo,
+            description: "alchemy-effect environment test",
+            visibility: "public",
+          });
+
+          return yield* GitHub.Environment("Env", {
+            owner,
+            repository: repoName(repository),
+            name,
+            deploymentBranchPolicy: {
+              customBranchPolicies: ["main"],
+            },
+          }).pipe(destroy());
+        }),
+      );
+
+      expect(updated.environmentId).toEqual(created.environmentId);
+      const afterUpdate = yield* getEnvironment(name);
+      const waitAfterUpdate = afterUpdate?.protection_rules?.find(
+        (rule) => rule.type === "wait_timer",
+      );
+      expect(waitAfterUpdate).toBeUndefined();
+      expect(yield* listBranchPolicies(name)).toEqual(["main"]);
+
+      // Switch the policy mode to protected branches only.
+      const switched = yield* stack.deploy(
+        Effect.gen(function* () {
+          const repository = yield* GitHub.Repository("Repo", {
+            owner,
+            name: repo,
+            description: "alchemy-effect environment test",
+            visibility: "public",
+          });
+
+          return yield* GitHub.Environment("Env", {
+            owner,
+            repository: repoName(repository),
+            name,
+            deploymentBranchPolicy: { protectedBranches: true },
+          }).pipe(destroy());
+        }),
+      );
+
+      expect(switched.environmentId).toEqual(created.environmentId);
+      const afterSwitch = yield* getEnvironment(name);
+      expect(afterSwitch?.deployment_branch_policy?.protected_branches).toBe(
+        true,
+      );
+
+      // Delete — the environment goes away; the retained repo stays.
+      yield* stack.destroy();
+      const afterDestroy = yield* getEnvironment(name);
+      expect(afterDestroy).toBeUndefined();
+    }).pipe(logLevel),
+  { timeout: 120_000 },
+);
+
+test.provider.skipIf(!owner)(
+  "environment-scoped variable lifecycle",
+  (stack) =>
+    Effect.gen(function* () {
+      const name = "alchemy-test-variables";
+
+      yield* stack.destroy();
+
+      const deployVariable = (value: string) =>
+        stack.deploy(
+          Effect.gen(function* () {
+            const repository = yield* GitHub.Repository("Repo", {
+              owner,
+              name: repo,
+              description: "alchemy-effect environment test",
+              visibility: "public",
+              autoInit: true,
+            });
+
+            const environment = yield* GitHub.Environment("Env", {
+              owner,
+              repository: repoName(repository),
+              name,
+            }).pipe(destroy());
+
+            return yield* GitHub.Variable("Variable", {
+              owner,
+              repository: repoName(repository),
+              environment: environment.name,
+              name: "ALCHEMY_ENV_TEST",
+              value,
+            }).pipe(destroy());
+          }),
+        );
+
+      const readVariable = Effect.gen(function* () {
+        const octokit = yield* Octokit;
+        return yield* Effect.tryPromise({
+          try: async () => {
+            try {
+              const { data } =
+                await octokit.rest.actions.getEnvironmentVariable({
+                  owner,
+                  repo,
+                  environment_name: name,
+                  name: "ALCHEMY_ENV_TEST",
+                });
+              return data;
+            } catch (error: any) {
+              if (error.status === 404) return undefined;
+              throw error;
+            }
+          },
+          catch: (e) => e as Error,
+        });
+      });
+
+      // Create — the variable lands in the environment, not the repo.
+      yield* deployVariable("one");
+      const fetched = yield* readVariable;
+      expect(fetched?.value).toEqual("one");
+
+      // Update — reconcile PATCHes the drifted value in place.
+      yield* deployVariable("two");
+      const afterUpdate = yield* readVariable;
+      expect(afterUpdate?.value).toEqual("two");
+
+      // Delete — destroying the stack removes the variable (and environment).
+      yield* stack.destroy();
+      const afterDestroy = yield* readVariable;
+      expect(afterDestroy).toBeUndefined();
+    }).pipe(logLevel),
+  { timeout: 120_000 },
+);

--- a/packages/alchemy/test/GitHub/Repository.test.ts
+++ b/packages/alchemy/test/GitHub/Repository.test.ts
@@ -14,9 +14,10 @@ const logLevel = Effect.provideService(
   process.env.DEBUG ? "Debug" : "Info",
 );
 
-// These tests create, mutate, and delete a real repository, so they require an
-// owner (user login or org) the token can write to. Skip when unset.
-const owner = process.env.GITHUB_TEST_OWNER ?? "";
+// These tests create, mutate, and delete real repositories, so they run
+// against the dedicated test org (never a real one). Set GITHUB_TEST_OWNER=""
+// to skip the owner-scoped tests entirely.
+const owner = process.env.GITHUB_TEST_OWNER ?? "alchemy-run-test";
 
 const getRepo = (repo: string) =>
   Effect.gen(function* () {

--- a/packages/alchemy/test/GitHub/Repository.test.ts
+++ b/packages/alchemy/test/GitHub/Repository.test.ts
@@ -15,21 +15,43 @@ const logLevel = Effect.provideService(
 );
 
 // These tests create, mutate, and delete real repositories, so they run
-// against the dedicated test org (never a real one). Set GITHUB_TEST_OWNER=""
-// to skip the owner-scoped tests entirely.
+// against the dedicated test orgs (never a real one). Set GITHUB_TEST_OWNER=""
+// to skip the owner-scoped tests entirely. The second org hosts the target
+// side of owner-change (replacement) tests.
 const owner = process.env.GITHUB_TEST_OWNER ?? "alchemy-run-test";
+const owner2 = process.env.GITHUB_TEST_OWNER_2 ?? "alchemy-run-test-2";
 
-const getRepo = (repo: string) =>
+const getRepo = (repo: string, repoOwner: string = owner) =>
   Effect.gen(function* () {
     const octokit = yield* Octokit;
     return yield* Effect.tryPromise({
       try: async () => {
         try {
-          const { data } = await octokit.rest.repos.get({ owner, repo });
+          const { data } = await octokit.rest.repos.get({
+            owner: repoOwner,
+            repo,
+          });
           return data;
         } catch (error: any) {
           if (error.status === 404) return undefined;
           throw error;
+        }
+      },
+      catch: (e) => e as Error,
+    });
+  });
+
+// Out-of-band cleanup for repos the engine intentionally leaves behind
+// (retain-policy tests). Idempotent — a 404 means it's already gone.
+const deleteRepo = (repo: string, repoOwner: string) =>
+  Effect.gen(function* () {
+    const octokit = yield* Octokit;
+    yield* Effect.tryPromise({
+      try: async () => {
+        try {
+          await octokit.rest.repos.delete({ owner: repoOwner, repo });
+        } catch (error: any) {
+          if (error.status !== 404) throw error;
         }
       },
       catch: (e) => e as Error,
@@ -155,6 +177,116 @@ test.provider.skipIf(!owner)(
       yield* stack.destroy();
       const afterDestroy = yield* getRepo(name);
       expect(afterDestroy).toBeUndefined();
+    }).pipe(logLevel),
+  { timeout: 120_000 },
+);
+
+// Owner changes are replacements, not moves (we never call GitHub's transfer
+// API). With deletion opted in via `destroy()`, the replaced old-generation
+// repo is deleted from the old org after the new one is created.
+test.provider.skipIf(!owner || !owner2)(
+  "changing the owner replaces the repository (destroy-opted)",
+  (stack) =>
+    Effect.gen(function* () {
+      const name = "alchemy-effect-repo-owner-test";
+
+      // Clean up any leftovers from a previous run in BOTH orgs.
+      yield* stack.destroy();
+      yield* deleteRepo(name, owner);
+      yield* deleteRepo(name, owner2);
+
+      const created = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* GitHub.Repository("Repo", {
+            owner,
+            name,
+            description: "alchemy-effect owner-change test",
+            visibility: "private",
+            autoInit: true,
+          }).pipe(destroy());
+        }),
+      );
+      expect(created.fullName).toEqual(`${owner}/${name}`);
+
+      // Same logical ID, new owner → replacement: fresh repoId under the new
+      // org, and (because deletion is opted in) the old repo is cleaned up.
+      const replaced = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* GitHub.Repository("Repo", {
+            owner: owner2,
+            name,
+            description: "alchemy-effect owner-change test",
+            visibility: "private",
+            autoInit: true,
+          }).pipe(destroy());
+        }),
+      );
+      expect(replaced.fullName).toEqual(`${owner2}/${name}`);
+      expect(replaced.repoId).not.toEqual(created.repoId);
+
+      const oldRepo = yield* getRepo(name, owner);
+      expect(oldRepo).toBeUndefined();
+      const newRepo = yield* getRepo(name, owner2);
+      expect(newRepo?.id).toEqual(replaced.repoId);
+
+      yield* stack.destroy();
+      const afterDestroy = yield* getRepo(name, owner2);
+      expect(afterDestroy).toBeUndefined();
+    }).pipe(logLevel),
+  { timeout: 120_000 },
+);
+
+// The safety property: under the DEFAULT `retain` removal policy, an owner
+// change creates the new repo but RETAINS the old one on GitHub — history is
+// never destroyed by a replacement unless deletion was explicitly opted in.
+test.provider.skipIf(!owner || !owner2)(
+  "changing the owner retains the old repository by default",
+  (stack) =>
+    Effect.gen(function* () {
+      const name = "alchemy-effect-repo-retain-test";
+
+      // Clean up any leftovers from a previous run in BOTH orgs (retained
+      // repos are invisible to stack.destroy, so delete out-of-band).
+      yield* stack.destroy();
+      yield* deleteRepo(name, owner);
+      yield* deleteRepo(name, owner2);
+
+      // No `destroy()` pipe — the default `retain` policy applies.
+      const created = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* GitHub.Repository("Repo", {
+            owner,
+            name,
+            description: "alchemy-effect retain-on-replace test",
+            visibility: "private",
+            autoInit: true,
+          });
+        }),
+      );
+
+      const replaced = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* GitHub.Repository("Repo", {
+            owner: owner2,
+            name,
+            description: "alchemy-effect retain-on-replace test",
+            visibility: "private",
+            autoInit: true,
+          });
+        }),
+      );
+      expect(replaced.repoId).not.toEqual(created.repoId);
+      expect(replaced.fullName).toEqual(`${owner2}/${name}`);
+
+      // The replaced old generation must still exist in the old org.
+      const oldRepo = yield* getRepo(name, owner);
+      expect(oldRepo?.id).toEqual(created.repoId);
+
+      // Cleanup: destroy retains the new repo too, so remove both
+      // out-of-band.
+      yield* stack.destroy();
+      yield* deleteRepo(name, owner);
+      yield* deleteRepo(name, owner2);
     }).pipe(logLevel),
   { timeout: 120_000 },
 );

--- a/packages/alchemy/test/GitHub/Repository.test.ts
+++ b/packages/alchemy/test/GitHub/Repository.test.ts
@@ -1,3 +1,4 @@
+import { adopt } from "@/AdoptPolicy";
 import * as GitHub from "@/GitHub";
 import { Octokit } from "@/GitHub/Octokit.ts";
 import * as Provider from "@/Provider";
@@ -35,23 +36,6 @@ const getRepo = (repo: string, repoOwner: string = owner) =>
         } catch (error: any) {
           if (error.status === 404) return undefined;
           throw error;
-        }
-      },
-      catch: (e) => e as Error,
-    });
-  });
-
-// Out-of-band cleanup for repos the engine intentionally leaves behind
-// (retain-policy tests). Idempotent — a 404 means it's already gone.
-const deleteRepo = (repo: string, repoOwner: string) =>
-  Effect.gen(function* () {
-    const octokit = yield* Octokit;
-    yield* Effect.tryPromise({
-      try: async () => {
-        try {
-          await octokit.rest.repos.delete({ owner: repoOwner, repo });
-        } catch (error: any) {
-          if (error.status !== 404) throw error;
         }
       },
       catch: (e) => e as Error,
@@ -190,10 +174,10 @@ test.provider.skipIf(!owner || !owner2)(
     Effect.gen(function* () {
       const name = "alchemy-effect-repo-owner-test";
 
-      // Clean up any leftovers from a previous run in BOTH orgs.
+      // Clean up any leftovers from a previous run. Repos a crashed run left
+      // behind converge back under management when the deploy below re-takes
+      // the same deterministic name (reconcile's create-race path).
       yield* stack.destroy();
-      yield* deleteRepo(name, owner);
-      yield* deleteRepo(name, owner2);
 
       const created = yield* stack.deploy(
         Effect.gen(function* () {
@@ -245,11 +229,10 @@ test.provider.skipIf(!owner || !owner2)(
     Effect.gen(function* () {
       const name = "alchemy-effect-repo-retain-test";
 
-      // Clean up any leftovers from a previous run in BOTH orgs (retained
-      // repos are invisible to stack.destroy, so delete out-of-band).
+      // Clean up any leftovers from a previous run. Retained repos a prior
+      // run left behind converge back under management when the deploys
+      // below re-take the same deterministic names.
       yield* stack.destroy();
-      yield* deleteRepo(name, owner);
-      yield* deleteRepo(name, owner2);
 
       // No `destroy()` pipe — the default `retain` policy applies.
       const created = yield* stack.deploy(
@@ -282,11 +265,36 @@ test.provider.skipIf(!owner || !owner2)(
       const oldRepo = yield* getRepo(name, owner);
       expect(oldRepo?.id).toEqual(created.repoId);
 
-      // Cleanup: destroy retains the new repo too, so remove both
-      // out-of-band.
+      // Cleanup — all through the engine: adopt the retained repo back into
+      // state under a second logical ID and flip both resources to the
+      // `destroy` removal policy, so the final stack.destroy() deletes both.
+      const adopted = yield* stack.deploy(
+        Effect.gen(function* () {
+          const current = yield* GitHub.Repository("Repo", {
+            owner: owner2,
+            name,
+            description: "alchemy-effect retain-on-replace test",
+            visibility: "private",
+          }).pipe(destroy());
+
+          const old = yield* GitHub.Repository("OldRepo", {
+            owner,
+            name,
+            description: "alchemy-effect retain-on-replace test",
+            visibility: "private",
+          }).pipe(adopt(), destroy());
+
+          return { current, old };
+        }),
+      );
+
+      // The adopted resource converged onto the retained repo, not a new one.
+      expect(adopted.old.repoId).toEqual(created.repoId);
+      expect(adopted.current.repoId).toEqual(replaced.repoId);
+
       yield* stack.destroy();
-      yield* deleteRepo(name, owner);
-      yield* deleteRepo(name, owner2);
+      expect(yield* getRepo(name, owner)).toBeUndefined();
+      expect(yield* getRepo(name, owner2)).toBeUndefined();
     }).pipe(logLevel),
   { timeout: 120_000 },
 );

--- a/packages/alchemy/test/GitHub/Secret.test.ts
+++ b/packages/alchemy/test/GitHub/Secret.test.ts
@@ -17,7 +17,8 @@ const logLevel = Effect.provideService(
 );
 
 // Deploying a secret needs an owner + repository the token can write to.
-const owner = process.env.GITHUB_TEST_OWNER ?? "alchemy-run";
+// Never default to a real organization — skip when GITHUB_TEST_OWNER is unset.
+const owner = process.env.GITHUB_TEST_OWNER ?? "";
 const repository = process.env.GITHUB_TEST_REPOSITORY ?? "test-repo";
 
 // GitHub never returns a secret's value, only its metadata — so `getRepoSecret`
@@ -40,7 +41,7 @@ const secretExists = (name: string) =>
     });
   });
 
-test.provider(
+test.provider.skipIf(!owner)(
   "Secrets resolves Config values before wrapping them as Redacted",
   (stack) =>
     Effect.gen(function* () {
@@ -77,7 +78,7 @@ test.provider(
 // ambient owner/repo scope, and GitHub exposes no account-wide enumeration —
 // only list-secrets *within* a specific repo. So `list()` always returns `[]`,
 // even when a secret exists in the cloud.
-test.provider(
+test.provider.skipIf(!owner)(
   "list returns an empty array for non-enumerable GitHub secrets",
   (stack) =>
     Effect.gen(function* () {

--- a/packages/alchemy/test/GitHub/Secret.test.ts
+++ b/packages/alchemy/test/GitHub/Secret.test.ts
@@ -16,9 +16,10 @@ const logLevel = Effect.provideService(
   process.env.DEBUG ? "Debug" : "Info",
 );
 
-// Deploying a secret needs an owner + repository the token can write to.
-// Never default to a real organization — skip when GITHUB_TEST_OWNER is unset.
-const owner = process.env.GITHUB_TEST_OWNER ?? "";
+// Deploying a secret needs an owner + repository the token can write to —
+// the dedicated test org (never a real one). Set GITHUB_TEST_OWNER="" to
+// skip.
+const owner = process.env.GITHUB_TEST_OWNER ?? "alchemy-run-test";
 const repository = process.env.GITHUB_TEST_REPOSITORY ?? "test-repo";
 
 // GitHub never returns a secret's value, only its metadata — so `getRepoSecret`

--- a/packages/alchemy/test/GitHub/Variable.test.ts
+++ b/packages/alchemy/test/GitHub/Variable.test.ts
@@ -13,11 +13,12 @@ const logLevel = Effect.provideService(
 );
 
 // Creating a real repository + variable requires an owner (user login or org)
-// the token can write to.
-const owner = process.env.GITHUB_TEST_OWNER ?? "alchemy-run";
+// the token can write to. Never default to a real organization — skip when
+// GITHUB_TEST_OWNER is unset.
+const owner = process.env.GITHUB_TEST_OWNER ?? "";
 const repo = process.env.GITHUB_TEST_REPOSITORY ?? "test-repo";
 
-test.provider(
+test.provider.skipIf(!owner)(
   "list enumerates the deployed variable",
   (stack) =>
     Effect.gen(function* () {

--- a/packages/alchemy/test/GitHub/Variable.test.ts
+++ b/packages/alchemy/test/GitHub/Variable.test.ts
@@ -12,10 +12,10 @@ const logLevel = Effect.provideService(
   process.env.DEBUG ? "Debug" : "Info",
 );
 
-// Creating a real repository + variable requires an owner (user login or org)
-// the token can write to. Never default to a real organization — skip when
-// GITHUB_TEST_OWNER is unset.
-const owner = process.env.GITHUB_TEST_OWNER ?? "";
+// Creating a real repository + variable requires an owner the token can
+// write to — the dedicated test org (never a real one). Set
+// GITHUB_TEST_OWNER="" to skip.
+const owner = process.env.GITHUB_TEST_OWNER ?? "alchemy-run-test";
 const repo = process.env.GITHUB_TEST_REPOSITORY ?? "test-repo";
 
 test.provider.skipIf(!owner)(

--- a/website/src/content/docs/github/actions-config.mdx
+++ b/website/src/content/docs/github/actions-config.mdx
@@ -82,14 +82,16 @@ const production = yield* GitHub.Environment("production", {
 yield* GitHub.Secret("deploy-key", {
   owner: "my-org",
   repository: "my-repo",
-  environment: production.name,
+  environment: production,
   name: "DEPLOY_KEY",
   value: Redacted.make("my-secret-value"),
 });
 ```
 
-Reviewers are referenced by user login and team slug — alchemy resolves
-them to the IDs GitHub's API expects. `deploymentBranchPolicy` restricts
+The `environment` prop on secrets and variables accepts either a name
+string or the `Environment` resource itself. Reviewers are referenced by
+user login and team slug — alchemy resolves them to the IDs GitHub's API
+expects. `deploymentBranchPolicy` restricts
 which branches can deploy: `{ protectedBranches: true }` or a list of
 branch name patterns via `customBranchPolicies`. Environments on private
 repositories are plan-gated (Pro/Team/Enterprise); public repositories

--- a/website/src/content/docs/github/actions-config.mdx
+++ b/website/src/content/docs/github/actions-config.mdx
@@ -57,6 +57,44 @@ yield* GitHub.Secret("deploy-key", {
 Environment secrets are only released to workflows once the
 environment's protection rules are satisfied.
 
+## Manage the environment itself
+
+`GitHub.Environment` manages the deployment environment as a resource —
+including its protection rules — so the environment a secret targets is
+declared in the same deploy:
+
+```typescript
+const production = yield* GitHub.Environment("production", {
+  owner: "my-org",
+  repository: "my-repo",
+  name: "production",
+  waitTimer: 30,
+  preventSelfReview: true,
+  reviewers: {
+    users: ["release-manager"],
+    teams: ["platform"],
+  },
+  deploymentBranchPolicy: {
+    customBranchPolicies: ["main", "release/*"],
+  },
+});
+
+yield* GitHub.Secret("deploy-key", {
+  owner: "my-org",
+  repository: "my-repo",
+  environment: production.name,
+  name: "DEPLOY_KEY",
+  value: Redacted.make("my-secret-value"),
+});
+```
+
+Reviewers are referenced by user login and team slug — alchemy resolves
+them to the IDs GitHub's API expects. `deploymentBranchPolicy` restricts
+which branches can deploy: `{ protectedBranches: true }` or a list of
+branch name patterns via `customBranchPolicies`. Environments on private
+repositories are plan-gated (Pro/Team/Enterprise); public repositories
+get them on every plan.
+
 ## Create a variable
 
 `GitHub.Variable` manages a plain-text repository variable —
@@ -74,6 +112,19 @@ yield* GitHub.Variable("aws-region", {
 
 Unlike secrets, variable values are readable back, so alchemy diffs
 the live value and skips the API call when nothing changed.
+
+Variables take the same `environment` prop as secrets to scope the
+variable to one Actions environment instead of the whole repository:
+
+```typescript
+yield* GitHub.Variable("region", {
+  owner: "my-org",
+  repository: "my-repo",
+  environment: "production",
+  name: "AWS_REGION",
+  value: "us-east-1",
+});
+```
 
 ## Wire in outputs from other resources
 
@@ -122,8 +173,9 @@ yield* GitHub.Variables({
 
 `Secrets` accepts plain strings, `Redacted` values, or unresolved
 inputs (outputs of other resources, `Config` values) — plain strings
-are wrapped with `Redacted.make` automatically. Pass `environment`
-to scope every secret in the map to one Actions environment.
+are wrapped with `Redacted.make` automatically. Both helpers take an
+`environment` to scope every entry in the map to one Actions
+environment.
 
 ## Provision CI credentials as code
 
@@ -195,7 +247,8 @@ for private repositories, or `public_repo` for public ones.
 
 Reference:
 
-- [Secret](/providers/github/secret) ·
+- [Environment](/providers/github/environment) ·
+  [Secret](/providers/github/secret) ·
   [Secrets](/providers/github/secrets) ·
   [Variable](/providers/github/variable) ·
   [Variables](/providers/github/variables)

--- a/website/src/content/docs/github/index.mdx
+++ b/website/src/content/docs/github/index.mdx
@@ -49,6 +49,18 @@ yield* GitHub.Variables({
 });
 ```
 
+`Environment` manages a deployment environment and its protection
+rules; secrets and variables scope to it via their `environment` prop:
+
+```typescript
+const production = yield* GitHub.Environment("production", {
+  owner: "my-org",
+  repository: "api",
+  name: "production",
+  reviewers: { teams: ["platform"] },
+});
+```
+
 `Webhook` manages a repository webhook pointed at any URL, and
 `consumeRepositoryEvents` subscribes a host (e.g. a Cloudflare
 Worker) to repository webhooks with typed payloads — see
@@ -108,6 +120,7 @@ credential that was itself provisioned as code. Walk through it in
 ## Reference
 
 [Repository](/providers/github/repository) ·
+[Environment](/providers/github/environment) ·
 [Secret](/providers/github/secret) ·
 [Secrets](/providers/github/secrets) ·
 [Variable](/providers/github/variable) ·

--- a/website/src/content/docs/github/setup.mdx
+++ b/website/src/content/docs/github/setup.mdx
@@ -48,6 +48,36 @@ back to `GITHUB_ACCESS_TOKEN` / `GITHUB_TOKEN`, and the `gh` CLI method
 runs `gh auth token --hostname <host>` (run
 `gh auth login --hostname <host>` once first).
 
+### Pin the host in code
+
+To fix the host for the whole app — independent of profile
+configuration or the environment — pass it to `providers()`:
+
+```typescript
+providers: GitHub.providers({ baseUrl: "github.example.com" }),
+```
+
+The auth provider sees the pinned host too: `alchemy login` stops
+prompting for it and authenticates against it directly.
+
+### Per-resource host override
+
+Every GitHub resource also takes its own `baseUrl` prop, so a single
+stack can span github.com and an enterprise instance:
+
+```typescript
+yield* GitHub.Repository("mirror", {
+  owner: "my-org",
+  name: "mirror",
+  baseUrl: "github.example.com",
+});
+```
+
+Resolution order is: resource `baseUrl` → `providers({ baseUrl })` →
+the host from the login profile or environment. Changing a resource's
+`baseUrl` replaces it — the same name on a different GitHub instance
+is a different physical resource.
+
 ## Token scopes
 
 - `repo` — always required.

--- a/website/src/content/docs/github/setup.mdx
+++ b/website/src/content/docs/github/setup.mdx
@@ -26,6 +26,28 @@ environment-variables method automatically.
 See [Profiles](/environments/profiles) for how credentials are stored
 and switched.
 
+## GitHub Enterprise
+
+All three methods work against GitHub Enterprise Server and GitHub
+Enterprise Cloud with data residency. `alchemy login --configure`
+prompts for the host — leave it blank for github.com, or enter your
+enterprise host (e.g. `github.example.com` or `acme.ghe.com`).
+
+The host is normalized into the REST API base URL automatically:
+
+- `github.example.com` → `https://github.example.com/api/v3` (GHES)
+- `acme.ghe.com` → `https://api.acme.ghe.com` (data residency)
+- an explicit URL like `https://github.example.com/api/v3` is used as-is
+
+Alternatively, set the host in the environment — `GITHUB_BASE_URL`,
+`GITHUB_API_URL` (set automatically on GitHub Actions runners), or
+`GH_HOST` — and every method picks it up without reconfiguring. On an
+enterprise host, the environment-variables method also honors the `gh`
+CLI's `GH_ENTERPRISE_TOKEN` / `GITHUB_ENTERPRISE_TOKEN` before falling
+back to `GITHUB_ACCESS_TOKEN` / `GITHUB_TOKEN`, and the `gh` CLI method
+runs `gh auth token --hostname <host>` (run
+`gh auth login --hostname <host>` once first).
+
 ## Token scopes
 
 - `repo` — always required.
@@ -43,9 +65,17 @@ you already have in hand — useful in tests:
 Effect.provide(GitHub.fromToken(token))
 ```
 
-`fromToken` accepts a plain string or a `Redacted` value. To read from
-the environment instead, `GitHub.fromEnv()` builds the same layer from
-`GITHUB_ACCESS_TOKEN` or `GITHUB_TOKEN`.
+`fromToken` accepts a plain string or a `Redacted` value, plus an
+optional `baseUrl` for GitHub Enterprise:
+
+```typescript
+Effect.provide(GitHub.fromToken(token, { baseUrl: "github.example.com" }))
+```
+
+To read from the environment instead, `GitHub.fromEnv()` builds the
+same layer from `GITHUB_ACCESS_TOKEN` or `GITHUB_TOKEN` (and resolves
+the enterprise host from `GITHUB_BASE_URL` / `GITHUB_API_URL` /
+`GH_HOST` when set).
 
 ## Next steps
 


### PR DESCRIPTION
Two additions to the GitHub provider: GitHub Enterprise support and deployment environments.

### GitHub Enterprise

`alchemy login` now asks for the GitHub host after the auth method — leave it blank for github.com, or enter your enterprise host:

```
$ alchemy login --configure
◆ GitHub authentication method
│ ● GitHub CLI  (delegate to `gh auth token`)
│ ○ Environment Variables
│ ○ Personal Access Token
◆ GitHub host (leave blank for github.com)
│ github.example.com
```

The host is normalized into the API base URL automatically (`github.example.com` → `https://github.example.com/api/v3` for GHES, `acme.ghe.com` → `https://api.acme.ghe.com` for data residency) and every GitHub resource then talks to that instance. With the `gh` CLI method, tokens are fetched via `gh auth token --hostname <host>`.

In CI, no configuration is needed — the host is picked up from `GITHUB_BASE_URL`, `GITHUB_API_URL` (set automatically on GitHub Actions runners), or `GH_HOST`, and on enterprise hosts `GH_ENTERPRISE_TOKEN` / `GITHUB_ENTERPRISE_TOKEN` are honored before `GITHUB_ACCESS_TOKEN` / `GITHUB_TOKEN`.

To pin the host in code instead of profile/env configuration:

```ts
providers: GitHub.providers({ baseUrl: "github.example.com" })
```

The auth provider sees the pinned host — `alchemy login` stops prompting for it and authenticates against it directly.

Every resource also takes its own `baseUrl` prop, so one stack can span github.com and an enterprise instance:

```ts
yield* GitHub.Repository("mirror", {
  owner: "my-org",
  name: "mirror",
  baseUrl: "github.example.com",
});
```

Resolution order: resource `baseUrl` → `providers({ baseUrl })` → login profile / environment. `baseUrl` is tracked in state; changing it replaces the resource (`diff` compares normalized hosts, so cosmetic rewrites of the same host don't replace), and `delete`/`read` use the host recorded in state so cleanup targets the right instance.

### Deployment environments

New `GitHub.Environment` resource — declare the environment and its protection rules next to the secrets and variables that live in it:

```ts
const production = yield* GitHub.Environment("production", {
  owner: "my-org",
  repository: "my-repo",
  name: "production",
  waitTimer: 30,
  preventSelfReview: true,
  reviewers: { users: ["release-manager"], teams: ["platform"] },
  deploymentBranchPolicy: { customBranchPolicies: ["main", "release/*"] },
});

yield* GitHub.Secret("deploy-key", {
  owner: "my-org",
  repository: "my-repo",
  environment: production, // string | Environment
  name: "DEPLOY_KEY",
  value: Redacted.make("my-secret-value"),
});

yield* GitHub.Variable("region", {
  owner: "my-org",
  repository: "my-repo",
  environment: production,
  name: "AWS_REGION",
  value: "us-east-1",
});
```

- the `environment` prop on `Secret`/`Secrets` and (newly) `Variable`/`Variables` accepts a name string or the `Environment` resource itself
- reviewers are given as user logins / team slugs and resolved to the IDs the API expects
- `deploymentBranchPolicy` is `{ protectedBranches: true }` or `{ customBranchPolicies: [...patterns] }`; patterns are diffed against the live list on every deploy
- changing the environment `name` replaces the environment (GitHub has no rename); destroying the stack deletes it

Unit tests cover URL normalization, env-var precedence, per-resource host override, and replace-on-host-change; live lifecycle tests for `Environment` and environment-scoped variables are gated on `GITHUB_TEST_OWNER`. Docs updated in `github/setup.mdx` and `github/actions-config.mdx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012qvQL7X8ZtySxsxF5bMpwB