### PR TITLE
feat(cloudflare): run vite dev servers in child processes

### DIFF
--- a/packages/alchemy/src/Cli/commands/dev.ts
+++ b/packages/alchemy/src/Cli/commands/dev.ts
@@ -4,6 +4,7 @@ import * as Schema from "effect/Schema";
 import * as Command from "effect/unstable/cli/Command";
 import * as ChildProcess from "effect/unstable/process/ChildProcess";
 import { fileURLToPath } from "node:url";
+import { transformTypesFlags } from "../../Util/Node.ts";
 import { SPAWNER_URL_ENV_KEY } from "../../Local/RpcProviderProxy.ts";
 import * as RpcSpawner from "../../Local/RpcSpawner.ts";
 import { envFile, force, profile, script, stage } from "./_shared.ts";
@@ -40,12 +41,7 @@ export const devCommand = Command.make(
           : [
               "node",
               ...process.execArgv,
-              ...(isTransformTypesSupported()
-                ? [
-                    "--experimental-transform-types",
-                    "--no-warnings=ExperimentalWarning",
-                  ]
-                : []),
+              ...transformTypesFlags(),
               "--watch",
               "--watch-preserve-output",
               fileURLToPath(import.meta.resolve("alchemy/bin/exec.js")),
@@ -73,10 +69,3 @@ export const devCommand = Command.make(
       )(effect),
   ),
 );
-
-const isTransformTypesSupported = (
-  version = process.versions.node,
-): boolean => {
-  const [major, minor] = version.split(".").map(Number);
-  return (major === 22 && minor >= 7) || (major >= 23 && major < 26);
-};

--- a/packages/alchemy/src/Cloudflare/LocalRuntime.ts
+++ b/packages/alchemy/src/Cloudflare/LocalRuntime.ts
@@ -60,12 +60,21 @@ const LocalRuntimeStateLive = Layer.succeed(
   }),
 );
 
+/**
+ * Directory under `.alchemy` holding local-provider persistent state
+ * (workerd storage). Shared so every consumer — the local runtime layer and
+ * Vite child processes — points at the same storage.
+ */
+export const localStorageDirectory = Effect.gen(function* () {
+  const { dotAlchemy } = yield* AlchemyContext;
+  const path = yield* Path.Path;
+  return path.join(dotAlchemy, "local");
+});
+
 const makeLocalRuntimeServices = () =>
   RpcProvider.providerServicesEffect(
     Effect.gen(function* () {
       const getEnv = yield* CloudflareEnvironment;
-      const { dotAlchemy } = yield* AlchemyContext;
-      const path = yield* Path.Path;
       return Layer.merge(
         LocalRuntimeStateLive,
         layerRuntime({
@@ -73,7 +82,7 @@ const makeLocalRuntimeServices = () =>
             accountId: getEnv.pipe(Effect.map((env) => env.accountId)),
           },
           storage: {
-            directory: path.join(dotAlchemy, "local"),
+            directory: yield* localStorageDirectory,
           },
         }),
       );

--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -6,43 +6,8 @@ import {
   type Module,
   type DurableObjectNamespace as RuntimeDurableObject,
   type QueueConsumer as RuntimeQueueConsumer,
-  type RuntimeServices,
   type Workflow as RuntimeWorkflow,
 } from "@distilled.cloud/cloudflare-runtime";
-import {
-  Ai,
-  AiSearch,
-  AnalyticsEngine,
-  Artifacts,
-  Assets,
-  Browser,
-  D1,
-  Data,
-  DispatchNamespace,
-  DurableObjectNamespace,
-  Flagship,
-  Hyperdrive,
-  Images,
-  Json,
-  KvNamespace,
-  MtlsCertificate,
-  Pipelines,
-  Queue,
-  R2Bucket,
-  RateLimit,
-  SecretKey,
-  SecretsStore,
-  SendEmail,
-  Service,
-  Stream as StreamSim,
-  Text,
-  Vectorize,
-  VersionMetadata,
-  VpcService,
-  WasmModule,
-  WorkerLoader,
-  Workflows,
-} from "@distilled.cloud/cloudflare-runtime/bindings";
 import type { ContainerImage } from "@distilled.cloud/cloudflare-runtime/Docker";
 import * as WorkerProxy from "@distilled.cloud/cloudflare-runtime/proxy/WorkerProxy";
 import * as Cause from "effect/Cause";
@@ -53,9 +18,7 @@ import type * as FileSystem from "effect/FileSystem";
 import * as MutableHashMap from "effect/MutableHashMap";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
-import * as Redacted from "effect/Redacted";
 import * as Result from "effect/Result";
-import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
 import * as Semaphore from "effect/Semaphore";
 import * as Stream from "effect/Stream";
@@ -68,9 +31,9 @@ import { unwrapRedacted } from "../../Util/index.ts";
 import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
 import {
   isLiveId,
-  isLocalId,
   LOCAL_ENTRY_URL,
   LocalRuntimeState,
+  localStorageDirectory,
 } from "../LocalRuntime.ts";
 import type { WorkerAssetsConfig, WorkerProps } from "../Workers/Worker.ts";
 import { readAssetsConfigFiles } from "./Assets.ts";
@@ -82,6 +45,12 @@ import type { WorkerBinding } from "./WorkerBinding.ts";
 import { WorkerBundle, type WorkerBundleOptions } from "./WorkerBundle.ts";
 import { createWorkerName } from "./WorkerName.ts";
 import { resolveTailConsumers } from "./WorkerProvider.ts";
+import {
+  materializeRuntimeBindings,
+  WorkerValidationError,
+} from "./RuntimeBindings.ts";
+import { startViteChild } from "./ViteChild.ts";
+import { DEFAULT_DEV_PORT } from "./ViteChild.shared.ts";
 
 /** Local dev-server options (the worker-mode arm of `WorkerProps["dev"]`). */
 type DevServerOptions = Extract<WorkerProps["dev"], { mode?: "worker" }> & {
@@ -121,15 +90,6 @@ const resolveLocalUrls = (serverUrl: URL): Effect.Effect<string[]> =>
     ];
   });
 
