### PR TITLE
fix(cloudflare/workers): the DO namespace interface was lying — implement get/idFromName/idFromString/newUniqueId, and make it uncheckable no longer

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/DurableObject.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/DurableObject.ts
@@ -82,6 +82,13 @@ export interface DurableObject<
   Shape = unknown,
 > extends DurableObjectLike<Shape> {
   Type: TypeId;
+  /**
+   * The resource's logical id, as every alchemy resource carries (see
+   * {@link Self}). Declared because the namespace really does carry one —
+   * leaving it off the interface is what made the whole value un-annotatable,
+   * and an un-annotatable literal is one nothing checks.
+   */
+  LogicalId: string;
   name: string;
   namespaceId: Output.Output<string>;
   getByName: (
@@ -1160,33 +1167,58 @@ export const DurableObject: DurableObjectClass = taggedFunction(
           }),
         );
 
-        return {
+        const namespaceId = worker.durableObjectNamespaces.pipe(
+          Output.map(
+            (durableObjectNamespaces) => durableObjectNamespaces?.[namespace],
+          ),
+        );
+
+        // Wrap a raw Cloudflare namespace as the alchemy-side one. A function
+        // rather than a literal because `jurisdiction` hands back another one
+        // of these, over the sub-namespace it returns.
+        //
+        // The `: DurableObject<any>` annotation is load-bearing: it is the only
+        // thing that checks this object against the interface it claims to be.
+        // Without it the literal's type was merely inferred and then cast, so
+        // `get` / `idFromName` / `idFromString` / `newUniqueId` could sit here
+        // commented out while TypeScript told every caller they existed — a
+        // `TypeError` in production and nothing at build time. Add a method to
+        // `DurableObject` and forget it here, and this now fails to compile.
+        const makeNamespace = (
+          ns: cf.DurableObjectNamespace,
+        ): DurableObject<any> => ({
+          // Really is a `DurableObjectLike`, which the interface has always
+          // claimed — carrying `kind` (plus the `scriptName`/`transferredFrom`
+          // this binding was built with) is what makes the claim true, so a
+          // live namespace handed to a Worker's `env` binds to the class it
+          // actually points at.
+          kind: TypeId,
+          scriptName,
+          transferredFrom,
           Type: TypeId,
           LogicalId: namespace,
           name: namespace,
-          namespaceId: worker.durableObjectNamespaces.pipe(
-            Output.map(
-              (durableObjectNamespaces) => durableObjectNamespaces?.[namespace],
-            ),
-          ),
+          namespaceId,
           getByName: (
             name: string,
             options?: DurableObjectGetDurableObjectOptions,
-          ) => makeRpcStub(binding.getByName(name, options)),
+          ) => makeRpcStub(ns.getByName(name, options)),
           // `get(id, options)` is the other way onto an instance — and the one
           // Cloudflare's docs reach for to pass a `locationHint`. It, and the
           // three id constructors that are the only way to obtain an `id` to
           // hand it, are plain pass-throughs to the underlying namespace.
-          newUniqueId: () => binding.newUniqueId(),
-          idFromName: (name: string) => binding.idFromName(name),
-          idFromString: (id: string) => binding.idFromString(id),
+          newUniqueId: () => ns.newUniqueId(),
+          idFromName: (name: string) => ns.idFromName(name),
+          idFromString: (id: string) => ns.idFromString(id),
           get: (
             id: DurableObjectId,
             options?: DurableObjectGetDurableObjectOptions,
-          ) => makeRpcStub(binding.get(id, options)),
-          // jurisdiction: (jurisdiction: cf.DurableObjectJurisdiction) =>
-          //   use((ns) => ns.jurisdiction(jurisdiction) as any),
-        };
+          ) => makeRpcStub(ns.get(id, options)),
+          jurisdiction: (jurisdiction: DurableObjectJurisdiction) =>
+            makeNamespace(ns.jurisdiction(jurisdiction)),
+        });
+
+        return makeNamespace(binding);
       });
 
     // Class-form declarations (`DurableObject<Self>()("Name", props?)`) can

--- a/packages/alchemy/src/Cloudflare/Workers/DurableObject.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/DurableObject.ts
@@ -1173,13 +1173,17 @@ export const DurableObject: DurableObjectClass = taggedFunction(
             name: string,
             options?: DurableObjectGetDurableObjectOptions,
           ) => makeRpcStub(binding.getByName(name, options)),
