### PR TITLE
fix(aws/cloudfront): merge observed config into UpdateDistribution requests

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -206,7 +206,7 @@
     },
     "distilled/packages/aws": {
       "name": "@distilled.cloud/aws",
-      "version": "0.30.1",
+      "version": "0.30.2",
       "dependencies": {
         "@aws-crypto/crc32": "catalog:",
         "@aws-crypto/util": "catalog:",
@@ -238,7 +238,7 @@
     },
     "distilled/packages/axiom": {
       "name": "@distilled.cloud/axiom",
-      "version": "0.30.1",
+      "version": "0.30.2",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
       },
@@ -255,7 +255,7 @@
     },
     "distilled/packages/azure": {
       "name": "@distilled.cloud/azure",
-      "version": "0.30.1",
+      "version": "0.30.2",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
       },
@@ -272,7 +272,7 @@
     },
     "distilled/packages/cloudflare": {
       "name": "@distilled.cloud/cloudflare",
-      "version": "0.30.1",
+      "version": "0.30.2",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
       },
@@ -292,7 +292,7 @@
     },
     "distilled/packages/coinbase": {
       "name": "@distilled.cloud/coinbase",
-      "version": "0.30.1",
+      "version": "0.30.2",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
       },
@@ -310,7 +310,7 @@
     },
     "distilled/packages/core": {
       "name": "@distilled.cloud/core",
-      "version": "0.30.1",
+      "version": "0.30.2",
       "devDependencies": {
         "@types/bun": "catalog:",
         "@types/node": "catalog:",
@@ -323,7 +323,7 @@
     },
     "distilled/packages/expo-eas": {
       "name": "@distilled.cloud/expo-eas",
-      "version": "0.30.1",
+      "version": "0.30.2",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
       },
@@ -340,7 +340,7 @@
     },
     "distilled/packages/fly-io": {
       "name": "@distilled.cloud/fly-io",
-      "version": "0.30.1",
+      "version": "0.30.2",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
       },
@@ -357,7 +357,7 @@
     },
     "distilled/packages/gcp": {
       "name": "@distilled.cloud/gcp",
-      "version": "0.30.1",
+      "version": "0.30.2",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
       },
@@ -374,7 +374,7 @@
     },
     "distilled/packages/kubernetes": {
       "name": "@distilled.cloud/kubernetes",
-      "version": "0.30.1",
+      "version": "0.30.2",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
       },
@@ -391,7 +391,7 @@
     },
     "distilled/packages/mongodb-atlas": {
       "name": "@distilled.cloud/mongodb-atlas",
-      "version": "0.30.1",
+      "version": "0.30.2",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
       },
@@ -408,7 +408,7 @@
     },
     "distilled/packages/neon": {
       "name": "@distilled.cloud/neon",
-      "version": "0.30.1",
+      "version": "0.30.2",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
       },
@@ -425,7 +425,7 @@
     },
     "distilled/packages/planetscale": {
       "name": "@distilled.cloud/planetscale",
-      "version": "0.30.1",
+      "version": "0.30.2",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
       },
@@ -442,7 +442,7 @@
     },
     "distilled/packages/posthog": {
       "name": "@distilled.cloud/posthog",
-      "version": "0.30.1",
+      "version": "0.30.2",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
       },
@@ -461,7 +461,7 @@
     },
     "distilled/packages/prisma-postgres": {
       "name": "@distilled.cloud/prisma-postgres",
-      "version": "0.30.1",
+      "version": "0.30.2",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
       },
@@ -478,7 +478,7 @@
     },
     "distilled/packages/stripe": {
       "name": "@distilled.cloud/stripe",
-      "version": "0.30.1",
+      "version": "0.30.2",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
       },
@@ -495,7 +495,7 @@
     },
     "distilled/packages/supabase": {
       "name": "@distilled.cloud/supabase",
-      "version": "0.30.1",
+      "version": "0.30.2",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
       },
@@ -512,7 +512,7 @@
     },
     "distilled/packages/turso": {
       "name": "@distilled.cloud/turso",
-      "version": "0.30.1",
+      "version": "0.30.2",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
       },
@@ -529,7 +529,7 @@
     },
     "distilled/packages/typesense": {
       "name": "@distilled.cloud/typesense",
-      "version": "0.30.1",
+      "version": "0.30.2",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
       },
