### PR TITLE
fix(aws): destroy converges in one pass with VPC-attached Lambdas

### DIFF
--- a/packages/alchemy/src/AWS/EC2/LingeringEnis.ts
+++ b/packages/alchemy/src/AWS/EC2/LingeringEnis.ts
@@ -1,0 +1,169 @@
+import * as ec2 from "@distilled.cloud/aws/ec2";
+import * as Effect from "effect/Effect";
+import * as Result from "effect/Result";
+
+/**
+ * Shared teardown accelerator for network interfaces that AWS releases
+ * *asynchronously* after their owning resource is deleted.
+ *
+ * The canonical case is a VPC-attached Lambda Function: `DeleteFunction`
+ * returns immediately, but the function's Hyperplane ENIs stay `in-use` in
+ * their subnets/security groups for several minutes, and Lambda's own reaper
+ * may not delete the detached ENI for up to ~20 minutes. Until the ENI is
+ * gone, `DeleteSubnet`/`DeleteSecurityGroup` fail with `DependencyViolation`
+ * — historically forcing users to run `destroy` twice, minutes apart.
+ *
+ * `retryWhileLingeringEnis` wraps a subnet/security-group delete call:
+ * on every `DependencyViolation` it observes the ENIs still occupying the
+ * resource, explicitly deletes any *detached* (status `available`) Lambda
+ * ENI instead of waiting for Lambda's reaper, and — while the blockers are
+ * exclusively Lambda ENIs that are provably on their way out — keeps waiting
+ * on an extended budget that covers AWS's worst-case release window. Any
+ * other lingering dependency keeps today's shorter budget.
+ */
+
+/**
+ * ENIs that their owning service tears down asynchronously and that are safe
+ * for us to delete once detached. Only Lambda Hyperplane ENIs qualify today:
+ * every other managed type (NAT gateways, VPC endpoints, ELB, EFS mount
+ * targets, ECS task ENIs) is deleted by the API call that deletes its owner
+ * — and their owners are proper alchemy resources ordered ahead of the
+ * subnet/SG by the deletion graph.
+ *
+ * Matching note (observed live): while attached, a Hyperplane ENI reports
+ * `InterfaceType: "lambda"` — but the moment Lambda detaches it, the type
+ * flips to plain `"interface"` and only the description (`AWS Lambda VPC
+ * ENI-{functionName}`) still identifies it. Match both, like Terraform does.
+ */
+const isReapableEni = (eni: ec2.NetworkInterface): boolean =>
+  eni.InterfaceType === "lambda" ||
+  (eni.Description?.startsWith("AWS Lambda VPC ENI") ?? false);
+
+export interface LingeringEniScope {
+  /** ENI filter naming the resource being deleted. */
+  readonly name: "subnet-id" | "group-id";
+  readonly value: string;
+}
+
+/**
+ * Observe ENIs still occupying the resource and delete any detached
+ * reapable ones. Best-effort by design: the reaper only accelerates the
+ * outer DependencyViolation retry, so an account that cannot describe or
+ * delete ENIs degrades to plain waiting instead of failing the destroy.
+ */
+const reapLingeringEnis = Effect.fn(function* (
+  scope: LingeringEniScope,
+  session: { note: (note: string) => Effect.Effect<void> },
+) {
+  const described = yield* ec2
+    .describeNetworkInterfaces({
+      Filters: [{ Name: scope.name, Values: [scope.value] }],
+    })
+    .pipe(Effect.catch(() => Effect.succeed({ NetworkInterfaces: [] })));
+
+  const lingering = (described.NetworkInterfaces ?? []).filter(isReapableEni);
+
+  let reaped = 0;
+  let pending = 0;
+  for (const eni of lingering) {
+    if (eni.Status !== "available" || eni.NetworkInterfaceId === undefined) {
+      pending += 1;
+      continue;
+    }
+    const outcome = yield* ec2
+      .deleteNetworkInterface({
+        NetworkInterfaceId: eni.NetworkInterfaceId,
+      })
+      .pipe(
+        Effect.as("deleted" as const),
+        // Already gone counts as progress; anything else (raced back to
+        // in-use, throttle, missing IAM permission) must not fail the
+        // destroy — reaping is purely an accelerator, so degrade to the
+        // outer retry's plain waiting.
+        Effect.catchTag("InvalidNetworkInterfaceID.NotFound", () =>
+          Effect.succeed("deleted" as const),
+        ),
+        Effect.catch(() => Effect.succeed("pending" as const)),
+      );
+    if (outcome === "deleted") {
+      yield* session.note(
+        `Deleted detached Lambda ENI ${eni.NetworkInterfaceId}`,
+      );
+      reaped += 1;
+    } else {
+      pending += 1;
+    }
+  }
+
+  return {
+    /** Reapable ENIs still occupying the resource after this pass. */
+    pendingReapable: pending,
+    /** Detached reapable ENIs actually deleted this pass. */
+    reaped,
+  };
+});
+
+/**
+ * Retry `deleteCall` while it fails with a dependency violation, reaping
+ * lingering ENIs between attempts.
+ *
+ * - Base budget (~12 min) matches the historical subnet schedule: fast
+ *   exponential start, capped at 30-second steps.
+ * - While the observed blockers include reapable ENIs (attached or just
+ *   reaped), the budget extends to ~25 min — Lambda's documented worst-case
+ *   ENI release window — because those blockers are guaranteed to clear.
+ */
+export const retryWhileLingeringEnis = <A, E extends { _tag: string }, R>(
+  deleteCall: Effect.Effect<A, E, R>,
+  options: {
+    scope: LingeringEniScope;
+    isDependencyViolation: (error: E) => boolean;
+    session: { note: (note: string) => Effect.Effect<void> };
+  },
+) =>
+  Effect.gen(function* () {
+    const BASE_BUDGET_MILLIS = 12 * 60 * 1000;
+    const EXTENDED_BUDGET_MILLIS = 25 * 60 * 1000;
+
+    let elapsedMillis = 0;
+    let sawReapable = false;
+
+    for (let attempt = 1; ; attempt++) {
+      const result = yield* Effect.result(deleteCall);
+      if (Result.isSuccess(result)) {
+        return result.success;
+      }
+      const error = result.failure;
+      if (!options.isDependencyViolation(error)) {
+        return yield* Effect.fail(error);
+      }
+
+      const { pendingReapable, reaped } = yield* reapLingeringEnis(
+        options.scope,
+        options.session,
+      );
+      if (reaped > 0) {
+        // An ENI just left — the next attempt has a real chance; skip the
+        // backoff sleep and try immediately.
+        continue;
+      }
+      sawReapable ||= pendingReapable > 0;
+
+      const budget = sawReapable ? EXTENDED_BUDGET_MILLIS : BASE_BUDGET_MILLIS;
+      if (elapsedMillis >= budget) {
+        return yield* Effect.fail(error);
+      }
+
+      yield* options.session.note(
+        pendingReapable > 0
+          ? `Waiting for AWS to release ${pendingReapable} lingering ENI(s)... (attempt ${attempt})`
+          : `Waiting for dependencies to clear... (attempt ${attempt})`,
+      );
+
+      // Fast exponential start capped at 30-second steps (the historical
+      // subnet schedule).
+      const delayMillis = Math.min(1000 * 1.5 ** (attempt - 1), 30_000);
+      yield* Effect.sleep(delayMillis);
+      elapsedMillis += delayMillis;
+    }
+  });

