### PR TITLE
fix(prisma): align provider with management api

### DIFF
--- a/packages/alchemy/src/Cli/commands/_shared.ts
+++ b/packages/alchemy/src/Cli/commands/_shared.ts
@@ -29,6 +29,7 @@ import { CloudflareAuth } from "../../Cloudflare/Auth/AuthProvider.ts";
 import { GitHubAuth } from "../../GitHub/AuthProvider.ts";
 import { NeonAuth } from "../../Neon/AuthProvider.ts";
 import { PlanetscaleAuth } from "../../Planetscale/AuthProvider.ts";
+import { PrismaAuth } from "../../Prisma/AuthProvider.ts";
 import * as Stack from "../../Stack.ts";
 import { Stage } from "../../Stage.ts";
 import { recordCli } from "../../Telemetry/Metrics.ts";
@@ -460,6 +461,7 @@ export const builtinAuth = Layer.mergeAll(
   GitHubAuth,
   NeonAuth,
   PlanetscaleAuth,
+  PrismaAuth,
 );
 
 /**

--- a/packages/alchemy/src/Prisma/Compute.ts
+++ b/packages/alchemy/src/Prisma/Compute.ts
@@ -620,6 +620,8 @@ const isEffectNativeCompute = (props: ComputeProps) =>
  *   },
  *   port: 8080,
  *   env: {
+ *     // Use this for a standalone Connection. A project's default database
+ *     // is injected by Prisma without an explicit DATABASE_URL entry.
  *     DATABASE_URL: connection.databaseUrl,
  *   },
  *   destroyOldDeployment: true,

--- a/packages/alchemy/src/Prisma/EnvironmentVariable.ts
+++ b/packages/alchemy/src/Prisma/EnvironmentVariable.ts
@@ -104,12 +104,12 @@ export interface EnvironmentVariable extends Resource<
  * @section Creating a Variable
  * @example Project-level production variable
  * ```typescript
- * yield* Prisma.EnvironmentVariable("database-url", {
+ * yield* Prisma.EnvironmentVariable("api-url", {
  *   project: project.projectId,
  *   // No branchId: this is a project-level template.
  *   class: "production",
- *   key: "DATABASE_URL",
- *   value: Redacted.make("postgres://..."),
+ *   key: "API_URL",
+ *   value: Redacted.make("https://api.example.com"),
  * });
  * ```
  *

--- a/packages/alchemy/src/Prisma/Providers.ts
+++ b/packages/alchemy/src/Prisma/Providers.ts
@@ -1,3 +1,4 @@
+import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import type * as Path from "effect/Path";
@@ -7,18 +8,24 @@ import type { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSp
 import { AlchemyContext } from "../AlchemyContext.ts";
 import { AuthProviders } from "../Auth/AuthProvider.ts";
 import { CredentialsStoreLive } from "../Auth/Credentials.ts";
-import { ProfileLive } from "../Auth/Profile.ts";
+import { AlchemyProfile, ProfileLive } from "../Auth/Profile.ts";
 import * as Provider from "../Provider.ts";
 import type { ResourceClass, ResourceLike } from "../Resource.ts";
 import { PlatformServices } from "../Util/PlatformServices.ts";
+import { proxyChain } from "../Util/proxy-chain.ts";
 import { PrismaAuth } from "./AuthProvider.ts";
 import { App, AppProvider } from "./App.ts";
 import { Branch, BranchProvider } from "./Branch.ts";
-import { Compute, ComputeDevProvider, ComputeProvider } from "./Compute.ts";
-import { Deployment, DeploymentProvider } from "./Deployment.ts";
+import {
+  PrismaClient,
+  PrismaClientLive,
+  type PrismaManagementClient,
+} from "./Client.ts";
 import { Connection, ConnectionProvider } from "./Connection.ts";
+import { Compute, ComputeDevProvider, ComputeProvider } from "./Compute.ts";
 import { CustomDomain, CustomDomainProvider } from "./CustomDomain.ts";
 import { Database, DatabaseProvider } from "./Database.ts";
+import { Deployment, DeploymentProvider } from "./Deployment.ts";
 import {
   EnvironmentVariable,
   EnvironmentVariableProvider,
@@ -28,7 +35,6 @@ import {
   closePrismaDevDatabase,
   ensurePrismaDevDatabase,
 } from "./PrismaDevDatabase.ts";
-import { PrismaClientLive } from "./Client.ts";
 import {
   PrismaHttpClientLive,
   PrismaUploadClientLive,
@@ -48,7 +54,12 @@ export class Providers extends Provider.ProviderCollection<Providers>()(
 
 export type ProviderRequirements = Layer.Services<ReturnType<typeof providers>>;
 
-const managementApiLayer = () =>
+/**
+ * Standalone operation helpers own a private auth registry because they run
+ * outside a Stack. Credential resolution stays eager here so constructing
+ * `managementApi()` preserves its existing fail-fast behavior.
+ */
+const standaloneManagementApiLayer = () =>
   PrismaClientLive.pipe(
     Layer.provideMerge(fromProfile()),
     Layer.provideMerge(PrismaAuth),
@@ -72,6 +83,54 @@ const managementApiLayer = () =>
   );
 
 /**
+ * Stack provider discovery must register auth without requiring credentials.
+ * The management client is resolved on its first API operation, after
+ * `alchemy login` has had a chance to configure the registered Prisma auth
+ * provider. The nested client layer shares the provider layer's lifetime.
+ */
+const stackManagementApiLayer = () =>
+  Layer.effect(
+    PrismaClient,
+    Effect.gen(function* () {
+      const scope = yield* Effect.scope;
+      const authProviders = yield* AuthProviders;
+      const profile = yield* AlchemyProfile;
+      const client = Layer.buildWithScope(
+        PrismaClientLive.pipe(
+          Layer.provideMerge(
+            fromProfile().pipe(
+              Layer.provide(
+                Layer.mergeAll(
+                  Layer.succeed(AuthProviders, authProviders),
+                  Layer.succeed(AlchemyProfile, profile),
+                ),
+              ),
+            ),
+          ),
+          Layer.provide(PrismaHttpClientLive),
+        ),
+        scope,
+      ).pipe(
+        Effect.map((context) => Context.get(context, PrismaClient)),
+        Effect.orDie,
+      );
+      const cached = yield* Effect.cached(client);
+      return proxyChain(cached) as PrismaManagementClient;
+    }),
+  ).pipe(
+    Layer.provideMerge(PrismaAuth),
+    Layer.provideMerge(
+      Layer.mergeAll(
+        // The Prisma-scoped upload client (node transport) rides the
+        // providers' output so artifact uploads can reach it at op time.
+        PrismaUploadClientLive,
+        Layer.provide(ProfileLive, PlatformServices),
+        Layer.provide(CredentialsStoreLive, PlatformServices),
+      ),
+    ),
+  );
+
+/**
  * Build a layer for Prisma Management API operation helpers.
  *
  * Use this when calling helpers like `Prisma.listProjects()` outside an
@@ -88,7 +147,8 @@ const managementApiLayer = () =>
  * );
  * ```
  */
