### PR TITLE
fix(cloudflare): match existing DNS record with relative records too

### DIFF
--- a/packages/alchemy/src/Cloudflare/DNS/Record.ts
+++ b/packages/alchemy/src/Cloudflare/DNS/Record.ts
@@ -1,4 +1,5 @@
 import * as dns from "@distilled.cloud/cloudflare/dns";
+import * as zones from "@distilled.cloud/cloudflare/zones";
 import * as Effect from "effect/Effect";
 import * as Stream from "effect/Stream";
 
@@ -46,7 +47,9 @@ export interface RecordProps {
    */
   zoneId: string;
   /**
-   * Fully-qualified record name (e.g. `cluster-admin.microtrack.ai`).
+   * Fully-qualified or zone-relative record name (e.g.
+   * `cluster-admin.microtrack.ai`, `_dmarc`, or `@` for the zone apex).
+   * Cloudflare normalizes relative names to their fully-qualified form.
    *
    * Stable — Cloudflare treats `(name, type)` as the record's identity,
    * so a rename is a delete + create. Declared as plain `string` (not
@@ -404,10 +407,27 @@ const observeById = (zoneId: string, dnsRecordId: string) =>
     return narrowRecord(r as Parameters<typeof narrowRecord>[0]);
   });
 
-// Locate an existing record by `(zoneId, name, type)`. Used both
-// for the adoption path and to surface a conflict when the caller
-// hasn't opted into adoption.
+// Locate an existing record by `(zoneId, name, type)`. Cloudflare accepts
+// relative names on writes but returns FQDNs on reads, so check the supplied
+// name first and then its zone-qualified form. Used both for the adoption path
+// and to surface a conflict when the caller hasn't opted into adoption.
 const findByNameType = (zoneId: string, name: string, type: RecordType) =>
+  findExactByNameType(zoneId, name, type).pipe(
+    Effect.flatMap((found) => {
+      if (found) return Effect.succeed(found);
+
+      return zones.getZone({ zoneId }).pipe(
+        Effect.flatMap((zone) => {
+          const normalizedName = normalizeRecordName(name, zone.name);
+          return normalizedName === name
+            ? Effect.succeed(undefined)
+            : findExactByNameType(zoneId, normalizedName, type);
+        }),
+      );
+    }),
+  );
+
+const findExactByNameType = (zoneId: string, name: string, type: RecordType) =>
   dns.listRecords
     .items({
       zoneId,
@@ -425,6 +445,12 @@ const findByNameType = (zoneId: string, name: string, type: RecordType) =>
           : narrowRecord(found as Parameters<typeof narrowRecord>[0]),
       ),
     );
+
+const normalizeRecordName = (name: string, zoneName: string): string => {
+  if (name === "@") return zoneName;
+  if (name === zoneName || name.endsWith(`.${zoneName}`)) return name;
+  return `${name}.${zoneName}`;
+};
 
 interface ObservedRecord {
   readonly id?: string;

--- a/packages/alchemy/test/Cloudflare/Dns/DnsRecord.test.ts
+++ b/packages/alchemy/test/Cloudflare/Dns/DnsRecord.test.ts
@@ -29,6 +29,8 @@ const NAME_DEFAULT = `alchemy-dnsrecord-default.${zoneName}`;
 const NAME_UPDATE = `alchemy-dnsrecord-update.${zoneName}`;
 const NAME_REPLACE = `alchemy-dnsrecord-replace.${zoneName}`;
 const NAME_ADOPT = `alchemy-dnsrecord-adopt.${zoneName}`;
+const NAME_ADOPT_RELATIVE = "alchemy-dnsrecord-relative-adopt";
+const NAME_ADOPT_RELATIVE_FQDN = `${NAME_ADOPT_RELATIVE}.${zoneName}`;
 const NAME_LIST = `alchemy-dnsrecord-list.${zoneName}`;
 
 const resolveZoneId = Effect.gen(function* () {
@@ -300,6 +302,45 @@ test.provider(
       yield* stack.destroy();
 
       const gone = yield* findRecord(zoneId, NAME_ADOPT, "A");
+      expect(gone).toBeUndefined();
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "adoption finds a normalized FQDN when given a relative record name",
+  (stack) =>
+    Effect.gen(function* () {
+      const zoneId = yield* resolveZoneId;
+
+      yield* stack.destroy();
+      yield* purgeRecords(zoneId, NAME_ADOPT_RELATIVE_FQDN, "TXT");
+
+      const pre = yield* dns.createRecord({
+        zoneId,
+        name: NAME_ADOPT_RELATIVE_FQDN,
+        type: "TXT",
+        content: "pre-existing",
+        ttl: 1,
+      });
+
+      const adopted = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.DNS.Record("RelativeAdoptedRecord", {
+            zoneId,
+            name: NAME_ADOPT_RELATIVE,
+            type: "TXT",
+            content: "adopted",
+          }).pipe(adopt(true));
+        }),
+      );
+
+      expect(adopted.recordId).toEqual(pre.id);
+      expect(adopted.name).toEqual(NAME_ADOPT_RELATIVE_FQDN);
+      expect(adopted.content).toEqual("adopted");
+
+      yield* stack.destroy();
+
+      const gone = yield* findRecord(zoneId, NAME_ADOPT_RELATIVE_FQDN, "TXT");
       expect(gone).toBeUndefined();
     }).pipe(logLevel),
 );


### PR DESCRIPTION
alchemy and cloudflare both accepts relative DNS records like `@` or `www` along with FQDN ones
but on read CF returns normalized FQDN records, which alchemy fails to match and errors out with
```
Error: Cloudflare reported an identical DNS record for (_dmarc, TXT) but it could not be found
```

this fixes that by normalizing the records