### PR TITLE
ci: pin the actions revision that defines force-latest

### DIFF
--- a/.github/workflows/pr-package.yml
+++ b/.github/workflows/pr-package.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   pr-package:
-    uses: alchemy-run/actions/.github/workflows/pr-package.yml@a18b368e044cb380a8c4904d5cfbccbc2798e768 # main
+    uses: alchemy-run/actions/.github/workflows/pr-package.yml@45c20065c654cb378d02a707427405a1ad9ac3f3 # main
     with:
       # The bun workspace includes `distilled/packages/*` from the
       # distilled submodule, so the publish jobs must check it out.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   release:
-    uses: alchemy-run/actions/.github/workflows/release.yml@a18b368e044cb380a8c4904d5cfbccbc2798e768 # main
+    uses: alchemy-run/actions/.github/workflows/release.yml@45c20065c654cb378d02a707427405a1ad9ac3f3 # main
     with:
       # The bun workspace includes `distilled/packages/*` from the
       # distilled submodule, so consumer checkouts must fetch it.


### PR DESCRIPTION
Releases have been failing to start:

```
The workflow is not valid. .github/workflows/release.yml (Line: 36, Col: 21):
Invalid input, force-latest is not defined in the referenced workflow.
```

#1074 added `force-latest: true` to always claim npm's `latest` dist-tag, but the reusable workflow stayed pinned at `a18b368`, which predates that input. GitHub validates a called workflow's inputs *before* running anything, so the entire run is rejected — nothing publishes, and there's no partial failure to diagnose from.

Moves both pins to [`alchemy-run/actions@45c2006`](https://github.com/alchemy-run/actions/commit/45c20065c654cb378d02a707427405a1ad9ac3f3) (current main), which defines `force-latest`.

`force-latest: true` stays exactly as #1074 set it — this only makes the input valid.

### Checked before bumping

The pin jumps several commits, so I diffed the caller-visible surface of both workflows:

- `release.yml` inputs: only **gains** `force-latest`; nothing removed or renamed.
- `pr-package.yml` inputs: **identical** (`packages`, `pr-package-host`, `install-host`, `build-command`, `node-version`, `actions-ref`, `force-ci-label`, `submodules`, `rebuild-all-paths`).

So nothing else has to move with it.
