### PR TITLE
feat(aws): deploy the S3 state store's infrastructure as an alchemy stack

### DIFF
--- a/packages/alchemy/src/AWS/S3/Bucket.ts
+++ b/packages/alchemy/src/AWS/S3/Bucket.ts
@@ -123,6 +123,17 @@ export interface BucketProps {
    */
   bucketName?: string;
   /**
+   * Bucket namespace. `"account-regional"` buckets only need a unique name
+   * within the account and region (names must follow the
+   * `<prefix>-<accountId>-<region>-an` convention); `"global"` is the
+   * classic globally-unique namespace. Fixed at creation time — changing
+   * it replaces the bucket.
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/userguide/gpbucketnamespaces.html#account-regional-gp-buckets
+   * @default "global"
+   */
+  bucketNamespace?: "global" | "account-regional";
+  /**
    * Indicates whether this bucket has Object Lock enabled.
    * Once enabled, cannot be disabled.
    */
@@ -532,6 +543,7 @@ export const BucketProvider = () =>
             yield* s3
               .createBucket({
                 Bucket: bucketName,
+                BucketNamespace: news.bucketNamespace,
                 ObjectLockEnabledForBucket: news.objectLockEnabled ?? false,
               })
               .pipe(
@@ -551,6 +563,7 @@ export const BucketProvider = () =>
           yield* s3
             .createBucket({
               Bucket: bucketName,
+              BucketNamespace: news.bucketNamespace,
               CreateBucketConfiguration: {
                 LocationConstraint: region as BucketLocationConstraint,
               },
@@ -1399,6 +1412,13 @@ export const BucketProvider = () =>
             yield* Effect.logInfo(
               `S3 Bucket diff: replacing bucket because name changed from ${oldBucketName} to ${newBucketName}`,
             );
+            return { action: "replace" } as const;
+          }
+          // The namespace is fixed at creation time
+          if (
+            (olds.bucketNamespace ?? "global") !==
+            (news.bucketNamespace ?? "global")
+          ) {
             return { action: "replace" } as const;
           }
           // Object lock can only be enabled at creation time

--- a/packages/alchemy/src/AWS/StateStore/Bootstrap.ts
+++ b/packages/alchemy/src/AWS/StateStore/Bootstrap.ts
@@ -1,0 +1,520 @@
+import * as kms from "@distilled.cloud/aws/kms";
+import * as s3 from "@distilled.cloud/aws/s3";
+import * as Config from "effect/Config";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import { adopt } from "../../AdoptPolicy.ts";
+import { AlchemyContext } from "../../AlchemyContext.ts";
+import { ALCHEMY_PROFILE } from "../../Auth/Profile.ts";
+import { deploy } from "../../Deploy.ts";
+import * as Alchemy from "../../Stack.ts";
+import {
+  hasLocalBootstrapStack,
+  hoistBootstrapStack,
+} from "../../State/Bootstrap.ts";
+import { makeLocalState } from "../../State/LocalState.ts";
+import {
+  State,
+  StateStoreError,
+  type StateService,
+} from "../../State/State.ts";
+import * as Clank from "../../Util/Clank.ts";
+import { AWSEnvironment } from "../Environment.ts";
+import { Alias } from "../KMS/Alias.ts";
+import { Key } from "../KMS/Key.ts";
+import * as AWSProviders from "../Providers.ts";
+import { Bucket } from "../S3/Bucket.ts";
+import {
+  createStateBucketName,
+  makeS3State,
+  STATE_KMS_ALIAS,
+  stateLayer,
+  type S3StateOptions,
+} from "./State.ts";
+
+/**
+ * The S3 state store's own infrastructure — the state bucket and the KMS
+ * secret-encryption key — is deployed as an alchemy stack, mirroring the
+ * Cloudflare state store bootstrap: the stack is first deployed against
+ * the *local* state store (the bucket does not exist yet), then its
+ * state is hoisted into the bucket it just created, and the local copy
+ * is deleted. From then on the stack's state lives in the bucket itself
+ * and re-running bootstrap converges/upgrades it like any other stack.
+ */
+
+/** Name of the stack that manages the state store's own infrastructure. */
+export const STATE_STACK_NAME = "AwsStateStore";
+
+const CI = Config.boolean("CI").pipe(Config.withDefault(false));
+
+export interface BootstrapOptions {
+  /** @default `alchemy-state-{accountId}-{region}-an` */
+  bucketName?: string;
+  /** Key prefix within the bucket. @default "" (bucket root) */
+  prefix?: string;
+  /** @default "alias/alchemy-state" */
+  kmsAlias?: `alias/${string}`;
+  /** @default false */
+  force?: boolean;
+}
+
+/**
+ * State store backed by an AWS S3 bucket.
+ *
+ * Stack state is persisted as JSON objects in an account-regional S3
+ * bucket, laid out exactly like the local state store's file tree with
+ * the bucket (plus optional `prefix`) taking the place of the
+ * `.alchemy/state` directory:
+ *
+ * ```
+ * s3://{bucket}/{prefix}{stack}/{stage}/{fqn}.json
+ * s3://{bucket}/{prefix}{stack}/{stage}/__stack_output__.json
+ * ```
+ *
+ * The bucket and the KMS secret-encryption key are provisioned by the
+ * {@link bootstrap} stack. When they are missing on first use, an
+ * interactive run asks for consent and deploys them; CI fails with an
+ * actionable message unless `--yes` is passed (which deploys
+ * automatically). `alchemy aws bootstrap` provisions them explicitly.
+ *
+ * @resource
+ *
+ * @section Using the S3 State Store
+ * Pass `AWS.state()` as the `state` option of a Stack. By default the
+ * state is stored in an account-regional bucket named
+ * `alchemy-state-{accountId}-{region}-an`.
+ *
+ * @example Default bucket
+ * ```typescript
+ * import * as Alchemy from "alchemy";
+ * import * as AWS from "alchemy/AWS";
+ *
+ * const Stack = Alchemy.Stack(
+ *   "my-stack",
+ *   { providers: AWS.providers(), state: AWS.state() },
+ *   Effect.gen(function* () {
+ *     // ...
+ *   }),
+ * );
+ * ```
+ *
+ * @example Custom bucket and key prefix
+ * ```typescript
+ * const Stack = Alchemy.Stack(
+ *   "my-stack",
+ *   {
+ *     providers: AWS.providers(),
+ *     state: AWS.state({
+ *       bucketName: "my-company-state",
+ *       prefix: "alchemy",
+ *     }),
+ *   },
+ *   Effect.gen(function* () {
+ *     // ...
+ *   }),
+ * );
+ * ```
+ */
+export const state = (options: S3StateOptions = {}) =>
+  Layer.unwrap(
+    Effect.gen(function* () {
+      const context =
+        yield* Effect.context<
+          Effect.Services<ReturnType<typeof consentBootstrap>>
+        >();
+      return stateLayer({
+        ...options,
+        onMissingInfra: (which) =>
+          consentBootstrap(which, options).pipe(
+            Effect.provideContext(context),
+            Effect.mapError((cause) =>
+              cause instanceof StateStoreError
+                ? cause
+                : new StateStoreError({
+                    message:
+                      cause instanceof Error
+                        ? cause.message
+                        : `AWS state store bootstrap failed: ${String(cause)}`,
+                    cause: cause instanceof Error ? cause : undefined,
+                  }),
+            ),
+          ),
+      });
+    }),
+  );
+
+/**
+ * The consent flow behind `AWS.state()` when state infrastructure is
+ * missing: deploy automatically under `--yes` (AlchemyContext
+ * `updateStateStore`), fail with an actionable message in CI, and ask
+ * in an interactive terminal.
+ */
+const consentBootstrap = (which: "bucket" | "kms", options: S3StateOptions) =>
+  Effect.gen(function* () {
+    const isCI = yield* CI;
+    const auto =
+      Option.getOrUndefined(yield* Effect.serviceOption(AlchemyContext))
+        ?.updateStateStore ?? false;
+    const run = bootstrap({
+      bucketName: options.bucketName,
+      prefix: options.prefix,
+      kmsAlias: options.kmsAlias,
+    }).pipe(Effect.asVoid);
+    if (auto) {
+      return yield* run;
+    }
+    if (isCI) {
+      return yield* Effect.fail(
+        new StateStoreError({
+          message:
+            which === "bucket"
+              ? `AWS S3 state store not found. Run 'alchemy aws bootstrap --profile <your-ci-profile>' to deploy it first, or pass --yes.`
+              : `The alchemy state secret-encryption key ('${options.kmsAlias ?? STATE_KMS_ALIAS}') was not found. ` +
+                `Run 'alchemy aws bootstrap --profile <your-ci-profile>' to create it, pass --yes, ` +
+                `or opt out of KMS with ALCHEMY_PASSWORD or secretEncryption: "off".`,
+        }),
+      );
+    }
+    const message =
+      which === "bucket"
+        ? "AWS S3 state store not found. Deploy it (S3 state bucket + KMS secret-encryption key)?"
+        : "Alchemy encrypts secrets in state with a managed KMS key (~$1/month). Create it?";
+    const ok = yield* Clank.confirm({ message }).pipe(
+      Effect.catchTag("PromptCancelled", () => Effect.succeed(false)),
+    );
+    if (!ok) {
+      return yield* Effect.die(new Clank.PromptCancelled());
+    }
+    return yield* run;
+  });
+
+/**
+ * Deploy (or converge) the AWS state store infrastructure: the
+ * account-regional state bucket (versioned, SSE, public access blocked,
+ * ACLs disabled) and the KMS key + alias that wrap state data keys.
+ *
+ * The first run deploys the stack against the local state store, hoists
+ * the stack's state into the bucket it just created, and deletes the
+ * local copy — an interrupted run resumes from the local stack. Later
+ * runs find the stack's state in the bucket and converge in place.
+ * Existing imperatively-created buckets and aliases are adopted.
+ */
+export const bootstrap = (options: BootstrapOptions = {}) =>
+  Effect.gen(function* () {
+    const { accountId, region } = yield* AWSEnvironment.current;
+    const profileName = yield* ALCHEMY_PROFILE;
+    const bucketName =
+      options.bucketName ?? createStateBucketName(accountId, region);
+    const kmsAlias = options.kmsAlias ?? STATE_KMS_ALIAS;
+    // Key off profile + bucket so concurrent bootstraps of different
+    // stores (or profiles) never collide in the local state tree.
+    const localStage = `${profileName}_${bucketName}`;
+    const remoteStage = region;
+    const s3StateOptions: S3StateOptions = {
+      bucketName,
+      prefix: options.prefix,
+      kmsAlias,
+    };
+
+    const finishWithLocalState = Effect.gen(function* () {
+      const localState = yield* makeLocalState();
+      yield* deployStateStack({
+        stage: localStage,
+        state: localState,
+        force: options.force,
+        bucketName,
+        kmsAlias,
+      });
+      const s3State = yield* makeS3State(s3StateOptions);
+      yield* hoistBootstrapStack({
+        stack: STATE_STACK_NAME,
+        source: { state: localState, stage: localStage },
+        destination: { state: s3State, stage: remoteStage },
+      });
+      yield* localState.deleteStack({
+        stack: STATE_STACK_NAME,
+        stage: localStage,
+      });
+    });
+
+    if (yield* hasLocalBootstrapStack(STATE_STACK_NAME, localStage)) {
+      // An interrupted bootstrap left the stack in the local store —
+      // finish the deploy and the hoist.
+      yield* finishWithLocalState;
+    } else {
+      const bucketExists = yield* s3.headBucket({ Bucket: bucketName }).pipe(
+        Effect.map(() => true),
+        Effect.catchTag(["NotFound", "NoSuchBucket"], () =>
+          Effect.succeed(false),
+        ),
+      );
+      const alreadyManaged =
+        bucketExists &&
+        (yield* Effect.flatMap(makeS3State(s3StateOptions), (s3State) =>
+          s3State.listStages(STATE_STACK_NAME),
+        )).includes(remoteStage);
+      if (alreadyManaged) {
+        // The stack's state lives in the bucket — a regular converge.
+        const s3State = yield* makeS3State(s3StateOptions);
+        yield* deployStateStack({
+          stage: remoteStage,
+          state: s3State,
+          force: options.force,
+          bucketName,
+          kmsAlias,
+        });
+      } else {
+        yield* finishWithLocalState;
+      }
+    }
+
+    yield* Clank.success(`AWS state store '${bucketName}' is ready.`);
+    return { bucketName, kmsAlias, region, accountId };
+  }).pipe(
+    Effect.withSpan("state_store.bootstrap", {
+      attributes: { "alchemy.state_store.op": "bootstrap" },
+    }),
+  );
+
+/** Deploy the state-store stack against the given state service. */
+const deployStateStack = ({
+  stage,
+  state,
+  force,
+  bucketName,
+  kmsAlias,
+}: {
+  stage: string;
+  state: StateService;
+  force?: boolean;
+  bucketName: string;
+  kmsAlias: `alias/${string}`;
+}) =>
+  Effect.gen(function* () {
+    const stateLayer = Layer.succeed(State, Effect.succeed(state));
+    yield* deploy({
+      stage,
+      force,
+      stack: Alchemy.Stack(
+        STATE_STACK_NAME,
+        { providers: AWSProviders.providers(), state: stateLayer },
+        Effect.gen(function* () {
+          const key = yield* Key("StateKey", {
+            description: "Alchemy state store secret encryption key",
+          });
+          const alias = yield* Alias("StateAlias", {
+            aliasName: kmsAlias,
+            targetKeyId: key.keyId,
+          });
+          const bucket = yield* Bucket("StateBucket", {
+            bucketName,
+            bucketNamespace: "account-regional",
+            versioning: "Enabled",
+            encryption: { sseAlgorithm: "AES256" },
+            publicAccessBlock: {
+              blockPublicAcls: true,
+              ignorePublicAcls: true,
+              blockPublicPolicy: true,
+              restrictPublicBuckets: true,
+            },
+            objectOwnership: "BucketOwnerEnforced",
+          });
+          return {
+            bucketName: bucket.bucketName.as<string>(),
+            keyArn: key.keyArn.as<string>(),
+            aliasName: alias.aliasName.as<string>(),
+          };
+        }),
+      ),
+    }).pipe(
+      // The state store is account-level infrastructure that outlives
+      // any single deploy: the bucket and alias may already exist from
+      // the imperative auto-create path or a previous (possibly
+      // partially-failed) bootstrap. Opt in to adoption so they
+      // reconcile in place instead of failing on conflict.
+      adopt(true),
+      Effect.provide(stateLayer),
+    );
+  }).pipe(
+    Effect.withSpan("state_store.deploy", {
+      attributes: { "alchemy.state_store.op": "deploy" },
+    }),
+  );
+
+export interface TeardownOptions {
+  /** @default `alchemy-state-{accountId}-{region}-an` */
+  bucketName?: string;
+  /** Key prefix within the bucket. @default "" (bucket root) */
+  prefix?: string;
+  /** @default "alias/alchemy-state" */
+  kmsAlias?: `alias/${string}`;
+  /**
+   * Proceed even when the bucket still holds state for other stacks —
+   * their state is destroyed with the bucket.
+   * @default false
+   */
+  force?: boolean;
+}
+
+/**
+ * The inverse of {@link bootstrap}: tear down the AWS state store.
+ * Empties and deletes the state bucket (refusing when it still holds
+ * state for other stacks, unless `force`), deletes the KMS alias, and
+ * schedules the key for deletion with a 7-day recovery window —
+ * re-running {@link bootstrap} within that window recovers the key;
+ * afterwards any state secrets encrypted under it are permanently
+ * unreadable.
+ *
+ * Idempotent — missing resources are treated as already-gone.
+ */
+export const teardown = (options: TeardownOptions = {}) =>
+  Effect.gen(function* () {
+    const { accountId, region } = yield* AWSEnvironment.current;
+    const profileName = yield* ALCHEMY_PROFILE;
+    const bucketName =
+      options.bucketName ?? createStateBucketName(accountId, region);
+    const kmsAlias = options.kmsAlias ?? STATE_KMS_ALIAS;
+
+    const bucketExists = yield* s3.headBucket({ Bucket: bucketName }).pipe(
+      Effect.map(() => true),
+      Effect.catchTag(["NotFound", "NoSuchBucket"], () =>
+        Effect.succeed(false),
+      ),
+    );
+    if (bucketExists) {
+      const s3State = yield* makeS3State({
+        bucketName,
+        prefix: options.prefix,
+        kmsAlias,
+        // Teardown must never mint infrastructure while destroying it.
+        secretEncryption: "off",
+      });
+      const foreign = (yield* s3State.listStacks()).filter(
+        (stack) => stack !== STATE_STACK_NAME,
+      );
+      if (foreign.length > 0 && !options.force) {
+        return yield* Effect.fail(
+          new StateStoreError({
+            message:
+              `State bucket '${bucketName}' still holds state for other stack(s): ${foreign.join(", ")}. ` +
+              `Destroying it makes their state unrecoverable — pass force to proceed.`,
+          }),
+        );
+      }
+      yield* Clank.info(
+        `Emptying and deleting state bucket '${bucketName}'...`,
+      );
+      yield* emptyBucket(bucketName);
+      yield* s3
+        .deleteBucket({ Bucket: bucketName })
+        .pipe(Effect.catchTag("NoSuchBucket", () => Effect.void));
+    }
+
+    const target = yield* kms.describeKey({ KeyId: kmsAlias }).pipe(
+      Effect.map((r) => r.KeyMetadata),
+      Effect.catchTag("NotFoundException", () => Effect.succeed(undefined)),
+    );
+    if (target?.KeyId !== undefined) {
+      yield* Clank.info(`Deleting KMS alias '${kmsAlias}'...`);
+      yield* kms
+        .deleteAlias({ AliasName: kmsAlias })
+        .pipe(Effect.catchTag("NotFoundException", () => Effect.void));
+      if (target.KeyState !== "PendingDeletion") {
+        yield* kms
+          .scheduleKeyDeletion({
+            KeyId: target.KeyId,
+            PendingWindowInDays: 7,
+          })
+          .pipe(
+            Effect.catchTag(
+              ["KMSInvalidStateException", "NotFoundException"],
+              () => Effect.void,
+            ),
+          );
+        yield* Clank.info(
+          `Scheduled KMS key ${target.KeyId} for deletion in 7 days. ` +
+            `Re-running 'alchemy aws bootstrap' within that window recovers it; ` +
+            `afterwards any state secrets encrypted under it are permanently unreadable.`,
+        );
+      }
+    }
+
+    // Drop any stranded local bootstrap stack for this store.
+    const localState = yield* makeLocalState();
+    yield* localState
+      .deleteStack({
+        stack: STATE_STACK_NAME,
+        stage: `${profileName}_${bucketName}`,
+      })
+      .pipe(Effect.ignore);
+
+    yield* Clank.success(`AWS state store '${bucketName}' torn down.`);
+  }).pipe(
+    Effect.withSpan("state_store.teardown", {
+      attributes: { "alchemy.state_store.op": "teardown" },
+    }),
+  );
+
+/**
+ * Delete every object version, delete marker, and in-progress multipart
+ * upload so `DeleteBucket` succeeds on the versioned state bucket.
+ */
+const emptyBucket = Effect.fn(function* (bucketName: string) {
+  let isTruncated = true;
+  let keyMarker: string | undefined;
+  let versionIdMarker: string | undefined;
+  while (isTruncated) {
+    const page = yield* s3.listObjectVersions({
+      Bucket: bucketName,
+      KeyMarker: keyMarker,
+      VersionIdMarker: versionIdMarker,
+    });
+    const objects = [
+      ...(page.Versions ?? []).map((v) => ({
+        Key: v.Key!,
+        VersionId: v.VersionId,
+      })),
+      ...(page.DeleteMarkers ?? []).map((dm) => ({
+        Key: dm.Key!,
+        VersionId: dm.VersionId,
+      })),
+    ];
+    if (objects.length > 0) {
+      yield* s3.deleteObjects({
+        Bucket: bucketName,
+        Delete: { Objects: objects, Quiet: true },
+      });
+    }
+    isTruncated = page.IsTruncated === true;
+    keyMarker = page.NextKeyMarker;
+    versionIdMarker = page.NextVersionIdMarker;
+  }
+  let uploadsTruncated = true;
+  let uploadKeyMarker: string | undefined;
+  let uploadIdMarker: string | undefined;
+  while (uploadsTruncated) {
+    const uploads = yield* s3.listMultipartUploads({
+      Bucket: bucketName,
+      KeyMarker: uploadKeyMarker,
+      UploadIdMarker: uploadIdMarker,
+    });
+    const inProgress = (uploads.Uploads ?? []).filter(
+      (u) => u.Key != null && u.UploadId != null,
+    );
+    if (inProgress.length > 0) {
+      yield* Effect.all(
+        inProgress.map((u) =>
+          s3.abortMultipartUpload({
+            Bucket: bucketName,
+            Key: u.Key!,
+            UploadId: u.UploadId!,
+          }),
+        ),
+      );
+    }
+    uploadsTruncated = uploads.IsTruncated === true;
+    uploadKeyMarker = uploads.NextKeyMarker;
+    uploadIdMarker = uploads.NextUploadIdMarker;
+  }
+});

--- a/packages/alchemy/src/AWS/StateStore/Bootstrap.ts
+++ b/packages/alchemy/src/AWS/StateStore/Bootstrap.ts
@@ -4,6 +4,8 @@ import * as Config from "effect/Config";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as Redacted from "effect/Redacted";
+import * as Stream from "effect/Stream";
 import { adopt } from "../../AdoptPolicy.ts";
 import { AlchemyContext } from "../../AlchemyContext.ts";
 import { ALCHEMY_PROFILE } from "../../Auth/Profile.ts";
@@ -55,8 +57,6 @@ export interface BootstrapOptions {
   prefix?: string;
   /** @default "alias/alchemy-state" */
   kmsAlias?: `alias/${string}`;
-  /** @default false */
-  force?: boolean;
 }
 
 /**
@@ -222,7 +222,6 @@ export const bootstrap = (options: BootstrapOptions = {}) =>
       yield* deployStateStack({
         stage: localStage,
         state: localState,
-        force: options.force,
         bucketName,
         kmsAlias,
       });
@@ -260,7 +259,6 @@ export const bootstrap = (options: BootstrapOptions = {}) =>
         yield* deployStateStack({
           stage: remoteStage,
           state: s3State,
-          force: options.force,
           bucketName,
           kmsAlias,
         });
@@ -268,6 +266,20 @@ export const bootstrap = (options: BootstrapOptions = {}) =>
         yield* finishWithLocalState;
       }
     }
+
+    // Converge the wrapped data key onto the stack-managed key: a store
+    // that predates the bootstrap stack wraps its data key under the
+    // old imperatively-created key, which would stay silently
+    // load-bearing forever (and brick all secrets if someone deleted
+    // the innocuous-looking unmanaged key). Best-effort — a failure
+    // leaves the store working exactly as before.
+    yield* rewrapDataKey({ bucketName, prefix: options.prefix, kmsAlias }).pipe(
+      Effect.catchCause((cause) =>
+        Clank.info(
+          `Could not re-wrap the state data key under '${kmsAlias}' — the store keeps working with its current key. Cause: ${cause}`,
+        ),
+      ),
+    );
 
     yield* Clank.success(`AWS state store '${bucketName}' is ready.`);
     return { bucketName, kmsAlias, region, accountId };
@@ -277,17 +289,102 @@ export const bootstrap = (options: BootstrapOptions = {}) =>
     }),
   );
 
+/**
+ * If the persisted data key is wrapped under a key other than the one
+ * behind `kmsAlias` (e.g. the imperatively-created key from before the
+ * bootstrap stack existed), decrypt it and re-wrap it under the
+ * stack-managed key, so the old key stops being load-bearing and can
+ * eventually be retired.
+ */
+const rewrapDataKey = ({
+  bucketName,
+  prefix,
+  kmsAlias,
+}: {
+  bucketName: string;
+  prefix?: string;
+  kmsAlias: `alias/${string}`;
+}) =>
+  Effect.gen(function* () {
+    const normalizedPrefix = prefix ? `${prefix.replace(/\/+$/, "")}/` : "";
+    const stateKeyObjectKey = `${normalizedPrefix}__state_key__.json`;
+
+    const wrapped = yield* s3
+      .getObject({ Bucket: bucketName, Key: stateKeyObjectKey })
+      .pipe(
+        Effect.flatMap((r) =>
+          r.Body === undefined
+            ? Effect.succeed(undefined)
+            : Stream.mkString(Stream.decodeText(r.Body)).pipe(
+                Effect.map(
+                  (text) =>
+                    JSON.parse(text) as { keyId?: string; ciphertext: string },
+                ),
+              ),
+        ),
+        Effect.catchTag("NoSuchKey", () => Effect.succeed(undefined)),
+      );
+    if (wrapped === undefined) return;
+
+    const target = yield* kms.describeKey({ KeyId: kmsAlias }).pipe(
+      Effect.map((r) => r.KeyMetadata),
+      Effect.catchTag("NotFoundException", () => Effect.succeed(undefined)),
+    );
+    if (target?.KeyId === undefined) return;
+
+    const wrappingKey =
+      wrapped.keyId === undefined
+        ? undefined
+        : yield* kms.describeKey({ KeyId: wrapped.keyId }).pipe(
+            Effect.map((r) => r.KeyMetadata?.KeyId),
+            Effect.catchTag("NotFoundException", () =>
+              Effect.succeed(undefined),
+            ),
+          );
+    if (wrappingKey === target.KeyId) return;
+
+    const decrypted = yield* kms.decrypt({
+      CiphertextBlob: Buffer.from(wrapped.ciphertext, "base64"),
+    });
+    const plaintext = Redacted.isRedacted(decrypted.Plaintext)
+      ? Redacted.value(decrypted.Plaintext)
+      : decrypted.Plaintext;
+    if (plaintext === undefined) return;
+
+    const rewrapped = yield* kms.encrypt({
+      KeyId: target.KeyId,
+      Plaintext: plaintext,
+    });
+    if (rewrapped.CiphertextBlob === undefined) return;
+    yield* s3.putObject({
+      Bucket: bucketName,
+      Key: stateKeyObjectKey,
+      Body: JSON.stringify(
+        {
+          keyId: rewrapped.KeyId ?? target.KeyId,
+          ciphertext: Buffer.from(rewrapped.CiphertextBlob).toString("base64"),
+        },
+        null,
+        2,
+      ),
+      ContentType: "application/json",
+    });
+    yield* Clank.info(
+      `Re-wrapped the state data key under '${kmsAlias}'${
+        wrapped.keyId === undefined ? "" : ` (was ${wrapped.keyId})`
+      }.`,
+    );
+  });
+
 /** Deploy the state-store stack against the given state service. */
 const deployStateStack = ({
   stage,
   state,
-  force,
   bucketName,
   kmsAlias,
 }: {
   stage: string;
   state: StateService;
-  force?: boolean;
   bucketName: string;
   kmsAlias: `alias/${string}`;
 }) =>
@@ -295,7 +392,14 @@ const deployStateStack = ({
     const stateLayer = Layer.succeed(State, Effect.succeed(state));
     yield* deploy({
       stage,
-      force,
+      // Always force: the whole point of re-running bootstrap is to
+      // heal drift, and the plan's prop-diff cannot see out-of-band
+      // damage (a deleted alias, a key scheduled for deletion — the
+      // persisted props are unchanged, so everything plans as noop).
+      // Forcing makes every reconciler run its observe-ensure-sync
+      // flow, which is a no-op at the API level when the cloud is
+      // already healthy.
+      force: true,
       stack: Alchemy.Stack(
         STATE_STACK_NAME,
         { providers: AWSProviders.providers(), state: stateLayer },
@@ -416,10 +520,11 @@ export const teardown = (options: TeardownOptions = {}) =>
       Effect.catchTag("NotFoundException", () => Effect.succeed(undefined)),
     );
     if (target?.KeyId !== undefined) {
-      yield* Clank.info(`Deleting KMS alias '${kmsAlias}'...`);
-      yield* kms
-        .deleteAlias({ AliasName: kmsAlias })
-        .pipe(Effect.catchTag("NotFoundException", () => Effect.void));
+      // Schedule the key deletion BEFORE removing the alias: a crash
+      // between the two then leaves an alias pointing at a
+      // pending-deletion key — a state every read path and re-run
+      // recovers from — rather than an alias-less key that no rerun of
+      // teardown can find again.
       if (target.KeyState !== "PendingDeletion") {
         yield* kms
           .scheduleKeyDeletion({
@@ -438,6 +543,10 @@ export const teardown = (options: TeardownOptions = {}) =>
             `afterwards any state secrets encrypted under it are permanently unreadable.`,
         );
       }
+      yield* Clank.info(`Deleting KMS alias '${kmsAlias}'...`);
+      yield* kms
+        .deleteAlias({ AliasName: kmsAlias })
+        .pipe(Effect.catchTag("NotFoundException", () => Effect.void));
     }
 
     // Drop any stranded local bootstrap stack for this store.

--- a/packages/alchemy/src/AWS/StateStore/State.ts
+++ b/packages/alchemy/src/AWS/StateStore/State.ts
@@ -258,6 +258,67 @@ export const makeS3State = (options: S3StateOptions = {}) =>
       );
 
     /**
+     * The state bucket is versioned, so an out-of-band delete of the
+     * data-key object leaves a delete marker with the real versions
+     * intact underneath. Restore the most recent real version instead
+     * of minting a fresh data key — a fresh key would permanently
+     * strand every value already encrypted under the old one.
+     */
+    const restoreWrappedKeyFromVersions = (bucketName: string) =>
+      Effect.gen(function* () {
+        const versions = yield* s3.listObjectVersions({
+          Bucket: bucketName,
+          Prefix: stateKeyObjectKey,
+        });
+        const candidates = (versions.Versions ?? [])
+          .filter(
+            (v) => v.Key === stateKeyObjectKey && v.VersionId !== undefined,
+          )
+          .sort(
+            (a, b) =>
+              new Date(b.LastModified ?? 0).getTime() -
+              new Date(a.LastModified ?? 0).getTime(),
+          );
+        const latest = candidates[0];
+        if (latest === undefined) return undefined;
+        const body = yield* s3
+          .getObject({
+            Bucket: bucketName,
+            Key: stateKeyObjectKey,
+            VersionId: latest.VersionId,
+          })
+          .pipe(
+            Effect.flatMap((r) =>
+              r.Body === undefined
+                ? Effect.succeed(undefined)
+                : Stream.mkString(Stream.decodeText(r.Body)),
+            ),
+            Effect.catchTag("NoSuchKey", () => Effect.succeed(undefined)),
+          );
+        if (body === undefined) return undefined;
+        yield* Effect.logInfo(
+          `S3 state store: restoring deleted state data key object '${stateKeyObjectKey}' from version ${latest.VersionId}`,
+        );
+        // Conditional put + read-back: a concurrent restorer (or a
+        // concurrent fresh mint) converges on whatever won.
+        yield* s3
+          .putObject({
+            Bucket: bucketName,
+            Key: stateKeyObjectKey,
+            Body: body,
+            ContentType: "application/json",
+            IfNoneMatch: "*",
+          })
+          .pipe(
+            Effect.catchTag(
+              ["PreconditionFailed", "ConditionalRequestConflict"],
+              () => Effect.void,
+            ),
+          );
+        return yield* readWrappedKey(bucketName);
+      });
+
+    /**
      * Recover the state key after an out-of-band cleanup (e.g. an
      * account nuke) scheduled it for deletion: cancel the pending
      * deletion and re-enable it. State encrypted under the key's data
@@ -380,6 +441,8 @@ export const makeS3State = (options: S3StateOptions = {}) =>
       Effect.gen(function* () {
         const existing = yield* readWrappedKey(bucketName);
         if (existing !== undefined) return yield* unwrapDataKey(existing);
+        const restored = yield* restoreWrappedKeyFromVersions(bucketName);
+        if (restored !== undefined) return yield* unwrapDataKey(restored);
         const keyId = yield* ensureKmsKey;
         const dataKey = yield* kms.generateDataKey({
           KeyId: keyId,

--- a/packages/alchemy/src/AWS/StateStore/State.ts
+++ b/packages/alchemy/src/AWS/StateStore/State.ts
@@ -99,74 +99,41 @@ export interface S3StateOptions {
    * @default "kms"
    */
   secretEncryption?: "kms" | "off";
+  /**
+   * KMS alias of the key that wraps state data keys.
+   *
+   * @default "alias/alchemy-state"
+   */
+  kmsAlias?: `alias/${string}`;
+  /**
+   * Consent hook invoked before the store creates missing state
+   * infrastructure (the state bucket, or the KMS key on first secret).
+   * When absent, missing infrastructure is created automatically.
+   * `AWS.state()` wires this to the interactive bootstrap flow
+   * (prompt in a TTY, actionable error in CI, auto under `--yes`).
+   *
+   * @internal
+   */
+  onMissingInfra?: (
+    which: "bucket" | "kms",
+  ) => Effect.Effect<void, StateStoreError>;
 }
 
 /** Alias of the auto-managed KMS key that wraps state data keys. */
-const STATE_KMS_ALIAS = "alias/alchemy-state";
+export const STATE_KMS_ALIAS = "alias/alchemy-state";
 
 /** Context required by the distilled S3 operations. */
 type S3Deps = Credentials | HttpClient | Region;
 
 /**
- * State store backed by an AWS S3 bucket.
+ * The plain (bootstrap-unaware) state layer: missing infrastructure is
+ * created automatically with no consent flow. The user-facing
+ * `AWS.state()` (in `Bootstrap.ts`) builds on this by wiring
+ * {@link S3StateOptions.onMissingInfra} to the interactive bootstrap.
  *
- * Stack state is persisted as JSON objects in an account-regional S3
- * bucket, laid out exactly like the local state store's file tree with
- * the bucket (plus optional `prefix`) taking the place of the
- * `.alchemy/state` directory:
- *
- * ```
- * s3://{bucket}/{prefix}{stack}/{stage}/{fqn}.json
- * s3://{bucket}/{prefix}{stack}/{stage}/__stack_output__.json
- * ```
- *
- * The bucket is created lazily on the first state operation if it does
- * not already exist — nothing touches AWS credentials at layer
- * construction time.
- *
- * @resource
- *
- * @section Using the S3 State Store
- * Pass `AWS.state()` as the `state` option of a Stack. By default the
- * state is stored in an account-regional bucket named
- * `alchemy-state-{accountId}-{region}-an`.
- *
- * @example Default bucket
- * ```typescript
- * import * as Alchemy from "alchemy";
- * import * as AWS from "alchemy/AWS";
- *
- * const Stack = Alchemy.Stack(
- *   "my-stack",
- *   { providers: AWS.providers(), state: AWS.state() },
- *   Effect.gen(function* () {
- *     // ...
- *   }),
- * );
- * ```
- *
- * @example Custom bucket and key prefix
- * ```typescript
- * const Stack = Alchemy.Stack(
- *   "my-stack",
- *   {
- *     providers: AWS.providers(),
- *     state: AWS.state({
- *       bucketName: "my-company-state",
- *       prefix: "alchemy",
- *       encryption: {
- *         sseAlgorithm: "aws:kms",
- *         kmsMasterKeyId: "alias/alchemy-state",
- *       },
- *     }),
- *   },
- *   Effect.gen(function* () {
- *     // ...
- *   }),
- * );
- * ```
+ * @internal
  */
-export const state = (options: S3StateOptions = {}) =>
+export const stateLayer = (options: S3StateOptions = {}) =>
   Layer.effect(
     State,
     Effect.gen(function* () {
@@ -228,6 +195,18 @@ export const makeS3State = (options: S3StateOptions = {}) =>
         const { accountId, region } = yield* AWSEnvironment.current;
         const bucketName =
           options.bucketName ?? createStateBucketName(accountId, region);
+        if (options.onMissingInfra) {
+          const exists = yield* s3.headBucket({ Bucket: bucketName }).pipe(
+            Effect.map(() => true),
+            Effect.catchTag(["NotFound", "NoSuchBucket"], () =>
+              Effect.succeed(false),
+            ),
+          );
+          // The consent flow deploys the bootstrap stack (bucket + KMS
+          // key); ensureStateBucket below then finds the bucket and only
+          // converges settings.
+          if (!exists) yield* options.onMissingInfra("bucket");
+        }
         yield* ensureStateBucket(bucketName, region, options);
         return bucketName;
       }).pipe(Effect.provideContext(context), Effect.mapError(toError)),
@@ -328,12 +307,22 @@ export const makeS3State = (options: S3StateOptions = {}) =>
       );
     };
 
-    /** Resolve the KeyId behind `alias/alchemy-state`, creating key + alias on first use. */
+    const kmsAlias = options.kmsAlias ?? STATE_KMS_ALIAS;
+
+    /** Resolve the KeyId behind the state alias, creating key + alias on first use. */
     const ensureKmsKey = Effect.gen(function* () {
-      const existing = yield* kms.describeKey({ KeyId: STATE_KMS_ALIAS }).pipe(
+      const describeAlias = kms.describeKey({ KeyId: kmsAlias }).pipe(
         Effect.map((r) => r.KeyMetadata),
         Effect.catchTag("NotFoundException", () => Effect.succeed(undefined)),
       );
+      let existing = yield* describeAlias;
+      if (existing?.KeyId === undefined && options.onMissingInfra) {
+        // The consent flow deploys the bootstrap stack (which includes
+        // the key + alias); re-observe and fall through to the
+        // automatic create only if it still doesn't exist.
+        yield* options.onMissingInfra("kms");
+        existing = yield* describeAlias;
+      }
       if (existing?.KeyId !== undefined) {
         if (
           existing.KeyState === "PendingDeletion" ||
@@ -353,7 +342,7 @@ export const makeS3State = (options: S3StateOptions = {}) =>
         );
       }
       return yield* kms
-        .createAlias({ AliasName: STATE_KMS_ALIAS, TargetKeyId: keyId })
+        .createAlias({ AliasName: kmsAlias, TargetKeyId: keyId })
         .pipe(
           Effect.map(() => keyId),
           // Lost the alias-creation race: schedule our now-orphaned key
@@ -363,14 +352,12 @@ export const makeS3State = (options: S3StateOptions = {}) =>
               .scheduleKeyDeletion({ KeyId: keyId, PendingWindowInDays: 7 })
               .pipe(
                 Effect.ignore,
-                Effect.flatMap(() =>
-                  kms.describeKey({ KeyId: STATE_KMS_ALIAS }),
-                ),
+                Effect.flatMap(() => kms.describeKey({ KeyId: kmsAlias })),
                 Effect.flatMap((r) =>
                   r.KeyMetadata?.KeyId === undefined
                     ? Effect.fail(
                         new StateStoreError({
-                          message: `KMS alias ${STATE_KMS_ALIAS} exists but has no target key`,
+                          message: `KMS alias ${kmsAlias} exists but has no target key`,
                         }),
                       )
                     : Effect.succeed(r.KeyMetadata.KeyId),

--- a/packages/alchemy/src/AWS/StateStore/index.ts
+++ b/packages/alchemy/src/AWS/StateStore/index.ts
@@ -1,1 +1,14 @@
-export { makeS3State, state, type S3StateOptions } from "./State.ts";
+export {
+  bootstrap as bootstrapStateStore,
+  state,
+  STATE_STACK_NAME,
+  teardown as teardownStateStore,
+  type BootstrapOptions as StateStoreBootstrapOptions,
+  type TeardownOptions as StateStoreTeardownOptions,
+} from "./Bootstrap.ts";
+export {
+  createStateBucketName,
+  makeS3State,
+  STATE_KMS_ALIAS,
+  type S3StateOptions,
+} from "./State.ts";

--- a/packages/alchemy/src/Cli/commands/aws.ts
+++ b/packages/alchemy/src/Cli/commands/aws.ts
@@ -15,6 +15,10 @@ import {
   bootstrap as bootstrapAws,
   destroyBootstrap as destroyBootstrapAws,
 } from "../../AWS/Bootstrap.ts";
+import {
+  bootstrap as bootstrapStateStore,
+  teardown as teardownStateStore,
+} from "../../AWS/StateStore/Bootstrap.ts";
 import * as AWSCredentials from "../../AWS/Credentials.ts";
 import { AWSEnvironment } from "../../AWS/Environment.ts";
 import * as AWSRegion from "../../AWS/Region.ts";
@@ -38,7 +42,16 @@ const awsRegion = Flag.string("region").pipe(
 );
 
 const bootstrapDestroy = Flag.boolean("destroy").pipe(
-  Flag.withDescription("Destroy all bootstrap buckets in the selected region"),
+  Flag.withDescription(
+    "Destroy the bootstrap resources in the selected region: assets buckets, the state bucket, and the state KMS key (scheduled for deletion with a 7-day recovery window)",
+  ),
+  Flag.withDefault(false),
+);
+
+const bootstrapForce = Flag.boolean("force").pipe(
+  Flag.withDescription(
+    "With --destroy: delete the state bucket even when it still holds state for other stacks",
+  ),
   Flag.withDefault(false),
 );
 
@@ -49,6 +62,7 @@ const bootstrapCommand = Command.make(
     profile: awsProfile,
     region: awsRegion,
     destroy: bootstrapDestroy,
+    force: bootstrapForce,
   },
   instrumentCommand(
     "aws.bootstrap",
@@ -58,7 +72,7 @@ const bootstrapCommand = Command.make(
       "alchemy.destroy": a.destroy,
     }),
   )(
-    Effect.fn(function* ({ envFile, profile, region, destroy }) {
+    Effect.fn(function* ({ envFile, profile, region, destroy, force }) {
       const logger = Logger.layer([fileLogger("bootstrap.txt")], {
         mergeWithExisting: true,
       });
@@ -109,6 +123,9 @@ const bootstrapCommand = Command.make(
               ),
               Effect.provide(bootstrapLayer),
             );
+            yield* teardownStateStore({ force }).pipe(
+              Effect.provide(bootstrapLayer),
+            );
             return;
           }
           yield* bootstrapAws().pipe(
@@ -119,6 +136,7 @@ const bootstrapCommand = Command.make(
             ),
             Effect.provide(bootstrapLayer),
           );
+          yield* bootstrapStateStore().pipe(Effect.provide(bootstrapLayer));
         });
       }).pipe(Effect.provide(logger));
     }),

--- a/packages/alchemy/src/Cloudflare/StateStore/State.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/State.ts
@@ -29,6 +29,10 @@ import {
   makeHttpStateStore,
   type HttpStateStoreCredentials,
 } from "../../State/HttpStateStore.ts";
+import {
+  hasLocalBootstrapStack,
+  hoistBootstrapStack,
+} from "../../State/Bootstrap.ts";
 import { makeLocalState } from "../../State/LocalState.ts";
 import { State, type StateService } from "../../State/State.ts";
 import {
@@ -571,6 +575,7 @@ const deployWithLocalState = ({
     const httpState = yield* makeCloudflareStateStore({ url, authToken });
 
     yield* hoistBootstrapStack({
+      stack: "CloudflareStateStore",
       source: {
         state: localState,
         stage: localStage,
@@ -578,6 +583,14 @@ const deployWithLocalState = ({
       destination: {
         state: httpState,
         stage: remoteStage,
+      },
+      retry: {
+        while: isTransientBootstrapWriteError,
+        // Bounded at ~30s: the freshly deployed worker (and its
+        // Secrets Store bindings) can take a while to serve
+        // consistently; anything persisting past that is a real
+        // failure to surface, not to spin on.
+        schedule: Schedule.max([Schedule.fixed(500), Schedule.recurs(60)]),
       },
     });
 
@@ -626,79 +639,7 @@ export const isTransientBootstrapWriteError = (error: {
 
 // check if there's a local stack that wasn't properly hoisted
 const hasLocalStack = (stage: string) =>
-  Effect.gen(function* () {
-    const localState = yield* makeLocalState();
-    return yield* Effect.map(
-      localState.listStages("CloudflareStateStore"),
-      // key off the profile name to avoid conflicts with other profiles
-      (stages) => stages.includes(stage),
-    );
-  });
-
-/**
- * Non-destructively copy every resource in the
- * `CloudflareStateStore/<scriptName>` stack from `source` into
- * `destination`, leaving every other stack in `destination` untouched.
- *
- * This intentionally does not delete anything from `destination`: at
- * bootstrap time the destination is the user's live remote state
- * store, and removing entries that happen to be missing locally would
- * be catastrophic.
- */
-const hoistBootstrapStack = Effect.fn(function* ({
-  source,
-  destination,
-}: {
-  source: {
-    state: StateService;
-    stage: string;
-  };
-  destination: {
-    state: StateService;
-    stage: string;
-  };
-}) {
-  const stack = "CloudflareStateStore";
-  const fqns = yield* source.state.list({ stack, stage: source.stage });
-  yield* Effect.annotateCurrentSpan({
-    "alchemy.state_store.stack": stack,
-    "alchemy.state_store.stage": source.stage,
-    "alchemy.state_store.resources.count": fqns.length,
-  });
-  yield* Effect.forEach(
-    fqns,
-    Effect.fn(function* (fqn) {
-      const value = yield* source.state.get({
-        stack,
-        stage: source.stage,
-        fqn,
-      });
-      if (value) {
-        yield* destination.state
-          .set({
-            stack,
-            stage: destination.stage,
-            fqn,
-            value,
-          })
-          .pipe(
-            Effect.retry({
-              while: isTransientBootstrapWriteError,
-              // Bounded at ~30s: the freshly deployed worker (and its
-              // Secrets Store bindings) can take a while to serve
-              // consistently; anything persisting past that is a real
-              // failure to surface, not to spin on.
-              schedule: Schedule.max([
-                Schedule.fixed(500),
-                Schedule.recurs(60),
-              ]),
-            }),
-          );
-      }
-    }),
-    { concurrency: "unbounded" },
-  );
-}, Effect.withSpan("state_store.hoist_bootstrap_stack"));
+  hasLocalBootstrapStack("CloudflareStateStore", stage);
 
 /**
  * Log in to a Cloudflare-deployed HTTP state-store.

--- a/packages/alchemy/src/State/Bootstrap.ts
+++ b/packages/alchemy/src/State/Bootstrap.ts
@@ -1,0 +1,93 @@
+import * as Effect from "effect/Effect";
+import type * as Schedule from "effect/Schedule";
+import { makeLocalState } from "./LocalState.ts";
+import type { StateService, StateStoreError } from "./State.ts";
+
+/**
+ * Shared machinery for state-store bootstrap flows: a state store whose
+ * own infrastructure is deployed as an alchemy stack. The stack is first
+ * deployed against the *local* state store (the remote store does not
+ * exist yet), then its state is hoisted into the store it just created,
+ * and the local copy is deleted. See the Cloudflare state store
+ * (`Cloudflare/StateStore/State.ts`) and the AWS S3 state store
+ * (`AWS/StateStore/Bootstrap.ts`) for the two concrete flows.
+ */
+
+/**
+ * Whether an interrupted bootstrap left the given stack behind in the
+ * local state store — i.e. the deploy ran but the hoist (or the local
+ * cleanup after it) did not complete. Callers use this to finish the
+ * bootstrap instead of starting a fresh one.
+ */
+export const hasLocalBootstrapStack = (stack: string, stage: string) =>
+  Effect.gen(function* () {
+    const localState = yield* makeLocalState();
+    return yield* Effect.map(
+      localState.listStages(stack),
+      // key off the profile name to avoid conflicts with other profiles
+      (stages) => stages.includes(stage),
+    );
+  });
+
+/**
+ * Non-destructively copy every resource in the `{stack}/{source.stage}`
+ * stack from `source` into `destination`, leaving every other stack in
+ * `destination` untouched.
+ *
+ * This intentionally does not delete anything from `destination`: at
+ * bootstrap time the destination is the user's live remote state
+ * store, and removing entries that happen to be missing locally would
+ * be catastrophic.
+ */
+export const hoistBootstrapStack = Effect.fn(function* ({
+  stack,
+  source,
+  destination,
+  retry,
+}: {
+  stack: string;
+  source: {
+    state: StateService;
+    stage: string;
+  };
+  destination: {
+    state: StateService;
+    stage: string;
+  };
+  /**
+   * Optional retry policy for destination writes — e.g. a freshly
+   * deployed HTTP store can serve transient 404/401/5xx while its
+   * deployment propagates.
+   */
+  retry?: {
+    while: (error: StateStoreError) => boolean;
+    schedule: Schedule.Schedule<unknown, unknown>;
+  };
+}) {
+  const fqns = yield* source.state.list({ stack, stage: source.stage });
+  yield* Effect.annotateCurrentSpan({
+    "alchemy.state_store.stack": stack,
+    "alchemy.state_store.stage": source.stage,
+    "alchemy.state_store.resources.count": fqns.length,
+  });
+  yield* Effect.forEach(
+    fqns,
+    Effect.fn(function* (fqn) {
+      const value = yield* source.state.get({
+        stack,
+        stage: source.stage,
+        fqn,
+      });
+      if (value) {
+        const write = destination.state.set({
+          stack,
+          stage: destination.stage,
+          fqn,
+          value,
+        });
+        yield* retry ? write.pipe(Effect.retry(retry)) : write;
+      }
+    }),
+    { concurrency: "unbounded" },
+  );
+}, Effect.withSpan("state_store.hoist_bootstrap_stack"));

--- a/packages/alchemy/test/AWS/StateStore/Bootstrap.test.ts
+++ b/packages/alchemy/test/AWS/StateStore/Bootstrap.test.ts
@@ -5,8 +5,13 @@ import {
   teardown,
 } from "@/AWS/StateStore/Bootstrap.ts";
 import { makeS3State } from "@/AWS";
-import type { ResourceState } from "@/State";
+import {
+  StateStoreError,
+  type ResourceState,
+  type StateService,
+} from "@/State";
 import { hasLocalBootstrapStack } from "@/State/Bootstrap.ts";
+import { makeLocalState } from "@/State/LocalState.ts";
 import * as Test from "@/Test/Alchemy";
 import * as kms from "@distilled.cloud/aws/kms";
 import * as s3 from "@distilled.cloud/aws/s3";
@@ -17,11 +22,91 @@ import * as Stream from "effect/Stream";
 
 const { test } = Test.make({ providers: AWS.providers() });
 
-// Isolated from the shared testing state bucket/key: this suite creates
-// and destroys its own store end-to-end.
+// Isolated from the shared testing state bucket/key: every test in this
+// suite creates and destroys its own store end-to-end, under its own
+// bucket + alias, so the tests are independent and safe to run
+// concurrently.
 const KMS_ALIAS = "alias/alchemy-state-btest" as const;
 const bucketNameFor = (accountId: string, region: string) =>
   `alchemy-state-btest-${accountId}-${region}-an`.toLowerCase();
+
+/** Per-failure-mode isolation: its own bucket + alias per suffix. */
+const isolated = (suffix: string) =>
+  Effect.gen(function* () {
+    const { accountId, region } = yield* AWS.AWSEnvironment.current;
+    return {
+      bucketName:
+        `alchemy-state-b${suffix}-${accountId}-${region}-an`.toLowerCase(),
+      kmsAlias: `alias/alchemy-state-b${suffix}` as const,
+      region,
+    };
+  });
+
+const secretRow = (fqn: string, secret: string): ResourceState =>
+  ({
+    resourceType: "test:resource",
+    namespace: undefined,
+    fqn,
+    logicalId: fqn,
+    instanceId: `instance-${fqn}`,
+    providerVersion: 1,
+    status: "created",
+    downstream: [],
+    bindings: [],
+    props: { apiKey: Redacted.make(secret) },
+    attr: {},
+  }) as ResourceState;
+
+const readSecret = (state: StateService, fqn: string) =>
+  Effect.gen(function* () {
+    const revived = (yield* state.get({
+      stack: "BootstrapSecretTest",
+      stage: "test",
+      fqn,
+    })) as ResourceState | undefined;
+    return Redacted.value(
+      (revived?.props as { apiKey: Redacted.Redacted<string> }).apiKey,
+    );
+  });
+
+const writeSecret = (state: StateService, fqn: string, secret: string) =>
+  state.set({
+    stack: "BootstrapSecretTest",
+    stage: "test",
+    fqn,
+    value: secretRow(fqn, secret),
+  });
+
+/** Version-aware bucket wipe + delete, for simulating out-of-band loss. */
+const nukeBucket = (bucketName: string) =>
+  Effect.gen(function* () {
+    let truncated = true;
+    let keyMarker: string | undefined;
+    let versionIdMarker: string | undefined;
+    while (truncated) {
+      const page = yield* s3.listObjectVersions({
+        Bucket: bucketName,
+        KeyMarker: keyMarker,
+        VersionIdMarker: versionIdMarker,
+      });
+      const objects = [
+        ...(page.Versions ?? []),
+        ...(page.DeleteMarkers ?? []),
+      ].map((v) => ({ Key: v.Key!, VersionId: v.VersionId }));
+      if (objects.length > 0) {
+        yield* s3.deleteObjects({
+          Bucket: bucketName,
+          Delete: { Objects: objects, Quiet: true },
+        });
+      }
+      truncated = page.IsTruncated === true;
+      keyMarker = page.NextKeyMarker;
+      versionIdMarker = page.NextVersionIdMarker;
+    }
+    yield* s3
+      .deleteBucket({ Bucket: bucketName })
+      .pipe(Effect.catchTag("NoSuchBucket", () => Effect.void));
+  });
 
 test.provider(
   "bootstrap deploys the state store stack, hoists state, and tears down",
@@ -161,6 +246,358 @@ test.provider(
           const keyState = yield* kms.describeKey({ KeyId: keyId });
           expect(keyState.KeyMetadata?.KeyState).toBe("PendingDeletion");
         }
+      }).pipe(
+        Effect.ensuring(
+          teardown({ ...options, force: true }).pipe(Effect.orDie),
+        ),
+      );
+    }),
+  { timeout: 300_000 },
+);
+
+test.provider(
+  "resumes an interrupted bootstrap from the stranded local stack",
+  () =>
+    Effect.gen(function* () {
+      const { bucketName, kmsAlias, region } = yield* isolated("resume");
+      const options = { bucketName, kmsAlias };
+      const localStage = `testing_${bucketName}`;
+
+      yield* teardown({ ...options, force: true }).pipe(Effect.orDie);
+
+      yield* Effect.gen(function* () {
+        yield* bootstrap(options);
+        const keyId = (yield* kms.describeKey({ KeyId: kmsAlias })).KeyMetadata
+          ?.KeyId;
+
+        // Simulate a crash after the hoist but before the local cleanup:
+        // copy the stack's rows from S3 back into the local store, and
+        // drop one row from S3 (as if the hoist had also been partial).
+        const s3State = yield* makeS3State(options);
+        const localState = yield* makeLocalState();
+        const fqns = yield* s3State.list({
+          stack: STATE_STACK_NAME,
+          stage: region,
+        });
+        yield* Effect.forEach(fqns, (fqn) =>
+          Effect.flatMap(
+            s3State.get({ stack: STATE_STACK_NAME, stage: region, fqn }),
+            (value) =>
+              value === undefined
+                ? Effect.void
+                : localState
+                    .set({
+                      stack: STATE_STACK_NAME,
+                      stage: localStage,
+                      fqn,
+                      value,
+                    })
+                    .pipe(Effect.asVoid),
+          ),
+        );
+        yield* s3State.delete({
+          stack: STATE_STACK_NAME,
+          stage: region,
+          fqn: "StateAlias",
+        });
+
+        // The re-run must finish the bootstrap: converge, re-hoist the
+        // missing row, clean up the local stack, and keep the same key.
+        yield* bootstrap(options);
+        expect(
+          yield* hasLocalBootstrapStack(STATE_STACK_NAME, localStage),
+        ).toBe(false);
+        const fqnsAfter = yield* s3State.list({
+          stack: STATE_STACK_NAME,
+          stage: region,
+        });
+        expect([...fqnsAfter].sort()).toEqual([
+          "StateAlias",
+          "StateBucket",
+          "StateKey",
+        ]);
+        const keyAfter = (yield* kms.describeKey({ KeyId: kmsAlias }))
+          .KeyMetadata?.KeyId;
+        expect(keyAfter).toBe(keyId);
+      }).pipe(
+        Effect.ensuring(
+          teardown({ ...options, force: true }).pipe(Effect.orDie),
+        ),
+      );
+    }),
+  { timeout: 300_000 },
+);
+
+test.provider(
+  "heals an out-of-band key deletion + alias removal (the nuke scenario)",
+  () =>
+    Effect.gen(function* () {
+      const { bucketName, kmsAlias } = yield* isolated("nuked");
+      const options = { bucketName, kmsAlias };
+
+      yield* teardown({ ...options, force: true }).pipe(Effect.orDie);
+
+      yield* Effect.gen(function* () {
+        yield* bootstrap(options);
+        const s3State = yield* makeS3State(options);
+        yield* writeSecret(s3State, "NukeSurvivor", "sk-live-nuke-survivor");
+        const keyId = (yield* kms.describeKey({ KeyId: kmsAlias })).KeyMetadata
+          ?.KeyId;
+        expect(keyId).toBeDefined();
+
+        // Out-of-band cleanup: alias deleted, key scheduled for deletion.
+        yield* kms.deleteAlias({ AliasName: kmsAlias });
+        yield* kms.scheduleKeyDeletion({
+          KeyId: keyId!,
+          PendingWindowInDays: 7,
+        });
+
+        // Re-bootstrap must recover the SAME key (replacing it would
+        // strand the encrypted state) and restore the alias.
+        yield* bootstrap(options);
+        const after = yield* kms.describeKey({ KeyId: kmsAlias });
+        expect(after.KeyMetadata?.KeyId).toBe(keyId);
+        expect(after.KeyMetadata?.KeyState).toBe("Enabled");
+
+        // Secrets written before the nuke still read.
+        const fresh = yield* makeS3State(options);
+        expect(yield* readSecret(fresh, "NukeSurvivor")).toBe(
+          "sk-live-nuke-survivor",
+        );
+      }).pipe(
+        Effect.ensuring(
+          teardown({ ...options, force: true }).pipe(Effect.orDie),
+        ),
+      );
+    }),
+  { timeout: 300_000 },
+);
+
+test.provider(
+  "re-bootstraps after the state bucket is deleted out-of-band",
+  () =>
+    Effect.gen(function* () {
+      const { bucketName, kmsAlias } = yield* isolated("bktgone");
+      const options = { bucketName, kmsAlias };
+
+      yield* teardown({ ...options, force: true }).pipe(Effect.orDie);
+
+      yield* Effect.gen(function* () {
+        yield* bootstrap(options);
+        // The bucket (and the stack state inside it) vanishes.
+        yield* nukeBucket(bucketName);
+
+        // Bootstrap starts over: recreates the bucket, adopts the
+        // still-existing alias, and produces a fully working store.
+        yield* bootstrap(options);
+        const key = yield* kms.describeKey({ KeyId: kmsAlias });
+        expect(key.KeyMetadata?.KeyState).toBe("Enabled");
+        const s3State = yield* makeS3State(options);
+        yield* writeSecret(s3State, "AfterLoss", "sk-live-after-loss");
+        expect(yield* readSecret(s3State, "AfterLoss")).toBe(
+          "sk-live-after-loss",
+        );
+      }).pipe(
+        Effect.ensuring(
+          teardown({ ...options, force: true }).pipe(Effect.orDie),
+        ),
+      );
+    }),
+  { timeout: 300_000 },
+);
+
+test.provider(
+  "restores a deleted data-key object from bucket versions instead of stranding secrets",
+  () =>
+    Effect.gen(function* () {
+      const { bucketName, kmsAlias } = yield* isolated("dkgone");
+      const options = { bucketName, kmsAlias };
+
+      yield* teardown({ ...options, force: true }).pipe(Effect.orDie);
+
+      yield* Effect.gen(function* () {
+        yield* bootstrap(options);
+        const s3State = yield* makeS3State(options);
+        yield* writeSecret(s3State, "VersionedSecret", "sk-live-versioned");
+
+        // Out-of-band delete of the wrapped data key object. Without
+        // version restore a fresh data key would be minted and every
+        // existing secret would become permanently unreadable.
+        yield* s3.deleteObject({
+          Bucket: bucketName,
+          Key: "__state_key__.json",
+        });
+
+        const fresh = yield* makeS3State(options);
+        expect(yield* readSecret(fresh, "VersionedSecret")).toBe(
+          "sk-live-versioned",
+        );
+        // The object is re-established as the current version.
+        const restored = yield* s3
+          .getObject({ Bucket: bucketName, Key: "__state_key__.json" })
+          .pipe(
+            Effect.map(() => true),
+            Effect.catchTag("NoSuchKey", () => Effect.succeed(false)),
+          );
+        expect(restored).toBe(true);
+      }).pipe(
+        Effect.ensuring(
+          teardown({ ...options, force: true }).pipe(Effect.orDie),
+        ),
+      );
+    }),
+  { timeout: 300_000 },
+);
+
+test.provider(
+  "migrates a legacy imperative store: adopts the bucket and re-wraps the data key",
+  () =>
+    Effect.gen(function* () {
+      const { bucketName, kmsAlias } = yield* isolated("legacy");
+      const options = { bucketName, kmsAlias };
+
+      yield* teardown({ ...options, force: true }).pipe(Effect.orDie);
+
+      yield* Effect.gen(function* () {
+        // The old world: the silent imperative path creates the bucket,
+        // mints a key behind the alias, and wraps a data key with it.
+        const legacyState = yield* makeS3State(options);
+        yield* writeSecret(legacyState, "LegacySecret", "sk-live-legacy");
+        const legacyKeyId = (yield* kms.describeKey({ KeyId: kmsAlias }))
+          .KeyMetadata?.KeyId;
+        expect(legacyKeyId).toBeDefined();
+
+        // Bootstrap takes over: adopts the bucket + alias onto the
+        // stack-managed key and re-wraps the data key under it, so the
+        // legacy key stops being load-bearing.
+        yield* bootstrap(options);
+        const aliasTarget = (yield* kms.describeKey({ KeyId: kmsAlias }))
+          .KeyMetadata?.KeyId;
+        expect(aliasTarget).toBeDefined();
+        expect(aliasTarget).not.toBe(legacyKeyId);
+
+        const wrapped = yield* s3
+          .getObject({ Bucket: bucketName, Key: "__state_key__.json" })
+          .pipe(
+            Effect.flatMap((r) =>
+              r.Body === undefined
+                ? Effect.succeed("")
+                : Stream.mkString(Stream.decodeText(r.Body)),
+            ),
+            Effect.map((text) => JSON.parse(text) as { keyId?: string }),
+          );
+        const wrappingKey = (yield* kms.describeKey({
+          KeyId: wrapped.keyId!,
+        })).KeyMetadata?.KeyId;
+        expect(wrappingKey).toBe(aliasTarget);
+
+        // Old secrets still read, new secrets still write — through a
+        // fresh store instance (fresh codec cache).
+        const fresh = yield* makeS3State(options);
+        expect(yield* readSecret(fresh, "LegacySecret")).toBe("sk-live-legacy");
+        yield* writeSecret(fresh, "PostMigration", "sk-live-post-migration");
+        expect(yield* readSecret(fresh, "PostMigration")).toBe(
+          "sk-live-post-migration",
+        );
+
+        // Retire the now-unreferenced legacy key.
+        yield* kms.scheduleKeyDeletion({
+          KeyId: legacyKeyId!,
+          PendingWindowInDays: 7,
+        });
+      }).pipe(
+        Effect.ensuring(
+          teardown({ ...options, force: true }).pipe(Effect.orDie),
+        ),
+      );
+    }),
+  { timeout: 300_000 },
+);
+
+test.provider(
+  "the consent seam fires for missing infrastructure and never creates silently",
+  () =>
+    Effect.gen(function* () {
+      const { bucketName, kmsAlias } = yield* isolated("consent");
+      const consent: Array<string> = [];
+
+      // Missing bucket: the hook fires before anything is created; its
+      // failure aborts the operation and the bucket is NOT created.
+      const gated = yield* makeS3State({
+        bucketName,
+        kmsAlias,
+        onMissingInfra: (which) =>
+          Effect.sync(() => {
+            consent.push(which);
+          }).pipe(
+            Effect.andThen(
+              Effect.fail(
+                new StateStoreError({ message: `declined:${which}` }),
+              ),
+            ),
+          ),
+      });
+      const result = yield* gated.listStacks().pipe(
+        Effect.map(() => "created"),
+        Effect.catchTag("StateStoreError", (e) => Effect.succeed(e.message)),
+      );
+      expect(result).toBe("declined:bucket");
+      expect(consent).toEqual(["bucket"]);
+      const bucketExists = yield* s3.headBucket({ Bucket: bucketName }).pipe(
+        Effect.map(() => true),
+        Effect.catchTag(["NotFound", "NoSuchBucket"], () =>
+          Effect.succeed(false),
+        ),
+      );
+      expect(bucketExists).toBe(false);
+    }),
+  { timeout: 120_000 },
+);
+
+test.provider(
+  "teardown is idempotent and survives its own crash windows",
+  () =>
+    Effect.gen(function* () {
+      const { bucketName, kmsAlias } = yield* isolated("tdown");
+      const options = { bucketName, kmsAlias };
+
+      yield* teardown({ ...options, force: true }).pipe(Effect.orDie);
+
+      yield* Effect.gen(function* () {
+        yield* bootstrap(options);
+        const keyId = (yield* kms.describeKey({ KeyId: kmsAlias })).KeyMetadata
+          ?.KeyId;
+
+        // Simulate the worst crash window: the key is already pending
+        // deletion (as if a previous teardown died right after
+        // scheduling it) while alias + bucket still exist.
+        yield* kms.scheduleKeyDeletion({
+          KeyId: keyId!,
+          PendingWindowInDays: 7,
+        });
+
+        // Teardown completes from that state…
+        yield* teardown({ ...options, force: true });
+        // …and a second run is a clean no-op.
+        yield* teardown({ ...options, force: true });
+
+        const bucketGone = yield* s3.headBucket({ Bucket: bucketName }).pipe(
+          Effect.map(() => false),
+          Effect.catchTag(["NotFound", "NoSuchBucket"], () =>
+            Effect.succeed(true),
+          ),
+        );
+        expect(bucketGone).toBe(true);
+        const aliasGone = yield* kms.describeKey({ KeyId: kmsAlias }).pipe(
+          Effect.map(() => false),
+          Effect.catchTag("NotFoundException", () => Effect.succeed(true)),
+        );
+        expect(aliasGone).toBe(true);
+        // And bootstrap can still resurrect the store afterwards.
+        yield* bootstrap(options);
+        const s3State = yield* makeS3State(options);
+        yield* writeSecret(s3State, "Reborn", "sk-live-reborn");
+        expect(yield* readSecret(s3State, "Reborn")).toBe("sk-live-reborn");
       }).pipe(
         Effect.ensuring(
           teardown({ ...options, force: true }).pipe(Effect.orDie),

--- a/packages/alchemy/test/AWS/StateStore/Bootstrap.test.ts
+++ b/packages/alchemy/test/AWS/StateStore/Bootstrap.test.ts
@@ -1,0 +1,171 @@
+import * as AWS from "@/AWS";
+import {
+  bootstrap,
+  STATE_STACK_NAME,
+  teardown,
+} from "@/AWS/StateStore/Bootstrap.ts";
+import { makeS3State } from "@/AWS";
+import type { ResourceState } from "@/State";
+import { hasLocalBootstrapStack } from "@/State/Bootstrap.ts";
+import * as Test from "@/Test/Alchemy";
+import * as kms from "@distilled.cloud/aws/kms";
+import * as s3 from "@distilled.cloud/aws/s3";
+import { expect } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import * as Redacted from "effect/Redacted";
+import * as Stream from "effect/Stream";
+
+const { test } = Test.make({ providers: AWS.providers() });
+
+// Isolated from the shared testing state bucket/key: this suite creates
+// and destroys its own store end-to-end.
+const KMS_ALIAS = "alias/alchemy-state-btest" as const;
+const bucketNameFor = (accountId: string, region: string) =>
+  `alchemy-state-btest-${accountId}-${region}-an`.toLowerCase();
+
+test.provider(
+  "bootstrap deploys the state store stack, hoists state, and tears down",
+  () =>
+    Effect.gen(function* () {
+      const { accountId, region } = yield* AWS.AWSEnvironment.current;
+      const bucketName = bucketNameFor(accountId, region);
+      const options = { bucketName, kmsAlias: KMS_ALIAS };
+
+      // Clean slate from any prior interrupted run.
+      yield* teardown({ ...options, force: true }).pipe(Effect.orDie);
+
+      yield* Effect.gen(function* () {
+        // 1. Fresh bootstrap: deploy with local state, hoist into the bucket.
+        const result = yield* bootstrap(options);
+        expect(result.bucketName).toBe(bucketName);
+
+        // The bucket exists with the secure defaults from the stack.
+        const versioning = yield* s3.getBucketVersioning({
+          Bucket: bucketName,
+        });
+        expect(versioning.Status).toBe("Enabled");
+        const publicAccess = yield* s3.getPublicAccessBlock({
+          Bucket: bucketName,
+        });
+        expect(publicAccess.PublicAccessBlockConfiguration).toEqual({
+          BlockPublicAcls: true,
+          IgnorePublicAcls: true,
+          BlockPublicPolicy: true,
+          RestrictPublicBuckets: true,
+        });
+
+        // The alias resolves to an enabled key.
+        const key = yield* kms.describeKey({ KeyId: KMS_ALIAS });
+        expect(key.KeyMetadata?.KeyState).toBe("Enabled");
+        const keyId = key.KeyMetadata?.KeyId;
+
+        // The stack's own state was hoisted into the bucket it created…
+        const s3State = yield* makeS3State(options);
+        const fqns = yield* s3State.list({
+          stack: STATE_STACK_NAME,
+          stage: region,
+        });
+        expect([...fqns].sort()).toEqual([
+          "StateAlias",
+          "StateBucket",
+          "StateKey",
+        ]);
+        // …and the local copy is gone.
+        expect(
+          yield* hasLocalBootstrapStack(
+            STATE_STACK_NAME,
+            `testing_${bucketName}`,
+          ),
+        ).toBe(false);
+
+        // 2. Secrets round-trip through the bootstrapped store under the
+        //    stack-managed key.
+        const value = {
+          resourceType: "test:resource",
+          namespace: undefined,
+          fqn: "SecretResource",
+          logicalId: "SecretResource",
+          instanceId: "instance-SecretResource",
+          providerVersion: 1,
+          status: "created",
+          downstream: [],
+          bindings: [],
+          props: { apiKey: Redacted.make("sk-live-bootstrap-secret") },
+          attr: {},
+        } as ResourceState;
+        yield* s3State.set({
+          stack: "BootstrapSecretTest",
+          stage: "test",
+          fqn: value.fqn,
+          value,
+        });
+        const raw = yield* s3
+          .getObject({
+            Bucket: bucketName,
+            Key: "BootstrapSecretTest/test/SecretResource.json",
+          })
+          .pipe(
+            Effect.flatMap((r) =>
+              r.Body === undefined
+                ? Effect.succeed("")
+                : Stream.mkString(Stream.decodeText(r.Body)),
+            ),
+          );
+        expect(raw).toContain("__secret__");
+        expect(raw).not.toContain("sk-live-bootstrap-secret");
+        const revived = (yield* s3State.get({
+          stack: "BootstrapSecretTest",
+          stage: "test",
+          fqn: "SecretResource",
+        })) as ResourceState | undefined;
+        expect(
+          Redacted.value(
+            (revived?.props as { apiKey: Redacted.Redacted<string> }).apiKey,
+          ),
+        ).toBe("sk-live-bootstrap-secret");
+
+        // 3. Idempotent re-run: converges against the state in the bucket
+        //    without minting a new key.
+        yield* bootstrap(options);
+        const keyAfter = yield* kms.describeKey({ KeyId: KMS_ALIAS });
+        expect(keyAfter.KeyMetadata?.KeyId).toBe(keyId);
+
+        // 4. Teardown refuses while foreign stack state is present…
+        const refused = yield* teardown(options).pipe(
+          Effect.map(() => "completed"),
+          Effect.catchTag("StateStoreError", (e) =>
+            Effect.succeed(
+              e.message.includes("BootstrapSecretTest")
+                ? "refused"
+                : `wrong-message: ${e.message}`,
+            ),
+          ),
+        );
+        expect(refused).toBe("refused");
+
+        // …and with force deletes bucket, alias, and schedules the key.
+        yield* teardown({ ...options, force: true });
+        const bucketGone = yield* s3.headBucket({ Bucket: bucketName }).pipe(
+          Effect.map(() => false),
+          Effect.catchTag(["NotFound", "NoSuchBucket"], () =>
+            Effect.succeed(true),
+          ),
+        );
+        expect(bucketGone).toBe(true);
+        const aliasGone = yield* kms.describeKey({ KeyId: KMS_ALIAS }).pipe(
+          Effect.map(() => false),
+          Effect.catchTag("NotFoundException", () => Effect.succeed(true)),
+        );
+        expect(aliasGone).toBe(true);
+        if (keyId !== undefined) {
+          const keyState = yield* kms.describeKey({ KeyId: keyId });
+          expect(keyState.KeyMetadata?.KeyState).toBe("PendingDeletion");
+        }
+      }).pipe(
+        Effect.ensuring(
+          teardown({ ...options, force: true }).pipe(Effect.orDie),
+        ),
+      );
+    }),
+  { timeout: 300_000 },
+);

--- a/website/src/content/docs/environments/secrets.mdx
+++ b/website/src/content/docs/environments/secrets.mdx
@@ -195,13 +195,16 @@ key for you to manage; each store has an automatic key source:
   in your home directory, state inside the repo is unreadable on its
   own — an agent (or an accidental commit) never sees a plaintext
   secret.
-- **S3 state** (`AWS.state()`) uses KMS envelope encryption: the first
-  time a secret is written, the store creates (or reuses) the
-  `alias/alchemy-state` KMS key, mints a data key, and stores the
-  KMS-wrapped data key in the bucket. Anyone who can deploy
+- **S3 state** (`AWS.state()`) uses KMS envelope encryption with the
+  `alias/alchemy-state` KMS key: on first use a data key is minted and
+  stored KMS-wrapped in the bucket. Anyone who can deploy
   (`kms:Decrypt`) can read state — teammates and CI work with nothing
-  to distribute. A stack with no secrets never touches KMS, so no
-  `kms:*` permission is required and no key is created. Opt out with
+  to distribute. The key (and the state bucket itself) are provisioned
+  by `alchemy aws bootstrap`, which deploys them as an ordinary alchemy
+  stack; when they are missing on first use, an interactive deploy asks
+  before creating them, and CI fails with instructions unless `--yes`
+  is passed. A stack with no secrets never touches KMS, so no `kms:*`
+  permission is required. Opt out with
   `AWS.state({ secretEncryption: "off" })`.
 - **The Cloudflare-hosted state store** (`Cloudflare.state()`)
   encrypts every record server-side with its own generated key held in


### PR DESCRIPTION
Stacked on #1030. The S3 state store's own infrastructure — the state bucket and the KMS secret-encryption key — is now provisioned as an alchemy stack, mirroring the Cloudflare state store bootstrap: deploy against local state, hoist the stack's state into the bucket it just created, delete the local copy.

```ts
// AwsStateStore stack (deployed by `alchemy aws bootstrap` or on consent)
const key = yield* Key("StateKey", { description: "Alchemy state store secret encryption key" });
const alias = yield* Alias("StateAlias", { aliasName: "alias/alchemy-state", targetKeyId: key.keyId });
const bucket = yield* Bucket("StateBucket", {
  bucketName, bucketNamespace: "account-regional",
  versioning: "Enabled", encryption: { sseAlgorithm: "AES256" },
  publicAccessBlock: { ...all true }, objectOwnership: "BucketOwnerEnforced",
});
```

### UX: consent instead of silent account mutation

`AWS.state()` now runs the Cloudflare-style flow when infrastructure is missing, at the exact moment it's needed (bucket on first state op, KMS key on first secret):

- Interactive TTY → `Do you want to deploy it?` prompt
- CI → actionable error: run `alchemy aws bootstrap`, pass `--yes`, or use `ALCHEMY_PASSWORD` / `secretEncryption: "off"`
- `--yes` (`AlchemyContext.updateStateStore`) → deploys automatically

`makeS3State` (programmatic API) keeps the silent auto-create path, so tests and library callers are unchanged.

### Bootstrap lifecycle

- `alchemy aws bootstrap` provisions the state store alongside the assets bucket. First run: deploy with local state → hoist into the bucket → delete local. Interrupted runs resume from the local stack (`hasLocalBootstrapStack`). Later runs find the stack's state in the bucket and converge in place — idempotent, no duplicate keys.
- `alchemy aws bootstrap --destroy` tears it down: refuses while the bucket holds other stacks' state (override with `--force`), empties the versioned bucket, deletes the alias, and schedules the key with a 7-day recovery window (re-running bootstrap inside the window recovers it via the existing pending-deletion recovery).
- Existing imperatively-created buckets/aliases are adopted (`adopt(true)`); drift in bucket settings is repaired by the Bucket reconciler instead of the hand-rolled fingerprint diffs.

### Supporting changes

- Shared hoist machinery extracted to `State/Bootstrap.ts` (`hasLocalBootstrapStack`, `hoistBootstrapStack` with pluggable retry); the Cloudflare store now uses it.
- `S3.Bucket` gains `bucketNamespace: "account-regional"` as a first-class prop (create-time, replace-on-change).
- `S3StateOptions` gains `kmsAlias` (default `alias/alchemy-state`) and the internal `onMissingInfra` consent seam.

### Never-brick hardening

Every failure mode we could construct is fixed and pinned by a live test (per-test isolated bucket + alias):

- **Re-running bootstrap always force-reconciles.** The plan's prop-diff cannot see out-of-band damage (deleted alias, key scheduled for deletion — persisted props are unchanged, everything plans noop, nothing heals). Forcing runs every reconciler's observe-ensure-sync flow; a no-op at the API level when the cloud is healthy. Found by the nuke-scenario test, which failed before this fix.
- **Deleted `__state_key__.json` restores from bucket versions** instead of minting a fresh data key that would permanently strand every existing secret (a true brick before this).
- **Bootstrap re-wraps the data key** under the stack-managed key when it's wrapped under the legacy imperative key, so that key stops being silently load-bearing (deleting it later would have bricked all secrets).
- **Teardown schedules key deletion before deleting the alias** — a crash between the two now leaves a recoverable alias→pending-key state instead of an aliasless key no rerun can find.

The battery: full lifecycle (deploy → hoist → secret round-trip → idempotent re-run → guarded teardown), resume from a stranded local stack with a partial hoist, nuke scenario (alias deleted + key pending → same key recovered, pre-nuke secrets readable), bucket deleted out-of-band, data-key object deleted, legacy store migration with rewrap, consent seam fires before anything is created, teardown idempotence including its own crash windows. All 8 green live, plus the existing state/encoding/Bucket suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
