### PR TITLE
fix(cloudflare/workers): send _redirects/_headers contents to Cloudflare

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/Assets.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Assets.ts
@@ -110,6 +110,44 @@ const createIgnoreMatcher = (patterns: string[]) => {
   return (file: string) => matcher.ignores(file);
 };
 
+/**
+ * Read the special `_headers` / `_redirects` files from an assets
+ * directory. They are excluded from the upload manifest, but their raw
+ * contents must be sent to Cloudflare in the script metadata's asset
+ * config (`config._headers` / `config._redirects`) for the rules to
+ * apply.
+ */
+export const readAssetsConfigFiles = Effect.fn(function* (directory: string) {
+  const path = yield* Path.Path;
+  const resolvedDirectory = path.resolve(directory);
+  const [_headers, _redirects] = yield* Effect.all([
+    maybeReadString(path.join(resolvedDirectory, "_headers")),
+    maybeReadString(path.join(resolvedDirectory, "_redirects")),
+  ]);
+  return { _headers, _redirects };
+});
+
+/**
+ * Merge `_headers` / `_redirects` file contents into an asset config,
+ * producing the config to send in the script-upload metadata. Explicit
+ * `headers` / `redirects` props win over the files.
+ */
+export const mergeAssetsConfigFiles = (
+  config: AssetsConfig | undefined,
+  files: { _headers: string | undefined; _redirects: string | undefined },
+): AssetsConfig | undefined => {
+  const headers = config?.headers ?? files._headers;
+  const redirects = config?.redirects ?? files._redirects;
+  if (headers === undefined && redirects === undefined) {
+    return config;
+  }
+  return {
+    ...config,
+    ...(headers !== undefined ? { headers } : undefined),
+    ...(redirects !== undefined ? { redirects } : undefined),
+  };
+};
+
 export const readAssets = Effect.fn(function* ({
   directory,
   ...config
@@ -193,7 +231,11 @@ export const readAssets = Effect.fn(function* ({
   });
   return {
     directory,
-    config,
+    // Fold the `_headers` / `_redirects` file contents into the config
+    // that gets sent to Cloudflare (`metadata.assets.config`). Merged
+    // *after* hashing so the hash input shape stays stable for
+    // already-deployed workers.
+    config: mergeAssetsConfigFiles(config, { _headers, _redirects }),
     manifest: sortedManifest,
     _headers,
     _redirects,

--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -65,6 +65,7 @@ import { sha256, unwrapRedacted } from "../../Util/index.ts";
 import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
 import { LOCAL_ENTRY_URL, LocalRuntimeState } from "../LocalRuntime.ts";
 import type { WorkerAssetsConfig, WorkerProps } from "../Workers/Worker.ts";
+import { readAssetsConfigFiles } from "./Assets.ts";
 import { getCompatibility } from "./Compatibility.ts";
 import { isPythonMain, watchPythonWorkerBundle } from "./PythonWorkerBundle.ts";
 import { Worker } from "./Worker.ts";
@@ -295,7 +296,7 @@ export const LocalWorkerProvider = () =>
                   durableObjectNamespaces: worker.durableObjectNamespaces,
                   queueConsumers,
                   modules: yield* toRuntimeModules(bundle),
-                  assets: toRuntimeAssets(worker.assets),
+                  assets: yield* toRuntimeAssets(worker.assets),
                 })
                 .pipe(Scope.provide(scope));
               workerdScopes.set(worker.id, scope);
@@ -588,7 +589,7 @@ export const LocalWorkerProvider = () =>
               durableObjectNamespaces: worker.durableObjectNamespaces,
               hyperdrives: worker.hyperdrives,
               queueConsumers: yield* getQueueConsumers(worker.name),
-              assets: toRuntimeAssets(worker.assets),
+              assets: yield* toRuntimeAssets(worker.assets),
             },
             context,
           },
@@ -949,19 +950,34 @@ const structuralSignature = (value: unknown): Effect.Effect<string> => {
   return sha256(JSON.stringify(normalize(value)));
 };
 
-const toRuntimeAssets = (
+const toRuntimeAssets = Effect.fn(function* (
   assets: WorkerAssetsConfig | undefined,
-): RuntimeAssets | undefined => {
+) {
   if (!assets) return undefined;
+  // Mirror the deploy path: the special `_headers` / `_redirects` files
+  // in the assets directory carry the rules unless overridden by
+  // explicit `headers` / `redirects` props. The local runtime parses
+  // the raw string contents just like Cloudflare does.
+  const directory = typeof assets === "string" ? assets : assets.directory;
+  // An unreadable file just means no rules here — the assets plugin
+  // reports directory problems itself.
+  const files = yield* readAssetsConfigFiles(directory).pipe(
+    Effect.orElseSucceed(() => ({
+      _headers: undefined,
+      _redirects: undefined,
+    })),
+  );
   if (typeof assets === "string") {
     return {
       directory: assets,
+      headers: files._headers,
+      redirects: files._redirects,
     };
   }
   return {
     directory: assets.directory,
-    headers: assets.headers,
-    redirects: assets.redirects,
+    headers: assets.headers ?? files._headers,
+    redirects: assets.redirects ?? files._redirects,
     // Distilled widened generated string enums to open unions (`string & {}`);
     // the API only ever returns the known variants here.
     htmlHandling: assets.htmlHandling as
@@ -978,7 +994,7 @@ const toRuntimeAssets = (
     runWorkerFirst: assets.runWorkerFirst,
     serveDirectly: assets.serveDirectly,
   };
-};
+});
 
 const moduleTypeFromExtension = (ext: string): Module["type"] | "SourceMap" => {
   switch (ext) {

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -23,7 +23,12 @@ import { sha256Object } from "../../Util/sha256.ts";
 import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
 import { CloudflareLogs } from "../Logs.ts";
 import { listAllZones, resolveZoneId } from "../Zone/lookup.ts";
-import { readAssets, uploadAssets } from "./Assets.ts";
+import {
+  mergeAssetsConfigFiles,
+  readAssets,
+  readAssetsConfigFiles,
+  uploadAssets,
+} from "./Assets.ts";
 import { getCompatibility } from "./Compatibility.ts";
 import { isDurableObjectExport } from "./DurableObject.ts";
 import { LocalWorkerProvider } from "./LocalWorkerProvider.ts";
@@ -1360,8 +1365,8 @@ export const LiveWorkerProvider = () =>
         output: Worker["Attributes"] | undefined,
       ) => {
         if (!Predicate.hasProperty(assets, "hash")) return undefined;
-        const { directory: _, hash, ...config } = assets;
-        return { config, hash, skip: hash === output?.hash?.assets };
+        const { directory, hash, ...config } = assets;
+        return { directory, config, hash, skip: hash === output?.hash?.assets };
       };
 
       const putWorker = Effect.fn(function* (
@@ -1445,7 +1450,16 @@ export const LiveWorkerProvider = () =>
             `Cloudflare Worker update: assets unchanged for ${name}, keeping existing`,
           );
           keepAssets = true;
-          metadataAssets = { config: prebuiltAssets.config };
+          // `keepAssets` only preserves the uploaded files — the PUT
+          // replaces the asset config wholesale. The skip path never
+          // walked the directory, so read just `_headers`/`_redirects`
+          // here or a no-op deploy would wipe their rules.
+          metadataAssets = {
+            config: mergeAssetsConfigFiles(
+              prebuiltAssets.config,
+              yield* readAssetsConfigFiles(prebuiltAssets.directory),
+            ),
+          };
           metadataBindings.push({
             type: "assets",
             name: "ASSETS",

--- a/packages/alchemy/test/Cloudflare/Utils/Http.ts
+++ b/packages/alchemy/test/Cloudflare/Utils/Http.ts
@@ -147,6 +147,141 @@ export const expectUrlContains = (
   );
 };
 
+export class HttpResponseMismatch extends Data.TaggedError(
+  "HttpResponseMismatch",
+)<{
+  url: string;
+  expected: string;
+  actual: string;
+}> {}
+
+const fetchOnceResponse = (
+  url: string,
+  check: (res: Response) => HttpResponseMismatch | undefined,
+) =>
+  Effect.tryPromise({
+    try: async (signal) => {
+      const u = new URL(url);
+      u.searchParams.set("__alchemy_cb", String(Date.now()));
+      const res = await fetch(u, {
+        signal,
+        cache: "no-store",
+        redirect: "manual",
+        headers: {
+          "cache-control": "no-cache",
+          pragma: "no-cache",
+          accept: "*/*",
+        },
+      });
+      const mismatch = check(res);
+      if (mismatch) {
+        throw mismatch;
+      }
+      return res;
+    },
+    catch: (e) =>
+      e instanceof HttpResponseMismatch
+        ? e
+        : new HttpFetchFailed({
+            url,
+            message: e instanceof Error ? e.message : String(e),
+          }),
+  });
+
+const retryResponse = (
+  url: string,
+  expected: string,
+  effect: Effect.Effect<Response, HttpResponseMismatch | HttpFetchFailed>,
+  options: ExpectUrlContainsOptions,
+) => {
+  const totalTimeout = Duration.fromInputUnsafe(
+    options.timeout ?? "90 seconds",
+  );
+  const initial = options.initialBackoff ?? "750 millis";
+  const label = options.label ?? "url";
+  return effect.pipe(
+    Effect.retry({
+      schedule: Schedule.min([
+        Schedule.exponential(initial, 1.5),
+        Schedule.spaced("8 seconds"),
+      ]),
+    }),
+    Effect.timeoutOrElse({
+      duration: totalTimeout,
+      orElse: () =>
+        Effect.fail(
+          new HttpResponseMismatch({
+            url,
+            expected,
+            actual: `[timed out after ${Duration.toMillis(totalTimeout)}ms waiting for ${expected}]`,
+          }),
+        ),
+    }),
+    Effect.tapError((error) =>
+      Effect.logError(`expect response (${label}) failed`, error),
+    ),
+  );
+};
+
+/**
+ * Fetch `url` without following redirects and assert the response is a
+ * redirect to `location` (with `status`, default 301). Retries through
+ * deploy propagation like {@link expectUrlContains}.
+ */
+export const expectUrlRedirect = (
+  url: string,
+  location: string,
+  options: ExpectUrlContainsOptions & { status?: number } = {},
+) => {
+  const status = options.status ?? 301;
+  const expected = `${status} -> ${location}`;
+  return retryResponse(
+    url,
+    expected,
+    fetchOnceResponse(url, (res) => {
+      // Cloudflare appends the request's query string to the Location
+      // header, so compare pathnames rather than the raw value.
+      const actual = res.headers.get("location");
+      const actualPath = actual === null ? null : new URL(actual, url).pathname;
+      return res.status === status && actualPath === location
+        ? undefined
+        : new HttpResponseMismatch({
+            url,
+            expected,
+            actual: `${res.status} -> ${actual}`,
+          });
+    }),
+    options,
+  );
+};
+
+/**
+ * Fetch `url` and assert response header `header` equals `value`.
+ * Retries through deploy propagation like {@link expectUrlContains}.
+ */
+export const expectUrlHeader = (
+  url: string,
+  header: string,
+  value: string,
+  options: ExpectUrlContainsOptions = {},
+) => {
+  const expected = `${header}: ${value}`;
+  return retryResponse(
+    url,
+    expected,
+    fetchOnceResponse(url, (res) =>
+      res.headers.get(header) === value
+        ? undefined
+        : new HttpResponseMismatch({
+            url,
+            expected,
+            actual: `${res.status} ${header}: ${res.headers.get(header)}`,
+          }),
+    ),
+    options,
+  );
+};
+
 const fetchOnceAbsent = (url: string, marker: string) =>
   Effect.tryPromise({
     try: async (signal) => {

--- a/packages/alchemy/test/Cloudflare/Workers/AssetsConfigFiles.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/AssetsConfigFiles.test.ts
@@ -1,0 +1,122 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Test from "@/Test/Alchemy";
+import { describe } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as pathe from "pathe";
+import { cloneFixture } from "../Utils/Fixture.ts";
+import {
+  expectUrlAbsent,
+  expectUrlContains,
+  expectUrlHeader,
+  expectUrlRedirect,
+} from "../Utils/Http.ts";
+
+const { test } = Test.make({ providers: Cloudflare.providers() });
+
+const fixtureDir = pathe.resolve(import.meta.dirname, "fixtures/assets-config");
+
+const workerScript = (marker: string) => `
+export default {
+  fetch: async () => new Response(${JSON.stringify(marker)}),
+};
+`;
+
+// Regression test for https://github.com/alchemy-run/alchemy/issues/927:
+// `_redirects` / `_headers` were read from the assets directory and folded
+// into the change-detection hash, but their contents were never sent to
+// Cloudflare, so the rules silently never applied.
+describe.concurrent("Cloudflare.Worker assets config files", () => {
+  test.provider(
+    "redirects and headers apply, update, and survive keep-assets deploys",
+    (stack) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+
+        yield* stack.destroy();
+
+        const deploy = (
+          assets: string | { directory: string; hash: string },
+          marker: string,
+        ) =>
+          stack.deploy(
+            Effect.gen(function* () {
+              return yield* Cloudflare.Worker("AssetsConfigFiles", {
+                script: workerScript(marker),
+                assets,
+                subdomain: { enabled: true },
+                compatibility: {
+                  date: "2024-01-01",
+                },
+              });
+            }),
+          );
+
+        // 1. Fresh deploy: rules from the fixture's `_redirects` /
+        //    `_headers` must reach Cloudflare and apply.
+        const worker = yield* deploy(fixtureDir, "worker-v1");
+        const url = worker.url!;
+        yield* expectUrlContains(`${url}/`, "alchemy-assets-config-index");
+        yield* expectUrlRedirect(`${url}/old-path`, "/index.html", {
+          status: 301,
+          label: "initial redirect",
+        });
+        yield* expectUrlHeader(
+          `${url}/`,
+          "x-alchemy-test",
+          "assets-config-header",
+          { label: "initial header" },
+        );
+        // The special files themselves stay excluded from serving.
+        yield* expectUrlAbsent(`${url}/_redirects`, "/old-path", {
+          timeout: "15 seconds",
+          label: "_redirects not served",
+        });
+
+        // 2. Update: editing only `_redirects` must deploy the new rules.
+        const dir = yield* cloneFixture(fixtureDir, {
+          prefix: "alchemy-assets-config-",
+        });
+        yield* fs.writeFileString(
+          path.join(dir, "_redirects"),
+          "/moved /index.html 302\n",
+        );
+        yield* deploy(dir, "worker-v2");
+        yield* expectUrlRedirect(`${url}/moved`, "/index.html", {
+          status: 302,
+          label: "updated redirect",
+        });
+        // The old rule is gone: `/old-path` now falls through to the
+        // user worker instead of redirecting.
+        yield* expectUrlContains(`${url}/old-path`, "worker-v2", {
+          label: "removed redirect falls through",
+        });
+
+        // 3. Precomputed-hash deploys: the first one uploads, the second
+        //    hits the keep-assets skip path (hash matches stored state)
+        //    which never walks the directory — it must still re-send the
+        //    `_redirects` / `_headers` contents or the PUT wipes them.
+        const prebuilt = { directory: dir, hash: "assets-config-files-test" };
+        yield* deploy(prebuilt, "worker-v3");
+        yield* expectUrlContains(`${url}/some-worker-route`, "worker-v3");
+        yield* deploy(prebuilt, "worker-v4");
+        // Once the new script serves, the skip-path deploy has landed.
+        yield* expectUrlContains(`${url}/some-worker-route`, "worker-v4");
+        yield* expectUrlRedirect(`${url}/moved`, "/index.html", {
+          status: 302,
+          label: "redirect after keep-assets deploy",
+        });
+        yield* expectUrlHeader(
+          `${url}/`,
+          "x-alchemy-test",
+          "assets-config-header",
+          { label: "header after keep-assets deploy" },
+        );
+
+        yield* stack.destroy();
+      }),
+    { timeout: 360_000 },
+  );
+});

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/assets-config/_headers
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/assets-config/_headers
@@ -1,0 +1,2 @@
+/*
+  X-Alchemy-Test: assets-config-header

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/assets-config/_redirects
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/assets-config/_redirects
@@ -1,0 +1,1 @@
+/old-path /index.html 301

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/assets-config/index.html
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/assets-config/index.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<html>
+  <body>
+    alchemy-assets-config-index
+  </body>
+</html>


### PR DESCRIPTION
Fixes #927.

`readAssets` read `_redirects` / `_headers` from the assets directory, excluded them from the upload manifest, and folded their contents into the change-detection hash — but never sent them to Cloudflare, so redirect/header rules were silently dropped (requests 404'd or fell through to the worker).

The distilled `PutScriptRequest.metadata.assets.config` type already carries `headers` / `redirects` (wire-encoded as `_headers` / `_redirects`), so no SDK change was needed — only the wiring:

- `readAssets` now folds the file contents into the returned `config`, mirroring wrangler's `metadata.assets.config._redirects` / `_headers`. Explicit `headers` / `redirects` props still win. The merge happens after hashing, so existing asset hashes are unchanged (no spurious redeploys).

```ts
// Assets.ts
return {
  directory,
  config: mergeAssetsConfigFiles(config, { _headers, _redirects }),
  ...
};
```

- The prebuilt-hash keep-assets path (`prebuiltAssets.skip`) never walks the directory, but the PUT replaces the asset config wholesale — it now re-reads just the two files so a no-op deploy doesn't wipe the rules:

```ts
metadataAssets = {
  config: mergeAssetsConfigFiles(
    prebuiltAssets.config,
    yield* readAssetsConfigFiles(prebuiltAssets.directory),
  ),
};
```

- Dev parity: `LocalWorkerProvider` reads the same files and passes their contents to the local runtime, which already parses `headers` / `redirects` strings.

Live test (`test/Cloudflare/Workers/AssetsConfigFiles.test.ts`) deploys a worker with a `_redirects` + `_headers` fixture and asserts over HTTP: the 301 applies, the header applies, `_redirects` itself isn't served, editing `_redirects` deploys the new rules, and the rules survive a keep-assets (hash-match skip) deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
