### PR TITLE
fix(core): whole-resource refs resolve fresh upstream attrs at apply

### DIFF
--- a/packages/alchemy/src/Plan.ts
+++ b/packages/alchemy/src/Plan.ts
@@ -473,7 +473,25 @@ export const make = <A>(
           ));
       });
 
-    const resolveInput = (input: any): Effect.Effect<any, Config.ConfigError> =>
+    const resolveInput = (
+      input: any,
+      options?: {
+        /**
+         * Keep a whole-resource reference to an *updating* upstream as its
+         * (evaluable) `ResourceExpr` instead of materializing the stable
+         * attributes into a plain object.
+         *
+         * The diff-facing resolution materializes so stable identifiers flow
+         * into the consumer's `diff` (see the comment at the `isResource`
+         * branch). But a plan node's `props` must stay evaluable: Apply
+         * re-resolves them via `Output.evaluate` against the upstream's FRESH
+         * post-reconcile attributes. Baking the stables-only snapshot into
+         * `node.props` would hand `reconcile` an object whose non-stable
+         * attributes (e.g. a Lambda Version's `version` number) are missing.
+         */
+        readonly preserveWholeResourceRefs?: boolean;
+      },
+    ): Effect.Effect<any, Config.ConfigError> =>
       Effect.gen(function* () {
         if (!input) {
           return input;
@@ -486,7 +504,7 @@ export const make = <A>(
           // providers receive a resolved value instead of a Config object.
           // `Config.redacted` resolves to a `Redacted`, which stays opaque via
           // the branch below.
-          return yield* resolveInput(yield* input);
+          return yield* resolveInput(yield* input, options);
         } else if (Duration.isDuration(input) || Redacted.isRedacted(input)) {
           // Opaque values that are resolved downstream. We don't walk them
           // because it would strip their prototype, resulting in a plain object
@@ -494,9 +512,12 @@ export const make = <A>(
           // stays wrapped to preserve the secrecy boundary.
           return input;
         } else if (Array.isArray(input)) {
-          return yield* Effect.all(input.map(resolveInput), {
-            concurrency: "unbounded",
-          });
+          return yield* Effect.all(
+            input.map((item) => resolveInput(item, options)),
+            {
+              concurrency: "unbounded",
+            },
+          );
         } else if (isResource(input)) {
           // Resource objects have dynamic properties (path, hash, etc.) that are
           // created on-demand by a Proxy getter and aren't enumerable via Object.entries.
@@ -513,15 +534,24 @@ export const make = <A>(
           // sees the whole reference as an unresolved `Expr`, `isResolved`
           // short-circuits, and a stable identifier that should have been
           // available is missing — forcing consumers to hand-extract it.
+          //
+          // Apply-facing resolutions (`preserveWholeResourceRefs`) keep the
+          // expression instead: the non-stable attributes are unknown at plan
+          // time and MUST be re-evaluated against the upstream's fresh
+          // attributes after its reconcile.
           if (Output.isResourceExpr(resolved) && resolved.stables) {
-            return yield* resolveInput(resolved.stables);
+            return options?.preserveWholeResourceRefs
+              ? resolved
+              : yield* resolveInput(resolved.stables, options);
           }
-          return yield* resolveInput(resolved);
+          return yield* resolveInput(resolved, options);
         } else if (typeof input === "object") {
           return Object.fromEntries(
             yield* Effect.all(
               Object.entries(input).map(([key, value]) =>
-                resolveInput(value).pipe(Effect.map((value) => [key, value])),
+                resolveInput(value, options).pipe(
+                  Effect.map((value) => [key, value]),
+                ),
               ),
               { concurrency: "unbounded" },
             ),
@@ -776,6 +806,16 @@ export const make = <A>(
             const id = resource.LogicalId;
             const fqn = resource.FQN;
             const news = yield* resolveInput(resource.Props);
+            // Apply-facing props: identical to `news` except whole-resource
+            // references to updating upstreams stay evaluable `ResourceExpr`s.
+            // Apply runs `Output.evaluate(node.props, outputs)` right before
+            // `reconcile`, so these references resolve to the upstream's
+            // fresh post-reconcile attributes — materialized stables-only
+            // snapshots (which `news` carries for `diff` visibility) would
+            // permanently hide every non-stable attribute from `reconcile`.
+            const applyProps = yield* resolveInput(resource.Props, {
+              preserveWholeResourceRefs: true,
+            });
             const downstream = newDownstreamDependencies[fqn] ?? [];
 
             // Collapse duplicate bindings by sid so the binding set handed to
@@ -932,7 +972,7 @@ export const make = <A>(
             if (oldState === undefined) {
               return Node<Create>({
                 action: "create",
-                props: news,
+                props: applyProps,
                 state: oldState,
               });
             } else if (
@@ -1077,7 +1117,7 @@ export const make = <A>(
                 // let's just continue where we left off
                 return Node<Create>({
                   action: "create",
-                  props: news,
+                  props: applyProps,
                   state: oldState,
                 });
               } else if (diff.action === "update") {
@@ -1086,7 +1126,7 @@ export const make = <A>(
                 // TODO(sam): should we maybe try an update instead?
                 return Node<Create>({
                   action: "create",
-                  props: news,
+                  props: applyProps,
                   state: oldState,
                 });
               } else {
@@ -1095,7 +1135,7 @@ export const make = <A>(
                 // we must use a replace step to create a new one and delete the potential old one
                 return Node<Replace>({
                   action: "replace",
-                  props: news,
+                  props: applyProps,
                   deleteFirst: diff.deleteFirst ?? false,
                   state: oldState,
                 });
@@ -1108,7 +1148,7 @@ export const make = <A>(
                 // we can continue where we left off
                 return Node<Update>({
                   action: "update",
-                  props: news,
+                  props: applyProps,
                   state: oldState,
                 });
               } else {
@@ -1116,7 +1156,7 @@ export const make = <A>(
                 return Node<Replace>({
                   action: "replace",
                   deleteFirst: diff.deleteFirst ?? false,
-                  props: news,
+                  props: applyProps,
                   // TODO(sam): can Apply handle replacements when the oldState is UpdatingResourceState?
                   // -> or should we do a provider.read to try and reconcile back to UpdatedResourceState?
                   state: oldState,
@@ -1131,7 +1171,7 @@ export const make = <A>(
                 return Node<Replace>({
                   action: "replace",
                   deleteFirst: oldState.deleteFirst,
-                  props: news,
+                  props: applyProps,
                   state: oldState,
                 });
               } else if (diff.action === "update") {
@@ -1142,7 +1182,7 @@ export const make = <A>(
                 return Node<Replace>({
                   action: "replace",
                   deleteFirst: oldState.deleteFirst,
-                  props: news,
+                  props: applyProps,
                   state: oldState,
                 });
               } else {
@@ -1153,7 +1193,7 @@ export const make = <A>(
                   restart: true,
                   action: "replace",
                   deleteFirst: diff.deleteFirst ?? oldState.deleteFirst,
-                  props: news,
+                  props: applyProps,
                   state: oldState,
                 });
               }
@@ -1166,7 +1206,7 @@ export const make = <A>(
                 return Node<Replace>({
                   action: "replace",
                   deleteFirst: oldState.deleteFirst,
-                  props: news,
+                  props: applyProps,
                   state: oldState,
                 });
               } else if (diff.action === "update") {
@@ -1176,7 +1216,7 @@ export const make = <A>(
                 // 2. Then proceed as normal to delete the replaced resources (after all downstream references are updated)
                 return Node<Update>({
                   action: "update",
-                  props: news,
+                  props: applyProps,
                   state: oldState,
                 });
               } else {
@@ -1187,7 +1227,7 @@ export const make = <A>(
                   restart: true,
                   action: "replace",
                   deleteFirst: diff.deleteFirst ?? oldState.deleteFirst,
-                  props: news,
+                  props: applyProps,
                   state: oldState,
                 });
               }
@@ -1196,7 +1236,7 @@ export const make = <A>(
               // so continue by re-creating it with the same instanceId and desired props
               return Node<Create>({
                 action: "create",
-                props: news,
+                props: applyProps,
                 state: {
                   ...oldState,
                   status: "creating",
@@ -1208,13 +1248,13 @@ export const make = <A>(
               return Node<Update>({
                 action: "update",
                 adopting: forceUpdateAfterAdoption,
-                props: news,
+                props: applyProps,
                 state: oldState,
               });
             } else if (diff.action === "replace") {
               return Node<Replace>({
                 action: "replace",
-                props: news,
+                props: applyProps,
                 state: oldState,
                 deleteFirst: diff?.deleteFirst ?? false,
               });

--- a/packages/alchemy/src/Plan.ts
+++ b/packages/alchemy/src/Plan.ts
@@ -365,7 +365,9 @@ export const make = <A>(
 
               const { provider, mode } =
                 yield* resolveProviderAndMode(resource);
-              const props = yield* resolveInput(resource.Props);
+              const props = materializeStableRefs(
+                yield* resolveInput(resource.Props),
+              );
               const persisted = yield* state.get({
                 stack: stackName,
                 stage: stage,
@@ -473,25 +475,17 @@ export const make = <A>(
           ));
       });
 
-    const resolveInput = (
-      input: any,
-      options?: {
-        /**
-         * Keep a whole-resource reference to an *updating* upstream as its
-         * (evaluable) `ResourceExpr` instead of materializing the stable
-         * attributes into a plain object.
-         *
-         * The diff-facing resolution materializes so stable identifiers flow
-         * into the consumer's `diff` (see the comment at the `isResource`
-         * branch). But a plan node's `props` must stay evaluable: Apply
-         * re-resolves them via `Output.evaluate` against the upstream's FRESH
-         * post-reconcile attributes. Baking the stables-only snapshot into
-         * `node.props` would hand `reconcile` an object whose non-stable
-         * attributes (e.g. a Lambda Version's `version` number) are missing.
-         */
-        readonly preserveWholeResourceRefs?: boolean;
-      },
-    ): Effect.Effect<any, Config.ConfigError> =>
+    /**
+     * Resolve an input value as far as *truth* permits, keeping everything
+     * else evaluable. A whole-resource reference to an updating upstream
+     * stays a `ResourceExpr` (its stable attributes riding along): the
+     * non-stable attributes are unknown at plan time and MUST be
+     * re-evaluated — Apply runs `Output.evaluate(node.props, outputs)`
+     * against the upstream's fresh post-reconcile attributes right before
+     * `reconcile`. This is the value plan nodes carry; the diff-facing view
+     * is derived from it by {@link materializeStableRefs}.
+     */
+    const resolveInput = (input: any): Effect.Effect<any, Config.ConfigError> =>
       Effect.gen(function* () {
         if (!input) {
           return input;
@@ -504,7 +498,7 @@ export const make = <A>(
           // providers receive a resolved value instead of a Config object.
           // `Config.redacted` resolves to a `Redacted`, which stays opaque via
           // the branch below.
-          return yield* resolveInput(yield* input, options);
+          return yield* resolveInput(yield* input);
         } else if (Duration.isDuration(input) || Redacted.isRedacted(input)) {
           // Opaque values that are resolved downstream. We don't walk them
           // because it would strip their prototype, resulting in a plain object
@@ -512,12 +506,9 @@ export const make = <A>(
           // stays wrapped to preserve the secrecy boundary.
           return input;
         } else if (Array.isArray(input)) {
-          return yield* Effect.all(
-            input.map((item) => resolveInput(item, options)),
-            {
-              concurrency: "unbounded",
-            },
-          );
+          return yield* Effect.all(input.map(resolveInput), {
+            concurrency: "unbounded",
+          });
         } else if (isResource(input)) {
           // Resource objects have dynamic properties (path, hash, etc.) that are
           // created on-demand by a Proxy getter and aren't enumerable via Object.entries.
@@ -525,33 +516,17 @@ export const make = <A>(
           // resolving any nested outputs in the result.
           const resourceExpr = Output.of(input);
           const resolved = yield* resolveOutput(resourceExpr);
-          // An upstream being updated in place resolves to a `ResourceExpr`
-          // carrying only its *stable* attributes (see `withStables` in
-          // `resolveResource`). When the resource is referenced *whole*
-          // (rather than via a single prop like `upstream.id`), materialize
-          // those stable attributes into a plain object so the known, stable
-          // values flow into the consumer's `diff`. Otherwise the consumer
-          // sees the whole reference as an unresolved `Expr`, `isResolved`
-          // short-circuits, and a stable identifier that should have been
-          // available is missing — forcing consumers to hand-extract it.
-          //
-          // Apply-facing resolutions (`preserveWholeResourceRefs`) keep the
-          // expression instead: the non-stable attributes are unknown at plan
-          // time and MUST be re-evaluated against the upstream's fresh
-          // attributes after its reconcile.
-          if (Output.isResourceExpr(resolved) && resolved.stables) {
-            return options?.preserveWholeResourceRefs
-              ? resolved
-              : yield* resolveInput(resolved.stables, options);
+          if (Output.isResourceExpr(resolved)) {
+            // Still-unresolved reference (creating, replacing, or updating
+            // upstream) — keep it evaluable for Apply.
+            return resolved;
           }
-          return yield* resolveInput(resolved, options);
+          return yield* resolveInput(resolved);
         } else if (typeof input === "object") {
           return Object.fromEntries(
             yield* Effect.all(
               Object.entries(input).map(([key, value]) =>
-                resolveInput(value, options).pipe(
-                  Effect.map((value) => [key, value]),
-                ),
+                resolveInput(value).pipe(Effect.map((value) => [key, value])),
               ),
               { concurrency: "unbounded" },
             ),
@@ -559,6 +534,44 @@ export const make = <A>(
         }
         return input;
       });
+
+    /**
+     * Project a {@link resolveInput} resolution into the DIFF-facing view:
+     * replace each whole-resource `ResourceExpr` that carries stable
+     * attributes (an upstream being *updated* in place — see `withStables` in
+     * `resolveResource`) with a plain object of those stables, so the known
+     * values flow into the consumer's `diff` and `havePropsChanged` instead
+     * of the whole reference looking unresolved and `isResolved`
+     * short-circuiting (#670 — this forced the Neon `Branch` to hand-extract
+     * `project.projectId`).
+     *
+     * The projection is deliberately lossy — diffs compare VALUES. Plan nodes
+     * never carry it: they keep the evaluable resolution so `reconcile` sees
+     * the upstream's fresh non-stable attributes (e.g. a Lambda Version's
+     * `version` number — #993's alias promotion bug).
+     */
+    const materializeStableRefs = (input: any): any => {
+      // Expr checks come first: Output proxies are callable, so a plain
+      // `typeof input === "object"` guard would let them slip through.
+      if (Output.isResourceExpr(input) && input.stables) {
+        return materializeStableRefs(input.stables);
+      } else if (Output.isExpr(input)) {
+        // Genuinely unknown (e.g. a creating upstream) — nothing to show diff.
+        return input;
+      } else if (!input || typeof input !== "object") {
+        return input;
+      } else if (Duration.isDuration(input) || Redacted.isRedacted(input)) {
+        return input;
+      } else if (Array.isArray(input)) {
+        return input.map(materializeStableRefs);
+      }
+      return Object.fromEntries(
+        Object.entries(input).map(([key, value]) => [
+          key,
+          materializeStableRefs(value),
+        ]),
+      );
+    };
 
     const resolveOutput = (expr: Output.Expr<any>): Effect.Effect<any> =>
       Effect.gen(function* () {
@@ -805,23 +818,28 @@ export const make = <A>(
             const { provider, mode } = yield* resolveProviderAndMode(resource);
             const id = resource.LogicalId;
             const fqn = resource.FQN;
-            const news = yield* resolveInput(resource.Props);
-            // Apply-facing props: identical to `news` except whole-resource
+            // Apply-facing props (stored on the plan node): whole-resource
             // references to updating upstreams stay evaluable `ResourceExpr`s.
             // Apply runs `Output.evaluate(node.props, outputs)` right before
             // `reconcile`, so these references resolve to the upstream's
-            // fresh post-reconcile attributes — materialized stables-only
-            // snapshots (which `news` carries for `diff` visibility) would
-            // permanently hide every non-stable attribute from `reconcile`.
-            const applyProps = yield* resolveInput(resource.Props, {
-              preserveWholeResourceRefs: true,
-            });
+            // fresh post-reconcile attributes.
+            const applyProps = yield* resolveInput(resource.Props);
+            // Diff-facing view of the same resolution: stable attributes
+            // materialized so their known values flow into `diff` /
+            // `havePropsChanged`.
+            const news = materializeStableRefs(applyProps);
             const downstream = newDownstreamDependencies[fqn] ?? [];
 
             // Collapse duplicate bindings by sid so the binding set handed to
             // `diff` matches what `reconcile` receives (see `dedupeBindings`).
+            // Bindings keep the diff-facing (materialized) shape for both the
+            // diff AND the node payload — the terminal commit must persist the
+            // exact payload `diffBindings` compared (#874). Re-resolving
+            // binding payloads freshly at apply is a separate change.
             const newBindings: ResourceBinding[] = dedupeBindings(
-              yield* resolveInput(stack.bindings[fqn] ?? []),
+              materializeStableRefs(
+                yield* resolveInput(stack.bindings[fqn] ?? []),
+              ),
             );
             const persisted = yield* state.get({
               stack: stackName,
@@ -1277,7 +1295,12 @@ export const make = <A>(
           Effect.fn("plan.diff.action")(function* (action) {
             const fqn = action.FQN;
             const downstream = newDownstreamDependencies[fqn] ?? [];
-            const resolvedInput = yield* resolveInput(action.Input);
+            // The node carries the RAW input expression (evaluated at apply);
+            // the drift hash uses the diff-facing view so stable upstream
+            // attributes hash as their known values.
+            const resolvedInput = materializeStableRefs(
+              yield* resolveInput(action.Input),
+            );
             const inputHash = yield* hashInput(resolvedInput);
             const oldState = yield* state.get({
               stack: stackName,

--- a/packages/alchemy/test/apply.test.ts
+++ b/packages/alchemy/test/apply.test.ts
@@ -4705,6 +4705,63 @@ describe("resource identity (fqn) threading", () => {
 });
 
 // =============================================================================
+// WHOLE-RESOURCE REFS RE-RESOLVE FRESH ATTRS AT APPLY
+// The plan materializes a whole-resource reference to an *updating* upstream
+// into its stable attributes for the downstream's `diff` — but the node's
+// props keep the evaluable reference, so `reconcile` receives the upstream's
+// fresh post-reconcile attributes, non-stable ones included. Baking the
+// stables-only snapshot into node.props left e.g. a Lambda Alias pointing at
+// the previous Lambda Version forever (#993's alias promotion bug).
+// =============================================================================
+
+describe("whole-resource refs re-resolve fresh attrs at apply", () => {
+  test.provider(
+    "downstream reconcile sees the upstream's fresh non-stable attributes",
+    (stack) =>
+      Effect.gen(function* () {
+        const observed: TestResourceProps[] = [];
+        const capture = hook({
+          create: () => Effect.void,
+          update: (id, props) =>
+            Effect.sync(() => {
+              if (id === "B") {
+                observed.push(props);
+              }
+            }),
+          delete: () => Effect.void,
+        });
+
+        const program = (version: string) =>
+          Effect.gen(function* () {
+            const A = yield* TestResource("A", { string: version });
+            // B references the WHOLE upstream resource, not a single prop.
+            return yield* TestResource("B", { object: A as any });
+          });
+
+        yield* program("v1").pipe(stack.deploy, capture);
+
+        // A updates in place: the non-stable `string` changes while
+        // `stableString` / `stableArray` stay put. B must re-reconcile
+        // against A's FRESH attributes — not the stables-only snapshot the
+        // plan hands B's diff.
+        yield* program("v2").pipe(stack.deploy, capture);
+
+        expect(observed).toHaveLength(1);
+        const object = observed[0]!.object as any;
+        expect(object.string).toBe("v2");
+        expect(object.stableString).toBe("A");
+
+        // The persisted props captured the fully-resolved attrs, so the next
+        // no-op deploy diffs full-against-full instead of churning.
+        const persisted = yield* getState("B");
+        expect((persisted?.props as any).object.string).toBe("v2");
+
+        yield* stack.destroy().pipe(capture);
+      }),
+  );
+});
+
+// =============================================================================
 // STATIC STABLE PROPERTIES (provider.stables defined on provider, not in diff)
 // This tests the bug where diff returns undefined but downstream resources
 // depend on stable properties that should be preserved

--- a/packages/alchemy/test/plan.test.ts
+++ b/packages/alchemy/test/plan.test.ts
@@ -2249,9 +2249,17 @@ describe("whole-resource refs resolve to the upstream's stable attributes", () =
   // that `ResourceExpr` to the downstream verbatim, so its `news` looked
   // unresolved (`isResolved(news) === false`) and the stable values never
   // reached the downstream `diff`. This forced the Neon `Branch` to manually
-  // extract `project.projectId` as a workaround. The engine must instead
-  // materialize the known stable attributes into a plain object so the
-  // stable values flow into the diff and the downstream can no-op.
+  // extract `project.projectId` as a workaround. The engine materializes the
+  // known stable attributes into a plain object for the DIFF-facing `news`
+  // so the stable values flow into the diff and the downstream can no-op.
+  //
+  // The plan node's `props`, however, must keep the reference as an
+  // evaluable `ResourceExpr`: Apply re-resolves `node.props` against the
+  // upstream's fresh post-reconcile attributes, and a materialized
+  // stables-only snapshot would permanently hide every non-stable attribute
+  // from the downstream's `reconcile` (e.g. a Lambda Alias promoting a
+  // freshly-published Lambda Version would never see the new version
+  // number — #993's alias promotion bug).
   const seedUpdatingUpstream = () =>
     seed({
       A: {
@@ -2276,7 +2284,7 @@ describe("whole-resource refs resolve to the upstream's stable attributes", () =
     });
 
   test(
-    "the whole-resource ref resolves to the upstream's stable attributes (not an Expr)",
+    "the node's whole-resource ref stays an evaluable Expr carrying the stable attributes",
     Effect.gen(function* () {
       yield* seedUpdatingUpstream();
 
@@ -2293,10 +2301,15 @@ describe("whole-resource refs resolve to the upstream's stable attributes", () =
       expect(plan.resources.A!.action).toBe("update");
 
       const bProps = (plan.resources.B as any).props as TestResourceProps;
-      // The whole-resource ref must resolve to a fully-resolved plain object
-      // of the upstream's stable attributes — NOT an unresolved Expr.
-      expect(Output.isExpr(bProps.object)).toBe(false);
-      expect(bProps.object).toEqual({
+      // The node's props keep the whole-resource ref as an evaluable
+      // `ResourceExpr` (so Apply resolves the upstream's FRESH attributes
+      // after its reconcile), with the stable attributes riding along for
+      // plan-time consumers.
+      expect(Output.isExpr(bProps.object)).toBe(true);
+      expect(Output.isResourceExpr(bProps.object)).toBe(true);
+      expect(
+        (bProps.object as any as Output.ResourceExpr<any>).stables,
+      ).toEqual({
         stableString: "A",
         stableArray: ["A"],
       });


### PR DESCRIPTION
Fixes the three Lambda live-test failures from #993 (Alias, Version, EventInvokeConfig). Root cause is in the engine, not the Lambda providers: a whole-resource reference to an upstream *updated* in the same deploy was materialized into a stables-only plain object at plan time (#670) and baked into `node.props`. Apply's `Output.evaluate(node.props, outputs)` then had nothing left to re-resolve, so `reconcile` never saw the upstream's fresh non-stable attributes:

```ts
// Alias reconcile, after Version published v2:
resolvedNews.version // { functionName, functionArn }  ← stables only
resolvedNews.version.version // undefined

// → updateAlias({ FunctionVersion: undefined })  — alias silently stays on v1
// → createAlias({ FunctionVersion: undefined })  — ParseError: Expected string, got undefined
```

### The fix: one resolution, one derived view

Plan-time resolution has two consumers with different needs: `diff` compares **values** (wants known stables materialized as plain data), while `reconcile` needs a **recipe** Apply can re-evaluate against fresh post-reconcile upstream attributes. `Plan.make` now models that explicitly:

```ts
// apply-faithful truth — still-unresolved whole-resource refs stay evaluable
// ResourceExprs (stables riding along); this is what plan nodes carry
const applyProps = yield* resolveInput(resource.Props);

// diff-facing view — a pure, lossy projection: ResourceExpr-with-stables
// becomes a plain object of its stable attributes
const news = materializeStableRefs(applyProps);
```

- `diff` visibility and no-op detection are unchanged — #670's "whole-resource ref to an updating upstream does not drag the downstream into an update" test passes unmodified.
- The action-input path already followed this model (raw expr on the node, resolved view for the drift hash); binding payloads keep the materialized shape for both diff and node so terminal commits persist the exact payload `diffBindings` compared (#874) — re-resolving binding payloads freshly at apply is a tracked follow-up.
- Also fixes a churn bug: terminal commits now persist full attrs instead of the stables-only snapshot, so the deploy *after* an upstream update no longer produces a spurious downstream update.

Verified: all engine unit suites green (`plan`, `apply`, `action`, `Diff`, `Output`, `binding-stability`, `provider-mode`, `destroy-*`, `sync`, …), `bun tsc -b` clean, and the three live suites pass with `--profile testing` (Alias ~65s, EventInvokeConfig ~75s, Version ~88s) with zero leaked functions/roles/queues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