-export class WorkerValidationError extends Schema.TaggedErrorClass<WorkerValidationError>()(
-  "WorkerValidationError",
-  {
-    message: Schema.String,
-    hint: Schema.optional(Schema.String),
-    value: Schema.Unknown,
-  },
-) {}
-
 export const LocalWorkerProvider = () =>
   LocalProvider.make(
     Worker,
@@ -138,11 +98,11 @@ export const LocalWorkerProvider = () =>
       const bundler = yield* WorkerBundle;
       const runtime = yield* Runtime;
       const stack = yield* Stack;
+      const storageDirectory = yield* localStorageDirectory;
       const path = yield* Path.Path;
       const localRuntimeState = yield* LocalRuntimeState;
       const workerProxy = yield* WorkerProxy.WorkerProxy;
       const cloudflareEnv = yield* CloudflareEnvironment;
-      const context = yield* Effect.context<RuntimeServices>();
       const rootScope = yield* Effect.scope;
 
       // Proxies are deliberately NOT owned by the per-instance scope: they
@@ -422,7 +382,7 @@ export const LocalWorkerProvider = () =>
                 mode: "worker" as const,
                 // This is the default. Vite and cloudflare-runtime will retry
                 // if unavailable, unless `strictPort` is true.
-                port: props.dev?.port ?? 1337,
+                port: props.dev?.port ?? DEFAULT_DEV_PORT,
               };
         return {
           id,
@@ -508,45 +468,11 @@ export const LocalWorkerProvider = () =>
         selfUrl: string | undefined,
       ) {
         const { accountId } = yield* cloudflareEnv;
-        // Resource-backed env entries (e.g. `env: { KV: namespace }`) are
-        // represented by their binding descriptor (same name) — don't ALSO
-        // serialize the resolved attributes as a duplicate json binding.
-        const descriptorNames = new Set(
-          config.bindingDescriptors.map((descriptor) => descriptor.name),
-        );
-        const workerBindings: BindingHook<BindingServices>[] = [
-          Text.local("ALCHEMY_PHASE", "runtime"),
-          Text.local("ALCHEMY_WORKER_NAME", config.name),
-          Text.local("ALCHEMY_STACK_NAME", stack.name),
-          Text.local("ALCHEMY_STAGE", stack.stage),
-          Text.local("ALCHEMY_CLOUDFLARE_ACCOUNT_ID", accountId),
-          ...Object.entries(config.env ?? {})
-            .filter(([key]) => !descriptorNames.has(key))
-            .map(([key, value]) => {
-              if (isSelfUrl(value)) {
-                return Text.local(key, selfUrl!);
-              }
-              const unredacted = Redacted.isRedacted(value)
-                ? Redacted.value(value)
-                : value;
-              return typeof unredacted === "string"
-                ? Text.local(key, unredacted)
-                : Json.local(key, unredacted);
-            }),
-          ...(config.hasAssets ? [Assets.local("ASSETS")] : []),
-        ];
-        for (const descriptor of config.bindingDescriptors) {
-          if (descriptor.type === "self_url") {
-            // Lowered here rather than in `toRuntimeBinding` — only this
-            // scope knows the worker's own dev-proxy URL.
-            workerBindings.push(Text.local(descriptor.name, selfUrl!));
-            continue;
-          }
-          workerBindings.push(
-            yield* toRuntimeBinding(descriptor, config.devRemote),
-          );
-        }
-        return workerBindings;
+        return yield* materializeRuntimeBindings(config, {
+          accountId,
+          selfUrl,
+          stack: { name: stack.name, stage: stack.stage },
+        });
       });
 
       // Latest successful serve per worker id, so runtime wiring changes
@@ -876,34 +802,54 @@ export const LocalWorkerProvider = () =>
       const runVite = Effect.fn(function* (
         worker: RunnableWorkerConfig,
         rootDir: string | undefined,
+        invalidate: Effect.Effect<void>,
       ) {
         const proxy = yield* maybeStartProxy(worker.id, worker.dev);
         yield* proxy.unset().pipe(Effect.forkChild);
-        // Loaded lazily: `./Vite.ts` pulls in `@distilled.cloud/cloudflare-vite-plugin`
-        // (~0.5s); only needed when running a vite dev server.
-        const Vite = yield* Effect.promise(() => import("./Vite.ts"));
-        const devServer = yield* Vite.viteDev(
-          rootDir,
-          worker.env ?? {},
+        // Vite and its workerd run in a child process rooted at the app.
+        const root = path.resolve(rootDir ?? process.cwd());
+        const { accountId } = yield* cloudflareEnv;
+        const child = yield* startViteChild(
           {
-            main: worker.viteMain,
-            compatibilityDate: worker.compatibility.date,
-            compatibilityFlags: worker.compatibility.flags,
-            viteEnvironments: worker.viteEnvironments,
+            rootDir: root,
+            publicUrl: proxy.url.toString().replace(/\/$/, ""),
+            accountId,
+            storageDirectory,
+            stack: { name: stack.name, stage: stack.stage },
+            // Already resolved to plain values by `start` (`Worker.URL`
+            // sentinels substituted); Redacted unwraps at the process
+            // boundary inside `startViteChild`.
+            env: worker.env ?? {},
             worker: {
               name: worker.name,
-              bindings: worker.workerBindings,
+              compatibility: worker.compatibility,
+              main: worker.viteMain,
+              viteEnvironments: worker.viteEnvironments,
+              hasAssets: worker.hasAssets,
+              bindingDescriptors: worker.bindingDescriptors,
+              devRemote: worker.devRemote,
               durableObjectNamespaces: worker.durableObjectNamespaces,
               workflows: worker.workflows,
               hyperdrives: worker.hyperdrives,
               queueConsumers: yield* getQueueConsumers(worker.name),
               assets: yield* toRuntimeAssets(worker.assets),
             },
-            context,
           },
-          { port: 0 },
+          (channel, line) => {
+            process[channel].write(`${worker.id} | ${line}\n`);
+          },
         );
-        yield* proxy.set(new URL(devServer.resolvedUrls!.local[0]));
+        yield* proxy.set(child.url);
+        yield* child.exitCode.pipe(
+          Effect.flatMap((exitCode) =>
+            Effect.logWarning(
+              `[${worker.id}] Vite child exited unexpectedly with code ${exitCode}`,
+            ),
+          ),
+          Effect.andThen(proxy.unset().pipe(Effect.ignore)),
+          Effect.andThen(invalidate),
+          Effect.forkScoped,
+        );
         return proxy.url;
       });
 
@@ -940,7 +886,7 @@ export const LocalWorkerProvider = () =>
               : yield* maybeStartProxy(id, {
                   ...news.dev,
                   mode: "worker" as const,
-                  port: news.dev?.port ?? 1337,
+                  port: news.dev?.port ?? DEFAULT_DEV_PORT,
                 }).pipe(Effect.flatMap((proxy) => resolveLocalUrls(proxy.url)));
           return {
             workerId: name,
@@ -960,7 +906,7 @@ export const LocalWorkerProvider = () =>
           };
         }),
 
