### PR TITLE
 fix(cloudflare/workers): encrypt Output env secrets and preserve inference

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/InferEnv.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/InferEnv.ts
@@ -3,6 +3,7 @@
 import type * as Effect from "effect/Effect";
 import type { Redacted } from "effect/Redacted";
 import type * as Stream from "effect/Stream";
+import type { Output } from "../../Output.ts";
 // Aliased so the ambient Cloudflare `Rpc` namespace (from
 // @cloudflare/workers-types, referenced above) stays reachable for
 // `Rpc.DurableObjectBranded`.
@@ -54,7 +55,9 @@ export type GetBindingType<T> =
     : // `Worker.URL` (an Effect resolving to a deferred string accessor) needs
       // no case of its own: the generic Effect unwrap below reduces it to
       // `string` via the fallthrough.
-      T extends Effect.Effect<infer A, infer _E, infer _R>
+      T extends
+          | Output<infer A, infer _Req>
+          | Effect.Effect<infer A, infer _E, infer _R>
       ? GetBindingType<A>
       : T extends FlagshipNs.App
         ? Flagship

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -11,6 +11,7 @@ import { type MemoOptions } from "../../Command/Memo.ts";
 import type { Dependencies } from "../../Dependencies.ts";
 import type { InputProps } from "../../Input.ts";
 import type { Named, Tag } from "../../Named.ts";
+import type * as Output from "../../Output.ts";
 import {
   Platform,
   type Main,
@@ -278,6 +279,13 @@ export type WorkerBindingProps = {
     | Effect.Effect<WorkerBindingResource, any, any>;
 };
 
+type Unwrap<T> = T extends Output.Output<infer A, infer _Req> ? A : T;
+
+// NOTE: `Worker<NormalizedBindings<...>>` must provably satisfy the
+// `WorkerBindings` constraint for *generic* `Bindings`, which restricts the
+// shapes usable here: conditional checks on the naked parameter `T` and an
+// outermost `Extract<..., WorkerBindingResource>` are provable; e.g.
+// `Unwrap<T> extends ...` as a check type is not.
 export type NormalizedBindings<
   Bindings extends WorkerBindingProps = {},
   AssetsConfig extends WorkerAssetsConfig | undefined = undefined,
@@ -287,10 +295,10 @@ export type NormalizedBindings<
     any,
     any
   >
-    ? T extends Redacted.Redacted<infer T> | Config.Config<infer T>
-      ? T
-      : T
-    : Extract<Bindings[B], WorkerBindingResource>;
+    ? T extends Redacted.Redacted<infer V> | Config.Config<infer V>
+      ? V
+      : Unwrap<T>
+    : Extract<Unwrap<Bindings[B]>, WorkerBindingResource>;
 } & (undefined extends AssetsConfig ? {} : { ASSETS: Assets });
 
 export type WorkerAssetsConfig = string | AssetsProps | AssetsWithHash;
@@ -444,6 +452,11 @@ export interface WorkerProps<
    *   [Secrets & env](/cloudflare/security/secrets-env).
    * - Literal values — routed by shape: `Redacted<string>` →
    *   `secret_text`, `string` → `plain_text`, anything else → `json`.
