### PR TITLE
feat(cloudflare/workers): class form without an impl (assets-only / external Workers)

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -1436,6 +1436,26 @@ export const Worker: ResourceClassLike<Worker> &
         Named<Id> & {
           new (): MakeShape<Shape, WorkerShape> & Named<Id> & Tag;
         };
+      /**
+       * Class form without an implementation — an external Worker (a plain
+       * bundled `main`, a raw `script`, or an assets-only Worker with no
+       * script at all):
+       *
+       * ```typescript
+       * export class Site extends Cloudflare.Worker<Site>()("Site", {
+       *   assets: { directory: "./public" },
+       * }) {}
+       * ```
+       */
+      <const Id extends string, Req = never>(
+        id: Id,
+        props:
+          | InputProps<WorkerProps>
+          | Effect.Effect<InputProps<WorkerProps>, ConfigError, Req>,
+      ): Effect.Effect<Worker & Rpc<{}>, never, Req | Providers> &
+        Named<Id> & {
+          new (): Named<Id> & Tag;
+        };
     };
     <
       const Bindings extends WorkerBindingProps = {},

--- a/packages/alchemy/src/Platform.ts
+++ b/packages/alchemy/src/Platform.ts
@@ -344,6 +344,21 @@ export const Platform = <
         constructor(id, props, impl, true);
     } else if (!impl) {
       const cls = makeClass(id);
+      // A resource declared without an inline impl is "external": there is
+      // no Effect-native entry to inject (an ordinary bundled worker, or an
+      // assets-only worker with no script at all).
+      const externalProps = () => {
+        const transformed = applyTransformProps(id, props);
+        return Effect.isEffect(transformed)
+          ? Effect.map(transformed, (p: any) => ({
+              ...p,
+              isExternal: true,
+            }))
+          : {
+              ...transformed,
+              isExternal: true,
+            };
+      };
       const evaluate = () =>
         (!isTag
           ? // this is a non-tagged resource yielded without providing an implementation
@@ -356,27 +371,24 @@ export const Platform = <
             //     return new Response("Hello, world!");
             //   }
             // }
-            resource(
-              id,
-              (() => {
-                const transformed = applyTransformProps(id, props);
-                return Effect.isEffect(transformed)
-                  ? Effect.map(transformed, (p: any) => ({
-                      ...p,
-                      isExternal: true,
-                    }))
-                  : {
-                      ...transformed,
-                      isExternal: true,
-                    };
-              })(),
-            )
+            resource(id, externalProps())
           : Effect.flatMap(
               // this is a tagged resource
               Effect.serviceOption(cls.Self),
               Option.match({
-                // we are likely running at runtime, so we create
-                onNone: () => resource(id, applyTransformProps(id, props)),
+                // we are likely running at runtime, so we create.
+                // A tagged class WITH props and no impl is the class form of
+                // the external resource above (e.g.
+                // `class Site extends Worker<Site>()("Site", { assets }) {}`)
+                // — same isExternal marking; without props, this is a bare
+                // tag whose props/impl arrive later via `.make`.
+                onNone: () =>
+                  resource(
+                    id,
+                    props === undefined
+                      ? applyTransformProps(id, props)
+                      : externalProps(),
+                  ),
                 onSome: Effect.succeed,
               }),
             )

--- a/packages/alchemy/test/Cloudflare/Workers/AssetsOnlyWorker.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/AssetsOnlyWorker.test.ts
@@ -129,4 +129,33 @@ describe.concurrent("Cloudflare.Worker assets-only", () => {
       }),
     { timeout: 360_000 },
   );
+
+  test.provider(
+    "class form deploys an assets-only Worker",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        class Site extends Cloudflare.Worker<Site>()("AssetsOnlyClass", {
+          assets: {
+            directory: fixtureDir,
+            notFoundHandling: "404-page",
+          },
+          subdomain: { enabled: true },
+          compatibility: { date: "2024-01-01" },
+        }) {}
+
+        const worker = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Site;
+          }),
+        );
+        const url = worker.url!;
+        yield* expectUrlContains(`${url}/`, "alchemy-assets-only-index");
+        yield* expectCustom404(`${url}/does-not-exist`);
+
+        yield* stack.destroy();
+      }),
+    { timeout: 240_000 },
+  );
 });

--- a/website/src/content/docs/cloudflare/compute/workers.mdx
+++ b/website/src/content/docs/cloudflare/compute/workers.mdx
@@ -285,6 +285,19 @@ single-page-application fallback) itself — the same deployment shape
 as an assets-only `wrangler deploy`. Static asset requests are free
 and never invoke a Worker.
 
+The class form works too — declare it in its own file and yield the
+class in your Stack:
+
+```typescript
+export class Site extends Cloudflare.Worker<Site>()("Site", {
+  assets: {
+    directory: "./public",
+    htmlHandling: "drop-trailing-slash",
+  },
+  domain: "static.example.com",
+}) {}
+```
+
 A `_headers` or `_redirects` file in the assets directory is applied
 automatically, and a `.assetsignore` file excludes files from the
 upload.


### PR DESCRIPTION
Follow-up to #969. The class form of `Cloudflare.Worker` required an implementation, so declaring an assets-only (or any external) Worker as a class was a type error — `Expected 3 arguments, but got 2`:

```ts
export class Site extends Cloudflare.Worker<Site>()("Site", {
  assets: {
    directory: "public",
    htmlHandling: "drop-trailing-slash",
  },
  domain: "static.rx2.dev",
}) {}
```

This now typechecks and deploys.

- New overload on the tagged class form: `(id, props)` with no `impl`, returning `Effect<Worker & Rpc<{}>> & Named<Id>` — same contract as the no-impl function form
- The tagged no-impl runtime path now marks props `isExternal` (matching the function form) so a class-declared external Worker gets external bundling/compat treatment instead of the Effect-entry wrapper; bare tags (`(id)` only, props via `.make`) are unchanged
- workers.mdx Static assets section shows the class form

Live-tested: class-form assets-only deploy serves the site and the custom 404 page; core `Worker.test.ts` suite (21 tests) passes on the shared `Platform.ts` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
