### PR TITLE
docs(prisma): improve user-facing provider documentation

### DIFF
--- a/packages/alchemy/src/Prisma/App.ts
+++ b/packages/alchemy/src/Prisma/App.ts
@@ -92,13 +92,27 @@ export interface App extends Resource<
 /**
  * A Prisma App, the long-lived application configuration that owns deployments.
  *
+ * The App Management API is experimental. Omit `branchId` and
+ * `branchGitName` to attach the App to the project's current default branch.
+ * App regions are immutable; create a second App and cut traffic over when
+ * moving regions. Use `Prisma.Compute` for the usual build, deployment,
+ * health-check, and promotion workflow; use `App` directly when managing
+ * standalone `Prisma.Deployment` resources.
+ *
  * @resource
  * @section Creating an App
- * @example App attached to a branch
+ * @example App on the default branch
  * ```typescript
  * const app = yield* Prisma.App("web", {
- *   project: project.projectId,
- *   branchGitName: "main",
+ *   project,
+ * });
+ * ```
+ *
+ * @example App on a preview branch
+ * ```typescript
+ * const app = yield* Prisma.App("preview-web", {
+ *   project,
+ *   branchId: preview.branchId,
  * });
  * ```
  */

--- a/packages/alchemy/src/Prisma/App.ts
+++ b/packages/alchemy/src/Prisma/App.ts
@@ -92,12 +92,11 @@ export interface App extends Resource<
 /**
  * A Prisma App, the long-lived application configuration that owns deployments.
  *
- * The App Management API is experimental. Omit `branchId` and
- * `branchGitName` to attach the App to the project's current default branch.
- * App regions are immutable; create a second App and cut traffic over when
- * moving regions. Use `Prisma.Compute` for the usual build, deployment,
- * health-check, and promotion workflow; use `App` directly when managing
- * standalone `Prisma.Deployment` resources.
+ * Omit `branchId` and `branchGitName` to attach the App to the project's
+ * current default branch. App regions are immutable; create a second App and
+ * cut traffic over when moving regions. Use `Prisma.Compute` for the usual
+ * build, deployment, health-check, and promotion workflow; use `App` directly
+ * when managing standalone `Prisma.Deployment` resources.
  *
  * @resource
  * @section Creating an App

--- a/packages/alchemy/src/Prisma/Branch.ts
+++ b/packages/alchemy/src/Prisma/Branch.ts
@@ -35,6 +35,7 @@ export interface BranchProps {
    * Promote this branch to be the project's default branch. Setting this to
    * `false` does not demote a current default because the Management API only
    * supports promotion; promoting another branch atomically demotes it.
+   * Promotion changes `isDefault`, not the branch's immutable `preview` role.
    *
    * @default false
    */
@@ -86,6 +87,14 @@ export interface Branch extends Resource<
 /**
  * A Prisma project branch for preview-class databases and compute resources.
  *
+ * The Branch Management API is experimental. A standalone `Prisma.Branch`
+ * is created with Prisma's immutable `preview` role because the owning project
+ * already has its project-owned `production` branch. `isDefault: true`
+ * changes which branch is the default without changing that role. On destroy,
+ * Alchemy restores the displaced default before deleting a promoted preview
+ * branch. The project-owned production branch cannot be managed as a
+ * standalone Branch resource.
+ *
  * @resource
  * @section Creating a Branch
  * @example Preview branch
@@ -93,6 +102,16 @@ export interface Branch extends Resource<
  * const branch = yield* Prisma.Branch("preview", {
  *   project: project.projectId,
  *   gitName: "feature/search", // optional — omitted, a stable name is generated
+ * });
+ * ```
+ *
+ * @section Promoting a Branch
+ * @example Make a preview branch the default
+ * ```typescript
+ * const release = yield* Prisma.Branch("release", {
+ *   project,
+ *   gitName: "release/next",
+ *   isDefault: true,
  * });
  * ```
  */

--- a/packages/alchemy/src/Prisma/Branch.ts
+++ b/packages/alchemy/src/Prisma/Branch.ts
@@ -87,13 +87,9 @@ export interface Branch extends Resource<
 /**
  * A Prisma project branch for preview-class databases and compute resources.
  *
- * The Branch Management API is experimental. A standalone `Prisma.Branch`
- * is created with Prisma's immutable `preview` role because the owning project
- * already has its project-owned `production` branch. `isDefault: true`
- * changes which branch is the default without changing that role. On destroy,
- * Alchemy restores the displaced default before deleting a promoted preview
- * branch. The project-owned production branch cannot be managed as a
- * standalone Branch resource.
+ * Standalone Branch resources always have the `preview` role. Promotion
+ * changes only the default branch; Alchemy restores the previous default
+ * before deleting a promoted branch.
  *
  * @resource
  * @section Creating a Branch
@@ -103,6 +99,9 @@ export interface Branch extends Resource<
  *   project: project.projectId,
  *   gitName: "feature/search", // optional — omitted, a stable name is generated
  * });
+ *
+ * branch.role;      // "preview"
+ * branch.isDefault; // false
  * ```
  *
  * @section Promoting a Branch
@@ -113,6 +112,9 @@ export interface Branch extends Resource<
  *   gitName: "release/next",
  *   isDefault: true,
  * });
+ *
+ * release.role;      // still "preview"
+ * release.isDefault; // true
  * ```
  */
 export const Branch = Resource<Branch>("Prisma.Branch");

