### PR TITLE
docs: fix misindented diff-block lines from #860/#972

### DIFF
--- a/website/src/content/docs/cloudflare/tutorial/part-6.mdx
+++ b/website/src/content/docs/cloudflare/tutorial/part-6.mdx
@@ -41,8 +41,8 @@ import * as Effect from "effect/Effect";
 export default Alchemy.Stack(
   "MyApp",
   {
--   providers: Cloudflare.providers(),
-+   providers: Layer.mergeAll(Cloudflare.providers(), Axiom.providers()),
+-    providers: Cloudflare.providers(),
++    providers: Layer.mergeAll(Cloudflare.providers(), Axiom.providers()),
     state: Cloudflare.state(),
   },
   // ...
@@ -139,15 +139,15 @@ export default Cloudflare.Worker(
   { main: import.meta.url },
   Effect.gen(function* () {
     // ...
-- }).pipe(Effect.provide(Cloudflare.R2.ReadWriteBucketBinding)),
-+ }).pipe(
-+   Effect.provide(
-+     Layer.mergeAll(
-+       Cloudflare.R2.ReadWriteBucketBinding,
-+       Axiom.Telemetry({ token: Ingest, traces: Traces, logs: Logs }),
-+     ),
-+   ),
-+ ),
+-  }).pipe(Effect.provide(Cloudflare.R2.ReadWriteBucketBinding)),
++  }).pipe(
++    Effect.provide(
++      Layer.mergeAll(
++        Cloudflare.R2.ReadWriteBucketBinding,
++        Axiom.Telemetry({ token: Ingest, traces: Traces, logs: Logs }),
++      ),
++    ),
++  ),
 );
 ```
 
@@ -192,10 +192,10 @@ time went*, wrap the R2 read in its own span:
           // ...
         }
 
--       const object = yield* bucket.get(key);
-+       const object = yield* bucket
-+         .get(key)
-+         .pipe(Effect.withSpan("bucket.get", { attributes: { key } }));
+-        const object = yield* bucket.get(key);
++        const object = yield* bucket
++          .get(key)
++          .pipe(Effect.withSpan("bucket.get", { attributes: { key } }));
 ```
 
 `Effect.withSpan` opens a child span under whatever span is current —
@@ -211,7 +211,7 @@ span IDs, so Axiom can jump from a log line to its trace:
 ```diff lang="typescript"
 // src/worker.ts
         const text = yield* object.text();
-+       yield* Effect.log("served object", { key });
++        yield* Effect.log("served object", { key });
         return HttpServerResponse.text(text);
 ```
 

--- a/website/src/content/docs/docker/swarm.mdx
+++ b/website/src/content/docs/docker/swarm.mdx
@@ -131,6 +131,8 @@ are no-ops.
 +import { ServerHost } from "alchemy/Server/Process";
 +import * as Schedule from "effect/Schedule";
 
+const api = yield* Docker.Service(
+  // ...
   Effect.gen(function* () {
 +    const host = yield* ServerHost;
 +    yield* host.run(
@@ -145,6 +147,7 @@ are no-ops.
       }),
     };
   }),
+);
 ```
 
 `host.run` registers a long-running loop that executes alongside the HTTP


### PR DESCRIPTION
The website build's diff-indent check fails on main since #860/#972 landed: the telemetry tutorial's `+`/`-` markers are one space short (markers must be an extra column before the code's full indentation), and the swarm doc's fragment has no flush context line, so expressive-code strips a marker column from every line.

Unblocks the `website` workflow on main; alchemy-run/alchemy#977 carries the same fix through its merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)