### PR TITLE
docs(aws): add EKS to runtime lists across the docs

### DIFF
--- a/website/scripts/generate-llms-txt.ts
+++ b/website/scripts/generate-llms-txt.ts
@@ -233,7 +233,7 @@ const SECTIONS: Section[] = [
   {
     heading: "AWS — start here",
     intro:
-      "The AWS hub: overview (runtimes + resources + recipes), setup (credentials, profiles, region), and the Lambda vs ECS vs EC2 decision page.",
+      "The AWS hub: overview (runtimes + resources + recipes), setup (credentials, profiles, region), and the Lambda vs ECS vs EKS vs EC2 decision page.",
     pages: {
       slugs: ["aws/index", "aws/setup", "aws/compute/choosing-a-runtime"],
     },

--- a/website/src/components/ProviderDirectory.astro
+++ b/website/src/components/ProviderDirectory.astro
@@ -54,7 +54,10 @@ const HUBS: Record<string, { href: string; blurb: string }> = {
     href: "/cloudflare",
     blurb: "Workers, Durable Objects, D1, R2, Queues, Hyperdrive",
   },
-  AWS: { href: "/aws", blurb: "Lambda, ECS, EC2, DynamoDB, S3, SQS, Kinesis" },
+  AWS: {
+    href: "/aws",
+    blurb: "Lambda, ECS, EKS, EC2, DynamoDB, S3, SQS, Kinesis",
+  },
   Planetscale: {
     href: "/planetscale",
     blurb: "Serverless MySQL & Postgres with branching workflows",

--- a/website/src/content/docs/aws/compute/choosing-a-runtime.mdx
+++ b/website/src/content/docs/aws/compute/choosing-a-runtime.mdx
@@ -1,27 +1,29 @@
 ---
 title: Choosing a runtime
-description: Lambda vs ECS vs EC2 for Alchemy apps — cold starts, cost shape, packaging, and how much of each Alchemy currently covers.
+description: Lambda vs ECS vs EKS vs EC2 for Alchemy apps — cold starts, cost shape, packaging, and how much of each Alchemy currently covers.
 ---
 
 Every Alchemy app on AWS needs somewhere for its code to run.
-Alchemy ships three runtimes, all driven by the same pattern —
+Alchemy ships four runtimes, all driven by the same pattern —
 bundle an Effect program, deploy it as a resource, bind building
 blocks to it:
 
 - **Lambda** — serverless functions. **Use this by default.**
 - **ECS** — long-running containers on Fargate.
+- **EKS** — containers as Kubernetes workloads on a managed
+  Auto Mode cluster.
 - **EC2** — virtual machines you fully control.
 
 ## At a glance
 
-|                  | Lambda                                     | ECS                                        | EC2                                      |
-| ---------------- | ------------------------------------------ | ------------------------------------------ | ---------------------------------------- |
-| Execution model  | Per-request, event-driven                  | Always-on containers                       | Always-on machine                        |
-| Cost shape       | Pay per invocation; scales to zero         | Pay per running task                       | Pay per running instance                 |
-| Startup          | Cold starts (ms–s), then warm              | Task launch (tens of seconds), then steady | Instance boot (minutes), then steady     |
-| Packaging        | Bundled zip (Rolldown)                     | Docker image, built + pushed for you       | Bundled program on an AMI you choose     |
-| Networking       | None required (Function URL)               | VPC required (awsvpc), optional ALB        | VPC required, you own every primitive    |
-| Alchemy coverage | Fully documented                           | Cluster/Service/Task resources             | Instance + full VPC primitives           |
+|                  | Lambda                                     | ECS                                        | EKS                                          | EC2                                      |
+| ---------------- | ------------------------------------------ | ------------------------------------------ | -------------------------------------------- | ---------------------------------------- |
+| Execution model  | Per-request, event-driven                  | Always-on containers                       | Kubernetes objects (Deployments, Jobs)       | Always-on machine                        |
+| Cost shape       | Pay per invocation; scales to zero         | Pay per running task                       | Control plane + Auto Mode nodes              | Pay per running instance                 |
+| Startup          | Cold starts (ms–s), then warm              | Task launch (tens of seconds), then steady | Cluster create (~10 min), Pods in seconds    | Instance boot (minutes), then steady     |
+| Packaging        | Bundled zip (Rolldown)                     | Docker image, built + pushed for you       | Docker image, built + pushed for you         | Bundled program on an AMI you choose     |
+| Networking       | None required (Function URL)               | VPC required (awsvpc), optional ALB        | VPC required, `LoadBalancer` Services        | VPC required, you own every primitive    |
+| Alchemy coverage | Fully documented                           | Cluster/Service/Task resources             | Cluster/Deployment/Job/Manifest/Helm         | Instance + full VPC primitives           |
 
 ## Lambda — the default
 
@@ -65,6 +67,35 @@ single call.
 
 → [ECS](/aws/compute/ecs)
 
+## EKS — when your platform is Kubernetes
+
+When the workload is container-shaped but you want Kubernetes
+itself — Helm charts, operators, raw manifests, or teams already
+speaking Deployments and Jobs — Alchemy targets **EKS Auto Mode**,
+where AWS manages the control plane, nodes, storage, and
+load-balancer integration. Alchemy models it with:
+
+- [`Cluster`](/providers/aws/eks/cluster) — the control plane;
+  `compute: "auto"` turns on Auto Mode with sensible defaults.
+- [`Deployment`](/providers/aws/eks/deployment) — a replicated
+  Kubernetes server (the Kubernetes analog of `AWS.ECS.Service`)
+  with the same three image sources as ECS: a registry `image`, a
+  Dockerfile `context`, or an inline Effect program via `main`.
+- [`Job`](/providers/aws/eks/job) — run-to-completion work, or a
+  `CronJob` when you set `schedule`.
+- [`Manifest`](/providers/aws/eks/manifest) and
+  [`HelmChart`](/providers/aws/eks/helmchart) — any raw Kubernetes
+  object or a rendered Helm chart, applied via server-side apply.
+
+Bindings work the same as on Lambda and ECS — env vars plus IAM
+policy statements, delivered through an EKS Pod Identity role —
+and there is no YAML and no `kubectl` step. You pay for the
+control plane and the nodes Auto Mode provisions, you bring a VPC
+(the [`Network`](/providers/aws/ec2/network) helper builds one),
+and the control plane takes ~10 minutes to create.
+
+→ [EKS](/aws/compute/eks)
+
 ## EC2 — when you need the machine
 
 Full-control VMs for workloads that need an OS, a GPU, custom
@@ -89,7 +120,10 @@ You own patching, scaling, and availability.
    whole documented binding/event-source surface.
 2. Move a workload to **ECS** when it's long-running, needs more
    than 15 minutes, or is already a container.
-3. Reach for **EC2** when you need the machine itself — kernel
+3. Pick **EKS** over ECS when you want Kubernetes itself —
+   Helm charts, operators, raw manifests — not just a container
+   runner.
+4. Reach for **EC2** when you need the machine itself — kernel
    access, GPUs, custom networking, or software that expects a
    host.
 
@@ -98,4 +132,4 @@ You own patching, scaling, and availability.
 - [Lambda](/aws/compute/lambda) — deploy a function with a public URL.
 - [AWS overview](/aws) — resources and recipes.
 - [Providers reference](/providers) — generated docs for every
-  ECS and EC2 resource.
+  ECS, EKS, and EC2 resource.

--- a/website/src/content/docs/aws/compute/ec2.mdx
+++ b/website/src/content/docs/aws/compute/ec2.mdx
@@ -11,8 +11,9 @@ roles — a **low-level compute primitive** (launch an AMI, attach
 networking, done), or a **host for a bundled Effect program**
 that Alchemy deploys onto the machine and keeps running.
 
-This is the lowest-level of Alchemy's three runtimes: unlike
-[Lambda](/aws/compute/lambda) and [ECS](/aws/compute/ecs), you own patching,
+This is the lowest-level of Alchemy's four runtimes: unlike
+[Lambda](/aws/compute/lambda), [ECS](/aws/compute/ecs), and
+[EKS](/aws/compute/eks), you own patching,
 scaling, and availability. Reach for it deliberately — see
 [Choosing a runtime](/aws/compute/choosing-a-runtime).
 
@@ -171,7 +172,8 @@ through the whole set.
 ## Where next
 
 - [Choosing a runtime](/aws/compute/choosing-a-runtime) — Lambda first,
-  ECS for containers, EC2 when you need the machine.
+  ECS for containers, EKS for Kubernetes, EC2 when you need the
+  machine.
 - [VPC & networking](/aws/networking) — the `Network` helper and
   the VPC primitives an instance lives in.
 - [`Instance` reference](/providers/aws/ec2/instance),

--- a/website/src/content/docs/aws/compute/ecs.mdx
+++ b/website/src/content/docs/aws/compute/ecs.mdx
@@ -304,8 +304,8 @@ function that fans work out to containers.
 
 ## Where next
 
-- [Choosing a runtime](/aws/compute/choosing-a-runtime) — when Lambda or
-  EC2 fits better than ECS.
+- [Choosing a runtime](/aws/compute/choosing-a-runtime) — when Lambda,
+  EKS, or EC2 fits better than ECS.
 - [VPC & networking](/aws/networking) — what the `Network`
   helper creates, and the primitives underneath it.
 - [EKS](/aws/compute/eks) — the same platform model on managed

--- a/website/src/content/docs/aws/compute/lambda.mdx
+++ b/website/src/content/docs/aws/compute/lambda.mdx
@@ -329,7 +329,7 @@ for the model across all runtimes.
 - [REST API (API Gateway v1)](/aws/apis/api-gateway) — put an
   API Gateway REST API with stages and custom domains in front
   instead of a Function URL.
-- [Choosing a runtime](/aws/compute/choosing-a-runtime) — when ECS or
-  EC2 fits better than Lambda.
+- [Choosing a runtime](/aws/compute/choosing-a-runtime) — when ECS,
+  EKS, or EC2 fits better than Lambda.
 - [`Function` reference](/providers/aws/lambda/function) — every
   prop and attribute.

--- a/website/src/content/docs/aws/index.mdx
+++ b/website/src/content/docs/aws/index.mdx
@@ -22,6 +22,9 @@ your first [Lambda](/aws/compute/lambda).
 - **[ECS](/aws/compute/ecs)** — long-running containers on Fargate.
   Alchemy bundles your Effect program into a Docker image and
   runs it as a Cluster + Service + Task.
+- **[EKS](/aws/compute/eks)** — managed Kubernetes (Auto Mode).
+  Deployments, Jobs, raw manifests, and Helm charts in the same
+  TypeScript program as the cluster — no YAML, no kubectl.
 - **[EC2](/aws/compute/ec2)** — full-control virtual machines, with the
   complete VPC networking toolkit around them.
 
@@ -68,8 +71,8 @@ Not sure which? See
   sites and built Vite apps on S3 + CloudFront as a single
   `StaticSite` resource.
 - **[VPC & networking](/aws/networking)** — the `Network` helper
-  and the VPC primitives, for when ECS or EC2 needs explicit
-  networking.
+  and the VPC primitives, for when ECS, EKS, or EC2 needs
+  explicit networking.
 
 ## What are you building?
 
@@ -86,6 +89,7 @@ Not sure which? See
 | Background jobs                       | [SQS](/aws/messaging/sqs) + Lambda                                                      |
 | Scheduled jobs                        | [EventBridge Scheduler](/aws/messaging/eventbridge) → Lambda                            |
 | A Postgres database                   | [RDS & Aurora](/aws/data/rds)                                                      |
+| Kubernetes workloads or Helm charts   | [EKS](/aws/compute/eks)                                                            |
 | Object processing                     | [S3 events](/aws/messaging/s3-events)                                            |
 | Change data capture                   | [DynamoDB Streams](/aws/messaging/dynamodb-streams)                              |
 | API keys or credentials for a function | [Secrets & env](/aws/security/secrets-env)                                            |

--- a/website/src/content/docs/aws/networking/index.mdx
+++ b/website/src/content/docs/aws/networking/index.mdx
@@ -7,7 +7,8 @@ Most Alchemy apps on AWS never touch a VPC. Lambda functions
 serve public traffic from Function URLs, and bindings wire
 access to tables, buckets, and queues without a single subnet.
 Networking becomes your problem when you run an
-[ECS Service](/aws/compute/ecs) or an [EC2 Instance](/aws/compute/ec2) — both
+[ECS Service](/aws/compute/ecs), an [EKS Cluster](/aws/compute/eks), or an
+[EC2 Instance](/aws/compute/ec2) — all
 need a VPC, subnets, and security groups — or when you attach to
 anything that lives inside one.
 

--- a/website/src/content/docs/aws/tutorial/part-5.mdx
+++ b/website/src/content/docs/aws/tutorial/part-5.mdx
@@ -431,8 +431,8 @@ You've completed the tutorial. You now know how to:
   [DynamoDB Streams](/aws/messaging/dynamodb-streams)
 - Put an [API Gateway REST API](/aws/apis/api-gateway) with
   stages and custom domains in front of your function
-- Read [Choosing a runtime](/aws/compute/choosing-a-runtime) for when ECS
-  or EC2 fits better than Lambda
+- Read [Choosing a runtime](/aws/compute/choosing-a-runtime) for when ECS,
+  EKS, or EC2 fits better than Lambda
 - Explore the [CI guide](/environments/ci) for more workflow patterns,
   including the Cloudflare equivalents
 - Check out the [Testing a Stack](/testing/testing-a-stack) guide for

--- a/website/src/content/docs/infrastructure-as-effects/functions-and-servers.mdx
+++ b/website/src/content/docs/infrastructure-as-effects/functions-and-servers.mdx
@@ -3,7 +3,8 @@ title: Functions & Servers
 description: Workers, Lambda Functions, and Containers ship runtime code along with their infrastructure — declared with the Effectful Constructor pattern, bind what you need, return what you expose.
 ---
 
-Cloudflare Workers, AWS Lambda Functions, ECS Tasks, and Containers
+Cloudflare Workers, AWS Lambda Functions, ECS Tasks, EKS
+Deployments, and Containers
 are [Resources](/infrastructure-as-code/resource) that ship **runtime code along
 with their infrastructure**. When you declare one you describe both:
 

--- a/website/src/pages/index.mdx
+++ b/website/src/pages/index.mdx
@@ -135,7 +135,7 @@ export const P99Alarm = AWS.CloudWatch.Alarm("p99Latency", {
     </a>
     <a class="alc-cloud-card" href="/aws">
       <span class="alc-cloud-card__title"><ProviderMark name="AWS" /> AWS</span>
-      <span class="alc-cloud-card__body">Lambda, ECS, EC2, DynamoDB, S3, SQS, Kinesis</span>
+      <span class="alc-cloud-card__body">Lambda, ECS, EKS, EC2, DynamoDB, S3, SQS, Kinesis</span>
       <span class="alc-cloud-card__cta">Start building &rarr;</span>
     </a>
   </div>


### PR DESCRIPTION
The EKS page shipped but every prose enumeration of AWS runtimes still said Lambda/ECS/EC2. This adds EKS everywhere the runtimes are listed:

- `/aws` hub — "Pick your runtime" bullet, VPC blurb, and a "Kubernetes workloads or Helm charts" recipe row
- `/aws/compute/choosing-a-runtime` — "three runtimes" → four, an EKS column in the at-a-glance table, a new "EKS — when your platform is Kubernetes" section, and a rule-of-thumb entry
- EC2 ("lowest-level of Alchemy's four runtimes"), Lambda, ECS, tutorial part-5, and `/aws/networking` cross-links
- Homepage AWS card + `ProviderDirectory.astro` blurbs and the llms.txt section intro

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1VHnmh9s2ie1bKhLJ325J)_