### PR TITLE
feat(cloudflare/workers): WorkerEntrypoint bindings — named entrypoints + ctx.props

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/InferEnv.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/InferEnv.ts
@@ -40,6 +40,7 @@ import type { RpcErrorEnvelope, RpcStreamEnvelope } from "./Rpc.ts";
 import type { SecretKeyBinding } from "./SecretKeyBinding.ts";
 import type { VersionMetadataBinding } from "./VersionMetadataBinding.ts";
 import type { Worker } from "./Worker.ts";
+import type { WorkerEntrypointBinding } from "./WorkerEntrypoint.ts";
 import type { WorkerLoader as WorkerLoaderResource } from "./WorkerLoader.ts";
 
 export type InferEnv<W> =
@@ -52,94 +53,99 @@ export type InferEnv<W> =
         };
 
 export type GetBindingType<T> =
-  // A Container bound in `env` is a container-backed Durable Object class —
-  // the runtime binding is the class's namespace. Must be tested BEFORE the
-  // generic Effect unwrap: a Container declaration is itself an Effect.
-  T extends Container.Decl<any, any, any, any, infer DOShape>
-    ? DurableObjectNamespace<DOShape & Rpc.DurableObjectBranded>
-    : // A Worker-only binding lifted by `.pipe(Alchemy.remote())` — the brand
-      // carries the underlying binding value type; recurse on it. Must also
-      // be tested BEFORE the generic Effect unwrap (its Effect `A` is the
-      // runtime client, not the binding value).
-      T extends WorkerOnlyBinding.BindingEffect<infer B>
-      ? GetBindingType<B>
-      : // `Worker.URL` (an Effect resolving to a deferred string accessor) needs
-        // no case of its own: the generic Effect unwrap below reduces it to
-        // `string` via the fallthrough.
-        T extends
-            | Output<infer A, infer _Req>
-            | Effect.Effect<infer A, infer _E, infer _R>
-        ? GetBindingType<A>
-        : T extends FlagshipNs.App
-          ? Flagship
-          : T extends Assets
-            ? Service
-            : T extends AlchemyRpc<infer Shape extends object>
-              ? RpcWireShape<Shape> & Service
-              : T extends D1.Database
-                ? D1Database
-                : T extends R2.Bucket
-                  ? R2Bucket
-                  : T extends KV.Namespace
-                    ? KVNamespace
-                    : T extends DispatchNamespaceResource
-                      ? DispatchNamespace
-                      : T extends Queues.Queue
-                        ? Queue<unknown>
-                        : T extends AI.Gateway
-                          ? Ai
-                          : T extends AIBinding
+  // A named-entrypoint service binding (`Cloudflare.WorkerEntrypoint`).
+  // Tested first: the marker *contains* a Worker, so the later Worker
+  // branches must never see it.
+  T extends WorkerEntrypointBinding
+    ? Fetcher
+    : // A Container bound in `env` is a container-backed Durable Object class —
+      // the runtime binding is the class's namespace. Must be tested BEFORE the
+      // generic Effect unwrap: a Container declaration is itself an Effect.
+      T extends Container.Decl<any, any, any, any, infer DOShape>
+      ? DurableObjectNamespace<DOShape & Rpc.DurableObjectBranded>
+      : // A Worker-only binding lifted by `.pipe(Alchemy.remote())` — the brand
+        // carries the underlying binding value type; recurse on it. Must also
+        // be tested BEFORE the generic Effect unwrap (its Effect `A` is the
+        // runtime client, not the binding value).
+        T extends WorkerOnlyBinding.BindingEffect<infer B>
+        ? GetBindingType<B>
+        : // `Worker.URL` (an Effect resolving to a deferred string accessor) needs
+          // no case of its own: the generic Effect unwrap below reduces it to
+          // `string` via the fallthrough.
+          T extends
+              | Output<infer A, infer _Req>
+              | Effect.Effect<infer A, infer _E, infer _R>
+          ? GetBindingType<A>
+          : T extends FlagshipNs.App
+            ? Flagship
+            : T extends Assets
+              ? Service
+              : T extends AlchemyRpc<infer Shape extends object>
+                ? RpcWireShape<Shape> & Service
+                : T extends D1.Database
+                  ? D1Database
+                  : T extends R2.Bucket
+                    ? R2Bucket
+                    : T extends KV.Namespace
+                      ? KVNamespace
+                      : T extends DispatchNamespaceResource
+                        ? DispatchNamespace
+                        : T extends Queues.Queue
+                          ? Queue<unknown>
+                          : T extends AI.Gateway
                             ? Ai
