### PR TITLE
fix(cloudflare/workers): queue-consumer wiring lost when Consumer reconciles mid workerd start

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -49,7 +49,7 @@
     },
     "cloudflare-tools/packages/cloudflare-rolldown-plugin": {
       "name": "@distilled.cloud/cloudflare-rolldown-plugin",
-      "version": "0.13.8",
+      "version": "0.13.9",
       "dependencies": {
         "@cloudflare/unenv-preset": "^2.16.0",
         "magic-string": "^0.30.21",
@@ -73,7 +73,7 @@
     },
     "cloudflare-tools/packages/cloudflare-runtime": {
       "name": "@distilled.cloud/cloudflare-runtime",
-      "version": "0.13.8",
+      "version": "0.13.9",
       "dependencies": {
         "@alchemy.run/node-utils": "catalog:",
         "workerd": "catalog:workers",
@@ -106,7 +106,7 @@
     },
     "cloudflare-tools/packages/cloudflare-vite-plugin": {
       "name": "@distilled.cloud/cloudflare-vite-plugin",
-      "version": "0.13.8",
+      "version": "0.13.9",
       "dependencies": {
         "@distilled.cloud/cloudflare-rolldown-plugin": "workspace:*",
       },
@@ -204,7 +204,7 @@
     },
     "distilled/packages/aws": {
       "name": "@distilled.cloud/aws",
-      "version": "0.30.0",
+      "version": "0.30.1",
       "dependencies": {
         "@aws-crypto/crc32": "catalog:",
         "@aws-crypto/util": "catalog:",
@@ -236,7 +236,7 @@
     },
     "distilled/packages/axiom": {
       "name": "@distilled.cloud/axiom",
-      "version": "0.30.0",
+      "version": "0.30.1",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
       },
@@ -253,7 +253,7 @@
     },
     "distilled/packages/azure": {
       "name": "@distilled.cloud/azure",
-      "version": "0.30.0",
+      "version": "0.30.1",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
       },
@@ -270,7 +270,7 @@
     },
     "distilled/packages/cloudflare": {
       "name": "@distilled.cloud/cloudflare",
-      "version": "0.30.0",
+      "version": "0.30.1",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
       },
@@ -290,7 +290,7 @@
     },
     "distilled/packages/coinbase": {
       "name": "@distilled.cloud/coinbase",
-      "version": "0.30.0",
+      "version": "0.30.1",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
       },
@@ -308,7 +308,7 @@
     },
     "distilled/packages/core": {
       "name": "@distilled.cloud/core",
-      "version": "0.30.0",
+      "version": "0.30.1",
       "devDependencies": {
         "@types/bun": "catalog:",
         "@types/node": "catalog:",
@@ -321,7 +321,7 @@
     },
     "distilled/packages/expo-eas": {
       "name": "@distilled.cloud/expo-eas",
-      "version": "0.30.0",
+      "version": "0.30.1",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
       },
@@ -338,7 +338,7 @@
     },
     "distilled/packages/fly-io": {
       "name": "@distilled.cloud/fly-io",
-      "version": "0.30.0",
+      "version": "0.30.1",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
       },
@@ -355,7 +355,7 @@
     },
     "distilled/packages/gcp": {
       "name": "@distilled.cloud/gcp",
-      "version": "0.30.0",
+      "version": "0.30.1",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
       },
@@ -372,7 +372,7 @@
     },
     "distilled/packages/kubernetes": {
       "name": "@distilled.cloud/kubernetes",
-      "version": "0.30.0",
+      "version": "0.30.1",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
       },
@@ -389,7 +389,7 @@
     },
     "distilled/packages/mongodb-atlas": {
       "name": "@distilled.cloud/mongodb-atlas",
-      "version": "0.30.0",
+      "version": "0.30.1",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
       },
@@ -406,7 +406,7 @@
     },
     "distilled/packages/neon": {
       "name": "@distilled.cloud/neon",
-      "version": "0.30.0",
+      "version": "0.30.1",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
       },
@@ -423,7 +423,7 @@
     },
     "distilled/packages/planetscale": {
       "name": "@distilled.cloud/planetscale",
-      "version": "0.30.0",
+      "version": "0.30.1",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
       },
