### PR TITLE
fix(aws): AWS_REGION env overrides SSO profile/stored region

### DIFF
--- a/packages/alchemy/src/AWS/AuthProvider.ts
+++ b/packages/alchemy/src/AWS/AuthProvider.ts
@@ -79,17 +79,15 @@ export interface AwsResolvedCredentials {
 }
 
 /**
- * An explicitly-set region env var always wins over the region recorded in an
- * SSO profile (`~/.aws/config`) or in stored credentials:
- * `AWS_REGION` > `AWS_DEFAULT_REGION` > profile/stored region.
+ * An explicitly-set `AWS_REGION` env var wins over the region recorded in an
+ * SSO profile (`~/.aws/config`) or in stored credentials. `AWS_DEFAULT_REGION`
+ * deliberately does NOT override — it is a *default* for when no region is
+ * configured anywhere, and the profile's region is explicit configuration.
  */
 export const applyEnvRegionOverride = <C extends { region: string }>(
   creds: C,
 ): Effect.Effect<C> =>
   getEnv("AWS_REGION").pipe(
-    Effect.flatMap((region) =>
-      region ? Effect.succeed(region) : getEnv("AWS_DEFAULT_REGION"),
-    ),
     Effect.map((envRegion) =>
       envRegion ? { ...creds, region: envRegion } : creds,
     ),

--- a/packages/alchemy/src/AWS/AuthProvider.ts
+++ b/packages/alchemy/src/AWS/AuthProvider.ts
@@ -79,6 +79,23 @@ export interface AwsResolvedCredentials {
 }
 
 /**
+ * An explicitly-set region env var always wins over the region recorded in an
+ * SSO profile (`~/.aws/config`) or in stored credentials:
+ * `AWS_REGION` > `AWS_DEFAULT_REGION` > profile/stored region.
+ */
+export const applyEnvRegionOverride = <C extends { region: string }>(
+  creds: C,
+): Effect.Effect<C> =>
+  getEnv("AWS_REGION").pipe(
+    Effect.flatMap((region) =>
+      region ? Effect.succeed(region) : getEnv("AWS_DEFAULT_REGION"),
+    ),
+    Effect.map((envRegion) =>
+      envRegion ? { ...creds, region: envRegion } : creds,
+    ),
+  );
+
+/**
  * Layer that registers the AWS {@link AuthProvider} into the
  * {@link AuthProviders} registry when built. Include this in the AWS
  * `providers()` layer so `alchemy login` can discover it.
@@ -365,6 +382,7 @@ export const AwsAuth = AuthProviderLayer<
           Effect.mapError(
             (e) => new AuthError({ message: "login failed", cause: e }),
           ),
+          Effect.flatMap(applyEnvRegionOverride),
         );
 
     const prettyPrint = (profileName: string, config: AwsAuthConfig) =>

--- a/packages/alchemy/test/AWS/AuthProvider.test.ts
+++ b/packages/alchemy/test/AWS/AuthProvider.test.ts
@@ -19,20 +19,13 @@ describe("applyEnvRegionOverride", () => {
     }).pipe(withEnv({ AWS_REGION: "us-east-2" })),
   );
 
-  it.effect("AWS_DEFAULT_REGION overrides when AWS_REGION is unset", () =>
+  // AWS_DEFAULT_REGION is a default, not an override — the profile's region
+  // is explicit configuration and must win over it.
+  it.effect("AWS_DEFAULT_REGION does NOT override the profile region", () =>
     Effect.gen(function* () {
       const creds = yield* applyEnvRegionOverride(profileCreds);
-      expect(creds.region).toBe("eu-west-1");
+      expect(creds.region).toBe("us-west-2");
     }).pipe(withEnv({ AWS_DEFAULT_REGION: "eu-west-1" })),
-  );
-
-  it.effect("AWS_REGION takes precedence over AWS_DEFAULT_REGION", () =>
-    Effect.gen(function* () {
-      const creds = yield* applyEnvRegionOverride(profileCreds);
-      expect(creds.region).toBe("us-east-2");
-    }).pipe(
-      withEnv({ AWS_REGION: "us-east-2", AWS_DEFAULT_REGION: "eu-west-1" }),
-    ),
   );
 
   it.effect("falls back to the profile region when no env is set", () =>

--- a/packages/alchemy/test/AWS/AuthProvider.test.ts
+++ b/packages/alchemy/test/AWS/AuthProvider.test.ts
@@ -1,0 +1,44 @@
+import { applyEnvRegionOverride } from "@/AWS/AuthProvider.ts";
+import { describe, expect, it } from "alchemy-test";
+import * as ConfigProvider from "effect/ConfigProvider";
+import * as Effect from "effect/Effect";
+
+const withEnv = (env: Record<string, string>) =>
+  Effect.provide(ConfigProvider.layer(ConfigProvider.fromEnv({ env })));
+
+// Simulates credentials resolved from an SSO profile whose ~/.aws/config
+// region differs from the region the user explicitly set in the environment.
+const profileCreds = { accountId: "123456789012", region: "us-west-2" };
+
+describe("applyEnvRegionOverride", () => {
+  it.effect("AWS_REGION overrides the profile region", () =>
+    Effect.gen(function* () {
+      const creds = yield* applyEnvRegionOverride(profileCreds);
+      expect(creds.region).toBe("us-east-2");
+      expect(creds.accountId).toBe("123456789012");
+    }).pipe(withEnv({ AWS_REGION: "us-east-2" })),
+  );
+
+  it.effect("AWS_DEFAULT_REGION overrides when AWS_REGION is unset", () =>
+    Effect.gen(function* () {
+      const creds = yield* applyEnvRegionOverride(profileCreds);
+      expect(creds.region).toBe("eu-west-1");
+    }).pipe(withEnv({ AWS_DEFAULT_REGION: "eu-west-1" })),
+  );
+
+  it.effect("AWS_REGION takes precedence over AWS_DEFAULT_REGION", () =>
+    Effect.gen(function* () {
+      const creds = yield* applyEnvRegionOverride(profileCreds);
+      expect(creds.region).toBe("us-east-2");
+    }).pipe(
+      withEnv({ AWS_REGION: "us-east-2", AWS_DEFAULT_REGION: "eu-west-1" }),
+    ),
+  );
+
+  it.effect("falls back to the profile region when no env is set", () =>
+    Effect.gen(function* () {
+      const creds = yield* applyEnvRegionOverride(profileCreds);
+      expect(creds.region).toBe("us-west-2");
+    }).pipe(withEnv({})),
+  );
+});


### PR DESCRIPTION
`resolveCredentials` returned the `~/.aws/config` profile region verbatim for `sso` (and `stored`) auth, silently ignoring an explicit `AWS_REGION` env var — e.g. `AWS_REGION=us-east-1` still deployed to the profile's `us-west-2`.

The fix applies the env override as the final step of `resolveCredentials`, for every auth method:

```ts
export const applyEnvRegionOverride = <C extends { region: string }>(
  creds: C,
): Effect.Effect<C> =>
  getEnv("AWS_REGION").pipe(
    Effect.map((envRegion) =>
      envRegion ? { ...creds, region: envRegion } : creds,
    ),
  );
```

Precedence: `AWS_REGION` > profile/stored region. `AWS_DEFAULT_REGION` deliberately does **not** override — it is a default, not an override, and the profile's region is explicit configuration (review feedback). When `AWS_REGION` is unset, behavior is unchanged (profile region wins). `Region.fromEnvironment` derives from `AWSEnvironment.region`, so the engine's `Region` service picks up the override everywhere.

Verified live against the testing SSO profile (profile region `us-west-2`):

```
no env                         -> resolvedRegion us-west-2  (unchanged default)
AWS_REGION=us-east-1           -> resolvedRegion us-east-1
pre-fix + AWS_REGION=us-east-1 -> resolvedRegion us-west-2  (the bug)
```

Offline unit coverage in `test/AWS/AuthProvider.test.ts` via `ConfigProvider.fromEnv({ env })`, including profile-beats-`AWS_DEFAULT_REGION`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
