### PR TITLE
feat(state): encrypt secrets in state by default (auto local key, KMS on S3)

### DIFF
--- a/packages/alchemy/src/AWS/StateStore/State.ts
+++ b/packages/alchemy/src/AWS/StateStore/State.ts
@@ -15,7 +15,8 @@ import {
   type PersistedState,
   type StateService,
 } from "../../State/State.ts";
-import { encodeState, reviveState } from "../../State/StateEncoding.ts";
+import { resolveSecretCodec } from "../../State/SecretCodec.ts";
+import { encodeState, makeStateReviver } from "../../State/StateEncoding.ts";
 import { recordStateStoreInit } from "../../Telemetry/Metrics.ts";
 import { AwsAuth } from "../AuthProvider.ts";
 import * as AwsCredentials from "../Credentials.ts";
@@ -165,6 +166,10 @@ export const makeS3State = (options: S3StateOptions = {}) =>
       ? `${options.prefix.replace(/\/+$/, "")}/`
       : "";
 
+    // Encrypts Redacted values at rest when ALCHEMY_PASSWORD is set.
+    const codec = yield* resolveSecretCodec;
+    const reviver = makeStateReviver(codec);
+
     const toError = (cause: unknown) =>
       new StateStoreError({
         message:
@@ -255,7 +260,7 @@ export const makeS3State = (options: S3StateOptions = {}) =>
             : Stream.mkString(Stream.decodeText(result.Body)).pipe(
                 Effect.flatMap((text) =>
                   Effect.try({
-                    try: () => JSON.parse(text, reviveState) as T,
+                    try: () => JSON.parse(text, reviver) as T,
                     catch: (cause) =>
                       new StateStoreError({
                         message: `Failed to parse state object '${key}'`,
@@ -272,7 +277,7 @@ export const makeS3State = (options: S3StateOptions = {}) =>
       s3.putObject({
         Bucket: bucket,
         Key: key,
-        Body: JSON.stringify(encodeState(value), null, 2),
+        Body: JSON.stringify(encodeState(value, codec), null, 2),
         ContentType: "application/json",
       });
 

--- a/packages/alchemy/src/AWS/StateStore/State.ts
+++ b/packages/alchemy/src/AWS/StateStore/State.ts
@@ -1,8 +1,11 @@
 import type { Credentials } from "@distilled.cloud/aws/Credentials";
 import type { Region } from "@distilled.cloud/aws/Region";
+import * as kms from "@distilled.cloud/aws/kms";
 import * as s3 from "@distilled.cloud/aws/s3";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Redacted from "effect/Redacted";
 import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
 import type { HttpClient } from "effect/unstable/http/HttpClient";
@@ -16,7 +19,12 @@ import {
   type PersistedState,
   type StateService,
 } from "../../State/State.ts";
-import { resolveSecretCodec } from "../../State/SecretCodec.ts";
+import {
+  makeSecretCodec,
+  makeSecretCodecFromKey,
+  resolveSecretPassword,
+  type SecretCodec,
+} from "../../State/SecretCodec.ts";
 import { encodeState, makeStateReviver } from "../../State/StateEncoding.ts";
 import { recordStateStoreInit } from "../../Telemetry/Metrics.ts";
 import { AwsAuth } from "../AuthProvider.ts";
@@ -64,7 +72,32 @@ export interface S3StateOptions {
    * @default `{ sseAlgorithm: "AES256" }`
    */
   encryption?: BucketEncryption;
+  /**
+   * How `Redacted` secret values are protected inside state objects
+   * (bucket-level SSE protects the objects at rest, but their JSON
+   * content is still readable by anyone with `s3:GetObject`).
+   *
+   * - `"kms"` (default): envelope encryption with an auto-managed KMS
+   *   key. On first use the store creates (or reuses) the
+   *   `alias/alchemy-state` KMS key, mints a data key, and stores the
+   *   KMS-wrapped data key at `{prefix}__state_key__.json` in the
+   *   bucket. Anyone who can deploy (`kms:Decrypt` on the key) can read
+   *   state — no key to manage or distribute.
+   * - `"off"`: secrets are persisted as plaintext
+   *   `{ "__redacted__": ... }` markers (the legacy behavior).
+   *
+   * Setting `ALCHEMY_PASSWORD` overrides both modes with password-based
+   * encryption — use it when readers can't reach KMS. Use one key source
+   * consistently per bucket: values encrypted under one key cannot be
+   * read with another.
+   *
+   * @default "kms"
+   */
+  secretEncryption?: "kms" | "off";
 }
+
+/** Alias of the auto-managed KMS key that wraps state data keys. */
+const STATE_KMS_ALIAS = "alias/alchemy-state";
 
 /** Context required by the distilled S3 operations. */
 type S3Deps = Credentials | HttpClient | Region;
@@ -167,18 +200,16 @@ export const makeS3State = (options: S3StateOptions = {}) =>
       ? `${options.prefix.replace(/\/+$/, "")}/`
       : "";
 
-    // Encrypts Redacted values at rest when ALCHEMY_PASSWORD is set.
-    const codec = yield* resolveSecretCodec;
-    const reviver = makeStateReviver(codec);
-
     const toError = (cause: unknown) =>
-      new StateStoreError({
-        message:
-          cause instanceof Error
-            ? cause.message
-            : `S3 state store error: ${String(cause)}`,
-        cause: cause instanceof Error ? cause : undefined,
-      });
+      cause instanceof StateStoreError
+        ? cause
+        : new StateStoreError({
+            message:
+              cause instanceof Error
+                ? cause.message
+                : `S3 state store error: ${String(cause)}`,
+            cause: cause instanceof Error ? cause : undefined,
+          });
 
     // Anything that touches AWS credentials must NOT run at layer
     // construction time. Resolving the environment (account/region),
@@ -196,6 +227,165 @@ export const makeS3State = (options: S3StateOptions = {}) =>
         return bucketName;
       }).pipe(Effect.provideContext(context), Effect.mapError(toError)),
     );
+
+    // Resolve the secret codec once, lazily (it may need the bucket for
+    // the wrapped data key, so it cannot run before `bucket`):
+    // ALCHEMY_PASSWORD → password codec; `secretEncryption: "off"` →
+    // plaintext markers; otherwise KMS envelope encryption (below).
+    const codecCached = yield* Effect.cached(
+      Effect.gen(function* () {
+        const password = yield* resolveSecretPassword;
+        if (Option.isSome(password)) {
+          return yield* Effect.sync(() => makeSecretCodec(password.value));
+        }
+        if (options.secretEncryption === "off") return undefined;
+        const bucketName = yield* bucket;
+        return yield* resolveKmsCodec(bucketName).pipe(
+          Effect.provideContext(context),
+          Effect.mapError(toError),
+        );
+      }),
+    );
+
+    /** S3 key of the KMS-wrapped data key, shared by every stack. */
+    const stateKeyObjectKey = `${prefix}__state_key__.json`;
+
+    interface WrappedStateKey {
+      keyId?: string;
+      ciphertext: string;
+    }
+
+    const readWrappedKey = (bucketName: string) =>
+      s3.getObject({ Bucket: bucketName, Key: stateKeyObjectKey }).pipe(
+        Effect.flatMap((result) =>
+          result.Body === undefined
+            ? Effect.succeed(undefined)
+            : Stream.mkString(Stream.decodeText(result.Body)).pipe(
+                Effect.map((text) => JSON.parse(text) as WrappedStateKey),
+              ),
+        ),
+        Effect.catchTag("NoSuchKey", () => Effect.succeed(undefined)),
+      );
+
+    const unwrapDataKey = (wrapped: WrappedStateKey) =>
+      kms
+        .decrypt({
+          CiphertextBlob: Buffer.from(wrapped.ciphertext, "base64"),
+        })
+        .pipe(
+          Effect.flatMap((result) => {
+            const plaintext = Redacted.isRedacted(result.Plaintext)
+              ? Redacted.value(result.Plaintext)
+              : result.Plaintext;
+            return plaintext === undefined
+              ? Effect.fail(
+                  new StateStoreError({
+                    message:
+                      "KMS Decrypt returned no plaintext for the state data key",
+                  }),
+                )
+              : Effect.sync(() => makeSecretCodecFromKey(plaintext));
+          }),
+        );
+
+    /** Resolve the KeyId behind `alias/alchemy-state`, creating key + alias on first use. */
+    const ensureKmsKey = Effect.gen(function* () {
+      const existing = yield* kms.describeKey({ KeyId: STATE_KMS_ALIAS }).pipe(
+        Effect.map((r) => r.KeyMetadata?.KeyId),
+        Effect.catchTag("NotFoundException", () => Effect.succeed(undefined)),
+      );
+      if (existing !== undefined) return existing;
+      const created = yield* kms.createKey({
+        Description: "Alchemy state store secret encryption key",
+      });
+      const keyId = created.KeyMetadata?.KeyId;
+      if (keyId === undefined) {
+        return yield* Effect.fail(
+          new StateStoreError({ message: "KMS CreateKey returned no KeyId" }),
+        );
+      }
+      return yield* kms
+        .createAlias({ AliasName: STATE_KMS_ALIAS, TargetKeyId: keyId })
+        .pipe(
+          Effect.map(() => keyId),
+          // Lost the alias-creation race: schedule our now-orphaned key
+          // for deletion and converge on the winner behind the alias.
+          Effect.catchTag("AlreadyExistsException", () =>
+            kms
+              .scheduleKeyDeletion({ KeyId: keyId, PendingWindowInDays: 7 })
+              .pipe(
+                Effect.ignore,
+                Effect.flatMap(() =>
+                  kms.describeKey({ KeyId: STATE_KMS_ALIAS }),
+                ),
+                Effect.flatMap((r) =>
+                  r.KeyMetadata?.KeyId === undefined
+                    ? Effect.fail(
+                        new StateStoreError({
+                          message: `KMS alias ${STATE_KMS_ALIAS} exists but has no target key`,
+                        }),
+                      )
+                    : Effect.succeed(r.KeyMetadata.KeyId),
+                ),
+              ),
+          ),
+        );
+    });
+
+    /**
+     * Envelope encryption: a 32-byte data key is minted via KMS
+     * `GenerateDataKey` against the auto-managed `alias/alchemy-state`
+     * key and persisted (KMS-wrapped) in the bucket. Every reader with
+     * `kms:Decrypt` unwraps the same data key, so teammates and CI work
+     * with nothing to distribute. The conditional `IfNoneMatch: "*"` put
+     * plus the read-back make concurrent first-time minters converge on
+     * a single key.
+     */
+    const resolveKmsCodec = (bucketName: string) =>
+      Effect.gen(function* () {
+        const existing = yield* readWrappedKey(bucketName);
+        if (existing !== undefined) return yield* unwrapDataKey(existing);
+        const keyId = yield* ensureKmsKey;
+        const dataKey = yield* kms.generateDataKey({
+          KeyId: keyId,
+          KeySpec: "AES_256",
+        });
+        if (dataKey.CiphertextBlob === undefined) {
+          return yield* Effect.fail(
+            new StateStoreError({
+              message: "KMS GenerateDataKey returned no CiphertextBlob",
+            }),
+          );
+        }
+        const wrapped: WrappedStateKey = {
+          keyId: dataKey.KeyId,
+          ciphertext: Buffer.from(dataKey.CiphertextBlob).toString("base64"),
+        };
+        yield* s3
+          .putObject({
+            Bucket: bucketName,
+            Key: stateKeyObjectKey,
+            Body: JSON.stringify(wrapped, null, 2),
+            ContentType: "application/json",
+            IfNoneMatch: "*",
+          })
+          .pipe(
+            Effect.catchTag(
+              ["PreconditionFailed", "ConditionalRequestConflict"],
+              () => Effect.void,
+            ),
+          );
+        // Converge on whatever is stored — covers losing the put race.
+        const stored = yield* readWrappedKey(bucketName);
+        if (stored === undefined) {
+          return yield* Effect.fail(
+            new StateStoreError({
+              message: `State data key object '${stateKeyObjectKey}' missing after write`,
+            }),
+          );
+        }
+        return yield* unwrapDataKey(stored);
+      });
 
     // Close over the captured context so every StateService method is
     // self-contained (`R = never`), matching the StateService contract.
@@ -254,29 +444,33 @@ export const makeS3State = (options: S3StateOptions = {}) =>
 
     /** Read and revive a JSON object; `undefined` when the key is absent. */
     const readJson = <T>(bucket: string, key: string) =>
-      s3.getObject({ Bucket: bucket, Key: key }).pipe(
-        Effect.flatMap((result) =>
-          result.Body === undefined
-            ? Effect.succeed(undefined)
-            : Stream.mkString(Stream.decodeText(result.Body)).pipe(
-                Effect.flatMap((text) =>
-                  Effect.try({
-                    try: () => JSON.parse(text, reviver) as T,
-                    catch: stateDecodeError(key),
-                  }),
+      Effect.flatMap(codecCached, (codec: SecretCodec | undefined) =>
+        s3.getObject({ Bucket: bucket, Key: key }).pipe(
+          Effect.flatMap((result) =>
+            result.Body === undefined
+              ? Effect.succeed(undefined)
+              : Stream.mkString(Stream.decodeText(result.Body)).pipe(
+                  Effect.flatMap((text) =>
+                    Effect.try({
+                      try: () => JSON.parse(text, makeStateReviver(codec)) as T,
+                      catch: stateDecodeError(key),
+                    }),
+                  ),
                 ),
-              ),
+          ),
+          Effect.catchTag("NoSuchKey", () => Effect.succeed(undefined)),
         ),
-        Effect.catchTag("NoSuchKey", () => Effect.succeed(undefined)),
       );
 
     const writeJson = (bucket: string, key: string, value: unknown) =>
-      s3.putObject({
-        Bucket: bucket,
-        Key: key,
-        Body: JSON.stringify(encodeState(value, codec), null, 2),
-        ContentType: "application/json",
-      });
+      Effect.flatMap(codecCached, (codec: SecretCodec | undefined) =>
+        s3.putObject({
+          Bucket: bucket,
+          Key: key,
+          Body: JSON.stringify(encodeState(value, codec), null, 2),
+          ContentType: "application/json",
+        }),
+      );
 
     /** Delete every object under `keyPrefix` in batches. Idempotent. */
     const deleteAll = (bucket: string, keyPrefix: string) =>

--- a/packages/alchemy/src/AWS/StateStore/State.ts
+++ b/packages/alchemy/src/AWS/StateStore/State.ts
@@ -11,6 +11,7 @@ import { decodeFqn, encodeFqn } from "../../FQN.ts";
 import { STATE_STORE_VERSION } from "../../State/HttpStateApi.ts";
 import {
   State,
+  stateDecodeError,
   StateStoreError,
   type PersistedState,
   type StateService,
@@ -261,11 +262,7 @@ export const makeS3State = (options: S3StateOptions = {}) =>
                 Effect.flatMap((text) =>
                   Effect.try({
                     try: () => JSON.parse(text, reviver) as T,
-                    catch: (cause) =>
-                      new StateStoreError({
-                        message: `Failed to parse state object '${key}'`,
-                        cause: cause instanceof Error ? cause : undefined,
-                      }),
+                    catch: stateDecodeError(key),
                   }),
                 ),
               ),

--- a/packages/alchemy/src/Cli/commands/state.ts
+++ b/packages/alchemy/src/Cli/commands/state.ts
@@ -10,6 +10,7 @@ import { AuthProviders } from "../../Auth/AuthProvider.ts";
 import { withProfileOverride } from "../../Auth/Profile.ts";
 import { Stage } from "../../Stage.ts";
 import * as State from "../../State/index.ts";
+import { resolveSecretCodec } from "../../State/SecretCodec.ts";
 import { encodeState } from "../../State/StateEncoding.ts";
 import * as Clank from "../../Util/Clank.ts";
 import { loadConfigProvider } from "../../Util/ConfigProvider.ts";
@@ -197,8 +198,13 @@ const getCommand = Command.make(
           }
           // encodeState produces a JSON-friendly view: redacted secrets
           // are unwrapped into `{ __redacted__: ... }`, Resources are
-          // flattened, etc. Same shape the store persists.
-          yield* Console.log(JSON.stringify(encodeState(value), null, 2));
+          // flattened, etc. Same shape the store persists. When
+          // ALCHEMY_PASSWORD is set, secrets print as encrypted
+          // `{ __secret__: ... }` envelopes instead of plaintext.
+          const codec = yield* resolveSecretCodec;
+          yield* Console.log(
+            JSON.stringify(encodeState(value, codec), null, 2),
+          );
         }),
       );
     }),

--- a/packages/alchemy/src/Cli/commands/state.ts
+++ b/packages/alchemy/src/Cli/commands/state.ts
@@ -10,7 +10,8 @@ import { AuthProviders } from "../../Auth/AuthProvider.ts";
 import { withProfileOverride } from "../../Auth/Profile.ts";
 import { Stage } from "../../Stage.ts";
 import * as State from "../../State/index.ts";
-import { resolveSecretCodec } from "../../State/SecretCodec.ts";
+import { resolveLocalSecretCodec } from "../../State/SecretCodec.ts";
+import { PlatformServices } from "../../Util/PlatformServices.ts";
 import { encodeState } from "../../State/StateEncoding.ts";
 import * as Clank from "../../Util/Clank.ts";
 import { loadConfigProvider } from "../../Util/ConfigProvider.ts";
@@ -196,12 +197,14 @@ const getCommand = Command.make(
             yield* Console.log(`(not found: ${stackName}/${stageName}/${fqn})`);
             return;
           }
-          // encodeState produces a JSON-friendly view: redacted secrets
-          // are unwrapped into `{ __redacted__: ... }`, Resources are
-          // flattened, etc. Same shape the store persists. When
-          // ALCHEMY_PASSWORD is set, secrets print as encrypted
-          // `{ __secret__: ... }` envelopes instead of plaintext.
-          const codec = yield* resolveSecretCodec;
+          // encodeState produces a JSON-friendly view: Resources are
+          // flattened, Durations tagged, etc. Secrets print as encrypted
+          // `{ __secret__: ... }` envelopes (ALCHEMY_PASSWORD or the
+          // local state key), never as plaintext.
+          const codec = yield* resolveLocalSecretCodec.pipe(
+            Effect.provide(PlatformServices),
+            Effect.orDie,
+          );
           yield* Console.log(
             JSON.stringify(encodeState(value, codec), null, 2),
           );

--- a/packages/alchemy/src/State/HttpStateStore.ts
+++ b/packages/alchemy/src/State/HttpStateStore.ts
@@ -8,6 +8,7 @@ import { StateApi } from "./HttpStateApi.ts";
 
 import type { ReplacedResourceState, ResourceState } from "./ResourceState.ts";
 import {
+  stateDecodeError,
   StateStoreError,
   type PersistedState,
   type StateService,
@@ -94,16 +95,10 @@ export const makeHttpStateStore = ({
     // Encrypts Redacted values before they leave the process when
     // ALCHEMY_PASSWORD is set; decrypts them on read.
     const codec = yield* resolveSecretCodec;
-    const tryRevive = <T>(s: unknown) =>
+    const tryRevive = <T>(s: unknown, what: string) =>
       Effect.try({
         try: () => reviveStateRecursive(s, codec) as T,
-        catch: (cause) =>
-          new StateStoreError({
-            message: `Failed to decode state: ${
-              cause instanceof Error ? cause.message : String(cause)
-            }`,
-            cause: cause instanceof Error ? cause : undefined,
-          }),
+        catch: stateDecodeError(what),
       });
 
     const service: StateService = {
@@ -135,14 +130,14 @@ export const makeHttpStateStore = ({
             Effect.flatMap((s) =>
               s == null
                 ? Effect.succeed(undefined)
-                : tryRevive<ResourceState>(s),
+                : tryRevive<ResourceState>(s, request.fqn),
             ),
             mapStateStoreError,
           ),
       getReplacedResources: (request) =>
         state.getReplacedResources({ params: request }).pipe(
           Effect.flatMap((resources) =>
-            tryRevive<ReplacedResourceState[]>(resources),
+            tryRevive<ReplacedResourceState[]>(resources, "replaced resources"),
           ),
           mapStateStoreError,
         ),
@@ -192,7 +187,9 @@ export const makeHttpStateStore = ({
           })
           .pipe(
             Effect.flatMap((s) =>
-              s == null ? Effect.succeed(undefined) : tryRevive(s),
+              s == null
+                ? Effect.succeed(undefined)
+                : tryRevive(s, "__stack_output__"),
             ),
             mapStateStoreError,
           ),

--- a/packages/alchemy/src/State/HttpStateStore.ts
+++ b/packages/alchemy/src/State/HttpStateStore.ts
@@ -12,6 +12,7 @@ import {
   type PersistedState,
   type StateService,
 } from "./State.ts";
+import { resolveSecretCodec } from "./SecretCodec.ts";
 import { encodeState, reviveStateRecursive } from "./StateEncoding.ts";
 
 /**
@@ -90,6 +91,21 @@ export const makeHttpStateStore = ({
     });
     const state = apiClient.state;
 
+    // Encrypts Redacted values before they leave the process when
+    // ALCHEMY_PASSWORD is set; decrypts them on read.
+    const codec = yield* resolveSecretCodec;
+    const tryRevive = <T>(s: unknown) =>
+      Effect.try({
+        try: () => reviveStateRecursive(s, codec) as T,
+        catch: (cause) =>
+          new StateStoreError({
+            message: `Failed to decode state: ${
+              cause instanceof Error ? cause.message : String(cause)
+            }`,
+            cause: cause instanceof Error ? cause : undefined,
+          }),
+      });
+
     const service: StateService = {
       id,
       getVersion: () =>
@@ -116,19 +132,17 @@ export const makeHttpStateStore = ({
             },
           })
           .pipe(
-            Effect.map((s) =>
+            Effect.flatMap((s) =>
               s == null
-                ? undefined
-                : (reviveStateRecursive(s) as ResourceState),
+                ? Effect.succeed(undefined)
+                : tryRevive<ResourceState>(s),
             ),
             mapStateStoreError,
           ),
       getReplacedResources: (request) =>
         state.getReplacedResources({ params: request }).pipe(
-          Effect.map((resources) =>
-            resources.map(
-              (s) => reviveStateRecursive(s) as ReplacedResourceState,
-            ),
+          Effect.flatMap((resources) =>
+            tryRevive<ReplacedResourceState[]>(resources),
           ),
           mapStateStoreError,
         ),
@@ -145,7 +159,7 @@ export const makeHttpStateStore = ({
               stage: request.stage,
               fqn: encodeURIComponent(request.fqn),
             },
-            payload: encodeState(request.value),
+            payload: encodeState(request.value, codec),
           })
           .pipe(
             // Server echoes the stored value, but the client already
@@ -177,8 +191,8 @@ export const makeHttpStateStore = ({
             params: { stack: request.stack, stage: request.stage },
           })
           .pipe(
-            Effect.map((s) =>
-              s == null ? undefined : reviveStateRecursive(s),
+            Effect.flatMap((s) =>
+              s == null ? Effect.succeed(undefined) : tryRevive(s),
             ),
             mapStateStoreError,
           ),
@@ -186,7 +200,7 @@ export const makeHttpStateStore = ({
         state
           .setStackOutput({
             params: { stack: request.stack, stage: request.stage },
-            payload: encodeState(request.value as any),
+            payload: encodeState(request.value as any, codec),
           })
           .pipe(
             Effect.map(() => request.value),

--- a/packages/alchemy/src/State/LocalState.ts
+++ b/packages/alchemy/src/State/LocalState.ts
@@ -7,7 +7,12 @@ import { decodeFqn, encodeFqn } from "../FQN.ts";
 import { recordStateStoreInit } from "../Telemetry/Metrics.ts";
 import { STATE_STORE_VERSION } from "./HttpStateApi.ts";
 import { resolveSecretCodec } from "./SecretCodec.ts";
-import { State, StateStoreError, type StateService } from "./State.ts";
+import {
+  State,
+  stateDecodeError,
+  StateStoreError,
+  type StateService,
+} from "./State.ts";
 import { encodeState, makeStateReviver } from "./StateEncoding.ts";
 
 export const localState = () =>
@@ -100,13 +105,7 @@ export const makeLocalState = () =>
           contents.trim().length === 0
             ? undefined
             : JSON.parse(contents, reviver),
-        catch: (cause) =>
-          new StateStoreError({
-            message: `Failed to decode state '${what}': ${
-              cause instanceof Error ? cause.message : String(cause)
-            }`,
-            cause: cause instanceof Error ? cause : undefined,
-          }),
+        catch: stateDecodeError(what),
       });
 
     const created = new Set<string>();

--- a/packages/alchemy/src/State/LocalState.ts
+++ b/packages/alchemy/src/State/LocalState.ts
@@ -6,8 +6,9 @@ import type { PlatformError } from "effect/PlatformError";
 import { decodeFqn, encodeFqn } from "../FQN.ts";
 import { recordStateStoreInit } from "../Telemetry/Metrics.ts";
 import { STATE_STORE_VERSION } from "./HttpStateApi.ts";
+import { resolveSecretCodec } from "./SecretCodec.ts";
 import { State, StateStoreError, type StateService } from "./State.ts";
-import { encodeState, reviveState } from "./StateEncoding.ts";
+import { encodeState, makeStateReviver } from "./StateEncoding.ts";
 
 export const localState = () =>
   Layer.effect(
@@ -30,6 +31,9 @@ export const makeLocalState = () =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
+    // Encrypts Redacted values at rest when ALCHEMY_PASSWORD is set.
+    const codec = yield* resolveSecretCodec;
+    const reviver = makeStateReviver(codec);
     const dotAlchemy = path.join(process.cwd(), ".alchemy");
     const stateDir = path.join(dotAlchemy, "state");
 
@@ -41,7 +45,9 @@ export const makeLocalState = () =>
         }),
       );
 
-    const recover = <T>(effect: Effect.Effect<T, PlatformError, never>) =>
+    const recover = <T>(
+      effect: Effect.Effect<T, PlatformError | StateStoreError, never>,
+    ) =>
       effect.pipe(
         Effect.catchTag("PlatformError", (e) =>
           e.reason._tag === "NotFound" ? Effect.void : fail(e),
@@ -86,10 +92,22 @@ export const makeLocalState = () =>
     // linger from a write that was interrupted before this atomic-write change
     // (or any non-atomic external writer); treat it as "absent" rather than
     // throwing a JSON parse error that would abort the whole operation.
-    const parseState = (contents: string) =>
-      contents.trim().length === 0
-        ? undefined
-        : JSON.parse(contents, reviveState);
+    // Decode failures (malformed JSON, missing/wrong ALCHEMY_PASSWORD for
+    // `__secret__` envelopes) surface as StateStoreError, not defects.
+    const parseState = (contents: string, what: string) =>
+      Effect.try({
+        try: () =>
+          contents.trim().length === 0
+            ? undefined
+            : JSON.parse(contents, reviver),
+        catch: (cause) =>
+          new StateStoreError({
+            message: `Failed to decode state '${what}': ${
+              cause instanceof Error ? cause.message : String(cause)
+            }`,
+            cause: cause instanceof Error ? cause : undefined,
+          }),
+      });
 
     const created = new Set<string>();
 
@@ -115,7 +133,7 @@ export const makeLocalState = () =>
         ),
       get: (request) =>
         fs.readFile(resource(request)).pipe(
-          Effect.map((file) => parseState(file.toString())),
+          Effect.flatMap((file) => parseState(file.toString(), request.fqn)),
           recover,
         ),
       getReplacedResources: Effect.fn(function* (request) {
@@ -134,7 +152,7 @@ export const makeLocalState = () =>
           Effect.flatMap(() =>
             writeAtomic(
               resource(request),
-              JSON.stringify(encodeState(request.value), null, 2),
+              JSON.stringify(encodeState(request.value, codec), null, 2),
             ),
           ),
           recover,
@@ -171,7 +189,9 @@ export const makeLocalState = () =>
         ),
       getOutput: (request) =>
         fs.readFile(outputFile(request)).pipe(
-          Effect.map((file) => parseState(file.toString())),
+          Effect.flatMap((file) =>
+            parseState(file.toString(), "__stack_output__"),
+          ),
           recover,
         ),
       setOutput: (request) =>
@@ -179,7 +199,7 @@ export const makeLocalState = () =>
           Effect.flatMap(() =>
             writeAtomic(
               outputFile(request),
-              JSON.stringify(encodeState(request.value as any), null, 2),
+              JSON.stringify(encodeState(request.value as any, codec), null, 2),
             ),
           ),
           recover,

--- a/packages/alchemy/src/State/LocalState.ts
+++ b/packages/alchemy/src/State/LocalState.ts
@@ -6,7 +6,7 @@ import type { PlatformError } from "effect/PlatformError";
 import { decodeFqn, encodeFqn } from "../FQN.ts";
 import { recordStateStoreInit } from "../Telemetry/Metrics.ts";
 import { STATE_STORE_VERSION } from "./HttpStateApi.ts";
-import { resolveSecretCodec } from "./SecretCodec.ts";
+import { resolveLocalSecretCodec } from "./SecretCodec.ts";
 import {
   State,
   stateDecodeError,
@@ -36,9 +36,23 @@ export const makeLocalState = () =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
-    // Encrypts Redacted values at rest when ALCHEMY_PASSWORD is set.
-    const codec = yield* resolveSecretCodec;
-    const reviver = makeStateReviver(codec);
+    const context = yield* Effect.context<FileSystem.FileSystem | Path.Path>();
+    // Local state is encrypted by default: ALCHEMY_PASSWORD when set,
+    // otherwise the auto-generated `~/.alchemy/state.key`. Resolved
+    // lazily (cached) so store construction stays infallible and no
+    // key file is created until state is actually touched.
+    const getCodec = yield* Effect.cached(
+      resolveLocalSecretCodec.pipe(
+        Effect.mapError(
+          (e) =>
+            new StateStoreError({
+              message: `Failed to initialize the state secret key: ${e.message}`,
+              cause: e,
+            }),
+        ),
+        Effect.provideContext(context),
+      ),
+    );
     const dotAlchemy = path.join(process.cwd(), ".alchemy");
     const stateDir = path.join(dotAlchemy, "state");
 
@@ -97,16 +111,20 @@ export const makeLocalState = () =>
     // linger from a write that was interrupted before this atomic-write change
     // (or any non-atomic external writer); treat it as "absent" rather than
     // throwing a JSON parse error that would abort the whole operation.
-    // Decode failures (malformed JSON, missing/wrong ALCHEMY_PASSWORD for
-    // `__secret__` envelopes) surface as StateStoreError, not defects.
+    // Decode failures (malformed JSON, wrong state key for `__secret__`
+    // envelopes) surface as StateStoreError, not defects.
     const parseState = (contents: string, what: string) =>
-      Effect.try({
-        try: () =>
-          contents.trim().length === 0
-            ? undefined
-            : JSON.parse(contents, reviver),
-        catch: stateDecodeError(what),
-      });
+      getCodec.pipe(
+        Effect.flatMap((codec) =>
+          Effect.try({
+            try: () =>
+              contents.trim().length === 0
+                ? undefined
+                : JSON.parse(contents, makeStateReviver(codec)),
+            catch: stateDecodeError(what),
+          }),
+        ),
+      );
 
     const created = new Set<string>();
 
@@ -147,8 +165,8 @@ export const makeLocalState = () =>
         )).filter((r) => r?.status === "replaced");
       }),
       set: (request) =>
-        ensure(stageDir(request)).pipe(
-          Effect.flatMap(() =>
+        Effect.all([getCodec, ensure(stageDir(request))]).pipe(
+          Effect.flatMap(([codec]) =>
             writeAtomic(
               resource(request),
               JSON.stringify(encodeState(request.value, codec), null, 2),
@@ -194,8 +212,8 @@ export const makeLocalState = () =>
           recover,
         ),
       setOutput: (request) =>
-        ensure(stageDir(request)).pipe(
-          Effect.flatMap(() =>
+        Effect.all([getCodec, ensure(stageDir(request))]).pipe(
+          Effect.flatMap(([codec]) =>
             writeAtomic(
               outputFile(request),
               JSON.stringify(encodeState(request.value as any, codec), null, 2),

--- a/packages/alchemy/src/State/SecretCodec.ts
+++ b/packages/alchemy/src/State/SecretCodec.ts
@@ -1,8 +1,12 @@
 import * as NodeCrypto from "node:crypto";
 import * as Config from "effect/Config";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
+import * as Path from "effect/Path";
+import type { PlatformError } from "effect/PlatformError";
 import * as Redacted from "effect/Redacted";
+import { rootDir } from "../Auth/Profile.ts";
 
 /**
  * Encrypts / decrypts the payload of a `Redacted<T>` value before it is
@@ -12,7 +16,10 @@ import * as Redacted from "effect/Redacted";
  * values in the clear.
  *
  * Both operations are synchronous so they can run inside `JSON.stringify`
- * / `JSON.parse` reviver callbacks on the state encode/decode path.
+ * / `JSON.parse` reviver callbacks on the state encode/decode path. Key
+ * material is therefore obtained *before* codec construction — from
+ * `ALCHEMY_PASSWORD`, the local `~/.alchemy/state.key` file, or a KMS
+ * data key — and closed over.
  */
 export interface SecretCodec {
   readonly encrypt: (plaintext: string) => string;
@@ -36,16 +43,16 @@ const IV_BYTES = 12;
 const TAG_BYTES = 16;
 
 /**
- * Build a {@link SecretCodec} from a password.
- *
- * Key derivation is scrypt (N=16384, one-shot at store init); payloads are
+ * Build a {@link SecretCodec} from raw 32-byte key material. Payloads are
  * AES-256-GCM with a random per-value IV, framed as
  * `v1:base64(iv || authTag || ciphertext)`.
  */
-export const makeSecretCodec = (
-  password: Redacted.Redacted<string>,
-): SecretCodec => {
-  const key = NodeCrypto.scryptSync(Redacted.value(password), KDF_SALT, 32);
+export const makeSecretCodecFromKey = (key: Uint8Array): SecretCodec => {
+  if (key.length !== 32) {
+    throw new Error(
+      `State secret key must be 32 bytes (got ${key.length}). The key material may be corrupted.`,
+    );
+  }
   return {
     encrypt: (plaintext) => {
       const iv = NodeCrypto.randomBytes(IV_BYTES);
@@ -81,7 +88,7 @@ export const makeSecretCodec = (
         ]).toString("utf8");
       } catch (cause) {
         throw new Error(
-          "Failed to decrypt a secret in state. ALCHEMY_PASSWORD does not match the password that wrote this state.",
+          "Failed to decrypt a secret in state: the configured key does not match the one that wrote this state (check ALCHEMY_PASSWORD, or the state key it was written with).",
           { cause },
         );
       }
@@ -90,18 +97,102 @@ export const makeSecretCodec = (
 };
 
 /**
- * Resolve the ambient state-secret codec from the `ALCHEMY_PASSWORD`
- * config value. Returns `undefined` when no password is configured, in
- * which case secrets are persisted with the plaintext
- * `{ "__redacted__": ... }` marker (the historical behavior).
+ * Build a {@link SecretCodec} from a password: scrypt (N=16384, one-shot
+ * at store init) derives the AES-256 key.
+ */
+export const makeSecretCodec = (
+  password: Redacted.Redacted<string>,
+): SecretCodec =>
+  makeSecretCodecFromKey(
+    NodeCrypto.scryptSync(Redacted.value(password), KDF_SALT, 32),
+  );
+
+/**
+ * Read the optional `ALCHEMY_PASSWORD` override. When set, it takes
+ * precedence over every automatic key source (local key file, KMS) so
+ * teams and CI can pin one shared key across machines and stores.
+ */
+export const resolveSecretPassword: Effect.Effect<
+  Option.Option<Redacted.Redacted<string>>
+> = Config.option(Config.redacted("ALCHEMY_PASSWORD")).pipe(Effect.orDie);
+
+/**
+ * Resolve the state-secret codec from the `ALCHEMY_PASSWORD` config value
+ * alone. Returns `undefined` when no password is configured. Used by
+ * stores whose state is shared across machines (HTTP) where an automatic
+ * machine-local key would break other readers.
  */
 export const resolveSecretCodec: Effect.Effect<SecretCodec | undefined> =
-  Config.option(Config.redacted("ALCHEMY_PASSWORD")).pipe(
+  resolveSecretPassword.pipe(
     Effect.flatMap(
       Option.match({
         onNone: () => Effect.succeed(undefined),
         onSome: (password) => Effect.sync(() => makeSecretCodec(password)),
       }),
     ),
-    Effect.orDie,
   );
+
+/** File name of the auto-generated local state key under `~/.alchemy`. */
+export const localStateKeyFileName = "state.key";
+
+/**
+ * Resolve the codec for machine-local state (the `.alchemy/state/` file
+ * store): `ALCHEMY_PASSWORD` when set, otherwise an auto-generated
+ * 32-byte key persisted at `~/.alchemy/state.key` (created on first use,
+ * mode 0600). Always yields a codec — local state is encrypted by
+ * default with zero key management.
+ *
+ * Concurrent first-time creation is safe: the key file is created with
+ * the exclusive `wx` flag, and every process then reads back whatever
+ * won the race, so all writers converge on one key.
+ */
+export const resolveLocalSecretCodec: Effect.Effect<
+  SecretCodec,
+  PlatformError,
+  FileSystem.FileSystem | Path.Path
+> = Effect.gen(function* () {
+  const password = yield* resolveSecretPassword;
+  if (Option.isSome(password)) {
+    return yield* Effect.sync(() => makeSecretCodec(password.value));
+  }
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const keyFile = path.join(rootDir, localStateKeyFileName);
+
+  const readKey = fs
+    .readFileString(keyFile)
+    .pipe(
+      Effect.map((hex) =>
+        makeSecretCodecFromKey(Buffer.from(hex.trim(), "hex")),
+      ),
+    );
+
+  return yield* readKey.pipe(
+    Effect.catchTag("PlatformError", (e) =>
+      e.reason._tag !== "NotFound"
+        ? Effect.fail(e)
+        : Effect.gen(function* () {
+            const fresh = yield* Effect.sync(() =>
+              NodeCrypto.randomBytes(32).toString("hex"),
+            );
+            yield* fs.makeDirectory(rootDir, { recursive: true });
+            // `wx` fails if the file already exists, so a concurrent
+            // creator can never be overwritten; the read-back below
+            // converges every process on the winning key.
+            yield* fs
+              .writeFileString(keyFile, `${fresh}\n`, {
+                flag: "wx",
+                mode: 0o600,
+              })
+              .pipe(
+                Effect.catchTag("PlatformError", (we) =>
+                  we.reason._tag === "AlreadyExists"
+                    ? Effect.void
+                    : Effect.fail(we),
+                ),
+              );
+            return yield* readKey;
+          }),
+    ),
+  );
+});

--- a/packages/alchemy/src/State/SecretCodec.ts
+++ b/packages/alchemy/src/State/SecretCodec.ts
@@ -1,0 +1,107 @@
+import * as NodeCrypto from "node:crypto";
+import * as Config from "effect/Config";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Redacted from "effect/Redacted";
+
+/**
+ * Encrypts / decrypts the payload of a `Redacted<T>` value before it is
+ * persisted by a state store. When a codec is active, secrets are written
+ * as `{ "__secret__": "<ciphertext>" }` envelopes instead of the plaintext
+ * `{ "__redacted__": ... }` marker, so state files never contain secret
+ * values in the clear.
+ *
+ * Both operations are synchronous so they can run inside `JSON.stringify`
+ * / `JSON.parse` reviver callbacks on the state encode/decode path.
+ */
+export interface SecretCodec {
+  readonly encrypt: (plaintext: string) => string;
+  readonly decrypt: (payload: string) => string;
+}
+
+/** Ciphertext format version prefix. */
+const VERSION_PREFIX = "v1:";
+
+/**
+ * Fixed KDF context string. The password is expected to be a high-entropy
+ * secret (not a memorable human password), so a per-store random salt —
+ * which would need its own persistence and rotation story — is not used.
+ */
+const KDF_SALT = "alchemy-state-secret:v1";
+
+/** AES-GCM recommended IV length. */
+const IV_BYTES = 12;
+
+/** AES-GCM auth tag length. */
+const TAG_BYTES = 16;
+
+/**
+ * Build a {@link SecretCodec} from a password.
+ *
+ * Key derivation is scrypt (N=16384, one-shot at store init); payloads are
+ * AES-256-GCM with a random per-value IV, framed as
+ * `v1:base64(iv || authTag || ciphertext)`.
+ */
+export const makeSecretCodec = (
+  password: Redacted.Redacted<string>,
+): SecretCodec => {
+  const key = NodeCrypto.scryptSync(Redacted.value(password), KDF_SALT, 32);
+  return {
+    encrypt: (plaintext) => {
+      const iv = NodeCrypto.randomBytes(IV_BYTES);
+      const cipher = NodeCrypto.createCipheriv("aes-256-gcm", key, iv);
+      const ciphertext = Buffer.concat([
+        cipher.update(plaintext, "utf8"),
+        cipher.final(),
+      ]);
+      return (
+        VERSION_PREFIX +
+        Buffer.concat([iv, cipher.getAuthTag(), ciphertext]).toString("base64")
+      );
+    },
+    decrypt: (payload) => {
+      if (!payload.startsWith(VERSION_PREFIX)) {
+        throw new Error(
+          `Unrecognized encrypted state secret format (expected "${VERSION_PREFIX}" prefix). The state may have been written by a newer version of alchemy.`,
+        );
+      }
+      const framed = Buffer.from(
+        payload.slice(VERSION_PREFIX.length),
+        "base64",
+      );
+      const iv = framed.subarray(0, IV_BYTES);
+      const tag = framed.subarray(IV_BYTES, IV_BYTES + TAG_BYTES);
+      const ciphertext = framed.subarray(IV_BYTES + TAG_BYTES);
+      const decipher = NodeCrypto.createDecipheriv("aes-256-gcm", key, iv);
+      decipher.setAuthTag(tag);
+      try {
+        return Buffer.concat([
+          decipher.update(ciphertext),
+          decipher.final(),
+        ]).toString("utf8");
+      } catch (cause) {
+        throw new Error(
+          "Failed to decrypt a secret in state. ALCHEMY_PASSWORD does not match the password that wrote this state.",
+          { cause },
+        );
+      }
+    },
+  };
+};
+
+/**
+ * Resolve the ambient state-secret codec from the `ALCHEMY_PASSWORD`
+ * config value. Returns `undefined` when no password is configured, in
+ * which case secrets are persisted with the plaintext
+ * `{ "__redacted__": ... }` marker (the historical behavior).
+ */
+export const resolveSecretCodec: Effect.Effect<SecretCodec | undefined> =
+  Config.option(Config.redacted("ALCHEMY_PASSWORD")).pipe(
+    Effect.flatMap(
+      Option.match({
+        onNone: () => Effect.succeed(undefined),
+        onSome: (password) => Effect.sync(() => makeSecretCodec(password)),
+      }),
+    ),
+    Effect.orDie,
+  );

--- a/packages/alchemy/src/State/State.ts
+++ b/packages/alchemy/src/State/State.ts
@@ -23,6 +23,20 @@ export class StateStoreError extends Data.TaggedError("StateStoreError")<{
   cause?: Error;
 }> {}
 
+/**
+ * Wrap a state decode failure (malformed JSON, missing/wrong
+ * `ALCHEMY_PASSWORD` for encrypted `__secret__` envelopes) in a
+ * {@link StateStoreError}. Shared by every client-side store so decode
+ * failures carry the same message shape everywhere.
+ */
+export const stateDecodeError = (what: string) => (cause: unknown) =>
+  new StateStoreError({
+    message: `Failed to decode state '${what}': ${
+      cause instanceof Error ? cause.message : String(cause)
+    }`,
+    cause: cause instanceof Error ? cause : undefined,
+  });
+
 export class State extends Context.Service<
   State,
   Effect.Effect<StateService>

--- a/packages/alchemy/src/State/StateEncoding.ts
+++ b/packages/alchemy/src/State/StateEncoding.ts
@@ -1,6 +1,9 @@
 import * as Duration from "effect/Duration";
 import * as Redacted from "effect/Redacted";
 import { isResource } from "../Resource.ts";
+// Type-only: SecretCodec.ts pulls in node:crypto, which must not be
+// bundled into workerd consumers of this module (Cloudflare StateStore DO).
+import type { SecretCodec } from "./SecretCodec.ts";
 
 /**
  * JSON marker used to tag a `Redacted<T>` value when writing state.
@@ -8,6 +11,14 @@ import { isResource } from "../Resource.ts";
  * the `Redacted` wrapper on read.
  */
 export const REDACTED_MARKER = "__redacted__";
+
+/**
+ * JSON marker used to tag an *encrypted* `Redacted<T>` value when a
+ * {@link SecretCodec} is active (i.e. `ALCHEMY_PASSWORD` is set). The
+ * payload is the codec's ciphertext of the JSON-encoded inner value, so
+ * secrets never reach the state store in the clear.
+ */
+export const SECRET_MARKER = "__secret__";
 
 /**
  * JSON marker used to tag a `Duration` value when writing state.
@@ -48,12 +59,14 @@ const decodeDuration = (encoded: unknown): Duration.Duration | undefined => {
  *
  * - `Redacted<T>` values are wrapped as `{ [REDACTED_MARKER]: <inner> }`
  *   so the actual string is persisted rather than the `<redacted>`
- *   placeholder produced by the default `toJSON`.
+ *   placeholder produced by the default `toJSON` — unless a `codec` is
+ *   provided, in which case they are wrapped as
+ *   `{ [SECRET_MARKER]: <ciphertext> }` and never persisted in plaintext.
  * - `Resource` instances are flattened to `{ id, type, props, attr }`
  *   so persisted state matches the schema used by the loader.
  * - Plain objects and arrays are walked structurally.
  */
-export const encodeState = (value: unknown): unknown => {
+export const encodeState = (value: unknown, codec?: SecretCodec): unknown => {
   if (
     value === null ||
     value === undefined ||
@@ -63,9 +76,17 @@ export const encodeState = (value: unknown): unknown => {
   )
     return value;
   if (Redacted.isRedacted(value)) {
-    return {
-      [REDACTED_MARKER]: encodeState(Redacted.value(value)),
-    };
+    // The inner value is encoded WITHOUT the codec: the whole envelope is
+    // encrypted, so nested markers inside it stay plain.
+    return codec
+      ? {
+          [SECRET_MARKER]: codec.encrypt(
+            JSON.stringify(encodeState(Redacted.value(value))),
+          ),
+        }
+      : {
+          [REDACTED_MARKER]: encodeState(Redacted.value(value)),
+        };
   }
   if (Duration.isDuration(value)) {
     // `JSON.stringify(Duration.seconds(N))` already invokes Duration.toJSON,
@@ -81,15 +102,15 @@ export const encodeState = (value: unknown): unknown => {
     return {
       id: value.LogicalId,
       type: value.Type,
-      props: encodeState(value.Props),
-      attr: encodeState(value.Attributes),
+      props: encodeState(value.Props, codec),
+      attr: encodeState(value.Attributes, codec),
     };
   }
-  if (Array.isArray(value)) return value.map(encodeState);
+  if (Array.isArray(value)) return value.map((v) => encodeState(v, codec));
   if (typeof value === "object") {
     const result: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(value)) {
-      result[k] = encodeState(v);
+      result[k] = encodeState(v, codec);
     }
     return result;
   }
@@ -97,22 +118,60 @@ export const encodeState = (value: unknown): unknown => {
 };
 
 /**
- * JSON reviver that rebuilds `Redacted<T>` values that were written
- * through {@link encodeState}. Intended for use with `JSON.parse`.
+ * Rebuild a `Redacted<T>` from a `{ [SECRET_MARKER]: <ciphertext> }`
+ * envelope. Throws with an actionable message when no codec is available
+ * (state was encrypted but `ALCHEMY_PASSWORD` is not set) — the state
+ * stores surface this as a `StateStoreError`.
  */
-export const reviveState = (_key: string, value: unknown): unknown => {
-  if (value !== null && typeof value === "object" && !Array.isArray(value)) {
-    const obj = value as Record<string, unknown>;
-    if (REDACTED_MARKER in obj) {
-      return Redacted.make(obj[REDACTED_MARKER]);
-    }
-    if (DURATION_MARKER in obj) {
-      const decoded = decodeDuration(obj[DURATION_MARKER]);
-      if (decoded !== undefined) return decoded;
-    }
+const decodeSecret = (
+  payload: unknown,
+  codec: SecretCodec | undefined,
+): Redacted.Redacted<unknown> => {
+  if (typeof payload !== "string") {
+    throw new Error(
+      `Malformed "${SECRET_MARKER}" envelope in state: expected a string ciphertext.`,
+    );
   }
-  return value;
+  if (codec === undefined) {
+    throw new Error(
+      `State contains encrypted secrets ("${SECRET_MARKER}") but no ALCHEMY_PASSWORD is set. Set ALCHEMY_PASSWORD to the password that wrote this state.`,
+    );
+  }
+  return Redacted.make(
+    reviveStateRecursive(JSON.parse(codec.decrypt(payload))),
+  );
 };
+
+/**
+ * Build a JSON reviver that rebuilds `Redacted<T>` values that were
+ * written through {@link encodeState}. Intended for use with `JSON.parse`.
+ * Pass the ambient {@link SecretCodec} (if any) so `{ __secret__: ... }`
+ * envelopes written under `ALCHEMY_PASSWORD` decrypt on read.
+ */
+export const makeStateReviver =
+  (codec?: SecretCodec) =>
+  (_key: string, value: unknown): unknown => {
+    if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+      const obj = value as Record<string, unknown>;
+      if (REDACTED_MARKER in obj) {
+        return Redacted.make(obj[REDACTED_MARKER]);
+      }
+      if (SECRET_MARKER in obj) {
+        return decodeSecret(obj[SECRET_MARKER], codec);
+      }
+      if (DURATION_MARKER in obj) {
+        const decoded = decodeDuration(obj[DURATION_MARKER]);
+        if (decoded !== undefined) return decoded;
+      }
+    }
+    return value;
+  };
+
+/**
+ * JSON reviver without a secret codec — plaintext `__redacted__` markers
+ * revive; encrypted `__secret__` envelopes throw (missing password).
+ */
+export const reviveState = makeStateReviver();
 
 /**
  * Recursively walk an already-decoded value and rebuild `Redacted<T>`
@@ -121,13 +180,20 @@ export const reviveState = (_key: string, value: unknown): unknown => {
  * value rather than a JSON string (e.g. the HTTP state-store client,
  * which receives values pre-parsed by `HttpApiClient`).
  */
-export const reviveStateRecursive = (value: unknown): unknown => {
+export const reviveStateRecursive = (
+  value: unknown,
+  codec?: SecretCodec,
+): unknown => {
   if (value === null || typeof value !== "object") return value;
-  if (Array.isArray(value)) return value.map(reviveStateRecursive);
+  if (Array.isArray(value))
+    return value.map((v) => reviveStateRecursive(v, codec));
   const obj = value as Record<string, unknown>;
   const keys = Object.keys(obj);
   if (keys.length === 1 && keys[0] === REDACTED_MARKER) {
     return Redacted.make(reviveStateRecursive(obj[REDACTED_MARKER]));
+  }
+  if (keys.length === 1 && keys[0] === SECRET_MARKER) {
+    return decodeSecret(obj[SECRET_MARKER], codec);
   }
   if (keys.length === 1 && keys[0] === DURATION_MARKER) {
     const decoded = decodeDuration(obj[DURATION_MARKER]);
@@ -135,7 +201,7 @@ export const reviveStateRecursive = (value: unknown): unknown => {
   }
   const result: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(obj)) {
-    result[k] = reviveStateRecursive(v);
+    result[k] = reviveStateRecursive(v, codec);
   }
   return result;
 };

--- a/packages/alchemy/src/State/StateEncoding.ts
+++ b/packages/alchemy/src/State/StateEncoding.ts
@@ -134,7 +134,7 @@ const decodeSecret = (
   }
   if (codec === undefined) {
     throw new Error(
-      `State contains encrypted secrets ("${SECRET_MARKER}") but no ALCHEMY_PASSWORD is set. Set ALCHEMY_PASSWORD to the password that wrote this state.`,
+      `State contains encrypted secrets ("${SECRET_MARKER}") but no decryption key is available. Set ALCHEMY_PASSWORD to the key that wrote this state.`,
     );
   }
   return Redacted.make(

--- a/packages/alchemy/src/State/index.ts
+++ b/packages/alchemy/src/State/index.ts
@@ -3,6 +3,7 @@ export * from "./HttpStateStore.ts";
 export * from "./InMemoryState.ts";
 export * from "./LocalState.ts";
 export * from "./ResourceState.ts";
+export * from "./SecretCodec.ts";
 export * from "./State.ts";
 export * from "./ActionState.ts";
 export * from "./StateEncoding.ts";

--- a/packages/alchemy/test/AWS/StateStore/State.test.ts
+++ b/packages/alchemy/test/AWS/StateStore/State.test.ts
@@ -6,6 +6,8 @@ import * as Test from "@/Test/Alchemy";
 import * as s3 from "@distilled.cloud/aws/s3";
 import { expect } from "alchemy-test";
 import * as Effect from "effect/Effect";
+import * as Redacted from "effect/Redacted";
+import * as Stream from "effect/Stream";
 
 const { test } = Test.make({ providers: AWS.providers() });
 
@@ -242,6 +244,66 @@ test.provider(
           stage,
         });
         expect(result.map((r) => r.fqn)).toEqual(["Replaced"]);
+      }).pipe(Effect.ensuring(cleanStage(state, stage)));
+    }),
+  { timeout: 120_000 },
+);
+
+test.provider(
+  "secrets are KMS-encrypted at rest and revive on read",
+  () =>
+    Effect.gen(function* () {
+      const state = yield* makeS3State({ prefix: "test-state" });
+      const stage = "kms-secrets";
+
+      yield* state.deleteStack({ stack: STACK, stage });
+
+      yield* Effect.gen(function* () {
+        const value = {
+          ...resource("SecretResource", { url: "https://example.com" }),
+          props: { apiKey: Redacted.make("sk-live-kms-secret") },
+        } as ResourceState;
+        yield* state.set({ stack: STACK, stage, fqn: value.fqn, value });
+
+        const { accountId, region } = yield* AWS.AWSEnvironment.current;
+        const bucket = createStateBucketName(accountId, region);
+        const readRaw = (key: string) =>
+          s3
+            .getObject({ Bucket: bucket, Key: key })
+            .pipe(
+              Effect.flatMap((r) =>
+                r.Body === undefined
+                  ? Effect.succeed("")
+                  : Stream.mkString(Stream.decodeText(r.Body)),
+              ),
+            );
+
+        // The raw S3 object holds an encrypted envelope, never plaintext.
+        const raw = yield* readRaw(
+          `test-state/${STACK}/${stage}/SecretResource.json`,
+        );
+        expect(raw).toContain("__secret__");
+        expect(raw).not.toContain("sk-live-kms-secret");
+        // Non-secret state stays introspectable.
+        expect(raw).toContain("https://example.com");
+
+        // The KMS-wrapped data key is persisted at the prefix root.
+        const wrapped = yield* readRaw("test-state/__state_key__.json");
+        expect(wrapped).toContain("ciphertext");
+        expect(wrapped).not.toContain("sk-live-kms-secret");
+
+        // Reading through the store unwraps the data key via KMS and
+        // decrypts back into a Redacted.
+        const revived = (yield* state.get({
+          stack: STACK,
+          stage,
+          fqn: "SecretResource",
+        })) as ResourceState | undefined;
+        expect(
+          Redacted.value(
+            (revived?.props as { apiKey: Redacted.Redacted<string> }).apiKey,
+          ),
+        ).toBe("sk-live-kms-secret");
       }).pipe(Effect.ensuring(cleanStage(state, stage)));
     }),
   { timeout: 120_000 },

--- a/packages/alchemy/test/State/StateEncoding.test.ts
+++ b/packages/alchemy/test/State/StateEncoding.test.ts
@@ -1,0 +1,181 @@
+import { makeLocalState } from "@/State/LocalState.ts";
+import type { ResourceState } from "@/State/ResourceState.ts";
+import { makeSecretCodec, resolveSecretCodec } from "@/State/SecretCodec.ts";
+import {
+  encodeState,
+  makeStateReviver,
+  reviveState,
+  reviveStateRecursive,
+  REDACTED_MARKER,
+  SECRET_MARKER,
+} from "@/State/StateEncoding.ts";
+import { PlatformServices } from "@/Util/PlatformServices.ts";
+import { describe, expect, it } from "alchemy-test";
+import * as ConfigProvider from "effect/ConfigProvider";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+import * as Redacted from "effect/Redacted";
+
+const PASSWORD = Redacted.make("correct horse battery staple");
+const codec = makeSecretCodec(PASSWORD);
+
+const sampleState = {
+  props: {
+    name: "my-worker",
+    apiKey: Redacted.make("sk-live-super-secret"),
+    nested: { tokens: [Redacted.make("t-1"), Redacted.make("t-2")] },
+  },
+  attr: { url: "https://example.com" },
+};
+
+describe("StateEncoding secrets", () => {
+  it("round-trips Redacted values without a codec (legacy plaintext marker)", () => {
+    const json = JSON.stringify(encodeState(sampleState));
+    expect(json).toContain(REDACTED_MARKER);
+    expect(json).toContain("sk-live-super-secret");
+    const revived = JSON.parse(json, reviveState);
+    expect(Redacted.value(revived.props.apiKey)).toBe("sk-live-super-secret");
+    expect(Redacted.value(revived.props.nested.tokens[1])).toBe("t-2");
+  });
+
+  it("encrypts Redacted values with a codec — plaintext never in the output", () => {
+    const json = JSON.stringify(encodeState(sampleState, codec));
+    expect(json).toContain(SECRET_MARKER);
+    expect(json).not.toContain(REDACTED_MARKER);
+    expect(json).not.toContain("sk-live-super-secret");
+    expect(json).not.toContain("t-1");
+    // Non-secret values stay introspectable.
+    expect(json).toContain("my-worker");
+    expect(json).toContain("https://example.com");
+
+    const revived = JSON.parse(json, makeStateReviver(codec));
+    expect(Redacted.value(revived.props.apiKey)).toBe("sk-live-super-secret");
+    expect(Redacted.value(revived.props.nested.tokens[0])).toBe("t-1");
+  });
+
+  it("reviveStateRecursive decrypts __secret__ envelopes", () => {
+    const encoded = encodeState(sampleState, codec);
+    // Simulate the HTTP store: value arrives pre-parsed, not as a JSON string.
+    const roundTripped = JSON.parse(JSON.stringify(encoded));
+    const revived = reviveStateRecursive(roundTripped, codec) as any;
+    expect(Redacted.value(revived.props.apiKey)).toBe("sk-live-super-secret");
+  });
+
+  it("still revives legacy plaintext __redacted__ markers when a codec is active", () => {
+    const legacyJson = JSON.stringify(encodeState(sampleState));
+    const revived = JSON.parse(legacyJson, makeStateReviver(codec));
+    expect(Redacted.value(revived.props.apiKey)).toBe("sk-live-super-secret");
+  });
+
+  it("fails with an actionable error when encrypted state is read without a password", () => {
+    const json = JSON.stringify(encodeState(sampleState, codec));
+    expect(() => JSON.parse(json, reviveState)).toThrow(/ALCHEMY_PASSWORD/);
+  });
+
+  it("fails with an actionable error on a wrong password", () => {
+    const json = JSON.stringify(encodeState(sampleState, codec));
+    const wrong = makeSecretCodec(Redacted.make("not the password"));
+    expect(() => JSON.parse(json, makeStateReviver(wrong))).toThrow(
+      /does not match/,
+    );
+  });
+
+  it.effect(
+    "resolveSecretCodec is undefined when ALCHEMY_PASSWORD is unset",
+    () =>
+      Effect.gen(function* () {
+        const resolved = yield* resolveSecretCodec;
+        expect(resolved).toBeUndefined();
+      }).pipe(
+        Effect.provide(
+          ConfigProvider.layer(ConfigProvider.fromEnv({ env: {} })),
+        ),
+      ),
+  );
+
+  it.effect(
+    "resolveSecretCodec builds a working codec from ALCHEMY_PASSWORD",
+    () =>
+      Effect.gen(function* () {
+        const resolved = yield* resolveSecretCodec;
+        expect(resolved).toBeDefined();
+        const ciphertext = resolved!.encrypt("hello");
+        expect(ciphertext).not.toContain("hello");
+        // Interoperates with a codec built directly from the same password.
+        expect(codec.decrypt(ciphertext)).toBe("hello");
+      }).pipe(
+        Effect.provide(
+          ConfigProvider.layer(
+            ConfigProvider.fromEnv({
+              env: { ALCHEMY_PASSWORD: Redacted.value(PASSWORD) },
+            }),
+          ),
+        ),
+      ),
+  );
+
+  it.effect(
+    "LocalState writes encrypted secrets to disk and revives them on read",
+    () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const state = yield* makeLocalState();
+        const stack = "state-encoding-secret-codec-test";
+        const key = { stack, stage: "test", fqn: "worker" };
+        const value: ResourceState = {
+          kind: "resource",
+          resourceType: "Test.Resource",
+          namespace: undefined,
+          fqn: "worker",
+          logicalId: "worker",
+          instanceId: "i-1",
+          providerVersion: 1,
+          status: "created",
+          downstream: [],
+          bindings: [],
+          props: { apiKey: Redacted.make("sk-live-super-secret") },
+          attr: { url: "https://example.com" },
+        };
+        yield* state.set({ ...key, value });
+
+        // The raw file on disk must not contain the plaintext secret.
+        const file = path.join(
+          process.cwd(),
+          ".alchemy",
+          "state",
+          stack,
+          "test",
+          "worker.json",
+        );
+        const raw = yield* fs.readFileString(file);
+        expect(raw).toContain(SECRET_MARKER);
+        expect(raw).not.toContain("sk-live-super-secret");
+        // Non-secret state stays introspectable.
+        expect(raw).toContain("https://example.com");
+
+        // Reading through the store decrypts back into a Redacted.
+        const revived = (yield* state.get(key)) as ResourceState;
+        expect(
+          Redacted.value(
+            (revived.props as { apiKey: Redacted.Redacted<string> }).apiKey,
+          ),
+        ).toBe("sk-live-super-secret");
+
+        yield* state.deleteStack({ stack });
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            ConfigProvider.layer(
+              ConfigProvider.fromEnv({
+                env: { ALCHEMY_PASSWORD: Redacted.value(PASSWORD) },
+              }),
+            ),
+            PlatformServices,
+          ),
+        ),
+      ),
+  );
+});

--- a/packages/alchemy/test/State/StateEncoding.test.ts
+++ b/packages/alchemy/test/State/StateEncoding.test.ts
@@ -178,4 +178,86 @@ describe("StateEncoding secrets", () => {
         ),
       ),
   );
+
+  it.effect(
+    "migrates legacy unencrypted local state: reads plaintext markers, re-writes encrypted",
+    () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const stack = "state-encoding-migration-test";
+        const key = { stack, stage: "test", fqn: "worker" };
+        const file = path.join(
+          process.cwd(),
+          ".alchemy",
+          "state",
+          stack,
+          "test",
+          "worker.json",
+        );
+        const value: ResourceState = {
+          kind: "resource",
+          resourceType: "Test.Resource",
+          namespace: undefined,
+          fqn: "worker",
+          logicalId: "worker",
+          instanceId: "i-1",
+          providerVersion: 1,
+          status: "created",
+          downstream: [],
+          bindings: [],
+          props: { apiKey: Redacted.make("sk-live-super-secret") },
+          attr: { url: "https://example.com" },
+        };
+
+        // 1. The old world: a store built WITHOUT a password persists the
+        //    plaintext `__redacted__` marker — the exact on-disk format
+        //    every pre-ALCHEMY_PASSWORD deployment left behind.
+        const legacyStore = yield* makeLocalState().pipe(
+          Effect.provide(
+            ConfigProvider.layer(ConfigProvider.fromEnv({ env: {} })),
+          ),
+        );
+        yield* legacyStore.set({ ...key, value });
+        const legacyRaw = yield* fs.readFileString(file);
+        expect(legacyRaw).toContain(REDACTED_MARKER);
+        expect(legacyRaw).toContain("sk-live-super-secret");
+
+        // 2. The user sets ALCHEMY_PASSWORD: the legacy plaintext state
+        //    must still read (backwards compatibility).
+        const store = yield* makeLocalState().pipe(
+          Effect.provide(
+            ConfigProvider.layer(
+              ConfigProvider.fromEnv({
+                env: { ALCHEMY_PASSWORD: Redacted.value(PASSWORD) },
+              }),
+            ),
+          ),
+        );
+        const revived = (yield* store.get(key)) as ResourceState;
+        expect(
+          Redacted.value(
+            (revived.props as { apiKey: Redacted.Redacted<string> }).apiKey,
+          ),
+        ).toBe("sk-live-super-secret");
+
+        // 3. The next write (what any subsequent deploy does) migrates the
+        //    file to the encrypted envelope.
+        yield* store.set({ ...key, value: revived });
+        const migratedRaw = yield* fs.readFileString(file);
+        expect(migratedRaw).toContain(SECRET_MARKER);
+        expect(migratedRaw).not.toContain(REDACTED_MARKER);
+        expect(migratedRaw).not.toContain("sk-live-super-secret");
+
+        // 4. The migrated state round-trips.
+        const migrated = (yield* store.get(key)) as ResourceState;
+        expect(
+          Redacted.value(
+            (migrated.props as { apiKey: Redacted.Redacted<string> }).apiKey,
+          ),
+        ).toBe("sk-live-super-secret");
+
+        yield* store.deleteStack({ stack });
+      }).pipe(Effect.provide(PlatformServices)),
+  );
 });

--- a/packages/alchemy/test/State/StateEncoding.test.ts
+++ b/packages/alchemy/test/State/StateEncoding.test.ts
@@ -1,6 +1,11 @@
+import { rootDir } from "@/Auth/Profile.ts";
 import { makeLocalState } from "@/State/LocalState.ts";
 import type { ResourceState } from "@/State/ResourceState.ts";
-import { makeSecretCodec, resolveSecretCodec } from "@/State/SecretCodec.ts";
+import {
+  localStateKeyFileName,
+  makeSecretCodec,
+  resolveSecretCodec,
+} from "@/State/SecretCodec.ts";
 import {
   encodeState,
   makeStateReviver,
@@ -210,15 +215,14 @@ describe("StateEncoding secrets", () => {
           attr: { url: "https://example.com" },
         };
 
-        // 1. The old world: a store built WITHOUT a password persists the
-        //    plaintext `__redacted__` marker — the exact on-disk format
-        //    every pre-ALCHEMY_PASSWORD deployment left behind.
-        const legacyStore = yield* makeLocalState().pipe(
-          Effect.provide(
-            ConfigProvider.layer(ConfigProvider.fromEnv({ env: {} })),
-          ),
+        // 1. The old world: hand-write the exact plaintext-marker JSON
+        //    every pre-encryption version of alchemy persisted (encodeState
+        //    without a codec is that legacy writer).
+        yield* fs.makeDirectory(path.dirname(file), { recursive: true });
+        yield* fs.writeFileString(
+          file,
+          JSON.stringify(encodeState(value), null, 2),
         );
-        yield* legacyStore.set({ ...key, value });
         const legacyRaw = yield* fs.readFileString(file);
         expect(legacyRaw).toContain(REDACTED_MARKER);
         expect(legacyRaw).toContain("sk-live-super-secret");
@@ -254,6 +258,65 @@ describe("StateEncoding secrets", () => {
         expect(
           Redacted.value(
             (migrated.props as { apiKey: Redacted.Redacted<string> }).apiKey,
+          ),
+        ).toBe("sk-live-super-secret");
+
+        yield* store.deleteStack({ stack });
+      }).pipe(Effect.provide(PlatformServices)),
+  );
+
+  it.effect(
+    "encrypts local state by default via the auto-generated ~/.alchemy/state.key",
+    () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const stack = "state-encoding-keyfile-default-test";
+        const key = { stack, stage: "test", fqn: "worker" };
+        const value: ResourceState = {
+          kind: "resource",
+          resourceType: "Test.Resource",
+          namespace: undefined,
+          fqn: "worker",
+          logicalId: "worker",
+          instanceId: "i-1",
+          providerVersion: 1,
+          status: "created",
+          downstream: [],
+          bindings: [],
+          props: { apiKey: Redacted.make("sk-live-super-secret") },
+          attr: { url: "https://example.com" },
+        };
+
+        // No ALCHEMY_PASSWORD anywhere in scope — the store must fall
+        // back to (and auto-create) the machine key.
+        const store = yield* makeLocalState().pipe(
+          Effect.provide(
+            ConfigProvider.layer(ConfigProvider.fromEnv({ env: {} })),
+          ),
+        );
+        yield* store.set({ ...key, value });
+
+        const keyFile = path.join(rootDir, localStateKeyFileName);
+        expect(yield* fs.exists(keyFile)).toBe(true);
+
+        const raw = yield* fs.readFileString(
+          path.join(
+            process.cwd(),
+            ".alchemy",
+            "state",
+            stack,
+            "test",
+            "worker.json",
+          ),
+        );
+        expect(raw).toContain(SECRET_MARKER);
+        expect(raw).not.toContain("sk-live-super-secret");
+
+        const revived = (yield* store.get(key)) as ResourceState;
+        expect(
+          Redacted.value(
+            (revived.props as { apiKey: Redacted.Redacted<string> }).apiKey,
           ),
         ).toBe("sk-live-super-secret");
 

--- a/website/src/content/docs/environments/secrets.mdx
+++ b/website/src/content/docs/environments/secrets.mdx
@@ -173,55 +173,72 @@ For the step-by-step "wire up `OPENAI_API_KEY` from `.env`" walk,
 see [Secrets & env on Cloudflare](/cloudflare/security/secrets-env) or
 [on AWS](/aws/security/secrets-env).
 
-## Encrypting secrets in state
+## Secrets in state are encrypted
 
 Every secret that flows through your stack — a `Config.redacted`
 value, a resource attribute like an API token's `value` — is also
 persisted to your state store, because Alchemy must remember the
 previous value to detect changes on the next deploy.
 
-By default the local state store (`.alchemy/state/`) writes secrets
-as plaintext markers:
-
-```json
-{ "apiKey": { "__redacted__": "sk-live-..." } }
-```
-
-Set `ALCHEMY_PASSWORD` to encrypt them at rest instead:
-
-```bash
-ALCHEMY_PASSWORD=$(openssl rand -base64 32) # save this somewhere safe
-```
-
-With the password set, every `Redacted` value is encrypted
-(AES-256-GCM, key derived with scrypt) before it is written:
+Secrets are encrypted (AES-256-GCM) before they are written:
 
 ```json
 { "apiKey": { "__secret__": "v1:kx4X0f..." } }
 ```
 
 Everything else in the state file stays plain JSON, so state remains
-introspectable — only the secret payloads are ciphertext.
+introspectable — only the secret payloads are ciphertext. There is no
+key for you to manage; each store has an automatic key source:
+
+- **Local state** (`.alchemy/state/`) uses an auto-generated key at
+  `~/.alchemy/state.key`, created on first use. Because the key lives
+  in your home directory, state inside the repo is unreadable on its
+  own — an agent (or an accidental commit) never sees a plaintext
+  secret.
+- **S3 state** (`AWS.state()`) uses KMS envelope encryption: on first
+  use the store creates (or reuses) the `alias/alchemy-state` KMS key,
+  mints a data key, and stores the KMS-wrapped data key in the bucket.
+  Anyone who can deploy (`kms:Decrypt`) can read state — teammates and
+  CI work with nothing to distribute. Opt out with
+  `AWS.state({ secretEncryption: "off" })`.
+- **The Cloudflare-hosted state store** (`Cloudflare.state()`)
+  encrypts every record server-side with its own generated key held in
+  the Secrets Store.
+
+### `ALCHEMY_PASSWORD`
+
+Set `ALCHEMY_PASSWORD` to override the automatic key with a shared
+password (scrypt-derived AES-256 key):
+
+```bash
+ALCHEMY_PASSWORD=$(openssl rand -base64 32) # save this somewhere safe
+```
+
+Use it when the automatic sources don't fit: a plain HTTP state store
+(which otherwise sends secrets in the request body and encrypts only
+server-side), sharing one local state tree across machines, or
+end-to-end encryption to the Cloudflare-hosted store so secrets leave
+your machine already encrypted.
 
 Behavior to know:
 
 - **Change detection still works.** Secrets are decrypted when state
   is read, so a changed secret value triggers an update exactly as
   before.
-- **The same password must be used for every deploy** of that state
-  (including CI). Reading encrypted state without the password (or
-  with the wrong one) fails with an explicit error.
 - **Existing plaintext state migrates automatically.** Old
-  `__redacted__` markers still read fine; each resource is
-  re-written encrypted the next time it is deployed.
-- **It applies to every client-side state store** — local,
-  S3 (`AWS.state()`), and HTTP. The Cloudflare-hosted state store
-  (`Cloudflare.state()`) additionally encrypts every record
-  server-side with its own generated key, whether or not
-  `ALCHEMY_PASSWORD` is set; setting it there gives you end-to-end
-  encryption where secrets leave your machine already encrypted.
-- `alchemy state get` prints `__secret__` envelopes (not plaintext)
-  when the password is set.
+  `__redacted__` markers still read fine; each resource is re-written
+  encrypted the next time it is deployed.
+- **Use one key source consistently per state store.** Values
+  encrypted under one key cannot be read with another — if you set
+  `ALCHEMY_PASSWORD`, set it everywhere that reads that state
+  (including CI). Reading with a missing or wrong key fails with an
+  explicit error, not silent corruption.
+- **Local state is machine-local.** Copying a repo's
+  `.alchemy/state/` to another machine leaves the secrets unreadable
+  there (the key stayed in `~/.alchemy/state.key`); redeploying
+  re-writes them. Use `ALCHEMY_PASSWORD` if you genuinely need to move
+  local state between machines.
+- `alchemy state get` prints `__secret__` envelopes, never plaintext.
 
 ## Where next
 

--- a/website/src/content/docs/environments/secrets.mdx
+++ b/website/src/content/docs/environments/secrets.mdx
@@ -173,6 +173,56 @@ For the step-by-step "wire up `OPENAI_API_KEY` from `.env`" walk,
 see [Secrets & env on Cloudflare](/cloudflare/security/secrets-env) or
 [on AWS](/aws/security/secrets-env).
 
+## Encrypting secrets in state
+
+Every secret that flows through your stack — a `Config.redacted`
+value, a resource attribute like an API token's `value` — is also
+persisted to your state store, because Alchemy must remember the
+previous value to detect changes on the next deploy.
+
+By default the local state store (`.alchemy/state/`) writes secrets
+as plaintext markers:
+
+```json
+{ "apiKey": { "__redacted__": "sk-live-..." } }
+```
+
+Set `ALCHEMY_PASSWORD` to encrypt them at rest instead:
+
+```bash
+ALCHEMY_PASSWORD=$(openssl rand -base64 32) # save this somewhere safe
+```
+
+With the password set, every `Redacted` value is encrypted
+(AES-256-GCM, key derived with scrypt) before it is written:
+
+```json
+{ "apiKey": { "__secret__": "v1:kx4X0f..." } }
+```
+
+Everything else in the state file stays plain JSON, so state remains
+introspectable — only the secret payloads are ciphertext.
+
+Behavior to know:
+
+- **Change detection still works.** Secrets are decrypted when state
+  is read, so a changed secret value triggers an update exactly as
+  before.
+- **The same password must be used for every deploy** of that state
+  (including CI). Reading encrypted state without the password (or
+  with the wrong one) fails with an explicit error.
+- **Existing plaintext state migrates automatically.** Old
+  `__redacted__` markers still read fine; each resource is
+  re-written encrypted the next time it is deployed.
+- **It applies to every client-side state store** — local,
+  S3 (`AWS.state()`), and HTTP. The Cloudflare-hosted state store
+  (`Cloudflare.state()`) additionally encrypts every record
+  server-side with its own generated key, whether or not
+  `ALCHEMY_PASSWORD` is set; setting it there gives you end-to-end
+  encryption where secrets leave your machine already encrypted.
+- `alchemy state get` prints `__secret__` envelopes (not plaintext)
+  when the password is set.
+
 ## Where next
 
 - [Local development](/environments/local-development) — `alchemy dev`: local code, real cloud resources.


### PR DESCRIPTION
State stores persist every `Redacted<T>` as a plaintext `{ "__redacted__": ... }` marker — the encrypted-at-rest behavior of v1's `alchemy.secret` was lost when `Alchemy.Secret` was replaced by `effect/Config` in beta.45. Secrets in state are now encrypted by default, with nothing for the user to manage:

```diff
- { "apiKey": { "__redacted__": "sk-live-..." } }
+ { "apiKey": { "__secret__": "v1:kx4X0f..." } }
```

Automatic key source per store (`ALCHEMY_PASSWORD` overrides all of them):

- **Local** (`.alchemy/state/`): auto-generated 32-byte key at `~/.alchemy/state.key` (created on first use, mode 0600, `wx`-exclusive so concurrent creators converge). Key lives outside the repo, so repo state alone never exposes a secret.
- **S3** (`AWS.state()`): KMS envelope encryption — first use creates/reuses the `alias/alchemy-state` KMS key, mints a data key, and stores the KMS-wrapped data key at `{prefix}__state_key__.json`. Anyone with `kms:Decrypt` (i.e. anyone who can deploy) reads state; teammates/CI need nothing distributed. Opt out with `secretEncryption: "off"`.
- **HTTP**: encrypts client-side only when `ALCHEMY_PASSWORD` is set (an automatic machine-local key would break other readers of a shared store). The Cloudflare-hosted store already encrypts every record server-side; the password adds end-to-end on top.

Mechanics:

- One codec implementation (`State/SecretCodec.ts`): AES-256-GCM, random per-value IV, `v1:` framing; password path derives the key via scrypt. Sync by design — it runs inside `JSON.parse`/`stringify` revivers, and lives in its own module so `node:crypto` never reaches workerd bundles (`StateEncoding` imports it type-only).
- Only `Redacted` payloads are ciphertext — the rest of the state JSON stays introspectable, and change detection is unaffected (secrets decrypt on read).
- Backwards compatible: legacy plaintext `__redacted__` markers still revive; the next write re-encrypts. Pinned by an explicit migration test (hand-written legacy file → read → re-write → assert encrypted).
- Missing/wrong key fails with an actionable `StateStoreError` (shared `stateDecodeError` helper across all client stores), never a defect or silent corruption.
- `alchemy state get` prints `__secret__` envelopes, never plaintext.

Tested: 11 hermetic encoding/keyfile/migration tests, plus a live S3 test verifying the real KMS flow end-to-end (key + alias creation, data-key mint, raw-object ciphertext assertion, revive) against the testing account.

Docs: rewritten "Secrets in state are encrypted" section on [environments/secrets](https://alchemy.run/environments/secrets/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
