### PR TITLE
test(github): migrate #845 tests off vitest — unbreaks main tsc

### DIFF
--- a/packages/alchemy/test/GitHub/BaseUrl.test.ts
+++ b/packages/alchemy/test/GitHub/BaseUrl.test.ts
@@ -9,7 +9,7 @@ import { gitHubBaseUrlChanged, octokitFor } from "@/GitHub/Octokit";
 import * as ConfigProvider from "effect/ConfigProvider";
 import * as Effect from "effect/Effect";
 import * as Result from "effect/Result";
-import { describe, expect, test } from "vitest";
+import { describe, expect, test } from "alchemy-test";
 
 const normalize = (input: string) =>
   Effect.runSync(normalizeGitHubBaseUrl(input));

--- a/packages/alchemy/test/GitHub/Environment.test.ts
+++ b/packages/alchemy/test/GitHub/Environment.test.ts
@@ -2,8 +2,8 @@ import * as GitHub from "@/GitHub";
 import { Octokit } from "@/GitHub/Octokit.ts";
 import * as Output from "@/Output";
 import { destroy } from "@/RemovalPolicy";
-import * as Test from "@/Test/Vitest";
-import { expect } from "@effect/vitest";
+import * as Test from "@/Test/Alchemy";
+import { expect } from "alchemy-test";
 import * as Effect from "effect/Effect";
 import { MinimumLogLevel } from "effect/References";
 


### PR DESCRIPTION
#845 branched before the vitest removal and merged with `test/GitHub/*.test.ts` importing `vitest` / `@/Test/Vitest` / `@effect/vitest` — none of which exist anymore — so `bun tsc -b` fails on main and on every PR's merge-ref check. Applied the standard `scripts/codemod-alchemy-test.ts` migration (2 files); tsc is fully clean and all 6 GitHub test files import/register under alchemy-test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
