### PR TITLE
fix(cloudflare/workers): send _redirects/_headers contents in the script PUT asset config

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/Assets.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Assets.ts
@@ -4,8 +4,8 @@ import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
-import * as Schedule from "effect/Schedule";
 import type { PlatformError } from "effect/PlatformError";
+import * as Schedule from "effect/Schedule";
 import type { ScopedPlanStatusSession } from "../../Cli/Cli.ts";
 import { sha256, sha256Object } from "../../Util/index.ts";
 
@@ -35,6 +35,17 @@ export interface AssetReadResult {
 
 export interface AssetsProps extends AssetsConfig {
   directory: string;
+}
+
+/**
+ * The contents of the special `_headers` / `_redirects` files from an assets
+ * directory. They are excluded from the upload manifest (Cloudflare must not
+ * serve them) and instead travel as strings on `metadata.assets.config`
+ * (`headers` / `redirects`, encoded to `_headers` / `_redirects` on the wire).
+ */
+export interface SpecialAssetFiles {
+  _headers: string | undefined;
+  _redirects: string | undefined;
 }
 
 export type ValidationError =
@@ -108,6 +119,31 @@ const maybeReadString = Effect.fn(function* (file: string) {
 const createIgnoreMatcher = (patterns: string[]) => {
   const matcher = createIgnore().add(patterns);
   return (file: string) => matcher.ignores(file);
+};
+
+export const readSpecialAssetFiles = Effect.fn(function* (directory: string) {
+  const path = yield* Path.Path;
+  const resolvedDirectory = path.resolve(directory);
+  const [_headers, _redirects] = yield* Effect.all([
+    maybeReadString(path.join(resolvedDirectory, "_headers")),
+    maybeReadString(path.join(resolvedDirectory, "_redirects")),
+  ]);
+  return { _headers, _redirects };
+});
+
+export const withSpecialAssetFiles = (
+  config: AssetsConfig | undefined,
+  files: SpecialAssetFiles,
+): AssetsConfig | undefined => {
+  const headers = config?.headers ?? files._headers;
+  const redirects = config?.redirects ?? files._redirects;
+  return headers === undefined && redirects === undefined
+    ? config
+    : {
+        ...config,
+        ...(headers !== undefined && { headers }),
+        ...(redirects !== undefined && { redirects }),
+      };
 };
 
 export const readAssets = Effect.fn(function* ({

--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -64,6 +64,7 @@ import { Stack } from "../../Stack.ts";
 import { sha256, unwrapRedacted } from "../../Util/index.ts";
 import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
 import { LOCAL_ENTRY_URL, LocalRuntimeState } from "../LocalRuntime.ts";
+import { readSpecialAssetFiles } from "./Assets.ts";
 import type { WorkerAssetsConfig, WorkerProps } from "../Workers/Worker.ts";
 import { getCompatibility } from "./Compatibility.ts";
 import { isPythonMain, watchPythonWorkerBundle } from "./PythonWorkerBundle.ts";
@@ -295,7 +296,7 @@ export const LocalWorkerProvider = () =>
                   durableObjectNamespaces: worker.durableObjectNamespaces,
                   queueConsumers,
                   modules: yield* toRuntimeModules(bundle),
-                  assets: toRuntimeAssets(worker.assets),
+                  assets: yield* toRuntimeAssets(worker.assets),
                 })
                 .pipe(Scope.provide(scope));
               workerdScopes.set(worker.id, scope);
@@ -588,7 +589,7 @@ export const LocalWorkerProvider = () =>
               durableObjectNamespaces: worker.durableObjectNamespaces,
               hyperdrives: worker.hyperdrives,
               queueConsumers: yield* getQueueConsumers(worker.name),
-              assets: toRuntimeAssets(worker.assets),
+              assets: yield* toRuntimeAssets(worker.assets),
             },
             context,
           },
@@ -949,19 +950,26 @@ const structuralSignature = (value: unknown): Effect.Effect<string> => {
   return sha256(JSON.stringify(normalize(value)));
 };
 
-const toRuntimeAssets = (
+const toRuntimeAssets = Effect.fn(function* (
   assets: WorkerAssetsConfig | undefined,
-): RuntimeAssets | undefined => {
+) {
   if (!assets) return undefined;
+  const directory = typeof assets === "string" ? assets : assets.directory;
+  // Dev serves the same `_headers` / `_redirects` rules as the deployed
+  // edge; the runtime parses them from these strings. Missing files read
+  // as undefined; any other filesystem failure is a defect.
+  const files = yield* readSpecialAssetFiles(directory).pipe(Effect.orDie);
   if (typeof assets === "string") {
     return {
       directory: assets,
-    };
+      headers: files._headers,
+      redirects: files._redirects,
+    } satisfies RuntimeAssets;
   }
   return {
     directory: assets.directory,
-    headers: assets.headers,
-    redirects: assets.redirects,
+    headers: assets.headers ?? files._headers,
+    redirects: assets.redirects ?? files._redirects,
     // Distilled widened generated string enums to open unions (`string & {}`);
     // the API only ever returns the known variants here.
     htmlHandling: assets.htmlHandling as
@@ -977,8 +985,8 @@ const toRuntimeAssets = (
       | undefined,
     runWorkerFirst: assets.runWorkerFirst,
     serveDirectly: assets.serveDirectly,
-  };
-};
+  } satisfies RuntimeAssets;
+});
 
 const moduleTypeFromExtension = (ext: string): Module["type"] | "SourceMap" => {
   switch (ext) {

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -23,10 +23,16 @@ import { sha256Object } from "../../Util/sha256.ts";
 import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
 import { CloudflareLogs } from "../Logs.ts";
 import { listAllZones, resolveZoneId } from "../Zone/lookup.ts";
-import { readAssets, uploadAssets } from "./Assets.ts";
+import {
+  readAssets,
+  readSpecialAssetFiles,
+  uploadAssets,
+  withSpecialAssetFiles,
+} from "./Assets.ts";
 import { getCompatibility } from "./Compatibility.ts";
 import { isDurableObjectExport } from "./DurableObject.ts";
 import { LocalWorkerProvider } from "./LocalWorkerProvider.ts";
+import { isPythonMain, readPythonWorkerBundle } from "./PythonWorkerBundle.ts";
 import {
   Worker,
   type ViteOptions,
@@ -35,7 +41,6 @@ import {
 } from "./Worker.ts";
 import { getCacheBinding, getCronBindings } from "./WorkerAsyncBindings.ts";
 import type { WorkerBinding, WorkerSettingsBinding } from "./WorkerBinding.ts";
-import { isPythonMain, readPythonWorkerBundle } from "./PythonWorkerBundle.ts";
 import { readPrebuiltWorkerBundle, WorkerBundle } from "./WorkerBundle.ts";
 import { isWorkerLoader } from "./WorkerLoader.ts";
 import { createWorkerName } from "./WorkerName.ts";
@@ -1360,8 +1365,8 @@ export const LiveWorkerProvider = () =>
         output: Worker["Attributes"] | undefined,
       ) => {
         if (!Predicate.hasProperty(assets, "hash")) return undefined;
-        const { directory: _, hash, ...config } = assets;
-        return { config, hash, skip: hash === output?.hash?.assets };
+        const { directory, hash, ...config } = assets;
+        return { config, directory, hash, skip: hash === output?.hash?.assets };
       };
 
       const putWorker = Effect.fn(function* (
@@ -1445,7 +1450,12 @@ export const LiveWorkerProvider = () =>
             `Cloudflare Worker update: assets unchanged for ${name}, keeping existing`,
           );
           keepAssets = true;
-          metadataAssets = { config: prebuiltAssets.config };
+          metadataAssets = {
+            config: withSpecialAssetFiles(
+              prebuiltAssets.config,
+              yield* readSpecialAssetFiles(prebuiltAssets.directory),
+            ),
+          };
           metadataBindings.push({
             type: "assets",
             name: "ASSETS",
@@ -1463,7 +1473,9 @@ export const LiveWorkerProvider = () =>
               `Cloudflare Worker update: assets unchanged for ${name}, keeping existing`,
             );
             keepAssets = true;
-            metadataAssets = { config: assets.config };
+            metadataAssets = {
+              config: withSpecialAssetFiles(assets.config, assets),
+            };
           } else {
             yield* Effect.logInfo(
               `Cloudflare Worker ${olds ? "update" : "create"}: uploading assets for ${name}`,
@@ -1476,7 +1488,7 @@ export const LiveWorkerProvider = () =>
             );
             metadataAssets = {
               jwt,
-              config: assets.config,
+              config: withSpecialAssetFiles(assets.config, assets),
             };
           }
           metadataBindings.push({

--- a/packages/alchemy/test/Cloudflare/Utils/Http.ts
+++ b/packages/alchemy/test/Cloudflare/Utils/Http.ts
@@ -39,6 +39,15 @@ export class HttpMarkerPresent extends Data.TaggedError("HttpMarkerPresent")<{
   bodyExcerpt: string;
 }> {}
 
+export class HttpHeadAssertionFailed extends Data.TaggedError(
+  "HttpHeadAssertionFailed",
+)<{
+  url: string;
+  expected: string;
+  status: number;
+  headers: string;
+}> {}
+
 export interface ExpectUrlContainsOptions {
   /** Maximum total time to retry before failing. Default 90s. */
   timeout?: Duration.Input;
@@ -179,6 +188,96 @@ const fetchOnceAbsent = (url: string, marker: string) =>
             message: e instanceof Error ? e.message : String(e),
           }),
   });
+
+export interface ExpectedResponseHead {
+  status: number;
+  /** Header name → substring its value must contain (e.g. `location`). */
+  headers?: Record<string, string>;
+}
+
+const fetchHeadOnce = (url: string, expected: ExpectedResponseHead) =>
+  Effect.tryPromise({
+    try: async (signal) => {
+      const u = new URL(url);
+      u.searchParams.set("__alchemy_cb", String(Date.now()));
+      const res = await fetch(u, {
+        signal,
+        // The point is to observe 3xx responses, not follow them.
+        redirect: "manual",
+        cache: "no-store",
+        headers: {
+          "cache-control": "no-cache",
+          pragma: "no-cache",
+          accept: "*/*",
+        },
+      });
+      await res.body?.cancel();
+      const matches =
+        res.status === expected.status &&
+        Object.entries(expected.headers ?? {}).every(([name, marker]) =>
+          (res.headers.get(name) ?? "").includes(marker),
+        );
+      if (!matches) {
+        throw new HttpHeadAssertionFailed({
+          url,
+          expected: JSON.stringify(expected),
+          status: res.status,
+          headers: JSON.stringify(Object.fromEntries(res.headers)),
+        });
+      }
+    },
+    catch: (e) =>
+      e instanceof HttpHeadAssertionFailed
+        ? e
+        : new HttpFetchFailed({
+            url,
+            message: e instanceof Error ? e.message : String(e),
+          }),
+  });
+
+/**
+ * Fetch `url` without following redirects and assert on the response head:
+ * the exact `status`, plus a substring match per named header. Retries with
+ * the same propagation-tolerant backoff as {@link expectUrlContains}. Used
+ * to verify `_redirects` (status + `location`) and `_headers` (injected
+ * header) rules actually apply at the edge — a body assertion can't see
+ * either.
+ */
+export const expectResponseHead = (
+  url: string,
+  expected: ExpectedResponseHead,
+  options: ExpectUrlContainsOptions = {},
+) => {
+  const totalTimeout = Duration.fromInputUnsafe(
+    options.timeout ?? "90 seconds",
+  );
+  const initial = options.initialBackoff ?? "750 millis";
+  const label = options.label ?? "url";
+
+  return fetchHeadOnce(url, expected).pipe(
+    Effect.retry({
+      schedule: Schedule.min([
+        Schedule.exponential(initial, 1.5),
+        Schedule.spaced("8 seconds"),
+      ]),
+    }),
+    Effect.timeoutOrElse({
+      duration: totalTimeout,
+      orElse: () =>
+        Effect.fail(
+          new HttpHeadAssertionFailed({
+            url,
+            expected: JSON.stringify(expected),
+            status: 0,
+            headers: `[timed out after ${Duration.toMillis(totalTimeout)}ms]`,
+          }),
+        ),
+    }),
+    Effect.tapError((error) =>
+      Effect.logError(`expectResponseHead(${label}) failed`, error),
+    ),
+  );
+};
 
 /**
  * Fetch `url` and assert the response body does *not* contain `marker`.

--- a/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
@@ -17,7 +17,7 @@ import * as Redacted from "effect/Redacted";
 import { MinimumLogLevel } from "effect/References";
 import * as pathe from "pathe";
 import { cloneFixture } from "../Utils/Fixture.ts";
-import { expectUrlContains } from "../Utils/Http.ts";
+import { expectResponseHead, expectUrlContains } from "../Utils/Http.ts";
 import {
   expectWorkerExists,
   expectWorkersDevPreviews,
@@ -418,6 +418,109 @@ describe.concurrent("Cloudflare.Worker", () => {
         yield* waitForWorkerToBeDeleted(v1.workerName, accountId);
       }).pipe(logLevel),
     { timeout: 360_000 },
+  );
+
+  test.provider(
+    "Worker assets: _redirects and _headers rules apply and survive every keep-assets path",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+
+        yield* stack.destroy();
+
+        // `_headers` / `_redirects` are config, not content: they are
+        // excluded from the asset manifest and travel as strings on
+        // `metadata.assets.config`. Because every script PUT replaces that
+        // config wholesale, the rules must be re-sent on *every* deploy —
+        // including the two paths that skip the asset upload. Each phase
+        // below pins one of the three `metadataAssets` branches.
+        const dir = yield* cloneFixture(assetsFixtureDir, {
+          prefix: "alchemy-worker-assets-special-",
+        });
+        const headerMarker = `alchemy-header-${Date.now()}`;
+        yield* fs.writeFileString(
+          path.join(dir, "_redirects"),
+          "/legacy /index.html 301\n",
+        );
+        yield* fs.writeFileString(
+          path.join(dir, "_headers"),
+          `/test.txt\n  x-alchemy-test: ${headerMarker}\n`,
+        );
+
+        const workerDir = yield* fs.makeTempDirectory({
+          prefix: "alchemy-worker-assets-special-entry-",
+        });
+        const workerPath = path.join(workerDir, "worker.ts");
+        const writeWorker = (marker: string) =>
+          fs.writeFileString(
+            workerPath,
+            `export default {
+  fetch: async () => new Response(${JSON.stringify(`Hello from SpecialAssets: ${marker}`)}),
+};
+`,
+          );
+
+        const deploy = (assets: string | { directory: string; hash: string }) =>
+          stack.deploy(
+            Effect.gen(function* () {
+              return yield* Cloudflare.Worker("SpecialAssetFiles", {
+                main: workerPath,
+                assets,
+                url: true,
+                subdomain: { enabled: true, previewsEnabled: true },
+                compatibility: { date: "2024-01-01" },
+              });
+            }),
+          );
+
+        const expectRulesLive = (url: string, phase: string) =>
+          Effect.all([
+            expectResponseHead(
+              `${url}/legacy`,
+              { status: 301, headers: { location: "/index.html" } },
+              { timeout: "120 seconds", label: `${phase}: redirect` },
+            ),
+            expectResponseHead(
+              `${url}/test.txt`,
+              { status: 200, headers: { "x-alchemy-test": headerMarker } },
+              { timeout: "120 seconds", label: `${phase}: header` },
+            ),
+          ]);
+
+        // Phase 1 — fresh upload: rules ride along with the manifest upload.
+        yield* writeWorker("v1");
+        const v1 = yield* deploy(dir);
+        expect(v1.hash?.assets).toBeDefined();
+        yield* expectRulesLive(v1.url!, "v1 upload");
+        // The special files themselves must not be served: requests for
+        // them fall through to the user worker.
+        yield* expectUrlContains(
+          `${v1.url!}/_redirects`,
+          "Hello from SpecialAssets",
+          { timeout: "60 seconds", label: "_redirects not served" },
+        );
+
+        // Phase 2 — bundle-only change: assets re-read but byte-identical,
+        // so the manifest is kept. The rules must be re-sent regardless.
+        yield* writeWorker("v2");
+        const v2 = yield* deploy(dir);
+        expect(v2.hash?.assets).toEqual(v1.hash?.assets);
+        expect(v2.hash?.bundle).not.toEqual(v1.hash?.bundle);
+        yield* expectRulesLive(v2.url!, "v2 keep-assets");
+
+        // Phase 3 — precomputed hash matches state, the directory walk is
+        // skipped entirely, and the special files are re-read on their own.
+        yield* writeWorker("v3");
+        const v3 = yield* deploy({ directory: dir, hash: v2.hash!.assets! });
+        expect(v3.hash?.assets).toEqual(v2.hash?.assets);
+        yield* expectRulesLive(v3.url!, "v3 skip-assets");
+
+        yield* stack.destroy();
+        yield* waitForWorkerToBeDeleted(v1.workerName, accountId);
+      }).pipe(logLevel),
+    { timeout: 600_000 },
   );
 
   test.provider("create, update, delete internal worker", (stack) =>


### PR DESCRIPTION
Fixes #927.

## Problem

`readAssets` reads `_headers` / `_redirects` from the assets directory and folds their contents into the asset hash, but no `metadataAssets` branch ever transmits them. Cloudflare only applies the rules when they arrive as `metadata.assets.config.redirects` / `.headers` (the distilled schema already encodes those to the underscored wire names), so every rule was silently dropped — requests to redirected paths fall through to the worker/404, and because the contents *are* hashed, editing only `_redirects` triggers an "assets changed" redeploy that visibly changes nothing.

## Fix

- `Assets.ts` — `readSpecialAssetFiles(directory)` reads just the two files; `withSpecialAssetFiles(config, files)` merges their contents into the config sent in the script PUT. Explicit `headers` / `redirects` props win; the files are the defaults; keys stay absent when neither exists.
- `WorkerProvider.ts` — all three `metadataAssets` branches now send the contents. `normalizePrebuiltAssets` keeps `directory` so the skip path re-reads the two files from disk: the script PUT replaces the asset config wholesale, so a metadata-only deploy would otherwise wipe rules that a previous deploy had applied.
- `LocalWorkerProvider.ts` — dev parity for directory-backed assets: `toRuntimeAssets` now reads the two files into the runtime assets config (the runtime already parses `redirects` / `headers` strings via `buildAssetConfigs`); read failures beyond NotFound are defects so the provider's typed error channel is unchanged.

No distilled changes needed — `PutScriptRequest.metadata.assets.config` already types and encodes `headers` / `redirects`.

## Tests

- New integration test in `Worker.test.ts` (`assets: _redirects and _headers rules apply and survive every keep-assets path`) walks all three branches with one worker: fresh upload → bundle-only change (manifest kept, assets re-read) → precomputed-hash deploy (directory walk skipped). Each phase asserts over HTTP that the 301 (status + `location`) and the injected header actually apply at the edge, and that `/_redirects` itself is not served (falls through to the worker). Passes against the real cloud (43s).
- New `expectResponseHead` helper in `test/Cloudflare/Utils/Http.ts`: fetches with `redirect: "manual"` and asserts on status + header substrings with the same propagation-tolerant retry as `expectUrlContains` — body-marker helpers can't observe a 3xx or a response header.

## Not in scope

Vite-mode dev (`Website.Vite` under `alchemy dev`) still doesn't apply the rules: Vite's public-dir middleware serves the files raw and there is no built assets directory, so `toRuntimeAssets` has nothing to read. Wiring the rules through the vite plugin (`cloudflare-tools`' `ViteAssets`, e.g. reading them from `publicDir`) is a cross-repo change — happy to follow up if you'd take it.

## Verification outside the suite

Also verified end-to-end on a real TanStack Start site (Worker + static assets via `Website.Vite`): before the patch all `_redirects` rules 404'd in production; with it they 301 at the edge and survive metadata-only redeploys.

## AI Disclosure 

PR created by a human and code changes pair programmed with Fable 5. I have pushed up a patch commit to my blog to confirm that redirects are now working