### PR TITLE
fix(engine): destroy robustness — aggregated GC failures + fatal zombie rows

### DIFF
--- a/packages/alchemy/src/Apply.ts
+++ b/packages/alchemy/src/Apply.ts
@@ -412,9 +412,20 @@ const executeNode = (
         // Early commits (`creating`/`replacing`) persist plan props that may
         // still hold unresolved Output exprs; strip them so state stores only
         // plain data (see stripUnresolved in Diff.ts).
+        //
+        // Binding rows follow the same rule. Even the RESOLVED binding
+        // payload can carry Effect leaves — a tagged Worker/Function class in
+        // `env` (the circular-bindings pattern) is a function-typed Effect
+        // that `Output.evaluate` passes through untouched. A JSON state store
+        // would persist it via its `toJSON` as an `{"_id":"Effect",...}`
+        // relic, which the next plan's `diffBindings` compares against the
+        // live class stripped to `undefined` — a phantom binding "update" on
+        // every deploy, forever. Stripping at the commit boundary keeps both
+        // store kinds consistent with the comparison in `havePropsChanged`.
         value: {
           ...value,
           props: stripUnresolved(value.props),
+          bindings: stripUnresolved(value.bindings),
           namespace,
         } as S,
       });
@@ -1437,8 +1448,10 @@ const converge = Effect.fn(function* (
           attr,
           providerVersion: node.provider.version ?? 0,
           // Resolved payload, not raw `node.bindings` — see the create
-          // commit in applyResource.
-          bindings: newBindings,
+          // commit in applyResource. Stripped like the commit helper so
+          // Effect leaves (e.g. tagged Worker classes in `env`) never reach
+          // the state store.
+          bindings: stripUnresolved(newBindings),
           downstream: node.downstream,
           namespace,
           removalPolicy: node.resource.RemovalPolicy,
@@ -1630,10 +1643,11 @@ const collectGarbage = Effect.fn(function* (
             stage,
             fqn,
             // Same rule as the lifecycle commit above: state only stores
-            // plain data, never unresolved Output exprs.
+            // plain data, never unresolved Output exprs or Effect leaves.
             value: {
               ...value,
               props: stripUnresolved(value.props),
+              bindings: stripUnresolved(value.bindings),
               namespace,
             } as S,
           });

--- a/packages/alchemy/src/Apply.ts
+++ b/packages/alchemy/src/Apply.ts
@@ -31,7 +31,7 @@ import {
   type Delete,
   type Plan,
 } from "./Plan.ts";
-import { missingProviderStub, tryFindProviderByType } from "./Provider.ts";
+import { missingProviderError, tryFindProviderByType } from "./Provider.ts";
 import type { ResourceBinding } from "./Resource.ts";
 import { Stack } from "./Stack.ts";
 import { Stage } from "./Stage.ts";
@@ -1648,12 +1648,21 @@ const collectGarbage = Effect.fn(function* (
               downstream: node.old.downstream,
               props: node.old.props,
               attr: node.old.attr,
-              // Zombie-tolerant lookup — see the deletions builder in
-              // Plan.ts. A missing provider fails THIS row's deletion with
-              // a typed MissingProviderError instead of killing the apply.
-              provider: Option.getOrElse(
-                yield* tryFindProviderByType(node.old.resourceType),
-                () => missingProviderStub(node.old.resourceType, node.fqn),
+              // A missing provider is fatal — plan already dies on zombie
+              // rows (see the deletions builder in Plan.ts); this guards
+              // the replaced-chain generations that bypass plan.
+              provider: yield* tryFindProviderByType(
+                node.old.resourceType,
+              ).pipe(
+                Effect.flatMap(
+                  Option.match({
+                    onNone: () =>
+                      Effect.die(
+                        missingProviderError(node.old.resourceType, node.fqn),
+                      ),
+                    onSome: Effect.succeed,
+                  }),
+                ),
               ),
             };
 

--- a/packages/alchemy/src/Apply.ts
+++ b/packages/alchemy/src/Apply.ts
@@ -24,13 +24,14 @@ import { havePropsChanged, stripUnresolved } from "./Diff.ts";
 import type { Input } from "./Input.ts";
 import { generateInstanceId, InstanceId } from "./InstanceId.ts";
 import * as Output from "./Output.ts";
+import * as Data from "effect/Data";
 import {
   type ActionApply,
   type Apply,
   type Delete,
   type Plan,
 } from "./Plan.ts";
-import { findProviderByType } from "./Provider.ts";
+import { missingProviderStub, tryFindProviderByType } from "./Provider.ts";
 import type { ResourceBinding } from "./Resource.ts";
 import { Stack } from "./Stack.ts";
 import { Stage } from "./Stage.ts";
@@ -1540,6 +1541,19 @@ const converge = Effect.fn(function* (
 
 // ── Phase 2: delete orphans and old replaced resources ─────────────────────
 
+/**
+ * Internal marker: this node's deletion was skipped because a DEPENDENT
+ * resource (one that still references it) failed to delete. The dependent's
+ * own failure is already recorded in the GC failure list, so nodes failing
+ * with ONLY this marker are not re-recorded — they just keep their state so
+ * the next destroy retries the whole chain.
+ */
+class DependentDeletionFailed extends Data.TaggedError(
+  "DependentDeletionFailed",
+)<{
+  fqn: string;
+}> {}
+
 const collectGarbage = Effect.fn(function* (
   plan: Plan,
   session: PlanStatusSession,
@@ -1548,6 +1562,12 @@ const collectGarbage = Effect.fn(function* (
   const stack = yield* Stack;
   const stackName = stack.name;
   const stage = yield* Stage;
+
+  // GC failures are aggregated, never fail-fast: one resource that refuses
+  // to delete must not interrupt sibling deletions mid-flight (which would
+  // leave THEIR physical resources behind too). Every deletable resource is
+  // deleted, then the combined cause is raised at the end.
+  const failures: LifecycleFailure[] = [];
 
   // Task deletions are pure state drops — no body is invoked. Run them in
   // parallel before resource GC; tasks never have provider-side dependencies
@@ -1628,7 +1648,13 @@ const collectGarbage = Effect.fn(function* (
               downstream: node.old.downstream,
               props: node.old.props,
               attr: node.old.attr,
-              provider: yield* findProviderByType(node.old.resourceType),
+              // Zombie-tolerant lookup — see the deletions builder in
+              // Plan.ts. A missing provider fails THIS row's deletion with
+              // a typed MissingProviderError instead of killing the apply.
+              provider: Option.getOrElse(
+                yield* tryFindProviderByType(node.old.resourceType),
+                () => missingProviderStub(node.old.resourceType, node.fqn),
+              ),
             };
 
         // Mutable: an attr-less row (interrupted create) may recover its
@@ -1672,6 +1698,12 @@ const collectGarbage = Effect.fn(function* (
 
         return yield* (deletions[fqn] ??= yield* Effect.cached(
           Effect.gen(function* () {
+            // Dependents (downstream) delete first. When one of them fails,
+            // this resource cannot safely be deleted this pass — its
+            // physical delete would hit a dependency violation. Replace the
+            // propagated cause with the DependentDeletionFailed marker so
+            // the catch below skips the delete WITHOUT re-recording the
+            // dependent's failure (it already recorded itself).
             yield* Effect.all(
               downstream.map((dep) =>
                 dep !== fqn && dep in deletionGraph && !ancestors.has(dep)
@@ -1682,6 +1714,10 @@ const collectGarbage = Effect.fn(function* (
                   : Effect.void,
               ),
               { concurrency: "unbounded" },
+            ).pipe(
+              Effect.catchCause(() =>
+                Effect.fail(new DependentDeletionFailed({ fqn })),
+              ),
             );
 
             if (isDeleteNode(node)) {
@@ -1858,14 +1894,42 @@ const collectGarbage = Effect.fn(function* (
                   : "Replaced resource cleanup complete.",
               );
             }
-          }),
+          }).pipe(
+            Effect.catchCause((cause) =>
+              Effect.gen(function* () {
+                // Record only DIRECT failures. A cause consisting solely of
+                // the DependentDeletionFailed marker means the real failure
+                // was already recorded by the dependent that produced it.
+                const dependentOnly = cause.reasons.every(
+                  (reason) =>
+                    Cause.isFailReason(reason) &&
+                    reason.error instanceof DependentDeletionFailed,
+                );
+                if (!dependentOnly) {
+                  failures.push({
+                    fqn,
+                    logicalId,
+                    type: resourceType,
+                    cause,
+                  });
+                }
+                yield* report("fail");
+                // Keep the cached effect failed so resources that depend on
+                // this one skip their own physical delete too.
+                return yield* Effect.failCause(cause);
+              }),
+            ),
+          ),
         ));
       });
 
+    // Attempt every root. Per-node failures were recorded (and their state
+    // retained) by the catch above — swallow them here so one bad resource
+    // never interrupts sibling deletions mid-flight.
     yield* Effect.all(
       Object.values(deletionGraph)
         .filter((node) => node !== undefined)
-        .map((node) => deleteResource(node)),
+        .map((node) => deleteResource(node).pipe(Effect.ignore)),
       { concurrency: "unbounded" },
     );
   });
@@ -1895,6 +1959,18 @@ const collectGarbage = Effect.fn(function* (
       ),
     });
     first = false;
+    // A failed pass cannot make further progress — the failing rows stay
+    // `replaced`/`deleting` in state, so looping again would spin on the
+    // same failures forever. Stop and surface the aggregate below.
+    if (failures.length > 0) {
+      break;
+    }
+  }
+
+  if (failures.length > 0) {
+    return yield* Effect.failCause(
+      failures.map((f) => f.cause).reduce(Cause.combine),
+    );
   }
 });
 

--- a/packages/alchemy/src/Diff.ts
+++ b/packages/alchemy/src/Diff.ts
@@ -214,7 +214,26 @@ const canonicalize = (value: unknown, stripNullish: boolean): unknown => {
 };
 
 /**
- * Collapse bindings that share the same `sid`, keeping the last occurrence.
+ * Deterministic ordering for binding rows.
+ *
+ * Bindings are registered by concurrently-built layers (a Function/Worker's
+ * capability layers run real IO — bundling, fs — before calling `host.bind`),
+ * so the registration order of `stack.bindings[fqn]` is not stable across
+ * deploys. `diffBindings` itself is sid-keyed and order-insensitive, but the
+ * row order flows into provider `diff`/`reconcile` inputs and persisted
+ * state — any consumer that hashes or deep-compares the binding array (e.g.
+ * a metadata hash over bindings) would churn on registration-order flips.
+ * Sorting by `sid` at every boundary makes binding rows stable.
+ */
+const bySid = (a: { sid: string }, b: { sid: string }): number =>
+  a.sid < b.sid ? -1 : a.sid > b.sid ? 1 : 0;
+
+export const sortBindings = <B extends { sid: string }>(bindings: B[]): B[] =>
+  [...bindings].sort(bySid);
+
+/**
+ * Collapse bindings that share the same `sid`, keeping the last occurrence,
+ * and return them in deterministic (sid-sorted) order.
  *
  * The same binding can be recorded more than once on a target resource — e.g.
  * a KV namespace bound to both a Worker and a Workflow ends up pushed twice to
@@ -224,7 +243,7 @@ const canonicalize = (value: unknown, stripNullish: boolean): unknown => {
  * binding set, keeping plan-time hashing consistent with deploy-time.
  */
 export const dedupeBindings = <B extends ResourceBinding>(bindings: B[]): B[] =>
-  Array.from(new Map(bindings.map((b) => [b.sid, b])).values());
+  sortBindings(Array.from(new Map(bindings.map((b) => [b.sid, b])).values()));
 
 export const diffBindings = (
   oldBindings: ResourceBinding[],
@@ -232,7 +251,7 @@ export const diffBindings = (
 ): BindingNode[] => {
   const oldMap = new Map(oldBindings.map((b) => [b.sid, b]));
   const newMap = new Map(newBindings.map((b) => [b.sid, b]));
-  return [
+  return sortBindings([
     ...Array.from(oldMap)
       .filter(([sid]) => !newMap.has(sid))
       .map(([sid, old]) => ({
@@ -252,5 +271,5 @@ export const diffBindings = (
         data: binding.data,
       };
     }),
-  ];
+  ]);
 };

--- a/packages/alchemy/src/Plan.ts
+++ b/packages/alchemy/src/Plan.ts
@@ -313,9 +313,11 @@ export const make = <A>(
                   ? oldState.old.props
                   : oldState.props;
 
-              const oldBindings = oldState.bindings ?? [];
-              // Collapse duplicate bindings by sid so the binding set handed to
-              // `diff` matches what `reconcile` receives (see `dedupeBindings`).
+              // Normalize both sides through `dedupeBindings` so the binding
+              // sets handed to `diff` are deduped AND sid-sorted — provider
+              // diffs that hash/compare the arrays never churn on
+              // registration-order flips (or on legacy unsorted state).
+              const oldBindings = dedupeBindings(oldState.bindings ?? []);
               const newBindings = dedupeBindings(
                 stack.bindings[resource.FQN] ?? [],
               );
@@ -802,7 +804,8 @@ export const make = <A>(
               }
             }
 
-            const oldBindings = oldState?.bindings ?? [];
+            // Sid-sorted like `newBindings` (see the resolveResource note).
+            const oldBindings = dedupeBindings(oldState?.bindings ?? []);
             const bindingDiffs = diffBindings(oldBindings, newBindings);
 
             const Node = <T extends Apply>(

--- a/packages/alchemy/src/Plan.ts
+++ b/packages/alchemy/src/Plan.ts
@@ -35,7 +35,9 @@ import { generateInstanceId, InstanceId } from "./InstanceId.ts";
 import * as Output from "./Output.ts";
 import {
   findProviderByType,
+  missingProviderStub,
   Provider,
+  tryFindProviderByType,
   type ProviderService,
 } from "./Provider.ts";
 import {
@@ -1287,7 +1289,17 @@ export const make = <A>(
             if (oldState) {
               const { logicalId } = parseFqn(fqn);
               const resourceType = oldState.resourceType;
-              const provider = yield* findProviderByType(resourceType);
+              // A "zombie" row references a type with no registered provider
+              // (removed from the program, or renamed without an alias).
+              // Dying here would block the ENTIRE plan — nothing could be
+              // deployed or destroyed until the row is hand-edited. Plan the
+              // deletion with a stub whose lifecycle fails with a typed
+              // `MissingProviderError` instead, so apply's aggregated GC
+              // destroys everything else and reports the zombie.
+              const provider = Option.getOrElse(
+                yield* tryFindProviderByType(resourceType),
+                () => missingProviderStub(resourceType, fqn),
+              );
               // NOTE: an attr-less row (interrupted create) is NOT recovered
               // here. Apply's `deleteResource` performs the authoritative
               // read-then-delete recovery — it also covers replaced-chain

--- a/packages/alchemy/src/Plan.ts
+++ b/packages/alchemy/src/Plan.ts
@@ -35,7 +35,7 @@ import { generateInstanceId, InstanceId } from "./InstanceId.ts";
 import * as Output from "./Output.ts";
 import {
   findProviderByType,
-  missingProviderStub,
+  missingProviderError,
   Provider,
   tryFindProviderByType,
   type ProviderService,
@@ -1291,15 +1291,17 @@ export const make = <A>(
               const resourceType = oldState.resourceType;
               // A "zombie" row references a type with no registered provider
               // (removed from the program, or renamed without an alias).
-              // Dying here would block the ENTIRE plan — nothing could be
-              // deployed or destroyed until the row is hand-edited. Plan the
-              // deletion with a stub whose lifecycle fails with a typed
-              // `MissingProviderError` instead, so apply's aggregated GC
-              // destroys everything else and reports the zombie.
-              const provider = Option.getOrElse(
-                yield* tryFindProviderByType(resourceType),
-                () => missingProviderStub(resourceType, fqn),
-              );
+              // That is fatal: the program and state disagree, and without
+              // the provider the row's physical resource cannot be deleted
+              // anyway. Die at plan time with a typed error naming the row
+              // and the remediation instead of limping into a partial apply.
+              const providerOption = yield* tryFindProviderByType(resourceType);
+              if (Option.isNone(providerOption)) {
+                return yield* Effect.die(
+                  missingProviderError(resourceType, fqn),
+                );
+              }
+              const provider = providerOption.value;
               // NOTE: an attr-less row (interrupted create) is NOT recovered
               // here. Apply's `deleteResource` performs the authoritative
               // read-then-delete recovery — it also covers replaced-chain

--- a/packages/alchemy/src/Provider.ts
+++ b/packages/alchemy/src/Provider.ts
@@ -507,9 +507,11 @@ export const findProvider: {
  * provider — the type was removed from the program (or renamed without an
  * alias) while its state row still exists ("zombie" row).
  *
- * Raised from the row's delete lifecycle at APPLY time (never at plan time)
- * so a destroy/deploy still processes every other resource and surfaces the
- * zombie through the aggregated failure.
+ * This is FATAL at plan time: the program and state fundamentally disagree,
+ * and without the provider the row's physical resource cannot be deleted
+ * anyway, so proceeding would only strand it silently. The plan dies with
+ * this error; nothing is deployed or destroyed until the provider is
+ * re-registered (or aliased), or the state row is cleared manually.
  */
 export class MissingProviderError extends Data.TaggedError(
   "MissingProviderError",
@@ -519,37 +521,22 @@ export class MissingProviderError extends Data.TaggedError(
   fqn: string;
 }> {}
 
-/**
- * Stand-in {@link ProviderService} for a state row whose resource type has
- * no registered provider (see {@link MissingProviderError}). Every lifecycle
- * operation fails with the typed error; the engine's delete path keeps the
- * row so a later run — with the provider re-registered or aliased — can
- * reclaim the physical resource.
- */
-export const missingProviderStub = (
+/** Build the fatal plan-time error for a zombie state row. */
+export const missingProviderError = (
   resourceType: string,
   fqn: string,
-): ProviderService => {
-  const fail = Effect.fail(
-    new MissingProviderError({
-      message:
-        `No provider is registered for resource type '${resourceType}' ` +
-        `(state row '${fqn}'). The type was removed from the program or ` +
-        "renamed without an alias. Re-register the provider (or add the " +
-        "old name to the resource's `aliases`) so this row can be " +
-        "destroyed, or clear the state row manually if the physical " +
-        "resource is already gone.",
-      resourceType,
-      fqn,
-    }),
-  );
-  return {
-    list: () => fail as Effect.Effect<never>,
-    read: () => fail,
-    reconcile: () => fail as Effect.Effect<never>,
-    delete: () => fail,
-  };
-};
+): MissingProviderError =>
+  new MissingProviderError({
+    message:
+      `No provider is registered for resource type '${resourceType}' ` +
+      `(state row '${fqn}'). The type was removed from the program or ` +
+      "renamed without an alias. Re-register the provider (or add the " +
+      "old name to the resource's `aliases`) so this row can be " +
+      "destroyed, or clear the state row manually if the physical " +
+      "resource is already gone.",
+    resourceType,
+    fqn,
+  });
 
 export const tryFindProviderByType: {
   <R extends ResourceLike>(

--- a/packages/alchemy/src/Provider.ts
+++ b/packages/alchemy/src/Provider.ts
@@ -1,4 +1,5 @@
 import * as Context from "effect/Context";
+import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
@@ -500,6 +501,55 @@ export const findProvider: {
   ): Effect.Effect<ProviderService<R>>;
 } = (resource: { Type?: string; key?: string }) =>
   findProviderByType((resource.Type ?? resource.key) as string) as any;
+
+/**
+ * A persisted state row references a resource type with no registered
+ * provider — the type was removed from the program (or renamed without an
+ * alias) while its state row still exists ("zombie" row).
+ *
+ * Raised from the row's delete lifecycle at APPLY time (never at plan time)
+ * so a destroy/deploy still processes every other resource and surfaces the
+ * zombie through the aggregated failure.
+ */
+export class MissingProviderError extends Data.TaggedError(
+  "MissingProviderError",
+)<{
+  message: string;
+  resourceType: string;
+  fqn: string;
+}> {}
+
+/**
+ * Stand-in {@link ProviderService} for a state row whose resource type has
+ * no registered provider (see {@link MissingProviderError}). Every lifecycle
+ * operation fails with the typed error; the engine's delete path keeps the
+ * row so a later run — with the provider re-registered or aliased — can
+ * reclaim the physical resource.
+ */
+export const missingProviderStub = (
+  resourceType: string,
+  fqn: string,
+): ProviderService => {
+  const fail = Effect.fail(
+    new MissingProviderError({
+      message:
+        `No provider is registered for resource type '${resourceType}' ` +
+        `(state row '${fqn}'). The type was removed from the program or ` +
+        "renamed without an alias. Re-register the provider (or add the " +
+        "old name to the resource's `aliases`) so this row can be " +
+        "destroyed, or clear the state row manually if the physical " +
+        "resource is already gone.",
+      resourceType,
+      fqn,
+    }),
+  );
+  return {
+    list: () => fail as Effect.Effect<never>,
+    read: () => fail,
+    reconcile: () => fail as Effect.Effect<never>,
+    delete: () => fail,
+  };
+};
 
 export const tryFindProviderByType: {
   <R extends ResourceLike>(

--- a/packages/alchemy/test/binding-stability.test.ts
+++ b/packages/alchemy/test/binding-stability.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Binding-diff stability: a deploy with NO changes must produce an all-noop
+ * plan for resources that carry bindings — regardless of the binding data's
+ * shape and regardless of the state store kind.
+ *
+ * The engine's default diff marks a resource "update" whenever any of its
+ * binding rows compares non-noop (`diffBindings` in Diff.ts), so any
+ * asymmetry between what apply persists and what the next plan resolves
+ * re-updates every bound resource on every deploy, forever.
+ *
+ * Two store kinds are exercised:
+ *  - the in-memory store used by the engine tests (retains live values), and
+ *  - a JSON round-tripping store mirroring every durable store (local file,
+ *    S3/R2, HTTP), which serializes state through
+ *    `JSON.stringify(encodeState(...))` + `reviveState`.
+ */
+import { apply } from "@/Apply";
+import { provideFreshArtifactStore } from "@/Artifacts";
+import * as Output from "@/Output";
+import * as Plan from "@/Plan";
+import type { ResourceBinding } from "@/Resource";
+import * as Stack from "@/Stack";
+import { Stage } from "@/Stage";
+import { encodeState, InMemoryService, reviveState, State } from "@/State";
+import * as Test from "@/Test/Alchemy";
+import { describe, expect } from "alchemy-test";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Redacted from "effect/Redacted";
+import {
+  BindingTarget,
+  TestLayers,
+  TestResource,
+  TestResourceHooks,
+} from "./test.resources.ts";
+
+const { test } = Test.make({
+  providers: TestLayers(),
+  state: Layer.effect(
+    State,
+    Effect.sync(() => InMemoryService({})),
+  ),
+});
+
+/**
+ * In-memory state that JSON round-trips every write, mirroring what durable
+ * state stores do to persisted state (function-valued leaves are dropped,
+ * `toJSON`-carrying objects — e.g. Effects — are replaced by their JSON
+ * form, `undefined` keys vanish).
+ */
+const jsonRoundTripState = () => {
+  const roundTrip = <T>(v: T): T =>
+    JSON.parse(JSON.stringify(encodeState(v)), reviveState);
+  const store: Record<string, Record<string, Record<string, any>>> = {};
+  return Layer.effect(
+    State,
+    Effect.sync(() =>
+      State.of(
+        (InMemoryService(store) as Effect.Effect<any>).pipe(
+          Effect.map((svc: any) => ({
+            ...svc,
+            set: (req: any) => svc.set({ ...req, value: roundTrip(req.value) }),
+          })),
+        ) as any,
+      ),
+    ),
+  );
+};
+
+type StoreKind = "in-memory" | "json";
+
+/** Minimal deploy/plan harness over a private state store. */
+const makeHarness = (name: string, kind: StoreKind) => {
+  // One store per harness, shared across the deploy and the follow-up plan
+  // (the layer itself is rebuilt for every Stack.make).
+  const store: Record<string, Record<string, Record<string, any>>> = {};
+  const stateLayer =
+    kind === "json"
+      ? jsonRoundTripState()
+      : Layer.effect(
+          State,
+          Effect.sync(() => InMemoryService(store)),
+        );
+  const compile = (effect: Effect.Effect<any, any, any>) =>
+    (effect as Effect.Effect<any, any, never>).pipe(
+      Stack.make({
+        name,
+        providers: TestLayers() as Layer.Layer<any, never, any>,
+        state: stateLayer,
+      }),
+    );
+  const deploy = (
+    effect: Effect.Effect<any, any, any>,
+  ): Effect.Effect<any, any, never> =>
+    compile(effect).pipe(
+      Effect.flatMap((compiled: any) =>
+        Plan.make(compiled).pipe(
+          Effect.flatMap(apply),
+          Effect.provide(compiled.services),
+        ),
+      ),
+      Effect.provide(Layer.succeed(Stage, "test")),
+      provideFreshArtifactStore,
+    ) as unknown as Effect.Effect<any, any, never>;
+  const plan = (
+    effect: Effect.Effect<any, any, any>,
+  ): Effect.Effect<any, any, never> =>
+    compile(effect).pipe(
+      Effect.flatMap((compiled: any) =>
+        Plan.make(compiled).pipe(Effect.provide(compiled.services)),
+      ),
+      Effect.provide(Layer.succeed(Stage, "test")),
+      provideFreshArtifactStore,
+    ) as unknown as Effect.Effect<any, any, never>;
+  return { deploy, plan };
+};
+
+const expectAllNoop = (plan: any) => {
+  for (const [fqn, node] of Object.entries<any>(plan.resources)) {
+    expect(`${fqn}:${node.action}`).toBe(`${fqn}:noop`);
+    for (const row of node.bindings ?? []) {
+      expect(`${fqn}:${row.sid}:${row.action}`).toBe(`${fqn}:${row.sid}:noop`);
+    }
+  }
+};
+
+/** Each shape deploys once, then asserts the second plan is entirely noop. */
+const shapes: Record<string, () => Effect.Effect<any, any, any>> = {
+  "PropExpr data": () =>
+    Effect.gen(function* () {
+      const upstream = yield* TestResource("Upstream", { string: "up-value" });
+      const target = yield* BindingTarget("Host", { name: "host" });
+      yield* target.bind("Cap", { env: { UPSTREAM: upstream.string } });
+      return target;
+    }),
+  "whole-resource data": () =>
+    Effect.gen(function* () {
+      const upstream = yield* TestResource("Upstream", { string: "up-value" });
+      const target = yield* BindingTarget("Host", { name: "host" });
+      yield* target.bind("Cap", {
+        env: { NAME: upstream.string },
+        resource: upstream,
+      } as any);
+      return target;
+    }),
+  "self-referential data": () =>
+    Effect.gen(function* () {
+      const target = yield* BindingTarget("Host", { name: "host" });
+      yield* target.bind("Self", { env: { ME: target.string } });
+      return target;
+    }),
+  "mapped Output data": () =>
+    Effect.gen(function* () {
+      const upstream = yield* TestResource("Upstream", { string: "up-value" });
+      const target = yield* BindingTarget("Host", { name: "host" });
+      yield* target.bind("Cap", {
+        env: { MAPPED: upstream.string.pipe(Output.map((s) => `${s}-sfx`)) },
+      });
+      return target;
+    }),
+  "Effect-valued data": () =>
+    Effect.gen(function* () {
+      const target = yield* BindingTarget("Host", { name: "host" });
+      yield* target.bind("Cap", {
+        env: { NAME: Effect.succeed("x") },
+      } as any);
+      return target;
+    }),
+  // A tagged Resource class is a function-typed Effect — the standard
+  // circular-binding pattern (`env: { WORKER: WorkerClass }`). It passes
+  // through plan/apply resolution untouched, and a JSON store persists it
+  // via its `toJSON` as an `{"_id":"Effect",...}` relic. Without stripping
+  // at the commit boundary, `diffBindings` compares that relic against the
+  // live class (stripped to `undefined`) — a phantom "update" on every
+  // deploy, forever.
+  "class-valued (Effectable) data": () =>
+    Effect.gen(function* () {
+      const target = yield* BindingTarget("Host", { name: "host" });
+      yield* target.bind("Cap", { env: { PEER: TestResource } } as any);
+      return target;
+    }),
+  "Redacted data": () =>
+    Effect.gen(function* () {
+      const target = yield* BindingTarget("Host", { name: "host" });
+      yield* target.bind("Cap", {
+        env: { SECRET: Redacted.make("shh") },
+      } as any);
+      return target;
+    }),
+  "Duration data": () =>
+    Effect.gen(function* () {
+      const target = yield* BindingTarget("Host", { name: "host" });
+      yield* target.bind("Cap", {
+        env: { TIMEOUT: Duration.seconds(30) },
+      } as any);
+      return target;
+    }),
+  "mutual bindings": () =>
+    Effect.gen(function* () {
+      const A = yield* BindingTarget("A", { name: "a" });
+      const B = yield* BindingTarget("B", { name: "b" });
+      yield* A.bind("FromB", { env: { PEER: B.string } });
+      yield* B.bind("FromA", { env: { PEER: A.string } });
+      return { A, B };
+    }),
+};
+
+for (const kind of ["in-memory", "json"] as StoreKind[]) {
+  describe(`no-change redeploy is all-noop (${kind} state)`, () => {
+    for (const [shape, program] of Object.entries(shapes)) {
+      test(
+        shape,
+        Effect.gen(function* () {
+          const { deploy, plan } = makeHarness(
+            `bind-${kind}-${shape.replaceAll(/[^a-zA-Z0-9]/g, "-")}`,
+            kind,
+          );
+          yield* deploy(program());
+          expectAllNoop(yield* plan(program()));
+        }),
+      );
+    }
+  });
+}
+
+describe("binding rows are deterministically ordered", () => {
+  // Bindings are registered by concurrently-built layers doing real IO before
+  // `host.bind`, so registration order is not stable across deploys. The
+  // engine sorts rows by sid at every boundary (dedupeBindings/diffBindings)
+  // so provider diff/reconcile inputs and persisted state never churn on a
+  // registration-order flip.
+  test(
+    "a registration-order flip stays noop and providers observe sorted rows",
+    Effect.gen(function* () {
+      const { deploy, plan } = makeHarness("bind-order", "in-memory");
+
+      const program = (flipped: boolean) =>
+        Effect.gen(function* () {
+          const target = yield* BindingTarget("Host", { name: "host" });
+          const bindA = target.bind("CapA", { env: { A: "1" } });
+          const bindB = target.bind("CapB", { env: { B: "2" } });
+          if (flipped) {
+            yield* bindB;
+            yield* bindA;
+          } else {
+            yield* bindA;
+            yield* bindB;
+          }
+          return target;
+        });
+
+      yield* deploy(program(false));
+
+      const observed: ResourceBinding[][] = [];
+      const p: any = yield* plan(program(true)).pipe(
+        Effect.provide(
+          Layer.succeed(TestResourceHooks, {
+            diff: (_id, newBindings) =>
+              Effect.sync(() => void observed.push(newBindings)),
+          }),
+        ),
+      );
+
+      expectAllNoop(p);
+      // The provider's diff observed the sid-sorted row order even though
+      // registration order was flipped between deploys.
+      expect(observed.length).toBeGreaterThan(0);
+      for (const rows of observed) {
+        expect(rows.map((r) => r.sid)).toEqual(["CapA", "CapB"]);
+      }
+      // The plan node's rows are sorted too.
+      expect(p.resources.Host.bindings.map((r: any) => r.sid)).toEqual([
+        "CapA",
+        "CapB",
+      ]);
+    }),
+  );
+});
+
+describe("persisted binding rows are plain data", () => {
+  // Mirror of the "interrupted create persists no unresolved Output exprs"
+  // apply test, for bindings: even non-terminal commits must not persist live
+  // Output proxies or Effect leaves into the state store.
+  test(
+    "terminal state holds no live Effect leaves in binding data",
+    Effect.gen(function* () {
+      const store: Record<string, any> = {};
+      const stateLayer = Layer.effect(
+        State,
+        Effect.sync(() => InMemoryService(store)),
+      );
+      const program = Effect.gen(function* () {
+        const target = yield* BindingTarget("Host", { name: "host" });
+        yield* target.bind("Cap", {
+          env: { PEER: TestResource, NAME: Effect.succeed("x") },
+        } as any);
+        return target;
+      });
+      yield* (program as unknown as Effect.Effect<any, any, never>).pipe(
+        Stack.make({
+          name: "bind-plain",
+          providers: TestLayers() as Layer.Layer<any, never, any>,
+          state: stateLayer,
+        }),
+        Effect.flatMap((compiled: any) =>
+          Plan.make(compiled).pipe(
+            Effect.flatMap(apply),
+            Effect.provide(compiled.services),
+          ),
+        ),
+        Effect.provide(Layer.succeed(Stage, "test")),
+        provideFreshArtifactStore,
+      ) as unknown as Effect.Effect<any, any, never>;
+
+      const persisted = store["bind-plain"].test.Host;
+      const hasLiveEffect = (value: unknown): boolean => {
+        if (Effect.isEffect(value)) return true;
+        if (Array.isArray(value)) return value.some(hasLiveEffect);
+        if (value && typeof value === "object") {
+          return Object.values(value).some(hasLiveEffect);
+        }
+        return false;
+      };
+      expect(hasLiveEffect(persisted.bindings)).toBe(false);
+    }),
+  );
+});

--- a/packages/alchemy/test/destroy-robustness.test.ts
+++ b/packages/alchemy/test/destroy-robustness.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Destroy robustness: a destroy (or the GC phase of a deploy) must delete
+ * everything it can, aggregate every failure, and never let one bad row
+ * block the rest of the teardown.
+ *
+ *  - a failing provider `delete` must not interrupt sibling deletions
+ *  - an upstream's delete is skipped (state retained) when a dependent fails
+ *  - a "zombie" state row whose resource type has no registered provider
+ *    (the type was removed/renamed without an alias) must not crash planning
+ *    — everything else is destroyed and the zombie surfaces as a typed
+ *    `MissingProviderError` in the aggregated failure
+ *  - an attr-less row whose `read` recovery fails must not block siblings
+ */
+import { MissingProviderError } from "@/Provider";
+import { Stack } from "@/Stack";
+import { State, type ResourceState } from "@/State";
+import * as Test from "@/Test/Alchemy";
+import { describe, expect } from "alchemy-test";
+import * as Cause from "effect/Cause";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Layer from "effect/Layer";
+import {
+  TestLayers,
+  TestResource,
+  TestResourceHooks,
+} from "./test.resources.ts";
+
+const { test } = Test.make({ providers: TestLayers() });
+
+const getState = Effect.fn(function* (fqn: string) {
+  const state = yield* yield* State;
+  const stk = yield* Stack;
+  return yield* state.get({ stack: stk.name, stage: stk.stage, fqn });
+});
+
+const seed = Effect.fn(function* (fqn: string, value: ResourceState) {
+  const state = yield* yield* State;
+  const stk = yield* Stack;
+  yield* state.set({ stack: stk.name, stage: stk.stage, fqn, value });
+});
+
+const instanceId = "852f6ec2e19b66589825efe14dca2971";
+
+const hooks = (impl: {
+  delete?: (id: string) => Effect.Effect<void, any>;
+  read?: (id: string) => Effect.Effect<any, any>;
+}): Layer.Layer<TestResourceHooks> => Layer.succeed(TestResourceHooks, impl);
+
+const failsWith = (exit: Exit.Exit<unknown, unknown>, tag: string): boolean =>
+  Exit.isFailure(exit) &&
+  exit.cause.reasons.some(
+    (r) =>
+      Cause.isFailReason(r) &&
+      (r.error as { _tag?: string } | undefined)?._tag === tag,
+  );
+
+describe("destroy aggregates failures", () => {
+  test.provider(
+    "a failing delete does not interrupt sibling deletions",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.deploy(
+          Effect.gen(function* () {
+            yield* TestResource("A", { string: "a" });
+            yield* TestResource("B", { string: "b" });
+            yield* TestResource("C", { string: "c" });
+          }),
+        );
+
+        const exit = yield* stack.destroy().pipe(
+          Effect.provide(
+            hooks({
+              delete: (id) =>
+                id === "A"
+                  ? Effect.fail(new Error("A refuses to die"))
+                  : id === "B"
+                    ? // Slow sibling: before aggregation, A's failure
+                      // interrupted B mid-delete and left its row behind.
+                      Effect.sleep("150 millis")
+                    : Effect.void,
+            }),
+          ),
+          Effect.exit,
+        );
+
+        // The destroy still fails overall...
+        expect(Exit.isFailure(exit)).toBe(true);
+        // ...but every deletable resource was deleted.
+        expect(yield* getState("B")).toBeUndefined();
+        expect(yield* getState("C")).toBeUndefined();
+        // The failed row keeps its state for the next attempt.
+        expect((yield* getState("A"))?.status).toBe("deleting");
+      }),
+  );
+
+  test.provider(
+    "an upstream's delete is skipped when a dependent fails",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.deploy(
+          Effect.gen(function* () {
+            const a = yield* TestResource("A", { string: "a" });
+            yield* TestResource("B", { string: a.string });
+          }),
+        );
+
+        const deleted: string[] = [];
+        const exit = yield* stack.destroy().pipe(
+          Effect.provide(
+            hooks({
+              delete: (id) =>
+                id === "B"
+                  ? Effect.fail(new Error("B refuses to die"))
+                  : Effect.sync(() => void deleted.push(id)),
+            }),
+          ),
+          Effect.exit,
+        );
+
+        expect(Exit.isFailure(exit)).toBe(true);
+        // A still has a dependent in the cloud — its physical delete must
+        // not have been attempted and its state must be retained.
+        expect(deleted).not.toContain("A");
+        expect(yield* getState("A")).toBeDefined();
+        expect(yield* getState("B")).toBeDefined();
+      }),
+  );
+
+  test.provider(
+    "an attr-less row with failing read recovery does not block siblings",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.deploy(
+          Effect.gen(function* () {
+            yield* TestResource("A", { string: "a" });
+          }),
+        );
+        // An interrupted create: `creating` with no attr snapshot.
+        yield* seed("Zombie", {
+          instanceId,
+          providerVersion: 0,
+          logicalId: "Zombie",
+          fqn: "Zombie",
+          namespace: undefined,
+          resourceType: "Test.TestResource",
+          status: "creating",
+          props: { string: "z" },
+          attr: undefined,
+          bindings: [],
+          downstream: [],
+        });
+
+        const exit = yield* stack.destroy().pipe(
+          Effect.provide(
+            hooks({
+              read: () => Effect.fail(new Error("read exploded")),
+              // Slow sibling so a fail-fast interruption would be observable.
+              delete: () => Effect.sleep("150 millis"),
+            }),
+          ),
+          Effect.exit,
+        );
+
+        expect(Exit.isFailure(exit)).toBe(true);
+        expect(yield* getState("A")).toBeUndefined();
+        // The unrecoverable row is retained, not silently dropped.
+        expect(yield* getState("Zombie")).toBeDefined();
+      }),
+  );
+});
+
+describe("zombie rows (no registered provider)", () => {
+  const ghostRow = (fqn: string): ResourceState => ({
+    instanceId,
+    providerVersion: 0,
+    logicalId: fqn,
+    fqn,
+    namespace: undefined,
+    resourceType: "Test.Vanished",
+    status: "created",
+    props: { name: "ghost" },
+    attr: { name: "ghost" },
+    bindings: [],
+    downstream: [],
+  });
+
+  test.provider(
+    "destroy deletes everything else and reports the zombie",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.deploy(
+          Effect.gen(function* () {
+            yield* TestResource("A", { string: "a" });
+          }),
+        );
+        yield* seed("Ghost", ghostRow("Ghost"));
+
+        const exit = yield* stack.destroy().pipe(Effect.exit);
+
+        expect(failsWith(exit, "MissingProviderError")).toBe(true);
+        if (Exit.isFailure(exit)) {
+          const reason = exit.cause.reasons.find(
+            (r) =>
+              Cause.isFailReason(r) && r.error instanceof MissingProviderError,
+          );
+          expect(
+            reason && Cause.isFailReason(reason)
+              ? (reason.error as MissingProviderError).resourceType
+              : undefined,
+          ).toBe("Test.Vanished");
+        }
+        // Everything with a provider was destroyed.
+        expect(yield* getState("A")).toBeUndefined();
+        // The zombie row is retained so re-registering the provider (or an
+        // alias) lets a later destroy reclaim the physical resource.
+        expect(yield* getState("Ghost")).toBeDefined();
+      }),
+  );
+
+  test.provider(
+    "a deploy with a zombie orphan still applies the program",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* seed("Ghost", ghostRow("Ghost"));
+
+        const exit = yield* stack
+          .deploy(
+            Effect.gen(function* () {
+              const a = yield* TestResource("A", { string: "a" });
+              return a.string;
+            }),
+          )
+          .pipe(Effect.exit);
+
+        // The zombie orphan fails the deploy's GC phase...
+        expect(failsWith(exit, "MissingProviderError")).toBe(true);
+        // ...but the program's resources were still applied.
+        expect((yield* getState("A"))?.status).toBe("created");
+        expect(yield* getState("Ghost")).toBeDefined();
+      }),
+  );
+});

--- a/packages/alchemy/test/destroy-robustness.test.ts
+++ b/packages/alchemy/test/destroy-robustness.test.ts
@@ -6,9 +6,10 @@
  *  - a failing provider `delete` must not interrupt sibling deletions
  *  - an upstream's delete is skipped (state retained) when a dependent fails
  *  - a "zombie" state row whose resource type has no registered provider
- *    (the type was removed/renamed without an alias) must not crash planning
- *    — everything else is destroyed and the zombie surfaces as a typed
- *    `MissingProviderError` in the aggregated failure
+ *    (the type was removed/renamed without an alias) is FATAL at plan time:
+ *    the plan dies with a typed `MissingProviderError` and nothing is
+ *    deployed or destroyed — the program and state disagree, and without
+ *    the provider the row cannot be deleted anyway
  *  - an attr-less row whose `read` recovery fails must not block siblings
  */
 import { MissingProviderError } from "@/Provider";
@@ -32,6 +33,12 @@ const getState = Effect.fn(function* (fqn: string) {
   const state = yield* yield* State;
   const stk = yield* Stack;
   return yield* state.get({ stack: stk.name, stage: stk.stage, fqn });
+});
+
+const clearState = Effect.fn(function* (fqn: string) {
+  const state = yield* yield* State;
+  const stk = yield* Stack;
+  yield* state.delete({ stack: stk.name, stage: stk.stage, fqn });
 });
 
 const seed = Effect.fn(function* (fqn: string, value: ResourceState) {
@@ -185,41 +192,46 @@ describe("zombie rows (no registered provider)", () => {
     downstream: [],
   });
 
-  test.provider(
-    "destroy deletes everything else and reports the zombie",
-    (stack) =>
-      Effect.gen(function* () {
-        yield* stack.deploy(
-          Effect.gen(function* () {
-            yield* TestResource("A", { string: "a" });
-          }),
-        );
-        yield* seed("Ghost", ghostRow("Ghost"));
+  const diesWithMissingProvider = (
+    exit: Exit.Exit<unknown, unknown>,
+  ): MissingProviderError | undefined => {
+    if (!Exit.isFailure(exit)) return undefined;
+    const reason = exit.cause.reasons.find(
+      (r) => Cause.isDieReason(r) && r.defect instanceof MissingProviderError,
+    );
+    return reason && Cause.isDieReason(reason)
+      ? (reason.defect as MissingProviderError)
+      : undefined;
+  };
 
-        const exit = yield* stack.destroy().pipe(Effect.exit);
+  test.provider("destroy dies at plan time and destroys nothing", (stack) =>
+    Effect.gen(function* () {
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          yield* TestResource("A", { string: "a" });
+        }),
+      );
+      yield* seed("Ghost", ghostRow("Ghost"));
 
-        expect(failsWith(exit, "MissingProviderError")).toBe(true);
-        if (Exit.isFailure(exit)) {
-          const reason = exit.cause.reasons.find(
-            (r) =>
-              Cause.isFailReason(r) && r.error instanceof MissingProviderError,
-          );
-          expect(
-            reason && Cause.isFailReason(reason)
-              ? (reason.error as MissingProviderError).resourceType
-              : undefined,
-          ).toBe("Test.Vanished");
-        }
-        // Everything with a provider was destroyed.
-        expect(yield* getState("A")).toBeUndefined();
-        // The zombie row is retained so re-registering the provider (or an
-        // alias) lets a later destroy reclaim the physical resource.
-        expect(yield* getState("Ghost")).toBeDefined();
-      }),
+      const exit = yield* stack.destroy().pipe(Effect.exit);
+
+      const defect = diesWithMissingProvider(exit);
+      expect(defect?.resourceType).toBe("Test.Vanished");
+      expect(defect?.fqn).toBe("Ghost");
+      // Fatal at plan time: NOTHING was destroyed — A's state is intact.
+      expect((yield* getState("A"))?.status).toBe("created");
+      expect(yield* getState("Ghost")).toBeDefined();
+
+      // Remediation path: clear the zombie row (as the error message
+      // instructs), then destroy proceeds normally.
+      yield* clearState("Ghost");
+      yield* stack.destroy();
+      expect(yield* getState("A")).toBeUndefined();
+    }),
   );
 
   test.provider(
-    "a deploy with a zombie orphan still applies the program",
+    "a deploy with a zombie orphan dies at plan time and applies nothing",
     (stack) =>
       Effect.gen(function* () {
         yield* seed("Ghost", ghostRow("Ghost"));
@@ -233,11 +245,14 @@ describe("zombie rows (no registered provider)", () => {
           )
           .pipe(Effect.exit);
 
-        // The zombie orphan fails the deploy's GC phase...
-        expect(failsWith(exit, "MissingProviderError")).toBe(true);
-        // ...but the program's resources were still applied.
-        expect((yield* getState("A"))?.status).toBe("created");
+        expect(diesWithMissingProvider(exit)?.resourceType).toBe(
+          "Test.Vanished",
+        );
+        // Fatal at plan time: the program was NOT applied.
+        expect(yield* getState("A")).toBeUndefined();
         expect(yield* getState("Ghost")).toBeDefined();
+
+        yield* clearState("Ghost");
       }),
   );
 });

--- a/packages/alchemy/test/plan.test.ts
+++ b/packages/alchemy/test/plan.test.ts
@@ -1079,11 +1079,12 @@ describe("duplicate bindings are collapsed by sid before diff", () => {
         { sid: "Shared", data: { env: { K: "last" } } },
       ]);
 
-      // The duplicated sid retains its first-seen position but takes the
-      // last value (matching `diffBindings`' `Map`-based collapse).
+      // The duplicated sid takes the last value (matching `diffBindings`'
+      // `Map`-based collapse) and the result is sid-sorted so binding rows
+      // are deterministic regardless of registration order.
       expect(deduped).toEqual([
-        { sid: "Shared", data: { env: { K: "last" } } },
         { sid: "Other", data: { env: { K: "x" } } },
+        { sid: "Shared", data: { env: { K: "last" } } },
       ]);
     }),
   );

--- a/packages/alchemy/test/plan.test.ts
+++ b/packages/alchemy/test/plan.test.ts
@@ -3348,6 +3348,44 @@ describe("type aliases", () => {
   });
 });
 
+describe("zombie rows", () => {
+  // A state row whose resource type has no registered provider (the type
+  // was removed from the program, or renamed without an alias). Planning
+  // must not die — the row becomes a normal deletion node whose lifecycle
+  // fails with a typed MissingProviderError at APPLY time, so everything
+  // else still deploys/destroys (see destroy-robustness.test.ts).
+  test(
+    "a row whose resource type has no provider still plans",
+    Effect.gen(function* () {
+      yield* seed({
+        Ghost: {
+          instanceId,
+          providerVersion: 0,
+          logicalId: "Ghost",
+          fqn: "Ghost",
+          namespace: undefined,
+          resourceType: "Test.Vanished",
+          status: "created",
+          props: { name: "ghost" },
+          attr: { name: "ghost" },
+          bindings: [],
+          downstream: [],
+        },
+      });
+      const plan = yield* makePlan(
+        Effect.gen(function* () {
+          yield* Bucket("Survivor", { name: "survivor" });
+        }),
+      );
+      expect(plan.resources.Survivor?.action).toBe("create");
+      expect(plan.deletions.Ghost).toMatchObject({
+        action: "delete",
+        resource: { LogicalId: "Ghost", Type: "Test.Vanished" },
+      });
+    }),
+  );
+});
+
 describe("read is never handed unresolved persisted props", () => {
   // A failed create persists `creating` state carrying the RAW plan-time
   // props, which may contain unresolved Output expressions (e.g. a prop

--- a/packages/alchemy/test/plan.test.ts
+++ b/packages/alchemy/test/plan.test.ts
@@ -3350,12 +3350,13 @@ describe("type aliases", () => {
 
 describe("zombie rows", () => {
   // A state row whose resource type has no registered provider (the type
-  // was removed from the program, or renamed without an alias). Planning
-  // must not die — the row becomes a normal deletion node whose lifecycle
-  // fails with a typed MissingProviderError at APPLY time, so everything
-  // else still deploys/destroys (see destroy-robustness.test.ts).
+  // was removed from the program, or renamed without an alias) is FATAL:
+  // the program and state disagree, and without the provider the row's
+  // physical resource cannot be deleted anyway. Planning dies with a typed
+  // MissingProviderError naming the row and the remediation (see
+  // destroy-robustness.test.ts for the deploy/destroy behavior).
   test(
-    "a row whose resource type has no provider still plans",
+    "a row whose resource type has no provider fails the plan",
     Effect.gen(function* () {
       yield* seed({
         Ghost: {
@@ -3372,16 +3373,27 @@ describe("zombie rows", () => {
           downstream: [],
         },
       });
-      const plan = yield* makePlan(
+      const exit = yield* makePlan(
         Effect.gen(function* () {
           yield* Bucket("Survivor", { name: "survivor" });
         }),
-      );
-      expect(plan.resources.Survivor?.action).toBe("create");
-      expect(plan.deletions.Ghost).toMatchObject({
-        action: "delete",
-        resource: { LogicalId: "Ghost", Type: "Test.Vanished" },
-      });
+      ).pipe(Effect.exit);
+
+      expect(Exit.isFailure(exit)).toBe(true);
+      const defect = Exit.isFailure(exit)
+        ? exit.cause.reasons.find(
+            (r) =>
+              Cause.isDieReason(r) &&
+              r.defect instanceof Provider.MissingProviderError,
+          )
+        : undefined;
+      expect(defect && Cause.isDieReason(defect)).toBe(true);
+      if (defect && Cause.isDieReason(defect)) {
+        const error = defect.defect as Provider.MissingProviderError;
+        expect(error.resourceType).toBe("Test.Vanished");
+        expect(error.fqn).toBe("Ghost");
+        expect(error.message).toContain("aliases");
+      }
     }),
   );
 });


### PR DESCRIPTION
Engine hardening 2/3 — based on `claude/engine-binding-diff-stability`; merge in order B1→B2→B3. Destroy (and the GC phase of a deploy) previously failed fast; now it deletes everything it can and aggregates every failure.

- One failing provider `delete` interrupted every sibling deletion mid-flight, leaving their physical resources and state rows behind. `collectGarbage` now records per-resource failures, keeps deleting, and raises the combined cause at the end. An upstream whose dependent failed skips its own physical delete (state retained) via an internal `DependentDeletionFailed` marker, without double-recording the cause.
- A "zombie" state row — a `resourceType` with no registered provider (type removed from the program, or renamed without an alias) — is **fatal at plan time**. The program and state fundamentally disagree, and without the provider the row's physical resource cannot be deleted anyway, so nothing is deployed or destroyed. Previously this died deep inside `findProviderByType` with a bare string; the plan now dies up front with a typed error naming the row and the remediation:

```ts
export class MissingProviderError extends Data.TaggedError("MissingProviderError")<{
  message: string; // includes remediation: re-register / alias / clear the row
  resourceType: string;
  fqn: string;
}> {}
```

- The replaced-chain drain loop stops after a failed pass instead of spinning forever on rows that cannot make progress.

New offline suite `test/destroy-robustness.test.ts`: sibling non-interruption, dependent-failure skip, failing attr-less `read` recovery, and zombie fatality on both destroy and deploy — including the remediation path (clear the row → destroy proceeds); `plan.test.ts` pins that a zombie row fails the plan with `resourceType`/`fqn`/remediation intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
