### PR TITLE
chore: full-suite convergence — typed errors, leak-proof deletes, census filters, test hardening

### DIFF
--- a/packages/alchemy-test/src/Registry.ts
+++ b/packages/alchemy-test/src/Registry.ts
@@ -1,58 +1,65 @@
 /**
- * Global registration state.
+ * Per-file registration state.
  *
- * The runner imports one test file at a time. While a file's module body is
- * evaluating, `describe`/`test`/hook calls register nodes against the current
- * collector. The registry lives on `globalThis` so that a duplicated module
- * instance (e.g. two resolutions of the package) still shares one registry.
+ * While a test file's module body is evaluating, `describe`/`test`/hook
+ * calls register nodes against that file's collector. The runner imports
+ * all test files in PARALLEL; attribution stays correct because the
+ * collector is carried by AsyncLocalStorage — the module loader propagates
+ * the async context of the `import()` call into the module's top-level
+ * evaluation (and into microtasks queued from it), so each file's
+ * registrations resolve to its own root no matter how many imports are in
+ * flight.
+ *
+ * The storage lives on `globalThis` so that a duplicated module instance
+ * (e.g. two resolutions of the package) still shares one registry.
  */
+import { AsyncLocalStorage } from "node:async_hooks";
 import { makeFileSuite, type FileSuite, type Suite } from "./Model.ts";
 
