### PR TITLE
ci(release): expose force-latest as a checkbox

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,17 @@ on:
         required: false
         type: string
         default: ""
+      force-latest:
+        description: >-
+          Publish under npm's `latest` dist-tag regardless of channel. On
+          by default — 2.0 prereleases are the effective current release,
+          so `latest` follows whatever we publish. Uncheck to cut a release
+          that stays off `latest` (it lands on `next` instead). If the
+          version is already on npm, its `latest` tag is moved rather than
+          the publish skipped.
+        required: false
+        type: boolean
+        default: true
 
 concurrency:
   group: release-${{ github.ref }}
@@ -31,9 +42,7 @@ jobs:
       # distilled submodule, so consumer checkouts must fetch it.
       submodules: "true"
       version: ${{ inputs.version }}
-      # 2.0 prereleases are the effective current release — always move
-      # npm's `latest` dist-tag to whatever we publish (betas included).
-      force-latest: true
+      force-latest: ${{ inputs.force-latest }}
       repo: alchemy-run/alchemy
       current-version: "2.0.0"
       # Each package builds in its own publish job: the tsc build pulls


### PR DESCRIPTION
Adds the **Force latest** checkbox to the Run workflow dialog — distilled's release workflow has one, alchemy's didn't.

#1074 hardcoded `force-latest: true`, so there was no way to cut a release that stays off npm's `latest` without editing the workflow.

```diff
+      force-latest:
+        description: >-
+          Publish under npm's `latest` dist-tag regardless of channel. …
+        type: boolean
+        default: true

-      force-latest: true
+      force-latest: ${{ inputs.force-latest }}
```

**Defaults to on**, so a normal release behaves exactly as it does today — 2.0 prereleases are the effective current release, and `latest` follows whatever we publish, which is what #1074 wanted. Unchecking cuts a release that lands on `next` instead.

Follows #1104, which fixed the invalid-input failure by pinning the actions revision that defines `force-latest`.
