### PR TITLE
feat(cloudflare/workers): assets-only Workers (no script)

### DIFF
--- a/packages/alchemy/src/Cloudflare/Website/StaticSite.ts
+++ b/packages/alchemy/src/Cloudflare/Website/StaticSite.ts
@@ -95,13 +95,21 @@ type StaticSiteWorker<Bindings extends WorkerBindingProps> = Worker<{
  * @category Workers & Compute
  *
  * @section Basic Usage
- * Point `command` at your build script, `outdir` at where it writes
- * output, and `main` at a Worker entrypoint that serves the assets.
- * Alchemy runs the command, hashes the output, and deploys the
- * Worker bound to the built assets.
+ * Point `command` at your build script and `outdir` at where it writes
+ * output. Alchemy runs the command, hashes the output, and deploys it as
+ * an assets-only Worker — no Worker code is uploaded, and Cloudflare's
+ * asset layer serves every request itself.
  *
- * The Worker receives an `ASSETS` binding it can delegate to. A
- * minimal passthrough Worker looks like:
+ * @example Deploying a Hugo site
+ * ```typescript
+ * const site = yield* Cloudflare.Website.StaticSite("Blog", {
+ *   command: "hugo --minify",
+ *   outdir: "public",
+ * });
+ * ```
+ *
+ * Provide `main` to put your own Worker in front of the assets instead.
+ * The Worker receives an `ASSETS` binding it can delegate to:
  *
  * ```typescript
  * // src/worker.ts
@@ -111,7 +119,7 @@ type StaticSiteWorker<Bindings extends WorkerBindingProps> = Worker<{
  * };
  * ```
  *
- * @example Deploying a Hugo site
+ * @example Custom Worker in front of the assets
  * ```typescript
  * const site = yield* Cloudflare.Website.StaticSite("Blog", {
  *   command: "hugo --minify",
@@ -253,14 +261,9 @@ const makeStaticSite = <
           env: serializeEnv(props.env),
         });
 
-    // Pure-static sites don't need a custom Worker entrypoint —
-    // delegate every request straight to the ASSETS binding. Only
-    // injected when the user provided neither `main` nor `script`.
-    const fallbackScript =
-      props.main == null && props.script == null
-        ? `export default { fetch: (request, env) => env.ASSETS.fetch(request) };`
-        : undefined;
-
+    // Pure-static sites (neither `main` nor `script`) deploy as
+    // assets-only Workers: no script is uploaded and Cloudflare's asset
+    // layer serves every request itself.
     return yield* Worker<Bindings, WorkerAssetsConfig, Req>("Worker", {
       ...props,
       assets: build
@@ -274,7 +277,7 @@ const makeStaticSite = <
       // is serving the content. The Worker resource still exists in
       // state with a stub Attributes shape.
       dev: dev ? { mode: "external", url: dev.url } : undefined,
-      script: fallbackScript ?? props.script,
+      script: props.script,
     });
   }).pipe(Namespace.push(id));
 

--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -621,6 +621,34 @@ export const LocalWorkerProvider = () =>
         return proxy.url;
       });
 
+      // Assets-only Worker: there is no entry module to bundle or watch.
+      // The local runtime requires a user worker module, so serve a stub
+      // that delegates every request to the ASSETS binding — the assets
+      // worker applies `htmlHandling` / `notFoundHandling` (including SPA
+      // fallback) itself, matching Cloudflare's deployed assets-only
+      // behavior.
+      const assetsOnlyBundle: Bundle.BundleOutput = {
+        files: [
+          {
+            path: "main.js",
+            content:
+              "export default { fetch: (request, env) => env.ASSETS.fetch(request) };",
+            hash: "assets-only-stub",
+          },
+        ],
+        hash: "assets-only-stub",
+      };
+
+      const runAssetsOnly = Effect.fn(function* (worker: WorkerConfig) {
+        const start = Date.now();
+        const proxy = yield* maybeStartProxy(worker.id, worker.dev);
+        yield* serveScoped(worker, assetsOnlyBundle, proxy);
+        yield* Effect.log(
+          `[${worker.id}] Started in ${Math.round(Date.now() - start)}ms`,
+        );
+        return proxy.url;
+      });
+
       const runVite = Effect.fn(function* (
         worker: WorkerConfig,
         rootDir: string | undefined,
@@ -680,7 +708,11 @@ export const LocalWorkerProvider = () =>
         const { props, bindings } = options;
         const config = yield* buildConfig(options);
         const url = yield* (
-          props.vite ? runVite(config, props.vite.rootDir) : runWorker(config)
+          props.vite
+            ? runVite(config, props.vite.rootDir)
+            : props.main === undefined && props.assets
+              ? runAssetsOnly(config)
+              : runWorker(config)
         ).pipe(Effect.map((url) => url.toString()));
         return {
           workerId: config.name,

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -367,6 +367,11 @@ export interface WorkerProps<
    * - A string path to the assets directory
    * - An AssetsProps object with directory and config
    * - An object with path and hash (e.g., from a Build resource)
+   *
+   * When neither {@link main} nor {@link script} is provided, the Worker is
+   * deployed **assets-only**: no script is uploaded at all and Cloudflare's
+   * asset layer serves every request, applying `htmlHandling` /
+   * `notFoundHandling` (including single-page-application fallback) itself.
    */
   assets?: Assets;
   subdomain?: {
@@ -409,7 +414,8 @@ export interface WorkerProps<
   tags?: string[];
   /**
    * Path to the Worker's entry module. Bundled with rolldown before
-   * upload. Mutually exclusive with {@link script} — provide exactly one.
+   * upload. Mutually exclusive with {@link script} — provide at most one.
+   * Omit both (with {@link assets} set) to deploy an assets-only Worker.
    *
    * A `.py` entry deploys a Python Worker instead: no bundling runs — the
    * entry plus every sibling `.py` file upload as Python modules, the
@@ -1012,6 +1018,22 @@ export const isSelfUrl = (value: unknown): value is URLEffect =>
  *   main: import.meta.url,
  *   assets: "./public",
  * }
+ * ```
+ *
+ * @example Assets-only Worker (static site)
+ * Omit `main` and `script` entirely to deploy a static site: no Worker
+ * code is uploaded — Cloudflare's asset layer serves every request and
+ * applies `htmlHandling` / `notFoundHandling` (including SPA fallback)
+ * itself, exactly like an assets-only `wrangler deploy`.
+ * ```typescript
+ * const site = yield* Cloudflare.Worker("Site", {
+ *   assets: {
+ *     directory: "./public",
+ *     htmlHandling: "drop-trailing-slash",
+ *     notFoundHandling: "404-page",
+ *   },
+ *   domain: "static.example.com",
+ * });
  * ```
  *
  * @example Zone routes

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -1394,6 +1394,28 @@ export const LiveWorkerProvider = () =>
           if (props.vite) {
             return yield* viteBuild(props, opts.selfUrl);
           }
+          // Assets-only Worker: no entry module at all. The script PUT goes
+          // out with no modules and no main_module — Cloudflare's asset
+          // layer serves every request and applies `notFoundHandling`
+          // (including SPA fallback) itself, exactly like Wrangler's
+          // assets-only deploys.
+          if (props.main === undefined) {
+            if (!props.assets) {
+              return yield* Effect.die(
+                new Error(
+                  `Worker "${id}" has no main, script, or assets. Provide an entry module (main / script) or an assets directory to deploy an assets-only Worker.`,
+                ),
+              );
+            }
+            return {
+              assets: opts.skipAssetsRead
+                ? undefined
+                : yield* prepareAssets(props.assets),
+              bundle: undefined,
+              input: undefined,
+              additionalWorkspaces: undefined,
+            };
+          }
           const [assets, bundle] = yield* Effect.all(
             [
               opts.skipAssetsRead
@@ -2199,6 +2221,25 @@ export const LiveWorkerProvider = () =>
             Effect.succeed(output.hash?.additionalWorkspaces ?? []),
           );
           return hash !== output.hash?.input;
+        }
+        // Assets-only Worker — there is no bundle to hash. A stored bundle
+        // hash means the Worker previously had a script and is being
+        // converted to assets-only, which must deploy.
+        if (props.main === undefined) {
+          if (output.hash?.bundle !== undefined) {
+            return true;
+          }
+          const assetsHash =
+            props.assets && Predicate.hasProperty(props.assets, "hash")
+              ? props.assets.hash
+              : undefined;
+          if (assetsHash === undefined) {
+            // Same conservative rule as the directory-shaped `assets` below:
+            // don't read the directory during diff; `putWorker` reads once
+            // and keeps the existing manifest if nothing actually changed.
+            return true;
+          }
+          return assetsHash !== output.hash?.assets;
         }
         const bundleHash = yield* prepareBundle(id, props).pipe(
           Effect.map((b) => b.hash),

--- a/packages/alchemy/test/Cloudflare/Workers/AssetsOnlyWorker.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/AssetsOnlyWorker.test.ts
@@ -1,0 +1,132 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Test from "@/Test/Alchemy";
+import { describe } from "alchemy-test";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as Schedule from "effect/Schedule";
+import * as pathe from "pathe";
+import { cloneFixture } from "../Utils/Fixture.ts";
+import { expectUrlContains } from "../Utils/Http.ts";
+
+const { test } = Test.make({ providers: Cloudflare.providers() });
+
+const fixtureDir = pathe.resolve(import.meta.dirname, "fixtures/assets-only");
+
+class NotFoundAssertionFailed extends Data.TaggedError(
+  "NotFoundAssertionFailed",
+)<{
+  url: string;
+  status: number;
+  bodyExcerpt: string;
+}> {}
+
+/**
+ * Assert `url` serves the custom 404 page: status 404 with the fixture's
+ * `404.html` marker in the body. `expectUrlContains` requires `res.ok`,
+ * so this needs its own retry loop.
+ */
+const expectCustom404 = (url: string) =>
+  Effect.tryPromise({
+    try: async (signal) => {
+      const res = await fetch(url, { signal, cache: "no-store" });
+      const body = await res.text();
+      if (res.status !== 404 || !body.includes("alchemy-assets-only-404")) {
+        throw new NotFoundAssertionFailed({
+          url,
+          status: res.status,
+          bodyExcerpt: body.slice(0, 240),
+        });
+      }
+    },
+    catch: (e) =>
+      e instanceof NotFoundAssertionFailed
+        ? e
+        : new NotFoundAssertionFailed({
+            url,
+            status: 0,
+            bodyExcerpt: e instanceof Error ? e.message : String(e),
+          }),
+  }).pipe(
+    Effect.retry({
+      schedule: Schedule.exponential("750 millis", 1.5),
+      times: 10,
+    }),
+  );
+
+describe.concurrent("Cloudflare.Worker assets-only", () => {
+  test.provider(
+    "deploys, updates, and converts an assets-only Worker",
+    (stack) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+
+        yield* stack.destroy();
+
+        const deploy = (props: {
+          assets: string | { directory: string; notFoundHandling?: "404-page" };
+          script?: string;
+        }) =>
+          stack.deploy(
+            Effect.gen(function* () {
+              return yield* Cloudflare.Worker("AssetsOnly", {
+                ...props,
+                subdomain: { enabled: true },
+                compatibility: { date: "2024-01-01" },
+              });
+            }),
+          );
+
+        // 1. Fresh assets-only deploy: no main, no script — Cloudflare's
+        //    asset layer serves everything, including the custom 404 page.
+        const worker = yield* deploy({
+          assets: { directory: fixtureDir, notFoundHandling: "404-page" },
+        });
+        const url = worker.url!;
+        yield* expectUrlContains(`${url}/`, "alchemy-assets-only-index");
+        yield* expectCustom404(`${url}/does-not-exist`);
+
+        // 2. Update: editing an asset must redeploy the new content.
+        const dir = yield* cloneFixture(fixtureDir, {
+          prefix: "alchemy-assets-only-",
+        });
+        yield* fs.writeFileString(
+          path.join(dir, "index.html"),
+          "<html><body>alchemy-assets-only-index-v2</body></html>",
+        );
+        yield* deploy({
+          assets: { directory: dir, notFoundHandling: "404-page" },
+        });
+        yield* expectUrlContains(`${url}/`, "alchemy-assets-only-index-v2", {
+          label: "updated asset",
+        });
+
+        // 3. Convert to a script Worker: unmatched routes now invoke the
+        //    script instead of the asset layer's 404 handling.
+        yield* deploy({
+          assets: dir,
+          script: `export default { fetch: () => new Response("alchemy-assets-only-script") };`,
+        });
+        yield* expectUrlContains(
+          `${url}/does-not-exist`,
+          "alchemy-assets-only-script",
+          { label: "script fallback after conversion" },
+        );
+
+        // 4. Convert back to assets-only: the stored bundle hash must not
+        //    mask the change, and the asset layer owns 404s again.
+        yield* deploy({
+          assets: { directory: dir, notFoundHandling: "404-page" },
+        });
+        yield* expectCustom404(`${url}/does-not-exist`);
+        yield* expectUrlContains(`${url}/`, "alchemy-assets-only-index-v2", {
+          label: "assets serve after conversion back",
+        });
+
+        yield* stack.destroy();
+      }),
+    { timeout: 360_000 },
+  );
+});

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/assets-only/404.html
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/assets-only/404.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<html>
+  <body>
+    alchemy-assets-only-404
+  </body>
+</html>

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/assets-only/index.html
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/assets-only/index.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<html>
+  <body>
+    alchemy-assets-only-index
+  </body>
+</html>

