### PR TITLE
feat(postgres): add generic Postgres.Database resource with migration support

### DIFF
--- a/packages/alchemy/package.json
+++ b/packages/alchemy/package.json
@@ -249,6 +249,18 @@
       "worker": "./src/Planetscale/*/index.ts",
       "import": "./lib/Planetscale/*/index.js"
     },
+    "./Postgres": {
+      "types": "./lib/Postgres/index.d.ts",
+      "bun": "./src/Postgres/index.ts",
+      "worker": "./src/Postgres/index.ts",
+      "import": "./lib/Postgres/index.js"
+    },
+    "./Postgres/*": {
+      "types": "./lib/Postgres/*.d.ts",
+      "bun": "./src/Postgres/*.ts",
+      "worker": "./src/Postgres/*.ts",
+      "import": "./lib/Postgres/*.js"
+    },
     "./Runtime": {
       "types": "./lib/Runtime.d.ts",
       "bun": "./src/Runtime.ts",

--- a/packages/alchemy/src/Postgres/Database.ts
+++ b/packages/alchemy/src/Postgres/Database.ts
@@ -1,0 +1,173 @@
+import * as Redacted from "effect/Redacted";
+import { Resource } from "../Resource.ts";
+import type { Providers } from "./Providers.ts";
+import type { PostgresOrigin } from "./PostgresOrigin.ts";
+
+type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never };
+type XOR<T, U> = (Without<T, U> & U) | (Without<U, T> & T);
+
+type ConnectionFields = {
+  host?: string;
+  port?: number;
+  user?: string;
+  password?: string;
+  database?: string;
+};
+
+type ExclusiveConnection = XOR<
+  { connectionString: string },
+  ConnectionFields
+>;
+
+export interface DockerDatabaseProps {
+  image?: string;
+  port?: number;
+}
+
+type DevPassthroughFields = {
+  connectionString?: string;
+  host?: string;
+  port?: number;
+  user?: string;
+  password?: string;
+  database?: string;
+};
+
+type ExclusiveDev = XOR<
+  { docker: DockerDatabaseProps },
+  DevPassthroughFields
+>;
+
+export type DatabaseProps = ExclusiveConnection & {
+  /**
+   * Directory containing `.sql` migration files. Files are sorted by their
+   * numeric prefix (e.g. `0001_init.sql`) and applied in order.
+   */
+  migrationsDir?: string;
+  /**
+   * Name of the table used to track applied migrations.
+   *
+   * @default "__alchemy_migrations"
+   */
+  migrationsTable?: string;
+  /**
+   * Paths to additional `.sql` files to apply after migrations.
+   * Each file is hashed and re-applied only when its contents change.
+   */
+  importFiles?: string[];
+  /**
+   * Dev mode configuration. In dev mode, connection params are taken
+   * from `dev` (with fallback to top-level). If `dev.docker` is set,
+   * a local Postgres Docker container is started automatically.
+   */
+  dev?: ExclusiveDev;
+};
+
+export interface Database extends Resource<
+  "Postgres.Database",
+  DatabaseProps,
+  {
+    host: string;
+    port: number;
+    user: string;
+    password: Redacted.Redacted<string>;
+    database: string;
+    connectionUri: string;
+    origin: PostgresOrigin;
+    migrationsDir: string | undefined;
+    migrationsTable: string | undefined;
+    migrationsHashes: Record<string, string>;
+    importHashes: Record<string, string>;
+  },
+  never,
+  Providers
+> {}
+
+/**
+ * A generic Postgres database connection with built-in migration support.
+ *
+ * Unlike provider-specific resources like `Neon.Project` or
+ * `Planetscale.PostgresDatabase`, this resource connects to any Postgres
+ * instance — self-hosted, cloud-hosted, or local. It handles migrations
+ * using the same `migrationsDir` / `importFiles` pattern as Neon and
+ * PlanetScale.
+ *
+ * In dev mode, it can automatically start a local Postgres Docker container
+ * so you never have to set up a database manually.
+ *
+ * @resource
+ *
+ * @section Basic usage
+ * @example Connect to a Postgres instance by URL
+ * ```typescript
+ * const db = yield* Postgres.Database("my-db", {
+ *   connectionString: Secret("DATABASE_URL"),
+ *   migrationsDir: "./migrations",
+ * });
+ * ```
+ *
+ * @example Connect by individual params
+ * ```typescript
+ * const db = yield* Postgres.Database("my-db", {
+ *   host: "db.internal",
+ *   port: 5432,
+ *   user: "app",
+ *   password: Secret("DB_PASSWORD"),
+ *   database: "my_app",
+ *   migrationsDir: "./migrations",
+ * });
+ * ```
+ *
+ * @section Dev with Docker
+ * @example Auto-start a local Postgres container in dev
+ * ```typescript
+ * const db = yield* Postgres.Database("my-db", {
+ *   host: "rds.internal",
+ *   user: "app",
+ *   password: Secret("DB_PASSWORD"),
+ *   database: "my_app",
+ *   migrationsDir: "./migrations",
+ *   dev: {
+ *     docker: {
+ *       image: "postgres:18-alpine",
+ *     },
+ *   },
+ * });
+ * ```
+ *
+ * @section Dev with passthrough
+ * @example Use a different host/port in dev
+ * ```typescript
+ * const db = yield* Postgres.Database("my-db", {
+ *   connectionString: Secret("PROD_DATABASE_URL"),
+ *   migrationsDir: "./migrations",
+ *   dev: {
+ *     host: "localhost",
+ *     user: "dev_user",
+ *     database: "dev_app",
+ *   },
+ * });
+ * ```
+ *
+ * @section Feeding into Hyperdrive
+ * @example Wire into Hyperdrive for Cloudflare Workers
+ * ```typescript
+ * const db = yield* Postgres.Database("my-db", {
+ *   connectionString: Secret("DATABASE_URL"),
+ * });
+ * const hd = yield* Cloudflare.Hyperdrive.Connection("app-hd", {
+ *   origin: db.origin,
+ * });
+ * ```
+ *
+ * @section Seed data
+ * @example Run seed files after migrations
+ * ```typescript
+ * const db = yield* Postgres.Database("my-db", {
+ *   connectionString: Secret("DATABASE_URL"),
+ *   migrationsDir: "./migrations",
+ *   importFiles: ["./seed/users.sql"],
+ * });
+ * ```
+ */
+export const Database = Resource<Database>("Postgres.Database");

