### PR TITLE
fix(planetscale): split same-line statement-breakpoint markers

### DIFF
--- a/packages/alchemy/src/Planetscale/MySQL/MySQLMigrations.ts
+++ b/packages/alchemy/src/Planetscale/MySQL/MySQLMigrations.ts
@@ -4,7 +4,12 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schedule from "effect/Schedule";
 import { createConnection, type Connection } from "mysql2/promise";
-import { listSqlFiles, readSqlFile, type SqlFile } from "../../SQL/SqlFile.ts";
+import {
+  listSqlFiles,
+  readSqlFile,
+  splitSqlStatements,
+  type SqlFile,
+} from "../../SQL/SqlFile.ts";
 
 const MIGRATION_PASSWORD_TTL_SECONDS = 600;
 
@@ -95,7 +100,7 @@ const applyMySQLMigrations = (options: ApplyMigrationsOptions) =>
         nextSeq += 1;
         yield* Effect.gen(function* () {
           yield* mysqlQuery(connection, "START TRANSACTION");
-          for (const statement of splitMySQLStatements(file.sql)) {
+          for (const statement of splitSqlStatements(file.sql)) {
             yield* mysqlQuery(connection, statement);
           }
           yield* mysqlExecute(
@@ -119,28 +124,11 @@ const applyMySQLMigrations = (options: ApplyMigrationsOptions) =>
 const runMySQLSql = (target: MySQLMigrationTarget, sql: string) =>
   withMySQLConnection(target, (connection) =>
     Effect.gen(function* () {
-      for (const statement of splitMySQLStatements(sql)) {
+      for (const statement of splitSqlStatements(sql)) {
         yield* mysqlQuery(connection, statement);
       }
     }),
   );
-
-// Drizzle (and other migration tools) emit `--> statement-breakpoint` as a
-// separator between statements. PlanetScale's Vitess parser rejects the `-->`
-// token ("syntax error at position 2") because MySQL line comments require
-// whitespace after `--`. Split on the marker and run each statement
-// individually so the connector never sees the breakpoint comment.
-// drizzle-kit puts the marker directly after single-line statements
-// (`...;--> statement-breakpoint`), so the split can't anchor on a
-// preceding newline.
-const STATEMENT_BREAKPOINT = /\s*-->\s*statement-breakpoint\s*/g;
-
-/** @internal exported for unit testing. */
-export const splitMySQLStatements = (sql: string): string[] =>
-  sql
-    .split(STATEMENT_BREAKPOINT)
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0);
 
 const getNextMySQLSeq = (connection: Connection, table: string) =>
   mysqlQueryRows<{ id: string }>(connection, `SELECT id FROM ${table};`).pipe(

--- a/packages/alchemy/src/Planetscale/MySQL/MySQLMigrations.ts
+++ b/packages/alchemy/src/Planetscale/MySQL/MySQLMigrations.ts
@@ -130,12 +130,13 @@ const runMySQLSql = (target: MySQLMigrationTarget, sql: string) =>
 // token ("syntax error at position 2") because MySQL line comments require
 // whitespace after `--`. Split on the marker and run each statement
 // individually so the connector never sees the breakpoint comment.
-// The marker is not always preceded by a newline: drizzle-kit appends it on
-// the same line for single-line statements (`...;--> statement-breakpoint`),
-// so split on the bare marker; the trailing `;` stays with its statement.
+// drizzle-kit puts the marker directly after single-line statements
+// (`...;--> statement-breakpoint`), so the split can't anchor on a
+// preceding newline.
 const STATEMENT_BREAKPOINT = /\s*-->\s*statement-breakpoint\s*/g;
 
-const splitMySQLStatements = (sql: string): string[] =>
+/** @internal exported for unit testing. */
+export const splitMySQLStatements = (sql: string): string[] =>
   sql
     .split(STATEMENT_BREAKPOINT)
     .map((s) => s.trim())

--- a/packages/alchemy/src/Planetscale/MySQL/MySQLMigrations.ts
+++ b/packages/alchemy/src/Planetscale/MySQL/MySQLMigrations.ts
@@ -130,7 +130,10 @@ const runMySQLSql = (target: MySQLMigrationTarget, sql: string) =>
 // token ("syntax error at position 2") because MySQL line comments require
 // whitespace after `--`. Split on the marker and run each statement
 // individually so the connector never sees the breakpoint comment.
-const STATEMENT_BREAKPOINT = /\r?\n\s*-->\s*statement-breakpoint\s*\r?\n?/g;
+// The marker is not always preceded by a newline: drizzle-kit appends it on
+// the same line for single-line statements (`...;--> statement-breakpoint`),
+// so split on the bare marker; the trailing `;` stays with its statement.
+const STATEMENT_BREAKPOINT = /\s*-->\s*statement-breakpoint\s*/g;
 
 const splitMySQLStatements = (sql: string): string[] =>
   sql

--- a/packages/alchemy/src/SQL/SqlFile.ts
+++ b/packages/alchemy/src/SQL/SqlFile.ts
@@ -75,3 +75,23 @@ const getPrefix = (name: string): number | null => {
   const num = Number.parseInt(prefix, 10);
   return Number.isNaN(num) ? null : num;
 };
+
+// Drizzle (and other migration tools) emit `--> statement-breakpoint` between
+// statements. drizzle-kit puts the marker directly after single-line
+// statements (`...;--> statement-breakpoint`), so the split can't anchor on a
+// preceding newline.
+const STATEMENT_BREAKPOINT = /\s*-->\s*statement-breakpoint\s*/g;
+
+/**
+ * Split a migration file into individual statements on its
+ * `--> statement-breakpoint` markers. MySQL engines need this: they only
+ * treat `--` as a comment when followed by whitespace, so the `-->` token is
+ * a syntax error ("syntax error at position 2" on Vitess). Postgres and
+ * sqlite comment on `--` regardless of the next character, so their runners
+ * send files whole.
+ */
+export const splitSqlStatements = (sql: string): string[] =>
+  sql
+    .split(STATEMENT_BREAKPOINT)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);

--- a/packages/alchemy/test/Planetscale/MySQL/MySQLMigrations.test.ts
+++ b/packages/alchemy/test/Planetscale/MySQL/MySQLMigrations.test.ts
@@ -1,0 +1,50 @@
+import { splitMySQLStatements } from "@/Planetscale/MySQL/MySQLMigrations";
+import { describe, expect, test } from "alchemy-test";
+
+describe("MySQLMigrations", () => {
+  describe("splitMySQLStatements", () => {
+    test("splits statements separated by breakpoints on their own line", () => {
+      const sql = [
+        "CREATE TABLE `users` (\n\t`id` int NOT NULL\n);",
+        "--> statement-breakpoint",
+        "CREATE TABLE `sessions` (\n\t`id` int NOT NULL\n);",
+      ].join("\n");
+      expect(splitMySQLStatements(sql)).toEqual([
+        "CREATE TABLE `users` (\n\t`id` int NOT NULL\n);",
+        "CREATE TABLE `sessions` (\n\t`id` int NOT NULL\n);",
+      ]);
+    });
+
+    // drizzle-kit puts the marker on the same line after single-line
+    // statements (`...;--> statement-breakpoint`). A newline-anchored split
+    // misses those, and the leftover `-->` makes Vitess bail with
+    // "syntax error at position 2".
+    test("splits breakpoints appended on the same line as the statement", () => {
+      const sql = [
+        "CREATE TABLE `users` (\n\t`id` int NOT NULL\n);",
+        "--> statement-breakpoint",
+        "CREATE INDEX `users_email` ON `users` (`email`);--> statement-breakpoint",
+        "CREATE INDEX `users_name` ON `users` (`name`);",
+      ].join("\n");
+      expect(splitMySQLStatements(sql)).toEqual([
+        "CREATE TABLE `users` (\n\t`id` int NOT NULL\n);",
+        "CREATE INDEX `users_email` ON `users` (`email`);",
+        "CREATE INDEX `users_name` ON `users` (`name`);",
+      ]);
+    });
+
+    test("splits CRLF-separated breakpoints", () => {
+      const sql =
+        "CREATE TABLE `users` (`id` int);\r\n--> statement-breakpoint\r\nCREATE TABLE `sessions` (`id` int);";
+      expect(splitMySQLStatements(sql)).toEqual([
+        "CREATE TABLE `users` (`id` int);",
+        "CREATE TABLE `sessions` (`id` int);",
+      ]);
+    });
+
+    test("drops empty segments and keeps sql without markers intact", () => {
+      expect(splitMySQLStatements("--> statement-breakpoint\n")).toEqual([]);
+      expect(splitMySQLStatements("SELECT 1;")).toEqual(["SELECT 1;"]);
+    });
+  });
+});

--- a/packages/alchemy/test/SQL/SqlFile.test.ts
+++ b/packages/alchemy/test/SQL/SqlFile.test.ts
@@ -1,15 +1,15 @@
-import { splitMySQLStatements } from "@/Planetscale/MySQL/MySQLMigrations";
+import { splitSqlStatements } from "@/SQL/SqlFile";
 import { describe, expect, test } from "alchemy-test";
 
-describe("MySQLMigrations", () => {
-  describe("splitMySQLStatements", () => {
+describe("SqlFile", () => {
+  describe("splitSqlStatements", () => {
     test("splits statements separated by breakpoints on their own line", () => {
       const sql = [
         "CREATE TABLE `users` (\n\t`id` int NOT NULL\n);",
         "--> statement-breakpoint",
         "CREATE TABLE `sessions` (\n\t`id` int NOT NULL\n);",
       ].join("\n");
-      expect(splitMySQLStatements(sql)).toEqual([
+      expect(splitSqlStatements(sql)).toEqual([
         "CREATE TABLE `users` (\n\t`id` int NOT NULL\n);",
         "CREATE TABLE `sessions` (\n\t`id` int NOT NULL\n);",
       ]);
@@ -26,7 +26,7 @@ describe("MySQLMigrations", () => {
         "CREATE INDEX `users_email` ON `users` (`email`);--> statement-breakpoint",
         "CREATE INDEX `users_name` ON `users` (`name`);",
       ].join("\n");
-      expect(splitMySQLStatements(sql)).toEqual([
+      expect(splitSqlStatements(sql)).toEqual([
         "CREATE TABLE `users` (\n\t`id` int NOT NULL\n);",
         "CREATE INDEX `users_email` ON `users` (`email`);",
         "CREATE INDEX `users_name` ON `users` (`name`);",
@@ -36,15 +36,15 @@ describe("MySQLMigrations", () => {
     test("splits CRLF-separated breakpoints", () => {
       const sql =
         "CREATE TABLE `users` (`id` int);\r\n--> statement-breakpoint\r\nCREATE TABLE `sessions` (`id` int);";
-      expect(splitMySQLStatements(sql)).toEqual([
+      expect(splitSqlStatements(sql)).toEqual([
         "CREATE TABLE `users` (`id` int);",
         "CREATE TABLE `sessions` (`id` int);",
       ]);
     });
 
     test("drops empty segments and keeps sql without markers intact", () => {
-      expect(splitMySQLStatements("--> statement-breakpoint\n")).toEqual([]);
-      expect(splitMySQLStatements("SELECT 1;")).toEqual(["SELECT 1;"]);
+      expect(splitSqlStatements("--> statement-breakpoint\n")).toEqual([]);
+      expect(splitSqlStatements("SELECT 1;")).toEqual(["SELECT 1;"]);
     });
   });
 });


### PR DESCRIPTION
Drizzle-kit appends the `--> statement-breakpoint` marker on the same line for single-line statements:

```sql
CREATE TABLE `users` (
	`id` int NOT NULL
);
--> statement-breakpoint
CREATE INDEX `users_email` ON `users` (`email`);--> statement-breakpoint
CREATE INDEX `users_name` ON `users` (`name`);
```

`STATEMENT_BREAKPOINT` requires a newline before `-->`, so same-line markers survive the split and the merged statement reaches Vitess, which rejects the `-->` token with `syntax error at position 2`. This is the exact failure the split exists to prevent.

```diff
-const STATEMENT_BREAKPOINT = /\r?\n\s*-->\s*statement-breakpoint\s*\r?\n?/g;
+const STATEMENT_BREAKPOINT = /\s*-->\s*statement-breakpoint\s*/g;
```

The `\s*` on both sides still absorbs surrounding newlines and the trailing `;` stays with its statement.
