### PR TITLE
fix(aws): wait for ECS service eventual consistency

### DIFF
--- a/packages/alchemy/src/AWS/ECR/Repository.ts
+++ b/packages/alchemy/src/AWS/ECR/Repository.ts
@@ -67,6 +67,8 @@ export interface Repository extends Resource<
     registryId: string;
     /** Whether image tags are `MUTABLE` or `IMMUTABLE`. */
     imageTagMutability: ecr.ImageTagMutability;
+    /** Whether repository images are scanned when they are pushed. */
+    scanOnPush: boolean;
     /** The JSON lifecycle policy applied to the repository, if any. */
     lifecyclePolicyText?: string;
     /** The JSON repository permissions policy, if any. */
@@ -219,6 +221,10 @@ export const RepositoryProvider = () =>
               repository.imageTagMutability ??
               output?.imageTagMutability ??
               "MUTABLE",
+            scanOnPush:
+              repository.imageScanningConfiguration?.scanOnPush ??
+              output?.scanOnPush ??
+              false,
             lifecyclePolicyText: output?.lifecyclePolicyText,
             policy: yield* readPolicy(repositoryName),
             tags: output?.tags ?? {},
@@ -289,6 +295,34 @@ export const RepositoryProvider = () =>
 
           const repositoryArn = repository.repositoryArn as RepositoryArn;
 
