### PR TITLE
feat(cloudflare): version.affinity sticky-session sugar for gradual deployments

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -383,6 +383,66 @@ export interface WorkerRouteConfig {
 }
 
 /**
+ * Version-affinity configuration — keeps each user on one version for the
+ * duration of a gradual rollout.
+ *
+ * Percentages route each request independently, so one user can bounce
+ * between versions mid-rollout. Cloudflare pins a request to a version
+ * deterministically when it carries a `Cloudflare-Workers-Version-Key`
+ * header: the key is hashed and assigned a version from the current
+ * percentages, so equal keys always land on the same version, and pinned
+ * users only move forward as percentages rise.
+ *
+ * Setting `affinity` provisions that header as infrastructure: a `rewrite`
+ * Transform Rule in the `http_request_late_transform` phase of every zone
+ * the Worker serves on (custom domains and zone routes), scoped to the
+ * Worker's hostnames, filling the header from the configured source. The
+ * rule is updated in place as the config changes and removed when
+ * `affinity` is removed or the Worker is destroyed; other rules in the
+ * zone's shared entrypoint are left untouched.
+ *
+ * Exactly one of {@link cookie}, {@link header}, or {@link key} may be
+ * set; {@link ip} combines with `cookie`/`header` as a fallback or stands
+ * alone as the sole source.
+ *
+ * Transform Rules only see **zone traffic** — the Worker must have a
+ * `domain` or `routes` (or, with `version.parent`, the parent must).
+ * A workers.dev-only Worker fails the deploy with
+ * `WorkerVersionConfigError`; on the bare workers.dev URL clients must
+ * send the header themselves.
+ */
+export interface WorkerVersionAffinity {
+  /**
+   * Pin by the value of this request cookie (e.g. a session id). Requests
+   * without the cookie fall back to {@link ip} when set, otherwise they
+   * route independently by percentage.
+   */
+  cookie?: string;
+  /**
+   * Pin by the value of this request header (e.g. a tenant or user id
+   * your edge already stamps, or a stable auth claim forwarded as a
+   * header). Requests without the header fall back to {@link ip} when
+   * set, otherwise they route independently by percentage.
+   */
+  header?: string;
+  /**
+   * Pin by client IP. On its own (`{ ip: true }`) every request is keyed
+   * by `ip.src`; combined with {@link cookie} or {@link header} it is the
+   * fallback for requests missing the primary source (e.g. sticky by
+   * session cookie, falling back to sticky IP before the cookie is set).
+   */
+  ip?: boolean;
+  /**
+   * Escape hatch: a raw [Rules-language](https://developers.cloudflare.com/ruleset-engine/rules-language/)
+   * expression that computes the version key — e.g. a JWT claim via API
+   * Shield's `http.request.jwt.claims`, or any composite of request
+   * fields. Applied to every request on the Worker's hostnames; cannot be
+   * combined with the other sources.
+   */
+  key?: string;
+}
+
+/**
  * Versioning configuration for a Worker deploy — controls Worker
  * [versions and gradual deployments](https://developers.cloudflare.com/workers/configuration/versions-and-deployments/).
  *
@@ -470,6 +530,27 @@ export interface WorkerVersionOptions {
    * 63 characters (a DNS label).
    */
   alias?: string;
+  /**
+   * Keep each user on one version for the duration of the rollout by
+   * pinning them to a stable request property — a session cookie, a
+   * header, the client IP, or a raw Rules-language expression:
+   *
+   * ```typescript
+   * version: {
+   *   traffic: 10,
+   *   // sticky by session cookie, falling back to sticky IP
+   *   affinity: { cookie: "session_id", ip: true },
+   * }
+   * ```
+   *
+   * Provisions a Transform Rule that fills the
+   * `Cloudflare-Workers-Version-Key` header on the zones the Worker
+   * serves on — the Worker (or, with {@link parent}, the parent) must
+   * have a `domain` or `routes`. With `parent` set, the rule lands on the
+   * parent's zones, pinning users across the canary split. See
+   * {@link WorkerVersionAffinity}.
+   */
+  affinity?: WorkerVersionAffinity;
   /**
    * Human-readable annotation attached to the uploaded version, shown in
    * the Cloudflare dashboard and `wrangler versions list`.
@@ -920,6 +1001,14 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
      * deployment.
      */
     deploymentId?: string | undefined;
