### PR TITLE
fix(state): injective fqn encoding, output-file isolation, and name validation

### DIFF
--- a/packages/alchemy/src/AWS/StateStore/State.ts
+++ b/packages/alchemy/src/AWS/StateStore/State.ts
@@ -7,11 +7,12 @@ import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
 import type { HttpClient } from "effect/unstable/http/HttpClient";
 import { CredentialsStoreLive } from "../../Auth/Credentials.ts";
-import { decodeFqn, encodeFqn } from "../../FQN.ts";
+import { decodeFqn, encodeFqn, encodeFqnLegacy } from "../../FQN.ts";
 import { STATE_STORE_VERSION } from "../../State/HttpStateApi.ts";
 import {
   State,
   StateStoreError,
+  withValidatedNames,
   type PersistedState,
   type StateService,
 } from "../../State/State.ts";
@@ -214,6 +215,23 @@ export const makeS3State = (options: S3StateOptions = {}) =>
       fqn: string;
     }) => `${stagePrefix(request)}${encodeFqn(request.fqn)}.json`;
 
+    // The pre-escaping key for the same fqn. `undefined` when identical to
+    // the current encoding (nothing to fall back to) or when it would
+    // collide with the bookkeeping object (an fqn like `__stack_output__`
+    // legacy-encodes to the output object's own key — reading or deleting
+    // it as a resource would corrupt the stack output).
+    const legacyResourceKey = (request: {
+      stack: string;
+      stage: string;
+      fqn: string;
+    }) => {
+      const name = `${encodeFqnLegacy(request.fqn)}.json`;
+      if (name === OUTPUT_FILE || name === `${encodeFqn(request.fqn)}.json`) {
+        return undefined;
+      }
+      return `${stagePrefix(request)}${name}`;
+    };
+
     const outputKey = (request: { stack: string; stage: string }) =>
       `${stagePrefix(request)}${OUTPUT_FILE}`;
 
@@ -300,7 +318,19 @@ export const makeS3State = (options: S3StateOptions = {}) =>
       listStages: (stack: string) =>
         run((bucket) => listChildren(bucket, `${prefix}${stack}/`)),
       get: (request) =>
-        run((bucket) => readJson<PersistedState>(bucket, resourceKey(request))),
+        run((bucket) =>
+          readJson<PersistedState>(bucket, resourceKey(request)).pipe(
+            Effect.flatMap((found) => {
+              if (found !== undefined) return Effect.succeed(found);
+              // Fall back to the key written by the legacy (pre-escaping)
+              // encoding so state persisted by older versions stays readable.
+              const legacy = legacyResourceKey(request);
+              return legacy === undefined
+                ? Effect.succeed(undefined)
+                : readJson<PersistedState>(bucket, legacy);
+            }),
+          ),
+        ),
       getReplacedResources: Effect.fn(function* (request) {
         return (yield* Effect.all(
           (yield* state.list(request)).map((fqn) =>
@@ -314,11 +344,29 @@ export const makeS3State = (options: S3StateOptions = {}) =>
       }),
       set: (request) =>
         run((bucket) =>
-          writeJson(bucket, resourceKey(request), request.value),
+          writeJson(bucket, resourceKey(request), request.value).pipe(
+            // Migrate on write: an object left under the legacy encoding for
+            // the same fqn would otherwise resurface as a duplicate in `list`.
+            Effect.flatMap(() => {
+              const legacy = legacyResourceKey(request);
+              return legacy === undefined
+                ? Effect.void
+                : s3.deleteObject({ Bucket: bucket, Key: legacy });
+            }),
+          ),
         ).pipe(Effect.map(() => request.value)),
       delete: (request) =>
         run((bucket) =>
-          s3.deleteObject({ Bucket: bucket, Key: resourceKey(request) }),
+          s3.deleteObject({ Bucket: bucket, Key: resourceKey(request) }).pipe(
+            Effect.flatMap(() => {
+              const legacy = legacyResourceKey(request);
+              return legacy === undefined
+                ? Effect.void
+                : Effect.asVoid(
+                    s3.deleteObject({ Bucket: bucket, Key: legacy }),
+                  );
+            }),
+          ),
         ).pipe(Effect.asVoid),
       deleteStack: ({ stack, stage }) =>
         run((bucket) =>
@@ -350,7 +398,7 @@ export const makeS3State = (options: S3StateOptions = {}) =>
           writeJson(bucket, outputKey(request), request.value),
         ).pipe(Effect.map(() => request.value)),
     };
-    return state;
+    return withValidatedNames(state);
   });
 
 /**

--- a/packages/alchemy/src/FQN.ts
+++ b/packages/alchemy/src/FQN.ts
@@ -6,17 +6,39 @@ import type { NamespaceNode } from "./Namespace.ts";
 export const FQN_SEPARATOR = "/";
 
 /**
- * Encode an FQN for safe filesystem storage.
- * Replaces `/` (FQN separator) with `__` to avoid subdirectory creation.
+ * Encode an FQN for safe filesystem/object-key storage.
+ *
+ * `%`, `_`, and `\` are percent-escaped BEFORE `/` (the FQN separator)
+ * is replaced with `__`, so every `__` in an encoded name is
+ * unambiguously a separator. This makes the codec injective: a logical
+ * id containing a literal `__` (e.g. `foo__bar`) encodes to
+ * `foo%5F%5Fbar` and can never collide with the encoding of `foo/bar`.
  */
 export const encodeFqn = (fqn: string): string =>
