### PR TITLE
feat(aws/bedrock): Effect AI LanguageModel binding over the Converse API

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -561,6 +561,16 @@
         "effect": "catalog:",
       },
     },
+    "examples/aws-bedrock-ai": {
+      "name": "aws-bedrock-ai",
+      "version": "0.0.0",
+      "dependencies": {
+        "@distilled.cloud/aws": "catalog:",
+        "@effect/platform-node": "catalog:",
+        "alchemy": "workspace:*",
+        "effect": "catalog:",
+      },
+    },
     "examples/aws-ec2": {
       "name": "aws-ec2-example",
       "version": "0.0.0",
@@ -2694,6 +2704,8 @@
     "async-sema": ["async-sema@3.1.1", "", {}, "sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg=="],
 
     "auto-bind": ["auto-bind@5.0.1", "", {}, "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="],
+
+    "aws-bedrock-ai": ["aws-bedrock-ai@workspace:examples/aws-bedrock-ai"],
 
     "aws-ec2-example": ["aws-ec2-example@workspace:examples/aws-ec2"],
 

--- a/examples/aws-bedrock-ai/alchemy.run.ts
+++ b/examples/aws-bedrock-ai/alchemy.run.ts
@@ -1,0 +1,25 @@
+import * as Alchemy from "alchemy";
+import * as AWS from "alchemy/AWS";
+import * as Output from "alchemy/Output";
+import * as Effect from "effect/Effect";
+import ChatFunction from "./src/ChatFunction.ts";
+
+// AWS.providers() already provides AWSEnvironment from the SSO profile
+// named by $AWS_PROFILE (defaults to "default").
+const aws = AWS.providers();
+
+export default Alchemy.Stack(
+  "BedrockAI",
+  {
+    providers: aws,
+    state: Alchemy.localState(),
+  },
+  Effect.gen(function* () {
+    const func = yield* ChatFunction;
+    return {
+      url: func.functionUrl,
+      streamUrl: Output.interpolate`${func.functionUrl}stream?prompt=Write+a+haiku`,
+      weatherUrl: Output.interpolate`${func.functionUrl}weather?prompt=What's+the+weather+in+Seattle%3F`,
+    };
+  }),
+);

--- a/examples/aws-bedrock-ai/package.json
+++ b/examples/aws-bedrock-ai/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "aws-bedrock-ai",
+  "version": "0.0.0",
+  "private": true,
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
+    "directory": "examples/aws-bedrock-ai"
+  },
+  "scripts": {
+    "build": "tsc -b",
+    "deploy": "alchemy deploy",
+    "dev": "alchemy dev",
+    "destroy": "alchemy destroy",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@distilled.cloud/aws": "catalog:",
+    "@effect/platform-node": "catalog:",
+    "alchemy": "workspace:*",
+    "effect": "catalog:"
+  }
+}

--- a/examples/aws-bedrock-ai/src/ChatFunction.ts
+++ b/examples/aws-bedrock-ai/src/ChatFunction.ts
@@ -1,0 +1,108 @@
+import * as AWS from "alchemy/AWS";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+import * as Stream from "effect/Stream";
+import {
+  LanguageModel as AiLanguageModel,
+  Tool,
+  Toolkit,
+} from "effect/unstable/ai";
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+// Amazon Nova Micro through the us cross-region inference profile — cheap
+// and fast. Any conversational Bedrock model works here (Claude, Llama,
+// Mistral, ...); enable it under "Model access" in the Bedrock console.
+const MODEL = "us.amazon.nova-micro-v1:0";
+
+const GetWeather = Tool.make("get_weather", {
+  description: "Get the current weather for a city.",
+  parameters: Schema.Struct({ city: Schema.String }),
+  success: Schema.Struct({
+    city: Schema.String,
+    temperatureF: Schema.Number,
+    condition: Schema.String,
+  }),
+});
+
+const WeatherToolkit = Toolkit.make(GetWeather);
+
+const WeatherToolkitLayer = WeatherToolkit.toLayer({
+  get_weather: ({ city }) =>
+    Effect.succeed({ city, temperatureF: 72, condition: "sunny" }),
+});
+
+export default class ChatFunction extends AWS.Lambda.Function<ChatFunction>()(
+  "ChatFunction",
+  {
+    main: import.meta.url,
+    url: true,
+    timeout: Duration.seconds(60),
+  },
+  Effect.gen(function* () {
+    // Init: bind the model. This grants the Function `bedrock:InvokeModel`
+    // and `bedrock:InvokeModelWithResponseStream` scoped to exactly MODEL
+    // and returns an Effect AI `LanguageModel` Layer.
+    const model = yield* AWS.Bedrock.LanguageModel(MODEL, {
+      parameters: { maxTokens: 1024, temperature: 0.7 },
+    });
+
+    return {
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        const url = new URL(request.originalUrl);
+        const prompt = url.searchParams.get("prompt") ?? "Say hello.";
+
+        // GET /stream?prompt=... — stream the answer as SSE parts.
+        if (url.pathname === "/stream") {
+          const parts = yield* Stream.runCollect(
+            AiLanguageModel.streamText({ prompt }),
+          );
+          const sse = [...parts]
+            .map((part) => `data: ${JSON.stringify(part)}\n\n`)
+            .join("");
+          return HttpServerResponse.text(sse, {
+            headers: { "content-type": "text/event-stream" },
+          });
+        }
+
+        // GET /weather?prompt=... — let the model call a typed tool.
+        if (url.pathname === "/weather") {
+          const response = yield* AiLanguageModel.generateText({
+            prompt,
+            toolkit: WeatherToolkit,
+          }).pipe(Effect.provide(WeatherToolkitLayer));
+          return yield* HttpServerResponse.json({
+            text: response.text,
+            toolCalls: response.toolCalls.map((call) => ({
+              name: call.name,
+              params: call.params,
+            })),
+            toolResults: response.toolResults.map((result) => ({
+              name: result.name,
+              result: result.result,
+            })),
+          });
+        }
+
+        // GET /?prompt=... — single-shot text generation.
+        const response = yield* AiLanguageModel.generateText({ prompt });
+        return yield* HttpServerResponse.json({
+          text: response.text,
+          finishReason: response.finishReason,
+          usage: {
+            inputTokens: response.usage.inputTokens.total,
+            outputTokens: response.usage.outputTokens.total,
+          },
+        });
+      }).pipe(
+        Effect.catchTag("AiError", (error) =>
+          HttpServerResponse.json({ error: error.message }, { status: 500 }),
+        ),
+        Effect.provide(model),
+        Effect.orDie,
+      ),
+    };
+  }).pipe(Effect.provide(AWS.Bedrock.LanguageModelHttp)),
+) {}

--- a/examples/aws-bedrock-ai/src/ChatFunction.ts
+++ b/examples/aws-bedrock-ai/src/ChatFunction.ts
@@ -86,8 +86,21 @@ export default class ChatFunction extends AWS.Lambda.Function<ChatFunction>()(
           });
         }
 
-        // GET /?prompt=... — single-shot text generation.
-        const response = yield* AiLanguageModel.generateText({ prompt });
+        // GET /?prompt=...&temperature=0.2&maxTokens=64 — single-shot text
+        // generation. IAM access to the model is bound at deploy time, but
+        // inference parameters are a per-request decision:
+        // `withModelParameters` overrides the binding's defaults for just
+        // this call.
+        const maxTokens = url.searchParams.get("maxTokens");
+        const temperature = url.searchParams.get("temperature");
+        const response = yield* AiLanguageModel.generateText({ prompt }).pipe(
+          AWS.Bedrock.withModelParameters({
+            ...(maxTokens !== null ? { maxTokens: Number(maxTokens) } : {}),
+            ...(temperature !== null
+              ? { temperature: Number(temperature) }
+              : {}),
+          }),
+        );
         return yield* HttpServerResponse.json({
           text: response.text,
           finishReason: response.finishReason,

--- a/examples/aws-bedrock-ai/test/integ.test.ts
+++ b/examples/aws-bedrock-ai/test/integ.test.ts
@@ -1,0 +1,37 @@
+import * as Alchemy from "alchemy";
+import * as AWS from "alchemy/AWS";
+import * as Test from "alchemy/Test/Bun";
+import { expect } from "bun:test";
+import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import Stack from "../alchemy.run.ts";
+
+const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
+  providers: AWS.providers(),
+  state: Alchemy.localState(),
+});
+
+const stack = beforeAll(deploy(Stack));
+afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(Stack));
+
+test(
+  "generates text through Bedrock",
+  Effect.gen(function* () {
+    const out = (yield* stack) as { url: string };
+    const client = HttpClient.filterStatusOk(yield* HttpClient.HttpClient);
+
+    // Fresh function URLs take a few seconds to start serving 200s.
+    const res = yield* client
+      .get(`${out.url}?prompt=${encodeURIComponent("Say pong.")}`)
+      .pipe(
+        Effect.retry({
+          schedule: Schedule.exponential("1 second"),
+          times: 10,
+        }),
+      );
+    const body = (yield* res.json) as { text: string; finishReason: string };
+    expect(body.text.length).toBeGreaterThan(0);
+  }),
+  { timeout: 300_000 },
+);

--- a/examples/aws-bedrock-ai/tsconfig.json
+++ b/examples/aws-bedrock-ai/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["alchemy.run.ts", "src/**/*.ts", "test/**/*.ts"],
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "module": "Preserve",
+    "moduleResolution": "Bundler",
+    "target": "ESNext"
+  },
+  "references": [
+    {
+      "path": "../../packages/alchemy/tsconfig.json"
+    }
+  ]
+}

--- a/packages/alchemy/src/AWS/Bedrock/LanguageModel.ts
+++ b/packages/alchemy/src/AWS/Bedrock/LanguageModel.ts
@@ -1,4 +1,5 @@
 import type * as bedrock from "@distilled.cloud/aws/bedrock-runtime";