+   * - `Output` values that resolve to a plain env value (e.g.
+   *   `Alchemy.makeRandom`) — classified at deploy time by their
+   *   resolved value using the literal rules above. Whole-resource
+   *   Outputs (`Output.of(bucket)`) are rejected at deploy time; bind
+   *   the resource itself instead.
    *
    * In Effect-native Workers you can alternatively `yield*` a
    * `Config` in the Init phase to register the binding implicitly;

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
@@ -75,9 +75,22 @@ export const bindWorkerAsyncBindings = Effect.fn(function* (
           : bindingEff
       ) as WorkerBindingResource;
 
-      const bindingMeta = toBinding(bindingName, binding);
+      const bindingMeta:
+        | BindingSpec
+        | Output.Output<WorkerBinding>
+        | undefined = toBinding(bindingName, binding);
 
       if (Output.isOutput(bindingMeta)) {
+        // A whole-resource Output resolves to the resource's raw attributes;
+        // uploading those as a plaintext json env var is never intended.
+        // This cannot be rejected at compile time (`Input<T>` admits any
+        // Output whose A is structurally Json), so this guard is the
+        // enforcement point.
+        if (Output.isResourceExpr(binding) || Output.isRefExpr(binding)) {
+          return yield* Effect.die(
+            `Cannot bind whole-resource Output "${bindingName}": pass the resource (or a typed ref) directly, or bind one of its attribute Outputs`,
+          );
+        }
         // Deferred classification (see `toBinding`'s Output arm): the engine
         // resolves the Output inside the binding data before the Worker
         // provider reads it.
@@ -117,14 +130,10 @@ export const bindWorkerAsyncBindings = Effect.fn(function* (
             : undefined,
         });
       } else {
-        // A whole-resource Output resolves to the resource's raw attributes;
-        // uploading those as a plaintext json env var is never intended.
-        // This cannot be rejected at compile time (`Input<T>` admits any
-        // Output whose A is structurally Json), so this guard is the
-        // enforcement point.
-        return yield* Effect.die(
-          `Cannot bind whole-resource Output "${bindingName}": pass the resource (or a typed ref) directly, or bind one of its attribute Outputs`,
-        );
+        // Defensive catch-all: `toBinding` currently always classifies
+        // (its final arm is the `json` fallback), but keep the branch so a
+        // future gap fails loudly instead of silently skipping the binding.
+        return yield* Effect.die(`Unknown binding type: ${bindingName}`);
       }
     }
   }