-                            : T extends AI.Search
-                              ? AiSearchInstance
-                              : T extends AI.SearchNamespace
-                                ? AiSearchNamespace
-                                : T extends Email.SendEmail
-                                  ? SendEmail
-                                  : T extends AnalyticsEngine.Dataset
-                                    ? AnalyticsEngineDataset
-                                    : T extends ArtifactsNs.Namespace
-                                      ? Artifacts
-                                      : T extends RateLimitBinding
-                                        ? RateLimit
-                                        : T extends SecretKeyBinding
-                                          ? CryptoKey
-                                          : T extends ImagesNs.ImagesBinding
-                                            ? ImagesBinding
-                                            : T extends BrowserBinding
-                                              ? BrowserRun
-                                              : // The ambient global `StreamBinding` from
-                                                // @cloudflare/workers-types (the alchemy binding value
-                                                // type of the same name is only reachable as
-                                                // `StreamNs.StreamBinding`).
-                                                T extends StreamNs.StreamBinding
-                                                ? StreamBinding
-                                                : T extends HyperdriveNs.Connection
-                                                  ? Hyperdrive
-                                                  : T extends VersionMetadataBinding
-                                                    ? WorkerVersionMetadata
-                                                    : T extends WorkerLoaderResource
-                                                      ? WorkerLoader
-                                                      : T extends WorkflowLike<
-                                                            infer Params
-                                                          >
-                                                        ? Workflow<Params>
-                                                        : T extends DurableObjectLike
-                                                          ? DurableObjectNamespace<
-                                                              Exclude<
-                                                                T["Shape"],
-                                                                undefined
-                                                              >
+                            : T extends AIBinding
+                              ? Ai
+                              : T extends AI.Search
+                                ? AiSearchInstance
+                                : T extends AI.SearchNamespace
+                                  ? AiSearchNamespace
+                                  : T extends Email.SendEmail
+                                    ? SendEmail
+                                    : T extends AnalyticsEngine.Dataset
+                                      ? AnalyticsEngineDataset
+                                      : T extends ArtifactsNs.Namespace
+                                        ? Artifacts
+                                        : T extends RateLimitBinding
+                                          ? RateLimit
+                                          : T extends SecretKeyBinding
+                                            ? CryptoKey
+                                            : T extends ImagesNs.ImagesBinding
+                                              ? ImagesBinding
+                                              : T extends BrowserBinding
+                                                ? BrowserRun
+                                                : // The ambient global `StreamBinding` from
+                                                  // @cloudflare/workers-types (the alchemy binding value
+                                                  // type of the same name is only reachable as
+                                                  // `StreamNs.StreamBinding`).
+                                                  T extends StreamNs.StreamBinding
+                                                  ? StreamBinding
+                                                  : T extends HyperdriveNs.Connection
+                                                    ? Hyperdrive
+                                                    : T extends VersionMetadataBinding
+                                                      ? WorkerVersionMetadata
+                                                      : T extends WorkerLoaderResource
+                                                        ? WorkerLoader
+                                                        : T extends WorkflowLike<
+                                                              infer Params
                                                             >
