### PR TITLE
fix(aws/rds): fingerprint-guard MasterUserPassword — stop re-sending it on every reconcile

### DIFF
--- a/packages/alchemy/src/AWS/RDS/DBInstance.ts
+++ b/packages/alchemy/src/AWS/RDS/DBInstance.ts
@@ -11,6 +11,7 @@ import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
 import type { Providers } from "../Providers.ts";
 import { createInternalTags, diffTags } from "../../Tags.ts";
+import { sha256 } from "../../Util/sha256.ts";
 
 export interface DBInstanceProps {
   /**
@@ -379,6 +380,13 @@ export interface DBInstance extends Resource<
      */
     finalDBSnapshotIdentifier: string | undefined;
     /**
+     * SHA-256 hex fingerprint of the last `masterUserPassword` this provider
+     * sent to RDS — never the secret itself. Lets reconcile skip the
+     * `MasterUserPassword` modify (and the `resetting-master-credentials`
+     * cycle it triggers) when the configured password has not changed.
+     */
+    masterUserPasswordFingerprint: string | undefined;
+    /**
      * ARN of the Secrets Manager secret holding master credentials.
      */
     masterUserSecretArn: string | undefined;
@@ -476,14 +484,17 @@ const toAttrs = ({
   tags,
   skipFinalSnapshot,
   finalDBSnapshotIdentifier,
+  masterUserPasswordFingerprint,
 }: {
   instance: rds.DBInstance;
   tags: Record<string, string>;
   skipFinalSnapshot?: boolean | undefined;
   finalDBSnapshotIdentifier?: string | undefined;
+  masterUserPasswordFingerprint?: string | undefined;
 }): DBInstance["Attributes"] => ({
   skipFinalSnapshot,
   finalDBSnapshotIdentifier,
+  masterUserPasswordFingerprint,
   dbInstanceIdentifier: instance.DBInstanceIdentifier ?? "",
   dbInstanceArn: instance.DBInstanceArn ?? "",
   dbClusterIdentifier: instance.DBClusterIdentifier,
@@ -687,14 +698,25 @@ export const DBInstanceProvider = () =>
             instance,
             tags: toTagRecord(instance.TagList),
             // Not observable from AWS — carry the stored deletion behavior
-            // forward so a refresh doesn't drop it.
+            // and last-sent fingerprint forward so a refresh drops neither.
             skipFinalSnapshot: output?.skipFinalSnapshot,
             finalDBSnapshotIdentifier: output?.finalDBSnapshotIdentifier,
+            masterUserPasswordFingerprint:
+              output?.masterUserPasswordFingerprint,
           });
         }),
         reconcile: Effect.fn(function* ({ id, news, output, session }) {
           const identifier =
             output?.dbInstanceIdentifier ?? (yield* toIdentifier(id, news));
+          // AWS never returns the master password, so there is nothing to
+          // observe-and-diff — fingerprint the configured value instead and
+          // only send `MasterUserPassword` when the fingerprint changed.
+          // Without this, every reconcile of an instance whose props carry a
+          // password triggers a live `resetting-master-credentials` modify.
+          const passwordFingerprint =
+            news.masterUserPassword !== undefined
+              ? yield* sha256(Redacted.value(news.masterUserPassword))
+              : undefined;
           const internalTags = yield* createInternalTags(id);
           const desiredTags = { ...internalTags, ...news.tags };
           // Duration props → the exact wire units the RDS API expects.
@@ -841,14 +863,20 @@ export const DBInstanceProvider = () =>
             if (news.allowMajorVersionUpgrade) {
               core.AllowMajorVersionUpgrade = true;
             }
-            // syncMasterPassword — rotation or explicit password update.
+            // syncMasterPassword — rotation or explicit password update. The
+            // explicit branch is fingerprint-guarded: send only when the
+            // configured password actually changed (or was never
+            // fingerprinted — pre-existing state sends once, then records).
             if (
               news.manageMasterUserPassword &&
               news.rotateMasterUserPassword
             ) {
               core.RotateMasterUserPassword = true;
               coreDirty = true;
-            } else if (news.masterUserPassword !== undefined) {
+            } else if (
+              news.masterUserPassword !== undefined &&
+              passwordFingerprint !== output?.masterUserPasswordFingerprint
+            ) {
               core.MasterUserPassword = news.masterUserPassword;
               coreDirty = true;
             }
@@ -897,6 +925,7 @@ export const DBInstanceProvider = () =>
             tags: desiredTags,
             skipFinalSnapshot: news.skipFinalSnapshot,
             finalDBSnapshotIdentifier: news.finalDBSnapshotIdentifier,
+            masterUserPasswordFingerprint: passwordFingerprint,
           });
         }),
         delete: Effect.fn(function* ({ output }) {

--- a/packages/alchemy/src/AWS/RDS/DBInstance.ts
+++ b/packages/alchemy/src/AWS/RDS/DBInstance.ts
@@ -380,12 +380,20 @@ export interface DBInstance extends Resource<
      */
     finalDBSnapshotIdentifier: string | undefined;
     /**
-     * SHA-256 hex fingerprint of the last `masterUserPassword` this provider
-     * sent to RDS — never the secret itself. Lets reconcile skip the
-     * `MasterUserPassword` modify (and the `resetting-master-credentials`
-     * cycle it triggers) when the configured password has not changed.
+     * Salted SHA-256 fingerprint of the last `masterUserPassword` this
+     * provider sent to RDS — `sha256(`${dbInstanceIdentifier}:${password}`)`,
+     * never the secret itself. Lets reconcile skip the `MasterUserPassword`
+     * modify (and the `resetting-master-credentials` cycle it triggers) when
+     * the configured password has not changed.
+     *
+     * Persisted `Redacted` because a password hash is still sensitive: an
+     * unsalted digest is vulnerable to rainbow-table lookup, so the state
+     * store must not surface it in plaintext (logs, `stringify`, dumps). The
+     * per-resource identifier salt additionally defeats precomputed tables;
+     * it is stable across a resource's life, so the fingerprint stays
+     * comparable across reconciles.
      */
-    masterUserPasswordFingerprint: string | undefined;
+    masterUserPasswordFingerprint: Redacted.Redacted<string> | undefined;
     /**
      * ARN of the Secrets Manager secret holding master credentials.
      */
@@ -479,6 +487,18 @@ const toTagRecord = (
       .map((tag) => [tag.Key, tag.Value]),
   );
 
+/**
+ * Whether two optional master-password fingerprints match, compared by their
+ * underlying (`Redacted`-unwrapped) digest. A missing stored fingerprint
+ * counts as "does not match" so a pre-existing instance sends its password
+ * once, then records the fingerprint for subsequent reconciles.
+ */
+const sameFingerprint = (
+  a: Redacted.Redacted<string> | undefined,
+  b: Redacted.Redacted<string> | undefined,
+): boolean =>
+  a !== undefined && b !== undefined && Redacted.value(a) === Redacted.value(b);
+
 const toAttrs = ({
   instance,
   tags,
@@ -490,7 +510,7 @@ const toAttrs = ({
   tags: Record<string, string>;
   skipFinalSnapshot?: boolean | undefined;
   finalDBSnapshotIdentifier?: string | undefined;
-  masterUserPasswordFingerprint?: string | undefined;
+  masterUserPasswordFingerprint?: Redacted.Redacted<string> | undefined;
 }): DBInstance["Attributes"] => ({
   skipFinalSnapshot,
   finalDBSnapshotIdentifier,
@@ -713,9 +733,16 @@ export const DBInstanceProvider = () =>
           // only send `MasterUserPassword` when the fingerprint changed.
           // Without this, every reconcile of an instance whose props carry a
           // password triggers a live `resetting-master-credentials` modify.
+          // The hash is salted with the (stable) instance identifier so the
+          // persisted digest is not rainbow-table-lookupable, and kept
+          // `Redacted` so it never leaks in plaintext through state/logs.
           const passwordFingerprint =
             news.masterUserPassword !== undefined
-              ? yield* sha256(Redacted.value(news.masterUserPassword))
+              ? Redacted.make(
+                  yield* sha256(
+                    `${identifier}:${Redacted.value(news.masterUserPassword)}`,
+                  ),
+                )
               : undefined;
           const internalTags = yield* createInternalTags(id);
           const desiredTags = { ...internalTags, ...news.tags };
@@ -875,7 +902,10 @@ export const DBInstanceProvider = () =>
               coreDirty = true;
             } else if (
               news.masterUserPassword !== undefined &&
-              passwordFingerprint !== output?.masterUserPasswordFingerprint
+              !sameFingerprint(
+                passwordFingerprint,
+                output?.masterUserPasswordFingerprint,
+              )
             ) {
               core.MasterUserPassword = news.masterUserPassword;
               coreDirty = true;


### PR DESCRIPTION
`DBInstance` re-sends `MasterUserPassword` on every reconcile of an instance whose props carry a password. AWS never returns the password, so there is nothing to observe-and-diff — the modify branch just sends it unconditionally:

```ts
} else if (news.masterUserPassword !== undefined) {
  core.MasterUserPassword = news.masterUserPassword; // fires on EVERY deploy
  coreDirty = true;
}
```

Each of those sends puts the live instance into a `resetting-master-credentials` modify cycle: existing connections can be reset, and `waitForInstance` blocks the whole deploy until the instance settles again. For anyone deploying regularly against a production database, every routine deploy pays that cost for a password that hasn't changed.

### Context — how we hit this

We run a production Postgres `DBInstance` behind Cloudflare Hyperdrive (a better-auth session store, so connection resets are user-visible). Our stack deploys several times a day. We had carried a vendored copy of this resource specifically because of this behavior; this PR upstreams that fix so we can drop the vendored copy.

### What this enables

Declaring the password in props becomes deploy-neutral: reconcile only touches the master password when the configured value actually changed.

```ts
const db = yield* DBInstance("Db", {
  engine: "postgres",
  dbInstanceClass: "db.t4g.micro",
  masterUserPassword: Redacted.make(process.env.DB_PASSWORD!),
});
// deploy N times → zero resetting-master-credentials cycles
// change DB_PASSWORD → exactly one modify on the next deploy
```

### How

The password can't be diffed against cloud state, so reconcile fingerprints the configured value (SHA-256, via the existing `Util/sha256`) and persists the fingerprint — never the secret — as a new `masterUserPasswordFingerprint` attribute. The modify branch sends `MasterUserPassword` only when the fingerprint differs from the stored one. `read` carries the stored fingerprint forward, since it isn't observable from AWS.

States that predate this attribute have no fingerprint, so their next reconcile sends the password once (exactly what happens today) and records it; every deploy after that skips.

The `manageMasterUserPassword`/`rotateMasterUserPassword` (Secrets Manager) branch is untouched.
