### PR TITLE
feat(cloudflare/workers): derive durable object exports

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/DurableObject.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/DurableObject.ts
@@ -230,9 +230,9 @@ export interface DurableObjectProps {
   scriptName?: Input<string> | undefined;
   /**
    * The Worker(s) that previously hosted this Durable Object class. When one
-   * of them still holds the namespace, the deploy performs Cloudflare's
-   * data-preserving `transferred_classes` migration, moving the namespace —
-   * including all stored objects — from that script to this Worker.
+   * of them still holds the namespace, Alchemy coordinates Cloudflare's
+   * declarative transfer flow, moving the namespace, including all stored
+   * objects, from that script to this Worker.
    *
    * Each entry names a former host — see
    * {@link DurableObjectTransferSource} for the accepted forms: a string
@@ -913,7 +913,7 @@ export class DurableObjectScope extends Context.Service<
  * set to the host Worker's script name.
  *
  * Cross-script async bindings are references only: the consumer uploads
- * the binding metadata, but Alchemy does not drive class migrations for
+ * the binding metadata, but Alchemy does not manage class lifecycle for
  * the foreign class. Deploy the host first so Cloudflare can verify that
  * the target script exports the requested class.
  *
@@ -981,10 +981,9 @@ export class DurableObjectScope extends Context.Service<
  * "transfer the data" and "delete it, start fresh", so Alchemy never
  * guesses (removing a DO deletes it; that is the default). Declare
  * `transferredFrom` on the Durable Object at its **new host**, naming the
- * former host, and the new host's deploy ships Cloudflare's
- * data-preserving `transferred_classes` migration. The former host's
- * deploy converges on its own — no delete migration is emitted for a
- * class that moved away.
+ * former host. Cloudflare coordinates this through declarative exports: the
+ * target records an expected transfer and the source commits it. Deploy the
+ * same desired stack a second time to activate the target's local binding.
  *
  * Each `transferredFrom` entry is either the former host's Worker
  * **logical id** (same stack + stage, resolved via alchemy's ownership
@@ -1042,13 +1041,11 @@ export class DurableObjectScope extends Context.Service<
  * })
  * ```
  *
- * Two rules for multi-worker migrations:
+ * Two rules for multi-worker transfers:
  *
- * - **Pure moves (the former host drops the DO entirely, keeping no
- *   cross-script reference) must be two deploys**: first add the class to
- *   the new host with `transferredFrom` and deploy; then remove it from
- *   the former host and deploy. In a single deploy nothing orders the
- *   transfer before the former host's delete.
+ * - **Moves converge over two deploys**: the first coordinates the target
+ *   expectation and source commit. The second activates the target binding.
+ *   For a pure move, remove the former host only after that second deploy.
  * - **Cross-stack moves deploy the new host's stack first**, naming the
  *   former host by physical script name; the former host's stack deploys
  *   after and converges.
@@ -1067,7 +1064,7 @@ export class DurableObjectScope extends Context.Service<
  * foreign worker has no such tag, so on the **adopting deploy** Alchemy
  * falls back to matching your binding to the live class **by binding
  * name**. The class is then reused in place — not recreated — so
- * Cloudflare's migration engine doesn't reject the upload for creating a
+ * Cloudflare's export reconciler doesn't reject the upload for creating a
  * class that already exists.
  *
  * The consequence is a one-time constraint: **on the adopting deploy the
@@ -1209,7 +1206,7 @@ export const DurableObject: DurableObjectClass = taggedFunction(
 
     // Class-form declarations (`DurableObject<Self>()("Name", props?)`) can
     // carry `transferredFrom` so the host's local binding drives a
-    // data-preserving transfer migration.
+    // data-preserving declarative transfer.
     const classProps =
       isClassForm && !Effect.isEffect(propsOrImpl)
         ? (propsOrImpl as
@@ -1310,9 +1307,9 @@ export const DurableObject: DurableObjectClass = taggedFunction(
           //   1) Track WorkerB → WorkerA as a binding-level upstream
           //      dependency (so WorkerA reconciles first).
           //   2) Persist `scriptName` as a real value (not `undefined`)
-          //      on the cross-script binding so the migration code in
+          //      on the cross-script binding so the lifecycle code in
           //      Worker.ts can detect it and skip emitting class
-          //      migrations for the foreign class.
+          //      changes for the foreign class.
           // Plain Effects and string literals are passed through as-is.
           const resolved: Effect.Effect<Worker | string, any, any> =
             typeof worker === "string"

--- a/packages/alchemy/src/Cloudflare/Workers/DurableObjectExportTags.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/DurableObjectExportTags.ts
@@ -1,8 +1,12 @@
 import type { DurableObjectExportState } from "@/Cloudflare/Workers/DurableObjectExports";
 import type * as workers from "@distilled.cloud/cloudflare/workers";
 
+const LEGACY_MAPPING_TAG_PREFIX = "alchemy:do:";
+const MAPPING_TAG_PREFIX = "alchemy:dos:";
 const EXPORT_TAG_PREFIX = "alchemy:doe:";
-const MAX_TAG_BYTES = 1024;
+
+/** Cloudflare rejects Worker tags larger than 1,024 bytes. */
+export const MAX_WORKER_TAG_BYTES = 1024;
 
 const encode = encodeURIComponent;
 
@@ -23,23 +27,69 @@ const isStorage = (value: unknown): value is "sqlite" | "legacy-kv" =>
 const decodeStorage = (value: string) =>
   value === "s" ? "sqlite" : value === "k" ? "legacy-kv" : undefined;
 
-const packRecords = (records: readonly string[]): string[] => {
+const packRecords = (prefix: string, records: readonly string[]): string[] => {
   const tags: string[] = [];
   let payload = "";
   for (const record of records) {
     const appended = payload === "" ? record : `${payload};${record}`;
     if (
-      EXPORT_TAG_PREFIX.length + appended.length > MAX_TAG_BYTES &&
+      prefix.length + appended.length > MAX_WORKER_TAG_BYTES &&
       payload !== ""
     ) {
-      tags.push(`${EXPORT_TAG_PREFIX}${payload}`);
+      tags.push(`${prefix}${payload}`);
       payload = record;
     } else {
       payload = appended;
     }
   }
-  if (payload !== "") tags.push(`${EXPORT_TAG_PREFIX}${payload}`);
+  if (payload !== "") tags.push(`${prefix}${payload}`);
   return tags;
+};
+
+/** Pack logical-id to class mappings into bounded Worker tags. */
+export const encodeDurableObjectTags = (
+  durableObjects: ReadonlyArray<{ logicalId: string; className: string }>,
+): string[] =>
+  packRecords(
+    MAPPING_TAG_PREFIX,
+    [...durableObjects]
+      .sort((left, right) => left.logicalId.localeCompare(right.logicalId))
+      .map(({ logicalId, className }) =>
+        logicalId === className
+          ? encode(className)
+          : `${encode(logicalId)}=${encode(className)}`,
+      ),
+  );
+
+/** Parse both current packed mappings and the legacy per-object format. */
+export const getDurableObjectTagMap = (
+  tags: readonly string[],
+): Record<string, string> => {
+  const mapping: Record<string, string> = {};
+  for (const tag of tags) {
+    if (!tag.startsWith(LEGACY_MAPPING_TAG_PREFIX)) continue;
+    const parts = tag.split(":");
+    const logicalId = parts[2];
+    const className = parts.slice(3).join(":");
+    if (logicalId && className && !(logicalId in mapping)) {
+      mapping[logicalId] = className;
+    }
+  }
+  for (const tag of tags) {
+    if (!tag.startsWith(MAPPING_TAG_PREFIX)) continue;
+    for (const pair of tag.slice(MAPPING_TAG_PREFIX.length).split(";")) {
+      if (pair === "") continue;
+      const separator = pair.indexOf("=");
+      const logicalId = decode(
+        separator === -1 ? pair : pair.slice(0, separator),
+      );
+      const className = decode(
+        separator === -1 ? pair : pair.slice(separator + 1),
+      );
+      if (logicalId && className) mapping[logicalId] = className;
+    }
+  }
+  return mapping;
 };
 
 /**
@@ -85,7 +135,7 @@ export const encodeDurableObjectExportTags = (
     records.push(`l:${encodedClassName}:${storageCode(storage)}${container}`);
   }
 
-  return packRecords(records);
+  return packRecords(EXPORT_TAG_PREFIX, records);
 };
 
 /** Read a previously submitted export contract from live Worker tags. */
@@ -151,9 +201,16 @@ export const getDurableObjectExportStateFromTags = (
   return Object.keys(tombstones).length > 0 ||
     Object.keys(pendingTransfers).length > 0 ||
     Object.keys(storageByClass).length > 0
-    ? { tombstones, pendingTransfers, storageByClass }
+    ? {
+        tombstones,
+        pendingTransfers,
+        storageByClass,
+        cleanupClassNames: [],
+      }
     : undefined;
 };
 
-export const isDurableObjectExportTag = (tag: string): boolean =>
+export const isDurableObjectTag = (tag: string): boolean =>
+  tag.startsWith(LEGACY_MAPPING_TAG_PREFIX) ||
+  tag.startsWith(MAPPING_TAG_PREFIX) ||
   tag.startsWith(EXPORT_TAG_PREFIX);

--- a/packages/alchemy/src/Cloudflare/Workers/DurableObjectExportTags.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/DurableObjectExportTags.ts
@@ -1,0 +1,159 @@
+import type { DurableObjectExportState } from "@/Cloudflare/Workers/DurableObjectExports";
+import type * as workers from "@distilled.cloud/cloudflare/workers";
+
+const EXPORT_TAG_PREFIX = "alchemy:doe:";
+const MAX_TAG_BYTES = 1024;
+
+const encode = encodeURIComponent;
+
+const decode = (value: string): string | undefined => {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return undefined;
+  }
+};
+
+const storageCode = (storage: "sqlite" | "legacy-kv") =>
+  storage === "sqlite" ? "s" : "k";
+
+const isStorage = (value: unknown): value is "sqlite" | "legacy-kv" =>
+  value === "sqlite" || value === "legacy-kv";
+
+const decodeStorage = (value: string) =>
+  value === "s" ? "sqlite" : value === "k" ? "legacy-kv" : undefined;
+
+const packRecords = (records: readonly string[]): string[] => {
+  const tags: string[] = [];
+  let payload = "";
+  for (const record of records) {
+    const appended = payload === "" ? record : `${payload};${record}`;
+    if (
+      EXPORT_TAG_PREFIX.length + appended.length > MAX_TAG_BYTES &&
+      payload !== ""
+    ) {
+      tags.push(`${EXPORT_TAG_PREFIX}${payload}`);
+      payload = record;
+    } else {
+      payload = appended;
+    }
+  }
+  if (payload !== "") tags.push(`${EXPORT_TAG_PREFIX}${payload}`);
+  return tags;
+};
+
+/**
+ * Persist the submitted Durable Object export contract in the same Worker
+ * upload as the contract itself. This makes retries recoverable even when
+ * Cloudflare's settings response omits its documented `exports` field.
+ */
+export const encodeDurableObjectExportTags = (
+  submitted: workers.PutScriptExports | undefined,
+): string[] => {
+  if (submitted === undefined) return [];
+  const records: string[] = [];
+
+  for (const [className, entry] of Object.entries(submitted).sort(
+    ([left], [right]) => left.localeCompare(right),
+  )) {
+    if (entry === undefined || entry.type !== "durable-object") continue;
+    const encodedClassName = encode(className);
+    if (entry.state === "deleted") {
+      records.push(`d:${encodedClassName}`);
+      continue;
+    }
+    if (entry.state === "renamed" && "renamedTo" in entry) {
+      records.push(`r:${encodedClassName}:${encode(entry.renamedTo)}`);
+      continue;
+    }
+    if (entry.state === "transferred" && "transferredTo" in entry) {
+      records.push(`t:${encodedClassName}:${encode(entry.transferredTo)}`);
+      continue;
+    }
+    if (!("storage" in entry) || !isStorage(entry.storage)) continue;
+    const storage = entry.storage;
+    const container =
+      "container" in entry && typeof entry.container === "string"
+        ? `:${encode(entry.container)}`
+        : "";
+    if (entry.state === "expecting-transfer" && "transferFrom" in entry) {
+      records.push(
+        `p:${encodedClassName}:${storageCode(storage)}:${encode(entry.transferFrom)}${container}`,
+      );
+      continue;
+    }
+    records.push(`l:${encodedClassName}:${storageCode(storage)}${container}`);
+  }
+
+  return packRecords(records);
+};
+
+/** Read a previously submitted export contract from live Worker tags. */
+export const getDurableObjectExportStateFromTags = (
+  tags: readonly string[],
+): DurableObjectExportState | undefined => {
+  const tombstones: DurableObjectExportState["tombstones"] = {};
+  const pendingTransfers: DurableObjectExportState["pendingTransfers"] = {};
+  const storageByClass: DurableObjectExportState["storageByClass"] = {};
+
+  for (const tag of tags) {
+    if (!tag.startsWith(EXPORT_TAG_PREFIX)) continue;
+    const payload = tag.slice(EXPORT_TAG_PREFIX.length);
+    for (const record of payload.split(";")) {
+      const [kind, encodedClassName, value, source, encodedContainer] =
+        record.split(":");
+      const className =
+        encodedClassName === undefined ? undefined : decode(encodedClassName);
+      if (className === undefined || className === "") continue;
+
+      if (kind === "d") {
+        tombstones[className] = { type: "durable-object", state: "deleted" };
+        continue;
+      }
+      if (kind === "r" || kind === "t") {
+        const target = value === undefined ? undefined : decode(value);
+        if (target === undefined || target === "") continue;
+        tombstones[className] =
+          kind === "r"
+            ? {
+                type: "durable-object",
+                state: "renamed",
+                renamedTo: target,
+              }
+            : {
+                type: "durable-object",
+                state: "transferred",
+                transferredTo: target,
+              };
+        continue;
+      }
+      if (kind !== "l" && kind !== "p") continue;
+      const storage = value === undefined ? undefined : decodeStorage(value);
+      if (storage === undefined) continue;
+
+      if (kind === "p") {
+        const transferFrom = source === undefined ? undefined : decode(source);
+        const container =
+          encodedContainer === undefined ? undefined : decode(encodedContainer);
+        if (transferFrom === undefined || transferFrom === "") continue;
+        storageByClass[className] = storage;
+        pendingTransfers[className] = {
+          transferFrom,
+          storage,
+          ...(container === undefined || container === "" ? {} : { container }),
+        };
+      } else {
+        storageByClass[className] = storage;
+      }
+    }
+  }
+
+  return Object.keys(tombstones).length > 0 ||
+    Object.keys(pendingTransfers).length > 0 ||
+    Object.keys(storageByClass).length > 0
+    ? { tombstones, pendingTransfers, storageByClass }
+    : undefined;
+};
+
+export const isDurableObjectExportTag = (tag: string): boolean =>
+  tag.startsWith(EXPORT_TAG_PREFIX);

--- a/packages/alchemy/src/Cloudflare/Workers/DurableObjectExports.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/DurableObjectExports.ts
@@ -1,4 +1,6 @@
 import type * as workers from "@distilled.cloud/cloudflare/workers";
+import * as Data from "effect/Data";
+import * as Predicate from "effect/Predicate";
 
 export type DurableObjectStorage = "sqlite" | "legacy-kv";
 
@@ -18,9 +20,16 @@ export type DurableObjectTombstone =
       transferredTo: string;
     };
 