+    /**
+     * The zone ids currently holding this resource's version-affinity
+     * Transform Rules (`version.affinity`) — the cleanup list consulted
+     * when affinity is removed or the resource is deleted. For a version
+     * worker these are the *parent's* zones. `undefined` when no affinity
+     * rules are deployed.
+     */
+    affinityZoneIds?: string[] | undefined;
     hash?: {
       assets: string | undefined;
       bundle: string | undefined;
@@ -1417,6 +1506,22 @@ export const isSelfUrl = (value: unknown): value is URLEffect =>
  * yield* Cloudflare.Worker("MyWorker", {
  *   main: "./src/worker.ts",
  *   version: { traffic: 25 },
+ * });
+ * ```
+ *
+ * @example Keep users on one version during the rollout
+ * ```typescript
+ * // Percentages route each request independently; affinity pins users by
+ * // filling the Cloudflare-Workers-Version-Key header on zone traffic —
+ * // here from the session cookie, falling back to the client IP. Requires
+ * // a `domain` or `routes` (with `parent`, the parent's).
+ * yield* Cloudflare.Worker("MyWorker", {
+ *   main: "./src/worker.ts",
+ *   domain: "api.example.com",
+ *   version: {
+ *     traffic: 25,
+ *     affinity: { cookie: "session_id", ip: true },
+ *   },
  * });
  * ```
  *

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -45,6 +45,7 @@ import {
   type ViteOptions,
   type WorkerProps,
   type WorkerRouteConfig,
+  type WorkerVersionAffinity,
 } from "./Worker.ts";
 import { getCacheBinding, getCronBindings } from "./WorkerAsyncBindings.ts";
 import type {
@@ -191,6 +192,188 @@ const validateTraffic = (traffic: number | undefined) =>
         }),
       )
     : Effect.void;
+
+/** The request header Cloudflare hashes to pin a request to a version. */
+const AFFINITY_HEADER = "Cloudflare-Workers-Version-Key";
+
+/**
+ * `version.affinity` normalized to a single key source plus the optional
+ * IP fallback.
+ *
+ * @internal exported for unit testing.
+ */
+export interface ResolvedVersionAffinity {
+  source:
+    | { kind: "cookie" | "header"; name: string }
+    | { kind: "ip" }
+    | { kind: "key"; expression: string };
+  ipFallback: boolean;
+}
+
+// Cookie / header names are interpolated into a double-quoted Rules-language
+// string literal — restrict them to the token characters real-world names
+// use so a name can never terminate the literal or smuggle expression text.
+const AFFINITY_NAME_PATTERN = /^[A-Za-z0-9_.-]+$/;
+
+/**
+ * Validate `version.affinity` and normalize it to its key source: exactly
+ * one of `cookie` / `header` / `key`, or `ip: true` alone; `ip` combines
+ * with `cookie` / `header` as the absent-source fallback.
+ *
+ * @internal exported for unit testing.
+ */
+export const resolveVersionAffinity = (
+  affinity: WorkerVersionAffinity,
+): Effect.Effect<ResolvedVersionAffinity, WorkerVersionConfigError> =>
+  Effect.gen(function* () {
+    const declared = [
+      ...(affinity.cookie !== undefined ? ["cookie"] : []),
+      ...(affinity.header !== undefined ? ["header"] : []),
+      ...(affinity.key !== undefined ? ["key"] : []),
+    ];
+    if (declared.length > 1) {
+      return yield* Effect.fail(
+        new WorkerVersionConfigError({
+          message: `version.affinity accepts exactly one key source, got ${declared.join(" and ")}. Combine sources with a raw \`key\` expression instead.`,
+        }),
+      );
+    }
+    if (declared.length === 0 && affinity.ip !== true) {
+      return yield* Effect.fail(
+        new WorkerVersionConfigError({
+          message:
+            "version.affinity requires a key source: set `cookie`, `header`, `key`, or `ip: true`.",
+        }),
+      );
+    }
+    if (affinity.key !== undefined && affinity.ip === true) {
+      return yield* Effect.fail(
+        new WorkerVersionConfigError({
+          message:
+            "version.affinity: `ip` is the fallback for an absent `cookie`/`header` — a raw `key` expression has no absence condition to fall back from. Fold `ip.src` into the expression instead.",
+        }),
+      );
+    }
+    for (const [prop, name] of [
+      ["cookie", affinity.cookie],
+      ["header", affinity.header],
+    ] as const) {
+      if (name !== undefined && !AFFINITY_NAME_PATTERN.test(name)) {
+        return yield* Effect.fail(
+          new WorkerVersionConfigError({
+            message: `version.affinity.${prop} '${name}' is not a valid ${prop} name: expected only letters, digits, '_', '.', and '-'.`,
+          }),
+        );
+      }
+    }
+    const source: ResolvedVersionAffinity["source"] =
+      affinity.cookie !== undefined
+        ? { kind: "cookie", name: affinity.cookie }
+        : affinity.header !== undefined
+          ? // Rules-language header map keys are lowercase.
+            { kind: "header", name: affinity.header.toLowerCase() }
+          : affinity.key !== undefined
+            ? { kind: "key", expression: affinity.key }
+            : { kind: "ip" };
+    return {
+      source,
+      ipFallback:
+        affinity.ip === true &&
+        (source.kind === "cookie" || source.kind === "header"),
+    };
+  });
+
+/** A hostname a Worker serves on within one zone. */
+interface AffinityZoneHost {
+  host: string;
+  /** `true` when `host` came from a route pattern containing `*`. */
+  wildcard: boolean;
+}
+
+/**
+ * The `http.host` clause scoping a zone's affinity rules to the Worker's
+ * own hostnames, so unrelated zone traffic — and other Workers' rollouts
+ * on the same zone — never get this Worker's version key.
+ *
+ * @internal exported for unit testing.
+ */
+export const affinityHostExpression = (
+  hosts: readonly AffinityZoneHost[],
+): string => {
+  const dedupe = (values: string[]) => [...new Set(values)].sort();
+  const exact = dedupe(hosts.filter((h) => !h.wildcard).map((h) => h.host));
+  const wild = dedupe(hosts.filter((h) => h.wildcard).map((h) => h.host));
+  const clauses = [
+    ...(exact.length === 1
+      ? [`http.host eq "${exact[0]}"`]
+      : exact.length > 1
+        ? [`http.host in {${exact.map((h) => `"${h}"`).join(" ")}}`]
+        : []),
+    ...wild.map((h) => `http.host wildcard "${h}"`),
+  ];
+  return clauses.length === 1 ? clauses[0] : `(${clauses.join(" or ")})`;
+};
+
+interface AffinityRuleSpec {
+  description: string;
+  expression: string;
+  /** Rules-language expression producing the header value. */
+  value: string;
+}
+
+const affinityRulePrefix = (scriptName: string) =>
+  `alchemy:worker:${scriptName}:affinity`;
+
+/**
+ * The transform rules pinning one zone's traffic: a primary rule filling
+ * the version-key header from the configured source, plus — for
+ * `cookie`/`header` sources with `ip: true` — a fallback rule keying
+ * requests that lack the source by client IP.
+ *
+ * @internal exported for unit testing.
+ */
+export const buildAffinityZoneRules = (
+  scriptName: string,
+  affinity: ResolvedVersionAffinity,
+  hosts: readonly AffinityZoneHost[],
+): AffinityRuleSpec[] => {
+  const prefix = affinityRulePrefix(scriptName);
+  const hostExpr = affinityHostExpression(hosts);
+  const { source } = affinity;
+  if (source.kind === "ip" || source.kind === "key") {
+    return [
+      {
+        description: `${prefix}:key`,
+        expression: hostExpr,
+        value: source.kind === "ip" ? "to_string(ip.src)" : source.expression,
+      },
+    ];
+  }
+  const field =
+    source.kind === "cookie"
+      ? `http.request.cookies["${source.name}"]`
+      : `http.request.headers["${source.name}"]`;
+  return [
+    {
+      description: `${prefix}:key`,
+      expression: `${hostExpr} and len(${field}) > 0`,
+      value: `${field}[0]`,
+    },
+    ...(affinity.ipFallback
+      ? [
+          {
+            // An absent cookie/header is a *missing* value in the Rules
+            // language, and every comparison on missing evaluates false —
+            // `len(field) == 0` can never match. `not (len(field) > 0)`
+            // is the complement that does: missing → false → `not` → true.
+            description: `${prefix}:ip`,
+            expression: `${hostExpr} and not (len(${field}) > 0)`,
+            value: "to_string(ip.src)",
+          },
+        ]
+      : []),
+  ];
+};
 
 /**
  * A Worker's `domain` configuration is invalid — a hostname appears in more
@@ -785,6 +968,7 @@ const resolveWorkerMetadataHash = ({
           parent: resolveVersionParentName(props.version),
           traffic: props.version.traffic,
           alias: props.version.alias,
+          affinity: props.version.affinity,
           message: props.version.message,
           tag: props.version.tag,
         }
@@ -1305,6 +1489,127 @@ export const LiveWorkerProvider = () =>
             rules: [...foreign, ...ourDesired] as PutZoneRedirectRules,
           });
         }
+      });
+
+      /**
+       * Converge the version-affinity transform rules (`version.affinity`)
+       * in each serving zone's `http_request_late_transform` phase
+       * entrypoint: `rewrite` rules that fill the
+       * `Cloudflare-Workers-Version-Key` header from the configured source,
+       * scoped to the Worker's hostnames in that zone. Rules are identified
+       * by an `alchemy:worker:<script>:affinity` description prefix; only
+       * our own rules are added/updated/removed — every other rule in the
+       * shared entrypoint passes through untouched. Zones that previously
+       * held our rules but no longer should (affinity removed, zone no
+       * longer served) are cleaned the same way. Returns the zone ids now
+       * holding rules, for persistence in `affinityZoneIds`.
+       */
+      const reconcileAffinityRules = Effect.fn(function* (params: {
+        scriptName: string;
+        /** `undefined` removes every rule (affinity removed / delete). */
+        desired:
+          | {
+              affinity: ResolvedVersionAffinity;
+              hostsByZone: ReadonlyMap<string, AffinityZoneHost[]>;
+            }
+          | undefined;
+        /** zone ids holding rules per previous state (for cleanup). */
+        previousZoneIds: readonly string[];
+      }) {
+        const prefix = affinityRulePrefix(params.scriptName);
+        const zoneIds = new Set([
+          ...(params.desired?.hostsByZone.keys() ?? []),
+          ...params.previousZoneIds,
+        ]);
+        for (const zoneId of zoneIds) {
+          const hosts = params.desired?.hostsByZone.get(zoneId);
+          const ourDesired =
+            params.desired !== undefined && hosts !== undefined
+              ? buildAffinityZoneRules(
+                  params.scriptName,
+                  params.desired.affinity,
+                  hosts,
+                )
+              : [];
+          const entrypoint = yield* rulesets
+            .getPhasForZone({
+              zoneId,
+              rulesetPhase: "http_request_late_transform",
+            })
+            .pipe(Effect.catch(() => Effect.succeed(undefined)));
+          const existingRules = entrypoint?.rules ?? [];
+          const isOurs = (rule: { description?: string | null }) =>
+            (rule.description ?? "").startsWith(prefix);
+          // The header-value expression of an existing rewrite rule, for
+          // convergence comparison. `headers` is an untyped wire record:
+          // `{ "<Header-Name>": { operation, expression | value } }`.
+          const existingValue = (rule: (typeof existingRules)[number]) => {
+            const headers =
+              "actionParameters" in rule
+                ? (
+                    rule.actionParameters as
+                      | { headers?: Record<string, unknown> | null }
+                      | null
+                      | undefined
+                  )?.headers
+                : undefined;
+            const header = headers?.[AFFINITY_HEADER] as
+              | { expression?: unknown }
+              | undefined;
+            return typeof header?.expression === "string"
+              ? header.expression
+              : undefined;
+          };
+          const ourExisting = existingRules.filter(isOurs);
+          const converged =
+            ourExisting.length === ourDesired.length &&
+            ourDesired.every((rule) =>
+              ourExisting.some(
+                (existing) =>
+                  existing.description === rule.description &&
+                  existing.expression === rule.expression &&
+                  existingValue(existing) === rule.value,
+              ),
+            );
+          if (converged) continue;
+          // Pass foreign rules through untouched (minus the read-only
+          // fields the PUT schema doesn't accept) and replace our own set.
+          const foreign = existingRules
+            .filter((rule) => !isOurs(rule))
+            .map((rule) => {
+              const {
+                lastUpdated: _lastUpdated,
+                version: _version,
+                ...rest
+              } = rule as Record<string, unknown> & {
+                lastUpdated?: string;
+                version?: string;
+              };
+              return rest;
+            });
+          yield* rulesets.putPhasForZone({
+            zoneId,
+            rulesetPhase: "http_request_late_transform",
+            rules: [
+              ...foreign,
+              ...ourDesired.map((rule) => ({
+                action: "rewrite" as const,
+                description: rule.description,
+                enabled: true,
+                expression: rule.expression,
+                actionParameters: {
+                  headers: {
+                    [AFFINITY_HEADER]: {
+                      operation: "set",
+                      expression: rule.value,
+                    },
+                  },
+                },
+              })),
+            ] as PutZoneRedirectRules,
+          });
+        }
+        return [...(params.desired?.hostsByZone.keys() ?? [])].sort();
       });
 
       type NormalizedWorkerRoute = {
@@ -2286,6 +2591,7 @@ export const LiveWorkerProvider = () =>
         news: WorkerProps,
         bindings: ResourceBinding<Worker["Binding"]>[],
         session: ScopedPlanStatusSession,
+        output: Worker["Attributes"] | undefined,
       ) {
         const { accountId } = yield* yield* CloudflareEnvironment;
         const version = news.version!;
@@ -2417,6 +2723,69 @@ export const LiveWorkerProvider = () =>
             message: version.message,
           });
         }
