### PR TITLE
feat(aws): fully-local dev against floci — local auth method, endpoint plumbing, auto-bootstrap

### DIFF
--- a/packages/alchemy/src/AWS/Assets.ts
+++ b/packages/alchemy/src/AWS/Assets.ts
@@ -5,6 +5,7 @@ import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
 import type { HttpClient } from "effect/unstable/http/HttpClient";
 import { AWSEnvironment } from "./Environment.ts";
@@ -85,11 +86,19 @@ export const AssetsLive = Layer.effect(
       Effect.flatMap(
         Option.match({
           onNone: () =>
-            Effect.die(
-              new Error(
-                "Assets bucket not found. Run 'alchemy aws bootstrap' to create it.",
-              ),
-            ),
+            Effect.gen(function* () {
+              const environment = yield* AWSEnvironment.current;
+              if (!environment.endpoint) {
+                return yield* Effect.die(
+                  new Error(
+                    "Assets bucket not found. Run 'alchemy aws bootstrap' to create it.",
+                  ),
+                );
+              }
+              // Local emulator (floci/LocalStack): bootstrap transparently —
+              // the bucket is free, instant, and disposable with the emulator.
+              return yield* createAssetsBucket;
+            }),
           onSome: (bucketName) => Effect.succeed(bucketName),
         }),
       ),
@@ -232,4 +241,44 @@ export const ensureAssetsBucketTags = Effect.fn(function* (bucketName: string) {
       })),
     },
   });
+});
+
+/**
+ * Create the tagged assets bucket for the current account+region and wait for
+ * it to be addressable. Idempotent — used by `alchemy aws bootstrap` and by
+ * the transparent local-emulator bootstrap in {@link AssetsLive}.
+ */
+export const createAssetsBucket = Effect.gen(function* () {
+  const { accountId, region } = yield* AWSEnvironment.current;
+  const bucketName = createAssetsBucketName(accountId, region);
+  yield* s3
+    .createBucket({
+      Bucket: bucketName,
+      BucketNamespace: "account-regional",
+      CreateBucketConfiguration: {
+        Tags: [{ Key: ASSETS_BUCKET_TAG, Value: "true" }],
+        ...(region === "us-east-1"
+          ? {}
+          : {
+              LocationConstraint: region as s3.BucketLocationConstraint,
+            }),
+      },
+    })
+    .pipe(
+      Effect.catchTag("BucketAlreadyOwnedByYou", () => Effect.void),
+      Effect.retry({
+        while: (e) =>
+          e._tag === "OperationAborted" || e._tag === "ServiceUnavailable",
+        schedule: Schedule.exponential(100),
+      }),
+    );
+
+  yield* s3.headBucket({ Bucket: bucketName }).pipe(
+    Effect.retry({
+      schedule: Schedule.max([Schedule.exponential(100), Schedule.recurs(10)]),
+    }),
+  );
+
+  yield* Effect.logInfo(`Created assets bucket: ${bucketName}`);
+  return bucketName;
 });

--- a/packages/alchemy/src/AWS/AuthProvider.ts
+++ b/packages/alchemy/src/AWS/AuthProvider.ts
@@ -25,6 +25,11 @@ import {
   retryOnce,
 } from "../Auth/Env.ts";
 import * as Clank from "../Util/Clank.ts";
+import * as Endpoint from "./Endpoint.ts";
+import {
+  DEFAULT_LOCAL_ENDPOINT,
+  ensureLocalEmulator,
+} from "./LocalEmulator.ts";
 import * as Region from "./Region.ts";
 
 export const AWS_AUTH_PROVIDER_NAME = "AWS";
@@ -32,7 +37,27 @@ export const AWS_AUTH_PROVIDER_NAME = "AWS";
 export type AwsAuthConfig =
   | { method: "sso"; ssoProfile: string }
   | { method: "stored" }
