### PR TITLE
feat(cloudflare): Alchemy.remote() for worker-only bindings, drop dev.remote props

### DIFF
--- a/examples/cloudflare-dev/alchemy.run.ts
+++ b/examples/cloudflare-dev/alchemy.run.ts
@@ -105,8 +105,9 @@ const AsyncWorker = (deps: {
  * Media & messaging worker: Browser Rendering, Images, Stream, Secrets
  * Store, and Email (send + inbound handler) — all served by local
  * simulators under `alchemy dev`. `IMAGES_REMOTE` demonstrates the per-
- * binding hybrid escape hatch: `dev: { remote: true }` proxies just that
- * binding to the real Images service while the worker stays local.
+ * binding hybrid escape hatch: piping the binding through
+ * `Alchemy.remote()` proxies just that binding to the real Images service
+ * while the worker stays local.
  */
 const MediaWorker = Effect.gen(function* () {
   const store = yield* Cloudflare.SecretsStore.Store("Secrets");
@@ -123,9 +124,9 @@ const MediaWorker = Effect.gen(function* () {
     env: {
       BROWSER: Cloudflare.Browser("BROWSER"),
       IMAGES: Cloudflare.Images.Images("IMAGES"),
-      IMAGES_REMOTE: Cloudflare.Images.Images("IMAGES_REMOTE", {
-        dev: { remote: true },
-      }),
+      IMAGES_REMOTE: Cloudflare.Images.Images("IMAGES_REMOTE").pipe(
+        Alchemy.remote(),
+      ),
       STREAM: Cloudflare.Stream.Stream("STREAM"),
       EMAIL: email,
       API_KEY: apiKey,

--- a/examples/cloudflare-dev/src/MediaWorker.ts
+++ b/examples/cloudflare-dev/src/MediaWorker.ts
@@ -62,7 +62,7 @@ export default {
         case "/images/info":
           return imagesInfo(env.IMAGES, request);
         case "/images/info-remote":
-          // Same call, but through the `dev: { remote: true }` binding —
+          // Same call, but through the `Alchemy.remote()`-piped binding —
           // served by the REAL Images service even during `alchemy dev`.
           return imagesInfo(env.IMAGES_REMOTE, request);
         case "/images/transform": {

--- a/examples/cloudflare-dev/test/integ.test.ts
+++ b/examples/cloudflare-dev/test/integ.test.ts
@@ -795,13 +795,13 @@ test(
 );
 
 /**
- * HYBRID — per-binding `dev: { remote: true }`: `IMAGES_REMOTE` proxies to
+ * HYBRID — per-binding `Alchemy.remote()`: `IMAGES_REMOTE` proxies to
  * the REAL Images service while the worker (and every other binding) stays
  * local. Requires real Cloudflare credentials, which this suite already has
  * (the state store is remote).
  */
 test(
-  "MediaWorker images binding with dev remote: true hits the real service",
+  "MediaWorker images binding with Alchemy.remote() hits the real service",
   Effect.gen(function* () {
     const { mediaWorker } = yield* stack;
     const info = (yield* Effect.gen(function* () {

--- a/packages/alchemy/src/Cloudflare/Images/Images.ts
+++ b/packages/alchemy/src/Cloudflare/Images/Images.ts
@@ -15,22 +15,6 @@ export class ImagesError extends Data.TaggedError("ImagesError")<{
   cause: unknown;
 }> {}
 
-/** Extra options accepted by the {@link Images} binding constructor. */
-export interface ImagesBindingProps {
-  /**
-   * Configuration for the binding in `alchemy dev`.
-   * @default { remote: false }
-   */
-  dev?: {
-    /**
-     * Whether to proxy to the real Images service in development. If `false`,
-     * transforms run locally via Sharp and hosted images are stored on disk.
-     * @default false
-     */
-    remote?: boolean;
-  };
-}
-
 /**
  * A Cloudflare Images binding for image transformation inside Workers — a
  * Worker-only binding with no backing cloud resource.
@@ -75,6 +59,18 @@ export interface ImagesBindingProps {
  * //   { MEDIA: ImagesBinding }
  * ```
  *
+ * @section Local development
+ * @example Proxy to the real Images service in dev
+ * ```typescript
+ * // Default: transforms run locally via Sharp under `alchemy dev` and
+ * // hosted images are stored on disk. Alchemy.remote() opts the binding
+ * // into the real Images service instead — in an Effect-native Worker:
+ * const images = yield* Cloudflare.Images.Images("IMAGES").pipe(Alchemy.remote());
+ *
+ * // or declared on an async Worker's env:
+ * env: { IMAGES: Cloudflare.Images.Images("IMAGES").pipe(Alchemy.remote()) }
+ * ```
+ *
  * @see https://developers.cloudflare.com/images/transform-images/bindings/
  */
 export interface Images extends Binding.Service<Images, TypeId, ImagesClient> {
@@ -82,16 +78,12 @@ export interface Images extends Binding.Service<Images, TypeId, ImagesClient> {
    * @param name Binding name (logical id) — the `env` key it resolves to.
    * @default "IMAGES"
    */
-  (name?: string, props?: ImagesBindingProps): ImagesBinding;
+  (name?: string): ImagesBinding;
 }
 
-export const Images = Binding.Service<Images, { devRemote?: boolean }>({
+export const Images = Binding.Service<Images>({
   id: TypeId,
   defaultName: "IMAGES",
-  parse: (name?: string, props?: ImagesBindingProps) => ({
-    name,
-    devRemote: props?.dev?.remote,
-  }),
   toWorkerBinding: (binding) => ({
     type: "images",
     name: binding.name,

--- a/packages/alchemy/src/Cloudflare/Stream/Stream.ts
+++ b/packages/alchemy/src/Cloudflare/Stream/Stream.ts
@@ -24,23 +24,6 @@ export class StreamError extends Data.TaggedError("StreamError")<{
 /** An Effect produced by a {@link StreamClient} operation. */
 type StreamEffect<A> = Effect.Effect<A, StreamError, RuntimeContext>;
 
-/** Extra options accepted by the {@link Stream} binding constructor. */
-export interface StreamBindingProps {
-  /**
-   * Configuration for the binding in `alchemy dev`.
-   * @default { remote: false }
-   */
-  dev?: {
-    /**
-     * Whether to proxy to the real Stream service in development. If `false`,
-     * videos are stored in a local simulator and served unmodified at
-     * `/cdn-cgi/mf/stream/<id>/watch` on the dev URL.
-     * @default false
-     */
-    remote?: boolean;
-  };
-}
-
 /**
  * A Cloudflare Stream binding for managing videos, captions, downloads and
  * watermarks from Workers — a Worker-only binding with no backing cloud
@@ -56,8 +39,9 @@ export interface StreamBindingProps {
  * video store and each video's `preview` URL is served unmodified at
  * `{devUrl}/cdn-cgi/mf/stream/<id>/watch`. The local store performs no
  * transcoding (the `hlsPlaybackUrl`/`dashPlaybackUrl` point at a placeholder
- * host), no signed URLs, and `createDirectUpload` is unsupported. Pass
- * `dev: { remote: true }` to proxy to the real Stream service instead.
+ * host), no signed URLs, and `createDirectUpload` is unsupported. Pipe the
+ * binding through `Alchemy.remote()` to proxy to the real Stream service
+ * instead.
  *
  * @binding
  * @product Stream
@@ -96,6 +80,18 @@ export interface StreamBindingProps {
  * //   { STREAM: StreamBinding }
  * ```
  *
+ * @section Local development
+ * @example Proxy to the real Stream service in dev
+ * ```typescript
+ * // Default: videos land in the local video store under `alchemy dev`.
+ * // Alchemy.remote() opts the binding into the real Stream service
+ * // instead — in an Effect-native Worker:
+ * const stream = yield* Cloudflare.Stream.Stream("STREAM").pipe(Alchemy.remote());
+ *
+ * // or declared on an async Worker's env:
+ * env: { STREAM: Cloudflare.Stream.Stream("STREAM").pipe(Alchemy.remote()) }
+ * ```
+ *
  * @see https://developers.cloudflare.com/stream/
  */
 export interface Stream extends Binding.Service<Stream, TypeId, StreamClient> {
@@ -103,16 +99,12 @@ export interface Stream extends Binding.Service<Stream, TypeId, StreamClient> {
    * @param name Binding name (logical id) — the `env` key it resolves to.
    * @default "STREAM"
    */
-  (name?: string, props?: StreamBindingProps): StreamBinding;
+  (name?: string): StreamBinding;
 }
 
-export const Stream = Binding.Service<Stream, { devRemote?: boolean }>({
+export const Stream = Binding.Service<Stream>({
   id: TypeId,
   defaultName: "STREAM",
-  parse: (name?: string, props?: StreamBindingProps) => ({
-    name,
-    devRemote: props?.dev?.remote,
-  }),
   toWorkerBinding: (binding) => ({
     type: "stream",
     name: binding.name,

--- a/packages/alchemy/src/Cloudflare/Workers/Binding.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Binding.ts
@@ -1,6 +1,8 @@
-import type * as Effect from "effect/Effect";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import { SingleShotGen } from "effect/Utils";
 import * as CoreBinding from "../../Binding.ts";
+import { ProviderModePolicy } from "../../ProviderMode.ts";
 import { taggedFunction } from "../../Util/effect.ts";
 import type { WorkerBinding } from "./WorkerBinding.ts";
 
@@ -29,10 +31,10 @@ export interface Binding<
   readonly name: string;
   /**
    * Alchemy-internal: opt this binding out of local emulation in
-   * `alchemy dev` (set by the constructor's `dev: { remote: true }` prop on
-   * capabilities that support it — Browser, Images, Stream). Registered on
-   * the host Worker via the binding-data `devRemote` channel, never on the
-   * wire binding itself.
+   * `alchemy dev` — the `Alchemy.remote()` decoration captured by
+   * {@link pipe} on capabilities with a local simulator (Browser, Images,
+   * Stream). Registered on the host Worker via the binding-data `devRemote`
+   * channel, never on the wire binding itself.
    */
   readonly devRemote?: boolean;
   /** Attach the binding to the surrounding Worker and resolve to the client. */
@@ -40,7 +42,55 @@ export interface Binding<
   [Symbol.iterator](): Generator<Effect.Effect<Client, never, Service>, Client>;
   /** Wire metadata emitted into the Worker script's `metadata.bindings`. */
   toWorkerBinding(): WorkerBinding;
+  /**
+   * Lift the binding into an Effect ({@link BindingEffect}) so registration
+   * aspects can decorate it — most notably `Alchemy.remote()`, which opts
+   * the binding out of local emulation in `alchemy dev`:
+   *
+   * ```ts
+   * // Effect-native Worker — resolves to the runtime client:
+   * const browser = yield* Cloudflare.Browser("BROWSER").pipe(Alchemy.remote());
+   *
+   * // async Worker env — declares the decorated binding:
+   * env: { IMAGES: Cloudflare.Images.Images("IMAGES").pipe(Alchemy.remote()) }
+   * ```
+   */
+  pipe(): BindingEffect<this>;
+  pipe<A>(ab: (self: BindingEffect<this>) => A): A;
+  pipe<A, B>(ab: (self: BindingEffect<this>) => A, bc: (a: A) => B): B;
+  pipe<A, B, C>(
+    ab: (self: BindingEffect<this>) => A,
+    bc: (a: A) => B,
+    cd: (b: B) => C,
+  ): C;
 }
+
+/**
+ * A Worker-only {@link Binding} lifted into an Effect by {@link Binding.pipe},
+ * with the ambient {@link ProviderModePolicy} (`Alchemy.remote()`) captured
+ * when it runs.
+ *
+ * Context-adaptive resolution: inside an Effect-native Worker (where the
+ * binding's implementation layer is provided) it registers the binding on the
+ * host and resolves to the runtime `Client` — same one-`yield*` shape as the
+ * bare binding value. Anywhere else (an async Worker's `env`, resolved by the
+ * engine) it resolves to the decorated binding *value*; the
+ * `"~alchemy/Binding"` brand lets `InferEnv` map it to the native runtime
+ * type.
+ */
+export interface BindingEffect<
+  B extends Binding<any, any, any>,
+> extends Effect.Effect<
+  B extends Binding<any, infer Client, any> ? Client : never,
+  never,
+  B extends Binding<any, any, infer Service> ? Service : never
+> {
+  readonly "~alchemy/Kind": "Cloudflare.Workers.BindingEffect";
+  readonly "~alchemy/Binding": B;
+}
+
+/** Any {@link BindingEffect} — the arm admitted by a Worker's `env`. */
+export type AnyBindingEffect = BindingEffect<Binding<any, any, any>>;
 
 /**
  * The fused tag + callable + type for a Worker-only binding — the same
@@ -109,22 +159,46 @@ export const Service = <
   );
   const bind = tag as unknown as (binding: unknown) => Effect.Effect<unknown>;
 
+  const make = (data: Record<PropertyKey, unknown>) => {
+    const self: Record<PropertyKey, unknown> = { ...data };
+    self.toWorkerBinding = () =>
+      config.toWorkerBinding(self as never as { name: string } & Payload);
+    self.asEffect = () => bind(self);
+    self[Symbol.iterator] = () => new SingleShotGen(bind(self));
+    // The lifted form (`BindingEffect`): capture the ambient
+    // `ProviderModePolicy` (`Alchemy.remote()` decoration), then resolve
+    // context-adaptively — to the runtime client when the binding's layer is
+    // in context (inside an Effect-native Worker), to the decorated binding
+    // value otherwise (an async Worker's `env`, resolved by the engine).
+    const lifted = Effect.gen(function* () {
+      const policy = yield* ProviderModePolicy;
+      const decorated =
+        policy === undefined || policy === !!data.devRemote
+          ? self
+          : make({ ...data, devRemote: policy || undefined });
+      const impl = yield* Effect.serviceOption(tag as never);
+      return Option.isSome(impl)
+        ? yield* (impl.value as (b: unknown) => Effect.Effect<unknown>)(
+            decorated,
+          )
+        : decorated;
+    });
+    self.pipe = (...fns: Array<(value: unknown) => unknown>) =>
+      fns.reduce((acc, fn) => fn(acc), lifted as unknown);
+    return self;
+  };
+
   const construct = (...args: unknown[]) => {
     const { name, ...payload } =
       config.parse?.(...args) ??
       ({ name: args[0] as string | undefined } as {
         name?: string;
       } & Payload);
-    const self: Record<PropertyKey, unknown> = {
+    return make({
       kind: config.id,
       name: name ?? config.defaultName,
       ...payload,
-    };
-    self.toWorkerBinding = () =>
-      config.toWorkerBinding(self as { name: string } & Payload);
-    self.asEffect = () => bind(self);
-    self[Symbol.iterator] = () => new SingleShotGen(bind(self));
-    return self;
+    });
   };
 
   return taggedFunction(tag as never, construct as never) as unknown as Self;

--- a/packages/alchemy/src/Cloudflare/Workers/Browser.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Browser.ts
@@ -116,23 +116,6 @@ export interface BrowserClient {
   ): BrowserEffect<BrowserMarkdownResult>;
 }
 
-/** Extra options accepted by the {@link Browser} binding constructor. */
-export interface BrowserBindingProps {
-  /**
-   * Configuration for the binding in `alchemy dev`.
-   * @default { remote: false }
-   */
-  dev?: {
-    /**
-     * Whether to proxy to the real Browser Rendering service in development.
-     * If `false`, a real headless Chrome is launched locally and driven over
-     * CDP (downloaded on first use into the shared wrangler cache).
-     * @default false
-     */
-    remote?: boolean;
-  };
-}
-
 /**
  * A Cloudflare Browser Rendering binding for launching headless browser sessions
  * from Workers — a Worker-only binding with no backing cloud resource.
@@ -178,6 +161,18 @@ export interface BrowserBindingProps {
  * //   { BROWSER: BrowserRun }
  * ```
  *
+ * @section Local development
+ * @example Proxy to the real Browser Rendering service in dev
+ * ```typescript
+ * // Default: a real headless Chrome is launched locally and driven over
+ * // CDP under `alchemy dev`. Alchemy.remote() opts the binding into the
+ * // real Browser Rendering service instead — in an Effect-native Worker:
+ * const browser = yield* Cloudflare.Browser("BROWSER").pipe(Alchemy.remote());
+ *
+ * // or declared on an async Worker's env:
+ * env: { BROWSER: Cloudflare.Browser("BROWSER").pipe(Alchemy.remote()) }
+ * ```
+ *
  * @see https://developers.cloudflare.com/browser-rendering/workers-binding-api/
  */
 export interface Browser extends Binding.Service<
@@ -189,16 +184,12 @@ export interface Browser extends Binding.Service<
    * @param name Binding name (logical id) — the `env` key it resolves to.
    * @default "BROWSER"
    */
-  (name?: string, props?: BrowserBindingProps): BrowserBinding;
+  (name?: string): BrowserBinding;
 }
 
-export const Browser = Binding.Service<Browser, { devRemote?: boolean }>({
+export const Browser = Binding.Service<Browser>({
   id: TypeId,
   defaultName: "BROWSER",
-  parse: (name?: string, props?: BrowserBindingProps) => ({
-    name,
-    devRemote: props?.dev?.remote,
-  }),
   toWorkerBinding: (binding) => ({
     type: "browser",
     name: binding.name,

--- a/packages/alchemy/src/Cloudflare/Workers/InferEnv.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/InferEnv.ts
@@ -30,6 +30,7 @@ import type * as StreamNs from "../Stream/index.ts";
 import type { DispatchNamespace as DispatchNamespaceResource } from "../WorkersForPlatforms/DispatchNamespace.ts";
 import type { AIBinding } from "./AIBinding.ts";
 import type { Assets } from "./Assets.ts";
+import type * as WorkerOnlyBinding from "./Binding.ts";
 import type { BrowserBinding } from "./BrowserBinding.ts";
 import type { DurableObjectLike } from "./DurableObject.ts";
 import type { RateLimitBinding } from "./RateLimitBinding.ts";
@@ -54,79 +55,85 @@ export type GetBindingType<T> =
   // generic Effect unwrap: a Container declaration is itself an Effect.
   T extends Container.Decl<any, any, any, any, infer DOShape>
     ? DurableObjectNamespace<DOShape & Rpc.DurableObjectBranded>
-    : // `Worker.URL` (an Effect resolving to a deferred string accessor) needs
-      // no case of its own: the generic Effect unwrap below reduces it to
-      // `string` via the fallthrough.
-      T extends
-          | Output<infer A, infer _Req>
-          | Effect.Effect<infer A, infer _E, infer _R>
-      ? GetBindingType<A>
-      : T extends FlagshipNs.App
-        ? Flagship
-        : T extends Assets
-          ? Service
-          : T extends AlchemyRpc<infer Shape extends object>
-            ? RpcWireShape<Shape> & Service
-            : T extends D1.Database
-              ? D1Database
-              : T extends R2.Bucket
-                ? R2Bucket
-                : T extends KV.Namespace
-                  ? KVNamespace
-                  : T extends DispatchNamespaceResource
-                    ? DispatchNamespace
-                    : T extends Queues.Queue
-                      ? Queue<unknown>
-                      : T extends AI.Gateway
-                        ? Ai
-                        : T extends AIBinding
+    : // A Worker-only binding lifted by `.pipe(Alchemy.remote())` — the brand
+      // carries the underlying binding value type; recurse on it. Must also
+      // be tested BEFORE the generic Effect unwrap (its Effect `A` is the
+      // runtime client, not the binding value).
+      T extends WorkerOnlyBinding.BindingEffect<infer B>
+      ? GetBindingType<B>
+      : // `Worker.URL` (an Effect resolving to a deferred string accessor) needs
+        // no case of its own: the generic Effect unwrap below reduces it to
+        // `string` via the fallthrough.
+        T extends
+            | Output<infer A, infer _Req>
+            | Effect.Effect<infer A, infer _E, infer _R>
+        ? GetBindingType<A>
+        : T extends FlagshipNs.App
+          ? Flagship
+          : T extends Assets
+            ? Service
+            : T extends AlchemyRpc<infer Shape extends object>
+              ? RpcWireShape<Shape> & Service
+              : T extends D1.Database
+                ? D1Database
+                : T extends R2.Bucket
+                  ? R2Bucket
+                  : T extends KV.Namespace
+                    ? KVNamespace
+                    : T extends DispatchNamespaceResource
+                      ? DispatchNamespace
+                      : T extends Queues.Queue
+                        ? Queue<unknown>
+                        : T extends AI.Gateway
                           ? Ai
-                          : T extends AI.Search
-                            ? AiSearchInstance
-                            : T extends AI.SearchNamespace
-                              ? AiSearchNamespace
-                              : T extends Email.SendEmail
-                                ? SendEmail
-                                : T extends AnalyticsEngine.Dataset
-                                  ? AnalyticsEngineDataset
-                                  : T extends ArtifactsNs.Namespace
-                                    ? Artifacts
-                                    : T extends RateLimitBinding
-                                      ? RateLimit
-                                      : T extends SecretKeyBinding
-                                        ? CryptoKey
-                                        : T extends ImagesNs.ImagesBinding
-                                          ? ImagesBinding
-                                          : T extends BrowserBinding
-                                            ? BrowserRun
-                                            : // The ambient global `StreamBinding` from
-                                              // @cloudflare/workers-types (the alchemy binding value
-                                              // type of the same name is only reachable as
-                                              // `StreamNs.StreamBinding`).
-                                              T extends StreamNs.StreamBinding
-                                              ? StreamBinding
-                                              : T extends HyperdriveNs.Connection
-                                                ? Hyperdrive
-                                                : T extends VersionMetadataBinding
-                                                  ? WorkerVersionMetadata
-                                                  : T extends WorkerLoaderResource
-                                                    ? WorkerLoader
-                                                    : T extends WorkflowLike<
-                                                          infer Params
-                                                        >
-                                                      ? Workflow<Params>
-                                                      : T extends DurableObjectLike
-                                                        ? DurableObjectNamespace<
-                                                            Exclude<
-                                                              T["Shape"],
-                                                              undefined
-                                                            >
+                          : T extends AIBinding
+                            ? Ai
+                            : T extends AI.Search
+                              ? AiSearchInstance
+                              : T extends AI.SearchNamespace
+                                ? AiSearchNamespace
+                                : T extends Email.SendEmail
+                                  ? SendEmail
+                                  : T extends AnalyticsEngine.Dataset
+                                    ? AnalyticsEngineDataset
+                                    : T extends ArtifactsNs.Namespace
+                                      ? Artifacts
+                                      : T extends RateLimitBinding
+                                        ? RateLimit
+                                        : T extends SecretKeyBinding
+                                          ? CryptoKey
+                                          : T extends ImagesNs.ImagesBinding
+                                            ? ImagesBinding
+                                            : T extends BrowserBinding
+                                              ? BrowserRun
+                                              : // The ambient global `StreamBinding` from
+                                                // @cloudflare/workers-types (the alchemy binding value
+                                                // type of the same name is only reachable as
+                                                // `StreamNs.StreamBinding`).
+                                                T extends StreamNs.StreamBinding
+                                                ? StreamBinding
+                                                : T extends HyperdriveNs.Connection
+                                                  ? Hyperdrive
+                                                  : T extends VersionMetadataBinding
+                                                    ? WorkerVersionMetadata
+                                                    : T extends WorkerLoaderResource
+                                                      ? WorkerLoader
+                                                      : T extends WorkflowLike<
+                                                            infer Params
                                                           >
-                                                        : T extends Redacted<any>
-                                                          ? // redacteds are always stored as secret_text, so are always string
-                                                            // we JSON.stringify when not a Redacted<string>
-                                                            string
-                                                          : T;
+                                                        ? Workflow<Params>
+                                                        : T extends DurableObjectLike
+                                                          ? DurableObjectNamespace<
+                                                              Exclude<
+                                                                T["Shape"],
+                                                                undefined
+                                                              >
+                                                            >
+                                                          : T extends Redacted<any>
+                                                            ? // redacteds are always stored as secret_text, so are always string
+                                                              // we JSON.stringify when not a Redacted<string>
+                                                              string
+                                                            : T;
 
 /**
  * Cloudflare service-binding wire shape for an Effect-native Worker.

--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -330,7 +330,7 @@ export const LocalWorkerProvider = () =>
         const workflows: Record<string, RuntimeWorkflow> = {};
         const hyperdrives: Record<string, Required<HyperdriveOrigin>> = {};
         // Dev-only channel (like `hyperdrives`): binding name → opt-out of
-        // local emulation (`dev: { remote: true }` on the capability). Read
+        // local emulation (the binding was piped through `Alchemy.remote()`). Read
         // by `toRuntimeBinding` when lowering browser/images/stream/
         // send_email descriptors. Part of the hashed config: flipping the
         // opt-out restarts the instance.
@@ -1110,7 +1110,7 @@ export const toRuntimeBinding = Effect.fn(function* (
     case "browser":
       // Local emulation launches a real headless Chrome on this machine and
       // proxies the Browser Rendering session protocol to its CDP endpoint;
-      // `dev: { remote: true }` opts into the real service instead.
+      // `Alchemy.remote()` opts into the real service instead.
       return devRemote?.[b.name]
         ? Browser.remote(b.name)
         : Browser.local({ binding: b.name });
@@ -1143,7 +1143,7 @@ export const toRuntimeBinding = Effect.fn(function* (
       return Hyperdrive.local(b.name, b.id);
     case "images":
       // Local emulation runs transforms via Sharp on this machine and stores
-      // hosted images in a local KV-backed store; `dev: { remote: true }`
+      // hosted images in a local KV-backed store; `Alchemy.remote()`
       // opts into the real Images service instead.
       return devRemote?.[b.name]
         ? Images.remote(b.name)
@@ -1255,7 +1255,7 @@ export const toRuntimeBinding = Effect.fn(function* (
     case "stream":
       // Local emulation stores videos in a local simulator (no transcoding,
       // no signed URLs) and serves each video's `preview` URL at
-      // /cdn-cgi/mf/stream/<id>/watch on the dev URL; `dev: { remote: true }`
+      // /cdn-cgi/mf/stream/<id>/watch on the dev URL; `Alchemy.remote()`
       // opts into the real Stream service instead.
       return devRemote?.[b.name]
         ? StreamSim.remote(b.name)

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -1098,7 +1098,7 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
     hyperdrives?: Record<string, Required<DevOrigin>>;
     /**
      * Dev-only channel (like `hyperdrives`): binding name → opt-out of local
-     * emulation in `alchemy dev` (`dev: { remote: true }` on the capability
+     * emulation in `alchemy dev` (the binding was piped through `Alchemy.remote()`
      * constructor). Contributed alongside the pure wire binding instead of
      * being embedded in it — wire descriptors stay exactly what Cloudflare
      * accepts. Records from multiple bind calls merge by key; the local

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
@@ -156,10 +156,10 @@ export const bindWorkerAsyncBindings = Effect.fn(function* (
             ? getHyperdriveDevOrigin(binding)
             : undefined,
           // Dev-only local-emulation opt-out channel (like `hyperdrives`):
-          // worker-only capabilities constructed with `dev: { remote: true }`
-          // and `SendEmail` descriptors piped through `Alchemy.remote()`
-          // carry the internal `devRemote` flag on their binding value;
-          // contribute it as binding data so the wire binding stays pure.
+          // worker-only bindings and `SendEmail` descriptors piped through
+          // `Alchemy.remote()` carry the internal `devRemote` flag on their
+          // binding value; contribute it as binding data so the wire binding
+          // stays pure.
           devRemote:
             (isWorkerOnlyBinding(binding) || isSendEmail(binding)) &&
             binding.devRemote

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerBinding.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerBinding.ts
@@ -26,6 +26,7 @@ import type { Index as VectorizeIndex } from "../Vectorize/VectorizeIndex.ts";
 import type { DispatchNamespace } from "../WorkersForPlatforms/DispatchNamespace.ts";
 import type { WorkflowLike } from "../Workflows/Workflow.ts";
 import type { AIBinding } from "./AIBinding.ts";
+import type { AnyBindingEffect } from "./Binding.ts";
 import type { Assets } from "./Assets.ts";
 import type { URLEffect } from "./Worker.ts";
 import type { BrowserBinding } from "./BrowserBinding.ts";
@@ -154,6 +155,8 @@ export type WorkerBindingResource =
   | VersionMetadataBinding
   // The Worker's own URL (`Worker.URL`).
   | URLEffect
+  // A Worker-only binding lifted by `.pipe(Alchemy.remote())`.
+  | AnyBindingEffect
   | DispatchNamespace
   | DurableObjectLike<any>
   | WorkflowLike<any>

--- a/packages/alchemy/src/ProviderMode.ts
+++ b/packages/alchemy/src/ProviderMode.ts
@@ -85,11 +85,11 @@ export class ConflictingProviderModeError extends Data.TaggedError(
  * live in dev; `remote()` on them is a no-op.
  */
 export const remote: {
+  // Identity-typed so branded effect interfaces (e.g. a Worker-only
+  // binding's `BindingEffect`) survive the pipe with their brand intact.
   (
     enabled?: boolean,
-  ): <A, E, R = never>(
-    effect: Effect.Effect<A, E, R>,
-  ) => Effect.Effect<A, E, R>;
+  ): <Eff extends Effect.Effect<any, any, any>>(effect: Eff) => Eff;
   <R1 = never>(
     enabled: Effect.Effect<boolean, never, R1>,
   ): <A, E, R2 = never>(

--- a/packages/alchemy/test/Cloudflare/Images/Images.local.test.ts
+++ b/packages/alchemy/test/Cloudflare/Images/Images.local.test.ts
@@ -1,4 +1,5 @@
 import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Alchemy from "@/index.ts";
 import * as Test from "@/Test/Alchemy";
 import { expect } from "alchemy-test";
 import * as Data from "effect/Data";
@@ -163,14 +164,14 @@ test.provider(
 );
 
 /**
- * `dev: { remote: true }` opts the binding OUT of local emulation (the
- * Worker-only-binding analogue of `Alchemy.remote()`): the locally-served
- * worker drives the real Images service through the remote-bindings preview
- * session. The live suite (test/Cloudflare/Images/Images.test.ts) covers
- * deployed-binding behavior; this leg pins the dev-mode remote lowering path.
+ * `Alchemy.remote()` opts the binding OUT of local emulation: the
+ * locally-served worker drives the real Images service through the
+ * remote-bindings preview session. The live suite
+ * (test/Cloudflare/Images/Images.test.ts) covers deployed-binding behavior;
+ * this leg pins the dev-mode remote lowering path.
  */
 test.provider(
-  "dev remote: true proxies the binding to the real Images service",
+  "Alchemy.remote() proxies the binding to the real Images service",
   (stack) =>
     Effect.gen(function* () {
       yield* stack.destroy();
@@ -180,9 +181,7 @@ test.provider(
           const worker = yield* Cloudflare.Worker("images-remote-worker", {
             main: fixtureMain,
             env: {
-              IMAGES: Cloudflare.Images.Images("IMAGES", {
-                dev: { remote: true },
-              }),
+              IMAGES: Cloudflare.Images.Images("IMAGES").pipe(Alchemy.remote()),
             },
           });
           return { url: worker.url.as<string>() };

--- a/packages/alchemy/test/Cloudflare/Images/fixtures/local-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Images/fixtures/local-worker.ts
@@ -1,7 +1,7 @@
 // Async (non-Effect) Worker that drives an Images binding the way real users
 // do — `info(...)` and `input(...).transform(...).output(...)` over the
 // request body. Used by Images.local.test.ts both against the local
-// Sharp-backed simulator and (with `dev: { remote: true }`) against the real
+// Sharp-backed simulator and (piped through `Alchemy.remote()`) against the real
 // Images service via the remote-bindings proxy.
 import type * as cf from "@cloudflare/workers-types";
 

--- a/packages/alchemy/test/Cloudflare/Stream/fixtures/local-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Stream/fixtures/local-worker.ts
@@ -1,7 +1,7 @@
 // Async (non-Effect) Worker that drives a Stream binding the way real users
 // do — upload / details / list / delete over simple routes. Used by
 // Stream.local.test.ts both against the local video-store simulator and
-// (with `dev: { remote: true }`) against the real Stream service via the
+// (piped through `Alchemy.remote()`) against the real Stream service via the
 // remote-bindings proxy.
 import type * as cf from "@cloudflare/workers-types";
 

--- a/packages/alchemy/test/Cloudflare/Workers/Browser.local.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/Browser.local.test.ts
@@ -1,4 +1,5 @@
 import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Alchemy from "@/index.ts";
 import * as Test from "@/Test/Alchemy";
 import { expect } from "alchemy-test";
 import * as Data from "effect/Data";
@@ -111,15 +112,14 @@ test.provider(
 );
 
 /**
- * `dev: { remote: true }` opts the binding OUT of local emulation (the
- * Worker-only-binding analogue of `Alchemy.remote()`): the locally-served
- * worker drives the real Browser Rendering service through the
- * remote-bindings preview session. The live suite
+ * `Alchemy.remote()` opts the binding OUT of local emulation: the
+ * locally-served worker drives the real Browser Rendering service through
+ * the remote-bindings preview session. The live suite
  * (test/Cloudflare/Browser/Browser.test.ts) covers deployed-binding
  * behavior; this leg pins the dev-mode remote lowering path.
  */
 test.provider(
-  "dev remote: true proxies the binding to the real Browser Rendering service",
+  "Alchemy.remote() proxies the binding to the real Browser Rendering service",
   (stack) =>
     Effect.gen(function* () {
       yield* stack.destroy();
@@ -130,9 +130,7 @@ test.provider(
             main: fixtureMain,
             compatibility: { flags: ["nodejs_compat"] },
             env: {
-              BROWSER: Cloudflare.Browser("BROWSER", {
-                dev: { remote: true },
-              }),
+              BROWSER: Cloudflare.Browser("BROWSER").pipe(Alchemy.remote()),
             },
           });
           return { url: worker.url.as<string>() };

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/browser-local-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/browser-local-worker.ts
@@ -1,7 +1,7 @@
 // Async (non-Effect) Worker that drives a Browser Rendering binding the way
 // real users do — through `@cloudflare/puppeteer` (acquire a session, open a
 // page, inspect it). Used by Browser.local.test.ts both against the local
-// Chrome-backed simulator and (with `dev: { remote: true }`) against the real
+// Chrome-backed simulator and (piped through `Alchemy.remote()`) against the real
 // Browser Rendering service via the remote-bindings proxy.
 import puppeteer from "@cloudflare/puppeteer";
 

--- a/website/src/content/docs/environments/local-development.mdx
+++ b/website/src/content/docs/environments/local-development.mdx
@@ -80,12 +80,21 @@ Every other resource runs live in dev automatically, and
 `Alchemy.remote()` (below) runs an emulatable resource against the
 real cloud when local fidelity isn't enough.
 
-Bindings whose only job is a side effect are simulated: a
-[`send_email` binding](/cloudflare/email/send-and-receive) defaults
-to a local simulator in dev, so `send()` persists the message as a
-`.eml` file under `.alchemy/local/email` instead of delivering mail.
-Pipe the binding through `Alchemy.remote()` (below) to send real
-mail from the dev loop.
+Worker-only bindings are simulated too: a
+[`send_email` binding](/cloudflare/email/send-and-receive) persists
+messages as `.eml` files under `.alchemy/local/email` instead of
+delivering mail, Browser Rendering drives a locally-launched headless
+Chrome, Images transforms run through Sharp, and Stream uploads land
+in a local video store. Each of these opts out the same way as a
+resource — pipe the binding through `Alchemy.remote()` (below) to hit
+the real service from the dev loop:
+
+```typescript
+env: {
+  EMAIL: email, // Alchemy.remote() on the SendEmail descriptor
+  BROWSER: Cloudflare.Browser("BROWSER").pipe(Alchemy.remote()),
+}
+```
 
 ## Debugging
 


### PR DESCRIPTION
Follow-up to #1064: audit of every remaining `dev`-shaped prop for mode selection duplicating `Alchemy.remote()`.

**Audit result.** Browser, Images, and Stream (from #1039) were the only offenders — `dev: { remote: true }` on their constructors selected local-vs-live in dev. Every other `dev` prop is genuine local-dev *configuration* and stays: `Worker.dev` (host/port/cache/cf/external), Hyperdrive `Connection.dev: DevOrigin` (where your local database lives), `StaticSite.dev` (dev command), `Container.dev` (dev image), Prisma `Compute.dev`/`Database.dev` (local server config). AWS has none.

**The fix.** Worker-only `Binding` values are plain data with no Effect to pipe the aspect onto, so `Binding` gains `pipe()`: it lifts the binding into a branded `BindingEffect` that captures the ambient `ProviderModePolicy` and resolves context-adaptively — the runtime client inside an Effect-native Worker (where the binding's layer is provided), the decorated binding value anywhere else (an async Worker's `env`, resolved by the engine):

```ts
// Effect-native Worker — one yield, same as the bare binding:
const browser = yield* Cloudflare.Browser("BROWSER").pipe(Alchemy.remote());

// async Worker env:
env: { IMAGES: Cloudflare.Images.Images("IMAGES").pipe(Alchemy.remote()) }
```

- `InferEnv` maps the branded effect through its `"~alchemy/Binding"` type to the native runtime type, so `env` typing is unchanged.
- `remote()`'s boolean overload is now identity-typed (`<Eff extends Effect<any, any, any>>(e: Eff) => Eff`) so the brand survives the pipe.
- The `devRemote` binding-data channel and local lowering are untouched — only the flag's *source* moved from the prop to the aspect.
- The `dev` props and their `parse` plumbing are deleted from all three constructors; JSDoc, local tests, fixtures, the `cloudflare-dev` example, and the local-development guide now show the `remote()` form.

Verified: `bun tsc -b` clean; Browser/Images/Stream/Email `.local.test.ts` suites green, including the `Alchemy.remote()` legs against the real services.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
