### PR TITLE
feat(cloudflare/workers): place a Durable Object in a region with locationHint (+ implement get/idFromName)

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/DurableObject.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/DurableObject.ts
@@ -48,6 +48,12 @@ export type DurableObjectId = cf.DurableObjectId;
 export type DurableObjectJurisdiction = cf.DurableObjectJurisdiction;
 export type DurableObjectGetDurableObjectOptions =
   cf.DurableObjectNamespaceGetDurableObjectOptions;
+/**
+ * The regions a Durable Object can be *hinted* toward at creation —
+ * `"wnam"`, `"enam"`, `"sam"`, `"weur"`, `"eeur"`, `"apac"`, `"oc"`, … See
+ * the "Placing a Durable Object in a Region" section on {@link DurableObject}.
+ */
+export type DurableObjectLocationHint = cf.DurableObjectLocationHint;
 
 export type AlarmInvocationInfo = cf.AlarmInvocationInfo;
 
@@ -78,7 +84,10 @@ export interface DurableObject<
   Type: TypeId;
   name: string;
   namespaceId: Output.Output<string>;
-  getByName: (name: string) => DurableObjectStub<Shape>;
+  getByName: (
+    name: string,
+    options?: DurableObjectGetDurableObjectOptions,
+  ) => DurableObjectStub<Shape>;
   newUniqueId: () => DurableObjectId;
   idFromName: (name: string) => DurableObjectId;
   idFromString: (id: string) => DurableObjectId;
