### PR TITLE
docs(website): dead d1/sqlclient reference link — unbreaks docs:check

### DIFF
--- a/website/src/content/docs/cloudflare/data/d1-drizzle.mdx
+++ b/website/src/content/docs/cloudflare/data/d1-drizzle.mdx
@@ -248,4 +248,4 @@ Reference:
 
 - [Schema](/providers/drizzle/schema) ·
   [D1](/providers/drizzle/d1) ·
-  [SqlClient](/providers/cloudflare/d1/sqlclient)
+  [Database](/providers/cloudflare/d1/database)


### PR DESCRIPTION
`SqlClient` is `effect/unstable/sql`'s interface, not an alchemy resource — no reference page is generated for it, so the case-sensitive link check fails every PR's docs build since #887. Points the reference row at the D1 `Database` page instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
