### PR TITLE
chore(ci): always force npm latest dist-tag on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,14 +12,6 @@ on:
         required: false
         type: string
         default: ""
-      force-latest:
-        description: >-
-          Also move npm's `latest` dist-tag to this release, even for a
-          prerelease (beta/alpha/rc). If the version is already
-          published, `latest` is moved onto it instead of skipping.
-        required: false
-        type: boolean
-        default: false
 
 concurrency:
   group: release-${{ github.ref }}
@@ -39,7 +31,9 @@ jobs:
       # distilled submodule, so consumer checkouts must fetch it.
       submodules: "true"
       version: ${{ inputs.version }}
-      force-latest: ${{ inputs.force-latest }}
+      # 2.0 prereleases are the effective current release — always move
+      # npm's `latest` dist-tag to whatever we publish (betas included).
+      force-latest: true
       repo: alchemy-run/alchemy
       current-version: "2.0.0"
       # Each package builds in its own publish job: the tsc build pulls

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,14 @@ on:
         required: false
         type: string
         default: ""
+      force-latest:
+        description: >-
+          Also move npm's `latest` dist-tag to this release, even for a
+          prerelease (beta/alpha/rc). If the version is already
+          published, `latest` is moved onto it instead of skipping.
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: release-${{ github.ref }}
@@ -31,6 +39,7 @@ jobs:
       # distilled submodule, so consumer checkouts must fetch it.
       submodules: "true"
       version: ${{ inputs.version }}
+      force-latest: ${{ inputs.force-latest }}
       repo: alchemy-run/alchemy
       current-version: "2.0.0"
       # Each package builds in its own publish job: the tsc build pulls


### PR DESCRIPTION
Always publish under npm's `latest` dist-tag, using the reusable release workflow's existing `force-latest` input. The 2.0 prereleases are the effective current release, so `latest` should track every publish (betas included) instead of sitting on 0.94.0.

```yaml
    with:
      version: ${{ inputs.version }}
      force-latest: true
```

If the version is already on the registry, `publish-package.ts` moves the `latest` tag onto it instead of skipping — so re-running a past release is a pure tag promotion (the manual equivalent of `npm dist-tag add alchemy@<version> latest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
