### PR TITLE
docs(blog): beta.66 release notes

### DIFF
--- a/website/src/content/docs/blog/2026-07-30-beta-66.md
+++ b/website/src/content/docs/blog/2026-07-30-beta-66.md
@@ -78,7 +78,7 @@ Remote queues work in both directions: a local Worker can produce
 to a live queue, and a local `queue()` handler drains a live queue
 through an `http_pull` consumer.
 
-The state store now records whether each resource is local or
+The State Store now records whether each resource is local or
 live. Switching between the two plans a replacement: `alchemy
 deploy` right after `alchemy dev` replaces local instances with
 real cloud resources instead of updating over them. Node-side

--- a/website/src/content/docs/blog/2026-07-30-beta-66.md
+++ b/website/src/content/docs/blog/2026-07-30-beta-66.md
@@ -78,12 +78,13 @@ Remote queues work in both directions: a local Worker can produce
 to a live queue, and a local `queue()` handler drains a live queue
 through an `http_pull` consumer.
 
-The mode that reconciled a resource is stamped into state, and
-switching modes plans a replacement — so `alchemy deploy` right
-after `alchemy dev` cleanly replaces local instances instead of
-updating over them. Node-side capability clients (e.g. in Actions)
-reach the same local simulators the Workers see, so a seed script
-writes to the same local KV your Worker reads.
+The state store now records whether each resource is local or
+live. Switching between the two plans a replacement: `alchemy
+deploy` right after `alchemy dev` replaces local instances with
+real cloud resources instead of updating over them. Node-side
+capability clients (e.g. in Actions) reach the same local
+simulators the Workers see, so a seed script writes to the same
+local KV your Worker reads.
 
 Docs: [Local development](/environments/local-development).
 