@@ -547,7 +547,7 @@
     },
     "distilled/packages/workos": {
       "name": "@distilled.cloud/workos",
-      "version": "0.30.1",
+      "version": "0.30.2",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
       },

--- a/packages/alchemy/src/AWS/CloudFront/Distribution.ts
+++ b/packages/alchemy/src/AWS/CloudFront/Distribution.ts
@@ -954,7 +954,10 @@ export const DistributionProvider = () =>
           // Sync config — diff observed config against desired and patch
           // via `updateDistribution` with the freshly observed ETag. We
           // keep the observed `CallerReference` because CloudFront does
-          // not allow it to change.
+          // not allow it to change, and fill every member the props don't
+          // express from the observed config: UpdateDistribution replaces
+          // the whole config and rejects requests with missing members
+          // (see `mergeWithObservedConfig`).
           yield* Effect.logInfo(
             `CloudFront Distribution reconcile: updating config for ${observed.distribution.Id} with etag=${observed.etag ?? "missing"}`,
           );
@@ -962,9 +965,9 @@ export const DistributionProvider = () =>
             .updateDistribution({
               Id: observed.distribution.Id,
               IfMatch: observed.etag,
-              DistributionConfig: toConfig(
-                observed.config.CallerReference,
-                news,
+              DistributionConfig: mergeWithObservedConfig(
+                toConfig(observed.config.CallerReference, news),
+                observed.config,
               ),
             })
             .pipe(
@@ -1275,6 +1278,92 @@ const toOrigin = (origin: DistributionOrigin): cloudfront.Origin => {
               : undefined,
           },
   };
+};
+
+/**
+ * Recursively fills `undefined` members of `desired` from `observed`.
+ * Defined values in `desired` always win; arrays are taken from `desired`
+ * wholesale (item-level merging is the caller's concern).
+ */
+const fillUndefined = <T>(desired: T, observed: T): T => {
+  if (desired === undefined) return observed;
+  if (
+    desired === null ||
+    typeof desired !== "object" ||
+    Array.isArray(desired) ||
+    observed === null ||
+    typeof observed !== "object" ||
+    Array.isArray(observed)
+  ) {
+    return desired;
+  }
+  const out: Record<string, unknown> = {
+    ...(desired as Record<string, unknown>),
+  };
+  for (const key of Object.keys(observed as Record<string, unknown>)) {
+    out[key] = fillUndefined(
+      (desired as Record<string, unknown>)[key],
+      (observed as Record<string, unknown>)[key],
+    );
+  }
+  return out as T;
+};
+
+/**
+ * Completes a desired `DistributionConfig` with the freshly observed live
+ * config before an `updateDistribution` call.
+ *
+ * CloudFront's `UpdateDistribution` replaces the ENTIRE distribution config:
+ * any member missing from the request is rejected with `IllegalUpdate`
+ * (observed in practice: "Default root object is missing for the resource",
+ * "The 'OriginCustomHeaders' field is missing"). `toConfig` emits only the
+ * members the props express, so updating a live distribution fails on every
+ * member the props don't model — some of which (e.g. per-origin
+ * `CustomHeaders`, per-behavior `TrustedSigners`) are nested inside
+ * collections and not expressible as props at all.
+ *
+ * The standard CloudFront update pattern is read-modify-write, which the
+ * delete path here already uses (`{ ...current.config, Enabled: false }`).
+ * This applies the same idea to updates: desired values always win — the
+ * declared props still fully control drift — and only `undefined` members
+ * are carried over from the observed config. `Origins` and `CacheBehaviors`
+ * items are additionally merged by identity (`Id` / `PathPattern`) so their
+ * nested unexpressed members carry over too.
+ *
+ * Exported for unit tests.
+ */
+export const mergeWithObservedConfig = (
+  desired: cloudfront.DistributionConfig,
+  observed: cloudfront.DistributionConfig,
+): cloudfront.DistributionConfig => {
+  const merged = fillUndefined(desired, observed);
+  if (merged.Origins?.Items && observed.Origins?.Items) {
+    const observedOrigins = observed.Origins.Items;
+    merged.Origins = {
+      ...merged.Origins,
+      Items: merged.Origins.Items.map((item) =>
+        fillUndefined(
+          item,
+          observedOrigins.find((origin) => origin.Id === item.Id) ?? item,
+        ),
+      ),
+    };
+  }
+  if (merged.CacheBehaviors?.Items && observed.CacheBehaviors?.Items) {
+    const observedBehaviors = observed.CacheBehaviors.Items;
+    merged.CacheBehaviors = {
+      ...merged.CacheBehaviors,
+      Items: merged.CacheBehaviors.Items.map((item) =>
+        fillUndefined(
+          item,
+          observedBehaviors.find(
+            (behavior) => behavior.PathPattern === item.PathPattern,
+          ) ?? item,
+        ),
+      ),
+    };
+  }
+  return merged;
 };
 
 const toConfig = (

--- a/packages/alchemy/src/AWS/CloudFront/Distribution.ts
+++ b/packages/alchemy/src/AWS/CloudFront/Distribution.ts
@@ -1149,8 +1149,16 @@ const toBehavior = (
   CachePolicyId: behavior.cachePolicyId,
   OriginRequestPolicyId: behavior.originRequestPolicyId,
   ResponseHeadersPolicyId: behavior.responseHeadersPolicyId,
-  ForwardedValues: behavior.forwardedValues,
-  MinTTL: toWireSeconds(behavior.minTtl),
+  // Without a cache policy, CloudFront is in legacy mode and rejects the
+  // request unless both ForwardedValues and MinTTL are present.
+  ForwardedValues:
+    behavior.forwardedValues ??
+    (behavior.cachePolicyId === undefined
+      ? { QueryString: false, Cookies: { Forward: "none" } }
+      : undefined),
+  MinTTL:
+    toWireSeconds(behavior.minTtl) ??
+    (behavior.cachePolicyId === undefined ? 0 : undefined),
   DefaultTTL: toWireSeconds(behavior.defaultTtl),
   MaxTTL: toWireSeconds(behavior.maxTtl),
   TrustedKeyGroups: behavior.trustedKeyGroups
@@ -1300,9 +1308,22 @@ const fillUndefined = <T>(desired: T, observed: T): T => {
   const out: Record<string, unknown> = {
     ...(desired as Record<string, unknown>),
   };
+  const desiredObj = desired as Record<string, unknown>;
   for (const key of Object.keys(observed as Record<string, unknown>)) {
+    // CloudFront list shapes pair `Quantity` with `Items`. A desired node
+    // that declares a `Quantity` but no `Items` (e.g. a geo restriction of
+    // `{ RestrictionType: "none", Quantity: 0 }`) is fully specified —
+    // filling `Items` from the observed config would desynchronize the two
+    // and CloudFront rejects the update with `InconsistentQuantities`.
+    if (
+      key === "Items" &&
+      typeof desiredObj.Quantity === "number" &&
+      desiredObj.Items === undefined
+    ) {
+      continue;
+    }
     out[key] = fillUndefined(
-      (desired as Record<string, unknown>)[key],
+      desiredObj[key],
       (observed as Record<string, unknown>)[key],
     );
   }

--- a/packages/alchemy/test/AWS/CloudFront/Distribution.test.ts
+++ b/packages/alchemy/test/AWS/CloudFront/Distribution.test.ts
@@ -8,7 +8,9 @@ import * as Test from "@/Test/Alchemy";
 import * as cloudfront from "@distilled.cloud/aws/cloudfront";
 import * as S3 from "@distilled.cloud/aws/s3";
 import { describe, expect } from "alchemy-test";
+import type * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as Redacted from "effect/Redacted";
 import * as Schedule from "effect/Schedule";
 
 const { test } = Test.make({ providers: AWS.providers() });
@@ -293,6 +295,107 @@ describe("AWS.CloudFront.Distribution", () => {
 
         yield* stack.destroy();
         yield* assertDistributionDeleted(deployed.distribution.distributionId);
+      }),
+    { timeout: 600_000 },
+  );
+
+  // Regression for the UpdateDistribution full-config-replacement failure:
+  // members the props don't express (DefaultRootObject, per-origin
+  // CustomHeaders) are set on the live distribution out-of-band, then an
+  // alchemy update is deployed. Before `mergeWithObservedConfig`, the update
+  // request omitted those members and CloudFront rejected it with
+  // `IllegalUpdate` ("Default root object is missing for the resource",
+  // "The 'OriginCustomHeaders' field is missing"). Now they are carried over
+  // from the observed config while the declared props still win.
+  test.provider.skipIf(!runLive)(
+    "update preserves config members set out-of-band",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        // A plain custom origin keeps the fixture to a single resource — the
+        // regression under test lives entirely in the distribution's config
+        // update, so no bucket/OAC is needed.
+        const program = (defaultTtl: Duration.Input) =>
+          Effect.gen(function* () {
+            return yield* Distribution("MergeDistribution", {
+              origins: [
+                {
+                  id: "site",
+                  domainName: "example.com",
+                },
+              ],
+              defaultCacheBehavior: {
+                targetOriginId: "site",
+                viewerProtocolPolicy: "redirect-to-https",
+                compress: true,
+                forwardedValues: {
+                  QueryString: false,
+                  Cookies: {
+                    Forward: "none",
+                  },
+                },
+                minTtl: 0,
+                defaultTtl,
+                maxTtl: "1 hour",
+              },
+            });
+          });
+
+        const deployed = yield* stack.deploy(program("5 minutes"));
+
+        // Out-of-band read-modify-write: enrich the live config with members
+        // the props above don't express.
+        const live = yield* cloudfront.getDistributionConfig({
+          Id: deployed.distributionId,
+        });
+        const liveConfig = live.DistributionConfig!;
+        yield* cloudfront.updateDistribution({
+          Id: deployed.distributionId,
+          IfMatch: live.ETag,
+          DistributionConfig: {
+            ...liveConfig,
+            DefaultRootObject: "index.html",
+            Origins: {
+              ...liveConfig.Origins,
+              Items: liveConfig.Origins.Items.map((origin) => ({
+                ...origin,
+                CustomHeaders: {
+                  Quantity: 1,
+                  Items: [{ HeaderName: "x-out-of-band", HeaderValue: "kept" }],
+                },
+              })),
+            },
+          },
+        });
+
+        // Update via alchemy with a changed prop. The props still don't
+        // express the members set above — pre-fix this deploy failed with
+        // `IllegalUpdate`.
+        yield* stack.deploy(program("10 minutes"));
+
+        const updated = yield* cloudfront.getDistributionConfig({
+          Id: deployed.distributionId,
+        });
+        const config = updated.DistributionConfig;
+        // Desired wins: the prop change went through.
+        expect(config?.DefaultCacheBehavior?.DefaultTTL).toEqual(600);
+        // Members the props don't express carried over from the observed
+        // config instead of being dropped (or rejected) by the update.
+        expect(config?.DefaultRootObject).toEqual("index.html");
+        const headers = config?.Origins?.Items?.[0]?.CustomHeaders?.Items?.map(
+          (header) => ({
+            name: header.HeaderName,
+            value:
+              typeof header.HeaderValue === "string"
+                ? header.HeaderValue
+                : Redacted.value(header.HeaderValue),
+          }),
+        );
+        expect(headers).toEqual([{ name: "x-out-of-band", value: "kept" }]);
+
+        yield* stack.destroy();
+        yield* assertDistributionDeleted(deployed.distributionId);
       }),
     { timeout: 600_000 },
   );

