### PR TITLE
docs(ci): match alchemy login prompt, link create-token quick path

### DIFF
--- a/website/src/content/docs/cloudflare/tutorial/part-5.mdx
+++ b/website/src/content/docs/cloudflare/tutorial/part-5.mdx
@@ -18,6 +18,15 @@ into GitHub, you'll write a small `stacks/github.ts` that mints a
 scoped Cloudflare API token, then stores it as a GitHub Actions
 secret — all from code, all checked in.
 
+:::tip[Just need a token?]
+If all you want is a `CLOUDFLARE_API_TOKEN` to paste into your
+repo's secrets by hand, run
+[`alchemy cloudflare create-token`](/cli/cloudflare#cloudflare-create-token)
+and set it (plus `CLOUDFLARE_ACCOUNT_ID`) under **Settings →
+Secrets and variables → Actions**. This part of the tutorial
+automates the same thing with code.
+:::
+
 ## Confirm your state store is remote
 
 CI needs to share state across runs, so a local `.alchemy/` directory
@@ -60,7 +69,18 @@ create a dedicated `admin` profile:
 alchemy login --profile admin
 ```
 
-When prompted for a Cloudflare credential, pick one of:
+The prompt asks for a Cloudflare authentication method:
+
+- **OAuth** (recommended — browser-based login with automatic token refresh)
+- **Environment Variables**
+- **API Token or API Key**
+
+Pick **API Token or API Key**. The OAuth recommendation is for
+day-to-day deploy profiles, not this one: Cloudflare's OAuth flow
+has no scope for managing API tokens, so an OAuth-backed profile
+cannot mint the CI token this stack creates.
+
+A second prompt asks which kind. Pick one of:
 
 - **API Key + Email** (the Global API Key) — has full account
   access, including the ability to mint tokens.
@@ -301,6 +321,12 @@ jobs:
 The cleanup job includes a safety check so `prod` can never be
 accidentally destroyed.
 :::
+
+Notice there is no `alchemy login` step. GitHub Actions sets
+`CI=true`, and when `CI` is set Alchemy skips the interactive login
+and reads credentials straight from the environment — the
+`CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` secrets you just
+provisioned. Profiles only exist on your machine.
 
 ## Add PR preview comments
 

--- a/website/src/content/docs/environments/ci.mdx
+++ b/website/src/content/docs/environments/ci.mdx
@@ -169,6 +169,15 @@ credentials your CI needs — a scoped Cloudflare API token, an AWS
 IAM role for OIDC, etc. — and write them straight into the repo as
 encrypted secrets.
 
+:::tip[Just need a token?]
+If all you want is a `CLOUDFLARE_API_TOKEN` to paste into your
+repo's secrets by hand, run
+[`alchemy cloudflare create-token`](/cli/cloudflare#cloudflare-create-token)
+and set it (plus `CLOUDFLARE_ACCOUNT_ID`) under **Settings →
+Secrets and variables → Actions**. This guide automates the same
+thing with code.
+:::
+
 ## How PR previews work
 
 Open a PR. Alchemy does the rest.
@@ -288,6 +297,12 @@ By the end you'll have:
    `GITHUB_TOKEN` is provided automatically by GitHub Actions and is used
    by the `GitHub.Comment` resource to post PR comments.
 
+   CI itself never runs `alchemy login`. GitHub Actions sets
+   `CI=true`, and when `CI` is set Alchemy skips the interactive
+   login and reads provider credentials directly from environment
+   variables — the secrets and variables you're about to wire in.
+   Profiles only exist on your machine.
+
 </Steps>
 
 ## The GitHub Stack
@@ -315,6 +330,13 @@ Rather than hand those rights to your default
 ```sh
 alchemy login --profile admin
 ```
+
+For Cloudflare, pick **API Token or API Key** at the
+authentication-method prompt, then **API Key + Email**. The prompt
+recommends OAuth, but that recommendation is for day-to-day deploy
+profiles: Cloudflare's OAuth flow has no scope for managing API
+tokens, so an OAuth-backed profile cannot mint the CI token. See
+[required Cloudflare permissions](#cloudflare) below.
 
 :::danger[Heads up]
 The credentials stored under `--profile admin` can mint new tokens


### PR DESCRIPTION
Fix the CI credential docs that stranded a user at the `alchemy login` menu. The tutorial said to pick **API Key + Email** at a prompt whose actual options are:

```
◆ Cloudflare authentication method
  ● OAuth (recommended — browser-based login with automatic token refresh)
  ○ Environment Variables
  ○ API Token or API Key
```

"API Key + Email" only appears in a second-level submenu, and the CLI's recommended OAuth option cannot back the `admin` profile at all — Cloudflare's OAuth flow has no token-management scope, so an OAuth profile fails later when `stacks/github.ts` mints the CI token.

Changes to `cloudflare/tutorial/part-5.mdx` and `environments/ci.mdx`:

- Walk through the real two-level prompt (**API Token or API Key** → **API Key + Email**), with a warning that OAuth cannot mint API tokens despite being the CLI's recommended default
- Cross-link the [`alchemy cloudflare create-token`](https://alchemy.run/cli/cloudflare#cloudflare-create-token) quick path, which answers this exact use case but was only discoverable in the CLI reference
- State plainly that CI never runs `alchemy login`: `CI=true` auto-selects the env auth method and reads `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` from the environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)
