### PR TITLE
feat(binding): Binding.Service.execute — plan-time data-source invokes

### DIFF
--- a/packages/alchemy/src/AWS/EC2/GetAmi.ts
+++ b/packages/alchemy/src/AWS/EC2/GetAmi.ts
@@ -1,0 +1,65 @@
+import type * as ec2 from "@distilled.cloud/aws/ec2";
+import type * as Effect from "effect/Effect";
+import * as Binding from "../../Binding.ts";
+import type { FindImageOptions } from "./Image.ts";
+
+/**
+ * The `DescribeImages`-backed AMI lookup (IAM action `ec2:DescribeImages`;
+ * `Describe*` actions do not support resource-level permissions, so the
+ * runtime grant is on `*`). Returns the newest available image matching the
+ * filters, or `undefined` when nothing matches.
+ *
+ * As a **data source**, invoke it at plan time via {@link getAmi} — the
+ * result is an `Output` resolved during plan/deploy and inert inside
+ * deployed bundles. As a **runtime binding**, bind it inside a Function to
+ * look images up at runtime with the IAM grant attached automatically.
+ * Provide the implementation with
+ * `Effect.provide(AWS.EC2.GetAmiHttp)` (already registered by
+ * `AWS.providers()` for plan-time use).
+ * @binding
+ * @section Looking Up Images
+ * @example Plan-time lookup (data source)
+ * ```typescript
+ * const instance = yield* AWS.EC2.Instance("web", {
+ *   imageId: AWS.EC2.getAmi({
+ *     owners: ["amazon"],
+ *     name: ["al2023-ami-2023.*"],
+ *   }).ImageId.as<string>(),
+ *   instanceType: "t3.micro",
+ *   subnetId: subnet.subnetId,
+ * });
+ * ```
+ * @example Runtime lookup inside a Function
+ * ```typescript
+ * // init — bind the operation
+ * const getAmi = yield* AWS.EC2.GetAmi({
+ *   owners: ["amazon"],
+ *   name: ["al2023-ami-2023.*"],
+ * });
+ *
+ * // runtime — read the newest matching image
+ * const latest = yield* getAmi();
+ * console.log(latest?.ImageId, latest?.CreationDate);
+ * ```
+ */
+export interface GetAmi extends Binding.Service<
+  GetAmi,
+  "AWS.EC2.GetAmi",
+  (
+    options: FindImageOptions,
+  ) => Effect.Effect<
+    () => Effect.Effect<ec2.Image | undefined, ec2.DescribeImagesError>
+  >
+> {}
+
+export const GetAmi = Binding.Service<GetAmi>("AWS.EC2.GetAmi");
+
+/**
+ * Plan-time AMI lookup — the data-source form of {@link GetAmi} (what
+ * Terraform calls a data source and Pulumi an invoke). Returns an
+ * `Output<ec2.Image | undefined>` resolved during plan/deploy; safe to call
+ * from composition code that is re-executed inside a deployed runtime
+ * bundle. Prefer {@link image} (or the distro presets) when you only need
+ * the AMI ID and want a missing image to fail the plan.
+ */
+export const getAmi = GetAmi.execute;

--- a/packages/alchemy/src/AWS/EC2/GetAmiHttp.ts
+++ b/packages/alchemy/src/AWS/EC2/GetAmiHttp.ts
@@ -1,0 +1,63 @@
+import * as ec2 from "@distilled.cloud/aws/ec2";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Binding from "../../Binding.ts";
+import { isBindingHost } from "../Lambda/Function.ts";
+import { GetAmi } from "./GetAmi.ts";
+import type { FindImageOptions } from "./Image.ts";
+import { isInstance } from "./Instance.ts";
+
+// Bespoke (not the shared scaffold): the lookup filters and sorts the
+// paginated image list to pick the newest available match, and the binding
+// is account-scoped — there is no resource to bind, only options.
+export const GetAmiHttp = Layer.effect(
+  GetAmi,
+  Effect.gen(function* () {
+    const describeImages = yield* ec2.describeImages;
+
+    return Effect.fn(function* (options: FindImageOptions) {
+      if (!globalThis.__ALCHEMY_RUNTIME__) {
+        const host = yield* Binding.Host;
+        if (isBindingHost(host) || isInstance(host)) {
+          yield* host.bind`Allow(${host}, AWS.EC2.GetAmi)`({
+            policyStatements: [
+              {
+                Effect: "Allow",
+                Action: ["ec2:DescribeImages"],
+                Resource: ["*"],
+              },
+            ],
+          });
+        }
+      }
+
+      const {
+        owners,
+        name,
+        architecture = "x86_64",
+        rootDeviceType = "ebs",
+        virtualizationType = "hvm",
+      } = options;
+
+      return Effect.fn("AWS.EC2.GetAmi")(function* () {
+        const response = yield* describeImages({
+          Owners: owners,
+          Filters: [
+            { Name: "name", Values: [...name] },
+            { Name: "architecture", Values: [architecture] },
+            { Name: "state", Values: ["available"] },
+            { Name: "root-device-type", Values: [rootDeviceType] },
+            { Name: "virtualization-type", Values: [virtualizationType] },
+          ],
+        });
+        return (response.Images ?? [])
+          .slice()
+          .sort((a: ec2.Image, b: ec2.Image) =>
+            String(b.CreationDate ?? "").localeCompare(
+              String(a.CreationDate ?? ""),
+            ),
+          )[0];
+      });
+    });
+  }),
+);

