### PR TITLE
chore(planetscale): restore mysql2 dependency dropped by #887 — unbreaks every PR check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -36,11 +36,6 @@ jobs:
           key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
           restore-keys: bun-${{ runner.os }}-
 
-      # Frozen: CI must install exactly what bun.lock pins. Without it, any
-      # manifest↔lockfile drift makes bun re-resolve on every CI run — which
-      # floated mysql2 to a version the isolated linker failed to link into
-      # packages/alchemy, failing tsc with "Cannot find module 'mysql2/promise'"
-      # on every branch (2026-07-21). Drift now fails loudly at install.
-      - run: bun install --frozen-lockfile
+      - run: bun install
       - run: bun tsc -b
       - run: bun run docs:check

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -36,6 +36,11 @@ jobs:
           key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
           restore-keys: bun-${{ runner.os }}-
 
-      - run: bun install
+      # Frozen: CI must install exactly what bun.lock pins. Without it, any
+      # manifest↔lockfile drift makes bun re-resolve on every CI run — which
+      # floated mysql2 to a version the isolated linker failed to link into
+      # packages/alchemy, failing tsc with "Cannot find module 'mysql2/promise'"
+      # on every branch (2026-07-21). Drift now fails loudly at install.
+      - run: bun install --frozen-lockfile
       - run: bun tsc -b
       - run: bun run docs:check

--- a/bun.lock
+++ b/bun.lock
@@ -1060,6 +1060,7 @@
         "jszip": "^3.10.1",
         "libsodium-wrappers": "^0.8.3",
         "mongodb": "^6.10.0",
+        "mysql2": "^3.15.3",
         "pathe": "^2.0.3",
         "pg": "^8.13.0",
         "picomatch": "^4.0.4",

--- a/packages/alchemy/package.json
+++ b/packages/alchemy/package.json
@@ -337,6 +337,7 @@
     "jszip": "^3.10.1",
     "libsodium-wrappers": "^0.8.3",
     "mongodb": "^6.10.0",
+    "mysql2": "^3.15.3",
     "pathe": "^2.0.3",
     "pg": "^8.13.0",
     "picomatch": "^4.0.4",


### PR DESCRIPTION
Every PR's check job fails tsc with `Cannot find module mysql2/promise` since #887 merged. PR CI builds the merge ref (branch + latest main), and #887 removed `mysql2` from `packages/alchemy`'s dependencies while `Planetscale/MySQL/MySQLMigrations.ts` still statically imports it — so the failure hits every PR regardless of its own content, and local checkouts mask it via stale node_modules links.

```diff
+    "mysql2": "^3.15.3",
```

(+ the matching lockfile entry.) An earlier commit on this branch trialed `--frozen-lockfile` in CI; it is reverted — bun's frozen check reports phantom drift on this workspace even against a lockfile its own resolver reproduces byte-identically, so it cannot be enabled until that upstream bug is fixed.

This PR's own check run is the proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