-export const managementApi = () => managementApiLayer().pipe(Layer.orDie);
+export const managementApi = () =>
+  standaloneManagementApiLayer().pipe(Layer.orDie);
 
 /**
  * Build a layer that registers all Prisma Management API resource providers,
@@ -408,4 +468,4 @@ const liveProviderLayer = () =>
     CustomDomainProvider(),
     EnvironmentVariableProvider(),
     SourceRepositoryProvider(),
-  ).pipe(Layer.provideMerge(managementApiLayer()), Layer.orDie);
+  ).pipe(Layer.provideMerge(stackManagementApiLayer()), Layer.orDie);

--- a/packages/alchemy/test/Prisma/ManagementCoverage.test.ts
+++ b/packages/alchemy/test/Prisma/ManagementCoverage.test.ts
@@ -172,7 +172,7 @@ describe("Prisma Management API coverage", () => {
   it("accounts for every route in the pinned Management API contract", () => {
     expect(managementApiContract.repository).toBe("prisma/pdp-control-plane");
     expect(managementApiContract.commit).toMatch(/^[0-9a-f]{40}$/);
-    expect(managementApiContract.routes).toHaveLength(102);
+    expect(managementApiContract.routes).toHaveLength(78);
     expect(managementApiContract.deferredRoutes).toHaveLength(7);
     expect(
       managementApiContract.deferredRoutes.every((route) =>
@@ -183,12 +183,6 @@ describe("Prisma Management API coverage", () => {
     expect(expectedManagementApiRoutes).toEqual(
       [...productionManagementApiRoutes].sort(),
     );
-    const expectedRouteSet = new Set<string>(expectedManagementApiRoutes);
-    expect(
-      managementApiContract.deprecatedRoutes.some((route) =>
-        expectedRouteSet.has(route),
-      ),
-    ).toBe(false);
     expect(
       expectedManagementApiRoutes.some((route) => route.includes("/__admin")),
     ).toBe(false);

--- a/packages/alchemy/test/Prisma/Providers.test.ts
+++ b/packages/alchemy/test/Prisma/Providers.test.ts
@@ -1,4 +1,5 @@
 import { AlchemyContext } from "@/AlchemyContext";
+import { AuthProviders } from "@/Auth/AuthProvider";
 import * as Provider from "@/Provider";
 import * as Prisma from "@/Prisma";
 import { describe, expect, it } from "alchemy-test";
@@ -31,6 +32,39 @@ const reconcileInput = (id: string, news: unknown, output?: unknown) =>
   }) as never;
 
 describe("Prisma providers", () => {
+  it.effect(
+    "registers Prisma auth without resolving credentials",
+    () =>
+      Effect.gen(function* () {
+        const authProviders: AuthProviders["Service"] = {};
+
+        yield* Layer.build(
+          Prisma.providers().pipe(
+            Layer.provideMerge(Layer.succeed(AuthProviders, authProviders)),
+          ),
+        );
+
+        expect(authProviders.Prisma?.name).toBe("Prisma");
+      }).pipe(
+        Effect.provide(
+          ConfigProvider.layer(
+            ConfigProvider.fromUnknown({
+              CI: true,
+            }),
+          ),
+        ),
+        Effect.provide(
+          Layer.succeed(AlchemyContext, {
+            dotAlchemy: ".alchemy-test",
+            dev: false,
+            adopt: false,
+          }),
+        ),
+        Effect.scoped,
+      ),
+    { timeout: 30_000 },
+  );
+
   it.effect("registers every Prisma resource provider", () =>
     Effect.gen(function* () {
       const resourceTypes = [

--- a/packages/alchemy/test/Prisma/fixtures/ManagementApiContract.ts
+++ b/packages/alchemy/test/Prisma/fixtures/ManagementApiContract.ts
@@ -5,14 +5,12 @@
  */
 export const managementApiContract = {
   repository: "prisma/pdp-control-plane",
-  commit: "77354f04b2dcd573682a87d0be6fb66a05d27a86",
+  commit: "4a71a1f3500c02c6d6914f86435c251f95fda536",
   routes: [
     "DELETE /v1/apps/{appId}",
     "DELETE /v1/branches/{branchId}",
     "DELETE /v1/buckets/{bucketId}",
     "DELETE /v1/buckets/{bucketId}/keys/{keyId}",
-    "DELETE /v1/compute-services/versions/{versionId}",
-    "DELETE /v1/compute-services/{computeServiceId}",
     "DELETE /v1/connections/{id}",
     "DELETE /v1/databases/{databaseId}",
     "DELETE /v1/deployments/{deploymentId}",
@@ -21,7 +19,6 @@ export const managementApiContract = {
     "DELETE /v1/integrations/{id}",
     "DELETE /v1/projects/{id}",
     "DELETE /v1/source-repositories/{id}",
-    "DELETE /v1/versions/{versionId}",
     "DELETE /v1/workspaces/{workspaceId}/integrations/{clientId}",
     "GET /v1/apps",
     "GET /v1/apps/{appId}",
@@ -32,12 +29,6 @@ export const managementApiContract = {
     "GET /v1/buckets",
     "GET /v1/buckets/{bucketId}",
     "GET /v1/buckets/{bucketId}/keys",
-    "GET /v1/compute-services",
-    "GET /v1/compute-services/versions/{versionId}",
-    "GET /v1/compute-services/versions/{versionId}/logs",
-    "GET /v1/compute-services/{computeServiceId}",
-    "GET /v1/compute-services/{computeServiceId}/domains",
-    "GET /v1/compute-services/{computeServiceId}/versions",
     "GET /v1/connections",
     "GET /v1/connections/{id}",
     "GET /v1/databases",
@@ -56,7 +47,6 @@ export const managementApiContract = {
     "GET /v1/projects",
     "GET /v1/projects/{id}",
     "GET /v1/projects/{projectId}/branches",
-    "GET /v1/projects/{projectId}/compute-services",
     "GET /v1/projects/{projectId}/databases",
     "GET /v1/regions",
     "GET /v1/regions/accelerate",
@@ -65,14 +55,11 @@ export const managementApiContract = {
     "GET /v1/scm-installations/{installationId}/repositories",
     "GET /v1/source-repositories",
     "GET /v1/source-repositories/{id}",
-    "GET /v1/versions",
-    "GET /v1/versions/{versionId}",
     "GET /v1/workspaces",
     "GET /v1/workspaces/{id}",
     "GET /v1/workspaces/{workspaceId}/integrations",
     "PATCH /v1/apps/{appId}",
     "PATCH /v1/branches/{branchId}",
-    "PATCH /v1/compute-services/{computeServiceId}",
     "PATCH /v1/databases/{databaseId}",
     "PATCH /v1/environment-variables/{envVarId}",
     "PATCH /v1/projects/{id}",
@@ -83,13 +70,6 @@ export const managementApiContract = {
     "POST /v1/apps/{appId}/rollback",
     "POST /v1/buckets",
     "POST /v1/buckets/{bucketId}/keys",
-    "POST /v1/compute-services",
-    "POST /v1/compute-services/versions/{versionId}/start",
-    "POST /v1/compute-services/versions/{versionId}/stop",
-    "POST /v1/compute-services/{computeServiceId}/domains",
-    "POST /v1/compute-services/{computeServiceId}/promote",
-    "POST /v1/compute-services/{computeServiceId}/rollback",
-    "POST /v1/compute-services/{computeServiceId}/versions",
     "POST /v1/connections",
     "POST /v1/connections/{id}/rotate",
     "POST /v1/databases",
@@ -102,44 +82,9 @@ export const managementApiContract = {
     "POST /v1/projects",
     "POST /v1/projects/{id}/transfer",
     "POST /v1/projects/{projectId}/branches",
-    "POST /v1/projects/{projectId}/compute-services",
     "POST /v1/projects/{projectId}/databases",
     "POST /v1/scm-installations/install-intents",
     "POST /v1/source-repositories",
-    "POST /v1/versions",
-    "POST /v1/versions/{versionId}/start",
-    "POST /v1/versions/{versionId}/stop",
-  ],
-  /**
-   * Compatibility aliases still mounted by the server but marked deprecated
-   * (plus the project-scoped compute-service aliases that share that legacy
-   * model). Alchemy intentionally exposes only Apps and Deployments.
-   */
-  deprecatedRoutes: [
-    "DELETE /v1/compute-services/versions/{versionId}",
-    "DELETE /v1/compute-services/{computeServiceId}",
-    "DELETE /v1/versions/{versionId}",
-    "GET /v1/compute-services",
-    "GET /v1/compute-services/versions/{versionId}",
-    "GET /v1/compute-services/versions/{versionId}/logs",
-    "GET /v1/compute-services/{computeServiceId}",
-    "GET /v1/compute-services/{computeServiceId}/domains",
-    "GET /v1/compute-services/{computeServiceId}/versions",
-    "GET /v1/projects/{projectId}/compute-services",
-    "GET /v1/versions",
-    "GET /v1/versions/{versionId}",
-    "PATCH /v1/compute-services/{computeServiceId}",
-    "POST /v1/compute-services",
-    "POST /v1/compute-services/versions/{versionId}/start",
-    "POST /v1/compute-services/versions/{versionId}/stop",
-    "POST /v1/compute-services/{computeServiceId}/domains",
-    "POST /v1/compute-services/{computeServiceId}/promote",
-    "POST /v1/compute-services/{computeServiceId}/rollback",
-    "POST /v1/compute-services/{computeServiceId}/versions",
-    "POST /v1/projects/{projectId}/compute-services",
-    "POST /v1/versions",
-    "POST /v1/versions/{versionId}/start",
-    "POST /v1/versions/{versionId}/stop",
   ],
   /**
    * Prisma Object Storage is a new product surface and is intentionally
@@ -157,13 +102,8 @@ export const managementApiContract = {
   ],
 } as const;
 
-const deprecatedRouteSet = new Set<string>(
-  managementApiContract.deprecatedRoutes,
-);
 const deferredRouteSet = new Set<string>(managementApiContract.deferredRoutes);
 
 /** Canonical production routes that Alchemy must map. */
 export const productionManagementApiRoutes =
-  managementApiContract.routes.filter(
-    (route) => !deprecatedRouteSet.has(route) && !deferredRouteSet.has(route),
-  );
+  managementApiContract.routes.filter((route) => !deferredRouteSet.has(route));

--- a/website/src/content/docs/prisma/compute/apps.mdx
+++ b/website/src/content/docs/prisma/compute/apps.mdx
@@ -10,37 +10,30 @@ upload, deployment, health check, and promotion — see
 
 ## Framework apps
 
-Point `path` at the app and describe its build. The command runs
-locally, the output directory is archived and uploaded, and the
-entrypoint starts the server:
+Point `path` at the app. With `build: "auto"`, alchemy detects the
+framework, builds it, archives the output, and deploys the correct
+server entrypoint:
 
 ```typescript
-import * as Prisma from "alchemy/Prisma";
-import * as SQL from "alchemy/SQL/Postgres";
-import * as Effect from "effect/Effect";
-import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
-
 const app = yield* Prisma.Compute("api", {
   project,
   path: "./app",
-  build: {
-    command: "bun run build",
-    outdir: ".output",
-    entrypoint: "server/index.mjs",
-  },
-  port: 3000,
+  build: "auto",
   healthCheck: { path: "/api/health" },
-  env: {
-    DATABASE_URL: connection.databaseUrl,
-  },
   destroyOldDeployment: true,
 });
 ```
 
-The server must listen on `PORT` (injected at runtime). With
-`build: "auto"` — the default when `path` points at a recognizable
-app — alchemy detects the framework (Bun, Next.js, Nuxt, Astro,
-TanStack Start, NestJS) and derives the build for you.
+The server must listen on `PORT` (injected at runtime). Auto-build
+supports Bun, Next.js, Nuxt, Astro, TanStack Start, and NestJS. Use an
+explicit build object when an app needs a custom command, output
+directory, or entrypoint.
+
+When `Prisma.Project` creates its default database, Prisma injects
+system-managed `DATABASE_URL` and `DATABASE_URL_POOLED` values into
+Compute deployments. Leave those keys out of `env`. For a standalone
+`Prisma.Postgres` database, create a `Prisma.Connection` and pass its
+outputs explicitly as shown in [Connections](/prisma/data/connections).
 
 `app.url` is the deployed endpoint.
 

--- a/website/src/content/docs/prisma/data/connections.mdx
+++ b/website/src/content/docs/prisma/data/connections.mdx
@@ -30,8 +30,9 @@ connection.pooledOrigin; //               parsed pooled connection components
 
 `databaseUrl` is the serverless-safe default for application
 traffic: it prefers the pooled endpoint, then direct, then
-Accelerate. Pass it (and the direct URL for migration tooling)
-straight into an app's env:
+Accelerate. For a standalone database under a project created with
+`createDatabase: false`, pass it (and the direct URL for migration
+tooling) straight into an app's env:
 
 ```typescript
 const app = yield* Prisma.Compute("api", {
@@ -43,6 +44,10 @@ const app = yield* Prisma.Compute("api", {
   },
 });
 ```
+
+If `Prisma.Project` created the project's default database, omit
+these env entries. Prisma injects system-managed `DATABASE_URL` and
+`DATABASE_URL_POOLED` values into Compute deployments automatically.
 
 ## The origin shape
 

--- a/website/src/content/docs/prisma/data/postgres.mdx
+++ b/website/src/content/docs/prisma/data/postgres.mdx
@@ -19,10 +19,11 @@ const project = yield* Prisma.Project("app", {
 ```
 
 By default, creating a project also provisions a default Prisma
-Postgres database in the chosen region. Pass
+Postgres database in the chosen region. Prisma Compute deployments
+under that project receive system-managed `DATABASE_URL` and
+`DATABASE_URL_POOLED` variables automatically. Pass
 `createDatabase: false` (as above) when you'd rather declare
-databases explicitly — the recommended shape, since standalone
-databases have their own lifecycle and outputs.
+databases explicitly with their own lifecycle and connection outputs.
 
 :::caution[Projects own their data]
 Destroying a `Prisma.Project` deletes the project and its contained

--- a/website/src/content/docs/prisma/index.mdx
+++ b/website/src/content/docs/prisma/index.mdx
@@ -14,14 +14,24 @@ New here? [Set up credentials](/prisma/setup) first.
 
 ## Resources
 
-A `Prisma.Project` is the top-level container. A `Prisma.Postgres`
-database lives inside it, and a `Prisma.Connection` materializes the
-credentials an application uses to reach that database:
+A `Prisma.Project` is the top-level container. By default it creates
+a Prisma Postgres database in `us-east-1`:
 
 ```typescript
 const project = yield* Prisma.Project("app", {
-  createDatabase: false,
+  region: "us-east-1",
 });
+```
+
+Prisma injects that database's system-managed `DATABASE_URL` and
+`DATABASE_URL_POOLED` variables into Compute deployments
+automatically.
+
+When you need a database with an independent lifecycle and explicit
+connection outputs, declare it separately:
+
+```typescript
+const project = yield* Prisma.Project("app", { createDatabase: false });
 
 const postgres = yield* Prisma.Postgres("db", {
   project,
@@ -54,18 +64,13 @@ an Effect-native app defined inline:
 const app = yield* Prisma.Compute("api", {
   project,
   path: "./app",
-  build: {
-    command: "bun run build",
-    outdir: ".output",
-    entrypoint: "server/index.mjs",
-  },
-  port: 3000,
+  build: "auto",
   healthCheck: { path: "/api/health" },
-  env: {
-    DATABASE_URL: connection.databaseUrl,
-  },
 });
 ```
+
+For a standalone database, pass `connection.databaseUrl` explicitly
+as shown in [Connections](/prisma/data/connections).
 
 The candidate health check gates promotion. If the stable endpoint
 fails after promotion, alchemy attempts to restore the previous


### PR DESCRIPTION
This PR fixes three issues in the existing Prisma provider:

- Registers Prisma with the built-in auth flow and creates the Management API client lazily, so `alchemy login` works before credentials are configured. Standalone `Prisma.managementApi()` calls remain fail-fast.
- Refreshes the pinned contract from the latest `prisma/pdp-control-plane` main, removing 24 retired Compute Service and Version routes while keeping all 71 canonical routes mapped.
- Corrects the docs for database environment variables and framework builds. Default project databases inject `DATABASE_URL` automatically; standalone databases use an explicit `Prisma.Connection`.

> **Note:** The automatic default database behavior was designed before Prisma Compute existed. I’ll discuss removing that implicit behavior with the team so databases are declared explicitly.

```ts
const project = yield* Prisma.Project("project", {
  createDatabase: false,
});

const postgres = yield* Prisma.Postgres("database", {
  project,
  region: "us-east-1",
});

const connection = yield* Prisma.Connection("app-connection", {
  database: postgres,
});

const app = yield* Prisma.Compute("app", {
  project,
  build: "auto",
  env: {
    DATABASE_URL: connection.databaseUrl,
  },
});
```
