### PR TITLE
fix(cloudflare/website)!: stop StaticSite duplicating env resources into its namespace

### DIFF
--- a/packages/alchemy/src/Cloudflare/Website/StaticSite.ts
+++ b/packages/alchemy/src/Cloudflare/Website/StaticSite.ts
@@ -255,6 +255,14 @@ const makeStaticSite = <
     const ctx = yield* AlchemyContext;
     const props = yield* asEffect(propsEff);
 
+    // `Dev` and `Build` carry constant logical ids, so they are namespaced
+    // under `id` to keep two sites on one stack from colliding. Nothing
+    // else is: the site's own `props` — and the resources its `env`
+    // bindings declare — must resolve in the CALLER's namespace. Pushing
+    // the namespace around the whole body instead re-declares a shared
+    // resource referenced from `env` as a second copy under `<id>/`.
+    // `Vite` already passes `id` straight through to `Worker`.
+
     // In dev mode with a dev.command, declare a DevCommand resource so
     // the sidecar owns the process lifecycle (survives user-code HMR),
     // skip the build, and tell Worker not to start a local instance.
@@ -267,6 +275,7 @@ const makeStaticSite = <
               (typeof props.cwd === "string" ? props.cwd : undefined),
             env: yield* serializeEnv(props.dev.env ?? props.env),
           }).pipe(
+            Namespace.push(id),
             Effect.map((d) =>
               Output.map(d.url, (url) => ({
                 url: url ?? props.dev?.url,
@@ -283,12 +292,12 @@ const makeStaticSite = <
           memo: props.memo,
           outdir: props.outdir,
           env: yield* serializeEnv(props.env),
-        });
+        }).pipe(Namespace.push(id));
 
     // Pure-static sites (neither `main` nor `script`) deploy as
     // assets-only Workers: no script is uploaded and Cloudflare's asset
     // layer serves every request itself.
-    return yield* Worker<Bindings, WorkerAssetsConfig, Req>("Worker", {
+    return yield* Worker<Bindings, WorkerAssetsConfig, Req>(id, {
       ...props,
       assets: build
         ? cast({
@@ -303,7 +312,7 @@ const makeStaticSite = <
       dev: dev ? { mode: "external", url: dev.url } : undefined,
       script: props.script,
     });
-  }).pipe(Namespace.push(id));
+  });
 
 /**
  * Serialize the site's `env` for the build/dev subprocess. The same record

--- a/packages/alchemy/test/Cloudflare/Website/StaticSiteNamespace.test.ts
+++ b/packages/alchemy/test/Cloudflare/Website/StaticSiteNamespace.test.ts
@@ -1,0 +1,70 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Stack from "@/Stack.ts";
+import { Stage } from "@/Stage.ts";
+import { inMemoryState, type State } from "@/State";
+import * as Test from "@/Test/Alchemy";
+import { expect } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+const { test } = Test.make({
+  providers: Layer.empty,
+  state: inMemoryState(),
+});
+
+// A resource declared once, at module scope, and referenced from a site's
+// `env` — the pattern `examples/cloudflare-tanstack` uses.
+const Cache = Cloudflare.KV.Namespace("Cache", {});
+
+/** Compile the stack and return the FQN of every registered resource. */
+const fqns = <A, Err = never, Req = never>(
+  effect: Effect.Effect<A, Err, Req>,
+): Effect.Effect<string[], Err, State> =>
+  effect.pipe(
+    // @ts-expect-error - Stack.make's typing erases R unsoundly here
+    Stack.make({
+      name: "test",
+      providers: Layer.empty,
+      state: inMemoryState(),
+    }),
+    Effect.provideService(Stage, "test"),
+    Effect.map((stack: Stack.CompiledStack) =>
+      Object.keys(stack.resources).sort(),
+    ),
+  );
+
+test(
+  "StaticSite declares env resources in the caller's namespace",
+  Effect.gen(function* () {
+    const keys = yield* fqns(
+      Effect.gen(function* () {
+        yield* Cache;
+        yield* Cloudflare.Website.StaticSite("Site", {
+          command: "echo build",
+          outdir: "dist",
+          main: "./worker.ts",
+          env: { CACHE: Cache },
+        });
+      }),
+    );
+    // Only the build sub-resource is namespaced; the Worker is the site
+    // itself and `Cache` stays where the caller declared it.
+    expect(keys).toEqual(["Cache", "Site", "Site/Build"]);
+  }),
+);
+
+test(
+  "Vite declares env resources in the caller's namespace",
+  Effect.gen(function* () {
+    const keys = yield* fqns(
+      Effect.gen(function* () {
+        yield* Cache;
+        yield* Cloudflare.Website.Vite("Site", {
+          main: "./worker.ts",
+          env: { CACHE: Cache },
+        });
+      }),
+    );
+    expect(keys).toEqual(["Cache", "Site"]);
+  }),
+);


### PR DESCRIPTION
Fixes #1052.

`makeStaticSite` wrapped its whole body in `Namespace.push(id)`, so the Effects in `props.env` resolved inside the pushed namespace and the resources they declare registered at `<id>/…` — a second physical copy of every shared resource. Only `Dev`/`Build` need it; they carry constant logical ids. `Vite` already passes `id` straight to `Worker`.

```diff
-        : yield* Command.Build("Build", { … });
+        : yield* Command.Build("Build", { … }).pipe(Namespace.push(id));

-    return yield* Worker<Bindings, WorkerAssetsConfig, Req>("Worker", {
+    return yield* Worker<Bindings, WorkerAssetsConfig, Req>(id, {
       …
     });
-  }).pipe(Namespace.push(id));
+  });
```

Registered FQNs for a site with `env: { CACHE: Cache }` where `Cache` is declared by the caller:

```diff
- [ "Cache", "Site/Build", "Site/Cache", "Site/Worker" ]
+ [ "Cache", "Site", "Site/Build" ]
```

### Breaking

The Worker's FQN moves from `<id>/Worker` to `<id>`, so its physical name changes. On upgrade the engine creates the site at the new FQN and orphans the old row — the Worker is recreated and gets a new `workers.dev` subdomain. `aliases` is resource-*type* only, so there is no FQN-level migration hook; if one is wanted before this lands, say so and I'll rework it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
