### PR TITLE
test(aws/rds): live-verify the MasterUserPassword fingerprint guard

### DIFF
--- a/packages/alchemy/test/AWS/RDS/DBInstance.test.ts
+++ b/packages/alchemy/test/AWS/RDS/DBInstance.test.ts
@@ -5,10 +5,12 @@ import type { DBInstanceProps } from "@/AWS/RDS/DBInstance.ts";
 import { DBSubnetGroup } from "@/AWS/RDS/DBSubnetGroup.ts";
 import * as Provider from "@/Provider";
 import * as Test from "@/Test/Alchemy";
+import * as rds from "@distilled.cloud/aws/rds";
 import { expect } from "alchemy-test";
 import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Result from "effect/Result";
+import * as Schedule from "effect/Schedule";
 
 const { test } = Test.make({ providers: AWS.providers() });
 
@@ -298,6 +300,120 @@ test.provider.skipIf(!process.env.RDS_TEST_LIFECYCLE)(
       // In-place modify — identity is preserved (no replacement).
       expect(updated.dbInstanceArn).toBe(created.dbInstanceArn);
       expect(updated.backupRetentionPeriod).toBe(3);
+
+      yield* stack.destroy();
+    }),
+  { timeout: 2_400_000 },
+);
+
+// Fingerprint-guarded master password lifecycle (#876), gated behind
+// RDS_TEST_LIFECYCLE=1 (real db.t3.micro, ~15-25 min).
+//
+// AWS never returns the master password, so the provider fingerprints the
+// configured value (identifier-salted sha256, persisted `Redacted`) and only
+// sends `MasterUserPassword` on modify when the fingerprint changed. RDS
+// durably records a "Reset master credentials" event whenever a password
+// modify actually applies, which makes the guard observable out-of-band:
+//
+//   1. create with password P1 — set at create time, no reset event
+//   2. redeploy P1 with a tag change (forces reconcile) — fingerprint stable
+//   3. redeploy P2 — fingerprint changes; RDS records the credentials reset
+//
+// After step 3's event is observed, the reset-event count over the whole run
+// must be exactly 1 — the anchored positive event proves step 2's reconcile
+// did not re-send the unchanged password (pre-#876 every reconcile did,
+// putting the instance through a live `resetting-master-credentials` cycle).
+test.provider.skipIf(!process.env.RDS_TEST_LIFECYCLE)(
+  "master password: fingerprint guard skips unchanged, applies rotation",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const identifier = "alchemy-rds-fingerprint";
+
+      // The testing account has no default VPC/subnets — provision a network
+      // and DB subnet group like the standalone lifecycle test above.
+      const network = Effect.gen(function* () {
+        const net = yield* Network("FingerprintNet", {
+          cidrBlock: "10.42.0.0/16",
+        });
+        const subnetGroup = yield* DBSubnetGroup("FingerprintSubnetGroup", {
+          description: "alchemy master-password fingerprint lifecycle",
+          subnetIds: net.privateSubnetIds,
+        });
+        return { dbSubnetGroupName: subnetGroup.dbSubnetGroupName };
+      });
+
+      const deployInstance = (password: string, round: string) =>
+        stack.deploy(
+          Effect.gen(function* () {
+            const { dbSubnetGroupName } = yield* network;
+            return yield* DBInstance("FingerprintInstance", {
+              dbInstanceIdentifier: identifier,
+              engine: "postgres",
+              dbInstanceClass: "db.t3.micro",
+              allocatedStorage: 20,
+              masterUsername: "alchemy",
+              masterUserPassword: Redacted.make(password),
+              deletionProtection: false,
+              dbSubnetGroupName,
+              publiclyAccessible: false,
+              // A changed tag guarantees the engine sees a props diff and
+              // runs `reconcile` — the exact path that used to re-send the
+              // unchanged password.
+              tags: { round },
+            });
+          }),
+        );
+
+      const resetEvents = rds
+        .describeEvents({
+          SourceIdentifier: identifier,
+          SourceType: "db-instance",
+          // Minutes of lookback — generously covers the whole test run.
+          Duration: 180,
+        })
+        .pipe(
+          Effect.map((response) =>
+            (response.Events ?? []).filter((event) =>
+              /reset master credentials/i.test(event.Message ?? ""),
+            ),
+          ),
+        );
+
+      const created = yield* deployInstance("FingerprintPass1", "one");
+      const createdFingerprint = created.masterUserPasswordFingerprint;
+      expect(createdFingerprint).toBeDefined();
+      // sha256 hex digest — never the password itself.
+      expect(Redacted.value(createdFingerprint!)).toMatch(/^[0-9a-f]{64}$/);
+
+      // Same password, tag-only change → reconcile runs but must skip the
+      // `MasterUserPassword` modify (same fingerprint).
+      const unchanged = yield* deployInstance("FingerprintPass1", "two");
+      expect(unchanged.dbInstanceArn).toBe(created.dbInstanceArn);
+      expect(Redacted.value(unchanged.masterUserPasswordFingerprint!)).toBe(
+        Redacted.value(createdFingerprint!),
+      );
+
+      // Rotation: new password → new fingerprint, and RDS applies a real
+      // master-credentials reset.
+      const rotated = yield* deployInstance("FingerprintPass2", "three");
+      expect(rotated.dbInstanceArn).toBe(created.dbInstanceArn);
+      expect(Redacted.value(rotated.masterUserPasswordFingerprint!)).not.toBe(
+        Redacted.value(createdFingerprint!),
+      );
+
+      // The reset event lands when the modify applies; poll bounded for it,
+      // then assert the count over the whole run is exactly 1 — proving
+      // round "two" (unchanged password) never triggered a reset.
+      const events = yield* resetEvents.pipe(
+        Effect.repeat({
+          schedule: Schedule.spaced("5 seconds"),
+          until: (found) => found.length > 0,
+          times: 36,
+        }),
+      );
+      expect(events).toHaveLength(1);
 
       yield* stack.destroy();
     }),


### PR DESCRIPTION
Follow-up to #876: a live lifecycle test proving the `MasterUserPassword` fingerprint guard on `AWS.RDS.DBInstance`.

AWS never returns the master password, so the guard can't be observed by reading instance state — but RDS durably records a `Reset master credentials` event whenever a password modify actually applies. The test uses that event stream as the out-of-band observable:

1. create a Postgres `db.t3.micro` with password P1
2. redeploy P1 with a tag-only change (forces a reconcile) → fingerprint attribute unchanged
3. rotate to P2 → fingerprint changes; poll until the reset event lands

```ts
// step 3's event anchors the negative assertion for step 2:
// exactly one reset over the whole run ⇒ the unchanged password
// was never re-sent (pre-#876, every reconcile re-sent it)
expect(events).toHaveLength(1);
```

Gated behind `RDS_TEST_LIFECYCLE=1` like the other multi-minute RDS lifecycle tests. Verified live (passed in ~11.5 min including teardown); ungated runs skip it cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