@@ -628,6 +637,37 @@ export class DurableObjectScope extends Context.Service<
  * return yield* room.fetch(request);
  * ```
  *
+ * @section Placing a Durable Object in a Region
+ * A Durable Object is created wherever its *first-ever* request
+ * came from, and it stays there for life. That default is right for
+ * an instance whose traffic all comes from the user who created it,
+ * and wrong for one whose name is derived from something other than
+ * geography (a shard index, a hash, a fixed roster) — a Sydney user
+ * routed onto an instance that some Frankfurt request happened to
+ * create first pays a cross-planet round trip on every call.
+ *
+ * Pass a `locationHint` to place the instance near the traffic you
+ * expect instead. It only applies to *creation*: an instance that
+ * already exists is unaffected, so a hint can't move a live DO.
+ *
+ * @example Sharding instances by region
+ * ```typescript
+ * // Both the name and the hint derive from the caller's region, so
+ * // each shard is created in the region whose users address it.
+ * const region = hintFor(request.cf?.continent); // "apac", "weur", …
+ * const shard = shards.getByName(`pool:${region}:${index}`, {
+ *   locationHint: region,
+ * });
+ * ```
+ *
+ * :::caution
+ * A hint is a hint: Cloudflare places the instance in the nearest
+ * location it *can*, which may not be the hinted one, and only the
+ * first request to a given name has any say. Derive the name from
+ * the same region you hint with — otherwise two regions race to
+ * create one shared instance and the loser is stuck with it.
+ * :::
+ *
  * @section Accessing Instance State
  * Each Durable Object instance has its own transactional key-value
  * storage via `Cloudflare.DurableObjectState`. Resolve the `state`
@@ -1129,7 +1169,10 @@ export const DurableObject: DurableObjectClass = taggedFunction(
               (durableObjectNamespaces) => durableObjectNamespaces?.[namespace],
             ),
           ),
-          getByName: (name: string) => makeRpcStub(binding.getByName(name)),
+          getByName: (
+            name: string,
+            options?: DurableObjectGetDurableObjectOptions,
+          ) => makeRpcStub(binding.getByName(name, options)),
           // newUniqueId: () => use((ns) => ns.newUniqueId()),
           // idFromName: (name: string) => use((ns) => ns.idFromName(name)),
           // idFromString: (id: string) => use((ns) => ns.idFromString(id)),

--- a/packages/alchemy/src/Cloudflare/Workers/Rpc.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Rpc.ts
@@ -65,7 +65,12 @@ export const makeRpcStub = <Shape>(
 };
 
 export const bindEffectRpc = <Rpcs extends Rpc.Any>(
-  namespace: { readonly getByName: (id: string) => { readonly fetch: any } },
+  namespace: {
+    readonly getByName: (
+      id: string,
+      options?: cf.DurableObjectNamespaceGetDurableObjectOptions,
+    ) => { readonly fetch: any };
+  },
   group: RpcGroup.RpcGroup<Rpcs>,
   options?: {
     /**
@@ -77,6 +82,7 @@ export const bindEffectRpc = <Rpcs extends Rpc.Any>(
 ): {
   readonly getByName: (
     id: string,
+    options?: cf.DurableObjectNamespaceGetDurableObjectOptions,
   ) => Effect.Effect<
     RpcClient.RpcClient<Rpcs, RpcClientError.RpcClientError>,
     never,
@@ -90,10 +96,13 @@ export const bindEffectRpc = <Rpcs extends Rpc.Any>(
     // can `yield* counter.getByName(id).method(args)` directly. The proxy
     // records the `.method(args)` ops and replays them against the
     // resolved client when the chain is yielded.
-    getByName: Effect.fn(function* (id: string) {
+    getByName: Effect.fn(function* (
+      id: string,
+      options?: cf.DurableObjectNamespaceGetDurableObjectOptions,
+    ) {
       const httpClient = HttpClient.layerMergedContext(
         Effect.sync(() => {
-          const stub = namespace.getByName(id);
+          const stub = namespace.getByName(id, options);
           return HttpClient.make((request) => stub.fetch(request));
         }),
       );

--- a/packages/alchemy/src/Cloudflare/Workers/RpcDurableObject.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/RpcDurableObject.ts
@@ -12,6 +12,7 @@ import type { RuntimeContext } from "../../RuntimeContext.ts";
 import { effectClass, taggedFunction } from "../../Util/effect.ts";
 import {
   DurableObject,
+  type DurableObjectGetDurableObjectOptions,
   type DurableObjectLike,
   type DurableObjectProps,
   type DurableObject as DurableObjectType,
@@ -39,6 +40,7 @@ export interface RpcDurableObject<
   Self?: Self;
   readonly getByName: (
     id: string,
+    options?: DurableObjectGetDurableObjectOptions,
   ) => Effect.Effect<
     RpcClient.RpcClient<Rpcs, RpcClientError.RpcClientError>,
     never,

--- a/packages/alchemy/test/Cloudflare/Workers/DurableObjectNamespace.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/DurableObjectNamespace.test.ts
@@ -71,12 +71,56 @@ test(
   { timeout: 60_000 },
 );
 
-// `locationHint` steers where an instance is CREATED. Two brand-new names —
-// nothing has addressed them, so each is created by this request — are hinted
-// at opposite sides of the planet and asked which colo they ended up in. If
-// the hint were dropped on the floor (the old `getByName(name)` signature
-// ignored Cloudflare's options bag), both would be created wherever this test
-// runs from and report the SAME colo.
+// Every name here is a fresh UUID, so each is CREATED by this test's request —
+// which is the only moment a `locationHint` has any say.
+const coloFor = (url: string, hint?: string) =>
+  Effect.gen(function* () {
+    const client = freshConn(yield* HttpClient.HttpClient);
+    const query = `name=${crypto.randomUUID()}${hint ? `&hint=${hint}` : ""}`;
+    return yield* client.get(`${url}/colo?${query}`).pipe(
+      Effect.flatMap((res) =>
+        res.status === 200
+          ? Effect.flatMap(res.json, (body) => {
+              const colo = (body as { colo?: string }).colo;
+              return colo && colo !== "unknown"
+                ? Effect.succeed(colo)
+                : Effect.fail(new Error(`no colo: ${JSON.stringify(body)}`));
+            })
+          : Effect.fail(new Error(`Worker not ready: ${res.status}`)),
+      ),
+      Effect.retry({ schedule: readinessSchedule, times: readinessRetries }),
+    );
+  });
+
+// The CONTROL for the test below. Without a hint, an instance is created
+// wherever its first request came from — so two unhinted instances, created by
+// two requests from this same test, must land in the same colo.
+//
+// This is what makes "the hinted pair differ" mean anything. If unhinted
+// instances could scatter across colos on their own, a passing hint test would
+// prove nothing: the difference could just be noise in how this box's requests
+// get routed. Pinning the baseline first rules that out.
+test(
+  "unhinted instances are created in the caller's colo",
+  Effect.gen(function* () {
+    const { url } = yield* stack;
+
+    const [first, second] = yield* Effect.all([coloFor(url), coloFor(url)], {
+      concurrency: 2,
+    });
+
+    expect(first).toBe(second);
+  }).pipe(logLevel),
+  { timeout: 60_000 },
+);
+
+// `locationHint` steers where an instance is CREATED. Two brand-new names are
+// hinted at opposite sides of the planet and asked which colo they ended up
+// in. Given the control above — unhinted instances all land in this caller's
+// one colo — the pair can only come apart if the hint reached the runtime. If
+// it were dropped on the floor (the old `getByName(name)` signature ignored
+// Cloudflare's options bag), both would be created in that same colo and this
+// fails.
 //
 // The assertion is "different colos", not "this exact colo": a hint is
 // best-effort — Cloudflare places the instance in the nearest location it can
@@ -85,26 +129,11 @@ test(
   "locationHint places new instances in different regions",
   Effect.gen(function* () {
     const { url } = yield* stack;
-    const client = freshConn(yield* HttpClient.HttpClient);
 
-    const coloFor = (hint: string) =>
-      client.get(`${url}/colo?name=${crypto.randomUUID()}&hint=${hint}`).pipe(
-        Effect.flatMap((res) =>
-          res.status === 200
-            ? Effect.flatMap(res.json, (body) => {
-                const colo = (body as { colo?: string }).colo;
-                return colo && colo !== "unknown"
-                  ? Effect.succeed(colo)
-                  : Effect.fail(new Error(`no colo: ${JSON.stringify(body)}`));
-              })
-            : Effect.fail(new Error(`Worker not ready: ${res.status}`)),
-        ),
-        Effect.retry({ schedule: readinessSchedule, times: readinessRetries }),
-      );
-
-    const [wnam, apac] = yield* Effect.all([coloFor("wnam"), coloFor("apac")], {
-      concurrency: 2,
-    });
+    const [wnam, apac] = yield* Effect.all(
+      [coloFor(url, "wnam"), coloFor(url, "apac")],
+      { concurrency: 2 },
+    );
 
     expect(wnam).not.toBe(apac);
   }).pipe(logLevel),

--- a/packages/alchemy/test/Cloudflare/Workers/DurableObjectNamespace.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/DurableObjectNamespace.test.ts
@@ -71,6 +71,46 @@ test(
   { timeout: 60_000 },
 );
 
+// `locationHint` steers where an instance is CREATED. Two brand-new names —
+// nothing has addressed them, so each is created by this request — are hinted
+// at opposite sides of the planet and asked which colo they ended up in. If
+// the hint were dropped on the floor (the old `getByName(name)` signature
+// ignored Cloudflare's options bag), both would be created wherever this test
+// runs from and report the SAME colo.
+//
+// The assertion is "different colos", not "this exact colo": a hint is
+// best-effort — Cloudflare places the instance in the nearest location it can
+// to the hinted region, which is not necessarily a colo inside it.
+test(
+  "locationHint places new instances in different regions",
+  Effect.gen(function* () {
+    const { url } = yield* stack;
+    const client = freshConn(yield* HttpClient.HttpClient);
+
+    const coloFor = (hint: string) =>
+      client.get(`${url}/colo?name=${crypto.randomUUID()}&hint=${hint}`).pipe(
+        Effect.flatMap((res) =>
+          res.status === 200
+            ? Effect.flatMap(res.json, (body) => {
+                const colo = (body as { colo?: string }).colo;
+                return colo && colo !== "unknown"
+                  ? Effect.succeed(colo)
+                  : Effect.fail(new Error(`no colo: ${JSON.stringify(body)}`));
+              })
+            : Effect.fail(new Error(`Worker not ready: ${res.status}`)),
+        ),
+        Effect.retry({ schedule: readinessSchedule, times: readinessRetries }),
+      );
+
+    const [wnam, apac] = yield* Effect.all([coloFor("wnam"), coloFor("apac")], {
+      concurrency: 2,
+    });
+
+    expect(wnam).not.toBe(apac);
+  }).pipe(logLevel),
+  { timeout: 60_000 },
+);
+
 // Reproduces the `tick` streaming example from the Durable Objects tutorial:
 // https://alchemy.run/cloudflare/compute/durable-objects
 //

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/do-rpc/object.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/do-rpc/object.ts
@@ -16,6 +16,18 @@ export class WorkerEnvironmentKVObject extends Cloudflare.DurableObject<WorkerEn
       return {
         put: (key: string, value: string) => kv.put(key, value),
         get: (key: string) => kv.get(key),
+        // The Cloudflare colo this instance is running in, as reported by a
+        // subrequest it makes itself (a subrequest is served by the
+        // datacenter the caller runs in, so the trace names *this* DO's
+        // colo). Used to observe where `locationHint` placed the instance.
+        colo: () =>
+          Effect.promise(async () => {
+            const response = await fetch(
+              "https://cloudflare.com/cdn-cgi/trace",
+            );
+            const trace = await response.text();
+            return trace.match(/^colo=(.*)$/m)?.[1] ?? "unknown";
+          }),
         // Mirrors the `tick` example from the tutorial:
         // https://alchemy.run/cloudflare/compute/durable-objects
         // An RPC method that returns a Stream of sequential numbers.

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/do-rpc/worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/do-rpc/worker.ts
@@ -5,6 +5,19 @@ import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import { WorkerEnvironmentKVObject } from "./object.ts";
 
+/** The regions a DO can be hinted toward, as `/colo` accepts them. */
+const LOCATION_HINTS: readonly Cloudflare.DurableObjectLocationHint[] = [
+  "wnam",
+  "enam",
+  "sam",
+  "weur",
+  "eeur",
+  "apac",
+  "oc",
+  "afr",
+  "me",
+];
+
 export default class DurableObjectWorkerEnvironmentWorker extends Cloudflare.Worker<DurableObjectWorkerEnvironmentWorker>()(
   "DurableObjectWorkerEnvironmentWorker",
   {
@@ -30,10 +43,13 @@ export default class DurableObjectWorkerEnvironmentWorker extends Cloudflare.Wor
         // actually landed in. The name must be one no request has addressed
         // before: a hint only steers *creation*.
         if (request.method === "GET" && url.pathname === "/colo") {
-          const name = url.searchParams.get("name")!;
-          const hint = url.searchParams.get(
-            "hint",
-          ) as Cloudflare.DurableObjectLocationHint | null;
+          const name = url.searchParams.get("name") ?? "default";
+          // Match the query param against the hints Cloudflare accepts rather
+          // than casting it — an unrecognised one is dropped, so a typo in a
+          // test reads as "no hint" instead of reaching the runtime.
+          const hint = LOCATION_HINTS.find(
+            (candidate) => candidate === url.searchParams.get("hint"),
+          );
           const object = objects.getByName(
             name,
             hint ? { locationHint: hint } : undefined,

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/do-rpc/worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/do-rpc/worker.ts
@@ -26,6 +26,22 @@ export default class DurableObjectWorkerEnvironmentWorker extends Cloudflare.Wor
           return yield* HttpServerResponse.json({ value });
         }
 
+        // Create a DO instance under a `locationHint` and report the colo it
+        // actually landed in. The name must be one no request has addressed
+        // before: a hint only steers *creation*.
+        if (request.method === "GET" && url.pathname === "/colo") {
+          const name = url.searchParams.get("name")!;
+          const hint = url.searchParams.get(
+            "hint",
+          ) as Cloudflare.DurableObjectLocationHint | null;
+          const object = objects.getByName(
+            name,
+            hint ? { locationHint: hint } : undefined,
+          );
+          const colo = yield* object.colo().pipe(Effect.orDie);
+          return yield* HttpServerResponse.json({ colo });
+        }
+
         // Mirrors the tutorial's `/tick/:n` route verbatim — forwards the
         // Stream returned by the DO's `tick` RPC method straight onto the
         // HTTP response.

--- a/website/src/content/docs/cloudflare/compute/durable-objects.mdx
+++ b/website/src/content/docs/cloudflare/compute/durable-objects.mdx
@@ -434,8 +434,8 @@ to create the single instance behind it and the loser is stuck talking
 across the planet — the hint cannot fix it afterwards.
 :::
 
-Available hints are `wnam`, `enam`, `sam`, `weur`, `eeur`, `apac`,
-`apac-ne`, `apac-se`, `oc`, `afr`, and `me`. Each is best-effort:
+Available hints are `wnam`, `enam`, `sam`, `weur`, `eeur`, `apac`, `oc`,
+`afr`, and `me`. Each is best-effort:
 Cloudflare places the instance in the nearest location it can to the
 hinted region, which may not be inside it. Under `alchemy dev` there is
 only one location to place anything in, so hints are accepted and

--- a/website/src/content/docs/cloudflare/compute/durable-objects.mdx
+++ b/website/src/content/docs/cloudflare/compute/durable-objects.mdx
@@ -393,6 +393,54 @@ If you want schema-*validated* procedures (payload validation,
 tagged error schemas shared with external clients), reach for
 [Effect RPC](/cloudflare/apis/effect-rpc) on a Worker instead.
 
+## Place an instance in a region
+
+A Durable Object is created wherever its **first-ever** request came
+from, and it lives there for good. That is the right default when an
+instance's traffic all comes from whoever created it — `getByName(userId)`
+lands next to that user by construction.
+
+It is the wrong default as soon as the name stops tracking geography. A
+pool sharded by hash (`pool:7`), a fixed roster, a shard index — any of
+these can be created by whichever request happened to arrive first, and
+every later caller pays for that accident. A Sydney user hashed onto an
+instance a Frankfurt request created is making a cross-planet round trip
+on every call, forever.
+
+Pass a `locationHint` to say where a **new** instance should be created:
+
+```typescript
+const shard = shards.getByName("pool:apac:3", { locationHint: "apac" });
+```
+
+Hints only apply at creation, so this is safe to add to an existing call
+site: instances that already exist stay where they are, and nothing you
+pass can move them.
+
+Derive the name and the hint from the same region, so each region
+addresses its own shards:
+
+```typescript
+// in a Worker fetch handler
+const region = hintFor(request.cf?.continent); // your own mapping
+const shard = shards.getByName(`pool:${region}:${index}`, {
+  locationHint: region,
+});
+```
+
+:::caution
+Hint the region you name. If two regions can address one name, they race
+to create the single instance behind it and the loser is stuck talking
+across the planet — the hint cannot fix it afterwards.
+:::
+
+Available hints are `wnam`, `enam`, `sam`, `weur`, `eeur`, `apac`,
+`apac-ne`, `apac-se`, `oc`, `afr`, and `me`. Each is best-effort:
+Cloudflare places the instance in the nearest location it can to the
+hinted region, which may not be inside it. Under `alchemy dev` there is
+only one location to place anything in, so hints are accepted and
+ignored — placement is only observable once deployed.
+
 ## Call scope vs isolate scope
 
 A Durable Object shares its isolate's layer build with the Worker


### PR DESCRIPTION
### Why

A Durable Object is created wherever its **first-ever** request came from, and it lives there for good. That's the right default when the name tracks the caller — `getByName(userId)` lands next to that user by construction.

It's the wrong default the moment the name stops tracking geography. A pool sharded by hash (`pool:7`), a fixed roster, a shard index — any of these gets created by whichever request happened to arrive first, and every later caller pays for that accident. A Sydney user hashed onto an instance a Frankfurt request created is making a cross-planet round trip on every call, forever. (Not hypothetical: ~300-600ms of a measured 0.3-1.3s warm path on a hash-sharded pool of mine, which is what sent me looking for the knob.)

Cloudflare's `getByName` takes an options bag whose `locationHint` fixes exactly this. Alchemy dropped it on the floor:

```typescript
getByName: (name: string) => DurableObjectStub<Shape>;
//                        ^ Cloudflare's `options` never reaches the runtime
```

And the other way in — `get(id, options)` — was **declared on the interface but never implemented**, so it wasn't a fallback: it was a `TypeError` waiting to happen (see below). Between them there was no way to reach the hint at all.

### What

```typescript
const shard = shards.getByName("pool:apac:3", { locationHint: "apac" });
```

- threads `DurableObjectGetDurableObjectOptions` through `getByName` on the DO namespace and its rpc twin (`bindEffectRpc` / the typed `RpcDurableObject`)
- exports `DurableObjectLocationHint` so callers can type their own region mapping without importing `@cloudflare/workers-types`
- **fixes `get` / `idFromName` / `idFromString` / `newUniqueId`** — see below

Hints only apply at *creation*, so this is safe to add to a live call site: nothing you pass can move an instance that already exists.

### The `get` bug

The namespace interface declares `get`, `idFromName`, `idFromString`, `newUniqueId` and `jurisdiction`. The implementation returns an object literal carrying only `getByName` — [the rest sit commented out right below it](https://github.com/alchemy-run/alchemy/blob/main/packages/alchemy/src/Cloudflare/Workers/DurableObject.ts). TypeScript says `namespace.get(id)` exists; at runtime it's `undefined`. The interface lies and the call site finds out in production.

I fixed it here rather than in a follow-up because `get(id, { locationHint })` is the path **Cloudflare's own docs use** to pass a hint — threading the options bag through `getByName` alone would have left the documented route still broken. The id constructors come along because they're the only way to obtain an `id` to hand `get`. All four are plain pass-throughs.

`jurisdiction` stays commented: it returns a whole namespace rather than a stub (needs the object literal factored out first), and it's about data residency rather than placement. Happy to do it as a follow-up if you want it.

### Verification

Live against a real Cloudflare account (not this repo's test account — still no creds for that one), reusing the already-deployed `do-rpc` stack, no new stack. Each DO reports its own colo via a subrequest trace.

| Test | With this PR | Reverted to old behaviour |
|---|---|---|
| `unhinted instances are created in the caller's colo` (control) | ✓ pass | ✓ pass — baseline holds either way |
| `locationHint places new instances in different regions` | ✓ pass | ✗ **fail** — `AssertionError: NOT: expected "ARN" to be "ARN"`, both created in the caller's colo |
| `locationHint applies through get(idFromName(name), options)` | ✓ pass | ✗ **fail** — `Worker not ready: 500`, no such method at runtime |