-          // newUniqueId: () => use((ns) => ns.newUniqueId()),
-          // idFromName: (name: string) => use((ns) => ns.idFromName(name)),
-          // idFromString: (id: string) => use((ns) => ns.idFromString(id)),
-          // get: (
-          //   id: cf.DurableObjectId,
-          //   options?: cf.DurableObjectNamespaceGetDurableObjectOptions,
-          // ) => use((ns) => makeRpcStub(ns.get(id, options))),
+          // `get(id, options)` is the other way onto an instance — and the one
+          // Cloudflare's docs reach for to pass a `locationHint`. It, and the
+          // three id constructors that are the only way to obtain an `id` to
+          // hand it, are plain pass-throughs to the underlying namespace.
+          newUniqueId: () => binding.newUniqueId(),
+          idFromName: (name: string) => binding.idFromName(name),
+          idFromString: (id: string) => binding.idFromString(id),
+          get: (
+            id: DurableObjectId,
+            options?: DurableObjectGetDurableObjectOptions,
+          ) => makeRpcStub(binding.get(id, options)),
           // jurisdiction: (jurisdiction: cf.DurableObjectJurisdiction) =>
           //   use((ns) => ns.jurisdiction(jurisdiction) as any),
         };

--- a/packages/alchemy/test/Cloudflare/Workers/DurableObjectAddressing.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/DurableObjectAddressing.test.ts
@@ -1,0 +1,133 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as Test from "@/Test/Alchemy";
+import { describe, expect } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+import * as Schedule from "effect/Schedule";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import AddressingStack from "./fixtures/do-addressing/stack.ts";
+
+// Runs on the LOCAL runtime: this is a regression guard, so it has to be cheap
+// enough to run on every change — ~12s here versus minutes for a deploy. The
+// bug it covers is not deployment-specific (the namespace simply never wired
+// the methods up), so `alchemy dev` reproduces it exactly. Note this still
+// reaches Cloudflare for the state store, so it wants an account like the rest
+// of the suite; the workers themselves stay local.
+const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
+  providers: Cloudflare.providers(),
+  state: Cloudflare.state(),
+  dev: true,
+});
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+const HOOK_TIMEOUT = 120_000;
+const TEST_TIMEOUT = 60_000;
+
+const readinessSchedule = Schedule.min([
+  Schedule.exponential("500 millis"),
+  Schedule.spaced("3 seconds"),
+]);
+
+// GET a route and return its parsed JSON, retrying until the local runtime is
+// serving. A non-200 carries the worker's error text, so a genuine failure
+// surfaces as that message rather than a JSON parse error.
+const json = <T>(url: string) =>
+  Effect.gen(function* () {
+    const client = yield* HttpClient.HttpClient;
+    return yield* client.get(url).pipe(
+      Effect.flatMap((res) =>
+        res.status === 200
+          ? (res.json as Effect.Effect<unknown, unknown>)
+          : Effect.flatMap(res.text, (body) =>
+              Effect.fail(new Error(`${res.status}: ${body}`)),
+            ),
+      ),
+      Effect.map((body) => body as T),
+      Effect.timeout("15 seconds"),
+      Effect.retry({ schedule: readinessSchedule, times: 20 }),
+    );
+  });
+
+/**
+ * Regression: the namespace declared `get`, `idFromName`, `idFromString` and
+ * `newUniqueId` on its interface and implemented none of them — the object
+ * literal wired up `getByName` and left the rest commented out directly below
+ * it. TypeScript reported them as present while they were `undefined` at
+ * runtime, so the interface lied and every call site found out in production.
+ *
+ * These assert the whole addressing surface reaches a real instance, and the
+ * *right* one: each route bumps the target's own counter, which is the only
+ * evidence that distinguishes "answered" from "answered from the instance you
+ * asked for".
+ */
+describe("durable object addressing", () => {
+  const stack = beforeAll(deploy(AddressingStack), { timeout: HOOK_TIMEOUT });
+  afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(AddressingStack), {
+    timeout: HOOK_TIMEOUT,
+  });
+
+  test(
+    "get(idFromName(name)) reaches the same instance as getByName(name)",
+    Effect.gen(function* () {
+      const { url } = yield* stack;
+      const name = `same-${crypto.randomUUID()}`;
+
+      // A fresh name, so the first bump through either route must see 1.
+      const first = yield* json<{ count: number }>(
+        `${url}/by-name?name=${name}`,
+      );
+      expect(first.count).toBe(1);
+
+      // The counter carries over only if this landed on that same instance —
+      // an independent instance would answer 1 again.
+      const second = yield* json<{ count: number }>(
+        `${url}/by-id?name=${name}`,
+      );
+      expect(second.count).toBe(2);
+    }).pipe(logLevel),
+    { timeout: TEST_TIMEOUT },
+  );
+
+  test(
+    "idFromString round-trips an id back to the same instance",
+    Effect.gen(function* () {
+      const { url } = yield* stack;
+      const name = `roundtrip-${crypto.randomUUID()}`;
+
+      const first = yield* json<{ count: number }>(
+        `${url}/by-name?name=${name}`,
+      );
+      expect(first.count).toBe(1);
+
+      // The id went out to its string form and back; it has to name the same
+      // instance on the way home.
+      const second = yield* json<{ count: number }>(
+        `${url}/by-id-string?name=${name}`,
+      );
+      expect(second.count).toBe(2);
+    }).pipe(logLevel),
+    { timeout: TEST_TIMEOUT },
+  );
+
+  test(
+    "newUniqueId yields a fresh instance every time",
+    Effect.gen(function* () {
+      const { url } = yield* stack;
+
+      // Two unique ids, two brand-new instances — so neither has a counter yet
+      // and both report 1. A shared or repeated id would show 1 then 2.
+      const { first, second } = yield* json<{
+        first: number;
+        second: number;
+      }>(`${url}/by-unique`);
+
+      expect(first).toBe(1);
+      expect(second).toBe(1);
+    }).pipe(logLevel),
+    { timeout: TEST_TIMEOUT },
+  );
+});

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/do-addressing/object.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/do-addressing/object.ts
@@ -1,0 +1,31 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as Effect from "effect/Effect";
+
+/**
+ * A Durable Object with per-instance state, used to prove *which* instance a
+ * given addressing route reached.
+ *
+ * `bump` returns the instance's own count, so two routes that reach the same
+ * instance see one shared, monotonic counter, and two routes that reach
+ * different instances each see their own. That is the only way to tell
+ * `get(idFromName("x"))` and `getByName("x")` apart from the outside — both
+ * answer, but only one identity is correct.
+ */
+export class AddressingObject extends Cloudflare.DurableObject<AddressingObject>()(
+  "AddressingObject",
+  Effect.gen(function* () {
+    const state = yield* Cloudflare.DurableObjectState;
+
+    return Effect.gen(function* () {
+      return {
+        bump: () =>
+          Effect.gen(function* () {
+            const count =
+              ((yield* state.storage.get<number>("count")) ?? 0) + 1;
+            yield* state.storage.put("count", count);
+            return count;
+          }),
+      };
+    });
+  }),
+) {}

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/do-addressing/stack.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/do-addressing/stack.ts
@@ -1,0 +1,18 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as Alchemy from "@/index.ts";
+import * as Effect from "effect/Effect";
+import Worker from "./worker.ts";
+
+export default Alchemy.Stack(
+  "DurableObjectAddressingStack",
+  {
+    providers: Cloudflare.providers(),
+    state: Cloudflare.state(),
+  },
+  Effect.gen(function* () {
+    const worker = yield* Worker;
+    return {
+      url: worker.url.as<string>(),
+    };
+  }),
+);

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/do-addressing/worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/do-addressing/worker.ts
@@ -1,0 +1,74 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as Effect from "effect/Effect";
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import { AddressingObject } from "./object.ts";
+
+/**
+ * Exercises every way the namespace lets you address an instance. Each route
+ * bumps the target instance's own counter and returns it, so a test can tell
+ * which instance it actually reached:
+ *  - `GET /by-name`     → `getByName(name)`
+ *  - `GET /by-id`       → `get(idFromName(name))`
+ *  - `GET /by-id-string`→ `get(idFromString(idFromName(name).toString()))`
+ *  - `GET /by-unique`   → `get(newUniqueId())`, twice, to prove ids are unique
+ *
+ * All but the first were declared on the namespace but never implemented, so
+ * these routes 500 with "not a function" against a namespace that only wires
+ * up `getByName`.
+ */
+export default Cloudflare.Worker(
+  "AddressingWorker",
+  {
+    main: import.meta.filename,
+  },
+  Effect.gen(function* () {
+    const objects = yield* AddressingObject;
+
+    return {
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        const url = new URL(request.url, "http://x");
+        const name = url.searchParams.get("name") ?? "default";
+
+        if (url.pathname === "/by-name") {
+          const count = yield* objects.getByName(name).bump();
+          return yield* HttpServerResponse.json({ count });
+        }
+
+        if (url.pathname === "/by-id") {
+          const count = yield* objects.get(objects.idFromName(name)).bump();
+          return yield* HttpServerResponse.json({ count });
+        }
+
+        // Round-trips the id through its string form — the shape a caller uses
+        // when an id arrives from outside the isolate (a URL, a queue message).
+        if (url.pathname === "/by-id-string") {
+          const id = objects.idFromName(name);
+          const count = yield* objects
+            .get(objects.idFromString(id.toString()))
+            .bump();
+          return yield* HttpServerResponse.json({ count });
+        }
+
+        // Two fresh unique ids must be two different instances, so each counter
+        // starts from scratch and both report 1.
+        if (url.pathname === "/by-unique") {
+          const first = yield* objects.get(objects.newUniqueId()).bump();
+          const second = yield* objects.get(objects.newUniqueId()).bump();
+          return yield* HttpServerResponse.json({ first, second });
+        }
+
+        return HttpServerResponse.text("Not Found", { status: 404 });
+      }).pipe(
+        // Surface failures as 5xx text rather than a thrown defect, so a test
+        // sees the real error instead of an opaque connection drop.
+        Effect.catchCause((cause) =>
+          Effect.succeed(
+            HttpServerResponse.text(String(cause), { status: 500 }),
+          ),
+        ),
+      ),
+    };
+  }),
+);