+        // Version-affinity transform rules (`version.affinity`): a canary
+        // rides the *parent's* zone traffic, so the rules land on the
+        // parent's zones — observed custom-domain attachments plus, when
+        // `parent` was passed as a Worker resource, its recorded routes.
+        const previousAffinityZoneIds = output?.affinityZoneIds ?? [];
+        let affinityZoneIds: string[] | undefined;
+        if (version.affinity !== undefined || previousAffinityZoneIds.length) {
+          const resolvedAffinity =
+            version.affinity !== undefined
+              ? yield* resolveVersionAffinity(version.affinity)
+              : undefined;
+          let hostsByZone: Map<string, AffinityZoneHost[]> | undefined;
+          if (resolvedAffinity !== undefined) {
+            hostsByZone = new Map();
+            const addHost = (zoneId: string, host: AffinityZoneHost) => {
+              const hosts = hostsByZone!.get(zoneId) ?? [];
+              hosts.push(host);
+              hostsByZone!.set(zoneId, hosts);
+            };
+            // A `version.parent` passed as a Worker resource resolves to
+            // the parent's Attributes at reconcile time (see
+            // resolveVersionParentName) — its recorded routes and domain
+            // tell us the zones the parent serves on.
+            const parentAttrs =
+              typeof version.parent === "object" && version.parent !== null
+                ? (version.parent as unknown as Partial<Worker["Attributes"]>)
+                : undefined;
+            const redirectHosts = new Set(parentAttrs?.domain?.redirects ?? []);
+            const attached = yield* workers
+              .listDomains({ accountId, service: parentName })
+              .pipe(Effect.map((r) => r.result ?? []));
+            for (const d of attached) {
+              if (!d.hostname || !d.zoneId || redirectHosts.has(d.hostname)) {
+                continue;
+              }
+              addHost(d.zoneId, { host: d.hostname, wildcard: false });
+            }
+            for (const route of parentAttrs?.routes ?? []) {
+              const host = route.pattern.split("/")[0];
+              if (!host || host.includes('"')) continue;
+              addHost(route.zoneId, { host, wildcard: host.includes("*") });
+            }
+            if (hostsByZone.size === 0) {
+              return yield* Effect.fail(
+                new WorkerVersionConfigError({
+                  message:
+                    `version.affinity pins users via a zone Transform Rule setting the ${AFFINITY_HEADER} header, which only sees zone traffic — the parent '${parentName}' has no custom domains (or recorded zone routes) to place the rule on. ` +
+                    `Give the parent a \`domain\` or zone \`routes\`, or pass the parent as a Worker resource so its routes are visible here.`,
+                }),
+              );
+            }
+            yield* session.note("Reconciling version-affinity rules ...");
+          }
+          const placed = yield* reconcileAffinityRules({
+            scriptName: parentName,
+            desired:
+              resolvedAffinity !== undefined && hostsByZone !== undefined
+                ? { affinity: resolvedAffinity, hostsByZone }
+                : undefined,
+            previousZoneIds: previousAffinityZoneIds,
+          });
+          affinityZoneIds = placed.length > 0 ? placed : undefined;
+        }
         // The aliased URL is primary (`url`): it is stable across deploys,
         // re-pointing at each newly uploaded version. The per-version URL
         // (prefixed by the version id) rides along in `urls`.