--- a/packages/alchemy/src/AWS/EC2/SecurityGroup.ts
+++ b/packages/alchemy/src/AWS/EC2/SecurityGroup.ts
@@ -11,6 +11,7 @@ import type { AccountID } from "../Environment.ts";
 import { AWSEnvironment } from "../Environment.ts";
 import type { Providers } from "../Providers.ts";
 import type { RegionID } from "../Region.ts";
+import { retryWhileLingeringEnis } from "./LingeringEnis.ts";
 import type { VpcId } from "./Vpc.ts";
 
 export type SecurityGroupId<ID extends string = string> = `sg-${ID}`;
@@ -681,34 +682,29 @@ export const SecurityGroupProvider = () =>
 
           yield* session.note(`Deleting Security Group: ${groupId}`);
 
-          yield* ec2
-            .deleteSecurityGroup({
-              GroupId: groupId,
-              DryRun: false,
-            })
-            .pipe(
-              Effect.catchTag("InvalidGroup.NotFound", () => Effect.void),
-              // Retry on dependency violations (e.g., ENIs still using the security group)
-              Effect.retry({
-                while: (e) => {
-                  return (
-                    e._tag === "DependencyViolation" ||
-                    (e._tag === "ValidationError" &&
-                      e.message?.includes("DependencyViolation"))
-                  );
-                },
-                schedule: Schedule.max([
-                  Schedule.fixed(5000),
-                  Schedule.recurs(30),
-                ]).pipe(
-                  Schedule.tap(({ attempt }) =>
-                    session.note(
-                      `Waiting for dependencies to clear... (attempt ${attempt})`,
-                    ),
-                  ),
-                ),
-              }),
-            );
+          // DependencyViolation means ENIs still reference the group — ALB,
+          // ECS task, or VPC-attached Lambda ENIs release minutes after the
+          // owning resource is deleted. Lambda Hyperplane ENIs are reaped
+          // explicitly between attempts (they otherwise linger up to ~20
+          // minutes and used to force a second `destroy` run).
+          yield* retryWhileLingeringEnis(
+            ec2
+              .deleteSecurityGroup({
+                GroupId: groupId,
+                DryRun: false,
+              })
+              .pipe(
+                Effect.catchTag("InvalidGroup.NotFound", () => Effect.void),
+              ),
+            {
+              scope: { name: "group-id", value: groupId },
+              isDependencyViolation: (e) =>
+                e._tag === "DependencyViolation" ||
+                (e._tag === "ValidationError" &&
+                  (e.message?.includes("DependencyViolation") ?? false)),
+              session,
+            },
+          );
 
           yield* session.note(`Security Group ${groupId} deleted`);
         }),