--- a/packages/alchemy/src/Postgres/DatabaseProvider.ts
+++ b/packages/alchemy/src/Postgres/DatabaseProvider.ts
@@ -1,0 +1,326 @@
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Redacted from "effect/Redacted";
+import * as Schedule from "effect/Schedule";
+import { isResolved } from "../Diff.ts";
+import * as ProviderLayer from "../Local/ProviderLayer.ts";
+import * as Provider from "../Provider.ts";
+import {
+  hashImports,
+  hashMigrations,
+  listSqlFiles,
+  readSqlFile,
+} from "../SQL/SqlFile.ts";
+import { recordsEqual } from "../Util/equal.ts";
+import { Docker } from "../Docker/Docker.ts";
+import { DockerLive } from "../Docker/Docker.ts";
+import { Database } from "./Database.ts";
+import type { DatabaseProps, DockerDatabaseProps } from "./Database.ts";
+import { applyMigrations, runSql, PgError } from "./Migrations.ts";
+import {
+  buildConnectionUri,
+  parsePostgresOrigin,
+  type PostgresOrigin,
+} from "./PostgresOrigin.ts";
+
+const DEFAULT_MIGRATIONS_TABLE = "__alchemy_migrations";
+const DEFAULT_HOST = "localhost";
+const DEFAULT_PORT = 5432;
+
+const rootDir = Effect.sync(() => process.cwd());
+
+const makeContainerName = (id: string) => `alchemy-postgres-${id}`;
+const makeVolumePath = (id: string) => `.alchemy/storage/postgres/${id}/data`;
+
+// --- Connection resolution helpers ---
+
+const resolveLiveOrigin = (news: DatabaseProps): PostgresOrigin => {
+  if (news.connectionString) {
+    return parsePostgresOrigin(news.connectionString);
+  }
+  const host = news.host ?? DEFAULT_HOST;
+  const port = news.port ?? DEFAULT_PORT;
+  const user = news.user ?? "postgres";
+  const password = news.password ?? "";
+  const database = news.database ?? "postgres";
+  return {
+    scheme: "postgres" as const,
+    host,
+    port,
+    database,
+    user,
+    password: Redacted.make(password),
+  };
+};
+
+const resolvePassthroughOrigin = (
+  dev: NonNullable<DatabaseProps["dev"]>,
+  news: DatabaseProps,
+): PostgresOrigin => {
+  if (dev.connectionString) {
+    return parsePostgresOrigin(dev.connectionString);
+  }
+  const host = dev.host ?? news.host ?? DEFAULT_HOST;
+  const port = dev.port ?? news.port ?? DEFAULT_PORT;
+  const user = dev.user ?? news.user ?? "postgres";
+  const password = dev.password ?? news.password ?? "";
+  const database = dev.database ?? news.database ?? "postgres";
+  return {
+    scheme: "postgres" as const,
+    host,
+    port,
+    database,
+    user,
+    password: Redacted.make(password),
+  };
+};
+
+const resolveDockerOrigin = (
+  id: string,
+  dockerConfig: DockerDatabaseProps,
+  news: DatabaseProps,
+) =>
+  Effect.gen(function* () {
+    const docker = yield* Docker;
+    const image = dockerConfig.image ?? "postgres:18-alpine";
+    const port = dockerConfig.port ?? 5432;
+
+    const user = news.user ?? "postgres";
+    const passwordStr = news.password ?? "password";
+    const database = news.database ?? "postgres";
+
+    const name = makeContainerName(id);
+    const volumePath = makeVolumePath(id);
+
+    const inspected = yield* docker.container.inspect(name).pipe(
+      Effect.catchAll(() => Effect.succeed(undefined)),
+    );
+
+    if (!inspected) {
+      yield* docker.container.create({
+        name,
+        image,
+        command: undefined,
+        env: {
+          POSTGRES_USER: user,
+          POSTGRES_PASSWORD: passwordStr,
+          POSTGRES_DB: database,
+        },
+        volume: [`${volumePath}:/var/lib/postgresql/data`],
+        p: [`${port}:5432/tcp`],
+        restart: "unless-stopped",
+        rm: false,
+        "health-cmd": `pg_isready -U ${user}`,
+        "health-interval": "5s",
+        "health-timeout": "5s",
+        "health-retries": 5,
+        "health-start-period": undefined,
+        "health-start-interval": undefined,
+        "stop-timeout": "10s",
+        label: {},
+      });
+    }
+
+    yield* docker.container.start(name);
+
+    const connectionUri = `postgres://${encodeURIComponent(user)}:${encodeURIComponent(passwordStr)}@${DEFAULT_HOST}:${port}/${database}`;
+
+    // Poll pg connection until ready (up to ~60s)
+    yield* Effect.retry(
+      Effect.tryPromise({
+        try: async () => {
+          const { Client } = await import("pg");
+          const client = new Client({ connectionString: connectionUri });
+          await client.connect();
+          await client.end();
+        },
+        catch: () =>
+          new PgError({ message: "Postgres not ready — retrying..." }),
+      }),
+      { schedule: Schedule.spaced("2 seconds"), times: 30 },
+    );
+
+    return {
+      scheme: "postgres" as const,
+      host: DEFAULT_HOST,
+      port,
+      database,
+      user,
+      password: Redacted.make(passwordStr),
+    };
+  });
+
+// --- Migration helpers ---
+
+const runMigrations = (
+  connectionUri: Redacted.Redacted<string>,
+  migrationsDir: string,
+  migrationsTable: string,
+) =>
+  Effect.gen(function* () {
+    const files = yield* listSqlFiles(migrationsDir);
+    if (files.length > 0) {
+      yield* applyMigrations({
+        connectionUri,
+        migrationsTable,
+        migrationsFiles: files,
+      });
+    }
+    const hashes: Record<string, string> = {};
+    for (const file of files) hashes[file.id] = file.hash;
+    return hashes;
+  });
+
+const runImports = (
+  connectionUri: Redacted.Redacted<string>,
+  importFiles: ReadonlyArray<string>,
+  rootDir: string,
+  previous: Record<string, string>,
+) =>
+  Effect.gen(function* () {
+    const hashes: Record<string, string> = { ...previous };
+    for (const filePath of importFiles) {
+      const file = yield* readSqlFile(rootDir, filePath);
+      if (previous[filePath] === file.hash) {
+        hashes[filePath] = file.hash;
+        continue;
+      }
+      yield* runSql(connectionUri, file.sql);
+      hashes[filePath] = file.hash;
+    }
+    const tracked = new Set(importFiles);
+    for (const key of Object.keys(hashes)) {
+      if (!tracked.has(key)) delete hashes[key];
+    }
+    return hashes;
+  });
+
+const diffCheck = Effect.fn(function* (
+  news: DatabaseProps,
+  output: Database["Attributes"] | undefined,
+) {
+  if (!isResolved(news)) return undefined;
+  if (news.migrationsDir) {
+    const newHashes = yield* hashMigrations(news.migrationsDir);
+    if (!recordsEqual(newHashes, output?.migrationsHashes ?? {})) {
+      return { action: "update" } as const;
+    }
+    if (
+      (news.migrationsTable ?? DEFAULT_MIGRATIONS_TABLE) !==
+      (output?.migrationsTable ?? DEFAULT_MIGRATIONS_TABLE)
+    ) {
+      return { action: "update" } as const;
+    }
+  }
+  if (news.importFiles?.length) {
+    const newHashes = yield* hashImports(news.importFiles, yield* rootDir);
+    if (!recordsEqual(newHashes, output?.importHashes ?? {})) {
+      return { action: "update" } as const;
+    }
+  }
+  return undefined;
+});
+
+const reconcileAttributes = Effect.fn(function* (
+  news: DatabaseProps,
+  output: Database["Attributes"] | undefined,
+  origin: PostgresOrigin,
+) {
+  const connectionUri = buildConnectionUri(origin);
+  const redactedUri = Redacted.make(connectionUri);
+
+  const migrationsTable =
+    news.migrationsTable ??
+    output?.migrationsTable ??
+    DEFAULT_MIGRATIONS_TABLE;
+  const migrationsHashes = news.migrationsDir
+    ? yield* runMigrations(redactedUri, news.migrationsDir, migrationsTable)
+    : (output?.migrationsHashes ?? {});
+  const importHashes = news.importFiles?.length
+    ? yield* runImports(
+        redactedUri,
+        news.importFiles,
+        yield* rootDir,
+        output?.importHashes ?? {},
+      )
+    : {};
+
+  return {
+    host: origin.host,
+    port: origin.port,
+    user: origin.user,
+    password: origin.password,
+    database: origin.database,
+    connectionUri,
+    origin,
+    migrationsDir: news.migrationsDir,
+    migrationsTable: news.migrationsDir ? migrationsTable : undefined,
+    migrationsHashes,
+    importHashes,
+  } satisfies Database["Attributes"];
+});
+
+// --- Live Provider (deploy mode) ---
+
+const PostgresLiveDatabaseProvider = Provider.succeed(Database, {
+  list: () => Effect.succeed([]),
+  read: Effect.fn(function* ({ output }) {
+    return output ?? undefined;
+  }),
+  diff: Effect.fn(function* ({ news, output }) {
+    return yield* diffCheck(news, output);
+  }),
+  reconcile: Effect.fn(function* ({ news, output }) {
+    const origin = resolveLiveOrigin(news);
+    return yield* reconcileAttributes(news, output, origin);
+  }),
+  delete: Effect.fn(function* () {}),
+});
+
+// --- Local Provider (dev mode) ---
+
+const PostgresLocalDatabaseProvider = Provider.effect(
+  Database,
+  Effect.gen(function* () {
+    const docker = yield* Docker;
+
+    return Database.Provider.of({
+      list: () => Effect.succeed([]),
+      read: Effect.fn(function* ({ output }) {
+        return output ?? undefined;
+      }),
+      diff: Effect.fn(function* ({ news, output }) {
+        return yield* diffCheck(news, output);
+      }),
+      reconcile: Effect.fn(function* ({ id, news, output }) {
+        const origin =
+          news.dev && "docker" in news.dev && news.dev.docker
+            ? yield* resolveDockerOrigin(id, news.dev.docker, news)
+            : news.dev
+              ? resolvePassthroughOrigin(news.dev, news)
+              : resolveLiveOrigin(news);
+        return yield* reconcileAttributes(news, output, origin);
+      }),
+      delete: Effect.fn(function* ({ id }) {
+        const name = makeContainerName(id);
+        yield* docker.container
+          .stop(name)
+          .pipe(
+            Effect.andThen(() => docker.container.remove(name, true)),
+            Effect.catchAll(() => Effect.void),
+          );
+      }),
+    });
+  }),
+);
+
+// --- Dual Provider ---
+
+export const PostgresDatabaseProvider = () =>
+  ProviderLayer.dual(Database, {
+    live: () => PostgresLiveDatabaseProvider,
+    local: () =>
+      PostgresLocalDatabaseProvider.pipe(
+        Layer.provide(DockerLive),
+      ),
+  });

