### PR TITLE
feat(cli): add bulk state read via `alchemy state export`

### DIFF
--- a/packages/alchemy/src/Cli/commands/state.ts
+++ b/packages/alchemy/src/Cli/commands/state.ts
@@ -262,6 +262,78 @@ const treeCommand = Command.make(
   ),
 );
 
+const optionalStackFlag = Flag.string("stack").pipe(
+  Flag.withDescription(
+    "Stack name to export. Omit to export ALL stacks in the store.",
+  ),
+  Flag.optional,
+  Flag.map(Option.getOrUndefined),
+);
+
+const optionalStageFlag = Flag.string("stage").pipe(
+  Flag.withDescription(
+    "Stage to export within the stack. Omit to export all stages.",
+  ),
+  Flag.optional,
+  Flag.map(Option.getOrUndefined),
+);
+
+/**
+ * Bulk state read: every matching resource record as one JSON
+ * document, so a whole estate is read in a single CLI invocation
+ * instead of `state resources` + one `state get` per FQN per
+ * stack/stage. Filter locally, e.g.:
+ *
+ * ```sh
+ * alchemy state export | jq '.resources[] | select(.state.resourceType == "AWS.EC2.Instance")'
+ * ```
+ */
+const exportCommand = Command.make(
+  "export",
+  {
+    stack: optionalStackFlag,
+    stageName: optionalStageFlag,
+    main: script,
+    envFile,
+    profile,
+    local: localFlag,
+  },
+  instrumentCommand("state.export")(
+    Effect.fn(function* ({ stack: stackName, stageName, ...rest }) {
+      if (stageName !== undefined && stackName === undefined) {
+        yield* Console.log(
+          "Error: cannot specify --stage without --stack. Pass the stack name via --stack.",
+        );
+        return yield* Effect.fail(new Error("missing stack"));
+      }
+
+      yield* withStateService(rest, (state) =>
+        Effect.gen(function* () {
+          const exported = yield* State.exportState(state, {
+            stack: stackName,
+            stage: stageName,
+          });
+          // Same JSON-friendly view `state get` prints: redacted
+          // secrets become `{ __redacted__: ... }`, Resources are
+          // flattened, etc.
+          yield* Console.log(
+            JSON.stringify(
+              {
+                resources: exported.resources.map((r) => ({
+                  ...r,
+                  state: encodeState(r.state),
+                })),
+              },
+              null,
+              2,
+            ),
+          );
+        }),
+      );
+    }),
+  ),
+);
+
 const clearStackFlag = Flag.string("stack").pipe(
   Flag.withDescription(
     "Stack name to clear. Omit to clear ALL stacks in the store.",
@@ -365,6 +437,7 @@ export const stateCommand = Command.make("state", {}).pipe(
     stagesCommand,
     resourcesCommand,
     getCommand,
+    exportCommand,
     treeCommand,
     clearCommand,
   ]),

--- a/packages/alchemy/src/State/Export.ts
+++ b/packages/alchemy/src/State/Export.ts
@@ -1,0 +1,96 @@
+import * as Effect from "effect/Effect";
+import type { PersistedState, StateService, StateStoreError } from "./State.ts";
+
+/**
+ * One resource record in a state export, addressed by the
+ * `(stack, stage, fqn)` triple so a flat list spans the whole estate.
+ */
+export interface ExportedResource {
+  /** Stack the record belongs to. */
+  stack: string;
+  /** Stage the record belongs to. */
+  stage: string;
+  /** Fully-qualified resource name (namespace path + logical ID). */
+  fqn: string;
+  /** The persisted record — the same value `state.get` returns. */
+  state: PersistedState;
+}
+
+/**
+ * A bulk read of the state store: every matching resource record in a
+ * single document. Shaped as a flat list so consumers can filter
+ * locally (e.g. `jq '.resources[] | select(...)'`) instead of issuing
+ * one read per resource.
+ */
+export interface StateExport {
+  resources: ExportedResource[];
+}
+
+/**
+ * Optional scope narrowing for {@link exportState}.
+ */
+export interface ExportStateFilter {
+  /** Only export this stack. Omit to export every stack in the store. */
+  stack?: string;
+  /** Only export this stage. Omit to export every stage. */
+  stage?: string;
+}
+
+/**
+ * Read every resource record in scope from the state store as one
+ * document.
+ *
+ * Traverses `listStacks → listStages → list → get` with the listing
+ * fan-out unbounded and the per-resource reads bounded, so a whole
+ * estate is fetched in a single pass instead of a call per resource.
+ * Records that disappear between `list` and `get` (a concurrent
+ * deploy/destroy) are skipped rather than failing the export.
+ *
+ * Results are ordered deterministically: by stack, then stage, then
+ * FQN.
+ */
+export const exportState = (
+  state: StateService,
+  filter: ExportStateFilter = {},
+): Effect.Effect<StateExport, StateStoreError> =>
+  Effect.gen(function* () {
+    const stacks =
+      filter.stack !== undefined
+        ? [filter.stack]
+        : [...(yield* state.listStacks())].sort();
+
+    const perStack = yield* Effect.forEach(
+      stacks,
+      (stack) =>
+        Effect.gen(function* () {
+          const stages =
+            filter.stage !== undefined
+              ? [filter.stage]
+              : [...(yield* state.listStages(stack))].sort();
+          return yield* Effect.forEach(
+            stages,
+            (stage) =>
+              Effect.gen(function* () {
+                const fqns = [...(yield* state.list({ stack, stage }))].sort();
+                const records = yield* Effect.forEach(
+                  fqns,
+                  (fqn) =>
+                    Effect.map(state.get({ stack, stage, fqn }), (value) =>
+                      value === undefined
+                        ? undefined
+                        : ({ stack, stage, fqn, state: value } as const),
+                    ),
+                  { concurrency: 16 },
+                );
+                return records.filter(
+                  (r): r is ExportedResource => r !== undefined,
+                );
+              }),
+            { concurrency: "unbounded" },
+          );
+        }),
+      { concurrency: "unbounded" },
+    );
+
+    return { resources: perStack.flat(2) };
+  });

--- a/packages/alchemy/src/State/index.ts
+++ b/packages/alchemy/src/State/index.ts
@@ -1,3 +1,4 @@
+export * from "./Export.ts";
 export * from "./HttpStateApi.ts";
 export * from "./HttpStateStore.ts";
 export * from "./InMemoryState.ts";

--- a/packages/alchemy/test/State/Export.test.ts
+++ b/packages/alchemy/test/State/Export.test.ts
@@ -1,0 +1,144 @@
+import { exportState, InMemoryService, type ResourceState } from "@/State";
+import { describe, expect, it } from "alchemy-test";
+import * as Effect from "effect/Effect";
+
+describe("exportState", () => {
+  it.effect("exports every stack/stage/resource as one document", () =>
+    Effect.gen(function* () {
+      const state = yield* InMemoryService({
+        "app-east": {
+          dev: {
+            WebServer: resource("WebServer", { instanceId: "i-1" }),
+            Database: resource("Database", { arn: "arn:db" }),
+          },
+          prod: {
+            WebServer: resource("WebServer", { instanceId: "i-2" }),
+          },
+        },
+        "app-west": {
+          dev: {
+            Bucket: resource("Bucket", { bucketName: "b-1" }),
+          },
+        },
+      });
+
+      const exported = yield* exportState(state);
+
+      // Deterministic order: stack, then stage, then FQN.
+      expect(
+        exported.resources.map((r) => `${r.stack}/${r.stage}/${r.fqn}`),
+      ).toEqual([
+        "app-east/dev/Database",
+        "app-east/dev/WebServer",
+        "app-east/prod/WebServer",
+        "app-west/dev/Bucket",
+      ]);
+
+      // Records are the same values `state.get` returns — props/attr intact.
+      const webServer = exported.resources.find(
+        (r) =>
+          r.stack === "app-east" && r.stage === "dev" && r.fqn === "WebServer",
+      );
+      expect(webServer?.state).toEqual(
+        yield* state.get({ stack: "app-east", stage: "dev", fqn: "WebServer" }),
+      );
+    }),
+  );
+
+  it.effect("filters by stack", () =>
+    Effect.gen(function* () {
+      const state = yield* InMemoryService({
+        "app-east": { dev: { A: resource("A", {}) } },
+        "app-west": { dev: { B: resource("B", {}) } },
+      });
+
+      const exported = yield* exportState(state, { stack: "app-west" });
+
+      expect(exported.resources.map((r) => `${r.stack}/${r.fqn}`)).toEqual([
+        "app-west/B",
+      ]);
+    }),
+  );
+
+  it.effect("filters by stack and stage", () =>
+    Effect.gen(function* () {
+      const state = yield* InMemoryService({
+        app: {
+          dev: { A: resource("A", {}) },
+          prod: { B: resource("B", {}) },
+        },
+      });
+
+      const exported = yield* exportState(state, {
+        stack: "app",
+        stage: "prod",
+      });
+
+      expect(
+        exported.resources.map((r) => `${r.stack}/${r.stage}/${r.fqn}`),
+      ).toEqual(["app/prod/B"]);
+    }),
+  );
+
+  it.effect("returns an empty document for an empty store", () =>
+    Effect.gen(function* () {
+      const state = yield* InMemoryService({});
+      expect(yield* exportState(state)).toEqual({ resources: [] });
+    }),
+  );
+
+  it.effect("tolerates a missing stack/stage filter target", () =>
+    Effect.gen(function* () {
+      const state = yield* InMemoryService({
+        app: { dev: { A: resource("A", {}) } },
+      });
+      expect(yield* exportState(state, { stack: "nope" })).toEqual({
+        resources: [],
+      });
+      expect(
+        yield* exportState(state, { stack: "app", stage: "nope" }),
+      ).toEqual({ resources: [] });
+    }),
+  );
+
+  it.effect("skips records deleted between list and get", () =>
+    Effect.gen(function* () {
+      const inner = yield* InMemoryService({
+        app: {
+          dev: {
+            A: resource("A", {}),
+            B: resource("B", {}),
+          },
+        },
+      });
+      // Simulate a concurrent destroy racing the export: `list` still
+      // returns the FQN but `get` comes back empty.
+      const racy = {
+        ...inner,
+        get: (request: { stack: string; stage: string; fqn: string }) =>
+          request.fqn === "A" ? Effect.succeed(undefined) : inner.get(request),
+      };
+
+      const exported = yield* exportState(racy);
+
+      expect(exported.resources.map((r) => r.fqn)).toEqual(["B"]);
+    }),
+  );
+});
+
+const resource = (
+  fqn: string,
+  attr: Record<string, unknown>,
+): ResourceState => ({
+  resourceType: "test:resource",
+  namespace: undefined,
+  fqn,
+  logicalId: fqn,
+  instanceId: `instance-${fqn}`,
+  providerVersion: 1,
+  status: "created",
+  downstream: [],
+  bindings: [],
+  props: {},
+  attr,
+});

--- a/website/src/content/docs/cli/index.mdx
+++ b/website/src/content/docs/cli/index.mdx
@@ -25,7 +25,7 @@ alchemy
 ├─ login [file]         # authenticate every provider in your stack
 ├─ profile show|clear   # inspect or wipe stored credentials
 │
-├─ state stacks|stages|resources|get|tree|clear   # inspect and manage the state store
+├─ state stacks|stages|resources|get|export|tree|clear   # inspect and manage the state store
 │
 ├─ aws bootstrap        # set up the per-account AWS assets bucket
 └─ cloudflare bootstrap|create-token|state logs   # state-store worker, API tokens, its logs

--- a/website/src/content/docs/cli/inspecting-state.mdx
+++ b/website/src/content/docs/cli/inspecting-state.mdx
@@ -44,6 +44,16 @@ bun alchemy state resources --stack myapp --stage dev_sam
 Prints the FQNs tracked under that stack/stage — the addresses
 `state get` takes.
 
+Or skip the drilling entirely and read the whole estate at once:
+
+```sh
+bun alchemy state export | jq '.resources[] | select(.state.resourceType == "AWS.EC2.Instance")'
+```
+
+One call returns every record across all stacks and stages as a
+single JSON document to filter locally — see
+[state export](/cli/state#state-export).
+
 ## Debugging a bad diff
 
 ```sh

--- a/website/src/content/docs/cli/state.mdx
+++ b/website/src/content/docs/cli/state.mdx
@@ -20,7 +20,7 @@ commands address what they inspect explicitly, so `--stack`,
 `--stage`, and `--fqn` are addressing flags that appear only on the
 subcommands that need them.
 
-All six subcommands share these options:
+All seven subcommands share these options:
 
 | Option              | Description                                                                                                                                    |
 | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -68,6 +68,58 @@ exists, it prints `(not found: <stack>/<stage>/<fqn>)`.
 # get the FQN from `state resources`, then:
 alchemy state get --stack MyApp --stage prod --fqn Bucket
 ```
+
+## `state export`
+
+```sh
+alchemy state export [--stack <stack>] [--stage <stage>] [file] [options]
+```
+
+Bulk state read: print every matching resource record as **one JSON
+document**, so a whole estate is read in a single invocation instead
+of `state resources` + one `state get` per FQN per stack/stage.
+
+- Omit `--stack` to export **all stacks** in the store.
+- Pass `--stack` to export every stage under that stack.
+- Pass `--stack` and `--stage` to export a single stage.
+- `--stage` without `--stack` is an error.
+
+The output is a flat `resources` array; each entry carries its
+`stack`, `stage`, and `fqn` alongside the same encoded record
+`state get` prints (`props` and `attr` intact, secrets as
+`{ __redacted__: ... }`):
+
+```json
+{
+  "resources": [
+    {
+      "stack": "my-app",
+      "stage": "prod",
+      "fqn": "WebServer",
+      "state": {
+        "resourceType": "AWS.EC2.Instance",
+        "props": { "instanceType": "t3.large" },
+        "attr": { "instanceId": "i-0456" }
+      }
+    }
+  ]
+}
+```
+
+The flat shape is made for local filtering — one call, then `jq`:
+
+```sh
+# every EC2 instance across all stacks and stages
+alchemy state export | jq '.resources[] | select(.state.resourceType == "AWS.EC2.Instance")'
+
+# diff two stages
+diff <(alchemy state export --stack my-app --stage dev) \
+     <(alchemy state export --stack my-app --stage prod)
+```
+
+Entries are ordered deterministically (stack, then stage, then FQN),
+so exports are stable across runs and safe to diff or assert on in
+CI.
 
 ## `state tree`
 


### PR DESCRIPTION
Reading a whole estate previously took one CLI invocation per resource
(`state resources` + `state get` per FQN per stack/stage). `state export`
returns every matching record as one JSON document:

    alchemy state export [--stack <stack>] [--stage <stage>] [--local]

- flat `resources` array of `{ stack, stage, fqn, state }`, filterable
  locally with jq, same encoded record `state get` prints
- omit `--stack` for all stacks; `--stage` narrows within a stack
- fetches concurrently in one pass; records deleted mid-export are
  skipped instead of failing
- deterministic ordering (stack, stage, FQN) so exports diff cleanly
- `exportState` exported from `alchemy/State` for programmatic use

Closes #1036

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013b2HHKxn26ZCyEAsCEQLmw