### PR TITLE
test(cloudflare): container test race — per-suite fixture identities

### DIFF
--- a/examples/cloudflare-agent/src/ClaudeCode.ts
+++ b/examples/cloudflare-agent/src/ClaudeCode.ts
@@ -1,9 +1,0 @@
-import * as Cloudflare from "alchemy/Cloudflare";
-
-export class ClaudeCode extends Cloudflare.Container("ClaudeCode", {
-  dockerfile: `
-    FROM alpine:latest
-    RUN curl -fsSL https://claude.ai/install.sh | bash
-  `,
-  context: ".",
-}) {}

--- a/examples/cloudflare-worker-async/alchemy.run.ts
+++ b/examples/cloudflare-worker-async/alchemy.run.ts
@@ -18,14 +18,6 @@ export const Counter = Cloudflare.DurableObject<CounterClass>("Counter", {
   className: "Counter",
 });
 
-export const ClaudeCode = Cloudflare.Container("ClaudeCode", {
-  dockerfile: `
-    FROM alpine:latest
-    RUN curl -fsSL https://claude.ai/install.sh | bash
-  `,
-  context: ".",
-});
-
 export type WorkerEnv = Cloudflare.InferEnv<typeof Worker>;
 
 export const Worker = Cloudflare.Worker("Worker", {

--- a/examples/cloudflare-worker-async/src/object.ts
+++ b/examples/cloudflare-worker-async/src/object.ts
@@ -1,8 +1,0 @@
-import { DurableObject } from "cloudflare:workers";
-import type { WorkerEnv } from "../alchemy.run.ts";
-
-export class ClaudeCode extends DurableObject {
-  constructor(state: DurableObjectState, env: WorkerEnv) {
-    super(state, env);
-  }
-}

--- a/packages/alchemy/test/Cloudflare/Container/fixtures/remote/local-object.ts
+++ b/packages/alchemy/test/Cloudflare/Container/fixtures/remote/local-object.ts
@@ -1,0 +1,48 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as Effect from "effect/Effect";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+
+/**
+ * Local-dev twin of `object.ts` with its own logical ids so
+ * `LocalContainer.test.ts` never shares a container application, Durable
+ * Object namespace, or worker with the live `Container.test.ts` deployment
+ * when the two files run concurrently.
+ */
+export class LocalRemoteContainer extends Cloudflare.Container<LocalRemoteContainer>()(
+  "LocalRemoteContainer",
+  {
+    image: "mendhak/http-https-echo:latest",
+    observability: { logs: { enabled: true } },
+  },
+) {}
+
+/**
+ * Durable Object that binds and starts the {@link LocalRemoteContainer} and
+ * proxies an HTTP request to the echo server running on port 8080 inside it.
+ */
+export class LocalRemoteContainerObject extends Cloudflare.DurableObject<LocalRemoteContainerObject>()(
+  "LocalRemoteContainerObject",
+  Effect.gen(function* () {
+    const container = yield* LocalRemoteContainer;
+
+    return Effect.gen(function* () {
+      const { fetch } = yield* container.getTcpPort(8080);
+
+      return {
+        hello: () =>
+          Effect.gen(function* () {
+            const response = yield* fetch(
+              HttpClientRequest.get("http://container/"),
+            );
+            return yield* response.text;
+          }),
+      };
+    });
+  }).pipe(
+    Effect.provide(
+      Cloudflare.Containers.layer(LocalRemoteContainer, {
+        enableInternet: true,
+      }),
+    ),
+  ),
+) {}

--- a/packages/alchemy/test/Cloudflare/Container/fixtures/remote/local-stack.ts
+++ b/packages/alchemy/test/Cloudflare/Container/fixtures/remote/local-stack.ts
@@ -1,18 +1,21 @@
 import * as Cloudflare from "@/Cloudflare";
 import * as Alchemy from "@/index.ts";
 import * as Effect from "effect/Effect";
-import RemoteContainerWorker from "./worker.ts";
+import LocalRemoteContainerWorker from "./local-worker.ts";
 
 /**
- * Same worker/DO/container arrangement as `stack.ts`, under a distinct stack
- * name so the local-dev test (`LocalContainer.test.ts`) never shares state
- * with the live `Container.test.ts` deployment.
+ * Same worker/DO/container arrangement as `stack.ts`, but under a distinct
+ * stack name AND a distinct fixture identity (`local-worker.ts` /
+ * `local-object.ts` — LocalRemoteContainer* logical ids) so the local-dev
+ * test (`LocalContainer.test.ts`) never shares state, a container
+ * application, or a workers.dev worker with the live `Container.test.ts`
+ * deployment when the two files run concurrently.
  */
 export default Alchemy.Stack(
   "LocalRemoteContainerStack",
   { providers: Cloudflare.providers(), state: Cloudflare.state() },
   Effect.gen(function* () {
-    const worker = yield* RemoteContainerWorker;
+    const worker = yield* LocalRemoteContainerWorker;
     return { url: worker.url.as<string>() };
   }),
 );

--- a/packages/alchemy/test/Cloudflare/Container/fixtures/remote/local-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Container/fixtures/remote/local-worker.ts
@@ -1,0 +1,43 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as Effect from "effect/Effect";
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import { LocalRemoteContainerObject } from "./local-object.ts";
+
+/**
+ * Local-dev twin of `worker.ts` with its own logical id — see
+ * `local-object.ts` for why the local suite owns a separate fixture identity.
+ */
+export default class LocalRemoteContainerWorker extends Cloudflare.Worker<LocalRemoteContainerWorker>()(
+  "LocalRemoteContainerWorker",
+  {
+    main: import.meta.url,
+  },
+  Effect.gen(function* () {
+    const objects = yield* LocalRemoteContainerObject;
+
+    return {
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        const url = new URL(request.url, "http://x");
+
+        if (url.pathname === "/hello") {
+          const text = yield* objects.getByName("default").hello();
+          return HttpServerResponse.text(text);
+        }
+
+        return HttpServerResponse.text("ok");
+      }).pipe(
+        Effect.catchTag("HttpClientError", (err) =>
+          Effect.succeed(
+            err.response
+              ? HttpServerResponse.fromClientResponse(err.response)
+              : HttpServerResponse.text(err.message, {
+                  status: 500,
+                }),
+          ),
+        ),
+      ),
+    };
+  }),
+) {}


### PR DESCRIPTION
Fix the Cloudflare container test race and remove dead ClaudeCode dockerfile-content usages.

`Container.test.ts` and `LocalContainer.test.ts` deployed the same shared fixture modules (`fixtures/remote/worker.ts` → `object.ts`), so both files raced on identical `RemoteContainer` / `RemoteContainerObject` / `RemoteContainerWorker` resource identities when run concurrently (the default) — both remote-image tests failed with `not ready: 500`. The local suite now owns its own fixture identity:

```
fixtures/remote/local-object.ts   # LocalRemoteContainer + LocalRemoteContainerObject
fixtures/remote/local-worker.ts   # LocalRemoteContainerWorker
fixtures/remote/local-stack.ts    # now imports local-worker.ts
```

Also removes dead `dockerfile: "<content>"`-style ClaudeCode leftovers from the container redesign:

- `examples/cloudflare-worker-async/alchemy.run.ts` — unused `ClaudeCode` container const
- `examples/cloudflare-worker-async/src/object.ts` — unreferenced DO class
- `examples/cloudflare-agent/src/ClaudeCode.ts` — unreferenced container class

🤖 Generated with [Claude Code](https://claude.com/claude-code)
