### PR TITLE
feat(docker): support container labels and stop timeout

### DIFF
--- a/packages/alchemy/src/Docker/Container.ts
+++ b/packages/alchemy/src/Docker/Container.ts
@@ -8,6 +8,7 @@ import { isResolved } from "../Diff.ts";
 import * as Provider from "../Provider.ts";
 import { Resource } from "../Resource.ts";
 import { createInternalTags, hasAlchemyTags } from "../Tags.ts";
+import { toSeconds } from "../Util/Duration.ts";
 import { Docker, dockerPhysicalName } from "./Docker.ts";
 import type { Providers } from "./Providers.ts";
 
@@ -30,6 +31,16 @@ export interface ContainerProps {
   volumes?: Container.VolumeMapping[];
   /** Restart policy. */
   restart?: "no" | "always" | "on-failure" | "unless-stopped";
+  /**
+   * Container labels. Alchemy's internal ownership labels are added
+   * automatically.
+   */
+  labels?: Record<string, string>;
+  /**
+   * Grace period before Docker forcefully kills the container after stopping
+   * it.
+   */
+  stopTimeout?: Duration.Input;
   /** Networks to connect after create. */
   networks?: Container.NetworkMapping[];
   /** Remove the container when it exits. @default false */
@@ -160,6 +171,22 @@ export interface Container extends Resource<
  *   start: true,
  * });
  * const runtime = yield* Docker.inspectContainer(postgresName);
+ * ```
+ *
+ * @section Traefik
+ * @example Route a container through Traefik
+ * ```typescript
+ * const api = yield* Docker.Container("api", {
+ *   image: "ghcr.io/acme/api:latest",
+ *   networks: [{ name: "traefik" }],
+ *   labels: {
+ *     "traefik.enable": "true",
+ *     "traefik.http.routers.api.rule": "Host(`api.example.com`)",
+ *     "traefik.http.services.api.loadbalancer.server.port": "3000",
+ *   },
+ *   stopTimeout: "30 seconds",
+ *   start: true,
+ * });
  * ```
  */
 export const Container = Resource<Container>("Docker.Container");
@@ -308,7 +335,7 @@ export const ContainerProvider = () =>
           const internalTags = yield* createInternalTags(id);
           const { stdout: containerId } = yield* docker.container.create({
             ...args,
-            label: internalTags,
+            label: { ...args.label, ...internalTags },
           });
           yield* Effect.forEach(
             news.networks ?? [],
@@ -355,6 +382,8 @@ const makeCreateArgs = (id: string, news: ContainerProps, instanceId: string) =>
             `${port.external}:${port.internal}/${port.protocol ?? "tcp"}`,
         ),
         restart: news.restart ?? "no",
+        label: news.labels,
+        "stop-timeout": toSeconds(news.stopTimeout)?.toString(),
         rm: news.removeOnExit ?? false,
         ...(news.healthcheck
           ? {

--- a/packages/alchemy/src/Docker/Docker.ts
+++ b/packages/alchemy/src/Docker/Docker.ts
@@ -49,6 +49,7 @@ export class Docker extends Context.Service<
         "health-retries": number | undefined;
         "health-start-period": string | undefined;
         "health-start-interval": string | undefined;
+        "stop-timeout": string | undefined;
         p: Array<string> | undefined;
         command: Array<string> | undefined;
         label?: Record<string, string>;
@@ -193,6 +194,7 @@ export declare namespace Docker {
       Cmd: string[] | null;
       Env: string[] | null;
       Labels: Record<string, string> | null;
+      StopTimeout?: number;
       Healthcheck?: {
         Test: string[] | null;
         Interval?: number;

--- a/packages/alchemy/test/Docker/Container.test.ts
+++ b/packages/alchemy/test/Docker/Container.test.ts
@@ -41,6 +41,42 @@ test.provider("diff replaces a container when its image changes", () =>
   }),
 );
 
+test.provider(
+  "diff replaces a container when its labels or stop timeout change",
+  () =>
+    Effect.gen(function* () {
+      const containerProvider = yield* Provider.findProvider(Docker.Container);
+      const containerDiff = yield* containerProvider.diff!({
+        id: "web",
+        fqn: "web",
+        instanceId: "instance",
+        olds: {
+          name: "web",
+          image: "nginx:alpine",
+          labels: { "traefik.enable": "true" },
+          stopTimeout: "10 seconds",
+        },
+        news: {
+          name: "web",
+          image: "nginx:alpine",
+          labels: { "traefik.enable": "false" },
+          stopTimeout: "30 seconds",
+        },
+        oldBindings: [],
+        newBindings: [],
+        output: {
+          id: "web",
+          name: "web",
+          status: "created",
+          createdAt: 0,
+          imageRef: "nginx:alpine",
+          ports: {},
+        },
+      });
+      expect(containerDiff).toEqual({ action: "replace", deleteFirst: true });
+    }),
+);
+
 describe("Docker.Container", { concurrent: false }, () => {
   test.provider.skipIf(!isDockerReady)(
     "publishes and inspects bound host ports",
@@ -84,6 +120,34 @@ describe("Docker.Container", { concurrent: false }, () => {
         );
         expect(container.status).toBe("created");
         expect(container.imageRef).toBe("nginx:alpine");
+      }),
+  );
+
+  test.provider.skipIf(!isDockerReady)(
+    "applies container labels and a stop timeout",
+    (stack) =>
+      Effect.gen(function* () {
+        const docker = yield* Docker.Docker;
+        const container = yield* stack.deploy(
+          Docker.Container("traefik-container", {
+            image: "nginx:alpine",
+            labels: {
+              "traefik.enable": "true",
+              "traefik.http.services.web.loadbalancer.server.port": "80",
+            },
+            stopTimeout: "10 minutes",
+            start: true,
+          }),
+        );
+
+        const info = yield* docker.container.inspect(container.name);
+        expect(info.Config.Labels).toEqual(
+          expect.objectContaining({
+            "traefik.enable": "true",
+            "traefik.http.services.web.loadbalancer.server.port": "80",
+          }),
+        );
+        expect(info.Config.StopTimeout).toBe(600);
       }),
   );
 


### PR DESCRIPTION
Adds `labels` and `stopTimeout` to `Docker.Container`, enabling Traefik-managed routing in a remote Docker context. User labels are preserved alongside Alchemy ownership labels, and changes replace the container.

Includes Docker-backed coverage for label and timeout round-tripping, plus a Traefik usage example.