### PR TITLE
docs(cloudflare/tanstack-start): warn against @cloudflare/vite-plugin

### DIFF
--- a/website/src/content/docs/cloudflare/frontend/tanstack-start.mdx
+++ b/website/src/content/docs/cloudflare/frontend/tanstack-start.mdx
@@ -29,9 +29,9 @@ export default defineConfig({
 
 :::caution[Remove @cloudflare/vite-plugin if present]
 The TanStack CLI adds `@cloudflare/vite-plugin` to `vite.config.ts`
-automatically when scaffolding a new app. Alchemy appends its own fork
-of the Cloudflare Vite plugin and is **not compatible** with the
-upstream `@cloudflare/vite-plugin` — remove it:
+automatically when scaffolding a new app. Alchemy appends its own
+Cloudflare Vite plugin and is **not compatible** with
+`@cloudflare/vite-plugin` — remove it:
 
 ```diff lang="typescript"
 // vite.config.ts

--- a/website/src/content/docs/cloudflare/frontend/tanstack-start.mdx
+++ b/website/src/content/docs/cloudflare/frontend/tanstack-start.mdx
@@ -25,6 +25,38 @@ export default defineConfig({
 });
 ```
 
+## Remove `@cloudflare/vite-plugin`
+
+:::caution[Remove @cloudflare/vite-plugin if present]
+The TanStack CLI adds `@cloudflare/vite-plugin` to `vite.config.ts`
+automatically when scaffolding a new app. Alchemy appends its own fork
+of the Cloudflare Vite plugin and is **not compatible** with the
+upstream `@cloudflare/vite-plugin` — remove it:
+
+```diff lang="typescript"
+// vite.config.ts
+import { tanstackStart } from "@tanstack/react-start/plugin/vite";
+import viteReact from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+-import { cloudflare } from "@cloudflare/vite-plugin";
+
+export default defineConfig({
+-  plugins: [
+-    cloudflare({ viteEnvironment: { name: "ssr" } }),
+-    tanstackStart(),
+-    viteReact(),
+-  ],
++  plugins: [tanstackStart(), viteReact()],
+});
+```
+
+Also drop the dependency:
+
+```sh
+bun remove @cloudflare/vite-plugin
+```
+:::
+
 ## Declare the Website
 
 Use the class form of `Cloudflare.Website.Vite` so the app gets a named

--- a/website/src/content/docs/cloudflare/frontend/vite.mdx
+++ b/website/src/content/docs/cloudflare/frontend/vite.mdx
@@ -22,8 +22,8 @@ const site = yield* Cloudflare.Website.Vite("Website");
 ```
 
 Alchemy loads **your** project's Vite install (resolved from
-`rootDir`'s `package.json`), appends the Cloudflare Vite plugin —
-Alchemy's fork of `@cloudflare/vite-plugin` — to the plugins your
+`rootDir`'s `package.json`), appends Alchemy's own Cloudflare Vite
+plugin to the plugins your
 `vite.config.ts` already declares, and runs `builder.buildApp()`.
 Client assets are uploaded as Worker static assets; if the build
 emits a server bundle (SSR), that bundle becomes the Worker entry —
@@ -59,9 +59,9 @@ directory of files.
 ## Remove `@cloudflare/vite-plugin`
 
 :::caution[Remove @cloudflare/vite-plugin if present]
-Alchemy appends its own fork of the Cloudflare Vite plugin
+Alchemy appends its own Cloudflare Vite plugin
 (`@distilled.cloud/cloudflare-vite-plugin`) and is **not
-compatible** with the upstream `@cloudflare/vite-plugin` in your
+compatible** with `@cloudflare/vite-plugin` in your
 `vite.config.ts`. Remove it — this applies to every framework
 deployed with this resource:
 


### PR DESCRIPTION
Users scaffolding a new TanStack Start app don't know they must remove `@cloudflare/vite-plugin` — the TanStack CLI adds it automatically, and Alchemy's own Cloudflare Vite plugin is not compatible with it.

Adds a "Remove `@cloudflare/vite-plugin`" caution to the TanStack Start docs, matching the existing callouts on the Vite and Vite SPA pages:

```diff lang="typescript"
// vite.config.ts
-import { cloudflare } from "@cloudflare/vite-plugin";

 export default defineConfig({
-  plugins: [
-    cloudflare({ viteEnvironment: { name: "ssr" } }),
-    tanstackStart(),
-    viteReact(),
-  ],
+  plugins: [tanstackStart(), viteReact()],
 });
```
