### PR TITLE
fix(cli): print the version-update warning before interactive prompts

### DIFF
--- a/packages/alchemy/src/Cli/checkVersion.ts
+++ b/packages/alchemy/src/Cli/checkVersion.ts
@@ -2,9 +2,9 @@ import * as Clock from "effect/Clock";
 import * as Console from "effect/Console";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
-import * as Result from "effect/Result";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 
 import { AlchemyContext } from "alchemy/AlchemyContext";
@@ -17,8 +17,8 @@ const CACHE_FILE = "version-check.json";
 const CACHE_TTL_MILLIS = Duration.toMillis(Duration.days(1));
 // npm's dist-tags endpoint is CDN-backed and typically answers in ~100ms;
 // the sync budget only needs to absorb a slow handshake, not a dead network.
-const SYNC_FETCH_TIMEOUT = Duration.seconds(3);
-const BACKGROUND_FETCH_TIMEOUT = Duration.seconds(15);
+const SYNC_WAIT = Duration.seconds(3);
+const FETCH_TIMEOUT = Duration.seconds(15);
 
 interface VersionCheckCache {
   checkedAt: number;
@@ -52,11 +52,7 @@ const readCache = (cachePath: string) =>
     const parsed = yield* Effect.try(
       () => JSON.parse(raw) as VersionCheckCache | null | undefined,
     );
-    if (typeof parsed?.checkedAt !== "number") return undefined;
-    if (parsed.distTags !== undefined && typeof parsed.distTags !== "object") {
-      return undefined;
-    }
-    return parsed;
+    return typeof parsed?.checkedAt === "number" ? parsed : undefined;
   }).pipe(Effect.catch(() => Effect.succeed(undefined)));
 
 const writeCache = (cachePath: string, distTags?: Record<string, string>) =>
@@ -67,31 +63,45 @@ const writeCache = (cachePath: string, distTags?: Record<string, string>) =>
     yield* fs.writeFileString(cachePath, JSON.stringify(cache));
   }).pipe(Effect.catch(() => Effect.void));
 