-  fqn.replaceAll(FQN_SEPARATOR, "__");
+  fqn
+    .replaceAll("%", "%25")
+    .replaceAll("_", "%5F")
+    .replaceAll("\\", "%5C")
+    .replaceAll(FQN_SEPARATOR, "__");
 
 /**
- * Decode a filename back to FQN.
+ * Decode a filename back to FQN. Exact inverse of {@link encodeFqn}.
  */
 export const decodeFqn = (filename: string): string =>
-  filename.replaceAll("__", FQN_SEPARATOR);
+  filename
+    .replaceAll("__", FQN_SEPARATOR)
+    .replaceAll("%5C", "\\")
+    .replaceAll("%5F", "_")
+    .replaceAll("%25", "%");
+
+/**
+ * The legacy (lossy) encoding used before {@link encodeFqn} escaped
+ * `%`/`_`/`\`: a bare `/` → `__` replacement. State stores keep this
+ * for read-fallback so state written by older versions stays readable;
+ * writes always use {@link encodeFqn} and clean up the legacy name.
+ */
+export const encodeFqnLegacy = (fqn: string): string =>
+  fqn.replaceAll(FQN_SEPARATOR, "__");
 
 /**
  * Convert a NamespaceNode chain to an array of namespace IDs, from root to leaf.

--- a/packages/alchemy/src/State/HttpStateStore.ts
+++ b/packages/alchemy/src/State/HttpStateStore.ts
@@ -9,6 +9,7 @@ import { StateApi } from "./HttpStateApi.ts";
 import type { ReplacedResourceState, ResourceState } from "./ResourceState.ts";
 import {
   StateStoreError,
+  withValidatedNames,
   type PersistedState,
   type StateService,
 } from "./State.ts";
@@ -193,7 +194,9 @@ export const makeHttpStateStore = ({
             mapStateStoreError,
           ),
     };
-    return service;
+    // Client-side guard: stack/stage travel as raw URL path segments, so a
+    // name containing `/` would silently address a different route.
+    return withValidatedNames(service);
   });
 
 /**

--- a/packages/alchemy/src/State/LocalState.ts
+++ b/packages/alchemy/src/State/LocalState.ts
@@ -3,10 +3,15 @@ import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 import type { PlatformError } from "effect/PlatformError";
-import { decodeFqn, encodeFqn } from "../FQN.ts";
+import { decodeFqn, encodeFqn, encodeFqnLegacy } from "../FQN.ts";
 import { recordStateStoreInit } from "../Telemetry/Metrics.ts";
 import { STATE_STORE_VERSION } from "./HttpStateApi.ts";
-import { State, StateStoreError, type StateService } from "./State.ts";
+import {
+  State,
+  StateStoreError,
+  withValidatedNames,
+  type StateService,
+} from "./State.ts";
 import { encodeState, reviveState } from "./StateEncoding.ts";
 
 export const localState = () =>
@@ -25,6 +30,13 @@ export const localState = () =>
       return yield* Effect.cached(make);
     }),
   );
+
+/**
+ * The bookkeeping file that stores a stack's resolved output. Lives
+ * alongside the resource files in the stage directory, so it must be
+ * filtered out of `list` results and shielded from legacy-fqn fallback.
+ */
+const OUTPUT_FILE = "__stack_output__.json";
 
 export const makeLocalState = () =>
   Effect.gen(function* () {
@@ -61,8 +73,25 @@ export const makeLocalState = () =>
       fqn: string;
     }) => path.join(stateDir, stack, stage, `${encodeFqn(fqn)}.json`);
 
