### PR TITLE
fix(cloudflare/website): pass a string assets hash from StaticSite

### DIFF
--- a/packages/alchemy/src/Cloudflare/Website/StaticSite.ts
+++ b/packages/alchemy/src/Cloudflare/Website/StaticSite.ts
@@ -14,7 +14,6 @@ import {
 import { asEffect } from "../../Util/types.ts";
 import type { Providers } from "../Providers.ts";
 import type { AssetsConfig } from "../Workers/Assets.ts";
-import { isContainerDecl } from "../Workers/WorkerAsyncBindings.ts";
 import {
   Worker,
   type NormalizedBindings,
@@ -22,6 +21,7 @@ import {
   type WorkerBindingProps,
   type WorkerProps,
 } from "../Workers/Worker.ts";
+import { isContainerDecl } from "../Workers/WorkerAsyncBindings.ts";
 
 export interface StaticSiteProps<Bindings extends WorkerBindingProps = {}>
   extends
@@ -285,23 +285,6 @@ const makeStaticSite = <
           env: yield* serializeEnv(props.env),
         });
 
-    // `AssetsWithHash.hash` is a single `string` that the Worker's assets
-    // diff compares with `!==` against the hash persisted in state, while
-    // `Command.Build` exposes a `{ input, output }` pair. Passing the pair
-    // through made every plan dirty — state round-trips through JSON, so a
-    // freshly built object is never `===` the deserialized one — and the
-    // Worker re-uploaded the whole asset directory on every deploy.
-    //
-    // `output` is the hash of the build's `outdir` contents, i.e. exactly
-    // the bytes being uploaded. It is `undefined` only under `memo: false`,
-    // where an absent hash makes the Worker hash the directory itself.
-    //
-    // The annotation is deliberate: the `cast` below erases the shape of the
-    // whole object literal, so this is what keeps the mapping type-checked.
-    const assetsHash: Output.Output<string | undefined> | undefined = build
-      ? Output.map(build.hash, (hash) => hash.output)
-      : undefined;
-
     // Pure-static sites (neither `main` nor `script`) deploy as
     // assets-only Workers: no script is uploaded and Cloudflare's asset
     // layer serves every request itself.
@@ -310,7 +293,7 @@ const makeStaticSite = <
       assets: build
         ? cast({
             directory: build.outdir,
-            hash: assetsHash,
+            hash: build.hash.output,
             ...props.assets,
           })
         : undefined,

--- a/packages/alchemy/src/Cloudflare/Website/StaticSite.ts
+++ b/packages/alchemy/src/Cloudflare/Website/StaticSite.ts
@@ -285,6 +285,23 @@ const makeStaticSite = <
           env: yield* serializeEnv(props.env),
         });
 
+    // `AssetsWithHash.hash` is a single `string` that the Worker's assets
+    // diff compares with `!==` against the hash persisted in state, while
+    // `Command.Build` exposes a `{ input, output }` pair. Passing the pair
+    // through made every plan dirty — state round-trips through JSON, so a
+    // freshly built object is never `===` the deserialized one — and the
+    // Worker re-uploaded the whole asset directory on every deploy.
+    //
+    // `output` is the hash of the build's `outdir` contents, i.e. exactly
+    // the bytes being uploaded. It is `undefined` only under `memo: false`,
+    // where an absent hash makes the Worker hash the directory itself.
+    //
+    // The annotation is deliberate: the `cast` below erases the shape of the
+    // whole object literal, so this is what keeps the mapping type-checked.
+    const assetsHash: Output.Output<string | undefined> | undefined = build
+      ? Output.map(build.hash, (hash) => hash.output)
+      : undefined;
+
     // Pure-static sites (neither `main` nor `script`) deploy as
     // assets-only Workers: no script is uploaded and Cloudflare's asset
     // layer serves every request itself.