-const fetchDistTags = (timeout: Duration.Duration) =>
+const fetchDistTags = Effect.gen(function* () {
+  const http = yield* HttpClient.HttpClient;
+  const response = yield* http.get(NPM_DIST_TAGS_URL);
+  const distTags = (yield* response.json) as Record<string, string> | null;
+  if (typeof distTags !== "object" || distTags === null) {
+    return yield* Effect.fail(new Error("malformed dist-tags response"));
+  }
+  return distTags;
+}).pipe(Effect.timeout(FETCH_TIMEOUT));
+
+/**
+ * Refresh the dist-tags cache with a single request. The fetch is forked so
+ * it outlives the sync wait: we give it {@link SYNC_WAIT} to land inline;
+ * if it's still in flight (or already failed) we record the attempt — so a
+ * dead network costs at most one blocking wait per TTL window — and the
+ * same request keeps going in the background, overwriting the cache when it
+ * completes. The background path never logs, so it can't interleave with
+ * interactive prompts.
+ */
+const refreshDistTags = (cachePath: string, stale?: Record<string, string>) =>
   Effect.gen(function* () {
-    const http = yield* HttpClient.HttpClient;
-    const response = yield* http.get(NPM_DIST_TAGS_URL);
-    const distTags = (yield* response.json) as Record<string, string>;
-    if (typeof distTags !== "object" || distTags === null) {
-      return yield* Effect.fail(new Error("malformed dist-tags response"));
-    }
-    return distTags;
-  }).pipe(Effect.timeout(timeout));
+    const fetch = yield* fetchDistTags.pipe(
+      Effect.tap((distTags) => writeCache(cachePath, distTags)),
+      Effect.forkScoped,
+    );
+    return yield* Fiber.join(fetch).pipe(
+      Effect.timeout(SYNC_WAIT),
+      Effect.catch(() => writeCache(cachePath, stale).pipe(Effect.as(stale))),
+    );
+  });
 
 /**
  * Warn if a newer `alchemy` version is published on the dist-tag matching
  * the current channel. Runs to completion before any interactive prompts so
  * the warning never interleaves with prompt rendering, and is bounded so it
- * can never stall the CLI for long:
- *
- * - the registry's dist-tags are cached in `.alchemy/version-check.json`
- *   for a day, so at most one run per day touches the network at all
- * - the blocking fetch times out after a few seconds; on failure the
- *   attempt itself is cached (so a dead network costs at most one timeout
- *   per day, not one per run) and a longer-budget background fetch is
- *   forked that silently refreshes the cache for subsequent runs — it
- *   never logs, so it cannot interleave with prompts
- * - every failure (offline, registry hiccup, corrupt cache) is swallowed
+ * can never stall the CLI: dist-tags are cached in
+ * `.alchemy/version-check.json` for a day (failed attempts included), so at
+ * most one run per day waits on the network, and only up to
+ * {@link SYNC_WAIT}. Best-effort: every failure is swallowed silently.
  */
 export const checkLatestVersion = Effect.gen(function* () {
   const path = yield* Path.Path;
@@ -100,32 +110,16 @@ export const checkLatestVersion = Effect.gen(function* () {
   const now = yield* Clock.currentTimeMillis;
 
   const cached = yield* readCache(cachePath);
-  let distTags = cached?.distTags;
-  if (cached === undefined || now - cached.checkedAt > CACHE_TTL_MILLIS) {
-    const fetched = yield* Effect.result(fetchDistTags(SYNC_FETCH_TIMEOUT));
-    if (Result.isSuccess(fetched)) {
-      distTags = fetched.success;
-      yield* writeCache(cachePath, distTags);
-    } else {
-      // Record the failed attempt so the next runs skip the blocking fetch
-      // for a full TTL window, then retry in the background with a longer
-      // budget: if it lands before the CLI exits, subsequent runs get the
-      // fresh dist-tags for free. It never logs, so it can't interleave
-      // with interactive prompts.
-      yield* writeCache(cachePath, distTags);
-      yield* fetchDistTags(BACKGROUND_FETCH_TIMEOUT).pipe(
-        Effect.flatMap((distTags) => writeCache(cachePath, distTags)),
-        Effect.catch(() => Effect.void),
-        Effect.forkScoped,
-      );
-      if (distTags === undefined) return;
-    }
-  }
+  const distTags =
+    cached !== undefined && now - cached.checkedAt <= CACHE_TTL_MILLIS
+      ? cached.distTags
+      : yield* refreshDistTags(cachePath, cached?.distTags);
   if (distTags === undefined) return;
 
   const current = packageJson.version;
   const latest = pickDistTag(current, distTags);
-  if (typeof latest !== "string" || latest === current) return;
+  if (latest === undefined || latest === current) return;
+
   const installCmd =
     typeof process !== "undefined" && (process as any).versions?.bun
       ? `bun add alchemy@${latest}`

--- a/packages/alchemy/src/Cli/checkVersion.ts
+++ b/packages/alchemy/src/Cli/checkVersion.ts
@@ -18,7 +18,6 @@ const CACHE_TTL_MILLIS = Duration.toMillis(Duration.days(1));
 // npm's dist-tags endpoint is CDN-backed and typically answers in ~100ms;
 // the sync budget only needs to absorb a slow handshake, not a dead network.
 const SYNC_WAIT = Duration.seconds(3);
-const FETCH_TIMEOUT = Duration.seconds(15);
 
 interface VersionCheckCache {
   checkedAt: number;
@@ -75,37 +74,28 @@ const fetchDistTags = Effect.gen(function* () {
     return yield* Effect.fail(new Error("malformed dist-tags response"));
   }
   return distTags;
-}).pipe(Effect.timeout(FETCH_TIMEOUT));
+});
 
 /**
  * Refresh the dist-tags cache with a single request. The fetch is forked so
  * it outlives the sync wait: we give it {@link SYNC_WAIT} to land inline,
  * and if it's still in flight the same request keeps going in the
- * background, writing fresh dist-tags to the cache when it completes. The
- * background path never logs, so it can't interleave with prompts.
+ * background, writing the cache when it completes. The background path
+ * never logs, so it can't interleave with prompts.
  */
-const refreshDistTags = Effect.fn(function* (
-  cachePath: string,
-  lastKnown?: Record<string, string>,
-) {
+const refreshDistTags = Effect.fn(function* (cachePath: string) {
   const fetch = yield* fetchDistTags.pipe(
-    // Fresh dist-tags land in the cache whenever the request completes —
-    // even after the sync wait below has given up on it.
+    // The fiber owns all cache writes, whenever it completes — even after
+    // the sync wait below has given up on it. A failed attempt is cached
+    // too (a bare checkedAt), so a dead network costs at most one blocking
+    // wait per TTL window, not one per run.
     Effect.tap((distTags) => writeCache(cachePath, distTags)),
+    Effect.tapError(() => writeCache(cachePath)),
     Effect.forkScoped,
   );
   return yield* Fiber.join(fetch).pipe(
     Effect.timeout(SYNC_WAIT),
-    // Still in flight (or failed): stamp checkedAt now — a cheap local file
-    // write — so runs in the next TTL window skip the blocking wait
-    // entirely; a dead network costs one wait per day, not one per run.
-    // Carrying the last-known dist-tags forward keeps the upgrade warning
-    // alive off yesterday's data instead of losing it for a day. If the
-    // in-flight request lands later, it overwrites all of this with fresh
-    // data.
-    Effect.catch(() =>
-      writeCache(cachePath, lastKnown).pipe(Effect.as(lastKnown)),
-    ),
+    Effect.catch(() => Effect.succeed(undefined)),
   );
 });
 
@@ -128,7 +118,7 @@ export const checkLatestVersion = Effect.gen(function* () {
   const distTags =
     cached !== undefined && now - cached.checkedAt <= CACHE_TTL_MILLIS
       ? cached.distTags
-      : yield* refreshDistTags(cachePath, cached?.distTags);
+      : yield* refreshDistTags(cachePath);
   if (distTags === undefined) return;
 
   const current = packageJson.version;

--- a/packages/alchemy/src/Cli/checkVersion.ts
+++ b/packages/alchemy/src/Cli/checkVersion.ts
@@ -44,17 +44,17 @@ const readCache = (cachePath: string) =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
     const raw = yield* fs.readFileString(cachePath);
-    const parsed = yield* Effect.try(() => JSON.parse(raw) as unknown);
+    const parsed = yield* Effect.try(
+      () => JSON.parse(raw) as VersionCheckCache | null | undefined,
+    );
     if (
-      typeof parsed !== "object" ||
-      parsed === null ||
-      typeof (parsed as VersionCheckCache).checkedAt !== "number" ||
-      typeof (parsed as VersionCheckCache).distTags !== "object" ||
-      (parsed as VersionCheckCache).distTags === null
+      typeof parsed?.checkedAt !== "number" ||
+      typeof parsed.distTags !== "object" ||
+      parsed.distTags === null
     ) {
       return undefined;
     }
-    return parsed as VersionCheckCache;
+    return parsed;
   }).pipe(Effect.catch(() => Effect.succeed(undefined)));
 
 const fetchDistTags = Effect.gen(function* () {

--- a/packages/alchemy/src/Cli/checkVersion.ts
+++ b/packages/alchemy/src/Cli/checkVersion.ts
@@ -45,23 +45,27 @@ const pickDistTag = (
   return distTags.latest;
 };
 
-const readCache = (cachePath: string) =>
-  Effect.gen(function* () {
+const readCache = Effect.fn(
+  function* (cachePath: string) {
     const fs = yield* FileSystem.FileSystem;
     const raw = yield* fs.readFileString(cachePath);
     const parsed = yield* Effect.try(
       () => JSON.parse(raw) as VersionCheckCache | null | undefined,
     );
     return typeof parsed?.checkedAt === "number" ? parsed : undefined;
-  }).pipe(Effect.catch(() => Effect.succeed(undefined)));
+  },
+  Effect.catch(() => Effect.succeed(undefined)),
+);
 
-const writeCache = (cachePath: string, distTags?: Record<string, string>) =>
-  Effect.gen(function* () {
+const writeCache = Effect.fn(
+  function* (cachePath: string, distTags?: Record<string, string>) {
     const fs = yield* FileSystem.FileSystem;
     const checkedAt = yield* Clock.currentTimeMillis;
     const cache: VersionCheckCache = { checkedAt, distTags };
     yield* fs.writeFileString(cachePath, JSON.stringify(cache));
-  }).pipe(Effect.catch(() => Effect.void));
+  },
+  Effect.catch(() => Effect.void),
+);
 
 const fetchDistTags = Effect.gen(function* () {
   const http = yield* HttpClient.HttpClient;
@@ -82,17 +86,19 @@ const fetchDistTags = Effect.gen(function* () {
  * completes. The background path never logs, so it can't interleave with
  * interactive prompts.
  */
-const refreshDistTags = (cachePath: string, stale?: Record<string, string>) =>
-  Effect.gen(function* () {
-    const fetch = yield* fetchDistTags.pipe(
-      Effect.tap((distTags) => writeCache(cachePath, distTags)),
-      Effect.forkScoped,
-    );
-    return yield* Fiber.join(fetch).pipe(
-      Effect.timeout(SYNC_WAIT),
-      Effect.catch(() => writeCache(cachePath, stale).pipe(Effect.as(stale))),
-    );
-  });
+const refreshDistTags = Effect.fn(function* (
+  cachePath: string,
+  stale?: Record<string, string>,
+) {
+  const fetch = yield* fetchDistTags.pipe(
+    Effect.tap((distTags) => writeCache(cachePath, distTags)),
+    Effect.forkScoped,
+  );
+  return yield* Fiber.join(fetch).pipe(
+    Effect.timeout(SYNC_WAIT),
+    Effect.catch(() => writeCache(cachePath, stale).pipe(Effect.as(stale))),
+  );
+});
 
 /**
  * Warn if a newer `alchemy` version is published on the dist-tag matching

--- a/packages/alchemy/src/Cli/checkVersion.ts
+++ b/packages/alchemy/src/Cli/checkVersion.ts
@@ -4,6 +4,7 @@ import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
+import * as Result from "effect/Result";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 
 import { AlchemyContext } from "alchemy/AlchemyContext";
@@ -14,11 +15,15 @@ const NPM_DIST_TAGS_URL =
 
 const CACHE_FILE = "version-check.json";
 const CACHE_TTL_MILLIS = Duration.toMillis(Duration.days(1));
-const FETCH_TIMEOUT = Duration.seconds(3);
+// npm's dist-tags endpoint is CDN-backed and typically answers in ~100ms;
+// the sync budget only needs to absorb a slow handshake, not a dead network.
+const SYNC_FETCH_TIMEOUT = Duration.seconds(3);
+const BACKGROUND_FETCH_TIMEOUT = Duration.seconds(15);
 
 interface VersionCheckCache {
   checkedAt: number;
-  distTags: Record<string, string>;
+  /** Absent when the last check attempt failed (offline, timeout, …). */
+  distTags?: Record<string, string>;
 }
 
 /**
@@ -47,35 +52,48 @@ const readCache = (cachePath: string) =>
     const parsed = yield* Effect.try(
       () => JSON.parse(raw) as VersionCheckCache | null | undefined,
     );
-    if (
-      typeof parsed?.checkedAt !== "number" ||
-      typeof parsed.distTags !== "object" ||
-      parsed.distTags === null
-    ) {
+    if (typeof parsed?.checkedAt !== "number") return undefined;
+    if (parsed.distTags !== undefined && typeof parsed.distTags !== "object") {
       return undefined;
     }
     return parsed;
   }).pipe(Effect.catch(() => Effect.succeed(undefined)));
 
-const fetchDistTags = Effect.gen(function* () {
-  const http = yield* HttpClient.HttpClient;
-  const response = yield* http.get(NPM_DIST_TAGS_URL);
-  const distTags = (yield* response.json) as Record<string, string>;
-  if (typeof distTags !== "object" || distTags === null) return undefined;
-  return distTags;
-}).pipe(Effect.timeout(FETCH_TIMEOUT));
+const writeCache = (cachePath: string, distTags?: Record<string, string>) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const checkedAt = yield* Clock.currentTimeMillis;
+    const cache: VersionCheckCache = { checkedAt, distTags };
+    yield* fs.writeFileString(cachePath, JSON.stringify(cache));
+  }).pipe(Effect.catch(() => Effect.void));
+
+const fetchDistTags = (timeout: Duration.Duration) =>
+  Effect.gen(function* () {
+    const http = yield* HttpClient.HttpClient;
+    const response = yield* http.get(NPM_DIST_TAGS_URL);
+    const distTags = (yield* response.json) as Record<string, string>;
+    if (typeof distTags !== "object" || distTags === null) {
+      return yield* Effect.fail(new Error("malformed dist-tags response"));
+    }
+    return distTags;
+  }).pipe(Effect.timeout(timeout));
 
 /**
  * Warn if a newer `alchemy` version is published on the dist-tag matching
- * the current channel. Runs synchronously (before any interactive prompts)
- * so the warning never interleaves with prompt rendering. The registry's
- * dist-tags are cached in `.alchemy/version-check.json` for a day so the
- * network round-trip only happens once daily. Best-effort: any failure
- * (offline, registry hiccup, slow response, unreadable cache) is swallowed
- * silently and the fetch times out after a few seconds.
+ * the current channel. Runs to completion before any interactive prompts so
+ * the warning never interleaves with prompt rendering, and is bounded so it
+ * can never stall the CLI for long:
+ *
+ * - the registry's dist-tags are cached in `.alchemy/version-check.json`
+ *   for a day, so at most one run per day touches the network at all
+ * - the blocking fetch times out after a few seconds; on failure the
+ *   attempt itself is cached (so a dead network costs at most one timeout
+ *   per day, not one per run) and a longer-budget background fetch is
+ *   forked that silently refreshes the cache for subsequent runs — it
+ *   never logs, so it cannot interleave with prompts
+ * - every failure (offline, registry hiccup, corrupt cache) is swallowed
  */
 export const checkLatestVersion = Effect.gen(function* () {
-  const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const { dotAlchemy } = yield* AlchemyContext;
   const cachePath = path.join(dotAlchemy, CACHE_FILE);
@@ -84,12 +102,24 @@ export const checkLatestVersion = Effect.gen(function* () {
   const cached = yield* readCache(cachePath);
   let distTags = cached?.distTags;
   if (cached === undefined || now - cached.checkedAt > CACHE_TTL_MILLIS) {
-    distTags = yield* fetchDistTags;
-    if (distTags === undefined) return;
-    const cache: VersionCheckCache = { checkedAt: now, distTags };
-    yield* fs
-      .writeFileString(cachePath, JSON.stringify(cache))
-      .pipe(Effect.catch(() => Effect.void));
+    const fetched = yield* Effect.result(fetchDistTags(SYNC_FETCH_TIMEOUT));
+    if (Result.isSuccess(fetched)) {
+      distTags = fetched.success;
+      yield* writeCache(cachePath, distTags);
+    } else {
+      // Record the failed attempt so the next runs skip the blocking fetch
+      // for a full TTL window, then retry in the background with a longer
+      // budget: if it lands before the CLI exits, subsequent runs get the
+      // fresh dist-tags for free. It never logs, so it can't interleave
+      // with interactive prompts.
+      yield* writeCache(cachePath, distTags);
+      yield* fetchDistTags(BACKGROUND_FETCH_TIMEOUT).pipe(
+        Effect.flatMap((distTags) => writeCache(cachePath, distTags)),
+        Effect.catch(() => Effect.void),
+        Effect.forkScoped,
+      );
+      if (distTags === undefined) return;
+    }
   }
   if (distTags === undefined) return;
 

--- a/packages/alchemy/src/Cli/checkVersion.ts
+++ b/packages/alchemy/src/Cli/checkVersion.ts
@@ -79,24 +79,33 @@ const fetchDistTags = Effect.gen(function* () {
 
 /**
  * Refresh the dist-tags cache with a single request. The fetch is forked so
- * it outlives the sync wait: we give it {@link SYNC_WAIT} to land inline;
- * if it's still in flight (or already failed) we record the attempt — so a
- * dead network costs at most one blocking wait per TTL window — and the
- * same request keeps going in the background, overwriting the cache when it
- * completes. The background path never logs, so it can't interleave with
- * interactive prompts.
+ * it outlives the sync wait: we give it {@link SYNC_WAIT} to land inline,
+ * and if it's still in flight the same request keeps going in the
+ * background, writing fresh dist-tags to the cache when it completes. The
+ * background path never logs, so it can't interleave with prompts.
  */
 const refreshDistTags = Effect.fn(function* (
   cachePath: string,
-  stale?: Record<string, string>,
+  lastKnown?: Record<string, string>,
 ) {
   const fetch = yield* fetchDistTags.pipe(
+    // Fresh dist-tags land in the cache whenever the request completes —
+    // even after the sync wait below has given up on it.
     Effect.tap((distTags) => writeCache(cachePath, distTags)),
     Effect.forkScoped,
   );
   return yield* Fiber.join(fetch).pipe(
     Effect.timeout(SYNC_WAIT),
-    Effect.catch(() => writeCache(cachePath, stale).pipe(Effect.as(stale))),
+    // Still in flight (or failed): stamp checkedAt now — a cheap local file
+    // write — so runs in the next TTL window skip the blocking wait
+    // entirely; a dead network costs one wait per day, not one per run.
+    // Carrying the last-known dist-tags forward keeps the upgrade warning
+    // alive off yesterday's data instead of losing it for a day. If the
+    // in-flight request lands later, it overwrites all of this with fresh
+    // data.
+    Effect.catch(() =>
+      writeCache(cachePath, lastKnown).pipe(Effect.as(lastKnown)),
+    ),
   );
 });
 

--- a/packages/alchemy/src/Cli/checkVersion.ts
+++ b/packages/alchemy/src/Cli/checkVersion.ts
@@ -1,11 +1,25 @@
+import * as Clock from "effect/Clock";
+import * as Console from "effect/Console";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 
+import { AlchemyContext } from "alchemy/AlchemyContext";
 import packageJson from "../../package.json" with { type: "json" };
 
 const NPM_DIST_TAGS_URL =
   "https://registry.npmjs.org/-/package/alchemy/dist-tags";
+
+const CACHE_FILE = "version-check.json";
+const CACHE_TTL_MILLIS = Duration.toMillis(Duration.days(1));
+const FETCH_TIMEOUT = Duration.seconds(3);
+
+interface VersionCheckCache {
+  checkedAt: number;
+  distTags: Record<string, string>;
+}
 
 /**
  * Pick the dist-tag matching the current channel. For pre-release versions
@@ -26,17 +40,59 @@ const pickDistTag = (
   return distTags.latest;
 };
 
-/**
- * Fetch the published `alchemy` version on the dist-tag matching the
- * current channel and log a warning if it's different from the bundled
- * version. Best-effort: any failure (offline, registry hiccup, slow
- * response) is swallowed silently.
- */
-export const checkLatestVersion = Effect.gen(function* () {
+const readCache = (cachePath: string) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const raw = yield* fs.readFileString(cachePath);
+    const parsed = yield* Effect.try(() => JSON.parse(raw) as unknown);
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      typeof (parsed as VersionCheckCache).checkedAt !== "number" ||
+      typeof (parsed as VersionCheckCache).distTags !== "object" ||
+      (parsed as VersionCheckCache).distTags === null
+    ) {
+      return undefined;
+    }
+    return parsed as VersionCheckCache;
+  }).pipe(Effect.catch(() => Effect.succeed(undefined)));
+
+const fetchDistTags = Effect.gen(function* () {
   const http = yield* HttpClient.HttpClient;
   const response = yield* http.get(NPM_DIST_TAGS_URL);
   const distTags = (yield* response.json) as Record<string, string>;
-  if (typeof distTags !== "object" || distTags === null) return;
+  if (typeof distTags !== "object" || distTags === null) return undefined;
+  return distTags;
+}).pipe(Effect.timeout(FETCH_TIMEOUT));
+
+/**
+ * Warn if a newer `alchemy` version is published on the dist-tag matching
+ * the current channel. Runs synchronously (before any interactive prompts)
+ * so the warning never interleaves with prompt rendering. The registry's
+ * dist-tags are cached in `.alchemy/version-check.json` for a day so the
+ * network round-trip only happens once daily. Best-effort: any failure
+ * (offline, registry hiccup, slow response, unreadable cache) is swallowed
+ * silently and the fetch times out after a few seconds.
+ */
+export const checkLatestVersion = Effect.gen(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const { dotAlchemy } = yield* AlchemyContext;
+  const cachePath = path.join(dotAlchemy, CACHE_FILE);
+  const now = yield* Clock.currentTimeMillis;
+
+  const cached = yield* readCache(cachePath);
+  let distTags = cached?.distTags;
+  if (cached === undefined || now - cached.checkedAt > CACHE_TTL_MILLIS) {
+    distTags = yield* fetchDistTags;
+    if (distTags === undefined) return;
+    const cache: VersionCheckCache = { checkedAt: now, distTags };
+    yield* fs
+      .writeFileString(cachePath, JSON.stringify(cache))
+      .pipe(Effect.catch(() => Effect.void));
+  }
+  if (distTags === undefined) return;
+
   const current = packageJson.version;
   const latest = pickDistTag(current, distTags);
   if (typeof latest !== "string" || latest === current) return;
@@ -44,14 +100,15 @@ export const checkLatestVersion = Effect.gen(function* () {
     typeof process !== "undefined" && (process as any).versions?.bun
       ? `bun add alchemy@${latest}`
       : `pnpm add alchemy@${latest}`;
-  yield* Effect.logWarning(
+  // Print via the Console service, not Effect.logWarning: TelemetryLive
+  // replaces the default stdout logger with an OTLP-only logger at this
+  // stage of the program, so log output would never reach the terminal.
+  const useColor = process.stderr.isTTY === true;
+  const message =
     `alchemy ${latest} is available (you're on ${current}). ` +
-      `Run \`${installCmd}\` to upgrade.`,
-  );
-}).pipe(
-  Effect.timeout(Duration.seconds(5)),
-  Effect.catch(() => Effect.void),
-);
+    `Run \`${installCmd}\` to upgrade.`;
+  yield* Console.warn(useColor ? `\x1b[33m${message}\x1b[0m` : message);
+}).pipe(Effect.catch(() => Effect.void));
 
 // Exported for tests.
 export const _internal = { pickDistTag };

--- a/packages/alchemy/src/Cli/main.ts
+++ b/packages/alchemy/src/Cli/main.ts
@@ -69,10 +69,11 @@ const services = Layer.mergeAll(
 );
 
 const program = Effect.gen(function* () {
-  // Best-effort, non-blocking check for a newer published version. If the
-  // CLI command finishes before the registry responds, the fiber is
-  // interrupted on scope close — that's intentional.
-  yield* checkLatestVersion.pipe(Effect.forkScoped);
+  // Best-effort check for a newer published version. Runs to completion
+  // before the command so the warning prints before any interactive
+  // prompts; the registry response is cached for a day and the fetch is
+  // bounded by a short timeout, so this stays fast.
+  yield* checkLatestVersion;
   return yield* cli;
 });
 


### PR DESCRIPTION
The npm version check ran as a forked fiber, so its warning could land mid-prompt and break `alchemy login`'s interactive flow. The check now runs to completion before the command starts, and stays fast by caching npm's dist-tags in `.alchemy/version-check.json` for a day.

```diff
 const program = Effect.gen(function* () {
-  yield* checkLatestVersion.pipe(Effect.forkScoped);
+  yield* checkLatestVersion;
   return yield* cli;
 });
```

- Fresh cache (< 1 day): no network call, warning decided from cached dist-tags (~1ms)
- Stale/missing cache: blocking fetch with a 3s timeout (npm's CDN-backed dist-tags endpoint typically answers in ~100ms)
- One request total: the fetch is forked and given 3s to land inline; if it's still in flight, the same request (never interrupted) keeps going in the background. The fiber owns all cache writes — fresh dist-tags on success, a bare `checkedAt` marker on failure so an offline machine skips the fetch for the next day. It never logs, so it can't interleave with prompts
- Best-effort throughout: offline, registry hiccups, and corrupt cache files are swallowed silently

Also fixes the warning being invisible whenever telemetry is enabled: `TelemetryLive` replaces the default stdout logger with an OTLP-only logger before any command-level logger is installed, so `Effect.logWarning` never reached the terminal. The notice now prints through the Console service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
