### PR TITLE
fix(planetscale): stop false role replacement on metadata-only branch/database updates

### DIFF
--- a/packages/alchemy/src/Planetscale/Branch.ts
+++ b/packages/alchemy/src/Planetscale/Branch.ts
@@ -4,7 +4,7 @@ import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
 import { Unowned } from "../AdoptPolicy.ts";
-import { isResolved } from "../Diff.ts";
+import { havePropsChanged, isResolved } from "../Diff.ts";
 import { createPhysicalName } from "../PhysicalName.ts";
 import * as Provider from "../Provider.ts";
 import type { ResourceClass, ResourceLike } from "../Resource.ts";
@@ -263,6 +263,29 @@ export const makeBranchProvider = <R extends ResourceLike>(opts: {
     diff: Effect.fn(function* ({ news, olds, output }: any) {
       if (!isResolved(news)) return undefined;
 
+      // Branch names are rename-mutable (reconcile syncs `news.name` in
+      // place), so `name` cannot live in the provider-level stables. But
+      // almost no update is a rename — for those, advertise `name` as
+      // stable on the update so downstream consumers referencing this
+      // branch still resolve `branch.name` at plan time. Without it, a
+      // metadata-only update (e.g. an embedded database ref whose
+      // `migrationsHashes` moved) resolves consumer refs to just
+      // `{ organization, database }`, and identity-sensitive consumers
+      // (PostgresRole) falsely plan a replacement against `name: undefined`.
+      //
+      // The name only changes when the `name` prop itself changes: an
+      // explicit name renames iff it differs from the observed name, and
+      // an omitted name is engine-generated deterministically (stable
+      // across updates — the instance id only rotates on replacement).
+      const nameIsStable =
+        output?.name !== undefined &&
+        (news.name !== undefined
+          ? news.name === output.name
+          : olds?.name === undefined);
+      const stables = nameIsStable
+        ? ["organization", "database", "name"]
+        : undefined;
+
       const newDb = resolveDatabase(news.database).name;
       const oldDbRef = output?.database ?? olds.database;
       if (oldDbRef) {
@@ -289,7 +312,7 @@ export const makeBranchProvider = <R extends ResourceLike>(opts: {
 
       if (news.replicas !== undefined) {
         if (output?.desiredReplicas !== news.replicas) {
-          return { action: "update" } as const;
+          return { action: "update", stables } as const;
         }
 
         const desiredHasReplicas = news.replicas > 0;
@@ -297,27 +320,37 @@ export const makeBranchProvider = <R extends ResourceLike>(opts: {
           output?.hasReplicas !== undefined &&
           output.hasReplicas !== desiredHasReplicas
         ) {
-          return { action: "update" } as const;
+          return { action: "update", stables } as const;
         }
       }
 
       if (news.migrationsDir) {
         const newHashes = yield* hashMigrations(news.migrationsDir);
         if (!recordsEqual(newHashes, output?.migrationsHashes ?? {})) {
-          return { action: "update" } as const;
+          return { action: "update", stables } as const;
         }
         if (
           (news.migrationsTable ?? DEFAULT_MIGRATIONS_TABLE) !==
           (output?.migrationsTable ?? DEFAULT_MIGRATIONS_TABLE)
         ) {
-          return { action: "update" } as const;
+          return { action: "update", stables } as const;
         }
       }
       if (news.importFiles?.length) {
         const newHashes = yield* hashImports(news.importFiles, yield* rootDir);
         if (!recordsEqual(newHashes, output?.importHashes ?? {})) {
-          return { action: "update" } as const;
+          return { action: "update", stables } as const;
         }
+      }
+
+      // Remaining prop changes (rename, safeMigrations, clusterSize,
+      // metadata embedded in resource refs) are all in-place updates.
+      // Decide them here instead of falling back to the engine's default
+      // deep-compare so the conditional `name` stable above is attached —
+      // the default path uses the provider-level stables, which strip
+      // `name` from downstream plan resolution.
+      if (havePropsChanged(olds, news)) {
+        return { action: "update", stables } as const;
       }
 
       return undefined;

--- a/packages/alchemy/src/Planetscale/MySQL/MySQLDatabase.ts
+++ b/packages/alchemy/src/Planetscale/MySQL/MySQLDatabase.ts
@@ -2,7 +2,7 @@ import { Credentials } from "@distilled.cloud/planetscale/Credentials";
 import * as planetscale from "@distilled.cloud/planetscale/Operations";
 import * as Effect from "effect/Effect";
 import * as Stream from "effect/Stream";
-import { isResolved } from "../../Diff.ts";
+import { havePropsChanged, isResolved } from "../../Diff.ts";
 import { createPhysicalName } from "../../PhysicalName.ts";
 import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
@@ -178,6 +178,25 @@ export const MySQLDatabaseProvider = () =>
     diff: Effect.fn(function* ({ news, olds, output }) {
       if (!isResolved(news)) return undefined;
 
+      // Database names are rename-mutable (reconcile folds `new_name`
+      // into the settings sync), so `name` cannot live in the
+      // provider-level stables. Almost no update is a rename though —
+      // for those, advertise `name` as stable on the update so
+      // downstream consumers (branches, passwords) still resolve
+      // `database.name` at plan time instead of seeing `undefined` and
+      // falsely planning a replacement. The name only changes when the
+      // `name` prop itself changes: an explicit name renames iff it
+      // differs from the observed name, and an omitted name is
+      // engine-generated deterministically (stable across updates).
+      const nameIsStable =
+        output?.name !== undefined &&
+        (news.name !== undefined
+          ? news.name === output.name
+          : olds?.name === undefined);
+      const stables = nameIsStable
+        ? ["id", "organization", "region", "name"]
+        : undefined;
+
       if (
         news.region?.slug !== undefined &&
         output?.region?.slug !== undefined &&
@@ -192,27 +211,36 @@ export const MySQLDatabaseProvider = () =>
         news.replicas !== undefined &&
         news.replicas !== (output?.replicas ?? olds.replicas)
       ) {
-        return { action: "update" } as const;
+        return { action: "update", stables } as const;
       }
       if (news.migrationsDir) {
         const newHashes = yield* hashMigrations(news.migrationsDir);
         if (!recordsEqual(newHashes, output?.migrationsHashes ?? {})) {
-          return { action: "update" } as const;
+          return { action: "update", stables } as const;
         }
         if (
           (news.migrationsTable ?? DEFAULT_MIGRATIONS_TABLE) !==
           (output?.migrationsTable ?? DEFAULT_MIGRATIONS_TABLE)
         ) {
-          return { action: "update" } as const;
+          return { action: "update", stables } as const;
         }
       }
       if (news.importFiles?.length) {
         const newHashes = yield* hashImports(news.importFiles, yield* rootDir);
         if (!recordsEqual(newHashes, output?.importHashes ?? {})) {
-          return { action: "update" } as const;
+          return { action: "update", stables } as const;
         }
       }
-      // Otherwise allow the engine to apply the default update logic.
+      // Remaining prop changes (rename, settings, clusterSize, …) are
+      // in-place updates. Decide them here instead of falling back to
+      // the engine's default deep-compare so the conditional `name`
+      // stable above is attached — the default path uses the
+      // provider-level stables, which strip `name` from downstream plan
+      // resolution.
+      if (havePropsChanged(olds, news)) {
+        return { action: "update", stables } as const;
+      }
+
       return undefined;
     }),
 

--- a/packages/alchemy/src/Planetscale/Postgres/PostgresDatabase.ts
+++ b/packages/alchemy/src/Planetscale/Postgres/PostgresDatabase.ts
@@ -2,7 +2,7 @@ import { Credentials } from "@distilled.cloud/planetscale/Credentials";
 import * as planetscale from "@distilled.cloud/planetscale/Operations";
 import * as Effect from "effect/Effect";
 import * as Stream from "effect/Stream";
-import { isResolved } from "../../Diff.ts";
+import { havePropsChanged, isResolved } from "../../Diff.ts";
 import { createPhysicalName } from "../../PhysicalName.ts";
 import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
@@ -110,6 +110,25 @@ export const PostgresDatabaseProvider = () =>
     diff: Effect.fn(function* ({ news, olds, output }) {
       if (!isResolved(news)) return undefined;
 
+      // Database names are rename-mutable (reconcile folds `new_name`
+      // into the settings sync), so `name` cannot live in the
+      // provider-level stables. Almost no update is a rename though —
+      // for those, advertise `name` as stable on the update so
+      // downstream consumers (branches, roles) still resolve
+      // `database.name` at plan time instead of seeing `undefined` and
+      // falsely planning a replacement. The name only changes when the
+      // `name` prop itself changes: an explicit name renames iff it
+      // differs from the observed name, and an omitted name is
+      // engine-generated deterministically (stable across updates).
+      const nameIsStable =
+        output?.name !== undefined &&
+        (news.name !== undefined
+          ? news.name === output.name
+          : olds?.name === undefined);
+      const stables = nameIsStable
+        ? ["id", "organization", "region", "name"]
+        : undefined;
+
       if (
         news.region?.slug &&
         output?.region?.slug &&
@@ -130,23 +149,32 @@ export const PostgresDatabaseProvider = () =>
       if (news.migrationsDir) {
         const newHashes = yield* hashMigrations(news.migrationsDir);
         if (!recordsEqual(newHashes, output?.migrationsHashes ?? {})) {
-          return { action: "update" } as const;
+          return { action: "update", stables } as const;
         }
         if (
           (news.migrationsTable ?? DEFAULT_MIGRATIONS_TABLE) !==
           (output?.migrationsTable ?? DEFAULT_MIGRATIONS_TABLE)
         ) {
-          return { action: "update" } as const;
+          return { action: "update", stables } as const;
         }
       }
       if (news.importFiles?.length) {
         const newHashes = yield* hashImports(news.importFiles, yield* rootDir);
         if (!recordsEqual(newHashes, output?.importHashes ?? {})) {
-          return { action: "update" } as const;
+          return { action: "update", stables } as const;
         }
       }
 
-      // Otherwise allow the engine to apply the default update logic.
+      // Remaining prop changes (rename, settings, clusterSize, …) are
+      // in-place updates. Decide them here instead of falling back to
+      // the engine's default deep-compare so the conditional `name`
+      // stable above is attached — the default path uses the
+      // provider-level stables, which strip `name` from downstream plan
+      // resolution.
+      if (havePropsChanged(olds, news)) {
+        return { action: "update", stables } as const;
+      }
+
       return undefined;
     }),
 

--- a/packages/alchemy/test/Planetscale/Branch.test.ts
+++ b/packages/alchemy/test/Planetscale/Branch.test.ts
@@ -75,7 +75,12 @@ test.provider("diff tracks Postgres branch replica intent", () =>
         hasReadOnlyReplicas: false,
       }),
     });
-    expect(exactHaCountChanged).toEqual({ action: "update" });
+    // A non-renaming update advertises `name` as stable so downstream
+    // consumers keep resolving `branch.name` at plan time.
+    expect(exactHaCountChanged).toEqual({
+      action: "update",
+      stables: ["organization", "database", "name"],
+    });
   }),
 );
 

--- a/packages/alchemy/test/Planetscale/PlanStables.test.ts
+++ b/packages/alchemy/test/Planetscale/PlanStables.test.ts
@@ -1,0 +1,328 @@
+import * as Plan from "@/Plan";
+import * as Planetscale from "@/Planetscale";
+import * as Stack from "@/Stack";
+import { Stage } from "@/Stage";
+import {
+  InMemoryService,
+  inMemoryState,
+  State,
+  type ResourceState,
+} from "@/State";
+import * as Test from "@/Test/Alchemy";
+import { describe, expect } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Redacted from "effect/Redacted";
+
+const TEST_STACK = "planetscale-plan-stables";
+const TEST_STAGE = "test";
+
+// Fresh in-memory state per test run so seeded resources from one test
+// don't leak into another in the same file.
+const freshState = Layer.effect(
+  State,
+  Effect.sync(() => InMemoryService({})),
+);
+
+const { test } = Test.make({
+  providers: Planetscale.providers(),
+  state: freshState,
+});
+
+const seed = (resources: Record<string, ResourceState>) =>
+  Effect.gen(function* () {
+    const state = yield* yield* State;
+    for (const [fqn, value] of Object.entries(resources)) {
+      yield* state.set({ stack: TEST_STACK, stage: TEST_STAGE, fqn, value });
+    }
+  });
+
+const instanceId = "852f6ec2e19b66589825efe14dca2971";
+
+const makePlan = <A, Err = never, Req = never>(
+  effect: Effect.Effect<A, Err, Req>,
+): Effect.Effect<Plan.Plan<A>, Err, State> =>
+  // @ts-expect-error - Stack.make's typing erases R unsoundly here
+  Effect.gen(function* () {
+    // @ts-expect-error
+    return yield* effect.pipe(
+      // @ts-expect-error
+      Stack.make({
+        name: TEST_STACK,
+        providers: Layer.empty,
+        state: inMemoryState(),
+      }),
+      Effect.provideService(Stage, TEST_STAGE),
+      Effect.flatMap((stackSpec: any) => Plan.make(stackSpec)),
+      Effect.provide(Planetscale.providers()),
+    );
+  });
+
+const ORG = "test-org";
+const DB_NAME = "relay-db";
+const BRANCH_NAME = "relay-branch";
+const ROLE_NAME = "relay-role";
+
+/** Attributes of the database as persisted after a previous deploy. */
+const databaseAttrs = (migrationsHashes: Record<string, string>) => ({
+  id: "db_123",
+  name: DB_NAME,
+  organization: ORG,
+  state: "ready",
+  defaultBranch: "main",
+  plan: "scaler",
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+  htmlUrl: `https://app.planetscale.com/${ORG}/${DB_NAME}`,
+  region: { slug: "us-east" },
+  migrationsDir: "./migrations",
+  migrationsTable: "relay_migrations",
+  migrationsHashes,
+  importHashes: {},
+  clusterSize: "PS_10",
+  arch: "x86" as const,
+  requireApprovalForDeploy: false,
+  restrictBranchRegion: false,
+  productionBranchWebConsole: false,
+});
+
+const branchAttrs = () => ({
+  name: BRANCH_NAME,
+  organization: ORG,
+  database: DB_NAME,
+  parentBranch: "main",
+  production: false,
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+  htmlUrl: `https://app.planetscale.com/${ORG}/${DB_NAME}/${BRANCH_NAME}`,
+  region: { slug: "us-east" },
+  migrationsDir: undefined,
+  migrationsTable: undefined,
+  migrationsHashes: {},
+  importHashes: {},
+  desiredReplicas: undefined,
+  hasReplicas: false,
+  hasReadOnlyReplicas: false,
+});
+
+const roleAttrs = () => ({
+  id: "role_123",
+  name: ROLE_NAME,
+  expiresAt: null,
+  host: "gateway.psdb.cloud",
+  username: ROLE_NAME,
+  password: Redacted.make("secret"),
+  database: DB_NAME,
+  databaseName: "postgres",
+  origin: {
+    scheme: "postgres",
+    host: "gateway.psdb.cloud",
+    port: 5432,
+    database: "postgres",
+    user: ROLE_NAME,
+    password: Redacted.make("secret"),
+  },
+  pooledOrigin: {
+    scheme: "postgres",
+    host: "gateway.psdb.cloud",
+    port: 6432,
+    database: "postgres",
+    user: ROLE_NAME,
+    password: Redacted.make("secret"),
+  },
+  connectionUrl: Redacted.make("postgresql://..."),
+  connectionUrlPooled: Redacted.make("postgresql://..."),
+  inheritedRoles: ["pg_read_all_data"],
+  successor: "postgres",
+  organization: ORG,
+  branch: BRANCH_NAME,
+  ttl: null,
+});
+
+const stateRow = (
+  fqn: string,
+  resourceType: string,
+  props: Record<string, unknown>,
+  attr: Record<string, unknown>,
+): ResourceState => ({
+  instanceId,
+  providerVersion: 0,
+  logicalId: fqn,
+  fqn,
+  namespace: undefined,
+  resourceType,
+  status: "created",
+  props,
+  attr,
+  bindings: [],
+  downstream: [],
+});
+
+describe("Planetscale plan-time name stables", () => {
+  // Regression: a metadata-only update on a PostgresBranch (e.g. a
+  // referenced database's `migrationsHashes` moved) must not strip
+  // `branch.name` from downstream plan resolution — PostgresRole used to
+  // compare the old branch name against `undefined` and falsely plan a
+  // replacement (rotating credentials and crashing on the replacement's
+  // reconcile with `branch: undefined`).
+  test(
+    "role updates (not replaces) when its branch gets a metadata-only update",
+    Effect.gen(function* () {
+      // The database is an external ref (another stack/stage); its attrs
+      // arrive in props as a plain object. The previous deploy persisted
+      // the old migration hash; the new plan resolves the new one.
+      const oldDatabase = databaseAttrs({ "0001_init.sql": "aaa" });
+      const newDatabase = databaseAttrs({
+        "0001_init.sql": "aaa",
+        "0002_add_table.sql": "bbb",
+      });
+
+      yield* seed({
+        Branch: stateRow(
+          "Branch",
+          "Planetscale.PostgresBranch",
+          { name: BRANCH_NAME, database: oldDatabase },
+          branchAttrs(),
+        ),
+        Role: stateRow(
+          "Role",
+          "Planetscale.PostgresRole",
+          {
+            name: ROLE_NAME,
+            database: oldDatabase,
+            branch: branchAttrs(),
+            inheritedRoles: ["pg_read_all_data"],
+          },
+          roleAttrs(),
+        ),
+      });
+
+      const plan = yield* Effect.gen(function* () {
+        const branch = yield* Planetscale.PostgresBranch("Branch", {
+          name: BRANCH_NAME,
+          database: newDatabase as unknown as Planetscale.PostgresDatabase,
+        });
+        yield* Planetscale.PostgresRole("Role", {
+          name: ROLE_NAME,
+          database: newDatabase as unknown as Planetscale.PostgresDatabase,
+          branch,
+          inheritedRoles: ["pg_read_all_data"],
+        });
+      }).pipe(makePlan);
+
+      expect(plan.resources.Branch!.action).toBe("update");
+      // The branch update is not a rename, so `branch.name` stays
+      // resolvable and the role must not be replaced.
+      expect(plan.resources.Role!.action).toBe("update");
+    }),
+  );
+
+  // Regression: an in-place update on a PostgresDatabase (settings toggle,
+  // new migration hash, …) must keep `database.name` resolvable — the
+  // branch used to compare its persisted database name against `undefined`
+  // and plan a replacement, cascading into the role.
+  test(
+    "branch and role update (not replace) when the database gets an in-place update",
+    Effect.gen(function* () {
+      const dbAttrs = databaseAttrs({});
+
+      yield* seed({
+        Db: stateRow(
+          "Db",
+          "Planetscale.PostgresDatabase",
+          {
+            name: DB_NAME,
+            clusterSize: "PS_10",
+            requireApprovalForDeploy: false,
+          },
+          dbAttrs,
+        ),
+        Branch: stateRow(
+          "Branch",
+          "Planetscale.PostgresBranch",
+          { name: BRANCH_NAME, database: dbAttrs },
+          branchAttrs(),
+        ),
+        Role: stateRow(
+          "Role",
+          "Planetscale.PostgresRole",
+          {
+            name: ROLE_NAME,
+            database: dbAttrs,
+            branch: branchAttrs(),
+            inheritedRoles: ["pg_read_all_data"],
+          },
+          roleAttrs(),
+        ),
+      });
+
+      const plan = yield* Effect.gen(function* () {
+        const db = yield* Planetscale.PostgresDatabase("Db", {
+          name: DB_NAME,
+          clusterSize: "PS_10",
+          // In-place settings change — triggers an update, not a rename.
+          requireApprovalForDeploy: true,
+        });
+        const branch = yield* Planetscale.PostgresBranch("Branch", {
+          name: BRANCH_NAME,
+          database: db,
+        });
+        yield* Planetscale.PostgresRole("Role", {
+          name: ROLE_NAME,
+          database: db,
+          branch,
+          inheritedRoles: ["pg_read_all_data"],
+        });
+      }).pipe(makePlan);
+
+      expect(plan.resources.Db!.action).toBe("update");
+      expect(plan.resources.Branch!.action).toBe("update");
+      expect(plan.resources.Role!.action).toBe("update");
+    }),
+  );
+
+  // A rename IS an identity change for downstream consumers: `name` must
+  // not be advertised as stable, and the role must plan a replacement.
+  test(
+    "role still replaces when the branch is renamed",
+    Effect.gen(function* () {
+      const database = databaseAttrs({});
+
+      yield* seed({
+        Branch: stateRow(
+          "Branch",
+          "Planetscale.PostgresBranch",
+          { name: BRANCH_NAME, database },
+          branchAttrs(),
+        ),
+        Role: stateRow(
+          "Role",
+          "Planetscale.PostgresRole",
+          {
+            name: ROLE_NAME,
+            database,
+            branch: branchAttrs(),
+            inheritedRoles: ["pg_read_all_data"],
+          },
+          roleAttrs(),
+        ),
+      });
+
+      const plan = yield* Effect.gen(function* () {
+        const branch = yield* Planetscale.PostgresBranch("Branch", {
+          name: "renamed-branch",
+          database: database as unknown as Planetscale.PostgresDatabase,
+        });
+        yield* Planetscale.PostgresRole("Role", {
+          name: ROLE_NAME,
+          database: database as unknown as Planetscale.PostgresDatabase,
+          branch,
+          inheritedRoles: ["pg_read_all_data"],
+        });
+      }).pipe(makePlan);
+
+      expect(plan.resources.Branch!.action).toBe("update");
+      expect(plan.resources.Role!.action).toBe("replace");
+    }),
+  );
+});


### PR DESCRIPTION
Fixes the reported false `PostgresRole` replacement when an upstream `PostgresBranch` receives a metadata-only update.

Branch and database names are rename-mutable, so `name` is not in the provider-level `stables`. That meant any in-place update — e.g. an embedded database ref whose `migrationsHashes` gained a new entry — resolved downstream refs to just the provider-level stables at plan time:

```text
previous role props.branch.name = "<actual-dev-branch-name>"
desired role props.branch.name  = undefined   // { organization, database } only
```

`PostgresRole.diff` compared the real old branch name against `undefined`, planned a `replace`, and the replacement's reconcile crashed with `SchemaError: Expected string, got undefined` on `getBranch({ branch: undefined })`.

The branch/database diffs now advertise `name` as a per-update stable whenever the update is not a rename — the name can only change when the `name` prop itself changes (omitted names are engine-generated deterministically and stable across updates):

```ts
const nameIsStable =
  output?.name !== undefined &&
  (news.name !== undefined
    ? news.name === output.name
    : olds?.name === undefined);
return { action: "update", stables: nameIsStable ? [...provider stables, "name"] : undefined };
```

The remaining in-place prop changes are also decided explicitly in the diff (instead of falling through to the engine's default deep-compare) so the conditional stable is attached on that path too.

- Applied to the shared `makeBranchProvider` (covers `PostgresBranch` + `MySQLBranch`), `PostgresDatabase`, and `MySQLDatabase`
- A genuine rename still omits `name` from the stables, so identity-sensitive consumers still plan a replacement
- New plan-level regression tests in `test/Planetscale/PlanStables.test.ts` reproduce the reported scenario (branch metadata-only update → role `update`, not `replace`), the database in-place update cascade, and the rename-still-replaces case

🤖 Generated with [Claude Code](https://claude.com/claude-code)