--- a/packages/alchemy/src/AWS/EC2/Subnet.ts
+++ b/packages/alchemy/src/AWS/EC2/Subnet.ts
@@ -7,6 +7,7 @@ import * as Stream from "effect/Stream";
 
 import type { ScopedPlanStatusSession } from "../../Cli/Cli.ts";
 import { isResolved, somePropsAreDifferent } from "../../Diff.ts";
+import { retryWhileLingeringEnis } from "./LingeringEnis.ts";
 import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
 import type { Providers } from "../Providers.ts";
@@ -597,40 +598,28 @@ export const SubnetProvider = () =>
 
           yield* session.note(`Deleting subnet: ${subnetId}`);
 
-          // 1. Attempt to delete subnet
-          yield* ec2
-            .deleteSubnet({
-              SubnetId: subnetId,
-              DryRun: false,
-            })
-            .pipe(
-              Effect.tapError(Effect.logDebug),
-              Effect.catchTag("InvalidSubnetID.NotFound", () => Effect.void),
-              // Retry on dependency violations (resources still being deleted).
-              // ENIs from a just-deleted ALB or CloudFront VPC origin can take
-              // several minutes to detach after the owning resource is gone, so
-              // budget ~12 min (fast exponential start, capped at 30s steps).
-              Effect.retry({
-                while: (e) => {
-                  // DependencyViolation means there are still dependent resources
-                  // This can happen if ENIs/instances are being deleted concurrently
-                  return e._tag === "DependencyViolation";
-                },
-                schedule: Schedule.max([
-                  Schedule.min([
-                    Schedule.exponential(1000, 1.5),
-                    Schedule.spaced("30 seconds"),
-                  ]),
-                  Schedule.recurs(30),
-                ]).pipe(
-                  Schedule.tap(({ attempt }) =>
-                    session.note(
-                      `Waiting for dependencies to clear... (attempt ${attempt})`,
-                    ),
-                  ),
-                ),
-              }),
-            );
+          // 1. Attempt to delete subnet. DependencyViolation means resources
+          // still occupy it — ENIs from a just-deleted ALB, CloudFront VPC
+          // origin, or a VPC-attached Lambda can take minutes to release
+          // after the owning resource is gone. Lambda Hyperplane ENIs are
+          // reaped explicitly between attempts (they otherwise linger up to
+          // ~20 minutes and used to force a second `destroy` run).
+          yield* retryWhileLingeringEnis(
+            ec2
+              .deleteSubnet({
+                SubnetId: subnetId,
+                DryRun: false,
+              })
+              .pipe(
+                Effect.tapError(Effect.logDebug),
+                Effect.catchTag("InvalidSubnetID.NotFound", () => Effect.void),
+              ),
+            {
+              scope: { name: "subnet-id", value: subnetId },
+              isDependencyViolation: (e) => e._tag === "DependencyViolation",
+              session,
+            },
+          );
 
           // 2. Wait for subnet to be fully deleted
           yield* waitForSubnetDeleted(subnetId, session);

