### PR TITLE
fix(cloudflare): Vite build treats Container env bindings as Effects

### DIFF
--- a/packages/alchemy/src/Cloudflare/Website/StaticSite.ts
+++ b/packages/alchemy/src/Cloudflare/Website/StaticSite.ts
@@ -14,6 +14,7 @@ import {
 import { asEffect } from "../../Util/types.ts";
 import type { Providers } from "../Providers.ts";
 import type { AssetsConfig } from "../Workers/Assets.ts";
+import { isContainerDecl } from "../Workers/WorkerAsyncBindings.ts";
 import {
   Worker,
   type NormalizedBindings,
@@ -318,8 +319,9 @@ const makeStaticSite = <
  * - `Output` references resolve at reconcile; the resolved value is
  *   serialized the same way inline values are (an `Output<object>` must
  *   reach the subprocess as JSON, not `[object Object]`)
- * - binding Effects (`~alchemy/Kind`-marked, e.g. a `WorkerLoader`) have no
- *   env-var representation and are dropped
+ * - binding Effects (`~alchemy/Kind`-marked, e.g. a `WorkerLoader`) and
+ *   `Cloudflare.Container` declarations have no env-var representation and
+ *   are dropped
  * - remaining plain values (`null`, numbers, JSON objects) are stringified
  */
 const serializeEnv = Effect.fn(function* (
@@ -336,6 +338,13 @@ const serializeEnv = Effect.fn(function* (
       entries.push([k, v]);
     } else if (Output.isOutput(v)) {
       entries.push([k, Output.map(v, serializeEnvValue)]);
+    } else if (isContainerDecl(v)) {
+      // A `Cloudflare.Container` declaration is Effect-shaped but is a
+      // binding (DO namespace + ContainerApplication) — yielding it would
+      // resolve the started-instance tag, which only exists inside a
+      // Durable Object (#997). Deploy-time only, nothing to expose to the
+      // build subprocess.
+      continue;
     } else if (isYieldableEffectLike(v)) {
       const resolved = serializeEnvValue(
         yield* asEffect(v as YieldableEffectLike<unknown, unknown, never>).pipe(

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
@@ -168,8 +168,12 @@ export const bindWorkerAsyncBindings = Effect.fn(function* (
  * the `~alchemy/Container/ClassName` marker (rather than importing from
  * `Containers/Container.ts`) to avoid a value-level import cycle through
  * `ContainerPlatform` → `Worker.ts` → this module.
+ *
+ * A Container declaration is Effect-shaped (yielding it resolves the
+ * *started instance* tag, which only exists inside a Durable Object), so
+ * every env-resolution site must check this before `Effect.isEffect`.
  */
-const isContainerDecl = (value: unknown): value is Container.Decl.Any =>
+export const isContainerDecl = (value: unknown): value is Container.Decl.Any =>
   (typeof value === "function" || typeof value === "object") &&
   value !== null &&
   "~alchemy/Container/ClassName" in value;

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -47,7 +47,11 @@ import {
   type WorkerRouteConfig,
   type WorkerVersionAffinity,
 } from "./Worker.ts";
-import { getCacheBinding, getCronBindings } from "./WorkerAsyncBindings.ts";
+import {
+  getCacheBinding,
+  getCronBindings,
+  isContainerDecl,
+} from "./WorkerAsyncBindings.ts";
 import type {
   WireWorkerBinding,
   WorkerBinding,
@@ -2101,9 +2105,16 @@ export const LiveWorkerProvider = () =>
                               // so we don't execute it as an inlined env entry.
                               isWorkerLoader(value)
                               ? undefined
-                              : Effect.isEffect(value)
-                                ? yield* value as any as Effect.Effect<any>
-                                : undefined,
+                              : // A `Cloudflare.Container` declaration is likewise
+                                // Effect-shaped but is a binding (DO namespace +
+                                // ContainerApplication) — yielding it would resolve
+                                // the started-instance tag, which only exists inside
+                                // a Durable Object (#997).
+                                isContainerDecl(value)
+                                ? undefined
+                                : Effect.isEffect(value)
+                                  ? yield* value as any as Effect.Effect<any>
+                                  : undefined,
                     ];
                   }),
                 ),

--- a/packages/alchemy/test/Cloudflare/Website/Vite.test.ts
+++ b/packages/alchemy/test/Cloudflare/Website/Vite.test.ts
@@ -35,6 +35,10 @@ const logLevel = Effect.provideService(
 const fixtureDir = pathe.resolve(import.meta.dirname, "vite-fixture");
 const spaFixtureDir = pathe.resolve(import.meta.dirname, "vite-spa-fixture");
 const doFixtureDir = pathe.resolve(import.meta.dirname, "vite-do-fixture");
+const containerFixtureDir = pathe.resolve(
+  import.meta.dirname,
+  "vite-container-fixture",
+);
 const reactRouterRscFixtureDir = pathe.resolve(
   import.meta.dirname,
   "react-router-rsc-fixture",
@@ -628,6 +632,75 @@ test.provider(
 );
 
 test.provider(
+  "Vite: Container binding on env deploys a container-backed DO class",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const rootDir = yield* cloneFixture(containerFixtureDir, {
+        prefix: "alchemy-vite-container-",
+        tempRoot,
+        entries: ["index.html", "package.json", "vite.config.ts", "src"],
+      });
+      const memoInclude = [
+        "index.html",
+        "src/**",
+        "package.json",
+        "vite.config.ts",
+      ];
+
+      // A `Cloudflare.Container` declaration on `env` is Effect-shaped —
+      // before #997 the Vite build's env resolution ran it as an inlined
+      // env Effect and the deploy died before the build started.
+      const site = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.Website.Vite("ViteContainer", {
+            ...viteProps(rootDir, memoInclude),
+            compatibility: {
+              date: "2026-03-17",
+              flags: ["nodejs_compat"],
+            },
+            assets: {
+              runWorkerFirst: ["/api/*"],
+            },
+            env: {
+              ECHO: Cloudflare.Container("ViteEchoContainer", {
+                className: "EchoObject",
+                image: "mendhak/http-https-echo:latest",
+                observability: { logs: { enabled: true } },
+              }),
+            },
+          });
+        }),
+      );
+
+      expect(site.url).toBeDefined();
+      yield* expectWorkerExists(site.workerName, accountId);
+      yield* expectUrlContains(`${site.url!}/`, "Vite Container fixture", {
+        timeout: "120 seconds",
+        label: "vite container fixture assets",
+      });
+
+      // The echo image reflects the request as JSON ("method" only appears
+      // in a real echo response, never in an error page) — proof the request
+      // went Worker → DO class → container port 8080 and back.
+      const echo = yield* fetchContainerReady(
+        `${site.url!}/api/echo`,
+        "method",
+      );
+      expect(echo).toContain("method");
+
+      yield* stack.destroy();
+      yield* waitForWorkerToBeDeleted(site.workerName, accountId);
+    }).pipe(logLevel),
+  // Container image pull + push + rollout comfortably exceeds the plain
+  // Vite deploy budget (mirrors AsyncContainer.test.ts).
+  { timeout: 600_000 },
+);
+
+test.provider(
   "Vite: main overrides the worker entry from the Vite config",
   (stack) =>
     Effect.gen(function* () {
@@ -963,6 +1036,40 @@ const fetchJsonReady = <T>(url: string) =>
       Effect.retry({
         schedule: Schedule.exponential("500 millis"),
         times: 15,
+      }),
+    );
+  });
+
+// Retry a container-backed route until it answers 200 with a body containing
+// `expected` — the container's first request rides through image provisioning
+// and instance cold start, which comfortably outlasts fetchJsonReady's budget
+// (mirrors AsyncContainer.test.ts's readiness poll).
+const fetchContainerReady = (url: string, expected: string) =>
+  Effect.gen(function* () {
+    const client = freshConn(yield* HttpClient.HttpClient);
+    return yield* client.get(url).pipe(
+      Effect.flatMap((res) =>
+        res.text.pipe(
+          Effect.flatMap((body) =>
+            res.status === 200 && body.includes(expected)
+              ? Effect.succeed(body)
+              : Effect.fail(
+                  new Error(
+                    `container not ready: ${res.status} ${body.slice(0, 200)}`,
+                  ),
+                ),
+          ),
+        ),
+      ),
+      Effect.timeout("10 seconds"),
+      Effect.retry({
+        // Cap exponential backoff at 3s — snappy fast path without the
+        // geometric blow-up dominating wall time on a slow rollout.
+        schedule: Schedule.min([
+          Schedule.exponential("500 millis"),
+          Schedule.spaced("3 seconds"),
+        ]),
+        times: 60,
       }),
     );
   });

--- a/packages/alchemy/test/Cloudflare/Website/vite-container-fixture/index.html
+++ b/packages/alchemy/test/Cloudflare/Website/vite-container-fixture/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Vite Container fixture</title>
+  </head>
+  <body>
+    <div id="app">Vite Container fixture</div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/packages/alchemy/test/Cloudflare/Website/vite-container-fixture/package.json
+++ b/packages/alchemy/test/Cloudflare/Website/vite-container-fixture/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "alchemy-vite-container-fixture",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "@cloudflare/containers": "catalog:",
+    "alchemy": "workspace:*",
+    "effect": "catalog:",
+    "vite": "catalog:"
+  }
+}

--- a/packages/alchemy/test/Cloudflare/Website/vite-container-fixture/src/main.ts
+++ b/packages/alchemy/test/Cloudflare/Website/vite-container-fixture/src/main.ts
@@ -1,0 +1,4 @@
+const el = document.getElementById("app");
+if (el) {
+  el.textContent = "Vite Container fixture hydrated";
+}

--- a/packages/alchemy/test/Cloudflare/Website/vite-container-fixture/src/worker.ts
+++ b/packages/alchemy/test/Cloudflare/Website/vite-container-fixture/src/worker.ts
@@ -1,0 +1,37 @@
+import { Container } from "@cloudflare/containers";
+
+/**
+ * Container-backed Durable Object class hosted by a Vite Worker (issue #997):
+ * the `Cloudflare.Container` declaration on the site's `env` is the DO
+ * namespace binding plus its ContainerApplication. `Container.fetch` starts
+ * the container on demand and forwards requests to the echo server listening
+ * on port 8080 inside it.
+ */
+export class EchoObject extends Container {
+  defaultPort = 8080;
+}
+
+type EchoStub = {
+  fetch(request: Request): Promise<Response>;
+};
+
+type Env = {
+  ASSETS: {
+    fetch(request: Request): Promise<Response>;
+  };
+  ECHO: {
+    getByName(name: string): EchoStub;
+  };
+};
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (url.pathname === "/api/echo") {
+      return env.ECHO.getByName("vite-container-fixture").fetch(request);
+    }
+
+    return env.ASSETS.fetch(request);
+  },
+};