-interface RegistryState {
-  /** Root suite of the file currently being collected. */
-  root: FileSuite | undefined;
+interface FileContext {
   /** Suite that `describe`/`test` calls currently attach to. */
-  current: Suite | undefined;
+  current: Suite;
 }
 
 const key = Symbol.for("alchemy-test/registry");
 
-const state: RegistryState = ((globalThis as any)[key] ??= {
-  root: undefined,
-  current: undefined,
-} satisfies RegistryState);
+const storage: AsyncLocalStorage<FileContext> = ((globalThis as any)[key] ??=
+  new AsyncLocalStorage<FileContext>());
 
-/** Begin collecting a file. Returns its root suite. */
-export const beginFile = (file: string): FileSuite => {
+/**
+ * Collect one file: run `f` (the file's dynamic import + microtask flush)
+ * with a fresh root as the ambient collector, and return the root.
+ */
+export const collect = async (
+  file: string,
+  f: () => Promise<void>,
+): Promise<FileSuite> => {
   const root = makeFileSuite(file);
-  state.root = root;
-  state.current = root;
+  await storage.run({ current: root }, f);
   return root;
 };
 
-/** Finish collecting the current file. */
-export const endFile = (): void => {
-  state.root = undefined;
-  state.current = undefined;
-};
-
-export const currentSuite = (): Suite => {
-  if (state.current === undefined) {
+const currentContext = (): FileContext => {
+  const context = storage.getStore();
+  if (context === undefined) {
     throw new Error(
       "alchemy-test: describe/test/hook called outside of a test file collection. " +
         "Run tests with the `alchemy-test` CLI.",
     );
   }
-  return state.current;
+  return context;
 };
+
+export const currentSuite = (): Suite => currentContext().current;
 
 /** Run `f` with `suite` as the current registration target. */
 export const withSuite = (suite: Suite, f: () => void): void => {
-  const previous = state.current;
-  state.current = suite;
+  const context = currentContext();
+  const previous = context.current;
+  context.current = suite;
   try {
     f();
   } finally {
-    state.current = previous;
+    context.current = previous;
   }
 };

--- a/packages/alchemy-test/src/Runner.ts
+++ b/packages/alchemy-test/src/Runner.ts
@@ -1,11 +1,13 @@
 /**
  * Single-process test runner.
  *
- * Discovers `*.test.ts` files, imports them one at a time (registration is
- * global), then executes every collected test as an Effect — files run
- * concurrently up to a limit, tests within a file run sequentially unless
- * their suite is `describe.concurrent`. Each test gets a buffering Effect
- * Logger + Console so its output can be shown in isolation.
+ * Discovers `*.test.ts` files, imports them ALL IN PARALLEL (the per-file
+ * collector rides AsyncLocalStorage, so registration attribution survives
+ * concurrent imports — see Registry.ts), then executes every collected
+ * test as an Effect — files run concurrently up to a limit, tests within a
+ * file run sequentially unless their suite is `describe.concurrent`. Each
+ * test gets a buffering Effect Logger + Console so its output can be shown
+ * in isolation.
  */
 import * as Cause from "effect/Cause";
 import * as ConsoleModule from "effect/Console";
@@ -242,13 +244,15 @@ const collectFile = (
   relative: string,
 ): Effect.Effect<CollectedFile> =>
   Effect.promise(async (): Promise<CollectedFile> => {
-    const root = Registry.beginFile(relative);
     try {
-      await import(pathToFileURL(absolute).href);
-      // Flush microtasks + one macrotask so registrations deferred with
-      // queueMicrotask (e.g. Test.make's fallback afterAll) land in the tree.
-      await new Promise((resolve) => setTimeout(resolve, 0));
-      return { file: relative, suite: root };
+      const suite = await Registry.collect(relative, async () => {
+        await import(pathToFileURL(absolute).href);
+        // Flush microtasks + one macrotask so registrations deferred with
+        // queueMicrotask (e.g. Test.make's fallback afterAll) land in the
+        // tree — their ALS context resolves this file's collector.
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+      return { file: relative, suite };
     } catch (error) {
       return {
         file: relative,
@@ -258,8 +262,6 @@ const collectFile = (
             ? (error.stack ?? error.message)
             : String(error),
       };
-    } finally {
-      Registry.endFile();
     }
   });
 
@@ -729,18 +731,32 @@ export const run = Effect.fn(function* (options: RunOptions) {
   const relative = absoluteFiles.map((f) => path.relative(options.root, f));
   yield* emit({ _tag: "CollectStart", files: relative });
 
-  // Phase 1 — import EVERY file before running anything. Imports are lazy
-  // and pure (registration only), and must be serial anyway because the
-  // registration state is global. Collecting fully up-front keeps run
-  // semantics simple: `.only` applies across the whole run, and the full
-  // test list is known before the first test starts.
-  const collected: Array<CollectedFile> = [];
-  for (let i = 0; i < absoluteFiles.length; i++) {
-    // collectFile never fails — import errors are captured on the result.
-    const c = yield* collectFile(absoluteFiles[i]!, relative[i]!);
-    collected.push(c);
-    yield* emit({ _tag: "FileCollected", file: relative[i]! });
-  }
+  // Phase 1 — import EVERY file before running anything, in parallel.
+  // The per-file collector rides AsyncLocalStorage (see Registry.ts), so
+  // registration stays correctly attributed under concurrent imports.
+  // Collecting fully up-front keeps run semantics simple: `.only` applies
+  // across the whole run, and the full test list is known before the first
+  // test starts.
+  //
+  // Concurrency is BOUNDED: kicking off every import at once floods the
+  // main thread with synchronous parse/link/evaluate work — timers and the
+  // progress line starve (a slow start becomes indistinguishable from a
+  // hang), and it maximizes exposure to loader races under concurrent
+  // dynamic imports. The shared dependency graph is deduped by the module
+  // cache, so a modest bound keeps nearly all of the speedup.
+  const collectConcurrency =
+    options.concurrency === "unbounded"
+      ? 32
+      : Math.min(options.concurrency, 32);
+  // collectFile never fails — import errors are captured on the result.
+  const collected = yield* Effect.forEach(
+    absoluteFiles.map((absolute, i) => [absolute, relative[i]!] as const),
+    ([absolute, rel]) =>
+      collectFile(absolute, rel).pipe(
+        Effect.tap(() => emit({ _tag: "FileCollected", file: rel })),
+      ),
+    { concurrency: collectConcurrency },
+  );
 
   const onlyMode = collected.some(
     (c) => c.suite !== undefined && containsOnly(c.suite),

--- a/packages/alchemy/src/AWS/ApiGateway/common.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/common.ts
@@ -3,6 +3,7 @@ import * as Retry from "@distilled.cloud/aws/Retry";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";
+import * as Semaphore from "effect/Semaphore";
 import { diffTags, normalizeTags } from "../../Tags.ts";
 
 /**
@@ -96,6 +97,13 @@ const restApiGoneSchedule = Schedule.max([
   Schedule.recurs(8),
 ]);
 
+// DeleteRestApi's ~1-per-30s quota is ACCOUNT-wide, so concurrent destroys
+// (parallel test files, parallel stacks in one process) all contend for the
+// same token — each one's individual retry wall can expire while the others
+// keep winning the race. Serialize deletes process-wide so each waiter only
+// contends with the quota window itself, never with its siblings.
+const restApiDeleteMutex = Semaphore.makeUnsafe(1);
+
 /**
  * Idempotently delete a REST API and observe it disappear.
  *
@@ -109,6 +117,7 @@ export const deleteRestApiAndWait = Effect.fn(function* (restApiId: string) {
       schedule: restApiDeleteSchedule,
     }),
     Effect.catchTag("NotFoundException", () => Effect.void),
+    Semaphore.withPermits(restApiDeleteMutex, 1),
   );
 
   // Avoid nesting the account-wide AWS retry policy inside the observable

--- a/packages/alchemy/src/AWS/CostExplorer/common.ts
+++ b/packages/alchemy/src/AWS/CostExplorer/common.ts
@@ -1,5 +1,6 @@
 import * as ce from "@distilled.cloud/aws/cost-explorer";
 import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
 import { diffTags } from "../../Tags.ts";
 import { Region } from "../Region.ts";
 
@@ -11,8 +12,28 @@ import { Region } from "../Region.ts";
 // (same pattern as CloudFront KVS / ECR Public / WAFv2 / GlobalAccelerator).
 export const CE_REGION = "us-east-1" as const;
 
-export const pinCe = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
-  effect.pipe(Effect.provideService(Region, Effect.succeed(CE_REGION)));
+// Cost Explorer's control-plane rate limits are extremely low and shared
+// account-wide, so concurrent deploys readily trip `LimitExceededException:
+// Rate limit exceeded`. Retry it with capped exponential backoff, bounded
+// (~47s total) so a genuine quota LimitExceeded still surfaces quickly.
+const ceThrottleRetrySchedule = Schedule.max([
+  Schedule.min([
+    Schedule.exponential("1 second"),
+    Schedule.spaced("8 seconds"),
+  ]),
+  Schedule.recurs(8),
+]);
+
+export const pinCe = <A, E extends { _tag: string }, R>(
+  effect: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> =>
+  effect.pipe(
+    Effect.provideService(Region, Effect.succeed(CE_REGION)),
+    Effect.retry({
+      while: (e) => e._tag === "LimitExceededException",
+      schedule: ceThrottleRetrySchedule,
+    }),
+  );
 
 /** Convert a plain tag record to Cost Explorer's `ResourceTag` list shape. */
 export const toResourceTags = (

--- a/packages/alchemy/src/AWS/DataSync/Task.ts
+++ b/packages/alchemy/src/AWS/DataSync/Task.ts
@@ -1,5 +1,6 @@
 import * as datasync from "@distilled.cloud/aws/datasync";
 import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
 import { isResolved } from "../../Diff.ts";
 import { createPhysicalName } from "../../PhysicalName.ts";
@@ -201,21 +202,35 @@ export const TaskProvider = () =>
 
           // 2. ENSURE — create if missing.
           if (t === undefined) {
-            const created = yield* datasync.createTask({
-              SourceLocationArn: news.sourceLocationArn,
-              DestinationLocationArn: news.destinationLocationArn,
-              Name: name,
-              Options: news.options,
-              Excludes: news.excludes,
-              Includes: news.includes,
-              Schedule: news.schedule,
-              CloudWatchLogGroupArn: news.cloudWatchLogGroupArn,
-              TaskMode: news.taskMode,
-              Tags: Object.entries(desiredTags).map(([Key, Value]) => ({
-                Key,
-                Value,
-              })),
-            });
+            const created = yield* datasync
+              .createTask({
+                SourceLocationArn: news.sourceLocationArn,
+                DestinationLocationArn: news.destinationLocationArn,
+                Name: name,
+                Options: news.options,
+                Excludes: news.excludes,
+                Includes: news.includes,
+                Schedule: news.schedule,
+                CloudWatchLogGroupArn: news.cloudWatchLogGroupArn,
+                TaskMode: news.taskMode,
+                Tags: Object.entries(desiredTags).map(([Key, Value]) => ({
+                  Key,
+                  Value,
+                })),
+              })
+              .pipe(
+                // createTask synchronously probes the locations' S3 access,
+                // and a freshly-created location role's IAM policy can lag
+                // (typed `LocationAccessTestFailed`). Retry bounded through
+                // the propagation window.
+                Effect.retry({
+                  while: (e) => e._tag === "LocationAccessTestFailed",
+                  schedule: Schedule.max([
+                    Schedule.spaced("5 seconds"),
+                    Schedule.recurs(9),
+                  ]),
+                }),
+              );
             arn = created.TaskArn!;
             t = yield* describe(arn);
           } else {

--- a/packages/alchemy/src/AWS/EC2/Vpc.ts
+++ b/packages/alchemy/src/AWS/EC2/Vpc.ts
@@ -408,27 +408,41 @@ export const VpcProvider = () =>
           }
 
           if (vpc === undefined) {
-            const createResult = yield* ec2.createVpc({
-              // TODO(sam): add all properties
-              AmazonProvidedIpv6CidrBlock: news.amazonProvidedIpv6CidrBlock,
-              InstanceTenancy: news.instanceTenancy,
-              CidrBlock: news.cidrBlock,
-              Ipv4IpamPoolId: news.ipv4IpamPoolId,
-              Ipv4NetmaskLength: news.ipv4NetmaskLength,
-              Ipv6Pool: news.ipv6Pool,
-              Ipv6CidrBlock: news.ipv6CidrBlock,
-              Ipv6IpamPoolId: news.ipv6IpamPoolId,
-              Ipv6NetmaskLength: news.ipv6NetmaskLength,
-              Ipv6CidrBlockNetworkBorderGroup:
-                news.ipv6CidrBlockNetworkBorderGroup,
-              TagSpecifications: [
-                {
-                  ResourceType: "vpc",
-                  Tags: createTagsList(desiredTags),
-                },
-              ],
-              DryRun: false,
-            });
+            const createResult = yield* ec2
+              .createVpc({
+                // TODO(sam): add all properties
+                AmazonProvidedIpv6CidrBlock: news.amazonProvidedIpv6CidrBlock,
+                InstanceTenancy: news.instanceTenancy,
+                CidrBlock: news.cidrBlock,
+                Ipv4IpamPoolId: news.ipv4IpamPoolId,
+                Ipv4NetmaskLength: news.ipv4NetmaskLength,
+                Ipv6Pool: news.ipv6Pool,
+                Ipv6CidrBlock: news.ipv6CidrBlock,
+                Ipv6IpamPoolId: news.ipv6IpamPoolId,
+                Ipv6NetmaskLength: news.ipv6NetmaskLength,
+                Ipv6CidrBlockNetworkBorderGroup:
+                  news.ipv6CidrBlockNetworkBorderGroup,
+                TagSpecifications: [
+                  {
+                    ResourceType: "vpc",
+                    Tags: createTagsList(desiredTags),
+                  },
+                ],
+                DryRun: false,
+              })
+              .pipe(
+                // The per-region VPC quota (default 5) is a shared pool;
+                // concurrent deploys transiently exhaust it while their VPCs
+                // are being torn down. Ride out the burst with a bounded
+                // spaced retry (~90s) before surfacing the quota error.
+                Effect.retry({
+                  while: (e) => e._tag === "VpcLimitExceeded",
+                  schedule: Schedule.max([
+                    Schedule.spaced("10 seconds"),
+                    Schedule.recurs(9),
+                  ]),
+                }),
+              );
             const newVpcId = createResult.Vpc!.VpcId! as VpcId;
             yield* session.note(`VPC created: ${newVpcId}`);
             vpc = yield* waitForVpcAvailable(newVpcId, session);

--- a/packages/alchemy/src/Cloudflare/AI/Search.ts
+++ b/packages/alchemy/src/Cloudflare/AI/Search.ts
@@ -24,19 +24,11 @@ export type Parse = {
    * How pages are discovered:
    * - `"sitemap"` (default) — read `<seed>/sitemap.xml` (found via
    *   `robots.txt`) and index the URLs it lists.
-   * - `"crawl"` — start at `source` and follow links.
-   * - `"feed-rss"` — treat the seed as an RSS / Atom feed.
+   * - `"discover"` — start at `source` and follow links.
    * @default "sitemap"
    */
   type?: NonNullable<WebCrawlerParams["parseType"]>;
 } & NonNullable<WebCrawlerParams["parseOptions"]>;
-
-/**
- * Link-discovery options for a web crawler (mainly for `parse.type: "crawl"`):
- * `depth`, `includeSubdomains`, `includeExternalLinks`, `maxAge`, and `source`
- * (`"all"` | `"sitemaps"` | `"links"`).
- */
-export type Crawl = NonNullable<WebCrawlerParams["crawlOptions"]>;
 
 /**
  * Where crawled content is stored. Cloudflare provisions managed storage by
@@ -94,7 +86,6 @@ export type R2Props = SharedProps & {
   /** R2 data-residency jurisdiction of the source bucket. */
   jurisdiction?: string;
   parse?: never;
-  crawl?: never;
   store?: never;
 };
 
@@ -107,8 +98,6 @@ export type WebCrawlerProps = SharedProps & {
   source: Input<string>;
   /** How pages are discovered and parsed. */
   parse?: Parse;
-  /** How links are followed from the seed. */
-  crawl?: Crawl;
   /** Where crawl output is stored (defaults to managed storage). */
   store?: Store;
   prefix?: never;
@@ -197,13 +186,12 @@ export type Search = SearchInstance & {
  *
  * @example Web-crawler source
  * Pass a URL as `source` to crawl and index a website (no service token
- * needed). `parse.type` defaults to `"sitemap"`; use `"crawl"` to follow
+ * needed). `parse.type` defaults to `"sitemap"`; use `"discover"` to follow
  * links from the seed instead.
  * ```typescript
  * const search = yield* Cloudflare.AI.Search("site-search", {
  *   source: "https://example.com",
- *   parse: { type: "crawl", contentSelector: [{ path: "/docs", selector: "main" }] },
- *   crawl: { depth: 3, includeSubdomains: true },
+ *   parse: { type: "discover", contentSelector: [{ path: "/docs", selector: "main" }] },
  * });
  * ```
  *
@@ -212,7 +200,7 @@ export type Search = SearchInstance & {
  * const store = yield* Cloudflare.R2.Bucket("crawl-store");
  * const search = yield* Cloudflare.AI.Search("site-search", {
  *   source: "https://example.com",
- *   parse: { type: "crawl" },
+ *   parse: { type: "discover" },
  *   store: { bucket: store },
  * });
  * ```
@@ -303,7 +291,6 @@ export const Search = (id: string, props: Props) =>
       exclude,
       jurisdiction,
       parse,
-      crawl,
       store,
       namespace,
       ...shared
@@ -359,7 +346,6 @@ export const Search = (id: string, props: Props) =>
       const webCrawler = clean({
         parseType,
         parseOptions: clean(parseOptions),
-        crawlOptions: crawl ? clean(crawl) : undefined,
         storeOptions: store
           ? clean({
               storageId: store.bucket.bucketName,

--- a/packages/alchemy/src/Cloudflare/AI/SearchInstance.ts
+++ b/packages/alchemy/src/Cloudflare/AI/SearchInstance.ts
@@ -388,15 +388,10 @@ export type SearchInstance = Resource<
  * `parseType` selects how pages are discovered:
  * - `"sitemap"` (Cloudflare default) — read `<seed>/sitemap.xml` (discovered
  *   via `robots.txt`) and index the URLs it lists.
- * - `"crawl"` — start at `source` and follow links.
- * - `"feed-rss"` — treat the seed as an RSS / Atom feed.
+ * - `"discover"` — start at `source` and follow links.
  *
- * `crawlOptions` controls link discovery (mainly for `parseType: "crawl"`):
- * - `depth` — how many links deep to follow from the seed.
- * - `includeSubdomains` — also crawl subdomains of the seed host.
- * - `includeExternalLinks` — follow links off the seed host.
- * - `maxAge` — skip re-fetching pages younger than this (seconds).
- * - `source` — where links come from: `"all"`, `"sitemaps"`, or `"links"`.
+ * `crawlOptions` is no longer accepted by the API — Cloudflare removed it;
+ * discovery behavior is controlled solely by `parseType`.
  *
  * `parseOptions` controls how each page is parsed:
  * - `useBrowserRendering` — render JS in a headless browser before parsing.
@@ -416,7 +411,7 @@ export type SearchInstance = Resource<
  * const instance = yield* Cloudflare.AI.SearchInstance("site-search", {
  *   type: "web-crawler",
  *   source: "https://example.com",
- *   sourceParams: { webCrawler: { parseType: "crawl" } },
+ *   sourceParams: { webCrawler: { parseType: "discover" } },
  * });
  * ```
  * @example Fully-configured crawl
@@ -426,14 +421,7 @@ export type SearchInstance = Resource<
  *   source: "https://example.com",
  *   sourceParams: {
  *     webCrawler: {
- *       parseType: "crawl",
- *       crawlOptions: {
- *         depth: 3,
- *         includeSubdomains: true,
- *         includeExternalLinks: false,
- *         maxAge: 86_400,
- *         source: "all",
- *       },
+ *       parseType: "discover",
  *       parseOptions: {
  *         useBrowserRendering: true,
  *         includeImages: false,
@@ -443,7 +431,7 @@ export type SearchInstance = Resource<
  *   },
  * });
  * ```
- * @example Sitemap and RSS sources
+ * @example Sitemap source
  * ```typescript
  * // Index the URLs listed in one or more sitemaps (the default parse mode).
  * const fromSitemap = yield* Cloudflare.AI.SearchInstance("sitemap-search", {
@@ -456,13 +444,6 @@ export type SearchInstance = Resource<
  *     },
  *   },
  * });
- *
- * // Treat the seed as an RSS / Atom feed.
- * const fromFeed = yield* Cloudflare.AI.SearchInstance("feed-search", {
- *   type: "web-crawler",
- *   source: "https://example.com/feed.xml",
- *   sourceParams: { webCrawler: { parseType: "feed-rss" } },
- * });
  * ```
  * @example Store crawl output in a specific R2 bucket
  * ```typescript
@@ -471,7 +452,7 @@ export type SearchInstance = Resource<
  *   source: "https://example.com",
  *   sourceParams: {
  *     webCrawler: {
- *       parseType: "crawl",
+ *       parseType: "discover",
  *       storeOptions: { storageId: "my-crawl-bucket", storageType: "r2" },
  *     },
  *   },

--- a/packages/alchemy/src/Cloudflare/Email/Address.ts
+++ b/packages/alchemy/src/Cloudflare/Email/Address.ts
@@ -1,5 +1,6 @@
 import * as emailRouting from "@distilled.cloud/cloudflare/email-routing";
 import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
 import { isResolved } from "../../Diff.ts";
 import * as Provider from "../../Provider.ts";
@@ -192,11 +193,27 @@ export const AddressProvider = () =>
     }),
     delete: Effect.fn(function* ({ output }) {
       if (!output?.addressId) return;
+      // Idempotent on the typed not-found; transient failures are retried
+      // bounded and a persistent failure surfaces — a swallowed failure
+      // silently leaks the destination address. Cloudflare refuses to
+      // delete an address for ~15 minutes after creation
+      // (`EmailAddressCreatedTooRecently`, code 2032) — retrying is
+      // pointless within a deploy's lifetime, so that error fails fast:
+      // either destroy later or retain the address (`RemovalPolicy.retain`).
       yield* emailRouting
         .deleteAddress({
           accountId: output.accountId,
           destinationAddressIdentifier: output.addressId,
         })
-        .pipe(Effect.catch(() => Effect.void));
+        .pipe(
+          Effect.catchTag("EmailAddressNotFound", () => Effect.void),
+          Effect.retry({
+            while: (e) => e._tag !== "EmailAddressCreatedTooRecently",
+            schedule: Schedule.max([
+              Schedule.spaced("3 seconds"),
+              Schedule.recurs(8),
+            ]),
+          }),
+        );
     }),
   });

--- a/packages/alchemy/src/Cloudflare/Flagship/App.ts
+++ b/packages/alchemy/src/Cloudflare/Flagship/App.ts
@@ -211,18 +211,30 @@ export const AppProvider = () =>
         .pipe(Effect.catchTag("FlagshipAppNotFound", () => Effect.void));
     }),
     // Account-scoped collection (pattern b): enumerate every app in the
-    // ambient account via the paginated listApps op. The list item shape
-    // matches GetAppResponse, so each maps directly into Attributes.
+    // ambient account via the paginated listApps op. Cloudflare's list
+    // index can contain ghost rows — apps that were deleted but survive in
+    // the listing while GET/DELETE both return "App not found" — so each
+    // row is validated via getApp and ghosts are dropped (otherwise census
+    // tooling re-discovers an undeletable app forever).
     list: Effect.fn(function* () {
       const { accountId } = yield* yield* CloudflareEnvironment;
-      return yield* flagship.listApps.pages({ accountId }).pipe(
+      const listed = yield* flagship.listApps.pages({ accountId }).pipe(
         Stream.runCollect,
         Effect.map((chunk) =>
-          Array.from(chunk).flatMap((page) =>
-            (page.result ?? []).map((app) => toAttributes(app, accountId)),
-          ),
+          Array.from(chunk).flatMap((page) => page.result ?? []),
         ),
       );
+      const rows = yield* Effect.forEach(
+        listed,
+        (app) =>
+          getApp(accountId, app.id).pipe(
+            Effect.map((observed) =>
+              observed ? toAttributes(observed, accountId) : undefined,
+            ),
+          ),
+        { concurrency: 10 },
+      );
+      return rows.filter((row): row is AppAttributes => row !== undefined);
     }),
   });
 

--- a/packages/alchemy/src/Cloudflare/Ruleset/AccountEntrypoint.ts
+++ b/packages/alchemy/src/Cloudflare/Ruleset/AccountEntrypoint.ts
@@ -194,7 +194,11 @@ export const AccountEntrypointProvider = () =>
         { concurrency: 10 },
       );
       return rows.filter(
-        (row): row is AccountEntrypointAttributes => row !== undefined,
+        (row): row is AccountEntrypointAttributes =>
+          // An entrypoint with zero rules is inert — it's what destroy
+          // leaves behind after emptying the rules we own. Don't surface
+          // it as a resource.
+          row !== undefined && row.rules.length > 0,
       );
     }),
 

--- a/packages/alchemy/src/Cloudflare/Ruleset/Ruleset.ts
+++ b/packages/alchemy/src/Cloudflare/Ruleset/Ruleset.ts
@@ -156,13 +156,23 @@ export const RulesetProvider = () =>
       return toRulesetAttributes(zoneId, ruleset);
     }),
     delete: Effect.fn(function* ({ olds, output }) {
-      yield* rulesets
-        .putPhasForZone({
+      // This resource owns the entire phase entrypoint, so destroy removes
+      // the entrypoint ruleset itself (emptying the rules would leave an
+      // inert-but-listed entrypoint behind on the zone forever). Observe
+      // first so the delete is idempotent and never acts on a stale id.
+      const entrypoint = yield* rulesets
+        .getPhasForZone({
           zoneId: output.zoneId,
-          rulesetPhase: olds.phase,
-          name: output.name,
-          description: output.description,
-          rules: [],
+          rulesetPhase: output.phase ?? olds.phase,
+        })
+        .pipe(
+          Effect.catchTag("RulesetNotFound", () => Effect.succeed(undefined)),
+        );
+      if (entrypoint === undefined) return;
+      yield* rulesets
+        .deleteRulesetForZone({
+          zoneId: output.zoneId,
+          rulesetId: entrypoint.id,
         })
         .pipe(Effect.catchTag("RulesetNotFound", () => Effect.void));
     }),
@@ -221,7 +231,11 @@ export const RulesetProvider = () =>
             ),
             Effect.map((items) =>
               items.filter(
-                (item): item is Ruleset["Attributes"] => item !== undefined,
+                (item): item is Ruleset["Attributes"] =>
+                  // An entrypoint with zero rules is inert — it's what other
+                  // owners (e.g. Worker redirect cleanup) leave behind after
+                  // removing their rules. Don't surface it as a resource.
+                  item !== undefined && item.rules.length > 0,
               ),
             ),
             // Plan-gated / partially-provisioned zones reject the route.

--- a/packages/alchemy/src/Cloudflare/Rum/Site.ts
+++ b/packages/alchemy/src/Cloudflare/Rum/Site.ts
@@ -327,10 +327,17 @@ const findSite = (
     Stream.runCollect,
     Effect.map((chunk) =>
       Array.from(chunk)
-        .filter(
-          (site) =>
-            (host !== undefined && site.host === host) ||
-            (zoneTag !== undefined && site.ruleset?.zoneTag === zoneTag),
+        .filter((site) =>
+          host !== undefined
+            ? site.host === host
+            : // A zone-identity site has no `host`. Host-scoped sites on the
+              // zone's subdomains ALSO carry `ruleset.zoneTag`, so a zone
+              // probe must only match true zone sites — otherwise an
+              // unrelated host site satisfies the probe and the engine
+              // refuses adoption with OwnedBySomeoneElse.
+              zoneTag !== undefined &&
+              !site.host &&
+              site.ruleset?.zoneTag === zoneTag,
         )
         .sort((a, b) => (a.created ?? "").localeCompare(b.created ?? ""))
         .at(0),

--- a/packages/alchemy/src/Cloudflare/Tunnel/Tunnel.ts
+++ b/packages/alchemy/src/Cloudflare/Tunnel/Tunnel.ts
@@ -2,6 +2,7 @@ import * as zeroTrust from "@distilled.cloud/cloudflare/zero-trust";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Redacted from "effect/Redacted";
+import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
 
 import { isResolved } from "../../Diff.ts";
@@ -322,12 +323,33 @@ export const TunnelProvider = () =>
       };
     }),
     delete: Effect.fn(function* ({ output }) {
+      // Observe — an already-(soft-)deleted tunnel means nothing to do.
+      const observed = yield* zeroTrust
+        .getTunnelCloudflared({
+          accountId: output.accountId,
+          tunnelId: output.tunnelId,
+        })
+        .pipe(
+          Effect.catchTag("TunnelNotFound", () => Effect.succeed(undefined)),
+        );
+      if (observed === undefined || observed.deletedAt != null) return;
+      // Delete — sibling route/config deletions propagate asynchronously and
+      // Cloudflare transiently rejects the tunnel delete while they drain.
+      // Retry bounded and let a persistent failure surface: a swallowed
+      // failure silently leaks the tunnel.
       yield* zeroTrust
         .deleteTunnelCloudflared({
           accountId: output.accountId,
           tunnelId: output.tunnelId,
         })
-        .pipe(Effect.catch(() => Effect.void));
+        .pipe(
+          Effect.retry({
+            schedule: Schedule.max([
+              Schedule.spaced("3 seconds"),
+              Schedule.recurs(10),
+            ]),
+          }),
+        );
     }),
     read: Effect.fn(function* ({ id, output, olds }) {
       const { accountId } = yield* yield* CloudflareEnvironment;

--- a/packages/alchemy/src/Test/Alchemy.ts
+++ b/packages/alchemy/src/Test/Alchemy.ts
@@ -264,7 +264,9 @@ export const make = <ROut = any>(options: MakeOptions<ROut>): TestApi => {
   // closes it. We defer registration to a microtask so it runs AFTER any
   // user-registered `afterAll` (including `destroy(Stack)`); the runner
   // executes afterAll hooks in registration order, and file collection
-  // flushes microtasks before sealing the file's suite tree.
+  // flushes microtasks before sealing the file's suite tree. (Files are
+  // collected in parallel, but the microtask carries the AsyncLocalStorage
+  // context of this file's import, so the hook lands on the right suite.)
   queueMicrotask(() => {
     registerHook("afterAll", {
       body: () => closeScope,

--- a/packages/alchemy/test/AWS/ApplicationAutoScaling/EcsServiceScaling.test.ts
+++ b/packages/alchemy/test/AWS/ApplicationAutoScaling/EcsServiceScaling.test.ts
@@ -1,7 +1,5 @@
 import * as AWS from "@/AWS";
 import { ScalableTarget, ScalingPolicy } from "@/AWS/ApplicationAutoScaling";
-import { Subnet } from "@/AWS/EC2/Subnet.ts";
-import { Vpc } from "@/AWS/EC2/Vpc.ts";
 import { Cluster } from "@/AWS/ECS/Cluster.ts";
 import { Service } from "@/AWS/ECS/Service.ts";
 import * as Output from "@/Output";
@@ -20,13 +18,15 @@ const clusterName = "alchemy-test-aas-ecs";
 // The flagship ECS-service scaling flow: register the service's DesiredCount
 // dimension (min 1 / max 3), attach a CPU target-tracking policy, verify both
 // out-of-band, update the policy target in place, and destroy in dependency
-// order (policy -> target -> service -> cluster -> networking).
+// order (policy -> target -> service -> cluster).
 //
 // To stay inside the speed budget we avoid building/pushing a Docker image
 // and register a minimal task definition against a public image out of band
-// (the same pattern as test/AWS/ECS/Service.test.ts). `createService` returns
-// without waiting for Fargate placement, so the suite never blocks on task
-// startup; the scalable target and policy only require the service to exist.
+// (the same pattern as test/AWS/ECS/Service.test.ts). The Service provider
+// waits for the deployment to stabilize, so the task must actually be able
+// to start: run in the account's default VPC (public subnets +
+// `assignPublicIp`, the provider's fallback) so Fargate can pull the public
+// nginx image without a NAT.
 test.provider(
   "ecs service DesiredCount target + CPU target tracking policy",
   (stack) =>
@@ -63,18 +63,13 @@ test.provider(
       const deploy = (targetValue: number) =>
         stack.deploy(
           Effect.gen(function* () {
-            const vpc = yield* Vpc("AasEcsVpc", { cidrBlock: "10.76.0.0/16" });
-            const subnet = yield* Subnet("AasEcsSubnet", {
-              vpcId: vpc.vpcId,
-              cidrBlock: "10.76.1.0/24",
-            });
             const cluster = yield* Cluster("AasEcsCluster", { clusterName });
+            // No vpcId/subnets: fall back to the default VPC's public
+            // subnets with assignPublicIp so the task can pull its image.
             const service = yield* Service("AasEcsService", {
               cluster,
               task: { taskDefinitionArn, containerName: "app", port: 80 },
               desiredCount: 1,
-              vpcId: vpc.vpcId,
-              subnets: [subnet.subnetId],
             });
             const target = yield* ScalableTarget("AasEcsTarget", {
               serviceNamespace: "ecs",

--- a/packages/alchemy/test/AWS/DataExchange/Bindings.test.ts
+++ b/packages/alchemy/test/AWS/DataExchange/Bindings.test.ts
@@ -75,6 +75,31 @@ const postJson = (path: string) =>
     Effect.flatMap((r) => r.json),
   );
 
+class IamPropagationLag extends Data.TaggedError("IamPropagationLag")<{
+  readonly path: string;
+}> {}
+
+// A freshly attached IAM policy can lag behind the Lambda's first calls —
+// DataExchange then rejects with AccessDeniedException, which the handler
+// surfaces as `{ error: "AccessDeniedException" }`. Retry the route through
+// the propagation window (bounded ~60s); any other outcome surfaces
+// immediately.
+const postJsonThroughIamPropagation = (path: string) =>
+  postJson(path).pipe(
+    Effect.flatMap((body) =>
+      (body as { error?: string }).error === "AccessDeniedException"
+        ? Effect.fail(new IamPropagationLag({ path }))
+        : Effect.succeed(body),
+    ),
+    Effect.retry({
+      while: (e) => e._tag === "IamPropagationLag",
+      schedule: Schedule.max([
+        Schedule.spaced("5 seconds"),
+        Schedule.recurs(12),
+      ]),
+    }),
+  );
+
 describe.sequential("DataExchange Bindings", () => {
   beforeAll(
     Effect.gen(function* () {
@@ -206,7 +231,9 @@ describe.sequential("DataExchange Bindings", () => {
       "imports an S3 object into the revision via a job and reads it back",
       (_stack) =>
         Effect.gen(function* () {
-          const response = (yield* postJson("/import")) as {
+          const response = (yield* postJsonThroughIamPropagation(
+            "/import",
+          )) as {
             jobState?: string;
             jobErrors?: unknown[];
             assetCount?: number;
@@ -240,7 +267,9 @@ describe.sequential("DataExchange Bindings", () => {
       "rejects a data set outside a Marketplace product with a typed error",
       (_stack) =>
         Effect.gen(function* () {
-          const response = (yield* postJson("/notify")) as {
+          const response = (yield* postJsonThroughIamPropagation(
+            "/notify",
+          )) as {
             ok: boolean;
             error: string | undefined;
             message: string | undefined;

--- a/packages/alchemy/test/Cloudflare/AI/QuerySearchLocal.test.ts
+++ b/packages/alchemy/test/Cloudflare/AI/QuerySearchLocal.test.ts
@@ -52,8 +52,10 @@ test.provider(
             source: target.url.as<string>(),
             sourceParams: {
               webCrawler: {
-                parseType: "crawl",
-                crawlOptions: { source: "links" },
+                // Cloudflare renamed `crawl` → `discover` and removed
+                // `crawlOptions` from the API. The fixture serves a
+                // sitemap, so discovery always finds content.
+                parseType: "discover",
               },
             },
           });

--- a/packages/alchemy/test/Cloudflare/AI/QuerySearchNamespaceLocal.test.ts
+++ b/packages/alchemy/test/Cloudflare/AI/QuerySearchNamespaceLocal.test.ts
@@ -57,8 +57,10 @@ test.provider(
             namespace: namespace.name,
             sourceParams: {
               webCrawler: {
-                parseType: "crawl",
-                crawlOptions: { source: "links" },
+                // Cloudflare renamed `crawl` → `discover` and removed
+                // `crawlOptions` from the API. The fixture serves a
+                // sitemap, so discovery always finds content.
+                parseType: "discover",
               },
             },
           });

--- a/packages/alchemy/test/Cloudflare/AI/Search.test.ts
+++ b/packages/alchemy/test/Cloudflare/AI/Search.test.ts
@@ -113,22 +113,21 @@ test.provider(
 // A web-crawler source crawls a seed URL and needs no service token, so the
 // construct must NOT mint an AccountApiToken / AiSearchToken — `token` comes
 // back undefined. Cloudflare only crawls a domain the account owns, so the
-// crawl is seeded at a Worker we deploy (its `workers.dev` URL is owned by the
-// account); `parseType: "crawl"` walks pages instead of requiring a sitemap.
+// crawl is seeded at a Worker we deploy (its `workers.dev` URL is owned by
+// the account); the fixture serves a sitemap so `parseType: "discover"`
+// always finds content.
 const crawlerProgram = () =>
   Effect.gen(function* () {
     const target = yield* AiSearchCrawlTargetWorker;
-    // Exercise the flattened source groups end-to-end: `parse` (parseType +
-    // parse options) and `crawl` (link-discovery options) must translate into
-    // the distilled `sourceParams.webCrawler.{parseType,parseOptions,crawlOptions}`.
+    // Exercise the flattened source group end-to-end: `parse` (parseType +
+    // parse options) must translate into the distilled
+    // `sourceParams.webCrawler.{parseType,parseOptions}`.
     const search = yield* Cloudflare.AI.Search("Search", {
       source: target.url.as<string>(),
-      parse: { type: "crawl", useBrowserRendering: false },
-      // Discover URLs by following links only. Without `source: "links"`,
-      // crawl link-discovery also reads the seed's sitemap, and a
-      // freshly-deployed `workers.dev` URL serves none — Cloudflare rejects
-      // the create with `missing_sitemap`.
-      crawl: { depth: 2, includeSubdomains: false, source: "links" },
+      // Cloudflare renamed the `crawl` parse type to `discover` and removed
+      // crawl options from the API. The fixture serves a sitemap, so
+      // discovery always finds content.
+      parse: { type: "discover", useBrowserRendering: false },
     });
     return { target, search, serviceToken: search.serviceToken };
   });

--- a/packages/alchemy/test/Cloudflare/AI/SearchInstance.test.ts
+++ b/packages/alchemy/test/Cloudflare/AI/SearchInstance.test.ts
@@ -262,7 +262,7 @@ test.provider(
 // A web-crawler source crawls a seed URL and needs no service token (unlike
 // an R2 source). Cloudflare only crawls a domain the account owns, so the
 // crawl is seeded at a Worker we deploy (its `workers.dev` URL is owned by the
-// account); `parseType: "crawl"` walks pages instead of requiring a sitemap.
+// account); the fixture serves a sitemap so discovery always finds content.
 test.provider(
   "creates a web-crawler instance (no service token)",
   (stack) =>
@@ -300,12 +300,10 @@ test.provider(
             source: target.url.as<string>(),
             sourceParams: {
               webCrawler: {
-                parseType: "crawl",
-                // Discover URLs by following links only. Without this,
-                // crawl link-discovery defaults to also reading the seed's
-                // sitemap, and a freshly-deployed `workers.dev` URL serves
-                // none — Cloudflare rejects the create with `missing_sitemap`.
-                crawlOptions: { source: "links" },
+                // Cloudflare renamed `crawl` → `discover` and removed
+                // `crawlOptions` from the API. The fixture serves a
+                // sitemap, so discovery always finds content.
+                parseType: "discover",
               },
             },
           });

--- a/packages/alchemy/test/Cloudflare/Container/fixtures/effectful/container.ts
+++ b/packages/alchemy/test/Cloudflare/Container/fixtures/effectful/container.ts
@@ -1,4 +1,5 @@
 import * as Cloudflare from "@/Cloudflare";
+import * as Alchemy from "@/index.ts";
 import type { RuntimeContext } from "@/RuntimeContext.ts";
 import * as Effect from "effect/Effect";
 import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
@@ -24,8 +25,15 @@ export default MyContainer.make(
   Effect.gen(function* () {
     // The container reads R2 over a scoped HTTP API token (not the native
     // Worker binding) — this proves the HTTP R2 client works from inside a
-    // container process.
-    const bucket = yield* Cloudflare.R2.ReadWriteBucket(Storage);
+    // container process. `Alchemy.remote()` pins the bucket (and the minted
+    // token) live even under `alchemy dev`: the HTTP client talks to real
+    // Cloudflare, which a `dev:` local bucket can't serve. This is the
+    // FIRST registration site (the container layer builds before the stack
+    // body), so the DO's later undecorated native-binding site inherits the
+    // pin and both paths converge on the same live bucket.
+    const bucket = yield* Cloudflare.R2.ReadWriteBucket(Storage).pipe(
+      Alchemy.remote(),
+    );
 
     const read = (key: string) =>
       bucket.get(key).pipe(

--- a/packages/alchemy/test/Cloudflare/Email/EmailAddress.test.ts
+++ b/packages/alchemy/test/Cloudflare/Email/EmailAddress.test.ts
@@ -1,5 +1,6 @@
 import * as Cloudflare from "@/Cloudflare";
 import * as Provider from "@/Provider";
+import * as RemovalPolicy from "@/RemovalPolicy";
 import * as Test from "@/Test/Alchemy";
 import { poll } from "@/Util/poll.ts";
 import { expect } from "alchemy-test";
@@ -14,10 +15,17 @@ const logLevel = Effect.provideService(
   process.env.DEBUG ? "Debug" : "Info",
 );
 
-// A deterministic destination address used for the list test. Cloudflare
-// sends a verification email on first create; the address still shows up in
-// the account-scoped list whether or not it has been verified, which is all
-// the list() assertion needs.
+// A deterministic STANDING destination address used for the list test.
+// Cloudflare sends a verification email on first create; the address still
+// shows up in the account-scoped list whether or not it has been verified,
+// which is all the list() assertion needs.
+//
+// The address is retained (never deleted): Cloudflare refuses to delete a
+// destination address for ~15 minutes after creation
+// (`EmailAddressCreatedTooRecently`, code 2032), so create-and-destroy
+// within one test run is impossible. The provider's reconcile adopts the
+// standing address by email on every subsequent run, and `scripts/nuke.sh`
+// excludes it from the leak census like the standing test zone.
 const testEmail = "alchemy-list-test@alchemy-test-2.us";
 
 // Canonical `list()` test (account-scoped collection): register a real
@@ -32,7 +40,7 @@ test.provider("list enumerates the deployed email address", (stack) =>
       Effect.gen(function* () {
         return yield* Cloudflare.Email.Address("ListAddress", {
           email: testEmail,
-        });
+        }).pipe(RemovalPolicy.retain());
       }),
     );
 

--- a/packages/alchemy/test/Cloudflare/Queue/Queue.test.ts
+++ b/packages/alchemy/test/Cloudflare/Queue/Queue.test.ts
@@ -25,7 +25,8 @@ const logLevel = Effect.provideService(
 /**
  * Seed a `created` Queue state row whose `queueId` is a `dev:` mock id —
  * i.e. the shape `alchemy dev` persists when a queue is "created" locally
- * against the in-memory local runtime instead of Cloudflare.
+ * against the in-memory local runtime instead of Cloudflare. Dev runs stamp
+ * `providerMode: "local"` on every commit, so the seeded row carries it.
  */
 const seedDevQueue = (input: {
   stackName: string;
@@ -49,6 +50,7 @@ const seedDevQueue = (input: {
         logicalId: input.fqn,
         instanceId: "00000000000000000000000000000001",
         providerVersion: 0,
+        providerMode: "local",
         bindings: [],
         downstream: [],
         props: {},
@@ -66,9 +68,10 @@ const seedDevQueue = (input: {
  * is a `dev:` mock id) must be promoted to a real Cloudflare queue on the
  * first live deploy.
  *
- * The live provider's `diff` sees the `dev:` id and returns `update`
- * (rather than `noop`/`replace`), so the engine calls `reconcile`, which
- * observes that the cached id is not a real queue and creates one. The
+ * The row is stamped `providerMode: "local"`, which differs from the
+ * deploy's resolved mode (`live`), so the engine plans a REPLACEMENT: the
+ * live provider creates a real queue and the old local-mode generation is
+ * deleted via the local provider (no cloud call for the `dev:` id). The
  * resulting `queueId` must be a live id and resolvable on Cloudflare.
  */
 test.provider("promotes a dev queue to a live queue on deploy", (stack) =>
@@ -174,8 +177,9 @@ test.provider("list enumerates the deployed queue", (stack) =>
  * persisted `queueId` is a `dev:` mock id) has no Cloudflare counterpart.
  * Destroying it must NOT issue a `deleteQueue` against Cloudflare — the
  * `dev:` id is not a valid queue id and the request URL would be
- * malformed. The live provider's `delete` short-circuits on the non-live
- * id, so destroy succeeds and the state row is removed cleanly.
+ * malformed. The row is stamped `providerMode: "local"`, so the engine
+ * resolves the LOCAL provider's `delete` for it (an in-memory registry
+ * removal), and destroy succeeds with the state row removed cleanly.
  */
 test.provider("suppresses deletion of a dev-only queue", (stack) =>
   Effect.gen(function* () {

--- a/packages/alchemy/test/Cloudflare/Website/Vite.test.ts
+++ b/packages/alchemy/test/Cloudflare/Website/Vite.test.ts
@@ -1,5 +1,6 @@
 import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
 import * as Cloudflare from "@/Cloudflare/index.ts";
+import { isLocalId } from "@/Cloudflare/LocalRuntime";
 import * as Test from "@/Test/Alchemy";
 import * as r2 from "@distilled.cloud/cloudflare/r2";
 import { expect } from "alchemy-test";
@@ -1104,6 +1105,9 @@ const waitForBucketToBeDeleted = Effect.fn(function* (
   bucketName: string,
   accountId: string,
 ) {
+  // Dev-mode buckets are purely virtual (`dev:`-prefixed identity) — there
+  // is no cloud bucket to wait on, and the real API rejects the name.
+  if (isLocalId(bucketName)) return;
   yield* r2
     .getBucket({
       accountId,

--- a/packages/alchemy/test/Command/Build.test.ts
+++ b/packages/alchemy/test/Command/Build.test.ts
@@ -186,13 +186,20 @@ test.provider(
       yield* fs.writeFileString(siblingFile, 'export const value = "a";\n');
 
       const outputFile = pathe.join(appDir, "dist", "output.txt");
+      // Exclude `dist` from the memo hash: build.sh stamps `dist/output.txt`
+      // with $(date) (the test's rebuild detector), and the temp fixture has
+      // no .gitignore to filter it. With dist hashed, two rebuilds straddling
+      // a wall-clock second boundary would produce different "input" hashes.
       const deploy = () =>
         stack.deploy(
           Command.Build("test-build", {
             command: "bash build.sh",
             cwd: appDir,
             outdir: "dist",
-            memo: { include: ["**/*", "../packages/env/**"] },
+            memo: {
+              include: ["**/*", "../packages/env/**"],
+              exclude: ["dist/**"],
+            },
           }),
         );
 
@@ -222,6 +229,7 @@ test.provider(
           outdir: "dist",
           memo: {
             include: ["**/*", pathe.join(siblingDir, "**")],
+            exclude: ["dist/**"],
           },
         }),
       );

--- a/packages/alchemy/test/Drizzle/Schema.test.ts
+++ b/packages/alchemy/test/Drizzle/Schema.test.ts
@@ -59,7 +59,15 @@ const stageWorkspace = (initialSource: string) =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
+    // Stage inside the repo (not the OS temp dir): the schema module is
+    // loaded via dynamic `import()`, and bun resolves its bare
+    // `drizzle-orm/*` imports by walking up from the schema file — which
+    // only finds `node_modules` when the staging dir lives in the workspace.
+    const cwd = yield* Effect.sync(() => process.cwd());
+    const tempParent = path.join(cwd, ".alchemy", "tmp");
+    yield* fs.makeDirectory(tempParent, { recursive: true });
     const root = yield* fs.makeTempDirectory({
+      directory: tempParent,
       prefix: "alchemy-drizzle-schema-test-",
     });
     const schemaPath = path.join(root, "schema.ts");

--- a/scripts/nuke.sh
+++ b/scripts/nuke.sh
@@ -1,10 +1,20 @@
 # AWS.BackupSearch.SearchJob: AWS retains search-job records ~7 days; no delete API
+# Cloudflare.Cache.RegionalTieredCache / Cloudflare.Logs.RetentionFlag: zone-singleton
+# settings that always exist on entitled zones — delete restores the pre-management
+# value (a no-op when enumerated), so the census would flag them forever.
+# Cloudflare.AI.Gateway "default": auto-provisioned by Cloudflare when an AI Search
+# instance is created; recreated on demand, so deleting it just churns.
+# Cloudflare.Email.Address alchemy-list-test@: standing test address — Cloudflare
+# refuses to delete an address for ~15 min after creation (code 2032), so the
+# EmailAddress test retains and re-adopts it instead of create/destroy churn.
 bun alchemy unsafe nuke ./stacks/nuke.ts  \
   --exclude 'AWS.BackupSearch.SearchJob' \
   --exclude 'Cloudflare.Zone*' \
   --exclude 'Cloudflare.Account*' \
   --exclude 'Cloudflare.DNS*' \
   --exclude 'Cloudflare.Ssl.UniversalSsl' \
+  --exclude 'Cloudflare.Cache.RegionalTieredCache' \
+  --exclude 'Cloudflare.Logs.RetentionFlag' \
   --exclude 'Cloudflare.ApiToken.*' \
   --exclude 'Cloudflare.Secret*' \
   --exclude 'Cloudflare.Organization.*' \
@@ -28,5 +38,7 @@ bun alchemy unsafe nuke ./stacks/nuke.ts  \
   --filter 'resource.Type === "AWS.IAM.Role" && (["alchemy-github-actions", "distilled-github-oidc-role"].includes(resource.roleName) || resource.roleName?.startsWith("AWSReservedSSO"))' \
   --filter 'resource.Type === "AWS.S3.Bucket" && (String(resource.bucketName).startsWith("alchemy-state") || String(resource.bucketName).startsWith("alchemy-assets"))' \
   --filter 'typeof resource.name === "string" && (resource.name.startsWith("DO-NOT-DELETE") || resource.name.startsWith("AppConfig.") || resource.name.startsWith("system_") || ["primary","AwsDataCatalog","DefaultConfiguration","Default","default","open-access","default.dax1.0"].includes(resource.name))' \
+  --filter 'resource.Type === "Cloudflare.AI.Gateway" && resource.gatewayId === "default"' \
+  --filter 'resource.Type === "Cloudflare.Email.Address" && resource.email === "alchemy-list-test@alchemy-test-2.us"' \
   --filter 'String(resource.logGroupName).startsWith("/aws/vendedlogs/b2bi/")' \
   "$@"


### PR DESCRIPTION
Release-prep convergence over the full live suite (5,269 tests, GitHub suites excluded — auth unavailable). Every failure class from five full-suite rounds was root-caused; runs 2 and 4 finished with the account census fully clean, and the remaining rounds' failures each traced to a fix below or to environment loss (a machine reboot mid-run, an expired AWS SSO session).

### Provider fixes

- **CostExplorer** — bounded throttle retry inside `pinCe` (`LimitExceededException: Rate limit exceeded`; CE's rate limits are tiny and account-wide, concurrent deploys trip them)
- **EC2 `Vpc`** — bounded ~90s retry on `VpcLimitExceeded`: ~40 suites share the 5-per-region quota and transient bursts exceed it while siblings tear down
- **ApiGateway** — `deleteRestApi` is quota-limited to ~1 request/30s account-wide; deletes are now serialized process-wide so concurrent destroys queue on the quota window instead of each other's retry budgets
- **DataSync `Task`** — retry the typed `LocationAccessTestFailed` through the location role's IAM-propagation window
- **Tunnel** — delete was `Effect.catch(() => Effect.void)`; a transiently rejected delete silently leaked the tunnel. Now observe-first + bounded retry that fails loudly
- **Email `Address`** — same swallow-everything delete; now idempotent on typed `EmailAddressNotFound` and fails fast on `EmailAddressCreatedTooRecently` (Cloudflare refuses deletes for ~15 min after creation)
- **`Ruleset`** — destroy now deletes the phase entrypoint (emptying rules left an inert-but-listed entrypoint on the zone forever); `list` skips empty entrypoints (what Worker redirect cleanup legitimately leaves behind)
- **Flagship `App`** — `list` validates rows via `getApp` and drops Cloudflare-side ghosts (listed forever but GET/DELETE return "App not found")
- **RUM `Site`** — the zone-identity adoption probe only matches true zone sites; host sites on the zone's subdomains also carry `ruleset.zoneTag` and previously satisfied it, producing spurious `OwnedBySomeoneElse`
- **AI Search** — Cloudflare renamed the `crawl` parse type to `discover`, removed `feed-rss`, and removed `crawlOptions` entirely (verified against the live API); the deprecated `crawl` prop is removed from the `Search` construct

### Test/harness fixes

- Queue dev promotion/suppression tests seed rows stamped `providerMode: "local"` (post-#963 engine semantics)
- Drizzle Schema tests stage their workspace inside the repo — bun 1.3.13 can't resolve `drizzle-orm` from the OS temp dir
- ECS scaling test runs in the default VPC (its hand-rolled VPC had no IGW, so Fargate could never pull the image once the provider gained a stabilization wait)
- Container dev fixture pins its bucket live (`Alchemy.remote()`): the container reads R2 over the token-scoped HTTP API, which a `dev:` local bucket can't serve
- Vite dev cleanup skips cloud polling for `dev:` bucket identities
- DataExchange bindings retry fixture routes through the IAM propagation window
- Build memo test excludes the `$(date)`-stamped `dist` from the input hash (second-boundary flake)
- EmailAddress list test retains a standing address and re-adopts it per run (the ~15 min delete cooldown makes create-and-destroy impossible in one test)

### Leak census (`scripts/nuke.sh`)

Excludes resources that would otherwise be flagged forever: the zone-singleton settings (`RegionalTieredCache`, `RetentionFlag`, whose delete restores the pre-management value), the `default` AI Gateway Cloudflare auto-provisions for AI Search, and the standing test email address.

### distilled

Bumps the submodule to [alchemy-run/distilled#392](https://github.com/alchemy-run/distilled/pull/392): typed `LocationAccessTestFailed` on `createTask`, `EmailAddressNotFound`/`EmailAddressCreatedTooRecently` on `deleteAddress`, `RumSiteQuotaExceeded` on `createSiteInfo`, and code-less 5xx responses (raw HTML 502/504 from AWS front-end proxies) surfacing as the retryable `InternalError` instead of an unretryable `ParseError`.
