### PR TITLE
test(cloudflare/workers): pin Random output accessor resolution under the local provider

### DIFF
--- a/packages/alchemy/test/Cloudflare/Workers/RandomEnvLocal.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/RandomEnvLocal.test.ts
@@ -1,0 +1,83 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Test from "@/Test/Alchemy";
+import { expect } from "alchemy-test";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+import * as Schedule from "effect/Schedule";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import RandomEnvWorker from "./fixtures/random-env/worker.ts";
+
+const { test } = Test.make({
+  providers: Cloudflare.providers(),
+  dev: true,
+});
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+interface RandomEnvBody {
+  resolvedType: string;
+  isHexSecret: boolean;
+}
+
+class WorkerNotReady extends Data.TaggedError("WorkerNotReady")<{
+  status: number;
+}> {}
+
+/**
+ * Pins that an `Alchemy.Random` output bound during init resolves to its
+ * minted value under the LOCAL worker provider, the same as in a real
+ * deploy.
+ *
+ * Regression shape (beta.62, fixed by #829's request-time env reification):
+ * the runtime accessor read of an output-bound env entry came back
+ * `undefined` under `alchemy dev` while the same code worked deployed —
+ * the first consumer crashed far from the cause (e.g.
+ * `Redacted.value(undefined)` dying inside effect internals). Nothing else
+ * in the suite exercises a generated-secret Output accessor under the
+ * local provider, so this pins the deploy/dev parity directly.
+ */
+test.provider(
+  "a Random output bound at init resolves under the local provider",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const { worker } = yield* stack.deploy(
+        Effect.gen(function* () {
+          const w = yield* RandomEnvWorker;
+          return { worker: w };
+        }),
+      );
+
+      const client = yield* HttpClient.HttpClient;
+      const body = yield* Effect.gen(function* () {
+        const res = yield* client.get(worker.url!).pipe(
+          Effect.flatMap((res) =>
+            res.status === 200
+              ? Effect.succeed(res)
+              : Effect.fail(new WorkerNotReady({ status: res.status })),
+          ),
+          Effect.retry({
+            while: (e): e is WorkerNotReady => e instanceof WorkerNotReady,
+            schedule: Schedule.max([
+              Schedule.exponential("500 millis"),
+              Schedule.recurs(10),
+            ]),
+          }),
+        );
+        return (yield* res.json) as unknown as RandomEnvBody;
+      }).pipe(Effect.orDie);
+
+      // The runtime read must observe the minted 32-byte hex secret —
+      // never `undefined`.
+      expect(body.resolvedType).toBe("string");
+      expect(body.isHexSecret).toBe(true);
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 240_000 },
+);

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/random-env/worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/random-env/worker.ts
@@ -1,0 +1,40 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import { Random } from "@/Random";
+import * as Effect from "effect/Effect";
+import * as Redacted from "effect/Redacted";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+/**
+ * Binds an `Alchemy.Random` output into the worker the way an app consumes a
+ * generated secret: the init phase binds `secret.text` (an Output of
+ * `Redacted<string>`), and the fetch handler reads the accessor per event.
+ *
+ * The response reports what the runtime read actually produced, so the test
+ * can assert deploy/dev parity: a correct provider resolves the accessor to
+ * the minted hex secret; one that fails to materialize the output yields
+ * `undefined` here (the beta.62 regression shape).
+ */
+export default class RandomEnvWorker extends Cloudflare.Worker<RandomEnvWorker>()(
+  "RandomEnvWorker",
+  {
+    main: import.meta.url,
+  },
+  Effect.gen(function* () {
+    const secret = yield* Random("RandomEnvSecret");
+    const accessor = yield* secret.text;
+
+    return {
+      fetch: Effect.gen(function* () {
+        const resolved = yield* accessor;
+        const value = Redacted.isRedacted(resolved)
+          ? Redacted.value(resolved)
+          : resolved;
+        return yield* HttpServerResponse.json({
+          resolvedType: typeof value,
+          isHexSecret:
+            typeof value === "string" && /^[0-9a-f]{64}$/.test(value),
+        });
+      }),
+    };
+  }),
+) {}


### PR DESCRIPTION
Adds a regression test for a deploy/dev parity break that shipped in beta.62 and was fixed by #829: an `Alchemy.Random` output bound during a Worker's init phase resolved to its minted value in a real deploy, but resolved to `undefined` under the local provider.

### The shape being pinned

This is how an app consumes a generated secret — bind the Output once at init, read the accessor per event:

```ts
// init phase
const secret = yield* Random("RandomEnvSecret");
const accessor = yield* secret.text; // Output<Redacted<string>> → per-event accessor

// fetch handler
const resolved = yield* accessor; // must be the minted value — was `undefined` at beta.62
```

Under the hood the init-phase `yield*` goes through the generic Output protocol: `RuntimeContext.set` binds the value under its `sanitizeKey`-canonicalized name (`BETTER_AUTH_SECRET.text` → `BETTER_AUTH_SECRET_text`), and the runtime accessor read is a `RuntimeContext.get` against the worker env. In a real deploy the interceptor bakes the value into a `secret_text` binding and the runtime read finds it. At beta.62, under `alchemy dev`, the runtime read missed the key the interceptor had bound and returned `undefined`.

### Why the failure was expensive to diagnose

`undefined` is not an error at the read site — it flows into whatever consumes the secret and detonates there. In our case (a better-auth session secret in a production app's dev loop, 2026-07-17):

```
TypeError: Cannot read properties of undefined (reading 'label')
    at value (effect/…/internal/redacted.js)   ← Redacted.value(undefined)
```

The crash points at effect internals, two layers from the actual cause, and only under `alchemy dev` — the same code deployed fine. Nothing suggested the binding layer; we found it by instrumenting the runtime value's shape (`PropExpr` at the property, then `undefined` after resolution).

### Why existing coverage doesn't catch a regression here

#829 fixed this class of bug (request-time env reification, plus the `sanitizeKey` fallback on a missed key), and its live coverage in `WorkerEnv.test.ts` exercises `Config` re-yields at request time. But `Config` and Output accessors enter the env through different front doors — nothing in the suite binds a `Random`/Output *accessor* at init and reads it per event under `dev: true`. A regression on the Output path would ship green and resurface as the misleading downstream crash above.

### What the test does

`fixtures/random-env/worker.ts` binds `Random("RandomEnvSecret").text` at init; its fetch handler reads the accessor and reports the resolved shape. `RandomEnvLocal.test.ts` deploys it with the `dev: true` harness (local workerd, same as `PythonWorkerLocal.test.ts`) and asserts over HTTP that the runtime read observed the minted 32-byte hex secret:

```ts
expect(body.resolvedType).toBe("string");
expect(body.isHexSecret).toBe(true); // /^[0-9a-f]{64}$/ — never undefined
```

Green on `main`; red on beta.62, where the accessor read yields `undefined`.
