### PR TITLE
fix(cloudflare/worker): hash the assets directory during plan diff

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -622,6 +622,11 @@ export interface WorkerProps<
    * - An AssetsProps object with directory and config
    * - An object with path and hash (e.g., from a Build resource)
    *
+   * Plans hash the directory contents, so an unchanged tree converges to a
+   * noop. Supplying a precomputed `hash` (e.g. from a Build resource) makes
+   * that hash authoritative instead — the directory is not read during
+   * planning at all.
+   *
    * When neither {@link main} nor {@link script} is provided, the Worker is
    * deployed **assets-only**: no script is uploaded at all and Cloudflare's
    * asset layer serves every request, applying `htmlHandling` /

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -19,7 +19,7 @@ import { Unowned } from "../../AdoptPolicy.ts";
 import * as Artifacts from "../../Artifacts.ts";
 import type { ScopedPlanStatusSession } from "../../Cli/Cli.ts";
 import { hashDirectory, type MemoOptions } from "../../Command/Memo.ts";
-import { isResolved, stripEffects } from "../../Diff.ts";
+import { havePropsChanged, isResolved, stripEffects } from "../../Diff.ts";
 import * as ProviderLayer from "../../Local/ProviderLayer.ts";
 import * as Provider from "../../Provider.ts";
 import { type ResourceBinding } from "../../Resource.ts";
@@ -3791,7 +3791,13 @@ export const LiveWorkerProvider = () =>
         if (!assets) {
           return false;
         }
-        if (Predicate.hasProperty(assets, "hash")) {
+        // An explicitly-undefined `hash` (`{ directory, hash: maybe }`) is
+        // the hash-less shape, not a supplied hash — fall through to the
+        // directory read instead of comparing undefined forever-dirty.
+        if (
+          Predicate.hasProperty(assets, "hash") &&
+          assets.hash !== undefined
+        ) {
           return assets.hash !== output.hash?.assets;
         }
         const read = yield* prepareAssets(assets).pipe(
@@ -4132,6 +4138,47 @@ export const LiveWorkerProvider = () =>
               action: "update",
               stables: stables.length > 0 ? stables : undefined,
             };
+          }
+          // Machine-local source locations (`main`, `assets.directory`,
+          // `vite.rootDir`) name WHERE the source lives; their deploy-relevant
+          // effect is fully captured by the content hashes `hasChanged` just
+          // compared (bundle, asset content, vite input — all deliberately
+          // path-independent). Left alone, the engine's raw-props fallback
+          // would still flag a relocated checkout (CI runner ↔ laptop, temp
+          // build dirs) as changed forever. When the ONLY residual raw-prop
+          // difference is such a path, suppress the fallback with an explicit
+          // noop; any other residual difference still falls through to the
+          // engine's conservative comparison, so props outside the hashed
+          // metadata surface keep deploying (#745). Guarded on resolved
+          // bindings — without them the metadata hash was skipped above and
+          // the raw-props fallback is the only net for metadata edits.
+          if (Array.isArray(newBindings)) {
+            const normalizeSourcePaths = (props: WorkerProps) => ({
+              ...props,
+              ...(props.main !== undefined ? { main: "<source>" } : undefined),
+              ...(props.assets
+                ? {
+                    assets: {
+                      ...(typeof props.assets === "string"
+                        ? undefined
+                        : props.assets),
+                      directory: "<source>",
+                    },
+                  }
+                : undefined),
+              ...(props.vite
+                ? { vite: { ...props.vite, rootDir: "<source>" } }
+                : undefined),
+            });
+            if (
+              olds !== undefined &&
+              !havePropsChanged(
+                normalizeSourcePaths(olds),
+                normalizeSourcePaths(news),
+              )
+            ) {
+              return { action: "noop" };
+            }
           }
         }),
         precreate: Effect.fn(function* ({ id, news, session, bindings }) {

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -3764,6 +3764,45 @@ export const LiveWorkerProvider = () =>
         } satisfies Worker["Attributes"];
       });
 