--- a/packages/alchemy/test/Cloudflare/Website/vite-container-fixture/vite.config.ts
+++ b/packages/alchemy/test/Cloudflare/Website/vite-container-fixture/vite.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  environments: {
+    ssr: {
+      build: {
+        rollupOptions: {
+          input: "./src/worker.ts",
+        },
+      },
+    },
+  },
+});


### PR DESCRIPTION
Fixes #997.

A `Cloudflare.Container` declaration on a Worker's `env` is Effect-shaped (yielding it resolves the *started instance* tag, which only exists inside a Durable Object), so the Vite build's env resolution ran it as an inlined env Effect and the deploy died before the build started:

```ts
export class Website extends Cloudflare.Website.Vite<Website>()("Website", {
  main: "src/server.ts",
  env: {
    MY_CONTAINER: Cloudflare.Container("MyContainer", { ... }), // 💥 vite build
  },
}) {}
```

- Export the existing `isContainerDecl` predicate from `WorkerAsyncBindings.ts` and check it before `Effect.isEffect` in `WorkerProvider`'s Vite env walk (same treatment as `WorkerLoader`)
- Same fix in `StaticSite`'s `serializeEnv`, which had the identical latent bug (its `env` doubles as the Worker's binding props)
- Live regression test: `vite-container-fixture` deploys a `Website.Vite` with a Container on `env` and round-trips a request Worker → container-backed DO class → echo container

🤖 Generated with [Claude Code](https://claude.com/claude-code)
