### PR TITLE
fix(kubernetes): parse OCI Helm chart output

### DIFF
--- a/packages/alchemy/src/Kubernetes/internal/helm.ts
+++ b/packages/alchemy/src/Kubernetes/internal/helm.ts
@@ -141,8 +141,17 @@ export const parseRenderedManifests = (
   rendered: string,
 ): Effect.Effect<Array<KubernetesObjectDefinition>, HelmError> =>
   Effect.gen(function* () {
+    // Helm 4 writes OCI pull metadata to stdout before the rendered YAML.
+    // Strip only that exact leading preamble; chart output remains subject to
+    // the same strict Kubernetes object validation below.
+    const manifests = chart.startsWith("oci://")
+      ? rendered.replace(
+          /^Pulled: [^\r\n]+\r?\nDigest: [^\r\n]+\r?\n(?=---(?:\r?\n|$))/,
+          "",
+        )
+      : rendered;
     const documents = yield* Effect.try({
-      try: () => YAML.parseAllDocuments(rendered),
+      try: () => YAML.parseAllDocuments(manifests),
       catch: (cause) =>
         new HelmError({
           message: `Failed to parse rendered manifests from chart '${chart}'`,

--- a/packages/alchemy/test/Kubernetes/HelmChart.test.ts
+++ b/packages/alchemy/test/Kubernetes/HelmChart.test.ts
@@ -1,6 +1,9 @@
 import * as AWS from "@/AWS";
 import * as Kubernetes from "@/Kubernetes";
-import { renderHelmChart } from "@/Kubernetes/internal/helm.ts";
+import {
+  parseRenderedManifests,
+  renderHelmChart,
+} from "@/Kubernetes/internal/helm.ts";
 import * as Provider from "@/Provider";
 import * as Test from "@/Test/Alchemy";
 import * as NodeServices from "@effect/platform-node/NodeServices";
@@ -89,6 +92,69 @@ describe("renderHelmChart (local fixture)", (it) => {
           expect(result.failure._tag).toBe("HelmError");
         }
       }),
+  );
+});
+
+describe("parseRenderedManifests", (it) => {
+  it.effect("ignores Helm OCI pull metadata", () =>
+    Effect.gen(function* () {
+      const objects = yield* parseRenderedManifests(
+        "oci://registry.example.test/charts/example",
+        `Pulled: registry.example.test/charts/example:1.2.3
+Digest: sha256:0123456789abcdef
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example
+`,
+      );
+
+      expect(objects).toHaveLength(1);
+      expect(objects[0]?.kind).toBe("ConfigMap");
+      expect(objects[0]?.metadata.name).toBe("example");
+    }),
+  );
+
+  it.effect("rejects pull-shaped metadata for non-OCI charts", () =>
+    Effect.gen(function* () {
+      const result = yield* Effect.result(
+        parseRenderedManifests(
+          "example",
+          `Pulled: registry.example.test/charts/example:1.2.3
+Digest: sha256:0123456789abcdef
+`,
+        ),
+      );
+
+      expect(Result.isFailure(result)).toBe(true);
+      if (Result.isFailure(result)) {
+        expect(result.failure._tag).toBe("HelmError");
+      }
+    }),
+  );
+
+  it.effect("rejects pull metadata that is not the leading OCI preamble", () =>
+    Effect.gen(function* () {
+      const result = yield* Effect.result(
+        parseRenderedManifests(
+          "oci://registry.example.test/charts/example",
+          `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example
+---
+Pulled: registry.example.test/charts/example:1.2.3
+Digest: sha256:0123456789abcdef
+`,
+        ),
+      );
+
+      expect(Result.isFailure(result)).toBe(true);
+      if (Result.isFailure(result)) {
+        expect(result.failure._tag).toBe("HelmError");
+      }
+    }),
   );
 });
 


### PR DESCRIPTION
Handle Helm 4's OCI pull metadata without weakening manifest validation.

`helm template` can prefix OCI output with:

```text
Pulled: registry.example/charts/example:1.2.3
Digest: sha256:...
---
apiVersion: v1
kind: ConfigMap
```

Strip only that exact leading preamble for `oci://` charts. Pull-shaped documents elsewhere, and all other non-Kubernetes YAML objects, remain errors.

Adds regression coverage for OCI, non-OCI, and non-leading metadata cases.