--- a/packages/alchemy/src/AWS/EC2/Image.ts
+++ b/packages/alchemy/src/AWS/EC2/Image.ts
@@ -1,6 +1,6 @@
-import * as ec2 from "@distilled.cloud/aws/ec2";
 import * as Effect from "effect/Effect";
 import * as Output from "../../Output.ts";
+import { getAmi } from "./GetAmi.ts";
 
 /**
  * CPU architecture of the AMI to look up.
@@ -43,58 +43,11 @@ export interface FindImageOptions {
   virtualizationType?: "hvm" | "paravirtual";
 }
 
-const findLatestImage = Effect.fn(function* ({
-  owners,
-  name,
-  architecture = "x86_64",
-  // description = "public image",
-  rootDeviceType = "ebs",
-  virtualizationType = "hvm",
-}: FindImageOptions) {
-  const response = yield* ec2
-    .describeImages({
-      Owners: owners,
-      Filters: [
-        { Name: "name", Values: [...name] },
-        { Name: "architecture", Values: [architecture] },
-        { Name: "state", Values: ["available"] },
-        { Name: "root-device-type", Values: [rootDeviceType] },
-        { Name: "virtualization-type", Values: [virtualizationType] },
-      ],
-    })
-    .pipe(Effect.orDie);
-
-  const latest = (response.Images ?? [])
-    .slice()
-    .sort((a: ec2.Image, b: ec2.Image) =>
-      String(b.CreationDate ?? "").localeCompare(String(a.CreationDate ?? "")),
-    )[0];
-
-  if (!latest?.ImageId) {
-    return undefined;
-  }
-
-  return latest.ImageId;
-});
-
-const findFirstImage = Effect.fn(function* <Req = never>(
-  lookups: ReadonlyArray<Effect.Effect<string | undefined, never, Req>>,
-  errorMessage: string,
-) {
-  for (const lookup of lookups) {
-    const result = yield* lookup;
-    if (result) {
-      return result;
-    }
-  }
-  return yield* Effect.die(new Error(errorMessage));
-});
-
-const findImage = (options: FindImageOptions) =>
-  findLatestImage(options).pipe(
-    Effect.flatMap((imageId) =>
-      imageId
-        ? Effect.succeed(imageId)
+const requireImageId = (options: FindImageOptions) =>
+  getAmi(options).pipe(
+    Output.mapEffect((image) =>
+      image?.ImageId
+        ? Effect.succeed(image.ImageId)
         : Effect.die(
             new Error(
               `Could not resolve ${options.description ?? "an AMI"} matching ${options.name.join(", ")}`,
@@ -106,12 +59,12 @@ const findImage = (options: FindImageOptions) =>
 /**
  * Look up the latest available AMI ID matching the given filters.
  *
- * Returns an `Output<string>` that resolves at plan/deploy time (and dies
- * with a descriptive error when nothing matches), so it is safe to use both
- * in resource props and in composition code that is re-executed inside a
- * deployed runtime — the lookup never runs on the deployed machine. Use the
- * preset helpers ({@link amazonLinux2023}, {@link ubuntu2404}, ...) for
- * common distros.
+ * Returns an `Output<string>` resolved at plan/deploy time via the
+ * {@link getAmi} data source (and dies with a descriptive error when
+ * nothing matches), so it is safe to use both in resource props and in
+ * composition code that is re-executed inside a deployed runtime — the
+ * lookup never runs on the deployed machine. Use the preset helpers
+ * ({@link amazonLinux2023}, {@link ubuntu2404}, ...) for common distros.
  *
  * @example Find a custom AMI
  * ```typescript
@@ -126,8 +79,7 @@ const findImage = (options: FindImageOptions) =>
  * });
  * ```
  */