--- a/packages/alchemy/src/Postgres/Migrations.ts
+++ b/packages/alchemy/src/Postgres/Migrations.ts
@@ -1,0 +1,105 @@
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import * as Redacted from "effect/Redacted";
+import type { Client } from "pg";
+import type { SqlFile } from "../SQL/SqlFile.ts";
+
+const importPg = () =>
+  import("pg").catch((cause) => {
+    throw new Error(
+      "Failed to load the 'pg' driver. Install the optional peer dependency 'pg' to run Postgres migrations.",
+      { cause },
+    );
+  });
+
+export class PgError extends Data.TaggedError("PgError")<{
+  message: string;
+  cause?: unknown;
+}> {}
+
+export interface ApplyMigrationsOptions {
+  connectionUri: Redacted.Redacted<string>;
+  migrationsTable: string;
+  migrationsFiles: ReadonlyArray<SqlFile>;
+}
+
+const withClient = <A, E>(
+  connectionUri: Redacted.Redacted<string>,
+  fn: (client: Client) => Promise<A>,
+): Effect.Effect<A, PgError | E> =>
+  Effect.tryPromise({
+    try: async () => {
+      const { Client } = await importPg();
+      const client = new Client({
+        connectionString: Redacted.value(connectionUri),
+      });
+      await client.connect();
+      try {
+        return await fn(client);
+      } finally {
+        await client.end().catch(() => {});
+      }
+    },
+    catch: (cause) =>
+      new PgError({
+        message: cause instanceof Error ? cause.message : String(cause),
+        cause,
+      }),
+  });
+
+const ensureMigrationsTable = (client: Client, migrationsTable: string) =>
+  client.query(
+    `CREATE TABLE IF NOT EXISTS "${migrationsTable}" (
+       id TEXT PRIMARY KEY,
+       name TEXT NOT NULL,
+       applied_at TIMESTAMPTZ NOT NULL DEFAULT now()
+     );`,
+  );
+
+const getApplied = (client: Client, migrationsTable: string) =>
+  client
+    .query<{ name: string }>(`SELECT name FROM "${migrationsTable}";`)
+    .then((r) => new Set(r.rows.map((row) => row.name)));
+
+const getNextSeq = (client: Client, migrationsTable: string) =>
+  client
+    .query<{ id: string }>(`SELECT id FROM "${migrationsTable}";`)
+    .then((r) => {
+      let max = 0;
+      for (const { id } of r.rows) {
+        if (/^\d+$/.test(id)) {
+          max = Math.max(max, Number.parseInt(id, 10));
+        }
+      }
+      return max + 1;
+    });
+
+export const applyMigrations = (options: ApplyMigrationsOptions) =>
+  withClient(options.connectionUri, async (client) => {
+    await ensureMigrationsTable(client, options.migrationsTable);
+    const applied = await getApplied(client, options.migrationsTable);
+    let nextSeq = await getNextSeq(client, options.migrationsTable);
+
+    for (const file of options.migrationsFiles) {
+      if (applied.has(file.id)) continue;
+      const migrationId = nextSeq.toString().padStart(5, "0");
+      nextSeq += 1;
+      await client.query("BEGIN");
+      try {
+        await client.query(file.sql);
+        await client.query(
+          `INSERT INTO "${options.migrationsTable}" (id, name) VALUES ($1, $2);`,
+          [migrationId, file.id],
+        );
+        await client.query("COMMIT");
+      } catch (err) {
+        await client.query("ROLLBACK").catch(() => {});
+        throw err;
+      }
+    }
+  });
+
+export const runSql = (connectionUri: Redacted.Redacted<string>, sql: string) =>
+  withClient(connectionUri, async (client) => {
+    await client.query(sql);
+  });

