### PR TITLE
fix(cloudflare): refresh OAuth credentials on expiry instead of caching forever

### DIFF
--- a/packages/alchemy/src/Cloudflare/Credentials.ts
+++ b/packages/alchemy/src/Cloudflare/Credentials.ts
@@ -3,6 +3,7 @@ import {
   apiTokenCredentials,
   Credentials,
   oauthCredentials,
+  type ResolvedCredentials,
 } from "@distilled.cloud/cloudflare/Credentials";
 import { ConfigError } from "@distilled.cloud/core/errors";
 import * as Config from "effect/Config";
@@ -10,6 +11,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Match from "effect/Match";
 import * as Redacted from "effect/Redacted";
+import * as Semaphore from "effect/Semaphore";
 import { getAuthProvider } from "../Auth/AuthProvider.ts";
 import { ALCHEMY_PROFILE, AlchemyProfile } from "../Auth/Profile.ts";
 import {
@@ -25,6 +27,66 @@ declare module "@distilled.cloud/cloudflare/Credentials" {
     readonly kind: "Credentials";
   }
 }
+
+/**
+ * Refresh OAuth credentials this long before they actually expire so that
+ * in-flight requests never race the expiry deadline.
+ */
+const CREDENTIAL_REFRESH_WINDOW_MS = 5 * 60 * 1000;
+
+const getRefreshAt = (
+  credentials: ResolvedCredentials,
+  now: number,
+): number => {
+  if (credentials.type !== "oauth" || credentials.expiresAt === undefined) {
+    return Number.POSITIVE_INFINITY;
+  }
+  return credentials.expiresAt <= now + CREDENTIAL_REFRESH_WINDOW_MS
+    ? credentials.expiresAt
+    : credentials.expiresAt - CREDENTIAL_REFRESH_WINDOW_MS;
+};
+
+/**
+ * Memoize a credentials-resolution effect until shortly before the resolved
+ * credentials expire.
+ *
+ * The distilled HTTP client resolves the `Credentials` service's effect on
+ * *every* request (`yield* config.credentials`), which is what allows OAuth
+ * tokens to rotate mid-process — a dev session can outlive the ~1h access
+ * token, so caching the first resolution forever leaves the process making
+ * API calls with a dead token until restart. At the same time, resolution
+ * acquires a cross-process file lock (`auth.read`), so resolving fresh on
+ * every request would stampede that lock under high concurrency (e.g.
+ * `unsafe nuke`).
+ *
+ * This cache serves both needs: callers get the cached credentials while
+ * they are still valid, the resolver re-runs (refreshing + persisting the
+ * token) once the refresh window is reached, and a mutex makes resolution
+ * single-flight so concurrent callers share one lock acquisition.
+ */
+export const cacheUntilExpiry = <E>(
+  resolve: Effect.Effect<ResolvedCredentials, E>,
+  now: () => number = () => Date.now(),
+): Effect.Effect<ResolvedCredentials, E> => {
+  const mutex = Semaphore.makeUnsafe(1);
+  let cached:
+    | { credentials: ResolvedCredentials; refreshAt: number }
+    | undefined;
+  return Semaphore.withPermits(
+    mutex,
+    1,
+  )(
+    Effect.suspend(() => {
+      if (cached && now() < cached.refreshAt) {
+        return Effect.succeed(cached.credentials);
+      }
+      return Effect.map(resolve, (credentials) => {
+        cached = { credentials, refreshAt: getRefreshAt(credentials, now()) };
+        return credentials;
+      });
+    }),
+  );
+};
 
 /**
  * Build a `Credentials` layer that resolves Cloudflare credentials via the
@@ -43,14 +105,7 @@ export const fromAuthProvider = () =>
       const profileName = yield* ALCHEMY_PROFILE;
       const ci = yield* Config.boolean("CI").pipe(Config.withDefault(false));
 
-      // The distilled HTTP client resolves this service's effect on *every*
-      // request (`yield* config.credentials`). `auth.read` is wrapped in a
-      // cross-process file lock, so without memoization a high-concurrency
-      // run (e.g. `unsafe nuke`) stampedes a single lock and the tail waiters
-      // blow the retry budget with "Lock file is already being held". Cache
-      // the resolution so the lock is acquired once per process, mirroring
-      // `CloudflareEnvironment.fromProfile`.
-      return yield* profile.loadOrConfigure(auth, profileName, { ci }).pipe(
+      const resolve = profile.loadOrConfigure(auth, profileName, { ci }).pipe(
         Effect.flatMap((config) =>
           auth.read(profileName, config as CloudflareAuthConfig),
         ),
@@ -82,7 +137,12 @@ export const fromAuthProvider = () =>
               message: `Failed to resolve Cloudflare credentials for profile '${profileName}': ${(e as { message?: string }).message ?? String(e)}`,
             }),
         ),
-        Effect.cached,
       );
+
+      // `auth.read` refreshes and persists expired OAuth tokens when it is
+      // re-run, so expiry-aware caching (instead of caching the first
+      // resolution forever) is what keeps long-lived dev sessions
+      // authenticated across the ~1h access-token lifetime.
+      return cacheUntilExpiry(resolve);
     }),
   );

--- a/packages/alchemy/test/Cloudflare/Credentials.test.ts
+++ b/packages/alchemy/test/Cloudflare/Credentials.test.ts
@@ -1,0 +1,143 @@
+import { cacheUntilExpiry } from "@/Cloudflare/Credentials";
+import {
+  apiTokenCredentials,
+  oauthCredentials,
+  type ResolvedCredentials,
+} from "@distilled.cloud/cloudflare/Credentials";
+import { describe, expect, it } from "alchemy-test";
+import * as Effect from "effect/Effect";
+
+/**
+ * Regression spec for "alchemy dev breaks once the Cloudflare OAuth access
+ * token expires": `fromAuthProvider` used to memoize the first credential
+ * resolution forever (`Effect.cached`), so when the remote-bindings preview
+ * session needed refreshing hours into a dev session, the preview-session
+ * API was called with the long-dead access token and every remote binding
+ * failed until the process was restarted.
+ *
+ * `cacheUntilExpiry` is the replacement: cache while valid, re-resolve
+ * (which refreshes + persists the token) once the refresh window is
+ * reached, single-flight under concurrency.
+ */
+
+const MINUTE_MS = 60_000;
+
+const makeOAuthResolver = (clock: { now: number }) => {
+  let resolutions = 0;
+  const resolve = Effect.sync(() => {
+    resolutions++;
+    return oauthCredentials({
+      accessToken: `token-${resolutions}`,
+      // each freshly resolved token is valid for 1 hour from "now"
+      expiresAt: clock.now + 60 * MINUTE_MS,
+    }) as ResolvedCredentials;
+  });
+  return { resolve, count: () => resolutions };
+};
+
+describe("Cloudflare Credentials cacheUntilExpiry", () => {
+  it.effect("caches OAuth credentials while they are valid", () =>
+    Effect.gen(function* () {
+      const clock = { now: 0 };
+      const resolver = makeOAuthResolver(clock);
+      const credentials = cacheUntilExpiry(resolver.resolve, () => clock.now);
+
+      const first = yield* credentials;
+      clock.now += 10 * MINUTE_MS;
+      const second = yield* credentials;
+
+      expect(resolver.count()).toBe(1);
+      expect(second).toBe(first);
+    }),
+  );
+
+  it.effect(
+    "re-resolves OAuth credentials once the refresh window is reached",
+    () =>
+      Effect.gen(function* () {
+        const clock = { now: 0 };
+        const resolver = makeOAuthResolver(clock);
+        const credentials = cacheUntilExpiry(resolver.resolve, () => clock.now);
+
+        const first = yield* credentials;
+        expect(first.type).toBe("oauth");
+
+        // 56 minutes in: inside the 5-minute refresh window of the 1h token.
+        clock.now += 56 * MINUTE_MS;
+        const second = yield* credentials;
+
+        expect(resolver.count()).toBe(2);
+        expect(second).not.toBe(first);
+
+        // The re-resolved token is cached again in turn.
+        clock.now += 10 * MINUTE_MS;
+        const third = yield* credentials;
+        expect(resolver.count()).toBe(2);
+        expect(third).toBe(second);
+      }),
+  );
+
+  it.effect(
+    "re-resolves OAuth credentials that are already fully expired",
+    () =>
+      Effect.gen(function* () {
+        const clock = { now: 0 };
+        const resolver = makeOAuthResolver(clock);
+        const credentials = cacheUntilExpiry(resolver.resolve, () => clock.now);
+
+        yield* credentials;
+        // The machine slept through the token's entire lifetime.
+        clock.now += 6 * 60 * MINUTE_MS;
+        yield* credentials;
+
+        expect(resolver.count()).toBe(2);
+      }),
+  );
+
+  it.effect("caches non-expiring credentials (api tokens) forever", () =>
+    Effect.gen(function* () {
+      const clock = { now: 0 };
+      let resolutions = 0;
+      const resolve = Effect.sync(() => {
+        resolutions++;
+        return apiTokenCredentials({
+          apiToken: "static",
+        }) as ResolvedCredentials;
+      });
+      const credentials = cacheUntilExpiry(resolve, () => clock.now);
+
+      yield* credentials;
+      clock.now += 365 * 24 * 60 * MINUTE_MS;
+      yield* credentials;
+
+      expect(resolutions).toBe(1);
+    }),
+  );
+
+  it.live("concurrent cold-cache resolutions are single-flight", () =>
+    Effect.gen(function* () {
+      const clock = { now: 0 };
+      let resolutions = 0;
+      const resolve = Effect.sleep("20 millis").pipe(
+        Effect.map(() => {
+          resolutions++;
+          return oauthCredentials({
+            accessToken: `token-${resolutions}`,
+            expiresAt: clock.now + 60 * MINUTE_MS,
+          }) as ResolvedCredentials;
+        }),
+      );
+      const credentials = cacheUntilExpiry(resolve, () => clock.now);
+
+      const results = yield* Effect.all(
+        [credentials, credentials, credentials, credentials],
+        { concurrency: "unbounded" },
+      );
+
+      expect(resolutions).toBe(1);
+      for (const result of results) {
+        expect(result).toBe(results[0]);
+      }
+    }),
+  );
+});


