### PR TITLE
fix(cloudflare): provide runtime for local D1 migrations

### DIFF
--- a/packages/alchemy/src/Cloudflare/D1/Database.ts
+++ b/packages/alchemy/src/Cloudflare/D1/Database.ts
@@ -19,7 +19,10 @@ import type { Providers } from "../Providers.ts";
 import { applyMigrations, applyMigrationsWith } from "./ApplyMigrations.ts";
 import { cloneDatabase } from "./CloneDatabase.ts";
 import { importD1Database } from "./ImportDatabase.ts";
-import { withLocalD1Executor } from "./LocalD1Gateway.ts";
+import {
+  localD1GatewayRuntime,
+  withLocalD1Executor,
+} from "./LocalD1Gateway.ts";
 
 export const isDatabase = (value: unknown): value is Database =>
   isResourceOfType(value, "Cloudflare.D1Database");
@@ -639,7 +642,10 @@ export const ProviderLocal = () =>
                   migrationsTable,
                   migrationsFiles: files,
                 }),
-              ).pipe(Effect.provideContext(runtimeContext));
+              ).pipe(
+                Effect.provide(localD1GatewayRuntime),
+                Effect.provideContext(runtimeContext),
+              );
             }
             for (const file of files) migrationsHashes[file.id] = file.hash;
           } else {
@@ -666,7 +672,10 @@ export const ProviderLocal = () =>
                 Effect.forEach(pending, (file) => executor(file.sql), {
                   discard: true,
                 }),
-              ).pipe(Effect.provideContext(runtimeContext));
+              ).pipe(
+                Effect.provide(localD1GatewayRuntime),
+                Effect.provideContext(runtimeContext),
+              );
               for (const file of pending) {
                 importHashes[file.path] = file.hash;
               }

--- a/packages/alchemy/src/Cloudflare/D1/Database.ts
+++ b/packages/alchemy/src/Cloudflare/D1/Database.ts
@@ -643,8 +643,11 @@ export const ProviderLocal = () =>
                   migrationsFiles: files,
                 }),
               ).pipe(
-                Effect.provide(localD1GatewayRuntime),
-                Effect.provideContext(runtimeContext),
+                Effect.provide(
+                  localD1GatewayRuntime.pipe(
+                    Layer.provideMerge(Layer.succeedContext(runtimeContext)),
+                  ),
+                ),
               );
             }
             for (const file of files) migrationsHashes[file.id] = file.hash;
