### PR TITLE
fix(cloudflare/vite): workflows not exported correctly in vite dev

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -49,7 +49,7 @@
     },
     "cloudflare-tools/packages/cloudflare-rolldown-plugin": {
       "name": "@distilled.cloud/cloudflare-rolldown-plugin",
-      "version": "0.13.8",
+      "version": "0.13.10",
       "dependencies": {
         "@cloudflare/unenv-preset": "^2.16.0",
         "magic-string": "^0.30.21",
@@ -59,6 +59,7 @@
         "@cloudflare/workers-types": "catalog:workers",
         "@distilled.cloud/test-utils": "workspace:*",
         "mysql2": "^3.22.3",
+        "rolldown": "catalog:",
         "vite": "catalog:",
         "vitest": "catalog:",
       },
@@ -73,7 +74,7 @@
     },
     "cloudflare-tools/packages/cloudflare-runtime": {
       "name": "@distilled.cloud/cloudflare-runtime",
-      "version": "0.13.8",
+      "version": "0.13.10",
       "dependencies": {
         "@alchemy.run/node-utils": "catalog:",
         "workerd": "catalog:workers",
@@ -106,7 +107,7 @@
     },
     "cloudflare-tools/packages/cloudflare-vite-plugin": {
       "name": "@distilled.cloud/cloudflare-vite-plugin",
-      "version": "0.13.8",
+      "version": "0.13.10",
       "dependencies": {
         "@distilled.cloud/cloudflare-rolldown-plugin": "workspace:*",
       },

--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -8,6 +8,7 @@ import {
   type Assets as RuntimeAssets,
   type DurableObjectNamespace as RuntimeDurableObject,
   type QueueConsumer as RuntimeQueueConsumer,
+  type Workflow as RuntimeWorkflow,
   type RuntimeServices,
 } from "@distilled.cloud/cloudflare-runtime";
 import {
@@ -294,6 +295,7 @@ export const LocalWorkerProvider = () =>
                   bindings: worker.workerBindings as never,
                   hyperdrives: worker.hyperdrives,
                   durableObjectNamespaces: worker.durableObjectNamespaces,
+                  workflows: worker.workflows,
                   queueConsumers,
                   modules: yield* toRuntimeModules(bundle),
                   assets: yield* toRuntimeAssets(worker.assets),
@@ -409,6 +411,7 @@ export const LocalWorkerProvider = () =>
           string,
           RuntimeDurableObject & { uniqueKey: string }
         > = {};
+        const workflows: Record<string, RuntimeWorkflow> = {};
         const hyperdrives: Record<string, Required<HyperdriveOrigin>> = {};
         const containers: Record<string, ContainerImage> = {};
         for (const { data } of bindings) {
@@ -436,6 +439,18 @@ export const LocalWorkerProvider = () =>
                 }),
               );
             } else {
+              if (
+                binding.type === "workflow" &&
+                // Same ownership rule as DOs: only declare workflows hosted by
+                // this worker. Cross-script workflow bindings are routed via
+                // the registry proxy.
+                (!binding.scriptName || binding.scriptName === name)
+              ) {
+                workflows[binding.workflowName] = {
+                  workflowName: binding.workflowName,
+                  className: binding.className,
+                };
+              }
               workerBindings.push(yield* toRuntimeBinding(binding));
             }
           }
@@ -480,6 +495,7 @@ export const LocalWorkerProvider = () =>
           compatibility,
           workerBindings,
           durableObjectNamespaces: Object.values(durableObjectNamespaces),
+          workflows: Object.values(workflows),
           viteMain: props.vite?.main,
           viteEnvironments: props.vite?.viteEnvironments,
           hyperdrives,
@@ -587,6 +603,7 @@ export const LocalWorkerProvider = () =>
               name: worker.name,
               bindings: worker.workerBindings,
               durableObjectNamespaces: worker.durableObjectNamespaces,
+              workflows: worker.workflows,
               hyperdrives: worker.hyperdrives,
               queueConsumers: yield* getQueueConsumers(worker.name),
               assets: yield* toRuntimeAssets(worker.assets),


### PR DESCRIPTION
Pass owned workflows into local `RuntimeWorker` the same way durable object namespaces are declared, so vite/dev re-exports `WorkflowEntrypoint` classes.

Depends on [alchemy-run/cloudflare-tools#83](https://github.com/alchemy-run/cloudflare-tools/pull/83), which adds `RuntimeWorker.workflows` and emits `createWorkflowEntrypointWrapper` in the vite module-runner.

```ts
// LocalWorkerProvider now collects same-worker workflow bindings:
workflows[binding.workflowName] = {
  workflowName: binding.workflowName,
  className: binding.className,
};

// and threads them into runtime.start / viteDev
workflows: worker.workflows,
```
