### PR TITLE
docs(blog): 2.0.0-beta.64 release post — Container Platforms

### DIFF
--- a/website/src/content/docs/blog/2026-07-21-beta-64.md
+++ b/website/src/content/docs/blog/2026-07-21-beta-64.md
@@ -1,0 +1,301 @@
+---
+title: 2.0.0-beta.64 - Container Platforms
+date: 2026-07-21T06:00:00Z
+category: release
+excerpt: v2.0.0-beta.64 unifies containers across ECS, EKS, and Cloudflare — new ECS Task/Service and EKS Deployment/Job/Manifest platforms, one image-source model with Dockerfile.inline, shared ALBs, and Helm charts. Plus generated 100% AWS resource coverage, Python Workers, and Drizzle D1.
+---
+
+beta.64 unifies containers across **ECS**, **EKS**, and
+**Cloudflare** under one authoring model
+([#867](https://github.com/alchemy-run/alchemy/pull/867)): every
+platform takes the same three forms (external image, inline
+effect, tagged effect) and the same flat image source — `image`
+composes with `main`, and `Dockerfile.inline` replaces
+content-in-a-string. It also adds **`AWS.ECS.Service`**,
+**`AWS.EKS.Job`**, **`AWS.EKS.Manifest`**, shared ALBs, and Helm
+charts.
+
+:::caution
+**Breaking changes** — all from
+([#867](https://github.com/alchemy-run/alchemy/pull/867)); each
+has a migration diff in the PR.
+
+- **`docker: {}` is removed** on ECS/EKS props —
+  `docker: { base }` becomes `image: "..."` next to `main`;
+  Dockerfile content becomes `dockerfile: Dockerfile.inline`.
+- **One-shot `ECS.Task` impls return `{ run }`**, not
+  `{ fetch }` — the container exits when the effect completes.
+- **`ECS.Task` no longer takes `cluster`** — a Task is a
+  TaskDefinition, which is cluster-independent. Launches declare
+  it: `RunTask(cluster, task)`, `StartTask(cluster, task)`, and
+  `Schedule` takes its own `cluster`.
+- **`EKS.ServerHost` → `EKS.Deployment`** (no alias; the tagged
+  form takes two type parameters). The resource Type string
+  changes, so the next deploy **replaces** — new physical names
+  and NLB/ELB URLs.
+- **The `EKS.Workload` family is deleted**
+  (`Workload` / `LoadBalancedWorkload` / `PodIdentityWorkload`) —
+  use `EKS.Deployment`, or `EKS.Manifest` for raw specs.
+- **`EKS.AutoCluster` → `EKS.Cluster("...", { compute: "auto" })`**.
+- **`alchemy/Kubernetes` is removed entirely** — `AWS.EKS.Manifest`
+  with a literal object is the only Kubernetes surface.
+- **`Cloudflare.Container` `dockerfile` content strings** become
+  `image: "..."` (bare base) or `dockerfile: Dockerfile.inline`
+  (content). A `dockerfile` string is now always a **path**.
+- Previously deployed `loadBalancer: true` ECS services redeploy
+  onto composed ALB/TargetGroup/Listener resources — the old
+  inline ingress is reaped automatically, and the service gets a
+  **new URL**.
+:::
+
+## ECS: Task and Service
+
+`AWS.ECS.Task` is the one-shot: its impl returns `{ run }` and the
+container exits when the effect completes. A remote image needs no
+impl at all:
+
+```typescript
+const migrate = yield* AWS.ECS.Task("DbMigrate", {
+  image: "public.ecr.aws/docker/library/busybox:stable",
+  command: ["sh", "-c", "echo done"],
+});
+
+// the cluster belongs to the launch, not the definition
+const runTask = yield* AWS.ECS.RunTask(cluster, migrate);
+yield* runTask({ overrides: { environment: { KEY: objectKey } } });
+```
+
+`AWS.ECS.Service` is the new long-running server platform — same
+triad, impls return `{ fetch }`:
+
+```typescript
+const api = yield* AWS.ECS.Service(
+  "Api",
+  { cluster, main: import.meta.url, port: 3000, desiredCount: 2, loadBalancer: true },
+  Effect.gen(function* () {
+    const putItem = yield* AWS.DynamoDB.PutItem(table);
+    return { fetch: Effect.gen(function* () { /* ... */ }) };
+  }).pipe(Effect.provide(AWS.DynamoDB.PutItemHttp)),
+);
+api.url; // string | undefined
+```
+
+Service also lands with `domain` (Route53 + DNS-validated ACM),
+`scaling` (min/max, CPU, request count), `capacity: "spot"`,
+`secrets`, `logging`, `serviceRegistry`, container `healthCheck`,
+and EFS `volumes`.
+
+Docs: [ECS](/aws/compute/ecs).
+
+## EKS: Deployment and Job
+
+`AWS.EKS.Deployment` (was `ServerHost`) is the replicated K8s
+server. Bindings resolve to pod-identity IAM policies:
+
+```typescript
+const api = yield* AWS.EKS.Deployment(
+  "Api",
+  { cluster, main: import.meta.url, port: 3000, replicas: 2, serviceType: "LoadBalancer" },
+  Effect.gen(function* () {
+    const putItem = yield* AWS.DynamoDB.PutItem(table); // → pod-identity IAM
+    return { fetch: Effect.gen(function* () { /* ... */ }) };
+  }).pipe(Effect.provide(AWS.DynamoDB.PutItemHttp)),
+);
+api.url;
+```
+
+`AWS.EKS.Job` is the run-to-completion counterpart; adding
+`schedule` synthesizes a K8s CronJob:
+
+```typescript
+const seed = yield* AWS.EKS.Job(
+  "SeedData",
+  { cluster, main: import.meta.url },
+  Effect.gen(function* () {
+    return { run: Effect.gen(function* () { /* runs to completion */ }) };
+  }),
+);
+
+const nightly = yield* AWS.EKS.Job("NightlyBackfill", {
+  cluster,
+  main: import.meta.url,
+  schedule: "0 3 * * *",
+});
+```
+
+An escape hatch covers everything the flat props don't: a literal
+deep-partial `podTemplate` merges onto the synthesized Pod spec.
+
+Docs: [EKS](/aws/compute/eks).
+
+## One image model
+
+Every platform takes one image source, flat on props:
+
+```typescript
+{ main }                                   // bundle this Effect program (default bun base)
+{ main, image }                            // bundle FROM your base image
+{ main, dockerfile: Dockerfile.inline`…` } // bundle in an inline-Dockerfile environment
+{ context, dockerfile? }                   // build your Dockerfile (a string is always a path)
+{ dockerfile: Dockerfile.inline`…` }       // inline content as the whole Dockerfile
+{ image }                                  // registry ref deployed verbatim, mirrored into ECR / CF registry
+```
+
+`Dockerfile.inline` makes the environment explicit when a bare
+base image isn't enough:
+
+```typescript
+AWS.ECS.Task("Transcoder", {
+  main: import.meta.url,
+  dockerfile: Dockerfile.inline`
+    FROM oven/bun:1
+    RUN apt-get update && apt-get install -y ffmpeg
+  `,
+}, impl);
+```
+
+Interpolations ride `Output.interpolate`, so
+`FROM ${base.imageUri}` is a real dependency edge. Conflicting
+sources (`image` + `dockerfile`, inline + `context`) are typed
+errors. `docker: { base } → image` is hash-stable — no image
+rebuild or task-definition churn on redeploy.
+
+## Shared load balancers
+
+Rules attach to **listeners**; ALBs own listeners. A string
+`listen` means the service owns the ALB; a `Listener` ref means it
+shares one, owning only its TargetGroups and ListenerRules:
+
+```typescript
+const alb   = yield* AWS.ELBv2.LoadBalancer("Shared", { subnets, securityGroups });
+const https = yield* AWS.ELBv2.Listener("Https", { loadBalancer: alb, port: 443, certificates: [cert] });
+
+const api = yield* AWS.ECS.Service("Api", {
+  cluster, main: import.meta.url, port: 3000,
+  loadBalancer: { listener: https, rules: [{ path: "/api/*" }] },
+}, impl);
+
+// simplest sharing: bare ref, default rule
+const web = yield* AWS.ECS.Service("Web", {
+  cluster, image: "ghcr.io/acme/web", port: 8080,
+  loadBalancer: https,
+});
+```
+
+Rule priorities auto-derive from the rule's logical id; a live
+collision is a typed `ListenerRulePriorityInUse` suggesting an
+explicit `priority`. Destroying a service removes exactly its
+rules and TargetGroups — shared infra survives.
+
+## Raw Kubernetes manifests
+
+`AWS.EKS.Manifest` applies any object, exactly as you'd write it
+in YAML — CRDs resolve via API discovery:
+
+```typescript
+const sts = yield* AWS.EKS.Manifest("Cache", {
+  cluster,
+  manifest: {
+    apiVersion: "apps/v1",
+    kind: "StatefulSet",
+    metadata: { name: "cache", namespace: "apps" },
+    spec: { replicas: 3 /* ... */ },
+  },
+});
+```
+
+The apply machinery (server-side apply, discovery, ordering) is
+internal to `AWS.EKS` — no kubeconfig, no client setup.
+
+## Helm charts
+
+`AWS.EKS.HelmChart` renders a chart locally (`helm template`) and
+converges its objects onto the cluster through the same
+server-side-apply machinery as `Manifest`
+([#891](https://github.com/alchemy-run/alchemy/pull/891)):
+
+```typescript
+const ingress = yield* AWS.EKS.HelmChart("IngressNginx", {
+  cluster,
+  chart: "ingress-nginx",
+  repo: "https://kubernetes.github.io/ingress-nginx",
+  version: "4.11.2",
+  namespace: "ingress-nginx",
+  createNamespace: true,
+  values: { controller: { replicaCount: 2 } },
+});
+```
+
+`chart` accepts a repository name (with `repo`), an `oci://` ref,
+or a local directory — local charts are content-hashed, so editing
+one redeploys without a prop change. Alchemy owns the lifecycle:
+drift is corrected on every deploy, objects that drop out of the
+render are pruned, and destroy deletes everything. No in-cluster
+Helm release record; install/upgrade hooks are not executed.
+
+## Also in this release
+
+- **Generated 100% AWS resource & binding coverage**
+  ([#797](https://github.com/alchemy-run/alchemy/pull/797)) —
+  the AWS resource factory ran to convergence: ~120 AWS service
+  directories with resources, bindings, event sources, and
+  Effect-first runtime functions, live-tested until the full
+  suite was green **and** left zero orphaned cloud resources,
+  twice consecutively. Includes `AWS.Lambda.DurableFunction`, a
+  replay-based orchestrator with `Durable.step` / `Durable.sleep`
+  / `Durable.waitForCallback`.
+- **Python Workers**
+  ([#861](https://github.com/alchemy-run/alchemy/pull/861)) —
+  `main: "worker.py"` deploys a Python Worker, with uv-vendored
+  packages.
+- **Workers AI binding** (`Cloudflare.Workers.AI`)
+  ([#850](https://github.com/alchemy-run/alchemy/pull/850)).
+- **Durable Objects take a `locationHint`**, and stubs gain
+  `get`/`idFromName`
+  ([#851](https://github.com/alchemy-run/alchemy/pull/851)).
+  Thanks **Matthew Aylward**!
+- **Drizzle D1** ([#887](https://github.com/alchemy-run/alchemy/pull/887)) —
+  `Drizzle.D1` plus `alchemy/SQL` clients, with an example and
+  docs.
+- **RDS**: `skipFinalSnapshot` opts a deliberate teardown out of
+  the final snapshot
+  ([#877](https://github.com/alchemy-run/alchemy/pull/877)), and
+  `MasterUserPassword` is fingerprint-guarded so reconcile stops
+  re-sending it on every deploy
+  ([#876](https://github.com/alchemy-run/alchemy/pull/876)).
+  Thanks **Zé Yuri**!
+- **Destroy no longer orphans physical resources** of rows that
+  crashed mid-create before attributes persisted
+  ([#862](https://github.com/alchemy-run/alchemy/pull/862)).
+- **Truncated physical names stay unique**
+  ([#868](https://github.com/alchemy-run/alchemy/pull/868)) —
+  `createPhysicalName` keeps the uniquifying suffix when it
+  truncates.
+- **The pure-annotation bundler plugin is rewritten** on rolldown
+  1.1's native MagicString
+  ([#849](https://github.com/alchemy-run/alchemy/pull/849)), and
+  wasm modules work in Vite dev
+  ([#881](https://github.com/alchemy-run/alchemy/pull/881)).
+  Thanks **John Royal**!
+- **Plans converge with Effect-valued env bindings**
+  ([#890](https://github.com/alchemy-run/alchemy/pull/890)) —
+  no more perpetual diffs on Workers whose env resolves through
+  an Effect.
+- **`esmExternalRequirePlugin` registers in the direct Worker
+  bundler** ([#889](https://github.com/alchemy-run/alchemy/pull/889)) —
+  fixes `require` of externals in non-Vite Worker builds.
+- **Website**: Astro 7 with compiler-free error annotations — 8x
+  faster builds
+  ([#873](https://github.com/alchemy-run/alchemy/pull/873)),
+  search works on mobile
+  ([#883](https://github.com/alchemy-run/alchemy/pull/883)), and
+  the API reference index moved to `llms-full.txt`
+  ([#872](https://github.com/alchemy-run/alchemy/pull/872)).
+
+## Where to go next
+
+- [ECS](/aws/compute/ecs)
+- [EKS](/aws/compute/eks)
+- [Choosing a runtime](/aws/compute/choosing-a-runtime)
+- [CHANGELOG](https://github.com/alchemy-run/alchemy/blob/main/CHANGELOG.md#v200-beta64)
+- [Compare v2.0.0-beta.63 → v2.0.0-beta.64](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.63...v2.0.0-beta.64)


### PR DESCRIPTION
Release blog post for the container-platform release (`website/src/content/docs/blog/2026-07-21-beta-64.md`).

- Breaking-changes `:::caution` from [#867](https://github.com/alchemy-run/alchemy/pull/867)'s migration table (`docker: {}` removal, `{ run }` one-shots, `ServerHost` → `Deployment`, Workload family deleted, AutoCluster fold-in, `alchemy/Kubernetes` removed, CF dockerfile-content → `image`/`Dockerfile.inline`, cluster off `Task`)
- Headline sections: ECS Task/Service, EKS Deployment/Job, the unified image-source model + `Dockerfile.inline`, shared ALBs, `EKS.Manifest`, `AWS.EKS.HelmChart` ([#891](https://github.com/alchemy-run/alchemy/pull/891))
- "Also in this release" long tail since v2.0.0-beta.63 ([#797](https://github.com/alchemy-run/alchemy/pull/797), Python Workers, Workers AI, Drizzle D1, RDS, engine + bundler fixes) with contributor credits

Draft until the release is cut: the version number may shift, and [#891](https://github.com/alchemy-run/alchemy/pull/891) (HelmChart) is referenced but not yet merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