--- a/packages/alchemy/test/AWS/CloudFront/Invalidation.test.ts
+++ b/packages/alchemy/test/AWS/CloudFront/Invalidation.test.ts
@@ -102,10 +102,12 @@ test.provider.skipIf(process.env.ALCHEMY_RUN_LIVE_AWS_WEBSITE_TESTS !== "true")(
         Id: deployed.invalidation.invalidationId,
       });
       expect(current.Invalidation?.Status).toEqual("Completed");
-      expect(current.Invalidation?.InvalidationBatch?.Paths?.Items).toEqual([
-        "/index.html",
-        "/docs/*",
-      ]);
+      // CloudFront returns invalidation paths in arbitrary order.
+      expect(
+        [
+          ...(current.Invalidation?.InvalidationBatch?.Paths?.Items ?? []),
+        ].sort(),
+      ).toEqual(["/docs/*", "/index.html"]);
 
       yield* stack.destroy();
       yield* assertDistributionDeleted(deployed.distribution.distributionId);

--- a/packages/alchemy/test/AWS/CloudFront/MergeObservedConfig.test.ts
+++ b/packages/alchemy/test/AWS/CloudFront/MergeObservedConfig.test.ts
@@ -227,6 +227,35 @@ describe("mergeWithObservedConfig", () => {
     expect(withoutOrigins.Origins).toEqual({ Quantity: 0, Items: [] });
   });
 