-export const image = (options: FindImageOptions) =>
-  Output.fromEffect(findImage(options));
+export const image = (options: FindImageOptions) => requireImageId(options);
 
 const amazonLinux2023Options = (options?: {
   architecture?: ImageArchitecture;
@@ -180,13 +132,14 @@ export const amazonLinux2 = (options?: { architecture?: ImageArchitecture }) =>
  * neither is available.
  */
 export const amazonLinux = (options?: { architecture?: ImageArchitecture }) =>
-  Output.fromEffect(
-    findFirstImage(
-      [
-        findLatestImage(amazonLinux2023Options(options)),
-        findLatestImage(amazonLinux2Options(options)),
-      ],
-      "Could not resolve a public Amazon Linux AMI",
+  getAmi(amazonLinux2023Options(options)).pipe(
+    Output.flatMap((al2023) =>
+      al2023?.ImageId
+        ? Output.literal(al2023.ImageId)
+        : requireImageId({
+            ...amazonLinux2Options(options),
+            description: "a public Amazon Linux AMI",
+          }),
     ),
   );
 

--- a/packages/alchemy/src/AWS/EC2/index.ts
+++ b/packages/alchemy/src/AWS/EC2/index.ts
@@ -10,6 +10,8 @@ export * from "./DhcpOptions.ts";
 export * from "./EgressOnlyInternetGateway.ts";
 export * from "./EIP.ts";
 export * from "./FlowLog.ts";
+export * from "./GetAmi.ts";
+export * from "./GetAmiHttp.ts";
 export * from "./GetConsoleOutput.ts";
 export * from "./GetConsoleOutputHttp.ts";
 export * from "./GetPasswordData.ts";

--- a/packages/alchemy/src/AWS/Lambda/MicrovmBinding.ts
+++ b/packages/alchemy/src/AWS/Lambda/MicrovmBinding.ts
@@ -351,7 +351,7 @@ export const makeImageBinding = <Req, Res, Err, Self>(
       return Effect.fn(function* (image: MicrovmImage) {
         const host = yield* Binding.Host;
         const statements = imagePolicyStatements(image, options);
-        const label = `Allow(${host.LogicalId}, AWS.Lambda.${options.name}(${image.LogicalId}))`;
+        const label = `Allow(${host?.LogicalId}, AWS.Lambda.${options.name}(${image.LogicalId}))`;
 
         // Accessors (registered on the host at deploy, resolved at runtime).
         const imageArn = yield* image.imageArn;
@@ -365,7 +365,7 @@ export const makeImageBinding = <Req, Res, Err, Self>(
           if (!globalThis.__ALCHEMY_RUNTIME__) {
             yield* host.bind`${label}`({ policyStatements: statements });
           }
-        } else if (isWorkerHost(host)) {
+        } else if (host !== undefined && isWorkerHost(host)) {
           access = yield* ensureWorkerAwsAccess(host);
           if (!globalThis.__ALCHEMY_RUNTIME__) {
             yield* access.role.bind`${label}`({ policyStatements: statements });
@@ -413,7 +413,7 @@ export const makeAccountBinding = <Req, Res, Err, Self>(
       const run = yield* options.operation;
       return Effect.fn(function* () {
         const host = yield* Binding.Host;
-        const label = `Allow(${host.LogicalId}, AWS.Lambda.${options.name}())`;
+        const label = `Allow(${host?.LogicalId}, AWS.Lambda.${options.name}())`;
         const statements: Input<PolicyStatement>[] = [
           { Effect: "Allow", Action: options.actions, Resource: ["*"] },
         ];
@@ -423,7 +423,7 @@ export const makeAccountBinding = <Req, Res, Err, Self>(
           if (!globalThis.__ALCHEMY_RUNTIME__) {
             yield* host.bind`${label}`({ policyStatements: statements });
           }
-        } else if (isWorkerHost(host)) {
+        } else if (host !== undefined && isWorkerHost(host)) {
           access = yield* ensureWorkerAwsAccess(host);
           if (!globalThis.__ALCHEMY_RUNTIME__) {
             yield* access.role.bind`${label}`({ policyStatements: statements });

--- a/packages/alchemy/src/AWS/Providers.ts
+++ b/packages/alchemy/src/AWS/Providers.ts
@@ -1669,6 +1669,10 @@ export const providers = () =>
         DockerLive,
       ),
     ),
+    // Plan-executable data-source capabilities: registering the impl layers
+    // at the stack level lets `Capability.execute(...)` Outputs (e.g.
+    // `AWS.EC2.getAmi`) resolve during plan.
+    Layer.provideMerge(EC2.GetAmiHttp),
     Layer.provideMerge(Region.fromEnvironment),
     Layer.provideMerge(Credentials.fromEnvironment),
     Layer.provideMerge(Endpoint.fromEnvironment),

--- a/packages/alchemy/src/Binding.ts
+++ b/packages/alchemy/src/Binding.ts
@@ -1,5 +1,6 @@
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import type { Input } from "./Input.ts";
 import * as Output from "./Output.ts";
 import type { ResourceLike } from "./Resource.ts";
@@ -86,9 +87,9 @@ export interface Service<
    * The capability's implementation layer must be registered on the stack
    * (cloud `providers()` layers include their plan-executable capabilities).
    *
-   * The binding host is stubbed during execution, so implementations skip
-   * their `host.bind` IAM/env wiring — only the read runs. Failures die and
-   * fail the plan.
+   * Execution is hostless — {@link Host} resolves `undefined`, so
+   * implementations skip their `host.bind` IAM/env wiring and only the read
+   * runs. Failures die and fail the plan.
    *
    * Only capabilities whose runtime client is nullary (`() => Effect<A>`)
    * are executable; parameterized clients type as `never` here.
@@ -125,18 +126,14 @@ export const Service = <
         { concurrency: "unbounded" },
       ).pipe(Effect.flatMap((resolved) => f(...resolved))),
     );
-  // Plan-time invoke (see the `execute` doc on `Service`): bind with a stub
-  // host (so impls skip their `host.bind` wiring — the isBindingHost /
-  // isInstance narrowing rejects it), run the nullary client, and lift the
-  // result into an Output the planner resolves with the stack's services.
+  // Plan-time invoke (see the `execute` doc on `Service`): bind hostless —
+  // `Binding.Host` is total and resolves `undefined`, so impls skip their
+  // `host.bind` wiring — run the nullary client, and lift the result into an
+  // Output the planner resolves with the stack's services.
   (callable as any).execute = (...args: any[]) =>
     Output.fromEffect(
       callable(...args).pipe(
         Effect.flatMap((client: any) => client()),
-        Effect.provideService(Self as any, {
-          Type: "Alchemy::Invoke",
-          LogicalId: id,
-        }),
         Effect.orDie,
       ) as Effect.Effect<any, never, any>,
     );
@@ -149,6 +146,14 @@ export const Service = <
  * is only ever read at DEPLOY time, inside the `if (!globalThis.__ALCHEMY_RUNTIME__)`
  * guard of a binding's impl layer — at runtime the host is absent and the guard
  * skips it, so leaking a `Self` requirement onto the runtime client would be
- * wrong. Narrow it with `isWorker`/`isFunction` before calling `host.bind`.
+ * wrong.
+ *
+ * Total: resolves to `undefined` when no host is ambient — a plan-time
+ * {@link Service.execute} invoke, or a binding client provided directly in a
+ * script/test outside any Function. Narrow it with `isWorker`/`isFunction`/
+ * `isBindingHost` before calling `host.bind`; the guards reject `undefined`.
  */
-export const Host = Self as unknown as Effect.Effect<ResourceLike>;
+export const Host: Effect.Effect<ResourceLike | undefined> =
+  Effect.serviceOption(
+    Self as unknown as Context.Service<ResourceLike, ResourceLike>,
+  ).pipe(Effect.map(Option.getOrUndefined));

--- a/packages/alchemy/src/Binding.ts
+++ b/packages/alchemy/src/Binding.ts
@@ -1,6 +1,7 @@
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import type { Input } from "./Input.ts";
+import * as Output from "./Output.ts";
 import type { ResourceLike } from "./Resource.ts";
 import { Self } from "./Self.ts";
 import { taggedFunction } from "./Util/effect.ts";
@@ -74,6 +75,33 @@ export interface Service<
     Effect.Error<ReturnType<Shape>>,
     Self | Effect.Services<ReturnType<Shape>> | Req
   >;
+  /**
+   * Invoke this capability at plan/deploy time as a **data source** — the
+   * Terraform data-source / Pulumi invoke shape — and get an
+   * {@link Output.Output} of the result.
+   *
+   * The returned Output is inert until the planner resolves it (with the
+   * stack's services provided), so `execute` is safe to call from
+   * composition code that is re-executed inside a deployed runtime bundle.
+   * The capability's implementation layer must be registered on the stack
+   * (cloud `providers()` layers include their plan-executable capabilities).
+   *
+   * The binding host is stubbed during execution, so implementations skip
+   * their `host.bind` IAM/env wiring — only the read runs. Failures die and
+   * fail the plan.
+   *
+   * Only capabilities whose runtime client is nullary (`() => Effect<A>`)
+   * are executable; parameterized clients type as `never` here.
+   */
+  execute<Req = never>(
+    ...args: BindParameters<Parameters<Shape>, Req>
+  ): Effect.Success<ReturnType<Shape>> extends () => Effect.Effect<
+    infer A,
+    infer _E,
+    infer R2
+  >
+    ? Output.ToOutput<A, Self | Effect.Services<ReturnType<Shape>> | R2 | Req>
+    : never;
 }
 
 /**
@@ -96,6 +124,21 @@ export const Service = <
         args.map((arg) => (Effect.isEffect(arg) ? arg : Effect.succeed(arg))),
         { concurrency: "unbounded" },
       ).pipe(Effect.flatMap((resolved) => f(...resolved))),
+    );
+  // Plan-time invoke (see the `execute` doc on `Service`): bind with a stub
+  // host (so impls skip their `host.bind` wiring — the isBindingHost /
+  // isInstance narrowing rejects it), run the nullary client, and lift the
+  // result into an Output the planner resolves with the stack's services.
+  (callable as any).execute = (...args: any[]) =>
+    Output.fromEffect(
+      callable(...args).pipe(
+        Effect.flatMap((client: any) => client()),
+        Effect.provideService(Self as any, {
+          Type: "Alchemy::Invoke",
+          LogicalId: id,
+        }),
+        Effect.orDie,
+      ) as Effect.Effect<any, never, any>,
     );
   return taggedFunction(tag as any, callable) as unknown as Self;
 };

--- a/packages/alchemy/src/Prisma/Connect.ts
+++ b/packages/alchemy/src/Prisma/Connect.ts
@@ -184,13 +184,13 @@ type ConnectWorkerBindingHost = Resource<
 >;
 
 const supportsConnectEnvBinding = (
-  host: ResourceLike,
+  host: ResourceLike | undefined,
 ): host is ConnectEnvBindingHost =>
-  host.Type === "Prisma.Compute" || host.Type === "AWS.Lambda.Function";
+  host?.Type === "Prisma.Compute" || host?.Type === "AWS.Lambda.Function";
 
 const supportsConnectWorkerBinding = (
-  host: ResourceLike,
-): host is ConnectWorkerBindingHost => host.Type === "Cloudflare.Worker";
+  host: ResourceLike | undefined,
+): host is ConnectWorkerBindingHost => host?.Type === "Cloudflare.Worker";
 
 // Compute env sync omits undefined and treats null as deletion. Connection
 // bindings need both values to round-trip into the typed runtime client.
@@ -376,7 +376,7 @@ export const ConnectBinding = Layer.effect(
         } else {
           return yield* Effect.die(
             new Error(
-              `Prisma.Connect supports Prisma.Compute, AWS.Lambda.Function, and Cloudflare.Worker runtimes, got '${host.Type}'`,
+              `Prisma.Connect supports Prisma.Compute, AWS.Lambda.Function, and Cloudflare.Worker runtimes, got '${host?.Type ?? "no host"}'`,
             ),
           );
         }

--- a/packages/alchemy/test/AWS/EC2/GetAmi.test.ts
+++ b/packages/alchemy/test/AWS/EC2/GetAmi.test.ts
@@ -1,0 +1,43 @@
+import * as AWS from "@/AWS";
+import * as Test from "@/Test/Alchemy";
+import { expect } from "alchemy-test";
+import * as Effect from "effect/Effect";
+
+const { test } = Test.make({ providers: AWS.providers() });
+
+// `GetAmi.execute` (aliased `getAmi`) is the data-source form of the
+// capability: the lookup runs during plan/deploy resolution against the
+// stack's services (GetAmiHttp is registered by AWS.providers()), never
+// inside a deployed runtime. No cloud resources are created — the stack is
+// outputs-only — so this pins the whole invoke path cheaply: Binding.Service
+// execute → EffectExpr resolution → distilled describeImages.
+test.provider(
+  "getAmi resolves images as plan-time Outputs",
+  (stack) =>
+    Effect.gen(function* () {
+      const { image, imageId, fallbackId } = yield* stack.deploy(
+        Effect.gen(function* () {
+          return {
+            // The generic data source: the full image description.
+            image: AWS.EC2.getAmi({
+              owners: ["amazon"],
+              name: ["al2023-ami-2023.*"],
+            }),
+            // The id-only helper built on it.
+            imageId: AWS.EC2.amazonLinux2023(),
+            // The preference-chain helper (flatMap over the data source).
+            fallbackId: AWS.EC2.amazonLinux(),
+          };
+        }),
+      );
+
+      expect(image?.ImageId).toMatch(/^ami-/);
+      expect(image?.CreationDate).toBeTruthy();
+      expect(imageId).toMatch(/^ami-/);
+      // AL2023 exists, so the fallback chain resolves to the same image id.
+      expect(fallbackId).toBe(imageId);
+
+      yield* stack.destroy();
+    }),
+  { timeout: 120_000 },
+);

--- a/website/src/content/docs/aws/compute/ec2.mdx
+++ b/website/src/content/docs/aws/compute/ec2.mdx
@@ -23,8 +23,9 @@ The minimal instance is an AMI plus an instance type. AMI IDs
 are per-region, so resolve one with Alchemy's image helpers
 instead of hard-coding — `amazonLinux()` finds the latest Amazon
 Linux AMI (there are also `amazonLinux2023`, `amazonLinux2`,
-`ubuntu2404`, `ubuntu2204`, and a general `image()` finder).
-Each returns an `Output<string>` resolved at deploy time:
+`ubuntu2404`, `ubuntu2204`, an id-only `image()` finder, and the
+underlying `getAmi()` data source returning the full image
+description). Each returns an `Output` resolved at deploy time:
 
 ```typescript
 const instance = yield* AWS.EC2.Instance("AppInstance", {

--- a/website/src/content/docs/infrastructure-as-code/outputs.mdx
+++ b/website/src/content/docs/infrastructure-as-code/outputs.mdx
@@ -95,13 +95,15 @@ a deployed runtime:
 Output.fromEffect(lookupLatestAmi());   // Output<string>
 ```
 
-This is the seam for lookup helpers that read cloud state to produce
-a prop value. Because constructing the Output is inert, such helpers
-are safe to call from composition code that is re-executed inside a
-deployed Function, Worker, or Instance bundle — no
-`__ALCHEMY_RUNTIME__` guard needed. The AMI finders
-(`AWS.EC2.amazonLinux2023()`, `AWS.EC2.ubuntu2404()`, ...) are built
-on it:
+This is the low-level seam for lookup helpers that read cloud state to
+produce a prop value. Because constructing the Output is inert, such
+helpers are safe to call from composition code that is re-executed
+inside a deployed Function, Worker, or Instance bundle — no
+`__ALCHEMY_RUNTIME__` guard needed. The higher-level form is
+[`Capability.execute`](/infrastructure-as-effects/binding#data-sources-execute)
+— invoking a binding as a plan-time data source — which the AMI
+finders (`AWS.EC2.getAmi`, `AWS.EC2.amazonLinux2023()`,
+`AWS.EC2.ubuntu2404()`, ...) are built on:
 
 ```typescript
 const instance = yield* AWS.EC2.Instance("web", {

--- a/website/src/content/docs/infrastructure-as-effects/binding.mdx
+++ b/website/src/content/docs/infrastructure-as-effects/binding.mdx
@@ -132,6 +132,30 @@ Bindings serialize the resolved Outputs the client needs — the queue
 URL, the bucket name, the table name — into the Function's environment.
 The typed client resolves them for you.
 
+## Data sources: `execute`
+
+Every binding is also invocable at **plan time** — the shape Terraform
+calls a data source and Pulumi an invoke. `Capability.execute(...)`
+runs the operation during plan/deploy resolution (with the stack's
+services, not a deployed host) and returns an
+[`Output`](/infrastructure-as-code/outputs) you can feed straight into
+resource props:
+
+```typescript
+// the raw invoke — Output<ec2.Image | undefined>
+const image = AWS.EC2.getAmi({ owners: ["amazon"], name: ["al2023-ami-2023.*"] });
+
+// helpers built on it — Output<string>, dies when nothing matches
+imageId: AWS.EC2.amazonLinux2023(),
+```
+
+Constructing the Output is inert, so `execute` is safe in composition
+code that re-executes inside a deployed bundle. The same capability
+bound inside a Function (`yield* AWS.EC2.GetAmi(...)`) still grants its
+IAM and runs at runtime — one contract, both phases. The capability's
+implementation layer must be registered on the stack; the cloud
+`providers()` layers include their plan-executable capabilities.
+
 ## Event Sources and Sinks
 
 An **[Event Source](/infrastructure-as-effects/event-sources)** runs


### PR DESCRIPTION
Every `Binding.Service` gains `execute(...)` — invoke a capability at plan/deploy time as a data source (the Terraform data-source / Pulumi invoke shape) and get an `Output`:

```ts
export interface Service<Self, Identifier, Shape> {
  // runtime binding (existing): yield* Capability(resource) inside a Function
  <Req = never>(...args): Effect<Client, E, Self | ...>;
  // plan-time invoke (new): resolved by the planner with the stack's services
  execute<Req = never>(...args): Output<A, Self | ...>;
}
```

`Binding.Host` is now **total** — it resolves via `Effect.serviceOption(Self)` to `ResourceLike | undefined` — so binding clients work in any hostless context: `execute` invokes, or a client provided directly in a script/test with no Function around it. Implementations' existing `isBindingHost`/`isInstance`/`isWorker` narrowing rejects `undefined` and skips the `host.bind` IAM/env wiring; only the read runs. The compiler audited all ~500 `Binding.Host` usages — the three impls that assumed a host (Microvm bind labels, Prisma Connect guards) now handle `undefined`. Failures die and fail the plan. Constructing the Output is inert, so invokes are safe in composition code that re-executes inside deployed bundles. Only nullary-client capabilities (`() => Effect<A>`) are executable; parameterized clients type as `never`.

### AWS.EC2.GetAmi — first capability on the pattern

```ts
export interface GetAmi extends Binding.Service<GetAmi, "AWS.EC2.GetAmi",
  (options: FindImageOptions) => Effect<() => Effect<ec2.Image | undefined, ec2.DescribeImagesError>>
> {}
export const getAmi = GetAmi.execute;   // (options) => Output<ec2.Image | undefined>
```

- `image()` and the distro presets (`amazonLinux2023`, `ubuntu2404`, ...) are rebased on `getAmi` — one `DescribeImages` implementation; `amazonLinux()`'s AL2023→AL2 preference is now an `Output.flatMap` chain over the data source.
- The same contract works as a runtime binding: `yield* AWS.EC2.GetAmi(opts)` inside a Function grants `ec2:DescribeImages` automatically and looks images up at runtime.
- `AWS.providers()` registers plan-executable capability layers (`GetAmiHttp`) so `execute` Outputs resolve during plan.

### Docs

- `binding.mdx` gains a "Data sources: `execute`" section; `outputs.mdx` and `ec2.mdx` link to it.

### Live verification

- New `GetAmi.test.ts` (outputs-only stack, no resources): `getAmi` resolves the full image description, `amazonLinux2023()` the id, and the `amazonLinux()` fallback chain matches — 1.5s against the real API.
- `InstanceCode.test.ts` green: capability-backed `image()` still resolves deterministically (`noop` on unchanged source, `update` on a code-only edit).
- `Bindings.test.ts` (EC2) green — 10 tests over a real deployed Lambda: the host-full path (`host.bind` IAM grants) is unchanged by the total `Binding.Host`.
- `Instance.smoke.test.ts` green: the presets construct inertly inside the deployed instance bundle; the hosted service serves HTTP.