-        start: Effect.fn(function* ({ id, config }) {
+        start: Effect.fn(function* ({ id, config, invalidate }) {
           const { accountId } = yield* cloudflareEnv;
 
           // `dev: { mode: "external" }` opts out of running a local Worker
@@ -1005,28 +951,30 @@ export const LocalWorkerProvider = () =>
                 .toString()
                 .replace(/\/$/, "")
             : undefined;
+          // Substitute `Worker.URL` sentinels once, up front — the runtime
+          // bindings, the Vite define entries, and the child-process config
+          // all consume the resolved URL as a plain string.
+          const env =
+            config.env && selfUrl !== undefined
+              ? Object.fromEntries(
+                  Object.entries(config.env).map(([key, value]) => [
+                    key,
+                    isSelfUrl(value) ? selfUrl : value,
+                  ]),
+                )
+              : config.env;
           const workerBindings = yield* materializeWorkerBindings(
-            config,
+            { ...config, env },
             selfUrl,
           );
           const worker: RunnableWorkerConfig = {
             ...config,
-            // Substitute `Worker.URL` sentinels so the Vite dev server
-            // inlines the local URL into VITE_*-prefixed define entries.
-            env:
-              config.env && selfUrl !== undefined
-                ? Object.fromEntries(
-                    Object.entries(config.env).map(([key, value]) => [
-                      key,
-                      isSelfUrl(value) ? selfUrl : value,
-                    ]),
-                  )
-                : config.env,
+            env,
             dev: config.dev,
             workerBindings,
           };
           const serverUrl = yield* config.vite
-            ? runVite(worker, config.viteRootDir)
+            ? runVite(worker, config.viteRootDir, invalidate)
             : config.assetsOnly
               ? runAssetsOnly(worker)
               : runWorker(worker);
@@ -1079,214 +1027,6 @@ export const LocalWorkerProvider = () =>
       >;
     }),
   );
-
-export const toRuntimeBinding = Effect.fn(function* (
-  b: WorkerBinding,
-  /**
-   * Dev-only channel from the Worker's binding data (see the `devRemote`
-   * member of the Worker binding contract): binding name → opt-out of local
-   * emulation for the capabilities that support it (browser / images /
-   * stream / send_email).
-   */
-  devRemote?: Record<string, boolean>,
-) {
-  const unsupported = () =>
-    new WorkerValidationError({
-      message: `${b.type} bindings are not supported in local mode`,
-      value: b,
-    });
-  switch (b.type) {
-    case "ai":
-      return Ai.remote(b.name);
-    case "ai_search":
-      return AiSearch.remote(b.name, b.instanceName);
-    case "ai_search_namespace":
-      return AiSearch.remoteNamespace(b.name, b.namespace);
-    case "analytics_engine":
-      return AnalyticsEngine.local(b.name, b.dataset);
-    case "artifacts":
-      return Artifacts.remote(b.name, b.namespace);
-    case "assets":
-      return Assets.local(b.name);
-    case "browser":
-      // Local emulation launches a real headless Chrome on this machine and
-      // proxies the Browser Rendering session protocol to its CDP endpoint;
-      // `Alchemy.remote()` opts into the real service instead.
-      return devRemote?.[b.name]
-        ? Browser.remote(b.name)
-        : Browser.local({ binding: b.name });
-    case "d1":
-      // A `dev:` id belongs to a locally-emulated database (local D1
-      // provider); a real id is a live database the dev worker proxies to
-      // (e.g. the resource opted out of emulation via `Alchemy.remote()`).
-      return isLocalId(b.databaseId)
-        ? D1.local({ binding: b.name, id: b.databaseId })
-        : D1.remote(b.name, b.databaseId);
-    case "data_blob":
-      return Data.local(b.name, Buffer.from(b.part));
-    case "dispatch_namespace":
-      return DispatchNamespace.remote({
-        binding: b.name,
-        namespace: b.namespace,
-      });
-    case "durable_object_namespace":
-      return DurableObjectNamespace.local({
-        binding: b.name,
-        className: b.className,
-        scriptName: b.scriptName,
-        uniqueKey:
-          b.namespaceId ??
-          encodeURIComponent(`${b.scriptName!}-${b.className}`),
-      });
-    case "flagship":
-      return Flagship.remote(b.name, b.appId);
-    case "hyperdrive":
-      return Hyperdrive.local(b.name, b.id);
-    case "images":
-      // Local emulation runs transforms via Sharp on this machine and stores
-      // hosted images in a local KV-backed store; `Alchemy.remote()`
-      // opts into the real Images service instead.
-      return devRemote?.[b.name]
-        ? Images.remote(b.name)
-        : Images.local({ binding: b.name });
-    case "inherit":
-      return yield* unsupported();
-    case "json":
-      return Json.local(b.name, b.json);
-    case "kv_namespace":
-      // A `dev:` id belongs to a locally-emulated namespace; a real id is
-      // a live namespace the dev worker proxies to.
-      return isLocalId(b.namespaceId)
-        ? KvNamespace.local({ binding: b.name, id: b.namespaceId })
-        : KvNamespace.remote(b.name, b.namespaceId);
-    case "mtls_certificate":
-      return MtlsCertificate.remote(b.name, b.certificateId);
-    case "pipelines":
-      return Pipelines.remote(b.name, b.pipeline);
-    case "plain_text":
-      return Text.local(b.name, b.text);
-    case "queue": {
-      // A real queueId belongs to an `Alchemy.remote()` queue. Queue bindings
-      // are NOT supported in Cloudflare's remote/preview sessions — a
-      // platform limitation (cloudflare/workers-sdk#9929) — so live
-      // production goes through the deployed shim worker registered at
-      // eval time (see `Queues/QueueShim.ts`): the local binding targets a
-      // forwarder service that relays the queue wire protocol to the shim
-      // over HTTPS with a bearer token.
-      if (b.queueId !== undefined && !isLocalId(b.queueId)) {
-        const url = b.shim?.url;
-        const token = b.shim?.token;
-        if (url === undefined || token === undefined) {
-          // Defensive: binding data produced by current eval always carries
-          // the shim for this mode combination.
-          return yield* new WorkerValidationError({
-            message:
-              `Queue binding "${b.name}" targets a live queue ` +
-              "(Alchemy.remote()) but no producer shim was registered for it — " +
-              "re-deploy, or remove remote() from the queue (local emulation).",
-            value: b,
-          });
-        }
-        return Queue.remote({
-          binding: b.name,
-          queueName: b.queueName,
-          url,
-          token: typeof token === "string" ? token : Redacted.value(token),
-        });
-      }
-      return Queue.local({
-        binding: b.name,
-        queueName: b.queueName,
-      });
-    }
-    case "r2_bucket":
-      // A `dev:`-prefixed bucket name belongs to a locally-emulated bucket
-      // (R2 has no opaque id — the name is the identity); a real name is a
-      // live bucket the dev worker proxies to.
-      return isLocalId(b.bucketName)
-        ? R2Bucket.local({ binding: b.name, id: b.bucketName })
-        : R2Bucket.remote(b.name, b.bucketName, b.jurisdiction);
-    case "ratelimit":
-      return RateLimit.local({
-        binding: b.name,
-        simple: b.simple,
-        namespaceId: b.namespaceId,
-      });
-    case "secret_key":
-      // workerd imports the key natively: raw material passes through as
-      // base64, pkcs8/spki base64 DER is PEM-wrapped, and JWK objects are
-      // serialized — all handled by the hook.
-      return SecretKey.local({
-        binding: b.name,
-        format: b.format,
-        algorithm: b.algorithm,
-        usages: b.usages,
-        keyBase64: b.keyBase64,
-        keyJwk: b.keyJwk,
-      });
-    case "secret_text":
-      return Text.local(b.name, b.text);
-    case "secrets_store_secret":
-      // A `dev:` store id belongs to a locally-emulated Secrets Store
-      // (local Store/Secret providers seed the simulator); a real id is a
-      // live secret the dev worker proxies to (`Alchemy.remote()`).
-      return isLocalId(b.storeId)
-        ? SecretsStore.local({
-            binding: b.name,
-            storeId: b.storeId,
-            secretName: b.secretName,
-          })
-        : SecretsStore.remote(b.name, b.storeId, b.secretName);
-    case "send_email":
-      // Local emulation validates and persists sent mail as `.eml` files
-      // under the local storage's `email/` dir; `Alchemy.remote()` on the
-      // descriptor opts into the real Email service instead.
-      return SendEmail[devRemote?.[b.name] ? "remote" : "local"]({
-        binding: b.name,
-        destinationAddress: b.destinationAddress,
-        allowedDestinationAddresses: b.allowedDestinationAddresses,
-        allowedSenderAddresses: b.allowedSenderAddresses,
-      });
-    case "service":
-      return Service.local({
-        binding: b.name,
-        scriptName: b.service,
-        entrypoint: b.entrypoint,
-      });
-    case "stream":
-      // Local emulation stores videos in a local simulator (no transcoding,
-      // no signed URLs) and serves each video's `preview` URL at
-      // /cdn-cgi/mf/stream/<id>/watch on the dev URL; `Alchemy.remote()`
-      // opts into the real Stream service instead.
-      return devRemote?.[b.name]
-        ? StreamSim.remote(b.name)
-        : StreamSim.local({ binding: b.name });
-    case "text_blob":
-      return Data.local(b.name, Buffer.from(b.part));
-    case "vectorize":
-      return Vectorize.remote(b.name, b.indexName);
-    case "version_metadata":
-      return VersionMetadata.local(b.name);
-    case "vpc_service":
-      // A VPC service tunnels into a private network — nothing to emulate
-      // locally, so the dev worker always proxies to the real service
-      // through the remote-binding bridge.
-      return VpcService.remote(b.name, b.serviceId);
-    case "wasm_module":
-      return WasmModule.local(b.name, Buffer.from(b.part));
-    case "worker_loader":
-      return WorkerLoader.local(b.name);
-    case "workflow":
-      return Workflows.local({
-        binding: b.name,
-        workflowName: b.workflowName,
-        className: b.className,
-        scriptName: b.scriptName,
-      });
-    default:
-      return yield* unsupported();
-  }
-});
 
 const toRuntimeAssets = Effect.fn(function* (
   assets: WorkerAssetsConfig | undefined,

--- a/packages/alchemy/src/Cloudflare/Workers/RuntimeBindings.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/RuntimeBindings.ts
@@ -1,0 +1,326 @@
+import type {
+  BindingHook,
+  BindingServices,
+} from "@distilled.cloud/cloudflare-runtime";
+import {
+  Ai,
+  AiSearch,
+  AnalyticsEngine,
+  Artifacts,
+  Assets,
+  Browser,
+  D1,
+  Data,
+  DispatchNamespace,
+  DurableObjectNamespace,
+  Flagship,
+  Hyperdrive,
+  Images,
+  Json,
+  KvNamespace,
+  MtlsCertificate,
+  Pipelines,
+  Queue,
+  R2Bucket,
+  RateLimit,
+  SecretKey,
+  SecretsStore,
+  SendEmail,
+  Service,
+  Stream as StreamSim,
+  Text,
+  Vectorize,
+  VersionMetadata,
+  VpcService,
+  WasmModule,
+  WorkerLoader,
+  Workflows,
+} from "@distilled.cloud/cloudflare-runtime/bindings";
+import * as Effect from "effect/Effect";
+import * as Redacted from "effect/Redacted";
+import * as Schema from "effect/Schema";
+import { isLocalId } from "../LocalRuntime.ts";
+import type { WorkerBinding } from "./WorkerBinding.ts";
+
+export class WorkerValidationError extends Schema.TaggedErrorClass<WorkerValidationError>()(
+  "WorkerValidationError",
+  {
+    message: Schema.String,
+    hint: Schema.optional(Schema.String),
+    value: Schema.Unknown,
+  },
+) {}
+
+export const toRuntimeBinding = Effect.fn(function* (
+  b: WorkerBinding,
+  /**
+   * Dev-only channel from the Worker's binding data (see the `devRemote`
+   * member of the Worker binding contract): binding name → opt-out of local
+   * emulation for the capabilities that support it (browser / images /
+   * stream / send_email).
+   */
+  devRemote?: Record<string, boolean>,
+) {
+  const unsupported = () =>
+    new WorkerValidationError({
+      message: `${b.type} bindings are not supported in local mode`,
+      value: b,
+    });
+  switch (b.type) {
+    case "ai":
+      return Ai.remote(b.name);
+    case "ai_search":
+      return AiSearch.remote(b.name, b.instanceName);
+    case "ai_search_namespace":
+      return AiSearch.remoteNamespace(b.name, b.namespace);
+    case "analytics_engine":
+      return AnalyticsEngine.local(b.name, b.dataset);
+    case "artifacts":
+      return Artifacts.remote(b.name, b.namespace);
+    case "assets":
+      return Assets.local(b.name);
+    case "browser":
+      // Local emulation launches a real headless Chrome on this machine and
+      // proxies the Browser Rendering session protocol to its CDP endpoint;
+      // `Alchemy.remote()` opts into the real service instead.
+      return devRemote?.[b.name]
+        ? Browser.remote(b.name)
+        : Browser.local({ binding: b.name });
+    case "d1":
+      // A `dev:` id belongs to a locally-emulated database (local D1
+      // provider); a real id is a live database the dev worker proxies to
+      // (e.g. the resource opted out of emulation via `Alchemy.remote()`).
+      return isLocalId(b.databaseId)
+        ? D1.local({ binding: b.name, id: b.databaseId })
+        : D1.remote(b.name, b.databaseId);
+    case "data_blob":
+      return Data.local(b.name, Buffer.from(b.part));
+    case "dispatch_namespace":
+      return DispatchNamespace.remote({
+        binding: b.name,
+        namespace: b.namespace,
+      });
+    case "durable_object_namespace":
+      return DurableObjectNamespace.local({
+        binding: b.name,
+        className: b.className,
+        scriptName: b.scriptName,
+        uniqueKey:
+          b.namespaceId ??
+          encodeURIComponent(`${b.scriptName!}-${b.className}`),
+      });
+    case "flagship":
+      return Flagship.remote(b.name, b.appId);
+    case "hyperdrive":
+      return Hyperdrive.local(b.name, b.id);
+    case "images":
+      // Local emulation runs transforms via Sharp on this machine and stores
+      // hosted images in a local KV-backed store; `Alchemy.remote()`
+      // opts into the real Images service instead.
+      return devRemote?.[b.name]
+        ? Images.remote(b.name)
+        : Images.local({ binding: b.name });
+    case "inherit":
+      return yield* unsupported();
+    case "json":
+      return Json.local(b.name, b.json);
+    case "kv_namespace":
+      // A `dev:` id belongs to a locally-emulated namespace; a real id is
+      // a live namespace the dev worker proxies to.
+      return isLocalId(b.namespaceId)
+        ? KvNamespace.local({ binding: b.name, id: b.namespaceId })
+        : KvNamespace.remote(b.name, b.namespaceId);
+    case "mtls_certificate":
+      return MtlsCertificate.remote(b.name, b.certificateId);
+    case "pipelines":
+      return Pipelines.remote(b.name, b.pipeline);
+    case "plain_text":
+      return Text.local(b.name, b.text);
+    case "queue": {
+      // A real queueId belongs to an `Alchemy.remote()` queue. Queue bindings
+      // are NOT supported in Cloudflare's remote/preview sessions — a
+      // platform limitation (cloudflare/workers-sdk#9929) — so live
+      // production goes through the deployed shim worker registered at
+      // eval time (see `Queues/QueueShim.ts`): the local binding targets a
+      // forwarder service that relays the queue wire protocol to the shim
+      // over HTTPS with a bearer token.
+      if (b.queueId !== undefined && !isLocalId(b.queueId)) {
+        const url = b.shim?.url;
+        const token = b.shim?.token;
+        if (url === undefined || token === undefined) {
+          // Defensive: binding data produced by current eval always carries
+          // the shim for this mode combination.
+          return yield* new WorkerValidationError({
+            message:
+              `Queue binding "${b.name}" targets a live queue ` +
+              "(Alchemy.remote()) but no producer shim was registered for it — " +
+              "re-deploy, or remove remote() from the queue (local emulation).",
+            value: b,
+          });
+        }
+        return Queue.remote({
+          binding: b.name,
+          queueName: b.queueName,
+          url,
+          token: typeof token === "string" ? token : Redacted.value(token),
+        });
+      }
+      return Queue.local({
+        binding: b.name,
+        queueName: b.queueName,
+      });
+    }
+    case "r2_bucket":
+      // A `dev:`-prefixed bucket name belongs to a locally-emulated bucket
+      // (R2 has no opaque id — the name is the identity); a real name is a
+      // live bucket the dev worker proxies to.
+      return isLocalId(b.bucketName)
+        ? R2Bucket.local({ binding: b.name, id: b.bucketName })
+        : R2Bucket.remote(b.name, b.bucketName, b.jurisdiction);
+    case "ratelimit":
+      return RateLimit.local({
+        binding: b.name,
+        simple: b.simple,
+        namespaceId: b.namespaceId,
+      });
+    case "secret_key":
+      // workerd imports the key natively: raw material passes through as
+      // base64, pkcs8/spki base64 DER is PEM-wrapped, and JWK objects are
+      // serialized — all handled by the hook.
+      return SecretKey.local({
+        binding: b.name,
+        format: b.format,
+        algorithm: b.algorithm,
+        usages: b.usages,
+        keyBase64: b.keyBase64,
+        keyJwk: b.keyJwk,
+      });
+    case "secret_text":
+      return Text.local(b.name, b.text);
+    case "secrets_store_secret":
+      // A `dev:` store id belongs to a locally-emulated Secrets Store
+      // (local Store/Secret providers seed the simulator); a real id is a
+      // live secret the dev worker proxies to (`Alchemy.remote()`).
+      return isLocalId(b.storeId)
+        ? SecretsStore.local({
+            binding: b.name,
+            storeId: b.storeId,
+            secretName: b.secretName,
+          })
+        : SecretsStore.remote(b.name, b.storeId, b.secretName);
+    case "send_email":
+      // Local emulation validates and persists sent mail as `.eml` files
+      // under the local storage's `email/` dir; `Alchemy.remote()` on the
+      // descriptor opts into the real Email service instead.
+      return SendEmail[devRemote?.[b.name] ? "remote" : "local"]({
+        binding: b.name,
+        destinationAddress: b.destinationAddress,
+        allowedDestinationAddresses: b.allowedDestinationAddresses,
+        allowedSenderAddresses: b.allowedSenderAddresses,
+      });
+    case "service":
+      return Service.local({
+        binding: b.name,
+        scriptName: b.service,
+        entrypoint: b.entrypoint,
+      });
+    case "stream":
+      // Local emulation stores videos in a local simulator (no transcoding,
+      // no signed URLs) and serves each video's `preview` URL at
+      // /cdn-cgi/mf/stream/<id>/watch on the dev URL; `Alchemy.remote()`
+      // opts into the real Stream service instead.
+      return devRemote?.[b.name]
+        ? StreamSim.remote(b.name)
+        : StreamSim.local({ binding: b.name });
+    case "text_blob":
+      return Data.local(b.name, Buffer.from(b.part));
+    case "vectorize":
+      return Vectorize.remote(b.name, b.indexName);
+    case "version_metadata":
+      return VersionMetadata.local(b.name);
+    case "vpc_service":
+      // A VPC service tunnels into a private network — nothing to emulate
+      // locally, so the dev worker always proxies to the real service
+      // through the remote-binding bridge.
+      return VpcService.remote(b.name, b.serviceId);
+    case "wasm_module":
+      return WasmModule.local(b.name, Buffer.from(b.part));
+    case "worker_loader":
+      return WorkerLoader.local(b.name);
+    case "workflow":
+      return Workflows.local({
+        binding: b.name,
+        workflowName: b.workflowName,
+        className: b.className,
+        scriptName: b.scriptName,
+      });
+    default:
+      return yield* unsupported();
+  }
+});
+
+/**
+ * Turns the serializable half of a local Worker configuration into the
+ * cloudflare-runtime binding hooks consumed by `Runtime.start`.
+ *
+ * Kept in a leaf module, independent of the provider, so a Vite child
+ * process can reconstruct the hooks after receiving plain binding
+ * descriptors from its parent without evaluating the provider's module
+ * graph. Binding hooks themselves are Effects and cannot cross a process
+ * boundary.
+ *
+ * `config.env` must already be resolved to plain values — `Worker.URL`
+ * sentinels substituted with the actual dev-proxy URL by the caller.
+ */
+export const materializeRuntimeBindings = Effect.fn(function* (
+  config: {
+    name: string;
+    env?: Record<string, unknown>;
+    hasAssets: boolean;
+    bindingDescriptors: WorkerBinding[];
+    /** Binding name → opt-out of local emulation (`Alchemy.remote()`). */
+    devRemote?: Record<string, boolean>;
+  },
+  options: {
+    accountId: string;
+    selfUrl: string | undefined;
+    stack: { name: string; stage: string };
+  },
+) {
+  // Resource-backed env entries (e.g. `env: { KV: namespace }`) are
+  // represented by their binding descriptor (same name) — don't ALSO
+  // serialize the resolved attributes as a duplicate json binding.
+  const descriptorNames = new Set(
+    config.bindingDescriptors.map((descriptor) => descriptor.name),
+  );
+  const workerBindings: BindingHook<BindingServices>[] = [
+    Text.local("ALCHEMY_PHASE", "runtime"),
+    Text.local("ALCHEMY_WORKER_NAME", config.name),
+    Text.local("ALCHEMY_STACK_NAME", options.stack.name),
+    Text.local("ALCHEMY_STAGE", options.stack.stage),
+    Text.local("ALCHEMY_CLOUDFLARE_ACCOUNT_ID", options.accountId),
+    ...Object.entries(config.env ?? {})
+      .filter(([key]) => !descriptorNames.has(key))
+      .map(([key, value]) => {
+        const unredacted = Redacted.isRedacted(value)
+          ? Redacted.value(value)
+          : value;
+        return typeof unredacted === "string"
+          ? Text.local(key, unredacted)
+          : Json.local(key, unredacted);
+      }),
+    ...(config.hasAssets ? [Assets.local("ASSETS")] : []),
+  ];
+  for (const descriptor of config.bindingDescriptors) {
+    if (descriptor.type === "self_url") {
+      // Lowered here rather than in `toRuntimeBinding` — only the caller
+      // knows the worker's own dev-proxy URL.
+      workerBindings.push(Text.local(descriptor.name, options.selfUrl!));
+      continue;
+    }
+    workerBindings.push(
+      yield* toRuntimeBinding(descriptor, config.devRemote),
+    );
+  }
+  return workerBindings;
+});

--- a/packages/alchemy/src/Cloudflare/Workers/ViteChild.shared.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/ViteChild.shared.ts
@@ -1,0 +1,43 @@
+import type {
+  DurableObjectNamespace,
+  HyperdriveOrigin,
+  QueueConsumer,
+  RuntimeWorker,
+  Workflow,
+} from "@distilled.cloud/cloudflare-runtime";
+import type { WorkerBinding } from "./WorkerBinding.ts";
+
+/**
+ * Default first port of the local dev-server range. Vite and
+ * cloudflare-runtime advance to the next available port when it is taken,
+ * unless `strictPort` is set.
+ */
+export const DEFAULT_DEV_PORT = 1337;
+
+/** Plain-data configuration transferred from the provider to a Vite child. */
+export interface ViteChildConfig {
+  rootDir: string;
+  publicUrl: string;
+  accountId: string;
+  storageDirectory: string;
+  stack: { name: string; stage: string };
+  env: Record<string, unknown>;
+  worker: {
+    name: string;
+    compatibility: { date: string; flags: string[] };
+    main: string | undefined;
+    viteEnvironments: { entry?: string; children?: string[] } | undefined;
+    hasAssets: boolean;
+    bindingDescriptors: WorkerBinding[];
+    /** Binding name → opt-out of local emulation (`Alchemy.remote()`). */
+    devRemote: Record<string, boolean>;
+    durableObjectNamespaces: DurableObjectNamespace[];
+    workflows: Workflow[];
+    hyperdrives: Record<string, Required<HyperdriveOrigin>>;
+    queueConsumers: QueueConsumer[];
+    assets: RuntimeWorker["assets"];
+  };
+}
+
+export const VITE_CHILD_READY_PREFIX = "<ALCHEMY_VITE_ADDRESS>";
+export const VITE_CHILD_READY_SUFFIX = "</ALCHEMY_VITE_ADDRESS>";

--- a/packages/alchemy/src/Cloudflare/Workers/ViteChild.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/ViteChild.ts
@@ -1,0 +1,94 @@
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as Stream from "effect/Stream";
+import * as ChildProcess from "effect/unstable/process/ChildProcess";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
+import { fileURLToPath } from "node:url";
+import * as NodeV8 from "node:v8";
+import { registerExitKill } from "../../Util/killProcessGroup.ts";
+import { transformTypesFlags } from "../../Util/Node.ts";
+import { unwrapRedacted } from "../../Util/index.ts";
+import {
+  type ViteChildConfig,
+  VITE_CHILD_READY_PREFIX,
+  VITE_CHILD_READY_SUFFIX,
+} from "./ViteChild.shared.ts";
+
+export interface ViteChildHandle {
+  readonly url: URL;
+  readonly pid: number;
+  readonly exitCode: Effect.Effect<number>;
+}
+
+const runnerUrl = import.meta.resolve(
+  import.meta.url.endsWith(".ts")
+    ? "./ViteChildRunner.ts"
+    : "./ViteChildRunner.js",
+);
+
+export const startViteChild = (
+  config: ViteChildConfig,
+  onOutput: (channel: "stdout" | "stderr", line: string) => void,
+) =>
+  Effect.gen(function* () {
+    const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+    const runner = fileURLToPath(runnerUrl);
+    const isBun = typeof globalThis.Bun !== "undefined";
+    // Redacted values can't cross the process boundary — the config is
+    // plain data once unwrapped.
+    const serializedConfig = NodeV8.serialize(unwrapRedacted(config));
+    const child = yield* spawner.spawn(
+      ChildProcess.make(
+        process.execPath,
+        isBun
+          ? ["run", runner]
+          : [...(runner.endsWith(".ts") ? transformTypesFlags() : []), runner],
+        {
+          cwd: config.rootDir,
+          stdin: Stream.succeed(serializedConfig),
+          stdout: "pipe",
+          stderr: "pipe",
+          extendEnv: true,
+          killSignal: "SIGKILL",
+        },
+      ),
+    );
+    yield* registerExitKill(child.pid);
+
+    const ready = yield* Deferred.make<URL>();
+    yield* child.stdout.pipe(
+      Stream.decodeText,
+      Stream.splitLines,
+      Stream.runForEach((line) => {
+        const start = line.indexOf(VITE_CHILD_READY_PREFIX);
+        const end = line.indexOf(VITE_CHILD_READY_SUFFIX);
+        if (start !== -1 && end > start) {
+          const value = line.slice(start + VITE_CHILD_READY_PREFIX.length, end);
+          return Deferred.succeed(ready, new URL(value));
+        }
+        return Effect.sync(() => onOutput("stdout", line));
+      }),
+      Effect.forkScoped,
+    );
+    yield* child.stderr.pipe(
+      Stream.decodeText,
+      Stream.splitLines,
+      Stream.runForEach((line) => Effect.sync(() => onOutput("stderr", line))),
+      Effect.forkScoped,
+    );
+
+    const exitCode = child.exitCode.pipe(Effect.orDie);
+    const url = yield* Effect.raceAllFirst([
+      Deferred.await(ready),
+      exitCode.pipe(
+        Effect.flatMap((exitCode) =>
+          Effect.die(
+            new Error(
+              `Vite child exited with code ${exitCode} before becoming ready`,
+            ),
+          ),
+        ),
+      ),
+    ]);
+    return { url, pid: child.pid, exitCode } satisfies ViteChildHandle;
+  });

--- a/packages/alchemy/src/Cloudflare/Workers/ViteChildRunner.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/ViteChildRunner.ts
@@ -1,0 +1,103 @@
+import { layerRuntime } from "@distilled.cloud/cloudflare-runtime";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Stdio from "effect/Stdio";
+import * as Stream from "effect/Stream";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import * as NodeV8 from "node:v8";
+import { CloudflareAuth } from "../Auth/AuthProvider.ts";
+import * as Credentials from "../Credentials.ts";
+import * as RpcServerEnvironment from "../../Local/RpcServerEnvironment.ts";
+import { PlatformServices, runMain } from "../../Util/PlatformServices.ts";
+import { materializeRuntimeBindings } from "./RuntimeBindings.ts";
+import * as Vite from "./Vite.ts";
+import {
+  DEFAULT_DEV_PORT,
+  type ViteChildConfig,
+  VITE_CHILD_READY_PREFIX,
+  VITE_CHILD_READY_SUFFIX,
+} from "./ViteChild.shared.ts";
+
+const readConfig = Effect.gen(function* () {
+  const stdio = yield* Stdio.Stdio;
+  const chunks = yield* Stream.runCollect(stdio.stdin);
+  return NodeV8.deserialize(Buffer.concat(chunks)) as ViteChildConfig;
+});
+
+const program = Effect.scoped(
+  Effect.gen(function* () {
+    const config = yield* readConfig;
+    const credentials = Credentials.fromAuthProvider().pipe(
+      Layer.provide(CloudflareAuth),
+    );
+    const runtimeContext = yield* layerRuntime({
+      api: { accountId: config.accountId },
+      storage: { directory: config.storageDirectory },
+    }).pipe(
+      Layer.provide(Layer.mergeAll(credentials, FetchHttpClient.layer)),
+      Layer.build,
+    );
+    // The non-runtime fields are consumed here; everything else in
+    // `config.worker` is the runtime worker shape `viteDev` expects, so new
+    // runtime fields flow through without being re-listed.
+    const {
+      compatibility,
+      main,
+      viteEnvironments,
+      hasAssets,
+      bindingDescriptors,
+      devRemote,
+      ...runtimeWorker
+    } = config.worker;
+    const bindings = yield* materializeRuntimeBindings(
+      {
+        name: config.worker.name,
+        env: config.env,
+        hasAssets,
+        bindingDescriptors,
+        devRemote,
+      },
+      {
+        accountId: config.accountId,
+        selfUrl: config.publicUrl,
+        stack: config.stack,
+      },
+    );
+    const devServer = yield* Vite.viteDev(
+      config.rootDir,
+      config.env,
+      {
+        main,
+        compatibilityDate: compatibility.date,
+        compatibilityFlags: compatibility.flags,
+        viteEnvironments,
+        worker: { ...runtimeWorker, bindings },
+        context: runtimeContext,
+      },
+      {
+        // Match Alchemy's local Worker port range. The stable Alchemy proxy
+        // normally occupies the first port in the range, so the internal
+        // Vite server must be allowed to advance.
+        port: DEFAULT_DEV_PORT,
+        strictPort: false,
+      },
+    );
+    const url = devServer.resolvedUrls?.local[0];
+    if (!url) {
+      return yield* Effect.die("Vite child started without a local URL");
+    }
+    yield* Effect.sync(() => {
+      process.stdout.write(
+        `${VITE_CHILD_READY_PREFIX}${url}${VITE_CHILD_READY_SUFFIX}\n`,
+      );
+    });
+    return yield* Effect.never;
+  }),
+);
+
+runMain(
+  program.pipe(
+    Effect.provide(RpcServerEnvironment.fromEnv()),
+    Effect.provide(PlatformServices),
+  ),
+);

--- a/packages/alchemy/src/Cloudflare/Workers/ViteChildRunner.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/ViteChildRunner.ts
@@ -1,21 +1,22 @@
 import { layerRuntime } from "@distilled.cloud/cloudflare-runtime";
+import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Stdio from "effect/Stdio";
 import * as Stream from "effect/Stream";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import * as NodeV8 from "node:v8";
-import { CloudflareAuth } from "../Auth/AuthProvider.ts";
-import * as Credentials from "../Credentials.ts";
 import * as RpcServerEnvironment from "../../Local/RpcServerEnvironment.ts";
 import { PlatformServices, runMain } from "../../Util/PlatformServices.ts";
+import { CloudflareAuth } from "../Auth/AuthProvider.ts";
+import * as Credentials from "../Credentials.ts";
 import { materializeRuntimeBindings } from "./RuntimeBindings.ts";
 import * as Vite from "./Vite.ts";
 import {
   DEFAULT_DEV_PORT,
-  type ViteChildConfig,
   VITE_CHILD_READY_PREFIX,
   VITE_CHILD_READY_SUFFIX,
+  type ViteChildConfig,
 } from "./ViteChild.shared.ts";
 
 const readConfig = Effect.gen(function* () {
@@ -86,18 +87,17 @@ const program = Effect.scoped(
     if (!url) {
       return yield* Effect.die("Vite child started without a local URL");
     }
-    yield* Effect.sync(() => {
-      process.stdout.write(
-        `${VITE_CHILD_READY_PREFIX}${url}${VITE_CHILD_READY_SUFFIX}\n`,
-      );
-    });
+    yield* Console.log(
+      `${VITE_CHILD_READY_PREFIX}${url}${VITE_CHILD_READY_SUFFIX}`,
+    );
     return yield* Effect.never;
   }),
 );
 
 runMain(
   program.pipe(
-    Effect.provide(RpcServerEnvironment.fromEnv()),
-    Effect.provide(PlatformServices),
+    Effect.provide(
+      RpcServerEnvironment.fromEnv().pipe(Layer.provideMerge(PlatformServices)),
+    ),
   ),
 );

--- a/packages/alchemy/src/Cloudflare/Workers/index.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/index.ts
@@ -25,6 +25,7 @@ export * from "./Route.ts";
 export * from "./Rpc.ts";
 export * from "./RpcDurableObject.ts";
 export * from "./RpcWorker.ts";
+export * from "./RuntimeBindings.ts";
 export * from "./ScheduledEvents.ts";
 export * from "./SecretKey.ts";
 export * from "./SecretKeyBinding.ts";

--- a/packages/alchemy/src/Command/Command.ts
+++ b/packages/alchemy/src/Command/Command.ts
@@ -3,7 +3,6 @@
  * Shared between the `Build`, `Dev`, and `Exec` resources.
  */
 
-import { exitHook } from "@alchemy.run/node-utils/exit-hook";
 import * as Context from "effect/Context";
 import * as Data from "effect/Data";
 import * as Duration from "effect/Duration";
@@ -24,7 +23,7 @@ import * as ChildProcess from "effect/unstable/process/ChildProcess";
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 import type { ScopedPlanStatusSession } from "../Cli/Cli.ts";
 import { isNonInteractive } from "../Util/interactive.ts";
-import { killProcessGroup } from "../Util/killProcessGroup.ts";
+import { registerExitKill } from "../Util/killProcessGroup.ts";
 import {
   makeCommandRedactor,
   redactPlatformReason,
@@ -330,20 +329,7 @@ export const CommandExecutorLive = () =>
               }),
             ),
           ),