@@ -2444,6 +2813,7 @@ export const LiveWorkerProvider = () =>
           versionId,
           versionAlias: alias,
           deploymentId,
+          affinityZoneIds,
           hash,
         } satisfies Worker["Attributes"];
       });
@@ -3289,6 +3659,68 @@ export const LiveWorkerProvider = () =>
           desiredRoutes,
           previousRoutes,
         );
+        // Version-affinity transform rules (`version.affinity`): pin each
+        // user to one version during gradual rollouts by filling the
+        // version-key header from a stable request property, on every zone
+        // this Worker serves on. Runs after the domain/route reconciles so
+        // freshly attached surfaces resolve their zones, and also when only
+        // *previous* state holds rules, so removing affinity converges.
+        const affinity =
+          news.version?.parent == null ? news.version?.affinity : undefined;
+        const previousAffinityZoneIds = output?.affinityZoneIds ?? [];
+        let affinityZoneIds: string[] | undefined;
+        if (affinity !== undefined || previousAffinityZoneIds.length > 0) {
+          const resolvedAffinity =
+            affinity !== undefined
+              ? yield* resolveVersionAffinity(affinity)
+              : undefined;
+          let hostsByZone: Map<string, AffinityZoneHost[]> | undefined;
+          if (resolvedAffinity !== undefined) {
+            hostsByZone = new Map();
+            const addHost = (zoneId: string, host: AffinityZoneHost) => {
+              const hosts = hostsByZone!.get(zoneId) ?? [];
+              hosts.push(host);
+              hostsByZone!.set(zoneId, hosts);
+            };
+            // Serving hostnames from *observed* domain attachments (covers
+            // managed, unmanaged, and adopted domains alike); redirect
+            // hostnames 301 before the Worker and never need a key.
+            const redirectHosts = new Set(effectiveDomain?.redirects ?? []);
+            const attached = yield* workers
+              .listDomains({ accountId, service: name })
+              .pipe(Effect.map((r) => r.result ?? []));
+            for (const d of attached) {
+              if (!d.hostname || !d.zoneId || redirectHosts.has(d.hostname)) {
+                continue;
+              }
+              addHost(d.zoneId, { host: d.hostname, wildcard: false });
+            }
+            for (const route of routes) {
+              const host = route.pattern.split("/")[0];
+              if (!host || host.includes('"')) continue;
+              addHost(route.zoneId, { host, wildcard: host.includes("*") });
+            }
+            if (hostsByZone.size === 0) {
+              return yield* Effect.fail(
+                new WorkerVersionConfigError({
+                  message:
+                    `version.affinity pins users via a zone Transform Rule setting the ${AFFINITY_HEADER} header, which only sees zone traffic — give '${name}' a custom domain (\`domain\`) or zone \`routes\`. ` +
+                    `On the bare workers.dev URL, clients must send the header themselves.`,
+                }),
+              );
+            }
+            yield* session.note("Reconciling version-affinity rules ...");
+          }
+          const placed = yield* reconcileAffinityRules({
+            scriptName: name,
+            desired:
+              resolvedAffinity !== undefined && hostsByZone !== undefined
+                ? { affinity: resolvedAffinity, hostsByZone }
+                : undefined,
+            previousZoneIds: previousAffinityZoneIds,
+          });
+          affinityZoneIds = placed.length > 0 ? placed : undefined;
+        }
         const desiredCrons = normalizeCrons([
           ...getCronBindings(bindings),
           ...(news.crons ?? []),
@@ -3316,6 +3748,7 @@ export const LiveWorkerProvider = () =>
           versionOf: undefined,
           versionId,
           deploymentId,
+          affinityZoneIds,
           hash,
         } satisfies Worker["Attributes"];
       });
