### PR TITLE
fix(core): infinite recursion on cyclic props and class-instance flattening in the engine's prop walkers

### DIFF
--- a/packages/alchemy/src/Diff.ts
+++ b/packages/alchemy/src/Diff.ts
@@ -44,12 +44,27 @@ export const hasUnresolvedInputs = <T>(value: Input<NoInfer<T>>): value is T =>
 export const isResolved = <T>(value: Input<T>): value is T =>
   !_hasUnresolved(value);
 
-const _hasUnresolved = (value: unknown): boolean => {
+const _hasUnresolved = (
+  value: unknown,
+  seen: WeakSet<object> = new WeakSet(),
+): boolean => {
   if (value == null || isPrimitive(value)) return false;
   if (Output.isExpr(value) || Effect.isEffect(value)) return true;
-  if (Array.isArray(value)) return value.some(_hasUnresolved);
+  // Layer/Context leaves (Effects are caught above): runtime-only values
+  // whose internals must not be walked — cyclic on effect ≥4.0.0-beta.103
+  // (#1082).
+  if (Output.isOpaqueRuntimeValue(value)) return false;
+  if (Array.isArray(value)) {
+    if (seen.has(value)) return false;
+    seen.add(value);
+    return value.some((v) => _hasUnresolved(v, seen));
+  }
   if (typeof value === "object") {
-    return Object.values(value as Record<string, unknown>).some(_hasUnresolved);
+    if (seen.has(value)) return false;
+    seen.add(value);
+    return Object.values(value as Record<string, unknown>).some((v) =>
+      _hasUnresolved(v, seen),
+    );
   }
   return false;
 };
@@ -73,7 +88,16 @@ export const stripUnresolved = <T>(value: T): T => _stripUnresolved(value) as T;
 
 const _stripUnresolved = (value: unknown): unknown => {
   if (value == null || isPrimitive(value)) return value;
-  if (Output.isExpr(value) || Effect.isEffect(value)) return undefined;
+  // Layer/Context are dropped like Effects: runtime-only wiring that can't
+  // be persisted (a Context is cyclic on effect ≥4.0.0-beta.103, so it
+  // can't even round-trip through JSON — #1082).
+  if (
+    Output.isExpr(value) ||
+    Effect.isEffect(value) ||
+    Output.isOpaqueRuntimeValue(value)
+  ) {
+    return undefined;
+  }
   // Opaque resolved values — rebuilding them structurally would strip
   // their prototype (see resolveInput in Plan.ts for the same rule).
   if (Redacted.isRedacted(value) || Duration.isDuration(value)) return value;
@@ -106,7 +130,11 @@ const _stripEffects = (value: unknown): unknown => {
   // must be tested BEFORE `Effect.isEffect` because Output exprs are
   // yieldable and would otherwise be misclassified as plain Effects.
   if (Output.isExpr(value)) return value;
-  if (Effect.isEffect(value)) return undefined;
+  // Layer/Context are dropped with Effects — same runtime-only rationale,
+  // and their internals are cyclic on effect ≥4.0.0-beta.103 (#1082).
+  if (Effect.isEffect(value) || Output.isOpaqueRuntimeValue(value)) {
+    return undefined;
+  }
   if (Redacted.isRedacted(value) || Duration.isDuration(value)) return value;
   if (Array.isArray(value)) return value.map(_stripEffects);
   if (typeof value === "object") {
@@ -193,6 +221,9 @@ export const deepEqual = (
 
 const canonicalize = (value: unknown, stripNullish: boolean): unknown => {
   if (stripNullish && value == null) return undefined;
+  // Effect/Layer/Context can reach here through provider-supplied values;
+  // never walk them (cyclic on effect ≥4.0.0-beta.103 — #1082).
+  if (Output.isOpaqueRuntimeValue(value)) return undefined;
   if (Redacted.isRedacted(value)) {
     return {
       _tag: "Redacted",

--- a/packages/alchemy/src/Diff.ts
+++ b/packages/alchemy/src/Diff.ts
@@ -5,7 +5,7 @@ import type { Input } from "./Input.ts";
 import * as Output from "./Output.ts";
 import type { BindingNode } from "./Plan.ts";
 import type { ResourceBinding } from "./Resource.ts";
-import { isPlainData, isPrimitive } from "./Util/data.ts";
+import { isPlainData, isPrimitive, mapPlainData } from "./Util/data.ts";
 
 export type Diff = NoopDiff | UpdateDiff | ReplaceDiff;
 
@@ -98,21 +98,9 @@ const _stripUnresolved = (
     return value;
   }
   if (isPlainData(value)) {
-    if (ancestors.has(value)) return undefined;
-    ancestors.add(value);
-    try {
-      if (Array.isArray(value)) {
-        return value.map((item) => _stripUnresolved(item, ancestors));
-      }
-      return Object.fromEntries(
-        Object.entries(value).map(([key, item]) => [
-          key,
-          _stripUnresolved(item, ancestors),
-        ]),
-      );
-    } finally {
-      ancestors.delete(value);
-    }
+    return mapPlainData(value, ancestors, (child) =>
+      _stripUnresolved(child, ancestors),
+    );
   }
   // Any other class instance (Layer, Context, SDK objects) is runtime-only
   // wiring that can't round-trip through JSON — a beta.103 Context is even
@@ -153,21 +141,9 @@ const _stripEffects = (
     return value;
   }
   if (isPlainData(value)) {
-    if (ancestors.has(value)) return undefined;
-    ancestors.add(value);
-    try {
-      if (Array.isArray(value)) {
-        return value.map((item) => _stripEffects(item, ancestors));
-      }
-      return Object.fromEntries(
-        Object.entries(value).map(([key, item]) => [
-          key,
-          _stripEffects(item, ancestors),
-        ]),
-      );
-    } finally {
-      ancestors.delete(value);
-    }
+    return mapPlainData(value, ancestors, (child) =>
+      _stripEffects(child, ancestors),
+    );
   }
   // Non-plain instances (Layer, Context, SDK objects) are dropped with
   // Effects — same runtime-only rationale, and their internals may be
@@ -266,24 +242,18 @@ const canonicalize = (
   // toJSON).
   if (Duration.isDuration(value) || value instanceof Date) return value;
   if (isPlainData(value)) {
-    if (ancestors.has(value)) return undefined;
-    ancestors.add(value);
-    try {
-      if (Array.isArray(value)) {
-        return value.map((v) => canonicalize(v, stripNullish, ancestors));
-      }
-      return Object.fromEntries(
-        Object.entries(value)
-          .filter(([, nested]) => !stripNullish || nested != null)
-          .sort(([a], [b]) => a.localeCompare(b))
-          .map(([key, nested]) => [
-            key,
-            canonicalize(nested, stripNullish, ancestors),
-          ]),
-      );
-    } finally {
-      ancestors.delete(value);
-    }
+    const rebuilt = mapPlainData(value, ancestors, (child) =>
+      canonicalize(child, stripNullish, ancestors),
+    );
+    if (rebuilt === undefined || Array.isArray(rebuilt)) return rebuilt;
+    // Deterministic key order for the JSON.stringify comparison. Filtering
+    // after the walk is JSON-equivalent to filtering before it —
+    // undefined-valued keys are dropped by JSON.stringify either way.
+    return Object.fromEntries(
+      Object.entries(rebuilt as Record<string, unknown>)
+        .filter(([, nested]) => !stripNullish || nested != null)
+        .sort(([a], [b]) => a.localeCompare(b)),
+    );
   }
   if (value && typeof value === "object") {
     // Non-plain instances (Effect, Layer, Context, SDK objects) never

--- a/packages/alchemy/src/Diff.ts
+++ b/packages/alchemy/src/Diff.ts
@@ -5,7 +5,7 @@ import type { Input } from "./Input.ts";
 import * as Output from "./Output.ts";
 import type { BindingNode } from "./Plan.ts";
 import type { ResourceBinding } from "./Resource.ts";
-import { isPrimitive } from "./Util/data.ts";
+import { isPlainData, isPrimitive } from "./Util/data.ts";
 
 export type Diff = NoopDiff | UpdateDiff | ReplaceDiff;
 
@@ -50,21 +50,12 @@ const _hasUnresolved = (
 ): boolean => {
   if (value == null || isPrimitive(value)) return false;
   if (Output.isExpr(value) || Effect.isEffect(value)) return true;
-  // Layer/Context leaves (Effects are caught above): runtime-only values
-  // whose internals must not be walked — cyclic on effect ≥4.0.0-beta.103
-  // (#1082).
-  if (Output.isOpaqueRuntimeValue(value)) return false;
-  if (Array.isArray(value)) {
+  // Only plain data is traversed; any other class instance (Layer, Context,
+  // Date, SDK objects) is a resolved leaf — see isPlainData (#1082).
+  if (isPlainData(value)) {
     if (seen.has(value)) return false;
     seen.add(value);
-    return value.some((v) => _hasUnresolved(v, seen));
-  }
-  if (typeof value === "object") {
-    if (seen.has(value)) return false;
-    seen.add(value);
-    return Object.values(value as Record<string, unknown>).some((v) =>
-      _hasUnresolved(v, seen),
-    );
+    return Object.values(value).some((v) => _hasUnresolved(v, seen));
   }
   return false;
 };
@@ -86,28 +77,47 @@ const _hasUnresolved = (
  */
 export const stripUnresolved = <T>(value: T): T => _stripUnresolved(value) as T;
 
-const _stripUnresolved = (value: unknown): unknown => {
+const _stripUnresolved = (
+  value: unknown,
+  // Ancestor-path cycle guard: a value on its own ancestor chain is cut to
+  // `undefined` (a cycle can never persist). Sync DFS, so add/delete around
+  // the recursion is race-free and keeps shared diamond references intact
+  // (#1082).
+  ancestors: WeakSet<object> = new WeakSet(),
+): unknown => {
   if (value == null || isPrimitive(value)) return value;
-  // Layer/Context are dropped like Effects: runtime-only wiring that can't
-  // be persisted (a Context is cyclic on effect ≥4.0.0-beta.103, so it
-  // can't even round-trip through JSON — #1082).
+  if (Output.isExpr(value) || Effect.isEffect(value)) return undefined;
+  // Serializable leaves — the only class instances persisted state may
+  // carry (StateEncoding knows Redacted/Duration; Date JSON-encodes).
+  // Rebuilding them structurally would strip their prototype.
   if (
-    Output.isExpr(value) ||
-    Effect.isEffect(value) ||
-    Output.isOpaqueRuntimeValue(value)
+    Redacted.isRedacted(value) ||
+    Duration.isDuration(value) ||
+    value instanceof Date
   ) {
-    return undefined;
+    return value;
   }
-  // Opaque resolved values — rebuilding them structurally would strip
-  // their prototype (see resolveInput in Plan.ts for the same rule).
-  if (Redacted.isRedacted(value) || Duration.isDuration(value)) return value;
-  if (Array.isArray(value)) return value.map(_stripUnresolved);
-  if (typeof value === "object") {
-    return Object.fromEntries(
-      Object.entries(value).map(([key, item]) => [key, _stripUnresolved(item)]),
-    );
+  if (isPlainData(value)) {
+    if (ancestors.has(value)) return undefined;
+    ancestors.add(value);
+    try {
+      if (Array.isArray(value)) {
+        return value.map((item) => _stripUnresolved(item, ancestors));
+      }
+      return Object.fromEntries(
+        Object.entries(value).map(([key, item]) => [
+          key,
+          _stripUnresolved(item, ancestors),
+        ]),
+      );
+    } finally {
+      ancestors.delete(value);
+    }
   }
-  return value;
+  // Any other class instance (Layer, Context, SDK objects) is runtime-only
+  // wiring that can't round-trip through JSON — a beta.103 Context is even
+  // cyclic (#1082). Persisted state holds plain data only.
+  return undefined;
 };
 
 /**
@@ -124,25 +134,45 @@ const _stripUnresolved = (value: unknown): unknown => {
  */
 export const stripEffects = <T>(value: T): T => _stripEffects(value) as T;
 
-const _stripEffects = (value: unknown): unknown => {
+const _stripEffects = (
+  value: unknown,
+  // Ancestor-path cycle guard — see _stripUnresolved (#1082).
+  ancestors: WeakSet<object> = new WeakSet(),
+): unknown => {
   if (value == null || isPrimitive(value)) return value;
   // Output proxies are left intact (so `isResolved` still sees them); they
   // must be tested BEFORE `Effect.isEffect` because Output exprs are
   // yieldable and would otherwise be misclassified as plain Effects.
   if (Output.isExpr(value)) return value;
-  // Layer/Context are dropped with Effects — same runtime-only rationale,
-  // and their internals are cyclic on effect ≥4.0.0-beta.103 (#1082).
-  if (Effect.isEffect(value) || Output.isOpaqueRuntimeValue(value)) {
-    return undefined;
+  if (Effect.isEffect(value)) return undefined;
+  if (
+    Redacted.isRedacted(value) ||
+    Duration.isDuration(value) ||
+    value instanceof Date
+  ) {
+    return value;
   }
-  if (Redacted.isRedacted(value) || Duration.isDuration(value)) return value;
-  if (Array.isArray(value)) return value.map(_stripEffects);
-  if (typeof value === "object") {
-    return Object.fromEntries(
-      Object.entries(value).map(([key, item]) => [key, _stripEffects(item)]),
-    );
+  if (isPlainData(value)) {
+    if (ancestors.has(value)) return undefined;
+    ancestors.add(value);
+    try {
+      if (Array.isArray(value)) {
+        return value.map((item) => _stripEffects(item, ancestors));
+      }
+      return Object.fromEntries(
+        Object.entries(value).map(([key, item]) => [
+          key,
+          _stripEffects(item, ancestors),
+        ]),
+      );
+    } finally {
+      ancestors.delete(value);
+    }
   }
-  return value;
+  // Non-plain instances (Layer, Context, SDK objects) are dropped with
+  // Effects — same runtime-only rationale, and their internals may be
+  // cyclic (effect ≥4.0.0-beta.103's Context — #1082).
+  return undefined;
 };
 
 export const somePropsAreDifferent = <Props extends Record<string, any>>(
@@ -219,27 +249,47 @@ export const deepEqual = (
   JSON.stringify(canonicalize(a, options?.stripNullish ?? false)) ===
   JSON.stringify(canonicalize(b, options?.stripNullish ?? false));
 
-const canonicalize = (value: unknown, stripNullish: boolean): unknown => {
+const canonicalize = (
+  value: unknown,
+  stripNullish: boolean,
+  // Ancestor-path cycle guard — see _stripUnresolved (#1082).
+  ancestors: WeakSet<object> = new WeakSet(),
+): unknown => {
   if (stripNullish && value == null) return undefined;
-  // Effect/Layer/Context can reach here through provider-supplied values;
-  // never walk them (cyclic on effect ≥4.0.0-beta.103 — #1082).
-  if (Output.isOpaqueRuntimeValue(value)) return undefined;
   if (Redacted.isRedacted(value)) {
     return {
       _tag: "Redacted",
       value: Redacted.value(value),
     };
   }
-  if (Array.isArray(value)) {
-    return value.map((v) => canonicalize(v, stripNullish));
+  // JSON-safe leaves compare by their serialized form (Duration/Date have
+  // toJSON).
+  if (Duration.isDuration(value) || value instanceof Date) return value;
+  if (isPlainData(value)) {
+    if (ancestors.has(value)) return undefined;
+    ancestors.add(value);
+    try {
+      if (Array.isArray(value)) {
+        return value.map((v) => canonicalize(v, stripNullish, ancestors));
+      }
+      return Object.fromEntries(
+        Object.entries(value)
+          .filter(([, nested]) => !stripNullish || nested != null)
+          .sort(([a], [b]) => a.localeCompare(b))
+          .map(([key, nested]) => [
+            key,
+            canonicalize(nested, stripNullish, ancestors),
+          ]),
+      );
+    } finally {
+      ancestors.delete(value);
+    }
   }
   if (value && typeof value === "object") {
-    return Object.fromEntries(
-      Object.entries(value)
-        .filter(([, nested]) => !stripNullish || nested != null)
-        .sort(([a], [b]) => a.localeCompare(b))
-        .map(([key, nested]) => [key, canonicalize(nested, stripNullish)]),
-    );
+    // Non-plain instances (Effect, Layer, Context, SDK objects) never
+    // canonicalize — walking them is unsafe (cyclic on effect
+    // ≥4.0.0-beta.103 — #1082) and comparing them is meaningless.
+    return undefined;
   }
   return value;
 };

--- a/packages/alchemy/src/Output.ts
+++ b/packages/alchemy/src/Output.ts
@@ -701,24 +701,21 @@ export const evaluate: <A, Req = never>(
         return output;
       }
     }
-    if (Array.isArray(expr)) {
-      if (ancestors.has(expr)) {
-        return undefined;
-      }
-      const nested = new Set(ancestors).add(expr);
-      return yield* Effect.all(
-        expr.map((item) => evaluate(item, upstream, nested)),
-      );
-    } else if (Config.isConfig(expr)) {
+    if (Config.isConfig(expr)) {
       // Resolve Config against the deploy environment — see resolveInput in
       // Plan.ts for rationale. `Config.redacted` resolves to a `Redacted`,
-      // which stays opaque via the branch below.
+      // which stays opaque via the leaf fallthrough below.
       return yield* evaluate(yield* expr, upstream, ancestors);
     } else if (isPlainData(expr)) {
       if (ancestors.has(expr)) {
         return undefined;
       }
       const nested = new Set(ancestors).add(expr);
+      if (Array.isArray(expr)) {
+        return yield* Effect.all(
+          expr.map((item) => evaluate(item, upstream, nested)),
+        );
+      }
       return Object.fromEntries(
         yield* Effect.all(
           Object.entries(expr).map(([key, value]) =>

--- a/packages/alchemy/src/Output.ts
+++ b/packages/alchemy/src/Output.ts
@@ -1,12 +1,8 @@
 import * as Config from "effect/Config";
-import * as Context from "effect/Context";
 import * as Data from "effect/Data";
-import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import { pipe } from "effect/Function";
-import * as Layer from "effect/Layer";
 import type { Pipeable } from "effect/Pipeable";
-import * as Redacted from "effect/Redacted";
 import { SingleShotGen } from "effect/Utils";
 import { getRefMetadata, isRef, type Ref } from "./Ref.ts";
 import { isResource, type Resource, type ResourceLike } from "./Resource.ts";
@@ -14,7 +10,7 @@ import { RuntimeContext, sanitizeKey } from "./RuntimeContext.ts";
 import { Stack } from "./Stack.ts";
 import { Stage } from "./Stage.ts";
 import * as State from "./State/State.ts";
-import { isPrimitive, type Primitive } from "./Util/data.ts";
+import { isPlainData, isPrimitive, type Primitive } from "./Util/data.ts";
 
 const inspect = Symbol.for("nodejs.util.inspect.custom");
 
@@ -610,11 +606,16 @@ export const evaluate: <A, Req = never>(
   upstream: {
     [Id in string]: any;
   },
+  // Ancestor-path cycle guard — a plain-data value that appears on its own
+  // ancestor chain is cut to `undefined` (it could never serialize anyway).
+  // Immutable per-level so legitimately-shared diamond references survive
+  // (#1082).
+  ancestors?: ReadonlySet<object>,
 ) => Effect.Effect<
   A,
   InvalidReferenceError | MissingSourceError | Config.ConfigError,
   State.State | Req
-> = (expr, upstream) =>
+> = (expr, upstream, ancestors = new Set()) =>
   Effect.gen(function* () {
     if (isResource(expr)) {
       const srcId = expr.FQN;
@@ -701,68 +702,44 @@ export const evaluate: <A, Req = never>(
       }
     }
     if (Array.isArray(expr)) {
-      return yield* Effect.all(expr.map((item) => evaluate(item, upstream)));
+      if (ancestors.has(expr)) {
+        return undefined;
+      }
+      const nested = new Set(ancestors).add(expr);
+      return yield* Effect.all(
+        expr.map((item) => evaluate(item, upstream, nested)),
+      );
     } else if (Config.isConfig(expr)) {
       // Resolve Config against the deploy environment — see resolveInput in
       // Plan.ts for rationale. `Config.redacted` resolves to a `Redacted`,
       // which stays opaque via the branch below.
-      return yield* evaluate(yield* expr, upstream);
-    } else if (
-      Duration.isDuration(expr) ||
-      Redacted.isRedacted(expr) ||
-      isOpaqueRuntimeValue(expr)
-    ) {
-      // Opaque value — see resolveInput in Plan.ts for rationale.
-      // Effect/Layer/Context values (e.g. a Worker's `exports`) pass through
-      // untouched: rebuilding them entry-by-entry would strip their
-      // prototype, and their internals are cyclic on effect ≥4.0.0-beta.103
-      // (#1082). This branch sits after `Config.isConfig` on purpose —
-      // Configs are Effects but must still resolve.
-      return expr;
-    } else if (typeof expr === "object" && expr !== null) {
+      return yield* evaluate(yield* expr, upstream, ancestors);
+    } else if (isPlainData(expr)) {
+      if (ancestors.has(expr)) {
+        return undefined;
+      }
+      const nested = new Set(ancestors).add(expr);
       return Object.fromEntries(
         yield* Effect.all(
           Object.entries(expr).map(([key, value]) =>
-            evaluate(value, upstream).pipe(Effect.map((value) => [key, value])),
+            evaluate(value, upstream, nested).pipe(
+              Effect.map((value) => [key, value]),
+            ),
           ),
         ),
       );
     }
+    // Everything else is a leaf returned by identity: Duration, Redacted,
+    // Date, and effect runtime values (a Worker's `exports` carries each
+    // DO's `constructor` Effect and captured `services` Context). Rebuilding
+    // a class instance entry-by-entry strips its prototype, and effect
+    // ≥4.0.0-beta.103's Context is cyclic (#1082). This sits after
+    // `Config.isConfig` on purpose — Configs are Effects but must resolve.
     return expr;
   }) as Effect.Effect<any>;
 
 export const hasOutputs = (value: any): value is Output<any, any> =>
   Object.keys(upstreamAny(value)).length > 0;
-
-/**
- * Is `value` a runtime-only effect-library construct (an `Effect`, `Layer`,
- * or `Context`)?
- *
- * These appear as data inside resource Props — e.g. an Effect-native
- * Worker's `exports` carries each Durable Object's `constructor` Effect and
- * its captured `services` Context — but they can never hold resource
- * references reachable by plain enumeration, and their internals are not
- * safe to walk structurally: effect ≥ 4.0.0-beta.103's Context is
- * self-referential (`cacheRoot` points back at itself), so a structural walk
- * recurses until the stack overflows (#1082). Every deep walker in the
- * engine must treat these values as leaves.
- *
- * NOTE: Output exprs are yieldable (`Effect.isEffect` reports true for
- * them), so callers must check `isExpr`/`isOutput` BEFORE this predicate.
- */
-export const isOpaqueRuntimeValue = (value: unknown): boolean =>
-  Effect.isEffect(value) || Layer.isLayer(value) || Context.isContext(value);
-
-/**
- * Opaque leaves for the upstream walkers: effect-library runtime values plus
- * resolved `Duration`/`Redacted` instances — none of them can contain
- * resource references, so walking their internals is at best wasted work and
- * at worst (cyclic internals) unbounded recursion.
- */
-const isUpstreamLeaf = (value: unknown): boolean =>
-  isOpaqueRuntimeValue(value) ||
-  Duration.isDuration(value) ||
-  Redacted.isRedacted(value);
 
 /**
  * Cycle guard shared by the upstream walkers. Marks `value` as visited in
@@ -778,6 +755,12 @@ const alreadySeen = (value: object, seen: WeakSet<object>): boolean => {
   return false;
 };
 
+// The dependency rule (#1082): a Resource or Output IS a dependency; plain
+// data (arrays, plain objects) is traversed to find them; every other value
+// — class instances like effect's Effect/Layer/Context, Dates, SDK objects,
+// functions — is a leaf. See `isPlainData` in Util/data.ts for why leaves
+// must never be walked.
+
 export const upstreamAny = (
   value: any,
   seen: WeakSet<object> = new WeakSet(),
@@ -788,17 +771,7 @@ export const upstreamAny = (
     return { [value.FQN]: value as Resource };
   } else if (isExpr(value)) {
     return upstream(value, seen);
-  } else if (isUpstreamLeaf(value)) {
-    return {};
-  } else if (Array.isArray(value)) {
-    if (alreadySeen(value, seen)) {
-      return {};
-    }
-    return Object.assign({}, ...value.map((v) => resolveUpstream(v, seen)));
-  } else if (
-    value &&
-    (typeof value === "object" || typeof value === "function")
-  ) {
+  } else if (isPlainData(value)) {
     if (alreadySeen(value, seen)) {
       return {};
     }
@@ -834,19 +807,12 @@ export const upstream = <E extends Output<any, any>>(
     isNamedExpr(expr)
   ) {
     return upstream(expr.expr, seen);
-  } else if (isUpstreamLeaf(expr)) {
-    return {};
-  } else if (Array.isArray(expr)) {
-    if (alreadySeen(expr, seen)) {
-      return {};
-    }
-    return expr.map((e) => upstream(e, seen)).reduce(toObject, {});
-  } else if (typeof expr === "object" && expr !== null) {
+  } else if (isPlainData(expr)) {
     if (alreadySeen(expr, seen)) {
       return {};
     }
     return Object.values(expr)
-      .map((v) => upstream(v, seen))
+      .map((v) => upstream(v as any, seen))
       .reduce(toObject, {});
   }
   return {};
@@ -863,21 +829,12 @@ export const resolveUpstream = <const A>(
     return { [(value as unknown as Resource).FQN]: value } as any;
   } else if (isOutput(value)) {
     return upstream(value, seen) as any;
-  } else if (isUpstreamLeaf(value)) {
-    return {} as any;
-  } else if (Array.isArray(value)) {
+  } else if (isPlainData(value)) {
     if (alreadySeen(value, seen)) {
       return {} as any;
     }
     return Object.fromEntries(
-      value.map((v) => resolveUpstream(v, seen)).flatMap(Object.entries),
-    ) as any;
-  } else if (typeof value === "object" || typeof value === "function") {
-    if (alreadySeen(value as object, seen)) {
-      return {} as any;
-    }
-    return Object.fromEntries(
-      Object.values(value as any)
+      Object.values(value)
         .map((v) => resolveUpstream(v, seen))
         .flatMap(Object.entries),
     ) as any;

--- a/packages/alchemy/src/Output.ts
+++ b/packages/alchemy/src/Output.ts
@@ -1,8 +1,10 @@
 import * as Config from "effect/Config";
+import * as Context from "effect/Context";
 import * as Data from "effect/Data";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import { pipe } from "effect/Function";
+import * as Layer from "effect/Layer";
 import type { Pipeable } from "effect/Pipeable";
 import * as Redacted from "effect/Redacted";
 import { SingleShotGen } from "effect/Utils";
@@ -705,8 +707,17 @@ export const evaluate: <A, Req = never>(
       // Plan.ts for rationale. `Config.redacted` resolves to a `Redacted`,
       // which stays opaque via the branch below.
       return yield* evaluate(yield* expr, upstream);
-    } else if (Duration.isDuration(expr) || Redacted.isRedacted(expr)) {
+    } else if (
+      Duration.isDuration(expr) ||
+      Redacted.isRedacted(expr) ||
+      isOpaqueRuntimeValue(expr)
+    ) {
       // Opaque value — see resolveInput in Plan.ts for rationale.
+      // Effect/Layer/Context values (e.g. a Worker's `exports`) pass through
+      // untouched: rebuilding them entry-by-entry would strip their
+      // prototype, and their internals are cyclic on effect ≥4.0.0-beta.103
+      // (#1082). This branch sits after `Config.isConfig` on purpose —
+      // Configs are Effects but must still resolve.
       return expr;
     } else if (typeof expr === "object" && expr !== null) {
       return Object.fromEntries(
@@ -723,31 +734,87 @@ export const evaluate: <A, Req = never>(
 export const hasOutputs = (value: any): value is Output<any, any> =>
   Object.keys(upstreamAny(value)).length > 0;
 
+/**
+ * Is `value` a runtime-only effect-library construct (an `Effect`, `Layer`,
+ * or `Context`)?
+ *
+ * These appear as data inside resource Props — e.g. an Effect-native
+ * Worker's `exports` carries each Durable Object's `constructor` Effect and
+ * its captured `services` Context — but they can never hold resource
+ * references reachable by plain enumeration, and their internals are not
+ * safe to walk structurally: effect ≥ 4.0.0-beta.103's Context is
+ * self-referential (`cacheRoot` points back at itself), so a structural walk
+ * recurses until the stack overflows (#1082). Every deep walker in the
+ * engine must treat these values as leaves.
+ *
+ * NOTE: Output exprs are yieldable (`Effect.isEffect` reports true for
+ * them), so callers must check `isExpr`/`isOutput` BEFORE this predicate.
+ */
+export const isOpaqueRuntimeValue = (value: unknown): boolean =>
+  Effect.isEffect(value) || Layer.isLayer(value) || Context.isContext(value);
+
+/**
+ * Opaque leaves for the upstream walkers: effect-library runtime values plus
+ * resolved `Duration`/`Redacted` instances — none of them can contain
+ * resource references, so walking their internals is at best wasted work and
+ * at worst (cyclic internals) unbounded recursion.
+ */
+const isUpstreamLeaf = (value: unknown): boolean =>
+  isOpaqueRuntimeValue(value) ||
+  Duration.isDuration(value) ||
+  Redacted.isRedacted(value);
+
+/**
+ * Cycle guard shared by the upstream walkers. Marks `value` as visited in
+ * `seen`; returns true when it was already visited (the caller returns `{}`
+ * — the first visit already contributed the subtree's resources to the
+ * FQN-keyed union, so skipping repeats is lossless).
+ */
+const alreadySeen = (value: object, seen: WeakSet<object>): boolean => {
+  if (seen.has(value)) {
+    return true;
+  }
+  seen.add(value);
+  return false;
+};
+
 export const upstreamAny = (
   value: any,
+  seen: WeakSet<object> = new WeakSet(),
 ): {
   [ID in string]: Resource;
 } => {
   if (isResource(value)) {
     return { [value.FQN]: value as Resource };
   } else if (isExpr(value)) {
-    return upstream(value);
+    return upstream(value, seen);
+  } else if (isUpstreamLeaf(value)) {
+    return {};
   } else if (Array.isArray(value)) {
-    return Object.assign({}, ...value.map(resolveUpstream));
+    if (alreadySeen(value, seen)) {
+      return {};
+    }
+    return Object.assign({}, ...value.map((v) => resolveUpstream(v, seen)));
   } else if (
     value &&
     (typeof value === "object" || typeof value === "function")
   ) {
+    if (alreadySeen(value, seen)) {
+      return {};
+    }
     return Object.assign(
       {},
-      ...Object.values(value).map((value) => resolveUpstream(value)),
+      ...Object.values(value).map((value) => resolveUpstream(value, seen)),
     );
   }
   return {};
 };
 
 // TODO(sam): add a type
-export const upstream = <E extends Output<any, any>>(expr: E): any => {
+export const upstream = <E extends Output<any, any>>(
+  expr: E,
+  seen: WeakSet<object> = new WeakSet(),
+): any => {
   if (isResource(expr)) {
     return {
       [(expr as unknown as Resource).FQN]: expr,
@@ -757,42 +824,61 @@ export const upstream = <E extends Output<any, any>>(expr: E): any => {
       [expr.src.FQN]: expr.src,
     };
   } else if (isPropExpr(expr)) {
-    return upstream(expr.expr);
+    return upstream(expr.expr, seen);
   } else if (isAllExpr(expr)) {
-    return Object.assign({}, ...expr.outs.map((out) => upstream(out)));
+    return Object.assign({}, ...expr.outs.map((out) => upstream(out, seen)));
   } else if (
     isEffectExpr(expr) ||
     isApplyExpr(expr) ||
     isFlatMapExpr(expr) ||
     isNamedExpr(expr)
   ) {
-    return upstream(expr.expr);
+    return upstream(expr.expr, seen);
+  } else if (isUpstreamLeaf(expr)) {
+    return {};
   } else if (Array.isArray(expr)) {
-    return expr.map(upstream).reduce(toObject, {});
+    if (alreadySeen(expr, seen)) {
+      return {};
+    }
+    return expr.map((e) => upstream(e, seen)).reduce(toObject, {});
   } else if (typeof expr === "object" && expr !== null) {
+    if (alreadySeen(expr, seen)) {
+      return {};
+    }
     return Object.values(expr)
-      .map((v) => upstream(v))
+      .map((v) => upstream(v, seen))
       .reduce(toObject, {});
   }
   return {};
 };
 
 // TODO(sam): add a type
-export const resolveUpstream = <const A>(value: A): any => {
+export const resolveUpstream = <const A>(
+  value: A,
+  seen: WeakSet<object> = new WeakSet(),
+): any => {
   if (isPrimitive(value)) {
     return {} as any;
   } else if (isResource(value)) {
     return { [(value as unknown as Resource).FQN]: value } as any;
   } else if (isOutput(value)) {
-    return upstream(value) as any;
+    return upstream(value, seen) as any;
+  } else if (isUpstreamLeaf(value)) {
+    return {} as any;
   } else if (Array.isArray(value)) {
+    if (alreadySeen(value, seen)) {
+      return {} as any;
+    }
     return Object.fromEntries(
-      value.map((v) => resolveUpstream(v)).flatMap(Object.entries),
+      value.map((v) => resolveUpstream(v, seen)).flatMap(Object.entries),
     ) as any;
   } else if (typeof value === "object" || typeof value === "function") {
+    if (alreadySeen(value as object, seen)) {
+      return {} as any;
+    }
     return Object.fromEntries(
       Object.values(value as any)
-        .map(resolveUpstream)
+        .map((v) => resolveUpstream(v, seen))
         .flatMap(Object.entries),
     ) as any;
   }

--- a/packages/alchemy/src/Plan.ts
+++ b/packages/alchemy/src/Plan.ts
@@ -2,10 +2,8 @@
 /** @effect-diagnostics missingEffectError:off */
 import * as Config from "effect/Config";
 import * as Data from "effect/Data";
-import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
-import * as Redacted from "effect/Redacted";
 import { asEffect } from ".//Util/types.ts";
 import { isAction, type ActionLike } from "./Action.ts";
 import {
@@ -62,6 +60,7 @@ import {
   type UpdatedResourceState,
   type UpdatingReourceState,
 } from "./State/index.ts";
+import { isPlainData } from "./Util/data.ts";
 import { findCycleMembers } from "./Util/scc.ts";
 import { hashInput } from "./Util/sha256.ts";
 
@@ -485,7 +484,15 @@ export const make = <A>(
      * `reconcile`. This is the value plan nodes carry; the diff-facing view
      * is derived from it by {@link materializeStableRefs}.
      */
-    const resolveInput = (input: any): Effect.Effect<any, Config.ConfigError> =>
+    const resolveInput = (
+      input: any,
+      // Ancestor chain of the current walk. A value that appears on its own
+      // ancestor path is a true cycle and is cut to `undefined` (a cycle can
+      // never persist or serialize anyway); an immutable per-level set (not
+      // a shared visited-set) keeps legitimately-shared diamond references
+      // intact and is race-free under `concurrency: "unbounded"` (#1082).
+      ancestors: ReadonlySet<object> = new Set(),
+    ): Effect.Effect<any, Config.ConfigError> =>
       Effect.gen(function* () {
         if (!input) {
           return input;
@@ -498,25 +505,18 @@ export const make = <A>(
           // providers receive a resolved value instead of a Config object.
           // `Config.redacted` resolves to a `Redacted`, which stays opaque via
           // the branch below.
-          return yield* resolveInput(yield* input);
-        } else if (
-          Duration.isDuration(input) ||
-          Redacted.isRedacted(input) ||
-          Output.isOpaqueRuntimeValue(input)
-        ) {
-          // Opaque values that are resolved downstream. We don't walk them
-          // because it would strip their prototype, resulting in a plain object
-          // that downstream consumers can't interpret. Redacted additionally
-          // stays wrapped to preserve the secrecy boundary. Effect/Layer/
-          // Context values (e.g. a Worker's `exports`) are also leaves — their
-          // internals are cyclic on effect ≥4.0.0-beta.103 (#1082). This
-          // branch must come after `Config.isConfig`: Configs are Effects but
-          // still resolve.
-          return input;
+          return yield* resolveInput(yield* input, ancestors);
         } else if (Array.isArray(input)) {
-          return yield* Effect.all(input.map(resolveInput), {
-            concurrency: "unbounded",
-          });
+          if (ancestors.has(input)) {
+            return undefined;
+          }
+          const nested = new Set(ancestors).add(input);
+          return yield* Effect.all(
+            input.map((item) => resolveInput(item, nested)),
+            {
+              concurrency: "unbounded",
+            },
+          );
         } else if (isResource(input)) {
           // Resource objects have dynamic properties (path, hash, etc.) that are
           // created on-demand by a Proxy getter and aren't enumerable via Object.entries.
@@ -529,17 +529,31 @@ export const make = <A>(
             // upstream) — keep it evaluable for Apply.
             return resolved;
           }
-          return yield* resolveInput(resolved);
-        } else if (typeof input === "object") {
+          return yield* resolveInput(resolved, ancestors);
+        } else if (isPlainData(input)) {
+          if (ancestors.has(input)) {
+            return undefined;
+          }
+          const nested = new Set(ancestors).add(input);
           return Object.fromEntries(
             yield* Effect.all(
               Object.entries(input).map(([key, value]) =>
-                resolveInput(value).pipe(Effect.map((value) => [key, value])),
+                resolveInput(value, nested).pipe(
+                  Effect.map((value) => [key, value]),
+                ),
               ),
               { concurrency: "unbounded" },
             ),
           );
         }
+        // Everything else is an opaque leaf returned by identity: Duration,
+        // Redacted, Date, and effect runtime values (a Worker's `exports`
+        // carries each DO's `constructor` Effect and captured `services`
+        // Context). Rebuilding a class instance entry-by-entry would strip
+        // its prototype, and effect ≥4.0.0-beta.103's Context is cyclic
+        // (#1082). Redacted additionally stays wrapped to preserve the
+        // secrecy boundary. This sits after `Config.isConfig` on purpose —
+        // Configs are Effects but must still resolve.
         return input;
       });
 
@@ -558,31 +572,44 @@ export const make = <A>(
      * the upstream's fresh non-stable attributes (e.g. a Lambda Version's
      * `version` number — #993's alias promotion bug).
      */
-    const materializeStableRefs = (input: any): any => {
+    const materializeStableRefs = (
+      input: any,
+      // Ancestor-path cycle guard — see resolveInput (#1082). Sync DFS, so
+      // add/delete around the recursion is race-free.
+      ancestors: WeakSet<object> = new WeakSet(),
+    ): any => {
       // Expr checks come first: Output proxies are callable, so a plain
       // `typeof input === "object"` guard would let them slip through.
       if (Output.isResourceExpr(input) && input.stables) {
-        return materializeStableRefs(input.stables);
+        return materializeStableRefs(input.stables, ancestors);
       } else if (Output.isExpr(input)) {
         // Genuinely unknown (e.g. a creating upstream) — nothing to show diff.
         return input;
-      } else if (!input || typeof input !== "object") {
+      } else if (!input || !isPlainData(input)) {
+        // Primitives and non-plain instances (Duration, Redacted, Date,
+        // Effect/Layer/Context) are leaves — see isPlainData (#1082).
         return input;
-      } else if (
-        Duration.isDuration(input) ||
-        Redacted.isRedacted(input) ||
-        Output.isOpaqueRuntimeValue(input)
-      ) {
-        return input;
+      } else if (ancestors.has(input)) {
+        return undefined;
       } else if (Array.isArray(input)) {
-        return input.map(materializeStableRefs);
+        ancestors.add(input);
+        try {
+          return input.map((item) => materializeStableRefs(item, ancestors));
+        } finally {
+          ancestors.delete(input);
+        }
       }
-      return Object.fromEntries(
-        Object.entries(input).map(([key, value]) => [
-          key,
-          materializeStableRefs(value),
-        ]),
-      );
+      ancestors.add(input);
+      try {
+        return Object.fromEntries(
+          Object.entries(input).map(([key, value]) => [
+            key,
+            materializeStableRefs(value, ancestors),
+          ]),
+        );
+      } finally {
+        ancestors.delete(input);
+      }
     };
 
     const resolveOutput = (expr: Output.Expr<any>): Effect.Effect<any> =>

--- a/packages/alchemy/src/Plan.ts
+++ b/packages/alchemy/src/Plan.ts
@@ -60,7 +60,7 @@ import {
   type UpdatedResourceState,
   type UpdatingReourceState,
 } from "./State/index.ts";
-import { isPlainData } from "./Util/data.ts";
+import { isPlainData, mapPlainData } from "./Util/data.ts";
 import { findCycleMembers } from "./Util/scc.ts";
 import { hashInput } from "./Util/sha256.ts";
 
@@ -506,17 +506,6 @@ export const make = <A>(
           // `Config.redacted` resolves to a `Redacted`, which stays opaque via
           // the branch below.
           return yield* resolveInput(yield* input, ancestors);
-        } else if (Array.isArray(input)) {
-          if (ancestors.has(input)) {
-            return undefined;
-          }
-          const nested = new Set(ancestors).add(input);
-          return yield* Effect.all(
-            input.map((item) => resolveInput(item, nested)),
-            {
-              concurrency: "unbounded",
-            },
-          );
         } else if (isResource(input)) {
           // Resource objects have dynamic properties (path, hash, etc.) that are
           // created on-demand by a Proxy getter and aren't enumerable via Object.entries.
@@ -535,6 +524,12 @@ export const make = <A>(
             return undefined;
           }
           const nested = new Set(ancestors).add(input);
+          if (Array.isArray(input)) {
+            return yield* Effect.all(
+              input.map((item) => resolveInput(item, nested)),
+              { concurrency: "unbounded" },
+            );
+          }
           return Object.fromEntries(
             yield* Effect.all(
               Object.entries(input).map(([key, value]) =>
@@ -589,27 +584,10 @@ export const make = <A>(
         // Primitives and non-plain instances (Duration, Redacted, Date,
         // Effect/Layer/Context) are leaves — see isPlainData (#1082).
         return input;
-      } else if (ancestors.has(input)) {
-        return undefined;
-      } else if (Array.isArray(input)) {
-        ancestors.add(input);
-        try {
-          return input.map((item) => materializeStableRefs(item, ancestors));
-        } finally {
-          ancestors.delete(input);
-        }
       }
-      ancestors.add(input);
-      try {
-        return Object.fromEntries(
-          Object.entries(input).map(([key, value]) => [
-            key,
-            materializeStableRefs(value, ancestors),
-          ]),
-        );
-      } finally {
-        ancestors.delete(input);
-      }
+      return mapPlainData(input, ancestors, (child) =>
+        materializeStableRefs(child, ancestors),
+      );
     };
 
     const resolveOutput = (expr: Output.Expr<any>): Effect.Effect<any> =>

--- a/packages/alchemy/src/Plan.ts
+++ b/packages/alchemy/src/Plan.ts
@@ -499,11 +499,19 @@ export const make = <A>(
           // `Config.redacted` resolves to a `Redacted`, which stays opaque via
           // the branch below.
           return yield* resolveInput(yield* input);
-        } else if (Duration.isDuration(input) || Redacted.isRedacted(input)) {
+        } else if (
+          Duration.isDuration(input) ||
+          Redacted.isRedacted(input) ||
+          Output.isOpaqueRuntimeValue(input)
+        ) {
           // Opaque values that are resolved downstream. We don't walk them
           // because it would strip their prototype, resulting in a plain object
           // that downstream consumers can't interpret. Redacted additionally
-          // stays wrapped to preserve the secrecy boundary.
+          // stays wrapped to preserve the secrecy boundary. Effect/Layer/
+          // Context values (e.g. a Worker's `exports`) are also leaves — their
+          // internals are cyclic on effect ≥4.0.0-beta.103 (#1082). This
+          // branch must come after `Config.isConfig`: Configs are Effects but
+          // still resolve.
           return input;
         } else if (Array.isArray(input)) {
           return yield* Effect.all(input.map(resolveInput), {
@@ -560,7 +568,11 @@ export const make = <A>(
         return input;
       } else if (!input || typeof input !== "object") {
         return input;
-      } else if (Duration.isDuration(input) || Redacted.isRedacted(input)) {
+      } else if (
+        Duration.isDuration(input) ||
+        Redacted.isRedacted(input) ||
+        Output.isOpaqueRuntimeValue(input)
+      ) {
         return input;
       } else if (Array.isArray(input)) {
         return input.map(materializeStableRefs);

--- a/packages/alchemy/src/Util/data.ts
+++ b/packages/alchemy/src/Util/data.ts
@@ -28,6 +28,29 @@ export const isPlainObject = (
   return Object.getPrototypeOf(value) === Object.prototype;
 };
 
+/**
+ * Is `value` plain data the engine's deep walkers may traverse — an array,
+ * or an object whose prototype is `Object.prototype`/`null`?
+ *
+ * Everything else (class instances: effect's Effect/Layer/Context, Dates,
+ * SDK config objects, functions, ...) is a LEAF for every deep walker in
+ * the engine. The engine cannot meaningfully evaluate, diff, or persist
+ * *through* a foreign class instance — rebuilding one entry-by-entry strips
+ * its prototype — and walking one is not safe: effect ≥4.0.0-beta.103's
+ * Context is self-referential (`cacheRoot` points back at itself), which
+ * sent the naive walk-everything traversal into unbounded recursion
+ * (#1082). Resources and Outputs are detected structurally *before* this
+ * gate, so dependencies declared in plain props are unaffected.
+ */
+export const isPlainData = (
+  value: unknown,
+): value is Record<string, unknown> | unknown[] => {
+  if (Array.isArray(value)) return true;
+  if (typeof value !== "object" || value === null) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+};
+
 export const stripFields = <T>(value: T, empty: null | undefined): T => {
   if (Array.isArray(value)) {
     return value.map((item) => stripFields(item, empty)) as T;

--- a/packages/alchemy/src/Util/data.ts
+++ b/packages/alchemy/src/Util/data.ts
@@ -51,6 +51,35 @@ export const isPlainData = (
   return proto === Object.prototype || proto === null;
 };
 
+/**
+ * Rebuild a plain-data value by mapping each child through `walk`,
+ * preserving the shape (array → array, object → object).
+ *
+ * Cycle-guarded by ancestor path: a value that appears on its own ancestor
+ * chain is a true cycle and becomes `undefined` (it could never serialize
+ * or persist anyway). The guard is scoped to the current path — NOT a
+ * visited-set — so a diamond (the same object legitimately referenced from
+ * two places) is rebuilt in both places. Sync DFS only: add/delete around
+ * the recursion is race-free. (#1082)
+ */
+export const mapPlainData = (
+  value: Record<string, unknown> | unknown[],
+  ancestors: WeakSet<object>,
+  walk: (child: unknown) => unknown,
+): unknown => {
+  if (ancestors.has(value)) return undefined;
+  ancestors.add(value);
+  try {
+    return Array.isArray(value)
+      ? value.map(walk)
+      : Object.fromEntries(
+          Object.entries(value).map(([key, child]) => [key, walk(child)]),
+        );
+  } finally {
+    ancestors.delete(value);
+  }
+};
+
 export const stripFields = <T>(value: T, empty: null | undefined): T => {
   if (Array.isArray(value)) {
     return value.map((item) => stripFields(item, empty)) as T;

--- a/packages/alchemy/test/Diff.test.ts
+++ b/packages/alchemy/test/Diff.test.ts
@@ -5,8 +5,10 @@ import {
   stripEffects,
   stripUnresolved,
 } from "@/Diff";
+import * as Output from "@/Output";
 import { describe, expect, test } from "alchemy-test";
 import * as Context from "effect/Context";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Redacted from "effect/Redacted";
@@ -180,10 +182,184 @@ describe("Diff", () => {
         cyclic.self = cyclic;
         return { config: cyclic };
       };
-      // Cyclic plain objects can't be JSON-encoded; the walkers must not
-      // hang before that surfaces. hasUnresolvedInputs is the cycle-prone
-      // pre-pass — pin that it terminates.
+      // The full comparison — stripUnresolved cuts the cycle, so the
+      // JSON.stringify comparison sees identical truncated shapes.
+      expect(havePropsChanged(make(), make())).toBe(false);
+      expect(havePropsChanged(make(), { ...make(), extra: "x" } as any)).toBe(
+        true,
+      );
       expect(hasUnresolvedInputs(make())).toBe(false);
+    });
+  });
+
+  describe("hasUnresolvedInputs across nesting shapes", () => {
+    test("finds an Output expr deep in arrays-in-objects-in-arrays", () => {
+      const expr = Output.literal("x");
+      expect(
+        hasUnresolvedInputs({ layers: [{ config: { hosts: [expr] } }] }),
+      ).toBe(true);
+      expect(hasUnresolvedInputs({ matrix: [[[expr]]] })).toBe(true);
+    });
+
+    test("finds an Effect deep in nested containers", () => {
+      expect(hasUnresolvedInputs({ a: [{ b: { c: [Effect.void] } }] })).toBe(
+        true,
+      );
+    });
+
+    test("a shared diamond subtree containing an expr is found from either parent", () => {
+      const shared = { dep: Output.literal("x") };
+      expect(hasUnresolvedInputs({ left: shared, right: shared })).toBe(true);
+      expect(hasUnresolvedInputs({ left: { v: 1 }, right: shared })).toBe(true);
+    });
+
+    test("fully-plain deep structures are resolved", () => {
+      expect(
+        hasUnresolvedInputs({ a: [{ b: [[{ c: 1 }]], d: new Date(0) }] }),
+      ).toBe(false);
+    });
+  });
+
+  describe("stripUnresolved semantics", () => {
+    test("preserves Date/Redacted/Duration by identity", () => {
+      const date = new Date(0);
+      const secret = Redacted.make("s");
+      const dur = Duration.seconds(5);
+      const stripped: any = stripUnresolved({ date, secret, dur });
+      expect(stripped.date).toBe(date);
+      expect(stripped.secret).toBe(secret);
+      expect(stripped.dur).toBe(dur);
+    });
+
+    test("drops Output exprs and Effects at any nesting depth", () => {
+      const stripped: any = stripUnresolved({
+        deep: [{ inner: { expr: Output.literal("x") } }],
+        arr: [[Effect.void]],
+        keep: [{ v: 1 }],
+      });
+      expect(stripped.deep[0].inner.expr).toBeUndefined();
+      expect(stripped.arr[0][0]).toBeUndefined();
+      expect(stripped.keep).toEqual([{ v: 1 }]);
+    });
+
+    test("cuts cycles but preserves diamonds", () => {
+      const shared = { v: 1 };
+      const cyclic: any = { name: "c" };
+      cyclic.self = cyclic;
+      const stripped: any = stripUnresolved({
+        left: shared,
+        right: shared,
+        cyc: cyclic,
+      });
+      expect(stripped.left).toEqual({ v: 1 });
+      expect(stripped.right).toEqual({ v: 1 });
+      expect(stripped.cyc.name).toBe("c");
+      expect(stripped.cyc.self).toBeUndefined();
+      expect(() => JSON.stringify(stripped)).not.toThrow();
+    });
+  });
+
+  describe("stripEffects semantics", () => {
+    test("keeps Output exprs intact but drops Effects, deeply", () => {
+      const expr = Output.literal("x");
+      const stripped: any = stripEffects({
+        deep: [{ expr, eff: Effect.void }],
+      });
+      expect(stripped.deep[0].expr).toBe(expr);
+      expect(stripped.deep[0].eff).toBeUndefined();
+    });
+
+    test("preserves Date/Redacted/Duration and cuts cycles", () => {
+      const date = new Date(0);
+      const cyclic: any = { date };
+      cyclic.self = cyclic;
+      const stripped: any = stripEffects({ cyc: cyclic });
+      expect(stripped.cyc.date).toBe(date);
+      expect(stripped.cyc.self).toBeUndefined();
+    });
+  });
+
+  describe("deepEqual / havePropsChanged across nesting shapes", () => {
+    test("deepEqual is key-order insensitive at every depth", () => {
+      expect(
+        deepEqual(
+          { a: [{ x: 1, y: [{ p: 1, q: 2 }] }], b: 2 },
+          { b: 2, a: [{ y: [{ q: 2, p: 1 }], x: 1 }] },
+        ),
+      ).toBe(true);
+    });
+
+    test("deepEqual compares Dates by value", () => {
+      expect(
+        deepEqual({ d: new Date("2027-01-01") }, { d: new Date("2027-01-01") }),
+      ).toBe(true);
+      expect(
+        deepEqual({ d: new Date("2027-01-01") }, { d: new Date("2027-01-02") }),
+      ).toBe(false);
+    });
+
+    test("deepEqual compares Durations by value", () => {
+      expect(
+        deepEqual({ d: Duration.seconds(5) }, { d: Duration.seconds(5) }),
+      ).toBe(true);
+      expect(
+        deepEqual({ d: Duration.seconds(5) }, { d: Duration.seconds(6) }),
+      ).toBe(false);
+    });
+
+    test("deepEqual terminates on cyclic values on either side", () => {
+      const make = () => {
+        const c: any = { v: 1 };
+        c.self = c;
+        return c;
+      };
+      expect(deepEqual({ c: make() }, { c: make() })).toBe(true);
+    });
+
+    test("havePropsChanged detects a change deep in arrays-in-objects-in-arrays", () => {
+      const shape = (url: string) => ({
+        layers: [{ config: { hosts: [{ url }, { url: "static" }] } }],
+      });
+      expect(havePropsChanged(shape("a"), shape("a"))).toBe(false);
+      expect(havePropsChanged(shape("a"), shape("b"))).toBe(true);
+    });
+
+    test("havePropsChanged detects array length and order changes", () => {
+      expect(
+        havePropsChanged({ arr: [[1, 2]] }, { arr: [[2, 1]] } as any),
+      ).toBe(true);
+      expect(havePropsChanged({ arr: [[1]] }, { arr: [[1], []] } as any)).toBe(
+        true,
+      );
+    });
+
+    test("havePropsChanged detects a changed Date", () => {
+      expect(
+        havePropsChanged(
+          { expires: new Date("2027-01-01") },
+          { expires: new Date("2027-01-01") },
+        ),
+      ).toBe(false);
+      expect(
+        havePropsChanged(
+          { expires: new Date("2027-01-01") },
+          { expires: new Date("2028-01-01") },
+        ),
+      ).toBe(true);
+    });
+
+    test("class instances never churn a diff — different instances compare equal", () => {
+      class SdkConfig {
+        constructor(readonly v: number) {}
+      }
+      // Runtime-only wiring: stripped at the commit boundary, so two deploys
+      // constructing fresh instances must not report a phantom change.
+      expect(
+        havePropsChanged(
+          { config: new SdkConfig(1) } as any,
+          { config: new SdkConfig(2) } as any,
+        ),
+      ).toBe(false);
     });
   });
 });

--- a/packages/alchemy/test/Diff.test.ts
+++ b/packages/alchemy/test/Diff.test.ts
@@ -1,5 +1,14 @@
-import { deepEqual, havePropsChanged } from "@/Diff";
+import {
+  deepEqual,
+  hasUnresolvedInputs,
+  havePropsChanged,
+  stripEffects,
+  stripUnresolved,
+} from "@/Diff";
 import { describe, expect, test } from "alchemy-test";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
 import * as Redacted from "effect/Redacted";
 
 describe("Diff", () => {
@@ -106,6 +115,75 @@ describe("Diff", () => {
           { secret: Redacted.make("b") },
         ),
       ).toBe(false);
+    });
+  });
+
+  // effect ≥4.0.0-beta.103's Context is self-referential; every deep walker
+  // must treat Effect/Layer/Context values as leaves instead of recursing
+  // into (or JSON-encoding) their internals (#1082).
+  describe("opaque effect values in props (#1082)", () => {
+    const opaqueProps = () => ({
+      name: "worker",
+      exports: {
+        Store: {
+          kind: "durableObject",
+          constructor: Effect.void,
+          services: Context.empty(),
+        },
+      },
+      layer: Layer.empty,
+    });
+
+    test("hasUnresolvedInputs treats Layer/Context as resolved leaves", () => {
+      expect(
+        hasUnresolvedInputs({ context: Context.empty(), layer: Layer.empty }),
+      ).toBe(false);
+    });
+
+    test("stripUnresolved drops Effect/Layer/Context", () => {
+      const stripped: any = stripUnresolved(opaqueProps());
+      expect(stripped.name).toBe("worker");
+      expect(stripped.exports.Store.kind).toBe("durableObject");
+      expect(stripped.exports.Store.constructor).toBeUndefined();
+      expect(stripped.exports.Store.services).toBeUndefined();
+      expect(stripped.layer).toBeUndefined();
+      // Round-trips through JSON — the commit boundary's contract.
+      expect(() => JSON.stringify(stripped)).not.toThrow();
+    });
+
+    test("stripEffects drops Effect/Layer/Context", () => {
+      const stripped: any = stripEffects(opaqueProps());
+      expect(stripped.exports.Store.constructor).toBeUndefined();
+      expect(stripped.exports.Store.services).toBeUndefined();
+      expect(stripped.layer).toBeUndefined();
+    });
+
+    test("havePropsChanged terminates and compares only plain data", () => {
+      expect(havePropsChanged(opaqueProps(), opaqueProps())).toBe(false);
+      expect(
+        havePropsChanged(opaqueProps(), {
+          ...opaqueProps(),
+          name: "renamed",
+        }),
+      ).toBe(true);
+    });
+
+    test("deepEqual does not recurse into Context internals", () => {
+      expect(
+        deepEqual({ ctx: Context.empty() }, { ctx: Context.empty() }),
+      ).toBe(true);
+    });
+
+    test("havePropsChanged terminates on cyclic plain objects", () => {
+      const make = () => {
+        const cyclic: any = { name: "cycle" };
+        cyclic.self = cyclic;
+        return { config: cyclic };
+      };
+      // Cyclic plain objects can't be JSON-encoded; the walkers must not
+      // hang before that surfaces. hasUnresolvedInputs is the cycle-prone
+      // pre-pass — pin that it terminates.
+      expect(hasUnresolvedInputs(make())).toBe(false);
     });
   });
 });

--- a/packages/alchemy/test/Output.test.ts
+++ b/packages/alchemy/test/Output.test.ts
@@ -1027,10 +1027,12 @@ describe("Output.upstream / hasOutputs / resolveUpstream", () => {
 
 // effect ≥4.0.0-beta.103's Context is self-referential (cacheRoot points back
 // at itself), which sent the prop walkers into unbounded recursion during
-// `Plan.make` of the Cloudflare state-store bootstrap stack (#1082). These
-// tests pin (a) cycle-safety for arbitrary cyclic props and (b) opacity of
-// Effect/Layer/Context values in every walker.
-describe("upstream walkers: cycles and opaque effect values (#1082)", () => {
+// `Plan.make` of the Cloudflare state-store bootstrap stack (#1082). The rule
+// pinned here: Resources/Outputs are dependencies, plain data (arrays, plain
+// objects) is traversed to find them, and every other value — ANY class
+// instance, effect's or otherwise — is a leaf. Plus WeakSet cycle guards so
+// cyclic plain data terminates.
+describe("upstream walkers: cycles and non-plain leaves (#1082)", () => {
   it("upstreamAny terminates on a cyclic plain object and still finds resources", () => {
     const a = fakeResource("Test.A", "CY-A");
     const cyclic: any = { name: "cycle" };
@@ -1064,6 +1066,23 @@ describe("upstream walkers: cycles and opaque effect values (#1082)", () => {
     expect(Output.hasOutputs({ effect, layer, context })).toBe(false);
   });
 
+  it("treats any class instance as a leaf (never walks its internals)", () => {
+    const a = fakeResource("Test.A", "CL-A");
+    class SdkConfig {
+      // A dependency smuggled inside a foreign class instance is invisible
+      // by design — the engine can't evaluate or persist through it.
+      dep = Output.of(a);
+      date = new Date(0);
+    }
+    expect(Output.upstreamAny({ config: new SdkConfig() })).toEqual({});
+    // ...but the same dependency in plain data right next to it is found.
+    expect(
+      Object.keys(
+        Output.upstreamAny({ config: new SdkConfig(), dep: Output.of(a) }),
+      ),
+    ).toEqual(["CL-A"]);
+  });
+
   it("mimics a Worker `exports` entry (constructor Effect + services Context)", () => {
     const a = fakeResource("Test.A", "EX-A");
     const props = {
@@ -1092,6 +1111,20 @@ describe("upstream walkers: cycles and opaque effect values (#1082)", () => {
         expect(result.context).toBe(context);
       }),
     ),
+  );
+
+  it.effect(
+    "evaluate passes Date/Redacted through by identity (prototype intact)",
+    () =>
+      provideState(
+        Effect.gen(function* () {
+          const date = new Date(0);
+          const secret = Redacted.make("hunter2");
+          const result = yield* Output.evaluate({ date, secret }, {});
+          expect(result.date).toBe(date);
+          expect(result.secret).toBe(secret);
+        }),
+      ),
   );
 
   it.effect("evaluate still resolves Config values (Configs are Effects)", () =>

--- a/packages/alchemy/test/Output.test.ts
+++ b/packages/alchemy/test/Output.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it } from "alchemy-test";
 import * as Cause from "effect/Cause";
 import * as Config from "effect/Config";
 import * as ConfigProvider from "effect/ConfigProvider";
+import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
@@ -1022,6 +1023,88 @@ describe("Output.upstream / hasOutputs / resolveUpstream", () => {
     });
     expect(Object.keys(result).sort()).toEqual(["RA", "RB"]);
   });
+});
+
+// effect ≥4.0.0-beta.103's Context is self-referential (cacheRoot points back
+// at itself), which sent the prop walkers into unbounded recursion during
+// `Plan.make` of the Cloudflare state-store bootstrap stack (#1082). These
+// tests pin (a) cycle-safety for arbitrary cyclic props and (b) opacity of
+// Effect/Layer/Context values in every walker.
+describe("upstream walkers: cycles and opaque effect values (#1082)", () => {
+  it("upstreamAny terminates on a cyclic plain object and still finds resources", () => {
+    const a = fakeResource("Test.A", "CY-A");
+    const cyclic: any = { name: "cycle" };
+    cyclic.self = cyclic;
+    const props = { config: cyclic, dep: Output.of(a) };
+    expect(Object.keys(Output.upstreamAny(props))).toEqual(["CY-A"]);
+  });
+
+  it("resolveUpstream terminates on mutually-cyclic objects and arrays", () => {
+    const x: any = { tag: "x" };
+    const y: any = { tag: "y", x };
+    x.y = y;
+    const arr: any[] = [x];
+    x.arr = arr;
+    expect(Output.resolveUpstream({ x, y, arr })).toEqual({});
+  });
+
+  it("a shared (diamond) sub-object still contributes its resources", () => {
+    const a = fakeResource("Test.A", "DI-A");
+    const shared = { dep: Output.of(a) };
+    const result = Output.upstreamAny({ left: shared, right: shared });
+    expect(Object.keys(result)).toEqual(["DI-A"]);
+  });
+
+  it("treats Effect, Layer, and Context values as leaves", () => {
+    const effect = Effect.succeed(1);
+    const layer = Layer.succeed(Stage, "test");
+    const context = Context.empty();
+    expect(Output.upstreamAny({ effect, layer, context })).toEqual({});
+    expect(Output.resolveUpstream({ effect, layer, context })).toEqual({});
+    expect(Output.hasOutputs({ effect, layer, context })).toBe(false);
+  });
+
+  it("mimics a Worker `exports` entry (constructor Effect + services Context)", () => {
+    const a = fakeResource("Test.A", "EX-A");
+    const props = {
+      name: "worker",
+      exports: {
+        Store: {
+          kind: "durableObject",
+          constructor: Effect.void,
+          services: Context.empty(),
+        },
+      },
+      dep: Output.of(a),
+    };
+    expect(Object.keys(Output.upstreamAny(props))).toEqual(["EX-A"]);
+  });
+
+  it.effect("evaluate passes Effect/Layer/Context through by identity", () =>
+    provideState(
+      Effect.gen(function* () {
+        const effect = Effect.succeed(1);
+        const layer = Layer.succeed(Stage, "test");
+        const context = Context.empty();
+        const result = yield* Output.evaluate({ effect, layer, context }, {});
+        expect(result.effect).toBe(effect);
+        expect(result.layer).toBe(layer);
+        expect(result.context).toBe(context);
+      }),
+    ),
+  );
+
+  it.effect("evaluate still resolves Config values (Configs are Effects)", () =>
+    provideState(
+      Effect.gen(function* () {
+        const result = yield* Output.evaluate(
+          { value: Config.succeed("resolved") },
+          {},
+        );
+        expect(result.value).toBe("resolved");
+      }),
+    ),
+  );
 });
 
 describe("Output.toEnvKey / toUpper", () => {

--- a/packages/alchemy/test/Output.test.ts
+++ b/packages/alchemy/test/Output.test.ts
@@ -1066,6 +1066,15 @@ describe("upstream walkers: cycles and non-plain leaves (#1082)", () => {
     expect(Output.hasOutputs({ effect, layer, context })).toBe(false);
   });
 
+  it("traverses null-prototype objects and treats functions as leaves", () => {
+    const a = fakeResource("Test.A", "NP-A");
+    const nullProto = Object.assign(Object.create(null), { dep: Output.of(a) });
+    expect(Object.keys(Output.upstreamAny({ nullProto }))).toEqual(["NP-A"]);
+    // A function in props is a leaf — a closure capturing a resource is not
+    // a declared dependency.
+    expect(Output.upstreamAny({ fn: () => a })).toEqual({});
+  });
+
   it("treats any class instance as a leaf (never walks its internals)", () => {
     const a = fakeResource("Test.A", "CL-A");
     class SdkConfig {
@@ -1137,6 +1146,77 @@ describe("upstream walkers: cycles and non-plain leaves (#1082)", () => {
         expect(result.value).toBe("resolved");
       }),
     ),
+  );
+
+  it.effect(
+    "evaluate resolves outputs at every nesting depth of plain data",
+    () =>
+      provideState(
+        Effect.gen(function* () {
+          const src = fakeResource("Test.A", "EV-A");
+          const out = (Output.of(src) as any).name;
+          const result = yield* Output.evaluate(
+            {
+              layers: [
+                { config: { hosts: [{ url: out }, { url: "static" }] } },
+              ],
+              matrix: [[out]],
+              mixed: [1, "x", { deep: [out] }, null],
+              nullProto: Object.assign(Object.create(null), { ref: out }),
+            },
+            { "EV-A": { name: "resolved-name" } },
+          );
+          expect(result.layers[0].config.hosts[0].url).toBe("resolved-name");
+          expect(result.layers[0].config.hosts[1].url).toBe("static");
+          expect(result.matrix[0][0]).toBe("resolved-name");
+          expect(result.mixed).toEqual([
+            1,
+            "x",
+            { deep: ["resolved-name"] },
+            null,
+          ]);
+          expect(result.nullProto.ref).toBe("resolved-name");
+        }),
+      ),
+  );
+
+  it.effect("evaluate cuts cyclic plain data but resolves siblings", () =>
+    provideState(
+      Effect.gen(function* () {
+        const src = fakeResource("Test.A", "CY-EV");
+        const out = (Output.of(src) as any).name;
+        const cyclic: any = { tag: "c" };
+        cyclic.self = cyclic;
+        const arr: any[] = [cyclic];
+        cyclic.arr = arr;
+        const result = yield* Output.evaluate(
+          { cyc: cyclic, url: out },
+          { "CY-EV": { name: "sibling" } },
+        );
+        expect(result.url).toBe("sibling");
+        expect(result.cyc.tag).toBe("c");
+        expect(result.cyc.self).toBeUndefined();
+        expect(result.cyc.arr[0]).toBeUndefined();
+      }),
+    ),
+  );
+
+  it.effect(
+    "evaluate preserves diamonds — shared objects evaluate in both positions",
+    () =>
+      provideState(
+        Effect.gen(function* () {
+          const src = fakeResource("Test.A", "DI-EV");
+          const shared = { url: (Output.of(src) as any).name };
+          const result = yield* Output.evaluate(
+            { left: shared, right: shared, list: [shared] },
+            { "DI-EV": { name: "diamond" } },
+          );
+          expect(result.left).toEqual({ url: "diamond" });
+          expect(result.right).toEqual({ url: "diamond" });
+          expect(result.list[0]).toEqual({ url: "diamond" });
+        }),
+      ),
   );
 });
 

--- a/packages/alchemy/test/Util/data.test.ts
+++ b/packages/alchemy/test/Util/data.test.ts
@@ -1,9 +1,15 @@
 import {
+  isPlainData,
   isPlainObject,
+  mapPlainData,
   stripNullFields,
   stripUndefinedFields,
   unwrapRedacted,
 } from "@/Util/data";
+import * as Context from "effect/Context";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
 import * as Redacted from "effect/Redacted";
 import { describe, expect, test } from "alchemy-test";
 
@@ -59,5 +65,110 @@ describe("data utilities", () => {
       nested: ["nested"],
       date,
     });
+  });
+});
+
+// The engine's traversal rule (#1082): plain data is walked; every class
+// instance is a leaf. isPlainData is the single gate, mapPlainData the
+// single cycle-guarded rebuild — pin their exact semantics here.
+describe("isPlainData", () => {
+  test("accepts arrays, object literals, and null-prototype objects", () => {
+    expect(isPlainData([])).toBe(true);
+    expect(isPlainData([1, 2, 3])).toBe(true);
+    expect(isPlainData({})).toBe(true);
+    expect(isPlainData({ a: 1 })).toBe(true);
+    expect(isPlainData(Object.create(null))).toBe(true);
+  });
+
+  test("rejects primitives and functions", () => {
+    expect(isPlainData(undefined)).toBe(false);
+    expect(isPlainData(null)).toBe(false);
+    expect(isPlainData(0)).toBe(false);
+    expect(isPlainData("s")).toBe(false);
+    expect(isPlainData(true)).toBe(false);
+    expect(isPlainData(Symbol("s"))).toBe(false);
+    expect(isPlainData(10n)).toBe(false);
+    expect(isPlainData(() => {})).toBe(false);
+  });
+
+  test("rejects every class instance — built-in, effect, and user-defined", () => {
+    class Custom {}
+    expect(isPlainData(new Custom())).toBe(false);
+    expect(isPlainData(new Date())).toBe(false);
+    expect(isPlainData(new Map())).toBe(false);
+    expect(isPlainData(new Set())).toBe(false);
+    expect(isPlainData(new URL("https://example.com"))).toBe(false);
+    expect(isPlainData(/regex/)).toBe(false);
+    expect(isPlainData(Buffer.from("x"))).toBe(false);
+    expect(isPlainData(Effect.succeed(1))).toBe(false);
+    expect(isPlainData(Layer.empty)).toBe(false);
+    expect(isPlainData(Context.empty())).toBe(false);
+    expect(isPlainData(Redacted.make("s"))).toBe(false);
+    expect(isPlainData(Duration.seconds(1))).toBe(false);
+  });
+});
+
+describe("mapPlainData", () => {
+  const identity = (ancestors: WeakSet<object>) => {
+    const walk = (child: unknown): unknown =>
+      isPlainData(child) ? mapPlainData(child, ancestors, walk) : child;
+    return walk;
+  };
+
+  test("rebuilds arrays as arrays and objects as objects", () => {
+    const ancestors = new WeakSet<object>();
+    const rebuilt: any = mapPlainData(
+      { a: [1, { b: 2 }], c: { d: [3] } },
+      ancestors,
+      identity(ancestors),
+    );
+    expect(rebuilt).toEqual({ a: [1, { b: 2 }], c: { d: [3] } });
+    expect(Array.isArray(rebuilt.a)).toBe(true);
+    expect(Array.isArray(rebuilt.c.d)).toBe(true);
+  });
+
+  test("cuts a self-referencing object to undefined", () => {
+    const cyclic: any = { name: "x" };
+    cyclic.self = cyclic;
+    const ancestors = new WeakSet<object>();
+    const rebuilt: any = mapPlainData(cyclic, ancestors, identity(ancestors));
+    expect(rebuilt.name).toBe("x");
+    expect(rebuilt.self).toBeUndefined();
+  });
+
+  test("cuts a mutual object<->array cycle to undefined", () => {
+    const obj: any = { tag: "obj" };
+    const arr: any[] = [obj];
+    obj.arr = arr;
+    const ancestors = new WeakSet<object>();
+    const rebuilt: any = mapPlainData(
+      { root: obj },
+      ancestors,
+      identity(ancestors),
+    );
+    expect(rebuilt.root.tag).toBe("obj");
+    expect(rebuilt.root.arr[0]).toBeUndefined();
+  });
+
+  test("preserves diamonds — the same object referenced twice is rebuilt twice", () => {
+    const shared = { v: 1 };
+    const ancestors = new WeakSet<object>();
+    const rebuilt: any = mapPlainData(
+      { left: shared, right: shared, list: [shared] },
+      ancestors,
+      identity(ancestors),
+    );
+    expect(rebuilt.left).toEqual({ v: 1 });
+    expect(rebuilt.right).toEqual({ v: 1 });
+    expect(rebuilt.list[0]).toEqual({ v: 1 });
+  });
+
+  test("leaves the ancestors set empty afterwards (guard is path-scoped)", () => {
+    const value = { a: { b: [1] } };
+    const ancestors = new WeakSet<object>();
+    mapPlainData(value, ancestors, identity(ancestors));
+    // Re-walking the same value must not see stale ancestors.
+    const again: any = mapPlainData(value, ancestors, identity(ancestors));
+    expect(again).toEqual({ a: { b: [1] } });
   });
 });

--- a/packages/alchemy/test/apply.test.ts
+++ b/packages/alchemy/test/apply.test.ts
@@ -6353,3 +6353,153 @@ describe("deeply nested dependencies (order + resolution)", () => {
       }),
   );
 });
+
+// End-to-end pins for the #1082 leaf rules: class instances in props reach
+// `reconcile` by identity (prototype intact), are stripped from persisted
+// state, and never churn a diff; cyclic plain data deploys and re-deploys
+// without hanging or phantom updates.
+describe("non-plain and cyclic props through deploy", () => {
+  test.provider(
+    "a Date prop reaches reconcile intact and re-deploys without churn",
+    (stack) =>
+      Effect.gen(function* () {
+        const seen: Date[] = [];
+        const updates: string[] = [];
+        const hooks = {
+          create: (_id: string, props: any) =>
+            Effect.sync(() => {
+              seen.push(props.expires);
+            }),
+          update: (id: string, props: any) =>
+            Effect.sync(() => {
+              updates.push(id);
+              seen.push(props.expires);
+            }),
+          delete: () => Effect.succeed(undefined),
+          read: () => Effect.succeed(undefined),
+        };
+
+        const program = (iso: string) =>
+          Effect.gen(function* () {
+            return yield* TestResource("A", {
+              string: "date-holder",
+              expires: new Date(iso),
+            } as any);
+          });
+
+        yield* program("2027-01-01").pipe(stack.deploy, hook(hooks));
+        // The Date arrives in reconcile as a real Date, not `{}`.
+        expect(seen[0]).toBeInstanceOf(Date);
+        expect(seen[0]!.toISOString()).toBe("2027-01-01T00:00:00.000Z");
+
+        // Same date again — no phantom update from Date handling.
+        yield* program("2027-01-01").pipe(stack.deploy, hook(hooks));
+        expect(updates).toEqual([]);
+
+        // Changed date — must be detected and delivered.
+        yield* program("2028-06-15").pipe(stack.deploy, hook(hooks));
+        expect(updates).toEqual(["A"]);
+        const last = seen[seen.length - 1]!;
+        expect(last).toBeInstanceOf(Date);
+        expect(last.toISOString()).toBe("2028-06-15T00:00:00.000Z");
+
+        yield* stack.destroy();
+        expect(yield* listState()).toEqual([]);
+      }),
+  );
+
+  test.provider(
+    "a class-instance prop reaches reconcile by identity and never churns",
+    (stack) =>
+      Effect.gen(function* () {
+        class SdkConfig {
+          constructor(readonly region: string) {}
+        }
+        const received: any[] = [];
+        const updates: string[] = [];
+        const hooks = {
+          create: (_id: string, props: any) =>
+            Effect.sync(() => {
+              received.push(props.config);
+            }),
+          update: (id: string) =>
+            Effect.sync(() => {
+              updates.push(id);
+            }),
+          delete: () => Effect.succeed(undefined),
+          read: () => Effect.succeed(undefined),
+        };
+
+        const program = () =>
+          Effect.gen(function* () {
+            // A fresh instance every deploy — identity differs run to run.
+            return yield* TestResource("A", {
+              string: "sdk-holder",
+              config: new SdkConfig("us-east-1"),
+            } as any);
+          });
+
+        yield* program().pipe(stack.deploy, hook(hooks));
+        // Prototype intact all the way into reconcile.
+        expect(received[0]).toBeInstanceOf(SdkConfig);
+        expect(received[0].region).toBe("us-east-1");
+
+        // Persisted state holds plain data only — the instance is stripped.
+        const persisted = yield* getState("A");
+        expect((persisted?.props as any).config).toBeUndefined();
+        expect(() => JSON.stringify(persisted?.props)).not.toThrow();
+
+        // A fresh (different-identity) instance must not cause an update:
+        // runtime-only wiring is invisible to the diff.
+        yield* program().pipe(stack.deploy, hook(hooks));
+        expect(updates).toEqual([]);
+
+        yield* stack.destroy();
+        expect(yield* listState()).toEqual([]);
+      }),
+  );
+
+  test.provider(
+    "cyclic plain props deploy, persist truncated, and re-deploy as noop",
+    (stack) =>
+      Effect.gen(function* () {
+        const updates: string[] = [];
+        const hooks = {
+          create: () => Effect.succeed(undefined),
+          update: (id: string) =>
+            Effect.sync(() => {
+              updates.push(id);
+            }),
+          delete: () => Effect.succeed(undefined),
+          read: () => Effect.succeed(undefined),
+        };
+
+        const program = () =>
+          Effect.gen(function* () {
+            const cyclic: any = { name: "cfg" };
+            cyclic.self = cyclic;
+            const A = yield* TestResource("A", { string: "up" });
+            const B = yield* TestResource("B", {
+              config: cyclic,
+              url: A.string,
+            } as any);
+            return { A, B };
+          });
+
+        yield* program().pipe(stack.deploy, hook(hooks));
+
+        // Persisted with the cycle cut — still JSON-serializable.
+        const persisted = yield* getState("B");
+        expect((persisted?.props as any).config.name).toBe("cfg");
+        expect((persisted?.props as any).config.self).toBeUndefined();
+        expect(() => JSON.stringify(persisted?.props)).not.toThrow();
+
+        // Identical (still-cyclic) props — a clean noop.
+        yield* program().pipe(stack.deploy, hook(hooks));
+        expect(updates).toEqual([]);
+
+        yield* stack.destroy();
+        expect(yield* listState()).toEqual([]);
+      }),
+  );
+});

--- a/packages/alchemy/test/apply.test.ts
+++ b/packages/alchemy/test/apply.test.ts
@@ -6199,3 +6199,157 @@ describe("provider modes (local ⇄ live)", () => {
       }),
   );
 });
+
+// Apply must honor dependency ORDER and resolve values for references at ANY
+// nesting depth of plain data — objects in arrays, arrays in objects, arrays
+// of arrays, whole-resource refs (#1082 hardened the walkers with a
+// plain-data gate + cycle guards; these pin end-to-end that no nesting shape
+// lost its edge or its resolution).
+describe("deeply nested dependencies (order + resolution)", () => {
+  test.provider(
+    "creates upstream first and resolves refs at every nesting depth",
+    (stack) =>
+      Effect.gen(function* () {
+        const createOrder: string[] = [];
+        let bCreateProps: any;
+        const createHooks = {
+          create: (id: string, props: any) =>
+            Effect.sync(() => {
+              createOrder.push(id);
+              if (id === "B") bCreateProps = props;
+            }),
+          update: () => Effect.succeed(undefined),
+          delete: () => Effect.succeed(undefined),
+          read: () => Effect.succeed(undefined),
+        };
+
+        const nestedProps = (a: any) =>
+          ({
+            layers: [{ config: { hosts: [{ url: a.string }] } }],
+            matrix: [[a.string]],
+            whole: { list: [a] },
+            mixed: [1, "x", { deep: [a.string] }, null],
+          }) as any;
+
+        yield* Effect.gen(function* () {
+          const A = yield* TestResource("A", { string: "deep-a" });
+          const B = yield* TestResource("B", nestedProps(A));
+          return { A, B };
+        }).pipe(stack.deploy, hook(createHooks));
+
+        // Order: the ONLY references to A are deeply nested — A must still
+        // be created before B.
+        expect(createOrder).toEqual(["A", "B"]);
+
+        // Resolution: every nested position received the concrete value.
+        expect(bCreateProps.layers[0].config.hosts[0].url).toBe("deep-a");
+        expect(bCreateProps.matrix[0][0]).toBe("deep-a");
+        expect(bCreateProps.mixed[2].deep[0]).toBe("deep-a");
+        // A whole-resource reference resolves to the upstream's attributes.
+        expect(bCreateProps.whole.list[0].string).toBe("deep-a");
+
+        // Second deploy: the upstream value changes; the change must
+        // propagate through every nested position, again upstream-first.
+        const updateOrder: string[] = [];
+        let bUpdateProps: any;
+        const updateHooks = {
+          create: () => Effect.succeed(undefined),
+          update: (id: string, props: any) =>
+            Effect.sync(() => {
+              updateOrder.push(id);
+              if (id === "B") bUpdateProps = props;
+            }),
+          delete: () => Effect.succeed(undefined),
+          read: () => Effect.succeed(undefined),
+        };
+
+        yield* Effect.gen(function* () {
+          const A = yield* TestResource("A", { string: "deep-a2" });
+          const B = yield* TestResource("B", nestedProps(A));
+          return { A, B };
+        }).pipe(stack.deploy, hook(updateHooks));
+
+        expect(updateOrder).toEqual(["A", "B"]);
+        expect(bUpdateProps.layers[0].config.hosts[0].url).toBe("deep-a2");
+        expect(bUpdateProps.matrix[0][0]).toBe("deep-a2");
+        expect(bUpdateProps.mixed[2].deep[0]).toBe("deep-a2");
+        expect(bUpdateProps.whole.list[0].string).toBe("deep-a2");
+
+        yield* stack.destroy();
+        expect(yield* listState()).toEqual([]);
+      }),
+  );
+
+  test.provider(
+    "a fan-in of deeply nested deps creates ALL upstreams before the dependent",
+    (stack) =>
+      Effect.gen(function* () {
+        const order: string[] = [];
+        let cProps: any;
+        const hooks = {
+          create: (id: string, props: any) =>
+            Effect.sync(() => {
+              order.push(id);
+              if (id === "C") cProps = props;
+            }),
+          update: () => Effect.succeed(undefined),
+          delete: () => Effect.succeed(undefined),
+          read: () => Effect.succeed(undefined),
+        };
+
+        yield* Effect.gen(function* () {
+          const A = yield* TestResource("A", { string: "fan-a" });
+          const B = yield* TestResource("B", { string: "fan-b" });
+          const C = yield* TestResource("C", {
+            fromA: { arr: [{ v: A.string }] },
+            fromB: [[{ v: B.string }]],
+          } as any);
+          return { A, B, C };
+        }).pipe(stack.deploy, hook(hooks));
+
+        // A and B may create in either order (they're independent), but C
+        // must come last.
+        expect(order).toHaveLength(3);
+        expect(order[2]).toBe("C");
+        expect(order.slice(0, 2).sort()).toEqual(["A", "B"]);
+        expect(cProps.fromA.arr[0].v).toBe("fan-a");
+        expect(cProps.fromB[0][0].v).toBe("fan-b");
+
+        yield* stack.destroy();
+        expect(yield* listState()).toEqual([]);
+      }),
+  );
+
+  test.provider(
+    "a dependency chain through nested containers applies in topological order",
+    (stack) =>
+      Effect.gen(function* () {
+        const order: string[] = [];
+        const hooks = {
+          create: (id: string) =>
+            Effect.sync(() => {
+              order.push(id);
+            }),
+          update: () => Effect.succeed(undefined),
+          delete: () => Effect.succeed(undefined),
+          read: () => Effect.succeed(undefined),
+        };
+
+        yield* Effect.gen(function* () {
+          const A = yield* TestResource("A", { string: "chain-a" });
+          const B = yield* TestResource("B", {
+            nested: [{ from: A.string }],
+          } as any);
+          const C = yield* TestResource("C", {
+            nested: { deep: [[B.string]] },
+          } as any);
+          return { A, B, C };
+        }).pipe(stack.deploy, hook(hooks));
+
+        expect(order).toEqual(["A", "B", "C"]);
+
+        yield* stack.destroy();
+        expect(yield* listState()).toEqual([]);
+      }),
+  );
+});

--- a/packages/alchemy/test/plan.test.ts
+++ b/packages/alchemy/test/plan.test.ts
@@ -4235,3 +4235,103 @@ describe("provider modes (local ⇄ live)", () => {
     }),
   );
 });
+
+// Upstream dependency detection must find a Resource/Output reference at ANY
+// nesting depth of plain data — objects in arrays, arrays in objects, and
+// arbitrary mixes (#1082 hardened the walkers with a plain-data gate + cycle
+// guards; these pin that no nesting shape lost its dependency edge). Each
+// case plans `A` (upstream) and `B` whose props embed a reference to `A` in a
+// different shape, then asserts the A→B edge exists in the plan DAG.
+describe("upstream detection across nesting shapes", () => {
+  // Each shape gets the raw resource and an attr Output to embed.
+  const shapes: [name: string, props: (a: any) => Record<string, any>][] = [
+    ["raw resource at top level", (a) => ({ ref: a })],
+    ["attr output at top level", (a) => ({ name: a.name })],
+    ["raw resource in object", (a) => ({ obj: { ref: a } })],
+    ["attr output in object", (a) => ({ obj: { name: a.name } })],
+    [
+      "deeply nested object (4 levels)",
+      (a) => ({ l1: { l2: { l3: { l4: { name: a.name } } } } }),
+    ],
+    ["raw resource in array", (a) => ({ arr: [a] })],
+    ["attr output in array", (a) => ({ arr: [a.name] })],
+    [
+      "output among primitives in array",
+      (a) => ({ arr: [1, "x", a.name, null, true] }),
+    ],
+    ["array in object in array", (a) => ({ arr: [{ inner: [a.name] }] })],
+    ["object in array in object", (a) => ({ obj: { list: [{ ref: a }] } })],
+    [
+      "arrays in objects in arrays in objects",
+      (a) => ({
+        layers: [
+          { config: { hosts: [{ url: a.name }, { url: "static" }] } },
+          { config: { hosts: [] } },
+        ],
+      }),
+    ],
+    [
+      "mixed: raw resource and output at different depths",
+      (a) => ({
+        top: a,
+        nested: { deep: [{ deeper: { name: a.name } }] },
+      }),
+    ],
+    [
+      "nested empty containers alongside the ref",
+      (a) => ({
+        empties: [{}, [], { x: [] }],
+        ref: { arr: [[a.name]] },
+      }),
+    ],
+    ["array of arrays", (a) => ({ matrix: [[a.name]] })],
+  ];
+
+  for (const [name, props] of shapes) {
+    test(
+      `finds the dependency: ${name}`,
+      Effect.gen(function* () {
+        const plan = yield* Effect.gen(function* () {
+          const a = yield* Bucket("A", { name: "nest-a" });
+          yield* TestResource("B", props(a) as any);
+        }).pipe(makePlan);
+
+        expect(plan.resources.A!.action).toBe("create");
+        expect(plan.resources.B!.action).toBe("create");
+        // The dependency edge A -> B must exist regardless of nesting shape.
+        expect(plan.resources.A!.downstream).toContain("B");
+        expect(plan.resources.B!.downstream).not.toContain("A");
+      }),
+    );
+  }
+
+  test(
+    "a reference inside a foreign class instance is NOT a dependency",
+    Effect.gen(function* () {
+      class SdkConfig {
+        constructor(readonly ref: any) {}
+      }
+      const plan = yield* Effect.gen(function* () {
+        const a = yield* Bucket("A", { name: "nest-a" });
+        yield* TestResource("B", { config: new SdkConfig(a.name) } as any);
+      }).pipe(makePlan);
+
+      expect(plan.resources.A!.downstream).not.toContain("B");
+    }),
+  );
+
+  test(
+    "cyclic plain objects in props do not hang planning",
+    Effect.gen(function* () {
+      const cyclic: any = { name: "cycle" };
+      cyclic.self = cyclic;
+      const plan = yield* Effect.gen(function* () {
+        const a = yield* Bucket("A", { name: "nest-a" });
+        yield* TestResource("B", { config: cyclic, ref: a.name } as any);
+      }).pipe(makePlan);
+
+      // The cycle is tolerated AND the sibling dependency is still found.
+      expect(plan.resources.A!.downstream).toContain("B");
+    }),
+  );
+});


### PR DESCRIPTION
Fixes https://github.com/alchemy-run/alchemy/issues/1082

effect ≥ 4.0.0-beta.103 rewrote Context/ServiceMap internals into plain objects whose `cacheRoot` references itself. The engine's deep prop walkers recursed into those internals with no cycle guard, so planning any Worker with `exports` (a DO's `constructor` Effect + captured `services` Context) crashed:

```
RangeError: Maximum call stack size exceeded
    at resolveUpstream (lib/Output.js:526)  ← repeats forever
    at plan.make (lib/Plan.js:1077)
    at state_store.deploy
```

The Cloudflare state-store bootstrap hits this on any fresh account before a single user resource is planned, making `Cloudflare.state()` unusable for consumers on newer effect betas. The repo pins beta.102 (where a Context's services hid in a `Map` with no own enumerable props), which is why it never reproduced in-repo — reproduced against published `2.0.0-beta.67` + `effect@4.0.0-beta.103`, exact trace from the issue.

The fix is one traversal rule that depends on no library's implementation details:

```ts
// a Resource or Output IS a dependency
// plain data (arrays, plain objects) is traversed to find them
// every other value — ANY class instance — is a leaf
export const isPlainData = (value: unknown) =>
  Array.isArray(value) ||
  (typeof value === "object" && value !== null &&
    [Object.prototype, null].includes(Object.getPrototypeOf(value)));
```

- `isPlainData` gates every deep walker: the upstream walkers, `evaluate`, `resolveInput`, `materializeStableRefs`, `hasUnresolvedInputs`, the strippers, and `canonicalize`
- `evaluate`/`resolveInput` return non-plain leaves by identity — prototypes intact (previously a `Date` in props was flattened to `{}`)
- the strippers keep only the serializable leaves (`Redacted`, `Duration`, `Date`) and drop every other class instance at the commit boundary — persisted state is plain data only
- cycle guards split by semantics: upstream walkers use a visited-set (lossless for the FQN-keyed union); value-rebuild walkers use an ancestor-path guard so true cycles are cut to `undefined` while legitimately-shared diamond references survive

### Before → after

Any stack containing an Effect-native Worker with a Durable Object crashed at plan time on effect ≥ 4.0.0-beta.103 — including the state-store bootstrap stack itself, which is why `Cloudflare.state()` died before touching a single user resource:

```ts
class Store extends DurableObject<Store>()("Store", impl) {}
// Worker props now carry exports: { Store: { constructor: Effect, services: Context } }
// planning it → RangeError: Maximum call stack size exceeded   ❌ before
// planning it → Store is a leaf; plan proceeds                  ✅ after
```

A cyclic value anywhere in props hung the walk even without effect involved:

```ts
const config: any = { name: "cfg" };
config.self = config; // e.g. an SDK object that back-references its parent
yield* TestResource("B", { config, url: bucket.name });
// plan → RangeError                                             ❌ before
// plan → cycle cut, and `bucket → B` edge still found           ✅ after
```

And `evaluate` rebuilt every object entry-by-entry, so any class instance in props lost its prototype — a `Date` literally became `{}` in the props handed to `reconcile`:

```ts
yield* TestResource("B", { expires: new Date("2027-01-01") });
// reconcile receives { expires: {} }                            ❌ before
// reconcile receives the same Date instance                     ✅ after
```

Dependencies in plain data are unaffected at any depth — pinned by 14 nesting-shape tests in plan.test.ts (outputs/raw resources in arrays-in-objects-in-arrays, arrays of arrays, mixed with primitives, cyclic siblings, class-instance negative) and by apply.test.ts asserting upstream-first create/update order plus value resolution at every nested position, fan-in, and a chain through nested containers:

```ts
const B = yield* TestResource("B", {
  layers: [{ config: { hosts: [{ url: A.string }] } }], // ← still a dependency,
  matrix: [[A.string]],                                 //   still resolved,
  whole: { list: [A] },                                 //   still ordered A-first
});
```

Verified by porting the fix onto the published beta.67 lib under effect beta.103: the greenfield state-store bootstrap then plans and deploys end-to-end. Note: stacks with DO workers deployed by older versions will see a one-time `update` on their next plan — persisted props previously contained flattened Context junk (`{"mapUnsafe":{}}`) that is now stripped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