--- a/packages/alchemy/src/AWS/Lambda/Function.ts
+++ b/packages/alchemy/src/AWS/Lambda/Function.ts
@@ -1420,8 +1420,10 @@ export default handler;
         // config untouched (precreate stub); `[]` explicitly clears mounts.
         fileSystemConfigs?: Lambda.FileSystemConfig[];
         // Effective VPC attachment (prop ∪ binding-channel requests).
-        // Defaults to `news.vpc` when omitted (precreate stub, before
-        // bindings are known).
+        // Omitted for the precreate stub: `news` is UNRESOLVED at precreate
+        // (Output-valued subnet/security-group ids would fail to serialize),
+        // and the stub doesn't need connectivity — `reconcile` attaches the
+        // resolved VPC config afterwards.
         vpc?: FunctionProps["vpc"];
         session: { note: (note: string) => Effect.Effect<void> };
       }) => Effect.Effect<
@@ -1438,7 +1440,7 @@ export default handler;
         functionName,
         preferUpdate,
         fileSystemConfigs,
-        vpc = news.vpc,
+        vpc,
         session,
       }: {
         id: string;

--- a/packages/alchemy/test/AWS/Lambda/VpcFunctionDestroy.test.ts
+++ b/packages/alchemy/test/AWS/Lambda/VpcFunctionDestroy.test.ts
@@ -1,0 +1,102 @@
+import * as AWS from "@/AWS";
+import * as Test from "@/Test/Alchemy";
+import * as EC2 from "@distilled.cloud/aws/ec2";
+import { expect } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
+import { fileURLToPath } from "node:url";
+
+const { test } = Test.make({ providers: AWS.providers() });
+
+const handlerPath = fileURLToPath(
+  new URL("./timeout-handler.ts", import.meta.url),
+);
+
+// Repro for https://github.com/xofromthemoon/alchemy-aws-demo — a VPC-attached
+// Lambda leaves Hyperplane ENIs in its subnets/security group after
+// DeleteFunction. AWS releases them asynchronously (up to ~20 minutes), which
+// used to outlive the Subnet/SecurityGroup DependencyViolation retry budgets
+// and fail the destroy, forcing users to run destroy multiple times. The
+// delete paths now reap detached Lambda ENIs explicitly so a single destroy
+// converges. Slow (minutes of AWS-side ENI release), so FAST-gated.
+test.provider.skipIf(!!process.env.FAST)(
+  "destroy converges in one pass with a VPC-attached function",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const program = Effect.gen(function* () {
+        const network = yield* AWS.EC2.Network("Network", {
+          cidrBlock: "10.42.0.0/16",
+          availabilityZones: 2,
+          nat: "none",
+        });
+
+        const sg = yield* AWS.EC2.SecurityGroup("FunctionSecurityGroup", {
+          vpcId: network.vpcId,
+          description: "VPC lambda destroy repro",
+          ingress: [
+            {
+              ipProtocol: "tcp",
+              fromPort: 443,
+              toPort: 443,
+              cidrIpv4: "10.42.0.0/16",
+              description: "intra-vpc https",
+            },
+          ],
+        });
+
+        const fn = yield* AWS.Lambda.Function("VpcFn", {
+          main: handlerPath,
+          handler: "handler",
+          isExternal: true,
+          url: false,
+          vpc: {
+            subnetIds: network.privateSubnetIds,
+            securityGroupIds: [sg.groupId],
+          },
+        });
+
+        return {
+          vpcId: network.vpcId,
+          privateSubnetIds: network.privateSubnetIds,
+          groupId: sg.groupId,
+          functionName: fn.functionName,
+        };
+      });
+
+      const deployed = yield* stack.deploy(program);
+
+      // The function's Hyperplane ENI(s) materialize in the private subnets
+      // shortly after the function goes Active — poll (describe is
+      // eventually consistent right after deploy). Note: attached Hyperplane
+      // ENIs report InterfaceType "lambda"; once detached they flip to plain
+      // "interface" and only the description identifies them.
+      const isLambdaEni = (eni: EC2.NetworkInterface): boolean =>
+        eni.InterfaceType === "lambda" ||
+        (eni.Description?.startsWith("AWS Lambda VPC ENI") ?? false);
+      const before = yield* EC2.describeNetworkInterfaces({
+        Filters: [{ Name: "vpc-id", Values: [deployed.vpcId] }],
+      }).pipe(
+        Effect.repeat({
+          schedule: Schedule.spaced("5 seconds"),
+          until: (page) => (page.NetworkInterfaces ?? []).some(isLambdaEni),
+          times: 36,
+        }),
+      );
+      expect((before.NetworkInterfaces ?? []).some(isLambdaEni)).toBe(true);
+
+      // One destroy must fully tear down: function, SG, subnets, VPC.
+      yield* stack.destroy();
+
+      const vpcs = yield* EC2.describeVpcs({
+        VpcIds: [deployed.vpcId],
+      }).pipe(
+        Effect.catchTag("InvalidVpcID.NotFound", () =>
+          Effect.succeed({ Vpcs: [] }),
+        ),
+      );
+      expect(vpcs.Vpcs ?? []).toHaveLength(0);
+    }),
+  { timeout: 30 * 60 * 1000 },
+);