+    // The pre-escaping filename for the same fqn. `undefined` when it is
+    // identical to the current encoding (nothing to fall back to) or when
+    // it would collide with the bookkeeping file (an fqn like
+    // `__stack_output__` legacy-encodes to the output file's own name —
+    // reading or deleting it as a resource would corrupt the stack output).
+    const legacyResource = (request: {
+      stack: string;
+      stage: string;
+      fqn: string;
+    }) => {
+      const name = `${encodeFqnLegacy(request.fqn)}.json`;
+      if (name === OUTPUT_FILE || name === `${encodeFqn(request.fqn)}.json`) {
+        return undefined;
+      }
+      return path.join(stateDir, request.stack, request.stage, name);
+    };
+
     const outputFile = ({ stack, stage }: { stack: string; stage: string }) =>
-      path.join(stateDir, stack, stage, `__stack_output__.json`);
+      path.join(stateDir, stack, stage, OUTPUT_FILE);
 
     // Write state files atomically: write to a unique sibling temp file, then
     // rename it over the target. Rename within a directory is atomic on POSIX
@@ -91,6 +120,12 @@ export const makeLocalState = () =>
         ? undefined
         : JSON.parse(contents, reviveState);
 
+    const readState = (file: string) =>
+      fs.readFile(file).pipe(
+        Effect.map((contents) => parseState(contents.toString())),
+        recover,
+      );
+
     const created = new Set<string>();
 
     const ensure = (dir: string) =>
@@ -114,9 +149,16 @@ export const makeLocalState = () =>
           Effect.map((files) => files ?? []),
         ),
       get: (request) =>
-        fs.readFile(resource(request)).pipe(
-          Effect.map((file) => parseState(file.toString())),
-          recover,
+        readState(resource(request)).pipe(
+          Effect.flatMap((found) => {
+            if (found !== undefined) return Effect.succeed(found);
+            // Fall back to the filename written by the legacy (pre-escaping)
+            // encoding so state persisted by older versions stays readable.
+            const legacy = legacyResource(request);
+            return legacy === undefined
+              ? Effect.succeed(undefined)
+              : readState(legacy);
+          }),
         ),
       getReplacedResources: Effect.fn(function* (request) {
         return (yield* Effect.all(
@@ -137,10 +179,25 @@ export const makeLocalState = () =>
               JSON.stringify(encodeState(request.value), null, 2),
             ),
           ),
+          // Migrate on write: a file left under the legacy encoding for the
+          // same fqn would otherwise resurface as a duplicate in `list`.
+          Effect.flatMap(() => {
+            const legacy = legacyResource(request);
+            return legacy === undefined ? Effect.void : fs.remove(legacy);
+          }),
           recover,
           Effect.map(() => request.value),
         ),
-      delete: (request) => fs.remove(resource(request)).pipe(recover),
+      delete: (request) =>
+        fs.remove(resource(request)).pipe(
+          recover,
+          Effect.flatMap(() => {
+            const legacy = legacyResource(request);
+            return legacy === undefined
+              ? Effect.void
+              : fs.remove(legacy).pipe(recover);
+          }),
+        ),
       deleteStack: ({ stack, stage }) =>
         Effect.suspend(() => {
           const dir =
@@ -175,10 +232,7 @@ export const makeLocalState = () =>
               //    non-existent resource;
               //  - in-flight `*.tmp` files written by `writeAtomic` (and any
               //    other non-`.json` entry), which are not resources.
-              .filter(
-                (file) =>
-                  file.endsWith(".json") && file !== "__stack_output__.json",
-              )
+              .filter((file) => file.endsWith(".json") && file !== OUTPUT_FILE)
               .map((file) => decodeFqn(file.replace(/\.json$/, ""))),
           ),
         ),
@@ -199,5 +253,5 @@ export const makeLocalState = () =>
           Effect.map(() => request.value),
         ),
     };