+import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Stream from "effect/Stream";
@@ -50,10 +51,63 @@ export interface LanguageModelParameters {
  */
 export interface LanguageModelOptions {
   /**
-   * Default inference parameters for every call made through this model.
+   * Default inference parameters. Every field can be overridden per call
+   * with {@link withModelParameters}.
    */
   parameters?: LanguageModelParameters;
 }
+
+/**
+ * Per-call overrides applied with {@link withModelParameters}: any
+ * {@link LanguageModelParameters} field plus the model to run the call on.
+ */
+export interface LanguageModelCallParameters extends LanguageModelParameters {
+  /**
+   * The model to run inference on for this call. Must be one of the model
+   * ids the {@link LanguageModel} binding was created with (IAM is scoped to
+   * exactly those).
+   * @default the first bound model id
+   */
+  modelId?: string;
+}
+
+/**
+ * Fiber-scoped {@link LanguageModelCallParameters} consulted on every
+ * generateText / streamText call made through a Bedrock-backed
+ * `LanguageModel`. Set it for a region of your program with
+ * {@link withModelParameters}.
+ */
+export const CurrentModelParameters =
+  Context.Reference<LanguageModelCallParameters>(
+    "AWS.Bedrock.CurrentModelParameters",
+    {
+      defaultValue: () => ({}),
+    },
+  );
+
+/**
+ * Scope per-call inference parameters (and optionally the target model)
+ * onto an Effect or Stream that talks to a Bedrock-backed `LanguageModel`.
+ * Defined fields override the binding's construction-time `parameters`;
+ * everything else falls through to those defaults.
+ *
+ * ```typescript
+ * const response = yield* LanguageModel.generateText({ prompt }).pipe(
+ *   Bedrock.withModelParameters({ temperature: 0, maxTokens: 64 }),
+ * );
+ * ```
+ */
+export const withModelParameters =
+  (parameters: LanguageModelCallParameters) =>
+  <S extends Effect.Effect<any, any, any> | Stream.Stream<any, any, any>>(
+    self: S,
+  ): S =>
+    (Effect.isEffect(self)
+      ? Effect.provideService(CurrentModelParameters, parameters)(self)
+      : Stream.provideService(
+          CurrentModelParameters,
+          parameters,
+        )(self as Stream.Stream<any, any, any>)) as S;
 
 /**
  * Runtime binding that turns an Amazon Bedrock model into an
@@ -64,11 +118,13 @@ export interface LanguageModelOptions {
  * Calls are translated to the Bedrock Converse API — Bedrock's unified
  * messages API that works across all conversational foundation models
  * (Amazon Nova, Anthropic Claude, Meta Llama, Mistral, ...) — so one binding
- * covers every model. The binding grants the function `bedrock:InvokeModel`
- * and `bedrock:InvokeModelWithResponseStream` scoped to exactly the bound
- * model. A model reference may be a foundation-model id, a cross-region
- * inference profile id (e.g. `us.amazon.nova-micro-v1:0`), or a full Bedrock
- * ARN.
+ * covers every model. Bind one model or a list of models: the function is
+ * granted `bedrock:InvokeModel` and `bedrock:InvokeModelWithResponseStream`
+ * scoped to exactly those models, the first is the default, and runtime code
+ * picks between them (and tunes inference parameters) per call with
+ * {@link withModelParameters}. A model reference may be a foundation-model
+ * id, a cross-region inference profile id (e.g. `us.amazon.nova-micro-v1:0`),
+ * or a full Bedrock ARN.
  *
  * Model access is an account entitlement — enable the model in the Bedrock
  * console (Model access) before invoking, otherwise calls fail with
@@ -100,6 +156,34 @@ export interface LanguageModelOptions {
  * // parts is a Stream of text-start / text-delta / ... / finish parts
  * ```
  *
+ * @section Runtime Configuration
+ * @example Override Parameters Per Call
+ * The binding's `parameters` are only defaults — scope overrides onto any
+ * call with `withModelParameters`.
+ * ```typescript
+ * const response = yield* LanguageModel.generateText({ prompt }).pipe(
+ *   Bedrock.withModelParameters({ temperature: 0, maxTokens: 64 }),
+ * );
+ * ```
+ *
+ * @example Bind Multiple Models and Pick Per Call
+ * IAM access is fixed at deploy time (scoped to the bound list); which of
+ * those models serves a given request is a runtime decision.
+ * ```typescript
+ * // init: one Layer, IAM for both models, Nova Micro is the default
+ * const model = yield* Bedrock.LanguageModel([
+ *   "us.amazon.nova-micro-v1:0",
+ *   "us.anthropic.claude-sonnet-4-20250514-v1:0",
+ * ]);
+ *
+ * // runtime: route this call to Claude
+ * const response = yield* LanguageModel.generateText({ prompt }).pipe(
+ *   Bedrock.withModelParameters({
+ *     modelId: "us.anthropic.claude-sonnet-4-20250514-v1:0",
+ *   }),
+ * );
+ * ```
+ *
  * @section Tool Calling
  * @example Call Tools with a Toolkit
  * ```typescript
@@ -128,7 +212,7 @@ export interface LanguageModel extends Binding.Service<
   LanguageModel,
   "AWS.Bedrock.LanguageModel",
   (
-    model: string,
+    model: string | readonly [string, ...string[]],
     options?: LanguageModelOptions,
   ) => Effect.Effect<Layer.Layer<AiLanguageModel.LanguageModel>>
 > {}
@@ -178,7 +262,14 @@ export const makeLanguageModel = ({
   AiLanguageModel.make({
     generateText: (options) =>
       Effect.gen(function* () {
-        const request = toConverseRequest({ options, parameters });
+        // Read the fiber-scoped per-call overrides (withModelParameters)
+        // and merge them over the binding's construction-time defaults.
+        const call = yield* CurrentModelParameters;
+        const request = toConverseRequest({
+          options,
+          parameters: mergeParameters(parameters, call),
+          modelId: call.modelId,
+        });
         const response = yield* converse(request).pipe(
           Effect.mapError((cause) => toAiError(cause, "generateText")),
         );
@@ -188,7 +279,12 @@ export const makeLanguageModel = ({
       Stream.unwrap(
         Effect.gen(function* () {
           const idGen = yield* IdGenerator.IdGenerator;
-          const request = toConverseRequest({ options, parameters });
+          const call = yield* CurrentModelParameters;
+          const request = toConverseRequest({
+            options,
+            parameters: mergeParameters(parameters, call),
+            modelId: call.modelId,
+          });
           const response = yield* converseStream(request).pipe(
             Effect.mapError((cause) => toAiError(cause, "streamText")),
           );
@@ -405,12 +501,31 @@ const toToolConfig = (
 // Request assembly
 // ---------------------------------------------------------------------------
 
+/**
+ * Merge per-call overrides over construction-time defaults, field by field —
+ * an undefined override field never clobbers a configured default.
+ */
+const mergeParameters = (
+  defaults: LanguageModelParameters | undefined,
+  overrides: LanguageModelCallParameters,
+): LanguageModelParameters => ({
+  maxTokens: overrides.maxTokens ?? defaults?.maxTokens,
+  temperature: overrides.temperature ?? defaults?.temperature,
+  topP: overrides.topP ?? defaults?.topP,
+  stopSequences: overrides.stopSequences ?? defaults?.stopSequences,
+  additionalModelRequestFields:
+    overrides.additionalModelRequestFields ??
+    defaults?.additionalModelRequestFields,
+});
+
 const toConverseRequest = ({
   options,
   parameters,
+  modelId,
 }: {
   readonly options: AiLanguageModel.ProviderOptions;
   readonly parameters: LanguageModelParameters | undefined;
+  readonly modelId?: string | undefined;
 }): ConverseRequest & ConverseStreamRequest => {
   const { system, messages } = convertPrompt(options.prompt);
   const toolConfig = toToolConfig(options.tools, options.toolChoice, messages);
@@ -428,6 +543,7 @@ const toConverseRequest = ({
   };
   return {
     messages,
+    ...(modelId !== undefined ? { modelId } : {}),
     ...(system.length > 0 ? { system } : {}),
     ...(Object.keys(inferenceConfig).length > 0 ? { inferenceConfig } : {}),
     ...(toolConfig !== undefined ? { toolConfig } : {}),

--- a/packages/alchemy/src/AWS/Bedrock/LanguageModel.ts
+++ b/packages/alchemy/src/AWS/Bedrock/LanguageModel.ts
@@ -1,0 +1,767 @@
+import type * as bedrock from "@distilled.cloud/aws/bedrock-runtime";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Stream from "effect/Stream";
+import {
+  AiError,
+  LanguageModel as AiLanguageModel,
+  IdGenerator,
+  Prompt,
+  Response,
+  Tool,
+} from "effect/unstable/ai";
+import * as Binding from "../../Binding.ts";
+import type { ConverseRequest } from "./Converse.ts";
+import type { ConverseStreamRequest } from "./ConverseStream.ts";
+
+/**
+ * Inference parameters applied to every request made through the
+ * {@link LanguageModel}. They translate to the Converse API's
+ * `inferenceConfig` (plus `additionalModelRequestFields` for
+ * model-specific extensions like `top_k` or reasoning budgets).
+ */
+export interface LanguageModelParameters {
+  /**
+   * Maximum number of tokens the model may generate in the response.
+   */
+  maxTokens?: number;
+  /**
+   * Sampling temperature. Lower values make the output more deterministic.
+   */
+  temperature?: number;
+  /**
+   * Nucleus-sampling probability mass.
+   */
+  topP?: number;
+  /**
+   * Sequences that stop generation when the model emits them.
+   */
+  stopSequences?: string[];
+  /**
+   * Model-specific request fields passed through verbatim as the Converse
+   * API's `additionalModelRequestFields` — e.g. `{ top_k: 50 }` for
+   * Anthropic models or `{ inferenceConfig: { topK: 5 } }` for Amazon Nova.
+   */
+  additionalModelRequestFields?: unknown;
+}
+
+/**
+ * Options for constructing a Bedrock-backed Effect AI `LanguageModel`.
+ */
+export interface LanguageModelOptions {
+  /**
+   * Default inference parameters for every call made through this model.
+   */
+  parameters?: LanguageModelParameters;
+}
+
+/**
+ * Runtime binding that turns an Amazon Bedrock model into an
+ * `effect/unstable/ai` {@link AiLanguageModel.LanguageModel} `Layer`, so any
+ * Effect AI program (`LanguageModel.generateText`, `streamText`, `Chat`,
+ * toolkits, ...) runs against Bedrock without code changes.
+ *
+ * Calls are translated to the Bedrock Converse API — Bedrock's unified
+ * messages API that works across all conversational foundation models
+ * (Amazon Nova, Anthropic Claude, Meta Llama, Mistral, ...) — so one binding
+ * covers every model. The binding grants the function `bedrock:InvokeModel`
+ * and `bedrock:InvokeModelWithResponseStream` scoped to exactly the bound
+ * model. A model reference may be a foundation-model id, a cross-region
+ * inference profile id (e.g. `us.amazon.nova-micro-v1:0`), or a full Bedrock
+ * ARN.
+ *
+ * Model access is an account entitlement — enable the model in the Bedrock
+ * console (Model access) before invoking, otherwise calls fail with
+ * `AccessDeniedException`. Many newer models are only invocable through a
+ * cross-region inference profile id, not their bare foundation-model id.
+ *
+ * @binding
+ * @section Effect AI on Bedrock
+ * @example Generate Text
+ * ```typescript
+ * import { LanguageModel } from "effect/unstable/ai";
+ *
+ * // init: bind the model and get a LanguageModel Layer
+ * const model = yield* Bedrock.LanguageModel("us.amazon.nova-micro-v1:0", {
+ *   parameters: { maxTokens: 1024, temperature: 0.7 },
+ * });
+ *
+ * // runtime: any Effect AI program works against Bedrock
+ * const response = yield* LanguageModel.generateText({
+ *   prompt: "Say hello.",
+ * }).pipe(Effect.provide(model));
+ * ```
+ *
+ * @example Stream Text
+ * ```typescript
+ * const parts = LanguageModel.streamText({ prompt }).pipe(
+ *   Stream.provide(model),
+ * );
+ * // parts is a Stream of text-start / text-delta / ... / finish parts
+ * ```
+ *
+ * @section Tool Calling
+ * @example Call Tools with a Toolkit
+ * ```typescript
+ * import { Tool, Toolkit } from "effect/unstable/ai";
+ * import * as Schema from "effect/Schema";
+ *
+ * const GetWeather = Tool.make("get_weather", {
+ *   description: "Get the current weather for a city.",
+ *   parameters: Schema.Struct({ city: Schema.String }),
+ *   success: Schema.Struct({ temperatureF: Schema.Number }),
+ * });
+ * const WeatherToolkit = Toolkit.make(GetWeather);
+ *
+ * const response = yield* LanguageModel.generateText({
+ *   prompt: "What's the weather in Seattle?",
+ *   toolkit: WeatherToolkit,
+ * }).pipe(
+ *   Effect.provide(WeatherToolkit.toLayer({
+ *     get_weather: ({ city }) => Effect.succeed({ temperatureF: 72 }),
+ *   })),
+ *   Effect.provide(model),
+ * );
+ * ```
+ */
+export interface LanguageModel extends Binding.Service<
+  LanguageModel,
+  "AWS.Bedrock.LanguageModel",
+  (
+    model: string,
+    options?: LanguageModelOptions,
+  ) => Effect.Effect<Layer.Layer<AiLanguageModel.LanguageModel>>
+> {}
+export const LanguageModel = Binding.Service<LanguageModel>(
+  "AWS.Bedrock.LanguageModel",
+);
+
+/**
+ * The already-bound Converse callables the adapter drives. Produced by
+ * `yield* Bedrock.Converse(model)` / `yield* Bedrock.ConverseStream(model)`
+ * (or any function of the same shape).
+ */
+export interface MakeLanguageModelOptions {
+  /** Non-streaming Converse callable (modelId already bound). */
+  readonly converse: (
+    request: ConverseRequest,
+  ) => Effect.Effect<bedrock.ConverseResponse, bedrock.ConverseError>;
+  /** Streaming Converse callable (modelId already bound). */
+  readonly converseStream: (
+    request: ConverseStreamRequest,
+  ) => Effect.Effect<
+    bedrock.ConverseStreamResponse,
+    bedrock.ConverseStreamError
+  >;
+  /** Default inference parameters for every call. */
+  readonly parameters?: LanguageModelParameters;
+}
+
+/**
+ * Provide an {@link AiLanguageModel.LanguageModel} layer backed by the
+ * supplied Bedrock Converse callables.
+ */
+export const makeLanguageModelLayer = (
+  options: MakeLanguageModelOptions,
+): Layer.Layer<AiLanguageModel.LanguageModel> =>
+  Layer.effect(AiLanguageModel.LanguageModel, makeLanguageModel(options));
+
+/**
+ * Build an {@link AiLanguageModel.Service} that proxies generateText /
+ * streamText through the Bedrock Converse API.
+ */
+export const makeLanguageModel = ({
+  converse,
+  converseStream,
+  parameters,
+}: MakeLanguageModelOptions): Effect.Effect<AiLanguageModel.Service> =>
+  AiLanguageModel.make({
+    generateText: (options) =>
+      Effect.gen(function* () {
+        const request = toConverseRequest({ options, parameters });
+        const response = yield* converse(request).pipe(
+          Effect.mapError((cause) => toAiError(cause, "generateText")),
+        );
+        return toResponseParts(response);
+      }),
+    streamText: (options) =>
+      Stream.unwrap(
+        Effect.gen(function* () {
+          const idGen = yield* IdGenerator.IdGenerator;
+          const request = toConverseRequest({ options, parameters });
+          const response = yield* converseStream(request).pipe(
+            Effect.mapError((cause) => toAiError(cause, "streamText")),
+          );
+          return parseStream(response, idGen);
+        }),
+      ),
+  });
+
+// ---------------------------------------------------------------------------
+// Prompt → Converse messages
+//
+// The Converse API separates system prompts from the message list, requires
+// strict user/assistant alternation, and carries tool results inside *user*
+// messages — so conversion merges consecutive same-role messages after
+// mapping.
+// ---------------------------------------------------------------------------
+
+const IMAGE_FORMATS: Record<string, bedrock.ImageFormat> = {
+  "image/png": "png",
+  "image/jpeg": "jpeg",
+  "image/gif": "gif",
+  "image/webp": "webp",
+};
+
+const base64ToUint8Array = (data: string): Uint8Array => {
+  const binary = atob(data);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+};
+
+const fileToImageBlock = (
+  data: string | Uint8Array | URL,
+  mediaType: string,
+): bedrock.ContentBlock | undefined => {
+  const format = IMAGE_FORMATS[mediaType];
+  // Converse only accepts inline bytes (or S3 locations) — remote URLs and
+  // non-image documents are not representable, so they are dropped.
+  if (format === undefined || data instanceof URL) return undefined;
+  const bytes =
+    data instanceof Uint8Array
+      ? data
+      : base64ToUint8Array(
+          data.startsWith("data:") ? data.slice(data.indexOf(",") + 1) : data,
+        );
+  return { image: { format, source: { bytes } } };
+};
+
+const toolCallInput = (params: unknown): unknown => {
+  if (typeof params !== "string") return params ?? {};
+  try {
+    return JSON.parse(params);
+  } catch {
+    return {};
+  }
+};
+
+interface ConverseMessages {
+  readonly system: bedrock.SystemContentBlock[];
+  readonly messages: bedrock.Message[];
+}
+
+const toUserContent = (
+  parts: Prompt.UserMessage["content"],
+): bedrock.ContentBlock[] =>
+  parts.flatMap((p): bedrock.ContentBlock[] => {
+    if (p.type === "text") return p.text.length > 0 ? [{ text: p.text }] : [];
+    if (p.type === "file") {
+      const block = fileToImageBlock(p.data, p.mediaType);
+      return block === undefined ? [] : [block];
+    }
+    return [];
+  });
+
+const toAssistantContent = (
+  parts: Prompt.AssistantMessage["content"],
+): bedrock.ContentBlock[] =>
+  parts.flatMap((p): bedrock.ContentBlock[] => {
+    // Reasoning parts are not replayed: Bedrock requires the original
+    // cryptographic signature alongside replayed reasoning, which the
+    // framework does not round-trip. Models tolerate its absence.
+    if (p.type === "text") return p.text.length > 0 ? [{ text: p.text }] : [];
+    if (p.type === "tool-call") {
+      return [
+        {
+          toolUse: {
+            toolUseId: p.id,
+            name: p.name,
+            input: toolCallInput(p.params),
+          },
+        },
+      ];
+    }
+    return [];
+  });
+
+const toToolResultContent = (
+  parts: Prompt.ToolMessage["content"],
+): bedrock.ContentBlock[] =>
+  parts.flatMap((p): bedrock.ContentBlock[] =>
+    p.type === "tool-result"
+      ? [
+          {
+            toolResult: {
+              toolUseId: p.id,
+              content:
+                typeof p.result === "string"
+                  ? [{ text: p.result }]
+                  : [{ json: p.result ?? {} }],
+              ...(p.isFailure ? { status: "error" as const } : {}),
+            },
+          },
+        ]
+      : [],
+  );
+
+const convertPrompt = (prompt: Prompt.Prompt): ConverseMessages => {
+  const system: bedrock.SystemContentBlock[] = [];
+  const messages: bedrock.Message[] = [];
+
+  const append = (
+    role: bedrock.ConversationRole,
+    content: bedrock.ContentBlock[],
+  ) => {
+    if (content.length === 0) return;
+    const last = messages[messages.length - 1];
+    // Converse requires user/assistant alternation; merge consecutive
+    // same-role messages (tool results become user messages, so a tool
+    // message followed by a user message must fuse).
+    if (last !== undefined && last.role === role) {
+      last.content.push(...content);
+    } else {
+      messages.push({ role, content });
+    }
+  };
+
+  for (const message of prompt.content) {
+    switch (message.role) {
+      case "system":
+        if (message.content.length > 0) system.push({ text: message.content });
+        break;
+      case "user":
+        append("user", toUserContent(message.content));
+        break;
+      case "assistant":
+        append("assistant", toAssistantContent(message.content));
+        break;
+      case "tool":
+        append("user", toToolResultContent(message.content));
+        break;
+    }
+  }
+
+  return { system, messages };
+};
+
+// ---------------------------------------------------------------------------
+// Tools / toolChoice
+// ---------------------------------------------------------------------------
+
+const toToolSpec = (tool: Tool.Any): bedrock.Tool => ({
+  toolSpec: {
+    name: tool.name,
+    description: Tool.getDescription(tool),
+    inputSchema: { json: Tool.getJsonSchema(tool) },
+  },
+});
+
+const hasToolBlocks = (messages: ReadonlyArray<bedrock.Message>): boolean =>
+  messages.some((m) =>
+    m.content.some(
+      (block) => block.toolUse !== undefined || block.toolResult !== undefined,
+    ),
+  );
+
+const toToolConfig = (
+  tools: ReadonlyArray<Tool.Any>,
+  toolChoice: AiLanguageModel.ProviderOptions["toolChoice"],
+  messages: ReadonlyArray<bedrock.Message>,
+): bedrock.ToolConfiguration | undefined => {
+  if (tools.length === 0) return undefined;
+  const mapped = tools.map(toToolSpec);
+
+  if (toolChoice === "none") {
+    // Converse has no "none" mode. Omit toolConfig entirely — unless the
+    // conversation already contains toolUse/toolResult blocks, which the API
+    // rejects without a toolConfig; then send the tools with auto choice.
+    return hasToolBlocks(messages)
+      ? { tools: mapped, toolChoice: { auto: {} } }
+      : undefined;
+  }
+  if (toolChoice === "required") {
+    return { tools: mapped, toolChoice: { any: {} } };
+  }
+  if (typeof toolChoice === "object" && "tool" in toolChoice) {
+    return {
+      tools: mapped,
+      toolChoice: { tool: { name: toolChoice.tool } },
+    };
+  }
+  if (typeof toolChoice === "object" && "oneOf" in toolChoice) {
+    const allowed = new Set(toolChoice.oneOf);
+    return {
+      tools: mapped.filter(
+        (t) => t.toolSpec !== undefined && allowed.has(t.toolSpec.name),
+      ),
+      toolChoice: toolChoice.mode === "required" ? { any: {} } : { auto: {} },
+    };
+  }
+  return { tools: mapped, toolChoice: { auto: {} } };
+};
+
+// ---------------------------------------------------------------------------
+// Request assembly
+// ---------------------------------------------------------------------------
+
+const toConverseRequest = ({
+  options,
+  parameters,
+}: {
+  readonly options: AiLanguageModel.ProviderOptions;
+  readonly parameters: LanguageModelParameters | undefined;
+}): ConverseRequest & ConverseStreamRequest => {
+  const { system, messages } = convertPrompt(options.prompt);
+  const toolConfig = toToolConfig(options.tools, options.toolChoice, messages);
+  const inferenceConfig: bedrock.InferenceConfiguration = {
+    ...(parameters?.maxTokens !== undefined
+      ? { maxTokens: parameters.maxTokens }
+      : {}),
+    ...(parameters?.temperature !== undefined
+      ? { temperature: parameters.temperature }
+      : {}),
+    ...(parameters?.topP !== undefined ? { topP: parameters.topP } : {}),
+    ...(parameters?.stopSequences !== undefined
+      ? { stopSequences: parameters.stopSequences }
+      : {}),
+  };
+  return {
+    messages,
+    ...(system.length > 0 ? { system } : {}),
+    ...(Object.keys(inferenceConfig).length > 0 ? { inferenceConfig } : {}),
+    ...(toolConfig !== undefined ? { toolConfig } : {}),
+    ...(parameters?.additionalModelRequestFields !== undefined
+      ? {
+          additionalModelRequestFields: parameters.additionalModelRequestFields,
+        }
+      : {}),
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Finish reason / usage mapping
+// ---------------------------------------------------------------------------
+
+const mapStopReason = (
+  raw: bedrock.StopReason | undefined,
+): Response.FinishReason => {
+  switch (raw) {
+    case "end_turn":
+    case "stop_sequence":
+      return "stop";
+    case "tool_use":
+      return "tool-calls";
+    case "max_tokens":
+    case "model_context_window_exceeded":
+      return "length";
+    case "guardrail_intervened":
+    case "content_filtered":
+      return "content-filter";
+    case "malformed_model_output":
+    case "malformed_tool_use":
+      return "error";
+    case undefined:
+      return "unknown";
+    default:
+      return "other";
+  }
+};
+
+const mapUsage = (usage: bedrock.TokenUsage | undefined): Response.Usage => {
+  // Bedrock's `inputTokens` excludes cache reads/writes, which are reported
+  // separately — so `total` is the sum of all three.
+  const input = usage?.inputTokens ?? 0;
+  const cacheRead = usage?.cacheReadInputTokens ?? 0;
+  const cacheWrite = usage?.cacheWriteInputTokens ?? 0;
+  return new Response.Usage({
+    inputTokens: {
+      uncached: input,
+      total: input + cacheRead + cacheWrite,
+      cacheRead,
+      cacheWrite,
+    },
+    outputTokens: {
+      total: usage?.outputTokens ?? 0,
+      text: 0,
+      reasoning: 0,
+    },
+  });
+};
+
+// ---------------------------------------------------------------------------
+// generateText: ConverseResponse → Response.PartEncoded[]
+// ---------------------------------------------------------------------------
+
+const toResponseParts = (
+  response: bedrock.ConverseResponse,
+): Array<Response.PartEncoded> => {
+  const content = response.output.message?.content ?? [];
+  const parts = content.flatMap((block): Response.PartEncoded[] => {
+    if (block.text !== undefined && block.text.length > 0) {
+      return [{ type: "text", text: block.text }];
+    }
+    if (block.reasoningContent?.reasoningText !== undefined) {
+      const text = block.reasoningContent.reasoningText.text;
+      return text.length > 0 ? [{ type: "reasoning", text }] : [];
+    }
+    if (block.toolUse !== undefined) {
+      return [
+        {
+          type: "tool-call",
+          id: block.toolUse.toolUseId,
+          name: block.toolUse.name,
+          params: block.toolUse.input ?? {},
+        },
+      ];
+    }
+    return [];
+  });
+  return [
+    ...parts,
+    {
+      type: "finish",
+      reason: mapStopReason(response.stopReason),
+      usage: mapUsage(response.usage),
+      response: undefined,
+    },
+  ];
+};
+
+// ---------------------------------------------------------------------------
+// streamText: ConverseStreamOutput events → Stream<Response.StreamPartEncoded>
+//
+// Bedrock's stream is fully structured: content blocks are opened by index
+// (`contentBlockStart` for tool use; text/reasoning open implicitly on the
+// first delta), advanced by `contentBlockDelta`, and closed by
+// `contentBlockStop`. `messageStop` carries the stop reason and `metadata`
+// carries usage. State threads through `Stream.mapAccumEffect`; the
+// per-event `parts` buffer is mutable but scoped to one event.
+// ---------------------------------------------------------------------------
+
+interface OpenBlock {
+  readonly kind: "text" | "reasoning" | "tool";
+  readonly id: string;
+}
+
+interface StreamState {
+  readonly blocks: ReadonlyMap<number, OpenBlock>;
+  readonly usage: bedrock.TokenUsage | undefined;
+  readonly stopReason: bedrock.StopReason | undefined;
+}
+
+const initialStreamState: StreamState = {
+  blocks: new Map(),
+  usage: undefined,
+  stopReason: undefined,
+};
+
+type StreamParts = Array<Response.StreamPartEncoded>;
+
+// Text/reasoning blocks open implicitly on their first delta; tool blocks
+// are opened by handleBlockStart (Bedrock names them via contentBlockStart).
+const openBlock = (
+  state: StreamState,
+  index: number,
+  block: OpenBlock & { readonly kind: "text" | "reasoning" },
+  parts: StreamParts,
+): StreamState => {
+  parts.push(
+    block.kind === "text"
+      ? { type: "text-start", id: block.id }
+      : { type: "reasoning-start", id: block.id },
+  );
+  const blocks = new Map(state.blocks);
+  blocks.set(index, block);
+  return { ...state, blocks };
+};
+
+const closeBlock = (
+  state: StreamState,
+  index: number,
+  parts: StreamParts,
+): StreamState => {
+  const block = state.blocks.get(index);
+  if (block === undefined) return state;
+  parts.push(
+    block.kind === "text"
+      ? { type: "text-end", id: block.id }
+      : block.kind === "reasoning"
+        ? { type: "reasoning-end", id: block.id }
+        : { type: "tool-params-end", id: block.id },
+  );
+  const blocks = new Map(state.blocks);
+  blocks.delete(index);
+  return { ...state, blocks };
+};
+
+const handleBlockStart = (
+  state: StreamState,
+  event: bedrock.ContentBlockStartEvent,
+  parts: StreamParts,
+): StreamState => {
+  const toolUse = event.start.toolUse;
+  if (toolUse === undefined) return state;
+  parts.push({
+    type: "tool-params-start",
+    id: toolUse.toolUseId,
+    name: toolUse.name,
+  });
+  const blocks = new Map(state.blocks);
+  blocks.set(event.contentBlockIndex, { kind: "tool", id: toolUse.toolUseId });
+  return { ...state, blocks };
+};
+
+const handleBlockDelta = (
+  state: StreamState,
+  event: bedrock.ContentBlockDeltaEvent,
+  parts: StreamParts,
+  idGen: IdGenerator.Service,
+): Effect.Effect<StreamState> =>
+  Effect.gen(function* () {
+    const index = event.contentBlockIndex;
+    const delta = event.delta;
+    let s = state;
+
+    if (delta.text !== undefined) {
+      let block = s.blocks.get(index);
+      if (block === undefined) {
+        const opened = {
+          kind: "text",
+          id: yield* idGen.generateId(),
+        } as const;
+        s = openBlock(s, index, opened, parts);
+        block = opened;
+      }
+      if (delta.text.length > 0) {
+        parts.push({ type: "text-delta", id: block.id, delta: delta.text });
+      }
+      return s;
+    }
+
+    if (delta.reasoningContent !== undefined) {
+      const text = delta.reasoningContent.text;
+      // Signature / redacted-content deltas carry no displayable text.
+      if (text === undefined) return s;
+      let block = s.blocks.get(index);
+      if (block === undefined) {
+        const opened = {
+          kind: "reasoning",
+          id: yield* idGen.generateId(),
+        } as const;
+        s = openBlock(s, index, opened, parts);
+        block = opened;
+      }
+      if (text.length > 0) {
+        parts.push({ type: "reasoning-delta", id: block.id, delta: text });
+      }
+      return s;
+    }
+
+    if (delta.toolUse !== undefined) {
+      const block = s.blocks.get(index);
+      if (block !== undefined && delta.toolUse.input.length > 0) {
+        parts.push({
+          type: "tool-params-delta",
+          id: block.id,
+          delta: delta.toolUse.input,
+        });
+      }
+      return s;
+    }
+
+    return s;
+  });
+
+const streamExceptionOf = (event: bedrock.ConverseStreamOutput): unknown =>
+  event.internalServerException ??
+  event.modelStreamErrorException ??
+  event.validationException ??
+  event.throttlingException ??
+  event.serviceUnavailableException;
+
+const handleStreamEvent = (
+  state: StreamState,
+  event: bedrock.ConverseStreamOutput,
+  idGen: IdGenerator.Service,
+): Effect.Effect<
+  readonly [StreamState, ReadonlyArray<Response.StreamPartEncoded>],
+  AiError.AiError
+> =>
+  Effect.gen(function* () {
+    const exception = streamExceptionOf(event);
+    if (exception !== undefined) {
+      return yield* Effect.fail(toAiError(exception, "streamText"));
+    }
+    const parts: StreamParts = [];
+    let s = state;
+    if (event.contentBlockStart !== undefined) {
+      s = handleBlockStart(s, event.contentBlockStart, parts);
+    } else if (event.contentBlockDelta !== undefined) {
+      s = yield* handleBlockDelta(s, event.contentBlockDelta, parts, idGen);
+    } else if (event.contentBlockStop !== undefined) {
+      s = closeBlock(s, event.contentBlockStop.contentBlockIndex, parts);
+    } else if (event.messageStop !== undefined) {
+      s = { ...s, stopReason: event.messageStop.stopReason };
+    } else if (event.metadata !== undefined) {
+      s = { ...s, usage: event.metadata.usage };
+    }
+    return [s, parts] as const;
+  });
+
+const finalizeStream = (
+  state: StreamState,
+): ReadonlyArray<Response.StreamPartEncoded> => {
+  const parts: StreamParts = [];
+  let s = state;
+  for (const index of [...s.blocks.keys()].sort((a, b) => a - b)) {
+    s = closeBlock(s, index, parts);
+  }
+  parts.push({
+    type: "finish",
+    reason: mapStopReason(s.stopReason),
+    usage: mapUsage(s.usage),
+    response: undefined,
+  });
+  return parts;
+};
+
+const parseStream = (
+  response: bedrock.ConverseStreamResponse,
+  idGen: IdGenerator.Service,
+): Stream.Stream<Response.StreamPartEncoded, AiError.AiError> => {
+  const events = response.stream;
+  if (events === undefined) {
+    return Stream.fromIterable(finalizeStream(initialStreamState));
+  }
+  return events.pipe(
+    Stream.mapError((cause) => toAiError(cause, "streamText")),
+    Stream.mapAccumEffect(
+      () => initialStreamState,
+      (state, event) => handleStreamEvent(state, event, idGen),
+      { onHalt: (state) => finalizeStream(state) },
+    ),
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Error mapping
+// ---------------------------------------------------------------------------
+
+const toAiError = (
+  cause: unknown,
+  method: "generateText" | "streamText",
+): AiError.AiError => {
+  const tagged = cause as { _tag?: string; message?: string } | undefined;
+  const description = [
+    tagged?._tag ?? (cause instanceof Error ? cause.name : undefined),
+    tagged?.message ?? "Bedrock Converse request failed",
+  ]
+    .filter((s): s is string => s !== undefined && s.length > 0)
+    .join(": ");
+  return AiError.AiError.make({
+    module: "AWS.Bedrock.LanguageModel",
+    method,
+    reason: new AiError.UnknownError({ description }),
+  });
+};

--- a/packages/alchemy/src/AWS/Bedrock/LanguageModelHttp.ts
+++ b/packages/alchemy/src/AWS/Bedrock/LanguageModelHttp.ts
@@ -21,10 +21,14 @@ export const LanguageModelHttp = Layer.effect(
   Effect.gen(function* () {
     const converse = yield* Converse;
     const converseStream = yield* ConverseStream;
-    return Effect.fn(function* (model: string, options?: LanguageModelOptions) {
+    return Effect.fn(function* (
+      model: string | readonly [string, ...string[]],
+      options?: LanguageModelOptions,
+    ) {
+      const [first, ...rest] = typeof model === "string" ? [model] : model;
       return makeLanguageModelLayer({
-        converse: yield* converse(model),
-        converseStream: yield* converseStream(model),
+        converse: yield* converse(first, ...rest),
+        converseStream: yield* converseStream(first, ...rest),
         parameters: options?.parameters,
       });
     });

--- a/packages/alchemy/src/AWS/Bedrock/LanguageModelHttp.ts
+++ b/packages/alchemy/src/AWS/Bedrock/LanguageModelHttp.ts
@@ -1,0 +1,32 @@
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { Converse } from "./Converse.ts";
+import { ConverseHttp } from "./ConverseHttp.ts";
+import { ConverseStream } from "./ConverseStream.ts";
+import { ConverseStreamHttp } from "./ConverseStreamHttp.ts";
+import {
+  LanguageModel,
+  type LanguageModelOptions,
+  makeLanguageModelLayer,
+} from "./LanguageModel.ts";
+
+/**
+ * HTTP implementation of {@link LanguageModel}. Composes the {@link Converse}
+ * and {@link ConverseStream} bindings, so binding a model registers both
+ * `bedrock:InvokeModel` and `bedrock:InvokeModelWithResponseStream` scoped to
+ * exactly that model.
+ */
+export const LanguageModelHttp = Layer.effect(
+  LanguageModel,
+  Effect.gen(function* () {
+    const converse = yield* Converse;
+    const converseStream = yield* ConverseStream;
+    return Effect.fn(function* (model: string, options?: LanguageModelOptions) {
+      return makeLanguageModelLayer({
+        converse: yield* converse(model),
+        converseStream: yield* converseStream(model),
+        parameters: options?.parameters,
+      });
+    });
+  }),
+).pipe(Layer.provide(Layer.mergeAll(ConverseHttp, ConverseStreamHttp)));

--- a/packages/alchemy/src/AWS/Bedrock/index.ts
+++ b/packages/alchemy/src/AWS/Bedrock/index.ts
@@ -26,6 +26,8 @@ export * from "./InvokeModelHttp.ts";
 export * from "./InvokeModelWithResponseStream.ts";
 export * from "./InvokeModelWithResponseStreamHttp.ts";
 export * from "./KnowledgeBase.ts";
+export * from "./LanguageModel.ts";
+export * from "./LanguageModelHttp.ts";
 export * from "./ListIngestionJobs.ts";
 export * from "./ListIngestionJobsHttp.ts";
 export * from "./ListKnowledgeBaseDocuments.ts";

--- a/packages/alchemy/test/AWS/Bedrock/LanguageModel.test.ts
+++ b/packages/alchemy/test/AWS/Bedrock/LanguageModel.test.ts
@@ -142,6 +142,52 @@ describe("Bedrock LanguageModel", () => {
   );
 
   test.provider(
+    "withModelParameters overrides maxTokens at runtime",
+    (_stack) =>
+      Effect.gen(function* () {
+        // The binding's default is maxTokens: 1024; the route clamps to 8
+        // via withModelParameters. Truncation proves the override reached
+        // Bedrock: the model runs out of budget mid-answer.
+        const response = (yield* send(
+          HttpClientRequest.get(
+            `${baseUrl}/generate-short?prompt=${encodeURIComponent(
+              "Write a detailed multi-paragraph essay about the history of infrastructure as code.",
+            )}`,
+          ),
+        ).pipe(Effect.flatMap((r) => r.json))) as {
+          finishReason: string;
+          outputTokens: number;
+        };
+
+        expect(response.finishReason).toBe("length");
+        expect(response.outputTokens).toBeLessThanOrEqual(8);
+      }),
+    { timeout: 120_000 },
+  );
+
+  test.provider(
+    "withModelParameters routes a call to another bound model",
+    (_stack) =>
+      Effect.gen(function* () {
+        // The layer binds [nova-micro, nova-lite]; this route overrides
+        // modelId to nova-lite. A 200 with text proves the per-call model
+        // selection and the multi-model IAM grant both work.
+        const response = (yield* send(
+          HttpClientRequest.get(
+            `${baseUrl}/generate-lite?prompt=${encodeURIComponent("Say pong.")}`,
+          ),
+        ).pipe(Effect.flatMap((r) => r.json))) as {
+          text: string;
+          finishReason: string;
+        };
+
+        expect(response.text.length).toBeGreaterThan(0);
+        expect(["stop", "length"]).toContain(response.finishReason);
+      }),
+    { timeout: 120_000 },
+  );
+
+  test.provider(
     "streamText emits ordered parts: text-start → text-delta+ → text-end → finish",
     (_stack) =>
       Effect.gen(function* () {

--- a/packages/alchemy/test/AWS/Bedrock/LanguageModel.test.ts
+++ b/packages/alchemy/test/AWS/Bedrock/LanguageModel.test.ts
@@ -1,0 +1,270 @@
+import * as AWS from "@/AWS";
+import * as Test from "@/Test/Alchemy";
+import * as Core from "@/Test/Core";
+import { describe, expect } from "alchemy-test";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import BedrockLanguageModelFunctionLive, {
+  BedrockLanguageModelFunction,
+} from "./language-model-handler";
+
+const testOptions = { providers: AWS.providers() };
+const { test, beforeAll, afterAll } = Test.make(testOptions);
+const sharedStack = Core.scratchStack(testOptions, "BedrockLanguageModel");
+
+// Lambda function URL cold-start (DNS, IAM propagation, init) can take well
+// over 60s on a fresh deploy under parallel-suite load. Budget ~150s of
+// readiness polling.
+const readinessPolicy = Schedule.max([
+  Schedule.fixed("2 seconds"),
+  Schedule.recurs(75),
+]);
+
+let baseUrl: string;
+
+class TransientUpstream extends Data.TaggedError("TransientUpstream")<{
+  readonly status: number;
+  readonly body: string;
+}> {}
+
+// The shared Lambda fixture occasionally answers a transient 5xx under
+// parallel load (cold re-init, IAM propagation, Bedrock throttling). Retry
+// 5xx only; a genuine 4xx/assertion failure surfaces immediately.
+const send = (request: HttpClientRequest.HttpClientRequest) =>
+  HttpClient.execute(request).pipe(
+    Effect.flatMap((response) =>
+      response.status >= 500
+        ? response.text.pipe(
+            Effect.flatMap((body) =>
+              Effect.fail(
+                new TransientUpstream({ status: response.status, body }),
+              ),
+            ),
+          )
+        : Effect.succeed(response),
+    ),
+    Effect.retry({
+      while: (e) => e._tag === "TransientUpstream",
+      schedule: Schedule.max([
+        Schedule.exponential("1 second"),
+        Schedule.recurs(5),
+      ]),
+    }),
+  );
+
+interface StreamPart {
+  type: string;
+  id?: string;
+  name?: string;
+  delta?: string;
+  reason?: string;
+  usage?: {
+    inputTokens?: { total?: number };
+    outputTokens?: { total?: number };
+  };
+}
+
+const parseSse = (sse: string): ReadonlyArray<StreamPart> =>
+  sse
+    .split("\n\n")
+    .map((frame) => frame.replace(/^data:\s*/, "").trim())
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line) as StreamPart);
+
+describe("Bedrock LanguageModel", () => {
+  beforeAll(
+    Effect.gen(function* () {
+      yield* Effect.logInfo(
+        "Bedrock LanguageModel setup: destroying previous resources",
+      );
+      yield* sharedStack.destroy();
+
+      yield* Effect.logInfo("Bedrock LanguageModel setup: deploying fixture");
+      const { functionUrl } = yield* sharedStack.deploy(
+        Effect.gen(function* () {
+          return yield* BedrockLanguageModelFunction;
+        }).pipe(Effect.provide(BedrockLanguageModelFunctionLive)),
+      );
+
+      expect(functionUrl).toBeTruthy();
+      baseUrl = functionUrl!.replace(/\/+$/, "");
+      const readinessUrl = `${baseUrl}/ping`;
+
+      yield* Effect.logInfo(
+        `Bedrock LanguageModel setup: probing readiness at ${readinessUrl}`,
+      );
+      yield* HttpClient.get(readinessUrl).pipe(
+        Effect.flatMap((response) =>
+          response.status === 200
+            ? Effect.succeed(response)
+            : Effect.fail(new Error(`Function not ready: ${response.status}`)),
+        ),
+        Effect.tapError((error) =>
+          Effect.logWarning(
+            `Bedrock LanguageModel setup: fixture not ready yet (${String(error)})`,
+          ),
+        ),
+        Effect.retry({ schedule: readinessPolicy }),
+      );
+    }),
+    { timeout: 240_000 },
+  );
+
+  afterAll.skipIf(!!process.env.NO_DESTROY)(sharedStack.destroy(), {
+    timeout: 120_000,
+  });
+
+  test.provider(
+    "generateText answers with text, usage, and a terminal finish reason",
+    (_stack) =>
+      Effect.gen(function* () {
+        const response = (yield* send(
+          HttpClientRequest.get(
+            `${baseUrl}/generate?prompt=${encodeURIComponent("Say pong.")}`,
+          ),
+        ).pipe(Effect.flatMap((r) => r.json))) as {
+          text: string;
+          finishReason: string;
+          usage: { inputTokens: number; outputTokens: number };
+        };
+
+        expect(typeof response.text).toBe("string");
+        expect(response.text.length).toBeGreaterThan(0);
+        expect(response.usage.inputTokens).toBeGreaterThan(0);
+        expect(response.usage.outputTokens).toBeGreaterThan(0);
+        // A normal Converse completion (`end_turn`) maps to `stop`.
+        expect(["stop", "length"]).toContain(response.finishReason);
+      }),
+    { timeout: 120_000 },
+  );
+
+  test.provider(
+    "streamText emits ordered parts: text-start → text-delta+ → text-end → finish",
+    (_stack) =>
+      Effect.gen(function* () {
+        const sse = yield* send(
+          HttpClientRequest.get(
+            `${baseUrl}/stream?prompt=${encodeURIComponent(
+              "Write a short paragraph (around 80 words) about why TypeScript developers might enjoy Effect TS.",
+            )}`,
+          ),
+        ).pipe(Effect.flatMap((r) => r.text));
+        const parts = parseSse(sse);
+
+        const startIdx = parts.findIndex((p) => p.type === "text-start");
+        const firstDeltaIdx = parts.findIndex((p) => p.type === "text-delta");
+        const deltas = parts.filter((p) => p.type === "text-delta");
+        const lastDeltaIdx = parts.lastIndexOf(deltas[deltas.length - 1]!);
+        const endIdx = parts.findIndex((p) => p.type === "text-end");
+        const finishIdx = parts.findIndex((p) => p.type === "finish");
+
+        // Adapter invariant: a text block opens before its first delta and
+        // closes before the terminal finish part.
+        expect(startIdx).toBeGreaterThanOrEqual(0);
+        expect(firstDeltaIdx).toBeGreaterThan(startIdx);
+        expect(endIdx).toBeGreaterThan(lastDeltaIdx);
+        expect(finishIdx).toBe(parts.length - 1);
+
+        // Bedrock streams one text-delta per contentBlockDelta event — a
+        // long response must produce many (a single fused delta would mean
+        // the adapter buffered the stream).
+        expect(deltas.length).toBeGreaterThan(3);
+        const text = deltas.map((p) => p.delta ?? "").join("");
+        expect(text.length).toBeGreaterThan(20);
+
+        // The metadata event's usage must survive into the finish part.
+        const finish = parts[finishIdx]!;
+        expect(finish.usage?.inputTokens?.total).toBeGreaterThan(0);
+        expect(finish.usage?.outputTokens?.total).toBeGreaterThan(0);
+        expect(["stop", "length"]).toContain(finish.reason);
+      }),
+    { timeout: 120_000 },
+  );
+
+  test.provider(
+    "generateText invokes a tool and returns its result",
+    (_stack) =>
+      Effect.gen(function* () {
+        const response = (yield* send(
+          HttpClientRequest.get(
+            `${baseUrl}/tool?prompt=${encodeURIComponent(
+              "What's the weather in San Francisco?",
+            )}`,
+          ),
+        ).pipe(Effect.flatMap((r) => r.json))) as {
+          finishReason: string;
+          toolCalls: Array<{
+            id: string;
+            name: string;
+            params: { city: string };
+          }>;
+          toolResults: Array<{
+            id: string;
+            name: string;
+            result: { city: string; temperatureF: number; condition: string };
+            isFailure: boolean;
+          }>;
+        };
+
+        expect(response.toolCalls.length).toBeGreaterThan(0);
+        const call = response.toolCalls[0]!;
+        expect(call.name).toBe("get_weather");
+        expect(typeof call.params.city).toBe("string");
+        expect(call.params.city.toLowerCase()).toContain("san francisco");
+
+        expect(response.toolResults.length).toBeGreaterThan(0);
+        const result = response.toolResults[0]!;
+        expect(result.name).toBe("get_weather");
+        expect(result.isFailure).toBe(false);
+        expect(result.result.temperatureF).toBe(72);
+        expect(result.result.condition).toBe("sunny");
+      }),
+    { timeout: 120_000 },
+  );
+
+  test.provider(
+    "streamText emits tool-params parts whose deltas concatenate to the arguments",
+    (_stack) =>
+      Effect.gen(function* () {
+        const sse = yield* send(
+          HttpClientRequest.get(
+            `${baseUrl}/tool-stream?prompt=${encodeURIComponent(
+              "What's the weather in Portland?",
+            )}`,
+          ),
+        ).pipe(Effect.flatMap((r) => r.text));
+        const parts = parseSse(sse);
+
+        const starts = parts.filter((p) => p.type === "tool-params-start");
+        const ends = parts.filter((p) => p.type === "tool-params-end");
+        expect(starts.length).toBeGreaterThan(0);
+        expect(starts[0]?.name).toBe("get_weather");
+        // Adapter invariant: every contentBlockStart-opened tool block is
+        // closed by contentBlockStop (or finalize), matched by id.
+        expect(new Set(ends.map((p) => p.id))).toEqual(
+          new Set(starts.map((p) => p.id)),
+        );
+
+        const firstId = starts[0]!.id!;
+        const joined = parts
+          .filter((p) => p.type === "tool-params-delta" && p.id === firstId)
+          .map((p) => p.delta ?? "")
+          .join("");
+        const args = yield* Effect.try({
+          try: () => JSON.parse(joined) as { city?: string },
+          catch: (cause) =>
+            new Error(
+              `Invalid concatenated tool arguments ${JSON.stringify(joined)}: ${cause}`,
+            ),
+        });
+        expect(typeof args.city).toBe("string");
+        expect(args.city!.toLowerCase()).toContain("portland");
+
+        expect(parts[parts.length - 1]?.type).toBe("finish");
+      }),
+    { timeout: 120_000 },
+  );
+});

--- a/packages/alchemy/test/AWS/Bedrock/language-model-handler.ts
+++ b/packages/alchemy/test/AWS/Bedrock/language-model-handler.ts
@@ -19,6 +19,8 @@ const main = path.resolve(import.meta.dirname, "language-model-handler.ts");
 // on-demand conversational model in the testing account, with full
 // Converse tool-use + streaming support.
 const MODEL = "us.amazon.nova-micro-v1:0";
+// A second bound model to exercise the per-call `modelId` override.
+const LITE_MODEL = "us.amazon.nova-lite-v1:0";
 
 const GetWeather = Tool.make("get_weather", {
   description:
@@ -59,7 +61,7 @@ export default BedrockLanguageModelFunction.make(
     timeout: Duration.seconds(120),
   },
   Effect.gen(function* () {
-    const model = yield* Bedrock.LanguageModel(MODEL, {
+    const model = yield* Bedrock.LanguageModel([MODEL, LITE_MODEL], {
       parameters: { maxTokens: 1024, temperature: 0.2 },
     });
 
@@ -86,6 +88,31 @@ export default BedrockLanguageModelFunction.make(
               inputTokens: response.usage.inputTokens.total,
               outputTokens: response.usage.outputTokens.total,
             },
+          });
+        }
+
+        if (pathname === "/generate-short") {
+          // Runtime override: clamp the same bound model to a tiny budget.
+          const response = yield* AiLanguageModel.generateText({
+            prompt,
+          }).pipe(
+            Bedrock.withModelParameters({ maxTokens: 8, temperature: 0 }),
+          );
+          return yield* HttpServerResponse.json({
+            text: response.text,
+            finishReason: response.finishReason,
+            outputTokens: response.usage.outputTokens.total,
+          });
+        }
+
+        if (pathname === "/generate-lite") {
+          // Runtime override: route this call to the second bound model.
+          const response = yield* AiLanguageModel.generateText({
+            prompt,
+          }).pipe(Bedrock.withModelParameters({ modelId: LITE_MODEL }));
+          return yield* HttpServerResponse.json({
+            text: response.text,
+            finishReason: response.finishReason,
           });
         }
 

--- a/packages/alchemy/test/AWS/Bedrock/language-model-handler.ts
+++ b/packages/alchemy/test/AWS/Bedrock/language-model-handler.ts
@@ -1,0 +1,158 @@
+import * as Bedrock from "@/AWS/Bedrock";
+import * as Lambda from "@/AWS/Lambda";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+import * as Stream from "effect/Stream";
+import {
+  LanguageModel as AiLanguageModel,
+  Tool,
+  Toolkit,
+} from "effect/unstable/ai";
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import path from "pathe";
+
+const main = path.resolve(import.meta.dirname, "language-model-handler.ts");
+
+// Nova Micro via the us cross-region inference profile: the cheapest
+// on-demand conversational model in the testing account, with full
+// Converse tool-use + streaming support.
+const MODEL = "us.amazon.nova-micro-v1:0";
+
+const GetWeather = Tool.make("get_weather", {
+  description:
+    "Get the current weather for a city. Always call this tool when the user asks about the weather.",
+  parameters: Schema.Struct({
+    city: Schema.String,
+  }),
+  success: Schema.Struct({
+    city: Schema.String,
+    temperatureF: Schema.Number,
+    condition: Schema.String,
+  }),
+});
+
+const WeatherToolkit = Toolkit.make(GetWeather);
+
+const WeatherToolkitLayer = WeatherToolkit.toLayer({
+  get_weather: ({ city }) =>
+    Effect.succeed({
+      city,
+      temperatureF: 72,
+      condition: "sunny",
+    }),
+});
+
+const toSse = (parts: Iterable<unknown>): string =>
+  [...parts].map((part) => `data: ${JSON.stringify(part)}\n\n`).join("");
+
+export class BedrockLanguageModelFunction extends Lambda.Function<Lambda.Function>()(
+  "BedrockLanguageModelFunction",
+) {}
+
+export default BedrockLanguageModelFunction.make(
+  {
+    main,
+    url: true,
+    // Model inference regularly exceeds Lambda's 3s default timeout.
+    timeout: Duration.seconds(120),
+  },
+  Effect.gen(function* () {
+    const model = yield* Bedrock.LanguageModel(MODEL, {
+      parameters: { maxTokens: 1024, temperature: 0.2 },
+    });
+
+    return {
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        const url = new URL(request.originalUrl);
+        const pathname = url.pathname;
+        const prompt =
+          url.searchParams.get("prompt") ??
+          "Say the single word 'pong' and nothing else.";
+
+        // Cheap readiness route — no Bedrock call.
+        if (pathname === "/ping") {
+          return yield* HttpServerResponse.json({ ok: true });
+        }
+
+        if (pathname === "/generate") {
+          const response = yield* AiLanguageModel.generateText({ prompt });
+          return yield* HttpServerResponse.json({
+            text: response.text,
+            finishReason: response.finishReason,
+            usage: {
+              inputTokens: response.usage.inputTokens.total,
+              outputTokens: response.usage.outputTokens.total,
+            },
+          });
+        }
+
+        if (pathname === "/stream") {
+          // Collected server-side: Lambda function URLs buffer responses by
+          // default, and the tests assert on the part sequence, not
+          // incremental delivery.
+          const parts = yield* Stream.runCollect(
+            AiLanguageModel.streamText({ prompt }),
+          );
+          return HttpServerResponse.text(toSse(parts), {
+            headers: { "content-type": "text/event-stream" },
+          });
+        }
+
+        if (pathname === "/tool") {
+          const response = yield* AiLanguageModel.generateText({
+            prompt,
+            toolkit: WeatherToolkit,
+            toolChoice: "required",
+          }).pipe(Effect.provide(WeatherToolkitLayer));
+          return yield* HttpServerResponse.json({
+            text: response.text,
+            finishReason: response.finishReason,
+            toolCalls: response.toolCalls.map((call) => ({
+              id: call.id,
+              name: call.name,
+              params: call.params,
+            })),
+            toolResults: response.toolResults.map((result) => ({
+              id: result.id,
+              name: result.name,
+              result: result.result,
+              isFailure: result.isFailure,
+            })),
+          });
+        }
+
+        if (pathname === "/tool-stream") {
+          const parts = yield* Stream.runCollect(
+            AiLanguageModel.streamText({
+              prompt,
+              toolkit: WeatherToolkit,
+              toolChoice: "required",
+            }).pipe(Stream.provide(WeatherToolkitLayer)),
+          );
+          return HttpServerResponse.text(toSse(parts), {
+            headers: { "content-type": "text/event-stream" },
+          });
+        }
+
+        return yield* HttpServerResponse.json(
+          { error: "Not found", pathname },
+          { status: 404 },
+        );
+      }).pipe(
+        // Surface adapter/model failures as a JSON 500 so live-test runs can
+        // read the failure without digging through CloudWatch.
+        Effect.catchTag("AiError", (error) =>
+          HttpServerResponse.json(
+            { error: String(error.message) },
+            { status: 500 },
+          ),
+        ),
+        Effect.provide(model),
+        Effect.orDie,
+      ),
+    };
+  }).pipe(Effect.provide(Bedrock.LanguageModelHttp)),
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -79,6 +79,9 @@
       "path": "./examples/aws-eks/tsconfig.json"
     },
     {
+      "path": "./examples/aws-bedrock-ai/tsconfig.json"
+    },
+    {
       "path": "./examples/aws-lambda-httpapi/tsconfig.json"
     },
     {

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -866,6 +866,12 @@ export default defineConfig({
               ],
             },
             {
+              label: "AI",
+              items: [
+                { label: "Bedrock & Effect AI", link: "/aws/ai/bedrock" },
+              ],
+            },
+            {
               label: "Messaging & events",
               items: [
                 { label: "SQS", link: "/aws/messaging/sqs" },

--- a/website/src/content/docs/aws/ai/bedrock.mdx
+++ b/website/src/content/docs/aws/ai/bedrock.mdx
@@ -127,36 +127,62 @@ const response = yield* LanguageModel.generateText({
 response.toolResults; // typed results, executed by your handlers
 ```
 
-## Multiple models
+## Configure parameters at runtime
 
-Each `LanguageModel(...)` call is its own layer with its own IAM
-grant, so you can bind several models and pick per route:
+Binding is the IAM boundary — *which models* the Function may call
+is fixed at deploy time. Everything else is a runtime decision. The
+`parameters` passed to the binding are only defaults; scope per-call
+overrides onto any call with `AWS.Bedrock.withModelParameters`:
 
 ```typescript
-const fast = yield* AWS.Bedrock.LanguageModel("us.amazon.nova-micro-v1:0");
-const smart = yield* AWS.Bedrock.LanguageModel(
-  "us.anthropic.claude-sonnet-4-20250514-v1:0",
+const response = yield* LanguageModel.generateText({ prompt }).pipe(
+  AWS.Bedrock.withModelParameters({ temperature: 0, maxTokens: 64 }),
 );
 ```
 
-## Model-specific parameters
+It works on streams the same way:
+
+```typescript
+const parts = LanguageModel.streamText({ prompt }).pipe(
+  Stream.provide(model),
+  AWS.Bedrock.withModelParameters({ temperature: 0.9 }),
+);
+```
+
+The override is fiber-scoped (a `Context.Reference`), so it applies
+to exactly the calls inside the piped region — concurrent requests
+with different settings never interfere. Defined fields win over the
+binding's defaults; omitted fields fall through.
 
 `parameters` covers the Converse API's portable `inferenceConfig`
 (`maxTokens`, `temperature`, `topP`, `stopSequences`). Anything
 model-specific passes through `additionalModelRequestFields`
-verbatim:
+verbatim — e.g. `{ top_k: 50 }` for Anthropic models.
+
+## Multiple models
+
+Bind a list of models to grant IAM for all of them in one layer —
+the first is the default, and `modelId` picks per call:
 
 ```typescript
-const model = yield* AWS.Bedrock.LanguageModel(
+// init: IAM for both models, Nova Micro is the default
+const model = yield* AWS.Bedrock.LanguageModel([
+  "us.amazon.nova-micro-v1:0",
   "us.anthropic.claude-sonnet-4-20250514-v1:0",
-  {
-    parameters: {
-      maxTokens: 2048,
-      additionalModelRequestFields: { top_k: 50 },
-    },
-  },
+]);
+
+// runtime: route this request to Claude, tuned for this call
+const response = yield* LanguageModel.generateText({ prompt }).pipe(
+  AWS.Bedrock.withModelParameters({
+    modelId: "us.anthropic.claude-sonnet-4-20250514-v1:0",
+    maxTokens: 2048,
+  }),
 );
 ```
+
+Separate `LanguageModel(...)` calls also work — each is its own
+layer with its own grant — when you'd rather select a model by
+providing a different layer per route.
 
 ## Why not an OpenAI-compatible endpoint?
 

--- a/website/src/content/docs/aws/ai/bedrock.mdx
+++ b/website/src/content/docs/aws/ai/bedrock.mdx
@@ -1,0 +1,190 @@
+---
+title: Bedrock & Effect AI
+description: Drive Effect's LanguageModel service with Amazon Bedrock models from a Lambda Function — IAM-scoped bindings, streaming, and tool calling over the Converse API.
+sidebar:
+  order: 1
+---
+
+Effect's AI surface gives you a single `LanguageModel` service that
+every model provider ships as a `Layer`. Once that layer is in scope,
+the rest of the surface (`generateText`, `streamText`, `Toolkit`,
+`Chat`, …) is provider-agnostic.
+
+`AWS.Bedrock.LanguageModel` builds that layer on top of Amazon
+Bedrock. It speaks Bedrock's [Converse
+API](https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference.html)
+— the unified messages API that works across all conversational
+foundation models (Amazon Nova, Anthropic Claude, Meta Llama,
+Mistral, …) — so one binding covers every model on Bedrock. Requests
+are signed with the Function's IAM role: there is no API key to
+provision, store, or rotate.
+
+## Bind a model
+
+`yield* AWS.Bedrock.LanguageModel(model)` in the Function's init
+phase returns a `LanguageModel` `Layer` and grants the Function
+`bedrock:InvokeModel` and `bedrock:InvokeModelWithResponseStream`
+scoped to exactly that model:
+
+```typescript
+// src/Api.ts
+import * as AWS from "alchemy/AWS";
+import * as Effect from "effect/Effect";
+import { LanguageModel } from "effect/unstable/ai";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+export default class Api extends AWS.Lambda.Function<Api>()(
+  "Api",
+  { main: import.meta.url, url: true },
+  Effect.gen(function* () {
+    const model = yield* AWS.Bedrock.LanguageModel(
+      "us.amazon.nova-micro-v1:0",
+      { parameters: { maxTokens: 1024, temperature: 0.7 } },
+    );
+
+    return {
+      fetch: Effect.gen(function* () {
+        const response = yield* LanguageModel.generateText({
+          prompt: "Say hello.",
+        }).pipe(Effect.orDie);
+        return yield* HttpServerResponse.json({ text: response.text });
+      }).pipe(Effect.provide(model)),
+    };
+  }).pipe(Effect.provide(AWS.Bedrock.LanguageModelHttp)),
+) {}
+```
+
+`AWS.Bedrock.LanguageModelHttp` is the binding's implementation
+layer. Provide it once at the bottom of the init chain — it composes
+the `Converse` and `ConverseStream` bindings, so it is bundled into
+the Lambda and signs requests with the invocation role's credentials.
+
+A model reference may be a foundation-model id
+(`anthropic.claude-sonnet-4-20250514-v1:0`), a cross-region inference
+profile id (`us.amazon.nova-micro-v1:0`), or a full Bedrock ARN.
+Model access is an account entitlement — enable the model in the
+Bedrock console (Model access) before invoking, otherwise calls fail
+with `AccessDeniedException`. Many newer models are only invocable
+through their cross-region inference profile id, not the bare
+foundation-model id.
+
+## Stream text
+
+`streamText` maps Bedrock's `ConverseStream` events onto Effect AI's
+stream parts (`text-start`, `text-delta`, …, `finish`), one part per
+Bedrock event:
+
+```typescript
+import * as Stream from "effect/Stream";
+
+const parts = LanguageModel.streamText({
+  prompt: "Write a haiku about infrastructure.",
+}).pipe(Stream.provide(model));
+
+yield* parts.pipe(
+  Stream.runForEach((part) =>
+    part.type === "text-delta"
+      ? Effect.sync(() => process.stdout.write(part.delta))
+      : Effect.void,
+  ),
+);
+```
+
+The terminal `finish` part carries the mapped stop reason
+(`end_turn` → `stop`, `tool_use` → `tool-calls`, `max_tokens` →
+`length`, …) and real token usage from the stream's `metadata` event,
+including prompt-cache read/write counts.
+
+## Call tools
+
+Effect AI toolkits work unchanged — tool schemas are translated to
+Converse `toolConfig` and Bedrock's structured tool-use blocks are
+decoded back into typed tool calls and results:
+
+```typescript
+import * as Schema from "effect/Schema";
+import { Tool, Toolkit } from "effect/unstable/ai";
+
+const GetWeather = Tool.make("get_weather", {
+  description: "Get the current weather for a city.",
+  parameters: Schema.Struct({ city: Schema.String }),
+  success: Schema.Struct({ temperatureF: Schema.Number }),
+});
+const WeatherToolkit = Toolkit.make(GetWeather);
+
+const response = yield* LanguageModel.generateText({
+  prompt: "What's the weather in Seattle?",
+  toolkit: WeatherToolkit,
+}).pipe(
+  Effect.provide(
+    WeatherToolkit.toLayer({
+      get_weather: ({ city }) => Effect.succeed({ temperatureF: 72 }),
+    }),
+  ),
+  Effect.provide(model),
+);
+
+response.toolResults; // typed results, executed by your handlers
+```
+
+## Multiple models
+
+Each `LanguageModel(...)` call is its own layer with its own IAM
+grant, so you can bind several models and pick per route:
+
+```typescript
+const fast = yield* AWS.Bedrock.LanguageModel("us.amazon.nova-micro-v1:0");
+const smart = yield* AWS.Bedrock.LanguageModel(
+  "us.anthropic.claude-sonnet-4-20250514-v1:0",
+);
+```
+
+## Model-specific parameters
+
+`parameters` covers the Converse API's portable `inferenceConfig`
+(`maxTokens`, `temperature`, `topP`, `stopSequences`). Anything
+model-specific passes through `additionalModelRequestFields`
+verbatim:
+
+```typescript
+const model = yield* AWS.Bedrock.LanguageModel(
+  "us.anthropic.claude-sonnet-4-20250514-v1:0",
+  {
+    parameters: {
+      maxTokens: 2048,
+      additionalModelRequestFields: { top_k: 50 },
+    },
+  },
+);
+```
+
+## Why not an OpenAI-compatible endpoint?
+
+Bedrock also exposes an OpenAI-compatible Chat Completions endpoint,
+but it authenticates with long-lived Bedrock API keys and only covers
+a subset of models. The Converse-backed binding uses the Function's
+IAM role (SigV4) with a least-privilege grant scoped to the bound
+model, works with every conversational model on Bedrock, and needs no
+secret material at all.
+
+## Lower-level access
+
+The `LanguageModel` binding is built on the raw Converse bindings,
+which remain available when you want the wire-level API:
+
+- [`AWS.Bedrock.Converse`](/providers/aws/bedrock/converse) — single-shot
+  messages API
+- [`AWS.Bedrock.ConverseStream`](/providers/aws/bedrock/conversestream) —
+  streaming event API
+- [`AWS.Bedrock.InvokeModel`](/providers/aws/bedrock/invokemodel) — raw
+  model-native payloads
+
+## Where to go next
+
+- [Effect AI documentation](https://effect.website/docs/ai/introduction)
+  — the API surface (`generateText`, `streamText`, `Toolkit`,
+  structured outputs).
+- [Lambda](/aws/compute/lambda) — the Function runtime this binding
+  attaches to.
+- [Effect AI on Cloudflare](/cloudflare/ai/effect-ai) — the same
+  `LanguageModel` programs running on Workers AI.

--- a/website/src/content/docs/cloudflare/ai/effect-ai.mdx
+++ b/website/src/content/docs/cloudflare/ai/effect-ai.mdx
@@ -256,6 +256,8 @@ model })` — is the same.
 - [`@effect/ai-amazon-bedrock`](https://www.npmjs.com/package/@effect/ai-amazon-bedrock)
 - `Cloudflare.Workers.AI` (the native Workers AI binding, via Alchemy itself)
 - `Cloudflare.AI.Gateway` (Workers AI behind an AI Gateway, via Alchemy itself)
+- [`AWS.Bedrock.LanguageModel`](/aws/ai/bedrock) (Amazon Bedrock over the
+  Converse API with IAM-scoped bindings, via Alchemy itself)
 
 ## Where to go next
 


### PR DESCRIPTION
`AWS.Bedrock.LanguageModel` turns any Bedrock model into an `effect/unstable/ai` `LanguageModel` `Layer`, so `generateText`, `streamText`, toolkits, and `Chat` run against Bedrock unchanged.

```ts
// init: one binding grants bedrock:InvokeModel + InvokeModelWithResponseStream
// scoped to exactly these models and returns the LanguageModel Layer
const model = yield* AWS.Bedrock.LanguageModel(
  ["us.amazon.nova-micro-v1:0", "us.anthropic.claude-sonnet-4-20250514-v1:0"],
  { parameters: { maxTokens: 1024, temperature: 0.7 } }, // defaults only
);

return {
  fetch: Effect.gen(function* () {
    // runtime: parameters and model choice are per-call decisions
    const response = yield* LanguageModel.generateText({ prompt }).pipe(
      AWS.Bedrock.withModelParameters({
        modelId: "us.anthropic.claude-sonnet-4-20250514-v1:0",
        temperature: 0,
        maxTokens: 64,
      }),
    );
    return yield* HttpServerResponse.json({ text: response.text });
  }).pipe(Effect.provide(model)),
};
// provide AWS.Bedrock.LanguageModelHttp on the Function Effect
```

Binding is the IAM boundary — which models the Function may call is fixed at deploy time. Everything else is runtime-configurable: `withModelParameters` scopes overrides (all `inferenceConfig` fields, `additionalModelRequestFields`, and `modelId` among the bound models) onto any Effect or Stream via a fiber-scoped `Context.Reference`, so concurrent requests with different settings never interfere.

The adapter speaks Bedrock's Converse API rather than pointing effect's OpenAI/Anthropic clients at a Bedrock URL:

- effect v4's `effect/unstable/ai` ships only the core abstractions — there are no v4 provider packages (the Cloudflare Workers AI integration hand-rolls its adapter for the same reason)
- Bedrock's OpenAI-compatible endpoint needs long-lived API keys and covers a model subset; Converse is SigV4-signed with the Function's IAM role and works across all conversational models (Nova, Claude, Llama, Mistral, ...)
- `LanguageModelHttp` composes the existing `Converse`/`ConverseStream` bindings, so least-privilege IAM comes from the same machinery

Mapping notes:

- Bedrock's structured stream events (`contentBlockStart/Delta/Stop`, `messageStop`, `metadata`) map 1:1 onto Effect AI stream parts, keyed by `contentBlockIndex`
- `stopReason` → `finishReason` (`end_turn`→`stop`, `tool_use`→`tool-calls`, `max_tokens`→`length`, ...); usage includes prompt-cache read/write counts
- tool schemas → `toolConfig.toolSpec`; `toolChoice` `required`→`{any:{}}`, named tool→`{tool:{name}}`; `"none"` omits `toolConfig` unless the history already carries tool blocks (the API rejects that)
- consecutive same-role messages are merged (Converse requires user/assistant alternation; tool results ride in user messages)

Tested live against `us.amazon.nova-micro-v1:0` + `us.amazon.nova-lite-v1:0` via a Lambda fixture ([LanguageModel.test.ts](https://github.com/alchemy-run/alchemy/blob/claude/bedrock-language-model-integration-981617/packages/alchemy/test/AWS/Bedrock/LanguageModel.test.ts)), 6/6 green: generateText with usage/finish-reason, stream part ordering, tool invocation, streamed tool-params deltas, runtime `maxTokens` override (proved by `length` truncation), and per-call `modelId` routing through the multi-model IAM grant.

Also in this PR:

- `examples/aws-bedrock-ai` — Lambda + Function URL example (generate with `?temperature=&maxTokens=` runtime overrides, SSE stream, tool call); integ test deploys, generates through Bedrock, and destroys clean
- Docs: new [AWS › AI › Bedrock & Effect AI](https://alchemy.run/aws/ai/bedrock) guide, sidebar entry, cross-link from the Cloudflare Effect AI guide; `@binding` JSDoc generates the `providers/AWS/Bedrock/LanguageModel` reference page

🤖 Generated with [Claude Code](https://claude.com/claude-code)
