### PR TITLE
fix(engine): interrupted first deploy no longer bricks later plans with SchemaError

### DIFF
--- a/packages/alchemy/src/Apply.ts
+++ b/packages/alchemy/src/Apply.ts
@@ -1921,6 +1921,25 @@ const collectGarbage = Effect.fn(function* (
                       logicalId,
                       instanceId,
                     ),
+                    // The persisted props of an interrupted create can carry
+                    // holes where unresolved Outputs were stripped at commit
+                    // time (see stripUnresolved) — e.g. a parent reference
+                    // persisted as `{}`. A provider that dereferences one
+                    // crashes deep inside its SDK client (a SchemaError
+                    // defect), which would make the stage impossible to
+                    // destroy. Recovery is best-effort: degrade the defect
+                    // to "nothing recovered", surface a note, and let the
+                    // row be dropped (#995).
+                    Effect.catchDefect((defect) =>
+                      scopedSession
+                        .note(
+                          "Recovery read crashed while looking up this " +
+                            "resource's interrupted create " +
+                            `(${String(defect)}) — if a physical resource ` +
+                            "was created, it must be cleaned up manually.",
+                        )
+                        .pipe(Effect.as(undefined)),
+                    ),
                   );
                 if (recovered !== undefined) {
                   if (Unowned.is(recovered)) {

--- a/packages/alchemy/src/Cloudflare/SecretsStore/Secret.ts
+++ b/packages/alchemy/src/Cloudflare/SecretsStore/Secret.ts
@@ -276,7 +276,12 @@ export const StoreSecretProvider = () =>
             Effect.catchTag("StoreNotFound", () => Effect.succeed(undefined)),
           );
       }
-      if (!olds?.store) return undefined;
+      // An interrupted first deploy can persist `creating` props whose
+      // parent Outputs were stripped to holes (see stripUnresolved), so
+      // `olds.store` can survive as `{}`. Treat an unresolved parent
+      // reference like a missing one — the plan falls through to the
+      // create path instead of handing `undefined` to the API (#995).
+      if (!olds?.store?.storeId || !olds.store.accountId) return undefined;
       const name = resolveName(id, olds.name);
       const match = yield* secretsStore.listStoreSecrets
         .items({

--- a/packages/alchemy/src/Plan.ts
+++ b/packages/alchemy/src/Plan.ts
@@ -952,7 +952,25 @@ export const make = <A>(
                     olds: oldState.props,
                     output: oldState.attr,
                   })
-                  .pipe(providePlanScope(fqn, oldState.instanceId));
+                  .pipe(
+                    providePlanScope(fqn, oldState.instanceId),
+                    // `creating` props pass `isResolved` yet can still carry
+                    // holes where unresolved Outputs were stripped at commit
+                    // time (see stripUnresolved) — e.g. a parent reference
+                    // persisted as `{}`. A provider that dereferences one
+                    // crashes deep inside its SDK client (a SchemaError
+                    // defect), which would brick every subsequent plan on
+                    // the stage. Recovery is best-effort: degrade the defect
+                    // to "nothing recovered" and re-drive the create (#995).
+                    Effect.catchDefect((defect) =>
+                      Effect.logWarning(
+                        `Recovery read for '${fqn}' crashed; treating the ` +
+                          "interrupted create as not recoverable and " +
+                          "re-driving it.",
+                        defect,
+                      ).pipe(Effect.as(undefined)),
+                    ),
+                  );
                 if (attr !== undefined) {
                   // The recovered resource may be foreign: our interrupted
                   // create could have lost a name race, or died before

--- a/packages/alchemy/test/Cloudflare/SecretsStore/Secret.test.ts
+++ b/packages/alchemy/test/Cloudflare/SecretsStore/Secret.test.ts
@@ -44,3 +44,30 @@ test.provider("list enumerates the deployed secret across stores", (stack) =>
     yield* stack.destroy();
   }).pipe(logLevel),
 );
+
+// #995: an interrupted first deploy can persist `creating` props whose parent
+// Outputs were stripped to holes, so `olds.store` survives as `{}`. `read`
+// must treat an unresolved parent reference like a missing one (return
+// `undefined` → plan falls through to the create path) instead of handing
+// `storeId: undefined` to the API and crashing every later plan with a
+// SchemaError defect.
+test.provider(
+  "read treats an unresolved parent store reference as missing",
+  () =>
+    Effect.gen(function* () {
+      const provider = yield* Provider.findProvider(
+        Cloudflare.SecretsStore.Secret,
+      );
+      const attr = yield* provider.read!({
+        id: "OrphanSecret",
+        fqn: "OrphanSecret",
+        instanceId: "orphan-instance",
+        olds: {
+          store: {} as never,
+          value: Redacted.make("sk-orphan"),
+        },
+        output: undefined,
+      });
+      expect(attr).toBeUndefined();
+    }).pipe(logLevel),
+);

