### PR TITLE
feat(auth): headless OAuth flow via hosted relay (Cloudflare + PlanetScale)

### DIFF
--- a/packages/alchemy/src/Cloudflare/Auth/AuthProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Auth/AuthProvider.ts
@@ -233,10 +233,23 @@ export const CloudflareAuth = AuthProviderLayer<
           ),
         );
         yield* Clank.info(
-          "Cloudflare: waiting for authorization (up to 5 minutes)...",
+          "Cloudflare: waiting for authorization (up to 5 minutes).",
         );
 
-        const credentials = yield* OAuthClient.callback(authorization);
+        const credentials = yield* Effect.raceFirst(
+          OAuthClient.callback(authorization),
+          Clank.text({
+            message: "Paste the authorization code or callback URL",
+            placeholder:
+              "The browser will complete this automatically when local",
+            validate: (value) =>
+              value.trim().length > 0 ? undefined : "Paste a code or URL",
+          }).pipe(
+            Effect.flatMap((input) =>
+              OAuthClient.exchangeCallbackInput(input, authorization),
+            ),
+          ),
+        );
         yield* store.write(profileName, "cf-oauth", credentials);
         yield* Clank.success("Cloudflare: OAuth credentials saved.");
         return credentials;
@@ -783,7 +796,8 @@ export const DEFAULT_SCOPES = [
 ];
 
 export const OAUTH_CLIENT_ID = "6d8c2255-0773-45f6-b376-2914632e6f91";