-    return state;
+    return withValidatedNames(state);
   });

--- a/packages/alchemy/src/State/State.ts
+++ b/packages/alchemy/src/State/State.ts
@@ -133,3 +133,82 @@ export interface StateService {
     value: unknown;
   }): Effect.Effect<unknown, StateStoreError, never>;
 }
+
+/**
+ * Validate a stack or stage name before it is used as a storage path
+ * segment (a directory name, S3 key segment, or URL path segment).
+ *
+ * Rejects names that would escape or restructure the store's layout:
+ * the empty string, `.`, `..`, and anything containing `/` or `\`.
+ */
+export const validateStateName = (
+  kind: "stack" | "stage",
+  name: string,
+): Effect.Effect<void, StateStoreError> =>
+  name.length === 0 ||
+  name === "." ||
+  name === ".." ||
+  name.includes("/") ||
+  name.includes("\\")
+    ? Effect.fail(
+        new StateStoreError({
+          message: `Invalid ${kind} name ${JSON.stringify(
+            name,
+          )}: must be non-empty, must not be "." or "..", and must not contain "/" or "\\"`,
+        }),
+      )
+    : Effect.void;
+
+/**
+ * Wrap a {@link StateService} so every operation validates its stack
+ * and stage names with {@link validateStateName} before touching the
+ * backend. This is the shared guard for all backends that embed the
+ * names in a path-like structure — the local file tree, S3 object
+ * keys, and HTTP route segments all share the same assumption that a
+ * name is a single path segment.
+ */
+export const withValidatedNames = (state: StateService): StateService => {
+  const check = (stack: string, stage?: string) =>
+    stage === undefined
+      ? validateStateName("stack", stack)
+      : Effect.flatMap(validateStateName("stack", stack), () =>
+          validateStateName("stage", stage),
+        );
+  return {
+    ...state,
+    listStages: (stack) =>
+      Effect.flatMap(check(stack), () => state.listStages(stack)),
+    get: (request) =>
+      Effect.flatMap(check(request.stack, request.stage), () =>
+        state.get(request),
+      ),
+    getReplacedResources: (request) =>
+      Effect.flatMap(check(request.stack, request.stage), () =>
+        state.getReplacedResources(request),
+      ),
+    set: (request) =>
+      Effect.flatMap(check(request.stack, request.stage), () =>
+        state.set(request),
+      ),
+    delete: (request) =>
+      Effect.flatMap(check(request.stack, request.stage), () =>
+        state.delete(request),
+      ),
+    deleteStack: (request) =>
+      Effect.flatMap(check(request.stack, request.stage), () =>
+        state.deleteStack(request),
+      ),
+    list: (request) =>
+      Effect.flatMap(check(request.stack, request.stage), () =>
+        state.list(request),
+      ),
+    getOutput: (request) =>
+      Effect.flatMap(check(request.stack, request.stage), () =>
+        state.getOutput(request),
+      ),
+    setOutput: (request) =>
+      Effect.flatMap(check(request.stack, request.stage), () =>
+        state.setOutput(request),
+      ),
+  };
+};

