### PR TITLE
fix(cloudflare): add flagship:write to the OAuth scope catalog

### DIFF
--- a/packages/alchemy/src/Cloudflare/Auth/AuthProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Auth/AuthProvider.ts
@@ -703,6 +703,7 @@ export const ALL_SCOPES = {
   "dns_settings:read": "Grants read level access to Cloudflare DNS Settings",
   "firstpartytags:write":
     "Can see, edit and publish Google tag gateway configuration.",
+  "flagship:write": "See and change Flagship feature flags and apps",
   "lb:edit": "Grants edit level access to lb and lb pools",
   "lb:read": "Grants read level access to lb and lb pools",
   "logpush:read": "See Cloudflare Logpush data",
@@ -777,6 +778,7 @@ export const DEFAULT_SCOPES = [
   "connectivity:admin",
   "containers:write",
   "d1:write",
+  "flagship:write",
   "pages:write",
   "pipelines:write",
   "queues:write",


### PR DESCRIPTION
The OAuth scope catalog has no Flagship entry, so OAuth-authenticated profiles can't use `Cloudflare.Flagship.*` resources — the first call fails:

```
Unauthorized: Authentication error
  at GET /accounts/{account_id}/flagship/apps
```

Adds `flagship:write` to `ALL_SCOPES` and `DEFAULT_SCOPES`. Name and description match Cloudflare's own catalog (`workers-auth/src/core/scopes.ts` in workers-sdk), where wrangler defaults it.

**Blocked on client registration, verified:** Cloudflare's authorize endpoint rejects the scope for alchemy's OAuth client:

```
error=invalid_scope
error_description=The OAuth 2.0 Client is not allowed to request scope 'flagship:write'.
```

So this needs Cloudflare to allowlist `flagship:write` on client `6d8c2255-0773-45f6-b376-2914632e6f91` first; until then the `DEFAULT_SCOPES` line would break every login. Draft until that lands — happy to split the catalog-only line out if you'd rather ship it independently.