-                                                          : T extends
-                                                                | VpcService
-                                                                | VpcServiceLookup
-                                                            ? Fetcher
-                                                            : T extends Redacted<any>
-                                                              ? // redacteds are always stored as secret_text, so are always string
-                                                                // we JSON.stringify when not a Redacted<string>
-                                                                string
-                                                              : T;
+                                                          ? Workflow<Params>
+                                                          : T extends DurableObjectLike
+                                                            ? DurableObjectNamespace<
+                                                                Exclude<
+                                                                  T["Shape"],
+                                                                  undefined
+                                                                >
+                                                              >
+                                                            : T extends
+                                                                  | VpcService
+                                                                  | VpcServiceLookup
+                                                              ? Fetcher
+                                                              : T extends Redacted<any>
+                                                                ? // redacteds are always stored as secret_text, so are always string
+                                                                  // we JSON.stringify when not a Redacted<string>
+                                                                  string
+                                                                : T;
 
 /**
  * Cloudflare service-binding wire shape for an Effect-native Worker.

--- a/packages/alchemy/src/Cloudflare/Workers/RuntimeBindings.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/RuntimeBindings.ts
@@ -228,6 +228,7 @@ export const toRuntimeBinding = Effect.fn(function* (
         binding: b.name,
         scriptName: b.service,
         entrypoint: b.entrypoint,
+        props: b.props,
       });
     case "stream":
       // Local emulation stores videos in a local simulator (no transcoding,

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
@@ -50,6 +50,7 @@ import {
   type WorkerProps,
 } from "./Worker.ts";
 import type { WorkerBinding, WorkerBindingResource } from "./WorkerBinding.ts";
+import { isWorkerEntrypoint } from "./WorkerEntrypoint.ts";
 import { isWorkerLoader } from "./WorkerLoader.ts";
 
 export const bindWorkerAsyncBindings = Effect.fn(function* (
@@ -470,6 +471,17 @@ const toBinding = (
       type: "hyperdrive",
       name: bindingName,
       id: binding.hyperdriveId,
+    };
+  } else if (isWorkerEntrypoint(binding)) {
+    // A named-entrypoint service binding (`Cloudflare.WorkerEntrypoint`).
+    // Tested BEFORE `isWorker` — the marker carries the Worker rather than
+    // being one, but keep the specific classifier ahead of the general one.
+    return {
+      type: "service",
+      name: bindingName,
+      service: binding.worker.workerName,
+      entrypoint: binding.entrypoint,
+      props: binding.props,
     };
   } else if (isWorker(binding)) {
     return {

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerBinding.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerBinding.ts
@@ -38,6 +38,7 @@ import { makeRpcStub } from "./Rpc.ts";
 import type { SecretKeyBinding } from "./SecretKeyBinding.ts";
 import type { VersionMetadataBinding } from "./VersionMetadataBinding.ts";
 import { Worker, WorkerEnvironment } from "./Worker.ts";
+import type { WorkerEntrypointBinding } from "./WorkerEntrypoint.ts";
 import type { WorkerLoader } from "./WorkerLoader.ts";
 
 type DistilledWorkerBinding = Exclude<
@@ -114,6 +115,21 @@ export type QueueWorkerBinding = Extract<
 };
 
 /**
+ * The `service` metadata binding extended with workerd's `ctx.props`.
+ * `props` is what a `Cloudflare.WorkerEntrypoint(worker, { props })` env
+ * entry lowers to; the local runtime delivers it to the target entrypoint.
+ * The Cloudflare API's binding schema does not carry the field yet, so on
+ * live uploads it is dropped at encode until the distilled `workers`
+ * service adds it.
+ */
+export type ServiceWorkerBinding = Extract<
+  DistilledWorkerBinding,
+  { type: "service" }
+> & {
+  props?: Record<string, unknown>;
+};
+
+/**
  * The wire-shape binding union the Cloudflare API accepts — {@link WorkerBinding}
  * minus the alchemy-only members that must be lowered before upload.
  */
@@ -125,10 +141,13 @@ export type WireWorkerBinding = Exclude<
 export type WorkerBinding =
   | Exclude<
       DistilledWorkerBinding,
-      { type: "durable_object_namespace" } | { type: "queue" }
+      | { type: "durable_object_namespace" }
+      | { type: "queue" }
+      | { type: "service" }
     >
   | DurableObjectNamespaceWorkerBinding
   | QueueWorkerBinding
+  | ServiceWorkerBinding
   | SelfUrlWorkerBinding
   | SelfServiceWorkerBinding;
 
@@ -173,6 +192,7 @@ export type WorkerBindingResource =
   | VectorizeIndex
   | Secret
   | Worker