--- a/packages/alchemy/test/FQN.test.ts
+++ b/packages/alchemy/test/FQN.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, test } from "alchemy-test";
-import { fromPath, FQN_SEPARATOR, parseFqn, toFqn, toPath } from "../src/FQN";
+import {
+  decodeFqn,
+  encodeFqn,
+  encodeFqnLegacy,
+  fromPath,
+  FQN_SEPARATOR,
+  parseFqn,
+  toFqn,
+  toPath,
+} from "../src/FQN";
 import type { NamespaceNode } from "../src/Namespace";
 
 describe("FQN", () => {
@@ -103,6 +112,82 @@ describe("FQN", () => {
       const reconstructedNs = fromPath(parsed.path);
       const roundtripFqn = toFqn(reconstructedNs, parsed.logicalId);
       expect(roundtripFqn).toBe(fqn);
+    });
+  });
+
+  describe("filename codec", () => {
+    /** Adversarial fqns covering every escape interaction. */
+    const CASES = [
+      "",
+      "a",
+      "resource-a",
+      "a/b",
+      "scope/nested/resource-b",
+      "a_b",
+      "a__b",
+      "a___b",
+      "_",
+      "__",
+      "/",
+      "//",
+      "a/_/b",
+      "a%b",
+      "%",
+      "%25",
+      "%5F",
+      "a%5Fb",
+      "a%5F_b",
+      "%%__%%",
+      "a\\b",
+      "\\",
+      "%5C",
+      "100%",
+      "50%_off",
+      "__stack_output__",
+      "my resource (α) #1 100%",
+    ];
+
+    test("encodeFqn/decodeFqn roundtrips adversarial fqns", () => {
+      for (const fqn of CASES) {
+        expect(decodeFqn(encodeFqn(fqn))).toBe(fqn);
+      }
+    });
+
+    test("encodeFqn is injective across all adversarial fqns", () => {
+      const seen = new Map<string, string>();
+      for (const fqn of CASES) {
+        const encoded = encodeFqn(fqn);
+        expect(seen.has(encoded) ? seen.get(encoded) : fqn).toBe(fqn);
+        seen.set(encoded, fqn);
+      }
+    });
+
+    test("a literal __ is distinct from an encoded separator", () => {
+      expect(encodeFqn("foo__bar")).not.toBe(encodeFqn("foo/bar"));
+      expect(decodeFqn(encodeFqn("foo__bar"))).toBe("foo__bar");
+      expect(decodeFqn(encodeFqn("foo/bar"))).toBe("foo/bar");
+    });
+
+    test("never encodes to the stack-output bookkeeping name", () => {
+      expect(encodeFqn("__stack_output__")).not.toBe("__stack_output__");
+      expect(encodeFqn("/stack_output/")).not.toBe("__stack_output__");
+    });
+
+    test("encoded filenames contain no path separators", () => {
+      for (const fqn of CASES) {
+        const encoded = encodeFqn(fqn);
+        expect(encoded).not.toContain("/");
+        expect(encoded).not.toContain("\\");
+      }
+    });
+
+    test("matches the legacy encoding when no character needs escaping", () => {
+      // Separator-only fqns produce identical filenames under both
+      // codecs, so legacy state files for namespaced resources are read
+      // in place without any fallback.
+      for (const fqn of ["a", "a/b", "scope/nested/resource-b", "a-b.c"]) {
+        expect(encodeFqn(fqn)).toBe(encodeFqnLegacy(fqn));
+      }
     });
   });
 });

--- a/packages/alchemy/test/State/LocalState.test.ts
+++ b/packages/alchemy/test/State/LocalState.test.ts
@@ -424,38 +424,61 @@ describe("makeLocalState", () => {
       }).pipe(Effect.provide(PlatformServices)),
     );
 
