### PR TITLE
fix(cloudflare/workers): register esmExternalRequirePlugin in direct Worker bundler

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/WorkerBundle.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerBundle.ts
@@ -5,9 +5,11 @@ import { flow } from "effect/Function";
 import type * as Path from "effect/Path";
 import * as Stream from "effect/Stream";
 import fg from "fast-glob";
+import { builtinModules } from "node:module";
 import { fileURLToPath } from "node:url";
 import path from "pathe";
 import type * as rolldown from "rolldown";
+import { esmExternalRequirePlugin } from "rolldown/plugins";
 import * as Bundle from "../../Bundle/Bundle.ts";
 import { findCwdForBundle } from "../../Bundle/TempRoot.ts";
 import { sha256 } from "../../Util/sha256.ts";
@@ -19,6 +21,18 @@ import {
   isWorkflowExport,
   type WorkflowExport,
 } from "../Workflows/Workflow.ts";
+
+/**
+ * Node builtin specifiers in both bare (`events`) and prefixed
+ * (`node:events`) forms. Some entries (`node:sea`, `node:test`, bun's
+ * `bun:*`) only exist prefixed, so already-prefixed names are kept as-is.
+ */
+const nodeBuiltinModules = builtinModules.flatMap((name) =>
+  name.includes(":") ? [name] : [name, `node:${name}`],
+);
+
+const hasNodejsCompat = (flags: string[]) =>
+  flags.includes("nodejs_compat") || flags.includes("nodejs_compat_v2");
 
 export interface WorkerBundleOptions {
   id: string;
@@ -65,6 +79,24 @@ export const WorkerBundle = Effect.gen(function* () {
         Effect.provide(context),
       ),
       plugins: [
+        // Convert CommonJS `require("events")` etc. of Node builtins into
+        // ESM imports so deps like `pg` run under `nodejs_compat`.
+        // cloudflareRolldown registers this same converter from its own
+        // `options` hook, but rolldown recognizes builtin plugins by class
+        // identity (`instanceof BuiltinPlugin`) — when the package manager
+        // installs the plugin's rolldown as a separate copy from ours, that
+        // registration silently no-ops and the bundle keeps rolldown's
+        // throwing `require` fallback, failing Cloudflare startup
+        // validation (#880). Registering it here, from the same rolldown
+        // instance that runs the build, is identity-safe.
+        ...(hasNodejsCompat(options.compatibility.flags)
+          ? [
+              esmExternalRequirePlugin({
+                external: nodeBuiltinModules,
+                skipDuplicateCheck: true,
+              }),
+            ]
+          : []),
         cloudflareRolldown({
           compatibilityDate: options.compatibility.date,
           compatibilityFlags: options.compatibility.flags,

--- a/packages/alchemy/test/Cloudflare/Workers/NodeBuiltinRequire.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/NodeBuiltinRequire.test.ts
@@ -1,0 +1,60 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as Alchemy from "@/index.ts";
+import * as Test from "@/Test/Alchemy";
+import { expect } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import RequireNodeBuiltinsWorker from "./fixtures/require-node-builtins/worker.ts";
+
+const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
+  providers: Cloudflare.providers(),
+});
+
+const Stack = Alchemy.Stack(
+  "NodeBuiltinRequireTestStack",
+  { providers: Cloudflare.providers(), state: Cloudflare.state() },
+  Effect.gen(function* () {
+    const worker = yield* RequireNodeBuiltinsWorker;
+    return { url: worker.url.as<string>() };
+  }),
+);
+
+const stack = beforeAll(deploy(Stack));
+afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(Stack));
+
+// Regression test for #880: the deploy itself is the primary assertion —
+// a bundle that keeps rolldown's throwing `require` fallback for
+// `require("events")` fails Cloudflare startup validation at upload time
+// and `beforeAll(deploy(Stack))` fails the suite.
+test(
+  "worker with a CJS dep requiring node builtins deploys and serves",
+  Effect.gen(function* () {
+    const { url } = yield* stack;
+    const client = yield* HttpClient.HttpClient;
+
+    const get = client.get(`${url}/?value=pong`).pipe(
+      Effect.flatMap((res) => res.text),
+      Effect.retry({
+        schedule: Schedule.exponential("500 millis"),
+        times: 5,
+      }),
+      Effect.orDie,
+    );
+
+    // Fresh workers.dev URLs can serve placeholder 200s while propagating,
+    // so anchor the readiness poll on the fixture's marker, not the status.
+    const body = yield* get.pipe(
+      Effect.repeat({
+        schedule: Schedule.exponential("500 millis"),
+        until: (b) => b.includes("require-node-builtins:"),
+        times: 10,
+      }),
+    );
+
+    // The converted builtins really work at runtime: the EventEmitter
+    // round-tripped the request's value and util.format made the marker.
+    expect(body).toBe("require-node-builtins:pong");
+  }),
+  { timeout: 180_000 },
+);

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerBundle.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerBundle.test.ts
@@ -1,0 +1,84 @@
+import { WorkerBundle } from "@/Cloudflare/Workers/WorkerBundle";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { expect, layer } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+
+const decode = (content: string | Uint8Array<ArrayBufferLike>) =>
+  typeof content === "string"
+    ? content
+    : new TextDecoder().decode(content as Uint8Array);
+
+/**
+ * Write `files` (paths relative to a fresh temp directory) and return
+ * the temp directory's absolute path.
+ */
+const writeFixture = Effect.fn(function* (files: Record<string, string>) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const root = yield* fs.makeTempDirectory({
+    prefix: "alchemy-worker-bundle-",
+  });
+  for (const [name, content] of Object.entries(files)) {
+    const file = path.join(root, name);
+    yield* fs.makeDirectory(path.dirname(file), { recursive: true });
+    yield* fs.writeFileString(file, content);
+  }
+  return root;
+});
+
+layer(NodeServices.layer)("WorkerBundle", (it) => {
+  // Regression test for #880: CJS dependencies (like `pg`) that
+  // `require("events")` must have those requires converted into ESM imports
+  // of the workerd-provided Node builtins. Left unconverted, rolldown emits
+  // a throwing `require` fallback and the Worker fails Cloudflare startup
+  // validation with "Calling `require` for \"events\" in an environment
+  // that doesn't expose the `require` function".
+  it.effect(
+    "converts CJS requires of Node builtins into ESM imports under nodejs_compat",
+    () =>
+      Effect.gen(function* () {
+        const path = yield* Path.Path;
+        const root = yield* writeFixture({
+          // Anchors findCwdForBundle so bundle output stays in the temp dir.
+          "package.json": "{}",
+          "dep.cjs": [
+            `const { EventEmitter } = require("events");`,
+            `const util = require("node:util");`,
+            `module.exports = {`,
+            `  Thing: class extends EventEmitter {`,
+            `    describe() { return util.format("thing %s", "one"); }`,
+            `  },`,
+            `};`,
+          ].join("\n"),
+          "worker.mjs": [
+            `import { Thing } from "./dep.cjs";`,
+            `export default {`,
+            `  fetch: () => new Response(new Thing().describe()),`,
+            `};`,
+          ].join("\n"),
+        });
+
+        const bundler = yield* WorkerBundle;
+        const output = yield* bundler.build({
+          id: "worker-bundle-require-events",
+          main: path.join(root, "worker.mjs"),
+          compatibility: { date: "2026-03-17", flags: ["nodejs_compat"] },
+          entry: { kind: "external" },
+          stack: { name: "worker-bundle-test", stage: "test" },
+          extraOptions: undefined,
+        });
+
+        const entry = decode(output.files[0].content);
+        // The CJS requires were rewritten to imports of the builtins.
+        expect(entry).toMatch(/from\s*["'](?:node:)?events["']/);
+        expect(entry).toMatch(/from\s*["']node:util["']/);
+        // No chunk retains rolldown's throwing `require` fallback.
+        for (const file of output.files) {
+          if (!file.path.endsWith(".js")) continue;
+          expect(decode(file.content)).not.toContain("Calling `require` for");
+        }
+      }),
+  );
+});

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/require-node-builtins/dep.cjs
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/require-node-builtins/dep.cjs
@@ -1,0 +1,21 @@
+// A CommonJS dependency that requires Node builtins at module scope — the
+// same shape as `pg` (#880). Module evaluation happens during Cloudflare's
+// startup validation, which is exactly where the unconverted throwing
+// `require` fallback used to crash the Worker.
+const { EventEmitter } = require("events");
+const util = require("node:util");
+
+const emitter = new EventEmitter();
+
+// Takes its value from the request so the bundler cannot constant-fold the
+// round-trip away at build time.
+function roundTrip(value) {
+  let received = "";
+  emitter.once("ping", (v) => {
+    received = v;
+  });
+  emitter.emit("ping", value);
+  return util.format("require-node-builtins:%s", received);
+}
+
+module.exports = { roundTrip };

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/require-node-builtins/dep.d.cts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/require-node-builtins/dep.d.cts
@@ -1,0 +1,1 @@
+export declare function roundTrip(value: string): string;

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/require-node-builtins/worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/require-node-builtins/worker.ts
@@ -1,0 +1,30 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Effect from "effect/Effect";
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import { roundTrip } from "./dep.cjs";
+
+/**
+ * A Worker whose bundle contains a CommonJS module with top-level
+ * `require("events")` / `require("node:util")` — the `pg` shape from #880.
+ * Deploying it proves the direct Worker bundler converts those requires
+ * into ESM imports of the workerd-provided builtins: an unconverted bundle
+ * fails Cloudflare's startup validation before any request is served.
+ */
+export default class RequireNodeBuiltinsWorker extends Cloudflare.Worker<RequireNodeBuiltinsWorker>()(
+  "RequireNodeBuiltinsWorker",
+  {
+    main: import.meta.url,
+  },
+  Effect.gen(function* () {
+    return {
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        const value =
+          new URL(request.url, "http://localhost").searchParams.get("value") ??
+          "";
+        return HttpServerResponse.text(roundTrip(value));
+      }),
+    };
+  }),
+) {}


### PR DESCRIPTION
Deploying a `Cloudflare.Worker` whose graph pulls in CJS deps like `pg` could fail Cloudflare startup validation with:

```text
ScriptStartupError: Uncaught Error: Calling `require` for "events"
in an environment that doesn't expose the `require` function.
```

`cloudflareRolldown`'s nodejs-compat plugin registers rolldown's `esmExternalRequirePlugin` (which rewrites CJS `require("events")` into ESM imports of the workerd-provided builtins) from its own `options` hook, via `await import("rolldown/plugins")` resolved in the plugin package's context. Rolldown recognizes builtin plugins by class identity (`instanceof BuiltinPlugin`), so when the package manager installs the plugin's rolldown as a separate physical copy from alchemy's (bun peer-variant duplication does this), the registered object fails the `instanceof` check and is treated as a hook-less JS plugin — a silent no-op. The bundle then keeps rolldown's throwing `require` fallback and dies at startup.

The direct Worker bundler now registers the converter itself, from the same rolldown instance that runs the build:

```ts
plugins: [
  ...(hasNodejsCompat(options.compatibility.flags)
    ? [esmExternalRequirePlugin({ external: nodeBuiltinModules, skipDuplicateCheck: true })]
    : []),
  cloudflareRolldown({ ... }),
]
```

Two regression tests:

- `WorkerBundle.test.ts` (offline) bundles a CJS fixture with `require("events")` / `require("node:util")` through `WorkerBundle` and asserts the requires become ESM imports with no throwing fallback in any chunk.
- `NodeBuiltinRequire.test.ts` (live) deploys a Worker fixture whose bundle contains that same CJS shape and drives it over HTTP — an unconverted bundle fails Cloudflare startup validation at upload, so the deploy itself is the assertion.

Closes #880

🤖 Generated with [Claude Code](https://claude.com/claude-code)