### PR DESCRIPTION
Fixes the destroy failure reported with https://github.com/xofromthemoon/alchemy-aws-demo — destroying a stack with a VPC-attached Lambda failed with subnets/security groups stuck on `DependencyViolation` (`Waiting for dependencies to clear... (attempt 17)`), forcing users to run `destroy` multiple times.

Root cause: `DeleteFunction` returns immediately, but the function's Hyperplane ENIs stay `in-use` in their subnets/security group for minutes and AWS's own reaper can take 20+ minutes to delete them after they detach (reproduced live: ENIs detached ~4 min after function delete and were still undeleted 12+ min later). The Subnet retry budget (~12 min) and SecurityGroup budget (~2.5 min) both expired first, failing the destroy even though deletion ordering was correct.

- `EC2/LingeringEnis.ts`: shared `retryWhileLingeringEnis` — on every `DependencyViolation`, observe the ENIs still occupying the subnet/SG and explicitly delete detached Lambda ENIs instead of waiting for Lambda's reaper. While the blockers are Lambda ENIs (guaranteed to clear), the retry budget extends from ~12 min to ~25 min; other dependencies keep the base budget.

  ```ts
  // detached Hyperplane ENIs flip InterfaceType "lambda" -> "interface";
  // only the description still identifies them (same matching as Terraform)
  const isReapableEni = (eni) =>
    eni.InterfaceType === "lambda" ||
    eni.Description?.startsWith("AWS Lambda VPC ENI");
  ```

- `EC2/Subnet.ts`, `EC2/SecurityGroup.ts`: delete paths now retry through the reaper (SecurityGroup's budget was previously only 30×5s).

- `Lambda/Function.ts`: `precreate` no longer forwards `news.vpc` into `CreateFunction` — precreate props are unresolved, so an Output-valued subnet id crashed serialization (`ParseError: Expected string, got PrivateSubnet1.subnetId`). The stub is created without a VPC config; `reconcile` attaches the resolved config as before.

- `test/AWS/Lambda/VpcFunctionDestroy.test.ts`: live regression test (FAST-gated) — deploys Network + SG + VPC-attached function, asserts one `destroy` removes everything including the VPC. Failed before the fix with the exact symptoms from the report; passes in a single pass with it.
