### PR TITLE
fix(cloudflare/workers): enable strictExecutionOrder to prevent cross-chunk TDZ at startup

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -7,7 +7,6 @@ import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import type * as Layer from "effect/Layer";
 import * as Redacted from "effect/Redacted";
-import * as Bundle from "../../Bundle/Bundle.ts";
 import { type MemoOptions } from "../../Command/Memo.ts";
 import type { Dependencies } from "../../Dependencies.ts";
 import type { InputProps } from "../../Input.ts";
@@ -45,7 +44,7 @@ import type {
   WorkerBindingResource,
   WorkerBindings,
 } from "./WorkerBinding.ts";
-import { type ModuleRule } from "./WorkerBundle.ts";
+import { type ModuleRule, type WorkerBuildOptions } from "./WorkerBundle.ts";
 import {
   makeWorkerRuntimeContext,
   type WorkerRuntimeContext,
@@ -478,10 +477,13 @@ export interface WorkerProps<
    */
   routes?: WorkerRouteConfig[];
   /**
-   * Extra bundler options applied on top of the standard rolldown input/output
-   * options used to build this Worker. See {@link Bundle.BundleExtraOptions}.
+   * Extra bundler options applied on top of the standard rolldown
+   * input/output options used to build this Worker. Includes the generic
+   * bundle extras (pure-annotation packages, bundle analyzer) plus an
+   * `output` field of rolldown output overrides (e.g. `codeSplitting`
+   * groups) merged over Alchemy's defaults. See {@link WorkerBuildOptions}.
    */
-  build?: Bundle.BundleExtraOptions;
+  build?: WorkerBuildOptions;
   /**
    * Whether to bundle {@link main} with rolldown before upload.
    *

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerBundle.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerBundle.ts
@@ -20,6 +20,18 @@ import {
   type DurableObjectExport,
 } from "./DurableObject.ts";
 
+/**
+ * Bundler options for a Worker: the generic {@link Bundle.BundleExtraOptions}
+ * plus rolldown output overrides merged over Alchemy's defaults.
+ */
+export interface WorkerBuildOptions extends Bundle.BundleExtraOptions {
+  /**
+   * Rolldown output options merged over Alchemy's defaults. Use this to
+   * control chunking (`codeSplitting`), minification, etc.
+   */
+  output?: rolldown.OutputOptions;
+}
+
 export interface WorkerBundleOptions {
   id: string;
   main: string;
@@ -36,7 +48,7 @@ export interface WorkerBundleOptions {
         exports: Record<string, DurableObjectExport | WorkflowExport>;
       };
   stack: { name: string; stage: string };
-  extraOptions: Bundle.BundleExtraOptions | undefined;
+  extraOptions: WorkerBuildOptions | undefined;
 }
 
 export const WorkerBundle = Effect.gen(function* () {
@@ -99,6 +111,7 @@ export const WorkerBundle = Effect.gen(function* () {
       // graph was chunked. See DrizzleSchemaChunks.test.ts.
       strictExecutionOrder: true,
       dir: `.alchemy/bundles/${options.id}`,
+      ...options.extraOptions?.output,
     };
     return { inputOptions, outputOptions, extraOptions: options.extraOptions };
   });

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerBundle.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerBundle.ts
@@ -30,6 +30,13 @@ export interface WorkerBuildOptions extends Bundle.BundleExtraOptions {
    * control chunking (`codeSplitting`), minification, etc.
    */
   output?: rolldown.OutputOptions;
+  /**
+   * Forwarded to rolldown's `preserveEntrySignatures` input option. Some
+   * `output.codeSplitting` configurations require relaxing it (e.g.
+   * `includeDependenciesRecursively: false` needs `"allow-extension"`).
+   * Workers must keep their entry exports, so never pass `false`.
+   */
+  preserveEntrySignatures?: rolldown.InputOptions["preserveEntrySignatures"];
 }
 
 export interface WorkerBundleOptions {
@@ -60,6 +67,7 @@ export const WorkerBundle = Effect.gen(function* () {
     const realMain = yield* sanitizeMain(options.main);
     const inputOptions: rolldown.InputOptions = {
       input: realMain,
+      preserveEntrySignatures: options.extraOptions?.preserveEntrySignatures,
       // Forever-devtool native modules that vite/chokidar reference behind
       // runtime guards. Rolldown resolves before tree-shaking, so the dead
       // `require('../pkg')` (lightningcss < 1.32) and `require('fsevents')`

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerBundle.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerBundle.ts
@@ -89,6 +89,15 @@ export const WorkerBundle = Effect.gen(function* () {
       sourcemap: "hidden",
       minify: true,
       keepNames: true,
+      // Rolldown's default chunking can split top-level initializer modules
+      // (e.g. Drizzle `pgTable` schemas) away from the classes they read,
+      // and workerd then evaluates a reader before its imported binding is
+      // initialized — the script fails Cloudflare startup validation with
+      // `ScriptStartupError: Cannot access '<minified>' before
+      // initialization` (#749). `strictExecutionOrder` wraps cross-chunk
+      // modules so evaluation follows ESM semantics regardless of how the
+      // graph was chunked. See DrizzleSchemaChunks.test.ts.
+      strictExecutionOrder: true,
       dir: `.alchemy/bundles/${options.id}`,
     };
     return { inputOptions, outputOptions, extraOptions: options.extraOptions };

--- a/packages/alchemy/test/Cloudflare/Workers/DrizzleSchemaChunks.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/DrizzleSchemaChunks.test.ts
@@ -20,14 +20,17 @@ const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
 /**
  * Regression stack for https://github.com/alchemy-run/alchemy/issues/749.
  *
- * The `build.output.codeSplitting` groups force the chunk layout from the
- * issue: top-level Drizzle schema modules (`schema/*`, `auth/*`) in their own
- * `auth-*` chunk, `drizzle-orm` in a separate `drizzle-*` chunk. Without
- * WorkerBundle's default `strictExecutionOrder: true`, workerd evaluates the
- * schema chunk before drizzle's class bindings initialize and Cloudflare
- * rejects the upload with `ScriptStartupError: Cannot access '<minified>'
- * before initialization` — so the deploy in `beforeAll` is itself the
- * regression assertion.
+ * The `build` options force the *cyclic* chunk layout from the issue: the
+ * schema group captures only the schema modules
+ * (`includeDependenciesRecursively: false`), so `drizzle-orm` stays in the
+ * entry chunk and the graph becomes `worker.js -> auth-*.js -> worker.js`.
+ * ESM evaluation then runs the schema chunk before drizzle's class bindings
+ * initialize. Without WorkerBundle's default `strictExecutionOrder: true`,
+ * Cloudflare rejects the upload with `ScriptStartupError: Cannot access
+ * '<minified>' before initialization` — so the deploy in `beforeAll` is
+ * itself the regression assertion. (An acyclic split — e.g. drizzle in its
+ * own chunk imported by the schema chunk — would NOT regress: plain import
+ * order already evaluates it correctly.)
  */
 const Stack = Alchemy.Stack(
   "DrizzleSchemaChunksTestStack",
@@ -37,15 +40,18 @@ const Stack = Alchemy.Stack(
       main: fixtureMain,
       compatibility: { date: "2026-06-24", flags: ["nodejs_compat"] },
       build: {
+        // Required by `includeDependenciesRecursively: false`; rolldown
+        // rejects it under the default "strict".
+        preserveEntrySignatures: "allow-extension",
         output: {
+          cleanDir: true,
           codeSplitting: {
             groups: [
-              // Claim drizzle-orm first so the schema group can't
-              // recursively capture it into the same chunk. String tests
-              // are regex patterns; RegExp literals wouldn't survive the
-              // engine's props serialization.
-              { name: "drizzle", test: "drizzle-orm" },
-              { name: "auth", test: "drizzle-schema-chunks/(schema|auth)/" },
+              {
+                name: "auth",
+                test: "drizzle-schema-chunks/(schema|auth)/",
+                includeDependenciesRecursively: false,
+              },
             ],
           },
         },
@@ -60,28 +66,35 @@ const bundleDir = Effect.gen(function* () {
   return path.resolve(".alchemy/bundles/DrizzleSchemaChunks");
 });
 
-const stack = beforeAll(
+// `cleanDir: true` on the stack's output options drops chunks from previous
+// runs, so the chunk-layout assertions below can't pass on stale files.
+const stack = beforeAll(deploy(Stack));
+afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(Stack));
+
+test(
+  "code splitting options are applied and produce the cyclic layout",
   Effect.gen(function* () {
-    // Drop chunks from previous runs so the chunk-layout assertion below
-    // can't pass on stale files.
     const fs = yield* FileSystem.FileSystem;
-    yield* fs.remove(yield* bundleDir, { recursive: true }).pipe(Effect.ignore);
-    return yield* deploy(Stack);
+    const path = yield* Path.Path;
+    const dir = yield* bundleDir;
+    const files = yield* fs.readDirectory(dir);
+
+    // The schema modules landed in their own chunk...
+    const authChunk = files.find((f) => /^auth-.*\.js$/.test(f));
+    expect(authChunk).toBeDefined();
+
+    // ...which imports the entry back (drizzle-orm stayed in `worker.js`):
+    // the cyclic `worker.js <-> auth-*.js` graph that TDZ-crashed workerd
+    // startup in #749 before `strictExecutionOrder` became the default.
+    const authContent = yield* fs.readFileString(path.join(dir, authChunk!));
+    expect(authContent).toMatch(/from\s*"\.\/worker\.js"/);
   }),
 );
-afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(Stack));
 
 test(
   "worker with drizzle schema modules split into their own chunk deploys and serves (#749)",
   Effect.gen(function* () {
     const { url } = yield* stack;
-
-    // The forced split actually happened: a standalone schema chunk exists
-    // separately from the drizzle-orm chunk.
-    const fs = yield* FileSystem.FileSystem;
-    const files = yield* fs.readDirectory(yield* bundleDir);
-    expect(files.some((f) => /^auth-.*\.js$/.test(f))).toBe(true);
-    expect(files.some((f) => /^drizzle-.*\.js$/.test(f))).toBe(true);
 
     // The worker evaluated its cross-chunk schema at startup and serves.
     const client = yield* HttpClient.HttpClient;

--- a/packages/alchemy/test/Cloudflare/Workers/DrizzleSchemaChunks.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/DrizzleSchemaChunks.test.ts
@@ -1,0 +1,277 @@
+import * as Bundle from "@/Bundle/Bundle";
+import * as Cloudflare from "@/Cloudflare";
+import cloudflareRolldown from "@distilled.cloud/cloudflare-rolldown-plugin";
+import * as Test from "@/Test/Alchemy";
+import { expect } from "alchemy-test";
+import { fileURLToPath } from "node:url";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import { MinimumLogLevel } from "effect/References";
+import * as Schedule from "effect/Schedule";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import type * as rolldown from "rolldown";
+
+/**
+ * Matches schema modules in this fixture (`schema/*`, `auth/*`) — the
+ * standalone `auth-*` chunk shape from #749.
+ */
+const schemaModuleTest = /(?:^|\/|\\)(?:schema|auth)(?:\/|\\)/;
+
+const fixtureMain = fileURLToPath(
+  new URL("./fixtures/drizzle-schema-chunks/worker.ts", import.meta.url),
+);
+
+const { test } = Test.make({
+  providers: Cloudflare.providers(),
+});
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+/**
+ * Mirror {@link WorkerBundle} defaults — except `strictExecutionOrder`,
+ * which each case sets explicitly — then apply `codeSplitting` groups.
+ * Alchemy's public `Worker.build` does not forward output chunk controls
+ * (#749), so the repro drives {@link Bundle.build} directly and deploys the
+ * result as a prebuilt Worker (`bundle: false`).
+ */
+const buildWorkerLike = Effect.fn(function* (options: {
+  id: string;
+  codeSplitting: rolldown.OutputOptions["codeSplitting"];
+  strictExecutionOrder?: boolean;
+}) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const outDir = path.resolve(".alchemy/bundles", options.id);
+  yield* fs.makeDirectory(outDir, { recursive: true });
+
+  const output = yield* Bundle.build(
+    {
+      input: fixtureMain,
+      cwd: path.dirname(fixtureMain),
+      preserveEntrySignatures: "allow-extension",
+      external: ["lightningcss", "fsevents"],
+      plugins: [
+        cloudflareRolldown({
+          compatibilityDate: "2026-06-24",
+          compatibilityFlags: ["nodejs_compat"],
+        }),
+      ],
+      checks: {
+        unresolvedImport: false,
+        ineffectiveDynamicImport: false,
+      },
+    },
+    {
+      format: "esm",
+      sourcemap: false,
+      minify: true,
+      keepNames: true,
+      dir: outDir,
+      codeSplitting: options.codeSplitting,
+      strictExecutionOrder: options.strictExecutionOrder,
+    },
+  );
+
+  return {
+    outDir,
+    main: path.join(outDir, output.files[0].path),
+    jsFiles: output.files
+      .map((file) => file.path)
+      .filter((name) => name.endsWith(".js")),
+  };
+});
+
+const deployPrebuilt = (logicalId: string, main: string) =>
+  Cloudflare.Worker(logicalId, {
+    main,
+    bundle: false,
+    subdomain: { enabled: true },
+    compatibility: {
+      date: "2026-06-24",
+      flags: ["nodejs_compat"],
+    },
+  });
+
+const errorText = (error: unknown): string => {
+  if (error instanceof Error) {
+    return `${error.name}: ${error.message}\n${error.stack ?? ""}`;
+  }
+  if (error && typeof error === "object") {
+    const tag =
+      "_tag" in error && typeof error._tag === "string" ? error._tag : "";
+    const message =
+      "message" in error && typeof error.message === "string"
+        ? error.message
+        : "";
+    return `${tag} ${message} ${JSON.stringify(error)}`;
+  }
+  return String(error);
+};
+
+/**
+ * Repro for https://github.com/alchemy-run/alchemy/issues/749
+ *
+ * When Rolldown splits top-level Drizzle schema modules into a chunk away
+ * from `drizzle-orm` — and no execution-order guard is applied — Cloudflare
+ * rejects the Worker at script startup (`ScriptStartupError` / incomplete
+ * cross-chunk class bindings). `WorkerBundle` now defaults to
+ * `strictExecutionOrder: true`, which the next case shows fixes exactly
+ * this split; this case pins the underlying failure by omitting it.
+ */
+test.provider(
+  "Cloudflare rejects a Worker when schema chunks are split away from drizzle-orm (#749)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const built = yield* buildWorkerLike({
+        id: "drizzle-schema-chunks-auth-alone",
+        codeSplitting: {
+          groups: [
+            {
+              name: "auth",
+              test: schemaModuleTest,
+              includeDependenciesRecursively: false,
+            },
+          ],
+        },
+      });
+
+      // Sanity: we actually produced the standalone auth chunk.
+      expect(built.jsFiles.some((name) => name.startsWith("auth-"))).toBe(true);
+
+      const error = yield* stack
+        .deploy(
+          Effect.gen(function* () {
+            return yield* deployPrebuilt(
+              "DrizzleSchemaChunksAuthAlone",
+              built.main,
+            );
+          }),
+        )
+        .pipe(Effect.flip);
+
+      // Cloudflare surfaces this as ScriptStartupError; the underlying
+      // workerd message is either the classic TDZ form from the issue
+      // (`Cannot access '<minified>' before initialization`) or the closely
+      // related incomplete-binding form (`PgSerialBuilder is not a constructor`).
+      const text = errorText(error);
+      expect(text).toMatch(
+        /ScriptStartupError|not a constructor|before initialization|Class extends value undefined/i,
+      );
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 180_000 },
+);
+
+// Pins the fix: `strictExecutionOrder: true` (now the WorkerBundle default)
+// makes the identical bad split evaluate correctly in workerd.
+test.provider(
+  "strictExecutionOrder makes the same bad split deploy and serve (#749 fix)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const built = yield* buildWorkerLike({
+        id: "drizzle-schema-chunks-strict-order",
+        strictExecutionOrder: true,
+        codeSplitting: {
+          groups: [
+            {
+              name: "auth",
+              test: schemaModuleTest,
+              includeDependenciesRecursively: false,
+            },
+          ],
+        },
+      });
+
+      // Same standalone auth chunk as the failing case above.
+      expect(built.jsFiles.some((name) => name.startsWith("auth-"))).toBe(true);
+
+      const worker = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* deployPrebuilt(
+            "DrizzleSchemaChunksStrictOrder",
+            built.main,
+          );
+        }),
+      );
+
+      expect(worker.url).toBeDefined();
+      const client = yield* HttpClient.HttpClient;
+      const body = yield* client.get(worker.url!).pipe(
+        Effect.flatMap((res) => res.text),
+        Effect.repeat({
+          schedule: Schedule.exponential("500 millis"),
+          until: (b) => b.includes('"ok":true'),
+          times: 10,
+        }),
+        Effect.orDie,
+      );
+      expect(body).toContain('"ok":true');
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 180_000 },
+);
+
+test.provider(
+  "Cloudflare accepts the same Worker when drizzle-orm is grouped with schema modules (#749 workaround)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const built = yield* buildWorkerLike({
+        id: "drizzle-schema-chunks-together",
+        codeSplitting: {
+          groups: [
+            {
+              name: "drizzle-auth-schema",
+              test: (id) => /drizzle-orm/.test(id) || schemaModuleTest.test(id),
+              includeDependenciesRecursively: false,
+            },
+          ],
+        },
+      });
+
+      expect(
+        built.jsFiles.some((name) => name.startsWith("drizzle-auth-schema-")),
+      ).toBe(true);
+      expect(built.jsFiles.some((name) => name.startsWith("auth-"))).toBe(
+        false,
+      );
+
+      const worker = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* deployPrebuilt(
+            "DrizzleSchemaChunksTogether",
+            built.main,
+          );
+        }),
+      );
+
+      expect(worker.url).toBeDefined();
+      const client = yield* HttpClient.HttpClient;
+      // Fresh workers.dev URLs can serve placeholder HTML while propagating —
+      // poll until the fixture's JSON marker appears.
+      const body = yield* client.get(worker.url!).pipe(
+        Effect.flatMap((res) => res.text),
+        Effect.repeat({
+          schedule: Schedule.exponential("500 millis"),
+          until: (b) => b.includes('"ok":true'),
+          times: 10,
+        }),
+        Effect.orDie,
+      );
+      expect(body).toContain('"ok":true');
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 180_000 },
+);