-    it.effect("literal __ in a logical id: get roundtrips, list decodes", () =>
+    it.effect("literal __ and / fqns coexist as distinct resources", () =>
       Effect.gen(function* () {
         const state = yield* makeLocalState();
         const stack = "local-state-test-underscores";
         const stage = "test";
-        const value = resource("foo__bar", { value: "u" });
+        const underscored = resource("foo__bar", { value: "underscore" });
+        const slashed = resource("foo/bar", { value: "slash" });
 
-        yield* state.set({ stack, stage, fqn: "foo__bar", value });
+        yield* state.set({ stack, stage, fqn: "foo__bar", value: underscored });
+        yield* state.set({ stack, stage, fqn: "foo/bar", value: slashed });
+
         expect(yield* state.get({ stack, stage, fqn: "foo__bar" })).toEqual(
-          value,
+          underscored,
         );
-        // Known encoding collision: `/` is stored as `__`, so decodeFqn
-        // cannot distinguish a literal `__` in a logical id from a
-        // namespace separator. `list` reports this resource as "foo/bar".
-        expect(yield* state.list({ stack, stage })).toEqual(["foo/bar"]);
+        expect(yield* state.get({ stack, stage, fqn: "foo/bar" })).toEqual(
+          slashed,
+        );
+        expect((yield* state.list({ stack, stage })).toSorted()).toEqual([
+          "foo/bar",
+          "foo__bar",
+        ]);
 
         yield* state.deleteStack({ stack });
       }).pipe(Effect.provide(PlatformServices)),
     );
 
-    it.effect("a resource named __stack_output__ never surfaces in list", () =>
-      Effect.gen(function* () {
-        const state = yield* makeLocalState();
-        const stack = "local-state-test-output-clash";
-        const stage = "test";
-        const value = resource("__stack_output__", { value: "clash" });
+    it.effect(
+      "a resource named __stack_output__ coexists with the output",
+      () =>
+        Effect.gen(function* () {
+          const state = yield* makeLocalState();
+          const stack = "local-state-test-output-clash";
+          const stage = "test";
+          const value = resource("__stack_output__", { value: "clash" });
 
-        yield* state.set({ stack, stage, fqn: "__stack_output__", value });
-        expect(yield* state.list({ stack, stage })).toEqual([]);
+          yield* state.set({ stack, stage, fqn: "__stack_output__", value });
+          yield* state.setOutput({ stack, stage, value: { out: true } });
 
-        yield* state.deleteStack({ stack });
-      }).pipe(Effect.provide(PlatformServices)),
+          expect(
+            yield* state.get({ stack, stage, fqn: "__stack_output__" }),
+          ).toEqual(value);
+          expect(yield* state.getOutput({ stack, stage })).toEqual({
+            out: true,
+          });
+          expect(yield* state.list({ stack, stage })).toEqual([
+            "__stack_output__",
+          ]);
+
+          yield* state.delete({ stack, stage, fqn: "__stack_output__" });
+          expect(yield* state.getOutput({ stack, stage })).toEqual({
+            out: true,
+          });
+
+          yield* state.deleteStack({ stack });
+        }).pipe(Effect.provide(PlatformServices)),
     );
 
     it.effect("overlong names fail with a typed StateStoreError", () =>
@@ -479,6 +502,177 @@ describe("makeLocalState", () => {
         expect(getError._tag).toBe("StateStoreError");
 
         yield* state.deleteStack({ stack });
+      }).pipe(Effect.provide(PlatformServices)),
+    );
+  });
+
+  describe("legacy encoding migration", () => {
+    // Simulate state written by an older version: `_`/`%`/`\` were not
+    // escaped, only `/` → `__`. For fqn "my_legacy_res" the legacy file
+    // is `my_legacy_res.json`; the current encoding writes
+    // `my%5Flegacy%5Fres.json`.
+    const legacyFqn = "my_legacy_res";
+    const legacyFile = (stack: string) =>
+      statePath(stack, "test", `${legacyFqn}.json`);
+
+    const writeLegacyFile = (stack: string, round: number) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const dir = yield* statePath(stack, "test");
+        yield* fs.makeDirectory(dir, { recursive: true });
+        yield* fs.writeFileString(
+          yield* legacyFile(stack),
+          JSON.stringify(resource(legacyFqn, { round })),
+        );
+      });
+
+    it.effect("get falls back to the legacy filename", () =>
+      Effect.gen(function* () {
+        const state = yield* makeLocalState();
+        const stack = "local-state-test-legacy-read";
+        yield* writeLegacyFile(stack, 1);
+
+        expect(
+          yield* state.get({ stack, stage: "test", fqn: legacyFqn }),
+        ).toMatchObject({ attr: { round: 1 } });
+        expect(yield* state.list({ stack, stage: "test" })).toEqual([
+          legacyFqn,
+        ]);
+
+        yield* state.deleteStack({ stack });
+      }).pipe(Effect.provide(PlatformServices)),
+    );
+
+    it.effect("set migrates the legacy file to the escaped filename", () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const state = yield* makeLocalState();
+        const stack = "local-state-test-legacy-set";
+        yield* writeLegacyFile(stack, 1);
+
+        yield* state.set({
+          stack,
+          stage: "test",
+          fqn: legacyFqn,
+          value: resource(legacyFqn, { round: 2 }),
+        });
+
+        expect(
+          yield* state.get({ stack, stage: "test", fqn: legacyFqn }),
+        ).toMatchObject({ attr: { round: 2 } });
+        // exactly one entry — the legacy file was removed, not duplicated
+        expect(yield* state.list({ stack, stage: "test" })).toEqual([
+          legacyFqn,
+        ]);
+        expect(yield* fs.exists(yield* legacyFile(stack))).toBe(false);
+
+        yield* state.deleteStack({ stack });
+      }).pipe(Effect.provide(PlatformServices)),
+    );
+
+    it.effect("delete removes the legacy file too", () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const state = yield* makeLocalState();
+        const stack = "local-state-test-legacy-delete";
+        yield* writeLegacyFile(stack, 1);
+
+        yield* state.delete({ stack, stage: "test", fqn: legacyFqn });
+
+        expect(
+          yield* state.get({ stack, stage: "test", fqn: legacyFqn }),
+        ).toBeUndefined();
+        expect(yield* fs.exists(yield* legacyFile(stack))).toBe(false);
+
+        yield* state.deleteStack({ stack });
+      }).pipe(Effect.provide(PlatformServices)),
+    );
+
+    it.effect("legacy fallback never reads the stack output file", () =>
+      Effect.gen(function* () {
+        const state = yield* makeLocalState();
+        const stack = "local-state-test-legacy-output-guard";
+        const stage = "test";
+        yield* state.setOutput({ stack, stage, value: { out: true } });
+
+        // fqn "__stack_output__" legacy-encodes to the bookkeeping file's
+        // own name; the fallback must not surface the output as a resource
+        expect(
+          yield* state.get({ stack, stage, fqn: "__stack_output__" }),
+        ).toBeUndefined();
+        // ...nor may delete remove the output through the legacy name
+        yield* state.delete({ stack, stage, fqn: "__stack_output__" });
+        expect(yield* state.getOutput({ stack, stage })).toEqual({ out: true });
+
+        yield* state.deleteStack({ stack });
+      }).pipe(Effect.provide(PlatformServices)),
+    );
+  });
+
+  describe("name validation", () => {
+    const INVALID = ["", ".", "..", "a/b", "a\\b"];
+
+    it.effect("rejects invalid stack names with a typed error", () =>
+      Effect.gen(function* () {
+        const state = yield* makeLocalState();
+        for (const stack of INVALID) {
+          const err = yield* state
+            .get({ stack, stage: "test", fqn: "resource-a" })
+            .pipe(Effect.flip);
+          expect(err._tag).toBe("StateStoreError");
+          const setErr = yield* state
+            .set({
+              stack,
+              stage: "test",
+              fqn: "resource-a",
+              value: resource("resource-a", {}),
+            })
+            .pipe(Effect.flip);
+          expect(setErr._tag).toBe("StateStoreError");
+          const deleteErr = yield* state
+            .deleteStack({ stack })
+            .pipe(Effect.flip);
+          expect(deleteErr._tag).toBe("StateStoreError");
+        }
+      }).pipe(Effect.provide(PlatformServices)),
+    );
+
+    it.effect("rejects invalid stage names with a typed error", () =>
+      Effect.gen(function* () {
+        const state = yield* makeLocalState();
+        const stack = "local-state-test-validation";
+        for (const stage of INVALID) {
+          const err = yield* state
+            .get({ stack, stage, fqn: "resource-a" })
+            .pipe(Effect.flip);
+          expect(err._tag).toBe("StateStoreError");
+          const outputErr = yield* state
+            .setOutput({ stack, stage, value: {} })
+            .pipe(Effect.flip);
+          expect(outputErr._tag).toBe("StateStoreError");
+          const deleteErr = yield* state
+            .deleteStack({ stack, stage })
+            .pipe(Effect.flip);
+          expect(deleteErr._tag).toBe("StateStoreError");
+        }
+      }).pipe(Effect.provide(PlatformServices)),
+    );
+
+    it.effect("stack deletion without a stage skips stage validation", () =>
+      Effect.gen(function* () {
+        const state = yield* makeLocalState();
+        const stack = "local-state-test-validation-nostage";
+        yield* state.set({
+          stack,
+          stage: "test",
+          fqn: "resource-a",
+          value: resource("resource-a", {}),
+        });
+
+        yield* state.deleteStack({ stack });
+        expect(
+          yield* state.get({ stack, stage: "test", fqn: "resource-a" }),
+        ).toBeUndefined();
       }).pipe(Effect.provide(PlatformServices)),
     );
   });