--- a/website/src/content/docs/blog/2026-07-30-beta-66.md
+++ b/website/src/content/docs/blog/2026-07-30-beta-66.md
@@ -1,0 +1,358 @@
+---
+title: 2.0.0-beta.66 - Local Emulation & Gradual Deployments
+date: 2026-07-30T20:00:00Z
+category: release
+excerpt: v2.0.0-beta.66 emulates KV, R2, D1, and Queues locally in alchemy dev with Alchemy.remote() opt-outs, ships Worker versions with gradual deployments and sticky sessions, redesigns Worker URLs around workersDev and a domain object, and adds OpenTelemetry export, a Prisma provider, and a Bedrock LanguageModel binding.
+---
+
+beta.66 makes `alchemy dev` fully local by default: KV, R2, D1, and
+Queues are emulated on your machine, and `Alchemy.remote()` opts any
+resource back onto the real cloud. Workers gain versions, gradual
+deployments, and sticky sessions. The release also redesigns how
+Worker URLs and domains are modeled, and adds OpenTelemetry export,
+a Prisma provider, and a Bedrock `LanguageModel` binding.
+
+:::caution
+**Breaking change**
+
+Worker URL configuration is redesigned
+([#977](https://github.com/alchemy-run/alchemy/pull/977)). The
+`url` and `subdomain` props are replaced by `workersDev`, `domain`
+takes an object form, and the `domains` output is replaced by
+`urls` + `domain`. This applies to `Cloudflare.Worker` and
+`Cloudflare.Website.*`.
+
+```diff lang="typescript"
+ const worker = yield* Cloudflare.Worker("Api", {
+   main: "./src/api.ts",
+-  url: false,
+-  subdomain: { previewsEnabled: true },
+-  domain: ["example.com", "www.example.com"],
++  workersDev: { enabled: false, previewsEnabled: true },
++  domain: {
++    name: "example.com",
++    aliases: ["www.example.com"],
++  },
+ });
+
+-worker.domains; // string[]
++worker.url;     // "https://example.com" — always urls[0]
++worker.urls;    // every URL serving the Worker, most significant first
++worker.domain;  // { name, aliases, redirects } | undefined
+```
+
+- `url: true` (the default) becomes `workersDev: true` — omit it.
+- `domain: "example.com"` still works as a string.
+- `domain: []` (explicit detach-all) becomes `domain: null`; an
+  omitted `domain` leaves attachments unmanaged.
+- Persisted state migrates automatically on the first redeploy.
+
+See [Worker URLs redesigned](#worker-urls-redesigned) below for the
+new model.
+:::
+
+## Local emulation in `alchemy dev`
+
+Provider mode (local vs live) is now a first-class engine concept
+([#963](https://github.com/alchemy-run/alchemy/pull/963)). KV
+Namespaces, R2 Buckets, D1 Databases, and Queues are emulated
+locally during `alchemy dev` — they fabricate `dev:`-prefixed ids
+with no cloud calls, and Worker bindings lower onto local workerd
+simulators. D1 applies `migrationsDir` and `importFiles` against
+the local database.
+
+`Alchemy.remote()` opts a resource (or a whole scope) back onto the
+real cloud during dev:
+
+```typescript
+// emulated locally in dev
+const db = yield* Cloudflare.D1.Database("DB", {});
+
+// real queue, even in dev
+const jobs = yield* Cloudflare.Queues.Queue("Jobs", {}).pipe(
+  Alchemy.remote(),
+);
+```
+
+Remote queues work in both directions: a local Worker can produce
+to a live queue, and a local `queue()` handler drains a live queue
+through an `http_pull` consumer.
+
+The mode that reconciled a resource is stamped into state, and
+switching modes plans a replacement — so `alchemy deploy` right
+after `alchemy dev` cleanly replaces local instances instead of
+updating over them. Node-side capability clients (e.g. in Actions)
+reach the same local simulators the Workers see, so a seed script
+writes to the same local KV your Worker reads.
+
+Docs: [Local development](/environments/local-development).
+
+## Worker versions & gradual deployments
+
+The `version` prop maps Cloudflare's [versions & gradual
+deployments](https://developers.cloudflare.com/workers/configuration/versions-and-deployments/)
+onto alchemy stages
+([#948](https://github.com/alchemy-run/alchemy/pull/948)).
+
+Upload one stage's code as a zero-traffic version of another
+stage's Worker — the PR-preview workflow:
+
+```typescript
+const parent = yield* Cloudflare.Worker.ref("Api", { stage: "staging" });
+
+yield* Cloudflare.Worker("Api", {
+  main: "./src/api.ts",
+  version: { parent, message: `PR #${process.env.PR_NUMBER}` },
+});
+```
+
+The version's `url` is a stable aliased preview URL that re-points
+at each newly uploaded version. Add `traffic` to canary a share of
+the parent's traffic, or roll out a Worker's own deploy gradually:
+
+```typescript
+version: { parent, traffic: 10 }  // canary: 10% of staging's traffic
+version: { traffic: 25 }          // self-rollout: new version at 25%
+```
+
+`version.affinity` pins each user to one version for the duration
+of a rollout
+([#985](https://github.com/alchemy-run/alchemy/pull/985)),
+requested by [Eric Clemmons](https://github.com/ericclemmons):
+
+```typescript
+version: {
+  traffic: 10,
+  // sticky by session cookie, falling back to sticky IP
+  affinity: { cookie: "session_id", ip: true },
+}
+```
+
+Docs: [Gradual deployments](/cloudflare/compute/gradual-deployments).
+
+## Worker URLs redesigned
+
+`workersDev` controls the `workers.dev` surface (and is actually
+reconciled — the old `subdomain` prop was silently ignored), and
+`domain` grows aliases and redirects
+([#977](https://github.com/alchemy-run/alchemy/pull/977)):
+
+```typescript
+const worker = yield* Cloudflare.Worker("Api", {
+  main: "./src/api.ts",
+  workersDev: false,
+  domain: {
+    name: "example.com",
+    aliases: ["www.example.com"],     // also serve the Worker
+    redirects: ["old.example.com"],   // 301 → https://example.com
+  },
+});
+```
+
+Each redirect hostname gets managed DNS and an edge certificate,
+plus a zone redirect rule that 301s (path and query preserved)
+before Workers run — redirected requests never invoke the Worker.
+
+`urls` lists every URL that serves the Worker, most significant
+first: custom domain, aliases, `workers.dev`, version preview URLs.
+`url` is always `urls[0]`. Under `alchemy dev`, `urls` is the dev
+server's actual surface (`[localhost, ...LAN]`). Redirect hostnames
+never appear — `worker.urls` is the CORS-allow-list answer.
+
+Docs: [Custom domains](/cloudflare/networking/custom-domains).
+
+## OpenTelemetry export
+
+Deployed apps export traces, logs, and metrics over OTLP from every
+runtime — Worker, Durable Object, Workflow, Lambda, Containers, ECS
+Task ([#860](https://github.com/alchemy-run/alchemy/pull/860)).
+Telemetry is a Layer, composed into the Function/Worker's
+`Effect.provide` like any other binding:
+
+```typescript
+Effect.provide(
+  Layer.mergeAll(
+    Cloudflare.R2.ReadWriteBucketBinding,
+    Axiom.Telemetry({ token: Ingest, traces: Traces, logs: Logs }),
+    Alchemy.Telemetry.layerOtlp({
+      url: "https://api.honeycomb.io",
+      headers: { "x-honeycomb-team": apiKey },
+    }),
+  ),
+)
+```
+
+`Axiom.Telemetry` is sugar over the generic
+`Alchemy.Telemetry.layerOtlp`, which speaks to any OTLP backend.
+Exporters compose: merge several and every destination receives the
+telemetry with agreeing trace ids. Without a telemetry layer,
+Effect's no-op tracer keeps instrumentation free.
+
+Docs: [Telemetry](/infrastructure-as-effects/telemetry).
+
+## Prisma provider
+
+`alchemy/Prisma` provisions Prisma Postgres and Prisma Compute
+([#416](https://github.com/alchemy-run/alchemy/pull/416)) — thanks
+[Aman Varshney](https://github.com/AmanVarshney01)!
+
+```typescript
+const project = yield* Prisma.Project("Project", { createDatabase: false });
+const postgres = yield* Prisma.Postgres("Postgres", { project });
+const connection = yield* Prisma.Connection("Connection", {
+  database: postgres,
+});
+
+const app = yield* Prisma.Compute("App", {
+  project,
+  path: "./app",
+  build: { command: "bun run build", outdir: ".output" },
+  env: { DATABASE_URL: connection.databaseUrl },
+});
+```
+
+Resources reconcile from observed API state, recover from
+interrupted deployments, and never persist Prisma credentials as
+plaintext.
+
+Docs: [Prisma](/prisma).
+
+## Bedrock LanguageModel
+
+`AWS.Bedrock.LanguageModel` turns any Bedrock model into an
+`effect/unstable/ai` `LanguageModel` Layer
+([#919](https://github.com/alchemy-run/alchemy/pull/919)), so
+`generateText`, `streamText`, toolkits, and `Chat` run against
+Bedrock unchanged:
+
+```typescript
+const model = yield* AWS.Bedrock.LanguageModel([
+  "us.anthropic.claude-sonnet-4-20250514-v1:0",
+]);
+
+return {
+  fetch: Effect.gen(function* () {
+    const response = yield* LanguageModel.generateText({ prompt });
+    return yield* HttpServerResponse.json({ text: response.text });
+  }).pipe(Effect.provide(model)),
+};
+```
+
+The binding is the IAM boundary: which models the Function may call
+is fixed at deploy time. Model choice and inference parameters are
+per-call decisions via `AWS.Bedrock.withModelParameters`. The
+adapter speaks Bedrock's Converse API directly.
+
+Docs: [Bedrock](/aws/ai/bedrock).
+
+## Also in this release
+
+- **Assets-only Workers**
+  ([#969](https://github.com/alchemy-run/alchemy/pull/969),
+  [#970](https://github.com/alchemy-run/alchemy/pull/970)) — a
+  Worker with only an `assets` directory deploys with no script at
+  all, so static requests are free and never invoke a Worker. The
+  class form works without an impl.
+- **Headless OAuth login**
+  ([#962](https://github.com/alchemy-run/alchemy/pull/962)) —
+  `alchemy login` now works over SSH and in containers via a hosted
+  relay page: paste the code when the browser can't reach the CLI.
+  Thanks [BlankParticle](https://github.com/BlankParticle) (who
+  also fixed prompt cancellation in
+  [#968](https://github.com/alchemy-run/alchemy/pull/968))!
+- **Lambda Layers**
+  ([#971](https://github.com/alchemy-run/alchemy/pull/971)) —
+  `AWS.Lambda.LayerVersion` plus a `layers` prop on `Function`.
+  Thanks [Arya Saatvik](https://github.com/aryasaatvik)!
+- **SES email receiving**
+  ([#939](https://github.com/alchemy-run/alchemy/pull/939)) —
+  receipt rule sets, rules, IP filters, and a `SendBounce` binding;
+  guide at [/aws/email/receiving](/aws/email/receiving). Thanks
+  again [Arya Saatvik](https://github.com/aryasaatvik)!
+- **Docker Swarm**
+  ([#972](https://github.com/alchemy-run/alchemy/pull/972)) —
+  `Docker.Swarm`, `Docker.Context`, and `Docker.Service`, including
+  effectful services bundled and deployed from an Effect impl.
+  Thanks [Sergey Bekrin](https://github.com/sbekrin)!
+- **Container-backed Durable Objects on async Workers**
+  ([#956](https://github.com/alchemy-run/alchemy/pull/956)) — host
+  npm-packaged container DO classes like `@cloudflare/sandbox`'s
+  `Sandbox` via `DurableObject("Sandbox", { container })`.
+- **`Worker.URL`**
+  ([#964](https://github.com/alchemy-run/alchemy/pull/964)) — bind
+  a Worker's own public URL onto itself; resolves to the local dev
+  URL under `alchemy dev`.
+- **Destroy aggregates failures**
+  ([#973](https://github.com/alchemy-run/alchemy/pull/973)) — a
+  failing delete no longer aborts the destroy. Every delete is
+  attempted and one typed `DestroyError` reports what failed and
+  what was blocked by it.
+- **Dev Worker handoff is make-before-break**
+  ([#863](https://github.com/alchemy-run/alchemy/pull/863)) — the
+  previous workerd instance keeps serving until its replacement
+  starts, closing the 503 window on slow restarts (e.g. container
+  image prep).
+- **`Output` env secrets upload encrypted**
+  ([#943](https://github.com/alchemy-run/alchemy/pull/943)) — an
+  `Output<Redacted>` in a Worker's `env` now uploads as
+  `secret_text` instead of readable text, and `InferEnv` types are
+  preserved. Thanks [Seth Carlton](https://github.com/sethcarlton)!
+- **OAuth credentials refresh on expiry**
+  ([#966](https://github.com/alchemy-run/alchemy/pull/966)) — a dev
+  session that outlives the access token re-resolves credentials
+  instead of failing until restart (the "dev breaks after machine
+  sleep" hang).
+- **Worker read fan-out cut**
+  ([#932](https://github.com/alchemy-run/alchemy/pull/932),
+  [#944](https://github.com/alchemy-run/alchemy/pull/944),
+  [#975](https://github.com/alchemy-run/alchemy/pull/975)) —
+  subdomain lookups are memoized, route discovery is scoped to
+  known zones, and unmanaged custom domains converge to a `noop`
+  plan — fixing 429 rate-limit errors on accounts with many zones.
+- **Plain Workers default to `nodejs_compat`**
+  ([#796](https://github.com/alchemy-run/alchemy/pull/796)) — the
+  default previously reached only Effect-native Workers. The same
+  PR resolves `Config`/`Output` env values in `StaticSite` builds.
+- **ECS** — service reconciliation waits for rollout, drain, and
+  healthy ALB targets
+  ([#945](https://github.com/alchemy-run/alchemy/pull/945), thanks
+  [samnan-kradle](https://github.com/samnan-kradle)!),
+  `taskRoleManagedPolicyArns` attach on the `Service` form
+  ([#936](https://github.com/alchemy-run/alchemy/pull/936), thanks
+  [bweis](https://github.com/bweis)!), and `environmentFiles` joins
+  the shared task-definition surface
+  ([#904](https://github.com/alchemy-run/alchemy/pull/904)).
+- **`send_email` stubs locally in dev**
+  ([#865](https://github.com/alchemy-run/alchemy/pull/865)) —
+  `send()` logs to the dev console instead of delivering mail; set
+  `dev: { remote: true }` to send for real.
+- **Destroy removes the persisted stack output**
+  ([#965](https://github.com/alchemy-run/alchemy/pull/965)) —
+  cross-stack refs to a destroyed stage now fail with the typed
+  `InvalidReferenceError` instead of reading an empty husk.
+- **PlanetScale metadata-only updates no longer replace roles**
+  ([#957](https://github.com/alchemy-run/alchemy/pull/957)).
+- **CloudFront updates merge observed config**
+  ([#935](https://github.com/alchemy-run/alchemy/pull/935)) — ends
+  `IllegalUpdate` failures on members the props don't express.
+- **CLI** — the version-update warning prints before interactive
+  prompts ([#959](https://github.com/alchemy-run/alchemy/pull/959)),
+  and rolldown's native binding loads lazily so non-Cloudflare
+  stacks deploy without it
+  ([#955](https://github.com/alchemy-run/alchemy/pull/955)).
+- **Local dev fixes** — a Worker consuming a queue with a
+  dead-letter queue starts again
+  ([#1000](https://github.com/alchemy-run/alchemy/pull/1000)), and
+  `Container` env bindings no longer break Vite builds
+  ([#999](https://github.com/alchemy-run/alchemy/pull/999)).
+
+## Where to go next
+
+- [Local development](/environments/local-development)
+- [Gradual deployments](/cloudflare/compute/gradual-deployments)
+- [Custom domains](/cloudflare/networking/custom-domains)
+- [Telemetry](/infrastructure-as-effects/telemetry)
+- [Prisma](/prisma)
+- [Bedrock](/aws/ai/bedrock)
+- [CHANGELOG](https://github.com/alchemy-run/alchemy/blob/main/CHANGELOG.md#v200-beta66)
+- [Compare v2.0.0-beta.65 → v2.0.0-beta.66](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.65...v2.0.0-beta.66)

--- a/website/src/content/docs/blog/2026-07-30-beta-66.md
+++ b/website/src/content/docs/blog/2026-07-30-beta-66.md
@@ -155,10 +155,21 @@ plus a zone redirect rule that 301s (path and query preserved)
 before Workers run — redirected requests never invoke the Worker.
 
 `urls` lists every URL that serves the Worker, most significant
-first: custom domain, aliases, `workers.dev`, version preview URLs.
-`url` is always `urls[0]`. Under `alchemy dev`, `urls` is the dev
-server's actual surface (`[localhost, ...LAN]`). Redirect hostnames
-never appear — `worker.urls` is the CORS-allow-list answer.
+first, and `url` is always `urls[0]`:
+
+1. `https://<domain.name>` — the canonical custom domain.
+2. Each alias, in declared order.
+3. The stable `workers.dev` URL, when `workersDev` is enabled.
+4. Version preview URLs. A version worker (`version.parent`)
+   serves only through previews, so its stable aliased preview URL
+   is its `url`. In a gradual rollout, the uploaded version's
+   preview URL trails the list.
+5. Under `alchemy dev`, the list is the dev server's actual
+   surface instead: `[localhost, ...LAN]`. A configured `domain`
+   is not served by the dev session, so `url` is the local URL.
+
+Redirect hostnames never appear in `urls` — they serve no content.
+When you need a CORS allow-list, `worker.urls` is the answer.
 
 Docs: [Custom domains](/cloudflare/networking/custom-domains).
 

--- a/website/src/content/docs/blog/2026-07-30-beta-66.md
+++ b/website/src/content/docs/blog/2026-07-30-beta-66.md
@@ -157,19 +157,53 @@ before Workers run — redirected requests never invoke the Worker.
 `urls` lists every URL that serves the Worker, most significant
 first, and `url` is always `urls[0]`:
 
-1. `https://<domain.name>` — the canonical custom domain.
-2. Each alias, in declared order.
-3. The stable `workers.dev` URL, when `workersDev` is enabled.
-4. Version preview URLs. A version worker (`version.parent`)
-   serves only through previews, so its stable aliased preview URL
-   is its `url`. In a gradual rollout, the uploaded version's
-   preview URL trails the list.
-5. Under `alchemy dev`, the list is the dev server's actual
-   surface instead: `[localhost, ...LAN]`. A configured `domain`
-   is not served by the dev session, so `url` is the local URL.
+```typescript
+// workers.dev only (the default)
+["https://api.my-team.workers.dev"]
+
+// custom domain — outranks workers.dev
+["https://example.com", "https://api.my-team.workers.dev"]
+
+// domain with aliases, workersDev: false
+["https://example.com", "https://www.example.com"]
+
+// version worker (version.parent) — the stable aliased preview
+// URL first, then this upload's per-version URL
+[
+  "https://pr-42-api.my-team.workers.dev",
+  "https://a1b2c3d4-api.my-team.workers.dev",
+]
+
+// gradual rollout (version: { traffic }) — the uploaded version's
+// preview URL trails
+[
+  "https://example.com",
+  "https://api.my-team.workers.dev",
+  "https://a1b2c3d4-api.my-team.workers.dev",
+]
+
+// alchemy dev — the dev server's actual surface
+["http://localhost:5173", "http://192.168.1.23:5173"]
+```
 
 Redirect hostnames never appear in `urls` — they serve no content.
-When you need a CORS allow-list, `worker.urls` is the answer.
+That makes `urls` the CORS allow-list:
+
+```typescript
+const site = yield* Cloudflare.Website.Vite("Site", { ... });
+
+// allow the site — on every URL that serves it — to call the API
+const api = yield* Cloudflare.Worker("Api", {
+  main: "./src/api.ts",
+  env: { ALLOWED_ORIGINS: site.urls },
+});
+```
+
+In production that allow-list is the site's custom domain, aliases,
+and `workers.dev` URL. Under `alchemy dev` it is the Vite dev
+server's Local and Network URLs — `localhost` plus the LAN address
+(`http://192.168…`) — so a phone on your Wi-Fi can load the site
+and call the API.
 
 Docs: [Custom domains](/cloudflare/networking/custom-domains).
 

--- a/website/src/content/docs/blog/2026-07-30-beta-66.md
+++ b/website/src/content/docs/blog/2026-07-30-beta-66.md
@@ -257,6 +257,29 @@ const app = yield* Prisma.Compute("App", {
 });
 ```
 
+`Prisma.Compute` is also an effectful runtime, like a Cloudflare
+Worker or a Lambda: pass `main` and an Effect body, and the app is
+bundled from your Stack file with the `Connect` binding wiring the
+database in:
+
+```typescript
+export default Prisma.Compute(
+  "Api",
+  { project, main: import.meta.filename },
+  Effect.gen(function* () {
+    const db = yield* Prisma.Connect(connection);
+    const sql = yield* SQL.Postgres({ url: db.databaseUrl });
+
+    return {
+      fetch: Effect.gen(function* () {
+        const users = yield* sql`SELECT * FROM users`;
+        return yield* HttpServerResponse.json(users);
+      }),
+    };
+  }).pipe(Effect.provide(Prisma.ConnectBinding)),
+);
+```
+
 Resources reconcile from observed API state, recover from
 interrupted deployments, and never persist Prisma credentials as
 plaintext.

--- a/website/src/content/docs/environments/local-development.mdx
+++ b/website/src/content/docs/environments/local-development.mdx
@@ -1,13 +1,15 @@
 ---
 title: Local development
-description: How alchemy dev provides hot reloading, local workerd execution, and cloud-backed resources for fast iteration.
+description: How alchemy dev provides hot reloading, local workerd execution, and local emulation with per-resource opt-in to real cloud services.
 ---
 
 import Terminal from "../../../components/Terminal.astro";
 
-`alchemy dev` gives you a fast local development loop without
-sacrificing access to real cloud services. Infrastructure is deployed
-to the cloud while your code runs locally with hot reloading.
+`alchemy dev` runs your stack on your machine. Workers execute in
+workerd, KV Namespaces, R2 Buckets, D1 Databases, and Queues are
+emulated locally, and code changes hot reload in milliseconds.
+`Alchemy.remote()` runs any resource against the real cloud when you
+need it.
 
 ## How it works
 
@@ -15,8 +17,8 @@ to the cloud while your code runs locally with hot reloading.
 alchemy dev
 ```
 
-<Terminal content={`[g]✓[/g] [b]Bucket[/b] [d](Cloudflare.R2.Bucket)[/d] [g]created[/g]
-[g]✓[/g] [b]DB[/b] [d](Cloudflare.D1.Database)[/d] [g]created[/g]
+<Terminal content={`[g]✓[/g] [b]Bucket[/b] [d](Cloudflare.R2.Bucket)[/d] [g]created[/g] [d](local)[/d]
+[g]✓[/g] [b]DB[/b] [d](Cloudflare.D1.Database)[/d] [g]created[/g] [d](local)[/d]
 [g]✓[/g] [b]Worker[/b] [d](Cloudflare.Worker)[/d] [g]created[/g] [d](local → workerd)[/d]
 [s2][d]• http://localhost:1337[/d]
 
@@ -24,18 +26,21 @@ alchemy dev
 
 Three things happen:
 
-1. **Infrastructure deploys to the cloud** — R2 Buckets, D1
-   Databases, KV Namespaces are created on the real provider. No
-   emulation, no fidelity gaps.
+1. **Emulatable services run locally** — KV Namespaces, R2 Buckets,
+   D1 Databases, and Queues are created as local simulators with
+   `dev:`-prefixed ids. No cloud calls. D1 applies `migrationsDir`
+   and `importFiles` against the local database.
 2. **Workers run locally in workerd** — your code executes in
-   workerd, the same runtime used in production. A proxy routes
-   requests between the cloud and your local process.
+   workerd, the same runtime used in production, with bindings wired
+   to the local simulators.
 3. **File changes hot reload** — edit your code and the Worker
    rebuilds instantly.
 
-`dev` deploys into your personal [stage](/environments/stages)
-(`dev_$USER` by default), so your loop never collides with
-teammates or prod.
+Resources whose provider has no local implementation (a Hyperdrive,
+a Vectorize index) deploy to the real cloud, into your personal
+[stage](/environments/stages) (`dev_$USER` by default), so your loop
+never collides with teammates or prod. A stack that mixes emulated
+and live-only resources just works.
 
 ## Hot module reloading
 
@@ -50,24 +55,32 @@ teammates or prod.
 [g]✓[/g] [b]Worker[/b] [d]reloaded in 38ms[/d]`} />
 
 - Code changes take effect in **milliseconds**, not minutes
-- Cloud resources stay deployed across reloads — only your
-  application code is rebuilt
+- Resources stay running across reloads — only your application
+  code is rebuilt
 
 Arbitrary dev processes — Vite, Next, anything with a dev server —
 join the loop via [Command.Dev](/command/dev-servers): started by
 `alchemy dev`, restarted when its inputs change, and a no-op on
 deploy.
 
-## Why not emulate everything?
+## Local by default, live on demand
 
-Full local emulation (Miniflare, LocalStack) replicates cloud APIs
-on your machine. This leads to fidelity gaps and missing features.
+KV, R2, D1, and Queues ship a local provider. In dev they are
+simulators running inside workerd, the same runtime used in
+production, so binding behavior matches what you deploy. A local
+resource's id is `dev:`-prefixed, which doubles as proof that no
+cloud call ran.
 
-Alchemy avoids this. Your R2 Bucket is a real R2 Bucket. Your D1
-Database is a real D1 Database. The only thing running locally is
-your application code.
+The local simulators reach beyond Worker bindings. Node-side
+capability clients follow the same rule: a seed script in an
+[Action](/infrastructure-as-code/action) that writes to a `dev:` KV
+Namespace lands in the same local simulator your Worker reads.
 
-Bindings whose only job is a side effect are the exception: a
+Every other resource runs live in dev automatically, and
+`Alchemy.remote()` (below) runs an emulatable resource against the
+real cloud when local fidelity isn't enough.
+
+Bindings whose only job is a side effect stay stubbed: a
 [`send_email` binding](/cloudflare/email/send-and-receive) defaults
 to a local stub in dev, so `send()` logs the message to the dev
 console instead of delivering mail. Set `dev: { remote: true }` on
@@ -89,8 +102,8 @@ Resources adapt their behavior in dev mode:
   instead of deploying to the edge
 - **Vite dev servers** — integrate with Alchemy's dev server for
   frontend hot reloading alongside your backend
-- **Databases** — connect to real cloud instances, eliminating schema
-  drift between dev and prod
+- **D1 Databases** — emulate locally, with `migrationsDir` and
+  `importFiles` applied to the local database on every reconcile
 
 A resource emulates locally when its provider ships a local
 implementation; everything else is live in dev automatically. See
@@ -120,8 +133,13 @@ yield* Effect.gen(function* () {
 
 The policy is ambient and captured at registration (like `adopt()`), so
 everything inside the scope runs live. Resources with no local emulation
-(an R2 Bucket, a D1 Database) already run live in dev — `remote()` on them
-is a no-op.
+(a Hyperdrive, a Vectorize index) already run live in dev — `remote()` on
+them is a no-op.
+
+Queues support `remote()` in both directions: a local Worker binding a
+live queue produces real messages, and a local `queue()` handler drains
+the live queue through a pull consumer — with the usual local batching,
+retry, and dead-letter semantics.
 
 ### Switching is a replacement
 
@@ -144,14 +162,14 @@ export default Cloudflare.Worker("Worker", {
 
 ## Dev vs Deploy
 
-|                  | `alchemy dev`           | `alchemy deploy`     |
-| ---------------- | ----------------------- | -------------------- |
-| Infrastructure   | Deployed to cloud       | Deployed to cloud    |
-| Application code | Runs locally in workerd | Deployed to cloud    |
-| File watching    | Hot reload on change    | Manual redeploy      |
-| Debugging        | Attach local debugger   | Tail logs            |
-| Speed            | Milliseconds            | Seconds to minutes   |
-| Fidelity         | Real cloud resources    | Real cloud resources |
+|                        | `alchemy dev`                          | `alchemy deploy`   |
+| ---------------------- | -------------------------------------- | ------------------ |
+| KV, R2, D1, Queues     | Local simulators (`remote()` for live) | Deployed to cloud  |
+| Everything else        | Deployed to cloud                      | Deployed to cloud  |
+| Application code       | Runs locally in workerd                | Deployed to cloud  |
+| File watching          | Hot reload on change                   | Manual redeploy    |
+| Debugging              | Attach local debugger                  | Tail logs          |
+| Speed                  | Milliseconds                           | Seconds to minutes |
 
 To automate the deploy side, see the [CI guide](/environments/ci).
 


### PR DESCRIPTION
Release notes for 2.0.0-beta.66.

- Breaking-change callout up top for the `workersDev` + `domain` redesign (#977) with a migration diff (`url`/`subdomain` → `workersDev`, `domain` array → `{ name, aliases, redirects }`, `domains` output → `urls` + `domain`)
- Headline sections: local emulation in `alchemy dev` (#963), Worker versions & gradual deployments (#948/#985), the new Worker URL model (#977), OpenTelemetry export (#860), Prisma provider (#416), Bedrock LanguageModel (#919)
- Long tail in "Also in this release" with external contributors credited (AmanVarshney01, BlankParticle, aryasaatvik, sbekrin, sethcarlton, samnan-kradle, bweis)

Also updates the local-development guide, which still described the pre-#963 behavior ("infrastructure deploys to the cloud, no emulation"). It now documents local-by-default emulation for KV/R2/D1/Queues (`dev:` ids, workerd simulators, D1 local migrations), live-by-default for everything else, `Alchemy.remote()` in both queue directions, and an updated Dev vs Deploy table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
