### PR TITLE
docs(website): rewrite Bindings page benefits-first

### DIFF
--- a/website/src/content/docs/infrastructure-as-effects/binding.mdx
+++ b/website/src/content/docs/infrastructure-as-effects/binding.mdx
@@ -3,16 +3,18 @@ title: Bindings
 description: A Binding connects a Resource to a Worker or Lambda. One line declares the capability and generates the permissions, the configuration, and a typed client.
 ---
 
-Code that uses a resource — a Worker reading from a bucket, a Lambda
-writing to a queue — needs three things wired up: permission to access
-the resource, configuration to find it, and a client to call it. A
-**Binding** generates all three from one line.
+A **Binding** connects a [Resource](/infrastructure-as-code/resource)
+to a Worker, Lambda Function, or Container. You yield the resource and
+get back a typed client:
 
-Bindings work the same on every cloud. On AWS a binding attaches
-least-privilege IAM policies; on Cloudflare it attaches native Worker
-bindings. Either way, the client you get back is a typed Effect API.
+```typescript
+const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
+```
 
-Let's look at how they work.
+Everything else the connection needs is derived from this line: the
+permission grant — least-privilege IAM on AWS, a native binding on
+Cloudflare — and the environment configuration that points the client
+at the deployed resource.
 
 ## A binding in one line
 

--- a/website/src/content/docs/infrastructure-as-effects/binding.mdx
+++ b/website/src/content/docs/infrastructure-as-effects/binding.mdx
@@ -12,8 +12,8 @@ const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
 ```
 
 Everything else the connection needs is derived from this line: the
-permission grant — least-privilege IAM on AWS, a native binding on
-Cloudflare — and the environment configuration that points the client
+permission grant (least-privilege IAM on AWS, a native binding on
+Cloudflare) and the environment configuration that points the client
 at the deployed resource.
 
 ## A binding in one line

--- a/website/src/content/docs/infrastructure-as-effects/binding.mdx
+++ b/website/src/content/docs/infrastructure-as-effects/binding.mdx
@@ -1,15 +1,18 @@
 ---
 title: Bindings
-description: A binding connects a resource to a Worker or Lambda. It generates IAM policies, env vars, and a typed SDK in one call.
+description: A Binding connects a Resource to a Worker or Lambda. One line declares the capability and generates the permissions, the configuration, and a typed client.
 ---
 
-A **Binding** connects a [Resource](/infrastructure-as-code/resource) to a
-Worker, Lambda Function, or Container.
-[Functions & Servers](/infrastructure-as-effects/functions-and-servers) showed
-bindings in action; this page covers the mechanics — what one
-binding call generates (the IAM policies, the environment variables,
-**and** the typed SDK wrapper) and why you never write any of it by
-hand.
+Code that uses a resource — a Worker reading from a bucket, a Lambda
+writing to a queue — needs three things wired up: permission to access
+the resource, configuration to find it, and a client to call it. A
+**Binding** generates all three from one line.
+
+Bindings work the same on every cloud. On AWS a binding attaches
+least-privilege IAM policies; on Cloudflare it attaches native Worker
+bindings. Either way, the client you get back is a typed Effect API.
+
+Let's look at how they work.
 
 ## A binding in one line
 
@@ -30,25 +33,27 @@ export default Cloudflare.Worker(
 );
 ```
 
