### PR TITLE
feat(aws/lambda): Live Lambda — proxy deployed Function invocations to local code under alchemy dev

### DIFF
--- a/examples/aws-lambda/live.run.ts
+++ b/examples/aws-lambda/live.run.ts
@@ -1,0 +1,17 @@
+import * as Alchemy from "alchemy";
+import * as AWS from "alchemy/AWS";
+import * as Effect from "effect/Effect";
+import LiveFunction from "./src/LiveFunction.ts";
+
+/** Live Lambda e2e fixture — see src/LiveFunction.ts. */
+export default Alchemy.Stack(
+  "LiveE2E",
+  {
+    providers: AWS.providers(),
+    state: Alchemy.localState(),
+  },
+  Effect.gen(function* () {
+    const func = yield* LiveFunction;
+    return { url: func.functionUrl.as<string>() };
+  }),
+);

--- a/examples/aws-lambda/src/LiveFunction.ts
+++ b/examples/aws-lambda/src/LiveFunction.ts
@@ -1,0 +1,24 @@
+import * as AWS from "alchemy/AWS";
+import * as Effect from "effect/Effect";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+/**
+ * Minimal fixture for exercising Live Lambda (`alchemy dev`): responds with
+ * `process.platform`, which is `linux` when the handler runs in AWS and the
+ * developer machine's platform (e.g. `darwin`) when proxied locally.
+ */
+export default class LiveFunction extends AWS.Lambda.Function<LiveFunction>()(
+  "LiveFunction",
+  { main: import.meta.url, url: true },
+  Effect.gen(function* () {
+    return {
+      fetch: Effect.gen(function* () {
+        return yield* HttpServerResponse.json({
+          marker: "live-v1",
+          platform: process.platform,
+          functionName: process.env.AWS_LAMBDA_FUNCTION_NAME ?? null,
+        });
+      }),
+    };
+  }),
+) {}

--- a/packages/alchemy/src/AWS/Lambda/Function.ts
+++ b/packages/alchemy/src/AWS/Lambda/Function.ts
@@ -10,10 +10,8 @@ import * as Context from "effect/Context";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
-import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
-import * as Redacted from "effect/Redacted";
 import * as Schedule from "effect/Schedule";
 import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
@@ -666,241 +664,56 @@ export const Function: Platform<
   },
 });
 
