### PR TITLE
fix(website): group Prisma under Data in mobile tab switcher

### DIFF
--- a/website/src/components/starlight/MobileTabSwitcher.astro
+++ b/website/src/components/starlight/MobileTabSwitcher.astro
@@ -17,13 +17,13 @@ const current = activeTab(Astro.url.pathname);
 /**
  * Mobile taxonomy. The desktop More ▾ categories only classify the
  * overflow residents; here the whole tab list renders at once, so the
- * grouping is redesigned — e.g. PlanetScale and Neon belong under Data
- * next to Drizzle, not in the ungrouped primary run.
+ * grouping is redesigned — e.g. PlanetScale, Neon, and Prisma belong
+ * under Data next to SQL, not in the ungrouped primary run.
  */
 const MOBILE_GROUPS: { heading?: string; labels: string[] }[] = [
   { labels: ["Core", "CLI"] },
   { heading: "Clouds", labels: ["Cloudflare", "AWS"] },
-  { heading: "Data", labels: ["PlanetScale", "Neon", "Drizzle"] },
+  { heading: "Data", labels: ["PlanetScale", "Neon", "Prisma", "SQL"] },
   { heading: "Containers", labels: ["Docker", "Kubernetes"] },
   { heading: "Observability", labels: ["Axiom"] },
   { heading: "Source & CI", labels: ["GitHub"] },


### PR DESCRIPTION
Prisma was falling into the mobile switcher's leftover "More" bucket because the mobile taxonomy in `MobileTabSwitcher.astro` never named it. The Data group also still referenced the stale "Drizzle" label (that tab is now "SQL" in `docs-tabs.ts`), which sent the SQL tab to "More" too.

```diff
-  { heading: "Data", labels: ["PlanetScale", "Neon", "Drizzle"] },
+  { heading: "Data", labels: ["PlanetScale", "Neon", "Prisma", "SQL"] },
```

With every tab now covered by the taxonomy, the fallback "More" heading no longer renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018WmuQwDmJU7EhYSTCdoA9k

---
_Generated by [Claude Code](https://claude.ai/code/session_018WmuQwDmJU7EhYSTCdoA9k)_