### PR TITLE
fix(core): re-resolve whole-resource binding payloads at apply

### DIFF
--- a/packages/alchemy/src/Plan.ts
+++ b/packages/alchemy/src/Plan.ts
@@ -830,17 +830,24 @@ export const make = <A>(
             const news = materializeStableRefs(applyProps);
             const downstream = newDownstreamDependencies[fqn] ?? [];
 
-            // Collapse duplicate bindings by sid so the binding set handed to
-            // `diff` matches what `reconcile` receives (see `dedupeBindings`).
-            // Bindings keep the diff-facing (materialized) shape for both the
-            // diff AND the node payload — the terminal commit must persist the
-            // exact payload `diffBindings` compared (#874). Re-resolving
-            // binding payloads freshly at apply is a separate change.
-            const newBindings: ResourceBinding[] = dedupeBindings(
-              materializeStableRefs(
-                yield* resolveInput(stack.bindings[fqn] ?? []),
-              ),
+            // Apply-facing binding rows, mirroring `applyProps`: payloads
+            // whose data embeds a whole-resource reference to an updating
+            // upstream keep it as an evaluable `ResourceExpr`. Apply runs
+            // `Output.evaluate(node.bindings, outputs)` right before
+            // `reconcile`, so the host receives the upstream's fresh
+            // post-reconcile attributes. Collapse duplicates by sid so the
+            // binding set handed to `diff` matches what `reconcile` receives
+            // (see `dedupeBindings`).
+            const applyBindings: ResourceBinding[] = dedupeBindings(
+              yield* resolveInput(stack.bindings[fqn] ?? []),
             );
+            // Diff-facing view of the same rows: stable attributes
+            // materialized so `diffBindings` / `provider.diff` compare known
+            // values. Terminal commits still persist the payload the provider
+            // actually reconciled with (#874) — Apply commits the evaluated
+            // `bindingOutputs`, not these plan-time shapes.
+            const newBindings: ResourceBinding[] =
+              materializeStableRefs(applyBindings);
             const persisted = yield* state.get({
               stack: stackName,
               stage: stage,
@@ -958,7 +965,20 @@ export const make = <A>(
 
             // Sid-sorted like `newBindings` (see the resolveResource note).
             const oldBindings = dedupeBindings(oldState?.bindings ?? []);
-            const bindingDiffs = diffBindings(oldBindings, newBindings);
+            // Actions come from the materialized comparison (`newBindings`);
+            // the payloads the node carries into Apply come from the
+            // apply-faithful rows, joined by sid — both are views of the same
+            // deduped `stack.bindings[fqn]` rows, so action and payload can
+            // never drift. `delete` rows keep the persisted old data.
+            const applyBindingData = new Map(
+              applyBindings.map((b) => [b.sid, b.data]),
+            );
+            const bindingDiffs = diffBindings(oldBindings, newBindings).map(
+              (b) =>
+                b.action === "delete" || !applyBindingData.has(b.sid)
+                  ? b
+                  : { ...b, data: applyBindingData.get(b.sid) },
+            );
 
             // Local ⇄ live switch: the persisted row was reconciled by a
             // different provider mode than the one resolved for this run.

--- a/packages/alchemy/test/apply.test.ts
+++ b/packages/alchemy/test/apply.test.ts
@@ -4759,6 +4759,71 @@ describe("whole-resource refs re-resolve fresh attrs at apply", () => {
         yield* stack.destroy().pipe(capture);
       }),
   );
+
+  test.provider(
+    "host reconcile sees the upstream's fresh non-stable attributes through a binding",
+    (stack) =>
+      Effect.gen(function* () {
+        // Captures the DIFF-facing binding rows the host provider observes
+        // at plan time (materialized stables-only snapshots).
+        const diffObserved: any[] = [];
+        const capture = <A, Err, Req>(test: Effect.Effect<A, Err, Req>) =>
+          test.pipe(
+            Effect.provide(
+              Layer.succeed(TestResourceHooks, {
+                diff: (id, newBindings) =>
+                  Effect.sync(() => {
+                    if (id === "Host") {
+                      diffObserved.push(newBindings);
+                    }
+                  }),
+              }),
+            ),
+          );
+
+        const program = (version: string) =>
+          Effect.gen(function* () {
+            const A = yield* TestResource("A", { string: version });
+            const host = yield* BindingTarget("Host", { name: "host" });
+            // The binding data embeds the WHOLE upstream resource.
+            yield* host.bind("FromA", { env: { A } } as any);
+            return host;
+          });
+
+        yield* program("v1").pipe(stack.deploy, capture);
+        const created = yield* getState("Host");
+        expect((created?.bindings as any)[0].data.env.A.string).toBe("v1");
+
+        // A updates in place: the host's `diff` compares against the
+        // materialized stables-only snapshot, but the binding payload the
+        // host's `reconcile` receives must re-resolve to A's FRESH
+        // post-reconcile attributes at apply.
+        yield* program("v2").pipe(stack.deploy, capture);
+
+        // The plan-time diff saw the stables-only materialization.
+        const lastDiff = diffObserved.at(-1);
+        expect(lastDiff[0].data.env.A).toEqual({
+          stableString: "A",
+          stableArray: ["A"],
+        });
+
+        // The reconciled attr merged the fresh payload...
+        const updated = yield* getState("Host");
+        expect((updated?.attr as any).env.A.string).toBe("v2");
+        // ...and the terminal commit persisted the RESOLVED payload the
+        // provider reconciled with (#874).
+        const bound = (updated?.bindings as any)[0].data.env.A;
+        expect(bound.string).toBe("v2");
+        expect(bound.stableString).toBe("A");
+
+        // With full attrs persisted, the next plan diffs full-against-full
+        // instead of churning on the stables-only snapshot.
+        const rePlan = yield* program("v2").pipe(stack.plan, capture);
+        expect((rePlan.resources as any).Host.action).toBe("noop");
+
+        yield* stack.destroy().pipe(capture);
+      }),
+  );
 });
 
 // =============================================================================

--- a/packages/alchemy/test/plan.test.ts
+++ b/packages/alchemy/test/plan.test.ts
@@ -2356,6 +2356,121 @@ describe("whole-resource refs resolve to the upstream's stable attributes", () =
       expect(plan.resources.B!.action).toBe("noop");
     }),
   );