@@ -293,7 +310,7 @@ const makeStaticSite = <
       assets: build
         ? cast({
             directory: build.outdir,
-            hash: build.hash,
+            hash: assetsHash,
             ...props.assets,
           })
         : undefined,

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -2314,7 +2314,17 @@ export const LiveWorkerProvider = () =>
         assets: WorkerProps["assets"],
         output: Worker["Attributes"] | undefined,
       ) => {
-        if (!Predicate.hasProperty(assets, "hash")) return undefined;
+        // An explicitly-undefined `hash` (`{ directory, hash: maybe }`) is
+        // the hash-less shape, not a supplied hash — the same rule
+        // `assetsChanged` applies during diff. Without the `undefined` check
+        // a greenfield create (`output === undefined`) compares `undefined
+        // === undefined`, sets `skip`, and uploads a Worker with no assets.
+        if (
+          !Predicate.hasProperty(assets, "hash") ||
+          assets.hash === undefined
+        ) {
+          return undefined;
+        }
         // `base` shapes the uploaded manifest paths (see `readAssets`); it
         // is alchemy-only and must not leak into the API's asset config.
         const { directory, hash, base, ...config } = assets;

--- a/packages/alchemy/test/Cloudflare/Website/StaticSite.test.ts
+++ b/packages/alchemy/test/Cloudflare/Website/StaticSite.test.ts
@@ -6,7 +6,7 @@ import type * as Plan from "@/Plan.ts";
 import { Stack } from "@/Stack";
 import { encodeState, type ResourceState, reviveState, State } from "@/State";
 import * as Test from "@/Test/Alchemy";
-import { expect } from "alchemy-test";
+import { describe, expect } from "alchemy-test";
 import * as Config from "effect/Config";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
@@ -31,768 +31,775 @@ const logLevel = Effect.provideService(
 const fixtureDir = pathe.resolve(import.meta.dirname, "staticsite-fixture");
 const workerEntry = pathe.resolve(import.meta.dirname, "fixtures/worker.ts");
 
-test.provider(
-  "StaticSite: editing a source file republishes the assets in a single deploy",
-  (stack) =>
-    Effect.gen(function* () {
-      const { accountId } = yield* yield* CloudflareEnvironment;
-      const fs = yield* FileSystem.FileSystem;
-      const path = yield* Path.Path;
+describe.concurrent("StaticSite", () => {
+  test.provider(
+    "StaticSite: editing a source file republishes the assets in a single deploy",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
 
-      yield* stack.destroy();
+        yield* stack.destroy();
 
-      const cwd = yield* cloneFixture(fixtureDir, {
-        prefix: "alchemy-staticsite-fix-",
-        entries: ["src", "build.sh"],
-      });
-      const indexPath = path.join(cwd, "src", "index.html");
+        const cwd = yield* cloneFixture(fixtureDir, {
+          prefix: "alchemy-staticsite-fix-",
+          entries: ["src", "build.sh"],
+        });
+        const indexPath = path.join(cwd, "src", "index.html");
 
-      // ── deploy 1: initial publish ──────────────────────────────────────
-      const v1Marker = `staticsite-v1-${Date.now()}`;
-      yield* fs.writeFileString(indexPath, htmlPage(v1Marker));
+        // ── deploy 1: initial publish ──────────────────────────────────────
+        const v1Marker = `staticsite-v1-${Date.now()}`;
+        yield* fs.writeFileString(indexPath, htmlPage(v1Marker));
 
-      const site1 = yield* stack.deploy(
-        Effect.gen(function* () {
-          return yield* Cloudflare.Website.StaticSite(
-            "FixSite",
-            staticSiteProps(cwd),
-          );
-        }),
-      );
-
-      expect(site1.url).toBeDefined();
-      expect(site1.hash?.assets).toBeDefined();
-      yield* expectWorkerExists(site1.workerName, accountId);
-      // End-to-end: the worker URL actually serves the v1 marker.
-      // Use a long timeout because workers.dev subdomains can take 60s+
-      // to propagate the very first time they're enabled.
-      yield* expectUrlContains(`${site1.url!}/index.html`, v1Marker, {
-        timeout: "120 seconds",
-        label: "deploy1 v1 marker",
-      });
-
-      // ── deploy 2: edit fixture, redeploy once ──────────────────────────
-      const v2Marker = `staticsite-v2-${Date.now()}`;
-      yield* fs.writeFileString(indexPath, htmlPage(v2Marker));
-
-      const site2 = yield* stack.deploy(
-        Effect.gen(function* () {
-          return yield* Cloudflare.Website.StaticSite(
-            "FixSite",
-            staticSiteProps(cwd),
-          );
-        }),
-      );
-
-      expect(site2.hash?.assets).toBeDefined();
-      expect(site2.hash?.assets).not.toEqual(site1.hash?.assets);
-
-      // The single-deploy guarantee: after one redeploy, the new
-      // marker is reachable over HTTP. Before the fix, this failure
-      // mode is what users were hitting — the worker version finalized
-      // pointing at the previous asset manifest because the initial
-      // Worker.update read dist mid-write.
-      yield* expectUrlContains(`${site2.url!}/index.html`, v2Marker, {
-        timeout: "60 seconds",
-        label: "deploy2 v2 marker",
-      });
-      // And the v1 marker should be gone — i.e. the new deploy fully
-      // replaced the previous content rather than coexisting with it.
-      yield* expectUrlAbsent(`${site2.url!}/index.html`, v1Marker, {
-        timeout: "30 seconds",
-      });
-
-      yield* stack.destroy();
-      yield* waitForWorkerToBeDeleted(site1.workerName, accountId);
-    }).pipe(logLevel),
-  { timeout: 360_000 },
-);
-
-test.provider(
-  "StaticSite: class form deploys and serves the built assets",
-  (stack) =>
-    Effect.gen(function* () {
-      const { accountId } = yield* yield* CloudflareEnvironment;
-      const fs = yield* FileSystem.FileSystem;
-      const path = yield* Path.Path;
-
-      yield* stack.destroy();
-
-      const cwd = yield* cloneFixture(fixtureDir, {
-        prefix: "alchemy-staticsite-class-",
-        entries: ["src", "build.sh"],
-      });
-      const indexPath = path.join(cwd, "src", "index.html");
-
-      const marker = `staticsite-class-${Date.now()}`;
-      yield* fs.writeFileString(indexPath, htmlPage(marker));
-
-      const site1 = yield* stack.deploy(
-        Effect.gen(function* () {
-          return yield* class FixSite extends Cloudflare.Website.StaticSite<FixSite>()(
-            "FixSite",
-            staticSiteProps(cwd),
-          ) {};
-        }),
-      );
-
-      expect(site1.url).toBeDefined();
-      expect(site1.hash?.assets).toBeDefined();
-      yield* expectWorkerExists(site1.workerName, accountId);
-      yield* expectUrlContains(`${site1.url!}/index.html`, marker, {
-        timeout: "120 seconds",
-        label: "class form marker",
-      });
-
-      yield* stack.destroy();
-      yield* waitForWorkerToBeDeleted(site1.workerName, accountId);
-    }).pipe(logLevel),
-  { timeout: 360_000 },
-);
-
-// ─────────────────────────────────────────────────────────────────────
-// Path-relocation / cross-machine state behavior
-//
-// `StaticSite` builds via `Build.Command` and hands its `outdir` +
-// content hash to `Worker` as `AssetsWithHash`. The hash is the only
-// thing the diff/keepAssets logic should care about — the recorded
-// `path` is *not* an input. These tests pin that down so that:
-//
-//   1. State produced on machine A (e.g. a CI runner) can be
-//      re-applied on machine B without `NotFound` failures from a
-//      stale `path` lurking in state.
-//   2. A worker-only edit, with `src/` byte-identical, keeps the
-//      asset manifest in place instead of re-uploading.
-//   3. A genuine source edit (already covered above) bumps the
-//      hash and ships new bytes — repeated here for symmetry.
-// ─────────────────────────────────────────────────────────────────────
-
-test.provider(
-  "StaticSite: relocating the project (and deleting the old one) preserves hash.assets",
-  (stack) =>
-    Effect.gen(function* () {
-      const { accountId } = yield* yield* CloudflareEnvironment;
-      const fs = yield* FileSystem.FileSystem;
-      const path = yield* Path.Path;
-
-      yield* stack.destroy();
-
-      // Include `.gitignore` so `Build.Command`'s default memo skips
-      // `dist/` between deploys; without it, the build output from
-      // deploy 1 would shift the input hash on deploy 2 and force an
-      // unnecessary rebuild that defeats the test.
-      const cwdA = yield* cloneFixture(fixtureDir, {
-        prefix: "alchemy-staticsite-relocate-a-",
-        entries: ["src", "build.sh", ".gitignore"],
-      });
-
-      // Pin a deterministic marker so both deploys hash to the same
-      // bytes regardless of timestamps.
-      const marker = `staticsite-relocate-${Date.now()}`;
-      yield* fs.writeFileString(
-        path.join(cwdA, "src", "index.html"),
-        htmlPage(marker),
-      );
-
-      const site1 = yield* stack.deploy(
-        Effect.gen(function* () {
-          return yield* Cloudflare.Website.StaticSite(
-            "RelocSite",
-            staticSiteProps(cwdA),
-          );
-        }),
-      );
-      expect(site1.hash?.assets).toBeDefined();
-      yield* expectUrlContains(`${site1.url!}/index.html`, marker, {
-        timeout: "120 seconds",
-        label: "deploy1 marker",
-      });
-
-      // Simulate the CI→local handoff: throw away the directory the
-      // first deploy ran in. Anything that still tries to readDir the
-      // recorded `outdir` will blow up here — the keepAssets path
-      // must not require it.
-      yield* fs.remove(cwdA, { recursive: true });
-
-      const cwdB = yield* cloneFixture(fixtureDir, {
-        prefix: "alchemy-staticsite-relocate-b-",
-        entries: ["src", "build.sh", ".gitignore"],
-      });
-      yield* fs.writeFileString(
-        path.join(cwdB, "src", "index.html"),
-        htmlPage(marker),
-      );
-
-      const site2 = yield* stack.deploy(
-        Effect.gen(function* () {
-          return yield* Cloudflare.Website.StaticSite(
-            "RelocSite",
-            staticSiteProps(cwdB),
-          );
-        }),
-      );
-
-      // The build still runs (Build.Command always re-runs its
-      // command), but the resulting content hash is identical, so
-      // Worker takes the keepAssets path and the recorded
-      // `hash.assets` is stable.
-      expect(site2.hash?.assets).toEqual(site1.hash?.assets);
-      // And the URL keeps serving — i.e. we didn't lose the asset
-      // binding in the process.
-      yield* expectUrlContains(`${site2.url!}/index.html`, marker, {
-        timeout: "60 seconds",
-        label: "deploy2 marker",
-      });
-
-      yield* stack.destroy();
-      yield* waitForWorkerToBeDeleted(site1.workerName, accountId);
-    }).pipe(logLevel),
-  { timeout: 360_000 },
-);
-
-test.provider(
-  "StaticSite: a bundle-only change keeps the asset manifest (hash.assets stable)",
-  (stack) =>
-    Effect.gen(function* () {
-      const { accountId } = yield* yield* CloudflareEnvironment;
-      const fs = yield* FileSystem.FileSystem;
-      const path = yield* Path.Path;
-
-      yield* stack.destroy();
-
-      // Include `.gitignore` so the memo (which falls back to gitignore
-      // when not explicitly configured) skips `dist/` between deploys —
-      // otherwise the second `hashDirectory` would observe the build
-      // output from deploy 1 and produce a different input hash.
-      const cwd = yield* cloneFixture(fixtureDir, {
-        prefix: "alchemy-staticsite-bundle-only-",
-        entries: ["src", "build.sh", ".gitignore"],
-      });
-      const marker = `staticsite-bundle-only-${Date.now()}`;
-      yield* fs.writeFileString(
-        path.join(cwd, "src", "index.html"),
-        htmlPage(marker),
-      );
-      // Use a temp worker entry so we can edit it between deploys to
-      // shift `hash.bundle` without touching `src/`.
-      const workerDir = yield* fs.makeTempDirectory({
-        prefix: "alchemy-staticsite-bundle-only-entry-",
-      });
-      const workerPath = path.join(workerDir, "worker.ts");
-      const writeWorker = (variant: string) =>
-        fs.writeFileString(
-          workerPath,
-          `export default {
-  fetch: async () => new Response(${JSON.stringify(`bundle-only ${variant}`)}),
-};
-`,
-        );
-
-      const deploy = () =>
-        stack.deploy(
+        const site1 = yield* stack.deploy(
           Effect.gen(function* () {
             return yield* Cloudflare.Website.StaticSite(
-              "BundleOnlyStaticSite",
-              {
-                ...staticSiteProps(cwd),
-                main: workerPath,
-              },
-            );
-          }),
-        );
-
-      yield* writeWorker("v1");
-      const v1 = yield* deploy();
-      expect(v1.hash?.assets).toBeDefined();
-      expect(v1.hash?.bundle).toBeDefined();
-      yield* expectUrlContains(`${v1.url!}/index.html`, marker, {
-        timeout: "120 seconds",
-        label: "v1 marker",
-      });
-
-      yield* writeWorker("v2");
-      const v2 = yield* deploy();
-      expect(v2.hash?.bundle).not.toEqual(v1.hash?.bundle);
-      expect(v2.hash?.assets).toEqual(v1.hash?.assets);
-      yield* expectUrlContains(`${v2.url!}/index.html`, marker, {
-        timeout: "60 seconds",
-        label: "v2 marker (assets unchanged)",
-      });
-
-      yield* stack.destroy();
-      yield* waitForWorkerToBeDeleted(v1.workerName, accountId);
-    }).pipe(logLevel),
-  { timeout: 360_000 },
-);
-
-test.provider(
-  "StaticSite: rebuilds when the build output is missing despite unchanged inputs",
-  (stack) =>
-    Effect.gen(function* () {
-      const { accountId } = yield* yield* CloudflareEnvironment;
-      const fs = yield* FileSystem.FileSystem;
-      const path = yield* Path.Path;
-
-      yield* stack.destroy();
-
-      const cwd = yield* cloneFixture(fixtureDir, {
-        prefix: "alchemy-staticsite-missing-output-",
-        entries: ["src", "build.sh", ".gitignore"],
-      });
-      const marker = `staticsite-missing-output-${Date.now()}`;
-      yield* fs.writeFileString(
-        path.join(cwd, "src", "index.html"),
-        htmlPage(marker),
-      );
-      const outdir = path.join(cwd, "dist");
-
-      const deploy = () =>
-        stack.deploy(
-          Effect.gen(function* () {
-            return yield* Cloudflare.Website.StaticSite(
-              "MissingOutputStaticSite",
+              "FixSite",
               staticSiteProps(cwd),
             );
           }),
         );
 
-      const v1 = yield* deploy();
-      expect(v1.hash?.assets).toBeDefined();
-      expect(yield* fs.exists(outdir)).toBe(true);
-      yield* expectUrlContains(`${v1.url!}/index.html`, marker, {
-        timeout: "120 seconds",
-        label: "v1 marker",
-      });
-
-      // Blow away the build output without touching any inputs. The input
-      // hash is unchanged, so memoization alone would skip the rebuild — but
-      // the Build provider also detects the missing output and forces an
-      // update, otherwise the Worker would have no assets to publish.
-      yield* fs.remove(outdir, { recursive: true });
-      expect(yield* fs.exists(outdir)).toBe(false);
-
-      const v2 = yield* deploy();
-      // The build re-ran: the output directory is back and the asset hash is
-      // identical (same source content reproduced the same manifest).
-      expect(yield* fs.exists(outdir)).toBe(true);
-      expect(v2.hash?.assets).toEqual(v1.hash?.assets);
-      yield* expectUrlContains(`${v2.url!}/index.html`, marker, {
-        timeout: "60 seconds",
-        label: "v2 marker (output rebuilt)",
-      });
-
-      yield* stack.destroy();
-      yield* waitForWorkerToBeDeleted(v1.workerName, accountId);
-    }).pipe(logLevel),
-  { timeout: 360_000 },
-);
-
-// ─────────────────────────────────────────────────────────────────────
-// #1056: the assets hash must be a string
-//
-// `Command.Build.hash` is a `{ input, output }` pair; `AssetsWithHash.hash`
-// is a single `string` that the Worker compares with `!==` against the value
-// it persisted. Handing the pair through made every redeploy dirty and
-// re-uploaded the whole asset directory, because state round-trips through
-// JSON and a freshly built object is never `===` its deserialized self.
-// ─────────────────────────────────────────────────────────────────────
-
-/**
- * Round-trip every state row through JSON, exactly like a real state store.
- *
- * `test.provider`'s scratch store keeps rows in memory *by reference*, so an
- * object-valued hash compares `===` against itself and this bug is invisible.
- * `localState` (and R2, and the HTTP store) serialize on write and revive on
- * read — that is what production plans diff against, so reproduce it here.
- */
-const roundTripState = Effect.gen(function* () {
-  const state = yield* yield* State;
-  const stk = yield* Stack;
-  const fqns = yield* state.list({ stack: stk.name, stage: stk.stage });
-  yield* Effect.forEach(fqns, (fqn) =>
-    Effect.gen(function* () {
-      const row = yield* state.get({ stack: stk.name, stage: stk.stage, fqn });
-      if (row === undefined) return;
-      yield* state.set({
-        stack: stk.name,
-        stage: stk.stage,
-        fqn,
-        value: JSON.parse(
-          JSON.stringify(encodeState(row)),
-          reviveState,
-        ) as ResourceState,
-      });
-    }),
-  );
-});
-
-const actionOf = (plan: Plan.Plan, fqn: string) => plan.resources[fqn]?.action;
-
-test.provider(
-  "StaticSite: redeploying an unchanged site is a noop (#1056)",
-  (stack) =>
-    Effect.gen(function* () {
-      const { accountId } = yield* yield* CloudflareEnvironment;
-      const fs = yield* FileSystem.FileSystem;
-      const path = yield* Path.Path;
-
-      yield* stack.destroy();
-
-      // `.gitignore` keeps `dist/` out of the build's input hash, so the
-      // second pass sees byte-identical inputs.
-      const cwd = yield* cloneFixture(fixtureDir, {
-        prefix: "alchemy-staticsite-noop-",
-        entries: ["src", "build.sh", ".gitignore"],
-      });
-      const marker = `staticsite-noop-${Date.now()}`;
-      yield* fs.writeFileString(
-        path.join(cwd, "src", "index.html"),
-        htmlPage(marker),
-      );
-
-      const program = () =>
-        Effect.gen(function* () {
-          return yield* Cloudflare.Website.StaticSite(
-            "NoopSite",
-            staticSiteProps(cwd),
-          );
+        expect(site1.url).toBeDefined();
+        expect(site1.hash?.assets).toBeDefined();
+        yield* expectWorkerExists(site1.workerName, accountId);
+        // End-to-end: the worker URL actually serves the v1 marker.
+        // Use a long timeout because workers.dev subdomains can take 60s+
+        // to propagate the very first time they're enabled.
+        yield* expectUrlContains(`${site1.url!}/index.html`, v1Marker, {
+          timeout: "120 seconds",
+          label: "deploy1 v1 marker",
         });
 
-      const site = yield* stack.deploy(program());
-      yield* expectWorkerExists(site.workerName, accountId);
+        // ── deploy 2: edit fixture, redeploy once ──────────────────────────
+        const v2Marker = `staticsite-v2-${Date.now()}`;
+        yield* fs.writeFileString(indexPath, htmlPage(v2Marker));
 
-      yield* roundTripState;
+        const site2 = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.Website.StaticSite(
+              "FixSite",
+              staticSiteProps(cwd),
+            );
+          }),
+        );
 
-      // Zero source changes between the two passes, so nothing may plan as
-      // changed. This is the user-visible defect: before the fix the Worker
-      // planned `update` on every single deploy and re-uploaded the whole
-      // asset directory, forever.
-      const settled = yield* stack.plan(program());
-      expect(actionOf(settled, "NoopSite/Build")).toBe("noop");
-      expect(actionOf(settled, "NoopSite/Worker")).toBe("noop");
+        expect(site2.hash?.assets).toBeDefined();
+        expect(site2.hash?.assets).not.toEqual(site1.hash?.assets);
 
-      // ...because the persisted hash is the build's `output` hash — the
-      // content hash of the uploaded bytes — and not the `{ input, output }`
-      // pair, which never compares equal to its own deserialized self.
-      expect(typeof site.hash?.assets).toBe("string");
+        // The single-deploy guarantee: after one redeploy, the new
+        // marker is reachable over HTTP. Before the fix, this failure
+        // mode is what users were hitting — the worker version finalized
+        // pointing at the previous asset manifest because the initial
+        // Worker.update read dist mid-write.
+        yield* expectUrlContains(`${site2.url!}/index.html`, v2Marker, {
+          timeout: "60 seconds",
+          label: "deploy2 v2 marker",
+        });
+        // And the v1 marker should be gone — i.e. the new deploy fully
+        // replaced the previous content rather than coexisting with it.
+        yield* expectUrlAbsent(`${site2.url!}/index.html`, v1Marker, {
+          timeout: "30 seconds",
+        });
 
-      yield* stack.destroy();
-      yield* waitForWorkerToBeDeleted(site.workerName, accountId);
-    }).pipe(logLevel),
-  { timeout: 360_000 },
-);
+        yield* stack.destroy();
+        yield* waitForWorkerToBeDeleted(site1.workerName, accountId);
+      }).pipe(logLevel),
+    { timeout: 360_000 },
+  );
 
-test.provider(
-  "StaticSite: a memo:false build has no hash and still uploads the assets",
-  (stack) =>
-    Effect.gen(function* () {
-      const { accountId } = yield* yield* CloudflareEnvironment;
-      const fs = yield* FileSystem.FileSystem;
-      const path = yield* Path.Path;
+  test.provider(
+    "StaticSite: class form deploys and serves the built assets",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
 
-      yield* stack.destroy();
+        yield* stack.destroy();
 
-      const cwd = yield* cloneFixture(fixtureDir, {
-        prefix: "alchemy-staticsite-no-memo-",
-        entries: ["src", "build.sh", ".gitignore"],
-      });
-      const marker = `staticsite-no-memo-${Date.now()}`;
-      yield* fs.writeFileString(
-        path.join(cwd, "src", "index.html"),
-        htmlPage(marker),
-      );
+        const cwd = yield* cloneFixture(fixtureDir, {
+          prefix: "alchemy-staticsite-class-",
+          entries: ["src", "build.sh"],
+        });
+        const indexPath = path.join(cwd, "src", "index.html");
 
-      const site = yield* stack.deploy(
-        Effect.gen(function* () {
-          return yield* Cloudflare.Website.StaticSite("NoMemoSite", {
-            ...staticSiteProps(cwd),
-            memo: false,
+        const marker = `staticsite-class-${Date.now()}`;
+        yield* fs.writeFileString(indexPath, htmlPage(marker));
+
+        const site1 = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* class FixSite extends Cloudflare.Website.StaticSite<FixSite>()(
+              "FixSite",
+              staticSiteProps(cwd),
+            ) {};
+          }),
+        );
+
+        expect(site1.url).toBeDefined();
+        expect(site1.hash?.assets).toBeDefined();
+        yield* expectWorkerExists(site1.workerName, accountId);
+        yield* expectUrlContains(`${site1.url!}/index.html`, marker, {
+          timeout: "120 seconds",
+          label: "class form marker",
+        });
+
+        yield* stack.destroy();
+        yield* waitForWorkerToBeDeleted(site1.workerName, accountId);
+      }).pipe(logLevel),
+    { timeout: 360_000 },
+  );
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Path-relocation / cross-machine state behavior
+  //
+  // `StaticSite` builds via `Build.Command` and hands its `outdir` +
+  // content hash to `Worker` as `AssetsWithHash`. The hash is the only
+  // thing the diff/keepAssets logic should care about — the recorded
+  // `path` is *not* an input. These tests pin that down so that:
+  //
+  //   1. State produced on machine A (e.g. a CI runner) can be
+  //      re-applied on machine B without `NotFound` failures from a
+  //      stale `path` lurking in state.
+  //   2. A worker-only edit, with `src/` byte-identical, keeps the
+  //      asset manifest in place instead of re-uploading.
+  //   3. A genuine source edit (already covered above) bumps the
+  //      hash and ships new bytes — repeated here for symmetry.
+  // ─────────────────────────────────────────────────────────────────────
+
+  test.provider(
+    "StaticSite: relocating the project (and deleting the old one) preserves hash.assets",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+
+        yield* stack.destroy();
+
+        // Include `.gitignore` so `Build.Command`'s default memo skips
+        // `dist/` between deploys; without it, the build output from
+        // deploy 1 would shift the input hash on deploy 2 and force an
+        // unnecessary rebuild that defeats the test.
+        const cwdA = yield* cloneFixture(fixtureDir, {
+          prefix: "alchemy-staticsite-relocate-a-",
+          entries: ["src", "build.sh", ".gitignore"],
+        });
+
+        // Pin a deterministic marker so both deploys hash to the same
+        // bytes regardless of timestamps.
+        const marker = `staticsite-relocate-${Date.now()}`;
+        yield* fs.writeFileString(
+          path.join(cwdA, "src", "index.html"),
+          htmlPage(marker),
+        );
+
+        const site1 = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.Website.StaticSite(
+              "RelocSite",
+              staticSiteProps(cwdA),
+            );
+          }),
+        );
+        expect(site1.hash?.assets).toBeDefined();
+        yield* expectUrlContains(`${site1.url!}/index.html`, marker, {
+          timeout: "120 seconds",
+          label: "deploy1 marker",
+        });
+
+        // Simulate the CI→local handoff: throw away the directory the
+        // first deploy ran in. Anything that still tries to readDir the
+        // recorded `outdir` will blow up here — the keepAssets path
+        // must not require it.
+        yield* fs.remove(cwdA, { recursive: true });
+
+        const cwdB = yield* cloneFixture(fixtureDir, {
+          prefix: "alchemy-staticsite-relocate-b-",
+          entries: ["src", "build.sh", ".gitignore"],
+        });
+        yield* fs.writeFileString(
+          path.join(cwdB, "src", "index.html"),
+          htmlPage(marker),
+        );
+
+        const site2 = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.Website.StaticSite(
+              "RelocSite",
+              staticSiteProps(cwdB),
+            );
+          }),
+        );
+
+        // The build still runs (Build.Command always re-runs its
+        // command), but the resulting content hash is identical, so
+        // Worker takes the keepAssets path and the recorded
+        // `hash.assets` is stable.
+        expect(site2.hash?.assets).toEqual(site1.hash?.assets);
+        // And the URL keeps serving — i.e. we didn't lose the asset
+        // binding in the process.
+        yield* expectUrlContains(`${site2.url!}/index.html`, marker, {
+          timeout: "60 seconds",
+          label: "deploy2 marker",
+        });
+
+        yield* stack.destroy();
+        yield* waitForWorkerToBeDeleted(site1.workerName, accountId);
+      }).pipe(logLevel),
+    { timeout: 360_000 },
+  );
+
+  test.provider(
+    "StaticSite: a bundle-only change keeps the asset manifest (hash.assets stable)",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+
+        yield* stack.destroy();
+
+        // Include `.gitignore` so the memo (which falls back to gitignore
+        // when not explicitly configured) skips `dist/` between deploys —
+        // otherwise the second `hashDirectory` would observe the build
+        // output from deploy 1 and produce a different input hash.
+        const cwd = yield* cloneFixture(fixtureDir, {
+          prefix: "alchemy-staticsite-bundle-only-",
+          entries: ["src", "build.sh", ".gitignore"],
+        });
+        const marker = `staticsite-bundle-only-${Date.now()}`;
+        yield* fs.writeFileString(
+          path.join(cwd, "src", "index.html"),
+          htmlPage(marker),
+        );
+        // Use a temp worker entry so we can edit it between deploys to
+        // shift `hash.bundle` without touching `src/`.
+        const workerDir = yield* fs.makeTempDirectory({
+          prefix: "alchemy-staticsite-bundle-only-entry-",
+        });
+        const workerPath = path.join(workerDir, "worker.ts");
+        const writeWorker = (variant: string) =>
+          fs.writeFileString(
+            workerPath,
+            `export default {
+  fetch: async () => new Response(${JSON.stringify(`bundle-only ${variant}`)}),
+};
+`,
+          );
+
+        const deploy = () =>
+          stack.deploy(
+            Effect.gen(function* () {
+              return yield* Cloudflare.Website.StaticSite(
+                "BundleOnlyStaticSite",
+                {
+                  ...staticSiteProps(cwd),
+                  main: workerPath,
+                },
+              );
+            }),
+          );
+
+        yield* writeWorker("v1");
+        const v1 = yield* deploy();
+        expect(v1.hash?.assets).toBeDefined();
+        expect(v1.hash?.bundle).toBeDefined();
+        yield* expectUrlContains(`${v1.url!}/index.html`, marker, {
+          timeout: "120 seconds",
+          label: "v1 marker",
+        });
+
+        yield* writeWorker("v2");
+        const v2 = yield* deploy();
+        expect(v2.hash?.bundle).not.toEqual(v1.hash?.bundle);
+        expect(v2.hash?.assets).toEqual(v1.hash?.assets);
+        yield* expectUrlContains(`${v2.url!}/index.html`, marker, {
+          timeout: "60 seconds",
+          label: "v2 marker (assets unchanged)",
+        });
+
+        yield* stack.destroy();
+        yield* waitForWorkerToBeDeleted(v1.workerName, accountId);
+      }).pipe(logLevel),
+    { timeout: 360_000 },
+  );
+
+  test.provider(
+    "StaticSite: rebuilds when the build output is missing despite unchanged inputs",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+
+        yield* stack.destroy();
+
+        const cwd = yield* cloneFixture(fixtureDir, {
+          prefix: "alchemy-staticsite-missing-output-",
+          entries: ["src", "build.sh", ".gitignore"],
+        });
+        const marker = `staticsite-missing-output-${Date.now()}`;
+        yield* fs.writeFileString(
+          path.join(cwd, "src", "index.html"),
+          htmlPage(marker),
+        );
+        const outdir = path.join(cwd, "dist");
+
+        const deploy = () =>
+          stack.deploy(
+            Effect.gen(function* () {
+              return yield* Cloudflare.Website.StaticSite(
+                "MissingOutputStaticSite",
+                staticSiteProps(cwd),
+              );
+            }),
+          );
+
+        const v1 = yield* deploy();
+        expect(v1.hash?.assets).toBeDefined();
+        expect(yield* fs.exists(outdir)).toBe(true);
+        yield* expectUrlContains(`${v1.url!}/index.html`, marker, {
+          timeout: "120 seconds",
+          label: "v1 marker",
+        });
+
+        // Blow away the build output without touching any inputs. The input
+        // hash is unchanged, so memoization alone would skip the rebuild — but
+        // the Build provider also detects the missing output and forces an
+        // update, otherwise the Worker would have no assets to publish.
+        yield* fs.remove(outdir, { recursive: true });
+        expect(yield* fs.exists(outdir)).toBe(false);
+
+        const v2 = yield* deploy();
+        // The build re-ran: the output directory is back and the asset hash is
+        // identical (same source content reproduced the same manifest).
+        expect(yield* fs.exists(outdir)).toBe(true);
+        expect(v2.hash?.assets).toEqual(v1.hash?.assets);
+        yield* expectUrlContains(`${v2.url!}/index.html`, marker, {
+          timeout: "60 seconds",
+          label: "v2 marker (output rebuilt)",
+        });
+
+        yield* stack.destroy();
+        yield* waitForWorkerToBeDeleted(v1.workerName, accountId);
+      }).pipe(logLevel),
+    { timeout: 360_000 },
+  );
+
+  // ─────────────────────────────────────────────────────────────────────
+  // #1056: the assets hash must be a string
+  //
+  // `Command.Build.hash` is a `{ input, output }` pair; `AssetsWithHash.hash`
+  // is a single `string` that the Worker compares with `!==` against the value
+  // it persisted. Handing the pair through made every redeploy dirty and
+  // re-uploaded the whole asset directory, because state round-trips through
+  // JSON and a freshly built object is never `===` its deserialized self.
+  // ─────────────────────────────────────────────────────────────────────
+
+  /**
+   * Round-trip every state row through JSON, exactly like a real state store.
+   *
+   * `test.provider`'s scratch store keeps rows in memory *by reference*, so an
+   * object-valued hash compares `===` against itself and this bug is invisible.
+   * `localState` (and R2, and the HTTP store) serialize on write and revive on
+   * read — that is what production plans diff against, so reproduce it here.
+   */
+  const roundTripState = Effect.gen(function* () {
+    const state = yield* yield* State;
+    const stk = yield* Stack;
+    const fqns = yield* state.list({ stack: stk.name, stage: stk.stage });
+    yield* Effect.forEach(fqns, (fqn) =>
+      Effect.gen(function* () {
+        const row = yield* state.get({
+          stack: stk.name,
+          stage: stk.stage,
+          fqn,
+        });
+        if (row === undefined) return;
+        yield* state.set({
+          stack: stk.name,
+          stage: stk.stage,
+          fqn,
+          value: JSON.parse(
+            JSON.stringify(encodeState(row)),
+            reviveState,
+          ) as ResourceState,
+        });
+      }),
+    );
+  });
+
+  const actionOf = (plan: Plan.Plan, fqn: string) =>
+    plan.resources[fqn]?.action;
+
+  test.provider(
+    "StaticSite: redeploying an unchanged site is a noop (#1056)",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+
+        yield* stack.destroy();
+
+        // `.gitignore` keeps `dist/` out of the build's input hash, so the
+        // second pass sees byte-identical inputs.
+        const cwd = yield* cloneFixture(fixtureDir, {
+          prefix: "alchemy-staticsite-noop-",
+          entries: ["src", "build.sh", ".gitignore"],
+        });
+        const marker = `staticsite-noop-${Date.now()}`;
+        yield* fs.writeFileString(
+          path.join(cwd, "src", "index.html"),
+          htmlPage(marker),
+        );
+
+        const program = () =>
+          Effect.gen(function* () {
+            return yield* Cloudflare.Website.StaticSite(
+              "NoopSite",
+              staticSiteProps(cwd),
+            );
           });
-        }),
-      );
 