+export interface DurableObjectPendingTransfer {
+  transferFrom: string;
+  storage: DurableObjectStorage;
+  container?: string;
+}
+
 export interface DurableObjectExportState {
   tombstones: Record<string, DurableObjectTombstone>;
-  pendingTransfers: string[];
+  pendingTransfers: Record<string, DurableObjectPendingTransfer>;
+  storageByClass: Record<string, DurableObjectStorage>;
 }
 
 export interface DurableObjectNamespace {
@@ -29,41 +38,235 @@ export interface DurableObjectNamespace {
   storage: DurableObjectStorage;
 }
 
-export interface DurableObjectExportClass {
+export interface DurableObjectClassObservation {
   className: string;
   previousClassName?: string;
   transferFrom?: string;
-  storage?: DurableObjectStorage;
 }
 
-export interface BuildDurableObjectExportsInput {
+export type DurableObjectRetirement =
+  | { kind: "deleted" }
+  | { kind: "transferred"; transferredTo: string };
+
+export type DurableObjectExportDirective =
+  | {
+      kind: "live";
+      storage: DurableObjectStorage;
+      container?: string;
+      changed: boolean;
+    }
+  | {
+      kind: "deleted";
+    }
+  | {
+      kind: "renamed";
+      renamedTo: string;
+    }
+  | {
+      kind: "transferred";
+      transferredTo: string;
+    }
+  | {
+      kind: "expecting-transfer";
+      transferFrom: string;
+      storage: DurableObjectStorage;
+      container?: string;
+    };
+
+export interface PlanDurableObjectExportsInput {
   scriptName: string;
-  classes: readonly DurableObjectExportClass[];
-  deletedClasses: readonly string[];
-  transferredClasses: ReadonlyArray<{
-    className: string;
-    transferredTo: string;
-  }>;
+  classes: readonly DurableObjectClassObservation[];
+  retirements: Readonly<Record<string, DurableObjectRetirement>>;
   containerClassNames: ReadonlySet<string>;
   namespaces: readonly DurableObjectNamespace[];
+  observedStorageByClass: Readonly<Record<string, DurableObjectStorage>>;
+  observedPendingTransfers: Readonly<
+    Record<string, DurableObjectPendingTransfer>
+  >;
   previousState?: DurableObjectExportState;
 }
 
 export interface DurableObjectExportPlan {
   exports: workers.PutScriptExports | undefined;
   changedClasses: string[];
+  omittedBindingClassNames: ReadonlySet<string>;
 }
+
+export class DurableObjectStorageUnknown extends Data.TaggedError(
+  "DurableObjectStorageUnknown",
+)<{
+  scriptName: string;
+  className: string;
+}> {
+  override get message() {
+    return `Durable Object class '${this.className}' already exists on Worker '${this.scriptName}', but Cloudflare did not report whether its immutable storage backend is SQLite or legacy KV. Alchemy did not upload a guessed storage value. Retry after the Worker settings API reports the class export, or declare the class with a Cloudflare client that can preserve its current storage backend.`;
+  }
+}
+
+export class ConflictingDurableObjectExports extends Data.TaggedError(
+  "ConflictingDurableObjectExports",
+)<{
+  scriptName: string;
+  className: string;
+  current: DurableObjectExportDirective;
+  next: DurableObjectExportDirective;
+}> {
+  override get message() {
+    return `Durable Object class '${this.className}' has conflicting lifecycle declarations on Worker '${this.scriptName}'. Give each hosted class one lifecycle identity before deploying.`;
+  }
+}
+
+export type DurableObjectExportPlanResult =
+  | { _tag: "Success"; plan: DurableObjectExportPlan }
+  | {
+      _tag: "Failure";
+      error: DurableObjectStorageUnknown | ConflictingDurableObjectExports;
+    };
+
+export interface ObservedDurableObjectExports {
+  storageByClass: Record<string, DurableObjectStorage>;
+  pendingTransfers: Record<string, DurableObjectPendingTransfer>;
+}
+
+const isStorage = (value: unknown): value is DurableObjectStorage =>
+  value === "sqlite" || value === "legacy-kv";
+
+const stringMember = (value: unknown, key: string): string | undefined =>
+  Predicate.hasProperty(value, key) && typeof value[key] === "string"
+    ? value[key]
+    : undefined;
+
+const stringArrayMember = (value: unknown, key: string): string[] =>
+  Predicate.hasProperty(value, key) && Array.isArray(value[key])
+    ? value[key].filter((item): item is string => typeof item === "string")
+    : [];
+
+const objectEntries = (value: unknown): Array<[string, unknown]> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+    ? Object.entries(value)
+    : [];
+
+/**
+ * Read the live export state returned by either the regular Worker settings
+ * endpoint or the Workers for Platforms settings endpoint.
+ */
+export const observeDurableObjectExports = (
+  value: unknown,
+): ObservedDurableObjectExports => {
+  const storageByClass: Record<string, DurableObjectStorage> = {};
+  const pendingTransfers: Record<string, DurableObjectPendingTransfer> = {};
+
+  for (const [className, entry] of objectEntries(value)) {
+    if (stringMember(entry, "type") !== "durable-object") continue;
+    const storage = Predicate.hasProperty(entry, "storage")
+      ? entry.storage
+      : undefined;
+    if (!isStorage(storage)) continue;
+    storageByClass[className] = storage;
+
+    if (stringMember(entry, "state") !== "expecting-transfer") continue;
+    const transferFrom = stringMember(entry, "transferFrom");
+    if (transferFrom === undefined) continue;
+    const container = stringMember(entry, "container");
+    pendingTransfers[className] = {
+      transferFrom,
+      storage,
+      ...(container === undefined ? {} : { container }),
+    };
+  }
+
+  return { storageByClass, pendingTransfers };
+};
+
+/**
+ * Recover immutable storage backends from legacy migration settings when an
+ * older Worker has not yet exposed a declarative live export.
+ */
+export const observeLegacyDurableObjectStorage = (
+  value: unknown,
+): Record<string, DurableObjectStorage> => {
+  const storageByClass: Record<string, DurableObjectStorage> = {};
+  const steps =
+    Predicate.hasProperty(value, "steps") && Array.isArray(value.steps)
+      ? value.steps
+      : [value];
+
+  for (const step of steps) {
+    for (const className of stringArrayMember(step, "newClasses")) {
+      storageByClass[className] = "legacy-kv";
+    }
+    for (const className of stringArrayMember(step, "newSqliteClasses")) {
+      storageByClass[className] = "sqlite";
+    }
+    if (
+      Predicate.hasProperty(step, "renamedClasses") &&
+      Array.isArray(step.renamedClasses)
+    ) {
+      for (const rename of step.renamedClasses) {
+        const from = stringMember(rename, "from");
+        const to = stringMember(rename, "to");
+        if (from === undefined || to === undefined) continue;
+        const storage = storageByClass[from];
+        delete storageByClass[from];
+        if (storage !== undefined) storageByClass[to] = storage;
+      }
+    }
+    for (const className of stringArrayMember(step, "deletedClasses")) {
+      delete storageByClass[className];
+    }
+  }
+
+  return storageByClass;
+};
+
+const directiveEqual = (
+  left: DurableObjectExportDirective,
+  right: DurableObjectExportDirective,
+): boolean => {
+  if (left.kind !== right.kind) return false;
+  switch (left.kind) {
+    case "live":
+      return (
+        right.kind === "live" &&
+        left.storage === right.storage &&
+        left.container === right.container &&
+        left.changed === right.changed
+      );
+    case "deleted":
+      return right.kind === "deleted";
+    case "renamed":
+      return right.kind === "renamed" && left.renamedTo === right.renamedTo;
+    case "transferred":
+      return (
+        right.kind === "transferred" &&
+        left.transferredTo === right.transferredTo
+      );
+    case "expecting-transfer":
+      return (
+        right.kind === "expecting-transfer" &&
+        left.transferFrom === right.transferFrom &&
+        left.storage === right.storage &&
+        left.container === right.container
+      );
+  }
+};
 
 const storageFor = (
   namespaces: readonly DurableObjectNamespace[],
   scriptName: string,
+  storageByClass: Readonly<Record<string, DurableObjectStorage>>,
   ...classNames: Array<string | undefined>
-): DurableObjectStorage =>
+): DurableObjectStorage | undefined =>
   namespaces.find(
     (namespace) =>
       namespace.script === scriptName &&
       classNames.some((className) => className === namespace.className),
-  )?.storage ?? "sqlite";
+  )?.storage ??
+  classNames.flatMap((className) =>
+    className === undefined || storageByClass[className] === undefined
+      ? []
+      : [storageByClass[className]],
+  )[0];
 
 const liveExport = (
   storage: DurableObjectStorage,
@@ -75,83 +278,240 @@ const liveExport = (
 });
 
 /**
- * Build the complete declarative Durable Object export map for one Worker.
- * Existing tombstones remain until Cloudflare reports them as removable.
+ * Build the complete declarative Durable Object export map from observed
+ * cloud state and the Worker's current Durable Object declarations.
  */
-export const buildDurableObjectExports = ({
+export const planDurableObjectExports = ({
   scriptName,
   classes,
-  deletedClasses,
-  transferredClasses,
+  retirements,
   containerClassNames,
   namespaces,
+  observedStorageByClass,
+  observedPendingTransfers,
   previousState,
-}: BuildDurableObjectExportsInput): DurableObjectExportPlan => {
-  const exports: workers.PutScriptExports = {
-    ...(previousState?.tombstones ?? {}),
+}: PlanDurableObjectExportsInput): DurableObjectExportPlanResult => {
+  const directives: Record<string, DurableObjectExportDirective> = {};
+  const storageByClass = {
+    ...(previousState?.storageByClass ?? {}),
+    ...observedStorageByClass,
   };
-  const changedClasses = new Set<string>();
+  const pendingTransfers = {
+    ...(previousState?.pendingTransfers ?? {}),
+    ...observedPendingTransfers,
+  };
+
+  const addDirective = (
+    className: string,
+    directive: DurableObjectExportDirective,
+  ) => {
+    const current = directives[className];
+    if (current === undefined || directiveEqual(current, directive)) {
+      directives[className] = directive;
+      return undefined;
+    }
+    return new ConflictingDurableObjectExports({
+      scriptName,
+      className,
+      current,
+      next: directive,
+    });
+  };
+
+  for (const [className, retirement] of Object.entries(retirements)) {
+    const error = addDirective(
+      className,
+      retirement.kind === "deleted"
+        ? { kind: "deleted" }
+        : {
+            kind: "transferred",
+            transferredTo: retirement.transferredTo,
+          },
+    );
+    if (error !== undefined) return { _tag: "Failure", error };
+  }
 
   for (const current of classes) {
     const container = containerClassNames.has(current.className)
       ? current.className
       : undefined;
-    const storage =
-      current.storage ??
-      storageFor(
-        namespaces,
-        scriptName,
-        current.className,
-        current.previousClassName,
+    const pending = pendingTransfers[current.className];
+    if (pending !== undefined) {
+      const sourceStillHosts = namespaces.some(
+        (namespace) =>
+          namespace.script === pending.transferFrom &&
+          namespace.className === current.className,
       );
+      const error = addDirective(
+        current.className,
+        sourceStillHosts
+          ? {
+              kind: "expecting-transfer",
+              transferFrom: pending.transferFrom,
+              storage: pending.storage,
+              container: pending.container ?? container,
+            }
+          : {
+              kind: "live",
+              storage: pending.storage,
+              container: pending.container ?? container,
+              changed: true,
+            },
+      );
+      if (error !== undefined) return { _tag: "Failure", error };
+      continue;
+    }
 
     if (
       current.previousClassName !== undefined &&
-      current.previousClassName !== current.className
+      current.transferFrom !== undefined
     ) {
-      exports[current.previousClassName] = {
-        type: "durable-object",
-        state: "renamed",
-        renamedTo: current.className,
-      };
-      changedClasses.add(current.previousClassName);
-      changedClasses.add(current.className);
-    }
-
-    exports[current.className] =
-      current.transferFrom === undefined
-        ? liveExport(storage, container)
-        : {
-            type: "durable-object",
-            state: "expecting-transfer",
-            storage,
+      return {
+        _tag: "Failure",
+        error: new ConflictingDurableObjectExports({
+          scriptName,
+          className: current.className,
+          current: { kind: "renamed", renamedTo: current.className },
+          next: {
+            kind: "expecting-transfer",
             transferFrom: current.transferFrom,
+            storage: "sqlite",
             container,
-          };
-    if (current.transferFrom !== undefined) {
-      changedClasses.add(current.className);
-    } else if (current.previousClassName === undefined) {
-      changedClasses.add(current.className);
+          },
+        }),
+      };
     }
+
+    if (current.previousClassName !== undefined) {
+      const storage = storageFor(
+        namespaces,
+        scriptName,
+        storageByClass,
+        current.className,
+        current.previousClassName,
+      );
+      if (storage === undefined) {
+        return {
+          _tag: "Failure",
+          error: new DurableObjectStorageUnknown({
+            scriptName,
+            className: current.previousClassName,
+          }),
+        };
+      }
+      if (current.previousClassName !== current.className) {
+        const renameError = addDirective(current.previousClassName, {
+          kind: "renamed",
+          renamedTo: current.className,
+        });
+        if (renameError !== undefined) {
+          return { _tag: "Failure", error: renameError };
+        }
+      }
+      const liveError = addDirective(current.className, {
+        kind: "live",
+        storage,
+        container,
+        changed: current.previousClassName !== current.className,
+      });
+      if (liveError !== undefined) {
+        return { _tag: "Failure", error: liveError };
+      }
+      continue;
+    }
+
+    if (current.transferFrom !== undefined) {
+      const storage = storageFor(
+        namespaces,
+        current.transferFrom,
+        storageByClass,
+        current.className,
+      );
+      if (storage === undefined) {
+        return {
+          _tag: "Failure",
+          error: new DurableObjectStorageUnknown({
+            scriptName: current.transferFrom,
+            className: current.className,
+          }),
+        };
+      }
+      const error = addDirective(current.className, {
+        kind: "expecting-transfer",
+        transferFrom: current.transferFrom,
+        storage,
+        container,
+      });
+      if (error !== undefined) return { _tag: "Failure", error };
+      continue;
+    }
+
+    const error = addDirective(current.className, {
+      kind: "live",
+      storage: "sqlite",
+      container,
+      changed: true,
+    });
+    if (error !== undefined) return { _tag: "Failure", error };
   }
 
-  for (const className of deletedClasses) {
-    exports[className] = { type: "durable-object", state: "deleted" };
-    changedClasses.add(className);
-  }
+  const exports: workers.PutScriptExports = Object.fromEntries(
+    Object.entries(previousState?.tombstones ?? {}).filter(([, tombstone]) => {
+      if (tombstone.state !== "renamed") return true;
+      return directives[tombstone.renamedTo]?.kind === "live";
+    }),
+  );
+  const changedClasses = new Set<string>();
+  const omittedBindingClassNames = new Set<string>();
 
-  for (const transfer of transferredClasses) {
-    exports[transfer.className] = {
-      type: "durable-object",
-      state: "transferred",
-      transferredTo: transfer.transferredTo,
-    };
-    changedClasses.add(transfer.className);
+  for (const [className, directive] of Object.entries(directives)) {
+    switch (directive.kind) {
+      case "live":
+        exports[className] = liveExport(directive.storage, directive.container);
+        if (directive.changed) changedClasses.add(className);
+        break;
+      case "deleted":
+        exports[className] = { type: "durable-object", state: "deleted" };
+        changedClasses.add(className);
+        break;
+      case "renamed":
+        exports[className] = {
+          type: "durable-object",
+          state: "renamed",
+          renamedTo: directive.renamedTo,
+        };
+        changedClasses.add(className);
+        changedClasses.add(directive.renamedTo);
+        break;
+      case "transferred":
+        exports[className] = {
+          type: "durable-object",
+          state: "transferred",
+          transferredTo: directive.transferredTo,
+        };
+        changedClasses.add(className);
+        break;
+      case "expecting-transfer":
+        exports[className] = {
+          type: "durable-object",
+          state: "expecting-transfer",
+          storage: directive.storage,
+          transferFrom: directive.transferFrom,
+          container: directive.container,
+        };
+        changedClasses.add(className);
+        omittedBindingClassNames.add(className);
+        break;
+    }
   }
 
   return {
-    exports: Object.keys(exports).length > 0 ? exports : undefined,
-    changedClasses: [...changedClasses],
+    _tag: "Success",
+    plan: {
+      exports: Object.keys(exports).length > 0 ? exports : undefined,
+      changedClasses: [...changedClasses],
+      omittedBindingClassNames,
+    },
   };
 };
 
@@ -162,23 +522,17 @@ export const nextDurableObjectExportState = (
   if (submitted === undefined) return undefined;
   const removable = new Set(reconciliation?.removableEntries ?? []);
   const tombstones: Record<string, DurableObjectTombstone> = {};
+  const pendingTransfers: Record<string, DurableObjectPendingTransfer> = {};
+  const storageByClass: Record<string, DurableObjectStorage> = {};
+
   for (const [className, entry] of Object.entries(submitted)) {
-    if (
-      entry === undefined ||
-      removable.has(className) ||
-      entry.type !== "durable-object"
-    ) {
-      continue;
-    }
+    if (entry === undefined || entry.type !== "durable-object") continue;
+    if (removable.has(className)) continue;
     if (entry.state === "deleted") {
       tombstones[className] = { type: "durable-object", state: "deleted" };
       continue;
     }
-    if (
-      entry.state === "renamed" &&
-      "renamedTo" in entry &&
-      typeof entry.renamedTo === "string"
-    ) {
+    if (entry.state === "renamed" && "renamedTo" in entry) {
       tombstones[className] = {
         type: "durable-object",
         state: "renamed",
@@ -186,29 +540,30 @@ export const nextDurableObjectExportState = (
       };
       continue;
     }
-    if (
-      entry.state === "transferred" &&
-      "transferredTo" in entry &&
-      typeof entry.transferredTo === "string"
-    ) {
+    if (entry.state === "transferred" && "transferredTo" in entry) {
       tombstones[className] = {
         type: "durable-object",
         state: "transferred",
         transferredTo: entry.transferredTo,
       };
+      continue;
+    }
+    if (!("storage" in entry) || !isStorage(entry.storage)) continue;
+    storageByClass[className] = entry.storage;
+    if (entry.state === "expecting-transfer" && "transferFrom" in entry) {
+      pendingTransfers[className] = {
+        transferFrom: entry.transferFrom,
+        storage: entry.storage,
+        ...("container" in entry && typeof entry.container === "string"
+          ? { container: entry.container }
+          : {}),
+      };
     }
   }
-  const pendingTransfers =
-    reconciliation === undefined || reconciliation === null
-      ? Object.entries(submitted).flatMap(([className, entry]) =>
-          entry?.type === "durable-object" &&
-          entry.state === "expecting-transfer"
-            ? [className]
-            : [],
-        )
-      : reconciliation.transferPending.map((transfer) => transfer.class);
 
-  return Object.keys(tombstones).length > 0 || pendingTransfers.length > 0
-    ? { tombstones, pendingTransfers }
+  return Object.keys(tombstones).length > 0 ||
+    Object.keys(pendingTransfers).length > 0 ||
+    Object.keys(storageByClass).length > 0
+    ? { tombstones, pendingTransfers, storageByClass }
     : undefined;
 };

--- a/packages/alchemy/src/Cloudflare/Workers/DurableObjectExports.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/DurableObjectExports.ts
@@ -1,0 +1,214 @@
+import type * as workers from "@distilled.cloud/cloudflare/workers";
+
+export type DurableObjectStorage = "sqlite" | "legacy-kv";
+
+export type DurableObjectTombstone =
+  | {
+      type: "durable-object";
+      state: "deleted";
+    }
+  | {
+      type: "durable-object";
+      state: "renamed";
+      renamedTo: string;
+    }
+  | {
+      type: "durable-object";
+      state: "transferred";
+      transferredTo: string;
+    };
+
+export interface DurableObjectExportState {
+  tombstones: Record<string, DurableObjectTombstone>;
+  pendingTransfers: string[];
+}
+
+export interface DurableObjectNamespace {
+  script: string;
+  className: string;
+  storage: DurableObjectStorage;
+}
+
+export interface DurableObjectExportClass {
+  className: string;
+  previousClassName?: string;
+  transferFrom?: string;
+  storage?: DurableObjectStorage;
+}
+
+export interface BuildDurableObjectExportsInput {
+  scriptName: string;
+  classes: readonly DurableObjectExportClass[];
+  deletedClasses: readonly string[];
+  transferredClasses: ReadonlyArray<{
+    className: string;
+    transferredTo: string;
+  }>;
+  containerClassNames: ReadonlySet<string>;
+  namespaces: readonly DurableObjectNamespace[];
+  previousState?: DurableObjectExportState;
+}
+
+export interface DurableObjectExportPlan {
+  exports: workers.PutScriptExports | undefined;
+  changedClasses: string[];
+}
+
+const storageFor = (
+  namespaces: readonly DurableObjectNamespace[],
+  scriptName: string,
+  ...classNames: Array<string | undefined>
+): DurableObjectStorage =>
+  namespaces.find(
+    (namespace) =>
+      namespace.script === scriptName &&
+      classNames.some((className) => className === namespace.className),
+  )?.storage ?? "sqlite";
+
+const liveExport = (
+  storage: DurableObjectStorage,
+  container: string | undefined,
+): workers.PutScriptDurableObjectLiveExport => ({
+  type: "durable-object",
+  storage,
+  container,
+});
+
+/**
+ * Build the complete declarative Durable Object export map for one Worker.
+ * Existing tombstones remain until Cloudflare reports them as removable.
+ */
+export const buildDurableObjectExports = ({
+  scriptName,
+  classes,
+  deletedClasses,
+  transferredClasses,
+  containerClassNames,
+  namespaces,
+  previousState,
+}: BuildDurableObjectExportsInput): DurableObjectExportPlan => {
+  const exports: workers.PutScriptExports = {
+    ...(previousState?.tombstones ?? {}),
+  };
+  const changedClasses = new Set<string>();
+
+  for (const current of classes) {
+    const container = containerClassNames.has(current.className)
+      ? current.className
+      : undefined;
+    const storage =
+      current.storage ??
+      storageFor(
+        namespaces,
+        scriptName,
+        current.className,
+        current.previousClassName,
+      );
+
+    if (
+      current.previousClassName !== undefined &&
+      current.previousClassName !== current.className
+    ) {
+      exports[current.previousClassName] = {
+        type: "durable-object",
+        state: "renamed",
+        renamedTo: current.className,
+      };
+      changedClasses.add(current.previousClassName);
+      changedClasses.add(current.className);
+    }
+
+    exports[current.className] =
+      current.transferFrom === undefined
+        ? liveExport(storage, container)
+        : {
+            type: "durable-object",
+            state: "expecting-transfer",
+            storage,
+            transferFrom: current.transferFrom,
+            container,
+          };
+    if (current.transferFrom !== undefined) {
+      changedClasses.add(current.className);
+    } else if (current.previousClassName === undefined) {
+      changedClasses.add(current.className);
+    }
+  }
+
+  for (const className of deletedClasses) {
+    exports[className] = { type: "durable-object", state: "deleted" };
+    changedClasses.add(className);
+  }
+
+  for (const transfer of transferredClasses) {
+    exports[transfer.className] = {
+      type: "durable-object",
+      state: "transferred",
+      transferredTo: transfer.transferredTo,
+    };
+    changedClasses.add(transfer.className);
+  }
+
+  return {
+    exports: Object.keys(exports).length > 0 ? exports : undefined,
+    changedClasses: [...changedClasses],
+  };
+};
+
+export const nextDurableObjectExportState = (
+  submitted: workers.PutScriptExports | undefined,
+  reconciliation: workers.PutScriptExportsReconciliation | null | undefined,
+): DurableObjectExportState | undefined => {
+  if (submitted === undefined) return undefined;
+  const removable = new Set(reconciliation?.removableEntries ?? []);
+  const tombstones: Record<string, DurableObjectTombstone> = {};
+  for (const [className, entry] of Object.entries(submitted)) {
+    if (
+      entry === undefined ||
+      removable.has(className) ||
+      entry.type !== "durable-object"
+    ) {
+      continue;
+    }
+    if (entry.state === "deleted") {
+      tombstones[className] = { type: "durable-object", state: "deleted" };
+      continue;
+    }
+    if (
+      entry.state === "renamed" &&
+      "renamedTo" in entry &&
+      typeof entry.renamedTo === "string"
+    ) {
+      tombstones[className] = {
+        type: "durable-object",
+        state: "renamed",
+        renamedTo: entry.renamedTo,
+      };
+      continue;
+    }
+    if (
+      entry.state === "transferred" &&
+      "transferredTo" in entry &&
+      typeof entry.transferredTo === "string"
+    ) {
+      tombstones[className] = {
+        type: "durable-object",
+        state: "transferred",
+        transferredTo: entry.transferredTo,
+      };
+    }
+  }
+  const pendingTransfers =
+    reconciliation === undefined || reconciliation === null
+      ? Object.entries(submitted).flatMap(([className, entry]) =>
+          entry?.type === "durable-object" &&
+          entry.state === "expecting-transfer"
+            ? [className]
+            : [],
+        )
+      : reconciliation.transferPending.map((transfer) => transfer.class);
+
+  return Object.keys(tombstones).length > 0 || pendingTransfers.length > 0
+    ? { tombstones, pendingTransfers }
+    : undefined;
+};

--- a/packages/alchemy/src/Cloudflare/Workers/DurableObjectExports.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/DurableObjectExports.ts
@@ -1,4 +1,5 @@
 import type * as workers from "@distilled.cloud/cloudflare/workers";
+import type * as wfp from "@distilled.cloud/cloudflare/workers-for-platforms";
 import * as Data from "effect/Data";
 import * as Predicate from "effect/Predicate";
 
@@ -30,6 +31,7 @@ export interface DurableObjectExportState {
   tombstones: Record<string, DurableObjectTombstone>;
   pendingTransfers: Record<string, DurableObjectPendingTransfer>;
   storageByClass: Record<string, DurableObjectStorage>;
+  cleanupClassNames: string[];
 }
 
 export interface DurableObjectNamespace {
@@ -38,11 +40,18 @@ export interface DurableObjectNamespace {
   storage: DurableObjectStorage;
 }
 
-export interface DurableObjectClassObservation {
-  className: string;
-  previousClassName?: string;
-  transferFrom?: string;
-}
+export type DurableObjectClassObservation =
+  | { kind: "new"; className: string }
+  | {
+      kind: "existing";
+      className: string;
+      previousClassName: string;
+    }
+  | {
+      kind: "incoming-transfer";
+      className: string;
+      transferFrom: string;
+    };
 
 export type DurableObjectRetirement =
   | { kind: "deleted" }
@@ -116,17 +125,51 @@ export class ConflictingDurableObjectExports extends Data.TaggedError(
   }
 }
 
+export class DurableObjectPendingTransferRename extends Data.TaggedError(
+  "DurableObjectPendingTransferRename",
+)<{
+  scriptName: string;
+  previousClassName: string;
+  className: string;
+}> {
+  override get message() {
+    return `Durable Object class '${this.previousClassName}' on Worker '${this.scriptName}' is still waiting for a namespace transfer and cannot be renamed to '${this.className}' yet. Deploy the transfer with class '${this.previousClassName}' until it completes, then rename it in a later deploy.`;
+  }
+}
+
 export type DurableObjectExportPlanResult =
   | { _tag: "Success"; plan: DurableObjectExportPlan }
   | {
       _tag: "Failure";
-      error: DurableObjectStorageUnknown | ConflictingDurableObjectExports;
+      error:
+        | DurableObjectStorageUnknown
+        | ConflictingDurableObjectExports
+        | DurableObjectPendingTransferRename;
     };
 
 export interface ObservedDurableObjectExports {
   storageByClass: Record<string, DurableObjectStorage>;
   pendingTransfers: Record<string, DurableObjectPendingTransfer>;
 }
+
+export const recoverDurableObjectExportState = (
+  tagged: DurableObjectExportState | undefined,
+  persisted: DurableObjectExportState | undefined,
+): DurableObjectExportState | undefined => {
+  if (tagged === undefined) return persisted;
+  const cleanupClassNames = persisted?.cleanupClassNames ?? [];
+  const cleanup = new Set(cleanupClassNames);
+  return {
+    tombstones: Object.fromEntries(
+      Object.entries(tagged.tombstones).filter(
+        ([className]) => !cleanup.has(className),
+      ),
+    ),
+    pendingTransfers: tagged.pendingTransfers,
+    storageByClass: tagged.storageByClass,
+    cleanupClassNames,
+  };
+};
 
 const isStorage = (value: unknown): value is DurableObjectStorage =>
   value === "sqlite" || value === "legacy-kv";
@@ -141,33 +184,32 @@ const stringArrayMember = (value: unknown, key: string): string[] =>
     ? value[key].filter((item): item is string => typeof item === "string")
     : [];
 
-const objectEntries = (value: unknown): Array<[string, unknown]> =>
-  typeof value === "object" && value !== null && !Array.isArray(value)
-    ? Object.entries(value)
-    : [];
+type SettingsExports =
+  | workers.ScriptsScriptAndVersionSettingsGetResponseExportsMap
+  | wfp.DispatchNamespacesScriptsSettingsGetResponseExportsMap
+  | null
+  | undefined;
 
 /**
  * Read the live export state returned by either the regular Worker settings
  * endpoint or the Workers for Platforms settings endpoint.
  */
 export const observeDurableObjectExports = (
-  value: unknown,
+  value: SettingsExports,
 ): ObservedDurableObjectExports => {
   const storageByClass: Record<string, DurableObjectStorage> = {};
   const pendingTransfers: Record<string, DurableObjectPendingTransfer> = {};
 
-  for (const [className, entry] of objectEntries(value)) {
-    if (stringMember(entry, "type") !== "durable-object") continue;
-    const storage = Predicate.hasProperty(entry, "storage")
-      ? entry.storage
-      : undefined;
+  for (const [className, entry] of Object.entries(value ?? {})) {
+    if (entry?.type !== "durable-object") continue;
+    const storage = entry.storage;
     if (!isStorage(storage)) continue;
     storageByClass[className] = storage;
 
-    if (stringMember(entry, "state") !== "expecting-transfer") continue;
-    const transferFrom = stringMember(entry, "transferFrom");
+    if (entry.state !== "expecting-transfer") continue;
+    const transferFrom = entry.transferFrom ?? undefined;
     if (transferFrom === undefined) continue;
-    const container = stringMember(entry, "container");
+    const container = entry.container ?? undefined;
     pendingTransfers[className] = {
       transferFrom,
       storage,
@@ -335,8 +377,22 @@ export const planDurableObjectExports = ({
     const container = containerClassNames.has(current.className)
       ? current.className
       : undefined;
-    const pending = pendingTransfers[current.className];
+    const pendingClassName =
+      current.kind === "existing"
+        ? current.previousClassName
+        : current.className;
+    const pending = pendingTransfers[pendingClassName];
     if (pending !== undefined) {
+      if (pendingClassName !== current.className) {
+        return {
+          _tag: "Failure",
+          error: new DurableObjectPendingTransferRename({
+            scriptName,
+            previousClassName: pendingClassName,
+            className: current.className,
+          }),
+        };
+      }
       const sourceStillHosts = namespaces.some(
         (namespace) =>
           namespace.script === pending.transferFrom &&
@@ -362,27 +418,7 @@ export const planDurableObjectExports = ({
       continue;
     }
 
-    if (
-      current.previousClassName !== undefined &&
-      current.transferFrom !== undefined
-    ) {
-      return {
-        _tag: "Failure",
-        error: new ConflictingDurableObjectExports({
-          scriptName,
-          className: current.className,
-          current: { kind: "renamed", renamedTo: current.className },
-          next: {
-            kind: "expecting-transfer",
-            transferFrom: current.transferFrom,
-            storage: "sqlite",
-            container,
-          },
-        }),
-      };
-    }
-
-    if (current.previousClassName !== undefined) {
+    if (current.kind === "existing") {
       const storage = storageFor(
         namespaces,
         scriptName,
@@ -420,7 +456,7 @@ export const planDurableObjectExports = ({
       continue;
     }
 
-    if (current.transferFrom !== undefined) {
+    if (current.kind === "incoming-transfer") {
       const storage = storageFor(
         namespaces,
         current.transferFrom,
@@ -461,7 +497,7 @@ export const planDurableObjectExports = ({
       return directives[tombstone.renamedTo]?.kind === "live";
     }),
   );
-  const changedClasses = new Set<string>();
+  const changedClasses = new Set(previousState?.cleanupClassNames ?? []);
   const omittedBindingClassNames = new Set<string>();
 
   for (const [className, directive] of Object.entries(directives)) {
@@ -563,7 +599,13 @@ export const nextDurableObjectExportState = (
 
   return Object.keys(tombstones).length > 0 ||
     Object.keys(pendingTransfers).length > 0 ||
-    Object.keys(storageByClass).length > 0
-    ? { tombstones, pendingTransfers, storageByClass }
+    Object.keys(storageByClass).length > 0 ||
+    removable.size > 0
+    ? {
+        tombstones,
+        pendingTransfers,
+        storageByClass,
+        cleanupClassNames: [...removable],
+      }
     : undefined;
 };

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -463,9 +463,9 @@ export interface WorkerVersionAffinity {
  * A gradual rollout carries only what a version can: code, bindings,
  * compatibility settings, and cache configuration. Workers with static
  * assets cannot roll out gradually (the versions API cannot carry assets),
- * a deploy that changes Durable Object class migrations must go out at
- * 100% (migrations cannot ride a rollout), and script-level settings
- * (tags, observability, limits, placement, logpush) keep their live
+ * a deploy that changes Durable Object class lifecycle must go out at
+ * 100% (export reconciliation cannot ride a rollout), and script-level
+ * settings (tags, observability, limits, placement, logpush) keep their live
  * values until the next full deploy.
  */
 export interface WorkerVersionOptions {
@@ -482,7 +482,7 @@ export interface WorkerVersionOptions {
    * `name`, `assets`, `namespace`, `crons`, `domain`, `routes`, `tags`,
    * `logpush`, `observability`, `placement`, `limits`, and `subdomain` are
    * rejected, as are locally-hosted Durable Object or Workflow classes
-   * (their migrations would mutate the parent).
+   * (their lifecycle changes would mutate the parent).
    *
    * Changing the parent replaces the resource (a version belongs to
    * exactly one script).
@@ -968,6 +968,13 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
       | undefined;
     tags: string[] | undefined;
     durableObjectNamespaces: Record<string, string>;
+    /**
+     * Provider-managed declarative export tombstones and pending transfers.
+     * Tombstones are retained until Cloudflare reports them as removable.
+     *
+     * @internal
+     */
+    durableObjectExportState?: import("./DurableObjectExports.ts").DurableObjectExportState;
     accountId: string;
     routes: { id: string; pattern: string; zoneId: string }[];
     crons: string[];

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -39,9 +39,17 @@ import {
 import { getCompatibility } from "./Compatibility.ts";
 import { isDurableObjectExport } from "./DurableObject.ts";
 import {
-  buildDurableObjectExports,
+  encodeDurableObjectExportTags,
+  getDurableObjectExportStateFromTags,
+  isDurableObjectExportTag,
+} from "./DurableObjectExportTags.ts";
+import {
   nextDurableObjectExportState,
-  type DurableObjectExportClass,
+  observeDurableObjectExports,
+  observeLegacyDurableObjectStorage,
+  planDurableObjectExports,
+  type DurableObjectClassObservation,
+  type DurableObjectRetirement,
 } from "./DurableObjectExports.ts";
 import { LocalWorkerProvider } from "./LocalWorkerProvider.ts";
 import {
@@ -582,9 +590,8 @@ export const stateWorkerDomain = (
 
 /**
  * Read a script's combined settings, routing to the dispatch-namespace
- * endpoint when `dispatchNamespace` is set. The two response shapes are
- * structurally identical for the fields the provider consumes (`bindings`,
- * `tags`, `logpush`), so the WFP response is surfaced as the workers shape.
+ * endpoint when `dispatchNamespace` is set. Both typed response shapes expose
+ * the settings this provider consumes, including live Durable Object exports.
  *
  * @internal
  */
@@ -603,15 +610,15 @@ const getScriptSettings = (
         dispatchNamespace,
         scriptName,
       });
-      // The dispatch-namespace settings response is structurally identical to
-      // the account-level one for the fields the provider reads.
-      return settings as unknown as workers.GetScriptScriptAndVersionSettingResponse;
+      return settings;
     }
     return yield* workers.getScriptScriptAndVersionSetting({
       accountId,
       scriptName,
     });
   });
+
+type ScriptSettings = Effect.Success<ReturnType<typeof getScriptSettings>>;
 
 /**
  * Deploy-time binding validation rejects an upload whose bindings
@@ -2842,7 +2849,7 @@ export const LiveWorkerProvider = () =>
         olds: WorkerProps | undefined,
         output: Worker["Attributes"] | undefined,
         session: ScopedPlanStatusSession,
-        existingSettings?: workers.GetScriptScriptAndVersionSettingResponse,
+        existingSettings?: ScriptSettings,
       ) {
         const { accountId } = yield* yield* CloudflareEnvironment;
         // Prefer the deployed name: regenerating would target a different
@@ -3027,6 +3034,15 @@ export const LiveWorkerProvider = () =>
 
         const oldTags = Array.from(new Set(oldSettings?.tags ?? []));
         const oldBindings = oldSettings?.bindings ?? [];
+        const taggedExportState = getDurableObjectExportStateFromTags(oldTags);
+        const observedExports = observeDurableObjectExports(
+          oldSettings?.exports,
+        );
+        const observedStorageByClass = {
+          ...observeLegacyDurableObjectStorage(oldSettings?.migrations),
+          ...taggedExportState?.storageByClass,
+          ...observedExports.storageByClass,
+        };
 
         // Parse the DO logical-id→class mapping from script tags (packed
         // `alchemy:dos:` and legacy per-DO `alchemy:do:` formats)
@@ -3120,14 +3136,10 @@ export const LiveWorkerProvider = () =>
         const scriptHostsClass = (scriptName: string, className: string) =>
           hosts(observedNamespaces, scriptName, className);
 
-        const deletedClasses: string[] = [];
-        const transferredOut: Array<{
-          className: string;
-          transferredTo: string;
-        }> = [];
+        const retirements: Record<string, DurableObjectRetirement> = {};
         for (const className of deletedClassCandidates) {
           if (dispatchNamespace) {
-            deletedClasses.push(className);
+            retirements[className] = { kind: "deleted" };
             continue;
           }
           const targetScriptName = crossScriptClassTargets.get(className);
@@ -3138,7 +3150,7 @@ export const LiveWorkerProvider = () =>
             // alchemy:do tag drops out either way because tags are recomputed
             // from current bindings.
             if (scriptHostsClass(name, className)) {
-              deletedClasses.push(className);
+              retirements[className] = { kind: "deleted" };
             }
             continue;
           }
@@ -3166,10 +3178,10 @@ export const LiveWorkerProvider = () =>
             // The destination has declared an expecting-transfer export. It
             // does not own the namespace until this source-side tombstone
             // commits the transfer.
-            transferredOut.push({
-              className,
+            retirements[className] = {
+              kind: "transferred",
               transferredTo: targetScriptName,
-            });
+            };
             continue;
           }
           // local → cross-script transition without a transfer. Fail before
@@ -3193,10 +3205,9 @@ export const LiveWorkerProvider = () =>
           ),
         );
 
-        // Derive the complete live export set plus lifecycle intent from the
-        // existing Durable Object declarations. Users do not maintain a
-        // second exports configuration alongside their bindings.
-        const exportClasses: DurableObjectExportClass[] = [];
+        // Resolve class identity and declared transfer sources. The dedicated
+        // planner below owns lifecycle classification and export serialization.
+        const classObservations: DurableObjectClassObservation[] = [];
         for (const binding of currentDoBindings) {
           let previousClassName: string | undefined =
             oldDoClassNameByLogicalId[binding.logicalId];
@@ -3239,7 +3250,7 @@ export const LiveWorkerProvider = () =>
             // declared source must be observed to still host the namespace;
             // otherwise (fresh stage, transfer already completed) fall
             // through to a plain create.
-            const fromScript = dispatchNamespace
+            const transferFrom = dispatchNamespace
               ? undefined
               : yield* resolveTransferSource({
                   accountId,
@@ -3252,50 +3263,43 @@ export const LiveWorkerProvider = () =>
                   ),
                   observedNamespaces,
                 });
-            if (fromScript !== undefined) {
-              const sourceNamespace = observedNamespaces.find(
-                (namespace) =>
-                  namespace.script === fromScript &&
-                  namespace.class === binding.className,
-              );
-              exportClasses.push({
-                className: binding.className,
-                transferFrom: fromScript,
-                storage:
-                  sourceNamespace?.useSqlite === false ? "legacy-kv" : "sqlite",
-              });
-              continue;
-            }
+            classObservations.push({
+              className: binding.className,
+              transferFrom,
+            });
+            continue;
           }
-          exportClasses.push({
+          classObservations.push({
             className: binding.className,
             previousClassName,
           });
         }
 
-        const durableObjectExportPlan = buildDurableObjectExports({
+        const durableObjectPlanResult = planDurableObjectExports({
           scriptName: name,
-          classes: exportClasses,
-          deletedClasses,
-          transferredClasses: transferredOut,
+          classes: classObservations,
+          retirements,
           containerClassNames,
           namespaces: observedNamespaces.map((namespace) => ({
             script: namespace.script,
             className: namespace.class,
             storage: namespace.useSqlite === false ? "legacy-kv" : "sqlite",
           })),
-          previousState: output?.durableObjectExportState,
+          observedStorageByClass,
+          observedPendingTransfers: {
+            ...taggedExportState?.pendingTransfers,
+            ...observedExports.pendingTransfers,
+          },
+          previousState: taggedExportState ?? output?.durableObjectExportState,
         });
-        const pendingTransferClasses = new Set(
-          exportClasses.flatMap((entry) =>
-            entry.transferFrom === undefined ? [] : [entry.className],
-          ),
-        );
+        if (durableObjectPlanResult._tag === "Failure") {
+          return yield* Effect.fail(durableObjectPlanResult.error);
+        }
+        const durableObjectExportPlan = durableObjectPlanResult.plan;
         // Cloudflare cannot provision a pending transfer and attach a local
-        // namespace binding in the same upload. The first deploy records the
-        // expectation without that binding. Reconciliation state forces the
-        // next deploy, which sends the normal live export and binding after
-        // the source has committed the transfer.
+        // namespace binding in the same upload. Keep omitting that binding on
+        // retries until observed cloud state confirms that the source no
+        // longer owns the namespace.
         const uploadMetadataBindings = metadataBindings.filter(
           (binding) =>
             !(
@@ -3303,7 +3307,9 @@ export const LiveWorkerProvider = () =>
               binding.className !== undefined &&
               (binding.scriptName === undefined ||
                 binding.scriptName === name) &&
-              pendingTransferClasses.has(binding.className)
+              durableObjectExportPlan.omittedBindingClassNames.has(
+                binding.className,
+              )
             ),
         );
         const expectedDurableObjectClassNames =
@@ -3314,7 +3320,7 @@ export const LiveWorkerProvider = () =>
             {
               oldDoClassNameByLogicalId,
               currentDoClassNameByLogicalId,
-              deletedClasses,
+              retirements,
               exports: durableObjectExportPlan.exports,
             },
           )}`,
@@ -3324,8 +3330,15 @@ export const LiveWorkerProvider = () =>
         // tags as possible — one tag per DO blows Cloudflare's 10-tag limit
         // at 7+ bindings (#811).
         const alchemyDoTags = encodeDurableObjectTags(currentDoBindings);
+        const alchemyExportTags = encodeDurableObjectExportTags(
+          durableObjectExportPlan.exports,
+        );
 
-        const alchemyTags = [...createAlchemyWorkerTags(id), ...alchemyDoTags];
+        const alchemyTags = [
+          ...createAlchemyWorkerTags(id),
+          ...alchemyDoTags,
+          ...alchemyExportTags,
+        ];
         const metadataTags = Array.from(
           new Set([...alchemyTags, ...(news.tags ?? [])]),
         );
@@ -3759,7 +3772,8 @@ export const LiveWorkerProvider = () =>
         accountId: string,
       ) {
         if (
-          (output.durableObjectExportState?.pendingTransfers.length ?? 0) > 0
+          Object.keys(output.durableObjectExportState?.pendingTransfers ?? {})
+            .length > 0
         ) {
           return true;
         }
@@ -5153,7 +5167,9 @@ export function getDurableObjectTagMap(tags: ReadonlyArray<string>) {
 }
 
 const isDurableObjectTag = (tag: string) =>
-  tag.startsWith(LEGACY_DO_TAG_PREFIX) || tag.startsWith(PACKED_DO_TAG_PREFIX);
+  tag.startsWith(LEGACY_DO_TAG_PREFIX) ||
+  tag.startsWith(PACKED_DO_TAG_PREFIX) ||
+  isDurableObjectExportTag(tag);
 
 /**
  * Fail fast — before the script upload — when a worker's tag set violates

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -38,6 +38,11 @@ import {
 } from "./Assets.ts";
 import { getCompatibility } from "./Compatibility.ts";
 import { isDurableObjectExport } from "./DurableObject.ts";
+import {
+  buildDurableObjectExports,
+  nextDurableObjectExportState,
+  type DurableObjectExportClass,
+} from "./DurableObjectExports.ts";
 import { LocalWorkerProvider } from "./LocalWorkerProvider.ts";
 import {
   isSelfUrl,
@@ -78,8 +83,8 @@ class MissingDurableObjects extends Data.TaggedError("MissingDurableObjects")<{
  * Moving a Durable Object class between Workers is always declared: set
  * `transferredFrom` on the Durable Object at its **new host** — naming the
  * former host by Worker logical id (same stack) or physical script name — and
- * Alchemy performs the data-preserving `transferred_classes` migration on the
- * new host's deploy; this deploy then converges on its own. To abandon the
+ * Alchemy performs Cloudflare's data-preserving declarative transfer; the
+ * next deploy activates the new host's local binding. To abandon the
  * data instead, remove the binding entirely in one deploy (which deletes the
  * class and its data), then add the cross-script binding in a second deploy.
  */
@@ -147,7 +152,7 @@ export const resolveNamespaceName = (
  * combined with `version.parent` (script-level settings belong to the
  * parent), a locally-hosted Durable Object / Workflow class on a version
  * worker, an out-of-range `traffic`, or a gradual rollout that requires
- * changes the versions API can't carry (assets, DO migrations).
+ * changes the versions API can't carry (assets, DO lifecycle changes).
  */
 export class WorkerVersionConfigError extends Data.TaggedError(
   "WorkerVersionConfigError",
@@ -2525,7 +2530,7 @@ export const LiveWorkerProvider = () =>
        * compatibility settings; everything script-level belongs to the
        * parent and must not be mutated from a version resource. Locally
        * hosted Durable Object / Workflow classes are rejected because their
-       * migrations would apply to the parent script when the version
+       * lifecycle changes would apply to the parent script when the version
        * deploys.
        */
       const validateVersionWorkerProps = Effect.fn(function* (
@@ -2570,7 +2575,7 @@ export const LiveWorkerProvider = () =>
         }
         // Any locally-hosted DO class (a durable_object_namespace binding
         // without a foreign scriptName) or DO/Workflow export would require
-        // migrations, which the versions API can't carry — and which would
+        // lifecycle changes, which the versions API can't carry and which would
         // mutate the parent's namespaces.
         const hostedClasses = getDurableObjectBindings(bindings, parentName);
         const exportedClasses = Object.keys(news.exports ?? {});
@@ -2584,7 +2589,7 @@ export const LiveWorkerProvider = () =>
                 ]),
               ].join(
                 ", ",
-              )}): class migrations apply to the parent script. Host the classes on the parent Worker and reference them cross-script instead.`,
+              )}): class lifecycle applies to the parent script. Host the classes on the parent Worker and reference them cross-script instead.`,
             }),
           );
         }
@@ -2906,7 +2911,7 @@ export const LiveWorkerProvider = () =>
         } satisfies Worker["Attributes"]["hash"];
         // `transferredFrom` is alchemy-only transfer metadata on
         // durable_object_namespace bindings — it drives the
-        // `transferred_classes` migration below and must be stripped from the
+        // declarative transfer below and must be stripped from the
         // wire-shape binding before upload.
         const metadataBindings = bindings.flatMap((b) =>
           (b.data.bindings ?? []).map((item): WireWorkerBinding => {
@@ -2935,8 +2940,6 @@ export const LiveWorkerProvider = () =>
             return item;
           }),
         );
-        const expectedDurableObjectClassNames =
-          getExpectedDurableObjectClassNames(metadataBindings, name);
         let metadataAssets:
           | workers.PutScriptRequest["metadata"]["assets"]
           | undefined;
@@ -3009,7 +3012,7 @@ export const LiveWorkerProvider = () =>
         const bundleSize = `${sizeKB > 1024 ? `${sizeMB.toFixed(2)} MB` : `${sizeKB.toFixed(2)} KB`}`;
         yield* session.note(`Uploading worker (${bundleSize}) ...`);
 
-        // Read existing worker settings for migration tracking
+        // Read existing worker settings for Durable Object lifecycle tracking.
         const oldSettings =
           existingSettings ??
           (yield* workers
@@ -3036,14 +3039,6 @@ export const LiveWorkerProvider = () =>
           ]),
         );
 
-        // Parse alchemy:migration-tag:{version}
-        const oldMigrationTag = oldTags.flatMap((tag) =>
-          tag.startsWith("alchemy:migration-tag:")
-            ? [tag.slice("alchemy:migration-tag:".length)]
-            : [],
-        )[0];
-        const newMigrationTag = bumpMigrationTagVersion(oldMigrationTag);
-
         // Compute delete-class candidates. Candidates are validated against
         // observed namespace ownership below — a class may already have been
         // transferred to another script by its new host's deploy.
@@ -3059,7 +3054,7 @@ export const LiveWorkerProvider = () =>
         // Backward compatibility for old workers that have DO bindings but no
         // alchemy:do tags yet. Cross-script bindings (`scriptName` set to
         // anything other than this worker) are NEVER candidates for
-        // delete-class migrations — the class lives on the foreign script
+        // delete-class tombstones — the class lives on the foreign script
         // and we don't own its lifecycle.
         if (Object.keys(oldDoClassNameByLogicalId).length === 0) {
           for (const oldBinding of oldBindings) {
@@ -3098,7 +3093,7 @@ export const LiveWorkerProvider = () =>
 
         // One account-level namespace listing serves both sides of a
         // transfer: the destination checks the source still hosts the class
-        // before emitting `transferred_classes`, and the former host checks
+        // before declaring a transfer, and the former host checks
         // whether a to-be-deleted class was already transferred away.
         // Dispatch-namespace user workers keep the legacy behavior — their
         // namespaces don't surface on the account-level list.
@@ -3109,7 +3104,9 @@ export const LiveWorkerProvider = () =>
         );
         const observedNamespaces =
           !dispatchNamespace &&
-          (deletedClassCandidates.length > 0 || mayTransferIn)
+          (currentDoBindings.length > 0 ||
+            deletedClassCandidates.length > 0 ||
+            mayTransferIn)
             ? yield* listDurableObjectNamespaces(accountId)
             : [];
         const hosts = (
@@ -3124,6 +3121,10 @@ export const LiveWorkerProvider = () =>
           hosts(observedNamespaces, scriptName, className);
 
         const deletedClasses: string[] = [];
+        const transferredOut: Array<{
+          className: string;
+          transferredTo: string;
+        }> = [];
         for (const className of deletedClassCandidates) {
           if (dispatchNamespace) {
             deletedClasses.push(className);
@@ -3142,7 +3143,7 @@ export const LiveWorkerProvider = () =>
             continue;
           }
           // The class went local → cross-script. When the new host's deploy
-          // ran a `transferred_classes` migration moments ago, the account
+          // committed a declarative transfer moments ago, the account
           // listing can briefly still attribute the namespace to this script,
           // so re-observe with a short bounded budget until the transfer
           // becomes visible (namespace off this script) or the state is
@@ -3159,6 +3160,16 @@ export const LiveWorkerProvider = () =>
           );
           if (!hosts(namespaces, name, className)) {
             // Transferred away — nothing to delete.
+            continue;
+          }
+          if (!hosts(namespaces, targetScriptName, className)) {
+            // The destination has declared an expecting-transfer export. It
+            // does not own the namespace until this source-side tombstone
+            // commits the transfer.
+            transferredOut.push({
+              className,
+              transferredTo: targetScriptName,
+            });
             continue;
           }
           // local → cross-script transition without a transfer. Fail before
@@ -3182,15 +3193,10 @@ export const LiveWorkerProvider = () =>
           ),
         );
 
-        // Compute new, renamed, and transferred classes
-        const newClasses: string[] = [];
-        const newSqliteClasses: string[] = [];
-        const renamedClasses: { from: string; to: string }[] = [];
-        const transferredClasses: {
-          from: string;
-          fromScript: string;
-          to: string;
-        }[] = [];
+        // Derive the complete live export set plus lifecycle intent from the
+        // existing Durable Object declarations. Users do not maintain a
+        // second exports configuration alongside their bindings.
+        const exportClasses: DurableObjectExportClass[] = [];
         for (const binding of currentDoBindings) {
           let previousClassName: string | undefined =
             oldDoClassNameByLogicalId[binding.logicalId];
@@ -3200,7 +3206,7 @@ export const LiveWorkerProvider = () =>
             // before these tags existed. Fall back to matching the observed
             // cloud binding by binding name so adoption reuses the existing
             // class instead of asking Cloudflare to create one that already
-            // exists (which fails the migration). This is the "first deploy
+            // exists (which fails reconciliation). This is the "first deploy
             // must match the existing class name" path; once we write the
             // `alchemy:dos:` tag, subsequent renames are driven by logical id.
             const observed = oldBindings.find(
@@ -3212,7 +3218,7 @@ export const LiveWorkerProvider = () =>
                 // this script. A cross-script binding under the same name —
                 // e.g. this worker previously referenced another host's
                 // class and now hosts its own — points at a foreign
-                // namespace and must not suppress the create migration
+                // namespace and must not suppress the live export
                 // (Cloudflare rejects a local binding for a class the
                 // script isn't configured to implement).
                 (!("scriptName" in old) ||
@@ -3247,27 +3253,61 @@ export const LiveWorkerProvider = () =>
                   observedNamespaces,
                 });
             if (fromScript !== undefined) {
-              // Data-preserving move: ship Cloudflare's
-              // `transferred_classes` migration instead of creating a
-              // fresh class.
-              transferredClasses.push({
-                from: binding.className,
-                fromScript,
-                to: binding.className,
+              const sourceNamespace = observedNamespaces.find(
+                (namespace) =>
+                  namespace.script === fromScript &&
+                  namespace.class === binding.className,
+              );
+              exportClasses.push({
+                className: binding.className,
+                transferFrom: fromScript,
+                storage:
+                  sourceNamespace?.useSqlite === false ? "legacy-kv" : "sqlite",
               });
               continue;
             }
-            // Default all new Durable Object classes to SQLite. Cloudflare
-            // recommends SQLite for new namespaces, and container-backed
-            // Durable Objects require it.
-            newSqliteClasses.push(binding.className);
-          } else if (previousClassName !== binding.className) {
-            renamedClasses.push({
-              from: previousClassName,
-              to: binding.className,
-            });
           }
+          exportClasses.push({
+            className: binding.className,
+            previousClassName,
+          });
         }
+
+        const durableObjectExportPlan = buildDurableObjectExports({
+          scriptName: name,
+          classes: exportClasses,
+          deletedClasses,
+          transferredClasses: transferredOut,
+          containerClassNames,
+          namespaces: observedNamespaces.map((namespace) => ({
+            script: namespace.script,
+            className: namespace.class,
+            storage: namespace.useSqlite === false ? "legacy-kv" : "sqlite",
+          })),
+          previousState: output?.durableObjectExportState,
+        });
+        const pendingTransferClasses = new Set(
+          exportClasses.flatMap((entry) =>
+            entry.transferFrom === undefined ? [] : [entry.className],
+          ),
+        );
+        // Cloudflare cannot provision a pending transfer and attach a local
+        // namespace binding in the same upload. The first deploy records the
+        // expectation without that binding. Reconciliation state forces the
+        // next deploy, which sends the normal live export and binding after
+        // the source has committed the transfer.
+        const uploadMetadataBindings = metadataBindings.filter(
+          (binding) =>
+            !(
+              binding.type === "durable_object_namespace" &&
+              binding.className !== undefined &&
+              (binding.scriptName === undefined ||
+                binding.scriptName === name) &&
+              pendingTransferClasses.has(binding.className)
+            ),
+        );
+        const expectedDurableObjectClassNames =
+          getExpectedDurableObjectClassNames(uploadMetadataBindings, name);
 
         yield* Effect.logInfo(
           `Cloudflare Worker put: durable object reconciliation ${JSON.stringify(
@@ -3275,9 +3315,7 @@ export const LiveWorkerProvider = () =>
               oldDoClassNameByLogicalId,
               currentDoClassNameByLogicalId,
               deletedClasses,
-              renamedClasses,
-              transferredClasses,
-              newSqliteClasses,
+              exports: durableObjectExportPlan.exports,
             },
           )}`,
         );
@@ -3287,27 +3325,11 @@ export const LiveWorkerProvider = () =>
         // at 7+ bindings (#811).
         const alchemyDoTags = encodeDurableObjectTags(currentDoBindings);
 
-        const alchemyTags = [
-          ...createAlchemyWorkerTags(id),
-          ...alchemyDoTags,
-          ...(newMigrationTag
-            ? [`alchemy:migration-tag:${newMigrationTag}`]
-            : []),
-        ];
+        const alchemyTags = [...createAlchemyWorkerTags(id), ...alchemyDoTags];
         const metadataTags = Array.from(
           new Set([...alchemyTags, ...(news.tags ?? [])]),
         );
         yield* validateWorkerTags(name, metadataTags, alchemyTags.length);
-
-        const migrations = {
-          oldTag: oldMigrationTag,
-          newTag: newMigrationTag,
-          newClasses,
-          deletedClasses,
-          renamedClasses,
-          transferredClasses,
-          newSqliteClasses,
-        };
 
         const metadataContainers = [...containerClassNames].map(
           (className) => ({
@@ -3318,7 +3340,7 @@ export const LiveWorkerProvider = () =>
         const compatibility = getCompatibility(news);
         const metadata: workers.PutScriptRequest["metadata"] = {
           assets: metadataAssets,
-          bindings: metadataBindings,
+          bindings: uploadMetadataBindings,
           bodyPart: undefined,
           cacheOptions: news.cache ?? getCacheBinding(bindings),
           compatibilityDate: compatibility.date,
@@ -3330,7 +3352,7 @@ export const LiveWorkerProvider = () =>
           limits: news.limits,
           logpush: news.logpush,
           mainModule: bundle.main,
-          migrations,
+          exports: durableObjectExportPlan.exports,
           observability: news.observability ?? {
             enabled: true,
             logs: {
@@ -3346,7 +3368,11 @@ export const LiveWorkerProvider = () =>
         const rolloutTraffic = getSelfRolloutTraffic(news);
         let versionId: string | undefined;
         let deploymentId: string | undefined;
-        let worker: { id?: string | null; logpush?: boolean | null };
+        let worker: {
+          id?: string | null;
+          logpush?: boolean | null;
+          exportsReconciliation?: workers.PutScriptExportsReconciliation | null;
+        };
         // A gradual rollout (`version.traffic` < 100) deploys through the
         // versions API instead of the full-cutover script PUT. That's only
         // possible when the script already has a live deployment to split
@@ -3369,17 +3395,10 @@ export const LiveWorkerProvider = () =>
               }),
             );
           }
-          const migratedClasses = [
-            ...migrations.newClasses,
-            ...migrations.newSqliteClasses,
-            ...migrations.deletedClasses,
-            ...migrations.renamedClasses.map((r) => r.to),
-            ...migrations.transferredClasses.map((t) => t.to),
-          ];
-          if (migratedClasses.length > 0) {
+          if (durableObjectExportPlan.changedClasses.length > 0) {
             return yield* Effect.fail(
               new WorkerVersionConfigError({
-                message: `This deploy of '${name}' changes Durable Object classes (${migratedClasses.join(", ")}), which requires a migration — migrations cannot ride a gradual rollout. Deploy at 100% (remove version.traffic) first, then resume gradual rollouts.`,
+                message: `This deploy of '${name}' changes Durable Object classes (${durableObjectExportPlan.changedClasses.join(", ")}), which cannot ride a gradual rollout. Deploy at 100% (remove version.traffic) first, then resume gradual rollouts.`,
               }),
             );
           }
@@ -3445,52 +3464,18 @@ export const LiveWorkerProvider = () =>
               `Cloudflare Worker ${name}: no previous live version to split traffic with; deploying at 100%`,
             );
           }
-          worker = yield* putWorkerScriptWithMigrationRecovery();
-        }
-
-        function putWorkerScriptWithMigrationRecovery() {
-          return putWorkerScript({
+          worker = yield* putWorkerScript({
             accountId,
             scriptName: name,
             dispatchNamespace,
             metadata,
             files: bundle.files,
-          }).pipe(
-            Effect.catch((err) => {
-              // When adopting a Worker managed by Wrangler (or after a previous
-              // deploy with mismatched migrations), the old_tag precondition
-              // fails. The only way to discover the actual tag is through the
-              // error message — getScriptSettings is meant to return it but
-              // doesn't at runtime.
-              const msg = String(
-                typeof err === "object" && err !== null && "message" in err
-                  ? err.message
-                  : err,
-              );
-              const expectedTag = msg.match(
-                /when expected tag is ['"]?([^'"]+)['"]?/,
-              )?.[1];
-              if (expectedTag) {
-                return putWorkerScript({
-                  accountId,
-                  scriptName: name,
-                  dispatchNamespace,
-                  metadata: {
-                    ...metadata,
-                    migrations: {
-                      ...migrations,
-                      oldTag: expectedTag,
-                      newTag: bumpMigrationTagVersion(expectedTag),
-                    },
-                  },
-                  files: bundle.files,
-                });
-              }
-              // @effect-diagnostics-next-line anyUnknownInErrorContext:off
-              return Effect.fail(err as any);
-            }),
-          );
+          });
         }
+        const durableObjectExportState = nextDurableObjectExportState(
+          durableObjectExportPlan.exports,
+          worker.exportsReconciliation,
+        );
         const { settings, durableObjectNamespaces } =
           yield* getWorkerSettingsWithDurableObjects(
             name,
@@ -3510,6 +3495,7 @@ export const LiveWorkerProvider = () =>
             url: undefined,
             tags: settings.tags ?? metadata.tags,
             durableObjectNamespaces,
+            durableObjectExportState,
             accountId,
             urls: [],
             domain: undefined,
@@ -3753,6 +3739,7 @@ export const LiveWorkerProvider = () =>
           domain: effectiveDomain,
           tags: settings.tags ?? metadata.tags,
           durableObjectNamespaces,
+          durableObjectExportState,
           accountId,
           routes,
           crons,
@@ -3771,6 +3758,11 @@ export const LiveWorkerProvider = () =>
         bindings: readonly ResourceBinding<Worker["Binding"]>[] | undefined,
         accountId: string,
       ) {
+        if (
+          (output.durableObjectExportState?.pendingTransfers.length ?? 0) > 0
+        ) {
+          return true;
+        }
         // #745: metadata-only edits (compatibility, observability, placement,
         // limits, logpush, env literals, bindings, subdomain config, tags)
         // don't touch the bundle/vite/asset-content hashes below, so compare a
@@ -4208,8 +4200,8 @@ export const LiveWorkerProvider = () =>
             .map((logicalId) => ({ logicalId, className: logicalId }));
           // Transfer-destination classes are excluded from the placeholder
           // entirely (class list, bindings, tags): Cloudflare forbids
-          // creating the destination class of a `transferred_classes`
-          // migration ahead of the transfer, so `reconcile` must perform it
+          // attaching a destination binding before an expected transfer is
+          // committed, so `reconcile` must perform it
           // with the real upload. (`transferredFrom` may still be an
           // unresolved Output here — precreate runs on raw props — but only
           // its presence matters.)
@@ -4309,17 +4301,22 @@ export const LiveWorkerProvider = () =>
                 compatibilityDate: compatibility.date,
                 compatibilityFlags: compatibility.flags,
                 containers,
-                migrations:
+                exports:
                   doClasses.length > 0
-                    ? {
-                        oldTag: undefined,
-                        newTag: undefined,
-                        newClasses: [],
-                        deletedClasses: [],
-                        renamedClasses: [],
-                        transferredClasses: [],
-                        newSqliteClasses: doClasses,
-                      }
+                    ? Object.fromEntries(
+                        doClasses.map((className) => [
+                          className,
+                          {
+                            type: "durable-object" as const,
+                            storage: "sqlite" as const,
+                            container: containers?.some(
+                              (container) => container.className === className,
+                            )
+                              ? className
+                              : undefined,
+                          },
+                        ]),
+                      )
                     : undefined,
                 observability: news.observability ?? {
                   enabled: true,
@@ -4447,6 +4444,7 @@ export const LiveWorkerProvider = () =>
                 url: undefined,
                 tags: settings.tags ?? undefined,
                 durableObjectNamespaces: getDurableObjects(settings.bindings),
+                durableObjectExportState: output?.durableObjectExportState,
                 urls: [],
                 domain: undefined,
                 routes: [],
@@ -4569,6 +4567,7 @@ export const LiveWorkerProvider = () =>
               domain: observedDomain,
               tags: settings.tags ?? undefined,
               durableObjectNamespaces: getDurableObjects(settings.bindings),
+              durableObjectExportState: output?.durableObjectExportState,
               routes: routesList,
               crons,
               // Rule placement is provider-managed state, not observed here
@@ -4642,7 +4641,7 @@ export const LiveWorkerProvider = () =>
           const dispatchNamespace = resolveNamespaceName(news.namespace);
           // Observe — fetch the script's current settings if it already exists.
           // `putWorker` is a true upsert against the Cloudflare API; the
-          // existing settings inform asset/migration decisions and let the
+          // existing settings inform asset/lifecycle decisions and let the
           // reconciler converge whether the worker is brand-new, adopted, or
           // an in-place update.
           const existingSettings = yield* getScriptSettings(
@@ -4921,9 +4920,10 @@ const contentTypeFromExtension = (extension: string) => {
 };
 
 /**
- * Observe every Durable Object namespace on the account as `(script, class)`
- * pairs. Namespace ownership is authoritative cloud state: after a
- * `transferred_classes` migration the namespace moves to the receiving
+ * Observe every Durable Object namespace on the account with its host,
+ * class, and immutable storage backend. Namespace ownership is authoritative
+ * cloud state: after a
+ * declarative transfer the namespace moves to the receiving
  * script, so this is how both sides of a transfer observe where a class
  * currently lives — the destination checks the source still hosts the class
  * before emitting the transfer, and the former host checks whether a class
@@ -4934,7 +4934,15 @@ const listDurableObjectNamespaces = (accountId: string) =>
     Stream.runCollect,
     Effect.map((namespaces) =>
       Array.from(namespaces).flatMap((ns) =>
-        ns.script && ns.class ? [{ script: ns.script, class: ns.class }] : [],
+        ns.script && ns.class
+          ? [
+              {
+                script: ns.script,
+                class: ns.class,
+                useSqlite: ns.useSqlite ?? undefined,
+              },
+            ]
+          : [],
       ),
     ),
   );
@@ -4954,15 +4962,6 @@ const normalizeTransferSources = (
       ? value
       : [value as string]
   ).filter((source) => source !== selfScriptName);
-
-function bumpMigrationTagVersion(
-  oldTag: string | undefined,
-): string | undefined {
-  if (!oldTag) return undefined;
-  const version = oldTag.match(/^(alchemy:)?v(\d+)$/)?.[2];
-  if (!version) return "alchemy:v1";
-  return `alchemy:v${parseInt(version, 10) + 1}`;
-}
 
 /**
  * Merges a worker's export-derived and binding-derived Durable Object class
@@ -5002,7 +5001,7 @@ function getDurableObjectBindings(
   // className)` tuple appears at most once. We also exclude cross-script
   // references: a `scriptName` pointing to *another* worker means this
   // worker just references a foreign class — ship the binding to
-  // Cloudflare, but don't drive class migrations for it.
+  // Cloudflare, but don't manage class lifecycle for it.
   const seen = new Set<string>();
   return bindings.flatMap((binding) =>
     (binding.data.bindings ?? []).flatMap((item: WorkerBinding) => {
@@ -5025,7 +5024,7 @@ function getDurableObjectBindings(
           bindingName: item.name,
           className: item.className,
           // Declared host history for a data-preserving
-          // `transferred_classes` migration. Normalize an empty list to
+          // declarative transfer. Normalize an empty list to
           // "not declared"; self-references are dropped at resolution time.
           transferredFrom:
             Array.isArray(item.transferredFrom) &&
@@ -5047,10 +5046,10 @@ function getDurableObjectBindings(
  * - tags may not contain `,` or `&`; everything else (`:`, `;`, `=`, `/`,
  *   spaces, unicode) is accepted and round-trips intact
  *
- * Alchemy reserves 3 ownership tags (`alchemy:stack/stage/id`) and 1
- * migration tag, so the Durable Object logical-id→class mapping must not
- * spend one tag per DO (#811). Instead all mappings are packed into as few
- * `alchemy:dos:` tags as possible.
+ * Alchemy reserves 3 ownership tags (`alchemy:stack/stage/id`), so the
+ * Durable Object logical-id→class mapping must not spend one tag per DO
+ * (#811). Instead all mappings are packed into as few `alchemy:dos:` tags as
+ * possible.
  */
 const MAX_TAGS_PER_WORKER = 10;
 const MAX_TAG_BYTES = 1024;
@@ -5160,7 +5159,7 @@ const isDurableObjectTag = (tag: string) =>
  * Fail fast — before the script upload — when a worker's tag set violates
  * Cloudflare's limits, instead of surfacing the raw `Forbidden`/`BadRequest`
  * at PUT time (#811). `alchemyTagCount` is the number of tags alchemy itself
- * generated (ownership + migration + packed DO tags) so the message can tell
+ * generated (ownership + packed DO tags) so the message can tell
  * the user how much of the budget is theirs.
  */
 const validateWorkerTags = (
@@ -5175,7 +5174,7 @@ const validateWorkerTags = (
           scriptName,
           reason:
             `worker "${scriptName}" needs ${tags.length} script tags but Cloudflare allows at most ${MAX_TAGS_PER_WORKER}. ` +
-            `Alchemy reserves ${alchemyTagCount} (ownership, migration and durable-object metadata); ` +
+            `Alchemy reserves ${alchemyTagCount} (ownership and durable-object metadata); ` +
             `${tags.length - alchemyTagCount} user tags were passed via \`tags\`. Remove ${tags.length - MAX_TAGS_PER_WORKER} tag(s).`,
         }),
       );

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -40,14 +40,18 @@ import { getCompatibility } from "./Compatibility.ts";
 import { isDurableObjectExport } from "./DurableObject.ts";
 import {
   encodeDurableObjectExportTags,
+  encodeDurableObjectTags,
   getDurableObjectExportStateFromTags,
-  isDurableObjectExportTag,
+  getDurableObjectTagMap,
+  isDurableObjectTag,
+  MAX_WORKER_TAG_BYTES,
 } from "./DurableObjectExportTags.ts";
 import {
   nextDurableObjectExportState,
   observeDurableObjectExports,
   observeLegacyDurableObjectStorage,
   planDurableObjectExports,
+  recoverDurableObjectExportState,
   type DurableObjectClassObservation,
   type DurableObjectRetirement,
 } from "./DurableObjectExports.ts";
@@ -3263,13 +3267,19 @@ export const LiveWorkerProvider = () =>
                   ),
                   observedNamespaces,
                 });
-            classObservations.push({
-              className: binding.className,
-              transferFrom,
-            });
+            classObservations.push(
+              transferFrom === undefined
+                ? { kind: "new", className: binding.className }
+                : {
+                    kind: "incoming-transfer",
+                    className: binding.className,
+                    transferFrom,
+                  },
+            );
             continue;
           }
           classObservations.push({
+            kind: "existing",
             className: binding.className,
             previousClassName,
           });
@@ -3290,7 +3300,10 @@ export const LiveWorkerProvider = () =>
             ...taggedExportState?.pendingTransfers,
             ...observedExports.pendingTransfers,
           },
-          previousState: taggedExportState ?? output?.durableObjectExportState,
+          previousState: recoverDurableObjectExportState(
+            taggedExportState,
+            output?.durableObjectExportState,
+          ),
         });
         if (durableObjectPlanResult._tag === "Failure") {
           return yield* Effect.fail(durableObjectPlanResult.error);
@@ -3773,7 +3786,8 @@ export const LiveWorkerProvider = () =>
       ) {
         if (
           Object.keys(output.durableObjectExportState?.pendingTransfers ?? {})
-            .length > 0
+            .length > 0 ||
+          (output.durableObjectExportState?.cleanupClassNames?.length ?? 0) > 0
         ) {
           return true;
         }
@@ -5051,125 +5065,12 @@ function getDurableObjectBindings(
   );
 }
 
-/**
- * Cloudflare Worker script-tag limits, verified empirically against the live
- * API (2026-07):
- *
- * - at most **10 tags** per Worker (the 11th is rejected with `Forbidden`)
- * - each tag is at most **1024 bytes** (`BadRequest: Tag is too large`)
- * - tags may not contain `,` or `&`; everything else (`:`, `;`, `=`, `/`,
- *   spaces, unicode) is accepted and round-trips intact
- *
- * Alchemy reserves 3 ownership tags (`alchemy:stack/stage/id`), so the
- * Durable Object logical-id→class mapping must not spend one tag per DO
- * (#811). Instead all mappings are packed into as few `alchemy:dos:` tags as
- * possible.
- */
 const MAX_TAGS_PER_WORKER = 10;
-const MAX_TAG_BYTES = 1024;
-const LEGACY_DO_TAG_PREFIX = "alchemy:do:";
-const PACKED_DO_TAG_PREFIX = "alchemy:dos:";
 
 class InvalidWorkerTags extends Data.TaggedError("InvalidWorkerTags")<{
   scriptName: string;
   reason: string;
 }> {}
-
-/**
- * Pack Durable Object logical-id→class mappings into `alchemy:dos:` tags.
- *
- * Each mapping is encoded as `logicalId=className` — elided to just
- * `className` when the two are equal (the common case for export-derived
- * classes) — with both components `encodeURIComponent`-escaped so the `;`
- * pair separator, the `=` delimiter, and Cloudflare's forbidden tag
- * characters (`,`, `&`) can never collide with user identifiers. Pairs are
- * sorted for deterministic output and greedily packed so each tag stays
- * within Cloudflare's 1024-byte tag limit; workers with more DOs than fit in
- * one tag spill into additional `alchemy:dos:` tags.
- *
- * `encodeURIComponent` output is pure ASCII, so `String.length` equals the
- * tag's byte length.
- *
- * @internal exported for unit testing.
- */
-export function encodeDurableObjectTags(
-  durableObjects: ReadonlyArray<{ logicalId: string; className: string }>,
-): string[] {
-  const pairs = [...durableObjects]
-    .sort((a, b) => a.logicalId.localeCompare(b.logicalId))
-    .map(({ logicalId, className }) =>
-      logicalId === className
-        ? encodeURIComponent(className)
-        : `${encodeURIComponent(logicalId)}=${encodeURIComponent(className)}`,
-    );
-  const tags: string[] = [];
-  let payload = "";
-  for (const pair of pairs) {
-    const appended = payload === "" ? pair : `${payload};${pair}`;
-    if (
-      PACKED_DO_TAG_PREFIX.length + appended.length > MAX_TAG_BYTES &&
-      payload !== ""
-    ) {
-      tags.push(`${PACKED_DO_TAG_PREFIX}${payload}`);
-      payload = pair;
-    } else {
-      payload = appended;
-    }
-  }
-  if (payload !== "") {
-    tags.push(`${PACKED_DO_TAG_PREFIX}${payload}`);
-  }
-  return tags;
-}
-
-/**
- * Parse the Durable Object logical-id→class mapping from a worker's script
- * tags. Reads both formats so workers deployed before the packed format roll
- * forward transparently:
- *
- * - legacy: one `alchemy:do:{logicalId}:{className}` tag per DO
- * - packed: `alchemy:dos:{pair};{pair};…` (see {@link encodeDurableObjectTags})
- *
- * A packed entry wins over a legacy entry for the same logical id.
- *
- * @internal exported for unit testing.
- */
-export function getDurableObjectTagMap(tags: ReadonlyArray<string>) {
-  const map: Record<string, string> = {};
-  for (const tag of tags) {
-    if (tag.startsWith(LEGACY_DO_TAG_PREFIX)) {
-      const parts = tag.split(":");
-      const logicalId = parts[2];
-      const className = parts.slice(3).join(":");
-      if (logicalId && className && !(logicalId in map)) {
-        map[logicalId] = className;
-      }
-    }
-  }
-  for (const tag of tags) {
-    if (tag.startsWith(PACKED_DO_TAG_PREFIX)) {
-      for (const pair of tag.slice(PACKED_DO_TAG_PREFIX.length).split(";")) {
-        if (pair === "") continue;
-        const eq = pair.indexOf("=");
-        const logicalId = decodeURIComponent(
-          eq === -1 ? pair : pair.slice(0, eq),
-        );
-        const className = decodeURIComponent(
-          eq === -1 ? pair : pair.slice(eq + 1),
-        );
-        if (logicalId && className) {
-          map[logicalId] = className;
-        }
-      }
-    }
-  }
-  return map;
-}
-
-const isDurableObjectTag = (tag: string) =>
-  tag.startsWith(LEGACY_DO_TAG_PREFIX) ||
-  tag.startsWith(PACKED_DO_TAG_PREFIX) ||
-  isDurableObjectExportTag(tag);
 
 /**
  * Fail fast — before the script upload — when a worker's tag set violates
@@ -5206,11 +5107,11 @@ const validateWorkerTags = (
         );
       }
       const bytes = yield* Effect.sync(() => encoder.encode(tag).length);
-      if (bytes > MAX_TAG_BYTES) {
+      if (bytes > MAX_WORKER_TAG_BYTES) {
         return yield* Effect.fail(
           new InvalidWorkerTags({
             scriptName,
-            reason: `worker "${scriptName}" tag ${JSON.stringify(tag.slice(0, 64))}… is ${bytes} bytes; Cloudflare allows at most ${MAX_TAG_BYTES}.`,
+            reason: `worker "${scriptName}" tag ${JSON.stringify(tag.slice(0, 64))}… is ${bytes} bytes; Cloudflare allows at most ${MAX_WORKER_TAG_BYTES}.`,
           }),
         );
       }

--- a/packages/alchemy/test/Cloudflare/Workers/DurableObjectExports.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/DurableObjectExports.test.ts
@@ -1,0 +1,122 @@
+import {
+  buildDurableObjectExports,
+  nextDurableObjectExportState,
+} from "@/Cloudflare/Workers/DurableObjectExports";
+import { describe, expect, test } from "alchemy-test";
+
+describe("DurableObjectExports", () => {
+  test("derives live, renamed, deleted, transferred, and container exports", () => {
+    const plan = buildDurableObjectExports({
+      scriptName: "worker-a",
+      classes: [
+        { className: "CounterV2", previousClassName: "Counter" },
+        { className: "Incoming", transferFrom: "worker-b" },
+        { className: "Sandbox" },
+      ],
+      deletedClasses: ["Removed"],
+      transferredClasses: [{ className: "Moved", transferredTo: "worker-c" }],
+      containerClassNames: new Set(["Sandbox"]),
+      namespaces: [
+        {
+          script: "worker-a",
+          className: "Counter",
+          storage: "legacy-kv",
+        },
+      ],
+    });
+
+    expect(plan.exports).toEqual({
+      Counter: {
+        type: "durable-object",
+        state: "renamed",
+        renamedTo: "CounterV2",
+      },
+      CounterV2: { type: "durable-object", storage: "legacy-kv" },
+      Incoming: {
+        type: "durable-object",
+        state: "expecting-transfer",
+        storage: "sqlite",
+        transferFrom: "worker-b",
+      },
+      Sandbox: {
+        type: "durable-object",
+        storage: "sqlite",
+        container: "Sandbox",
+      },
+      Removed: { type: "durable-object", state: "deleted" },
+      Moved: {
+        type: "durable-object",
+        state: "transferred",
+        transferredTo: "worker-c",
+      },
+    });
+    expect(plan.changedClasses).toEqual([
+      "Counter",
+      "CounterV2",
+      "Incoming",
+      "Sandbox",
+      "Removed",
+      "Moved",
+    ]);
+  });
+
+  test("retains tombstones until Cloudflare reports them removable", () => {
+    const submitted = {
+      Counter: {
+        type: "durable-object" as const,
+        state: "deleted" as const,
+      },
+      Room: {
+        type: "durable-object" as const,
+        storage: "sqlite" as const,
+      },
+    };
+    const pending = nextDurableObjectExportState(submitted, {
+      created: [],
+      updated: [],
+      deleted: ["Counter"],
+      renamed: [],
+      transferred: [],
+      transferPending: [],
+      warnings: [],
+      info: [],
+      removableEntries: [],
+    });
+    expect(pending).toEqual({
+      tombstones: {
+        Counter: { type: "durable-object", state: "deleted" },
+      },
+      pendingTransfers: [],
+    });
+
+    expect(
+      nextDurableObjectExportState(submitted, {
+        created: [],
+        updated: [],
+        deleted: [],
+        renamed: [],
+        transferred: [],
+        transferPending: [],
+        warnings: [],
+        info: [],
+        removableEntries: ["Counter"],
+      }),
+    ).toBeUndefined();
+  });
+
+  test("retains pending transfers when an endpoint omits reconciliation", () => {
+    expect(
+      nextDurableObjectExportState(
+        {
+          Counter: {
+            type: "durable-object",
+            state: "expecting-transfer",
+            storage: "sqlite",
+            transferFrom: "source-worker",
+          },
+        },
+        undefined,
+      ),
+    ).toEqual({ tombstones: {}, pendingTransfers: ["Counter"] });
+  });
+});

--- a/packages/alchemy/test/Cloudflare/Workers/DurableObjectExports.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/DurableObjectExports.test.ts
@@ -1,31 +1,63 @@
 import {
-  buildDurableObjectExports,
   nextDurableObjectExportState,
+  observeDurableObjectExports,
+  observeLegacyDurableObjectStorage,
+  planDurableObjectExports,
+  type DurableObjectExportPlan,
+  type DurableObjectExportPlanResult,
 } from "@/Cloudflare/Workers/DurableObjectExports";
+import {
+  encodeDurableObjectExportTags,
+  getDurableObjectExportStateFromTags,
+} from "@/Cloudflare/Workers/DurableObjectExportTags.ts";
 import { describe, expect, test } from "alchemy-test";
+
+const unwrapPlan = (
+  result: DurableObjectExportPlanResult,
+): DurableObjectExportPlan => {
+  if (result._tag === "Failure") throw result.error;
+  return result.plan;
+};
 
 describe("DurableObjectExports", () => {
   test("derives live, renamed, deleted, transferred, and container exports", () => {
-    const plan = buildDurableObjectExports({
-      scriptName: "worker-a",
-      classes: [
-        { className: "CounterV2", previousClassName: "Counter" },
-        { className: "Incoming", transferFrom: "worker-b" },
-        { className: "Sandbox" },
-      ],
-      deletedClasses: ["Removed"],
-      transferredClasses: [{ className: "Moved", transferredTo: "worker-c" }],
-      containerClassNames: new Set(["Sandbox"]),
-      namespaces: [
-        {
-          script: "worker-a",
-          className: "Counter",
-          storage: "legacy-kv",
+    const plan = unwrapPlan(
+      planDurableObjectExports({
+        scriptName: "worker-a",
+        classes: [
+          { className: "CounterV2", previousClassName: "Counter" },
+          { className: "Incoming", transferFrom: "worker-b" },
+          { className: "Sandbox" },
+        ],
+        retirements: {
+          Removed: { kind: "deleted" },
+          Moved: { kind: "transferred", transferredTo: "worker-c" },
         },
-      ],
-    });
+        containerClassNames: new Set(["Sandbox"]),
+        namespaces: [
+          {
+            script: "worker-a",
+            className: "Counter",
+            storage: "legacy-kv",
+          },
+          {
+            script: "worker-b",
+            className: "Incoming",
+            storage: "sqlite",
+          },
+        ],
+        observedStorageByClass: {},
+        observedPendingTransfers: {},
+      }),
+    );
 
     expect(plan.exports).toEqual({
+      Removed: { type: "durable-object", state: "deleted" },
+      Moved: {
+        type: "durable-object",
+        state: "transferred",
+        transferredTo: "worker-c",
+      },
       Counter: {
         type: "durable-object",
         state: "renamed",
@@ -43,21 +75,16 @@ describe("DurableObjectExports", () => {
         storage: "sqlite",
         container: "Sandbox",
       },
-      Removed: { type: "durable-object", state: "deleted" },
-      Moved: {
-        type: "durable-object",
-        state: "transferred",
-        transferredTo: "worker-c",
-      },
     });
     expect(plan.changedClasses).toEqual([
+      "Removed",
+      "Moved",
       "Counter",
       "CounterV2",
       "Incoming",
       "Sandbox",
-      "Removed",
-      "Moved",
     ]);
+    expect([...plan.omittedBindingClassNames]).toEqual(["Incoming"]);
   });
 
   test("retains tombstones until Cloudflare reports them removable", () => {
@@ -86,7 +113,8 @@ describe("DurableObjectExports", () => {
       tombstones: {
         Counter: { type: "durable-object", state: "deleted" },
       },
-      pendingTransfers: [],
+      pendingTransfers: {},
+      storageByClass: { Room: "sqlite" },
     });
 
     expect(
@@ -101,22 +129,242 @@ describe("DurableObjectExports", () => {
         info: [],
         removableEntries: ["Counter"],
       }),
-    ).toBeUndefined();
+    ).toEqual({
+      tombstones: {},
+      pendingTransfers: {},
+      storageByClass: { Room: "sqlite" },
+    });
   });
 
-  test("retains pending transfers when an endpoint omits reconciliation", () => {
+  test("drops a rename tombstone when its target is retired", () => {
+    const plan = unwrapPlan(
+      planDurableObjectExports({
+        scriptName: "worker",
+        classes: [],
+        retirements: { CounterV2: { kind: "deleted" } },
+        containerClassNames: new Set(),
+        namespaces: [],
+        observedStorageByClass: {},
+        observedPendingTransfers: {},
+        previousState: {
+          tombstones: {
+            Counter: {
+              type: "durable-object",
+              state: "renamed",
+              renamedTo: "CounterV2",
+            },
+          },
+          pendingTransfers: {},
+          storageByClass: { CounterV2: "sqlite" },
+        },
+      }),
+    );
+
+    expect(plan.exports).toEqual({
+      CounterV2: { type: "durable-object", state: "deleted" },
+    });
+  });
+
+  test("retains submitted pending transfers even without reconciliation", () => {
     expect(
       nextDurableObjectExportState(
         {
           Counter: {
             type: "durable-object",
             state: "expecting-transfer",
-            storage: "sqlite",
+            storage: "legacy-kv",
             transferFrom: "source-worker",
           },
         },
         undefined,
       ),
-    ).toEqual({ tombstones: {}, pendingTransfers: ["Counter"] });
+    ).toEqual({
+      tombstones: {},
+      pendingTransfers: {
+        Counter: {
+          transferFrom: "source-worker",
+          storage: "legacy-kv",
+        },
+      },
+      storageByClass: { Counter: "legacy-kv" },
+    });
+  });
+
+  test("keeps a transfer pending until the source no longer owns it", () => {
+    const previousState = {
+      tombstones: {},
+      pendingTransfers: {
+        Counter: {
+          transferFrom: "source-worker",
+          storage: "sqlite" as const,
+        },
+      },
+      storageByClass: { Counter: "sqlite" as const },
+    };
+    const waiting = unwrapPlan(
+      planDurableObjectExports({
+        scriptName: "target-worker",
+        classes: [{ className: "Counter", previousClassName: "Counter" }],
+        retirements: {},
+        containerClassNames: new Set(),
+        namespaces: [
+          {
+            script: "source-worker",
+            className: "Counter",
+            storage: "sqlite",
+          },
+        ],
+        observedStorageByClass: {},
+        observedPendingTransfers: {},
+        previousState,
+      }),
+    );
+    expect(waiting.exports?.Counter).toEqual({
+      type: "durable-object",
+      state: "expecting-transfer",
+      storage: "sqlite",
+      transferFrom: "source-worker",
+    });
+    expect([...waiting.omittedBindingClassNames]).toEqual(["Counter"]);
+    expect(waiting.changedClasses).toEqual(["Counter"]);
+
+    const activated = unwrapPlan(
+      planDurableObjectExports({
+        scriptName: "target-worker",
+        classes: [{ className: "Counter", previousClassName: "Counter" }],
+        retirements: {},
+        containerClassNames: new Set(),
+        namespaces: [
+          {
+            script: "target-worker",
+            className: "Counter",
+            storage: "sqlite",
+          },
+        ],
+        observedStorageByClass: {},
+        observedPendingTransfers: {},
+        previousState,
+      }),
+    );
+    expect(activated.exports?.Counter).toEqual({
+      type: "durable-object",
+      storage: "sqlite",
+    });
+    expect([...activated.omittedBindingClassNames]).toEqual([]);
+    expect(activated.changedClasses).toEqual(["Counter"]);
+  });
+
+  test("recovers storage and pending transfers from settings exports", () => {
+    expect(
+      observeDurableObjectExports({
+        Counter: {
+          type: "durable-object",
+          state: "expecting-transfer",
+          storage: "legacy-kv",
+          transferFrom: "source-worker",
+        },
+        Handler: { type: "worker" },
+      }),
+    ).toEqual({
+      storageByClass: { Counter: "legacy-kv" },
+      pendingTransfers: {
+        Counter: {
+          transferFrom: "source-worker",
+          storage: "legacy-kv",
+        },
+      },
+    });
+  });
+
+  test("recovers immutable storage from legacy migration history", () => {
+    expect(
+      observeLegacyDurableObjectStorage({
+        steps: [
+          { newClasses: ["Legacy"], newSqliteClasses: ["Room"] },
+          { renamedClasses: [{ from: "Legacy", to: "LegacyV2" }] },
+          { deletedClasses: ["Room"] },
+        ],
+      }),
+    ).toEqual({ LegacyV2: "legacy-kv" });
+  });
+
+  test("fails instead of guessing storage for an existing class", () => {
+    const result = planDurableObjectExports({
+      scriptName: "dispatch-worker",
+      classes: [{ className: "Counter", previousClassName: "Counter" }],
+      retirements: {},
+      containerClassNames: new Set(),
+      namespaces: [],
+      observedStorageByClass: {},
+      observedPendingTransfers: {},
+    });
+    expect(result._tag).toBe("Failure");
+    if (result._tag === "Failure") {
+      expect(result.error._tag).toBe("DurableObjectStorageUnknown");
+    }
+  });
+
+  test("round-trips export recovery state through Worker tags", () => {
+    const tags = encodeDurableObjectExportTags({
+      Room: {
+        type: "durable-object",
+        storage: "sqlite",
+        container: "RoomContainer",
+      },
+      Incoming: {
+        type: "durable-object",
+        state: "expecting-transfer",
+        storage: "legacy-kv",
+        transferFrom: "source:worker",
+      },
+      Removed: { type: "durable-object", state: "deleted" },
+      Old: {
+        type: "durable-object",
+        state: "renamed",
+        renamedTo: "New",
+      },
+      Moved: {
+        type: "durable-object",
+        state: "transferred",
+        transferredTo: "target-worker",
+      },
+    });
+
+    expect(tags.every((tag) => tag.length <= 1024)).toBe(true);
+    expect(getDurableObjectExportStateFromTags(tags)).toEqual({
+      tombstones: {
+        Moved: {
+          type: "durable-object",
+          state: "transferred",
+          transferredTo: "target-worker",
+        },
+        Old: {
+          type: "durable-object",
+          state: "renamed",
+          renamedTo: "New",
+        },
+        Removed: { type: "durable-object", state: "deleted" },
+      },
+      pendingTransfers: {
+        Incoming: {
+          transferFrom: "source:worker",
+          storage: "legacy-kv",
+        },
+      },
+      storageByClass: {
+        Incoming: "legacy-kv",
+        Room: "sqlite",
+      },
+    });
+  });
+
+  test("ignores malformed export recovery tags", () => {
+    expect(
+      getDurableObjectExportStateFromTags([
+        "alchemy:doe:p:Counter:x:source",
+        "alchemy:doe:l:%ZZ:s",
+        "user-tag",
+      ]),
+    ).toBeUndefined();
   });
 });

--- a/packages/alchemy/test/Cloudflare/Workers/DurableObjectExports.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/DurableObjectExports.test.ts
@@ -3,6 +3,7 @@ import {
   observeDurableObjectExports,
   observeLegacyDurableObjectStorage,
   planDurableObjectExports,
+  recoverDurableObjectExportState,
   type DurableObjectExportPlan,
   type DurableObjectExportPlanResult,
 } from "@/Cloudflare/Workers/DurableObjectExports";
@@ -25,9 +26,17 @@ describe("DurableObjectExports", () => {
       planDurableObjectExports({
         scriptName: "worker-a",
         classes: [
-          { className: "CounterV2", previousClassName: "Counter" },
-          { className: "Incoming", transferFrom: "worker-b" },
-          { className: "Sandbox" },
+          {
+            kind: "existing",
+            className: "CounterV2",
+            previousClassName: "Counter",
+          },
+          {
+            kind: "incoming-transfer",
+            className: "Incoming",
+            transferFrom: "worker-b",
+          },
+          { kind: "new", className: "Sandbox" },
         ],
         retirements: {
           Removed: { kind: "deleted" },
@@ -115,6 +124,7 @@ describe("DurableObjectExports", () => {
       },
       pendingTransfers: {},
       storageByClass: { Room: "sqlite" },
+      cleanupClassNames: [],
     });
 
     expect(
@@ -133,6 +143,7 @@ describe("DurableObjectExports", () => {
       tombstones: {},
       pendingTransfers: {},
       storageByClass: { Room: "sqlite" },
+      cleanupClassNames: ["Counter"],
     });
   });
 
@@ -156,6 +167,7 @@ describe("DurableObjectExports", () => {
           },
           pendingTransfers: {},
           storageByClass: { CounterV2: "sqlite" },
+          cleanupClassNames: [],
         },
       }),
     );
@@ -163,6 +175,44 @@ describe("DurableObjectExports", () => {
     expect(plan.exports).toEqual({
       CounterV2: { type: "durable-object", state: "deleted" },
     });
+  });
+
+  test("does not restore a tombstone already marked for cleanup", () => {
+    const recovered = recoverDurableObjectExportState(
+      {
+        tombstones: {
+          Counter: { type: "durable-object", state: "deleted" },
+        },
+        pendingTransfers: {},
+        storageByClass: {},
+        cleanupClassNames: [],
+      },
+      {
+        tombstones: {},
+        pendingTransfers: {},
+        storageByClass: {},
+        cleanupClassNames: ["Counter"],
+      },
+    );
+    expect(recovered).toEqual({
+      tombstones: {},
+      pendingTransfers: {},
+      storageByClass: {},
+      cleanupClassNames: ["Counter"],
+    });
+    const plan = unwrapPlan(
+      planDurableObjectExports({
+        scriptName: "worker",
+        classes: [],
+        retirements: {},
+        containerClassNames: new Set(),
+        namespaces: [],
+        observedStorageByClass: {},
+        observedPendingTransfers: {},
+        previousState: recovered,
+      }),
+    );
+    expect(plan.changedClasses).toEqual(["Counter"]);
   });
 
   test("retains submitted pending transfers even without reconciliation", () => {
@@ -187,6 +237,7 @@ describe("DurableObjectExports", () => {
         },
       },
       storageByClass: { Counter: "legacy-kv" },
+      cleanupClassNames: [],
     });
   });
 
@@ -200,11 +251,18 @@ describe("DurableObjectExports", () => {
         },
       },
       storageByClass: { Counter: "sqlite" as const },
+      cleanupClassNames: [],
     };
     const waiting = unwrapPlan(
       planDurableObjectExports({
         scriptName: "target-worker",
-        classes: [{ className: "Counter", previousClassName: "Counter" }],
+        classes: [
+          {
+            kind: "existing",
+            className: "Counter",
+            previousClassName: "Counter",
+          },
+        ],
         retirements: {},
         containerClassNames: new Set(),
         namespaces: [
@@ -231,7 +289,13 @@ describe("DurableObjectExports", () => {
     const activated = unwrapPlan(
       planDurableObjectExports({
         scriptName: "target-worker",
-        classes: [{ className: "Counter", previousClassName: "Counter" }],
+        classes: [
+          {
+            kind: "existing",
+            className: "Counter",
+            previousClassName: "Counter",
+          },
+        ],
         retirements: {},
         containerClassNames: new Set(),
         namespaces: [
@@ -252,6 +316,46 @@ describe("DurableObjectExports", () => {
     });
     expect([...activated.omittedBindingClassNames]).toEqual([]);
     expect(activated.changedClasses).toEqual(["Counter"]);
+  });
+
+  test("rejects renaming a destination while its transfer is pending", () => {
+    const result = planDurableObjectExports({
+      scriptName: "target-worker",
+      classes: [
+        {
+          kind: "existing",
+          className: "CounterV2",
+          previousClassName: "Counter",
+        },
+      ],
+      retirements: {},
+      containerClassNames: new Set(),
+      namespaces: [
+        {
+          script: "source-worker",
+          className: "Counter",
+          storage: "sqlite",
+        },
+      ],
+      observedStorageByClass: {},
+      observedPendingTransfers: {},
+      previousState: {
+        tombstones: {},
+        pendingTransfers: {
+          Counter: {
+            transferFrom: "source-worker",
+            storage: "sqlite",
+          },
+        },
+        storageByClass: { Counter: "sqlite" },
+        cleanupClassNames: [],
+      },
+    });
+
+    expect(result._tag).toBe("Failure");
+    if (result._tag === "Failure") {
+      expect(result.error._tag).toBe("DurableObjectPendingTransferRename");
+    }
   });
 
   test("recovers storage and pending transfers from settings exports", () => {
@@ -291,7 +395,13 @@ describe("DurableObjectExports", () => {
   test("fails instead of guessing storage for an existing class", () => {
     const result = planDurableObjectExports({
       scriptName: "dispatch-worker",
-      classes: [{ className: "Counter", previousClassName: "Counter" }],
+      classes: [
+        {
+          kind: "existing",
+          className: "Counter",
+          previousClassName: "Counter",
+        },
+      ],
       retirements: {},
       containerClassNames: new Set(),
       namespaces: [],
@@ -355,6 +465,7 @@ describe("DurableObjectExports", () => {
         Incoming: "legacy-kv",
         Room: "sqlite",
       },
+      cleanupClassNames: [],
     });
   });
 

--- a/packages/alchemy/test/Cloudflare/Workers/DurableObjectNamespace.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/DurableObjectNamespace.test.ts
@@ -358,13 +358,13 @@ describe.concurrent("scratch", () => {
 
   // Walk an async worker through four redeploys against the same scratch state,
   // each one swapping in a new script + bindings shape so we exercise the
-  // migration paths `putWorker` relies on:
+  // lifecycle paths `putWorker` relies on:
   //   v1 — create with a single DO class `DO_A`
   //   v2 — rename `DO_A` → `DO_A_v2` (className change, same binding id)
   //   v3 — add a brand-new DO class `DO_B` alongside `DO_A_v2`
   //   v4 — delete `DO_A`, keep only `DO_B`
   test.provider(
-    "durable object class migrations across redeploys",
+    "durable object class lifecycle across redeploys",
     (scratch) =>
       Effect.gen(function* () {
         const v1 = yield* scratch.deploy(
@@ -549,7 +549,7 @@ export default { async fetch() { return new Response("v4"); } };
   // `alchemy:do:` logical-id→class mapping, so `read` returns `Unowned` and the
   // takeover requires `adopt(true)`. The matching `Counter` class must be reused
   // — if `putWorker` instead asked Cloudflare to create it as a *new* class the
-  // migration would fail with "class already exists". This is the documented
+  // reconciliation would fail with "class already exists". This is the documented
   // limitation: on the first (adopting) deploy the binding's class name must
   // match the existing class; renames only work once Alchemy owns the worker.
   test.provider(
@@ -562,7 +562,7 @@ export default { async fetch() { return new Response("v4"); } };
         // Cloudflare API — no Alchemy involvement, so none of our tags. The
         // name is deterministic (never Date.now()/random); a crashed run can
         // leave the worker behind, and `putScript` would then reject the
-        // `newSqliteClasses` migration ("class already exists"), so purge any
+        // legacy seed migration ("class already exists"), so purge any
         // leftover first.
         const physicalName = "alchemy-test-do-adopt";
 
@@ -638,14 +638,14 @@ export default { async fetch() { return new Response("v4"); } };
   // here by Worker *logical id*, resolved to the actual script via alchemy's
   // ownership tags (`alchemy:id:` + stack + stage) among scripts observed to
   // host the class. Worker-a's deploy ships Cloudflare's data-preserving
-  // `transferred_classes` migration; worker-b's deploy converges on its own
-  // (no `deleted_classes` for a class that moved away).
+  // declarative transfer; worker-b's deploy commits the handoff.
   //
   //   v1 — worker-b hosts `Counter` locally; write data into the namespace
-  //   v2 — worker-a hosts `Counter` with `transferredFrom: "worker-b"`;
-  //        worker-b re-binds it cross-script. The stored data must survive
-  //        the move, reachable from both.
-  //   v3 — redeploy of the same shape is inert (no re-transfer; the
+  //   v2a — worker-a declares an expecting transfer; worker-b commits it.
+  //   v2b — the same declaration converges worker-a to a live export and
+  //         attaches its binding. The stored data must survive the move,
+  //         reachable from both.
+  //   v3 — redeploy of the converged shape is inert (no re-transfer; the
   //        declaration stays in the code).
   test.provider(
     "durable object host move declared by worker logical id preserves data",
@@ -695,6 +695,7 @@ export default { async fetch() { return new Response("v4"); } };
           return { a, b };
         });
 
+        yield* scratch.deploy(moved);
         const v2 = yield* scratch.deploy(moved);
 
         // The namespace moved to worker-a with its data intact...
@@ -712,7 +713,7 @@ export default { async fetch() { return new Response("v4"); } };
 
         // Redeploying the same shape is inert: the class now lives on
         // worker-a (tracked by its alchemy:do tag), so the standing
-        // declaration must not re-emit a transfer migration. Data intact.
+        // declaration must not restart the transfer. Data intact.
         const v3 = yield* scratch.deploy(moved);
         const afterRedeploy = yield* fetchJsonReady<{ value: number }>(
           `${v3.a.url}/get`,
@@ -721,7 +722,7 @@ export default { async fetch() { return new Response("v4"); } };
 
         // ...and once the move has landed everywhere, the declaration can be
         // removed entirely: the class is anchored by its alchemy:do tag, so
-        // dropping `transferredFrom` emits no migration and touches no data.
+        // dropping `transferredFrom` changes no lifecycle state or data.
         const v4 = yield* scratch.deploy(
           Effect.gen(function* () {
             const a = yield* Cloudflare.Worker("worker-a", {
@@ -789,32 +790,33 @@ export default { async fetch() { return new Response("v4"); } };
         const aScriptName = v1.a.workerName;
         const bScriptName = v1.b.workerName;
 
-        const v2 = yield* scratch.deploy(
-          Effect.gen(function* () {
-            const a = yield* Cloudflare.Worker("worker-a", {
-              script: hostWorkerScript,
-              env: {
-                Counter: Cloudflare.DurableObject("Counter", {
-                  // Thunk form — evaluated lazily at plan time and
-                  // normalized to the plain script name.
-                  transferredFrom: () => bScriptName,
-                }),
-              },
-            });
-            const b = yield* Cloudflare.Worker("worker-b", {
-              script: consumerWorkerScript,
-              env: {
-                // Service binding orders worker-b after worker-a (the raw
-                // string scriptName below carries no dependency edge).
-                A: a,
-                Counter: Cloudflare.DurableObject("Counter", {
-                  scriptName: aScriptName,
-                }),
-              },
-            });
-            return { a, b };
-          }),
-        );
+        const moved = Effect.gen(function* () {
+          const a = yield* Cloudflare.Worker("worker-a", {
+            script: hostWorkerScript,
+            env: {
+              Counter: Cloudflare.DurableObject("Counter", {
+                // Thunk form — evaluated lazily at plan time and
+                // normalized to the plain script name.
+                transferredFrom: () => bScriptName,
+              }),
+            },
+          });
+          const b = yield* Cloudflare.Worker("worker-b", {
+            script: consumerWorkerScript,
+            env: {
+              // Service binding orders worker-b after worker-a (the raw
+              // string scriptName below carries no dependency edge).
+              A: a,
+              Counter: Cloudflare.DurableObject("Counter", {
+                scriptName: aScriptName,
+              }),
+            },
+          });
+          return { a, b };
+        });
+
+        yield* scratch.deploy(moved);
+        const v2 = yield* scratch.deploy(moved);
 
         const viaA = yield* fetchJsonReady<{ value: number }>(
           `${v2.a.url}/get`,
@@ -891,15 +893,12 @@ export default { async fetch() { return new Response("v4"); } };
     { timeout: 240_000 },
   );
 
-  // #799: the documented *pure move* — the former host drops the DO entirely,
-  // keeping no cross-script reference — done as two deploys. Phase 1 adds the
-  // class to worker-a, declaring the former host by **Worker resource
-  // reference** (`transferredFrom: b`, normalized at plan time to worker-b's
-  // logical id — no dependency edge on b); worker-b is untouched. Phase 2
-  // removes the DO from worker-b, whose deploy observes the class already
-  // transferred away and skips the delete.
+  // #799: the documented *pure move* ends with the former host dropping the
+  // DO entirely. The transfer first converges over two deploys while worker-b
+  // keeps a cross-script reference, then a final deploy removes worker-b's
+  // binding. `transferredFrom: b` uses the Worker resource-reference form.
   test.provider(
-    "two-deploy pure move with a Worker resource reference",
+    "pure move with a Worker resource reference",
     (scratch) =>
       Effect.gen(function* () {
         yield* scratch.destroy();
@@ -923,27 +922,33 @@ export default { async fetch() { return new Response("v4"); } };
         );
         expect(written.value).toBe(1);
 
-        // Phase 1: worker-a takes the class, naming the former host by
-        // resource reference. worker-b's declaration is unchanged (noop).
-        const v2 = yield* scratch.deploy(
-          Effect.gen(function* () {
-            const b = yield* Cloudflare.Worker("worker-b", {
-              script: hostWorkerScript,
-              env: {
-                Counter: Cloudflare.DurableObject("Counter"),
+        const moving = Effect.gen(function* () {
+          const b = yield* Cloudflare.Worker("worker-b", {
+            script: consumerWorkerScript,
+          });
+          const a = yield* Cloudflare.Worker("worker-a", {
+            script: hostWorkerScript,
+            env: {
+              Counter: Cloudflare.DurableObject("Counter", {
+                transferredFrom: b,
+              }),
+            },
+          });
+          yield* b.bind("counter", {
+            bindings: [
+              {
+                type: "durable_object_namespace",
+                name: "Counter",
+                className: "Counter",
+                scriptName: a.workerName,
               },
-            });
-            const a = yield* Cloudflare.Worker("worker-a", {
-              script: hostWorkerScript,
-              env: {
-                Counter: Cloudflare.DurableObject("Counter", {
-                  transferredFrom: b,
-                }),
-              },
-            });
-            return { a, b };
-          }),
-        );
+            ],
+          });
+          return { a, b };
+        });
+
+        yield* scratch.deploy(moving);
+        const v2 = yield* scratch.deploy(moving);
 
         // The namespace moved to worker-a with its data intact.
         const viaA = yield* fetchJsonReady<{ value: number }>(
@@ -951,8 +956,8 @@ export default { async fetch() { return new Response("v4"); } };
         );
         expect(viaA.value).toBe(1);
 
-        // Phase 2: worker-b drops the DO entirely. Its deploy observes the
-        // class already lives on worker-a and emits no delete migration.
+        // Final phase: worker-b drops the DO entirely. Its deploy observes the
+        // class already lives on worker-a and emits no delete tombstone.
         const v3 = yield* scratch.deploy(
           Effect.gen(function* () {
             const b = yield* Cloudflare.Worker("worker-b", {
@@ -981,12 +986,12 @@ export default { async fetch() { return new Response("v4"); } };
   );
 
   // Reproduces #811: one script tag per DO binding blew Cloudflare's 10-tag
-  // limit at 7+ Durable Objects (3 ownership tags + 1 migration tag + N DO
-  // tags). The logical-id→class mapping is now packed into `alchemy:dos:`
+  // limit at 8+ Durable Objects (3 ownership tags + N DO tags). The
+  // logical-id→class mapping is now packed into `alchemy:dos:`
   // tags, so a worker with 20 DOs — double the count that used to consume the
   // entire tag budget — deploys fine and the whole tag set stays within the
   // limit. The second deploy renames a class and drops another to prove
-  // migrations are still driven by the packed mapping.
+  // lifecycle changes are still driven by the packed mapping.
   test.provider(
     "worker with 20 durable objects deploys within the 10-tag limit",
     (scratch) =>
@@ -1027,7 +1032,7 @@ export default { async fetch() { return new Response("${version}"); } };
         expect(tags.filter((t) => t.startsWith("alchemy:do:"))).toHaveLength(0);
 
         // Rename Class0 → Class0V2 (same binding id) and delete DO_19 — both
-        // migrations resolve their previous class through the packed tag.
+        // lifecycle changes resolve their previous class through the packed tag.
         const v2 = yield* scratch.deploy(
           Effect.gen(function* () {
             return {
@@ -1101,6 +1106,18 @@ export default { async fetch() { return new Response("v1"); } };
           accountId,
           scriptName,
           settings: {
+            // Settings PATCHes also reconcile the complete export map. Keep
+            // both live classes declared while this test rewrites only tags.
+            exports: {
+              CounterClass: {
+                type: "durable-object",
+                storage: "sqlite",
+              },
+              MeterClass: {
+                type: "durable-object",
+                storage: "sqlite",
+              },
+            },
             tags: [
               ...deployedTags.filter((t) => !t.startsWith("alchemy:dos:")),
               "alchemy:do:Counter:CounterClass",
@@ -1110,7 +1127,7 @@ export default { async fetch() { return new Response("v1"); } };
         });
 
         // Redeploy with a rename; the previous class must be resolved from the
-        // legacy tags for the migration to succeed.
+        // legacy tags for the rename to succeed.
         const v2 = yield* scratch.deploy(
           Effect.gen(function* () {
             return {
@@ -1161,7 +1178,7 @@ export default { async fetch() { return new Response("v2"); } };
   //        while that same-name namespace exists on worker-b: the class is
   //        already anchored to worker-a by its DO tag, so the stale
   //        declaration must not steal worker-b's namespace or emit any
-  //        migration. Distinct counter values prove both namespaces survive
+  //        lifecycle change. Distinct counter values prove both namespaces survive
   //        untouched.
   test.provider(
     "standing transferredFrom is inert on fresh stages and never steals a same-name namespace",
@@ -1243,7 +1260,7 @@ export default { async fetch() { return new Response("v2"); } };
 
         // Force a real reconcile of worker-a with the stale declaration while
         // the twin exists. The class is tag-anchored to worker-a, so no
-        // migration may be emitted and neither namespace may change.
+        // lifecycle change may be emitted and neither namespace may change.
         const v3 = yield* scratch.deploy(
           Effect.gen(function* () {
             const a = yield* Cloudflare.Worker("worker-a", {

--- a/packages/alchemy/test/Cloudflare/Workers/DurableObjectNamespace.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/DurableObjectNamespace.test.ts
@@ -1,6 +1,8 @@
 import { adopt } from "@/AdoptPolicy";
 import * as Cloudflare from "@/Cloudflare";
 import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
+import { getDurableObjectExportStateFromTags } from "@/Cloudflare/Workers/DurableObjectExportTags.ts";
+import { WorkerVersionConfigError } from "@/Cloudflare/Workers/WorkerProvider.ts";
 import * as Output from "@/Output";
 import * as Test from "@/Test/Alchemy";
 import * as workers from "@distilled.cloud/cloudflare/workers";
@@ -641,8 +643,10 @@ export default { async fetch() { return new Response("v4"); } };
   // declarative transfer; worker-b's deploy commits the handoff.
   //
   //   v1 — worker-b hosts `Counter` locally; write data into the namespace
-  //   v2a — worker-a declares an expecting transfer; worker-b commits it.
-  //   v2b — the same declaration converges worker-a to a live export and
+  //   v2a — worker-a declares an expecting transfer while worker-b remains
+  //         the source. Repeating this phase must remain pending.
+  //   v2b — worker-b commits the transfer.
+  //   v2c — the same declaration converges worker-a to a live export and
   //         attaches its binding. The stored data must survive the move,
   //         reachable from both.
   //   v3 — redeploy of the converged shape is inert (no re-transfer; the
@@ -672,6 +676,63 @@ export default { async fetch() { return new Response("v4"); } };
           `${v1.b.url}/increment`,
         );
         expect(written.value).toBe(1);
+
+        const waiting = Effect.gen(function* () {
+          const a = yield* Cloudflare.Worker("worker-a", {
+            script: hostWorkerScript,
+            env: {
+              Counter: Cloudflare.DurableObject("Counter", {
+                transferredFrom: "worker-b",
+              }),
+            },
+          });
+          const b = yield* Cloudflare.Worker("worker-b", {
+            script: hostWorkerScript,
+            env: {
+              Counter: Cloudflare.DurableObject("Counter"),
+            },
+          });
+          return { a, b };
+        });
+
+        const pending = yield* scratch.deploy(waiting);
+        const retried = yield* scratch.deploy(waiting);
+        const { accountId } = yield* yield* CloudflareEnvironment;
+        const pendingTags = yield* getWorkerTags(
+          retried.a.workerName,
+          accountId,
+        );
+        expect(
+          getDurableObjectExportStateFromTags(pendingTags)?.pendingTransfers
+            .Counter,
+        ).toEqual({
+          storage: "sqlite",
+          transferFrom: pending.b.workerName,
+        });
+
+        const versionError = yield* scratch
+          .deploy(
+            Effect.gen(function* () {
+              const a = yield* Cloudflare.Worker("worker-a", {
+                script: hostWorkerScript,
+                version: { traffic: 50 },
+                env: {
+                  Counter: Cloudflare.DurableObject("Counter", {
+                    transferredFrom: "worker-b",
+                  }),
+                },
+              });
+              const b = yield* Cloudflare.Worker("worker-b", {
+                script: hostWorkerScript,
+                env: {
+                  Counter: Cloudflare.DurableObject("Counter"),
+                },
+              });
+              return { a, b };
+            }),
+          )
+          .pipe(Effect.flip);
+        expect(versionError).toBeInstanceOf(WorkerVersionConfigError);
 
         const moved = Effect.gen(function* () {
           const a = yield* Cloudflare.Worker("worker-a", {

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerProvider.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerProvider.test.ts
@@ -1,6 +1,8 @@
 import {
   encodeDurableObjectTags,
   getDurableObjectTagMap,
+} from "@/Cloudflare/Workers/DurableObjectExportTags";
+import {
   normalizeStateDomains,
   resolveWorkerDomain,
   resolveWorkersDev,


### PR DESCRIPTION
Replace Worker migration metadata with Cloudflare's declarative Durable Object export reconciliation. Existing Durable Object declarations remain the source of truth.

```ts
const Counter = Cloudflare.DurableObject("Counter");

yield* Cloudflare.Worker("worker", {
  main: "./worker.ts",
  env: { Counter },
});
```

- Derive live, renamed, deleted, and transferred exports from Worker bindings and persisted class identity
- Preserve immutable namespace storage when adopting existing Workers, including Workers for Platforms
- Recover interrupted transfers from live settings when available and bounded Worker lifecycle tags otherwise
- Retain valid tombstones until Cloudflare reports them removable
- Keep pending transfers retry-safe and reject them on the versions path

Depends on [alchemy-run/distilled#394](https://github.com/alchemy-run/distilled/pull/394).

Closes #996.
