### PR TITLE
fix: use distilled auto-paginating streams for multi-page list calls

### DIFF
--- a/packages/alchemy/src/AWS/ACM/Certificate.ts
+++ b/packages/alchemy/src/AWS/ACM/Certificate.ts
@@ -225,18 +225,21 @@ export const CertificateProvider = () =>
         id: string,
         props: CertificateProps,
       ) {
-        const listed = yield* withCertRegion(props.region)(
-          acm.listCertificates({
-            Includes: {
-              keyTypes: props.keyAlgorithm ? [props.keyAlgorithm] : undefined,
-            },
-          } as any),
+        const summaries = yield* withCertRegion(props.region)(
+          acm.listCertificates
+            .items({
+              Includes: {
+                keyTypes: props.keyAlgorithm ? [props.keyAlgorithm] : undefined,
+              },
+            } as any)
+            .pipe(
+              Stream.filter(
+                (summary) => summary.DomainName === props.domainName,
+              ),
+              Stream.runCollect,
+              Effect.map((chunk) => Array.from(chunk)),
+            ),
         );
-
-        const summaries =
-          listed.CertificateSummaryList?.filter(
-            (summary) => summary.DomainName === props.domainName,
-          ) ?? [];
 
         for (const summary of summaries) {
           if (!summary.CertificateArn) {

--- a/packages/alchemy/src/AWS/ACM/Certificate.ts
+++ b/packages/alchemy/src/AWS/ACM/Certificate.ts
@@ -2,6 +2,7 @@ import { Region as AwsRegion } from "@distilled.cloud/aws/Region";
 import * as acm from "@distilled.cloud/aws/acm";
 import * as route53 from "@distilled.cloud/aws/route-53";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
 import { deepEqual, isResolved } from "../../Diff.ts";
@@ -225,7 +226,9 @@ export const CertificateProvider = () =>
         id: string,
         props: CertificateProps,
       ) {
-        const summaries = yield* withCertRegion(props.region)(
+        // Describe candidates lazily as pages stream in and stop at the first
+        // match, so pagination terminates early instead of draining every page.
+        return yield* withCertRegion(props.region)(
           acm.listCertificates
             .items({
               Includes: {
@@ -236,42 +239,49 @@ export const CertificateProvider = () =>
               Stream.filter(
                 (summary) => summary.DomainName === props.domainName,
               ),
-              Stream.runCollect,
-              Effect.map((chunk) => Array.from(chunk)),
+              Stream.mapEffect((summary) =>
+                Effect.gen(function* () {
+                  if (!summary.CertificateArn) {
+                    return undefined;
+                  }
+                  const detail = yield* describeCertificate(
+                    summary.CertificateArn,
+                  );
+                  if (!detail?.CertificateArn) {
+                    return undefined;
+                  }
+                  if (
+                    detail.DomainName !== props.domainName ||
+                    JSON.stringify(
+                      normalizeSanList(detail.SubjectAlternativeNames),
+                    ) !==
+                      JSON.stringify(
+                        normalizeSanList(props.subjectAlternativeNames),
+                      )
+                  ) {
+                    return undefined;
+                  }
+                  // Exportability is fixed at request time, so a certificate
+                  // with a different export option can never converge to these
+                  // props — it is the doomed half of a replacement, not a
+                  // match.
+                  if (
+                    (props.export ?? "DISABLED") !==
+                    (detail.Options?.Export ?? "DISABLED")
+                  ) {
+                    return undefined;
+                  }
+                  const tags = yield* listCertificateTags(
+                    detail.CertificateArn,
+                  );
+                  return (yield* hasAlchemyTags(id, tags)) ? detail : undefined;
+                }),
+              ),
+              Stream.filter((detail) => detail !== undefined),
+              Stream.runHead,
+              Effect.map(Option.getOrUndefined),
             ),
         );
-
-        for (const summary of summaries) {
-          if (!summary.CertificateArn) {
-            continue;
-          }
-          const detail = yield* describeCertificate(summary.CertificateArn);
-          if (!detail?.CertificateArn) {
-            continue;
-          }
-          if (
-            detail.DomainName !== props.domainName ||
-            JSON.stringify(normalizeSanList(detail.SubjectAlternativeNames)) !==
-              JSON.stringify(normalizeSanList(props.subjectAlternativeNames))
-          ) {
-            continue;
-          }
-          // Exportability is fixed at request time, so a certificate with a
-          // different export option can never converge to these props — it
-          // is the doomed half of a replacement, not a match.
-          if (
-            (props.export ?? "DISABLED") !==
-            (detail.Options?.Export ?? "DISABLED")
-          ) {
-            continue;
-          }
-          const tags = yield* listCertificateTags(detail.CertificateArn);
-          if (yield* hasAlchemyTags(id, tags)) {
-            return detail;
-          }
-        }
-
-        return undefined;
       });
 
       const waitForValidationRecords = Effect.fn(function* (

--- a/packages/alchemy/src/AWS/AppRunner/ObservabilityConfiguration.ts
+++ b/packages/alchemy/src/AWS/AppRunner/ObservabilityConfiguration.ts
@@ -176,17 +176,21 @@ export const ObservabilityConfigurationProvider = () =>
        * with InvalidRequestException — retry through that window (bounded).
        */
       const deleteAllRevisions = Effect.fn(function* (name: string) {
-        const page = yield* apprunner.listObservabilityConfigurations({
-          ObservabilityConfigurationName: name,
-          LatestOnly: false,
-        });
-        const arns = (page.ObservabilityConfigurationSummaryList ?? [])
-          .filter((s) => s.ObservabilityConfigurationName === name)
-          .flatMap((s) =>
-            s.ObservabilityConfigurationArn !== undefined
-              ? [s.ObservabilityConfigurationArn]
-              : [],
-          );
+        const pages = yield* apprunner.listObservabilityConfigurations
+          .pages({
+            ObservabilityConfigurationName: name,
+            LatestOnly: false,
+          })
+          .pipe(Stream.runCollect);
+        const arns = Array.from(pages).flatMap((page) =>
+          (page.ObservabilityConfigurationSummaryList ?? [])
+            .filter((s) => s.ObservabilityConfigurationName === name)
+            .flatMap((s) =>
+              s.ObservabilityConfigurationArn !== undefined
+                ? [s.ObservabilityConfigurationArn]
+                : [],
+            ),
+        );
         for (const arn of arns) {
           yield* apprunner
             .deleteObservabilityConfiguration({

--- a/packages/alchemy/src/AWS/AppRunner/Service.ts
+++ b/packages/alchemy/src/AWS/AppRunner/Service.ts
@@ -5,6 +5,7 @@ import type { Region } from "@distilled.cloud/aws/Region";
 import * as Data from "effect/Data";
 import type * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import * as Redacted from "effect/Redacted";
 import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
@@ -1114,17 +1115,17 @@ await Effect.runPromise(program).catch((err) => {
 
       /** Find a live service by name (list has no name filter). */
       const findByName = Effect.fn(function* (name: string) {
-        const summaries = yield* apprunner.listServices.pages({}).pipe(
-          Stream.runCollect,
-          Effect.map((chunk) =>
-            Array.from(chunk).flatMap((page) => page.ServiceSummaryList ?? []),
+        const summary = yield* apprunner.listServices.pages({}).pipe(
+          Stream.map((page) => page.ServiceSummaryList ?? []),
+          Stream.flattenIterable,
+          Stream.filter(
+            (s) =>
+              s.ServiceName === name &&
+              !statusIs(s.Status, "DELETED") &&
+              s.ServiceArn !== undefined,
           ),
-        );
-        const summary = summaries.find(
-          (s) =>
-            s.ServiceName === name &&
-            !statusIs(s.Status, "DELETED") &&
-            s.ServiceArn !== undefined,
+          Stream.runHead,
+          Effect.map(Option.getOrUndefined),
         );
         if (!summary?.ServiceArn) return undefined;
         return yield* readService(summary.ServiceArn);

--- a/packages/alchemy/src/AWS/AppRunner/Service.ts
+++ b/packages/alchemy/src/AWS/AppRunner/Service.ts
@@ -1587,53 +1587,42 @@ await Effect.runPromise(program).catch((err) => {
             output.accessRoleName,
           ]) {
             if (roleName === undefined) continue;
-            yield* iam.listRolePolicies({ RoleName: roleName }).pipe(
+            yield* iam.listRolePolicies.items({ RoleName: roleName }).pipe(
+              Stream.mapEffect((policyName) =>
+                iam
+                  .deleteRolePolicy({
+                    RoleName: roleName,
+                    PolicyName: policyName,
+                  })
+                  .pipe(
+                    Effect.catchTag("NoSuchEntityException", () => Effect.void),
+                  ),
+              ),
+              Stream.runDrain,
               // The role may already be gone (delete re-run / race) —
               // treat a missing role as "no policies" so delete is
               // idempotent.
-              Effect.catchTag("NoSuchEntityException", () =>
-                Effect.succeed({ PolicyNames: [] as string[] }),
-              ),
-              Effect.flatMap((policies) =>
-                Effect.all(
-                  (policies.PolicyNames ?? []).map((policyName) =>
-                    iam
-                      .deleteRolePolicy({
-                        RoleName: roleName,
-                        PolicyName: policyName,
-                      })
-                      .pipe(
-                        Effect.catchTag(
-                          "NoSuchEntityException",
-                          () => Effect.void,
-                        ),
-                      ),
-                  ),
-                ),
-              ),
+              Effect.catchTag("NoSuchEntityException", () => Effect.void),
             );
-            yield* iam.listAttachedRolePolicies({ RoleName: roleName }).pipe(
-              Effect.catchTag("NoSuchEntityException", () =>
-                Effect.succeed({ AttachedPolicies: [] }),
-              ),
-              Effect.flatMap((policies) =>
-                Effect.all(
-                  (policies.AttachedPolicies ?? []).map((policy) =>
-                    iam
-                      .detachRolePolicy({
-                        RoleName: roleName,
-                        PolicyArn: policy.PolicyArn!,
-                      })
-                      .pipe(
-                        Effect.catchTag(
-                          "NoSuchEntityException",
-                          () => Effect.void,
-                        ),
+            yield* iam.listAttachedRolePolicies
+              .items({ RoleName: roleName })
+              .pipe(
+                Stream.mapEffect((policy) =>
+                  iam
+                    .detachRolePolicy({
+                      RoleName: roleName,
+                      PolicyArn: policy.PolicyArn!,
+                    })
+                    .pipe(
+                      Effect.catchTag(
+                        "NoSuchEntityException",
+                        () => Effect.void,
                       ),
-                  ),
+                    ),
                 ),
-              ),
-            );
+                Stream.runDrain,
+                Effect.catchTag("NoSuchEntityException", () => Effect.void),
+              );
             yield* iam
               .deleteRole({ RoleName: roleName })
               .pipe(

--- a/packages/alchemy/src/AWS/AppSync/DataSource.ts
+++ b/packages/alchemy/src/AWS/AppSync/DataSource.ts
@@ -1,6 +1,7 @@
 import * as appsync from "@distilled.cloud/aws/appsync";
 import * as iam from "@distilled.cloud/aws/iam";
 import * as Effect from "effect/Effect";
+import * as Stream from "effect/Stream";
 import { deepEqual, isResolved } from "../../Diff.ts";
 import type { Input } from "../../Input.ts";
 import { createPhysicalName } from "../../PhysicalName.ts";
@@ -311,19 +312,18 @@ export const DataSourceProvider = () =>
 
       /** Delete the auto-created service role and its inline policies. */
       const deleteServiceRole = Effect.fn(function* (roleName: string) {
-        yield* iam.listRolePolicies({ RoleName: roleName }).pipe(
-          Effect.flatMap((policies) =>
-            Effect.forEach(policies.PolicyNames ?? [], (policyName) =>
-              iam
-                .deleteRolePolicy({
-                  RoleName: roleName,
-                  PolicyName: policyName,
-                })
-                .pipe(
-                  Effect.catchTag("NoSuchEntityException", () => Effect.void),
-                ),
-            ),
+        yield* iam.listRolePolicies.items({ RoleName: roleName }).pipe(
+          Stream.mapEffect((policyName) =>
+            iam
+              .deleteRolePolicy({
+                RoleName: roleName,
+                PolicyName: policyName,
+              })
+              .pipe(
+                Effect.catchTag("NoSuchEntityException", () => Effect.void),
+              ),
           ),
+          Stream.runDrain,
           Effect.catchTag("NoSuchEntityException", () => Effect.void),
         );
         yield* iam

--- a/packages/alchemy/src/AWS/Athena/DataCatalog.ts
+++ b/packages/alchemy/src/AWS/Athena/DataCatalog.ts
@@ -125,8 +125,9 @@ export const DataCatalogProvider = () =>
         );
 
       const fetchTags = (arn: string) =>
-        athena.listTagsForResource({ ResourceARN: arn }).pipe(
-          Effect.map((res) => observedTagsOf(res.Tags)),
+        athena.listTagsForResource.items({ ResourceARN: arn }).pipe(
+          Stream.runCollect,
+          Effect.map((chunk) => observedTagsOf(Array.from(chunk))),
           Effect.catch(() => Effect.succeed({} as Record<string, string>)),
         );
 

--- a/packages/alchemy/src/AWS/Athena/WorkGroup.ts
+++ b/packages/alchemy/src/AWS/Athena/WorkGroup.ts
@@ -158,8 +158,9 @@ export const WorkGroupProvider = () =>
         );
 
       const fetchTags = (arn: string) =>
-        athena.listTagsForResource({ ResourceARN: arn }).pipe(
-          Effect.map((res) => observedTagsOf(res.Tags)),
+        athena.listTagsForResource.items({ ResourceARN: arn }).pipe(
+          Stream.runCollect,
+          Effect.map((chunk) => observedTagsOf(Array.from(chunk))),
           Effect.catch(() => Effect.succeed({} as Record<string, string>)),
         );
 

--- a/packages/alchemy/src/AWS/AutoScaling/LifecycleHook.ts
+++ b/packages/alchemy/src/AWS/AutoScaling/LifecycleHook.ts
@@ -175,7 +175,10 @@ export const LifecycleHookProvider = () =>
   Provider.effect(
     LifecycleHook,
     Effect.gen(function* () {
-      const toName = (id: string, props: { lifecycleHookName?: string } = {}) =>
+      const toName = (
+        id: string,
+        props: { lifecycleHookName?: string } = {},
+      ) =>
         props.lifecycleHookName
           ? Effect.succeed(props.lifecycleHookName)
           : createPhysicalName({ id, maxLength: 255, lowercase: true });

--- a/packages/alchemy/src/AWS/Batch/ComputeEnvironment.ts
+++ b/packages/alchemy/src/AWS/Batch/ComputeEnvironment.ts
@@ -228,9 +228,14 @@ const resolveDefaultNetwork = Effect.gen(function* () {
       }),
     );
   }
-  const subnets = yield* ec2.describeSubnets({
-    Filters: [{ Name: "vpc-id", Values: [vpcId] }],
-  });
+  const subnets = yield* ec2.describeSubnets
+    .items({
+      Filters: [{ Name: "vpc-id", Values: [vpcId] }],
+    })
+    .pipe(
+      Stream.runCollect,
+      Effect.map((chunk) => Array.from(chunk)),
+    );
   const groups = yield* ec2.describeSecurityGroups({
     Filters: [
       { Name: "vpc-id", Values: [vpcId] },
@@ -238,7 +243,7 @@ const resolveDefaultNetwork = Effect.gen(function* () {
     ],
   });
   const network = {
-    subnets: (subnets.Subnets ?? []).flatMap((s) =>
+    subnets: subnets.flatMap((s) =>
       s.SubnetId && (s.State === undefined || s.State === "available")
         ? [s.SubnetId]
         : [],

--- a/packages/alchemy/src/AWS/Batch/JobDefinition.ts
+++ b/packages/alchemy/src/AWS/Batch/JobDefinition.ts
@@ -535,7 +535,10 @@ export const JobDefinitionProvider = () =>
         ALCHEMY_PHASE: "runtime",
       };
 
-      const toName = (id: string, props: { jobDefinitionName?: string } = {}) =>
+      const toName = (
+        id: string,
+        props: { jobDefinitionName?: string } = {},
+      ) =>
         props.jobDefinitionName
           ? Effect.succeed(props.jobDefinitionName)
           : createPhysicalName({ id, maxLength: 128 });
@@ -594,13 +597,13 @@ export const JobDefinitionProvider = () =>
         family: string,
         status: "ACTIVE" | "INACTIVE",
       ) =>
-        ecs.listTaskDefinitions({ familyPrefix: family, status }).pipe(
-          Effect.map((response) =>
-            (response.taskDefinitionArns ?? []).filter((arn) => {
-              const suffix = arn.split("/").at(-1);
-              return suffix?.slice(0, suffix.lastIndexOf(":")) === family;
-            }),
-          ),
+        ecs.listTaskDefinitions.items({ familyPrefix: family, status }).pipe(
+          Stream.filter((arn) => {
+            const suffix = arn.split("/").at(-1);
+            return suffix?.slice(0, suffix.lastIndexOf(":")) === family;
+          }),
+          Stream.runCollect,
+          Effect.map((chunk) => Array.from(chunk)),
         );
 
       const waitUntilBackingRevisionDeletionStarted = (
@@ -1060,29 +1063,24 @@ await Effect.runPromise(program).then(
           platform.executionRoleName,
         ]) {
           if (!roleName) continue;
-          yield* iam.listRolePolicies({ RoleName: roleName }).pipe(
-            Effect.catchTag("NoSuchEntityException", () =>
-              Effect.succeed({ PolicyNames: [] as string[] }),
+          yield* iam.listRolePolicies.items({ RoleName: roleName }).pipe(
+            Stream.mapEffect((policyName) =>
+              iam
+                .deleteRolePolicy({
+                  RoleName: roleName,
+                  PolicyName: policyName,
+                })
+                .pipe(
+                  Effect.catchTag("NoSuchEntityException", () => Effect.void),
+                ),
             ),
-            Effect.flatMap((policies) =>
-              Effect.forEach(policies.PolicyNames ?? [], (policyName) =>
-                iam
-                  .deleteRolePolicy({
-                    RoleName: roleName,
-                    PolicyName: policyName,
-                  })
-                  .pipe(
-                    Effect.catchTag("NoSuchEntityException", () => Effect.void),
-                  ),
-              ),
-            ),
+            Stream.runDrain,
+            Effect.catchTag("NoSuchEntityException", () => Effect.void),
           );
-          yield* iam.listAttachedRolePolicies({ RoleName: roleName }).pipe(
-            Effect.catchTag("NoSuchEntityException", () =>
-              Effect.succeed({ AttachedPolicies: [] }),
-            ),
-            Effect.flatMap((policies) =>
-              Effect.forEach(policies.AttachedPolicies ?? [], (policy) =>
+          yield* iam.listAttachedRolePolicies
+            .items({ RoleName: roleName })
+            .pipe(
+              Stream.mapEffect((policy) =>
                 iam
                   .detachRolePolicy({
                     RoleName: roleName,
@@ -1092,8 +1090,9 @@ await Effect.runPromise(program).then(
                     Effect.catchTag("NoSuchEntityException", () => Effect.void),
                   ),
               ),
-            ),
-          );
+              Stream.runDrain,
+              Effect.catchTag("NoSuchEntityException", () => Effect.void),
+            );
           yield* iam
             .deleteRole({ RoleName: roleName })
             .pipe(Effect.catchTag("NoSuchEntityException", () => Effect.void));

--- a/packages/alchemy/src/AWS/CloudFront/KeyValueStore.ts
+++ b/packages/alchemy/src/AWS/CloudFront/KeyValueStore.ts
@@ -78,10 +78,14 @@ export const KeyValueStoreProvider = () =>
     KeyValueStore,
     Effect.gen(function* () {
       const getByName = Effect.fn(function* (name: string) {
-        const listed = yield* cloudfront.listKeyValueStores({});
-        const store =
-          listed.KeyValueStoreList?.Items?.find((item) => item.Name === name) ??
-          undefined;
+        const store = yield* cloudfront.listKeyValueStores.pages({}).pipe(
+          Stream.runCollect,
+          Effect.map((chunk) =>
+            Array.from(chunk)
+              .flatMap((page) => page.KeyValueStoreList?.Items ?? [])
+              .find((item) => item.Name === name),
+          ),
+        );
         if (!store?.Name) {
           return undefined;
         }

--- a/packages/alchemy/src/AWS/CloudFront/KeyValueStore.ts
+++ b/packages/alchemy/src/AWS/CloudFront/KeyValueStore.ts
@@ -1,5 +1,6 @@
 import * as cloudfront from "@distilled.cloud/aws/cloudfront";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import * as Stream from "effect/Stream";
 import { isResolved } from "../../Diff.ts";
 import { createPhysicalName } from "../../PhysicalName.ts";
@@ -79,12 +80,11 @@ export const KeyValueStoreProvider = () =>
     Effect.gen(function* () {
       const getByName = Effect.fn(function* (name: string) {
         const store = yield* cloudfront.listKeyValueStores.pages({}).pipe(
-          Stream.runCollect,
-          Effect.map((chunk) =>
-            Array.from(chunk)
-              .flatMap((page) => page.KeyValueStoreList?.Items ?? [])
-              .find((item) => item.Name === name),
-          ),
+          Stream.map((page) => page.KeyValueStoreList?.Items ?? []),
+          Stream.flattenIterable,
+          Stream.filter((item) => item.Name === name),
+          Stream.runHead,
+          Effect.map(Option.getOrUndefined),
         );
         if (!store?.Name) {
           return undefined;

--- a/packages/alchemy/src/AWS/CloudFront/OriginAccessControl.ts
+++ b/packages/alchemy/src/AWS/CloudFront/OriginAccessControl.ts
@@ -1,5 +1,6 @@
 import * as cloudfront from "@distilled.cloud/aws/cloudfront";
 import * as Effect from "effect/Effect";
+import * as Stream from "effect/Stream";
 import { isResolved } from "../../Diff.ts";
 import { createPhysicalName } from "../../PhysicalName.ts";
 import * as Provider from "../../Provider.ts";
@@ -92,11 +93,16 @@ export const OriginAccessControlProvider = () =>
     OriginAccessControl,
     Effect.gen(function* () {
       const getByName = Effect.fn(function* (name: string) {
-        const listed = yield* cloudfront.listOriginAccessControls({});
-        const summary =
-          listed.OriginAccessControlList?.Items?.find(
-            (item) => item.Name === name,
-          ) ?? undefined;
+        const summary = yield* cloudfront.listOriginAccessControls
+          .pages({})
+          .pipe(
+            Stream.runCollect,
+            Effect.map((chunk) =>
+              Array.from(chunk)
+                .flatMap((page) => page.OriginAccessControlList?.Items ?? [])
+                .find((item) => item.Name === name),
+            ),
+          );
         if (!summary?.Id) {
           return undefined;
         }
@@ -144,47 +150,42 @@ export const OriginAccessControlProvider = () =>
       return {
         stables: ["originAccessControlId"],
         list: () =>
-          Effect.gen(function* () {
-            const items: ReturnType<typeof toAttrs>[] = [];
-            let marker: string | undefined = undefined;
-            do {
-              const listed: cloudfront.ListOriginAccessControlsResult =
-                yield* cloudfront.listOriginAccessControls({ Marker: marker });
-              for (const summary of listed.OriginAccessControlList?.Items ??
-                []) {
-                if (!summary.Id) continue;
+          cloudfront.listOriginAccessControls.pages({}).pipe(
+            Stream.map((page) => page.OriginAccessControlList?.Items ?? []),
+            Stream.flattenIterable,
+            Stream.filter((summary) => summary.Id !== undefined),
+            Stream.mapEffect((summary) =>
+              Effect.gen(function* () {
                 // Fetch per-item config for the fresh ETag (the list summary
                 // omits it). Tolerate a concurrent delete between list and get.
                 const config = yield* cloudfront
-                  .getOriginAccessControlConfig({ Id: summary.Id })
+                  .getOriginAccessControlConfig({ Id: summary.Id! })
                   .pipe(
                     Effect.catchTag("NoSuchOriginAccessControl", () =>
                       Effect.succeed(undefined),
                     ),
                   );
-                items.push(
-                  toAttrs(
-                    {
-                      Id: summary.Id,
-                      OriginAccessControlConfig:
-                        config?.OriginAccessControlConfig ?? {
-                          Name: summary.Name,
-                          Description: summary.Description,
-                          OriginAccessControlOriginType:
-                            summary.OriginAccessControlOriginType,
-                          SigningBehavior: summary.SigningBehavior,
-                          SigningProtocol: summary.SigningProtocol,
-                        },
-                    },
-                    config?.ETag,
-                    summary.Name,
-                  ),
+                return toAttrs(
+                  {
+                    Id: summary.Id!,
+                    OriginAccessControlConfig:
+                      config?.OriginAccessControlConfig ?? {
+                        Name: summary.Name,
+                        Description: summary.Description,
+                        OriginAccessControlOriginType:
+                          summary.OriginAccessControlOriginType,
+                        SigningBehavior: summary.SigningBehavior,
+                        SigningProtocol: summary.SigningProtocol,
+                      },
+                  },
+                  config?.ETag,
+                  summary.Name,
                 );
-              }
-              marker = listed.OriginAccessControlList?.NextMarker;
-            } while (marker);
-            return items;
-          }),
+              }),
+            ),
+            Stream.runCollect,
+            Effect.map((chunk) => Array.from(chunk)),
+          ),
         diff: Effect.fn(function* ({ id, olds, news: _news }) {
           if (!isResolved(_news)) return undefined;
           const news = _news as typeof olds;

--- a/packages/alchemy/src/AWS/CloudFront/OriginAccessControl.ts
+++ b/packages/alchemy/src/AWS/CloudFront/OriginAccessControl.ts
@@ -1,5 +1,6 @@
 import * as cloudfront from "@distilled.cloud/aws/cloudfront";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import * as Stream from "effect/Stream";
 import { isResolved } from "../../Diff.ts";
 import { createPhysicalName } from "../../PhysicalName.ts";
@@ -96,12 +97,11 @@ export const OriginAccessControlProvider = () =>
         const summary = yield* cloudfront.listOriginAccessControls
           .pages({})
           .pipe(
-            Stream.runCollect,
-            Effect.map((chunk) =>
-              Array.from(chunk)
-                .flatMap((page) => page.OriginAccessControlList?.Items ?? [])
-                .find((item) => item.Name === name),
-            ),
+            Stream.map((page) => page.OriginAccessControlList?.Items ?? []),
+            Stream.flattenIterable,
+            Stream.filter((item) => item.Name === name),
+            Stream.runHead,
+            Effect.map(Option.getOrUndefined),
           );
         if (!summary?.Id) {
           return undefined;

--- a/packages/alchemy/src/AWS/CloudFront/PublicKey.ts
+++ b/packages/alchemy/src/AWS/CloudFront/PublicKey.ts
@@ -1,5 +1,6 @@
 import * as cloudfront from "@distilled.cloud/aws/cloudfront";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import * as Redacted from "effect/Redacted";
 import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
@@ -100,12 +101,11 @@ export const PublicKeyProvider = () =>
 
       const getByName = Effect.fn(function* (name: string) {
         const summary = yield* cloudfront.listPublicKeys.pages({}).pipe(
-          Stream.runCollect,
-          Effect.map((chunk) =>
-            Array.from(chunk)
-              .flatMap((page) => page.PublicKeyList?.Items ?? [])
-              .find((item) => item.Name === name),
-          ),
+          Stream.map((page) => page.PublicKeyList?.Items ?? []),
+          Stream.flattenIterable,
+          Stream.filter((item) => item.Name === name),
+          Stream.runHead,
+          Effect.map(Option.getOrUndefined),
         );
         if (!summary?.Id) return undefined;
         return yield* getById(summary.Id).pipe(

--- a/packages/alchemy/src/AWS/CloudFront/PublicKey.ts
+++ b/packages/alchemy/src/AWS/CloudFront/PublicKey.ts
@@ -99,9 +99,13 @@ export const PublicKeyProvider = () =>
       });
 
       const getByName = Effect.fn(function* (name: string) {
-        const listed = yield* cloudfront.listPublicKeys({});
-        const summary = listed.PublicKeyList?.Items?.find(
-          (item) => item.Name === name,
+        const summary = yield* cloudfront.listPublicKeys.pages({}).pipe(
+          Stream.runCollect,
+          Effect.map((chunk) =>
+            Array.from(chunk)
+              .flatMap((page) => page.PublicKeyList?.Items ?? [])
+              .find((item) => item.Name === name),
+          ),
         );
         if (!summary?.Id) return undefined;
         return yield* getById(summary.Id).pipe(

--- a/packages/alchemy/src/AWS/CloudMap/Service.ts
+++ b/packages/alchemy/src/AWS/CloudMap/Service.ts
@@ -222,12 +222,20 @@ export const ServiceProvider = () =>
             return byId;
           }
         }
-        const listed = yield* sd.listServices({
-          Filters: [
-            { Name: "NAMESPACE_ID", Values: [namespaceId], Condition: "EQ" },
-          ],
-        });
-        const summary = listed.Services?.find((s) => s.Name === name);
+        const summary = yield* sd.listServices
+          .pages({
+            Filters: [
+              { Name: "NAMESPACE_ID", Values: [namespaceId], Condition: "EQ" },
+            ],
+          })
+          .pipe(
+            Stream.runCollect,
+            Effect.map((chunk) =>
+              Array.from(chunk)
+                .flatMap((page) => page.Services ?? [])
+                .find((s) => s.Name === name),
+            ),
+          );
         if (summary?.Id === undefined) {
           return undefined;
         }

--- a/packages/alchemy/src/AWS/CloudMap/Service.ts
+++ b/packages/alchemy/src/AWS/CloudMap/Service.ts
@@ -1,6 +1,7 @@
 import * as sd from "@distilled.cloud/aws/servicediscovery";
 import type * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import * as Stream from "effect/Stream";
 import { Unowned } from "../../AdoptPolicy.ts";
 import { isResolved } from "../../Diff.ts";
@@ -229,12 +230,11 @@ export const ServiceProvider = () =>
             ],
           })
           .pipe(
-            Stream.runCollect,
-            Effect.map((chunk) =>
-              Array.from(chunk)
-                .flatMap((page) => page.Services ?? [])
-                .find((s) => s.Name === name),
-            ),
+            Stream.map((page) => page.Services ?? []),
+            Stream.flattenIterable,
+            Stream.filter((s) => s.Name === name),
+            Stream.runHead,
+            Effect.map(Option.getOrUndefined),
           );
         if (summary?.Id === undefined) {
           return undefined;

--- a/packages/alchemy/src/AWS/CloudWatch/AnomalyDetector.ts
+++ b/packages/alchemy/src/AWS/CloudWatch/AnomalyDetector.ts
@@ -136,8 +136,12 @@ const describeDetector = Effect.fn(function* (
   },
 ) {
   const request = toDescribeRequest(props);
-  const response = yield* cloudwatch.describeAnomalyDetectors(request);
-  const detectors = response.AnomalyDetectors ?? [];
+  const detectors = yield* cloudwatch.describeAnomalyDetectors
+    .items(request)
+    .pipe(
+      Stream.runCollect,
+      Effect.map((chunk) => Array.from(chunk)),
+    );
   const detector = detectors.find((candidate) =>
     matchesDetectorIdentity(candidate, props),
   );

--- a/packages/alchemy/src/AWS/CloudWatch/AnomalyDetector.ts
+++ b/packages/alchemy/src/AWS/CloudWatch/AnomalyDetector.ts
@@ -136,9 +136,14 @@ const describeDetector = Effect.fn(function* (
   },
 ) {
   const request = toDescribeRequest(props);
+  // Stop paginating at the first identity match; a miss drains every page
+  // anyway, which is exactly what the miss diagnostics below need.
   const detectors = yield* cloudwatch.describeAnomalyDetectors
     .items(request)
     .pipe(
+      Stream.takeUntil((candidate) =>
+        matchesDetectorIdentity(candidate, props),
+      ),
       Stream.runCollect,
       Effect.map((chunk) => Array.from(chunk)),
     );

--- a/packages/alchemy/src/AWS/DataBrew/Job.ts
+++ b/packages/alchemy/src/AWS/DataBrew/Job.ts
@@ -2,6 +2,7 @@ import * as databrew from "@distilled.cloud/aws/databrew";
 import * as Data from "effect/Data";
 import type * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
 import { Unowned } from "../../AdoptPolicy.ts";
@@ -617,10 +618,11 @@ export const JobProvider = () =>
           );
           if (runs.some((run) => isActive(run.State))) {
             yield* databrew.listJobRuns.items({ Name: output.jobName }).pipe(
-              Stream.runCollect,
-              Effect.map((chunk) =>
-                Array.from(chunk).every((run) => !isActive(run.State)),
-              ),
+              // Settled = no active run observed; stop paginating at the
+              // first active run instead of draining every page.
+              Stream.filter((run) => isActive(run.State)),
+              Stream.runHead,
+              Effect.map(Option.isNone),
               Effect.catchTag("ResourceNotFoundException", () =>
                 Effect.succeed(true),
               ),

--- a/packages/alchemy/src/AWS/DataBrew/Job.ts
+++ b/packages/alchemy/src/AWS/DataBrew/Job.ts
@@ -587,10 +587,11 @@ export const JobProvider = () =>
           // with ConflictException ("is used in job …") long after DeleteJob
           // itself succeeds. Stop in-flight runs and wait (bounded) for every
           // run to reach a terminal state before deleting the job.
-          const runs = yield* databrew
-            .listJobRuns({ Name: output.jobName })
+          const runs = yield* databrew.listJobRuns
+            .items({ Name: output.jobName })
             .pipe(
-              Effect.map((r) => r.JobRuns ?? []),
+              Stream.runCollect,
+              Effect.map((chunk) => Array.from(chunk)),
               Effect.catchTag("ResourceNotFoundException", () =>
                 Effect.succeed([]),
               ),
@@ -615,9 +616,10 @@ export const JobProvider = () =>
                 ),
           );
           if (runs.some((run) => isActive(run.State))) {
-            yield* databrew.listJobRuns({ Name: output.jobName }).pipe(
-              Effect.map((r) =>
-                (r.JobRuns ?? []).every((run) => !isActive(run.State)),
+            yield* databrew.listJobRuns.items({ Name: output.jobName }).pipe(
+              Stream.runCollect,
+              Effect.map((chunk) =>
+                Array.from(chunk).every((run) => !isActive(run.State)),
               ),
               Effect.catchTag("ResourceNotFoundException", () =>
                 Effect.succeed(true),

--- a/packages/alchemy/src/AWS/DataZone/EnvironmentBlueprintConfiguration.ts
+++ b/packages/alchemy/src/AWS/DataZone/EnvironmentBlueprintConfiguration.ts
@@ -2,6 +2,7 @@ import * as datazone from "@distilled.cloud/aws/datazone";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";
+import * as Stream from "effect/Stream";
 import { isResolved } from "../../Diff.ts";
 import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
@@ -184,13 +185,18 @@ export const EnvironmentBlueprintConfigurationProvider = () =>
         domainId: string,
         nameOrId: string,
       ) {
-        const found = yield* datazone.listEnvironmentBlueprints({
-          domainIdentifier: domainId,
-          managed: true,
-        });
-        const match = (found.items ?? []).find(
-          (b) => b.name === nameOrId || b.id === nameOrId,
-        );
+        const match = yield* datazone.listEnvironmentBlueprints
+          .items({
+            domainIdentifier: domainId,
+            managed: true,
+          })
+          .pipe(
+            Stream.filter((b) => b.name === nameOrId || b.id === nameOrId),
+            Stream.runHead,
+            Effect.map((head) =>
+              head._tag === "Some" ? head.value : undefined,
+            ),
+          );
         if (match === undefined) {
           return yield* new EnvironmentBlueprintNotFound({
             domainId,

--- a/packages/alchemy/src/AWS/EC2/NatGateway.ts
+++ b/packages/alchemy/src/AWS/EC2/NatGateway.ts
@@ -1,6 +1,7 @@
 import * as ec2 from "@distilled.cloud/aws/ec2";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
 
@@ -302,13 +303,10 @@ export const NatGatewayProvider = () =>
       // Find NAT Gateway by alchemy tags when we don't have the ID
       const findNatGatewayByTags = Effect.fn(function* (id: string) {
         const filters = yield* createAlchemyTagFilters(id);
-        const result = yield* ec2.describeNatGateways({ Filter: filters });
-
         // Find a NAT Gateway that's not deleted and has matching tags
-        for (const gw of result.NatGateways ?? []) {
-          return gw;
-        }
-        return undefined;
+        return yield* ec2.describeNatGateways
+          .items({ Filter: filters })
+          .pipe(Stream.runHead, Effect.map(Option.getOrUndefined));
       });
 
       return {

--- a/packages/alchemy/src/AWS/EC2/NetworkAclAssociation.ts
+++ b/packages/alchemy/src/AWS/EC2/NetworkAclAssociation.ts
@@ -1,5 +1,6 @@
 import * as ec2 from "@distilled.cloud/aws/ec2";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import * as Stream from "effect/Stream";
 
 import { isResolved } from "../../Diff.ts";
@@ -244,14 +245,16 @@ export const NetworkAclAssociationProvider = () =>
             return;
           }
 
-          const defaultAclResult = yield* ec2.describeNetworkAcls({
-            Filters: [
-              { Name: "vpc-id", Values: [vpcId] },
-              { Name: "default", Values: ["true"] },
-            ],
-          });
+          const defaultAcl = yield* ec2.describeNetworkAcls
+            .items({
+              Filters: [
+                { Name: "vpc-id", Values: [vpcId] },
+                { Name: "default", Values: ["true"] },
+              ],
+            })
+            .pipe(Stream.runHead, Effect.map(Option.getOrUndefined));
 
-          const defaultAclId = defaultAclResult.NetworkAcls?.[0]?.NetworkAclId;
+          const defaultAclId = defaultAcl?.NetworkAclId;
 
           if (defaultAclId && defaultAclId !== (olds.networkAclId as string)) {
             // Replace with default NACL

--- a/packages/alchemy/src/AWS/EC2/SecurityGroup.ts
+++ b/packages/alchemy/src/AWS/EC2/SecurityGroup.ts
@@ -380,9 +380,14 @@ export const SecurityGroupProvider = () =>
         );
 
       const describeSecurityGroupRules = (groupId: string) =>
-        ec2.describeSecurityGroupRules({
-          Filters: [{ Name: "group-id", Values: [groupId] }],
-        });
+        ec2.describeSecurityGroupRules
+          .items({
+            Filters: [{ Name: "group-id", Values: [groupId] }],
+          })
+          .pipe(
+            Stream.runCollect,
+            Effect.map((chunk) => Array.from(chunk)),
+          );
 
       const toAttrs = Effect.fn(function* (
         sg: ec2.SecurityGroup,
@@ -464,8 +469,8 @@ export const SecurityGroupProvider = () =>
         read: Effect.fn(function* ({ output }) {
           if (!output) return undefined;
           const sg = yield* describeSecurityGroup(output.groupId);
-          const rulesResult = yield* describeSecurityGroupRules(output.groupId);
-          return yield* toAttrs(sg, rulesResult.SecurityGroupRules ?? []);
+          const rules = yield* describeSecurityGroupRules(output.groupId);
+          return yield* toAttrs(sg, rules);
         }),
 
         list: () =>
@@ -488,13 +493,8 @@ export const SecurityGroupProvider = () =>
               groups,
               (sg) =>
                 Effect.gen(function* () {
-                  const rulesResult = yield* describeSecurityGroupRules(
-                    sg.GroupId,
-                  );
-                  return yield* toAttrs(
-                    sg,
-                    rulesResult.SecurityGroupRules ?? [],
-                  );
+                  const rules = yield* describeSecurityGroupRules(sg.GroupId);
+                  return yield* toAttrs(sg, rules);
                 }),
               { concurrency: 10 },
             );
@@ -607,8 +607,7 @@ export const SecurityGroupProvider = () =>
           // (cidr/group ref/prefix list), so the simplest convergent strategy
           // is full-replace each reconcile. Default egress (-1, 0.0.0.0/0)
           // is restored when no explicit egress is desired.
-          const currentRulesResult = yield* describeSecurityGroupRules(groupId);
-          const currentRules = currentRulesResult.SecurityGroupRules ?? [];
+          const currentRules = yield* describeSecurityGroupRules(groupId);
           const currentIngress = currentRules.filter((r) => !r.IsEgress);
           const currentEgress = currentRules.filter((r) => r.IsEgress);
           if (currentIngress.length > 0) {
@@ -674,7 +673,7 @@ export const SecurityGroupProvider = () =>
           // Re-read final state.
           const finalSg = yield* describeSecurityGroup(groupId);
           const finalRules = yield* describeSecurityGroupRules(groupId);
-          return yield* toAttrs(finalSg, finalRules.SecurityGroupRules ?? []);
+          return yield* toAttrs(finalSg, finalRules);
         }),
 
         delete: Effect.fn(function* ({ output, session }) {

--- a/packages/alchemy/src/AWS/EC2/Subnet.ts
+++ b/packages/alchemy/src/AWS/EC2/Subnet.ts
@@ -1,6 +1,7 @@
 import * as ec2 from "@distilled.cloud/aws/ec2";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
 
@@ -436,20 +437,25 @@ export const SubnetProvider = () =>
                     if (news.cidrBlock === undefined) {
                       return yield* Effect.fail(error);
                     }
-                    const lookup = yield* ec2.describeSubnets({
-                      Filters: [
-                        { Name: "vpc-id", Values: [news.vpcId] },
-                        { Name: "cidr-block", Values: [news.cidrBlock] },
-                      ],
-                    });
-                    const existing = lookup.Subnets?.find((s) =>
-                      hasTags(
-                        alchemyTags,
-                        Object.fromEntries(
-                          (s.Tags ?? []).map((t) => [t.Key ?? "", t.Value]),
+                    const existing = yield* ec2.describeSubnets
+                      .items({
+                        Filters: [
+                          { Name: "vpc-id", Values: [news.vpcId] },
+                          { Name: "cidr-block", Values: [news.cidrBlock] },
+                        ],
+                      })
+                      .pipe(
+                        Stream.filter((s) =>
+                          hasTags(
+                            alchemyTags,
+                            Object.fromEntries(
+                              (s.Tags ?? []).map((t) => [t.Key ?? "", t.Value]),
+                            ),
+                          ),
                         ),
-                      ),
-                    );
+                        Stream.runHead,
+                        Effect.map(Option.getOrUndefined),
+                      );
                     if (existing?.SubnetId === undefined) {
                       return yield* Effect.fail(error);
                     }

--- a/packages/alchemy/src/AWS/EC2/VpcEndpoint.ts
+++ b/packages/alchemy/src/AWS/EC2/VpcEndpoint.ts
@@ -844,12 +844,18 @@ const waitForEndpointEnisReleased = (
   session: ScopedPlanStatusSession,
 ) =>
   Effect.gen(function* () {
-    const result = yield* ec2.describeNetworkInterfaces({
-      Filters: [{ Name: "network-interface-id", Values: networkInterfaceIds }],
-    });
-    const remaining = (result.NetworkInterfaces ?? [])
-      .map((eni) => eni.NetworkInterfaceId)
-      .filter((id): id is string => Boolean(id));
+    const remaining = yield* ec2.describeNetworkInterfaces
+      .items({
+        Filters: [
+          { Name: "network-interface-id", Values: networkInterfaceIds },
+        ],
+      })
+      .pipe(
+        Stream.map((eni) => eni.NetworkInterfaceId),
+        Stream.filter((id): id is string => Boolean(id)),
+        Stream.runCollect,
+        Effect.map((chunk) => Array.from(chunk)),
+      );
     if (remaining.length > 0) {
       return yield* new VpcEndpointEnisLingering({
         networkInterfaceIds: remaining,

--- a/packages/alchemy/src/AWS/ECS/Service.ts
+++ b/packages/alchemy/src/AWS/ECS/Service.ts
@@ -8,6 +8,7 @@ import type { Region } from "@distilled.cloud/aws/Region";
 import * as Data from "effect/Data";
 import type * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
 import { deepEqual, isResolved } from "../../Diff.ts";
@@ -1378,10 +1379,15 @@ const parseListenSpec = (serviceId: string, spec: string, kind: string) =>
  * and the provider's network resolution.
  */
 const lookupDefaultNetwork = Effect.gen(function* () {
-  const vpcs = yield* ec2.describeVpcs({
-    Filters: [{ Name: "isDefault", Values: ["true"] }],
-  });
-  const vpc = (vpcs.Vpcs ?? []).find((v) => v.IsDefault);
+  const vpc = yield* ec2.describeVpcs
+    .items({
+      Filters: [{ Name: "isDefault", Values: ["true"] }],
+    })
+    .pipe(
+      Stream.filter((v) => v.IsDefault === true),
+      Stream.runHead,
+      Effect.map(Option.getOrUndefined),
+    );
   if (!vpc?.VpcId) {
     return yield* Effect.die(
       new Error(
@@ -1389,15 +1395,19 @@ const lookupDefaultNetwork = Effect.gen(function* () {
       ),
     );
   }
-  const subnets = yield* ec2.describeSubnets({
-    Filters: [
-      { Name: "vpc-id", Values: [vpc.VpcId] },
-      { Name: "default-for-az", Values: ["true"] },
-    ],
-  });
-  const subnetIds = (subnets.Subnets ?? [])
-    .map((s) => s.SubnetId)
-    .filter((s): s is string => s !== undefined);
+  const subnetIds = yield* ec2.describeSubnets
+    .items({
+      Filters: [
+        { Name: "vpc-id", Values: [vpc.VpcId] },
+        { Name: "default-for-az", Values: ["true"] },
+      ],
+    })
+    .pipe(
+      Stream.map((s) => s.SubnetId),
+      Stream.filter((s): s is string => s !== undefined),
+      Stream.runCollect,
+      Effect.map((chunk) => Array.from(chunk)),
+    );
   if (subnetIds.length === 0) {
     return yield* Effect.die(
       new Error(
@@ -2074,7 +2084,9 @@ const composeManagedIngress = (
       }
     }
 
-    const actionToListenerAction = (action: NormalizedAction): ListenerAction =>
+    const actionToListenerAction = (
+      action: NormalizedAction,
+    ): ListenerAction =>
       action.type === "redirect"
         ? {
             type: "redirect",

--- a/packages/alchemy/src/AWS/EKS/Cluster.ts
+++ b/packages/alchemy/src/AWS/EKS/Cluster.ts
@@ -672,43 +672,33 @@ export const ClusterProvider = () =>
       });
 
       const deleteManagedRole = Effect.fn(function* (roleName: string) {
-        yield* iam.listAttachedRolePolicies({ RoleName: roleName }).pipe(
-          Effect.catchTag("NoSuchEntityException", () =>
-            Effect.succeed({ AttachedPolicies: [] }),
-          ),
-          Effect.flatMap((policies) =>
-            Effect.all(
-              (policies.AttachedPolicies ?? []).map((policy) =>
-                iam
-                  .detachRolePolicy({
-                    RoleName: roleName,
-                    PolicyArn: policy.PolicyArn!,
-                  })
-                  .pipe(
-                    Effect.catchTag("NoSuchEntityException", () => Effect.void),
-                  ),
+        yield* iam.listAttachedRolePolicies.items({ RoleName: roleName }).pipe(
+          Stream.mapEffect((policy) =>
+            iam
+              .detachRolePolicy({
+                RoleName: roleName,
+                PolicyArn: policy.PolicyArn!,
+              })
+              .pipe(
+                Effect.catchTag("NoSuchEntityException", () => Effect.void),
               ),
-            ),
           ),
+          Stream.runDrain,
+          Effect.catchTag("NoSuchEntityException", () => Effect.void),
         );
-        yield* iam.listRolePolicies({ RoleName: roleName }).pipe(
-          Effect.catchTag("NoSuchEntityException", () =>
-            Effect.succeed({ PolicyNames: [] as string[] }),
-          ),
-          Effect.flatMap((policies) =>
-            Effect.all(
-              (policies.PolicyNames ?? []).map((policyName) =>
-                iam
-                  .deleteRolePolicy({
-                    RoleName: roleName,
-                    PolicyName: policyName,
-                  })
-                  .pipe(
-                    Effect.catchTag("NoSuchEntityException", () => Effect.void),
-                  ),
+        yield* iam.listRolePolicies.items({ RoleName: roleName }).pipe(
+          Stream.mapEffect((policyName) =>
+            iam
+              .deleteRolePolicy({
+                RoleName: roleName,
+                PolicyName: policyName,
+              })
+              .pipe(
+                Effect.catchTag("NoSuchEntityException", () => Effect.void),
               ),
-            ),
           ),
+          Stream.runDrain,
+          Effect.catchTag("NoSuchEntityException", () => Effect.void),
         );
         yield* iam
           .deleteRole({ RoleName: roleName })

--- a/packages/alchemy/src/AWS/EKS/internal/podIdentity.ts
+++ b/packages/alchemy/src/AWS/EKS/internal/podIdentity.ts
@@ -6,6 +6,7 @@
 import * as eks from "@distilled.cloud/aws/eks";
 import * as iam from "@distilled.cloud/aws/iam";
 import * as Effect from "effect/Effect";
+import * as Stream from "effect/Stream";
 import { createPhysicalName } from "../../../PhysicalName.ts";
 import type { ResourceBinding } from "../../../Resource.ts";
 import { createInternalTags, hasTags } from "../../../Tags.ts";
@@ -267,40 +268,30 @@ export const deleteAssociation = Effect.fn(function* ({
  * then the role itself. Idempotent throughout.
  */
 export const deletePodRole = Effect.fn(function* (roleName: string) {
-  yield* iam.listRolePolicies({ RoleName: roleName }).pipe(
-    Effect.catchTag("NoSuchEntityException", () =>
-      Effect.succeed({ PolicyNames: [] as string[] }),
+  yield* iam.listRolePolicies.items({ RoleName: roleName }).pipe(
+    Stream.mapEffect((policyName) =>
+      iam
+        .deleteRolePolicy({
+          RoleName: roleName,
+          PolicyName: policyName,
+        })
+        .pipe(Effect.catchTag("NoSuchEntityException", () => Effect.void)),
     ),
-    Effect.flatMap((policies) =>
-      Effect.all(
-        (policies.PolicyNames ?? []).map((policyName) =>
-          iam
-            .deleteRolePolicy({
-              RoleName: roleName,
-              PolicyName: policyName,
-            })
-            .pipe(Effect.catchTag("NoSuchEntityException", () => Effect.void)),
-        ),
-      ),
-    ),
+    Stream.runDrain,
+    Effect.catchTag("NoSuchEntityException", () => Effect.void),
   );
 
-  yield* iam.listAttachedRolePolicies({ RoleName: roleName }).pipe(
-    Effect.catchTag("NoSuchEntityException", () =>
-      Effect.succeed({ AttachedPolicies: [] }),
+  yield* iam.listAttachedRolePolicies.items({ RoleName: roleName }).pipe(
+    Stream.mapEffect((policy) =>
+      iam
+        .detachRolePolicy({
+          RoleName: roleName,
+          PolicyArn: policy.PolicyArn!,
+        })
+        .pipe(Effect.catchTag("NoSuchEntityException", () => Effect.void)),
     ),
-    Effect.flatMap((policies) =>
-      Effect.all(
-        (policies.AttachedPolicies ?? []).map((policy) =>
-          iam
-            .detachRolePolicy({
-              RoleName: roleName,
-              PolicyArn: policy.PolicyArn!,
-            })
-            .pipe(Effect.catchTag("NoSuchEntityException", () => Effect.void)),
-        ),
-      ),
-    ),
+    Stream.runDrain,
+    Effect.catchTag("NoSuchEntityException", () => Effect.void),
   );
 
   yield* iam

--- a/packages/alchemy/src/AWS/ELBv2/ListenerCertificate.ts
+++ b/packages/alchemy/src/AWS/ELBv2/ListenerCertificate.ts
@@ -1,5 +1,6 @@
 import * as elbv2 from "@distilled.cloud/aws/elastic-load-balancing-v2";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import * as Stream from "effect/Stream";
 import { isResolved } from "../../Diff.ts";
 import type { Input } from "../../Input.ts";
@@ -79,12 +80,11 @@ export const ListenerCertificateProvider = () =>
       const attached = yield* elbv2.describeListenerCertificates
         .items({ ListenerArn: output.listenerArn })
         .pipe(
-          Stream.runCollect,
-          Effect.map((chunk) =>
-            Array.from(chunk).some(
-              (c) => !c.IsDefault && c.CertificateArn === output.certificateArn,
-            ),
+          Stream.filter(
+            (c) => !c.IsDefault && c.CertificateArn === output.certificateArn,
           ),
+          Stream.runHead,
+          Effect.map(Option.isSome),
           Effect.catchTag("ListenerNotFoundException", () =>
             Effect.succeed(false),
           ),
@@ -159,12 +159,11 @@ export const ListenerCertificateProvider = () =>
       const attached = yield* elbv2.describeListenerCertificates
         .items({ ListenerArn: listenerArn })
         .pipe(
-          Stream.runCollect,
-          Effect.map((chunk) =>
-            Array.from(chunk).some(
-              (c) => !c.IsDefault && c.CertificateArn === news.certificateArn,
-            ),
+          Stream.filter(
+            (c) => !c.IsDefault && c.CertificateArn === news.certificateArn,
           ),
+          Stream.runHead,
+          Effect.map(Option.isSome),
         );
 
       // Ensure — the API is an idempotent add, but skip the call on no-op.

--- a/packages/alchemy/src/AWS/ELBv2/ListenerCertificate.ts
+++ b/packages/alchemy/src/AWS/ELBv2/ListenerCertificate.ts
@@ -76,16 +76,19 @@ export const ListenerCertificateProvider = () =>
       if (!output) {
         return undefined;
       }
-      const described = yield* elbv2
-        .describeListenerCertificates({ ListenerArn: output.listenerArn })
+      const attached = yield* elbv2.describeListenerCertificates
+        .items({ ListenerArn: output.listenerArn })
         .pipe(
+          Stream.runCollect,
+          Effect.map((chunk) =>
+            Array.from(chunk).some(
+              (c) => !c.IsDefault && c.CertificateArn === output.certificateArn,
+            ),
+          ),
           Effect.catchTag("ListenerNotFoundException", () =>
-            Effect.succeed(undefined),
+            Effect.succeed(false),
           ),
         );
-      const attached = described?.Certificates?.some(
-        (c) => !c.IsDefault && c.CertificateArn === output.certificateArn,
-      );
       return attached ? output : undefined;
     }),
     // Certificates belong to a listener, which belongs to a load balancer.
@@ -130,19 +133,20 @@ export const ListenerCertificateProvider = () =>
       const rows = yield* Effect.forEach(
         listenerArns.flat(),
         (listenerArn) =>
-          elbv2.describeListenerCertificates({ ListenerArn: listenerArn }).pipe(
-            Effect.map((res) =>
-              (res.Certificates ?? [])
-                .filter((c) => !c.IsDefault && c.CertificateArn)
-                .map((c) => ({
-                  listenerArn,
-                  certificateArn: c.CertificateArn!,
-                })),
+          elbv2.describeListenerCertificates
+            .items({ ListenerArn: listenerArn })
+            .pipe(
+              Stream.filter((c) => !c.IsDefault && c.CertificateArn != null),
+              Stream.map((c) => ({
+                listenerArn,
+                certificateArn: c.CertificateArn!,
+              })),
+              Stream.runCollect,
+              Effect.map((chunk) => Array.from(chunk)),
+              Effect.catchTag("ListenerNotFoundException", () =>
+                Effect.succeed([]),
+              ),
             ),
-            Effect.catchTag("ListenerNotFoundException", () =>
-              Effect.succeed([]),
-            ),
-          ),
         { concurrency: 10 },
       );
       const result: ListenerCertificate["Attributes"][] = rows.flat();
@@ -152,12 +156,16 @@ export const ListenerCertificateProvider = () =>
       const listenerArn = news.listenerArn as ListenerArn;
 
       // Observe — is the certificate already attached?
-      const described = yield* elbv2.describeListenerCertificates({
-        ListenerArn: listenerArn,
-      });
-      const attached = described.Certificates?.some(
-        (c) => !c.IsDefault && c.CertificateArn === news.certificateArn,
-      );
+      const attached = yield* elbv2.describeListenerCertificates
+        .items({ ListenerArn: listenerArn })
+        .pipe(
+          Stream.runCollect,
+          Effect.map((chunk) =>
+            Array.from(chunk).some(
+              (c) => !c.IsDefault && c.CertificateArn === news.certificateArn,
+            ),
+          ),
+        );
 
       // Ensure — the API is an idempotent add, but skip the call on no-op.
       if (!attached) {

--- a/packages/alchemy/src/AWS/ELBv2/ListenerRule.ts
+++ b/packages/alchemy/src/AWS/ELBv2/ListenerRule.ts
@@ -198,20 +198,19 @@ export const ListenerRuleProvider = () =>
       const rows = yield* Effect.forEach(
         listenerArns.flat(),
         (listenerArn) =>
-          elbv2.describeRules({ ListenerArn: listenerArn }).pipe(
-            Effect.map((res) =>
-              (res.Rules ?? [])
-                .filter(
-                  (r): r is typeof r & { RuleArn: string } =>
-                    r.RuleArn != null && !r.IsDefault,
-                )
-                .map((rule) => ({
-                  ruleArn: rule.RuleArn as RuleArn,
-                  listenerArn,
-                  priority: Number(rule.Priority ?? 0),
-                  isDefault: rule.IsDefault ?? false,
-                })),
+          elbv2.describeRules.items({ ListenerArn: listenerArn }).pipe(
+            Stream.filter(
+              (r): r is typeof r & { RuleArn: string } =>
+                r.RuleArn != null && !r.IsDefault,
             ),
+            Stream.map((rule) => ({
+              ruleArn: rule.RuleArn as RuleArn,
+              listenerArn,
+              priority: Number(rule.Priority ?? 0),
+              isDefault: rule.IsDefault ?? false,
+            })),
+            Stream.runCollect,
+            Effect.map((chunk) => Array.from(chunk)),
             Effect.catchTag("ListenerNotFoundException", () =>
               Effect.succeed([]),
             ),

--- a/packages/alchemy/src/AWS/EMR/Cluster.ts
+++ b/packages/alchemy/src/AWS/EMR/Cluster.ts
@@ -1,6 +1,7 @@
 import * as emr from "@distilled.cloud/aws/emr";
 import type * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
 import { Unowned } from "../../AdoptPolicy.ts";
@@ -347,14 +348,13 @@ export const ClusterProvider = () =>
       // is. Find the live (non-terminal) cluster carrying our name — used
       // when state was lost and we only know the derived name.
       const findClusterByName = Effect.fn(function* (name: string) {
-        const matches = yield* emr.listClusters
+        const summary = yield* emr.listClusters
           .items({ ClusterStates: [...ACTIVE_STATES] })
           .pipe(
             Stream.filter((summary) => summary.Name === name),
-            Stream.take(1),
-            Stream.runCollect,
+            Stream.runHead,
+            Effect.map(Option.getOrUndefined),
           );
-        const summary = Array.from(matches)[0];
         return summary?.Id ? yield* readCluster(summary.Id) : undefined;
       });
 
@@ -656,13 +656,13 @@ export const ClusterProvider = () =>
           // Core instance-group resize (in place between non-zero counts).
           const desiredCore = props.instances?.coreInstanceCount ?? 1;
           if (desiredCore > 0) {
-            const groups = yield* emr.listInstanceGroups
+            const core = yield* emr.listInstanceGroups
               .items({ ClusterId: clusterId })
               .pipe(
-                Stream.runCollect,
-                Effect.map((chunk) => Array.from(chunk)),
+                Stream.filter((g) => g.InstanceGroupType === "CORE"),
+                Stream.runHead,
+                Effect.map(Option.getOrUndefined),
               );
-            const core = groups.find((g) => g.InstanceGroupType === "CORE");
             if (
               core?.Id !== undefined &&
               (core.RequestedInstanceCount ?? 0) !== desiredCore

--- a/packages/alchemy/src/AWS/EMR/Cluster.ts
+++ b/packages/alchemy/src/AWS/EMR/Cluster.ts
@@ -656,12 +656,13 @@ export const ClusterProvider = () =>
           // Core instance-group resize (in place between non-zero counts).
           const desiredCore = props.instances?.coreInstanceCount ?? 1;
           if (desiredCore > 0) {
-            const groups = yield* emr.listInstanceGroups({
-              ClusterId: clusterId,
-            });
-            const core = (groups.InstanceGroups ?? []).find(
-              (g) => g.InstanceGroupType === "CORE",
-            );
+            const groups = yield* emr.listInstanceGroups
+              .items({ ClusterId: clusterId })
+              .pipe(
+                Stream.runCollect,
+                Effect.map((chunk) => Array.from(chunk)),
+              );
+            const core = groups.find((g) => g.InstanceGroupType === "CORE");
             if (
               core?.Id !== undefined &&
               (core.RequestedInstanceCount ?? 0) !== desiredCore

--- a/packages/alchemy/src/AWS/EMR/SecurityConfiguration.ts
+++ b/packages/alchemy/src/AWS/EMR/SecurityConfiguration.ts
@@ -121,7 +121,10 @@ export const SecurityConfigurationProvider = () =>
   Provider.effect(
     SecurityConfiguration,
     Effect.gen(function* () {
-      const toName = (id: string, props: Partial<SecurityConfigurationProps>) =>
+      const toName = (
+        id: string,
+        props: Partial<SecurityConfigurationProps>,
+      ) =>
         props.securityConfigurationName
           ? Effect.succeed(props.securityConfigurationName)
           : createPhysicalName({ id, maxLength: 64 });

--- a/packages/alchemy/src/AWS/IAM/Group.ts
+++ b/packages/alchemy/src/AWS/IAM/Group.ts
@@ -86,11 +86,14 @@ export const GroupProvider = () =>
           : createPhysicalName({ id, maxLength: 128 });
 
       const readInlinePolicies = Effect.fn(function* (groupName: string) {
-        const listed = yield* iam.listGroupPolicies({
-          GroupName: groupName,
-        });
+        const policyNames = yield* iam.listGroupPolicies
+          .items({ GroupName: groupName })
+          .pipe(
+            Stream.runCollect,
+            Effect.map((chunk) => Array.from(chunk)),
+          );
         const entries = yield* Effect.all(
-          (listed.PolicyNames ?? []).map((policyName) =>
+          policyNames.map((policyName) =>
             iam
               .getGroupPolicy({
                 GroupName: groupName,
@@ -119,10 +122,13 @@ export const GroupProvider = () =>
       });
 
       const readManagedPolicies = Effect.fn(function* (groupName: string) {
-        const listed = yield* iam.listAttachedGroupPolicies({
-          GroupName: groupName,
-        });
-        return (listed.AttachedPolicies ?? [])
+        const attached = yield* iam.listAttachedGroupPolicies
+          .items({ GroupName: groupName })
+          .pipe(
+            Stream.runCollect,
+            Effect.map((chunk) => Array.from(chunk)),
+          );
+        return attached
           .map((policy) => policy.PolicyArn)
           .filter(
             (policyArn): policyArn is string => typeof policyArn === "string",
@@ -350,67 +356,63 @@ export const GroupProvider = () =>
           };
         }),
         delete: Effect.fn(function* ({ output }) {
-          const groupState = yield* iam
-            .getGroup({
-              GroupName: output.groupName,
-            })
+          yield* iam.getGroup.items({ GroupName: output.groupName }).pipe(
+            Stream.mapEffect((user) =>
+              user.UserName
+                ? iam
+                    .removeUserFromGroup({
+                      GroupName: output.groupName,
+                      UserName: user.UserName,
+                    })
+                    .pipe(
+                      Effect.catchTag(
+                        "NoSuchEntityException",
+                        () => Effect.void,
+                      ),
+                    )
+                : Effect.void,
+            ),
+            Stream.runDrain,
+            // The group itself may already be gone.
+            Effect.catchTag("NoSuchEntityException", () => Effect.void),
+          );
+          yield* iam.listGroupPolicies
+            .items({ GroupName: output.groupName })
             .pipe(
-              Effect.catchTag("NoSuchEntityException", () =>
-                Effect.succeed(undefined),
+              Stream.mapEffect((policyName) =>
+                iam
+                  .deleteGroupPolicy({
+                    GroupName: output.groupName,
+                    PolicyName: policyName,
+                  })
+                  .pipe(
+                    Effect.catchTag("NoSuchEntityException", () => Effect.void),
+                  ),
               ),
+              Stream.runDrain,
+              Effect.catchTag("NoSuchEntityException", () => Effect.void),
             );
-          for (const user of groupState?.Users ?? []) {
-            if (user.UserName) {
-              yield* iam
-                .removeUserFromGroup({
-                  GroupName: output.groupName,
-                  UserName: user.UserName,
-                })
-                .pipe(
-                  Effect.catchTag("NoSuchEntityException", () => Effect.void),
-                );
-            }
-          }
-          const inlinePolicies = yield* iam
-            .listGroupPolicies({
-              GroupName: output.groupName,
-            })
+          yield* iam.listAttachedGroupPolicies
+            .items({ GroupName: output.groupName })
             .pipe(
-              Effect.catchTag("NoSuchEntityException", () =>
-                Effect.succeed(undefined),
+              Stream.mapEffect((policy) =>
+                policy.PolicyArn
+                  ? iam
+                      .detachGroupPolicy({
+                        GroupName: output.groupName,
+                        PolicyArn: policy.PolicyArn,
+                      })
+                      .pipe(
+                        Effect.catchTag(
+                          "NoSuchEntityException",
+                          () => Effect.void,
+                        ),
+                      )
+                  : Effect.void,
               ),
+              Stream.runDrain,
+              Effect.catchTag("NoSuchEntityException", () => Effect.void),
             );
-          for (const policyName of inlinePolicies?.PolicyNames ?? []) {
-            yield* iam
-              .deleteGroupPolicy({
-                GroupName: output.groupName,
-                PolicyName: policyName,
-              })
-              .pipe(
-                Effect.catchTag("NoSuchEntityException", () => Effect.void),
-              );
-          }
-          const attachedPolicies = yield* iam
-            .listAttachedGroupPolicies({
-              GroupName: output.groupName,
-            })
-            .pipe(
-              Effect.catchTag("NoSuchEntityException", () =>
-                Effect.succeed(undefined),
-              ),
-            );
-          for (const policy of attachedPolicies?.AttachedPolicies ?? []) {
-            if (policy.PolicyArn) {
-              yield* iam
-                .detachGroupPolicy({
-                  GroupName: output.groupName,
-                  PolicyArn: policy.PolicyArn,
-                })
-                .pipe(
-                  Effect.catchTag("NoSuchEntityException", () => Effect.void),
-                );
-            }
-          }
           yield* iam
             .deleteGroup({
               GroupName: output.groupName,

--- a/packages/alchemy/src/AWS/IAM/Role.ts
+++ b/packages/alchemy/src/AWS/IAM/Role.ts
@@ -244,11 +244,14 @@ export const RoleProvider = () =>
           : createPhysicalName({ id, maxLength: 64 });
 
       const readInlinePolicies = Effect.fn(function* (roleName: string) {
-        const listed = yield* iam.listRolePolicies({
-          RoleName: roleName,
-        });
+        const policyNames = yield* iam.listRolePolicies
+          .items({ RoleName: roleName })
+          .pipe(
+            Stream.runCollect,
+            Effect.map((chunk) => Array.from(chunk)),
+          );
         const entries = yield* Effect.all(
-          (listed.PolicyNames ?? []).map((policyName) =>
+          policyNames.map((policyName) =>
             iam
               .getRolePolicy({
                 RoleName: roleName,
@@ -277,10 +280,13 @@ export const RoleProvider = () =>
       });
 
       const readManagedPolicies = Effect.fn(function* (roleName: string) {
-        const listed = yield* iam.listAttachedRolePolicies({
-          RoleName: roleName,
-        });
-        return (listed.AttachedPolicies ?? [])
+        const attached = yield* iam.listAttachedRolePolicies
+          .items({ RoleName: roleName })
+          .pipe(
+            Stream.runCollect,
+            Effect.map((chunk) => Array.from(chunk)),
+          );
+        return attached
           .map((policy) => policy.PolicyArn)
           .filter(
             (policyArn): policyArn is string => typeof policyArn === "string",
@@ -680,48 +686,36 @@ export const RoleProvider = () =>
             })
             .pipe(Effect.catchTag("NoSuchEntityException", () => Effect.void));
 
-          yield* iam.listRolePolicies({ RoleName: output.roleName }).pipe(
-            Effect.flatMap((policies) =>
-              Effect.all(
-                (policies.PolicyNames ?? []).map((policyName) =>
-                  iam
-                    .deleteRolePolicy({
-                      RoleName: output.roleName,
-                      PolicyName: policyName,
-                    })
-                    .pipe(
-                      Effect.catchTag(
-                        "NoSuchEntityException",
-                        () => Effect.void,
-                      ),
-                    ),
+          yield* iam.listRolePolicies.items({ RoleName: output.roleName }).pipe(
+            Stream.mapEffect((policyName) =>
+              iam
+                .deleteRolePolicy({
+                  RoleName: output.roleName,
+                  PolicyName: policyName,
+                })
+                .pipe(
+                  Effect.catchTag("NoSuchEntityException", () => Effect.void),
                 ),
-              ),
             ),
+            Stream.runDrain,
             // The role itself may already be gone.
             Effect.catchTag("NoSuchEntityException", () => Effect.void),
           );
 
-          yield* iam
-            .listAttachedRolePolicies({ RoleName: output.roleName })
+          yield* iam.listAttachedRolePolicies
+            .items({ RoleName: output.roleName })
             .pipe(
-              Effect.flatMap((policies) =>
-                Effect.all(
-                  (policies.AttachedPolicies ?? []).map((policy) =>
-                    iam
-                      .detachRolePolicy({
-                        RoleName: output.roleName,
-                        PolicyArn: policy.PolicyArn!,
-                      })
-                      .pipe(
-                        Effect.catchTag(
-                          "NoSuchEntityException",
-                          () => Effect.void,
-                        ),
-                      ),
+              Stream.mapEffect((policy) =>
+                iam
+                  .detachRolePolicy({
+                    RoleName: output.roleName,
+                    PolicyArn: policy.PolicyArn!,
+                  })
+                  .pipe(
+                    Effect.catchTag("NoSuchEntityException", () => Effect.void),
                   ),
-                ),
               ),
+              Stream.runDrain,
               // The role itself may already be gone.
               Effect.catchTag("NoSuchEntityException", () => Effect.void),
             );

--- a/packages/alchemy/src/AWS/IAM/User.ts
+++ b/packages/alchemy/src/AWS/IAM/User.ts
@@ -101,10 +101,13 @@ export const UserProvider = () =>
           : createPhysicalName({ id, maxLength: 64 });
 
       const readManagedPolicies = Effect.fn(function* (userName: string) {
-        const listed = yield* iam.listAttachedUserPolicies({
-          UserName: userName,
-        });
-        return (listed.AttachedPolicies ?? [])
+        const attached = yield* iam.listAttachedUserPolicies
+          .items({ UserName: userName })
+          .pipe(
+            Stream.runCollect,
+            Effect.map((chunk) => Array.from(chunk)),
+          );
+        return attached
           .map((policy) => policy.PolicyArn)
           .filter(
             (policyArn): policyArn is string => typeof policyArn === "string",
@@ -112,11 +115,14 @@ export const UserProvider = () =>
       });
 
       const readInlinePolicies = Effect.fn(function* (userName: string) {
-        const listed = yield* iam.listUserPolicies({
-          UserName: userName,
-        });
+        const policyNames = yield* iam.listUserPolicies
+          .items({ UserName: userName })
+          .pipe(
+            Stream.runCollect,
+            Effect.map((chunk) => Array.from(chunk)),
+          );
         const entries = yield* Effect.all(
-          (listed.PolicyNames ?? []).map((policyName) =>
+          policyNames.map((policyName) =>
             iam
               .getUserPolicy({
                 UserName: userName,
@@ -435,47 +441,44 @@ export const UserProvider = () =>
             })
             .pipe(Effect.catchTag("NoSuchEntityException", () => Effect.void));
 
-          const inlinePolicies = yield* iam
-            .listUserPolicies({
-              UserName: output.userName,
-            })
-            .pipe(
-              Effect.catchTag("NoSuchEntityException", () =>
-                Effect.succeed(undefined),
-              ),
-            );
-          for (const policyName of inlinePolicies?.PolicyNames ?? []) {
-            yield* iam
-              .deleteUserPolicy({
-                UserName: output.userName,
-                PolicyName: policyName,
-              })
-              .pipe(
-                Effect.catchTag("NoSuchEntityException", () => Effect.void),
-              );
-          }
-
-          const attachedPolicies = yield* iam
-            .listAttachedUserPolicies({
-              UserName: output.userName,
-            })
-            .pipe(
-              Effect.catchTag("NoSuchEntityException", () =>
-                Effect.succeed(undefined),
-              ),
-            );
-          for (const policy of attachedPolicies?.AttachedPolicies ?? []) {
-            if (policy.PolicyArn) {
-              yield* iam
-                .detachUserPolicy({
+          yield* iam.listUserPolicies.items({ UserName: output.userName }).pipe(
+            Stream.mapEffect((policyName) =>
+              iam
+                .deleteUserPolicy({
                   UserName: output.userName,
-                  PolicyArn: policy.PolicyArn,
+                  PolicyName: policyName,
                 })
                 .pipe(
                   Effect.catchTag("NoSuchEntityException", () => Effect.void),
-                );
-            }
-          }
+                ),
+            ),
+            Stream.runDrain,
+            // The user itself may already be gone.
+            Effect.catchTag("NoSuchEntityException", () => Effect.void),
+          );
+
+          yield* iam.listAttachedUserPolicies
+            .items({ UserName: output.userName })
+            .pipe(
+              Stream.mapEffect((policy) =>
+                policy.PolicyArn
+                  ? iam
+                      .detachUserPolicy({
+                        UserName: output.userName,
+                        PolicyArn: policy.PolicyArn,
+                      })
+                      .pipe(
+                        Effect.catchTag(
+                          "NoSuchEntityException",
+                          () => Effect.void,
+                        ),
+                      )
+                  : Effect.void,
+              ),
+              Stream.runDrain,
+              // The user itself may already be gone.
+              Effect.catchTag("NoSuchEntityException", () => Effect.void),
+            );
 
           yield* iam
             .deleteUser({

--- a/packages/alchemy/src/AWS/IAM/VirtualMFADevice.ts
+++ b/packages/alchemy/src/AWS/IAM/VirtualMFADevice.ts
@@ -103,12 +103,16 @@ export const VirtualMFADeviceProvider = () =>
         userName: string | undefined;
       }) {
         if (!userName) {
-          const listed = yield* iam.listVirtualMFADevices({
-            AssignmentStatus: "Unassigned",
-          });
-          const device = listed.VirtualMFADevices.find(
-            (entry) => entry.SerialNumber === serialNumber,
-          );
+          const device = yield* iam.listVirtualMFADevices
+            .items({ AssignmentStatus: "Unassigned" })
+            .pipe(
+              Stream.runCollect,
+              Effect.map((chunk) =>
+                Array.from(chunk).find(
+                  (entry) => entry.SerialNumber === serialNumber,
+                ),
+              ),
+            );
           return device
             ? {
                 SerialNumber: device.SerialNumber,

--- a/packages/alchemy/src/AWS/IAM/VirtualMFADevice.ts
+++ b/packages/alchemy/src/AWS/IAM/VirtualMFADevice.ts
@@ -1,5 +1,6 @@
 import * as iam from "@distilled.cloud/aws/iam";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import * as Redacted from "effect/Redacted";
 import * as Stream from "effect/Stream";
 import { isResolved } from "../../Diff.ts";
@@ -106,12 +107,9 @@ export const VirtualMFADeviceProvider = () =>
           const device = yield* iam.listVirtualMFADevices
             .items({ AssignmentStatus: "Unassigned" })
             .pipe(
-              Stream.runCollect,
-              Effect.map((chunk) =>
-                Array.from(chunk).find(
-                  (entry) => entry.SerialNumber === serialNumber,
-                ),
-              ),
+              Stream.filter((entry) => entry.SerialNumber === serialNumber),
+              Stream.runHead,
+              Effect.map(Option.getOrUndefined),
             );
           return device
             ? {

--- a/packages/alchemy/src/AWS/ImageBuilder/internal.ts
+++ b/packages/alchemy/src/AWS/ImageBuilder/internal.ts
@@ -2,6 +2,7 @@ import * as logs from "@distilled.cloud/aws/cloudwatch-logs";
 import * as imagebuilder from "@distilled.cloud/aws/imagebuilder";
 import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";
+import * as Stream from "effect/Stream";
 import { deepEqual, isResolved } from "../../Diff.ts";
 import type { Input } from "../../Input.ts";
 import * as Output from "../../Output.ts";
@@ -71,13 +72,16 @@ export const deleteImageBuilderLogGroup = Effect.fn(function* (
   );
 
   for (let attempt = 0; attempt < 20; attempt++) {
-    const response = yield* logs.describeLogGroups({
-      logGroupNamePrefix: logGroupName,
-      limit: 1,
-    });
-    const present = (response.logGroups ?? []).some(
-      (group) => group.logGroupName === logGroupName,
-    );
+    const present = yield* logs.describeLogGroups
+      .items({ logGroupNamePrefix: logGroupName })
+      .pipe(
+        Stream.runCollect,
+        Effect.map((chunk) =>
+          Array.from(chunk).some(
+            (group) => group.logGroupName === logGroupName,
+          ),
+        ),
+      );
     if (!present) return;
     yield* Effect.sleep("500 millis");
   }

--- a/packages/alchemy/src/AWS/ImageBuilder/internal.ts
+++ b/packages/alchemy/src/AWS/ImageBuilder/internal.ts
@@ -1,6 +1,7 @@
 import * as logs from "@distilled.cloud/aws/cloudwatch-logs";
 import * as imagebuilder from "@distilled.cloud/aws/imagebuilder";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
 import { deepEqual, isResolved } from "../../Diff.ts";
@@ -75,12 +76,9 @@ export const deleteImageBuilderLogGroup = Effect.fn(function* (
     const present = yield* logs.describeLogGroups
       .items({ logGroupNamePrefix: logGroupName })
       .pipe(
-        Stream.runCollect,
-        Effect.map((chunk) =>
-          Array.from(chunk).some(
-            (group) => group.logGroupName === logGroupName,
-          ),
-        ),
+        Stream.filter((group) => group.logGroupName === logGroupName),
+        Stream.runHead,
+        Effect.map(Option.isSome),
       );
     if (!present) return;
     yield* Effect.sleep("500 millis");

--- a/packages/alchemy/src/AWS/Logs/Destination.ts
+++ b/packages/alchemy/src/AWS/Logs/Destination.ts
@@ -1,5 +1,6 @@
 import * as logs from "@distilled.cloud/aws/cloudwatch-logs";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
 import { isResolved } from "../../Diff.ts";
@@ -115,12 +116,15 @@ export const DestinationProvider = () =>
             : JSON.stringify(policy);
 
       const observe = Effect.fn(function* (destinationName: string) {
-        const described = yield* logs.describeDestinations({
-          DestinationNamePrefix: destinationName,
-        });
-        return (described.destinations ?? []).find(
-          (destination) => destination.destinationName === destinationName,
-        );
+        return yield* logs.describeDestinations
+          .items({ DestinationNamePrefix: destinationName })
+          .pipe(
+            Stream.filter(
+              (destination) => destination.destinationName === destinationName,
+            ),
+            Stream.runHead,
+            Effect.map(Option.getOrUndefined),
+          );
       });
 
       return {

--- a/packages/alchemy/src/AWS/Logs/LogGroup.ts
+++ b/packages/alchemy/src/AWS/Logs/LogGroup.ts
@@ -1,6 +1,7 @@
 import * as logs from "@distilled.cloud/aws/cloudwatch-logs";
 import type * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
 import { isResolved } from "../../Diff.ts";
@@ -163,6 +164,15 @@ export const LogGroupProvider = () =>
       // phantom drift and interpolated IAM ARNs (`${arn}:*`) stay correct.
       const normalizeLogGroupArn = (arn: string): LogGroupArn =>
         (arn.endsWith(":*") ? arn.slice(0, -2) : arn) as LogGroupArn;
+      const observe = Effect.fn(function* (logGroupName: string) {
+        return yield* logs.describeLogGroups
+          .items({ logGroupNamePrefix: logGroupName })
+          .pipe(
+            Stream.filter((group) => group.logGroupName === logGroupName),
+            Stream.runHead,
+            Effect.map(Option.getOrUndefined),
+          );
+      });
 
       return {
         stables: ["logGroupArn", "logGroupName"],
@@ -238,13 +248,7 @@ export const LogGroupProvider = () =>
         read: Effect.fn(function* ({ id, olds, output }) {
           const logGroupName =
             output?.logGroupName ?? (yield* toLogGroupName(id, olds ?? {}));
-          const described = yield* logs.describeLogGroups({
-            logGroupNamePrefix: logGroupName,
-            limit: 1,
-          });
-          const match = (described.logGroups ?? []).find(
-            (group) => group.logGroupName === logGroupName,
-          );
+          const match = yield* observe(logGroupName);
           if (!match?.arn) {
             return undefined;
           }
@@ -272,13 +276,7 @@ export const LogGroupProvider = () =>
           // Observe - fetch live state. `describeLogGroups` returns
           // retention/kms info so we can diff against desired without
           // trusting `olds` or `output`.
-          const described = yield* logs.describeLogGroups({
-            logGroupNamePrefix: logGroupName,
-            limit: 1,
-          });
-          let observed = (described.logGroups ?? []).find(
-            (group) => group.logGroupName === logGroupName,
-          );
+          let observed = yield* observe(logGroupName);
 
           // Ensure - create if missing. `createLogGroup` accepts tags and
           // kmsKeyId on first create; tolerate `ResourceAlreadyExistsException`
@@ -298,13 +296,7 @@ export const LogGroupProvider = () =>
                   () => Effect.void,
                 ),
               );
-            const reread = yield* logs.describeLogGroups({
-              logGroupNamePrefix: logGroupName,
-              limit: 1,
-            });
-            observed = (reread.logGroups ?? []).find(
-              (group) => group.logGroupName === logGroupName,
-            );
+            observed = yield* observe(logGroupName);
           }
 
           // Sync KMS key - create accepts kmsKeyId, but updates require the
@@ -441,17 +433,14 @@ export const LogGroupProvider = () =>
             );
 
           const remaining = yield* Effect.repeat(
-            logs
-              .describeLogGroups({
-                logGroupNamePrefix: output.logGroupName,
-                limit: 1,
-              })
+            logs.describeLogGroups
+              .items({ logGroupNamePrefix: output.logGroupName })
               .pipe(
-                Effect.map((response) =>
-                  (response.logGroups ?? []).some(
-                    (group) => group.logGroupName === output.logGroupName,
-                  ),
+                Stream.filter(
+                  (group) => group.logGroupName === output.logGroupName,
                 ),
+                Stream.runHead,
+                Effect.map(Option.isSome),
               ),
             {
               schedule: Schedule.fixed("250 millis"),

--- a/packages/alchemy/src/AWS/Logs/SubscriptionFilter.ts
+++ b/packages/alchemy/src/AWS/Logs/SubscriptionFilter.ts
@@ -1,5 +1,6 @@
 import * as logs from "@distilled.cloud/aws/cloudwatch-logs";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
 import { isResolved } from "../../Diff.ts";
@@ -151,22 +152,24 @@ export const SubscriptionFilterProvider = () =>
         logGroupName: string,
         filterName: string,
       ) {
-        const described = yield* logs
-          .describeSubscriptionFilters({
+        return yield* logs.describeSubscriptionFilters
+          .items({
             logGroupName,
             filterNamePrefix: filterName,
           })
           .pipe(
+            Stream.filter(
+              (
+                filter,
+              ): filter is logs.SubscriptionFilter & { filterName: string } =>
+                filter.filterName === filterName,
+            ),
+            Stream.runHead,
+            Effect.map(Option.getOrUndefined),
             Effect.catchTag("ResourceNotFoundException", () =>
-              Effect.succeed({ subscriptionFilters: [] }),
+              Effect.succeed(undefined),
             ),
           );
-        return (described.subscriptionFilters ?? []).find(
-          (
-            filter,
-          ): filter is logs.SubscriptionFilter & { filterName: string } =>
-            filter.filterName === filterName,
-        );
       });
 
       return {
@@ -187,17 +190,19 @@ export const SubscriptionFilterProvider = () =>
             const perGroup = yield* Effect.forEach(
               groups,
               (logGroupName) =>
-                logs.describeSubscriptionFilters({ logGroupName }).pipe(
-                  Effect.map((r) =>
-                    (r.subscriptionFilters ?? [])
-                      .filter(
-                        (
-                          filter,
-                        ): filter is logs.SubscriptionFilter & {
-                          filterName: string;
-                        } => filter.filterName != null,
-                      )
-                      .map((filter) => toAttributes(logGroupName, filter)),
+                logs.describeSubscriptionFilters.items({ logGroupName }).pipe(
+                  Stream.filter(
+                    (
+                      filter,
+                    ): filter is logs.SubscriptionFilter & {
+                      filterName: string;
+                    } => filter.filterName != null,
+                  ),
+                  Stream.runCollect,
+                  Effect.map((chunk) =>
+                    Array.from(chunk).map((filter) =>
+                      toAttributes(logGroupName, filter),
+                    ),
                   ),
                   // group deleted between list and describe — skip
                   Effect.catchTag("ResourceNotFoundException", () =>

--- a/packages/alchemy/src/AWS/Redshift/ClusterParameterGroup.ts
+++ b/packages/alchemy/src/AWS/Redshift/ClusterParameterGroup.ts
@@ -109,7 +109,10 @@ export const ClusterParameterGroupProvider = () =>
   Provider.effect(
     ClusterParameterGroup,
     Effect.gen(function* () {
-      const toName = (id: string, props: Partial<ClusterParameterGroupProps>) =>
+      const toName = (
+        id: string,
+        props: Partial<ClusterParameterGroupProps>,
+      ) =>
         props.clusterParameterGroupName
           ? Effect.succeed(props.clusterParameterGroupName)
           : createPhysicalName({ id, maxLength: 255, lowercase: true });

--- a/packages/alchemy/src/AWS/Route53Resolver/ResolverEndpoint.ts
+++ b/packages/alchemy/src/AWS/Route53Resolver/ResolverEndpoint.ts
@@ -1,5 +1,6 @@
 import * as r53r from "@distilled.cloud/aws/route53resolver";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
 import { Unowned } from "../../AdoptPolicy.ts";
@@ -243,12 +244,15 @@ export const ResolverEndpointProvider = () =>
             return byId;
           }
         }
-        const listed = yield* r53r.listResolverEndpoints({
-          Filters: [{ Name: "CreatorRequestId", Values: [name] }],
-        });
-        return (listed.ResolverEndpoints ?? []).find(
-          (endpoint) => endpoint.Status !== "DELETING",
-        );
+        return yield* r53r.listResolverEndpoints
+          .items({
+            Filters: [{ Name: "CreatorRequestId", Values: [name] }],
+          })
+          .pipe(
+            Stream.filter((endpoint) => endpoint.Status !== "DELETING"),
+            Stream.runHead,
+            Effect.map(Option.getOrUndefined),
+          );
       });
 
       return ResolverEndpoint.Provider.of({

--- a/packages/alchemy/src/AWS/Route53Resolver/ResolverRule.ts
+++ b/packages/alchemy/src/AWS/Route53Resolver/ResolverRule.ts
@@ -1,5 +1,6 @@
 import * as r53r from "@distilled.cloud/aws/route53resolver";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
 import { Unowned } from "../../AdoptPolicy.ts";
@@ -211,12 +212,15 @@ export const ResolverRuleProvider = () =>
             return byId;
           }
         }
-        const listed = yield* r53r.listResolverRules({
-          Filters: [{ Name: "CreatorRequestId", Values: [name] }],
-        });
-        return (listed.ResolverRules ?? []).find(
-          (rule) => rule.Status !== "DELETING",
-        );
+        return yield* r53r.listResolverRules
+          .items({
+            Filters: [{ Name: "CreatorRequestId", Values: [name] }],
+          })
+          .pipe(
+            Stream.filter((rule) => rule.Status !== "DELETING"),
+            Stream.runHead,
+            Effect.map(Option.getOrUndefined),
+          );
       });
 
       // Desired-vs-observed comparison of target IPs, tolerant of the

--- a/packages/alchemy/src/AWS/Route53Resolver/internal.ts
+++ b/packages/alchemy/src/AWS/Route53Resolver/internal.ts
@@ -1,5 +1,6 @@
 import * as r53r from "@distilled.cloud/aws/route53resolver";
 import * as Effect from "effect/Effect";
+import * as Stream from "effect/Stream";
 import { diffTags } from "../../Tags.ts";
 
 /**
@@ -11,11 +12,12 @@ import { diffTags } from "../../Tags.ts";
  * @internal
  */
 export const fetchResolverTags = (arn: string) =>
-  r53r.listTagsForResource({ ResourceArn: arn }).pipe(
+  r53r.listTagsForResource.items({ ResourceArn: arn }).pipe(
+    Stream.runCollect,
     Effect.map(
-      (r) =>
+      (chunk) =>
         Object.fromEntries(
-          (r.Tags ?? []).map((tag) => [tag.Key, tag.Value]),
+          Array.from(chunk).map((tag) => [tag.Key, tag.Value]),
         ) as Record<string, string>,
     ),
     Effect.catch(() => Effect.succeed({} as Record<string, string>)),

--- a/packages/alchemy/src/AWS/S3Tables/Table.ts
+++ b/packages/alchemy/src/AWS/S3Tables/Table.ts
@@ -128,7 +128,9 @@ const createTableName = (id: string, props: { name?: string | undefined }) =>
     return base.replaceAll("-", "_");
   });
 
-const buildMetadata = (props: TableProps): s3tables.TableMetadata | undefined =>
+const buildMetadata = (
+  props: TableProps,
+): s3tables.TableMetadata | undefined =>
   props.schema
     ? {
         iceberg: {

--- a/packages/alchemy/src/AWS/SNS/Subscription.ts
+++ b/packages/alchemy/src/AWS/SNS/Subscription.ts
@@ -1,5 +1,6 @@
 import * as sns from "@distilled.cloud/aws/sns";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import * as Stream from "effect/Stream";
 import { isResolved } from "../../Diff.ts";
 import type { Input } from "../../Input.ts";
@@ -337,30 +338,20 @@ const findSubscription = Effect.fn(function* ({
     return undefined;
   }
 
-  let nextToken: string | undefined;
-
-  while (true) {
-    const response = yield* sns.listSubscriptionsByTopic({
-      TopicArn: topicArn,
-      NextToken: nextToken,
-    });
-
-    const match = response.Subscriptions?.find(
-      (subscription) =>
-        subscription.Protocol === protocol &&
-        subscription.Endpoint === endpoint,
+  const match = yield* sns.listSubscriptionsByTopic
+    .items({ TopicArn: topicArn })
+    .pipe(
+      Stream.filter(
+        (subscription) =>
+          subscription.Protocol === protocol &&
+          subscription.Endpoint === endpoint &&
+          !!subscription.SubscriptionArn,
+      ),
+      Stream.runHead,
+      Effect.map(Option.getOrUndefined),
     );
 
-    if (match?.SubscriptionArn) {
-      return match.SubscriptionArn;
-    }
-
-    if (!response.NextToken) {
-      return undefined;
-    }
-
-    nextToken = response.NextToken;
-  }
+  return match?.SubscriptionArn;
 });
 
 const readSubscription = Effect.fn(function* ({

--- a/packages/alchemy/src/AWS/SNS/Topic.ts
+++ b/packages/alchemy/src/AWS/SNS/Topic.ts
@@ -1,5 +1,6 @@
 import * as sns from "@distilled.cloud/aws/sns";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import * as Stream from "effect/Stream";
 import { Unowned } from "../../AdoptPolicy.ts";
 import { isResolved } from "../../Diff.ts";
@@ -373,27 +374,12 @@ const toAttributeMap = (
   );
 
 const findTopicArnByName = Effect.fn(function* (topicName: string) {
-  let nextToken: string | undefined;
-
-  while (true) {
-    const response = yield* sns.listTopics({
-      NextToken: nextToken,
-    });
-
-    const match = response.Topics?.find(
-      (topic) => topic.TopicArn?.split(":").at(-1) === topicName,
-    )?.TopicArn;
-
-    if (match) {
-      return match;
-    }
-
-    if (!response.NextToken) {
-      return undefined;
-    }
-
-    nextToken = response.NextToken;
-  }
+  const match = yield* sns.listTopics.items({}).pipe(
+    Stream.filter((topic) => topic.TopicArn?.split(":").at(-1) === topicName),
+    Stream.runHead,
+    Effect.map(Option.getOrUndefined),
+  );
+  return match?.TopicArn;
 });
 
 const readTopic = Effect.fn(function* ({

--- a/packages/alchemy/src/AWS/SSM/Parameter.ts
+++ b/packages/alchemy/src/AWS/SSM/Parameter.ts
@@ -1,6 +1,7 @@
 import * as kms from "@distilled.cloud/aws/kms";
 import * as ssm from "@distilled.cloud/aws/ssm";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import * as Redacted from "effect/Redacted";
 import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
@@ -235,19 +236,18 @@ export const ParameterProvider = () =>
       // allowedPattern, and the KMS key id. It is eventually consistent, so
       // treat an absent result as "no metadata yet" rather than "missing".
       const describeByName = Effect.fn(function* (name: string) {
-        const parameters = yield* ssm.describeParameters
+        return yield* ssm.describeParameters
           .pages({
             ParameterFilters: [
               { Key: "Name", Option: "Equals", Values: [name] },
             ],
           })
           .pipe(
-            Stream.runCollect,
-            Effect.map((chunk) =>
-              Array.from(chunk).flatMap((page) => page.Parameters ?? []),
-            ),
+            Stream.map((page) => page.Parameters ?? []),
+            Stream.flattenIterable,
+            Stream.runHead,
+            Effect.map(Option.getOrUndefined),
           );
-        return parameters[0];
       });
 
       // Resolve a key id/alias/ARN to the key ARN for the `keyArn` attribute.

--- a/packages/alchemy/src/AWS/SSM/Parameter.ts
+++ b/packages/alchemy/src/AWS/SSM/Parameter.ts
@@ -235,10 +235,19 @@ export const ParameterProvider = () =>
       // allowedPattern, and the KMS key id. It is eventually consistent, so
       // treat an absent result as "no metadata yet" rather than "missing".
       const describeByName = Effect.fn(function* (name: string) {
-        const result = yield* ssm.describeParameters({
-          ParameterFilters: [{ Key: "Name", Option: "Equals", Values: [name] }],
-        });
-        return result.Parameters?.[0];
+        const parameters = yield* ssm.describeParameters
+          .pages({
+            ParameterFilters: [
+              { Key: "Name", Option: "Equals", Values: [name] },
+            ],
+          })
+          .pipe(
+            Stream.runCollect,
+            Effect.map((chunk) =>
+              Array.from(chunk).flatMap((page) => page.Parameters ?? []),
+            ),
+          );
+        return parameters[0];
       });
 
       // Resolve a key id/alias/ARN to the key ARN for the `keyArn` attribute.

--- a/packages/alchemy/src/AWS/SageMaker/Model.ts
+++ b/packages/alchemy/src/AWS/SageMaker/Model.ts
@@ -135,12 +135,16 @@ const createModelName = (
     : createPhysicalName({ id, maxLength: 63 });
 
 const fetchModelTags = Effect.fn(function* (arn: string) {
-  const response = yield* sagemaker.listTags({ ResourceArn: arn }).pipe(
+  const tags = yield* sagemaker.listTags.items({ ResourceArn: arn }).pipe(
+    EffectStream.runCollect,
+    Effect.map((chunk) => Array.from(chunk)),
     // A just-deleted (or foreign) resource ARN surfaces as AccessDenied.
-    Effect.catchTag("AccessDeniedException", () => Effect.succeed(undefined)),
+    Effect.catchTag("AccessDeniedException", () =>
+      Effect.succeed<sagemaker.Tag[]>([]),
+    ),
   );
   return Object.fromEntries(
-    (response?.Tags ?? []).flatMap((tag) =>
+    tags.flatMap((tag) =>
       tag.Key !== undefined ? [[tag.Key, tag.Value ?? ""]] : [],
     ),
   );

--- a/packages/alchemy/src/AWS/StepFunctions/StateMachine.ts
+++ b/packages/alchemy/src/AWS/StepFunctions/StateMachine.ts
@@ -923,22 +923,18 @@ export const StateMachineProvider = () =>
           // being partially or fully gone already.
           if (output.roleName !== undefined) {
             const roleName = output.roleName;
-            yield* iam.listRolePolicies({ RoleName: roleName }).pipe(
-              Effect.flatMap((policies) =>
-                Effect.forEach(policies.PolicyNames ?? [], (policyName) =>
-                  iam
-                    .deleteRolePolicy({
-                      RoleName: roleName,
-                      PolicyName: policyName,
-                    })
-                    .pipe(
-                      Effect.catchTag(
-                        "NoSuchEntityException",
-                        () => Effect.void,
-                      ),
-                    ),
-                ),
+            yield* iam.listRolePolicies.items({ RoleName: roleName }).pipe(
+              Stream.mapEffect((policyName) =>
+                iam
+                  .deleteRolePolicy({
+                    RoleName: roleName,
+                    PolicyName: policyName,
+                  })
+                  .pipe(
+                    Effect.catchTag("NoSuchEntityException", () => Effect.void),
+                  ),
               ),
+              Stream.runDrain,
               Effect.catchTag("NoSuchEntityException", () => Effect.void),
             );
             yield* iam

--- a/packages/alchemy/src/AWS/Timestream/ScheduledQuery.ts
+++ b/packages/alchemy/src/AWS/Timestream/ScheduledQuery.ts
@@ -193,21 +193,24 @@ const readScheduledQuery = Effect.fn(function* (scheduledQueryArn: string) {
     return undefined;
   }
   const scheduledQuery = response.ScheduledQuery;
-  const tagsResponse = yield* withQueryEndpoint(
-    TSQ.listTagsForResource({ ResourceARN: scheduledQuery.Arn }),
+  const tags = yield* withQueryEndpoint(
+    TSQ.listTagsForResource.items({ ResourceARN: scheduledQuery.Arn }).pipe(
+      EffectStream.runCollect,
+      Effect.map((chunk) => Array.from(chunk)),
+    ),
   ).pipe(
     Effect.catchTag("ResourceNotFoundException", () =>
       Effect.succeed(undefined),
     ),
   );
-  if (!tagsResponse) {
+  if (!tags) {
     return undefined;
   }
   return {
     scheduledQueryArn: scheduledQuery.Arn,
     name: scheduledQuery.Name,
     state: scheduledQuery.State,
-    tags: toTagRecord(tagsResponse.Tags),
+    tags: toTagRecord(tags),
   } satisfies ScheduledQuery["Attributes"];
 });
 

--- a/packages/alchemy/src/AWS/Timestream/ScheduledQuery.ts
+++ b/packages/alchemy/src/AWS/Timestream/ScheduledQuery.ts
@@ -1,5 +1,6 @@
 import * as TSQ from "@distilled.cloud/aws/timestream-query";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import * as EffectStream from "effect/Stream";
 import { Unowned } from "../../AdoptPolicy.ts";
 import { isResolved } from "../../Diff.ts";
@@ -215,14 +216,14 @@ const readScheduledQuery = Effect.fn(function* (scheduledQueryArn: string) {
 });
 
 const findScheduledQueryByName = Effect.fn(function* (name: string) {
-  const summaries = yield* withQueryEndpoint(
-    TSQ.listScheduledQueries.pages({}).pipe(EffectStream.runCollect),
-  ).pipe(
-    Effect.map((chunk) =>
-      Array.from(chunk).flatMap((page) => page.ScheduledQueries ?? []),
+  const match = yield* withQueryEndpoint(
+    TSQ.listScheduledQueries.pages({}).pipe(
+      EffectStream.map((page) => page.ScheduledQueries ?? []),
+      EffectStream.flattenIterable,
+      EffectStream.filter((summary) => summary.Name === name),
+      EffectStream.runHead,
     ),
-  );
-  const match = summaries.find((summary) => summary.Name === name);
+  ).pipe(Effect.map(Option.getOrUndefined));
   if (!match) return undefined;
   return yield* readScheduledQuery(match.Arn);
 });

--- a/packages/alchemy/src/AWS/XRay/Group.ts
+++ b/packages/alchemy/src/AWS/XRay/Group.ts
@@ -134,9 +134,10 @@ export const GroupProvider = () =>
         );
 
       const observedTags = (groupArn: string) =>
-        xray.listTagsForResource({ ResourceARN: groupArn }).pipe(
-          Effect.map((r) =>
-            Object.fromEntries((r.Tags ?? []).map((t) => [t.Key, t.Value])),
+        xray.listTagsForResource.items({ ResourceARN: groupArn }).pipe(
+          Stream.runCollect,
+          Effect.map((chunk) =>
+            Object.fromEntries(Array.from(chunk).map((t) => [t.Key, t.Value])),
           ),
           Effect.catchTag("ResourceNotFoundException", () =>
             Effect.succeed({} as Record<string, string>),

--- a/packages/alchemy/src/AWS/XRay/SamplingRule.ts
+++ b/packages/alchemy/src/AWS/XRay/SamplingRule.ts
@@ -215,9 +215,10 @@ export const SamplingRuleProvider = () =>
         );
 
       const observedTags = (ruleArn: string) =>
-        xray.listTagsForResource({ ResourceARN: ruleArn }).pipe(
-          Effect.map((r) =>
-            Object.fromEntries((r.Tags ?? []).map((t) => [t.Key, t.Value])),
+        xray.listTagsForResource.items({ ResourceARN: ruleArn }).pipe(
+          Stream.runCollect,
+          Effect.map((chunk) =>
+            Object.fromEntries(Array.from(chunk).map((t) => [t.Key, t.Value])),
           ),
           Effect.catchTag("ResourceNotFoundException", () =>
             Effect.succeed({} as Record<string, string>),

--- a/packages/alchemy/src/Cloudflare/AI/Dataset.ts
+++ b/packages/alchemy/src/Cloudflare/AI/Dataset.ts
@@ -341,15 +341,18 @@ const getDataset = (accountId: string, gatewayId: string, id: string) =>
  * dataset is gone too.
  */
 const findByName = (accountId: string, gatewayId: string, name: string) =>
-  aiGateway.listDatasets({ accountId, gatewayId, name, perPage: 50 }).pipe(
-    Effect.map((list) =>
-      list.result
-        .filter((d) => d.name === name)
-        .sort((a, b) => a.createdAt.localeCompare(b.createdAt))
-        .at(0),
-    ),
-    Effect.catchTag("GatewayNotFound", () => Effect.succeed(undefined)),
-  );
+  aiGateway.listDatasets
+    .items({ accountId, gatewayId, name, perPage: 50 })
+    .pipe(
+      Stream.filter((d) => d.name === name),
+      Stream.runCollect,
+      Effect.map((chunk) =>
+        Array.from(chunk)
+          .sort((a, b) => a.createdAt.localeCompare(b.createdAt))
+          .at(0),
+      ),
+      Effect.catchTag("GatewayNotFound", () => Effect.succeed(undefined)),
+    );
 
 const createDatasetName = (id: string, name: string | undefined) =>
   Effect.gen(function* () {

--- a/packages/alchemy/src/Cloudflare/AI/Evaluation.ts
+++ b/packages/alchemy/src/Cloudflare/AI/Evaluation.ts
@@ -321,14 +321,17 @@ const getEvaluation = (accountId: string, gatewayId: string, id: string) =>
  * returns an empty list on this endpoint.
  */
 const findByName = (accountId: string, gatewayId: string, name: string) =>
-  aiGateway.listEvaluations({ accountId, gatewayId, name, perPage: 50 }).pipe(
-    Effect.map((list) =>
-      list.result
-        .filter((e) => e.name === name)
-        .sort((a, b) => a.createdAt.localeCompare(b.createdAt))
-        .at(0),
-    ),
-  );
+  aiGateway.listEvaluations
+    .items({ accountId, gatewayId, name, perPage: 50 })
+    .pipe(
+      Stream.filter((e) => e.name === name),
+      Stream.runCollect,
+      Effect.map((chunk) =>
+        Array.from(chunk)
+          .sort((a, b) => a.createdAt.localeCompare(b.createdAt))
+          .at(0),
+      ),
+    );
 
 const createEvaluationName = (id: string, name: string | undefined) =>
   Effect.gen(function* () {

--- a/packages/alchemy/src/Cloudflare/Acm/TotalTls.ts
+++ b/packages/alchemy/src/Cloudflare/Acm/TotalTls.ts
@@ -300,7 +300,10 @@ type ObservedTotalTls = acm.GetTotalTlResponse | acm.UpdateTotalTlResponse;
 const initialStateOf = (
   output: TotalTlsAttributes | undefined,
   observed: ObservedTotalTls,
-): Pick<TotalTlsAttributes, "initialEnabled" | "initialCertificateAuthority"> =>
+): Pick<
+  TotalTlsAttributes,
+  "initialEnabled" | "initialCertificateAuthority"
+> =>
   output !== undefined
     ? {
         initialEnabled: output.initialEnabled,

--- a/packages/alchemy/src/Cloudflare/Alerting/NotificationPolicy.ts
+++ b/packages/alchemy/src/Cloudflare/Alerting/NotificationPolicy.ts
@@ -1,5 +1,6 @@
 import * as alerting from "@distilled.cloud/cloudflare/alerting";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import * as Predicate from "effect/Predicate";
 import * as Stream from "effect/Stream";
 
@@ -337,13 +338,10 @@ const observePolicy = (accountId: string, policyId: string) =>
 
 const findPolicyByName = (accountId: string, name: string) =>
   alerting.listPolicies.items({ accountId }).pipe(
-    Stream.runCollect,
-    Effect.map((chunk) =>
-      Array.from(chunk)
-        .filter((p) => p.name === name)
-        .map(narrowPolicy)
-        .find((p) => p !== undefined),
-    ),
+    Stream.filter((p) => p.name === name && p.id != null),
+    Stream.runHead,
+    Effect.map(Option.getOrUndefined),
+    Effect.map((p) => (p === undefined ? undefined : narrowPolicy(p))),
   );
 
 const toPolicyAttributes = (

--- a/packages/alchemy/src/Cloudflare/Alerting/NotificationPolicy.ts
+++ b/packages/alchemy/src/Cloudflare/Alerting/NotificationPolicy.ts
@@ -336,9 +336,10 @@ const observePolicy = (accountId: string, policyId: string) =>
   );
 
 const findPolicyByName = (accountId: string, name: string) =>
-  alerting.listPolicies({ accountId }).pipe(
-    Effect.map((list) =>
-      list.result
+  alerting.listPolicies.items({ accountId }).pipe(
+    Stream.runCollect,
+    Effect.map((chunk) =>
+      Array.from(chunk)
         .filter((p) => p.name === name)
         .map(narrowPolicy)
         .find((p) => p !== undefined),

--- a/packages/alchemy/src/Cloudflare/Alerting/Silence.ts
+++ b/packages/alchemy/src/Cloudflare/Alerting/Silence.ts
@@ -345,9 +345,10 @@ const findSilence = (
   startTime: string,
   endTime: string,
 ) =>
-  alerting.listSilences({ accountId }).pipe(
-    Effect.map((list) =>
-      list.result
+  alerting.listSilences.items({ accountId }).pipe(
+    Stream.runCollect,
+    Effect.map((chunk) =>
+      Array.from(chunk)
         .filter(
           (s) =>
             s.policyId === policyId &&

--- a/packages/alchemy/src/Cloudflare/Alerting/Silence.ts
+++ b/packages/alchemy/src/Cloudflare/Alerting/Silence.ts
@@ -1,6 +1,7 @@
 import * as alerting from "@distilled.cloud/cloudflare/alerting";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import * as Predicate from "effect/Predicate";
 import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
@@ -346,18 +347,16 @@ const findSilence = (
   endTime: string,
 ) =>
   alerting.listSilences.items({ accountId }).pipe(
-    Stream.runCollect,
-    Effect.map((chunk) =>
-      Array.from(chunk)
-        .filter(
-          (s) =>
-            s.policyId === policyId &&
-            sameInstant(undef(s.startTime), startTime) &&
-            sameInstant(undef(s.endTime), endTime),
-        )
-        .map(narrowSilence)
-        .find((s) => s !== undefined),
+    Stream.filter(
+      (s) =>
+        s.id != null &&
+        s.policyId === policyId &&
+        sameInstant(undef(s.startTime), startTime) &&
+        sameInstant(undef(s.endTime), endTime),
     ),
+    Stream.runHead,
+    Effect.map(Option.getOrUndefined),
+    Effect.map((s) => (s === undefined ? undefined : narrowSilence(s))),
   );
 
 /** Compare two ISO8601 timestamps by the instant they denote. */

--- a/packages/alchemy/src/Cloudflare/Alerting/Webhook.ts
+++ b/packages/alchemy/src/Cloudflare/Alerting/Webhook.ts
@@ -1,5 +1,6 @@
 import * as alerting from "@distilled.cloud/cloudflare/alerting";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import * as Predicate from "effect/Predicate";
 import * as Redacted from "effect/Redacted";
 
@@ -323,13 +324,10 @@ const observeWebhook = (accountId: string, webhookId: string) =>
 
 const findWebhookByName = (accountId: string, name: string) =>
   alerting.listDestinationWebhooks.items({ accountId }).pipe(
-    Stream.runCollect,
-    Effect.map((chunk) =>
-      Array.from(chunk)
-        .filter((w) => w.name === name)
-        .map(narrowWebhook)
-        .find((w) => w !== undefined),
-    ),
+    Stream.filter((w) => w.name === name && w.id != null),
+    Stream.runHead,
+    Effect.map(Option.getOrUndefined),
+    Effect.map((w) => (w === undefined ? undefined : narrowWebhook(w))),
   );
 
 const toWebhookAttributes = (

--- a/packages/alchemy/src/Cloudflare/Alerting/Webhook.ts
+++ b/packages/alchemy/src/Cloudflare/Alerting/Webhook.ts
@@ -322,9 +322,10 @@ const observeWebhook = (accountId: string, webhookId: string) =>
   );
 
 const findWebhookByName = (accountId: string, name: string) =>
-  alerting.listDestinationWebhooks({ accountId }).pipe(
-    Effect.map((list) =>
-      list.result
+  alerting.listDestinationWebhooks.items({ accountId }).pipe(
+    Stream.runCollect,
+    Effect.map((chunk) =>
+      Array.from(chunk)
         .filter((w) => w.name === name)
         .map(narrowWebhook)
         .find((w) => w !== undefined),

--- a/packages/alchemy/src/Cloudflare/CloudConnector/Rules.ts
+++ b/packages/alchemy/src/Cloudflare/CloudConnector/Rules.ts
@@ -1,6 +1,7 @@
 import * as cloudConnector from "@distilled.cloud/cloudflare/cloud-connector";
 import * as Effect from "effect/Effect";
 import * as Predicate from "effect/Predicate";
+import * as Stream from "effect/Stream";
 
 import { Unowned } from "../../AdoptPolicy.ts";
 import * as Provider from "../../Provider.ts";
@@ -268,15 +269,10 @@ export const RulesProvider = () =>
   });
 
 const listObservedRules = (zoneId: string) =>
-  cloudConnector.listRules({ zoneId }).pipe(
-    // A zone that has never had Cloud Connector rules configured reports
-    // "could not find entrypoint ruleset" (code 10003) — that's just an
-    // empty list.
-    Effect.catchTag("CloudConnectorRulesNotFound", () =>
-      Effect.succeed({ result: [] }),
-    ),
-    Effect.map((response): RuleAttribute[] =>
-      response.result.flatMap((rule) =>
+  cloudConnector.listRules.items({ zoneId }).pipe(
+    Stream.runCollect,
+    Effect.map((chunk): RuleAttribute[] =>
+      Array.from(chunk).flatMap((rule) =>
         rule.expression == null ||
         rule.provider == null ||
         rule.parameters?.host == null
@@ -292,6 +288,12 @@ const listObservedRules = (zoneId: string) =>
               },
             ],
       ),
+    ),
+    // A zone that has never had Cloud Connector rules configured reports
+    // "could not find entrypoint ruleset" (code 10003) — that's just an
+    // empty list.
+    Effect.catchTag("CloudConnectorRulesNotFound", () =>
+      Effect.succeed([] as RuleAttribute[]),
     ),
   );
 

--- a/packages/alchemy/src/Cloudflare/ContentScanning/Expression.ts
+++ b/packages/alchemy/src/Cloudflare/ContentScanning/Expression.ts
@@ -195,9 +195,12 @@ export const ExpressionProvider = () =>
       //    a guarantee: a missing expression falls through to the payload
       //    scan and then to create. (Scanning must be enabled here — a
       //    disabled zone fails with the typed ContentScanningNotEnabled.)
-      const expressions = yield* contentScanning
-        .listPayloads({ zoneId })
-        .pipe(Effect.map((r) => r.result));
+      const expressions = yield* contentScanning.listPayloads
+        .items({ zoneId })
+        .pipe(
+          Stream.runCollect,
+          Effect.map((chunk) => Array.from(chunk)),
+        );
       let observed = output?.expressionId
         ? expressions.find((e) => e.id === output.expressionId)
         : undefined;
@@ -254,9 +257,10 @@ type ObservedExpression = { id?: string | null; payload?: string | null };
  * (scanning disabled on the zone, or the zone itself gone) to `undefined`.
  */
 const listExpressions = (zoneId: string) =>
-  contentScanning.listPayloads({ zoneId }).pipe(
-    Effect.map(
-      (response): readonly ObservedExpression[] | undefined => response.result,
+  contentScanning.listPayloads.items({ zoneId }).pipe(
+    Stream.runCollect,
+    Effect.map((chunk): readonly ObservedExpression[] | undefined =>
+      Array.from(chunk),
     ),
     Effect.catchTag("ContentScanningNotEnabled", () =>
       Effect.succeed(undefined),

--- a/packages/alchemy/src/Cloudflare/ContentScanning/Expression.ts
+++ b/packages/alchemy/src/Cloudflare/ContentScanning/Expression.ts
@@ -1,6 +1,7 @@
 import * as contentScanning from "@distilled.cloud/cloudflare/content-scanning";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import * as Predicate from "effect/Predicate";
 import * as Stream from "effect/Stream";
 
@@ -195,14 +196,9 @@ export const ExpressionProvider = () =>
       //    a guarantee: a missing expression falls through to the payload
       //    scan and then to create. (Scanning must be enabled here — a
       //    disabled zone fails with the typed ContentScanningNotEnabled.)
-      const expressions = yield* contentScanning.listPayloads
-        .items({ zoneId })
-        .pipe(
-          Stream.runCollect,
-          Effect.map((chunk) => Array.from(chunk)),
-        );
-      let observed = output?.expressionId
-        ? expressions.find((e) => e.id === output.expressionId)
+      const expressionId = output?.expressionId;
+      let observed: ObservedExpression | undefined = expressionId
+        ? yield* findExpression(zoneId, (e) => e.id === expressionId)
         : undefined;
 
       // 2. Fall back to matching by payload text. Ownership has already
@@ -210,7 +206,10 @@ export const ExpressionProvider = () =>
       //    `Unowned` and the engine gates takeover behind the adopt policy
       //    before reconcile ever runs.
       if (!observed) {
-        observed = expressions.find((e) => e.payload === news.payload);
+        observed = yield* findExpression(
+          zoneId,
+          (e) => e.payload === news.payload,
+        );
       }
 
       // 3. Ensure — create when missing. The create call returns the full
@@ -251,6 +250,23 @@ export const ExpressionProvider = () =>
   });
 
 type ObservedExpression = { id?: string | null; payload?: string | null };
+
+/**
+ * Find the first expression on the zone matching `predicate`, terminating
+ * pagination as soon as a match is seen. Unlike {@link listExpressions},
+ * "not observable" errors propagate (reconcile requires scanning enabled).
+ */
+const findExpression = (
+  zoneId: string,
+  predicate: (e: ObservedExpression) => boolean,
+) =>
+  contentScanning.listPayloads
+    .items({ zoneId })
+    .pipe(
+      Stream.filter(predicate),
+      Stream.runHead,
+      Effect.map(Option.getOrUndefined),
+    );
 
 /**
  * List the zone's custom scan expressions, mapping "not observable"

--- a/packages/alchemy/src/Cloudflare/D1/Database.ts
+++ b/packages/alchemy/src/Cloudflare/D1/Database.ts
@@ -1,8 +1,8 @@
 import * as d1 from "@distilled.cloud/cloudflare/d1";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import * as Stream from "effect/Stream";
 
-import type { HttpClient } from "effect/unstable/http/HttpClient";
 import { isResolved } from "../../Diff.ts";
 import { createPhysicalName } from "../../PhysicalName.ts";
 import * as Provider from "../../Provider.ts";
@@ -10,7 +10,6 @@ import { isResourceOfType, Resource } from "../../Resource.ts";
 import { listSqlFiles, readSqlFile } from "../../SQL/SqlFile.ts";
 import { recordsEqual } from "../../Util/equal.ts";
 import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
-import type { Credentials } from "../Credentials.ts";
 import type { Providers } from "../Providers.ts";
 import { applyMigrations } from "./ApplyMigrations.ts";
 import { cloneDatabase } from "./CloneDatabase.ts";
@@ -369,8 +368,11 @@ export const DatabaseProvider = () =>
           );
       }
       const name = yield* createDatabaseName(id, olds?.name);
-      const dbs = yield* d1.listDatabases({ accountId, name });
-      const match = dbs.result.find((db) => db.name === name);
+      const match = yield* d1.listDatabases.items({ accountId, name }).pipe(
+        Stream.filter((db) => db.name === name),
+        Stream.runHead,
+        Effect.map(Option.getOrUndefined),
+      );
       if (match) {
         return {
           databaseId: match.uuid!,
@@ -417,8 +419,13 @@ export const DatabaseProvider = () =>
           );
       }
       if (!observed) {
-        const dbs = yield* d1.listDatabases({ accountId: acct, name });
-        observed = dbs.result.find((db) => db.name === name);
+        observed = yield* d1.listDatabases
+          .items({ accountId: acct, name })
+          .pipe(
+            Stream.filter((db) => db.name === name),
+            Stream.runHead,
+            Effect.map(Option.getOrUndefined),
+          );
       }
 
       // Ensure — create if missing. Cloudflare returns
@@ -438,11 +445,13 @@ export const DatabaseProvider = () =>
           .pipe(
             Effect.catchTag("InvalidProperty", () =>
               Effect.gen(function* () {
-                const dbs = yield* d1.listDatabases({
-                  accountId: acct,
-                  name,
-                });
-                const match = dbs.result.find((db) => db.name === name);
+                const match = yield* d1.listDatabases
+                  .items({ accountId: acct, name })
+                  .pipe(
+                    Stream.filter((db) => db.name === name),
+                    Stream.runHead,
+                    Effect.map(Option.getOrUndefined),
+                  );
                 if (match) {
                   return match;
                 }
@@ -482,11 +491,7 @@ export const DatabaseProvider = () =>
       // Clone is a one-shot seed performed only on first creation.
       // Re-running it on an existing database would clobber data.
       if (isFirstCreation && news.clone) {
-        const sourceId = yield* resolveCloneSource(
-          news.clone,
-          acct,
-          d1.listDatabases,
-        );
+        const sourceId = yield* resolveCloneSource(news.clone, acct);
         yield* cloneDatabase({
           accountId: acct,
           sourceDatabaseId: sourceId,
@@ -558,18 +563,7 @@ const rootDir = Effect.sync(() => process.cwd());
  * Resolve a clone source spec into a concrete database UUID. Looks up by
  * name through `listDatabases` when only a name is provided.
  */
-const resolveCloneSource = (
-  source: CloneSource,
-  accountId: string,
-  listDbs: (input: {
-    accountId: string;
-    name?: string;
-  }) => Effect.Effect<
-    d1.ListDatabasesResponse,
-    d1.ListDatabasesError,
-    Credentials | HttpClient
-  >,
-) =>
+const resolveCloneSource = (source: CloneSource, accountId: string) =>
   Effect.gen(function* () {
     if ("databaseId" in source && source.databaseId) {
       // At lifecycle time, Output<string> attributes have resolved to strings.
@@ -577,8 +571,11 @@ const resolveCloneSource = (
     }
     if ("name" in source && source.name) {
       const name = source.name as unknown as string;
-      const dbs = yield* listDbs({ accountId, name });
-      const match = dbs.result.find((db) => db.name === name);
+      const match = yield* d1.listDatabases.items({ accountId, name }).pipe(
+        Stream.filter((db) => db.name === name),
+        Stream.runHead,
+        Effect.map(Option.getOrUndefined),
+      );
       if (!match?.uuid) {
         return yield* Effect.die(
           `Source database "${name}" not found for cloning`,

--- a/packages/alchemy/src/Cloudflare/DNS/Dnssec.ts
+++ b/packages/alchemy/src/Cloudflare/DNS/Dnssec.ts
@@ -380,7 +380,9 @@ interface InitialDnssec {
  * desired family (`pending` is on its way to `active`,
  * `pending-disabled` / `error` / unknown collapse to `disabled`).
  */
-const statusFamily = (status: string | null | undefined): DnssecDesiredStatus =>
+const statusFamily = (
+  status: string | null | undefined,
+): DnssecDesiredStatus =>
   status === "active" || status === "pending" ? "active" : "disabled";
 
 const flag = (v: boolean | null | undefined): boolean => v ?? false;

--- a/packages/alchemy/src/Cloudflare/DNS/ZoneTransferAcl.ts
+++ b/packages/alchemy/src/Cloudflare/DNS/ZoneTransferAcl.ts
@@ -209,10 +209,11 @@ const getAcl = (accountId: string, aclId: string) =>
  * pick the lexicographically-first id for determinism.
  */
 const findByName = (accountId: string, name: string) =>
-  dns.listZoneTransferAcls({ accountId }).pipe(
-    Effect.map((list) =>
-      list.result
-        .filter((a) => a.name === name)
+  dns.listZoneTransferAcls.items({ accountId }).pipe(
+    Stream.filter((a) => a.name === name),
+    Stream.runCollect,
+    Effect.map((chunk) =>
+      Array.from(chunk)
         .sort((a, b) => a.id.localeCompare(b.id))
         .at(0),
     ),

--- a/packages/alchemy/src/Cloudflare/DNS/ZoneTransferPeer.ts
+++ b/packages/alchemy/src/Cloudflare/DNS/ZoneTransferPeer.ts
@@ -251,10 +251,11 @@ const getPeer = (accountId: string, peerId: string) =>
  * pick the lexicographically-first id for determinism.
  */
 const findByName = (accountId: string, name: string) =>
-  dns.listZoneTransferPeers({ accountId }).pipe(
-    Effect.map((list) =>
-      list.result
-        .filter((p) => p.name === name)
+  dns.listZoneTransferPeers.items({ accountId }).pipe(
+    Stream.filter((p) => p.name === name),
+    Stream.runCollect,
+    Effect.map((chunk) =>
+      Array.from(chunk)
         .sort((a, b) => a.id.localeCompare(b.id))
         .at(0),
     ),

--- a/packages/alchemy/src/Cloudflare/DNS/ZoneTransferTsig.ts
+++ b/packages/alchemy/src/Cloudflare/DNS/ZoneTransferTsig.ts
@@ -213,10 +213,11 @@ const getTsig = (accountId: string, tsigId: string) =>
  * pick the lexicographically-first id for determinism.
  */
 const findByName = (accountId: string, name: string) =>
-  dns.listZoneTransferTsigs({ accountId }).pipe(
-    Effect.map((list) =>
-      list.result
-        .filter((t) => t.name === name)
+  dns.listZoneTransferTsigs.items({ accountId }).pipe(
+    Stream.filter((t) => t.name === name),
+    Stream.runCollect,
+    Effect.map((chunk) =>
+      Array.from(chunk)
         .sort((a, b) => a.id.localeCompare(b.id))
         .at(0),
     ),

--- a/packages/alchemy/src/Cloudflare/Devices/CustomProfile.ts
+++ b/packages/alchemy/src/Cloudflare/Devices/CustomProfile.ts
@@ -560,10 +560,11 @@ const observeLists = Effect.fn(function* (accountId: string, policyId: string) {
  * determinism when names collide).
  */
 const findByName = (accountId: string, name: string) =>
-  zeroTrust.listDevicePolicyCustoms({ accountId }).pipe(
-    Effect.map((list) =>
-      list.result
-        .filter((p) => p.name === name && p.policyId != null)
+  zeroTrust.listDevicePolicyCustoms.items({ accountId }).pipe(
+    Stream.filter((p) => p.name === name && p.policyId != null),
+    Stream.runCollect,
+    Effect.map((chunk) =>
+      Array.from(chunk)
         .sort((a, b) => (a.policyId ?? "").localeCompare(b.policyId ?? ""))
         .at(0),
     ),

--- a/packages/alchemy/src/Cloudflare/Devices/PostureRule.ts
+++ b/packages/alchemy/src/Cloudflare/Devices/PostureRule.ts
@@ -304,10 +304,11 @@ const observeRule = (accountId: string, ruleId: string) =>
  * names collide).
  */
 const findByName = (accountId: string, name: string) =>
-  zeroTrust.listDevicePostures({ accountId }).pipe(
-    Effect.map((list) =>
-      list.result
-        .filter((r) => r.name === name && r.id != null)
+  zeroTrust.listDevicePostures.items({ accountId }).pipe(
+    Stream.filter((r) => r.name === name && r.id != null),
+    Stream.runCollect,
+    Effect.map((chunk) =>
+      Array.from(chunk)
         .sort((a, b) => (a.id ?? "").localeCompare(b.id ?? ""))
         .at(0),
     ),

--- a/packages/alchemy/src/Cloudflare/Flagship/App.ts
+++ b/packages/alchemy/src/Cloudflare/Flagship/App.ts
@@ -241,10 +241,11 @@ const getApp = (accountId: string, appId: string) =>
  * oldest for determinism.
  */
 const findByName = (accountId: string, name: string) =>
-  flagship.listApps({ accountId }).pipe(
-    Effect.map((list) =>
-      list.result
-        .filter((a) => a.name === name)
+  flagship.listApps.items({ accountId }).pipe(
+    Stream.filter((a) => a.name === name),
+    Stream.runCollect,
+    Effect.map((chunk) =>
+      Array.from(chunk)
         .sort((a, b) => a.createdAt.localeCompare(b.createdAt))
         .at(0),
     ),

--- a/packages/alchemy/src/Cloudflare/Hyperdrive/Connection.ts
+++ b/packages/alchemy/src/Cloudflare/Hyperdrive/Connection.ts
@@ -1,5 +1,6 @@
 import * as hyperdrive from "@distilled.cloud/cloudflare/hyperdrive";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import * as Redacted from "effect/Redacted";
 import * as Stream from "effect/Stream";
 
@@ -349,8 +350,11 @@ const createConfigName = (id: string, name: string | undefined) =>
 const findByName = (name: string) =>
   Effect.gen(function* () {
     const { accountId } = yield* yield* CloudflareEnvironment;
-    const list = yield* hyperdrive.listConfigs({ accountId });
-    return list.result.find((c) => c.name === name);
+    return yield* hyperdrive.listConfigs.items({ accountId }).pipe(
+      Stream.filter((c) => c.name === name),
+      Stream.runHead,
+      Effect.map(Option.getOrUndefined),
+    );
   });
 
 export const defaultPort = (scheme: Scheme): number =>

--- a/packages/alchemy/src/Cloudflare/Intel/IndicatorFeed.ts
+++ b/packages/alchemy/src/Cloudflare/Intel/IndicatorFeed.ts
@@ -369,10 +369,11 @@ const getFeed = (accountId: string, feedId: number) =>
  * determinism.
  */
 const findByName = (accountId: string, name: string) =>
-  intel.listIndicatorFeeds({ accountId }).pipe(
-    Effect.map((list) =>
-      list.result
-        .filter((f) => f.name === name)
+  intel.listIndicatorFeeds.items({ accountId }).pipe(
+    Stream.filter((f) => f.name === name),
+    Stream.runCollect,
+    Effect.map((chunk) =>
+      Array.from(chunk)
         .sort((a, b) => (a.createdOn ?? "").localeCompare(b.createdOn ?? ""))
         .at(0),
     ),

--- a/packages/alchemy/src/Cloudflare/ResourceSharing/Share.ts
+++ b/packages/alchemy/src/Cloudflare/ResourceSharing/Share.ts
@@ -284,12 +284,13 @@ export const ShareProvider = () =>
 
       // Sync recipients — diff observed cloud state against desired and
       // apply add/remove deltas through the recipient sub-API.
-      const observedRecipients = yield* resourceSharing.listRecipients({
-        accountId: acct,
-        shareId: observed.id,
-        perPage: 50,
-      });
-      const liveRecipients = observedRecipients.result.filter(
+      const observedRecipients = yield* resourceSharing.listRecipients
+        .items({ accountId: acct, shareId: observed.id, perPage: 50 })
+        .pipe(
+          Stream.runCollect,
+          Effect.map((chunk) => Array.from(chunk)),
+        );
+      const liveRecipients = observedRecipients.filter(
         (r) => r.associationStatus !== "disassociated",
       );
       for (const desired of desiredRecipients) {
@@ -322,12 +323,13 @@ export const ShareProvider = () =>
 
       // Sync resources — keyed by (resourceType, resourceId): create
       // missing entries, update `meta` in place, delete extras.
-      const observedResources = yield* resourceSharing.listResources({
-        accountId: acct,
-        shareId: observed.id,
-        perPage: 50,
-      });
-      const liveResources = observedResources.result.filter(
+      const observedResources = yield* resourceSharing.listResources
+        .items({ accountId: acct, shareId: observed.id, perPage: 50 })
+        .pipe(
+          Stream.runCollect,
+          Effect.map((chunk) => Array.from(chunk)),
+        );
+      const liveResources = observedResources.filter(
         (r) => r.status !== "deleted" && r.status !== "deleting",
       );
       for (const desired of desiredResources) {

--- a/packages/alchemy/src/Cloudflare/ResourceSharing/ShareRecipient.ts
+++ b/packages/alchemy/src/Cloudflare/ResourceSharing/ShareRecipient.ts
@@ -288,15 +288,18 @@ const getRecipient = (
  * surfaces as `ShareNotFound` — treat it as "no recipient".
  */
 const findRecipient = (accountId: string, shareId: string, target: string) =>
-  resourceSharing.listRecipients({ accountId, shareId, perPage: 50 }).pipe(
-    Effect.map((list) =>
-      list.result.find(
-        (r) =>
-          r.accountId === target && r.associationStatus !== "disassociated",
+  resourceSharing.listRecipients
+    .items({ accountId, shareId, perPage: 50 })
+    .pipe(
+      Stream.runCollect,
+      Effect.map((chunk) =>
+        Array.from(chunk).find(
+          (r) =>
+            r.accountId === target && r.associationStatus !== "disassociated",
+        ),
       ),
-    ),
-    Effect.catchTag("ShareNotFound", () => Effect.succeed(undefined)),
-  );
+      Effect.catchTag("ShareNotFound", () => Effect.succeed(undefined)),
+    );
 
 const toAttributes = (
   recipient:

--- a/packages/alchemy/src/Cloudflare/ResourceSharing/ShareRecipient.ts
+++ b/packages/alchemy/src/Cloudflare/ResourceSharing/ShareRecipient.ts
@@ -1,5 +1,6 @@
 import * as resourceSharing from "@distilled.cloud/cloudflare/resource-sharing";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import * as Predicate from "effect/Predicate";
 import * as Stream from "effect/Stream";
 
@@ -291,13 +292,12 @@ const findRecipient = (accountId: string, shareId: string, target: string) =>
   resourceSharing.listRecipients
     .items({ accountId, shareId, perPage: 50 })
     .pipe(
-      Stream.runCollect,
-      Effect.map((chunk) =>
-        Array.from(chunk).find(
-          (r) =>
-            r.accountId === target && r.associationStatus !== "disassociated",
-        ),
+      Stream.filter(
+        (r) =>
+          r.accountId === target && r.associationStatus !== "disassociated",
       ),
+      Stream.runHead,
+      Effect.map(Option.getOrUndefined),
       Effect.catchTag("ShareNotFound", () => Effect.succeed(undefined)),
     );
 

--- a/packages/alchemy/src/Cloudflare/SchemaValidation/Schema.ts
+++ b/packages/alchemy/src/Cloudflare/SchemaValidation/Schema.ts
@@ -321,10 +321,11 @@ const getSchema = (zoneId: string, schemaId: string) =>
  * schemas carry the same name, pick the oldest for determinism.
  */
 const findByName = (zoneId: string, name: string) =>
-  schemaValidation.listSchemas({ zoneId, omitSource: true }).pipe(
-    Effect.map((page) =>
-      page.result
-        .filter((s) => s.name === name)
+  schemaValidation.listSchemas.items({ zoneId, omitSource: true }).pipe(
+    Stream.filter((s) => s.name === name),
+    Stream.runCollect,
+    Effect.map((chunk) =>
+      Array.from(chunk)
         .sort((a, b) => a.createdAt.localeCompare(b.createdAt))
         .at(0),
     ),

--- a/packages/alchemy/src/Cloudflare/SecretsStore/SecretsStore.ts
+++ b/packages/alchemy/src/Cloudflare/SecretsStore/SecretsStore.ts
@@ -1,5 +1,6 @@
 import * as secretsStore from "@distilled.cloud/cloudflare/secrets-store";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import * as Stream from "effect/Stream";
 import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
@@ -59,20 +60,15 @@ export const SecretsStoreProvider = () =>
     // ever invoked when no store exists yet.
     read: Effect.fn(function* ({ output }) {
       const { accountId } = yield* yield* CloudflareEnvironment;
-      const stores = yield* secretsStore.listStores
-        .items({ accountId: output?.accountId ?? accountId })
-        .pipe(
-          Stream.runCollect,
-          Effect.map((chunk) => Array.from(chunk)),
-        );
+      const acct = output?.accountId ?? accountId;
       const match = output?.storeId
-        ? stores.find((s) => s.id === output.storeId)
-        : stores[0];
+        ? yield* findStoreById(acct, output.storeId)
+        : yield* firstStore(acct);
       if (!match) return undefined;
       return {
         storeId: match.id,
         storeName: match.name,
-        accountId: output?.accountId ?? accountId,
+        accountId: acct,
       };
     }),
     reconcile: Effect.fn(function* ({ output }) {
@@ -80,17 +76,12 @@ export const SecretsStoreProvider = () =>
       const acct = output?.accountId ?? accountId;
 
       // Observe — Cloudflare permits exactly one Secrets Store per
-      // account. List the account's stores; reuse the cached one if
-      // it still exists, otherwise reuse the first one.
-      const stores = yield* secretsStore.listStores
-        .items({ accountId: acct })
-        .pipe(
-          Stream.runCollect,
-          Effect.map((chunk) => Array.from(chunk)),
-        );
-      const observed = output?.storeId
-        ? (stores.find((s) => s.id === output.storeId) ?? stores[0])
-        : stores[0];
+      // account. Reuse the cached store if it still exists, otherwise
+      // reuse the first one listed.
+      const cached = output?.storeId
+        ? yield* findStoreById(acct, output.storeId)
+        : undefined;
+      const observed = cached ?? (yield* firstStore(acct));
 
       if (observed) {
         return {
@@ -124,13 +115,7 @@ export const SecretsStoreProvider = () =>
         };
       }
 
-      const after = yield* secretsStore.listStores
-        .items({ accountId: acct })
-        .pipe(
-          Stream.runCollect,
-          Effect.map((chunk) => Array.from(chunk)),
-        );
-      const first = after[0];
+      const first = yield* firstStore(acct);
       if (first) {
         return {
           storeId: first.id,
@@ -172,3 +157,17 @@ export const SecretsStoreProvider = () =>
       // should never be torn down by a single stack.
     }),
   });
+
+/** First store on the account (Cloudflare permits at most one). */
+const firstStore = (accountId: string) =>
+  secretsStore.listStores
+    .items({ accountId })
+    .pipe(Stream.runHead, Effect.map(Option.getOrUndefined));
+
+/** Look a store up by id, terminating pagination on the first match. */
+const findStoreById = (accountId: string, storeId: string) =>
+  secretsStore.listStores.items({ accountId }).pipe(
+    Stream.filter((s) => s.id === storeId),
+    Stream.runHead,
+    Effect.map(Option.getOrUndefined),
+  );

--- a/packages/alchemy/src/Cloudflare/SecretsStore/SecretsStore.ts
+++ b/packages/alchemy/src/Cloudflare/SecretsStore/SecretsStore.ts
@@ -59,12 +59,15 @@ export const SecretsStoreProvider = () =>
     // ever invoked when no store exists yet.
     read: Effect.fn(function* ({ output }) {
       const { accountId } = yield* yield* CloudflareEnvironment;
-      const stores = yield* secretsStore.listStores({
-        accountId: output?.accountId ?? accountId,
-      });
+      const stores = yield* secretsStore.listStores
+        .items({ accountId: output?.accountId ?? accountId })
+        .pipe(
+          Stream.runCollect,
+          Effect.map((chunk) => Array.from(chunk)),
+        );
       const match = output?.storeId
-        ? stores.result.find((s) => s.id === output.storeId)
-        : stores.result[0];
+        ? stores.find((s) => s.id === output.storeId)
+        : stores[0];
       if (!match) return undefined;
       return {
         storeId: match.id,
@@ -79,11 +82,15 @@ export const SecretsStoreProvider = () =>
       // Observe — Cloudflare permits exactly one Secrets Store per
       // account. List the account's stores; reuse the cached one if
       // it still exists, otherwise reuse the first one.
-      const stores = yield* secretsStore.listStores({ accountId: acct });
+      const stores = yield* secretsStore.listStores
+        .items({ accountId: acct })
+        .pipe(
+          Stream.runCollect,
+          Effect.map((chunk) => Array.from(chunk)),
+        );
       const observed = output?.storeId
-        ? (stores.result.find((s) => s.id === output.storeId) ??
-          stores.result[0])
-        : stores.result[0];
+        ? (stores.find((s) => s.id === output.storeId) ?? stores[0])
+        : stores[0];
 
       if (observed) {
         return {
@@ -117,8 +124,13 @@ export const SecretsStoreProvider = () =>
         };
       }
 
-      const after = yield* secretsStore.listStores({ accountId: acct });
-      const first = after.result[0];
+      const after = yield* secretsStore.listStores
+        .items({ accountId: acct })
+        .pipe(
+          Stream.runCollect,
+          Effect.map((chunk) => Array.from(chunk)),
+        );
+      const first = after[0];
       if (first) {
         return {
           storeId: first.id,

--- a/packages/alchemy/src/Cloudflare/StateStore/State.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/State.ts
@@ -4,6 +4,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Redacted from "effect/Redacted";
 import * as Schedule from "effect/Schedule";
+import * as Stream from "effect/Stream";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
 import * as HttpApiClient from "effect/unstable/httpapi/HttpApiClient";
@@ -408,20 +409,21 @@ export const teardownStateStore = (options: TeardownOptions = {}) =>
       AuthTokenSecretName,
       EncryptionKeySecretName,
     ]);
-    const stores = yield* SecretsStore.listStores({ accountId }).pipe(
-      Effect.map((r) => r.result),
+    const stores = yield* SecretsStore.listStores.items({ accountId }).pipe(
+      Stream.runCollect,
+      Effect.map((chunk) => Array.from(chunk)),
       Effect.catchTag("InvalidAccountId", () => Effect.succeed([])),
     );
     for (const store of stores) {
-      const secrets = yield* SecretsStore.listStoreSecrets({
-        accountId,
-        storeId: store.id,
-      }).pipe(
-        Effect.map((r) => r.result),
-        Effect.catchTag(["StoreNotFound", "InvalidAccountId"], () =>
-          Effect.succeed([]),
-        ),
-      );
+      const secrets = yield* SecretsStore.listStoreSecrets
+        .items({ accountId, storeId: store.id })
+        .pipe(
+          Stream.runCollect,
+          Effect.map((chunk) => Array.from(chunk)),
+          Effect.catchTag(["StoreNotFound", "InvalidAccountId"], () =>
+            Effect.succeed([]),
+          ),
+        );
       const ours = secrets.filter((s) => ourSecretNames.has(s.name));
       for (const secret of ours) {
         yield* Clank.info(`Deleting secret '${secret.name}'...`);
@@ -739,8 +741,9 @@ export const loginWithCloudflare = (profileName: string, force: boolean) =>
     }
 
     // 1. Locate the single Secrets Store on the account.
-    const stores = yield* SecretsStore.listStores({ accountId });
-    const store = stores.result[0];
+    const store = yield* SecretsStore.listStores
+      .items({ accountId })
+      .pipe(Stream.runHead, Effect.map(Option.getOrUndefined));
     if (!store) {
       return yield* Effect.fail(
         new AuthError({

--- a/packages/alchemy/src/Cloudflare/Turnstile/Widget.ts
+++ b/packages/alchemy/src/Cloudflare/Turnstile/Widget.ts
@@ -344,10 +344,11 @@ const getWidget = (accountId: string, sitekey: string) =>
  * the same name, pick the oldest for determinism.
  */
 const findByName = (accountId: string, name: string) =>
-  turnstile.listWidgets({ accountId, filter: `name:${name}` }).pipe(
-    Effect.map((list) =>
-      list.result
-        .filter((w) => w.name === name)
+  turnstile.listWidgets.items({ accountId, filter: `name:${name}` }).pipe(
+    Stream.filter((w) => w.name === name),
+    Stream.runCollect,
+    Effect.map((chunk) =>
+      Array.from(chunk)
         .sort((a, b) => a.createdOn.localeCompare(b.createdOn))
         .at(0),
     ),

--- a/packages/alchemy/test/AWS/EFS/bindings-handler.ts
+++ b/packages/alchemy/test/AWS/EFS/bindings-handler.ts
@@ -182,11 +182,10 @@ export default EfsBindingsFunction.make(
           }).pipe(
             Effect.catchTag("AccessPointAlreadyExists", () =>
               describeAccessPoints().pipe(
-                Effect.map(
-                  (r) =>
-                    r.AccessPoints?.find(
-                      (ap) => ap.ClientToken === ACCESS_POINT_CLIENT_TOKEN,
-                    )!,
+                Effect.map((r) =>
+                  r.AccessPoints?.find(
+                    (ap) => ap.ClientToken === ACCESS_POINT_CLIENT_TOKEN,
+                  )!,
                 ),
               ),
             ),

--- a/packages/alchemy/test/AWS/Translate/handler.ts
+++ b/packages/alchemy/test/AWS/Translate/handler.ts
@@ -193,8 +193,8 @@ export default TranslateTestFunction.make(
               got.TerminologyProperties?.SourceLanguageCode ?? null,
             downloadLocation:
               got.TerminologyDataLocation?.RepositoryType ?? null,
-            listedNames: (listed.TerminologyPropertiesList ?? []).flatMap((t) =>
-              t.Name ? [t.Name] : [],
+            listedNames: (listed.TerminologyPropertiesList ?? []).flatMap(
+              (t) => (t.Name ? [t.Name] : []),
             ),
           });
         }

--- a/packages/alchemy/test/Cloudflare/Gateway/Certificate.test.ts
+++ b/packages/alchemy/test/Cloudflare/Gateway/Certificate.test.ts
@@ -87,7 +87,9 @@ const deployUnlessQuotaReached = (
     .deploy(eff)
     .pipe(
       Effect.catchCause(
-        (cause): Effect.Effect<CertificateAttributes | undefined, any, never> =>
+        (
+          cause,
+        ): Effect.Effect<CertificateAttributes | undefined, any, never> =>
           findQuotaError(cause)
             ? Effect.succeed(undefined)
             : Effect.failCause(cause),

--- a/packages/alchemy/test/GitHub/Environment.test.ts
+++ b/packages/alchemy/test/GitHub/Environment.test.ts
@@ -2,8 +2,8 @@ import * as GitHub from "@/GitHub";
 import { Octokit } from "@/GitHub/Octokit.ts";
 import * as Output from "@/Output";
 import { destroy } from "@/RemovalPolicy";
-import * as Test from "@/Test/Vitest";
-import { expect } from "@effect/vitest";
+import * as Test from "@/Test/Alchemy";
+import { expect } from "alchemy-test";
 import * as Effect from "effect/Effect";
 import { MinimumLogLevel } from "effect/References";
 


### PR DESCRIPTION
Audited every call site of a distilled paginated operation (`API.makePaginated`) in `packages/alchemy/src` — 239 flagged sites across AWS and Cloudflare — and converted the ones that fetch a single page while enumerating the results. A single-shot call to a paginated op silently returns only the first page, so `find`/`filter`/`map` over the response misses anything past page 1.

~95 call sites converted across 67 files. The computation stays inside the Stream so pagination terminates early where possible — `runCollect` is used only when every element is genuinely needed:

```ts
// first match — stops fetching pages at the first hit
yield* svc.listX.items(input).pipe(
  Stream.filter((x) => x.Name === name),
  Stream.runHead,
  Effect.map(Option.getOrUndefined),
)
// existence / universal checks short-circuit the same way
Stream.filter(pred), Stream.runHead, Effect.map(Option.isSome)   // some
Stream.filter((x) => !pred(x)), Stream.runHead, Effect.map(Option.isNone) // every
// full enumeration (delete-alls, diff baselines, provider list ops)
Stream.runCollect, Effect.map((chunk) => Array.from(chunk))
```

- find-by-name/identity scans → `.items(...)` + `Stream.filter` + `Stream.runHead` (ACM, CloudFront, CloudMap, DataZone, Logs, SNS, Route53Resolver, Alerting, D1, DNS zone-transfer, Devices, Flagship, Hyperdrive, Intel, Turnstile, SchemaValidation, SecretsStore, ...). Find-by-name lookups that sort matches to pick a deterministic winner (oldest `createdAt` / lowest id) still collect, since all matches are load-bearing.
- iterate-and-delete cleanup loops → `.items(...)` + `Stream.mapEffect(delete...)` + `Stream.runDrain` (role inline/attached policies in AppRunner, AppSync, Batch, EKS, StepFunctions, IAM delete paths; IAM group-member removal)
- observed-state baselines for diffing → `.items` + `runCollect` (SecurityGroup rules, ELBv2 listener certificates, ResourceSharing recipients/resources, tag reads)
- CloudFront nested-path lists (`*List.Items`) use `.pages` + flatten, since distilled types `.items` as `unknown` for nested item paths; same for ops whose pagination config has no `items` field (AppRunner revisions, CloudMap services, SSM `describeParameters`)
- notable: Cloudflare StateStore's "store is empty, safe to delete" check only counted page 1 of secrets

Deliberately left as-is:

- exact-ID lookups (`VpcIds: [id]`, `repositoryNames: [name]`, `name: { exact }`) — ≤1 result by construction
- hard-capped lists (IAM/resource tags ≤50, policy versions ≤5, access keys ≤2, GuardDuty's one detector per region)
- correct manual pagination loops (Organizations `collectPages`, S3 `do/while ContinuationToken`, Textract bounded loops)
- runtime HTTP binding clients (`ReadDnsHttp`, `ReadBucketHttp`, `ReadNamespaceHttp`, `ReadTunnel`) where the end user controls cursors
- Cloudflare `mode: "single"` endpoints (MagicTransit, mTLS, PageShield, Workers routes, ...) — genuinely non-paginated, single-shot is a full read
- mutations the generator marks paginated (`putRule`, `createSiteLan`, `updateSilence`, ...)

Also migrates `test/GitHub/Environment.test.ts` off the removed `@/Test/Vitest` module (pre-existing `tsc` breakage from #845); that suite passes live.

Verified with `bun tsc -b` (clean). The converted providers were not exercised against live clouds in this PR.