@@ -440,7 +440,7 @@
     },
     "distilled/packages/posthog": {
       "name": "@distilled.cloud/posthog",
-      "version": "0.30.0",
+      "version": "0.30.1",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
       },
@@ -459,7 +459,7 @@
     },
     "distilled/packages/prisma-postgres": {
       "name": "@distilled.cloud/prisma-postgres",
-      "version": "0.30.0",
+      "version": "0.30.1",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
       },
@@ -476,7 +476,7 @@
     },
     "distilled/packages/stripe": {
       "name": "@distilled.cloud/stripe",
-      "version": "0.30.0",
+      "version": "0.30.1",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
       },
@@ -493,7 +493,7 @@
     },
     "distilled/packages/supabase": {
       "name": "@distilled.cloud/supabase",
-      "version": "0.30.0",
+      "version": "0.30.1",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
       },
@@ -510,7 +510,7 @@
     },
     "distilled/packages/turso": {
       "name": "@distilled.cloud/turso",
-      "version": "0.30.0",
+      "version": "0.30.1",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
       },
@@ -527,7 +527,7 @@
     },
     "distilled/packages/typesense": {
       "name": "@distilled.cloud/typesense",
-      "version": "0.30.0",
+      "version": "0.30.1",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
       },
@@ -545,7 +545,7 @@
     },
     "distilled/packages/workos": {
       "name": "@distilled.cloud/workos",
-      "version": "0.30.0",
+      "version": "0.30.1",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
       },

