### PR TITLE
fix(engine): preserve name uniqueness when createPhysicalName truncates

### DIFF
--- a/packages/alchemy/src/AWS/EC2/SecurityGroup.ts
+++ b/packages/alchemy/src/AWS/EC2/SecurityGroup.ts
@@ -508,9 +508,8 @@ export const SecurityGroupProvider = () =>
           }
 
           // Group name change requires replacement
-          const oldGroupName = output?.groupName
-            ? output.groupName
-            : yield* createGroupName(id, olds.groupName);
+          const oldGroupName =
+            output?.groupName ?? (yield* createGroupName(id, olds.groupName));
           // Auto-generated names are engine-owned: the deployed name stays
           // authoritative even if the generator would name this id differently
           // today. Only an explicit user-provided name can force a replace.

--- a/packages/alchemy/src/AWS/EC2/SecurityGroup.ts
+++ b/packages/alchemy/src/AWS/EC2/SecurityGroup.ts
@@ -508,10 +508,16 @@ export const SecurityGroupProvider = () =>
           }
 
           // Group name change requires replacement
-          const newGroupName = yield* createGroupName(id, news.groupName);
           const oldGroupName = output?.groupName
             ? output.groupName
             : yield* createGroupName(id, olds.groupName);
+          // Auto-generated names are engine-owned: the deployed name stays
+          // authoritative even if the generator would name this id differently
+          // today. Only an explicit user-provided name can force a replace.
+          const newGroupName =
+            news.groupName !== undefined || olds.groupName !== undefined
+              ? yield* createGroupName(id, news.groupName)
+              : oldGroupName;
           if (newGroupName !== oldGroupName) {
             return { action: "replace" };
           }
@@ -520,7 +526,12 @@ export const SecurityGroupProvider = () =>
         }),
 
         reconcile: Effect.fn(function* ({ id, news, output, session }) {
-          const groupName = yield* createGroupName(id, news.groupName);
+          // Prefer the deployed name: regenerating would target a different
+          // resource if the generator's output for this id ever drifts. (An
+          // explicit groupName change arrives here as a fresh replacement
+          // instance with no output.)
+          const groupName =
+            output?.groupName ?? (yield* createGroupName(id, news.groupName));
           const desiredTags = yield* createTags(id, news.tags);
 
           // Observe — find the SG via cached id, else fall through to create.

--- a/packages/alchemy/src/AWS/EC2/SecurityGroup.ts
+++ b/packages/alchemy/src/AWS/EC2/SecurityGroup.ts
@@ -514,10 +514,7 @@ export const SecurityGroupProvider = () =>
           // Auto-generated names are engine-owned: the deployed name stays
           // authoritative even if the generator would name this id differently
           // today. Only an explicit user-provided name can force a replace.
-          const newGroupName =
-            news.groupName !== undefined || olds.groupName !== undefined
-              ? yield* createGroupName(id, news.groupName)
-              : oldGroupName;
+          const newGroupName = news.groupName ?? oldGroupName;
           if (newGroupName !== oldGroupName) {
             return { action: "replace" };
           }

--- a/packages/alchemy/src/AWS/ECR/Repository.ts
+++ b/packages/alchemy/src/AWS/ECR/Repository.ts
@@ -227,8 +227,11 @@ export const RepositoryProvider = () =>
             ? attrs
             : Unowned(attrs);
         }),