+
+  // The binding path mirrors the props split: `diffBindings` compares the
+  // materialized (stables-only) view, but the node's binding rows carry the
+  // apply-faithful payload so `Output.evaluate(node.bindings, outputs)`
+  // re-resolves the upstream's fresh post-reconcile attributes.
+  const seedHostWithFullPayload = () =>
+    seed({
+      Host: {
+        instanceId,
+        providerVersion: 0,
+        logicalId: "Host",
+        fqn: "Host",
+        namespace: undefined,
+        resourceType: "Test.BindingTarget",
+        status: "created",
+        props: { name: "host" },
+        attr: {
+          name: "host",
+          string: "Host",
+          env: {},
+          replaceString: undefined,
+        },
+        downstream: [],
+        // Terminal commits persist the payload the provider reconciled
+        // with — the upstream's FULL attributes (#874), not the plan-time
+        // stables-only projection.
+        bindings: [
+          {
+            sid: "FromA",
+            data: {
+              env: {
+                A: {
+                  string: "old-value",
+                  stableString: "A",
+                  stableArray: ["A"],
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+  const hostProgram = (upstreamString: string) =>
+    Effect.gen(function* () {
+      const A = yield* TestResource("A", { string: upstreamString });
+      const host = yield* BindingTarget("Host", { name: "host" });
+      // The binding data embeds the WHOLE upstream resource.
+      yield* host.bind("FromA", { env: { A } } as any);
+    });
+
+  test(
+    "the node's binding payload keeps the whole-resource ref as an evaluable Expr carrying the stable attributes",
+    Effect.gen(function* () {
+      yield* seedUpdatingUpstream();
+
+      const plan = yield* hostProgram("new-value").pipe(makePlan);
+
+      expect(plan.resources.A!.action).toBe("update");
+
+      const rows = (plan.resources.Host as any).bindings;
+      expect(rows).toHaveLength(1);
+      expect(rows[0].sid).toBe("FromA");
+      const payload = rows[0].data.env.A;
+      expect(Output.isResourceExpr(payload)).toBe(true);
+      expect((payload as Output.ResourceExpr<any>).stables).toEqual({
+        stableString: "A",
+        stableArray: ["A"],
+      });
+    }),
+  );
+
+  test(
+    "an updating upstream marks the binding row 'update' from the materialized comparison while the payload stays evaluable",
+    Effect.gen(function* () {
+      yield* seedUpdatingUpstream();
+      yield* seedHostWithFullPayload();
+
+      const plan = yield* hostProgram("new-value").pipe(makePlan);
+
+      expect(plan.resources.A!.action).toBe("update");
+      // The host's own props are unchanged; the binding drift alone drags
+      // it into the update that re-delivers A's fresh attributes.
+      expect(plan.resources.Host!.action).toBe("update");
+
+      const rows = (plan.resources.Host as any).bindings;
+      expect(rows).toHaveLength(1);
+      // Action from the materialized comparison (persisted full attrs vs
+      // stables-only projection)...
+      expect(rows[0].action).toBe("update");
+      // ...payload from the apply-faithful resolution.
+      expect(Output.isResourceExpr(rows[0].data.env.A)).toBe(true);
+    }),
+  );
+
+  test(
+    "an unchanged upstream's full persisted binding payload no-ops instead of churning",
+    Effect.gen(function* () {
+      yield* seedUpdatingUpstream();
+      yield* seedHostWithFullPayload();
+
+      // Same props as seeded — A no-ops, so it resolves to its full
+      // persisted attrs and the materialized binding payload matches the
+      // persisted row exactly.
+      const plan = yield* hostProgram("old-value").pipe(makePlan);
+
+      expect(plan.resources.A!.action).toBe("noop");
+      expect(plan.resources.Host!.action).toBe("noop");
+      const rows = (plan.resources.Host as any).bindings;
+      expect(rows[0].action).toBe("noop");
+      // Nothing left to re-evaluate — the payload is the plain full attrs.
+      expect(Output.isExpr(rows[0].data.env.A)).toBe(false);
+      expect(rows[0].data.env.A.string).toBe("old-value");
+    }),
+  );
 });
 
 describe("diff.stables overrides provider.stables", () => {


### PR DESCRIPTION
The follow-up tracked in #1068: binding payloads now get the same dual resolution as props. A binding whose data embeds a whole resource updated in the same deploy used to carry the materialized stables-only snapshot into the host's `reconcile` — `Output.evaluate(node.bindings, outputs)` had nothing left to re-resolve, so the upstream's non-stable attributes were permanently invisible to the host.

```ts
// apply-faithful rows — whole-resource refs to updating upstreams stay
// evaluable ResourceExprs; Apply re-resolves them against fresh attrs
const applyBindings = dedupeBindings(yield* resolveInput(stack.bindings[fqn] ?? []));

// diff-facing view of the same rows — same projection props use
const newBindings = materializeStableRefs(applyBindings);
```

- `diffBindings` / `provider.diff` still compare the materialized view; the node's payloads come from `applyBindings`, joined by sid, so binding actions and payloads cannot drift. `delete` rows keep the persisted old data.
- #874 holds: terminal commits already persist the evaluated `bindingOutputs`, so state stores the exact payload the provider reconciled with — the regression test asserts the persisted row carries the fresh attrs and that the following plan is a `noop` (no churn against the stables-only snapshot).
- Single-prop refs (`queue.queueArn`) were never affected; only whole-resource refs in binding data.

The new test in `apply.test.ts` mirrors #1068's "whole-resource refs re-resolve fresh attrs at apply" case through a binding: the host's `diff` observes the stables-only materialization while its `reconcile` receives the upstream's fresh post-reconcile attributes. Three plan-level tests additionally pin the node shape directly: binding rows keep evaluable `ResourceExpr`s (stables riding along) for updating upstreams, row actions come from the materialized comparison, and a full persisted payload no-ops when the upstream is unchanged. The evaluable-payload assertions fail if the payload join is reverted to the materialized rows.

Verified: `plan`, `apply`, and `binding-stability` suites green (316 tests), `bun tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