--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -270,6 +270,11 @@ export const LocalWorkerProvider = () =>
           1,
         )(
           Effect.gen(function* () {
+            // Queue-consumer wiring can change while `runtime.start` is in
+            // flight (a sibling `Consumer` reconcile), before the restart
+            // hook below exists to pick it up. We hold the serve lock, so a
+            // restart would deadlock — instead, loop and serve again until
+            // the wiring is stable across a start.
             while (true) {
               const previous = workerdScopes.get(worker.id);
               if (previous) {
@@ -278,13 +283,6 @@ export const LocalWorkerProvider = () =>
                 yield* Scope.close(previous, Exit.void);
                 workerdScopes.delete(worker.id);
               }
-              // Snapshot the start-time runtime wiring. A sibling `Consumer`
-              // reconcile can mutate `localRuntimeState.queueConsumers` while
-              // `runtime.start` is in flight; its `restartScripts` call would
-              // find no restart hook yet (registered below, after start) and
-              // silently no-op — the worker would then run without its queue
-              // consumer and every produced message would be dropped. Re-check
-              // after start and serve again if the wiring changed mid-start.
               const queueConsumers = yield* getQueueConsumers(worker.name);
               const scope = yield* Scope.fork(parentScope);
               const url = yield* runtime
@@ -307,10 +305,9 @@ export const LocalWorkerProvider = () =>
                 proxy,
                 scope: parentScope,
               });
-              // Register the restart hook BEFORE the wiring re-check below:
-              // any consumer change that lands after the re-check will find
-              // the hook and queue a restart behind this serve's lock, so no
-              // update can fall between the two mechanisms.
+              // Register the restart hook before the re-check below: changes
+              // landing after the re-check find the hook; changes before it
+              // are caught by the re-check. Nothing falls in between.
               MutableHashMap.set(
                 localRuntimeState.workerRestarts,
                 worker.name,

--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -270,41 +270,64 @@ export const LocalWorkerProvider = () =>
           1,
         )(
           Effect.gen(function* () {
-            const previous = workerdScopes.get(worker.id);
-            if (previous) {
-              // Both runtimes use the same registry key. Close the old scope first so
-              // its unregister finalizer cannot delete the replacement registration.
-              yield* Scope.close(previous, Exit.void);
-              workerdScopes.delete(worker.id);
+            while (true) {
+              const previous = workerdScopes.get(worker.id);
+              if (previous) {
+                // Both runtimes use the same registry key. Close the old scope first so
+                // its unregister finalizer cannot delete the replacement registration.
+                yield* Scope.close(previous, Exit.void);
+                workerdScopes.delete(worker.id);
+              }
+              // Snapshot the start-time runtime wiring. A sibling `Consumer`
+              // reconcile can mutate `localRuntimeState.queueConsumers` while
+              // `runtime.start` is in flight; its `restartScripts` call would
+              // find no restart hook yet (registered below, after start) and
+              // silently no-op — the worker would then run without its queue
+              // consumer and every produced message would be dropped. Re-check
+              // after start and serve again if the wiring changed mid-start.
+              const queueConsumers = yield* getQueueConsumers(worker.name);
+              const scope = yield* Scope.fork(parentScope);
+              const url = yield* runtime
+                .start({
+                  name: worker.name,
+                  compatibilityDate: worker.compatibility.date,
+                  compatibilityFlags: worker.compatibility.flags,
+                  bindings: worker.workerBindings as never,
+                  hyperdrives: worker.hyperdrives,
+                  durableObjectNamespaces: worker.durableObjectNamespaces,
+                  queueConsumers,
+                  modules: yield* toRuntimeModules(bundle),
+                  assets: toRuntimeAssets(worker.assets),
+                })
+                .pipe(Scope.provide(scope));
+              workerdScopes.set(worker.id, scope);
+              latestServes.set(worker.id, {
+                worker,
+                bundle,
+                proxy,
+                scope: parentScope,
+              });
+              // Register the restart hook BEFORE the wiring re-check below:
+              // any consumer change that lands after the re-check will find
+              // the hook and queue a restart behind this serve's lock, so no
+              // update can fall between the two mechanisms.
+              MutableHashMap.set(
+                localRuntimeState.workerRestarts,
+                worker.name,
+                restartWorker(worker.id),
+              );
+              const currentConsumers = yield* getQueueConsumers(worker.name);
+              if (
+                JSON.stringify(currentConsumers) !==
+                JSON.stringify(queueConsumers)
+              ) {
+                // Wiring changed while workerd was starting — serve again with
+                // the fresh consumers before exposing the instance.
+                continue;
+              }
+              yield* proxy.set(url);
+              return url;
             }
-            const scope = yield* Scope.fork(parentScope);
-            const url = yield* runtime
-              .start({
-                name: worker.name,
-                compatibilityDate: worker.compatibility.date,
-                compatibilityFlags: worker.compatibility.flags,
-                bindings: worker.workerBindings as never,
-                hyperdrives: worker.hyperdrives,
-                durableObjectNamespaces: worker.durableObjectNamespaces,
-                queueConsumers: yield* getQueueConsumers(worker.name),
-                modules: yield* toRuntimeModules(bundle),
-                assets: toRuntimeAssets(worker.assets),
-              })
-              .pipe(Scope.provide(scope));
-            workerdScopes.set(worker.id, scope);
-            latestServes.set(worker.id, {
-              worker,
-              bundle,
-              proxy,
-              scope: parentScope,
-            });
-            MutableHashMap.set(
-              localRuntimeState.workerRestarts,
-              worker.name,
-              restartWorker(worker.id),
-            );
-            yield* proxy.set(url);
-            return url;
           }),
         );
 


### PR DESCRIPTION
Fixes `cloudflare-dev` flaking under `bun test:examples`: the queue test times out, bun kills the workerd processes, and every later test fails with `ConnectionRefused`.

Queue-consumer wiring is baked into workerd at `runtime.start` time. The restart hook that compensates for a late `Consumer` reconcile was only registered *after* `runtime.start` returned:

```ts
const url = yield* runtime.start({
  queueConsumers: yield* getQueueConsumers(worker.name), // read before start
  ...
});
MutableHashMap.set(localRuntimeState.workerRestarts, ...); // hook registered after
```

A `Consumer` reconcile landing during the start finds no hook, no-ops, and the worker runs with no queue consumer — every message is dropped. Solo runs never hit it (workerd boots in ~50ms); parallel example runs stretch the start to seconds.

The fix loops in `serveWith`: start, register the hook, re-read the wiring, and serve again if it changed mid-start. It can't just call `restartWorker` — `serveWith` holds the per-worker serve lock and would deadlock. Changes after the re-check find the hook; changes before it are caught by the re-check.

Verified with 3 consecutive green `bun test:examples` runs (previously failed roughly every other run).