--- a/packages/alchemy/src/Prisma/Compute.ts
+++ b/packages/alchemy/src/Prisma/Compute.ts
@@ -545,7 +545,10 @@ const isEffectNativeCompute = (props: ComputeProps) =>
   hasEffectNativeComputeInput(props);
 
 /**
- * A Prisma Compute deployment resource.
+ * Build and deploy an application to Prisma Compute.
+ *
+ * The App, Deployment, environment-variable, and custom-domain Management API
+ * endpoints used by this resource are experimental.
  *
  * Prisma's create-deployment API exposes neither an idempotency key nor a
  * caller-defined recovery key. If the API commits a deployment but its create
@@ -578,7 +581,7 @@ const isEffectNativeCompute = (props: ComputeProps) =>
  *   },
  *   Effect.gen(function* () {
  *     return {
- *       fetch: HttpServerResponse.text("ok"),
+ *       fetch: Effect.succeed(HttpServerResponse.text("ok")),
  *     };
  *   }),
  * );
@@ -601,7 +604,7 @@ const isEffectNativeCompute = (props: ComputeProps) =>
  *     return {
  *       fetch: Effect.gen(function* () {
  *         const users = yield* sql`SELECT * FROM users`;
- *         return HttpServerResponse.json(users);
+ *         return yield* HttpServerResponse.json(users);
  *       }),
  *     };
  *   }).pipe(Effect.provide(Prisma.ConnectBinding)),
@@ -620,7 +623,7 @@ const isEffectNativeCompute = (props: ComputeProps) =>
  *   },
  *   port: 8080,
  *   env: {
- *     DATABASE_URL: database.directConnectionString,
+ *     DATABASE_URL: connection.databaseUrl,
  *   },
  *   destroyOldDeployment: true,
  * });

--- a/packages/alchemy/src/Prisma/Compute.ts
+++ b/packages/alchemy/src/Prisma/Compute.ts
@@ -547,9 +547,6 @@ const isEffectNativeCompute = (props: ComputeProps) =>
 /**
  * Build and deploy an application to Prisma Compute.
  *
- * The App, Deployment, environment-variable, and custom-domain Management API
- * endpoints used by this resource are experimental.
- *
  * Prisma's create-deployment API exposes neither an idempotency key nor a
  * caller-defined recovery key. If the API commits a deployment but its create
  * response is lost before Alchemy persists the returned ID, that deployment

--- a/packages/alchemy/src/Prisma/Connect.ts
+++ b/packages/alchemy/src/Prisma/Connect.ts
@@ -85,6 +85,29 @@ export interface ConnectClient {
  * Context tag, its type, and the callable —
  * `yield* Prisma.Connect(connection)`.
  *
+ * Provide `Prisma.ConnectBinding` on the host implementation so Alchemy can
+ * register the deploy-time binding and resolve the client at runtime.
+ *
+ * @section Binding a Connection
+ * @example Use a connection inside Prisma Compute
+ * ```typescript
+ * export default Prisma.Compute(
+ *   "api",
+ *   { project, main: import.meta.filename },
+ *   Effect.gen(function* () {
+ *     const db = yield* Prisma.Connect(connection);
+ *     const sql = yield* SQL.Postgres({ url: db.databaseUrl });
+ *
+ *     return {
+ *       fetch: Effect.gen(function* () {
+ *         const users = yield* sql`SELECT * FROM users`;
+ *         return yield* HttpServerResponse.json(users);
+ *       }),
+ *     };
+ *   }).pipe(Effect.provide(Prisma.ConnectBinding)),
+ * );
+ * ```
+ *
  * @binding
  */
 export interface Connect extends Binding.Service<

