### PR TITLE
fix(bundle): stop CLI startup from loading rolldown's native binding

### DIFF
--- a/packages/alchemy/src/Bundle/Bundle.ts
+++ b/packages/alchemy/src/Bundle/Bundle.ts
@@ -6,14 +6,16 @@ import * as Stream from "effect/Stream";
 import assert from "node:assert";
 import type * as rolldown from "rolldown";
 import { sha256, sha256Object } from "../Util/sha256.ts";
-import type { BundleAnalyzerPluginOptions } from "./BundleAnalyzerPlugin.ts";
-import type { PurePluginOptions } from "./PurePlugin.ts";
+import {
+  bundleAnalyzerPlugin,
+  type BundleAnalyzerPluginOptions,
+} from "./BundleAnalyzerPlugin.ts";
+import { purePlugin, type PurePluginOptions } from "./PurePlugin.ts";
 import { rawPlugin } from "./RawPlugin.ts";
 
 /**
- * Rolldown (and the local plugins that import its native binding) are
- * loaded lazily on first {@link build}/{@link watch} so that merely
- * importing alchemy — the CLI command tree, the Cloudflare provider
+ * Rolldown is loaded lazily on first {@link build}/{@link watch} so that
+ * merely importing alchemy — the CLI command tree, the Cloudflare provider
  * barrel — never loads `@rolldown/binding-*`. A stack that bundles
  * nothing must not require the native bundler to be loadable (#562).
  */
