### PR TITLE
fix(cloudflare/vite): hash the real root when `rootDir` is relative

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -2220,15 +2220,25 @@ export const LiveWorkerProvider = () =>
         options: ViteOptions["memo"],
         additionalWorkspaces: Effect.Effect<Iterable<string>, E>,
       ) {
+        // Resolved once: every workspace cwd is relative to the Vite root, so
+        // the root must be an absolute base. Resolving it per call and passing
+        // `rootDir` as its own cwd would apply a relative root twice
+        // (`path.resolve("app", "app")` → `<cwd>/app/app`), hashing a
+        // directory that doesn't exist — a constant hash that never registers
+        // an edit, so the deploy no-ops forever. See issue #1016.
+        const resolvedRoot = path.resolve(rootDir);
         // Relative paths participate in memo hashes and surface in outputs;
         // keep them POSIX so Windows and CI agree.
         const relativeToRoot = (cwd: string) =>
-          path.relative(rootDir, cwd).replaceAll("\\", "/");
+          path
+            .relative(resolvedRoot, path.resolve(resolvedRoot, cwd))
+            .replaceAll("\\", "/");
         const hashWorkspaceDirectory = (cwd: string, memo?: MemoOptions) =>
-          hashDirectory({ cwd: path.resolve(rootDir, cwd), memo }).pipe(
+          hashDirectory({ cwd: path.resolve(resolvedRoot, cwd), memo }).pipe(
             Effect.map((hash) => `${relativeToRoot(cwd)}:${hash}`),
           );
-        const hashRoot = hashWorkspaceDirectory(rootDir, options);
+        // `"."` — the root itself, never re-applied on top of itself.
+        const hashRoot = hashWorkspaceDirectory(".", options);
         if (Array.isArray(options?.workspaces)) {
           return yield* Effect.all(
             [

--- a/packages/alchemy/test/Cloudflare/Website/Vite.test.ts
+++ b/packages/alchemy/test/Cloudflare/Website/Vite.test.ts
@@ -130,6 +130,67 @@ test.provider(
   { timeout: 360_000 },
 );
 
+// Regression test for https://github.com/alchemy-run/alchemy/issues/1016.
+//
+// `hashViteInput` used to pass a relative root as both the directory and its
+// base, resolving `app` as `<cwd>/app/app`. The empty match produced a constant
+// input hash, so source edits were incorrectly treated as no-ops.
+test.provider(
+  "Vite: a source edit changes the input hash when rootDir is relative",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* yield* CloudflareEnvironment;
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+
+      yield* stack.destroy();
+
+      const absoluteRoot = yield* cloneFixture(fixtureDir, {
+        prefix: "alchemy-vite-relative-root-",
+        tempRoot,
+        entries: ["index.html", "package.json", "vite.config.ts", "src"],
+      });
+      const rootDir = path.relative(process.cwd(), absoluteRoot);
+      const indexPath = path.join(absoluteRoot, "index.html");
+      const memoInclude = [
+        "index.html",
+        "src/**",
+        "package.json",
+        "vite.config.ts",
+      ];
+
+      expect(path.isAbsolute(rootDir)).toBe(false);
+      yield* fs.writeFileString(indexPath, htmlPage("relative-root-v1"));
+
+      const site1 = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.Website.Vite(
+            "ViteRelativeRoot",
+            viteProps(rootDir, memoInclude),
+          );
+        }),
+      );
+      expect(site1.hash?.input).toBeDefined();
+
+      yield* fs.writeFileString(indexPath, htmlPage("relative-root-v2"));
+
+      const site2 = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.Website.Vite(
+            "ViteRelativeRoot",
+            viteProps(rootDir, memoInclude),
+          );
+        }),
+      );
+      expect(site2.hash?.input).toBeDefined();
+      expect(site2.hash?.input).not.toEqual(site1.hash?.input);
+
+      yield* stack.destroy();
+      yield* waitForWorkerToBeDeleted(site1.workerName, accountId);
+    }).pipe(logLevel),
+  { timeout: 360_000 },
+);
+
 // Regression test for https://github.com/alchemy-run/alchemy/issues/792.
 //
 // A pure client-only Vite project (no vite.config.ts, no plugins, no worker


### PR DESCRIPTION
`hashViteInput` passed `rootDir` as both the base and the cwd of `hashWorkspaceDirectory`, so a relative root was applied twice:

```
path.resolve("app", "app")  ->  <cwd>/app/app   // does not exist
```

fast-glob matched nothing there, making the input hash a constant that never changed — so `alchemy deploy` reported "no change" after every source edit and kept serving stale assets (`--force` was the workaround). An absolute `rootDir` was unaffected, since `path.resolve(abs, abs)` returns `abs` — which is why the existing coverage, built on absolute temp dirs, never caught it.

Resolve the root once and pass `"."` as its own cwd. The root's hash key stays `""`, so deployments that were already hashing correctly keep their input hash and don't rebuild.

Fixes #1016