--- a/packages/alchemy/src/Prisma/Connection.ts
+++ b/packages/alchemy/src/Prisma/Connection.ts
@@ -47,7 +47,10 @@ export interface ConnectionProps {
    */
   name?: string;
   /**
-   * Rotate credentials during the next update while keeping the connection ID.
+   * Rotate credentials when this value changes from `false` to `true` while
+   * keeping the connection ID. Prisma revokes the previous credentials on a
+   * best-effort basis. Deploy `false` before changing back to `true` for a
+   * later rotation.
    *
    * @default false
    */
@@ -129,6 +132,11 @@ export interface Connection extends Resource<
 /**
  * A Prisma database connection/API key.
  *
+ * Prisma returns connection credentials only when it creates or rotates a
+ * connection. Alchemy stores those outputs as `Redacted` values. Changing the
+ * database or name replaces the connection; changing `rotate` from `false` to
+ * `true` keeps the connection ID and requests fresh credentials.
+ *
  * @section Creating a Connection
  * @example Application connection
  * ```typescript
@@ -146,8 +154,7 @@ export interface Connection extends Resource<
  *
  * const app = yield* Prisma.Compute("api", {
  *   project,
- *   appName: "api",
- *   main: import.meta.filename,
+ *   path: "./apps/api",
  *   env: {
  *     DATABASE_URL: connection.databaseUrl,
  *     DIRECT_URL: connection.directConnectionString,
@@ -195,17 +202,27 @@ export interface Connection extends Resource<
  * ```typescript
  * export default Cloudflare.Worker(
  *   "api",
- *   { main: import.meta.filename },
+ *   { main: import.meta.filename, compatibility: { flags: ["nodejs_compat"] } },
  *   Effect.gen(function* () {
  *     const db = yield* Prisma.Connect(connection);
+ *     const sql = yield* SQL.Postgres({ url: db.databaseUrl });
  *     return {
  *       fetch: Effect.gen(function* () {
- *         const databaseUrl = yield* db.databaseUrl;
- *         return yield* HttpServerResponse.text("connected");
+ *         const result = yield* sql`SELECT 1 AS ok`;
+ *         return yield* HttpServerResponse.json(result);
  *       }),
  *     };
  *   }).pipe(Effect.provide(Prisma.ConnectBinding)),
  * );
+ * ```
+ *
+ * @section Rotating Credentials
+ * @example Request one rotation
+ * ```typescript
+ * const connection = yield* Prisma.Connection("api", {
+ *   database,
+ *   rotate: true,
+ * });
  * ```
  *
  * @section Connecting over Hyperdrive

--- a/packages/alchemy/src/Prisma/CustomDomain.ts
+++ b/packages/alchemy/src/Prisma/CustomDomain.ts
@@ -91,11 +91,10 @@ export interface CustomDomain extends Resource<
 /**
  * A Prisma app custom domain.
  *
- * The custom-domain Management API is experimental. Domains can only attach
- * to Apps on the project's current default branch. Creating this resource
- * starts asynchronous DNS and certificate provisioning; configure the
- * returned `dnsRecords` and inspect `status`, `foundryStatus`, and
- * `failureReason` before routing production traffic.
+ * Domains can only attach to Apps on the project's current default branch.
+ * Creating this resource starts asynchronous DNS and certificate provisioning;
+ * configure the returned `dnsRecords` and inspect `status`, `foundryStatus`,
+ * and `failureReason` before routing production traffic.
  *
  * App and hostname changes are intentionally rejected because the Management
  * API cannot replace a live domain atomically. Create a second resource,

--- a/packages/alchemy/src/Prisma/CustomDomain.ts
+++ b/packages/alchemy/src/Prisma/CustomDomain.ts
@@ -25,7 +25,8 @@ type AppReference = string | App | Compute;
 
 export interface CustomDomainProps {
   /**
-   * App ID or Compute output that owns the domain.
+   * App ID or Compute output that owns the domain. The App must be attached to
+   * the project's current default branch.
    */
   app: AppReference;
   /**
@@ -89,6 +90,16 @@ export interface CustomDomain extends Resource<
 
 /**
  * A Prisma app custom domain.
+ *
+ * The custom-domain Management API is experimental. Domains can only attach
+ * to Apps on the project's current default branch. Creating this resource
+ * starts asynchronous DNS and certificate provisioning; configure the
+ * returned `dnsRecords` and inspect `status`, `foundryStatus`, and
+ * `failureReason` before routing production traffic.
+ *
+ * App and hostname changes are intentionally rejected because the Management
+ * API cannot replace a live domain atomically. Create a second resource,
+ * verify DNS and TLS, cut traffic over, and then remove the old resource.
  *
  * @resource
  * @section Creating a Custom Domain

--- a/packages/alchemy/src/Prisma/Database.ts
+++ b/packages/alchemy/src/Prisma/Database.ts
@@ -150,8 +150,9 @@ export interface DatabaseProps {
   dev?: false | DatabaseDev;
   /**
    * Rotate the adopted database's default connection to recover its one-time
-   * credentials. Rotation revokes the previous key and may interrupt existing
-   * consumers, so adoption leaves credentials unset unless explicitly opted in.
+   * credentials. Prisma revokes the previous key on a best-effort basis and
+   * rotation may interrupt existing consumers, so adoption leaves credentials
+   * unset unless explicitly opted in.
    *
    * @default false
    */
@@ -230,15 +231,28 @@ export interface Database extends Resource<
 /**
  * A Prisma Postgres database inside a Prisma project.
  *
+ * Standalone `Prisma.Database` resources cannot be the project's default
+ * database. Use `Prisma.Project` when the project should own a default
+ * database. Project, region, and source changes require replacement; display
+ * name and branch attachment can converge in place. Destroying this resource
+ * deletes its database and data.
+ *
  * @resource
  * @section Creating a Database
  * @example Database in a project
  * ```typescript
  * const project = yield* Prisma.Project("app", { createDatabase: false });
  * const database = yield* Prisma.Database("db", {
- *   project: project.projectId,
- *   name: "production",
+ *   project,
  *   region: "us-east-1",
+ * });
+ * ```
+ *
+ * @example Database attached to a preview branch
+ * ```typescript
+ * const database = yield* Prisma.Database("preview-db", {
+ *   project,
+ *   branchId: preview.branchId,
  * });
  * ```
  */

--- a/packages/alchemy/src/Prisma/Deployment.ts
+++ b/packages/alchemy/src/Prisma/Deployment.ts
@@ -55,7 +55,8 @@ export interface DeploymentProps {
    */
   portMapping?: { http?: number | null };
   /**
-   * Create the deployment by reusing the latest artifact instead of uploading code.
+   * Create the deployment by reusing the App's currently promoted artifact
+   * instead of uploading code. Requires an existing promoted deployment.
    */
   skipCodeUpload?: boolean;
   /**
@@ -128,6 +129,12 @@ export interface Deployment extends Resource<
 /**
  * A Prisma deployment owned by an App.
  *
+ * The Deployment Management API is experimental. This is the low-level
+ * resource: it can upload or reuse an artifact, start it, and promote it, but
+ * it does not provide `Prisma.Compute`'s preview/stable health checks or
+ * automatic rollback. Prefer `Prisma.Compute` for production application
+ * deployments.
+ *
  * Prisma's create-deployment API currently exposes neither an idempotency key
  * nor a caller-defined natural key. After a crash that loses state immediately
  * after creation, Alchemy deliberately does not adopt the App's latest
@@ -137,7 +144,7 @@ export interface Deployment extends Resource<
  *
  * @resource
  * @section Creating a Deployment
- * @example Fork the latest uploaded artifact
+ * @example Fork the currently promoted artifact
  * ```typescript
  * const deployment = yield* Prisma.Deployment("web-v2", {
  *   app: app.appId,

--- a/packages/alchemy/src/Prisma/Deployment.ts
+++ b/packages/alchemy/src/Prisma/Deployment.ts
@@ -129,11 +129,10 @@ export interface Deployment extends Resource<
 /**
  * A Prisma deployment owned by an App.
  *
- * The Deployment Management API is experimental. This is the low-level
- * resource: it can upload or reuse an artifact, start it, and promote it, but
- * it does not provide `Prisma.Compute`'s preview/stable health checks or
- * automatic rollback. Prefer `Prisma.Compute` for production application
- * deployments.
+ * This is the low-level resource: it can upload or reuse an artifact, start it,
+ * and promote it, but it does not provide `Prisma.Compute`'s preview/stable
+ * health checks or automatic rollback. Prefer `Prisma.Compute` for production
+ * application deployments.
  *
  * Prisma's create-deployment API currently exposes neither an idempotency key
  * nor a caller-defined natural key. After a crash that loses state immediately

--- a/packages/alchemy/src/Prisma/EnvironmentVariable.ts
+++ b/packages/alchemy/src/Prisma/EnvironmentVariable.ts
@@ -97,6 +97,13 @@ export interface EnvironmentVariable extends Resource<
 /**
  * A Prisma compute environment variable.
  *
+ * The environment-variable Management API is experimental. Values are
+ * write-only in Prisma and must be wrapped in `Redacted`; Alchemy retains the
+ * desired value in redacted state and reapplies it to heal out-of-band drift.
+ * Omit `branchId` for a project template. A branch override requires
+ * `class: "preview"` because environment class follows the branch's immutable
+ * role rather than its current default status.
+ *
  * @resource
  * @section Creating a Variable
  * @example Production secret
@@ -106,6 +113,17 @@ export interface EnvironmentVariable extends Resource<
  *   class: "production",
  *   key: "DATABASE_URL",
  *   value: Redacted.make("postgres://..."),
+ * });
+ * ```
+ *
+ * @example Preview branch override
+ * ```typescript
+ * yield* Prisma.EnvironmentVariable("preview-api-url", {
+ *   project,
+ *   branchId: preview.branchId,
+ *   class: "preview",
+ *   key: "API_URL",
+ *   value: Redacted.make("https://preview.example.com"),
  * });
  * ```
  */

--- a/packages/alchemy/src/Prisma/EnvironmentVariable.ts
+++ b/packages/alchemy/src/Prisma/EnvironmentVariable.ts
@@ -97,19 +97,16 @@ export interface EnvironmentVariable extends Resource<
 /**
  * A Prisma compute environment variable.
  *
- * The environment-variable Management API is experimental. Values are
- * write-only in Prisma and must be wrapped in `Redacted`; Alchemy retains the
- * desired value in redacted state and reapplies it to heal out-of-band drift.
- * Omit `branchId` for a project template. A branch override requires
- * `class: "preview"` because environment class follows the branch's immutable
- * role rather than its current default status.
+ * Values are write-only in Prisma. Alchemy stores them as `Redacted` values
+ * and reapplies the desired value to repair drift.
  *
  * @resource
  * @section Creating a Variable
- * @example Production secret
+ * @example Project-level production variable
  * ```typescript
  * yield* Prisma.EnvironmentVariable("database-url", {
  *   project: project.projectId,
+ *   // No branchId: this is a project-level template.
  *   class: "production",
  *   key: "DATABASE_URL",
  *   value: Redacted.make("postgres://..."),
@@ -121,6 +118,7 @@ export interface EnvironmentVariable extends Resource<
  * yield* Prisma.EnvironmentVariable("preview-api-url", {
  *   project,
  *   branchId: preview.branchId,
+ *   // Branch overrides always use the preview class.
  *   class: "preview",
  *   key: "API_URL",
  *   value: Redacted.make("https://preview.example.com"),

--- a/packages/alchemy/src/Prisma/Postgres.ts
+++ b/packages/alchemy/src/Prisma/Postgres.ts
@@ -6,14 +6,15 @@ import { Database } from "./Database.ts";
  * `Prisma.Postgres(...)` and `Prisma.Database(...)` use the same underlying
  * Prisma Postgres resource provider. Prefer `Postgres` when you want the code
  * to read like the Prisma product name, and `Database` when you want to mirror
- * the Management API route names.
+ * the Management API route names. Like `Database`, this standalone resource
+ * cannot be the project's default database; use `Prisma.Project` to own the
+ * default.
  *
  * @example
  * ```typescript
  * const project = yield* Prisma.Project("app", { createDatabase: false });
  * const postgres = yield* Prisma.Postgres("db", {
  *   project,
- *   name: "main",
  *   region: "us-east-1",
  * });
  * ```

--- a/packages/alchemy/src/Prisma/Project.ts
+++ b/packages/alchemy/src/Prisma/Project.ts
@@ -54,8 +54,9 @@ export interface ProjectProps {
   settings?: Record<string, unknown>;
   /**
    * Rotate the adopted default database connection to recover its one-time
-   * credentials. Rotation revokes the previous key and may interrupt existing
-   * consumers, so adoption leaves credentials unset unless explicitly opted in.
+   * credentials. Prisma revokes the previous key on a best-effort basis and
+   * rotation may interrupt existing consumers, so adoption leaves credentials
+   * unset unless explicitly opted in.
    *
    * @default false
    */
@@ -125,6 +126,11 @@ export interface Project extends Resource<
 
 /**
  * A Prisma project, optionally with a default Prisma Postgres database.
+ *
+ * A Project is the ownership boundary for its databases, branches, apps, and
+ * repository link. Destroying this resource deletes the project and its
+ * contained data. Set `createDatabase: false` when you want standalone
+ * `Prisma.Database` resources with independent lifecycles.
  *
  * @resource
  * @section Creating a Project

--- a/packages/alchemy/src/Prisma/SourceRepository.ts
+++ b/packages/alchemy/src/Prisma/SourceRepository.ts
@@ -109,11 +109,11 @@ export interface SourceRepository extends Resource<
 /**
  * A linked source repository for Prisma apps.
  *
- * The source-repository Management API is experimental and currently supports
- * GitHub only. Linking requires an existing Prisma SCM installation.
- * `providerRepositoryId` is GitHub's permanent numeric repository ID; retrieve
- * it with `gh api repos/OWNER/REPO --jq '.id'`. When `installationId` is
- * omitted, Prisma selects the workspace installation.
+ * GitHub is currently the only supported provider. Linking requires an
+ * existing Prisma SCM installation. `providerRepositoryId` is GitHub's
+ * permanent numeric repository ID; retrieve it with
+ * `gh api repos/OWNER/REPO --jq '.id'`. When `installationId` is omitted,
+ * Prisma selects the workspace installation.
  *
  * Linking creates or renames the repository-owned default branch. Observe
  * that branch through the Management API; do not declare it again as a

--- a/packages/alchemy/src/Prisma/SourceRepository.ts
+++ b/packages/alchemy/src/Prisma/SourceRepository.ts
@@ -38,7 +38,12 @@ export interface SourceRepositoryProps {
    */
   provider?: "github";
   /**
-   * Numeric provider repository ID.
+   * GitHub's permanent numeric repository ID, not `owner/repo`, a Prisma
+   * project ID, or an SCM installation ID. Retrieve it with:
+   *
+   * ```bash
+   * gh api repos/OWNER/REPO --jq '.id'
+   * ```
    */
   providerRepositoryId: number;
   /**
@@ -104,6 +109,12 @@ export interface SourceRepository extends Resource<
 /**
  * A linked source repository for Prisma apps.
  *
+ * The source-repository Management API is experimental and currently supports
+ * GitHub only. Linking requires an existing Prisma SCM installation.
+ * `providerRepositoryId` is GitHub's permanent numeric repository ID; retrieve
+ * it with `gh api repos/OWNER/REPO --jq '.id'`. When `installationId` is
+ * omitted, Prisma selects the workspace installation.
+ *
  * Linking creates or renames the repository-owned default branch. Observe
  * that branch through the Management API; do not declare it again as a
  * separate `Prisma.Branch` resource. Use this resource's outputs to order
@@ -111,12 +122,24 @@ export interface SourceRepository extends Resource<
  * Deleting the link does not roll those side effects back: existing branches,
  * databases, and apps remain in the project.
  *
+ * The project, repository ID, provider, and installation form an immutable
+ * link identity. Alchemy refuses an automatic relink because unlinking cannot
+ * roll back branch and resource attachments. Existing links require explicit
+ * adoption.
+ *
  * @resource
+ * @section Finding the Repository ID
+ * @example Read the numeric GitHub repository ID
+ * ```bash
+ * gh api repos/OWNER/REPO --jq '.id'
+ * ```
+ *
  * @section Linking a Repository
  * @example GitHub repository
  * ```typescript
  * const repo = yield* Prisma.SourceRepository("repo", {
  *   project: project.projectId,
+ *   // Replace with the value returned by the GitHub command above.
  *   providerRepositoryId: 123456789,
  * });
  * const database = yield* Prisma.Database("database", {

--- a/website/src/content/docs/prisma/compute/apps.mdx
+++ b/website/src/content/docs/prisma/compute/apps.mdx
@@ -4,8 +4,8 @@ description: Prisma Compute apps as Stack resources — framework builds or Effe
 ---
 
 `Prisma.Compute` deploys an application onto Prisma's managed
-runtime. One resource covers the whole path: build (optional),
-upload, deploy, health-check, promote — see
+runtime. One resource covers the whole path: optional build, artifact
+upload, deployment, health check, and promotion — see
 [Deployments](/prisma/compute/deployments) for the lifecycle.
 
 ## Framework apps
@@ -16,6 +16,9 @@ entrypoint starts the server:
 
 ```typescript
 import * as Prisma from "alchemy/Prisma";
+import * as SQL from "alchemy/SQL/Postgres";
+import * as Effect from "effect/Effect";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 
 const app = yield* Prisma.Compute("api", {
   project,
@@ -67,12 +70,21 @@ export default Prisma.Compute(
 
 ## Custom domains
 
+Custom domains can only attach to an app on the project's current
+default branch. Creating the resource starts DNS and certificate
+provisioning; use `domain.dnsRecords` to configure DNS and inspect
+`domain.status` before directing production traffic:
+
 ```typescript
 const domain = yield* Prisma.CustomDomain("api-domain", {
   app,
   hostname: "api.example.com",
 });
 ```
+
+Changing the hostname or app in place is intentionally rejected.
+Create a second domain, verify DNS and TLS, cut traffic over, and then
+remove the old resource.
 
 ## Local dev
 

--- a/website/src/content/docs/prisma/compute/deployments.mdx
+++ b/website/src/content/docs/prisma/compute/deployments.mdx
@@ -1,19 +1,20 @@
 ---
 title: Deployments
-description: The fail-closed Compute deployment lifecycle — health-checked promotion, automatic rollback, old-generation cleanup, and env-only redeploys.
+description: The fail-closed Compute deployment lifecycle — health-checked promotion, rollback recovery, old-generation cleanup, and env-only redeploys.
 ---
 
-Every `Prisma.Compute` update creates a new deployment and walks it
-through a fail-closed sequence: upload the artifact, start the
-candidate, verify its preview health endpoint, promote it, confirm
-the app reports it as latest, verify the stable endpoint — and only
-then touch the previous deployment.
+When the artifact or deployment configuration changes,
+`Prisma.Compute` creates a new generation and walks it through a
+fail-closed sequence: upload the artifact, start the candidate, verify
+its preview health endpoint, promote it, confirm the app reports it as
+latest, verify the stable endpoint — and only then touch the previous
+deployment.
 
 ## Health checks and promotion
 
-`healthCheck.path` gates promotion. A candidate that never answers
-is destroyed and the previous deployment keeps serving — a failed
-deploy never takes the app down:
+`healthCheck.path` gates promotion. If the candidate never becomes
+healthy, alchemy attempts to destroy it without changing the stable
+deployment. When a previous deployment exists, it keeps serving:
 
 ```typescript
 const app = yield* Prisma.Compute("api", {
@@ -25,9 +26,12 @@ const app = yield* Prisma.Compute("api", {
 ```
 
 When promotion succeeds but the stable endpoint fails verification,
-alchemy rolls the app back to the previous deployment and destroys
-the failed candidate. Terminally failed deployments are never
-restarted or selected as rollback targets.
+alchemy attempts to restore the previous deployment. If recovery
+converges, it cleans up the failed candidate. If recovery cannot
+converge—or no safe rollback target exists—alchemy fails the deploy,
+preserves the generations needed for recovery, and retries recovery
+before making further cloud changes. Terminally failed deployments
+are never restarted or selected as rollback targets.
 
 ## Old-generation cleanup
 
@@ -43,19 +47,18 @@ const app = yield* Prisma.Compute("api", {
 });
 ```
 
-If cleanup fails (e.g. a transient API error), the pending cleanup
-is persisted and retried on the next deploy — nothing is orphaned.
+If cleanup fails, alchemy records the pending action in state and
+retries it before creating another generation.
 
 ## Env-only redeploys
 
-`skipCodeUpload: true` creates the next deployment from the previous
-code artifact — useful when only environment variables changed and
-rebuilding/uploading would be wasted work:
+`skipCodeUpload: true` creates the next deployment from the currently
+promoted artifact. It requires an existing promoted deployment and is
+useful when only environment variables changed:
 
 ```typescript
 const app = yield* Prisma.Compute("api", {
   project,
-  path: "./app",
   skipCodeUpload: true,
   env: { FEATURE_FLAG: "on" },
 });

--- a/website/src/content/docs/prisma/data/branches.mdx
+++ b/website/src/content/docs/prisma/data/branches.mdx
@@ -3,10 +3,18 @@ title: Branches
 description: Prisma branches group databases under git-style names — preview branches per stage, default-branch promotion, and database attachment.
 ---
 
-A `Prisma.Branch` groups databases under a git-style name inside a
-project. Branches are how a project separates production data from
-previews: the default branch carries the `production` role, every
-other branch is a `preview`.
+A `Prisma.Branch` groups databases and apps under a git-style name
+inside a project. Prisma tracks two separate properties:
+
+- `role` controls whether Compute resolves `production` or `preview`
+  environment variables.
+- `isDefault` identifies the branch new resources use when they omit
+  a branch.
+
+The first branch created with a project has the immutable
+`production` role. Additional branches have the `preview` role.
+Promoting a preview branch changes `isDefault`; it does not change
+that branch's role.
 
 ```typescript
 import * as Prisma from "alchemy/Prisma";
@@ -35,9 +43,9 @@ const previewDb = yield* Prisma.Postgres("preview-db", {
 });
 ```
 
-Compute apps attach the same way — an app on a preview branch gets
-the `preview` environment class, so its environment variables stay
-separate from production's.
+Compute apps attach the same way. Environment-variable scope follows
+the branch's `role`, not `isDefault`, so a promoted preview branch
+continues to use the `preview` class.
 
 ## A branch per stage
 
@@ -58,10 +66,10 @@ const branch = yield* Prisma.Branch("stage", {
 
 ## Default-branch promotion
 
-`isDefault: true` promotes the branch, atomically demoting the
-current default. The Management API only supports promotion — a
-demotion happens by promoting another branch — and alchemy records
-the displaced branch so destroying the resource can restore it:
+`isDefault: true` promotes the branch, atomically clearing the current
+default flag. The Management API only supports promotion — demotion
+happens by promoting another branch — and alchemy records the
+displaced branch so destroying the resource can restore it:
 
 ```typescript
 const release = yield* Prisma.Branch("release", {
@@ -71,8 +79,11 @@ const release = yield* Prisma.Branch("release", {
 });
 ```
 
-The production branch itself is owned by the project and cannot be
-deleted directly — delete the owning `Prisma.Project` instead.
+The original `production`-role branch is owned by the project and
+cannot be deleted through `Prisma.Branch`. A preview-role
+`Prisma.Branch` promoted to default remains owned by its Branch
+resource: on destroy, alchemy restores the displaced default and then
+deletes the promoted branch.
 
 ## Where next
 

--- a/website/src/content/docs/prisma/data/connections.mdx
+++ b/website/src/content/docs/prisma/data/connections.mdx
@@ -101,8 +101,8 @@ them back as `Redacted` values.
 
 ## Rotation
 
-Set `rotate: true` to mint fresh credentials on the next deploy
-while keeping the connection's identity:
+Change `rotate` from `false` to `true` to mint fresh credentials on
+the next deploy while keeping the connection's identity:
 
 ```typescript
 const connection = yield* Prisma.Connection("api", {
@@ -111,8 +111,10 @@ const connection = yield* Prisma.Connection("api", {
 });
 ```
 
-Rotation revokes the previous key, so downstream consumers pick up
-the new secret on the same deploy through their bindings.
+Prisma attempts to revoke the previous credentials on a best-effort
+basis. Downstream consumers receive the new secret on the same deploy
+through their bindings. To rotate again, deploy once with
+`rotate: false`, then change it back to `true`.
 
 ## Where next
 

--- a/website/src/content/docs/prisma/data/postgres.mdx
+++ b/website/src/content/docs/prisma/data/postgres.mdx
@@ -24,10 +24,18 @@ Postgres database in the chosen region. Pass
 databases explicitly — the recommended shape, since standalone
 databases have their own lifecycle and outputs.
 
+:::caution[Projects own their data]
+Destroying a `Prisma.Project` deletes the project and its contained
+databases and apps. Use a durable state backend and review the destroy
+plan before removing a project from a Stack.
+:::
+
 ## Database
 
 `Prisma.Postgres` and `Prisma.Database` are the same resource under
-two names — use whichever reads better:
+two names — use whichever reads better. Standalone database resources
+cannot be the project's default database; let `Prisma.Project` own the
+default database when you need one:
 
 ```typescript
 const postgres = yield* Prisma.Postgres("db", {

--- a/website/src/content/docs/prisma/guides/cloudflare-workers.mdx
+++ b/website/src/content/docs/prisma/guides/cloudflare-workers.mdx
@@ -8,7 +8,11 @@ from the same resources:
 
 ```typescript
 import * as Cloudflare from "alchemy/Cloudflare";
+import * as Drizzle from "alchemy/Drizzle";
 import * as Prisma from "alchemy/Prisma";
+import * as SQL from "alchemy/SQL/Postgres";
+import * as Effect from "effect/Effect";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 
 const project = yield* Prisma.Project("app", { createDatabase: false });
 const postgres = yield* Prisma.Postgres("db", { project });
@@ -30,7 +34,10 @@ const hyperdrive = yield* Cloudflare.Hyperdrive.Connection("api-hd", {
 
 export default Cloudflare.Worker(
   "api",
-  { main: import.meta.filename },
+  {
+    main: import.meta.filename,
+    compatibility: { flags: ["nodejs_compat"] },
+  },
   Effect.gen(function* () {
     const hd = yield* Cloudflare.Hyperdrive.Connect(hyperdrive);
     const sql = yield* SQL.Postgres({ url: hd.connectionString });
@@ -57,7 +64,10 @@ text bindings, and the runtime client hands back `Redacted` URLs:
 ```typescript
 export default Cloudflare.Worker(
   "api",
-  { main: import.meta.filename },
+  {
+    main: import.meta.filename,
+    compatibility: { flags: ["nodejs_compat"] },
+  },
   Effect.gen(function* () {
     const db = yield* Prisma.Connect(connection);
     const sql = yield* SQL.Postgres({ url: db.databaseUrl });
@@ -74,7 +84,8 @@ export default Cloudflare.Worker(
 
 `db.databaseUrl` prefers the pooled endpoint, so short-lived Worker
 connections share Prisma's pooler instead of opening a direct
-connection per request.
+connection per request. Both examples enable `nodejs_compat` because
+the Postgres driver uses Node.js networking and crypto APIs.
 
 ## Where next
 

--- a/website/src/content/docs/prisma/index.mdx
+++ b/website/src/content/docs/prisma/index.mdx
@@ -12,6 +12,13 @@ provision.
 
 New here? [Set up credentials](/prisma/setup) first.
 
+:::caution[Experimental Management API surface]
+The App, Deployment, Branch, environment-variable, custom-domain, and
+source-repository endpoints used by these resources are experimental.
+Their request and response shapes may change while Prisma develops the
+Management API.
+:::
+
 ## Resources
 
 A `Prisma.Project` is the top-level container. A `Prisma.Postgres`
@@ -32,17 +39,17 @@ const connection = yield* Prisma.Connection("api", {
 });
 ```
 
-Names are optional everywhere — omit them and alchemy generates
-stable physical names from the Stack, logical ID, and stage.
+Display names are optional for these resources — omit them and alchemy
+generates stable physical names from the Stack, logical ID, and stage.
 
 The connection exposes ready-to-use outputs — a conventional
 `databaseUrl`, direct and pooled connection strings, and parsed
 `origin` components for poolers like Hyperdrive. See
 [Connections](/prisma/data/connections).
 
-[Branches](/prisma/data/branches) group databases under git-style
-names — a preview branch per stage, promoted to default when it
-ships.
+[Branches](/prisma/data/branches) group databases and apps under
+git-style names. A standalone `Prisma.Branch` has Prisma's `preview`
+role even when promoted to be the project's default branch.
 
 ## Compute
 
@@ -67,8 +74,10 @@ const app = yield* Prisma.Compute("api", {
 });
 ```
 
-Deployments are verified against the health check before promotion
-and rolled back when it fails — see [Compute](/prisma/compute/apps).
+The candidate health check gates promotion. If the stable endpoint
+fails after promotion, alchemy attempts to restore the previous
+deployment and fails closed if recovery cannot converge. See
+[Deployments](/prisma/compute/deployments).
 
 ## Runtime bindings
 
@@ -108,4 +117,6 @@ Postgres providers:
 - [Project](/providers/prisma/project)
 - [Database](/providers/prisma/database)
 - [Connection](/providers/prisma/connection)
+- [Branch](/providers/prisma/branch)
 - [Compute](/providers/prisma/compute)
+- [SourceRepository](/providers/prisma/sourcerepository)

--- a/website/src/content/docs/prisma/index.mdx
+++ b/website/src/content/docs/prisma/index.mdx
@@ -12,13 +12,6 @@ provision.
 
 New here? [Set up credentials](/prisma/setup) first.
 
-:::caution[Experimental Management API surface]
-The App, Deployment, Branch, environment-variable, custom-domain, and
-source-repository endpoints used by these resources are experimental.
-Their request and response shapes may change while Prisma develops the
-Management API.
-:::
-
 ## Resources
 
 A `Prisma.Project` is the top-level container. A `Prisma.Postgres`

--- a/website/src/content/docs/prisma/setup.mdx
+++ b/website/src/content/docs/prisma/setup.mdx
@@ -10,9 +10,25 @@ cloud's:
 
 ```typescript
 // alchemy.run.ts
+import * as Alchemy from "alchemy";
+import * as Cloudflare from "alchemy/Cloudflare";
 import * as Prisma from "alchemy/Prisma";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
 
-providers: Layer.mergeAll(Cloudflare.providers(), Prisma.providers()),
+export default Alchemy.Stack(
+  "App",
+  {
+    providers: Layer.mergeAll(
+      Cloudflare.providers(),
+      Prisma.providers(),
+    ),
+    state: Alchemy.localState(),
+  },
+  Effect.gen(function* () {
+    // Declare Prisma and Cloudflare resources here.
+  }),
+);
 ```
 
 The next `alchemy login` adds a `Prisma` step with two options:
@@ -30,10 +46,10 @@ and switched.
 
 ## Local dev
 
-`bun alchemy dev` needs no credentials at all: the Prisma providers
-run against a local `@prisma/dev` Postgres, and every resource
-(project, database, connection) resolves to its local equivalent
-with the same output shape. See
+`bun alchemy dev` needs no Prisma credentials. Database resources run
+against a local `@prisma/dev` Postgres, Compute resources run their
+configured `dev.command`, and the remaining Prisma resources return
+compatible local outputs. See
 [Postgres](/prisma/data/postgres) for the dev database options.
 
 ## Next steps


### PR DESCRIPTION
Improves the user-facing Prisma provider documentation with clearer guidance for setup, databases, branches, connections, Compute deployments, custom domains, and GitHub repository linking.

The TypeScript changes are documentation comments and examples used to generate the website reference. No provider runtime logic or public types changed.
