### PR TITLE
fix(cloudflare/workers): converge plans with Effect-valued env bindings

### DIFF
--- a/packages/alchemy/src/Apply.ts
+++ b/packages/alchemy/src/Apply.ts
@@ -681,7 +681,14 @@ const executeNode = (
           resourceType: node.resource.Type,
           props: news,
           attr,
-          bindings: excludeDeletedBindings(node.bindings),
+          // Terminal commits persist the RESOLVED binding payload the
+          // provider actually reconciled with, not the raw plan-time
+          // expressions. Raw `node.bindings` may hold unresolved Outputs
+          // (silently dropped by JSON state stores), so persisting them
+          // makes the next plan's `diffBindings` compare a lossy stored
+          // shape against fully-resolved data — a phantom binding update
+          // on every plan (#874).
+          bindings: bindingOutputs,
           providerVersion: node.provider.version ?? 0,
           downstream: node.downstream,
           removalPolicy: node.resource.RemovalPolicy,
@@ -813,7 +820,8 @@ const executeNode = (
             resourceType: node.resource.Type,
             props: news,
             attr,
-            bindings: excludeDeletedBindings(node.bindings),
+            // Resolved payload, not raw `node.bindings` — see create commit.
+            bindings: bindingOutputs,
             providerVersion: node.provider.version ?? 0,
             downstream: node.downstream,
             removalPolicy: node.resource.RemovalPolicy,
@@ -1040,7 +1048,8 @@ const executeNode = (
             props: news,
             attr,
             providerVersion: node.provider.version ?? 0,
-            bindings: excludeDeletedBindings(node.bindings),
+            // Resolved payload, not raw `node.bindings` — see create commit.
+            bindings: bindingOutputs,
             downstream: node.downstream,
             removalPolicy: node.resource.RemovalPolicy,
           });
@@ -1056,7 +1065,8 @@ const executeNode = (
             props: news,
             attr,
             providerVersion: node.provider.version ?? 0,
-            bindings: excludeDeletedBindings(node.bindings),
+            // Resolved payload, not raw `node.bindings` — see create commit.
+            bindings: bindingOutputs,
             downstream: node.downstream,
             // Preserve the remaining backlog exactly as-is. GC is responsible for
             // popping one generation at a time until the chain is exhausted.
@@ -1420,10 +1430,15 @@ const converge = Effect.fn(function* (
           logicalId,
           instanceId,
           resourceType: node.resource.Type,
-          props: newProps,
+          // This site bypasses the `commit` helper, so strip unresolved
+          // leaves (Effect-valued env entries survive `Output.evaluate`)
+          // the same way `commit` does — state only ever holds plain data.
+          props: stripUnresolved(newProps),
           attr,
           providerVersion: node.provider.version ?? 0,
-          bindings: excludeDeletedBindings(node.bindings),
+          // Resolved payload, not raw `node.bindings` — see the create
+          // commit in applyResource.
+          bindings: newBindings,
           downstream: node.downstream,
           namespace,
           removalPolicy: node.resource.RemovalPolicy,

--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -57,7 +57,7 @@ import * as Scope from "effect/Scope";
 import * as Semaphore from "effect/Semaphore";
 import * as Stream from "effect/Stream";
 import type * as Bundle from "../../Bundle/Bundle.ts";
-import { isResolved } from "../../Diff.ts";
+import { isResolved, stripEffects } from "../../Diff.ts";
 import * as RpcProvider from "../../Local/RpcProvider.ts";
 import type { ResourceBinding } from "../../Resource.ts";
 import { Stack } from "../../Stack.ts";
@@ -638,7 +638,12 @@ export const LocalWorkerProvider = () =>
             (instance) => Fiber.join(instance.fiber),
             { concurrency: "unbounded" },
           ),
-        diff: Effect.fn(function* ({ id, news, newBindings, output }) {
+        diff: Effect.fn(function* ({ id, news: desired, newBindings, output }) {
+          // Effect-valued `env` entries (tagged Worker classes) never resolve
+          // at plan time; their identity is carried by the resolved binding
+          // data. Strip them so the signature-based diff still runs — same
+          // rationale as the cloud WorkerProvider (#874).
+          const news = stripEffects(desired);
           if (!isResolved(news) || !isResolved(newBindings)) return undefined;
           const options = {
             id,

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -14,7 +14,7 @@ import { Unowned } from "../../AdoptPolicy.ts";
 import * as Artifacts from "../../Artifacts.ts";
 import type { ScopedPlanStatusSession } from "../../Cli/Cli.ts";
 import { hashDirectory, type MemoOptions } from "../../Command/Memo.ts";
-import { isResolved } from "../../Diff.ts";
+import { isResolved, stripEffects } from "../../Diff.ts";
 import * as ProviderLayer from "../../Local/ProviderLayer.ts";
 import * as Provider from "../../Provider.ts";
 import { type ResourceBinding } from "../../Resource.ts";
@@ -2182,8 +2182,24 @@ export const LiveWorkerProvider = () =>
               ),
             );
           }),
-        diff: Effect.fn(function* ({ id, news, olds, output, newBindings }) {
+        diff: Effect.fn(function* ({
+          id,
+          news: desired,
+          olds,
+          output,
+          newBindings,
+        }) {
           const { accountId } = yield* yield* CloudflareEnvironment;
+          // Effect-valued `env` entries (tagged Worker classes / resource
+          // Effects — the circular-bindings pattern) never resolve at plan
+          // time and are dropped from persisted props by `stripUnresolved`
+          // at the commit boundary. Their deploy-time identity is carried by
+          // the resolved binding data, which the metadata hash below covers.
+          // Strip them before the resolution check so a tag in `env` doesn't
+          // force the raw-props fallback — which compares the Effect's JSON
+          // form against the stripped stored props and re-plans an update
+          // forever (#874).
+          const news = stripEffects(desired);
           if (!isResolved(news)) return undefined;
           if ((output?.accountId ?? accountId) !== accountId) {
             return { action: "replace" };

--- a/packages/alchemy/src/Diff.ts
+++ b/packages/alchemy/src/Diff.ts
@@ -86,6 +86,37 @@ const _stripUnresolved = (value: unknown): unknown => {
   return value;
 };
 
+/**
+ * Deeply replace Effect-valued entries with `undefined`, leaving resolved
+ * values AND unresolved `Output`/`Expr`s intact.
+ *
+ * Effect-valued props — e.g. a tagged Worker class in `env` (the
+ * circular-bindings pattern) — can never be evaluated inside lifecycle
+ * operations, and {@link stripUnresolved} drops them from persisted state at
+ * the commit boundary. A provider `diff` that wants its structural change
+ * detection to still run despite them strips them first, so `isResolved`
+ * gates only on genuinely-unresolved Outputs (#874). The Effects' deploy-time
+ * identity is carried by the resolved binding data instead.
+ */
+export const stripEffects = <T>(value: T): T => _stripEffects(value) as T;
+
+const _stripEffects = (value: unknown): unknown => {
+  if (value == null || isPrimitive(value)) return value;
+  // Output proxies are left intact (so `isResolved` still sees them); they
+  // must be tested BEFORE `Effect.isEffect` because Output exprs are
+  // yieldable and would otherwise be misclassified as plain Effects.
+  if (Output.isExpr(value)) return value;
+  if (Effect.isEffect(value)) return undefined;
+  if (Redacted.isRedacted(value) || Duration.isDuration(value)) return value;
+  if (Array.isArray(value)) return value.map(_stripEffects);
+  if (typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [key, _stripEffects(item)]),
+    );
+  }
+  return value;
+};
+
 export const somePropsAreDifferent = <Props extends Record<string, any>>(
   olds: Props,
   news: Props,
@@ -121,8 +152,17 @@ export const havePropsChanged = <Props extends object>(
   newProps: Props,
 ) =>
   Output.hasOutputs(newProps) ||
-  JSON.stringify(canonicalize(oldProps ?? {}, false)) !==
-    JSON.stringify(canonicalize(newProps ?? {}, false));
+  // Compare both sides through `stripUnresolved` so the comparison is
+  // symmetric with the commit boundary: persisted props can never hold an
+  // Effect or Output expr (stripped at commit / silently dropped by JSON
+  // serialization), while desired props may still carry them — e.g. a tagged
+  // Worker class in `env` serializes via its `toJSON` to
+  // `{"_id":"Effect",...}` and would otherwise report a phantom change on
+  // every plan, forever (#874). Unresolved Outputs in `newProps` are already
+  // caught by the `hasOutputs` guard above, so stripping here never hides a
+  // real difference.
+  JSON.stringify(canonicalize(stripUnresolved(oldProps ?? {}), false)) !==
+    JSON.stringify(canonicalize(stripUnresolved(newProps ?? {}), false));
 
 export type DeepEqualOptions = {
   /**

--- a/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
@@ -11,6 +11,7 @@ import * as workers from "@distilled.cloud/cloudflare/workers";
 import { describe, expect } from "alchemy-test";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 import * as Redacted from "effect/Redacted";
 import { MinimumLogLevel } from "effect/References";
@@ -855,6 +856,100 @@ describe.concurrent("Cloudflare.Worker", () => {
 
         yield* stack.destroy();
         yield* waitForWorkerToBeDeleted(v1.workerName, accountId);
+      }).pipe(logLevel),
+    { timeout: 360_000 },
+  );
+
+  // #874 regression: binding a tagged Worker identity (an Effect class) in
+  // another Worker's `env` — the circular-bindings pattern — must converge.
+  // The tag stays in the desired props (`news.env.TARGET` is an Effect) while
+  // `stripUnresolved` removes it from the stored props at commit, so a diff
+  // that compares the two raw shapes plans an update on every deploy, forever.
+  // After a successful deploy, an identical program must plan as a noop —
+  // and a code-only change must STILL plan as an update (the tag must not
+  // knock the diff off its bundle-hash path onto the raw-props fallback,
+  // which can't see file contents).
+  test.provider(
+    "Effect-valued worker tag in env converges to a noop plan",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+
+        yield* stack.destroy();
+
+        class EnvTagTarget extends Cloudflare.Worker<EnvTagTarget, {}>()(
+          "EnvTagTargetWorker",
+        ) {}
+        class EnvTagCaller extends Cloudflare.Worker<EnvTagCaller, {}>()(
+          "EnvTagCallerWorker",
+        ) {}
+
+        // The caller's entry lives in a temp dir so the test can edit its
+        // contents mid-flight without touching the shared checked-in fixture.
+        const callerScript = (marker: string) =>
+          `export default { fetch: async () => new Response(${JSON.stringify(marker)}) };\n`;
+        const tempDir = yield* fs.makeTempDirectory({
+          prefix: "alchemy-env-tag-worker",
+        });
+        const callerMain = path.join(tempDir, "worker.ts");
+        yield* fs.writeFileString(callerMain, callerScript("v1"));
+
+        const layers = Layer.mergeAll(
+          EnvTagTarget.make({ main, isExternal: true }, Effect.succeed({})),
+          EnvTagCaller.make(
+            {
+              main: callerMain,
+              isExternal: true,
+              env: { TARGET: EnvTagTarget },
+            },
+            Effect.succeed({}),
+          ),
+        );
+
+        const program = () =>
+          Effect.gen(function* () {
+            const target = yield* EnvTagTarget;
+            const caller = yield* EnvTagCaller;
+            return { target, caller };
+          }).pipe(Effect.provide(layers));
+
+        const actionOf = (plan: any, logicalId: string) =>
+          (Object.values(plan.resources) as any[]).find(
+            (node: any) => node.resource.LogicalId === logicalId,
+          )?.action;
+
+        const deployed = yield* stack.deploy(program());
+
+        // The env tag must have landed as a live service binding.
+        const settings = yield* workers.getScriptScriptAndVersionSetting({
+          accountId,
+          scriptName: deployed.caller.workerName,
+        });
+        expect(settings.bindings).toContainEqual(
+          expect.objectContaining({
+            type: "service",
+            name: "TARGET",
+            service: deployed.target.workerName,
+          }),
+        );
+
+        // Identical program → both workers plan as noop.
+        const settledPlan = yield* stack.plan(program());
+        expect(actionOf(settledPlan, "EnvTagTargetWorker")).toBe("noop");
+        expect(actionOf(settledPlan, "EnvTagCallerWorker")).toBe("noop");
+
+        // A code-only change to the caller's entry (identical props — the
+        // bundle hash is the only difference) must still plan as an update.
+        yield* fs.writeFileString(callerMain, callerScript("v2"));
+        const codeChangePlan = yield* stack.plan(program());
+        expect(actionOf(codeChangePlan, "EnvTagTargetWorker")).toBe("noop");
+        expect(actionOf(codeChangePlan, "EnvTagCallerWorker")).toBe("update");
+
+        yield* stack.destroy();
+        yield* waitForWorkerToBeDeleted(deployed.caller.workerName, accountId);
+        yield* waitForWorkerToBeDeleted(deployed.target.workerName, accountId);
       }).pipe(logLevel),
     { timeout: 360_000 },
   );

--- a/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
@@ -1027,6 +1027,69 @@ describe.concurrent("Cloudflare.Worker", () => {
     { timeout: 360_000 },
   );
 
+  // #874 (comments): an Output-valued `worker.bind` binding must also
+  // converge. Terminal apply commits must persist the RESOLVED binding
+  // payload — raw `node.bindings` hold the Output expression, which JSON
+  // state stores silently drop, so every later plan's `diffBindings` would
+  // compare a lossy stored shape against resolved data and re-update
+  // forever (the PR #266 path).
+  test.provider(
+    "Output-valued worker.bind binding converges to a noop plan",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+
+        yield* stack.destroy();
+
+        const program = () =>
+          Effect.gen(function* () {
+            const source = yield* Cloudflare.Worker("BindTextSource", {
+              main,
+            });
+            const host = yield* Cloudflare.Worker("BindTextHost", {
+              main,
+            });
+            // `source.workerName` is an Output<string> at plan time — the
+            // same shape as an Action-produced value bound as plain_text.
+            yield* host.bind`REV`({
+              bindings: [
+                { type: "plain_text", name: "REV", text: source.workerName },
+              ],
+            });
+            return { source, host };
+          });
+
+        const actionOf = (plan: any, logicalId: string) =>
+          (Object.values(plan.resources) as any[]).find(
+            (node: any) => node.resource.LogicalId === logicalId,
+          )?.action;
+
+        const deployed = yield* stack.deploy(program());
+
+        // The resolved text must have landed in the live binding.
+        const settings = yield* workers.getScriptScriptAndVersionSetting({
+          accountId,
+          scriptName: deployed.host.workerName,
+        });
+        expect(settings.bindings).toContainEqual(
+          expect.objectContaining({
+            type: "plain_text",
+            name: "REV",
+            text: deployed.source.workerName,
+          }),
+        );
+
+        const settled = yield* stack.plan(program());
+        expect(actionOf(settled, "BindTextSource")).toBe("noop");
+        expect(actionOf(settled, "BindTextHost")).toBe("noop");
+
+        yield* stack.destroy();
+        yield* waitForWorkerToBeDeleted(deployed.host.workerName, accountId);
+        yield* waitForWorkerToBeDeleted(deployed.source.workerName, accountId);
+      }).pipe(logLevel),
+    { timeout: 360_000 },
+  );
+
   // `domains` should reflect the workers.dev URL when the subdomain is
   // enabled and be empty when it isn't. `worker.url` is just `domains[0]`,
   // so the two must stay in lockstep across deploys.

--- a/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
@@ -1090,6 +1090,82 @@ describe.concurrent("Cloudflare.Worker", () => {
     { timeout: 360_000 },
   );
 
+  // Effect-valued env entries are stripped from the props comparison (#874),
+  // so change detection for them rides entirely on the evaluated binding
+  // data. This test guards that channel: when only the VALUE an env Effect
+  // resolves to changes (a `gen` Effect — serializes value-blind, so the
+  // props comparison could never see it), the plan must still flip from
+  // noop to update.
+  test.provider(
+    "changing the value of an Effect-valued env entry plans an update",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+
+        yield* stack.destroy();
+
+        const program = (value: string) =>
+          Effect.gen(function* () {
+            return yield* Cloudflare.Worker("EffectEnvValueWorker", {
+              main,
+              env: {
+                VALUE: Effect.gen(function* () {
+                  return value;
+                }),
+              },
+            });
+          });
+
+        const actionOf = (plan: any, logicalId: string) =>
+          (Object.values(plan.resources) as any[]).find(
+            (node: any) => node.resource.LogicalId === logicalId,
+          )?.action;
+
+        const deployed = yield* stack.deploy(program("v1"));
+
+        // The evaluated value lands as a plain_text binding.
+        const settings = yield* workers.getScriptScriptAndVersionSetting({
+          accountId,
+          scriptName: deployed.workerName,
+        });
+        expect(settings.bindings).toContainEqual(
+          expect.objectContaining({
+            type: "plain_text",
+            name: "VALUE",
+            text: "v1",
+          }),
+        );
+
+        // Same value → noop; changed value → update.
+        const samePlan = yield* stack.plan(program("v1"));
+        expect(actionOf(samePlan, "EffectEnvValueWorker")).toBe("noop");
+        const changedPlan = yield* stack.plan(program("v2"));
+        expect(actionOf(changedPlan, "EffectEnvValueWorker")).toBe("update");
+
+        // The changed value must actually deploy — and then converge.
+        const redeployed = yield* stack.deploy(program("v2"));
+        const updatedSettings = yield* workers.getScriptScriptAndVersionSetting(
+          {
+            accountId,
+            scriptName: redeployed.workerName,
+          },
+        );
+        expect(updatedSettings.bindings).toContainEqual(
+          expect.objectContaining({
+            type: "plain_text",
+            name: "VALUE",
+            text: "v2",
+          }),
+        );
+        const resettled = yield* stack.plan(program("v2"));
+        expect(actionOf(resettled, "EffectEnvValueWorker")).toBe("noop");
+
+        yield* stack.destroy();
+        yield* waitForWorkerToBeDeleted(deployed.workerName, accountId);
+      }).pipe(logLevel),
+    { timeout: 360_000 },
+  );
+
   // `domains` should reflect the workers.dev URL when the subdomain is
   // enabled and be empty when it isn't. `worker.url` is just `domains[0]`,
   // so the two must stay in lockstep across deploys.

--- a/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
@@ -954,6 +954,79 @@ describe.concurrent("Cloudflare.Worker", () => {
     { timeout: 360_000 },
   );
 
+  // The full circular case from the #874 report: A and B each bind the
+  // OTHER's tag in env. The tags keep the dependency on the binding channel
+  // (precreate stubs + converge pass) — a cycle the props channel cannot
+  // express — and both workers must still converge to noop plans.
+  test.provider(
+    "circular worker tags in env converge to noop plans",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+
+        yield* stack.destroy();
+
+        class CircTagA extends Cloudflare.Worker<CircTagA, {}>()(
+          "CircTagAWorker",
+        ) {}
+        class CircTagB extends Cloudflare.Worker<CircTagB, {}>()(
+          "CircTagBWorker",
+        ) {}
+
+        const layers = Layer.mergeAll(
+          CircTagA.make(
+            { main, isExternal: true, env: { PEER: CircTagB } },
+            Effect.succeed({}),
+          ),
+          CircTagB.make(
+            { main, isExternal: true, env: { PEER: CircTagA } },
+            Effect.succeed({}),
+          ),
+        );
+
+        const program = () =>
+          Effect.gen(function* () {
+            const a = yield* CircTagA;
+            const b = yield* CircTagB;
+            return { a, b };
+          }).pipe(Effect.provide(layers));
+
+        const actionOf = (plan: any, logicalId: string) =>
+          (Object.values(plan.resources) as any[]).find(
+            (node: any) => node.resource.LogicalId === logicalId,
+          )?.action;
+
+        const deployed = yield* stack.deploy(program());
+
+        // Each side must carry a live service binding to the other.
+        for (const [self, peer] of [
+          [deployed.a, deployed.b],
+          [deployed.b, deployed.a],
+        ] as const) {
+          const settings = yield* workers.getScriptScriptAndVersionSetting({
+            accountId,
+            scriptName: self.workerName,
+          });
+          expect(settings.bindings).toContainEqual(
+            expect.objectContaining({
+              type: "service",
+              name: "PEER",
+              service: peer.workerName,
+            }),
+          );
+        }
+
+        const settled = yield* stack.plan(program());
+        expect(actionOf(settled, "CircTagAWorker")).toBe("noop");
+        expect(actionOf(settled, "CircTagBWorker")).toBe("noop");
+
+        yield* stack.destroy();
+        yield* waitForWorkerToBeDeleted(deployed.a.workerName, accountId);
+        yield* waitForWorkerToBeDeleted(deployed.b.workerName, accountId);
+      }).pipe(logLevel),
+    { timeout: 360_000 },
+  );
+
   // `domains` should reflect the workers.dev URL when the subdomain is
   // enabled and be empty when it isn't. `worker.url` is just `domains[0]`,
   // so the two must stay in lockstep across deploys.

--- a/packages/alchemy/test/apply.test.ts
+++ b/packages/alchemy/test/apply.test.ts
@@ -351,6 +351,68 @@ describe("basic operations", () => {
       }),
   );
 
+  // #874: terminal commits must persist the RESOLVED binding payload the
+  // provider reconciled with, not the raw plan-time expressions. Raw
+  // `node.bindings` hold unresolved Outputs (silently dropped by JSON state
+  // stores), so persisting them makes every later plan's `diffBindings`
+  // compare a lossy stored shape against fully-resolved data — a phantom
+  // binding update on every plan. Exercises the create, update, and replace
+  // commit sites.
+  test.provider("terminal commits persist resolved binding payloads", (stack) =>
+    Effect.gen(function* () {
+      const program = (opts: { source: string; replaceString?: string }) =>
+        Effect.gen(function* () {
+          const source = yield* BindingTarget("BindSource", {
+            string: opts.source,
+          });
+          const host = yield* BindingTarget("BindHost", {
+            name: "host",
+            replaceString: opts.replaceString,
+          });
+          // `source.string` is an unresolved Output at plan time.
+          yield* host.bind("FromSource", {
+            env: { VALUE: source.string },
+          });
+          return { source, host };
+        });
+
+      const actionOf = (plan: any, logicalId: string) =>
+        (Object.values(plan.resources) as any[]).find(
+          (node: any) => node.resource.LogicalId === logicalId,
+        )?.action;
+
+      const expectHostBindings = Effect.fn(function* (value: string) {
+        const hostState = yield* getState("BindHost");
+        expect(hostState?.bindings).toEqual([
+          { sid: "FromSource", data: { env: { VALUE: value } } },
+        ]);
+      });
+
+      // ── create commit ──
+      yield* stack.deploy(program({ source: "v1" }));
+      yield* expectHostBindings("v1");
+      const created = yield* stack.plan(program({ source: "v1" }));
+      expect(actionOf(created, "BindSource")).toBe("noop");
+      expect(actionOf(created, "BindHost")).toBe("noop");
+
+      // ── update commit ──
+      yield* stack.deploy(program({ source: "v2" }));
+      yield* expectHostBindings("v2");
+      const updated = yield* stack.plan(program({ source: "v2" }));
+      expect(actionOf(updated, "BindSource")).toBe("noop");
+      expect(actionOf(updated, "BindHost")).toBe("noop");
+
+      // ── replace commit ──
+      yield* stack.deploy(program({ source: "v2", replaceString: "flip" }));
+      yield* expectHostBindings("v2");
+      const replaced = yield* stack.plan(
+        program({ source: "v2", replaceString: "flip" }),
+      );
+      expect(actionOf(replaced, "BindSource")).toBe("noop");
+      expect(actionOf(replaced, "BindHost")).toBe("noop");
+    }),
+  );
+
   test.provider(
     "should update a surviving consumer before deleting a removed dependency",
     (stack) =>


### PR DESCRIPTION
Binding a tagged Worker identity in another Worker's `env` (the circular-bindings pattern) deployed correctly but re-planned as `update` on every subsequent plan, forever.

```ts
class Target extends Cloudflare.Worker<Target, {}>()("Target") {}

Caller.make({ main, env: { TARGET: Target } }, Effect.succeed({}))
// deploy → plan → "update", deploy → plan → "update", ...
```

The tag is an Effect: `stripUnresolved` drops it from stored props at commit, while the desired props still carry it — and its `toJSON` serializes to `{"_id":"Effect",...}`, so the engine's raw-props fallback saw a permanent diff.

Three changes, each covered by the new regression test:

- `havePropsChanged` compares both sides through `stripUnresolved`, symmetric with the commit boundary, so an Effect in desired props no longer reports a phantom change.
- `WorkerProvider.diff` (and the local dev provider) strip Effect-valued entries before the `isResolved` gate instead of bailing to the raw-props fallback — bundle/metadata hash change detection still runs, so a code-only edit to `main` still plans an `update` (verified: reverting just this piece makes the code-change assertion fail with a silent noop).
- Terminal apply commits persist the resolved `bindingOutputs` the provider reconciled with instead of raw `node.bindings` (which hold unresolved Outputs that JSON state stores silently drop), so the next plan's `diffBindings` compares like against like. This is the second non-convergence path reported in the issue comments (the PR #266 case).

The regression test deploys a target + a caller bound via the Effect tag in `env`, asserts the live service binding, asserts an identical program plans `noop` for both workers, then edits the caller's entry file and asserts the plan flips to `update`.

Closes #874

🤖 Generated with [Claude Code](https://claude.com/claude-code)
