### PR TITLE
fix(cloudflare/queues): local dev worker fails to start with a dead-letter queue

### DIFF
--- a/packages/alchemy/test/Cloudflare/Queues/Queue.local.test.ts
+++ b/packages/alchemy/test/Cloudflare/Queues/Queue.local.test.ts
@@ -107,6 +107,66 @@ test.provider(
 );
 
 /**
+ * Regression test for #988: a consumer configured with a dead-letter queue
+ * that the worker does not itself consume. The DLQ binding resolves through
+ * the local runtime's registry proxy; the worker previously failed to start
+ * with `WorkerdStartFailed` because the DLQ binding referenced the
+ * `cloudflare-runtime:registry-proxy` service before it was defined.
+ */
+test.provider(
+  "local queue consumer with an unconsumed dead-letter queue starts and delivers",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const deployed = yield* stack.deploy(
+        Effect.gen(function* () {
+          const queue = yield* Cloudflare.Queues.Queue("DlqSourceQueue");
+          const dlq = yield* Cloudflare.Queues.Queue("DlqTargetQueue");
+          const worker = yield* Cloudflare.Worker("queue-dlq-local-worker", {
+            main: pathe.resolve(
+              import.meta.dirname,
+              "fixtures/queue-local-worker.ts",
+            ),
+            env: { QUEUE: queue },
+          });
+          yield* Cloudflare.Queues.Consumer("DlqLocalConsumer", {
+            queueId: queue.queueId,
+            scriptName: worker.workerName,
+            deadLetterQueue: dlq.queueName,
+            settings: { maxRetries: 1 },
+          });
+          return { queue, dlq, worker };
+        }),
+      );
+
+      expect(deployed.queue.queueId).toMatch(/^dev:/);
+      expect(deployed.dlq.queueId).toMatch(/^dev:/);
+
+      // The worker starts (the DLQ binding resolves) and delivers normally.
+      const sent = (yield* getJsonReady(
+        `${deployed.worker.url}/send?text=dlq-hello`,
+      )) as { sent: string };
+      expect(sent.sent).toBe("dlq-hello");
+
+      const received = yield* getJsonReady(
+        `${deployed.worker.url}/received`,
+      ).pipe(
+        Effect.map((body) => (body as { received: string[] }).received),
+        Effect.repeat({
+          schedule: Schedule.spaced("500 millis"),
+          until: (received) => received.includes("dlq-hello"),
+          times: 30,
+        }),
+      );
+      expect(received).toContain("dlq-hello");
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 120_000 },
+);
+
+/**
  * The full `Alchemy.remote()` queue roundtrip in dev: the local worker
  * produces through the deployed shim into the REAL queue, and its local
  * `queue()` handler receives the messages back through the runtime's pull


### PR DESCRIPTION
`alchemy dev` failed to start any worker consuming a queue configured with a `deadLetterQueue` the worker does not itself consume:

```
SystemError: WorkerdStartFailed
Worker "queues:my-queue"'s binding "DLQ:my-dead-letter-queue"
refers to a service "cloudflare-runtime:registry-proxy",
but no such service is defined.
```

Root cause is in the local runtime, fixed in alchemy-run/cloudflare-tools#92 (bumped here as a submodule pointer): the Queue plugin subscribed to the registry proxy for the DLQ inside its `defer`, racing the RegistryProxy `defer` that decides whether to emit the proxy service at all. DLQ designators are now resolved eagerly at plugin init, before any `defer` runs.

Adds a regression test to `Queue.local.test.ts` deploying the issue's exact shape — two local queues, a worker consuming one with `deadLetterQueue` pointing at the other:

```ts
yield* Cloudflare.Queues.Consumer("DlqLocalConsumer", {
  queueId: queue.queueId,
  scriptName: worker.workerName,
  deadLetterQueue: dlq.queueName,
  settings: { maxRetries: 1 },
});
```

Hangs on `WorkerdStartFailed` before the runtime fix; passes after. Runtime-level coverage (orphan DLQ + cross-instance dead-lettering through the registry proxy) lives in the cloudflare-tools PR.

Fixes #988

🤖 Generated with [Claude Code](https://claude.com/claude-code)