@@ -4127,6 +4560,10 @@ export const LiveWorkerProvider = () =>
               durableObjectNamespaces: getDurableObjects(settings.bindings),
               routes: routesList,
               crons,
+              // Rule placement is provider-managed state, not observed here
+              // (a getPhas call per known zone on every read); carry the
+              // cleanup list forward like any other stable cache.
+              affinityZoneIds: output?.affinityZoneIds,
             } satisfies Worker["Attributes"];
 
             // Centralized ownership decision: the engine routes `read`'s
@@ -4171,7 +4608,7 @@ export const LiveWorkerProvider = () =>
           // script instead of owning a script of its own — none of the
           // script-level observation below applies.
           if (news.version?.parent != null) {
-            return yield* putWorkerVersion(id, news, bindings, session);
+            return yield* putWorkerVersion(id, news, bindings, session, output);
           }
           const { accountId } = yield* yield* CloudflareEnvironment;
           const name =
@@ -4248,6 +4685,17 @@ export const LiveWorkerProvider = () =>
           // current deployment routes traffic to our version, restore 100%
           // to the other version in the split.
           if (output.versionOf !== undefined) {
+            // Remove our affinity rules from the parent's zones — the
+            // canary owned them, and with the canary gone there is no
+            // split left to pin. Best-effort: a zone we can no longer
+            // touch must not fail the destroy.
+            if (output.affinityZoneIds?.length) {
+              yield* reconcileAffinityRules({
+                scriptName: output.versionOf,
+                desired: undefined,
+                previousZoneIds: output.affinityZoneIds,
+              }).pipe(Effect.catch(() => Effect.void));
+            }
             if (!output.versionId) return;
             yield* Effect.logInfo(
               `Cloudflare Worker delete: releasing version ${output.versionId} of ${output.versionOf}`,
@@ -4334,6 +4782,15 @@ export const LiveWorkerProvider = () =>
           // Reconciling with an empty domain config removes exactly the
           // rules tagged `alchemy:worker:<script>:redirect:*`, leaving
           // everything else in the shared entrypoint untouched.
+          // Remove our version-affinity rules from every zone state says
+          // holds them. Best-effort, like the redirect rules below.
+          if (output.affinityZoneIds?.length) {
+            yield* reconcileAffinityRules({
+              scriptName: output.workerName,
+              desired: undefined,
+              previousZoneIds: output.affinityZoneIds,
+            }).pipe(Effect.catch(() => Effect.void));
+          }
           const redirects = stateWorkerDomain(output)?.redirects ?? [];
           if (redirects.length > 0) {
             yield* reconcileRedirectRules({

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerVersionAffinity.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerVersionAffinity.test.ts
@@ -1,0 +1,338 @@
+import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import { WorkerVersionConfigError } from "@/Cloudflare/Workers/WorkerProvider.ts";
+import { findZoneByName } from "@/Cloudflare/Zone/lookup";
+import * as Test from "@/Test/Alchemy";
+import * as rulesets from "@distilled.cloud/cloudflare/rulesets";
+import { describe, expect } from "alchemy-test";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+import * as Schedule from "effect/Schedule";
+
+const { test } = Test.make({ providers: Cloudflare.providers() });
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+// The worker echoes the version-key header the transform rule sets, so a
+// plain fetch proves the rule rewrote the request end-to-end.
+const script = `export default { fetch(request) { return new Response(request.headers.get("Cloudflare-Workers-Version-Key") ?? "no-key"); } };`;
+
+const zoneName =
+  process.env.CLOUDFLARE_TEST_WORKER_DOMAIN_ZONE_NAME ??
+  process.env.CLOUDFLARE_TEST_DNS_ZONE_NAME ??
+  "alchemy-test-2.us";
+
+// Deterministic per-run hostnames on the standing test zone (never derive
+// names from Date.now()).
+const suffix = process.env.PULL_REQUEST ?? process.env.USER ?? "local";
+
+const resolveZone = Effect.gen(function* () {
+  const { accountId } = yield* yield* CloudflareEnvironment;
+  const zone = yield* findZoneByName({ accountId, name: zoneName });
+  if (!zone) {
+    return yield* Effect.die(
+      new Error(`zone "${zoneName}" not found in account`),
+    );
+  }
+  return zone;
+});
+
+/**
+ * Our affinity rules in the zone's late-transform phase entrypoint, as
+ * `{ description, expression, value }` (value = the header-value
+ * expression), sorted by description.
+ */
+const listAffinityRules = Effect.fn(function* (
+  zoneId: string,
+  scriptName: string,
+) {
+  const entrypoint = yield* rulesets
+    .getPhasForZone({ zoneId, rulesetPhase: "http_request_late_transform" })
+    .pipe(Effect.catch(() => Effect.succeed(undefined)));
+  return (entrypoint?.rules ?? [])
+    .flatMap((rule) => {
+      if (
+        !(rule.description ?? "").startsWith(
+          `alchemy:worker:${scriptName}:affinity`,
+        )
+      ) {
+        return [];
+      }
+      const headers =
+        "actionParameters" in rule
+          ? (
+              rule.actionParameters as
+                | { headers?: Record<string, unknown> | null }
+                | null
+                | undefined
+            )?.headers
+          : undefined;
+      const header = headers?.["Cloudflare-Workers-Version-Key"] as
+        | { expression?: unknown }
+        | undefined;
+      return [
+        {
+          description: rule.description as string,
+          expression: rule.expression ?? "",
+          value:
+            typeof header?.expression === "string"
+              ? header.expression
+              : undefined,
+        },
+      ];
+    })
+    .sort((a, b) => a.description.localeCompare(b.description));
+});
+
+class DnsNotReady extends Data.TaggedError("DnsNotReady")<{
+  hostname: string;
+}> {}
+
+/**
+ * Wait until `hostname` resolves, querying over DNS-over-HTTPS. The system
+ * resolver must not be asked before the record exists — an early lookup
+ * negative-caches NXDOMAIN for the zone's SOA minimum TTL, poisoning every
+ * later fetch in the test. Public DoH resolvers negative-cache too, so
+ * each attempt alternates between two independent resolvers — a cached
+ * pre-propagation NODATA answer on one can't stall the whole loop.
+ */
+const waitForDns = Effect.fn(function* (hostname: string) {
+  const resolvers = ["1.1.1.1", "dns.google"];
+  let attempt = 0;
+  yield* Effect.tryPromise({
+    try: async (signal) => {
+      const resolver = resolvers[attempt++ % resolvers.length];
+      const res = await fetch(
+        `https://${resolver}/dns-query?name=${hostname}&type=AAAA`,
+        { headers: { accept: "application/dns-json" }, signal },
+      );
+      const body = (await res.json()) as { Answer?: unknown[] };
+      if (!body.Answer?.length) throw new Error("no answer");
+    },
+    catch: () => new DnsNotReady({ hostname }),
+  }).pipe(
+    Effect.retry({
+      while: (e) => e._tag === "DnsNotReady",
+      schedule: Schedule.spaced("5 seconds"),
+      times: 60,
+    }),
+  );
+});
+
+class BodyMismatch extends Data.TaggedError("BodyMismatch")<{
+  url: string;
+  body: string;
+}> {
+  override get message() {
+    return `unexpected body from ${this.url}: '${this.body}'`;
+  }
+}
+
+/**
+ * Fetch `url` (optionally with request headers) and assert the response
+ * body satisfies `check`, retried through DNS/certificate/edge propagation
+ * on a freshly attached custom domain.
+ */
+const expectBody = Effect.fn(function* (
+  url: string,
+  headers: Record<string, string>,
+  check: (body: string) => boolean,
+  options?: { times?: number },
+) {
+  yield* Effect.tryPromise({
+    try: async (signal) => {
+      const res = await fetch(url, { headers, signal });
+      return await res.text();
+    },
+    catch: (cause) => new BodyMismatch({ url, body: String(cause) }),
+  }).pipe(
+    Effect.flatMap((body) =>
+      check(body) ? Effect.void : Effect.fail(new BodyMismatch({ url, body })),
+    ),
+    Effect.retry({
+      while: (e) => e._tag === "BodyMismatch",
+      schedule: Schedule.spaced("5 seconds"),
+      times: options?.times ?? 36,
+    }),
+  );
+});
+
+describe.concurrent("Cloudflare.Worker version affinity", () => {
+  test.provider(
+    "affinity rules converge across sources and clean up on destroy",
+    (stack) =>
+      Effect.gen(function* () {
+        const zone = yield* resolveZone;
+        const host = `wa-b-${suffix}.${zoneName}`;
+        const routeHost = `*.wa-rt-${suffix}.${zoneName}`;
+
+        yield* stack.destroy();
+
+        const deploy = (
+          affinity: Cloudflare.WorkerVersionAffinity | undefined,
+        ) =>
+          stack.deploy(
+            Effect.gen(function* () {
+              return yield* Cloudflare.Worker("AffinityWorker", {
+                script,
+                workersDev: false,
+                domain: host,
+                routes: [{ pattern: `${routeHost}/*` }],
+                version: { traffic: 50, affinity },
+              });
+            }),
+          );
+
+        // Sticky by session cookie, falling back to sticky IP: one rule
+        // per condition, scoped to this Worker's hostnames in the zone.
+        const v1 = yield* deploy({ cookie: "session_id", ip: true });
+        expect(v1.affinityZoneIds).toEqual([zone.id]);
+        const prefix = `alchemy:worker:${v1.workerName}:affinity`;
+        const hostExpr = `(http.host eq "${host}" or http.host wildcard "${routeHost}")`;
+        expect(yield* listAffinityRules(zone.id, v1.workerName)).toEqual([
+          {
+            description: `${prefix}:ip`,
+            expression: `${hostExpr} and not (len(http.request.cookies["session_id"]) > 0)`,
+            value: "to_string(ip.src)",
+          },
+          {
+            description: `${prefix}:key`,
+            expression: `${hostExpr} and len(http.request.cookies["session_id"]) > 0`,
+            value: `http.request.cookies["session_id"][0]`,
+          },
+        ]);
+
+        // The rule rewrites live zone traffic: the worker echoes the
+        // version-key header, so a request carrying the cookie echoes the
+        // cookie value and a bare request echoes the client IP.
+        yield* waitForDns(host);
+        // First fetch pays DNS + edge-certificate propagation on the fresh
+        // custom domain — give it a longer budget than the follow-ups.
+        yield* expectBody(
+          `https://${host}`,
+          { cookie: "session_id=alchemy-test-key" },
+          (body) => body === "alchemy-test-key",
+          { times: 60 },
+        );
+        yield* expectBody(
+          `https://${host}`,
+          {},
+          (body) => body !== "no-key" && /^[0-9a-fA-F.:]+$/.test(body),
+        );
+
+        // Switching the source converges in place: the header rule
+        // replaces the cookie rule and the IP fallback goes away.
+        const v2 = yield* deploy({ header: "X-User-Id" });
+        expect(v2.affinityZoneIds).toEqual([zone.id]);
+        expect(yield* listAffinityRules(zone.id, v2.workerName)).toEqual([
+          {
+            description: `${prefix}:key`,
+            expression: `${hostExpr} and len(http.request.headers["x-user-id"]) > 0`,
+            value: `http.request.headers["x-user-id"][0]`,
+          },
+        ]);
+
+        // Removing affinity removes the rules while the rollout continues.
+        const v3 = yield* deploy(undefined);
+        expect(v3.affinityZoneIds).toBeUndefined();
+        expect(yield* listAffinityRules(zone.id, v3.workerName)).toEqual([]);
+
+        // Re-add, then destroy — teardown must remove the rules too.
+        const v4 = yield* deploy({ cookie: "session_id" });
+        expect(yield* listAffinityRules(zone.id, v4.workerName)).toHaveLength(
+          1,
+        );
+        yield* stack.destroy();
+        expect(yield* listAffinityRules(zone.id, v4.workerName)).toEqual([]);
+      }).pipe(logLevel),
+    { timeout: 600_000 },
+  );
+
+  test.provider(
+    "rejects affinity on a workers.dev-only worker",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const error = yield* stack
+          .deploy(
+            Effect.gen(function* () {
+              return yield* Cloudflare.Worker("DevOnlyAffinity", {
+                script,
+                version: { traffic: 50, affinity: { cookie: "session_id" } },
+              });
+            }),
+          )
+          .pipe(Effect.flip);
+
+        expect(error).toBeInstanceOf(WorkerVersionConfigError);
+        expect(String(error)).toContain("zone Transform Rule");
+
+        yield* stack.destroy();
+      }).pipe(logLevel),
+    { timeout: 180_000 },
+  );
+
+  test.provider(
+    "a canary version worker pins users on the parent's zone",
+    (stack) =>
+      Effect.gen(function* () {
+        const zone = yield* resolveZone;
+        const host = `wa-p-${suffix}.${zoneName}`;
+
+        yield* stack.destroy();
+
+        const parentWorker = (marker: string) =>
+          Cloudflare.Worker("AffinityParent", {
+            script: `export default { fetch() { return new Response("${marker}"); } };`,
+            workersDev: false,
+            domain: host,
+          });
+
+        // Parent + canary in one stack: the canary carries the affinity,
+        // and the rule lands on the parent's zone under the parent's name.
+        const v1 = yield* stack.deploy(
+          Effect.gen(function* () {
+            const parent = yield* parentWorker("parent-v1");
+            const canary = yield* Cloudflare.Worker("AffinityCanary", {
+              script,
+              version: {
+                parent,
+                traffic: 25,
+                affinity: { cookie: "session_id" },
+              },
+            });
+            return { parent, canary };
+          }),
+        );
+        expect(v1.canary.affinityZoneIds).toEqual([zone.id]);
+        const rules = yield* listAffinityRules(zone.id, v1.parent.workerName);
+        expect(rules).toHaveLength(1);
+        expect(rules[0].description).toEqual(
+          `alchemy:worker:${v1.parent.workerName}:affinity:key`,
+        );
+        expect(rules[0].expression).toEqual(
+          `http.host eq "${host}" and len(http.request.cookies["session_id"]) > 0`,
+        );
+
+        // Releasing the canary deletes the version resource — its delete
+        // must also clear the rules it owned on the parent's zone.
+        const v2 = yield* stack.deploy(
+          Effect.gen(function* () {
+            const parent = yield* parentWorker("parent-v1");
+            return { parent };
+          }),
+        );
+        expect(yield* listAffinityRules(zone.id, v2.parent.workerName)).toEqual(
+          [],
+        );
+
+        yield* stack.destroy();
+      }).pipe(logLevel),
+    { timeout: 420_000 },
+  );
+});

--- a/website/src/content/docs/cloudflare/compute/gradual-deployments.mdx
+++ b/website/src/content/docs/cloudflare/compute/gradual-deployments.mdx
@@ -183,15 +183,57 @@ the smoke test fails, re-deploy the last good ref at the default 100
 Percentages route each request independently, so one user can bounce
 between versions mid-rollout. The `Cloudflare-Workers-Version-Key`
 header pins them: Cloudflare hashes the key and assigns a version
-deterministically from the percentages.
+deterministically from the percentages. Declare the key source with
+`version.affinity`:
+
+```typescript
+yield* Cloudflare.Worker("Api", {
+  main: "./src/api.ts",
+  domain: "api.example.com",
+  version: {
+    traffic: 10,
+    // sticky by session cookie, falling back to sticky IP
+    affinity: { cookie: "session_id", ip: true },
+  },
+});
+```
+
+Alchemy provisions a transform rule on each zone the Worker serves on
+(custom domains and routes), scoped to the Worker's hostnames, that
+fills the header from the cookie — and, for requests that don't carry
+the cookie yet, from the client IP. The rule updates in place as the
+config changes and is removed when `affinity` is removed or the
+Worker is destroyed. On a [canary of another stage's
+Worker](#canary-another-stages-worker) (`version.parent`), the rule
+lands on the parent's zones, pinning users across the canary split.
+
+Besides `cookie`, the key can come from a request `header` (a tenant
+or user id your edge already stamps), the client IP alone
+(`{ ip: true }`), or — for anything else, like a JWT claim via API
+Shield — a raw
+[Rules-language](https://developers.cloudflare.com/ruleset-engine/rules-language/)
+expression:
+
+```typescript
+version: {
+  traffic: 10,
+  affinity: { key: `http.request.jwt.claims["<token-config-id>"][0]` },
+}
+```
+
+Transform rules only see zone traffic; on the bare `workers.dev` URL,
+clients send the header themselves:
 
 ```sh
 curl -s https://api.example.com -H 'Cloudflare-Workers-Version-Key: user-123'
 ```
 
-On zone traffic (custom domains and routes), declare the pinning as
-infrastructure — a transform rule that fills the header from a
-session cookie, with no Worker code changes:
+Pinned users only move forward as percentages rise, never back.
+
+For full control over the rule — custom match conditions, keys
+composed from several fields, rules spanning Workers — drop down to a
+manual `Ruleset` in the same phase, which is exactly what the sugar
+manages for you:
 
 ```typescript
 const zone = yield* Cloudflare.Zone.Zone("Zone", { name: "example.com" });
@@ -216,11 +258,6 @@ yield* Cloudflare.Ruleset.Ruleset("VersionAffinity", {
   ],
 });
 ```
-
-Any stable request property works as the key — a cookie, an auth
-claim, a tenant id. Transform rules only see zone traffic; on the bare
-`workers.dev` URL, clients send the header themselves. Pinned users
-only move forward as percentages rise, never back.
 
 ## Verify which version served a request
 


### PR DESCRIPTION
First-class version affinity for gradual deployments — pin each user to one version for the duration of a rollout by declaring the key source on the `version` prop (requested by Eric Clemmons in review of #981):

```ts
yield* Cloudflare.Worker("Api", {
  main: "./src/api.ts",
  domain: "api.example.com",
  version: {
    traffic: 10,
    // sticky by session cookie, falling back to sticky IP
    affinity: { cookie: "session_id", ip: true },
  },
});
```

Provisions `rewrite` Transform Rules in each serving zone's `http_request_late_transform` entrypoint that fill the `Cloudflare-Workers-Version-Key` header, scoped to the Worker's own hostnames (`http.host eq/in/wildcard …`) so other zone traffic and other Workers' rollouts are untouched. Managed like the worker redirect rules: tagged by an `alchemy:worker:<script>:affinity` description prefix, foreign rules pass through, removed when `affinity` is removed or the resource is deleted.

- Sources: `cookie`, `header`, `ip: true` (standalone or as fallback for an absent cookie/header), and `key` — a raw Rules-language expression escape hatch (e.g. a JWT claim via API Shield).
- Zones resolve from observed custom-domain attachments plus reconciled route zone ids; a workers.dev-only Worker fails with a typed `WorkerVersionConfigError`.
- Parent-mode canaries (`version.parent`) are supported: the rule lands on the parent's zones under the parent's script name, and releasing the canary removes it.
- Placed zones persist as `affinityZoneIds` on Attributes (the cleanup list for delete and affinity-removal); `affinity` participates in the metadata hash so toggling it plans an update.

One subtlety worth knowing: an absent cookie/header is a *missing* value in the Rules language and every comparison on missing evaluates false, so the IP-fallback guard is `not (len(field) > 0)` — `len(field) == 0` never matches. The live test proved this end-to-end (worker echoes the rewritten header for cookie and bare requests).

Live tests in `WorkerVersionAffinity.test.ts` (all green, ~47s): rule convergence across sources + destroy cleanup with functional header-rewrite assertions on the standing test zone, the workers.dev-only rejection, and the parent-mode canary. Existing `WorkerVersion.test.ts` suite still green. The gradual-deployments guide now leads with the sugar and keeps the manual `Ruleset` as the escape hatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
