### PR TITLE
refactor(cloudflare/workers): source provider interface

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -66,11 +66,16 @@ import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
 import { LOCAL_ENTRY_URL, LocalRuntimeState } from "../LocalRuntime.ts";
 import type { WorkerAssetsConfig, WorkerProps } from "../Workers/Worker.ts";
 import { getCompatibility } from "./Compatibility.ts";
-import { isPythonMain, watchPythonWorkerBundle } from "./PythonWorkerBundle.ts";
+import {
+  makeSourceContext,
+  resolveSource,
+  type DevContext,
+  type SourceDevServices,
+  type SourceError,
+} from "./Source.ts";
 import { Worker } from "./Worker.ts";
 import { getCronBindings } from "./WorkerAsyncBindings.ts";
 import type { WorkerBinding } from "./WorkerBinding.ts";
-import { WorkerBundle, type WorkerBundleOptions } from "./WorkerBundle.ts";
 import { createWorkerName } from "./WorkerName.ts";
 
 type WorkerPropsWithDev = Omit<WorkerProps, "dev"> & {
@@ -91,7 +96,6 @@ export const LocalWorkerProvider = () =>
     Worker,
     LOCAL_ENTRY_URL,
     Effect.gen(function* () {
-      const bundler = yield* WorkerBundle;
       const runtime = yield* Runtime;
       const stack = yield* Stack;
       const path = yield* Path.Path;
@@ -214,16 +218,17 @@ export const LocalWorkerProvider = () =>
               content: file.content,
             });
           } else {
-            if (typeof file.content !== "string") {
-              return yield* new WorkerValidationError({
-                message: `Expected string for ${file.path} (${type})`,
-                value: file.content,
-              });
-            }
+            // Prebuilt (`bundle: false`) workers read every module as raw
+            // bytes; string-typed workerd modules (ESModule, Text, ...)
+            // are decoded here, mirroring the deploy path which uploads
+            // the same bytes with a text content type.
             modules.push({
               name: file.path,
               type,
-              content: file.content,
+              content:
+                typeof file.content === "string"
+                  ? file.content
+                  : new TextDecoder().decode(file.content),
             });
           }
         }
@@ -459,20 +464,7 @@ export const LocalWorkerProvider = () =>
           compatibility,
           workerBindings,
           durableObjectNamespaces: Object.values(durableObjectNamespaces),
-          viteMain: props.vite?.main,
-          viteEnvironments: props.vite?.viteEnvironments,
           hyperdrives,