-      // `memo: false` computes no hashes, so the site hands the Worker
-      // `hash: undefined` — the hash-*less* shape, which must make the
-      // Worker hash `outdir` itself. Reading an explicit `undefined` as a
-      // supplied hash instead makes a greenfield create compare `undefined
-      // === undefined`, set `skip`, and publish a Worker with no assets.
-      expect(site.hash?.assets).toBeDefined();
-      yield* expectWorkerExists(site.workerName, accountId);
-      yield* expectUrlContains(`${site.url!}/index.html`, marker, {
-        timeout: "120 seconds",
-        label: "memo:false marker",
-      });
+        const site = yield* stack.deploy(program());
+        yield* expectWorkerExists(site.workerName, accountId);
 
-      yield* stack.destroy();
-      yield* waitForWorkerToBeDeleted(site.workerName, accountId);
-    }).pipe(logLevel),
-  { timeout: 360_000 },
-);
+        yield* roundTripState;
 
-// ─────────────────────────────────────────────────────────────────────
-// Legacy state migration
-//
-// `StaticSite`'s build sub-resource was renamed `Build.Command` →
-// `Command.Build` and its `attr.hash` shape changed from a bare `string`
-// to `{ input, output }`. An existing deployment upgrading across the
-// rename has the old row on disk. Deploying the new `StaticSite` over it
-// must not error — it re-runs the build (the memoization shape changed)
-// and republishes the assets, migrating the row to the new type.
-// ─────────────────────────────────────────────────────────────────────
-test.provider(
-  "StaticSite: deploys over legacy Build.Command state and republishes assets",
-  (stack) =>
-    Effect.gen(function* () {
-      const { accountId } = yield* yield* CloudflareEnvironment;
-      const fs = yield* FileSystem.FileSystem;
-      const path = yield* Path.Path;
-      const state = yield* yield* State;
-      const stk = yield* Stack;
+        // Zero source changes between the two passes, so nothing may plan as
+        // changed. This is the user-visible defect: before the fix the Worker
+        // planned `update` on every single deploy and re-uploaded the whole
+        // asset directory, forever.
+        const settled = yield* stack.plan(program());
+        expect(actionOf(settled, "NoopSite/Build")).toBe("noop");
+        expect(actionOf(settled, "NoopSite/Worker")).toBe("noop");
 
-      yield* stack.destroy();
+        // ...because the persisted hash is the build's `output` hash — the
+        // content hash of the uploaded bytes — and not the `{ input, output }`
+        // pair, which never compares equal to its own deserialized self.
+        expect(typeof site.hash?.assets).toBe("string");
 
-      const cwd = yield* cloneFixture(fixtureDir, {
-        prefix: "alchemy-staticsite-migrate-",
-        entries: ["src", "build.sh", ".gitignore"],
-      });
-      const marker = `staticsite-migrate-${Date.now()}`;
-      yield* fs.writeFileString(
-        path.join(cwd, "src", "index.html"),
-        htmlPage(marker),
-      );
+        yield* stack.destroy();
+        yield* waitForWorkerToBeDeleted(site.workerName, accountId);
+      }).pipe(logLevel),
+    { timeout: 360_000 },
+  );
 