-          // Last line of defense against abrupt process exit: exit-hook's
-          // SIGTERM/SIGINT handlers call `process.exit` synchronously (the
-          // node-utils lockfile registers one at import time), which preempts
-          // the Effect finalizers that would normally kill the child. Run the
-          // group kill from the exit hook itself; unregister when the scope
-          // closes normally so restarts/deletes don't accumulate hooks.
-          Effect.tap((child) =>
-            Effect.acquireRelease(
-              Effect.sync(() =>
-                exitHook(() => killProcessGroup(child.pid, "SIGKILL")),
-              ),
-              (unregister) => Effect.sync(unregister),
-            ),
-          ),
+          Effect.tap((child) => registerExitKill(child.pid)),
           Effect.map((child) =>
             redactChildProcessHandle(child, makeCommandRedactor(props.env)),
           ),

--- a/packages/alchemy/src/Local/RpcSpawner.ts
+++ b/packages/alchemy/src/Local/RpcSpawner.ts
@@ -19,6 +19,7 @@ import * as ChildProcess from "effect/unstable/process/ChildProcess";
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 import { fileURLToPath } from "node:url";
 import { killProcessGroup } from "../Util/killProcessGroup.ts";
+import { transformTypesFlags } from "../Util/Node.ts";
 import { httpServer } from "../Util/PlatformServices.ts";
 import { SPAWNER_URL_ENV_KEY } from "./RpcProviderProxy.ts";
 import {
@@ -113,13 +114,7 @@ export const make = Effect.fn(function* ({
         // `dev.ts` already does for the outer process, so the dev experience
         // is symmetric on both runtimes whether the entry came from `src/`
         // (dev/tests) or `lib/` (published packages).
-        node: main.endsWith(".ts")
-          ? [
-              "--experimental-transform-types",
-              "--no-warnings=ExperimentalWarning",
-              main,
-            ]
-          : [main],
+        node: main.endsWith(".ts") ? [...transformTypesFlags(), main] : [main],
       }[bin],
       {
         stdout: "pipe",

--- a/packages/alchemy/src/Util/Node.ts
+++ b/packages/alchemy/src/Util/Node.ts
@@ -1,0 +1,16 @@
+export const isTransformTypesSupported = (
+  version = process.versions.node,
+): boolean => {
+  const [major, minor] = version.split(".").map(Number);
+  return (major === 22 && minor >= 7) || (major >= 23 && major < 26);
+};
+
+/**
+ * Node CLI flags that transparently transform TypeScript types so `.ts`
+ * entry points work the same way they do under Bun. Empty when the running
+ * Node doesn't support (or no longer needs) the experimental flag.
+ */
+export const transformTypesFlags = (): string[] =>
+  isTransformTypesSupported()
+    ? ["--experimental-transform-types", "--no-warnings=ExperimentalWarning"]
+    : [];

--- a/packages/alchemy/src/Util/killProcessGroup.ts
+++ b/packages/alchemy/src/Util/killProcessGroup.ts
@@ -1,3 +1,5 @@
+import { exitHook } from "@alchemy.run/node-utils/exit-hook";
+import * as Effect from "effect/Effect";
 import * as NodeChildProcess from "node:child_process";
 
 /**
@@ -18,3 +20,17 @@ export const killProcessGroup = (pid: number, signal: NodeJS.Signals) => {
     // ignore errors during best-effort cleanup
   }
 };
+
+/**
+ * Last line of defense against abrupt process exit: exit-hook's
+ * SIGTERM/SIGINT handlers call `process.exit` synchronously (the node-utils
+ * lockfile registers one at import time), which preempts the Effect
+ * finalizers that would normally kill the child. Run the group kill from the
+ * exit hook itself; unregister when the scope closes normally so
+ * restarts/deletes don't accumulate hooks.
+ */
+export const registerExitKill = (pid: number) =>
+  Effect.acquireRelease(
+    Effect.sync(() => exitHook(() => killProcessGroup(pid, "SIGKILL"))),
+    (unregister) => Effect.sync(unregister),
+  );

--- a/packages/alchemy/test/Cloudflare/Website/Vite.test.ts
+++ b/packages/alchemy/test/Cloudflare/Website/Vite.test.ts
@@ -49,6 +49,10 @@ const tanstackDevBindingsFixtureDir = pathe.resolve(
   import.meta.dirname,
   "tanstack-dev-bindings-fixture",
 );
+const viteChildFixtureDir = pathe.resolve(
+  import.meta.dirname,
+  "vite-child-fixture",
+);
 
 // Vite/Rollup's `vite:build-html` plugin chokes when the project root
 // is outside the current working directory because it tries to express
@@ -904,6 +908,83 @@ test.provider(
       yield* waitForWorkerToBeDeleted(site.workerName, accountId);
     }).pipe(logLevel),
   { timeout: 360_000 },
+);
+
+devTest.provider(
+  "Vite dev: each app runs in a child rooted at its own cwd",
+  (stack) =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      yield* stack.destroy();
+
+      const entries = [
+        "index.html",
+        "package.json",
+        "vite.config.ts",
+        "worker.ts",
+      ];
+      const clone = (prefix: string) =>
+        cloneFixture(viteChildFixtureDir, { prefix, tempRoot, entries });
+      const [rootA, rootB] = yield* Effect.all(
+        [clone("alchemy-vite-child-a-"), clone("alchemy-vite-child-b-")],
+        { concurrency: "unbounded" },
+      );
+      yield* Effect.all([
+        fs.writeFileString(
+          path.join(rootA, "index.html"),
+          htmlPage("child-app-a"),
+        ),
+        fs.writeFileString(
+          path.join(rootB, "index.html"),
+          htmlPage("child-app-b"),
+        ),
+      ]);
+
+      const deployed = yield* stack.deploy(
+        Effect.gen(function* () {
+          const props = (rootDir: string) => ({
+            ...viteProps(rootDir, entries),
+            main: "worker.ts",
+            assets: { notFoundHandling: "single-page-application" as const },
+            dev: { port: 0 },
+          });
+          const appA = yield* Cloudflare.Website.Vite(
+            "ViteChildA",
+            props(rootA),
+          );
+          const appB = yield* Cloudflare.Website.Vite(
+            "ViteChildB",
+            props(rootB),
+          );
+          return { appA, appB };
+        }),
+      );
+
+      expect(deployed.appA.url).not.toBe(deployed.appB.url);
+      yield* Effect.all(
+        [
+          expectUrlContains(deployed.appA.url!, "child-app-a", {
+            timeout: "30 seconds",
+            label: "child A HTML",
+          }),
+          expectUrlContains(deployed.appB.url!, "child-app-b", {
+            timeout: "30 seconds",
+            label: "child B HTML",
+          }),
+          expectUrlContains(deployed.appA.url!, rootA, {
+            timeout: "30 seconds",
+            label: "child A cwd",
+          }),
+          expectUrlContains(deployed.appB.url!, rootB, {
+            timeout: "30 seconds",
+            label: "child B cwd",
+          }),
+        ],
+        { concurrency: "unbounded" },
+      );
+    }).pipe(Effect.ensuring(stack.destroy().pipe(Effect.ignore)), logLevel),
+  { timeout: 120_000 },
 );
 
 devTest.provider(

--- a/packages/alchemy/test/Cloudflare/Website/vite-child-fixture/index.html
+++ b/packages/alchemy/test/Cloudflare/Website/vite-child-fixture/index.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+  <head>
+    <title>vite-child-fixture</title>
+  </head>
+  <body>
+    vite-child-fixture
+  </body>
+</html>

--- a/packages/alchemy/test/Cloudflare/Website/vite-child-fixture/package.json
+++ b/packages/alchemy/test/Cloudflare/Website/vite-child-fixture/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "alchemy-vite-child-fixture",
+  "private": true,
+  "type": "module"
+}