+      // Compare the desired assets against the deployed asset-content hash.
+      //
+      // For `AssetsWithHash` (the documented `Command.Build` contract) the
+      // upstream build already produced an authoritative hash — compare
+      // strings without touching the filesystem. Reading the directory here
+      // would crash when the prior state was written on a different machine
+      // and the path doesn't exist locally, blocking any local reapply even
+      // though the precomputed hash is right there in props.
+      //
+      // For the plain `string` / `AssetsProps` shapes there is no hash in
+      // props, so read + hash the directory exactly like the apply path does
+      // (`readAssets`) and compare against the stored content hash — an
+      // unchanged tree converges to a noop plan instead of a forever-dirty
+      // conservative update. The overall read cost is unchanged: previously
+      // every plan reported "changed" and `putWorker` read the tree during
+      // apply only to discover nothing changed (`keepAssets`); now the diff
+      // reads it and a match skips reconcile entirely. A directory that is
+      // missing or invalid at plan time (e.g. produced by an upstream build
+      // step that only runs during apply) degrades to "changed" — apply
+      // reads it once and either uploads or surfaces the real typed error.
+      const assetsChanged = Effect.fn(function* (
+        assets: WorkerProps["assets"],
+        output: Worker["Attributes"],
+      ) {
+        if (!assets) {
+          return false;
+        }
+        if (Predicate.hasProperty(assets, "hash")) {
+          return assets.hash !== output.hash?.assets;
+        }
+        const read = yield* prepareAssets(assets).pipe(
+          Effect.catchTag(
+            ["PlatformError", "AssetTooLargeError", "TooManyAssetsError"],
+            () => Effect.succeed(undefined),
+          ),
+        );
+        return read === undefined || read.hash !== output.hash?.assets;
+      });
+
       const hasChanged = Effect.fn(function* (
         id: string,
         props: WorkerProps,
@@ -3816,16 +3855,7 @@ export const LiveWorkerProvider = () =>
           if (scriptHash !== output.hash?.bundle) {
             return true;
           }
-          if (!props.assets) {
-            return false;
-          }
-          const assetsHash = Predicate.hasProperty(props.assets, "hash")
-            ? props.assets.hash
-            : undefined;
-          if (assetsHash === undefined) {
-            return true;
-          }
-          return assetsHash !== output.hash?.assets;
+          return yield* assetsChanged(props.assets, output);
         }
         if (props.vite) {
           const { hash } = yield* hashViteInput(
@@ -3842,17 +3872,12 @@ export const LiveWorkerProvider = () =>
           if (output.hash?.bundle !== undefined) {
             return true;
           }
-          const assetsHash =
-            props.assets && Predicate.hasProperty(props.assets, "hash")
-              ? props.assets.hash
-              : undefined;
-          if (assetsHash === undefined) {
-            // Same conservative rule as the directory-shaped `assets` below:
-            // don't read the directory during diff; `putWorker` reads once
-            // and keeps the existing manifest if nothing actually changed.
+          // No assets either — the config is invalid; report "changed" so
+          // the apply runs and surfaces the descriptive error.
+          if (!props.assets) {
             return true;
           }
-          return assetsHash !== output.hash?.assets;
+          return yield* assetsChanged(props.assets, output);
         }
         const bundleHash = yield* prepareBundle(id, props).pipe(
           Effect.map((b) => b.hash),
@@ -3860,32 +3885,7 @@ export const LiveWorkerProvider = () =>
         if (bundleHash !== output.hash?.bundle) {
           return true;
         }
-        if (!props.assets) {
-          return false;
-        }
-        // We deliberately don't read the assets directory during diff.
-        // For `AssetsWithHash` (the documented contract) the upstream
-        // `Command.Build` already gave us an authoritative hash — we
-        // just compare strings. Reading the directory here would
-        // (a) hash the same tree twice per apply (`putWorker` reads
-        // again when an upload is actually required), and (b) crash
-        // when the prior state was written on a different machine
-        // and `path` doesn't exist locally — blocking any local
-        // reapply even though the precomputed hash is right there
-        // in props.
-        //
-        // For the legacy `string` / `AssetsProps` shapes there's no
-        // hash in props to compare against, so we conservatively
-        // assume the assets changed; `putWorker` will read once,
-        // hash, and use `keepAssets` if it turns out nothing actually
-        // changed.
-        const assetsHash = Predicate.hasProperty(props.assets, "hash")
-          ? props.assets.hash
-          : undefined;
-        if (assetsHash === undefined) {
-          return true;
-        }
-        return assetsHash !== output.hash?.assets;
+        return yield* assetsChanged(props.assets, output);
       });
 
       return Worker.Provider.of({

--- a/packages/alchemy/test/Cloudflare/Workers/AssetsPlanConvergence.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/AssetsPlanConvergence.test.ts
@@ -50,34 +50,34 @@ describe.concurrent("Cloudflare.Worker assets plan convergence", () => {
         // conservative "changed" whenever `assets` carried no precomputed
         // hash: bundled main + assets, assets-only (no entry), and inline
         // script + assets.
-        const program = () =>
+        const program = (a: string, b: string) =>
           Effect.gen(function* () {
             const withMain = yield* Cloudflare.Worker("AssetsPlanWithMain", {
               main,
-              assets: { directory: dirA },
+              assets: { directory: a },
               compatibility: { date: "2024-01-01" },
             });
             const assetsOnly = yield* Cloudflare.Worker(
               "AssetsPlanAssetsOnly",
               {
-                assets: { directory: dirB, notFoundHandling: "404-page" },
+                assets: { directory: b, notFoundHandling: "404-page" },
                 compatibility: { date: "2024-01-01" },
               },
             );
             const withScript = yield* Cloudflare.Worker("AssetsPlanScript", {
               script: `export default { fetch: () => new Response("assets-plan-script") };`,
-              assets: { directory: dirB },
+              assets: { directory: b },
               compatibility: { date: "2024-01-01" },
             });
             return { withMain, assetsOnly, withScript };
           });
 
-        yield* stack.deploy(program());
+        yield* stack.deploy(program(dirA, dirB));
 
         // Nothing changed → every worker must plan as a noop. This is the
         // regression: the diff used to refuse to read the assets directory
         // and conservatively reported "update" on every plan.
-        const settled = yield* stack.plan(program());
+        const settled = yield* stack.plan(program(dirA, dirB));
         expect(actionOf(settled, "AssetsPlanWithMain")).toBe("noop");
         expect(actionOf(settled, "AssetsPlanAssetsOnly")).toBe("noop");
         expect(actionOf(settled, "AssetsPlanScript")).toBe("noop");
@@ -88,17 +88,113 @@ describe.concurrent("Cloudflare.Worker assets plan convergence", () => {
           path.join(dirA, "index.html"),
           "<html><body>alchemy-assets-plan-index-v2</body></html>",
         );
-        const changed = yield* stack.plan(program());
+        const changed = yield* stack.plan(program(dirA, dirB));
         expect(actionOf(changed, "AssetsPlanWithMain")).toBe("update");
         expect(actionOf(changed, "AssetsPlanAssetsOnly")).toBe("noop");
         expect(actionOf(changed, "AssetsPlanScript")).toBe("noop");
 
         // Deploying the change re-settles the plan.
-        yield* stack.deploy(program());
-        const resettled = yield* stack.plan(program());
+        yield* stack.deploy(program(dirA, dirB));
+        const resettled = yield* stack.plan(program(dirA, dirB));
         expect(actionOf(resettled, "AssetsPlanWithMain")).toBe("noop");
         expect(actionOf(resettled, "AssetsPlanAssetsOnly")).toBe("noop");
         expect(actionOf(resettled, "AssetsPlanScript")).toBe("noop");
+
+        // Path invariance: identical bytes at a different absolute path
+        // must hash identically — a plan made from a different checkout
+        // (CI runner → laptop, monorepo root → workspace root) converges
+        // without spurious updates. The directory path is deliberately
+        // excluded from the content hash.
+        const dirB2 = yield* cloneFixture(dirB, {
+          prefix: "alchemy-assets-plan-b2-",
+        });
+        const moved = yield* stack.plan(program(dirA, dirB2));
+        expect(actionOf(moved, "AssetsPlanAssetsOnly")).toBe("noop");
+        expect(actionOf(moved, "AssetsPlanScript")).toBe("noop");
+
+        // `.assetsignore` and the files it excludes participate in neither
+        // the manifest nor the hash — adding them must stay a noop.
+        yield* fs.writeFileString(path.join(dirB, ".assetsignore"), "junk.txt");
+        yield* fs.writeFileString(path.join(dirB, "junk.txt"), "not-an-asset");
+        const ignored = yield* stack.plan(program(dirA, dirB));
+        expect(actionOf(ignored, "AssetsPlanAssetsOnly")).toBe("noop");
+        expect(actionOf(ignored, "AssetsPlanScript")).toBe("noop");
+
+        // `_headers` is excluded from the manifest but shipped via the
+        // asset config, so editing it must dirty every worker serving the
+        // directory.
+        yield* fs.writeFileString(
+          path.join(dirB, "_headers"),
+          "/*\n  X-Assets-Plan: v1\n",
+        );
+        const headers = yield* stack.plan(program(dirA, dirB));
+        expect(actionOf(headers, "AssetsPlanWithMain")).toBe("noop");
+        expect(actionOf(headers, "AssetsPlanAssetsOnly")).toBe("update");
+        expect(actionOf(headers, "AssetsPlanScript")).toBe("update");
+        yield* fs.remove(path.join(dirB, "_headers"));
+        const headersReverted = yield* stack.plan(program(dirA, dirB));
+        expect(actionOf(headersReverted, "AssetsPlanAssetsOnly")).toBe("noop");
+        expect(actionOf(headersReverted, "AssetsPlanScript")).toBe("noop");
+
+        // A directory that's missing at plan time (e.g. produced by an
+        // upstream build step that only runs during apply) degrades to
+        // "update" — the plan must not crash.
+        yield* fs.remove(dirA, { recursive: true });
+        const missing = yield* stack.plan(program(dirA, dirB));
+        expect(actionOf(missing, "AssetsPlanWithMain")).toBe("update");
+        expect(actionOf(missing, "AssetsPlanAssetsOnly")).toBe("noop");
+        expect(actionOf(missing, "AssetsPlanScript")).toBe("noop");
+
+        yield* stack.destroy();
+      }),
+    { timeout: 360_000 },
+  );
+
+  // The migration path off a hand-rolled hash: a worker deployed with a
+  // user-supplied `assets.hash` whose props then drop the hash must plan
+  // exactly one update (the stored custom hash can't match the content
+  // hash), converge after the deploy, and dirty again if a different
+  // supplied hash is introduced.
+  test.provider(
+    "removing a supplied assets hash converges after one deploy",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const dir = yield* cloneFixture(assetsFixture, {
+          prefix: "alchemy-assets-hash-migration-",
+        });
+
+        const program = (hash?: string) =>
+          Effect.gen(function* () {
+            return yield* Cloudflare.Worker("AssetsHashMigration", {
+              main,
+              assets: hash ? { directory: dir, hash } : { directory: dir },
+              compatibility: { date: "2024-01-01" },
+            });
+          });
+
+        // Deployed with a hand-rolled hash: the supplied hash is
+        // authoritative, so an identical plan is a noop without reading
+        // the directory.
+        yield* stack.deploy(program("hand-rolled-hash-v1"));
+        const settled = yield* stack.plan(program("hand-rolled-hash-v1"));
+        expect(actionOf(settled, "AssetsHashMigration")).toBe("noop");
+
+        // Dropping the hash falls back to content hashing — the stored
+        // custom hash can't match, so exactly one update is planned...
+        const dropped = yield* stack.plan(program());
+        expect(actionOf(dropped, "AssetsHashMigration")).toBe("update");
+
+        // ...and after deploying, the stored hash is the content hash and
+        // the plan converges.
+        yield* stack.deploy(program());
+        const converged = yield* stack.plan(program());
+        expect(actionOf(converged, "AssetsHashMigration")).toBe("noop");
+
+        // Re-introducing a different supplied hash dirties the plan again.
+        const reintroduced = yield* stack.plan(program("hand-rolled-hash-v2"));
+        expect(actionOf(reintroduced, "AssetsHashMigration")).toBe("update");
 
         yield* stack.destroy();
       }),

--- a/packages/alchemy/test/Cloudflare/Workers/AssetsPlanConvergence.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/AssetsPlanConvergence.test.ts
@@ -1,0 +1,107 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Test from "@/Test/Alchemy";
+import { describe, expect } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as pathe from "pathe";
+import { cloneFixture } from "../Utils/Fixture.ts";
+
+const { test } = Test.make({ providers: Cloudflare.providers() });
+
+const main = pathe.resolve(import.meta.dirname, "fixtures/worker.ts");
+const assetsFixture = pathe.resolve(
+  import.meta.dirname,
+  "fixtures/assets-only",
+);
+
+const actionOf = (plan: any, logicalId: string) =>
+  (Object.values(plan.resources) as any[]).find(
+    (node: any) => node.resource.LogicalId === logicalId,
+  )?.action;
+
+describe.concurrent("Cloudflare.Worker assets plan convergence", () => {
+  // A Worker whose `assets` is a plain `{ directory }` (no precomputed
+  // `hash` from an upstream build) must still converge to a noop plan when
+  // the directory contents are unchanged. The diff hashes the tree the same
+  // way the apply does, so users don't have to hand-roll their own
+  // directory hashing to get convergent plans.
+  test.provider(
+    "unchanged assets directory converges to a noop plan",
+    (stack) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+
+        yield* stack.destroy();
+
+        // Two independent mutable copies of the assets fixture: `dirA`
+        // feeds the main+assets worker, `dirB` feeds the assets-only and
+        // script+assets workers, so editing `dirA` must dirty only the
+        // first worker.
+        const dirA = yield* cloneFixture(assetsFixture, {
+          prefix: "alchemy-assets-plan-a-",
+        });
+        const dirB = yield* cloneFixture(assetsFixture, {
+          prefix: "alchemy-assets-plan-b-",
+        });
+
+        // One worker per `hasChanged` branch that previously returned a
+        // conservative "changed" whenever `assets` carried no precomputed
+        // hash: bundled main + assets, assets-only (no entry), and inline
+        // script + assets.
+        const program = () =>
+          Effect.gen(function* () {
+            const withMain = yield* Cloudflare.Worker("AssetsPlanWithMain", {
+              main,
+              assets: { directory: dirA },
+              compatibility: { date: "2024-01-01" },
+            });
+            const assetsOnly = yield* Cloudflare.Worker(
+              "AssetsPlanAssetsOnly",
+              {
+                assets: { directory: dirB, notFoundHandling: "404-page" },
+                compatibility: { date: "2024-01-01" },
+              },
+            );
+            const withScript = yield* Cloudflare.Worker("AssetsPlanScript", {
+              script: `export default { fetch: () => new Response("assets-plan-script") };`,
+              assets: { directory: dirB },
+              compatibility: { date: "2024-01-01" },
+            });
+            return { withMain, assetsOnly, withScript };
+          });
+
+        yield* stack.deploy(program());
+
+        // Nothing changed → every worker must plan as a noop. This is the
+        // regression: the diff used to refuse to read the assets directory
+        // and conservatively reported "update" on every plan.
+        const settled = yield* stack.plan(program());
+        expect(actionOf(settled, "AssetsPlanWithMain")).toBe("noop");
+        expect(actionOf(settled, "AssetsPlanAssetsOnly")).toBe("noop");
+        expect(actionOf(settled, "AssetsPlanScript")).toBe("noop");
+
+        // Editing an asset in dirA must dirty exactly the worker that
+        // serves it — content changes still surface as updates.
+        yield* fs.writeFileString(
+          path.join(dirA, "index.html"),
+          "<html><body>alchemy-assets-plan-index-v2</body></html>",
+        );
+        const changed = yield* stack.plan(program());
+        expect(actionOf(changed, "AssetsPlanWithMain")).toBe("update");
+        expect(actionOf(changed, "AssetsPlanAssetsOnly")).toBe("noop");
+        expect(actionOf(changed, "AssetsPlanScript")).toBe("noop");
+
+        // Deploying the change re-settles the plan.
+        yield* stack.deploy(program());
+        const resettled = yield* stack.plan(program());
+        expect(actionOf(resettled, "AssetsPlanWithMain")).toBe("noop");
+        expect(actionOf(resettled, "AssetsPlanAssetsOnly")).toBe("noop");
+        expect(actionOf(resettled, "AssetsPlanScript")).toBe("noop");
+
+        yield* stack.destroy();
+      }),
+    { timeout: 360_000 },
+  );
+});


### PR DESCRIPTION
Closes https://github.com/alchemy-run/alchemy/issues/1047

Workers with `assets: { directory }` and no precomputed `hash` planned as "update" on every run — the diff deliberately never read the directory, so unchanged asset trees could not converge to a noop. Users worked around it by hand-rolling directory hashing and passing `assets.hash` (reported in [UsefulSoftwareCo/executor#1510](https://github.com/UsefulSoftwareCo/executor/pull/1510#discussion_r3699451570)).

The diff now reads and hashes the directory the same way apply does (`readAssets`) and compares against the stored content hash:

```ts
const assetsChanged = Effect.fn(function* (assets, output) {
  if (!assets) return false;
  // Command.Build contract: a supplied hash stays authoritative,
  // the directory is never read during planning.
  if (Predicate.hasProperty(assets, "hash") && assets.hash !== undefined) {
    return assets.hash !== output.hash?.assets;
  }
  const read = yield* prepareAssets(assets).pipe(
    Effect.catchTag(
      ["PlatformError", "AssetTooLargeError", "TooManyAssetsError"],
      () => Effect.succeed(undefined),
    ),
  );
  return read === undefined || read.hash !== output.hash?.assets;
});
```

- Applies to all three `hasChanged` shapes: `main`+assets, `script`+assets, and assets-only.
- A directory that is missing or invalid at plan time (e.g. produced by an upstream build step that only runs during apply) degrades to "changed"; apply reads it once and either uploads or surfaces the real typed error.
- Overall read cost is unchanged: previously every plan reported "changed" and `putWorker` read the tree during apply only to discover nothing changed (`keepAssets`); now the diff reads it and a match skips reconcile entirely.

### Relocated checkouts plan as noop

The content hashes (bundle, asset content, vite input) are deliberately path-independent, but the engine's raw-props fallback still flagged a relocated checkout (CI runner ↔ laptop, temp build dirs) as changed forever, because `main` / `assets.directory` / `vite.rootDir` are machine-local paths stored in props. When the only residual raw-prop difference is such a source path, the Worker diff now returns an explicit `noop`; any other residual difference still falls through to the engine's conservative comparison, preserving the #745 metadata-edit safety net.

### Tests

`AssetsPlanConvergence.test.ts` (live) covers: noop plans for unchanged trees across all three shapes; an asset edit dirtying exactly the affected Worker; path invariance across a directory move; a missing directory at plan time degrading to update without crashing; `_headers` edits dirtying the plan; `.assetsignore`d files staying noop; and the supplied-hash migration (dropping a hand-rolled hash → one update → converge → re-adding a different hash dirties again). Full `test/Cloudflare/Workers` + `test/Cloudflare/Website` suites pass (272 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