### PR DESCRIPTION
Fixes the three name-handling weaknesses found while writing the LocalState unit suite (#1072).

### Injective fqn codec

`encodeFqn` escapes `%`, `_`, and `\` before replacing `/` with `__`, so every `__` in a filename is unambiguously a separator:

```ts
encodeFqn("foo/bar");   // "foo__bar"       (unchanged)
encodeFqn("foo__bar");  // "foo%5F%5Fbar"   (was "foo__bar" — collided)
decodeFqn(encodeFqn(fqn)) === fqn; // for every fqn
```

Fqns without `_`/`%`/`\` — including all `/`-separated namespaced fqns — produce the same filename as before, so most existing state is read in place. For the rest, the stores fall back and migrate:

- `get` falls back to the legacy filename when the new one is absent
- `set` writes the new filename and removes the legacy one
- `delete` removes both

`encodeFqnLegacy` preserves the old encoding for that fallback.

### `__stack_output__` isolation

A resource with fqn `__stack_output__` now encodes to its own file (`%5F%5Fstack%5Foutput%5F%5F.json`) instead of clobbering the stack-output bookkeeping object, and it appears in `list`. The legacy fallback explicitly refuses to read or delete the bookkeeping file as a resource.

### Stack/stage name validation

All backends embed stack/stage as path segments (local directory tree, S3 keys, HTTP routes), where a name like `..` escapes the store — `deleteStack({ stack: ".." })` would have removed `.alchemy` wholesale. A shared `withValidatedNames` wrapper now guards every operation on the local, S3, and HTTP-client stores:

```ts
validateStateName("stack", "..");  // StateStoreError
// rejected: "", ".", "..", and names containing "/" or "\"
```

The Cloudflare store is covered via the HTTP client; `InMemoryService` (test util, plain Map keys) is unwrapped.

### Compatibility

- Reads are fully backward compatible (legacy fallback + identical filenames for the common cases).
- Forward compatibility caveat: state written by this version for fqns containing `_`/`%`/`\` uses the escaped filename, which an older CLI would not find. Same-direction upgrades are unaffected.

Covered by 6 new codec tests in `test/FQN.test.ts` and 7 new/updated LocalState tests (legacy migration, output-file isolation, validation); verified green against the live S3 and Cloudflare state store suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