+  | WorkerEntrypointBinding
   | WorkerLoader
   | VersionMetadataBinding
   // The Worker's own URL (`Worker.URL`).

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerEntrypoint.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerEntrypoint.ts
@@ -95,8 +95,8 @@ export interface WorkerEntrypointBinding {
  * ```typescript
  * env: {
  *   VENDOR: Cloudflare.WorkerEntrypoint(vendorWorker, {
- *     entrypoint: "GatekeeperVendor",
- *     props: { sharingDomain: site.url },
+ *     entrypoint: "Vendor",
+ *     props: { baseUrl: site.url },
  *   }),
  * }
  * ```

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerEntrypoint.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerEntrypoint.ts
@@ -1,0 +1,126 @@
+import type { Input } from "../../Input.ts";
+import type { Worker } from "./Worker.ts";
+
+type WorkerEntrypointTypeId = "Cloudflare.WorkerEntrypoint";
+const WorkerEntrypointTypeId: WorkerEntrypointTypeId =
+  "Cloudflare.WorkerEntrypoint";
+
+export interface WorkerEntrypointOptions {
+  /**
+   * Named entrypoint on the target Worker — the exported
+   * `WorkerEntrypoint` class the binding calls. Omitted → the default
+   * entrypoint (equivalent to binding the Worker directly, but with
+   * {@link props} support).
+   */
+  entrypoint?: string;
+  /**
+   * Properties exposed to the target entrypoint via workerd's
+   * `ctx.props`. Values accept `Output` references and resolve at deploy
+   * time.
+   *
+   * Local dev (`alchemy dev`) delivers these today. On deployed Workers
+   * the Cloudflare API's binding schema does not carry `props` yet, so
+   * they are typed and plumbed but dropped at upload until the distilled
+   * `workers` service adds the field.
+   */
+  props?: Record<string, Input<unknown>>;
+}
+
+/**
+ * A service binding to a specific entrypoint of another Worker — the value
+ * form accepted in an async Worker's `env`. See {@link WorkerEntrypoint}.
+ */
+export interface WorkerEntrypointBinding {
+  /** Brand discriminating entrypoint bindings in `env` classification. */
+  readonly kind: WorkerEntrypointTypeId;
+  /** The target Worker resource. */
+  readonly worker: Worker;
+  /** Named entrypoint on the target, or `undefined` for the default. */
+  readonly entrypoint: string | undefined;
+  /** `ctx.props` delivered to the target entrypoint. */
+  readonly props: Record<string, Input<unknown>> | undefined;
+}
+
+/**
+ * Bind a specific `WorkerEntrypoint` class exported by another Worker.
+ *
+ * Binding a Worker directly in `env` (`env: { TARGET: worker }`) targets
+ * its *default* entrypoint. A Worker that exposes additional
+ * `WorkerEntrypoint` classes — workerd treats every named class export of
+ * an entry module as an entrypoint — is bound with `WorkerEntrypoint`,
+ * which selects the class by name and can deliver `ctx.props` to it.
+ *
+ * @resource
+ * @product Workers
+ * @category Workers & Compute
+ *
+ * @section Binding a Named Entrypoint
+ * The target Worker exports a `WorkerEntrypoint` class alongside its
+ * default handler; the consumer selects it by name. `InferEnv` types the
+ * binding as a `Fetcher` service stub — RPC methods are called on it
+ * directly.
+ *
+ * @example Bind and call a named entrypoint
+ * ```typescript
+ * // target/src/worker.ts
+ * import { WorkerEntrypoint } from "cloudflare:workers";
+ *
+ * export class Api extends WorkerEntrypoint {
+ *   async greet(name: string): Promise<string> {
+ *     return `hello ${name}`;
+ *   }
+ * }
+ *
+ * export default { async fetch() { return new Response("ok"); } };
+ * ```
+ *
+ * ```typescript
+ * // alchemy.run.ts
+ * const target = yield* Cloudflare.Worker("Target", { main: "./target/src/worker.ts" });
+ *
+ * const caller = yield* Cloudflare.Worker("Caller", {
+ *   main: "./caller/src/worker.ts",
+ *   env: {
+ *     API: Cloudflare.WorkerEntrypoint(target, "Api"),
+ *   },
+ * });
+ * ```
+ *
+ * @section Delivering ctx.props
+ * The options form attaches properties the target reads from
+ * `this.ctx.props` — workerd's per-binding configuration channel. `Output`
+ * values resolve at deploy time.
+ *
+ * @example Entrypoint binding with props
+ * ```typescript
+ * env: {
+ *   VENDOR: Cloudflare.WorkerEntrypoint(vendorWorker, {
+ *     entrypoint: "GatekeeperVendor",
+ *     props: { sharingDomain: site.url },
+ *   }),
+ * }
+ * ```
+ */
+export const WorkerEntrypoint = (
+  worker: Worker,
+  entrypointOrOptions?: string | WorkerEntrypointOptions,
+): WorkerEntrypointBinding => {
+  const options =
+    typeof entrypointOrOptions === "string"
+      ? { entrypoint: entrypointOrOptions }
+      : (entrypointOrOptions ?? {});
+  return {
+    kind: WorkerEntrypointTypeId,
+    worker,
+    entrypoint: options.entrypoint,
+    props: options.props,
+  };
+};
+
+/** Structural guard for {@link WorkerEntrypointBinding} `env` values. */
+export const isWorkerEntrypoint = (
+  value: unknown,
+): value is WorkerEntrypointBinding =>
+  typeof value === "object" &&
+  value !== null &&
+  (value as { kind?: unknown }).kind === WorkerEntrypointTypeId;

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerLoader.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerLoader.ts
@@ -27,12 +27,12 @@ export interface WorkerLoaderWorkerCode {
   streamingTails?: Fetcher[];
 }
 
-export type WorkerEntrypoint<Shape = unknown> = Fetcher & {
+export type DynamicWorkerEntrypoint<Shape = unknown> = Fetcher & {
   [K in keyof Shape]: Shape[K];
 };
 
 export interface WorkerStub extends Fetcher {
-  getEntrypoint<Shape = unknown>(name?: string): WorkerEntrypoint<Shape>;
+  getEntrypoint<Shape = unknown>(name?: string): DynamicWorkerEntrypoint<Shape>;
 }
 
 export type WorkerLoader = {
@@ -278,7 +278,7 @@ export const WorkerLoader: WorkerLoaderClass = Object.assign(
             ) =>
               Effect.flatMap(Effect.context<Req>(), (context) =>
                 Effect.sync(() =>
-                  wrapWorkerEntrypoint(
+                  wrapDynamicWorkerEntrypoint(
                     loader.get(name, () =>
                       asEffect(getCode()).pipe(
                         Effect.provide(context),
@@ -320,7 +320,9 @@ const unwrapWorkerLoader = (loader: WorkerLoaderWorkerCode) => ({
   streamingTails: loader.streamingTails?.map((t) => t.raw),
 });
 
-const wrapWorkerEntrypoint = <Shape>(raw: any): WorkerEntrypoint<Shape> =>
+const wrapDynamicWorkerEntrypoint = <Shape>(
+  raw: any,
+): DynamicWorkerEntrypoint<Shape> =>
   Object.assign(makeRpcStub<any>(raw), fromCloudflareFetcher(raw));
 
 const wrapWorkerStub = (raw: any): WorkerStub => {
@@ -328,7 +330,7 @@ const wrapWorkerStub = (raw: any): WorkerStub => {
   return {
     ...defaultEntrypoint,
     getEntrypoint: <Shape>(name?: string) =>
-      wrapWorkerEntrypoint<Shape>(
+      wrapDynamicWorkerEntrypoint<Shape>(
         name ? raw.getEntrypoint(name) : raw.getEntrypoint(),
       ),
   };

--- a/packages/alchemy/src/Cloudflare/Workers/index.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/index.ts
@@ -37,5 +37,6 @@ export * from "./WebSocket.ts";
 export * from "./Worker.ts";
 export * from "./WorkerBinding.ts";
 export * from "./WorkerBridge.ts";
+export * from "./WorkerEntrypoint.ts";
 export * from "./WorkerLoader.ts";
 export * from "./WorkerProvider.ts";

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerEntrypoint.local.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerEntrypoint.local.test.ts
@@ -1,0 +1,96 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Test from "@/Test/Alchemy";
+import { expect } from "alchemy-test";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+import * as Schedule from "effect/Schedule";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as pathe from "pathe";
+
+// `dev: true` runs local providers behind the RPC sidecar proxy by default,
+// matching the process topology of the real `alchemy dev` command.
+const { test } = Test.make({
+  providers: Cloudflare.providers(),
+  dev: true,
+});
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+class WorkerNotReady extends Data.TaggedError("WorkerNotReady")<{
+  status: number;
+}> {}
+
+const getReady = (url: string) =>
+  Effect.gen(function* () {
+    const client = yield* HttpClient.HttpClient;
+    return yield* client.get(url).pipe(
+      Effect.flatMap((res) =>
+        res.status === 200
+          ? Effect.succeed(res)
+          : Effect.fail(new WorkerNotReady({ status: res.status })),
+      ),
+      Effect.retry({
+        while: (error) => error instanceof WorkerNotReady,
+        schedule: Schedule.exponential("250 millis"),
+        times: 20,
+      }),
+    );
+  }).pipe(Effect.orDie);
+
+/**
+ * Under `alchemy dev` both Workers run on local workerd, and the
+ * `Cloudflare.WorkerEntrypoint` env entry lowers to a local service
+ * designator with `entrypoint` AND `props` — unlike live deploys, workerd
+ * delivers `ctx.props` today, so this test covers the full contract.
+ */
+test.provider(
+  "WorkerEntrypoint binding targets the named entrypoint and delivers ctx.props locally",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const deployed = yield* stack.deploy(
+        Effect.gen(function* () {
+          const target = yield* Cloudflare.Worker("entrypoint-local-target", {
+            main: pathe.resolve(
+              import.meta.dirname,
+              "fixtures/worker-entrypoint-binding/entrypoint-target-worker.ts",
+            ),
+          });
+          const caller = yield* Cloudflare.Worker("entrypoint-local-caller", {
+            main: pathe.resolve(
+              import.meta.dirname,
+              "fixtures/worker-entrypoint-binding/entrypoint-caller-worker.ts",
+            ),
+            env: {
+              API: Cloudflare.WorkerEntrypoint(target, {
+                entrypoint: "Api",
+                props: { tenant: "acme" },
+              }),
+            },
+          });
+          return { target, caller };
+        }),
+      );
+
+      // Local dev URLs — proof no cloud call ran.
+      expect(deployed.caller.url).toMatch(/^http:\/\/localhost:\d+$/);
+
+      const greeting = yield* getReady(
+        `${deployed.caller.url}/greet?name=alice`,
+      ).pipe(Effect.flatMap((res) => res.text));
+      expect(greeting).toBe("hello alice from Api");
+
+      const props = (yield* getReady(`${deployed.caller.url}/props`).pipe(
+        Effect.flatMap((res) => res.json),
+      )) as Record<string, unknown>;
+      expect(props).toEqual({ tenant: "acme" });
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 120_000 },
+);

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerEntrypoint.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerEntrypoint.test.ts
@@ -1,0 +1,71 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as Test from "@/Test/Alchemy";
+import { expect } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import Stack from "./fixtures/worker-entrypoint-binding/stack.ts";
+
+const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
+  providers: Cloudflare.providers(),
+});
+
+const stack = beforeAll(deploy(Stack));
+afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(Stack));
+
+// Cold-start retry — fresh `workers.dev` URLs take a few seconds to start
+// answering, capped at 3s so the doubling sleeps can't blow the timeout.
+const coldStartRetry = Effect.retry({
+  schedule: Schedule.min([
+    Schedule.exponential("500 millis"),
+    Schedule.spaced("3 seconds"),
+  ]),
+  times: 30,
+});
+
+test(
+  "target worker's default entrypoint responds",
+  Effect.gen(function* () {
+    const { targetUrl } = yield* stack;
+    const client = HttpClient.filterStatusOk(yield* HttpClient.HttpClient);
+
+    const res = yield* client.get(targetUrl).pipe(coldStartRetry);
+    expect(yield* res.text).toBe("hello from EntrypointTargetWorker");
+  }),
+  { timeout: 180_000 },
+);
+
+test(
+  "caller reaches the NAMED entrypoint through the binding",
+  Effect.gen(function* () {
+    const { callerUrl } = yield* stack;
+    const client = HttpClient.filterStatusOk(yield* HttpClient.HttpClient);
+
+    // The default entrypoint has no `greet` — a greeting proves the
+    // binding targeted the named `Api` class.
+    const res = yield* client
+      .get(`${callerUrl}/greet?name=alice`)
+      .pipe(coldStartRetry);
+    expect(yield* res.text).toBe("hello alice from Api");
+  }),
+  { timeout: 180_000 },
+);
+
+// The Cloudflare API's service-binding schema does not carry `props` yet:
+// the distilled `workers` service drops the field at encode, so deployed
+// bindings deliver no ctx.props. Local dev already delivers them (see
+// WorkerEntrypoint.local.test.ts). Flip this on when the distilled patch
+// lands.
+test.skip(
+  "props reach the named entrypoint's ctx.props",
+  Effect.gen(function* () {
+    const { callerUrl } = yield* stack;
+    const client = HttpClient.filterStatusOk(yield* HttpClient.HttpClient);
+
+    const res = yield* client.get(`${callerUrl}/props`).pipe(coldStartRetry);
+    expect((yield* res.json) as Record<string, unknown>).toEqual({
+      tenant: "acme",
+    });
+  }),
+  { timeout: 180_000 },
+);

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/worker-entrypoint-binding/entrypoint-caller-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/worker-entrypoint-binding/entrypoint-caller-worker.ts
@@ -1,0 +1,38 @@
+/// <reference types="@cloudflare/workers-types" />
+
+/**
+ * Plain (non-Effect) Worker whose `API` binding was declared with
+ * `Cloudflare.WorkerEntrypoint(target, { entrypoint: "Api", props })`.
+ *
+ * GET /greet?name=foo  →  target's `Api.greet(name)` through the binding
+ * GET /props           →  JSON of the target's `ctx.props` (delivery probe)
+ *
+ * Errors surface as a 500 with the message in the body so the test can
+ * assert against it directly.
+ */
+export default {
+  async fetch(
+    request: Request,
+    env: {
+      API: Service & {
+        greet: (name: string) => Promise<string>;
+        getProps: () => Promise<Record<string, unknown>>;
+      };
+    },
+  ): Promise<Response> {
+    const url = new URL(request.url);
+    try {
+      if (url.pathname === "/greet") {
+        const name = url.searchParams.get("name") ?? "world";
+        return new Response(await env.API.greet(name));
+      }
+      if (url.pathname === "/props") {
+        return Response.json(await env.API.getProps());
+      }
+      return new Response("caller up");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return new Response(`caller failed: ${message}`, { status: 500 });
+    }
+  },
+};

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/worker-entrypoint-binding/entrypoint-target-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/worker-entrypoint-binding/entrypoint-target-worker.ts
@@ -1,0 +1,27 @@
+/// <reference types="@cloudflare/workers-types" />
+
+/**
+ * Plain (non-Effect) Worker exposing a NAMED entrypoint alongside its
+ * default handler. workerd treats every named class export of an entry
+ * module as an entrypoint; `Api` is only reachable through a service
+ * binding that names it — the default entrypoint has no `greet`, so a
+ * caller succeeding proves the binding targeted the named class.
+ */
+import { WorkerEntrypoint } from "cloudflare:workers";
+
+export class Api extends WorkerEntrypoint<unknown, Record<string, unknown>> {
+  async greet(name: string): Promise<string> {
+    return `hello ${name} from Api`;
+  }
+
+  /** Echoes the binding's `ctx.props` so callers can assert delivery. */
+  async getProps(): Promise<Record<string, unknown>> {
+    return this.ctx.props ?? {};
+  }
+}
+
+export default {
+  async fetch(): Promise<Response> {
+    return new Response("hello from EntrypointTargetWorker");
+  },
+};

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/worker-entrypoint-binding/stack.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/worker-entrypoint-binding/stack.ts
@@ -1,0 +1,49 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as Alchemy from "@/index";
+import * as Effect from "effect/Effect";
+import * as pathe from "pathe";
+
+const targetMain = pathe.resolve(
+  import.meta.dirname,
+  "entrypoint-target-worker.ts",
+);
+const callerMain = pathe.resolve(
+  import.meta.dirname,
+  "entrypoint-caller-worker.ts",
+);
+
+/**
+ * Stack with two plain Workers:
+ *
+ * - `EntrypointTarget` — exports a named `Api` entrypoint (greet + a
+ *   ctx.props echo) alongside its default handler.
+ * - `EntrypointCaller` — binds the target's `Api` entrypoint via
+ *   `Cloudflare.WorkerEntrypoint(target, { entrypoint: "Api", props })`.
+ */
+export default Alchemy.Stack(
+  "WorkerEntrypointBindingStack",
+  {
+    providers: Cloudflare.providers(),
+    state: Cloudflare.state(),
+  },
+  Effect.gen(function* () {
+    const target = yield* Cloudflare.Worker("EntrypointTarget", {
+      main: targetMain,
+    });
+
+    const caller = yield* Cloudflare.Worker("EntrypointCaller", {
+      main: callerMain,
+      env: {
+        API: Cloudflare.WorkerEntrypoint(target, {
+          entrypoint: "Api",
+          props: { tenant: "acme" },
+        }),
+      },
+    });
+
+    return {
+      targetUrl: target.url.as<string>(),
+      callerUrl: caller.url.as<string>(),
+    };
+  }),
+);

--- a/website/src/content/docs/cloudflare/compute/workers.mdx
+++ b/website/src/content/docs/cloudflare/compute/workers.mdx
@@ -461,7 +461,7 @@ values resolve at deploy time:
 env: {
   VENDOR: Cloudflare.WorkerEntrypoint(vendorWorker, {
     entrypoint: "Vendor",
-    props: { sharingDomain: site.url },
+    props: { baseUrl: site.url },
   }),
 }
 ```

--- a/website/src/content/docs/cloudflare/compute/workers.mdx
+++ b/website/src/content/docs/cloudflare/compute/workers.mdx
@@ -431,6 +431,49 @@ export default {
 };
 ```
 
+## Named entrypoints
+
+Binding another Worker directly (`env: { TARGET: worker }`) targets its
+*default* entrypoint. A Worker can export additional
+[`WorkerEntrypoint` classes](https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/rpc/) —
+workerd treats every named class export of an entry module as an
+entrypoint. Bind one by name with `Cloudflare.WorkerEntrypoint`:
+
+```typescript
+const caller = yield* Cloudflare.Worker("Caller", {
+  main: "./src/caller.ts",
+  env: {
+    API: Cloudflare.WorkerEntrypoint(target, "Api"),
+  },
+});
+```
+
+`InferEnv` types the entry as a `Fetcher` service stub; RPC methods on
+the target class are called on it directly (`env.API.greet("alice")`).
+
+## Entrypoint props
+
+The options form attaches properties the target entrypoint reads from
+`this.ctx.props` — workerd's per-binding configuration channel. `Output`
+values resolve at deploy time:
+
+```typescript
+env: {
+  VENDOR: Cloudflare.WorkerEntrypoint(vendorWorker, {
+    entrypoint: "Vendor",
+    props: { sharingDomain: site.url },
+  }),
+}
+```
+
+:::caution
+`alchemy dev` delivers `props` to the local workerd today. On deployed
+Workers the Cloudflare API's binding schema does not carry the field
+yet, so `props` are dropped at upload until the distilled `workers`
+service adds it — the binding itself (service + entrypoint) deploys
+correctly either way.
+:::
+
 ## Versions & gradual deployments
 
 Every deploy of a Worker uploads an immutable


### PR DESCRIPTION
Bind a specific `WorkerEntrypoint` class exported by another Worker — with optional workerd `ctx.props` — as a plain `env` entry on async Workers:

```ts
const caller = yield* Cloudflare.Worker("Caller", {
  main: "./src/caller.ts",
  env: {
    // shorthand: entrypoint name
    API: Cloudflare.WorkerEntrypoint(target, "Api"),
    // options form: props ride to the target's ctx.props
    VENDOR: Cloudflare.WorkerEntrypoint(vendor, {
      entrypoint: "Vendor",
      props: { baseUrl: site.url },
    }),
  },
});
```

- `env` classification lowers the marker to `{ type: "service", service, entrypoint, props }`; `InferEnv` types it as `Fetcher`.
- The local runtime's `Service.local` already supports `entrypoint` + `props`, so `alchemy dev` delivers `ctx.props` today — pinned by `WorkerEntrypoint.local.test.ts` (props assertion included).
- Live coverage in `WorkerEntrypoint.test.ts`: default entrypoint + named-entrypoint RPC round-trip against a real deploy. The `ctx.props` live assertion is a `todo`: the distilled `workers` service's binding schema doesn't carry `props` yet, so it is dropped at encode on upload. Follow-up: distilled Smithy patch adding `props` to the service binding (wrangler already uploads it), then flip the test on.
- Renames `WorkerLoader.ts`'s internal `WorkerEntrypoint<Shape>` stub type to `DynamicWorkerEntrypoint<Shape>` (referenced nowhere outside that file) to free the name.
- Docs: "Named entrypoints" + "Entrypoint props" sections in `cloudflare/compute/workers.mdx`; resource JSDoc generates the provider reference page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