--- a/packages/alchemy/src/Postgres/PostgresOrigin.ts
+++ b/packages/alchemy/src/Postgres/PostgresOrigin.ts
@@ -1,0 +1,29 @@
+import * as Redacted from "effect/Redacted";
+
+export type PostgresOrigin = {
+  scheme: "postgres" | "postgresql";
+  host: string;
+  port: number;
+  database: string;
+  user: string;
+  password: Redacted.Redacted<string>;
+};
+
+export const parsePostgresOrigin = (uri: string): PostgresOrigin => {
+  const url = new URL(uri);
+  const scheme: PostgresOrigin["scheme"] =
+    url.protocol === "postgresql:" ? "postgresql" : "postgres";
+  return {
+    scheme,
+    host: url.hostname,
+    port: url.port ? Number(url.port) : 5432,
+    database: url.pathname.replace(/^\//, ""),
+    user: decodeURIComponent(url.username),
+    password: Redacted.make(decodeURIComponent(url.password)),
+  };
+};
+
+export const buildConnectionUri = (origin: PostgresOrigin): string => {
+  const password = Redacted.value(origin.password);
+  return `${origin.scheme}://${encodeURIComponent(origin.user)}:${encodeURIComponent(password)}@${origin.host}:${origin.port}/${origin.database}`;
+};

--- a/packages/alchemy/src/Postgres/Providers.ts
+++ b/packages/alchemy/src/Postgres/Providers.ts
@@ -1,0 +1,41 @@
+import * as Layer from "effect/Layer";
+import * as Provider from "../Provider.ts";
+import { Database } from "./Database.ts";
+import { PostgresDatabaseProvider } from "./DatabaseProvider.ts";
+
+export class Providers extends Provider.ProviderCollection<Providers>()(
+  "Postgres",
+) {}
+
+/**
+ * Build a layer that registers the Postgres Database resource provider.
+ * Include this from your stack alongside other cloud `providers()` layers.
+ *
+ * @example
+ * ```typescript
+ * import * as Alchemy from "alchemy";
+ * import * as Postgres from "alchemy/Postgres";
+ * import * as Effect from "effect/Effect";
+ * import * as Layer from "effect/Layer";
+ *
+ * export default Alchemy.Stack(
+ *   "MyStack",
+ *   {
+ *     providers: Layer.mergeAll(Cloudflare.providers(), Postgres.providers()),
+ *     state: Alchemy.localState(),
+ *   },
+ *   Effect.gen(function* () {
+ *     const db = yield* Postgres.Database("app-db", {
+ *       connectionString: Secret("DATABASE_URL"),
+ *       migrationsDir: "./migrations",
+ *     });
+ *     return { connectionUri: db.connectionUri };
+ *   }),
+ * );
+ * ```
+ */
+export const providers = () =>
+  Layer.effect(Providers, Provider.collection([Database])).pipe(
+    Layer.provide(PostgresDatabaseProvider()),
+    Layer.orDie,
+  );

--- a/packages/alchemy/src/Postgres/index.ts
+++ b/packages/alchemy/src/Postgres/index.ts
@@ -1,0 +1,5 @@
+export * from "./Database.ts";
+export * from "./DatabaseProvider.ts";
+export * from "./Migrations.ts";
+export * from "./PostgresOrigin.ts";
+export * from "./Providers.ts";


### PR DESCRIPTION
Adds a `Postgres.Database` resource that connects to any Postgres instance and handles
migrations automatically — the same `migrationsDir` / `importFiles` flow as Neon and
PlanetScale, but for self- or cloud-hosted Postgres.

### Usage

```ts
import * as Postgres from "alchemy/Postgres";

// Connection string — simplest path
const db = yield* Postgres.Database("app-db", {
  connectionString: Secret("DATABASE_URL"),
  migrationsDir: "./migrations",
});

// Individual params
const db = yield* Postgres.Database("app-db", {
  host: "db.internal",
  port: 5432,
  user: "app",
  password: Secret("DB_PASSWORD"),
  database: "my_app",
  migrationsDir: "./migrations",
});
```

### Dev mode — auto Docker container

In dev you never set up a local Postgres manually. `alchemy dev` starts one for you:

```ts
const db = yield* Postgres.Database("app-db", {
  host: "prod-db.internal",
  user: "app",
  password: Secret("DB_PASSWORD"),
  database: "my_app",
  migrationsDir: "./migrations",
  dev: {
    docker: {
      image: "postgres:18-alpine",
    },
  },
});
```

Data persists in `.alchemy/storage/postgres/app-db/data` via a Docker bind mount.

A `pg_isready` healthcheck ensures the container is accepting connections before
migrations run.

### Dev mode — passthrough

Use a different connection in dev (e.g. a staging DB):

```ts
const db = yield* Postgres.Database("app-db", {
  connectionString: Secret("PROD_DATABASE_URL"),
  migrationsDir: "./migrations",
  dev: {
    host: "localhost",
    user: "dev_user",
    database: "dev_app",
  },
});
```

### Wired into Hyperdrive

The `origin` attribute feeds directly into `Cloudflare.Hyperdrive`:

```ts
const db = yield* Postgres.Database("app-db", {
  connectionString: Secret("DATABASE_URL"),
});

const hd = yield* Cloudflare.Hyperdrive.Connection("app-hd", {
  origin: db.origin,
});
```

### XOR compilation errors

Two compiler-guarded constraints:

```ts
// ❌ connectionString + host (mutually exclusive)
Database("db", { connectionString: "...", host: "..." })

// ❌ dev.docker + dev.host (mutually exclusive)
Database("db", { dev: { docker: {...}, host: "..." } })
```

### Migration internals

- Creates `__alchemy_migrations` tracking table on first run
- Applies each `.sql` file inside a transaction (`BEGIN → query → INSERT → COMMIT`)
- Skips already-applied files by name
- `importFiles` are content-hashed and re-applied on change (no tracking table row)

### What this PR does not include

- No `read` / `list` implementation (these providers are pass-through, there's no
  cloud API to query)
- No binding/connect layer for Workers — Hyperdrive is the intended path for now
- No live-deploy tests (see disclosure below)

### Files

```
packages/alchemy/src/Postgres/
  Database.ts            # Resource type, Props, XOR types, Attributes
  DatabaseProvider.ts    # ProviderLayer.dual — live (passthrough) + local (dev/docker)
  Migrations.ts          # pg-based migration runner
  PostgresOrigin.ts      # PostgresOrigin type, parse/build utilities
  Providers.ts           # ProviderCollection registration
  index.ts               # Barrel exports
packages/alchemy/package.json  # Added "./Postgres" and "./Postgres/*" exports
```

---

### Disclosure

**a)** This feature was developed with the assistance of AI (Anthropic, Kimi & DeepSeek).
All code was manually reviewed for correctness against the existing alchemy
provider patterns.

**b)** The feature has not been tested thoroughly because this repository depends on
git submodules (distilled, cloudflare-tools) that recursively pull in gigabytes
of dependencies — framework-specific adapters for Astro, Svelte, Waku, Nuxt,
React Start, Next.js, etc. These submodules are unnecessary for a single new
resource and would consume excessive bandwidth and storage. A full `bun install`
followed by `bun tsc -b` could not be run. All 17 import paths were verified
manually against their target exports; one bug (incorrect namespace import for
`ProviderLayer`) was caught and fixed during review.

