### PR TITLE
fix(aws/ecs): attach taskRoleManagedPolicyArns in Service reconcile

### DIFF
--- a/packages/alchemy/src/AWS/ECS/Service.ts
+++ b/packages/alchemy/src/AWS/ECS/Service.ts
@@ -2792,6 +2792,20 @@ export const ServiceProvider = () =>
         const taskRoleArn =
           output?.taskRoleArn ??
           (yield* createTaskRoleIfNotExists({ id, roleName: taskRoleName }));
+
+        // `taskRoleManagedPolicyArns` is part of the inherited
+        // `TaskDefinitionConfig` surface — attach it exactly like the
+        // standalone Task provider does (its sibling
+        // `executionRoleManagedPolicyArns` is already honored below).
+        for (const policyArn of news.taskRoleManagedPolicyArns ?? []) {
+          yield* iam
+            .attachRolePolicy({
+              RoleName: taskRoleName,
+              PolicyArn: policyArn,
+            })
+            .pipe(Effect.catchTag("LimitExceededException", () => Effect.void));
+        }
+
         const executionRoleArn =
           output?.executionRoleArn ??
           (yield* ensureTaskExecutionRole({

--- a/packages/alchemy/src/AWS/ECS/Service.ts
+++ b/packages/alchemy/src/AWS/ECS/Service.ts
@@ -2794,17 +2794,21 @@ export const ServiceProvider = () =>
           (yield* createTaskRoleIfNotExists({ id, roleName: taskRoleName }));
 
         // `taskRoleManagedPolicyArns` is part of the inherited
-        // `TaskDefinitionConfig` surface — attach it exactly like the
-        // standalone Task provider does (its sibling
-        // `executionRoleManagedPolicyArns` is already honored below).
-        for (const policyArn of news.taskRoleManagedPolicyArns ?? []) {
-          yield* iam
-            .attachRolePolicy({
+        // `TaskDefinitionConfig` surface — attach it like the standalone
+        // Task provider does (its sibling `executionRoleManagedPolicyArns`
+        // is already honored below). `attachRolePolicy` is idempotent for
+        // already-attached ARNs; a `LimitExceededException` means the
+        // policy was NOT attached, so it propagates and fails the deploy
+        // rather than silently shipping a role with missing permissions.
+        yield* Effect.all(
+          (news.taskRoleManagedPolicyArns ?? []).map((policyArn) =>
+            iam.attachRolePolicy({
               RoleName: taskRoleName,
               PolicyArn: policyArn,
-            })
-            .pipe(Effect.catchTag("LimitExceededException", () => Effect.void));
-        }
+            }),
+          ),
+          { concurrency: "unbounded" },
+        );
 
         const executionRoleArn =
           output?.executionRoleArn ??

--- a/packages/alchemy/test/AWS/ECS/Service.test.ts
+++ b/packages/alchemy/test/AWS/ECS/Service.test.ts
@@ -7,6 +7,7 @@ import { isResourceState, State, type ResourceState } from "@/State";
 import * as Test from "@/Test/Alchemy";
 import * as ec2 from "@distilled.cloud/aws/ec2";
 import * as ecs from "@distilled.cloud/aws/ecs";
+import * as iam from "@distilled.cloud/aws/iam";
 import * as elbv2 from "@distilled.cloud/aws/elastic-load-balancing-v2";
 import { expect } from "alchemy-test";
 import * as Effect from "effect/Effect";
@@ -586,6 +587,74 @@ test.provider(
 
       yield* stack.destroy();
       yield* reclaimTaskDefinitionFamily(family);
+    }),
+  { timeout: 240_000 },
+);
+
+// Regression: the image-owning `ServiceProps` form inherits
+// `taskRoleManagedPolicyArns` from `TaskDefinitionConfig`, but reconcile
+// used to honor only its sibling `executionRoleManagedPolicyArns` — services
+// deployed with task roles silently missing their declared permissions.
+// Deploy an image-form service (desiredCount 0, no ingress) declaring an
+// AWS-managed policy, verify out of band that the policy is attached to the
+// task role, redeploy to prove the attach is idempotent, and verify destroy
+// detaches the policy and deletes the role.
+test.provider(
+  "attaches taskRoleManagedPolicyArns to the task role (image form)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const managedPolicyArn = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess";
+
+      const deployService = () =>
+        stack.deploy(
+          Effect.gen(function* () {
+            const cluster = yield* Cluster("TaskRolePolicyCluster", {
+              clusterName: "alchemy-test-ecs-service-task-role-policy",
+            });
+            return yield* Service("TaskRolePolicyService", {
+              cluster,
+              image: "busybox:stable",
+              command: ["sh", "-c", "while true; do sleep 30; done"],
+              port: 80,
+              desiredCount: 0,
+              taskRoleManagedPolicyArns: [managedPolicyArn],
+            });
+          }),
+        );
+
+      const created = yield* deployService();
+      const taskRoleName = created.taskRoleName;
+      if (!taskRoleName) {
+        return yield* Effect.die(
+          new Error("image-form service returned no taskRoleName"),
+        );
+      }
+
+      const listAttachedArns = iam
+        .listAttachedRolePolicies({ RoleName: taskRoleName })
+        .pipe(
+          Effect.map((r) => (r.AttachedPolicies ?? []).map((p) => p.PolicyArn)),
+        );
+
+      expect(yield* listAttachedArns).toContain(managedPolicyArn);
+
+      // Second deploy re-runs the attach against an already-attached ARN —
+      // `attachRolePolicy` is idempotent, so reconcile must not fail.
+      const updated = yield* deployService();
+      expect(updated.serviceArn).toEqual(created.serviceArn);
+      expect(yield* listAttachedArns).toContain(managedPolicyArn);
+
+      yield* stack.destroy();
+
+      // Gone-proof: destroy detached the managed policy and deleted the
+      // task role.
+      const roleGone = yield* iam.getRole({ RoleName: taskRoleName }).pipe(
+        Effect.map(() => false),
+        Effect.catchTag("NoSuchEntityException", () => Effect.succeed(true)),
+      );
+      expect(roleGone).toBe(true);
     }),
   { timeout: 240_000 },
 );


