### PR TITLE
fix(engine): binding-diff stability — plain-data binding persistence + deterministic sid order

### DIFF
--- a/packages/alchemy/src/Apply.ts
+++ b/packages/alchemy/src/Apply.ts
@@ -412,9 +412,20 @@ const executeNode = (
         // Early commits (`creating`/`replacing`) persist plan props that may
         // still hold unresolved Output exprs; strip them so state stores only
         // plain data (see stripUnresolved in Diff.ts).
+        //
+        // Binding rows follow the same rule. Even the RESOLVED binding
+        // payload can carry Effect leaves — a tagged Worker/Function class in
+        // `env` (the circular-bindings pattern) is a function-typed Effect
+        // that `Output.evaluate` passes through untouched. A JSON state store
+        // would persist it via its `toJSON` as an `{"_id":"Effect",...}`
+        // relic, which the next plan's `diffBindings` compares against the
+        // live class stripped to `undefined` — a phantom binding "update" on
+        // every deploy, forever. Stripping at the commit boundary keeps both
+        // store kinds consistent with the comparison in `havePropsChanged`.
         value: {
           ...value,
           props: stripUnresolved(value.props),
+          bindings: stripUnresolved(value.bindings),
           namespace,
         } as S,
       });
@@ -1437,8 +1448,10 @@ const converge = Effect.fn(function* (
           attr,
           providerVersion: node.provider.version ?? 0,
           // Resolved payload, not raw `node.bindings` — see the create
-          // commit in applyResource.
-          bindings: newBindings,
+          // commit in applyResource. Stripped like the commit helper so
+          // Effect leaves (e.g. tagged Worker classes in `env`) never reach
+          // the state store.
+          bindings: stripUnresolved(newBindings),
           downstream: node.downstream,
           namespace,
           removalPolicy: node.resource.RemovalPolicy,
@@ -1630,10 +1643,11 @@ const collectGarbage = Effect.fn(function* (
             stage,
             fqn,
             // Same rule as the lifecycle commit above: state only stores
-            // plain data, never unresolved Output exprs.
+            // plain data, never unresolved Output exprs or Effect leaves.
             value: {
               ...value,
               props: stripUnresolved(value.props),
+              bindings: stripUnresolved(value.bindings),
               namespace,
             } as S,
           });

--- a/packages/alchemy/src/Diff.ts
+++ b/packages/alchemy/src/Diff.ts
@@ -214,7 +214,26 @@ const canonicalize = (value: unknown, stripNullish: boolean): unknown => {
 };
 
 /**
- * Collapse bindings that share the same `sid`, keeping the last occurrence.
+ * Deterministic ordering for binding rows.
+ *
+ * Bindings are registered by concurrently-built layers (a Function/Worker's
+ * capability layers run real IO — bundling, fs — before calling `host.bind`),
+ * so the registration order of `stack.bindings[fqn]` is not stable across
+ * deploys. `diffBindings` itself is sid-keyed and order-insensitive, but the
+ * row order flows into provider `diff`/`reconcile` inputs and persisted
+ * state — any consumer that hashes or deep-compares the binding array (e.g.
+ * a metadata hash over bindings) would churn on registration-order flips.
+ * Sorting by `sid` at every boundary makes binding rows stable.
+ */
+const bySid = (a: { sid: string }, b: { sid: string }): number =>
+  a.sid < b.sid ? -1 : a.sid > b.sid ? 1 : 0;
+
+export const sortBindings = <B extends { sid: string }>(bindings: B[]): B[] =>
+  [...bindings].sort(bySid);
+
+/**
+ * Collapse bindings that share the same `sid`, keeping the last occurrence,
+ * and return them in deterministic (sid-sorted) order.
  *
  * The same binding can be recorded more than once on a target resource — e.g.
  * a KV namespace bound to both a Worker and a Workflow ends up pushed twice to
@@ -224,7 +243,7 @@ const canonicalize = (value: unknown, stripNullish: boolean): unknown => {
  * binding set, keeping plan-time hashing consistent with deploy-time.
  */
 export const dedupeBindings = <B extends ResourceBinding>(bindings: B[]): B[] =>
-  Array.from(new Map(bindings.map((b) => [b.sid, b])).values());
+  sortBindings(Array.from(new Map(bindings.map((b) => [b.sid, b])).values()));
 
 export const diffBindings = (
   oldBindings: ResourceBinding[],
@@ -232,7 +251,7 @@ export const diffBindings = (
 ): BindingNode[] => {
   const oldMap = new Map(oldBindings.map((b) => [b.sid, b]));
   const newMap = new Map(newBindings.map((b) => [b.sid, b]));
-  return [
+  return sortBindings([
     ...Array.from(oldMap)
       .filter(([sid]) => !newMap.has(sid))
       .map(([sid, old]) => ({
@@ -252,5 +271,5 @@ export const diffBindings = (
         data: binding.data,
       };
     }),
-  ];
+  ]);
 };

--- a/packages/alchemy/src/Plan.ts
+++ b/packages/alchemy/src/Plan.ts
@@ -313,9 +313,11 @@ export const make = <A>(
                   ? oldState.old.props
                   : oldState.props;
 
-              const oldBindings = oldState.bindings ?? [];
-              // Collapse duplicate bindings by sid so the binding set handed to
-              // `diff` matches what `reconcile` receives (see `dedupeBindings`).
+              // Normalize both sides through `dedupeBindings` so the binding
+              // sets handed to `diff` are deduped AND sid-sorted — provider
+              // diffs that hash/compare the arrays never churn on
+              // registration-order flips (or on legacy unsorted state).
+              const oldBindings = dedupeBindings(oldState.bindings ?? []);
               const newBindings = dedupeBindings(
                 stack.bindings[resource.FQN] ?? [],
               );
@@ -802,7 +804,8 @@ export const make = <A>(
               }
             }
 
-            const oldBindings = oldState?.bindings ?? [];
+            // Sid-sorted like `newBindings` (see the resolveResource note).
+            const oldBindings = dedupeBindings(oldState?.bindings ?? []);
             const bindingDiffs = diffBindings(oldBindings, newBindings);
 
             const Node = <T extends Apply>(

--- a/packages/alchemy/test/binding-stability.test.ts
+++ b/packages/alchemy/test/binding-stability.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Binding-diff stability: a deploy with NO changes must produce an all-noop
+ * plan for resources that carry bindings — regardless of the binding data's
+ * shape and regardless of the state store kind.
+ *
+ * The engine's default diff marks a resource "update" whenever any of its
+ * binding rows compares non-noop (`diffBindings` in Diff.ts), so any
+ * asymmetry between what apply persists and what the next plan resolves
+ * re-updates every bound resource on every deploy, forever.
+ *
+ * Two store kinds are exercised:
+ *  - the in-memory store used by the engine tests (retains live values), and
+ *  - a JSON round-tripping store mirroring every durable store (local file,
+ *    S3/R2, HTTP), which serializes state through
+ *    `JSON.stringify(encodeState(...))` + `reviveState`.
+ */
+import { apply } from "@/Apply";
+import { provideFreshArtifactStore } from "@/Artifacts";
+import * as Output from "@/Output";
+import * as Plan from "@/Plan";
+import type { ResourceBinding } from "@/Resource";
+import * as Stack from "@/Stack";
+import { Stage } from "@/Stage";
+import { encodeState, InMemoryService, reviveState, State } from "@/State";
+import * as Test from "@/Test/Alchemy";
+import { describe, expect } from "alchemy-test";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Redacted from "effect/Redacted";
+import {
+  BindingTarget,
+  TestLayers,
+  TestResource,
+  TestResourceHooks,
+} from "./test.resources.ts";
+
+const { test } = Test.make({
+  providers: TestLayers(),
+  state: Layer.effect(
+    State,
+    Effect.sync(() => InMemoryService({})),
+  ),
+});
+
+/**
+ * In-memory state that JSON round-trips every write, mirroring what durable
+ * state stores do to persisted state (function-valued leaves are dropped,
+ * `toJSON`-carrying objects — e.g. Effects — are replaced by their JSON
+ * form, `undefined` keys vanish).
+ */
+const jsonRoundTripState = () => {
+  const roundTrip = <T>(v: T): T =>
+    JSON.parse(JSON.stringify(encodeState(v)), reviveState);
+  const store: Record<string, Record<string, Record<string, any>>> = {};
+  return Layer.effect(
+    State,
+    Effect.sync(() =>
+      State.of(
+        (InMemoryService(store) as Effect.Effect<any>).pipe(
+          Effect.map((svc: any) => ({
+            ...svc,
+            set: (req: any) => svc.set({ ...req, value: roundTrip(req.value) }),
+          })),
+        ) as any,
+      ),
+    ),
+  );
+};
+
+type StoreKind = "in-memory" | "json";
+
+/** Minimal deploy/plan harness over a private state store. */
+const makeHarness = (name: string, kind: StoreKind) => {
+  // One store per harness, shared across the deploy and the follow-up plan
+  // (the layer itself is rebuilt for every Stack.make).
+  const store: Record<string, Record<string, Record<string, any>>> = {};
+  const stateLayer =
+    kind === "json"
+      ? jsonRoundTripState()
+      : Layer.effect(
+          State,
+          Effect.sync(() => InMemoryService(store)),
+        );
+  const compile = (effect: Effect.Effect<any, any, any>) =>
+    (effect as Effect.Effect<any, any, never>).pipe(
+      Stack.make({
+        name,
+        providers: TestLayers() as Layer.Layer<any, never, any>,
+        state: stateLayer,
+      }),
+    );
+  const deploy = (
+    effect: Effect.Effect<any, any, any>,
+  ): Effect.Effect<any, any, never> =>
+    compile(effect).pipe(
+      Effect.flatMap((compiled: any) =>
+        Plan.make(compiled).pipe(
+          Effect.flatMap(apply),
+          Effect.provide(compiled.services),
+        ),
+      ),
+      Effect.provide(Layer.succeed(Stage, "test")),
+      provideFreshArtifactStore,
+    ) as unknown as Effect.Effect<any, any, never>;
+  const plan = (
+    effect: Effect.Effect<any, any, any>,
+  ): Effect.Effect<any, any, never> =>
+    compile(effect).pipe(
+      Effect.flatMap((compiled: any) =>
+        Plan.make(compiled).pipe(Effect.provide(compiled.services)),
+      ),
+      Effect.provide(Layer.succeed(Stage, "test")),
+      provideFreshArtifactStore,
+    ) as unknown as Effect.Effect<any, any, never>;
+  return { deploy, plan };
+};
+
+const expectAllNoop = (plan: any) => {
+  for (const [fqn, node] of Object.entries<any>(plan.resources)) {
+    expect(`${fqn}:${node.action}`).toBe(`${fqn}:noop`);
+    for (const row of node.bindings ?? []) {
+      expect(`${fqn}:${row.sid}:${row.action}`).toBe(`${fqn}:${row.sid}:noop`);
+    }
+  }
+};
+
+/** Each shape deploys once, then asserts the second plan is entirely noop. */
+const shapes: Record<string, () => Effect.Effect<any, any, any>> = {
+  "PropExpr data": () =>
+    Effect.gen(function* () {
+      const upstream = yield* TestResource("Upstream", { string: "up-value" });
+      const target = yield* BindingTarget("Host", { name: "host" });
+      yield* target.bind("Cap", { env: { UPSTREAM: upstream.string } });
+      return target;
+    }),
+  "whole-resource data": () =>
+    Effect.gen(function* () {
+      const upstream = yield* TestResource("Upstream", { string: "up-value" });
+      const target = yield* BindingTarget("Host", { name: "host" });
+      yield* target.bind("Cap", {
+        env: { NAME: upstream.string },
+        resource: upstream,
+      } as any);
+      return target;
+    }),
+  "self-referential data": () =>
+    Effect.gen(function* () {
+      const target = yield* BindingTarget("Host", { name: "host" });
+      yield* target.bind("Self", { env: { ME: target.string } });
+      return target;
+    }),
+  "mapped Output data": () =>
+    Effect.gen(function* () {
+      const upstream = yield* TestResource("Upstream", { string: "up-value" });
+      const target = yield* BindingTarget("Host", { name: "host" });
+      yield* target.bind("Cap", {
+        env: { MAPPED: upstream.string.pipe(Output.map((s) => `${s}-sfx`)) },
+      });
+      return target;
+    }),
+  "Effect-valued data": () =>
+    Effect.gen(function* () {
+      const target = yield* BindingTarget("Host", { name: "host" });
+      yield* target.bind("Cap", {
+        env: { NAME: Effect.succeed("x") },
+      } as any);
+      return target;
+    }),
+  // A tagged Resource class is a function-typed Effect — the standard
+  // circular-binding pattern (`env: { WORKER: WorkerClass }`). It passes
+  // through plan/apply resolution untouched, and a JSON store persists it
+  // via its `toJSON` as an `{"_id":"Effect",...}` relic. Without stripping
+  // at the commit boundary, `diffBindings` compares that relic against the
+  // live class (stripped to `undefined`) — a phantom "update" on every
+  // deploy, forever.
+  "class-valued (Effectable) data": () =>
+    Effect.gen(function* () {
+      const target = yield* BindingTarget("Host", { name: "host" });
+      yield* target.bind("Cap", { env: { PEER: TestResource } } as any);
+      return target;
+    }),
+  "Redacted data": () =>
+    Effect.gen(function* () {
+      const target = yield* BindingTarget("Host", { name: "host" });
+      yield* target.bind("Cap", {
+        env: { SECRET: Redacted.make("shh") },
+      } as any);
+      return target;
+    }),
+  "Duration data": () =>
+    Effect.gen(function* () {
+      const target = yield* BindingTarget("Host", { name: "host" });
+      yield* target.bind("Cap", {
+        env: { TIMEOUT: Duration.seconds(30) },
+      } as any);
+      return target;
+    }),
+  "mutual bindings": () =>
+    Effect.gen(function* () {
+      const A = yield* BindingTarget("A", { name: "a" });
+      const B = yield* BindingTarget("B", { name: "b" });
+      yield* A.bind("FromB", { env: { PEER: B.string } });
+      yield* B.bind("FromA", { env: { PEER: A.string } });
+      return { A, B };
+    }),
+};
+
+for (const kind of ["in-memory", "json"] as StoreKind[]) {
+  describe(`no-change redeploy is all-noop (${kind} state)`, () => {
+    for (const [shape, program] of Object.entries(shapes)) {
+      test(
+        shape,
+        Effect.gen(function* () {
+          const { deploy, plan } = makeHarness(
+            `bind-${kind}-${shape.replaceAll(/[^a-zA-Z0-9]/g, "-")}`,
+            kind,
+          );
+          yield* deploy(program());
+          expectAllNoop(yield* plan(program()));
+        }),
+      );
+    }
+  });
+}
+
+describe("binding rows are deterministically ordered", () => {
+  // Bindings are registered by concurrently-built layers doing real IO before
+  // `host.bind`, so registration order is not stable across deploys. The
+  // engine sorts rows by sid at every boundary (dedupeBindings/diffBindings)
+  // so provider diff/reconcile inputs and persisted state never churn on a
+  // registration-order flip.
+  test(
+    "a registration-order flip stays noop and providers observe sorted rows",
+    Effect.gen(function* () {
+      const { deploy, plan } = makeHarness("bind-order", "in-memory");
+
+      const program = (flipped: boolean) =>
+        Effect.gen(function* () {
+          const target = yield* BindingTarget("Host", { name: "host" });
+          const bindA = target.bind("CapA", { env: { A: "1" } });
+          const bindB = target.bind("CapB", { env: { B: "2" } });
+          if (flipped) {
+            yield* bindB;
+            yield* bindA;
+          } else {
+            yield* bindA;
+            yield* bindB;
+          }
+          return target;
+        });
+
+      yield* deploy(program(false));
+
+      const observed: ResourceBinding[][] = [];
+      const p: any = yield* plan(program(true)).pipe(
+        Effect.provide(
+          Layer.succeed(TestResourceHooks, {
+            diff: (_id, newBindings) =>
+              Effect.sync(() => void observed.push(newBindings)),
+          }),
+        ),
+      );
+
+      expectAllNoop(p);
+      // The provider's diff observed the sid-sorted row order even though
+      // registration order was flipped between deploys.
+      expect(observed.length).toBeGreaterThan(0);
+      for (const rows of observed) {
+        expect(rows.map((r) => r.sid)).toEqual(["CapA", "CapB"]);
+      }
+      // The plan node's rows are sorted too.
+      expect(p.resources.Host.bindings.map((r: any) => r.sid)).toEqual([
+        "CapA",
+        "CapB",
+      ]);
+    }),
+  );
+});
+
+describe("persisted binding rows are plain data", () => {
+  // Mirror of the "interrupted create persists no unresolved Output exprs"
+  // apply test, for bindings: even non-terminal commits must not persist live
+  // Output proxies or Effect leaves into the state store.
+  test(
+    "terminal state holds no live Effect leaves in binding data",
+    Effect.gen(function* () {
+      const store: Record<string, any> = {};
+      const stateLayer = Layer.effect(
+        State,
+        Effect.sync(() => InMemoryService(store)),
+      );
+      const program = Effect.gen(function* () {
+        const target = yield* BindingTarget("Host", { name: "host" });
+        yield* target.bind("Cap", {
+          env: { PEER: TestResource, NAME: Effect.succeed("x") },
+        } as any);
+        return target;
+      });
+      yield* (program as unknown as Effect.Effect<any, any, never>).pipe(
+        Stack.make({
+          name: "bind-plain",
+          providers: TestLayers() as Layer.Layer<any, never, any>,
+          state: stateLayer,
+        }),
+        Effect.flatMap((compiled: any) =>
+          Plan.make(compiled).pipe(
+            Effect.flatMap(apply),
+            Effect.provide(compiled.services),
+          ),
+        ),
+        Effect.provide(Layer.succeed(Stage, "test")),
+        provideFreshArtifactStore,
+      ) as unknown as Effect.Effect<any, any, never>;
+
+      const persisted = store["bind-plain"].test.Host;
+      const hasLiveEffect = (value: unknown): boolean => {
+        if (Effect.isEffect(value)) return true;
+        if (Array.isArray(value)) return value.some(hasLiveEffect);
+        if (value && typeof value === "object") {
+          return Object.values(value).some(hasLiveEffect);
+        }
+        return false;
+      };
+      expect(hasLiveEffect(persisted.bindings)).toBe(false);
+    }),
+  );
+});

--- a/packages/alchemy/test/plan.test.ts
+++ b/packages/alchemy/test/plan.test.ts
@@ -1079,11 +1079,12 @@ describe("duplicate bindings are collapsed by sid before diff", () => {
         { sid: "Shared", data: { env: { K: "last" } } },
       ]);
 
-      // The duplicated sid retains its first-seen position but takes the
-      // last value (matching `diffBindings`' `Map`-based collapse).
+      // The duplicated sid takes the last value (matching `diffBindings`'
+      // `Map`-based collapse) and the result is sid-sorted so binding rows
+      // are deterministic regardless of registration order.
       expect(deduped).toEqual([
-        { sid: "Shared", data: { env: { K: "last" } } },
         { sid: "Other", data: { env: { K: "x" } } },
+        { sid: "Shared", data: { env: { K: "last" } } },
       ]);
     }),
   );


### PR DESCRIPTION
Engine hardening 1/3 (merge in order B1→B2→B3). A no-change redeploy could mark every bound resource "update" forever — binding rows didn't compare stable across deploys.

Two root causes, both at the engine level:

**Persisted binding rows weren't plain data.** A function-typed Effect in binding data — a tagged Worker/Function class in `env`, the standard circular-binding pattern — passes through plan/apply resolution untouched, and durable (JSON) state stores persist it via its `toJSON`:

```jsonc
// what a JSON state store persisted for `env: { WORKER: WorkerClass }`
{ "sid": "Cap", "data": { "env": { "WORKER": { "_id": "Effect", "op": "Resource<...>" } } } }
```

The next plan's `diffBindings` compares that relic against the live class stripped to `undefined` — a phantom binding "update" on every deploy, forever. Apply now strips binding rows at every commit boundary (lifecycle commits, converge, GC), extending the props invariant from #835/#874/#890 to bindings.

**Binding order wasn't deterministic.** Capability layers do real IO concurrently before `host.bind`, so registration order flips across deploys. `dedupeBindings`/`diffBindings` now return sid-sorted rows and Plan normalizes `oldBindings` the same way, so provider `diff`/`reconcile` inputs and persisted rows never churn on an order flip (or hash differently in providers that hash the binding array).

New offline suite `test/binding-stability.test.ts` pins no-change redeploys to all-noop plans across nine binding-data shapes (PropExpr, whole-resource, self-referential, mapped Output, Effect-valued, class-valued, Redacted, Duration, mutual) on both the in-memory store and a JSON round-tripping store, plus the ordering and plain-data invariants.

Note: CI currently has two known, unrelated failures on every branch (mysql2 tsc errors from Planetscale MySQLMigrations; docs build broken /kubernetes link until #892).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
