### PR TITLE
feat(cloudflare/access): support managed OAuth applications

### DIFF
--- a/packages/alchemy/src/Cloudflare/Access/Application.ts
+++ b/packages/alchemy/src/Cloudflare/Access/Application.ts
@@ -50,6 +50,32 @@ export type ApplicationDestination =
     }
   | { type: "via_mcp_server_portal"; mcpServerId: string };
 
+/**
+ * Configuration for an OAuth authorization flow managed by Cloudflare Access.
+ */
+export interface OAuthConfiguration {
+  /** Whether Access acts as the OAuth authorization server. */
+  enabled?: boolean;
+  /** OAuth grant and token lifetimes. */
+  grant?: {
+    /** Lifetime of issued access tokens, as a Go-style duration. */
+    accessTokenLifetime?: string;
+    /** Lifetime of the authorization session, as a Go-style duration. */
+    sessionDuration?: string;
+  };
+  /** Settings for OAuth dynamic client registration. */
+  dynamicClientRegistration?: {
+    /** Whether dynamic client registration is enabled. */
+    enabled?: boolean;
+    /** Explicit redirect URIs that dynamically registered clients may use. */
+    allowedUris?: ReadonlyArray<string>;
+    /** Whether any localhost redirect URI is allowed. */
+    allowAnyOnLocalhost?: boolean;
+    /** Whether any loopback-address redirect URI is allowed. */
+    allowAnyOnLoopback?: boolean;
+  };
+}
+
 export interface ApplicationProps {
   /**
    * The Access application type.
@@ -91,6 +117,12 @@ export interface ApplicationProps {
    * ```
    */
   destinations?: ReadonlyArray<ApplicationDestination>;
+  /**
+   * Optional OAuth authorization-server configuration managed by Access.
+   * Use this for non-browser clients such as MCP clients that authenticate
+   * through OAuth and may register redirect URIs dynamically.
+   */
+  oauthConfiguration?: OAuthConfiguration;
   /**
    * Token TTL for sessions issued by this application. Accepts Go-style
    * duration strings, e.g. `"24h"`, `"720h"`, `"2h45m"`.
@@ -171,6 +203,8 @@ export interface ApplicationAttributes {
   domain: string;
   /** Resolved destinations (echoed back by Cloudflare). */
   destinations: ReadonlyArray<ApplicationDestination> | undefined;
+  /** Resolved managed OAuth configuration. */
+  oauthConfiguration: OAuthConfiguration | undefined;
   /** Application type. */
   type: ApplicationType;
   /** Display name (resolved). */
@@ -218,6 +252,26 @@ export type Application = Resource<
  *   domain: "dashboard.example.com",
  *   sessionDuration: "24h",
  *   policies: [allowMyOrg.policyId],
+ * });
+ * ```
+ *
+ * @example Managed OAuth for an MCP server
+ * ```typescript
+ * const app = yield* Cloudflare.Access.Application("McpServer", {
+ *   type: "self_hosted",
+ *   domain: "mcp.example.com",
+ *   oauthConfiguration: {
+ *     enabled: true,
+ *     grant: {
+ *       sessionDuration: "24h",
+ *       accessTokenLifetime: "15m",
+ *     },
+ *     dynamicClientRegistration: {
+ *       enabled: true,
+ *       allowAnyOnLocalhost: true,
+ *       allowAnyOnLoopback: true,
+ *     },
+ *   },
  * });
  * ```
  *
@@ -347,6 +401,9 @@ export const ApplicationProvider = () =>
         aud: observed.aud,
         domain,
         destinations: observed.destinations ?? output?.destinations,
+        // Live cloud state is authoritative. In particular, do not resurrect
+        // a persisted configuration when Cloudflare explicitly returns null.
+        oauthConfiguration: observed.oauthConfiguration,
         type: observed.type,
         name,
         accountId: output?.accountId ?? accountId,
@@ -408,6 +465,9 @@ export const ApplicationProvider = () =>
               body.destinations === undefined
                 ? undefined
                 : Array.from(body.destinations),
+            oauthConfiguration: toRequestOAuthConfiguration(
+              body.oauthConfiguration,
+            ),
           })
           .pipe(
             // A referenced policy may be propagating, or the call may be
@@ -458,6 +518,15 @@ export const ApplicationProvider = () =>
               body.destinations === undefined
                 ? undefined
                 : Array.from(body.destinations),
+            // Preserve a live managed OAuth configuration when the caller
+            // does not manage it but another mutable field triggers this
+            // PUT-style update.
+            oauthConfiguration: toRequestOAuthConfiguration(
+              mergeOAuthConfiguration(
+                observed.oauthConfiguration,
+                body.oauthConfiguration,
+              ),
+            ),
           })
           // A just-added policy reference may still be propagating, or the
           // call may be throttled (403) — ride out both.
@@ -478,6 +547,10 @@ export const ApplicationProvider = () =>
         aud: observed.aud,
         domain: observed.domain ?? body.domain ?? "",
         destinations: observed.destinations ?? body.destinations,
+        // Keep the provider output cloud-authoritative. If Cloudflare rejects
+        // or clears the desired configuration, do not mask that drift with
+        // the request body.
+        oauthConfiguration: observed.oauthConfiguration,
         type: observed.type,
         name: observed.name ?? resolvedName,
         accountId,
@@ -513,6 +586,7 @@ export const ApplicationProvider = () =>
                     aud: app.aud,
                     domain: app.domain ?? "",
                     destinations: app.destinations,
+                    oauthConfiguration: app.oauthConfiguration,
                     type: app.type,
                     name: app.name ?? "",
                     accountId,
@@ -632,6 +706,7 @@ interface ObservedApp {
   readonly type?: ApplicationType;
   readonly domain?: string;
   readonly destinations?: ReadonlyArray<ApplicationDestination>;
+  readonly oauthConfiguration?: OAuthConfiguration;
   readonly allowedIdps?: ReadonlyArray<string>;
   readonly autoRedirectToIdentity?: boolean;
   readonly appLauncherVisible?: boolean;
@@ -650,6 +725,51 @@ const undefArr = <T>(
 ): ReadonlyArray<T> | undefined =>
   v == null ? undefined : (v.filter((x) => x != null) as ReadonlyArray<T>);
 
+interface RawOAuthConfiguration {
+  readonly enabled?: boolean | null;
+  readonly grant?: {
+    readonly accessTokenLifetime?: string | null;
+    readonly sessionDuration?: string | null;
+  } | null;
+  readonly dynamicClientRegistration?: {
+    readonly enabled?: boolean | null;
+    readonly allowedUris?: ReadonlyArray<string | null> | null;
+    readonly allowAnyOnLocalhost?: boolean | null;
+    readonly allowAnyOnLoopback?: boolean | null;
+  } | null;
+}
+
+const narrowOAuthConfiguration = (
+  raw: RawOAuthConfiguration | null | undefined,
+): OAuthConfiguration | undefined =>
+  raw == null
+    ? undefined
+    : {
+        enabled: undef(raw.enabled),
+        grant:
+          raw.grant == null
+            ? undefined
+            : {
+                accessTokenLifetime: undef(raw.grant.accessTokenLifetime),
+                sessionDuration: undef(raw.grant.sessionDuration),
+              },
+        dynamicClientRegistration:
+          raw.dynamicClientRegistration == null
+            ? undefined
+            : {
+                enabled: undef(raw.dynamicClientRegistration.enabled),
+                allowedUris: undefArr(
+                  raw.dynamicClientRegistration.allowedUris,
+                ) as string[] | undefined,
+                allowAnyOnLocalhost: undef(
+                  raw.dynamicClientRegistration.allowAnyOnLocalhost,
+                ),
+                allowAnyOnLoopback: undef(
+                  raw.dynamicClientRegistration.allowAnyOnLoopback,
+                ),
+              },
+      };
+
 const narrowApp = (raw: {
   id?: string | null;
   aud?: string | null;
@@ -657,6 +777,7 @@ const narrowApp = (raw: {
   type?: ApplicationType | null | string;
   domain?: string | null;
   destinations?: ReadonlyArray<unknown> | null;
+  oauthConfiguration?: RawOAuthConfiguration | null;
   allowedIdps?: ReadonlyArray<string> | null;
   autoRedirectToIdentity?: boolean | null;
   appLauncherVisible?: boolean | null;
@@ -675,6 +796,7 @@ const narrowApp = (raw: {
     raw.destinations == null
       ? undefined
       : (raw.destinations as ReadonlyArray<ApplicationDestination>),
+  oauthConfiguration: narrowOAuthConfiguration(raw.oauthConfiguration),
   allowedIdps: undefArr(raw.allowedIdps ?? undefined),
   autoRedirectToIdentity: undef(raw.autoRedirectToIdentity),
   appLauncherVisible: undef(raw.appLauncherVisible),
@@ -729,6 +851,7 @@ type RequestPolicy = Exclude<
 interface AppMutableBody {
   domain?: string;
   destinations?: ReadonlyArray<ApplicationDestination>;
+  oauthConfiguration?: OAuthConfiguration;
   type: ApplicationType;
   name?: string;
   sessionDuration?: string;
@@ -787,6 +910,63 @@ const toRequestPolicies = (
 ): Array<RequestPolicy> | undefined =>
   policies === undefined ? undefined : policies.map(toRequestPolicy);
 
+const mergeOAuthConfiguration = (
+  observed: OAuthConfiguration | undefined,
+  desired: OAuthConfiguration | undefined,
+): OAuthConfiguration | undefined => {
+  if (desired === undefined) return observed;
+  return {
+    enabled: desired.enabled ?? observed?.enabled,
+    grant:
+      desired.grant === undefined
+        ? observed?.grant
+        : {
+            accessTokenLifetime:
+              desired.grant.accessTokenLifetime ??
+              observed?.grant?.accessTokenLifetime,
+            sessionDuration:
+              desired.grant.sessionDuration ?? observed?.grant?.sessionDuration,
+          },
+    dynamicClientRegistration:
+      desired.dynamicClientRegistration === undefined
+        ? observed?.dynamicClientRegistration
+        : {
+            enabled:
+              desired.dynamicClientRegistration.enabled ??
+              observed?.dynamicClientRegistration?.enabled,
+            allowedUris:
+              desired.dynamicClientRegistration.allowedUris ??
+              observed?.dynamicClientRegistration?.allowedUris,
+            allowAnyOnLocalhost:
+              desired.dynamicClientRegistration.allowAnyOnLocalhost ??
+              observed?.dynamicClientRegistration?.allowAnyOnLocalhost,
+            allowAnyOnLoopback:
+              desired.dynamicClientRegistration.allowAnyOnLoopback ??
+              observed?.dynamicClientRegistration?.allowAnyOnLoopback,
+          },
+  };
+};
+
+const toRequestOAuthConfiguration = (
+  config: OAuthConfiguration | undefined,
+): zeroTrust.CreateAccessApplicationForAccountRequest["oauthConfiguration"] =>
+  config === undefined
+    ? undefined
+    : {
+        enabled: config.enabled,
+        grant: config.grant,
+        dynamicClientRegistration:
+          config.dynamicClientRegistration === undefined
+            ? undefined
+            : {
+                ...config.dynamicClientRegistration,
+                allowedUris:
+                  config.dynamicClientRegistration.allowedUris === undefined
+                    ? undefined
+                    : Array.from(config.dynamicClientRegistration.allowedUris),
+              },
+      };
+
 const resolvePolicies = (
   policies: ApplicationProps["policies"],
 ): ReadonlyArray<ResolvedPolicy> | undefined =>
@@ -812,6 +992,9 @@ const buildMutableBody = (
   }
   if (news.destinations !== undefined) {
     body.destinations = news.destinations;
+  }
+  if (news.oauthConfiguration !== undefined) {
+    body.oauthConfiguration = news.oauthConfiguration;
   }
   if (news.sessionDuration !== undefined) {
     body.sessionDuration = news.sessionDuration;
@@ -840,6 +1023,65 @@ const buildMutableBody = (
 
 const jsonEq = <T>(x: T, y: T): boolean =>
   JSON.stringify(x) === JSON.stringify(y);
+
+const oauthConfigurationEquals = (
+  desired: OAuthConfiguration | undefined,
+  observed: OAuthConfiguration | undefined,
+): boolean => {
+  if (desired === undefined) return true;
+  if (observed === undefined) return false;
+  if (desired.enabled !== undefined && desired.enabled !== observed.enabled) {
+    return false;
+  }
+
+  const desiredGrant = desired.grant;
+  if (desiredGrant?.accessTokenLifetime !== undefined) {
+    if (
+      desiredGrant.accessTokenLifetime !== observed.grant?.accessTokenLifetime
+    ) {
+      return false;
+    }
+  }
+  if (desiredGrant?.sessionDuration !== undefined) {
+    if (desiredGrant.sessionDuration !== observed.grant?.sessionDuration) {
+      return false;
+    }
+  }
+
+  const desiredRegistration = desired.dynamicClientRegistration;
+  const observedRegistration = observed.dynamicClientRegistration;
+  if (
+    desiredRegistration?.enabled !== undefined &&
+    desiredRegistration.enabled !== observedRegistration?.enabled
+  ) {
+    return false;
+  }
+  if (
+    desiredRegistration?.allowAnyOnLocalhost !== undefined &&
+    desiredRegistration.allowAnyOnLocalhost !==
+      observedRegistration?.allowAnyOnLocalhost
+  ) {
+    return false;
+  }
+  if (
+    desiredRegistration?.allowAnyOnLoopback !== undefined &&
+    desiredRegistration.allowAnyOnLoopback !==
+      observedRegistration?.allowAnyOnLoopback
+  ) {
+    return false;
+  }
+  if (
+    desiredRegistration?.allowedUris !== undefined &&
+    !arrayEquals(
+      [...desiredRegistration.allowedUris].sort(),
+      [...(observedRegistration?.allowedUris ?? [])].sort(),
+      jsonEq,
+    )
+  ) {
+    return false;
+  }
+  return true;
+};
 
 const policiesEq = (
   desired: ReadonlyArray<ResolvedPolicy> | undefined,
@@ -888,6 +1130,14 @@ const bodyEqualsObserved = (
     desired.destinations !== undefined &&
     JSON.stringify(desired.destinations) !==
       JSON.stringify(observed.destinations ?? [])
+  ) {
+    return false;
+  }
+  if (
+    !oauthConfigurationEquals(
+      desired.oauthConfiguration,
+      observed.oauthConfiguration,
+    )
   ) {
     return false;
   }

--- a/packages/alchemy/test/Cloudflare/Access/Application.test.ts
+++ b/packages/alchemy/test/Cloudflare/Access/Application.test.ts
@@ -50,6 +50,19 @@ test.provider(
             type: "self_hosted",
             domain,
             sessionDuration: "24h",
+            oauthConfiguration: {
+              enabled: true,
+              grant: {
+                sessionDuration: "24h",
+                accessTokenLifetime: "15m",
+              },
+              dynamicClientRegistration: {
+                enabled: true,
+                allowedUris: [],
+                allowAnyOnLocalhost: true,
+                allowAnyOnLoopback: true,
+              },
+            },
             policies: [policy.policyId],
           });
           return { app, policy };
@@ -60,6 +73,15 @@ test.provider(
       expect(app.type).toEqual("self_hosted");
       expect(app.domain).toEqual(domain);
       expect(app.aud.length).toBeGreaterThan(0);
+      expect(app.oauthConfiguration?.enabled).toBe(true);
+      expect(app.oauthConfiguration?.grant?.sessionDuration).toBe("24h");
+      expect(app.oauthConfiguration?.grant?.accessTokenLifetime).toBe("15m");
+      expect(app.oauthConfiguration?.dynamicClientRegistration?.enabled).toBe(
+        true,
+      );
+      expect(
+        app.oauthConfiguration?.dynamicClientRegistration?.allowedUris ?? [],
+      ).toEqual([]);
       expect(policy.policyId.length).toBeGreaterThan(0);
 
       const live = yield* zeroTrust.getAccessApplicationForAccount({
@@ -70,12 +92,45 @@ test.provider(
         id?: string | null;
         type?: string | null;
         policies?: ReadonlyArray<{ id?: string | null }> | null;
+        oauthConfiguration?: {
+          enabled?: boolean | null;
+          grant?: {
+            sessionDuration?: string | null;
+            accessTokenLifetime?: string | null;
+          } | null;
+          dynamicClientRegistration?: {
+            enabled?: boolean | null;
+            allowedUris?: ReadonlyArray<string | null> | null;
+            allowAnyOnLocalhost?: boolean | null;
+            allowAnyOnLoopback?: boolean | null;
+          } | null;
+        } | null;
       };
       expect(liveRecord.id).toEqual(app.applicationId);
       expect(liveRecord.type).toEqual("self_hosted");
       expect(liveRecord.policies?.length ?? 0).toBeGreaterThanOrEqual(1);
       const liveIds = (liveRecord.policies ?? []).map((p) => p.id);
       expect(liveIds).toContain(policy.policyId);
+      expect(liveRecord.oauthConfiguration?.enabled).toBe(true);
+      expect(liveRecord.oauthConfiguration?.grant?.sessionDuration).toBe("24h");
+      expect(liveRecord.oauthConfiguration?.grant?.accessTokenLifetime).toBe(
+        "15m",
+      );
+      expect(
+        liveRecord.oauthConfiguration?.dynamicClientRegistration?.enabled,
+      ).toBe(true);
+      expect(
+        liveRecord.oauthConfiguration?.dynamicClientRegistration?.allowedUris ??
+          [],
+      ).toEqual([]);
+      expect(
+        liveRecord.oauthConfiguration?.dynamicClientRegistration
+          ?.allowAnyOnLocalhost,
+      ).toBe(true);
+      expect(
+        liveRecord.oauthConfiguration?.dynamicClientRegistration
+          ?.allowAnyOnLoopback,
+      ).toBe(true);
 
       yield* stack.destroy();
     }).pipe(logLevel),
@@ -198,6 +253,18 @@ test.provider(
           return yield* Cloudflare.Access.Application("UpdatePolicies", {
             type: "self_hosted",
             domain,
+            oauthConfiguration: {
+              enabled: true,
+              grant: {
+                sessionDuration: "24h",
+                accessTokenLifetime: "15m",
+              },
+              dynamicClientRegistration: {
+                enabled: true,
+                allowedUris: ["https://client.example.com/callback"],
+                allowAnyOnLocalhost: true,
+              },
+            },
             policies: [allow.policyId],
           });
         }),
@@ -221,6 +288,12 @@ test.provider(
           return yield* Cloudflare.Access.Application("UpdatePolicies", {
             type: "self_hosted",
             domain,
+            // Update one managed OAuth leaf while preserving omitted fields.
+            oauthConfiguration: {
+              dynamicClientRegistration: {
+                allowAnyOnLoopback: true,
+              },
+            },
             policies: [allow.policyId, deny.policyId],
           });
         }),
@@ -234,8 +307,42 @@ test.provider(
       });
       const liveRecord = live as unknown as {
         policies?: ReadonlyArray<unknown> | null;
+        oauthConfiguration?: {
+          enabled?: boolean | null;
+          grant?: {
+            sessionDuration?: string | null;
+            accessTokenLifetime?: string | null;
+          } | null;
+          dynamicClientRegistration?: {
+            enabled?: boolean | null;
+            allowedUris?: ReadonlyArray<string | null> | null;
+            allowAnyOnLocalhost?: boolean | null;
+            allowAnyOnLoopback?: boolean | null;
+          } | null;
+        } | null;
       };
       expect(liveRecord.policies?.length ?? 0).toEqual(2);
+      // The partial desired body must merge over the live managed OAuth
+      // configuration before the PUT-style application update.
+      expect(liveRecord.oauthConfiguration?.enabled).toBe(true);
+      expect(liveRecord.oauthConfiguration?.grant?.sessionDuration).toBe("24h");
+      expect(liveRecord.oauthConfiguration?.grant?.accessTokenLifetime).toBe(
+        "15m",
+      );
+      expect(
+        liveRecord.oauthConfiguration?.dynamicClientRegistration?.enabled,
+      ).toBe(true);
+      expect(
+        liveRecord.oauthConfiguration?.dynamicClientRegistration?.allowedUris,
+      ).toEqual(["https://client.example.com/callback"]);
+      expect(
+        liveRecord.oauthConfiguration?.dynamicClientRegistration
+          ?.allowAnyOnLocalhost,
+      ).toBe(true);
+      expect(
+        liveRecord.oauthConfiguration?.dynamicClientRegistration
+          ?.allowAnyOnLoopback,
+      ).toBe(true);
 
       yield* stack.destroy();
     }).pipe(logLevel),


### PR DESCRIPTION
`Cloudflare.Access.Application` currently drops the API's `oauth_configuration` field, so stacks cannot declaratively create Access-managed OAuth applications for non-browser clients such as MCP servers. The distilled Cloudflare client already types the field.

```ts
const app = yield* Cloudflare.Access.Application("McpServer", {
  type: "self_hosted",
  domain: "mcp.example.com",
  oauthConfiguration: {
    enabled: true,
    grant: {
      sessionDuration: "24h",
      accessTokenLifetime: "15m",
    },
    dynamicClientRegistration: {
      enabled: true,
      allowAnyOnLocalhost: true,
      allowAnyOnLoopback: true,
    },
  },
});
```

The provider sends the configuration through create and update requests, normalizes it into resource attributes, and deep-merges partial desired changes over live state before PUT updates so omitted OAuth fields are preserved.