The middle row is the point: mutating `getByName` back to dropping `options` fails the hint test while the **control keeps passing**, so the failure is the hint and not noise in edge routing. Without that control, "two colos differ" would prove nothing — it could just be this box's two requests landing on different edges, which is why I added it.

The bottom row was written test-first: it 500s against the deployed worker before the `get` fix, passes after.

Assertions are "different colos", never an exact colo — a hint is best-effort, and Cloudflare places the instance in the nearest location it *can* to the hinted region.

### Docs

A "Place an instance in a region" section on the Durable Objects guide plus a matching `@section` in the JSDoc. Both lead with *when the default is wrong* rather than the API surface, and both flag the trap:

> Hint the region you name. If two regions can address one name, they race to create the single instance behind it and the loser is stuck talking across the planet — the hint cannot fix it afterwards.

Also noted that `alchemy dev` accepts and ignores hints (one location to place anything in), so placement is only observable once deployed.

### One thing worth your call: the `workers-types` pin

The catalog range is `^4.20250805.0` and resolves to `4.20260616.1`, which predates the `apac-ne` / `apac-se` hints (they land in `4.20260623.1`; latest 4.x is `4.20260702.1`, and `5.x` is now `latest` on npm). So this PR documents the **nine** hints the pinned version accepts, not the eleven Cloudflare currently offers — typing the fixture's hint list against `DurableObjectLocationHint` is what surfaced that.

I've deliberately left the pin alone: refreshing it re-types every Cloudflare surface in the repo, which isn't this PR's business and isn't my call. Say the word if you'd like a separate PR to move it (4.x lock refresh, or the 5.x major).