### PR DESCRIPTION
### The bug

```typescript
const counter = counters.get(counters.idFromName("user-123"));
//                        ^ typechecks. undefined at runtime.
```

```
TypeError: e.idFromName is not a function
```

The DO namespace interface declares `get`, `idFromName`, `idFromString`, `newUniqueId` and `jurisdiction`. The implementation returned an object literal carrying only `getByName` — the rest sat commented out directly below it. TypeScript reported them as present; they were `undefined`. The interface lied, and the call site found out in production.

`get(id, options)` matters beyond completeness: it is the route **Cloudflare's own docs use** to pass a `locationHint`, so #851 threaded the options bag through `getByName` while the documented path stayed broken. That fix was part of #851 but landed after the merge, so it never shipped — hence this PR.

### Why it could happen, and why it can't again

Nothing checked the literal against the interface. Its type was inferred and then cast, so the two were free to drift.

It wouldn't accept an annotation either — `satisfies DurableObject<any>` was rejected outright, for two reasons that turned out to be the same bug wearing different clothes:

- **`LogicalId`** — the literal carries one (as every alchemy resource does, per `Self.ts`), and the interface never declared it. Now declared.
- **`kind`** — the interface has always said a namespace *is* a `DurableObjectLike`, while the literal carried no `kind`, so the claim was false. It now carries `kind`, plus the `scriptName` / `transferredFrom` the binding was built with, so the value stays faithful.

