### PR TITLE
feat(cloudflare/workers): add Worker.lookup data source for external Workers

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/InferEnv.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/InferEnv.ts
@@ -44,6 +44,7 @@ import type { VersionMetadataBinding } from "./VersionMetadataBinding.ts";
 import type { Worker } from "./Worker.ts";
 import type { WorkerEntrypointBinding } from "./WorkerEntrypoint.ts";
 import type { WorkerLoader as WorkerLoaderResource } from "./WorkerLoader.ts";
+import type { WorkerLookup } from "./WorkerLookup.ts";
 
 export type InferEnv<W> =
   W extends Effect.Effect<infer A, infer _E, infer _R>
@@ -143,15 +144,17 @@ export type GetBindingType<T> =
                                                                   | VpcService
                                                                   | VpcServiceLookup
                                                               ? Fetcher
-                                                              : T extends
-                                                                    | PipelinesNs.Stream
-                                                                    | PipelinesNs.LegacyPipeline
-                                                                ? Pipeline
-                                                                : T extends Redacted<any>
-                                                                  ? // redacteds are always stored as secret_text, so are always string
-                                                                    // we JSON.stringify when not a Redacted<string>
-                                                                    string
-                                                                  : T;
+                                                              : T extends WorkerLookup
+                                                                ? Service
+                                                                : T extends
+                                                                      | PipelinesNs.Stream
+                                                                      | PipelinesNs.LegacyPipeline
+                                                                  ? Pipeline
+                                                                  : T extends Redacted<any>
+                                                                    ? // redacteds are always stored as secret_text, so are always string
+                                                                      // we JSON.stringify when not a Redacted<string>
+                                                                      string
+                                                                    : T;
 
 /**
  * Cloudflare service-binding wire shape for an Effect-native Worker.

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -48,6 +48,10 @@ import type {
   WorkerBindings,
 } from "./WorkerBinding.ts";
 import {
+  lookup as workerLookup,
+  type WorkerLookupProps,
+} from "./WorkerLookup.ts";
+import {
   makeWorkerRuntimeContext,
   type WorkerRuntimeContext,
 } from "./WorkerRuntimeContext.ts";
@@ -2232,6 +2236,11 @@ export const Worker: ResourceClassLike<Worker> &
      * accessor. See {@link URLEffect}.
      */
     readonly URL: URLEffect;