@@ -673,8 +676,11 @@ export const ProviderLocal = () =>
                   discard: true,
                 }),
               ).pipe(
-                Effect.provide(localD1GatewayRuntime),
-                Effect.provideContext(runtimeContext),
+                Effect.provide(
+                  localD1GatewayRuntime.pipe(
+                    Layer.provideMerge(Layer.succeedContext(runtimeContext)),
+                  ),
+                ),
               );
               for (const file of pending) {
                 importHashes[file.path] = file.hash;

--- a/packages/alchemy/test/Cloudflare/D1/Database.local.test.ts
+++ b/packages/alchemy/test/Cloudflare/D1/Database.local.test.ts
@@ -1,12 +1,15 @@
 import { Action } from "@/Action";
 import * as Cloudflare from "@/Cloudflare/index.ts";
 import * as Alchemy from "@/index.ts";
+import * as RpcProviderProxy from "@/Local/RpcProviderProxy";
+import * as RpcSpawner from "@/Local/RpcSpawner";
 import * as Test from "@/Test/Alchemy";
 import * as d1 from "@distilled.cloud/cloudflare/d1";
 import { expect } from "alchemy-test";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
@@ -14,7 +17,7 @@ import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as pathe from "pathe";
 import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment.ts";
 
-const { test } = Test.make({
+const { test, deploy, destroy } = Test.make({
   providers: Cloudflare.providers(),
   dev: true,
 });
@@ -22,6 +25,39 @@ const { test } = Test.make({
 const logLevel = Effect.provideService(
   MinimumLogLevel,
   process.env.DEBUG ? "Debug" : "Info",
+);
+
+/**
+ * Run local providers with the RPC proxy used by the real `alchemy dev`
+ * command. In-process provider tests do not install this proxy, so
+ * `RpcProvider.providerServicesEffect` keeps `localRuntimeServices()` in the
+ * caller and masks missing lifecycle dependencies.
+ */
+const Sidecar = Layer.unwrap(
+  Effect.map(RpcSpawner.RpcSpawner, (spawner) =>
+    RpcProviderProxy.layer(spawner.url),
+  ),
+).pipe(
+  Layer.provideMerge(
+    RpcSpawner.layerServer({
+      profile: process.env.ALCHEMY_PROFILE,
+      envFile: undefined,
+    }),
+  ),
+);
+
+const RpcMigrationStack = Alchemy.Stack(
+  "D1RpcMigrationStack",
+  {
+    providers: Cloudflare.providers(),
+    state: Alchemy.localState(),
+  },
+  Cloudflare.D1.Database("RpcMigratedDB", {
+    migrationsDir: pathe.resolve(
+      import.meta.dirname,
+      "fixtures/rpc-migrations",
+    ),
+  }),
 );
 
 class WorkerNotReady extends Data.TaggedError("WorkerNotReady")<{
@@ -52,6 +88,28 @@ const getJsonReady = (url: string) =>
     );
     return yield* res.json;
   }).pipe(Effect.orDie);
+
+/**
+ * Regression test for #1007. Under the RPC proxy used by `alchemy dev`,
+ * `localRuntimeServices()` is intentionally omitted from the caller because
+ * RPC providers consume it in the sidecar. D1's local provider is not an RPC
+ * provider, so its migration lifecycle must provide the standalone gateway
+ * runtime explicitly.
+ */
+test(
+  "D1 migrations apply with the alchemy dev RPC proxy",
+  Effect.gen(function* () {
+    yield* destroy(RpcMigrationStack);
+
+    const database = yield* deploy(RpcMigrationStack);
+
+    expect(database.databaseId).toMatch(/^dev:/);
+    expect(Object.keys(database.migrationsHashes)).toEqual(["0001_notes.sql"]);
+
+    yield* destroy(RpcMigrationStack);
+  }).pipe(Effect.provide(Sidecar), logLevel),
+  { timeout: 120_000 },
+);
 
 /**
  * Under `alchemy dev` the D1 Database resource is emulated by the local

--- a/packages/alchemy/test/Cloudflare/D1/fixtures/rpc-migrations/0001_notes.sql
+++ b/packages/alchemy/test/Cloudflare/D1/fixtures/rpc-migrations/0001_notes.sql
@@ -1,0 +1,4 @@
+CREATE TABLE notes (
+  id INTEGER PRIMARY KEY,
+  body TEXT NOT NULL
+);


### PR DESCRIPTION
## Summary

- provide the standalone local D1 gateway runtime while local migrations and imports run
- add a regression test using the same RPC sidecar topology as `alchemy dev`

## Root cause

When `alchemy dev` installs `RpcProviderProxy`, `RpcProvider.providerServicesEffect` leaves `localRuntimeServices()` out of the caller because RPC-backed providers consume those services in the sidecar.

D1's local provider is not RPC-backed, though: its migration and import lifecycle still executes in the main process. `withLocalD1Executor` therefore reached `LocalD1Gateway` without `cloudflare-runtime/Runtime`.

Providing `localD1GatewayRuntime` directly at those two lifecycle call sites makes their standalone dependency explicit while preserving the existing in-process and RPC provider behavior.

## Validation

- confirmed the new RPC-sidecar test fails without the fix with `Service not found: cloudflare-runtime/Runtime`
- relevant local D1 tests: 3 passed
- `bunx bun@1.3.13 tsc -b`
- `oxfmt --check`

Closes #1007
