### PR TITLE
fix(alchemy-test): restore collection under Bun 1.3.14

### DIFF
--- a/packages/alchemy-test/src/AsyncContextProbe.ts
+++ b/packages/alchemy-test/src/AsyncContextProbe.ts
@@ -1,0 +1,14 @@
+/**
+ * Side-effect-only module used by `Registry.probeAsyncContext` to detect
+ * whether the host runtime propagates AsyncLocalStorage into the top-level
+ * evaluation of a dynamically imported module.
+ *
+ * It MUST NOT be imported statically anywhere — the probe relies on this
+ * module being evaluated exactly once, inside the probe's `storage.run`.
+ * A `data:` URL module is NOT a valid substitute: Bun evaluates those
+ * without the importer's async context on every version tested, so the
+ * probe would report a false negative on runtimes that are fine.
+ */
+const key = Symbol.for("alchemy-test/async-context-probe");
+
+((globalThis as any)[key] as (() => void) | undefined)?.();

--- a/packages/alchemy-test/src/Registry.ts
+++ b/packages/alchemy-test/src/Registry.ts
@@ -10,6 +10,12 @@
  * registrations resolve to its own root no matter how many imports are in
  * flight.
  *
+ * That propagation is NOT universal: Bun dropped it in 1.3.14 (1.3.13 and
+ * earlier propagate; Node does too), which makes every registration throw
+ * "called outside of a test file collection". `probeAsyncContext` detects
+ * the behaviour at startup and the runner falls back to SERIAL collection,
+ * where the ambient `serialContext` below is an unambiguous stand-in.
+ *
  * The storage lives on `globalThis` so that a duplicated module instance
  * (e.g. two resolutions of the package) still shares one registry.
  */
@@ -27,6 +33,13 @@ const storage: AsyncLocalStorage<FileContext> = ((globalThis as any)[key] ??=
   new AsyncLocalStorage<FileContext>());
 
 /**
+ * Ambient collector for runtimes that lose the async context across module
+ * evaluation. Only sound while collection is serial — the runner guarantees
+ * that by dropping collect concurrency to 1 when `probeAsyncContext` fails.
+ */
+let serialContext: FileContext | undefined;
+
+/**
  * Collect one file: run `f` (the file's dynamic import + microtask flush)
  * with a fresh root as the ambient collector, and return the root.
  */
@@ -35,12 +48,43 @@ export const collect = async (
   f: () => Promise<void>,
 ): Promise<FileSuite> => {
   const root = makeFileSuite(file);
-  await storage.run({ current: root }, f);
+  const context: FileContext = { current: root };
+  const previous = serialContext;
+  serialContext = context;
+  try {
+    await storage.run(context, f);
+  } finally {
+    serialContext = previous;
+  }
   return root;
 };
 
+/**
+ * True when the runtime propagates AsyncLocalStorage into the top-level
+ * evaluation of a dynamically imported module — i.e. when test files may be
+ * collected concurrently. Imports a real on-disk module (a `data:` URL is
+ * evaluated without the importer's context even on runtimes that are fine,
+ * so it would report a false negative) exactly once per process.
+ */
+export const probeAsyncContext = async (): Promise<boolean> => {
+  const key = Symbol.for("alchemy-test/async-context-probe");
+  let propagated = false;
+  (globalThis as any)[key] = () => {
+    propagated = storage.getStore() !== undefined;
+  };
+  try {
+    await storage.run(
+      { current: makeFileSuite("<probe>") },
+      () => import("./AsyncContextProbe.ts"),
+    );
+  } finally {
+    delete (globalThis as any)[key];
+  }
+  return propagated;
+};
+
 const currentContext = (): FileContext => {
-  const context = storage.getStore();
+  const context = storage.getStore() ?? serialContext;
   if (context === undefined) {
     throw new Error(
       "alchemy-test: describe/test/hook called outside of a test file collection. " +

--- a/packages/alchemy-test/src/Runner.ts
+++ b/packages/alchemy-test/src/Runner.ts
@@ -744,8 +744,19 @@ export const run = Effect.fn(function* (options: RunOptions) {
   // hang), and it maximizes exposure to loader races under concurrent
   // dynamic imports. The shared dependency graph is deduped by the module
   // cache, so a modest bound keeps nearly all of the speedup.
-  const collectConcurrency =
-    options.concurrency === "unbounded"
+  //
+  // …unless the runtime doesn't propagate AsyncLocalStorage into module
+  // evaluation (Bun >= 1.3.14), in which case attribution is only sound
+  // when exactly one file is being collected at a time. Detected by probe,
+  // never by version sniffing: the behaviour first shipped in a Bun 1.4
+  // preview and was then back-ported into the 1.3 line, so a version test
+  // silently mis-classifies.
+  const concurrentCollectionSafe = yield* Effect.promise(
+    Registry.probeAsyncContext,
+  );
+  const collectConcurrency = !concurrentCollectionSafe
+    ? 1
+    : options.concurrency === "unbounded"
       ? 32
       : Math.min(options.concurrency, 32);
   // collectFile never fails — import errors are captured on the result.


### PR DESCRIPTION
Bun 1.3.14 stopped propagating `AsyncLocalStorage` into the top-level evaluation of dynamically imported modules — the mechanism `alchemy-test` uses to establish each file's collection context. On Bun >= 1.3.14 every `bun run test` invocation dies at collection:

```
Error: alchemy-test: describe/test/hook called outside of a test file collection.
       Run tests with the `alchemy-test` CLI.
  at currentContext (packages/alchemy-test/src/Registry.ts:45)
```

Minimal repro (passes on <= 1.3.13 and node, fails on 1.3.14):

```ts
const s = new AsyncLocalStorage();
(globalThis as any).__als = s;
await s.run(7, () => import("./probe.ts"));
// probe.ts reads __als.getStore() at module top level → undefined on 1.3.14
```

The fix detects the behavior at runtime instead of sniffing versions (the regression shipped in a 1.4 preview and was back-ported into the 1.3 line, so version checks are unreliable):

- `AsyncContextProbe.ts` — one-shot probe importing a real on-disk module. A `data:` URL module reports `undefined` on **every** Bun version, so the probe must be a file.
- `Registry.ts` — restores an ambient `serialContext` fallback: `storage.getStore() ?? serialContext`.
- `Runner.ts` — drops collection concurrency to 1 when the probe fails.

Serial collection costs ~2% (18.4s vs 18.1s across 803 files) — collection is transpile-bound, so the old concurrency bought essentially nothing.

Note: the `check` workflow never executes the test runner, so this class of regression is invisible to CI — but every contributor on a current Bun hits it locally.