-      // Mirror `examples/.../Website__Build.json`: a pre-rename
-      // `Build.Command` row at the build sub-resource's FQN, carrying the
-      // legacy `attr.hash` string (pre-`{ input, output }`).
-      yield* state.set({
-        stack: stk.name,
-        stage: stk.stage,
-        fqn: "MigSite/Build",
-        value: {
-          status: "created",
+  test.provider(
+    "StaticSite: a memo:false build has no hash and still uploads the assets",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+
+        yield* stack.destroy();
+
+        const cwd = yield* cloneFixture(fixtureDir, {
+          prefix: "alchemy-staticsite-no-memo-",
+          entries: ["src", "build.sh", ".gitignore"],
+        });
+        const marker = `staticsite-no-memo-${Date.now()}`;
+        yield* fs.writeFileString(
+          path.join(cwd, "src", "index.html"),
+          htmlPage(marker),
+        );
+
+        const site = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.Website.StaticSite("NoMemoSite", {
+              ...staticSiteProps(cwd),
+              memo: false,
+            });
+          }),
+        );
+
+        // `memo: false` computes no hashes, so the site hands the Worker
+        // `hash: undefined` — the hash-*less* shape, which must make the
+        // Worker hash `outdir` itself. Reading an explicit `undefined` as a
+        // supplied hash instead makes a greenfield create compare `undefined
+        // === undefined`, set `skip`, and publish a Worker with no assets.
+        expect(site.hash?.assets).toBeDefined();
+        yield* expectWorkerExists(site.workerName, accountId);
+        yield* expectUrlContains(`${site.url!}/index.html`, marker, {
+          timeout: "120 seconds",
+          label: "memo:false marker",
+        });
+
+        yield* stack.destroy();
+        yield* waitForWorkerToBeDeleted(site.workerName, accountId);
+      }).pipe(logLevel),
+    { timeout: 360_000 },
+  );
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Legacy state migration
+  //
+  // `StaticSite`'s build sub-resource was renamed `Build.Command` →
+  // `Command.Build` and its `attr.hash` shape changed from a bare `string`
+  // to `{ input, output }`. An existing deployment upgrading across the
+  // rename has the old row on disk. Deploying the new `StaticSite` over it
+  // must not error — it re-runs the build (the memoization shape changed)
+  // and republishes the assets, migrating the row to the new type.
+  // ─────────────────────────────────────────────────────────────────────
+  test.provider(
+    "StaticSite: deploys over legacy Build.Command state and republishes assets",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const state = yield* yield* State;
+        const stk = yield* Stack;
+
+        yield* stack.destroy();
+
+        const cwd = yield* cloneFixture(fixtureDir, {
+          prefix: "alchemy-staticsite-migrate-",
+          entries: ["src", "build.sh", ".gitignore"],
+        });
+        const marker = `staticsite-migrate-${Date.now()}`;
+        yield* fs.writeFileString(
+          path.join(cwd, "src", "index.html"),
+          htmlPage(marker),
+        );
+
+        // Mirror `examples/.../Website__Build.json`: a pre-rename
+        // `Build.Command` row at the build sub-resource's FQN, carrying the
+        // legacy `attr.hash` string (pre-`{ input, output }`).
+        yield* state.set({
+          stack: stk.name,
+          stage: stk.stage,
           fqn: "MigSite/Build",
-          logicalId: "Build",
-          instanceId: "606bcaf4c0a931156f5a314ba7b57fc3",
-          resourceType: "Build.Command",
-          props: { command: "bash build.sh", outdir: "dist", env: {} },
-          attr: {
-            outdir: "dist",
-            hash: "a41cbcecfdeb355f6f98130ca4ff8269d0ad5cc3a628f1918d956c71f859648c",
-          },
-          bindings: [],
-          providerVersion: 0,
-          downstream: ["MigSite/Worker"],
-          removalPolicy: "destroy",
-          namespace: { Id: "MigSite" },
-        } satisfies ResourceState,
-      });
-
-      const site = yield* stack.deploy(
-        Effect.gen(function* () {
-          return yield* Cloudflare.Website.StaticSite(
-            "MigSite",
-            staticSiteProps(cwd),
-          );
-        }),
-      );
-
-      expect(site.url).toBeDefined();
-      expect(site.hash?.assets).toBeDefined();
-      yield* expectWorkerExists(site.workerName, accountId);
-      yield* expectUrlContains(`${site.url!}/index.html`, marker, {
-        timeout: "120 seconds",
-        label: "migrated site marker",
-      });
-
-      // The build sub-resource row migrated to the new resource type.
-      const build = (yield* state.get({
-        stack: stk.name,
-        stage: stk.stage,
-        fqn: "MigSite/Build",
-      })) as ResourceState | undefined;
-      expect(build?.resourceType).toBe("Command.Build");
-
-      yield* stack.destroy();
-      yield* waitForWorkerToBeDeleted(site.workerName, accountId);
-    }).pipe(logLevel),
-  { timeout: 360_000 },
-);
-
-// ─────────────────────────────────────────────────────────────────────
-// Orphaned dev-server cleanup across the rename
-//
-// A prior `alchemy dev` run writes a `Build.DevServer` row at the
-// StaticSite's `Dev` sub-resource FQN. A subsequent normal `deploy` never
-// declares that dev resource, so the row is orphaned and must be torn
-// down. Before the `Renamed("Build.DevServer" → "Command.Dev")` shim
-// existed, that teardown failed: the engine couldn't resolve a provider
-// for the now-nonexistent `Build.DevServer` type and the deploy errored.
-// This guards that the deploy succeeds and the orphan is reaped.
-// ─────────────────────────────────────────────────────────────────────
-test.provider(
-  "StaticSite: deploys cleanly when a legacy Build.DevServer row is orphaned",
-  (stack) =>
-    Effect.gen(function* () {
-      const { accountId } = yield* yield* CloudflareEnvironment;
-      const fs = yield* FileSystem.FileSystem;
-      const path = yield* Path.Path;
-      const state = yield* yield* State;
-      const stk = yield* Stack;
-
-      yield* stack.destroy();
-
-      const cwd = yield* cloneFixture(fixtureDir, {
-        prefix: "alchemy-staticsite-orphan-dev-",
-        entries: ["src", "build.sh", ".gitignore"],
-      });
-      const marker = `staticsite-orphan-dev-${Date.now()}`;
-      yield* fs.writeFileString(
-        path.join(cwd, "src", "index.html"),
-        htmlPage(marker),
-      );
-
-      // Mirror `examples/.../Website__Dev.json`: a pre-rename
-      // `Build.DevServer` row left behind by an earlier `alchemy dev` run,
-      // sitting at the `Dev` sub-resource FQN that a normal deploy never
-      // declares.
-      yield* state.set({
-        stack: stk.name,
-        stage: stk.stage,
-        fqn: "MigSite/Dev",
-        value: {
-          status: "created",
-          fqn: "MigSite/Dev",
-          logicalId: "Dev",
-          instanceId: "b4ca740550ef6e2e409481cedf9314c7",
-          resourceType: "Build.DevServer",
-          props: { command: "zola serve", env: {} },
-          attr: { url: "http://127.0.0.1:1024" },
-          bindings: [],
-          providerVersion: 0,
-          downstream: ["MigSite/Worker"],
-          removalPolicy: "destroy",
-          namespace: { Id: "MigSite" },
-        } satisfies ResourceState,
-      });
-
-      const site = yield* stack.deploy(
-        Effect.gen(function* () {
-          return yield* Cloudflare.Website.StaticSite(
-            "MigSite",
-            staticSiteProps(cwd),
-          );
-        }),
-      );
-
-      expect(site.url).toBeDefined();
-      yield* expectWorkerExists(site.workerName, accountId);
-      yield* expectUrlContains(`${site.url!}/index.html`, marker, {
-        timeout: "120 seconds",
-        label: "orphan-dev site marker",
-      });
-
-      // The orphaned dev-server row was reaped via the renamed provider.
-      const orphan = yield* state.get({
-        stack: stk.name,
-        stage: stk.stage,
-        fqn: "MigSite/Dev",
-      });
-      expect(orphan).toBeUndefined();
-
-      yield* stack.destroy();
-      yield* waitForWorkerToBeDeleted(site.workerName, accountId);
-    }).pipe(logLevel),
-  { timeout: 360_000 },
-);
-
-test.provider(
-  "StaticSite: build env resolves Config, Output, and JSON values (#796)",
-  (stack) =>
-    Effect.gen(function* () {
-      const fs = yield* FileSystem.FileSystem;
-      const path = yield* Path.Path;
-
-      yield* stack.destroy();
-
-      // A build that snapshots the env vars it receives into its output.
-      const cwd = yield* fs.makeTempDirectory({
-        prefix: "alchemy-staticsite-env-",
-      });
-      yield* fs.writeFileString(
-        path.join(cwd, "build.sh"),
-        [
-          "#!/bin/bash",
-          "set -euo pipefail",
-          "mkdir -p dist",
-          "{",
-          '  echo "FROM_STRING=${FROM_STRING:-missing}"',
-          '  echo "FROM_CONFIG=${FROM_CONFIG:-missing}"',
-          '  echo "FROM_OUTPUT=${FROM_OUTPUT:-missing}"',
-          '  echo "FROM_OUTPUT_OBJECT=${FROM_OUTPUT_OBJECT:-missing}"',
-          '  echo "FROM_NULL=${FROM_NULL:-missing}"',
-          "} > dist/env.txt",
-        ].join("\n"),
-      );
-
-      // A sibling resource whose attributes provide real `Output` values.
-      const depCwd = yield* fs.makeTempDirectory({
-        prefix: "alchemy-staticsite-env-dep-",
-      });
-      yield* fs.writeFileString(
-        path.join(depCwd, "build.sh"),
-        "#!/bin/bash\nmkdir -p dist\necho dep > dist/dep.txt\n",
-      );
-
-      yield* Effect.sync(() => {
-        process.env.STATICSITE_ENV_TEST = "from-config";
-      });
-
-      yield* stack.deploy(
-        Effect.gen(function* () {
-          const dep = yield* Command.Build("EnvDep", {
-            command: "bash build.sh",
-            shell: true,
-            cwd: depCwd,
-            outdir: "dist",
-          });
-          return yield* Cloudflare.Website.StaticSite("EnvSite", {
-            command: "bash build.sh",
-            shell: true,
-            cwd,
-            outdir: "dist",
-            workersDev: false,
-            env: {
-              FROM_STRING: "plain",
-              FROM_CONFIG: Config.string("STATICSITE_ENV_TEST"),
-              FROM_OUTPUT: dep.outdir,
-              FROM_OUTPUT_OBJECT: Output.map(dep.outdir, (dir) => ({ dir })),
-              // JS callers can pass `null`; it must serialize, not throw.
-              FROM_NULL: null as unknown as string,
+          value: {
+            status: "created",
+            fqn: "MigSite/Build",
+            logicalId: "Build",
+            instanceId: "606bcaf4c0a931156f5a314ba7b57fc3",
+            resourceType: "Build.Command",
+            props: { command: "bash build.sh", outdir: "dist", env: {} },
+            attr: {
+              outdir: "dist",
+              hash: "a41cbcecfdeb355f6f98130ca4ff8269d0ad5cc3a628f1918d956c71f859648c",
             },
-          });
-        }),
-      );
+            bindings: [],
+            providerVersion: 0,
+            downstream: ["MigSite/Worker"],
+            removalPolicy: "destroy",
+            namespace: { Id: "MigSite" },
+          } satisfies ResourceState,
+        });
 
-      const envFile = yield* fs.readFileString(
-        path.join(cwd, "dist", "env.txt"),
-      );
-      expect(envFile).toContain("FROM_STRING=plain");
-      expect(envFile).toContain("FROM_CONFIG=from-config");
-      // Resolved Output<string> — the dep's outdir path, not garbage.
-      const fromOutput = envFile.match(/FROM_OUTPUT=(.*)/)?.[1];
-      expect(fromOutput).toBeDefined();
-      expect(fromOutput).not.toBe("missing");
-      expect(fromOutput).toContain("dist");
-      expect(fromOutput).not.toContain("[object");
-      // Resolved Output<object> — serialized as JSON.
-      const fromOutputObject = envFile.match(/FROM_OUTPUT_OBJECT=(.*)/)?.[1];
-      expect(fromOutputObject).toContain('{"dir":');
-      expect(envFile).toContain("FROM_NULL=null");
+        const site = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.Website.StaticSite(
+              "MigSite",
+              staticSiteProps(cwd),
+            );
+          }),
+        );
 