+          // Sync mutable repository settings against OBSERVED cloud state.
+          // These must converge for adopted repositories and out-of-band
+          // drift, not only when createRepository happens to run.
+          const desiredImageTagMutability =
+            news.imageTagMutability ?? "MUTABLE";
+          if (
+            (repository.imageTagMutability ?? "MUTABLE") !==
+            desiredImageTagMutability
+          ) {
+            yield* ecr.putImageTagMutability({
+              repositoryName,
+              imageTagMutability: desiredImageTagMutability,
+            });
+          }
+
+          const desiredScanOnPush = news.scanOnPush ?? false;
+          if (
+            (repository.imageScanningConfiguration?.scanOnPush ?? false) !==
+            desiredScanOnPush
+          ) {
+            yield* ecr.putImageScanningConfiguration({
+              repositoryName,
+              imageScanningConfiguration: {
+                scanOnPush: desiredScanOnPush,
+              },
+            });
+          }
+
           // Sync lifecycle policy — observed ↔ desired.
           if (news.lifecyclePolicyText) {
             yield* ecr.putLifecyclePolicy({
@@ -333,10 +367,8 @@ export const RepositoryProvider = () =>
             repositoryArn,
             repositoryUri: repository.repositoryUri as RepositoryUri,
             registryId: repository.registryId!,
-            imageTagMutability:
-              news.imageTagMutability ??
-              repository.imageTagMutability ??
-              "MUTABLE",
+            imageTagMutability: desiredImageTagMutability,
+            scanOnPush: desiredScanOnPush,
             lifecyclePolicyText: news.lifecyclePolicyText,
             policy: desiredPolicy,
             tags: desiredTags,
@@ -398,6 +430,9 @@ export const RepositoryProvider = () =>
                     registryId: repository.registryId!,
                     imageTagMutability:
                       repository.imageTagMutability ?? "MUTABLE",
+                    scanOnPush:
+                      repository.imageScanningConfiguration?.scanOnPush ??
+                      false,
                     lifecyclePolicyText,
                     policy: yield* readPolicy(repository.repositoryName),
                     tags,

--- a/packages/alchemy/src/AWS/ECS/Service.ts
+++ b/packages/alchemy/src/AWS/ECS/Service.ts
@@ -11,6 +11,7 @@ import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
+import type { HttpClient } from "effect/unstable/http/HttpClient";
 import { deepEqual, isResolved } from "../../Diff.ts";
 import * as Namespace from "../../Namespace.ts";
 import * as Output from "../../Output.ts";
@@ -21,7 +22,7 @@ import { Resource } from "../../Resource.ts";
 import type { HostRuntimeContext, ServerHost } from "../../Server/Process.ts";
 import { Stack } from "../../Stack.ts";
 import { createInternalTags, diffTags } from "../../Tags.ts";
-import { toSeconds, toWireSeconds } from "../../Util/Duration.ts";
+import { toMillis, toSeconds, toWireSeconds } from "../../Util/Duration.ts";
 import { Certificate } from "../ACM/Certificate.ts";
 import { ScalableTarget } from "../ApplicationAutoScaling/ScalableTarget.ts";
 import { ScalingPolicy } from "../ApplicationAutoScaling/ScalingPolicy.ts";
@@ -363,6 +364,22 @@ export class RequestCountScalingRequiresLoadBalancer extends Data.TaggedError(
   readonly message: string;
 }> {}
 
+/** An ECS service did not converge to the requested deployment before timeout. */
+export class ServiceDidNotStabilize extends Data.TaggedError(
+  "ServiceDidNotStabilize",
+)<{
+  readonly clusterArn: string;
+  readonly serviceName: string;
+  readonly expectedTaskDefinitionArn: string | undefined;
+  readonly status: string | undefined;
+  readonly desiredCount: number | undefined;
+  readonly runningCount: number | undefined;
+  readonly pendingCount: number | undefined;
+  readonly deploymentCount: number;
+  readonly unhealthyTargetCount: number;
+  readonly message: string;
+}> {}
+
 /**
  * Derive a deterministic listener-rule priority (1–50000) from the rule's
  * namespaced logical id (FNV-1a 32-bit). Stable across deploys for the same
@@ -679,6 +696,14 @@ export interface ServicePropsBase extends PlatformProps {
    * breaker, deployment strategy, alarms). Updated in place.
    */
   deploymentConfiguration?: ecs.DeploymentConfiguration;
+
+  /**
+   * Maximum time to wait for an ECS deployment, old-task drain, and target
+   * health to converge before failing the resource operation. The provider
+   * hard-caps this at 30 minutes so polling always remains bounded.
+   * @default "10 minutes"
+   */
+  deploymentStabilizationTimeout?: Duration.Input;
 
   /**
    * Deployment controller (`ECS`, `CODE_DEPLOY`, `EXTERNAL`). The controller
@@ -2526,6 +2551,219 @@ const resolveServiceVolumes = (
   return { volumes: resolved, mountPoints };
 };
 
+type ServiceConvergenceDependencies = Credentials | HttpClient | Region;
+
+interface ServiceConvergenceSnapshot {
+  readonly service: ecs.Service | undefined;
+  readonly targetGroups: readonly {
+    readonly missing: boolean;
+    readonly states: readonly (string | undefined)[];
+  }[];
+  readonly converged: boolean;
+}
+
+type ServiceConvergenceMode = "stable" | "drained" | "deleted";
+
+/**
+ * Observe the complete service deployment boundary: ECS rollout state,
+ * desired/running/pending counts, superseded deployments, and every target
+ * group's registered target state.
+ */
+const observeServiceConvergence = (input: {
+  clusterArn: string;
+  serviceName: string;
+  expectedTaskDefinitionArn?: string;
+  mode: ServiceConvergenceMode;
+}): Effect.Effect<
+  ServiceConvergenceSnapshot,
+  ecs.DescribeServicesError | elbv2.DescribeTargetHealthError,
+  ServiceConvergenceDependencies
+> =>
+  Effect.gen(function* () {
+    const described = yield* ecs
+      .describeServices({
+        cluster: input.clusterArn,
+        services: [input.serviceName],
+      })
+      .pipe(
+        Effect.catchTag("ClusterNotFoundException", () =>
+          Effect.succeed(undefined),
+        ),
+      );
+    const service = described?.services?.find(
+      (candidate) =>
+        candidate.serviceName === input.serviceName &&
+        candidate.status !== "INACTIVE",
+    );
+
+    if (service === undefined) {
+      return {
+        service,
+        targetGroups: [],
+        converged: input.mode === "drained" || input.mode === "deleted",
+      };
+    }
+
+    const targetGroupArns = [
+      ...new Set(
+        (service.loadBalancers ?? []).flatMap((loadBalancer) =>
+          loadBalancer.targetGroupArn ? [loadBalancer.targetGroupArn] : [],
+        ),
+      ),
+    ];
+    const targetGroups = yield* Effect.forEach(
+      targetGroupArns,
+      (targetGroupArn) =>
+        elbv2.describeTargetHealth({ TargetGroupArn: targetGroupArn }).pipe(
+          Effect.map((health) => ({
+            missing: false,
+            states: (health.TargetHealthDescriptions ?? []).map(
+              (target) => target.TargetHealth?.State,
+            ),
+          })),
+          Effect.catchTag("TargetGroupNotFoundException", () =>
+            Effect.succeed({
+              missing: true,
+              states: [] as (string | undefined)[],
+            }),
+          ),
+        ),
+      { concurrency: 4 },
+    );
+
+    if (input.mode === "deleted") {
+      return { service, targetGroups, converged: false };
+    }
+
+    const runningCount = service.runningCount ?? 0;
+    const pendingCount = service.pendingCount ?? 0;
+    const desiredCount = service.desiredCount ?? 0;
+    const expectedTargetCount =
+      service.schedulingStrategy === "DAEMON" ? runningCount : desiredCount;
+
+    if (input.mode === "drained") {
+      return {
+        service,
+        targetGroups,
+        converged:
+          runningCount === 0 &&
+          pendingCount === 0 &&
+          targetGroups.every(
+            (targetGroup) =>
+              targetGroup.missing || targetGroup.states.length === 0,
+          ),
+      };
+    }
+
+    const deployments = service.deployments ?? [];
+    const primary = deployments.find(
+      (deployment) => deployment.status === "PRIMARY",
+    );
+    const deploymentController = service.deploymentController?.type ?? "ECS";
+    const countsConverged =
+      service.schedulingStrategy === "DAEMON"
+        ? pendingCount === 0
+        : runningCount === desiredCount && pendingCount === 0;
+    const deploymentConverged =
+      deployments.length === 1 &&
+      primary !== undefined &&
+      primary.taskDefinition === input.expectedTaskDefinitionArn &&
+      (deploymentController === "ECS"
+        ? primary.rolloutState === "COMPLETED"
+        : primary.rolloutState === undefined ||
+          primary.rolloutState === "COMPLETED");
+    const targetsConverged = targetGroups.every(
+      (targetGroup) =>
+        !targetGroup.missing &&
+        targetGroup.states.length === expectedTargetCount &&
+        targetGroup.states.every((state) => state === "healthy"),
+    );
+
+    return {
+      service,
+      targetGroups,
+      converged:
+        service.status === "ACTIVE" &&
+        service.taskDefinition === input.expectedTaskDefinitionArn &&
+        countsConverged &&
+        deploymentConverged &&
+        targetsConverged,
+    };
+  });
+
+const waitForServiceConvergence = (input: {
+  clusterArn: string;
+  serviceName: string;
+  expectedTaskDefinitionArn?: string;
+  mode: ServiceConvergenceMode;
+  timeout?: Duration.Input;
+}): Effect.Effect<
+  ServiceConvergenceSnapshot,
+  | ecs.DescribeServicesError
+  | elbv2.DescribeTargetHealthError
+  | ServiceDidNotStabilize,
+  ServiceConvergenceDependencies
+> => {
+  const pollIntervalMillis = 5_000;
+  const timeoutMillis = Math.min(
+    toMillis(input.timeout ?? "10 minutes")!,
+    30 * 60 * 1_000,
+  );
+  const attempts = Math.max(1, Math.ceil(timeoutMillis / pollIntervalMillis));
+
+  return observeServiceConvergence(input).pipe(
+    Effect.repeat({
+      schedule: Schedule.max([
+        Schedule.spaced(pollIntervalMillis),
+        Schedule.recurs(attempts),
+      ]),
+      until: (snapshot) =>
+        snapshot.converged ||
+        snapshot.service?.deployments?.some(
+          (deployment) => deployment.rolloutState === "FAILED",
+        ) === true,
+    }),
+    Effect.flatMap((snapshot) => {
+      if (snapshot.converged) {
+        return Effect.succeed(snapshot);
+      }
+      const service = snapshot.service;
+      const expectedTargetCount =
+        service?.schedulingStrategy === "DAEMON"
+          ? (service.runningCount ?? 0)
+          : (service?.desiredCount ?? 0);
+      const unhealthyTargetCount = snapshot.targetGroups.reduce(
+        (total, targetGroup) =>
+          total +
+          (targetGroup.missing
+            ? Math.max(1, expectedTargetCount)
+            : targetGroup.states.filter((state) => state !== "healthy").length +
+              Math.abs(targetGroup.states.length - expectedTargetCount)),
+        0,
+      );
+      return Effect.fail(
+        new ServiceDidNotStabilize({
+          clusterArn: input.clusterArn,
+          serviceName: input.serviceName,
+          expectedTaskDefinitionArn: input.expectedTaskDefinitionArn,
+          status: service?.status,
+          desiredCount: service?.desiredCount,
+          runningCount: service?.runningCount,
+          pendingCount: service?.pendingCount,
+          deploymentCount: service?.deployments?.length ?? 0,
+          unhealthyTargetCount,
+          message:
+            service?.deployments?.some(
+              (deployment) => deployment.rolloutState === "FAILED",
+            ) === true
+              ? `ECS service ${input.serviceName} reported a failed deployment`
+              : `ECS service ${input.serviceName} did not become ${input.mode} before timeout`,
+        }),
+      );
+    }),
+  );
+};
+
 export const ServiceProvider = () =>
   Provider.effect(
     Service,
@@ -3292,6 +3530,17 @@ export const ServiceProvider = () =>
                 new Error("createService returned no service"),
               );
             }
+            yield* session.note(
+              `Waiting for ECS service ${serviceName} to stabilize`,
+            );
+            const stable = yield* waitForServiceConvergence({
+              clusterArn,
+              serviceName,
+              expectedTaskDefinitionArn: task.taskDefinitionArn,
+              mode: "stable",
+              timeout: news.deploymentStabilizationTimeout,
+            });
+            const stableService = stable.service!;
             // Legacy inline ingress recorded in prior attrs (service itself
             // was missing — e.g. recreated) is stale now: reap it.
             yield* reapLegacyIngress({ output, session });
@@ -3306,11 +3555,11 @@ export const ServiceProvider = () =>
             }
             yield* session.note(service.serviceArn);
             return {
-              serviceArn: service.serviceArn as ServiceArn,
-              serviceName: service.serviceName!,
-              clusterArn: service.clusterArn as ClusterArn,
-              taskDefinitionArn: service.taskDefinition!,
-              status: service.status ?? "ACTIVE",
+              serviceArn: stableService.serviceArn as ServiceArn,
+              serviceName: stableService.serviceName!,
+              clusterArn: stableService.clusterArn as ClusterArn,
+              taskDefinitionArn: stableService.taskDefinition!,
+              status: stableService.status ?? "ACTIVE",
               ...ingressAttrs,
               ...ownedAttributes,
             };
@@ -3319,7 +3568,7 @@ export const ServiceProvider = () =>
           // Sync — apply in-place mutable fields via updateService. Force a new
           // deployment so a changed task definition (same revision-less ARN) or
           // load-balancer wiring rolls out.
-          const updated = yield* ecs
+          yield* ecs
             .updateService({
               ...mutableInput(news, task, network, securityGroups),
               // While autoscaling manages the desired count, leave it
@@ -3359,7 +3608,17 @@ export const ServiceProvider = () =>
                 ]),
               }),
             );
