### PR TITLE
ci: use prod & main as stages for deployment

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -33,7 +33,7 @@ env:
   STAGE: ${{ github.event_name == 'pull_request' && format('pr-{0}',
     github.event.number) || (github.event_name == 'workflow_dispatch' ||
     startsWith(github.event.head_commit.message, 'chore(release):')) && 'prod' ||
-    (github.ref == 'refs/heads/main' && 'staging' || github.ref_name) }}
+    (github.ref == 'refs/heads/main' && 'main' || github.ref_name) }}
 
 jobs:
   deploy:
@@ -85,8 +85,8 @@ jobs:
         run: bun alchemy deploy --stage "$STAGE" --yes
         env:
           PULL_REQUEST: ${{ github.event.number }}
-          CLOUDFLARE_API_TOKEN: ${{ startsWith(env.STAGE, 'prod') && secrets.PROD_CLOUDFLARE_API_TOKEN || secrets.TEST_CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ startsWith(env.STAGE, 'prod') && secrets.PROD_CLOUDFLARE_ACCOUNT_ID || secrets.TEST_CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ (env.STAGE == 'main' || env.STAGE == 'prod') && secrets.PROD_CLOUDFLARE_API_TOKEN || secrets.TEST_CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ (env.STAGE == 'main' || env.STAGE == 'prod') && secrets.PROD_CLOUDFLARE_ACCOUNT_ID || secrets.TEST_CLOUDFLARE_ACCOUNT_ID }}
           BUILD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           GITHUB_TOKEN: ${{ steps.bot-token.outputs.token }}
 

--- a/website/alchemy.run.ts
+++ b/website/alchemy.run.ts
@@ -24,7 +24,7 @@ const Website = Cloudflare.Website.StaticSite(
         domain:
           stack.stage === "prod"
             ? { name: "alchemy.run", redirects: ["v2.alchemy.run"] }
-            : stack.stage === "staging"
+            : stack.stage === "main"
               ? { name: "main.alchemy.run" }
               : undefined,
         memo: {


### PR DESCRIPTION
`staging` never deployed successfully due to misconfig
fixed it and renamed to `main` for keeping consistency