### PR TITLE
fix(state): destroy removes the persisted stack output instead of writing an empty husk

### DIFF
--- a/packages/alchemy/src/Apply.ts
+++ b/packages/alchemy/src/Apply.ts
@@ -193,6 +193,16 @@ export const apply = <P extends Plan>(
 
     yield* session.done();
 
+    if (plan.destroy) {
+      // The destroy converged: every resource row was deleted above. Drop
+      // the rest of the stage's persisted state — notably the stack output
+      // record written by the last deploy — so `getOutput` returns
+      // undefined and `listStages` no longer reports the stage.
+      // https://github.com/alchemy-run/alchemy/issues/961
+      yield* state.deleteStack({ stack: stackName, stage });
+      return undefined;
+    }
+
     if (!plan.output) {
       return undefined;
     }

--- a/packages/alchemy/src/Cli/commands/deploy.ts
+++ b/packages/alchemy/src/Cli/commands/deploy.ts
@@ -121,20 +121,9 @@ export const execStack = Effect.fn(function* ({
     const stack = yield* stackEffect;
 
     yield* Effect.gen(function* () {
-      const updatePlan = yield* Plan.make(
-        destroy
-          ? {
-              ...stack,
-              // zero these out (destroy will treat all as orphans)
-              // TODO(sam): probably better to have Plan.destroy and Plan.update
-              resources: {},
-              bindings: {},
-              actions: {},
-              output: {},
-            }
-          : stack,
-        { force },
-      );
+      const updatePlan = destroy
+        ? yield* Plan.destroy(stack)
+        : yield* Plan.make(stack, { force });
       if (dryRun) {
         yield* cli.displayPlan(updatePlan);
       } else {

--- a/packages/alchemy/src/Destroy.ts
+++ b/packages/alchemy/src/Destroy.ts
@@ -22,15 +22,6 @@ export const destroy = ({
 }) =>
   evalStack(
     stack,
-    (stack) =>
-      Plan.make({
-        ...stack,
-        // zero these out (destroy will treat all as orphans)
-        // TODO(sam): probably better to have Plan.destroy and Plan.update
-        resources: {},
-        bindings: {},
-        actions: {},
-        output: {},
-      }).pipe(Effect.flatMap(Apply.apply)),
+    (stack) => Plan.destroy(stack).pipe(Effect.flatMap(Apply.apply)),
     { stage, dev, scope },
   );

--- a/packages/alchemy/src/Plan.ts
+++ b/packages/alchemy/src/Plan.ts
@@ -229,6 +229,13 @@ export type Plan<Output = any> = {
    * publish a fresh attr (the common, linear case).
    */
   cycleMembers: ReadonlySet<string>;
+  /**
+   * Marks a plan built by {@link destroy}. `apply` finishes a destroy plan
+   * by deleting the stage's remaining persisted state — notably the stack
+   * output record written by the last deploy — instead of persisting a new
+   * (empty) output.
+   */
+  destroy?: boolean;
 };
 
 export interface MakePlanOptions {
@@ -1390,6 +1397,31 @@ export const make = <A>(
       },
     }),
   );
+
+/**
+ * Build the plan that destroys every resource of `(stack.name, stack.stage)`.
+ *
+ * The spec is emptied out so every persisted resource becomes an orphan
+ * deletion, and `output` is left undefined so `apply` does not overwrite the
+ * last deploy's persisted stack output with an empty husk. `apply` recognizes
+ * the `destroy` marker and deletes the stage's remaining persisted state (the
+ * stack output record) once the destroy has converged, so `state.getOutput`
+ * and `state.listStages` agree the stage is gone.
+ *
+ * @see https://github.com/alchemy-run/alchemy/issues/961
+ */
+export const destroy = (stack: {
+  name: string;
+  stage: string;
+}): Effect.Effect<Plan<undefined>, never, State> =>
+  make({
+    name: stack.name,
+    stage: stack.stage,
+    resources: {},
+    bindings: {},
+    actions: {},
+    output: undefined,
+  }).pipe(Effect.map((plan) => ({ ...plan, destroy: true })));
 
 const providePlanScope =
   (fqn: string, instanceId: string) =>

--- a/packages/alchemy/src/State/InMemoryState.ts
+++ b/packages/alchemy/src/State/InMemoryState.ts
@@ -87,8 +87,10 @@ export const InMemoryService = (
         Effect.sync(() => {
           if (stage === undefined) {
             delete state[stack];
+            delete outputs[stack];
           } else {
             delete state[stack]?.[stage];
+            delete outputs[stack]?.[stage];
           }
         }),
       list: ({ stack, stage }: { stack: string; stage: string }) =>

--- a/packages/alchemy/src/Test/Core.ts
+++ b/packages/alchemy/src/Test/Core.ts
@@ -288,14 +288,7 @@ export const scratchStack = <ROut>(
     plan: ((effect: Effect.Effect<any, any, any>) =>
       buildPlan(effect)) as ScratchStack<ROut>["plan"],
     destroy: () =>
-      Plan.make({
-        name: stackName,
-        stage,
-        resources: {},
-        bindings: {},
-        actions: {},
-        output: {},
-      }).pipe(
+      Plan.destroy({ name: stackName, stage }).pipe(
         Effect.flatMap(apply),
         Effect.asVoid,
         Effect.provide(stateLayer),

--- a/packages/alchemy/test/destroy-output.test.ts
+++ b/packages/alchemy/test/destroy-output.test.ts
@@ -1,0 +1,75 @@
+import * as Alchemy from "@/index.ts";
+import { Stack } from "@/Stack";
+import { InMemoryService, State, type ResourceState } from "@/State";
+import * as Test from "@/Test/Alchemy";
+import { describe, expect } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { TestLayers, TestResource } from "./test.resources.ts";
+
+// Regression coverage for https://github.com/alchemy-run/alchemy/issues/961:
+// destroying a stack used to re-persist an empty `{}` output record for the
+// stage. `state.getOutput` then returned a non-null, field-less husk while
+// `state stages` no longer reported the stage, and cross-stack
+// `Output.stackRef` consumers crashed reading fields off the husk at plan
+// time. After destroy, the persisted output record must be gone entirely.
+
+const { test } = Test.make({ providers: TestLayers() });
+
+describe("destroy clears the persisted stack output", () => {
+  test.provider("scratch stack destroy removes the output record", (stack) =>
+    Effect.gen(function* () {
+      const state = yield* yield* State;
+      const stk = yield* Stack;
+
+      const deployed = yield* Effect.gen(function* () {
+        const A = yield* TestResource("A", { string: "test-string" });
+        return { url: A.string };
+      }).pipe(stack.deploy);
+      expect(deployed).toEqual({ url: "test-string" });
+
+      expect(
+        yield* state.getOutput({ stack: stk.name, stage: stk.stage }),
+      ).toEqual({ url: "test-string" });
+
+      yield* stack.destroy();
+
+      // The output record must be removed, not overwritten with `{}`.
+      expect(
+        yield* state.getOutput({ stack: stk.name, stage: stk.stage }),
+      ).toBeUndefined();
+      // ... and `listStages` must agree the stage is gone.
+      expect(yield* state.listStages(stk.name)).not.toContain(stk.stage);
+    }),
+  );
+});
+
+// The same regression through the real `deploy`/`destroy` entry points
+// (`Destroy.ts`), which is what `alchemy destroy` and the test harness's
+// `destroy(Stack)` run.
+const store: Record<string, Record<string, Record<string, ResourceState>>> = {};
+const outputs: Record<string, Record<string, unknown>> = {};
+const stateLayer = Layer.succeed(State, InMemoryService(store, outputs));
+
+const harness = Test.make({ providers: TestLayers(), state: stateLayer });
+
+const DestroyOutputStack = Alchemy.Stack(
+  "DestroyOutputStack",
+  { providers: TestLayers(), state: stateLayer },
+  Effect.gen(function* () {
+    const A = yield* TestResource("A", { string: "test-string" });
+    return { url: A.string };
+  }),
+);
+
+harness.test(
+  "stack destroy removes the persisted stack output",
+  Effect.gen(function* () {
+    yield* harness.deploy(DestroyOutputStack);
+    expect(outputs.DestroyOutputStack?.test).toEqual({ url: "test-string" });
+
+    yield* harness.destroy(DestroyOutputStack);
+    expect(outputs.DestroyOutputStack?.test).toBeUndefined();
+    expect(store.DestroyOutputStack?.test).toBeUndefined();
+  }),
+);


### PR DESCRIPTION
Destroying a stack left a stale persisted output record: the destroy plan was built with `output: {}`, so `apply` re-persisted an empty `{}` husk for the stage. `state.getOutput` then returned non-null while `state stages` no longer listed the stage, and cross-stack `Output.stackRef` consumers crashed at plan time reading fields off the husk instead of getting the typed `InvalidReferenceError`.

Fix: destroy plans now carry no output and `apply` deletes the stage's persisted state once the destroy converges.

```ts
// Plan.ts — realizes the old "Plan.destroy" TODO
export const destroy = (stack: { name: string; stage: string }) =>
  make({ ...emptySpec(stack), output: undefined })
    .pipe(Effect.map((plan) => ({ ...plan, destroy: true })));

// Apply.ts
if (plan.destroy) {
  // every resource row was already deleted; drop the rest of the stage —
  // notably the stack output record written by the last deploy
  yield* state.deleteStack({ stack: stackName, stage });
  return undefined;
}
```

- All three destroy paths (engine `destroy`, `alchemy destroy`, test scratch stacks) now go through `Plan.destroy`.
- `InMemoryService.deleteStack` also drops the stage's outputs (the other stores already did).
- Regression test: [destroy-output.test.ts](https://github.com/alchemy-run/alchemy/blob/claude/issue-961-regression-test-708e55/packages/alchemy/test/destroy-output.test.ts) covers both the scratch-stack path and the real `deploy`/`destroy` entry points; both failed with `expected {} to be undefined` before the fix.

Fixes #961

🤖 Generated with [Claude Code](https://claude.com/claude-code)