-          const service = updated.service;
+          yield* session.note(
+            `Waiting for ECS service ${serviceName} to stabilize`,
+          );
+          const stable = yield* waitForServiceConvergence({
+            clusterArn,
+            serviceName,
+            expectedTaskDefinitionArn: task.taskDefinitionArn,
+            mode: "stable",
+            timeout: news.deploymentStabilizationTimeout,
+          });
+          const stableService = stable.service!;
 
           // Sync tags — diff observed service tags against desired.
           const observedTags = Object.fromEntries(
@@ -3405,24 +3664,18 @@ export const ServiceProvider = () =>
 
           yield* session.note(observed.serviceArn);
           return {
-            serviceArn: observed.serviceArn as ServiceArn,
-            serviceName: observed.serviceName!,
-            clusterArn: observed.clusterArn as ClusterArn,
-            taskDefinitionArn:
-              service?.taskDefinition ??
-              observed.taskDefinition ??
-              output?.taskDefinitionArn ??
-              "",
-            status: service?.status ?? observed.status ?? "ACTIVE",
+            serviceArn: stableService.serviceArn as ServiceArn,
+            serviceName: stableService.serviceName!,
+            clusterArn: stableService.clusterArn as ClusterArn,
+            taskDefinitionArn: stableService.taskDefinition!,
+            status: stableService.status ?? "ACTIVE",
             ...ingressAttrs,
             ...ownedAttributes,
           };
         }),
         delete: Effect.fn(function* ({ output, session }) {
-          // Scale to zero first so `deleteService` has no running tasks to
-          // drain. If the service is mid-transition (`ServiceNotActiveException`)
-          // we skip the scale-down — `deleteService({ force: true })` below
-          // tears it down regardless.
+          // Scale to zero and prove every task/target has drained before
+          // deleting the service or its dependent task-definition resources.
           yield* ecs
             .updateService({
               cluster: output.clusterArn,
@@ -3430,10 +3683,25 @@ export const ServiceProvider = () =>
               desiredCount: 0,
             })
             .pipe(
+              Effect.retry({
+                while: (error) => error._tag === "ServiceNotActiveException",
+                schedule: Schedule.max([
+                  Schedule.spaced("5 seconds"),
+                  Schedule.recurs(8),
+                ]),
+              }),
               Effect.catchTag("ServiceNotFoundException", () => Effect.void),
               Effect.catchTag("ClusterNotFoundException", () => Effect.void),
-              Effect.catchTag("ServiceNotActiveException", () => Effect.void),
             );
+
+          yield* session.note(
+            `Waiting for ECS service ${output.serviceName} to drain`,
+          );
+          yield* waitForServiceConvergence({
+            clusterArn: output.clusterArn,
+            serviceName: output.serviceName,
+            mode: "drained",
+          });
 
           yield* ecs
             .deleteService({
@@ -3445,6 +3713,12 @@ export const ServiceProvider = () =>
               Effect.catchTag("ServiceNotFoundException", () => Effect.void),
               Effect.catchTag("ClusterNotFoundException", () => Effect.void),
             );
+
+          yield* waitForServiceConvergence({
+            clusterArn: output.clusterArn,
+            serviceName: output.serviceName,
+            mode: "deleted",
+          });
 
           // Inline ingress teardown applies ONLY to legacy state rows (no
           // `ingressKind` marker) whose ALB/TG/listener/SG were created

--- a/packages/alchemy/src/AWS/StateStore/State.ts
+++ b/packages/alchemy/src/AWS/StateStore/State.ts
@@ -25,6 +25,7 @@ import {
   Default as DefaultEnvironment,
 } from "../Environment.ts";
 import * as AwsRegion from "../Region.ts";
+import type { BucketEncryption } from "../S3/Bucket.ts";
 
 /**
  * The bookkeeping object that stores a stack's resolved output. Lives
@@ -55,6 +56,12 @@ export interface S3StateOptions {
    * @default "" (bucket root)
    */
   prefix?: string;
+  /**
+   * Default encryption enforced on the state bucket.
+   *
+   * @default `{ sseAlgorithm: "AES256" }`
+   */
+  encryption?: BucketEncryption;
 }
 
 /** Context required by the distilled S3 operations. */
@@ -107,6 +114,10 @@ type S3Deps = Credentials | HttpClient | Region;
  *     state: AWS.state({
  *       bucketName: "my-company-state",
  *       prefix: "alchemy",
+ *       encryption: {
+ *         sseAlgorithm: "aws:kms",
+ *         kmsMasterKeyId: "alias/alchemy-state",
+ *       },
  *     }),
  *   },
  *   Effect.gen(function* () {
@@ -175,7 +186,7 @@ export const makeS3State = (options: S3StateOptions = {}) =>
         const { accountId, region } = yield* AWSEnvironment.current;
         const bucketName =
           options.bucketName ?? createStateBucketName(accountId, region);
-        yield* ensureStateBucket(bucketName, region);
+        yield* ensureStateBucket(bucketName, region, options);
         return bucketName;
       }).pipe(Effect.provideContext(context), Effect.mapError(toError)),
     );
