### PR TITLE
fix(cloudflare/workers): retry asset upload session when completion JWT is missing

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/Assets.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Assets.ts
@@ -4,6 +4,7 @@ import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
+import * as Schedule from "effect/Schedule";
 import type { PlatformError } from "effect/PlatformError";
 import type { ScopedPlanStatusSession } from "../../Cli/Cli.ts";
 import { sha256, sha256Object } from "../../Util/index.ts";
@@ -65,6 +66,13 @@ export class FailedToReadAssetError extends Data.TaggedError(
   message: string;
   name: string;
   cause: PlatformError;
+}> {}
+
+export class AssetUploadSessionError extends Data.TaggedError(
+  "AssetUploadSessionError",
+)<{
+  message: string;
+  workerName: string;
 }> {}
 
 const getContentType = (name: string) => {
@@ -204,70 +212,112 @@ export const uploadAssets = Effect.fn(function* (
   const createScriptAssetUpload = yield* workers.createScriptAssetUpload;
   const createAssetUpload = yield* workers.createAssetUpload;
 
-  yield* note("Checking assets...");
-  const session = yield* createScriptAssetUpload({
-    accountId,
-    scriptName: workerName,
-    manifest: assets.manifest,
-  });
-  if (!session.buckets?.length) {
-    return { jwt: session.jwt ?? undefined };
-  }
-  if (!session.jwt) {
-    return { jwt: undefined };
-  }
-  const uploadJwt = session.jwt;
-  let uploaded = 0;
-  const total = session.buckets.flat().length;
-  yield* note(`Uploaded ${uploaded} of ${total} assets...`);
   const assetsByHash = new Map<string, string>();
   for (const [name, { hash }] of Object.entries(assets.manifest)) {
     assetsByHash.set(hash, name);
   }
-  let jwt: string | undefined | null;
   const directory = path.resolve(assets.directory);
-  yield* Effect.forEach(
-    session.buckets,
-    Effect.fn(function* (bucket) {
-      const body: Record<string, File> = {};
-      yield* Effect.forEach(
-        bucket,
-        Effect.fn(function* (hash) {
-          const name = assetsByHash.get(hash);
-          if (!name) {
-            return yield* new AssetNotFoundError({
-              message: `Asset ${hash} not found in manifest`,
-              hash,
-            });
-          }
-          const file = yield* fs.readFile(path.join(directory, name)).pipe(
-            Effect.mapError(
-              (error) =>
-                new FailedToReadAssetError({
-                  message: `Failed to read asset ${name}: ${error.message}`,
-                  name,
-                  cause: error,
-                }),
-            ),
-          );
-          body[hash] = new File([Buffer.from(file).toString("base64")], hash, {
-            type: getContentType(name),
-          });
-        }),
-      );
-      const result = yield* createAssetUpload({
-        accountId,
-        base64: true,
-        body,
-        jwtToken: uploadJwt,
-      });
 
-      uploaded += bucket.length;
-      yield* note(`Uploaded ${uploaded} of ${total} assets...`);
-      if (result.jwt) {
-        jwt = result.jwt;
+  // One full upload session: ask Cloudflare which assets are missing,
+  // upload each bucket, and return the completion JWT that putWorker
+  // must redeem. The session JWT can expire mid-upload on very large
+  // asset sets (Unauthorized), and the final bucket response has been
+  // observed in the wild to omit the completion JWT — both cases are
+  // retried below with a fresh session. Already-uploaded assets are
+  // not re-bucketed, so a retry resumes where the last session
+  // stopped, and a fresh session with nothing left to upload returns
+  // the completion JWT directly.
+  const runSession = Effect.fn(function* () {
+    yield* note("Checking assets...");
+    const session = yield* createScriptAssetUpload({
+      accountId,
+      scriptName: workerName,
+      manifest: assets.manifest,
+    });
+    if (!session.buckets?.length) {
+      if (!session.jwt) {
+        return yield* new AssetUploadSessionError({
+          message: `Asset upload session for worker ${workerName} returned no completion token`,
+          workerName,
+        });
       }
+      return session.jwt;
+    }
+    if (!session.jwt) {
+      return yield* new AssetUploadSessionError({
+        message: `Asset upload session for worker ${workerName} returned ${session.buckets.length} buckets to upload but no upload token`,
+        workerName,
+      });
+    }
+    const uploadJwt = session.jwt;
+    let uploaded = 0;
+    const total = session.buckets.flat().length;
+    yield* note(`Uploaded ${uploaded} of ${total} assets...`);
+    let jwt: string | undefined | null;
+    yield* Effect.forEach(
+      session.buckets,
+      Effect.fn(function* (bucket) {
+        const body: Record<string, File> = {};
+        yield* Effect.forEach(
+          bucket,
+          Effect.fn(function* (hash) {
+            const name = assetsByHash.get(hash);
+            if (!name) {
+              return yield* new AssetNotFoundError({
+                message: `Asset ${hash} not found in manifest`,
+                hash,
+              });
+            }
+            const file = yield* fs.readFile(path.join(directory, name)).pipe(
+              Effect.mapError(
+                (error) =>
+                  new FailedToReadAssetError({
+                    message: `Failed to read asset ${name}: ${error.message}`,
+                    name,
+                    cause: error,
+                  }),
+              ),
+            );
+            body[hash] = new File(
+              [Buffer.from(file).toString("base64")],
+              hash,
+              {
+                type: getContentType(name),
+              },
+            );
+          }),
+        );
+        const result = yield* createAssetUpload({
+          accountId,
+          base64: true,
+          body,
+          jwtToken: uploadJwt,
+        });
+
+        uploaded += bucket.length;
+        yield* note(`Uploaded ${uploaded} of ${total} assets...`);
+        if (result.jwt) {
+          jwt = result.jwt;
+        }
+      }),
+    );
+    if (!jwt) {
+      return yield* new AssetUploadSessionError({
+        message: `Uploaded ${total} assets for worker ${workerName} but Cloudflare did not return a completion token`,
+        workerName,
+      });
+    }
+    return jwt;
+  });
+
+  const jwt = yield* runSession().pipe(
+    Effect.retry({
+      while: (error): boolean =>
+        error._tag === "Unauthorized" ||
+        error._tag === "AssetUploadSessionError",
+      schedule: Schedule.exponential("1 second"),
+      times: 3,
     }),
   );
-  return { jwt: jwt ?? undefined };
+  return { jwt };
 });


### PR DESCRIPTION
`uploadAssets` could finish uploading every bucket and still return `{ jwt: undefined }` when no bucket response carried the completion JWT (observed in actions run 29860893544: 16,496 assets over ~19 minutes). The provider then called `putWorker` with an `ASSETS` binding but `assets: { jwt: undefined, config }`, failing with the opaque `BadRequest: Cannot use an assets binding without assets`.

The upload is now a retryable session pass with typed failures:

```ts
const jwt = yield* runSession().pipe(
  Effect.retry({
    while: (error): boolean =>
      error._tag === "Unauthorized" ||
      error._tag === "AssetUploadSessionError",
    schedule: Schedule.exponential("1 second"),
    times: 3,
  }),
);
return { jwt }; // now always a string
```

- New `AssetUploadSessionError` raised whenever a session ends without the token `putWorker` needs: no completion token with nothing to upload, buckets but no upload token, or the upload loop finishing without a completion token (the observed case).
- Retrying starts a fresh `createScriptAssetUpload` session — already-uploaded assets aren't re-bucketed, so a retry resumes where the last session stopped, and a session with nothing left returns the completion JWT directly.
- `Unauthorized` in the retry predicate covers the session JWT expiring during very long uploads (mirrors wrangler's re-request-on-401); it's already a typed tag in every distilled operation's error union.
- If retries exhaust, the descriptive typed error propagates instead of the opaque `putWorker` failure.

Verified live: all 4 assets tests in `test/Cloudflare/Workers/Worker.test.ts` pass (`bun run test test/Cloudflare/Workers/Worker.test.ts -t "assets" --profile testing`). The failure mode itself (Cloudflare omitting the completion JWT) can't be provoked from a live deploy, so no new test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
