### PR TITLE
docs: clarify multiple providers per stack

### DIFF
--- a/website/src/content/docs/infrastructure-as-code/provider.mdx
+++ b/website/src/content/docs/infrastructure-as-code/provider.mdx
@@ -29,7 +29,10 @@ Alchemy.Stack(
 The type system enforces this — using a Cloudflare resource without
 `Cloudflare.providers()` raises a compile-time error.
 
-To mix clouds, merge the layers:
+## Multiple providers
+
+A stack can use any number of providers. Because providers are
+Layers, combining them is just `Layer.mergeAll`:
 
 ```typescript
 import * as Layer from "effect/Layer";
@@ -45,6 +48,25 @@ Alchemy.Stack(
   }),
 );
 ```
+
+This works for as many providers as you need — built-in ones
+(`Cloudflare`, `AWS`, `Neon`, `Planetscale`, `Docker`, …) and
+[custom providers](/infrastructure-as-code/custom-provider) merge
+the same way:
+
+```typescript
+providers: Layer.mergeAll(
+  Cloudflare.providers(),
+  AWS.providers(),
+  Neon.providers(),
+  StripeProviders, // your own custom provider layer
+),
+```
+
+The type system tracks the requirements per resource: each resource
+you `yield*` demands its own provider from the merged layer, so a
+missing provider is a compile-time error, never a deploy-time
+surprise.
 
 ## Lifecycle operations
 

--- a/website/src/content/docs/infrastructure-as-code/stack.mdx
+++ b/website/src/content/docs/infrastructure-as-code/stack.mdx
@@ -50,6 +50,49 @@ See the [CLI reference](/cli/deploy) for the full invocation
 syntax.
 :::
 
+## Multiple providers
+
+A stack is not limited to one cloud. Providers are Effect Layers, so
+to deploy resources from several providers in a single stack, merge
+their layers with `Layer.mergeAll`:
+
+```typescript
+import * as Alchemy from "alchemy";
+import * as AWS from "alchemy/AWS";
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Neon from "alchemy/Neon";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+export default Alchemy.Stack(
+  "MyApp",
+  {
+    providers: Layer.mergeAll(
+      Cloudflare.providers(),
+      AWS.providers(),
+      Neon.providers(),
+    ),
+    state: Cloudflare.state(),
+  },
+  Effect.gen(function* () {
+    const db = yield* Neon.Project("Db");
+    const queue = yield* AWS.SQS.Queue("Jobs");
+    const bucket = yield* Cloudflare.R2.Bucket("Uploads");
+    return { projectId: db.projectId };
+  }),
+);
+```
+
+The type system tracks which providers the stack's resources need —
+declaring an AWS resource without `AWS.providers()` in the merged
+layer is a compile-time error.
+
+`state` is independent of `providers`: pick one state layer no
+matter how many clouds the stack deploys to.
+
+See [Providers](/infrastructure-as-code/provider#multiple-providers)
+for more on provider layers.
+
 ## Stack outputs
 
 The value returned from the generator becomes the **stack output**.

--- a/website/src/content/docs/what-is-alchemy.mdx
+++ b/website/src/content/docs/what-is-alchemy.mdx
@@ -192,9 +192,19 @@ Alchemy.Stack(
 
 The type system checks the wiring — using a Cloudflare resource
 without `Cloudflare.providers()`, or providing the wrong cloud's
-providers, is a compile-time error. To support a new cloud or
-third-party API, see [Writing a Custom Resource
-Provider](/infrastructure-as-code/custom-provider).
+providers, is a compile-time error.
+
+A stack can use any number of providers at once — merge their
+layers with `Layer.mergeAll`:
+
+```typescript
+providers: Layer.mergeAll(Cloudflare.providers(), AWS.providers()),
+```
+
+See [Providers › Multiple
+providers](/infrastructure-as-code/provider#multiple-providers). To
+support a new cloud or third-party API, see [Writing a Custom
+Resource Provider](/infrastructure-as-code/custom-provider).
 
 ## Two styles: Effect and async
 


### PR DESCRIPTION
A user was confused about whether a stack supports multiple providers — the docs said "providers" plural but every example was single-provider. Make multi-provider support explicit and discoverable:

- **Stacks** gains a `## Multiple providers` section with a full Cloudflare + AWS + Neon stack example
- **Providers** promotes the buried "to mix clouds" snippet into its own linkable `## Multiple providers` heading, noting any number of built-in and custom providers merge the same way
- **What is Alchemy** mentions merging in the provider intro and links to the new section

```typescript
providers: Layer.mergeAll(
  Cloudflare.providers(),
  AWS.providers(),
  Neon.providers(),
),
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