-  | { method: "env" };
+  | { method: "env" }
+  | {
+      /**
+       * Local AWS emulator (floci, LocalStack, or any endpoint-compatible
+       * emulator). Resolves dummy credentials and points every AWS call at
+       * {@link LocalAwsConfig.endpoint} — no AWS account required.
+       */
+      method: "local";
+      /** @default "http://localhost:4566" */
+      endpoint?: string;
+      /** @default "us-east-1" */
+      region?: string;
+      /** @default "000000000000" */
+      accountId?: string;
+      /**
+       * Start the floci container automatically when nothing is listening on
+       * the (default) endpoint. Only applies to the default endpoint.
+       * @default true
+       */
+      autoStart?: boolean;
+    };
 
 const options: Array<{
   value: AwsAuthConfig["method"];
@@ -54,6 +79,11 @@ const options: Array<{
     label: "Stored",
     hint: "stored in ~/.alchemy/credentials",
   },
+  {
+    value: "local",
+    label: "Local emulator",
+    hint: "floci / LocalStack on localhost:4566 — no AWS account",
+  },
 ];
 
 export interface AwsStoredCredentials {
@@ -72,6 +102,12 @@ export interface AwsResolvedCredentials {
     sessionToken: Redacted.Redacted<string> | undefined;
   }>;
   region: string;
+  /**
+   * Custom AWS endpoint (local emulator). Flows into
+   * `AWSEnvironment.endpoint`, which `Endpoint.fromEnvironment` applies to
+   * every AWS SDK call.
+   */
+  endpoint?: string;
   source: {
     type: AwsAuthConfig["method"];
     details?: string;
@@ -96,11 +132,13 @@ export const AwsAuth = AuthProviderLayer<
       secretAccessKey,
       sessionToken,
       region,
+      endpoint,
     }: {
       accessKeyId: Redacted.Redacted<string>;
       secretAccessKey: Redacted.Redacted<string>;
       sessionToken?: Redacted.Redacted<string>;
       region: string;
+      endpoint?: string;
     }) =>
       STS.getCallerIdentity({}).pipe(
         Effect.provide(
@@ -118,6 +156,9 @@ export const AwsAuth = AuthProviderLayer<
             // deadlock: it derives the region from AWSEnvironment, which is the
             // very service still being constructed by this STS call.
             Region.of(region),
+            // A custom endpoint (local emulator) must apply to this STS call
+            // too — the default resolver would call real AWS.
+            endpoint ? Endpoint.of(endpoint) : Layer.empty,
           ),
         ),
         Effect.flatMap((self) =>
@@ -195,6 +236,25 @@ export const AwsAuth = AuthProviderLayer<
               }),
             ),
             Match.when("stored", () => loginStored(profileName)),
+            Match.when("local", () =>
+              Effect.gen(function* () {
+                const endpoint = yield* Clank.text({
+                  message: "Emulator endpoint",
+                  placeholder: DEFAULT_LOCAL_ENDPOINT,
+                  defaultValue: DEFAULT_LOCAL_ENDPOINT,
+                });
+                const region = yield* Clank.text({
+                  message: "Region",
+                  placeholder: "us-east-1",
+                  defaultValue: "us-east-1",
+                });
+                return {
+                  method: "local" as const,
+                  endpoint: endpoint || DEFAULT_LOCAL_ENDPOINT,
+                  region: region || "us-east-1",
+                };
+              }),
+            ),
             Match.exhaustive,
           ),
         ),
@@ -243,6 +303,10 @@ export const AwsAuth = AuthProviderLayer<
                   }),
                 );
               }
+              // LocalStack-standard endpoint override: with
+              // AWS_ENDPOINT_URL set, every AWS call (including the STS
+              // account lookup below) targets the emulator.
+              const endpoint = yield* getEnv("AWS_ENDPOINT_URL");
               const accountId = yield* getEnvRequired("AWS_ACCOUNT_ID").pipe(
                 Effect.catch(() =>
                   getAccountId({
@@ -250,6 +314,7 @@ export const AwsAuth = AuthProviderLayer<
                     secretAccessKey,
                     sessionToken,
                     region,
+                    endpoint,
                   }),
                 ),
               );
@@ -261,7 +326,39 @@ export const AwsAuth = AuthProviderLayer<
                   sessionToken,
                 }),
                 region,
+                endpoint,
                 source: { type: "env" as const },