@@ -252,13 +261,14 @@ const toValueBinding = (
  * `json` fallback and deploy e.g. a resolved `Redacted` secret as an
  * unencrypted json binding. Resource refs never land in the Output arm:
  * they surface their target's `Type` statically, so a native classifier
- * (kv_namespace, r2_bucket, ...) already matched above. Returns `undefined`
- * for a whole-resource Output, which the caller rejects.
+ * (kv_namespace, r2_bucket, ...) already matched above. Whole-resource
+ * Outputs also land here (lazily, nothing is resolved); the caller rejects
+ * them before the returned Output is ever bound.
  */
 const toBinding = (
   bindingName: string,
   binding: WorkerBindingResource,
-): BindingSpec | Output.Output<WorkerBinding, unknown> | undefined => {
+): BindingSpec | Output.Output<WorkerBinding, unknown> => {
   if (typeof binding === "string" || Redacted.isRedacted(binding)) {
     return toValueBinding(bindingName, binding);
   } else if (isAssets(binding)) {
@@ -431,9 +441,6 @@ const toBinding = (
       name: bindingName,
     };
   } else if (Output.isOutput(binding)) {
-    if (Output.isResourceExpr(binding) || Output.isRefExpr(binding)) {
-      return undefined;
-    }
     return Output.map(binding, (value: Json | Redacted.Redacted<Json>) =>
       toValueBinding(bindingName, value),
     );

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
@@ -1,5 +1,6 @@
 import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
+import type { Json } from "effect/Schema";
 import type { InputProps } from "../../Input.ts";
 import * as Output from "../../Output.ts";
 import type { ResourceBinding } from "../../Resource.ts";
@@ -74,10 +75,15 @@ export const bindWorkerAsyncBindings = Effect.fn(function* (
           : bindingEff
       ) as WorkerBindingResource;
 
-      let bindingMeta: InputProps<WorkerBinding> | undefined = toBinding(
-        bindingName,
-        binding,
-      );
+      const bindingMeta = toBinding(bindingName, binding);
+
+      if (Output.isOutput(bindingMeta)) {
+        // Deferred classification (see `toBinding`'s Output arm): the engine
+        // resolves the Output inside the binding data before the Worker
+        // provider reads it.
+        yield* resource.bind`${bindingName}`({ bindings: [bindingMeta] });
+        continue;
+      }
 
       if (bindingMeta) {
         let resolvedBindingMeta: InputProps<WorkerBinding> = bindingMeta;
@@ -111,7 +117,14 @@ export const bindWorkerAsyncBindings = Effect.fn(function* (
             : undefined,
         });
       } else {
-        return yield* Effect.die(`Unknown binding type: ${bindingName}`);
+        // A whole-resource Output resolves to the resource's raw attributes;
+        // uploading those as a plaintext json env var is never intended.
+        // This cannot be rejected at compile time (`Input<T>` admits any
+        // Output whose A is structurally Json), so this guard is the
+        // enforcement point.
+        return yield* Effect.die(
+          `Cannot bind whole-resource Output "${bindingName}": pass the resource (or a typed ref) directly, or bind one of its attribute Outputs`,
+        );
       }
     }
   }
@@ -198,31 +211,56 @@ const bindContainerClass = Effect.fn(function* (
 
 type BindingSpec = InputProps<WorkerBinding>;
 
-const toBinding = (
+/**
+ * Classify a plain env value (string / Redacted / Json) into its wire
+ * binding. Called by {@link toBinding} both eagerly (literal values) and
+ * deferred (the resolved value of an Output env entry).
+ */
+const toValueBinding = (
   bindingName: string,
-  binding: WorkerBindingResource,
-): BindingSpec => {
-  if (typeof binding === "string") {
+  value: Json | Redacted.Redacted<Json>,
+): WorkerBinding => {
+  if (typeof value === "string") {
     return {
       type: "plain_text",
       name: bindingName,
-      text: binding,
+      text: value,
     };
-  } else if (Redacted.isRedacted(binding)) {
-    const val = Redacted.value(binding);
-    if (typeof val === "string") {
-      return {
-        type: "secret_text",
-        name: bindingName,
-        text: val,
-      };
-    } else {
-      return {
-        type: "secret_text",
-        name: bindingName,
-        text: JSON.stringify(val),
-      };
-    }
+  }
+  if (Redacted.isRedacted(value)) {
+    const val = Redacted.value(value);
+    return {
+      type: "secret_text",
+      name: bindingName,
+      text: typeof val === "string" ? val : JSON.stringify(val),
+    };
+  }
+  return {
+    type: "json",
+    name: bindingName,
+    json: value,
+  };
+};
+
+/**
+ * Classify a binding into its wire shape.
+ *
+ * An Output that no native classifier recognized resolves to a plain env
+ * value, unknown until the engine resolves it, so its classification
+ * (plain_text vs secret_text vs json) is deferred to resolution time via
+ * {@link toValueBinding} — classifying eagerly would fall through to the
+ * `json` fallback and deploy e.g. a resolved `Redacted` secret as an
+ * unencrypted json binding. Resource refs never land in the Output arm:
+ * they surface their target's `Type` statically, so a native classifier
+ * (kv_namespace, r2_bucket, ...) already matched above. Returns `undefined`
+ * for a whole-resource Output, which the caller rejects.
+ */
+const toBinding = (
+  bindingName: string,
+  binding: WorkerBindingResource,
+): BindingSpec | Output.Output<WorkerBinding, unknown> | undefined => {
+  if (typeof binding === "string" || Redacted.isRedacted(binding)) {
+    return toValueBinding(bindingName, binding);
   } else if (isAssets(binding)) {
     return {
       type: "assets",
@@ -392,6 +430,13 @@ const toBinding = (
       type: "worker_loader",
       name: bindingName,
     };
+  } else if (Output.isOutput(binding)) {
+    if (Output.isResourceExpr(binding) || Output.isRefExpr(binding)) {
+      return undefined;
+    }
+    return Output.map(binding, (value: Json | Redacted.Redacted<Json>) =>
+      toValueBinding(bindingName, value),
+    );
   } else {
     return {
       type: "json",

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerBinding.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerBinding.ts
@@ -3,6 +3,7 @@ import * as Config from "effect/Config";
 import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import type { Json } from "effect/Schema";
+import type * as Output from "../../Output.ts";
 import type { Rpc } from "../../Rpc.ts";
 import { isYieldableEffectLike } from "../../Util/effect.ts";
 import type { Gateway as AiGateway } from "../AI/Gateway.ts";
@@ -86,6 +87,14 @@ export type WorkerBindingResource =
   | Json
   | Redacted.Redacted<Json>
   | Config.Config<Json>
+  // Outputs that resolve to a plain env value (e.g. `Alchemy.makeRandom`,
+  // `Output.literal`), classified by their resolved value at deploy time.
+  // Whole-resource Outputs (`Output.of(bucket)`) cannot be excluded here:
+  // `Input<T>` wraps this whole union in `Output<T>`, so any Output whose
+  // A is structurally Json (most resource attribute shapes) is admitted
+  // upstream regardless of this arm. `bindWorkerAsyncBindings` rejects
+  // them at deploy time instead.
+  | Output.Output<Json | Redacted.Redacted<Json>, unknown>
   // CF resources
   | Assets
   | Bucket

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerEnv.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerEnv.test.ts
@@ -1,5 +1,7 @@
+import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
 import * as Cloudflare from "@/Cloudflare/index.ts";
 import * as Test from "@/Test/Alchemy";
+import * as workers from "@distilled.cloud/cloudflare/workers";
 import { describe, expect } from "alchemy-test";
 import * as Effect from "effect/Effect";
 import { MinimumLogLevel } from "effect/References";
@@ -51,6 +53,7 @@ describe.concurrent("Cloudflare.Worker env bindings", () => {
         OBJ: { nested: { value: "ok" }, count: 7 },
         ARR: [1, 2, 3],
         OUTPUT_STR: "output-str",
+        RANDOM_IS_HEX: true,
         SECRET_STR: "shh",
         SECRET_JSON: { token: "abc", scopes: ["read", "write"] },
         CONFIG_STR: CONFIG_STR_VALUE,
@@ -63,6 +66,29 @@ describe.concurrent("Cloudflare.Worker env bindings", () => {
         },
       });
     }).pipe(logLevel),
+  );
+
+  test.provider(
+    "Output env values classify by resolved value on the wire",
+    () =>
+      Effect.gen(function* () {
+        const { asyncWorkerName } = yield* stack;
+        const { accountId } = yield* yield* CloudflareEnvironment;
+
+        const settings = yield* workers.getScriptScriptAndVersionSetting({
+          accountId,
+          scriptName: asyncWorkerName,
+        });
+        // Output<Redacted<string>> (Alchemy.Random) must deploy encrypted,
+        // never as a plaintext json binding.
+        expect(settings.bindings).toContainEqual(
+          expect.objectContaining({ type: "secret_text", name: "RANDOM" }),
+        );
+        // Output<string> resolves to a string, so it lands as plain_text.
+        expect(settings.bindings).toContainEqual(
+          expect.objectContaining({ type: "plain_text", name: "OUTPUT_STR" }),
+        );
+      }).pipe(logLevel),
   );
 
   test(

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/env/async.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/env/async.ts
@@ -15,6 +15,7 @@ export default {
         OBJ: env.OBJ,
         ARR: env.ARR,
         OUTPUT_STR: env.OUTPUT_STR,
+        RANDOM_IS_HEX: /^[0-9a-f]{64}$/.test(env.RANDOM),
         SECRET_STR: env.SECRET_STR,
         // Redacted<Json> is JSON-stringified into secret_text on the way in,
         // so the async runtime sees a string here. Parse it back so the

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/env/stack.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/env/stack.ts
@@ -20,6 +20,7 @@ export const AsyncWorker = Cloudflare.Worker("EnvAsyncWorker", {
     OBJ: { nested: { value: "ok" }, count: 7 },
     ARR: [1, 2, 3],
     OUTPUT_STR: Output.literal("output-str"),
+    RANDOM: Alchemy.makeRandom("WorkerEnvRandom"),
     SECRET_STR: Redacted.make("shh"),
     SECRET_JSON: Redacted.make({
       token: "abc",
@@ -44,6 +45,7 @@ export default Alchemy.Stack(
 
     return {
       asyncUrl: asyncWorker.url.as<string>(),
+      asyncWorkerName: asyncWorker.workerName,
       effectUrl: effectWorker.url.as<string>(),
     };
   }),

--- a/packages/alchemy/test/types/WorkerEnvOutput.ts
+++ b/packages/alchemy/test/types/WorkerEnvOutput.ts
@@ -1,0 +1,39 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as Alchemy from "@/index.ts";
+import * as Output from "@/Output";
+
+// ── Worker `env` Output inference guards ───────────────────────────────────
+//
+// `WorkerBindingResource` admits Outputs that resolve to a plain env value
+// (`Output<Json | Redacted<Json>>`). Before that arm existed, a single
+// Output env value (e.g. `Alchemy.makeRandom`) failed the `env` constraint,
+// TypeScript fell back to the constraint's index signature, and EVERY
+// `InferEnv` key collapsed to the full binding union. These probes pin the
+// per-key inference.
+//
+// Note: whole-resource Outputs (`Output.of(queue)`) still compile — `Input<T>`
+// wraps the whole union in `Output<T>`, so any Output whose A is structurally
+// Json is admitted upstream of `WorkerBindingResource`. They are rejected at
+// deploy time by `bindWorkerAsyncBindings` instead.
+
+declare const queue: Cloudflare.Queues.Queue;
+
+export const Worker = Cloudflare.Worker("EnvOutputTypeProbe", {
+  script: "export default {}",
+  env: {
+    URL: "https://example.com",
+    SECRET: Alchemy.makeRandom("Secret"),
+    STR: Output.literal("str"),
+    QUEUE: queue,
+  },
+});
+
+type Env = Cloudflare.InferEnv<typeof Worker>;
+declare const env: Env;
+
+// An Output env value must not collapse sibling keys to the binding union.
+export const _url: string = env.URL;
+// `Output<Redacted<string>>` (makeRandom) infers as a decrypted string.
+export const _secret: string = env.SECRET;
+// `Output<string>` infers as a string.
+export const _str: string = env.STR;

--- a/website/src/content/docs/cloudflare/security/secrets-env.mdx
+++ b/website/src/content/docs/cloudflare/security/secrets-env.mdx
@@ -139,7 +139,9 @@ export default {
 ```
 
 Literal values route by shape: `Redacted<string>` → `secret_text`,
-`string` → `plain_text`, anything else → `json`.
+`string` → `plain_text`, anything else → `json`. `Output` values
+(e.g. `Alchemy.makeRandom`) classify by their resolved value with the
+same rules, so a resolved `Redacted` still uploads as `secret_text`.
 
 ## Generate tokens with Alchemy.Random
 


### PR DESCRIPTION
 Binding an `Output` in a Worker's env could expose a `Redacted` secret and collapse
 `InferEnv` types.

   Reproduction:
 [sethcarlton/alchemy-binding-test](https://github.com/sethcarlton/alchemy-binding-test)

   ```ts
   env: {
     APP_URL: "https://example.com",
     SECRET: Alchemy.makeRandom("Secret"),
   }
   ```

   ### Secret classification

   Env bindings were classified before Outputs resolved. An `Output<Redacted<string>>`
 fell through to the json binding, then resolved and uploaded as readable text:

   ```json
   { "type": "json", "name": "SECRET", "json": "<readable secret>" }
   ```

   Classification now waits for the resolved value. A resolved `Redacted` uploads as
 `secret_text`; a resolved string uploads as `plain_text`.

   Anyone who deployed a secret this way should rotate it.

   ### Type inference

   `WorkerBindingResource` had no Output arm. One Output value could make TypeScript
 fall back to the binding index signature, turning every `InferEnv` key into the full
 binding union.

   The new arm accepts `Output<Json | Redacted<Json>>`, preserving each key's inferred
 type.

   ### Whole-resource Outputs

   `Output.of(resource)` can still compile because `Input<T>` accepts Outputs whose
 attributes are structurally Json. This predates the change.

   Deploy now rejects these values instead of uploading the resource attributes as a
 plaintext json binding. Bind the resource directly or bind one of its attribute
 Outputs.