### PR TITLE
docs(blog): rename beta.63 release post to beta.64

### DIFF
--- a/website/src/content/docs/blog/2026-07-22-a-test-runner-for-agents.md
+++ b/website/src/content/docs/blog/2026-07-22-a-test-runner-for-agents.md
@@ -1,7 +1,6 @@
 ---
 title: A Test Runner for Agents
 date: 2026-07-22T07:00:00Z
-draft: true
 excerpt: Alchemy's test suite is 4,000+ live tests against real clouds, and some take minutes. Vitest forked processes and reloaded our generated SDK on every fork; bun test assumes tests are fast and runs them one file at a time. So we wrote our own runner — one bun process, everything concurrent, plain output tuned for agents and a live TUI for humans.
 ---
 

--- a/website/src/content/docs/blog/2026-07-22-beta-64.md
+++ b/website/src/content/docs/blog/2026-07-22-beta-64.md
@@ -1,11 +1,11 @@
 ---
-title: 2.0.0-beta.63 - Full AWS Coverage
+title: 2.0.0-beta.64 - Full AWS Coverage
 date: 2026-07-22T06:00:00Z
 category: release
-excerpt: v2.0.0-beta.63 is the AWS release — generated coverage of (nearly) every AWS service, unified container platforms on ECS and EKS, Durable Lambda Functions, and Helm charts on EKS. Plus Python Workers, Drizzle for D1, GitHub Enterprise, and a new Effect-native test runner.
+excerpt: v2.0.0-beta.64 is the AWS release — generated coverage of (nearly) every AWS service, unified container platforms on ECS and EKS, Durable Lambda Functions, and Helm charts on EKS. Plus Python Workers, Drizzle for D1, GitHub Enterprise, and a new Effect-native test runner.
 ---
 
-beta.63 is the AWS release. Alchemy now covers **206 AWS
+beta.64 is the AWS release. Alchemy now covers **206 AWS
 services**, with every resource and binding live-tested against
 the real cloud. It also adds first-class **containers on ECS and
 EKS**, **Durable Lambda Functions**, and **Helm charts** on EKS.
@@ -542,5 +542,5 @@ one place
 - [Choosing a runtime](/aws/compute/choosing-a-runtime)
 - [SQL](/sql)
 - [Bindings](/infrastructure-as-effects/binding)
-- [CHANGELOG](https://github.com/alchemy-run/alchemy/blob/main/CHANGELOG.md#v200-beta63)
-- [Compare v2.0.0-beta.62 → v2.0.0-beta.63](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.62...v2.0.0-beta.63)
+- [CHANGELOG](https://github.com/alchemy-run/alchemy/blob/main/CHANGELOG.md#v200-beta64)
+- [Compare v2.0.0-beta.63 → v2.0.0-beta.64](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.63...v2.0.0-beta.64)


### PR DESCRIPTION
The release shipped as `2.0.0-beta.64` (beta.63 was already taken by the Jul 17 release), so the release blog post is renamed to match: file, title, excerpt, intro, and the CHANGELOG/compare links now all say beta.64.