-        reconcile: Effect.fn(function* ({ id, news, session }) {
-          const repositoryName = yield* toRepositoryName(id, news);
+        reconcile: Effect.fn(function* ({ id, news, output, session }) {
+          // Prefer the deployed name: regenerating would target a different
+          // repository if the generator's output for this id ever drifts.
+          const repositoryName =
+            output?.repositoryName ?? (yield* toRepositoryName(id, news));
           const internalTags = yield* createInternalTags(id);
           const desiredTags = { ...internalTags, ...news.tags };
 

--- a/packages/alchemy/src/AWS/ECS/Task.ts
+++ b/packages/alchemy/src/AWS/ECS/Task.ts
@@ -982,7 +982,11 @@ await Effect.runPromise(program).catch((err) => {
           output,
           session,
         }) {
-          const family = yield* toTaskFamily(id, news);
+          // Prefer the deployed name: regenerating would target a different
+          // resource if the generator's output for this id ever drifts. (An
+          // explicit taskName change arrives here as a fresh replacement
+          // instance with no output.)
+          const family = output?.taskFamily ?? (yield* toTaskFamily(id, news));
           const taskRoleName =
             output?.taskRoleName ?? (yield* createRoleName(id, "task-role"));
           const executionRoleName =

--- a/packages/alchemy/src/AWS/Lambda/Function.ts
+++ b/packages/alchemy/src/AWS/Lambda/Function.ts
@@ -1789,10 +1789,7 @@ export default handler;
           // authoritative even if the generator would name this id
           // differently today. Only an explicit user-provided functionName
           // can force a replace.
-          const newFunctionName =
-            news.functionName !== undefined || olds.functionName !== undefined
-              ? yield* createFunctionName(id, news.functionName)
-              : output.functionName;
+          const newFunctionName = news.functionName ?? output.functionName;
           if (output.functionName !== newFunctionName) {
             return { action: "replace" };
           }

--- a/packages/alchemy/src/AWS/Lambda/Function.ts
+++ b/packages/alchemy/src/AWS/Lambda/Function.ts
@@ -1785,11 +1785,15 @@ export default handler;
           if (!output) {
             return undefined;
           }
-          if (
-            // function name changed
-            output.functionName !==
-            (yield* createFunctionName(id, news.functionName))
-          ) {
+          // Auto-generated names are engine-owned: the deployed name stays
+          // authoritative even if the generator would name this id
+          // differently today. Only an explicit user-provided functionName
+          // can force a replace.
+          const newFunctionName =
+            news.functionName !== undefined || olds.functionName !== undefined
+              ? yield* createFunctionName(id, news.functionName)
+              : output.functionName;
+          if (output.functionName !== newFunctionName) {
             return { action: "replace" };
           }
           if (!!olds.durableConfig !== !!news.durableConfig) {
@@ -1986,8 +1990,15 @@ export default handler;
           output,
           session,
         }) {
-          const { roleName, policyName, functionName, functionArn } =
-            yield* createNames(id, news.functionName);
+          const generated = yield* createNames(id, news.functionName);
+          // Prefer the deployed identifiers: regenerating would target
+          // different physical resources if the generator's output for this
+          // id ever drifts. (An explicit functionName change arrives here as
+          // a fresh replacement instance with no output.)
+          const functionName = output?.functionName ?? generated.functionName;
+          const roleName = output?.roleName ?? generated.roleName;
+          const functionArn = output?.functionArn ?? generated.functionArn;
+          const policyName = generated.policyName;
 
           // State is only a cache: the execution role may have been removed
           // out-of-band (or by a previously interrupted cleanup) while the

--- a/packages/alchemy/src/Cloudflare/AI/Evaluation.ts
+++ b/packages/alchemy/src/Cloudflare/AI/Evaluation.ts
@@ -147,7 +147,7 @@ export const listEvaluationTypes = (accountId: string) =>
 export const EvaluationProvider = () =>
   Provider.succeed(Evaluation, {
     stables: ["evaluationId", "accountId", "gatewayId", "createdAt"],
-    diff: Effect.fn(function* ({ id, news, output }) {
+    diff: Effect.fn(function* ({ id, olds, news, output }) {
       if (!isResolved(news)) return undefined;
       const { accountId } = yield* yield* CloudflareEnvironment;
       if ((output?.accountId ?? accountId) !== accountId) {
@@ -155,7 +155,13 @@ export const EvaluationProvider = () =>
       }
       if (output === undefined) return undefined;
       // Evaluations have no update API — any change is a replacement.
-      const newName = yield* createEvaluationName(id, news.name);
+      // Auto-generated names are engine-owned: the deployed name stays
+      // authoritative even if the generator would name this id differently
+      // today. Only an explicit user-provided name can force a replace.
+      const newName =
+        news.name !== undefined || olds?.name !== undefined
+          ? yield* createEvaluationName(id, news.name)
+          : output.name;
       if (
         output.gatewayId !== news.gatewayId ||
         output.name !== newName ||
@@ -197,7 +203,9 @@ export const EvaluationProvider = () =>
     reconcile: Effect.fn(function* ({ id, news, output }) {
       const { accountId } = yield* yield* CloudflareEnvironment;
       const gatewayId = news.gatewayId as string;
-      const name = yield* createEvaluationName(id, news.name);
+      // Prefer the deployed name: regenerating would target a different
+      // resource if the generator's output for this id ever drifts.
+      const name = output?.name ?? (yield* createEvaluationName(id, news.name));
       const datasetIds = news.datasetIds as string[];
       const evaluationTypeIds = news.evaluationTypeIds;
 

--- a/packages/alchemy/src/Cloudflare/AI/Evaluation.ts
+++ b/packages/alchemy/src/Cloudflare/AI/Evaluation.ts
@@ -158,10 +158,7 @@ export const EvaluationProvider = () =>
       // Auto-generated names are engine-owned: the deployed name stays
       // authoritative even if the generator would name this id differently
       // today. Only an explicit user-provided name can force a replace.
-      const newName =
-        news.name !== undefined || olds?.name !== undefined
-          ? yield* createEvaluationName(id, news.name)
-          : output.name;
+      const newName = news.name ?? output.name;
       if (
         output.gatewayId !== news.gatewayId ||
         output.name !== newName ||

--- a/packages/alchemy/src/Cloudflare/AI/Gateway.ts
+++ b/packages/alchemy/src/Cloudflare/AI/Gateway.ts
@@ -484,10 +484,7 @@ export const GatewayResourceProvider = () =>
       // Auto-generated ids are engine-owned: the deployed id stays
       // authoritative even if the generator would name this id differently
       // today. Only an explicit user-provided id can force a replace.
-      const newGatewayId =
-        news.id !== undefined || olds.id !== undefined
-          ? next.gatewayId
-          : oldGatewayId;
+      const newGatewayId = news.id ?? oldGatewayId;
       if (
         (output?.accountId ?? accountId) !== accountId ||
         oldGatewayId !== newGatewayId

--- a/packages/alchemy/src/Cloudflare/AI/Gateway.ts
+++ b/packages/alchemy/src/Cloudflare/AI/Gateway.ts
@@ -481,9 +481,16 @@ export const GatewayResourceProvider = () =>
       const next = yield* desired(id, news);
       const oldGatewayId =
         output?.gatewayId ?? (yield* createGatewayId(id, olds.id));
+      // Auto-generated ids are engine-owned: the deployed id stays
+      // authoritative even if the generator would name this id differently
+      // today. Only an explicit user-provided id can force a replace.
+      const newGatewayId =
+        news.id !== undefined || olds.id !== undefined
+          ? next.gatewayId
+          : oldGatewayId;
       if (
         (output?.accountId ?? accountId) !== accountId ||
-        oldGatewayId !== next.gatewayId
+        oldGatewayId !== newGatewayId
       ) {
         return { action: "replace" } as const;
       }
@@ -519,7 +526,9 @@ export const GatewayResourceProvider = () =>
       // idempotency: a peer reconciler may have created it concurrently,
       // or state persistence may have failed after a previous create.
       if (observed === undefined) {
-        const request = yield* createRequest(id, news);
+        // Prefer the deployed id: regenerating would target a different
+        // resource if the generator's output for this id ever drifts.
+        const request = { ...(yield* createRequest(id, news)), id: gatewayId };
         yield* aiGateway
           .createAiGateway(request)
           .pipe(
@@ -532,7 +541,12 @@ export const GatewayResourceProvider = () =>
       // Sync — the Cloudflare.AI. Gateway update API is a full PATCH that
       // overwrites all mutable fields. We always apply the desired shape
       // so adoption, drift, and routine updates all converge.
-      const update = yield* updateRequest(id, news, acct);
+      // Prefer the deployed id: regenerating would target a different
+      // resource if the generator's output for this id ever drifts.
+      const update = {
+        ...(yield* updateRequest(id, news, acct)),
+        id: gatewayId,
+      };
       const gateway = yield* aiGateway.updateAiGateway(update);
       return mapGateway(gateway, acct);
     }),

--- a/packages/alchemy/src/Cloudflare/AI/GatewayProvider.ts
+++ b/packages/alchemy/src/Cloudflare/AI/GatewayProvider.ts
@@ -202,10 +202,7 @@ export const GatewayProviderProvider = () =>
       // Auto-generated aliases are engine-owned: the deployed alias stays
       // authoritative even if the generator would name this id differently
       // today. Only an explicit user-provided alias can force a replace.
-      const newAlias =
-        news.alias !== undefined || olds?.alias !== undefined
-          ? yield* createAlias(id, news.alias)
-          : output.alias;
+      const newAlias = news.alias ?? output.alias;
       if (
         output.gatewayId !== news.gatewayId ||
         output.providerSlug !== news.providerSlug ||

--- a/packages/alchemy/src/Cloudflare/AI/GatewayProvider.ts
+++ b/packages/alchemy/src/Cloudflare/AI/GatewayProvider.ts
@@ -189,7 +189,7 @@ export const isGatewayProvider = (value: unknown): value is GatewayProvider =>
 export const GatewayProviderProvider = () =>
   Provider.succeed(GatewayProvider, {
     stables: ["providerConfigId", "accountId", "gatewayId"],
-    diff: Effect.fn(function* ({ id, news, output }) {
+    diff: Effect.fn(function* ({ id, olds, news, output }) {
       if (!isResolved(news)) return undefined;
       const { accountId } = yield* yield* CloudflareEnvironment;
       if ((output?.accountId ?? accountId) !== accountId) {
@@ -199,7 +199,13 @@ export const GatewayProviderProvider = () =>
       // Provider configs have no update API — any change is a replacement.
       // Delete first: a gateway rejects a second config for the same
       // provider slug/alias with "already exists".
-      const newAlias = yield* createAlias(id, news.alias);
+      // Auto-generated aliases are engine-owned: the deployed alias stays
+      // authoritative even if the generator would name this id differently
+      // today. Only an explicit user-provided alias can force a replace.
+      const newAlias =
+        news.alias !== undefined || olds?.alias !== undefined
+          ? yield* createAlias(id, news.alias)
+          : output.alias;
       if (
         output.gatewayId !== news.gatewayId ||
         output.providerSlug !== news.providerSlug ||
@@ -235,7 +241,9 @@ export const GatewayProviderProvider = () =>
     }),
     reconcile: Effect.fn(function* ({ id, news, output }) {
       const { accountId } = yield* yield* CloudflareEnvironment;
-      const alias = yield* createAlias(id, news.alias);
+      // Prefer the deployed alias: regenerating would target a different
+      // resource if the generator's output for this id ever drifts.
+      const alias = output?.alias ?? (yield* createAlias(id, news.alias));
       return yield* reconcileProviderConfig({
         accountId,
         gatewayId: news.gatewayId as string,

--- a/packages/alchemy/src/Cloudflare/AI/SearchInstance.ts
+++ b/packages/alchemy/src/Cloudflare/AI/SearchInstance.ts
@@ -599,10 +599,7 @@ export const SearchInstanceProvider = () =>
       // Auto-generated ids are engine-owned: the deployed id stays
       // authoritative even if the generator would name this id differently
       // today. Only an explicit user-provided instanceId can force a replace.
-      const newId =
-        news.instanceId !== undefined || olds.instanceId !== undefined
-          ? yield* createInstanceId(id, news.instanceId)
-          : oldId;
+      const newId = news.instanceId ?? oldId;
       if (newId !== oldId) {
         return { action: "replace" } as const;
       }

--- a/packages/alchemy/src/Cloudflare/AI/SearchInstance.ts
+++ b/packages/alchemy/src/Cloudflare/AI/SearchInstance.ts
@@ -594,9 +594,15 @@ export const SearchInstanceProvider = () =>
         return { action: "replace" } as const;
       }
       // The instance id is its identity — renaming is a replacement.
-      const newId = yield* createInstanceId(id, news.instanceId);
       const oldId =
         output?.instanceId ?? (yield* createInstanceId(id, olds.instanceId));
+      // Auto-generated ids are engine-owned: the deployed id stays
+      // authoritative even if the generator would name this id differently
+      // today. Only an explicit user-provided instanceId can force a replace.
+      const newId =
+        news.instanceId !== undefined || olds.instanceId !== undefined
+          ? yield* createInstanceId(id, news.instanceId)
+          : oldId;
       if (newId !== oldId) {
         return { action: "replace" } as const;
       }

--- a/packages/alchemy/src/Cloudflare/AI/SearchNamespace.ts
+++ b/packages/alchemy/src/Cloudflare/AI/SearchNamespace.ts
@@ -197,9 +197,15 @@ export const SearchNamespaceProvider = () =>
       // The name is the namespace's identity (it is the API path
       // parameter) — renaming is a replacement. Props are all optional, so a
       // no-props resource resolves `news`/`olds` to `undefined` at runtime.
-      const newName = yield* createNamespaceName(id, news?.name);
       const oldName =
         output?.name ?? (yield* createNamespaceName(id, olds?.name));
+      // Auto-generated names are engine-owned: the deployed name stays
+      // authoritative even if the generator would name this id differently
+      // today. Only an explicit user-provided name can force a replace.
+      const newName =
+        news?.name !== undefined || olds?.name !== undefined
+          ? yield* createNamespaceName(id, news?.name)
+          : oldName;
       if (newName !== oldName) {
         // A user-pinned name collides with the still-existing old
         // namespace only when both resolve to the same string — they

--- a/packages/alchemy/src/Cloudflare/AI/SearchNamespace.ts
+++ b/packages/alchemy/src/Cloudflare/AI/SearchNamespace.ts
@@ -202,10 +202,7 @@ export const SearchNamespaceProvider = () =>
       // Auto-generated names are engine-owned: the deployed name stays
       // authoritative even if the generator would name this id differently
       // today. Only an explicit user-provided name can force a replace.
-      const newName =
-        news?.name !== undefined || olds?.name !== undefined
-          ? yield* createNamespaceName(id, news?.name)
-          : oldName;
+      const newName = news?.name ?? oldName;
       if (newName !== oldName) {
         // A user-pinned name collides with the still-existing old
         // namespace only when both resolve to the same string — they

--- a/packages/alchemy/src/Cloudflare/Access/Policy.ts
+++ b/packages/alchemy/src/Cloudflare/Access/Policy.ts
@@ -177,9 +177,7 @@ export const PolicyProvider = () =>
       if ((output?.accountId ?? accountId) !== accountId) {
         return { action: "replace" } as const;
       }
-      const oldName = output?.name
-        ? output.name
-        : yield* createPolicyName(id, olds.name);
+      const oldName = output?.name ?? (yield* createPolicyName(id, olds.name));
       // Auto-generated names are engine-owned: the deployed name stays
       // authoritative even if the generator would name this id differently
       // today. Only an explicit user-provided name can force a replace.

--- a/packages/alchemy/src/Cloudflare/Access/Policy.ts
+++ b/packages/alchemy/src/Cloudflare/Access/Policy.ts
@@ -183,10 +183,7 @@ export const PolicyProvider = () =>
       // Auto-generated names are engine-owned: the deployed name stays
       // authoritative even if the generator would name this id differently
       // today. Only an explicit user-provided name can force a replace.
-      const name =
-        news.name !== undefined || olds.name !== undefined
-          ? yield* createPolicyName(id, news.name)
-          : oldName;
+      const name = news.name ?? oldName;
       if (name !== oldName) {
         return { action: "replace" } as const;
       }

--- a/packages/alchemy/src/Cloudflare/Access/Policy.ts
+++ b/packages/alchemy/src/Cloudflare/Access/Policy.ts
@@ -177,10 +177,16 @@ export const PolicyProvider = () =>
       if ((output?.accountId ?? accountId) !== accountId) {
         return { action: "replace" } as const;
       }
-      const name = yield* createPolicyName(id, news.name);
       const oldName = output?.name
         ? output.name
         : yield* createPolicyName(id, olds.name);
+      // Auto-generated names are engine-owned: the deployed name stays
+      // authoritative even if the generator would name this id differently
+      // today. Only an explicit user-provided name can force a replace.
+      const name =
+        news.name !== undefined || olds.name !== undefined
+          ? yield* createPolicyName(id, news.name)
+          : oldName;
       if (name !== oldName) {
         return { action: "replace" } as const;
       }
@@ -191,7 +197,9 @@ export const PolicyProvider = () =>
     }),
     reconcile: Effect.fn(function* ({ id, news = {} as PolicyProps, output }) {
       const { accountId } = yield* yield* CloudflareEnvironment;
-      const name = yield* createPolicyName(id, news.name);
+      // Prefer the deployed name: regenerating would target a different
+      // resource if the generator's output for this id ever drifts.
+      const name = yield* createPolicyName(id, news.name ?? output?.name);
       const acct = output?.accountId ?? accountId;
 
       // Observe — prefer cached policyId, fall back to a name lookup so

--- a/packages/alchemy/src/Cloudflare/ApiShield/Label.ts
+++ b/packages/alchemy/src/Cloudflare/ApiShield/Label.ts
@@ -148,7 +148,13 @@ export const LabelProvider = () =>
       // The name is the label's identity — compare the resolved physical
       // names (an omitted name resolves deterministically from the id).
       const oldName = output?.name ?? (yield* createLabelName(id, o.name));
-      const newName = yield* createLabelName(id, n.name);
+      // Auto-generated names are engine-owned: the deployed name stays
+      // authoritative even if the generator would name this id differently
+      // today. Only an explicit user-provided name can force a replace.
+      const newName =
+        n.name !== undefined || o.name !== undefined
+          ? yield* createLabelName(id, n.name)
+          : oldName;
       if (oldName !== newName) {
         return { action: "replace" } as const;
       }

--- a/packages/alchemy/src/Cloudflare/ApiShield/Label.ts
+++ b/packages/alchemy/src/Cloudflare/ApiShield/Label.ts
@@ -151,10 +151,7 @@ export const LabelProvider = () =>
       // Auto-generated names are engine-owned: the deployed name stays
       // authoritative even if the generator would name this id differently
       // today. Only an explicit user-provided name can force a replace.
-      const newName =
-        n.name !== undefined || o.name !== undefined
-          ? yield* createLabelName(id, n.name)
-          : oldName;
+      const newName = n.name ?? oldName;
       if (oldName !== newName) {
         return { action: "replace" } as const;
       }

--- a/packages/alchemy/src/Cloudflare/ApiShield/UserSchema.ts
+++ b/packages/alchemy/src/Cloudflare/ApiShield/UserSchema.ts
@@ -133,10 +133,7 @@ export const UserSchemaProvider = () =>
       // Auto-generated names are engine-owned: the deployed name stays
       // authoritative even if the generator would name this id differently
       // today. Only an explicit user-provided name can force a replace.
-      const newName =
-        n.name !== undefined || o.name !== undefined
-          ? yield* createSchemaName(id, n.name)
-          : oldName;
+      const newName = n.name ?? oldName;
       if (oldName !== newName) {
         return { action: "replace" } as const;
       }

--- a/packages/alchemy/src/Cloudflare/ApiShield/UserSchema.ts
+++ b/packages/alchemy/src/Cloudflare/ApiShield/UserSchema.ts
@@ -130,7 +130,13 @@ export const UserSchemaProvider = () =>
       // The name is part of the schema's identity — compare the resolved
       // physical names (an omitted name resolves deterministically).
       const oldName = output?.name ?? (yield* createSchemaName(id, o.name));
-      const newName = yield* createSchemaName(id, n.name);
+      // Auto-generated names are engine-owned: the deployed name stays
+      // authoritative even if the generator would name this id differently
+      // today. Only an explicit user-provided name can force a replace.
+      const newName =
+        n.name !== undefined || o.name !== undefined
+          ? yield* createSchemaName(id, n.name)
+          : oldName;
       if (oldName !== newName) {
         return { action: "replace" } as const;
       }

--- a/packages/alchemy/src/Cloudflare/Containers/ContainerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Containers/ContainerProvider.ts
@@ -664,9 +664,9 @@ export const LiveContainerProvider = () =>
           }
           const { accountId } = yield* yield* CloudflareEnvironment;
 
-          const oldName = output?.applicationName
-            ? output.applicationName
-            : yield* createApplicationName(id, olds.name);
+          const oldName =
+            output?.applicationName ??
+            (yield* createApplicationName(id, olds.name));
           // Auto-generated names are engine-owned: the deployed name stays
           // authoritative even if the generator would name this id differently
           // today. Only an explicit user-provided name can force a replace.

--- a/packages/alchemy/src/Cloudflare/Containers/ContainerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Containers/ContainerProvider.ts
@@ -670,10 +670,7 @@ export const LiveContainerProvider = () =>
           // Auto-generated names are engine-owned: the deployed name stays
           // authoritative even if the generator would name this id differently
           // today. Only an explicit user-provided name can force a replace.
-          const name =
-            news.name !== undefined || olds.name !== undefined
-              ? yield* createApplicationName(id, news.name)
-              : oldName;
+          const name = news.name ?? oldName;
 
           if (
             (output?.accountId ?? accountId) !== accountId ||

--- a/packages/alchemy/src/Cloudflare/Containers/ContainerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Containers/ContainerProvider.ts
@@ -664,10 +664,16 @@ export const LiveContainerProvider = () =>
           }
           const { accountId } = yield* yield* CloudflareEnvironment;
 
-          const name = yield* createApplicationName(id, news.name);
           const oldName = output?.applicationName
             ? output.applicationName
             : yield* createApplicationName(id, olds.name);
+          // Auto-generated names are engine-owned: the deployed name stays
+          // authoritative even if the generator would name this id differently
+          // today. Only an explicit user-provided name can force a replace.
+          const name =
+            news.name !== undefined || olds.name !== undefined
+              ? yield* createApplicationName(id, news.name)
+              : oldName;
 
           if (
             (output?.accountId ?? accountId) !== accountId ||
@@ -750,7 +756,11 @@ export const LiveContainerProvider = () =>
           output,
           session,
         }) {
-          const name = yield* createApplicationName(id, news.name);
+          // Prefer the deployed name: regenerating would target a different
+          // resource if the generator's output for this id ever drifts.
+          const name =
+            output?.applicationName ??
+            (yield* createApplicationName(id, news.name));
           yield* Effect.logInfo(
             `Cloudflare Container reconcile: starting ${name}`,
           );

--- a/packages/alchemy/src/Cloudflare/D1/Database.ts
+++ b/packages/alchemy/src/Cloudflare/D1/Database.ts
@@ -264,10 +264,7 @@ export const DatabaseProvider = () =>
       // Auto-generated names are engine-owned: the deployed name stays
       // authoritative even if the generator would name this id differently
       // today. Only an explicit user-provided name can force a replace.
-      const name =
-        news.name !== undefined || olds.name !== undefined
-          ? yield* createDatabaseName(id, news.name)
-          : oldName;
+      const name = news.name ?? oldName;
       const oldJurisdiction =
         output?.jurisdiction ?? olds.jurisdiction ?? "default";
       if (

--- a/packages/alchemy/src/Cloudflare/D1/Database.ts
+++ b/packages/alchemy/src/Cloudflare/D1/Database.ts
@@ -258,9 +258,8 @@ export const DatabaseProvider = () =>
       if ((output?.accountId ?? accountId) !== accountId) {
         return { action: "replace" } as const;
       }
-      const oldName = output?.databaseName
-        ? output.databaseName
-        : yield* createDatabaseName(id, olds.name);
+      const oldName =
+        output?.databaseName ?? (yield* createDatabaseName(id, olds.name));
       // Auto-generated names are engine-owned: the deployed name stays
       // authoritative even if the generator would name this id differently
       // today. Only an explicit user-provided name can force a replace.

--- a/packages/alchemy/src/Cloudflare/D1/Database.ts
+++ b/packages/alchemy/src/Cloudflare/D1/Database.ts
@@ -258,10 +258,16 @@ export const DatabaseProvider = () =>
       if ((output?.accountId ?? accountId) !== accountId) {
         return { action: "replace" } as const;
       }
-      const name = yield* createDatabaseName(id, news.name);
       const oldName = output?.databaseName
         ? output.databaseName
         : yield* createDatabaseName(id, olds.name);
+      // Auto-generated names are engine-owned: the deployed name stays
+      // authoritative even if the generator would name this id differently
+      // today. Only an explicit user-provided name can force a replace.
+      const name =
+        news.name !== undefined || olds.name !== undefined
+          ? yield* createDatabaseName(id, news.name)
+          : oldName;
       const oldJurisdiction =
         output?.jurisdiction ?? olds.jurisdiction ?? "default";
       if (

--- a/packages/alchemy/src/Cloudflare/DNS/Firewall.ts
+++ b/packages/alchemy/src/Cloudflare/DNS/Firewall.ts
@@ -258,8 +258,14 @@ export const FirewallProvider = () =>
         return { action: "replace" } as const;
       }
       // The name is the cold-state recovery identity — renames replace.
-      const name = yield* createClusterName(id, news.name);
       const oldName = output?.name ?? (yield* createClusterName(id, olds.name));
+      // Auto-generated names are engine-owned: the deployed name stays
+      // authoritative even if the generator would name this id differently
+      // today. Only an explicit user-provided name can force a replace.
+      const name =
+        news.name !== undefined || olds.name !== undefined
+          ? yield* createClusterName(id, news.name)
+          : oldName;
       if (name !== oldName) {
         return { action: "replace" } as const;
       }
@@ -313,7 +319,9 @@ export const FirewallProvider = () =>
     }),
     reconcile: Effect.fn(function* ({ id, news, output }) {
       const { accountId } = yield* yield* CloudflareEnvironment;
-      const name = yield* createClusterName(id, news.name);
+      // Prefer the deployed name: regenerating would rename the deployed
+      // cluster if the generator's output for this id ever drifts.
+      const name = output?.name ?? (yield* createClusterName(id, news.name));
 
       // Observe — the id cached on `output` is a hint, not a guarantee: a
       // missing cluster falls through to "missing" and we recreate.

--- a/packages/alchemy/src/Cloudflare/DNS/Firewall.ts
+++ b/packages/alchemy/src/Cloudflare/DNS/Firewall.ts
@@ -262,10 +262,7 @@ export const FirewallProvider = () =>
       // Auto-generated names are engine-owned: the deployed name stays
       // authoritative even if the generator would name this id differently
       // today. Only an explicit user-provided name can force a replace.
-      const name =
-        news.name !== undefined || olds.name !== undefined
-          ? yield* createClusterName(id, news.name)
-          : oldName;
+      const name = news.name ?? oldName;
       if (name !== oldName) {
         return { action: "replace" } as const;
       }

--- a/packages/alchemy/src/Cloudflare/Diagnostics/EndpointHealthcheck.ts
+++ b/packages/alchemy/src/Cloudflare/Diagnostics/EndpointHealthcheck.ts
@@ -124,7 +124,13 @@ export const EndpointHealthcheckProvider = () =>
       }
       // The name is create-only: Cloudflare's PUT echoes a new name back
       // but never persists it, so a name change forces a replacement.
-      const desiredName = yield* createHealthcheckName(id, news.name);
+      // Auto-generated names are engine-owned: the deployed name stays
+      // authoritative even if the generator would name this id differently
+      // today. Only an explicit user-provided name can force a replace.
+      const desiredName =
+        news.name ??
+        output?.name ??
+        (yield* createHealthcheckName(id, news.name));
       if (output !== undefined && output.name !== desiredName) {
         return { action: "replace" } as const;
       }

--- a/packages/alchemy/src/Cloudflare/Hyperdrive/Connection.ts
+++ b/packages/alchemy/src/Cloudflare/Hyperdrive/Connection.ts
@@ -199,9 +199,7 @@ export const ConnectionProvider = () =>
       if ((output?.accountId ?? accountId) !== accountId) {
         return { action: "replace" } as const;
       }
-      const oldName = output?.name
-        ? output.name
-        : yield* createConfigName(id, olds.name);
+      const oldName = output?.name ?? (yield* createConfigName(id, olds.name));
       // Auto-generated names are engine-owned: the deployed name stays
       // authoritative even if the generator would name this id differently
       // today. Only an explicit user-provided name can force a replace.

--- a/packages/alchemy/src/Cloudflare/Hyperdrive/Connection.ts
+++ b/packages/alchemy/src/Cloudflare/Hyperdrive/Connection.ts
@@ -205,10 +205,7 @@ export const ConnectionProvider = () =>
       // Auto-generated names are engine-owned: the deployed name stays
       // authoritative even if the generator would name this id differently
       // today. Only an explicit user-provided name can force a replace.
-      const name =
-        news.name !== undefined || olds.name !== undefined
-          ? yield* createConfigName(id, news.name)
-          : oldName;
+      const name = news.name ?? oldName;
       if (oldName !== name) {
         return { action: "replace" } as const;
       }

--- a/packages/alchemy/src/Cloudflare/Hyperdrive/Connection.ts
+++ b/packages/alchemy/src/Cloudflare/Hyperdrive/Connection.ts
@@ -199,10 +199,16 @@ export const ConnectionProvider = () =>
       if ((output?.accountId ?? accountId) !== accountId) {
         return { action: "replace" } as const;
       }
-      const name = yield* createConfigName(id, news.name);
       const oldName = output?.name
         ? output.name
         : yield* createConfigName(id, olds.name);
+      // Auto-generated names are engine-owned: the deployed name stays
+      // authoritative even if the generator would name this id differently
+      // today. Only an explicit user-provided name can force a replace.
+      const name =
+        news.name !== undefined || olds.name !== undefined
+          ? yield* createConfigName(id, news.name)
+          : oldName;
       if (oldName !== name) {
         return { action: "replace" } as const;
       }

--- a/packages/alchemy/src/Cloudflare/KV/Namespace.ts
+++ b/packages/alchemy/src/Cloudflare/KV/Namespace.ts
@@ -84,10 +84,7 @@ export const NamespaceProvider = () =>
       // Auto-generated titles are engine-owned: the deployed title stays
       // authoritative even if the generator would title this id differently
       // today. Only an explicit user-provided title can force a rename.
-      const title =
-        news.title !== undefined || olds.title !== undefined
-          ? yield* createTitle(id, news.title)
-          : oldTitle;
+      const title = news.title ?? oldTitle;
       if (title !== oldTitle) {
         return { action: "update" } as const;
       }

--- a/packages/alchemy/src/Cloudflare/KV/Namespace.ts
+++ b/packages/alchemy/src/Cloudflare/KV/Namespace.ts
@@ -80,8 +80,14 @@ export const NamespaceProvider = () =>
       if ((output?.accountId ?? accountId) !== accountId) {
         return { action: "replace" } as const;
       }
-      const title = yield* createTitle(id, news.title);
       const oldTitle = output?.title ?? (yield* createTitle(id, olds.title));
+      // Auto-generated titles are engine-owned: the deployed title stays
+      // authoritative even if the generator would title this id differently
+      // today. Only an explicit user-provided title can force a rename.
+      const title =
+        news.title !== undefined || olds.title !== undefined
+          ? yield* createTitle(id, news.title)
+          : oldTitle;
       if (title !== oldTitle) {
         return { action: "update" } as const;
       }

--- a/packages/alchemy/src/Cloudflare/MtlsCertificate/MtlsCertificate.ts
+++ b/packages/alchemy/src/Cloudflare/MtlsCertificate/MtlsCertificate.ts
@@ -186,10 +186,16 @@ export const MtlsCertificateProvider = () =>
       if ((output?.accountId ?? accountId) !== accountId) {
         return { action: "replace" } as const;
       }
-      const name = yield* createCertificateName(id, news.name);
       const oldName = output?.name
         ? output.name
         : yield* createCertificateName(id, olds.name);
+      // Auto-generated names are engine-owned: the deployed name stays
+      // authoritative even if the generator would name this id differently
+      // today. Only an explicit user-provided name can force a replace.
+      const name =
+        news.name !== undefined || olds.name !== undefined
+          ? yield* createCertificateName(id, news.name)
+          : oldName;
       if (
         oldName !== name ||
         (news.ca ?? undefined) !== (olds.ca ?? undefined) ||

--- a/packages/alchemy/src/Cloudflare/MtlsCertificate/MtlsCertificate.ts
+++ b/packages/alchemy/src/Cloudflare/MtlsCertificate/MtlsCertificate.ts
@@ -186,9 +186,8 @@ export const MtlsCertificateProvider = () =>
       if ((output?.accountId ?? accountId) !== accountId) {
         return { action: "replace" } as const;
       }
-      const oldName = output?.name
-        ? output.name
-        : yield* createCertificateName(id, olds.name);
+      const oldName =
+        output?.name ?? (yield* createCertificateName(id, olds.name));
       // Auto-generated names are engine-owned: the deployed name stays
       // authoritative even if the generator would name this id differently
       // today. Only an explicit user-provided name can force a replace.

--- a/packages/alchemy/src/Cloudflare/MtlsCertificate/MtlsCertificate.ts
+++ b/packages/alchemy/src/Cloudflare/MtlsCertificate/MtlsCertificate.ts
@@ -192,10 +192,7 @@ export const MtlsCertificateProvider = () =>
       // Auto-generated names are engine-owned: the deployed name stays
       // authoritative even if the generator would name this id differently
       // today. Only an explicit user-provided name can force a replace.
-      const name =
-        news.name !== undefined || olds.name !== undefined
-          ? yield* createCertificateName(id, news.name)
-          : oldName;
+      const name = news.name ?? oldName;
       if (
         oldName !== name ||
         (news.ca ?? undefined) !== (olds.ca ?? undefined) ||

--- a/packages/alchemy/src/Cloudflare/Pages/Project.ts
+++ b/packages/alchemy/src/Cloudflare/Pages/Project.ts
@@ -269,10 +269,7 @@ export const ProjectProvider = () =>
       // Auto-generated names are engine-owned: the deployed name stays
       // authoritative even if the generator would name this id differently
       // today. Only an explicit user-provided name can force a replace.
-      const name =
-        news.name !== undefined || olds?.name !== undefined
-          ? yield* createProjectName(id, news.name)
-          : oldName;
+      const name = news.name ?? oldName;
       if (name !== oldName) {
         return { action: "replace" } as const;
       }

--- a/packages/alchemy/src/Cloudflare/Pages/Project.ts
+++ b/packages/alchemy/src/Cloudflare/Pages/Project.ts
@@ -264,9 +264,15 @@ export const ProjectProvider = () =>
       }
       // The name is the project's identity (it forms the *.pages.dev
       // subdomain) — renames are a delete + create.
-      const name = yield* createProjectName(id, news.name);
       const oldName =
         output?.name ?? (yield* createProjectName(id, olds?.name));
+      // Auto-generated names are engine-owned: the deployed name stays
+      // authoritative even if the generator would name this id differently
+      // today. Only an explicit user-provided name can force a replace.
+      const name =
+        news.name !== undefined || olds?.name !== undefined
+          ? yield* createProjectName(id, news.name)
+          : oldName;
       if (name !== oldName) {
         return { action: "replace" } as const;
       }

--- a/packages/alchemy/src/Cloudflare/Queues/Queue.ts
+++ b/packages/alchemy/src/Cloudflare/Queues/Queue.ts
@@ -122,10 +122,16 @@ export const ProviderLive = () =>
       if ((output?.accountId ?? accountId) !== accountId) {
         return { action: "replace" } as const;
       }
-      const name = yield* createQueueName(id, news.name);
       const oldName = output?.queueName
         ? output.queueName
         : yield* createQueueName(id, olds.name);
+      // Auto-generated names are engine-owned: the deployed name stays
+      // authoritative even if the generator would name this id differently
+      // today. Only an explicit user-provided name can force a replace.
+      const name =
+        news.name !== undefined || olds.name !== undefined
+          ? yield* createQueueName(id, news.name)
+          : oldName;
       if (name !== oldName) {
         return { action: "replace" } as const;
       }

--- a/packages/alchemy/src/Cloudflare/Queues/Queue.ts
+++ b/packages/alchemy/src/Cloudflare/Queues/Queue.ts
@@ -128,10 +128,7 @@ export const ProviderLive = () =>
       // Auto-generated names are engine-owned: the deployed name stays
       // authoritative even if the generator would name this id differently
       // today. Only an explicit user-provided name can force a replace.
-      const name =
-        news.name !== undefined || olds.name !== undefined
-          ? yield* createQueueName(id, news.name)
-          : oldName;
+      const name = news.name ?? oldName;
       if (name !== oldName) {
         return { action: "replace" } as const;
       }

--- a/packages/alchemy/src/Cloudflare/Queues/Queue.ts
+++ b/packages/alchemy/src/Cloudflare/Queues/Queue.ts
@@ -122,9 +122,8 @@ export const ProviderLive = () =>
       if ((output?.accountId ?? accountId) !== accountId) {
         return { action: "replace" } as const;
       }
-      const oldName = output?.queueName
-        ? output.queueName
-        : yield* createQueueName(id, olds.name);
+      const oldName =
+        output?.queueName ?? (yield* createQueueName(id, olds.name));
       // Auto-generated names are engine-owned: the deployed name stays
       // authoritative even if the generator would name this id differently
       // today. Only an explicit user-provided name can force a replace.

--- a/packages/alchemy/src/Cloudflare/R2/Bucket.ts
+++ b/packages/alchemy/src/Cloudflare/R2/Bucket.ts
@@ -922,9 +922,8 @@ export const BucketProvider = () =>
         diff: Effect.fn(function* ({ id, olds = {}, news = {}, output }) {
           if (!isResolved(news)) return undefined;
           const { accountId } = yield* yield* CloudflareEnvironment;
-          const oldName = output?.bucketName
-            ? output.bucketName
-            : yield* createBucketName(id, olds.name);
+          const oldName =
+            output?.bucketName ?? (yield* createBucketName(id, olds.name));
           // Auto-generated names are engine-owned: the deployed name stays
           // authoritative even if the generator would name this id
           // differently today. Only an explicit user-provided name can

--- a/packages/alchemy/src/Cloudflare/R2/Bucket.ts
+++ b/packages/alchemy/src/Cloudflare/R2/Bucket.ts
@@ -922,10 +922,17 @@ export const BucketProvider = () =>
         diff: Effect.fn(function* ({ id, olds = {}, news = {}, output }) {
           if (!isResolved(news)) return undefined;
           const { accountId } = yield* yield* CloudflareEnvironment;
-          const name = yield* createBucketName(id, news.name);
           const oldName = output?.bucketName
             ? output.bucketName
             : yield* createBucketName(id, olds.name);
+          // Auto-generated names are engine-owned: the deployed name stays
+          // authoritative even if the generator would name this id
+          // differently today. Only an explicit user-provided name can
+          // force a replace.
+          const name =
+            news.name !== undefined || olds.name !== undefined
+              ? yield* createBucketName(id, news.name)
+              : oldName;
           const oldJurisdiction =
             output?.jurisdiction ?? olds.jurisdiction ?? "default";
           const oldStorageClass =
@@ -960,7 +967,10 @@ export const BucketProvider = () =>
         }),
         reconcile: Effect.fn(function* ({ id, news = {}, output }) {
           const { accountId } = yield* yield* CloudflareEnvironment;
-          const name = yield* createBucketName(id, news.name);
+          // Prefer the deployed name: regenerating would target a different
+          // bucket if the generator's output for this id ever drifts.
+          const name =
+            output?.bucketName ?? (yield* createBucketName(id, news.name));
           const acct = output?.accountId ?? accountId;
           const jurisdiction =
             output?.jurisdiction ?? news.jurisdiction ?? "default";

--- a/packages/alchemy/src/Cloudflare/R2/Bucket.ts
+++ b/packages/alchemy/src/Cloudflare/R2/Bucket.ts
@@ -929,10 +929,7 @@ export const BucketProvider = () =>
           // authoritative even if the generator would name this id
           // differently today. Only an explicit user-provided name can
           // force a replace.
-          const name =
-            news.name !== undefined || olds.name !== undefined
-              ? yield* createBucketName(id, news.name)
-              : oldName;
+          const name = news.name ?? oldName;
           const oldJurisdiction =
             output?.jurisdiction ?? olds.jurisdiction ?? "default";
           const oldStorageClass =

--- a/packages/alchemy/src/Cloudflare/Rules/List.ts
+++ b/packages/alchemy/src/Cloudflare/Rules/List.ts
@@ -315,8 +315,14 @@ export const ListProvider = () =>
         return { action: "replace" } as const;
       }
       // Lists cannot be renamed and the kind is immutable.
-      const desiredName = yield* createListName(id, news.name);
       const oldName = output?.name ?? olds?.name;
+      // Auto-generated names are engine-owned: the deployed name stays
+      // authoritative even if the generator would name this id differently
+      // today. Only an explicit user-provided name can force a replace.
+      const desiredName =
+        news.name !== undefined || olds?.name !== undefined
+          ? yield* createListName(id, news.name)
+          : oldName;
       if (oldName !== undefined && desiredName !== oldName) {
         return { action: "replace" } as const;
       }
@@ -346,7 +352,9 @@ export const ListProvider = () =>
     }),
     reconcile: Effect.fn(function* ({ id, news, output }) {
       const { accountId } = yield* yield* CloudflareEnvironment;
-      const name = yield* createListName(id, news.name);
+      // Prefer the deployed name: regenerating would target a different
+      // resource if the generator's output for this id ever drifts.
+      const name = yield* createListName(id, news.name ?? output?.name);
 
       // Observe — the listId cached on `output` is a hint, not a guarantee:
       // a missing list falls through to "missing" and ensure recreates.

--- a/packages/alchemy/src/Cloudflare/Rules/List.ts
+++ b/packages/alchemy/src/Cloudflare/Rules/List.ts
@@ -319,10 +319,7 @@ export const ListProvider = () =>
       // Auto-generated names are engine-owned: the deployed name stays
       // authoritative even if the generator would name this id differently
       // today. Only an explicit user-provided name can force a replace.
-      const desiredName =
-        news.name !== undefined || olds?.name !== undefined
-          ? yield* createListName(id, news.name)
-          : oldName;
+      const desiredName = news.name ?? oldName;
       if (oldName !== undefined && desiredName !== oldName) {
         return { action: "replace" } as const;
       }

--- a/packages/alchemy/src/Cloudflare/Ruleset/AccountEntrypoint.ts
+++ b/packages/alchemy/src/Cloudflare/Ruleset/AccountEntrypoint.ts
@@ -149,7 +149,13 @@ export const AccountEntrypointProvider = () =>
       }
       const oldName =
         output?.name ?? olds.name ?? (yield* createPhysicalName({ id }));
-      const name = news.name ?? (yield* createPhysicalName({ id }));
+      // Auto-generated names are engine-owned: the deployed name stays
+      // authoritative even if the generator would name this id differently
+      // today. Only an explicit user-provided name can force a rename.
+      const name =
+        news.name !== undefined || olds.name !== undefined
+          ? (news.name ?? (yield* createPhysicalName({ id })))
+          : oldName;
       if (
         oldName !== name ||
         olds.description !== news.description ||

--- a/packages/alchemy/src/Cloudflare/Ruleset/AccountEntrypoint.ts
+++ b/packages/alchemy/src/Cloudflare/Ruleset/AccountEntrypoint.ts
@@ -152,10 +152,7 @@ export const AccountEntrypointProvider = () =>
       // Auto-generated names are engine-owned: the deployed name stays
       // authoritative even if the generator would name this id differently
       // today. Only an explicit user-provided name can force a rename.
-      const name =
-        news.name !== undefined || olds.name !== undefined
-          ? (news.name ?? (yield* createPhysicalName({ id })))
-          : oldName;
+      const name = news.name ?? oldName;
       if (
         oldName !== name ||
         olds.description !== news.description ||

--- a/packages/alchemy/src/Cloudflare/Ruleset/CustomRuleset.ts
+++ b/packages/alchemy/src/Cloudflare/Ruleset/CustomRuleset.ts
@@ -165,7 +165,13 @@ export const CustomRulesetProvider = () =>
       }
       const oldName =
         output?.name ?? olds.name ?? (yield* createPhysicalName({ id }));
-      const name = news.name ?? (yield* createPhysicalName({ id }));
+      // Auto-generated names are engine-owned: the deployed name stays
+      // authoritative even if the generator would name this id differently
+      // today. Only an explicit user-provided name can force a rename.
+      const name =
+        news.name !== undefined || olds.name !== undefined
+          ? (news.name ?? (yield* createPhysicalName({ id })))
+          : oldName;
       if (
         oldName !== name ||
         olds.description !== news.description ||
@@ -219,7 +225,10 @@ export const CustomRulesetProvider = () =>
 
     reconcile: Effect.fn(function* ({ id, news, output }) {
       const { accountId } = yield* yield* CloudflareEnvironment;
-      const name = news.name ?? (yield* createPhysicalName({ id }));
+      // Prefer the deployed name: regenerating would target a different
+      // resource if the generator's output for this id ever drifts.
+      const name =
+        news.name ?? output?.name ?? (yield* createPhysicalName({ id }));
       const kind = news.kind ?? "custom";
 
       // 1. Observe — the persisted rulesetId is a cache, not a guarantee.

--- a/packages/alchemy/src/Cloudflare/Ruleset/CustomRuleset.ts
+++ b/packages/alchemy/src/Cloudflare/Ruleset/CustomRuleset.ts
@@ -168,10 +168,7 @@ export const CustomRulesetProvider = () =>
       // Auto-generated names are engine-owned: the deployed name stays
       // authoritative even if the generator would name this id differently
       // today. Only an explicit user-provided name can force a rename.
-      const name =
-        news.name !== undefined || olds.name !== undefined
-          ? (news.name ?? (yield* createPhysicalName({ id })))
-          : oldName;
+      const name = news.name ?? oldName;
       if (
         oldName !== name ||
         olds.description !== news.description ||

--- a/packages/alchemy/src/Cloudflare/Ruleset/Ruleset.ts
+++ b/packages/alchemy/src/Cloudflare/Ruleset/Ruleset.ts
@@ -126,7 +126,13 @@ export const RulesetProvider = () =>
       }
 
       const oldName = output?.name ?? (yield* createRulesetName(id, olds.name));
-      const name = yield* createRulesetName(id, news.name);
+      // Auto-generated names are engine-owned: the deployed name stays
+      // authoritative even if the generator would name this id differently
+      // today. Only an explicit user-provided name can force a rename.
+      const name =
+        news.name !== undefined || olds.name !== undefined
+          ? yield* createRulesetName(id, news.name)
+          : oldName;
       if (
         oldName !== name ||
         olds.description !== news.description ||

--- a/packages/alchemy/src/Cloudflare/Ruleset/Ruleset.ts
+++ b/packages/alchemy/src/Cloudflare/Ruleset/Ruleset.ts
@@ -129,10 +129,7 @@ export const RulesetProvider = () =>
       // Auto-generated names are engine-owned: the deployed name stays
       // authoritative even if the generator would name this id differently
       // today. Only an explicit user-provided name can force a rename.
-      const name =
-        news.name !== undefined || olds.name !== undefined
-          ? yield* createRulesetName(id, news.name)
-          : oldName;
+      const name = news.name ?? oldName;
       if (
         oldName !== name ||
         olds.description !== news.description ||

--- a/packages/alchemy/src/Cloudflare/Snippets/Snippet.ts
+++ b/packages/alchemy/src/Cloudflare/Snippets/Snippet.ts
@@ -174,10 +174,7 @@ export const SnippetProvider = () =>
       // Auto-generated names are engine-owned: the deployed name stays
       // authoritative even if the generator would name this id differently
       // today. Only an explicit user-provided name can force a replace.
-      const name =
-        n.name !== undefined || o.name !== undefined
-          ? yield* createSnippetName(id, n.name)
-          : oldName;
+      const name = n.name ?? oldName;
       if (oldName !== name) {
         return { action: "replace" } as const;
       }

--- a/packages/alchemy/src/Cloudflare/Snippets/Snippet.ts
+++ b/packages/alchemy/src/Cloudflare/Snippets/Snippet.ts
@@ -169,9 +169,15 @@ export const SnippetProvider = () =>
       const n = news as SnippetProps;
 
       // Name is the snippet's identity within the zone.
-      const name = yield* createSnippetName(id, n.name);
       const oldName =
         output?.name ?? (yield* createSnippetName(id, o.name as string));
+      // Auto-generated names are engine-owned: the deployed name stays
+      // authoritative even if the generator would name this id differently
+      // today. Only an explicit user-provided name can force a replace.
+      const name =
+        n.name !== undefined || o.name !== undefined
+          ? yield* createSnippetName(id, n.name)
+          : oldName;
       if (oldName !== name) {
         return { action: "replace" } as const;
       }

--- a/packages/alchemy/src/Cloudflare/Tunnel/Tunnel.ts
+++ b/packages/alchemy/src/Cloudflare/Tunnel/Tunnel.ts
@@ -209,10 +209,16 @@ export const TunnelProvider = () =>
       if ((output?.accountId ?? accountId) !== accountId) {
         return { action: "replace" } as const;
       }
-      const name = yield* createTunnelName(id, news.name);
       const oldName = output?.tunnelName
         ? output.tunnelName
         : yield* createTunnelName(id, olds.name);
+      // Auto-generated names are engine-owned: the deployed name stays
+      // authoritative even if the generator would name this id differently
+      // today. Only an explicit user-provided name can force a replace.
+      const name =
+        news.name !== undefined || olds.name !== undefined
+          ? yield* createTunnelName(id, news.name)
+          : oldName;
       if (name !== oldName) {
         return { action: "replace" } as const;
       }
@@ -233,7 +239,9 @@ export const TunnelProvider = () =>
     }),
     reconcile: Effect.fn(function* ({ id, news = {}, output }) {
       const { accountId } = yield* yield* CloudflareEnvironment;
-      const name = yield* createTunnelName(id, news.name);
+      // Prefer the deployed name: regenerating would target a different
+      // resource if the generator's output for this id ever drifts.
+      const name = yield* createTunnelName(id, news.name ?? output?.tunnelName);
       const configSrc = news.configSrc ?? output?.configSrc ?? "cloudflare";
       const tunnelSecret = news.tunnelSecret
         ? Redacted.value(news.tunnelSecret)

--- a/packages/alchemy/src/Cloudflare/Tunnel/Tunnel.ts
+++ b/packages/alchemy/src/Cloudflare/Tunnel/Tunnel.ts
@@ -209,9 +209,8 @@ export const TunnelProvider = () =>
       if ((output?.accountId ?? accountId) !== accountId) {
         return { action: "replace" } as const;
       }
-      const oldName = output?.tunnelName
-        ? output.tunnelName
-        : yield* createTunnelName(id, olds.name);
+      const oldName =
+        output?.tunnelName ?? (yield* createTunnelName(id, olds.name));
       // Auto-generated names are engine-owned: the deployed name stays
       // authoritative even if the generator would name this id differently
       // today. Only an explicit user-provided name can force a replace.

--- a/packages/alchemy/src/Cloudflare/Tunnel/Tunnel.ts
+++ b/packages/alchemy/src/Cloudflare/Tunnel/Tunnel.ts
@@ -215,10 +215,7 @@ export const TunnelProvider = () =>
       // Auto-generated names are engine-owned: the deployed name stays
       // authoritative even if the generator would name this id differently
       // today. Only an explicit user-provided name can force a replace.
-      const name =
-        news.name !== undefined || olds.name !== undefined
-          ? yield* createTunnelName(id, news.name)
-          : oldName;
+      const name = news.name ?? oldName;
       if (name !== oldName) {
         return { action: "replace" } as const;
       }

--- a/packages/alchemy/src/Cloudflare/Vectorize/VectorizeIndex.ts
+++ b/packages/alchemy/src/Cloudflare/Vectorize/VectorizeIndex.ts
@@ -147,9 +147,8 @@ export const IndexProvider = () =>
       if ((output?.accountId ?? accountId) !== accountId) {
         return { action: "replace" } as const;
       }
-      const oldName = output?.indexName
-        ? output.indexName
-        : yield* createIndexName(id, olds.name);
+      const oldName =
+        output?.indexName ?? (yield* createIndexName(id, olds.name));
       // Auto-generated names are engine-owned: the deployed name stays
       // authoritative even if the generator would name this id differently
       // today. Only an explicit user-provided name can force a replace.

--- a/packages/alchemy/src/Cloudflare/Vectorize/VectorizeIndex.ts
+++ b/packages/alchemy/src/Cloudflare/Vectorize/VectorizeIndex.ts
@@ -153,10 +153,7 @@ export const IndexProvider = () =>
       // Auto-generated names are engine-owned: the deployed name stays
       // authoritative even if the generator would name this id differently
       // today. Only an explicit user-provided name can force a replace.
-      const name =
-        news.name !== undefined || olds.name !== undefined
-          ? yield* createIndexName(id, news.name)
-          : oldName;
+      const name = news.name ?? oldName;
       if (
         oldName !== name ||
         (news.preset ?? undefined) !== (olds.preset ?? undefined) ||

--- a/packages/alchemy/src/Cloudflare/Vectorize/VectorizeIndex.ts
+++ b/packages/alchemy/src/Cloudflare/Vectorize/VectorizeIndex.ts
@@ -147,10 +147,16 @@ export const IndexProvider = () =>
       if ((output?.accountId ?? accountId) !== accountId) {
         return { action: "replace" } as const;
       }
-      const name = yield* createIndexName(id, news.name);
       const oldName = output?.indexName
         ? output.indexName
         : yield* createIndexName(id, olds.name);
+      // Auto-generated names are engine-owned: the deployed name stays
+      // authoritative even if the generator would name this id differently
+      // today. Only an explicit user-provided name can force a replace.
+      const name =
+        news.name !== undefined || olds.name !== undefined
+          ? yield* createIndexName(id, news.name)
+          : oldName;
       if (
         oldName !== name ||
         (news.preset ?? undefined) !== (olds.preset ?? undefined) ||
@@ -176,9 +182,12 @@ export const IndexProvider = () =>
           ),
         );
     }),
-    reconcile: Effect.fn(function* ({ id, news = {} }) {
+    reconcile: Effect.fn(function* ({ id, news = {}, output }) {
       const { accountId } = yield* yield* CloudflareEnvironment;
-      const indexName = yield* createIndexName(id, news.name);
+      // Prefer the deployed name: regenerating would target a different
+      // index if the generator's output for this id ever drifts.
+      const indexName =
+        output?.indexName ?? (yield* createIndexName(id, news.name));
 
       // Observe — read the live index by name. The name is the stable
       // identifier; fall back through a NotFound to the create path so

--- a/packages/alchemy/src/Cloudflare/VpcService/VpcService.ts
+++ b/packages/alchemy/src/Cloudflare/VpcService/VpcService.ts
@@ -180,10 +180,7 @@ export const VpcServiceProvider = () =>
       // Auto-generated names are engine-owned: the deployed name stays
       // authoritative even if the generator would name this id differently
       // today. Only an explicit user-provided name can force a rename.
-      const name =
-        news.name !== undefined || olds?.name !== undefined
-          ? yield* createServiceName(id, news.name)
-          : oldName;
+      const name = news.name ?? oldName;
       if (name !== oldName) {
         return { action: "update" } as const;
       }

--- a/packages/alchemy/src/Cloudflare/VpcService/VpcService.ts
+++ b/packages/alchemy/src/Cloudflare/VpcService/VpcService.ts
@@ -174,17 +174,29 @@ export const VpcServiceProvider = () =>
       if ((output?.accountId ?? accountId) !== accountId) {
         return { action: "replace" } as const;
       }
-      const name = yield* createServiceName(id, news.name);
       const oldName = output?.serviceName
         ? output.serviceName
         : yield* createServiceName(id, olds?.name);
+      // Auto-generated names are engine-owned: the deployed name stays
+      // authoritative even if the generator would name this id differently
+      // today. Only an explicit user-provided name can force a rename.
+      const name =
+        news.name !== undefined || olds?.name !== undefined
+          ? yield* createServiceName(id, news.name)
+          : oldName;
       if (name !== oldName) {
         return { action: "update" } as const;
       }
     }),
     reconcile: Effect.fn(function* ({ id, news, output }) {
       const { accountId } = yield* yield* CloudflareEnvironment;
-      const name = yield* createServiceName(id, news.name);
+      // Prefer the deployed name: regenerating would rename the deployed
+      // service if the generator's output for this id ever drifts. An
+      // explicit user-provided name still wins (renames apply in place).
+      const name =
+        news.name ??
+        output?.serviceName ??
+        (yield* createServiceName(id, news.name));
       const acct = output?.accountId ?? accountId;
 
       // Observe — re-fetch the cached service; fall back to a name

--- a/packages/alchemy/src/Cloudflare/VpcService/VpcService.ts
+++ b/packages/alchemy/src/Cloudflare/VpcService/VpcService.ts
@@ -174,9 +174,8 @@ export const VpcServiceProvider = () =>
       if ((output?.accountId ?? accountId) !== accountId) {
         return { action: "replace" } as const;
       }
-      const oldName = output?.serviceName
-        ? output.serviceName
-        : yield* createServiceName(id, olds?.name);
+      const oldName =
+        output?.serviceName ?? (yield* createServiceName(id, olds?.name));
       // Auto-generated names are engine-owned: the deployed name stays
       // authoritative even if the generator would name this id differently
       // today. Only an explicit user-provided name can force a rename.

--- a/packages/alchemy/src/Cloudflare/Workers/ObservabilityDestination.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/ObservabilityDestination.ts
@@ -193,7 +193,13 @@ export const ObservabilityDestinationProvider = () =>
       // cannot rename — a name change is a replacement.
       const oldName =
         output?.name ?? olds?.name ?? (yield* createDestinationName(id));
-      const newName = news.name ?? (yield* createDestinationName(id));
+      // Auto-generated names are engine-owned: the deployed name stays
+      // authoritative even if the generator would name this id differently
+      // today. Only an explicit user-provided name can force a replace.
+      const newName =
+        news.name !== undefined || olds?.name !== undefined
+          ? (news.name ?? (yield* createDestinationName(id)))
+          : oldName;
       if (oldName !== newName) {
         return { action: "replace" } as const;
       }
@@ -226,7 +232,10 @@ export const ObservabilityDestinationProvider = () =>
 
     reconcile: Effect.fn(function* ({ id, news, output }) {
       const { accountId } = yield* yield* CloudflareEnvironment;
-      const name = news.name ?? (yield* createDestinationName(id));
+      // Prefer the deployed name: regenerating would target a different
+      // resource if the generator's output for this id ever drifts.
+      const name =
+        news.name ?? output?.name ?? (yield* createDestinationName(id));
       // Inputs have been resolved to concrete strings by Plan.
       const url = news.url as string;
       const headers = (news.headers ?? {}) as Record<string, string>;

--- a/packages/alchemy/src/Cloudflare/Workers/ObservabilityDestination.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/ObservabilityDestination.ts
@@ -196,10 +196,7 @@ export const ObservabilityDestinationProvider = () =>
       // Auto-generated names are engine-owned: the deployed name stays
       // authoritative even if the generator would name this id differently
       // today. Only an explicit user-provided name can force a replace.
-      const newName =
-        news.name !== undefined || olds?.name !== undefined
-          ? (news.name ?? (yield* createDestinationName(id)))
-          : oldName;
+      const newName = news.name ?? oldName;
       if (oldName !== newName) {
         return { action: "replace" } as const;
       }

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -1374,7 +1374,10 @@ export const LiveWorkerProvider = () =>
         existingSettings?: workers.GetScriptScriptAndVersionSettingResponse,
       ) {
         const { accountId } = yield* yield* CloudflareEnvironment;
-        const name = yield* createWorkerName(id, news.name);
+        // Prefer the deployed name: regenerating would target a different
+        // script if the generator's output for this id ever drifts.
+        const name =
+          output?.workerName ?? (yield* createWorkerName(id, news.name));
         // When set, this Worker is a Workers for Platforms "user worker"
         // uploaded into a dispatch namespace rather than a routable
         // account-level script. The put/settings calls switch endpoints and
@@ -2194,10 +2197,18 @@ export const LiveWorkerProvider = () =>
           if (newNamespace !== oldNamespace) {
             return { action: "replace" };
           }
-          const workerName = yield* createWorkerName(id, news.name);
           const oldWorkerName = output?.workerName
             ? output.workerName
             : yield* createWorkerName(id, olds?.name);
+          // Auto-generated names are engine-owned: the deployed name stays
+          // authoritative even if the generator would name this id
+          // differently today (a Worker replace would also destroy its
+          // Durable Object storage). Only an explicit user-provided name
+          // can force a replace.
+          const workerName =
+            news.name !== undefined || olds?.name !== undefined
+              ? yield* createWorkerName(id, news.name)
+              : oldWorkerName;
           if (workerName !== oldWorkerName) {
             return { action: "replace" };
           }

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -2205,10 +2205,7 @@ export const LiveWorkerProvider = () =>
           // differently today (a Worker replace would also destroy its
           // Durable Object storage). Only an explicit user-provided name
           // can force a replace.
-          const workerName =
-            news.name !== undefined || olds?.name !== undefined
-              ? yield* createWorkerName(id, news.name)
-              : oldWorkerName;
+          const workerName = news.name ?? oldWorkerName;
           if (workerName !== oldWorkerName) {
             return { action: "replace" };
           }

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -2197,9 +2197,8 @@ export const LiveWorkerProvider = () =>
           if (newNamespace !== oldNamespace) {
             return { action: "replace" };
           }
-          const oldWorkerName = output?.workerName
-            ? output.workerName
-            : yield* createWorkerName(id, olds?.name);
+          const oldWorkerName =
+            output?.workerName ?? (yield* createWorkerName(id, olds?.name));
           // Auto-generated names are engine-owned: the deployed name stays
           // authoritative even if the generator would name this id
           // differently today (a Worker replace would also destroy its

--- a/packages/alchemy/src/Docker/Network.ts
+++ b/packages/alchemy/src/Docker/Network.ts
@@ -104,8 +104,12 @@ export const NetworkProvider = () =>
         diff: Effect.fn(function* ({ id, output, instanceId, news }) {
           if (!isResolved(news) || !output) return undefined;
           const args = yield* makeNetworkArgs(id, news, instanceId);
+          // Auto-generated names are engine-owned: the deployed name stays
+          // authoritative even if the generator would name this id differently
+          // today. Only an explicit user-provided name can force a replace.
+          const desiredName = news.name ?? output.name;
           if (
-            output.name !== args.name ||
+            output.name !== desiredName ||
             output.driver !== args.driver ||
             output.enableIPv6 !== args.ipv6 ||
             // Compare only user labels; internal `alchemy::*` branding lives on

--- a/packages/alchemy/src/Docker/Volume.ts
+++ b/packages/alchemy/src/Docker/Volume.ts
@@ -125,8 +125,12 @@ export const VolumeProvider = () =>
         diff: Effect.fn(function* ({ id, instanceId, output, news }) {
           if (!isResolved(news)) return undefined;
           const args = yield* makeVolumeArgs(id, news, instanceId);
+          // Auto-generated names are engine-owned: the deployed name stays
+          // authoritative even if the generator would name this id differently
+          // today. Only an explicit user-provided name can force a replace.
+          const desiredName = news.name ?? output?.name ?? args.name;
           if (
-            output?.name !== args.name ||
+            output?.name !== desiredName ||
             output?.driver !== args.driver ||
             !Equal.equals(output?.driverOpts ?? {}, args.opt ?? {}) ||
             // Compare only user labels; internal `alchemy::*` branding lives on
@@ -136,11 +140,15 @@ export const VolumeProvider = () =>
             return { action: "replace" as const, deleteFirst: true };
           }
         }),
-        reconcile: Effect.fn(function* ({ id, instanceId, news }) {
+        reconcile: Effect.fn(function* ({ id, instanceId, news, output }) {
           const args = yield* makeVolumeArgs(id, news, instanceId);
+          // Prefer the deployed name: regenerating would target a different
+          // volume if the generator's output for this id ever drifts.
+          const name = news.name ?? output?.name ?? args.name;
           const internalTags = yield* createInternalTags(id);
           const result = yield* docker.volume.create({
             ...args,
+            name,
             label: { ...internalTags, ...args.label },
           });
           return toVolumeAttributes(

--- a/packages/alchemy/src/Neon/Branch.ts
+++ b/packages/alchemy/src/Neon/Branch.ts
@@ -245,10 +245,7 @@ export const BranchProvider = () =>
       // Auto-generated names are engine-owned: the deployed name stays
       // authoritative even if the generator would name this id differently
       // today. Only an explicit user-provided name can force a rename.
-      const newName =
-        news.name !== undefined || olds.name !== undefined
-          ? yield* createBranchName(id, news.name)
-          : oldName;
+      const newName = news.name ?? oldName;
       if (
         newName !== oldName ||
         (news.protected ?? false) !== (output?.protected ?? false) ||

--- a/packages/alchemy/src/Neon/Branch.ts
+++ b/packages/alchemy/src/Neon/Branch.ts
@@ -239,10 +239,16 @@ export const BranchProvider = () =>
       ) {
         return { action: "replace" } as const;
       }
-      const newName = yield* createBranchName(id, news.name);
       const oldName = output?.branchName
         ? output.branchName
         : yield* createBranchName(id, olds.name);
+      // Auto-generated names are engine-owned: the deployed name stays
+      // authoritative even if the generator would name this id differently
+      // today. Only an explicit user-provided name can force a rename.
+      const newName =
+        news.name !== undefined || olds.name !== undefined
+          ? yield* createBranchName(id, news.name)
+          : oldName;
       if (
         newName !== oldName ||
         (news.protected ?? false) !== (output?.protected ?? false) ||
@@ -339,7 +345,13 @@ export const BranchProvider = () =>
       };
     }),
     reconcile: Effect.fn(function* ({ id, news, output }) {
-      const newName = yield* createBranchName(id, news.name);
+      // Prefer the deployed name: regenerating would target a different
+      // resource if the generator's output for this id ever drifts. An
+      // explicit `news.name` still renames the branch in place.
+      const newName =
+        news.name ??
+        output?.branchName ??
+        (yield* createBranchName(id, news.name));
 
       // Ensure — when no prior output exists we create the branch;
       // otherwise sync the mutable scalar fields on the existing

--- a/packages/alchemy/src/Neon/Branch.ts
+++ b/packages/alchemy/src/Neon/Branch.ts
@@ -239,9 +239,8 @@ export const BranchProvider = () =>
       ) {
         return { action: "replace" } as const;
       }
-      const oldName = output?.branchName
-        ? output.branchName
-        : yield* createBranchName(id, olds.name);
+      const oldName =
+        output?.branchName ?? (yield* createBranchName(id, olds.name));
       // Auto-generated names are engine-owned: the deployed name stays
       // authoritative even if the generator would name this id differently
       // today. Only an explicit user-provided name can force a rename.

--- a/packages/alchemy/src/Neon/Project.ts
+++ b/packages/alchemy/src/Neon/Project.ts
@@ -235,10 +235,16 @@ export const ProjectProvider = () =>
     }),
     diff: Effect.fn(function* ({ id, olds = {}, news = {}, output }) {
       if (!isResolved(news)) return undefined;
-      const name = yield* createProjectName(id, news.name);
       const oldName = output?.projectName
         ? output.projectName
         : yield* createProjectName(id, olds.name);
+      // Auto-generated names are engine-owned: the deployed name stays
+      // authoritative even if the generator would name this id differently
+      // today. Only an explicit user-provided name can force a replace.
+      const name =
+        news.name !== undefined || olds.name !== undefined
+          ? yield* createProjectName(id, news.name)
+          : oldName;
       if (
         oldName !== name ||
         (news.region ?? output?.region ?? DEFAULT_REGION) !==

--- a/packages/alchemy/src/Neon/Project.ts
+++ b/packages/alchemy/src/Neon/Project.ts
@@ -241,10 +241,7 @@ export const ProjectProvider = () =>
       // Auto-generated names are engine-owned: the deployed name stays
       // authoritative even if the generator would name this id differently
       // today. Only an explicit user-provided name can force a replace.
-      const name =
-        news.name !== undefined || olds.name !== undefined
-          ? yield* createProjectName(id, news.name)
-          : oldName;
+      const name = news.name ?? oldName;
       if (
         oldName !== name ||
         (news.region ?? output?.region ?? DEFAULT_REGION) !==

--- a/packages/alchemy/src/Neon/Project.ts
+++ b/packages/alchemy/src/Neon/Project.ts
@@ -235,9 +235,8 @@ export const ProjectProvider = () =>
     }),
     diff: Effect.fn(function* ({ id, olds = {}, news = {}, output }) {
       if (!isResolved(news)) return undefined;
-      const oldName = output?.projectName
-        ? output.projectName
-        : yield* createProjectName(id, olds.name);
+      const oldName =
+        output?.projectName ?? (yield* createProjectName(id, olds.name));
       // Auto-generated names are engine-owned: the deployed name stays
       // authoritative even if the generator would name this id differently
       // today. Only an explicit user-provided name can force a replace.

--- a/packages/alchemy/src/PhysicalName.ts
+++ b/packages/alchemy/src/PhysicalName.ts
@@ -1,8 +1,14 @@
+import { createHash } from "node:crypto";
 import * as Effect from "effect/Effect";
 import { base32 } from ".//Util/base32.ts";
 import { InstanceId } from "./InstanceId.ts";
 import { Stack } from "./Stack.ts";
 import { Stage } from "./Stage.ts";
+
+// 8 base32 chars = 40 bits of the sha256 of the full untruncated name,
+// appended when truncation occurs so names that differ only in the truncated
+// portion of the prefix stay distinct.
+const TRUNCATION_HASH_LENGTH = 8;
 
 export const createPhysicalName = Effect.fn(function* ({
   id,
@@ -31,7 +37,9 @@ export const createPhysicalName = Effect.fn(function* ({
   /**
    * Maximum length of the physical name.
    *
-   * If the name exceeds this length, the human-friendly portion of the name will be truncated to maxLength-suffixLength
+   * If the name exceeds this length, the human-friendly prefix is truncated
+   * and a stable hash of the full name is kept alongside the instance suffix
+   * so distinct names never collapse to the same truncated string.
    */
   maxLength?: number;
   /** @default - "-" */
@@ -56,7 +64,21 @@ export const createPhysicalName = Effect.fn(function* ({
   const suffix = randomId.slice(0, suffixLength);
   const name = `${prefix}${suffix}`;
   if (maxLength && name.length > maxLength) {
-    return sanitize(`${prefix.slice(0, maxLength - suffix.length)}${suffix}`);
+    // The instance suffix alone cannot disambiguate: every name derived from
+    // the same resource shares one InstanceId, so two prefixes that differ
+    // only in their truncated tail (e.g. `…-task-role-` vs `…-execution-role-`)
+    // would collapse to the same string. Keep a stable hash of the full name
+    // next to the suffix so truncated names remain unique.
+    const hash = yield* Effect.sync(() =>
+      base32(createHash("sha256").update(name).digest()).slice(
+        0,
+        TRUNCATION_HASH_LENGTH,
+      ),
+    );
+    const tail = `${hash}${suffix}`.slice(-maxLength);
+    return sanitize(
+      `${prefix.slice(0, Math.max(0, maxLength - tail.length))}${tail}`,
+    );
   }
   return sanitize(name);
 });

--- a/packages/alchemy/src/PhysicalName.ts
+++ b/packages/alchemy/src/PhysicalName.ts
@@ -75,7 +75,11 @@ export const createPhysicalName = Effect.fn(function* ({
         TRUNCATION_HASH_LENGTH,
       ),
     );
-    const tail = `${hash}${suffix}`.slice(-maxLength);
+    // The hash is what keeps same-resource names distinct, so it always
+    // survives in full; when maxLength is tight (e.g. DAX's 20-char limit)
+    // the instance suffix shrinks instead — 12 base32 chars still carry 60
+    // bits of instance entropy.
+    const tail = `${hash}${suffix}`.slice(0, maxLength);
     return sanitize(
       `${prefix.slice(0, Math.max(0, maxLength - tail.length))}${tail}`,
     );

--- a/packages/alchemy/test/Cloudflare/EngineOwnedNames.test.ts
+++ b/packages/alchemy/test/Cloudflare/EngineOwnedNames.test.ts
@@ -1,0 +1,255 @@
+import type { CloudflareResolvedCredentials } from "@/Cloudflare/Auth/AuthProvider.ts";
+import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment.ts";
+import { type Database, DatabaseProvider } from "@/Cloudflare/D1/Database.ts";
+import {
+  type Connection,
+  ConnectionProvider,
+} from "@/Cloudflare/Hyperdrive/Connection.ts";
+import {
+  type Namespace,
+  NamespaceProvider,
+} from "@/Cloudflare/KV/Namespace.ts";
+import { type Queue, QueueProvider } from "@/Cloudflare/Queues/Queue.ts";
+import { type Bucket, BucketProvider } from "@/Cloudflare/R2/Bucket.ts";
+import {
+  type Index,
+  IndexProvider,
+} from "@/Cloudflare/Vectorize/VectorizeIndex.ts";
+import { AlchemyContext } from "@/AlchemyContext.ts";
+import { InstanceId } from "@/InstanceId.ts";
+import { Provider } from "@/Provider.ts";
+import { Stack, type StackSpec } from "@/Stack.ts";
+import { Stage } from "@/Stage.ts";
+import { describe, expect, it } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Redacted from "effect/Redacted";
+
+// Regression tests for the "engine-owned names" invariant: a provider's
+// `diff` must never order a replace (or rename) because the physical-name
+// generator's output for a logical id has drifted from the deployed name.
+// This is exactly what happens when the naming algorithm evolves (e.g. the
+// truncation fix) — deployed resources keep their old-style names, while a
+// fresh recompute yields a new-style name. Before the guard, that mismatch
+// deleted the deployed resource (databases included) via replace.
+//
+// Live suites can never catch this class of bug: a fresh deploy generates
+// names with the current algorithm, so `output` always matches the
+// recompute. These tests simulate drift directly by handing the real
+// provider `diff` a persisted output whose name no generator run today
+// could produce.
+
+const TEST_ACCOUNT = "test-account-id";
+
+// A name no current-generator run can produce for the ids used below.
+const DRIFTED = "old-algorithm-name-a1b2c3";
+
+const stack: Omit<StackSpec, "output"> = {
+  name: "my-stack",
+  stage: "dev",
+  resources: {},
+  bindings: {},
+  actions: {},
+};
+
+const credentials: CloudflareResolvedCredentials = {
+  type: "apiToken",
+  apiToken: Redacted.make("test-token"),
+  accountId: TEST_ACCOUNT,
+  source: { type: "env" },
+};
+
+const env = Layer.mergeAll(
+  Layer.succeed(CloudflareEnvironment, Effect.succeed(credentials)),
+  Layer.succeed(Stack, stack),
+  Layer.succeed(Stage, stack.stage),
+  Layer.succeed(InstanceId, "0123456789abcdef0123456789abcdef"),
+  Layer.succeed(AlchemyContext, {
+    dotAlchemy: "/tmp/.alchemy-test",
+    dev: false,
+    adopt: false,
+  }),
+);
+
+const diffInput = <Olds, News, Output>(
+  id: string,
+  olds: Olds,
+  news: News,
+  output: Output,
+) => ({
+  id,
+  fqn: id,
+  instanceId: "0123456789abcdef0123456789abcdef",
+  olds: olds as never,
+  news: news as never,
+  output: output as never,
+  oldBindings: [] as never,
+  newBindings: [] as never,
+});
+
+describe("engine-owned names: generator drift never replaces", () => {
+  it.effect("D1 Database: drifted auto-generated name does not replace", () =>
+    Effect.gen(function* () {
+      const provider = yield* Provider<Database>("Cloudflare.D1Database");
+      const result = yield* provider.diff!(
+        diffInput(
+          "Db",
+          {},
+          {},
+          {
+            databaseId: "11111111-2222-3333-4444-555555555555",
+            databaseName: DRIFTED,
+            accountId: TEST_ACCOUNT,
+          },
+        ),
+      );
+      expect(result?.action).not.toBe("replace");
+    }).pipe(Effect.provide(DatabaseProvider()), Effect.provide(env)),
+  );
+
+  it.effect("D1 Database: explicit user rename still replaces", () =>
+    Effect.gen(function* () {
+      const provider = yield* Provider<Database>("Cloudflare.D1Database");
+      const result = yield* provider.diff!(
+        diffInput(
+          "Db",
+          {},
+          { name: "explicit-new-name" },
+          {
+            databaseId: "11111111-2222-3333-4444-555555555555",
+            databaseName: DRIFTED,
+            accountId: TEST_ACCOUNT,
+          },
+        ),
+      );
+      expect(result?.action).toBe("replace");
+    }).pipe(Effect.provide(DatabaseProvider()), Effect.provide(env)),
+  );
+
+  it.effect(
+    "D1 Database: explicit name equal to deployed name does not replace",
+    () =>
+      Effect.gen(function* () {
+        const provider = yield* Provider<Database>("Cloudflare.D1Database");
+        const result = yield* provider.diff!(
+          diffInput(
+            "Db",
+            { name: DRIFTED },
+            { name: DRIFTED },
+            {
+              databaseId: "11111111-2222-3333-4444-555555555555",
+              databaseName: DRIFTED,
+              accountId: TEST_ACCOUNT,
+            },
+          ),
+        );
+        expect(result?.action).not.toBe("replace");
+      }).pipe(Effect.provide(DatabaseProvider()), Effect.provide(env)),
+  );
+
+  it.effect("R2 Bucket: drifted auto-generated name does not replace", () =>
+    Effect.gen(function* () {
+      const provider = yield* Provider<Bucket>("Cloudflare.R2.Bucket");
+      const result = yield* provider.diff!(
+        diffInput(
+          "Files",
+          {},
+          {},
+          { bucketName: DRIFTED, accountId: TEST_ACCOUNT },
+        ),
+      );
+      expect(result?.action).not.toBe("replace");
+    }).pipe(Effect.provide(BucketProvider()), Effect.provide(env)),
+  );
+
+  it.effect("R2 Bucket: explicit user rename still replaces", () =>
+    Effect.gen(function* () {
+      const provider = yield* Provider<Bucket>("Cloudflare.R2.Bucket");
+      const result = yield* provider.diff!(
+        diffInput(
+          "Files",
+          {},
+          { name: "explicit-new-bucket" },
+          { bucketName: DRIFTED, accountId: TEST_ACCOUNT },
+        ),
+      );
+      expect(result?.action).toBe("replace");
+    }).pipe(Effect.provide(BucketProvider()), Effect.provide(env)),
+  );
+
+  it.effect("Queue: drifted auto-generated name does not replace", () =>
+    Effect.gen(function* () {
+      const provider = yield* Provider<Queue>("Cloudflare.Queues.Queue");
+      const result = yield* provider.diff!(
+        diffInput(
+          "Jobs",
+          {},
+          {},
+          {
+            queueId: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+            queueName: DRIFTED,
+            accountId: TEST_ACCOUNT,
+          },
+        ),
+      );
+      expect(result?.action).not.toBe("replace");
+    }).pipe(Effect.provide(QueueProvider()), Effect.provide(env)),
+  );
+
+  it.effect(
+    "Vectorize Index: drifted auto-generated name does not replace",
+    () =>
+      Effect.gen(function* () {
+        const provider = yield* Provider<Index>("Cloudflare.VectorizeIndex");
+        const result = yield* provider.diff!(
+          diffInput(
+            "Vectors",
+            {},
+            {},
+            { indexName: DRIFTED, accountId: TEST_ACCOUNT },
+          ),
+        );
+        expect(result?.action).not.toBe("replace");
+      }).pipe(Effect.provide(IndexProvider()), Effect.provide(env)),
+  );
+
+  it.effect("KV Namespace: drifted auto-generated title does not rename", () =>
+    Effect.gen(function* () {
+      const provider = yield* Provider<Namespace>("Cloudflare.KV.Namespace");
+      const result = yield* provider.diff!(
+        diffInput(
+          "Cache",
+          {},
+          {},
+          {
+            namespaceId: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+            title: DRIFTED,
+            accountId: TEST_ACCOUNT,
+          },
+        ),
+      );
+      expect(result).toBeUndefined();
+    }).pipe(Effect.provide(NamespaceProvider()), Effect.provide(env)),
+  );
+
+  it.effect(
+    "Hyperdrive Connection: drifted auto-generated name does not replace",
+    () =>
+      Effect.gen(function* () {
+        const provider = yield* Provider<Connection>("Cloudflare.Hyperdrive");
+        const result = yield* provider.diff!(
+          diffInput(
+            "Pg",
+            {},
+            {},
+            {
+              hyperdriveId: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+              name: DRIFTED,
+              accountId: TEST_ACCOUNT,
+            },
+          ),
+        );
+        expect(result?.action).not.toBe("replace");
+      }).pipe(Effect.provide(ConnectionProvider()), Effect.provide(env)),
+  );
+});

--- a/packages/alchemy/test/Cloudflare/EngineOwnedNames.test.ts
+++ b/packages/alchemy/test/Cloudflare/EngineOwnedNames.test.ts
@@ -16,14 +16,23 @@ import {
   IndexProvider,
 } from "@/Cloudflare/Vectorize/VectorizeIndex.ts";
 import { AlchemyContext } from "@/AlchemyContext.ts";
+import { ArtifactStore, createArtifactStore } from "@/Artifacts.ts";
+import { LocalRuntimeState } from "@/Cloudflare/LocalRuntime.ts";
 import { InstanceId } from "@/InstanceId.ts";
 import { Provider } from "@/Provider.ts";
 import { Stack, type StackSpec } from "@/Stack.ts";
 import { Stage } from "@/Stage.ts";
+import {
+  apiTokenCredentials,
+  Credentials,
+} from "@distilled.cloud/cloudflare/Credentials";
+import { NodeServices } from "@effect/platform-node";
 import { describe, expect, it } from "alchemy-test";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as MutableHashMap from "effect/MutableHashMap";
 import * as Redacted from "effect/Redacted";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 
 // Regression tests for the "engine-owned names" invariant: a provider's
 // `diff` must never order a replace (or rename) because the physical-name
@@ -69,6 +78,23 @@ const env = Layer.mergeAll(
     dev: false,
     adopt: false,
   }),
+  // The remaining layers only satisfy the provider layers' type-level
+  // requirements (reconcile/read need clients); diff never touches them.
+  Layer.succeed(
+    Credentials,
+    Effect.succeed(apiTokenCredentials({ apiToken: "test-token" })),
+  ),
+  Layer.sync(ArtifactStore, createArtifactStore),
+  Layer.succeed(
+    LocalRuntimeState,
+    LocalRuntimeState.of({
+      queues: MutableHashMap.empty(),
+      queueConsumers: MutableHashMap.empty(),
+      workerRestarts: MutableHashMap.empty(),
+    }),
+  ),
+  NodeServices.layer,
+  FetchHttpClient.layer,
 );
 
 const diffInput = <Olds, News, Output>(

--- a/packages/alchemy/test/PhysicalName.test.ts
+++ b/packages/alchemy/test/PhysicalName.test.ts
@@ -1,0 +1,129 @@
+import { InstanceId } from "@/InstanceId.ts";
+import { createPhysicalName } from "@/PhysicalName.ts";
+import { Stack, type StackSpec } from "@/Stack.ts";
+import { Stage } from "@/Stage.ts";
+import { describe, expect, it } from "alchemy-test";
+import * as Effect from "effect/Effect";
+
+type StackShape = Omit<StackSpec, "output">;
+
+const stack: StackShape = {
+  name: "my-stack",
+  stage: "dev",
+  resources: {},
+  bindings: {},
+  actions: {},
+};
+
+const provide = <A, E>(
+  effect: Effect.Effect<A, E, Stack | Stage | InstanceId>,
+  instanceId = "0123456789abcdef0123456789abcdef",
+) =>
+  effect.pipe(
+    Effect.provideService(Stack, stack),
+    Effect.provideService(Stage, stack.stage),
+    Effect.provideService(InstanceId, instanceId),
+  );
+
+describe("createPhysicalName", () => {
+  it.effect("keeps short names untruncated", () =>
+    provide(
+      Effect.gen(function* () {
+        const name = yield* createPhysicalName({ id: "api", maxLength: 64 });
+        expect(name.length).toBeLessThanOrEqual(64);
+        expect(name.startsWith("my-stack-api-dev-")).toBe(true);
+      }),
+    ),
+  );
+
+  it.effect("is deterministic for the same inputs", () =>
+    provide(
+      Effect.gen(function* () {
+        const longId = "a".repeat(80);
+        const first = yield* createPhysicalName({ id: longId, maxLength: 64 });
+        const second = yield* createPhysicalName({ id: longId, maxLength: 64 });
+        expect(first).toBe(second);
+        expect(first.length).toBe(64);
+      }),
+    ),
+  );
+
+  it.effect(
+    "preserves suffix uniqueness when a long id truncates away the suffix (task-role vs execution-role)",
+    () =>
+      provide(
+        Effect.gen(function* () {
+          // Pathological logical id: long enough that `${stack}-${id}-…` alone
+          // exceeds IAM's 64-char role-name limit, so the distinguishing
+          // `-task-role` / `-execution-role` tail falls entirely inside the
+          // truncated region. Both names share the same InstanceId (same
+          // resource), which is exactly the collision scenario.
+          const longId = "my-very-long-container-platform-service-logical-id";
+          const taskRole = yield* createPhysicalName({
+            id: `${longId}-task-role`,
+            maxLength: 64,
+          });
+          const executionRole = yield* createPhysicalName({
+            id: `${longId}-execution-role`,
+            maxLength: 64,
+          });
+          expect(taskRole.length).toBe(64);
+          expect(executionRole.length).toBe(64);
+          expect(taskRole).not.toBe(executionRole);
+        }),
+      ),
+  );
+
+  it.effect(
+    "distinguishes every colliding suffix pair used by role helpers",
+    () =>
+      provide(
+        Effect.gen(function* () {
+          const longId = "z".repeat(100);
+          const suffixes = [
+            "task-role",
+            "execution-role",
+            "job-role",
+            "instance-role",
+            "access-role",
+          ];
+          const names = yield* Effect.forEach(suffixes, (suffix) =>
+            createPhysicalName({ id: `${longId}-${suffix}`, maxLength: 64 }),
+          );
+          expect(new Set(names).size).toBe(suffixes.length);
+          for (const name of names) {
+            expect(name.length).toBe(64);
+          }
+        }),
+      ),
+  );
+
+  it.effect("different instance ids still produce different names", () =>
+    Effect.gen(function* () {
+      const longId = "b".repeat(80);
+      const first = yield* provide(
+        createPhysicalName({ id: longId, maxLength: 64 }),
+        "0123456789abcdef0123456789abcdef",
+      );
+      const second = yield* provide(
+        createPhysicalName({ id: longId, maxLength: 64 }),
+        "fedcba9876543210fedcba9876543210",
+      );
+      expect(first).not.toBe(second);
+    }),
+  );
+
+  it.effect("lowercase truncated names stay DNS-safe", () =>
+    provide(
+      Effect.gen(function* () {
+        const name = yield* createPhysicalName({
+          id: `MyMixedCase_${"x".repeat(80)}`,
+          maxLength: 63,
+          lowercase: true,
+        });
+        expect(name.length).toBe(63);
+        expect(name).toMatch(/^[a-z0-9-]+$/);
+      }),
+    ),
+  );
+});

--- a/packages/alchemy/test/PhysicalName.test.ts
+++ b/packages/alchemy/test/PhysicalName.test.ts
@@ -113,6 +113,49 @@ describe("createPhysicalName", () => {
     }),
   );
 
+  it.effect(
+    "keeps the full hash under tight limits (DAX-style maxLength 20)",
+    () =>
+      provide(
+        Effect.gen(function* () {
+          // maxLength 20 with the default 16-char instance suffix leaves no
+          // room for prefix + hash + suffix; the hash must survive in full
+          // (the suffix shrinks) or same-resource names collide again.
+          const longId = "c".repeat(60);
+          const names = yield* Effect.forEach(["alpha", "beta"], (suffix) =>
+            createPhysicalName({
+              id: `${longId}-${suffix}`,
+              maxLength: 20,
+              lowercase: true,
+            }),
+          );
+          expect(names[0]!.length).toBe(20);
+          expect(names[1]!.length).toBe(20);
+          expect(names[0]).not.toBe(names[1]);
+        }),
+      ),
+  );
+
+  it.effect(
+    "keeps uniqueness with a shortened suffixLength (Canary-style 21/8)",
+    () =>
+      provide(
+        Effect.gen(function* () {
+          const longId = "d".repeat(60);
+          const names = yield* Effect.forEach(["alpha", "beta"], (suffix) =>
+            createPhysicalName({
+              id: `${longId}-${suffix}`,
+              maxLength: 21,
+              suffixLength: 8,
+              lowercase: true,
+            }),
+          );
+          expect(names[0]!.length).toBe(21);
+          expect(names[0]).not.toBe(names[1]);
+        }),
+      ),
+  );
+
   it.effect("lowercase truncated names stay DNS-safe", () =>
     provide(
       Effect.gen(function* () {

--- a/packages/alchemy/test/plan.test.ts
+++ b/packages/alchemy/test/plan.test.ts
@@ -3413,8 +3413,12 @@ describe("read is never handed unresolved persisted props", () => {
   );
 
   test(
-    "resolved persisted creating props still go through read recovery on destroy (control)",
+    "destroy of a creating row defers read recovery to apply even with resolved props",
     Effect.gen(function* () {
+      // Plan never probes a deleted attr-less row — resolved or not. Apply's
+      // `deleteResource` owns the authoritative read-then-delete recovery
+      // (it also covers replaced-chain old generations that never pass
+      // through plan); see the apply.test.ts destroy-recovery cases.
       yield* seed({
         Zombie: {
           ...creatingWithUnresolvedProps("Zombie"),
@@ -3423,8 +3427,29 @@ describe("read is never handed unresolved persisted props", () => {
       });
       const { reads, layer } = trackReads();
       const plan = yield* makePlan(Effect.void).pipe(Effect.provide(layer));
-      expect(reads).toContain("Zombie");
+      expect(reads).not.toContain("Zombie");
       expect(plan.deletions.Zombie).toMatchObject({ action: "delete" });
+      expect((plan.deletions.Zombie as any).state.attr).toBeUndefined();
+    }),
+  );
+
+  test(
+    "resolved persisted creating props still go through read recovery when re-declared (control)",
+    Effect.gen(function* () {
+      yield* seed({
+        Half: {
+          ...creatingWithUnresolvedProps("Half"),
+          props: { string: "resolved" },
+        },
+      });
+      const { reads, layer } = trackReads();
+      const plan = yield* makePlan(
+        Effect.gen(function* () {
+          yield* TestResource("Half", { string: "resolved-now" });
+        }),
+      ).pipe(Effect.provide(layer));
+      expect(reads).toContain("Half");
+      expect(plan.resources.Half!.action).toBe("create");
     }),
   );
 });


### PR DESCRIPTION
`createPhysicalName`'s truncation kept only the InstanceId-derived suffix — which is identical for every name minted by the same resource. With a long logical id, names differing only in their tail truncated to the same string, colliding two IAM roles:

```ts
// both 64-char truncations collapse to `my-stack-my-very-long-…-id-{instanceSuffix}`
createRoleName(id, "task-role");      // ECS Task
createRoleName(id, "execution-role");
```

Truncated names now keep 8 base32 chars of the sha256 of the full untruncated name next to the instance suffix (the full hash always survives, even at tight limits like DAX's 20 chars — the suffix shrinks instead), so distinct names stay distinct. Still deterministic given (stack, id, stage, instanceId); non-truncated names are unchanged.

At-risk suffix pairs (all at IAM's 64-char limit, all covered by the central fix): ECS Task `task-role`/`execution-role`, Batch JobDefinition `job-role`/`execution-role`, AppRunner Service `instance-role`/`access-role`.

### Auto-generated names are engine-owned

An audit of every data-holding provider found 33 providers where the name-scheme change (or any future one) would have been destructive: their `diff` compared a freshly recomputed generated name against the persisted `output` name and ordered a **replace** (create new + delete old) on mismatch — including D1 Database, R2 Bucket, Vectorize Index, Neon Project, Lambda Function, Workers (destroying Durable Object storage), and EC2 SecurityGroup — and/or their `reconcile` re-derived the name with no `output` fallback (Lambda, ECR Repository, R2, Vectorize), silently re-creating an empty resource and orphaning the real one.

Two invariants now hold across all of them:

```ts
// diff: deployed name is authoritative for auto-generated names;
// only an explicit user-provided name can force a rename/replace
const oldName = output?.xName ?? (yield* createXName(id, olds.name));
const name = news.name ?? oldName;

// reconcile: prefer the persisted name when observing/mutating
const name = output?.xName ?? (yield* createXName(id, news.name));
```

AWS providers whose diffs compare olds-vs-news symmetrically (both sides recomputed with the current algorithm, so drift cancels) were already safe. With these guards, the naming algorithm is freely evolvable: generator changes can never rename, replace, or delete a deployed resource.

`test/Cloudflare/EngineOwnedNames.test.ts` locks the invariant in: it drives the real D1/R2/Queue/Vectorize/KV/Hyperdrive providers' `diff` with a persisted output whose name no current generator run can produce (the exact state an algorithm change leaves behind) and asserts no replace/rename, plus controls that explicit user renames still replace. All six drift cases fail against the pre-guard providers. Live suites cannot cover this class: a fresh deploy always generates names with the current algorithm, so output never drifts.

### Also

Fixes the stale `plan.test.ts` destroy read-recovery control: since #862, plan defers attr-less-row read recovery to Apply's `deleteResource`, so the control now asserts no plan-time read on destroy and re-targets the `isResolved` control at the re-declared creating-state recovery path, which still probes at plan time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
