### PR TITLE
feat(cloudflare): credential-free alchemy dev

### DIFF
--- a/examples/cloudflare-dev/alchemy.run.ts
+++ b/examples/cloudflare-dev/alchemy.run.ts
@@ -42,8 +42,25 @@ const TailWorker = Effect.gen(function* () {
   });
 });
 
+/**
+ * Streaming tail consumer: listed in AsyncWorker's `streamingTailConsumers`,
+ * its `tailStream()` receives each invocation's events live (onset → log →
+ * outcome) and records completed sessions into KV, exposed over
+ * `GET /events`.
+ */
+const StreamTailWorker = Effect.gen(function* () {
+  const events = yield* Cloudflare.KV.Namespace("StreamTailEvents");
+  return yield* Cloudflare.Worker("StreamTailWorker", {
+    main: "./src/StreamTailWorker.ts",
+    env: {
+      EVENTS: events,
+    },
+  });
+});
+
 const AsyncWorker = (deps: {
   tailWorker: Cloudflare.Worker;
+  streamTailWorker: Cloudflare.Worker;
   liveKv: Cloudflare.KV.Namespace;
 }) =>
   Effect.gen(function* () {
@@ -63,6 +80,9 @@ const AsyncWorker = (deps: {
       // Every invocation of this worker delivers a trace batch (console
       // logs, outcome) to the tail worker.
       tailConsumers: [deps.tailWorker],
+      // ... and streams the same invocation's events live (onset → log →
+      // outcome) to the streaming tail worker's `tailStream()` handler.
+      streamingTailConsumers: [deps.streamTailWorker],
       env: {
         COUNTER: Cloudflare.DurableObject<Counter>("Counter", {
           className: "Counter",
@@ -158,10 +178,15 @@ export default Alchemy.Stack(
   },
   Effect.gen(function* () {
     const tailWorker = yield* TailWorker;
+    const streamTailWorker = yield* StreamTailWorker;
     const liveKv = yield* Cloudflare.KV.Namespace("LiveKV").pipe(
       Alchemy.remote(),
     );
-    const asyncWorker = yield* AsyncWorker({ tailWorker, liveKv });
+    const asyncWorker = yield* AsyncWorker({
+      tailWorker,
+      streamTailWorker,
+      liveKv,
+    });
     const effectWorker = yield* EffectWorker;
     const media = yield* MediaWorker;
     const inboxWorker = yield* InboxWorker;
@@ -174,6 +199,7 @@ export default Alchemy.Stack(
       effectWorker: effectWorker.url,
       mediaWorker: media.worker.url,
       tailWorker: tailWorker.url,
+      streamTailWorker: streamTailWorker.url,
       inboxWorker: inboxWorker.url,
       // `dev:`-prefixed ids mean "locally emulated"; LiveKV must NOT carry
       // one (it's a real cloud namespace, even during dev).

--- a/examples/cloudflare-dev/src/StreamTailWorker.ts
+++ b/examples/cloudflare-dev/src/StreamTailWorker.ts
@@ -1,0 +1,69 @@
+/**
+ * Streaming tail consumer for {@link AsyncWorker}. Listed in the producer's
+ * `streamingTailConsumers`, so every invocation of the producer opens a
+ * streaming session against `tailStream()`: the handler is invoked with the
+ * invocation's `onset` event while the producer is still executing, and the
+ * returned function receives every subsequent event (`log`, ...) ending with
+ * the terminal `outcome`. Completed sessions are recorded into a KV
+ * namespace and exposed over `GET /events` so the integ test can assert the
+ * producer's `console.log` marker streamed end-to-end.
+ *
+ * NOTE: the default export must be this module's ONLY export — extra named
+ * exports become workerd top-level exports and fail startup validation.
+ */
+interface TailEventsKV {
+  put(key: string, value: string): Promise<void>;
+  get(key: string): Promise<string | null>;
+  list(options?: { prefix?: string }): Promise<{ keys: { name: string }[] }>;
+}
+
+interface StreamTailEvent {
+  invocationId?: string;
+  timestamp?: string;
+  sequence?: number;
+  event?: {
+    type?: string;
+    outcome?: string;
+    level?: string;
+    message?: unknown;
+    info?: { type?: string; url?: string; method?: string };
+  };
+}
+
+export default {
+  async fetch(
+    request: Request,
+    env: { EVENTS: TailEventsKV },
+  ): Promise<Response> {
+    const url = new URL(request.url);
+    if (url.pathname === "/events") {
+      const list = await env.EVENTS.list({ prefix: "evt:" });
+      const sessions = await Promise.all(
+        list.keys.map((key) => env.EVENTS.get(key.name)),
+      );
+      return Response.json({
+        keys: list.keys.map((key) => key.name),
+        sessions: sessions.filter(
+          (session): session is string => session !== null,
+        ),
+      });
+    }
+    return new Response("stream-tail-consumer-ok");
+  },
+  tailStream(
+    onset: StreamTailEvent,
+    env: { EVENTS: TailEventsKV },
+  ): (tailEvent: StreamTailEvent) => Promise<void> {
+    const events: StreamTailEvent[] = [onset];
+    return async (tailEvent: StreamTailEvent): Promise<void> => {
+      events.push(tailEvent);
+      if (tailEvent.event?.type === "outcome") {
+        const id = onset.invocationId ?? `${Date.now()}`;
+        await env.EVENTS.put(
+          `evt:${id}:${Date.now()}`,
+          JSON.stringify(events),
+        );
+      }
+    };
+  },
+};

--- a/examples/cloudflare-dev/test/credential-free.test.ts
+++ b/examples/cloudflare-dev/test/credential-free.test.ts
@@ -1,0 +1,174 @@
+/**
+ * The headline proof for local-first dev: `alchemy dev` boots an all-local
+ * stack (test/fixtures/local-only.run.ts) in a SCRUBBED environment —
+ * temp HOME (no ~/.alchemy/profiles.json), no CLOUDFLARE_* / ALCHEMY_* env
+ * vars, CI unset — a worker serves, a KV binding roundtrips, and no auth
+ * error ever surfaces. `Cloudflare.state()` resolves to the local file
+ * store in dev, so state demands no credentials either.
+ */
+import { afterAll, expect, test } from "bun:test";
+import { spawn } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const root = path.resolve(import.meta.dirname, "..");
+const alchemyBin = path.join(
+  root,
+  "node_modules",
+  "alchemy",
+  "bin",
+  "alchemy.ts",
+);
+const STAGE = "credential-free-test";
+const STACK = "CloudflareDevLocalOnly";
+
+let proc: ReturnType<typeof spawn> | undefined;
+let tmpHome: string | undefined;
+let output = "";
+
+const pump = (stream: NodeJS.ReadableStream) => {
+  stream.on("data", (chunk: Buffer) => {
+    const text = chunk.toString();
+    output += text;
+    if (process.env.DEBUG) process.stderr.write(text);
+  });
+};
+
+/** Bounded poll for a (possibly async) producer to yield a value. */
+const pollUntil = async <T>(
+  what: string,
+  f: () => T | undefined | Promise<T | undefined>,
+  { tries = 30, delayMs = 1000 }: { tries?: number; delayMs?: number } = {},
+): Promise<T> => {
+  for (let i = 0; i < tries; i++) {
+    const value = await f();
+    if (value !== undefined) return value;
+    await Bun.sleep(delayMs);
+  }
+  throw new Error(
+    `Timed out waiting for ${what}.\n--- alchemy dev output (tail) ---\n${output.slice(-4000)}`,
+  );
+};
+
+/** Fetch with retries — a fresh workerd takes a moment to start serving. */
+const fetchOk = async (
+  url: string | URL,
+  { tries = 20, delayMs = 500 }: { tries?: number; delayMs?: number } = {},
+) => {
+  let last: Response | undefined;
+  for (let i = 0; i < tries; i++) {
+    try {
+      last = await fetch(url);
+      if (last.ok) return last;
+    } catch {
+      // dev proxy not listening yet
+    }
+    await Bun.sleep(delayMs);
+  }
+  throw new Error(
+    `GET ${url} never returned 2xx (last status: ${last?.status})\n--- alchemy dev output (tail) ---\n${output.slice(-4000)}`,
+  );
+};
+
+const outputUrl = (key: string) =>
+  output.match(new RegExp(`${key}:\\s*['"]?(http[^\\s'",]+)`))?.[1];
+
+/**
+ * A copy of process.env with every credential/profile source removed:
+ * - HOME/XDG point at a throwaway dir, so ~/.alchemy/profiles.json and any
+ *   cached state-store credentials are invisible.
+ * - CLOUDFLARE_* (api token/key/account) and ALCHEMY_* (profile/password)
+ *   are dropped.
+ * - CI is unset so nothing takes CI shortcuts.
+ */
+const scrubbedEnv = (home: string): Record<string, string> => {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value === undefined) continue;
+    if (key.startsWith("CLOUDFLARE_")) continue;
+    if (key.startsWith("ALCHEMY_")) continue;
+    if (key.startsWith("WRANGLER_")) continue;
+    if (key === "CI" || key === "HOME" || key.startsWith("XDG_")) continue;
+    env[key] = value;
+  }
+  env.HOME = home;
+  env.XDG_CONFIG_HOME = path.join(home, ".config");
+  return env;
+};
+
+afterAll(async () => {
+  if (proc?.pid) {
+    const killGroup = (signal: NodeJS.Signals) => {
+      try {
+        process.kill(-proc!.pid!, signal);
+      } catch {
+        // group already gone
+      }
+    };
+    const exited = new Promise((resolve) => proc!.once("exit", resolve));
+    killGroup("SIGINT");
+    await Promise.race([exited, Bun.sleep(15_000)]);
+    if (proc.exitCode === null && proc.signalCode === null) {
+      killGroup("SIGKILL");
+      await Promise.race([exited, Bun.sleep(5_000)]);
+    }
+  }
+  // Dev state is machine-local (that's the point) — drop the fixture
+  // stack's rows so reruns start clean. No cloud destroy: nothing was
+  // created in the cloud.
+  fs.rmSync(path.join(root, ".alchemy", "state", STACK), {
+    recursive: true,
+    force: true,
+  });
+  if (tmpHome) fs.rmSync(tmpHome, { recursive: true, force: true });
+}, 60_000);
+
+// TODO(credential-free-dev): un-gate at the wave boundary. The state half is
+test(
+  "alchemy dev boots an all-local stack with zero Cloudflare credentials",
+  async () => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "alchemy-credfree-"));
+    proc = spawn(
+      "bun",
+      [alchemyBin, "dev", "test/fixtures/local-only.run.ts", "--stage", STAGE],
+      {
+        cwd: root,
+        detached: true,
+        stdio: ["ignore", "pipe", "pipe"],
+        env: scrubbedEnv(tmpHome),
+      },
+    );
+    pump(proc.stdout!);
+    pump(proc.stderr!);
+
+    const workerUrl = await pollUntil(
+      "localOnlyWorker url in stack outputs",
+      () => outputUrl("localOnlyWorker"),
+      { tries: 180, delayMs: 1000 },
+    );
+    expect(workerUrl).toContain("http://localhost");
+
+    // The KV namespace must be a `dev:` row — proof no cloud call ran.
+    const kvId = await pollUntil(
+      "kvNamespaceId in stack outputs",
+      () => output.match(/kvNamespaceId:\s*['"]?(dev:[^\s'",]+)/)?.[1],
+      { tries: 30, delayMs: 500 },
+    );
+    expect(kvId).toStartWith("dev:");
+
+    // The worker serves and the local KV binding roundtrips.
+    const body = (await (await fetchOk(workerUrl)).json()) as {
+      marker: string;
+      value: string | null;
+    };
+    expect(body.marker).toBe("credential-free-ok");
+    expect(body.value).toBe("hello from credential-free dev");
+
+    // No credential demand ever surfaced.
+    expect(output).not.toMatch(
+      /AuthError|not authenticated|api token|configure a profile|oauth/i,
+    );
+  },
+  { timeout: 300_000 },
+);

--- a/examples/cloudflare-dev/test/dev.test.ts
+++ b/examples/cloudflare-dev/test/dev.test.ts
@@ -11,7 +11,8 @@
  * under the harness) is the class of bug this suite exists to catch.
  *
  * Coverage per binding, all against the local simulators (no cloud
- * resources beyond the state store):
+ * resources at all — `Cloudflare.state()` resolves to the local file store
+ * during dev, so even state stays on this machine):
  *   - assets            → `/` serves the static index
  *   - vars + secrets    → `/env` echoes MY_VARIABLE / MY_SECRET
  *   - self_url          → `/env`.PUBLIC_URL and EffectWorker `/url`

--- a/examples/cloudflare-dev/test/fixtures/local-only-worker.ts
+++ b/examples/cloudflare-dev/test/fixtures/local-only-worker.ts
@@ -1,0 +1,21 @@
+/**
+ * Minimal worker for the credential-free `alchemy dev` proof
+ * (test/credential-free.test.ts): one KV roundtrip so a local resource
+ * binding is exercised, one marker response so the test can assert the
+ * worker actually served.
+ *
+ * NOTE: the default export must be this module's ONLY export — extra named
+ * exports become workerd top-level exports and fail startup validation.
+ */
+interface KVLite {
+  put(key: string, value: string): Promise<void>;
+  get(key: string): Promise<string | null>;
+}
+
+export default {
+  async fetch(_request: Request, env: { KV: KVLite }): Promise<Response> {
+    await env.KV.put("greeting", "hello from credential-free dev");
+    const value = await env.KV.get("greeting");
+    return Response.json({ marker: "credential-free-ok", value });
+  },
+};

--- a/examples/cloudflare-dev/test/fixtures/local-only.run.ts
+++ b/examples/cloudflare-dev/test/fixtures/local-only.run.ts
@@ -1,0 +1,35 @@
+/**
+ * All-local stack for the credential-free `alchemy dev` proof
+ * (test/credential-free.test.ts).
+ *
+ * Unlike ../../alchemy.run.ts, this stack has NO `Alchemy.remote()` /
+ * `dev: { remote: true }` resources — those legitimately demand Cloudflare
+ * credentials even during dev. Everything here is locally emulated, and
+ * `Cloudflare.state()` resolves to the local file store in dev, so the whole
+ * flow must boot with zero Cloudflare credentials.
+ */
+import * as Alchemy from "alchemy";
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+
+export default Alchemy.Stack(
+  "CloudflareDevLocalOnly",
+  {
+    providers: Cloudflare.providers(),
+    state: Cloudflare.state(),
+  },
+  Effect.gen(function* () {
+    const kv = yield* Cloudflare.KV.Namespace("LocalKV");
+    const worker = yield* Cloudflare.Worker("LocalOnlyWorker", {
+      main: "./test/fixtures/local-only-worker.ts",
+      env: {
+        KV: kv,
+      },
+    });
+    return {
+      localOnlyWorker: worker.url,
+      // `dev:` marker id — proof no cloud call created the namespace.
+      kvNamespaceId: kv.namespaceId,
+    };
+  }),
+);

--- a/examples/cloudflare-dev/test/integ.test.ts
+++ b/examples/cloudflare-dev/test/integ.test.ts
@@ -31,6 +31,7 @@ const stack = beforeAll(
           effectWorker,
           mediaWorker,
           tailWorker,
+          streamTailWorker,
           inboxWorker,
           liveKvNamespaceId,
           secretsStoreId,
@@ -40,13 +41,21 @@ const stack = beforeAll(
         assert(typeof effectWorker === "string");
         assert(typeof mediaWorker === "string");
         assert(typeof tailWorker === "string");
+        assert(typeof streamTailWorker === "string");
         assert(typeof inboxWorker === "string");
         assert(typeof liveKvNamespaceId === "string");
         assert(typeof secretsStoreId === "string");
         assert(typeof secretsSecretId === "string");
         const hyperdrive = (outputs as { hyperdrive?: string }).hyperdrive;
         yield* Effect.forEach(
-          [asyncWorker, effectWorker, mediaWorker, tailWorker, inboxWorker],
+          [
+            asyncWorker,
+            effectWorker,
+            mediaWorker,
+            tailWorker,
+            streamTailWorker,
+            inboxWorker,
+          ],
           (url) =>
             HttpClient.get(url).pipe(
               Effect.flatMap(HttpClientResponse.filterStatusOk),
@@ -63,6 +72,7 @@ const stack = beforeAll(
           effectWorker,
           mediaWorker,
           tailWorker,
+          streamTailWorker,
           inboxWorker,
           liveKvNamespaceId,
           secretsStoreId,
@@ -155,8 +165,14 @@ const findEmlContaining = (needle: string) =>
 test(
   "deploys all workers with URLs",
   Effect.gen(function* () {
-    const { asyncWorker, effectWorker, mediaWorker, tailWorker, inboxWorker } =
-      yield* stack;
+    const {
+      asyncWorker,
+      effectWorker,
+      mediaWorker,
+      tailWorker,
+      streamTailWorker,
+      inboxWorker,
+    } = yield* stack;
 
     // Local dev proxy URLs — proof no cloud deploy ran for the workers.
     for (const url of [
@@ -164,6 +180,7 @@ test(
       effectWorker,
       mediaWorker,
       tailWorker,
+      streamTailWorker,
       inboxWorker,
     ]) {
       expect(url).toBeString();
@@ -548,6 +565,65 @@ test(
         ),
       ),
     ).toBe(true);
+  }),
+  { timeout: 60_000 },
+);
+
+/**
+ * streamingTailConsumers: AsyncWorker lists StreamTailWorker as a streaming
+ * tail consumer, so every invocation opens a streaming session against its
+ * `tailStream()` handler — onset delivered while the producer is still
+ * executing, then each event live, ending with the terminal `outcome` — and
+ * the completed session is recorded into KV. Each poll re-invokes the
+ * producer so an early dropped session (registry still warming) doesn't
+ * strand the test.
+ */
+test(
+  "StreamTailWorker streams AsyncWorker's invocation events",
+  Effect.gen(function* () {
+    const { asyncWorker, streamTailWorker } = yield* stack;
+
+    const sessions = yield* Effect.gen(function* () {
+      yield* HttpClient.get(new URL("/tail-ping", asyncWorker)).pipe(
+        Effect.flatMap((res) => res.text),
+        Effect.orDie,
+      );
+      const res = yield* HttpClient.get(new URL("/events", streamTailWorker));
+      if (res.status !== 200) return [] as string[];
+      const body = (yield* res.json) as { sessions?: unknown };
+      return Array.isArray(body.sessions) ? (body.sessions as string[]) : [];
+    }).pipe(
+      Effect.repeat({
+        schedule: Schedule.spaced("1 second"),
+        until: (sessions): boolean =>
+          sessions.some((session) =>
+            session.includes("cloudflare-dev-tail-marker"),
+          ),
+        times: 20,
+      }),
+    );
+
+    const session = sessions.find((s) =>
+      s.includes("cloudflare-dev-tail-marker"),
+    );
+    expect(session).toBeDefined();
+    const events = JSON.parse(session!) as {
+      event?: { type?: string; outcome?: string; message?: unknown };
+    }[];
+    const types = events.map((tailEvent) => tailEvent.event?.type);
+    expect(types).toContain("onset");
+    expect(types).toContain("outcome");
+    const log = events.find(
+      (tailEvent) =>
+        tailEvent.event?.type === "log" &&
+        Array.isArray(tailEvent.event?.message) &&
+        tailEvent.event.message.includes("cloudflare-dev-tail-marker"),
+    );
+    expect(log).toBeDefined();
+    const outcome = events.find(
+      (tailEvent) => tailEvent.event?.type === "outcome",
+    );
+    expect(outcome?.event?.outcome).toBe("ok");
   }),
   { timeout: 60_000 },
 );

--- a/packages/alchemy/src/Auth/AuthProvider.ts
+++ b/packages/alchemy/src/Auth/AuthProvider.ts
@@ -66,6 +66,15 @@ export interface ConfigureContext {
    * `{ method: "env" }`) so unattended runs work.
    */
   readonly ci: boolean;
+
+  /**
+   * Optional human-readable explanation of WHY credentials are being
+   * demanded right now — e.g. which resources in a dev plan require the
+   * real cloud (see `Auth/Demand.ts`). Interactive `configure`
+   * implementations should display it before their first prompt so the
+   * user knows what triggered the flow.
+   */
+  readonly reason?: string;
 }
 
 export interface AuthProviderImpl<

--- a/packages/alchemy/src/Auth/Demand.ts
+++ b/packages/alchemy/src/Auth/Demand.ts
@@ -1,0 +1,260 @@
+/**
+ * The credential-demand seam for credential-free `alchemy dev`.
+ *
+ * A dev run whose plan is entirely local must never touch (or prompt for)
+ * cloud credentials. When the plan DOES need the cloud — a resource opted
+ * out of local emulation via `Alchemy.remote()`, a local Worker binding
+ * that proxies to a remote resource (`dev: { remote: true }`), or the
+ * deletion of a row that was last reconciled live — credentials are
+ * demanded exactly once, up front, in the exec process (which owns the
+ * tty), BEFORE apply begins:
+ *
+ *   - interactive: the provider's existing `configure` flow runs, prefixed
+ *     with a human-readable reason naming the demanding resources
+ *     (threaded via {@link ConfigureContext}'s `reason`).
+ *   - non-interactive: fail with the typed {@link CredentialsRequired}
+ *     error naming the demanding resources and pointing at `alchemy login`.
+ *
+ * The RPC sidecar never prompts — its stdio is piped and it only ever
+ * reads credentials persisted by this seam (or a prior `alchemy login`).
+ *
+ * Non-dev runs (`alchemy deploy` / `destroy`) never enter this seam:
+ * state-store init and live providers drive the pre-existing lazy
+ * credential-resolution flow unchanged.
+ */
+import * as Config from "effect/Config";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import type { BindingNode, Plan } from "../Plan.ts";
+import { isNonInteractive } from "../Util/interactive.ts";
+import { AuthProviders, type ConfigureContext } from "./AuthProvider.ts";
+import { ALCHEMY_PROFILE, AlchemyProfile } from "./Profile.ts";
+
+/** Why a plan row demands live (cloud) credentials during a dev run. */
+export type CredentialDemandReason =
+  /** The resource's resolved provider mode is `"live"` (`Alchemy.remote()`). */
+  | "remote"
+  /** Binding data carries a truthy `devRemote` entry — the local runtime proxies this binding to the real cloud. */
+  | "remote-binding"
+  /** The plan deletes a row stamped `providerMode: "live"` — the live provider must run to delete it. */
+  | "live-delete";
+
+export interface DemandingResource {
+  /** FQN of the demanding resource within the stack. */
+  readonly fqn: string;
+  readonly reason: CredentialDemandReason;
+}
+
+/**
+ * All the resources of one cloud provider that demand live credentials.
+ * `provider` is the auth-provider name, derived from the resource Type's
+ * leading namespace segment (`"Cloudflare.KV.Namespace"` → `"Cloudflare"`,
+ * matching the name Cloudflare's auth provider registers under).
+ */
+export interface CredentialDemand {
+  readonly provider: string;
+  readonly resources: readonly DemandingResource[];
+}
+
+/**
+ * A dev-mode plan needs cloud credentials, none are configured for the
+ * active profile, and the process is non-interactive so the configure flow
+ * cannot run. The message names the demanding resources and the fix.
+ */
+export class CredentialsRequired extends Data.TaggedError(
+  "CredentialsRequired",
+)<{
+  message: string;
+  /** Auth-provider name whose credentials are missing (e.g. `"Cloudflare"`). */
+  provider: string;
+  /** FQNs of the resources demanding the credentials. */
+  resources: string[];
+  /** Short summary of why the credentials are needed. */
+  reason: string;
+}> {}
+
+const describeReason = (reason: CredentialDemandReason): string => {
+  switch (reason) {
+    case "remote":
+      return "runs against the real cloud via Alchemy.remote()";
+    case "remote-binding":
+      return "has a binding that proxies to a remote resource (dev: { remote: true })";
+    case "live-delete":
+      return "deletes an instance that was deployed to the real cloud";
+  }
+};
+
+/** `"Cloudflare.KV.Namespace"` → `"Cloudflare"` (the auth-provider name). */
+const cloudOf = (type: string): string => type.split(".")[0] ?? type;
+
+const resourceLines = (demand: CredentialDemand): string =>
+  demand.resources
+    .map((r) => `  - ${r.fqn} (${describeReason(r.reason)})`)
+    .join("\n");
+
+/**
+ * Build the typed {@link CredentialsRequired} failure for a demand.
+ * Exported so tests can pin the message format.
+ */
+export const credentialsRequired = (
+  demand: CredentialDemand,
+  profileName: string,
+): CredentialsRequired =>
+  new CredentialsRequired({
+    provider: demand.provider,
+    resources: demand.resources.map((r) => r.fqn),
+    reason: [...new Set(demand.resources.map((r) => r.reason))].join(", "),
+    message:
+      `${demand.provider} credentials are required, but none are configured ` +
+      `for profile '${profileName}' and this process is non-interactive so ` +
+      "they can't be configured now.\n" +
+      `These resources require ${demand.provider} credentials:\n` +
+      `${resourceLines(demand)}\n` +
+      `Run \`alchemy login --profile ${profileName}\` to configure ` +
+      "credentials, or set CI=1 to use environment-variable credentials.",
+  });
+
+/**
+ * The human-readable reason shown at the top of an interactive configure
+ * flow triggered by this seam (threaded via {@link ConfigureContext}).
+ */
+const demandBanner = (demand: CredentialDemand): string =>
+  `This dev session requires ${demand.provider} credentials:\n` +
+  resourceLines(demand);
+
+const bindingDemandsRemote = (
+  bindings: readonly BindingNode[] | undefined,
+): boolean =>
+  (bindings ?? []).some((binding) => {
+    // A binding being REMOVED needs no runtime proxy — the restarted
+    // local instance simply no longer carries it.
+    if (binding.action === "delete") return false;
+    const data = binding.data as
+      | { devRemote?: Record<string, boolean> }
+      | null
+      | undefined;
+    return (
+      data != null &&
+      typeof data === "object" &&
+      data.devRemote != null &&
+      typeof data.devRemote === "object" &&
+      Object.values(data.devRemote).some((remote) => remote === true)
+    );
+  });
+
+/**
+ * Scan a plan for rows that need live (cloud) credentials during a dev
+ * run, grouped by cloud provider:
+ *
+ *   1. resources whose resolved provider mode is `"live"` (`Alchemy.remote()`)
+ *   2. resources whose binding data carries a truthy `devRemote` entry
+ *      (the local runtime proxies that binding to the real cloud)
+ *   3. planned deletions of rows stamped `providerMode: "live"`
+ *
+ * Pure and side-effect-free — callers gate on the run being a dev run
+ * (in a live run every dual-provider row resolves `"live"` and the
+ * pre-existing lazy credential flow applies instead).
+ *
+ * Mode-agnostic rows (`mode === undefined`, single-implementation
+ * providers that run live even in dev) are deliberately NOT collected:
+ * they resolve credentials lazily exactly as they do today.
+ */
+export const collectCredentialDemands = (plan: Plan): CredentialDemand[] => {
+  const byProvider = new Map<string, Map<string, CredentialDemandReason>>();
+  const add = (
+    type: string,
+    fqn: string,
+    reason: CredentialDemandReason,
+  ): void => {
+    const provider = cloudOf(type);
+    const resources =
+      byProvider.get(provider) ?? new Map<string, CredentialDemandReason>();
+    if (!resources.has(fqn)) resources.set(fqn, reason);
+    byProvider.set(provider, resources);
+  };
+  for (const [fqn, node] of Object.entries(plan.resources)) {
+    if (node.mode === "live") {
+      add(node.resource.Type, fqn, "remote");
+    } else if (bindingDemandsRemote(node.bindings)) {
+      add(node.resource.Type, fqn, "remote-binding");
+    }
+  }
+  for (const [fqn, node] of Object.entries(plan.deletions)) {
+    if (node !== undefined && node.mode === "live") {
+      add(node.resource.Type, fqn, "live-delete");
+    }
+  }
+  return [...byProvider.entries()].map(([provider, resources]) => ({
+    provider,
+    resources: [...resources.entries()].map(([fqn, reason]) => ({
+      fqn,
+      reason,
+    })),
+  }));
+};
+
+export interface DemandCredentialsOptions {
+  /**
+   * Overrides {@link isNonInteractive} — a test seam. When `true`, a
+   * missing profile fails with {@link CredentialsRequired} instead of
+   * driving the interactive configure flow.
+   */
+  readonly nonInteractive?: boolean;
+}
+
+/**
+ * Ensure credentials exist for every demand, prompting at most once per
+ * provider and only when nothing is configured yet:
+ *
+ *   - already configured for the active profile → no-op (never re-prompts)
+ *   - missing + interactive → the provider's `configure` flow runs (via
+ *     `AlchemyProfile.loadOrConfigure`), prefixed with a reason naming the
+ *     demanding resources
+ *   - missing + non-interactive (and not CI) → typed
+ *     {@link CredentialsRequired} failure
+ *   - CI → `loadOrConfigure` picks the provider's non-interactive default
+ *     (env-var credentials), matching every other CI path
+ *
+ * Demands whose cloud has no registered auth provider are skipped (bare
+ * engine runs with test providers demand nothing). All context is
+ * resolved optionally, so the effect is safe to run in any environment.
+ */
+export const demandCredentials = Effect.fn("Alchemy.demandCredentials")(
+  function* (
+    demands: readonly CredentialDemand[],
+    options?: DemandCredentialsOptions,
+  ) {
+    if (demands.length === 0) return;
+    const registry = Option.getOrUndefined(
+      yield* Effect.serviceOption(AuthProviders),
+    );
+    const profile = Option.getOrUndefined(
+      yield* Effect.serviceOption(AlchemyProfile),
+    );
+    if (registry === undefined || profile === undefined) return;
+    const profileName = yield* ALCHEMY_PROFILE;
+    const ci = yield* Config.boolean("CI").pipe(Config.withDefault(false));
+    const nonInteractive = options?.nonInteractive ?? isNonInteractive();
+    for (const demand of demands) {
+      const auth = registry[demand.provider];
+      if (auth == null) continue;
+      const existing = yield* profile.getProfile(profileName);
+      if (existing?.[auth.name] != null) continue;
+      if (!ci && nonInteractive) {
+        return yield* credentialsRequired(demand, profileName);
+      }
+      const ctx: ConfigureContext = { ci, reason: demandBanner(demand) };
+      yield* profile.loadOrConfigure(auth, profileName, ctx);
+    }
+  },
+);
+
+/**
+ * The one-call seam wired into the dev path: scan the plan for live
+ * demand and, if any, run {@link demandCredentials} BEFORE apply begins.
+ */
+export const demandPlanCredentials = (
+  plan: Plan,
+  options?: DemandCredentialsOptions,
+) => demandCredentials(collectCredentialDemands(plan), options);

--- a/packages/alchemy/src/Auth/index.ts
+++ b/packages/alchemy/src/Auth/index.ts
@@ -1,4 +1,5 @@
 export * from "./AuthProvider.ts";
 export * from "./Credentials.ts";
+export * from "./Demand.ts";
 export * from "./Env.ts";
 export * from "./Profile.ts";

--- a/packages/alchemy/src/Cli/commands/deploy.ts
+++ b/packages/alchemy/src/Cli/commands/deploy.ts
@@ -14,6 +14,7 @@ import { AlchemyContext } from "../../AlchemyContext.ts";
 import { apply } from "../../Apply.ts";
 import { ArtifactStore, createArtifactStore } from "../../Artifacts.ts";
 import { AuthProviders } from "../../Auth/AuthProvider.ts";
+import { demandPlanCredentials } from "../../Auth/Demand.ts";
 import { withProfileOverride } from "../../Auth/Profile.ts";
 import * as CLI from "../../Cli/Cli.ts";
 import * as Plan from "../../Plan.ts";
@@ -127,6 +128,15 @@ export const execStack = Effect.fn(function* ({
       if (dryRun) {
         yield* cli.displayPlan(updatePlan);
       } else {
+        // Credential-free dev: a dev plan that is entirely local must never
+        // touch cloud credentials. When the plan DOES need the cloud
+        // (remote() rows, devRemote bindings, live-stamped deletes), demand
+        // credentials exactly once, here in the exec process (which owns
+        // the tty), BEFORE apply begins — the RPC sidecar never prompts.
+        // Non-dev runs keep the pre-existing lazy credential flow.
+        if (dev) {
+          yield* demandPlanCredentials(updatePlan);
+        }
         const hasChanges =
           Object.keys(updatePlan.deletions).length > 0 ||
           Object.values(updatePlan.resources).some(

--- a/packages/alchemy/src/Cloudflare/AI/ProviderKey.ts
+++ b/packages/alchemy/src/Cloudflare/AI/ProviderKey.ts
@@ -24,7 +24,12 @@ export interface ProviderKeyProps {
    */
   store: {
     storeId: string;
-    accountId: string;
+    /**
+     * Undefined when the store is a local (dev) row created without
+     * configured credentials — the provider falls back to the current
+     * environment's account.
+     */
+    accountId: string | undefined;
   };
   /**
    * The provider API key. Stored in Cloudflare Secrets Store and never bound

--- a/packages/alchemy/src/Cloudflare/Auth/AuthProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Auth/AuthProvider.ts
@@ -340,26 +340,30 @@ export const CloudflareAuth = AuthProviderLayer<
       };
     });
 
-    const configureInteractive = (profileName: string) =>
-      Clank.select({
-        message: "Cloudflare authentication method",
-        options,
-      }).pipe(
-        Effect.flatMap((method) =>
-          Match.value(method).pipe(
-            Match.when("env", () => Effect.succeed({ method: "env" as const })),
-            Match.when("oauth", () => configureOAuth(profileName)),
-            Match.when("stored", () => loginStored(profileName)),
-            Match.exhaustive,
-          ),
-        ),
-      );
+    const configureInteractive = (profileName: string, ctx: ConfigureContext) =>
+      Effect.gen(function* () {
+        // Explain WHY credentials are being demanded (e.g. which dev-plan
+        // resources require the real cloud) before the first prompt.
+        if (ctx.reason !== undefined) {
+          yield* Clank.info(ctx.reason);
+        }
+        const method = yield* Clank.select({
+          message: "Cloudflare authentication method",
+          options,
+        });
+        return yield* Match.value(method).pipe(
+          Match.when("env", () => Effect.succeed({ method: "env" as const })),
+          Match.when("oauth", () => configureOAuth(profileName)),
+          Match.when("stored", () => loginStored(profileName)),
+          Match.exhaustive,
+        );
+      });
 
     const configureCredentials = (profileName: string, ctx: ConfigureContext) =>
       Effect.gen(function* () {
         const config = ctx.ci
           ? { method: "env" as const }
-          : yield* configureInteractive(profileName);
+          : yield* configureInteractive(profileName, ctx);
         // Re-configuring auth may point this profile at a different
         // Cloudflare account. The cached state-store credentials
         // (`~/.alchemy/credentials/{profile}/cloudflare-state-store.json`)

--- a/packages/alchemy/src/Cloudflare/CloudflareEnvironment.ts
+++ b/packages/alchemy/src/Cloudflare/CloudflareEnvironment.ts
@@ -1,3 +1,4 @@
+import * as Cause from "effect/Cause";
 import * as Config from "effect/Config";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
@@ -31,6 +32,88 @@ export const fromEnv = () =>
       return { account: accountId } as any;
     }),
   );
+
+/**
+ * Non-forcing accountId probe against a specific {@link CloudflareEnvironment}
+ * resolution effect.
+ *
+ * Resolves the current account id ONLY when doing so cannot prompt the user:
+ * credential resolution is attempted only if the Cloudflare auth provider
+ * already has stored config for the active profile (so `loadOrConfigure`
+ * would return it without running the interactive `configure` flow). When no
+ * config is stored — or resolution fails/dies anyway (broken stored
+ * credentials, an expired token, a test override that dies on force) — the
+ * probe returns `undefined` instead of failing.
+ *
+ * Used by the LOCAL (dev) providers to stamp `accountId` on local attributes
+ * opportunistically: an all-local `alchemy dev` run must work with zero
+ * configured credentials, so local lifecycle code must never *demand*
+ * credential resolution. See {@link currentAccountId} for the ambient
+ * variant.
+ */
+export const probeAccountId = (
+  env: Effect.Effect<CloudflareResolvedCredentials>,
+): Effect.Effect<string | undefined> =>
+  Effect.gen(function* () {
+    // Safety gate: forcing the environment effect may drive an interactive
+    // configure flow (browser OAuth, clack prompts) when nothing is stored
+    // for the active profile. Only force once stored config proves the
+    // resolution is non-interactive. If the profile service isn't in
+    // context we can't prove safety, so don't force.
+    const profile = yield* Effect.serviceOption(AlchemyProfile);
+    if (Option.isNone(profile)) return undefined;
+    const profileName = yield* ALCHEMY_PROFILE.pipe(
+      Effect.orElseSucceed(() => "default"),
+    );
+    const providers = yield* profile.value.getProfile(profileName);
+    if (providers?.[CLOUDFLARE_AUTH_PROVIDER_NAME] === undefined) {
+      return undefined;
+    }
+    // Stored config exists — resolution is non-interactive (`auth.read`
+    // never prompts). It can still fail or die (env vars missing, expired
+    // refresh token, a test layer that dies on force): a probe is best
+    // effort, so swallow everything except interruption.
+    return yield* env.pipe(
+      Effect.map((credentials): string | undefined => credentials.accountId),
+      Effect.catchCause(
+        (cause): Effect.Effect<string | undefined> =>
+          Cause.hasInterrupts(cause)
+            ? Effect.failCause(cause)
+            : Effect.succeed(undefined),
+      ),
+    );
+  });
+
+/**
+ * Ambient variant of {@link probeAccountId}: probes the
+ * {@link CloudflareEnvironment} available in the current context, returning
+ * `undefined` when the service isn't provided at all.
+ *
+ * This is the primitive LOCAL providers use in `diff`/`reconcile` to stamp
+ * `accountId: string | undefined` without ever demanding credentials.
+ */
+export const currentAccountId: Effect.Effect<string | undefined> =
+  Effect.serviceOption(CloudflareEnvironment).pipe(
+    Effect.flatMap(
+      Option.match({
+        onNone: () => Effect.succeed(undefined),
+        onSome: (env) => probeAccountId(env),
+      }),
+    ),
+  );
+
+/**
+ * Local-mode account-drift rule for provider `diff`s: a local resource is
+ * replaced on an account switch ONLY when both the stamped and the currently
+ * probed account id are known and differ. `undefined` on either side matches
+ * anything — otherwise the first run after `alchemy login` would replace
+ * every credential-free local resource and wipe its data.
+ */
+export const isAccountDrift = (
+  stamped: string | undefined,
+  current: string | undefined,
+): boolean =>
+  stamped !== undefined && current !== undefined && stamped !== current;
 
 export const fromProfile = () =>
   Layer.effect(

--- a/packages/alchemy/src/Cloudflare/Containers/ContainerApplication.ts
+++ b/packages/alchemy/src/Cloudflare/Containers/ContainerApplication.ts
@@ -637,9 +637,12 @@ export interface ContainerApplication<Shape = unknown> extends Resource<
      */
     applicationName: string;
     /**
-     * The Cloudflare account ID that owns the application.
+     * The Cloudflare account ID that owns the application. Always stamped
+     * by the live provider; the local (dev) provider stamps it
+     * opportunistically and leaves it `undefined` when no credentials are
+     * configured (credential-free `alchemy dev`).
      */
-    accountId: string;
+    accountId: string | undefined;
     /**
      * The scheduling policy in effect for the application's deployments.
      */

--- a/packages/alchemy/src/Cloudflare/Containers/ContainerBundle.ts
+++ b/packages/alchemy/src/Cloudflare/Containers/ContainerBundle.ts
@@ -44,7 +44,10 @@ import type { AnyContainerApplicationProps } from "./ContainerApplication.ts";
  */
 export const makeContainerEnv = (
   props: AnyContainerApplicationProps,
-  accountId: string,
+  // Undefined only on the local (dev) path when no credentials are
+  // configured — the account-id env var is then simply not injected
+  // (HTTP capability fallbacks need it only against real resources).
+  accountId: string | undefined,
 ) => {
   const env: Record<string, string | Redacted.Redacted<string>> = {};
   for (const [name, value] of Object.entries(props.env ?? {})) {
@@ -56,7 +59,7 @@ export const makeContainerEnv = (
   for (const value of props.environmentVariables ?? []) {
     env[value.name] = value.value;
   }
-  if (!env.ALCHEMY_CLOUDFLARE_ACCOUNT_ID) {
+  if (!env.ALCHEMY_CLOUDFLARE_ACCOUNT_ID && accountId !== undefined) {
     env.ALCHEMY_CLOUDFLARE_ACCOUNT_ID = accountId;
   }
   return env;

--- a/packages/alchemy/src/Cloudflare/Containers/ContainerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Containers/ContainerProvider.ts
@@ -4,6 +4,7 @@ import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
 import * as Redacted from "effect/Redacted";
 import * as Schedule from "effect/Schedule";
+import * as Stream from "effect/Stream";
 import { Unowned } from "../../AdoptPolicy.ts";
 import { AlchemyContext } from "../../AlchemyContext.ts";
 import { getStableContextDir } from "../../Bundle/TempRoot.ts";
@@ -885,7 +886,7 @@ export const LiveContainerProvider = () =>
           // so we promote the local resource to a real application.
           if (output?.applicationId && isLiveId(output.applicationId)) {
             existing = yield* Containers.getContainerApplication({
-              accountId: output.accountId,
+              accountId: output.accountId ?? accountId,
               applicationId: output.applicationId,
             }).pipe(
               Effect.map((app) => ({
@@ -946,7 +947,7 @@ export const LiveContainerProvider = () =>
               `Recreating container application ${name} with durable object binding...`,
             );
             yield* Containers.deleteContainerApplication({
-              accountId: existing.accountId,
+              accountId: existing.accountId ?? accountId,
               applicationId: existing.applicationId,
             }).pipe(
               Effect.catchTag(
@@ -1017,8 +1018,9 @@ export const LiveContainerProvider = () =>
           yield* Effect.logInfo(
             `Cloudflare Container delete: deleting ${output.applicationName}`,
           );
+          const { accountId } = yield* yield* CloudflareEnvironment;
           yield* Containers.deleteContainerApplication({
-            accountId: output.accountId,
+            accountId: output.accountId ?? accountId,
             applicationId: output.applicationId,
           }).pipe(
             Effect.catchTag("ContainerApplicationNotFound", () => Effect.void),
@@ -1058,8 +1060,9 @@ export const LiveContainerProvider = () =>
             yield* Effect.logInfo(
               `Cloudflare Container read: checking ${output.applicationName}`,
             );
+            const { accountId } = yield* yield* CloudflareEnvironment;
             attrs = yield* Containers.getContainerApplication({
-              accountId: output.accountId,
+              accountId: output.accountId ?? accountId,
               applicationId: output.applicationId,
             }).pipe(
               Effect.map((app) => ({
@@ -1102,15 +1105,27 @@ export const LiveContainerProvider = () =>
             );
           }),
         tail: ({ output }) =>
-          telemetry.tailStream({
-            accountId: output.accountId,
-            filters: containerFilters(output.applicationId),
-          }),
+          Stream.unwrap(
+            Effect.gen(function* () {
+              const accountId =
+                output.accountId ??
+                (yield* yield* CloudflareEnvironment).accountId;
+              return telemetry.tailStream({
+                accountId,
+                filters: containerFilters(output.applicationId),
+              });
+            }),
+          ),
         logs: ({ output, options }) =>
-          telemetry.queryLogs({
-            accountId: output.accountId,
-            filters: containerFilters(output.applicationId),
-            options,
+          Effect.gen(function* () {
+            const accountId =
+              output.accountId ??
+              (yield* yield* CloudflareEnvironment).accountId;
+            return yield* telemetry.queryLogs({
+              accountId,
+              filters: containerFilters(output.applicationId),
+              options,
+            });
           }),
       });
     }),

--- a/packages/alchemy/src/Cloudflare/Containers/LocalContainerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Containers/LocalContainerProvider.ts
@@ -8,7 +8,7 @@ import { isResolved } from "../../Diff.ts";
 import * as RpcProvider from "../../Local/RpcProvider.ts";
 import { sha256Object } from "../../Util/sha256.ts";
 import { normalizeNulls } from "../../Util/stable.ts";
-import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
+import { currentAccountId } from "../CloudflareEnvironment.ts";
 import { generateLocalId, LOCAL_ENTRY_URL } from "../LocalRuntime.ts";
 import type {
   AnyContainerApplicationProps,
@@ -173,7 +173,10 @@ export const LocalContainerProvider = () =>
         news: AnyContainerApplicationProps;
         output: ContainerApplication["Attributes"] | undefined;
       }) {
-        const { accountId } = yield* yield* CloudflareEnvironment;
+        // Non-forcing probe: the local container must build and run without
+        // configured credentials. Stamped opportunistically — `undefined`
+        // in a credential-free dev session.
+        const accountId = yield* currentAccountId;
         const env = makeContainerEnv(news, accountId);
         const { dev, hash } = yield* prepareImage(id, news);
         return {

--- a/packages/alchemy/src/Cloudflare/D1/Database.ts
+++ b/packages/alchemy/src/Cloudflare/D1/Database.ts
@@ -14,7 +14,11 @@ import * as Provider from "../../Provider.ts";
 import { isResourceOfType, Resource } from "../../Resource.ts";
 import { listSqlFiles, readSqlFile } from "../../SQL/SqlFile.ts";
 import { recordsEqual } from "../../Util/equal.ts";
-import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
+import {
+  CloudflareEnvironment,
+  currentAccountId,
+  isAccountDrift,
+} from "../CloudflareEnvironment.ts";
 import {
   generateLocalId,
   LOCAL_ENTRY_URL,
@@ -125,7 +129,12 @@ export type Database = Resource<
     databaseName: string;
     jurisdiction: Jurisdiction;
     readReplication: { mode: "auto" | "disabled" } | undefined;
-    accountId: string;
+    /**
+     * Always stamped by the live provider; the local (dev) provider stamps
+     * it opportunistically and leaves it `undefined` when no credentials
+     * are configured (credential-free `alchemy dev`).
+     */
+    accountId: string | undefined;
     migrationsDir: string | undefined;
     migrationsTable: string | undefined;
     migrationsHashes: Record<string, string>;
@@ -353,9 +362,10 @@ export const ProviderLive = () =>
     read: Effect.fn(function* ({ id, output, olds }) {
       const { accountId } = yield* yield* CloudflareEnvironment;
       if (output?.databaseId) {
+        const acct = output.accountId ?? accountId;
         return yield* d1
           .getDatabase({
-            accountId: output.accountId,
+            accountId: acct,
             databaseId: output.databaseId,
           })
           .pipe(
@@ -367,7 +377,7 @@ export const ProviderLive = () =>
               readReplication: (db.readReplication ?? undefined) as
                 | { mode: "auto" | "disabled" }
                 | undefined,
-              accountId: output.accountId,
+              accountId: acct,
               migrationsDir: output.migrationsDir,
               migrationsTable: output.migrationsTable,
               migrationsHashes: output.migrationsHashes,
@@ -554,9 +564,10 @@ export const ProviderLive = () =>
       };
     }),
     delete: Effect.fn(function* ({ output }) {
+      const { accountId } = yield* yield* CloudflareEnvironment;
       yield* d1
         .deleteDatabase({
-          accountId: output.accountId,
+          accountId: output.accountId ?? accountId,
           databaseId: output.databaseId,
         })
         .pipe(Effect.catchTag("DatabaseNotFound", () => Effect.void));
@@ -598,10 +609,11 @@ export const ProviderLocal = () =>
       return {
         stables: ["accountId"],
         diff: Effect.fn(function* ({ news = {}, output }) {
-          const { accountId } = yield* yield* CloudflareEnvironment;
+          // Non-forcing probe: local diffs must never demand credentials.
+          const accountId = yield* currentAccountId;
           if (!output?.databaseId) return { action: "update" } as const;
           if (!isResolved(news)) return undefined;
-          if (output.accountId !== accountId) {
+          if (isAccountDrift(output.accountId, accountId)) {
             return { action: "replace" } as const;
           }
           // Detect migration/import file drift — same rules as the live
@@ -634,7 +646,6 @@ export const ProviderLocal = () =>
           return output ?? undefined;
         }),
         reconcile: Effect.fn(function* ({ id, news = {}, output }) {
-          const { accountId } = yield* yield* CloudflareEnvironment;
           const databaseId = output?.databaseId ?? generateLocalId();
 
           // Sync migrations — the shared flow is idempotent (skips applied
@@ -691,7 +702,9 @@ export const ProviderLocal = () =>
             databaseName: yield* createDatabaseName(id, news.name),
             jurisdiction: (news.jurisdiction ?? "default") as Jurisdiction,
             readReplication: news.readReplication,
-            accountId: output?.accountId ?? accountId,
+            // Stamped opportunistically — `undefined` in a credential-free
+            // dev session; matches any account in the local diff.
+            accountId: output?.accountId ?? (yield* currentAccountId),
             migrationsDir: news.migrationsDir,
             migrationsTable: news.migrationsDir ? migrationsTable : undefined,
             migrationsHashes,

--- a/packages/alchemy/src/Cloudflare/D1/QueryDatabaseHttpClient.ts
+++ b/packages/alchemy/src/Cloudflare/D1/QueryDatabaseHttpClient.ts
@@ -29,7 +29,11 @@ export interface D1Auth {
   authorize: <A, E>(
     eff: Effect.Effect<A, E, Credentials | HttpClient.HttpClient>,
   ) => Effect.Effect<A, E>;
-  accountId: string;
+  /**
+   * Deferred so building a client never demands credential resolution — the
+   * account id resolves only when an HTTP query op actually runs.
+   */
+  accountId: Effect.Effect<string>;
 }
 
 /**
@@ -79,11 +83,13 @@ const runQuery = (
 ): Promise<d1.QueryDatabaseResponse> =>
   auth
     .authorize(
-      d1.queryDatabase({
-        accountId: auth.accountId,
-        databaseId,
-        ...(body as any),
-      }),
+      Effect.flatMap(auth.accountId, (accountId) =>
+        d1.queryDatabase({
+          accountId,
+          databaseId,
+          ...(body as any),
+        }),
+      ),
     )
     .pipe(Effect.runPromise);
 

--- a/packages/alchemy/src/Cloudflare/D1/QueryDatabaseLocal.ts
+++ b/packages/alchemy/src/Cloudflare/D1/QueryDatabaseLocal.ts
@@ -50,14 +50,17 @@ export const QueryDatabaseLocal = Layer.effect(
   Effect.gen(function* () {
     // Account + credentials are ambient during stack-eval (the stack's
     // providers layer). Capture the full context so the HTTP query ops run
-    // with the current credentials — no `host.bind`, no minted token.
-    const { accountId } = yield* yield* CloudflareEnvironment;
+    // with the current credentials — no `host.bind`, no minted token. The
+    // accountId stays a DEFERRED effect: it only resolves if the HTTP branch
+    // is actually taken (a real database id), so an all-local dev run never
+    // forces credential resolution.
+    const getEnv = yield* CloudflareEnvironment;
     const context = yield* Effect.context<
       Credentials | HttpClient.HttpClient
     >();
     const auth: D1Auth = {
       authorize: (eff) => eff.pipe(Effect.provideContext(context)),
-      accountId,
+      accountId: getEnv.pipe(Effect.map((env) => env.accountId)),
     };
     // The FULL ambient context, for the dev-mode gateway: booting an
     // ephemeral workerd needs the platform services (FileSystem, Path,

--- a/packages/alchemy/src/Cloudflare/Flagship/ReadFlagsHttpClient.ts
+++ b/packages/alchemy/src/Cloudflare/Flagship/ReadFlagsHttpClient.ts
@@ -27,7 +27,11 @@ export interface FlagshipAuth {
   authorize: <A, E>(
     eff: Effect.Effect<A, E, Credentials | HttpClient.HttpClient>,
   ) => Effect.Effect<A, E>;
-  accountId: string;
+  /**
+   * Deferred so building a client never demands credential resolution — the
+   * account id resolves only when an evaluate op actually runs.
+   */
+  accountId: Effect.Effect<string>;
 }
 
 /**
@@ -60,12 +64,14 @@ export const makeHttpFlagshipClient = (
     appId.pipe(
       Effect.flatMap((id) =>
         auth.authorize(
-          flagship.getAppEvaluate({
-            accountId: auth.accountId,
-            appId: id,
-            flagKey,
-            targetingKey: targetingKeyOf(context),
-          }),
+          Effect.flatMap(auth.accountId, (accountId) =>
+            flagship.getAppEvaluate({
+              accountId,
+              appId: id,
+              flagKey,
+              targetingKey: targetingKeyOf(context),
+            }),
+          ),
         ),
       ),
     );

--- a/packages/alchemy/src/Cloudflare/Flagship/ReadFlagsLocal.ts
+++ b/packages/alchemy/src/Cloudflare/Flagship/ReadFlagsLocal.ts
@@ -49,14 +49,17 @@ export const ReadFlagsLocal = Layer.effect(
   Effect.gen(function* () {
     // Account + credentials are ambient during stack-eval (the stack's
     // providers layer). Capture the full context so the evaluate op can run
-    // with the current credentials — no `host.bind`, no minted token.
-    const { accountId } = yield* yield* CloudflareEnvironment;
+    // with the current credentials — no `host.bind`, no minted token. The
+    // accountId stays a DEFERRED effect: it only resolves when an evaluate op
+    // actually runs, so an all-local dev run never forces credential
+    // resolution just by building this layer.
+    const getEnv = yield* CloudflareEnvironment;
     const context = yield* Effect.context<
       Credentials | HttpClient.HttpClient
     >();
     const auth: FlagshipAuth = {
       authorize: (eff) => eff.pipe(Effect.provideContext(context)),
-      accountId,
+      accountId: getEnv.pipe(Effect.map((env) => env.accountId)),
     };
 
     return Effect.fn(function* (app: App) {

--- a/packages/alchemy/src/Cloudflare/KV/Namespace.ts
+++ b/packages/alchemy/src/Cloudflare/KV/Namespace.ts
@@ -7,7 +7,11 @@ import * as ProviderLayer from "../../Local/ProviderLayer.ts";
 import { createPhysicalName } from "../../PhysicalName.ts";
 import * as Provider from "../../Provider.ts";
 import { isResourceOfType, Resource } from "../../Resource.ts";
-import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
+import {
+  CloudflareEnvironment,
+  currentAccountId,
+  isAccountDrift,
+} from "../CloudflareEnvironment.ts";
 import { generateLocalId } from "../LocalRuntime.ts";
 import type { Providers } from "../Providers.ts";
 
@@ -30,7 +34,12 @@ export type Namespace = Resource<
     title: string;
     namespaceId: string;
     supportsUrlEncoding: boolean | undefined;
-    accountId: string;
+    /**
+     * Always stamped by the live provider; the local (dev) provider stamps
+     * it opportunistically and leaves it `undefined` when no credentials
+     * are configured (credential-free `alchemy dev`).
+     */
+    accountId: string | undefined;
   },
   never,
   Providers
@@ -168,9 +177,10 @@ export const ProviderLive = () =>
       };
     }),
     delete: Effect.fn(function* ({ output }) {
+      const { accountId } = yield* yield* CloudflareEnvironment;
       yield* kv
         .deleteNamespace({
-          accountId: output.accountId,
+          accountId: output.accountId ?? accountId,
           namespaceId: output.namespaceId,
         })
         .pipe(Effect.catchTag("NamespaceNotFound", () => Effect.void));
@@ -194,9 +204,10 @@ export const ProviderLive = () =>
     read: Effect.fn(function* ({ id, olds, output }) {
       const { accountId } = yield* yield* CloudflareEnvironment;
       if (output?.namespaceId) {
+        const acct = output.accountId ?? accountId;
         return yield* kv
           .getNamespace({
-            accountId: output.accountId,
+            accountId: acct,
             namespaceId: output.namespaceId,
           })
           .pipe(
@@ -204,7 +215,7 @@ export const ProviderLive = () =>
               title: namespace.title,
               namespaceId: namespace.id,
               supportsUrlEncoding: namespace.supportsUrlEncoding ?? undefined,
-              accountId: output.accountId,
+              accountId: acct,
             })),
             Effect.catchTag("NamespaceNotFound", () =>
               Effect.succeed(undefined),
@@ -235,10 +246,11 @@ export const ProviderLocal = () =>
   Provider.succeed(Namespace, {
     stables: ["accountId"],
     diff: Effect.fn(function* ({ news = {}, output }) {
-      const { accountId } = yield* yield* CloudflareEnvironment;
+      // Non-forcing probe: local diffs must never demand credentials.
+      const accountId = yield* currentAccountId;
       if (!output?.namespaceId) return { action: "update" } as const;
       if (!isResolved(news)) return undefined;
-      if (output.accountId !== accountId) {
+      if (isAccountDrift(output.accountId, accountId)) {
         return { action: "replace" } as const;
       }
       // Fall through to the engine's default prop diff (title renames
@@ -249,12 +261,13 @@ export const ProviderLocal = () =>
       return output ?? undefined;
     }),
     reconcile: Effect.fn(function* ({ id, news = {}, output }) {
-      const { accountId } = yield* yield* CloudflareEnvironment;
       return {
         title: yield* createTitle(id, news.title),
         namespaceId: output?.namespaceId ?? generateLocalId(),
         supportsUrlEncoding: true,
-        accountId: output?.accountId ?? accountId,
+        // Stamped opportunistically — `undefined` in a credential-free dev
+        // session; matches any account in the local diff.
+        accountId: output?.accountId ?? (yield* currentAccountId),
       };
     }),
     delete: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/KV/NamespaceLocal.ts
+++ b/packages/alchemy/src/Cloudflare/KV/NamespaceLocal.ts
@@ -38,8 +38,11 @@ export const makeLocalKVNamespaceBinding = <Client extends object>(options: {
   Effect.gen(function* () {
     // Account + credentials are ambient during stack-eval (the stack's
     // providers layer). Capture the full context so KV HTTP ops can run with
-    // the current credentials — no `host.bind`, no minted token.
-    const { accountId } = yield* yield* CloudflareEnvironment;
+    // the current credentials — no `host.bind`, no minted token. The
+    // accountId stays a DEFERRED effect: it only resolves if the HTTP branch
+    // is actually taken (a real id), so an all-local dev run never forces
+    // credential resolution.
+    const getEnv = yield* CloudflareEnvironment;
     const context = yield* Effect.context<
       Credentials | HttpClient.HttpClient
     >();
@@ -55,7 +58,7 @@ export const makeLocalKVNamespaceBinding = <Client extends object>(options: {
       const namespaceId = yield* namespace.namespaceId;
       const auth: KVAuth = {
         authorize: (eff) => eff.pipe(Effect.provideContext(context)),
-        accountId: Effect.succeed(accountId),
+        accountId: getEnv.pipe(Effect.map((env) => env.accountId)),
       };
       const httpClient = options.makeHttpClient(auth, namespaceId);
       return dispatchByMode(namespaceId, httpClient, (id) =>

--- a/packages/alchemy/src/Cloudflare/Queues/Consumer.ts
+++ b/packages/alchemy/src/Cloudflare/Queues/Consumer.ts
@@ -10,7 +10,11 @@ import * as ProviderLayer from "../../Local/ProviderLayer.ts";
 import * as RpcProvider from "../../Local/RpcProvider.ts";
 import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
-import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
+import {
+  CloudflareEnvironment,
+  currentAccountId,
+  isAccountDrift,
+} from "../CloudflareEnvironment.ts";
 import {
   isLiveId,
   LOCAL_ENTRY_URL,
@@ -71,7 +75,13 @@ export type Consumer = Resource<
     consumerId: string;
     queueId: string;
     scriptName: string;
-    accountId: string;
+    /**
+     * Always stamped by the live provider; the local (dev) provider stamps
+     * it opportunistically and leaves it `undefined` when no credentials
+     * are configured (credential-free `alchemy dev`; a consumer of a LIVE
+     * queue always stamps it — the pull path demands credentials).
+     */
+    accountId: string | undefined;
     deadLetterQueue?: string;
     settings?: ConsumerSettings;
     /**
@@ -478,9 +488,11 @@ export const ConsumerProviderLive = () =>
       // If the consumerId is a `dev:` ID, the resource only exists locally, so we don't need to delete it from Cloudflare.
       if (!isLiveId(output.consumerId)) return;
 
+      const acct =
+        output.accountId ?? (yield* yield* CloudflareEnvironment).accountId;
       yield* queues
         .deleteConsumer({
-          accountId: output.accountId,
+          accountId: acct,
           queueId: output.queueId,
           consumerId: output.consumerId,
         })
@@ -493,7 +505,7 @@ export const ConsumerProviderLive = () =>
       // queue subsystem before the script-side view propagates.
       yield* queues
         .getConsumer({
-          accountId: output.accountId,
+          accountId: acct,
           queueId: output.queueId,
           consumerId: output.consumerId,
         })
@@ -512,9 +524,11 @@ export const ConsumerProviderLive = () =>
     }),
     read: Effect.fn(function* ({ output }) {
       if (output?.consumerId) {
+        const acct =
+          output.accountId ?? (yield* yield* CloudflareEnvironment).accountId;
         const fetched = yield* queues
           .getConsumer({
-            accountId: output.accountId,
+            accountId: acct,
             queueId: output.queueId,
             consumerId: output.consumerId,
           })
@@ -528,7 +542,7 @@ export const ConsumerProviderLive = () =>
             consumerId: fetched.consumerId!,
             queueId: output.queueId,
             scriptName: toObserved(fetched)?.scriptName ?? output.scriptName,
-            accountId: output.accountId,
+            accountId: acct,
             deadLetterQueue: output.deadLetterQueue,
             settings: output.settings,
           };
@@ -612,12 +626,13 @@ export const ConsumerProviderLocal = () =>
             Array.from(MutableHashMap.values(localRuntimeState.queueConsumers)),
           ),
         diff: Effect.fn(function* ({ news, output }) {
-          const { accountId } = yield* yield* CloudflareEnvironment;
+          // Non-forcing probe: local diffs must never demand credentials.
+          const accountId = yield* currentAccountId;
           if (!output) return { action: "update" };
           if (!isResolved(news)) return undefined;
           if (
             output.queueId !== news.queueId ||
-            output.accountId !== accountId
+            isAccountDrift(output.accountId, accountId)
           ) {
             return { action: "replace" };
           }
@@ -646,7 +661,11 @@ export const ConsumerProviderLocal = () =>
           ).pipe(Option.getOrUndefined);
         }),
         reconcile: Effect.fn(function* ({ news, output }) {
-          const { accountId } = yield* yield* CloudflareEnvironment;
+          // Non-forcing probe — a consumer of a LOCAL queue must reconcile
+          // without credentials. The live-queue pull path below upgrades
+          // this to a real (forcing) resolution: that path talks to the
+          // cloud, so demanding credentials there is legitimate.
+          let accountId = yield* currentAccountId;
           // A LIVE queue (`Alchemy.remote()`) consumed by a LOCAL worker:
           // Cloudflare only pushes to deployed consumers, so the local
           // runtime drains the real queue via the HTTP pull API instead.
@@ -655,6 +674,7 @@ export const ConsumerProviderLocal = () =>
           let queueName: string | undefined;
           let pullConsumerId: string | undefined;
           if (isLiveId(news.queueId)) {
+            accountId = (yield* yield* CloudflareEnvironment).accountId;
             const queue = yield* queues.getQueue({
               accountId,
               queueId: news.queueId,
@@ -719,9 +739,14 @@ export const ConsumerProviderLocal = () =>
           // queue. Idempotent: gone-already (or queue deleted first) is
           // success.
           if (output.pullConsumerId && isLiveId(output.queueId)) {
+            // Live-demand path: the pull consumer lives on the real queue,
+            // so credentials are legitimately required to remove it.
+            const accountId =
+              output.accountId ??
+              (yield* yield* CloudflareEnvironment).accountId;
             yield* queues
               .deleteConsumer({
-                accountId: output.accountId,
+                accountId,
                 queueId: output.queueId,
                 consumerId: output.pullConsumerId,
               })

--- a/packages/alchemy/src/Cloudflare/Queues/Queue.ts
+++ b/packages/alchemy/src/Cloudflare/Queues/Queue.ts
@@ -11,7 +11,11 @@ import * as RpcProvider from "../../Local/RpcProvider.ts";
 import { createPhysicalName } from "../../PhysicalName.ts";
 import * as Provider from "../../Provider.ts";
 import { isResourceOfType, Resource } from "../../Resource.ts";
-import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
+import {
+  CloudflareEnvironment,
+  currentAccountId,
+  isAccountDrift,
+} from "../CloudflareEnvironment.ts";
 import {
   generateLocalId,
   LOCAL_ENTRY_URL,
@@ -37,7 +41,12 @@ export type Queue = Resource<
   {
     queueId: string;
     queueName: string;
-    accountId: string;
+    /**
+     * Always stamped by the live provider; the local (dev) provider stamps
+     * it opportunistically and leaves it `undefined` when no credentials
+     * are configured (credential-free `alchemy dev`).
+     */
+    accountId: string | undefined;
   },
   never,
   Providers
@@ -189,13 +198,14 @@ export const ProviderLive = () =>
       };
     }),
     delete: Effect.fn(function* ({ output }) {
+      const { accountId } = yield* yield* CloudflareEnvironment;
       // Dependents (e.g. R2 event notification configs targeting this
       // queue) may still be tearing down concurrently — ride out the
       // dependency violation briefly, then fail loudly instead of
       // silently leaking the queue.
       yield* queues
         .deleteQueue({
-          accountId: output.accountId,
+          accountId: output.accountId ?? accountId,
           queueId: output.queueId,
         })
         .pipe(
@@ -232,16 +242,17 @@ export const ProviderLive = () =>
     read: Effect.fn(function* ({ id, output, olds }) {
       const { accountId } = yield* yield* CloudflareEnvironment;
       if (output?.queueId) {
+        const acct = output.accountId ?? accountId;
         return yield* queues
           .getQueue({
-            accountId: output.accountId,
+            accountId: acct,
             queueId: output.queueId,
           })
           .pipe(
             Effect.map((queue) => ({
               queueId: queue.queueId!,
               queueName: queue.queueName!,
-              accountId: output.accountId,
+              accountId: acct,
             })),
             Effect.catchTag(["QueueNotFound", "InvalidRoute"], () =>
               Effect.succeed(undefined),
@@ -291,14 +302,15 @@ export const ProviderLocal = () =>
       return {
         stables: ["accountId"],
         diff: Effect.fn(function* ({ id, olds = {}, news = {}, output }) {
-          const { accountId } = yield* yield* CloudflareEnvironment;
+          // Non-forcing probe: local diffs must never demand credentials.
+          const accountId = yield* currentAccountId;
           if (!output?.queueId) return { action: "update" };
           if (!isResolved(news)) return undefined;
           const name = yield* createQueueName(id, news.name);
           const oldName = output?.queueName
             ? yield* createQueueName(id, olds.name)
             : yield* createQueueName(id, olds.name);
-          if (name !== oldName || output.accountId !== accountId) {
+          if (name !== oldName || isAccountDrift(output.accountId, accountId)) {
             return { action: "replace" };
           }
           // If the resource is a noop, add it to the local runtime state so it's available downstream.
@@ -314,11 +326,12 @@ export const ProviderLocal = () =>
           ).pipe(Option.getOrUndefined);
         }),
         reconcile: Effect.fn(function* ({ id, news = {}, output }) {
-          const { accountId } = yield* yield* CloudflareEnvironment;
           const queue: Queue["Attributes"] = {
             queueId: output?.queueId ?? generateLocalId(),
             queueName: yield* createQueueName(id, news.name),
-            accountId: output?.accountId ?? accountId,
+            // Stamped opportunistically — `undefined` in a credential-free
+            // dev session; matches any account in the local diff.
+            accountId: output?.accountId ?? (yield* currentAccountId),
           };
           MutableHashMap.set(localRuntimeState.queues, queue.queueId, queue);
           return queue;

--- a/packages/alchemy/src/Cloudflare/Queues/WriteQueueLocal.ts
+++ b/packages/alchemy/src/Cloudflare/Queues/WriteQueueLocal.ts
@@ -41,8 +41,11 @@ export const WriteQueueLocal = Layer.effect(
   Effect.gen(function* () {
     // Account + credentials are ambient during stack-eval (the stack's
     // providers layer). Capture the full context so the bulk-push effect can
-    // run with the current credentials instead of a scoped token.
-    const { accountId } = yield* yield* CloudflareEnvironment;
+    // run with the current credentials instead of a scoped token. The
+    // accountId stays a DEFERRED effect: it only resolves when an HTTP op
+    // actually runs against a real queue, so an all-local dev run never
+    // forces credential resolution.
+    const getEnv = yield* CloudflareEnvironment;
     const context = yield* Effect.context<
       Credentials | HttpClient.HttpClient
     >();
@@ -55,7 +58,7 @@ export const WriteQueueLocal = Layer.effect(
       return makeWriteQueueHttpClient(
         {
           authorize: (eff) => eff.pipe(Effect.provideContext(context)),
-          accountId: Effect.succeed(accountId),
+          accountId: getEnv.pipe(Effect.map((env) => env.accountId)),
         },
         queueId,
       );

--- a/packages/alchemy/src/Cloudflare/R2/Bucket.ts
+++ b/packages/alchemy/src/Cloudflare/R2/Bucket.ts
@@ -8,7 +8,11 @@ import * as ProviderLayer from "../../Local/ProviderLayer.ts";
 import { createPhysicalName } from "../../PhysicalName.ts";
 import * as Provider from "../../Provider.ts";
 import { isResourceOfType, Resource } from "../../Resource.ts";
-import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
+import {
+  CloudflareEnvironment,
+  currentAccountId,
+  isAccountDrift,
+} from "../CloudflareEnvironment.ts";
 import { generateLocalId } from "../LocalRuntime.ts";
 import type * as Cloudflare from "../Providers.ts";
 import * as Zone from "../Zone/index.ts";
@@ -182,7 +186,12 @@ export type Bucket = Resource<
     storageClass: Bucket.StorageClass;
     jurisdiction: Bucket.Jurisdiction;
     location: Bucket.Location | undefined;
-    accountId: string;
+    /**
+     * Always stamped by the live provider; the local (dev) provider stamps
+     * it opportunistically and leaves it `undefined` when no credentials
+     * are configured (credential-free `alchemy dev`).
+     */
+    accountId: string | undefined;
     domains: Bucket.CustomDomain[];
     lifecycleRules: Bucket.LifecycleRule[];
     cors: Bucket.CorsRule[];
@@ -1101,11 +1110,13 @@ export const ProviderLive = () =>
           };
         }),
         delete: Effect.fn(function* ({ output }) {
+          const { accountId } = yield* yield* CloudflareEnvironment;
+          const acct = output.accountId ?? accountId;
           yield* Effect.all(
             (output.domains ?? []).map((domain) =>
               r2
                 .deleteBucketDomainCustom({
-                  accountId: output.accountId,
+                  accountId: acct,
                   bucketName: output.bucketName,
                   domain: domain.domain,
                   jurisdiction: output.jurisdiction,
@@ -1123,7 +1134,7 @@ export const ProviderLive = () =>
           yield* emptyBucket(output.bucketName, output.jurisdiction);
           yield* r2
             .deleteBucket({
-              accountId: output.accountId,
+              accountId: acct,
               bucketName: output.bucketName,
               jurisdiction: output.jurisdiction,
             })
@@ -1176,10 +1187,11 @@ export const ProviderLocal = () =>
   Provider.succeed(Bucket, {
     stables: ["accountId"],
     diff: Effect.fn(function* ({ news = {}, output }) {
-      const { accountId } = yield* yield* CloudflareEnvironment;
+      // Non-forcing probe: local diffs must never demand credentials.
+      const accountId = yield* currentAccountId;
       if (!output?.bucketName) return { action: "update" } as const;
       if (!isResolved(news)) return undefined;
-      if (output.accountId !== accountId) {
+      if (isAccountDrift(output.accountId, accountId)) {
         return { action: "replace" } as const;
       }
       // Fall through to the engine's default prop diff.
@@ -1189,13 +1201,14 @@ export const ProviderLocal = () =>
       return output ?? undefined;
     }),
     reconcile: Effect.fn(function* ({ news = {}, output }) {
-      const { accountId } = yield* yield* CloudflareEnvironment;
       return {
         bucketName: output?.bucketName ?? generateLocalId(),
         storageClass: (news.storageClass ?? "Standard") as Bucket.StorageClass,
         jurisdiction: (news.jurisdiction ?? "default") as Bucket.Jurisdiction,
         location: undefined,
-        accountId: output?.accountId ?? accountId,
+        // Stamped opportunistically — `undefined` in a credential-free dev
+        // session; matches any account in the local diff.
+        accountId: output?.accountId ?? (yield* currentAccountId),
         domains: [],
         lifecycleRules: [],
         cors: [],

--- a/packages/alchemy/src/Cloudflare/R2/BucketLocal.ts
+++ b/packages/alchemy/src/Cloudflare/R2/BucketLocal.ts
@@ -34,9 +34,11 @@ export const makeLocalBucketBinding = <Client extends object>(options: {
 }) =>
   Effect.gen(function* () {
     // Account + credentials are ambient during stack-eval (the stack's
-    // providers layer). Capture the full context so each op can be run with the
-    // current credentials.
-    const { accountId } = yield* yield* CloudflareEnvironment;
+    // providers layer). Capture the full context so each op can be run with
+    // the current credentials. The accountId stays a DEFERRED effect: it only
+    // resolves if the HTTP branch is actually taken (a real bucket name), so
+    // an all-local dev run never forces credential resolution.
+    const getEnv = yield* CloudflareEnvironment;
     const context = yield* Effect.context<
       Credentials | HttpClient.HttpClient
     >();
@@ -48,7 +50,7 @@ export const makeLocalBucketBinding = <Client extends object>(options: {
 
     const auth: R2Auth = {
       authorize: (eff) => eff.pipe(Effect.provideContext(context)),
-      accountId: Effect.succeed(accountId),
+      accountId: getEnv.pipe(Effect.map((env) => env.accountId)),
     };
 
     return Effect.fn(function* (bucket: Bucket) {

--- a/packages/alchemy/src/Cloudflare/SecretsStore/Secret.ts
+++ b/packages/alchemy/src/Cloudflare/SecretsStore/Secret.ts
@@ -32,7 +32,12 @@ export type StoreSecretProps = {
    */
   store: {
     storeId: string;
-    accountId: string;
+    /**
+     * Undefined when the store is a local (dev) row created without
+     * configured credentials — the live provider falls back to the
+     * current environment's account.
+     */
+    accountId: string | undefined;
   };
   /**
    * The name of the secret within the store.
@@ -61,7 +66,12 @@ export type Secret = Resource<
     secretId: string;
     secretName: string;
     storeId: string;
-    accountId: string;
+    /**
+     * Always stamped by the live provider; the local (dev) provider stamps
+     * it opportunistically and leaves it `undefined` when no credentials
+     * are configured (credential-free `alchemy dev`).
+     */
+    accountId: string | undefined;
     status: SecretStatus;
     scopes: string[];
     comment: string | undefined;
@@ -131,7 +141,11 @@ export const SecretProviderLive = () =>
     reconcile: Effect.fn(function* ({ id, news, output }) {
       const name = resolveName(id, news.name);
       const scopes = resolveScopes(news.scopes);
-      const accountId = news.store.accountId;
+      // A store row created by the LOCAL provider without credentials has
+      // no stamped account — the live path is a credential demand anyway,
+      // so fall back to the current environment's account.
+      const accountId =
+        news.store.accountId ?? (yield* yield* CloudflareEnvironment).accountId;
       const storeId = news.store.storeId;
 
       // Observe — re-fetch the cached secret; fall back to a name
@@ -149,7 +163,7 @@ export const SecretProviderLive = () =>
       if (output?.secretId) {
         observed = yield* secretsStore
           .getStoreSecret({
-            accountId: output.accountId,
+            accountId: output.accountId ?? accountId,
             storeId: output.storeId,
             secretId: output.secretId,
           })
@@ -254,9 +268,10 @@ export const SecretProviderLive = () =>
       };
     }),
     delete: Effect.fn(function* ({ output }) {
+      const { accountId } = yield* yield* CloudflareEnvironment;
       yield* secretsStore
         .deleteStoreSecret({
-          accountId: output.accountId,
+          accountId: output.accountId ?? accountId,
           storeId: output.storeId,
           secretId: output.secretId,
         })
@@ -270,9 +285,11 @@ export const SecretProviderLive = () =>
     }),
     read: Effect.fn(function* ({ id, olds, output }) {
       if (output?.secretId) {
+        const acct =
+          output.accountId ?? (yield* yield* CloudflareEnvironment).accountId;
         return yield* secretsStore
           .getStoreSecret({
-            accountId: output.accountId,
+            accountId: acct,
             storeId: output.storeId,
             secretId: output.secretId,
           })
@@ -281,7 +298,7 @@ export const SecretProviderLive = () =>
               secretId: secret.id,
               secretName: secret.name,
               storeId: secret.storeId,
-              accountId: output.accountId,
+              accountId: acct,
               status: asSecretStatus(secret.status),
               scopes: output.scopes,
               comment: secret.comment ?? undefined,

--- a/packages/alchemy/src/Cloudflare/SecretsStore/SecretsStore.ts
+++ b/packages/alchemy/src/Cloudflare/SecretsStore/SecretsStore.ts
@@ -5,7 +5,11 @@ import * as Stream from "effect/Stream";
 import * as ProviderLayer from "../../Local/ProviderLayer.ts";
 import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
-import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
+import {
+  CloudflareEnvironment,
+  currentAccountId,
+  isAccountDrift,
+} from "../CloudflareEnvironment.ts";
 import { generateLocalId } from "../LocalRuntime.ts";
 import type { Providers } from "../Providers.ts";
 
@@ -15,7 +19,12 @@ export type Store = Resource<
   {
     storeId: string;
     storeName: string;
-    accountId: string;
+    /**
+     * Always stamped by the live provider; the local (dev) provider stamps
+     * it opportunistically and leaves it `undefined` when no credentials
+     * are configured (credential-free `alchemy dev`).
+     */
+    accountId: string | undefined;
   },
   never,
   Providers
@@ -172,9 +181,10 @@ export const StoreProviderLocal = () =>
   Provider.succeed(Store, {
     stables: ["accountId"],
     diff: Effect.fn(function* ({ output }) {
-      const { accountId } = yield* yield* CloudflareEnvironment;
+      // Non-forcing probe: local diffs must never demand credentials.
+      const accountId = yield* currentAccountId;
       if (!output?.storeId) return { action: "update" } as const;
-      if (output.accountId !== accountId) {
+      if (isAccountDrift(output.accountId, accountId)) {
         return { action: "replace" } as const;
       }
       // Fall through to the engine's default prop diff.
@@ -184,12 +194,13 @@ export const StoreProviderLocal = () =>
       return output ?? undefined;
     }),
     reconcile: Effect.fn(function* ({ output }) {
-      const { accountId } = yield* yield* CloudflareEnvironment;
       return {
         storeId: output?.storeId ?? generateLocalId(),
         // Mirror the name Cloudflare uses for an account's default store.
         storeName: output?.storeName ?? "default_secrets_store",
-        accountId: output?.accountId ?? accountId,
+        // Stamped opportunistically — `undefined` in a credential-free dev
+        // session; matches any account in the local diff.
+        accountId: output?.accountId ?? (yield* currentAccountId),
       };
     }),
     delete: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/StateStore/State.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/State.ts
@@ -11,7 +11,9 @@ import * as HttpApiClient from "effect/unstable/httpapi/HttpApiClient";
 import crypto from "node:crypto";
 
 import * as Config from "effect/Config";
+import type * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
+import type * as Path from "effect/Path";
 import { isHttpClientError } from "effect/unstable/http/HttpClientError";
 import { adopt } from "../../AdoptPolicy.ts";
 import { AlchemyContext } from "../../AlchemyContext.ts";
@@ -54,10 +56,88 @@ import {
 
 const CI = Config.boolean("CI").pipe(Config.withDefault(false));
 
+/**
+ * `StateService.id` reported on `state_store.init` telemetry
+ * (`alchemy.state_store.id`) when {@link state} resolves to the local file
+ * store during `alchemy dev`. Distinct from `"local"` (an explicit
+ * `Alchemy.localState()`) and `"cloudflare-http"` (the deployed cloud store)
+ * so dashboards can see the dev-resolved-local path honestly.
+ */
+export const DEV_LOCAL_STATE_ID = "cloudflare-dev-local";
+
+/**
+ * The branch selector behind {@link state}: dev runs ALWAYS resolve to the
+ * machine-local file store; everything else uses the Cloudflare-deployed
+ * HTTP store. Deterministic — the decision depends only on the run mode,
+ * never on whether Cloudflare credentials happen to be present.
+ *
+ * @internal exported for unit testing
+ */
+export const resolveStateStoreMode = (
+  context: { dev: boolean } | undefined,
+): "dev-local" | "cloud" => (context?.dev ? "dev-local" : "cloud");
+
+/**
+ * Init effect for the dev-local branch of {@link state}: the same
+ * machine-local file store as `Alchemy.localState()`
+ * (`.alchemy/state/<stack>/<stage>/`), re-labeled with
+ * {@link DEV_LOCAL_STATE_ID} for telemetry. Requires only `FileSystem` and
+ * `Path` — by construction it can never demand Cloudflare credentials.
+ *
+ * @internal exported for unit testing
+ */
+export const makeDevLocalState: Effect.Effect<
+  StateService,
+  never,
+  FileSystem.FileSystem | Path.Path
+> = Effect.gen(function* () {
+  yield* Clank.info(
+    "dev: Cloudflare.state() using local state at .alchemy/state",
+  );
+  const local = yield* makeLocalState();
+  return { ...local, id: DEV_LOCAL_STATE_ID };
+});
+
+/**
+ * State store layer backed by the Cloudflare-deployed HTTP state store (the
+ * `alchemy-state-store` Worker + Durable Object), bootstrapped/upgraded on
+ * first use.
+ *
+ * During `alchemy dev` (`AlchemyContext.dev`), the layer resolves to the
+ * machine-local file store at `.alchemy/state/<stack>/<stage>/` instead —
+ * always, regardless of whether Cloudflare credentials are available. Dev
+ * state describes machine-local emulator instances (`dev:` ids, localhost
+ * URLs, sidecar processes) that are meaningless on any other machine, so a
+ * cloud store holding those rows is wrong-shaped — and keeping dev state
+ * local means `alchemy dev` demands no Cloudflare credentials for state.
+ *
+ * Consequence: with `Cloudflare.state()`, dev and deploy state are disjoint.
+ * A deploy after a dev session starts from the cloud store and creates fresh
+ * live resources (no local→live mode-switch replacement), and a dev session
+ * never sees deploy rows — the same split `Alchemy.localState()` users
+ * already have between machines.
+ */
 export const state = () =>
   Layer.effect(
     State,
     Effect.gen(function* () {
+      // Resolve the run context FIRST: dev runs never touch the cloud store,
+      // so the branch must be decided before anything can demand credentials
+      // or prompt.
+      const alchemyContext = Option.getOrUndefined(
+        yield* Effect.serviceOption(AlchemyContext),
+      );
+      if (resolveStateStoreMode(alchemyContext) === "dev-local") {
+        const localContext = yield* Effect.context<
+          FileSystem.FileSystem | Path.Path
+        >();
+        return yield* Effect.cached(
+          makeDevLocalState.pipe(
+            recordStateStoreInit,
+            Effect.provideContext(localContext),
+          ),
+        );
+      }
       const isCI = yield* CI;
       const scriptName = STATE_STORE_SCRIPT_NAME;
       const profileName = yield* ALCHEMY_PROFILE;
@@ -66,9 +146,7 @@ export const state = () =>
       // `deploy --yes` flows in here (via AlchemyContext.updateStateStore) to
       // auto-accept an out-of-date state store upgrade instead of prompting.
       // Optional so callers that don't provide AlchemyContext keep the prompt.
-      const autoUpdateStateStore =
-        Option.getOrUndefined(yield* Effect.serviceOption(AlchemyContext))
-          ?.updateStateStore ?? false;
+      const autoUpdateStateStore = alchemyContext?.updateStateStore ?? false;
       const context = yield* Effect.context<Effect.Services<typeof init>>();
 
       const init = Effect.gen(function* () {

--- a/packages/alchemy/src/Cloudflare/Tunnel/TunnelLocalBinding.ts
+++ b/packages/alchemy/src/Cloudflare/Tunnel/TunnelLocalBinding.ts
@@ -21,9 +21,12 @@ export const makeLocalTunnelClient = <Client>(
 ) =>
   Effect.gen(function* () {
     // Account + credentials are ambient during stack-eval (the stack's
-    // providers layer). Capture the full context so cfd_tunnel HTTP ops can run
-    // with the current credentials — no `host.bind`, no minted token.
-    const { accountId } = yield* yield* CloudflareEnvironment;
+    // providers layer). Capture the full context so cfd_tunnel HTTP ops can
+    // run with the current credentials — no `host.bind`, no minted token. The
+    // accountId stays a DEFERRED effect: it only resolves when a tunnel HTTP
+    // op actually runs, so an all-local dev run never forces credential
+    // resolution just by building this layer.
+    const getEnv = yield* CloudflareEnvironment;
     const context = yield* Effect.context<
       Credentials | HttpClient.HttpClient
     >();
@@ -31,7 +34,7 @@ export const makeLocalTunnelClient = <Client>(
     return Effect.fn(function* () {
       const auth: TunnelAuth = {
         authorize: (eff) => eff.pipe(Effect.provideContext(context)),
-        accountId: Effect.succeed(accountId),
+        accountId: getEnv.pipe(Effect.map((env) => env.accountId)),
       };
       return makeClient(auth);
     });

--- a/packages/alchemy/src/Cloudflare/Workers/BrowserHttpClient.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/BrowserHttpClient.ts
@@ -31,7 +31,11 @@ export interface BrowserAuth {
   authorize: <A, E>(
     eff: Effect.Effect<A, E, Credentials | HttpClient.HttpClient>,
   ) => Effect.Effect<A, E>;
-  accountId: string;
+  /**
+   * Deferred so building a client never demands credential resolution — the
+   * account id resolves only when a browser action actually runs.
+   */
+  accountId: Effect.Effect<string>;
 }
 
 /** A byte stream produced by a binary {@link BrowserClient} action. */
@@ -60,11 +64,15 @@ type BrowserByteStream = Stream.Stream<
 export const makeHttpBrowserClient = (auth: BrowserAuth): BrowserClient => {
   // Run a distilled Browser Rendering op with the injected auth and surface
   // transport/API failures as {@link BrowserError} (matching the native
-  // binding's declared error channel).
+  // binding's declared error channel). The account id resolves per action —
+  // never at client construction — so building the client stays free of
+  // credential resolution.
   const run = <A, E>(
-    eff: Effect.Effect<A, E, Credentials | HttpClient.HttpClient>,
+    make: (
+      accountId: string,
+    ) => Effect.Effect<A, E, Credentials | HttpClient.HttpClient>,
   ): Effect.Effect<A, BrowserError, RuntimeContext> =>
-    auth.authorize(eff).pipe(
+    auth.authorize(Effect.flatMap(auth.accountId, make)).pipe(
       Effect.mapError(
         (cause) =>
           new BrowserError({
@@ -77,11 +85,11 @@ export const makeHttpBrowserClient = (auth: BrowserAuth): BrowserClient => {
   // The cf option types (`url`/`html` + puppeteer options) are structurally the
   // REST request body; add the account id and let distilled's encoder drop any
   // fields it doesn't model.
-  const req = (options: unknown) =>
-    ({ accountId: auth.accountId, ...(options as object) }) as never;
+  const req = (accountId: string, options: unknown) =>
+    ({ accountId, ...(options as object) }) as never;
 
   const content = (options: unknown) =>
-    run(browser.createContent(req(options))).pipe(
+    run((accountId) => browser.createContent(req(accountId, options))).pipe(
       Effect.map(
         (result): BrowserContentResult => ({
           success: true,
@@ -92,14 +100,14 @@ export const makeHttpBrowserClient = (auth: BrowserAuth): BrowserClient => {
     );
 
   const markdown = (options: unknown) =>
-    run(browser.createMarkdown(req(options))).pipe(
+    run((accountId) => browser.createMarkdown(req(accountId, options))).pipe(
       Effect.map(
         (result): BrowserMarkdownResult => ({ success: true, result }),
       ),
     );
 
   const links = (options: unknown) =>
-    run(browser.createLink(req(options))).pipe(
+    run((accountId) => browser.createLink(req(accountId, options))).pipe(
       Effect.map(
         (result): BrowserLinksResult => ({
           success: true,
@@ -109,12 +117,12 @@ export const makeHttpBrowserClient = (auth: BrowserAuth): BrowserClient => {
     );
 
   const json = (options: unknown) =>
-    run(browser.createJson(req(options))).pipe(
+    run((accountId) => browser.createJson(req(accountId, options))).pipe(
       Effect.map((result): BrowserJsonResult => ({ success: true, result })),
     );
 
   const scrape = (options: unknown) =>
-    run(browser.createScrape(req(options))).pipe(
+    run((accountId) => browser.createScrape(req(accountId, options))).pipe(
       Effect.map(
         (result): BrowserScrapeResult => ({
           success: true,
@@ -133,7 +141,7 @@ export const makeHttpBrowserClient = (auth: BrowserAuth): BrowserClient => {
     );
 
   const snapshot = (options: unknown) =>
-    run(browser.createSnapshot(req(options))).pipe(
+    run((accountId) => browser.createSnapshot(req(accountId, options))).pipe(
       Effect.map(
         (result): BrowserSnapshotResult => ({
           success: true,

--- a/packages/alchemy/src/Cloudflare/Workers/BrowserLocal.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/BrowserLocal.ts
@@ -45,14 +45,17 @@ export const BrowserLocal = Layer.effect(
   Effect.gen(function* () {
     // Account + credentials are ambient during stack-eval (the stack's
     // providers layer). Capture the full context so the REST ops run with the
-    // current credentials — no `host.bind`, no minted token.
-    const { accountId } = yield* yield* CloudflareEnvironment;
+    // current credentials — no `host.bind`, no minted token. The accountId
+    // stays a DEFERRED effect: it only resolves when a browser action
+    // actually runs, so an all-local dev run never forces credential
+    // resolution just by building this layer.
+    const getEnv = yield* CloudflareEnvironment;
     const context = yield* Effect.context<
       Credentials | HttpClient.HttpClient
     >();
     const auth: BrowserAuth = {
       authorize: (eff) => eff.pipe(Effect.provideContext(context)),
-      accountId,
+      accountId: getEnv.pipe(Effect.map((env) => env.accountId)),
     };
 
     return Effect.fn(function* (_binding: BrowserBinding) {

--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -64,7 +64,10 @@ import type * as Bundle from "../../Bundle/Bundle.ts";
 import * as LocalProvider from "../../Local/LocalProvider.ts";
 import { Stack } from "../../Stack.ts";
 import { unwrapRedacted } from "../../Util/index.ts";
-import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
+import {
+  CloudflareEnvironment,
+  probeAccountId,
+} from "../CloudflareEnvironment.ts";
 import {
   isLiveId,
   isLocalId,
@@ -141,6 +144,11 @@ export const LocalWorkerProvider = () =>
       const localRuntimeState = yield* LocalRuntimeState;
       const workerProxy = yield* WorkerProxy.WorkerProxy;
       const cloudflareEnv = yield* CloudflareEnvironment;
+      // Non-forcing accountId probe: the local worker must build, bundle,
+      // and serve without configured credentials (credential-free
+      // `alchemy dev`). Resolves only when stored config proves resolution
+      // is non-interactive; otherwise `undefined`.
+      const probeCurrentAccountId = probeAccountId(cloudflareEnv);
       const context = yield* Effect.context<RuntimeServices>();
       const rootScope = yield* Effect.scope;
 
@@ -171,6 +179,14 @@ export const LocalWorkerProvider = () =>
               if (!consumer.queueName) {
                 return yield* Effect.die(
                   `Consumer of live queue ${consumer.queueId} is missing its resolved queueName — re-deploy the consumer`,
+                );
+              }
+              // A live-queue consumer always reconciles through the pull
+              // path, which forces credential resolution and stamps the
+              // account — a missing accountId means a stale/corrupt row.
+              if (consumer.accountId === undefined) {
+                return yield* Effect.die(
+                  `Consumer of live queue ${consumer.queueId} is missing its accountId — re-deploy the consumer`,
                 );
               }
               consumers.push({
@@ -506,7 +522,7 @@ export const LocalWorkerProvider = () =>
         config: WorkerConfig,
         selfUrl: string | undefined,
       ) {
-        const { accountId } = yield* cloudflareEnv;
+        const accountId = yield* probeCurrentAccountId;
         // Resource-backed env entries (e.g. `env: { KV: namespace }`) are
         // represented by their binding descriptor (same name) — don't ALSO
         // serialize the resolved attributes as a duplicate json binding.
@@ -518,7 +534,12 @@ export const LocalWorkerProvider = () =>
           Text.local("ALCHEMY_WORKER_NAME", config.name),
           Text.local("ALCHEMY_STACK_NAME", stack.name),
           Text.local("ALCHEMY_STAGE", stack.stage),
-          Text.local("ALCHEMY_CLOUDFLARE_ACCOUNT_ID", accountId),
+          // Injected only when the account is known — in-worker HTTP
+          // capability fallbacks need it only against real (remote)
+          // resources, which require credentials anyway.
+          ...(accountId !== undefined
+            ? [Text.local("ALCHEMY_CLOUDFLARE_ACCOUNT_ID", accountId)]
+            : []),
           ...Object.entries(config.env ?? {})
             .filter(([key]) => !descriptorNames.has(key))
             .map(([key, value]) => {
@@ -931,7 +952,7 @@ export const LocalWorkerProvider = () =>
               }
             }
           }
-          const { accountId } = yield* cloudflareEnv;
+          const accountId = yield* probeCurrentAccountId;
           const urls =
             news.dev?.mode === "external"
               ? // news.dev.url may be an unresolved output; avoid trying to resolve it here.
@@ -960,7 +981,7 @@ export const LocalWorkerProvider = () =>
         }),
 
         start: Effect.fn(function* ({ id, config }) {
-          const { accountId } = yield* cloudflareEnv;
+          const accountId = yield* probeCurrentAccountId;
 
           // `dev: { mode: "external" }` opts out of running a local Worker
           // entirely — typically because an external dev process

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -1014,7 +1014,12 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
       | undefined;
     tags: string[] | undefined;
     durableObjectNamespaces: Record<string, string>;
-    accountId: string;
+    /**
+     * Always stamped by the live provider; the local (dev) provider stamps
+     * it opportunistically and leaves it `undefined` when no credentials
+     * are configured (credential-free `alchemy dev`).
+     */
+    accountId: string | undefined;
     routes: { id: string; pattern: string; zoneId: string }[];
     crons: string[];
     /**

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -4833,6 +4833,11 @@ export const LiveWorkerProvider = () =>
           );
         }),
         delete: Effect.fn(function* ({ output }) {
+          // Rows stamped by the local provider in a credential-free dev
+          // session have no accountId — deleting them live is a credential
+          // demand anyway, so fall back to the environment's account.
+          const acct =
+            output.accountId ?? (yield* yield* CloudflareEnvironment).accountId;
           // Version workers own a version, not the script — `workerName` is
           // the *parent's* script and must never be deleted here. Versions
           // can't be deleted through the API (they age out of Cloudflare's
@@ -4857,7 +4862,7 @@ export const LiveWorkerProvider = () =>
             );
             const { deployments } = yield* workers
               .listScriptDeployments({
-                accountId: output.accountId,
+                accountId: acct,
                 scriptName: output.versionOf,
               })
               .pipe(
@@ -4889,7 +4894,7 @@ export const LiveWorkerProvider = () =>
             }
             yield* workers
               .createScriptDeployment({
-                accountId: output.accountId,
+                accountId: acct,
                 scriptName: output.versionOf,
                 strategy: "percentage",
                 versions: [{ versionId: stable.versionId, percentage: 100 }],
@@ -4904,7 +4909,7 @@ export const LiveWorkerProvider = () =>
           // the script straight out of its dispatch namespace.
           if (output.namespace) {
             yield* deleteWorkerScript(
-              output.accountId,
+              acct,
               output.workerName,
               output.namespace,
             ).pipe(
@@ -4924,7 +4929,7 @@ export const LiveWorkerProvider = () =>
           // adopted workers whose domains we never recorded.
           const liveDomains = yield* workers
             .listDomains({
-              accountId: output.accountId,
+              accountId: acct,
               service: output.workerName,
             })
             .pipe(
@@ -4968,7 +4973,7 @@ export const LiveWorkerProvider = () =>
                   ? [
                       workers
                         .deleteDomain({
-                          accountId: output.accountId,
+                          accountId: acct,
                           domainId: d.id,
                         })
                         .pipe(
@@ -4996,29 +5001,39 @@ export const LiveWorkerProvider = () =>
               { concurrency: "unbounded" },
             );
           }
-          yield* deleteWorkerScript(
-            output.accountId,
-            output.workerName,
-            undefined,
-          ).pipe(Effect.catchTag("WorkerNotFound", () => Effect.void));
+          yield* deleteWorkerScript(acct, output.workerName, undefined).pipe(
+            Effect.catchTag("WorkerNotFound", () => Effect.void),
+          );
         }),
         tail: ({ output }) =>
-          telemetry.tailScript({
-            accountId: output.accountId,
-            scriptName: output.workerName,
-          }),
+          Stream.unwrap(
+            Effect.gen(function* () {
+              const accountId =
+                output.accountId ??
+                (yield* yield* CloudflareEnvironment).accountId;
+              return telemetry.tailScript({
+                accountId,
+                scriptName: output.workerName,
+              });
+            }),
+          ),
         logs: ({ output, options }) =>
-          telemetry.queryLogs({
-            accountId: output.accountId,
-            filters: [
-              {
-                key: "$workers.scriptName",
-                operation: "eq",
-                type: "string",
-                value: output.workerName,
-              },
-            ],
-            options,
+          Effect.gen(function* () {
+            const accountId =
+              output.accountId ??
+              (yield* yield* CloudflareEnvironment).accountId;
+            return yield* telemetry.queryLogs({
+              accountId,
+              filters: [
+                {
+                  key: "$workers.scriptName",
+                  operation: "eq",
+                  type: "string",
+                  value: output.workerName,
+                },
+              ],
+              options,
+            });
           }),
       });
     }),

--- a/packages/alchemy/src/Cloudflare/Workflows/Workflow.ts
+++ b/packages/alchemy/src/Cloudflare/Workflows/Workflow.ts
@@ -13,7 +13,11 @@ import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
 import type { RuntimeContext } from "../../RuntimeContext.ts";
 import { effectClass, taggedFunction } from "../../Util/effect.ts";
-import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
+import {
+  CloudflareEnvironment,
+  currentAccountId,
+  isAccountDrift,
+} from "../CloudflareEnvironment.ts";
 import { generateLocalId } from "../LocalRuntime.ts";
 import {
   Worker,
@@ -871,7 +875,12 @@ export interface WorkflowResourceAttrs {
   workflowName: string;
   className: string;
   scriptName: string;
-  accountId: string;
+  /**
+   * Always stamped by the live provider; the local (dev) provider stamps
+   * it opportunistically and leaves it `undefined` when no credentials
+   * are configured (credential-free `alchemy dev`).
+   */
+  accountId: string | undefined;
 }
 
 const WorkflowResourceTypeId = "Cloudflare.Workflow";
@@ -969,9 +978,10 @@ export const ProviderLive = () =>
       yield* Effect.logInfo(
         `Cloudflare Workflow delete: ${output.workflowName}`,
       );
+      const { accountId } = yield* yield* CloudflareEnvironment;
       yield* workflows
         .deleteWorkflow({
-          accountId: output.accountId,
+          accountId: output.accountId ?? accountId,
           workflowName: output.workflowName,
         })
         .pipe(Effect.catchTag("WorkflowNotFound", () => Effect.void));
@@ -989,10 +999,11 @@ export const ProviderLocal = () =>
   Provider.succeed(WorkflowResource, {
     stables: ["accountId"],
     diff: Effect.fn(function* ({ news, output }) {
-      const { accountId } = yield* yield* CloudflareEnvironment;
+      // Non-forcing probe: local diffs must never demand credentials.
+      const accountId = yield* currentAccountId;
       if (!output?.workflowId) return { action: "update" } as const;
       if (!isResolved(news)) return undefined;
-      if (output.accountId !== accountId) {
+      if (isAccountDrift(output.accountId, accountId)) {
         return { action: "replace" } as const;
       }
       // Fall through to the engine's default prop diff (className /
@@ -1003,13 +1014,14 @@ export const ProviderLocal = () =>
       return output ?? undefined;
     }),
     reconcile: Effect.fn(function* ({ news, output }) {
-      const { accountId } = yield* yield* CloudflareEnvironment;
       return {
         workflowId: output?.workflowId ?? generateLocalId(),
         workflowName: news.workflowName,
         className: news.className,
         scriptName: news.scriptName,
-        accountId: output?.accountId ?? accountId,
+        // Stamped opportunistically — `undefined` in a credential-free dev
+        // session; matches any account in the local diff.
+        accountId: output?.accountId ?? (yield* currentAccountId),
       };
     }),
     delete: Effect.fn(function* () {

--- a/packages/alchemy/src/Deploy.ts
+++ b/packages/alchemy/src/Deploy.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 import type * as Scope from "effect/Scope";
 import { AlchemyContext } from "./AlchemyContext.ts";
 import * as Apply from "./Apply.ts";
+import { demandPlanCredentials } from "./Auth/Demand.ts";
 import type { Input } from "./Input.ts";
 import * as Plan from "./Plan.ts";
 import { evalStack, type CompiledStack, type StackEffect } from "./Stack.ts";
@@ -27,6 +28,12 @@ export const deploy = <A>({
     (stack) =>
       Effect.gen(function* () {
         const plan = yield* Plan.make(stack, { force });
+        // Credential-free dev: demand cloud credentials up front (and only
+        // when the plan actually needs the cloud) so a fully-local dev
+        // deploy never touches them. See `Auth/Demand.ts`.
+        if (dev) {
+          yield* demandPlanCredentials(plan);
+        }
         const output = yield* Apply.apply(plan);
         return output as Input.Resolve<A>;
       }),

--- a/packages/alchemy/src/Destroy.ts
+++ b/packages/alchemy/src/Destroy.ts
@@ -3,6 +3,7 @@ import { Effect } from "effect";
 import type * as Scope from "effect/Scope";
 import type { AlchemyContext } from "./AlchemyContext.ts";
 import * as Apply from "./Apply.ts";
+import { demandPlanCredentials } from "./Auth/Demand.ts";
 import * as Plan from "./Plan.ts";
 import type { CompiledStack, StackEffect } from "./Stack.ts";
 import { evalStack } from "./Stack.ts";
@@ -22,6 +23,13 @@ export const destroy = ({
 }) =>
   evalStack(
     stack,
-    (stack) => Plan.destroy(stack).pipe(Effect.flatMap(Apply.apply)),
+    (stack) =>
+      Plan.destroy(stack).pipe(
+        // Credential-free dev: a dev destroy of a purely-local stack must
+        // never touch cloud credentials; rows stamped `providerMode:
+        // "live"` demand them up front. See `Auth/Demand.ts`.
+        Effect.tap((plan) => (dev ? demandPlanCredentials(plan) : Effect.void)),
+        Effect.flatMap(Apply.apply),
+      ),
     { stage, dev, scope },
   );

--- a/packages/alchemy/src/Test/Core.ts
+++ b/packages/alchemy/src/Test/Core.ts
@@ -229,12 +229,16 @@ export const toEffect = <A>(
     );
   }).pipe(
     Effect.provideService(AdoptPolicy, options.adopt ?? false),
-    Effect.provide(overrideAlchemyContext({ dev: resolveDev(options) })),
     // `options.state` (e.g. `Cloudflare.state()`) itself requires
     // `AuthProviders` to read credentials, so AuthProviders must be provided
     // AFTER the state layer or the state layer's requirement is never
     // satisfied — which surfaces as `Service not found: AuthProviders`.
     Effect.provide(options.state ?? State.localState()),
+    // AFTER (outside) the state layer, so the state layer builds with the
+    // dev-overridden AlchemyContext — `Cloudflare.state()` resolves to the
+    // local file store when `dev: true`, exactly like the CLI, where
+    // `execStack` provides the override outside `stack.services`.
+    Effect.provide(overrideAlchemyContext({ dev: resolveDev(options) })),
     Effect.provideService(AuthProviders, {}),
     Effect.provide(Layer.provideMerge(alchemyLayer, platformLayer)),
   );

--- a/packages/alchemy/test/Auth/CredentialDemand.test.ts
+++ b/packages/alchemy/test/Auth/CredentialDemand.test.ts
@@ -1,0 +1,528 @@
+/**
+ * The credential-demand seam for credential-free `alchemy dev`
+ * (`src/Auth/Demand.ts`):
+ *
+ *   - `collectCredentialDemands` scans a plan for rows that need live
+ *     credentials during a dev run: `remote()` rows, truthy `devRemote`
+ *     binding entries, and deletions of rows stamped `providerMode: "live"`.
+ *   - `demandCredentials` demands them exactly once, up front: no-op when
+ *     already configured, the provider's `configure` flow (with a reason
+ *     naming the demanding resources) when interactive, and the typed
+ *     `CredentialsRequired` failure when non-interactive.
+ *   - End-to-end: a fully-local dev deploy never touches credentials; a
+ *     dev plan with a `remote()` row in a non-interactive process fails
+ *     with `CredentialsRequired` BEFORE apply begins.
+ */
+import {
+  AuthProviderLayer,
+  AuthProviders,
+  type ConfigureContext,
+} from "@/Auth/AuthProvider.ts";
+import {
+  collectCredentialDemands,
+  CredentialsRequired,
+  credentialsRequired,
+  demandCredentials,
+} from "@/Auth/Demand.ts";
+import {
+  AlchemyProfile,
+  CONFIG_VERSION,
+  type AlchemyProfileProviders,
+  type ProfileService,
+} from "@/Auth/Profile.ts";
+import * as Alchemy from "@/index.ts";
+import { remote } from "@/ProviderMode.ts";
+import { InMemoryService, State, type ResourceState } from "@/State";
+import * as Test from "@/Test/Alchemy";
+import { describe, expect, it } from "alchemy-test";
+import * as ConfigProvider from "effect/ConfigProvider";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { v4 as uuidv4 } from "uuid";
+import {
+  BindingTarget,
+  Bucket,
+  inDev,
+  ModalResource,
+  TestLayers,
+} from "../test.resources.ts";
+
+// ── plan-scan detector ──────────────────────────────────────────────────────
+
+const { test } = Test.make({ providers: TestLayers() });
+
+describe("collectCredentialDemands", () => {
+  test.provider("an all-local dev plan demands nothing", (stack) =>
+    Effect.gen(function* () {
+      const plan = yield* inDev(
+        Effect.gen(function* () {
+          yield* ModalResource("A", { value: "v1" });
+          return {};
+        }).pipe(stack.plan),
+      );
+      expect(plan.resources["A"].mode).toEqual("local");
+      expect(collectCredentialDemands(plan)).toEqual([]);
+    }),
+  );
+
+  test.provider(
+    "a mode-agnostic (single-implementation) resource demands nothing",
+    (stack) =>
+      Effect.gen(function* () {
+        // Mode-agnostic providers run live even in dev, but they resolve
+        // credentials lazily exactly as they do today — the demand seam
+        // deliberately leaves them alone (mode === undefined).
+        const plan = yield* inDev(
+          Effect.gen(function* () {
+            yield* Bucket("B", {});
+            return {};
+          }).pipe(stack.plan),
+        );
+        expect(plan.resources["B"].mode).toBeUndefined();
+        expect(collectCredentialDemands(plan)).toEqual([]);
+      }),
+  );
+
+  test.provider("a remote() row in a dev plan demands its cloud", (stack) =>
+    Effect.gen(function* () {
+      const plan = yield* inDev(
+        Effect.gen(function* () {
+          yield* ModalResource("A", { value: "v1" }).pipe(remote());
+          return {};
+        }).pipe(stack.plan),
+      );
+      expect(collectCredentialDemands(plan)).toEqual([
+        {
+          provider: "Test",
+          resources: [{ fqn: "A", reason: "remote" }],
+        },
+      ]);
+    }),
+  );
+
+  test.provider(
+    "a truthy devRemote binding entry demands; a falsy one does not",
+    (stack) =>
+      Effect.gen(function* () {
+        const planFor = (devRemote: Record<string, boolean>) =>
+          inDev(
+            Effect.gen(function* () {
+              const host = yield* BindingTarget("Host", {});
+              yield* host.bind("Remote", {
+                env: {},
+                devRemote,
+              } as any);
+              return {};
+            }).pipe(stack.plan),
+          );
+
+        const demanding = yield* planFor({ FOO: true });
+        expect(collectCredentialDemands(demanding)).toEqual([
+          {
+            provider: "Test",
+            resources: [{ fqn: "Host", reason: "remote-binding" }],
+          },
+        ]);
+
+        const notDemanding = yield* planFor({ FOO: false });
+        expect(collectCredentialDemands(notDemanding)).toEqual([]);
+      }),
+  );
+
+  test.provider(
+    "deleting a live-stamped row during a dev run demands; a local-stamped one does not",
+    (stack) =>
+      Effect.gen(function* () {
+        // 1. deploy live (run default), then plan its removal in dev: the
+        //    delete resolves the LIVE provider (the mode that created the
+        //    row), so it needs credentials.
+        yield* Effect.gen(function* () {
+          yield* ModalResource("A", { value: "v1" });
+          return {};
+        }).pipe(stack.deploy);
+
+        const liveDelete = yield* inDev(stack.plan(Effect.succeed({})));
+        expect(collectCredentialDemands(liveDelete)).toEqual([
+          {
+            provider: "Test",
+            resources: [{ fqn: "A", reason: "live-delete" }],
+          },
+        ]);
+
+        // 2. flip the row to local (dev deploy), then plan its removal in
+        //    dev: a local delete needs no credentials.
+        yield* inDev(
+          Effect.gen(function* () {
+            yield* ModalResource("A", { value: "v1" });
+            return {};
+          }).pipe(stack.deploy),
+        );
+        const localDelete = yield* inDev(stack.plan(Effect.succeed({})));
+        expect(collectCredentialDemands(localDelete)).toEqual([]);
+
+        yield* stack.destroy();
+      }),
+  );
+});
+
+// ── CredentialsRequired formatting ──────────────────────────────────────────
+
+it.live("CredentialsRequired names the resources and the fix", () =>
+  Effect.sync(() => {
+    const error = credentialsRequired(
+      {
+        provider: "Cloudflare",
+        resources: [
+          { fqn: "MyStack/Queue", reason: "remote" },
+          { fqn: "MyStack/Worker", reason: "remote-binding" },
+          { fqn: "MyStack/Old", reason: "live-delete" },
+        ],
+      },
+      "default",
+    );
+    expect(error).toBeInstanceOf(CredentialsRequired);
+    expect(error.provider).toEqual("Cloudflare");
+    expect(error.resources).toEqual([
+      "MyStack/Queue",
+      "MyStack/Worker",
+      "MyStack/Old",
+    ]);
+    expect(error.reason).toEqual("remote, remote-binding, live-delete");
+    expect(error.message).toContain("Cloudflare credentials are required");
+    expect(error.message).toContain("profile 'default'");
+    expect(error.message).toContain("non-interactive");
+    expect(error.message).toContain(
+      "MyStack/Queue (runs against the real cloud via Alchemy.remote())",
+    );
+    expect(error.message).toContain(
+      "MyStack/Worker (has a binding that proxies to a remote resource (dev: { remote: true }))",
+    );
+    expect(error.message).toContain(
+      "MyStack/Old (deletes an instance that was deployed to the real cloud)",
+    );
+    expect(error.message).toContain("alchemy login --profile default");
+  }),
+);
+
+// ── demandCredentials ───────────────────────────────────────────────────────
+
+const FAKE_PROVIDER = "Test";
+
+/** In-memory ProfileService — never touches ~/.alchemy. */
+const inMemoryProfileLayer = (
+  initial: Record<string, AlchemyProfileProviders> = {},
+) => {
+  const profiles: Record<string, AlchemyProfileProviders> = { ...initial };
+  const service: ProfileService = {
+    readConfig: Effect.sync(() => ({ version: CONFIG_VERSION, profiles })),
+    writeConfig: () => Effect.void,
+    getProfile: (name) => Effect.sync(() => profiles[name]),
+    setProfile: (name, profile) =>
+      Effect.sync(() => {
+        profiles[name] = profile;
+      }),
+    deleteProfile: (name) =>
+      Effect.sync(() => {
+        if (!(name in profiles)) return false;
+        delete profiles[name];
+        return true;
+      }),
+    // Mirrors the real loadOrConfigure: stored config wins; otherwise the
+    // provider's configure flow runs and the result is persisted.
+    loadOrConfigure: (auth, profileName, ctx) =>
+      Effect.suspend(() => {
+        const stored = profiles[profileName]?.[auth.name];
+        if (stored) return Effect.succeed(stored as any);
+        return auth.configure(profileName, ctx).pipe(
+          Effect.tap((config) =>
+            Effect.sync(() => {
+              profiles[profileName] = {
+                ...profiles[profileName],
+                [auth.name]: config as any,
+              };
+            }),
+          ),
+        );
+      }),
+  };
+  return Layer.succeed(AlchemyProfile, service);
+};
+
+/** Proves the seam never consults the credential store. */
+const untouchableProfileLayer = Layer.succeed(AlchemyProfile, {
+  readConfig: Effect.die("credential store touched"),
+  writeConfig: () => Effect.die("credential store touched"),
+  getProfile: () => Effect.die("credential store touched"),
+  setProfile: () => Effect.die("credential store touched"),
+  deleteProfile: () => Effect.die("credential store touched"),
+  loadOrConfigure: () => Effect.die("configure flow entered"),
+} as ProfileService);
+
+const makeFakeAuth = () => {
+  const record = {
+    configureCalls: 0,
+    contexts: [] as ConfigureContext[],
+  };
+  const layer = AuthProviderLayer<{ method: string }, undefined>()(
+    FAKE_PROVIDER,
+    {
+      configure: (_profileName: string, ctx: ConfigureContext) =>
+        Effect.sync(() => {
+          record.configureCalls += 1;
+          record.contexts.push(ctx);
+          return { method: "fake" };
+        }),
+      login: () => Effect.void,
+      logout: () => Effect.void,
+      prettyPrint: () => Effect.void,
+      read: () => Effect.succeed(undefined),
+    },
+  );
+  return { record, layer };
+};
+
+const demandEnv = (
+  profileLayer: Layer.Layer<AlchemyProfile>,
+  authLayer: Layer.Layer<never, never, AuthProviders>,
+  config: Record<string, string> = {},
+) =>
+  Layer.mergeAll(profileLayer, authLayer).pipe(
+    Layer.provideMerge(
+      Layer.mergeAll(
+        Layer.succeed(AuthProviders, {}),
+        ConfigProvider.layer(ConfigProvider.fromUnknown(config)),
+      ),
+    ),
+  );
+
+const remoteDemand = {
+  provider: FAKE_PROVIDER,
+  resources: [{ fqn: "A", reason: "remote" as const }],
+};
+
+it.live("no demands → the credential store is never touched", () =>
+  Effect.gen(function* () {
+    const { record, layer } = makeFakeAuth();
+    yield* demandCredentials([]).pipe(
+      Effect.provide(demandEnv(untouchableProfileLayer, layer)),
+    );
+    expect(record.configureCalls).toBe(0);
+  }),
+);
+
+it.live("a demand for an unregistered cloud is skipped", () =>
+  Effect.gen(function* () {
+    const { layer } = makeFakeAuth();
+    yield* demandCredentials(
+      [
+        {
+          provider: "NoSuchCloud",
+          resources: [{ fqn: "A", reason: "remote" }],
+        },
+      ],
+      { nonInteractive: true },
+    ).pipe(Effect.provide(demandEnv(untouchableProfileLayer, layer)));
+  }),
+);
+
+it.live("already-configured credentials are never re-prompted", () =>
+  Effect.gen(function* () {
+    const profileName = `demand-${uuidv4()}`;
+    const { record, layer } = makeFakeAuth();
+    yield* demandCredentials([remoteDemand], { nonInteractive: true }).pipe(
+      Effect.provide(
+        demandEnv(
+          inMemoryProfileLayer({
+            [profileName]: { [FAKE_PROVIDER]: { method: "fake" } },
+          }),
+          layer,
+          { ALCHEMY_PROFILE: profileName },
+        ),
+      ),
+    );
+    expect(record.configureCalls).toBe(0);
+  }),
+);
+
+it.live(
+  "missing credentials + non-interactive → typed CredentialsRequired",
+  () =>
+    Effect.gen(function* () {
+      const profileName = `demand-${uuidv4()}`;
+      const { record, layer } = makeFakeAuth();
+      const error = yield* demandCredentials([remoteDemand], {
+        nonInteractive: true,
+      }).pipe(
+        Effect.provide(
+          demandEnv(inMemoryProfileLayer(), layer, {
+            ALCHEMY_PROFILE: profileName,
+          }),
+        ),
+        Effect.flip,
+      );
+      expect(error).toBeInstanceOf(CredentialsRequired);
+      const required = error as CredentialsRequired;
+      expect(required.provider).toEqual(FAKE_PROVIDER);
+      expect(required.resources).toEqual(["A"]);
+      expect(required.message).toContain(
+        `alchemy login --profile ${profileName}`,
+      );
+      // The configure flow must never have been entered (it would acquire
+      // an auth lockfile).
+      expect(record.configureCalls).toBe(0);
+    }),
+);
+
+it.live(
+  "missing credentials + interactive → configure runs once with the reason",
+  () =>
+    Effect.gen(function* () {
+      const profileName = `demand-${uuidv4()}`;
+      const { record, layer } = makeFakeAuth();
+      const env = demandEnv(inMemoryProfileLayer(), layer, {
+        ALCHEMY_PROFILE: profileName,
+      });
+
+      yield* demandCredentials([remoteDemand], {
+        nonInteractive: false,
+      }).pipe(Effect.provide(env));
+      expect(record.configureCalls).toBe(1);
+      expect(record.contexts[0]?.ci).toBe(false);
+      // The reason names the demanding resources so the prompt says WHY.
+      expect(record.contexts[0]?.reason).toContain(
+        "This dev session requires Test credentials",
+      );
+      expect(record.contexts[0]?.reason).toContain("A (runs against");
+
+      // Demanded exactly once: the configured profile short-circuits the
+      // next demand.
+      yield* demandCredentials([remoteDemand], {
+        nonInteractive: false,
+      }).pipe(Effect.provide(env));
+      expect(record.configureCalls).toBe(1);
+    }),
+);
+
+it.live("CI runs configure with ci: true instead of failing", () =>
+  Effect.gen(function* () {
+    const profileName = `demand-${uuidv4()}`;
+    const { record, layer } = makeFakeAuth();
+    yield* demandCredentials([remoteDemand], { nonInteractive: true }).pipe(
+      Effect.provide(
+        demandEnv(inMemoryProfileLayer(), layer, {
+          ALCHEMY_PROFILE: profileName,
+          CI: "true",
+        }),
+      ),
+    );
+    // In CI the provider picks its non-interactive default (env-var
+    // credentials) via configure(ctx.ci === true) — no prompt, no failure.
+    expect(record.configureCalls).toBe(1);
+    expect(record.contexts[0]?.ci).toBe(true);
+  }),
+);
+
+// ── end-to-end: the dev seam in Deploy.ts ───────────────────────────────────
+//
+// Runs the real `deploy(Stack)` entry point (the same code path `alchemy
+// dev` and the test harness use) with `dev: true`.
+
+const e2eAuth = makeFakeAuth();
+const e2eStore: Record<
+  string,
+  Record<string, Record<string, ResourceState>>
+> = {};
+const e2eStateLayer = Layer.succeed(State, InMemoryService(e2eStore));
+// The demand seam resolves Config through the ConfigProvider captured in
+// `stack.services` (innermost). The alchemy-test CLI exports `CI=true`
+// before imports (which would legitimately route the demand to the CI
+// env-credentials branch) — pin a deterministic provider with CI unset and
+// a unique, never-configured profile so the seam's non-CI, non-interactive
+// branch is what the test exercises. ProfileLive reads ~/.alchemy READ-ONLY
+// here: the demand fails before any configure flow could persist anything.
+const E2E_PROFILE = `demand-e2e-${uuidv4()}`;
+const e2eProviders = () =>
+  Layer.mergeAll(
+    TestLayers(),
+    e2eAuth.layer,
+    ConfigProvider.layer(
+      ConfigProvider.fromUnknown({ ALCHEMY_PROFILE: E2E_PROFILE }),
+    ),
+  );
+
+// The seam resolves ALCHEMY_PROFILE from the ambient env (evalStack rebuilds
+// its ConfigProvider from env/.env), and the real ProfileLive reads
+// ~/.alchemy/profiles.json READ-ONLY. The non-interactive test below pins a
+// unique, never-configured profile name via the env (exclusively) so the
+// demand deterministically finds nothing configured for "Test".
+const devHarness = Test.make({
+  providers: e2eProviders(),
+  state: e2eStateLayer,
+  dev: true,
+});
+
+const AllLocalStack = Alchemy.Stack(
+  "CredentialDemandAllLocal",
+  { providers: e2eProviders(), state: e2eStateLayer },
+  Effect.gen(function* () {
+    const a = yield* ModalResource("A", { value: "v1" });
+    return { runtime: a.runtime };
+  }),
+);
+
+const RemoteStack = Alchemy.Stack(
+  "CredentialDemandRemote",
+  { providers: e2eProviders(), state: e2eStateLayer },
+  Effect.gen(function* () {
+    const a = yield* ModalResource("A", { value: "v1" }).pipe(remote());
+    return { runtime: a.runtime };
+  }),
+);
+
+devHarness.test(
+  "an all-local dev deploy succeeds without any credential resolution",
+  Effect.gen(function* () {
+    const before = e2eAuth.record.configureCalls;
+    const output = yield* devHarness.deploy(AllLocalStack);
+    expect(output.runtime).toEqual("local");
+    // No credential resolution: the fake auth provider's configure flow
+    // never ran (a demand would have — this profile has nothing stored).
+    expect(e2eAuth.record.configureCalls).toBe(before);
+  }),
+);
+
+devHarness.test(
+  "a remote() row in a non-interactive dev deploy fails with CredentialsRequired before apply",
+  Effect.gen(function* () {
+    // Force non-interactivity deterministically (ALCHEMY_PLAIN wins over
+    // every other isNonInteractive() signal), restore afterwards.
+    const previous = yield* Effect.sync(() => {
+      const prior = process.env.ALCHEMY_PLAIN;
+      process.env.ALCHEMY_PLAIN = "1";
+      return prior;
+    });
+    const error = yield* devHarness.deploy(RemoteStack).pipe(
+      Effect.flip,
+      Effect.ensuring(
+        Effect.sync(() => {
+          if (previous === undefined) {
+            delete process.env.ALCHEMY_PLAIN;
+          } else {
+            process.env.ALCHEMY_PLAIN = previous;
+          }
+        }),
+      ),
+    );
+    expect(error).toBeInstanceOf(CredentialsRequired);
+    const required = error as CredentialsRequired;
+    expect(required.provider).toEqual("Test");
+    expect(required.resources).toEqual(["A"]);
+    expect(required.message).toContain(
+      `alchemy login --profile ${E2E_PROFILE}`,
+    );
+    // Demand fails BEFORE apply: nothing was reconciled or persisted.
+    expect(e2eStore.CredentialDemandRemote?.test?.A).toBeUndefined();
+    expect(e2eAuth.record.configureCalls).toBe(0);
+  }),
+  { exclusive: true },
+);

--- a/packages/alchemy/test/Cloudflare/AI/ProviderKey.test.ts
+++ b/packages/alchemy/test/Cloudflare/AI/ProviderKey.test.ts
@@ -165,7 +165,7 @@ test.provider(
       // The replaced secret is reclaimed — no orphan left in the store.
       const oldSecret = yield* secretsStore
         .getStoreSecret({
-          accountId: initial.secret.accountId,
+          accountId: initial.secret.accountId!,
           storeId: initial.secret.storeId,
           secretId: initial.secret.secretId,
         })
@@ -214,7 +214,7 @@ test.provider(
       // `SecretNotFound`, not `StoreNotFound`.
       const secretAfter = yield* secretsStore
         .getStoreSecret({
-          accountId: deployed.secret.accountId,
+          accountId: deployed.secret.accountId!,
           storeId: deployed.secret.storeId,
           secretId: deployed.secret.secretId,
         })

--- a/packages/alchemy/test/Cloudflare/CredentialFree/AccountDrift.test.ts
+++ b/packages/alchemy/test/Cloudflare/CredentialFree/AccountDrift.test.ts
@@ -1,0 +1,183 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Test from "@/Test/Alchemy";
+import { expect } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Redacted from "effect/Redacted";
+import { AlchemyContext } from "@/AlchemyContext.ts";
+import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment.ts";
+import { localRuntimeServices } from "@/Cloudflare/LocalRuntime.ts";
+import type { CloudflareResolvedCredentials } from "@/Cloudflare/Auth/AuthProvider.ts";
+import { AlchemyProfile, type ProfileService } from "@/Auth/Profile.ts";
+
+/**
+ * The local-mode account-drift rule, end to end through plan/apply:
+ *
+ * - a local row stamped `accountId: undefined` (created credential-free)
+ *   is NEVER replaced when credentials later become available — the first
+ *   deploy after `alchemy login` must not wipe local data;
+ * - once an account IS stamped, switching to a *different* account
+ *   replaces the local resource (fresh identity, fresh data);
+ * - un-stamped siblings are untouched by the switch.
+ *
+ * Credential state is simulated with a mutable `CloudflareEnvironment` +
+ * `AlchemyProfile` override pair: `currentCreds === undefined` models the
+ * logged-out state (profile unconfigured, forcing dies), a value models a
+ * logged-in account. The overrides only reach providers running in this
+ * process, so the suite uses `sidecar: false` (in-process dev — the same
+ * path a plain `alchemy deploy` takes when touching local-mode rows) and a
+ * plain (non-RPC) local provider, KV.
+ */
+
+const ACCOUNT_A = "a".repeat(32);
+const ACCOUNT_B = "b".repeat(32);
+
+const makeCreds = (accountId: string): CloudflareResolvedCredentials => ({
+  type: "apiToken",
+  apiToken: Redacted.make("test-token"),
+  accountId,
+  source: { type: "env" },
+});
+
+let currentCreds: CloudflareResolvedCredentials | undefined;
+
+const envOverride = Layer.succeed(
+  CloudflareEnvironment,
+  CloudflareEnvironment.of(
+    Effect.suspend(() =>
+      currentCreds !== undefined
+        ? Effect.succeed(currentCreds)
+        : Effect.die(
+            new Error(
+              "CloudflareEnvironment was forced during a credential-free local run",
+            ),
+          ),
+    ),
+  ),
+);
+
+const profileOverride = Layer.succeed(
+  AlchemyProfile,
+  AlchemyProfile.of({
+    readConfig: Effect.sync(() => ({
+      version: 0 as const,
+      profiles: {},
+    })),
+    writeConfig: () => Effect.void,
+    getProfile: () =>
+      Effect.sync(() =>
+        currentCreds !== undefined
+          ? { Cloudflare: { method: "env" } }
+          : undefined,
+      ),
+    setProfile: () => Effect.void,
+    deleteProfile: () => Effect.succeed(false),
+    loadOrConfigure: () =>
+      Effect.die(
+        new Error(
+          "loadOrConfigure was called during a credential-free local run",
+        ),
+      ),
+  } satisfies ProfileService),
+);
+
+const { test } = Test.make({
+  providers: Layer.mergeAll(envOverride, profileOverride).pipe(
+    Layer.provideMerge(Cloudflare.providers()),
+  ),
+  dev: true,
+  sidecar: false,
+});
+
+/**
+ * Guard-rail for the eager local-variant build (`ProviderLayer.dual`
+ * builds the run-default variant eagerly in dev): the shared local-runtime
+ * dependency layer must BUILD against a `CloudflareEnvironment` whose
+ * resolution dies on force — construction is credential-free today; pin it.
+ * (The `accountId` handed to the runtime is a deferred effect, only forced
+ * if the runtime actually needs the account for a remote call.)
+ */
+test(
+  "localRuntimeServices builds against a CloudflareEnvironment that dies on force",
+  Effect.gen(function* () {
+    currentCreds = undefined;
+    const fs = yield* FileSystem.FileSystem;
+    const dir = yield* fs.makeTempDirectory({ prefix: "alchemy-credfree-" });
+    const context = yield* Layer.build(
+      localRuntimeServices() as Layer.Layer<unknown, unknown, never>,
+    ).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          envOverride,
+          Layer.succeed(AlchemyContext, {
+            dotAlchemy: dir,
+            dev: true,
+            adopt: false,
+          }),
+        ),
+      ),
+      Effect.scoped,
+    );
+    expect(context).toBeDefined();
+  }),
+  { timeout: 60_000 },
+);
+
+test.provider(
+  "login after a credential-free deploy is a noop; a real account switch replaces",
+  (stack) =>
+    Effect.gen(function* () {
+      currentCreds = undefined;
+      yield* stack.destroy();
+
+      const makeStack = (kvTitle?: string) =>
+        Effect.gen(function* () {
+          const kv = yield* Cloudflare.KV.Namespace(
+            "DriftKV",
+            kvTitle === undefined ? {} : { title: kvTitle },
+          );
+          // A sibling that stays un-stamped for the whole test — the
+          // account switch in the final phase must not touch it.
+          const bucket = yield* Cloudflare.R2.Bucket("DriftBucket");
+          return { kv, bucket };
+        });
+
+      // ── Phase 1: credential-free create — nothing stamped ─────────────
+      const v1 = yield* stack.deploy(makeStack());
+      expect(v1.kv.namespaceId).toMatch(/^dev:/);
+      expect(v1.kv.accountId).toBeUndefined();
+      expect(v1.bucket.accountId).toBeUndefined();
+
+      // ── Phase 2: "the user logs in" — the first credentialed deploy is
+      // a NOOP, never a replacement (undefined matches any account) ──────
+      currentCreds = makeCreds(ACCOUNT_A);
+      const v2 = yield* stack.deploy(makeStack());
+      expect(v2.kv.namespaceId).toBe(v1.kv.namespaceId);
+      expect(v2.bucket.bucketName).toBe(v1.bucket.bucketName);
+      // A noop keeps the persisted attributes — still un-stamped.
+      expect(v2.kv.accountId).toBeUndefined();
+
+      // ── Phase 3: an unrelated prop change updates in place and stamps
+      // the now-known account opportunistically ──────────────────────────
+      const v3 = yield* stack.deploy(makeStack("drift-kv-renamed"));
+      expect(v3.kv.namespaceId).toBe(v1.kv.namespaceId);
+      expect(v3.kv.title).toBe("drift-kv-renamed");
+      expect(v3.kv.accountId).toBe(ACCOUNT_A);
+
+      // ── Phase 4: a REAL account switch (both sides known + different)
+      // replaces the stamped resource; the un-stamped sibling is untouched
+      currentCreds = makeCreds(ACCOUNT_B);
+      const v4 = yield* stack.deploy(makeStack("drift-kv-renamed"));
+      expect(v4.kv.namespaceId).not.toBe(v3.kv.namespaceId);
+      expect(v4.kv.namespaceId).toMatch(/^dev:/);
+      expect(v4.kv.accountId).toBe(ACCOUNT_B);
+      expect(v4.bucket.bucketName).toBe(v1.bucket.bucketName);
+      expect(v4.bucket.accountId).toBeUndefined();
+
+      // ── Teardown: destroy must work logged-out again ──────────────────
+      currentCreds = undefined;
+      yield* stack.destroy();
+    }),
+  { timeout: 120_000 },
+);

--- a/packages/alchemy/test/Cloudflare/CredentialFree/CredentialFreeLocal.test.ts
+++ b/packages/alchemy/test/Cloudflare/CredentialFree/CredentialFreeLocal.test.ts
@@ -1,0 +1,198 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Test from "@/Test/Alchemy";
+import { expect } from "alchemy-test";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Redacted from "effect/Redacted";
+import { MinimumLogLevel } from "effect/References";
+import * as Schedule from "effect/Schedule";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as pathe from "pathe";
+import { configFilePath } from "@/Auth/Profile.ts";
+
+/**
+ * Credential-free `alchemy dev`: an all-local stack must deploy, serve, and
+ * tear down with ZERO Cloudflare credential resolutions.
+ *
+ * The suite pins the real mechanism, through the real `alchemy dev` process
+ * topology (RPC sidecar): it runs under a profile name that has NO stored
+ * configuration (asserted below). In this state:
+ *
+ * - the non-forcing `currentAccountId` probe sees no stored Cloudflare
+ *   config and returns `undefined` WITHOUT attempting resolution, so local
+ *   attributes are stamped `accountId: undefined`;
+ * - any code path that still *forces* `CloudflareEnvironment` hits
+ *   `loadOrConfigure`, which fails (`AuthError`, non-interactive, no
+ *   prompt) and crashes the deploy — every forced resolution is loud.
+ *
+ * This is exactly the state of a fresh machine that has never run
+ * `alchemy login`.
+ */
+const CREDENTIAL_FREE_PROFILE = "alchemy-test-credential-free";
+
+const { test } = Test.make({
+  providers: Cloudflare.providers(),
+  dev: true,
+  profile: CREDENTIAL_FREE_PROFILE,
+});
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+class WorkerNotReady extends Data.TaggedError("WorkerNotReady")<{
+  status: number;
+}> {}
+
+const getJsonReady = (url: string) =>
+  Effect.gen(function* () {
+    const client = yield* HttpClient.HttpClient;
+    const res = yield* client.get(url).pipe(
+      Effect.flatMap((res) =>
+        res.status === 200
+          ? Effect.succeed(res)
+          : Effect.fail(new WorkerNotReady({ status: res.status })),
+      ),
+      Effect.retry({
+        while: (e): e is WorkerNotReady => e instanceof WorkerNotReady,
+        schedule: Schedule.max([
+          Schedule.min([
+            Schedule.exponential("500 millis"),
+            Schedule.spaced("2 seconds"),
+          ]),
+          Schedule.recurs(10),
+        ]),
+      }),
+    );
+    return yield* res.json;
+  }).pipe(Effect.orDie);
+
+/**
+ * Guard-rail: the test profile must actually be unconfigured, or the suite
+ * would silently test the credentialed path. If this fails, delete the
+ * profile from `~/.alchemy/profiles.json`.
+ */
+const assertProfileUnconfigured = Effect.gen(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const raw = yield* fs
+    .readFileString(configFilePath)
+    .pipe(Effect.orElseSucceed(() => "{}"));
+  const parsed = yield* Effect.try({
+    try: () => JSON.parse(raw) as { profiles?: Record<string, unknown> },
+    catch: () => ({}) as { profiles?: Record<string, unknown> },
+  }).pipe(
+    Effect.orElseSucceed(() => ({}) as { profiles?: Record<string, unknown> }),
+  );
+  expect(parsed.profiles?.[CREDENTIAL_FREE_PROFILE]).toBeUndefined();
+});
+
+test.provider(
+  "all-local stack deploys, serves, and destroys with zero credential resolutions",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* assertProfileUnconfigured;
+      yield* stack.destroy();
+
+      const deployed = yield* stack.deploy(
+        Effect.gen(function* () {
+          const kv = yield* Cloudflare.KV.Namespace("CredFreeKV");
+          const bucket = yield* Cloudflare.R2.Bucket("CredFreeBucket");
+          const db = yield* Cloudflare.D1.Database("CredFreeDB");
+          const queue = yield* Cloudflare.Queues.Queue("CredFreeQueue");
+          const store = yield* Cloudflare.SecretsStore.Store("CredFreeStore");
+          const secret = yield* Cloudflare.SecretsStore.Secret(
+            "CredFreeSecret",
+            {
+              store,
+              value: Redacted.make("sk-credential-free"),
+            },
+          );
+          const worker = yield* Cloudflare.Worker("cred-free-worker", {
+            main: pathe.resolve(
+              import.meta.dirname,
+              "fixtures/credential-free-worker.ts",
+            ),
+            env: {
+              KV: kv,
+              BUCKET: bucket,
+              DB: db,
+              QUEUE: queue,
+              SECRET: secret,
+            },
+          });
+          const consumer = yield* Cloudflare.Queues.Consumer(
+            "CredFreeConsumer",
+            {
+              queueId: queue.queueId,
+              scriptName: worker.workerName,
+            },
+          );
+          return { kv, bucket, db, queue, store, secret, worker, consumer };
+        }),
+      );
+
+      // Every local resource fabricated a `dev:` identity — proof no cloud
+      // call ran — and no accountId was stamped: the non-forcing probe
+      // returned `undefined` (a forced resolution would have failed the
+      // deploy with an AuthError).
+      expect(deployed.kv.namespaceId).toMatch(/^dev:/);
+      expect(deployed.bucket.bucketName).toMatch(/^dev:/);
+      expect(deployed.db.databaseId).toMatch(/^dev:/);
+      expect(deployed.queue.queueId).toMatch(/^dev:/);
+      expect(deployed.store.storeId).toMatch(/^dev:/);
+      expect(deployed.secret.secretId).toMatch(/^dev:/);
+      expect(deployed.consumer.consumerId).toMatch(/^dev:/);
+      expect(deployed.worker.url).toMatch(/^http:\/\/localhost:\d+$/);
+      expect(deployed.kv.accountId).toBeUndefined();
+      expect(deployed.bucket.accountId).toBeUndefined();
+      expect(deployed.db.accountId).toBeUndefined();
+      expect(deployed.queue.accountId).toBeUndefined();
+      expect(deployed.store.accountId).toBeUndefined();
+      expect(deployed.secret.accountId).toBeUndefined();
+      expect(deployed.consumer.accountId).toBeUndefined();
+      expect(deployed.worker.accountId).toBeUndefined();
+
+      // Full local data plane over the worker's native bindings.
+      const kvBody = (yield* getJsonReady(`${deployed.worker.url}/kv`)) as {
+        value: string | null;
+      };
+      expect(kvBody.value).toBe("hello-kv");
+
+      const r2Body = (yield* getJsonReady(`${deployed.worker.url}/r2`)) as {
+        text: string | null;
+      };
+      expect(r2Body.text).toBe("hello-r2");
+
+      const d1Body = (yield* getJsonReady(`${deployed.worker.url}/d1`)) as {
+        names: string[];
+      };
+      expect(d1Body.names).toEqual(["alice"]);
+
+      const secretBody = (yield* getJsonReady(
+        `${deployed.worker.url}/secret`,
+      )) as { value: string };
+      expect(secretBody.value).toBe("sk-credential-free");
+
+      const sent = (yield* getJsonReady(
+        `${deployed.worker.url}/queue/send?text=cred-free`,
+      )) as { sent: string };
+      expect(sent.sent).toBe("cred-free");
+      const received = yield* getJsonReady(
+        `${deployed.worker.url}/queue/received`,
+      ).pipe(
+        Effect.map((body) => (body as { received: string[] }).received),
+        Effect.repeat({
+          schedule: Schedule.spaced("500 millis"),
+          until: (received) => received.includes("cred-free"),
+          times: 30,
+        }),
+      );
+      expect(received).toContain("cred-free");
+
+      // Teardown must also be credential-free.
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 240_000 },
+);

--- a/packages/alchemy/test/Cloudflare/CredentialFree/fixtures/credential-free-worker.ts
+++ b/packages/alchemy/test/Cloudflare/CredentialFree/fixtures/credential-free-worker.ts
@@ -1,0 +1,84 @@
+// Async (non-Effect) Worker exercising every major local binding in one
+// script — KV, R2, D1, Queues (producer + consumer), and a Secrets Store
+// secret — so the credential-free suite can prove the whole local data
+// plane works without any configured Cloudflare credentials.
+interface Env {
+  KV: {
+    put(key: string, value: string): Promise<void>;
+    get(key: string): Promise<string | null>;
+  };
+  BUCKET: {
+    put(key: string, value: string): Promise<unknown>;
+    get(key: string): Promise<{ text(): Promise<string> } | null>;
+  };
+  DB: {
+    exec(sql: string): Promise<{ count: number }>;
+    prepare(sql: string): {
+      bind(...params: unknown[]): {
+        run(): Promise<{ success: boolean }>;
+        all<T>(): Promise<{ results: T[] }>;
+      };
+      run(): Promise<{ success: boolean }>;
+      all<T>(): Promise<{ results: T[] }>;
+    };
+  };
+  QUEUE: {
+    send(body: unknown, options?: { contentType?: string }): Promise<void>;
+  };
+  SECRET: { get(): Promise<string> };
+}
+
+const received: string[] = [];
+
+export default {
+  fetch: async (request: Request, env: Env) => {
+    const url = new URL(request.url);
+    if (url.pathname === "/kv") {
+      await env.KV.put("greeting", "hello-kv");
+      const value = await env.KV.get("greeting");
+      return Response.json({ value });
+    }
+    if (url.pathname === "/r2") {
+      await env.BUCKET.put("greeting.txt", "hello-r2");
+      const object = await env.BUCKET.get("greeting.txt");
+      return Response.json({
+        text: object === null ? null : await object.text(),
+      });
+    }
+    if (url.pathname === "/d1") {
+      await env.DB.exec(
+        "CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY, name TEXT NOT NULL)",
+      );
+      await env.DB.prepare("DELETE FROM users").run();
+      await env.DB.prepare("INSERT INTO users (name) VALUES (?)")
+        .bind("alice")
+        .run();
+      const all = await env.DB.prepare(
+        "SELECT name FROM users ORDER BY name",
+      ).all<{ name: string }>();
+      return Response.json({ names: all.results.map((r) => r.name) });
+    }
+    if (url.pathname === "/queue/send") {
+      const text = url.searchParams.get("text") ?? "hello-queue";
+      await env.QUEUE.send(text, { contentType: "text" });
+      return Response.json({ sent: text });
+    }
+    if (url.pathname === "/queue/received") {
+      return Response.json({ received });
+    }
+    if (url.pathname === "/secret") {
+      try {
+        const value = await env.SECRET.get();
+        return Response.json({ value });
+      } catch (e) {
+        return Response.json({ error: (e as Error).message }, { status: 404 });
+      }
+    }
+    return new Response("not found", { status: 404 });
+  },
+  queue: async (batch: { messages: Array<{ body: unknown }> }) => {
+    for (const message of batch.messages) {
+      received.push(String(message.body));
+    }
+  },
+};

--- a/packages/alchemy/test/Cloudflare/StateStore/DevLocalState.test.ts
+++ b/packages/alchemy/test/Cloudflare/StateStore/DevLocalState.test.ts
@@ -1,0 +1,178 @@
+import { AlchemyContext } from "@/AlchemyContext.ts";
+import { AuthProviders } from "@/Auth/AuthProvider.ts";
+import * as Cloudflare from "@/Cloudflare";
+import {
+  DEV_LOCAL_STATE_ID,
+  makeDevLocalState,
+  resolveStateStoreMode,
+} from "@/Cloudflare/StateStore/State.ts";
+import { State, type StateService } from "@/State/State.ts";
+import { NodeServices } from "@effect/platform-node";
+import { describe, expect, it } from "alchemy-test";
+import * as ConfigProvider from "effect/ConfigProvider";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import { ArtifactStore, createArtifactStore } from "@/Artifacts.ts";
+import { LoggingCli } from "@/Cli/LoggingCli.ts";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+
+/**
+ * Unit coverage for the dev-mode branch of `Cloudflare.state()`:
+ *
+ * - `alchemy dev` (`AlchemyContext.dev === true`) ALWAYS resolves to the
+ *   machine-local file store — deterministically, never dependent on whether
+ *   Cloudflare credentials happen to exist. The whole environment below is
+ *   scrubbed (empty AuthProviders registry, a profile name that cannot have
+ *   stored credentials, CI so nothing can prompt), so any credential demand
+ *   would fail loudly instead of silently authenticating with the machine's
+ *   real profile.
+ * - non-dev keeps the cloud init path: the layer still BUILDS lazily without
+ *   credentials, and first use dies on credential resolution in the scrubbed
+ *   environment (the seam right before any cloud/bootstrap work).
+ */
+
+/** Deterministic scratch namespace — cleaned up by each test. */
+const STACK = "CfDevLocalStateUnit";
+
+const sampleState = (fqn: string, instanceId: string) => ({
+  kind: "resource" as const,
+  resourceType: "Test.Resource",
+  namespace: undefined,
+  fqn,
+  logicalId: fqn.split("/").pop()!,
+  instanceId,
+  providerVersion: 1,
+  status: "created" as const,
+  downstream: [],
+  bindings: [],
+  props: { hello: "world" },
+  attr: { id: instanceId },
+});
+
+/**
+ * Fully scrubbed environment: an empty AuthProviders registry (the
+ * `CloudflareAuth` layer inside `Cloudflare.state()` registers into it), a
+ * profile that cannot exist in `~/.alchemy`, and `CI` so `loadOrConfigure`
+ * bails instead of prompting. Any code path that demands Cloudflare
+ * credentials fails in this environment.
+ */
+const scrubbedEnv = (dev: boolean) =>
+  Layer.mergeAll(
+    Layer.succeed(AuthProviders, {}),
+    Layer.succeed(AlchemyContext, {
+      dev,
+      adopt: false,
+      dotAlchemy: ".alchemy",
+    }),
+    Layer.succeed(
+      ConfigProvider.ConfigProvider,
+      ConfigProvider.fromUnknown({
+        ALCHEMY_PROFILE: "cf-dev-local-state-unit-nonexistent-profile",
+        CI: "true",
+      }),
+    ),
+    NodeServices.layer,
+    FetchHttpClient.layer,
+  );
+
+const stateLayer = (dev: boolean) =>
+  Cloudflare.state().pipe(
+    Layer.provide(scrubbedEnv(dev)),
+    // The state layer's type also carries the cloud branch's renderer and
+    // artifact requirements; satisfy them so the tests stay self-contained.
+    Layer.provide(
+      Layer.mergeAll(
+        LoggingCli,
+        Layer.succeed(ArtifactStore, createArtifactStore()),
+      ),
+    ),
+  );
+
+const roundtrip = (store: StateService) =>
+  Effect.gen(function* () {
+    const stage = "unit";
+    const fqn = "stack/scope/resource-a";
+    yield* store.deleteStack({ stack: STACK });
+    const echoed = yield* store.set({
+      stack: STACK,
+      stage,
+      fqn,
+      value: sampleState(fqn, "inst-a"),
+    });
+    expect(echoed.instanceId).toBe("inst-a");
+    const got = yield* store.get({ stack: STACK, stage, fqn });
+    expect(got?.fqn).toBe(fqn);
+    expect((got as any).props).toEqual({ hello: "world" });
+    const fqns = yield* store.list({ stack: STACK, stage });
+    expect([...fqns]).toEqual([fqn]);
+    yield* store.deleteStack({ stack: STACK });
+  });
+
+describe("Cloudflare.state() dev-local branch", () => {
+  it("resolveStateStoreMode is deterministic on the run mode", () => {
+    expect(resolveStateStoreMode({ dev: true })).toBe("dev-local");
+    expect(resolveStateStoreMode({ dev: false })).toBe("cloud");
+    // No AlchemyContext at all (bare library use) keeps the cloud store.
+    expect(resolveStateStoreMode(undefined)).toBe("cloud");
+  });
+
+  it.live("makeDevLocalState needs only FileSystem + Path", () =>
+    Effect.gen(function* () {
+      const store = yield* makeDevLocalState;
+      expect(store.id).toBe(DEV_LOCAL_STATE_ID);
+      yield* roundtrip(store);
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  it.live(
+    "dev: true resolves Cloudflare.state() to the local file store without credentials",
+    () =>
+      Effect.gen(function* () {
+        const store = yield* yield* State;
+        expect(store.id).toBe(DEV_LOCAL_STATE_ID);
+
+        // Proof the rows land on the local disk (same layout as
+        // Alchemy.localState()) before the roundtrip cleans up after itself.
+        const fqn = "stack/scope/on-disk";
+        yield* store.set({
+          stack: STACK,
+          stage: "disk",
+          fqn,
+          value: sampleState(fqn, "inst-disk"),
+        });
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const dir = path.join(process.cwd(), ".alchemy", "state", STACK);
+        expect(yield* fs.exists(dir)).toBe(true);
+
+        yield* roundtrip(store);
+      }).pipe(
+        Effect.provide(Layer.mergeAll(stateLayer(true), NodeServices.layer)),
+      ),
+  );
+
+  it.live(
+    "dev: false keeps the cloud init path (builds lazily, demands credentials on first use)",
+    () =>
+      Effect.gen(function* () {
+        // Layer BUILD must succeed without credentials — the cloud init is
+        // deferred to first use.
+        const init = yield* State;
+        // First use walks the cloud path: in the scrubbed environment the
+        // credential force fails (AuthError -> orDie) BEFORE any bootstrap
+        // work. A dev-local store here would be a branch-selection bug.
+        const exit = yield* Effect.exit(init);
+        if (Exit.isSuccess(exit)) {
+          expect(exit.value.id).not.toBe(DEV_LOCAL_STATE_ID);
+          throw new Error(
+            `expected the scrubbed cloud init to fail, got store '${exit.value.id}'`,
+          );
+        }
+        expect(Exit.isFailure(exit)).toBe(true);
+      }).pipe(Effect.provide(stateLayer(false))),
+    { timeout: 30_000 },
+  );
+});

--- a/website/src/content/docs/state-store/index.mdx
+++ b/website/src/content/docs/state-store/index.mdx
@@ -72,9 +72,23 @@ already running on Cloudflare. It persists state in a Worker backed
 by a Durable Object with embedded SQLite, with the auth token and
 encryption key kept in your account's Secrets Store.
 
+### Local state during `alchemy dev`
+
+During `alchemy dev`, `Cloudflare.state()` resolves to the local
+file store (`.alchemy/state/`) instead of the cloud store. This is
+always the case in dev, whether or not Cloudflare credentials are
+configured. Dev state describes emulator instances on your machine —
+`dev:` ids, localhost URLs — so it belongs on your machine, and
+`alchemy dev` starts without any Cloudflare credentials for state.
+
+One consequence: dev and deploy state are disjoint. A deploy after a
+dev session reads the cloud store and creates fresh live resources,
+and a dev session never sees deploy rows. This matches the split
+`Alchemy.localState()` users already have between machines.
+
 ### First-run bootstrap
 
-The first time you run `alchemy deploy`, `plan`, or `dev` against a
+The first time you run `alchemy deploy` or `plan` against a
 stack configured with `Cloudflare.state()`, Alchemy can't find the
 state-store Worker on your account and pauses to ask permission
 before deploying it. Confirming kicks off a one-time deploy of the


### PR DESCRIPTION
`alchemy dev` now runs with **zero Cloudflare configuration** when every resource resolves to a local provider — no profile, no env vars, no login. Credentials are demanded lazily, exactly once, and only when the plan actually needs the real cloud.

```sh
# fresh machine, nothing configured
bun alchemy dev   # plans, applies, serves — entirely local
```

:::caution
`Cloudflare.state()` now resolves to a **local file store** (`.alchemy/state`) whenever `alchemy dev` runs. Dev and deploy states become disjoint for `Cloudflare.state()` users: a deploy after dev creates fresh resources instead of mode-replacing dev rows (which only ever described machine-local emulator instances). This matches what `Alchemy.localState()` users already have.
:::

### Plan-time credential demand

After plan resolution, the dev path scans for genuine cloud needs — live-mode nodes (`Alchemy.remote()`), bindings opted out via `dev: { remote: true }`, and deletes of live-stamped rows. Only then does it run the existing profile setup flow, interactively, with the reason spelled out:

```
This dev session requires Cloudflare credentials:
  - LiveKV (runs against the real cloud via Alchemy.remote())
```

Non-interactive runs fail with a typed `CredentialsRequired` naming the resources and pointing at `alchemy login`. The RPC sidecar never prompts — it reads the credentials the exec process persisted.

### Local providers no longer force `accountId`

Seven capability `*Local` layers deferred (they only needed the account for an HTTP branch never taken for `dev:` ids), and local providers now stamp `accountId` opportunistically through a non-forcing probe. The replace-on-account-drift rule fires only when **both** old and new accounts are known — so resources created credential-free are not replaced (and their data not destroyed) on the first run after login.

### Proof

`examples/cloudflare-dev/test/credential-free.test.ts` runs the real CLI with a scrubbed `HOME`, no `CLOUDFLARE_*` env, and no profile: dev boots, the worker serves, rows land in the local store. Plus 22 new engine tests (demand detector matrix, drift rule, dev-state selection) and the existing local/live suites re-verified green.

Also fixes a latent `Test.make` bug: the dev context override was applied inside the state layer, so `Test.make({ dev: true, state: Cloudflare.state() })` built state seeing `dev: false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