+    /**
+     * Reference an existing Worker managed outside this stack, by its
+     * deployed script name. See {@link workerLookup}.
+     */
+    readonly lookup: typeof workerLookup;
   } = Platform(
   WorkerTypeId,
   {
@@ -2246,5 +2255,7 @@ export const Worker: ResourceClassLike<Worker> &
       bindWorkerAsyncBindings(resource as Worker, props),
     createRuntimeContext: (id) => makeWorkerRuntimeContext(id),
   },
-  { URL },
+  // `lookup` is arrow-wrapped for the same reason the hooks above are:
+  // WorkerLookup.ts imports `WorkerTypeId` from this module.
+  { URL, lookup: (props: WorkerLookupProps) => workerLookup(props) },
 );

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
@@ -54,6 +54,7 @@ import {
 import type { WorkerBinding, WorkerBindingResource } from "./WorkerBinding.ts";
 import { isWorkerEntrypoint } from "./WorkerEntrypoint.ts";
 import { isWorkerLoader } from "./WorkerLoader.ts";
+import type { WorkerLookup } from "./WorkerLookup.ts";
 
 export const bindWorkerAsyncBindings = Effect.fn(function* (
   resource: Worker,
@@ -545,20 +546,28 @@ const toBinding = (
   } else if (Output.isOutput(binding)) {
     return Output.map(
       binding,
-      (value: Json | Redacted.Redacted<Json> | VpcServiceLookup) =>
-        // A `VpcService.lookup(...)` data source resolves to the service's
-        // attributes branded with the resource `Type`; classify it like the
-        // managed resource instead of a plain json env value.
+      (
+        value: Json | Redacted.Redacted<Json> | VpcServiceLookup | WorkerLookup,
+      ) =>
+        // A `lookup(...)` data source resolves to the target's attributes
+        // branded with the resource `Type`; classify it like the managed
+        // resource instead of a plain json env value.
         isVpcService(value)
           ? {
               type: "vpc_service" as const,
               name: bindingName,
               serviceId: (value as VpcServiceLookup).serviceId,
             }
-          : toValueBinding(
-              bindingName,
-              value as Json | Redacted.Redacted<Json>,
-            ),
+          : isWorker(value)
+            ? {
+                type: "service" as const,
+                name: bindingName,
+                service: (value as WorkerLookup).workerName,
+              }
+            : toValueBinding(
+                bindingName,
+                value as Json | Redacted.Redacted<Json>,
+              ),
     );
   } else {
     return {

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerBinding.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerBinding.ts
@@ -42,6 +42,7 @@ import type { VersionMetadataBinding } from "./VersionMetadataBinding.ts";
 import { Worker, WorkerEnvironment } from "./Worker.ts";
 import type { WorkerEntrypointBinding } from "./WorkerEntrypoint.ts";
 import type { WorkerLoader } from "./WorkerLoader.ts";
+import type { WorkerLookup } from "./WorkerLookup.ts";
 
 type DistilledWorkerBinding = Exclude<
   workers.PutScriptRequest["metadata"]["bindings"],
@@ -197,6 +198,7 @@ export type WorkerBindingResource =
   | Secret
   | Worker
   | WorkerEntrypointBinding
+  | WorkerLookup
   | WorkerLoader
   | VersionMetadataBinding
   // The Worker's own URL (`Worker.URL`).

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerLookup.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerLookup.ts
@@ -1,0 +1,75 @@
+import * as workers from "@distilled.cloud/cloudflare/workers";
+import * as Effect from "effect/Effect";
+
+import * as Output from "../../Output.ts";
+import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
+import { WorkerTypeId } from "./Worker.ts";
+
+export type WorkerLookupProps = {
+  /**
+   * Deployed script name of the Worker.
+   */
+  name: string;
+};
+
+/**
+ * The resolved value of a {@link lookup} — the external Worker's identifying
+ * attributes branded with the Worker resource `Type`, so Worker binding
+ * classification treats it exactly like a managed Worker.
+ */
+export interface WorkerLookup {
+  readonly Type: typeof WorkerTypeId;
+  readonly workerId: string;
+  readonly workerName: string;
+  readonly accountId: string;
+}
+
+/**
+ * Look up an existing Cloudflare Worker (managed outside this stack) without
+ * managing its lifecycle — the data-source form (what Terraform calls a data
+ * source and Pulumi an invoke). Reads the script by `name` and returns an
+ * `Output` of its identifying attributes, resolved during plan/deploy and
+ * inert inside deployed bundles. Place it in a Worker's `env` to attach a
+ * `service` binding.
+ *
+ * Fails the deploy when no Worker of that name exists on the account. The
+ * target is never created, updated, or deleted by this stack.
+ * @resource
+ * @product Workers
+ * @category Workers & Compute
+ * @section Referencing an External Worker
+ * @example Look up by name
+ * ```typescript
+ * const auth = Cloudflare.Worker.lookup({ name: "auth-service" });
+ * ```
+ *
+ * @example Bind to a Worker
+ * ```typescript
+ * const worker = yield* Cloudflare.Worker("Worker", {
+ *   main: "./src/worker.ts",
+ *   env: { AUTH: Cloudflare.Worker.lookup({ name: "auth-service" }) },
+ * });
+ * ```
+ */
+export const lookup = (props: WorkerLookupProps) =>
+  Output.fromEffect(
+    Effect.gen(function* () {
+      const { accountId } = yield* yield* CloudflareEnvironment;
+      // Fails with `WorkerNotFound` when the script doesn't exist — the
+      // existence check, without pulling down the script content.
+      yield* workers
+        .getScriptScriptAndVersionSetting({ accountId, scriptName: props.name })
+        .pipe(
+          Effect.catchTag("WorkerNotFound", () =>
+            Effect.die(`Worker "${props.name}" not found`),
+          ),
+        );
+      // A Worker's script name is its id.
+      return {
+        Type: WorkerTypeId,
+        workerId: props.name,
+        workerName: props.name,
+        accountId,
+      } satisfies WorkerLookup;
+    }).pipe(Effect.orDie),
+  );

--- a/packages/alchemy/src/Cloudflare/Workers/index.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/index.ts
@@ -39,4 +39,8 @@ export * from "./WorkerBinding.ts";
 export * from "./WorkerBridge.ts";
 export * from "./WorkerEntrypoint.ts";
 export * from "./WorkerLoader.ts";
+// Types only — this module is re-exported flat from `Cloudflare/index.ts`, so
+// a bare `lookup` export would surface as `Cloudflare.lookup`. It is reachable
+// as `Cloudflare.Worker.lookup(...)`.
+export type { WorkerLookup, WorkerLookupProps } from "./WorkerLookup.ts";
 export * from "./WorkerProvider.ts";

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerLookup.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerLookup.test.ts
@@ -1,0 +1,158 @@
+import * as Cloudflare from "@/Cloudflare";
+import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
+import * as Test from "@/Test/Alchemy";
+import * as workers from "@distilled.cloud/cloudflare/workers";
+import { expect } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import { MinimumLogLevel } from "effect/References";
+import * as Schedule from "effect/Schedule";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+
+const { test } = Test.make({ providers: Cloudflare.providers() });
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+const targetScript = `export default {
+  async fetch() {
+    return new Response("hello from target");
+  },
+};
+`;
+
+// Forwards to the managed binding or the lookup binding, per path.
+const consumerScript = `export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    if (url.pathname.startsWith("/managed")) {
+      return env.TARGET_MANAGED.fetch(new Request("https://target/"));
+    }
+    if (url.pathname.startsWith("/lookup")) {
+      return env.TARGET_LOOKUP.fetch(new Request("https://target/"));
+    }
+    return new Response("ok");
+  },
+};
+`;
+
+// Yielded in both deploys (same logical id), so the first deploy creates it and
+// the second is a no-op reconcile that keeps it alive while the consumer binds.
+const targetWorker = Cloudflare.Worker("lookup-target-worker", {
+  script: targetScript,
+});
+
+// Read the worker's live `service` bindings out-of-band from the script
+// settings API.
+const readServiceBindings = (scriptName: string) =>
+  Effect.gen(function* () {
+    const { accountId } = yield* yield* CloudflareEnvironment;
+    const settings = yield* workers.getScriptScriptAndVersionSetting({
+      accountId,
+      scriptName,
+    });
+    return (settings.bindings ?? []).filter(
+      (b): b is Extract<typeof b, { type: "service" }> => b.type === "service",
+    );
+  });
+
+// A freshly-deployed workers.dev URL 404s for a few seconds before it starts
+// serving.
+const getText = (url: string) =>
+  Effect.gen(function* () {
+    const client = yield* HttpClient.HttpClient;
+    const res = yield* client.get(url).pipe(
+      Effect.flatMap((res) =>
+        res.status === 200
+          ? Effect.succeed(res)
+          : Effect.fail(new Error(`worker not ready: ${res.status}`)),
+      ),
+      Effect.retry({
+        schedule: Schedule.min([
+          Schedule.exponential("500 millis"),
+          Schedule.spaced("3 seconds"),
+        ]),
+        times: 15,
+      }),
+    );
+    return yield* res.text;
+  });
+
+test.provider(
+  "looks up a worker by name and binds it to a worker",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const target = yield* stack.deploy(targetWorker);
+
+      // Bind it two ways — the managed resource directly, and a `lookup` data
+      // source by deployed name. Both emit a `service` binding. The lookup is
+      // also returned as a stack output, pinning plan-time Output resolution.
+      const { looked, consumer } = yield* stack.deploy(
+        Effect.gen(function* () {
+          const managed = yield* targetWorker;
+          const consumer = yield* Cloudflare.Worker("lookup-consumer-worker", {
+            script: consumerScript,
+            env: {
+              TARGET_MANAGED: managed,
+              TARGET_LOOKUP: Cloudflare.Worker.lookup({
+                name: target.workerName,
+              }),
+            },
+          });
+          return {
+            looked: Cloudflare.Worker.lookup({ name: target.workerName }),
+            consumer,
+          };
+        }),
+      );
+
+      expect(looked.workerName).toEqual(target.workerName);
+      expect(looked.workerId).toEqual(target.workerName);
+
+      const services = yield* readServiceBindings(consumer.workerName);
+      expect(
+        services.find((b) => b.name === "TARGET_MANAGED")?.service,
+      ).toEqual(target.workerName);
+      expect(services.find((b) => b.name === "TARGET_LOOKUP")?.service).toEqual(
+        target.workerName,
+      );
+
+      expect(yield* getText(`${consumer.url!}/managed`)).toBe(
+        "hello from target",
+      );
+      expect(yield* getText(`${consumer.url!}/lookup`)).toBe(
+        "hello from target",
+      );
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 180_000 },
+);
+
+test.provider(
+  "fails the deploy when the looked-up worker does not exist",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const exit = yield* Effect.exit(
+        stack.deploy(
+          Effect.gen(function* () {
+            return {
+              missing: Cloudflare.Worker.lookup({
+                name: "alchemy-worker-lookup-does-not-exist",
+              }),
+            };
+          }),
+        ),
+      );
+      expect(Exit.isFailure(exit)).toBe(true);
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 120_000 },
+);


### PR DESCRIPTION
Reference a Worker deployed outside the stack (Wrangler, the dashboard, another pipeline) and bind it as a `service` binding, without provisioning or taking ownership of it.

    env: { AUTH: Cloudflare.Worker.lookup({ name: "auth-service" }) }

Follows the VpcService.lookup shape: an Output that reads the live account during plan/deploy and resolves to the target's attributes branded with the resource Type, so binding classification treats it like the managed resource. Existence is probed via getScriptScriptAndVersionSetting, so a name typo fails the deploy rather than producing a broken binding.

Exported from Workers/index.ts as types only — that module is re-exported flat from Cloudflare/index.ts, so a bare `lookup` const would surface as `Cloudflare.lookup`.