-      yield* stack.destroy();
-    }).pipe(logLevel),
-  { timeout: 360_000 },
-);
+        expect(site.url).toBeDefined();
+        expect(site.hash?.assets).toBeDefined();
+        yield* expectWorkerExists(site.workerName, accountId);
+        yield* expectUrlContains(`${site.url!}/index.html`, marker, {
+          timeout: "120 seconds",
+          label: "migrated site marker",
+        });
+
+        // The build sub-resource row migrated to the new resource type.
+        const build = (yield* state.get({
+          stack: stk.name,
+          stage: stk.stage,
+          fqn: "MigSite/Build",
+        })) as ResourceState | undefined;
+        expect(build?.resourceType).toBe("Command.Build");
+
+        yield* stack.destroy();
+        yield* waitForWorkerToBeDeleted(site.workerName, accountId);
+      }).pipe(logLevel),
+    { timeout: 360_000 },
+  );
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Orphaned dev-server cleanup across the rename
+  //
+  // A prior `alchemy dev` run writes a `Build.DevServer` row at the
+  // StaticSite's `Dev` sub-resource FQN. A subsequent normal `deploy` never
+  // declares that dev resource, so the row is orphaned and must be torn
+  // down. Before the `Renamed("Build.DevServer" → "Command.Dev")` shim
+  // existed, that teardown failed: the engine couldn't resolve a provider
+  // for the now-nonexistent `Build.DevServer` type and the deploy errored.
+  // This guards that the deploy succeeds and the orphan is reaped.
+  // ─────────────────────────────────────────────────────────────────────
+  test.provider(
+    "StaticSite: deploys cleanly when a legacy Build.DevServer row is orphaned",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const state = yield* yield* State;
+        const stk = yield* Stack;
+
+        yield* stack.destroy();
+
+        const cwd = yield* cloneFixture(fixtureDir, {
+          prefix: "alchemy-staticsite-orphan-dev-",
+          entries: ["src", "build.sh", ".gitignore"],
+        });
+        const marker = `staticsite-orphan-dev-${Date.now()}`;
+        yield* fs.writeFileString(
+          path.join(cwd, "src", "index.html"),
+          htmlPage(marker),
+        );
+
+        // Mirror `examples/.../Website__Dev.json`: a pre-rename
+        // `Build.DevServer` row left behind by an earlier `alchemy dev` run,
+        // sitting at the `Dev` sub-resource FQN that a normal deploy never
+        // declares.
+        yield* state.set({
+          stack: stk.name,
+          stage: stk.stage,
+          fqn: "MigSite/Dev",
+          value: {
+            status: "created",
+            fqn: "MigSite/Dev",
+            logicalId: "Dev",
+            instanceId: "b4ca740550ef6e2e409481cedf9314c7",
+            resourceType: "Build.DevServer",
+            props: { command: "zola serve", env: {} },
+            attr: { url: "http://127.0.0.1:1024" },
+            bindings: [],
+            providerVersion: 0,
+            downstream: ["MigSite/Worker"],
+            removalPolicy: "destroy",
+            namespace: { Id: "MigSite" },
+          } satisfies ResourceState,
+        });
+
+        const site = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.Website.StaticSite(
+              "MigSite",
+              staticSiteProps(cwd),
+            );
+          }),
+        );
+
+        expect(site.url).toBeDefined();
+        yield* expectWorkerExists(site.workerName, accountId);
+        yield* expectUrlContains(`${site.url!}/index.html`, marker, {
+          timeout: "120 seconds",
+          label: "orphan-dev site marker",
+        });
+
+        // The orphaned dev-server row was reaped via the renamed provider.
+        const orphan = yield* state.get({
+          stack: stk.name,
+          stage: stk.stage,
+          fqn: "MigSite/Dev",
+        });
+        expect(orphan).toBeUndefined();
+
+        yield* stack.destroy();
+        yield* waitForWorkerToBeDeleted(site.workerName, accountId);
+      }).pipe(logLevel),
+    { timeout: 360_000 },
+  );
+
+  test.provider(
+    "StaticSite: build env resolves Config, Output, and JSON values (#796)",
+    (stack) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+
+        yield* stack.destroy();
+
+        // A build that snapshots the env vars it receives into its output.
+        const cwd = yield* fs.makeTempDirectory({
+          prefix: "alchemy-staticsite-env-",
+        });
+        yield* fs.writeFileString(
+          path.join(cwd, "build.sh"),
+          [
+            "#!/bin/bash",
+            "set -euo pipefail",
+            "mkdir -p dist",
+            "{",
+            '  echo "FROM_STRING=${FROM_STRING:-missing}"',
+            '  echo "FROM_CONFIG=${FROM_CONFIG:-missing}"',
+            '  echo "FROM_OUTPUT=${FROM_OUTPUT:-missing}"',
+            '  echo "FROM_OUTPUT_OBJECT=${FROM_OUTPUT_OBJECT:-missing}"',
+            '  echo "FROM_NULL=${FROM_NULL:-missing}"',
+            "} > dist/env.txt",
+          ].join("\n"),
+        );
+
+        // A sibling resource whose attributes provide real `Output` values.
+        const depCwd = yield* fs.makeTempDirectory({
+          prefix: "alchemy-staticsite-env-dep-",
+        });
+        yield* fs.writeFileString(
+          path.join(depCwd, "build.sh"),
+          "#!/bin/bash\nmkdir -p dist\necho dep > dist/dep.txt\n",
+        );
+
+        yield* Effect.sync(() => {
+          process.env.STATICSITE_ENV_TEST = "from-config";
+        });
+
+        yield* stack.deploy(
+          Effect.gen(function* () {
+            const dep = yield* Command.Build("EnvDep", {
+              command: "bash build.sh",
+              shell: true,
+              cwd: depCwd,
+              outdir: "dist",
+            });
+            return yield* Cloudflare.Website.StaticSite("EnvSite", {
+              command: "bash build.sh",
+              shell: true,
+              cwd,
+              outdir: "dist",
+              workersDev: false,
+              env: {
+                FROM_STRING: "plain",
+                FROM_CONFIG: Config.string("STATICSITE_ENV_TEST"),
+                FROM_OUTPUT: dep.outdir,
+                FROM_OUTPUT_OBJECT: Output.map(dep.outdir, (dir) => ({ dir })),
+                // JS callers can pass `null`; it must serialize, not throw.
+                FROM_NULL: null as unknown as string,
+              },
+            });
+          }),
+        );
+
+        const envFile = yield* fs.readFileString(
+          path.join(cwd, "dist", "env.txt"),
+        );
+        expect(envFile).toContain("FROM_STRING=plain");
+        expect(envFile).toContain("FROM_CONFIG=from-config");
+        // Resolved Output<string> — the dep's outdir path, not garbage.
+        const fromOutput = envFile.match(/FROM_OUTPUT=(.*)/)?.[1];
+        expect(fromOutput).toBeDefined();
+        expect(fromOutput).not.toBe("missing");
+        expect(fromOutput).toContain("dist");
+        expect(fromOutput).not.toContain("[object");
+        // Resolved Output<object> — serialized as JSON.
+        const fromOutputObject = envFile.match(/FROM_OUTPUT_OBJECT=(.*)/)?.[1];
+        expect(fromOutputObject).toContain('{"dir":');
+        expect(envFile).toContain("FROM_NULL=null");
+
+        yield* stack.destroy();
+      }).pipe(logLevel),
+    { timeout: 360_000 },
+  );
+});
 
 const staticSiteProps = (cwd: string): Cloudflare.Website.StaticSiteProps => ({
   command: "bash build.sh",

--- a/packages/alchemy/test/Cloudflare/Website/StaticSite.test.ts
+++ b/packages/alchemy/test/Cloudflare/Website/StaticSite.test.ts
@@ -2,8 +2,9 @@ import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
 import * as Cloudflare from "@/Cloudflare/index.ts";
 import * as Command from "@/Command/index.ts";
 import * as Output from "@/Output.ts";
+import type * as Plan from "@/Plan.ts";
 import { Stack } from "@/Stack";
-import { type ResourceState, State } from "@/State";
+import { encodeState, type ResourceState, reviveState, State } from "@/State";
 import * as Test from "@/Test/Alchemy";
 import { expect } from "alchemy-test";
 import * as Config from "effect/Config";
@@ -382,6 +383,148 @@ test.provider(
 
       yield* stack.destroy();
       yield* waitForWorkerToBeDeleted(v1.workerName, accountId);
+    }).pipe(logLevel),
+  { timeout: 360_000 },
+);
+
+// ─────────────────────────────────────────────────────────────────────
+// #1056: the assets hash must be a string
+//
+// `Command.Build.hash` is a `{ input, output }` pair; `AssetsWithHash.hash`
+// is a single `string` that the Worker compares with `!==` against the value
+// it persisted. Handing the pair through made every redeploy dirty and
+// re-uploaded the whole asset directory, because state round-trips through
+// JSON and a freshly built object is never `===` its deserialized self.
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Round-trip every state row through JSON, exactly like a real state store.
+ *
+ * `test.provider`'s scratch store keeps rows in memory *by reference*, so an
+ * object-valued hash compares `===` against itself and this bug is invisible.
+ * `localState` (and R2, and the HTTP store) serialize on write and revive on
+ * read — that is what production plans diff against, so reproduce it here.
+ */
+const roundTripState = Effect.gen(function* () {
+  const state = yield* yield* State;
+  const stk = yield* Stack;
+  const fqns = yield* state.list({ stack: stk.name, stage: stk.stage });
+  yield* Effect.forEach(fqns, (fqn) =>
+    Effect.gen(function* () {
+      const row = yield* state.get({ stack: stk.name, stage: stk.stage, fqn });
+      if (row === undefined) return;
+      yield* state.set({
+        stack: stk.name,
+        stage: stk.stage,
+        fqn,
+        value: JSON.parse(
+          JSON.stringify(encodeState(row)),
+          reviveState,
+        ) as ResourceState,
+      });
+    }),
+  );
+});
+
+const actionOf = (plan: Plan.Plan, fqn: string) => plan.resources[fqn]?.action;
+
+test.provider(
+  "StaticSite: redeploying an unchanged site is a noop (#1056)",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* yield* CloudflareEnvironment;
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+
+      yield* stack.destroy();
+
+      // `.gitignore` keeps `dist/` out of the build's input hash, so the
+      // second pass sees byte-identical inputs.
+      const cwd = yield* cloneFixture(fixtureDir, {
+        prefix: "alchemy-staticsite-noop-",
+        entries: ["src", "build.sh", ".gitignore"],
+      });
+      const marker = `staticsite-noop-${Date.now()}`;
+      yield* fs.writeFileString(
+        path.join(cwd, "src", "index.html"),
+        htmlPage(marker),
+      );
+
+      const program = () =>
+        Effect.gen(function* () {
+          return yield* Cloudflare.Website.StaticSite(
+            "NoopSite",
+            staticSiteProps(cwd),
+          );
+        });
+
+      const site = yield* stack.deploy(program());
+      yield* expectWorkerExists(site.workerName, accountId);
+
+      yield* roundTripState;
+
+      // Zero source changes between the two passes, so nothing may plan as
+      // changed. This is the user-visible defect: before the fix the Worker
+      // planned `update` on every single deploy and re-uploaded the whole
+      // asset directory, forever.
+      const settled = yield* stack.plan(program());
+      expect(actionOf(settled, "NoopSite/Build")).toBe("noop");
+      expect(actionOf(settled, "NoopSite/Worker")).toBe("noop");
+
+      // ...because the persisted hash is the build's `output` hash — the
+      // content hash of the uploaded bytes — and not the `{ input, output }`
+      // pair, which never compares equal to its own deserialized self.
+      expect(typeof site.hash?.assets).toBe("string");
+
+      yield* stack.destroy();
+      yield* waitForWorkerToBeDeleted(site.workerName, accountId);
+    }).pipe(logLevel),
+  { timeout: 360_000 },
+);
+
+test.provider(
+  "StaticSite: a memo:false build has no hash and still uploads the assets",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* yield* CloudflareEnvironment;
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+
+      yield* stack.destroy();
+
+      const cwd = yield* cloneFixture(fixtureDir, {
+        prefix: "alchemy-staticsite-no-memo-",
+        entries: ["src", "build.sh", ".gitignore"],
+      });
+      const marker = `staticsite-no-memo-${Date.now()}`;
+      yield* fs.writeFileString(
+        path.join(cwd, "src", "index.html"),
+        htmlPage(marker),
+      );
+
+      const site = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.Website.StaticSite("NoMemoSite", {
+            ...staticSiteProps(cwd),
+            memo: false,
+          });
+        }),
+      );
+
+      // `memo: false` computes no hashes, so the site hands the Worker
+      // `hash: undefined` — the hash-*less* shape, which must make the
+      // Worker hash `outdir` itself. Reading an explicit `undefined` as a
+      // supplied hash instead makes a greenfield create compare `undefined
+      // === undefined`, set `skip`, and publish a Worker with no assets.
+      expect(site.hash?.assets).toBeDefined();
+      yield* expectWorkerExists(site.workerName, accountId);
+      yield* expectUrlContains(`${site.url!}/index.html`, marker, {
+        timeout: "120 seconds",
+        label: "memo:false marker",
+      });
+
+      yield* stack.destroy();
+      yield* waitForWorkerToBeDeleted(site.workerName, accountId);
     }).pipe(logLevel),
   { timeout: 360_000 },
 );