+  test("a Quantity-only desired list never resurrects observed Items", () => {
+    // Dropping a geo whitelist produces `{ RestrictionType: "none",
+    // Quantity: 0 }` with no `Items`; filling `Items` from the observed
+    // whitelist would desynchronize Quantity/Items and CloudFront rejects
+    // the update with `InconsistentQuantities`.
+    const withWhitelist = {
+      ...observed,
+      Restrictions: {
+        GeoRestriction: {
+          RestrictionType: "whitelist",
+          Quantity: 2,
+          Items: ["US", "GB"],
+        },
+      },
+    } as cloudfront.DistributionConfig;
+    const dropped = mergeWithObservedConfig(
+      {
+        ...desired,
+        Restrictions: {
+          GeoRestriction: { RestrictionType: "none", Quantity: 0 },
+        },
+      } as cloudfront.DistributionConfig,
+      withWhitelist,
+    );
+    expect(dropped.Restrictions).toEqual({
+      GeoRestriction: { RestrictionType: "none", Quantity: 0 },
+    });
+  });
+
   test("an origin absent from observed is passed through unchanged", () => {
     const withNewOrigin = mergeWithObservedConfig(
       {

--- a/packages/alchemy/test/AWS/CloudFront/MergeObservedConfig.test.ts
+++ b/packages/alchemy/test/AWS/CloudFront/MergeObservedConfig.test.ts
@@ -1,0 +1,251 @@
+import { mergeWithObservedConfig } from "@/AWS/CloudFront/Distribution";
+import type * as cloudfront from "@distilled.cloud/aws/cloudfront";
+import { describe, expect, test } from "alchemy-test";
+
+/**
+ * A live distribution config as returned by `GetDistributionConfig` for a
+ * distribution CloudFront has normalized — every member present, including
+ * the ones `DistributionProps` cannot express (per-origin `CustomHeaders`,
+ * per-behavior `TrustedSigners`, `GrpcConfig`, …). `UpdateDistribution`
+ * rejects requests missing any of these with `IllegalUpdate`.
+ */
+const observed: cloudfront.DistributionConfig = {
+  CallerReference: "caller-ref",
+  Aliases: { Quantity: 0 },
+  DefaultRootObject: "",
+  Origins: {
+    Quantity: 1,
+    Items: [
+      {
+        Id: "s3",
+        DomainName: "bucket.s3.us-east-1.amazonaws.com",
+        OriginPath: "",
+        CustomHeaders: { Quantity: 0 },
+        S3OriginConfig: { OriginAccessIdentity: "", OriginReadTimeout: 30 },
+        ConnectionAttempts: 3,
+        ConnectionTimeout: 10,
+        OriginShield: { Enabled: false },
+        OriginAccessControlId: "OAC_OBSERVED",
+      },
+    ],
+  },
+  OriginGroups: { Quantity: 0 },
+  DefaultCacheBehavior: {
+    TargetOriginId: "s3",
+    TrustedSigners: { Enabled: false, Quantity: 0 },
+    TrustedKeyGroups: { Enabled: false, Quantity: 0 },
+    ViewerProtocolPolicy: "redirect-to-https",
+    AllowedMethods: {
+      Quantity: 2,
+      Items: ["HEAD", "GET"],
+      CachedMethods: { Quantity: 2, Items: ["HEAD", "GET"] },
+    },
+    SmoothStreaming: false,
+    Compress: true,
+    LambdaFunctionAssociations: { Quantity: 0 },
+    FunctionAssociations: { Quantity: 0 },
+    FieldLevelEncryptionId: "",
+    CachePolicyId: "cache-policy-id",
+    GrpcConfig: { Enabled: false },
+  },
+  CacheBehaviors: {
+    Quantity: 1,
+    Items: [
+      {
+        PathPattern: "*.webp",
+        TargetOriginId: "s3",
+        TrustedSigners: { Enabled: false, Quantity: 0 },
+        TrustedKeyGroups: { Enabled: false, Quantity: 0 },
+        ViewerProtocolPolicy: "redirect-to-https",
+        AllowedMethods: {
+          Quantity: 2,
+          Items: ["HEAD", "GET"],
+          CachedMethods: { Quantity: 2, Items: ["HEAD", "GET"] },
+        },
+        SmoothStreaming: false,
+        Compress: true,
+        LambdaFunctionAssociations: { Quantity: 0 },
+        FunctionAssociations: { Quantity: 0 },
+        FieldLevelEncryptionId: "",
+        CachePolicyId: "cache-policy-id",
+        GrpcConfig: { Enabled: false },
+      },
+    ],
+  },
+  CustomErrorResponses: { Quantity: 0 },
+  Comment: "",
+  Logging: { Enabled: false, IncludeCookies: false, Bucket: "", Prefix: "" },
+  PriceClass: "PriceClass_100",
+  Enabled: true,
+  ViewerCertificate: {
+    CloudFrontDefaultCertificate: true,
+    SSLSupportMethod: "vip",
+    MinimumProtocolVersion: "TLSv1",
+  },
+  Restrictions: { GeoRestriction: { RestrictionType: "none", Quantity: 0 } },
+  WebACLId: "",
+  HttpVersion: "http2",
+  IsIPV6Enabled: false,
+  ContinuousDeploymentPolicyId: "",
+  Staging: false,
+};
+
+/**
+ * The sparse config `toConfig` builds from props — only what the props
+ * express, everything else `undefined` (i.e. omitted from the request).
+ */
+const desired: cloudfront.DistributionConfig = {
+  CallerReference: "caller-ref",
+  Aliases: { Quantity: 0, Items: [] },
+  Origins: {
+    Quantity: 1,
+    Items: [
+      {
+        Id: "s3",
+        DomainName: "bucket.s3.us-east-1.amazonaws.com",
+        OriginAccessControlId: "OAC_DESIRED",
+        S3OriginConfig: { OriginAccessIdentity: "" },
+      },
+    ],
+  },
+  DefaultCacheBehavior: {
+    TargetOriginId: "s3",
+    ViewerProtocolPolicy: "redirect-to-https",
+    AllowedMethods: {
+      Quantity: 2,
+      Items: ["GET", "HEAD"],
+      CachedMethods: { Quantity: 2, Items: ["GET", "HEAD"] },
+    },
+    Compress: true,
+    CachePolicyId: "cache-policy-id",
+    FunctionAssociations: {
+      Quantity: 1,
+      Items: [
+        {
+          FunctionARN: "arn:aws:cloudfront::123:function/deny-all",
+          EventType: "viewer-request",
+        },
+      ],
+    },
+  },
+  CacheBehaviors: {
+    Quantity: 1,
+    Items: [
+      {
+        PathPattern: "*.webp",
+        TargetOriginId: "s3",
+        ViewerProtocolPolicy: "redirect-to-https",
+        AllowedMethods: {
+          Quantity: 2,
+          Items: ["GET", "HEAD"],
+          CachedMethods: { Quantity: 2, Items: ["GET", "HEAD"] },
+        },
+        Compress: true,
+        CachePolicyId: "cache-policy-id",
+      },
+    ],
+  },
+  Comment: "",
+  Enabled: false,
+  Restrictions: { GeoRestriction: { RestrictionType: "none", Quantity: 0 } },
+  IsIPV6Enabled: true,
+} as cloudfront.DistributionConfig;
+
+describe("mergeWithObservedConfig", () => {
+  const merged = mergeWithObservedConfig(desired, observed);
+
+  test("desired values win over observed ones", () => {
+    expect(merged.Enabled).toBe(false);
+    expect(merged.IsIPV6Enabled).toBe(true);
+    expect(merged.Origins?.Items?.[0]?.OriginAccessControlId).toBe(
+      "OAC_DESIRED",
+    );
+    expect(merged.DefaultCacheBehavior?.FunctionAssociations?.Quantity).toBe(1);
+  });
+
+  test("top-level members the desired config omits are filled from observed", () => {
+    expect(merged.DefaultRootObject).toBe("");
+    expect(merged.WebACLId).toBe("");
+    expect(merged.ContinuousDeploymentPolicyId).toBe("");
+    expect(merged.Staging).toBe(false);
+    expect(merged.PriceClass).toBe("PriceClass_100");
+    expect(merged.Logging).toEqual(observed.Logging);
+    expect(merged.OriginGroups).toEqual({ Quantity: 0 });
+    expect(merged.CustomErrorResponses).toEqual({ Quantity: 0 });
+  });
+
+  test("nested members inside origin items are filled by Id", () => {
+    const origin = merged.Origins?.Items?.[0];
+    expect(origin?.CustomHeaders).toEqual({ Quantity: 0 });
+    expect(origin?.OriginPath).toBe("");
+    expect(origin?.ConnectionAttempts).toBe(3);
+    expect(origin?.ConnectionTimeout).toBe(10);
+    expect(origin?.OriginShield).toEqual({ Enabled: false });
+    expect(origin?.S3OriginConfig?.OriginReadTimeout).toBe(30);
+  });
+
+  test("nested members inside behaviors are filled (default + by PathPattern)", () => {
+    for (const behavior of [
+      merged.DefaultCacheBehavior,
+      merged.CacheBehaviors?.Items?.[0],
+    ]) {
+      expect(behavior?.TrustedSigners).toEqual({ Enabled: false, Quantity: 0 });
+      expect(behavior?.TrustedKeyGroups).toEqual({
+        Enabled: false,
+        Quantity: 0,
+      });
+      expect(behavior?.SmoothStreaming).toBe(false);
+      expect(behavior?.FieldLevelEncryptionId).toBe("");
+      expect(behavior?.GrpcConfig).toEqual({ Enabled: false });
+      expect(behavior?.LambdaFunctionAssociations).toEqual({ Quantity: 0 });
+    }
+  });
+
+  test("partial nested objects are completed member-wise, not replaced", () => {
+    // Desired sets CloudFrontDefaultCertificate only; the observed
+    // SSLSupportMethod / MinimumProtocolVersion carry over.
+    const mergedWithCert = mergeWithObservedConfig(
+      { ...desired, ViewerCertificate: { CloudFrontDefaultCertificate: true } },
+      observed,
+    );
+    expect(mergedWithCert.ViewerCertificate).toEqual({
+      CloudFrontDefaultCertificate: true,
+      SSLSupportMethod: "vip",
+      MinimumProtocolVersion: "TLSv1",
+    });
+  });
+
+  test("desired arrays are never extended by observed items", () => {
+    // Observed has one origin; a desired config that removes it must win.
+    const withoutOrigins = mergeWithObservedConfig(
+      {
+        ...desired,
+        Origins: { Quantity: 0, Items: [] },
+      },
+      observed,
+    );
+    expect(withoutOrigins.Origins).toEqual({ Quantity: 0, Items: [] });
+  });
+
+  test("an origin absent from observed is passed through unchanged", () => {
+    const withNewOrigin = mergeWithObservedConfig(
+      {
+        ...desired,
+        Origins: {
+          Quantity: 1,
+          Items: [
+            {
+              Id: "brand-new",
+              DomainName: "new.example.com",
+            } as cloudfront.Origin,
+          ],
+        },
+      },
+      observed,
+    );
+    expect(withNewOrigin.Origins?.Items?.[0]).toEqual({
+      Id: "brand-new",
+      DomainName: "new.example.com",
+    });
+  });
+});


### PR DESCRIPTION
### Problem

`UpdateDistribution` replaces the **entire** distribution config — CloudFront rejects a request with any missing member as `IllegalUpdate`. The update path builds its request purely from props (`toConfig`), so updating a live distribution fails on every member the props don't express. Hit in production while managing adopted distributions:

```
IllegalUpdate: Default root object is missing for the resource
IllegalUpdate: The 'OriginCustomHeaders' field is missing.
```

Pinning members one-by-one in props can't close this: some required members (per-origin `CustomHeaders`, per-behavior `TrustedSigners`/`GrpcConfig`, …) live inside collection items and aren't expressible in `DistributionProps` at all.

### Fix

The standard CloudFront update pattern is read-modify-write — which the **delete** path here already uses (`{ ...current.config, Enabled: false }`). This PR applies the same idea to updates: members the desired config leaves `undefined` are filled from the freshly observed config (already fetched for the ETag), with item-wise merging for `Origins` (by `Id`) and `CacheBehaviors` (by `PathPattern`). Desired values always win, so declared props still fully control drift; desired removals are never resurrected from the observed config.

### Testing

Unit tests for `mergeWithObservedConfig` with a `GetDistributionConfig`-shaped fixture (desired-wins, top-level + nested fill, partial-object completion, removal/new-origin edge cases). Also validated live: this change (as a runtime patch on `2.0.0-beta.64`) unblocked real `UpdateDistribution` calls against three production distributions that previously failed with the errors above.