### PR DESCRIPTION
### Problem
The image-owning `ServiceProps` form inherits `TaskDefinitionConfig`, which declares both `taskRoleManagedPolicyArns` and `executionRoleManagedPolicyArns`. `Service`'s reconcile honors the execution-role prop but silently drops the task-role one — services deploy with task roles missing their declared permissions, and nothing fails until the workload's first AWS call is denied at runtime. (Hit in production: a worker's `ses:Send*`/`bedrock:InvokeModel*` policy was declared but never attached.)

### Fix
Attach `taskRoleManagedPolicyArns` in `Service`'s reconcile right after the task role is resolved:

```ts
yield* Effect.all(
  (news.taskRoleManagedPolicyArns ?? []).map((policyArn) =>
    iam.attachRolePolicy({ RoleName: taskRoleName, PolicyArn: policyArn }),
  ),
  { concurrency: "unbounded" },
);
```

Per review:

- Attaches run in parallel via `Effect.all` instead of a sequential loop.
- `LimitExceededException` is no longer swallowed — it means the policy was NOT attached, so it now fails the deploy instead of silently shipping a role with missing permissions. `attachRolePolicy` is idempotent for already-attached ARNs, so reconcile stays idempotent without the catch.

### Regression test
New live test in `Service.test.ts`: deploys an image-form service (`desiredCount: 0`, no ingress) declaring an AWS-managed policy, proves attachment out of band via `iam.listAttachedRolePolicies`, redeploys to prove the attach is idempotent (same `serviceArn`), and gone-proofs that destroy detaches the policy and deletes the task role.