@@ -357,7 +368,11 @@ export const createStateBucketName = (accountId: string, region: string) =>
  * Observe-then-ensure the state bucket: head it, create it if missing
  * (tolerating create races), and wait for it to become available.
  */
-const ensureStateBucket = (bucket: string, region: string) =>
+const ensureStateBucket = (
+  bucket: string,
+  region: string,
+  options: S3StateOptions,
+) =>
   Effect.gen(function* () {
     // An absent bucket surfaces as either `NotFound` (the HEAD 404) or
     // `NoSuchBucket` depending on the namespace/path — treat both as "create
@@ -369,56 +384,158 @@ const ensureStateBucket = (bucket: string, region: string) =>
         Effect.succeed(false),
       ),
     );
-    if (exists) {
-      return;
+    if (!exists) {
+      yield* Effect.logInfo(
+        `S3 state store: creating bucket ${bucket} in ${region}`,
+      );
+      yield* s3
+        .createBucket({
+          Bucket: bucket,
+          // account-regional namespace: the bucket name only needs to be
+          // unique within this account+region, so deterministic default
+          // names can't collide with other AWS customers.
+          BucketNamespace: "account-regional",
+          // us-east-1 rejects an explicit LocationConstraint
+          ...(region === "us-east-1"
+            ? {}
+            : {
+                CreateBucketConfiguration: {
+                  LocationConstraint: region as s3.BucketLocationConstraint,
+                },
+              }),
+        })
+        .pipe(
+          // Many callers race to create the shared default state bucket on
+          // first use. The loser sees the create already done
+          // (`BucketAlreadyOwnedByYou`/`BucketAlreadyExists`) or mid-flight
+          // (`OperationAborted`). All mean "someone else is creating it".
+          Effect.catchTag(
+            [
+              "BucketAlreadyOwnedByYou",
+              "BucketAlreadyExists",
+              "OperationAborted",
+            ],
+            () => Effect.void,
+          ),
+        );
+
+      // Wait for the bucket to become available. Under a concurrent create
+      // the bucket is briefly not yet head-able and object/configuration ops
+      // would race ahead of it.
+      yield* s3.headBucket({ Bucket: bucket }).pipe(
+        Effect.retry({
+          while: (error) =>
+            error._tag === "NotFound" || error._tag === "NoSuchBucket",
+          schedule: Schedule.max([
+            Schedule.spaced("1 second"),
+            Schedule.recurs(10),
+          ]),
+        }),
+      );
     }
 
-    yield* Effect.logInfo(
-      `S3 state store: creating bucket ${bucket} in ${region}`,
-    );
-    yield* s3
-      .createBucket({
+    // Secure defaults are reconciled for BOTH newly-created and existing
+    // buckets. This makes AWS.state converge out-of-band drift and explicit
+    // custom buckets rather than only securing the greenfield path.
+    const desiredVersioning = "Enabled";
+    const observedVersioning = yield* s3.getBucketVersioning({
+      Bucket: bucket,
+    });
+    if (observedVersioning.Status !== desiredVersioning) {
+      yield* s3.putBucketVersioning({
         Bucket: bucket,
-        // account-regional namespace: the bucket name only needs to be
-        // unique within this account+region, so deterministic default
-        // names can't collide with other AWS customers.
-        BucketNamespace: "account-regional",
-        // us-east-1 rejects an explicit LocationConstraint
-        ...(region === "us-east-1"
-          ? {}
-          : {
-              CreateBucketConfiguration: {
-                LocationConstraint: region as s3.BucketLocationConstraint,
-              },
-            }),
-      })
-      .pipe(
-        // Many callers race to create the shared default state bucket on first
-        // use. The loser sees the create already done
-        // (`BucketAlreadyOwnedByYou`/`BucketAlreadyExists`) or mid-flight
-        // (`OperationAborted` — "a conflicting conditional operation is in
-        // progress"). All mean "someone else is creating it" — fall through to
-        // the readiness wait.
-        Effect.catchTag(
-          [
-            "BucketAlreadyOwnedByYou",
-            "BucketAlreadyExists",
-            "OperationAborted",
-          ],
-          () => Effect.void,
-        ),
-      );
+        VersioningConfiguration: { Status: desiredVersioning },
+      });
+    }
 
-    // Wait for the bucket to become available. Under a concurrent create the
-    // bucket is briefly not yet head-able (NotFound/NoSuchBucket) and object
-    // ops would race ahead of it — keep polling until HEAD succeeds.
-    yield* s3
-      .headBucket({ Bucket: bucket })
+    const desiredEncryption = options.encryption ?? {
+      sseAlgorithm: "AES256",
+    };
+    const observedEncryption = (yield* s3.getBucketEncryption({
+      Bucket: bucket,
+    })).ServerSideEncryptionConfiguration?.Rules?.[0];
+    const desiredEncryptionRule: s3.ServerSideEncryptionRule = {
+      ApplyServerSideEncryptionByDefault: {
+        SSEAlgorithm: desiredEncryption.sseAlgorithm,
+        KMSMasterKeyID: desiredEncryption.kmsMasterKeyId,
+      },
+      BucketKeyEnabled: desiredEncryption.bucketKeyEnabled ?? false,
+    };
+    const encryptionFingerprint = (
+      rule: s3.ServerSideEncryptionRule | undefined,
+    ) =>
+      JSON.stringify({
+        algorithm:
+          rule?.ApplyServerSideEncryptionByDefault?.SSEAlgorithm ?? null,
+        key: rule?.ApplyServerSideEncryptionByDefault?.KMSMasterKeyID ?? null,
+        bucketKey: rule?.BucketKeyEnabled ?? false,
+      });
+    if (
+      encryptionFingerprint(observedEncryption) !==
+      encryptionFingerprint(desiredEncryptionRule)
+    ) {
+      yield* s3.putBucketEncryption({
+        Bucket: bucket,
+        ServerSideEncryptionConfiguration: {
+          Rules: [desiredEncryptionRule],
+        },
+      });
+    }
+
+    const desiredPublicAccess: s3.PublicAccessBlockConfiguration = {
+      BlockPublicAcls: true,
+      IgnorePublicAcls: true,
+      BlockPublicPolicy: true,
+      RestrictPublicBuckets: true,
+    };
+    const observedPublicAccess = yield* s3
+      .getPublicAccessBlock({ Bucket: bucket })
       .pipe(
-        Effect.retry(
-          Schedule.max([Schedule.spaced("1 second"), Schedule.recurs(15)]),
+        Effect.map((result) => result.PublicAccessBlockConfiguration),
+        Effect.catchTag("NoSuchPublicAccessBlockConfiguration", () =>
+          Effect.succeed<s3.PublicAccessBlockConfiguration | undefined>(
+            undefined,
+          ),
         ),
       );
+    const publicAccessFingerprint = (
+      config: s3.PublicAccessBlockConfiguration | undefined,
+    ) =>
+      JSON.stringify({
+        blockAcls: config?.BlockPublicAcls ?? false,
+        ignoreAcls: config?.IgnorePublicAcls ?? false,
+        blockPolicy: config?.BlockPublicPolicy ?? false,
+        restrictBuckets: config?.RestrictPublicBuckets ?? false,
+      });
+    if (
+      publicAccessFingerprint(observedPublicAccess) !==
+      publicAccessFingerprint(desiredPublicAccess)
+    ) {
+      yield* s3.putPublicAccessBlock({
+        Bucket: bucket,
+        PublicAccessBlockConfiguration: desiredPublicAccess,
+      });
+    }
+
+    const desiredOwnership = "BucketOwnerEnforced";
+    const observedOwnership = yield* s3
+      .getBucketOwnershipControls({ Bucket: bucket })
+      .pipe(
+        Effect.map(
+          (result) => result.OwnershipControls?.Rules?.[0]?.ObjectOwnership,
+        ),
+        Effect.catchTag("OwnershipControlsNotFoundError", () =>
+          Effect.succeed<string | undefined>(undefined),
+        ),
+      );
+    if (observedOwnership !== desiredOwnership) {
+      yield* s3.putBucketOwnershipControls({
+        Bucket: bucket,
+        OwnershipControls: {
+          Rules: [{ ObjectOwnership: desiredOwnership }],
+        },
+      });
+    }
   }).pipe(
     // The whole observe→create→wait sequence races other first-callers of the
     // shared bucket; `OperationAborted` (conflicting create) and a transiently

--- a/packages/alchemy/test/AWS/ECR/Repository.test.ts
+++ b/packages/alchemy/test/AWS/ECR/Repository.test.ts
@@ -56,6 +56,42 @@ test.provider("list enumerates the deployed repository", (stack) =>
   }),
 );
 
