### PR TITLE
docs(blog): beta.63 release notes and alchemy-test announcement

### DIFF
--- a/website/src/content/docs/blog/2026-07-22-a-test-runner-for-agents.md
+++ b/website/src/content/docs/blog/2026-07-22-a-test-runner-for-agents.md
@@ -1,0 +1,197 @@
+---
+title: A Test Runner for Agents
+date: 2026-07-22T07:00:00Z
+draft: true
+excerpt: Alchemy's test suite is 4,000+ live tests against real clouds, and some take minutes. Vitest forked processes and reloaded our generated SDK on every fork; bun test assumes tests are fast and runs them one file at a time. So we wrote our own runner — one bun process, everything concurrent, plain output tuned for agents and a live TUI for humans.
+---
+
+Alchemy's test suite is not a normal test suite. It's **4,000+
+live tests** that deploy real resources to real clouds and tear
+them down again. Some finish in milliseconds. Some take minutes —
+provisioning an EKS cluster, waiting for an eventually consistent
+API to converge, pushing a message through a queue and polling
+until it comes out the other side.
+
+That shape broke every runner we tried. So we built our own:
+[`alchemy-test`](https://github.com/alchemy-run/alchemy/tree/main/packages/alchemy-test)
+([#848](https://github.com/alchemy-run/alchemy/pull/848)), a
+vitest-compatible runner built for our scale: the entire suite
+runs in a single bun process, plain output is designed for the
+agent reading it, and an interactive TUI gives humans a live view
+of a run with thousands of tests in flight.
+
+## Why not vitest
+
+Vitest parallelizes across workers, and every worker builds its
+own module graph — threads don't share modules any more than
+forks do. Everything alchemy depends on includes
+[distilled](https://github.com/alchemy-run/distilled), our
+generated AWS/Cloudflare SDK, which spans hundreds of service
+modules. Paying that import cost once is fine. Paying it per
+worker, hundreds of times per run, is not.
+
+There's no way out of that trade-off inside vitest. It can run
+everything in one worker (`singleFork` with `isolate: false`) —
+but [by vitest's own
+docs](https://vitest.dev/config/#pooloptions-forks-singlefork)
+that "will force tests to run one after another", and source code
+processed by vite "will still be reevaluated for each test" even
+then. Parallel files mean many workers; one worker means a
+sequential suite. The quadrant we needed — many files in flight,
+one module graph — doesn't exist.
+
+For us it was worse than that. Our toolchain runs on bun, and
+bun's `worker_threads` segfaults under vitest's tinypool at
+worker spawn — so we were pinned to `pool: "forks"`, full
+`child_process` forks, the most expensive flavor of an already
+expensive design. And no, "just run tests on node" doesn't fix
+it: the per-worker import cost is the same, and node can't
+execute distilled's TypeScript natively, so a transform layer
+comes back.
+
+The module cost also made iteration slow in a way that hurt
+agents most. To load distilled's TypeScript source in vitest we
+needed a rolldown plugin; the alternative was compiling
+distilled's `.ts` to `.js` before every run. Either way there was
+a build step between "agent edits code" and "agent sees the test
+result". Agents iterate on failing tests in tight loops — every
+second of compile tax is paid dozens of times per task.
+
+## Why not bun test
+
+`bun test` solves both problems: it's bun-native, so `.ts` loads
+directly with no plugin and no compile step. But it runs test
+files one at a time, an assumption that only works when tests are
+fast.
+
+Alchemy tests are slow on purpose — they wait for real clouds. Run
+them sequentially and a directory that should take two minutes
+takes an hour. We needed dozens of files in flight at once, in one
+process, on bun.
+
+## One process, everything concurrent
+
+`alchemy-test` imports every test file up front (imports are cheap
+when they happen once) and then runs files and tests concurrently
+on the Effect runtime — fibers, not forks. A `--concurrency` flag
+bounds how many files run at once, and tests that mutate global
+state can take a whole-process lock with `{ exclusive: true }`.
+
+The CLI is vitest-compatible — positional paths, `-t` filters,
+timeouts, retries — so the migration was a codemod.
+
+```sh
+bun run test test/Cloudflare/Workers -t "cron"
+```
+
+## Output an agent can act on
+
+Performance forced our hand, but once we owned the runner we
+could fix something that had bothered us just as long: the
+output.
+
+Vitest's default reporter prints stdout noisily: interleaved
+across parallel tests, indented and reflowed on top of your raw
+output. When a test fails, the error is somewhere in the scroll.
+We watched agents run a suite, `tail` the output to save context,
+and lose the one error they needed — even when prompted not to.
+A custom reporter can quiet some of this, but it works by
+intercepting `console` and guessing which test a log belongs to —
+best-effort attribution you're consuming, not controlling.
+
+Our tests are Effects, which means we control the runtime they
+execute in. Each test runs under a buffering `Logger` and
+`Console`, so every log line is captured and attributed to its
+test by construction — nothing interleaves, nothing prints as it
+happens. The console gets exactly one line per test:
+
+```
+✓ test/Cloudflare/Workers/Subdomain.test.ts > enable and disable the workers.dev subdomain (3.2s)
+✓ test/Cloudflare/Workers/Rpc.test.ts > detects valid envelope (1ms)
+✗ test/Cloudflare/Workers/Route.test.ts > replaces the route when the zone changes (12.4s)
+  AssertionError: expected "alchemy-test-2.us/api/*" to be "alchemy-test-2.us/v2/*"
+      at test/Cloudflare/Workers/Route.test.ts:87:22
+  --- captured output ---
+  Plan: 1 to replace
+  [route] deleting
+  [route] created
+  --- end output ---
+✓ test/Cloudflare/Workers/Workflow.test.ts > runs a workflow to completion (51.9s)
+```
+
+A failing test prints its error and its captured output inline,
+immediately, while the run continues. Passing tests stay silent —
+their output would be noise.
+
+If nothing finishes for ten seconds, the runner prints what's
+still running, so a hang is diagnosable from the console instead
+of a mystery:
+
+```
+⧗ [16:38:12] no tests finished in the last 10s — 2 still running:
+    test/Cloudflare/Workers/Workflow.test.ts > runs a workflow to completion (48.1s)
+    test/Cloudflare/Workers/CronEventSource.test.ts > cron handler fires (32.7s)
+```
+
+And the run ends by telling the agent exactly how to go deeper:
+the summary, the failures repeated in one place, and a per-run
+log file — with its size, so the agent knows whether to read it
+or search it:
+
+```
+Tests: 1 failed | 171 passed | 1 skipped (31 files, 89.3s)
+
+Full log: .alchemy/log/test/2026-07-16T23-42-38-pid92186.log (1055 lines, 118 KB)
+```
+
+The log file has everything the console suppressed: every test's
+captured output, passes included, written color-free as the run
+progresses. Each run gets its own timestamped file, so concurrent
+runs in different terminals never trample each other. The console
+is the summary; the log is the record. The agent reads the one
+line it needs and greps the file when it needs more.
+
+## Humans get a TUI
+
+For interactive use, `--tui` opens a k9s-style live view: a
+collapsible file/test tree, type-to-filter, and retry/kill on
+running tests:
+
+```
+ alchemy-test  ✓ 159  ✗ 0  ◐ 7  · 5  │ 53.4s
+ ▸ ✓ test/Cloudflare/Workers/AccountSetting.test.ts  3/3 passed
+ ▾ ◐ test/Cloudflare/Workers/DurableObjectNamespace.test.ts  2 running · 11/13 passed
+     ✓ getByName round-trips state (1.9s)
+     ◐ websocket hibernation survives eviction (12.3s…)
+ ▸ ◐ test/Cloudflare/Workers/HttpApi.test.ts  5/5 passed  — afterAll running (18.6s)…
+ ▸ · test/Cloudflare/Workers/WaitUntil.test.ts  0/2 passed  — waiting for a worker slot…
+ ▸ ✓ test/Cloudflare/Workers/Worker.test.ts  17/17 passed
+```
+
+Pressing `enter` on a running test live-tails its captured
+output — useful when a deploy is three minutes into `beforeAll`
+and you want to know what it's doing.
+
+The hotkeys are vim-flavored: `j`/`k` and `ctrl-d`/`ctrl-u` to
+move, `/` for live type-to-filter, `p`/`f`/`n`/`s` to toggle
+passing, failing, pending, and skipped tests in and out of view.
+`r` retries the selected test or file, `R` retries everything
+that failed, `x` kills a running test, and `y` copies a failure's
+error and captured output to the clipboard — handy for pasting
+straight into an agent chat.
+
+## Owning the runner
+
+The whole thing was easy to build — a test harness, a scheduler,
+and two reporters over an event stream, in a codebase that
+already runs everything on Effect. That's the part worth
+underlining: it was cheap to make *because* we only target
+Effect, and owning it means the feedback loop is ours to tune.
+When we notice agents misreading output, we change the output.
+No plugin API in between.
+
+## Where to go next
+
+- [alchemy-test on GitHub](https://github.com/alchemy-run/alchemy/tree/main/packages/alchemy-test)
+- [The PR](https://github.com/alchemy-run/alchemy/pull/848)
+- [Looping the Generation of IaC and SDKs](/blog/2026-07-02-cloudflare-resource-factory) — the agent fleet this runner feeds

--- a/website/src/content/docs/blog/2026-07-22-beta-63.md
+++ b/website/src/content/docs/blog/2026-07-22-beta-63.md
@@ -1,0 +1,546 @@
+---
+title: 2.0.0-beta.63 - Full AWS Coverage
+date: 2026-07-22T06:00:00Z
+category: release
+excerpt: v2.0.0-beta.63 is the AWS release — generated coverage of (nearly) every AWS service, unified container platforms on ECS and EKS, Durable Lambda Functions, and Helm charts on EKS. Plus Python Workers, Drizzle for D1, GitHub Enterprise, and a new Effect-native test runner.
+---
+
+beta.63 is the AWS release. Alchemy now covers **206 AWS
+services**, with every resource and binding live-tested against
+the real cloud. It also adds first-class **containers on ECS and
+EKS**, **Durable Lambda Functions**, and **Helm charts** on EKS.
+
+:::caution
+**Breaking changes**
+
+- **Container props are restructured**
+  ([#867](https://github.com/alchemy-run/alchemy/pull/867)):
+  `docker: { base }` → `image`, `AWS.EKS.ServerHost` →
+  `AWS.EKS.Deployment`, `alchemy/Kubernetes` is removed in favor
+  of `AWS.EKS.Manifest`, and one-shot ECS Task impls return
+  `{ run }` instead of `{ fetch }`.
+- **AWS prop data types are richer**
+  ([#797](https://github.com/alchemy-run/alchemy/pull/797)):
+  duration props take `Duration.Input` (`"1 hour"`,
+  `Duration.hours(1)`), and sensitive props (passwords, secrets,
+  keys) are `Redacted.Redacted<string>`.
+:::
+
+## "100%" AWS coverage
+
+One PR ([#797](https://github.com/alchemy-run/alchemy/pull/797))
+took the AWS provider from a handful of services to all of them,
+using the same [resource
+factory](/blog/2026-07-02-cloudflare-resource-factory) that built
+out the Cloudflare provider. Fleets of agents cataloged all 428
+generated SDK modules, then implemented and live-tested them in
+waves: serverless first, then ECS/Fargate, EKS, EC2, and the long
+tail. Everything left over is documented as out of scope
+(deprecated APIs, data-only endpoints, billing objects). The
+result:
+
+- **206 AWS services** with **683 resources** and **2,842
+  bindings** (plus event sources and sinks), from DynamoDB and S3
+  all the way out to MediaLive, IoT SiteWise, Bedrock, and
+  SageMaker.
+- **2,692 live tests green by default** against real AWS. 375
+  more are gated behind env vars because they are slow to
+  provision, expensive, or need special account entitlements.
+- **Zero-orphan guarantee**: each round wiped the test account
+  clean, ran the full suite, then audited the account for
+  leftover resources. The loop ran until two consecutive rounds
+  left nothing behind. A passing test that leaks a cloud resource
+  is a provider bug, and the loop caught dozens of them.
+
+Bindings are 1:1 with IAM actions. Each binding your code uses
+becomes a least-privilege policy statement on exactly the
+resources it touches, whether the code runs on Lambda, ECS, or
+EKS:
+
+```typescript
+const api = yield* AWS.ECS.Service(
+  "Api",
+  { cluster, main: import.meta.url, port: 3000, desiredCount: 2 },
+  Effect.gen(function* () {
+    // init: each binding grants one IAM action on one ARN
+    const getItem = yield* AWS.DynamoDB.GetItem(table);
+    const send = yield* AWS.SQS.SendMessage(queue);
+
+    return {
+      fetch: Effect.gen(function* () {
+        const item = yield* getItem({ Key: { pk: { S: "user#1" } } });
+        yield* send({ MessageBody: JSON.stringify(item.Item) });
+        return yield* HttpServerResponse.json({ ok: true });
+      }),
+    };
+  }).pipe(
+    Effect.provide([AWS.DynamoDB.GetItemHttp, AWS.SQS.SendMessageHttp]),
+  ),
+);
+```
+
+You never write an IAM policy, and every error is typed — the
+compiler tells you what can fail and you handle it like any other
+Effect error. See [Bindings](/infrastructure-as-effects/binding)
+for how it works.
+
+All of it is documented in the [API reference](/providers), with
+usage examples on every resource and binding.
+
+## ECS: Tasks and Services
+
+ECS gets the full platform treatment
+([#867](https://github.com/alchemy-run/alchemy/pull/867)):
+[`Task`](/providers/aws/ecs/task) for run-to-completion work and
+[`Service`](/providers/aws/ecs/service) for long-running servers.
+Both are authored the same three ways as Workers and Lambda: an
+external image, an inline effect, or a tagged class.
+
+Every container platform takes one image source, flat on props:
+
+```typescript
+{ main }                                   // bundle this Effect program
+{ main, image }                            // bundle FROM your base image
+{ context, dockerfile? }                   // build your own Dockerfile
+{ dockerfile: Dockerfile.inline`...` }     // inline Dockerfile content
+{ image }                                  // registry ref, mirrored into ECR
+```
+
+The simplest `Service` runs a registry image behind a provisioned
+Application Load Balancer:
+
+```typescript
+const cluster = yield* AWS.ECS.Cluster("AppCluster", {});
+
+const nginx = yield* AWS.ECS.Service("Edge", {
+  cluster,
+  image: "public.ecr.aws/nginx/nginx:1.27",
+  port: 80,
+  desiredCount: 2,
+  loadBalancer: true,
+});
+
+return { url: nginx.url }; // http://<alb-dns-name>
+```
+
+A `Service` can also run an Effect program. The impl returns
+`{ fetch }`, and bindings grant IAM to the task role:
+
+```typescript
+const api = yield* AWS.ECS.Service(
+  "Api",
+  { cluster, main: import.meta.url, port: 3000, desiredCount: 2 },
+  Effect.gen(function* () {
+    const putItem = yield* AWS.DynamoDB.PutItem(table);
+    return {
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        const order = (yield* request.json) as { orderId: string };
+        yield* putItem({ Item: { pk: { S: order.orderId } } });
+        return yield* HttpServerResponse.json({ ok: true });
+      }),
+    };
+  }).pipe(Effect.provide(AWS.DynamoDB.PutItemHttp)),
+);
+```
+
+A one-shot `Task` is the run-to-completion counterpart: the impl
+returns `{ run }`, and the container exits when the effect
+completes. Here it composes `main` with `Dockerfile.inline` — the
+inline content builds the environment, and the bundled program is
+layered on top:
+
+```typescript
+import { Dockerfile } from "alchemy/Docker";
+
+const thumbnailer = yield* AWS.ECS.Task(
+  "Thumbnailer",
+  {
+    main: import.meta.url,
+    dockerfile: Dockerfile.inline`
+      FROM oven/bun:1
+      RUN apt-get update && apt-get install -y ffmpeg
+    `,
+    cpu: 1024,
+    memory: 2048,
+  },
+  Effect.gen(function* () {
+    const getObject = yield* AWS.S3.GetObject(bucket);
+    return {
+      run: Effect.gen(function* () {
+        // pull the video from S3, shell out to ffmpeg, then exit
+      }),
+    };
+  }).pipe(Effect.provide(AWS.S3.GetObjectHttp)),
+);
+```
+
+Tasks are launched from other compute with the
+[`RunTask`](/providers/aws/ecs/runtask) binding, which grants
+`ecs:RunTask` and `iam:PassRole` automatically — here a Lambda
+function launches a task per request:
+
+```typescript
+const api = yield* AWS.Lambda.Function(
+  "Api",
+  { main: import.meta.url, url: true },
+  Effect.gen(function* () {
+    const runTask = yield* AWS.ECS.RunTask(cluster, thumbnailer);
+
+    return {
+      fetch: Effect.gen(function* () {
+        const response = yield* runTask({
+          launchType: "FARGATE",
+          networkConfiguration: {
+            awsvpcConfiguration: { subnets: [subnetId] },
+          },
+        });
+        return yield* HttpServerResponse.json({
+          taskArn: response.tasks?.[0]?.taskArn,
+        });
+      }),
+    };
+  }),
+);
+```
+
+Or run a task on a schedule with `AWS.ECS.every`, which
+provisions the EventBridge rule and invoke role:
+
+```typescript
+yield* AWS.ECS.every("NightlyJob", "cron(0 3 * * ? *)", {
+  cluster,
+  task: nightlyTask,
+  subnets: [privateSubnet.subnetId],
+});
+```
+
+Services go well past `loadBalancer: true`: multiple services can
+share one load balancer, and props cover custom domains,
+auto-scaling on CPU or request count, Fargate Spot capacity, EFS
+volumes, secrets, and health checks. Docs:
+[ECS](/aws/compute/ecs).
+
+## EKS: Deployments, Jobs, Manifests, and Helm
+
+Kubernetes workloads live in the same TypeScript program as the
+cluster itself — no YAML, no `kubectl`. `compute: "auto"` stands
+up an EKS Auto Mode cluster where AWS manages the nodes:
+
+```typescript
+const network = yield* AWS.EC2.Network("Network", {
+  cidrBlock: "10.42.0.0/16",
+  availabilityZones: 2,
+  nat: "single",
+});
+
+const cluster = yield* AWS.EKS.Cluster("Cluster", {
+  compute: "auto",
+  resourcesVpcConfig: { subnetIds: network.privateSubnetIds },
+});
+
+const api = yield* AWS.EKS.Deployment(
+  "Api",
+  { cluster, main: import.meta.url, port: 3000, replicas: 2, serviceType: "LoadBalancer" },
+  Effect.gen(function* () {
+    const putItem = yield* AWS.DynamoDB.PutItem(table); // → pod-identity IAM
+    return { fetch: Effect.gen(function* () { /* ... */ }) };
+  }).pipe(Effect.provide(AWS.DynamoDB.PutItemHttp)),
+);
+```
+
+[`Deployment`](/providers/aws/eks/deployment) synthesizes a
+Kubernetes `Deployment`, `Service`, and `ServiceAccount`, with
+bindings landing as pod-identity IAM.
+
+[`Job`](/providers/aws/eks/job) is the run-to-completion
+counterpart — same image sources, and the impl returns `{ run }`:
+
+```typescript
+const seed = yield* AWS.EKS.Job(
+  "SeedData",
+  { cluster, main: import.meta.url },
+  Effect.gen(function* () {
+    const putItem = yield* AWS.DynamoDB.PutItem(table);
+    return {
+      run: Effect.gen(function* () {
+        // runs to completion, then the pod exits
+      }),
+    };
+  }).pipe(Effect.provide(AWS.DynamoDB.PutItemHttp)),
+);
+```
+
+Add `schedule` and a Job becomes a Kubernetes CronJob — here in
+the external form, running a pre-built image:
+
+```typescript
+const nightly = yield* AWS.EKS.Job("NightlyBackfill", {
+  cluster,
+  image: "ghcr.io/acme/backfill:v3",
+  schedule: "0 3 * * *",
+});
+```
+
+[`Manifest`](/providers/aws/eks/manifest) applies any raw
+Kubernetes object via server-side apply, CRDs included — the
+manifest is a literal object, exactly what you'd write in YAML.
+No kubeconfig required:
+
+```typescript
+const sts = yield* AWS.EKS.Manifest("Cache", {
+  cluster,
+  manifest: {
+    apiVersion: "apps/v1",
+    kind: "StatefulSet",
+    metadata: { name: "cache", namespace: "apps" },
+    spec: { replicas: 3 /* ... */ },
+  },
+});
+```
+
+[`HelmChart`](/providers/aws/eks/helmchart) installs Helm charts
+([#891](https://github.com/alchemy-run/alchemy/pull/891)). It
+renders the chart locally with `helm template` and applies the
+objects to the cluster, so Alchemy owns the lifecycle: drift is
+corrected on every deploy, dropped objects are pruned, and
+destroy deletes everything:
+
+```typescript
+const ingress = yield* AWS.EKS.HelmChart("IngressNginx", {
+  cluster,
+  chart: "ingress-nginx",
+  repo: "https://kubernetes.github.io/ingress-nginx",
+  version: "4.11.2",
+  namespace: "ingress-nginx",
+  createNamespace: true,
+  values: { controller: { replicaCount: 2 } },
+});
+```
+
+Docs: [EKS](/aws/compute/eks).
+
+## Durable Lambda Functions
+
+`AWS.Lambda.DurableFunction` writes long-running orchestrations
+as plain code, built on AWS Lambda's durable execution model
+([#797](https://github.com/alchemy-run/alchemy/pull/797)). It
+**is** a Lambda Function, with the same props and bindings, but
+its body is checkpointed. `Durable.step` records each result so
+it isn't re-run on replay. `Durable.sleep` suspends the execution
+entirely; Lambda re-invokes the function to resume it. And
+`Durable.waitForCallback` pauses on an external signal for up to
+a year:
+
+```typescript
+export class OrderFlow extends AWS.Lambda.DurableFunction<OrderFlow>()(
+  "OrderFlow",
+) {}
+
+export default OrderFlow.make(
+  { main: import.meta.url, executionTimeout: "1 hour" },
+  Effect.gen(function* () {
+    // init: resolve typed binding clients (IAM lands on this role)
+    const putItem = yield* AWS.DynamoDB.PutItem(table);
+
+    return Effect.fn(function* (input: { orderId: string }) {
+      const reserved = yield* AWS.Lambda.Durable.step(
+        "reserve",
+        putItem({ Item: { pk: { S: input.orderId } } }).pipe(Effect.orDie),
+        { retry: { limit: 3, delay: "5 seconds" } },
+      );
+      yield* AWS.Lambda.Durable.sleep("cooldown", "10 minutes");
+      return { orderId: input.orderId, reserved };
+    });
+  }).pipe(Effect.provide(AWS.DynamoDB.PutItemHttp)),
+);
+```
+
+Replay requires the body to be deterministic, and the type system
+enforces it: the run body has no access to cloud credentials, so
+the only way to do I/O is through a binding client resolved in
+init and called inside a `Durable.step`.
+
+`yield* OrderFlow` returns a typed handle to start, inspect, and
+stop executions, and to complete callbacks from the outside:
+
+```typescript
+const orders = yield* OrderFlow;
+const ref = yield* orders.start({
+  name: "order-123", // idempotent start
+  params: { orderId: "123" },
+});
+const execution = yield* orders.get(ref.executionArn!);
+// execution.Status: "RUNNING" | "SUCCEEDED" | "FAILED" | ...
+```
+
+The vocabulary mirrors Cloudflare
+[Workflows](/cloudflare/compute/workflows), so orchestration code
+reads the same on both clouds. Reference:
+[DurableFunction](/providers/aws/lambda/durablefunction).
+
+## Effect SQL and Drizzle for D1
+
+Drizzle now works end to end on Cloudflare D1
+([#887](https://github.com/alchemy-run/alchemy/pull/887)),
+mirroring the Neon and PlanetScale integrations. At deploy time,
+`Drizzle.Schema` diffs your schema module and writes pending
+migration SQL, and passing `schema.out` as the database's
+`migrationsDir` makes the database apply it — generate first,
+apply second, in one deploy:
+
+```typescript
+// src/db.ts
+export const Database = Effect.gen(function* () {
+  const schema = yield* Drizzle.Schema("app-schema", {
+    schema: "./src/schema.ts",
+    out: "./migrations",
+    dialect: "sqlite",
+  });
+
+  return yield* Cloudflare.D1.Database("app-db", {
+    migrationsDir: schema.out,
+  });
+});
+```
+
+At runtime, a Worker binds the database with
+`Cloudflare.D1.QueryDatabase` and hands the client to
+`Drizzle.D1`. Every query is an Effect with `SqlError` in the
+typed error channel:
+
+```typescript
+// src/api.ts
+export default class Api extends Cloudflare.Worker<Api>()(
+  "Api",
+  { main: import.meta.url },
+  Effect.gen(function* () {
+    const database = yield* Database;
+    const d1 = yield* Cloudflare.D1.QueryDatabase(database);
+    const db = yield* Drizzle.D1(d1, { relations });
+
+    return {
+      fetch: Effect.gen(function* () {
+        const users = yield* db.query.Users.findMany({
+          with: { posts: true },
+        });
+        return yield* HttpServerResponse.json({ users });
+      }),
+    };
+  }).pipe(Effect.provide(Cloudflare.D1.QueryDatabaseBinding)),
+) {}
+```
+
+The low-level effect-sql clients also get one home: the new
+`alchemy/SQL` namespace, with a raw tagged-template client for
+each Drizzle integration. It binds inside a Worker the same way:
+
+```typescript
+import * as SQL from "alchemy/SQL";
+
+Effect.gen(function* () {
+  const d1 = yield* Cloudflare.D1.QueryDatabase(database);
+  const sql = yield* SQL.D1(d1);
+
+  return {
+    fetch: Effect.gen(function* () {
+      const rows = yield* sql`SELECT id, name FROM users`;
+      return yield* HttpServerResponse.json({ rows });
+    }),
+  };
+}).pipe(Effect.provide(Cloudflare.D1.QueryDatabaseBinding));
+```
+
+All clients share the same lifecycle: nothing connects at plan or
+deploy time, the client is built lazily on the first query, and
+it's torn down when the request settles. The website's new
+[SQL hub](/sql) collects effect-sql, Drizzle, and migrations in
+one place
+([#903](https://github.com/alchemy-run/alchemy/pull/903)).
+
+## Also in this release
+
+- **Python Workers**
+  ([#861](https://github.com/alchemy-run/alchemy/pull/861)) —
+  point `main` at a `.py` file and `Cloudflare.Worker` deploys a
+  Python Worker, with dependencies vendored from `pyproject.toml`
+  via uv. Docs:
+  [Python Workers](/cloudflare/compute/python-workers).
+- **Workers AI binding**
+  ([#850](https://github.com/alchemy-run/alchemy/pull/850)) —
+  `Cloudflare.Workers.AI` runs models on Cloudflare's GPU fleet
+  from a Worker.
+- **Durable Objects pin to a region**
+  ([#851](https://github.com/alchemy-run/alchemy/pull/851)) with
+  `locationHint`, and DO classes **transfer between workers**
+  declaratively
+  ([#803](https://github.com/alchemy-run/alchemy/pull/803)).
+- **GitHub Enterprise + deployment environments**
+  ([#845](https://github.com/alchemy-run/alchemy/pull/845)) —
+  `alchemy login` accepts an enterprise host (GHES and data
+  residency), and the new `GitHub.Environment` resource manages
+  deployment environments.
+- **Effect-native test runner**
+  ([#848](https://github.com/alchemy-run/alchemy/pull/848)) —
+  the whole alchemy test suite now runs in a single bun process
+  on `alchemy-test`, with output designed for agents. Full story:
+  [A Test Runner Built for
+  Agents](/blog/2026-07-22-a-test-runner-for-agents). The live
+  suite converged to green: 4,458 passed
+  ([#916](https://github.com/alchemy-run/alchemy/pull/916)).
+- **RDS safety**: `MasterUserPassword` is fingerprint-guarded so
+  it's no longer re-sent on every reconcile
+  ([#876](https://github.com/alchemy-run/alchemy/pull/876)), and
+  `skipFinalSnapshot: false` takes a final snapshot on deliberate
+  teardown
+  ([#877](https://github.com/alchemy-run/alchemy/pull/877)).
+- **`AWS_REGION` overrides the SSO profile's stored region**
+  ([#895](https://github.com/alchemy-run/alchemy/pull/895)).
+- **Engine reliability** — destroy aggregates GC failures and
+  refuses to silently orphan zombie rows
+  ([#899](https://github.com/alchemy-run/alchemy/pull/899),
+  [#862](https://github.com/alchemy-run/alchemy/pull/862)),
+  `--force` refreshes stale bound attributes
+  ([#900](https://github.com/alchemy-run/alchemy/pull/900)),
+  binding diffs are stable across runs
+  ([#898](https://github.com/alchemy-run/alchemy/pull/898)),
+  unresolved Outputs are never persisted into state
+  ([#835](https://github.com/alchemy-run/alchemy/pull/835)), and
+  truncated physical names stay unique
+  ([#868](https://github.com/alchemy-run/alchemy/pull/868)).
+- **Actions get local bindings and Output accessors**
+  ([#807](https://github.com/alchemy-run/alchemy/pull/807)), and
+  `alchemy login` works without an `alchemy.run.ts`
+  ([#842](https://github.com/alchemy-run/alchemy/pull/842)).
+- **Migrating from v1** now adopts existing resources instead of
+  destroying and recreating them
+  ([#819](https://github.com/alchemy-run/alchemy/pull/819)) —
+  see [Migrating from v1](/migrating-from-v1).
+- **Cloudflare fixes**: queue-consumer wiring surviving mid-start
+  reconciles
+  ([#917](https://github.com/alchemy-run/alchemy/pull/917)),
+  asset-upload retries
+  ([#914](https://github.com/alchemy-run/alchemy/pull/914)),
+  wasm in `alchemy dev`
+  ([#881](https://github.com/alchemy-run/alchemy/pull/881)), and
+  Effect-valued env bindings converging in plans
+  ([#890](https://github.com/alchemy-run/alchemy/pull/890)).
+- **The website now lives at
+  [alchemy.run](https://alchemy.run)**
+  ([#806](https://github.com/alchemy-run/alchemy/pull/806)),
+  builds 8x faster on Astro 7
+  ([#873](https://github.com/alchemy-run/alchemy/pull/873)), and
+  the [Layers](/infrastructure-as-effects/layers),
+  [Bindings](/infrastructure-as-effects/binding), and
+  [Functions & Servers](/infrastructure-as-effects/functions-and-servers)
+  concept pages are rewritten.
+
+## Where to go next
+
+- [AWS](/aws) — the provider hub: setup, tutorial, and guides
+- [ECS](/aws/compute/ecs) and [EKS](/aws/compute/eks)
+- [Choosing a runtime](/aws/compute/choosing-a-runtime)
+- [SQL](/sql)
+- [Bindings](/infrastructure-as-effects/binding)
+- [CHANGELOG](https://github.com/alchemy-run/alchemy/blob/main/CHANGELOG.md#v200-beta63)
+- [Compare v2.0.0-beta.62 → v2.0.0-beta.63](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.62...v2.0.0-beta.63)


### PR DESCRIPTION
Two blog posts for the beta.63 release:

- `2026-07-22-beta-63.md` — release notes: AWS coverage (206 services, 683 resources, 2,842 bindings), ECS/EKS container platforms, Durable Lambda Functions, Effect SQL + Drizzle for D1, breaking changes, and the long tail.
- `2026-07-22-a-test-runner-for-agents.md` — announcement for `alchemy-test`: why vitest and bun test didn't fit a 4,000+ live-test suite, the single-process concurrent design, agent-oriented plain output, and the interactive TUI.

Both posts are marked `draft: true`.