### PR DESCRIPTION
`Command.Build`'s `hash` attribute is a `{ input, output }` pair, but `AssetsWithHash.hash` is a single `string` — and the `cast` hid the mismatch:

```diff
+    const assetsHash: Output.Output<string | undefined> | undefined = build
+      ? Output.map(build.hash, (hash) => hash.output)
+      : undefined;
+
     return yield* Worker<Bindings, WorkerAssetsConfig, Req>("Worker", {
       ...props,
       assets: build
         ? cast({
             directory: build.outdir,
-            hash: build.hash,
+            hash: assetsHash,
             ...props.assets,
           })
         : undefined,
```

The Worker compares that hash by reference (`assets.hash !== output.hash?.assets` in diff, `effectiveHash === output?.hash?.assets` in apply) against the value read back from state. State round-trips through JSON, so an object is never equal to its deserialized self: every plan reported the Worker as changed and every apply re-uploaded the whole asset directory.

`hash.output` is the content hash of the build's `outdir` — exactly the bytes being uploaded. Under `memo: false` no hashes are computed at all, so it is `undefined` and the Worker hashes the directory itself (the path #1045 added).

The local annotation is load-bearing: `cast` erases the object literal's shape, so it is the only thing type-checking the mapping.

`normalizePrebuiltAssets` now treats an explicitly-undefined `hash` as the hash-less shape, matching what `assetsChanged` already does:

```diff
-        if (!Predicate.hasProperty(assets, "hash")) return undefined;
+        if (
+          !Predicate.hasProperty(assets, "hash") ||
+          assets.hash === undefined
+        ) {
+          return undefined;
+        }
```

Without it a greenfield create (`output === undefined`) compares `undefined === undefined`, sets `skip`, and uploads a Worker with no assets.

Not covered by #1047/#1045: those fix the hash-*less* `assets: { directory }` shape. #1045 deliberately keeps the precomputed-hash branch ahead of the new directory hashing, and StaticSite always supplies a hash, so it never reaches it.

Closes #1056

🤖 Generated with [Claude Code](https://claude.com/claude-code)