### PR DESCRIPTION
Companion to [cloudflare-tools#87](https://github.com/alchemy-run/cloudflare-tools/pull/87) for the "alchemy dev breaks after machine sleep" hang (D1 error 1031 / R2 "Unspecified error (0)" until restart).

`fromAuthProvider` memoized the first credential resolution forever, so a dev session that outlived the ~1h OAuth access token kept calling Cloudflare APIs with the dead token — when the remote-bindings preview session needed refreshing, session creation failed and every remote binding stayed broken until the process was restarted.

```diff
-      return yield* profile.loadOrConfigure(auth, profileName, { ci }).pipe(
-        ...,
-        Effect.cached,
-      );
+      const resolve = profile.loadOrConfigure(auth, profileName, { ci }).pipe(...);
+      return cacheUntilExpiry(resolve);
```

`cacheUntilExpiry` keeps the cached credentials while they are valid, re-resolves 5 minutes before expiry (`auth.read` refreshes and persists the token when re-run), and is semaphore-guarded so concurrent resolutions still acquire the cross-process file lock once — the stampede `Effect.cached` was originally protecting against.

The runtime-side session refresh ships via a `@distilled.cloud/cloudflare-runtime` release after cloudflare-tools#87 lands; this fix is independent and effective on its own for API-call auth.
