### PR TITLE
docs(cloudflare): resolve account ID from profile in CI/CD docs

### DIFF
--- a/packages/alchemy/src/Cloudflare/ApiToken/AccountApiToken.ts
+++ b/packages/alchemy/src/Cloudflare/ApiToken/AccountApiToken.ts
@@ -53,6 +53,9 @@ export type AccountApiToken = Resource<
  * @section Creating a Token
  * @example A token for managing Workers and KV from CI
  * ```typescript
+ * // the account ID resolves from the profile you're deploying with
+ * const { accountId } = yield* yield* Cloudflare.CloudflareEnvironment;
+ *
  * const token = yield* Cloudflare.ApiToken.AccountApiToken("ci-token", {
  *   name: "my-ci-token",
  *   accountId,

--- a/website/src/content/docs/cloudflare/tutorial/part-5.mdx
+++ b/website/src/content/docs/cloudflare/tutorial/part-5.mdx
@@ -95,7 +95,6 @@ profile) to provision the Cloudflare API token CI will use.
 import * as Alchemy from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
 import * as GitHub from "alchemy/GitHub";
-import * as Config from "effect/Config";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Redacted from "effect/Redacted";
@@ -110,10 +109,21 @@ export default Alchemy.Stack(
     state: Cloudflare.state(),
   },
   Effect.gen(function* () {
-    const accountId = yield* Config.string("CLOUDFLARE_ACCOUNT_ID");
+    const { accountId } = yield* yield* Cloudflare.CloudflareEnvironment;
   }),
 );
 ```
+
+`Cloudflare.CloudflareEnvironment` resolves the credentials of the
+profile you're deploying with — here, the `admin` profile — and the
+account ID comes along with them. You don't need to set a
+`CLOUDFLARE_ACCOUNT_ID` environment variable; your login already
+knows it.
+
+Note the double `yield*`: the service's value is itself an Effect,
+because credentials are cached and can refresh themselves (OAuth
+tokens expire). The first `yield*` gets the service, the second
+resolves the current credentials.
 
 Reusing the same `Cloudflare.state()` you set up in Part 1 means the
 token's ID is tracked alongside the rest of your infrastructure, so
@@ -128,7 +138,7 @@ in state — the raw token never touches your terminal.
 
 ```diff lang="typescript"
   Effect.gen(function* () {
-    const accountId = yield* Config.string("CLOUDFLARE_ACCOUNT_ID");
+    const { accountId } = yield* yield* Cloudflare.CloudflareEnvironment;
 +
 +   const apiToken = yield* Cloudflare.ApiToken.AccountApiToken("CIToken", {
 +     accountId,
@@ -208,8 +218,8 @@ Run it once from your laptop, under the `admin` profile:
 alchemy deploy stacks/github.ts --profile admin
 ```
 
-You'll see Alchemy plan two creates — the Cloudflare token and the
-GitHub secret — then apply them. When it's done, head to your repo's
+You'll see Alchemy plan three creates — the Cloudflare token and the
+two GitHub secrets — then apply them. When it's done, head to your repo's
 **Settings → Secrets and variables → Actions** page; you should see
 `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` listed there.
 
@@ -379,6 +389,11 @@ state.
 If you want to keep preview environments on one Cloudflare account
 and production on another, deploy two tokens from the same
 `stacks/github.ts` and prefix the secrets accordingly.
+
+Your profile resolves a single account ID, so this is the one case
+where you pass the account IDs in explicitly — set
+`TEST_CLOUDFLARE_ACCOUNT_ID` and `PROD_CLOUDFLARE_ACCOUNT_ID` in
+your environment when deploying this stack.
 
 ```typescript
 // stacks/github.ts

--- a/website/src/content/docs/environments/ci.mdx
+++ b/website/src/content/docs/environments/ci.mdx
@@ -361,7 +361,6 @@ token-management token.
 import * as Alchemy from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
 import * as GitHub from "alchemy/GitHub";
-import * as Config from "effect/Config";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Redacted from "effect/Redacted";
@@ -376,7 +375,7 @@ export default Alchemy.Stack(
     state: Cloudflare.state(),
   },
   Effect.gen(function* () {
-    const accountId = yield* Config.string("CLOUDFLARE_ACCOUNT_ID");
+    const { accountId } = yield* yield* Cloudflare.CloudflareEnvironment;
 
     const apiToken = yield* Cloudflare.ApiToken.AccountApiToken("CIToken", {
       accountId,
@@ -420,6 +419,13 @@ export default Alchemy.Stack(
 
 A few details worth knowing:
 
+- `Cloudflare.CloudflareEnvironment` resolves the credentials of the
+  profile you're deploying with, account ID included — no
+  `CLOUDFLARE_ACCOUNT_ID` env var needed for this local deploy. The
+  double `yield*` is because the service's value is itself an Effect:
+  credentials are cached and can refresh themselves (OAuth tokens
+  expire), so you yield once for the service and once to resolve the
+  current credentials.
 - `Cloudflare.ApiToken.AccountApiToken` calls
   `POST /accounts/{account_id}/tokens` and Cloudflare returns the
   freshly minted token value exactly once. Alchemy captures it,
@@ -472,6 +478,11 @@ For stricter isolation you can run preview environments on one
 Cloudflare account and production on another. Mint two tokens from
 the same `stacks/github.ts` and prefix the secrets so the workflow
 can pick the right pair based on `STAGE`.
+
+Your profile resolves a single account ID, so this is the one case
+where you pass the account IDs in explicitly — set
+`TEST_CLOUDFLARE_ACCOUNT_ID` and `PROD_CLOUDFLARE_ACCOUNT_ID` in
+your environment when deploying this stack.
 
 ```typescript
 // stacks/github.ts


### PR DESCRIPTION
The CI/CD docs told readers to read `CLOUDFLARE_ACCOUNT_ID` from the environment, which fails on `alchemy deploy stacks/github.ts --profile admin` because nothing sets that variable. The logged-in profile already resolves the account ID, so the `github.ts` stack should pull it from there.

```diff
-const accountId = yield* Config.string("CLOUDFLARE_ACCOUNT_ID");
+const { accountId } = yield* yield* Cloudflare.CloudflareEnvironment;
```

- `cloudflare/tutorial/part-5.mdx` and `environments/ci.mdx`: switch the single-account `stacks/github.ts` examples to `CloudflareEnvironment`, drop the unused `Config` import, and explain the double `yield*` (the service's value is an Effect because credentials cache and auto-refresh)
- Both multi-account sections: note that the profile resolves a single account ID, so `TEST_/PROD_CLOUDFLARE_ACCOUNT_ID` env vars stay explicit there by design
- `AccountApiToken` JSDoc: make the CI-token example self-contained by showing where `accountId` comes from

Reported by BlankParticle on Discord.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
