### PR TITLE
chore(ts): resolve project references through .d.ts, not distilled's sources

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -20,6 +20,14 @@
     // Best practices
     "strict": true,
     "skipLibCheck": true,
+    // Resolve project references (notably every `distilled/packages/*`)
+    // through their emitted `lib/*.d.ts` instead of redirecting to their
+    // sources. Without this, editors and `tsc` pull distilled's generated
+    // SDK sources — hundreds of thousands of lines across 20 packages —
+    // into the program, which is what makes intellisense crawl. distilled
+    // builds with `noCheck: true` and gates its own typechecking in its
+    // own CI, so re-checking its sources from here buys nothing.
+    "disableSourceOfProjectReferenceRedirect": true,
     "noFallthroughCasesInSwitch": true,
     // Some stricter flags (disabled by default)
     "noUnusedLocals": false,


### PR DESCRIPTION
Resolve project references (notably every `distilled/packages/*`) through their emitted `lib/*.d.ts` instead of redirecting to their sources.

Without this, editors and `tsc` pull distilled's generated SDK sources — hundreds of thousands of lines across 20 packages — into the program, which is what makes intellisense crawl. distilled builds with `noCheck: true` and gates its own typechecking in its own CI, so re-checking its sources from here buys nothing.

---

The `force-latest` and actions-pin changes that were originally in this PR have moved to #1104, which fixes the broken release workflow and is independent of this.
