### PR TITLE
fix(cloudflare/workers): converge plans for unmanaged custom domains

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -2476,9 +2476,16 @@ export const LiveWorkerProvider = () =>
           const oldDomains = normalizeStateDomains(output?.domains)
             .filter((u) => !u.endsWith(".workers.dev"))
             .sort();
+          // An omitted `domain` unmanages the surface (#942): reconcile skips
+          // reconcileDomains and carries previously-observed custom domains
+          // forward in state, so comparing the empty desired set against those
+          // persisted domains would report a dirty plan on every deploy,
+          // forever. Only a declared `domain` (including `[]`, the explicit
+          // detach-all) participates in the diff.
           const domainsChanged =
-            newDomains.length !== oldDomains.length ||
-            newDomains.some((d, i) => d !== oldDomains[i]);
+            news.domain !== undefined &&
+            (newDomains.length !== oldDomains.length ||
+              newDomains.some((d, i) => d !== oldDomains[i]));
           const newCrons = normalizeCrons([
             ...(Array.isArray(newBindings)
               ? getCronBindings(
@@ -2510,10 +2517,19 @@ export const LiveWorkerProvider = () =>
           // Webhook delivery URL built via `Output.interpolate`) resolve it
           // to a concrete value during planning instead of an unresolved
           // Output — otherwise every worker update spuriously re-updates them.
-          const newCustomDomains = normalizeDomains(news.domain);
+          // Mirror reconcile's `domains[0]`: with `domain` declared, the
+          // first declared hostname; unmanaged (`domain` omitted, #942),
+          // previously-observed custom domains carry forward in state order;
+          // otherwise the workers.dev URL.
+          const newCustomDomains =
+            news.domain !== undefined
+              ? normalizeDomains(news.domain).map((h) => `https://${h}`)
+              : normalizeStateDomains(output.domains).filter(
+                  (u) => !u.endsWith(".workers.dev"),
+                );
           const newUrl =
             newCustomDomains.length > 0
-              ? `https://${newCustomDomains[0]}`
+              ? newCustomDomains[0]
               : news.url !== false
                 ? normalizeStateDomains(output.domains).find((u) =>
                     u.endsWith(".workers.dev"),

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerDomain.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerDomain.test.ts
@@ -162,6 +162,23 @@ test.provider.skipIf(!zoneName)(
         // subsequent reads keep observing them.
         expect(unmanaged.domains).toContain(`https://${DECLARED_HOSTNAME}`);
 
+        // The unmanaged surface must also converge: the custom domains
+        // carried forward in state must not diff dirty against the omitted
+        // `domain` prop — an identical program plans as a noop.
+        const settled = yield* stack.plan(
+          Effect.gen(function* () {
+            return yield* Cloudflare.Worker("DomainWorker", {
+              main,
+              url: false,
+              compatibility: { date: "2024-01-02" },
+            });
+          }),
+        );
+        const settledAction = (Object.values(settled.resources) as any[]).find(
+          (node: any) => node.resource.LogicalId === "DomainWorker",
+        )?.action;
+        expect(settledAction).toBe("noop");
+
         // `domain: []` is the explicit detach-all.
         const detached = yield* stack.deploy(
           Effect.gen(function* () {


### PR DESCRIPTION
Closes #942

#932 stopped an omitted `domain` from deleting out-of-band custom-domain attachments, but the diff still compared the empty desired set against custom domains carried forward in state — so an unmanaged Worker with previously-observed domains re-planned an update on every deploy, forever.

```diff
  const domainsChanged =
+   news.domain !== undefined &&
-   newDomains.length !== oldDomains.length ||
-   newDomains.some((d, i) => d !== oldDomains[i]);
+   (newDomains.length !== oldDomains.length ||
+     newDomains.some((d, i) => d !== oldDomains[i]));
```

- `newUrl` in `diff` now mirrors reconcile's carry-forward: with `domain` omitted, persisted custom domains stay first in `domains`, so `url` stays stable across unmanaged updates.
- Extends the #942 live regression test: after the unmanaged update (out-of-band hostname attached, `domain` omitted), an identical program must plan as a `noop`.

fixes #942

🤖 Generated with [Claude Code](https://claude.com/claude-code)
