### PR TITLE
feat(cloudflare/email): local send_email stub in dev with dev.remote opt-in

### DIFF
--- a/packages/alchemy/src/Cloudflare/Email/SendBinding.ts
+++ b/packages/alchemy/src/Cloudflare/Email/SendBinding.ts
@@ -28,6 +28,7 @@ export const SendBinding = Layer.effect(
               allowedSenderAddresses: sender.allowedSenderAddresses,
             },
           ],
+          dev: sender.dev,
         });
       }
 

--- a/packages/alchemy/src/Cloudflare/Email/SendEmail.ts
+++ b/packages/alchemy/src/Cloudflare/Email/SendEmail.ts
@@ -24,6 +24,18 @@ export type SendEmailProps = {
    * {@link Routing}) and the addresses must be verified.
    */
   allowedSenderAddresses?: string[];
+  /**
+   * Configuration for the binding in `alchemy dev`.
+   * @default { remote: false }
+   */
+  dev?: {
+    /**
+     * Whether to send emails through the live Cloudflare Email service in development.
+     * If `false`, emails will be logged to the console instead.
+     * @default false
+     */
+    remote?: boolean;
+  };
 };
 
 /**
@@ -83,5 +95,6 @@ export const SendEmail: (
     destinationAddress: props?.destinationAddress,
     allowedDestinationAddresses: props?.allowedDestinationAddresses,
     allowedSenderAddresses: props?.allowedSenderAddresses,
+    dev: props?.dev,
   } satisfies SendEmail;
 });

--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -771,7 +771,10 @@ export const LocalWorkerProvider = () =>
     }),
   );
 
-export const toRuntimeBinding = Effect.fn(function* (b: WorkerBinding) {
+export const toRuntimeBinding = Effect.fn(function* (
+  b: WorkerBinding,
+  dev?: { remote?: boolean },
+) {
   const unsupported = () =>
     new WorkerValidationError({
       message: `${b.type} bindings are not supported in local mode`,
@@ -848,7 +851,7 @@ export const toRuntimeBinding = Effect.fn(function* (b: WorkerBinding) {
     case "secrets_store_secret":
       return yield* unsupported();
     case "send_email":
-      return SendEmail.remote({
+      return SendEmail[dev?.remote ? "remote" : "local"]({
         binding: b.name,
         destinationAddress: b.destinationAddress,
         allowedDestinationAddresses: b.allowedDestinationAddresses,

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -675,6 +675,7 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
     containers?: { className: string; dev: DevContainerImage | undefined }[];
     crons?: string[];
     hyperdrives?: Record<string, Required<DevOrigin>>;
+    dev?: { remote?: boolean };
   },
   Providers
 >;

--- a/website/src/content/docs/cloudflare/email/send-and-receive.mdx
+++ b/website/src/content/docs/cloudflare/email/send-and-receive.mdx
@@ -150,13 +150,10 @@ two are mutually exclusive). `allowedSenderAddresses` restricts the
 destination on the account.
 
 :::caution
-This binding is **live under `alchemy dev`**. Like every binding,
-`send_email` connects to the real provider — there is no local email
-stub — so `send()` from your dev loop sends real mail from your
-domain. If your app should not send during local development, branch
-on something you control (an env var, or the injected `ALCHEMY_STAGE`
-binding) and log instead of sending. Don't test the negative branch
-by pointing `send()` at a made-up address — that's still a real send.
+`send_email` is live under `alchemy dev` — there is no local email
+stub, so `send()` from your dev loop sends real mail from your
+domain. To keep dev runs from sending, branch on an env var (or the
+injected `ALCHEMY_STAGE` binding) and log instead.
 :::
 
 ## Send from the Worker

--- a/website/src/content/docs/cloudflare/email/send-and-receive.mdx
+++ b/website/src/content/docs/cloudflare/email/send-and-receive.mdx
@@ -149,6 +149,16 @@ two are mutually exclusive). `allowedSenderAddresses` restricts the
 `from:` side. Omit all three to let the Worker send to any verified
 destination on the account.
 
+:::caution
+This binding is **live under `alchemy dev`**. Like every binding,
+`send_email` connects to the real provider — there is no local email
+stub — so `send()` from your dev loop sends real mail from your
+domain. If your app should not send during local development, branch
+on something you control (an env var, or the injected `ALCHEMY_STAGE`
+binding) and log instead of sending. Don't test the negative branch
+by pointing `send()` at a made-up address — that's still a real send.
+:::
+
 ## Send from the Worker
 
 Bind the descriptor with `Email.Send` in the Worker's init phase and

--- a/website/src/content/docs/cloudflare/email/send-and-receive.mdx
+++ b/website/src/content/docs/cloudflare/email/send-and-receive.mdx
@@ -149,11 +149,24 @@ two are mutually exclusive). `allowedSenderAddresses` restricts the
 `from:` side. Omit all three to let the Worker send to any verified
 destination on the account.
 
+Under `alchemy dev`, the binding is a local stub by default: `send()`
+logs the message's `from`, `to`, and `subject` to the dev console and
+resolves without delivering mail. The stub also skips the
+sender/destination restrictions — Cloudflare enforces those only on
+real sends. Opt into the live binding with `dev.remote`:
+
+```typescript
+export const Email = Cloudflare.Email.SendEmail("Email", {
+  allowedSenderAddresses: ["bot@example.com"],
+  destinationAddress: "you@personal.example",
+  dev: { remote: true },
+});
+```
+
 :::caution
-`send_email` is live under `alchemy dev` — there is no local email
-stub, so `send()` from your dev loop sends real mail from your
-domain. To keep dev runs from sending, branch on an env var (or the
-injected `ALCHEMY_STAGE` binding) and log instead.
+With `dev: { remote: true }`, `send()` from your dev loop sends real
+mail from your domain — a made-up recipient address is still a real
+send attempt.
 :::
 
 ## Send from the Worker

--- a/website/src/content/docs/environments/local-development.mdx
+++ b/website/src/content/docs/environments/local-development.mdx
@@ -67,11 +67,11 @@ Alchemy avoids this. Your R2 Bucket is a real R2 Bucket. Your D1
 Database is a real D1 Database. The only thing running locally is
 your application code.
 
-The same is true of side effects: a
-[`send_email` binding](/cloudflare/email/send-and-receive) sends real
-mail in dev, exactly as in production. Gate calls like that on an env
-var (or the injected `ALCHEMY_STAGE` binding) when your dev loop
-shouldn't fire them.
+Bindings whose only job is a side effect are the exception: a
+[`send_email` binding](/cloudflare/email/send-and-receive) defaults
+to a local stub in dev, so `send()` logs the message to the dev
+console instead of delivering mail. Set `dev: { remote: true }` on
+the binding to send real mail from the dev loop.
 
 ## Debugging
 

--- a/website/src/content/docs/environments/local-development.mdx
+++ b/website/src/content/docs/environments/local-development.mdx
@@ -67,6 +67,13 @@ Alchemy avoids this. Your R2 Bucket is a real R2 Bucket. Your D1
 Database is a real D1 Database. The only thing running locally is
 your application code.
 
+This includes bindings whose side effects leave your account:
+a [`send_email` binding](/cloudflare/email/send-and-receive) sends
+real mail from your domain in dev, exactly as it does in production.
+For storage a stray dev write is recoverable; for outbound email it
+isn't — gate side-effectful calls yourself (an env var, or the
+injected `ALCHEMY_STAGE` binding) when dev runs shouldn't fire them.
+
 ## Debugging
 
 Because Workers run locally in workerd, you can attach a debugger:

--- a/website/src/content/docs/environments/local-development.mdx
+++ b/website/src/content/docs/environments/local-development.mdx
@@ -67,12 +67,11 @@ Alchemy avoids this. Your R2 Bucket is a real R2 Bucket. Your D1
 Database is a real D1 Database. The only thing running locally is
 your application code.
 
-This includes bindings whose side effects leave your account:
-a [`send_email` binding](/cloudflare/email/send-and-receive) sends
-real mail from your domain in dev, exactly as it does in production.
-For storage a stray dev write is recoverable; for outbound email it
-isn't — gate side-effectful calls yourself (an env var, or the
-injected `ALCHEMY_STAGE` binding) when dev runs shouldn't fire them.
+The same is true of side effects: a
+[`send_email` binding](/cloudflare/email/send-and-receive) sends real
+mail in dev, exactly as in production. Gate calls like that on an env
+var (or the injected `ALCHEMY_STAGE` binding) when your dev loop
+shouldn't fire them.
 
 ## Debugging
 


### PR DESCRIPTION
Under `alchemy dev`, a `send_email` binding used to proxy straight to the live Cloudflare binding, so `send()` from a dev loop sent real mail (an OTP flow test made real send attempts). It now defaults to a local stub: `send()` logs the message's `from`/`to`/`subject` to the dev console and resolves without delivering. Opt into real sends per binding:

```ts
Cloudflare.Email.SendEmail("Email", {
  destinationAddress: "you@personal.example",
  dev: { remote: true }, // default false — local logging stub
});
```

- `SendEmailProps.dev.remote` threads through the Worker's local provider to select `SendEmail.remote` vs `SendEmail.local` (the cloudflare-tools stub keeps the `EmailMessage` shim, so user code can still construct messages in dev)
- `cloudflare/email/send-and-receive.mdx` documents the stub and the `dev.remote` opt-in; `environments/local-development.mdx` notes that side-effect bindings default to local

🤖 Generated with [Claude Code](https://claude.com/claude-code)