+test.provider(
+  "reconciles tag mutability and scan-on-push on an existing repository",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const deployRepository = (
+        imageTagMutability: "MUTABLE" | "IMMUTABLE",
+        scanOnPush: boolean,
+      ) =>
+        stack.deploy(
+          Repository("SettingsRepository", {
+            repositoryName: "alchemy-test-ecr-repo-settings",
+            imageTagMutability,
+            scanOnPush,
+          }),
+        );
+
+      yield* deployRepository("MUTABLE", false);
+      const updated = yield* deployRepository("IMMUTABLE", true);
+
+      const described = yield* ecr.describeRepositories({
+        repositoryNames: [updated.repositoryName],
+      });
+      const observed = described.repositories?.[0];
+      expect(observed?.imageTagMutability).toBe("IMMUTABLE");
+      expect(observed?.imageScanningConfiguration?.scanOnPush).toBe(true);
+      expect(updated.imageTagMutability).toBe("IMMUTABLE");
+      expect(updated.scanOnPush).toBe(true);
+
+      yield* stack.destroy();
+      yield* assertRepositoryDeleted(updated.repositoryName);
+    }),
+  { timeout: 120_000 },
+);
+
 const repositoryPolicy: PolicyDocument = {
   Version: "2012-10-17",
   Statement: [

--- a/packages/alchemy/test/AWS/ECS/Service.test.ts
+++ b/packages/alchemy/test/AWS/ECS/Service.test.ts
@@ -208,6 +208,12 @@ test.provider(
       });
       const svc = described.services?.[0];
       expect(svc?.serviceArn).toEqual(created.serviceArn);
+      expect(svc?.taskDefinition).toEqual(taskDefinitionArn);
+      expect(svc?.runningCount).toBe(0);
+      expect(svc?.pendingCount).toBe(0);
+      expect(svc?.deployments).toHaveLength(1);
+      expect(svc?.deployments?.[0]?.status).toBe("PRIMARY");
+      expect(svc?.deployments?.[0]?.rolloutState).toBe("COMPLETED");
       expect(
         svc?.deploymentConfiguration?.deploymentCircuitBreaker?.enable,
       ).toBe(true);

--- a/packages/alchemy/test/AWS/ECS/Task.smoke.test.ts
+++ b/packages/alchemy/test/AWS/ECS/Task.smoke.test.ts
@@ -3,6 +3,7 @@ import { SecurityGroup } from "@/AWS/EC2";
 import { Cluster } from "@/AWS/ECS/Cluster.ts";
 import { Service } from "@/AWS/ECS/Service.ts";
 import * as Test from "@/Test/Alchemy";
+import * as ecs from "@distilled.cloud/aws/ecs";
 import * as elbv2 from "@distilled.cloud/aws/elastic-load-balancing-v2";
 import { expect } from "alchemy-test";
 import * as Effect from "effect/Effect";
@@ -56,7 +57,13 @@ test.provider.skipIf(!process.env.AWS_TEST_SLOW || !!process.env.FAST)(
       }
       const publicSubnetIds = subnetIds.slice(0, 2);
 
-      const { url, targetGroupArn } = yield* stack.deploy(
+      const {
+        url,
+        targetGroupArn,
+        clusterArn,
+        serviceName,
+        taskDefinitionArn,
+      } = yield* stack.deploy(
         Effect.gen(function* () {
           // The default VPC supplies public routing and subnets; this managed
           // security group remains isolated to the test and is swept exactly.
@@ -115,6 +122,9 @@ test.provider.skipIf(!process.env.AWS_TEST_SLOW || !!process.env.FAST)(
           return {
             url: service.url,
             targetGroupArn: service.targetGroupArn,
+            clusterArn: service.clusterArn,
+            serviceName: service.serviceName,
+            taskDefinitionArn: service.taskDefinitionArn,
           };
         }),
       );
@@ -122,30 +132,29 @@ test.provider.skipIf(!process.env.AWS_TEST_SLOW || !!process.env.FAST)(
       expect(url).toBeTruthy();
       expect(targetGroupArn).toBeTruthy();
 
-      // Gate on target health via the ELBv2 API (no DNS): wait until the task
-      // is placed, the image pulled, and the ALB health check on `/health`
-      // passes. Polling via the API — rather than HTTP — avoids looking up the
-      // freshly-created ALB hostname before its DNS record exists (a premature
-      // lookup gets NXDOMAIN negatively cached by the resolver for minutes).
-      yield* elbv2
-        .describeTargetHealth({ TargetGroupArn: targetGroupArn! })
-        .pipe(
-          Effect.flatMap((result) => {
-            const states = (result.TargetHealthDescriptions ?? []).map(
-              (t) => t.TargetHealth?.State,
-            );
-            return states.includes("healthy")
-              ? Effect.void
-              : Effect.fail(
-                  new Error(`no healthy target yet: [${states.join(", ")}]`),
-                );
-          }),
-          Effect.tapError((error) => Effect.logError(error)),
-          // ~12 min budget: image pull + container boot + the ALB health check
-          // ramp (default 5 × 30s consecutive successes) can take several
-          // minutes for a cold Fargate task.
-          Effect.retry({ schedule: Schedule.spaced("12 seconds"), times: 60 }),
-        );
+      // Service.deploy now blocks until the exact task definition is the sole
+      // completed deployment, ECS counts have settled, and every registered
+      // target is healthy. Prove that contract immediately out-of-band.
+      const describedService = yield* ecs.describeServices({
+        cluster: clusterArn,
+        services: [serviceName],
+      });
+      const deployedService = describedService.services?.[0];
+      expect(deployedService?.taskDefinition).toBe(taskDefinitionArn);
+      expect(deployedService?.desiredCount).toBe(1);
+      expect(deployedService?.runningCount).toBe(1);
+      expect(deployedService?.pendingCount).toBe(0);
+      expect(deployedService?.deployments).toHaveLength(1);
+      expect(deployedService?.deployments?.[0]?.status).toBe("PRIMARY");
+
+      const targetHealth = yield* elbv2.describeTargetHealth({
+        TargetGroupArn: targetGroupArn!,
+      });
+      expect(
+        (targetHealth.TargetHealthDescriptions ?? []).map(
+          (target) => target.TargetHealth?.State,
+        ),
+      ).toEqual(["healthy"]);
 
       // The ALB has been active for a while now, so its DNS resolves. Probe the
       // public endpoint (still retry through edge/DNS propagation).

--- a/packages/alchemy/test/AWS/StateStore/State.test.ts
+++ b/packages/alchemy/test/AWS/StateStore/State.test.ts
@@ -1,7 +1,9 @@
 import * as AWS from "@/AWS";
 import { makeS3State } from "@/AWS";
+import { createStateBucketName } from "@/AWS/StateStore/State.ts";
 import type { ResourceState, StateService } from "@/State";
 import * as Test from "@/Test/Alchemy";
+import * as s3 from "@distilled.cloud/aws/s3";
 import { expect } from "alchemy-test";
 import * as Effect from "effect/Effect";
 
@@ -74,6 +76,103 @@ test.provider(
         yield* state.deleteStack({ stack: STACK, stage });
         expect(yield* state.list({ stack: STACK, stage })).toEqual([]);
       }).pipe(Effect.ensuring(cleanStage(state, stage)));
+    }),
+  { timeout: 120_000 },
+);
+
+test.provider(
+  "existing state buckets converge to secure defaults",
+  () =>
+    Effect.gen(function* () {
+      const { accountId, region } = yield* AWS.AWSEnvironment.current;
+      const bucketName = createStateBucketName(`security-${accountId}`, region);
+      const deleteBucket = s3.deleteBucket({ Bucket: bucketName }).pipe(
+        Effect.catchTag("NoSuchBucket", () => Effect.void),
+        Effect.orDie,
+      );
+
+      yield* s3
+        .deleteBucket({ Bucket: bucketName })
+        .pipe(Effect.catchTag("NoSuchBucket", () => Effect.void));
+
+      yield* Effect.gen(function* () {
+        // First create the bucket, then simulate out-of-band configuration
+        // drift. The second state service targets the SAME existing bucket and
+        // must repair every setting from observed cloud state.
+        const initial = yield* makeS3State({
+          bucketName,
+          prefix: "security-test",
+        });
+        yield* initial.listStacks();
+
+        yield* s3.putBucketVersioning({
+          Bucket: bucketName,
+          VersioningConfiguration: { Status: "Suspended" },
+        });
+        yield* s3.putBucketEncryption({
+          Bucket: bucketName,
+          ServerSideEncryptionConfiguration: {
+            Rules: [
+              {
+                ApplyServerSideEncryptionByDefault: {
+                  SSEAlgorithm: "aws:kms",
+                },
+              },
+            ],
+          },
+        });
+        yield* s3.putPublicAccessBlock({
+          Bucket: bucketName,
+          PublicAccessBlockConfiguration: {
+            BlockPublicAcls: false,
+            IgnorePublicAcls: false,
+            BlockPublicPolicy: false,
+            RestrictPublicBuckets: false,
+          },
+        });
+        yield* s3.putBucketOwnershipControls({
+          Bucket: bucketName,
+          OwnershipControls: {
+            Rules: [{ ObjectOwnership: "ObjectWriter" }],
+          },
+        });
+
+        const secured = yield* makeS3State({
+          bucketName,
+          prefix: "security-test",
+        });
+        yield* secured.listStacks();
+
+        const versioning = yield* s3.getBucketVersioning({
+          Bucket: bucketName,
+        });
+        expect(versioning.Status).toBe("Enabled");
+
+        const encryption = yield* s3.getBucketEncryption({
+          Bucket: bucketName,
+        });
+        expect(
+          encryption.ServerSideEncryptionConfiguration?.Rules?.[0]
+            ?.ApplyServerSideEncryptionByDefault?.SSEAlgorithm,
+        ).toBe("AES256");
+
+        const publicAccess = yield* s3.getPublicAccessBlock({
+          Bucket: bucketName,
+        });
+        expect(publicAccess.PublicAccessBlockConfiguration).toEqual({
+          BlockPublicAcls: true,
+          IgnorePublicAcls: true,
+          BlockPublicPolicy: true,
+          RestrictPublicBuckets: true,
+        });
+
+        const ownership = yield* s3.getBucketOwnershipControls({
+          Bucket: bucketName,
+        });
+        expect(ownership.OwnershipControls?.Rules?.[0]?.ObjectOwnership).toBe(
+          "BucketOwnerEnforced",
+        );
+      }).pipe(Effect.ensuring(deleteBucket));
     }),
   { timeout: 120_000 },
 );


### PR DESCRIPTION
## Summary

- make ECS service reconciliation wait for the exact task definition, completed rollout, settled desired/running/pending counts, old-task drain, and healthy ALB targets
- make deletion wait for task and target drain
- reconcile ECR tag mutability and scan-on-push for existing/adopted repositories
- harden AWS.state() buckets with versioning, encryption, bucket-owner ownership, and full public-access blocking
- keep every poll bounded, including a 30-minute ECS ceiling

## Validation

- `bun tsc -b`
- `bun run format:check`
- `bun run lint:providers`
- live AWS ECR reconciliation: 3/3 passed
- live AWS state-store convergence: 4/4 passed
- live AWS ECS service reconciliation/recovery: 4/4 passed across bounded sequential runs
- post-run inventory: zero `alchemy-test` ECR repositories, ECS clusters, or security-test S3 buckets

The live suites use an explicit `AWS_ACCOUNT_ID` resolved from STS because the current default AWS provider layer can deadlock while deriving it from the surrounding environment.