### PR TITLE
fix(aws/ec2): hosted instance bootstrap, planning, and replacement fixes

### DIFF
--- a/examples/aws-ec2/src/Server.ts
+++ b/examples/aws-ec2/src/Server.ts
@@ -10,12 +10,11 @@ import { Network, NetworkLive } from "./Network.ts";
 export default class Server extends AWS.EC2.Instance<Server>()(
   "ServerInstance",
   Effect.gen(function* () {
-    const imageId = yield* AWS.EC2.amazonLinux();
     const network = yield* Network;
 
     return {
       main: import.meta.url,
-      imageId,
+      imageId: AWS.EC2.amazonLinux(),
       instanceType: "t3.small",
       subnetId: network.publicSubnetIds[0],
       securityGroupIds: [network.appSecurityGroupId],

--- a/packages/alchemy/src/AWS/AutoScaling/LaunchTemplate.ts
+++ b/packages/alchemy/src/AWS/AutoScaling/LaunchTemplate.ts
@@ -406,7 +406,7 @@ export const LaunchTemplateProvider = () =>
           "launchTemplateArn",
           "launchTemplateName",
         ],
-        diff: Effect.fn(function* ({ id, olds, news: _news }) {
+        diff: Effect.fn(function* ({ id, olds, news: _news, output }) {
           if (!isResolved(_news)) return undefined;
           const news = _news as typeof olds;
           const oldName = yield* toName(id, olds ?? {});
@@ -424,6 +424,25 @@ export const LaunchTemplateProvider = () =>
                 "launchTemplateName",
               ],
             } as const;
+          }
+
+          // The hosted bundle hash participates in planning: a change confined
+          // to the runtime program (or its imports) leaves every prop equal,
+          // so re-bundle and compare against the deployed hash. A mismatch
+          // plans an in-place update, whose reconcile publishes a new template
+          // version carrying the new bundle.
+          if (news.main && output?.code?.hash) {
+            const { hash } = yield* hosted.bundleProgram(id, news);
+            if (hash !== output.code.hash) {
+              return {
+                action: "update",
+                stables: [
+                  "launchTemplateId",
+                  "launchTemplateArn",
+                  "launchTemplateName",
+                ],
+              } as const;
+            }
           }
         }),
         read: Effect.fn(function* ({ id, olds, output }) {

--- a/packages/alchemy/src/AWS/EC2/Image.ts
+++ b/packages/alchemy/src/AWS/EC2/Image.ts
@@ -1,5 +1,6 @@
 import * as ec2 from "@distilled.cloud/aws/ec2";
 import * as Effect from "effect/Effect";
+import * as Output from "../../Output.ts";
 
 /**
  * CPU architecture of the AMI to look up.
@@ -89,31 +90,74 @@ const findFirstImage = Effect.fn(function* <Req = never>(
   return yield* Effect.die(new Error(errorMessage));
 });
 
+const findImage = (options: FindImageOptions) =>
+  findLatestImage(options).pipe(
+    Effect.flatMap((imageId) =>
+      imageId
+        ? Effect.succeed(imageId)
+        : Effect.die(
+            new Error(
+              `Could not resolve ${options.description ?? "an AMI"} matching ${options.name.join(", ")}`,
+            ),
+          ),
+    ),
+  );
+
 /**
- * Look up the latest available AMI ID matching the given filters, or
- * `undefined` when nothing matches. Use the preset helpers
- * ({@link amazonLinux2023}, {@link ubuntu2404}, ...) for common distros.
+ * Look up the latest available AMI ID matching the given filters.
+ *
+ * Returns an `Output<string>` that resolves at plan/deploy time (and dies
+ * with a descriptive error when nothing matches), so it is safe to use both
+ * in resource props and in composition code that is re-executed inside a
+ * deployed runtime — the lookup never runs on the deployed machine. Use the
+ * preset helpers ({@link amazonLinux2023}, {@link ubuntu2404}, ...) for
+ * common distros.
  *
  * @example Find a custom AMI
  * ```typescript
- * const imageId = yield* AWS.EC2.image({
- *   owners: ["amazon"],
- *   name: ["al2023-ami-ecs-hvm-*"],
- *   architecture: "arm64",
+ * const instance = yield* AWS.EC2.Instance("web", {
+ *   imageId: AWS.EC2.image({
+ *     owners: ["amazon"],
+ *     name: ["al2023-ami-ecs-hvm-*"],
+ *     architecture: "arm64",
+ *   }),
+ *   instanceType: "t4g.micro",
+ *   subnetId: subnet.subnetId,
  * });
  * ```
  */
-export const image = (options: FindImageOptions) => findLatestImage(options);
+export const image = (options: FindImageOptions) =>
+  Output.fromEffect(findImage(options));
+
+const amazonLinux2023Options = (options?: {
+  architecture?: ImageArchitecture;
+}): FindImageOptions => ({
+  owners: ["amazon"],
+  // `al2023-ami-2023.*` selects the standard image. The broader
+  // `al2023-ami-*` also matches `al2023-ami-minimal-*`, which ships without
+  // the SSM agent and a stripped toolset and frequently sorts newest.
+  name: ["al2023-ami-2023.*"],
+  architecture: options?.architecture,
+  description: "Amazon Linux 2023",
+});
+
+const amazonLinux2Options = (options?: {
+  architecture?: ImageArchitecture;
+}): FindImageOptions => ({
+  owners: ["amazon"],
+  name: ["amzn2-ami-hvm-*-*-gp2"],
+  architecture: options?.architecture,
+  description: "Amazon Linux 2",
+});
 
 /**
- * Resolve the latest Amazon Linux 2023 AMI ID for the current region.
+ * Resolve the latest Amazon Linux 2023 AMI ID for the current region as an
+ * `Output<string>`.
  *
  * @example Launch an Instance on Amazon Linux 2023
  * ```typescript
- * const imageId = yield* AWS.EC2.amazonLinux2023();
- *
  * const instance = yield* AWS.EC2.Instance("web", {
- *   imageId: imageId!,
+ *   imageId: AWS.EC2.amazonLinux2023(),
  *   instanceType: "t3.micro",
  *   subnetId: subnet.subnetId,
  * });
@@ -121,43 +165,46 @@ export const image = (options: FindImageOptions) => findLatestImage(options);
  */
 export const amazonLinux2023 = (options?: {
   architecture?: ImageArchitecture;
-}) =>
-  findLatestImage({
-    owners: ["amazon"],
-    // `al2023-ami-2023.*` selects the standard image. The broader
-    // `al2023-ami-*` also matches `al2023-ami-minimal-*`, which ships without
-    // the SSM agent and a stripped toolset and frequently sorts newest.
-    name: ["al2023-ami-2023.*"],
-    architecture: options?.architecture,
-    description: "Amazon Linux 2023",
-  });
+}) => image(amazonLinux2023Options(options));
 
 /**
- * Resolve the latest Amazon Linux 2 AMI ID for the current region.
+ * Resolve the latest Amazon Linux 2 AMI ID for the current region as an
+ * `Output<string>`.
  */
 export const amazonLinux2 = (options?: { architecture?: ImageArchitecture }) =>
-  findLatestImage({
-    owners: ["amazon"],
-    name: ["amzn2-ami-hvm-*-*-gp2"],
-    architecture: options?.architecture,
-    description: "Amazon Linux 2",
-  });
+  image(amazonLinux2Options(options));
 
 /**
- * Resolve the newest public Amazon Linux AMI, preferring Amazon Linux 2023
- * and falling back to Amazon Linux 2. Dies if neither is available.
+ * Resolve the newest public Amazon Linux AMI as an `Output<string>`,
+ * preferring Amazon Linux 2023 and falling back to Amazon Linux 2. Dies if
+ * neither is available.
  */
 export const amazonLinux = (options?: { architecture?: ImageArchitecture }) =>
-  findFirstImage(
-    [amazonLinux2023(options), amazonLinux2(options)],
-    "Could not resolve a public Amazon Linux AMI",
+  Output.fromEffect(
+    findFirstImage(
+      [
+        findLatestImage(amazonLinux2023Options(options)),
+        findLatestImage(amazonLinux2Options(options)),
+      ],
+      "Could not resolve a public Amazon Linux AMI",
+    ),
   );
 
 /**
- * Resolve the latest Canonical Ubuntu 24.04 LTS AMI ID for the current region.
+ * Resolve the latest Canonical Ubuntu 24.04 LTS AMI ID for the current
+ * region as an `Output<string>`.
+ *
+ * @example Launch an Instance on Ubuntu 24.04
+ * ```typescript
+ * const instance = yield* AWS.EC2.Instance("web", {
+ *   imageId: AWS.EC2.ubuntu2404(),
+ *   instanceType: "t3.micro",
+ *   subnetId: subnet.subnetId,
+ * });
+ * ```
  */
 export const ubuntu2404 = (options?: { architecture?: ImageArchitecture }) =>
-  findLatestImage({
+  image({
     owners: ["099720109477"],
     name: [
       "ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-*-server-*",
@@ -168,10 +215,11 @@ export const ubuntu2404 = (options?: { architecture?: ImageArchitecture }) =>
   });
 
 /**
- * Resolve the latest Canonical Ubuntu 22.04 LTS AMI ID for the current region.
+ * Resolve the latest Canonical Ubuntu 22.04 LTS AMI ID for the current
+ * region as an `Output<string>`.
  */
 export const ubuntu2204 = (options?: { architecture?: ImageArchitecture }) =>
-  findLatestImage({
+  image({
     owners: ["099720109477"],
     name: [
       "ubuntu/images/hvm-ssd-gp3/ubuntu-jammy-22.04-*-server-*",

--- a/packages/alchemy/src/AWS/EC2/Instance.ts
+++ b/packages/alchemy/src/AWS/EC2/Instance.ts
@@ -438,8 +438,21 @@ export const InstanceProvider = () =>
             ),
           );
 
-      const findInstanceByTags = Effect.fn(function* (id: string) {
-        const filters = yield* createAlchemyTagFilters(id);
+      // Generation-scoped recovery lookup: instances are branded with the
+      // engine's per-generation instance id (`alchemy::instance`) on top of
+      // the stack/stage/id ownership tags. An interrupted create resumes with
+      // the same generation id, so it still recovers its own orphan — while a
+      // replacement's create phase runs under a freshly minted generation id
+      // and can never re-adopt the old generation's live instance that the
+      // cleanup phase is about to terminate.
+      const findInstanceByTags = Effect.fn(function* (
+        id: string,
+        generation: string,
+      ) {
+        const filters = [
+          ...(yield* createAlchemyTagFilters(id)),
+          { Name: "tag:alchemy::instance", Values: [generation] },
+        ];
         return yield* ec2.describeInstances
           .items({
             Filters: filters,
@@ -599,7 +612,7 @@ export const InstanceProvider = () =>
               (instance) => toAttributes(instance),
             );
           }),
-        diff: Effect.fn(function* ({ news, olds }) {
+        diff: Effect.fn(function* ({ id, news, olds, output }) {
           if (!isResolved(news)) return;
           const hostModeChanged = Boolean(olds.main) !== Boolean(news.main);
           if (
@@ -639,8 +652,23 @@ export const InstanceProvider = () =>
               stables: ["instanceId", "instanceArn", "vpcId", "subnetId"],
             } as const;
           }
+
+          // The hosted bundle hash participates in planning: a change confined
+          // to the runtime program (or its imports) leaves every prop equal, so
+          // re-bundle and compare against the deployed hash. A mismatch plans
+          // an in-place update, whose reconcile re-uploads the bundle and
+          // reboots the instance.
+          if (news.main && output?.code?.hash) {
+            const { hash } = yield* hosted.bundleProgram(id, news);
+            if (hash !== output.code.hash) {
+              return {
+                action: "update",
+                stables: ["instanceId", "instanceArn", "vpcId", "subnetId"],
+              } as const;
+            }
+          }
         }),
-        read: Effect.fn(function* ({ id, output }) {
+        read: Effect.fn(function* ({ id, instanceId, output }) {
           const instance = output?.instanceId
             ? yield* describeInstance(output.instanceId).pipe(
                 Effect.catchTag("InvalidInstanceID.NotFound", () =>
@@ -650,7 +678,7 @@ export const InstanceProvider = () =>
                   Effect.succeed(undefined),
                 ),
               )
-            : yield* findInstanceByTags(id);
+            : yield* findInstanceByTags(id, instanceId);
           return instance
             ? {
                 ...(yield* toAttributes(instance)),
@@ -667,6 +695,7 @@ export const InstanceProvider = () =>
         }),
         reconcile: Effect.fn(function* ({
           id,
+          instanceId: generation,
           news,
           output,
           bindings,
@@ -674,6 +703,8 @@ export const InstanceProvider = () =>
         }) {
           const desiredTags = {
             ...(yield* createInternalTags(id)),
+            // Generation brand consumed by the recovery lookup above.
+            "alchemy::instance": generation,
             ...news.tags,
           };
           const runtime = yield* hosted.resolveHostedRuntime({
@@ -696,7 +727,7 @@ export const InstanceProvider = () =>
                   Effect.succeed(undefined),
                 ),
               )
-            : yield* findInstanceByTags(id);
+            : yield* findInstanceByTags(id, generation);
 
           // A terminated instance is a tombstone; treat as missing so we
           // launch a fresh one.

--- a/packages/alchemy/src/AWS/EC2/Instance.ts
+++ b/packages/alchemy/src/AWS/EC2/Instance.ts
@@ -278,7 +278,7 @@ export type InstanceRuntimeContext = Ec2HostRuntimeContext;
  * @example Basic Instance
  * ```typescript
  * const instance = yield* AWS.EC2.Instance("AppInstance", {
- *   imageId,
+ *   imageId: AWS.EC2.amazonLinux2023(),
  *   instanceType: "t3.micro",
  *   subnetId: subnet.subnetId,
  * });
@@ -294,7 +294,7 @@ export type InstanceRuntimeContext = Ec2HostRuntimeContext;
  *
  *   return {
  *     main: import.meta.url,
- *     imageId,
+ *     imageId: AWS.EC2.amazonLinux2023(),
  *     instanceType: "t3.small",
  *     subnetId: subnet.subnetId,
  *     securityGroupIds: [securityGroup.groupId],

--- a/packages/alchemy/src/AWS/EC2/hosted.ts
+++ b/packages/alchemy/src/AWS/EC2/hosted.ts
@@ -264,7 +264,10 @@ const program = handler.pipe(
         }))
       )
     ).pipe(
-      Layer.provideMerge(Credentials.fromEnv()),
+      // The instance authenticates via its instance profile (IMDS), which
+      // only the full provider chain resolves — env-only credentials never
+      // exist on a hosted EC2 box.
+      Layer.provideMerge(Credentials.fromChain()),
       Layer.provideMerge(Region.fromEnv()),
       Layer.provideMerge(BunHttpServer()),
       Layer.provideMerge(platform),
@@ -712,6 +715,11 @@ systemctl enable --now ${unitName}.service
     const env = {
       ...bindingEnv,
       ...alchemyEnv,
+      // Lambda injects AWS_REGION natively; an EC2 systemd service does not
+      // get one, and the runtime's `Region.fromEnv()` (and any composition
+      // code that reads the region, e.g. EC2.Network's runtime AZ branch)
+      // dies without it.
+      AWS_REGION: region,
       ...(news.port !== undefined ? { PORT: news.port } : {}),
       ...news.env,
     };

--- a/packages/alchemy/src/AWS/EC2/hosted.ts
+++ b/packages/alchemy/src/AWS/EC2/hosted.ts
@@ -348,7 +348,8 @@ export HOME=/root
 # unzip (needed below) — install if missing.
 command -v unzip >/dev/null 2>&1 || {
   (command -v dnf >/dev/null 2>&1 && dnf install -y unzip) \
-    || (command -v yum >/dev/null 2>&1 && yum install -y unzip) || true
+    || (command -v yum >/dev/null 2>&1 && yum install -y unzip) \
+    || (command -v apt-get >/dev/null 2>&1 && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y unzip) || true
 }
 
 # AWS CLI — preinstalled on Amazon Linux 2023; install v2 otherwise.
@@ -386,7 +387,10 @@ Type=simple
 WorkingDirectory=${appDir}
 ExecStartPre=/usr/local/bin/${unitName}-setup.sh
 EnvironmentFile=-${appDir}/env
-ExecStart=/root/.bun/bin/bun ${appDir}/index.mjs
+# --no-install: the uploaded bundle is self-contained; bun must never fall
+# into its auto-install path (which hangs startup on network package
+# resolution) — fail fast if the bundle is incomplete instead.
+ExecStart=/root/.bun/bin/bun --no-install ${appDir}/index.mjs
 Restart=always
 RestartSec=5
 
@@ -907,6 +911,7 @@ systemctl enable --now ${unitName}.service
   return {
     normalizeSecurityGroups,
     buildLaunchTemplateData,
+    bundleProgram,
     resolveHostedRuntime,
     cleanupHostedRuntime,
   };

--- a/packages/alchemy/src/Output.ts
+++ b/packages/alchemy/src/Output.ts
@@ -48,6 +48,23 @@ export const asOutput = <T>(t: T | Output<T> | Effect.Effect<T>): Output<T> =>
       ? new EffectExpr(VoidExpr, () => t)
       : new LiteralExpr(t);
 
+/**
+ * Lift a plan-time Effect into an {@link Output}.
+ *
+ * The effect runs when the stack resolves the Output during plan/deploy —
+ * with the stack's services (cloud credentials, region, ...) provided — and
+ * never inside a deployed runtime: constructing the Output is inert, so
+ * helpers built on `fromEffect` (e.g. AMI lookups) are safe to call from
+ * composition code that is re-executed inside a Function/Worker/Instance
+ * bundle.
+ *
+ * The effect must not fail (`E = never`) — die with a descriptive error for
+ * unresolvable lookups.
+ */
+export const fromEffect = <A, Req = never>(
+  effect: Effect.Effect<A, never, Req>,
+): ToOutput<A, Req> => new EffectExpr(VoidExpr, () => effect) as any;
+
 export const isOutput = (value: any): value is Output<any> =>
   value &&
   (typeof value === "object" || typeof value === "function") &&

--- a/packages/alchemy/test/AWS/AutoScaling/AutoScalingGroup.test.ts
+++ b/packages/alchemy/test/AWS/AutoScaling/AutoScalingGroup.test.ts
@@ -52,7 +52,7 @@ test.provider(
     Effect.gen(function* () {
       yield* stack.destroy();
 
-      const imageId = (yield* amazonLinux2023()) ?? "ami-00000000000000000";
+      const imageId = amazonLinux2023();
 
       yield* cleanupLaunchTemplate;
       yield* ec2.createLaunchTemplate({
@@ -121,7 +121,7 @@ test.provider(
 
       // Launch templates do not validate the AMI at creation time; fall back
       // to a syntactically valid id if the lookup returns nothing.
-      const imageId = (yield* amazonLinux2023()) ?? "ami-00000000000000000";
+      const imageId = amazonLinux2023();
 
       const subnetId = yield* getAutoScalingTestSubnetId;
 

--- a/packages/alchemy/test/AWS/AutoScaling/LaunchTemplate.test.ts
+++ b/packages/alchemy/test/AWS/AutoScaling/LaunchTemplate.test.ts
@@ -22,7 +22,7 @@ test.provider("list enumerates the deployed launch template", (stack) =>
 
     // Launch templates do not validate the AMI at creation time; fall back to a
     // syntactically valid id if the lookup returns nothing.
-    const imageId = (yield* amazonLinux2023()) ?? "ami-00000000000000000";
+    const imageId = amazonLinux2023();
 
     const template = yield* stack.deploy(
       Effect.gen(function* () {

--- a/packages/alchemy/test/AWS/AutoScaling/LifecycleHook.test.ts
+++ b/packages/alchemy/test/AWS/AutoScaling/LifecycleHook.test.ts
@@ -50,7 +50,7 @@ test.provider(
 
       // Launch templates do not validate the AMI at creation time; fall back to
       // a syntactically valid id if the lookup returns nothing.
-      const imageId = (yield* amazonLinux2023()) ?? "ami-00000000000000000";
+      const imageId = amazonLinux2023();
 
       // Place the fleet into a subnet of the account's default VPC (resolved
       // out-of-band) rather than a throwaway Vpc resource — a failed run loses

--- a/packages/alchemy/test/AWS/AutoScaling/ScalingPolicy.test.ts
+++ b/packages/alchemy/test/AWS/AutoScaling/ScalingPolicy.test.ts
@@ -59,7 +59,7 @@ test.provider(
 
       // Launch templates do not validate the AMI at creation time; fall back to
       // a syntactically valid id if the lookup returns nothing.
-      const imageId = (yield* amazonLinux2023()) ?? "ami-00000000000000000";
+      const imageId = amazonLinux2023();
 
       const policy = yield* stack.deploy(
         Effect.gen(function* () {
@@ -150,7 +150,7 @@ test.provider(
 
       // Launch templates do not validate the AMI at creation time; fall back
       // to a syntactically valid id if the lookup returns nothing.
-      const imageId = (yield* amazonLinux2023()) ?? "ami-00000000000000000";
+      const imageId = amazonLinux2023();
       yield* ec2.createLaunchTemplate({
         LaunchTemplateName: recoveryLtName,
         LaunchTemplateData: { ImageId: imageId, InstanceType: "t3.micro" },

--- a/packages/alchemy/test/AWS/AutoScaling/ScheduledAction.test.ts
+++ b/packages/alchemy/test/AWS/AutoScaling/ScheduledAction.test.ts
@@ -47,7 +47,7 @@ test.provider(
       yield* cleanupAsg;
       yield* stack.destroy();
 
-      const imageId = (yield* amazonLinux2023()) ?? "ami-00000000000000000";
+      const imageId = amazonLinux2023();
 
       const subnetId = yield* getAutoScalingTestSubnetId;
 

--- a/packages/alchemy/test/AWS/AutoScaling/fixtures/bindings-handler.ts
+++ b/packages/alchemy/test/AWS/AutoScaling/fixtures/bindings-handler.ts
@@ -23,6 +23,7 @@ import {
   TerminateInstanceInAutoScalingGroupHttp,
 } from "@/AWS/AutoScaling";
 import { amazonLinux2023 } from "@/AWS/EC2";
+import * as Output from "@/Output";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -43,9 +44,9 @@ export class AsgBindingsFunction extends AWS.Lambda.Function<AWS.Lambda.Function
 
 /**
  * Shared fleet for the bindings E2E: a launch template + Auto Scaling Group
- * sized to zero (no instances launch). Subnet/AMI are resolved only at deploy
- * time — at runtime the ASG resolves to a reference, so the lookups are
- * guarded off inside the deployed Lambda.
+ * sized to zero (no instances launch). Subnet/AMI are `Output`s resolved at
+ * deploy time only, so this composition is safe to re-execute inside the
+ * deployed Lambda without runtime guards.
  */
 export class BindingsFleet extends Context.Service<
   BindingsFleet,
@@ -55,13 +56,10 @@ export class BindingsFleet extends Context.Service<
 export const BindingsFleetLive = Layer.effect(
   BindingsFleet,
   Effect.gen(function* () {
-    const isDeploy = !globalThis.__ALCHEMY_RUNTIME__;
-    const imageId = isDeploy
-      ? ((yield* amazonLinux2023()) ?? "ami-00000000000000000")
-      : "ami-00000000000000000";
-    const subnetId = isDeploy
-      ? yield* getAutoScalingTestSubnetId.pipe(Effect.orDie)
-      : ("subnet-0" as `subnet-${string}`);
+    const imageId = amazonLinux2023();
+    const subnetId = Output.fromEffect(
+      getAutoScalingTestSubnetId.pipe(Effect.orDie),
+    );
 
     const template = yield* LaunchTemplate("BindingsTemplate", {
       imageId,

--- a/packages/alchemy/test/AWS/AutoScaling/fixtures/lifecycle-handler.ts
+++ b/packages/alchemy/test/AWS/AutoScaling/fixtures/lifecycle-handler.ts
@@ -7,6 +7,7 @@ import {
   LaunchTemplate,
 } from "@/AWS/AutoScaling";
 import { amazonLinux2023 } from "@/AWS/EC2";
+import * as Output from "@/Output";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -24,9 +25,9 @@ export class LifecycleTestFunction extends AWS.Lambda.Function<AWS.Lambda.Functi
 
 /**
  * Shared fleet for the lifecycle-hook E2E: a launch template + Auto Scaling
- * Group sized to zero (no instances launch by default). Subnet/AMI are resolved
- * only at deploy time — at runtime the ASG resolves to a reference, so the
- * lookups are guarded off inside the deployed Lambda.
+ * Group sized to zero (no instances launch by default). Subnet/AMI are
+ * `Output`s resolved at deploy time only, so this composition is safe to
+ * re-execute inside the deployed Lambda without runtime guards.
  */
 export class LifecycleFleet extends Context.Service<
   LifecycleFleet,
@@ -36,13 +37,10 @@ export class LifecycleFleet extends Context.Service<
 export const LifecycleFleetLive = Layer.effect(
   LifecycleFleet,
   Effect.gen(function* () {
-    const isDeploy = !globalThis.__ALCHEMY_RUNTIME__;
-    const imageId = isDeploy
-      ? ((yield* amazonLinux2023()) ?? "ami-00000000000000000")
-      : "ami-00000000000000000";
-    const subnetId = isDeploy
-      ? yield* getAutoScalingTestSubnetId.pipe(Effect.orDie)
-      : ("subnet-0" as `subnet-${string}`);
+    const imageId = amazonLinux2023();
+    const subnetId = Output.fromEffect(
+      getAutoScalingTestSubnetId.pipe(Effect.orDie),
+    );
 
     const template = yield* LaunchTemplate("LifecycleTemplate", {
       imageId,

--- a/packages/alchemy/test/AWS/EC2/Instance.test.ts
+++ b/packages/alchemy/test/AWS/EC2/Instance.test.ts
@@ -8,7 +8,9 @@ import * as Effect from "effect/Effect";
 import { MinimumLogLevel } from "effect/References";
 import { assertInstanceTerminated, assertVpcGone } from "./Gone.ts";
 
-const { test } = Test.make({ providers: AWS.providers() });
+// Two permits: the list test and the replacement test each hold a custom VPC
+// and may run concurrently within this file.
+const { test } = Test.make({ providers: AWS.providers() }, 2);
 
 const logLevel = Effect.provideService(
   MinimumLogLevel,

--- a/packages/alchemy/test/AWS/EC2/Instance.test.ts
+++ b/packages/alchemy/test/AWS/EC2/Instance.test.ts
@@ -1,6 +1,7 @@
 import * as AWS from "@/AWS";
 import { amazonLinux2023, Instance, Subnet, Vpc } from "@/AWS/EC2";
 import * as Provider from "@/Provider";
+import * as ec2 from "@distilled.cloud/aws/ec2";
 import * as Test from "./VpcTest.ts";
 import { expect } from "alchemy-test";
 import * as Effect from "effect/Effect";
@@ -62,4 +63,66 @@ test.provider(
       yield* assertVpcGone(deployed.vpc.vpcId);
     }).pipe(logLevel),
   { timeout: 240_000 },
+);
+
+// Replacement must launch a distinct physical instance. The create phase of a
+// replacement runs under a freshly minted generation id, so the tag-based
+// recovery lookup (branded with `alchemy::instance`) can never re-adopt the
+// old generation's live instance — which the cleanup phase then terminates,
+// leaving state pointing at a terminated instance (#1026).
+test.provider.skipIf(!!process.env.FAST)(
+  "replace launches a distinct instance and terminates only the old one",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const imageId = (yield* amazonLinux2023()) ?? "ami-00000000000000000";
+
+      const deploy = (userData: string) =>
+        stack.deploy(
+          Effect.gen(function* () {
+            const vpc = yield* Vpc("ReplaceInstanceVpc", {
+              cidrBlock: "10.0.0.0/16",
+            });
+            const subnet = yield* Subnet("ReplaceInstanceSubnet", {
+              vpcId: vpc.vpcId,
+              cidrBlock: "10.0.1.0/24",
+            });
+            const instance = yield* Instance("ReplaceInstance", {
+              imageId,
+              instanceType: "t3.micro",
+              subnetId: subnet.subnetId,
+              userData,
+              tags: { Name: "alchemy-replace-instance-test" },
+            });
+            return { vpc, instance };
+          }),
+        );
+
+      const first = yield* deploy("#!/bin/bash\necho generation-one\n");
+
+      // userData is a force-new prop, so this deploy plans a replacement.
+      const second = yield* deploy("#!/bin/bash\necho generation-two\n");
+
+      // The replacement created a distinct physical instance...
+      expect(second.instance.instanceId).not.toBe(first.instance.instanceId);
+
+      // ...that is alive after cleanup (out-of-band via distilled)...
+      const live = yield* ec2.describeInstances({
+        InstanceIds: [second.instance.instanceId],
+      });
+      const liveState =
+        live.Reservations?.[0]?.Instances?.[0]?.State?.Name ?? "unknown";
+      expect(["pending", "running"]).toContain(liveState);
+
+      // ...while the old generation was the one terminated.
+      yield* assertInstanceTerminated(first.instance.instanceId);
+
+      yield* stack.destroy();
+
+      // Zero-orphan proof for the replacement generation and the VPC.
+      yield* assertInstanceTerminated(second.instance.instanceId);
+      yield* assertVpcGone(second.vpc.vpcId);
+    }).pipe(logLevel),
+  { timeout: 600_000 },
 );

--- a/packages/alchemy/test/AWS/EC2/Instance.test.ts
+++ b/packages/alchemy/test/AWS/EC2/Instance.test.ts
@@ -28,7 +28,7 @@ test.provider(
     Effect.gen(function* () {
       yield* stack.destroy();
 
-      const imageId = (yield* amazonLinux2023()) ?? "ami-00000000000000000";
+      const imageId = amazonLinux2023();
 
       // The testing account has no default VPC, so provision a VPC + subnet to
       // launch the instance into.
@@ -78,7 +78,7 @@ test.provider.skipIf(!!process.env.FAST)(
     Effect.gen(function* () {
       yield* stack.destroy();
 
-      const imageId = (yield* amazonLinux2023()) ?? "ami-00000000000000000";
+      const imageId = amazonLinux2023();
 
       const deploy = (userData: string) =>
         stack.deploy(

--- a/packages/alchemy/test/AWS/EC2/Instance.ubuntu.smoke.test.ts
+++ b/packages/alchemy/test/AWS/EC2/Instance.ubuntu.smoke.test.ts
@@ -1,0 +1,84 @@
+import * as AWS from "@/AWS";
+import * as Test from "./VpcTest.ts";
+import { expect } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import TestUbuntuInstance from "./fixtures/ubuntu-instance.ts";
+import { assertInstanceTerminated } from "./Gone.ts";
+
+const { test } = Test.make({ providers: AWS.providers() });
+
+// Ubuntu 24.04 end-to-end for the hosted bootstrap (issues #1027 + #1028):
+// Ubuntu AMIs ship without `unzip`, `dnf`, or `yum`, so a served HTTP response
+// proves the bootstrap's `apt-get` branch installed `unzip`, the AWS CLI
+// install and S3 bundle sync succeeded, and the systemd unit's
+// `bun --no-install` start ran the self-contained bundle.
+//
+// Heavy (instance boot + apt-get + AWS CLI install + bun install + S3 sync),
+// so skipped under `FAST=1`.
+test.provider.skipIf(!!process.env.FAST)(
+  "deploys a hosted Ubuntu 24.04 instance that serves HTTP",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const { instanceId, publicIpAddress } = yield* stack.deploy(
+        Effect.gen(function* () {
+          const instance = yield* TestUbuntuInstance;
+          return {
+            instanceId: instance.instanceId,
+            publicIpAddress: instance.publicIpAddress,
+          };
+        }),
+      );
+
+      expect(publicIpAddress).toBeTruthy();
+      const base = `http://${publicIpAddress}:3000`;
+
+      // Poll until the instance boots, apt-get installs unzip, the AWS CLI
+      // installs, bun installs, the bundle syncs from S3, and the systemd
+      // unit serves 200 on :3000. Connection errors before the server binds
+      // are normalised to "not ready" so the poll keeps going.
+      const served = yield* HttpClient.get(`${base}/health`).pipe(
+        Effect.map((res) => res.status === 200),
+        Effect.catch(() => Effect.succeed(false)),
+        Effect.repeat({
+          schedule: Schedule.spaced("8 seconds"),
+          until: (ok) => ok,
+          times: 75,
+        }),
+      );
+      expect(served).toBe(true);
+
+      const getJson = (path: string) =>
+        HttpClient.get(`${base}${path}`).pipe(
+          Effect.flatMap((res) =>
+            res.status === 200
+              ? res.json
+              : Effect.fail(
+                  new Error(`${path} temporarily returned ${res.status}`),
+                ),
+          ),
+          Effect.retry({ schedule: Schedule.spaced("1 second"), times: 10 }),
+        );
+
+      const body = yield* getJson("/health");
+      expect(body).toEqual({ ok: true });
+
+      // Prove the ServerHost.run background loop is executing on the instance.
+      const readTicks = getJson("/ticks").pipe(
+        Effect.map((value) => (value as { ticks: number }).ticks),
+      );
+      const first = yield* readTicks;
+      yield* Effect.sleep("3 seconds");
+      const second = yield* readTicks;
+      expect(second).toBeGreaterThan(first);
+
+      yield* stack.destroy();
+
+      // Zero-orphan proof: the (billed) instance reached a terminal state.
+      yield* assertInstanceTerminated(instanceId);
+    }),
+  { timeout: 1_200_000 },
+);

--- a/packages/alchemy/test/AWS/EC2/InstanceCode.test.ts
+++ b/packages/alchemy/test/AWS/EC2/InstanceCode.test.ts
@@ -22,7 +22,7 @@ test.provider.skipIf(!!process.env.FAST)(
       const fs = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
 
-      const imageId = (yield* amazonLinux2023()) ?? "ami-00000000000000000";
+      const imageId = amazonLinux2023();
       const dir = yield* fs.makeTempDirectory({ prefix: "alchemy-ec2-code-" });
       const mainPath = path.join(dir, "main.ts");
       // A marker-bearing long-running program; only its bundle hash matters

--- a/packages/alchemy/test/AWS/EC2/InstanceCode.test.ts
+++ b/packages/alchemy/test/AWS/EC2/InstanceCode.test.ts
@@ -1,0 +1,73 @@
+import * as AWS from "@/AWS";
+import { amazonLinux2023, Instance, Subnet, Vpc } from "@/AWS/EC2";
+import * as Test from "./VpcTest.ts";
+import { expect } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import { assertInstanceTerminated, assertVpcGone } from "./Gone.ts";
+
+const { test } = Test.make({ providers: AWS.providers() });
+
+// A change confined to the hosted runtime program must participate in
+// planning (#1025): before the fix, `code.hash` was only computed during
+// reconcile, so a code-only edit planned `noop` and the stale bundle stayed
+// live. The program is `isExternal` (a plain script) so the test can rewrite
+// the source between plans.
+test.provider.skipIf(!!process.env.FAST)(
+  "code-only change to the hosted program plans an in-place update",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+
+      const imageId = (yield* amazonLinux2023()) ?? "ami-00000000000000000";
+      const dir = yield* fs.makeTempDirectory({ prefix: "alchemy-ec2-code-" });
+      const mainPath = path.join(dir, "main.ts");
+      // A marker-bearing long-running program; only its bundle hash matters
+      // to this test, never its runtime behavior.
+      const writeProgram = (marker: string) =>
+        fs.writeFileString(
+          mainPath,
+          `setInterval(() => console.log(${JSON.stringify(marker)}), 60_000);\n`,
+        );
+      yield* writeProgram("generation-one");
+
+      const makeStack = Effect.gen(function* () {
+        const vpc = yield* Vpc("CodeInstanceVpc", {
+          cidrBlock: "10.0.0.0/16",
+        });
+        const subnet = yield* Subnet("CodeInstanceSubnet", {
+          vpcId: vpc.vpcId,
+          cidrBlock: "10.0.1.0/24",
+        });
+        const instance = yield* Instance("CodeInstance", {
+          imageId,
+          instanceType: "t3.micro",
+          subnetId: subnet.subnetId,
+          main: mainPath,
+          isExternal: true,
+        });
+        return { vpc, instance };
+      });
+
+      const { vpc, instance } = yield* stack.deploy(makeStack);
+
+      // Unchanged source replans as noop (bundling is deterministic)...
+      const before = yield* stack.plan(makeStack);
+      expect(before.resources.CodeInstance).toMatchObject({ action: "noop" });
+
+      // ...and a code-only edit plans an in-place update.
+      yield* writeProgram("generation-two");
+      const after = yield* stack.plan(makeStack);
+      expect(after.resources.CodeInstance).toMatchObject({ action: "update" });
+
+      yield* stack.destroy();
+
+      // Zero-orphan proof.
+      yield* assertInstanceTerminated(instance.instanceId);
+      yield* assertVpcGone(vpc.vpcId);
+    }),
+  { timeout: 600_000 },
+);

--- a/packages/alchemy/test/AWS/EC2/Storage.smoke.test.ts
+++ b/packages/alchemy/test/AWS/EC2/Storage.smoke.test.ts
@@ -36,7 +36,7 @@ test.provider(
     Effect.gen(function* () {
       yield* stack.destroy();
 
-      const imageId = (yield* amazonLinux2023()) ?? "ami-00000000000000000";
+      const imageId = amazonLinux2023();
 
       const deployed = yield* stack.deploy(
         Effect.gen(function* () {

--- a/packages/alchemy/test/AWS/EC2/fixtures/bindings-handler.ts
+++ b/packages/alchemy/test/AWS/EC2/fixtures/bindings-handler.ts
@@ -51,9 +51,9 @@ export class Ec2BindingsFunction extends AWS.Lambda.Function<AWS.Lambda.Function
 /**
  * Shared fleet for the bindings E2E: a dedicated VPC/subnet (the testing
  * account has no default VPC), a t3.micro instance, a 1 GiB volume, and an
- * empty security group. The AMI is resolved only at deploy time — at runtime
- * the resources resolve to references, so the lookup is guarded off inside
- * the deployed Lambda.
+ * empty security group. The AMI is an `Output` resolved at deploy time only,
+ * so this composition is safe to re-execute inside the deployed Lambda
+ * without runtime guards.
  */
 export class BindingsFleet extends Context.Service<
   BindingsFleet,
@@ -63,10 +63,7 @@ export class BindingsFleet extends Context.Service<
 export const BindingsFleetLive = Layer.effect(
   BindingsFleet,
   Effect.gen(function* () {
-    const isDeploy = !globalThis.__ALCHEMY_RUNTIME__;
-    const imageId = isDeploy
-      ? ((yield* amazonLinux2023()) ?? "ami-00000000000000000")
-      : "ami-00000000000000000";
+    const imageId = amazonLinux2023();
 
     const vpc = yield* Vpc("BindingsVpc", { cidrBlock: "10.61.0.0/16" });
     const subnet = yield* Subnet("BindingsSubnet", {

--- a/packages/alchemy/test/AWS/EC2/fixtures/instance.ts
+++ b/packages/alchemy/test/AWS/EC2/fixtures/instance.ts
@@ -28,30 +28,10 @@ export const keyPair = AWS.EC2.KeyPair("Ec2E2EKeyPair", {
 export default class TestInstance extends AWS.EC2.Instance<TestInstance>()(
   "Ec2E2EInstance",
   Effect.gen(function* () {
-    // Props (image AMI lookup, networking) are only needed at plan/deploy
-    // time. Inside the deployed instance the resource already exists and only
-    // `exports.program` is used, so short-circuit before the infra-resolving
-    // calls — `__ALCHEMY_RUNTIME__` is folded to `true` in the bundle, so this
-    // branch (and the AWS SDK it pulls in) is dead-code-eliminated from the
-    // image.
-    if (globalThis.__ALCHEMY_RUNTIME__) {
-      // Only the required props need a value here; the infra-derived ones
-      // (subnetId / securityGroupIds / …) are unused at runtime and are left
-      // unset so the stub still satisfies `InstanceProps`.
-      return {
-        main: import.meta.filename,
-        imageId: "",
-        instanceType: "t3.small",
-        port: 3000,
-      };
-    }
-
-    const imageId = yield* AWS.EC2.amazonLinux2023();
-    if (!imageId) {
-      return yield* Effect.die(
-        new Error("could not resolve an Amazon Linux 2023 AMI"),
-      );
-    }
+    // This composition is re-executed inside the deployed instance's bundle:
+    // the AMI lookup is an `Output` resolved at plan/deploy time only, and
+    // resource yields resolve to references at runtime, so no runtime guard
+    // is needed.
     const network = yield* AWS.EC2.Network("Ec2E2ENetwork", {
       cidrBlock: "10.81.0.0/16",
       availabilityZones: 1,
@@ -89,7 +69,7 @@ export default class TestInstance extends AWS.EC2.Instance<TestInstance>()(
 
     return {
       main: import.meta.filename,
-      imageId,
+      imageId: AWS.EC2.amazonLinux2023(),
       instanceType: "t3.small",
       subnetId: network.publicSubnetIds[0],
       securityGroupIds: [securityGroup.groupId],

--- a/packages/alchemy/test/AWS/EC2/fixtures/ubuntu-instance.ts
+++ b/packages/alchemy/test/AWS/EC2/fixtures/ubuntu-instance.ts
@@ -24,25 +24,10 @@ export const ubuntuKeyPair = AWS.EC2.KeyPair("Ec2UbuntuKeyPair", {
 export default class TestUbuntuInstance extends AWS.EC2.Instance<TestUbuntuInstance>()(
   "Ec2UbuntuE2EInstance",
   Effect.gen(function* () {
-    // Props (image AMI lookup, networking) are only needed at plan/deploy
-    // time; inside the deployed instance only `exports.program` is used, so
-    // short-circuit before the infra-resolving calls (`__ALCHEMY_RUNTIME__`
-    // is folded to `true` in the bundle and this branch is eliminated).
-    if (globalThis.__ALCHEMY_RUNTIME__) {
-      return {
-        main: import.meta.filename,
-        imageId: "",
-        instanceType: "t3.small",
-        port: 3000,
-      };
-    }
-
-    const imageId = yield* AWS.EC2.ubuntu2404();
-    if (!imageId) {
-      return yield* Effect.die(
-        new Error("could not resolve an Ubuntu 24.04 AMI"),
-      );
-    }
+    // This composition is re-executed inside the deployed instance's bundle:
+    // the AMI lookup is an `Output` resolved at plan/deploy time only, and
+    // resource yields resolve to references at runtime, so no runtime guard
+    // is needed.
     const network = yield* AWS.EC2.Network("Ec2UbuntuE2ENetwork", {
       cidrBlock: "10.82.0.0/16",
       availabilityZones: 1,
@@ -79,7 +64,7 @@ export default class TestUbuntuInstance extends AWS.EC2.Instance<TestUbuntuInsta
 
     return {
       main: import.meta.filename,
-      imageId,
+      imageId: AWS.EC2.ubuntu2404(),
       instanceType: "t3.small",
       subnetId: network.publicSubnetIds[0],
       securityGroupIds: [securityGroup.groupId],

--- a/packages/alchemy/test/AWS/EC2/fixtures/ubuntu-instance.ts
+++ b/packages/alchemy/test/AWS/EC2/fixtures/ubuntu-instance.ts
@@ -1,0 +1,119 @@
+import * as AWS from "@/AWS";
+import { ServerHost } from "@/Server/Process.ts";
+import * as Effect from "effect/Effect";
+import * as Ref from "effect/Ref";
+import * as Schedule from "effect/Schedule";
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+/**
+ * Alchemy-managed EC2 key pair granting SSH access to the Ubuntu instance for
+ * debugging bootstrap failures.
+ */
+export const ubuntuKeyPair = AWS.EC2.KeyPair("Ec2UbuntuKeyPair", {
+  keyType: "ed25519",
+});
+
+/**
+ * Ubuntu 24.04 variant of the hosted-instance e2e fixture (issues #1027 and
+ * #1028): Ubuntu AMIs ship without `unzip`, `dnf`, or `yum`, so serving HTTP
+ * from the hosted runtime proves the bootstrap's `apt-get` branch installed
+ * `unzip`, the AWS CLI install + S3 bundle sync succeeded, and the systemd
+ * unit's `bun --no-install` start worked end-to-end.
+ */
+export default class TestUbuntuInstance extends AWS.EC2.Instance<TestUbuntuInstance>()(
+  "Ec2UbuntuE2EInstance",
+  Effect.gen(function* () {
+    // Props (image AMI lookup, networking) are only needed at plan/deploy
+    // time; inside the deployed instance only `exports.program` is used, so
+    // short-circuit before the infra-resolving calls (`__ALCHEMY_RUNTIME__`
+    // is folded to `true` in the bundle and this branch is eliminated).
+    if (globalThis.__ALCHEMY_RUNTIME__) {
+      return {
+        main: import.meta.filename,
+        imageId: "",
+        instanceType: "t3.small",
+        port: 3000,
+      };
+    }
+
+    const imageId = yield* AWS.EC2.ubuntu2404();
+    if (!imageId) {
+      return yield* Effect.die(
+        new Error("could not resolve an Ubuntu 24.04 AMI"),
+      );
+    }
+    const network = yield* AWS.EC2.Network("Ec2UbuntuE2ENetwork", {
+      cidrBlock: "10.82.0.0/16",
+      availabilityZones: 1,
+    });
+    const securityGroup = yield* AWS.EC2.SecurityGroup("Ec2UbuntuE2ESg", {
+      vpcId: network.vpcId,
+      description: "alchemy ec2 ubuntu instance e2e",
+      ingress: [
+        {
+          ipProtocol: "tcp",
+          fromPort: 3000,
+          toPort: 3000,
+          cidrIpv4: "0.0.0.0/0",
+          description: "app",
+        },
+        {
+          ipProtocol: "tcp",
+          fromPort: 22,
+          toPort: 22,
+          cidrIpv4: "0.0.0.0/0",
+          description: "ssh",
+        },
+      ],
+      egress: [
+        {
+          ipProtocol: "-1",
+          cidrIpv4: "0.0.0.0/0",
+          description: "all outbound",
+        },
+      ],
+    });
+
+    const key = yield* ubuntuKeyPair;
+
+    return {
+      main: import.meta.filename,
+      imageId,
+      instanceType: "t3.small",
+      subnetId: network.publicSubnetIds[0],
+      securityGroupIds: [securityGroup.groupId],
+      associatePublicIpAddress: true,
+      port: 3000,
+      keyName: key.keyName,
+    };
+  }),
+  Effect.gen(function* () {
+    const host = yield* ServerHost;
+    const ticks = yield* Ref.make(0);
+
+    // Long-running background loop (the `host.run` pattern from #706).
+    yield* host.run(
+      Ref.update(ticks, (n) => n + 1).pipe(
+        Effect.repeat(Schedule.spaced("1 second")),
+        Effect.asVoid,
+      ),
+    );
+
+    return {
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        const url = new URL(request.url, "http://instance");
+        if (url.pathname === "/health") {
+          return yield* HttpServerResponse.json({ ok: true });
+        }
+        if (url.pathname === "/ticks") {
+          return yield* HttpServerResponse.json({
+            ticks: yield* Ref.get(ticks),
+          });
+        }
+        return HttpServerResponse.text("hello from ubuntu ec2 instance");
+      }),
+    };
+  }),
+) {}

--- a/website/src/content/docs/aws/compute/ec2.mdx
+++ b/website/src/content/docs/aws/compute/ec2.mdx
@@ -23,13 +23,12 @@ The minimal instance is an AMI plus an instance type. AMI IDs
 are per-region, so resolve one with Alchemy's image helpers
 instead of hard-coding — `amazonLinux()` finds the latest Amazon
 Linux AMI (there are also `amazonLinux2023`, `amazonLinux2`,
-`ubuntu2404`, `ubuntu2204`, and a general `image()` finder):
+`ubuntu2404`, `ubuntu2204`, and a general `image()` finder).
+Each returns an `Output<string>` resolved at deploy time:
 
 ```typescript
-const imageId = yield* AWS.EC2.amazonLinux();
-
 const instance = yield* AWS.EC2.Instance("AppInstance", {
-  imageId,
+  imageId: AWS.EC2.amazonLinux(),
   instanceType: "t3.micro",
   subnetId: subnet.subnetId,
 });
@@ -44,8 +43,11 @@ for every prop and attribute.
 
 Give the instance a `main` entrypoint and it becomes a runtime,
 same class pattern as Lambda and ECS. Because instance props
-(the AMI lookup, the network) are themselves resolved by
-Effects, the props slot takes an `Effect.gen` block:
+(the network, the AMI) are resolved by the stack, the props slot
+takes an `Effect.gen` block. The composition is also re-executed
+inside the deployed instance's bundle — that's safe as-is:
+resource yields resolve to references at runtime, and the AMI
+helper returns an `Output` that only resolves at deploy time:
 
 ```typescript
 // src/server.ts
@@ -57,21 +59,6 @@ import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 export default class Server extends AWS.EC2.Instance<Server>()(
   "Server",
   Effect.gen(function* () {
-    // Props run at deploy time. Inside the deployed instance only
-    // the program below matters, so short-circuit the infra
-    // lookups — the bundler folds `__ALCHEMY_RUNTIME__` to `true`
-    // and dead-code-eliminates this branch (and the AWS SDK with
-    // it) from the machine's bundle.
-    if (globalThis.__ALCHEMY_RUNTIME__) {
-      return {
-        main: import.meta.url,
-        imageId: "",
-        instanceType: "t3.small",
-        port: 3000,
-      };
-    }
-
-    const imageId = yield* AWS.EC2.amazonLinux();
     const network = yield* AWS.EC2.Network("AppNetwork", {
       cidrBlock: "10.81.0.0/16",
       availabilityZones: 1,
@@ -99,7 +86,7 @@ export default class Server extends AWS.EC2.Instance<Server>()(
 
     return {
       main: import.meta.url,
-      imageId,
+      imageId: AWS.EC2.amazonLinux(),
       instanceType: "t3.small",
       subnetId: network.publicSubnetIds[0],
       securityGroupIds: [securityGroup.groupId],

--- a/website/src/content/docs/infrastructure-as-code/outputs.mdx
+++ b/website/src/content/docs/infrastructure-as-code/outputs.mdx
@@ -84,6 +84,36 @@ Output.asOutput(existingOutput);         // returns it unchanged
 
 Use this when writing helpers that should accept "anything output-y."
 
+## `fromEffect`
+
+Lifts a plan-time Effect into an `Output`. The effect runs when the
+stack resolves the Output during plan/deploy — with the stack's
+services (cloud credentials, region, ...) provided — and never inside
+a deployed runtime:
+
+```typescript
+Output.fromEffect(lookupLatestAmi());   // Output<string>
+```
+
+This is the seam for lookup helpers that read cloud state to produce
+a prop value. Because constructing the Output is inert, such helpers
+are safe to call from composition code that is re-executed inside a
+deployed Function, Worker, or Instance bundle — no
+`__ALCHEMY_RUNTIME__` guard needed. The AMI finders
+(`AWS.EC2.amazonLinux2023()`, `AWS.EC2.ubuntu2404()`, ...) are built
+on it:
+
+```typescript
+const instance = yield* AWS.EC2.Instance("web", {
+  imageId: AWS.EC2.amazonLinux2023(),
+  instanceType: "t3.micro",
+  subnetId: subnet.subnetId,
+});
+```
+
+The effect must not fail (`E = never`) — die with a descriptive error
+for unresolvable lookups.
+
 ## `map`
 
 `Output.map` transforms an `Output<A>` into an `Output<B>` without


### PR DESCRIPTION
AMI lookups are now `Output`s, safe in both plan and runtime environments, plus four EC2 hosted-runtime fixes (#1025–#1028) — each live-verified against the real cloud.

### DX: AMI lookups without runtime guards

Hosted compositions are re-executed inside the deployed bundle, so an Effect-based AMI lookup forced every user to write this hack:

```ts
// before
export default class Server extends AWS.EC2.Instance<Server>()(
  "Server",
  Effect.gen(function* () {
    if (globalThis.__ALCHEMY_RUNTIME__) {
      // stub props so the AMI lookup doesn't run (and crash) on the instance
      return { main: import.meta.filename, imageId: "", instanceType: "t3.small", port: 3000 };
    }
    const imageId = yield* AWS.EC2.ubuntu2404();
    if (!imageId) {
      return yield* Effect.die(new Error("could not resolve an Ubuntu 24.04 AMI"));
    }
    const network = yield* AWS.EC2.Network("Net", { availabilityZones: 1 });
    return { main: import.meta.filename, imageId, instanceType: "t3.small", subnetId: network.publicSubnetIds[0], port: 3000 };
  }),
  program,
) {}
```

The helpers (`image`, `amazonLinux2023`, `amazonLinux2`, `amazonLinux`, `ubuntu2404`, `ubuntu2204`) now return `Output<string>` — resolved at plan/deploy time, inert inside the deployed bundle, and dying with a descriptive error when nothing matches:

```ts
// after
export default class Server extends AWS.EC2.Instance<Server>()(
  "Server",
  Effect.gen(function* () {
    const network = yield* AWS.EC2.Network("Net", { availabilityZones: 1 });
    return {
      main: import.meta.filename,
      imageId: AWS.EC2.ubuntu2404(),
      instanceType: "t3.small",
      subnetId: network.publicSubnetIds[0],
      port: 3000,
    };
  }),
  program,
) {}
```

Built on the new `Output.fromEffect`, the general seam for plan-time lookups:

```ts
export const fromEffect: <A, Req>(effect: Effect.Effect<A, never, Req>) => Output<A, Req>;
```

Running the fixtures guard-free exposed two latent gaps in the hosted entry, both fixed: the env file now injects `AWS_REGION` (the lazy `Region.fromEnv` only died when runtime code actually read the region, e.g. `EC2.Network`'s AZ branch), and the entry uses `Credentials.fromChain()` (env → ini → IMDS instance profile) instead of `Credentials.fromEnv()`, which can never resolve on an instance-profile box.

### Hosted runtime fixes

Closes #1028 — the bootstrap installs `unzip` via `apt-get` on Ubuntu AMIs:

```sh
|| (command -v apt-get >/dev/null 2>&1 && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y unzip)
```

Closes #1027 — the generated systemd unit starts the bundle with `--no-install` so bun fails fast on an incomplete bundle instead of hanging in its auto-install path:

```ini
ExecStart=/root/.bun/bin/bun --no-install /opt/<unit>/index.mjs
```

Closes #1025 — the hosted bundle hash participates in planning: `diff` re-bundles and compares against the deployed `code.hash` (the `AWS.Lambda.Function` pattern), so a code-only change plans an in-place update that re-uploads the bundle and reboots the instance. Applied to both `AWS.EC2.Instance` and the hosted `AWS.AutoScaling.LaunchTemplate`.

Closes #1026 — instances are branded with a per-generation `alchemy::instance` tag and the tag-based recovery lookup filters on it: an interrupted create (same generation id) still recovers its orphan, while a replacement's create phase (fresh generation id) can no longer re-adopt the live old instance that cleanup then terminates.

### Live verification

- New `Instance.ubuntu.smoke.test.ts`: a hosted Ubuntu 24.04 instance serves HTTP end-to-end with a guard-free fixture, proving the `apt-get` branch, AWS CLI install, S3 sync, `--no-install` start, and runtime-safe composition (#1027, #1028).
- `Instance.smoke.test.ts` green on Amazon Linux 2023 with the guard removed from its fixture.
- New `InstanceCode.test.ts`: unchanged source replans `noop`; a code-only edit plans `update` (#1025).
- New replacement test in `Instance.test.ts`: force-new `userData` launches a distinct physical instance, the old generation terminates, the new one stays alive, zero orphans after destroy (#1026).
- `LaunchTemplate.test.ts` green with the Output `imageId` flowing through plain resource props.
