### PR TITLE
fix(cloudflare/workers): skip Container env bindings during Vite build

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
@@ -61,7 +61,7 @@ export const bindWorkerAsyncBindings = Effect.fn(function* (
       // its ContainerApplication. Handled before the generic Effect
       // resolution below — yielding the Container class would resolve its
       // *started instance* tag, which only exists inside a Durable Object.
-      if (isContainerDecl(bindingEff)) {
+      if (isContainerDeclaration(bindingEff)) {
         yield* bindContainerClass(resource, bindingName, bindingEff);
         continue;
       }
@@ -168,8 +168,13 @@ export const bindWorkerAsyncBindings = Effect.fn(function* (
  * the `~alchemy/Container/ClassName` marker (rather than importing from
  * `Containers/Container.ts`) to avoid a value-level import cycle through
  * `ContainerPlatform` → `Worker.ts` → this module.
+ *
+ * Also used by Vite build env resolution: Container declarations are
+ * Effect-shaped bindings and must not be executed as inlined env Effects.
  */
-const isContainerDecl = (value: unknown): value is Container.Decl.Any =>
+export const isContainerDeclaration = (
+  value: unknown,
+): value is Container.Decl.Any =>
   (typeof value === "function" || typeof value === "object") &&
   value !== null &&
   "~alchemy/Container/ClassName" in value;

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -47,7 +47,7 @@ import {
   type WorkerRouteConfig,
   type WorkerVersionAffinity,
 } from "./Worker.ts";
-import { getCacheBinding, getCronBindings } from "./WorkerAsyncBindings.ts";
+import { getCacheBinding, getCronBindings, isContainerDeclaration } from "./WorkerAsyncBindings.ts";
 import type {
   WireWorkerBinding,
   WorkerBinding,
@@ -2101,9 +2101,14 @@ export const LiveWorkerProvider = () =>
                               // so we don't execute it as an inlined env entry.
                               isWorkerLoader(value)
                               ? undefined
-                              : Effect.isEffect(value)
-                                ? yield* value as any as Effect.Effect<any>
-                                : undefined,
+                              : // Direct Container declarations are also Effect-shaped
+                                // bindings. Resolving one here asks Effect for a service
+                                // that is only available while deploying the Worker.
+                                isContainerDeclaration(value)
+                                ? undefined
+                                : Effect.isEffect(value)
+                                  ? yield* value as any as Effect.Effect<any>
+                                  : undefined,
                     ];
                   }),
                 ),


### PR DESCRIPTION
## Summary

Deploying a `Cloudflare.Website.Vite` Worker with `Cloudflare.Container` values on `env` fails during Vite build. Container declarations are Effect-shaped, so the env walk resolves them with `Effect.isEffect` as if they were inlined env services. Those services only exist while deploying the Worker.

Worker loaders are already special-cased before `Effect.isEffect`; Containers were not.

## Change

- Export the existing `~alchemy/Container/ClassName` structural check as `isContainerDeclaration`
- Skip Container declarations in Vite build env resolution (same idea as `isWorkerLoader`)

Closes #997.