--- a/packages/alchemy/test/Cloudflare/Website/vite-child-fixture/vite.config.ts
+++ b/packages/alchemy/test/Cloudflare/Website/vite-child-fixture/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [
+    {
+      name: "report-process-cwd",
+      transformIndexHtml(html) {
+        return html.replace(
+          "</head>",
+          `<meta name="vite-process-cwd" content="${process.cwd()}"></head>`,
+        );
+      },
+    },
+  ],
+});

--- a/packages/alchemy/test/Cloudflare/Website/vite-child-fixture/worker.ts
+++ b/packages/alchemy/test/Cloudflare/Website/vite-child-fixture/worker.ts
@@ -1,0 +1,7 @@
+interface Env {
+  ASSETS: Fetcher;
+}
+
+export default {
+  fetch: (request: Request, env: Env) => env.ASSETS.fetch(request),
+};

--- a/packages/alchemy/test/Util/Node.test.ts
+++ b/packages/alchemy/test/Util/Node.test.ts
@@ -1,0 +1,11 @@
+import { isTransformTypesSupported } from "@/Util/Node";
+import { describe, expect, test } from "alchemy-test";
+
+describe("Node utilities", () => {
+  test("detects versions that support --experimental-transform-types", () => {
+    expect(isTransformTypesSupported("22.6.0")).toBe(false);
+    expect(isTransformTypesSupported("22.7.0")).toBe(true);
+    expect(isTransformTypesSupported("25.9.0")).toBe(true);
+    expect(isTransformTypesSupported("26.0.0")).toBe(false);
+  });
+});


### PR DESCRIPTION
run vite server in child process to make sure everything that relies on `process.cwd()` gets correct cwd, also capture logs from processes and add `[worker] |` prefix to logs
<img width="945" height="321" alt="Screenshot 2026-08-04 at 15-24-58" src="https://github.com/user-attachments/assets/51a3c55c-6dfc-4f22-a746-bcc0d3a74672" />

fixes #1014
fixes #1019

vite side bug fix for `server.port` https://github.com/vitejs/vite/pull/23158