-export const OAUTH_REDIRECT_URI = "http://localhost:9976/auth/callback";
+export const OAUTH_REDIRECT_URI = "https://alchemy.run/auth/callback";
+export const OAUTH_LOCAL_CALLBACK_URI = "http://localhost:9976/auth/callback";
 export const OAUTH_ENDPOINTS = {
   authorize: "https://dash.cloudflare.com/oauth2/authorize",
   token: "https://dash.cloudflare.com/oauth2/token",

--- a/packages/alchemy/src/Cloudflare/Auth/OAuthClient.ts
+++ b/packages/alchemy/src/Cloudflare/Auth/OAuthClient.ts
@@ -6,6 +6,7 @@ import { AUTH_ERROR_URL, AUTH_SUCCESS_URL } from "../../Auth/AuthProvider.ts";
 import {
   OAUTH_CLIENT_ID,
   OAUTH_ENDPOINTS,
+  OAUTH_LOCAL_CALLBACK_URI,
   OAUTH_REDIRECT_URI,
 } from "./AuthProvider.ts";
 
@@ -188,6 +189,46 @@ export const revoke = (
   });
 
 /**
+ * Exchange a code copied from the hosted relay page, or extract the code from
+ * either the hosted or loopback callback URL.
+ */
+export const exchangeCallbackInput = (
+  input: string,
+  authorization: Authorization,
+): Effect.Effect<OAuthCredentials, OAuthError> =>
+  Effect.gen(function* () {
+    const value = input.trim();
+    let code = value;
+    let state: string | null = null;
+
+    try {
+      const url = new URL(value);
+      code = url.searchParams.get("code") ?? "";
+      state = url.searchParams.get("state");
+    } catch {
+      const separator = value.lastIndexOf("#");
+      if (separator >= 0) {
+        code = value.slice(0, separator);
+        state = value.slice(separator + 1);
+      }
+    }
+
+    if (!code) {
+      return yield* new OAuthError({
+        error: "invalid_request",
+        errorDescription: "The authorization code is missing.",
+      });
+    }
+    if (state !== null && state !== authorization.state) {
+      return yield* new OAuthError({
+        error: "invalid_request",
+        errorDescription: "The authorization state does not match.",
+      });
+    }
+    return yield* exchange(code, authorization.verifier);
+  });
+
+/**
  * Start a local HTTP server to listen for the OAuth callback, exchange
  * the authorization code, and return the credentials.
  *
@@ -197,7 +238,7 @@ export const callback = (
   authorization: Authorization,
 ): Effect.Effect<OAuthCredentials, OAuthError> =>
   Effect.tryPromise({
-    try: () => callbackPromise(authorization),
+    try: (signal) => callbackPromise(authorization, signal),
     catch: (err) => {
       if (err instanceof OAuthError) return err;
       return new OAuthError({
@@ -209,12 +250,24 @@ export const callback = (
 
 function callbackPromise(
   authorization: Authorization,
+  signal: AbortSignal,
 ): Promise<OAuthCredentials> {
-  const { pathname, port } = new URL(OAUTH_REDIRECT_URI);
+  const { pathname, port } = new URL(OAUTH_LOCAL_CALLBACK_URI);
 
   return new Promise<OAuthCredentials>((resolve, reject) => {
     const server = http.createServer(async (req, res) => {
       const url = new URL(req.url ?? "/", `http://${req.headers.host}`);
+
+      if (url.pathname === "/auth/ping") {
+        res.writeHead(req.method === "OPTIONS" ? 204 : 200, {
+          "Access-Control-Allow-Origin": new URL(OAUTH_REDIRECT_URI).origin,
+          "Access-Control-Allow-Methods": "GET, OPTIONS",
+          "Access-Control-Allow-Private-Network": "true",
+          "Cache-Control": "no-store",
+        });
+        res.end();
+        return;
+      }
 
       if (url.pathname !== pathname) {
         res.statusCode = 404;
@@ -296,8 +349,11 @@ function callbackPromise(
 
     function cleanup() {
       clearTimeout(timeout);
+      signal.removeEventListener("abort", cleanup);
       server.close();
     }
+
+    signal.addEventListener("abort", cleanup, { once: true });
 
     server.on("error", (err) => {
       cleanup();

--- a/packages/alchemy/src/Planetscale/AuthProvider.ts
+++ b/packages/alchemy/src/Planetscale/AuthProvider.ts
@@ -199,10 +199,23 @@ export const PlanetscaleAuth = AuthProviderLayer<
           ),
         );
         yield* Clank.info(
-          "Planetscale: waiting for authorization (up to 5 minutes)...",
+          "Planetscale: waiting for authorization (up to 5 minutes).",
         );
 
-        const credentials = yield* OAuthClient.callback(authorization);
+        const credentials = yield* Effect.raceFirst(
+          OAuthClient.callback(authorization),
+          Clank.text({
+            message: "Paste the authorization code or callback URL",
+            placeholder:
+              "The browser will complete this automatically when local",
+            validate: (value) =>
+              value.trim().length > 0 ? undefined : "Paste a code or URL",
+          }).pipe(
+            Effect.flatMap((input) =>
+              OAuthClient.exchangeCallbackInput(input, authorization),
+            ),
+          ),
+        );
         yield* store.write(profileName, "planetscale-oauth", credentials);
         yield* Clank.success("Planetscale: OAuth credentials saved.");
         return credentials;

--- a/packages/alchemy/src/Planetscale/OAuthClient.ts
+++ b/packages/alchemy/src/Planetscale/OAuthClient.ts
@@ -46,7 +46,8 @@ export const OAUTH_CLIENT_ID = "pscale_app_aa12e3938baebb788aac443f66e422da";
 export const OAUTH_CLIENT_SECRET =
   "pscale_app_secret_yyZ3Q8oe99GP9_yA5wrA5er6RuN6Lz9dC66Bj1OJzpg";
 
-export const OAUTH_REDIRECT_URI = "http://localhost:9976/auth/callback";
+export const OAUTH_REDIRECT_URI = "https://alchemy.run/auth/callback";
+export const OAUTH_LOCAL_CALLBACK_URI = "http://localhost:9976/auth/callback";
 export const OAUTH_ENDPOINTS = {
   // PlanetScale's own .well-known OAuth discovery doc declares this as
   // the authorization_endpoint — NOT auth.planetscale.com/oauth/authorize
@@ -183,6 +184,46 @@ export const refresh = (
   });
 
 /**
+ * Exchange a code copied from the hosted relay page, or extract the code from
+ * either the hosted or loopback callback URL.
+ */
+export const exchangeCallbackInput = (
+  input: string,
+  authorization: Authorization,
+): Effect.Effect<OAuthCredentials, OAuthError> =>
+  Effect.gen(function* () {
+    const value = input.trim();
+    let code = value;
+    let state: string | null = null;
+
+    try {
+      const url = new URL(value);
+      code = url.searchParams.get("code") ?? "";
+      state = url.searchParams.get("state");
+    } catch {
+      const separator = value.lastIndexOf("#");
+      if (separator >= 0) {
+        code = value.slice(0, separator);
+        state = value.slice(separator + 1);
+      }
+    }
+
+    if (!code) {
+      return yield* new OAuthError({
+        error: "invalid_request",
+        errorDescription: "The authorization code is missing.",
+      });
+    }
+    if (state !== null && state !== authorization.state) {
+      return yield* new OAuthError({
+        error: "invalid_request",
+        errorDescription: "The authorization state does not match.",
+      });
+    }
+    return yield* exchange(code);
+  });
+
+/**
  * Start a local HTTP server to listen for the OAuth callback, exchange
  * the authorization code, and return the credentials.
  *
@@ -192,7 +233,7 @@ export const callback = (
   authorization: Authorization,
 ): Effect.Effect<OAuthCredentials, OAuthError> =>
   Effect.tryPromise({
-    try: () => callbackPromise(authorization),
+    try: (signal) => callbackPromise(authorization, signal),
     catch: (err) => {
       if (err instanceof OAuthError) return err;
       return new OAuthError({
@@ -204,12 +245,24 @@ export const callback = (
 
 function callbackPromise(
   authorization: Authorization,
+  signal: AbortSignal,
 ): Promise<OAuthCredentials> {
-  const { pathname, port } = new URL(OAUTH_REDIRECT_URI);
+  const { pathname, port } = new URL(OAUTH_LOCAL_CALLBACK_URI);
 
   return new Promise<OAuthCredentials>((resolve, reject) => {
     const server = http.createServer(async (req, res) => {
       const url = new URL(req.url ?? "/", `http://${req.headers.host}`);
+
+      if (url.pathname === "/auth/ping") {
+        res.writeHead(req.method === "OPTIONS" ? 204 : 200, {
+          "Access-Control-Allow-Origin": new URL(OAUTH_REDIRECT_URI).origin,
+          "Access-Control-Allow-Methods": "GET, OPTIONS",
+          "Access-Control-Allow-Private-Network": "true",
+          "Cache-Control": "no-store",
+        });
+        res.end();
+        return;
+      }
 
       if (url.pathname !== pathname) {
         res.statusCode = 404;
@@ -289,8 +342,11 @@ function callbackPromise(
 
     function cleanup() {
       clearTimeout(timeout);
+      signal.removeEventListener("abort", cleanup);
       server.close();
     }
+
+    signal.addEventListener("abort", cleanup, { once: true });
 
     server.on("error", (err) => {
       cleanup();

--- a/website/src/layouts/Auth.astro
+++ b/website/src/layouts/Auth.astro
@@ -41,6 +41,8 @@ const {
 
       <p class="alc-auth__message" set:html={message} />
 
+      <slot />
+
       {(primaryAction || secondaryAction) && (
         <div class="alc-auth__actions">
           {primaryAction && (

--- a/website/src/pages/auth/callback.astro
+++ b/website/src/pages/auth/callback.astro
@@ -1,0 +1,107 @@
+---
+import Auth from "../../layouts/Auth.astro";
+---
+
+<Auth
+  title="Complete Authentication"
+  message="Trying to complete the OAuth flow"
+>
+  <section class="relay" aria-live="polite">
+    <p id="relay-connecting">Connecting to your local Alchemy process…</p>
+    <div id="relay-manual" hidden>
+      <code id="relay-code"></code>
+      <div class="relay__actions">
+        <button id="relay-copy" type="button">Copy code</button>
+        <a id="relay-local" href="#">Try local callback anyway</a>
+      </div>
+    </div>
+  </section>
+</Auth>
+
+<script>
+  const params = new URLSearchParams(window.location.search);
+  const code = params.get("code");
+  const state = params.get("state");
+  const error = params.get("error");
+  const localCallback = new URL("http://localhost:9976/auth/callback");
+  localCallback.search = params.toString();
+
+  const connecting = document.querySelector<HTMLElement>("#relay-connecting")!;
+  const manual = document.querySelector<HTMLElement>("#relay-manual")!;
+  const codeBox = document.querySelector<HTMLElement>("#relay-code")!;
+  const copyButton = document.querySelector<HTMLButtonElement>("#relay-copy")!;
+  const localLink = document.querySelector<HTMLAnchorElement>("#relay-local")!;
+
+  localLink.href = localCallback.toString();
+
+  const showManual = () => {
+    connecting.textContent = error
+      ? "Cloudflare did not authorize the request."
+      : "Couldn't connect to your local Alchemy process.";
+    if (!code || !state) return;
+    codeBox.textContent = `${code}#${state}`;
+    manual.hidden = false;
+  };
+
+  if (error || !code || !state) {
+    showManual();
+  } else {
+    const controller = new AbortController();
+    const timeout = window.setTimeout(() => controller.abort(), 10000);
+    
+    fetch("http://localhost:9976/auth/ping", {
+      mode: "cors",
+      cache: "no-store",
+      signal: controller.signal,
+    })
+    .then(async (response) => {
+        if (!response.ok) throw new Error("Local callback unavailable");
+        window.location.replace(localCallback);
+      })
+      .catch(showManual)
+      .finally(() => window.clearTimeout(timeout));
+  }
+
+  copyButton.addEventListener("click", async () => {
+    await navigator.clipboard.writeText(codeBox.textContent ?? "");
+    copyButton.textContent = "Copied";
+  });
+</script>
+
+<style>
+  .relay {
+    width: 100%;
+    color: var(--alc-fg-2);
+  }
+  .relay p {
+    line-height: 1.6;
+  }
+  .relay code {
+    display: block;
+    overflow-wrap: anywhere;
+    padding: 1rem;
+    border: 1px solid var(--alc-hairline-2);
+    border-radius: 0.5rem;
+    background: var(--alc-bg-elev-1);
+    color: var(--alc-fg-1);
+    text-align: left;
+    user-select: all;
+  }
+  .relay__actions {
+    display: flex;
+    justify-content: center;
+    gap: 0.75rem;
+    margin-top: 1rem;
+  }
+  .relay__actions button,
+  .relay__actions a {
+    padding: 0.625rem 1rem;
+    border: 1px solid var(--alc-hairline-2);
+    border-radius: 0.5rem;
+    background: var(--alc-bg-elev-1);
+    color: var(--alc-fg-1);
+    font: inherit;
+    text-decoration: none;
+    cursor: pointer;
+  }
+</style>


### PR DESCRIPTION
OAuth login now works on headless machines (SSH sessions, containers) where the browser can't reach the CLI's loopback server.

- The OAuth redirect URI is now a hosted relay page at `https://alchemy.run/auth/callback`. The page probes the local callback server (`GET /auth/ping`, CORS-scoped to alchemy.run) and redirects to it when reachable, so local logins complete automatically as before. When the CLI is remote, it shows a copyable `code#state` string instead.
- The CLI races the loopback callback against a paste prompt, so a headless session completes login by pasting the code or the callback URL:

```ts
const credentials = yield* Effect.raceFirst(
  OAuthClient.callback(authorization),
  Clank.text({ message: "Paste the authorization code or callback URL" }).pipe(
    Effect.flatMap((input) => OAuthClient.exchangeCallbackInput(input, authorization)),
  ),
);
```

- Applies to both OAuth providers: Cloudflare and PlanetScale.

https://github.com/user-attachments/assets/592642b3-7802-478a-b3df-18a2840cb21c