With the shape true, `makeNamespace` takes an explicit `: DurableObject<any>` return type — and the original bug becomes a build failure that names the damage:

```
error TS2739: Type '{ kind: ...; getByName: ...; jurisdiction: ... }' is missing the
following properties from type 'DurableObject<any>': newUniqueId, idFromName, idFromString, get
```

I verified that by re-introducing the exact original bug on top of the fix. Add a method to `DurableObject` and forget to wire it up, and it now fails to compile instead of paging someone.

`jurisdiction` is implemented rather than left commented, because the annotation makes it mandatory. It returns another namespace over the sub-namespace, which is why this is a function rather than a literal.

### A silent failure this also fixes

`mapBinding` dispatches on `kind`. A live namespace handed to a Worker's `env` therefore matched no branch and fell through to the final `else`:

```typescript
} else {
  return { type: "json", name: bindingName, json: binding };
}
```

It was serialized as **data** — functions dropped, no error anywhere. It now binds as the `durable_object_namespace` it always claimed to be. This is the one behaviour change in the PR, and it's why I carried `scriptName`/`transferredFrom` onto the value rather than just `kind`: a cross-script namespace has to bind to the class it actually points at.

### Regression tests

On the **local runtime** (`dev: true`) — the namespace simply never wired these up, so no deploy is needed to reproduce and the guard costs ~8s instead of minutes. (It still reaches Cloudflare for the state store, like the rest of the suite; the workers stay local.)

Each route bumps the target instance's **own counter** and returns it. That is the only evidence separating "something answered" from "the instance you asked for answered" — every route answers *something*; only one identity is correct.

| Test | Parent commit | With fix |
|---|---|---|
| `get(idFromName(name))` reaches the same instance as `getByName(name)` | ✗ `TypeError: e.idFromName is not a function` | ✓ counter carries over 1 → 2 |
| `idFromString` round-trips an id back to the same instance | ✗ `TypeError: e.idFromName is not a function` | ✓ counter carries over 1 → 2 |
| `newUniqueId` yields a fresh instance every time | ✗ `TypeError: e.newUniqueId is not a function` | ✓ two ids, both count 1 |

Written test-first and run against the parent commit, so each is confirmed to fail for the stated reason rather than passing vacuously.

### Verification

- re-introducing the original bug now **fails the build** (error above)
- the 3 addressing tests: ✓ 3/3
- the existing DO suite, live: **✓ 15/15** — including the migration, adopt, transfer and cross-worker `scriptName` cases the `kind` change could plausibly have disturbed
- run against a real Cloudflare account (not this repo's test account — I still don't have creds for that one)