--- a/website/src/content/docs/cloudflare/compute/workers.mdx
+++ b/website/src/content/docs/cloudflare/compute/workers.mdx
@@ -248,6 +248,51 @@ export default Cloudflare.Worker(
 For zone setup, DNS records, and route patterns, see the
 [custom domains guide](/cloudflare/networking/custom-domains).
 
+## Static assets
+
+A Worker can serve a directory of static files alongside its code.
+Pass `assets` and Cloudflare serves matching requests from its asset
+layer; everything else invokes your handlers:
+
+```typescript
+export default Cloudflare.Worker(
+  "Worker",
+  {
+    main: import.meta.url,
+    assets: "./public",
+  },
+  // ...
+);
+```
+
+Omit `main` entirely to deploy an **assets-only Worker** — a static
+site with no Worker code of your own:
+
+```typescript
+const site = yield* Cloudflare.Worker("Site", {
+  assets: {
+    directory: "./public",
+    htmlHandling: "drop-trailing-slash",
+    notFoundHandling: "404-page",
+  },
+  domain: "static.example.com",
+});
+```
+
+Cloudflare's asset layer serves every request and applies
+`htmlHandling` / `notFoundHandling` (including
+single-page-application fallback) itself — the same deployment shape
+as an assets-only `wrangler deploy`. Static asset requests are free
+and never invoke a Worker.
+
+A `_headers` or `_redirects` file in the assets directory is applied
+automatically, and a `.assetsignore` file excludes files from the
+upload.
+
+If the directory comes from a build command, use
+[StaticSite](/cloudflare/frontend/static-site); for Vite projects,
+use the [Vite resource](/cloudflare/frontend/vite).
+
 ## The Worker's own URL
 
 A Worker often needs to know the URL it is served at — to build

--- a/website/src/content/docs/cloudflare/frontend/static-site.mdx
+++ b/website/src/content/docs/cloudflare/frontend/static-site.mdx
@@ -14,17 +14,27 @@ re-runs), so it works for anything that produces a directory of files — a
 Zola or Hugo site, a bash script, or the static output of a framework the
 [Vite resource](/cloudflare/frontend/vite) doesn't support yet.
 
