### PR TITLE
feat(sentry): add Sentry provider with configurable API base URL

### DIFF
--- a/packages/alchemy/package.json
+++ b/packages/alchemy/package.json
@@ -175,6 +175,12 @@
       "worker": "./src/Axiom/index.ts",
       "import": "./lib/Axiom/index.js"
     },
+    "./Sentry": {
+      "types": "./lib/Sentry/index.d.ts",
+      "bun": "./src/Sentry/index.ts",
+      "worker": "./src/Sentry/index.ts",
+      "import": "./lib/Sentry/index.js"
+    },
     "./GitHub": {
       "types": "./lib/GitHub/index.d.ts",
       "bun": "./src/GitHub/index.ts",

--- a/packages/alchemy/src/Sentry/Api.ts
+++ b/packages/alchemy/src/Sentry/Api.ts
@@ -1,0 +1,109 @@
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import * as Redacted from "effect/Redacted";
+import * as HttpBody from "effect/unstable/http/HttpBody";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import { Credentials } from "./Credentials.ts";
+
+/** The resource does not exist. */
+export class SentryNotFound extends Data.TaggedError("SentryNotFound")<{
+  readonly path: string;
+}> {}
+
+/** A resource with the same slug already exists. */
+export class SentryConflict extends Data.TaggedError("SentryConflict")<{
+  readonly path: string;
+  readonly message: string;
+}> {}
+
+/** Sentry rejected the request. */
+export class SentryApiError extends Data.TaggedError("SentryApiError")<{
+  readonly path: string;
+  readonly status: number;
+  readonly message: string;
+}> {}
+
+/** The request never reached Sentry. */
+export class SentryTransportError extends Data.TaggedError(
+  "SentryTransportError",
+)<{
+  readonly path: string;
+  readonly cause: unknown;
+}> {}
+
+export type SentryError =
+  | SentryNotFound
+  | SentryConflict
+  | SentryApiError
+  | SentryTransportError;
+
+const describe = (payload: unknown): string => {
+  if (typeof payload === "string") return payload;
+  if (payload && typeof payload === "object") {
+    const detail = (payload as Record<string, unknown>).detail;
+    if (typeof detail === "string") return detail;
+    const slug = (payload as Record<string, unknown>).slug;
+    if (Array.isArray(slug) && typeof slug[0] === "string") return slug[0];
+    return JSON.stringify(payload);
+  }
+  return "";
+};
+
+const isConflict = (status: number, message: string) =>
+  status === 409 ||
+  (status === 400 && /already exists|is not available/i.test(message));
+
+/**
+ * Issue a request against Sentry's `/api/0` surface and decode the JSON body.
+ *
+ * The base URL comes from `Credentials`, so the same providers drive Sentry
+ * SaaS and a self-hosted instance.
+ */
+export const request = Effect.fn("Sentry.request")(function* (
+  method: "GET" | "POST" | "PUT" | "DELETE",
+  path: string,
+  body?: unknown,
+) {
+  const { authToken, apiBaseUrl } = yield* yield* Credentials;
+  const url = `${apiBaseUrl}${path}`;
+
+  const options = {
+    headers: {
+      authorization: `Bearer ${Redacted.value(authToken)}`,
+      ...(body === undefined ? {} : { "content-type": "application/json" }),
+    },
+    ...(body === undefined
+      ? {}
+      : { body: HttpBody.text(JSON.stringify(body), "application/json") }),
+  };
+
+  const response = yield* (
+    method === "GET"
+      ? HttpClient.get(url, options)
+      : method === "POST"
+        ? HttpClient.post(url, options)
+        : method === "PUT"
+          ? HttpClient.put(url, options)
+          : HttpClient.del(url, options)
+  ).pipe(Effect.mapError((cause) => new SentryTransportError({ path, cause })));
+
+  if (response.status === 204 || response.status === 202) {
+    return undefined;
+  }
+
+  const payload: unknown = yield* response.json.pipe(
+    Effect.catch(() => Effect.succeed(undefined)),
+  );
+
+  if (response.status >= 200 && response.status < 300) {
+    return payload;
+  }
+  if (response.status === 404) {
+    return yield* new SentryNotFound({ path });
+  }
+  const message = describe(payload);
+  if (isConflict(response.status, message)) {
+    return yield* new SentryConflict({ path, message });
+  }
+  return yield* new SentryApiError({ path, status: response.status, message });
+});

--- a/packages/alchemy/src/Sentry/Credentials.ts
+++ b/packages/alchemy/src/Sentry/Credentials.ts
@@ -1,0 +1,76 @@
+import * as Config from "effect/Config";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Redacted from "effect/Redacted";
+
+/**
+ * Base URL of Sentry's SaaS API. Self-hosted instances expose the same
+ * `/api/0` surface under their own host.
+ */
+export const DEFAULT_API_BASE_URL = "https://sentry.io/api/0";
+
+export type CredentialsValue = {
+  /** Auth token used as `Authorization: Bearer <token>`. */
+  readonly authToken: Redacted.Redacted<string>;
+  /** API root, e.g. `https://sentry.example.com/api/0` for self-hosted. */
+  readonly apiBaseUrl: string;
+};
+
+/**
+ * Sentry credentials. Resolved once per stack and shared by every Sentry
+ * provider.
+ */
+export class Credentials extends Context.Service<
+  Credentials,
+  Effect.Effect<CredentialsValue>
+>()("alchemy/Sentry/Credentials") {}
+
+/**
+ * Build a `Credentials` layer from an explicit token.
+ *
+ * @example
+ * ```ts
+ * Effect.provide(
+ *   Sentry.fromToken({
+ *     authToken: process.env.SENTRY_AUTH_TOKEN!,
+ *     apiBaseUrl: "https://sentry.example.com/api/0",
+ *   }),
+ * )
+ * ```
+ */
+export const fromToken = (input: {
+  authToken: string | Redacted.Redacted<string>;
+  apiBaseUrl?: string;
+}) =>
+  Layer.succeed(
+    Credentials,
+    Effect.succeed({
+      authToken:
+        typeof input.authToken === "string"
+          ? Redacted.make(input.authToken)
+          : input.authToken,
+      apiBaseUrl: input.apiBaseUrl ?? DEFAULT_API_BASE_URL,
+    }),
+  );
+
+/**
+ * Build a `Credentials` layer from the environment.
+ *
+ * Reads `SENTRY_AUTH_TOKEN` and, for self-hosted instances,
+ * `SENTRY_API_BASE_URL` (defaults to `https://sentry.io/api/0`).
+ */
+export const fromEnv = () =>
+  Layer.effect(
+    Credentials,
+    Effect.gen(function* () {
+      const authToken = yield* Config.redacted("SENTRY_AUTH_TOKEN");
+      const apiBaseUrl = yield* Config.string("SENTRY_API_BASE_URL").pipe(
+        Config.withDefault(DEFAULT_API_BASE_URL),
+      );
+      return Effect.succeed({
+        authToken,
+        apiBaseUrl: apiBaseUrl.replace(/\/$/, ""),
+      });
+    }),
+  );

--- a/packages/alchemy/src/Sentry/Project.ts
+++ b/packages/alchemy/src/Sentry/Project.ts
@@ -1,0 +1,237 @@
+import * as Effect from "effect/Effect";
+import { Unowned } from "../AdoptPolicy.ts";
+import { isResolved } from "../Diff.ts";
+import * as Provider from "../Provider.ts";
+import { Resource } from "../Resource.ts";
+import { request, SentryApiError } from "./Api.ts";
+import type { Providers } from "./Providers.ts";
+
+export type ProjectProps = {
+  /** Organization slug that owns the project, e.g. `my-org`. */
+  organization: string;
+  /**
+   * Team slug the project is created under. Changing it triggers a
+   * replacement — Sentry has no in-place team transfer on this endpoint.
+   */
+  team: string;
+  /** Display name shown in the Sentry UI. */
+  name: string;
+  /**
+   * URL slug. Sentry derives one from `name` when omitted, and the derived
+   * value is read back into the `slug` attribute.
+   */
+  slug?: string;
+  /** Platform identifier, e.g. `javascript`, `node`, `python`. */
+  platform?: string;
+};
+
+export type Project = Resource<
+  "Sentry.Project",
+  ProjectProps,
+  {
+    /** Numeric project id assigned by Sentry. */
+    id: string;
+    /** URL slug, either supplied or derived from `name`. */
+    slug: string;
+    /** Display name. */
+    name: string;
+    /** Organization slug that owns the project. */
+    organization: string;
+    /** Platform identifier, when set. */
+    platform: string | undefined;
+    /** ISO timestamp of creation. */
+    dateCreated: string | undefined;
+  },
+  never,
+  Providers
+>;
+
+/**
+ * A Sentry project — the container that receives events from one application
+ * and owns its client keys (DSNs).
+ *
+ * Works against Sentry SaaS and self-hosted instances; point
+ * `SENTRY_API_BASE_URL` at your own host to manage the latter.
+ * @resource
+ * @see https://docs.sentry.io/api/projects/
+ *
+ * @section Creating a Project
+ * @example Basic project
+ * ```typescript
+ * const project = yield* Sentry.Project("api", {
+ *   organization: "my-org",
+ *   team: "backend",
+ *   name: "API",
+ *   platform: "node",
+ * });
+ * ```
+ *
+ * @example Explicit slug
+ * ```typescript
+ * const project = yield* Sentry.Project("api", {
+ *   organization: "my-org",
+ *   team: "backend",
+ *   name: "API",
+ *   slug: "api-prod",
+ * });
+ * ```
+ */
+export const Project = Resource<Project>("Sentry.Project");
+
+type ProjectAttrs = Project["Attributes"];
+
+const str = (value: unknown): string | undefined =>
+  typeof value === "string"
+    ? value
+    : typeof value === "number"
+      ? String(value)
+      : undefined;
+
+const parseProject = (
+  payload: unknown,
+  organization: string,
+): ProjectAttrs | undefined => {
+  if (payload === null || typeof payload !== "object") return undefined;
+  const record: Record<string, unknown> = { ...payload };
+  const id = str(record.id);
+  const slug = str(record.slug);
+  const name = str(record.name);
+  if (id === undefined || slug === undefined || name === undefined) {
+    return undefined;
+  }
+  return {
+    id,
+    slug,
+    name,
+    organization,
+    platform: str(record.platform),
+    dateCreated: str(record.dateCreated),
+  };
+};
+
+const decode = (payload: unknown, organization: string, path: string) =>
+  Effect.suspend(() => {
+    const project = parseProject(payload, organization);
+    return project === undefined
+      ? Effect.fail(
+          new SentryApiError({
+            path,
+            status: 200,
+            message: "unexpected project payload",
+          }),
+        )
+      : Effect.succeed(project);
+  });
+
+export const ProjectProvider = () =>
+  Provider.effect(
+    Project,
+    Effect.gen(function* () {
+      const get = (organization: string, slug: string) => {
+        const path = `/projects/${organization}/${slug}/`;
+        return request("GET", path).pipe(
+          Effect.flatMap((payload) => decode(payload, organization, path)),
+          Effect.catchTag("SentryNotFound", () => Effect.succeed(undefined)),
+        );
+      };
+
+      return {
+        stables: ["id", "organization"],
+        diff: Effect.fn(function* ({ olds, news, output }) {
+          if (!isResolved(news)) return undefined;
+          if (output && news.organization !== output.organization) {
+            return { action: "replace" } as const;
+          }
+          if (olds && news.team !== olds.team) {
+            return { action: "replace" } as const;
+          }
+          if (
+            news.name !== olds?.name ||
+            news.slug !== olds?.slug ||
+            news.platform !== olds?.platform
+          ) {
+            return { action: "update" } as const;
+          }
+          return undefined;
+        }),
+        reconcile: Effect.fn(function* ({ news, output }) {
+          // Observe — the slug is Sentry's path identifier. Prefer the cached
+          // one, then the requested one; a create derives it from `name`.
+          const observedSlug = output?.slug ?? news.slug;
+          const observed = observedSlug
+            ? yield* get(news.organization, observedSlug)
+            : undefined;
+
+          // Ensure — create when missing. A Conflict means a peer reconciler
+          // (or a slug collision) won the race, so fall through to the sync.
+          if (observed === undefined) {
+            const path = `/teams/${news.organization}/${news.team}/projects/`;
+            const created = yield* request("POST", path, {
+              name: news.name,
+              slug: news.slug,
+              platform: news.platform,
+            }).pipe(
+              Effect.flatMap((payload) =>
+                decode(payload, news.organization, path),
+              ),
+              Effect.catchTag("SentryConflict", () =>
+                news.slug
+                  ? get(news.organization, news.slug)
+                  : Effect.succeed(undefined),
+              ),
+            );
+            if (created !== undefined) {
+              return created;
+            }
+          }
+
+          // Sync — apply the mutable aspects against observed state.
+          const current =
+            observed ?? (yield* get(news.organization, news.slug ?? news.name));
+          if (current === undefined) {
+            return yield* new SentryApiError({
+              path: `/projects/${news.organization}/${news.slug ?? news.name}/`,
+              status: 404,
+              message: "project vanished during reconcile",
+            });
+          }
+          const desiredSlug = news.slug ?? current.slug;
+          if (
+            current.name === news.name &&
+            current.slug === desiredSlug &&
+            current.platform === news.platform
+          ) {
+            return current;
+          }
+          const path = `/projects/${news.organization}/${current.slug}/`;
+          const updated = yield* request("PUT", path, {
+            name: news.name,
+            slug: desiredSlug,
+            platform: news.platform,
+          }).pipe(
+            Effect.flatMap((payload) =>
+              decode(payload, news.organization, path),
+            ),
+          );
+          return updated;
+        }),
+        delete: Effect.fn(function* ({ output }) {
+          yield* request(
+            "DELETE",
+            `/projects/${output.organization}/${output.slug}/`,
+          ).pipe(Effect.catchTag("SentryNotFound", () => Effect.void));
+        }),
+        read: Effect.fn(function* ({ olds, output }) {
+          const slug = output?.slug ?? olds?.slug;
+          const organization = output?.organization ?? olds?.organization;
+          if (!slug || !organization) return undefined;
+          const existing = yield* get(organization, slug);
+          if (existing === undefined) return undefined;
+          // Sentry has no tag or free-text field we can brand, so a project we
+          // have never provisioned is surfaced as foreign and the engine gates
+          // the takeover behind `--adopt`.
+          return output === undefined ? Unowned(existing) : existing;
+        }),
+      };
+    }),
+  );

--- a/packages/alchemy/src/Sentry/Providers.ts
+++ b/packages/alchemy/src/Sentry/Providers.ts
@@ -1,0 +1,24 @@
+import * as Layer from "effect/Layer";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import * as Provider from "../Provider.ts";
+import * as Credentials from "./Credentials.ts";
+import { Project, ProjectProvider } from "./Project.ts";
+
+export class Providers extends Provider.ProviderCollection<Providers>()(
+  "Sentry",
+) {}
+
+export type ProviderRequirements = Layer.Services<ReturnType<typeof providers>>;
+
+/**
+ * Sentry providers and credentials. Credentials come from
+ * `SENTRY_AUTH_TOKEN`, with `SENTRY_API_BASE_URL` selecting a self-hosted
+ * instance.
+ */
+export const providers = () =>
+  Layer.effect(Providers, Provider.collection([Project])).pipe(
+    Layer.provide(Layer.mergeAll(ProjectProvider())),
+    Layer.provideMerge(Credentials.fromEnv()),
+    Layer.provideMerge(FetchHttpClient.layer),
+    Layer.orDie,
+  );

--- a/packages/alchemy/src/Sentry/index.ts
+++ b/packages/alchemy/src/Sentry/index.ts
@@ -1,0 +1,4 @@
+export * from "./Api.ts";
+export * from "./Credentials.ts";
+export * from "./Project.ts";
+export * from "./Providers.ts";


### PR DESCRIPTION
Adds a `Sentry` provider with a `Project` resource. The API base URL is part of the credentials, so one provider drives both Sentry SaaS and a self-hosted instance — the v1 provider hardcoded `https://sentry.io/api/0`.

```ts
const project = yield* Sentry.Project("api", {
  organization: "my-org",
  team: "backend",
  name: "API",
  platform: "node",
});
```

```sh
SENTRY_AUTH_TOKEN=...                                   # required
SENTRY_API_BASE_URL=https://sentry.example.com/api/0    # self-hosted, defaults to sentry.io
```

Follows #1001. Requests go through `HttpClient` directly because `distilled` has no `sentry` package. If you would rather see `@distilled.cloud/sentry` generated from Sentry's OpenAPI schema first, I will rebuild this on top of it.