-`yield* ReadWriteBucket(Bucket)` is the binding — declared in the
-[Effectful Constructor](/infrastructure-as-effects/functions-and-servers#the-effectful-constructor-pattern),
-used in the interface it returns. `bucket` is the resource itself,
-presented as a typed client. There is no `env.BUCKET`, no
-`BUCKET_NAME` lookup — the binding **is** the SDK, and the
-`Effect.provide` on the last line is what supplies it.
+`yield* ReadWriteBucket(Bucket)` declares the binding — `bucket` is the
+resource itself, presented as a typed client. The binding is the SDK.
+
+`Effect.provide(ReadWriteBucketBinding)` on the last line chooses how
+the binding is implemented.
+
+Bindings work in async-style handlers too, declared on `env` and typed
+with `InferEnv` — see
+[Functions & Servers](/infrastructure-as-effects/functions-and-servers#effect-handlers-vs-async-handlers).
+This page uses the Effect style; the mechanics are identical in both.
 
 ## A contract and a Layer
 
-A binding has two halves. The **declaration** is a contract:
+A binding has two halves. The declaration is a contract:
 
 ```typescript
 const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
 ```
 
-`Cloudflare.R2.ReadWriteBucket` is a `Binding.Service` — a callable
-Context tag. Yielding it declares the capability and adds the tag to
-the Effect's requirements; it says nothing about *how* the capability
-is satisfied. The entire contract is three lines:
+`ReadWriteBucket` is a `Binding.Service` — a callable Context tag. It
+names the capability and says nothing about how it's satisfied:
 
 ```typescript
 export interface ReadWriteBucket extends Binding.Service<
@@ -58,80 +63,55 @@ export interface ReadWriteBucket extends Binding.Service<
 > {}
 ```
 
-The **implementation** is a Layer, provided at the end of the
-constructor — and there are two interchangeable ones:
+The implementation is a Layer, and there are two interchangeable ones:
 
 ```diff lang="typescript"
 -  }).pipe(Effect.provide(Cloudflare.R2.ReadWriteBucketBinding)),
 +  }).pipe(Effect.provide(Cloudflare.R2.ReadWriteBucketHttp)),
 ```
 
-`ReadWriteBucketBinding` implements the contract as a **native
-Cloudflare binding**: at deploy time it registers an `r2_bucket`
-workerd binding on the Worker; at runtime it reads that binding
-straight off the Worker env — no tokens, no HTTP.
-`ReadWriteBucketHttp` implements the **same contract** over
-Cloudflare's HTTP API: at deploy time it mints a scoped
-`AccountApiToken` whose policies carry exactly the needed permission
-groups (`"Workers R2 Storage Read"` / `"Workers R2 Storage Write"` —
-least privilege per access level); at runtime the client calls R2
-over HTTP with that token. This split is what lets the handler body
-be written generically, independent of how the binding is satisfied.
+`ReadWriteBucketBinding` registers a native `r2_bucket` binding on the
+Worker and reads it off the Worker env at runtime.
+`ReadWriteBucketHttp` mints a scoped `AccountApiToken` at deploy time
+and calls R2 over HTTP at runtime. Same contract, same handler code.
 
-### The Layer is where the platform lives
+## The Layer is where the platform lives
 
-`ReadWriteBucketBinding`'s construction Effect does
-`yield* WorkerEnvironment; yield* Worker`, so the Layer carries those
-requirements — and only a `Cloudflare.Worker` constructor admits
-them. Piping the same implementation into an `AWS.Lambda.Function` is
-a **type error**: its constraint admits only
-`Credentials | Region | AWSEnvironment` (plus platform services), and
-the compiler names `WorkerEnvironment` and `Worker` as the services
-it cannot satisfy.
+`ReadWriteBucketBinding` requires `WorkerEnvironment` and `Worker`, so
+only a Cloudflare Worker can provide it:
 
-On AWS the same idea collapses to a single Layer per capability —
-`DynamoDB.GetItemHttp`, `S3.GetObjectHttp` — because Lambda has no
-workerd-style native binding interface to split against. At deploy
-time the Layer attaches least-privilege IAM policy statements to the
-Function's existing role via `host.bind`; at runtime it calls the
-service over HTTP through distilled, its requirements
-(`Credentials | Region | HttpClient`) satisfied by the Lambda
-runtime.
+```typescript
+export default AWS.Lambda.Function(
+  "Api",
+  { main: import.meta.url },
+  handler.pipe(Effect.provide(Cloudflare.R2.ReadWriteBucketBinding)),
+  // ✗ Type error: the Layer requires `WorkerEnvironment` and `Worker`,
+  //   which a Lambda Function can't provide
+);
+```
 
-Contract yielded in the constructor, implementation chosen with one
-`Effect.provide` — this is the seed of the
-[Layers](/infrastructure-as-effects/layers) story, which covers the
-`Layer.provide` composition mechanics.
+On AWS, each capability is a single Layer — `DynamoDB.GetItemHttp`,
+`S3.GetObjectHttp` — that attaches least-privilege IAM statements at
+deploy time and calls the service over HTTP at runtime.
 
-## Effect style vs async style
-
-Bindings work in both handler styles — Effect style binds inside the
-init Effect; async style declares bindings on `env` and types them
-with `InferEnv`. See [Functions & Servers › Effect handlers vs async
-handlers](/infrastructure-as-effects/functions-and-servers#effect-handlers-vs-async-handlers)
-for the full comparison. The rest of this page uses the Effect
-style; the deploy-time mechanics are identical in both.
+[Layers](/infrastructure-as-effects/layers) builds on this same
+tag/Layer split, one level up.
 
 ## What one binding call does at deploy time
 
-Each call records three things on the platform's plan — the
-recording is done by the implementation Layer you provided, so
-*which* things get recorded depends on the Layer (a native binding
-entry, token policies, or IAM statements):
+The implementation Layer records three things on the plan:
 
-1. **Permissions** — IAM (AWS) or Worker bindings (Cloudflare)
-2. **Environment / configuration** — physical names, ARNs, URLs
-3. **A typed SDK wrapper** — bundled into the handler
+1. **Permissions** — IAM policies (AWS) or native bindings (Cloudflare)
+2. **Configuration** — physical names, ARNs, URLs, serialized into the
+   Function's environment
+3. **A typed SDK client** — bundled into the handler
 
 ### Automatic IAM (AWS)
 
-Each binding maps to specific IAM actions on the exact resource
-ARNs. Alchemy generates **least-privilege** policies — `Resource:
-"*"` is only used when the API genuinely doesn't support
-resource-level scoping.
+Each binding maps to specific IAM actions on the exact resource ARNs:
 
-| Binding                        | IAM Actions        | Resource                     |
-| ------------------------------ | ------------------ | ---------------------------- |
+| Binding                   | IAM Actions        | Resource                     |
+| ------------------------- | ------------------ | ---------------------------- |
 | `S3.GetObject(bucket)`    | `s3:GetObject`     | `arn:aws:s3:::bucket-name/*` |
 | `S3.PutObject(bucket)`    | `s3:PutObject`     | `arn:aws:s3:::bucket-name/*` |
 | `SQS.SendMessage(queue)`  | `sqs:SendMessage`  | Queue ARN                    |
@@ -147,34 +127,17 @@ const batchGet = yield* DynamoDB.BatchGetItem(JobsTable, AuditTable);
 
 ### Automatic environment variables
 
-Bindings capture the resolved Outputs the client needs — the queue
-URL, bucket name, table name — and serialize them into the
-Function's environment under canonical Output keys. You never read
-these yourself; the typed client resolves them.
-
-## Cloudflare bindings
-
-On Cloudflare, the same call attaches a native Worker binding (R2,
-KV, D1, Durable Object…) instead of an IAM policy:
-
-```typescript
-const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
-const kv = yield* Cloudflare.KV.ReadWriteNamespace(Sessions);
-```
-
-The runtime API is identical to the AWS counterpart — code that
-consumes one consumes the other.
+Bindings serialize the resolved Outputs the client needs — the queue
+URL, the bucket name, the table name — into the Function's environment.
+The typed client resolves them for you.
 
 ## Event Sources and Sinks
 
-Two binding specializations round out the model. An
-**[Event Source](/infrastructure-as-effects/event-sources)** runs
-your Function when something happens on a resource — the records
-arrive as an Effect `Stream` you can map, filter, and batch. A
-**[Sink](/infrastructure-as-effects/sinks)** is the write-side dual —
-the resource exposed as an Effect `Sink` that batches into the
-underlying batch API. Both wire their own permissions, exactly like
-every other binding:
+An **[Event Source](/infrastructure-as-effects/event-sources)** runs
+your Function when something happens on a resource — the records arrive
+as an Effect `Stream`. A **[Sink](/infrastructure-as-effects/sinks)**
+is the write side — the resource exposed as an Effect `Sink`. Both wire
+their own permissions, like every other binding:
 
 ```typescript
 // Event Source: run this Function on queue messages.
@@ -183,10 +146,6 @@ yield* SQS.consumeQueueMessages(InboundQueue, (records) => /* Stream */);
 // Sink: write to a queue by running a Stream into it.
 const sink = yield* SQS.QueueSink(OutboundQueue);
 ```
-
-Each has a dedicated page:
-[Event Sources](/infrastructure-as-effects/event-sources) and
-[Sinks](/infrastructure-as-effects/sinks).
 
 ## How it works under the hood
 
@@ -201,17 +160,13 @@ if (!globalThis.__ALCHEMY_RUNTIME__) {
 // always: return the typed runtime client
 ```
 
-This guarded setup Effect is the body of the implementation Layer
-(`makeBucketBinding` for the native Layer, `makeHttpBucketBinding`
-for the HTTP one) — the contract itself contains no such code.
 [Phases](/infrastructure-as-effects/phases#the-__alchemy_runtime__-guard)
-covers this guard in depth.
+covers the guard in depth.
 
 ## All of Effect, on every binding
 
-Bindings return `Effect` values. That means `Effect.retry`,
-`timeout`, `catchTag` — they all just work, with typed error
-channels:
+Bindings return `Effect` values, so `Effect.retry`, `timeout`, and
+`catchTag` work with typed error channels:
 
 ```typescript
 const sendWithRetry = enqueue({ MessageBody: msg }).pipe(
@@ -221,12 +176,11 @@ const sendWithRetry = enqueue({ MessageBody: msg }).pipe(
 );
 ```
 
-Because every binding is an Effect with the same shape, you can
-hide them behind a service interface and swap implementations
-without touching handler code — that's what
-[Layers](/infrastructure-as-effects/layers) covers. Two Workers can even bind
-each other — [Circular Bindings](/infrastructure-as-effects/circular-bindings),
-covered later in this category.
+And because every binding has the same shape, you can hide one behind a
+service interface and swap implementations without touching handler
+code — that's [Layers](/infrastructure-as-effects/layers). Two Functions
+can even bind each other —
+[Circular Bindings](/infrastructure-as-effects/circular-bindings).
 
 ## Where next
 

--- a/website/src/content/docs/infrastructure-as-effects/binding.mdx
+++ b/website/src/content/docs/infrastructure-as-effects/binding.mdx
@@ -11,11 +11,12 @@ get back a typed client:
 const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
 ```
 
-Everything else the connection needs is derived from this line: the
-permission grant (least-privilege IAM on AWS, a native binding on
-Cloudflare) and the environment configuration that points the client
-at the deployed resource (a table ARN, a queue URL, a sensitive API
-key).
+Everything else the connection needs is derived from this line:
+
+1. **permission grant** — least-privilege IAM on AWS, a native binding
+   on Cloudflare
+2. **environment configuration** — points the client at the deployed
+   resource: a table ARN, a queue URL, a sensitive API key
 
 ## A binding in one line
 

--- a/website/src/content/docs/infrastructure-as-effects/binding.mdx
+++ b/website/src/content/docs/infrastructure-as-effects/binding.mdx
@@ -43,11 +43,6 @@ resource itself, presented as a typed client. The binding is the SDK.
 `Effect.provide(ReadWriteBucketBinding)` on the last line chooses how
 the binding is implemented.
 
-Bindings work in async-style handlers too, declared on `env` and typed
-with `InferEnv` — see
-[Functions & Servers](/infrastructure-as-effects/functions-and-servers#effect-handlers-vs-async-handlers).
-This page uses the Effect style; the mechanics are identical in both.
-
 ## A contract and a Layer
 
 A binding has two halves. The declaration is a contract:

--- a/website/src/content/docs/infrastructure-as-effects/binding.mdx
+++ b/website/src/content/docs/infrastructure-as-effects/binding.mdx
@@ -14,7 +14,8 @@ const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
 Everything else the connection needs is derived from this line: the
 permission grant (least-privilege IAM on AWS, a native binding on
 Cloudflare) and the environment configuration that points the client
-at the deployed resource.
+at the deployed resource (a table ARN, a queue URL, a sensitive API
+key).
 
 ## A binding in one line
 

--- a/website/src/content/docs/infrastructure-as-effects/binding.mdx
+++ b/website/src/content/docs/infrastructure-as-effects/binding.mdx
@@ -62,7 +62,9 @@ export interface ReadWriteBucket extends Binding.Service<
 > {}
 ```
 
-The implementation is a Layer, and there are two interchangeable ones:
+The implementation is a Layer, and any Layer that satisfies the
+contract can be provided. Cloudflare ships two interchangeable ones for
+R2:
 
 ```diff lang="typescript"
 -  }).pipe(Effect.provide(Cloudflare.R2.ReadWriteBucketBinding)),


### PR DESCRIPTION
Rewrite the Bindings concept page in the same style as the Layers rewrite (#864): benefits-first intro, one tight pass through the mechanics, redundant language cut (236 → 190 lines).

- New intro leads with what a binding generates:

  > Code that uses a resource — a Worker reading from a bucket, a Lambda writing to a queue — needs three things wired up: permission to access the resource, configuration to find it, and a client to call it. A **Binding** generates all three from one line.

- "The Layer is where the platform lives" now shows the wrong-platform case as code instead of describing it:

  ```typescript
  handler.pipe(Effect.provide(Cloudflare.R2.ReadWriteBucketBinding)),
  // ✗ Type error: the Layer requires `WorkerEnvironment` and `Worker`,
  //   which a Lambda Function can't provide
  ```

- The two-implementation paragraph (native vs HTTP) compressed to two sentences; the standalone "Cloudflare bindings" section folded into the intro and the deploy-time list; "Effect style vs async style" reduced to a pointer paragraph.
- Links only to `/infrastructure-as-effects/layers` (the Building with Layers page is removed in #864), so this merges cleanly in either order.