@@ -361,13 +363,11 @@ async function builtInPlugins(
 ): Promise<rolldown.RolldownPluginOption> {
   return [
     extra?.bundleAnalyzer
-      ? (await import("./BundleAnalyzerPlugin.ts")).bundleAnalyzerPlugin(
+      ? await bundleAnalyzerPlugin(
           extra.bundleAnalyzer === true ? {} : extra.bundleAnalyzer,
         )
       : undefined,
-    extra?.pure !== false
-      ? (await import("./PurePlugin.ts")).purePlugin(extra?.pure ?? {})
-      : undefined,
+    extra?.pure !== false ? purePlugin(extra?.pure ?? {}) : undefined,
     rawPlugin(),
   ];
 }

--- a/packages/alchemy/src/Bundle/Bundle.ts
+++ b/packages/alchemy/src/Bundle/Bundle.ts
@@ -4,14 +4,20 @@ import * as Queue from "effect/Queue";
 import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 import assert from "node:assert";
-import * as rolldown from "rolldown";
+import type * as rolldown from "rolldown";
 import { sha256, sha256Object } from "../Util/sha256.ts";
-import {
-  bundleAnalyzerPlugin,
-  type BundleAnalyzerPluginOptions,
-} from "./BundleAnalyzerPlugin.ts";
-import { purePlugin, type PurePluginOptions } from "./PurePlugin.ts";
+import type { BundleAnalyzerPluginOptions } from "./BundleAnalyzerPlugin.ts";
+import type { PurePluginOptions } from "./PurePlugin.ts";
 import { rawPlugin } from "./RawPlugin.ts";
+
+/**
+ * Rolldown (and the local plugins that import its native binding) are
+ * loaded lazily on first {@link build}/{@link watch} so that merely
+ * importing alchemy — the CLI command tree, the Cloudflare provider
+ * barrel — never loads `@rolldown/binding-*`. A stack that bundles
+ * nothing must not require the native bundler to be loadable (#562).
+ */
+const loadRolldown = () => import("rolldown");
 
 /**
  * Extra options accepted by {@link build} / {@link watch} on top of the
@@ -148,9 +154,10 @@ export const build = (
 ): Effect.Effect<BundleOutput, BundleError> =>
   Effect.tryPromise({
     try: async () => {
+      const rolldown = await loadRolldown();
       const bundle = await rolldown.rolldown({
         ...withAlchemyDefine(inputOptions),
-        plugins: [inputOptions.plugins, builtInPlugins(extra)],
+        plugins: [inputOptions.plugins, await builtInPlugins(extra)],
         optimization: inputOptions.optimization ?? {
           inlineConst: {
             mode: "smart",
@@ -188,12 +195,13 @@ export const watch = (
       }
   >((queue) =>
     Effect.acquireRelease(
-      Effect.sync(() => {
+      Effect.promise(async () => {
+        const rolldown = await loadRolldown();
         const watcher = rolldown.watch({
           ...withAlchemyDefine(inputOptions),
           plugins: [
             inputOptions.plugins,
-            builtInPlugins(extra),
+            await builtInPlugins(extra),
             // The watcher event listener does not receive the bundle output, so we grab it using a plugin.
             {
               name: "alchemy:watch-bundle",
@@ -348,16 +356,18 @@ export function bundleOutputFromRolldownOutputBundle(
  * `node_modules/<pkg>/...` by upstream resolver plugins such as
  * `@distilled.cloud/cloudflare-rolldown-plugin`.
  */
-function builtInPlugins(
+async function builtInPlugins(
   extra?: BundleExtraOptions,
-): rolldown.RolldownPluginOption {
+): Promise<rolldown.RolldownPluginOption> {
   return [
     extra?.bundleAnalyzer
-      ? bundleAnalyzerPlugin(
+      ? (await import("./BundleAnalyzerPlugin.ts")).bundleAnalyzerPlugin(
           extra.bundleAnalyzer === true ? {} : extra.bundleAnalyzer,
         )
       : undefined,
-    extra?.pure !== false ? purePlugin(extra?.pure ?? {}) : undefined,
+    extra?.pure !== false
+      ? (await import("./PurePlugin.ts")).purePlugin(extra?.pure ?? {})
+      : undefined,
     rawPlugin(),
   ];
 }

--- a/packages/alchemy/src/Bundle/BundleAnalyzerPlugin.ts
+++ b/packages/alchemy/src/Bundle/BundleAnalyzerPlugin.ts
@@ -1,5 +1,4 @@
 import type { Plugin } from "rolldown";
-import { bundleAnalyzerPlugin as rolldownBundleAnalyzerPlugin } from "rolldown/experimental";
 
 export interface BundleAnalyzerPluginOptions {
   /**
@@ -24,10 +23,16 @@ export interface BundleAnalyzerPluginOptions {
  * - import dependencies between chunks
  * - the modules reachable from each entry point
  */
-export const bundleAnalyzerPlugin = (
+export const bundleAnalyzerPlugin = async (
   options: BundleAnalyzerPluginOptions = {},
-): Plugin =>
-  rolldownBundleAnalyzerPlugin({
+): Promise<Plugin> => {
+  // `rolldown/experimental` loads `@rolldown/binding-*` at module scope,
+  // so it is imported lazily — importing this module (e.g. via the
+  // `alchemy/Bundle` barrel) must never load the native binding (#562).
+  const { bundleAnalyzerPlugin: rolldownBundleAnalyzerPlugin } =
+    await import("rolldown/experimental");
+  return rolldownBundleAnalyzerPlugin({
     fileName: options.fileName,
     format: options.format ?? "md",
   });
+};

--- a/packages/alchemy/src/Bundle/PurePlugin.ts
+++ b/packages/alchemy/src/Bundle/PurePlugin.ts
@@ -13,8 +13,15 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import picomatch from "picomatch";
 import type * as rolldown from "rolldown";
-import { RolldownMagicString } from "rolldown";
-import { parseAst } from "rolldown/parseAst";
+
+/**
+ * `rolldown` and `rolldown/parseAst` load `@rolldown/binding-*` at module
+ * scope, so they are imported lazily on first use — importing this module
+ * (e.g. via the `alchemy/Bundle` barrel) must never load the native
+ * binding (#562).
+ */
+const loadRolldown = () => import("rolldown");
+const loadParseAst = () => import("rolldown/parseAst");
 
 /**
  * Default packages whose modules will receive `/*#__PURE__*\/` annotations.
@@ -149,7 +156,7 @@ export const purePlugin = (
         const markSideEffectFree =
           markSideEffectFreeOpt && !isEntry && sideEffectFreePkg;
 
-        const anchors = collectPureAnchorsCached(code, cleanId);
+        const anchors = await collectPureAnchorsCached(code, cleanId);
         // Annotating a call whose result is BOUND (variable initializer,
         // export) only lets the minifier drop it when the binding itself
         // is unused — safe everywhere. Annotating a call whose result is
@@ -175,7 +182,9 @@ export const purePlugin = (
         // `code`. Returning it as `code` hands sourcemap generation to
         // rolldown's native side (computed on a background thread). The
         // fallback covers direct hook invocations (unit tests).
-        const s = meta.magicString ?? new RolldownMagicString(code);
+        const s =
+          meta.magicString ??
+          new (await loadRolldown()).RolldownMagicString(code);
         for (const anchor of positions) s.appendLeft(anchor, PURE_COMMENT);
         return {
           code: s,
@@ -342,15 +351,15 @@ const anchorsCache = new Map<
 >();
 const ANCHORS_CACHE_MAX = 10_000;
 
-const collectPureAnchorsCached = (
+const collectPureAnchorsCached = async (
   code: string,
   filename: string,
-): PureAnchors | null => {
+): Promise<PureAnchors | null> => {
   const cached = anchorsCache.get(filename);
   if (cached !== undefined && cached.code === code) {
     return cached.anchors;
   }
-  const anchors = collectPureAnchors(code, filename);
+  const anchors = await collectPureAnchors(code, filename);
   if (anchorsCache.size >= ANCHORS_CACHE_MAX) {
     anchorsCache.clear();
   }
@@ -386,10 +395,11 @@ export interface PureAnchors {
  * Returns `null` if the file does not need to be modified (parse failure
  * or no annotations needed).
  */
-export function collectPureAnchors(
+export async function collectPureAnchors(
   code: string,
   filename: string,
-): PureAnchors | null {
+): Promise<PureAnchors | null> {
+  const { parseAst } = await loadParseAst();
   let program: Program;
   try {
     // Use TS lang so the parser tolerates TS syntax (`as`, `satisfies`,

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerBundle.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerBundle.ts
@@ -1,4 +1,3 @@
-import cloudflareRolldown from "@distilled.cloud/cloudflare-rolldown-plugin";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import { flow } from "effect/Function";
@@ -64,6 +63,12 @@ export const WorkerBundle = Effect.gen(function* () {
   const virtualEntryPlugin = yield* Bundle.virtualEntryPlugin;
 
   const makeOptions = Effect.fn(function* (options: WorkerBundleOptions) {
+    // Loaded lazily so importing the Cloudflare provider (or the CLI, whose
+    // command tree reaches this module) never loads rolldown's native
+    // binding — only actually bundling a Worker does (#562).
+    const { default: cloudflareRolldown } = yield* Effect.promise(
+      () => import("@distilled.cloud/cloudflare-rolldown-plugin"),
+    );
     const realMain = yield* sanitizeMain(options.main);
     const inputOptions: rolldown.InputOptions = {
       input: realMain,

--- a/packages/alchemy/test/Bundle/LazyRolldown.test.ts
+++ b/packages/alchemy/test/Bundle/LazyRolldown.test.ts
@@ -1,0 +1,64 @@
+import { exec } from "@/Util/exec.ts";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { describe, expect, it } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import { ChildProcess } from "effect/unstable/process";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Regression tests for #562: importing alchemy's CLI or provider modules
+ * must never load rolldown's native binding (`@rolldown/binding-*`). A
+ * user whose stack bundles nothing (e.g. a non-Cloudflare stack running
+ * `alchemy deploy`) must not require the native bundler to be loadable.
+ *
+ * Each entry is imported in a fresh subprocess — the single-process test
+ * runner has long since loaded rolldown for other suites, so the check
+ * can only be made in an isolated module registry. `process.dlopen` is
+ * the choke point every native-addon load goes through, so intercepting
+ * it detects the binding no matter which package (`rolldown`,
+ * `rolldown/parseAst`, `@distilled.cloud/cloudflare-rolldown-plugin`)
+ * pulled it in.
+ */
+
+const entries = [
+  "src/Bundle/index.ts",
+  "src/Cli/main.ts",
+  "src/Cloudflare/index.ts",
+] as const;
+
+const importInSubprocess = (entry: string) => {
+  const entryPath = fileURLToPath(new URL(`../../${entry}`, import.meta.url));
+  const script = `
+    const orig = process.dlopen;
+    const loaded = [];
+    process.dlopen = function (mod, path, ...rest) {
+      loaded.push(path);
+      return orig.call(process, mod, path, ...rest);
+    };
+    await import(${JSON.stringify(entryPath)});
+    const hits = loaded.filter((p) => p.includes("rolldown"));
+    if (hits.length > 0) {
+      console.error("rolldown native binding loaded by:\\n" + hits.join("\\n"));
+      process.exit(1);
+    }
+    console.log("no rolldown native binding loaded");
+  `;
+  return exec(
+    ChildProcess.make(process.execPath, ["-e", script], { shell: false }),
+  ).pipe(Effect.scoped);
+};
+
+describe("lazy rolldown (#562)", () => {
+  for (const entry of entries) {
+    it.effect(
+      `importing ${entry} does not load rolldown's native binding`,
+      () =>
+        Effect.gen(function* () {
+          const { exitCode, stdout, stderr } = yield* importInSubprocess(entry);
+          expect(stderr).toBe("");
+          expect(stdout).toContain("no rolldown native binding loaded");
+          expect(exitCode).toBe(0);
+        }).pipe(Effect.provide(NodeServices.layer)),
+    );
+  }
+});

--- a/packages/alchemy/test/Bundle/PurePlugin.test.ts
+++ b/packages/alchemy/test/Bundle/PurePlugin.test.ts
@@ -151,16 +151,16 @@ describe("collectPureAnchors", () => {
   };
   // Applies BOTH bound and discarded anchors — the full-annotation view a
   // sideEffects-free package receives.
-  const annotate = (code: string): string | null => {
-    const anchors = collectPureAnchors(code, "/n/effect/dist/x.js");
+  const annotate = async (code: string): Promise<string | null> => {
+    const anchors = await collectPureAnchors(code, "/n/effect/dist/x.js");
     return anchors === null
       ? null
       : apply(code, [...anchors.bound, ...anchors.discarded]);
   };
 
-  it("annotates calls in TypeScript source (worker/bun condition path)", () => {
+  it("annotates calls in TypeScript source (worker/bun condition path)", async () => {
     const code = `import { make } from "./util";\nexport const x: number = make();\n`;
-    const anchors = collectPureAnchors(
+    const anchors = await collectPureAnchors(
       code,
       "/proj/packages/alchemy/src/Util.ts",
     );
@@ -168,26 +168,29 @@ describe("collectPureAnchors", () => {
     expect(apply(code, anchors!.bound)).toContain("/*#__PURE__*/ make()");
   });
 
-  it("classifies variable-initializer calls as bound", () => {
-    const anchors = collectPureAnchors(`const x = create();`, "/n/x.js");
+  it("classifies variable-initializer calls as bound", async () => {
+    const anchors = await collectPureAnchors(`const x = create();`, "/n/x.js");
     expect(anchors!.bound.length).toBe(1);
     expect(anchors!.discarded.length).toBe(0);
   });
 
-  it("classifies bare expression-statement calls as discarded", () => {
-    const anchors = collectPureAnchors(`app.get("/", handler);`, "/n/x.js");
+  it("classifies bare expression-statement calls as discarded", async () => {
+    const anchors = await collectPureAnchors(
+      `app.get("/", handler);`,
+      "/n/x.js",
+    );
     expect(anchors!.bound.length).toBe(0);
     expect(anchors!.discarded.length).toBe(1);
   });
 
-  it("classifies assignment right-hand sides as bound, even in statement position", () => {
-    const anchors = collectPureAnchors(`exports.x = make();`, "/n/x.js");
+  it("classifies assignment right-hand sides as bound, even in statement position", async () => {
+    const anchors = await collectPureAnchors(`exports.x = make();`, "/n/x.js");
     expect(anchors!.bound.length).toBe(1);
     expect(anchors!.discarded.length).toBe(0);
   });
 
-  it("classifies non-final sequence expressions as discarded even in initializers", () => {
-    const anchors = collectPureAnchors(
+  it("classifies non-final sequence expressions as discarded even in initializers", async () => {
+    const anchors = await collectPureAnchors(
       `const x = (register(), make());`,
       "/n/x.js",
     );
@@ -195,72 +198,72 @@ describe("collectPureAnchors", () => {
     expect(anchors!.discarded.length).toBe(1);
   });
 
-  it("classifies optional-chained statement calls as discarded", () => {
-    const anchors = collectPureAnchors(`app?.get("/", h);`, "/n/x.js");
+  it("classifies optional-chained statement calls as discarded", async () => {
+    const anchors = await collectPureAnchors(`app?.get("/", h);`, "/n/x.js");
     expect(anchors!.bound.length).toBe(0);
     expect(anchors!.discarded.length).toBe(1);
   });
 
-  it("annotates top-level call expressions", () => {
-    expect(annotate(`const x = create();`)).toBe(
+  it("annotates top-level call expressions", async () => {
+    expect(await annotate(`const x = create();`)).toBe(
       `const x = /*#__PURE__*/ create();`,
     );
   });
 
-  it("annotates top-level new expressions", () => {
-    expect(annotate(`const x = new Klass();`)).toBe(
+  it("annotates top-level new expressions", async () => {
+    expect(await annotate(`const x = new Klass();`)).toBe(
       `const x = /*#__PURE__*/ new Klass();`,
     );
   });
 
-  it("annotates calls inside named exports", () => {
-    expect(annotate(`export const x = make();`)).toBe(
+  it("annotates calls inside named exports", async () => {
+    expect(await annotate(`export const x = make();`)).toBe(
       `export const x = /*#__PURE__*/ make();`,
     );
   });
 
-  it("annotates calls inside default exports", () => {
-    expect(annotate(`export default make();`)).toBe(
+  it("annotates calls inside default exports", async () => {
+    expect(await annotate(`export default make();`)).toBe(
       `export default /*#__PURE__*/ make();`,
     );
   });
 
-  it("does NOT annotate calls inside function bodies", () => {
-    expect(annotate(`function f() { return inner(); }`)).toBeNull();
+  it("does NOT annotate calls inside function bodies", async () => {
+    expect(await annotate(`function f() { return inner(); }`)).toBeNull();
   });
 
-  it("does NOT annotate IIFEs", () => {
-    expect(annotate(`(function () { sideEffect(); })();`)).toBeNull();
+  it("does NOT annotate IIFEs", async () => {
+    expect(await annotate(`(function () { sideEffect(); })();`)).toBeNull();
   });
 
-  it("does NOT annotate arrow IIFEs", () => {
-    expect(annotate(`(() => sideEffect())();`)).toBeNull();
+  it("does NOT annotate arrow IIFEs", async () => {
+    expect(await annotate(`(() => sideEffect())();`)).toBeNull();
   });
 
-  it("skips already-annotated calls", () => {
-    expect(annotate(`const x = /*#__PURE__*/ create();`)).toBeNull();
+  it("skips already-annotated calls", async () => {
+    expect(await annotate(`const x = /*#__PURE__*/ create();`)).toBeNull();
   });
 
-  it("annotates calls through ts-as expressions", () => {
-    expect(annotate(`const x = make() as Foo;`)).toContain(
+  it("annotates calls through ts-as expressions", async () => {
+    expect(await annotate(`const x = make() as Foo;`)).toContain(
       "/*#__PURE__*/ make()",
     );
   });
 
-  it("annotates both branches of ternary initializers", () => {
-    const result = annotate(`const x = cond ? a() : b();`);
+  it("annotates both branches of ternary initializers", async () => {
+    const result = await annotate(`const x = cond ? a() : b();`);
     expect(result).toContain("/*#__PURE__*/ a()");
     expect(result).toContain("/*#__PURE__*/ b()");
   });
 
-  it("preserves line numbers", () => {
+  it("preserves line numbers", async () => {
     const input = `const a = first();\nconst b = second();\n`;
-    const result = annotate(input);
+    const result = await annotate(input);
     expect(result!.split("\n").length).toBe(input.split("\n").length);
   });
 
-  it("returns null on unparseable input", () => {
-    expect(collectPureAnchors(`const x = {;`, "/n/x.js")).toBeNull();
+  it("returns null on unparseable input", async () => {
+    expect(await collectPureAnchors(`const x = {;`, "/n/x.js")).toBeNull();
   });
 });
 


### PR DESCRIPTION
`alchemy/Cli/main` (and the `alchemy/Cloudflare` barrel) eagerly loaded rolldown's native binding at import time, so `alchemy deploy` crashed on non-Cloudflare stacks whenever `@rolldown/binding-*` couldn't load. Rolldown and everything that pulls in its native binding are now imported lazily, on first bundle build/watch.

```diff
// src/Cloudflare/Workers/WorkerBundle.ts
-import cloudflareRolldown from "@distilled.cloud/cloudflare-rolldown-plugin";
   const makeOptions = Effect.fn(function* (options: WorkerBundleOptions) {
+    const { default: cloudflareRolldown } = yield* Effect.promise(
+      () => import("@distilled.cloud/cloudflare-rolldown-plugin"),
+    );
```

```diff
// src/Bundle/Bundle.ts
-import * as rolldown from "rolldown";
+import type * as rolldown from "rolldown";
+const loadRolldown = () => import("rolldown");
```

- `Bundle.build` / `Bundle.watch` await `import("rolldown")` inside the effect
- `PurePlugin.ts` lazily imports `rolldown` / `rolldown/parseAst` (`collectPureAnchors` becomes async; its only production caller was already the async transform hook)
- `bundleAnalyzerPlugin` becomes async and lazily imports `rolldown/experimental`
- `WorkerBundle` dynamically imports `@distilled.cloud/cloudflare-rolldown-plugin` inside `makeOptions`

`test/Bundle/LazyRolldown.test.ts` guards the regression: it imports `Bundle/index.ts`, `Cli/main.ts`, and `Cloudflare/index.ts` each in a fresh subprocess with `process.dlopen` intercepted, and fails if any `rolldown` native module is loaded. Both import paths also verified to succeed with the binding forcibly broken (the reporter's failure mode). `test/Bundle` (86 passed) and the live `WorkerBundle` / `DrizzleSchemaChunks` / `PrebuiltWorkerBundle` suites (deploy+serve) cover the lazy paths.

Fixes #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)
