### PR TITLE
feat(cloudflare/workers): support entrypoint on raw service binding specs in Worker env

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
@@ -34,7 +34,11 @@ import { isRateLimit } from "./RateLimit.ts";
 import { isVersionMetadata } from "./VersionMetadata.ts";
 import type { WorkerBindingProps } from "./Worker.ts";
 import { isWorker, type Worker, type WorkerProps } from "./Worker.ts";
-import type { WorkerBinding, WorkerBindingResource } from "./WorkerBinding.ts";
+import {
+  isServiceBindingSpec,
+  type WorkerBinding,
+  type WorkerBindingResource,
+} from "./WorkerBinding.ts";
 import { isWorkerLoader } from "./WorkerLoader.ts";
 
 export const bindWorkerAsyncBindings = Effect.fn(function* (
@@ -266,6 +270,17 @@ const toBinding = (
       type: "service",
       name: bindingName,
       service: binding.workerName,
+    };
+  } else if (isServiceBindingSpec(binding)) {
+    // Raw service-binding spec: bind a Worker by script name (possibly one
+    // managed outside this stack) and, when given, target a named
+    // `WorkerEntrypoint` class / environment on it.
+    return {
+      type: "service",
+      name: bindingName,
+      service: binding.service,
+      entrypoint: binding.entrypoint,
+      environment: binding.environment,
     };
   } else if (isIndex(binding)) {
     return {

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerBinding.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerBinding.ts
@@ -61,11 +61,63 @@ export type WorkerSettingsBinding = Exclude<
   null | undefined
 >[number];
 
+/**
+ * Raw service-binding descriptor for binding a Worker by script name —
+ * including Workers managed outside this stack — with an optional named
+ * `entrypoint` class (a `WorkerEntrypoint` RPC target) and `environment`.
+ *
+ * Declaring a service binding as a {@link Worker} resource always targets the
+ * script's default export, so a fleet whose scripts expose several named
+ * `WorkerEntrypoint` classes cannot address the non-default ones. This spec
+ * fills that gap: it passes straight through to the Workers API
+ * service-binding metadata, which accepts `entrypoint`/`environment`.
+ *
+ * @example
+ * ```ts
+ * const worker = yield* Cloudflare.Worker("api", {
+ *   env: {
+ *     BILLING: {
+ *       $binding: "service",
+ *       service: "billing-worker",
+ *       entrypoint: "BillingRpc",
+ *     },
+ *   },
+ * });
+ * ```
+ */
+export interface ServiceBindingSpec {
+  /** Discriminant marking this object as a raw service-binding descriptor. */
+  readonly $binding: "service";
+  /** Name of the target Worker script to bind to. */
+  readonly service: string;
+  /**
+   * Optional named `WorkerEntrypoint` class on the target script. When
+   * omitted, the binding targets the script's default export.
+   */
+  readonly entrypoint?: string;
+  /** Optional target environment on the bound service. */
+  readonly environment?: string;
+}
+
+/**
+ * Type guard for {@link ServiceBindingSpec} — matches any object carrying the
+ * `$binding: "service"` discriminant and a `service` script name.
+ */
+export const isServiceBindingSpec = (
+  value: unknown,
+): value is ServiceBindingSpec =>
+  typeof value === "object" &&
+  value !== null &&
+  (value as ServiceBindingSpec).$binding === "service" &&
+  typeof (value as ServiceBindingSpec).service === "string";
+
 export type WorkerBindingResource =
   // Config values
   | Json
   | Redacted.Redacted<Json>
   | Config.Config<Json>
+  // Raw service-binding descriptor (entrypoint-capable)
+  | ServiceBindingSpec
   // CF resources
   | Assets
   | Bucket

--- a/packages/alchemy/test/Cloudflare/Workers/ServiceBindingSpec.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/ServiceBindingSpec.test.ts
@@ -1,0 +1,40 @@
+import { isServiceBindingSpec } from "@/Cloudflare/Workers/WorkerBinding.ts";
+import { describe, expect, it } from "alchemy-test";
+
+// `isServiceBindingSpec` is the discriminator that routes a raw
+// `{ $binding: "service", ... }` env entry to the entrypoint-capable service
+// binding branch in `toBinding`. A pure guard — no cloud credentials needed.
+describe("isServiceBindingSpec", () => {
+  it("matches a bare service spec", () => {
+    expect(isServiceBindingSpec({ $binding: "service", service: "api" })).toBe(
+      true,
+    );
+  });
+
+  it("matches a spec carrying entrypoint and environment", () => {
+    expect(
+      isServiceBindingSpec({
+        $binding: "service",
+        service: "billing-worker",
+        entrypoint: "BillingRpc",
+        environment: "production",
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects a spec without a service name", () => {
+    expect(isServiceBindingSpec({ $binding: "service" })).toBe(false);
+  });
+
+  it("rejects a different $binding discriminant", () => {
+    expect(isServiceBindingSpec({ $binding: "kv", service: "api" })).toBe(
+      false,
+    );
+  });
+
+  it("rejects non-object values", () => {
+    expect(isServiceBindingSpec(null)).toBe(false);
+    expect(isServiceBindingSpec(undefined)).toBe(false);
+    expect(isServiceBindingSpec("api")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Motivation

A service binding declared as a `Cloudflare.Worker` resource always targets the bound script's **default export**. That leaves no way to address a **named `WorkerEntrypoint` class** on the target script — the standard Cloudflare pattern for exposing several RPC surfaces from one Worker (`export class BillingRpc extends WorkerEntrypoint { … }`). A multi-worker Cloudflare deployment using named entrypoint RPC targets therefore cannot express its fleet's bindings in Alchemy today.

The Workers platform already supports this: the script-upload service-binding metadata accepts `entrypoint` and `environment`, and the `@distilled.cloud/cloudflare` `service` binding variant already types both as `entrypoint?: string | null` / `environment?: string | null`. Nothing in the Worker `env` surface emits them.

## Change

Two additive pieces, both in `src/Cloudflare/Workers`:

1. **`WorkerBinding.ts`** — a new exported `ServiceBindingSpec` interface (`{ $binding: "service"; service: string; entrypoint?: string; environment?: string }`), an `isServiceBindingSpec` type guard, and the spec added to the `WorkerBindingResource` union. A Worker's `env` can now carry a raw service-binding descriptor directly:

   ```ts
   const worker = yield* Cloudflare.Worker("api", {
     env: {
       BILLING: {
         $binding: "service",
         service: "billing-worker",
         entrypoint: "BillingRpc",
       },
     },
   });
   ```

2. **`WorkerAsyncBindings.ts`** — a new `isServiceBindingSpec` branch in `toBinding`, right after the existing `isWorker` branch, emitting `{ type: "service", name, service, entrypoint, environment }`. `entrypoint` and `environment` pass straight through (both optional); omitting `entrypoint` preserves today's default-export behavior.

## Notes

- **Backwards-compatible / additive.** No existing binding path changes; the `Cloudflare.Worker`-as-binding shape (`isWorker`) is untouched and still emits `{ type: "service", service }` with no entrypoint.
- **`environment` passthrough.** The spec also forwards the wire schema's `environment` field for parity, defaulting to the bound service's default environment when omitted.

## Tests

Added `test/Cloudflare/Workers/ServiceBindingSpec.test.ts` — a pure unit test for the `isServiceBindingSpec` guard (matches bare / entrypoint+environment specs, rejects missing `service`, other `$binding` discriminants, and non-objects), in the offline `describe`/`it` style of `test/Cloudflare/Fetcher.test.ts` (no cloud credentials required).

The existing service-binding integration tests (`test/Cloudflare/Workers/WorkerBinding.test.ts`) deploy live Workers and hit `workers.dev` URLs, so an end-to-end test that a named entrypoint resolves at runtime would need live Cloudflare credentials; I've left that out of this PR. `toBinding` is not exported, so the guard test is the isolated-unit seam for this change.

`bun tsc -b packages/alchemy` and the test tsconfig both typecheck clean.
