### PR TITLE
docs(prisma): clarify database environment wiring

### DIFF
--- a/packages/alchemy/src/Prisma/Compute.ts
+++ b/packages/alchemy/src/Prisma/Compute.ts
@@ -620,6 +620,8 @@ const isEffectNativeCompute = (props: ComputeProps) =>
  *   },
  *   port: 8080,
  *   env: {
+ *     // Use this for a standalone Connection. A project's default database
+ *     // is injected by Prisma without an explicit DATABASE_URL entry.
  *     DATABASE_URL: connection.databaseUrl,
  *   },
  *   destroyOldDeployment: true,

--- a/packages/alchemy/src/Prisma/EnvironmentVariable.ts
+++ b/packages/alchemy/src/Prisma/EnvironmentVariable.ts
@@ -104,12 +104,12 @@ export interface EnvironmentVariable extends Resource<
  * @section Creating a Variable
  * @example Project-level production variable
  * ```typescript
- * yield* Prisma.EnvironmentVariable("database-url", {
+ * yield* Prisma.EnvironmentVariable("api-url", {
  *   project: project.projectId,
  *   // No branchId: this is a project-level template.
  *   class: "production",
- *   key: "DATABASE_URL",
- *   value: Redacted.make("postgres://..."),
+ *   key: "API_URL",
+ *   value: Redacted.make("https://api.example.com"),
  * });
  * ```
  *

--- a/website/src/content/docs/prisma/compute/apps.mdx
+++ b/website/src/content/docs/prisma/compute/apps.mdx
@@ -10,37 +10,30 @@ upload, deployment, health check, and promotion — see
 
 ## Framework apps
 
-Point `path` at the app and describe its build. The command runs
-locally, the output directory is archived and uploaded, and the
-entrypoint starts the server:
+Point `path` at the app. With `build: "auto"`, alchemy detects the
+framework, builds it, archives the output, and deploys the correct
+server entrypoint:
 
 ```typescript
-import * as Prisma from "alchemy/Prisma";
-import * as SQL from "alchemy/SQL/Postgres";
-import * as Effect from "effect/Effect";
-import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
-
 const app = yield* Prisma.Compute("api", {
   project,
   path: "./app",
-  build: {
-    command: "bun run build",
-    outdir: ".output",
-    entrypoint: "server/index.mjs",
-  },
-  port: 3000,
+  build: "auto",
   healthCheck: { path: "/api/health" },
-  env: {
-    DATABASE_URL: connection.databaseUrl,
-  },
   destroyOldDeployment: true,
 });
 ```
 
-The server must listen on `PORT` (injected at runtime). With
-`build: "auto"` — the default when `path` points at a recognizable
-app — alchemy detects the framework (Bun, Next.js, Nuxt, Astro,
-TanStack Start, NestJS) and derives the build for you.
+The server must listen on `PORT` (injected at runtime). Auto-build
+supports Bun, Next.js, Nuxt, Astro, TanStack Start, and NestJS. Use an
+explicit build object when an app needs a custom command, output
+directory, or entrypoint.
+
+When `Prisma.Project` creates its default database, Prisma injects
+system-managed `DATABASE_URL` and `DATABASE_URL_POOLED` values into
+Compute deployments. Leave those keys out of `env`. For a standalone
+`Prisma.Postgres` database, create a `Prisma.Connection` and pass its
+outputs explicitly as shown in [Connections](/prisma/data/connections).
 
 `app.url` is the deployed endpoint.
 

--- a/website/src/content/docs/prisma/data/connections.mdx
+++ b/website/src/content/docs/prisma/data/connections.mdx
@@ -30,8 +30,9 @@ connection.pooledOrigin; //               parsed pooled connection components
 
 `databaseUrl` is the serverless-safe default for application
 traffic: it prefers the pooled endpoint, then direct, then
-Accelerate. Pass it (and the direct URL for migration tooling)
-straight into an app's env:
+Accelerate. For a standalone database under a project created with
+`createDatabase: false`, pass it (and the direct URL for migration
+tooling) straight into an app's env:
 
 ```typescript
 const app = yield* Prisma.Compute("api", {
@@ -43,6 +44,10 @@ const app = yield* Prisma.Compute("api", {
   },
 });
 ```
+
+If `Prisma.Project` created the project's default database, omit
+these env entries. Prisma injects system-managed `DATABASE_URL` and
+`DATABASE_URL_POOLED` values into Compute deployments automatically.
 
 ## The origin shape
 

--- a/website/src/content/docs/prisma/data/postgres.mdx
+++ b/website/src/content/docs/prisma/data/postgres.mdx
@@ -19,10 +19,11 @@ const project = yield* Prisma.Project("app", {
 ```
 
 By default, creating a project also provisions a default Prisma
-Postgres database in the chosen region. Pass
+Postgres database in the chosen region. Prisma Compute deployments
+under that project receive system-managed `DATABASE_URL` and
+`DATABASE_URL_POOLED` variables automatically. Pass
 `createDatabase: false` (as above) when you'd rather declare
-databases explicitly — the recommended shape, since standalone
-databases have their own lifecycle and outputs.
+databases explicitly with their own lifecycle and connection outputs.
 
 :::caution[Projects own their data]
 Destroying a `Prisma.Project` deletes the project and its contained

--- a/website/src/content/docs/prisma/index.mdx
+++ b/website/src/content/docs/prisma/index.mdx
@@ -14,14 +14,24 @@ New here? [Set up credentials](/prisma/setup) first.
 
 ## Resources
 
-A `Prisma.Project` is the top-level container. A `Prisma.Postgres`
-database lives inside it, and a `Prisma.Connection` materializes the
-credentials an application uses to reach that database:
+A `Prisma.Project` is the top-level container. By default it creates
+a Prisma Postgres database in `us-east-1`:
 
 ```typescript
 const project = yield* Prisma.Project("app", {
-  createDatabase: false,
+  region: "us-east-1",
 });
+```
+
+Prisma injects that database's system-managed `DATABASE_URL` and
+`DATABASE_URL_POOLED` variables into Compute deployments
+automatically.
+
+When you need a database with an independent lifecycle and explicit
+connection outputs, declare it separately:
+
+```typescript
+const project = yield* Prisma.Project("app", { createDatabase: false });
 
 const postgres = yield* Prisma.Postgres("db", {
   project,
@@ -54,18 +64,13 @@ an Effect-native app defined inline:
 const app = yield* Prisma.Compute("api", {
   project,
   path: "./app",
-  build: {
-    command: "bun run build",
-    outdir: ".output",
-    entrypoint: "server/index.mjs",
-  },
-  port: 3000,
+  build: "auto",
   healthCheck: { path: "/api/health" },
-  env: {
-    DATABASE_URL: connection.databaseUrl,
-  },
 });
 ```
+
+For a standalone database, pass `connection.databaseUrl` explicitly
+as shown in [Connections](/prisma/data/connections).
 
 The candidate health check gates promotion. If the stable endpoint
 fails after promotion, alchemy attempts to restore the previous


### PR DESCRIPTION
Clarifies the two supported database wiring paths:

- A default Project database gets system-managed DATABASE_URL and DATABASE_URL_POOLED values automatically.
- A standalone Postgres resource uses explicit Connection outputs.

The overview now starts with the minimal Project plus auto-built Compute flow, and the environment-variable example uses a user-managed API_URL key.