--- a/packages/alchemy/test/apply.test.ts
+++ b/packages/alchemy/test/apply.test.ts
@@ -1871,6 +1871,39 @@ describe("from creating state", () => {
   );
 
   test.provider(
+    "destroy survives a recovery read that crashes on degraded creating props",
+    (stack) =>
+      Effect.gen(function* () {
+        // An interrupted create can persist `creating` props whose
+        // unresolved Outputs were stripped to holes; a provider read that
+        // dereferences one crashes with a defect (e.g. a SchemaError deep
+        // in its SDK client, see #995). Destroy must degrade to "nothing
+        // recovered" and drop the row instead of bricking the stage.
+        yield* Effect.gen(function* () {
+          yield* TestResource("A", {
+            string: "test-string",
+          });
+        }).pipe(stack.deploy, hook());
+        expect((yield* getState("A"))?.status).toEqual("creating");
+
+        const deleted: string[] = [];
+        yield* stack.destroy().pipe(
+          hook({
+            read: () =>
+              Effect.die(
+                new Error("SchemaError: Expected string, got undefined"),
+              ),
+            delete: (id) => Effect.sync(() => void deleted.push(id)),
+          }),
+        );
+
+        // Recovery failed — delete is not invoked, state is still dropped.
+        expect(deleted).toEqual([]);
+        expect(yield* getState("A")).toBeUndefined();
+      }),
+  );
+
+  test.provider(
     "destroy drops an attr-less creating row when the provider has no read",
     (stack) =>
       Effect.gen(function* () {

--- a/packages/alchemy/test/plan.test.ts
+++ b/packages/alchemy/test/plan.test.ts
@@ -3700,6 +3700,34 @@ describe("read is never handed unresolved persisted props", () => {
   );
 
   test(
+    "a recovery read that crashes degrades to re-driving the create instead of killing the plan",
+    Effect.gen(function* () {
+      // Stripped-at-commit props: an unresolved Output persisted as a hole
+      // still passes `isResolved`, so the read probe DOES run — and a
+      // provider that dereferences the hole crashes with a defect (e.g. a
+      // SchemaError deep in its SDK client, see #995). The plan must
+      // contain the defect to this resource's probe and fall through to
+      // re-driving the create.
+      yield* seed({
+        Half: {
+          ...creatingWithUnresolvedProps("Half"),
+          props: { string: undefined } as any,
+        },
+      });
+      const layer = Layer.succeed(TestResourceHooks, {
+        read: () =>
+          Effect.die(new Error("SchemaError: Expected string, got undefined")),
+      });
+      const plan = yield* makePlan(
+        Effect.gen(function* () {
+          yield* TestResource("Half", { string: "resolved-now" });
+        }),
+      ).pipe(Effect.provide(layer));
+      expect(plan.resources.Half!.action).toBe("create");
+    }),
+  );
+
+  test(
     "resolved persisted creating props still go through read recovery when re-declared (control)",
     Effect.gen(function* () {
       yield* seed({


### PR DESCRIPTION
Fixes #995.

An interrupted first deploy persists a `creating` row whose unresolved Outputs were stripped to holes at commit time — `stripUnresolved` keeps the parent key, so `store: { storeId: <Output> }` survives as `store: {}`. Those props pass `isResolved`, so the recovery read probes run against them, and a provider that dereferences the hole crashes with a synchronous `SchemaError` defect from the distilled client. That defect aborted every subsequent plan — deploy **and** destroy — locking the stage until `state clear`.

Three layers, matching the issue's two asks plus the concrete provider:

- **Plan** (creating-recovery probe): contain defects from `provider.read` — log a warning and degrade to "nothing recovered", so the plan re-drives the create instead of dying.

```ts
Effect.catchDefect((defect) =>
  Effect.logWarning(`Recovery read for '${fqn}' crashed; ...`, defect)
    .pipe(Effect.as(undefined)),
)
```

- **Apply** (delete-recovery probe for attr-less rows): same containment, surfacing a session note that a physical resource may need manual cleanup, then dropping the row — destroy converges instead of bricking.
- **`Cloudflare.SecretsStore.Secret.read`**: treat an unresolved parent reference like a missing one.

```diff
-if (!olds?.store) return undefined;
+if (!olds?.store?.storeId || !olds.store.accountId) return undefined;
```

Typed errors from `read` still propagate — only defects (crashes the probe could never recover from) are contained, and only at the two best-effort recovery sites; the cold-start adoption probe is untouched.

Tests: plan-level (defective probe → plan still emits `create`), apply-level (defective probe during destroy → row dropped, no delete call), and a live `Secret.read` guard regression — all verified to fail without the fix.
