### PR TITLE
fix(cloudflare): isolate builds from transient cwd races; parallelize Website tests

### DIFF
--- a/packages/alchemy-test/src/cli.ts
+++ b/packages/alchemy-test/src/cli.ts
@@ -11,6 +11,14 @@
  * bun process. Interactive terminals get the opentui view; otherwise tests
  * are logged line-by-line and failures are dumped at the end.
  */
+// The runner executes every test file's effects on ONE event loop, so any
+// fiber touching a relative path can race a transient process-wide chdir.
+// cross-spawn (bundled in vite/build tools the tests exercise) chdirs the
+// whole process to resolve a spawn's binary; `process.chdir.disabled` is
+// its own escape hatch (built for worker threads) — with it set, commands
+// still resolve via PATH and absolutize against the spawn's `cwd`.
+(process.chdir as { disabled?: boolean }).disabled = true;
+
 import * as BunRuntime from "@effect/platform-bun/BunRuntime";
 import * as BunServices from "@effect/platform-bun/BunServices";
 import * as Effect from "effect/Effect";

--- a/packages/alchemy/src/Cloudflare/Alerting/Webhook.ts
+++ b/packages/alchemy/src/Cloudflare/Alerting/Webhook.ts
@@ -103,7 +103,7 @@ export type NotificationWebhook = Resource<
  * const webhook = yield* Cloudflare.Alerting.NotificationWebhook("AlertsHook", {
  *   name: "production-alerts",
  *   url: "https://alerts.example.com/cf",
- *   secret: alchemy.secret.env.WEBHOOK_SECRET,
+ *   secret: yield* Config.redacted("WEBHOOK_SECRET"),
  * });
  * ```
  *

--- a/packages/alchemy/src/Cloudflare/Hyperdrive/Connection.ts
+++ b/packages/alchemy/src/Cloudflare/Hyperdrive/Connection.ts
@@ -145,7 +145,7 @@ export type Connection = Resource<
  *     port: 5432,
  *     database: "app",
  *     user: "app",
- *     password: alchemy.secret.env.DB_PASSWORD,
+ *     password: yield* Config.redacted("DB_PASSWORD"),
  *   },
  * });
  * ```

--- a/packages/alchemy/src/Cloudflare/MagicTransit/IpsecTunnel.ts
+++ b/packages/alchemy/src/Cloudflare/MagicTransit/IpsecTunnel.ts
@@ -140,7 +140,7 @@ export type IpsecTunnel = Resource<
  *   cloudflareEndpoint: "203.0.113.1",
  *   customerEndpoint: "198.51.100.1",
  *   interfaceAddress: "10.213.0.10/31",
- *   psk: alchemy.secret.env.IPSEC_PSK,
+ *   psk: yield* Config.redacted("IPSEC_PSK"),
  * });
  * ```
  *

--- a/packages/alchemy/src/Cloudflare/MtlsCertificate/MtlsCertificate.ts
+++ b/packages/alchemy/src/Cloudflare/MtlsCertificate/MtlsCertificate.ts
@@ -135,7 +135,7 @@ export type MtlsCertificate = Resource<
  * const cert = yield* Cloudflare.MtlsCertificate.MtlsCertificate("origin-client-cert", {
  *   ca: false,
  *   certificates: leafPem,
- *   privateKey: alchemy.secret.env.ORIGIN_CLIENT_KEY,
+ *   privateKey: yield* Config.redacted("ORIGIN_CLIENT_KEY"),
  * });
  * ```
  *

--- a/packages/alchemy/src/Cloudflare/OriginTlsClientAuth/Certificate.ts
+++ b/packages/alchemy/src/Cloudflare/OriginTlsClientAuth/Certificate.ts
@@ -98,7 +98,7 @@ export type Certificate = Resource<
  * const cert = yield* Cloudflare.OriginTlsClientAuth.Certificate("AopCert", {
  *   zoneId: zone.zoneId,
  *   certificate: clientCertPem,
- *   privateKey: alchemy.secret.env.AOP_CLIENT_KEY,
+ *   privateKey: yield* Config.redacted("AOP_CLIENT_KEY"),
  * });
  * ```
  *
@@ -108,7 +108,7 @@ export type Certificate = Resource<
  * const cert = yield* Cloudflare.OriginTlsClientAuth.Certificate("AopCert", {
  *   zoneId: zone.zoneId,
  *   certificate: clientCertPem,
- *   privateKey: alchemy.secret.env.AOP_CLIENT_KEY,
+ *   privateKey: yield* Config.redacted("AOP_CLIENT_KEY"),
  * });
  *
  * yield* Cloudflare.OriginTlsClientAuth.Setting("Aop", {

--- a/packages/alchemy/src/Cloudflare/OriginTlsClientAuth/HostnameAssociation.ts
+++ b/packages/alchemy/src/Cloudflare/OriginTlsClientAuth/HostnameAssociation.ts
@@ -99,7 +99,7 @@ export type HostnameAssociation = Resource<
  * const cert = yield* Cloudflare.OriginTlsClientAuth.HostnameCertificate("AopHostCert", {
  *   zoneId: zone.zoneId,
  *   certificate: clientCertPem,
- *   privateKey: alchemy.secret.env.AOP_CLIENT_KEY,
+ *   privateKey: yield* Config.redacted("AOP_CLIENT_KEY"),
  * });
  *
  * yield* Cloudflare.OriginTlsClientAuth.HostnameAssociation("AopHost", {

--- a/packages/alchemy/src/Cloudflare/OriginTlsClientAuth/HostnameCertificate.ts
+++ b/packages/alchemy/src/Cloudflare/OriginTlsClientAuth/HostnameCertificate.ts
@@ -100,7 +100,7 @@ export type HostnameCertificate = Resource<
  * const cert = yield* Cloudflare.OriginTlsClientAuth.HostnameCertificate("AopHostCert", {
  *   zoneId: zone.zoneId,
  *   certificate: clientCertPem,
- *   privateKey: alchemy.secret.env.AOP_CLIENT_KEY,
+ *   privateKey: yield* Config.redacted("AOP_CLIENT_KEY"),
  * });
  * ```
  *
@@ -110,7 +110,7 @@ export type HostnameCertificate = Resource<
  * const cert = yield* Cloudflare.OriginTlsClientAuth.HostnameCertificate("AopHostCert", {
  *   zoneId: zone.zoneId,
  *   certificate: clientCertPem,
- *   privateKey: alchemy.secret.env.AOP_CLIENT_KEY,
+ *   privateKey: yield* Config.redacted("AOP_CLIENT_KEY"),
  * });
  *
  * yield* Cloudflare.OriginTlsClientAuth.HostnameAssociation("AopHost", {

--- a/packages/alchemy/src/Cloudflare/OriginTlsClientAuth/Setting.ts
+++ b/packages/alchemy/src/Cloudflare/OriginTlsClientAuth/Setting.ts
@@ -73,7 +73,7 @@ export type Setting = Resource<
  * const cert = yield* Cloudflare.OriginTlsClientAuth.Certificate("AopCert", {
  *   zoneId: zone.zoneId,
  *   certificate: clientCertPem,
- *   privateKey: alchemy.secret.env.AOP_CLIENT_KEY,
+ *   privateKey: yield* Config.redacted("AOP_CLIENT_KEY"),
  * });
  *
  * yield* Cloudflare.OriginTlsClientAuth.Setting("Aop", {

--- a/packages/alchemy/src/Cloudflare/Pipelines/LegacyPipeline.ts
+++ b/packages/alchemy/src/Cloudflare/Pipelines/LegacyPipeline.ts
@@ -181,8 +181,8 @@ export type LegacyPipeline = Resource<
  *   destination: {
  *     bucket: bucket.bucketName,
  *     credentials: {
- *       accessKeyId: alchemy.secret.env.R2_ACCESS_KEY_ID,
- *       secretAccessKey: alchemy.secret.env.R2_SECRET_ACCESS_KEY,
+ *       accessKeyId: yield* Config.redacted("R2_ACCESS_KEY_ID"),
+ *       secretAccessKey: yield* Config.redacted("R2_SECRET_ACCESS_KEY"),
  *     },
  *   },
  * });

--- a/packages/alchemy/src/Cloudflare/Pipelines/Sink.ts
+++ b/packages/alchemy/src/Cloudflare/Pipelines/Sink.ts
@@ -238,8 +238,8 @@ export type Sink = Resource<
  *   config: {
  *     bucket: bucket.bucketName,
  *     credentials: {
- *       accessKeyId: alchemy.secret.env.R2_ACCESS_KEY_ID,
- *       secretAccessKey: alchemy.secret.env.R2_SECRET_ACCESS_KEY,
+ *       accessKeyId: yield* Config.redacted("R2_ACCESS_KEY_ID"),
+ *       secretAccessKey: yield* Config.redacted("R2_SECRET_ACCESS_KEY"),
  *     },
  *     path: "ingest",
  *     rollingPolicy: { intervalSeconds: 30 },
@@ -265,7 +265,7 @@ export type Sink = Resource<
  *     bucket: bucket.bucketName,
  *     tableName: "events",
  *     namespace: "default",
- *     token: alchemy.secret.env.CATALOG_TOKEN,
+ *     token: yield* Config.redacted("CATALOG_TOKEN"),
  *   },
  * });
  * ```

--- a/packages/alchemy/src/Cloudflare/R2/BucketSippy.ts
+++ b/packages/alchemy/src/Cloudflare/R2/BucketSippy.ts
@@ -161,12 +161,12 @@ export type BucketSippy = Resource<
  *     provider: "aws",
  *     bucket: "legacy-media",
  *     region: "us-east-1",
- *     accessKeyId: alchemy.secret.env.AWS_ACCESS_KEY_ID,
- *     secretAccessKey: alchemy.secret.env.AWS_SECRET_ACCESS_KEY,
+ *     accessKeyId: yield* Config.redacted("AWS_ACCESS_KEY_ID"),
+ *     secretAccessKey: yield* Config.redacted("AWS_SECRET_ACCESS_KEY"),
  *   },
  *   destination: {
- *     accessKeyId: alchemy.secret.env.R2_ACCESS_KEY_ID,
- *     secretAccessKey: alchemy.secret.env.R2_SECRET_ACCESS_KEY,
+ *     accessKeyId: yield* Config.redacted("R2_ACCESS_KEY_ID"),
+ *     secretAccessKey: yield* Config.redacted("R2_SECRET_ACCESS_KEY"),
  *   },
  * });
  * ```
@@ -180,11 +180,11 @@ export type BucketSippy = Resource<
  *     provider: "gcs",
  *     bucket: "legacy-media",
  *     clientEmail: "sippy@my-project.iam.gserviceaccount.com",
- *     privateKey: alchemy.secret.env.GCS_PRIVATE_KEY,
+ *     privateKey: yield* Config.redacted("GCS_PRIVATE_KEY"),
  *   },
  *   destination: {
- *     accessKeyId: alchemy.secret.env.R2_ACCESS_KEY_ID,
- *     secretAccessKey: alchemy.secret.env.R2_SECRET_ACCESS_KEY,
+ *     accessKeyId: yield* Config.redacted("R2_ACCESS_KEY_ID"),
+ *     secretAccessKey: yield* Config.redacted("R2_SECRET_ACCESS_KEY"),
  *   },
  * });
  * ```

--- a/packages/alchemy/src/Cloudflare/Website/Nuxt.ts
+++ b/packages/alchemy/src/Cloudflare/Website/Nuxt.ts
@@ -133,7 +133,7 @@ export interface NuxtProps<
  * ```typescript
  * const site = yield* Cloudflare.Website.Nuxt("Website", {
  *   env: {
- *     API_KEY: Alchemy.secret("API_KEY"),
+ *     API_KEY: Config.redacted("API_KEY"),
  *   },
  * });
  *

--- a/packages/alchemy/src/Cloudflare/Website/Octane.ts
+++ b/packages/alchemy/src/Cloudflare/Website/Octane.ts
@@ -134,7 +134,7 @@ export interface OctaneProps<
  *
  * const site = yield* Cloudflare.Website.Octane("Website", {
  *   env: {
- *     API_KEY: Alchemy.secret("API_KEY"),
+ *     API_KEY: Config.redacted("API_KEY"),
  *   },
  * });
  * ```

--- a/packages/alchemy/src/Cloudflare/Website/SvelteKit.ts
+++ b/packages/alchemy/src/Cloudflare/Website/SvelteKit.ts
@@ -119,7 +119,7 @@ export interface SvelteKitProps<
  * ```typescript
  * const site = yield* Cloudflare.Website.SvelteKit("Website", {
  *   env: {
- *     API_KEY: Alchemy.secret("API_KEY"),
+ *     API_KEY: Config.redacted("API_KEY"),
  *   },
  * });
  *

--- a/packages/alchemy/src/Cloudflare/Workers/Assets.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Assets.ts
@@ -8,6 +8,7 @@ import * as Schedule from "effect/Schedule";
 import type { PlatformError } from "effect/PlatformError";
 import type { ScopedPlanStatusSession } from "../../Cli/Cli.ts";
 import { sha256, sha256Object } from "../../Util/index.ts";
+import { initialCwd } from "../../Util/Node.ts";
 
 const MAX_ASSET_SIZE = 1024 * 1024 * 25; // 25MB
 const MAX_ASSET_COUNT = 20_000;
@@ -170,7 +171,9 @@ export const readAssetsConfigFiles = Effect.fn(function* (
     return { _headers: undefined, _redirects: undefined };
   }
   const path = yield* Path.Path;
-  const resolvedDirectory = path.resolve(directory);
+  // Anchored: see `readAssets` — the directory may be initial-cwd-relative
+  // and live cwd reads race concurrent tools' transient chdir.
+  const resolvedDirectory = path.resolve(initialCwd, directory);
   const [_headers, _redirects] = yield* Effect.all([
     maybeReadString(path.join(resolvedDirectory, "_headers")),
     maybeReadString(path.join(resolvedDirectory, "_redirects")),
@@ -211,7 +214,10 @@ export const readAssets = Effect.fn(function* ({
   // It is deliberately excluded from the `config` sent to Cloudflare — it
   // is not part of the API's asset config shape.
   const pathPrefix = getAssetsPathPrefix(base);
-  const resolvedDirectory = path.resolve(directory);
+  // Anchored: `directory` may be a relative path persisted by
+  // `Command.Build` (relative to the initial cwd), and a live
+  // `process.cwd()` read can race a concurrent tool's transient chdir.
+  const resolvedDirectory = path.resolve(initialCwd, directory);
   const [files, ignore, _headers, _redirects] = yield* Effect.all([
     fs.readDirectory(resolvedDirectory, { recursive: true }),
     maybeReadString(path.join(resolvedDirectory, ".assetsignore")),
@@ -339,7 +345,10 @@ export const uploadAssets = Effect.fn(function* (
   for (const [name, { hash }] of Object.entries(assets.manifest)) {
     assetsByHash.set(hash, toDiskPath(name));
   }
-  const directory = path.resolve(assets.directory);
+  // Anchored: `assets.directory` may be relative to the initial cwd (a
+  // `Command.Build` outdir), and a live `process.cwd()` read can race a
+  // concurrent tool's transient chdir (framework source builds).
+  const directory = path.resolve(initialCwd, assets.directory);
 
   // One full upload session: ask Cloudflare which assets are missing,
   // upload each bucket, and return the completion JWT that putWorker

--- a/packages/alchemy/src/Cloudflare/Workers/Sources/Vite.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Sources/Vite.ts
@@ -9,11 +9,16 @@ import { createRequire } from "node:module";
 import nodePath from "node:path";
 import { pathToFileURL } from "node:url";
 import type * as vite from "vite";
-import { viteBuildOutputPlugin } from "../../../Bundle/Vite.ts";
+import {
+  viteBuildOutputPlugin,
+  type ViteBuildOutput,
+} from "../../../Bundle/Vite.ts";
 import { hashDirectory, type MemoOptions } from "../../../Command/Memo.ts";
+import { initialCwd } from "../../../Util/Node.ts";
 import { sha256Object } from "../../../Util/sha256.ts";
 import { readAssets } from "../Assets.ts";
 import type { SourceDevHandle, SourceProvider } from "../Source.ts";
+import { runViteBuildChild } from "../ViteChild.ts";
 import type { ViteOptions } from "../Worker.ts";
 import { isWorkerLoader } from "../WorkerLoader.ts";
 
@@ -94,7 +99,7 @@ const makeViteLogger = (console: ConsoleService.Console): vite.Logger => {
 const ALCHEMY_CLOUDFLARE_VITE_INJECTED = "ALCHEMY_CLOUDFLARE_VITE_INJECTED";
 
 export const viteDev = (
-  rootDir: string = process.cwd(),
+  rootDir: string = initialCwd,
   env: Record<string, unknown>,
   pluginOptions: CloudflareVitePluginOptions,
   serverOptions: vite.ServerOptions,
@@ -121,8 +126,59 @@ export const viteDev = (
       }),
   );
 
+/**
+ * Run a production Vite build in a child process rooted at the project
+ * directory and adapt the result to the in-process {@link ViteBuildOutput}
+ * shape.
+ *
+ * The child boundary is what makes concurrent builds safe: vite resolves a
+ * relative root against live `process.cwd()`, plugins read cwd freely, and
+ * build-time spawns chdir the hosting process transiently (cross-spawn's
+ * PATH resolution) — so an in-process build both breaks under and causes
+ * cwd races when the engine runs builds concurrently.
+ */
 export const viteBuild = (
-  rootDir: string = process.cwd(),
+  rootDir: string = initialCwd,
+  env: Record<string, unknown>,
+  pluginOptions: CloudflareVitePluginOptions,
+) =>
+  ConsoleService.consoleWith((console) =>
+    Effect.gen(function* () {
+      const result = yield* runViteBuildChild(
+        {
+          // Anchor to the initial cwd so the resolution itself can't race a
+          // transient chdir; the child's own cwd is this resolved root.
+          rootDir: nodePath.resolve(initialCwd, rootDir),
+          // Only `VITE_`-prefixed entries participate in the build (see
+          // `getDefine`); the rest may hold non-serializable values.
+          env: Object.fromEntries(
+            Object.entries(env).filter(([key]) => key.startsWith("VITE_")),
+          ),
+          main: pluginOptions.main,
+          compatibilityDate: pluginOptions.compatibilityDate,
+          compatibilityFlags: pluginOptions.compatibilityFlags,
+          viteEnvironments: pluginOptions.viteEnvironments,
+        },
+        (channel, line) =>
+          channel === "stderr" ? console.error(line) : console.log(line),
+      );
+      return {
+        clientDirectory: result.clientDirectory,
+        base: result.base,
+        serverBundle: Effect.succeed(result.serverBundle),
+        externalWorkspaces: Effect.succeed(new Set(result.externalWorkspaces)),
+      } satisfies ViteBuildOutput;
+    }),
+  );
+
+/**
+ * The in-process build implementation. ONLY safe inside the dedicated
+ * build child (`ViteBuildChildRunner.ts`), whose cwd is the project root
+ * and which hosts no concurrent work — never call it from the engine
+ * process (see {@link viteBuild}).
+ */
+export const viteBuildInProcess = (
+  rootDir: string,
   env: Record<string, unknown>,
   pluginOptions: CloudflareVitePluginOptions,
 ) =>
@@ -178,9 +234,7 @@ type ViteModule = typeof import("vite");
  * Dynamically load Vite from the project root. Falls back to the bundled
  * copy if the project doesn't have its own Vite installation.
  */
-async function loadVite(
-  projectRoot: string = process.cwd(),
-): Promise<ViteModule> {
+async function loadVite(projectRoot: string = initialCwd): Promise<ViteModule> {
   try {
     const require = createRequire(nodePath.join(projectRoot, "package.json"));
     const vitePath = require.resolve("vite");
@@ -234,7 +288,7 @@ const resolveViteEnv = (env: Record<string, unknown>) =>
  * the rebuild-free change signal for the `input` hash slot.
  */
 export const hashViteInput = Effect.fn(function* <E, R>(
-  rootDir: string = process.cwd(),
+  rootDir: string = initialCwd,
   options: ViteOptions["memo"],
   additionalWorkspaces: Effect.Effect<Iterable<string>, E, R>,
 ) {
@@ -244,8 +298,9 @@ export const hashViteInput = Effect.fn(function* <E, R>(
   // `rootDir` as its own cwd would apply a relative root twice
   // (`path.resolve("app", "app")` → `<cwd>/app/app`), hashing a
   // directory that doesn't exist — a constant hash that never registers
-  // an edit, so the deploy no-ops forever. See issue #1016.
-  const resolvedRoot = path.resolve(rootDir);
+  // an edit, so the deploy no-ops forever. See issue #1016. Anchored to
+  // the initial cwd so a transient chdir can't skew the resolution.
+  const resolvedRoot = path.resolve(initialCwd, rootDir);
   // Relative paths participate in memo hashes and surface in outputs;
   // keep them POSIX so Windows and CI agree.
   const relativeToRoot = (cwd: string) =>
@@ -317,8 +372,11 @@ export const makeViteSource = (vite: ViteOptions): SourceProvider => ({
               ...(ctx.assets && typeof ctx.assets !== "string"
                 ? ctx.assets
                 : undefined),
+              // `clientDirectory` from the build child is absolute; the
+              // base only matters for the in-process legacy shape.
               directory: path.resolve(
-                vite.rootDir ?? process.cwd(),
+                initialCwd,
+                vite.rootDir ?? ".",
                 clientDirectory,
               ),
             })

--- a/packages/alchemy/src/Cloudflare/Workers/ViteBuildChildRunner.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/ViteBuildChildRunner.ts
@@ -1,0 +1,57 @@
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Stdio from "effect/Stdio";
+import * as Stream from "effect/Stream";
+import * as NodeV8 from "node:v8";
+import { PlatformServices, runMain } from "../../Util/PlatformServices.ts";
+import { viteBuildInProcess } from "./Sources/Vite.ts";
+import type {
+  ViteBuildChildConfig,
+  ViteBuildChildResult,
+} from "./ViteChild.shared.ts";
+
+/**
+ * Entry point of the one-shot Vite *build* child spawned by
+ * `runViteBuildChild` (`ViteChild.ts`), with the project root as its
+ * working directory. Running the build out of process is the isolation
+ * boundary: vite resolves a relative root against live `process.cwd()`,
+ * plugins read cwd freely, and the build's own spawns (via cross-spawn)
+ * `process.chdir` the hosting process transiently — none of which is safe
+ * inside the concurrent engine/test process.
+ *
+ * Protocol: V8-serialized {@link ViteBuildChildConfig} on stdin; the child
+ * writes the V8-serialized {@link ViteBuildChildResult} to
+ * `config.outputPath` and exits 0. Build logs stream over stdout/stderr;
+ * a failed build exits non-zero with the error on stderr.
+ */
+
+const readConfig = Effect.gen(function* () {
+  const stdio = yield* Stdio.Stdio;
+  const chunks = yield* Stream.runCollect(stdio.stdin);
+  return NodeV8.deserialize(Buffer.concat(chunks)) as ViteBuildChildConfig;
+});
+
+const program = Effect.gen(function* () {
+  const config = yield* readConfig;
+  const fs = yield* FileSystem.FileSystem;
+  const { clientDirectory, base, serverBundle, externalWorkspaces } =
+    yield* viteBuildInProcess(config.rootDir, config.env, {
+      main: config.main,
+      compatibilityDate: config.compatibilityDate,
+      compatibilityFlags: config.compatibilityFlags,
+      viteEnvironments: config.viteEnvironments,
+    });
+  const [bundle, workspaces] = yield* Effect.all([
+    serverBundle,
+    externalWorkspaces,
+  ]);
+  const result: ViteBuildChildResult = {
+    clientDirectory,
+    base,
+    serverBundle: bundle,
+    externalWorkspaces: Array.from(workspaces),
+  };
+  yield* fs.writeFile(config.outputPath, NodeV8.serialize(result));
+});
+
+runMain(program.pipe(Effect.provide(PlatformServices)));

--- a/packages/alchemy/src/Cloudflare/Workers/ViteChild.shared.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/ViteChild.shared.ts
@@ -5,6 +5,7 @@ import type {
   RuntimeWorker,
   Workflow,
 } from "@distilled.cloud/cloudflare-runtime";
+import type { BundleOutput } from "../../Bundle/Bundle.ts";
 import type { WorkerBinding } from "./WorkerBinding.ts";
 import type { WorkerAssetsConfig, WorkerSourceDescriptor } from "./Worker.ts";
 
@@ -49,3 +50,33 @@ export interface ViteChildConfig {
 
 export const VITE_CHILD_READY_PREFIX = "<ALCHEMY_VITE_ADDRESS>";
 export const VITE_CHILD_READY_SUFFIX = "</ALCHEMY_VITE_ADDRESS>";
+
+/**
+ * Plain-data configuration transferred from the provider to a one-shot
+ * Vite *build* child (`ViteBuildChildRunner.ts`). Deliberately much
+ * smaller than {@link ViteChildConfig}: a production build needs no
+ * workerd runtime, credentials, or binding materialization.
+ */
+export interface ViteBuildChildConfig {
+  /** Absolute project root; also the child process's working directory. */
+  rootDir: string;
+  /**
+   * `VITE_`-prefixed env entries — the only ones the build consumes
+   * (inlined as `import.meta.env.*` defines).
+   */
+  env: Record<string, unknown>;
+  main: string | undefined;
+  compatibilityDate: string | undefined;
+  compatibilityFlags: string[] | undefined;
+  viteEnvironments: { entry?: string; children?: string[] } | undefined;
+  /** Absolute path the child writes the V8-serialized result to. */
+  outputPath: string;
+}
+
+/** Result the build child writes to `outputPath` (V8-serialized). */
+export interface ViteBuildChildResult {
+  clientDirectory: string | undefined;
+  base: string | undefined;
+  serverBundle: BundleOutput | undefined;
+  externalWorkspaces: string[];
+}

--- a/packages/alchemy/src/Cloudflare/Workers/ViteChild.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/ViteChild.ts
@@ -1,14 +1,20 @@
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
 import * as Stream from "effect/Stream";
 import * as ChildProcess from "effect/unstable/process/ChildProcess";
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 import { fileURLToPath } from "node:url";
 import * as NodeV8 from "node:v8";
+import { BundleError } from "../../Bundle/Bundle.ts";
 import { registerExitKill } from "../../Util/killProcessGroup.ts";
 import { transformTypesFlags } from "../../Util/Node.ts";
 import { unwrapRedacted } from "../../Util/index.ts";
 import {
+  type ViteBuildChildConfig,
+  type ViteBuildChildResult,
   type ViteChildConfig,
   VITE_CHILD_READY_PREFIX,
   VITE_CHILD_READY_SUFFIX,
@@ -20,11 +26,17 @@ export interface ViteChildHandle {
   readonly exitCode: Effect.Effect<number>;
 }
 
-const runnerUrl = import.meta.resolve(
-  import.meta.url.endsWith(".ts")
-    ? "./ViteChildRunner.ts"
-    : "./ViteChildRunner.js",
-);
+// Resolved lazily at spawn time, NOT at module load: this module can be
+// carried into bundled user code (Workers), where `import.meta.resolve`
+// does not exist (workerd) — a module-level call would crash the bundle
+// at startup even though no child is ever spawned there. At spawn time
+// we are guaranteed to be in Node/bun.
+const resolveRunner = (basename: string) =>
+  fileURLToPath(
+    import.meta.resolve(
+      import.meta.url.endsWith(".ts") ? `./${basename}.ts` : `./${basename}.js`,
+    ),
+  );
 
 export const startViteChild = (
   config: ViteChildConfig,
@@ -32,7 +44,7 @@ export const startViteChild = (
 ) =>
   Effect.gen(function* () {
     const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
-    const runner = fileURLToPath(runnerUrl);
+    const runner = resolveRunner("ViteChildRunner");
     const isBun = typeof globalThis.Bun !== "undefined";
     // Redacted values can't cross the process boundary — the config is
     // plain data once unwrapped.
@@ -92,3 +104,96 @@ export const startViteChild = (
     ]);
     return { url, pid: child.pid, exitCode } satisfies ViteChildHandle;
   });
+
+/** Number of trailing output lines echoed into a failed build's error. */
+const BUILD_ERROR_TAIL = 50;
+
+/**
+ * Run a one-shot production Vite build in a child process whose working
+ * directory is the project root, and read back the serialized result.
+ *
+ * Isolation is the point (the dev server already runs this way): an
+ * in-process build both suffers from and causes transient `process.cwd()`
+ * changes — cross-spawn `process.chdir`s the hosting process while
+ * resolving a spawn's binary, and vite/plugins resolve relative paths
+ * against live cwd — which corrupts concurrent deploys sharing the
+ * process. See `ViteBuildChildRunner.ts` for the child side.
+ */
+export const runViteBuildChild = (
+  config: Omit<ViteBuildChildConfig, "outputPath">,
+  onOutput: (channel: "stdout" | "stderr", line: string) => void,
+) =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const runner = resolveRunner("ViteBuildChildRunner");
+      const isBun = typeof globalThis.Bun !== "undefined";
+      const outputDir = yield* fs.makeTempDirectoryScoped({
+        prefix: "alchemy-vite-build-",
+      });
+      const outputPath = path.join(outputDir, "result.v8");
+      // Redacted values can't cross the process boundary — the config is
+      // plain data once unwrapped.
+      const serializedConfig = NodeV8.serialize(
+        unwrapRedacted({ ...config, outputPath }),
+      );
+      const child = yield* spawner.spawn(
+        ChildProcess.make(
+          process.execPath,
+          isBun
+            ? ["run", runner]
+            : [
+                ...(runner.endsWith(".ts") ? transformTypesFlags() : []),
+                runner,
+              ],
+          {
+            cwd: config.rootDir,
+            stdin: Stream.succeed(serializedConfig),
+            stdout: "pipe",
+            stderr: "pipe",
+            extendEnv: true,
+            killSignal: "SIGKILL",
+          },
+        ),
+      );
+      yield* registerExitKill(child.pid);
+
+      const tail: string[] = [];
+      const forward = (channel: "stdout" | "stderr") => (line: string) =>
+        Effect.sync(() => {
+          tail.push(line);
+          if (tail.length > BUILD_ERROR_TAIL) tail.shift();
+          onOutput(channel, line);
+        });
+      const stdoutFiber = yield* Effect.forkChild(
+        child.stdout.pipe(
+          Stream.decodeText,
+          Stream.splitLines,
+          Stream.runForEach(forward("stdout")),
+        ),
+      );
+      const stderrFiber = yield* Effect.forkChild(
+        child.stderr.pipe(
+          Stream.decodeText,
+          Stream.splitLines,
+          Stream.runForEach(forward("stderr")),
+        ),
+      );
+
+      const exitCode = yield* child.exitCode.pipe(Effect.orDie);
+      // Drain both pipes before reporting so the error tail is complete.
+      yield* Fiber.join(stdoutFiber).pipe(Effect.ignore);
+      yield* Fiber.join(stderrFiber).pipe(Effect.ignore);
+      if (exitCode !== 0) {
+        return yield* Effect.fail(
+          new BundleError({
+            message: `Vite build child exited with code ${exitCode}:\n${tail.join("\n")}`,
+          }),
+        );
+      }
+      const bytes = yield* fs.readFile(outputPath).pipe(Effect.orDie);
+      return NodeV8.deserialize(Buffer.from(bytes)) as ViteBuildChildResult;
+    }),
+  );

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -25,6 +25,7 @@ import * as Provider from "../../Provider.ts";
 import { type ResourceBinding } from "../../Resource.ts";
 import { Stack } from "../../Stack.ts";
 import { cachedFunction } from "../../Util/cached-function.ts";
+import { initialCwd } from "../../Util/Node.ts";
 import { sha256Object } from "../../Util/sha256.ts";
 import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
 import { localRuntimeServices } from "../LocalRuntime.ts";
@@ -2170,7 +2171,8 @@ export const LiveWorkerProvider = () =>
               // package) — absolutize before handing it over (#796).
               main: props.vite?.main
                 ? path.resolve(
-                    props.vite.rootDir ?? process.cwd(),
+                    initialCwd,
+                    props.vite.rootDir ?? ".",
                     props.vite.main,
                   )
                 : undefined,
@@ -2186,8 +2188,11 @@ export const LiveWorkerProvider = () =>
                   ...(props.assets && typeof props.assets !== "string"
                     ? props.assets
                     : undefined),
+                  // `clientDirectory` from the build child is absolute;
+                  // the base only matters as a legacy fallback.
                   directory: path.resolve(
-                    props.vite?.rootDir ?? process.cwd(),
+                    initialCwd,
+                    props.vite?.rootDir ?? ".",
                     clientDirectory,
                   ),
                   // The resolved Vite `base` is what rewrote the URLs in

--- a/packages/alchemy/src/Command/Build.ts
+++ b/packages/alchemy/src/Command/Build.ts
@@ -6,6 +6,7 @@ import * as Redacted from "effect/Redacted";
 import { havePropsChanged, isResolved } from "../Diff.ts";
 import * as Provider from "../Provider.ts";
 import { Resource } from "../Resource.ts";
+import { initialCwd } from "../Util/Node.ts";
 import { sha256Object } from "../Util/sha256.ts";
 import {
   CommandExecutor,
@@ -39,13 +40,15 @@ export interface Build extends Resource<
   BuildProps,
   {
     /**
-     * Path to the build output, relative to `process.cwd()`.
+     * Path to the build output, relative to the process's initial working
+     * directory (`initialCwd` — captured at startup, immune to transient
+     * chdir by tools sharing the process).
      *
      * Stored relative (rather than absolute) so the value is portable across
      * machines — state written by a CI runner
      * (`/home/runner/work/.../dist`) resolves correctly on a local laptop and
-     * vice versa. Consumers should `path.resolve()` it against their own cwd
-     * to obtain an absolute path.
+     * vice versa. Consumers should resolve it against `initialCwd` to obtain
+     * an absolute path.
      */
     outdir: string;
     hash: {
@@ -80,7 +83,7 @@ export interface Build extends Resource<
  *   cwd: "./frontend",
  *   outdir: "dist",
  * });
- * yield* Console.log(build.outdir); // path to the dist directory, relative to process.cwd()
+ * yield* Console.log(build.outdir); // path to the dist directory, relative to the initial cwd
  * yield* Console.log(build.hash.output); // hash of the output files (when memo is enabled)
  * ```
  *
@@ -135,7 +138,11 @@ export const BuildProvider = () =>
       const { run } = yield* CommandExecutor;
 
       const makeOutput = Effect.fn(function* (props: BuildProps) {
-        const cwd = path.resolve(props.cwd ?? process.cwd());
+        // Anchored to the initial cwd: a live `process.cwd()` read can race
+        // a concurrent tool's transient chdir (framework source builds),
+        // and the relative `outdir` stored here is resolved again later
+        // (assets read) — mismatched bases corrupt the path.
+        const cwd = path.resolve(initialCwd, props.cwd ?? ".");
         const outdir = path.resolve(cwd, props.outdir);
         if (!(yield* fs.exists(outdir))) {
           return yield* makeCommandError(
@@ -146,7 +153,7 @@ export const BuildProvider = () =>
           );
         }
         return {
-          outdir: path.relative(process.cwd(), outdir),
+          outdir: path.relative(initialCwd, outdir),
           hash:
             props.memo === false
               ? { input: undefined, output: undefined }
@@ -209,7 +216,8 @@ export const BuildProvider = () =>
         reconcile: ({ news, session }) =>
           run(news, session).pipe(Effect.andThen(makeOutput(news))),
         delete: Effect.fn(function* ({ output }) {
-          const outdir = path.resolve(output.outdir);
+          // `output.outdir` is persisted relative to the initial cwd.
+          const outdir = path.resolve(initialCwd, output.outdir);
           if (!(yield* fs.exists(outdir))) return;
           yield* fs.remove(outdir, { recursive: true });
         }),

--- a/packages/alchemy/src/Command/Command.ts
+++ b/packages/alchemy/src/Command/Command.ts
@@ -17,6 +17,7 @@ import { BadArgument, SystemError } from "effect/PlatformError";
 import * as Predicate from "effect/Predicate";
 import * as Redacted from "effect/Redacted";
 import type * as Scope from "effect/Scope";
+import { initialCwd } from "../Util/Node.ts";
 import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
 import * as ChildProcess from "effect/unstable/process/ChildProcess";
@@ -310,7 +311,9 @@ export const CommandExecutorLive = () =>
           Effect.flatMap(({ bin, args }) =>
             spawner.spawn(
               ChildProcess.make(bin, args, {
-                cwd: path.resolve(props.cwd ?? process.cwd()),
+                // Anchored: a live `process.cwd()` read can race a
+                // concurrent tool's transient chdir (see Util/Node.ts).
+                cwd: path.resolve(initialCwd, props.cwd ?? "."),
                 shell: props.shell ?? false,
                 env: Object.fromEntries(
                   Object.entries(props.env ?? {}).map(([k, v]) => [

--- a/packages/alchemy/src/Command/Memo.ts
+++ b/packages/alchemy/src/Command/Memo.ts
@@ -4,6 +4,7 @@ import * as Path from "effect/Path";
 import type { PlatformError } from "effect/PlatformError";
 import fg from "fast-glob";
 import { gitignoreRulesToGlobs } from "../Util/gitignore-rules-to-globs.ts";
+import { initialCwd } from "../Util/Node.ts";
 import { sha256, sha256Object } from "../Util/sha256.ts";
 
 /**
@@ -103,7 +104,9 @@ const Memo = Effect.gen(function* () {
     cwd: string | undefined,
     options: MemoOptions,
   ): Effect.fn.Return<ResolvedMemoOptions, PlatformError> {
-    const resolvedCwd = cwd ? path.resolve(cwd) : process.cwd();
+    // Anchored: a live `process.cwd()` read can race a concurrent tool's
+    // transient chdir (see Util/Node.ts `initialCwd`).
+    const resolvedCwd = path.resolve(initialCwd, cwd ?? ".");
     return {
       cwd: resolvedCwd,
       // Rewrite absolute include patterns to cwd-relative ones: fast-glob

--- a/packages/alchemy/src/Util/Node.ts
+++ b/packages/alchemy/src/Util/Node.ts
@@ -1,6 +1,51 @@
 import * as Effect from "effect/Effect";
 import * as NodeNet from "node:net";
 
+/**
+ * The process's working directory, captured ONCE at module load.
+ *
+ * Relative user paths (Vite roots, asset directories) must resolve against
+ * this instead of a live `process.cwd()` read: third-party code sharing the
+ * process can change the working directory transiently — most notably
+ * cross-spawn, which `process.chdir`s into a spawn's `cwd` to resolve its
+ * binary on PATH and then chdirs back. A live read racing that window
+ * resolves against an unrelated directory. (`State/LocalState.ts` anchors
+ * the state tree the same way, for the same reason.)
+ */
+export const initialCwd: string = process.cwd();
+
+/**
+ * Opt out of cross-spawn's temporary `process.chdir` dance.
+ *
+ * cross-spawn (bundled inside vite, wrangler, next, tinyexec, playwright,
+ * tsx, prisma, …) resolves a spawn's binary by `process.chdir`ing the
+ * WHOLE parent process into the spawn's `cwd`, calling `which.sync`, and
+ * chdiring back. In an alchemy process — which runs many resource builds
+ * and hashers concurrently on one event loop — every fiber that touches a
+ * relative path can race that window and resolve against an unrelated
+ * directory.
+ *
+ * `process.chdir.disabled = true` is NODE'S OWN convention: Node sets it
+ * on `process.chdir` inside worker threads (where chdir is forbidden),
+ * and cross-spawn checks it to skip the dance. Setting it on the main
+ * thread opts us into the exact mode every cross-spawn copy already runs
+ * in inside jest/vitest/playwright workers daily — not an untested path.
+ * The flag is purely advisory: `process.chdir` itself keeps working, and
+ * an audit of the dependency tree shows the only readers are bundled
+ * cross-spawn copies; nothing else writes or consults it.
+ *
+ * Behavior delta: a spawn combining a custom `cwd` with a command that is
+ * neither absolute nor on PATH (e.g. `./scripts/build.sh`). POSIX still
+ * works (cross-spawn falls back to the raw command; the OS resolves it in
+ * the child's cwd). On Windows that shape can fail to resolve — the same
+ * limitation those tools already have inside worker threads. Everything
+ * alchemy and its toolchains spawn is absolute or on PATH, and `Command`
+ * resources use effect's ChildProcess (plain spawn, no cross-spawn).
+ */
+export const disableCrossSpawnChdir = (): void => {
+  (process.chdir as { disabled?: boolean }).disabled = true;
+};
+
 export const isTransformTypesSupported = (
   version = process.versions.node,
 ): boolean => {

--- a/packages/alchemy/src/Util/PlatformServices.ts
+++ b/packages/alchemy/src/Util/PlatformServices.ts
@@ -1,6 +1,7 @@
 import * as Effect from "effect/Effect";
 import type { FileSystem } from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import { disableCrossSpawnChdir } from "./Node.ts";
 import type { Path } from "effect/Path";
 import { defaultTeardown, type Teardown } from "effect/Runtime";
 import type { Stdio } from "effect/Stdio";
@@ -82,6 +83,10 @@ export const runMain = <E, A>(
     readonly teardown?: Teardown | undefined;
   },
 ): void => {
+  // Every alchemy process (CLI, exec child, sidecar, build/dev runners)
+  // runs concurrent effects that depend on a stable working directory —
+  // forbid cross-spawn's transient process-wide chdir (see Util/Node.ts).
+  disableCrossSpawnChdir();
   const opts = {
     ...options,
     teardown: options?.teardown ?? exitingTeardown,

--- a/packages/alchemy/test/Cloudflare/Website/Astro.local.test.ts
+++ b/packages/alchemy/test/Cloudflare/Website/Astro.local.test.ts
@@ -4,7 +4,7 @@ import { isLocalId } from "@/Cloudflare/LocalRuntime";
 import * as Alchemy from "@/index.ts";
 import * as Test from "@/Test/Alchemy";
 import * as kv from "@distilled.cloud/cloudflare/kv";
-import { expect } from "alchemy-test";
+import { describe, expect } from "alchemy-test";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
@@ -110,295 +110,302 @@ const expectStatusBody = (url: string, status: number, marker: string) =>
     devRetry,
   );
 
-test.provider(
-  "Astro dev: local dev server renders SSR with bindings and local sessions",
-  (stack) =>
-    Effect.gen(function* () {
-      yield* stack.destroy();
+// Tests are independent (per-test scratch stacks, private fixture clones),
+// so run them concurrently; suites are sequential by default.
+describe.concurrent("Astro dev", () => {
+  test.provider(
+    "Astro dev: local dev server renders SSR with bindings and local sessions",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
 
-      const rootDir = yield* cloneFixture(fixtureDir, {
-        prefix: "alchemy-astro-dev-",
-        tempRoot,
-        entries: ["astro.config.mjs", "package.json", "public", "src"],
-      });
+        const rootDir = yield* cloneFixture(fixtureDir, {
+          prefix: "alchemy-astro-dev-",
+          tempRoot,
+          entries: ["astro.config.mjs", "package.json", "public", "src"],
+        });
 
-      const marker = "astro-dev-marker";
+        const marker = "astro-dev-marker";
 
-      const { site, sessions } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const site = yield* Cloudflare.Website.Astro("AstroLocal", {
-            rootDir,
-            dev: { port: 0 },
-            memo: {
-              include: [
-                "src/**",
-                "public/**",
-                "astro.config.mjs",
-                "package.json",
-              ],
-            },
-            env: { TEST_MARKER: marker },
-          });
-          // Dedupes by logical id — a handle on the session namespace the
-          // Astro resource auto-provisioned, for the dev-identity assertion.
-          const sessions = yield* Cloudflare.KV.Namespace("AstroLocalSession");
-          return { site, sessions };
-        }),
-      );
-
-      // Local identity: the url points at the alchemy dev proxy — no
-      // cloud Worker exists.
-      expect(site.url).toBeDefined();
-      expect(site.url).toMatch(/^http:\/\/localhost:\d+/);
-
-      // The auto-provisioned session namespace is emulated locally — a
-      // `dev:` id is proof no cloud call ran.
-      expect(isLocalId(sessions.namespaceId)).toBe(true);
-
-      // SSR page rendered by astro's dev server (ssr environment runs
-      // in workerd behind the proxy) — reads the TEST_MARKER binding.
-      yield* expectUrlContains(`${site.url!}/`, marker, {
-        timeout: "120 seconds",
-        label: "astro dev SSR home with env binding",
-      });
-
-      // Prerendered route renders on demand in dev.
-      yield* expectUrlContains(`${site.url!}/about/`, "prerendered-page", {
-        timeout: "60 seconds",
-        label: "astro dev prerender route",
-      });
-
-      // Static asset from `public/` through the dev server.
-      yield* expectUrlContains(
-        `${site.url!}/static.txt`,
-        "astro-static-asset",
-        {
-          timeout: "60 seconds",
-          label: "astro dev static asset",
-        },
-      );
-
-      // ── sessions round-trip against the LOCAL simulator ────────────────
-      const first = yield* fetchSession(`${site.url!}/session`).pipe(
-        Effect.filterOrFail(
-          (r) => r.status === 200 && r.body.includes("session-count=1"),
-          (r) =>
-            new DevResponseMismatch({
-              url: `${site.url!}/session`,
-              detail: `${r.status} ${r.body.slice(0, 240)}`,
-            }),
-        ),
-        devRetry,
-      );
-      expect(first.sessionCookie).toBeDefined();
-
-      const second = yield* fetchSession(
-        `${site.url!}/session`,
-        first.sessionCookie,
-      ).pipe(
-        Effect.filterOrFail(
-          (r) => r.body.includes("session-count=2"),
-          (r) =>
-            new DevResponseMismatch({
-              url: `${site.url!}/session`,
-              detail: `expected session-count=2, got ${r.body.slice(0, 240)}`,
-            }),
-        ),
-        devRetry,
-      );
-      expect(second.body).toContain("session-count=2");
-
-      // Out-of-band: NO real cloud namespace was created for the
-      // auto-provisioned session KV. (Physical titles embed the logical id
-      // verbatim: `{stack}-AstroLocalSession-{stage}-{suffix}`.)
-      const { accountId } = yield* yield* CloudflareEnvironment;
-      const cloudNamespace = yield* kv.listNamespaces.items({ accountId }).pipe(
-        Stream.filter((ns) => ns.title.includes("AstroLocalSession")),
-        Stream.runHead,
-        Effect.map(Option.getOrUndefined),
-      );
-      expect(cloudNamespace).toBeUndefined();
-
-      yield* stack.destroy();
-    }).pipe(logLevel),
-  { timeout: 300_000 },
-);
-
-// ─────────────────────────────────────────────────────────────────────
-// Declared-static app in dev: `astro: { output: "static" }` produces no
-// server modules — the dev server must still answer every route from the
-// assets-only dispatch, including the custom 404 page.
-// ─────────────────────────────────────────────────────────────────────
-
-test.provider(
-  "Astro dev: declared-static app serves pages and the 404 page assets-only",
-  (stack) =>
-    Effect.gen(function* () {
-      yield* stack.destroy();
-
-      const rootDir = yield* cloneFixture(staticFixtureDir, {
-        prefix: "alchemy-astro-static-dev-",
-        tempRoot,
-        entries: ["package.json", "public", "src"],
-      });
-
-      const site = yield* stack.deploy(
-        Effect.gen(function* () {
-          return yield* Cloudflare.Website.Astro("AstroStaticLocal", {
-            rootDir,
-            dev: { port: 0 },
-            memo: {
-              include: ["src/**", "public/**", "package.json"],
-            },
-            astro: { output: "static" },
-            assets: { notFoundHandling: "404-page" },
-          });
-        }),
-      );
-
-      expect(site.url).toBeDefined();
-      expect(site.url).toMatch(/^http:\/\/localhost:\d+/);
-
-      yield* expectUrlContains(`${site.url!}/`, "static-home", {
-        timeout: "120 seconds",
-        label: "astro dev static home",
-      });
-      yield* expectUrlContains(`${site.url!}/about/`, "static-about", {
-        timeout: "60 seconds",
-        label: "astro dev static about",
-      });
-      // Unknown routes serve the custom 404 page with a real 404 status.
-      yield* expectStatusBody(
-        `${site.url!}/definitely-not-a-page`,
-        404,
-        "static-404",
-      );
-
-      yield* stack.destroy();
-    }).pipe(logLevel),
-  { timeout: 300_000 },
-);
-
-// ─────────────────────────────────────────────────────────────────────
-// `Alchemy.remote()` opt-out: the SITE_KV namespace runs LIVE even in a
-// dev run — the local dev server's binding proxies to the real cloud
-// namespace, and destroy deletes it from the cloud (stamped-mode delete).
-// ─────────────────────────────────────────────────────────────────────
-
-test.provider(
-  "Astro dev: Alchemy.remote() SITE_KV binds the real namespace from the local server",
-  (stack) =>
-    Effect.gen(function* () {
-      yield* stack.destroy();
-
-      const rootDir = yield* cloneFixture(fixtureDir, {
-        prefix: "alchemy-astro-remote-",
-        tempRoot,
-        entries: ["astro.config.mjs", "package.json", "public", "src"],
-      });
-
-      const marker = "astro-remote-marker";
-
-      const { site, liveKv } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const liveKv = yield* Cloudflare.KV.Namespace(
-            "AstroRemoteSiteKV",
-          ).pipe(Alchemy.remote());
-          const site = yield* Cloudflare.Website.Astro("AstroRemoteLocal", {
-            rootDir,
-            dev: { port: 0 },
-            memo: {
-              include: [
-                "src/**",
-                "public/**",
-                "astro.config.mjs",
-                "package.json",
-              ],
-            },
-            env: { TEST_MARKER: marker, SITE_KV: liveKv },
-          });
-          return { site, liveKv };
-        }),
-      );
-
-      // The site itself is local; the remote() namespace is REAL.
-      expect(site.url).toMatch(/^http:\/\/localhost:\d+/);
-      expect(isLocalId(liveKv.namespaceId)).toBe(false);
-
-      // Wait for the dev server before driving the binding.
-      yield* expectUrlContains(`${site.url!}/`, marker, {
-        timeout: "120 seconds",
-        label: "astro dev home (remote kv stack)",
-      });
-
-      // Write through the remote-proxied binding via the fixture's
-      // /api/kv route, then read it back through the same binding.
-      yield* Effect.tryPromise({
-        try: async (signal) => {
-          const res = await fetch(
-            `${site.url!}/api/kv?key=remote-key&value=${marker}`,
-            { signal, method: "PUT", cache: "no-store" },
-          );
-          return { status: res.status, body: await res.text() };
-        },
-        catch: (e) =>
-          new DevResponseMismatch({
-            url: `${site.url!}/api/kv`,
-            detail: e instanceof Error ? e.message : String(e),
+        const { site, sessions } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const site = yield* Cloudflare.Website.Astro("AstroLocal", {
+              rootDir,
+              dev: { port: 0 },
+              memo: {
+                include: [
+                  "src/**",
+                  "public/**",
+                  "astro.config.mjs",
+                  "package.json",
+                ],
+              },
+              env: { TEST_MARKER: marker },
+            });
+            // Dedupes by logical id — a handle on the session namespace the
+            // Astro resource auto-provisioned, for the dev-identity assertion.
+            const sessions =
+              yield* Cloudflare.KV.Namespace("AstroLocalSession");
+            return { site, sessions };
           }),
-      }).pipe(
-        Effect.filterOrFail(
-          (r) => r.status === 200,
-          (r) =>
+        );
+
+        // Local identity: the url points at the alchemy dev proxy — no
+        // cloud Worker exists.
+        expect(site.url).toBeDefined();
+        expect(site.url).toMatch(/^http:\/\/localhost:\d+/);
+
+        // The auto-provisioned session namespace is emulated locally — a
+        // `dev:` id is proof no cloud call ran.
+        expect(isLocalId(sessions.namespaceId)).toBe(true);
+
+        // SSR page rendered by astro's dev server (ssr environment runs
+        // in workerd behind the proxy) — reads the TEST_MARKER binding.
+        yield* expectUrlContains(`${site.url!}/`, marker, {
+          timeout: "120 seconds",
+          label: "astro dev SSR home with env binding",
+        });
+
+        // Prerendered route renders on demand in dev.
+        yield* expectUrlContains(`${site.url!}/about/`, "prerendered-page", {
+          timeout: "60 seconds",
+          label: "astro dev prerender route",
+        });
+
+        // Static asset from `public/` through the dev server.
+        yield* expectUrlContains(
+          `${site.url!}/static.txt`,
+          "astro-static-asset",
+          {
+            timeout: "60 seconds",
+            label: "astro dev static asset",
+          },
+        );
+
+        // ── sessions round-trip against the LOCAL simulator ────────────────
+        const first = yield* fetchSession(`${site.url!}/session`).pipe(
+          Effect.filterOrFail(
+            (r) => r.status === 200 && r.body.includes("session-count=1"),
+            (r) =>
+              new DevResponseMismatch({
+                url: `${site.url!}/session`,
+                detail: `${r.status} ${r.body.slice(0, 240)}`,
+              }),
+          ),
+          devRetry,
+        );
+        expect(first.sessionCookie).toBeDefined();
+
+        const second = yield* fetchSession(
+          `${site.url!}/session`,
+          first.sessionCookie,
+        ).pipe(
+          Effect.filterOrFail(
+            (r) => r.body.includes("session-count=2"),
+            (r) =>
+              new DevResponseMismatch({
+                url: `${site.url!}/session`,
+                detail: `expected session-count=2, got ${r.body.slice(0, 240)}`,
+              }),
+          ),
+          devRetry,
+        );
+        expect(second.body).toContain("session-count=2");
+
+        // Out-of-band: NO real cloud namespace was created for the
+        // auto-provisioned session KV. (Physical titles embed the logical id
+        // verbatim: `{stack}-AstroLocalSession-{stage}-{suffix}`.)
+        const { accountId } = yield* yield* CloudflareEnvironment;
+        const cloudNamespace = yield* kv.listNamespaces
+          .items({ accountId })
+          .pipe(
+            Stream.filter((ns) => ns.title.includes("AstroLocalSession")),
+            Stream.runHead,
+            Effect.map(Option.getOrUndefined),
+          );
+        expect(cloudNamespace).toBeUndefined();
+
+        yield* stack.destroy();
+      }).pipe(logLevel),
+    { timeout: 300_000 },
+  );
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Declared-static app in dev: `astro: { output: "static" }` produces no
+  // server modules — the dev server must still answer every route from the
+  // assets-only dispatch, including the custom 404 page.
+  // ─────────────────────────────────────────────────────────────────────
+
+  test.provider(
+    "Astro dev: declared-static app serves pages and the 404 page assets-only",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const rootDir = yield* cloneFixture(staticFixtureDir, {
+          prefix: "alchemy-astro-static-dev-",
+          tempRoot,
+          entries: ["package.json", "public", "src"],
+        });
+
+        const site = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.Website.Astro("AstroStaticLocal", {
+              rootDir,
+              dev: { port: 0 },
+              memo: {
+                include: ["src/**", "public/**", "package.json"],
+              },
+              astro: { output: "static" },
+              assets: { notFoundHandling: "404-page" },
+            });
+          }),
+        );
+
+        expect(site.url).toBeDefined();
+        expect(site.url).toMatch(/^http:\/\/localhost:\d+/);
+
+        yield* expectUrlContains(`${site.url!}/`, "static-home", {
+          timeout: "120 seconds",
+          label: "astro dev static home",
+        });
+        yield* expectUrlContains(`${site.url!}/about/`, "static-about", {
+          timeout: "60 seconds",
+          label: "astro dev static about",
+        });
+        // Unknown routes serve the custom 404 page with a real 404 status.
+        yield* expectStatusBody(
+          `${site.url!}/definitely-not-a-page`,
+          404,
+          "static-404",
+        );
+
+        yield* stack.destroy();
+      }).pipe(logLevel),
+    { timeout: 300_000 },
+  );
+
+  // ─────────────────────────────────────────────────────────────────────
+  // `Alchemy.remote()` opt-out: the SITE_KV namespace runs LIVE even in a
+  // dev run — the local dev server's binding proxies to the real cloud
+  // namespace, and destroy deletes it from the cloud (stamped-mode delete).
+  // ─────────────────────────────────────────────────────────────────────
+
+  test.provider(
+    "Astro dev: Alchemy.remote() SITE_KV binds the real namespace from the local server",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const rootDir = yield* cloneFixture(fixtureDir, {
+          prefix: "alchemy-astro-remote-",
+          tempRoot,
+          entries: ["astro.config.mjs", "package.json", "public", "src"],
+        });
+
+        const marker = "astro-remote-marker";
+
+        const { site, liveKv } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const liveKv = yield* Cloudflare.KV.Namespace(
+              "AstroRemoteSiteKV",
+            ).pipe(Alchemy.remote());
+            const site = yield* Cloudflare.Website.Astro("AstroRemoteLocal", {
+              rootDir,
+              dev: { port: 0 },
+              memo: {
+                include: [
+                  "src/**",
+                  "public/**",
+                  "astro.config.mjs",
+                  "package.json",
+                ],
+              },
+              env: { TEST_MARKER: marker, SITE_KV: liveKv },
+            });
+            return { site, liveKv };
+          }),
+        );
+
+        // The site itself is local; the remote() namespace is REAL.
+        expect(site.url).toMatch(/^http:\/\/localhost:\d+/);
+        expect(isLocalId(liveKv.namespaceId)).toBe(false);
+
+        // Wait for the dev server before driving the binding.
+        yield* expectUrlContains(`${site.url!}/`, marker, {
+          timeout: "120 seconds",
+          label: "astro dev home (remote kv stack)",
+        });
+
+        // Write through the remote-proxied binding via the fixture's
+        // /api/kv route, then read it back through the same binding.
+        yield* Effect.tryPromise({
+          try: async (signal) => {
+            const res = await fetch(
+              `${site.url!}/api/kv?key=remote-key&value=${marker}`,
+              { signal, method: "PUT", cache: "no-store" },
+            );
+            return { status: res.status, body: await res.text() };
+          },
+          catch: (e) =>
             new DevResponseMismatch({
               url: `${site.url!}/api/kv`,
-              detail: `PUT ${r.status} ${r.body.slice(0, 240)}`,
+              detail: e instanceof Error ? e.message : String(e),
             }),
-        ),
-        devRetry,
-      );
-
-      yield* expectStatusBody(
-        `${site.url!}/api/kv?key=remote-key`,
-        200,
-        `"value":"${marker}"`,
-      );
-
-      // Out-of-band: the write landed in the REAL cloud namespace.
-      const { accountId } = yield* yield* CloudflareEnvironment;
-      const observed = yield* kv
-        .getNamespaceValue({
-          accountId,
-          namespaceId: liveKv.namespaceId,
-          keyName: "remote-key",
-        })
-        .pipe(
-          Effect.flatMap((res) =>
-            Effect.tryPromise(() =>
-              new Response(
-                Stream.toReadableStream(res.body) as BodyInit,
-              ).text(),
-            ),
+        }).pipe(
+          Effect.filterOrFail(
+            (r) => r.status === 200,
+            (r) =>
+              new DevResponseMismatch({
+                url: `${site.url!}/api/kv`,
+                detail: `PUT ${r.status} ${r.body.slice(0, 240)}`,
+              }),
           ),
-          Effect.retry({
-            schedule: Schedule.exponential("1 second", 1.5),
-            times: 8,
-          }),
+          devRetry,
         );
-      expect(observed).toBe(marker);
 
-      yield* stack.destroy();
-
-      // The live namespace was deleted from the cloud on destroy (its
-      // state row is stamped live, so the live provider handles the
-      // delete even in a dev run).
-      const gone = yield* kv
-        .getNamespace({ accountId, namespaceId: liveKv.namespaceId })
-        .pipe(
-          Effect.as(false),
-          Effect.catchTag("NamespaceNotFound", () => Effect.succeed(true)),
+        yield* expectStatusBody(
+          `${site.url!}/api/kv?key=remote-key`,
+          200,
+          `"value":"${marker}"`,
         );
-      expect(gone).toBe(true);
-    }).pipe(logLevel),
-  { timeout: 300_000 },
-);
+
+        // Out-of-band: the write landed in the REAL cloud namespace.
+        const { accountId } = yield* yield* CloudflareEnvironment;
+        const observed = yield* kv
+          .getNamespaceValue({
+            accountId,
+            namespaceId: liveKv.namespaceId,
+            keyName: "remote-key",
+          })
+          .pipe(
+            Effect.flatMap((res) =>
+              Effect.tryPromise(() =>
+                new Response(
+                  Stream.toReadableStream(res.body) as BodyInit,
+                ).text(),
+              ),
+            ),
+            Effect.retry({
+              schedule: Schedule.exponential("1 second", 1.5),
+              times: 8,
+            }),
+          );
+        expect(observed).toBe(marker);
+
+        yield* stack.destroy();
+
+        // The live namespace was deleted from the cloud on destroy (its
+        // state row is stamped live, so the live provider handles the
+        // delete even in a dev run).
+        const gone = yield* kv
+          .getNamespace({ accountId, namespaceId: liveKv.namespaceId })
+          .pipe(
+            Effect.as(false),
+            Effect.catchTag("NamespaceNotFound", () => Effect.succeed(true)),
+          );
+        expect(gone).toBe(true);
+      }).pipe(logLevel),
+    { timeout: 300_000 },
+  );
+});

--- a/packages/alchemy/test/Cloudflare/Website/Astro.test.ts
+++ b/packages/alchemy/test/Cloudflare/Website/Astro.test.ts
@@ -2,7 +2,7 @@ import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
 import * as Cloudflare from "@/Cloudflare/index.ts";
 import * as Test from "@/Test/Alchemy";
 import * as kv from "@distilled.cloud/cloudflare/kv";
-import { expect } from "alchemy-test";
+import { describe, expect } from "alchemy-test";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
@@ -332,430 +332,435 @@ const waitForNamespaceToBeDeleted = Effect.fn(function* (
   );
 });
 
-test.provider(
-  "Astro: SSR + env binding + prerender + static assets deploy; unchanged sources memo-skip the rebuild",
-  (stack) =>
-    Effect.gen(function* () {
-      const { accountId } = yield* yield* CloudflareEnvironment;
-      const fs = yield* FileSystem.FileSystem;
-      const path = yield* Path.Path;
+// Tests are independent (per-test scratch stacks, private fixture clones),
+// so run them concurrently; suites are sequential by default.
+describe.concurrent("Astro", () => {
+  test.provider(
+    "Astro: SSR + env binding + prerender + static assets deploy; unchanged sources memo-skip the rebuild",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
 
-      yield* stack.destroy();
+        yield* stack.destroy();
 
-      const rootDir = yield* cloneFixture(fixtureDir, {
-        prefix: "alchemy-astro-",
-        tempRoot,
-        entries: ["astro.config.mjs", "package.json", "public", "src"],
-      });
+        const rootDir = yield* cloneFixture(fixtureDir, {
+          prefix: "alchemy-astro-",
+          tempRoot,
+          entries: ["astro.config.mjs", "package.json", "public", "src"],
+        });
 
-      // Restrict the input memo to fixture sources so the test isn't
-      // re-hashing the whole monorepo on every deploy. `workspaces: []`
-      // pins the hash to the fixture alone: auto-detection would fold in
-      // workspace-linked integration packages, whose trees can change
-      // between deploys (concurrent development in this repo), breaking
-      // the unchanged-rebuild memo assertion below. Workspace-aware
-      // memoization has its own dedicated test in Vite.test.ts.
-      const memo = {
-        include: ["src/**", "public/**", "package.json", "astro.config.mjs"],
-        workspaces: [],
-      };
+        // Restrict the input memo to fixture sources so the test isn't
+        // re-hashing the whole monorepo on every deploy. `workspaces: []`
+        // pins the hash to the fixture alone: auto-detection would fold in
+        // workspace-linked integration packages, whose trees can change
+        // between deploys (concurrent development in this repo), breaking
+        // the unchanged-rebuild memo assertion below. Workspace-aware
+        // memoization has its own dedicated test in Vite.test.ts.
+        const memo = {
+          include: ["src/**", "public/**", "package.json", "astro.config.mjs"],
+          workspaces: [],
+        };
 
-      // A random value is fine here — it is binding data, not a resource
-      // name — and it stays constant across this test's deploys so the
-      // metadata hash cannot mask a broken input-hash memo.
-      const marker = `astro-marker-${Date.now()}`;
+        // A random value is fine here — it is binding data, not a resource
+        // name — and it stays constant across this test's deploys so the
+        // metadata hash cannot mask a broken input-hash memo.
+        const marker = `astro-marker-${Date.now()}`;
 
-      const deploy = () =>
-        stack.deploy(
-          Effect.gen(function* () {
-            // A REAL user-declared KV namespace bound through `env` —
-            // distinct from the auto-provisioned session namespace. The
-            // fixture's `/api/kv` route reads/writes it via the runtime env.
-            const siteKv = yield* Cloudflare.KV.Namespace("SiteKV");
-            const site = yield* Cloudflare.Website.Astro("AstroSite", {
-              rootDir,
-              workersDev: { enabled: true, previewsEnabled: true },
-              // `nodejs_compat` deliberately omitted — the resource
-              // auto-injects it, and this deploy proves that path.
-              compatibility: { date: "2026-03-10" },
-              memo,
-              env: { TEST_MARKER: marker, SITE_KV: siteKv },
-              assets: {
-                htmlHandling: "auto-trailing-slash",
-                notFoundHandling: "none",
-              },
-            });
-            // Resource creation dedupes by logical id, so this returns the
-            // session namespace the Astro resource auto-provisioned — a
-            // handle for the out-of-band lifecycle assertions below.
-            const sessions = yield* Cloudflare.KV.Namespace("AstroSiteSession");
-            return { site, sessions, siteKv };
-          }),
+        const deploy = () =>
+          stack.deploy(
+            Effect.gen(function* () {
+              // A REAL user-declared KV namespace bound through `env` —
+              // distinct from the auto-provisioned session namespace. The
+              // fixture's `/api/kv` route reads/writes it via the runtime env.
+              const siteKv = yield* Cloudflare.KV.Namespace("SiteKV");
+              const site = yield* Cloudflare.Website.Astro("AstroSite", {
+                rootDir,
+                workersDev: { enabled: true, previewsEnabled: true },
+                // `nodejs_compat` deliberately omitted — the resource
+                // auto-injects it, and this deploy proves that path.
+                compatibility: { date: "2026-03-10" },
+                memo,
+                env: { TEST_MARKER: marker, SITE_KV: siteKv },
+                assets: {
+                  htmlHandling: "auto-trailing-slash",
+                  notFoundHandling: "none",
+                },
+              });
+              // Resource creation dedupes by logical id, so this returns the
+              // session namespace the Astro resource auto-provisioned — a
+              // handle for the out-of-band lifecycle assertions below.
+              const sessions =
+                yield* Cloudflare.KV.Namespace("AstroSiteSession");
+              return { site, sessions, siteKv };
+            }),
+          );
+
+        // ── deploy 1: build + serve ────────────────────────────────────────
+        const { site: site1, sessions, siteKv } = yield* deploy();
+        expect(site1.url).toBeDefined();
+        expect(site1.hash?.input).toBeDefined();
+        yield* expectWorkerExists(site1.workerName, accountId);
+
+        // SSR page rendered in the Worker, reading the env binding.
+        yield* expectUrlContains(`${site1.url!}/`, marker, {
+          timeout: "120 seconds",
+          label: "SSR page renders env binding",
+        });
+        // Prerendered page served from static assets. Keep the body — the
+        // hashed-asset assertion below extracts the `/_astro/*.css` href.
+        const aboutBody = yield* expectUrlContains(
+          `${site1.url!}/about/`,
+          "prerendered-page",
+          {
+            timeout: "60 seconds",
+            label: "prerendered page",
+          },
+        );
+        // Plain static asset from public/.
+        yield* expectUrlContains(
+          `${site1.url!}/static.txt`,
+          "astro-static-asset",
+          {
+            timeout: "60 seconds",
+            label: "static asset",
+          },
         );
 
-      // ── deploy 1: build + serve ────────────────────────────────────────
-      const { site: site1, sessions, siteKv } = yield* deploy();
-      expect(site1.url).toBeDefined();
-      expect(site1.hash?.input).toBeDefined();
-      yield* expectWorkerExists(site1.workerName, accountId);
-
-      // SSR page rendered in the Worker, reading the env binding.
-      yield* expectUrlContains(`${site1.url!}/`, marker, {
-        timeout: "120 seconds",
-        label: "SSR page renders env binding",
-      });
-      // Prerendered page served from static assets. Keep the body — the
-      // hashed-asset assertion below extracts the `/_astro/*.css` href.
-      const aboutBody = yield* expectUrlContains(
-        `${site1.url!}/about/`,
-        "prerendered-page",
-        {
-          timeout: "60 seconds",
-          label: "prerendered page",
-        },
-      );
-      // Plain static asset from public/.
-      yield* expectUrlContains(
-        `${site1.url!}/static.txt`,
-        "astro-static-asset",
-        {
-          timeout: "60 seconds",
-          label: "static asset",
-        },
-      );
-
-      // ── sessions: the SESSION KV namespace is auto-provisioned and
-      // `Astro.session` round-trips through it ───────────────────────────
-      expect(sessions.namespaceId).toBeDefined();
-      const actualSessions = yield* kv.getNamespace({
-        accountId,
-        namespaceId: sessions.namespaceId,
-      });
-      expect(actualSessions.id).toEqual(sessions.namespaceId);
-
-      // Wait for the route to serve before the cookie round-trip.
-      yield* expectUrlContains(`${site1.url!}/session`, "session-count=", {
-        timeout: "60 seconds",
-        label: "session page",
-      });
-
-      // A single edge request can still 404 right after the readiness
-      // probe above succeeded (workers.dev colo inconsistency) — retry
-      // through it, bounded, before asserting on the body.
-      const first = yield* fetchSession(`${site1.url!}/session`).pipe(
-        Effect.filterOrFail(
-          (res) => res.status === 200,
-          (res) =>
-            new SessionFetchFailed({
-              url: `${site1.url!}/session`,
-              message: `expected 200, got ${res.status}: ${res.body.slice(0, 240)}`,
-            }),
-        ),
-        Effect.retry({
-          schedule: Schedule.exponential("1 second", 1.5),
-          times: 8,
-        }),
-      );
-      expect(first.status).toBe(200);
-      expect(first.body).toContain("session-count=1");
-      expect(first.sessionCookie).toBeDefined();
-
-      // Replaying the session cookie must observe the previous request's
-      // KV write. Retry through KV's (brief, same-colo) read lag.
-      const second = yield* fetchSession(
-        `${site1.url!}/session`,
-        first.sessionCookie,
-      ).pipe(
-        Effect.filterOrFail(
-          (res) => res.body.includes("session-count=2"),
-          (res) =>
-            new SessionFetchFailed({
-              url: `${site1.url!}/session`,
-              message: `expected session-count=2, got: ${res.body.slice(0, 240)}`,
-            }),
-        ),
-        Effect.retry({
-          schedule: Schedule.exponential("1 second", 1.5),
-          times: 8,
-        }),
-      );
-      expect(second.body).toContain("session-count=2");
-
-      // ── middleware: locals + response-header mutation ──────────────────
-      yield* expectMiddlewareLocals(`${site1.url!}/locals`);
-
-      // ── config redirects flow through `_redirects` to the asset layer ──
-      yield* expectUrlRedirect(`${site1.url!}/old-about`, "/about/", {
-        status: 301,
-        timeout: "60 seconds",
-        label: "config redirect via _redirects",
-      });
-
-      // ── binary endpoint returns the exact bytes ────────────────────────
-      yield* expectBinaryEndpoint(`${site1.url!}/api/binary`);
-
-      // ── urlencoded form POST reaches the Worker through the asset
-      // router and re-renders with the echoed message ─────────────────────
-      yield* expectFormPostEcho(`${site1.url!}/feedback`, marker);
-
-      // ── user-declared KV binding: round-trip through the runtime env,
-      // then verify out-of-band that the write landed in the REAL
-      // namespace ────────────────────────────────────────────────────────
-      expect(siteKv.namespaceId).toBeDefined();
-      yield* kvRoundTrip(site1.url!, "astro-live-key", marker);
-      const observed = yield* kv
-        .getNamespaceValue({
+        // ── sessions: the SESSION KV namespace is auto-provisioned and
+        // `Astro.session` round-trips through it ───────────────────────────
+        expect(sessions.namespaceId).toBeDefined();
+        const actualSessions = yield* kv.getNamespace({
           accountId,
-          namespaceId: siteKv.namespaceId,
-          keyName: "astro-live-key",
-        })
-        .pipe(
-          Effect.flatMap((res) =>
-            Effect.tryPromise(() =>
-              new Response(
-                Stream.toReadableStream(res.body) as BodyInit,
-              ).text(),
-            ),
+          namespaceId: sessions.namespaceId,
+        });
+        expect(actualSessions.id).toEqual(sessions.namespaceId);
+
+        // Wait for the route to serve before the cookie round-trip.
+        yield* expectUrlContains(`${site1.url!}/session`, "session-count=", {
+          timeout: "60 seconds",
+          label: "session page",
+        });
+
+        // A single edge request can still 404 right after the readiness
+        // probe above succeeded (workers.dev colo inconsistency) — retry
+        // through it, bounded, before asserting on the body.
+        const first = yield* fetchSession(`${site1.url!}/session`).pipe(
+          Effect.filterOrFail(
+            (res) => res.status === 200,
+            (res) =>
+              new SessionFetchFailed({
+                url: `${site1.url!}/session`,
+                message: `expected 200, got ${res.status}: ${res.body.slice(0, 240)}`,
+              }),
           ),
           Effect.retry({
             schedule: Schedule.exponential("1 second", 1.5),
             times: 8,
           }),
         );
-      expect(observed).toBe(marker);
+        expect(first.status).toBe(200);
+        expect(first.body).toContain("session-count=1");
+        expect(first.sessionCookie).toBeDefined();
 
-      // ── hashed `/_astro/*` asset serves with the immutable Cache-Control
-      // from the adapter-emitted `_headers` — pins the WorkerProvider
-      // folding a source build's `_headers`/`_redirects` into the PUT
-      // asset config (source providers hash the files but don't pre-merge
-      // them into `config`; only alchemy's own `readAssets` does). Without
-      // that merge the asset serves Cloudflare's default
-      // `public, max-age=0, must-revalidate`. ───────────────────────────
-      const assetHref = aboutBody.match(/\/_astro\/[^"']+\.css/)?.[0];
-      expect(assetHref).toBeDefined();
-      const assetUrl = `${site1.url!}${assetHref!}`;
-      yield* expectImmutableAsset(assetUrl);
-
-      // ── deploy 2: nothing changed ⇒ memo hit (no rebuild) ──────────────
-      const { site: site2 } = yield* deploy();
-      expect(site2.hash?.input).toEqual(site1.hash?.input);
-      expect(site2.hash?.bundle).toEqual(site1.hash?.bundle);
-      expect(site2.hash?.assets).toEqual(site1.hash?.assets);
-
-      // The no-op redeploy takes the provider's hash-matched KEEP path,
-      // which rebuilds the asset config wholesale (no upload jwt). A
-      // regression there would silently wipe the `_headers`/`_redirects`
-      // rules on every no-op deploy — re-assert both still serve.
-      yield* expectImmutableAsset(assetUrl);
-      yield* expectUrlRedirect(`${site1.url!}/old-about`, "/about/", {
-        status: 301,
-        timeout: "60 seconds",
-        label: "redirect after no-op keep-assets deploy",
-      });
-
-      // ── deploy 3: edit a page ⇒ memo busts, new content serves ─────────
-      const indexPath = path.join(rootDir, "src/pages/index.astro");
-      const source = yield* fs.readFileString(indexPath);
-      yield* fs.writeFileString(
-        indexPath,
-        source.replace("Astro Fixture", "Astro Fixture Edited"),
-      );
-
-      const { site: site3 } = yield* deploy();
-      expect(site3.hash?.input).toBeDefined();
-      expect(site3.hash?.input).not.toEqual(site1.hash?.input);
-      yield* expectUrlContains(`${site3.url!}/`, "Astro Fixture Edited", {
-        timeout: "60 seconds",
-        label: "edited SSR page",
-      });
-
-      yield* stack.destroy();
-      yield* waitForWorkerToBeDeleted(site1.workerName, accountId);
-
-      // Destroy must also clean up the auto-provisioned session namespace
-      // and the user-declared SITE_KV namespace.
-      yield* waitForNamespaceToBeDeleted(sessions.namespaceId, accountId);
-      yield* waitForNamespaceToBeDeleted(siteKv.namespaceId, accountId);
-    }).pipe(logLevel),
-  { timeout: 420_000 },
-);
-
-class NotFoundPageMismatch extends Data.TaggedError("NotFoundPageMismatch")<{
-  url: string;
-  actual: string;
-}> {}
-
-/**
- * Assert `url` answers a REAL `404` whose body contains `marker` — the
- * built `404.html` served by the asset layer (`notFoundHandling:
- * "404-page"`), not a worker-rendered page and not Cloudflare's
- * placeholder. Retries through edge propagation like `expectUrlContains`
- * (which can't be used here: it requires `res.ok`).
- */
-const expectNotFoundPage = (url: string, marker: string) =>
-  Effect.tryPromise({
-    try: async (signal) => {
-      const u = new URL(url);
-      u.searchParams.set("__alchemy_cb", String(Date.now()));
-      const res = await fetch(u, {
-        signal,
-        cache: "no-store",
-        headers: { "cache-control": "no-cache", accept: "*/*" },
-      });
-      const body = await res.text();
-      return { status: res.status, body };
-    },
-    catch: (e) =>
-      new NotFoundPageMismatch({
-        url,
-        actual: e instanceof Error ? e.message : String(e),
-      }),
-  }).pipe(
-    Effect.filterOrFail(
-      (res) => res.status === 404 && res.body.includes(marker),
-      (res) =>
-        new NotFoundPageMismatch({
-          url,
-          actual: `${res.status} ${res.body.slice(0, 240)}`,
-        }),
-    ),
-    Effect.retry({
-      schedule: Schedule.max([
-        Schedule.min([
-          Schedule.exponential("750 millis", 1.5),
-          Schedule.spaced("8 seconds"),
-        ]),
-        Schedule.recurs(15),
-      ]),
-    }),
-  );
-
-// ─────────────────────────────────────────────────────────────────────
-// Assets-only deploys (seam: SourceBuildOutput.bundle === undefined)
-//
-// A declared `astro: { output: "static" }` project prerenders every page,
-// so the astro source's build produces NO server modules — the source
-// path must flow `bundle: undefined` into the WorkerProvider's
-// assets-only mode: the script PUT carries no modules and no main_module,
-// and Cloudflare's asset layer answers every request (including the built
-// 404.html via `notFoundHandling: "404-page"`). Session auto-provisioning
-// is skipped — no Worker code could ever read the namespace.
-// ─────────────────────────────────────────────────────────────────────
-
-test.provider(
-  "Astro: output 'static' deploys assets-only — no server bundle, 404.html from assets, memoized rebuilds",
-  (stack) =>
-    Effect.gen(function* () {
-      const { accountId } = yield* yield* CloudflareEnvironment;
-      const fs = yield* FileSystem.FileSystem;
-      const path = yield* Path.Path;
-
-      yield* stack.destroy();
-
-      const rootDir = yield* cloneFixture(staticFixtureDir, {
-        prefix: "alchemy-astro-static-",
-        tempRoot,
-        entries: ["package.json", "public", "src"],
-      });
-
-      // Same discipline as the SSR test above: pin the input hash to the
-      // fixture so concurrent development in this repo can't bust the
-      // unchanged-rebuild memo assertion.
-      const memo = {
-        include: ["src/**", "public/**", "package.json"],
-        workspaces: [],
-      };
-
-      const deploy = () =>
-        stack.deploy(
-          Effect.gen(function* () {
-            return yield* Cloudflare.Website.Astro("AstroStaticSite", {
-              rootDir,
-              workersDev: { enabled: true, previewsEnabled: true },
-              compatibility: { date: "2026-03-10" },
-              memo,
-              astro: { output: "static" },
-              assets: { notFoundHandling: "404-page" },
-            });
+        // Replaying the session cookie must observe the previous request's
+        // KV write. Retry through KV's (brief, same-colo) read lag.
+        const second = yield* fetchSession(
+          `${site1.url!}/session`,
+          first.sessionCookie,
+        ).pipe(
+          Effect.filterOrFail(
+            (res) => res.body.includes("session-count=2"),
+            (res) =>
+              new SessionFetchFailed({
+                url: `${site1.url!}/session`,
+                message: `expected session-count=2, got: ${res.body.slice(0, 240)}`,
+              }),
+          ),
+          Effect.retry({
+            schedule: Schedule.exponential("1 second", 1.5),
+            times: 8,
           }),
         );
+        expect(second.body).toContain("session-count=2");
 
-      // ── deploy 1: build + assets-only serve ────────────────────────────
-      const site1 = yield* deploy();
-      expect(site1.url).toBeDefined();
-      expect(site1.hash?.input).toBeDefined();
-      expect(site1.hash?.assets).toBeDefined();
-      // The contract under test: no server bundle was produced or
-      // uploaded — the bundle hash slot stays empty.
-      expect(site1.hash?.bundle).toBeUndefined();
-      yield* expectWorkerExists(site1.workerName, accountId);
+        // ── middleware: locals + response-header mutation ──────────────────
+        yield* expectMiddlewareLocals(`${site1.url!}/locals`);
 
-      // Every page serves from the asset layer.
-      yield* expectUrlContains(`${site1.url!}/`, "static-home", {
-        timeout: "120 seconds",
-        label: "static home page",
-      });
-      yield* expectUrlContains(`${site1.url!}/about/`, "static-about", {
-        timeout: "60 seconds",
-        label: "static about page",
-      });
-      yield* expectUrlContains(
-        `${site1.url!}/static.txt`,
-        "astro-static-public-asset",
-        {
+        // ── config redirects flow through `_redirects` to the asset layer ──
+        yield* expectUrlRedirect(`${site1.url!}/old-about`, "/about/", {
+          status: 301,
           timeout: "60 seconds",
-          label: "public asset",
-        },
-      );
+          label: "config redirect via _redirects",
+        });
 
-      // Unknown routes get the BUILT 404.html with a real 404 status —
-      // Cloudflare's asset layer applies `notFoundHandling` itself; no
-      // Worker script is involved.
-      yield* expectNotFoundPage(
-        `${site1.url!}/definitely-not-a-page`,
-        "static-404",
-      );
+        // ── binary endpoint returns the exact bytes ────────────────────────
+        yield* expectBinaryEndpoint(`${site1.url!}/api/binary`);
 
-      // Session auto-provisioning is skipped for declared-static sites:
-      // no KV namespace titled for this stack's session id may exist.
-      // (Physical titles embed the logical id verbatim:
-      // `{stack}-AstroStaticSiteSession-{stage}-{suffix}`.)
-      const sessionNamespace = yield* kv.listNamespaces
-        .items({ accountId })
-        .pipe(
-          Stream.filter((ns) => ns.title.includes("AstroStaticSiteSession")),
-          Stream.runHead,
-          Effect.map(Option.getOrUndefined),
+        // ── urlencoded form POST reaches the Worker through the asset
+        // router and re-renders with the echoed message ─────────────────────
+        yield* expectFormPostEcho(`${site1.url!}/feedback`, marker);
+
+        // ── user-declared KV binding: round-trip through the runtime env,
+        // then verify out-of-band that the write landed in the REAL
+        // namespace ────────────────────────────────────────────────────────
+        expect(siteKv.namespaceId).toBeDefined();
+        yield* kvRoundTrip(site1.url!, "astro-live-key", marker);
+        const observed = yield* kv
+          .getNamespaceValue({
+            accountId,
+            namespaceId: siteKv.namespaceId,
+            keyName: "astro-live-key",
+          })
+          .pipe(
+            Effect.flatMap((res) =>
+              Effect.tryPromise(() =>
+                new Response(
+                  Stream.toReadableStream(res.body) as BodyInit,
+                ).text(),
+              ),
+            ),
+            Effect.retry({
+              schedule: Schedule.exponential("1 second", 1.5),
+              times: 8,
+            }),
+          );
+        expect(observed).toBe(marker);
+
+        // ── hashed `/_astro/*` asset serves with the immutable Cache-Control
+        // from the adapter-emitted `_headers` — pins the WorkerProvider
+        // folding a source build's `_headers`/`_redirects` into the PUT
+        // asset config (source providers hash the files but don't pre-merge
+        // them into `config`; only alchemy's own `readAssets` does). Without
+        // that merge the asset serves Cloudflare's default
+        // `public, max-age=0, must-revalidate`. ───────────────────────────
+        const assetHref = aboutBody.match(/\/_astro\/[^"']+\.css/)?.[0];
+        expect(assetHref).toBeDefined();
+        const assetUrl = `${site1.url!}${assetHref!}`;
+        yield* expectImmutableAsset(assetUrl);
+
+        // ── deploy 2: nothing changed ⇒ memo hit (no rebuild) ──────────────
+        const { site: site2 } = yield* deploy();
+        expect(site2.hash?.input).toEqual(site1.hash?.input);
+        expect(site2.hash?.bundle).toEqual(site1.hash?.bundle);
+        expect(site2.hash?.assets).toEqual(site1.hash?.assets);
+
+        // The no-op redeploy takes the provider's hash-matched KEEP path,
+        // which rebuilds the asset config wholesale (no upload jwt). A
+        // regression there would silently wipe the `_headers`/`_redirects`
+        // rules on every no-op deploy — re-assert both still serve.
+        yield* expectImmutableAsset(assetUrl);
+        yield* expectUrlRedirect(`${site1.url!}/old-about`, "/about/", {
+          status: 301,
+          timeout: "60 seconds",
+          label: "redirect after no-op keep-assets deploy",
+        });
+
+        // ── deploy 3: edit a page ⇒ memo busts, new content serves ─────────
+        const indexPath = path.join(rootDir, "src/pages/index.astro");
+        const source = yield* fs.readFileString(indexPath);
+        yield* fs.writeFileString(
+          indexPath,
+          source.replace("Astro Fixture", "Astro Fixture Edited"),
         );
-      expect(sessionNamespace).toBeUndefined();
 
-      // ── deploy 2: nothing changed ⇒ memo hit, still assets-only ────────
-      const site2 = yield* deploy();
-      expect(site2.hash?.input).toEqual(site1.hash?.input);
-      expect(site2.hash?.assets).toEqual(site1.hash?.assets);
-      expect(site2.hash?.bundle).toBeUndefined();
-      expect(site2.url).toBe(site1.url);
+        const { site: site3 } = yield* deploy();
+        expect(site3.hash?.input).toBeDefined();
+        expect(site3.hash?.input).not.toEqual(site1.hash?.input);
+        yield* expectUrlContains(`${site3.url!}/`, "Astro Fixture Edited", {
+          timeout: "60 seconds",
+          label: "edited SSR page",
+        });
 
-      // ── deploy 3: edit a page ⇒ memo busts, new content serves,
-      // and the deploy REMAINS assets-only ───────────────────────────────
-      const indexPath = path.join(rootDir, "src/pages/index.astro");
-      const source = yield* fs.readFileString(indexPath);
-      yield* fs.writeFileString(
-        indexPath,
-        source.replace("static-home", "static-home-v2"),
-      );
+        yield* stack.destroy();
+        yield* waitForWorkerToBeDeleted(site1.workerName, accountId);
 
-      const site3 = yield* deploy();
-      expect(site3.hash?.input).toBeDefined();
-      expect(site3.hash?.input).not.toEqual(site1.hash?.input);
-      expect(site3.hash?.bundle).toBeUndefined();
-      yield* expectUrlContains(`${site3.url!}/`, "static-home-v2", {
-        timeout: "60 seconds",
-        label: "edited static home page",
-      });
+        // Destroy must also clean up the auto-provisioned session namespace
+        // and the user-declared SITE_KV namespace.
+        yield* waitForNamespaceToBeDeleted(sessions.namespaceId, accountId);
+        yield* waitForNamespaceToBeDeleted(siteKv.namespaceId, accountId);
+      }).pipe(logLevel),
+    { timeout: 420_000 },
+  );
 
-      yield* stack.destroy();
-      yield* waitForWorkerToBeDeleted(site1.workerName, accountId);
-    }).pipe(logLevel),
-  { timeout: 360_000 },
-);
+  class NotFoundPageMismatch extends Data.TaggedError("NotFoundPageMismatch")<{
+    url: string;
+    actual: string;
+  }> {}
+
+  /**
+   * Assert `url` answers a REAL `404` whose body contains `marker` — the
+   * built `404.html` served by the asset layer (`notFoundHandling:
+   * "404-page"`), not a worker-rendered page and not Cloudflare's
+   * placeholder. Retries through edge propagation like `expectUrlContains`
+   * (which can't be used here: it requires `res.ok`).
+   */
+  const expectNotFoundPage = (url: string, marker: string) =>
+    Effect.tryPromise({
+      try: async (signal) => {
+        const u = new URL(url);
+        u.searchParams.set("__alchemy_cb", String(Date.now()));
+        const res = await fetch(u, {
+          signal,
+          cache: "no-store",
+          headers: { "cache-control": "no-cache", accept: "*/*" },
+        });
+        const body = await res.text();
+        return { status: res.status, body };
+      },
+      catch: (e) =>
+        new NotFoundPageMismatch({
+          url,
+          actual: e instanceof Error ? e.message : String(e),
+        }),
+    }).pipe(
+      Effect.filterOrFail(
+        (res) => res.status === 404 && res.body.includes(marker),
+        (res) =>
+          new NotFoundPageMismatch({
+            url,
+            actual: `${res.status} ${res.body.slice(0, 240)}`,
+          }),
+      ),
+      Effect.retry({
+        schedule: Schedule.max([
+          Schedule.min([
+            Schedule.exponential("750 millis", 1.5),
+            Schedule.spaced("8 seconds"),
+          ]),
+          Schedule.recurs(15),
+        ]),
+      }),
+    );
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Assets-only deploys (seam: SourceBuildOutput.bundle === undefined)
+  //
+  // A declared `astro: { output: "static" }` project prerenders every page,
+  // so the astro source's build produces NO server modules — the source
+  // path must flow `bundle: undefined` into the WorkerProvider's
+  // assets-only mode: the script PUT carries no modules and no main_module,
+  // and Cloudflare's asset layer answers every request (including the built
+  // 404.html via `notFoundHandling: "404-page"`). Session auto-provisioning
+  // is skipped — no Worker code could ever read the namespace.
+  // ─────────────────────────────────────────────────────────────────────
+
+  test.provider(
+    "Astro: output 'static' deploys assets-only — no server bundle, 404.html from assets, memoized rebuilds",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+
+        yield* stack.destroy();
+
+        const rootDir = yield* cloneFixture(staticFixtureDir, {
+          prefix: "alchemy-astro-static-",
+          tempRoot,
+          entries: ["package.json", "public", "src"],
+        });
+
+        // Same discipline as the SSR test above: pin the input hash to the
+        // fixture so concurrent development in this repo can't bust the
+        // unchanged-rebuild memo assertion.
+        const memo = {
+          include: ["src/**", "public/**", "package.json"],
+          workspaces: [],
+        };
+
+        const deploy = () =>
+          stack.deploy(
+            Effect.gen(function* () {
+              return yield* Cloudflare.Website.Astro("AstroStaticSite", {
+                rootDir,
+                workersDev: { enabled: true, previewsEnabled: true },
+                compatibility: { date: "2026-03-10" },
+                memo,
+                astro: { output: "static" },
+                assets: { notFoundHandling: "404-page" },
+              });
+            }),
+          );
+
+        // ── deploy 1: build + assets-only serve ────────────────────────────
+        const site1 = yield* deploy();
+        expect(site1.url).toBeDefined();
+        expect(site1.hash?.input).toBeDefined();
+        expect(site1.hash?.assets).toBeDefined();
+        // The contract under test: no server bundle was produced or
+        // uploaded — the bundle hash slot stays empty.
+        expect(site1.hash?.bundle).toBeUndefined();
+        yield* expectWorkerExists(site1.workerName, accountId);
+
+        // Every page serves from the asset layer.
+        yield* expectUrlContains(`${site1.url!}/`, "static-home", {
+          timeout: "120 seconds",
+          label: "static home page",
+        });
+        yield* expectUrlContains(`${site1.url!}/about/`, "static-about", {
+          timeout: "60 seconds",
+          label: "static about page",
+        });
+        yield* expectUrlContains(
+          `${site1.url!}/static.txt`,
+          "astro-static-public-asset",
+          {
+            timeout: "60 seconds",
+            label: "public asset",
+          },
+        );
+
+        // Unknown routes get the BUILT 404.html with a real 404 status —
+        // Cloudflare's asset layer applies `notFoundHandling` itself; no
+        // Worker script is involved.
+        yield* expectNotFoundPage(
+          `${site1.url!}/definitely-not-a-page`,
+          "static-404",
+        );
+
+        // Session auto-provisioning is skipped for declared-static sites:
+        // no KV namespace titled for this stack's session id may exist.
+        // (Physical titles embed the logical id verbatim:
+        // `{stack}-AstroStaticSiteSession-{stage}-{suffix}`.)
+        const sessionNamespace = yield* kv.listNamespaces
+          .items({ accountId })
+          .pipe(
+            Stream.filter((ns) => ns.title.includes("AstroStaticSiteSession")),
+            Stream.runHead,
+            Effect.map(Option.getOrUndefined),
+          );
+        expect(sessionNamespace).toBeUndefined();
+
+        // ── deploy 2: nothing changed ⇒ memo hit, still assets-only ────────
+        const site2 = yield* deploy();
+        expect(site2.hash?.input).toEqual(site1.hash?.input);
+        expect(site2.hash?.assets).toEqual(site1.hash?.assets);
+        expect(site2.hash?.bundle).toBeUndefined();
+        expect(site2.url).toBe(site1.url);
+
+        // ── deploy 3: edit a page ⇒ memo busts, new content serves,
+        // and the deploy REMAINS assets-only ───────────────────────────────
+        const indexPath = path.join(rootDir, "src/pages/index.astro");
+        const source = yield* fs.readFileString(indexPath);
+        yield* fs.writeFileString(
+          indexPath,
+          source.replace("static-home", "static-home-v2"),
+        );
+
+        const site3 = yield* deploy();
+        expect(site3.hash?.input).toBeDefined();
+        expect(site3.hash?.input).not.toEqual(site1.hash?.input);
+        expect(site3.hash?.bundle).toBeUndefined();
+        yield* expectUrlContains(`${site3.url!}/`, "static-home-v2", {
+          timeout: "60 seconds",
+          label: "edited static home page",
+        });
+
+        yield* stack.destroy();
+        yield* waitForWorkerToBeDeleted(site1.workerName, accountId);
+      }).pipe(logLevel),
+    { timeout: 360_000 },
+  );
+});

--- a/packages/alchemy/test/Cloudflare/Website/Nextjs.isr.test.ts
+++ b/packages/alchemy/test/Cloudflare/Website/Nextjs.isr.test.ts
@@ -1,7 +1,7 @@
 import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
 import * as Cloudflare from "@/Cloudflare/index.ts";
 import * as Test from "@/Test/Alchemy";
-import { expect } from "alchemy-test";
+import { describe, expect } from "alchemy-test";
 import * as Effect from "effect/Effect";
 import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
@@ -68,144 +68,148 @@ const pollStamp = (
  * 4. a second deploy is a noop (pins the self_service + DO binding
  *    metadata hash stability)
  */
-test.provider(
-  "Nextjs writable ISR: KV cache + DO queue + self-reference on real Cloudflare",
-  (stack) =>
-    Effect.gen(function* () {
-      const { accountId } = yield* yield* CloudflareEnvironment;
+// Tests are independent (per-test scratch stacks, private fixture clones),
+// so run them concurrently; suites are sequential by default.
+describe.concurrent("Nextjs ISR", () => {
+  test.provider(
+    "Nextjs writable ISR: KV cache + DO queue + self-reference on real Cloudflare",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
 
-      yield* stack.destroy();
+        yield* stack.destroy();
 
-      const rootDir = yield* cloneFixture(fixtureDir, {
-        prefix: "alchemy-nextjs-isr-",
-        tempRoot,
-        entries: [
-          "package.json",
-          "tsconfig.json",
-          "next.config.mjs",
-          "open-next.config.ts",
-          "app",
-          "public",
-        ],
-      });
-      yield* linkJsApiTypeScript(rootDir);
+        const rootDir = yield* cloneFixture(fixtureDir, {
+          prefix: "alchemy-nextjs-isr-",
+          tempRoot,
+          entries: [
+            "package.json",
+            "tsconfig.json",
+            "next.config.mjs",
+            "open-next.config.ts",
+            "app",
+            "public",
+          ],
+        });
+        yield* linkJsApiTypeScript(rootDir);
 
-      const deploy = () =>
-        stack.deploy(
-          Effect.gen(function* () {
-            const incCache = yield* Cloudflare.KV.Namespace("NextIncCache");
-            const tagCache = yield* Cloudflare.KV.Namespace("NextTagCache");
-            const site = yield* Cloudflare.Website.Nextjs("NextjsIsrSite", {
-              rootDir,
-              workersDev: { enabled: true, previewsEnabled: true },
-              memo: {
-                include: [
-                  "app/**",
-                  "public/**",
-                  "package.json",
-                  "tsconfig.json",
-                  "next.config.mjs",
-                  "open-next.config.ts",
-                ],
-              },
-              env: {
-                NEXT_INC_CACHE_KV: incCache,
-                NEXT_TAG_CACHE_KV: tagCache,
-                NEXT_CACHE_DO_QUEUE: Cloudflare.DurableObject(
-                  "NEXT_CACHE_DO_QUEUE",
-                  { className: "DOQueueHandler" },
-                ),
-              },
-            });
-            return { site };
-          }),
+        const deploy = () =>
+          stack.deploy(
+            Effect.gen(function* () {
+              const incCache = yield* Cloudflare.KV.Namespace("NextIncCache");
+              const tagCache = yield* Cloudflare.KV.Namespace("NextTagCache");
+              const site = yield* Cloudflare.Website.Nextjs("NextjsIsrSite", {
+                rootDir,
+                workersDev: { enabled: true, previewsEnabled: true },
+                memo: {
+                  include: [
+                    "app/**",
+                    "public/**",
+                    "package.json",
+                    "tsconfig.json",
+                    "next.config.mjs",
+                    "open-next.config.ts",
+                  ],
+                },
+                env: {
+                  NEXT_INC_CACHE_KV: incCache,
+                  NEXT_TAG_CACHE_KV: tagCache,
+                  NEXT_CACHE_DO_QUEUE: Cloudflare.DurableObject(
+                    "NEXT_CACHE_DO_QUEUE",
+                    { className: "DOQueueHandler" },
+                  ),
+                },
+              });
+              return { site };
+            }),
+          );
+
+        const { site } = yield* deploy();
+        expect(site.url).toBeDefined();
+
+        // 1. The ISR page caches in KV: the stamp stabilizes across hits.
+        // (The very first hits may race the initial cache write, so anchor
+        // on two consecutive equal reads.)
+        const client = yield* HttpClient.HttpClient;
+        const primed = yield* pollStamp(
+          `${site.url!}/isr`,
+          "isr-stamp",
+          () => true,
         );
+        const settled = yield* pollStamp(
+          `${site.url!}/isr`,
+          "isr-stamp",
+          () => true,
+        );
+        if (primed === settled) {
+          // Cached: consecutive reads agree.
+          expect(settled).toBe(primed);
+        }
+        const cached = yield* pollStamp(
+          `${site.url!}/isr`,
+          "isr-stamp",
+          () => true,
+        );
+        expect(cached).toBe(settled);
 
-      const { site } = yield* deploy();
-      expect(site.url).toBeDefined();
-
-      // 1. The ISR page caches in KV: the stamp stabilizes across hits.
-      // (The very first hits may race the initial cache write, so anchor
-      // on two consecutive equal reads.)
-      const client = yield* HttpClient.HttpClient;
-      const primed = yield* pollStamp(
-        `${site.url!}/isr`,
-        "isr-stamp",
-        () => true,
-      );
-      const settled = yield* pollStamp(
-        `${site.url!}/isr`,
-        "isr-stamp",
-        () => true,
-      );
-      if (primed === settled) {
-        // Cached: consecutive reads agree.
-        expect(settled).toBe(primed);
-      }
-      const cached = yield* pollStamp(
-        `${site.url!}/isr`,
-        "isr-stamp",
-        () => true,
-      );
-      expect(cached).toBe(settled);
-
-      // 2. On-demand revalidation: revalidatePath purges the KV entry; a
-      // subsequent render produces a NEW stamp. With a read-only cache
-      // this would never change. A single edge request can still 404
-      // right after earlier probes succeeded (workers.dev colo
-      // inconsistency), so retry through non-200s, bounded —
-      // revalidatePath is idempotent.
-      const revalidateRes = yield* client
-        .execute(HttpClientRequest.post(`${site.url!}/api/revalidate`))
-        .pipe(
-          Effect.flatMap((res) =>
-            res.status === 200
-              ? Effect.succeed(res)
-              : Effect.flatMap(res.text, (body) =>
-                  Effect.fail(
-                    new Error(
-                      `revalidate not ready (${res.status}): ${body.slice(0, 200)}`,
+        // 2. On-demand revalidation: revalidatePath purges the KV entry; a
+        // subsequent render produces a NEW stamp. With a read-only cache
+        // this would never change. A single edge request can still 404
+        // right after earlier probes succeeded (workers.dev colo
+        // inconsistency), so retry through non-200s, bounded —
+        // revalidatePath is idempotent.
+        const revalidateRes = yield* client
+          .execute(HttpClientRequest.post(`${site.url!}/api/revalidate`))
+          .pipe(
+            Effect.flatMap((res) =>
+              res.status === 200
+                ? Effect.succeed(res)
+                : Effect.flatMap(res.text, (body) =>
+                    Effect.fail(
+                      new Error(
+                        `revalidate not ready (${res.status}): ${body.slice(0, 200)}`,
+                      ),
                     ),
                   ),
-                ),
-          ),
-          Effect.retry({ schedule: Schedule.spaced("2 seconds"), times: 30 }),
+            ),
+            Effect.retry({ schedule: Schedule.spaced("2 seconds"), times: 30 }),
+          );
+        expect(revalidateRes.status).toBe(200);
+        const fresh = yield* pollStamp(
+          `${site.url!}/isr`,
+          "isr-stamp",
+          (s) => s !== cached,
         );
-      expect(revalidateRes.status).toBe(200);
-      const fresh = yield* pollStamp(
-        `${site.url!}/isr`,
-        "isr-stamp",
-        (s) => s !== cached,
-      );
-      expect(fresh).not.toBe(cached);
+        expect(fresh).not.toBe(cached);
 
-      // 3. Time-based revalidation: after the 2s window lapses, a stale
-      // hit enqueues regeneration through the DO queue (which re-fetches
-      // the worker via WORKER_SELF_REFERENCE) and a later hit serves the
-      // regenerated payload.
-      const fastPrimed = yield* pollStamp(
-        `${site.url!}/fast-isr`,
-        "fast-isr-stamp",
-        () => true,
-      );
-      yield* Effect.sleep("3 seconds");
-      const fastFresh = yield* pollStamp(
-        `${site.url!}/fast-isr`,
-        "fast-isr-stamp",
-        (s) => s !== fastPrimed,
-        60,
-      );
-      expect(fastFresh).not.toBe(fastPrimed);
+        // 3. Time-based revalidation: after the 2s window lapses, a stale
+        // hit enqueues regeneration through the DO queue (which re-fetches
+        // the worker via WORKER_SELF_REFERENCE) and a later hit serves the
+        // regenerated payload.
+        const fastPrimed = yield* pollStamp(
+          `${site.url!}/fast-isr`,
+          "fast-isr-stamp",
+          () => true,
+        );
+        yield* Effect.sleep("3 seconds");
+        const fastFresh = yield* pollStamp(
+          `${site.url!}/fast-isr`,
+          "fast-isr-stamp",
+          (s) => s !== fastPrimed,
+          60,
+        );
+        expect(fastFresh).not.toBe(fastPrimed);
 
-      // 4. Second deploy: nothing changed, so the deploy is a noop — pins
-      // the metadata-hash stability of the self_service sentinel and the
-      // own-class DO binding.
-      const again = yield* deploy();
-      expect(again.site.hash?.input).toEqual(site.hash?.input);
-      expect(again.site.url).toBe(site.url);
+        // 4. Second deploy: nothing changed, so the deploy is a noop — pins
+        // the metadata-hash stability of the self_service sentinel and the
+        // own-class DO binding.
+        const again = yield* deploy();
+        expect(again.site.hash?.input).toEqual(site.hash?.input);
+        expect(again.site.url).toBe(site.url);
 
-      yield* stack.destroy();
-      yield* waitForWorkerToBeDeleted(site.workerName, accountId);
-    }).pipe(logLevel),
-  { timeout: 600_000 },
-);
+        yield* stack.destroy();
+        yield* waitForWorkerToBeDeleted(site.workerName, accountId);
+      }).pipe(logLevel),
+    { timeout: 600_000 },
+  );
+});

--- a/packages/alchemy/test/Cloudflare/Website/Nextjs.local.test.ts
+++ b/packages/alchemy/test/Cloudflare/Website/Nextjs.local.test.ts
@@ -4,7 +4,7 @@ import { isLocalId } from "@/Cloudflare/LocalRuntime";
 import * as Alchemy from "@/index.ts";
 import * as Test from "@/Test/Alchemy";
 import * as kv from "@distilled.cloud/cloudflare/kv";
-import { expect } from "alchemy-test";
+import { describe, expect } from "alchemy-test";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
@@ -99,250 +99,257 @@ const putKv = (base: string, key: string, value: string) =>
 // under workerd locally — production parity, no HMR.
 // ─────────────────────────────────────────────────────────────────────
 
-test.provider(
-  "Nextjs dev (preview): OpenNext worker under local workerd with emulated bindings",
-  (stack) =>
-    Effect.gen(function* () {
-      yield* stack.destroy();
+// Tests are independent (per-test scratch stacks, private fixture clones),
+// so run them concurrently; suites are sequential by default.
+describe.concurrent("Nextjs dev", () => {
+  test.provider(
+    "Nextjs dev (preview): OpenNext worker under local workerd with emulated bindings",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
 
-      const rootDir = yield* cloneFixture(fixtureDir, {
-        prefix: "alchemy-nextjs-dev-",
-        tempRoot,
-        entries: fixtureEntries,
-      });
-      yield* linkJsApiTypeScript(rootDir);
+        const rootDir = yield* cloneFixture(fixtureDir, {
+          prefix: "alchemy-nextjs-dev-",
+          tempRoot,
+          entries: fixtureEntries,
+        });
+        yield* linkJsApiTypeScript(rootDir);
 
-      const bindingMarker = "nextjs-dev-binding-marker";
+        const bindingMarker = "nextjs-dev-binding-marker";
 
-      const deployed = yield* stack.deploy(
-        Effect.gen(function* () {
-          const siteKv = yield* Cloudflare.KV.Namespace("NextjsDevKV");
-          const site = yield* Cloudflare.Website.Nextjs("NextjsLocal", {
-            rootDir,
-            dev: { port: 0 },
-            memo: { include: memoInclude },
-            env: {
-              TEST_TEXT: bindingMarker,
-              FIXTURE_KV: siteKv,
-            },
-          });
-          return { site, siteKv };
-        }),
-      );
-      const site = deployed.site;
-
-      // Local identity: the url points at the alchemy dev proxy — no cloud
-      // Worker exists — and the KV namespace is emulated (`dev:` id, proof
-      // no cloud API call ran).
-      expect(site.url).toBeDefined();
-      expect(site.url).toMatch(/^http:\/\/localhost:\d+/);
-      expect(isLocalId(deployed.siteKv.namespaceId)).toBe(true);
-
-      // The SSR page rendered by the OpenNext worker under workerd.
-      yield* expectUrlContains(`${site.url!}/`, "NEXTJS_SSR_MARKER", {
-        timeout: "120 seconds",
-        label: "nextjs dev SSR home page",
-      });
-
-      // Binding read through OpenNext's getCloudflareContext().
-      const binding = yield* fetchJsonReady<{ value: string | null }>(
-        `${site.url!}/api/binding`,
-      );
-      expect(binding.value).toBe(bindingMarker);
-
-      // Prerendered ISR page serves from the read-only static-assets cache.
-      yield* expectUrlContains(`${site.url!}/isr`, "NEXTJS_ISR_MARKER", {
-        timeout: "60 seconds",
-        label: "nextjs dev prerendered ISR page",
-      });
-
-      // Static asset from public/.
-      yield* expectUrlContains(
-        `${site.url!}/static.txt`,
-        "NEXTJS_STATIC_ASSET_MARKER",
-        { timeout: "60 seconds", label: "nextjs dev static asset" },
-      );
-
-      // KV round-trip against the local simulator through the worker.
-      yield* putKv(site.url!, "dev-key", "dev-value");
-      const got = yield* fetchJsonReady<{ value: string | null }>(
-        `${site.url!}/api/kv?key=dev-key`,
-      );
-      expect(got.value).toBe("dev-value");
-
-      yield* stack.destroy();
-    }).pipe(logLevel),
-  { timeout: 420_000 },
-);
-
-// ─────────────────────────────────────────────────────────────────────
-// HMR mode: the real `next dev` (Turbopack) in Node, bindings proxied
-// onto OpenNext's getCloudflareContext() contract.
-// ─────────────────────────────────────────────────────────────────────
-
-test.provider(
-  "Nextjs dev (hmr): real next dev serves edits without redeploying",
-  (stack) =>
-    Effect.gen(function* () {
-      const fs = yield* FileSystem.FileSystem;
-      const path = yield* Path.Path;
-
-      yield* stack.destroy();
-
-      const rootDir = yield* cloneFixture(fixtureDir, {
-        prefix: "alchemy-nextjs-dev-hmr-",
-        tempRoot,
-        entries: fixtureEntries,
-      });
-      yield* linkJsApiTypeScript(rootDir);
-
-      const bindingMarker = "nextjs-hmr-binding-marker";
-
-      const deployed = yield* stack.deploy(
-        Effect.gen(function* () {
-          const site = yield* Cloudflare.Website.Nextjs("NextjsHmrLocal", {
-            rootDir,
-            dev: { port: 0 },
-            memo: { include: memoInclude },
-            nextjs: { devMode: "hmr" },
-            env: {
-              TEST_TEXT: bindingMarker,
-            },
-          });
-          return { site };
-        }),
-      );
-      const site = deployed.site;
-
-      expect(site.url).toMatch(/^http:\/\/localhost:\d+/);
-
-      // The SSR page through the real `next dev` (Turbopack).
-      yield* expectUrlContains(`${site.url!}/`, "NEXTJS_SSR_MARKER", {
-        timeout: "180 seconds",
-        label: "nextjs hmr dev SSR home page",
-      });
-
-      // getCloudflareContext().env binding through the platform proxy.
-      const binding = yield* fetchJsonReady<{ value: string | null }>(
-        `${site.url!}/api/binding`,
-      );
-      expect(binding.value).toBe(bindingMarker);
-
-      // ── HMR: edit the page in place. The stack is NOT re-applied —
-      // Turbopack must recompile and serve the new marker through the
-      // same alchemy proxy ─────────────────────────────────────────────
-      const pagePath = path.join(rootDir, "app", "page.tsx");
-      const page = yield* fs.readFileString(pagePath);
-      yield* fs.writeFileString(
-        pagePath,
-        page.replace("NEXTJS_SSR_MARKER", "NEXTJS_SSR_MARKER_HMR"),
-      );
-      yield* expectUrlContains(`${site.url!}/`, "NEXTJS_SSR_MARKER_HMR", {
-        timeout: "120 seconds",
-        label: "nextjs hmr dev page after edit",
-      });
-
-      // The binding bridge survived the recompile.
-      const still = yield* fetchJsonReady<{ value: string | null }>(
-        `${site.url!}/api/binding`,
-      );
-      expect(still.value).toBe(bindingMarker);
-
-      yield* stack.destroy();
-    }).pipe(logLevel),
-  { timeout: 420_000 },
-);
-
-// ─────────────────────────────────────────────────────────────────────
-// Alchemy.remote(): the KV namespace opts OUT of local emulation — real
-// cloud namespace behind the locally-served site.
-// ─────────────────────────────────────────────────────────────────────
-
-test.provider(
-  "Nextjs dev: Alchemy.remote() KV namespace runs live behind the dev server",
-  (stack) =>
-    Effect.gen(function* () {
-      yield* stack.destroy();
-
-      const rootDir = yield* cloneFixture(fixtureDir, {
-        prefix: "alchemy-nextjs-dev-remote-",
-        tempRoot,
-        entries: fixtureEntries,
-      });
-      yield* linkJsApiTypeScript(rootDir);
-
-      const deployed = yield* stack.deploy(
-        Effect.gen(function* () {
-          const siteKv = yield* Cloudflare.KV.Namespace(
-            "NextjsDevRemoteKV",
-          ).pipe(Alchemy.remote());
-          const site = yield* Cloudflare.Website.Nextjs("NextjsRemoteKvLocal", {
-            rootDir,
-            dev: { port: 0 },
-            memo: { include: memoInclude },
-            env: {
-              TEST_TEXT: "nextjs-dev-remote-marker",
-              FIXTURE_KV: siteKv,
-            },
-          });
-          return { site, siteKv };
-        }),
-      );
-      const site = deployed.site;
-
-      // Served locally, but the remote() namespace is REAL — a live cloud
-      // id, not a `dev:` fabrication.
-      expect(site.url).toMatch(/^http:\/\/localhost:\d+/);
-      expect(deployed.siteKv.namespaceId).toBeDefined();
-      expect(deployed.siteKv.namespaceId).not.toMatch(/^dev:/);
-
-      // Write through the worker's remote-proxied binding.
-      yield* putKv(site.url!, "remote-key", "remote-value");
-      const got = yield* fetchJsonReady<{ value: string | null }>(
-        `${site.url!}/api/kv?key=remote-key`,
-      );
-      expect(got.value).toBe("remote-value");
-
-      // Out-of-band: the write is visible through the cloud KV API — the
-      // remote-proxied binding really hit the live namespace.
-      const { accountId } = yield* yield* CloudflareEnvironment;
-      const observed = yield* kv
-        .getNamespaceValue({
-          accountId,
-          namespaceId: deployed.siteKv.namespaceId,
-          keyName: "remote-key",
-        })
-        .pipe(
-          Effect.retry({
-            while: (e): boolean => e._tag === "KeyNotFound",
-            schedule: Schedule.exponential("1 second"),
-            times: 8,
+        const deployed = yield* stack.deploy(
+          Effect.gen(function* () {
+            const siteKv = yield* Cloudflare.KV.Namespace("NextjsDevKV");
+            const site = yield* Cloudflare.Website.Nextjs("NextjsLocal", {
+              rootDir,
+              dev: { port: 0 },
+              memo: { include: memoInclude },
+              env: {
+                TEST_TEXT: bindingMarker,
+                FIXTURE_KV: siteKv,
+              },
+            });
+            return { site, siteKv };
           }),
-          Effect.flatMap((res) =>
-            Effect.tryPromise(() =>
-              new Response(
-                Stream.toReadableStream(res.body) as BodyInit,
-              ).text(),
+        );
+        const site = deployed.site;
+
+        // Local identity: the url points at the alchemy dev proxy — no cloud
+        // Worker exists — and the KV namespace is emulated (`dev:` id, proof
+        // no cloud API call ran).
+        expect(site.url).toBeDefined();
+        expect(site.url).toMatch(/^http:\/\/localhost:\d+/);
+        expect(isLocalId(deployed.siteKv.namespaceId)).toBe(true);
+
+        // The SSR page rendered by the OpenNext worker under workerd.
+        yield* expectUrlContains(`${site.url!}/`, "NEXTJS_SSR_MARKER", {
+          timeout: "120 seconds",
+          label: "nextjs dev SSR home page",
+        });
+
+        // Binding read through OpenNext's getCloudflareContext().
+        const binding = yield* fetchJsonReady<{ value: string | null }>(
+          `${site.url!}/api/binding`,
+        );
+        expect(binding.value).toBe(bindingMarker);
+
+        // Prerendered ISR page serves from the read-only static-assets cache.
+        yield* expectUrlContains(`${site.url!}/isr`, "NEXTJS_ISR_MARKER", {
+          timeout: "60 seconds",
+          label: "nextjs dev prerendered ISR page",
+        });
+
+        // Static asset from public/.
+        yield* expectUrlContains(
+          `${site.url!}/static.txt`,
+          "NEXTJS_STATIC_ASSET_MARKER",
+          { timeout: "60 seconds", label: "nextjs dev static asset" },
+        );
+
+        // KV round-trip against the local simulator through the worker.
+        yield* putKv(site.url!, "dev-key", "dev-value");
+        const got = yield* fetchJsonReady<{ value: string | null }>(
+          `${site.url!}/api/kv?key=dev-key`,
+        );
+        expect(got.value).toBe("dev-value");
+
+        yield* stack.destroy();
+      }).pipe(logLevel),
+    { timeout: 420_000 },
+  );
+
+  // ─────────────────────────────────────────────────────────────────────
+  // HMR mode: the real `next dev` (Turbopack) in Node, bindings proxied
+  // onto OpenNext's getCloudflareContext() contract.
+  // ─────────────────────────────────────────────────────────────────────
+
+  test.provider(
+    "Nextjs dev (hmr): real next dev serves edits without redeploying",
+    (stack) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+
+        yield* stack.destroy();
+
+        const rootDir = yield* cloneFixture(fixtureDir, {
+          prefix: "alchemy-nextjs-dev-hmr-",
+          tempRoot,
+          entries: fixtureEntries,
+        });
+        yield* linkJsApiTypeScript(rootDir);
+
+        const bindingMarker = "nextjs-hmr-binding-marker";
+
+        const deployed = yield* stack.deploy(
+          Effect.gen(function* () {
+            const site = yield* Cloudflare.Website.Nextjs("NextjsHmrLocal", {
+              rootDir,
+              dev: { port: 0 },
+              memo: { include: memoInclude },
+              nextjs: { devMode: "hmr" },
+              env: {
+                TEST_TEXT: bindingMarker,
+              },
+            });
+            return { site };
+          }),
+        );
+        const site = deployed.site;
+
+        expect(site.url).toMatch(/^http:\/\/localhost:\d+/);
+
+        // The SSR page through the real `next dev` (Turbopack).
+        yield* expectUrlContains(`${site.url!}/`, "NEXTJS_SSR_MARKER", {
+          timeout: "180 seconds",
+          label: "nextjs hmr dev SSR home page",
+        });
+
+        // getCloudflareContext().env binding through the platform proxy.
+        const binding = yield* fetchJsonReady<{ value: string | null }>(
+          `${site.url!}/api/binding`,
+        );
+        expect(binding.value).toBe(bindingMarker);
+
+        // ── HMR: edit the page in place. The stack is NOT re-applied —
+        // Turbopack must recompile and serve the new marker through the
+        // same alchemy proxy ─────────────────────────────────────────────
+        const pagePath = path.join(rootDir, "app", "page.tsx");
+        const page = yield* fs.readFileString(pagePath);
+        yield* fs.writeFileString(
+          pagePath,
+          page.replace("NEXTJS_SSR_MARKER", "NEXTJS_SSR_MARKER_HMR"),
+        );
+        yield* expectUrlContains(`${site.url!}/`, "NEXTJS_SSR_MARKER_HMR", {
+          timeout: "120 seconds",
+          label: "nextjs hmr dev page after edit",
+        });
+
+        // The binding bridge survived the recompile.
+        const still = yield* fetchJsonReady<{ value: string | null }>(
+          `${site.url!}/api/binding`,
+        );
+        expect(still.value).toBe(bindingMarker);
+
+        yield* stack.destroy();
+      }).pipe(logLevel),
+    { timeout: 420_000 },
+  );
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Alchemy.remote(): the KV namespace opts OUT of local emulation — real
+  // cloud namespace behind the locally-served site.
+  // ─────────────────────────────────────────────────────────────────────
+
+  test.provider(
+    "Nextjs dev: Alchemy.remote() KV namespace runs live behind the dev server",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const rootDir = yield* cloneFixture(fixtureDir, {
+          prefix: "alchemy-nextjs-dev-remote-",
+          tempRoot,
+          entries: fixtureEntries,
+        });
+        yield* linkJsApiTypeScript(rootDir);
+
+        const deployed = yield* stack.deploy(
+          Effect.gen(function* () {
+            const siteKv = yield* Cloudflare.KV.Namespace(
+              "NextjsDevRemoteKV",
+            ).pipe(Alchemy.remote());
+            const site = yield* Cloudflare.Website.Nextjs(
+              "NextjsRemoteKvLocal",
+              {
+                rootDir,
+                dev: { port: 0 },
+                memo: { include: memoInclude },
+                env: {
+                  TEST_TEXT: "nextjs-dev-remote-marker",
+                  FIXTURE_KV: siteKv,
+                },
+              },
+            );
+            return { site, siteKv };
+          }),
+        );
+        const site = deployed.site;
+
+        // Served locally, but the remote() namespace is REAL — a live cloud
+        // id, not a `dev:` fabrication.
+        expect(site.url).toMatch(/^http:\/\/localhost:\d+/);
+        expect(deployed.siteKv.namespaceId).toBeDefined();
+        expect(deployed.siteKv.namespaceId).not.toMatch(/^dev:/);
+
+        // Write through the worker's remote-proxied binding.
+        yield* putKv(site.url!, "remote-key", "remote-value");
+        const got = yield* fetchJsonReady<{ value: string | null }>(
+          `${site.url!}/api/kv?key=remote-key`,
+        );
+        expect(got.value).toBe("remote-value");
+
+        // Out-of-band: the write is visible through the cloud KV API — the
+        // remote-proxied binding really hit the live namespace.
+        const { accountId } = yield* yield* CloudflareEnvironment;
+        const observed = yield* kv
+          .getNamespaceValue({
+            accountId,
+            namespaceId: deployed.siteKv.namespaceId,
+            keyName: "remote-key",
+          })
+          .pipe(
+            Effect.retry({
+              while: (e): boolean => e._tag === "KeyNotFound",
+              schedule: Schedule.exponential("1 second"),
+              times: 8,
+            }),
+            Effect.flatMap((res) =>
+              Effect.tryPromise(() =>
+                new Response(
+                  Stream.toReadableStream(res.body) as BodyInit,
+                ).text(),
+              ),
             ),
-          ),
-        );
-      expect(observed).toBe("remote-value");
+          );
+        expect(observed).toBe("remote-value");
 
-      yield* stack.destroy();
+        yield* stack.destroy();
 
-      // The live namespace was deleted from the cloud on destroy (its
-      // state row is stamped live, so the live provider handles the
-      // delete even in a dev run).
-      const gone = yield* kv
-        .getNamespace({
-          accountId,
-          namespaceId: deployed.siteKv.namespaceId,
-        })
-        .pipe(
-          Effect.as(false),
-          Effect.catchTag("NamespaceNotFound", () => Effect.succeed(true)),
-        );
-      expect(gone).toBe(true);
-    }).pipe(logLevel),
-  { timeout: 420_000 },
-);
+        // The live namespace was deleted from the cloud on destroy (its
+        // state row is stamped live, so the live provider handles the
+        // delete even in a dev run).
+        const gone = yield* kv
+          .getNamespace({
+            accountId,
+            namespaceId: deployed.siteKv.namespaceId,
+          })
+          .pipe(
+            Effect.as(false),
+            Effect.catchTag("NamespaceNotFound", () => Effect.succeed(true)),
+          );
+        expect(gone).toBe(true);
+      }).pipe(logLevel),
+    { timeout: 420_000 },
+  );
+});

--- a/packages/alchemy/test/Cloudflare/Website/Nextjs.test.ts
+++ b/packages/alchemy/test/Cloudflare/Website/Nextjs.test.ts
@@ -1,7 +1,7 @@
 import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
 import * as Cloudflare from "@/Cloudflare/index.ts";
 import * as Test from "@/Test/Alchemy";
-import { expect } from "alchemy-test";
+import { describe, expect } from "alchemy-test";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
@@ -74,240 +74,255 @@ const fetchJsonReady = <T>(url: string) =>
     );
   });
 
-test.provider(
-  "Nextjs: deploys SSR + binding + static assets, serves prerendered ISR, and memoizes unchanged rebuilds",
-  (stack) =>
-    Effect.gen(function* () {
-      const { accountId } = yield* yield* CloudflareEnvironment;
-      const fs = yield* FileSystem.FileSystem;
-      const path = yield* Path.Path;
+// Tests are independent (per-test scratch stacks, private fixture clones),
+// so run them concurrently; suites are sequential by default.
+describe.concurrent("Nextjs", () => {
+  test.provider(
+    "Nextjs: deploys SSR + binding + static assets, serves prerendered ISR, and memoizes unchanged rebuilds",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
 
-      yield* stack.destroy();
+        yield* stack.destroy();
 
-      const rootDir = yield* cloneFixture(fixtureDir, {
-        prefix: "alchemy-nextjs-",
-        tempRoot,
-        entries: [
-          "package.json",
-          "tsconfig.json",
-          "next.config.mjs",
-          "open-next.config.ts",
-          "middleware.ts",
-          "app",
-          "pages",
-          "public",
-        ],
-      });
-      yield* linkJsApiTypeScript(rootDir);
+        const rootDir = yield* cloneFixture(fixtureDir, {
+          prefix: "alchemy-nextjs-",
+          tempRoot,
+          entries: [
+            "package.json",
+            "tsconfig.json",
+            "next.config.mjs",
+            "open-next.config.ts",
+            "middleware.ts",
+            "app",
+            "pages",
+            "public",
+          ],
+        });
+        yield* linkJsApiTypeScript(rootDir);
 
-      const bindingMarker = "nextjs-binding-marker";
+        const bindingMarker = "nextjs-binding-marker";
 
-      const deploy = () =>
-        stack.deploy(
-          Effect.gen(function* () {
-            const kv = yield* Cloudflare.KV.Namespace("NextjsFixtureKv");
-            return yield* Cloudflare.Website.Nextjs("NextjsSite", {
-              ...nextjsProps(rootDir),
-              env: {
-                TEST_TEXT: bindingMarker,
-                FIXTURE_KV: kv,
-              },
-            });
-          }),
+        const deploy = () =>
+          stack.deploy(
+            Effect.gen(function* () {
+              const kv = yield* Cloudflare.KV.Namespace("NextjsFixtureKv");
+              return yield* Cloudflare.Website.Nextjs("NextjsSite", {
+                ...nextjsProps(rootDir),
+                env: {
+                  TEST_TEXT: bindingMarker,
+                  FIXTURE_KV: kv,
+                },
+              });
+            }),
+          );
+
+        const site1 = yield* deploy();
+
+        expect(site1.url).toBeDefined();
+        expect(site1.hash?.input).toBeDefined();
+        yield* expectWorkerExists(site1.workerName, accountId);
+
+        // Dynamic (force-dynamic) app-router page rendered by the Worker.
+        yield* expectUrlContains(`${site1.url!}/`, "NEXTJS_SSR_MARKER", {
+          timeout: "120 seconds",
+          label: "nextjs SSR home page",
+        });
+
+        // API route handler — the middleware matcher covers /api/*, so the
+        // pass-through header also proves middleware executes on deploy.
+        const client = yield* HttpClient.HttpClient;
+        const helloRes = yield* client
+          .get(`${site1.url!}/api/hello`)
+          .pipe(
+            Effect.retry({ schedule: Schedule.spaced("2 seconds"), times: 30 }),
+          );
+        expect(helloRes.status).toBe(200);
+        expect(helloRes.headers["x-fixture-middleware"]).toBe("passed");
+        const hello = (yield* helloRes.json) as { hello: string };
+        expect(hello.hello).toBe("world");
+
+        // Middleware rewrite: /mw-rewrite serves the API route's response.
+        const rewritten = yield* fetchJsonReady<{ hello: string }>(
+          `${site1.url!}/mw-rewrite`,
         );
+        expect(rewritten.hello).toBe("world");
 
-      const site1 = yield* deploy();
-
-      expect(site1.url).toBeDefined();
-      expect(site1.hash?.input).toBeDefined();
-      yield* expectWorkerExists(site1.workerName, accountId);
-
-      // Dynamic (force-dynamic) app-router page rendered by the Worker.
-      yield* expectUrlContains(`${site1.url!}/`, "NEXTJS_SSR_MARKER", {
-        timeout: "120 seconds",
-        label: "nextjs SSR home page",
-      });
-
-      // API route handler — the middleware matcher covers /api/*, so the
-      // pass-through header also proves middleware executes on deploy.
-      const client = yield* HttpClient.HttpClient;
-      const helloRes = yield* client
-        .get(`${site1.url!}/api/hello`)
-        .pipe(
-          Effect.retry({ schedule: Schedule.spaced("2 seconds"), times: 30 }),
+        // Binding read through OpenNext's `getCloudflareContext()`.
+        const binding = yield* fetchJsonReady<{ value: string | null }>(
+          `${site1.url!}/api/binding`,
         );
-      expect(helloRes.status).toBe(200);
-      expect(helloRes.headers["x-fixture-middleware"]).toBe("passed");
-      const hello = (yield* helloRes.json) as { hello: string };
-      expect(hello.hello).toBe("world");
+        expect(binding.value).toBe(bindingMarker);
 
-      // Middleware rewrite: /mw-rewrite serves the API route's response.
-      const rewritten = yield* fetchJsonReady<{ hello: string }>(
-        `${site1.url!}/mw-rewrite`,
-      );
-      expect(rewritten.hello).toBe("world");
-
-      // Binding read through OpenNext's `getCloudflareContext()`.
-      const binding = yield* fetchJsonReady<{ value: string | null }>(
-        `${site1.url!}/api/binding`,
-      );
-      expect(binding.value).toBe(bindingMarker);
-
-      // KV round-trip through a real resource binding: PUT then GET.
-      const kvKey = `nextjs-live-${site1.hash?.input?.slice(0, 8)}`;
-      const kvValue = `kv-value-${bindingMarker}`;
-      const putRes = yield* client.execute(
-        HttpClientRequest.put(`${site1.url!}/api/kv`).pipe(
-          HttpClientRequest.bodyJsonUnsafe({ key: kvKey, value: kvValue }),
-        ),
-      );
-      expect(putRes.status).toBe(200);
-      const kvRead = yield* fetchJsonReady<{ value: string | null }>(
-        `${site1.url!}/api/kv?key=${kvKey}`,
-      );
-      expect(kvRead.value).toBe(kvValue);
-
-      // Static asset from `public/`.
-      yield* expectUrlContains(
-        `${site1.url!}/static.txt`,
-        "NEXTJS_STATIC_ASSET_MARKER",
-        {
-          timeout: "60 seconds",
-          label: "nextjs static asset",
-        },
-      );
-
-      // ISR page: the prerendered payload serves (read-only static-assets
-      // incremental cache; revalidation writes are a documented no-op).
-      yield* expectUrlContains(`${site1.url!}/isr`, "NEXTJS_ISR_MARKER", {
-        timeout: "60 seconds",
-        label: "nextjs prerendered ISR page",
-      });
-
-      // Dynamic segment prerendered by generateStaticParams (SSG).
-      yield* expectUrlContains(
-        `${site1.url!}/products/alpha`,
-        "product-slug:",
-        { timeout: "60 seconds", label: "nextjs prerendered dynamic segment" },
-      );
-      // Non-prerendered slug renders on demand in the Worker.
-      yield* expectUrlContains(
-        `${site1.url!}/products/gamma`,
-        "product-slug:",
-        { timeout: "60 seconds", label: "nextjs on-demand dynamic segment" },
-      );
-      // Catch-all dynamic segment.
-      yield* expectUrlContains(
-        `${site1.url!}/docs/guides/deploy/workers`,
-        "DOCS_CATCHALL_MARKER",
-        { timeout: "60 seconds", label: "nextjs catch-all segment" },
-      );
-
-      // Streaming SSR through the real edge: the shell (with the Suspense
-      // fallback) flushes before the slow segment resolves. identity
-      // encoding keeps intermediate proxies from buffering the stream.
-      const streamRes = yield* client.execute(
-        HttpClientRequest.get(`${site1.url!}/streaming`).pipe(
-          HttpClientRequest.setHeader("accept-encoding", "identity"),
-        ),
-      );
-      expect(streamRes.status).toBe(200);
-      const streamBody = yield* streamRes.text;
-      expect(streamBody).toContain("STREAMING_SUSPENSE_MARKER");
-      expect(streamBody).toContain("STREAMING_RESOLVED_MARKER");
-
-      // Custom not-found boundary: unmatched routes and notFound() calls
-      // both serve the custom 404 content with a 404 status. A colo that
-      // hasn't picked up the deployment yet serves Cloudflare's platform
-      // "Page not found" (also a 404), so retry until the response is the
-      // app's own boundary rather than asserting the first answer.
-      const expectCustom404 = (url: string, label: string) =>
-        client.get(url).pipe(
-          Effect.flatMap((res) =>
-            Effect.flatMap(res.text, (body) =>
-              res.status === 404 && body.includes("CUSTOM_NOT_FOUND_MARKER")
-                ? Effect.void
-                : Effect.fail(
-                    new Error(
-                      `${label}: status=${res.status}, custom not-found marker absent`,
-                    ),
-                  ),
-            ),
+        // KV round-trip through a real resource binding: PUT then GET.
+        const kvKey = `nextjs-live-${site1.hash?.input?.slice(0, 8)}`;
+        const kvValue = `kv-value-${bindingMarker}`;
+        const putRes = yield* client.execute(
+          HttpClientRequest.put(`${site1.url!}/api/kv`).pipe(
+            HttpClientRequest.bodyJsonUnsafe({ key: kvKey, value: kvValue }),
           ),
-          Effect.retry({ schedule: Schedule.spaced("2 seconds"), times: 30 }),
         );
-      yield* expectCustom404(
-        `${site1.url!}/definitely/not/a/route`,
-        "unmatched route",
-      );
-      yield* expectCustom404(`${site1.url!}/gone`, "notFound() page");
+        expect(putRes.status).toBe(200);
+        const kvRead = yield* fetchJsonReady<{ value: string | null }>(
+          `${site1.url!}/api/kv?key=${kvKey}`,
+        );
+        expect(kvRead.value).toBe(kvValue);
 
-      // next.config redirects / rewrites / headers. The fetch-backed
-      // client follows the 308, so assert the redirect lands on the home
-      // page's content — a broken redirect would 404 instead.
-      yield* expectUrlContains(`${site1.url!}/old-home`, "NEXTJS_SSR_MARKER", {
-        timeout: "60 seconds",
-        label: "nextjs next.config redirect (followed to home)",
-      });
-      const rewritten2 = yield* fetchJsonReady<{ hello: string }>(
-        `${site1.url!}/rewritten-hello`,
-      );
-      expect(rewritten2.hello).toBe("world");
-      const headered = yield* client.get(`${site1.url!}/api/hello`);
-      expect(headered.headers["x-fixture-config-header"]).toBe(
-        "from-next-config",
-      );
+        // Static asset from `public/`.
+        yield* expectUrlContains(
+          `${site1.url!}/static.txt`,
+          "NEXTJS_STATIC_ASSET_MARKER",
+          {
+            timeout: "60 seconds",
+            label: "nextjs static asset",
+          },
+        );
 
-      // next/image (unoptimized): the page renders the img and the raw
-      // asset serves through the ASSETS binding. Real optimization needs
-      // a zone with Cloudflare Images — documented on the resource.
-      yield* expectUrlContains(`${site1.url!}/image`, "IMAGE_PAGE_MARKER", {
-        timeout: "60 seconds",
-        label: "nextjs next/image page",
-      });
-      const pixel = yield* client.get(`${site1.url!}/pixel.png`);
-      expect(pixel.status).toBe(200);
-      expect(pixel.headers["content-type"]).toContain("image/png");
+        // ISR page: the prerendered payload serves (read-only static-assets
+        // incremental cache; revalidation writes are a documented no-op).
+        yield* expectUrlContains(`${site1.url!}/isr`, "NEXTJS_ISR_MARKER", {
+          timeout: "60 seconds",
+          label: "nextjs prerendered ISR page",
+        });
 
-      // Pages Router page (getServerSideProps) + API route, coexisting
-      // with the App Router.
-      yield* expectUrlContains(`${site1.url!}/legacy`, "PAGES_ROUTER_MARKER", {
-        timeout: "60 seconds",
-        label: "nextjs pages-router page",
-      });
-      const legacy = yield* fetchJsonReady<{ legacy: string }>(
-        `${site1.url!}/api/legacy`,
-      );
-      expect(legacy.legacy).toBe("pages-api");
+        // Dynamic segment prerendered by generateStaticParams (SSG).
+        yield* expectUrlContains(
+          `${site1.url!}/products/alpha`,
+          "product-slug:",
+          {
+            timeout: "60 seconds",
+            label: "nextjs prerendered dynamic segment",
+          },
+        );
+        // Non-prerendered slug renders on demand in the Worker.
+        yield* expectUrlContains(
+          `${site1.url!}/products/gamma`,
+          "product-slug:",
+          { timeout: "60 seconds", label: "nextjs on-demand dynamic segment" },
+        );
+        // Catch-all dynamic segment.
+        yield* expectUrlContains(
+          `${site1.url!}/docs/guides/deploy/workers`,
+          "DOCS_CATCHALL_MARKER",
+          { timeout: "60 seconds", label: "nextjs catch-all segment" },
+        );
 
-      // ── deploy 2: no changes ⇒ the rebuild-free input hash matches and
-      // the deploy short-circuits without rebuilding ───────────────────────
-      const site2 = yield* deploy();
+        // Streaming SSR through the real edge: the shell (with the Suspense
+        // fallback) flushes before the slow segment resolves. identity
+        // encoding keeps intermediate proxies from buffering the stream.
+        const streamRes = yield* client.execute(
+          HttpClientRequest.get(`${site1.url!}/streaming`).pipe(
+            HttpClientRequest.setHeader("accept-encoding", "identity"),
+          ),
+        );
+        expect(streamRes.status).toBe(200);
+        const streamBody = yield* streamRes.text;
+        expect(streamBody).toContain("STREAMING_SUSPENSE_MARKER");
+        expect(streamBody).toContain("STREAMING_RESOLVED_MARKER");
 
-      expect(site2.hash?.input).toBeDefined();
-      expect(site2.hash?.input).toEqual(site1.hash?.input);
-      expect(site2.url).toBe(site1.url);
+        // Custom not-found boundary: unmatched routes and notFound() calls
+        // both serve the custom 404 content with a 404 status. A colo that
+        // hasn't picked up the deployment yet serves Cloudflare's platform
+        // "Page not found" (also a 404), so retry until the response is the
+        // app's own boundary rather than asserting the first answer.
+        const expectCustom404 = (url: string, label: string) =>
+          client.get(url).pipe(
+            Effect.flatMap((res) =>
+              Effect.flatMap(res.text, (body) =>
+                res.status === 404 && body.includes("CUSTOM_NOT_FOUND_MARKER")
+                  ? Effect.void
+                  : Effect.fail(
+                      new Error(
+                        `${label}: status=${res.status}, custom not-found marker absent`,
+                      ),
+                    ),
+              ),
+            ),
+            Effect.retry({ schedule: Schedule.spaced("2 seconds"), times: 30 }),
+          );
+        yield* expectCustom404(
+          `${site1.url!}/definitely/not/a/route`,
+          "unmatched route",
+        );
+        yield* expectCustom404(`${site1.url!}/gone`, "notFound() page");
 
-      // ── deploy 3: edit the SSR page ⇒ the input hash changes and the
-      // new content deploys ────────────────────────────────────────────────
-      const pagePath = path.join(rootDir, "app/page.tsx");
-      const page = yield* fs.readFileString(pagePath);
-      yield* fs.writeFileString(
-        pagePath,
-        page.replace("NEXTJS_SSR_MARKER", "NEXTJS_SSR_MARKER_V2"),
-      );
+        // next.config redirects / rewrites / headers. The fetch-backed
+        // client follows the 308, so assert the redirect lands on the home
+        // page's content — a broken redirect would 404 instead.
+        yield* expectUrlContains(
+          `${site1.url!}/old-home`,
+          "NEXTJS_SSR_MARKER",
+          {
+            timeout: "60 seconds",
+            label: "nextjs next.config redirect (followed to home)",
+          },
+        );
+        const rewritten2 = yield* fetchJsonReady<{ hello: string }>(
+          `${site1.url!}/rewritten-hello`,
+        );
+        expect(rewritten2.hello).toBe("world");
+        const headered = yield* client.get(`${site1.url!}/api/hello`);
+        expect(headered.headers["x-fixture-config-header"]).toBe(
+          "from-next-config",
+        );
 
-      const site3 = yield* deploy();
+        // next/image (unoptimized): the page renders the img and the raw
+        // asset serves through the ASSETS binding. Real optimization needs
+        // a zone with Cloudflare Images — documented on the resource.
+        yield* expectUrlContains(`${site1.url!}/image`, "IMAGE_PAGE_MARKER", {
+          timeout: "60 seconds",
+          label: "nextjs next/image page",
+        });
+        const pixel = yield* client.get(`${site1.url!}/pixel.png`);
+        expect(pixel.status).toBe(200);
+        expect(pixel.headers["content-type"]).toContain("image/png");
 
-      expect(site3.hash?.input).toBeDefined();
-      expect(site3.hash?.input).not.toEqual(site1.hash?.input);
-      yield* expectUrlContains(`${site3.url!}/`, "NEXTJS_SSR_MARKER_V2", {
-        timeout: "120 seconds",
-        label: "nextjs SSR page after edit",
-      });
+        // Pages Router page (getServerSideProps) + API route, coexisting
+        // with the App Router.
+        yield* expectUrlContains(
+          `${site1.url!}/legacy`,
+          "PAGES_ROUTER_MARKER",
+          {
+            timeout: "60 seconds",
+            label: "nextjs pages-router page",
+          },
+        );
+        const legacy = yield* fetchJsonReady<{ legacy: string }>(
+          `${site1.url!}/api/legacy`,
+        );
+        expect(legacy.legacy).toBe("pages-api");
 
-      yield* stack.destroy();
-      yield* waitForWorkerToBeDeleted(site1.workerName, accountId);
-    }).pipe(logLevel),
-  { timeout: 600_000 },
-);
+        // ── deploy 2: no changes ⇒ the rebuild-free input hash matches and
+        // the deploy short-circuits without rebuilding ───────────────────────
+        const site2 = yield* deploy();
+
+        expect(site2.hash?.input).toBeDefined();
+        expect(site2.hash?.input).toEqual(site1.hash?.input);
+        expect(site2.url).toBe(site1.url);
+
+        // ── deploy 3: edit the SSR page ⇒ the input hash changes and the
+        // new content deploys ────────────────────────────────────────────────
+        const pagePath = path.join(rootDir, "app/page.tsx");
+        const page = yield* fs.readFileString(pagePath);
+        yield* fs.writeFileString(
+          pagePath,
+          page.replace("NEXTJS_SSR_MARKER", "NEXTJS_SSR_MARKER_V2"),
+        );
+
+        const site3 = yield* deploy();
+
+        expect(site3.hash?.input).toBeDefined();
+        expect(site3.hash?.input).not.toEqual(site1.hash?.input);
+        yield* expectUrlContains(`${site3.url!}/`, "NEXTJS_SSR_MARKER_V2", {
+          timeout: "120 seconds",
+          label: "nextjs SSR page after edit",
+        });
+
+        yield* stack.destroy();
+        yield* waitForWorkerToBeDeleted(site1.workerName, accountId);
+      }).pipe(logLevel),
+    { timeout: 600_000 },
+  );
+});

--- a/packages/alchemy/test/Cloudflare/Website/Nuxt.local.test.ts
+++ b/packages/alchemy/test/Cloudflare/Website/Nuxt.local.test.ts
@@ -4,7 +4,7 @@ import { isLocalId } from "@/Cloudflare/LocalRuntime";
 import * as Alchemy from "@/index.ts";
 import * as Test from "@/Test/Alchemy";
 import * as kv from "@distilled.cloud/cloudflare/kv";
-import { expect } from "alchemy-test";
+import { describe, expect } from "alchemy-test";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
@@ -44,216 +44,220 @@ const memoInclude = [
   "package.json",
 ];
 
-test.provider(
-  "Nuxt dev: local dev server renders SSR with event.context.cloudflare bindings",
-  (stack) =>
-    Effect.gen(function* () {
-      const fs = yield* FileSystem.FileSystem;
-      const path = yield* Path.Path;
+// Tests are independent (per-test scratch stacks, private fixture clones),
+// so run them concurrently; suites are sequential by default.
+describe.concurrent("Nuxt dev", () => {
+  test.provider(
+    "Nuxt dev: local dev server renders SSR with event.context.cloudflare bindings",
+    (stack) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
 
-      yield* stack.destroy();
+        yield* stack.destroy();
 
-      const rootDir = yield* cloneFixture(fixtureDir, {
-        prefix: "alchemy-nuxt-dev-",
-        tempRoot,
-        entries: fixtureEntries,
-      });
+        const rootDir = yield* cloneFixture(fixtureDir, {
+          prefix: "alchemy-nuxt-dev-",
+          tempRoot,
+          entries: fixtureEntries,
+        });
 
-      const bindingMarker = "nuxt-dev-binding-marker";
+        const bindingMarker = "nuxt-dev-binding-marker";
 
-      const deployed = yield* stack.deploy(
-        Effect.gen(function* () {
-          const siteKv = yield* Cloudflare.KV.Namespace("NuxtDevKV");
-          const site = yield* Cloudflare.Website.Nuxt("NuxtLocal", {
-            rootDir,
-            dev: { port: 0 },
-            memo: { include: memoInclude },
-            env: {
-              TEST_BINDING: bindingMarker,
-              SITE_KV: siteKv,
-            },
-          });
-          return { site, siteKv };
-        }),
-      );
-      const site = deployed.site;
-
-      // Local identity: the url points at the alchemy dev proxy — no
-      // cloud Worker exists — and the KV namespace is emulated (a `dev:`
-      // id, proof no cloud API call ran).
-      expect(site.url).toBeDefined();
-      expect(site.url).toMatch(/^http:\/\/localhost:\d+/);
-      expect(isLocalId(deployed.siteKv.namespaceId)).toBe(true);
-
-      // SSR page rendered by nitro's dev server behind the proxy.
-      yield* expectUrlContains(`${site.url!}/`, "NUXT_PAGE_MARKER", {
-        timeout: "120 seconds",
-        label: "nuxt dev SSR home page",
-      });
-
-      // The SSR page reads `event.context.cloudflare.env.TEST_BINDING` —
-      // the dev platform bridge reconstructs the runtime contract over
-      // the cloudflare-runtime platform proxy.
-      yield* expectUrlContains(`${site.url!}/`, `binding:${bindingMarker}`, {
-        timeout: "60 seconds",
-        label: "nuxt dev SSR page with event.context.cloudflare.env binding",
-      });
-
-      // API route through the same contract.
-      yield* expectUrlContains(`${site.url!}/api/hello`, "api-route-ok", {
-        timeout: "60 seconds",
-        label: "nuxt dev API route",
-      });
-
-      // KV binding round-trip against the local simulator, through the
-      // platform-proxy bridge (nitro dev worker thread → host workerd).
-      const put = yield* putJsonReady<{ put: boolean }>(
-        `${site.url!}/api/kv?key=dev-key&value=dev-value`,
-      );
-      expect(put.put).toBe(true);
-      const got = yield* fetchJsonReady<{ value: string | null }>(
-        `${site.url!}/api/kv?key=dev-key`,
-      );
-      expect(got.value).toBe("dev-value");
-
-      // ── HMR: edit an API route in place. The stack is NOT re-applied —
-      // nitro's dev rebuild must pick the change up and serve it through
-      // the same alchemy proxy ─────────────────────────────────────────
-      const helloPath = path.join(rootDir, "server/api/hello.ts");
-      const hello = yield* fs.readFileString(helloPath);
-      yield* fs.writeFileString(
-        helloPath,
-        hello.replace('marker: "api-route-ok"', 'marker: "api-route-v2"'),
-      );
-
-      // Bounded poll until nitro's dev rebuild serves the new marker.
-      yield* expectUrlContains(`${site.url!}/api/hello`, "api-route-v2", {
-        timeout: "90 seconds",
-        label: "nuxt dev API route after HMR edit",
-      });
-
-      // The binding bridge survived the dev-server reload: the KV binding
-      // still round-trips (old key readable, new write lands).
-      const stillThere = yield* fetchJsonReady<{ value: string | null }>(
-        `${site.url!}/api/kv?key=dev-key`,
-      );
-      expect(stillThere.value).toBe("dev-value");
-      const put2 = yield* putJsonReady<{ put: boolean }>(
-        `${site.url!}/api/kv?key=post-hmr-key&value=post-hmr-value`,
-      );
-      expect(put2.put).toBe(true);
-      const got2 = yield* fetchJsonReady<{ value: string | null }>(
-        `${site.url!}/api/kv?key=post-hmr-key`,
-      );
-      expect(got2.value).toBe("post-hmr-value");
-
-      yield* stack.destroy();
-    }).pipe(logLevel),
-  { timeout: 300_000 },
-);
-
-/**
- * `Alchemy.remote()` opts the KV namespace OUT of local emulation: even
- * under `alchemy dev` the namespace is created on real Cloudflare and the
- * dev server's binding proxies to it remotely. Out-of-band reads through
- * the cloud API prove the write landed in the real namespace, and destroy
- * (with the state row stamped live) deletes it from the cloud.
- *
- * The dev platform proxy is hosted in the sidecar's runtime stack
- * (`DevContext.runtimeContext` threaded through the framework dev bridge),
- * which includes remote-bindings support — the proxy's internal layer is
- * local-only by design.
- */
-test.provider(
-  "Nuxt dev: Alchemy.remote() KV namespace runs live behind the dev server",
-  (stack) =>
-    Effect.gen(function* () {
-      yield* stack.destroy();
-
-      const rootDir = yield* cloneFixture(fixtureDir, {
-        prefix: "alchemy-nuxt-dev-remote-",
-        tempRoot,
-        entries: fixtureEntries,
-      });
-
-      const deployed = yield* stack.deploy(
-        Effect.gen(function* () {
-          const siteKv = yield* Cloudflare.KV.Namespace("NuxtDevRemoteKV").pipe(
-            Alchemy.remote(),
-          );
-          const site = yield* Cloudflare.Website.Nuxt("NuxtRemoteKvLocal", {
-            rootDir,
-            dev: { port: 0 },
-            memo: { include: memoInclude },
-            env: {
-              TEST_BINDING: "nuxt-dev-remote-marker",
-              SITE_KV: siteKv,
-            },
-          });
-          return { site, siteKv };
-        }),
-      );
-      const site = deployed.site;
-
-      // The site is served locally, but the remote() namespace is REAL —
-      // a live cloud id, not a `dev:` fabrication.
-      expect(site.url).toMatch(/^http:\/\/localhost:\d+/);
-      expect(deployed.siteKv.namespaceId).toBeDefined();
-      expect(deployed.siteKv.namespaceId).not.toMatch(/^dev:/);
-
-      // Write through the dev server's remote-proxied binding.
-      const put = yield* putJsonReady<{ put: boolean }>(
-        `${site.url!}/api/kv?key=remote-key&value=remote-value`,
-      );
-      expect(put.put).toBe(true);
-      const got = yield* fetchJsonReady<{ value: string | null }>(
-        `${site.url!}/api/kv?key=remote-key`,
-      );
-      expect(got.value).toBe("remote-value");
-
-      // Out-of-band: the write is visible through the cloud KV API — the
-      // remote-proxied binding really hit the live namespace.
-      const { accountId } = yield* yield* CloudflareEnvironment;
-      const observed = yield* kv
-        .getNamespaceValue({
-          accountId,
-          namespaceId: deployed.siteKv.namespaceId,
-          keyName: "remote-key",
-        })
-        .pipe(
-          Effect.retry({
-            while: (e): boolean => e._tag === "KeyNotFound",
-            schedule: Schedule.exponential("1 second"),
-            times: 8,
+        const deployed = yield* stack.deploy(
+          Effect.gen(function* () {
+            const siteKv = yield* Cloudflare.KV.Namespace("NuxtDevKV");
+            const site = yield* Cloudflare.Website.Nuxt("NuxtLocal", {
+              rootDir,
+              dev: { port: 0 },
+              memo: { include: memoInclude },
+              env: {
+                TEST_BINDING: bindingMarker,
+                SITE_KV: siteKv,
+              },
+            });
+            return { site, siteKv };
           }),
-          Effect.flatMap((res) =>
-            Effect.tryPromise(() =>
-              new Response(
-                Stream.toReadableStream(res.body) as BodyInit,
-              ).text(),
+        );
+        const site = deployed.site;
+
+        // Local identity: the url points at the alchemy dev proxy — no
+        // cloud Worker exists — and the KV namespace is emulated (a `dev:`
+        // id, proof no cloud API call ran).
+        expect(site.url).toBeDefined();
+        expect(site.url).toMatch(/^http:\/\/localhost:\d+/);
+        expect(isLocalId(deployed.siteKv.namespaceId)).toBe(true);
+
+        // SSR page rendered by nitro's dev server behind the proxy.
+        yield* expectUrlContains(`${site.url!}/`, "NUXT_PAGE_MARKER", {
+          timeout: "120 seconds",
+          label: "nuxt dev SSR home page",
+        });
+
+        // The SSR page reads `event.context.cloudflare.env.TEST_BINDING` —
+        // the dev platform bridge reconstructs the runtime contract over
+        // the cloudflare-runtime platform proxy.
+        yield* expectUrlContains(`${site.url!}/`, `binding:${bindingMarker}`, {
+          timeout: "60 seconds",
+          label: "nuxt dev SSR page with event.context.cloudflare.env binding",
+        });
+
+        // API route through the same contract.
+        yield* expectUrlContains(`${site.url!}/api/hello`, "api-route-ok", {
+          timeout: "60 seconds",
+          label: "nuxt dev API route",
+        });
+
+        // KV binding round-trip against the local simulator, through the
+        // platform-proxy bridge (nitro dev worker thread → host workerd).
+        const put = yield* putJsonReady<{ put: boolean }>(
+          `${site.url!}/api/kv?key=dev-key&value=dev-value`,
+        );
+        expect(put.put).toBe(true);
+        const got = yield* fetchJsonReady<{ value: string | null }>(
+          `${site.url!}/api/kv?key=dev-key`,
+        );
+        expect(got.value).toBe("dev-value");
+
+        // ── HMR: edit an API route in place. The stack is NOT re-applied —
+        // nitro's dev rebuild must pick the change up and serve it through
+        // the same alchemy proxy ─────────────────────────────────────────
+        const helloPath = path.join(rootDir, "server/api/hello.ts");
+        const hello = yield* fs.readFileString(helloPath);
+        yield* fs.writeFileString(
+          helloPath,
+          hello.replace('marker: "api-route-ok"', 'marker: "api-route-v2"'),
+        );
+
+        // Bounded poll until nitro's dev rebuild serves the new marker.
+        yield* expectUrlContains(`${site.url!}/api/hello`, "api-route-v2", {
+          timeout: "90 seconds",
+          label: "nuxt dev API route after HMR edit",
+        });
+
+        // The binding bridge survived the dev-server reload: the KV binding
+        // still round-trips (old key readable, new write lands).
+        const stillThere = yield* fetchJsonReady<{ value: string | null }>(
+          `${site.url!}/api/kv?key=dev-key`,
+        );
+        expect(stillThere.value).toBe("dev-value");
+        const put2 = yield* putJsonReady<{ put: boolean }>(
+          `${site.url!}/api/kv?key=post-hmr-key&value=post-hmr-value`,
+        );
+        expect(put2.put).toBe(true);
+        const got2 = yield* fetchJsonReady<{ value: string | null }>(
+          `${site.url!}/api/kv?key=post-hmr-key`,
+        );
+        expect(got2.value).toBe("post-hmr-value");
+
+        yield* stack.destroy();
+      }).pipe(logLevel),
+    { timeout: 300_000 },
+  );
+
+  /**
+   * `Alchemy.remote()` opts the KV namespace OUT of local emulation: even
+   * under `alchemy dev` the namespace is created on real Cloudflare and the
+   * dev server's binding proxies to it remotely. Out-of-band reads through
+   * the cloud API prove the write landed in the real namespace, and destroy
+   * (with the state row stamped live) deletes it from the cloud.
+   *
+   * The dev platform proxy is hosted in the sidecar's runtime stack
+   * (`DevContext.runtimeContext` threaded through the framework dev bridge),
+   * which includes remote-bindings support — the proxy's internal layer is
+   * local-only by design.
+   */
+  test.provider(
+    "Nuxt dev: Alchemy.remote() KV namespace runs live behind the dev server",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const rootDir = yield* cloneFixture(fixtureDir, {
+          prefix: "alchemy-nuxt-dev-remote-",
+          tempRoot,
+          entries: fixtureEntries,
+        });
+
+        const deployed = yield* stack.deploy(
+          Effect.gen(function* () {
+            const siteKv = yield* Cloudflare.KV.Namespace(
+              "NuxtDevRemoteKV",
+            ).pipe(Alchemy.remote());
+            const site = yield* Cloudflare.Website.Nuxt("NuxtRemoteKvLocal", {
+              rootDir,
+              dev: { port: 0 },
+              memo: { include: memoInclude },
+              env: {
+                TEST_BINDING: "nuxt-dev-remote-marker",
+                SITE_KV: siteKv,
+              },
+            });
+            return { site, siteKv };
+          }),
+        );
+        const site = deployed.site;
+
+        // The site is served locally, but the remote() namespace is REAL —
+        // a live cloud id, not a `dev:` fabrication.
+        expect(site.url).toMatch(/^http:\/\/localhost:\d+/);
+        expect(deployed.siteKv.namespaceId).toBeDefined();
+        expect(deployed.siteKv.namespaceId).not.toMatch(/^dev:/);
+
+        // Write through the dev server's remote-proxied binding.
+        const put = yield* putJsonReady<{ put: boolean }>(
+          `${site.url!}/api/kv?key=remote-key&value=remote-value`,
+        );
+        expect(put.put).toBe(true);
+        const got = yield* fetchJsonReady<{ value: string | null }>(
+          `${site.url!}/api/kv?key=remote-key`,
+        );
+        expect(got.value).toBe("remote-value");
+
+        // Out-of-band: the write is visible through the cloud KV API — the
+        // remote-proxied binding really hit the live namespace.
+        const { accountId } = yield* yield* CloudflareEnvironment;
+        const observed = yield* kv
+          .getNamespaceValue({
+            accountId,
+            namespaceId: deployed.siteKv.namespaceId,
+            keyName: "remote-key",
+          })
+          .pipe(
+            Effect.retry({
+              while: (e): boolean => e._tag === "KeyNotFound",
+              schedule: Schedule.exponential("1 second"),
+              times: 8,
+            }),
+            Effect.flatMap((res) =>
+              Effect.tryPromise(() =>
+                new Response(
+                  Stream.toReadableStream(res.body) as BodyInit,
+                ).text(),
+              ),
             ),
-          ),
-        );
-      expect(observed).toBe("remote-value");
+          );
+        expect(observed).toBe("remote-value");
 
-      yield* stack.destroy();
+        yield* stack.destroy();
 
-      // The live namespace was deleted from the cloud on destroy (its
-      // state row is stamped live, so the live provider handles the
-      // delete even in a dev run).
-      const gone = yield* kv
-        .getNamespace({
-          accountId,
-          namespaceId: deployed.siteKv.namespaceId,
-        })
-        .pipe(
-          Effect.as(false),
-          Effect.catchTag("NamespaceNotFound", () => Effect.succeed(true)),
-        );
-      expect(gone).toBe(true);
-    }).pipe(logLevel),
-  { timeout: 300_000 },
-);
+        // The live namespace was deleted from the cloud on destroy (its
+        // state row is stamped live, so the live provider handles the
+        // delete even in a dev run).
+        const gone = yield* kv
+          .getNamespace({
+            accountId,
+            namespaceId: deployed.siteKv.namespaceId,
+          })
+          .pipe(
+            Effect.as(false),
+            Effect.catchTag("NamespaceNotFound", () => Effect.succeed(true)),
+          );
+        expect(gone).toBe(true);
+      }).pipe(logLevel),
+    { timeout: 300_000 },
+  );
+});
 
 /** GET `url` until it answers 200 with a JSON body. */
 const fetchJsonReady = <T>(url: string) =>

--- a/packages/alchemy/test/Cloudflare/Website/Nuxt.test.ts
+++ b/packages/alchemy/test/Cloudflare/Website/Nuxt.test.ts
@@ -2,7 +2,7 @@ import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
 import * as Cloudflare from "@/Cloudflare/index.ts";
 import * as Test from "@/Test/Alchemy";
 import * as kv from "@distilled.cloud/cloudflare/kv";
-import { expect } from "alchemy-test";
+import { describe, expect } from "alchemy-test";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
@@ -102,272 +102,277 @@ const readNamespaceValue = Effect.fn(function* (options: {
   );
 });
 
-test.provider(
-  "Nuxt: deploys SSR + bindings + static assets and memoizes unchanged rebuilds",
-  (stack) =>
-    Effect.gen(function* () {
-      const { accountId } = yield* yield* CloudflareEnvironment;
-      const fs = yield* FileSystem.FileSystem;
-      const path = yield* Path.Path;
+// Tests are independent (per-test scratch stacks, private fixture clones),
+// so run them concurrently; suites are sequential by default.
+describe.concurrent("Nuxt", () => {
+  test.provider(
+    "Nuxt: deploys SSR + bindings + static assets and memoizes unchanged rebuilds",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
 
-      yield* stack.destroy();
+        yield* stack.destroy();
 
-      const rootDir = yield* cloneFixture(fixtureDir, {
-        prefix: "alchemy-nuxt-",
-        tempRoot,
-        entries: fixtureEntries,
-      });
+        const rootDir = yield* cloneFixture(fixtureDir, {
+          prefix: "alchemy-nuxt-",
+          tempRoot,
+          entries: fixtureEntries,
+        });
 
-      const bindingMarker = "nuxt-binding-marker";
+        const bindingMarker = "nuxt-binding-marker";
 
-      const deploy = () =>
-        stack.deploy(
+        const deploy = () =>
+          stack.deploy(
+            Effect.gen(function* () {
+              const siteKv = yield* Cloudflare.KV.Namespace("SiteKV");
+              const site = yield* Cloudflare.Website.Nuxt("NuxtSite", {
+                ...nuxtProps(rootDir),
+                env: {
+                  TEST_BINDING: bindingMarker,
+                  SITE_KV: siteKv,
+                },
+              });
+              return { site, siteKv };
+            }),
+          );
+
+        const { site: site1, siteKv } = yield* deploy();
+
+        expect(site1.url).toBeDefined();
+        expect(site1.hash?.input).toBeDefined();
+        yield* expectWorkerExists(site1.workerName, accountId);
+
+        // SSR page: rendered by the Worker at request time.
+        yield* expectUrlContains(`${site1.url!}/`, "NUXT_PAGE_MARKER", {
+          timeout: "120 seconds",
+          label: "SSR home page",
+        });
+
+        // The SSR page reads `event.context.cloudflare.env.TEST_BINDING` —
+        // proves bindings reach nitro's cloudflare_module runtime contract.
+        yield* expectUrlContains(`${site1.url!}/`, `binding:${bindingMarker}`, {
+          timeout: "60 seconds",
+          label: "SSR page with event.context.cloudflare.env binding",
+        });
+
+        // The fixture's own nuxt.config.ts loaded natively — its
+        // `runtimeConfig.public.fixtureMarker` renders on the page.
+        yield* expectUrlContains(
+          `${site1.url!}/`,
+          "config:nuxt-user-config-loaded",
+          {
+            timeout: "60 seconds",
+            label: "user nuxt.config.ts applied",
+          },
+        );
+
+        // API route: reads the binding + waitUntil from the runtime contract.
+        const hello = yield* fetchJsonReady<{
+          marker: string;
+          binding: string | null;
+          hasWaitUntil: boolean;
+        }>(`${site1.url!}/api/hello`);
+        expect(hello.marker).toBe("api-route-ok");
+        expect(hello.binding).toBe(bindingMarker);
+        expect(hello.hasWaitUntil).toBe(true);
+
+        // POST route: the JSON body flows through h3's readBody and comes
+        // back verbatim, with the binding visible on a non-GET route.
+        const echoPayload = { message: "hello-from-post", n: 42 };
+        const echo = yield* postJsonReady<{
+          method: string;
+          echoed: { message: string; n: number };
+          binding: string | null;
+        }>(`${site1.url!}/api/echo`, echoPayload);
+        expect(echo.method).toBe("POST");
+        expect(echo.echoed).toEqual(echoPayload);
+        expect(echo.binding).toBe(bindingMarker);
+
+        // KV binding: the worker's PUT lands in the real namespace and the
+        // worker's GET reads it back through the native binding.
+        const kvKey = "nuxt-live-key";
+        const kvValue = "nuxt-live-value";
+        expect(siteKv.namespaceId).toBeDefined();
+        const put = yield* putJsonReady<{ put: boolean; key: string }>(
+          `${site1.url!}/api/kv?key=${kvKey}&value=${kvValue}`,
+        );
+        expect(put.put).toBe(true);
+        const got = yield* fetchJsonReady<{
+          key: string;
+          value: string | null;
+        }>(`${site1.url!}/api/kv?key=${kvKey}`);
+        expect(got.value).toBe(kvValue);
+
+        // Out-of-band: the write is visible through the cloud KV API — the
+        // binding really targeted the namespace this stack provisioned.
+        const observed = yield* readNamespaceValue({
+          accountId,
+          namespaceId: siteKv.namespaceId,
+          keyName: kvKey,
+        });
+        expect(observed).toBe(kvValue);
+
+        // Static asset from `public/`.
+        yield* expectUrlContains(`${site1.url!}/robots.txt`, "User-agent", {
+          timeout: "60 seconds",
+          label: "static asset",
+        });
+
+        // Route-rule prerendered page, served from assets.
+        yield* expectUrlContains(
+          `${site1.url!}/prerendered`,
+          "this-page-is-prerendered",
+          {
+            timeout: "60 seconds",
+            label: "prerendered page",
+          },
+        );
+
+        // ── deploy 2: no changes ⇒ the rebuild-free input hash matches and
+        // the deploy short-circuits without building ─────────────────────────
+        const { site: site2 } = yield* deploy();
+
+        expect(site2.hash?.input).toBeDefined();
+        expect(site2.hash?.input).toEqual(site1.hash?.input);
+        expect(site2.url).toBe(site1.url);
+
+        // ── deploy 3: edit a page ⇒ the input hash changes and the new
+        // content deploys. The edited marker is asserted on the *dynamic*
+        // page (worker-rendered per request) — a changed static asset at the
+        // same URL can stay stale at a PoP far longer than a worker-version
+        // flip ─────────────────────────────────────────────────────────────
+        const indexPath = path.join(rootDir, "app/pages/index.vue");
+        const index = yield* fs.readFileString(indexPath);
+        yield* fs.writeFileString(
+          indexPath,
+          index.replace("NUXT_PAGE_MARKER", "NUXT_PAGE_MARKER_V2"),
+        );
+
+        const { site: site3 } = yield* deploy();
+
+        expect(site3.hash?.input).toBeDefined();
+        expect(site3.hash?.input).not.toEqual(site1.hash?.input);
+        yield* expectUrlContains(`${site3.url!}/`, "NUXT_PAGE_MARKER_V2", {
+          timeout: "180 seconds",
+          label: "SSR page after edit",
+        });
+
+        yield* stack.destroy();
+        yield* waitForWorkerToBeDeleted(site1.workerName, accountId);
+
+        // Destroy must also delete the stack-provisioned KV namespace.
+        yield* waitForNamespaceToBeDeleted(siteKv.namespaceId, accountId);
+      }).pipe(logLevel),
+    { timeout: 600_000 },
+  );
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Custom worker entry (seam: NuxtProps.main → nitro.options.entry)
+  //
+  // `main` points the deploy at the user's own module, which wraps nitro's
+  // emitted cloudflare-module handler (imported from
+  // `nitropack/presets/cloudflare/runtime/cloudflare-module`) and re-exports
+  // the `Counter` Durable Object class — DO classes must live on the
+  // deployed worker for their namespace bindings to resolve. Mirrors
+  // Waku.test.ts's "main deploys a custom worker entry" test.
+  // ─────────────────────────────────────────────────────────────────────
+
+  test.provider(
+    "Nuxt: main deploys a custom worker entry hosting a Durable Object",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+
+        yield* stack.destroy();
+
+        const rootDir = yield* cloneFixture(fixtureDir, {
+          prefix: "alchemy-nuxt-main-",
+          tempRoot,
+          entries: fixtureEntries,
+        });
+
+        const bindingMarker = "nuxt-main-marker";
+
+        const site = yield* stack.deploy(
           Effect.gen(function* () {
-            const siteKv = yield* Cloudflare.KV.Namespace("SiteKV");
-            const site = yield* Cloudflare.Website.Nuxt("NuxtSite", {
+            return yield* Cloudflare.Website.Nuxt("NuxtMainSite", {
               ...nuxtProps(rootDir),
+              // The user's own worker entry: wraps nitro's handler and
+              // exports the Counter DO.
+              main: "worker-entry.ts",
               env: {
                 TEST_BINDING: bindingMarker,
-                SITE_KV: siteKv,
+                COUNTER: Cloudflare.DurableObject("Counter", {
+                  className: "Counter",
+                }),
               },
             });
-            return { site, siteKv };
           }),
         );
 
-      const { site: site1, siteKv } = yield* deploy();
+        expect(site.url).toBeDefined();
+        yield* expectWorkerExists(site.workerName, accountId);
 
-      expect(site1.url).toBeDefined();
-      expect(site1.hash?.input).toBeDefined();
-      yield* expectWorkerExists(site1.workerName, accountId);
+        // The DO namespace is bound and state increments ACROSS requests —
+        // instance identity on the deployed worker, through the custom entry.
+        // (POST increments, GET reads — see server/api/counter.ts.)
+        const first = yield* postJsonReady<{ count: number }>(
+          `${site.url!}/api/counter`,
+          {},
+        );
+        const second = yield* postJsonReady<{ count: number }>(
+          `${site.url!}/api/counter`,
+          {},
+        );
+        expect(second.count).toBe(first.count + 1);
 
-      // SSR page: rendered by the Worker at request time.
-      yield* expectUrlContains(`${site1.url!}/`, "NUXT_PAGE_MARKER", {
-        timeout: "120 seconds",
-        label: "SSR home page",
-      });
+        const read = yield* fetchJsonReady<{ count: number }>(
+          `${site.url!}/api/counter`,
+        );
+        expect(read.count).toBe(second.count);
 
-      // The SSR page reads `event.context.cloudflare.env.TEST_BINDING` —
-      // proves bindings reach nitro's cloudflare_module runtime contract.
-      yield* expectUrlContains(`${site1.url!}/`, `binding:${bindingMarker}`, {
-        timeout: "60 seconds",
-        label: "SSR page with event.context.cloudflare.env binding",
-      });
-
-      // The fixture's own nuxt.config.ts loaded natively — its
-      // `runtimeConfig.public.fixtureMarker` renders on the page.
-      yield* expectUrlContains(
-        `${site1.url!}/`,
-        "config:nuxt-user-config-loaded",
-        {
+        // Wrapping nitro's handler keeps every framework route working:
+        // the SSR page still renders (and still reads bindings).
+        yield* expectUrlContains(`${site.url!}/`, "NUXT_PAGE_MARKER", {
+          timeout: "120 seconds",
+          label: "SSR page through the custom entry",
+        });
+        yield* expectUrlContains(`${site.url!}/`, `binding:${bindingMarker}`, {
           timeout: "60 seconds",
-          label: "user nuxt.config.ts applied",
-        },
-      );
+          label: "env binding through the custom entry",
+        });
 
-      // API route: reads the binding + waitUntil from the runtime contract.
-      const hello = yield* fetchJsonReady<{
-        marker: string;
-        binding: string | null;
-        hasWaitUntil: boolean;
-      }>(`${site1.url!}/api/hello`);
-      expect(hello.marker).toBe("api-route-ok");
-      expect(hello.binding).toBe(bindingMarker);
-      expect(hello.hasWaitUntil).toBe(true);
+        // API route through the wrapped handler.
+        const hello = yield* fetchJsonReady<{
+          marker: string;
+          binding: string | null;
+        }>(`${site.url!}/api/hello`);
+        expect(hello.marker).toBe("api-route-ok");
+        expect(hello.binding).toBe(bindingMarker);
 
-      // POST route: the JSON body flows through h3's readBody and comes
-      // back verbatim, with the binding visible on a non-GET route.
-      const echoPayload = { message: "hello-from-post", n: 42 };
-      const echo = yield* postJsonReady<{
-        method: string;
-        echoed: { message: string; n: number };
-        binding: string | null;
-      }>(`${site1.url!}/api/echo`, echoPayload);
-      expect(echo.method).toBe("POST");
-      expect(echo.echoed).toEqual(echoPayload);
-      expect(echo.binding).toBe(bindingMarker);
-
-      // KV binding: the worker's PUT lands in the real namespace and the
-      // worker's GET reads it back through the native binding.
-      const kvKey = "nuxt-live-key";
-      const kvValue = "nuxt-live-value";
-      expect(siteKv.namespaceId).toBeDefined();
-      const put = yield* putJsonReady<{ put: boolean; key: string }>(
-        `${site1.url!}/api/kv?key=${kvKey}&value=${kvValue}`,
-      );
-      expect(put.put).toBe(true);
-      const got = yield* fetchJsonReady<{ key: string; value: string | null }>(
-        `${site1.url!}/api/kv?key=${kvKey}`,
-      );
-      expect(got.value).toBe(kvValue);
-
-      // Out-of-band: the write is visible through the cloud KV API — the
-      // binding really targeted the namespace this stack provisioned.
-      const observed = yield* readNamespaceValue({
-        accountId,
-        namespaceId: siteKv.namespaceId,
-        keyName: kvKey,
-      });
-      expect(observed).toBe(kvValue);
-
-      // Static asset from `public/`.
-      yield* expectUrlContains(`${site1.url!}/robots.txt`, "User-agent", {
-        timeout: "60 seconds",
-        label: "static asset",
-      });
-
-      // Route-rule prerendered page, served from assets.
-      yield* expectUrlContains(
-        `${site1.url!}/prerendered`,
-        "this-page-is-prerendered",
-        {
+        // Static asset + prerendered page still serve from assets alongside
+        // the custom entry.
+        yield* expectUrlContains(`${site.url!}/robots.txt`, "User-agent", {
           timeout: "60 seconds",
-          label: "prerendered page",
-        },
-      );
+          label: "static asset with custom entry",
+        });
+        yield* expectUrlContains(
+          `${site.url!}/prerendered`,
+          "this-page-is-prerendered",
+          {
+            timeout: "60 seconds",
+            label: "prerendered page with custom entry",
+          },
+        );
 
-      // ── deploy 2: no changes ⇒ the rebuild-free input hash matches and
-      // the deploy short-circuits without building ─────────────────────────
-      const { site: site2 } = yield* deploy();
-
-      expect(site2.hash?.input).toBeDefined();
-      expect(site2.hash?.input).toEqual(site1.hash?.input);
-      expect(site2.url).toBe(site1.url);
-
-      // ── deploy 3: edit a page ⇒ the input hash changes and the new
-      // content deploys. The edited marker is asserted on the *dynamic*
-      // page (worker-rendered per request) — a changed static asset at the
-      // same URL can stay stale at a PoP far longer than a worker-version
-      // flip ─────────────────────────────────────────────────────────────
-      const indexPath = path.join(rootDir, "app/pages/index.vue");
-      const index = yield* fs.readFileString(indexPath);
-      yield* fs.writeFileString(
-        indexPath,
-        index.replace("NUXT_PAGE_MARKER", "NUXT_PAGE_MARKER_V2"),
-      );
-
-      const { site: site3 } = yield* deploy();
-
-      expect(site3.hash?.input).toBeDefined();
-      expect(site3.hash?.input).not.toEqual(site1.hash?.input);
-      yield* expectUrlContains(`${site3.url!}/`, "NUXT_PAGE_MARKER_V2", {
-        timeout: "180 seconds",
-        label: "SSR page after edit",
-      });
-
-      yield* stack.destroy();
-      yield* waitForWorkerToBeDeleted(site1.workerName, accountId);
-
-      // Destroy must also delete the stack-provisioned KV namespace.
-      yield* waitForNamespaceToBeDeleted(siteKv.namespaceId, accountId);
-    }).pipe(logLevel),
-  { timeout: 600_000 },
-);
-
-// ─────────────────────────────────────────────────────────────────────
-// Custom worker entry (seam: NuxtProps.main → nitro.options.entry)
-//
-// `main` points the deploy at the user's own module, which wraps nitro's
-// emitted cloudflare-module handler (imported from
-// `nitropack/presets/cloudflare/runtime/cloudflare-module`) and re-exports
-// the `Counter` Durable Object class — DO classes must live on the
-// deployed worker for their namespace bindings to resolve. Mirrors
-// Waku.test.ts's "main deploys a custom worker entry" test.
-// ─────────────────────────────────────────────────────────────────────
-
-test.provider(
-  "Nuxt: main deploys a custom worker entry hosting a Durable Object",
-  (stack) =>
-    Effect.gen(function* () {
-      const { accountId } = yield* yield* CloudflareEnvironment;
-
-      yield* stack.destroy();
-
-      const rootDir = yield* cloneFixture(fixtureDir, {
-        prefix: "alchemy-nuxt-main-",
-        tempRoot,
-        entries: fixtureEntries,
-      });
-
-      const bindingMarker = "nuxt-main-marker";
-
-      const site = yield* stack.deploy(
-        Effect.gen(function* () {
-          return yield* Cloudflare.Website.Nuxt("NuxtMainSite", {
-            ...nuxtProps(rootDir),
-            // The user's own worker entry: wraps nitro's handler and
-            // exports the Counter DO.
-            main: "worker-entry.ts",
-            env: {
-              TEST_BINDING: bindingMarker,
-              COUNTER: Cloudflare.DurableObject("Counter", {
-                className: "Counter",
-              }),
-            },
-          });
-        }),
-      );
-
-      expect(site.url).toBeDefined();
-      yield* expectWorkerExists(site.workerName, accountId);
-
-      // The DO namespace is bound and state increments ACROSS requests —
-      // instance identity on the deployed worker, through the custom entry.
-      // (POST increments, GET reads — see server/api/counter.ts.)
-      const first = yield* postJsonReady<{ count: number }>(
-        `${site.url!}/api/counter`,
-        {},
-      );
-      const second = yield* postJsonReady<{ count: number }>(
-        `${site.url!}/api/counter`,
-        {},
-      );
-      expect(second.count).toBe(first.count + 1);
-
-      const read = yield* fetchJsonReady<{ count: number }>(
-        `${site.url!}/api/counter`,
-      );
-      expect(read.count).toBe(second.count);
-
-      // Wrapping nitro's handler keeps every framework route working:
-      // the SSR page still renders (and still reads bindings).
-      yield* expectUrlContains(`${site.url!}/`, "NUXT_PAGE_MARKER", {
-        timeout: "120 seconds",
-        label: "SSR page through the custom entry",
-      });
-      yield* expectUrlContains(`${site.url!}/`, `binding:${bindingMarker}`, {
-        timeout: "60 seconds",
-        label: "env binding through the custom entry",
-      });
-
-      // API route through the wrapped handler.
-      const hello = yield* fetchJsonReady<{
-        marker: string;
-        binding: string | null;
-      }>(`${site.url!}/api/hello`);
-      expect(hello.marker).toBe("api-route-ok");
-      expect(hello.binding).toBe(bindingMarker);
-
-      // Static asset + prerendered page still serve from assets alongside
-      // the custom entry.
-      yield* expectUrlContains(`${site.url!}/robots.txt`, "User-agent", {
-        timeout: "60 seconds",
-        label: "static asset with custom entry",
-      });
-      yield* expectUrlContains(
-        `${site.url!}/prerendered`,
-        "this-page-is-prerendered",
-        {
-          timeout: "60 seconds",
-          label: "prerendered page with custom entry",
-        },
-      );
-
-      yield* stack.destroy();
-      yield* waitForWorkerToBeDeleted(site.workerName, accountId);
-    }).pipe(logLevel),
-  { timeout: 600_000 },
-);
+        yield* stack.destroy();
+        yield* waitForWorkerToBeDeleted(site.workerName, accountId);
+      }).pipe(logLevel),
+    { timeout: 600_000 },
+  );
+});
 
 /**
  * GET `url` until it answers 200 with a JSON body (fresh workers.dev URLs

--- a/packages/alchemy/test/Cloudflare/Website/Octane.local.test.ts
+++ b/packages/alchemy/test/Cloudflare/Website/Octane.local.test.ts
@@ -2,7 +2,7 @@ import * as Cloudflare from "@/Cloudflare/index.ts";
 import * as Alchemy from "@/index.ts";
 import * as Test from "@/Test/Alchemy";
 import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
-import { expect } from "alchemy-test";
+import { describe, expect } from "alchemy-test";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
@@ -43,133 +43,137 @@ const memoInclude = [
   "package.json",
 ];
 
-test.provider(
-  "Octane dev: local dev server renders SSR and picks up edits",
-  (stack) =>
-    Effect.gen(function* () {
-      const fs = yield* FileSystem.FileSystem;
-      const path = yield* Path.Path;
+// Tests are independent (per-test scratch stacks, private fixture clones),
+// so run them concurrently; suites are sequential by default.
+describe.concurrent("Octane dev", () => {
+  test.provider(
+    "Octane dev: local dev server renders SSR and picks up edits",
+    (stack) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
 
-      yield* stack.destroy();
+        yield* stack.destroy();
 
-      const rootDir = yield* cloneFixture(fixtureDir, {
-        prefix: "alchemy-octane-dev-",
-        tempRoot,
-        entries: fixtureEntries,
-      });
+        const rootDir = yield* cloneFixture(fixtureDir, {
+          prefix: "alchemy-octane-dev-",
+          tempRoot,
+          entries: fixtureEntries,
+        });
 
-      const site = yield* stack.deploy(
-        Cloudflare.Website.Octane("OctaneLocal", {
-          rootDir,
-          dev: { port: 0 },
-          memo: { include: memoInclude },
-        }),
-      );
+        const site = yield* stack.deploy(
+          Cloudflare.Website.Octane("OctaneLocal", {
+            rootDir,
+            dev: { port: 0 },
+            memo: { include: memoInclude },
+          }),
+        );
 
-      // Local identity: the url points at the alchemy dev proxy — no
-      // cloud Worker exists.
-      expect(site.url).toBeDefined();
-      expect(site.url).toMatch(/^http:\/\/localhost:\d+/);
+        // Local identity: the url points at the alchemy dev proxy — no
+        // cloud Worker exists.
+        expect(site.url).toBeDefined();
+        expect(site.url).toMatch(/^http:\/\/localhost:\d+/);
 
-      // SSR page rendered by Octane's dev middleware behind the proxy.
-      yield* expectUrlContains(`${site.url!}/`, "OCTANE_PAGE_MARKER", {
-        timeout: "120 seconds",
-        label: "octane dev SSR home page",
-      });
+        // SSR page rendered by Octane's dev middleware behind the proxy.
+        yield* expectUrlContains(`${site.url!}/`, "OCTANE_PAGE_MARKER", {
+          timeout: "120 seconds",
+          label: "octane dev SSR home page",
+        });
 
-      // Server route through the same middleware. Octane's dev server
-      // supplies no `context.platform` (upstream limitation), so the
-      // handler degrades to a null binding — the route itself must work.
-      const hello = yield* fetchJsonReady<{
-        marker: string;
-        binding: string | null;
-        hasWaitUntil: boolean;
-      }>(`${site.url!}/api/hello`);
-      expect(hello.marker).toBe("api-route-ok");
-      expect(hello.binding).toBeNull();
-      expect(hello.hasWaitUntil).toBe(false);
+        // Server route through the same middleware. Octane's dev server
+        // supplies no `context.platform` (upstream limitation), so the
+        // handler degrades to a null binding — the route itself must work.
+        const hello = yield* fetchJsonReady<{
+          marker: string;
+          binding: string | null;
+          hasWaitUntil: boolean;
+        }>(`${site.url!}/api/hello`);
+        expect(hello.marker).toBe("api-route-ok");
+        expect(hello.binding).toBeNull();
+        expect(hello.hasWaitUntil).toBe(false);
 
-      // ── HMR: edit the page in place. The stack is NOT re-applied — the
-      // dev server must pick the change up and serve it through the same
-      // alchemy proxy ──────────────────────────────────────────────────────
-      const appPath = path.join(rootDir, "src/App.tsx");
-      const app = yield* fs.readFileString(appPath);
-      yield* fs.writeFileString(
-        appPath,
-        app.replace("OCTANE_PAGE_MARKER", "OCTANE_PAGE_MARKER_V2"),
-      );
+        // ── HMR: edit the page in place. The stack is NOT re-applied — the
+        // dev server must pick the change up and serve it through the same
+        // alchemy proxy ──────────────────────────────────────────────────────
+        const appPath = path.join(rootDir, "src/App.tsx");
+        const app = yield* fs.readFileString(appPath);
+        yield* fs.writeFileString(
+          appPath,
+          app.replace("OCTANE_PAGE_MARKER", "OCTANE_PAGE_MARKER_V2"),
+        );
 
-      yield* expectUrlContains(`${site.url!}/`, "OCTANE_PAGE_MARKER_V2", {
-        timeout: "90 seconds",
-        label: "octane dev SSR page after edit",
-      });
+        yield* expectUrlContains(`${site.url!}/`, "OCTANE_PAGE_MARKER_V2", {
+          timeout: "90 seconds",
+          label: "octane dev SSR page after edit",
+        });
 
-      yield* stack.destroy();
-    }).pipe(logLevel),
-  { timeout: 300_000 },
-);
+        yield* stack.destroy();
+      }).pipe(logLevel),
+    { timeout: 300_000 },
+  );
 
-/**
- * `Alchemy.remote()` opts the whole site OUT of local emulation: even under
- * `alchemy dev` the Worker builds and deploys to real Cloudflare (pinning
- * the stamped-mode delete path on destroy). This is the supported way to
- * exercise bindings during dev while Octane's dev middleware cannot serve
- * `context.platform`.
- */
-test.provider(
-  "Octane dev: Alchemy.remote() deploys the real Worker",
-  (stack) =>
-    Effect.gen(function* () {
-      const { accountId } = yield* yield* CloudflareEnvironment;
+  /**
+   * `Alchemy.remote()` opts the whole site OUT of local emulation: even under
+   * `alchemy dev` the Worker builds and deploys to real Cloudflare (pinning
+   * the stamped-mode delete path on destroy). This is the supported way to
+   * exercise bindings during dev while Octane's dev middleware cannot serve
+   * `context.platform`.
+   */
+  test.provider(
+    "Octane dev: Alchemy.remote() deploys the real Worker",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
 
-      yield* stack.destroy();
+        yield* stack.destroy();
 
-      const rootDir = yield* cloneFixture(fixtureDir, {
-        prefix: "alchemy-octane-dev-remote-",
-        tempRoot,
-        entries: fixtureEntries,
-      });
+        const rootDir = yield* cloneFixture(fixtureDir, {
+          prefix: "alchemy-octane-dev-remote-",
+          tempRoot,
+          entries: fixtureEntries,
+        });
 
-      const bindingMarker = "octane-dev-remote-marker";
+        const bindingMarker = "octane-dev-remote-marker";
 
-      const site = yield* stack.deploy(
-        Cloudflare.Website.Octane("OctaneRemoteSite", {
-          rootDir,
-          workersDev: { enabled: true, previewsEnabled: true },
-          memo: { include: memoInclude },
-          env: {
-            TEST_BINDING: bindingMarker,
-          },
-        }).pipe(Alchemy.remote()),
-      );
+        const site = yield* stack.deploy(
+          Cloudflare.Website.Octane("OctaneRemoteSite", {
+            rootDir,
+            workersDev: { enabled: true, previewsEnabled: true },
+            memo: { include: memoInclude },
+            env: {
+              TEST_BINDING: bindingMarker,
+            },
+          }).pipe(Alchemy.remote()),
+        );
 
-      // A real deployment: workers.dev URL, not the local proxy.
-      expect(site.url).toBeDefined();
-      expect(site.url).not.toMatch(/^http:\/\/localhost/);
+        // A real deployment: workers.dev URL, not the local proxy.
+        expect(site.url).toBeDefined();
+        expect(site.url).not.toMatch(/^http:\/\/localhost/);
 
-      yield* expectUrlContains(`${site.url!}/`, "OCTANE_PAGE_MARKER", {
-        timeout: "120 seconds",
-        label: "remote() SSR home page in dev mode",
-      });
+        yield* expectUrlContains(`${site.url!}/`, "OCTANE_PAGE_MARKER", {
+          timeout: "120 seconds",
+          label: "remote() SSR home page in dev mode",
+        });
 
-      // The deployed worker carries the real binding through
-      // `context.platform.env`.
-      const hello = yield* fetchJsonReady<{
-        marker: string;
-        binding: string | null;
-        hasWaitUntil: boolean;
-      }>(`${site.url!}/api/hello`);
-      expect(hello.marker).toBe("api-route-ok");
-      expect(hello.binding).toBe(bindingMarker);
-      expect(hello.hasWaitUntil).toBe(true);
+        // The deployed worker carries the real binding through
+        // `context.platform.env`.
+        const hello = yield* fetchJsonReady<{
+          marker: string;
+          binding: string | null;
+          hasWaitUntil: boolean;
+        }>(`${site.url!}/api/hello`);
+        expect(hello.marker).toBe("api-route-ok");
+        expect(hello.binding).toBe(bindingMarker);
+        expect(hello.hasWaitUntil).toBe(true);
 
-      yield* stack.destroy();
+        yield* stack.destroy();
 
-      // The stamped-live row deletes the real Worker even in a dev run.
-      yield* waitForWorkerToBeDeleted(site.workerName, accountId);
-    }).pipe(logLevel),
-  { timeout: 600_000 },
-);
+        // The stamped-live row deletes the real Worker even in a dev run.
+        yield* waitForWorkerToBeDeleted(site.workerName, accountId);
+      }).pipe(logLevel),
+    { timeout: 600_000 },
+  );
+});
 
 /** GET `url` until it answers 200 with a JSON body. */
 const fetchJsonReady = <T>(url: string) =>

--- a/packages/alchemy/test/Cloudflare/Website/Octane.test.ts
+++ b/packages/alchemy/test/Cloudflare/Website/Octane.test.ts
@@ -2,7 +2,7 @@ import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
 import * as Cloudflare from "@/Cloudflare/index.ts";
 import * as Test from "@/Test/Alchemy";
 import * as kv from "@distilled.cloud/cloudflare/kv";
-import { expect } from "alchemy-test";
+import { describe, expect } from "alchemy-test";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
@@ -102,129 +102,134 @@ const readNamespaceValue = Effect.fn(function* (options: {
   );
 });
 
-test.provider(
-  "Octane: deploys SSR + bindings + static assets and memoizes unchanged rebuilds",
-  (stack) =>
-    Effect.gen(function* () {
-      const { accountId } = yield* yield* CloudflareEnvironment;
-      const fs = yield* FileSystem.FileSystem;
-      const path = yield* Path.Path;
+// Tests are independent (per-test scratch stacks, private fixture clones),
+// so run them concurrently; suites are sequential by default.
+describe.concurrent("Octane", () => {
+  test.provider(
+    "Octane: deploys SSR + bindings + static assets and memoizes unchanged rebuilds",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
 
-      yield* stack.destroy();
+        yield* stack.destroy();
 
-      const rootDir = yield* cloneFixture(fixtureDir, {
-        prefix: "alchemy-octane-",
-        tempRoot,
-        entries: fixtureEntries,
-      });
+        const rootDir = yield* cloneFixture(fixtureDir, {
+          prefix: "alchemy-octane-",
+          tempRoot,
+          entries: fixtureEntries,
+        });
 
-      const bindingMarker = "octane-binding-marker";
+        const bindingMarker = "octane-binding-marker";
 
-      const deploy = () =>
-        stack.deploy(
-          Effect.gen(function* () {
-            const siteKv = yield* Cloudflare.KV.Namespace("SiteKV");
-            const site = yield* Cloudflare.Website.Octane("OctaneSite", {
-              ...octaneProps(rootDir),
-              env: {
-                TEST_BINDING: bindingMarker,
-                SITE_KV: siteKv,
-              },
-            });
-            return { site, siteKv };
-          }),
+        const deploy = () =>
+          stack.deploy(
+            Effect.gen(function* () {
+              const siteKv = yield* Cloudflare.KV.Namespace("SiteKV");
+              const site = yield* Cloudflare.Website.Octane("OctaneSite", {
+                ...octaneProps(rootDir),
+                env: {
+                  TEST_BINDING: bindingMarker,
+                  SITE_KV: siteKv,
+                },
+              });
+              return { site, siteKv };
+            }),
+          );
+
+        const { site: site1, siteKv } = yield* deploy();
+
+        expect(site1.url).toBeDefined();
+        expect(site1.hash?.input).toBeDefined();
+        yield* expectWorkerExists(site1.workerName, accountId);
+
+        // SSR page: the adapter-emitted worker renders on asset miss.
+        yield* expectUrlContains(`${site1.url!}/`, "OCTANE_PAGE_MARKER", {
+          timeout: "120 seconds",
+          label: "SSR home page",
+        });
+
+        // Server route: reads `context.platform` — the adapter-forwarded
+        // `{ env, ctx }` pair — proving bindings reach Octane's runtime
+        // contract.
+        const hello = yield* fetchJsonReady<{
+          marker: string;
+          binding: string | null;
+          hasWaitUntil: boolean;
+        }>(`${site1.url!}/api/hello`);
+        expect(hello.marker).toBe("api-route-ok");
+        expect(hello.binding).toBe(bindingMarker);
+        expect(hello.hasWaitUntil).toBe(true);
+
+        // KV binding: the worker's PUT lands in the real namespace and the
+        // worker's GET reads it back through the native binding.
+        const kvKey = "octane-live-key";
+        const kvValue = "octane-live-value";
+        expect(siteKv.namespaceId).toBeDefined();
+        const put = yield* putJsonReady<{ put: boolean; key: string }>(
+          `${site1.url!}/api/kv?key=${kvKey}&value=${kvValue}`,
+        );
+        expect(put.put).toBe(true);
+        const got = yield* fetchJsonReady<{
+          key: string;
+          value: string | null;
+        }>(`${site1.url!}/api/kv?key=${kvKey}`);
+        expect(got.value).toBe(kvValue);
+
+        // Out-of-band: the write is visible through the cloud KV API — the
+        // binding really targeted the namespace this stack provisioned.
+        const observed = yield* readNamespaceValue({
+          accountId,
+          namespaceId: siteKv.namespaceId,
+          keyName: kvKey,
+        });
+        expect(observed).toBe(kvValue);
+
+        // Static asset from `public/`, served asset-first.
+        yield* expectUrlContains(`${site1.url!}/robots.txt`, "User-agent", {
+          timeout: "60 seconds",
+          label: "static asset",
+        });
+
+        // ── deploy 2: no changes ⇒ the rebuild-free input hash matches and
+        // the deploy short-circuits without building ─────────────────────────
+        const { site: site2 } = yield* deploy();
+
+        expect(site2.hash?.input).toBeDefined();
+        expect(site2.hash?.input).toEqual(site1.hash?.input);
+        expect(site2.url).toBe(site1.url);
+
+        // ── deploy 3: edit the page ⇒ the input hash changes and the new
+        // content deploys. The edited marker is asserted on the *dynamic*
+        // SSR page (worker-rendered per request) — a changed static asset at
+        // the same URL can stay stale at a PoP far longer than a
+        // worker-version flip ────────────────────────────────────────────────
+        const appPath = path.join(rootDir, "src/App.tsx");
+        const app = yield* fs.readFileString(appPath);
+        yield* fs.writeFileString(
+          appPath,
+          app.replace("OCTANE_PAGE_MARKER", "OCTANE_PAGE_MARKER_V2"),
         );
 
-      const { site: site1, siteKv } = yield* deploy();
+        const { site: site3 } = yield* deploy();
 
-      expect(site1.url).toBeDefined();
-      expect(site1.hash?.input).toBeDefined();
-      yield* expectWorkerExists(site1.workerName, accountId);
+        expect(site3.hash?.input).toBeDefined();
+        expect(site3.hash?.input).not.toEqual(site1.hash?.input);
+        yield* expectUrlContains(`${site3.url!}/`, "OCTANE_PAGE_MARKER_V2", {
+          timeout: "180 seconds",
+          label: "SSR page after edit",
+        });
 
-      // SSR page: the adapter-emitted worker renders on asset miss.
-      yield* expectUrlContains(`${site1.url!}/`, "OCTANE_PAGE_MARKER", {
-        timeout: "120 seconds",
-        label: "SSR home page",
-      });
+        yield* stack.destroy();
+        yield* waitForWorkerToBeDeleted(site1.workerName, accountId);
 
-      // Server route: reads `context.platform` — the adapter-forwarded
-      // `{ env, ctx }` pair — proving bindings reach Octane's runtime
-      // contract.
-      const hello = yield* fetchJsonReady<{
-        marker: string;
-        binding: string | null;
-        hasWaitUntil: boolean;
-      }>(`${site1.url!}/api/hello`);
-      expect(hello.marker).toBe("api-route-ok");
-      expect(hello.binding).toBe(bindingMarker);
-      expect(hello.hasWaitUntil).toBe(true);
-
-      // KV binding: the worker's PUT lands in the real namespace and the
-      // worker's GET reads it back through the native binding.
-      const kvKey = "octane-live-key";
-      const kvValue = "octane-live-value";
-      expect(siteKv.namespaceId).toBeDefined();
-      const put = yield* putJsonReady<{ put: boolean; key: string }>(
-        `${site1.url!}/api/kv?key=${kvKey}&value=${kvValue}`,
-      );
-      expect(put.put).toBe(true);
-      const got = yield* fetchJsonReady<{ key: string; value: string | null }>(
-        `${site1.url!}/api/kv?key=${kvKey}`,
-      );
-      expect(got.value).toBe(kvValue);
-
-      // Out-of-band: the write is visible through the cloud KV API — the
-      // binding really targeted the namespace this stack provisioned.
-      const observed = yield* readNamespaceValue({
-        accountId,
-        namespaceId: siteKv.namespaceId,
-        keyName: kvKey,
-      });
-      expect(observed).toBe(kvValue);
-
-      // Static asset from `public/`, served asset-first.
-      yield* expectUrlContains(`${site1.url!}/robots.txt`, "User-agent", {
-        timeout: "60 seconds",
-        label: "static asset",
-      });
-
-      // ── deploy 2: no changes ⇒ the rebuild-free input hash matches and
-      // the deploy short-circuits without building ─────────────────────────
-      const { site: site2 } = yield* deploy();
-
-      expect(site2.hash?.input).toBeDefined();
-      expect(site2.hash?.input).toEqual(site1.hash?.input);
-      expect(site2.url).toBe(site1.url);
-
-      // ── deploy 3: edit the page ⇒ the input hash changes and the new
-      // content deploys. The edited marker is asserted on the *dynamic*
-      // SSR page (worker-rendered per request) — a changed static asset at
-      // the same URL can stay stale at a PoP far longer than a
-      // worker-version flip ────────────────────────────────────────────────
-      const appPath = path.join(rootDir, "src/App.tsx");
-      const app = yield* fs.readFileString(appPath);
-      yield* fs.writeFileString(
-        appPath,
-        app.replace("OCTANE_PAGE_MARKER", "OCTANE_PAGE_MARKER_V2"),
-      );
-
-      const { site: site3 } = yield* deploy();
-
-      expect(site3.hash?.input).toBeDefined();
-      expect(site3.hash?.input).not.toEqual(site1.hash?.input);
-      yield* expectUrlContains(`${site3.url!}/`, "OCTANE_PAGE_MARKER_V2", {
-        timeout: "180 seconds",
-        label: "SSR page after edit",
-      });
-
-      yield* stack.destroy();
-      yield* waitForWorkerToBeDeleted(site1.workerName, accountId);
-
-      // Destroy must also delete the stack-provisioned KV namespace.
-      yield* waitForNamespaceToBeDeleted(siteKv.namespaceId, accountId);
-    }).pipe(logLevel),
-  { timeout: 600_000 },
-);
+        // Destroy must also delete the stack-provisioned KV namespace.
+        yield* waitForNamespaceToBeDeleted(siteKv.namespaceId, accountId);
+      }).pipe(logLevel),
+    { timeout: 600_000 },
+  );
+});
 
 /**
  * GET `url` until it answers 200 with a JSON body (fresh workers.dev URLs

--- a/packages/alchemy/test/Cloudflare/Website/StaticSite.test.ts
+++ b/packages/alchemy/test/Cloudflare/Website/StaticSite.test.ts
@@ -31,6 +31,13 @@ const logLevel = Effect.provideService(
 const fixtureDir = pathe.resolve(import.meta.dirname, "staticsite-fixture");
 const workerEntry = pathe.resolve(import.meta.dirname, "fixtures/worker.ts");
 
+// Read back through `Config.string` by the #796 test below. Set at module
+// load (collection time): `ConfigProvider.fromEnv` snapshots `process.env`
+// when the test harness constructs the provider — BEFORE a test body runs —
+// so setting this inside the test only ever satisfied the NEXT attempt
+// (the failure was masked by the runner's default retry).
+process.env.STATICSITE_ENV_TEST = "from-config";
+
 describe.concurrent("StaticSite", () => {
   test.provider(
     "StaticSite: editing a source file republishes the assets in a single deploy",
@@ -751,10 +758,9 @@ describe.concurrent("StaticSite", () => {
           "#!/bin/bash\nmkdir -p dist\necho dep > dist/dep.txt\n",
         );
 
-        yield* Effect.sync(() => {
-          process.env.STATICSITE_ENV_TEST = "from-config";
-        });
-
+        // `STATICSITE_ENV_TEST` is set at module load (see top of file) —
+        // the harness's ConfigProvider snapshots process.env before the
+        // test body runs.
         yield* stack.deploy(
           Effect.gen(function* () {
             const dep = yield* Command.Build("EnvDep", {

--- a/packages/alchemy/test/Cloudflare/Website/SvelteKit.local.test.ts
+++ b/packages/alchemy/test/Cloudflare/Website/SvelteKit.local.test.ts
@@ -4,7 +4,7 @@ import { isLocalId } from "@/Cloudflare/LocalRuntime.ts";
 import * as Alchemy from "@/index.ts";
 import * as Test from "@/Test/Alchemy";
 import * as kv from "@distilled.cloud/cloudflare/kv";
-import { expect } from "alchemy-test";
+import { describe, expect } from "alchemy-test";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
@@ -87,205 +87,210 @@ const fetchJsonReady = <T>(url: string) =>
     );
   });
 
-test.provider(
-  "SvelteKit dev: local dev server renders SSR with platform.env bindings, local KV, and HMR",
-  (stack) =>
-    Effect.gen(function* () {
-      yield* stack.destroy();
+// Concurrent for consistency with the other Website suites; both tests
+// are `exclusive: true` (the kit dev server is cwd-sensitive), so the
+// runner's whole-process lock still serializes them globally.
+describe.concurrent("SvelteKit dev", () => {
+  test.provider(
+    "SvelteKit dev: local dev server renders SSR with platform.env bindings, local KV, and HMR",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
 
-      const rootDir = yield* cloneFixture(fixtureDir, {
-        prefix: "alchemy-sveltekit-dev-",
-        tempRoot,
-        entries: ["package.json", "src", "static"],
-      });
+        const rootDir = yield* cloneFixture(fixtureDir, {
+          prefix: "alchemy-sveltekit-dev-",
+          tempRoot,
+          entries: ["package.json", "src", "static"],
+        });
 
-      const bindingMarker = "sveltekit-dev-binding-marker";
+        const bindingMarker = "sveltekit-dev-binding-marker";
 
-      const { site, siteKv } = yield* stack.deploy(
-        Effect.gen(function* () {
-          // A locally-emulated KV namespace bound into `platform.env` —
-          // no cloud call runs for it in dev.
-          const siteKv = yield* Cloudflare.KV.Namespace("SiteKV");
-          const site = yield* Cloudflare.Website.SvelteKit("SvelteKitLocal", {
-            rootDir,
-            dev: { port: 0 },
-            memo: { include: ["src/**", "static/**", "package.json"] },
-            env: {
-              TEST_BINDING: bindingMarker,
-              SITE_KV: siteKv,
-            },
-          });
-          return { site, siteKv };
-        }),
-      );
-
-      // Local identity: the url points at the alchemy dev proxy — no
-      // cloud Worker exists — and the namespace id carries the `dev:`
-      // marker (proof no cloud call ran for it).
-      expect(site.url).toBeDefined();
-      expect(site.url).toMatch(/^http:\/\/localhost:\d+/);
-      expect(isLocalId(siteKv.namespaceId)).toBe(true);
-      expect(siteKv.namespaceId).toMatch(/^dev:/);
-
-      // SSR route: kit's own Vite dev server (Node SSR), with
-      // `platform.env` served by the cloudflare-runtime platform proxy
-      // and the literal env overlaid.
-      yield* expectUrlContains(`${site.url!}/`, `binding:${bindingMarker}`, {
-        timeout: "120 seconds",
-        label: "sveltekit dev SSR home with platform.env binding",
-      });
-
-      // API endpoint: node:crypto + platform.env through the dev server.
-      yield* expectUrlContains(
-        `${site.url!}/api/hello`,
-        `"binding":"${bindingMarker}"`,
-        {
-          timeout: "60 seconds",
-          label: "sveltekit dev API route",
-        },
-      );
-
-      // Static asset from `static/`.
-      yield* expectUrlContains(`${site.url!}/robots.txt`, "User-agent", {
-        timeout: "60 seconds",
-        label: "sveltekit dev static asset",
-      });
-
-      // ── local KV round-trip: the /api/kv routes write and read
-      // `platform.env.SITE_KV`, backed by the local simulator ─────────────
-      const kvValue = "sveltekit-dev-kv-value";
-      yield* putTextReady(`${site.url!}/api/kv?key=greeting`, kvValue);
-      const kvRead = yield* fetchJsonReady<{ value: string | null }>(
-        `${site.url!}/api/kv?key=greeting`,
-      );
-      expect(kvRead.value).toBe(kvValue);
-
-      // ── HMR: edit the home route in place; kit's dev server hot-reloads
-      // and the dev URL serves the new markup without a redeploy ──────────
-      const fs = yield* FileSystem.FileSystem;
-      const path = yield* Path.Path;
-      const pagePath = path.join(rootDir, "src", "routes", "+page.svelte");
-      const page = yield* fs.readFileString(pagePath);
-      yield* fs.writeFileString(
-        pagePath,
-        page.replace("SvelteKit SSR home", "SvelteKit SSR home v2-marker"),
-      );
-
-      // Bounded poll: expectUrlContains retries with a capped backoff and
-      // a hard total timeout.
-      yield* expectUrlContains(`${site.url!}/`, "v2-marker", {
-        timeout: "90 seconds",
-        label: "sveltekit dev HMR-updated home page",
-      });
-
-      // The KV binding survives the hot reload.
-      const kvReadAfterHmr = yield* fetchJsonReady<{ value: string | null }>(
-        `${site.url!}/api/kv?key=greeting`,
-      );
-      expect(kvReadAfterHmr.value).toBe(kvValue);
-
-      yield* stack.destroy();
-    }).pipe(logLevel),
-  // The kit dev server is cwd-sensitive (same reason the live test is
-  // exclusive): `svelte-kit sync` and the config loader resolve from the
-  // process working directory.
-  { timeout: 300_000, exclusive: true },
-);
-
-/**
- * `Alchemy.remote()` opts the KV namespace OUT of local emulation: even
- * under `alchemy dev` it is created on real Cloudflare and the dev
- * server's `platform.env.SITE_KV` proxies to it remotely. Out-of-band
- * reads through the cloud API prove the dev server's write landed in the
- * real namespace, and destroy deletes it from the cloud (the state row is
- * stamped live).
- */
-test.provider(
-  "SvelteKit dev: Alchemy.remote() KV namespace runs live behind the dev server",
-  (stack) =>
-    Effect.gen(function* () {
-      yield* stack.destroy();
-
-      const rootDir = yield* cloneFixture(fixtureDir, {
-        prefix: "alchemy-sveltekit-dev-remote-",
-        tempRoot,
-        entries: ["package.json", "src", "static"],
-      });
-
-      const { site, siteKv } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const siteKv = yield* Cloudflare.KV.Namespace("RemoteSiteKV").pipe(
-            Alchemy.remote(),
-          );
-          const site = yield* Cloudflare.Website.SvelteKit(
-            "SvelteKitLocalRemoteKV",
-            {
+        const { site, siteKv } = yield* stack.deploy(
+          Effect.gen(function* () {
+            // A locally-emulated KV namespace bound into `platform.env` —
+            // no cloud call runs for it in dev.
+            const siteKv = yield* Cloudflare.KV.Namespace("SiteKV");
+            const site = yield* Cloudflare.Website.SvelteKit("SvelteKitLocal", {
               rootDir,
               dev: { port: 0 },
               memo: { include: ["src/**", "static/**", "package.json"] },
               env: {
-                TEST_BINDING: "sveltekit-dev-remote-marker",
+                TEST_BINDING: bindingMarker,
                 SITE_KV: siteKv,
               },
-            },
-          );
-          return { site, siteKv };
-        }),
-      );
-
-      // The remote() namespace is REAL — a cloud id, not a `dev:` one —
-      // while the site itself still serves from the local dev proxy.
-      expect(site.url).toMatch(/^http:\/\/localhost:\d+/);
-      expect(isLocalId(siteKv.namespaceId)).toBe(false);
-      expect(siteKv.namespaceId).not.toMatch(/^dev:/);
-
-      // Write through the dev server's remote-proxied binding.
-      const kvValue = "sveltekit-dev-remote-kv-value";
-      yield* putTextReady(`${site.url!}/api/kv?key=remote-key`, kvValue);
-      const kvRead = yield* fetchJsonReady<{ value: string | null }>(
-        `${site.url!}/api/kv?key=remote-key`,
-      );
-      expect(kvRead.value).toBe(kvValue);
-
-      // Out-of-band: the write is visible through the cloud API — the
-      // binding really hit the live namespace.
-      const { accountId } = yield* yield* CloudflareEnvironment;
-      const cloudValue = yield* kv
-        .getNamespaceValue({
-          accountId,
-          namespaceId: siteKv.namespaceId,
-          keyName: "remote-key",
-        })
-        .pipe(
-          Effect.flatMap((res) =>
-            Effect.tryPromise(() =>
-              new Response(
-                Stream.toReadableStream(res.body) as BodyInit,
-              ).text(),
-            ),
-          ),
-          Effect.retry({
-            schedule: Schedule.exponential("1 second", 1.5),
-            times: 5,
+            });
+            return { site, siteKv };
           }),
         );
-      expect(cloudValue).toBe(kvValue);
 
-      yield* stack.destroy();
+        // Local identity: the url points at the alchemy dev proxy — no
+        // cloud Worker exists — and the namespace id carries the `dev:`
+        // marker (proof no cloud call ran for it).
+        expect(site.url).toBeDefined();
+        expect(site.url).toMatch(/^http:\/\/localhost:\d+/);
+        expect(isLocalId(siteKv.namespaceId)).toBe(true);
+        expect(siteKv.namespaceId).toMatch(/^dev:/);
 
-      // The live namespace was deleted from the cloud on destroy (its
-      // state row is stamped live, so the live provider handles the
-      // delete even in a dev run).
-      const gone = yield* kv
-        .getNamespace({
-          accountId,
-          namespaceId: siteKv.namespaceId,
-        })
-        .pipe(
-          Effect.as(false),
-          Effect.catchTag("NamespaceNotFound", () => Effect.succeed(true)),
+        // SSR route: kit's own Vite dev server (Node SSR), with
+        // `platform.env` served by the cloudflare-runtime platform proxy
+        // and the literal env overlaid.
+        yield* expectUrlContains(`${site.url!}/`, `binding:${bindingMarker}`, {
+          timeout: "120 seconds",
+          label: "sveltekit dev SSR home with platform.env binding",
+        });
+
+        // API endpoint: node:crypto + platform.env through the dev server.
+        yield* expectUrlContains(
+          `${site.url!}/api/hello`,
+          `"binding":"${bindingMarker}"`,
+          {
+            timeout: "60 seconds",
+            label: "sveltekit dev API route",
+          },
         );
-      expect(gone).toBe(true);
-    }).pipe(logLevel),
-  { timeout: 300_000, exclusive: true },
-);
+
+        // Static asset from `static/`.
+        yield* expectUrlContains(`${site.url!}/robots.txt`, "User-agent", {
+          timeout: "60 seconds",
+          label: "sveltekit dev static asset",
+        });
+
+        // ── local KV round-trip: the /api/kv routes write and read
+        // `platform.env.SITE_KV`, backed by the local simulator ─────────────
+        const kvValue = "sveltekit-dev-kv-value";
+        yield* putTextReady(`${site.url!}/api/kv?key=greeting`, kvValue);
+        const kvRead = yield* fetchJsonReady<{ value: string | null }>(
+          `${site.url!}/api/kv?key=greeting`,
+        );
+        expect(kvRead.value).toBe(kvValue);
+
+        // ── HMR: edit the home route in place; kit's dev server hot-reloads
+        // and the dev URL serves the new markup without a redeploy ──────────
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const pagePath = path.join(rootDir, "src", "routes", "+page.svelte");
+        const page = yield* fs.readFileString(pagePath);
+        yield* fs.writeFileString(
+          pagePath,
+          page.replace("SvelteKit SSR home", "SvelteKit SSR home v2-marker"),
+        );
+
+        // Bounded poll: expectUrlContains retries with a capped backoff and
+        // a hard total timeout.
+        yield* expectUrlContains(`${site.url!}/`, "v2-marker", {
+          timeout: "90 seconds",
+          label: "sveltekit dev HMR-updated home page",
+        });
+
+        // The KV binding survives the hot reload.
+        const kvReadAfterHmr = yield* fetchJsonReady<{ value: string | null }>(
+          `${site.url!}/api/kv?key=greeting`,
+        );
+        expect(kvReadAfterHmr.value).toBe(kvValue);
+
+        yield* stack.destroy();
+      }).pipe(logLevel),
+    // The kit dev server is cwd-sensitive (same reason the live test is
+    // exclusive): `svelte-kit sync` and the config loader resolve from the
+    // process working directory.
+    { timeout: 300_000, exclusive: true },
+  );
+
+  /**
+   * `Alchemy.remote()` opts the KV namespace OUT of local emulation: even
+   * under `alchemy dev` it is created on real Cloudflare and the dev
+   * server's `platform.env.SITE_KV` proxies to it remotely. Out-of-band
+   * reads through the cloud API prove the dev server's write landed in the
+   * real namespace, and destroy deletes it from the cloud (the state row is
+   * stamped live).
+   */
+  test.provider(
+    "SvelteKit dev: Alchemy.remote() KV namespace runs live behind the dev server",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const rootDir = yield* cloneFixture(fixtureDir, {
+          prefix: "alchemy-sveltekit-dev-remote-",
+          tempRoot,
+          entries: ["package.json", "src", "static"],
+        });
+
+        const { site, siteKv } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const siteKv = yield* Cloudflare.KV.Namespace("RemoteSiteKV").pipe(
+              Alchemy.remote(),
+            );
+            const site = yield* Cloudflare.Website.SvelteKit(
+              "SvelteKitLocalRemoteKV",
+              {
+                rootDir,
+                dev: { port: 0 },
+                memo: { include: ["src/**", "static/**", "package.json"] },
+                env: {
+                  TEST_BINDING: "sveltekit-dev-remote-marker",
+                  SITE_KV: siteKv,
+                },
+              },
+            );
+            return { site, siteKv };
+          }),
+        );
+
+        // The remote() namespace is REAL — a cloud id, not a `dev:` one —
+        // while the site itself still serves from the local dev proxy.
+        expect(site.url).toMatch(/^http:\/\/localhost:\d+/);
+        expect(isLocalId(siteKv.namespaceId)).toBe(false);
+        expect(siteKv.namespaceId).not.toMatch(/^dev:/);
+
+        // Write through the dev server's remote-proxied binding.
+        const kvValue = "sveltekit-dev-remote-kv-value";
+        yield* putTextReady(`${site.url!}/api/kv?key=remote-key`, kvValue);
+        const kvRead = yield* fetchJsonReady<{ value: string | null }>(
+          `${site.url!}/api/kv?key=remote-key`,
+        );
+        expect(kvRead.value).toBe(kvValue);
+
+        // Out-of-band: the write is visible through the cloud API — the
+        // binding really hit the live namespace.
+        const { accountId } = yield* yield* CloudflareEnvironment;
+        const cloudValue = yield* kv
+          .getNamespaceValue({
+            accountId,
+            namespaceId: siteKv.namespaceId,
+            keyName: "remote-key",
+          })
+          .pipe(
+            Effect.flatMap((res) =>
+              Effect.tryPromise(() =>
+                new Response(
+                  Stream.toReadableStream(res.body) as BodyInit,
+                ).text(),
+              ),
+            ),
+            Effect.retry({
+              schedule: Schedule.exponential("1 second", 1.5),
+              times: 5,
+            }),
+          );
+        expect(cloudValue).toBe(kvValue);
+
+        yield* stack.destroy();
+
+        // The live namespace was deleted from the cloud on destroy (its
+        // state row is stamped live, so the live provider handles the
+        // delete even in a dev run).
+        const gone = yield* kv
+          .getNamespace({
+            accountId,
+            namespaceId: siteKv.namespaceId,
+          })
+          .pipe(
+            Effect.as(false),
+            Effect.catchTag("NamespaceNotFound", () => Effect.succeed(true)),
+          );
+        expect(gone).toBe(true);
+      }).pipe(logLevel),
+    { timeout: 300_000, exclusive: true },
+  );
+});

--- a/packages/alchemy/test/Cloudflare/Website/SvelteKit.test.ts
+++ b/packages/alchemy/test/Cloudflare/Website/SvelteKit.test.ts
@@ -2,7 +2,7 @@ import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
 import * as Cloudflare from "@/Cloudflare/index.ts";
 import * as Test from "@/Test/Alchemy";
 import * as kv from "@distilled.cloud/cloudflare/kv";
-import { expect } from "alchemy-test";
+import { describe, expect } from "alchemy-test";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
@@ -43,424 +43,435 @@ const svelteKitProps = (rootDir: string) => ({
   memo: { include: ["src/**", "static/**", "package.json"] },
 });
 
-test.provider(
-  "SvelteKit: deploys SSR + bindings + static assets and memoizes unchanged rebuilds",
-  (stack) =>
-    Effect.gen(function* () {
-      const { accountId } = yield* yield* CloudflareEnvironment;
+// Concurrent for consistency with the other Website suites; both tests
+// are `exclusive: true` (the SvelteKit source build chdirs in-process),
+// so the runner's whole-process lock still serializes them globally.
+describe.concurrent("SvelteKit", () => {
+  test.provider(
+    "SvelteKit: deploys SSR + bindings + static assets and memoizes unchanged rebuilds",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
 
-      yield* stack.destroy();
+        yield* stack.destroy();
 
-      const rootDir = yield* cloneFixture(fixtureDir, {
-        prefix: "alchemy-sveltekit-",
-        tempRoot,
-        entries: ["package.json", "src", "static"],
-      });
+        const rootDir = yield* cloneFixture(fixtureDir, {
+          prefix: "alchemy-sveltekit-",
+          tempRoot,
+          entries: ["package.json", "src", "static"],
+        });
 
-      const bindingMarker = "sveltekit-binding-marker";
+        const bindingMarker = "sveltekit-binding-marker";
 
-      const deploy = () =>
-        stack.deploy(
-          Effect.gen(function* () {
-            // A REAL KV namespace bound into `platform.env.SITE_KV` — the
-            // /api/kv routes round-trip it server-side.
-            const siteKv = yield* Cloudflare.KV.Namespace("SiteKV");
-            const site = yield* Cloudflare.Website.SvelteKit("SvelteKitSite", {
-              ...svelteKitProps(rootDir),
-              env: {
-                TEST_BINDING: bindingMarker,
-                SITE_KV: siteKv,
-              },
-            });
-            return { site, siteKv };
-          }),
+        const deploy = () =>
+          stack.deploy(
+            Effect.gen(function* () {
+              // A REAL KV namespace bound into `platform.env.SITE_KV` — the
+              // /api/kv routes round-trip it server-side.
+              const siteKv = yield* Cloudflare.KV.Namespace("SiteKV");
+              const site = yield* Cloudflare.Website.SvelteKit(
+                "SvelteKitSite",
+                {
+                  ...svelteKitProps(rootDir),
+                  env: {
+                    TEST_BINDING: bindingMarker,
+                    SITE_KV: siteKv,
+                  },
+                },
+              );
+              return { site, siteKv };
+            }),
+          );
+
+        const { site: site1, siteKv } = yield* deploy();
+
+        expect(site1.url).toBeDefined();
+        expect(site1.hash?.input).toBeDefined();
+        yield* expectWorkerExists(site1.workerName, accountId);
+
+        // SSR route: the server `load` reads `platform.env.TEST_BINDING`.
+        yield* expectUrlContains(`${site1.url!}/`, `binding:${bindingMarker}`, {
+          timeout: "120 seconds",
+          label: "SSR home with platform.env binding",
+        });
+
+        // API endpoint: node:crypto under nodejs_compat + platform.env.
+        const hello = yield* fetchJsonReady<{ uuid: string; binding: string }>(
+          `${site1.url!}/api/hello`,
+        );
+        expect(hello.binding).toBe(bindingMarker);
+        expect(hello.uuid).toMatch(/^[0-9a-f-]{36}$/);
+
+        // Static asset from `static/`.
+        yield* expectUrlContains(`${site1.url!}/robots.txt`, "User-agent", {
+          timeout: "60 seconds",
+          label: "static asset",
+        });
+
+        // Prerendered page served from assets.
+        yield* expectUrlContains(
+          `${site1.url!}/prerendered`,
+          "this-page-is-prerendered",
+          {
+            timeout: "60 seconds",
+            label: "prerendered page",
+          },
         );
 
-      const { site: site1, siteKv } = yield* deploy();
+        // ── form action: the first non-GET against an alchemy-deployed
+        // framework worker. The urlencoded POST must route through the asset
+        // layer to the worker, run the `greet` action server-side, and
+        // observe `platform.env` ─────────────────────────────────────────────
+        const formBody = yield* postFormReady(
+          `${site1.url!}/form?/greet`,
+          new URL(site1.url!).origin,
+          { name: "alchemy" },
+        );
+        expect(formBody).toContain("result:hello alchemy");
+        expect(formBody).toContain(`form-binding:${bindingMarker}`);
 
-      expect(site1.url).toBeDefined();
-      expect(site1.hash?.input).toBeDefined();
-      yield* expectWorkerExists(site1.workerName, accountId);
-
-      // SSR route: the server `load` reads `platform.env.TEST_BINDING`.
-      yield* expectUrlContains(`${site1.url!}/`, `binding:${bindingMarker}`, {
-        timeout: "120 seconds",
-        label: "SSR home with platform.env binding",
-      });
-
-      // API endpoint: node:crypto under nodejs_compat + platform.env.
-      const hello = yield* fetchJsonReady<{ uuid: string; binding: string }>(
-        `${site1.url!}/api/hello`,
-      );
-      expect(hello.binding).toBe(bindingMarker);
-      expect(hello.uuid).toMatch(/^[0-9a-f-]{36}$/);
-
-      // Static asset from `static/`.
-      yield* expectUrlContains(`${site1.url!}/robots.txt`, "User-agent", {
-        timeout: "60 seconds",
-        label: "static asset",
-      });
-
-      // Prerendered page served from assets.
-      yield* expectUrlContains(
-        `${site1.url!}/prerendered`,
-        "this-page-is-prerendered",
-        {
-          timeout: "60 seconds",
-          label: "prerendered page",
-        },
-      );
-
-      // ── form action: the first non-GET against an alchemy-deployed
-      // framework worker. The urlencoded POST must route through the asset
-      // layer to the worker, run the `greet` action server-side, and
-      // observe `platform.env` ─────────────────────────────────────────────
-      const formBody = yield* postFormReady(
-        `${site1.url!}/form?/greet`,
-        new URL(site1.url!).origin,
-        { name: "alchemy" },
-      );
-      expect(formBody).toContain("result:hello alchemy");
-      expect(formBody).toContain(`form-binding:${bindingMarker}`);
-
-      // ── real KV binding: PUT writes through `platform.env.SITE_KV`,
-      // GET reads it back, and the cloud API sees the same value ──────────
-      expect(siteKv.namespaceId).toBeDefined();
-      const kvKey = "greeting";
-      const kvValue = `sveltekit-kv-${bindingMarker}`;
-      yield* putTextReady(`${site1.url!}/api/kv?key=${kvKey}`, kvValue);
-      const kvRead = yield* fetchJsonReady<{ value: string | null }>(
-        `${site1.url!}/api/kv?key=${kvKey}`,
-      ).pipe(
-        Effect.filterOrFail(
-          (r) => r.value === kvValue,
-          (r) => new Error(`kv value not visible yet: ${JSON.stringify(r)}`),
-        ),
-        Effect.retry({
-          schedule: Schedule.exponential("1 second", 1.5),
-          times: 8,
-        }),
-      );
-      expect(kvRead.value).toBe(kvValue);
-
-      // Out-of-band: the worker's write landed in the REAL namespace.
-      const cloudValue = yield* kv
-        .getNamespaceValue({
-          accountId,
-          namespaceId: siteKv.namespaceId,
-          keyName: kvKey,
-        })
-        .pipe(
-          Effect.flatMap((res) =>
-            Effect.tryPromise(() =>
-              new Response(
-                Stream.toReadableStream(res.body) as BodyInit,
-              ).text(),
-            ),
+        // ── real KV binding: PUT writes through `platform.env.SITE_KV`,
+        // GET reads it back, and the cloud API sees the same value ──────────
+        expect(siteKv.namespaceId).toBeDefined();
+        const kvKey = "greeting";
+        const kvValue = `sveltekit-kv-${bindingMarker}`;
+        yield* putTextReady(`${site1.url!}/api/kv?key=${kvKey}`, kvValue);
+        const kvRead = yield* fetchJsonReady<{ value: string | null }>(
+          `${site1.url!}/api/kv?key=${kvKey}`,
+        ).pipe(
+          Effect.filterOrFail(
+            (r) => r.value === kvValue,
+            (r) => new Error(`kv value not visible yet: ${JSON.stringify(r)}`),
           ),
           Effect.retry({
             schedule: Schedule.exponential("1 second", 1.5),
-            times: 5,
+            times: 8,
           }),
         );
-      expect(cloudValue).toBe(kvValue);
+        expect(kvRead.value).toBe(kvValue);
 
-      // ── deploy 2: no changes ⇒ the rebuild-free input hash matches and
-      // the deploy short-circuits without building ─────────────────────────
-      const { site: site2 } = yield* deploy();
+        // Out-of-band: the worker's write landed in the REAL namespace.
+        const cloudValue = yield* kv
+          .getNamespaceValue({
+            accountId,
+            namespaceId: siteKv.namespaceId,
+            keyName: kvKey,
+          })
+          .pipe(
+            Effect.flatMap((res) =>
+              Effect.tryPromise(() =>
+                new Response(
+                  Stream.toReadableStream(res.body) as BodyInit,
+                ).text(),
+              ),
+            ),
+            Effect.retry({
+              schedule: Schedule.exponential("1 second", 1.5),
+              times: 5,
+            }),
+          );
+        expect(cloudValue).toBe(kvValue);
 
-      expect(site2.hash?.input).toBeDefined();
-      expect(site2.hash?.input).toEqual(site1.hash?.input);
-      expect(site2.url).toBe(site1.url);
+        // ── deploy 2: no changes ⇒ the rebuild-free input hash matches and
+        // the deploy short-circuits without building ─────────────────────────
+        const { site: site2 } = yield* deploy();
 
-      // ── deploy 3: edit a route ⇒ the input hash busts and the rebuilt
-      // page serves the new content ────────────────────────────────────────
-      const fs = yield* FileSystem.FileSystem;
-      const path = yield* Path.Path;
-      const pagePath = path.join(rootDir, "src", "routes", "+page.svelte");
-      const editedMarker = "sveltekit-edited-marker";
-      const page = yield* fs.readFileString(pagePath);
-      yield* fs.writeFileString(
-        pagePath,
-        page.replace(
-          "SvelteKit SSR home",
-          `SvelteKit SSR home ${editedMarker}`,
-        ),
-      );
+        expect(site2.hash?.input).toBeDefined();
+        expect(site2.hash?.input).toEqual(site1.hash?.input);
+        expect(site2.url).toBe(site1.url);
 
-      const { site: site3 } = yield* deploy();
-
-      expect(site3.hash?.input).toBeDefined();
-      expect(site3.hash?.input).not.toEqual(site1.hash?.input);
-      yield* expectUrlContains(`${site3.url!}/`, editedMarker, {
-        timeout: "120 seconds",
-        label: "edited SSR home page",
-      });
-
-      yield* stack.destroy();
-      yield* waitForWorkerToBeDeleted(site1.workerName, accountId);
-      // Destroy must also delete the bound KV namespace from the cloud.
-      yield* waitForNamespaceToBeDeleted(siteKv.namespaceId, accountId);
-    }).pipe(logLevel),
-  // exclusive: the SvelteKit build temporarily switches process.cwd() to
-  // the project root (kit resolves config relative to the cwd).
-  { timeout: 360_000, exclusive: true },
-);
-
-// ─────────────────────────────────────────────────────────────────────
-// SPA mode: `adapter.notFoundHandling: "single-page-application"`
-//
-// Pages are `ssr = false`, so deep links and unknown routes must serve
-// the generated app-shell `index.html` (identified by the fixture's
-// shell marker), while `+server.ts` endpoints still execute server-side
-// in the worker with access to `platform.env`.
-// ─────────────────────────────────────────────────────────────────────
-
-const spaFixtureDir = pathe.resolve(
-  import.meta.dirname,
-  "fixtures",
-  "sveltekit-spa-app",
-);
-
-const SPA_SHELL_MARKER = "sveltekit-spa-shell";
-
-test.provider(
-  "SvelteKit SPA: deep links and unknown routes serve the app shell; server endpoints still run in the worker",
-  (stack) =>
-    Effect.gen(function* () {
-      const { accountId } = yield* yield* CloudflareEnvironment;
-
-      yield* stack.destroy();
-
-      const rootDir = yield* cloneFixture(spaFixtureDir, {
-        prefix: "alchemy-sveltekit-spa-",
-        tempRoot,
-        entries: ["package.json", "src"],
-      });
-
-      const bindingMarker = "sveltekit-spa-binding-marker";
-
-      const site = yield* stack.deploy(
-        Effect.gen(function* () {
-          return yield* Cloudflare.Website.SvelteKit("SvelteKitSpaSite", {
-            rootDir,
-            workersDev: { enabled: true, previewsEnabled: true },
-            memo: { include: ["src/**", "package.json"] },
-            // `assets.notFoundHandling` deliberately NOT set: the resource
-            // defaults the assets-layer knob from the adapter's, so this
-            // one prop configures both the app-shell fallback generation
-            // and the assets layer that serves it. This deploy pins that
-            // default — without it, unknown routes 404 with an empty body.
-            adapter: { notFoundHandling: "single-page-application" },
-            env: {
-              TEST_BINDING: bindingMarker,
-            },
-          });
-        }),
-      );
-
-      expect(site.url).toBeDefined();
-      // SPA mode still ships a worker: the kit server bundle serves the
-      // `+server.ts` endpoints.
-      expect(site.hash?.bundle).toBeDefined();
-      yield* expectWorkerExists(site.workerName, accountId);
-
-      // (a) A deep link to a CLIENT route serves the app shell — the
-      // shell marker is present and the widget markup (which only ever
-      // renders in the browser) is absent.
-      const widgetsBody = yield* expectSpaShell(`${site.url!}/widgets`);
-      expect(widgetsBody).toContain(SPA_SHELL_MARKER);
-      expect(widgetsBody).not.toContain("sveltekit-spa-widgets");
-      expect(widgetsBody).not.toContain("sprocket");
-
-      // (b) A route that doesn't exist at all serves the shell too — the
-      // client router owns 404 handling in SPA mode.
-      const unknownBody = yield* expectSpaShell(
-        `${site.url!}/definitely/not/a/route`,
-      );
-      expect(unknownBody).toContain(SPA_SHELL_MARKER);
-
-      // (c) The server endpoint executes in the worker with the binding.
-      const widgets = yield* fetchJsonReady<{
-        server: boolean;
-        message: string | null;
-        widgets: Array<{ id: string; name: string }>;
-      }>(`${site.url!}/api/widgets`);
-      expect(widgets.server).toBe(true);
-      expect(widgets.message).toBe(bindingMarker);
-      expect(widgets.widgets.map((w) => w.name)).toEqual([
-        "sprocket",
-        "flange",
-        "grommet",
-      ]);
-
-      yield* stack.destroy();
-      yield* waitForWorkerToBeDeleted(site.workerName, accountId);
-    }).pipe(logLevel),
-  // exclusive: the SvelteKit build temporarily switches process.cwd() to
-  // the project root (kit resolves config relative to the cwd).
-  { timeout: 360_000, exclusive: true },
-);
-
-class NamespaceStillExists extends Data.TaggedError("NamespaceStillExists") {}
-
-const waitForNamespaceToBeDeleted = Effect.fn(function* (
-  namespaceId: string,
-  accountId: string,
-) {
-  yield* kv.getNamespace({ accountId, namespaceId }).pipe(
-    Effect.flatMap(() => Effect.fail(new NamespaceStillExists())),
-    Effect.retry({
-      while: (e): e is NamespaceStillExists =>
-        e instanceof NamespaceStillExists,
-      schedule: Schedule.exponential(250),
-      times: 10,
-    }),
-    Effect.catchTag("NamespaceNotFound", () => Effect.void),
-  );
-});
-
-class SpaShellMismatch extends Data.TaggedError("SpaShellMismatch")<{
-  url: string;
-  actual: string;
-}> {
-  override get message() {
-    return `${this.url} :: ${this.actual}`;
-  }
-}
-
-/**
- * Assert `url` answers 200 with the SPA app-shell body (contains the
- * fixture's shell marker). Retries through edge propagation with a
- * bounded schedule; returns the body for further (negative) assertions.
- */
-const expectSpaShell = (url: string) =>
-  Effect.tryPromise({
-    try: async (signal) => {
-      const u = new URL(url);
-      u.searchParams.set("__alchemy_cb", String(Date.now()));
-      const res = await fetch(u, {
-        signal,
-        cache: "no-store",
-        headers: { "cache-control": "no-cache", accept: "text/html" },
-      });
-      const body = await res.text();
-      return { status: res.status, body };
-    },
-    catch: (e) =>
-      new SpaShellMismatch({
-        url,
-        actual: e instanceof Error ? e.message : String(e),
-      }),
-  }).pipe(
-    Effect.filterOrFail(
-      (res) => res.status === 200 && res.body.includes(SPA_SHELL_MARKER),
-      (res) =>
-        new SpaShellMismatch({
-          url,
-          actual: `${res.status} ${res.body.slice(0, 240)}`,
-        }),
-    ),
-    Effect.map((res) => res.body),
-    Effect.retry({
-      schedule: Schedule.max([
-        Schedule.min([
-          Schedule.exponential("750 millis", 1.5),
-          Schedule.spaced("8 seconds"),
-        ]),
-        Schedule.recurs(15),
-      ]),
-    }),
-  );
-
-/**
- * POST an urlencoded form to a kit action URL (`/route?/action`) with an
- * `origin` header matching the site (kit's CSRF check) and
- * `accept: text/html` so the action result is server-rendered into the
- * page. Retries until the route serves 200.
- */
-const postFormReady = (
-  url: string,
-  origin: string,
-  form: Record<string, string>,
-) =>
-  Effect.gen(function* () {
-    const client = yield* HttpClient.HttpClient;
-    return yield* client
-      .execute(
-        HttpClientRequest.post(url).pipe(
-          HttpClientRequest.setHeaders({ origin, accept: "text/html" }),
-          HttpClientRequest.bodyText(
-            new URLSearchParams(form).toString(),
-            "application/x-www-form-urlencoded",
+        // ── deploy 3: edit a route ⇒ the input hash busts and the rebuilt
+        // page serves the new content ────────────────────────────────────────
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const pagePath = path.join(rootDir, "src", "routes", "+page.svelte");
+        const editedMarker = "sveltekit-edited-marker";
+        const page = yield* fs.readFileString(pagePath);
+        yield* fs.writeFileString(
+          pagePath,
+          page.replace(
+            "SvelteKit SSR home",
+            `SvelteKit SSR home ${editedMarker}`,
           ),
-        ),
-      )
-      .pipe(
-        Effect.flatMap((res) =>
-          res.status === 200
-            ? res.text
-            : Effect.fail(new Error(`form action not ready: ${res.status}`)),
-        ),
-        Effect.retry({
-          schedule: Schedule.min([
-            Schedule.exponential("500 millis"),
-            Schedule.spaced("4 seconds"),
-          ]),
-          times: 15,
-        }),
-      );
-  });
+        );
 
-/**
- * PUT a text body to `url`, retrying until the route serves 200. Kit's
- * CSRF protection 403s form-like content types (`text/plain` included)
- * on non-GET requests unless the `origin` header matches the site, so
- * the site origin is sent explicitly.
- */
-const putTextReady = (url: string, body: string) =>
-  Effect.gen(function* () {
-    const client = yield* HttpClient.HttpClient;
-    yield* client
-      .execute(
-        HttpClientRequest.put(url).pipe(
-          HttpClientRequest.setHeaders({ origin: new URL(url).origin }),
-          HttpClientRequest.bodyText(body, "text/plain"),
-        ),
-      )
-      .pipe(
-        Effect.flatMap((res) =>
-          res.status === 200
-            ? Effect.void
-            : Effect.fail(new Error(`PUT not ready: ${res.status}`)),
-        ),
-        Effect.retry({
-          schedule: Schedule.min([
-            Schedule.exponential("500 millis"),
-            Schedule.spaced("4 seconds"),
-          ]),
-          times: 15,
-        }),
-      );
-  });
+        const { site: site3 } = yield* deploy();
 
-const fetchJsonReady = <T>(url: string) =>
-  Effect.gen(function* () {
-    const client = yield* HttpClient.HttpClient;
-    return yield* client.get(url).pipe(
-      Effect.flatMap((res) =>
-        res.status === 200
-          ? Effect.flatMap(res.text, (body) =>
-              Effect.try({
-                try: () => JSON.parse(body) as T,
-                catch: () => new Error(`non-json body: ${body}`),
-              }),
-            )
-          : Effect.fail(new Error(`Worker not ready: ${res.status}`)),
-      ),
+        expect(site3.hash?.input).toBeDefined();
+        expect(site3.hash?.input).not.toEqual(site1.hash?.input);
+        yield* expectUrlContains(`${site3.url!}/`, editedMarker, {
+          timeout: "120 seconds",
+          label: "edited SSR home page",
+        });
+
+        yield* stack.destroy();
+        yield* waitForWorkerToBeDeleted(site1.workerName, accountId);
+        // Destroy must also delete the bound KV namespace from the cloud.
+        yield* waitForNamespaceToBeDeleted(siteKv.namespaceId, accountId);
+      }).pipe(logLevel),
+    // exclusive: the SvelteKit build temporarily switches process.cwd() to
+    // the project root (kit resolves config relative to the cwd).
+    { timeout: 360_000, exclusive: true },
+  );
+
+  // ─────────────────────────────────────────────────────────────────────
+  // SPA mode: `adapter.notFoundHandling: "single-page-application"`
+  //
+  // Pages are `ssr = false`, so deep links and unknown routes must serve
+  // the generated app-shell `index.html` (identified by the fixture's
+  // shell marker), while `+server.ts` endpoints still execute server-side
+  // in the worker with access to `platform.env`.
+  // ─────────────────────────────────────────────────────────────────────
+
+  const spaFixtureDir = pathe.resolve(
+    import.meta.dirname,
+    "fixtures",
+    "sveltekit-spa-app",
+  );
+
+  const SPA_SHELL_MARKER = "sveltekit-spa-shell";
+
+  test.provider(
+    "SvelteKit SPA: deep links and unknown routes serve the app shell; server endpoints still run in the worker",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+
+        yield* stack.destroy();
+
+        const rootDir = yield* cloneFixture(spaFixtureDir, {
+          prefix: "alchemy-sveltekit-spa-",
+          tempRoot,
+          entries: ["package.json", "src"],
+        });
+
+        const bindingMarker = "sveltekit-spa-binding-marker";
+
+        const site = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.Website.SvelteKit("SvelteKitSpaSite", {
+              rootDir,
+              workersDev: { enabled: true, previewsEnabled: true },
+              memo: { include: ["src/**", "package.json"] },
+              // `assets.notFoundHandling` deliberately NOT set: the resource
+              // defaults the assets-layer knob from the adapter's, so this
+              // one prop configures both the app-shell fallback generation
+              // and the assets layer that serves it. This deploy pins that
+              // default — without it, unknown routes 404 with an empty body.
+              adapter: { notFoundHandling: "single-page-application" },
+              env: {
+                TEST_BINDING: bindingMarker,
+              },
+            });
+          }),
+        );
+
+        expect(site.url).toBeDefined();
+        // SPA mode still ships a worker: the kit server bundle serves the
+        // `+server.ts` endpoints.
+        expect(site.hash?.bundle).toBeDefined();
+        yield* expectWorkerExists(site.workerName, accountId);
+
+        // (a) A deep link to a CLIENT route serves the app shell — the
+        // shell marker is present and the widget markup (which only ever
+        // renders in the browser) is absent.
+        const widgetsBody = yield* expectSpaShell(`${site.url!}/widgets`);
+        expect(widgetsBody).toContain(SPA_SHELL_MARKER);
+        expect(widgetsBody).not.toContain("sveltekit-spa-widgets");
+        expect(widgetsBody).not.toContain("sprocket");
+
+        // (b) A route that doesn't exist at all serves the shell too — the
+        // client router owns 404 handling in SPA mode.
+        const unknownBody = yield* expectSpaShell(
+          `${site.url!}/definitely/not/a/route`,
+        );
+        expect(unknownBody).toContain(SPA_SHELL_MARKER);
+
+        // (c) The server endpoint executes in the worker with the binding.
+        const widgets = yield* fetchJsonReady<{
+          server: boolean;
+          message: string | null;
+          widgets: Array<{ id: string; name: string }>;
+        }>(`${site.url!}/api/widgets`);
+        expect(widgets.server).toBe(true);
+        expect(widgets.message).toBe(bindingMarker);
+        expect(widgets.widgets.map((w) => w.name)).toEqual([
+          "sprocket",
+          "flange",
+          "grommet",
+        ]);
+
+        yield* stack.destroy();
+        yield* waitForWorkerToBeDeleted(site.workerName, accountId);
+      }).pipe(logLevel),
+    // exclusive: the SvelteKit build temporarily switches process.cwd() to
+    // the project root (kit resolves config relative to the cwd).
+    { timeout: 360_000, exclusive: true },
+  );
+
+  class NamespaceStillExists extends Data.TaggedError("NamespaceStillExists") {}
+
+  const waitForNamespaceToBeDeleted = Effect.fn(function* (
+    namespaceId: string,
+    accountId: string,
+  ) {
+    yield* kv.getNamespace({ accountId, namespaceId }).pipe(
+      Effect.flatMap(() => Effect.fail(new NamespaceStillExists())),
       Effect.retry({
-        schedule: Schedule.exponential("500 millis"),
-        times: 15,
+        while: (e): e is NamespaceStillExists =>
+          e instanceof NamespaceStillExists,
+        schedule: Schedule.exponential(250),
+        times: 10,
       }),
+      Effect.catchTag("NamespaceNotFound", () => Effect.void),
     );
   });
+
+  class SpaShellMismatch extends Data.TaggedError("SpaShellMismatch")<{
+    url: string;
+    actual: string;
+  }> {
+    override get message() {
+      return `${this.url} :: ${this.actual}`;
+    }
+  }
+
+  /**
+   * Assert `url` answers 200 with the SPA app-shell body (contains the
+   * fixture's shell marker). Retries through edge propagation with a
+   * bounded schedule; returns the body for further (negative) assertions.
+   */
+  const expectSpaShell = (url: string) =>
+    Effect.tryPromise({
+      try: async (signal) => {
+        const u = new URL(url);
+        u.searchParams.set("__alchemy_cb", String(Date.now()));
+        const res = await fetch(u, {
+          signal,
+          cache: "no-store",
+          headers: { "cache-control": "no-cache", accept: "text/html" },
+        });
+        const body = await res.text();
+        return { status: res.status, body };
+      },
+      catch: (e) =>
+        new SpaShellMismatch({
+          url,
+          actual: e instanceof Error ? e.message : String(e),
+        }),
+    }).pipe(
+      Effect.filterOrFail(
+        (res) => res.status === 200 && res.body.includes(SPA_SHELL_MARKER),
+        (res) =>
+          new SpaShellMismatch({
+            url,
+            actual: `${res.status} ${res.body.slice(0, 240)}`,
+          }),
+      ),
+      Effect.map((res) => res.body),
+      Effect.retry({
+        // ~127s budget — matches the 120s first-request convention used by
+        // `expectUrlContains`: a fully concurrent suite creates dozens of
+        // fresh workers.dev subdomains at once and propagation slows down.
+        schedule: Schedule.max([
+          Schedule.min([
+            Schedule.exponential("750 millis", 1.5),
+            Schedule.spaced("8 seconds"),
+          ]),
+          Schedule.recurs(20),
+        ]),
+      }),
+    );
+
+  /**
+   * POST an urlencoded form to a kit action URL (`/route?/action`) with an
+   * `origin` header matching the site (kit's CSRF check) and
+   * `accept: text/html` so the action result is server-rendered into the
+   * page. Retries until the route serves 200.
+   */
+  const postFormReady = (
+    url: string,
+    origin: string,
+    form: Record<string, string>,
+  ) =>
+    Effect.gen(function* () {
+      const client = yield* HttpClient.HttpClient;
+      return yield* client
+        .execute(
+          HttpClientRequest.post(url).pipe(
+            HttpClientRequest.setHeaders({ origin, accept: "text/html" }),
+            HttpClientRequest.bodyText(
+              new URLSearchParams(form).toString(),
+              "application/x-www-form-urlencoded",
+            ),
+          ),
+        )
+        .pipe(
+          Effect.flatMap((res) =>
+            res.status === 200
+              ? res.text
+              : Effect.fail(new Error(`form action not ready: ${res.status}`)),
+          ),
+          Effect.retry({
+            schedule: Schedule.min([
+              Schedule.exponential("500 millis"),
+              Schedule.spaced("4 seconds"),
+            ]),
+            times: 15,
+          }),
+        );
+    });
+
+  /**
+   * PUT a text body to `url`, retrying until the route serves 200. Kit's
+   * CSRF protection 403s form-like content types (`text/plain` included)
+   * on non-GET requests unless the `origin` header matches the site, so
+   * the site origin is sent explicitly.
+   */
+  const putTextReady = (url: string, body: string) =>
+    Effect.gen(function* () {
+      const client = yield* HttpClient.HttpClient;
+      yield* client
+        .execute(
+          HttpClientRequest.put(url).pipe(
+            HttpClientRequest.setHeaders({ origin: new URL(url).origin }),
+            HttpClientRequest.bodyText(body, "text/plain"),
+          ),
+        )
+        .pipe(
+          Effect.flatMap((res) =>
+            res.status === 200
+              ? Effect.void
+              : Effect.fail(new Error(`PUT not ready: ${res.status}`)),
+          ),
+          Effect.retry({
+            schedule: Schedule.min([
+              Schedule.exponential("500 millis"),
+              Schedule.spaced("4 seconds"),
+            ]),
+            times: 15,
+          }),
+        );
+    });
+
+  const fetchJsonReady = <T>(url: string) =>
+    Effect.gen(function* () {
+      const client = yield* HttpClient.HttpClient;
+      return yield* client.get(url).pipe(
+        Effect.flatMap((res) =>
+          res.status === 200
+            ? Effect.flatMap(res.text, (body) =>
+                Effect.try({
+                  try: () => JSON.parse(body) as T,
+                  catch: () => new Error(`non-json body: ${body}`),
+                }),
+              )
+            : Effect.fail(new Error(`Worker not ready: ${res.status}`)),
+        ),
+        Effect.retry({
+          schedule: Schedule.exponential("500 millis"),
+          times: 15,
+        }),
+      );
+    });
+});

--- a/packages/alchemy/test/Cloudflare/Website/Vite.test.ts
+++ b/packages/alchemy/test/Cloudflare/Website/Vite.test.ts
@@ -2,8 +2,9 @@ import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
 import * as Cloudflare from "@/Cloudflare/index.ts";
 import { isLocalId } from "@/Cloudflare/LocalRuntime";
 import * as Test from "@/Test/Alchemy";
+import { initialCwd } from "@/Util/Node.ts";
 import * as r2 from "@distilled.cloud/cloudflare/r2";
-import { expect } from "alchemy-test";
+import { describe, expect } from "alchemy-test";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
@@ -62,1166 +63,1176 @@ const viteChildFixtureDir = pathe.resolve(
 // root as `cwd`.
 const tempRoot = pathe.resolve(import.meta.dirname, "../../../.tmp");
 
-test.provider(
-  "Vite: editing a source file republishes the assets in a single deploy",
-  (stack) =>
-    Effect.gen(function* () {
-      const { accountId } = yield* yield* CloudflareEnvironment;
-      const fs = yield* FileSystem.FileSystem;
-      const path = yield* Path.Path;
+// Suites are sequential by default; every test here deploys its own
+// scratch stack with its own worker names and fixture clone, so they are
+// independent and can run concurrently. Builds run in per-project child
+// processes (`runViteBuildChild`), so concurrent builds can't race each
+// other's working directory.
+describe.concurrent("Vite", () => {
+  test.provider(
+    "Vite: editing a source file republishes the assets in a single deploy",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
 
-      yield* stack.destroy();
+        yield* stack.destroy();
 
-      const rootDir = yield* cloneFixture(fixtureDir, {
-        prefix: "alchemy-vite-fix-",
-        tempRoot,
-        entries: ["index.html", "package.json", "vite.config.ts", "src"],
-      });
-      const indexPath = path.join(rootDir, "index.html");
+        const rootDir = yield* cloneFixture(fixtureDir, {
+          prefix: "alchemy-vite-fix-",
+          tempRoot,
+          entries: ["index.html", "package.json", "vite.config.ts", "src"],
+        });
+        const indexPath = path.join(rootDir, "index.html");
 
-      // Restrict the input memo to fixture sources so the test isn't
-      // re-hashing the whole monorepo on every deploy.
-      const memoInclude = [
-        "index.html",
-        "src/**",
-        "package.json",
-        "vite.config.ts",
-      ];
+        // Restrict the input memo to fixture sources so the test isn't
+        // re-hashing the whole monorepo on every deploy.
+        const memoInclude = [
+          "index.html",
+          "src/**",
+          "package.json",
+          "vite.config.ts",
+        ];
 
-      const v1Marker = `vite-v1-${Date.now()}`;
-      yield* fs.writeFileString(indexPath, htmlPage(v1Marker));
+        const v1Marker = `vite-v1-${Date.now()}`;
+        yield* fs.writeFileString(indexPath, htmlPage(v1Marker));
 
-      const site1 = yield* stack.deploy(
-        Effect.gen(function* () {
-          return yield* Cloudflare.Website.Vite(
-            "FixVite",
-            viteProps(rootDir, memoInclude),
-          );
-        }),
-      );
-
-      expect(site1.url).toBeDefined();
-      expect(site1.hash?.input).toBeDefined();
-      yield* expectWorkerExists(site1.workerName, accountId);
-      yield* expectUrlContains(`${site1.url!}/`, v1Marker, {
-        timeout: "120 seconds",
-        label: "deploy1 v1 marker",
-      });
-
-      // ── deploy 2: edit fixture, redeploy once ──────────────────────────
-      const v2Marker = `vite-v2-${Date.now()}`;
-      yield* fs.writeFileString(indexPath, htmlPage(v2Marker));
-
-      const site2 = yield* stack.deploy(
-        Effect.gen(function* () {
-          return yield* Cloudflare.Website.Vite(
-            "FixVite",
-            viteProps(rootDir, memoInclude),
-          );
-        }),
-      );
-
-      expect(site2.hash?.input).toBeDefined();
-      expect(site2.hash?.input).not.toEqual(site1.hash?.input);
-      yield* expectUrlContains(`${site2.url!}/`, v2Marker, {
-        timeout: "60 seconds",
-        label: "deploy2 v2 marker",
-      });
-
-      yield* stack.destroy();
-      yield* waitForWorkerToBeDeleted(site1.workerName, accountId);
-    }).pipe(logLevel),
-  { timeout: 360_000 },
-);
-
-// Regression test for https://github.com/alchemy-run/alchemy/issues/1016.
-//
-// `hashViteInput` used to pass a relative root as both the directory and its
-// base, resolving `app` as `<cwd>/app/app`. The empty match produced a constant
-// input hash, so source edits were incorrectly treated as no-ops.
-test.provider(
-  "Vite: a source edit changes the input hash when rootDir is relative",
-  (stack) =>
-    Effect.gen(function* () {
-      const { accountId } = yield* yield* CloudflareEnvironment;
-      const fs = yield* FileSystem.FileSystem;
-      const path = yield* Path.Path;
-
-      yield* stack.destroy();
-
-      const absoluteRoot = yield* cloneFixture(fixtureDir, {
-        prefix: "alchemy-vite-relative-root-",
-        tempRoot,
-        entries: ["index.html", "package.json", "vite.config.ts", "src"],
-      });
-      const rootDir = path.relative(process.cwd(), absoluteRoot);
-      const indexPath = path.join(absoluteRoot, "index.html");
-      const memoInclude = [
-        "index.html",
-        "src/**",
-        "package.json",
-        "vite.config.ts",
-      ];
-
-      expect(path.isAbsolute(rootDir)).toBe(false);
-      yield* fs.writeFileString(indexPath, htmlPage("relative-root-v1"));
-
-      const site1 = yield* stack.deploy(
-        Effect.gen(function* () {
-          return yield* Cloudflare.Website.Vite(
-            "ViteRelativeRoot",
-            viteProps(rootDir, memoInclude),
-          );
-        }),
-      );
-      expect(site1.hash?.input).toBeDefined();
-
-      yield* fs.writeFileString(indexPath, htmlPage("relative-root-v2"));
-
-      const site2 = yield* stack.deploy(
-        Effect.gen(function* () {
-          return yield* Cloudflare.Website.Vite(
-            "ViteRelativeRoot",
-            viteProps(rootDir, memoInclude),
-          );
-        }),
-      );
-      expect(site2.hash?.input).toBeDefined();
-      expect(site2.hash?.input).not.toEqual(site1.hash?.input);
-
-      yield* stack.destroy();
-      yield* waitForWorkerToBeDeleted(site1.workerName, accountId);
-    }).pipe(logLevel),
-  { timeout: 360_000 },
-);
-
-// Regression test for https://github.com/alchemy-run/alchemy/issues/792.
-//
-// A pure client-only Vite project (no vite.config.ts, no plugins, no worker
-// entry) resolves as `appType: "spa"`, so the Cloudflare Vite plugin declares
-// no `builder.buildApp`. On Vite 8, `builder.buildApp()` then runs post-order
-// `buildApp` hooks *before* the default environment builds — which used to make
-// our build-output plugin resolve while the client output was still undefined,
-// so the deploy died with "Vite build produced neither assets nor server
-// output". Detecting completion in `writeBundle` (per environment) instead of a
-// post-order `buildApp` hook fixes it; this test proves the SPA path deploys.
-test.provider(
-  "Vite: client-only SPA (no config, no plugins) builds and serves assets",
-  (stack) =>
-    Effect.gen(function* () {
-      const { accountId } = yield* yield* CloudflareEnvironment;
-      const fs = yield* FileSystem.FileSystem;
-      const path = yield* Path.Path;
-
-      yield* stack.destroy();
-
-      const rootDir = yield* cloneFixture(spaFixtureDir, {
-        prefix: "alchemy-vite-spa-",
-        tempRoot,
-        entries: ["index.html", "package.json", "src"],
-      });
-      const indexPath = path.join(rootDir, "index.html");
-      const memoInclude = ["index.html", "src/**", "package.json"];
-
-      const marker = `vite-spa-${Date.now()}`;
-      yield* fs.writeFileString(indexPath, htmlPage(marker));
-
-      const site = yield* stack.deploy(
-        Effect.gen(function* () {
-          return yield* Cloudflare.Website.Vite(
-            "FixViteSpa",
-            viteProps(rootDir, memoInclude),
-          );
-        }),
-      );
-
-      expect(site.url).toBeDefined();
-      expect(site.hash?.input).toBeDefined();
-      yield* expectWorkerExists(site.workerName, accountId);
-      yield* expectUrlContains(`${site.url!}/`, marker, {
-        timeout: "120 seconds",
-        label: "spa marker",
-      });
-
-      yield* stack.destroy();
-      yield* waitForWorkerToBeDeleted(site.workerName, accountId);
-    }).pipe(logLevel),
-  { timeout: 360_000 },
-);
-
-// Foldkit (foldkit.dev) is an Effect-native Elm-architecture frontend
-// framework. Its apps are plain client-only Vite projects (the Foldkit Vite
-// plugin only adds HMR/devtools wiring), so `Cloudflare.Website.Vite` deploys
-// them as-is. This pins that the Foldkit plugin composes with the injected
-// Cloudflare Vite plugin and that deep links fall back to `index.html` via
-// `single-page-application` not-found handling.
-test.provider(
-  "Vite: Foldkit SPA deploys and serves with SPA fallback",
-  (stack) =>
-    Effect.gen(function* () {
-      const { accountId } = yield* yield* CloudflareEnvironment;
-
-      yield* stack.destroy();
-
-      const rootDir = yield* cloneFixture(foldkitFixtureDir, {
-        prefix: "alchemy-vite-foldkit-",
-        tempRoot,
-        entries: ["index.html", "package.json", "vite.config.ts", "src"],
-      });
-      const memoInclude = [
-        "index.html",
-        "src/**",
-        "package.json",
-        "vite.config.ts",
-      ];
-
-      const site = yield* stack.deploy(
-        Effect.gen(function* () {
-          return yield* Cloudflare.Website.Vite("FixViteFoldkit", {
-            ...viteProps(rootDir, memoInclude),
-            assets: {
-              notFoundHandling: "single-page-application",
-            },
-          });
-        }),
-      );
-
-      expect(site.url).toBeDefined();
-      expect(site.hash?.input).toBeDefined();
-      yield* expectWorkerExists(site.workerName, accountId);
-      yield* expectUrlContains(`${site.url!}/`, "Foldkit Fixture", {
-        timeout: "120 seconds",
-        label: "foldkit index",
-      });
-      // Deep link falls back to index.html so client-side routing can boot.
-      yield* expectUrlContains(`${site.url!}/counter/42`, "Foldkit Fixture", {
-        timeout: "60 seconds",
-        label: "foldkit spa fallback",
-      });
-
-      yield* stack.destroy();
-      yield* waitForWorkerToBeDeleted(site.workerName, accountId);
-    }).pipe(logLevel),
-  { timeout: 360_000 },
-);
-
-test.provider(
-  "Vite: class form deploys and serves the built assets",
-  (stack) =>
-    Effect.gen(function* () {
-      const { accountId } = yield* yield* CloudflareEnvironment;
-      const fs = yield* FileSystem.FileSystem;
-      const path = yield* Path.Path;
-
-      yield* stack.destroy();
-
-      const rootDir = yield* cloneFixture(fixtureDir, {
-        prefix: "alchemy-vite-class-",
-        tempRoot,
-        entries: ["index.html", "package.json", "vite.config.ts", "src"],
-      });
-      const indexPath = path.join(rootDir, "index.html");
-      const memoInclude = [
-        "index.html",
-        "src/**",
-        "package.json",
-        "vite.config.ts",
-      ];
-
-      const marker = `vite-class-${Date.now()}`;
-      yield* fs.writeFileString(indexPath, htmlPage(marker));
-
-      const site1 = yield* stack.deploy(
-        Effect.gen(function* () {
-          return yield* class FixVite extends Cloudflare.Website.Vite<FixVite>()(
-            "FixVite",
-            viteProps(rootDir, memoInclude),
-          ) {};
-        }),
-      );
-
-      expect(site1.url).toBeDefined();
-      expect(site1.hash?.input).toBeDefined();
-      yield* expectWorkerExists(site1.workerName, accountId);
-      yield* expectUrlContains(`${site1.url!}/`, marker, {
-        timeout: "120 seconds",
-        label: "class form marker",
-      });
-
-      yield* stack.destroy();
-      yield* waitForWorkerToBeDeleted(site1.workerName, accountId);
-    }).pipe(logLevel),
-  { timeout: 360_000 },
-);
-
-// ─────────────────────────────────────────────────────────────────────
-// Path-relocation behavior for the vite path
-//
-// `Cloudflare.Website.Vite` stores a path-insensitive `hash.input` made from
-// the memo'd input tree plus build-affecting Vite options. The diff is:
-//
-//   `input !== output.hash?.input`
-//
-// — a pure content comparison that must be stable across rootDir
-// moves. We delete the original rootDir between deploys to make the
-// test fail loudly if anything still depends on the recorded path.
-// ─────────────────────────────────────────────────────────────────────
-
-test.provider(
-  "Vite: relocating rootDir (and deleting the old one) is a no-op when sources are identical",
-  (stack) =>
-    Effect.gen(function* () {
-      const { accountId } = yield* yield* CloudflareEnvironment;
-      const fs = yield* FileSystem.FileSystem;
-      const path = yield* Path.Path;
-
-      yield* stack.destroy();
-
-      const memoInclude = [
-        "index.html",
-        "src/**",
-        "package.json",
-        "vite.config.ts",
-      ];
-      const marker = `vite-relocate-${Date.now()}`;
-
-      const rootA = yield* cloneFixture(fixtureDir, {
-        prefix: "alchemy-vite-relocate-a-",
-        tempRoot,
-        entries: ["index.html", "package.json", "vite.config.ts", "src"],
-      });
-      yield* fs.writeFileString(
-        path.join(rootA, "index.html"),
-        htmlPage(marker),
-      );
-
-      const site1 = yield* stack.deploy(
-        Effect.gen(function* () {
-          return yield* Cloudflare.Website.Vite(
-            "ViteReloc",
-            viteProps(rootA, memoInclude),
-          );
-        }),
-      );
-      expect(site1.hash?.input).toBeDefined();
-      yield* expectUrlContains(`${site1.url!}/`, marker, {
-        timeout: "120 seconds",
-        label: "deploy1 marker",
-      });
-
-      // Drop rootA so a stale path comparison can't quietly succeed.
-      yield* fs.remove(rootA, { recursive: true });
-
-      const rootB = yield* cloneFixture(fixtureDir, {
-        prefix: "alchemy-vite-relocate-b-",
-        tempRoot,
-        entries: ["index.html", "package.json", "vite.config.ts", "src"],
-      });
-      yield* fs.writeFileString(
-        path.join(rootB, "index.html"),
-        htmlPage(marker),
-      );
-
-      const site2 = yield* stack.deploy(
-        Effect.gen(function* () {
-          return yield* Cloudflare.Website.Vite(
-            "ViteReloc",
-            viteProps(rootB, memoInclude),
-          );
-        }),
-      );
-
-      // Identical sources ⇒ identical input hash ⇒ diff says
-      // unchanged ⇒ no rebuild required for the apply to succeed.
-      expect(site2.hash?.input).toEqual(site1.hash?.input);
-      yield* expectUrlContains(`${site2.url!}/`, marker, {
-        timeout: "60 seconds",
-        label: "deploy2 marker",
-      });
-
-      yield* stack.destroy();
-      yield* waitForWorkerToBeDeleted(site1.workerName, accountId);
-    }).pipe(logLevel),
-  { timeout: 360_000 },
-);
-
-// ─────────────────────────────────────────────────────────────────────
-// Workspace-aware memoization
-//
-// A Vite project in a monorepo can bundle source from sibling workspace
-// packages. Those directories are discovered from the module graph at
-// build time, persisted in `hash.workspaces` (relative to the Vite
-// root), and included in the `hash.input` computation — so editing only
-// a sibling package busts the memo and triggers a rebuild.
-// ─────────────────────────────────────────────────────────────────────
-
-test.provider(
-  "Vite: edits in a sibling workspace package bust the build memo",
-  (stack) =>
-    Effect.gen(function* () {
-      const { accountId } = yield* yield* CloudflareEnvironment;
-      const fs = yield* FileSystem.FileSystem;
-      const path = yield* Path.Path;
-
-      yield* stack.destroy();
-
-      // Hand-rolled two-package workspace: `app` is the Vite root and
-      // `shared` is a sibling package whose source the client bundle
-      // imports directly (escaping the Vite root).
-      yield* fs.makeDirectory(tempRoot, { recursive: true });
-      const parent = yield* fs.makeTempDirectory({
-        prefix: "alchemy-vite-ws-",
-        directory: tempRoot,
-      });
-      yield* Effect.addFinalizer(
-        Exit.match({
-          onSuccess: () =>
-            Effect.ignore(fs.remove(parent, { recursive: true })),
-          onFailure: () => Effect.void,
-        }),
-      );
-      const rootDir = path.join(parent, "app");
-      const sharedDir = path.join(parent, "shared");
-
-      const writeShared = (marker: string) =>
-        fs.writeFileString(
-          path.join(sharedDir, "src/message.ts"),
-          `export const message = ${JSON.stringify(marker)};\n`,
+        const site1 = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.Website.Vite(
+              "FixVite",
+              viteProps(rootDir, memoInclude),
+            );
+          }),
         );
 
-      yield* fs.makeDirectory(path.join(rootDir, "src"), { recursive: true });
-      yield* fs.makeDirectory(path.join(sharedDir, "src"), {
-        recursive: true,
-      });
-      yield* fs.writeFileString(
-        path.join(rootDir, "index.html"),
-        htmlPage("vite-workspace-fixture"),
-      );
-      yield* fs.writeFileString(
-        path.join(rootDir, "package.json"),
-        JSON.stringify({
-          name: "alchemy-vite-workspace-app",
-          version: "0.0.0",
-          private: true,
-          type: "module",
-        }),
-      );
-      // Same shape as vite-fixture/vite.config.ts: point the SSR build at
-      // the minimal worker entry so the cloudflare-vite-plugin can wrap it.
-      yield* fs.writeFileString(
-        path.join(rootDir, "vite.config.ts"),
-        `import { defineConfig } from "vite";
+        expect(site1.url).toBeDefined();
+        expect(site1.hash?.input).toBeDefined();
+        yield* expectWorkerExists(site1.workerName, accountId);
+        yield* expectUrlContains(`${site1.url!}/`, v1Marker, {
+          timeout: "120 seconds",
+          label: "deploy1 v1 marker",
+        });
+
+        // ── deploy 2: edit fixture, redeploy once ──────────────────────────
+        const v2Marker = `vite-v2-${Date.now()}`;
+        yield* fs.writeFileString(indexPath, htmlPage(v2Marker));
+
+        const site2 = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.Website.Vite(
+              "FixVite",
+              viteProps(rootDir, memoInclude),
+            );
+          }),
+        );
+
+        expect(site2.hash?.input).toBeDefined();
+        expect(site2.hash?.input).not.toEqual(site1.hash?.input);
+        yield* expectUrlContains(`${site2.url!}/`, v2Marker, {
+          timeout: "60 seconds",
+          label: "deploy2 v2 marker",
+        });
+
+        yield* stack.destroy();
+        yield* waitForWorkerToBeDeleted(site1.workerName, accountId);
+      }).pipe(logLevel),
+    { timeout: 360_000 },
+  );
+
+  // Regression test for https://github.com/alchemy-run/alchemy/issues/1016.
+  //
+  // `hashViteInput` used to pass a relative root as both the directory and its
+  // base, resolving `app` as `<cwd>/app/app`. The empty match produced a constant
+  // input hash, so source edits were incorrectly treated as no-ops.
+  test.provider(
+    "Vite: a source edit changes the input hash when rootDir is relative",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+
+        yield* stack.destroy();
+
+        const absoluteRoot = yield* cloneFixture(fixtureDir, {
+          prefix: "alchemy-vite-relative-root-",
+          tempRoot,
+          entries: ["index.html", "package.json", "vite.config.ts", "src"],
+        });
+        // Relative to the process's anchored cwd (what a relative rootDir
+        // means to the engine) — a live `process.cwd()` read can race a
+        // concurrent tool's transient chdir.
+        const rootDir = path.relative(initialCwd, absoluteRoot);
+        const indexPath = path.join(absoluteRoot, "index.html");
+        const memoInclude = [
+          "index.html",
+          "src/**",
+          "package.json",
+          "vite.config.ts",
+        ];
+
+        expect(path.isAbsolute(rootDir)).toBe(false);
+        yield* fs.writeFileString(indexPath, htmlPage("relative-root-v1"));
+
+        const site1 = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.Website.Vite(
+              "ViteRelativeRoot",
+              viteProps(rootDir, memoInclude),
+            );
+          }),
+        );
+        expect(site1.hash?.input).toBeDefined();
+
+        yield* fs.writeFileString(indexPath, htmlPage("relative-root-v2"));
+
+        const site2 = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.Website.Vite(
+              "ViteRelativeRoot",
+              viteProps(rootDir, memoInclude),
+            );
+          }),
+        );
+        expect(site2.hash?.input).toBeDefined();
+        expect(site2.hash?.input).not.toEqual(site1.hash?.input);
+
+        yield* stack.destroy();
+        yield* waitForWorkerToBeDeleted(site1.workerName, accountId);
+      }).pipe(logLevel),
+    { timeout: 360_000 },
+  );
+
+  // Regression test for https://github.com/alchemy-run/alchemy/issues/792.
+  //
+  // A pure client-only Vite project (no vite.config.ts, no plugins, no worker
+  // entry) resolves as `appType: "spa"`, so the Cloudflare Vite plugin declares
+  // no `builder.buildApp`. On Vite 8, `builder.buildApp()` then runs post-order
+  // `buildApp` hooks *before* the default environment builds — which used to make
+  // our build-output plugin resolve while the client output was still undefined,
+  // so the deploy died with "Vite build produced neither assets nor server
+  // output". Detecting completion in `writeBundle` (per environment) instead of a
+  // post-order `buildApp` hook fixes it; this test proves the SPA path deploys.
+  test.provider(
+    "Vite: client-only SPA (no config, no plugins) builds and serves assets",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+
+        yield* stack.destroy();
+
+        const rootDir = yield* cloneFixture(spaFixtureDir, {
+          prefix: "alchemy-vite-spa-",
+          tempRoot,
+          entries: ["index.html", "package.json", "src"],
+        });
+        const indexPath = path.join(rootDir, "index.html");
+        const memoInclude = ["index.html", "src/**", "package.json"];
+
+        const marker = `vite-spa-${Date.now()}`;
+        yield* fs.writeFileString(indexPath, htmlPage(marker));
+
+        const site = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.Website.Vite(
+              "FixViteSpa",
+              viteProps(rootDir, memoInclude),
+            );
+          }),
+        );
+
+        expect(site.url).toBeDefined();
+        expect(site.hash?.input).toBeDefined();
+        yield* expectWorkerExists(site.workerName, accountId);
+        yield* expectUrlContains(`${site.url!}/`, marker, {
+          timeout: "120 seconds",
+          label: "spa marker",
+        });
+
+        yield* stack.destroy();
+        yield* waitForWorkerToBeDeleted(site.workerName, accountId);
+      }).pipe(logLevel),
+    { timeout: 360_000 },
+  );
+
+  // Foldkit (foldkit.dev) is an Effect-native Elm-architecture frontend
+  // framework. Its apps are plain client-only Vite projects (the Foldkit Vite
+  // plugin only adds HMR/devtools wiring), so `Cloudflare.Website.Vite` deploys
+  // them as-is. This pins that the Foldkit plugin composes with the injected
+  // Cloudflare Vite plugin and that deep links fall back to `index.html` via
+  // `single-page-application` not-found handling.
+  test.provider(
+    "Vite: Foldkit SPA deploys and serves with SPA fallback",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+
+        yield* stack.destroy();
+
+        const rootDir = yield* cloneFixture(foldkitFixtureDir, {
+          prefix: "alchemy-vite-foldkit-",
+          tempRoot,
+          entries: ["index.html", "package.json", "vite.config.ts", "src"],
+        });
+        const memoInclude = [
+          "index.html",
+          "src/**",
+          "package.json",
+          "vite.config.ts",
+        ];
+
+        const site = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.Website.Vite("FixViteFoldkit", {
+              ...viteProps(rootDir, memoInclude),
+              assets: {
+                notFoundHandling: "single-page-application",
+              },
+            });
+          }),
+        );
+
+        expect(site.url).toBeDefined();
+        expect(site.hash?.input).toBeDefined();
+        yield* expectWorkerExists(site.workerName, accountId);
+        yield* expectUrlContains(`${site.url!}/`, "Foldkit Fixture", {
+          timeout: "120 seconds",
+          label: "foldkit index",
+        });
+        // Deep link falls back to index.html so client-side routing can boot.
+        yield* expectUrlContains(`${site.url!}/counter/42`, "Foldkit Fixture", {
+          timeout: "60 seconds",
+          label: "foldkit spa fallback",
+        });
+
+        yield* stack.destroy();
+        yield* waitForWorkerToBeDeleted(site.workerName, accountId);
+      }).pipe(logLevel),
+    { timeout: 360_000 },
+  );
+
+  test.provider(
+    "Vite: class form deploys and serves the built assets",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+
+        yield* stack.destroy();
+
+        const rootDir = yield* cloneFixture(fixtureDir, {
+          prefix: "alchemy-vite-class-",
+          tempRoot,
+          entries: ["index.html", "package.json", "vite.config.ts", "src"],
+        });
+        const indexPath = path.join(rootDir, "index.html");
+        const memoInclude = [
+          "index.html",
+          "src/**",
+          "package.json",
+          "vite.config.ts",
+        ];
+
+        const marker = `vite-class-${Date.now()}`;
+        yield* fs.writeFileString(indexPath, htmlPage(marker));
+
+        const site1 = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* class FixVite extends Cloudflare.Website.Vite<FixVite>()(
+              "FixVite",
+              viteProps(rootDir, memoInclude),
+            ) {};
+          }),
+        );
+
+        expect(site1.url).toBeDefined();
+        expect(site1.hash?.input).toBeDefined();
+        yield* expectWorkerExists(site1.workerName, accountId);
+        yield* expectUrlContains(`${site1.url!}/`, marker, {
+          timeout: "120 seconds",
+          label: "class form marker",
+        });
+
+        yield* stack.destroy();
+        yield* waitForWorkerToBeDeleted(site1.workerName, accountId);
+      }).pipe(logLevel),
+    { timeout: 360_000 },
+  );
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Path-relocation behavior for the vite path
+  //
+  // `Cloudflare.Website.Vite` stores a path-insensitive `hash.input` made from
+  // the memo'd input tree plus build-affecting Vite options. The diff is:
+  //
+  //   `input !== output.hash?.input`
+  //
+  // — a pure content comparison that must be stable across rootDir
+  // moves. We delete the original rootDir between deploys to make the
+  // test fail loudly if anything still depends on the recorded path.
+  // ─────────────────────────────────────────────────────────────────────
+
+  test.provider(
+    "Vite: relocating rootDir (and deleting the old one) is a no-op when sources are identical",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+
+        yield* stack.destroy();
+
+        const memoInclude = [
+          "index.html",
+          "src/**",
+          "package.json",
+          "vite.config.ts",
+        ];
+        const marker = `vite-relocate-${Date.now()}`;
+
+        const rootA = yield* cloneFixture(fixtureDir, {
+          prefix: "alchemy-vite-relocate-a-",
+          tempRoot,
+          entries: ["index.html", "package.json", "vite.config.ts", "src"],
+        });
+        yield* fs.writeFileString(
+          path.join(rootA, "index.html"),
+          htmlPage(marker),
+        );
+
+        const site1 = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.Website.Vite(
+              "ViteReloc",
+              viteProps(rootA, memoInclude),
+            );
+          }),
+        );
+        expect(site1.hash?.input).toBeDefined();
+        yield* expectUrlContains(`${site1.url!}/`, marker, {
+          timeout: "120 seconds",
+          label: "deploy1 marker",
+        });
+
+        // Drop rootA so a stale path comparison can't quietly succeed.
+        yield* fs.remove(rootA, { recursive: true });
+
+        const rootB = yield* cloneFixture(fixtureDir, {
+          prefix: "alchemy-vite-relocate-b-",
+          tempRoot,
+          entries: ["index.html", "package.json", "vite.config.ts", "src"],
+        });
+        yield* fs.writeFileString(
+          path.join(rootB, "index.html"),
+          htmlPage(marker),
+        );
+
+        const site2 = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.Website.Vite(
+              "ViteReloc",
+              viteProps(rootB, memoInclude),
+            );
+          }),
+        );
+
+        // Identical sources ⇒ identical input hash ⇒ diff says
+        // unchanged ⇒ no rebuild required for the apply to succeed.
+        expect(site2.hash?.input).toEqual(site1.hash?.input);
+        yield* expectUrlContains(`${site2.url!}/`, marker, {
+          timeout: "60 seconds",
+          label: "deploy2 marker",
+        });
+
+        yield* stack.destroy();
+        yield* waitForWorkerToBeDeleted(site1.workerName, accountId);
+      }).pipe(logLevel),
+    { timeout: 360_000 },
+  );
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Workspace-aware memoization
+  //
+  // A Vite project in a monorepo can bundle source from sibling workspace
+  // packages. Those directories are discovered from the module graph at
+  // build time, persisted in `hash.workspaces` (relative to the Vite
+  // root), and included in the `hash.input` computation — so editing only
+  // a sibling package busts the memo and triggers a rebuild.
+  // ─────────────────────────────────────────────────────────────────────
+
+  test.provider(
+    "Vite: edits in a sibling workspace package bust the build memo",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+
+        yield* stack.destroy();
+
+        // Hand-rolled two-package workspace: `app` is the Vite root and
+        // `shared` is a sibling package whose source the client bundle
+        // imports directly (escaping the Vite root).
+        yield* fs.makeDirectory(tempRoot, { recursive: true });
+        const parent = yield* fs.makeTempDirectory({
+          prefix: "alchemy-vite-ws-",
+          directory: tempRoot,
+        });
+        yield* Effect.addFinalizer(
+          Exit.match({
+            onSuccess: () =>
+              Effect.ignore(fs.remove(parent, { recursive: true })),
+            onFailure: () => Effect.void,
+          }),
+        );
+        const rootDir = path.join(parent, "app");
+        const sharedDir = path.join(parent, "shared");
+
+        const writeShared = (marker: string) =>
+          fs.writeFileString(
+            path.join(sharedDir, "src/message.ts"),
+            `export const message = ${JSON.stringify(marker)};\n`,
+          );
+
+        yield* fs.makeDirectory(path.join(rootDir, "src"), { recursive: true });
+        yield* fs.makeDirectory(path.join(sharedDir, "src"), {
+          recursive: true,
+        });
+        yield* fs.writeFileString(
+          path.join(rootDir, "index.html"),
+          htmlPage("vite-workspace-fixture"),
+        );
+        yield* fs.writeFileString(
+          path.join(rootDir, "package.json"),
+          JSON.stringify({
+            name: "alchemy-vite-workspace-app",
+            version: "0.0.0",
+            private: true,
+            type: "module",
+          }),
+        );
+        // Same shape as vite-fixture/vite.config.ts: point the SSR build at
+        // the minimal worker entry so the cloudflare-vite-plugin can wrap it.
+        yield* fs.writeFileString(
+          path.join(rootDir, "vite.config.ts"),
+          `import { defineConfig } from "vite";
 export default defineConfig({
   environments: {
     ssr: { build: { rollupOptions: { input: "./src/worker.ts" } } },
   },
 });
 `,
-      );
-      yield* fs.writeFileString(
-        path.join(rootDir, "src/worker.ts"),
-        `type Env = { ASSETS: { fetch: (req: Request) => Promise<Response> } };
+        );
+        yield* fs.writeFileString(
+          path.join(rootDir, "src/worker.ts"),
+          `type Env = { ASSETS: { fetch: (req: Request) => Promise<Response> } };
 export default {
   fetch(request: Request, env: Env): Promise<Response> {
     return env.ASSETS.fetch(request);
   },
 };
 `,
-      );
-      // The client entry imports across the Vite root boundary into the
-      // sibling package's source.
-      yield* fs.writeFileString(
-        path.join(rootDir, "src/main.ts"),
-        `import { message } from "../../shared/src/message.ts";
+        );
+        // The client entry imports across the Vite root boundary into the
+        // sibling package's source.
+        yield* fs.writeFileString(
+          path.join(rootDir, "src/main.ts"),
+          `import { message } from "../../shared/src/message.ts";
 const el = document.getElementById("app");
 if (el) {
   el.textContent = message;
 }
 `,
-      );
-      yield* fs.writeFileString(
-        path.join(sharedDir, "package.json"),
-        JSON.stringify({
-          name: "alchemy-vite-workspace-shared",
-          version: "0.0.0",
-          private: true,
-          type: "module",
-        }),
-      );
+        );
+        yield* fs.writeFileString(
+          path.join(sharedDir, "package.json"),
+          JSON.stringify({
+            name: "alchemy-vite-workspace-shared",
+            version: "0.0.0",
+            private: true,
+            type: "module",
+          }),
+        );
 
-      const memoInclude = [
-        "index.html",
-        "src/**",
-        "package.json",
-        "vite.config.ts",
-      ];
-
-      const marker1 = `vite-ws-1-${Date.now()}`;
-      yield* writeShared(marker1);
-
-      const site1 = yield* stack.deploy(
-        Effect.gen(function* () {
-          return yield* Cloudflare.Website.Vite(
-            "ViteWorkspace",
-            viteProps(rootDir, memoInclude),
-          );
-        }),
-      );
-
-      expect(site1.url).toBeDefined();
-      expect(site1.hash?.input).toBeDefined();
-      // The sibling package was discovered from the module graph and
-      // persisted relative to the Vite root.
-      expect(site1.hash?.additionalWorkspaces).toContain("../shared");
-      yield* expectWorkerExists(site1.workerName, accountId);
-      yield* expectBundleContains(site1.url!, marker1, {
-        label: "workspace marker v1 in client bundle",
-      });
-
-      // ── deploy 2: edit ONLY the sibling package ────────────────────────
-      const marker2 = `vite-ws-2-${Date.now()}`;
-      yield* writeShared(marker2);
-
-      const site2 = yield* stack.deploy(
-        Effect.gen(function* () {
-          return yield* Cloudflare.Website.Vite(
-            "ViteWorkspace",
-            viteProps(rootDir, memoInclude),
-          );
-        }),
-      );
-
-      // Nothing under `rootDir` changed — only the sibling workspace did.
-      // The workspace-aware input hash must still bust the memo.
-      expect(site2.hash?.input).toBeDefined();
-      expect(site2.hash?.input).not.toEqual(site1.hash?.input);
-      expect(site2.hash?.additionalWorkspaces).toContain("../shared");
-      yield* expectBundleContains(site2.url!, marker2, {
-        label: "workspace marker v2 in client bundle",
-      });
-
-      // ── deploy 3: no changes anywhere ⇒ memo hit ───────────────────────
-      const site3 = yield* stack.deploy(
-        Effect.gen(function* () {
-          return yield* Cloudflare.Website.Vite(
-            "ViteWorkspace",
-            viteProps(rootDir, memoInclude),
-          );
-        }),
-      );
-
-      expect(site3.hash?.input).toEqual(site2.hash?.input);
-      expect(site3.hash?.additionalWorkspaces).toEqual(
-        site2.hash?.additionalWorkspaces,
-      );
-
-      yield* stack.destroy();
-      yield* waitForWorkerToBeDeleted(site1.workerName, accountId);
-    }).pipe(logLevel),
-  { timeout: 360_000 },
-);
-
-test.provider(
-  "Vite: `env` props are inlined and env-only changes redeploy",
-  (stack) =>
-    Effect.gen(function* () {
-      const { accountId } = yield* yield* CloudflareEnvironment;
-
-      yield* stack.destroy();
-
-      const rootDir = yield* cloneFixture(fixtureDir, {
-        prefix: "alchemy-vite-env-",
-        tempRoot,
-        entries: ["index.html", "package.json", "vite.config.ts", "src"],
-      });
-      const memoInclude = ["index.html", "src/**", "package.json"];
-      const marker1 = `vite-env-1-${Date.now()}`;
-
-      const site1 = yield* stack.deploy(
-        Effect.gen(function* () {
-          return yield* Cloudflare.Website.Vite("FixViteEnv", {
-            ...viteProps(rootDir, memoInclude),
-            env: { VITE_TEST_MARKER: marker1 },
-          });
-        }),
-      );
-
-      expect(site1.url).toBeDefined();
-      expect(site1.hash?.input).toBeDefined();
-      // Resolve the hashed bundle URL by reading the deployed HTML, then
-      // assert the marker that `main.ts` references via
-      // `import.meta.env.VITE_TEST_MARKER` was actually inlined into the
-      // served JS asset by `Cloudflare.Website.Vite`'s `env`-→-`define` plumbing.
-      yield* expectBundleContains(site1.url!, marker1, {
-        label: "VITE_TEST_MARKER v1 inlined into client bundle",
-      });
-
-      const marker2 = `vite-env-2-${Date.now()}`;
-      const site2 = yield* stack.deploy(
-        Effect.gen(function* () {
-          return yield* Cloudflare.Website.Vite("FixViteEnv", {
-            ...viteProps(rootDir, memoInclude),
-            env: { VITE_TEST_MARKER: marker2 },
-          });
-        }),
-      );
-
-      expect(site2.hash?.input).toBeDefined();
-      yield* expectBundleContains(site2.url!, marker2, {
-        label: "VITE_TEST_MARKER v2 inlined into client bundle",
-      });
-
-      yield* stack.destroy();
-      yield* waitForWorkerToBeDeleted(site1.workerName, accountId);
-    }).pipe(logLevel),
-  { timeout: 360_000 },
-);
-
-test.provider(
-  "Vite: worker entry can host a local Durable Object binding",
-  (stack) =>
-    Effect.gen(function* () {
-      const { accountId } = yield* yield* CloudflareEnvironment;
-
-      yield* stack.destroy();
-
-      const rootDir = yield* cloneFixture(doFixtureDir, {
-        prefix: "alchemy-vite-do-",
-        tempRoot,
-        // Keep the fixture's real stack file available for local
-        // `alchemy dev` smoke tests. The live deploy below uses an inline
-        // stack so cleanup stays under the provider test harness.
-        entries: [
-          "alchemy.run.ts",
+        const memoInclude = [
           "index.html",
+          "src/**",
           "package.json",
           "vite.config.ts",
-          "src",
-        ],
-      });
-      const memoInclude = [
-        "index.html",
-        "src/**",
-        "package.json",
-        "vite.config.ts",
-      ];
+        ];
 
-      const site = yield* stack.deploy(
-        Effect.gen(function* () {
-          return yield* Cloudflare.Website.Vite("ViteDo", {
-            ...viteProps(rootDir, memoInclude),
-            compatibility: {
-              date: "2026-03-17",
-              flags: ["nodejs_compat"],
-            },
-            assets: {
-              runWorkerFirst: ["/api/*"],
-            },
-            env: {
-              Counter: Cloudflare.DurableObject<ViteDoCounter>("Counter", {
-                className: "Counter",
-              }),
-            },
-          });
-        }),
-      );
+        const marker1 = `vite-ws-1-${Date.now()}`;
+        yield* writeShared(marker1);
 
-      expect(site.url).toBeDefined();
-      yield* expectWorkerExists(site.workerName, accountId);
-      yield* expectUrlContains(`${site.url!}/`, "Vite DO fixture", {
-        timeout: "120 seconds",
-        label: "vite do fixture assets",
-      });
-
-      const reset = yield* fetchJsonReady<{ ok: boolean }>(
-        `${site.url!}/api/reset`,
-      );
-      expect(reset.ok).toBe(true);
-
-      const first = yield* fetchJsonReady<{ count: number }>(
-        `${site.url!}/api/count`,
-      );
-      expect(first.count).toBe(1);
-
-      const second = yield* fetchJsonReady<{ count: number }>(
-        `${site.url!}/api/count`,
-      );
-      expect(second.count).toBe(2);
-
-      yield* stack.destroy();
-      yield* waitForWorkerToBeDeleted(site.workerName, accountId);
-    }).pipe(logLevel),
-  { timeout: 360_000 },
-);
-
-test.provider(
-  "Vite: Container binding on env deploys a container-backed DO class",
-  (stack) =>
-    Effect.gen(function* () {
-      const { accountId } = yield* yield* CloudflareEnvironment;
-
-      yield* stack.destroy();
-
-      const rootDir = yield* cloneFixture(containerFixtureDir, {
-        prefix: "alchemy-vite-container-",
-        tempRoot,
-        entries: ["index.html", "package.json", "vite.config.ts", "src"],
-      });
-      const memoInclude = [
-        "index.html",
-        "src/**",
-        "package.json",
-        "vite.config.ts",
-      ];
-
-      // A `Cloudflare.Container` declaration on `env` is Effect-shaped —
-      // before #997 the Vite build's env resolution ran it as an inlined
-      // env Effect and the deploy died before the build started.
-      const site = yield* stack.deploy(
-        Effect.gen(function* () {
-          return yield* Cloudflare.Website.Vite("ViteContainer", {
-            ...viteProps(rootDir, memoInclude),
-            compatibility: {
-              date: "2026-03-17",
-              flags: ["nodejs_compat"],
-            },
-            assets: {
-              runWorkerFirst: ["/api/*"],
-            },
-            env: {
-              ECHO: Cloudflare.Container("ViteEchoContainer", {
-                className: "EchoObject",
-                image: "mendhak/http-https-echo:latest",
-                observability: { logs: { enabled: true } },
-              }),
-            },
-          });
-        }),
-      );
-
-      expect(site.url).toBeDefined();
-      yield* expectWorkerExists(site.workerName, accountId);
-      yield* expectUrlContains(`${site.url!}/`, "Vite Container fixture", {
-        timeout: "120 seconds",
-        label: "vite container fixture assets",
-      });
-
-      // The echo image reflects the request as JSON ("method" only appears
-      // in a real echo response, never in an error page) — proof the request
-      // went Worker → DO class → container port 8080 and back.
-      const echo = yield* fetchContainerReady(
-        `${site.url!}/api/echo`,
-        "method",
-      );
-      expect(echo).toContain("method");
-
-      yield* stack.destroy();
-      yield* waitForWorkerToBeDeleted(site.workerName, accountId);
-    }).pipe(logLevel),
-  // Container image pull + push + rollout comfortably exceeds the plain
-  // Vite deploy budget (mirrors AsyncContainer.test.ts).
-  { timeout: 600_000 },
-);
-
-test.provider(
-  "Vite: main overrides the worker entry from the Vite config",
-  (stack) =>
-    Effect.gen(function* () {
-      const { accountId } = yield* yield* CloudflareEnvironment;
-
-      yield* stack.destroy();
-
-      const rootDir = yield* cloneFixture(doFixtureDir, {
-        prefix: "alchemy-vite-main-",
-        tempRoot,
-        entries: [
-          "alchemy.run.ts",
-          "index.html",
-          "package.json",
-          "vite.config.ts",
-          "src",
-        ],
-      });
-      const memoInclude = [
-        "index.html",
-        "src/**",
-        "package.json",
-        "vite.config.ts",
-      ];
-
-      // The fixture's vite.config.ts points the ssr environment at
-      // `src/worker.ts`. `main` must take precedence and deploy
-      // `src/worker-main.ts`, which re-exports the Durable Object and
-      // additionally answers `/api/entry`.
-      const site = yield* stack.deploy(
-        Effect.gen(function* () {
-          return yield* Cloudflare.Website.Vite("ViteMain", {
-            ...viteProps(rootDir, memoInclude),
-            main: "src/worker-main.ts",
-            compatibility: {
-              date: "2026-03-17",
-              flags: ["nodejs_compat"],
-            },
-            assets: {
-              runWorkerFirst: ["/api/*"],
-            },
-            env: {
-              Counter: Cloudflare.DurableObject<ViteDoCounter>("Counter", {
-                className: "Counter",
-              }),
-            },
-          });
-        }),
-      );
-
-      expect(site.url).toBeDefined();
-      yield* expectWorkerExists(site.workerName, accountId);
-
-      const entry = yield* fetchJsonReady<{ entry: string }>(
-        `${site.url!}/api/entry`,
-      );
-      expect(entry.entry).toBe("worker-main");
-
-      const reset = yield* fetchJsonReady<{ ok: boolean }>(
-        `${site.url!}/api/reset`,
-      );
-      expect(reset.ok).toBe(true);
-
-      const first = yield* fetchJsonReady<{ count: number }>(
-        `${site.url!}/api/count`,
-      );
-      expect(first.count).toBe(1);
-
-      yield* stack.destroy();
-      yield* waitForWorkerToBeDeleted(site.workerName, accountId);
-    }).pipe(logLevel),
-  { timeout: 360_000 },
-);
-
-test.provider(
-  "Vite: React Router RSC deploys from a distilled manifest",
-  (stack) =>
-    Effect.gen(function* () {
-      const { accountId } = yield* yield* CloudflareEnvironment;
-
-      yield* stack.destroy();
-
-      const rootDir = yield* cloneFixture(reactRouterRscFixtureDir, {
-        prefix: "alchemy-vite-rsc-",
-        tempRoot,
-        // Keep the fixture's stack file available for local `alchemy dev`
-        // smoke tests. The live deploy below uses an inline stack so cleanup
-        // stays under the provider test harness.
-        entries: [
-          "alchemy.run.ts",
-          "app",
-          "package.json",
-          "react-router-vite",
-          "tsconfig.json",
-          "vite.config.ts",
-        ],
-      });
-      const memoInclude = [
-        "app/**",
-        "react-router-vite/**",
-        "package.json",
-        "tsconfig.json",
-        "vite.config.ts",
-      ];
-      const compatibility = {
-        date: "2026-03-10",
-        flags: ["nodejs_compat"],
-      };
-      const assets = {
-        runWorkerFirst: true,
-      };
-      const viteEnvironments = { entry: "rsc", children: ["ssr"] };
-
-      const site = yield* stack.deploy(
-        Effect.gen(function* () {
-          return yield* Cloudflare.Website.Vite("ReactRouterRsc", {
-            ...viteProps(rootDir, memoInclude),
-            assets,
-            compatibility,
-            viteEnvironments,
-          });
-        }),
-      );
-
-      expect(site.url).toBeDefined();
-      yield* expectWorkerExists(site.workerName, accountId);
-      yield* expectUrlContains(`${site.url!}/`, "React Router Vite", {
-        timeout: "120 seconds",
-        label: "react router rsc home route",
-      });
-      yield* expectUrlContains(`${site.url!}/about`, "About", {
-        timeout: "60 seconds",
-        label: "react router rsc client route",
-      });
-
-      const render = yield* fetchJsonReady<{ ok: boolean; html: string }>(
-        `${site.url!}/worker-render`,
-      );
-      expect(render.ok).toBe(true);
-      expect(render.html).toContain("Worker render via the ssr environment.");
-
-      yield* stack.destroy();
-      yield* waitForWorkerToBeDeleted(site.workerName, accountId);
-    }).pipe(logLevel),
-  { timeout: 360_000 },
-);
-
-devTest.provider(
-  "Vite dev: each app runs in a child rooted at its own cwd",
-  (stack) =>
-    Effect.gen(function* () {
-      const fs = yield* FileSystem.FileSystem;
-      const path = yield* Path.Path;
-      yield* stack.destroy();
-
-      const entries = [
-        "index.html",
-        "package.json",
-        "vite.config.ts",
-        "worker.ts",
-      ];
-      const clone = (prefix: string) =>
-        cloneFixture(viteChildFixtureDir, { prefix, tempRoot, entries });
-      const [rootA, rootB] = yield* Effect.all(
-        [clone("alchemy-vite-child-a-"), clone("alchemy-vite-child-b-")],
-        { concurrency: "unbounded" },
-      );
-      yield* Effect.all([
-        fs.writeFileString(
-          path.join(rootA, "index.html"),
-          htmlPage("child-app-a"),
-        ),
-        fs.writeFileString(
-          path.join(rootB, "index.html"),
-          htmlPage("child-app-b"),
-        ),
-      ]);
-
-      const deployed = yield* stack.deploy(
-        Effect.gen(function* () {
-          const props = (rootDir: string) => ({
-            ...viteProps(rootDir, entries),
-            main: "worker.ts",
-            assets: { notFoundHandling: "single-page-application" as const },
-            dev: { port: 0 },
-          });
-          const appA = yield* Cloudflare.Website.Vite(
-            "ViteChildA",
-            props(rootA),
-          );
-          const appB = yield* Cloudflare.Website.Vite(
-            "ViteChildB",
-            props(rootB),
-          );
-          const defaultPortWorker = yield* Cloudflare.Worker(
-            "ViteChildDefaultPortWorker",
-            {
-              script:
-                'export default { fetch: () => new Response("default-port-worker") };',
-            },
-          );
-          return { appA, appB, defaultPortWorker };
-        }),
-      );
-
-      expect(deployed.appA.url).not.toBe(deployed.appB.url);
-      yield* Effect.all(
-        [
-          expectUrlContains(
-            deployed.defaultPortWorker.url!,
-            "default-port-worker",
-            {
-              timeout: "30 seconds",
-              label: "default-port worker",
-            },
-          ),
-          expectUrlContains(deployed.appA.url!, "child-app-a", {
-            timeout: "30 seconds",
-            label: "child A HTML",
+        const site1 = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.Website.Vite(
+              "ViteWorkspace",
+              viteProps(rootDir, memoInclude),
+            );
           }),
-          expectUrlContains(deployed.appB.url!, "child-app-b", {
-            timeout: "30 seconds",
-            label: "child B HTML",
-          }),
-          expectUrlContains(deployed.appA.url!, rootA, {
-            timeout: "30 seconds",
-            label: "child A cwd",
-          }),
-          expectUrlContains(deployed.appB.url!, rootB, {
-            timeout: "30 seconds",
-            label: "child B cwd",
-          }),
-        ],
-        { concurrency: "unbounded" },
-      );
-    }).pipe(Effect.ensuring(stack.destroy().pipe(Effect.ignore)), logLevel),
-  { timeout: 120_000 },
-);
+        );
 
-devTest.provider(
-  "Vite dev: TanStack Start keeps Alchemy-managed R2 bindings",
-  (stack) =>
-    Effect.gen(function* () {
-      const { accountId } = yield* yield* CloudflareEnvironment;
-      const fs = yield* FileSystem.FileSystem;
-      const path = yield* Path.Path;
-      const bucketNames = new Set<string>();
+        expect(site1.url).toBeDefined();
+        expect(site1.hash?.input).toBeDefined();
+        // The sibling package was discovered from the module graph and
+        // persisted relative to the Vite root.
+        expect(site1.hash?.additionalWorkspaces).toContain("../shared");
+        yield* expectWorkerExists(site1.workerName, accountId);
+        yield* expectBundleContains(site1.url!, marker1, {
+          label: "workspace marker v1 in client bundle",
+        });
 
-      const cleanup = Effect.gen(function* () {
+        // ── deploy 2: edit ONLY the sibling package ────────────────────────
+        const marker2 = `vite-ws-2-${Date.now()}`;
+        yield* writeShared(marker2);
+
+        const site2 = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.Website.Vite(
+              "ViteWorkspace",
+              viteProps(rootDir, memoInclude),
+            );
+          }),
+        );
+
+        // Nothing under `rootDir` changed — only the sibling workspace did.
+        // The workspace-aware input hash must still bust the memo.
+        expect(site2.hash?.input).toBeDefined();
+        expect(site2.hash?.input).not.toEqual(site1.hash?.input);
+        expect(site2.hash?.additionalWorkspaces).toContain("../shared");
+        yield* expectBundleContains(site2.url!, marker2, {
+          label: "workspace marker v2 in client bundle",
+        });
+
+        // ── deploy 3: no changes anywhere ⇒ memo hit ───────────────────────
+        const site3 = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.Website.Vite(
+              "ViteWorkspace",
+              viteProps(rootDir, memoInclude),
+            );
+          }),
+        );
+
+        expect(site3.hash?.input).toEqual(site2.hash?.input);
+        expect(site3.hash?.additionalWorkspaces).toEqual(
+          site2.hash?.additionalWorkspaces,
+        );
+
         yield* stack.destroy();
-        for (const bucketName of bucketNames) {
-          yield* waitForBucketToBeDeleted(bucketName, accountId);
-        }
-      });
+        yield* waitForWorkerToBeDeleted(site1.workerName, accountId);
+      }).pipe(logLevel),
+    { timeout: 360_000 },
+  );
 
-      const body = Effect.gen(function* () {
+  test.provider(
+    "Vite: `env` props are inlined and env-only changes redeploy",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+
         yield* stack.destroy();
 
-        const rootDir = yield* cloneFixture(tanstackDevBindingsFixtureDir, {
-          prefix: "alchemy-tanstack-dev-bindings-",
+        const rootDir = yield* cloneFixture(fixtureDir, {
+          prefix: "alchemy-vite-env-",
           tempRoot,
+          entries: ["index.html", "package.json", "vite.config.ts", "src"],
+        });
+        const memoInclude = ["index.html", "src/**", "package.json"];
+        const marker1 = `vite-env-1-${Date.now()}`;
+
+        const site1 = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.Website.Vite("FixViteEnv", {
+              ...viteProps(rootDir, memoInclude),
+              env: { VITE_TEST_MARKER: marker1 },
+            });
+          }),
+        );
+
+        expect(site1.url).toBeDefined();
+        expect(site1.hash?.input).toBeDefined();
+        // Resolve the hashed bundle URL by reading the deployed HTML, then
+        // assert the marker that `main.ts` references via
+        // `import.meta.env.VITE_TEST_MARKER` was actually inlined into the
+        // served JS asset by `Cloudflare.Website.Vite`'s `env`-→-`define` plumbing.
+        yield* expectBundleContains(site1.url!, marker1, {
+          label: "VITE_TEST_MARKER v1 inlined into client bundle",
+        });
+
+        const marker2 = `vite-env-2-${Date.now()}`;
+        const site2 = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.Website.Vite("FixViteEnv", {
+              ...viteProps(rootDir, memoInclude),
+              env: { VITE_TEST_MARKER: marker2 },
+            });
+          }),
+        );
+
+        expect(site2.hash?.input).toBeDefined();
+        yield* expectBundleContains(site2.url!, marker2, {
+          label: "VITE_TEST_MARKER v2 inlined into client bundle",
+        });
+
+        yield* stack.destroy();
+        yield* waitForWorkerToBeDeleted(site1.workerName, accountId);
+      }).pipe(logLevel),
+    { timeout: 360_000 },
+  );
+
+  test.provider(
+    "Vite: worker entry can host a local Durable Object binding",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+
+        yield* stack.destroy();
+
+        const rootDir = yield* cloneFixture(doFixtureDir, {
+          prefix: "alchemy-vite-do-",
+          tempRoot,
+          // Keep the fixture's real stack file available for local
+          // `alchemy dev` smoke tests. The live deploy below uses an inline
+          // stack so cleanup stays under the provider test harness.
           entries: [
             "alchemy.run.ts",
+            "index.html",
             "package.json",
-            "tsconfig.json",
             "vite.config.ts",
             "src",
           ],
         });
-        const indexRoutePath = path.join(rootDir, "src/routes/index.tsx");
         const memoInclude = [
+          "index.html",
           "src/**",
+          "package.json",
+          "vite.config.ts",
+        ];
+
+        const site = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.Website.Vite("ViteDo", {
+              ...viteProps(rootDir, memoInclude),
+              compatibility: {
+                date: "2026-03-17",
+                flags: ["nodejs_compat"],
+              },
+              assets: {
+                runWorkerFirst: ["/api/*"],
+              },
+              env: {
+                Counter: Cloudflare.DurableObject<ViteDoCounter>("Counter", {
+                  className: "Counter",
+                }),
+              },
+            });
+          }),
+        );
+
+        expect(site.url).toBeDefined();
+        yield* expectWorkerExists(site.workerName, accountId);
+        yield* expectUrlContains(`${site.url!}/`, "Vite DO fixture", {
+          timeout: "120 seconds",
+          label: "vite do fixture assets",
+        });
+
+        const reset = yield* fetchJsonReady<{ ok: boolean }>(
+          `${site.url!}/api/reset`,
+        );
+        expect(reset.ok).toBe(true);
+
+        const first = yield* fetchJsonReady<{ count: number }>(
+          `${site.url!}/api/count`,
+        );
+        expect(first.count).toBe(1);
+
+        const second = yield* fetchJsonReady<{ count: number }>(
+          `${site.url!}/api/count`,
+        );
+        expect(second.count).toBe(2);
+
+        yield* stack.destroy();
+        yield* waitForWorkerToBeDeleted(site.workerName, accountId);
+      }).pipe(logLevel),
+    { timeout: 360_000 },
+  );
+
+  test.provider(
+    "Vite: Container binding on env deploys a container-backed DO class",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+
+        yield* stack.destroy();
+
+        const rootDir = yield* cloneFixture(containerFixtureDir, {
+          prefix: "alchemy-vite-container-",
+          tempRoot,
+          entries: ["index.html", "package.json", "vite.config.ts", "src"],
+        });
+        const memoInclude = [
+          "index.html",
+          "src/**",
+          "package.json",
+          "vite.config.ts",
+        ];
+
+        // A `Cloudflare.Container` declaration on `env` is Effect-shaped —
+        // before #997 the Vite build's env resolution ran it as an inlined
+        // env Effect and the deploy died before the build started.
+        const site = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.Website.Vite("ViteContainer", {
+              ...viteProps(rootDir, memoInclude),
+              compatibility: {
+                date: "2026-03-17",
+                flags: ["nodejs_compat"],
+              },
+              assets: {
+                runWorkerFirst: ["/api/*"],
+              },
+              env: {
+                ECHO: Cloudflare.Container("ViteEchoContainer", {
+                  className: "EchoObject",
+                  image: "mendhak/http-https-echo:latest",
+                  observability: { logs: { enabled: true } },
+                }),
+              },
+            });
+          }),
+        );
+
+        expect(site.url).toBeDefined();
+        yield* expectWorkerExists(site.workerName, accountId);
+        yield* expectUrlContains(`${site.url!}/`, "Vite Container fixture", {
+          timeout: "120 seconds",
+          label: "vite container fixture assets",
+        });
+
+        // The echo image reflects the request as JSON ("method" only appears
+        // in a real echo response, never in an error page) — proof the request
+        // went Worker → DO class → container port 8080 and back.
+        const echo = yield* fetchContainerReady(
+          `${site.url!}/api/echo`,
+          "method",
+        );
+        expect(echo).toContain("method");
+
+        yield* stack.destroy();
+        yield* waitForWorkerToBeDeleted(site.workerName, accountId);
+      }).pipe(logLevel),
+    // Container image pull + push + rollout comfortably exceeds the plain
+    // Vite deploy budget (mirrors AsyncContainer.test.ts).
+    { timeout: 600_000 },
+  );
+
+  test.provider(
+    "Vite: main overrides the worker entry from the Vite config",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+
+        yield* stack.destroy();
+
+        const rootDir = yield* cloneFixture(doFixtureDir, {
+          prefix: "alchemy-vite-main-",
+          tempRoot,
+          entries: [
+            "alchemy.run.ts",
+            "index.html",
+            "package.json",
+            "vite.config.ts",
+            "src",
+          ],
+        });
+        const memoInclude = [
+          "index.html",
+          "src/**",
+          "package.json",
+          "vite.config.ts",
+        ];
+
+        // The fixture's vite.config.ts points the ssr environment at
+        // `src/worker.ts`. `main` must take precedence and deploy
+        // `src/worker-main.ts`, which re-exports the Durable Object and
+        // additionally answers `/api/entry`.
+        const site = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.Website.Vite("ViteMain", {
+              ...viteProps(rootDir, memoInclude),
+              main: "src/worker-main.ts",
+              compatibility: {
+                date: "2026-03-17",
+                flags: ["nodejs_compat"],
+              },
+              assets: {
+                runWorkerFirst: ["/api/*"],
+              },
+              env: {
+                Counter: Cloudflare.DurableObject<ViteDoCounter>("Counter", {
+                  className: "Counter",
+                }),
+              },
+            });
+          }),
+        );
+
+        expect(site.url).toBeDefined();
+        yield* expectWorkerExists(site.workerName, accountId);
+
+        const entry = yield* fetchJsonReady<{ entry: string }>(
+          `${site.url!}/api/entry`,
+        );
+        expect(entry.entry).toBe("worker-main");
+
+        const reset = yield* fetchJsonReady<{ ok: boolean }>(
+          `${site.url!}/api/reset`,
+        );
+        expect(reset.ok).toBe(true);
+
+        const first = yield* fetchJsonReady<{ count: number }>(
+          `${site.url!}/api/count`,
+        );
+        expect(first.count).toBe(1);
+
+        yield* stack.destroy();
+        yield* waitForWorkerToBeDeleted(site.workerName, accountId);
+      }).pipe(logLevel),
+    { timeout: 360_000 },
+  );
+
+  test.provider(
+    "Vite: React Router RSC deploys from a distilled manifest",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+
+        yield* stack.destroy();
+
+        const rootDir = yield* cloneFixture(reactRouterRscFixtureDir, {
+          prefix: "alchemy-vite-rsc-",
+          tempRoot,
+          // Keep the fixture's stack file available for local `alchemy dev`
+          // smoke tests. The live deploy below uses an inline stack so cleanup
+          // stays under the provider test harness.
+          entries: [
+            "alchemy.run.ts",
+            "app",
+            "package.json",
+            "react-router-vite",
+            "tsconfig.json",
+            "vite.config.ts",
+          ],
+        });
+        const memoInclude = [
+          "app/**",
+          "react-router-vite/**",
           "package.json",
           "tsconfig.json",
           "vite.config.ts",
-          "alchemy.run.ts",
         ];
-        const key = `dev-binding-${Date.now()}.txt`;
+        const compatibility = {
+          date: "2026-03-10",
+          flags: ["nodejs_compat"],
+        };
+        const assets = {
+          runWorkerFirst: true,
+        };
+        const viteEnvironments = { entry: "rsc", children: ["ssr"] };
 
-        yield* fs.writeFileString(
-          indexRoutePath,
-          tanstackIndexRouteSource("hmr-marker-v1"),
+        const site = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.Website.Vite("ReactRouterRsc", {
+              ...viteProps(rootDir, memoInclude),
+              assets,
+              compatibility,
+              viteEnvironments,
+            });
+          }),
         );
 
-        const deploy = (bucketId: string, marker: string) =>
-          stack.deploy(
-            Effect.gen(function* () {
-              const bucket = yield* Cloudflare.R2.Bucket(bucketId);
-              const worker = yield* Cloudflare.Website.Vite(
-                "TanStackDevBindings",
-                {
-                  ...viteProps(rootDir, memoInclude),
-                  assets: {
-                    runWorkerFirst: true,
-                  },
-                  dev: {
-                    port: 0,
-                  },
-                  env: {
-                    BUCKET: bucket,
-                    DEV_MARKER: marker,
-                  },
-                },
-              );
-              return { bucket, worker };
+        expect(site.url).toBeDefined();
+        yield* expectWorkerExists(site.workerName, accountId);
+        yield* expectUrlContains(`${site.url!}/`, "React Router Vite", {
+          timeout: "120 seconds",
+          label: "react router rsc home route",
+        });
+        yield* expectUrlContains(`${site.url!}/about`, "About", {
+          timeout: "60 seconds",
+          label: "react router rsc client route",
+        });
+
+        const render = yield* fetchJsonReady<{ ok: boolean; html: string }>(
+          `${site.url!}/worker-render`,
+        );
+        expect(render.ok).toBe(true);
+        expect(render.html).toContain("Worker render via the ssr environment.");
+
+        yield* stack.destroy();
+        yield* waitForWorkerToBeDeleted(site.workerName, accountId);
+      }).pipe(logLevel),
+    { timeout: 360_000 },
+  );
+
+  devTest.provider(
+    "Vite dev: each app runs in a child rooted at its own cwd",
+    (stack) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        yield* stack.destroy();
+
+        const entries = [
+          "index.html",
+          "package.json",
+          "vite.config.ts",
+          "worker.ts",
+        ];
+        const clone = (prefix: string) =>
+          cloneFixture(viteChildFixtureDir, { prefix, tempRoot, entries });
+        const [rootA, rootB] = yield* Effect.all(
+          [clone("alchemy-vite-child-a-"), clone("alchemy-vite-child-b-")],
+          { concurrency: "unbounded" },
+        );
+        yield* Effect.all([
+          fs.writeFileString(
+            path.join(rootA, "index.html"),
+            htmlPage("child-app-a"),
+          ),
+          fs.writeFileString(
+            path.join(rootB, "index.html"),
+            htmlPage("child-app-b"),
+          ),
+        ]);
+
+        const deployed = yield* stack.deploy(
+          Effect.gen(function* () {
+            const props = (rootDir: string) => ({
+              ...viteProps(rootDir, entries),
+              main: "worker.ts",
+              assets: { notFoundHandling: "single-page-application" as const },
+              dev: { port: 0 },
+            });
+            const appA = yield* Cloudflare.Website.Vite(
+              "ViteChildA",
+              props(rootA),
+            );
+            const appB = yield* Cloudflare.Website.Vite(
+              "ViteChildB",
+              props(rootB),
+            );
+            const defaultPortWorker = yield* Cloudflare.Worker(
+              "ViteChildDefaultPortWorker",
+              {
+                script:
+                  'export default { fetch: () => new Response("default-port-worker") };',
+              },
+            );
+            return { appA, appB, defaultPortWorker };
+          }),
+        );
+
+        expect(deployed.appA.url).not.toBe(deployed.appB.url);
+        yield* Effect.all(
+          [
+            expectUrlContains(
+              deployed.defaultPortWorker.url!,
+              "default-port-worker",
+              {
+                timeout: "30 seconds",
+                label: "default-port worker",
+              },
+            ),
+            expectUrlContains(deployed.appA.url!, "child-app-a", {
+              timeout: "30 seconds",
+              label: "child A HTML",
             }),
+            expectUrlContains(deployed.appB.url!, "child-app-b", {
+              timeout: "30 seconds",
+              label: "child B HTML",
+            }),
+            expectUrlContains(deployed.appA.url!, rootA, {
+              timeout: "30 seconds",
+              label: "child A cwd",
+            }),
+            expectUrlContains(deployed.appB.url!, rootB, {
+              timeout: "30 seconds",
+              label: "child B cwd",
+            }),
+          ],
+          { concurrency: "unbounded" },
+        );
+      }).pipe(Effect.ensuring(stack.destroy().pipe(Effect.ignore)), logLevel),
+    { timeout: 120_000 },
+  );
+
+  devTest.provider(
+    "Vite dev: TanStack Start keeps Alchemy-managed R2 bindings",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const bucketNames = new Set<string>();
+
+        const cleanup = Effect.gen(function* () {
+          yield* stack.destroy();
+          for (const bucketName of bucketNames) {
+            yield* waitForBucketToBeDeleted(bucketName, accountId);
+          }
+        });
+
+        const body = Effect.gen(function* () {
+          yield* stack.destroy();
+
+          const rootDir = yield* cloneFixture(tanstackDevBindingsFixtureDir, {
+            prefix: "alchemy-tanstack-dev-bindings-",
+            tempRoot,
+            entries: [
+              "alchemy.run.ts",
+              "package.json",
+              "tsconfig.json",
+              "vite.config.ts",
+              "src",
+            ],
+          });
+          const indexRoutePath = path.join(rootDir, "src/routes/index.tsx");
+          const memoInclude = [
+            "src/**",
+            "package.json",
+            "tsconfig.json",
+            "vite.config.ts",
+            "alchemy.run.ts",
+          ];
+          const key = `dev-binding-${Date.now()}.txt`;
+
+          yield* fs.writeFileString(
+            indexRoutePath,
+            tanstackIndexRouteSource("hmr-marker-v1"),
           );
 
-        const first = yield* deploy("DevBucketA", "dev-marker-v1");
-        bucketNames.add(first.bucket.bucketName);
-        expect(first.worker.url).toBeDefined();
-        const r2Url = (base: string) =>
-          joinUrl(base, `/api/r2?key=${encodeURIComponent(key)}`);
-        yield* expectUrlContains(
-          joinUrl(first.worker.url!, "/"),
-          "hmr-marker-v1",
-          {
-            timeout: "30 seconds",
-            label: "tanstack dev initial route",
-          },
+          const deploy = (bucketId: string, marker: string) =>
+            stack.deploy(
+              Effect.gen(function* () {
+                const bucket = yield* Cloudflare.R2.Bucket(bucketId);
+                const worker = yield* Cloudflare.Website.Vite(
+                  "TanStackDevBindings",
+                  {
+                    ...viteProps(rootDir, memoInclude),
+                    assets: {
+                      runWorkerFirst: true,
+                    },
+                    dev: {
+                      port: 0,
+                    },
+                    env: {
+                      BUCKET: bucket,
+                      DEV_MARKER: marker,
+                    },
+                  },
+                );
+                return { bucket, worker };
+              }),
+            );
+
+          const first = yield* deploy("DevBucketA", "dev-marker-v1");
+          bucketNames.add(first.bucket.bucketName);
+          expect(first.worker.url).toBeDefined();
+          const r2Url = (base: string) =>
+            joinUrl(base, `/api/r2?key=${encodeURIComponent(key)}`);
+          yield* expectUrlContains(
+            joinUrl(first.worker.url!, "/"),
+            "hmr-marker-v1",
+            {
+              timeout: "30 seconds",
+              label: "tanstack dev initial route",
+            },
+          );
+
+          const env1 = yield* fetchJsonReady<{ marker: string }>(
+            r2Url(first.worker.url!),
+          );
+          expect(env1.marker).toBe("dev-marker-v1");
+
+          const put1 = yield* putTextJsonReady<{ ok: boolean }>(
+            r2Url(first.worker.url!),
+            "from-a",
+          );
+          expect(put1.ok).toBe(true);
+
+          const get1 = yield* fetchJsonReady<{ value: string | null }>(
+            r2Url(first.worker.url!),
+          );
+          expect(get1.value).toBe("from-a");
+
+          // Change only a TanStack route file. The stack is not re-applied; the
+          // local Vite server should render the updated route through the same
+          // Alchemy proxy.
+          yield* fs.writeFileString(
+            indexRoutePath,
+            tanstackIndexRouteSource("hmr-marker-v2"),
+          );
+          yield* expectUrlContains(
+            joinUrl(first.worker.url!, "/"),
+            "hmr-marker-v2",
+            {
+              timeout: "30 seconds",
+              label: "tanstack dev updated route",
+            },
+          );
+
+          const second = yield* deploy("DevBucketB", "dev-marker-v2");
+          bucketNames.add(second.bucket.bucketName);
+          expect(second.worker.url).toBe(first.worker.url);
+
+          const env2 = yield* fetchJsonReady<{ marker: string }>(
+            r2Url(second.worker.url!),
+          );
+          expect(env2.marker).toBe("dev-marker-v2");
+
+          // The Worker was rebound to DevBucketB. The object written through
+          // DevBucketA should not be visible through the new binding.
+          const reboundRead = yield* fetchJsonReady<{ value: string | null }>(
+            r2Url(second.worker.url!),
+          );
+          expect(reboundRead.value).toBeNull();
+
+          const put2 = yield* putTextJsonReady<{ ok: boolean }>(
+            r2Url(second.worker.url!),
+            "from-b",
+          );
+          expect(put2.ok).toBe(true);
+
+          const get2 = yield* fetchJsonReady<{ value: string | null }>(
+            r2Url(second.worker.url!),
+          );
+          expect(get2.value).toBe("from-b");
+        });
+
+        const exit = yield* Effect.exit(body);
+        if (Exit.isSuccess(exit)) {
+          yield* cleanup;
+          return exit.value;
+        }
+
+        yield* cleanup.pipe(
+          Effect.tapError((error) =>
+            Effect.logError("Vite dev live test cleanup failed", error),
+          ),
+          Effect.ignore,
         );
-
-        const env1 = yield* fetchJsonReady<{ marker: string }>(
-          r2Url(first.worker.url!),
-        );
-        expect(env1.marker).toBe("dev-marker-v1");
-
-        const put1 = yield* putTextJsonReady<{ ok: boolean }>(
-          r2Url(first.worker.url!),
-          "from-a",
-        );
-        expect(put1.ok).toBe(true);
-
-        const get1 = yield* fetchJsonReady<{ value: string | null }>(
-          r2Url(first.worker.url!),
-        );
-        expect(get1.value).toBe("from-a");
-
-        // Change only a TanStack route file. The stack is not re-applied; the
-        // local Vite server should render the updated route through the same
-        // Alchemy proxy.
-        yield* fs.writeFileString(
-          indexRoutePath,
-          tanstackIndexRouteSource("hmr-marker-v2"),
-        );
-        yield* expectUrlContains(
-          joinUrl(first.worker.url!, "/"),
-          "hmr-marker-v2",
-          {
-            timeout: "30 seconds",
-            label: "tanstack dev updated route",
-          },
-        );
-
-        const second = yield* deploy("DevBucketB", "dev-marker-v2");
-        bucketNames.add(second.bucket.bucketName);
-        expect(second.worker.url).toBe(first.worker.url);
-
-        const env2 = yield* fetchJsonReady<{ marker: string }>(
-          r2Url(second.worker.url!),
-        );
-        expect(env2.marker).toBe("dev-marker-v2");
-
-        // The Worker was rebound to DevBucketB. The object written through
-        // DevBucketA should not be visible through the new binding.
-        const reboundRead = yield* fetchJsonReady<{ value: string | null }>(
-          r2Url(second.worker.url!),
-        );
-        expect(reboundRead.value).toBeNull();
-
-        const put2 = yield* putTextJsonReady<{ ok: boolean }>(
-          r2Url(second.worker.url!),
-          "from-b",
-        );
-        expect(put2.ok).toBe(true);
-
-        const get2 = yield* fetchJsonReady<{ value: string | null }>(
-          r2Url(second.worker.url!),
-        );
-        expect(get2.value).toBe("from-b");
-      });
-
-      const exit = yield* Effect.exit(body);
-      if (Exit.isSuccess(exit)) {
-        yield* cleanup;
-        return exit.value;
-      }
-
-      yield* cleanup.pipe(
-        Effect.tapError((error) =>
-          Effect.logError("Vite dev live test cleanup failed", error),
-        ),
-        Effect.ignore,
-      );
-      return yield* Effect.failCause(exit.cause);
-    }).pipe(logLevel),
-  { timeout: 360_000 },
-);
+        return yield* Effect.failCause(exit.cause);
+      }).pipe(logLevel),
+    { timeout: 360_000 },
+  );
+});
 
 const freshConn = HttpClient.mapRequest(
   HttpClientRequest.setHeader("connection", "close"),

--- a/packages/alchemy/test/Cloudflare/Website/ViteRoutePrefix.test.ts
+++ b/packages/alchemy/test/Cloudflare/Website/ViteRoutePrefix.test.ts
@@ -19,7 +19,7 @@ import { findZoneByName } from "@/Cloudflare/Zone/lookup";
 import * as Test from "@/Test/Alchemy";
 import * as dns from "@distilled.cloud/cloudflare/dns";
 import * as workers from "@distilled.cloud/cloudflare/workers";
-import { expect } from "alchemy-test";
+import { describe, expect } from "alchemy-test";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
@@ -209,116 +209,120 @@ const evaluateSite = Effect.fn(function* (pageUrl: string, label: string) {
   return { page, src, script };
 });
 
-test.provider(
-  "Vite: base from vite.config.ts serves the site on a path-prefixed zone route",
-  (stack) =>
-    Effect.gen(function* () {
-      const { accountId } = yield* yield* CloudflareEnvironment;
-      const fs = yield* FileSystem.FileSystem;
-      const path = yield* Path.Path;
-      const zoneId = yield* resolveZoneId;
+// Tests are independent (per-test scratch stacks, private fixture clones),
+// so run them concurrently; suites are sequential by default.
+describe.concurrent("ViteRoutePrefix", () => {
+  test.provider(
+    "Vite: base from vite.config.ts serves the site on a path-prefixed zone route",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const zoneId = yield* resolveZoneId;
 
-      yield* stack.destroy();
-      yield* purgeRoutes(zoneId, routePattern);
-      yield* ensureApexPlaceholder(zoneId);
+        yield* stack.destroy();
+        yield* purgeRoutes(zoneId, routePattern);
+        yield* ensureApexPlaceholder(zoneId);
 
-      const rootDir = yield* cloneFixture(spaFixtureDir, {
-        prefix: "alchemy-vite-route-",
-        tempRoot,
-        entries: ["index.html", "package.json", "src"],
-      });
-      yield* fs.writeFileString(path.join(rootDir, "index.html"), htmlPage);
-      // The base lives in the app's own Vite config — the deploy adopts
-      // the resolved value; nothing is configured on the alchemy side.
-      yield* fs.writeFileString(
-        path.join(rootDir, "vite.config.ts"),
-        `import { defineConfig } from "vite";\n\nexport default defineConfig({ base: "${basePath}/" });\n`,
-      );
-      const memoInclude = [
-        "index.html",
-        "src/**",
-        "package.json",
-        "vite.config.ts",
-      ];
-
-      let workerName: string | undefined;
-
-      yield* Effect.gen(function* () {
-        const site = yield* stack.deploy(
-          Effect.gen(function* () {
-            return yield* Cloudflare.Website.Vite("ViteRoutePrefix", {
-              rootDir,
-              workersDev: true,
-              compatibility: {
-                date: "2024-09-23",
-                flags: ["nodejs_compat"],
-              },
-              memo: { include: memoInclude },
-              assets: { notFoundHandling: "single-page-application" },
-              routes: [{ pattern: routePattern, zoneName }],
-            });
-          }),
+        const rootDir = yield* cloneFixture(spaFixtureDir, {
+          prefix: "alchemy-vite-route-",
+          tempRoot,
+          entries: ["index.html", "package.json", "src"],
+        });
+        yield* fs.writeFileString(path.join(rootDir, "index.html"), htmlPage);
+        // The base lives in the app's own Vite config — the deploy adopts
+        // the resolved value; nothing is configured on the alchemy side.
+        yield* fs.writeFileString(
+          path.join(rootDir, "vite.config.ts"),
+          `import { defineConfig } from "vite";\n\nexport default defineConfig({ base: "${basePath}/" });\n`,
         );
-        workerName = site.workerName;
+        const memoInclude = [
+          "index.html",
+          "src/**",
+          "package.json",
+          "vite.config.ts",
+        ];
 
-        expect(site.url).toBeDefined();
-        expect(site.routes).toHaveLength(1);
-        expect(site.routes[0]?.pattern).toEqual(routePattern);
+        let workerName: string | undefined;
 
-        // Control — the same manifest serves under the prefix on
-        // workers.dev too (the manifest is nested, not the route).
-        const control = yield* evaluateSite(
-          `${site.url!}${basePath}/`,
-          "workers.dev",
+        yield* Effect.gen(function* () {
+          const site = yield* stack.deploy(
+            Effect.gen(function* () {
+              return yield* Cloudflare.Website.Vite("ViteRoutePrefix", {
+                rootDir,
+                workersDev: true,
+                compatibility: {
+                  date: "2024-09-23",
+                  flags: ["nodejs_compat"],
+                },
+                memo: { include: memoInclude },
+                assets: { notFoundHandling: "single-page-application" },
+                routes: [{ pattern: routePattern, zoneName }],
+              });
+            }),
+          );
+          workerName = site.workerName;
+
+          expect(site.url).toBeDefined();
+          expect(site.routes).toHaveLength(1);
+          expect(site.routes[0]?.pattern).toEqual(routePattern);
+
+          // Control — the same manifest serves under the prefix on
+          // workers.dev too (the manifest is nested, not the route).
+          const control = yield* evaluateSite(
+            `${site.url!}${basePath}/`,
+            "workers.dev",
+          );
+          expect(control.page.status).toBe(200);
+          expect(control.page.body).toContain(marker);
+          // Vite `base` bakes the prefix into the emitted script URL.
+          expect(control.src).toContain(`${basePath}/`);
+          expect(control.script?.status).toBe(200);
+          expect(control.script?.contentType).toContain("javascript");
+
+          // The point of the feature: the site works end-to-end behind the
+          // path-prefixed zone route — HTML serves AND the module script it
+          // references resolves under the prefix (inside the route).
+          const routed = yield* evaluateSite(routePageUrl, "zone route");
+          expect(routed.page.status).toBe(200);
+          expect(routed.page.body).toContain(marker);
+          expect(routed.script?.status).toBe(200);
+          expect(routed.script?.contentType).toContain("javascript");
+          // `(hydrated)` is a string literal in the fixture's client module,
+          // so it proves the response is the real script — a 404 here would
+          // be answered by the SPA fallback with the shell, which contains
+          // the marker but never that literal.
+          expect(routed.script?.body).toContain("(hydrated)");
+          expect(
+            routed.script?.url.startsWith(`https://${zoneName}${basePath}/`),
+          ).toBe(true);
+
+          // Cloudflare's SPA fallback resolves `/index.html` at the manifest
+          // root, hard-coded — the shell is aliased back there so client-side
+          // routes under the base still boot the app.
+          const deep = yield* probeStable(
+            `https://${zoneName}${basePath}/deep/route`,
+          );
+          yield* Effect.log(
+            `[spa deep link] ${deep.status} ${deep.contentType ?? "-"} :: ${excerpt(deep.body)}`,
+          );
+          expect(deep.status).toBe(200);
+          expect(deep.body).toContain(marker);
+        }).pipe(
+          Effect.ensuring(
+            Effect.gen(function* () {
+              yield* stack.destroy().pipe(Effect.ignore);
+              yield* purgeRoutes(zoneId, routePattern).pipe(Effect.ignore);
+              if (workerName) {
+                yield* waitForWorkerToBeDeleted(workerName, accountId).pipe(
+                  Effect.ignore,
+                );
+              }
+            }),
+          ),
         );
-        expect(control.page.status).toBe(200);
-        expect(control.page.body).toContain(marker);
-        // Vite `base` bakes the prefix into the emitted script URL.
-        expect(control.src).toContain(`${basePath}/`);
-        expect(control.script?.status).toBe(200);
-        expect(control.script?.contentType).toContain("javascript");
-
-        // The point of the feature: the site works end-to-end behind the
-        // path-prefixed zone route — HTML serves AND the module script it
-        // references resolves under the prefix (inside the route).
-        const routed = yield* evaluateSite(routePageUrl, "zone route");
-        expect(routed.page.status).toBe(200);
-        expect(routed.page.body).toContain(marker);
-        expect(routed.script?.status).toBe(200);
-        expect(routed.script?.contentType).toContain("javascript");
-        // `(hydrated)` is a string literal in the fixture's client module,
-        // so it proves the response is the real script — a 404 here would
-        // be answered by the SPA fallback with the shell, which contains
-        // the marker but never that literal.
-        expect(routed.script?.body).toContain("(hydrated)");
-        expect(
-          routed.script?.url.startsWith(`https://${zoneName}${basePath}/`),
-        ).toBe(true);
-
-        // Cloudflare's SPA fallback resolves `/index.html` at the manifest
-        // root, hard-coded — the shell is aliased back there so client-side
-        // routes under the base still boot the app.
-        const deep = yield* probeStable(
-          `https://${zoneName}${basePath}/deep/route`,
-        );
-        yield* Effect.log(
-          `[spa deep link] ${deep.status} ${deep.contentType ?? "-"} :: ${excerpt(deep.body)}`,
-        );
-        expect(deep.status).toBe(200);
-        expect(deep.body).toContain(marker);
-      }).pipe(
-        Effect.ensuring(
-          Effect.gen(function* () {
-            yield* stack.destroy().pipe(Effect.ignore);
-            yield* purgeRoutes(zoneId, routePattern).pipe(Effect.ignore);
-            if (workerName) {
-              yield* waitForWorkerToBeDeleted(workerName, accountId).pipe(
-                Effect.ignore,
-              );
-            }
-          }),
-        ),
-      );
-    }).pipe(logLevel),
-  { timeout: 360_000 },
-);
+      }).pipe(logLevel),
+    { timeout: 360_000 },
+  );
+});

--- a/packages/alchemy/test/Cloudflare/Website/Waku.local.test.ts
+++ b/packages/alchemy/test/Cloudflare/Website/Waku.local.test.ts
@@ -4,7 +4,7 @@ import { isLocalId } from "@/Cloudflare/LocalRuntime";
 import * as Alchemy from "@/index.ts";
 import * as Test from "@/Test/Alchemy";
 import * as kv from "@distilled.cloud/cloudflare/kv";
-import { expect } from "alchemy-test";
+import { describe, expect } from "alchemy-test";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
@@ -93,202 +93,228 @@ const kvRoundTrip = Effect.fn(function* (
  * waku's own dev server serves the app behind the alchemy dev proxy, with
  * the `kv_namespace` binding lowered onto the local workerd simulator.
  */
-test.provider(
-  "Waku dev: local dev server renders RSC SSR with bindings, local KV, and HMR",
-  (stack) =>
-    Effect.gen(function* () {
-      const fs = yield* FileSystem.FileSystem;
-      const path = yield* Path.Path;
+// Tests are independent (per-test scratch stacks, private fixture clones),
+// so run them concurrently; suites are sequential by default.
+describe.concurrent("Waku dev", () => {
+  test.provider(
+    "Waku dev: local dev server renders RSC SSR with bindings, local KV, and HMR",
+    (stack) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
 
-      yield* stack.destroy();
+        yield* stack.destroy();
 
-      const rootDir = yield* cloneFixture(fixtureDir, {
-        prefix: "alchemy-waku-dev-",
-        tempRoot,
-        entries: fixtureEntries,
-      });
+        const rootDir = yield* cloneFixture(fixtureDir, {
+          prefix: "alchemy-waku-dev-",
+          tempRoot,
+          entries: fixtureEntries,
+        });
 
-      const bindingMarker = "waku-dev-binding-marker";
+        const bindingMarker = "waku-dev-binding-marker";
 
-      const { site, siteKv } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const siteKv = yield* Cloudflare.KV.Namespace("WakuLocalKV");
-          const site = yield* Cloudflare.Website.Waku("WakuLocal", {
-            rootDir,
-            dev: { port: 0 },
-            memo: {
-              include: ["src/**", "public/**", "package.json", "tsconfig.json"],
-            },
-            env: {
-              MESSAGE: bindingMarker,
-              SITE_KV: siteKv,
-            },
-          });
-          return { site, siteKv };
-        }),
-      );
-
-      // Local identity: the url points at the alchemy dev proxy — no
-      // cloud Worker exists — and the namespace id carries the `dev:`
-      // marker, proof the KV provider never called the cloud.
-      expect(site.url).toBeDefined();
-      expect(site.url).toMatch(/^http:\/\/localhost:\d+/);
-      expect(isLocalId(siteKv.namespaceId)).toBe(true);
-
-      // Dynamic RSC page rendered by waku's dev server (rsc environment
-      // runs in workerd behind the proxy).
-      yield* expectUrlContains(`${site.url!}/`, "WAKU_PAGE_MARKER", {
-        timeout: "120 seconds",
-        label: "waku dev dynamic home page",
-      });
-
-      // The page reads the `MESSAGE` binding from `cloudflare:workers`
-      // env — proves alchemy-managed bindings reach the dev RSC server.
-      yield* expectUrlContains(`${site.url!}/`, `MESSAGE=${bindingMarker}`, {
-        timeout: "60 seconds",
-        label: "waku dev env binding in SSR output",
-      });
-
-      // Static asset from `public/` through the dev server.
-      yield* expectUrlContains(`${site.url!}/hello.txt`, "hello from public/", {
-        timeout: "60 seconds",
-        label: "waku dev static asset",
-      });
-
-      // The KV binding round-trips through the `/api/kv` route against the
-      // local simulator.
-      const roundTrip = yield* kvRoundTrip(
-        site.url!,
-        "waku-dev-key",
-        "kv-dev-value",
-      );
-      expect(roundTrip.value).toBe("kv-dev-value");
-
-      // ── HMR: edit the page in place; the dev server rebuilds and serves
-      // the new marker at the same URL without a redeploy ─────────────────
-      const indexPath = path.join(rootDir, "src/pages/index.tsx");
-      const index = yield* fs.readFileString(indexPath);
-      yield* fs.writeFileString(
-        indexPath,
-        index.replace("WAKU_PAGE_MARKER", "WAKU_PAGE_MARKER_V2"),
-      );
-
-      // Bounded poll; transient non-200s mid-rebuild are retried inside
-      // expectUrlContains' budget.
-      yield* expectUrlContains(`${site.url!}/`, "WAKU_PAGE_MARKER_V2", {
-        timeout: "120 seconds",
-        label: "waku dev page after HMR edit",
-      });
-
-      // The KV binding survives the rebuild: the previous write is still
-      // readable and new writes land.
-      const afterHmr = yield* kvRoundTrip(
-        site.url!,
-        "waku-dev-key-2",
-        "kv-dev-value-2",
-      );
-      expect(afterHmr.value).toBe("kv-dev-value-2");
-      const stillThere = yield* requestJsonReady<{ value: string | null }>(
-        HttpClientRequest.get(`${site.url!}/api/kv?key=waku-dev-key`),
-      );
-      expect(stillThere.value).toBe("kv-dev-value");
-
-      yield* stack.destroy();
-    }).pipe(logLevel),
-  { timeout: 300_000 },
-);
-
-/**
- * `Alchemy.remote()` opts the namespace OUT of local emulation: even under
- * `alchemy dev` it is created on real Cloudflare and the dev worker's
- * binding proxies to it remotely. Out-of-band reads through the cloud API
- * prove the local site's writes landed in the real namespace, and destroy
- * (stamped-mode delete path) removes it from the cloud.
- */
-test.provider(
-  "Waku dev: Alchemy.remote() KV namespace runs live behind the local site",
-  (stack) =>
-    Effect.gen(function* () {
-      yield* stack.destroy();
-
-      const rootDir = yield* cloneFixture(fixtureDir, {
-        prefix: "alchemy-waku-dev-remote-",
-        tempRoot,
-        entries: fixtureEntries,
-      });
-
-      const { site, liveKv } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const liveKv = yield* Cloudflare.KV.Namespace("WakuRemoteKV").pipe(
-            Alchemy.remote(),
-          );
-          const site = yield* Cloudflare.Website.Waku("WakuLocalRemoteKV", {
-            rootDir,
-            dev: { port: 0 },
-            memo: {
-              include: ["src/**", "public/**", "package.json", "tsconfig.json"],
-            },
-            env: {
-              MESSAGE: "waku-dev-remote-marker",
-              SITE_KV: liveKv,
-            },
-          });
-          return { site, liveKv };
-        }),
-      );
-
-      // The site is local, the namespace is REAL: a non-`dev:` id proves
-      // the live provider ran even in a dev deploy.
-      expect(site.url).toMatch(/^http:\/\/localhost:\d+/);
-      expect(isLocalId(liveKv.namespaceId)).toBe(false);
-
-      // Write through the locally-served site into the remote-proxied
-      // binding.
-      const roundTrip = yield* kvRoundTrip(
-        site.url!,
-        "waku-remote-key",
-        "kv-remote-value",
-      );
-      expect(roundTrip.value).toBe("kv-remote-value");
-
-      // Out-of-band: the write is visible through the cloud API — the
-      // remote-proxied binding really hit the live namespace.
-      const { accountId } = yield* yield* CloudflareEnvironment;
-      const rawValue = yield* kv
-        .getNamespaceValue({
-          accountId,
-          namespaceId: liveKv.namespaceId,
-          keyName: "waku-remote-key",
-        })
-        .pipe(
-          Effect.flatMap((res) =>
-            Effect.tryPromise(() =>
-              new Response(
-                Stream.toReadableStream(res.body) as BodyInit,
-              ).text(),
-            ),
-          ),
-          // The KV REST read can lag the proxied write briefly.
-          Effect.retry({
-            while: (e) => e._tag === "KeyNotFound",
-            schedule: Schedule.exponential("1 second", 1.5),
-            times: 8,
+        const { site, siteKv } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const siteKv = yield* Cloudflare.KV.Namespace("WakuLocalKV");
+            const site = yield* Cloudflare.Website.Waku("WakuLocal", {
+              rootDir,
+              dev: { port: 0 },
+              memo: {
+                include: [
+                  "src/**",
+                  "public/**",
+                  "package.json",
+                  "tsconfig.json",
+                ],
+              },
+              env: {
+                MESSAGE: bindingMarker,
+                SITE_KV: siteKv,
+              },
+            });
+            return { site, siteKv };
           }),
         );
-      expect(rawValue).toBe("kv-remote-value");
 
-      yield* stack.destroy();
+        // Local identity: the url points at the alchemy dev proxy — no
+        // cloud Worker exists — and the namespace id carries the `dev:`
+        // marker, proof the KV provider never called the cloud.
+        expect(site.url).toBeDefined();
+        expect(site.url).toMatch(/^http:\/\/localhost:\d+/);
+        expect(isLocalId(siteKv.namespaceId)).toBe(true);
 
-      // The live namespace was deleted from the cloud on destroy (its
-      // state row is stamped live, so the live provider handles the delete
-      // even in a dev run).
-      const gone = yield* kv
-        .getNamespace({ accountId, namespaceId: liveKv.namespaceId })
-        .pipe(
-          Effect.as(false),
-          Effect.catchTag("NamespaceNotFound", () => Effect.succeed(true)),
+        // Dynamic RSC page rendered by waku's dev server (rsc environment
+        // runs in workerd behind the proxy). Waku's cold first compile
+        // (RSC + vite dep optimization) can exceed 120s when the whole
+        // suite's builds and dev servers contend for the CPU.
+        yield* expectUrlContains(`${site.url!}/`, "WAKU_PAGE_MARKER", {
+          timeout: "180 seconds",
+          label: "waku dev dynamic home page",
+        });
+
+        // The page reads the `MESSAGE` binding from `cloudflare:workers`
+        // env — proves alchemy-managed bindings reach the dev RSC server.
+        yield* expectUrlContains(`${site.url!}/`, `MESSAGE=${bindingMarker}`, {
+          timeout: "60 seconds",
+          label: "waku dev env binding in SSR output",
+        });
+
+        // Static asset from `public/` through the dev server.
+        yield* expectUrlContains(
+          `${site.url!}/hello.txt`,
+          "hello from public/",
+          {
+            timeout: "60 seconds",
+            label: "waku dev static asset",
+          },
         );
-      expect(gone).toBe(true);
-    }).pipe(logLevel),
-  { timeout: 300_000 },
-);
+
+        // The KV binding round-trips through the `/api/kv` route against the
+        // local simulator.
+        const roundTrip = yield* kvRoundTrip(
+          site.url!,
+          "waku-dev-key",
+          "kv-dev-value",
+        );
+        expect(roundTrip.value).toBe("kv-dev-value");
+
+        // ── HMR: edit the page in place; the dev server rebuilds and serves
+        // the new marker at the same URL without a redeploy ─────────────────
+        const indexPath = path.join(rootDir, "src/pages/index.tsx");
+        const index = yield* fs.readFileString(indexPath);
+        yield* fs.writeFileString(
+          indexPath,
+          index.replace("WAKU_PAGE_MARKER", "WAKU_PAGE_MARKER_V2"),
+        );
+
+        // Bounded poll; transient non-200s mid-rebuild are retried inside
+        // expectUrlContains' budget.
+        yield* expectUrlContains(`${site.url!}/`, "WAKU_PAGE_MARKER_V2", {
+          timeout: "120 seconds",
+          label: "waku dev page after HMR edit",
+        });
+
+        // The KV binding survives the rebuild: the previous write is still
+        // readable and new writes land.
+        const afterHmr = yield* kvRoundTrip(
+          site.url!,
+          "waku-dev-key-2",
+          "kv-dev-value-2",
+        );
+        expect(afterHmr.value).toBe("kv-dev-value-2");
+        const stillThere = yield* requestJsonReady<{ value: string | null }>(
+          HttpClientRequest.get(`${site.url!}/api/kv?key=waku-dev-key`),
+        );
+        expect(stillThere.value).toBe("kv-dev-value");
+
+        yield* stack.destroy();
+      }).pipe(logLevel),
+    { timeout: 300_000 },
+  );
+
+  /**
+   * `Alchemy.remote()` opts the namespace OUT of local emulation: even under
+   * `alchemy dev` it is created on real Cloudflare and the dev worker's
+   * binding proxies to it remotely. Out-of-band reads through the cloud API
+   * prove the local site's writes landed in the real namespace, and destroy
+   * (stamped-mode delete path) removes it from the cloud.
+   */
+  test.provider(
+    "Waku dev: Alchemy.remote() KV namespace runs live behind the local site",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const rootDir = yield* cloneFixture(fixtureDir, {
+          prefix: "alchemy-waku-dev-remote-",
+          tempRoot,
+          entries: fixtureEntries,
+        });
+
+        const { site, liveKv } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const liveKv = yield* Cloudflare.KV.Namespace("WakuRemoteKV").pipe(
+              Alchemy.remote(),
+            );
+            const site = yield* Cloudflare.Website.Waku("WakuLocalRemoteKV", {
+              rootDir,
+              dev: { port: 0 },
+              memo: {
+                include: [
+                  "src/**",
+                  "public/**",
+                  "package.json",
+                  "tsconfig.json",
+                ],
+              },
+              env: {
+                MESSAGE: "waku-dev-remote-marker",
+                SITE_KV: liveKv,
+              },
+            });
+            return { site, liveKv };
+          }),
+        );
+
+        // The site is local, the namespace is REAL: a non-`dev:` id proves
+        // the live provider ran even in a dev deploy.
+        expect(site.url).toMatch(/^http:\/\/localhost:\d+/);
+        expect(isLocalId(liveKv.namespaceId)).toBe(false);
+
+        // Write through the locally-served site into the remote-proxied
+        // binding.
+        const roundTrip = yield* kvRoundTrip(
+          site.url!,
+          "waku-remote-key",
+          "kv-remote-value",
+        );
+        expect(roundTrip.value).toBe("kv-remote-value");
+
+        // Out-of-band: the write is visible through the cloud API — the
+        // remote-proxied binding really hit the live namespace.
+        const { accountId } = yield* yield* CloudflareEnvironment;
+        const rawValue = yield* kv
+          .getNamespaceValue({
+            accountId,
+            namespaceId: liveKv.namespaceId,
+            keyName: "waku-remote-key",
+          })
+          .pipe(
+            Effect.flatMap((res) =>
+              Effect.tryPromise(() =>
+                new Response(
+                  Stream.toReadableStream(res.body) as BodyInit,
+                ).text(),
+              ),
+            ),
+            // The KV REST read can lag the proxied write — propagation is
+            // documented at up to 60s and runs longer under account load
+            // (a fully concurrent suite), so budget ~91s: exponential ramp
+            // capped at 10s spacing.
+            Effect.retry({
+              while: (e) => e._tag === "KeyNotFound",
+              schedule: Schedule.min([
+                Schedule.exponential("1 second", 1.5),
+                Schedule.spaced("10 seconds"),
+              ]),
+              times: 13,
+            }),
+          );
+        expect(rawValue).toBe("kv-remote-value");
+
+        yield* stack.destroy();
+
+        // The live namespace was deleted from the cloud on destroy (its
+        // state row is stamped live, so the live provider handles the delete
+        // even in a dev run).
+        const gone = yield* kv
+          .getNamespace({ accountId, namespaceId: liveKv.namespaceId })
+          .pipe(
+            Effect.as(false),
+            Effect.catchTag("NamespaceNotFound", () => Effect.succeed(true)),
+          );
+        expect(gone).toBe(true);
+      }).pipe(logLevel),
+    { timeout: 300_000 },
+  );
+});

--- a/packages/alchemy/test/Cloudflare/Website/Waku.test.ts
+++ b/packages/alchemy/test/Cloudflare/Website/Waku.test.ts
@@ -2,7 +2,7 @@ import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
 import * as Cloudflare from "@/Cloudflare/index.ts";
 import * as Test from "@/Test/Alchemy";
 import * as kv from "@distilled.cloud/cloudflare/kv";
-import { expect } from "alchemy-test";
+import { describe, expect } from "alchemy-test";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
@@ -52,311 +52,321 @@ const wakuProps = (rootDir: string) => ({
   },
 });
 
-test.provider(
-  "Waku: deploys RSC SSR + binding + static assets and memoizes unchanged rebuilds",
-  (stack) =>
-    Effect.gen(function* () {
-      const { accountId } = yield* yield* CloudflareEnvironment;
-      const fs = yield* FileSystem.FileSystem;
-      const path = yield* Path.Path;
+// Tests are independent (per-test scratch stacks, private fixture clones),
+// so run them concurrently; suites are sequential by default.
+describe.concurrent("Waku", () => {
+  test.provider(
+    "Waku: deploys RSC SSR + binding + static assets and memoizes unchanged rebuilds",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
 
-      yield* stack.destroy();
+        yield* stack.destroy();
 
-      const rootDir = yield* cloneFixture(fixtureDir, {
-        prefix: "alchemy-waku-",
-        tempRoot,
-        entries: [
-          ".gitignore",
-          "package.json",
-          "tsconfig.json",
-          "public",
-          "src",
-        ],
-      });
+        const rootDir = yield* cloneFixture(fixtureDir, {
+          prefix: "alchemy-waku-",
+          tempRoot,
+          entries: [
+            ".gitignore",
+            "package.json",
+            "tsconfig.json",
+            "public",
+            "src",
+          ],
+        });
 
-      const bindingMarker = "waku-binding-marker";
+        const bindingMarker = "waku-binding-marker";
 
-      const deploy = () =>
-        stack.deploy(
+        const deploy = () =>
+          stack.deploy(
+            Effect.gen(function* () {
+              const siteKv = yield* Cloudflare.KV.Namespace("SiteKV");
+              const site = yield* Cloudflare.Website.Waku("WakuSite", {
+                ...wakuProps(rootDir),
+                env: {
+                  MESSAGE: bindingMarker,
+                  // A real resource binding (not a plain-string var): the
+                  // `/api/kv` route reads and writes through it at request
+                  // time via `cloudflare:workers` env.
+                  SITE_KV: siteKv,
+                },
+              });
+              return { site, siteKv };
+            }),
+          );
+
+        const { site: site1, siteKv } = yield* deploy();
+
+        expect(site1.url).toBeDefined();
+        expect(site1.hash?.input).toBeDefined();
+        yield* expectWorkerExists(site1.workerName, accountId);
+
+        // Dynamic RSC page rendered by the Worker at request time.
+        yield* expectUrlContains(`${site1.url!}/`, "WAKU_PAGE_MARKER", {
+          timeout: "120 seconds",
+          label: "waku dynamic home page",
+        });
+
+        // The same page reads the `MESSAGE` binding from `cloudflare:workers`
+        // env at request time — proves bindings reach the RSC server bundle.
+        yield* expectUrlContains(`${site1.url!}/`, `MESSAGE=${bindingMarker}`, {
+          timeout: "60 seconds",
+          label: "waku env binding in SSR output",
+        });
+
+        // Static asset from `public/`.
+        yield* expectUrlContains(
+          `${site1.url!}/hello.txt`,
+          "hello from public/",
+          {
+            timeout: "60 seconds",
+            label: "waku static asset",
+          },
+        );
+
+        // SSG page prerendered at build time and served from assets.
+        yield* expectUrlContains(
+          `${site1.url!}/about`,
+          "WAKU_ABOUT_STATIC_MARKER",
+          {
+            timeout: "60 seconds",
+            label: "waku SSG page",
+          },
+        );
+
+        // The SSG page serves 200 directly at the extensionless URL — the
+        // default `drop-trailing-slash` asset handling must not 307-redirect
+        // `/about` to `/about/`.
+        yield* expectDirectStatus(`${site1.url!}/about`, 200, {
+          label: "waku SSG page serves without a redirect",
+        });
+
+        // ── API route: a POST reaches the worker through the asset router
+        // and round-trips a JSON body plus the env binding ──────────────────
+        const echoed = yield* requestJsonReady<{
+          echoed: { ping: string };
+          message: string;
+        }>(
+          HttpClientRequest.post(`${site1.url!}/echo`).pipe(
+            HttpClientRequest.bodyJsonUnsafe({ ping: "pong" }),
+          ),
+        );
+        expect(echoed.echoed).toEqual({ ping: "pong" });
+        expect(echoed.message).toBe(bindingMarker);
+
+        // ── middleware: `src/middleware/*.ts` runs ahead of the RSC
+        // middleware for every worker-handled request — the header shows on
+        // the dynamic SSR page (static assets bypass the worker) ────────────
+        yield* expectUrlHeader(
+          `${site1.url!}/`,
+          "x-waku-middleware",
+          "alchemy-waku-fixture",
+          {
+            timeout: "60 seconds",
+            label: "waku middleware response header",
+          },
+        );
+
+        // ── KV: the SITE_KV namespace binding round-trips through the
+        // `/api/kv` route ───────────────────────────────────────────────────
+        expect(siteKv.namespaceId).toBeDefined();
+        yield* requestJsonReady<{ ok: boolean }>(
+          HttpClientRequest.put(`${site1.url!}/api/kv`).pipe(
+            HttpClientRequest.bodyJsonUnsafe({
+              key: "waku-live-key",
+              value: "kv-live-value",
+            }),
+          ),
+        );
+        const kvRead = yield* requestJsonReady<{
+          key: string;
+          value: string | null;
+        }>(
+          HttpClientRequest.get(`${site1.url!}/api/kv?key=waku-live-key`),
+        ).pipe(
+          Effect.filterOrFail(
+            (res) => res.value === "kv-live-value",
+            (res) => new Error(`kv value not visible yet: ${res.value}`),
+          ),
+          Effect.retry({
+            schedule: Schedule.exponential("1 second", 1.5),
+            times: 6,
+          }),
+        );
+        expect(kvRead.value).toBe("kv-live-value");
+
+        // Out-of-band via the cloud API: the worker's write landed in the
+        // REAL namespace the stack provisioned.
+        const rawValue = yield* kv
+          .getNamespaceValue({
+            accountId,
+            namespaceId: siteKv.namespaceId,
+            keyName: "waku-live-key",
+          })
+          .pipe(
+            Effect.flatMap((res) =>
+              Effect.tryPromise(() =>
+                new Response(
+                  Stream.toReadableStream(res.body) as BodyInit,
+                ).text(),
+              ),
+            ),
+            // The KV REST read can lag the worker's write briefly.
+            Effect.retry({
+              while: (e) => e._tag === "KeyNotFound",
+              schedule: Schedule.exponential("1 second", 1.5),
+              times: 8,
+            }),
+          );
+        expect(rawValue).toBe("kv-live-value");
+
+        // ── deploy 2: no changes ⇒ the rebuild-free input hash matches and
+        // the deploy short-circuits without rebuilding ───────────────────────
+        const { site: site2 } = yield* deploy();
+
+        expect(site2.hash?.input).toBeDefined();
+        expect(site2.hash?.input).toEqual(site1.hash?.input);
+        expect(site2.url).toBe(site1.url);
+
+        // ── deploy 3: edit a page ⇒ the input hash changes and the new
+        // content deploys. The edited marker is asserted on the *dynamic*
+        // page (worker-rendered per request) — a changed static asset at the
+        // same URL can stay stale at a PoP far longer than a worker-version
+        // flip ─────────────────────────────────────────────────────────────
+        const indexPath = path.join(rootDir, "src/pages/index.tsx");
+        const index = yield* fs.readFileString(indexPath);
+        yield* fs.writeFileString(
+          indexPath,
+          index.replace("WAKU_PAGE_MARKER", "WAKU_PAGE_MARKER_V2"),
+        );
+
+        const { site: site3 } = yield* deploy();
+
+        expect(site3.hash?.input).toBeDefined();
+        expect(site3.hash?.input).not.toEqual(site1.hash?.input);
+        yield* expectUrlContains(`${site3.url!}/`, "WAKU_PAGE_MARKER_V2", {
+          timeout: "180 seconds",
+          label: "waku dynamic page after edit",
+        });
+
+        yield* stack.destroy();
+        yield* waitForWorkerToBeDeleted(site1.workerName, accountId);
+        // Destroy must also delete the bound KV namespace from the cloud.
+        yield* waitForNamespaceToBeDeleted(siteKv.namespaceId, accountId);
+      }).pipe(logLevel),
+    { timeout: 600_000 },
+  );
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Custom worker entry (seam: WakuProps.main → the waku target's
+  // user-entry carriage → framework-core's DeployTarget.entry)
+  //
+  // `main` points the deploy at the user's own module, which wraps waku's
+  // emitted handler via `virtual:waku/server-entry` and re-exports the
+  // `Counter` Durable Object class — DO classes must live on the deployed
+  // worker for their namespace bindings to resolve. Mirrors
+  // `Website.Vite`'s "main overrides the worker entry" test.
+  // ─────────────────────────────────────────────────────────────────────
+
+  test.provider(
+    "Waku: main deploys a custom worker entry hosting a Durable Object",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+
+        yield* stack.destroy();
+
+        const rootDir = yield* cloneFixture(fixtureDir, {
+          prefix: "alchemy-waku-main-",
+          tempRoot,
+          entries: [
+            ".gitignore",
+            "package.json",
+            "tsconfig.json",
+            "public",
+            "src",
+          ],
+        });
+
+        const site = yield* stack.deploy(
           Effect.gen(function* () {
-            const siteKv = yield* Cloudflare.KV.Namespace("SiteKV");
-            const site = yield* Cloudflare.Website.Waku("WakuSite", {
+            return yield* Cloudflare.Website.Waku("WakuMainSite", {
               ...wakuProps(rootDir),
+              // The user's own worker entry: wraps waku's handler (imported
+              // from `virtual:waku/server-entry`) and exports the Counter DO.
+              main: "src/worker-entry.ts",
               env: {
-                MESSAGE: bindingMarker,
-                // A real resource binding (not a plain-string var): the
-                // `/api/kv` route reads and writes through it at request
-                // time via `cloudflare:workers` env.
-                SITE_KV: siteKv,
+                MESSAGE: "waku-main-marker",
+                COUNTER: Cloudflare.DurableObject("Counter", {
+                  className: "Counter",
+                }),
               },
             });
-            return { site, siteKv };
           }),
         );
 
-      const { site: site1, siteKv } = yield* deploy();
+        expect(site.url).toBeDefined();
+        yield* expectWorkerExists(site.workerName, accountId);
 
-      expect(site1.url).toBeDefined();
-      expect(site1.hash?.input).toBeDefined();
-      yield* expectWorkerExists(site1.workerName, accountId);
-
-      // Dynamic RSC page rendered by the Worker at request time.
-      yield* expectUrlContains(`${site1.url!}/`, "WAKU_PAGE_MARKER", {
-        timeout: "120 seconds",
-        label: "waku dynamic home page",
-      });
-
-      // The same page reads the `MESSAGE` binding from `cloudflare:workers`
-      // env at request time — proves bindings reach the RSC server bundle.
-      yield* expectUrlContains(`${site1.url!}/`, `MESSAGE=${bindingMarker}`, {
-        timeout: "60 seconds",
-        label: "waku env binding in SSR output",
-      });
-
-      // Static asset from `public/`.
-      yield* expectUrlContains(
-        `${site1.url!}/hello.txt`,
-        "hello from public/",
-        {
-          timeout: "60 seconds",
-          label: "waku static asset",
-        },
-      );
-
-      // SSG page prerendered at build time and served from assets.
-      yield* expectUrlContains(
-        `${site1.url!}/about`,
-        "WAKU_ABOUT_STATIC_MARKER",
-        {
-          timeout: "60 seconds",
-          label: "waku SSG page",
-        },
-      );
-
-      // The SSG page serves 200 directly at the extensionless URL — the
-      // default `drop-trailing-slash` asset handling must not 307-redirect
-      // `/about` to `/about/`.
-      yield* expectDirectStatus(`${site1.url!}/about`, 200, {
-        label: "waku SSG page serves without a redirect",
-      });
-
-      // ── API route: a POST reaches the worker through the asset router
-      // and round-trips a JSON body plus the env binding ──────────────────
-      const echoed = yield* requestJsonReady<{
-        echoed: { ping: string };
-        message: string;
-      }>(
-        HttpClientRequest.post(`${site1.url!}/echo`).pipe(
-          HttpClientRequest.bodyJsonUnsafe({ ping: "pong" }),
-        ),
-      );
-      expect(echoed.echoed).toEqual({ ping: "pong" });
-      expect(echoed.message).toBe(bindingMarker);
-
-      // ── middleware: `src/middleware/*.ts` runs ahead of the RSC
-      // middleware for every worker-handled request — the header shows on
-      // the dynamic SSR page (static assets bypass the worker) ────────────
-      yield* expectUrlHeader(
-        `${site1.url!}/`,
-        "x-waku-middleware",
-        "alchemy-waku-fixture",
-        {
-          timeout: "60 seconds",
-          label: "waku middleware response header",
-        },
-      );
-
-      // ── KV: the SITE_KV namespace binding round-trips through the
-      // `/api/kv` route ───────────────────────────────────────────────────
-      expect(siteKv.namespaceId).toBeDefined();
-      yield* requestJsonReady<{ ok: boolean }>(
-        HttpClientRequest.put(`${site1.url!}/api/kv`).pipe(
-          HttpClientRequest.bodyJsonUnsafe({
-            key: "waku-live-key",
-            value: "kv-live-value",
-          }),
-        ),
-      );
-      const kvRead = yield* requestJsonReady<{
-        key: string;
-        value: string | null;
-      }>(HttpClientRequest.get(`${site1.url!}/api/kv?key=waku-live-key`)).pipe(
-        Effect.filterOrFail(
-          (res) => res.value === "kv-live-value",
-          (res) => new Error(`kv value not visible yet: ${res.value}`),
-        ),
-        Effect.retry({
-          schedule: Schedule.exponential("1 second", 1.5),
-          times: 6,
-        }),
-      );
-      expect(kvRead.value).toBe("kv-live-value");
-
-      // Out-of-band via the cloud API: the worker's write landed in the
-      // REAL namespace the stack provisioned.
-      const rawValue = yield* kv
-        .getNamespaceValue({
-          accountId,
-          namespaceId: siteKv.namespaceId,
-          keyName: "waku-live-key",
-        })
-        .pipe(
-          Effect.flatMap((res) =>
-            Effect.tryPromise(() =>
-              new Response(
-                Stream.toReadableStream(res.body) as BodyInit,
-              ).text(),
-            ),
-          ),
-          // The KV REST read can lag the worker's write briefly.
-          Effect.retry({
-            while: (e) => e._tag === "KeyNotFound",
-            schedule: Schedule.exponential("1 second", 1.5),
-            times: 8,
-          }),
+        // The deployed entry is the USER module, not waku's own entry.
+        const entry = yield* fetchJsonReady<{ entry: string }>(
+          `${site.url!}/api/entry`,
         );
-      expect(rawValue).toBe("kv-live-value");
+        expect(entry.entry).toBe("worker-entry");
 
-      // ── deploy 2: no changes ⇒ the rebuild-free input hash matches and
-      // the deploy short-circuits without rebuilding ───────────────────────
-      const { site: site2 } = yield* deploy();
+        // The DO namespace is bound and state increments ACROSS requests —
+        // instance identity on the deployed worker, through the custom entry.
+        const first = yield* fetchJsonReady<{ count: number }>(
+          `${site.url!}/api/counter/increment`,
+        );
+        const second = yield* fetchJsonReady<{ count: number }>(
+          `${site.url!}/api/counter/increment`,
+        );
+        expect(second.count).toBe(first.count + 1);
 
-      expect(site2.hash?.input).toBeDefined();
-      expect(site2.hash?.input).toEqual(site1.hash?.input);
-      expect(site2.url).toBe(site1.url);
+        const read = yield* fetchJsonReady<{ count: number }>(
+          `${site.url!}/api/counter`,
+        );
+        expect(read.count).toBe(second.count);
 
-      // ── deploy 3: edit a page ⇒ the input hash changes and the new
-      // content deploys. The edited marker is asserted on the *dynamic*
-      // page (worker-rendered per request) — a changed static asset at the
-      // same URL can stay stale at a PoP far longer than a worker-version
-      // flip ─────────────────────────────────────────────────────────────
-      const indexPath = path.join(rootDir, "src/pages/index.tsx");
-      const index = yield* fs.readFileString(indexPath);
-      yield* fs.writeFileString(
-        indexPath,
-        index.replace("WAKU_PAGE_MARKER", "WAKU_PAGE_MARKER_V2"),
-      );
-
-      const { site: site3 } = yield* deploy();
-
-      expect(site3.hash?.input).toBeDefined();
-      expect(site3.hash?.input).not.toEqual(site1.hash?.input);
-      yield* expectUrlContains(`${site3.url!}/`, "WAKU_PAGE_MARKER_V2", {
-        timeout: "180 seconds",
-        label: "waku dynamic page after edit",
-      });
-
-      yield* stack.destroy();
-      yield* waitForWorkerToBeDeleted(site1.workerName, accountId);
-      // Destroy must also delete the bound KV namespace from the cloud.
-      yield* waitForNamespaceToBeDeleted(siteKv.namespaceId, accountId);
-    }).pipe(logLevel),
-  { timeout: 600_000 },
-);
-
-// ─────────────────────────────────────────────────────────────────────
-// Custom worker entry (seam: WakuProps.main → the waku target's
-// user-entry carriage → framework-core's DeployTarget.entry)
-//
-// `main` points the deploy at the user's own module, which wraps waku's
-// emitted handler via `virtual:waku/server-entry` and re-exports the
-// `Counter` Durable Object class — DO classes must live on the deployed
-// worker for their namespace bindings to resolve. Mirrors
-// `Website.Vite`'s "main overrides the worker entry" test.
-// ─────────────────────────────────────────────────────────────────────
-
-test.provider(
-  "Waku: main deploys a custom worker entry hosting a Durable Object",
-  (stack) =>
-    Effect.gen(function* () {
-      const { accountId } = yield* yield* CloudflareEnvironment;
-
-      yield* stack.destroy();
-
-      const rootDir = yield* cloneFixture(fixtureDir, {
-        prefix: "alchemy-waku-main-",
-        tempRoot,
-        entries: [
-          ".gitignore",
-          "package.json",
-          "tsconfig.json",
-          "public",
-          "src",
-        ],
-      });
-
-      const site = yield* stack.deploy(
-        Effect.gen(function* () {
-          return yield* Cloudflare.Website.Waku("WakuMainSite", {
-            ...wakuProps(rootDir),
-            // The user's own worker entry: wraps waku's handler (imported
-            // from `virtual:waku/server-entry`) and exports the Counter DO.
-            main: "src/worker-entry.ts",
-            env: {
-              MESSAGE: "waku-main-marker",
-              COUNTER: Cloudflare.DurableObject("Counter", {
-                className: "Counter",
-              }),
-            },
-          });
-        }),
-      );
-
-      expect(site.url).toBeDefined();
-      yield* expectWorkerExists(site.workerName, accountId);
-
-      // The deployed entry is the USER module, not waku's own entry.
-      const entry = yield* fetchJsonReady<{ entry: string }>(
-        `${site.url!}/api/entry`,
-      );
-      expect(entry.entry).toBe("worker-entry");
-
-      // The DO namespace is bound and state increments ACROSS requests —
-      // instance identity on the deployed worker, through the custom entry.
-      const first = yield* fetchJsonReady<{ count: number }>(
-        `${site.url!}/api/counter/increment`,
-      );
-      const second = yield* fetchJsonReady<{ count: number }>(
-        `${site.url!}/api/counter/increment`,
-      );
-      expect(second.count).toBe(first.count + 1);
-
-      const read = yield* fetchJsonReady<{ count: number }>(
-        `${site.url!}/api/counter`,
-      );
-      expect(read.count).toBe(second.count);
-
-      // Wrapping waku's handler keeps every framework route working:
-      // the dynamic RSC page still renders (and still reads bindings).
-      yield* expectUrlContains(`${site.url!}/`, "WAKU_PAGE_MARKER", {
-        timeout: "120 seconds",
-        label: "waku dynamic page through the custom entry",
-      });
-      yield* expectUrlContains(`${site.url!}/`, "MESSAGE=waku-main-marker", {
-        timeout: "60 seconds",
-        label: "waku env binding through the custom entry",
-      });
-
-      // SSG page + public asset still serve from assets alongside the
-      // custom entry.
-      yield* expectUrlContains(
-        `${site.url!}/about`,
-        "WAKU_ABOUT_STATIC_MARKER",
-        {
+        // Wrapping waku's handler keeps every framework route working:
+        // the dynamic RSC page still renders (and still reads bindings).
+        yield* expectUrlContains(`${site.url!}/`, "WAKU_PAGE_MARKER", {
+          timeout: "120 seconds",
+          label: "waku dynamic page through the custom entry",
+        });
+        yield* expectUrlContains(`${site.url!}/`, "MESSAGE=waku-main-marker", {
           timeout: "60 seconds",
-          label: "waku SSG page with custom entry",
-        },
-      );
-      yield* expectUrlContains(`${site.url!}/hello.txt`, "hello from public/", {
-        timeout: "60 seconds",
-        label: "waku static asset with custom entry",
-      });
+          label: "waku env binding through the custom entry",
+        });
 
-      yield* stack.destroy();
-      yield* waitForWorkerToBeDeleted(site.workerName, accountId);
-    }).pipe(logLevel),
-  { timeout: 600_000 },
-);
+        // SSG page + public asset still serve from assets alongside the
+        // custom entry.
+        yield* expectUrlContains(
+          `${site.url!}/about`,
+          "WAKU_ABOUT_STATIC_MARKER",
+          {
+            timeout: "60 seconds",
+            label: "waku SSG page with custom entry",
+          },
+        );
+        yield* expectUrlContains(
+          `${site.url!}/hello.txt`,
+          "hello from public/",
+          {
+            timeout: "60 seconds",
+            label: "waku static asset with custom entry",
+          },
+        );
+
+        yield* stack.destroy();
+        yield* waitForWorkerToBeDeleted(site.workerName, accountId);
+      }).pipe(logLevel),
+    { timeout: 600_000 },
+  );
+});
 
 /**
  * Execute `request` until it answers 200 with a JSON body (fresh

--- a/website/src/content/docs/cloudflare/frontend/astro.mdx
+++ b/website/src/content/docs/cloudflare/frontend/astro.mdx
@@ -5,27 +5,71 @@ sidebar:
   order: 9
 ---
 
-`Cloudflare.Website.Astro` deploys an Astro project as a Cloudflare
-Worker. It runs Astro's programmatic build with a wrangler-free
-Cloudflare adapter: server-rendered pages execute in the Worker,
-prerendered pages and client assets deploy as static assets. There is
-no `astro.config.*` to write, no adapter to install into your config,
-and no Wrangler file.
+import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
+
+export const devDeps = "@distilled.cloud/astro";
+
+`Cloudflare.Website.Astro` deploys an [Astro](https://astro.build)
+project as a Cloudflare Worker. It runs Astro's programmatic build
+with a wrangler-free Cloudflare adapter: server-rendered pages
+execute in the Worker, prerendered pages and client assets deploy as
+static assets. There is no `astro.config.*` to write, no adapter to
+install into your config, and no Wrangler file.
 
 ## Install
 
-The build integration is loaded from your project at deploy time:
+The build integration is not bundled with alchemy — the resource
+dynamically imports `@distilled.cloud/astro` from your project at
+deploy time, so it must be installed alongside your framework. It is
+only used at build time, so a dev dependency is enough:
 
-```sh
-bun add -d @distilled.cloud/astro
+<Tabs syncKey="pkgManager">
+  <TabItem label="bun" icon="bun">
+    <Code code={`bun add -d ${devDeps}`} lang="sh" />
+  </TabItem>
+  <TabItem label="npm" icon="npm">
+    <Code code={`npm install -D ${devDeps}`} lang="sh" />
+  </TabItem>
+  <TabItem label="pnpm" icon="pnpm">
+    <Code code={`pnpm add -D ${devDeps}`} lang="sh" />
+  </TabItem>
+  <TabItem label="yarn" icon="seti:yarn">
+    <Code code={`yarn add -D ${devDeps}`} lang="sh" />
+  </TabItem>
+</Tabs>
+
+## Configure Astro
+
+There is no framework config to write: the integration is fully
+programmatic, and your `astro.config.*` file is not read. Common
+serializable options are passed via the `astro` prop instead — see
+[Astro configuration](#astro-configuration) below for the details.
+
+## Declare the Website
+
+Declare the site as a module-level const (rather than inline in the
+Stack) and derive the typed shape of its bindings from it:
+
+```typescript
+// alchemy.run.ts
+import * as Cloudflare from "alchemy/Cloudflare";
+
+export const Website = Cloudflare.Website.Astro("Website");
+
+export type WebsiteEnv = Cloudflare.InferEnv<typeof Website>;
 ```
 
+`WebsiteEnv` is the typed shape of the Worker's bindings, derived
+from the class — you'll import it into your Astro code in
+[Read bindings in server code](#read-bindings-in-server-code).
+
 ## Add it to the Stack
+
+Yield the class from your Stack and return its URL:
 
 ```typescript
 // alchemy.run.ts
 import * as Alchemy from "alchemy";
-import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
 
 export default Alchemy.Stack(
@@ -35,7 +79,7 @@ export default Alchemy.Stack(
     state: Cloudflare.state(),
   },
   Effect.gen(function* () {
-    const site = yield* Cloudflare.Website.Astro("Website");
+    const site = yield* Website;
     return { url: site.url };
   }),
 );
@@ -47,30 +91,75 @@ server runtime is built against Node APIs, so the `nodejs_compat`
 compatibility flag is added automatically — you don't need to pass
 it.
 
+During `alchemy dev`, Astro's dev server runs with SSR executing in
+workerd, so server code sees the same runtime and the same real
+bindings it will have in production.
+
 See
 [examples/cloudflare-website-astro](https://github.com/alchemy-run/alchemy/tree/main/examples/cloudflare-website-astro)
 for the checked-in example.
 
-## Bindings
+## Add bindings
 
 The resource returns a plain `Worker`, so `env` accepts the full
 binding vocabulary — KV namespaces, R2 buckets, Durable Objects,
 secrets:
 
-```typescript
-const kv = yield* Cloudflare.KV.Namespace("Cache");
-const bucket = yield* Cloudflare.R2.Bucket("Uploads");
+```diff lang="typescript"
+// alchemy.run.ts
++import * as Config from "effect/Config";
 
-const site = yield* Cloudflare.Website.Astro("Website", {
-  env: {
-    CACHE: kv,
-    UPLOADS: bucket,
-  },
++export const Cache = Cloudflare.KV.Namespace("Cache");
+
+export const Website = Cloudflare.Website.Astro("Website", {
++  env: {
++    CACHE: Cache,
++    API_KEY: Config.redacted("API_KEY"),
++  },
 });
 ```
 
-Astro code reads them via `import { env } from "cloudflare:workers"`
-or `Astro.locals.runtime.env`.
+`Cache` is a description, not a deploy — Alchemy provisions the real
+namespace because the Website binds it. `Config.redacted` reads
+`API_KEY` from your environment at deploy time and binds it as a
+Worker secret — see [Secrets & env](/cloudflare/security/secrets-env).
+
+## Read bindings in server code
+
+Astro code reads bindings via `Astro.locals.runtime.env` (or
+`import { env } from "cloudflare:workers"`). Type the locals once by
+augmenting `App.Locals` with the inferred env type:
+
+```typescript
+// src/env.d.ts
+import type { WebsiteEnv } from "../alchemy.run.ts";
+
+declare global {
+  namespace App {
+    interface Locals {
+      runtime: { env: WebsiteEnv };
+    }
+  }
+}
+
+export {};
+```
+
+Every server-rendered page and endpoint now gets fully typed
+bindings:
+
+```astro
+---
+// src/pages/index.astro
+const cached = await Astro.locals.runtime.env.CACHE.get("greeting");
+---
+
+<h1>{cached ?? "hello"}</h1>
+```
+
+`Astro.locals.runtime.env.CACHE` is typed as a KV namespace and
+`.API_KEY` as a string — renaming a binding in `alchemy.run.ts` is a
+type error in your pages.
 
 ## Sessions
 
@@ -81,11 +170,11 @@ zero configuration.
 Bind your own namespace under that name to use it instead:
 
 ```typescript
-const sessions = yield* Cloudflare.KV.Namespace("Sessions");
+export const Sessions = Cloudflare.KV.Namespace("Sessions");
 
-const site = yield* Cloudflare.Website.Astro("Website", {
+export const Website = Cloudflare.Website.Astro("Website", {
   env: {
-    SESSION: sessions,
+    SESSION: Sessions,
   },
 });
 ```
@@ -93,7 +182,7 @@ const site = yield* Cloudflare.Website.Astro("Website", {
 Or opt out of session provisioning entirely:
 
 ```typescript
-const site = yield* Cloudflare.Website.Astro("Website", {
+export const Website = Cloudflare.Website.Astro("Website", {
   sessionKVBindingName: false,
 });
 ```
@@ -105,7 +194,7 @@ build time and the deploy is assets-only — no server bundle is
 uploaded, and Cloudflare's asset layer answers every request:
 
 ```typescript
-const site = yield* Cloudflare.Website.Astro("Docs", {
+export const Website = Cloudflare.Website.Astro("Website", {
   astro: { output: "static" },
   assets: { notFoundHandling: "404-page" },
 });
@@ -117,39 +206,14 @@ sites, since no Worker code runs at request time.
 
 ## Astro configuration
 
-The integration is fully programmatic — your `astro.config.*` file
-is not read. Common serializable options are exposed under `astro`:
+Common serializable options from `astro.config.*` are exposed under
+the `astro` prop:
 
 ```typescript
-const site = yield* Cloudflare.Website.Astro("Blog", {
+export const Website = Cloudflare.Website.Astro("Website", {
   astro: {
     site: "https://blog.example.com",
     srcDir: "./app",
   },
 });
 ```
-
-## Rebuilds and memo
-
-Input files are content-hashed (respecting `.gitignore` by default),
-so an unchanged project skips both the build and the deploy. Narrow
-the scope with `memo` when the project has large directories that
-don't affect the build output:
-
-```typescript
-const site = yield* Cloudflare.Website.Astro("Docs", {
-  memo: {
-    include: ["src/**", "public/**", "package.json"],
-  },
-});
-```
-
-## Local dev
-
-```sh
-bun alchemy dev
-```
-
-`alchemy dev` runs Astro's dev server with SSR executing in workerd,
-so server code sees the same runtime it will have in production. The
-Worker's bindings are real — the same `env` your deployed site reads.

--- a/website/src/content/docs/cloudflare/frontend/foldkit.mdx
+++ b/website/src/content/docs/cloudflare/frontend/foldkit.mdx
@@ -12,7 +12,7 @@ the Foldkit Vite plugin only adds HMR and devtools wiring — so
 with a single declaration: no `main` entrypoint, no build command,
 no output directory, no Wrangler configuration.
 
-## vite.config.ts
+## Configure Vite
 
 Your Vite config stays what Foldkit's setup gives you:
 
@@ -33,16 +33,40 @@ Alchemy runs Vite programmatically on the project root and layers
 its Cloudflare integration on top of this config — the Foldkit
 plugin and the rest of your setup are preserved as-is.
 
-## Deploy it from a Stack
+:::note[Pinned Effect versions]
+Foldkit pins its `effect` peer dependency to an exact version.
+Alchemy runs your app's own Vite build with your app's own
+`node_modules`, so that pin is between Foldkit and your package
+manager — Alchemy imposes no Effect version on your frontend.
+:::
 
-Yield the Vite resource from your Stack — this is
+## Declare the Website
+
+Declare the site as a module-level const (rather than inline in the
+Stack). Foldkit apps that use URL routing need the SPA fallback so
+deep links reach the client router — see
+[Deep links](#deep-links) below:
+
+```typescript
+// alchemy.run.ts
+import * as Cloudflare from "alchemy/Cloudflare";
+
+export const Website = Cloudflare.Website.Vite("Foldkit", {
+  assets: {
+    notFoundHandling: "single-page-application",
+  },
+});
+```
+
+## Add it to the Stack
+
+Yield the class from your Stack and return its URL — see
 [examples/cloudflare-foldkit](https://github.com/alchemy-run/alchemy/tree/main/examples/cloudflare-foldkit)
-verbatim:
+for the checked-in example:
 
 ```typescript
 // alchemy.run.ts
 import * as Alchemy from "alchemy";
-import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
 
 export default Alchemy.Stack(
@@ -52,15 +76,7 @@ export default Alchemy.Stack(
     state: Cloudflare.state(),
   },
   Effect.gen(function* () {
-    const worker = yield* Cloudflare.Website.Vite("Foldkit", {
-      compatibility: {
-        flags: ["nodejs_compat"],
-      },
-      memo: {},
-      assets: {
-        notFoundHandling: "single-page-application",
-      },
-    });
+    const worker = yield* Website;
 
     return {
       url: worker.url,
@@ -69,9 +85,8 @@ export default Alchemy.Stack(
 );
 ```
 
-Every prop is optional — a bare `Cloudflare.Website.Vite("Foldkit")`
-deploys too; Alchemy builds the client assets and serves them from a
-Worker at the returned `url`.
+Alchemy builds the client assets and serves them from a Worker at
+the returned `url`.
 
 ## Deep links
 
@@ -83,45 +98,42 @@ request for a file that doesn't exist. The
 `index.html` for unmatched paths instead of a 404, and the Foldkit
 runtime resolves the route once the app boots.
 
-## Wire in a backend URL
+## Add environment variables
 
 A Foldkit SPA has no server, so anything it needs from the rest of
 your Stack is baked into the bundle at build time — pass a
-`VITE_`-prefixed key in `env` and read it as
-`import.meta.env.VITE_API_URL` in your Foldkit code (e.g. from a
-`Command` that fetches it):
+`VITE_`-prefixed key in `env`:
 
 ```diff lang="typescript"
 // alchemy.run.ts
-const worker = yield* Cloudflare.Website.Vite("Foldkit", {
+export const Website = Cloudflare.Website.Vite("Foldkit", {
 +  env: {
 +    VITE_API_URL: backend.url,
 +  },
+  assets: {
+    notFoundHandling: "single-page-application",
+  },
 });
 ```
 
-See [Environment](/cloudflare/frontend/vite#environment) for the
-full inlining semantics.
+Type it for your Foldkit code with Vite's standard `ImportMetaEnv`
+augmentation:
 
-## Deploy
+```typescript
+// src/vite-env.d.ts
+/// <reference types="vite/client" />
 
-```sh
-bun alchemy deploy
+interface ImportMetaEnv {
+  readonly VITE_API_URL: string;
+}
 ```
 
-## Local dev
+Client code reads it as `import.meta.env.VITE_API_URL` (e.g. from a
+`Command` that fetches it). See
+[Environment](/cloudflare/frontend/vite#environment) for the full
+inlining semantics.
 
-```sh
-bun alchemy dev
-```
-
-`alchemy dev` boots Vite's own dev server, so you keep Foldkit's
-HMR (with model preservation across edits) while Alchemy wires in
-the same env values as a deploy.
-
-:::note[Pinned Effect versions]
-Foldkit pins its `effect` peer dependency to an exact version.
-Alchemy runs your app's own Vite build with your app's own
-`node_modules`, so that pin is between Foldkit and your package
-manager — Alchemy imposes no Effect version on your frontend.
-:::
+Because a SPA ships no server code, there are no runtime bindings to
+type with `Cloudflare.InferEnv` — when you need server logic, bind a
+separate [Worker](/cloudflare/compute/workers) and call it from the
+client.

--- a/website/src/content/docs/cloudflare/frontend/full-stack-tanstack-rpc-drizzle.mdx
+++ b/website/src/content/docs/cloudflare/frontend/full-stack-tanstack-rpc-drizzle.mdx
@@ -288,7 +288,7 @@ import Backend from "./src/backend/api.ts";
 import { Hyperdrive, NeonDatabase } from "./src/backend/database.ts";
 
 export class Website extends Cloudflare.Website.Vite<Website>()("Website", {
-  compatibility: { flags: ["nodejs_compat", "enable_request_signal"] },
+  compatibility: { flags: ["enable_request_signal"] },
   env: { BACKEND: Backend },
   assets: { runWorkerFirst: true },
 }) {}

--- a/website/src/content/docs/cloudflare/frontend/nextjs.mdx
+++ b/website/src/content/docs/cloudflare/frontend/nextjs.mdx
@@ -5,12 +5,16 @@ sidebar:
   order: 9.5
 ---
 
-`Cloudflare.Website.Nextjs` deploys a Next.js app as a Cloudflare
-Worker. It runs `next build` through the OpenNext pipeline
-(`@opennextjs/cloudflare`), bundles the resulting server into a
-self-contained Worker, and deploys client assets plus prerendered
-pages as Worker static assets. There is no adapter to configure and
-no Wrangler file.
+import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
+
+export const devDeps = "@distilled.cloud/nextjs @opennextjs/cloudflare";
+
+`Cloudflare.Website.Nextjs` deploys a [Next.js](https://nextjs.org)
+app as a Cloudflare Worker. It runs `next build` through the OpenNext
+pipeline (`@opennextjs/cloudflare`), bundles the resulting server
+into a self-contained Worker, and deploys client assets plus
+prerendered pages as Worker static assets. There is no adapter to
+configure and no Wrangler file.
 
 App Router and Pages Router both work — server components, API
 routes, middleware, server actions, dynamic segments, streaming SSR,
@@ -18,18 +22,33 @@ and `getServerSideProps` pages all run in the Worker.
 
 ## Install
 
-The build integration and OpenNext are loaded from your project at
-deploy time:
+The build integration is not bundled with alchemy — the resource
+dynamically imports `@distilled.cloud/nextjs` (and its peer,
+OpenNext) from your project at deploy time, so both must be installed
+alongside your framework. They are only used at build time, so dev
+dependencies are enough:
 
-```sh
-bun add -d @distilled.cloud/nextjs @opennextjs/cloudflare
-```
+<Tabs syncKey="pkgManager">
+  <TabItem label="bun" icon="bun">
+    <Code code={`bun add -d ${devDeps}`} lang="sh" />
+  </TabItem>
+  <TabItem label="npm" icon="npm">
+    <Code code={`npm install -D ${devDeps}`} lang="sh" />
+  </TabItem>
+  <TabItem label="pnpm" icon="pnpm">
+    <Code code={`pnpm add -D ${devDeps}`} lang="sh" />
+  </TabItem>
+  <TabItem label="yarn" icon="seti:yarn">
+    <Code code={`yarn add -D ${devDeps}`} lang="sh" />
+  </TabItem>
+</Tabs>
 
-## Add `open-next.config.ts`
+## Configure OpenNext
 
-OpenNext needs a config next to `next.config.*`. The static-assets
-incremental cache is the zero-infrastructure default — prerendered
-ISR pages serve their build-time payloads:
+Your `next.config.*` stays untouched. OpenNext needs one config file
+next to it — the static-assets incremental cache is the
+zero-infrastructure default, where prerendered ISR pages serve their
+build-time payloads:
 
 ```typescript
 // open-next.config.ts
@@ -41,12 +60,34 @@ export default defineCloudflareConfig({
 });
 ```
 
+For revalidation that actually writes, see
+[Writable ISR](#writable-isr) below.
+
+## Declare the Website
+
+Declare the site as a module-level const (rather than inline in the
+Stack) and derive the typed shape of its bindings from it:
+
+```typescript
+// alchemy.run.ts
+import * as Cloudflare from "alchemy/Cloudflare";
+
+export const Website = Cloudflare.Website.Nextjs("Website");
+
+export type WebsiteEnv = Cloudflare.InferEnv<typeof Website>;
+```
+
+`WebsiteEnv` is the typed shape of the Worker's bindings, derived
+from the class — you'll import it into your Next.js code in
+[Read bindings in server code](#read-bindings-in-server-code).
+
 ## Add it to the Stack
+
+Yield the class from your Stack and return its URL:
 
 ```typescript
 // alchemy.run.ts
 import * as Alchemy from "alchemy";
-import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
 
 export default Alchemy.Stack(
@@ -56,7 +97,7 @@ export default Alchemy.Stack(
     state: Cloudflare.state(),
   },
   Effect.gen(function* () {
-    const site = yield* Cloudflare.Website.Nextjs("Website");
+    const site = yield* Website;
     return { url: site.url };
   }),
 );
@@ -69,25 +110,50 @@ See
 [examples/cloudflare-website-nextjs](https://github.com/alchemy-run/alchemy/tree/main/examples/cloudflare-website-nextjs)
 for the checked-in example.
 
-## Bindings
+## Add bindings
 
 The resource returns a plain `Worker`, so `env` accepts the full
 binding vocabulary — KV namespaces, R2 buckets, Durable Objects,
 secrets:
 
-```typescript
-const bucket = yield* Cloudflare.R2.Bucket("Uploads");
+```diff lang="typescript"
+// alchemy.run.ts
++import * as Config from "effect/Config";
 
-const site = yield* Cloudflare.Website.Nextjs("Website", {
-  env: {
-    UPLOADS: bucket,
-    API_KEY: Alchemy.secret("API_KEY"),
-  },
++export const Uploads = Cloudflare.R2.Bucket("Uploads");
+
+export const Website = Cloudflare.Website.Nextjs("Website", {
++  env: {
++    UPLOADS: Uploads,
++    API_KEY: Config.redacted("API_KEY"),
++  },
 });
 ```
 
-Route handlers, server components, and server actions read them
-through OpenNext's `getCloudflareContext()`:
+`Uploads` is a description, not a deploy — Alchemy provisions the
+real bucket because the Website binds it. `Config.redacted` reads
+`API_KEY` from your environment at deploy time and binds it as a
+Worker secret — see [Secrets & env](/cloudflare/security/secrets-env).
+
+## Read bindings in server code
+
+Route handlers, server components, and server actions read bindings
+through OpenNext's `getCloudflareContext()`. Its `env` is typed by
+the global `CloudflareEnv` interface — extend it once with the
+inferred env type:
+
+```typescript
+// cloudflare-env.d.ts
+import type { WebsiteEnv } from "./alchemy.run.ts";
+
+declare global {
+  interface CloudflareEnv extends WebsiteEnv {}
+}
+
+export {};
+```
+
+Every server entry point now gets fully typed bindings:
 
 ```typescript
 // app/api/upload/route.ts
@@ -99,6 +165,10 @@ export async function PUT(request: Request) {
   return Response.json({ ok: true });
 }
 ```
+
+`env.UPLOADS` is typed as an R2 bucket and `env.API_KEY` as a
+string — renaming a binding in `alchemy.run.ts` is a type error in
+your routes.
 
 ## Writable ISR
 
@@ -125,13 +195,14 @@ Bind the pieces — the `WORKER_SELF_REFERENCE` self service binding
 OpenNext uses to re-render pages is wired automatically:
 
 ```typescript
-const incCache = yield* Cloudflare.KV.Namespace("NextIncCache");
-const tagCache = yield* Cloudflare.KV.Namespace("NextTagCache");
+// alchemy.run.ts
+export const IncCache = Cloudflare.KV.Namespace("NextIncCache");
+export const TagCache = Cloudflare.KV.Namespace("NextTagCache");
 
-const site = yield* Cloudflare.Website.Nextjs("Website", {
+export const Website = Cloudflare.Website.Nextjs("Website", {
   env: {
-    NEXT_INC_CACHE_KV: incCache,
-    NEXT_TAG_CACHE_KV: tagCache,
+    NEXT_INC_CACHE_KV: IncCache,
+    NEXT_TAG_CACHE_KV: TagCache,
     NEXT_CACHE_DO_QUEUE: Cloudflare.DurableObject("NEXT_CACHE_DO_QUEUE", {
       className: "DOQueueHandler",
     }),
@@ -141,20 +212,6 @@ const site = yield* Cloudflare.Website.Nextjs("Website", {
 
 `DOQueueHandler` ships inside the OpenNext worker bundle — the
 binding declaration is all it takes.
-
-## Rebuilds and memo
-
-Input files are content-hashed, so an unchanged project skips both
-the build and the deploy. Narrow the scope with `memo` when the
-project lives in a large repository:
-
-```typescript
-const site = yield* Cloudflare.Website.Nextjs("Website", {
-  memo: {
-    include: ["app/**", "public/**", "package.json", "next.config.mjs", "open-next.config.ts"],
-  },
-});
-```
 
 ## Local dev
 
@@ -171,7 +228,7 @@ For an edit-refresh loop, switch to the real `next dev` (Turbopack
 HMR):
 
 ```typescript
-const site = yield* Cloudflare.Website.Nextjs("Website", {
+export const Website = Cloudflare.Website.Nextjs("Website", {
   nextjs: { devMode: "hmr" },
 });
 ```

--- a/website/src/content/docs/cloudflare/frontend/nuxt.mdx
+++ b/website/src/content/docs/cloudflare/frontend/nuxt.mdx
@@ -5,27 +5,75 @@ sidebar:
   order: 10
 ---
 
-`Cloudflare.Website.Nuxt` deploys a Nuxt app as a Cloudflare Worker.
-It builds the app through your project's own `@nuxt/kit` with nitro's
-`cloudflare_module` preset: the nitro server bundle deploys as the
-Worker script, and client assets plus prerendered pages deploy as
-Worker static assets. There is no `nitro.preset` to edit, no Wrangler
-file, and no build command to run.
+import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
+
+export const devDeps = "@distilled.cloud/nuxt";
+
+`Cloudflare.Website.Nuxt` deploys a [Nuxt](https://nuxt.com) app as
+a Cloudflare Worker. It builds the app through your project's own
+`@nuxt/kit` with nitro's `cloudflare_module` preset: the nitro server
+bundle deploys as the Worker script, and client assets plus
+prerendered pages deploy as Worker static assets. There is no
+`nitro.preset` to edit, no Wrangler file, and no build command to
+run.
 
 ## Install
 
-The build integration is loaded from your project at deploy time:
+The build integration is not bundled with alchemy — the resource
+dynamically imports `@distilled.cloud/nuxt` from your project at
+deploy time, so it must be installed alongside your framework. It is
+only used at build time, so a dev dependency is enough:
 
-```sh
-bun add -d @distilled.cloud/nuxt
+<Tabs syncKey="pkgManager">
+  <TabItem label="bun" icon="bun">
+    <Code code={`bun add -d ${devDeps}`} lang="sh" />
+  </TabItem>
+  <TabItem label="npm" icon="npm">
+    <Code code={`npm install -D ${devDeps}`} lang="sh" />
+  </TabItem>
+  <TabItem label="pnpm" icon="pnpm">
+    <Code code={`pnpm add -D ${devDeps}`} lang="sh" />
+  </TabItem>
+  <TabItem label="yarn" icon="seti:yarn">
+    <Code code={`yarn add -D ${devDeps}`} lang="sh" />
+  </TabItem>
+</Tabs>
+
+## Configure Nuxt
+
+There is no framework config to change: your `nuxt.config.ts` loads
+natively — modules, layers, and all. Deploy-specific overrides are
+merged over it via the `nuxt` prop (the override wins) — see
+[Prerendering](#prerendering) below for an example.
+
+Don't set `nitro.preset` — the Cloudflare deploy target owns the
+preset, and a foreign preset is a hard error.
+
+## Declare the Website
+
+Declare the site as a module-level const (rather than inline in the
+Stack) and derive the typed shape of its bindings from it:
+
+```typescript
+// alchemy.run.ts
+import * as Cloudflare from "alchemy/Cloudflare";
+
+export const Website = Cloudflare.Website.Nuxt("Website");
+
+export type WebsiteEnv = Cloudflare.InferEnv<typeof Website>;
 ```
 
+`WebsiteEnv` is the typed shape of the Worker's bindings, derived
+from the class — you'll import it into your Nuxt code in
+[Read bindings in server code](#read-bindings-in-server-code).
+
 ## Add it to the Stack
+
+Yield the class from your Stack and return its URL:
 
 ```typescript
 // alchemy.run.ts
 import * as Alchemy from "alchemy";
-import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
 
 export default Alchemy.Stack(
@@ -35,7 +83,7 @@ export default Alchemy.Stack(
     state: Cloudflare.state(),
   },
   Effect.gen(function* () {
-    const site = yield* Cloudflare.Website.Nuxt("Website");
+    const site = yield* Website;
     return { url: site.url };
   }),
 );
@@ -49,44 +97,51 @@ See
 [examples/cloudflare-website-nuxt](https://github.com/alchemy-run/alchemy/tree/main/examples/cloudflare-website-nuxt)
 for the checked-in example.
 
-## Your `nuxt.config.ts` still applies
-
-Unlike some of its siblings, the resource loads your project's
-`nuxt.config.ts` natively — modules, layers, and all. The `nuxt` prop
-is for deploy-specific overrides merged over it (the override wins):
-
-```typescript
-const site = yield* Cloudflare.Website.Nuxt("Website", {
-  nuxt: {
-    routeRules: {
-      "/about": { prerender: true },
-    },
-  },
-});
-```
-
-Don't set `nitro.preset` — the Cloudflare deploy target owns the
-preset, and a foreign preset is a hard error.
-
-## Bindings
+## Add bindings
 
 The resource returns a plain `Worker`, so `env` accepts the full
 binding vocabulary — KV namespaces, R2 buckets, Durable Objects,
 secrets:
 
-```typescript
-const bucket = yield* Cloudflare.R2.Bucket("Uploads");
+```diff lang="typescript"
+// alchemy.run.ts
++import * as Config from "effect/Config";
 
-const site = yield* Cloudflare.Website.Nuxt("Website", {
-  env: {
-    UPLOADS: bucket,
-    API_KEY: Alchemy.secret("API_KEY"),
-  },
++export const Uploads = Cloudflare.R2.Bucket("Uploads");
+
+export const Website = Cloudflare.Website.Nuxt("Website", {
++  env: {
++    UPLOADS: Uploads,
++    API_KEY: Config.redacted("API_KEY"),
++  },
 });
 ```
 
-Server routes and SSR read them through nitro's Cloudflare runtime
-contract, `event.context.cloudflare.env`:
+`Uploads` is a description, not a deploy — Alchemy provisions the
+real bucket because the Website binds it. `Config.redacted` reads
+`API_KEY` from your environment at deploy time and binds it as a
+Worker secret — see [Secrets & env](/cloudflare/security/secrets-env).
+
+## Read bindings in server code
+
+Server routes and SSR read bindings through nitro's Cloudflare
+runtime contract, `event.context.cloudflare.env`. Type it once by
+augmenting h3's event context with the inferred env type:
+
+```typescript
+// server/types.d.ts
+import type { WebsiteEnv } from "../alchemy.run.ts";
+
+declare module "h3" {
+  interface H3EventContext {
+    cloudflare: {
+      env: WebsiteEnv;
+    };
+  }
+}
+```
+
+Every server route now gets fully typed bindings:
 
 ```typescript
 // server/api/upload.ts
@@ -97,8 +152,11 @@ export default defineEventHandler(async (event) => {
 });
 ```
 
-`event.context.cf` and `event.context.cloudflare.context.waitUntil`
-are available the same way.
+`event.context.cloudflare.env.UPLOADS` is typed as an R2 bucket and
+`.API_KEY` as a string — renaming a binding in `alchemy.run.ts` is a
+type error in your routes. `event.context.cf` and
+`event.context.cloudflare.context.waitUntil` are available the same
+way.
 
 ## Prerendering
 
@@ -107,7 +165,7 @@ Routes marked for prerendering in `routeRules` (or via
 served as static assets, with no Worker invocation:
 
 ```typescript
-const site = yield* Cloudflare.Website.Nuxt("Website", {
+export const Website = Cloudflare.Website.Nuxt("Website", {
   nuxt: {
     routeRules: {
       "/about": { prerender: true },
@@ -137,7 +195,7 @@ export default nitroHandler;
 ```
 
 ```typescript
-const site = yield* Cloudflare.Website.Nuxt("Website", {
+export const Website = Cloudflare.Website.Nuxt("Website", {
   main: "worker-entry.ts",
   env: {
     COUNTER: Cloudflare.DurableObject("Counter", {
@@ -148,20 +206,6 @@ const site = yield* Cloudflare.Website.Nuxt("Website", {
 ```
 
 Every framework route keeps working through the re-exported handler.
-
-## Rebuilds and memo
-
-Input files are content-hashed (respecting `.gitignore` by default),
-so an unchanged project skips both the build and the deploy. Narrow
-the scope with `memo` when the project lives in a large repository:
-
-```typescript
-const site = yield* Cloudflare.Website.Nuxt("Website", {
-  memo: {
-    include: ["app/**", "server/**", "public/**", "nuxt.config.ts", "package.json"],
-  },
-});
-```
 
 ## Local dev
 

--- a/website/src/content/docs/cloudflare/frontend/octane.mdx
+++ b/website/src/content/docs/cloudflare/frontend/octane.mdx
@@ -5,6 +5,10 @@ sidebar:
   order: 13
 ---
 
+import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
+
+export const devDeps = "@distilled.cloud/octane @octanejs/adapter-cloudflare";
+
 `Cloudflare.Website.Octane` deploys an [OctaneJS](https://octanejs.dev)
 fullstack app as a Cloudflare Worker. Octane wraps Vite, so the resource
 is deliberately thin: it runs your project's own `vite build` — Octane's
@@ -16,14 +20,28 @@ command to run.
 
 ## Install
 
-The build integration is loaded from your project at deploy time,
-alongside Octane's own packages:
+The build integration is not bundled with alchemy — the resource
+dynamically imports `@distilled.cloud/octane` from your project at
+deploy time, so it must be installed alongside Octane's own
+Cloudflare adapter. Both are only used at build time, so dev
+dependencies are enough:
 
-```sh
-bun add -d @distilled.cloud/octane @octanejs/adapter-cloudflare
-```
+<Tabs syncKey="pkgManager">
+  <TabItem label="bun" icon="bun">
+    <Code code={`bun add -d ${devDeps}`} lang="sh" />
+  </TabItem>
+  <TabItem label="npm" icon="npm">
+    <Code code={`npm install -D ${devDeps}`} lang="sh" />
+  </TabItem>
+  <TabItem label="pnpm" icon="pnpm">
+    <Code code={`pnpm add -D ${devDeps}`} lang="sh" />
+  </TabItem>
+  <TabItem label="yarn" icon="seti:yarn">
+    <Code code={`yarn add -D ${devDeps}`} lang="sh" />
+  </TabItem>
+</Tabs>
 
-## Select the Cloudflare adapter
+## Configure Octane
 
 Your `octane.config.ts` picks the deploy target, exactly as in Octane's
 own deployment story:
@@ -43,12 +61,31 @@ export default defineConfig({
 
 A missing or foreign adapter fails the deploy with an actionable error.
 
+## Declare the Website
+
+Declare the site as a module-level const (rather than inline in the
+Stack) and derive the typed shape of its bindings from it:
+
+```typescript
+// alchemy.run.ts
+import * as Cloudflare from "alchemy/Cloudflare";
+
+export const Website = Cloudflare.Website.Octane("Website");
+
+export type WebsiteEnv = Cloudflare.InferEnv<typeof Website>;
+```
+
+`WebsiteEnv` is the typed shape of the Worker's bindings, derived
+from the class — you'll import it into your Octane code in
+[Read bindings in server code](#read-bindings-in-server-code).
+
 ## Add it to the Stack
+
+Yield the class from your Stack and return its URL:
 
 ```typescript
 // alchemy.run.ts
 import * as Alchemy from "alchemy";
-import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
 
 export default Alchemy.Stack(
@@ -58,7 +95,7 @@ export default Alchemy.Stack(
     state: Cloudflare.state(),
   },
   Effect.gen(function* () {
-    const site = yield* Cloudflare.Website.Octane("Website");
+    const site = yield* Website;
     return { url: site.url };
   }),
 );
@@ -72,39 +109,66 @@ See
 [examples/cloudflare-octane](https://github.com/alchemy-run/alchemy/tree/main/examples/cloudflare-octane)
 for the checked-in example.
 
-## Bindings
+## Add bindings
 
 The resource returns a plain `Worker`, so `env` accepts the full binding
 vocabulary — KV namespaces, R2 buckets, secrets:
 
-```typescript
-const cache = yield* Cloudflare.KV.Namespace("Cache");
+```diff lang="typescript"
+// alchemy.run.ts
++import * as Config from "effect/Config";
 
-const site = yield* Cloudflare.Website.Octane("Website", {
-  env: {
-    CACHE: cache,
-    API_KEY: Alchemy.secret("API_KEY"),
-  },
++export const Cache = Cloudflare.KV.Namespace("Cache");
+
+export const Website = Cloudflare.Website.Octane("Website", {
++  env: {
++    CACHE: Cache,
++    API_KEY: Config.redacted("API_KEY"),
++  },
 });
 ```
 
-Octane middleware and `ServerRoute` handlers read them through the
+`Cache` is a description, not a deploy — Alchemy provisions the real
+namespace because the Website binds it. `Config.redacted` reads
+`API_KEY` from your environment at deploy time and binds it as a
+Worker secret — see [Secrets & env](/cloudflare/security/secrets-env).
+
+## Read bindings in server code
+
+Octane middleware and `ServerRoute` handlers read bindings through the
 adapter's runtime contract: `context.platform` is the Cloudflare
-`{ env, ctx }` pair.
+`{ env, ctx }` pair. Type it with the inferred env type — `env` and
+`ctx` are optional because Octane's dev server supplies no platform
+(see [Local dev](#local-dev)):
 
 ```typescript
 // octane.config.ts
+import type { WebsiteEnv } from "./alchemy.run.ts";
+
+interface Platform {
+  readonly env?: WebsiteEnv;
+  readonly ctx?: { waitUntil(promise: Promise<unknown>): void };
+}
+
 new ServerRoute({
   path: "/api/visits",
   methods: ["GET"],
   handler: async (context) => {
-    const { env, ctx } = context.platform as CloudflarePlatform<Env>;
-    const visits = Number((await env.CACHE.get("visits")) ?? "0") + 1;
-    ctx.waitUntil(env.CACHE.put("visits", String(visits)));
+    const platform = context.platform as Platform | undefined;
+    const cache = platform?.env?.CACHE;
+    if (cache === undefined) {
+      return Response.json({ visits: null, dev: true });
+    }
+    const visits = Number((await cache.get("visits")) ?? "0") + 1;
+    platform?.ctx?.waitUntil(cache.put("visits", String(visits)));
     return Response.json({ visits });
   },
 });
 ```
+
+`platform.env.CACHE` is typed as a KV namespace and `.API_KEY` as a
+string — renaming a binding in `alchemy.run.ts` is a type error in
+your handlers.
 
 ## Asset routing
 
@@ -122,23 +186,9 @@ plugin, so deploy it with
 [`Cloudflare.Website.Vite`](/cloudflare/frontend/vite):
 
 ```typescript
-const app = yield* Cloudflare.Website.Vite("Octane", {
+export const OctaneApp = Cloudflare.Website.Vite("Octane", {
   assets: {
     notFoundHandling: "single-page-application",
-  },
-});
-```
-
-## Rebuilds and memo
-
-Input files are content-hashed (respecting `.gitignore` by default), so
-an unchanged project skips both the build and the deploy. Narrow the
-scope with `memo` when the project lives in a large repository:
-
-```typescript
-const site = yield* Cloudflare.Website.Octane("Website", {
-  memo: {
-    include: ["src/**", "public/**", "index.html", "octane.config.ts", "vite.config.ts", "package.json"],
   },
 });
 ```

--- a/website/src/content/docs/cloudflare/frontend/react-router.mdx
+++ b/website/src/content/docs/cloudflare/frontend/react-router.mdx
@@ -10,7 +10,7 @@ import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 export const deps = `react react-dom react-router`;
 export const devDeps = `vite @vitejs/plugin-react @vitejs/plugin-rsc`;
 
-React Router v7 builds through Vite, so
+[React Router](https://reactrouter.com) v7 builds through Vite, so
 [`Cloudflare.Website.Vite`](/cloudflare/frontend/vite) deploys it — one
 resource, no Wrangler config, no manual entrypoint. In React Server
 Components mode the build emits **multiple server environments** (`rsc`
@@ -134,15 +134,42 @@ pattern for Worker code that needs a non-`react-server` module such as
 `react-dom/server`, which must not be imported directly from the `rsc`
 entry.
 
-## Deploy with Cloudflare.Website.Vite
+## Declare the Website
 
-Yield the Vite resource from your Stack and describe the environment
-topology with `viteEnvironments`:
+Declare the site as a module-level const (rather than inline in the
+Stack) and describe the environment topology with `viteEnvironments`:
+
+```typescript
+// alchemy.run.ts
+import * as Cloudflare from "alchemy/Cloudflare";
+
+export const Website = Cloudflare.Website.Vite("Website", {
+  assets: {
+    runWorkerFirst: true,
+  },
+  viteEnvironments: {
+    entry: "rsc",
+    children: ["ssr"],
+  },
+});
+
+export type WebsiteEnv = Cloudflare.InferEnv<typeof Website>;
+```
+
+These props come straight from the live-tested configuration:
+`assets: { runWorkerFirst: true }` routes requests through the Worker
+before static-asset serving so the RSC handler sees every request
+instead of only the ones that miss an asset. The server bundle's
+Node APIs are covered by the `nodejs_compat` compatibility flag,
+which is enabled by default for every Worker.
+
+## Add it to the Stack
+
+Yield the Website from your Stack and return its URL:
 
 ```typescript
 // alchemy.run.ts
 import * as Alchemy from "alchemy";
-import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
 
 export default Alchemy.Stack(
@@ -152,30 +179,59 @@ export default Alchemy.Stack(
     state: Cloudflare.state(),
   },
   Effect.gen(function* () {
-    const website = yield* Cloudflare.Website.Vite("Website", {
-      compatibility: {
-        date: "2026-03-10",
-        flags: ["nodejs_compat"],
-      },
-      assets: {
-        runWorkerFirst: true,
-      },
-      viteEnvironments: {
-        entry: "rsc",
-        children: ["ssr"],
-      },
-    });
-
+    const website = yield* Website;
     return { url: website.url };
   }),
 );
 ```
 
-These props come straight from the live-tested configuration:
-`nodejs_compat` is enabled for the server bundle, and
-`assets: { runWorkerFirst: true }` routes requests through the Worker
-before static-asset serving so the RSC handler sees every request
-instead of only the ones that miss an asset.
+## Add bindings
+
+The resource returns a plain `Worker`, so `env` accepts the full
+binding vocabulary — KV namespaces, R2 buckets, Durable Objects,
+secrets:
+
+```diff lang="typescript"
+// alchemy.run.ts
++import * as Config from "effect/Config";
+
++export const Uploads = Cloudflare.R2.Bucket("Uploads");
+
+export const Website = Cloudflare.Website.Vite("Website", {
++  env: {
++    UPLOADS: Uploads,
++    API_KEY: Config.redacted("API_KEY"),
++  },
+  assets: {
+    runWorkerFirst: true,
+  },
+  viteEnvironments: {
+    entry: "rsc",
+    children: ["ssr"],
+  },
+});
+```
+
+`Uploads` is a description, not a deploy — Alchemy provisions the
+real bucket because the Website binds it. `Config.redacted` reads
+`API_KEY` from your environment at deploy time and binds it as a
+Worker secret — see [Secrets & env](/cloudflare/security/secrets-env).
+
+The Worker entry receives `env` as the standard second argument of
+the module-worker `fetch` contract — type it with the inferred
+shape:
+
+```typescript
+// react-router-vite/entry.worker.tsx
+import type { WebsiteEnv } from "../alchemy.run.ts";
+
+export default {
+  async fetch(request: Request, env: WebsiteEnv, ctx: ExecutionContext) {
+    // env.UPLOADS and env.API_KEY are fully typed here
+    // ... hand off to the RSC request handler
+  },
+};
+```
 
 ## How viteEnvironments maps to the deploy
 

--- a/website/src/content/docs/cloudflare/frontend/solidstart.mdx
+++ b/website/src/content/docs/cloudflare/frontend/solidstart.mdx
@@ -5,12 +5,12 @@ sidebar:
   order: 8
 ---
 
-SolidStart builds through Vite: the `solidStart()` plugin in your
-`vite.config.ts` owns routing, SSR, and the server entry, and a
-single `vite build` produces the whole app. That makes it a pure-Vite
-project, so [`Cloudflare.Website.Vite`](/cloudflare/frontend/vite)
-deploys it directly — no adapter config, no Wrangler file, no manual
-entrypoint.
+[SolidStart](https://start.solidjs.com) builds through Vite: the
+`solidStart()` plugin in your `vite.config.ts` owns routing, SSR, and
+the server entry, and a single `vite build` produces the whole app.
+That makes it a pure-Vite project, so
+[`Cloudflare.Website.Vite`](/cloudflare/frontend/vite) deploys it
+directly — no adapter config, no Wrangler file, no manual entrypoint.
 
 :::note[Verified version line]
 The checked-in example
@@ -45,15 +45,31 @@ programmatic `vite build` picks up the client assets and the SSR
 server bundle from this one config — the server bundle becomes the
 deployed Worker, the client output becomes its static assets.
 
+## Declare the Website
+
+Declare the site as a module-level const (rather than inline in the
+Stack) and derive the typed shape of its bindings from it:
+
+```typescript
+// alchemy.run.ts
+import * as Cloudflare from "alchemy/Cloudflare";
+
+export const Website = Cloudflare.Website.Vite("Website");
+
+export type WebsiteEnv = Cloudflare.InferEnv<typeof Website>;
+```
+
+SolidStart's SSR server bundle uses Node APIs at runtime — the
+`nodejs_compat` compatibility flag covers that, and it is enabled by
+default for every Worker, so there is nothing to pass.
+
 ## Add it to the Stack
 
-Yield `Cloudflare.Website.Vite` from your Stack with `nodejs_compat`
-enabled:
+Yield the class from your Stack and return its URL:
 
 ```typescript
 // alchemy.run.ts
 import * as Alchemy from "alchemy";
-import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
 
 export default Alchemy.Stack(
@@ -63,11 +79,7 @@ export default Alchemy.Stack(
     state: Cloudflare.state(),
   },
   Effect.gen(function* () {
-    const worker = yield* Cloudflare.Website.Vite("CloudflareSolidStart", {
-      compatibility: {
-        flags: ["nodejs_compat"],
-      },
-    });
+    const worker = yield* Website;
 
     return {
       url: worker.url,
@@ -76,9 +88,38 @@ export default Alchemy.Stack(
 );
 ```
 
-The `nodejs_compat` flag is required because SolidStart's SSR server
-bundle uses Node APIs at runtime; without it the deployed Worker
-fails to start.
+## Add bindings
+
+Both env channels of the Vite resource apply unchanged:
+`VITE_`-prefixed entries are inlined into the client bundle as
+`import.meta.env.<KEY>` at build time, and everything else attaches
+to the SSR Worker as runtime bindings:
+
+```diff lang="typescript"
+// alchemy.run.ts
++import * as Config from "effect/Config";
+
++export const Uploads = Cloudflare.R2.Bucket("Uploads");
+
+export const Website = Cloudflare.Website.Vite("Website", {
++  env: {
++    UPLOADS: Uploads,
++    API_KEY: Config.redacted("API_KEY"),
++  },
+});
+```
+
+`Uploads` is a description, not a deploy — Alchemy provisions the
+real bucket because the Website binds it. `Config.redacted` reads
+`API_KEY` from your environment at deploy time and binds it as a
+Worker secret — see [Secrets & env](/cloudflare/security/secrets-env).
+
+`WebsiteEnv` (from
+[Declare the Website](#declare-the-website)) is the typed shape of
+the runtime bindings — import it wherever your server code reads the
+Worker env. See
+[the Vite resource page](/cloudflare/frontend/vite#environment) for
+how each env channel works.
 
 ## Hand-rolled SolidJS SSR
 
@@ -124,64 +165,14 @@ before the asset layer answers — set `assets.runWorkerFirst`:
 
 ```typescript
 // alchemy.run.ts
-import * as Alchemy from "alchemy";
-import * as Cloudflare from "alchemy/Cloudflare";
-import * as Effect from "effect/Effect";
-
-export default Alchemy.Stack(
-  "CloudflareSolidJSSSRExample",
-  {
-    providers: Cloudflare.providers(),
-    state: Cloudflare.state(),
+export const SolidSsr = Cloudflare.Website.Vite("SolidJSSsr", {
+  assets: {
+    runWorkerFirst: true,
   },
-  Effect.gen(function* () {
-    const worker = yield* Cloudflare.Website.Vite("SolidJSSrr", {
-      compatibility: {
-        flags: ["nodejs_compat"],
-      },
-      assets: {
-        runWorkerFirst: true,
-      },
-    });
-
-    return {
-      url: worker.url,
-    };
-  }),
-);
+});
 ```
 
 With `runWorkerFirst: true` the SSR handler sees every request first
 and delegates to the `ASSETS` binding itself for static files —
 without it, a request matching a built asset (like `/index.html`)
 would be served directly and never hit your renderer.
-
-## Deploy
-
-```sh
-bun alchemy deploy
-```
-
-Alchemy runs the Vite build, uploads the client assets, deploys the
-SSR bundle as the Worker, and prints the stack's `url` output.
-Inputs are content-hashed, so re-deploying an unchanged project
-skips the build entirely.
-
-## Local dev
-
-```sh
-bun alchemy dev
-```
-
-`alchemy dev` boots Vite's own dev server programmatically — HMR and
-instant module updates work as in a plain SolidStart project, while
-any bound backend resources are the real cloud resources.
-
-## Environment variables and bindings
-
-Both env channels of the Vite resource apply unchanged: `VITE_`-prefixed
-`env` entries are inlined into the client bundle as
-`import.meta.env.<KEY>` at build time, and everything else attaches
-to the SSR Worker as runtime bindings. See
-[the Vite resource page](/cloudflare/frontend/vite) for how each
-channel works.

--- a/website/src/content/docs/cloudflare/frontend/static-site.mdx
+++ b/website/src/content/docs/cloudflare/frontend/static-site.mdx
@@ -124,10 +124,6 @@ const Website = Cloudflare.Website.StaticSite(
         "../bun.lock",
       ],
     },
-    compatibility: {
-      date: "2026-04-02",
-      flags: ["nodejs_compat"],
-    },
     assets: {
       runWorkerFirst: true,
     },

--- a/website/src/content/docs/cloudflare/frontend/sveltekit.mdx
+++ b/website/src/content/docs/cloudflare/frontend/sveltekit.mdx
@@ -5,29 +5,75 @@ sidebar:
   order: 11
 ---
 
-`Cloudflare.Website.SvelteKit` deploys a SvelteKit app as a
-Cloudflare Worker. It builds the app with SvelteKit's own Vite
-pipeline and a wrangler-free in-memory Cloudflare adapter, then
-re-bundles the server output for workerd. Client assets and
-prerendered pages deploy as Worker static assets; dynamic routes are
-served by the generated Worker. There is no `svelte.config.js` to
-write, no `@sveltejs/adapter-cloudflare` to install, and no Wrangler
-file.
+import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
+
+export const devDeps = "@distilled.cloud/sveltekit";
+
+`Cloudflare.Website.SvelteKit` deploys a
+[SvelteKit](https://svelte.dev/docs/kit) app as a Cloudflare Worker.
+It builds the app with SvelteKit's own Vite pipeline and a
+wrangler-free in-memory Cloudflare adapter, then re-bundles the
+server output for workerd. Client assets and prerendered pages deploy
+as Worker static assets; dynamic routes are served by the generated
+Worker. There is no `svelte.config.js` to write, no
+`@sveltejs/adapter-cloudflare` to install, and no Wrangler file.
 
 ## Install
 
-The build integration is loaded from your project at deploy time:
+The build integration is not bundled with alchemy — the resource
+dynamically imports `@distilled.cloud/sveltekit` from your project at
+deploy time, so it must be installed alongside your framework. It is
+only used at build time, so a dev dependency is enough:
 
-```sh
-bun add -d @distilled.cloud/sveltekit
+<Tabs syncKey="pkgManager">
+  <TabItem label="bun" icon="bun">
+    <Code code={`bun add -d ${devDeps}`} lang="sh" />
+  </TabItem>
+  <TabItem label="npm" icon="npm">
+    <Code code={`npm install -D ${devDeps}`} lang="sh" />
+  </TabItem>
+  <TabItem label="pnpm" icon="pnpm">
+    <Code code={`pnpm add -D ${devDeps}`} lang="sh" />
+  </TabItem>
+  <TabItem label="yarn" icon="seti:yarn">
+    <Code code={`yarn add -D ${devDeps}`} lang="sh" />
+  </TabItem>
+</Tabs>
+
+## Configure SvelteKit
+
+There is no framework config to write. The resource drives
+SvelteKit's Vite pipeline programmatically and injects its own
+Cloudflare adapter, so a fresh SvelteKit project deploys as-is.
+Options that would normally live in `svelte.config.js` are passed via
+the `kit` prop instead — see
+[Kit and adapter options](#kit-and-adapter-options) below.
+
+## Declare the Website
+
+Declare the site as a module-level const (rather than inline in the
+Stack) and derive the typed shape of its bindings from it:
+
+```typescript
+// alchemy.run.ts
+import * as Cloudflare from "alchemy/Cloudflare";
+
+export const Website = Cloudflare.Website.SvelteKit("Website");
+
+export type WebsiteEnv = Cloudflare.InferEnv<typeof Website>;
 ```
 
+`WebsiteEnv` is the typed shape of the Worker's bindings, derived
+from the class — you'll import it into your SvelteKit code in
+[Read bindings in server code](#read-bindings-in-server-code).
+
 ## Add it to the Stack
+
+Yield the class from your Stack and return its URL:
 
 ```typescript
 // alchemy.run.ts
 import * as Alchemy from "alchemy";
-import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
 
 export default Alchemy.Stack(
@@ -37,7 +83,7 @@ export default Alchemy.Stack(
     state: Cloudflare.state(),
   },
   Effect.gen(function* () {
-    const site = yield* Cloudflare.Website.SvelteKit("Website");
+    const site = yield* Website;
     return { url: site.url };
   }),
 );
@@ -51,24 +97,52 @@ See
 [examples/cloudflare-website-sveltekit](https://github.com/alchemy-run/alchemy/tree/main/examples/cloudflare-website-sveltekit)
 for the checked-in example.
 
-## Bindings
+## Add bindings
 
 The resource returns a plain `Worker`, so `env` accepts the full
 binding vocabulary — KV namespaces, R2 buckets, Durable Objects,
 secrets:
 
-```typescript
-const kv = yield* Cloudflare.KV.Namespace("Cache");
+```diff lang="typescript"
+// alchemy.run.ts
++import * as Config from "effect/Config";
 
-const site = yield* Cloudflare.Website.SvelteKit("Website", {
-  env: {
-    CACHE: kv,
-    API_KEY: Alchemy.secret("API_KEY"),
-  },
++export const Cache = Cloudflare.KV.Namespace("Cache");
+
+export const Website = Cloudflare.Website.SvelteKit("Website", {
++  env: {
++    CACHE: Cache,
++    API_KEY: Config.redacted("API_KEY"),
++  },
 });
 ```
 
-Server routes read them through SvelteKit's `platform.env`:
+`Cache` is a description, not a deploy — Alchemy provisions the real
+namespace because the Website binds it. `Config.redacted` reads
+`API_KEY` from your environment at deploy time and binds it as a
+Worker secret — see [Secrets & env](/cloudflare/security/secrets-env).
+
+## Read bindings in server code
+
+Server routes read bindings through SvelteKit's `platform.env`. Type
+it once by augmenting `App.Platform` with the inferred env type:
+
+```typescript
+// src/app.d.ts
+import type { WebsiteEnv } from "../alchemy.run.ts";
+
+declare global {
+  namespace App {
+    interface Platform {
+      env: WebsiteEnv;
+    }
+  }
+}
+
+export {};
+```
+
+Every server route now gets fully typed bindings:
 
 ```typescript
 // src/routes/+page.server.ts
@@ -78,6 +152,10 @@ export const load = async ({ platform }) => {
 };
 ```
 
+`platform.env.CACHE` is typed as a KV namespace and
+`platform.env.API_KEY` as a string — renaming a binding in
+`alchemy.run.ts` is a type error in your routes.
+
 ## Kit and adapter options
 
 Since kit v3 the configuration lives in memory — pass it via the
@@ -85,7 +163,7 @@ Since kit v3 the configuration lives in memory — pass it via the
 adapter is configured via `adapter`:
 
 ```typescript
-const site = yield* Cloudflare.Website.SvelteKit("Website", {
+export const Website = Cloudflare.Website.SvelteKit("Website", {
   kit: {
     alias: { $lib: "src/lib" },
   },
@@ -98,20 +176,6 @@ const site = yield* Cloudflare.Website.SvelteKit("Website", {
 
 Don't set `kit.adapter` — Alchemy injects its own wrangler-free
 Cloudflare adapter.
-
-## Rebuilds and memo
-
-Input files are content-hashed (respecting `.gitignore` by default),
-so an unchanged project skips both the build and the deploy. Narrow
-the scope with `memo` when the project lives in a large repository:
-
-```typescript
-const site = yield* Cloudflare.Website.SvelteKit("Website", {
-  memo: {
-    include: ["src/**", "static/**", "package.json"],
-  },
-});
-```
 
 ## Local dev
 

--- a/website/src/content/docs/cloudflare/frontend/tanstack-start.mdx
+++ b/website/src/content/docs/cloudflare/frontend/tanstack-start.mdx
@@ -5,14 +5,23 @@ sidebar:
   order: 5
 ---
 
-TanStack Start is pure Vite — `tanstackStart()` and `viteReact()` are
-ordinary plugins in `vite.config.ts`, so
+import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
+
+[TanStack Start](https://tanstack.com/start) is pure Vite —
+`tanstackStart()` and `viteReact()` are ordinary plugins in
+`vite.config.ts`, so
 [`Cloudflare.Website.Vite`](/cloudflare/frontend/vite) builds the client
 assets and the SSR server bundle in a single `vite build` pass, no
 adapter or Wrangler config required. Support is verified: the
 [examples/cloudflare-tanstack](https://github.com/alchemy-run/alchemy/tree/main/examples/cloudflare-tanstack)
 example is checked in, and a live test deploys it in dev mode with real
 Alchemy-managed R2 bindings.
+
+## Configure Vite
+
+Your Vite config stays exactly what TanStack Start's scaffold gives
+you — Alchemy layers its Cloudflare integration on top when it
+builds:
 
 ```typescript
 // vite.config.ts
@@ -50,17 +59,29 @@ export default defineConfig({
 });
 ```
 
+:::
+
 Also drop the dependency:
 
-```sh
-bun remove @cloudflare/vite-plugin
-```
-:::
+<Tabs syncKey="pkgManager">
+  <TabItem label="bun" icon="bun">
+    <Code code="bun remove @cloudflare/vite-plugin" lang="sh" />
+  </TabItem>
+  <TabItem label="npm" icon="npm">
+    <Code code="npm uninstall @cloudflare/vite-plugin" lang="sh" />
+  </TabItem>
+  <TabItem label="pnpm" icon="pnpm">
+    <Code code="pnpm remove @cloudflare/vite-plugin" lang="sh" />
+  </TabItem>
+  <TabItem label="yarn" icon="seti:yarn">
+    <Code code="yarn remove @cloudflare/vite-plugin" lang="sh" />
+  </TabItem>
+</Tabs>
 
 ## Declare the Website
 
-Use the class form of `Cloudflare.Website.Vite` so the app gets a named
-type you can infer bindings from:
+Declare the site as a module-level const (rather than inline in the
+Stack) and derive the typed shape of its bindings from it:
 
 ```typescript
 // alchemy.run.ts
@@ -69,10 +90,7 @@ import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
 import Backend, { Bucket } from "./src/backend.ts";
 
-export class Website extends Cloudflare.Website.Vite<Website>()("Website", {
-  compatibility: {
-    flags: ["nodejs_compat"],
-  },
+export const Website = Cloudflare.Website.Vite("Website", {
   env: {
     BUCKET: Bucket,
     BACKEND: Backend,
@@ -80,21 +98,22 @@ export class Website extends Cloudflare.Website.Vite<Website>()("Website", {
   assets: {
     runWorkerFirst: true,
   },
-}) {}
+});
 
 export type WebsiteEnv = Cloudflare.InferEnv<typeof Website>;
 ```
 
-`nodejs_compat` gives the SSR server bundle the Node APIs it needs at
-runtime; each `env` entry becomes a native Worker binding (`BUCKET` an
-R2 bucket, `BACKEND` a service binding to another Worker); and
+Each `env` entry becomes a native Worker binding (`BUCKET` an
+R2 bucket, `BACKEND` a service binding to another Worker), and
 `runWorkerFirst` routes requests to the SSR Worker before static-asset
 matching, so server routes win over files. `WebsiteEnv` is the typed
-shape of those bindings, derived from the class.
+shape of those bindings, derived from the declaration. The SSR server
+bundle's Node APIs are covered by the `nodejs_compat` compatibility
+flag, which is enabled by default for every Worker.
 
 ## Add it to the Stack
 
-Yield the class from the Stack alongside anything it binds to:
+Yield the Website from the Stack alongside anything it binds to:
 
 ```typescript
 // alchemy.run.ts
@@ -199,4 +218,4 @@ export default defineConfig({
 
 `@tanstack/solid-start` provides the same `tanstackStart()` plugin
 entry point, so `Cloudflare.Website.Vite` builds it identically —
-`nodejs_compat` on, no other changes.
+no changes needed.

--- a/website/src/content/docs/cloudflare/frontend/vite-spa.mdx
+++ b/website/src/content/docs/cloudflare/frontend/vite-spa.mdx
@@ -230,10 +230,20 @@ const web = yield* Cloudflare.Website.Vite("Website", {
 If you'd rather start from a real framework scaffold (React + TS
 with HMR, ESLint, etc.), use Vite's official template:
 
-```sh
-bun create vite@latest web -- --template react-ts
-cd web && bun install && cd ..
-```
+<Tabs syncKey="pkgManager">
+  <TabItem label="bun" icon="bun">
+    <Code code={`bun create vite@latest web -- --template react-ts\ncd web && bun install && cd ..`} lang="sh" />
+  </TabItem>
+  <TabItem label="npm" icon="npm">
+    <Code code={`npm create vite@latest web -- --template react-ts\ncd web && npm install && cd ..`} lang="sh" />
+  </TabItem>
+  <TabItem label="pnpm" icon="pnpm">
+    <Code code={`pnpm create vite web --template react-ts\ncd web && pnpm install && cd ..`} lang="sh" />
+  </TabItem>
+  <TabItem label="yarn" icon="seti:yarn">
+    <Code code={`yarn create vite web --template react-ts\ncd web && yarn install && cd ..`} lang="sh" />
+  </TabItem>
+</Tabs>
 
 That drops a complete project into `./web/` with its own
 `package.json`, `tsconfig.json`, and `vite.config.ts`.

--- a/website/src/content/docs/cloudflare/frontend/vite.mdx
+++ b/website/src/content/docs/cloudflare/frontend/vite.mdx
@@ -87,7 +87,6 @@ export default defineConfig({
 ```typescript
 const site = yield* Cloudflare.Website.Vite("Website", {
   rootDir: "./web",
-  compatibility: { flags: ["nodejs_compat"] },
   assets: { runWorkerFirst: true },
 });
 ```
@@ -106,6 +105,10 @@ const site = yield* Cloudflare.Website.Vite("Website", {
   `compatibility`, `crons`, and so on. See
   [Workers](/cloudflare/compute/workers).
 
+SSR server bundles routinely use Node APIs at runtime — the
+`nodejs_compat` compatibility flag covers that, and it is enabled by
+default for every Worker, so there is nothing to pass.
+
 :::caution[index.html must be at rootDir]
 Vite resolves `index.html` relative to its project root. `rootDir`
 defaults to `process.cwd()` — so place `index.html` next to your
@@ -114,18 +117,16 @@ See Vite's
 [project structure docs](https://vite.dev/guide/#index-html-and-project-root).
 :::
 
-Like `Worker`, the resource also has a class form — useful when
-other resources bind to the site, or when you want to derive its
-`env` types:
+Like `Worker`, the resource also has a class form — only needed
+when *other* resources bind to the site (the class gives it a named
+type they can reference):
 
 ```typescript
-export class Website extends Cloudflare.Website.Vite<Website>()("Website", {
-  compatibility: { flags: ["nodejs_compat"] },
-}) {}
+export class Website extends Cloudflare.Website.Vite<Website>()("Website", {}) {}
 ```
 
-See [TanStack Start](/cloudflare/frontend/tanstack-start) for the
-class form in a real app.
+For everything else — including deriving `env` types — a plain
+`const` is enough; see [Runtime bindings](#runtime-bindings) below.
 
 ## Environment
 
@@ -180,13 +181,12 @@ Non-`VITE_` values become native Worker bindings, available to SSR
 code and typed via `Cloudflare.InferEnv`:
 
 ```typescript
-export class Website extends Cloudflare.Website.Vite<Website>()("Website", {
-  compatibility: { flags: ["nodejs_compat"] },
+export const Website = Cloudflare.Website.Vite("Website", {
   env: {
     BUCKET: Bucket,
     BACKEND: Backend,
   },
-}) {}
+});
 
 export type WebsiteEnv = Cloudflare.InferEnv<typeof Website>;
 ```
@@ -203,7 +203,6 @@ produces the Worker entry chunk and which are bundled alongside it:
 
 ```typescript
 const app = yield* Cloudflare.Website.Vite("ReactRouterRSC", {
-  compatibility: { flags: ["nodejs_compat"] },
   viteEnvironments: { entry: "rsc", children: ["ssr"] },
 });
 ```

--- a/website/src/content/docs/cloudflare/frontend/vue.mdx
+++ b/website/src/content/docs/cloudflare/frontend/vue.mdx
@@ -5,12 +5,13 @@ sidebar:
   order: 7
 ---
 
-Vue is pure Vite — the entire app builds from `@vitejs/plugin-vue`
-in your `vite.config.ts`, so [`Cloudflare.Website.Vite`](/cloudflare/frontend/vite)
+[Vue](https://vuejs.org) is pure Vite — the entire app builds from
+`@vitejs/plugin-vue` in your `vite.config.ts`, so
+[`Cloudflare.Website.Vite`](/cloudflare/frontend/vite)
 deploys it with a single declaration: no `main` entrypoint, no
 build command, no output directory, no Wrangler configuration.
 
-## vite.config.ts
+## Configure Vite
 
 Your Vite config stays exactly what Vue's scaffold gives you:
 
@@ -28,16 +29,28 @@ Alchemy runs Vite programmatically on the project root and layers
 its Cloudflare integration on top of this config — your plugins,
 aliases, and the rest of your setup are preserved as-is.
 
-## Deploy it from a Stack
+## Declare the Website
 
-Yield the Vite resource from your Stack — this is
+Declare the site as a module-level const (rather than inline in the
+Stack) — every prop is optional, so the minimal declaration is just
+a name:
+
+```typescript
+// alchemy.run.ts
+import * as Cloudflare from "alchemy/Cloudflare";
+
+export const Website = Cloudflare.Website.Vite("Vue");
+```
+
+## Add it to the Stack
+
+Yield the class from your Stack and return its URL — see
 [examples/cloudflare-vue](https://github.com/alchemy-run/alchemy/tree/main/examples/cloudflare-vue)
-verbatim:
+for the checked-in example:
 
 ```typescript
 // alchemy.run.ts
 import * as Alchemy from "alchemy";
-import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
 
 export default Alchemy.Stack(
@@ -47,12 +60,7 @@ export default Alchemy.Stack(
     state: Cloudflare.state(),
   },
   Effect.gen(function* () {
-    const worker = yield* Cloudflare.Website.Vite("Vue", {
-      compatibility: {
-        flags: ["nodejs_compat"],
-      },
-      memo: {},
-    });
+    const worker = yield* Website;
 
     return {
       url: worker.url,
@@ -61,9 +69,8 @@ export default Alchemy.Stack(
 );
 ```
 
-Every prop is optional — a bare `Cloudflare.Website.Vite("Vue")`
-deploys too; Alchemy builds the client assets and serves them from a
-Worker at the returned `url`.
+Alchemy builds the client assets and serves them from a Worker at
+the returned `url`.
 
 ## Deep links with vue-router
 
@@ -74,11 +81,7 @@ asset layer to fall back to `index.html`:
 
 ```diff lang="typescript"
 // alchemy.run.ts
-const worker = yield* Cloudflare.Website.Vite("Vue", {
-  compatibility: {
-    flags: ["nodejs_compat"],
-  },
-  memo: {},
+export const Website = Cloudflare.Website.Vite("Vue", {
 +  assets: {
 +    htmlHandling: "auto-trailing-slash",
 +    notFoundHandling: "single-page-application",
@@ -90,36 +93,39 @@ With `notFoundHandling: "single-page-application"`, unmatched
 paths return `index.html` instead of a 404, and vue-router
 resolves the route on the client.
 
-## Wire in a backend URL
+## Add environment variables
 
 A pure SPA has no server, so anything it needs from the rest of
 your Stack is baked into the bundle at build time — pass a
-`VITE_`-prefixed key in `env` and read it as
-`import.meta.env.VITE_API_URL` in your Vue code:
+`VITE_`-prefixed key in `env`:
 
 ```diff lang="typescript"
 // alchemy.run.ts
-const worker = yield* Cloudflare.Website.Vite("Vue", {
+export const Website = Cloudflare.Website.Vite("Vue", {
 +  env: {
 +    VITE_API_URL: backend.url,
 +  },
 });
 ```
 
-See [Environment](/cloudflare/frontend/vite#environment) for the
-full inlining semantics.
+Type it for your Vue code with Vite's standard `ImportMetaEnv`
+augmentation:
 
-## Deploy
+```typescript
+// src/vite-env.d.ts
+/// <reference types="vite/client" />
 
-```sh
-bun alchemy deploy
+interface ImportMetaEnv {
+  readonly VITE_API_URL: string;
+}
 ```
 
-## Local dev
+Client code reads it as `import.meta.env.VITE_API_URL`. See
+[Environment](/cloudflare/frontend/vite#environment) for the full
+inlining semantics.
 
-```sh
-bun alchemy dev
-```
-
-`alchemy dev` boots Vite's own dev server, so you keep Vue's HMR
-while Alchemy wires in the same env values as a deploy.
+Because a SPA ships no server code, there are no runtime bindings to
+type with `Cloudflare.InferEnv` — when you add server routes (via an
+SSR framework like [TanStack Start](/cloudflare/frontend/tanstack-start)
+or a separate [Worker](/cloudflare/compute/workers)), that's where
+`InferEnv` comes in.

--- a/website/src/content/docs/cloudflare/frontend/waku.mdx
+++ b/website/src/content/docs/cloudflare/frontend/waku.mdx
@@ -5,6 +5,10 @@ sidebar:
   order: 12
 ---
 
+import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
+
+export const devDeps = "@distilled.cloud/waku";
+
 `Cloudflare.Website.Waku` deploys a [Waku](https://waku.gg) app as a
 Cloudflare Worker. It builds the project programmatically: the React
 Server Components server bundle deploys as the Worker script, and the
@@ -14,18 +18,57 @@ no build command to run.
 
 ## Install
 
-The build integration is loaded from your project at deploy time:
+The build integration is not bundled with alchemy — the resource
+dynamically imports `@distilled.cloud/waku` from your project at
+deploy time, so it must be installed alongside your framework. It is
+only used at build time, so a dev dependency is enough:
 
-```sh
-bun add -d @distilled.cloud/waku
+<Tabs syncKey="pkgManager">
+  <TabItem label="bun" icon="bun">
+    <Code code={`bun add -d ${devDeps}`} lang="sh" />
+  </TabItem>
+  <TabItem label="npm" icon="npm">
+    <Code code={`npm install -D ${devDeps}`} lang="sh" />
+  </TabItem>
+  <TabItem label="pnpm" icon="pnpm">
+    <Code code={`pnpm add -D ${devDeps}`} lang="sh" />
+  </TabItem>
+  <TabItem label="yarn" icon="seti:yarn">
+    <Code code={`yarn add -D ${devDeps}`} lang="sh" />
+  </TabItem>
+</Tabs>
+
+## Configure Waku
+
+There is no framework config to write: the resource builds the
+project programmatically, so a fresh Waku project deploys as-is —
+your `waku.config.ts` stays untouched.
+
+## Declare the Website
+
+Declare the site as a module-level const (rather than inline in the
+Stack) and derive the typed shape of its bindings from it:
+
+```typescript
+// alchemy.run.ts
+import * as Cloudflare from "alchemy/Cloudflare";
+
+export const Website = Cloudflare.Website.Waku("Website");
+
+export type WebsiteEnv = Cloudflare.InferEnv<typeof Website>;
 ```
 
+`WebsiteEnv` is the typed shape of the Worker's bindings, derived
+from the class — you'll import it into your Waku code in
+[Read bindings in server code](#read-bindings-in-server-code).
+
 ## Add it to the Stack
+
+Yield the class from your Stack and return its URL:
 
 ```typescript
 // alchemy.run.ts
 import * as Alchemy from "alchemy";
-import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
 
 export default Alchemy.Stack(
@@ -35,7 +78,7 @@ export default Alchemy.Stack(
     state: Cloudflare.state(),
   },
   Effect.gen(function* () {
-    const site = yield* Cloudflare.Website.Waku("Site");
+    const site = yield* Website;
     return { url: site.url };
   }),
 );
@@ -46,31 +89,73 @@ compatibility flag is added automatically — you don't need to pass
 it. SSG pages are served at their extensionless URLs (`/about`) via
 the default `drop-trailing-slash` asset handling.
 
+During `alchemy dev`, Waku's dev server runs with SSR executing in
+workerd, so server code sees the same runtime and the same real
+bindings it will have in production.
+
 See
 [examples/cloudflare-website-waku](https://github.com/alchemy-run/alchemy/tree/main/examples/cloudflare-website-waku)
 for the checked-in example.
 
-## Bindings
+## Add bindings
 
 The resource returns a plain `Worker`, so `env` accepts the full
 binding vocabulary — KV namespaces, R2 buckets, Durable Objects,
 secrets:
 
-```typescript
-const bucket = yield* Cloudflare.R2.Bucket("Uploads");
+```diff lang="typescript"
+// alchemy.run.ts
++import * as Config from "effect/Config";
 
-const site = yield* Cloudflare.Website.Waku("Site", {
-  env: {
-    UPLOADS: bucket,
-  },
++export const Uploads = Cloudflare.R2.Bucket("Uploads");
+
+export const Website = Cloudflare.Website.Waku("Website", {
++  env: {
++    UPLOADS: Uploads,
++    API_KEY: Config.redacted("API_KEY"),
++  },
 });
 ```
 
-Server components and API routes read them from the
-`cloudflare:workers` env at request time. Prefer a guarded dynamic
-import in page modules — Waku's SSG step renders static pages in
-Node, where a top-level `import { env } from "cloudflare:workers"`
-cannot resolve.
+`Uploads` is a description, not a deploy — Alchemy provisions the
+real bucket because the Website binds it. `Config.redacted` reads
+`API_KEY` from your environment at deploy time and binds it as a
+Worker secret — see [Secrets & env](/cloudflare/security/secrets-env).
+
+## Read bindings in server code
+
+Server components and API routes read bindings from the
+`cloudflare:workers` env at request time. Use a guarded dynamic
+import — Waku's SSG step renders static pages in Node, where a
+top-level `import { env } from "cloudflare:workers"` cannot
+resolve — and type the result with the inferred env type:
+
+```typescript
+// src/lib/env.ts
+import type { WebsiteEnv } from "../../alchemy.run.ts";
+
+export const getEnv = async (): Promise<WebsiteEnv> => {
+  const { env } = await import("cloudflare:workers");
+  return env as WebsiteEnv;
+};
+```
+
+Server code calls it per request:
+
+```typescript
+// src/pages/api/upload.ts
+import { getEnv } from "../../lib/env.ts";
+
+export const POST = async (request: Request) => {
+  const env = await getEnv();
+  await env.UPLOADS.put("hello.txt", await request.text());
+  return Response.json({ ok: true });
+};
+```
+
+`env.UPLOADS` is typed as an R2 bucket and `env.API_KEY` as a
+string — renaming a binding in `alchemy.run.ts` is a type error in
+your server code.
 
 ## Custom Worker entry (Durable Objects)
 
@@ -89,7 +174,7 @@ export default {
 ```
 
 ```typescript
-const site = yield* Cloudflare.Website.Waku("Site", {
+export const Website = Cloudflare.Website.Waku("Website", {
   main: "src/worker-entry.ts",
   env: {
     COUNTER: Cloudflare.DurableObject("Counter", {
@@ -98,28 +183,3 @@ const site = yield* Cloudflare.Website.Waku("Site", {
   },
 });
 ```
-
-## Rebuilds and memo
-
-Input files are content-hashed (respecting `.gitignore` by default),
-so an unchanged project skips both the build and the deploy. Narrow
-the scope with `memo` when the project has large directories that
-don't affect the build output:
-
-```typescript
-const site = yield* Cloudflare.Website.Waku("Site", {
-  memo: {
-    include: ["src/**", "public/**", "package.json"],
-  },
-});
-```
-
-## Local dev
-
-```sh
-bun alchemy dev
-```
-
-`alchemy dev` runs Waku's dev server with SSR executing in workerd,
-so server code sees the same runtime it will have in production. The
-Worker's bindings are real — the same `env` your deployed site reads.


### PR DESCRIPTION
Concurrent deploys in one process were corrupting each other's relative-path resolution: cross-spawn (bundled in vite, wrangler, next, tinyexec, …) temporarily `process.chdir`s the whole process to resolve a spawn's binary, and some framework source builds chdir in-process themselves. Any fiber that read `process.cwd()` during such a window resolved paths against an unrelated directory — surfacing as `UNRESOLVED_ENTRY` vite failures, mangled asset paths (`/Users/x/var/folders/...`), and esbuild "Could not resolve" errors on absolute paths.

### Engine fixes

- **Production Vite builds now run in a child process** rooted at the project dir (same isolation the dev server already had): new `ViteBuildChildRunner` + `runViteBuildChild`, wired through `Sources/Vite.ts`. The in-process implementation survives as `viteBuildInProcess`, only callable from the child.
- **`process.chdir.disabled = true`** in `runMain` and the test-runner CLI — cross-spawn's own escape hatch (Node sets the same flag in worker threads), neutralizing every bundled copy's chdir dance. Audited: the only readers in the tree are cross-spawn copies.
- **All engine paths anchored to `initialCwd`** (captured at startup, like the local-state anchor): `Command.Build`'s persisted relative `outdir` (both ends), asset reads/uploads, memo hashing, spawn cwds, vite root/main/hash resolution.

```ts
// Command/Build.ts — the relativize and every later resolve share one base
outdir: path.relative(initialCwd, outdir)
// Assets.ts
const directory = path.resolve(initialCwd, assets.directory);
```

- The Next.js final-bundle-pass fix (`absWorkingDir` — esbuild's shared service process otherwise inherits whatever cwd it was first spawned under, possibly a since-deleted temp dir, after which even absolute entry paths fail to resolve) lands separately in alchemy-run/cloudflare-tools#102.
- Runner-file URLs (`ViteChildRunner` / `ViteBuildChildRunner`) resolve lazily at spawn time — `import.meta.resolve` doesn't exist in workerd, so a module-level call crashes bundled user code.

### Website tests: concurrent + deflaked

- Every `test/Cloudflare/Website` suite is wrapped in `describe.concurrent` (suites are sequential by default): per-test scratch stacks and private fixture clones make them independent. The full directory now runs in ~4 min (`Vite.test.ts` alone was 9 min sequential).
- Fixed a latent StaticSite test bug: it set `process.env` *inside* the body, but the harness's `ConfigProvider.fromEnv()` snapshots env before the body runs — only ever passed via the default retry. Now set at module load.
- Budget fixes for full-parallel load: SvelteKit SPA shell probe → 120s convention, Waku remote-KV read → ~91s (KV propagation is documented up to 60s), Waku dev cold compile → 180s.

Verified: `test/Cloudflare/Website` passes 57/57 with `--retry 0`; `bun tsc -b` clean.

Also includes JSDoc/docs updates migrating examples to `Config.redacted` and refreshed frontend guides.