-export const FunctionProvider = () =>
-  Provider.effect(
-    Function,
-    Effect.gen(function* () {
-      const stack = yield* Stack;
+/**
+ * Resolved Rolldown input/output options for a Function's bundle — shared by
+ * the one-shot deploy build (`Bundle.build`) and the Live Lambda dev watcher
+ * (`Bundle.watch`). For Effect Functions the generated entry (layer build,
+ * graceful shutdown, config reification) is injected via the virtual entry
+ * plugin; `isExternal` Functions bundle the user module as-is.
+ */
+export const resolveFunctionBundleConfig = Effect.fn(function* (
+  props: FunctionProps,
+) {
+  const virtualEntryPlugin = yield* Bundle.virtualEntryPlugin;
+  const {
+    output: buildOutput,
+    install,
+    ...userInputOptions
+  } = props.build ?? {};
+  const sourcemap = buildOutput?.sourcemap ?? true;
+  const uploadSourceMap = props.uploadSourceMap ?? true;
 
-      const fs = yield* FileSystem.FileSystem;
-      const virtualEntryPlugin = yield* Bundle.virtualEntryPlugin;
-      const alchemyEnv = {
-        ALCHEMY_STACK_NAME: stack.name,
-        ALCHEMY_STAGE: stack.stage,
-        ALCHEMY_PHASE: "runtime",
-      };
+  const realMain = yield* TempRoot.resolveMainPath(props.main);
+  const cwd = yield* TempRoot.findCwdForBundle(realMain);
+  const architecture: FunctionArchitecture = props.architecture ?? "x86_64";
 
-      const createFunctionName = (
-        id: string,
-        functionName: string | undefined,
-      ) =>
-        Effect.gen(function* () {
-          return (
-            functionName ?? (yield* createPhysicalName({ id, maxLength: 64 }))
-          );
-        });
+  // Explicit install roots are excluded from the bundle and installed
+  // into the deployment artifact. build.external stays a pure Rolldown
+  // escape hatch and is not installed by Alchemy.
+  const requested = yield* normalizeInstallTargets(install);
+  const installRoots = new Set(Object.keys(requested));
+  const configuredExternal = userInputOptions.external;
+  const externalOption = (
+    moduleId: string,
+    parentId: string | undefined,
+    isResolvedId: boolean,
+  ): boolean => {
+    if (moduleId.startsWith("@aws-sdk/")) return true;
+    for (const root of installRoots) {
+      if (matchesPackageRoot(moduleId, root)) return true;
+    }
+    return matchesConfiguredExternal(
+      configuredExternal,
+      moduleId,
+      parentId,
+      isResolvedId,
+    );
+  };
 
-      const createRoleName = (id: string) =>
-        createPhysicalName({ id, maxLength: 64 });
-
-      const createPolicyName = (id: string) =>
-        createPhysicalName({ id, maxLength: 128 });
-
-      const hashBundle = (code: Uint8Array<ArrayBufferLike>) => sha256(code);
-
-      const createNames = (id: string, functionName: string | undefined) =>
-        Effect.gen(function* () {
-          const { accountId, region } = yield* AWSEnvironment.current;
-          const roleName = yield* createRoleName(id);
-          const policyName = yield* createPolicyName(id);
-          const fn = yield* createFunctionName(id, functionName);
-          return {
-            roleName,
-            policyName,
-            functionName: fn,
-            roleArn: `arn:aws:iam::${accountId}:role/${roleName}`,
-            functionArn: `arn:aws:lambda:${region}:${accountId}:function:${fn}`,
-          };
-        });
-
-      const attachBindings = Effect.fn(function* ({
-        roleName,
-        policyName,
-        // functionArn,
-        // functionName,
-        bindings,
-      }: {
-        roleName: string;
-        policyName: string;
-        functionArn: string;
-        functionName: string;
-        bindings: ResourceBinding<Function["Binding"]>[];
-      }) {
-        const activeBindings = bindings.filter(
-          (
-            binding: ResourceBinding<Function["Binding"]> & { action?: string },
-          ) => binding.action !== "delete",
-        );
-        const env = activeBindings
-          .map((binding) => binding?.data?.env)
-          .reduce((acc, env) => ({ ...acc, ...env }), {});
-        const policyStatements = activeBindings.flatMap(
-          (binding) =>
-            binding?.data?.policyStatements?.map(
-              (stmt: IAM.PolicyStatement) => ({
-                ...stmt,
-                Sid: stmt.Sid?.replace(/[^A-Za-z0-9]+/gi, ""),
-              }),
-            ) ?? [],
-        );
-
-        if (policyStatements.length > 0) {
-          yield* iam.putRolePolicy({
-            RoleName: roleName,
-            PolicyName: policyName,
-            PolicyDocument: JSON.stringify({
-              Version: "2012-10-17",
-              Statement: policyStatements,
-            } satisfies IAM.PolicyDocument),
-          });
-        } else {
-          yield* iam
-            .deleteRolePolicy({
-              RoleName: roleName,
-              PolicyName: policyName,
-            })
-            .pipe(Effect.catchTag("NoSuchEntityException", () => Effect.void));
-        }
-
-        return env;
-      });
-
-      const createRoleIfNotExists = Effect.fn(function* ({
-        id,
-        roleName,
-        vpc,
-      }: {
-        id: string;
-        roleName: string;
-        vpc?: FunctionProps["vpc"];
-      }) {
-        yield* Effect.logDebug(`creating role ${id}`);
-        const tags = yield* createInternalTags(id);
-        // Engine has cleared us via `read` — foreign-tagged functions are
-        // surfaced as `Unowned` and require `--adopt`. On a race between
-        // read and create, treat `EntityAlreadyExistsException` as adoption.
-        const role = yield* iam
-          .createRole({
-            RoleName: roleName,
-            AssumeRolePolicyDocument: JSON.stringify({
-              Version: "2012-10-17",
-              Statement: [
-                {
-                  Effect: "Allow",
-                  Principal: {
-                    Service: "lambda.amazonaws.com",
-                  },
-                  Action: "sts:AssumeRole",
-                },
-              ],
-            }),
-            Tags: createTagsList(tags),
-          })
-          .pipe(
-            Effect.catchTag("EntityAlreadyExistsException", () =>
-              iam.getRole({
-                RoleName: roleName,
-              }),
-            ),
-          );
-
-        yield* Effect.logDebug(`attaching policy ${id}`);
-        yield* iam
-          .attachRolePolicy({
-            RoleName: roleName,
-            PolicyArn:
-              "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-          })
-          .pipe(Effect.tapError(Effect.logDebug), Effect.tap(Effect.logDebug));
-
-        if (vpc) {
-          yield* iam
-            .attachRolePolicy({
-              RoleName: roleName,
-              PolicyArn:
-                "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole",
-            })
-            .pipe(
-              Effect.tapError(Effect.logDebug),
-              Effect.tap(Effect.logDebug),
-            );
-        }
-
-        yield* Effect.logDebug(`attached policy ${id}`);
-        return role;
-      });
-
-      const bundleCode = Effect.fn(function* (
-        id: string,
-        props: FunctionProps,
-      ) {
-        const {
-          output: buildOutput,
-          install,
-          ...inputOptions
-        } = props.build ?? {};
-        const sourcemap = buildOutput?.sourcemap ?? true;
-        const uploadSourceMap = props.uploadSourceMap ?? true;
-
-        const realMain = yield* TempRoot.resolveMainPath(props.main);
-        const cwd = yield* TempRoot.findCwdForBundle(realMain);
-
-        const rolldownSourcemap = sourcemap;
-        const architecture = props.architecture ?? "x86_64";
-
-        // Explicit install roots are excluded from the bundle and installed
-        // into the deployment artifact. build.external stays a pure Rolldown
-        // escape hatch and is not installed by Alchemy.
-        const requested = yield* normalizeInstallTargets(install);
-        const installRoots = new Set(Object.keys(requested));
-        const configuredExternal = inputOptions.external;
-        const externalOption = (
-          moduleId: string,
-          parentId: string | undefined,
-          isResolved: boolean,
-        ): boolean => {
-          if (moduleId.startsWith("@aws-sdk/")) return true;
-          for (const root of installRoots) {
-            if (matchesPackageRoot(moduleId, root)) return true;
-          }
-          return matchesConfiguredExternal(
-            configuredExternal,
-            moduleId,
-            parentId,
-            isResolved,
-          );
-        };
-
-        const buildBundle = Effect.fn(function* (
-          entry: string,
-          plugins?: rolldown.RolldownPluginOption,
-        ) {
-          return yield* Bundle.build(
-            {
-              ...inputOptions,
-              input: entry,
-              cwd,
-              external: externalOption,
-              platform: "node",
-              plugins: [inputOptions.plugins, plugins],
-            },
-            {
-              ...buildOutput,
-              format: "esm",
-              sourcemap: rolldownSourcemap,
-              minify: buildOutput?.minify ?? false,
-              entryFileNames: "index.js",
-              codeSplitting: buildOutput?.codeSplitting ?? false,
-            },
-          );
-        });
-
-        const bundleOutput = props.isExternal
-          ? yield* buildBundle(realMain)
-          : yield* buildBundle(
-              realMain,
-              virtualEntryPlugin(
-                (importPath) => `
+  const entryPlugin = props.isExternal
+    ? undefined
+    : virtualEntryPlugin(
+        (importPath) => `
 import { layer as nodeServicesLayer } from "@effect/platform-node/NodeServices";
 import { Stack } from "alchemy/Stack";
 import { makeEntrypointLayer, reifyBoundConfigProvider } from "alchemy/Runtime";
@@ -1006,901 +819,1142 @@ process.on("SIGTERM", () => {
 
 export default handler;
 `,
-              ),
-            );
+      );
 
-        const mainFile = bundleOutput.files[0];
-        const code =
-          typeof mainFile.content === "string"
-            ? new TextEncoder().encode(mainFile.content)
-            : mainFile.content;
+  const inputOptions: rolldown.InputOptions = {
+    ...userInputOptions,
+    input: realMain,
+    cwd,
+    external: externalOption,
+    platform: "node",
+    plugins: [userInputOptions.plugins, entryPlugin],
+  };
 
-        const includeSourceMaps =
-          uploadSourceMap && (sourcemap === true || sourcemap === "hidden");
+  const outputOptions: rolldown.OutputOptions = {
+    ...buildOutput,
+    format: "esm",
+    sourcemap,
+    minify: buildOutput?.minify ?? false,
+    entryFileNames: "index.js",
+    codeSplitting: buildOutput?.codeSplitting ?? false,
+  };
 
-        const extraFiles = bundleOutput.files
-          .slice(1)
-          .filter(
-            (f: Bundle.BundleFile) =>
-              includeSourceMaps || !f.path.endsWith(".map"),
-          )
-          .map((f: Bundle.BundleFile) => ({
-            path: f.path,
-            content: f.content,
-          }));
+  return {
+    inputOptions,
+    outputOptions,
+    cwd,
+    architecture,
+    requested,
+    sourcemap,
+    uploadSourceMap,
+  };
+});
 
-        // Resolve install versions without running npm so `diff` can compare a
-        // stable identity hash. The archive build performs the install.
-        const installIdentity = yield* resolvePackageInstallIdentity({
-          cwd,
-          requested,
-        });
-        const resolved = installIdentity.resolved;
-        const hasInstalledPackages = Object.keys(resolved).length > 0;
+/**
+ * The code-bundling contract of the Function provider. The default
+ * implementation bundles the user's entry module with Rolldown; the Live
+ * Lambda dev provider substitutes the bridge bundle instead.
+ */
+export interface FunctionCodeBundle {
+  /** Drives change detection in `diff` and is persisted as `code.hash`. */
+  identityHash: string;
+  /** Deferred zip build — only run when the code actually needs uploading. */
+  buildArchive: Effect.Effect<{
+    archive: Uint8Array<ArrayBufferLike>;
+    archiveHash: string;
+  }>;
+}
 
-        // Identity hash drives change detection in `diff`. With native packages,
-        // the installed bytes are not captured by the bundle hash, so fold the
-        // resolved versions, package-manager lockfile, and architecture in
-        // instead of installing.
-        const identityHash = hasInstalledPackages
-          ? yield* hashPackageInstallIdentity({
-              bundleHash: bundleOutput.hash,
-              identity: installIdentity,
-              architecture,
-            })
-          : bundleOutput.hash;
+export interface FunctionProviderOptions {
+  /**
+   * Override the code bundling step. Used by the Live Lambda dev provider to
+   * deploy the bridge in place of the user's code.
+   */
+  bundleCode?: (
+    id: string,
+    props: FunctionProps,
+  ) => Effect.Effect<FunctionCodeBundle, Bundle.BundleError>;
+}
 
-        const buildArchive = Effect.gen(function* () {
-          const installedPackageFiles = hasInstalledPackages
-            ? yield* installResolvedPackages({ resolved, architecture })
-            : [];
-          const archiveFiles = [...extraFiles, ...installedPackageFiles];
-          const archive = yield* zipCode(
-            code,
-            archiveFiles.length > 0 ? archiveFiles : undefined,
-          );
-          // The S3 asset key is content-addressed, so the archive hash must be a
-          // true hash of the bytes when native packages are present.
-          const archiveHash =
-            installedPackageFiles.length > 0
-              ? yield* sha256(archive)
-              : bundleOutput.hash;
-          return { archive, archiveHash };
-        });
+/**
+ * Input shape of a Function provider lifecycle method. The provider record
+ * is built outside `Provider.effect`'s contextual position (so it can be
+ * shared with the Live Lambda dev provider), which loses parameter
+ * inference — these aliases restore it.
+ */
+export type FunctionLifecycleInput<
+  K extends keyof Provider.ProviderService<Function>,
+> = Parameters<
+  Extract<Provider.ProviderService<Function>[K], (...args: any) => any>
+>[0];
 
-        return { identityHash, buildArchive };
+export const makeFunctionProvider = (options?: FunctionProviderOptions) =>
+  Effect.gen(function* () {
+    const stack = yield* Stack;
+
+    const alchemyEnv = {
+      ALCHEMY_STACK_NAME: stack.name,
+      ALCHEMY_STAGE: stack.stage,
+      ALCHEMY_PHASE: "runtime",
+    };
+
+    const createFunctionName = (id: string, functionName: string | undefined) =>
+      Effect.gen(function* () {
+        return (
+          functionName ?? (yield* createPhysicalName({ id, maxLength: 64 }))
+        );
       });
 
-      const withNodeSourceMaps = (
-        env: Record<string, string> | undefined,
-        props: FunctionProps,
-      ) => {
-        const sourcemap = props.build?.output?.sourcemap ?? true;
-        const uploadSourceMap = props.uploadSourceMap ?? true;
-        const shouldEnableSourceMaps =
-          sourcemap === "inline" ||
-          (uploadSourceMap && (sourcemap === true || sourcemap === "hidden"));
+    const createRoleName = (id: string) =>
+      createPhysicalName({ id, maxLength: 64 });
 
-        if (!shouldEnableSourceMaps) {
-          return env;
-        }
+    const createPolicyName = (id: string) =>
+      createPhysicalName({ id, maxLength: 128 });
 
-        const current = env?.NODE_OPTIONS;
-        if (current?.split(/\s+/).includes("--enable-source-maps")) {
-          return env;
-        }
+    const hashBundle = (code: Uint8Array<ArrayBufferLike>) => sha256(code);
 
+    const createNames = (id: string, functionName: string | undefined) =>
+      Effect.gen(function* () {
+        const { accountId, region } = yield* AWSEnvironment.current;
+        const roleName = yield* createRoleName(id);
+        const policyName = yield* createPolicyName(id);
+        const fn = yield* createFunctionName(id, functionName);
         return {
-          ...env,
-          NODE_OPTIONS: current
-            ? `${current} --enable-source-maps`
-            : "--enable-source-maps",
+          roleName,
+          policyName,
+          functionName: fn,
+          roleArn: `arn:aws:iam::${accountId}:role/${roleName}`,
+          functionArn: `arn:aws:lambda:${region}:${accountId}:function:${fn}`,
         };
+      });
+
+    const attachBindings = Effect.fn(function* ({
+      roleName,
+      policyName,
+      // functionArn,
+      // functionName,
+      bindings,
+    }: {
+      roleName: string;
+      policyName: string;
+      functionArn: string;
+      functionName: string;
+      bindings: ResourceBinding<Function["Binding"]>[];
+    }) {
+      const activeBindings = bindings.filter(
+        (binding: ResourceBinding<Function["Binding"]> & { action?: string }) =>
+          binding.action !== "delete",
+      );
+      const env = activeBindings
+        .map((binding) => binding?.data?.env)
+        .reduce((acc, env) => ({ ...acc, ...env }), {});
+      const policyStatements = activeBindings.flatMap(
+        (binding) =>
+          binding?.data?.policyStatements?.map((stmt: IAM.PolicyStatement) => ({
+            ...stmt,
+            Sid: stmt.Sid?.replace(/[^A-Za-z0-9]+/gi, ""),
+          })) ?? [],
+      );
+
+      if (policyStatements.length > 0) {
+        yield* iam.putRolePolicy({
+          RoleName: roleName,
+          PolicyName: policyName,
+          PolicyDocument: JSON.stringify({
+            Version: "2012-10-17",
+            Statement: policyStatements,
+          } satisfies IAM.PolicyDocument),
+        });
+      } else {
+        yield* iam
+          .deleteRolePolicy({
+            RoleName: roleName,
+            PolicyName: policyName,
+          })
+          .pipe(Effect.catchTag("NoSuchEntityException", () => Effect.void));
+      }
+
+      return env;
+    });
+
+    const createRoleIfNotExists = Effect.fn(function* ({
+      id,
+      roleName,
+      vpc,
+    }: {
+      id: string;
+      roleName: string;
+      vpc?: FunctionProps["vpc"];
+    }) {
+      yield* Effect.logDebug(`creating role ${id}`);
+      const tags = yield* createInternalTags(id);
+      // Engine has cleared us via `read` — foreign-tagged functions are
+      // surfaced as `Unowned` and require `--adopt`. On a race between
+      // read and create, treat `EntityAlreadyExistsException` as adoption.
+      const role = yield* iam
+        .createRole({
+          RoleName: roleName,
+          AssumeRolePolicyDocument: JSON.stringify({
+            Version: "2012-10-17",
+            Statement: [
+              {
+                Effect: "Allow",
+                Principal: {
+                  Service: "lambda.amazonaws.com",
+                },
+                Action: "sts:AssumeRole",
+              },
+            ],
+          }),
+          Tags: createTagsList(tags),
+        })
+        .pipe(
+          Effect.catchTag("EntityAlreadyExistsException", () =>
+            iam.getRole({
+              RoleName: roleName,
+            }),
+          ),
+        );
+
+      yield* Effect.logDebug(`attaching policy ${id}`);
+      yield* iam
+        .attachRolePolicy({
+          RoleName: roleName,
+          PolicyArn:
+            "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        })
+        .pipe(Effect.tapError(Effect.logDebug), Effect.tap(Effect.logDebug));
+
+      if (vpc) {
+        yield* iam
+          .attachRolePolicy({
+            RoleName: roleName,
+            PolicyArn:
+              "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole",
+          })
+          .pipe(Effect.tapError(Effect.logDebug), Effect.tap(Effect.logDebug));
+      }
+
+      yield* Effect.logDebug(`attached policy ${id}`);
+      return role;
+    });
+
+    const defaultBundleCode = Effect.fn(function* (
+      _id: string,
+      props: FunctionProps,
+    ) {
+      const config = yield* resolveFunctionBundleConfig(props);
+      const { cwd, architecture, requested, sourcemap, uploadSourceMap } =
+        config;
+
+      const bundleOutput = yield* Bundle.build(
+        config.inputOptions,
+        config.outputOptions,
+      );
+
+      const mainFile = bundleOutput.files[0];
+      const code =
+        typeof mainFile.content === "string"
+          ? new TextEncoder().encode(mainFile.content)
+          : mainFile.content;
+
+      const includeSourceMaps =
+        uploadSourceMap && (sourcemap === true || sourcemap === "hidden");
+
+      const extraFiles = bundleOutput.files
+        .slice(1)
+        .filter(
+          (f: Bundle.BundleFile) =>
+            includeSourceMaps || !f.path.endsWith(".map"),
+        )
+        .map((f: Bundle.BundleFile) => ({
+          path: f.path,
+          content: f.content,
+        }));
+
+      // Resolve install versions without running npm so `diff` can compare a
+      // stable identity hash. The archive build performs the install.
+      const installIdentity = yield* resolvePackageInstallIdentity({
+        cwd,
+        requested,
+      });
+      const resolved = installIdentity.resolved;
+      const hasInstalledPackages = Object.keys(resolved).length > 0;
+
+      // Identity hash drives change detection in `diff`. With native packages,
+      // the installed bytes are not captured by the bundle hash, so fold the
+      // resolved versions, package-manager lockfile, and architecture in
+      // instead of installing.
+      const identityHash = hasInstalledPackages
+        ? yield* hashPackageInstallIdentity({
+            bundleHash: bundleOutput.hash,
+            identity: installIdentity,
+            architecture,
+          })
+        : bundleOutput.hash;
+
+      const buildArchive = Effect.gen(function* () {
+        const installedPackageFiles = hasInstalledPackages
+          ? yield* installResolvedPackages({ resolved, architecture })
+          : [];
+        const archiveFiles = [...extraFiles, ...installedPackageFiles];
+        const archive = yield* zipCode(
+          code,
+          archiveFiles.length > 0 ? archiveFiles : undefined,
+        );
+        // The S3 asset key is content-addressed, so the archive hash must be a
+        // true hash of the bytes when native packages are present.
+        const archiveHash =
+          installedPackageFiles.length > 0
+            ? yield* sha256(archive)
+            : bundleOutput.hash;
+        return { archive, archiveHash };
+      });
+
+      return { identityHash, buildArchive };
+    });
+
+    const bundleCode = options?.bundleCode ?? defaultBundleCode;
+
+    const withNodeSourceMaps = (
+      env: Record<string, string> | undefined,
+      props: FunctionProps,
+    ) => {
+      const sourcemap = props.build?.output?.sourcemap ?? true;
+      const uploadSourceMap = props.uploadSourceMap ?? true;
+      const shouldEnableSourceMaps =
+        sourcemap === "inline" ||
+        (uploadSourceMap && (sourcemap === true || sourcemap === "hidden"));
+
+      if (!shouldEnableSourceMaps) {
+        return env;
+      }
+
+      const current = env?.NODE_OPTIONS;
+      if (current?.split(/\s+/).includes("--enable-source-maps")) {
+        return env;
+      }
+
+      return {
+        ...env,
+        NODE_OPTIONS: current
+          ? `${current} --enable-source-maps`
+          : "--enable-source-maps",
+      };
+    };
+
+    const retryFunctionMutation = Effect.retry({
+      while: (e: any) =>
+        e._tag === "ResourceConflictException" ||
+        e._tag === "TooManyRequestsException",
+      schedule: Schedule.max([Schedule.exponential(100), Schedule.recurs(30)]),
+    }) as <A, R, Err>(
+      self: Effect.Effect<A, Err, R>,
+    ) => Effect.Effect<A, Err, R>;
+
+    const getReservedConcurrentExecutions = Effect.fn(function* (
+      functionName: string,
+    ) {
+      return yield* Lambda.getFunctionConcurrency({
+        FunctionName: functionName,
+      }).pipe(
+        Effect.map((config) => config.ReservedConcurrentExecutions),
+        Effect.catchTag("ResourceNotFoundException", () =>
+          Effect.succeed(undefined),
+        ),
+      );
+    });
+
+    const syncReservedConcurrentExecutions = Effect.fn(function* ({
+      functionName,
+      reservedConcurrentExecutions,
+    }: {
+      functionName: string;
+      reservedConcurrentExecutions: number | undefined;
+    }) {
+      const current = yield* getReservedConcurrentExecutions(functionName);
+      if (current === reservedConcurrentExecutions) {
+        return current;
+      }
+
+      if (reservedConcurrentExecutions === undefined) {
+        yield* Lambda.deleteFunctionConcurrency({
+          FunctionName: functionName,
+        }).pipe(
+          retryFunctionMutation,
+          Effect.catchTag("ResourceNotFoundException", () => Effect.void),
+        );
+        return undefined;
+      }
+
+      const updated = yield* Lambda.putFunctionConcurrency({
+        FunctionName: functionName,
+        ReservedConcurrentExecutions: reservedConcurrentExecutions,
+      }).pipe(retryFunctionMutation);
+      return (
+        updated.ReservedConcurrentExecutions ?? reservedConcurrentExecutions
+      );
+    });
+
+    const createOrUpdateFunction: (input: {
+      id: string;
+      news: FunctionProps;
+      roleArn: string;
+      archive: Uint8Array<ArrayBufferLike>;
+      hash: string;
+      env: Record<string, string> | undefined;
+      functionName: string;
+      preferUpdate?: boolean;
+      session: { note: (note: string) => Effect.Effect<void> };
+    }) => Effect.Effect<
+      void,
+      any,
+      Credentials | Region | HttpClient | Stack | Stage | AWSEnvironment
+    > = Effect.fn(function* ({
+      id,
+      news,
+      roleArn,
+      archive,
+      hash,
+      env,
+      functionName,
+      preferUpdate,
+      session,
+    }: {
+      id: string;
+      news: FunctionProps;
+      roleArn: string;
+      archive: Uint8Array<ArrayBufferLike>;
+      hash: string;
+      env: Record<string, string> | undefined;
+      functionName: string;
+      preferUpdate?: boolean;
+      session: { note: (note: string) => Effect.Effect<void> };
+    }) {
+      yield* Effect.logDebug(`creating function ${id}`);
+      const waitStartedAt = Date.now();
+
+      const isRolePropagationError = <
+        E extends Lambda.UpdateFunctionCodeError | Lambda.CreateFunctionError,
+      >(
+        e: E,
+      ) =>
+        e._tag === "InvalidParameterValueException" &&
+        (e.message?.includes("cannot be assumed by Lambda") ||
+          (e.message?.includes("KMS key is invalid for CreateGrant") &&
+            e.message?.includes("ARN does not refer to a valid principal")));
+
+      const noteRolePropagationWait = () =>
+        session.note(
+          `Waiting for Lambda execution role to become assumable: ${functionName} (${Math.ceil((Date.now() - waitStartedAt) / 1000)}s)`,
+        );
+
+      const tags = yield* createInternalTags(id);
+
+      // Try to use S3 if assets bucket is available, otherwise fall back to inline ZipFile
+      const assets = (yield* Effect.serviceOption(Assets)).pipe(
+        Option.getOrUndefined,
+      );
+
+      const codeLocation = yield* Effect.gen(function* () {
+        if (assets) {
+          const key = yield* assets.uploadAsset(hash, archive);
+          yield* Effect.logDebug(
+            `Using S3 for code: s3://${yield* assets.bucketName}/${key}`,
+          );
+          return {
+            S3Bucket: yield* assets.bucketName,
+            S3Key: key,
+          } as const;
+        } else {
+          return { ZipFile: archive } as const;
+        }
+      });
+      const runtimeEnv = withNodeSourceMaps(env, news);
+
+      const createFunctionRequest: CreateFunctionRequest = {
+        FunctionName: functionName,
+        Handler: `index.${news.handler ?? "default"}`,
+        Role: roleArn,
+        Code: codeLocation,
+        Runtime: news.runtime ?? "nodejs22.x",
+        Architectures: [news.architecture ?? "x86_64"],
+        MemorySize: news.memorySize,
+        Environment: runtimeEnv
+          ? {
+              Variables: {
+                ...runtimeEnv,
+                ...alchemyEnv,
+              },
+            }
+          : undefined,
+        Tags: tags,
+        Timeout: toTimeoutSeconds(news.timeout),
+        VpcConfig: news.vpc
+          ? {
+              SubnetIds: news.vpc.subnetIds,
+              SecurityGroupIds: news.vpc.securityGroupIds,
+            }
+          : undefined,
       };
 
-      const retryFunctionMutation = Effect.retry({
-        while: (e: any) =>
-          e._tag === "ResourceConflictException" ||
-          e._tag === "TooManyRequestsException",
-        schedule: Schedule.max([
-          Schedule.exponential(100),
-          Schedule.recurs(30),
-        ]),
-      }) as <A, R, Err>(
-        self: Effect.Effect<A, Err, R>,
-      ) => Effect.Effect<A, Err, R>;
-
-      const getReservedConcurrentExecutions = Effect.fn(function* (
-        functionName: string,
-      ) {
-        return yield* Lambda.getFunctionConcurrency({
-          FunctionName: functionName,
-        }).pipe(
-          Effect.map((config) => config.ReservedConcurrentExecutions),
-          Effect.catchTag("ResourceNotFoundException", () =>
-            Effect.succeed(undefined),
-          ),
-        );
-      });
-
-      const syncReservedConcurrentExecutions = Effect.fn(function* ({
-        functionName,
-        reservedConcurrentExecutions,
-      }: {
-        functionName: string;
-        reservedConcurrentExecutions: number | undefined;
-      }) {
-        const current = yield* getReservedConcurrentExecutions(functionName);
-        if (current === reservedConcurrentExecutions) {
-          return current;
-        }
-
-        if (reservedConcurrentExecutions === undefined) {
-          yield* Lambda.deleteFunctionConcurrency({
-            FunctionName: functionName,
-          }).pipe(
-            retryFunctionMutation,
-            Effect.catchTag("ResourceNotFoundException", () => Effect.void),
-          );
-          return undefined;
-        }
-
-        const updated = yield* Lambda.putFunctionConcurrency({
-          FunctionName: functionName,
-          ReservedConcurrentExecutions: reservedConcurrentExecutions,
-        }).pipe(retryFunctionMutation);
-        return (
-          updated.ReservedConcurrentExecutions ?? reservedConcurrentExecutions
-        );
-      });
-
-      const createOrUpdateFunction: (input: {
-        id: string;
-        news: FunctionProps;
-        roleArn: string;
-        archive: Uint8Array<ArrayBufferLike>;
-        hash: string;
-        env: Record<string, string> | undefined;
-        functionName: string;
-        preferUpdate?: boolean;
-        session: { note: (note: string) => Effect.Effect<void> };
-      }) => Effect.Effect<
-        void,
-        any,
-        Credentials | Region | HttpClient | Stack | Stage | AWSEnvironment
-      > = Effect.fn(function* ({
-        id,
-        news,
-        roleArn,
-        archive,
-        hash,
-        env,
-        functionName,
-        preferUpdate,
-        session,
-      }: {
-        id: string;
-        news: FunctionProps;
-        roleArn: string;
-        archive: Uint8Array<ArrayBufferLike>;
-        hash: string;
-        env: Record<string, string> | undefined;
-        functionName: string;
-        preferUpdate?: boolean;
-        session: { note: (note: string) => Effect.Effect<void> };
-      }) {
-        yield* Effect.logDebug(`creating function ${id}`);
-        const waitStartedAt = Date.now();
-
-        const isRolePropagationError = <
-          E extends Lambda.UpdateFunctionCodeError | Lambda.CreateFunctionError,
-        >(
-          e: E,
-        ) =>
-          e._tag === "InvalidParameterValueException" &&
-          (e.message?.includes("cannot be assumed by Lambda") ||
-            (e.message?.includes("KMS key is invalid for CreateGrant") &&
-              e.message?.includes("ARN does not refer to a valid principal")));
-
-        const noteRolePropagationWait = () =>
-          session.note(
-            `Waiting for Lambda execution role to become assumable: ${functionName} (${Math.ceil((Date.now() - waitStartedAt) / 1000)}s)`,
-          );
-
-        const tags = yield* createInternalTags(id);
-
-        // Try to use S3 if assets bucket is available, otherwise fall back to inline ZipFile
-        const assets = (yield* Effect.serviceOption(Assets)).pipe(
-          Option.getOrUndefined,
-        );
-
-        const codeLocation = yield* Effect.gen(function* () {
-          if (assets) {
-            const key = yield* assets.uploadAsset(hash, archive);
-            yield* Effect.logDebug(
-              `Using S3 for code: s3://${yield* assets.bucketName}/${key}`,
+      const getAndUpdate = Lambda.getFunction({
+        FunctionName: functionName,
+      }).pipe(
+        Effect.filterOrFail(
+          // if it exists and contains these tags, we will assume it was created by alchemy
+          // but state was lost, so if it exists, let's adopt it
+          (f) => hasTags(tags, f.Tags),
+          () =>
+            // TODO(sam): add custom
+            new Error("Function tags do not match expected values"),
+        ),
+        Effect.flatMap(() =>
+          Effect.gen(function* () {
+            yield* Effect.logDebug(`updating function code ${id}`);
+            yield* Lambda.updateFunctionCode({
+              FunctionName: createFunctionRequest.FunctionName,
+              Architectures: createFunctionRequest.Architectures,
+              // Use S3 or ZipFile based on what was used for create
+              ...("S3Bucket" in codeLocation
+                ? {
+                    S3Bucket: codeLocation.S3Bucket,
+                    S3Key: codeLocation.S3Key,
+                  }
+                : { ZipFile: codeLocation.ZipFile }),
+            }).pipe(
+              Effect.tapError((e) =>
+                isRolePropagationError(e)
+                  ? noteRolePropagationWait()
+                  : Effect.void,
+              ),
+              Effect.retry({
+                while: (e) =>
+                  e._tag === "ResourceConflictException" ||
+                  isRolePropagationError(e),
+                schedule: Schedule.exponential(100),
+              }),
             );
-            return {
-              S3Bucket: yield* assets.bucketName,
-              S3Key: key,
-            } as const;
-          } else {
-            return { ZipFile: archive } as const;
-          }
-        });
-        const runtimeEnv = withNodeSourceMaps(env, news);
-
-        const createFunctionRequest: CreateFunctionRequest = {
-          FunctionName: functionName,
-          Handler: `index.${news.handler ?? "default"}`,
-          Role: roleArn,
-          Code: codeLocation,
-          Runtime: news.runtime ?? "nodejs22.x",
-          Architectures: [news.architecture ?? "x86_64"],
-          MemorySize: news.memorySize,
-          Environment: runtimeEnv
-            ? {
-                Variables: {
-                  ...runtimeEnv,
-                  ...alchemyEnv,
-                },
-              }
-            : undefined,
-          Tags: tags,
-          Timeout: toTimeoutSeconds(news.timeout),
-          VpcConfig: news.vpc
-            ? {
-                SubnetIds: news.vpc.subnetIds,
-                SecurityGroupIds: news.vpc.securityGroupIds,
-              }
-            : undefined,
-        };
-
-        const getAndUpdate = Lambda.getFunction({
-          FunctionName: functionName,
-        }).pipe(
-          Effect.filterOrFail(
-            // if it exists and contains these tags, we will assume it was created by alchemy
-            // but state was lost, so if it exists, let's adopt it
-            (f) => hasTags(tags, f.Tags),
-            () =>
-              // TODO(sam): add custom
-              new Error("Function tags do not match expected values"),
-          ),
-          Effect.flatMap(() =>
-            Effect.gen(function* () {
-              yield* Effect.logDebug(`updating function code ${id}`);
-              yield* Lambda.updateFunctionCode({
-                FunctionName: createFunctionRequest.FunctionName,
-                Architectures: createFunctionRequest.Architectures,
-                // Use S3 or ZipFile based on what was used for create
-                ...("S3Bucket" in codeLocation
-                  ? {
-                      S3Bucket: codeLocation.S3Bucket,
-                      S3Key: codeLocation.S3Key,
-                    }
-                  : { ZipFile: codeLocation.ZipFile }),
-              }).pipe(
-                Effect.tapError((e) =>
-                  isRolePropagationError(e)
-                    ? noteRolePropagationWait()
-                    : Effect.void,
-                ),
-                Effect.retry({
-                  while: (e) =>
-                    e._tag === "ResourceConflictException" ||
-                    isRolePropagationError(e),
-                  schedule: Schedule.exponential(100),
-                }),
-              );
-              yield* Effect.logDebug(`updated function code ${id}`);
-              yield* Lambda.updateFunctionConfiguration({
-                FunctionName: createFunctionRequest.FunctionName,
-                DeadLetterConfig: createFunctionRequest.DeadLetterConfig,
-                Description: createFunctionRequest.Description,
-                Environment: createFunctionRequest.Environment,
-                EphemeralStorage: createFunctionRequest.EphemeralStorage,
-                FileSystemConfigs: createFunctionRequest.FileSystemConfigs,
-                Handler: createFunctionRequest.Handler,
-                ImageConfig: createFunctionRequest.ImageConfig,
-                KMSKeyArn: createFunctionRequest.KMSKeyArn,
-                Layers: createFunctionRequest.Layers,
-                LoggingConfig: createFunctionRequest.LoggingConfig,
-                MemorySize: createFunctionRequest.MemorySize,
-                // RevisionId: "???"
-                Role: createFunctionRequest.Role,
-                Runtime: createFunctionRequest.Runtime,
-                SnapStart: createFunctionRequest.SnapStart,
-                Timeout: createFunctionRequest.Timeout,
-                TracingConfig: createFunctionRequest.TracingConfig,
-                VpcConfig: createFunctionRequest.VpcConfig,
-              }).pipe(
-                Effect.tapError((e) =>
-                  isRolePropagationError(e)
-                    ? noteRolePropagationWait()
-                    : Effect.void,
-                ),
-                Effect.retry({
-                  while: (e) =>
-                    e._tag === "ResourceConflictException" ||
-                    isRolePropagationError(e),
-                  schedule: Schedule.exponential(100),
-                }),
-              );
-              yield* Effect.logDebug(`updated function configuration ${id}`);
-            }),
-          ),
-        ) as Effect.Effect<any, any, Credentials | Region | HttpClient>;
-
-        const create = Lambda.createFunction(createFunctionRequest).pipe(
-          Effect.tapError((e) =>
-            Effect.gen(function* () {
-              yield* Effect.logDebug(e);
-            }),
-          ),
-          Effect.retry({
-            while: (e) => isRolePropagationError(e),
-            schedule: Schedule.fixed(1000).pipe(
-              Schedule.tap(() => noteRolePropagationWait()),
-            ),
+            yield* Effect.logDebug(`updated function code ${id}`);
+            yield* Lambda.updateFunctionConfiguration({
+              FunctionName: createFunctionRequest.FunctionName,
+              DeadLetterConfig: createFunctionRequest.DeadLetterConfig,
+              Description: createFunctionRequest.Description,
+              Environment: createFunctionRequest.Environment,
+              EphemeralStorage: createFunctionRequest.EphemeralStorage,
+              FileSystemConfigs: createFunctionRequest.FileSystemConfigs,
+              Handler: createFunctionRequest.Handler,
+              ImageConfig: createFunctionRequest.ImageConfig,
+              KMSKeyArn: createFunctionRequest.KMSKeyArn,
+              Layers: createFunctionRequest.Layers,
+              LoggingConfig: createFunctionRequest.LoggingConfig,
+              MemorySize: createFunctionRequest.MemorySize,
+              // RevisionId: "???"
+              Role: createFunctionRequest.Role,
+              Runtime: createFunctionRequest.Runtime,
+              SnapStart: createFunctionRequest.SnapStart,
+              Timeout: createFunctionRequest.Timeout,
+              TracingConfig: createFunctionRequest.TracingConfig,
+              VpcConfig: createFunctionRequest.VpcConfig,
+            }).pipe(
+              Effect.tapError((e) =>
+                isRolePropagationError(e)
+                  ? noteRolePropagationWait()
+                  : Effect.void,
+              ),
+              Effect.retry({
+                while: (e) =>
+                  e._tag === "ResourceConflictException" ||
+                  isRolePropagationError(e),
+                schedule: Schedule.exponential(100),
+              }),
+            );
+            yield* Effect.logDebug(`updated function configuration ${id}`);
           }),
+        ),
+      ) as Effect.Effect<any, any, Credentials | Region | HttpClient>;
+
+      const create = Lambda.createFunction(createFunctionRequest).pipe(
+        Effect.tapError((e) =>
+          Effect.gen(function* () {
+            yield* Effect.logDebug(e);
+          }),
+        ),
+        Effect.retry({
+          while: (e) => isRolePropagationError(e),
+          schedule: Schedule.fixed(1000).pipe(
+            Schedule.tap(() => noteRolePropagationWait()),
+          ),
+        }),
+        Effect.catchTags({
+          ResourceConflictException: () => getAndUpdate,
+        }),
+      ) as Effect.Effect<any, any, Credentials | Region | HttpClient>;
+
+      if (preferUpdate) {
+        yield* getAndUpdate.pipe(
           Effect.catchTags({
-            ResourceConflictException: () => getAndUpdate,
+            ResourceNotFoundException: () => create,
           }),
-        ) as Effect.Effect<any, any, Credentials | Region | HttpClient>;
-
-        if (preferUpdate) {
-          yield* getAndUpdate.pipe(
-            Effect.catchTags({
-              ResourceNotFoundException: () => create,
-            }),
-          );
-        } else {
-          yield* create;
-        }
-      });
-
-      const publicUrlAccessStatementId = "FunctionURLAllowPublicAccess";
-      const publicUrlInvokeStatementId = "FunctionURLAllowPublicInvoke";
-
-      const removePublicFunctionUrlPermissions = Effect.fn(function* (
-        functionName: string,
-      ) {
-        yield* Effect.all(
-          [
-            Lambda.removePermission({
-              FunctionName: functionName,
-              StatementId: publicUrlAccessStatementId,
-            }).pipe(
-              Effect.catchTag("ResourceNotFoundException", () => Effect.void),
-            ),
-            Lambda.removePermission({
-              FunctionName: functionName,
-              StatementId: publicUrlInvokeStatementId,
-            }).pipe(
-              Effect.catchTag("ResourceNotFoundException", () => Effect.void),
-            ),
-          ],
-          { concurrency: "unbounded" },
         );
-      });
+      } else {
+        yield* create;
+      }
+    });
 
-      const upsertPermission = (permission: Lambda.AddPermissionRequest) =>
-        Lambda.addPermission(permission).pipe(
+    const publicUrlAccessStatementId = "FunctionURLAllowPublicAccess";
+    const publicUrlInvokeStatementId = "FunctionURLAllowPublicInvoke";
+
+    const removePublicFunctionUrlPermissions = Effect.fn(function* (
+      functionName: string,
+    ) {
+      yield* Effect.all(
+        [
+          Lambda.removePermission({
+            FunctionName: functionName,
+            StatementId: publicUrlAccessStatementId,
+          }).pipe(
+            Effect.catchTag("ResourceNotFoundException", () => Effect.void),
+          ),
+          Lambda.removePermission({
+            FunctionName: functionName,
+            StatementId: publicUrlInvokeStatementId,
+          }).pipe(
+            Effect.catchTag("ResourceNotFoundException", () => Effect.void),
+          ),
+        ],
+        { concurrency: "unbounded" },
+      );
+    });
+
+    const upsertPermission = (permission: Lambda.AddPermissionRequest) =>
+      Lambda.addPermission(permission).pipe(
+        Effect.catchTag("ResourceConflictException", () =>
+          Effect.gen(function* () {
+            yield* Lambda.removePermission({
+              FunctionName: permission.FunctionName,
+              StatementId: permission.StatementId,
+            }).pipe(
+              Effect.catchTag("ResourceNotFoundException", () => Effect.void),
+            );
+            yield* Lambda.addPermission(permission);
+          }),
+        ),
+        retryFunctionMutation,
+      );
+
+    const upsertPublicFunctionUrlPermissions = Effect.fn(function* (
+      functionName: string,
+    ) {
+      yield* Effect.all(
+        [
+          upsertPermission({
+            FunctionName: functionName,
+            StatementId: publicUrlAccessStatementId,
+            Action: "lambda:InvokeFunctionUrl",
+            Principal: "*",
+            FunctionUrlAuthType: "NONE",
+          }),
+          upsertPermission({
+            FunctionName: functionName,
+            StatementId: publicUrlInvokeStatementId,
+            Action: "lambda:InvokeFunction",
+            Principal: "*",
+            InvokedViaFunctionUrl: true,
+          }),
+        ],
+        { concurrency: "unbounded" },
+      );
+    });
+
+    const createOrUpdateFunctionUrl = Effect.fn(function* ({
+      functionName,
+      url,
+      oldUrl,
+      currentFunctionUrl,
+    }: {
+      functionName: string;
+      url: FunctionProps["url"];
+      oldUrl?: FunctionProps["url"];
+      currentFunctionUrl?: string;
+    }) {
+      const desired = normalizeFunctionUrl(url);
+      const previous = normalizeFunctionUrl(oldUrl);
+      const hadFunctionUrl = previous !== undefined || !!currentFunctionUrl;
+
+      if (desired) {
+        yield* Effect.logDebug(`creating function url config ${functionName}`);
+        const shouldClearCors =
+          desired.cors === undefined && previous?.cors !== undefined;
+        const config = {
+          FunctionName: functionName,
+          AuthType: desired.authType,
+          Cors: desired.cors ?? (shouldClearCors ? {} : undefined),
+          InvokeMode: desired.invokeMode,
+        } satisfies
+          | Lambda.CreateFunctionUrlConfigRequest
+          | Lambda.UpdateFunctionUrlConfigRequest;
+        const { FunctionUrl } = yield* Lambda.createFunctionUrlConfig(
+          config,
+        ).pipe(
           Effect.catchTag("ResourceConflictException", () =>
-            Effect.gen(function* () {
-              yield* Lambda.removePermission({
-                FunctionName: permission.FunctionName,
-                StatementId: permission.StatementId,
-              }).pipe(
-                Effect.catchTag("ResourceNotFoundException", () => Effect.void),
-              );
-              yield* Lambda.addPermission(permission);
-            }),
+            Lambda.updateFunctionUrlConfig(config),
           ),
           retryFunctionMutation,
         );
 
-      const upsertPublicFunctionUrlPermissions = Effect.fn(function* (
-        functionName: string,
-      ) {
-        yield* Effect.all(
-          [
-            upsertPermission({
-              FunctionName: functionName,
-              StatementId: publicUrlAccessStatementId,
-              Action: "lambda:InvokeFunctionUrl",
-              Principal: "*",
-              FunctionUrlAuthType: "NONE",
-            }),
-            upsertPermission({
-              FunctionName: functionName,
-              StatementId: publicUrlInvokeStatementId,
-              Action: "lambda:InvokeFunction",
-              Principal: "*",
-              InvokedViaFunctionUrl: true,
-            }),
-          ],
-          { concurrency: "unbounded" },
-        );
-      });
-
-      const createOrUpdateFunctionUrl = Effect.fn(function* ({
-        functionName,
-        url,
-        oldUrl,
-        currentFunctionUrl,
-      }: {
-        functionName: string;
-        url: FunctionProps["url"];
-        oldUrl?: FunctionProps["url"];
-        currentFunctionUrl?: string;
-      }) {
-        const desired = normalizeFunctionUrl(url);
-        const previous = normalizeFunctionUrl(oldUrl);
-        const hadFunctionUrl = previous !== undefined || !!currentFunctionUrl;
-
-        if (desired) {
-          yield* Effect.logDebug(
-            `creating function url config ${functionName}`,
-          );
-          const shouldClearCors =
-            desired.cors === undefined && previous?.cors !== undefined;
-          const config = {
-            FunctionName: functionName,
-            AuthType: desired.authType,
-            Cors: desired.cors ?? (shouldClearCors ? {} : undefined),
-            InvokeMode: desired.invokeMode,
-          } satisfies
-            | Lambda.CreateFunctionUrlConfigRequest
-            | Lambda.UpdateFunctionUrlConfigRequest;
-          const { FunctionUrl } = yield* Lambda.createFunctionUrlConfig(
-            config,
-          ).pipe(
-            Effect.catchTag("ResourceConflictException", () =>
-              Lambda.updateFunctionUrlConfig(config),
-            ),
-            retryFunctionMutation,
-          );
-
-          if (desired.authType === "NONE") {
-            yield* upsertPublicFunctionUrlPermissions(functionName);
-          } else {
-            yield* removePublicFunctionUrlPermissions(functionName);
-          }
-
-          yield* Effect.logDebug(`created function url config ${functionName}`);
-          return FunctionUrl;
-        } else if (hadFunctionUrl) {
-          yield* Effect.logDebug(
-            `deleting function url config ${functionName}`,
-          );
-          yield* Effect.all([
-            Lambda.deleteFunctionUrlConfig({
-              FunctionName: functionName,
-            }).pipe(
-              retryFunctionMutation,
-              Effect.catchTag("ResourceNotFoundException", () => Effect.void),
-            ),
-            removePublicFunctionUrlPermissions(functionName),
-          ]);
-          yield* Effect.logDebug(`deleted function url config ${functionName}`);
+        if (desired.authType === "NONE") {
+          yield* upsertPublicFunctionUrlPermissions(functionName);
+        } else {
+          yield* removePublicFunctionUrlPermissions(functionName);
         }
-        return undefined;
-      });
 
-      const summary = ({ archive }: { archive: Uint8Array<ArrayBufferLike> }) =>
-        `${
-          archive.length >= 1024 * 1024
-            ? `${(archive.length / (1024 * 1024)).toFixed(2)}MB`
-            : archive.length >= 1024
-              ? `${(archive.length / 1024).toFixed(2)}KB`
-              : `${archive.length}B`
-        }`;
-
-      return {
-        stables: ["functionArn", "functionName", "roleName"],
-        diff: Effect.fn(function* ({ id, olds, news, output }) {
-          if (!isResolved(news)) return;
-          // If output is undefined (resource in creating state), defer to default diff
-          if (!output) {
-            return undefined;
-          }
-          if (
-            // function name changed
-            output.functionName !==
-            (yield* createFunctionName(id, news.functionName))
-          ) {
-            return { action: "replace" };
-          }
-          if (
-            !deepEqual(
-              normalizeFunctionUrl(olds.url),
-              normalizeFunctionUrl(news.url),
-            )
-          ) {
-            return { action: "update" };
-          }
-          if (output.code.hash !== (yield* bundleCode(id, news)).identityHash) {
-            // code changed
-            return { action: "update" };
-          }
-          if (
-            toTimeoutSeconds(olds.timeout) !== toTimeoutSeconds(news.timeout)
-          ) {
-            return { action: "update" };
-          }
-          if (
-            (olds.architecture ?? "x86_64") !== (news.architecture ?? "x86_64")
-          ) {
-            return { action: "update" };
-          }
-          if (
-            olds.reservedConcurrentExecutions !==
-            news.reservedConcurrentExecutions
-          ) {
-            return { action: "update" };
-          }
-        }),
-        read: Effect.fn(function* ({ id, olds, output }) {
-          const functionName =
-            output?.functionName ??
-            (yield* createFunctionName(id, olds?.functionName));
-          yield* Effect.logDebug(`reading function ${functionName}`);
-          const fn = yield* Lambda.getFunction({
+        yield* Effect.logDebug(`created function url config ${functionName}`);
+        return FunctionUrl;
+      } else if (hadFunctionUrl) {
+        yield* Effect.logDebug(`deleting function url config ${functionName}`);
+        yield* Effect.all([
+          Lambda.deleteFunctionUrlConfig({
             FunctionName: functionName,
           }).pipe(
-            Effect.map((r) => r.Configuration),
-            Effect.catchTag("ResourceNotFoundException", () =>
-              Effect.succeed(undefined),
-            ),
-          );
-          if (!fn?.FunctionArn || !fn.FunctionName || !fn.Role) {
-            return undefined;
-          }
-          const tagsResult = yield* Lambda.listTags({
-            Resource: fn.FunctionArn,
-          }).pipe(
-            Effect.map((r) => r.Tags ?? {}),
-            Effect.catchTag("ResourceNotFoundException", () =>
-              Effect.succeed({} as Record<string, string>),
-            ),
-          );
-          const functionUrl = yield* Lambda.getFunctionUrlConfig({
-            FunctionName: fn.FunctionName,
-          }).pipe(
-            Effect.map((f) => f.FunctionUrl),
-            Effect.retry({
-              while: (e: any) => e._tag === "ResourceConflictException",
-              schedule: Schedule.exponential(100),
-            }),
-            Effect.catchTag("ResourceNotFoundException", () =>
-              Effect.succeed(undefined),
-            ),
-          );
-          const reservedConcurrentExecutions =
-            yield* getReservedConcurrentExecutions(fn.FunctionName);
-          // Reuse the persisted output where we have it (e.g. code hash) so
-          // diff doesn't see drift it can't reconstruct from the API.
-          const attrs = {
-            ...output,
-            functionArn: fn.FunctionArn,
-            functionName: fn.FunctionName,
-            functionUrl,
-            roleArn: fn.Role,
-            roleName: output?.roleName ?? fn.Role.split("/").pop()!,
-            reservedConcurrentExecutions,
-          } as any;
-          return (yield* hasAlchemyTags(id, tagsResult))
-            ? attrs
-            : Unowned(attrs);
-        }),
-        // Account/region collection: exhaustively paginate `listFunctions`
-        // (its `Functions` items are `FunctionConfiguration`s, the same shape
-        // `read` pulls from `getFunction().Configuration`), then hydrate each
-        // into the exact `read` Attributes shape with a bounded fan-out. The
-        // code hash is not recoverable from the API (it lives in persisted
-        // state), so it is left empty — `delete`/nuke only needs the
-        // function/role identifiers.
-        list: () =>
-          Effect.gen(function* () {
-            const configs = yield* Lambda.listFunctions.items({}).pipe(
-              Stream.runCollect,
-              Effect.map((chunk) => Array.from(chunk)),
-            );
-            const rows = yield* Effect.forEach(
-              configs,
-              (fn) =>
-                Effect.gen(function* () {
-                  if (!fn.FunctionArn || !fn.FunctionName || !fn.Role) {
-                    return undefined;
-                  }
-                  const functionUrl = yield* Lambda.getFunctionUrlConfig({
-                    FunctionName: fn.FunctionName,
-                  }).pipe(
-                    Effect.map((f) => f.FunctionUrl),
-                    // No URL config (or the function vanished between the
-                    // list and the hydrate) — surface `undefined`, matching
-                    // `read`.
-                    Effect.catchTag("ResourceNotFoundException", () =>
-                      Effect.succeed(undefined),
-                    ),
-                  );
-                  const reservedConcurrentExecutions =
-                    yield* getReservedConcurrentExecutions(fn.FunctionName);
-                  return {
-                    functionArn: fn.FunctionArn,
-                    functionName: fn.FunctionName,
-                    functionUrl,
-                    roleArn: fn.Role,
-                    roleName: fn.Role.split("/").pop()!,
-                    code: { hash: "" },
-                    ...(reservedConcurrentExecutions === undefined
-                      ? {}
-                      : { reservedConcurrentExecutions }),
-                  } satisfies Function["Attributes"];
-                }),
-              { concurrency: 10 },
-            );
-            return rows.filter(
-              (row): row is Function["Attributes"] => row !== undefined,
-            );
+            retryFunctionMutation,
+            Effect.catchTag("ResourceNotFoundException", () => Effect.void),
+          ),
+          removePublicFunctionUrlPermissions(functionName),
+        ]);
+        yield* Effect.logDebug(`deleted function url config ${functionName}`);
+      }
+      return undefined;
+    });
+
+    const summary = ({ archive }: { archive: Uint8Array<ArrayBufferLike> }) =>
+      `${
+        archive.length >= 1024 * 1024
+          ? `${(archive.length / (1024 * 1024)).toFixed(2)}MB`
+          : archive.length >= 1024
+            ? `${(archive.length / 1024).toFixed(2)}KB`
+            : `${archive.length}B`
+      }`;
+
+    return {
+      stables: ["functionArn", "functionName", "roleName"] satisfies Extract<
+        keyof Function["Attributes"],
+        string
+      >[],
+      diff: Effect.fn(function* ({
+        id,
+        olds,
+        news,
+        output,
+      }: FunctionLifecycleInput<"diff">) {
+        if (!isResolved(news)) return;
+        // If output is undefined (resource in creating state), defer to default diff
+        if (!output) {
+          return undefined;
+        }
+        if (
+          // function name changed
+          output.functionName !==
+          (yield* createFunctionName(id, news.functionName))
+        ) {
+          return { action: "replace" } as const;
+        }
+        if (
+          !deepEqual(
+            normalizeFunctionUrl(olds.url),
+            normalizeFunctionUrl(news.url),
+          )
+        ) {
+          return { action: "update" } as const;
+        }
+        if (output.code.hash !== (yield* bundleCode(id, news)).identityHash) {
+          // code changed
+          return { action: "update" } as const;
+        }
+        if (toTimeoutSeconds(olds.timeout) !== toTimeoutSeconds(news.timeout)) {
+          return { action: "update" } as const;
+        }
+        if (
+          (olds.architecture ?? "x86_64") !== (news.architecture ?? "x86_64")
+        ) {
+          return { action: "update" } as const;
+        }
+        if (
+          olds.reservedConcurrentExecutions !==
+          news.reservedConcurrentExecutions
+        ) {
+          return { action: "update" } as const;
+        }
+      }),
+      read: Effect.fn(function* ({
+        id,
+        olds,
+        output,
+      }: FunctionLifecycleInput<"read">) {
+        const functionName =
+          output?.functionName ??
+          (yield* createFunctionName(id, olds?.functionName));
+        yield* Effect.logDebug(`reading function ${functionName}`);
+        const fn = yield* Lambda.getFunction({
+          FunctionName: functionName,
+        }).pipe(
+          Effect.map((r) => r.Configuration),
+          Effect.catchTag("ResourceNotFoundException", () =>
+            Effect.succeed(undefined),
+          ),
+        );
+        if (!fn?.FunctionArn || !fn.FunctionName || !fn.Role) {
+          return undefined;
+        }
+        const tagsResult = yield* Lambda.listTags({
+          Resource: fn.FunctionArn,
+        }).pipe(
+          Effect.map((r) => r.Tags ?? {}),
+          Effect.catchTag("ResourceNotFoundException", () =>
+            Effect.succeed({} as Record<string, string>),
+          ),
+        );
+        const functionUrl = yield* Lambda.getFunctionUrlConfig({
+          FunctionName: fn.FunctionName,
+        }).pipe(
+          Effect.map((f) => f.FunctionUrl),
+          Effect.retry({
+            while: (e: any) => e._tag === "ResourceConflictException",
+            schedule: Schedule.exponential(100),
           }),
-
-        precreate: Effect.fn(function* ({ id, news, session }) {
-          const { accountId, region } = yield* AWSEnvironment.current;
-          const { roleName, functionName, roleArn } = yield* createNames(
-            id,
-            news.functionName,
+          Effect.catchTag("ResourceNotFoundException", () =>
+            Effect.succeed(undefined),
+          ),
+        );
+        const reservedConcurrentExecutions =
+          yield* getReservedConcurrentExecutions(fn.FunctionName);
+        // Reuse the persisted output where we have it (e.g. code hash) so
+        // diff doesn't see drift it can't reconstruct from the API.
+        const attrs = {
+          ...output,
+          functionArn: fn.FunctionArn,
+          functionName: fn.FunctionName,
+          functionUrl,
+          roleArn: fn.Role,
+          roleName: output?.roleName ?? fn.Role.split("/").pop()!,
+          reservedConcurrentExecutions,
+        } as any;
+        return (yield* hasAlchemyTags(id, tagsResult)) ? attrs : Unowned(attrs);
+      }),
+      // Account/region collection: exhaustively paginate `listFunctions`
+      // (its `Functions` items are `FunctionConfiguration`s, the same shape
+      // `read` pulls from `getFunction().Configuration`), then hydrate each
+      // into the exact `read` Attributes shape with a bounded fan-out. The
+      // code hash is not recoverable from the API (it lives in persisted
+      // state), so it is left empty — `delete`/nuke only needs the
+      // function/role identifiers.
+      list: () =>
+        Effect.gen(function* () {
+          const configs = yield* Lambda.listFunctions.items({}).pipe(
+            Stream.runCollect,
+            Effect.map((chunk) => Array.from(chunk)),
           );
-
-          const role = yield* createRoleIfNotExists({
-            id,
-            roleName,
-            vpc: news.vpc,
-          });
-
-          // Mock code for the pre-created stub. It responds 503 (rather than a
-          // bare 200) so that, during the brief window where the real
-          // code/config update is still `InProgress`, a Function URL hit serves
-          // an honest "not ready" signal instead of a successful-but-empty 200.
-          // Downstream readiness probes already retry on non-200, so they wait
-          // for the real handler to go live without the provider blocking.
-          const code = new TextEncoder().encode(
-            `export default () => ({ statusCode: 503, headers: { "content-type": "application/json" }, body: JSON.stringify({ error: "function initializing" }) })`,
+          const rows = yield* Effect.forEach(
+            configs,
+            (fn) =>
+              Effect.gen(function* () {
+                if (!fn.FunctionArn || !fn.FunctionName || !fn.Role) {
+                  return undefined;
+                }
+                const functionUrl = yield* Lambda.getFunctionUrlConfig({
+                  FunctionName: fn.FunctionName,
+                }).pipe(
+                  Effect.map((f) => f.FunctionUrl),
+                  // No URL config (or the function vanished between the
+                  // list and the hydrate) — surface `undefined`, matching
+                  // `read`.
+                  Effect.catchTag("ResourceNotFoundException", () =>
+                    Effect.succeed(undefined),
+                  ),
+                );
+                const reservedConcurrentExecutions =
+                  yield* getReservedConcurrentExecutions(fn.FunctionName);
+                return {
+                  functionArn: fn.FunctionArn,
+                  functionName: fn.FunctionName,
+                  functionUrl,
+                  roleArn: fn.Role,
+                  roleName: fn.Role.split("/").pop()!,
+                  code: { hash: "" },
+                  ...(reservedConcurrentExecutions === undefined
+                    ? {}
+                    : { reservedConcurrentExecutions }),
+                } satisfies Function["Attributes"];
+              }),
+            { concurrency: 10 },
           );
-          const archive = yield* zipCode(code);
-          const hash = yield* hashBundle(code);
-          yield* createOrUpdateFunction({
-            id,
-            news,
-            roleArn: role.Role.Arn,
-            archive,
-            hash,
-            functionName,
-            env: alchemyEnv,
-            session,
-          });
-
-          return {
-            functionArn: `arn:aws:lambda:${region}:${accountId}:function:${functionName}`,
-            functionName,
-            functionUrl: undefined,
-            roleName,
-            code: {
-              hash,
-            },
-            roleArn,
-          };
+          return rows.filter(
+            (row): row is Function["Attributes"] => row !== undefined,
+          );
         }),
-        reconcile: Effect.fn(function* ({
+
+      precreate: Effect.fn(function* ({
+        id,
+        news,
+        session,
+      }: FunctionLifecycleInput<"precreate">) {
+        const { accountId, region } = yield* AWSEnvironment.current;
+        const { roleName, functionName, roleArn } = yield* createNames(
+          id,
+          news.functionName,
+        );
+
+        const role = yield* createRoleIfNotExists({
+          id,
+          roleName,
+          vpc: news.vpc,
+        });
+
+        // Mock code for the pre-created stub. It responds 503 (rather than a
+        // bare 200) so that, during the brief window where the real
+        // code/config update is still `InProgress`, a Function URL hit serves
+        // an honest "not ready" signal instead of a successful-but-empty 200.
+        // Downstream readiness probes already retry on non-200, so they wait
+        // for the real handler to go live without the provider blocking.
+        const code = new TextEncoder().encode(
+          `export default () => ({ statusCode: 503, headers: { "content-type": "application/json" }, body: JSON.stringify({ error: "function initializing" }) })`,
+        );
+        const archive = yield* zipCode(code);
+        const hash = yield* hashBundle(code);
+        yield* createOrUpdateFunction({
           id,
           news,
-          olds,
-          bindings,
-          output,
+          roleArn: role.Role.Arn,
+          archive,
+          hash,
+          functionName,
+          env: alchemyEnv,
           session,
-        }) {
-          const { roleName, policyName, functionName, functionArn } =
-            yield* createNames(id, news.functionName);
+        });
 
-          const roleArn =
-            output?.roleArn ??
-            (yield* createRoleIfNotExists({ id, roleName, vpc: news.vpc })).Role
-              .Arn;
+        return {
+          functionArn: `arn:aws:lambda:${region}:${accountId}:function:${functionName}`,
+          functionName,
+          functionUrl: undefined,
+          roleName,
+          code: {
+            hash,
+          },
+          roleArn,
+        };
+      }),
+      reconcile: Effect.fn(function* ({
+        id,
+        news,
+        olds,
+        bindings,
+        output,
+        session,
+      }: FunctionLifecycleInput<"reconcile">) {
+        const { roleName, policyName, functionName, functionArn } =
+          yield* createNames(id, news.functionName);
 
-          const env = yield* attachBindings({
-            roleName,
-            policyName,
-            functionArn,
+        const roleArn =
+          output?.roleArn ??
+          (yield* createRoleIfNotExists({ id, roleName, vpc: news.vpc })).Role
+            .Arn;
+
+        const env = yield* attachBindings({
+          roleName,
+          policyName,
+          functionArn,
+          functionName,
+          bindings,
+        });
+
+        const { identityHash, buildArchive } = yield* bundleCode(id, news);
+        const { archive, archiveHash } = yield* buildArchive;
+
+        yield* createOrUpdateFunction({
+          id,
+          news,
+          roleArn,
+          archive,
+          hash: archiveHash,
+          env: {
+            ...env,
+            ...news.env,
+          },
+          functionName,
+          preferUpdate: output !== undefined,
+          session,
+        });
+
+        const reservedConcurrentExecutions =
+          yield* syncReservedConcurrentExecutions({
             functionName,
-            bindings,
+            reservedConcurrentExecutions: news.reservedConcurrentExecutions,
           });
 
-          const { identityHash, buildArchive } = yield* bundleCode(id, news);
-          const { archive, archiveHash } = yield* buildArchive;
+        yield* syncEventInvokeConfig({
+          functionName,
+          config: news.eventInvokeConfig,
+        });
 
-          yield* createOrUpdateFunction({
-            id,
-            news,
-            roleArn,
-            archive,
-            hash: archiveHash,
-            env: {
-              ...env,
-              ...news.env,
-            },
-            functionName,
-            preferUpdate: output !== undefined,
-            session,
-          });
+        const functionUrl = yield* createOrUpdateFunctionUrl({
+          functionName,
+          url: news.url,
+          oldUrl: olds?.url,
+          currentFunctionUrl: output?.functionUrl,
+        });
 
-          const reservedConcurrentExecutions =
-            yield* syncReservedConcurrentExecutions({
-              functionName,
-              reservedConcurrentExecutions: news.reservedConcurrentExecutions,
-            });
+        yield* session.note(summary({ archive }));
 
-          yield* syncEventInvokeConfig({
-            functionName,
-            config: news.eventInvokeConfig,
-          });
-
-          const functionUrl = yield* createOrUpdateFunctionUrl({
-            functionName,
-            url: news.url,
-            oldUrl: olds?.url,
-            currentFunctionUrl: output?.functionUrl,
-          });
-
-          yield* session.note(summary({ archive }));
-
-          return {
-            ...output,
-            functionArn,
-            functionName,
-            functionUrl: functionUrl as any,
-            roleName,
-            roleArn,
-            code: {
-              hash: identityHash,
-            },
-            reservedConcurrentExecutions,
-          };
-        }),
-        delete: Effect.fn(function* ({ output }) {
-          // The role may already be gone (e.g. deleted out-of-band or by a
-          // previous partial delete) — treat every step as idempotent.
-          yield* iam
-            .listRolePolicies({
-              RoleName: output.roleName,
-            })
-            .pipe(
-              Effect.flatMap((policies) =>
-                Effect.all(
-                  (policies.PolicyNames ?? []).map((policyName) =>
-                    iam
-                      .deleteRolePolicy({
-                        RoleName: output.roleName,
-                        PolicyName: policyName,
-                      })
-                      .pipe(
-                        Effect.catchTag(
-                          "NoSuchEntityException",
-                          () => Effect.void,
-                        ),
+        return {
+          ...output,
+          functionArn,
+          functionName,
+          functionUrl: functionUrl as any,
+          roleName,
+          roleArn,
+          code: {
+            hash: identityHash,
+          },
+          reservedConcurrentExecutions,
+        };
+      }),
+      delete: Effect.fn(function* ({
+        output,
+      }: FunctionLifecycleInput<"delete">) {
+        // The role may already be gone (e.g. deleted out-of-band or by a
+        // previous partial delete) — treat every step as idempotent.
+        yield* iam
+          .listRolePolicies({
+            RoleName: output.roleName,
+          })
+          .pipe(
+            Effect.flatMap((policies) =>
+              Effect.all(
+                (policies.PolicyNames ?? []).map((policyName) =>
+                  iam
+                    .deleteRolePolicy({
+                      RoleName: output.roleName,
+                      PolicyName: policyName,
+                    })
+                    .pipe(
+                      Effect.catchTag(
+                        "NoSuchEntityException",
+                        () => Effect.void,
                       ),
-                  ),
+                    ),
                 ),
-              ),
-              Effect.catchTag("NoSuchEntityException", () => Effect.void),
-            );
-
-          yield* iam
-            .listAttachedRolePolicies({
-              RoleName: output.roleName,
-            })
-            .pipe(
-              Effect.flatMap((policies) =>
-                Effect.all(
-                  (policies.AttachedPolicies ?? []).map((policy) =>
-                    iam
-                      .detachRolePolicy({
-                        RoleName: output.roleName,
-                        PolicyArn: policy.PolicyArn!,
-                      })
-                      .pipe(
-                        Effect.catchTag(
-                          "NoSuchEntityException",
-                          () => Effect.void,
-                        ),
-                      ),
-                  ),
-                ),
-              ),
-              Effect.catchTag("NoSuchEntityException", () => Effect.void),
-            );
-
-          yield* Lambda.deleteFunction({
-            FunctionName: output.functionName,
-          }).pipe(
-            Effect.catchTag("ResourceNotFoundException", () => Effect.void),
-          );
-
-          yield* iam
-            .deleteRole({
-              RoleName: output.roleName,
-            })
-            .pipe(Effect.catchTag("NoSuchEntityException", () => Effect.void));
-          return null as any;
-        }),
-        tail: ({ output }) => {
-          const runTailSession = Effect.gen(function* () {
-            const { accountId, region } = yield* AWSEnvironment.current;
-
-            const logGroupArn = `arn:aws:logs:${region}:${accountId}:log-group:/aws/lambda/${output.functionName}`;
-            const response = yield* logs.startLiveTail({
-              logGroupIdentifiers: [logGroupArn],
-            });
-
-            if (!response.responseStream) {
-              return Stream.empty as Stream.Stream<LogLine>;
-            }
-
-            return response.responseStream.pipe(
-              Stream.flatMap((event) => {
-                if ("sessionUpdate" in event && event.sessionUpdate) {
-                  const lines: LogLine[] = (
-                    event.sessionUpdate.sessionResults ?? []
-                  ).flatMap((result) => {
-                    if (!result.message) return [];
-                    return [
-                      {
-                        timestamp: new Date(result.timestamp ?? Date.now()),
-                        message: result.message.trimEnd(),
-                      },
-                    ];
-                  });
-                  return Stream.fromIterable(lines);
-                }
-                return Stream.empty;
-              }),
-            );
-          });
-
-          return Stream.unwrap(runTailSession).pipe(
-            Stream.retry(Schedule.spaced("1 second")),
-          );
-        },
-        logs: ({
-          output,
-          options,
-        }: {
-          output: Function["Attributes"];
-          options: LogsInput;
-        }) =>
-          logs
-            .filterLogEvents({
-              logGroupName: `/aws/lambda/${output.functionName}`,
-              startTime: options.since?.getTime(),
-              limit: options.limit ?? 100,
-            })
-            .pipe(
-              Effect.map((response) =>
-                (response.events ?? []).flatMap((event): LogLine[] => {
-                  if (!event.message) return [];
-                  return [
-                    {
-                      timestamp: new Date(event.timestamp ?? Date.now()),
-                      message: event.message.trimEnd(),
-                    },
-                  ];
-                }),
-              ),
-              Effect.catchTag("ResourceNotFoundException", () =>
-                Effect.succeed([] as LogLine[]),
               ),
             ),
-      };
-    }),
-  );
+            Effect.catchTag("NoSuchEntityException", () => Effect.void),
+          );
+
+        yield* iam
+          .listAttachedRolePolicies({
+            RoleName: output.roleName,
+          })
+          .pipe(
+            Effect.flatMap((policies) =>
+              Effect.all(
+                (policies.AttachedPolicies ?? []).map((policy) =>
+                  iam
+                    .detachRolePolicy({
+                      RoleName: output.roleName,
+                      PolicyArn: policy.PolicyArn!,
+                    })
+                    .pipe(
+                      Effect.catchTag(
+                        "NoSuchEntityException",
+                        () => Effect.void,
+                      ),
+                    ),
+                ),
+              ),
+            ),
+            Effect.catchTag("NoSuchEntityException", () => Effect.void),
+          );
+
+        yield* Lambda.deleteFunction({
+          FunctionName: output.functionName,
+        }).pipe(
+          Effect.catchTag("ResourceNotFoundException", () => Effect.void),
+        );
+
+        yield* iam
+          .deleteRole({
+            RoleName: output.roleName,
+          })
+          .pipe(Effect.catchTag("NoSuchEntityException", () => Effect.void));
+        return null as any;
+      }),
+      tail: ({ output }: { output: Function["Attributes"] }) => {
+        const runTailSession = Effect.gen(function* () {
+          const { accountId, region } = yield* AWSEnvironment.current;
+
+          const logGroupArn = `arn:aws:logs:${region}:${accountId}:log-group:/aws/lambda/${output.functionName}`;
+          const response = yield* logs.startLiveTail({
+            logGroupIdentifiers: [logGroupArn],
+          });
+
+          if (!response.responseStream) {
+            return Stream.empty as Stream.Stream<LogLine>;
+          }
+
+          return response.responseStream.pipe(
+            Stream.flatMap((event) => {
+              if ("sessionUpdate" in event && event.sessionUpdate) {
+                const lines: LogLine[] = (
+                  event.sessionUpdate.sessionResults ?? []
+                ).flatMap((result) => {
+                  if (!result.message) return [];
+                  return [
+                    {
+                      timestamp: new Date(result.timestamp ?? Date.now()),
+                      message: result.message.trimEnd(),
+                    },
+                  ];
+                });
+                return Stream.fromIterable(lines);
+              }
+              return Stream.empty;
+            }),
+          );
+        });
+
+        return Stream.unwrap(runTailSession).pipe(
+          Stream.retry(Schedule.spaced("1 second")),
+        );
+      },
+      logs: ({
+        output,
+        options,
+      }: {
+        output: Function["Attributes"];
+        options: LogsInput;
+      }) =>
+        logs
+          .filterLogEvents({
+            logGroupName: `/aws/lambda/${output.functionName}`,
+            startTime: options.since?.getTime(),
+            limit: options.limit ?? 100,
+          })
+          .pipe(
+            Effect.map((response) =>
+              (response.events ?? []).flatMap((event): LogLine[] => {
+                if (!event.message) return [];
+                return [
+                  {
+                    timestamp: new Date(event.timestamp ?? Date.now()),
+                    message: event.message.trimEnd(),
+                  },
+                ];
+              }),
+            ),
+            Effect.catchTag("ResourceNotFoundException", () =>
+              Effect.succeed([] as LogLine[]),
+            ),
+          ),
+    };
+  });
+
+export const LiveFunctionProvider = () =>
+  Provider.effect(Function, makeFunctionProvider());

--- a/packages/alchemy/src/AWS/Lambda/FunctionProvider.ts
+++ b/packages/alchemy/src/AWS/Lambda/FunctionProvider.ts
@@ -1,0 +1,300 @@
+/**
+ * Provider selection for {@link Function}: the live (deploy) provider, or —
+ * under `alchemy dev` — the Live Lambda provider, which deploys a bridge in
+ * place of the user's code, runs the handler locally, and proxies every
+ * invocation of the real Lambda to the developer's machine.
+ */
+import * as Deferred from "effect/Deferred";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as Result from "effect/Result";
+import * as Scope from "effect/Scope";
+import * as Stream from "effect/Stream";
+import { AlchemyContext } from "../../AlchemyContext.ts";
+import * as Bundle from "../../Bundle/Bundle.ts";
+import type { ScopedPlanStatusSession } from "../../Cli/Cli.ts";
+import { isResolved } from "../../Diff.ts";
+import * as ProviderLayer from "../../Local/ProviderLayer.ts";
+import * as RpcProvider from "../../Local/RpcProvider.ts";
+import type { ResourceBinding } from "../../Resource.ts";
+import { structuralSignature } from "../../Util/StructuralSignature.ts";
+import type { PolicyStatement } from "../IAM/Policy.ts";
+import { AWS_LOCAL_ENTRY_URL } from "../LocalRuntime.ts";
+import {
+  Function,
+  LiveFunctionProvider,
+  makeFunctionProvider,
+  resolveFunctionBundleConfig,
+  toTimeoutSeconds,
+  type FunctionLifecycleInput,
+  type FunctionProps,
+} from "./Function.ts";
+import { bridgeCodeBundle } from "./Live/BridgeBundle.ts";
+import { LiveLambdaRuntime } from "./Live/LiveRuntime.ts";
+
+export const FunctionProvider = () =>
+  ProviderLayer.select({
+    live: () => LiveFunctionProvider(),
+    local: () => LocalFunctionProvider(),
+  });
+
+/**
+ * Sessions crossing the RPC boundary lose their callables (functions
+ * serialize to `null`) — fall back to plain logging.
+ */
+const usableSession = (
+  session: ScopedPlanStatusSession | undefined,
+): ScopedPlanStatusSession =>
+  typeof session?.note === "function"
+    ? session
+    : {
+        note: (note: string) => Effect.logDebug(note),
+        emit: () => Effect.void,
+        done: () => Effect.void,
+      };
+
+/**
+ * Debugging through a live invocation needs more headroom than Lambda's 3s
+ * default — floor the deployed bridge's timeout at 60s. The bridge itself
+ * fails fast (16s) when no dev session is connected.
+ */
+const devTimeout = (
+  timeout: Duration.Duration | undefined,
+): Duration.Duration =>
+  Duration.seconds(Math.max(toTimeoutSeconds(timeout) ?? 3, 60));
+
+const sanitizeId = (id: string) => id.replace(/[^a-zA-Z0-9_-]/g, "-");
+
+export const LocalFunctionProvider = () =>
+  RpcProvider.effect(
+    Function,
+    AWS_LOCAL_ENTRY_URL,
+    Effect.gen(function* () {
+      const live = yield* makeFunctionProvider({
+        bundleCode: () => bridgeCodeBundle,
+      });
+      const runtime = yield* LiveLambdaRuntime;
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const { dotAlchemy } = yield* AlchemyContext;
+      const rootScope = yield* Effect.scope;
+
+      /**
+       * Deploy-time wiring for the bridge, attached as a synthetic binding:
+       * AppSync endpoints + function id via env, and IAM permissions to
+       * connect/publish/subscribe on the shared Event API.
+       */
+      const liveBinding = (
+        id: string,
+      ): ResourceBinding<Function["Binding"]> => ({
+        sid: "alchemy:live-lambda",
+        data: {
+          env: {
+            ALCHEMY_LIVE_APPSYNC_HTTP: runtime.eventApi.httpEndpoint,
+            ALCHEMY_LIVE_APPSYNC_REALTIME: runtime.eventApi.realtimeEndpoint,
+            ALCHEMY_LIVE_FUNCTION_ID: id,
+          },
+          policyStatements: [
+            {
+              Sid: "AlchemyLiveLambda",
+              Effect: "Allow",
+              Action: [
+                "appsync:EventConnect",
+                "appsync:EventPublish",
+                "appsync:EventSubscribe",
+              ],
+              Resource: [
+                runtime.eventApi.apiArn,
+                `${runtime.eventApi.apiArn}/*`,
+              ],
+            } satisfies PolicyStatement,
+          ],
+        },
+      });
+
+      const devInputs = <
+        T extends {
+          news: FunctionProps;
+          bindings: ResourceBinding<Function["Binding"]>[];
+          session: ScopedPlanStatusSession;
+        },
+      >(
+        id: string,
+        args: T,
+      ): T => ({
+        ...args,
+        news: {
+          ...args.news,
+          handler: "handler",
+          timeout: devTimeout(args.news.timeout),
+        },
+        bindings: [...args.bindings, liveBinding(id)],
+        session: usableSession(args.session),
+      });
+
+      const instances = new Map<
+        string,
+        {
+          signature: string;
+          scope: Scope.Closeable;
+          ready: Deferred.Deferred<void>;
+        }
+      >();
+
+      const dropInstance = Effect.fn(function* (id: string) {
+        const existing = instances.get(id);
+        if (!existing) return;
+        instances.delete(id);
+        yield* Scope.close(existing.scope, Exit.void);
+      });
+
+      /**
+       * Watch → rebuild → hand the fresh bundle to {@link LiveLambdaRuntime}.
+       * Lives in its own scope so a props change (or delete) can tear it down.
+       */
+      const runWatch = Effect.fn(function* (
+        id: string,
+        props: FunctionProps,
+        ready: Deferred.Deferred<void>,
+      ) {
+        const config = yield* resolveFunctionBundleConfig(props);
+        // Inside the project tree so the bundle's externalized imports
+        // (@aws-sdk/*, native installs) resolve from the project's own
+        // node_modules.
+        const bundleDir = path.join(
+          dotAlchemy,
+          "local",
+          "aws",
+          "lambda",
+          sanitizeId(id),
+        );
+        yield* fs.makeDirectory(bundleDir, { recursive: true });
+        const handlerName = props.handler ?? "default";
+        let start = Date.now();
+        let status: "start" | "update" = "start";
+        yield* Bundle.watch(config.inputOptions, {
+          ...config.outputOptions,
+          dir: bundleDir,
+        }).pipe(
+          Stream.tap((event) => {
+            if (event._tag === "Start") {
+              start = Date.now();
+            } else if (event._tag === "Error") {
+              return Effect.logError(`[${id}] Build error`, event.error);
+            }
+            return Effect.void;
+          }),
+          Stream.filterMap((event) =>
+            event._tag === "Success"
+              ? Result.succeed(event.output)
+              : Result.failVoid,
+          ),
+          Stream.mapEffect((bundle) =>
+            Effect.gen(function* () {
+              for (const file of bundle.files) {
+                const filePath = path.join(bundleDir, file.path);
+                if (typeof file.content === "string") {
+                  yield* fs.writeFileString(filePath, file.content);
+                } else {
+                  yield* fs.writeFile(filePath, file.content);
+                }
+              }
+              yield* runtime.setTarget(id, {
+                bundlePath: path.join(bundleDir, "index.js"),
+                handler: handlerName,
+              });
+              yield* Effect.log(
+                `[${id}] ${status === "start" ? "Serving locally" : "Rebuilt"} in ${Date.now() - start}ms`,
+              );
+              status = "update";
+              yield* Deferred.succeed(ready, undefined);
+            }).pipe(
+              Effect.catchCause((cause) =>
+                Effect.logError(`[${id}] Failed to serve locally`, cause),
+              ),
+            ),
+          ),
+          Stream.runDrain,
+        );
+      });
+
+      const ensureInstance = Effect.fn(function* (
+        id: string,
+        props: FunctionProps,
+        bindings: ResourceBinding<Function["Binding"]>[],
+      ) {
+        const signature = yield* structuralSignature({ props, bindings });
+        const existing = instances.get(id);
+        if (existing?.signature === signature) {
+          return yield* Deferred.await(existing.ready);
+        }
+        if (existing) {
+          yield* dropInstance(id);
+        }
+        const scope = yield* Scope.fork(rootScope);
+        const ready = yield* Deferred.make<void>();
+        yield* runWatch(id, props, ready).pipe(Effect.forkIn(scope));
+        instances.set(id, { signature, scope, ready });
+        // Don't return until the first local build is servable — otherwise
+        // an eager invocation of the freshly-deployed bridge would race the
+        // build and fail with "not being served".
+        yield* Deferred.await(ready).pipe(
+          Effect.timeoutOrElse({
+            duration: "120 seconds",
+            orElse: () =>
+              Effect.die(new Error(`[${id}] initial local build timed out`)),
+          }),
+        );
+      });
+
+      return {
+        stables: live.stables,
+        read: live.read,
+        list: live.list,
+        tail: live.tail,
+        logs: live.logs,
+        diff: Effect.fn(function* ({
+          id,
+          olds,
+          news,
+          newBindings,
+        }: FunctionLifecycleInput<"diff">) {
+          if (!isResolved(news) || !isResolved(newBindings)) return undefined;
+          if (olds !== undefined && olds.functionName !== news.functionName) {
+            return { action: "replace" as const };
+          }
+          const signature = yield* structuralSignature({
+            props: news,
+            bindings: newBindings,
+          });
+          if (instances.get(id)?.signature === signature) {
+            return { action: "noop" as const };
+          }
+          return { action: "update" as const };
+        }),
+        precreate: Effect.fn(function* (
+          args: FunctionLifecycleInput<"precreate">,
+        ) {
+          return yield* live.precreate!(devInputs(args.id, args));
+        }),
+        reconcile: Effect.fn(function* (
+          args: FunctionLifecycleInput<"reconcile">,
+        ) {
+          const attributes = yield* live.reconcile(devInputs(args.id, args));
+          yield* ensureInstance(args.id, args.news, args.bindings);
+          return attributes;
+        }),
+        delete: Effect.fn(function* (args: FunctionLifecycleInput<"delete">) {
+          yield* dropInstance(args.id);
+          yield* runtime.removeTarget(args.id);
+          yield* live.delete({
+            ...args,
+            session: usableSession(args.session),
+          });
+        }),
+      };
+    }),
+  );

--- a/packages/alchemy/src/AWS/Lambda/Live/AppSyncEvents.ts
+++ b/packages/alchemy/src/AWS/Lambda/Live/AppSyncEvents.ts
@@ -1,0 +1,362 @@
+/**
+ * Minimal AWS AppSync Events client: SigV4-authenticated WebSocket
+ * subscriptions plus signed HTTPS publishes.
+ *
+ * Mirrors the protocol SST v3 uses for its live bridge:
+ * - Connect: `wss://{realtime}/event/realtime` with subprotocols
+ *   `aws-appsync-event-ws` and `header-{base64url(signed headers)}`, then a
+ *   `connection_init` / `connection_ack` handshake.
+ * - Subscribe: a `subscribe` frame whose `authorization` is the signed header
+ *   set for `POST https://{http}/event` with body `{"channel": ...}`.
+ * - Publish: a plain SigV4-signed `POST https://{http}/event` (never over the
+ *   WebSocket).
+ * - Keepalive: the server sends `ka` frames; missing them for
+ *   `connectionTimeoutMs` means the connection is dead.
+ *
+ * Plain TypeScript (global `WebSocket` + `fetch`, available on Node >= 22 and
+ * Bun) because it is bundled into the bridge Lambda; the local (Effect) side
+ * wraps it.
+ */
+import { signRequest, type AwsCredentials } from "./SigV4.ts";
+
+export interface AppSyncEventsClientOptions {
+  /** e.g. `abc123.appsync-api.us-east-1.amazonaws.com` */
+  httpEndpoint: string;
+  /** e.g. `abc123.appsync-realtime-api.us-east-1.amazonaws.com` */
+  realtimeEndpoint: string;
+  region: string;
+  getCredentials: () => Promise<AwsCredentials>;
+  log?: (message: string) => void;
+}
+
+interface Subscription {
+  channel: string;
+  handler: (event: string) => void;
+}
+
+const SUBSCRIBE_TIMEOUT_MS = 5_000;
+const CONNECT_TIMEOUT_MS = 10_000;
+const RECONNECT_DELAY_MS = 5_000;
+
+export class AppSyncEventsClient {
+  private ws: WebSocket | undefined;
+  private connecting: Promise<void> | undefined;
+  private subscriptions = new Map<string, Subscription>();
+  private acks = new Map<string, (error?: Error) => void>();
+  private kaTimeoutMs = 5 * 60_000;
+  private kaTimer: ReturnType<typeof setTimeout> | undefined;
+  private lastActivity = 0;
+  private nextSubscriptionId = 0;
+  private closed = false;
+
+  constructor(private readonly options: AppSyncEventsClientOptions) {}
+
+  private log(message: string) {
+    this.options.log?.(`[appsync] ${message}`);
+  }
+
+  /**
+   * Signed header set authorizing a `POST /event` with the given body — used
+   * both as the WebSocket connect subprotocol payload and per-subscription
+   * authorization.
+   */
+  private async getAuth(body: unknown): Promise<Record<string, string>> {
+    const credentials = await this.options.getCredentials();
+    const bodyJson = JSON.stringify(body);
+    const url = new URL(`https://${this.options.httpEndpoint}/event`);
+    const signed = signRequest(
+      {
+        method: "POST",
+        url,
+        headers: {
+          accept: "application/json, text/javascript",
+          "content-encoding": "amz-1.0",
+          "content-type": "application/json; charset=UTF-8",
+        },
+        body: bodyJson,
+      },
+      {
+        credentials,
+        region: this.options.region,
+        service: "appsync",
+      },
+    );
+    const auth: Record<string, string> = {
+      accept: signed.accept,
+      "content-encoding": signed["content-encoding"],
+      "content-type": signed["content-type"],
+      host: signed.host,
+      "x-amz-date": signed["x-amz-date"],
+      Authorization: signed.authorization,
+    };
+    if (signed["x-amz-security-token"]) {
+      auth["X-Amz-Security-Token"] = signed["x-amz-security-token"];
+    }
+    return auth;
+  }
+
+  /** Publish one event (JSON-encoded) to a channel over signed HTTPS. */
+  async publish(channel: string, event: unknown): Promise<void> {
+    const credentials = await this.options.getCredentials();
+    const body = JSON.stringify({
+      channel,
+      events: [JSON.stringify(event)],
+    });
+    const url = new URL(`https://${this.options.httpEndpoint}/event`);
+    const headers = signRequest(
+      {
+        method: "POST",
+        url,
+        headers: { "content-type": "application/json" },
+        body,
+      },
+      {
+        credentials,
+        region: this.options.region,
+        service: "appsync",
+      },
+    );
+    const response = await fetch(url, { method: "POST", headers, body });
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      throw new Error(
+        `AppSync publish to ${channel} failed with ${response.status}: ${text}`,
+      );
+    }
+    // Drain so the socket can be reused.
+    await response.arrayBuffer().catch(() => undefined);
+  }
+
+  /**
+   * Subscribe to a channel. The subscription survives reconnects. Returns an
+   * unsubscribe function.
+   */
+  async subscribe(
+    channel: string,
+    handler: (event: string) => void,
+  ): Promise<() => void> {
+    const id = `sub-${this.nextSubscriptionId++}`;
+    // Connect BEFORE registering: `connect` re-subscribes everything already
+    // in the map, so registering first would double-subscribe this id.
+    await this.ensureConnected();
+    this.subscriptions.set(id, { channel, handler });
+    try {
+      await this.sendSubscribe(id, channel);
+    } catch (error) {
+      this.subscriptions.delete(id);
+      throw error;
+    }
+    return () => {
+      this.subscriptions.delete(id);
+      try {
+        this.ws?.send(JSON.stringify({ type: "unsubscribe", id }));
+      } catch {
+        // connection already gone — nothing to clean up remotely
+      }
+    };
+  }
+
+  /**
+   * Ensure the WebSocket is live. Detects zombie connections (e.g. after a
+   * Lambda sandbox freeze/thaw) by checking the keepalive recency and forces
+   * a reconnect when stale.
+   */
+  async ensureHealthy(): Promise<void> {
+    if (
+      this.ws?.readyState === WebSocket.OPEN &&
+      Date.now() - this.lastActivity < this.kaTimeoutMs
+    ) {
+      return;
+    }
+    this.teardown();
+    await this.ensureConnected();
+  }
+
+  private ensureConnected(): Promise<void> {
+    if (this.closed) {
+      return Promise.reject(new Error("AppSyncEventsClient is closed"));
+    }
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      return Promise.resolve();
+    }
+    this.connecting ??= this.connect().finally(() => {
+      this.connecting = undefined;
+    });
+    return this.connecting;
+  }
+
+  private async connect(): Promise<void> {
+    const auth = await this.getAuth({});
+    const auth64 = Buffer.from(JSON.stringify(auth), "utf8")
+      .toString("base64")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+
+    const ws = new WebSocket(
+      `wss://${this.options.realtimeEndpoint}/event/realtime`,
+      ["aws-appsync-event-ws", `header-${auth64}`],
+    );
+    this.ws = ws;
+
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        reject(new Error("AppSync connection timed out"));
+        ws.close();
+      }, CONNECT_TIMEOUT_MS);
+      const fail = (error: Error) => {
+        clearTimeout(timer);
+        reject(error);
+      };
+      ws.addEventListener("error", () =>
+        fail(new Error("AppSync connection failed")),
+      );
+      ws.addEventListener("close", () =>
+        fail(new Error("AppSync connection closed during handshake")),
+      );
+      ws.addEventListener("open", () => {
+        ws.send(JSON.stringify({ type: "connection_init" }));
+      });
+      ws.addEventListener("message", (event) => {
+        const message = this.parse(event.data);
+        if (message?.type === "connection_ack") {
+          clearTimeout(timer);
+          if (typeof message.connectionTimeoutMs === "number") {
+            this.kaTimeoutMs = message.connectionTimeoutMs;
+          }
+          this.lastActivity = Date.now();
+          this.armKaTimer();
+          resolve();
+        }
+      });
+    });
+
+    ws.addEventListener("message", (event) => {
+      const message = this.parse(event.data);
+      if (!message) return;
+      this.lastActivity = Date.now();
+      switch (message.type) {
+        case "ka":
+          this.armKaTimer();
+          break;
+        case "subscribe_success": {
+          this.acks.get(String(message.id))?.();
+          break;
+        }
+        case "subscribe_error": {
+          this.acks.get(String(message.id))?.(
+            new Error(
+              `AppSync subscription failed: ${JSON.stringify(message.errors ?? message)}`,
+            ),
+          );
+          break;
+        }
+        case "data": {
+          const subscription = this.subscriptions.get(String(message.id));
+          if (subscription && typeof message.event === "string") {
+            subscription.handler(message.event);
+          }
+          break;
+        }
+      }
+    });
+
+    const onDrop = () => {
+      if (this.ws !== ws) return;
+      this.log("connection lost");
+      this.scheduleReconnect();
+    };
+    ws.addEventListener("close", onDrop);
+    ws.addEventListener("error", onDrop);
+
+    // Restore subscriptions after a reconnect.
+    for (const [id, subscription] of this.subscriptions) {
+      await this.sendSubscribe(id, subscription.channel);
+    }
+  }
+
+  private async sendSubscribe(id: string, channel: string): Promise<void> {
+    const ws = this.ws;
+    if (!ws || ws.readyState !== WebSocket.OPEN) {
+      throw new Error("AppSync connection is not open");
+    }
+    const auth = await this.getAuth({ channel });
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.acks.delete(id);
+        reject(new Error(`AppSync subscription to ${channel} timed out`));
+      }, SUBSCRIBE_TIMEOUT_MS);
+      this.acks.set(id, (error) => {
+        clearTimeout(timer);
+        this.acks.delete(id);
+        if (error) reject(error);
+        else resolve();
+      });
+      ws.send(
+        JSON.stringify({ type: "subscribe", id, channel, authorization: auth }),
+      );
+    });
+  }
+
+  private armKaTimer() {
+    if (this.kaTimer) clearTimeout(this.kaTimer);
+    this.kaTimer = setTimeout(() => {
+      this.log("keepalive expired");
+      this.scheduleReconnect();
+    }, this.kaTimeoutMs);
+    // Don't hold the process open just for the keepalive watchdog.
+    (this.kaTimer as { unref?: () => void }).unref?.();
+  }
+
+  private scheduleReconnect() {
+    this.teardown();
+    if (this.closed) return;
+    const attempt = () => {
+      if (this.closed) return;
+      this.ensureConnected().catch((error) => {
+        this.log(`reconnect failed: ${error}`);
+        const timer = setTimeout(attempt, RECONNECT_DELAY_MS);
+        (timer as { unref?: () => void }).unref?.();
+      });
+    };
+    attempt();
+  }
+
+  private teardown() {
+    if (this.kaTimer) clearTimeout(this.kaTimer);
+    this.kaTimer = undefined;
+    const ws = this.ws;
+    this.ws = undefined;
+    if (ws && ws.readyState !== WebSocket.CLOSED) {
+      try {
+        ws.close();
+      } catch {
+        // already closing
+      }
+    }
+  }
+
+  close() {
+    this.closed = true;
+    this.teardown();
+  }
+
+  private parse(data: unknown): Record<string, any> | undefined {
+    try {
+      if (typeof data === "string") return JSON.parse(data);
+      if (data instanceof ArrayBuffer) {
+        return JSON.parse(Buffer.from(data).toString("utf8"));
+      }
+      if (ArrayBuffer.isView(data)) {
+        return JSON.parse(
+          Buffer.from(data.buffer, data.byteOffset, data.byteLength).toString(
+            "utf8",
+          ),
+        );
+      }
+    } catch {
+      // non-JSON frame — ignore
+    }
+    return undefined;
+  }
+}

--- a/packages/alchemy/src/AWS/Lambda/Live/Bridge.ts
+++ b/packages/alchemy/src/AWS/Lambda/Live/Bridge.ts
@@ -1,0 +1,223 @@
+/**
+ * Live Lambda bridge — the code actually deployed to AWS Lambda when a
+ * Function runs under `alchemy dev`.
+ *
+ * Each invocation is forwarded over AWS AppSync Events to the developer's
+ * machine, executed there against the locally-built handler, and the result
+ * is returned as this function's response. One bridge sandbox = one
+ * `workerId` (the tail of the log stream name, unique per concurrent
+ * execution environment), mirroring SST's live bridge:
+ *
+ * 1. On first invoke, subscribe to `{prefix}/{workerId}/in` and publish an
+ *    `init` message (function id + sandbox environment, including the
+ *    execution role's credentials) to `{prefix}/in`.
+ * 2. Per invocation, publish a `next` message and wait. The dev machine
+ *    replies `ping` immediately (extending the wait from 16s to the
+ *    invocation deadline), then `response` or `error`.
+ * 3. `reboot` means the dev machine doesn't know this worker (CLI
+ *    restarted) — re-publish `init`.
+ * 4. No `ping` within 16s → the dev machine is offline; fail the invocation.
+ *
+ * This file is bundled standalone (plus its local imports) at deploy time —
+ * it must stay dependency-free apart from node builtins.
+ */
+import type * as lambda from "aws-lambda";
+import { AppSyncEventsClient } from "./AppSyncEvents.ts";
+import {
+  channelPrefix,
+  devChannel,
+  encodePackets,
+  ENV_BLACKLIST,
+  PacketAssembler,
+  workerChannel,
+  type ErrorBody,
+  type InitBody,
+  type Message,
+  type NextBody,
+  type Packet,
+  type ResponseBody,
+} from "./Protocol.ts";
+
+const OFFLINE_TIMEOUT_MS = 16_000;
+
+const env = (name: string): string => {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`live lambda bridge: missing environment variable ${name}`);
+  }
+  return value;
+};
+
+const logStreamName = process.env.AWS_LAMBDA_LOG_STREAM_NAME ?? "";
+const workerId =
+  logStreamName.length >= 32
+    ? logStreamName.slice(-32)
+    : crypto.randomUUID().replace(/-/g, "");
+
+let client: AppSyncEventsClient | undefined;
+let session: Promise<void> | undefined;
+let currentWait:
+  | { requestId: string; onMessage: (message: Message) => void }
+  | undefined;
+
+const getClient = (): AppSyncEventsClient => {
+  client ??= new AppSyncEventsClient({
+    httpEndpoint: env("ALCHEMY_LIVE_APPSYNC_HTTP"),
+    realtimeEndpoint: env("ALCHEMY_LIVE_APPSYNC_REALTIME"),
+    region: env("AWS_REGION"),
+    getCredentials: async () => ({
+      accessKeyId: env("AWS_ACCESS_KEY_ID"),
+      secretAccessKey: env("AWS_SECRET_ACCESS_KEY"),
+      sessionToken: process.env.AWS_SESSION_TOKEN,
+    }),
+    log: (message) => console.log(message),
+  });
+  return client;
+};
+
+const prefix = () =>
+  channelPrefix("alchemy", env("ALCHEMY_STACK_NAME"), env("ALCHEMY_STAGE"));
+
+const sendInit = async () => {
+  const environment: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined && !ENV_BLACKLIST.has(key)) {
+      environment[key] = value;
+    }
+  }
+  const body: InitBody = {
+    functionId: env("ALCHEMY_LIVE_FUNCTION_ID"),
+    workerId,
+    environment,
+  };
+  for (const packet of encodePackets(
+    "init",
+    workerId,
+    crypto.randomUUID(),
+    body,
+  )) {
+    await getClient().publish(devChannel(prefix()), packet);
+  }
+};
+
+const assembler = new PacketAssembler();
+
+const onChannelEvent = (raw: string) => {
+  let packet: Packet;
+  try {
+    packet = JSON.parse(raw);
+  } catch {
+    return;
+  }
+  const message = assembler.push(packet);
+  if (!message) return;
+  if (message.type === "reboot") {
+    // Dev machine restarted and doesn't know this worker — re-introduce
+    // ourselves (fire and forget; the pending invocation keeps waiting).
+    sendInit().catch((error) => console.error("re-init failed", error));
+    return;
+  }
+  currentWait?.onMessage(message);
+};
+
+/**
+ * Connect + subscribe + announce, memoized per sandbox. The memo is cleared
+ * on failure so a transient AppSync outage doesn't poison the sandbox, and
+ * `ensureHealthy` revives connections that died while the sandbox was frozen.
+ */
+const ensureSession = async () => {
+  await getClient().ensureHealthy();
+  session ??= (async () => {
+    await getClient().subscribe(
+      workerChannel(prefix(), workerId),
+      onChannelEvent,
+    );
+    await sendInit();
+  })().catch((error) => {
+    session = undefined;
+    throw error;
+  });
+  await session;
+};
+
+export const handler = async (
+  event: unknown,
+  context: lambda.Context,
+): Promise<unknown> => {
+  await ensureSession();
+  const requestId = context.awsRequestId;
+  const deadlineMs = Date.now() + context.getRemainingTimeInMillis();
+
+  const body: NextBody = {
+    functionId: env("ALCHEMY_LIVE_FUNCTION_ID"),
+    workerId,
+    requestId,
+    event,
+    context: {
+      functionName: context.functionName,
+      functionVersion: context.functionVersion,
+      invokedFunctionArn: context.invokedFunctionArn,
+      memoryLimitInMB: context.memoryLimitInMB,
+      awsRequestId: context.awsRequestId,
+      logGroupName: context.logGroupName,
+      logStreamName: context.logStreamName,
+      identity: context.identity,
+      clientContext: context.clientContext,
+      deadlineMs,
+    },
+  };
+
+  const result = new Promise<unknown>((resolve, reject) => {
+    let timer: ReturnType<typeof setTimeout>;
+    const armTimer = (ms: number) => {
+      clearTimeout(timer);
+      timer = setTimeout(() => {
+        currentWait = undefined;
+        reject(
+          new Error(
+            `alchemy dev is not running (worker: ${workerId}). Start it with \`alchemy dev\`.`,
+          ),
+        );
+      }, ms);
+    };
+    armTimer(OFFLINE_TIMEOUT_MS);
+    currentWait = {
+      requestId,
+      onMessage: (message) => {
+        if (message.id !== requestId) return;
+        switch (message.type) {
+          case "ping":
+            // Dev machine acknowledged — wait until just before our own
+            // deadline for the real response.
+            armTimer(Math.max(deadlineMs - Date.now() - 500, 1_000));
+            break;
+          case "response": {
+            clearTimeout(timer);
+            currentWait = undefined;
+            const { result } = JSON.parse(message.body) as ResponseBody;
+            resolve(result);
+            break;
+          }
+          case "error": {
+            clearTimeout(timer);
+            currentWait = undefined;
+            const errorBody = JSON.parse(message.body) as ErrorBody;
+            const error = new Error(errorBody.errorMessage);
+            error.name = errorBody.errorType;
+            if (errorBody.trace) {
+              error.stack = errorBody.trace.join("\n");
+            }
+            reject(error);
+            break;
+          }
+        }
+      },
+    };
+  });
+
+  for (const packet of encodePackets("next", workerId, requestId, body)) {
+    await getClient().publish(devChannel(prefix()), packet);
+  }
+
+  return result;
+};

--- a/packages/alchemy/src/AWS/Lambda/Live/BridgeBundle.ts
+++ b/packages/alchemy/src/AWS/Lambda/Live/BridgeBundle.ts
@@ -1,0 +1,58 @@
+/**
+ * Builds (and caches) the Live Lambda bridge bundle — the code deployed to
+ * AWS Lambda in place of the user's handler under `alchemy dev`.
+ */
+import * as Effect from "effect/Effect";
+import { fileURLToPath } from "node:url";
+import * as Bundle from "../../../Bundle/Bundle.ts";
+import { zipCode } from "../../../Util/zip.ts";
+import { sha256 } from "../../../Util/sha256.ts";
+import type { FunctionCodeBundle } from "../Function.ts";
+
+const BRIDGE_ENTRY_URL = import.meta.resolve(
+  import.meta.url.endsWith(".ts") ? "./Bridge.ts" : "./Bridge.js",
+  import.meta.url,
+);
+
+let cached:
+  | { identityHash: string; archive: Uint8Array<ArrayBufferLike> }
+  | undefined;
+
+/**
+ * The bridge's {@link FunctionCodeBundle}. Identical for every function —
+ * per-function wiring travels via environment variables — so the build and
+ * zip are memoized per process.
+ */
+export const bridgeCodeBundle: Effect.Effect<
+  FunctionCodeBundle,
+  Bundle.BundleError
+> = Effect.gen(function* () {
+  if (!cached) {
+    const output = yield* Bundle.build(
+      {
+        input: fileURLToPath(BRIDGE_ENTRY_URL),
+        platform: "node",
+      },
+      {
+        format: "esm",
+        entryFileNames: "index.js",
+        sourcemap: false,
+        minify: false,
+        codeSplitting: false,
+      },
+    );
+    const mainFile = output.files[0];
+    const code =
+      typeof mainFile.content === "string"
+        ? new TextEncoder().encode(mainFile.content)
+        : mainFile.content;
+    const archive = yield* zipCode(code);
+    const archiveHash = yield* sha256(archive);
+    cached = { identityHash: archiveHash, archive };
+  }
+  const { identityHash, archive } = cached;
+  return {
+    identityHash,
+    buildArchive: Effect.succeed({ archive, archiveHash: identityHash }),
+  };
+});

--- a/packages/alchemy/src/AWS/Lambda/Live/Child.ts
+++ b/packages/alchemy/src/AWS/Lambda/Live/Child.ts
@@ -1,0 +1,129 @@
+/**
+ * Live Lambda local runner — the child process that executes the user's
+ * handler on the developer's machine.
+ *
+ * One child per bridge sandbox (`workerId`), spawned by the local Function
+ * provider with the environment forwarded from the real sandbox (including
+ * the execution role's credentials), plus:
+ *
+ * - `ALCHEMY_LIVE_BUNDLE`  — path to the locally-built entry module
+ * - `ALCHEMY_LIVE_HANDLER` — the export name of the handler (e.g. `default`)
+ *
+ * The child imports the bundle eagerly (so init errors surface immediately),
+ * serves `POST /invoke` on a loopback port, and prints the address inside an
+ * `<ALCHEMY_CHILD_ADDRESS>` sentinel for the parent to scrape — the same
+ * pattern the RPC spawner uses. Invocations arrive serially per sandbox,
+ * matching Lambda semantics.
+ */
+import * as http from "node:http";
+import { pathToFileURL } from "node:url";
+import type { ErrorBody, SerializedContext } from "./Protocol.ts";
+
+interface InvokeRequest {
+  event: unknown;
+  context: SerializedContext;
+}
+
+type InvokeResponse =
+  | { ok: true; result: unknown }
+  | { ok: false; error: ErrorBody };
+
+const toErrorBody = (error: unknown): ErrorBody => {
+  if (error instanceof Error) {
+    return {
+      errorType: error.name || "Error",
+      errorMessage: error.message,
+      trace: error.stack?.split("\n"),
+    };
+  }
+  return {
+    errorType: "Error",
+    errorMessage: typeof error === "string" ? error : JSON.stringify(error),
+  };
+};
+
+const main = async () => {
+  const bundlePath = process.env.ALCHEMY_LIVE_BUNDLE;
+  const handlerName = process.env.ALCHEMY_LIVE_HANDLER ?? "default";
+  if (!bundlePath) {
+    throw new Error("ALCHEMY_LIVE_BUNDLE is not set");
+  }
+
+  const mod = await import(pathToFileURL(bundlePath).href);
+  const handler = mod[handlerName];
+  if (typeof handler !== "function") {
+    throw new Error(
+      `Handler export "${handlerName}" of ${bundlePath} is not a function`,
+    );
+  }
+
+  const invoke = async (request: InvokeRequest): Promise<InvokeResponse> => {
+    const { deadlineMs, ...contextFields } = request.context;
+    const context = {
+      ...contextFields,
+      callbackWaitsForEmptyEventLoop: false,
+      getRemainingTimeInMillis: () => deadlineMs - Date.now(),
+    };
+    try {
+      const result =
+        handler.length >= 3
+          ? await new Promise<unknown>((resolve, reject) => {
+              // Legacy callback-style handler.
+              const maybePromise = handler(
+                request.event,
+                context,
+                (error: unknown, value: unknown) =>
+                  error ? reject(error) : resolve(value),
+              );
+              if (maybePromise && typeof maybePromise.then === "function") {
+                maybePromise.then(resolve, reject);
+              }
+            })
+          : await handler(request.event, context);
+      return { ok: true, result };
+    } catch (error) {
+      return { ok: false, error: toErrorBody(error) };
+    }
+  };
+
+  const server = http.createServer((req, res) => {
+    if (req.method !== "POST" || req.url !== "/invoke") {
+      res.writeHead(404).end();
+      return;
+    }
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk) => chunks.push(chunk));
+    req.on("end", () => {
+      void (async () => {
+        let response: InvokeResponse;
+        try {
+          const request: InvokeRequest = JSON.parse(
+            Buffer.concat(chunks).toString("utf8"),
+          );
+          response = await invoke(request);
+        } catch (error) {
+          response = { ok: false, error: toErrorBody(error) };
+        }
+        const body = JSON.stringify(response);
+        res.writeHead(200, { "content-type": "application/json" }).end(body);
+      })();
+    });
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("failed to bind local invoke server");
+  }
+  console.log(
+    `<ALCHEMY_CHILD_ADDRESS>http://127.0.0.1:${address.port}</ALCHEMY_CHILD_ADDRESS>`,
+  );
+
+  process.on("SIGTERM", () => process.exit(0));
+  process.on("SIGINT", () => process.exit(0));
+};
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/alchemy/src/AWS/Lambda/Live/EventApi.ts
+++ b/packages/alchemy/src/AWS/Lambda/Live/EventApi.ts
@@ -1,0 +1,100 @@
+/**
+ * Account-wide AppSync Events API used as the Live Lambda transport.
+ *
+ * Like SST's live bridge, one Event API (named `alchemy`) is shared by every
+ * stack/stage in an account+region. It is bootstrap infrastructure — created
+ * lazily the first time `alchemy dev` runs an AWS Function, never torn down
+ * by stack destroy — so it is provisioned imperatively here rather than as a
+ * stack resource.
+ */
+import * as appsync from "@distilled.cloud/aws/appsync";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Stream from "effect/Stream";
+
+/** Name of the shared Event API and its channel namespace. */
+export const EVENT_API_NAME = "alchemy";
+
+export interface EventApi {
+  apiId: string;
+  apiArn: string;
+  /** e.g. `abc123.appsync-api.us-east-1.amazonaws.com` */
+  httpEndpoint: string;
+  /** e.g. `abc123.appsync-realtime-api.us-east-1.amazonaws.com` */
+  realtimeEndpoint: string;
+}
+
+const AUTH_MODES = [{ authType: "AWS_IAM" as const }];
+
+const toEventApi = (api: appsync.Api): Effect.Effect<EventApi, Error> => {
+  const httpEndpoint = api.dns?.HTTP;
+  const realtimeEndpoint = api.dns?.REALTIME;
+  if (!api.apiId || !api.apiArn || !httpEndpoint || !realtimeEndpoint) {
+    return Effect.fail(
+      new Error(
+        `AppSync Event API "${EVENT_API_NAME}" is missing expected fields: ${JSON.stringify(api)}`,
+      ),
+    );
+  }
+  return Effect.succeed({
+    apiId: api.apiId,
+    apiArn: api.apiArn,
+    httpEndpoint,
+    realtimeEndpoint,
+  });
+};
+
+/**
+ * Find (or create) the shared `alchemy` Event API and its channel namespace.
+ */
+export const ensureEventApi = Effect.gen(function* () {
+  const existing = yield* appsync.listApis.items({}).pipe(
+    Stream.filter((api) => api.name === EVENT_API_NAME),
+    Stream.runHead,
+  );
+  if (Option.isSome(existing) && existing.value.apiId) {
+    // ListApis omits `dns` — hydrate through GetApi.
+    const detail = yield* appsync.getApi({ apiId: existing.value.apiId });
+    return yield* toEventApi(detail.api ?? existing.value);
+  }
+
+  yield* Effect.logDebug(`creating AppSync Event API "${EVENT_API_NAME}"`);
+  const created = yield* appsync
+    .createApi({
+      name: EVENT_API_NAME,
+      eventConfig: {
+        authProviders: AUTH_MODES,
+        connectionAuthModes: AUTH_MODES,
+        defaultPublishAuthModes: AUTH_MODES,
+        defaultSubscribeAuthModes: AUTH_MODES,
+      },
+    })
+    .pipe(
+      // Two dev sessions racing to create it — fall back to the winner's.
+      Effect.catchTag("ConcurrentModificationException", () =>
+        appsync.listApis.items({}).pipe(
+          Stream.filter((api) => api.name === EVENT_API_NAME),
+          Stream.runHead,
+          Effect.map((api) => ({ api: Option.getOrUndefined(api) })),
+        ),
+      ),
+    );
+  if (!created.api?.apiId) {
+    return yield* Effect.fail(
+      new Error(`failed to create AppSync Event API "${EVENT_API_NAME}"`),
+    );
+  }
+
+  yield* appsync
+    .createChannelNamespace({
+      apiId: created.api.apiId,
+      name: EVENT_API_NAME,
+      publishAuthModes: AUTH_MODES,
+      subscribeAuthModes: AUTH_MODES,
+    })
+    .pipe(
+      Effect.catchTag("ConflictException", () => Effect.succeed(undefined)),
+    );
+
+  return yield* toEventApi(created.api);
+});

--- a/packages/alchemy/src/AWS/Lambda/Live/LiveRuntime.ts
+++ b/packages/alchemy/src/AWS/Lambda/Live/LiveRuntime.ts
@@ -1,0 +1,431 @@
+/**
+ * Live Lambda dev-side runtime.
+ *
+ * Runs inside the AWS local RPC child process. Maintains one AppSync Events
+ * subscription for the whole stack, tracks the locally-served functions
+ * (registered by the local Function provider), and executes invocations
+ * forwarded by deployed bridge sandboxes:
+ *
+ * - `init` — a bridge sandbox announced itself: remember its `workerId`,
+ *   function id and forwarded environment (including the execution role's
+ *   credentials).
+ * - `next` — an invocation: reply `ping` immediately (extends the bridge's
+ *   wait to the invocation deadline), run the handler in a per-worker child
+ *   process, publish `response`/`error` back to the sandbox's channel.
+ * - Unknown worker (this process restarted) — publish `reboot` so the bridge
+ *   re-sends `init`, and buffer the invocation until it does.
+ */
+import * as Redacted from "effect/Redacted";
+import * as Context from "effect/Context";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Layer from "effect/Layer";
+import * as Queue from "effect/Queue";
+import * as Schedule from "effect/Schedule";
+import * as Scope from "effect/Scope";
+import * as Semaphore from "effect/Semaphore";
+import * as Stream from "effect/Stream";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import * as ChildProcess from "effect/unstable/process/ChildProcess";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
+import { fileURLToPath } from "node:url";
+import { Stack } from "../../../Stack.ts";
+import { AWSEnvironment } from "../../Environment.ts";
+import { AppSyncEventsClient } from "./AppSyncEvents.ts";
+import { ensureEventApi, type EventApi } from "./EventApi.ts";
+import {
+  channelPrefix,
+  DEV_SOURCE,
+  devChannel,
+  encodePackets,
+  PacketAssembler,
+  workerChannel,
+  type ErrorBody,
+  type InitBody,
+  type Message,
+  type MessageType,
+  type NextBody,
+  type Packet,
+} from "./Protocol.ts";
+import { EVENT_API_NAME } from "./EventApi.ts";
+
+/**
+ * Entry module of the per-worker handler child process. Resolved relative to
+ * this file so it works both from `src/` (bun / tests) and the compiled
+ * `lib/` (published package).
+ */
+export const LIVE_CHILD_ENTRY_URL = import.meta.resolve(
+  import.meta.url.endsWith(".ts") ? "./Child.ts" : "./Child.js",
+  import.meta.url,
+);
+
+export interface FunctionTarget {
+  /** Absolute path to the locally-built entry module. */
+  bundlePath: string;
+  /** Export name of the handler (`default` for Effect Functions). */
+  handler: string;
+}
+
+interface RegisteredTarget extends FunctionTarget {
+  /** Bumped on every rebuild; children on an older version are recycled. */
+  version: number;
+}
+
+interface Worker {
+  functionId: string;
+  environment: Record<string, string>;
+}
+
+interface HandlerChild {
+  functionId: string;
+  version: number;
+  address: Deferred.Deferred<string>;
+  scope: Scope.Closeable;
+  lock: Semaphore.Semaphore;
+}
+
+interface ChildInvokeResponse {
+  ok: boolean;
+  result?: unknown;
+  error?: ErrorBody;
+}
+
+export class LiveLambdaRuntime extends Context.Service<
+  LiveLambdaRuntime,
+  {
+    readonly eventApi: EventApi;
+    readonly channelPrefix: string;
+    /** Register (or refresh after a rebuild) a locally-served function. */
+    readonly setTarget: (
+      functionId: string,
+      target: FunctionTarget,
+    ) => Effect.Effect<void>;
+    /** Stop serving a function locally and recycle its children. */
+    readonly removeTarget: (functionId: string) => Effect.Effect<void>;
+  }
+>()("alchemy/AWS/Lambda/LiveLambdaRuntime") {}
+
+export const makeLiveLambdaRuntime = Effect.gen(function* () {
+  const stack = yield* Stack;
+  const environment = yield* AWSEnvironment.current;
+  const httpClient = yield* HttpClient.HttpClient;
+  const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+  const rootScope = yield* Effect.scope;
+
+  const eventApi = yield* ensureEventApi.pipe(Effect.orDie);
+  const prefix = channelPrefix(EVENT_API_NAME, stack.name, stack.stage);
+
+  const client = new AppSyncEventsClient({
+    httpEndpoint: eventApi.httpEndpoint,
+    realtimeEndpoint: eventApi.realtimeEndpoint,
+    region: environment.region,
+    getCredentials: () =>
+      Effect.runPromise(
+        environment.credentials.pipe(
+          Effect.map((credentials) => ({
+            accessKeyId: Redacted.value(credentials.accessKeyId),
+            secretAccessKey: Redacted.value(credentials.secretAccessKey),
+            sessionToken: credentials.sessionToken
+              ? Redacted.value(credentials.sessionToken)
+              : undefined,
+          })),
+        ),
+      ),
+  });
+  yield* Effect.addFinalizer(() => Effect.sync(() => client.close()));
+
+  const targets = new Map<string, RegisteredTarget>();
+  const workers = new Map<string, Worker>();
+  const children = new Map<string, HandlerChild>();
+  /** Invocations that arrived before their worker's `init` (or re-`init`). */
+  const pendingNexts = new Map<string, NextBody[]>();
+
+  const publish = (
+    type: MessageType,
+    workerId: string,
+    id: string,
+    body: unknown,
+  ) =>
+    Effect.forEach(
+      encodePackets(type, DEV_SOURCE, id, body),
+      (packet) =>
+        Effect.tryPromise(() =>
+          client.publish(workerChannel(prefix, workerId), packet),
+        ).pipe(
+          Effect.retry({
+            schedule: Schedule.exponential(200),
+            times: 3,
+          }),
+        ),
+      { discard: true },
+    );
+
+  const killChild = Effect.fn(function* (workerId: string) {
+    const child = children.get(workerId);
+    if (!child) return;
+    children.delete(workerId);
+    yield* Scope.close(child.scope, Exit.void);
+  });
+
+  const spawnChild = Effect.fn(function* (workerId: string, worker: Worker) {
+    const target = targets.get(worker.functionId);
+    if (!target) {
+      return yield* Effect.fail(
+        new Error(
+          `function "${worker.functionId}" is not being served by this dev session`,
+        ),
+      );
+    }
+    const scope = yield* Scope.fork(rootScope);
+    const main = fileURLToPath(LIVE_CHILD_ENTRY_URL);
+    const bin = typeof globalThis.Bun !== "undefined" ? "bun" : "node";
+    const command = ChildProcess.make(
+      bin,
+      {
+        bun: ["run", main],
+        node: main.endsWith(".ts")
+          ? [
+              "--experimental-transform-types",
+              "--no-warnings=ExperimentalWarning",
+              main,
+            ]
+          : [main],
+      }[bin],
+      {
+        stdout: "pipe",
+        stderr: "pipe",
+        detached: false,
+        env: {
+          // The deployed sandbox's environment: binding env vars, ALCHEMY_*,
+          // AWS_REGION and the execution role's credentials — so local code
+          // runs with the same configuration and permissions as the real
+          // function.
+          ...worker.environment,
+          ALCHEMY_LIVE_BUNDLE: target.bundlePath,
+          ALCHEMY_LIVE_HANDLER: target.handler,
+          NODE_OPTIONS: "--enable-source-maps",
+        },
+        extendEnv: true,
+      },
+    );
+    const handle = yield* spawner.spawn(command).pipe(Scope.provide(scope));
+    yield* Scope.addFinalizer(
+      scope,
+      handle.kill({ forceKillAfter: "500 millis" }).pipe(Effect.ignore),
+    );
+
+    const address = yield* Deferred.make<string>();
+    const label = `[${worker.functionId}]`;
+    let found = false;
+    yield* handle.stdout.pipe(
+      Stream.decodeText,
+      Stream.splitLines,
+      Stream.runForEach((line) => {
+        if (!found) {
+          const match = line.match(
+            /<ALCHEMY_CHILD_ADDRESS>(.+)<\/ALCHEMY_CHILD_ADDRESS>/,
+          );
+          if (match) {
+            found = true;
+            return Deferred.succeed(address, match[1]);
+          }
+        }
+        return Effect.log(`${label} ${line}`);
+      }),
+      Effect.ignore,
+      Effect.forkIn(scope),
+    );
+    yield* handle.stderr.pipe(
+      Stream.decodeText,
+      Stream.splitLines,
+      Stream.runForEach((line) => Effect.logError(`${label} ${line}`)),
+      Effect.ignore,
+      Effect.forkIn(scope),
+    );
+
+    const child: HandlerChild = {
+      functionId: worker.functionId,
+      version: target.version,
+      address,
+      scope,
+      lock: Semaphore.makeUnsafe(1),
+    };
+    children.set(workerId, child);
+    return child;
+  });
+
+  const ensureChild = Effect.fn(function* (workerId: string, worker: Worker) {
+    const target = targets.get(worker.functionId);
+    const existing = children.get(workerId);
+    if (existing && target && existing.version === target.version) {
+      return existing;
+    }
+    if (existing) {
+      yield* killChild(workerId);
+    }
+    return yield* spawnChild(workerId, worker);
+  });
+
+  const invokeChild = Effect.fn(function* (
+    child: HandlerChild,
+    next: NextBody,
+  ) {
+    const address = yield* Deferred.await(child.address).pipe(
+      Effect.timeoutOrElse({
+        duration: "30 seconds",
+        orElse: () =>
+          Effect.fail(new Error("local handler child failed to start")),
+      }),
+    );
+    const response = yield* httpClient
+      .execute(
+        HttpClientRequest.post(`${address}/invoke`).pipe(
+          HttpClientRequest.bodyJsonUnsafe({
+            event: next.event,
+            context: next.context,
+          }),
+        ),
+      )
+      .pipe(
+        Effect.flatMap((response) => response.json),
+        Effect.timeoutOrElse({
+          // The bridge gives up at the invocation deadline anyway; cap the
+          // local run slightly past it so a hung handler can't pin the child.
+          duration:
+            Math.max(next.context.deadlineMs - Date.now(), 1_000) + 5_000,
+          orElse: () => Effect.fail(new Error("local handler timed out")),
+        }),
+      );
+    return response as unknown as ChildInvokeResponse;
+  });
+
+  const handleNext = Effect.fn(function* (next: NextBody) {
+    // Acknowledge immediately so the bridge extends its wait from the 16s
+    // offline window to the invocation deadline.
+    yield* publish("ping", next.workerId, next.requestId, {});
+
+    const worker = workers.get(next.workerId);
+    if (!worker) {
+      // We restarted and lost the worker's environment — ask the bridge to
+      // re-introduce itself and park the invocation until it does.
+      const pending = pendingNexts.get(next.workerId) ?? [];
+      pending.push(next);
+      pendingNexts.set(next.workerId, pending);
+      yield* publish("reboot", next.workerId, next.requestId, {});
+      return;
+    }
+
+    const result = yield* Effect.gen(function* () {
+      const child = yield* ensureChild(next.workerId, worker);
+      return yield* Semaphore.withPermits(
+        child.lock,
+        1,
+      )(invokeChild(child, next));
+    }).pipe(
+      Effect.catch((error) =>
+        Effect.succeed<ChildInvokeResponse>({
+          ok: false,
+          error: {
+            errorType: "Error",
+            errorMessage:
+              error instanceof Error ? error.message : String(error),
+          },
+        }),
+      ),
+    );
+
+    if (result.ok) {
+      yield* publish("response", next.workerId, next.requestId, {
+        result: result.result,
+      });
+    } else {
+      yield* publish("error", next.workerId, next.requestId, result.error);
+    }
+  });
+
+  const handleMessage = Effect.fn(function* (message: Message) {
+    switch (message.type) {
+      case "init": {
+        const init = JSON.parse(message.body) as InitBody;
+        workers.set(init.workerId, {
+          functionId: init.functionId,
+          environment: init.environment,
+        });
+        yield* Effect.log(
+          `[${init.functionId}] connected (worker: ${init.workerId})`,
+        );
+        const pending = pendingNexts.get(init.workerId) ?? [];
+        pendingNexts.delete(init.workerId);
+        yield* Effect.forEach(
+          pending,
+          (next) => handleNext(next).pipe(Effect.forkIn(rootScope)),
+          { discard: true },
+        );
+        break;
+      }
+      case "next": {
+        const next = JSON.parse(message.body) as NextBody;
+        yield* handleNext(next).pipe(Effect.forkIn(rootScope));
+        break;
+      }
+    }
+  });
+
+  const assembler = new PacketAssembler();
+  const messages = Stream.callback<Message>((queue) =>
+    Effect.acquireRelease(
+      Effect.tryPromise(() =>
+        client.subscribe(devChannel(prefix), (raw) => {
+          try {
+            const packet = JSON.parse(raw) as Packet;
+            if (packet.source === DEV_SOURCE) return;
+            const message = assembler.push(packet);
+            if (message) {
+              Queue.offerUnsafe(queue, message);
+            }
+          } catch {
+            // malformed packet — ignore
+          }
+        }),
+      ),
+      (unsubscribe) => Effect.sync(() => unsubscribe()),
+    ),
+  );
+  yield* messages.pipe(Stream.runForEach(handleMessage), Effect.forkScoped);
+
+  return LiveLambdaRuntime.of({
+    eventApi,
+    channelPrefix: prefix,
+    setTarget: Effect.fn(function* (functionId, target) {
+      const existing = targets.get(functionId);
+      targets.set(functionId, {
+        ...target,
+        version: (existing?.version ?? 0) + 1,
+      });
+      // Recycle children running the previous build; they respawn with the
+      // fresh bundle on the next invocation.
+      yield* Effect.forEach(
+        [...children.entries()].filter(
+          ([, child]) => child.functionId === functionId,
+        ),
+        ([workerId]) => killChild(workerId),
+        { discard: true },
+      );
+    }),
+    removeTarget: Effect.fn(function* (functionId) {
+      targets.delete(functionId);
+      yield* Effect.forEach(
+        [...children.entries()].filter(
+          ([, child]) => child.functionId === functionId,
+        ),
+        ([workerId]) => killChild(workerId),
+        { discard: true },
+      );
+    }),
+  });
+});
+
+export const LiveLambdaRuntimeLive = () =>
+  Layer.effect(LiveLambdaRuntime, makeLiveLambdaRuntime);

--- a/packages/alchemy/src/AWS/Lambda/Live/Protocol.ts
+++ b/packages/alchemy/src/AWS/Lambda/Live/Protocol.ts
@@ -1,0 +1,207 @@
+/**
+ * Wire protocol for Live Lambda.
+ *
+ * A deployed "bridge" Lambda forwards invocations to the developer's machine
+ * over AWS AppSync Events and waits for the response. Messages are JSON
+ * "packets" chunked to fit under AppSync's per-event payload limit, mirroring
+ * SST v3's live bridge framing.
+ *
+ * This module is plain TypeScript (no Effect) because it is bundled into the
+ * bridge Lambda and the local handler child process as-is.
+ */
+
+/**
+ * One AppSync event. Large messages are split into multiple packets sharing
+ * an `id`; `index` orders them and `final` marks the last one.
+ */
+export interface Packet {
+  type: MessageType;
+  /** Sender: a bridge sandbox's workerId, or {@link DEV_SOURCE} for the CLI. */
+  source: string;
+  /** Correlates chunks and request/response pairs (the Lambda requestId). */
+  id: string;
+  index: number;
+  /** Base64 chunk of the JSON body. */
+  data: string;
+  final: boolean;
+}
+
+export type MessageType =
+  /** Bridge sandbox announces itself + its environment to the dev machine. */
+  | "init"
+  /** Dev machine acknowledges an invocation, extending the bridge's wait. */
+  | "ping"
+  /** Bridge forwards an invocation to the dev machine. */
+  | "next"
+  /** Dev machine returns the handler result. */
+  | "response"
+  /** Dev machine returns a handler (or init) error. */
+  | "error"
+  /** Dev machine doesn't recognize the worker; bridge must re-`init`. */
+  | "reboot";
+
+/** `source` used by the dev-machine side. */
+export const DEV_SOURCE = "dev";
+
+export interface InitBody {
+  functionId: string;
+  workerId: string;
+  /** The sandbox environment (minus {@link ENV_BLACKLIST}), including the execution role's credentials. */
+  environment: Record<string, string>;
+}
+
+export interface NextBody {
+  functionId: string;
+  workerId: string;
+  requestId: string;
+  /** Serialized subset of the Lambda context to rebuild on the local side. */
+  context: SerializedContext;
+  event: unknown;
+}
+
+export interface SerializedContext {
+  functionName: string;
+  functionVersion: string;
+  invokedFunctionArn: string;
+  memoryLimitInMB: string;
+  awsRequestId: string;
+  logGroupName: string;
+  logStreamName: string;
+  identity?: unknown;
+  clientContext?: unknown;
+  /** Epoch millis after which the invocation is dead. */
+  deadlineMs: number;
+}
+
+export interface ResponseBody {
+  result: unknown;
+}
+
+export interface ErrorBody {
+  errorType: string;
+  errorMessage: string;
+  trace?: string[];
+}
+
+/**
+ * Raw bytes per chunk before base64. AppSync Events caps each event around
+ * 240KB; 128KB of raw data base64-encodes to ~171KB, leaving headroom for the
+ * packet envelope.
+ */
+export const CHUNK_SIZE = 128 * 1024;
+
+/** Channel the dev machine subscribes to: bridges publish `init`/`next` here. */
+export const devChannel = (prefix: string) => `${prefix}/in`;
+
+/** Channel a bridge sandbox subscribes to: the dev machine publishes here. */
+export const workerChannel = (prefix: string, workerId: string) =>
+  `${prefix}/${workerId}/in`;
+
+const sanitizeSegment = (segment: string) =>
+  segment.replace(/[^a-zA-Z0-9_-]/g, "-");
+
+/**
+ * Channel prefix for a stack+stage, e.g. `/alchemy/my-app/dev-sam`.
+ * The leading segment is the AppSync channel namespace name.
+ */
+export const channelPrefix = (
+  namespace: string,
+  stack: string,
+  stage: string,
+) => `/${namespace}/${sanitizeSegment(stack)}/${sanitizeSegment(stage)}`;
+
+/** Environment variables never forwarded from the sandbox to the local child. */
+export const ENV_BLACKLIST: ReadonlySet<string> = new Set([
+  "AWS_LAMBDA_LOG_GROUP_NAME",
+  "AWS_LAMBDA_LOG_STREAM_NAME",
+  "AWS_LAMBDA_RUNTIME_API",
+  "AWS_EXECUTION_ENV",
+  "AWS_LAMBDA_INITIALIZATION_TYPE",
+  "AWS_XRAY_DAEMON_ADDRESS",
+  "AWS_XRAY_DAEMON_PORT",
+  "AWS_XRAY_CONTEXT_MISSING",
+  "LD_LIBRARY_PATH",
+  "LAMBDA_TASK_ROOT",
+  "LAMBDA_RUNTIME_DIR",
+  "PATH",
+  "PWD",
+  "LANG",
+  "NODE_PATH",
+  "NODE_OPTIONS",
+  "SHLVL",
+  "_HANDLER",
+]);
+
+/** Split a JSON-encoded body into ordered packets. */
+export const encodePackets = (
+  type: MessageType,
+  source: string,
+  id: string,
+  body: unknown,
+): Packet[] => {
+  const bytes = Buffer.from(JSON.stringify(body ?? {}), "utf8");
+  const packets: Packet[] = [];
+  let index = 0;
+  for (let offset = 0; ; offset += CHUNK_SIZE) {
+    const chunk = bytes.subarray(offset, offset + CHUNK_SIZE);
+    const final = offset + CHUNK_SIZE >= bytes.length;
+    packets.push({
+      type,
+      source,
+      id,
+      index,
+      data: chunk.toString("base64"),
+      final,
+    });
+    index++;
+    if (final) break;
+  }
+  return packets;
+};
+
+export interface Message {
+  type: MessageType;
+  source: string;
+  id: string;
+  body: string;
+}
+
+/**
+ * Reassembles packets (possibly out of order, interleaved across ids) into
+ * complete messages.
+ */
+export class PacketAssembler {
+  private pending = new Map<
+    string,
+    { packets: Map<number, Packet>; total: number | undefined }
+  >();
+
+  /** Feed one packet; returns the completed message if this was the last piece. */
+  push(packet: Packet): Message | undefined {
+    let entry = this.pending.get(packet.id);
+    if (!entry) {
+      entry = { packets: new Map(), total: undefined };
+      this.pending.set(packet.id, entry);
+    }
+    entry.packets.set(packet.index, packet);
+    if (packet.final) {
+      entry.total = packet.index + 1;
+    }
+    if (entry.total === undefined || entry.packets.size < entry.total) {
+      return undefined;
+    }
+    this.pending.delete(packet.id);
+    const chunks: Buffer[] = [];
+    for (let i = 0; i < entry.total; i++) {
+      const piece = entry.packets.get(i);
+      if (!piece) return undefined; // duplicate `final` with missing middle — drop
+      chunks.push(Buffer.from(piece.data, "base64"));
+    }
+    return {
+      type: packet.type,
+      source: packet.source,
+      id: packet.id,
+      body: Buffer.concat(chunks).toString("utf8"),
+    };
+  }
+}

--- a/packages/alchemy/src/AWS/Lambda/Live/SigV4.ts
+++ b/packages/alchemy/src/AWS/Lambda/Live/SigV4.ts
@@ -1,0 +1,98 @@
+/**
+ * Minimal AWS Signature Version 4 request signing.
+ *
+ * Plain TypeScript (node:crypto only) because it is bundled into the bridge
+ * Lambda; the local side reuses it through {@link AppSyncEventsClient}.
+ */
+import * as crypto from "node:crypto";
+
+export interface AwsCredentials {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+}
+
+export interface SignableRequest {
+  method: string;
+  url: URL;
+  /** Lower-case header names. `host` is derived from the URL. */
+  headers: Record<string, string>;
+  body: string;
+}
+
+const hmac = (key: string | Uint8Array, data: string) =>
+  crypto.createHmac("sha256", key).update(data, "utf8").digest();
+
+const hex = (data: string | Uint8Array) =>
+  crypto.createHash("sha256").update(data).digest("hex");
+
+/**
+ * Signs the request, returning the full header set to send (input headers
+ * plus `host`, `x-amz-date`, `x-amz-security-token` and `authorization`).
+ */
+export const signRequest = (
+  request: SignableRequest,
+  options: {
+    credentials: AwsCredentials;
+    region: string;
+    service: string;
+    date?: Date;
+  },
+): Record<string, string> => {
+  const { credentials, region, service } = options;
+  const now = options.date ?? new Date();
+  const amzDate = now.toISOString().replace(/[:-]|\.\d{3}/g, ""); // YYYYMMDDTHHMMSSZ
+  const dateStamp = amzDate.slice(0, 8);
+
+  const headers: Record<string, string> = {
+    ...Object.fromEntries(
+      Object.entries(request.headers).map(([k, v]) => [k.toLowerCase(), v]),
+    ),
+    host: request.url.host,
+    "x-amz-date": amzDate,
+  };
+  if (credentials.sessionToken) {
+    headers["x-amz-security-token"] = credentials.sessionToken;
+  }
+
+  const signedHeaderNames = Object.keys(headers).sort();
+  const canonicalHeaders = signedHeaderNames
+    .map((name) => `${name}:${headers[name].trim()}\n`)
+    .join("");
+  const signedHeaders = signedHeaderNames.join(";");
+  const payloadHash = hex(request.body);
+
+  const canonicalQuery = [...request.url.searchParams.entries()]
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+    .sort()
+    .join("&");
+
+  const canonicalRequest = [
+    request.method,
+    request.url.pathname,
+    canonicalQuery,
+    canonicalHeaders,
+    signedHeaders,
+    payloadHash,
+  ].join("\n");
+
+  const scope = `${dateStamp}/${region}/${service}/aws4_request`;
+  const stringToSign = [
+    "AWS4-HMAC-SHA256",
+    amzDate,
+    scope,
+    hex(canonicalRequest),
+  ].join("\n");
+
+  const kDate = hmac(`AWS4${credentials.secretAccessKey}`, dateStamp);
+  const kRegion = hmac(kDate, region);
+  const kService = hmac(kRegion, service);
+  const kSigning = hmac(kService, "aws4_request");
+  const signature = crypto
+    .createHmac("sha256", kSigning)
+    .update(stringToSign, "utf8")
+    .digest("hex");
+
+  headers.authorization = `AWS4-HMAC-SHA256 Credential=${credentials.accessKeyId}/${scope}, SignedHeaders=${signedHeaders}, Signature=${signature}`;
+  return headers;
+};

--- a/packages/alchemy/src/AWS/Lambda/index.ts
+++ b/packages/alchemy/src/AWS/Lambda/index.ts
@@ -10,6 +10,7 @@ export * from "./EventBridgeEventSource.ts";
 export * from "./EventInvokeConfig.ts";
 export * from "./EventSourceMapping.ts";
 export * from "./Function.ts";
+export * from "./FunctionProvider.ts";
 export * from "./GetMicrovm.ts";
 export * from "./GetMicrovmHttp.ts";
 export * from "./GetMicrovmImage.ts";

--- a/packages/alchemy/src/AWS/Local.ts
+++ b/packages/alchemy/src/AWS/Local.ts
@@ -1,0 +1,35 @@
+/**
+ * Entry point of the AWS local dev sidecar process.
+ *
+ * Spawned by the RPC spawner the first time the engine (running under
+ * `alchemy dev`) touches an AWS local provider. Providers hosted here — and
+ * their state: the AppSync Events subscription, bundle watchers, and handler
+ * child processes — outlive the engine's `--watch` restarts, which is what
+ * keeps Live Lambda sessions warm across code edits.
+ */
+import * as Layer from "effect/Layer";
+import { CredentialsStoreLive } from "../Auth/Credentials.ts";
+import * as RpcServer from "../Local/RpcServer.ts";
+import { AwsAuth } from "./AuthProvider.ts";
+import * as Credentials from "./Credentials.ts";
+import * as Endpoint from "./Endpoint.ts";
+import { Default as DefaultEnvironment } from "./Environment.ts";
+import { LocalFunctionProvider } from "./Lambda/FunctionProvider.ts";
+import { localRuntimeServices } from "./LocalRuntime.ts";
+import * as Region from "./Region.ts";
+
+const awsServices = Layer.mergeAll(
+  Credentials.fromEnvironment,
+  Region.fromEnvironment,
+  Endpoint.fromEnvironment,
+).pipe(
+  Layer.provideMerge(DefaultEnvironment),
+  Layer.provideMerge(AwsAuth),
+  Layer.provideMerge(CredentialsStoreLive),
+);
+
+LocalFunctionProvider().pipe(
+  Layer.provide(localRuntimeServices()),
+  Layer.provide(awsServices),
+  RpcServer.launch,
+);

--- a/packages/alchemy/src/AWS/LocalRuntime.ts
+++ b/packages/alchemy/src/AWS/LocalRuntime.ts
@@ -1,0 +1,26 @@
+import * as Effect from "effect/Effect";
+import * as RpcProvider from "../Local/RpcProvider.ts";
+import { LiveLambdaRuntimeLive } from "./Lambda/Live/LiveRuntime.ts";
+
+/**
+ * Entry module of the AWS local dev sidecar process (see `./Local.ts`).
+ *
+ * `import.meta.resolve(<string>)` is a runtime API — TypeScript's
+ * `rewriteRelativeImportExtensions` does NOT touch the string literal, so we
+ * pick the extension from `import.meta.url`: `.ts` when running from `src/`
+ * (bun / tests), `.js` from the compiled `lib/` (published package).
+ */
+export const AWS_LOCAL_ENTRY_URL = import.meta.resolve(
+  import.meta.url.endsWith(".ts") ? "./Local.ts" : "./Local.js",
+  import.meta.url,
+);
+
+/**
+ * Runtime services for AWS local dev providers. Only constructed inside the
+ * sidecar process (dev mode, no RPC proxy) — in the engine process the
+ * providers are RPC stubs and these layers stay empty.
+ */
+export const localRuntimeServices = () =>
+  RpcProvider.providerServicesEffect(
+    Effect.sync(() => LiveLambdaRuntimeLive()),
+  );

--- a/packages/alchemy/src/AWS/Providers.ts
+++ b/packages/alchemy/src/AWS/Providers.ts
@@ -45,6 +45,7 @@ import * as IdentityCenter from "./IdentityCenter/index.ts";
 import * as Kinesis from "./Kinesis/index.ts";
 import * as KMS from "./KMS/index.ts";
 import * as Lambda from "./Lambda/index.ts";
+import { localRuntimeServices } from "./LocalRuntime.ts";
 import * as Logs from "./Logs/index.ts";
 import * as Organizations from "./Organizations/index.ts";
 import * as RDS from "./RDS/index.ts";
@@ -358,6 +359,7 @@ export const providers = () =>
         DockerLive,
       ),
     ),
+    Layer.provideMerge(localRuntimeServices()),
     Layer.provideMerge(Region.fromEnvironment),
     Layer.provideMerge(Credentials.fromEnvironment),
     Layer.provideMerge(Endpoint.fromEnvironment),

--- a/packages/alchemy/src/Util/StructuralSignature.ts
+++ b/packages/alchemy/src/Util/StructuralSignature.ts
@@ -1,0 +1,38 @@
+import * as Effect from "effect/Effect";
+import * as Redacted from "effect/Redacted";
+import { sha256 } from "./sha256.ts";
+
+/**
+ * Stable, collision-free structural signature used by local dev providers to
+ * decide whether a running instance needs to be torn down and restarted.
+ *
+ * A canonical JSON serialization (sorted keys, unwrapped `Redacted`,
+ * cycle-safe) gives an exact comparison instead of a lossy fingerprint
+ * (`Hash.structure` XOR-folds sibling fields, so mirrored values — e.g. an
+ * env var that also appears in derived bindings — can cancel out). The
+ * serialization is SHA-256 hashed so each retained signature is a fixed
+ * 64-char digest rather than a copy of the whole props/bindings blob.
+ */
+export const structuralSignature = (value: unknown): Effect.Effect<string> => {
+  const seen = new WeakSet<object>();
+  const normalize = (input: unknown): unknown => {
+    if (typeof input === "bigint") return `bigint:${input.toString()}`;
+    if (input === null || typeof input !== "object") return input;
+    if (Redacted.isRedacted(input)) {
+      return { __redacted: normalize(Redacted.value(input)) };
+    }
+    if (seen.has(input)) return "[circular]";
+    seen.add(input);
+    if (input instanceof Uint8Array) return { __bytes: Array.from(input) };
+    if (Array.isArray(input)) return input.map(normalize);
+    return Object.fromEntries(
+      Object.keys(input)
+        .sort()
+        .map((key) => [
+          key,
+          normalize((input as Record<string, unknown>)[key]),
+        ]),
+    );
+  };
+  return sha256(JSON.stringify(normalize(value)));
+};


### PR DESCRIPTION
Live Lambda for `AWS.Lambda.Function`: under `alchemy dev`, the deployed function becomes a small bridge that proxies every invocation to the developer's machine, where the handler runs against a locally-built bundle with hot reload. The response round-trips as the real Lambda's response, so Function URLs, event source mappings, and anything else that invokes the function keep working unchanged.

```sh
alchemy dev            # deploys the bridge, serves handlers locally
curl $FUNCTION_URL     # → {"platform":"darwin"} — ran on the dev machine
alchemy deploy         # code-hash diff swaps the real bundle back in
```

### How it works

Provider selection mirrors the Cloudflare Worker dev pattern:

```ts
export const FunctionProvider = () =>
  ProviderLayer.select({
    live: () => LiveFunctionProvider(),
    local: () => LocalFunctionProvider(), // RpcProvider.effect → AWS Local.ts sidecar
  });
```

`LocalFunctionProvider` runs in a new AWS RPC sidecar process (`src/AWS/Local.ts`), so AppSync subscriptions, bundle watchers, and handler children survive the engine's `--watch` restarts. Its `reconcile` delegates to the shared provider (`makeFunctionProvider({ bundleCode })`) with the bridge bundle substituted and a synthetic binding injecting the AppSync endpoints + `appsync:Event*` IAM permissions — role, bindings, URL config, and event sources deploy exactly as in live mode.

The transport is an account-wide **AppSync Events API** named `alchemy` (created lazily, shared by all stacks — the same architecture SST v3 uses, which replaced its IoT transport):

- Bridge (a ~6KB `nodejs22.x` handler) publishes `init` (function id + sandbox env, including the execution role's credentials) and one `next` per invocation, then waits: 16s offline window, extended to the invocation deadline once the dev machine replies `ping`.
- Dev side subscribes to `/alchemy/{stack}/{stage}/in`, runs each invocation in a per-sandbox child process spawned with the forwarded sandbox environment — local code gets the function's real env vars and IAM role credentials — and publishes `response`/`error` back.
- Payloads are chunked (128KB base64 packets) to fit AppSync's event size limit; SigV4 signing is hand-rolled (validated against the AWS reference vector) so the bridge stays dependency-free.

### Dev-loop behavior

- Code edit → provider `diff` is a **noop** (structural signature); only the local `Bundle.watch` rebuild runs (~300ms), children recycle on next invoke.
- Dev offline → the bridge fails the invocation after 16s (`alchemy dev is not running`), so Function URLs return 502 and event sources retry.
- `dev` ↔ `deploy` transitions are just code-hash diffs: deploy swaps the real bundle back in, dev swaps the bridge in.
- Dev bumps the deployed timeout to ≥60s so breakpoint debugging survives; everything else (memory, VPC, URL auth) deploys as configured.

Verified live end-to-end (us-west-2): fresh `alchemy dev` deploy → Function URL returns `platform: "darwin"`; hot edit picked up without any AWS API calls; kill dev → 502 after 16s; `alchemy deploy` → `platform: "linux"`; dev again → back to `darwin`. Existing `test/AWS/Lambda/Function.test.ts` passes (7/7). `examples/aws-lambda/live.run.ts` + `src/LiveFunction.ts` is a minimal runnable fixture.

### Floci

Floci (https://floci.io) is a LocalStack-compatible local AWS emulator (port 4566, `AWS_ENDPOINT_URL`). It is complementary to Live Lambda rather than an alternative: Live Lambda runs local code against **real** AWS; floci would run the rest of the stack **without** AWS. `AWSEnvironment` already carries an `endpoint` override that all distilled calls honor, so a floci-backed fully-local dev mode is mostly a profile/env concern — left as a follow-up.

### Known limitations (follow-ups)

- `RESPONSE_STREAM` function URLs are not proxied (buffered only).
- Forwarded role credentials are read per sandbox `init`; multi-hour sessions may need a re-`init` on expiry.
- The AppSync Event API is account-level bootstrap infrastructure and is never torn down by `destroy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
