### PR TITLE
fix(cloudflare/workers): apply Vite base to the assets manifest

### DIFF
--- a/packages/alchemy/src/Bundle/Vite.ts
+++ b/packages/alchemy/src/Bundle/Vite.ts
@@ -17,6 +17,7 @@ import {
 
 export interface ViteBuildOutput {
   readonly clientDirectory: string | undefined;
+  readonly base: string | undefined;
   // This is emitted as an Effect instead of a value so we can process it in parallel with reading the client assets.
   readonly serverBundle: Effect.Effect<BundleOutput | undefined, BundleError>;
   readonly externalWorkspaces: Effect.Effect<Set<string>, PlatformError>;
@@ -39,6 +40,7 @@ type RscManifestId = keyof typeof RSC_MANIFEST;
 interface EnvironmentLike {
   readonly name: string;
   readonly config: {
+    readonly base: string;
     readonly root: string;
     readonly build: { readonly outDir: string };
   };
@@ -56,6 +58,7 @@ export const viteBuildOutputPlugin = Effect.fn(function* ({
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   let clientDirectory: string | undefined;
+  let base: string | undefined;
   let serverEntry: string | undefined;
   const serverChunks = new Map<
     string,
@@ -125,6 +128,7 @@ export const viteBuildOutputPlugin = Effect.fn(function* ({
           root,
           this.environment.config.build.outDir,
         );
+        base = this.environment.config.base;
         return;
       }
       const files = Object.values(bundle);
@@ -261,6 +265,7 @@ export const viteBuildOutputPlugin = Effect.fn(function* ({
     output: Effect.sync(
       (): ViteBuildOutput => ({
         clientDirectory,
+        base,
         serverBundle: makeServerBundle(),
         externalWorkspaces: collectExternalWorkspaces(),
       }),

--- a/packages/alchemy/src/Cloudflare/Workers/Assets.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Assets.ts
@@ -26,6 +26,13 @@ export interface AssetsConfig extends Exclude<
 
 export interface AssetReadResult {
   directory: string;
+  /**
+   * The normalized `base` this manifest was keyed with (`""` when the
+   * assets are served from the origin root). Manifest keys are request
+   * paths, so `uploadAssets` strips this back off to find each file on
+   * disk.
+   */
+  pathPrefix: string;
   config: AssetsConfig | undefined;
   manifest: Record<string, { hash: string; size: number }>;
   _headers: string | undefined;
@@ -35,6 +42,29 @@ export interface AssetReadResult {
 
 export interface AssetsProps extends AssetsConfig {
   directory: string;
+  /**
+   * The path this site is served from, when it is not the origin root —
+   * e.g. `"/docs"` for a Worker on the route `example.com/docs*`. Matches
+   * Vite's `base`, and `Website.Vite` fills it in from the Vite config
+   * automatically; set it by hand when you bring your own build.
+   *
+   * The asset router matches request paths against the manifest literally
+   * and never strips a prefix, so Cloudflare's model is that the assets
+   * directory mirrors the served path. This does that at manifest time:
+   * `dist/app.js` is uploaded as `/docs/app.js`, leaving the build output
+   * on disk untouched.
+   *
+   * Bases that name no path — `"/"`, `"./"`, `"https://cdn.example.com/"` —
+   * are ignored, as an absolute base means the assets are served by a CDN
+   * rather than by this Worker.
+   *
+   * `_headers` and `_redirects` are NOT rewritten: their rules match the
+   * incoming request path, so author them with the full served path
+   * (`/docs/old /docs/new 301`).
+   *
+   * @default undefined (assets are served from the origin root)
+   */
+  base?: string;
 }
 
 export type ValidationError =
@@ -148,8 +178,19 @@ export const mergeAssetsConfigFiles = (
   };
 };
 
+/**
+ * `base` → manifest path prefix. Only a root-relative base names a path
+ * this Worker serves; `"/"`, `"./"`, protocol-relative and absolute URLs
+ * all mean "no prefix".
+ */
+const getAssetsPathPrefix = (base: string | undefined) =>
+  base?.startsWith("/") && !base.startsWith("//")
+    ? base.replace(/\/+$/, "")
+    : "";
+
 export const readAssets = Effect.fn(function* ({
   directory,
+  base,
   ...config
 }: AssetsProps) {
   const fs = yield* FileSystem.FileSystem;
@@ -170,6 +211,7 @@ export const readAssets = Effect.fn(function* ({
       .map((line) => line.trim())
       .filter((line) => line.length > 0 && !line.startsWith("#")) ?? []),
   ]);
+  const pathPrefix = getAssetsPathPrefix(base);
   const manifest = new Map<string, { hash: string; size: number }>();
   let count = 0;
   yield* Effect.forEach(
@@ -204,14 +246,21 @@ export const readAssets = Effect.fn(function* ({
         });
       }
       manifest.set(
-        (name.startsWith("/") ? name : `/${name}`).replaceAll("\\", "/"),
-        {
-          hash,
-          size,
-        },
+        `${pathPrefix}${(name.startsWith("/") ? name : `/${name}`).replaceAll("\\", "/")}`,
+        { hash, size },
       );
     }),
   );
+  // The SPA fallback is hard-coded to `/index.html` at the manifest root, so
+  // prefixing every key would 404 every client-side route under the base.
+  const indexHtml = manifest.get(`${pathPrefix}/index.html`);
+  if (
+    indexHtml &&
+    config.notFoundHandling === "single-page-application" &&
+    !manifest.has("/index.html")
+  ) {
+    manifest.set("/index.html", indexHtml);
+  }
   const sortedManifest = Object.fromEntries(
     Array.from(manifest.entries()).sort((a, b) => a[0].localeCompare(b[0])),
   );
@@ -231,10 +280,13 @@ export const readAssets = Effect.fn(function* ({
   });
   return {
     directory,
+    pathPrefix,
     // Fold the `_headers` / `_redirects` file contents into the config
     // that gets sent to Cloudflare (`metadata.assets.config`). Merged
     // *after* hashing so the hash input shape stays stable for
-    // already-deployed workers.
+    // already-deployed workers. Deliberately NOT `base`-prefixed: their
+    // rules match the incoming request path, which already carries the
+    // base, so they are authored with the full served path.
     config: mergeAssetsConfigFiles(config, { _headers, _redirects }),
     manifest: sortedManifest,
     _headers,
@@ -254,9 +306,18 @@ export const uploadAssets = Effect.fn(function* (
   const createScriptAssetUpload = yield* workers.createScriptAssetUpload;
   const createAssetUpload = yield* workers.createAssetUpload;
 
+  // Manifest keys are the paths Cloudflare *serves*, so they carry the
+  // `base` prefix. The files themselves are on disk at the un-prefixed
+  // path relative to the assets directory, so drop the prefix to get
+  // back to something `readFile` can open.
+  const toDiskPath = (name: string) =>
+    assets.pathPrefix && name.startsWith(`${assets.pathPrefix}/`)
+      ? name.slice(assets.pathPrefix.length)
+      : name;
+
   const assetsByHash = new Map<string, string>();
   for (const [name, { hash }] of Object.entries(assets.manifest)) {
-    assetsByHash.set(hash, name);
+    assetsByHash.set(hash, toDiskPath(name));
   }
   const directory = path.resolve(assets.directory);
 

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -1181,7 +1181,7 @@ export const LiveWorkerProvider = () =>
         // (~0.5s), which is only needed for vite-based workers at build time —
         // not for every Worker definition at module-load time.
         const Vite = yield* Effect.promise(() => import("./Vite.ts"));
-        const { clientDirectory, serverBundle, externalWorkspaces } =
+        const { clientDirectory, serverBundle, externalWorkspaces, base } =
           yield* Vite.viteBuild(
             props.vite?.rootDir,
             Object.fromEntries(
@@ -1227,6 +1227,10 @@ export const LiveWorkerProvider = () =>
                     props.vite?.rootDir ?? process.cwd(),
                     clientDirectory,
                   ),
+                  // Vite's `base` overrides `assets.base`: it is what
+                  // rewrote the URLs in the emitted HTML, so it is the
+                  // only prefix the manifest can agree with.
+                  base,
                 })
               : Effect.undefined,
             serverBundle,

--- a/packages/alchemy/test/Cloudflare/Website/Vite.test.ts
+++ b/packages/alchemy/test/Cloudflare/Website/Vite.test.ts
@@ -178,6 +178,91 @@ test.provider(
   { timeout: 360_000 },
 );
 
+// Vite's `base` rewrites the URLs it *emits* but never the directory it
+// emits *into*. Cloudflare's asset router matches request paths against
+// manifest keys literally and strips no prefix, so a root-keyed manifest
+// disagrees with the emitted HTML by exactly the base — every asset 404s
+// and the site loads with no CSS and no JS.
+//
+// One deploy pins all three serving assumptions the fix rests on:
+// the shell resolves at the base, the hashed assets the HTML actually
+// references resolve, and the SPA fallback still fires for client routes
+// underneath it.
+test.provider(
+  "Vite: a non-root base serves assets and the SPA fallback under that path",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* yield* CloudflareEnvironment;
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+
+      yield* stack.destroy();
+
+      const rootDir = yield* cloneFixture(spaFixtureDir, {
+        prefix: "alchemy-vite-base-",
+        tempRoot,
+        entries: ["index.html", "package.json", "src"],
+      });
+      yield* fs.writeFileString(
+        path.join(rootDir, "vite.config.ts"),
+        `import { defineConfig } from "vite";\n\nexport default defineConfig({ base: "/example/" });\n`,
+      );
+      const memoInclude = [
+        "index.html",
+        "src/**",
+        "package.json",
+        "vite.config.ts",
+      ];
+
+      const marker = `vite-base-${Date.now()}`;
+      yield* fs.writeFileString(
+        path.join(rootDir, "index.html"),
+        htmlPage(marker),
+      );
+
+      const site = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.Website.Vite("FixViteBase", {
+            ...viteProps(rootDir, memoInclude),
+            assets: { notFoundHandling: "single-page-application" },
+          });
+        }),
+      );
+
+      expect(site.url).toBeDefined();
+      yield* expectWorkerExists(site.workerName, accountId);
+
+      const html = yield* expectUrlContains(`${site.url!}/example/`, marker, {
+        timeout: "120 seconds",
+        label: "base shell",
+      });
+
+      // Follow the reference the built HTML actually ships rather than
+      // guessing the hashed filename. `(hydrated)` is a string literal in
+      // the fixture's client module, so it proves the response is the real
+      // script — a 404 here would be answered by the SPA fallback with the
+      // shell, which contains the marker but never that literal.
+      const scriptSrc = html.match(/src="(\/example\/assets\/[^"]+\.js)"/)?.[1];
+      expect(scriptSrc).toBeDefined();
+      yield* expectUrlContains(`${site.url!}${scriptSrc}`, "(hydrated)", {
+        timeout: "60 seconds",
+        label: "hashed asset under base",
+      });
+
+      // Cloudflare's SPA fallback is hard-coded to `/index.html` at the
+      // manifest root, so prefixing every key would 404 every client-side
+      // route under the base without the alias.
+      yield* expectUrlContains(`${site.url!}/example/deep/route`, marker, {
+        timeout: "60 seconds",
+        label: "spa fallback under base",
+      });
+
+      yield* stack.destroy();
+      yield* waitForWorkerToBeDeleted(site.workerName, accountId);
+    }).pipe(logLevel),
+  { timeout: 360_000 },
+);
+
 test.provider(
   "Vite: class form deploys and serves the built assets",
   (stack) =>

--- a/packages/alchemy/test/Cloudflare/Workers/Assets.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/Assets.test.ts
@@ -1,0 +1,118 @@
+import { readAssets } from "@/Cloudflare/Workers/Assets.ts";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { expect, layer } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+
+// Cloudflare matches request paths against the manifest literally and never
+// strips a prefix, so `base` produces the manifest its documented
+// subdirectory layout would, without moving the build output on disk.
+layer(NodeServices.layer)("readAssets base", (it) => {
+  const site = Effect.fnUntraced(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const dir = yield* fs.makeTempDirectoryScoped({ prefix: "alchemy-base-" });
+    yield* fs.makeDirectory(path.join(dir, "assets"), { recursive: true });
+    yield* fs.writeFileString(path.join(dir, "assets", "app.js"), "app");
+    yield* fs.writeFileString(path.join(dir, "index.html"), "<html>");
+    yield* fs.writeFileString(path.join(dir, "robots.txt"), "robots");
+    yield* fs.writeFileString(path.join(dir, "ignored.txt"), "ignored");
+    yield* fs.writeFileString(path.join(dir, ".assetsignore"), "ignored.txt\n");
+    yield* fs.writeFileString(path.join(dir, "_headers"), "/docs/*\n  X: y\n");
+    yield* fs.writeFileString(path.join(dir, "_redirects"), "/a /docs/b 301\n");
+    return dir;
+  });
+
+  it.effect("keys the manifest with the base", () =>
+    Effect.gen(function* () {
+      const directory = yield* site();
+      const assets = yield* readAssets({ directory, base: "/docs/" });
+
+      expect(Object.keys(assets.manifest)).toEqual([
+        "/docs/assets/app.js",
+        "/docs/index.html",
+        "/docs/robots.txt",
+      ]);
+      expect(assets.pathPrefix).toEqual("/docs");
+    }),
+  );
+
+  it.effect("leaves the manifest at the root without a base", () =>
+    Effect.gen(function* () {
+      const directory = yield* site();
+      const assets = yield* readAssets({ directory });
+
+      expect(Object.keys(assets.manifest)).toEqual([
+        "/assets/app.js",
+        "/index.html",
+        "/robots.txt",
+      ]);
+      expect(assets.pathPrefix).toEqual("");
+    }),
+  );
+
+  // "/" and "./" are already the root; an absolute base means a CDN serves
+  // the assets, not this Worker.
+  it.effect("ignores bases that name no path", () =>
+    Effect.gen(function* () {
+      const directory = yield* site();
+      for (const base of ["/", "./", "//cdn.example.com/", "https://cdn.x/"]) {
+        const assets = yield* readAssets({ directory, base });
+        expect([base, assets.pathPrefix]).toEqual([base, ""]);
+      }
+    }),
+  );
+
+  it.effect("aliases the SPA shell back to the root", () =>
+    Effect.gen(function* () {
+      const directory = yield* site();
+      const assets = yield* readAssets({
+        directory,
+        base: "/docs/",
+        notFoundHandling: "single-page-application",
+      });
+
+      expect(assets.manifest["/index.html"]).toEqual(
+        assets.manifest["/docs/index.html"],
+      );
+    }),
+  );
+
+  it.effect("only aliases the shell in single-page-application mode", () =>
+    Effect.gen(function* () {
+      const directory = yield* site();
+      const assets = yield* readAssets({ directory, base: "/docs/" });
+
+      expect(assets.manifest["/index.html"]).toBeUndefined();
+    }),
+  );
+
+  // Their rules match the incoming request path, so they are authored with
+  // the full served path and sent verbatim rather than prefixed.
+  it.effect("sends the config files verbatim and never uploads them", () =>
+    Effect.gen(function* () {
+      const directory = yield* site();
+      const assets = yield* readAssets({ directory, base: "/docs/" });
+
+      expect(assets.config).toMatchObject({
+        headers: "/docs/*\n  X: y\n",
+        redirects: "/a /docs/b 301\n",
+      });
+      expect(Object.keys(assets.manifest)).not.toContain("/docs/_headers");
+      expect(Object.keys(assets.manifest)).not.toContain("/docs/.assetsignore");
+    }),
+  );
+
+  // The prefix has to reach the change-detection hash, or a base change
+  // alone would be a no-op deploy that leaves the old manifest live.
+  it.effect("changes the hash when the base changes", () =>
+    Effect.gen(function* () {
+      const directory = yield* site();
+      const root = yield* readAssets({ directory });
+      const docs = yield* readAssets({ directory, base: "/docs/" });
+
+      expect(docs.hash).not.toEqual(root.hash);
+    }),
+  );
+});


### PR DESCRIPTION
A Vite `base` other than `/` deploys a site with zero CSS and zero JS — every asset URL in the emitted HTML 404s.

Vite's `base` rewrites the URLs it *emits*, never the directory it emits *into*. Cloudflare's asset router matches request paths against manifest keys literally and strips no prefix, so the two disagree by exactly the base:

```
manifest key   /assets/x.css
request path   /example/assets/x.css   → no match → 404
```

Visible on disk without deploying anything:

```sh
vite build                                          # with base: '/example/'
grep -ro '/example/assets/[^"]*' dist/client | head # HTML references /example/assets/…
ls dist/client/assets                               # files are at assets/…
```

This hits `publicDir` (`robots.txt`, favicons, OG images) exactly as hard as hashed build assets, so `build.assetsDir` is not a workaround. Neither is serving flat — a Worker bound to `example.com/docs*` never receives a request for `/assets/x.css` at all.

### The fix

Key the manifest with the base. Disk layout is untouched: the manifest *is* the serve-path→hash map, so there is nothing to move.

```diff
-manifest.set(`/${name}`, { hash, size })
+manifest.set(`${pathPrefix}/${name}`, { hash, size })
```

`base` reaches `readAssets` from the client environment's resolved Vite config, and is also a first-class `assets` prop so a prebuilt or `StaticSite` deploy can express it without Vite:

```ts
assets: { directory: "./dist", base: "/docs" }
```

Two things the prefix must not break:

- **SPA fallback.** Cloudflare's `notFoundHandling: "single-page-application"` resolves `exists("/index.html")` at the manifest root, hard-coded — so prefixing every key would 404 every client-side route. The shell is aliased back to `/index.html`: one extra manifest line, zero extra uploads, since entries are content-addressed.
- **`_headers` / `_redirects`.** Sent verbatim. Their rules match the incoming request path, which already carries the base, so they are authored with the full served path.

Bases that name no path (`/`, `./`, `//cdn…`, `https://cdn…`) are ignored — an absolute base means a CDN serves the assets, not this Worker.

### Tests

`Vite.test.ts` deploys a fixture with `base: "/example/"`, then follows the script reference out of the served HTML rather than guessing the hashed filename. It fails on `main` at exactly that fetch. `Assets.test.ts` covers manifest keying, base normalization, the SPA alias, config-file passthrough, and hash sensitivity.

### Known limitation

`alchemy dev` hands miniflare a bare assets directory, so a non-Vite Worker using `assets.base` serves at the root locally. Vite dev is unaffected — its dev server honours `base` itself.

### Possible follow-up

`routes: ["example.com/docs*"]` with assets keyed at the root is always broken. Comparing each route's path prefix against the manifest keys would catch it at plan time, before the upload session. Left out of this PR as it is a separate, opinionated diagnostic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
