### PR TITLE
fix(engine): destroy no longer orphans physical resources of attr-less creating rows

### DIFF
--- a/packages/alchemy/src/Apply.ts
+++ b/packages/alchemy/src/Apply.ts
@@ -5,6 +5,7 @@ import * as Option from "effect/Option";
 import type { Simplify } from "effect/Types";
 import type { ActionLike } from "./Action.ts";
 import { makeResolveContext } from "./ActionRuntimeContext.ts";
+import { stripUnowned, Unowned } from "./AdoptPolicy.ts";
 import { RuntimeContext } from "./RuntimeContext.ts";
 import {
   Artifacts,
@@ -1570,7 +1571,7 @@ const collectGarbage = Effect.fn(function* (
           instanceId,
           downstream,
           props,
-          attr,
+          attr: persistedAttr,
           provider,
         } = isDeleteNode(node)
           ? {
@@ -1601,6 +1602,10 @@ const collectGarbage = Effect.fn(function* (
               attr: node.old.attr,
               provider: yield* findProviderByType(node.old.resourceType),
             };
+
+        // Mutable: an attr-less row (interrupted create) may recover its
+        // attributes from `provider.read` below, right before deletion.
+        let attr = persistedAttr;
 
         const nextAncestors = new Set(ancestors).add(fqn);
 
@@ -1661,19 +1666,6 @@ const collectGarbage = Effect.fn(function* (
                 yield* report("retained");
                 return;
               }
-              yield* commit<DeletingResourceState>({
-                status: "deleting",
-                fqn,
-                logicalId,
-                instanceId,
-                resourceType,
-                props,
-                attr,
-                downstream,
-                providerVersion: provider.version ?? 0,
-                bindings: excludeDeletedBindings(node.bindings),
-                removalPolicy: node.resource.RemovalPolicy,
-              });
             }
 
             // Honor `retain` for the old generation of a replacement, mirroring
@@ -1687,6 +1679,76 @@ const collectGarbage = Effect.fn(function* (
               yield* scopedSession.note(
                 "Retaining replaced resource (removal policy: retain)...",
               );
+            }
+
+            // A row can reach deletion with `attr === undefined` when a create
+            // was interrupted after the cloud-side call succeeded but before
+            // `reconcile` returned Attributes (a `creating` row — or the old
+            // generation of a replacement chain in the same predicament).
+            // Skipping the provider's delete outright would silently orphan
+            // the physical resource, so ask `read` to look it up from the
+            // persisted props (providers derive the deterministic physical
+            // name from id/props):
+            //   - plain attrs    → exists and is ours; proceed to delete
+            //   - Unowned(attrs) → exists but is NOT ours (e.g. our create
+            //                      actually lost a name race, or died before
+            //                      stamping ownership) — never delete a
+            //                      foreign resource; drop our state and say so
+            //   - undefined      → nothing exists; dropping state is safe
+            if (attr === undefined && !retainOldGeneration) {
+              if (provider.read) {
+                const recovered = yield* provider
+                  .read({
+                    id: logicalId,
+                    fqn,
+                    instanceId,
+                    olds: props as never,
+                    output: undefined,
+                  })
+                  .pipe(
+                    instrumentLifecycle(
+                      "read",
+                      fqn,
+                      resourceType,
+                      logicalId,
+                      instanceId,
+                    ),
+                  );
+                if (recovered !== undefined) {
+                  if (Unowned.is(recovered)) {
+                    yield* scopedSession.note(
+                      "Resource exists in the cloud but is not owned by this " +
+                        "stack — leaving it in place (re-deploy with --adopt " +
+                        "to take ownership, then destroy).",
+                    );
+                  } else {
+                    attr = stripUnowned(recovered as Record<string, any>);
+                  }
+                }
+              } else {
+                yield* scopedSession.note(
+                  "No attributes were recorded for this resource (its create " +
+                    "was interrupted) and the provider does not implement " +
+                    "`read` — if a physical resource was created, it must be " +
+                    "cleaned up manually.",
+                );
+              }
+            }
+
+            if (isDeleteNode(node)) {
+              yield* commit<DeletingResourceState>({
+                status: "deleting",
+                fqn,
+                logicalId,
+                instanceId,
+                resourceType,
+                props,
+                attr,
+                downstream,
+                providerVersion: provider.version ?? 0,
+                bindings: excludeDeletedBindings(node.bindings),
+                removalPolicy: node.resource.RemovalPolicy,
+              });
             }
 
             if (attr !== undefined && !retainOldGeneration) {

--- a/packages/alchemy/src/Plan.ts
+++ b/packages/alchemy/src/Plan.ts
@@ -846,10 +846,32 @@ export const make = <A>(
                   })
                   .pipe(providePlanScope(fqn, oldState.instanceId));
                 if (attr) {
+                  // The recovered resource may be foreign: our interrupted
+                  // create could have lost a name race, or died before
+                  // stamping ownership. Route `Unowned` through the same
+                  // adoption table as the cold-start probe above — never
+                  // silently take over (and later mutate/delete) a resource
+                  // we cannot prove we created.
+                  if (Unowned.is(attr)) {
+                    const adoptThis = resource.Adopt ?? (yield* shouldAdopt);
+                    if (!adoptThis) {
+                      return yield* new OwnedBySomeoneElse({
+                        message:
+                          `Cannot resume creating resource '${fqn}' ` +
+                          `(${resource.Type}): a resource with its physical ` +
+                          "identity exists in the cloud but is not owned by " +
+                          "this stack/stage/logical-id. Re-run with `--adopt` " +
+                          "(or wrap the effect in `adopt(true)`) to take it " +
+                          "over.",
+                        resourceType: resource.Type,
+                        logicalId: id,
+                      });
+                    }
+                  }
                   return Node<Create>({
                     action: "create",
                     props: news,
-                    state: { ...oldState, attr },
+                    state: { ...oldState, attr: stripUnowned(attr) },
                   });
                 }
               }
@@ -1251,36 +1273,27 @@ export const make = <A>(
             // Tasks are routed through `actionDeletions` above.
             if (isActionState(persisted)) return;
             const oldState = persisted as ResourceState | undefined;
-            let attr: any = oldState?.attr;
             if (oldState) {
               const { logicalId } = parseFqn(fqn);
               const resourceType = oldState.resourceType;
               const provider = yield* findProviderByType(resourceType);
-              if (oldState.attr === undefined) {
-                if (provider.read) {
-                  attr = yield* provider
-                    .read({
-                      id: logicalId,
-                      fqn,
-                      instanceId: oldState.instanceId,
-                      olds: oldState.props as never,
-                      output: oldState.attr as never,
-                    })
-                    .pipe(providePlanScope(fqn, oldState.instanceId));
-                }
-              }
+              // NOTE: an attr-less row (interrupted create) is NOT recovered
+              // here. Apply's `deleteResource` performs the authoritative
+              // read-then-delete recovery — it also covers replaced-chain
+              // old generations that never pass through plan, and routes
+              // `Unowned` results away from `provider.delete`.
               return [
                 fqn,
                 {
                   action: "delete",
-                  state: { ...oldState, attr },
+                  state: oldState,
                   provider: provider,
                   resource: {
                     Namespace: oldState.namespace,
                     FQN: fqn,
                     LogicalId: logicalId,
                     Type: oldState.resourceType,
-                    Attributes: attr,
+                    Attributes: oldState.attr,
                     Props: oldState.props,
                     Binding: undefined!,
                     Provider: Provider(resourceType),

--- a/packages/alchemy/test/apply.test.ts
+++ b/packages/alchemy/test/apply.test.ts
@@ -6,6 +6,7 @@ import * as Provider from "@/Provider";
 import * as RemovalPolicy from "@/RemovalPolicy.ts";
 import { Stack } from "@/Stack";
 import {
+  type CreatingResourceState,
   type ReplacedResourceState,
   type ReplacingResourceState,
   type ResourceState,
@@ -14,8 +15,10 @@ import {
 import * as Test from "@/Test/Alchemy";
 import { describe, expect } from "alchemy-test";
 import { Data, Layer } from "effect";
+import * as Cause from "effect/Cause";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 import * as Redacted from "effect/Redacted";
 import {
   AliasedWidget,
@@ -1701,6 +1704,241 @@ describe("from creating state", () => {
 
         // Resource should be cleaned up
         expect(yield* getState("A")).toBeUndefined();
+      }),
+  );
+
+  // ── attr-less `creating` rows must not orphan the physical resource ──
+  //
+  // A create can be interrupted AFTER the cloud-side call succeeded but
+  // BEFORE reconcile returned Attributes, leaving a `creating` row with
+  // `attr === undefined`. Destroy used to skip `provider.delete` entirely
+  // for such rows and drop the state, silently orphaning the physical
+  // resource. The engine now read-then-deletes: `provider.read` recovers
+  // the attributes from the persisted props (deterministic physical name),
+  // and only a confirmed-missing or Unowned resource skips the delete.
+
+  test.provider(
+    "destroy deletes the recovered physical resource of an attr-less creating row",
+    (stack) =>
+      Effect.gen(function* () {
+        // Interrupted create: cloud-side create "succeeded" but no attrs
+        // were ever persisted.
+        yield* Effect.gen(function* () {
+          yield* TestResource("A", {
+            string: "test-string",
+          });
+        }).pipe(stack.deploy, hook());
+        expect((yield* getState("A"))?.status).toEqual("creating");
+        expect((yield* getState("A"))?.attr).toBeUndefined();
+
+        const deleted: string[] = [];
+        yield* stack.destroy().pipe(
+          hook({
+            read: () => Effect.succeed({ string: "test-string" }),
+            delete: (id) => Effect.sync(() => void deleted.push(id)),
+          }),
+        );
+
+        // The physical resource recovered by `read` was actually deleted —
+        // not silently orphaned.
+        expect(deleted).toEqual(["A"]);
+        expect(yield* getState("A")).toBeUndefined();
+      }),
+  );
+
+  test.provider(
+    "destroy never deletes a recovered resource that is Unowned",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* Effect.gen(function* () {
+          yield* TestResource("A", {
+            string: "test-string",
+          });
+        }).pipe(stack.deploy, hook());
+        expect((yield* getState("A"))?.status).toEqual("creating");
+
+        const deleted: string[] = [];
+        yield* stack.destroy().pipe(
+          hook({
+            // The physical name exists but belongs to someone else — our
+            // interrupted create actually lost a name race (or died before
+            // stamping ownership).
+            read: () => Effect.succeed(Unowned({ string: "foreign" })),
+            delete: (id) => Effect.sync(() => void deleted.push(id)),
+          }),
+        );
+
+        // Foreign resources are left in place; only our state is dropped.
+        expect(deleted).toEqual([]);
+        expect(yield* getState("A")).toBeUndefined();
+      }),
+  );
+
+  test.provider(
+    "destroy tolerates not-found for an attr-less creating row",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* Effect.gen(function* () {
+          yield* TestResource("A", {
+            string: "test-string",
+          });
+        }).pipe(stack.deploy, hook());
+        expect((yield* getState("A"))?.status).toEqual("creating");
+
+        const deleted: string[] = [];
+        yield* stack.destroy().pipe(
+          hook({
+            read: () => Effect.succeed(undefined),
+            delete: (id) => Effect.sync(() => void deleted.push(id)),
+          }),
+        );
+
+        // Nothing exists cloud-side — delete is not invoked, state is dropped.
+        expect(deleted).toEqual([]);
+        expect(yield* getState("A")).toBeUndefined();
+      }),
+  );
+
+  test.provider(
+    "destroy drops an attr-less creating row when the provider has no read",
+    (stack) =>
+      Effect.gen(function* () {
+        // Manufacture the interrupted-create row directly: Test.Queue's
+        // provider implements no `read`, so recovery is impossible and the
+        // engine can only drop the row (surfacing a note, not crashing).
+        const state = yield* yield* State;
+        const stk = yield* Stack;
+        yield* state.set({
+          stack: stk.name,
+          stage: stk.stage,
+          fqn: "Q",
+          value: {
+            kind: "resource",
+            status: "creating",
+            resourceType: "Test.Queue",
+            namespace: undefined,
+            fqn: "Q",
+            logicalId: "Q",
+            instanceId: "q-instance",
+            providerVersion: 0,
+            downstream: [],
+            bindings: [],
+            props: { name: "q" },
+          } satisfies CreatingResourceState,
+        });
+
+        yield* stack.destroy();
+        expect(yield* getState("Q")).toBeUndefined();
+      }),
+  );
+
+  test.provider(
+    "replacement drain recovers and deletes an attr-less old generation",
+    (stack) =>
+      Effect.gen(function* () {
+        // 1. Interrupted create — `creating` row with no attr.
+        yield* Effect.gen(function* () {
+          yield* TestResource("A", {
+            replaceString: "original",
+          });
+        }).pipe(stack.deploy, hook());
+        expect((yield* getState("A"))?.status).toEqual("creating");
+        expect((yield* getState("A"))?.attr).toBeUndefined();
+
+        // 2. Deploy a replacement. The first `read` (plan-time create-resume
+        // probe) reports not-found so the engine plans a replacement instead
+        // of resuming the create; the drain-time `read` then discovers the
+        // physical resource the interrupted create actually made, and the
+        // engine must delete it while draining the replaced old generation.
+        const deleted: string[] = [];
+        let reads = 0;
+        yield* Effect.gen(function* () {
+          yield* TestResource("A", {
+            replaceString: "new",
+          });
+        }).pipe(
+          stack.deploy,
+          hook({
+            read: () =>
+              Effect.sync(() => ++reads).pipe(
+                Effect.map((n) =>
+                  n === 1 ? undefined : { replaceString: "original" },
+                ),
+              ),
+            delete: (id) => Effect.sync(() => void deleted.push(id)),
+          }),
+        );
+
+        // The old generation's physical resource was recovered and deleted,
+        // and the replacement collapsed to a stable `created` row.
+        expect(deleted).toEqual(["A"]);
+        expect((yield* getState("A"))?.status).toEqual("created");
+        expect(
+          ((yield* getState("A"))?.attr as TestResourceProps)?.replaceString,
+        ).toEqual("new");
+      }),
+  );
+
+  test.provider(
+    "resuming an interrupted create fails loudly when the recovered resource is Unowned",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* Effect.gen(function* () {
+          yield* TestResource("A", {
+            string: "test-string",
+          });
+        }).pipe(stack.deploy, hook());
+        expect((yield* getState("A"))?.status).toEqual("creating");
+
+        const exit = yield* Effect.gen(function* () {
+          yield* TestResource("A", {
+            string: "test-string",
+          });
+        }).pipe(
+          stack.deploy,
+          hook({
+            read: () => Effect.succeed(Unowned({ string: "foreign" })),
+          }),
+          Effect.exit,
+        );
+
+        expect(Exit.isFailure(exit)).toBe(true);
+        if (Exit.isFailure(exit)) {
+          const reason = exit.cause.reasons.find(Cause.isFailReason);
+          expect((reason?.error as any)?._tag).toBe("OwnedBySomeoneElse");
+        }
+        // The row is untouched — the user can re-run with --adopt.
+        expect((yield* getState("A"))?.status).toEqual("creating");
+      }),
+  );
+
+  test.provider(
+    "resuming an interrupted create with adopt(true) takes over an Unowned resource",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* Effect.gen(function* () {
+          yield* TestResource("A", {
+            string: "test-string",
+          });
+        }).pipe(stack.deploy, hook());
+        expect((yield* getState("A"))?.status).toEqual("creating");
+
+        yield* Effect.gen(function* () {
+          yield* TestResource("A", {
+            string: "test-string",
+          });
+        }).pipe(
+          adopt(true),
+          stack.deploy,
+          hook({
+            read: () => Effect.succeed(Unowned({ string: "test-string" })),
+          }),
+        );
+
+        const persisted = yield* getState("A");
+        expect(persisted?.status).toEqual("created");
+        // The Unowned brand never reaches persisted state.
+        expect(Unowned.is(persisted?.attr)).toBe(false);
       }),
   );
 });


### PR DESCRIPTION
A create interrupted after the cloud-side call succeeded but before `reconcile` returned Attributes leaves a `creating` state row with `attr === undefined`. Destroy's `collectGarbage`/`deleteResource` path skipped `provider.delete` entirely for such rows and dropped the row, silently orphaning the physical resource (discovered via a leaked Polly Lexicon; `Polly/Lexicon.ts` works around it with an early-persisting `precreate`).

The engine now performs read-then-delete recovery at apply time, inside `deleteResource` — covering plan deletions and replaced-chain old generations (which are pulled straight from state in the drain loop and never pass through plan):

```ts
// deleteResource, when attr === undefined
const recovered = yield* provider.read({ id, fqn, instanceId, olds: props, output: undefined });
// plain attrs    -> ours; proceed to provider.delete (attrs persisted in the `deleting` commit)
// Unowned(attrs) -> foreign; never delete, drop state with a note
// undefined      -> nothing exists; dropping state is safe
// no read impl   -> drop state with an explicit note (was silent)
```

- The plan-time read in the deletions builder is removed: it double-read on every destroy and leaked `Unowned`-branded attrs straight into `provider.delete` (deleting a foreign resource).
- The create-resume probe in `Plan.make` (`creating` + no attr on re-deploy) now routes `Unowned` through the adoption table — `OwnedBySomeoneElse` unless adopt is enabled — and strips the brand before the attrs ride onto the plan node.
- Pre-create stubs are unaffected: precreate persists stub attrs, so those rows never hit the recovery path.

Seven new engine tests under `from creating state`: delete actually invoked with recovered attrs, Unowned → no delete, not-found tolerated, no-`read` provider path, replaced-chain old-generation recovery during drain, and `OwnedBySomeoneElse`/`adopt(true)` takeover on create-resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