+              } satisfies AwsResolvedCredentials;
+            }),
+          ),
+          Match.when(
+            { method: "local" },
+            Effect.fn(function* (config) {
+              const endpoint = config.endpoint ?? DEFAULT_LOCAL_ENDPOINT;
+              yield* ensureLocalEmulator({
+                endpoint,
+                autoStart:
+                  config.autoStart ?? endpoint === DEFAULT_LOCAL_ENDPOINT,
+              }).pipe(
+                Effect.mapError(
+                  (e) =>
+                    new AuthError({
+                      message: e.message,
+                      cause: e,
+                    }),
+                ),
+              );
+              return {
+                // Emulators accept any non-empty credentials.
+                accountId: config.accountId ?? "000000000000",
+                credentials: Effect.succeed({
+                  accessKeyId: Redacted.make("test"),
+                  secretAccessKey: Redacted.make("test"),
+                  sessionToken: undefined,
+                }),
+                region: config.region ?? "us-east-1",
+                endpoint,
+                source: { type: "local" as const, details: endpoint },
               } satisfies AwsResolvedCredentials;
             }),
           ),
@@ -398,6 +495,7 @@ export const AwsAuth = AuthProviderLayer<
     const logout = (profileName: string, config: AwsAuthConfig) =>
       Match.value(config).pipe(
         Match.when({ method: "env" }, () => Effect.void),
+        Match.when({ method: "local" }, () => Effect.void),
         Match.when({ method: "sso" }, (config) =>
           Clank.info(
             `AWS: running 'aws sso logout --profile ${config.ssoProfile}'...`,
@@ -425,6 +523,7 @@ export const AwsAuth = AuthProviderLayer<
       Match.value(config)
         .pipe(
           Match.when({ method: "env" }, () => Effect.void),
+          Match.when({ method: "local" }, () => Effect.void),
           Match.when({ method: "sso" }, loginSSO),
           Match.when({ method: "stored" }, () =>
             store

--- a/packages/alchemy/src/AWS/Bootstrap.ts
+++ b/packages/alchemy/src/AWS/Bootstrap.ts
@@ -1,16 +1,13 @@
-import type { BucketLocationConstraint } from "@distilled.cloud/aws/s3";
 import * as s3 from "@distilled.cloud/aws/s3";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Schedule from "effect/Schedule";
 import {
-  ASSETS_BUCKET_TAG,
-  createAssetsBucketName,
+  createAssetsBucket,
   ensureAssetsBucketTags,
   lookupAssetsBucket,
   lookupAssetsBuckets,
 } from "./Assets.ts";
-import { AWSEnvironment } from "./Environment.ts";
 
 /**
  * Bootstrap the AWS environment by creating the assets bucket.
@@ -19,7 +16,6 @@ import { AWSEnvironment } from "./Environment.ts";
  * The bucket is tagged and later discovered by tag lookup instead of by name.
  */
 export const bootstrap = Effect.fn(function* () {
-  const { region } = yield* AWSEnvironment.current;
   const existingBucket = yield* lookupAssetsBucket;
 
   if (Option.isSome(existingBucket)) {
@@ -30,36 +26,7 @@ export const bootstrap = Effect.fn(function* () {
     return { bucketName: existingBucket.value, created: false };
   }
 
-  const { accountId } = yield* AWSEnvironment.current;
-  const bucketName = createAssetsBucketName(accountId, region);
-  yield* s3
-    .createBucket({
-      Bucket: bucketName,
-      BucketNamespace: "account-regional",
-      CreateBucketConfiguration: {
-        Tags: [{ Key: ASSETS_BUCKET_TAG, Value: "true" }],
-        ...(region === "us-east-1"
-          ? {}
-          : { LocationConstraint: region as BucketLocationConstraint }),
-      },
-    })
-    .pipe(
-      Effect.catchTag("BucketAlreadyOwnedByYou", () => Effect.void),
-      Effect.retry({
-        while: (e) =>
-          e._tag === "OperationAborted" || e._tag === "ServiceUnavailable",
-        schedule: Schedule.exponential(100),
-      }),
-    );
-
-  yield* s3.headBucket({ Bucket: bucketName }).pipe(
-    Effect.retry({
-      schedule: Schedule.max([Schedule.exponential(100), Schedule.recurs(10)]),
-    }),
-  );
-
-  yield* Effect.logInfo(`Created assets bucket: ${bucketName}`);
-
+  const bucketName = yield* createAssetsBucket;
   return { bucketName, created: true };
 });
 

--- a/packages/alchemy/src/AWS/Lambda/Function.ts
+++ b/packages/alchemy/src/AWS/Lambda/Function.ts
@@ -1301,10 +1301,24 @@ export const makeFunctionProvider = (options?: FunctionProviderOptions) =>
       const getAndUpdate = Lambda.getFunction({
         FunctionName: functionName,
       }).pipe(
+        // If it exists and contains these tags, we will assume it was created
+        // by alchemy but state was lost, so if it exists, let's adopt it.
+        // Some backends (e.g. local emulators) omit `Tags` on GetFunction —
+        // fall back to ListTags before concluding the function is foreign.
+        Effect.flatMap((f) =>
+          f.Tags !== undefined
+            ? Effect.succeed(hasTags(tags, f.Tags))
+            : Lambda.listTags({
+                Resource: f.Configuration?.FunctionArn ?? "",
+              }).pipe(
+                Effect.map((r) => hasTags(tags, r.Tags ?? {})),
+                Effect.catchTag("ResourceNotFoundException", () =>
+                  Effect.succeed(false),
+                ),
+              ),
+        ),
         Effect.filterOrFail(
-          // if it exists and contains these tags, we will assume it was created by alchemy
-          // but state was lost, so if it exists, let's adopt it
-          (f) => hasTags(tags, f.Tags),
+          (owned) => owned,
           () =>
             // TODO(sam): add custom
             new Error("Function tags do not match expected values"),

--- a/packages/alchemy/src/AWS/Lambda/FunctionProvider.ts
+++ b/packages/alchemy/src/AWS/Lambda/FunctionProvider.ts
@@ -9,6 +9,7 @@ import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 import * as Result from "effect/Result";
 import * as Scope from "effect/Scope";
@@ -17,10 +18,10 @@ import { AlchemyContext } from "../../AlchemyContext.ts";
 import * as Bundle from "../../Bundle/Bundle.ts";
 import type { ScopedPlanStatusSession } from "../../Cli/Cli.ts";
 import { isResolved } from "../../Diff.ts";
-import * as ProviderLayer from "../../Local/ProviderLayer.ts";
 import * as RpcProvider from "../../Local/RpcProvider.ts";
 import type { ResourceBinding } from "../../Resource.ts";
 import { structuralSignature } from "../../Util/StructuralSignature.ts";
+import { AWSEnvironment } from "../Environment.ts";
 import type { PolicyStatement } from "../IAM/Policy.ts";
 import { AWS_LOCAL_ENTRY_URL } from "../LocalRuntime.ts";
 import {
@@ -36,10 +37,21 @@ import { bridgeCodeBundle } from "./Live/BridgeBundle.ts";
 import { LiveLambdaRuntime } from "./Live/LiveRuntime.ts";
 
 export const FunctionProvider = () =>
-  ProviderLayer.select({
-    live: () => LiveFunctionProvider(),
-    local: () => LocalFunctionProvider(),
-  });
+  Layer.unwrap(
+    Effect.gen(function* () {
+      const context = yield* AlchemyContext;
+      if (!context.dev) {
+        return LiveFunctionProvider();
+      }
+      const environment = yield* AWSEnvironment.current;
+      // A custom endpoint means a local emulator (floci/LocalStack): deploy
+      // the real bundle into the emulator's Docker Lambda. The Live Lambda
+      // bridge needs real AppSync Events, so it only runs against real AWS.
+      return environment.endpoint
+        ? LiveFunctionProvider()
+        : LocalFunctionProvider();
+    }),
+  );
 
 /**
  * Sessions crossing the RPC boundary lose their callables (functions

--- a/packages/alchemy/src/AWS/Lambda/HttpServer.ts
+++ b/packages/alchemy/src/AWS/Lambda/HttpServer.ts
@@ -89,10 +89,10 @@ export const makeFunctionHttpHandler = <Req>(handler: Http.HttpEffect<Req>) => {
 const functionUrlEventToWebRequest = (
   event: LambdaFunctionURLEvent,
 ): Request => {
-  const protocol =
-    event.headers["x-forwarded-proto"] ??
-    event.requestContext.http.protocol ??
-    "https";
+  // `requestContext.http.protocol` is the HTTP version ("HTTP/1.1"), never a
+  // URL scheme — without `x-forwarded-proto` (real Function URLs always set
+  // it; local emulators may not) fall back to https.
+  const protocol = event.headers["x-forwarded-proto"] ?? "https";
   const host = event.headers.host ?? event.requestContext.domainName;
   const url = `${protocol}://${host}${event.rawPath}${event.rawQueryString ? `?${event.rawQueryString}` : ""}`;
   const method = event.requestContext.http.method;

--- a/packages/alchemy/src/AWS/LocalEmulator.ts
+++ b/packages/alchemy/src/AWS/LocalEmulator.ts
@@ -1,0 +1,122 @@
+/**
+ * Lifecycle helpers for a local AWS emulator (floci — a LocalStack-compatible
+ * emulator on port 4566, https://floci.io).
+ *
+ * The `local` AWS auth method points `AWSEnvironment.endpoint` at the
+ * emulator; this module makes sure something is actually listening there,
+ * auto-starting the floci container for the default endpoint.
+ */
+import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as ChildProcess from "effect/unstable/process/ChildProcess";
+
+export const DEFAULT_LOCAL_ENDPOINT = "http://localhost:4566";
+
+const FLOCI_CONTAINER_NAME = "floci";
+const FLOCI_IMAGE = "floci/floci:latest";
+
+export class LocalEmulatorError extends Error {
+  readonly _tag = "LocalEmulatorError";
+}
+
+/**
+ * Any HTTP response (even an error status) proves a listener; only transport
+ * failures mean the emulator is down.
+ */
+const isReachable = (endpoint: string) =>
+  Effect.gen(function* () {
+    const client = yield* HttpClient.HttpClient;
+    return yield* client.get(endpoint).pipe(
+      Effect.as(true),
+      Effect.catch((error) =>
+        Effect.succeed(error.reason._tag !== "TransportError"),
+      ),
+    );
+  });
+
+const docker = (args: string[]) =>
+  Effect.gen(function* () {
+    const handle = yield* ChildProcess.make("docker", args, {
+      shell: false,
+      stdin: "ignore",
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    return yield* handle.exitCode;
+  }).pipe(
+    Effect.scoped,
+    Effect.catch(() => Effect.succeed(-1)),
+  );
+
+/**
+ * Ensure an emulator is listening at `endpoint`. For the default endpoint
+ * (with `autoStart`), starts — or creates — the `floci` Docker container and
+ * waits for it to come up (first run pulls the image, so the wait is
+ * generous). Fails with {@link LocalEmulatorError} when the endpoint stays
+ * unreachable.
+ */
+export const ensureLocalEmulator = Effect.fn(function* (options: {
+  endpoint: string;
+  autoStart: boolean;
+}) {
+  if (yield* isReachable(options.endpoint)) {
+    return;
+  }
+  if (!options.autoStart) {
+    return yield* Effect.fail(
+      new LocalEmulatorError(
+        `no local AWS emulator is listening at ${options.endpoint} — start floci with:\n` +
+          `  docker run -d --name ${FLOCI_CONTAINER_NAME} -p 4566:4566 -v /var/run/docker.sock:/var/run/docker.sock -u root ${FLOCI_IMAGE}`,
+      ),
+    );
+  }
+
+  yield* Effect.logInfo(
+    `starting local AWS emulator (${FLOCI_IMAGE}) at ${options.endpoint}`,
+  );
+  // A previously-created container restarts fast; otherwise create one. The
+  // Docker socket mount is required for floci's Docker-backed services
+  // (Lambda, RDS, ...).
+  const started = yield* docker(["start", FLOCI_CONTAINER_NAME]);
+  if (started !== 0) {
+    const ran = yield* docker([
+      "run",
+      "-d",
+      "--name",
+      FLOCI_CONTAINER_NAME,
+      "-p",
+      "4566:4566",
+      "-v",
+      "/var/run/docker.sock:/var/run/docker.sock",
+      "-u",
+      "root",
+      FLOCI_IMAGE,
+    ]);
+    if (ran !== 0) {
+      return yield* Effect.fail(
+        new LocalEmulatorError(
+          `failed to start the ${FLOCI_CONTAINER_NAME} Docker container — is Docker running?`,
+        ),
+      );
+    }
+  }
+
+  yield* isReachable(options.endpoint).pipe(
+    Effect.flatMap((up) =>
+      up
+        ? Effect.void
+        : Effect.fail(
+            new LocalEmulatorError(
+              `local AWS emulator did not become reachable at ${options.endpoint}`,
+            ),
+          ),
+    ),
+    Effect.retry({
+      while: (e) => e._tag === "LocalEmulatorError",
+      // First run pulls the image; allow up to two minutes.
+      schedule: Schedule.spaced("1 second"),
+      times: 120,
+    }),
+  );
+});


### PR DESCRIPTION
Fully-local AWS dev backed by [floci](https://floci.io) (a LocalStack-compatible emulator, MIT, port 4566). The entire stack — IAM roles, Lambda functions with Function URLs, DynamoDB, S3 assets bucket — deploys into a Docker container instead of AWS. No account, no network, disposable state.

```sh
alchemy login --configure --profile local   # pick "Local emulator" — one time
alchemy deploy --profile local              # whole stack into floci
alchemy dev --profile local                 # hot reload into floci's Docker Lambda
```

Verified end-to-end against floci 1.5.33: the unmodified live Function provider deployed an Effect-native Lambda into floci (role + inline policy + tags + Function URL), the URL served real requests from floci's `nodejs22.x` Docker container, `alchemy dev` hot-reloaded an edit into the emulator, `destroy` cleaned up, and the container auto-starts when stopped. Existing `Function.test.ts` still passes against real AWS (7/7).

### How it works

`AWSEnvironment.endpoint` already existed and `Endpoint.fromEnvironment` already applies it to every distilled call — nothing populated it until now.

```ts
export type AwsAuthConfig =
  | { method: "sso"; ssoProfile: string }
  | { method: "stored" }
  | { method: "env" }
  | { method: "local"; endpoint?; region?; accountId?; autoStart? }  // new
```

The `local` method resolves dummy credentials + the endpoint, and auto-starts the `floci` Docker container when nothing is listening on the default endpoint (`docker start` → `docker run`, waiting through the first image pull). `AWS_ENDPOINT_URL` is also honored by the `env` method — the LocalStack-standard zero-config path.

### Relationship to Live Lambda (#853)

The two dev modes are complementary, selected by where the stack lives:

```ts
export const FunctionProvider = () =>
  Layer.unwrap(Effect.gen(function* () {
    const context = yield* AlchemyContext;
    if (!context.dev) return LiveFunctionProvider();
    const environment = yield* AWSEnvironment.current;
    // emulator: deploy the real bundle into its Docker Lambda;
    // real AWS: swap in the AppSync live bridge and run code natively
    return environment.endpoint ? LiveFunctionProvider() : LocalFunctionProvider();
  }));
```

- `alchemy dev` (real AWS) — full-fidelity hybrid: real services, real IAM, handler runs natively on the dev machine via the Live Lambda bridge (~ms hot reload, breakpoints).
- `alchemy dev --profile local` (floci) — no AWS account at all; handlers run inside the emulator's Docker Lambda; hot reload is a fast local `UpdateFunctionCode` (~1–2s).

A follow-up can combine them: an HTTP loopback bridge (`host.docker.internal`) deployed into floci would reuse the #853 runtime for native-process execution + sub-second reload in fully-local mode.

### Also in this change

Two live-provider robustness fixes the emulator surfaced:

- The Lambda ownership check falls back to `ListTags` when `GetFunction` omits `Tags` (floci omits it; real AWS can too under restricted IAM).
- Function URL event parsing no longer uses `requestContext.http.protocol` (`"HTTP/1.1"`) as a URL scheme when `x-forwarded-proto` is absent.
- `Assets` auto-bootstraps its bucket when targeting an emulator (creation logic moved from `Bootstrap.ts` to `Assets.createAssetsBucket`, shared with `alchemy aws bootstrap`).

### Out of scope (follow-ups)

- HTTP loopback bridge for native-process execution in local mode (best-of-both dev loop).
- Emulator fidelity gaps beyond Lambda/DynamoDB/S3/SQS/IAM are undiscovered — broader provider coverage against floci needs its own probe pass.
- `aws bootstrap` CLI still resolves profiles from `~/.aws` directly; unchanged here (local mode bypasses it via auto-bootstrap).

Stacked on #853.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