--- a/packages/alchemy/test/Cloudflare/Workers/DrizzleSchemaChunks.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/DrizzleSchemaChunks.test.ts
@@ -1,277 +1,105 @@
-import * as Bundle from "@/Bundle/Bundle";
 import * as Cloudflare from "@/Cloudflare";
-import cloudflareRolldown from "@distilled.cloud/cloudflare-rolldown-plugin";
+import * as Alchemy from "@/index.ts";
 import * as Test from "@/Test/Alchemy";
 import { expect } from "alchemy-test";
-import { fileURLToPath } from "node:url";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
-import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
 import * as HttpClient from "effect/unstable/http/HttpClient";
-import type * as rolldown from "rolldown";
-
-/**
- * Matches schema modules in this fixture (`schema/*`, `auth/*`) — the
- * standalone `auth-*` chunk shape from #749.
- */
-const schemaModuleTest = /(?:^|\/|\\)(?:schema|auth)(?:\/|\\)/;
+import { fileURLToPath } from "node:url";
 
 const fixtureMain = fileURLToPath(
   new URL("./fixtures/drizzle-schema-chunks/worker.ts", import.meta.url),
 );
 
-const { test } = Test.make({
+const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Cloudflare.providers(),
 });
 
-const logLevel = Effect.provideService(
-  MinimumLogLevel,
-  process.env.DEBUG ? "Debug" : "Info",
+/**
+ * Regression stack for https://github.com/alchemy-run/alchemy/issues/749.
+ *
+ * The `build.output.codeSplitting` groups force the chunk layout from the
+ * issue: top-level Drizzle schema modules (`schema/*`, `auth/*`) in their own
+ * `auth-*` chunk, `drizzle-orm` in a separate `drizzle-*` chunk. Without
+ * WorkerBundle's default `strictExecutionOrder: true`, workerd evaluates the
+ * schema chunk before drizzle's class bindings initialize and Cloudflare
+ * rejects the upload with `ScriptStartupError: Cannot access '<minified>'
+ * before initialization` — so the deploy in `beforeAll` is itself the
+ * regression assertion.
+ */
+const Stack = Alchemy.Stack(
+  "DrizzleSchemaChunksTestStack",
+  { providers: Cloudflare.providers(), state: Cloudflare.state() },
+  Effect.gen(function* () {
+    const worker = yield* Cloudflare.Worker("DrizzleSchemaChunks", {
+      main: fixtureMain,
+      compatibility: { date: "2026-06-24", flags: ["nodejs_compat"] },
+      build: {
+        output: {
+          codeSplitting: {
+            groups: [
+              // Claim drizzle-orm first so the schema group can't
+              // recursively capture it into the same chunk. String tests
+              // are regex patterns; RegExp literals wouldn't survive the
+              // engine's props serialization.
+              { name: "drizzle", test: "drizzle-orm" },
+              { name: "auth", test: "drizzle-schema-chunks/(schema|auth)/" },
+            ],
+          },
+        },
+      },
+    });
+    return { url: worker.url.as<string>() };
+  }),
 );
 
-/**
- * Mirror {@link WorkerBundle} defaults — except `strictExecutionOrder`,
- * which each case sets explicitly — then apply `codeSplitting` groups.
- * Alchemy's public `Worker.build` does not forward output chunk controls
- * (#749), so the repro drives {@link Bundle.build} directly and deploys the
- * result as a prebuilt Worker (`bundle: false`).
- */
-const buildWorkerLike = Effect.fn(function* (options: {
-  id: string;
-  codeSplitting: rolldown.OutputOptions["codeSplitting"];
-  strictExecutionOrder?: boolean;
-}) {
-  const fs = yield* FileSystem.FileSystem;
+const bundleDir = Effect.gen(function* () {
   const path = yield* Path.Path;
-  const outDir = path.resolve(".alchemy/bundles", options.id);
-  yield* fs.makeDirectory(outDir, { recursive: true });
-
-  const output = yield* Bundle.build(
-    {
-      input: fixtureMain,
-      cwd: path.dirname(fixtureMain),
-      preserveEntrySignatures: "allow-extension",
-      external: ["lightningcss", "fsevents"],
-      plugins: [
-        cloudflareRolldown({
-          compatibilityDate: "2026-06-24",
-          compatibilityFlags: ["nodejs_compat"],
-        }),
-      ],
-      checks: {
-        unresolvedImport: false,
-        ineffectiveDynamicImport: false,
-      },
-    },
-    {
-      format: "esm",
-      sourcemap: false,
-      minify: true,
-      keepNames: true,
-      dir: outDir,
-      codeSplitting: options.codeSplitting,
-      strictExecutionOrder: options.strictExecutionOrder,
-    },
-  );
-
-  return {
-    outDir,
-    main: path.join(outDir, output.files[0].path),
-    jsFiles: output.files
-      .map((file) => file.path)
-      .filter((name) => name.endsWith(".js")),
-  };
+  return path.resolve(".alchemy/bundles/DrizzleSchemaChunks");
 });
 
-const deployPrebuilt = (logicalId: string, main: string) =>
-  Cloudflare.Worker(logicalId, {
-    main,
-    bundle: false,
-    subdomain: { enabled: true },
-    compatibility: {
-      date: "2026-06-24",
-      flags: ["nodejs_compat"],
-    },
-  });
-
-const errorText = (error: unknown): string => {
-  if (error instanceof Error) {
-    return `${error.name}: ${error.message}\n${error.stack ?? ""}`;
-  }
-  if (error && typeof error === "object") {
-    const tag =
-      "_tag" in error && typeof error._tag === "string" ? error._tag : "";
-    const message =
-      "message" in error && typeof error.message === "string"
-        ? error.message
-        : "";
-    return `${tag} ${message} ${JSON.stringify(error)}`;
-  }
-  return String(error);
-};
-
-/**
- * Repro for https://github.com/alchemy-run/alchemy/issues/749
- *
- * When Rolldown splits top-level Drizzle schema modules into a chunk away
- * from `drizzle-orm` — and no execution-order guard is applied — Cloudflare
- * rejects the Worker at script startup (`ScriptStartupError` / incomplete
- * cross-chunk class bindings). `WorkerBundle` now defaults to
- * `strictExecutionOrder: true`, which the next case shows fixes exactly
- * this split; this case pins the underlying failure by omitting it.
- */
-test.provider(
-  "Cloudflare rejects a Worker when schema chunks are split away from drizzle-orm (#749)",
-  (stack) =>
-    Effect.gen(function* () {
-      yield* stack.destroy();
-
-      const built = yield* buildWorkerLike({
-        id: "drizzle-schema-chunks-auth-alone",
-        codeSplitting: {
-          groups: [
-            {
-              name: "auth",
-              test: schemaModuleTest,
-              includeDependenciesRecursively: false,
-            },
-          ],
-        },
-      });
-
-      // Sanity: we actually produced the standalone auth chunk.
-      expect(built.jsFiles.some((name) => name.startsWith("auth-"))).toBe(true);
-
-      const error = yield* stack
-        .deploy(
-          Effect.gen(function* () {
-            return yield* deployPrebuilt(
-              "DrizzleSchemaChunksAuthAlone",
-              built.main,
-            );
-          }),
-        )
-        .pipe(Effect.flip);
-
-      // Cloudflare surfaces this as ScriptStartupError; the underlying
-      // workerd message is either the classic TDZ form from the issue
-      // (`Cannot access '<minified>' before initialization`) or the closely
-      // related incomplete-binding form (`PgSerialBuilder is not a constructor`).
-      const text = errorText(error);
-      expect(text).toMatch(
-        /ScriptStartupError|not a constructor|before initialization|Class extends value undefined/i,
-      );
-
-      yield* stack.destroy();
-    }).pipe(logLevel),
-  { timeout: 180_000 },
+const stack = beforeAll(
+  Effect.gen(function* () {
+    // Drop chunks from previous runs so the chunk-layout assertion below
+    // can't pass on stale files.
+    const fs = yield* FileSystem.FileSystem;
+    yield* fs.remove(yield* bundleDir, { recursive: true }).pipe(Effect.ignore);
+    return yield* deploy(Stack);
+  }),
 );
+afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(Stack));
 
-// Pins the fix: `strictExecutionOrder: true` (now the WorkerBundle default)
-// makes the identical bad split evaluate correctly in workerd.
-test.provider(
-  "strictExecutionOrder makes the same bad split deploy and serve (#749 fix)",
-  (stack) =>
-    Effect.gen(function* () {
-      yield* stack.destroy();
+test(
+  "worker with drizzle schema modules split into their own chunk deploys and serves (#749)",
+  Effect.gen(function* () {
+    const { url } = yield* stack;
 
-      const built = yield* buildWorkerLike({
-        id: "drizzle-schema-chunks-strict-order",
-        strictExecutionOrder: true,
-        codeSplitting: {
-          groups: [
-            {
-              name: "auth",
-              test: schemaModuleTest,
-              includeDependenciesRecursively: false,
-            },
-          ],
-        },
-      });
+    // The forced split actually happened: a standalone schema chunk exists
+    // separately from the drizzle-orm chunk.
+    const fs = yield* FileSystem.FileSystem;
+    const files = yield* fs.readDirectory(yield* bundleDir);
+    expect(files.some((f) => /^auth-.*\.js$/.test(f))).toBe(true);
+    expect(files.some((f) => /^drizzle-.*\.js$/.test(f))).toBe(true);
 
-      // Same standalone auth chunk as the failing case above.
-      expect(built.jsFiles.some((name) => name.startsWith("auth-"))).toBe(true);
-
-      const worker = yield* stack.deploy(
-        Effect.gen(function* () {
-          return yield* deployPrebuilt(
-            "DrizzleSchemaChunksStrictOrder",
-            built.main,
-          );
-        }),
-      );
-
-      expect(worker.url).toBeDefined();
-      const client = yield* HttpClient.HttpClient;
-      const body = yield* client.get(worker.url!).pipe(
-        Effect.flatMap((res) => res.text),
-        Effect.repeat({
-          schedule: Schedule.exponential("500 millis"),
-          until: (b) => b.includes('"ok":true'),
-          times: 10,
-        }),
-        Effect.orDie,
-      );
-      expect(body).toContain('"ok":true');
-
-      yield* stack.destroy();
-    }).pipe(logLevel),
-  { timeout: 180_000 },
-);
-
-test.provider(
-  "Cloudflare accepts the same Worker when drizzle-orm is grouped with schema modules (#749 workaround)",
-  (stack) =>
-    Effect.gen(function* () {
-      yield* stack.destroy();
-
-      const built = yield* buildWorkerLike({
-        id: "drizzle-schema-chunks-together",
-        codeSplitting: {
-          groups: [
-            {
-              name: "drizzle-auth-schema",
-              test: (id) => /drizzle-orm/.test(id) || schemaModuleTest.test(id),
-              includeDependenciesRecursively: false,
-            },
-          ],
-        },
-      });
-
-      expect(
-        built.jsFiles.some((name) => name.startsWith("drizzle-auth-schema-")),
-      ).toBe(true);
-      expect(built.jsFiles.some((name) => name.startsWith("auth-"))).toBe(
-        false,
-      );
-
-      const worker = yield* stack.deploy(
-        Effect.gen(function* () {
-          return yield* deployPrebuilt(
-            "DrizzleSchemaChunksTogether",
-            built.main,
-          );
-        }),
-      );
-
-      expect(worker.url).toBeDefined();
-      const client = yield* HttpClient.HttpClient;
-      // Fresh workers.dev URLs can serve placeholder HTML while propagating —
-      // poll until the fixture's JSON marker appears.
-      const body = yield* client.get(worker.url!).pipe(
-        Effect.flatMap((res) => res.text),
-        Effect.repeat({
-          schedule: Schedule.exponential("500 millis"),
-          until: (b) => b.includes('"ok":true'),
-          times: 10,
-        }),
-        Effect.orDie,
-      );
-      expect(body).toContain('"ok":true');
-
-      yield* stack.destroy();
-    }).pipe(logLevel),
+    // The worker evaluated its cross-chunk schema at startup and serves.
+    const client = yield* HttpClient.HttpClient;
+    const body = yield* client.get(url).pipe(
+      Effect.flatMap((res) => res.text),
+      Effect.retry({
+        schedule: Schedule.exponential("500 millis"),
+        times: 5,
+      }),
+      // Fresh workers.dev URLs can serve placeholder pages while propagating.
+      Effect.repeat({
+        schedule: Schedule.exponential("500 millis"),
+        until: (b) => b.includes('"ok":true'),
+        times: 10,
+      }),
+      Effect.orDie,
+    );
+    expect(body).toContain('"ok":true');
+  }),
   { timeout: 180_000 },
 );

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/drizzle-schema-chunks/README.md
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/drizzle-schema-chunks/README.md
@@ -20,11 +20,25 @@ Mirrors the reporter's monorepo shape:
 
 Small graphs stay single-chunk under Alchemy's default Worker bundler, so
 `DrizzleSchemaChunks.test.ts` deploys a stack whose `Cloudflare.Worker`
-*forces* the issue's chunk layout via `build.output.codeSplitting` groups —
-schema modules in a standalone `auth-*` chunk, `drizzle-orm` in its own
-chunk. Cloudflare's script-startup validation runs on exactly those chunks
-at upload, so the deploy itself is the regression assertion; the test then
-verifies the chunk layout on disk and fetches the worker.
+*forces* the issue's chunk layout via `build` options: the schema group
+captures only the schema modules (`includeDependenciesRecursively: false`),
+leaving `drizzle-orm` in the entry chunk. The resulting graph is **cyclic**
+(`worker.js -> auth-*.js -> worker.js`), so ESM evaluation runs the schema
+chunk before drizzle's class bindings initialize — the TDZ. Cloudflare's
+script-startup validation runs on exactly those chunks at upload, so the
+deploy itself is the regression assertion; the test then verifies the
+cyclic layout on disk and fetches the worker.
+
+The cycle is essential: an *acyclic* split (e.g. drizzle in its own chunk
+imported by the schema chunk) evaluates correctly under plain import order
+and never triggers the bug, with or without `strictExecutionOrder`. Setting
+`strictExecutionOrder: false` on the stack's `build.output` restores the
+exact issue error:
+
+```
+ScriptStartupError: Uncaught ReferenceError: Cannot access 'a' before initialization
+  at auth-BFaahPAe.js:1:110
+```
 
 ## The fix
 

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/drizzle-schema-chunks/README.md
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/drizzle-schema-chunks/README.md
@@ -16,23 +16,20 @@ Mirrors the reporter's monorepo shape:
 - `auth/*` — auth package tables that cross-import the db schema
 - `worker.ts` — Worker entry that imports the full graph
 
-## How the test reproduces it
+## How the test pins the fix
 
 Small graphs stay single-chunk under Alchemy's default Worker bundler, so
-`DrizzleSchemaChunks.test.ts`:
-
-1. Builds with Alchemy's rolldown pipeline (`Bundle.build`, same defaults as
-   `WorkerBundle`) while *forcing* the bad split via `output.codeSplitting`
-   (not yet exposed on `Worker.build`)
-2. Deploys the emitted multi-module graph with
-   `Cloudflare.Worker({ bundle: false })` so Cloudflare's script-startup
-   validation runs on the exact chunks
+`DrizzleSchemaChunks.test.ts` deploys a stack whose `Cloudflare.Worker`
+*forces* the issue's chunk layout via `build.output.codeSplitting` groups —
+schema modules in a standalone `auth-*` chunk, `drizzle-orm` in its own
+chunk. Cloudflare's script-startup validation runs on exactly those chunks
+at upload, so the deploy itself is the regression assertion; the test then
+verifies the chunk layout on disk and fetches the worker.
 
 ## The fix
 
 `WorkerBundle` sets `strictExecutionOrder: true` on its rolldown output
 options, which wraps cross-chunk modules so evaluation follows ESM semantics
-regardless of how the graph was chunked. The test pins this: the identical
-bad split deploys and serves once `strictExecutionOrder` is applied. The
-user-side `advancedChunks` grouping workaround from the issue is also
-covered but no longer necessary.
+regardless of how the graph was chunked. Before that default, this exact
+split failed Cloudflare startup validation. The user-side `advancedChunks`
+grouping workaround from the issue is no longer necessary.

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/drizzle-schema-chunks/README.md
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/drizzle-schema-chunks/README.md
@@ -1,0 +1,38 @@
+# drizzle-schema-chunks
+
+Fixture for [#749](https://github.com/alchemy-run/alchemy/issues/749).
+
+Cloudflare Worker `ScriptStartupError` after Alchemy/Rolldown bundling when
+top-level Drizzle schema modules are code-split into a chunk separate from
+`drizzle-orm`. Cross-chunk evaluation in workerd leaves class bindings
+incomplete (`PgSerialBuilder is not a constructor`, or the classic
+`Cannot access '<minified>' before initialization` TDZ).
+
+## Layout
+
+Mirrors the reporter's monorepo shape:
+
+- `schema/*` — db package tables (`pgTable` at module scope)
+- `auth/*` — auth package tables that cross-import the db schema
+- `worker.ts` — Worker entry that imports the full graph
+
+## How the test reproduces it
+
+Small graphs stay single-chunk under Alchemy's default Worker bundler, so
+`DrizzleSchemaChunks.test.ts`:
+
+1. Builds with Alchemy's rolldown pipeline (`Bundle.build`, same defaults as
+   `WorkerBundle`) while *forcing* the bad split via `output.codeSplitting`
+   (not yet exposed on `Worker.build`)
+2. Deploys the emitted multi-module graph with
+   `Cloudflare.Worker({ bundle: false })` so Cloudflare's script-startup
+   validation runs on the exact chunks
+
+## The fix
+
+`WorkerBundle` sets `strictExecutionOrder: true` on its rolldown output
+options, which wraps cross-chunk modules so evaluation follows ESM semantics
+regardless of how the graph was chunked. The test pins this: the identical
+bad split deploys and serves once `strictExecutionOrder` is applied. The
+user-side `advancedChunks` grouping workaround from the issue is also
+covered but no longer necessary.

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/drizzle-schema-chunks/auth/invitations.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/drizzle-schema-chunks/auth/invitations.ts
@@ -1,0 +1,13 @@
+import { integer, pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
+import { users } from "../schema/users.ts";
+
+/**
+ * Mirrors the issue #749 layout: auth package schema modules that construct
+ * Drizzle tables at module scope and cross-import the db schema.
+ */
+export const invitations = pgTable("invitations", {
+  id: serial("id").primaryKey(),
+  email: text("email").notNull(),
+  invitedBy: integer("invited_by").references(() => users.id),
+  createdAt: timestamp("created_at").defaultNow(),
+});

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/drizzle-schema-chunks/auth/workspace.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/drizzle-schema-chunks/auth/workspace.ts
@@ -1,0 +1,15 @@
+import { integer, pgTable, serial, text } from "drizzle-orm/pg-core";
+import { users } from "../schema/users.ts";
+import { invitations } from "./invitations.ts";
+
+export const workspaces = pgTable("workspaces", {
+  id: serial("id").primaryKey(),
+  name: text("name").notNull(),
+  ownerId: integer("owner_id").references(() => users.id),
+});
+
+export const workspaceInvites = pgTable("workspace_invites", {
+  id: serial("id").primaryKey(),
+  workspaceId: integer("workspace_id").references(() => workspaces.id),
+  invitationId: integer("invitation_id").references(() => invitations.id),
+});

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/drizzle-schema-chunks/schema/sessions.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/drizzle-schema-chunks/schema/sessions.ts
@@ -1,0 +1,10 @@
+import { integer, pgTable, serial, text } from "drizzle-orm/pg-core";
+import { users } from "./users.ts";
+
+export const sessions = pgTable("sessions", {
+  id: serial("id").primaryKey(),
+  userId: integer("user_id")
+    .notNull()
+    .references(() => users.id),
+  token: text("token").notNull(),
+});

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/drizzle-schema-chunks/schema/users.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/drizzle-schema-chunks/schema/users.ts
@@ -1,0 +1,12 @@
+import { pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
+
+/**
+ * Top-level `pgTable(...)` — evaluated at module init. When Rolldown puts
+ * this module in a separate chunk from `drizzle-orm`, workerd can observe
+ * incomplete cross-chunk bindings during startup (#749).
+ */
+export const users = pgTable("users", {
+  id: serial("id").primaryKey(),
+  email: text("email").notNull(),
+  createdAt: timestamp("created_at").defaultNow(),
+});

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/drizzle-schema-chunks/schema/waitlist.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/drizzle-schema-chunks/schema/waitlist.ts
@@ -1,0 +1,9 @@
+import { boolean, integer, pgTable, serial, text } from "drizzle-orm/pg-core";
+import { users } from "./users.ts";
+
+export const waitlist = pgTable("waitlist", {
+  id: serial("id").primaryKey(),
+  email: text("email").notNull(),
+  approved: boolean("approved").default(false),
+  referredBy: integer("referred_by").references(() => users.id),
+});

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/drizzle-schema-chunks/worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/drizzle-schema-chunks/worker.ts
@@ -1,0 +1,31 @@
+/**
+ * Plain Worker entry that imports a multi-module Drizzle schema graph with
+ * top-level `pgTable(...)` initializers — the shape that triggers #749 when
+ * Rolldown splits those schema modules into a chunk away from `drizzle-orm`.
+ *
+ * See `DrizzleSchemaChunks.test.ts` for the forced-split repro and the
+ * grouping workaround.
+ */
+import { invitations } from "./auth/invitations.ts";
+import { workspaces, workspaceInvites } from "./auth/workspace.ts";
+import { sessions } from "./schema/sessions.ts";
+import { users } from "./schema/users.ts";
+import { waitlist } from "./schema/waitlist.ts";
+
+export default {
+  async fetch() {
+    const tables = [
+      users,
+      sessions,
+      waitlist,
+      invitations,
+      workspaces,
+      workspaceInvites,
+    ];
+    return Response.json({
+      ok: true,
+      count: tables.length,
+      userCols: Object.keys(users),
+    });
+  },
+};


### PR DESCRIPTION
Closes #749

Rolldown's chunking can split top-level initializer modules (e.g. Drizzle `pgTable` schemas) into a chunk that forms a **cycle** with the entry chunk (`worker.js -> auth-*.js -> worker.js` when `drizzle-orm` stays in the entry). ESM evaluation then runs the schema chunk before drizzle's class bindings initialize, and the script fails Cloudflare startup validation:

```
ScriptStartupError: Uncaught ReferenceError: Cannot access 'a' before initialization
  at auth-BFaahPAe.js:1:110
```

The fix enables rolldown's `strictExecutionOrder` on `WorkerBundle`'s output options, which wraps cross-chunk modules so evaluation follows ESM semantics regardless of chunk boundaries:

```diff
 const outputOptions: rolldown.OutputOptions = {
   format: "esm",
   sourcemap: "hidden",
   minify: true,
   keepNames: true,
+  strictExecutionOrder: true,
   dir: `.alchemy/bundles/${options.id}`,
 };
```

Lambda's `codeSplitting: false` approach is not safe for Workers: Worker bundles rely on chunks to keep dynamically-imported Node/Bun-only modules from evaluating eagerly in workerd. `strictExecutionOrder` keeps the chunks and fixes only the evaluation order. This makes the user-side `advancedChunks` grouping workaround from the issue unnecessary.

`WorkerProps.build` now also forwards rolldown output overrides (merged over `WorkerBundle`'s defaults) plus `preserveEntrySignatures` — the issue's other ask, chunking was previously uncontrollable per Worker:

```ts
Cloudflare.Worker("Api", {
  main,
  build: {
    preserveEntrySignatures: "allow-extension",
    output: {
      codeSplitting: {
        groups: [{ name: "auth", test: "packages/(schema|auth)/", includeDependenciesRecursively: false }],
      },
    },
  },
});
```

Group `test` patterns are strings (compiled to regexes by rolldown) — RegExp literals don't survive props serialization.

### Repro / tests

`test/Cloudflare/Workers/DrizzleSchemaChunks.test.ts` + `fixtures/drizzle-schema-chunks/` mirror the reporter's monorepo shape (db `schema/*` + auth package tables with top-level `pgTable(...)` cross-imports). The test deploys a stack whose `Cloudflare.Worker` forces the cyclic chunk layout via `build` options. Cloudflare's startup validation runs on exactly those chunks at upload, so the deploy is itself the regression assertion; the test also verifies the cyclic layout on disk (`auth-*.js` importing `./worker.js` back) and fetches the worker.

The cycle is essential: an acyclic split (e.g. drizzle in its own chunk imported by the schema chunk) evaluates correctly under plain import order and never triggers the bug. Verified live that flipping `strictExecutionOrder: false` on the stack restores the exact `ScriptStartupError` above.

Passes live, plus `WorkerBundle.test.ts` (CJS-require conversion + deploy integration) and `RandomEnvLocal.test.ts` (local workerd path) are green with the new default.
