### PR TITLE
fix(bundle): externalize the workerd virtual module

### DIFF
--- a/packages/alchemy/bin/exec.ts
+++ b/packages/alchemy/bin/exec.ts
@@ -1,4 +1,4 @@
-import { exec } from "alchemy/Cli";
+import { exec } from "alchemy/Cli/exec";
 import { runMain } from "alchemy/Util/PlatformServices";
 
 exec().pipe(runMain);

--- a/packages/alchemy/src/AWS/Lambda/FunctionBundle.ts
+++ b/packages/alchemy/src/AWS/Lambda/FunctionBundle.ts
@@ -168,6 +168,11 @@ export const makeFunctionBundler = Effect.gen(function* () {
       parentId: string | undefined,
       isResolved: boolean,
     ): boolean => {
+      // Alchemy's cross-provider runtime helpers contain a guarded dynamic
+      // import of workerd's virtual module. A Lambda can never resolve it;
+      // keep the import external so the runtime fallback handles it instead
+      // of tripping [UNRESOLVED_IMPORT] before dead-code elimination.
+      if (moduleId === "cloudflare:workers") return true;
       if (moduleId.startsWith("@aws-sdk/")) return true;
       for (const root of installRoots) {
         if (matchesPackageRoot(moduleId, root)) return true;

--- a/packages/alchemy/test/Bundle/NamespaceInitialization.test.ts
+++ b/packages/alchemy/test/Bundle/NamespaceInitialization.test.ts
@@ -67,7 +67,6 @@ layer(NodeServices.layer)("Bundle namespace initialization", (it) => {
           const plan = yield* bundler.resolveBundlePlan({
             main: entry,
             isExternal: true,
-            build: { external: ["cloudflare:workers"] },
           } as FunctionZipProps);
           const bundle = yield* Bundle.build(
             plan.inputOptions,

--- a/packages/alchemy/tsdown.config.ts
+++ b/packages/alchemy/tsdown.config.ts
@@ -23,6 +23,10 @@ export default [
   // the cli bundle below).
   defineConfig({
     entry: ["bin/exec.ts"],
+    // Supplied by workerd at runtime; it has no filesystem existence, and
+    // rolldown resolves before tree-shaking, so the guarded import trips
+    // [UNRESOLVED_IMPORT] even though it is dead code outside workerd.
+    external: ["cloudflare:workers"],
     format: ["esm"],
     clean: false,
     shims: true,

--- a/packages/alchemy/tsdown.config.ts
+++ b/packages/alchemy/tsdown.config.ts
@@ -23,10 +23,6 @@ export default [
   // the cli bundle below).
   defineConfig({
     entry: ["bin/exec.ts"],
-    // Supplied by workerd at runtime; it has no filesystem existence, and
-    // rolldown resolves before tree-shaking, so the guarded import trips
-    // [UNRESOLVED_IMPORT] even though it is dead code outside workerd.
-    external: ["cloudflare:workers"],
     format: ["esm"],
     clean: false,
     shims: true,


### PR DESCRIPTION
Keep workerd's virtual module external when bundling Lambda functions whose dependency graph reaches Cloudflare runtime helpers outside workerd.

```ts
if (moduleId === "cloudflare:workers") return true;
```

The Lambda bundler applies this by default, and the regression exercises the Lambda plan without a caller-provided workaround.

The packaged dev executable does not need the workerd virtual module. It now imports the leaf `alchemy/Cli/exec` entry instead of traversing the full CLI barrel and Cloudflare graph, so its tsdown configuration needs no special externalization.

The isolated-install resolution architecture is handled by #1324; this PR retains only the independent runtime-module externalization.
