### PR TITLE
fix(cloudflare/workflows): preserve pause control-flow errors in WorkflowBridge

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workflows/WorkflowBridge.ts
+++ b/packages/alchemy/src/Cloudflare/Workflows/WorkflowBridge.ts
@@ -116,7 +116,7 @@ const wrapWorkflowEvent = (event: any): WorkflowEventService["Service"] => ({
   schedule: event.schedule,
 });
 
-const wrapWorkflowStep = (step: any): WorkflowStep["Service"] => ({
+export const wrapWorkflowStep = (step: any): WorkflowStep["Service"] => ({
   do: <T>(options: WorkflowTaskOptions<T, any, any>): Effect.Effect<T> => {
     const { name } = options;
     // The surrounding body context is already provided in `task`; the bridge
@@ -151,7 +151,7 @@ const wrapWorkflowStep = (step: any): WorkflowStep["Service"] => ({
           rollbackConfig: options.rollbackConfig,
         }
       : undefined;
-    return Effect.tryPromise(() => {
+    return Effect.promise(() => {
       if (config && rollback) return step.do(name, config, callback, rollback);
       if (config) return step.do(name, config, callback);
       if (rollback) return step.do(name, callback, rollback);
@@ -159,14 +159,14 @@ const wrapWorkflowStep = (step: any): WorkflowStep["Service"] => ({
     });
   },
   sleep: (name: string, duration: string | number): Effect.Effect<void> =>
-    Effect.tryPromise(() => step.sleep(name, duration)),
+    Effect.promise(() => step.sleep(name, duration)),
   sleepUntil: (name: string, timestamp: Date | number): Effect.Effect<void> =>
-    Effect.tryPromise(() => step.sleepUntil(name, timestamp)),
+    Effect.promise(() => step.sleepUntil(name, timestamp)),
   waitForEvent: <T>(
     name: string,
     options: any,
   ): Effect.Effect<WorkflowStepEvent<T>> =>
-    Effect.tryPromise(
+    Effect.promise(
       () => step.waitForEvent(name, options) as Promise<WorkflowStepEvent<T>>,
     ),
 });

--- a/packages/alchemy/src/Cloudflare/Workflows/index.ts
+++ b/packages/alchemy/src/Cloudflare/Workflows/index.ts
@@ -1,2 +1,2 @@
 export * from "./Workflow.ts";
-export * from "./WorkflowBridge.ts";
+export { makeWorkflowBridge } from "./WorkflowBridge.ts";

--- a/packages/alchemy/test/Cloudflare/Workers/WorkflowBridge.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkflowBridge.test.ts
@@ -1,0 +1,36 @@
+import { wrapWorkflowStep } from "@/Cloudflare/Workflows/WorkflowBridge.ts";
+import { describe, expect, it } from "alchemy-test";
+import * as Cause from "effect/Cause";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+
+describe("WorkflowBridge", () => {
+  it.effect("preserves native Workflow control-flow rejections", () =>
+    Effect.gen(function* () {
+      const controlError = new Error("Aborting engine: User called pause");
+      const rejectWithControlError = () =>
+        Effect.runPromise(Effect.die(controlError));
+      const step = wrapWorkflowStep({
+        do: rejectWithControlError,
+        sleep: rejectWithControlError,
+        sleepUntil: rejectWithControlError,
+        waitForEvent: rejectWithControlError,
+      });
+
+      const effects = [
+        step.do({ name: "task", effect: Effect.succeed("done") }),
+        step.sleep("sleep", "1 second"),
+        step.sleepUntil("sleep-until", 1),
+        step.waitForEvent("event", { type: "test-event" }),
+      ];
+
+      for (const effect of effects) {
+        const exit = yield* Effect.exit(effect);
+        expect(Exit.isFailure(exit)).toBe(true);
+        if (Exit.isFailure(exit)) {
+          expect(Cause.squash(exit.cause)).toBe(controlError);
+        }
+      }
+    }),
+  );
+});

--- a/packages/alchemy/test/Cloudflare/Workers/WorkflowBridgeLocal.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkflowBridgeLocal.test.ts
@@ -1,0 +1,115 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as Test from "@/Test/Alchemy";
+import { expect } from "alchemy-test";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+import * as Schedule from "effect/Schedule";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import PauseWorkflowWorker from "./fixtures/workflow-pause/worker.ts";
+
+const { test } = Test.make({
+  providers: Cloudflare.providers(),
+  dev: true,
+});
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+interface WorkflowStatus {
+  status: string;
+  error?: { message?: string } | null;
+}
+
+class WorkerNotReady extends Data.TaggedError("WorkerNotReady")<{
+  status: number;
+}> {}
+
+const isSettledAfterPause = (status: WorkflowStatus) =>
+  status.status === "paused" ||
+  status.status === "errored" ||
+  status.status === "complete" ||
+  status.status === "terminated";
+
+/**
+ * End-to-end regression for #930: under local `alchemy dev`, pausing during an
+ * active `Cloudflare.Workflows.task` must leave the instance `paused` once that
+ * task finishes — not `errored` with `UnknownError` from `Effect.tryPromise`.
+ */
+test.provider(
+  "pausing during an active task settles as paused under local workerd",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const { worker } = yield* stack.deploy(
+        Effect.gen(function* () {
+          const w = yield* PauseWorkflowWorker;
+          return { worker: w };
+        }),
+      );
+
+      const client = yield* HttpClient.HttpClient;
+      const url = worker.url!;
+      expect(url).toBeTypeOf("string");
+
+      const { instanceId } = yield* client
+        .post(`${url}/workflow/start/world`)
+        .pipe(
+          Effect.flatMap((res) =>
+            res.status === 200
+              ? res.json.pipe(
+                  Effect.flatMap((body) => {
+                    const instanceId = (body as { instanceId?: unknown })
+                      .instanceId;
+                    return typeof instanceId === "string"
+                      ? Effect.succeed({ instanceId })
+                      : Effect.fail(
+                          new Error("Worker returned no workflow id"),
+                        );
+                  }),
+                )
+              : Effect.fail(new WorkerNotReady({ status: res.status })),
+          ),
+          Effect.retry({
+            while: (e): e is WorkerNotReady => e instanceof WorkerNotReady,
+            schedule: Schedule.max([
+              Schedule.exponential("500 millis"),
+              Schedule.recurs(15),
+            ]),
+          }),
+        );
+
+      const pauseRes = yield* client.post(
+        `${url}/workflow/pause/${instanceId}`,
+      );
+      expect(pauseRes.status).toBe(200);
+
+      // The active task sleeps 8s; give the engine time to finish the step and
+      // apply the pending pause (or incorrectly mark the run errored).
+      const lastStatus = yield* client
+        .get(`${url}/workflow/status/${instanceId}`)
+        .pipe(
+          Effect.flatMap((res) =>
+            res.status === 200
+              ? res.json.pipe(
+                  Effect.map((json) => json as unknown as WorkflowStatus),
+                )
+              : Effect.succeed({ status: "pending" } as WorkflowStatus),
+          ),
+          Effect.repeat({
+            schedule: Schedule.spaced("500 millis"),
+            until: isSettledAfterPause,
+            times: 40,
+          }),
+        );
+
+      expect(lastStatus.status).toBe("paused");
+      expect(lastStatus.error).toBeFalsy();
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 180_000 },
+);

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/workflow-pause/pause-workflow.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/workflow-pause/pause-workflow.ts
@@ -1,0 +1,24 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as Effect from "effect/Effect";
+
+/**
+ * One durable task that stays active long enough for `instance.pause()` to
+ * land while `step.do` is still running. When the task then finishes, the
+ * local Workflow engine rejects with Cloudflare's pause control-flow error;
+ * `WorkflowBridge` must preserve that rejection so status becomes `paused`.
+ */
+export default class PauseWorkflow extends Cloudflare.Workflow<PauseWorkflow>()(
+  "PauseWorkflow",
+  Effect.gen(function* () {
+    return Effect.fn(function* (_input: { value: string }) {
+      yield* Cloudflare.Workflows.task(
+        "slow",
+        Effect.gen(function* () {
+          yield* Effect.sleep("8 seconds");
+          return "done";
+        }),
+      );
+      return { ok: true };
+    });
+  }),
+) {}

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/workflow-pause/worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/workflow-pause/worker.ts
@@ -1,0 +1,43 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as Effect from "effect/Effect";
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import PauseWorkflow from "./pause-workflow.ts";
+
+export default class PauseWorkflowWorker extends Cloudflare.Worker<PauseWorkflowWorker>()(
+  "PauseWorkflowWorker",
+  {
+    main: import.meta.url,
+  },
+  Effect.gen(function* () {
+    const workflow = yield* PauseWorkflow;
+
+    return {
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+
+        if (request.url.startsWith("/workflow/start/")) {
+          const value = request.url.split("/workflow/start/")[1] ?? "world";
+          const instance = yield* workflow.create({ params: { value } });
+          return yield* HttpServerResponse.json({ instanceId: instance.id });
+        }
+
+        if (request.url.startsWith("/workflow/pause/")) {
+          const instanceId = request.url.split("/workflow/pause/")[1] ?? "";
+          const instance = yield* workflow.get(instanceId);
+          yield* instance.pause();
+          return yield* HttpServerResponse.json({ ok: true });
+        }
+
+        if (request.url.startsWith("/workflow/status/")) {
+          const instanceId = request.url.split("/workflow/status/")[1] ?? "";
+          const instance = yield* workflow.get(instanceId);
+          const status = yield* instance.status();
+          return yield* HttpServerResponse.json(status);
+        }
+
+        return HttpServerResponse.text("ok");
+      }),
+    };
+  }),
+) {}


### PR DESCRIPTION
Fixes Workflow pause under `alchemy dev` reporting `errored` instead of `paused` after an active task finishes ([#930](https://github.com/alchemy-run/alchemy/issues/930)).

`WorkflowBridge` adapted native `step.do` / `sleep` / `waitForEvent` with `Effect.tryPromise`, which rewrote Cloudflare's pause control-flow rejection (`Aborting engine: User called pause`) as `Cause.UnknownError`. The local Workflow engine matches abort reasons by message, so pause was treated as failure.

```diff
-return Effect.tryPromise(() => step.do(...));
+return Effect.promise(() => step.do(...));
```

Also narrows the Workflows barrel to `makeWorkflowBridge` so the test helper `wrapWorkflowStep` stays internal to the module surface used by consumers.
