### PR TITLE
fix(core): keep branded primitives opaque in ToOutput

### DIFF
--- a/packages/alchemy/src/Output.ts
+++ b/packages/alchemy/src/Output.ts
@@ -12,7 +12,7 @@ import { RuntimeContext, sanitizeKey } from "./RuntimeContext.ts";
 import { Stack } from "./Stack.ts";
 import { Stage } from "./Stage.ts";
 import * as State from "./State/State.ts";
-import { isPrimitive } from "./Util/data.ts";
+import { isPrimitive, type Primitive } from "./Util/data.ts";
 
 const inspect = Symbol.for("nodejs.util.inspect.custom");
 
@@ -73,16 +73,24 @@ export interface Output<A = any, Req = any> extends Pipeable {
 
 export interface Accessor<A> extends Effect.Effect<A> {}
 
-export type ToOutput<A, Req = never> = [Extract<A, object>] extends [never]
-  ? Output<A, Req>
-  : [Extract<A, any[]>] extends [never]
-    ? ObjectExpr<
-        {
-          [attr in keyof A]: A[attr];
-        },
-        Req
-      >
-    : ArrayExpr<Extract<A, any[]>, Req>;
+export type ToOutput<A, Req = never> =
+  // Branded primitives (`string & Brand<"...">`) are assignable to `object`
+  // via the brand intersection, so they must short-circuit to a plain Output
+  // before the object check — otherwise they explode into an ObjectExpr
+  // mapped over every String/Number method. Date is opaque for the same
+  // reason (mirrors AttrOutput in Resource.ts).
+  [A] extends [Primitive | Date]
+    ? Output<A, Req>
+    : [Extract<A, object>] extends [never]
+      ? Output<A, Req>
+      : [Extract<A, any[]>] extends [never]
+        ? ObjectExpr<
+            {
+              [attr in keyof A]: A[attr];
+            },
+            Req
+          >
+        : ArrayExpr<Extract<A, any[]>, Req>;
 
 export const ExprSymbol = Symbol.for("alchemy/Expr");
 

--- a/packages/alchemy/test/types/BrandedTypes.ts
+++ b/packages/alchemy/test/types/BrandedTypes.ts
@@ -1,0 +1,73 @@
+import { Action } from "@/Action.ts";
+import type { Input } from "@/Input.ts";
+import type * as Output from "@/Output.ts";
+import type * as Brand from "effect/Brand";
+import * as Effect from "effect/Effect";
+import * as S from "effect/Schema";
+
+// Branded primitives (effect/Brand or Schema.brand) must stay opaque
+// Outputs. Before the `[A] extends [Primitive]` short-circuit in
+// `ToOutput`, `string & Brand<..>` matched `Extract<A, object>` (the brand
+// is an object-typed intersection member) and exploded into an ObjectExpr
+// mapped over every String method.
+
+type UserId = string & Brand.Brand<"UserId">;
+
+const OrderId = S.String.pipe(S.brand("OrderId"));
+type OrderId = typeof OrderId.Type;
+
+type PortNum = number & Brand.Brand<"PortNum">;
+
+// --- ToOutput keeps branded primitives as plain Output ---
+type NotExploded<T> = "charAt" extends keyof T
+  ? false
+  : "toFixed" extends keyof T
+    ? false
+    : true;
+
+declare const t1: NotExploded<Output.ToOutput<UserId, never>>;
+declare const t2: NotExploded<Output.ToOutput<OrderId, never>>;
+declare const t3: NotExploded<Output.ToOutput<PortNum, never>>;
+const _t1: true = t1;
+const _t2: true = t2;
+const _t3: true = t3;
+
+// branded primitive Output is assignable where the plain Output is expected
+declare const brandedOut: Output.ToOutput<UserId, never>;
+const _o1: Output.Output<UserId, never> = brandedOut;
+
+// --- objects still upgrade to ObjectExpr, and their branded props stay opaque ---
+type Attrs = { id: UserId; nested?: { orderId: OrderId } };
+declare const attrs: Output.ToOutput<Attrs, never>;
+const idOut = attrs.id;
+declare const t4: NotExploded<typeof idOut>;
+const _t4: true = t4;
+const _o2: Output.Output<UserId, never> = idOut;
+
+// arrays still upgrade to ArrayExpr
+declare const arr: Output.ToOutput<UserId[], never>;
+const first = arr[0];
+declare const t5: NotExploded<typeof first>;
+const _t5: true = t5;
+
+// --- Input accepts branded values without expanding them ---
+declare const uid: UserId;
+declare const uidOut: Output.Output<UserId>;
+const _i1: Input<UserId> = uid;
+const _i2: Input<UserId> = uidOut;
+
+// --- Action outputs carrying branded types stay opaque ---
+const MintId = Action(
+  "MintId",
+  Effect.fn(function* (_input: { seed: string }) {
+    return { userId: uid, plain: "x" as string };
+  }),
+);
+
+const _program = Effect.gen(function* () {
+  const minted = yield* MintId({ seed: "s" });
+  const mintedId = minted.userId;
+  const t6: NotExploded<typeof mintedId> = true;
+  const _o3: Output.Output<UserId, never> = mintedId;
+  return [t6, _o3] as const;
+});


### PR DESCRIPTION
Branded primitives used in Action outputs exploded into `ObjectExpr` mapped over every `String`/`Number` method, because `string & Brand<"...">` is assignable to `object` through the brand intersection and `ToOutput` classified with `Extract<A, object>`.

```ts
type UserId = string & Brand.Brand<"UserId">;

const MintId = Action("MintId", Effect.fn(function* (_: { seed: string }) {
  return { userId: "u1" as UserId };
}));

const minted = yield* MintId({ seed: "s" });
minted.userId; // was: ObjectExpr<string & Brand<"UserId">> with charAt, slice, ...
               // now: Output<UserId>
```

Fix mirrors the existing `AttrOutput` guard in `Resource.ts` — short-circuit before the object check:

```diff
-export type ToOutput<A, Req = never> = [Extract<A, object>] extends [never]
-  ? Output<A, Req>
+export type ToOutput<A, Req = never> =
+  [A] extends [Primitive | Date]
+    ? Output<A, Req>
+    : [Extract<A, object>] extends [never]
+      ? Output<A, Req>
```

- Objects still upgrade to `ObjectExpr`, arrays to `ArrayExpr`; branded props reached through a nested `ObjectExpr` also stay opaque since it recurses through `ToOutput`.
- `Input<T>` needed no change — its `T extends Primitive` guard already matches branded primitives.
- Type test at `packages/alchemy/test/types/BrandedTypes.ts` covers `effect/Brand` strings, `Schema.brand` strings, branded numbers, nested access, arrays, `Input` assignability, and the Action scenario; all explosion assertions fail without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