-          env: props.env,
-          bundleOptions: {
-            id,
-            main: props.main!,
-            compatibility,
-            entry: props.isExternal
-              ? { kind: "external" }
-              : { kind: "effect", exports: props.exports ?? {} },
-            stack: { name: stack.name, stage: stack.stage },
-            extraOptions: props.build,
-          } satisfies WorkerBundleOptions,
           assets: props.assets,
           dev: {
             ...props.dev,
@@ -484,19 +476,18 @@ export const LocalWorkerProvider = () =>
 
       type WorkerConfig = Effect.Success<ReturnType<typeof buildConfig>>;
 
-      const runWorker = Effect.fn(function* (worker: WorkerConfig) {
+      const runWorker = Effect.fn(function* (
+        worker: WorkerConfig,
+        proxy: WorkerProxy.WorkerProxyInstance,
+        bundles: Stream.Stream<
+          Bundle.BundleWatchEvent,
+          SourceError,
+          SourceDevServices
+        >,
+      ) {
         let start = Date.now();
         let status: "start" | "update" = "start";
-        const proxy = yield* maybeStartProxy(worker.id, worker.dev);
-        yield* (
-          isPythonMain(worker.bundleOptions.main)
-            ? watchPythonWorkerBundle({
-                id: worker.bundleOptions.id,
-                main: worker.bundleOptions.main,
-                compatibility: worker.compatibility,
-              })
-            : bundler.watch(worker.bundleOptions)
-        ).pipe(
+        yield* bundles.pipe(
           Stream.tap((event) => {
             if (event._tag === "Start") {
               start = Date.now();
@@ -545,39 +536,6 @@ export const LocalWorkerProvider = () =>
         return proxy.url;
       });
 
-      const runVite = Effect.fn(function* (
-        worker: WorkerConfig,
-        rootDir: string | undefined,
-      ) {
-        const proxy = yield* maybeStartProxy(worker.id, worker.dev);
-        yield* proxy.unset().pipe(Effect.forkChild);
-        // Loaded lazily: `./Vite.ts` pulls in `@distilled.cloud/cloudflare-vite-plugin`
-        // (~0.5s); only needed when running a vite dev server.
-        const Vite = yield* Effect.promise(() => import("./Vite.ts"));
-        const devServer = yield* Vite.viteDev(
-          rootDir,
-          worker.env ?? {},
-          {
-            main: worker.viteMain,
-            compatibilityDate: worker.compatibility.date,
-            compatibilityFlags: worker.compatibility.flags,
-            viteEnvironments: worker.viteEnvironments,
-            worker: {
-              name: worker.name,
-              bindings: worker.workerBindings,
-              durableObjectNamespaces: worker.durableObjectNamespaces,
-              hyperdrives: worker.hyperdrives,
-              queueConsumers: yield* getQueueConsumers(worker.name),
-              assets: toRuntimeAssets(worker.assets),
-            },
-            context,
-          },
-          { port: 0 },
-        );
-        yield* proxy.set(new URL(devServer.resolvedUrls!.local[0]));
-        return proxy.url;
-      });
-
       const rootScope = yield* Effect.scope;
       const workerdScopes = new Map<string, Scope.Closeable>();
 
@@ -588,7 +546,7 @@ export const LocalWorkerProvider = () =>
           signature: string;
           fiber: Fiber.Fiber<
             Worker["Attributes"],
-            Bundle.BundleError | WorkerValidationError | RuntimeError
+            SourceError | WorkerValidationError | RuntimeError
           >;
           scope: Scope.Closeable;
         }
@@ -602,8 +560,35 @@ export const LocalWorkerProvider = () =>
         const { accountId } = yield* yield* CloudflareEnvironment;
         const { props, bindings } = options;
         const config = yield* buildConfig(options);
+        const source = resolveSource(props);
+        const devCtx: DevContext = {
+          ...makeSourceContext({
+            id: options.id,
+            workerName: config.name,
+            props,
+            compatibility: config.compatibility,
+            stack: { name: stack.name, stage: stack.stage },
+          }),
+          worker: {
+            name: config.name,
+            bindings: config.workerBindings,
+            durableObjectNamespaces: config.durableObjectNamespaces,
+            hyperdrives: config.hyperdrives,
+            queueConsumers: getQueueConsumers(config.name),
+            assets: toRuntimeAssets(config.assets),
+          },
+          runtimeContext: context,
+        };
+        const proxy = yield* maybeStartProxy(config.id, config.dev);
+        // Queue requests until the source's first output is served —
+        // whether that's the first workerd serve (bundle mode) or the
+        // dev server URL (server mode).
+        yield* proxy.unset().pipe(Effect.forkChild);
+        const handle = yield* source.dev(devCtx);
         const url = yield* (
-          props.vite ? runVite(config, props.vite.rootDir) : runWorker(config)
+          handle.mode === "server"
+            ? proxy.set(handle.url).pipe(Effect.as(proxy.url))
+            : runWorker(config, proxy, handle.bundles)
         ).pipe(Effect.map((url) => url.toString()));
         return {
           workerId: config.name,

--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -560,7 +560,7 @@ export const LocalWorkerProvider = () =>
         const { accountId } = yield* yield* CloudflareEnvironment;
         const { props, bindings } = options;
         const config = yield* buildConfig(options);
-        const source = resolveSource(props);
+        const source = yield* resolveSource(props);
         const devCtx: DevContext = {
           ...makeSourceContext({
             id: options.id,

--- a/packages/alchemy/src/Cloudflare/Workers/Source.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Source.ts
@@ -1,0 +1,297 @@
+import type {
+  BindingHook,
+  BindingServices,
+  HyperdriveOrigin,
+  Assets as RuntimeAssets,
+  DurableObjectNamespace as RuntimeDurableObject,
+  QueueConsumer as RuntimeQueueConsumer,
+  RuntimeServices,
+} from "@distilled.cloud/cloudflare-runtime";
+import type * as Context from "effect/Context";
+import * as Data from "effect/Data";
+import type * as Effect from "effect/Effect";
+import type * as FileSystem from "effect/FileSystem";
+import type * as Path from "effect/Path";
+import type { PlatformError } from "effect/PlatformError";
+import type * as Scope from "effect/Scope";
+import type * as Stream from "effect/Stream";
+import type { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner";
+import type { Artifacts } from "../../Artifacts.ts";
+import type * as Bundle from "../../Bundle/Bundle.ts";
+import type { WorkflowExport } from "../Workflows/Workflow.ts";
+import type { AssetReadResult, ValidationError } from "./Assets.ts";
+import type { DurableObjectExport } from "./DurableObject.ts";
+import { isPythonMain } from "./PythonWorkerBundle.ts";
+import { makeInlineScriptSource } from "./Sources/InlineScript.ts";
+import { makePrebuiltSource } from "./Sources/Prebuilt.ts";
+import { makePythonSource } from "./Sources/Python.ts";
+import { makeRolldownSource } from "./Sources/Rolldown.ts";
+import { makeViteSource } from "./Sources/Vite.ts";
+import type { WorkerAssetsConfig, WorkerProps } from "./Worker.ts";
+
+/**
+ * The hash slots a Worker source contributes to
+ * `Worker["Attributes"]["hash"]`. Slots a source doesn't use are
+ * `undefined`. The `metadata` hash (#745) is deliberately NOT a source
+ * slot — it covers the deploy-time metadata surface and stays owned by
+ * the WorkerProvider.
+ */
+export interface SourceHash {
+  readonly bundle: string | undefined;
+  readonly assets: string | undefined;
+  readonly input: string | undefined;
+  /**
+   * Auxiliary metadata for the `input` hash (vite's auto-detected
+   * workspace directories, relative to the source root). Never compared
+   * as a change signal — only carried so the next `hash()` call can
+   * recompute `input` over the same workspace set.
+   */
+  readonly additionalWorkspaces: string[] | undefined;
+}
+
+export interface SourceBuildOutput {
+  /**
+   * Server bundle. `undefined` for assets-only workers (e.g. a static
+   * vite site with no server environment).
+   */
+  readonly bundle: Bundle.BundleOutput | undefined;
+  /**
+   * Static assets, already read and manifest-hashed. `undefined` when the
+   * source doesn't own assets — the WorkerProvider merges in the
+   * props-level `assets` for those sources (see
+   * {@link SourceProvider.ownsAssets}).
+   */
+  readonly assets: AssetReadResult | undefined;
+  /** Source-owned hash slots. Slots the source doesn't use are `undefined`. */
+  readonly hash: SourceHash;
+}
+
+/**
+ * Everything a source may need, derived once by the WorkerProvider from
+ * `(id, props, stack)`. Source-specific inputs (entry module path, vite
+ * options, inline script, ...) are closed over by the provider instance
+ * itself — providers are resolved per Worker from props, not injected
+ * once per stack.
+ */
+export interface SourceContext {
+  /** Logical id of the Worker resource. */
+  readonly id: string;
+  /** Physical script name. */
+  readonly workerName: string;
+  readonly compatibility: {
+    readonly date: string;
+    readonly flags: string[];
+  };
+  /** Effect-entry vs external-entry (async workers). Drives the virtual-entry plugin. */
+  readonly entry:
+    | { readonly kind: "external" }
+    | {
+        readonly kind: "effect";
+        readonly exports: Record<string, DurableObjectExport | WorkflowExport>;
+      };
+  readonly stack: { readonly name: string; readonly stage: string };
+  /**
+   * Raw `props.env`. Deliberately unresolved: env entries may be Effects
+   * whose evaluation requires plan-phase context that is not available
+   * inside lifecycle operations — a source that needs literal values
+   * (e.g. vite's `import.meta.env` defines) resolves them itself, exactly
+   * as the vite arm always has.
+   */
+  readonly env: Record<string, unknown> | undefined;
+  /** `props.build` passthrough for rolldown-based sources. */
+  readonly extraOptions: Bundle.BundleExtraOptions | undefined;
+  /**
+   * Raw `props.assets`. Sources that own their assets (vite) merge its
+   * routing config into the assets they read out of the build; sources
+   * that don't own assets never touch it (the WorkerProvider reads and
+   * diffs props-level assets centrally).
+   */
+  readonly assets: WorkerAssetsConfig | undefined;
+}
+
+/**
+ * Runtime wiring for local dev, derived by the LocalWorkerProvider.
+ * Server-mode sources that embed their own workerd (the vite plugin)
+ * consume `worker` + `runtimeContext`; bundle-mode sources ignore both.
+ */
+export interface DevContext extends SourceContext {
+  readonly worker: {
+    readonly name: string;
+    readonly bindings: BindingHook<BindingServices>[];
+    readonly durableObjectNamespaces: (RuntimeDurableObject & {
+      uniqueKey: string;
+    })[];
+    readonly hyperdrives: Record<string, Required<HyperdriveOrigin>>;
+    /** Re-read on each (re)start so late-registered consumers are observed. */
+    readonly queueConsumers: Effect.Effect<RuntimeQueueConsumer[]>;
+    readonly assets: RuntimeAssets | undefined;
+  };
+  /** RuntimeServices context for providers that embed cloudflare-runtime. */
+  readonly runtimeContext: Context.Context<RuntimeServices>;
+}
+
+/**
+ * How a source serves local dev. Two irreducible modes:
+ *
+ * - `bundle` — the host runs workerd; the source supplies rebuild events
+ *   and the host restarts workerd with each successful bundle.
+ * - `server` — the source runs its own dev server (vite dev); the host
+ *   points the WorkerProxy at `url`.
+ */
+export type SourceDevHandle =
+  | {
+      readonly mode: "bundle";
+      readonly bundles: Stream.Stream<
+        Bundle.BundleWatchEvent,
+        SourceError,
+        SourceDevServices
+      >;
+    }
+  | {
+      readonly mode: "server";
+      readonly url: URL;
+    };
+
+/**
+ * The closed requirements channel of a source. Anything else a source
+ * needs (vite module loading, framework CLIs, workerd runtime services
+ * for dev) it constructs internally — external providers must NOT demand
+ * bespoke services from the WorkerProvider.
+ */
+export type SourceServices =
+  | FileSystem.FileSystem
+  | Path.Path
+  | ChildProcessSpawner
+  | Scope.Scope
+  | Artifacts;
+
+/** Requirements available to `dev()` (no per-run Artifacts cache in the local host). */
+export type SourceDevServices =
+  | FileSystem.FileSystem
+  | Path.Path
+  | ChildProcessSpawner
+  | Scope.Scope;
+
+/**
+ * An error raised by an external source provider, wrapped at the load
+ * boundary so the WorkerProvider's lifecycle error union stays closed.
+ */
+export class SourceProviderError extends Data.TaggedError(
+  "Cloudflare.Workers.SourceProviderError",
+)<{
+  /** Module specifier or built-in kind. */
+  readonly provider: string;
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+export type SourceError =
+  | Bundle.BundleError
+  | ValidationError
+  | PlatformError
+  | SourceProviderError;
+
+/**
+ * A Worker source provider: supplies the static assets, the server
+ * bundle, and hashes for memoization, plus a dev-serving story. The five
+ * built-in arms (inline script, rolldown, python, prebuilt, vite) live in
+ * `Workers/Sources/`; framework providers implement the same interface.
+ */
+export interface SourceProvider {
+  /**
+   * Whether this source produces its own static assets from its build
+   * (vite, framework builds). When `false`, the WorkerProvider reads and
+   * diffs the props-level `assets` directory centrally — including the
+   * AssetsWithHash fast path — and the source only supplies the bundle.
+   */
+  readonly ownsAssets: boolean;
+
+  /**
+   * Full build. Called from reconcile (`putWorker`). If the build is
+   * expensive it MUST be memoized per run via `Artifacts.cached` under
+   * the same key `hash()` uses, so a diff that had to build doesn't
+   * build twice.
+   */
+  readonly build: (
+    ctx: SourceContext,
+  ) => Effect.Effect<SourceBuildOutput, SourceError, SourceServices>;
+
+  /**
+   * Recompute the source-owned hash slots for diff, as cheaply as
+   * possible and WITHOUT a full build when the source supports it.
+   * `previous` is `output.hash` from state. Returns only the slots this
+   * source uses; the WorkerProvider compares slot-wise against
+   * `previous` — any defined slot that differs ⇒ update.
+   *
+   * Invariants:
+   * - MUST be deterministic for an unchanged source tree and
+   *   machine-independent for identical bytes (never hash absolute paths).
+   * - If it cannot avoid building, it MUST route the build through the
+   *   same `Artifacts.cached` key as `build()` so diff→reconcile builds
+   *   once.
+   * - `previous` is a hint, never truth: a source must not skip
+   *   recomputation because `previous` looks fresh — it may only use it
+   *   for auxiliary inputs (`additionalWorkspaces`).
+   */
+  readonly hash: (
+    ctx: SourceContext,
+    previous: SourceHash | undefined,
+  ) => Effect.Effect<Partial<SourceHash>, SourceError, SourceServices>;
+
+  /**
+   * Local dev. Scoped: closing the Scope stops the watcher / dev server.
+   */
+  readonly dev: (
+    ctx: DevContext,
+  ) => Effect.Effect<
+    SourceDevHandle,
+    SourceError,
+    SourceDevServices | Scope.Scope
+  >;
+}
+
+/**
+ * Resolve the {@link SourceProvider} for a Worker from its props. Legacy
+ * props map to the built-in providers, preserving the historical
+ * precedence exactly: `script` → `vite` → `.py` main → `bundle: false`
+ * → rolldown (default).
+ */
+export const resolveSource = (props: WorkerProps): SourceProvider => {
+  if (props.script !== undefined) {
+    return makeInlineScriptSource(props.script);
+  }
+  if (props.vite) {
+    return makeViteSource(props.vite);
+  }
+  if (isPythonMain(props.main)) {
+    return makePythonSource(props.main);
+  }
+  if (props.bundle === false) {
+    return makePrebuiltSource({ main: props.main!, rules: props.rules });
+  }
+  return makeRolldownSource({ main: props.main! });
+};
+
+/**
+ * Derive the shared {@link SourceContext} from a Worker's props. Pure —
+ * the physical `workerName` is computed by the caller (it may come from
+ * persisted output state rather than the name generator).
+ */
+export const makeSourceContext = (params: {
+  id: string;
+  workerName: string;
+  props: WorkerProps;
+  compatibility: { date: string; flags: string[] };
+  stack: { name: string; stage: string };
+}): SourceContext => ({
+  id: params.id,
+  workerName: params.workerName,
+  compatibility: params.compatibility,
+  entry: params.props.isExternal
+    ? { kind: "external" }
+    : { kind: "effect", exports: params.props.exports ?? {} },
+  stack: { name: params.stack.name, stage: params.stack.stage },
+  env: params.props.env,
+  extraOptions: params.props.build,
+  assets: params.props.assets,
+});

--- a/packages/alchemy/src/Cloudflare/Workers/Source.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Source.ts
@@ -9,7 +9,7 @@ import type {
 } from "@distilled.cloud/cloudflare-runtime";
 import type * as Context from "effect/Context";
 import * as Data from "effect/Data";
-import type * as Effect from "effect/Effect";
+import * as Effect from "effect/Effect";
 import type * as FileSystem from "effect/FileSystem";
 import type * as Path from "effect/Path";
 import type { PlatformError } from "effect/PlatformError";
@@ -27,7 +27,11 @@ import { makePrebuiltSource } from "./Sources/Prebuilt.ts";
 import { makePythonSource } from "./Sources/Python.ts";
 import { makeRolldownSource } from "./Sources/Rolldown.ts";
 import { makeViteSource } from "./Sources/Vite.ts";
-import type { WorkerAssetsConfig, WorkerProps } from "./Worker.ts";
+import type {
+  WorkerAssetsConfig,
+  WorkerProps,
+  WorkerSourceDescriptor,
+} from "./Worker.ts";
 
 /**
  * The hash slots a Worker source contributes to
@@ -251,25 +255,126 @@ export interface SourceProvider {
 }
 
 /**
- * Resolve the {@link SourceProvider} for a Worker from its props. Legacy
- * props map to the built-in providers, preserving the historical
- * precedence exactly: `script` → `vite` → `.py` main → `bundle: false`
- * → rolldown (default).
+ * The contract of a dynamically-imported source-provider module: its
+ * default export builds a {@link SourceProvider} from the descriptor's
+ * (JSON-serializable) options. `make` provides the package's own layers
+ * internally, so the closed {@link SourceServices} requirement holds.
  */
-export const resolveSource = (props: WorkerProps): SourceProvider => {
+export interface WorkerSourceModule {
+  readonly make: (
+    options: unknown,
+  ) => Effect.Effect<SourceProvider, SourceProviderError, SourceServices>;
+}
+
+/**
+ * Module imports memoized per specifier for the process lifetime.
+ * `make(options)` still runs per Worker — a stack can host several
+ * Workers of the same provider with different options.
+ */
+const sourceModules = new Map<
+  string,
+  Effect.Effect<WorkerSourceModule, SourceProviderError>
+>();
+
+const importSourceModule = (
+  specifier: string,
+): Effect.Effect<WorkerSourceModule, SourceProviderError> => {
+  const cached = sourceModules.get(specifier);
+  if (cached) {
+    return cached;
+  }
+  const load = Effect.tryPromise({
+    try: () => import(/* @vite-ignore */ specifier),
+    catch: (cause) =>
+      new SourceProviderError({
+        provider: specifier,
+        message:
+          `Failed to import Worker source provider "${specifier}". ` +
+          `Is the package installed in your project? Install it and re-run.`,
+        cause,
+      }),
+  }).pipe(
+    Effect.flatMap((mod: { default?: Partial<WorkerSourceModule> }) => {
+      if (typeof mod.default?.make !== "function") {
+        return Effect.fail(
+          new SourceProviderError({
+            provider: specifier,
+            message:
+              `Module "${specifier}" is not a Worker source provider: ` +
+              `its default export must satisfy WorkerSourceModule ({ make(options) }).`,
+          }),
+        );
+      }
+      return Effect.succeed(mod.default as WorkerSourceModule);
+    }),
+  );
+  // The underlying `import()` is memoized by the JS module registry;
+  // caching the composed effect just skips rebuilding it per resolution.
+  sourceModules.set(specifier, load);
+  return load;
+};
+
+/**
+ * Load an external source provider from its serializable descriptor:
+ * dynamically import the module, validate the shape, and call
+ * `make(options)`.
+ */
+export const loadSource = (
+  descriptor: WorkerSourceDescriptor,
+): Effect.Effect<SourceProvider, SourceProviderError, SourceServices> =>
+  importSourceModule(descriptor.provider).pipe(
+    Effect.flatMap((mod) => mod.make(descriptor.options)),
+  );
+
+/**
+ * Resolve the {@link SourceProvider} for a Worker from its props. The
+ * `source` descriptor (external providers) wins; legacy props map to the
+ * built-in providers, preserving the historical precedence exactly:
+ * `script` → `vite` → `.py` main → `bundle: false` → rolldown (default).
+ *
+ * `source` is mutually exclusive with `script`/`vite`/`main` — a source
+ * is self-contained, and a provider that needs a custom entry takes it
+ * in its own `options`.
+ */
+export const resolveSource = (
+  props: WorkerProps,
+): Effect.Effect<SourceProvider, SourceProviderError, SourceServices> => {
+  if (props.source) {
+    const conflict =
+      props.script !== undefined
+        ? "script"
+        : props.vite
+          ? "vite"
+          : props.main !== undefined
+            ? "main"
+            : undefined;
+    if (conflict) {
+      return Effect.fail(
+        new SourceProviderError({
+          provider: props.source.provider,
+          message:
+            `Worker prop "source" is mutually exclusive with "${conflict}": ` +
+            `a source provider is self-contained — pass a custom entry via the provider's own options instead.`,
+        }),
+      );
+    }
+    return loadSource(props.source);
+  }
   if (props.script !== undefined) {
-    return makeInlineScriptSource(props.script);
+    return Effect.succeed(makeInlineScriptSource(props.script));
   }
   if (props.vite) {
-    return makeViteSource(props.vite);
+    return Effect.succeed(makeViteSource(props.vite));
   }
   if (isPythonMain(props.main)) {
-    return makePythonSource(props.main);
+    return Effect.succeed(makePythonSource(props.main));
   }
   if (props.bundle === false) {
-    return makePrebuiltSource({ main: props.main!, rules: props.rules });
+    return Effect.succeed(
+      makePrebuiltSource({ main: props.main!, rules: props.rules }),
+    );
   }
-  return makeRolldownSource({ main: props.main! });
+  return Effect.succeed(makeRolldownSource({ main: props.main! }));
 };
 
 /**

--- a/packages/alchemy/src/Cloudflare/Workers/Sources/InlineScript.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Sources/InlineScript.ts
@@ -1,0 +1,56 @@
+import * as Effect from "effect/Effect";
+import * as Stream from "effect/Stream";
+import * as crypto from "node:crypto";
+import type * as Bundle from "../../../Bundle/Bundle.ts";
+import type { SourceDevHandle, SourceProvider } from "../Source.ts";
+
+/**
+ * Source provider for `props.script` workers: the raw module source is
+ * uploaded as a single ESM module (`main.js`), bypassing bundling
+ * entirely. The bundle hash is `sha256(script)` — identical to the
+ * pre-SourceProvider `hashScript` slot, so persisted state diffs cleanly
+ * across the refactor.
+ */
+export const makeInlineScriptSource = (script: string): SourceProvider => {
+  const bundle = Effect.sync(() =>
+    crypto.createHash("sha256").update(script).digest("hex"),
+  ).pipe(
+    Effect.map(
+      (hash): Bundle.BundleOutput => ({
+        files: [{ path: "main.js", content: script, hash }],
+        hash,
+      }),
+    ),
+  );
+  return {
+    ownsAssets: false,
+    build: () =>
+      bundle.pipe(
+        Effect.map((output) => ({
+          bundle: output,
+          assets: undefined,
+          hash: {
+            bundle: output.hash,
+            assets: undefined,
+            input: undefined,
+            additionalWorkspaces: undefined,
+          },
+        })),
+      ),
+    hash: () => bundle.pipe(Effect.map((output) => ({ bundle: output.hash }))),
+    // Local dev: a single-element stream — script changes arrive as new
+    // props, which restart the instance via `structuralSignature`.
+    dev: () =>
+      bundle.pipe(
+        Effect.map(
+          (output): SourceDevHandle => ({
+            mode: "bundle",
+            bundles: Stream.make({
+              _tag: "Success",
+              output,
+            } as Bundle.BundleWatchEvent),
+          }),
+        ),
+      ),
+  };
+};

--- a/packages/alchemy/src/Cloudflare/Workers/Sources/Prebuilt.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Sources/Prebuilt.ts
@@ -1,0 +1,54 @@
+import * as Effect from "effect/Effect";
+import * as Artifacts from "../../../Artifacts.ts";
+import type { SourceDevHandle, SourceProvider } from "../Source.ts";
+import {
+  readPrebuiltWorkerBundle,
+  watchPrebuiltWorkerBundle,
+  type ModuleRule,
+} from "../WorkerBundle.ts";
+
+/**
+ * Source provider for prebuilt workers (`bundle: false`): the entry and
+ * every file matching the module rules are uploaded byte-for-byte — no
+ * bundling, no minification. `hash()` is a cheap re-read (IO + sha256,
+ * no bundling), cached per run under the shared `"build"` artifact key.
+ *
+ * Local dev honors the same byte-for-byte contract: the entry directory
+ * is fs-watched and re-read on change — never re-bundled with rolldown,
+ * which would violate the prebuilt contract ("re-bundling such artifacts
+ * is unsafe").
+ */
+export const makePrebuiltSource = (options: {
+  main: string;
+  rules: ModuleRule[] | undefined;
+}): SourceProvider => {
+  const build = readPrebuiltWorkerBundle({
+    main: options.main,
+    rules: options.rules,
+  }).pipe(Artifacts.cached("build"));
+  return {
+    ownsAssets: false,
+    build: () =>
+      build.pipe(
+        Effect.map((output) => ({
+          bundle: output,
+          assets: undefined,
+          hash: {
+            bundle: output.hash,
+            assets: undefined,
+            input: undefined,
+            additionalWorkspaces: undefined,
+          },
+        })),
+      ),
+    hash: () => build.pipe(Effect.map((output) => ({ bundle: output.hash }))),
+    dev: () =>
+      Effect.succeed({
+        mode: "bundle",
+        bundles: watchPrebuiltWorkerBundle({
+          main: options.main,
+          rules: options.rules,
+        }),
+      } satisfies SourceDevHandle),
+  };
+};

--- a/packages/alchemy/src/Cloudflare/Workers/Sources/Python.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Sources/Python.ts
@@ -1,0 +1,50 @@
+import * as Effect from "effect/Effect";
+import * as Artifacts from "../../../Artifacts.ts";
+import {
+  readPythonWorkerBundle,
+  watchPythonWorkerBundle,
+} from "../PythonWorkerBundle.ts";
+import type {
+  SourceContext,
+  SourceDevHandle,
+  SourceProvider,
+} from "../Source.ts";
+
+/**
+ * Source provider for Python workers (`.py` entry): no bundling — the
+ * entry plus sibling `.py` files upload as Python modules with
+ * dependencies vendored via uv. The read is cached per run under the
+ * shared `"build"` artifact key so diff and reconcile vendor once.
+ */
+export const makePythonSource = (main: string): SourceProvider => {
+  const pythonOptions = (ctx: SourceContext) => ({
+    id: ctx.id,
+    main,
+    compatibility: ctx.compatibility,
+  });
+  const build = (ctx: SourceContext) =>
+    readPythonWorkerBundle(pythonOptions(ctx)).pipe(Artifacts.cached("build"));
+  return {
+    ownsAssets: false,
+    build: (ctx) =>
+      build(ctx).pipe(
+        Effect.map((output) => ({
+          bundle: output,
+          assets: undefined,
+          hash: {
+            bundle: output.hash,
+            assets: undefined,
+            input: undefined,
+            additionalWorkspaces: undefined,
+          },
+        })),
+      ),
+    hash: (ctx) =>
+      build(ctx).pipe(Effect.map((output) => ({ bundle: output.hash }))),
+    dev: (ctx) =>
+      Effect.succeed({
+        mode: "bundle",
+        bundles: watchPythonWorkerBundle(pythonOptions(ctx)),
+      } satisfies SourceDevHandle),
+  };
+};

--- a/packages/alchemy/src/Cloudflare/Workers/Sources/Rolldown.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Sources/Rolldown.ts
@@ -1,0 +1,61 @@
+import * as Effect from "effect/Effect";
+import * as Artifacts from "../../../Artifacts.ts";
+import type {
+  SourceContext,
+  SourceDevHandle,
+  SourceProvider,
+} from "../Source.ts";
+import { WorkerBundle, type WorkerBundleOptions } from "../WorkerBundle.ts";
+
+/**
+ * The default source provider: bundle `props.main` with rolldown.
+ *
+ * `hash()` deliberately builds — recomputing "without building" is
+ * impossible for rolldown without a source-tree memo hash, and today's
+ * semantics accept that. The build routes through `Artifacts.cached`
+ * under the same key as `build()`, so a diff that had to build shares
+ * its output with the reconcile in the same run.
+ */
+export const makeRolldownSource = (options: {
+  main: string;
+}): SourceProvider => {
+  const bundleOptions = (ctx: SourceContext): WorkerBundleOptions => ({
+    id: ctx.id,
+    main: options.main,
+    compatibility: ctx.compatibility,
+    entry: ctx.entry,
+    stack: ctx.stack,
+    extraOptions: ctx.extraOptions,
+  });
+  const build = (ctx: SourceContext) =>
+    Effect.gen(function* () {
+      const bundler = yield* WorkerBundle;
+      return yield* bundler.build(bundleOptions(ctx));
+    }).pipe(Artifacts.cached("build"));
+  return {
+    ownsAssets: false,
+    build: (ctx) =>
+      build(ctx).pipe(
+        Effect.map((output) => ({
+          bundle: output,
+          assets: undefined,
+          hash: {
+            bundle: output.hash,
+            assets: undefined,
+            input: undefined,
+            additionalWorkspaces: undefined,
+          },
+        })),
+      ),
+    hash: (ctx) =>
+      build(ctx).pipe(Effect.map((output) => ({ bundle: output.hash }))),
+    dev: (ctx) =>
+      Effect.gen(function* () {
+        const bundler = yield* WorkerBundle;
+        return {
+          mode: "bundle",
+          bundles: bundler.watch(bundleOptions(ctx)),
+        } satisfies SourceDevHandle;
+      }),
+  };
+};

--- a/packages/alchemy/src/Cloudflare/Workers/Sources/Vite.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Sources/Vite.ts
@@ -1,0 +1,192 @@
+import * as Effect from "effect/Effect";
+import * as Path from "effect/Path";
+import * as Redacted from "effect/Redacted";
+import { hashDirectory, type MemoOptions } from "../../../Command/Memo.ts";
+import { sha256Object } from "../../../Util/sha256.ts";
+import { readAssets } from "../Assets.ts";
+import type { SourceDevHandle, SourceProvider } from "../Source.ts";
+import type { ViteOptions } from "../Worker.ts";
+import { isWorkerLoader } from "../WorkerLoader.ts";
+
+/**
+ * Resolve `props.env` to the literal values vite's `import.meta.env`
+ * defines are computed from: strings pass through, `Redacted<string>`s
+ * are unwrapped, env-bound Effects are evaluated, and `WorkerLoader`s
+ * (bindings that happen to be Effects) are skipped.
+ */
+const resolveViteEnv = (env: Record<string, unknown>) =>
+  Effect.gen(function* () {
+    return Object.fromEntries(
+      (yield* Effect.all(
+        Object.entries(env).map(
+          Effect.fn(function* ([key, value]) {
+            return [
+              key,
+              typeof value === "string"
+                ? value
+                : Redacted.isRedacted(value) &&
+                    typeof Redacted.value(value) === "string"
+                  ? Redacted.value(value)
+                  : // A `WorkerLoader` is a real Effect that also carries
+                    // the `~alchemy/Kind` marker — it is a binding, not a
+                    // runnable env value. Check it before `Effect.isEffect`
+                    // so we don't execute it as an inlined env entry.
+                    isWorkerLoader(value)
+                    ? undefined
+                    : Effect.isEffect(value)
+                      ? yield* value as any as Effect.Effect<any>
+                      : undefined,
+            ];
+          }),
+        ),
+      )).filter(([_, value]) => value !== undefined),
+    );
+  });
+
+/**
+ * Hash the vite project's input tree (root + workspaces + lockfiles) —
+ * the rebuild-free change signal for the `input` hash slot.
+ */
+export const hashViteInput = Effect.fn(function* <E, R>(
+  rootDir: string = process.cwd(),
+  options: ViteOptions["memo"],
+  additionalWorkspaces: Effect.Effect<Iterable<string>, E, R>,
+) {
+  const path = yield* Path.Path;
+  const hashWorkspaceDirectory = (cwd: string, memo?: MemoOptions) =>
+    hashDirectory({ cwd: path.resolve(rootDir, cwd), memo }).pipe(
+      Effect.map((hash) => `${path.relative(rootDir, cwd)}:${hash}`),
+    );
+  const hashRoot = hashWorkspaceDirectory(rootDir, options);
+  if (Array.isArray(options?.workspaces)) {
+    return yield* Effect.all(
+      [
+        hashRoot,
+        ...options.workspaces.map(({ cwd, ...options }) =>
+          hashWorkspaceDirectory(cwd, options),
+        ),
+      ],
+      { concurrency: "unbounded" },
+    ).pipe(
+      Effect.flatMap(([root, ...workspaces]) =>
+        sha256Object([root, ...workspaces.sort()]),
+      ),
+      Effect.map((hash) => ({ hash, workspaces: undefined })),
+    );
+  }
+  const [root, workspaces] = yield* Effect.all(
+    [hashRoot, additionalWorkspaces],
+    { concurrency: "unbounded" },
+  );
+  const workspaceHashes = yield* Effect.forEach(
+    workspaces,
+    (cwd) => hashWorkspaceDirectory(cwd),
+    { concurrency: "unbounded" },
+  );
+  const hash = yield* sha256Object([root, ...workspaceHashes.sort()]);
+  return {
+    hash,
+    workspaces: Array.from(workspaces).map((cwd) =>
+      path.relative(rootDir, cwd),
+    ),
+  };
+});
+
+/**
+ * Source provider for vite-based workers (`props.vite`, set by
+ * `Website.Vite`): the vite builder produces the client assets and the
+ * server bundle in one pass; diff never builds — the `input` hash over
+ * the project tree is the change signal.
+ *
+ * The heavy `../Vite.ts` module (which pulls in
+ * `@distilled.cloud/cloudflare-vite-plugin`, ~0.5s) is loaded lazily
+ * inside `build()`/`dev()` so its module cost stays off the hot path.
+ */
+export const makeViteSource = (vite: ViteOptions): SourceProvider => ({
+  ownsAssets: true,
+  build: Effect.fn(function* (ctx) {
+    const path = yield* Path.Path;
+    // Loaded lazily: `../Vite.ts` pulls in `@distilled.cloud/cloudflare-vite-plugin`
+    // (~0.5s), which is only needed for vite-based workers at build time —
+    // not for every Worker definition at module-load time.
+    const Vite = yield* Effect.promise(() => import("../Vite.ts"));
+    const env = yield* resolveViteEnv(ctx.env ?? {});
+    const { clientDirectory, serverBundle, externalWorkspaces } =
+      yield* Vite.viteBuild(vite.rootDir, env, {
+        main: vite.main,
+        compatibilityDate: ctx.compatibility.date,
+        compatibilityFlags: ctx.compatibility.flags,
+        viteEnvironments: vite.viteEnvironments,
+      });
+    const [assets, bundle, input] = yield* Effect.all(
+      [
+        clientDirectory
+          ? readAssets({
+              ...(ctx.assets && typeof ctx.assets !== "string"
+                ? ctx.assets
+                : undefined),
+              directory: path.resolve(
+                vite.rootDir ?? process.cwd(),
+                clientDirectory,
+              ),
+            })
+          : Effect.undefined,
+        serverBundle,
+        hashViteInput(vite.rootDir, vite.memo, externalWorkspaces),
+      ],
+      { concurrency: "unbounded" },
+    );
+    if (!assets && !bundle) {
+      return yield* Effect.die(
+        new Error("Vite build produced neither assets nor server output"),
+      );
+    }
+    return {
+      bundle,
+      assets,
+      hash: {
+        bundle: bundle?.hash,
+        assets: assets?.hash,
+        input: input.hash,
+        additionalWorkspaces: input.workspaces,
+      },
+    };
+  }),
+  hash: Effect.fn(function* (_ctx, previous) {
+    const { hash, workspaces } = yield* hashViteInput(
+      vite.rootDir,
+      vite.memo,
+      Effect.succeed(previous?.additionalWorkspaces ?? []),
+    );
+    return { input: hash, additionalWorkspaces: workspaces };
+  }),
+  dev: Effect.fn(function* (ctx) {
+    // Loaded lazily: `../Vite.ts` pulls in `@distilled.cloud/cloudflare-vite-plugin`
+    // (~0.5s); only needed when running a vite dev server.
+    const Vite = yield* Effect.promise(() => import("../Vite.ts"));
+    const devServer = yield* Vite.viteDev(
+      vite.rootDir,
+      ctx.env ?? {},
+      {
+        main: vite.main,
+        compatibilityDate: ctx.compatibility.date,
+        compatibilityFlags: ctx.compatibility.flags,
+        viteEnvironments: vite.viteEnvironments,
+        worker: {
+          name: ctx.worker.name,
+          bindings: ctx.worker.bindings,
+          durableObjectNamespaces: ctx.worker.durableObjectNamespaces,
+          hyperdrives: ctx.worker.hyperdrives,
+          queueConsumers: yield* ctx.worker.queueConsumers,
+          assets: ctx.worker.assets,
+        },
+        context: ctx.runtimeContext,
+      },
+      { port: 0 },
+    );
+    return {
+      mode: "server",
+      url: new URL(devServer.resolvedUrls!.local[0]),
+    } satisfies SourceDevHandle;
+  }),
+});

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -368,6 +368,22 @@ export interface WorkerProps<
   };
   /** @internal used by Cloudflare.Website.Vite resource */
   vite?: ViteOptions;
+  /**
+   * An external source provider for this Worker — a package that builds
+   * the assets and server bundle (and serves local dev) in place of the
+   * built-in bundling pipeline. Used by framework integrations
+   * (Next/OpenNext, Astro, SvelteKit, Waku); most users configure it
+   * through the framework's `Website.*` wrapper rather than directly.
+   *
+   * The named package must be installed in your project — it is loaded
+   * with a dynamic `import()` and its default export must satisfy the
+   * `WorkerSourceModule` contract (`{ make(options) }`).
+   *
+   * Mutually exclusive with {@link script}, {@link vite}, and
+   * {@link main} — a source is self-contained; a provider that needs a
+   * custom entry takes it in its own `options`.
+   */
+  source?: WorkerSourceDescriptor;
   logpush?: boolean;
   /**
    * Cloudflare Workers Observability settings. Controls Workers Logs
@@ -559,6 +575,28 @@ export interface WorkerProps<
          */
         url?: string;
       };
+}
+
+/**
+ * A serializable reference to an external Worker source provider.
+ * Persists in state (`olds`) and crosses the local-provider RPC
+ * boundary, so it must stay plain JSON data — the implementation is
+ * resolved by dynamically importing {@link provider}.
+ */
+export interface WorkerSourceDescriptor {
+  /**
+   * Module specifier resolved with `import()`, e.g.
+   * `"@alchemy.run/cloudflare-next"`. The module's default export must
+   * satisfy the `WorkerSourceModule` contract.
+   */
+  readonly provider: string;
+  /**
+   * Provider-specific options (rootDir, memo, framework config, ...).
+   * Must be JSON-serializable AND JSON-stable: the descriptor persists
+   * in state and participates in the metadata hash, so non-deterministic
+   * values here cause perpetual redeploys.
+   */
+  readonly options?: unknown;
 }
 
 export interface ViteOptions {

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerBundle.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerBundle.ts
@@ -315,3 +315,47 @@ export const readPrebuiltWorkerBundle = Effect.fn(function* (
     Effect.flatMap(Bundle.bundleOutputFromFiles),
   );
 });
+
+/**
+ * Watch a prebuilt Worker (`bundle: false`) for changes: emits the
+ * initial byte-for-byte read, then re-reads whenever a file under the
+ * entry's directory changes (debounced). Mirrors the
+ * {@link Bundle.BundleWatchEvent} protocol of the rolldown watcher so
+ * local dev can consume either stream interchangeably — crucially
+ * WITHOUT re-bundling the prebuilt artifact, preserving the same
+ * byte-for-byte contract as the deploy path.
+ */
+export const watchPrebuiltWorkerBundle = (
+  options: PrebuiltWorkerBundleOptions,
+) =>
+  Stream.unwrap(
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const main = yield* Effect.sync(() => {
+        try {
+          return fileURLToPath(options.main);
+        } catch {
+          return options.main;
+        }
+      }).pipe(Effect.map((p) => path.resolve(p)));
+      const root = path.dirname(main);
+      const read = readPrebuiltWorkerBundle(options).pipe(
+        Effect.map(
+          (output): Bundle.BundleWatchEvent => ({ _tag: "Success", output }),
+        ),
+        Effect.catch((error) =>
+          Effect.succeed<Bundle.BundleWatchEvent>({ _tag: "Error", error }),
+        ),
+      );
+      const rebuilds = fs.watch(root).pipe(
+        Stream.debounce("200 millis"),
+        Stream.flatMap(() =>
+          Stream.make({ _tag: "Start" } as Bundle.BundleWatchEvent).pipe(
+            Stream.concat(Stream.fromEffect(read)),
+          ),
+        ),
+        Stream.catchCause(() => Stream.empty),
+      );
+      return Stream.fromEffect(read).pipe(Stream.concat(rebuilds));
+    }),
+  );

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -4,16 +4,12 @@ import * as wfp from "@distilled.cloud/cloudflare/workers-for-platforms";
 import * as zones from "@distilled.cloud/cloudflare/zones";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
-import * as Path from "effect/Path";
 import * as Predicate from "effect/Predicate";
 import * as Redacted from "effect/Redacted";
 import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
-import * as crypto from "node:crypto";
 import { Unowned } from "../../AdoptPolicy.ts";
-import * as Artifacts from "../../Artifacts.ts";
 import type { ScopedPlanStatusSession } from "../../Cli/Cli.ts";
-import { hashDirectory, type MemoOptions } from "../../Command/Memo.ts";
 import { isResolved } from "../../Diff.ts";
 import * as ProviderLayer from "../../Local/ProviderLayer.ts";
 import * as Provider from "../../Provider.ts";
@@ -27,17 +23,10 @@ import { readAssets, uploadAssets } from "./Assets.ts";
 import { getCompatibility } from "./Compatibility.ts";
 import { isDurableObjectExport } from "./DurableObject.ts";
 import { LocalWorkerProvider } from "./LocalWorkerProvider.ts";
-import {
-  Worker,
-  type ViteOptions,
-  type WorkerProps,
-  type WorkerRouteConfig,
-} from "./Worker.ts";
+import { makeSourceContext, resolveSource } from "./Source.ts";
+import { Worker, type WorkerProps, type WorkerRouteConfig } from "./Worker.ts";
 import { getCacheBinding, getCronBindings } from "./WorkerAsyncBindings.ts";
 import type { WorkerBinding, WorkerSettingsBinding } from "./WorkerBinding.ts";
-import { isPythonMain, readPythonWorkerBundle } from "./PythonWorkerBundle.ts";
-import { readPrebuiltWorkerBundle, WorkerBundle } from "./WorkerBundle.ts";
-import { isWorkerLoader } from "./WorkerLoader.ts";
 import { createWorkerName } from "./WorkerName.ts";
 class MissingDurableObjects extends Data.TaggedError("MissingDurableObjects")<{
   scriptName: string;
@@ -435,9 +424,6 @@ export const LiveWorkerProvider = () =>
   Provider.effect(
     Worker,
     Effect.gen(function* () {
-      const path = yield* Path.Path;
-
-      const bundler = yield* WorkerBundle;
       const stack = yield* Stack;
 
       // const createScriptSubdomain = yield* workers.createScriptSubdomain;
@@ -1136,206 +1122,44 @@ export const LiveWorkerProvider = () =>
         );
       });
 
-      const prepareBundle = (id: string, props: WorkerProps) =>
-        (isPythonMain(props.main)
-          ? readPythonWorkerBundle({
-              id,
-              main: props.main,
-              compatibility: getCompatibility(props),
-            })
-          : props.bundle === false
-            ? readPrebuiltWorkerBundle({
-                main: props.main!,
-                rules: props.rules,
-              })
-            : bundler.build({
-                id,
-                main: props.main!,
-                compatibility: getCompatibility(props),
-                entry: props.isExternal
-                  ? {
-                      kind: "external",
-                    }
-                  : {
-                      kind: "effect",
-                      exports: props.exports ?? {},
-                    },
-                stack: { name: stack.name, stage: stack.stage },
-                extraOptions: props.build,
-              })
-        ).pipe(Artifacts.cached("build"));
-
-      const hashScript = (script: string) =>
-        Effect.sync(() =>
-          crypto.createHash("sha256").update(script).digest("hex"),
-        );
-
-      const viteBuild = Effect.fn(function* (props: WorkerProps) {
-        const compatibility = getCompatibility(props);
-        // Loaded lazily: `./Vite.ts` pulls in `@distilled.cloud/cloudflare-vite-plugin`
-        // (~0.5s), which is only needed for vite-based workers at build time —
-        // not for every Worker definition at module-load time.
-        const Vite = yield* Effect.promise(() => import("./Vite.ts"));
-        const { clientDirectory, serverBundle, externalWorkspaces } =
-          yield* Vite.viteBuild(
-            props.vite?.rootDir,
-            Object.fromEntries(
-              (yield* Effect.all(
-                Object.entries(props.env ?? {}).map(
-                  Effect.fn(function* ([key, value]) {
-                    return [
-                      key,
-                      typeof value === "string"
-                        ? value
-                        : Redacted.isRedacted(value) &&
-                            typeof Redacted.value(value) === "string"
-                          ? Redacted.value(value)
-                          : // A `WorkerLoader` is a real Effect that also carries
-                            // the `~alchemy/Kind` marker — it is a binding, not a
-                            // runnable env value. Check it before `Effect.isEffect`
-                            // so we don't execute it as an inlined env entry.
-                            isWorkerLoader(value)
-                            ? undefined
-                            : Effect.isEffect(value)
-                              ? yield* value as any as Effect.Effect<any>
-                              : undefined,
-                    ];
-                  }),
-                ),
-              )).filter(([_, value]) => value !== undefined),
-            ),
-            {
-              main: props.vite?.main,
-              compatibilityDate: compatibility.date,
-              compatibilityFlags: compatibility.flags,
-              viteEnvironments: props.vite?.viteEnvironments,
-            },
-          );
-        const [assets, bundle, input] = yield* Effect.all(
-          [
-            clientDirectory
-              ? readAssets({
-                  ...(props.assets && typeof props.assets !== "string"
-                    ? props.assets
-                    : undefined),
-                  directory: path.resolve(
-                    props.vite?.rootDir ?? process.cwd(),
-                    clientDirectory,
-                  ),
-                })
-              : Effect.undefined,
-            serverBundle,
-            hashViteInput(
-              props.vite?.rootDir,
-              props.vite?.memo,
-              externalWorkspaces,
-            ),
-          ],
-          { concurrency: "unbounded" },
-        );
-        if (!assets && !bundle) {
-          return yield* Effect.die(
-            new Error("Vite build produced neither assets nor server output"),
-          );
-        }
-        return {
-          assets,
-          bundle,
-          input: input.hash,
-          additionalWorkspaces: input.workspaces,
-        };
-      });
-
-      const hashViteInput = Effect.fn(function* <E>(
-        rootDir: string = process.cwd(),
-        options: ViteOptions["memo"],
-        additionalWorkspaces: Effect.Effect<Iterable<string>, E>,
-      ) {
-        const hashWorkspaceDirectory = (cwd: string, memo?: MemoOptions) =>
-          hashDirectory({ cwd: path.resolve(rootDir, cwd), memo }).pipe(
-            Effect.map((hash) => `${path.relative(rootDir, cwd)}:${hash}`),
-          );
-        const hashRoot = hashWorkspaceDirectory(rootDir, options);
-        if (Array.isArray(options?.workspaces)) {
-          return yield* Effect.all(
-            [
-              hashRoot,
-              ...options.workspaces.map(({ cwd, ...options }) =>
-                hashWorkspaceDirectory(cwd, options),
-              ),
-            ],
-            { concurrency: "unbounded" },
-          ).pipe(
-            Effect.flatMap(([root, ...workspaces]) =>
-              sha256Object([root, ...workspaces.sort()]),
-            ),
-            Effect.map((hash) => ({ hash, workspaces: undefined })),
-          );
-        }
-        const [root, workspaces] = yield* Effect.all(
-          [hashRoot, additionalWorkspaces],
-          { concurrency: "unbounded" },
-        );
-        const workspaceHashes = yield* Effect.forEach(
-          workspaces,
-          (cwd) => hashWorkspaceDirectory(cwd),
-          { concurrency: "unbounded" },
-        );
-        const hash = yield* sha256Object([root, ...workspaceHashes.sort()]);
-        return {
-          hash,
-          workspaces: Array.from(workspaces).map((cwd) =>
-            path.relative(rootDir, cwd),
-          ),
-        };
-      });
+      const makeWorkerSourceContext = (
+        id: string,
+        workerName: string,
+        props: WorkerProps,
+      ) =>
+        makeSourceContext({
+          id,
+          workerName,
+          props,
+          compatibility: getCompatibility(props),
+          stack: { name: stack.name, stage: stack.stage },
+        });
 
       const prepareAssetsAndBundle = (
         id: string,
+        workerName: string,
         props: WorkerProps,
         opts: { skipAssetsRead?: boolean } = {},
       ) =>
         Effect.gen(function* () {
-          if (props.script !== undefined) {
-            const [assets, bundleHash] = yield* Effect.all(
-              [
-                opts.skipAssetsRead
-                  ? Effect.succeed(undefined)
-                  : prepareAssets(props.assets),
-                hashScript(props.script),
-              ],
-              { concurrency: "unbounded" },
-            );
-            return {
-              assets,
-              bundle: {
-                files: [{ path: "main.js", content: props.script }],
-                hash: bundleHash,
-              },
-              input: undefined,
-              additionalWorkspaces: undefined,
-            };
-          }
-          if (props.vite) {
-            return yield* viteBuild(props);
-          }
-          const [assets, bundle] = yield* Effect.all(
+          const source = resolveSource(props);
+          const ctx = makeWorkerSourceContext(id, workerName, props);
+          // Sources that own their assets (vite) produce them from the
+          // build; for every other source the props-level `assets`
+          // directory is read here — skipped entirely when putWorker's
+          // AssetsWithHash fast path already decided nothing changed.
+          const [output, propsAssets] = yield* Effect.all(
             [
-              opts.skipAssetsRead
-                ? Effect.succeed(undefined)
+              source.build(ctx),
+              source.ownsAssets || opts.skipAssetsRead
+                ? Effect.undefined
                 : prepareAssets(props.assets),
-              prepareBundle(id, props),
             ],
             { concurrency: "unbounded" },
           );
+          const assets = output.assets ?? propsAssets;
+          const bundle = output.bundle;
           return {
-            assets,
-            bundle,
-            input: undefined,
-            additionalWorkspaces: undefined,
-          };
-        }).pipe(
-          Effect.map(({ assets, bundle, input, additionalWorkspaces }) => ({
             assets,
             bundle: {
               main: bundle?.files[0].path,
@@ -1349,11 +1173,11 @@ export const LiveWorkerProvider = () =>
             hash: {
               assets: assets?.hash,
               bundle: bundle?.hash,
-              input,
-              additionalWorkspaces,
+              input: output.hash.input,
+              additionalWorkspaces: output.hash.additionalWorkspaces,
             } satisfies Worker["Attributes"]["hash"],
-          })),
-        );
+          };
+        });
 
       const normalizePrebuiltAssets = (
         assets: WorkerProps["assets"],
@@ -1396,7 +1220,7 @@ export const LiveWorkerProvider = () =>
           assets,
           bundle,
           hash: preparedHash,
-        } = yield* prepareAssetsAndBundle(id, news, {
+        } = yield* prepareAssetsAndBundle(id, name, news, {
           skipAssetsRead: prebuiltAssets?.skip,
         });
         // When the caller supplied a precomputed hash (e.g. via
@@ -2048,6 +1872,7 @@ export const LiveWorkerProvider = () =>
 
       const hasChanged = Effect.fn(function* (
         id: string,
+        workerName: string,
         props: WorkerProps,
         output: Worker["Attributes"],
         bindings: readonly ResourceBinding<Worker["Binding"]>[] | undefined,
@@ -2070,35 +1895,33 @@ export const LiveWorkerProvider = () =>
             return true;
           }
         }
-        if (props.script !== undefined) {
-          const scriptHash = yield* hashScript(props.script);
-          if (scriptHash !== output.hash?.bundle) {
-            return true;
-          }
-          if (!props.assets) {
-            return false;
-          }
-          const assetsHash = Predicate.hasProperty(props.assets, "hash")
-            ? props.assets.hash
-            : undefined;
-          if (assetsHash === undefined) {
-            return true;
-          }
-          return assetsHash !== output.hash?.assets;
-        }
-        if (props.vite) {
-          const { hash } = yield* hashViteInput(
-            props.vite.rootDir,
-            props.vite.memo,
-            Effect.succeed(output.hash?.additionalWorkspaces ?? []),
-          );
-          return hash !== output.hash?.input;
-        }
-        const bundleHash = yield* prepareBundle(id, props).pipe(
-          Effect.map((b) => b.hash),
+        // Source diff: the source recomputes the hash slots it owns
+        // (without building where it can) and any defined slot that
+        // differs from state means an update. `additionalWorkspaces` is
+        // auxiliary metadata for the input hash, never a change signal.
+        const source = resolveSource(props);
+        const slots = yield* source.hash(
+          makeWorkerSourceContext(id, workerName, props),
+          output.hash,
         );
-        if (bundleHash !== output.hash?.bundle) {
+        if (
+          slots.bundle !== undefined &&
+          slots.bundle !== output.hash?.bundle
+        ) {
           return true;
+        }
+        if (slots.input !== undefined && slots.input !== output.hash?.input) {
+          return true;
+        }
+        if (
+          slots.assets !== undefined &&
+          slots.assets !== output.hash?.assets
+        ) {
+          return true;
+        }
+        if (source.ownsAssets) {
+          // Source-owned assets (vite) are covered by the `input` hash.
+          return false;
         }
         if (!props.assets) {
           return false;
@@ -2296,6 +2119,7 @@ export const LiveWorkerProvider = () =>
             cronsChanged ||
             (yield* hasChanged(
               id,
+              workerName,
               news,
               output,
               Array.isArray(newBindings)

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -409,6 +409,10 @@ const resolveWorkerMetadataHash = ({
     logpush: props.logpush,
     observability: props.observability,
     placement: props.placement,
+    // The source descriptor is plain JSON data; hashing it means
+    // switching providers (or changing provider options) triggers an
+    // update even when no hash slot the new source computes differs.
+    source: props.source,
     subdomain: props.subdomain,
     tags: props.tags,
     url: props.url,
@@ -1142,7 +1146,7 @@ export const LiveWorkerProvider = () =>
         opts: { skipAssetsRead?: boolean } = {},
       ) =>
         Effect.gen(function* () {
-          const source = resolveSource(props);
+          const source = yield* resolveSource(props);
           const ctx = makeWorkerSourceContext(id, workerName, props);
           // Sources that own their assets (vite) produce them from the
           // build; for every other source the props-level `assets`
@@ -1899,7 +1903,7 @@ export const LiveWorkerProvider = () =>
         // (without building where it can) and any defined slot that
         // differs from state means an update. `additionalWorkspaces` is
         // auxiliary metadata for the input hash, never a change signal.
-        const source = resolveSource(props);
+        const source = yield* resolveSource(props);
         const slots = yield* source.hash(
           makeWorkerSourceContext(id, workerName, props),
           output.hash,

--- a/packages/alchemy/src/Cloudflare/Workers/index.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/index.ts
@@ -26,6 +26,7 @@ export * from "./Rpc.ts";
 export * from "./RpcDurableObject.ts";
 export * from "./RpcWorker.ts";
 export * from "./ScheduledEvents.ts";
+export * from "./Source.ts";
 export * from "./Subdomain.ts";
 export * from "./VersionMetadata.ts";
 export * from "./VersionMetadataBinding.ts";

--- a/packages/alchemy/test/Cloudflare/Workers/PrebuiltWorkerLocal.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/PrebuiltWorkerLocal.test.ts
@@ -1,0 +1,62 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Test from "@/Test/Alchemy";
+import { expect } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+import * as pathe from "pathe";
+import { expectUrlContains } from "../Utils/Http.ts";
+
+const { test } = Test.make({
+  providers: Cloudflare.providers(),
+  dev: true,
+});
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+const main = pathe.resolve(import.meta.dirname, "fixtures/prebuilt/worker.mjs");
+
+// `dev: true` selects the local provider. A `bundle: false` Worker must be
+// served byte-for-byte in local dev exactly like the deploy path: the entry
+// plus its rule-matched siblings (nested ES modules AND the nested text
+// module) are handed to workerd as-is.
+//
+// Regression: the local provider used to run every non-Python `main`
+// through the rolldown watcher, re-bundling the prebuilt artifact. That
+// broke the byte-for-byte contract outright — this fixture's `.txt` module
+// import isn't even bundleable — so local dev of `bundle: false` workers
+// failed while deploy worked. The prebuilt source now fs-watches and
+// re-reads the module graph instead of bundling.
+test.provider(
+  "serves a prebuilt (bundle: false) Worker byte-for-byte from local workerd",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const worker = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.Worker("PrebuiltLocalWorker", {
+            main,
+            bundle: false,
+            compatibility: {
+              date: "2024-01-01",
+            },
+          });
+        }),
+      );
+
+      expect(worker.url).toBeDefined();
+      // The response is assembled across both nested ES modules and the
+      // nested text module — it can only be produced when the full module
+      // graph reached workerd unbundled.
+      yield* expectUrlContains(
+        worker.url!,
+        "prebuilt-modules-survived alchemy-prebuilt-notice-4d2a!",
+      );
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 120_000 },
+);

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerSource.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerSource.test.ts
@@ -1,0 +1,155 @@
+import {
+  Artifacts,
+  createArtifactStore,
+  makeScopedArtifacts,
+} from "@/Artifacts.ts";
+import {
+  makeSourceContext,
+  resolveSource,
+  SourceProviderError,
+  type SourceContext,
+} from "@/Cloudflare/Workers/Source.ts";
+import type { WorkerProps } from "@/Cloudflare/Workers/Worker.ts";
+import { NodeServices } from "@effect/platform-node";
+import { describe, expect, it } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import * as crypto from "node:crypto";
+
+const providerModule = new URL(
+  "./fixtures/source-provider/provider.ts",
+  import.meta.url,
+).href;
+const invalidModule = new URL(
+  "./fixtures/source-provider/invalid.ts",
+  import.meta.url,
+).href;
+
+const ctx = (props: WorkerProps): SourceContext =>
+  makeSourceContext({
+    id: "TestWorker",
+    workerName: "stack-testworker-dev-abc123",
+    props,
+    compatibility: { date: "2024-01-01", flags: [] },
+    stack: { name: "stack", stage: "dev" },
+  });
+
+const provide = <A, E>(
+  effect: Effect.Effect<
+    A,
+    E,
+    Effect.Services<ReturnType<typeof resolveSource>> | Artifacts
+  >,
+) =>
+  effect.pipe(
+    Effect.provideService(
+      Artifacts,
+      makeScopedArtifacts(createArtifactStore(), "test"),
+    ),
+    Effect.provide(NodeServices.layer),
+    Effect.scoped,
+  );
+
+describe("resolveSource", () => {
+  it.effect("maps props.script to the inline-script source", () =>
+    provide(
+      Effect.gen(function* () {
+        const script = "export default { fetch: () => new Response('hi') };";
+        const props: WorkerProps = { script };
+        const source = yield* resolveSource(props);
+        expect(source.ownsAssets).toBe(false);
+        const slots = yield* source.hash(ctx(props), undefined);
+        expect(slots.bundle).toBe(
+          crypto.createHash("sha256").update(script).digest("hex"),
+        );
+        const out = yield* source.build(ctx(props));
+        expect(out.bundle?.files[0].path).toBe("main.js");
+        expect(out.bundle?.hash).toBe(slots.bundle);
+        expect(out.assets).toBeUndefined();
+      }),
+    ),
+  );
+
+  it.effect("maps props.vite to the asset-owning vite source", () =>
+    provide(
+      Effect.gen(function* () {
+        const source = yield* resolveSource({ vite: { rootDir: "." } });
+        expect(source.ownsAssets).toBe(true);
+      }),
+    ),
+  );
+
+  it.effect("loads an external provider from a source descriptor", () =>
+    provide(
+      Effect.gen(function* () {
+        const props: WorkerProps = {
+          source: { provider: providerModule, options: { marker: "abc-123" } },
+        };
+        const source = yield* resolveSource(props);
+        const out = yield* source.build(ctx(props));
+        expect(String(out.bundle?.files[0].content)).toContain("abc-123");
+        const slots = yield* source.hash(ctx(props), undefined);
+        expect(slots.bundle).toBe(out.bundle?.hash);
+      }),
+    ),
+  );
+
+  it.effect(
+    "fails with SourceProviderError naming the package when the module cannot be imported",
+    () =>
+      provide(
+        Effect.gen(function* () {
+          const result = yield* Effect.result(
+            resolveSource({
+              source: { provider: "@alchemy.run/does-not-exist-fixture" },
+            }),
+          );
+          expect(result._tag).toBe("Failure");
+          if (result._tag === "Failure") {
+            expect(result.failure).toBeInstanceOf(SourceProviderError);
+            expect((result.failure as SourceProviderError).message).toContain(
+              "@alchemy.run/does-not-exist-fixture",
+            );
+          }
+        }),
+      ),
+  );
+
+  it.effect(
+    "fails with SourceProviderError when the module's default export lacks make()",
+    () =>
+      provide(
+        Effect.gen(function* () {
+          const result = yield* Effect.result(
+            resolveSource({ source: { provider: invalidModule } }),
+          );
+          expect(result._tag).toBe("Failure");
+          if (result._tag === "Failure") {
+            expect(result.failure).toBeInstanceOf(SourceProviderError);
+            expect((result.failure as SourceProviderError).message).toContain(
+              "WorkerSourceModule",
+            );
+          }
+        }),
+      ),
+  );
+
+  it.effect("rejects source combined with main/script/vite", () =>
+    provide(
+      Effect.gen(function* () {
+        const result = yield* Effect.result(
+          resolveSource({
+            source: { provider: providerModule },
+            main: "./worker.ts",
+          }),
+        );
+        expect(result._tag).toBe("Failure");
+        if (result._tag === "Failure") {
+          expect(result.failure).toBeInstanceOf(SourceProviderError);
+          expect((result.failure as SourceProviderError).message).toContain(
+            '"main"',
+          );
+        }
+      }),
+    ),
+  );
+});

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/source-provider/invalid.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/source-provider/invalid.ts
@@ -1,0 +1,5 @@
+/**
+ * A module that is NOT a valid Worker source provider: its default
+ * export lacks `make`. Used to pin loadSource's shape validation.
+ */
+export default { notMake: true };

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/source-provider/provider.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/source-provider/provider.ts
@@ -1,0 +1,56 @@
+import type * as Bundle from "@/Bundle/Bundle.ts";
+import type {
+  SourceProvider,
+  WorkerSourceModule,
+} from "@/Cloudflare/Workers/Source.ts";
+import * as Effect from "effect/Effect";
+import * as Stream from "effect/Stream";
+import * as crypto from "node:crypto";
+
+/**
+ * Minimal external source-provider fixture for the loadSource unit
+ * tests: builds a one-module bundle whose content embeds the
+ * descriptor's `marker` option.
+ */
+const make: WorkerSourceModule["make"] = (options) =>
+  Effect.sync((): SourceProvider => {
+    const marker = (options as { marker?: string } | undefined)?.marker ?? "";
+    const content = `export default { fetch: () => new Response(${JSON.stringify(marker)}) };`;
+    const bundle = Effect.sync((): Bundle.BundleOutput => {
+      const hash = crypto.createHash("sha256").update(content).digest("hex");
+      return {
+        files: [{ path: "main.js", content, hash }],
+        hash,
+      };
+    });
+    return {
+      ownsAssets: false,
+      build: () =>
+        bundle.pipe(
+          Effect.map((output) => ({
+            bundle: output,
+            assets: undefined,
+            hash: {
+              bundle: output.hash,
+              assets: undefined,
+              input: undefined,
+              additionalWorkspaces: undefined,
+            },
+          })),
+        ),
+      hash: () =>
+        bundle.pipe(Effect.map((output) => ({ bundle: output.hash }))),
+      dev: () =>
+        bundle.pipe(
+          Effect.map((output) => ({
+            mode: "bundle" as const,
+            bundles: Stream.make({
+              _tag: "Success",
+              output,
+            } as Bundle.BundleWatchEvent),
+          })),
+        ),
+    };
+  });
+
+export default { make } satisfies WorkerSourceModule;


### PR DESCRIPTION
Replace the per-bundler `if/else` ladders in `WorkerProvider` (`prepareAssetsAndBundle`, `hasChanged`) and `LocalWorkerProvider` (`runVite` vs `runWorker`) with a uniform `SourceProvider` interface, implemented by the five existing arms and pluggable by framework packages (Next/Astro/SvelteKit/Waku). Implements `cloudflare-tools/research/source-provider-design.md`, steps 1–3.

```ts
export interface SourceProvider {
  readonly ownsAssets: boolean; // vite/frameworks: assets come out of the build
  readonly build: (ctx: SourceContext) => Effect<SourceBuildOutput, SourceError, SourceServices>;
  readonly hash: (ctx: SourceContext, previous: SourceHash | undefined) => Effect<Partial<SourceHash>, SourceError, SourceServices>;
  readonly dev: (ctx: DevContext) => Effect<SourceDevHandle, SourceError, SourceDevServices | Scope>;
}

// dev is either "host runs workerd, source streams bundles" or "source serves itself"
export type SourceDevHandle =
  | { mode: "bundle"; bundles: Stream<BundleWatchEvent, SourceError, SourceDevServices> }
  | { mode: "server"; url: URL };
```

- `resolveSource(props)` maps the legacy props to built-ins with the historical precedence (`script` → `vite` → `.py` → `bundle: false` → rolldown), so nothing changes for existing workers: same hash slots (`bundle`/`assets`/`input`/`additionalWorkspaces`), same `Artifacts.cached("build")` reuse across diff→reconcile, same AssetsWithHash/`keepAssets` fast path, #745 metadata hash untouched and still compared first.
- New `source` prop for external providers, resolved by dynamic `import()` (props stay serializable across state and the local-provider RPC boundary):

```ts
Worker("Site", {
  source: { provider: "@alchemy.run/cloudflare-next", options: { rootDir: "." } },
})
```

  `loadSource` validates the module's default export (`WorkerSourceModule`: `{ make(options) }`) and wraps failures in a typed `SourceProviderError` naming the package to install. The descriptor participates in the metadata hash, so switching providers or changing options always deploys.
- Fixes local dev of `bundle: false` workers: the local provider re-bundled prebuilt entries through rolldown, breaking the byte-for-byte contract the deploy path documents. `PrebuiltSource.dev` now fs-watches the entry directory and re-reads the module graph (`watchPrebuiltWorkerBundle`); pinned by `PrebuiltWorkerLocal.test.ts`.
- `props.script` workers now also work under `alchemy dev` (single-emit bundle stream; previously they fell into the rolldown watcher with `main: undefined`).

### Deviations from the design doc

- `SourceContext.env`/`assets` carry the raw props values instead of pre-resolved ones — resolving env Effects centrally would execute plan-phase-only Effects for non-vite arms; the vite source resolves them itself exactly as before.
- `ownsAssets` is a provider field (the doc implied it structurally); `skipAssetsRead` stays a `putWorker` concern instead of a ctx field, since props-assets reading never moved out of the WorkerProvider.
- `additionalWorkspaces` is explicitly documented as auxiliary (not compared as a change signal), matching today's diff exactly.
- `source` + `script`/`vite`/`main` mutual exclusion fails with `SourceProviderError` rather than `WorkerValidationError` (avoids a module cycle with `LocalWorkerProvider`).