-If you provide neither `main` nor `script`, Alchemy injects a fallback
-passthrough Worker in front of the assets:
+If you provide neither `main` nor `script`, the site deploys as an
+**assets-only Worker**: no Worker code is uploaded at all. Cloudflare's
+asset layer serves every request itself — static asset requests are free
+and never invoke a Worker — and applies your `notFoundHandling` /
+`htmlHandling` config, exactly like an assets-only `wrangler deploy`.
+Provide `main` to put a real Worker in front instead (see
+[below](#a-custom-worker-in-front-of-your-assets)).
+
+If your files need no build step at all, you can skip `StaticSite` and
+give a plain [Worker](/cloudflare/compute/workers) just an assets
+directory:
 
 ```typescript
-export default { fetch: (request, env) => env.ASSETS.fetch(request) };
+const site = yield* Cloudflare.Worker("Site", {
+  assets: {
+    directory: "./public",
+    htmlHandling: "drop-trailing-slash",
+  },
+  domain: "static.example.com",
+});
 ```
-
-Every request delegates straight to the `ASSETS` binding — you get a pure
-static site with no Worker code of your own. Provide `main` to put a real
-Worker in front instead (see
-[below](#a-custom-worker-in-front-of-your-assets)).
 
 ## Deploy a Zola site
 


### PR DESCRIPTION
A Worker with only an assets directory — no `main`, no `script`, no build — now deploys as a true assets-only Worker, matching an assets-only `wrangler deploy`:

```ts
const site = yield* Cloudflare.Worker("Site", {
  assets: {
    directory: "./public",
    htmlHandling: "drop-trailing-slash",
  },
  domain: "static.example.com",
});
```

No script is uploaded at all (the PUT carries no `main_module` and no modules — the same wire shape the Vite assets-only path already uses), so Cloudflare's asset layer serves every request and applies `htmlHandling` / `notFoundHandling` (including SPA fallback) itself. Static asset requests are free and never invoke a Worker.

- `prepareAssetsAndBundle` skips bundling when `main`/`script`/`vite` are all absent; a Worker with none of `main`/`script`/`assets` dies with a clear error
- `hasChanged` gains the matching diff branch (a stored bundle hash means "converting from a script Worker" → deploy)
- Local dev serves a stub module delegating to the `ASSETS` binding (the local runtime requires a user worker module); the assets worker applies the routing config itself
- `Website.StaticSite` drops its injected passthrough stub and deploys assets-only when no `main`/`script` is given
- Docs: assets-only example on `Worker`, updated `StaticSite` JSDoc, and `static-site.mdx` now shows the plain-Worker form for no-build sites

Live-tested: fresh assets-only deploy (custom 404 page served by the asset layer), asset update, conversion to a script Worker and back ([AssetsOnlyWorker.test.ts](https://github.com/alchemy-run/alchemy/blob/claude/cloudflare-worker-assets-only-fa4e70/packages/alchemy/test/Cloudflare/Workers/AssetsOnlyWorker.test.ts)); all 7 existing StaticSite tests pass with the stub removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
