### PR TITLE
feat(engine): renamedFrom() — migrate state rows across FQN renames

### DIFF
--- a/packages/alchemy/src/Apply.ts
+++ b/packages/alchemy/src/Apply.ts
@@ -170,11 +170,22 @@ export const apply = <P extends Plan>(
     // ── FQN migrations (renamedFrom) ──
     // Persist renames before any lifecycle operation runs: a node whose row
     // was found under a former FQN carries that row pre-remapped in
-    // `node.state` (see Plan's `getPersistedRow`). Commit it at the current
+    // `node.state` (see Plan's rename resolution). Commit it at the current
     // FQN FIRST, then drop the former row — in that order, so an
     // interruption leaves rows at both FQNs with the same instanceId, which
     // the next plan recognizes as an in-flight migration (and never as an
     // orphan to delete).
+    //
+    // In a same-deploy shift (A→B while B→C), C's former FQN `B` is
+    // simultaneously B's migration TARGET. C must NOT delete it: B's own
+    // `state.set` supersedes the stale copy, and the migrations run
+    // concurrently — the delete could land after B's write and destroy the
+    // freshly migrated row.
+    const migrationTargets = new Set(
+      Object.values(plan.resources)
+        .filter((node) => node.renamedFrom?.length && node.state !== undefined)
+        .map((node) => node.resource.FQN),
+    );
     yield* Effect.forEach(
       Object.values(plan.resources),
       (node) => {
@@ -191,7 +202,9 @@ export const apply = <P extends Plan>(
                 value: row,
               });
               yield* Effect.forEach(
-                renamedFrom,
+                renamedFrom.filter(
+                  (formerFqn) => !migrationTargets.has(formerFqn),
+                ),
                 (formerFqn) =>
                   state.delete({ stack: stackName, stage, fqn: formerFqn }),
                 { concurrency: "unbounded" },

--- a/packages/alchemy/src/Apply.ts
+++ b/packages/alchemy/src/Apply.ts
@@ -179,7 +179,9 @@ export const apply = <P extends Plan>(
       Object.values(plan.resources),
       (node) => {
         const { renamedFrom, state: row } = node;
-        return renamedFrom === undefined || row === undefined
+        return renamedFrom === undefined ||
+          renamedFrom.length === 0 ||
+          row === undefined
           ? Effect.void
           : Effect.gen(function* () {
               yield* state.set({
@@ -188,11 +190,12 @@ export const apply = <P extends Plan>(
                 fqn: node.resource.FQN,
                 value: row,
               });
-              yield* state.delete({
-                stack: stackName,
-                stage,
-                fqn: renamedFrom,
-              });
+              yield* Effect.forEach(
+                renamedFrom,
+                (formerFqn) =>
+                  state.delete({ stack: stackName, stage, fqn: formerFqn }),
+                { concurrency: "unbounded" },
+              );
             });
       },
       { concurrency: "unbounded" },

--- a/packages/alchemy/src/Apply.ts
+++ b/packages/alchemy/src/Apply.ts
@@ -167,6 +167,37 @@ export const apply = <P extends Plan>(
       }
     >();
 
+    // ── FQN migrations (renamedFrom) ──
+    // Persist renames before any lifecycle operation runs: a node whose row
+    // was found under a former FQN carries that row pre-remapped in
+    // `node.state` (see Plan's `getPersistedRow`). Commit it at the current
+    // FQN FIRST, then drop the former row — in that order, so an
+    // interruption leaves rows at both FQNs with the same instanceId, which
+    // the next plan recognizes as an in-flight migration (and never as an
+    // orphan to delete).
+    yield* Effect.forEach(
+      Object.values(plan.resources),
+      (node) => {
+        const { renamedFrom, state: row } = node;
+        return renamedFrom === undefined || row === undefined
+          ? Effect.void
+          : Effect.gen(function* () {
+              yield* state.set({
+                stack: stackName,
+                stage,
+                fqn: node.resource.FQN,
+                value: row,
+              });
+              yield* state.delete({
+                stack: stackName,
+                stage,
+                fqn: renamedFrom,
+              });
+            });
+      },
+      { concurrency: "unbounded" },
+    );
+
     yield* executePlan(
       plan,
       tracker,

--- a/packages/alchemy/src/Cli/LoggingCli.ts
+++ b/packages/alchemy/src/Cli/LoggingCli.ts
@@ -97,7 +97,14 @@ export const formatPlanLines = (plan: Plan): string[] => {
         item.action === "replace" ? item.state.providerMode : undefined,
       defaultMode: plan.defaultMode,
     });
-    lines.push(`${tag(item.resource.LogicalId)} ${action}${mode}`);
+    // Surface FQN migrations: `[Assets] update (renamed from Bucket)` —
+    // the update exists to re-brand the moved row's physical resource, and
+    // without the note the plan gives no hint why an untouched resource
+    // reconciles.
+    const renamed = item.renamedFrom?.length
+      ? ` ${dim(`(renamed from ${item.renamedFrom.join(", ")})`)}`
+      : "";
+    lines.push(`${tag(item.resource.LogicalId)} ${action}${mode}${renamed}`);
     for (const binding of item.bindings) {
       if (binding.action === "noop") continue;
       const bindingAction = actionColor[binding.action](binding.action);

--- a/packages/alchemy/src/Cli/LoggingCli.ts
+++ b/packages/alchemy/src/Cli/LoggingCli.ts
@@ -100,10 +100,12 @@ export const formatPlanLines = (plan: Plan): string[] => {
     // Surface FQN migrations: `[Assets] update (renamed from Bucket)` —
     // the update exists to re-brand the moved row's physical resource, and
     // without the note the plan gives no hint why an untouched resource
-    // reconciles.
-    const renamed = item.renamedFrom?.length
-      ? ` ${dim(`(renamed from ${item.renamedFrom.join(", ")})`)}`
-      : "";
+    // reconciles. (Only apply-side nodes can carry a rename — see
+    // `ApplyNodeBase`.)
+    const renamed =
+      item.action !== "delete" && item.renamedFrom?.length
+        ? ` ${dim(`(renamed from ${item.renamedFrom.join(", ")})`)}`
+        : "";
     lines.push(`${tag(item.resource.LogicalId)} ${action}${mode}${renamed}`);
     for (const binding of item.bindings) {
       if (binding.action === "noop") continue;

--- a/packages/alchemy/src/Cloudflare/Access/Group.ts
+++ b/packages/alchemy/src/Cloudflare/Access/Group.ts
@@ -24,6 +24,20 @@ import type { Providers } from "../Providers.ts";
 export type GroupRule =
   zeroTrust.CreateAccessGroupForAccountRequest["include"][number];
 
+/**
+ * One arm of the exclude-side rule union, and its require-side twin.
+ * Cloudflare's spec types the exclude/require rule lists separately from
+ * include — a few rule kinds (e.g. the GitHub-organization rule) carry the
+ * raw wire shape there — so these props use the SDK's own unions rather
+ * than reusing {@link GroupRule}.
+ */
+export type GroupExcludeRule = NonNullable<
+  zeroTrust.CreateAccessGroupForAccountRequest["exclude"]
+>[number];
+export type GroupRequireRule = NonNullable<
+  zeroTrust.CreateAccessGroupForAccountRequest["require"]
+>[number];
+
 export type GroupProps = {
   /**
    * Display name for the group. Used as a stable identifier so the provider
@@ -42,12 +56,12 @@ export type GroupProps = {
    * Rules combined with logical NOT. A user matching any Exclude rule does
    * not match the group, even if they satisfied an Include rule.
    */
-  exclude?: GroupRule[];
+  exclude?: GroupExcludeRule[];
   /**
    * Rules combined with logical AND. A user must satisfy every Require rule
    * in addition to an Include rule.
    */
-  require?: GroupRule[];
+  require?: GroupRequireRule[];
   /**
    * Whether this is the default group for the Zero Trust organization.
    *

--- a/packages/alchemy/src/Cloudflare/Access/Policy.ts
+++ b/packages/alchemy/src/Cloudflare/Access/Policy.ts
@@ -22,6 +22,20 @@ import type { Providers } from "../Providers.ts";
 export type PolicyRule = zeroTrust.CreateAccessPolicyRequest["include"][number];
 
 /**
+ * One arm of the exclude-side rule union, and its require-side twin.
+ * Cloudflare's spec types the exclude/require rule lists separately from
+ * include — a few rule kinds (e.g. the GitHub-organization rule) carry the
+ * raw wire shape there — so these props use the SDK's own unions rather
+ * than reusing {@link PolicyRule}.
+ */
+export type PolicyExcludeRule = NonNullable<
+  zeroTrust.CreateAccessPolicyRequest["exclude"]
+>[number];
+export type PolicyRequireRule = NonNullable<
+  zeroTrust.CreateAccessPolicyRequest["require"]
+>[number];
+
+/**
  * Decision Cloudflare Access takes when a request matches this policy.
  *
  * - `"allow"` — admit the user.
@@ -61,12 +75,12 @@ export type PolicyProps = {
    * Rules combined with logical NOT. A request matching any exclude rule is
    * rejected by the policy even if it satisfied an include rule.
    */
-  exclude?: Policy.RuleGroup[];
+  exclude?: PolicyExcludeRule[];
   /**
    * Rules combined with logical AND. A request must satisfy every require
    * rule in addition to an include rule.
    */
-  require?: Policy.RuleGroup[];
+  require?: PolicyRequireRule[];
   /**
    * Duration of issued session tokens. Format: `300ms`, `2h45m`, etc. When
    * unset, applications using this policy fall back to their own configured

--- a/packages/alchemy/src/Cloudflare/Website/StaticSite.ts
+++ b/packages/alchemy/src/Cloudflare/Website/StaticSite.ts
@@ -6,6 +6,7 @@ import * as Command from "../../Command/index.ts";
 import type { Input, InputProps } from "../../Input.ts";
 import * as Namespace from "../../Namespace.ts";
 import * as Output from "../../Output.ts";
+import { renamedFrom } from "../../Rename.ts";
 import {
   effectClass,
   isYieldableEffectLike,
@@ -297,6 +298,12 @@ const makeStaticSite = <
     // Pure-static sites (neither `main` nor `script`) deploy as
     // assets-only Workers: no script is uploaded and Cloudflare's asset
     // layer serves every request itself.
+    //
+    // The Worker's FQN was `<id>/Worker` before #1053 flattened it to
+    // `<id>`; `renamedFrom` migrates the pre-existing state row to the new
+    // FQN instead of letting the engine plan a create+delete replacement
+    // (a new physical name, a torn-down workers.dev URL, and a
+    // custom-domain handover that crashes the deploy).
     return yield* Worker<Bindings, WorkerAssetsConfig, Req>(id, {
       ...props,
       assets: build
@@ -311,7 +318,7 @@ const makeStaticSite = <
       // state with a stub Attributes shape.
       dev: dev ? { mode: "external", url: dev.url } : undefined,
       script: props.script,
-    });
+    }).pipe(renamedFrom(`${id}/Worker`));
   });
 
 /**

--- a/packages/alchemy/src/Plan.ts
+++ b/packages/alchemy/src/Plan.ts
@@ -356,19 +356,15 @@ export const make = <A>(
 
     // ── FQN renames ──────────────────────────────────────────────────────
     // Map every former FQN claimed via `renamedFrom(...)` to its claimant's
-    // current FQN. A former FQN that is still actively declared is not a
-    // rename (the "old" resource still exists and owns its row); two
-    // resources claiming the same former FQN is ambiguous and fatal.
-    const declaredFqns = new Set<string>([
-      ...resources.map((r) => r.FQN),
-      ...actions.map((t) => t.FQN),
-    ]);
+    // current FQN. Two resources claiming the same former FQN is ambiguous
+    // and fatal. A former FQN MAY still be actively declared — that is the
+    // "old id reused by a new resource" case: the rename claim wins the
+    // row (it is an explicit user statement that the row was theirs), and
+    // the reusing resource plans a fresh create.
     const formerFqnClaims = new Map<string, string>();
     for (const resource of resources) {
       for (const formerFqn of resource.FormerFqns ?? []) {
-        if (formerFqn === resource.FQN || declaredFqns.has(formerFqn)) {
-          continue;
-        }
+        if (formerFqn === resource.FQN) continue;
         const claimant = formerFqnClaims.get(formerFqn);
         if (claimant !== undefined && claimant !== resource.FQN) {
           return yield* Effect.die(
@@ -384,42 +380,41 @@ export const make = <A>(
       }
     }
 
-    /**
-     * Fetch the persisted row for a declared resource, falling back to its
-     * former FQNs (`renamedFrom(...)`, checked in declaration order — list
-     * the most recent former id first):
-     *
-     * - No row at the current FQN, a row at a former FQN → the row IS this
-     *   resource's state. It is adopted under the new identity in-memory
-     *   (plan construction is side-effect-free — see the adoption notes
-     *   below); apply persists the move before any lifecycle runs.
-     * - Rows at both with the same `instanceId` → an interrupted migration
-     *   (the new row was committed, the former row not yet deleted). Plan
-     *   from the new row; `renamedFrom` marks the leftover for state-only
-     *   cleanup at apply.
-     * - Rows at both with different `instanceId`s → the former row belongs
-     *   to some other resource (e.g. a new resource reusing the old name
-     *   after the rename shipped). Ignore it — normal orphan handling
-     *   applies (see the `formerFqnClaims` guard in `deletions`).
-     *
-     * Hardened against the messy multi-rename histories:
-     *
-     * - EVERY former row sharing the source row's `instanceId` is collected
-     *   into `renamedFrom` (a rename chain with repeated partial failures
-     *   can leave several same-instance leftovers — migration always
-     *   preserved the instanceId, so they are provably copies of this
-     *   resource's row, never someone else's). One apply drops them all.
-     * - A former row whose `resourceType` is neither the resource's type
-     *   nor one of its registered type-aliases is never migrated — it
-     *   cannot be this resource's row, whatever its FQN says. It falls
-     *   through to normal orphan handling.
-     */
-    const getPersistedRow = Effect.fn(function* (
-      resource: Pick<
-        ResourceLike,
-        "FQN" | "LogicalId" | "Namespace" | "FormerFqns" | "Type"
-      >,
-    ) {
+    // Resolve every rename migration up-front against the state snapshot,
+    // BEFORE any node is built — other resources' planning depends on the
+    // outcome (a resource declared at a former FQN whose row is migrating
+    // away must start from scratch).
+    //
+    // For each renamer, in former-id declaration order (most recent
+    // first):
+    //
+    // - `source` is the row that defines the resource's physical identity:
+    //   the row at its own FQN when present AND type-matching, otherwise
+    //   the first type-matching former row (→ `moved`).
+    // - every OTHER type-matching former row sharing `source.instanceId`
+    //   is a leftover from an interrupted migration (only migration copies
+    //   instanceIds) — collected for state-only cleanup.
+    // - former rows with a different instanceId belong to someone else and
+    //   are left to normal orphan handling; former rows with a different
+    //   resourceType (modulo registered type-aliases) can never be this
+    //   resource's row and are skipped entirely.
+    // - a FOREIGN-typed row at the renamer's own FQN blocks the migration
+    //   fatally: landing the migrated row there would silently abandon
+    //   that row's cloud resource.
+    const renameMigrations = new Map<
+      string,
+      { row: ResourceState; renamedFrom: string[]; moved: boolean }
+    >();
+    const migratedRowFqns = new Set<string>();
+    for (const resource of resources) {
+      if (!resource.FormerFqns?.length) continue;
+      const provider = Option.getOrUndefined(
+        yield* tryFindProviderByType(resource.Type),
+      );
+      const allowedTypes = new Set([
+        resource.Type,
+        ...(provider?.aliases ?? []),
+      ]);
       const persisted = yield* state.get({
         stack: stackName,
         stage: stage,
@@ -428,37 +423,12 @@ export const make = <A>(
       const persistedRow = isActionState(persisted)
         ? undefined
         : (persisted as ResourceState | undefined);
-      if (!resource.FormerFqns?.length) {
-        return { row: persistedRow, renamedFrom: undefined };
-      }
-
-      const provider = Option.getOrUndefined(
-        yield* tryFindProviderByType(resource.Type),
-      );
-      const allowedTypes = new Set([
-        resource.Type,
-        ...(provider?.aliases ?? []),
-      ]);
-
-      // A row at the resource's own FQN only counts as a claim when it is
-      // actually this resource's row — its resourceType matches. A
-      // foreign-typed row (e.g. a different resource type occupied this
-      // FQN before a same-release shuffle) cannot be ours, so a
-      // type-matching former row takes precedence as the migration source.
-      // The foreign row is overwritten by the migration commit — the same
-      // silent clobber the resource's first terminal commit would perform
-      // without the rename, but the resource plans against its REAL
-      // predecessor's state instead of a foreign type's.
       const ownRow =
         persistedRow !== undefined &&
         allowedTypes.has(persistedRow.resourceType)
           ? persistedRow
           : undefined;
 
-      // `source` is the row whose instanceId defines this resource's
-      // physical identity: the row at the current FQN if present (and
-      // type-matching), otherwise the first (most recent) matching former
-      // row.
       let source: ResourceState | undefined = ownRow;
       let adopted: ResourceState | undefined = ownRow;
       const renamedFrom: string[] = [];
@@ -487,13 +457,59 @@ export const make = <A>(
           renamedFrom.push(formerFqn);
         }
       }
-      return {
-        // No migration happened: fall back to whatever sits at the FQN
-        // (even a foreign-typed row — pre-existing engine behavior for
-        // type collisions is unchanged when no rename resolves it).
-        row: adopted ?? persistedRow,
-        renamedFrom: renamedFrom.length > 0 ? renamedFrom : undefined,
-      };
+      if (renamedFrom.length === 0) continue;
+      if (persistedRow !== undefined && ownRow === undefined) {
+        return yield* Effect.die(
+          new Error(
+            `Cannot migrate '${renamedFrom[0]}' to '${resource.FQN}': a ` +
+              `state row of a different type ('${persistedRow.resourceType}') ` +
+              `already occupies '${resource.FQN}'. Migrating over it would ` +
+              "silently abandon that row's cloud resource. Delete or " +
+              "rename the conflicting resource first, then re-deploy.",
+          ),
+        );
+      }
+      renameMigrations.set(resource.FQN, {
+        row: adopted!,
+        renamedFrom,
+        moved: adopted !== ownRow,
+      });
+      for (const formerFqn of renamedFrom) migratedRowFqns.add(formerFqn);
+    }
+
+    /**
+     * Fetch the persisted row for a declared resource, resolving renames
+     * (see the pre-computed `renameMigrations` above):
+     *
+     * - a renamer plans from its migrated row (`renamedFrom` rides onto
+     *   the plan node; apply persists the move before any lifecycle op)
+     * - a resource declared at a former FQN whose row is migrating away
+     *   starts from scratch — the row is NOT its state, whatever the FQN
+     *   says
+     */
+    const getPersistedRow = Effect.fn(function* (
+      resource: Pick<ResourceLike, "FQN">,
+    ) {
+      const migration = renameMigrations.get(resource.FQN);
+      if (migration !== undefined) {
+        return {
+          row: migration.row,
+          renamedFrom: migration.renamedFrom,
+          renameMoved: migration.moved,
+        };
+      }
+      const persisted = yield* state.get({
+        stack: stackName,
+        stage: stage,
+        fqn: resource.FQN,
+      });
+      const row = isActionState(persisted)
+        ? undefined
+        : (persisted as ResourceState | undefined);
+      if (row !== undefined && migratedRowFqns.has(resource.FQN)) {
+        return { row: undefined, renamedFrom: undefined, renameMoved: false };
+      }
+      return { row, renamedFrom: undefined, renameMoved: false };
     });
 
     const resolvedResources: Record<string, Effect.Effect<any>> = {};
@@ -1017,8 +1033,11 @@ export const make = <A>(
             // `renamedFrom` rides onto the plan node so apply persists the
             // move. (A Task previously holding this FQN is treated as no
             // prior state — its row is reaped by `actionDeletions` below.)
-            const { row: persistedRow, renamedFrom } =
-              yield* getPersistedRow(resource);
+            const {
+              row: persistedRow,
+              renamedFrom,
+              renameMoved,
+            } = yield* getPersistedRow(resource);
             let oldState: ResourceState | undefined = persistedRow;
 
             // Engine-level adoption. When there is no prior state, always
@@ -1069,8 +1088,20 @@ export const make = <A>(
             // SDK protocol layer. Resources whose props depend on
             // not-yet-created upstreams cannot themselves be pre-existing
             // — there's nothing to adopt.
+            // A resource declared at a former FQN whose row just migrated
+            // away is genuinely NEW by declaration — skip the probe. Its
+            // predecessor's physical resource still carries tags branded
+            // with THIS logical id (the migrated row's reconcile hasn't
+            // re-branded them yet), so a tag-based `read` would find it
+            // and silently adopt the very resource that was renamed away.
+            const reusesMigratedFqn = migratedRowFqns.has(fqn);
             let forceUpdateAfterAdoption = false;
-            if (oldState === undefined && provider.read && isResolved(news)) {
+            if (
+              oldState === undefined &&
+              provider.read &&
+              isResolved(news) &&
+              !reusesMigratedFqn
+            ) {
               const adoptInstanceId = yield* generateInstanceId();
               const readResult = yield* provider
                 .read({
@@ -1304,8 +1335,16 @@ export const make = <A>(
                   // would noop and any drift between the existing cloud
                   // resource and `news` — including foreign-owned tags after a
                   // takeover — would persist).
+                  //
+                  // A row that just migrated from a former FQN (`renameMoved`)
+                  // gets the same treatment: its cloud resource is still
+                  // branded with the OLD logical id's tags, and if the old id
+                  // is being reused by a new resource, leaving them stale
+                  // would let the reuser's future adoption probes match the
+                  // wrong physical resource.
                   Effect.map((diff) =>
-                    forceUpdateAfterAdoption && diff.action === "noop"
+                    (forceUpdateAfterAdoption || renameMoved) &&
+                    diff.action === "noop"
                       ? ({ action: "update" } satisfies UpdateDiff)
                       : diff,
                   ),
@@ -1664,23 +1703,13 @@ export const make = <A>(
             if (isActionState(persisted)) return;
             const oldState = persisted as ResourceState | undefined;
             if (oldState) {
-              // A row at a former FQN claimed by a renamed resource is not
-              // an orphan while its migration is in flight. Compare against
-              // the claimant's PLANNED node state (which reflects the
-              // in-memory migration) rather than re-reading persisted
-              // state: a row sharing the claimant's instanceId is provably
-              // a pre-move copy of the claimant's own row (migration
-              // preserves instanceIds) and is dropped state-only by apply.
-              // A claimed row with a DIFFERENT instanceId — or one the
-              // claimant never adopted (e.g. wrong resourceType) — is a
-              // genuinely distinct resource and falls through to normal
-              // orphan deletion.
-              const claimant = formerFqnClaims.get(fqn);
-              if (
-                claimant !== undefined &&
-                resourceGraph[claimant]?.state?.instanceId ===
-                  oldState.instanceId
-              ) {
+              // A row being migrated by a rename (`renameMigrations`) is
+              // moving, not orphaned — apply drops it state-only after
+              // committing the migrated row at its new FQN. Rows at former
+              // FQNs that did NOT migrate (foreign type, different
+              // instanceId, unclaimed) are absent from this set and fall
+              // through to normal orphan deletion.
+              if (migratedRowFqns.has(fqn)) {
                 return;
               }
               const { logicalId } = parseFqn(fqn);
@@ -1917,7 +1946,10 @@ export const printPlan = (plan: Plan): string => {
     const downstream = node.state?.downstream?.length
       ? ` → [${node.state?.downstream.join(", ")}]`
       : "";
-    lines.push(`│ [${symbol}] ${id} (${type})${downstream}`);
+    const renamed = node.renamedFrom?.length
+      ? ` (renamed from ${node.renamedFrom.join(", ")})`
+      : "";
+    lines.push(`│ [${symbol}] ${id} (${type})${downstream}${renamed}`);
   }
   if (resourceIds.length === 0) {
     lines.push("│ (none)");

--- a/packages/alchemy/src/Plan.ts
+++ b/packages/alchemy/src/Plan.ts
@@ -115,6 +115,15 @@ export interface BaseNode<
   mode: ProviderMode | undefined;
   downstream: string[];
   bindings: BindingNode<R["Binding"]>[];
+  /**
+   * Set when this resource's persisted row was found under a former FQN
+   * (`renamedFrom(...)`) — either adopted in-memory as `state` (no row at
+   * the current FQN yet) or as a stale leftover from an interrupted
+   * migration (same `instanceId` as the row at the current FQN). Apply
+   * persists the move up-front, before any lifecycle operation runs:
+   * commit `state` at the current FQN, then delete the former row.
+   */
+  renamedFrom?: string | undefined;
 }
 
 export interface Create<
@@ -344,6 +353,96 @@ export const make = <A>(
       { concurrency: "unbounded" },
     );
 
+    // ── FQN renames ──────────────────────────────────────────────────────
+    // Map every former FQN claimed via `renamedFrom(...)` to its claimant's
+    // current FQN. A former FQN that is still actively declared is not a
+    // rename (the "old" resource still exists and owns its row); two
+    // resources claiming the same former FQN is ambiguous and fatal.
+    const declaredFqns = new Set<string>([
+      ...resources.map((r) => r.FQN),
+      ...actions.map((t) => t.FQN),
+    ]);
+    const formerFqnClaims = new Map<string, string>();
+    for (const resource of resources) {
+      for (const formerFqn of resource.FormerFqns ?? []) {
+        if (formerFqn === resource.FQN || declaredFqns.has(formerFqn)) {
+          continue;
+        }
+        const claimant = formerFqnClaims.get(formerFqn);
+        if (claimant !== undefined && claimant !== resource.FQN) {
+          return yield* Effect.die(
+            new Error(
+              `Resources '${claimant}' and '${resource.FQN}' both claim ` +
+                `former FQN '${formerFqn}' via renamedFrom(...). A former ` +
+                "FQN can migrate to exactly one resource — remove the " +
+                "decoration from one of them.",
+            ),
+          );
+        }
+        formerFqnClaims.set(formerFqn, resource.FQN);
+      }
+    }
+
+    /**
+     * Fetch the persisted row for a declared resource, falling back to its
+     * former FQNs (`renamedFrom(...)`):
+     *
+     * - No row at the current FQN, a row at a former FQN → the row IS this
+     *   resource's state. It is adopted under the new identity in-memory
+     *   (plan construction is side-effect-free — see the adoption notes
+     *   below); apply persists the move before any lifecycle runs.
+     * - Rows at both with the same `instanceId` → an interrupted migration
+     *   (the new row was committed, the former row not yet deleted). Plan
+     *   from the new row; `renamedFrom` marks the leftover for state-only
+     *   cleanup at apply.
+     * - Rows at both with different `instanceId`s → the former row belongs
+     *   to some other resource (e.g. a new resource reusing the old name
+     *   after the rename shipped). Ignore it — normal orphan handling
+     *   applies.
+     */
+    const getPersistedRow = Effect.fn(function* (
+      resource: Pick<
+        ResourceLike,
+        "FQN" | "LogicalId" | "Namespace" | "FormerFqns"
+      >,
+    ) {
+      const persisted = yield* state.get({
+        stack: stackName,
+        stage: stage,
+        fqn: resource.FQN,
+      });
+      const row = isActionState(persisted)
+        ? undefined
+        : (persisted as ResourceState | undefined);
+      for (const formerFqn of resource.FormerFqns ?? []) {
+        if (formerFqnClaims.get(formerFqn) !== resource.FQN) continue;
+        const formerPersisted = yield* state.get({
+          stack: stackName,
+          stage: stage,
+          fqn: formerFqn,
+        });
+        if (formerPersisted === undefined || isActionState(formerPersisted)) {
+          continue;
+        }
+        const formerRow = formerPersisted as ResourceState;
+        if (row === undefined) {
+          return {
+            row: {
+              ...formerRow,
+              fqn: resource.FQN,
+              logicalId: resource.LogicalId,
+              namespace: resource.Namespace,
+            } as ResourceState,
+            renamedFrom: formerFqn,
+          };
+        }
+        if (row.instanceId === formerRow.instanceId) {
+          return { row, renamedFrom: formerFqn };
+        }
+      }
+      return { row, renamedFrom: undefined };
+    });
+
     const resolvedResources: Record<string, Effect.Effect<any>> = {};
 
     const resolveResource = (
@@ -367,16 +466,10 @@ export const make = <A>(
               const props = materializeStableRefs(
                 yield* resolveInput(resource.Props),
               );
-              const persisted = yield* state.get({
-                stack: stackName,
-                stage: stage,
-                fqn: resource.FQN,
-              });
-              const oldState: ResourceState | undefined = isActionState(
-                persisted,
-              )
-                ? undefined
-                : (persisted as ResourceState | undefined);
+              // Falls back to the row at a former FQN (`renamedFrom`) so a
+              // renamed resource's stable attributes keep flowing to
+              // downstream diffs across the migration.
+              const { row: oldState } = yield* getPersistedRow(resource);
 
               if (!oldState || oldState.status === "creating") {
                 return resourceExpr;
@@ -865,17 +958,15 @@ export const make = <A>(
             // `bindingOutputs`, not these plan-time shapes.
             const newBindings: ResourceBinding[] =
               materializeStableRefs(applyBindings);
-            const persisted = yield* state.get({
-              stack: stackName,
-              stage: stage,
-              fqn,
-            });
-            // A Task previously held this FQN. Treat as if there were no
-            // prior state — the Task's row will be reaped by `actionDeletions`
-            // below and the resource starts from scratch.
-            let oldState: ResourceState | undefined = isActionState(persisted)
-              ? undefined
-              : (persisted as ResourceState | undefined);
+            // The row is looked up at the resource's FQN with a fallback to
+            // its former FQNs (`renamedFrom`); a row found under a former
+            // FQN arrives here already remapped to the new identity, and
+            // `renamedFrom` rides onto the plan node so apply persists the
+            // move. (A Task previously holding this FQN is treated as no
+            // prior state — its row is reaped by `actionDeletions` below.)
+            const { row: persistedRow, renamedFrom } =
+              yield* getPersistedRow(resource);
+            let oldState: ResourceState | undefined = persistedRow;
 
             // Engine-level adoption. When there is no prior state, always
             // consult `provider.read` (if implemented) so the engine — not
@@ -1019,6 +1110,7 @@ export const make = <A>(
                 bindings: bindingDiffs,
                 downstream,
                 mode,
+                renamedFrom,
               }) as any as T;
 
             // Plan against the persisted state we have, not the ideal final state we
@@ -1519,6 +1611,29 @@ export const make = <A>(
             if (isActionState(persisted)) return;
             const oldState = persisted as ResourceState | undefined;
             if (oldState) {
+              // A row at a former FQN claimed by a renamed resource is not
+              // an orphan while its migration is in flight: the claimant
+              // either has no row yet (this row IS its state, pre-move) or
+              // a row with the same instanceId (interrupted move — the
+              // leftover is dropped state-only by apply). Only a claimed
+              // row with a DIFFERENT instanceId is a genuinely distinct
+              // resource and falls through to normal orphan deletion.
+              const claimant = formerFqnClaims.get(fqn);
+              if (claimant !== undefined) {
+                const claimantRow = yield* state.get({
+                  stack: stackName,
+                  stage: stage,
+                  fqn: claimant,
+                });
+                if (
+                  claimantRow === undefined ||
+                  (!isActionState(claimantRow) &&
+                    (claimantRow as ResourceState).instanceId ===
+                      oldState.instanceId)
+                ) {
+                  return;
+                }
+              }
               const { logicalId } = parseFqn(fqn);
               const resourceType = oldState.resourceType;
               // A "zombie" row references a type with no registered provider
@@ -1566,6 +1681,7 @@ export const make = <A>(
                     RemovalPolicy: oldState.removalPolicy,
                     Adopt: undefined,
                     Mode: oldState.providerMode,
+                    FormerFqns: undefined,
                     RuntimeContext: undefined!,
                     Providers: undefined,
                   } as ResourceLike,

--- a/packages/alchemy/src/Plan.ts
+++ b/packages/alchemy/src/Plan.ts
@@ -366,6 +366,16 @@ export const make = <A>(
       { concurrency: "unbounded" },
     );
 
+    // Snapshot of every persisted row, keyed by FQN. The rename resolution
+    // below reads from this map instead of issuing per-FQN `state.get`s —
+    // every renamedFrom-decorated resource (each StaticSite carries one
+    // forever) would otherwise add two round-trips per resource to every
+    // plan against a remote state store. Plan is read-only, so the
+    // snapshot cannot go stale within this run.
+    const persistedRows = new Map(
+      resourceFqns.map((fqn, i) => [fqn, oldResources[i]]),
+    );
+
     // ── FQN renames ──────────────────────────────────────────────────────
     // Map every former FQN claimed via `renamedFrom(...)` to its claimant's
     // current FQN. Two resources claiming the same former FQN is ambiguous
@@ -427,11 +437,7 @@ export const make = <A>(
         resource.Type,
         ...(provider?.aliases ?? []),
       ]);
-      const persisted = yield* state.get({
-        stack: stackName,
-        stage: stage,
-        fqn: resource.FQN,
-      });
+      const persisted = persistedRows.get(resource.FQN);
       const persistedRow = isActionState(persisted)
         ? undefined
         : (persisted as ResourceState | undefined);
@@ -455,11 +461,7 @@ export const make = <A>(
         // The same former id may be listed twice (or resolve identically);
         // collect each former row once.
         if (renamedFrom.includes(formerFqn)) continue;
-        const formerPersisted = yield* state.get({
-          stack: stackName,
-          stage: stage,
-          fqn: formerFqn,
-        });
+        const formerPersisted = persistedRows.get(formerFqn);
         if (formerPersisted === undefined || isActionState(formerPersisted)) {
           continue;
         }

--- a/packages/alchemy/src/Plan.ts
+++ b/packages/alchemy/src/Plan.ts
@@ -446,6 +446,9 @@ export const make = <A>(
       const renamedFrom: string[] = [];
       for (const formerFqn of resource.FormerFqns) {
         if (formerFqnClaims.get(formerFqn) !== resource.FQN) continue;
+        // The same former id may be listed twice (or resolve identically);
+        // collect each former row once.
+        if (renamedFrom.includes(formerFqn)) continue;
         const formerPersisted = yield* state.get({
           stack: stackName,
           stage: stage,

--- a/packages/alchemy/src/Plan.ts
+++ b/packages/alchemy/src/Plan.ts
@@ -115,6 +115,18 @@ export interface BaseNode<
   mode: ProviderMode | undefined;
   downstream: string[];
   bindings: BindingNode<R["Binding"]>[];
+}
+
+/**
+ * Base for the apply-side nodes (create/update/replace/noop) — the nodes a
+ * DECLARED resource plans to. Only these can carry a rename: a `Delete`
+ * node is an orphaned row with no declaration, so nothing can claim to
+ * have renamed it (migrating rows are excluded from the orphan pass
+ * entirely).
+ */
+export interface ApplyNodeBase<
+  R extends ResourceLike<string> = ResourceLike<string>,
+> extends BaseNode<R> {
   /**
    * Set when this resource's persisted row was found under former FQNs
    * (`renamedFrom(...)`) — the migration source (no row at the current FQN
@@ -129,7 +141,7 @@ export interface BaseNode<
 
 export interface Create<
   R extends ResourceLike = ResourceLike,
-> extends BaseNode<R> {
+> extends ApplyNodeBase<R> {
   action: "create";
   props: R["Props"];
   state: CreatingResourceState | undefined;
@@ -137,7 +149,7 @@ export interface Create<
 
 export interface Update<
   R extends ResourceLike = ResourceLike,
-> extends BaseNode<R> {
+> extends ApplyNodeBase<R> {
   action: "update";
   /** True while this is the first reconcile after a cold adoption. */
   adopting?: boolean;
@@ -161,14 +173,14 @@ export interface Delete<
 
 export interface NoopUpdate<
   R extends ResourceLike = ResourceLike,
-> extends BaseNode<R> {
+> extends ApplyNodeBase<R> {
   action: "noop";
   state: CreatedResourceState | UpdatedResourceState;
 }
 
 export interface Replace<
   R extends ResourceLike = ResourceLike,
-> extends BaseNode<R> {
+> extends ApplyNodeBase<R> {
   action: "replace";
   props: any;
   deleteFirst: boolean;

--- a/packages/alchemy/src/Plan.ts
+++ b/packages/alchemy/src/Plan.ts
@@ -425,11 +425,11 @@ export const make = <A>(
         stage: stage,
         fqn: resource.FQN,
       });
-      const row = isActionState(persisted)
+      const persistedRow = isActionState(persisted)
         ? undefined
         : (persisted as ResourceState | undefined);
       if (!resource.FormerFqns?.length) {
-        return { row, renamedFrom: undefined };
+        return { row: persistedRow, renamedFrom: undefined };
       }
 
       const provider = Option.getOrUndefined(
@@ -440,11 +440,27 @@ export const make = <A>(
         ...(provider?.aliases ?? []),
       ]);
 
+      // A row at the resource's own FQN only counts as a claim when it is
+      // actually this resource's row — its resourceType matches. A
+      // foreign-typed row (e.g. a different resource type occupied this
+      // FQN before a same-release shuffle) cannot be ours, so a
+      // type-matching former row takes precedence as the migration source.
+      // The foreign row is overwritten by the migration commit — the same
+      // silent clobber the resource's first terminal commit would perform
+      // without the rename, but the resource plans against its REAL
+      // predecessor's state instead of a foreign type's.
+      const ownRow =
+        persistedRow !== undefined &&
+        allowedTypes.has(persistedRow.resourceType)
+          ? persistedRow
+          : undefined;
+
       // `source` is the row whose instanceId defines this resource's
-      // physical identity: the row at the current FQN if present, otherwise
-      // the first (most recent) matching former row.
-      let source: ResourceState | undefined = row;
-      let adopted: ResourceState | undefined = row;
+      // physical identity: the row at the current FQN if present (and
+      // type-matching), otherwise the first (most recent) matching former
+      // row.
+      let source: ResourceState | undefined = ownRow;
+      let adopted: ResourceState | undefined = ownRow;
       const renamedFrom: string[] = [];
       for (const formerFqn of resource.FormerFqns) {
         if (formerFqnClaims.get(formerFqn) !== resource.FQN) continue;
@@ -472,7 +488,10 @@ export const make = <A>(
         }
       }
       return {
-        row: adopted,
+        // No migration happened: fall back to whatever sits at the FQN
+        // (even a foreign-typed row — pre-existing engine behavior for
+        // type collisions is unchanged when no rename resolves it).
+        row: adopted ?? persistedRow,
         renamedFrom: renamedFrom.length > 0 ? renamedFrom : undefined,
       };
     });

--- a/packages/alchemy/src/Plan.ts
+++ b/packages/alchemy/src/Plan.ts
@@ -418,8 +418,8 @@ export const make = <A>(
       { row: ResourceState; renamedFrom: string[]; moved: boolean }
     >();
     const migratedRowFqns = new Set<string>();
-    for (const resource of resources) {
-      if (!resource.FormerFqns?.length) continue;
+
+    const resolveRenamer = Effect.fn(function* (resource: ResourceLike) {
       const provider = Option.getOrUndefined(
         yield* tryFindProviderByType(resource.Type),
       );
@@ -435,7 +435,13 @@ export const make = <A>(
       const persistedRow = isActionState(persisted)
         ? undefined
         : (persisted as ResourceState | undefined);
+      // A row at this resource's own FQN that a PREVIOUSLY RESOLVED
+      // renamer claimed (a same-deploy shift: A→B while B→C — C took the
+      // row at B) is moving away: it is not ours to keep and it does not
+      // block the migration landing here.
+      const rowTaken = migratedRowFqns.has(resource.FQN);
       const ownRow =
+        !rowTaken &&
         persistedRow !== undefined &&
         allowedTypes.has(persistedRow.resourceType)
           ? persistedRow
@@ -444,7 +450,7 @@ export const make = <A>(
       let source: ResourceState | undefined = ownRow;
       let adopted: ResourceState | undefined = ownRow;
       const renamedFrom: string[] = [];
-      for (const formerFqn of resource.FormerFqns) {
+      for (const formerFqn of resource.FormerFqns!) {
         if (formerFqnClaims.get(formerFqn) !== resource.FQN) continue;
         // The same former id may be listed twice (or resolve identically);
         // collect each former row once.
@@ -472,8 +478,8 @@ export const make = <A>(
           renamedFrom.push(formerFqn);
         }
       }
-      if (renamedFrom.length === 0) continue;
-      if (persistedRow !== undefined && ownRow === undefined) {
+      if (renamedFrom.length === 0) return;
+      if (persistedRow !== undefined && ownRow === undefined && !rowTaken) {
         return yield* Effect.die(
           new Error(
             `Cannot migrate '${renamedFrom[0]}' to '${resource.FQN}': a ` +
@@ -490,6 +496,42 @@ export const make = <A>(
         moved: adopted !== ownRow,
       });
       for (const formerFqn of renamedFrom) migratedRowFqns.add(formerFqn);
+    });
+
+    // Resolve renamers in claim-dependency order: when resource R's OWN
+    // FQN is claimed as a former id by resource S (a same-deploy shift:
+    // A→B while B→C), S must resolve first — whether S takes R's row
+    // decides whether R still owns it, or falls back to ITS former rows.
+    // Iterate to fixpoint; anything left is a claim CYCLE (a swap: A⇄B),
+    // which cannot be persisted safely — the migrations would overwrite
+    // and delete each other's rows — and dies loudly.
+    let pendingRenamers = resources.filter((r) => r.FormerFqns?.length);
+    const resolvedRenamers = new Set<string>();
+    while (pendingRenamers.length > 0) {
+      const ready = pendingRenamers.filter((resource) => {
+        const claimant = formerFqnClaims.get(resource.FQN);
+        return claimant === undefined || resolvedRenamers.has(claimant);
+      });
+      if (ready.length === 0) {
+        return yield* Effect.die(
+          new Error(
+            `Rename cycle detected among [${pendingRenamers
+              .map((r) => `'${r.FQN}'`)
+              .join(
+                ", ",
+              )}]: their renamedFrom(...) declarations claim each other's ` +
+              "FQNs. Swapping ids in one deploy is not supported — rename " +
+              "through a temporary id across two deploys instead.",
+          ),
+        );
+      }
+      for (const resource of ready) {
+        yield* resolveRenamer(resource);
+        resolvedRenamers.add(resource.FQN);
+      }
+      pendingRenamers = pendingRenamers.filter(
+        (r) => !resolvedRenamers.has(r.FQN),
+      );
     }
 
     /**

--- a/packages/alchemy/src/Plan.ts
+++ b/packages/alchemy/src/Plan.ts
@@ -116,14 +116,15 @@ export interface BaseNode<
   downstream: string[];
   bindings: BindingNode<R["Binding"]>[];
   /**
-   * Set when this resource's persisted row was found under a former FQN
-   * (`renamedFrom(...)`) — either adopted in-memory as `state` (no row at
-   * the current FQN yet) or as a stale leftover from an interrupted
-   * migration (same `instanceId` as the row at the current FQN). Apply
-   * persists the move up-front, before any lifecycle operation runs:
-   * commit `state` at the current FQN, then delete the former row.
+   * Set when this resource's persisted row was found under former FQNs
+   * (`renamedFrom(...)`) — the migration source (no row at the current FQN
+   * yet) and/or stale leftovers from interrupted migrations (same
+   * `instanceId` as the resource's row; a rename chain with repeated
+   * partial failures can leave several). Apply persists the move up-front,
+   * before any lifecycle operation runs: commit `state` at the current
+   * FQN, then delete every former row.
    */
-  renamedFrom?: string | undefined;
+  renamedFrom?: string[] | undefined;
 }
 
 export interface Create<
@@ -385,7 +386,8 @@ export const make = <A>(
 
     /**
      * Fetch the persisted row for a declared resource, falling back to its
-     * former FQNs (`renamedFrom(...)`):
+     * former FQNs (`renamedFrom(...)`, checked in declaration order — list
+     * the most recent former id first):
      *
      * - No row at the current FQN, a row at a former FQN → the row IS this
      *   resource's state. It is adopted under the new identity in-memory
@@ -398,12 +400,24 @@ export const make = <A>(
      * - Rows at both with different `instanceId`s → the former row belongs
      *   to some other resource (e.g. a new resource reusing the old name
      *   after the rename shipped). Ignore it — normal orphan handling
-     *   applies.
+     *   applies (see the `formerFqnClaims` guard in `deletions`).
+     *
+     * Hardened against the messy multi-rename histories:
+     *
+     * - EVERY former row sharing the source row's `instanceId` is collected
+     *   into `renamedFrom` (a rename chain with repeated partial failures
+     *   can leave several same-instance leftovers — migration always
+     *   preserved the instanceId, so they are provably copies of this
+     *   resource's row, never someone else's). One apply drops them all.
+     * - A former row whose `resourceType` is neither the resource's type
+     *   nor one of its registered type-aliases is never migrated — it
+     *   cannot be this resource's row, whatever its FQN says. It falls
+     *   through to normal orphan handling.
      */
     const getPersistedRow = Effect.fn(function* (
       resource: Pick<
         ResourceLike,
-        "FQN" | "LogicalId" | "Namespace" | "FormerFqns"
+        "FQN" | "LogicalId" | "Namespace" | "FormerFqns" | "Type"
       >,
     ) {
       const persisted = yield* state.get({
@@ -414,7 +428,25 @@ export const make = <A>(
       const row = isActionState(persisted)
         ? undefined
         : (persisted as ResourceState | undefined);
-      for (const formerFqn of resource.FormerFqns ?? []) {
+      if (!resource.FormerFqns?.length) {
+        return { row, renamedFrom: undefined };
+      }
+
+      const provider = Option.getOrUndefined(
+        yield* tryFindProviderByType(resource.Type),
+      );
+      const allowedTypes = new Set([
+        resource.Type,
+        ...(provider?.aliases ?? []),
+      ]);
+
+      // `source` is the row whose instanceId defines this resource's
+      // physical identity: the row at the current FQN if present, otherwise
+      // the first (most recent) matching former row.
+      let source: ResourceState | undefined = row;
+      let adopted: ResourceState | undefined = row;
+      const renamedFrom: string[] = [];
+      for (const formerFqn of resource.FormerFqns) {
         if (formerFqnClaims.get(formerFqn) !== resource.FQN) continue;
         const formerPersisted = yield* state.get({
           stack: stackName,
@@ -425,22 +457,24 @@ export const make = <A>(
           continue;
         }
         const formerRow = formerPersisted as ResourceState;
-        if (row === undefined) {
-          return {
-            row: {
-              ...formerRow,
-              fqn: resource.FQN,
-              logicalId: resource.LogicalId,
-              namespace: resource.Namespace,
-            } as ResourceState,
-            renamedFrom: formerFqn,
-          };
-        }
-        if (row.instanceId === formerRow.instanceId) {
-          return { row, renamedFrom: formerFqn };
+        if (!allowedTypes.has(formerRow.resourceType)) continue;
+        if (source === undefined) {
+          source = formerRow;
+          adopted = {
+            ...formerRow,
+            fqn: resource.FQN,
+            logicalId: resource.LogicalId,
+            namespace: resource.Namespace,
+          } as ResourceState;
+          renamedFrom.push(formerFqn);
+        } else if (source.instanceId === formerRow.instanceId) {
+          renamedFrom.push(formerFqn);
         }
       }
-      return { row, renamedFrom: undefined };
+      return {
+        row: adopted,
+        renamedFrom: renamedFrom.length > 0 ? renamedFrom : undefined,
+      };
     });
 
     const resolvedResources: Record<string, Effect.Effect<any>> = {};
@@ -1612,27 +1646,23 @@ export const make = <A>(
             const oldState = persisted as ResourceState | undefined;
             if (oldState) {
               // A row at a former FQN claimed by a renamed resource is not
-              // an orphan while its migration is in flight: the claimant
-              // either has no row yet (this row IS its state, pre-move) or
-              // a row with the same instanceId (interrupted move — the
-              // leftover is dropped state-only by apply). Only a claimed
-              // row with a DIFFERENT instanceId is a genuinely distinct
-              // resource and falls through to normal orphan deletion.
+              // an orphan while its migration is in flight. Compare against
+              // the claimant's PLANNED node state (which reflects the
+              // in-memory migration) rather than re-reading persisted
+              // state: a row sharing the claimant's instanceId is provably
+              // a pre-move copy of the claimant's own row (migration
+              // preserves instanceIds) and is dropped state-only by apply.
+              // A claimed row with a DIFFERENT instanceId — or one the
+              // claimant never adopted (e.g. wrong resourceType) — is a
+              // genuinely distinct resource and falls through to normal
+              // orphan deletion.
               const claimant = formerFqnClaims.get(fqn);
-              if (claimant !== undefined) {
-                const claimantRow = yield* state.get({
-                  stack: stackName,
-                  stage: stage,
-                  fqn: claimant,
-                });
-                if (
-                  claimantRow === undefined ||
-                  (!isActionState(claimantRow) &&
-                    (claimantRow as ResourceState).instanceId ===
-                      oldState.instanceId)
-                ) {
-                  return;
-                }
+              if (
+                claimant !== undefined &&
+                resourceGraph[claimant]?.state?.instanceId ===
+                  oldState.instanceId
+              ) {
+                return;
               }
               const { logicalId } = parseFqn(fqn);
               const resourceType = oldState.resourceType;

--- a/packages/alchemy/src/Rename.ts
+++ b/packages/alchemy/src/Rename.ts
@@ -2,14 +2,26 @@ import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 
 /**
- * RenamePolicy carries the logical ids a resource was previously declared
+ * A former id a resource was previously declared under:
+ *
+ * - a bare `string` resolves against the ambient namespace, exactly like
+ *   the resource's own `id` argument does
+ * - `{ fqn: "..." }` is absolute — the full FQN as persisted in state,
+ *   ignoring any surrounding namespace. Needed when a resource moved
+ *   BETWEEN namespaces (a relative id can only address the current
+ *   namespace's subtree).
+ */
+export type FormerId = string | { fqn: string };
+
+/**
+ * RenamePolicy carries the former ids a resource was previously declared
  * under. It is captured from the ambient context at registration time (like
  * `AdoptPolicy` / `RemovalPolicy`) and resolved against the same namespace
  * as the resource's own id — see `ResourceLike.FormerFqns`.
  */
 export class RenamePolicy extends Context.Service<
   RenamePolicy,
-  readonly string[]
+  readonly FormerId[]
 >()("RenamePolicy") {}
 
 /**
@@ -24,10 +36,13 @@ export class RenamePolicy extends Context.Service<
  * );
  * ```
  *
- * Former ids are namespace-relative: they resolve against the same ambient
- * namespace as the resource's own id, so a resource declared inside
- * `Namespace.push("Site")` with `renamedFrom("Worker")` claims the former
- * FQN `Site/Worker`.
+ * A bare-string former id behaves exactly like the resource's own `id`
+ * argument: it resolves against the ambient namespace, so a resource
+ * declared inside `Namespace.push("Site")` with `renamedFrom("Worker")`
+ * claims the former FQN `Site/Worker`. When the resource moved BETWEEN
+ * namespaces, pass the absolute form instead — `renamedFrom({ fqn:
+ * "Legacy/Worker" })` claims exactly that FQN regardless of the ambient
+ * namespace.
  *
  * Renamed more than once? List every former id, MOST RECENT FIRST — the
  * planner checks them in declaration order and migrates from the first
@@ -55,6 +70,6 @@ export class RenamePolicy extends Context.Service<
  *   ambiguous and fails the plan loudly.
  */
 export const renamedFrom =
-  (...formerIds: [string, ...string[]]) =>
+  (...formerIds: [FormerId, ...FormerId[]]) =>
   <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
     Effect.provideService(effect, RenamePolicy, formerIds);

--- a/packages/alchemy/src/Rename.ts
+++ b/packages/alchemy/src/Rename.ts
@@ -1,0 +1,50 @@
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+
+/**
+ * RenamePolicy carries the logical ids a resource was previously declared
+ * under. It is captured from the ambient context at registration time (like
+ * `AdoptPolicy` / `RemovalPolicy`) and resolved against the same namespace
+ * as the resource's own id — see `ResourceLike.FormerFqns`.
+ */
+export class RenamePolicy extends Context.Service<
+  RenamePolicy,
+  readonly string[]
+>()("RenamePolicy") {}
+
+/**
+ * Declare the logical id(s) this resource was previously registered under,
+ * so the engine migrates its persisted state row instead of planning a
+ * create+delete replacement when the id changes.
+ *
+ * ```ts
+ * // was `Worker("Website/Worker", ...)` in a previous release:
+ * const worker = yield* Worker("Website", props).pipe(
+ *   renamedFrom("Website/Worker"),
+ * );
+ * ```
+ *
+ * Former ids are namespace-relative: they resolve against the same ambient
+ * namespace as the resource's own id, so a resource declared inside
+ * `Namespace.push("Site")` with `renamedFrom("Worker")` claims the former
+ * FQN `Site/Worker`.
+ *
+ * Migration semantics (see Plan's rename fallback):
+ *
+ * - No state row at the resource's FQN, a row at a former FQN → the row is
+ *   the resource's state. Plan builds the node from it (an update/noop, not
+ *   a create) and apply moves the row to the new FQN before any lifecycle
+ *   operation runs.
+ * - Rows at BOTH FQNs with the same `instanceId` → an interrupted
+ *   migration; the leftover former row is dropped (state only — the
+ *   physical resource is never touched).
+ * - Rows at both FQNs with different `instanceId`s → the former row is some
+ *   other resource's (e.g. a new resource reusing the old name after the
+ *   rename shipped); it is ignored and handled like any other row.
+ * - A former FQN that is still actively declared by another resource is not
+ *   a rename and is ignored.
+ */
+export const renamedFrom =
+  (...formerIds: [string, ...string[]]) =>
+  <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
+    Effect.provideService(effect, RenamePolicy, formerIds);

--- a/packages/alchemy/src/Rename.ts
+++ b/packages/alchemy/src/Rename.ts
@@ -68,20 +68,36 @@ export class RenamePolicy extends Context.Service<
  * `new` = the row at the resource's FQN, `old` = a row at a former FQN):
  *
  * ```text
- * new  old                     → outcome
+ * new                     old                     → outcome
  * ──────────────────────────────────────────────────────────────────────
- * —    row                     → migrate: the old row IS the resource's
- *                                state (noop/update, never a create);
- *                                apply moves it before any lifecycle op
- * row  row, same instanceId    → interrupted migration: leftovers are
- *                                dropped state-only — ALL of them in one
- *                                apply — the physical resource is never
- *                                touched
- * row  row, diff instanceId    → someone else's row (a new resource
- *                                reusing the old name): ignored, normal
- *                                orphan handling
- * any  row, diff resourceType  → never migrated — cannot be this
- *                                resource's row, whatever its FQN says
+ * —                       row                     → migrate: the old row
+ *                                                   IS the resource's
+ *                                                   state (noop/update,
+ *                                                   never a create);
+ *                                                   apply moves it before
+ *                                                   any lifecycle op
+ * row, same instanceId    row                     → interrupted
+ *                                                   migration: leftovers
+ *                                                   dropped state-only —
+ *                                                   ALL of them in one
+ *                                                   apply — the physical
+ *                                                   resource is never
+ *                                                   touched
+ * row, diff instanceId    row                     → someone else's row (a
+ *                                                   new resource reusing
+ *                                                   the old name):
+ *                                                   ignored, normal
+ *                                                   orphan handling
+ * row, diff resourceType  row                     → the new-FQN row is
+ *                                                   not a claim (it
+ *                                                   cannot be this
+ *                                                   resource's row); the
+ *                                                   type-matching old row
+ *                                                   migrates over it
+ * any                     row, diff resourceType  → never migrated —
+ *                                                   cannot be this
+ *                                                   resource's row,
+ *                                                   whatever its FQN says
  * ```
  *
  * A former FQN that is still actively declared is not a rename and is

--- a/packages/alchemy/src/Rename.ts
+++ b/packages/alchemy/src/Rename.ts
@@ -115,7 +115,19 @@ export class RenamePolicy extends Context.Service<
  * yield* Bucket("Bucket");
  * ```
  *
- * Two resources claiming the same former FQN fail the plan loudly.
+ * Renames may SHIFT through each other in one deploy — each row follows
+ * its resource (resolved in claim-dependency order):
+ *
+ * ```ts
+ * // the resource at `A` is now `B`; the resource at `B` is now `C`
+ * yield* Bucket("B").pipe(renamedFrom("A"));
+ * yield* Bucket("C").pipe(renamedFrom("B"));
+ * ```
+ *
+ * A SWAP (`A` ⇄ `B`) is a rename cycle and fails the plan loudly — the two
+ * migrations would overwrite and delete each other's rows. Rename through
+ * a temporary id across two deploys instead. Two resources claiming the
+ * same former FQN also fail loudly.
  */
 export const renamedFrom =
   (...formerIds: [FormerId, ...FormerId[]]) =>

--- a/packages/alchemy/src/Rename.ts
+++ b/packages/alchemy/src/Rename.ts
@@ -64,7 +64,7 @@ export class RenamePolicy extends Context.Service<
  * yield* Bucket("Assets").pipe(renamedFrom("StaticAssets", "Bucket"));
  * ```
  *
- * Migration semantics, by state-row shape (see Plan's `getPersistedRow`;
+ * Migration semantics, by state-row shape (see Plan's rename resolution;
  * `new` = the row at the resource's FQN, `old` = a row at a former FQN):
  *
  * ```text
@@ -72,10 +72,13 @@ export class RenamePolicy extends Context.Service<
  * ──────────────────────────────────────────────────────────────────────
  * —                       row                     → migrate: the old row
  *                                                   IS the resource's
- *                                                   state (noop/update,
- *                                                   never a create);
- *                                                   apply moves it before
- *                                                   any lifecycle op
+ *                                                   state; apply moves it
+ *                                                   before any lifecycle
+ *                                                   op, and ONE update
+ *                                                   reconcile re-brands
+ *                                                   the physical resource
+ *                                                   under the new logical
+ *                                                   id (never a create)
  * row, same instanceId    row                     → interrupted
  *                                                   migration: leftovers
  *                                                   dropped state-only —
@@ -84,25 +87,35 @@ export class RenamePolicy extends Context.Service<
  *                                                   resource is never
  *                                                   touched
  * row, diff instanceId    row                     → someone else's row (a
- *                                                   new resource reusing
- *                                                   the old name):
+ *                                                   resource reused the
+ *                                                   old name after the
+ *                                                   rename shipped):
  *                                                   ignored, normal
  *                                                   orphan handling
- * row, diff resourceType  row                     → the new-FQN row is
- *                                                   not a claim (it
- *                                                   cannot be this
- *                                                   resource's row); the
- *                                                   type-matching old row
- *                                                   migrates over it
+ * row, diff resourceType  row                     → FATAL: migrating over
+ *                                                   the foreign-typed row
+ *                                                   would silently
+ *                                                   abandon its cloud
+ *                                                   resource — resolve
+ *                                                   the collision first
  * any                     row, diff resourceType  → never migrated —
  *                                                   cannot be this
  *                                                   resource's row,
  *                                                   whatever its FQN says
  * ```
  *
- * A former FQN that is still actively declared is not a rename and is
- * ignored; two resources claiming the same former FQN fail the plan
- * loudly.
+ * The old id can be REUSED by a new resource in the same deploy — the
+ * rename claim wins the row (it is an explicit statement that the row was
+ * the renamer's), and the reusing resource is created fresh:
+ *
+ * ```ts
+ * // `Assets` keeps the physical resource previously known as `Bucket`;
+ * // this `Bucket` is a brand-new one.
+ * yield* Bucket("Assets").pipe(renamedFrom("Bucket"));
+ * yield* Bucket("Bucket");
+ * ```
+ *
+ * Two resources claiming the same former FQN fail the plan loudly.
  */
 export const renamedFrom =
   (...formerIds: [FormerId, ...FormerId[]]) =>

--- a/packages/alchemy/src/Rename.ts
+++ b/packages/alchemy/src/Rename.ts
@@ -29,7 +29,11 @@ export class RenamePolicy extends Context.Service<
  * `Namespace.push("Site")` with `renamedFrom("Worker")` claims the former
  * FQN `Site/Worker`.
  *
- * Migration semantics (see Plan's rename fallback):
+ * Renamed more than once? List every former id, MOST RECENT FIRST — the
+ * planner checks them in declaration order and migrates from the first
+ * matching row.
+ *
+ * Migration semantics (see Plan's `getPersistedRow`):
  *
  * - No state row at the resource's FQN, a row at a former FQN → the row is
  *   the resource's state. Plan builds the node from it (an update/noop, not
@@ -37,12 +41,18 @@ export class RenamePolicy extends Context.Service<
  *   operation runs.
  * - Rows at BOTH FQNs with the same `instanceId` → an interrupted
  *   migration; the leftover former row is dropped (state only — the
- *   physical resource is never touched).
+ *   physical resource is never touched). ALL former rows sharing the
+ *   resource's instanceId are cleaned up in one apply, so a rename chain
+ *   with repeated partial failures still converges in a single deploy.
  * - Rows at both FQNs with different `instanceId`s → the former row is some
  *   other resource's (e.g. a new resource reusing the old name after the
  *   rename shipped); it is ignored and handled like any other row.
+ * - A former row whose `resourceType` is neither this resource's type nor
+ *   one of its registered type-aliases is never migrated — it cannot be
+ *   this resource's row, whatever its FQN says.
  * - A former FQN that is still actively declared by another resource is not
- *   a rename and is ignored.
+ *   a rename and is ignored; two resources claiming the same former FQN is
+ *   ambiguous and fails the plan loudly.
  */
 export const renamedFrom =
   (...formerIds: [string, ...string[]]) =>

--- a/packages/alchemy/src/Rename.ts
+++ b/packages/alchemy/src/Rename.ts
@@ -30,44 +30,63 @@ export class RenamePolicy extends Context.Service<
  * create+delete replacement when the id changes.
  *
  * ```ts
- * // was `Worker("Website/Worker", ...)` in a previous release:
- * const worker = yield* Worker("Website", props).pipe(
- *   renamedFrom("Website/Worker"),
+ * // was: Bucket("Bucket") — the row migrates and the deploy plans a noop
+ * const bucket = yield* Bucket("Assets").pipe(renamedFrom("Bucket"));
+ * ```
+ *
+ * A bare string resolves against the ambient namespace, exactly like the
+ * resource's own `id`:
+ *
+ * ```ts
+ * // FQN `Site/Assets`, former FQN `Site/Bucket`
+ * yield* Bucket("Assets").pipe(
+ *   renamedFrom("Bucket"),
+ *   Namespace.push("Site"),
  * );
  * ```
  *
- * A bare-string former id behaves exactly like the resource's own `id`
- * argument: it resolves against the ambient namespace, so a resource
- * declared inside `Namespace.push("Site")` with `renamedFrom("Worker")`
- * claims the former FQN `Site/Worker`. When the resource moved BETWEEN
- * namespaces, pass the absolute form instead — `renamedFrom({ fqn:
- * "Legacy/Worker" })` claims exactly that FQN regardless of the ambient
- * namespace.
+ * Moved between namespaces? Pass `{ fqn }` — the absolute FQN exactly as
+ * persisted in state, ignoring the ambient namespace:
  *
- * Renamed more than once? List every former id, MOST RECENT FIRST — the
- * planner checks them in declaration order and migrates from the first
- * matching row.
+ * ```ts
+ * // former FQN `LegacySite/Assets` (NOT `NewSite/LegacySite/Assets`)
+ * yield* Bucket("Assets").pipe(
+ *   renamedFrom({ fqn: "LegacySite/Assets" }),
+ *   Namespace.push("NewSite"),
+ * );
+ * ```
  *
- * Migration semantics (see Plan's `getPersistedRow`):
+ * Renamed more than once? List every former id, most recent first — the
+ * planner checks them in order and migrates from the first matching row:
  *
- * - No state row at the resource's FQN, a row at a former FQN → the row is
- *   the resource's state. Plan builds the node from it (an update/noop, not
- *   a create) and apply moves the row to the new FQN before any lifecycle
- *   operation runs.
- * - Rows at BOTH FQNs with the same `instanceId` → an interrupted
- *   migration; the leftover former row is dropped (state only — the
- *   physical resource is never touched). ALL former rows sharing the
- *   resource's instanceId are cleaned up in one apply, so a rename chain
- *   with repeated partial failures still converges in a single deploy.
- * - Rows at both FQNs with different `instanceId`s → the former row is some
- *   other resource's (e.g. a new resource reusing the old name after the
- *   rename shipped); it is ignored and handled like any other row.
- * - A former row whose `resourceType` is neither this resource's type nor
- *   one of its registered type-aliases is never migrated — it cannot be
- *   this resource's row, whatever its FQN says.
- * - A former FQN that is still actively declared by another resource is not
- *   a rename and is ignored; two resources claiming the same former FQN is
- *   ambiguous and fails the plan loudly.
+ * ```ts
+ * // rename history: Bucket → StaticAssets → Assets
+ * yield* Bucket("Assets").pipe(renamedFrom("StaticAssets", "Bucket"));
+ * ```
+ *
+ * Migration semantics, by state-row shape (see Plan's `getPersistedRow`;
+ * `new` = the row at the resource's FQN, `old` = a row at a former FQN):
+ *
+ * ```text
+ * new  old                     → outcome
+ * ──────────────────────────────────────────────────────────────────────
+ * —    row                     → migrate: the old row IS the resource's
+ *                                state (noop/update, never a create);
+ *                                apply moves it before any lifecycle op
+ * row  row, same instanceId    → interrupted migration: leftovers are
+ *                                dropped state-only — ALL of them in one
+ *                                apply — the physical resource is never
+ *                                touched
+ * row  row, diff instanceId    → someone else's row (a new resource
+ *                                reusing the old name): ignored, normal
+ *                                orphan handling
+ * any  row, diff resourceType  → never migrated — cannot be this
+ *                                resource's row, whatever its FQN says
+ * ```
+ *
+ * A former FQN that is still actively declared is not a rename and is
+ * ignored; two resources claiming the same former FQN fail the plan
+ * loudly.
  */
 export const renamedFrom =
   (...formerIds: [FormerId, ...FormerId[]]) =>

--- a/packages/alchemy/src/Resource.ts
+++ b/packages/alchemy/src/Resource.ts
@@ -16,6 +16,7 @@ import {
 } from "./ProviderMode.ts";
 import { ref as makeRef } from "./Ref.ts";
 import { RemovalPolicy } from "./RemovalPolicy.ts";
+import { RenamePolicy } from "./Rename.ts";
 import { Self } from "./Self.ts";
 import { Stack } from "./Stack.ts";
 
@@ -136,6 +137,15 @@ export interface ResourceLike<
    * during dev); `undefined` means the run default (`AlchemyContext.dev`).
    */
   Mode: ProviderMode | undefined;
+  /**
+   * Former FQNs this resource's state may still be persisted under,
+   * captured from the ambient {@link RenamePolicy} at registration (via
+   * `.pipe(renamedFrom("OldId"))`) and resolved against the same namespace
+   * as the resource's own FQN. The planner migrates a state row found at a
+   * former FQN to {@link FQN} instead of planning a create+delete
+   * replacement — see `renamedFrom` in Rename.ts for the full semantics.
+   */
+  FormerFqns: readonly string[] | undefined;
   /** @internal phantom */
   Attributes: Attributes;
   /** @internal phantom */
@@ -381,6 +391,18 @@ export function Resource<R extends ResourceLike>(
           Effect.map(Option.getOrUndefined),
         ),
         Mode: ambientMode,
+        // Former logical ids resolve against the SAME namespace as the
+        // resource's own id, so `renamedFrom("Site/Worker")` declared at the
+        // caller's level claims `<callerNs>/Site/Worker`.
+        FormerFqns: yield* Effect.serviceOption(RenamePolicy).pipe(
+          Effect.map(
+            Option.match({
+              onNone: () => undefined,
+              onSome: (formerIds) =>
+                formerIds.map((formerId) => toFqn(namespace, formerId)),
+            }),
+          ),
+        ),
         bind,
         toString(this: typeof target) {
           return `Resource<${this.Type}>(${this.LogicalId})`;

--- a/packages/alchemy/src/Resource.ts
+++ b/packages/alchemy/src/Resource.ts
@@ -391,15 +391,20 @@ export function Resource<R extends ResourceLike>(
           Effect.map(Option.getOrUndefined),
         ),
         Mode: ambientMode,
-        // Former logical ids resolve against the SAME namespace as the
+        // Bare-string former ids resolve against the SAME namespace as the
         // resource's own id, so `renamedFrom("Site/Worker")` declared at the
-        // caller's level claims `<callerNs>/Site/Worker`.
+        // caller's level claims `<callerNs>/Site/Worker`; the `{ fqn }` form
+        // is absolute (cross-namespace moves).
         FormerFqns: yield* Effect.serviceOption(RenamePolicy).pipe(
           Effect.map(
             Option.match({
               onNone: () => undefined,
               onSome: (formerIds) =>
-                formerIds.map((formerId) => toFqn(namespace, formerId)),
+                formerIds.map((formerId) =>
+                  typeof formerId === "string"
+                    ? toFqn(namespace, formerId)
+                    : formerId.fqn,
+                ),
             }),
           ),
         ),

--- a/packages/alchemy/src/Sync.ts
+++ b/packages/alchemy/src/Sync.ts
@@ -472,6 +472,7 @@ export const plan = (stack: {
           Provider: Provider(persisted.resourceType),
           RemovalPolicy: persisted.removalPolicy,
           Adopt: undefined,
+          FormerFqns: undefined,
           Mode: persisted.providerMode,
           RuntimeContext: undefined!,
           Providers: undefined,

--- a/packages/alchemy/src/index.ts
+++ b/packages/alchemy/src/index.ts
@@ -30,6 +30,7 @@ export { remote } from "./ProviderMode.ts";
 export * from "./Random.ts";
 export * from "./Ref.ts";
 export * as RemovalPolicy from "./RemovalPolicy.ts";
+export { renamedFrom } from "./Rename.ts";
 export * from "./Resource.ts";
 export * as Schema from "./Schema.ts";
 export * as Server from "./Server/index.ts";

--- a/packages/alchemy/test/Cli/ModeTag.test.ts
+++ b/packages/alchemy/test/Cli/ModeTag.test.ts
@@ -137,6 +137,23 @@ const makePlan = (options: {
 const lineFor = (lines: string[], id: string) =>
   lines.find((line) => line.includes(`[${id}]`));
 
+describe("formatPlanLines rename tags", () => {
+  test("a migrated resource shows its former FQN", () => {
+    const lines = formatPlanLines(
+      makePlan({
+        defaultMode: "live",
+        resources: {
+          Assets: {
+            ...crud({ id: "Assets", action: "update", mode: "live" }),
+            renamedFrom: ["Bucket"],
+          } as CRUD,
+        },
+      }),
+    );
+    expect(lineFor(lines, "Assets")).toContain("(renamed from Bucket)");
+  });
+});
+
 describe("formatPlanLines mode tags", () => {
   test("deploy (default live): local deletion rows get a dim local tag", () => {
     const lines = formatPlanLines(

--- a/packages/alchemy/test/Cloudflare/Website/StaticSiteBeta67Migration.test.ts
+++ b/packages/alchemy/test/Cloudflare/Website/StaticSiteBeta67Migration.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Cross-version FQN-migration regression test for the beta.68 StaticSite
+ * incident (#1053 / #1108).
+ *
+ * A temp project deploys a StaticSite with the PUBLISHED alchemy@2.0.0-beta.67
+ * (whose StaticSite persists its Worker at the `<id>/Worker` FQN), then the
+ * CURRENT workspace version re-deploys over the same local state. The
+ * `renamedFrom(`${id}/Worker`)` migration must move the state row to `<id>`
+ * and re-brand the worker in place — the worker must NOT be deleted or
+ * recreated.
+ */
+import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Test from "@/Test/Alchemy";
+import { expect } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import { spawn } from "node:child_process";
+import * as pathe from "pathe";
+import {
+  expectWorkerExists,
+  waitForWorkerToBeDeleted,
+} from "../Utils/Worker.ts";
+
+const { test } = Test.make({ providers: Cloudflare.providers() });
+
+const repoRoot = pathe.resolve(import.meta.dirname, "../../../../..");
+const workspaceCli = pathe.join(repoRoot, "packages/alchemy/bin/alchemy.ts");
+
+const STACK = "B67MigrationTest";
+const STAGE = "b67mig";
+
+/**
+ * Run a command to completion without blocking the runner's event loop
+ * (the suite shares one bun process; a sync spawn would stall every
+ * concurrently running test). Fails with the combined output on a
+ * non-zero exit.
+ */
+const run = (options: {
+  cmd: string;
+  args: string[];
+  cwd: string;
+}): Effect.Effect<string, Error> =>
+  Effect.callback<string, Error>((resume) => {
+    const child = spawn(options.cmd, options.args, {
+      cwd: options.cwd,
+      env: { ...process.env, NO_COLOR: "1" },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let output = "";
+    child.stdout.on("data", (chunk) => (output += chunk));
+    child.stderr.on("data", (chunk) => (output += chunk));
+    child.once("error", (error) => resume(Effect.fail(error)));
+    child.once("close", (code) =>
+      resume(
+        code === 0
+          ? Effect.succeed(output)
+          : Effect.fail(
+              new Error(
+                `${options.cmd} ${options.args.join(" ")} exited ${code}:\n${output}`,
+              ),
+            ),
+      ),
+    );
+    return Effect.sync(() => child.kill("SIGKILL"));
+  });
+
+/** The stack program, valid for both beta.67 and the current version. */
+const stackProgram = (alchemyImport: string, cloudflareImport: string) =>
+  [
+    `import * as Alchemy from "${alchemyImport}";`,
+    `import * as Cloudflare from "${cloudflareImport}";`,
+    "",
+    "export default Alchemy.Stack(",
+    `  "${STACK}",`,
+    "  { providers: Cloudflare.providers(), state: Alchemy.localState() },",
+    // A pure-static site: no `main`, no bundling — the smallest surface
+    // that exists identically in both versions.
+    '  Cloudflare.Website.StaticSite("Site", {',
+    '    command: "bash build.sh",',
+    '    outdir: "dist",',
+    "  }),",
+    ");",
+    "",
+  ].join("\n");
+
+test.provider.skipIf(!!process.env.FAST)(
+  "a beta.67 StaticSite migrates to the current version without recreating the worker",
+  () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const { accountId } = yield* yield* CloudflareEnvironment;
+
+      const dir = yield* fs.makeTempDirectory({ prefix: "alchemy-b67-mig-" });
+      const stateFile = (fqn: string) =>
+        // LocalState layout: .alchemy/state/<stack>/<stage>/<encodeFqn>.json
+        path.join(dir, ".alchemy", "state", STACK, STAGE, `${fqn}.json`);
+      const readRow = (fqn: string) =>
+        fs
+          .readFileString(stateFile(fqn))
+          .pipe(Effect.map((raw) => JSON.parse(raw)));
+
+      // ── Fixture ─────────────────────────────────────────────────────────
+      yield* fs.writeFileString(
+        path.join(dir, "package.json"),
+        JSON.stringify(
+          {
+            name: "b67-migration-fixture",
+            private: true,
+            dependencies: {
+              alchemy: "2.0.0-beta.67",
+              // beta.67's peers, pinned to the workspace's resolved
+              // versions (bun does not auto-install them for the src/
+              // resolution path the alchemy CLI runs under).
+              effect: "4.0.0-beta.102",
+              "@effect/platform-node": "4.0.0-beta.102",
+              "@effect/platform-bun": "4.0.0-beta.102",
+            },
+          },
+          null,
+          2,
+        ),
+      );
+      yield* fs.writeFileString(
+        path.join(dir, "index.html"),
+        "<h1>b67-migration</h1>",
+      );
+      yield* fs.writeFileString(
+        path.join(dir, "build.sh"),
+        "mkdir -p dist && cp index.html dist/index.html",
+      );
+      // beta.67 entry: resolves `alchemy` from the temp node_modules.
+      yield* fs.writeFileString(
+        path.join(dir, "alchemy.run.ts"),
+        stackProgram("alchemy", "alchemy/Cloudflare"),
+      );
+      // Current-version entry: resolves the WORKSPACE sources directly, so
+      // no linking dance is needed and `effect` is the workspace instance.
+      yield* fs.writeFileString(
+        path.join(dir, "alchemy.current.run.ts"),
+        stackProgram(
+          pathe.join(repoRoot, "packages/alchemy/src/index.ts"),
+          pathe.join(repoRoot, "packages/alchemy/src/Cloudflare/index.ts"),
+        ),
+      );
+
+      // ── Phase 1: deploy with the published beta.67 ──────────────────────
+      yield* run({ cmd: "bun", args: ["install"], cwd: dir });
+      yield* run({
+        cmd: "bun",
+        args: [
+          "node_modules/alchemy/bin/cli.js",
+          "deploy",
+          "--stage",
+          STAGE,
+          "--yes",
+        ],
+        cwd: dir,
+      });
+
+      // beta.67 persisted the Worker at the legacy `Site/Worker` FQN.
+      const before = yield* readRow("Site__Worker");
+      const workerName: string = before.attr.workerName;
+      expect(before.fqn).toEqual("Site/Worker");
+      expect(workerName).toBeDefined();
+      yield* expectWorkerExists(workerName, accountId);
+
+      // ── Phase 2: re-deploy with the CURRENT workspace version ───────────
+      const output = yield* run({
+        cmd: "bun",
+        args: [
+          workspaceCli,
+          "deploy",
+          "./alchemy.current.run.ts",
+          "--stage",
+          STAGE,
+          "--yes",
+        ],
+        cwd: dir,
+      });
+
+      // The plan surfaced the migration and never planned a create/delete.
+      expect(output).toContain("renamed from Site/Worker");
+      expect(output).not.toContain("to create");
+      expect(output).not.toContain("to delete");
+
+      // The row moved: same instanceId, same physical worker, new FQN.
+      const after = yield* readRow("Site");
+      expect(after.instanceId).toEqual(before.instanceId);
+      expect(after.attr.workerName).toEqual(workerName);
+      expect(after.logicalId).toEqual("Site");
+      expect(yield* fs.exists(stateFile("Site__Worker"))).toBe(false);
+
+      // THE assertion: the worker survived the upgrade.
+      yield* expectWorkerExists(workerName, accountId);
+
+      // ── Cleanup ─────────────────────────────────────────────────────────
+      yield* run({
+        cmd: "bun",
+        args: [
+          workspaceCli,
+          "destroy",
+          "./alchemy.current.run.ts",
+          "--stage",
+          STAGE,
+          "--yes",
+        ],
+        cwd: dir,
+      });
+      yield* waitForWorkerToBeDeleted(workerName, accountId);
+      yield* fs.remove(dir, { recursive: true });
+    }),
+  { timeout: 600_000 },
+);

--- a/packages/alchemy/test/Cloudflare/Website/StaticSiteNamespace.test.ts
+++ b/packages/alchemy/test/Cloudflare/Website/StaticSiteNamespace.test.ts
@@ -1,4 +1,5 @@
 import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Namespace from "@/Namespace.ts";
 import * as Stack from "@/Stack.ts";
 import { Stage } from "@/Stage.ts";
 import { inMemoryState, type State } from "@/State";
@@ -16,10 +17,10 @@ const { test } = Test.make({
 // `env` — the pattern `examples/cloudflare-tanstack` uses.
 const Cache = Cloudflare.KV.Namespace("Cache", {});
 
-/** Compile the stack and return the FQN of every registered resource. */
-const fqns = <A, Err = never, Req = never>(
+/** Compile the stack and return its registered resources. */
+const compile = <A, Err = never, Req = never>(
   effect: Effect.Effect<A, Err, Req>,
-): Effect.Effect<string[], Err, State> =>
+): Effect.Effect<Stack.CompiledStack["resources"], Err, State> =>
   effect.pipe(
     // @ts-expect-error - Stack.make's typing erases R unsoundly here
     Stack.make({
@@ -28,9 +29,15 @@ const fqns = <A, Err = never, Req = never>(
       state: inMemoryState(),
     }),
     Effect.provideService(Stage, "test"),
-    Effect.map((stack: Stack.CompiledStack) =>
-      Object.keys(stack.resources).sort(),
-    ),
+    Effect.map((stack: Stack.CompiledStack) => stack.resources),
+  );
+
+/** Compile the stack and return the FQN of every registered resource. */
+const fqns = <A, Err = never, Req = never>(
+  effect: Effect.Effect<A, Err, Req>,
+): Effect.Effect<string[], Err, State> =>
+  compile(effect).pipe(
+    Effect.map((resources) => Object.keys(resources).sort()),
   );
 
 test(
@@ -50,6 +57,31 @@ test(
     // Only the build sub-resource is namespaced; the Worker is the site
     // itself and `Cache` stays where the caller declared it.
     expect(keys).toEqual(["Cache", "Site", "Site/Build"]);
+  }),
+);
+
+test(
+  "StaticSite claims its pre-#1053 `<id>/Worker` FQN, including when nested",
+  Effect.gen(function* () {
+    const resources = yield* compile(
+      Effect.gen(function* () {
+        // Top-level site.
+        yield* Cloudflare.Website.StaticSite("Site", {
+          command: "echo build",
+          outdir: "dist",
+          main: "./worker.ts",
+        });
+        // Site nested inside a caller namespace — the former FQN must
+        // resolve under the same `App/` prefix as the site itself.
+        yield* Cloudflare.Website.StaticSite("Nested", {
+          command: "echo build",
+          outdir: "dist",
+          main: "./worker.ts",
+        }).pipe(Namespace.push("App"));
+      }),
+    );
+    expect(resources["Site"]?.FormerFqns).toEqual(["Site/Worker"]);
+    expect(resources["App/Nested"]?.FormerFqns).toEqual(["App/Nested/Worker"]);
   }),
 );
 

--- a/packages/alchemy/test/apply.test.ts
+++ b/packages/alchemy/test/apply.test.ts
@@ -6650,6 +6650,57 @@ describe("renamed resources (renamedFrom)", () => {
   );
 
   test.provider(
+    "a rename chain with repeated partial failures converges in one deploy",
+    (stack) =>
+      Effect.gen(function* () {
+        // A → B rename, then B → C, with the A→B migration's delete having
+        // failed (a leftover copy of the row remains at A).
+        yield* stack.deploy(
+          Effect.gen(function* () {
+            yield* TestResource("A", { string: "v1" });
+          }),
+        );
+        yield* stack.deploy(
+          Effect.gen(function* () {
+            yield* TestResource("B", { string: "v1" }).pipe(renamedFrom("A"));
+          }),
+        );
+        const row = yield* getState("B");
+        yield* setState("A", { ...row!, fqn: "A", logicalId: "A" });
+
+        const touched: string[] = [];
+        const track = (op: string) => (id: string) =>
+          Effect.sync(() => void touched.push(`${op}:${id}`));
+        yield* stack
+          .deploy(
+            Effect.gen(function* () {
+              // Most recent former id first.
+              yield* TestResource("C", { string: "v1" }).pipe(
+                renamedFrom("B", "A"),
+              );
+            }),
+          )
+          .pipe(
+            hook({
+              create: track("create"),
+              update: track("update"),
+              delete: track("delete"),
+            }),
+          );
+
+        // One deploy: migrated from B AND dropped the stale copy at A,
+        // without any lifecycle operation.
+        expect(touched).toEqual([]);
+        expect((yield* getState("C"))?.instanceId).toEqual(row?.instanceId);
+        expect(yield* getState("B")).toBeUndefined();
+        expect(yield* getState("A")).toBeUndefined();
+
+        yield* stack.destroy();
+        expect(yield* listState()).toEqual([]);
+      }),
+  );
+
+  test.provider(
     "ignores the alias when the new FQN row exists with a different instanceId",
     (stack) =>
       Effect.gen(function* () {

--- a/packages/alchemy/test/apply.test.ts
+++ b/packages/alchemy/test/apply.test.ts
@@ -6776,6 +6776,113 @@ describe("renamed resources (renamedFrom)", () => {
   );
 
   test.provider(
+    "a same-deploy rename shift (A→B while B→C) moves both rows end-to-end",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.deploy(
+          Effect.gen(function* () {
+            yield* TestResource("A", { string: "a" });
+            yield* TestResource("B", { string: "b" });
+          }),
+        );
+        const oldA = yield* getState("A");
+        const oldB = yield* getState("B");
+
+        // One deploy shifts both names: A→B and B→C. B's migration write
+        // and C's former-row cleanup target the same FQN — the apply-side
+        // discipline must never let C's delete destroy B's migrated row.
+        const touched: string[] = [];
+        const track = (op: string) => (id: string) =>
+          Effect.sync(() => void touched.push(`${op}:${id}`));
+        yield* stack
+          .deploy(
+            Effect.gen(function* () {
+              yield* TestResource("B", { string: "a" }).pipe(renamedFrom("A"));
+              yield* TestResource("C", { string: "b" }).pipe(renamedFrom("B"));
+            }),
+          )
+          .pipe(
+            hook({
+              create: track("create"),
+              delete: track("delete"),
+            }),
+          );
+
+        // No physical resource was created or deleted — both rows moved.
+        expect(touched).toEqual([]);
+        expect((yield* getState("B"))?.instanceId).toEqual(oldA?.instanceId);
+        expect((yield* getState("C"))?.instanceId).toEqual(oldB?.instanceId);
+        expect(yield* getState("A")).toBeUndefined();
+
+        yield* stack.destroy();
+        expect(yield* listState()).toEqual([]);
+      }),
+  );
+
+  test.provider(
+    "a pending replacement backlog drains after a rename",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.deploy(
+          Effect.gen(function* () {
+            yield* TestResource("A", { string: "x", replaceString: "1" });
+          }),
+        );
+
+        // A replacement whose old-generation delete FAILS: the new
+        // generation is live but the old one stays queued in the row's
+        // `old` chain (status `replaced`). The failed cleanup is soft at
+        // deploy time — the deploy may still report success.
+        yield* stack
+          .deploy(
+            Effect.gen(function* () {
+              yield* TestResource("A", { string: "x", replaceString: "2" });
+            }),
+          )
+          .pipe(
+            hook({
+              delete: () => Effect.fail(new ResourceFailure()),
+            }),
+            Effect.exit,
+          );
+        const mid = yield* getState("A");
+        expect(mid?.status).toEqual("replaced");
+        expect((mid as any).old).toBeDefined();
+
+        // Rename while the backlog is pending: the chain must ride the
+        // migration and STILL drain — the old generation's physical
+        // resource is deleted during the rename deploy.
+        const deleted: string[] = [];
+        yield* stack
+          .deploy(
+            Effect.gen(function* () {
+              yield* TestResource("B", {
+                string: "x",
+                replaceString: "2",
+              }).pipe(renamedFrom("A"));
+            }),
+          )
+          .pipe(
+            hook({
+              delete: (id: string) => Effect.sync(() => void deleted.push(id)),
+            }),
+          );
+
+        // Exactly one physical delete: the queued old generation.
+        expect(deleted).toHaveLength(1);
+        const after = yield* getState("B");
+        // The new generation survived under the new identity, chain drained.
+        expect(after?.instanceId).toEqual(mid?.instanceId);
+        expect(["created", "updated"]).toContain(after?.status);
+        expect((after as any).old).toBeUndefined();
+        expect(yield* getState("A")).toBeUndefined();
+
+        yield* stack.destroy();
+        expect(yield* listState()).toEqual([]);
+      }),
+  );
+
+  test.provider(
     "ignores the alias when the new FQN row exists with a different instanceId",
     (stack) =>
       Effect.gen(function* () {

--- a/packages/alchemy/test/apply.test.ts
+++ b/packages/alchemy/test/apply.test.ts
@@ -5,6 +5,7 @@ import * as Namespace from "@/Namespace.ts";
 import * as Output from "@/Output";
 import * as Provider from "@/Provider";
 import * as RemovalPolicy from "@/RemovalPolicy.ts";
+import { renamedFrom } from "@/Rename.ts";
 import { Stack } from "@/Stack";
 import {
   type CreatingResourceState,
@@ -6497,6 +6498,195 @@ describe("non-plain and cyclic props through deploy", () => {
         // Identical (still-cyclic) props — a clean noop.
         yield* program().pipe(stack.deploy, hook(hooks));
         expect(updates).toEqual([]);
+
+        yield* stack.destroy();
+        expect(yield* listState()).toEqual([]);
+      }),
+  );
+});
+
+describe("renamed resources (renamedFrom)", () => {
+  const setState = Effect.fn(function* (fqn: string, value: ResourceState) {
+    const state = yield* yield* State;
+    const stk = yield* Stack;
+    yield* state.set({ stack: stk.name, stage: stk.stage, fqn, value });
+  });
+
+  test.provider(
+    "migrates the state row from a former FQN without touching the resource",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.deploy(
+          Effect.gen(function* () {
+            yield* TestResource("Old", { string: "v1" });
+          }),
+        );
+        const before = yield* getState("Old");
+        expect(before?.status).toEqual("created");
+
+        // Redeploy under the new id: no create, no update, no delete —
+        // only the state row moves.
+        const touched: string[] = [];
+        const track = (op: string) => (id: string) =>
+          Effect.sync(() => void touched.push(`${op}:${id}`));
+        yield* stack
+          .deploy(
+            Effect.gen(function* () {
+              yield* TestResource("New", { string: "v1" }).pipe(
+                renamedFrom("Old"),
+              );
+            }),
+          )
+          .pipe(
+            hook({
+              create: track("create"),
+              update: track("update"),
+              delete: track("delete"),
+            }),
+          );
+        expect(touched).toEqual([]);
+
+        const after = yield* getState("New");
+        expect(after?.instanceId).toEqual(before?.instanceId);
+        expect(after?.attr).toEqual(before?.attr);
+        expect(after?.logicalId).toEqual("New");
+        expect(yield* getState("Old")).toBeUndefined();
+
+        yield* stack.destroy();
+        expect(yield* listState()).toEqual([]);
+      }),
+  );
+
+  test.provider(
+    "migrates a namespaced row (StaticSite's <id>/Worker → <id> shape)",
+    (stack) =>
+      Effect.gen(function* () {
+        // The pre-rename shape: `Worker` declared under the `App/Site`
+        // namespace chain (fqn `App/Site/Worker`).
+        yield* stack.deploy(
+          Effect.gen(function* () {
+            yield* Effect.gen(function* () {
+              yield* TestResource("Worker", { string: "v1" });
+            }).pipe(Namespace.push("Site"), Namespace.push("App"));
+          }),
+        );
+        const before = yield* getState("App/Site/Worker");
+        expect(before?.status).toEqual("created");
+
+        // The post-rename shape: the resource is `Site` itself, still under
+        // `App`, claiming its former namespace-RELATIVE id — exactly what
+        // StaticSite does with `renamedFrom(`${id}/Worker`)`.
+        const touched: string[] = [];
+        const track = (op: string) => (id: string) =>
+          Effect.sync(() => void touched.push(`${op}:${id}`));
+        yield* stack
+          .deploy(
+            Effect.gen(function* () {
+              yield* TestResource("Site", { string: "v1" }).pipe(
+                renamedFrom("Site/Worker"),
+                Namespace.push("App"),
+              );
+            }),
+          )
+          .pipe(
+            hook({
+              create: track("create"),
+              update: track("update"),
+              delete: track("delete"),
+            }),
+          );
+        expect(touched).toEqual([]);
+
+        const after = yield* getState("App/Site");
+        expect(after?.instanceId).toEqual(before?.instanceId);
+        expect(after?.logicalId).toEqual("Site");
+        expect(yield* getState("App/Site/Worker")).toBeUndefined();
+
+        yield* stack.destroy();
+        expect(yield* listState()).toEqual([]);
+      }),
+  );
+
+  test.provider(
+    "finishes an interrupted migration state-only (rows at both FQNs, same instanceId)",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.deploy(
+          Effect.gen(function* () {
+            yield* TestResource("New", { string: "v1" }).pipe(
+              renamedFrom("Old"),
+            );
+          }),
+        );
+        const row = yield* getState("New");
+
+        // Simulate a crash between apply's `state.set` (new FQN) and
+        // `state.delete` (former FQN): a stale copy remains at `Old`.
+        yield* setState("Old", { ...row!, fqn: "Old", logicalId: "Old" });
+
+        const deleted: string[] = [];
+        yield* stack
+          .deploy(
+            Effect.gen(function* () {
+              yield* TestResource("New", { string: "v1" }).pipe(
+                renamedFrom("Old"),
+              );
+            }),
+          )
+          .pipe(
+            hook({
+              delete: (id: string) => Effect.sync(() => void deleted.push(id)),
+            }),
+          );
+
+        // The leftover row was dropped WITHOUT a provider.delete.
+        expect(deleted).toEqual([]);
+        expect(yield* getState("Old")).toBeUndefined();
+        expect((yield* getState("New"))?.instanceId).toEqual(row?.instanceId);
+
+        yield* stack.destroy();
+        expect(yield* listState()).toEqual([]);
+      }),
+  );
+
+  test.provider(
+    "ignores the alias when the new FQN row exists with a different instanceId",
+    (stack) =>
+      Effect.gen(function* () {
+        // Both resources exist independently.
+        yield* stack.deploy(
+          Effect.gen(function* () {
+            yield* TestResource("Old", { string: "old" });
+            yield* TestResource("New", { string: "new" });
+          }),
+        );
+        const oldRow = yield* getState("Old");
+        const newRow = yield* getState("New");
+        expect(oldRow?.instanceId).not.toEqual(newRow?.instanceId);
+
+        // `New` claims `Old` as a former FQN, but already has its own row —
+        // the alias is ignored and `Old` is a normal orphan delete (the
+        // physical resource IS deleted).
+        const deleted: string[] = [];
+        yield* stack
+          .deploy(
+            Effect.gen(function* () {
+              yield* TestResource("New", { string: "new" }).pipe(
+                renamedFrom("Old"),
+              );
+            }),
+          )
+          .pipe(
+            hook({
+              delete: (id: string) => Effect.sync(() => void deleted.push(id)),
+            }),
+          );
+
+        expect(deleted).toEqual(["Old"]);
+        expect(yield* getState("Old")).toBeUndefined();
+        expect((yield* getState("New"))?.instanceId).toEqual(
+          newRow?.instanceId,
+        );
 
         yield* stack.destroy();
         expect(yield* listState()).toEqual([]);

--- a/packages/alchemy/test/apply.test.ts
+++ b/packages/alchemy/test/apply.test.ts
@@ -6513,7 +6513,7 @@ describe("renamed resources (renamedFrom)", () => {
   });
 
   test.provider(
-    "migrates the state row from a former FQN without touching the resource",
+    "migrates the state row from a former FQN without recreating the resource",
     (stack) =>
       Effect.gen(function* () {
         yield* stack.deploy(
@@ -6524,8 +6524,9 @@ describe("renamed resources (renamedFrom)", () => {
         const before = yield* getState("Old");
         expect(before?.status).toEqual("created");
 
-        // Redeploy under the new id: no create, no update, no delete —
-        // only the state row moves.
+        // Redeploy under the new id: no create, no delete — the state row
+        // moves and exactly ONE update reconcile runs to re-brand the
+        // physical resource (its tags still carry the old logical id).
         const touched: string[] = [];
         const track = (op: string) => (id: string) =>
           Effect.sync(() => void touched.push(`${op}:${id}`));
@@ -6544,13 +6545,87 @@ describe("renamed resources (renamedFrom)", () => {
               delete: track("delete"),
             }),
           );
-        expect(touched).toEqual([]);
+        expect(touched).toEqual(["update:New"]);
 
         const after = yield* getState("New");
         expect(after?.instanceId).toEqual(before?.instanceId);
-        expect(after?.attr).toEqual(before?.attr);
         expect(after?.logicalId).toEqual("New");
         expect(yield* getState("Old")).toBeUndefined();
+
+        // A second deploy is a clean noop — the migration is done.
+        const touchedAgain: string[] = [];
+        const trackAgain = (op: string) => (id: string) =>
+          Effect.sync(() => void touchedAgain.push(`${op}:${id}`));
+        yield* stack
+          .deploy(
+            Effect.gen(function* () {
+              yield* TestResource("New", { string: "v1" }).pipe(
+                renamedFrom("Old"),
+              );
+            }),
+          )
+          .pipe(
+            hook({
+              create: trackAgain("create"),
+              update: trackAgain("update"),
+              delete: trackAgain("delete"),
+            }),
+          );
+        expect(touchedAgain).toEqual([]);
+
+        yield* stack.destroy();
+        expect(yield* listState()).toEqual([]);
+      }),
+  );
+
+  test.provider(
+    "the old id can be reused by a new resource without stealing the migrated physical",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.deploy(
+          Effect.gen(function* () {
+            yield* TestResource("Old", { string: "v1" });
+          }),
+        );
+        const before = yield* getState("Old");
+
+        // One deploy renames Old → New AND declares a brand-new resource
+        // reusing the id `Old`. The read hook simulates a tag-based
+        // adoption probe that would FIND the migrated physical resource
+        // (its cloud tags still say `Old`) — the engine must not consult
+        // it for the reuser.
+        const touched: string[] = [];
+        const track = (op: string) => (id: string) =>
+          Effect.sync(() => void touched.push(`${op}:${id}`));
+        yield* stack
+          .deploy(
+            Effect.gen(function* () {
+              yield* TestResource("New", { string: "v1" }).pipe(
+                renamedFrom("Old"),
+              );
+              yield* TestResource("Old", { string: "fresh" });
+            }),
+          )
+          .pipe(
+            hook({
+              create: track("create"),
+              update: track("update"),
+              delete: track("delete"),
+              read: () =>
+                Effect.succeed({ string: "v1", urn: "stolen-physical" }),
+            }),
+          );
+
+        // The renamed resource kept its identity...
+        const renamed = yield* getState("New");
+        expect(renamed?.instanceId).toEqual(before?.instanceId);
+        // ...and the reuser was created FRESH: new instanceId, a real
+        // create call, and no adoption of the migrated physical.
+        const reuser = yield* getState("Old");
+        expect(reuser?.instanceId).not.toEqual(before?.instanceId);
+        expect(touched).toContain("create:Old");
+        expect(touched).toContain("update:New");
+        expect(touched.filter((t) => t.startsWith("delete"))).toEqual([]);
 
         yield* stack.destroy();
         expect(yield* listState()).toEqual([]);
@@ -6595,7 +6670,7 @@ describe("renamed resources (renamedFrom)", () => {
               delete: track("delete"),
             }),
           );
-        expect(touched).toEqual([]);
+        expect(touched).toEqual(["update:Site"]);
 
         const after = yield* getState("App/Site");
         expect(after?.instanceId).toEqual(before?.instanceId);
@@ -6688,9 +6763,9 @@ describe("renamed resources (renamedFrom)", () => {
             }),
           );
 
-        // One deploy: migrated from B AND dropped the stale copy at A,
-        // without any lifecycle operation.
-        expect(touched).toEqual([]);
+        // One deploy: migrated from B AND dropped the stale copy at A —
+        // one re-branding update, no create, no delete.
+        expect(touched).toEqual(["update:C"]);
         expect((yield* getState("C"))?.instanceId).toEqual(row?.instanceId);
         expect(yield* getState("B")).toBeUndefined();
         expect(yield* getState("A")).toBeUndefined();

--- a/packages/alchemy/test/plan.test.ts
+++ b/packages/alchemy/test/plan.test.ts
@@ -4357,7 +4357,7 @@ describe("renamed resources (renamedFrom)", () => {
   const parseFqnLogicalId = (fqn: string) => fqn.split("/").pop()!;
 
   test(
-    "a row at a former FQN plans as a noop at the new FQN, never a create+delete",
+    "a row at a former FQN plans as an update at the new FQN, never a create+delete",
     Effect.gen(function* () {
       yield* seed({ OldBucket: bucketRow("OldBucket") });
 
@@ -4369,7 +4369,10 @@ describe("renamed resources (renamedFrom)", () => {
       }).pipe(makePlan);
 
       const node = plan.resources.NewBucket!;
-      expect(node.action).toEqual("noop");
+      // An update, not a noop: the physical resource's tags are still
+      // branded with the OLD logical id, so a reconcile must run to
+      // re-brand them under the new identity. Never a create.
+      expect(node.action).toEqual("update");
       expect(node.renamedFrom).toEqual(["OldBucket"]);
       // The row rides on the node under its NEW identity (apply persists
       // the move before any lifecycle runs).
@@ -4433,24 +4436,30 @@ describe("renamed resources (renamedFrom)", () => {
   );
 
   test(
-    "a former FQN that is still actively declared is not a rename",
+    "the old id can be reused by a new resource in the same deploy",
     Effect.gen(function* () {
       yield* seed({ OldBucket: bucketRow("OldBucket") });
 
       const plan = yield* Effect.gen(function* () {
-        yield* Bucket("OldBucket", { name: "b" });
+        // A brand-new resource reuses the old id...
+        yield* Bucket("OldBucket", { name: "fresh" });
+        // ...while the original resource (which owns the row) renames.
         yield* Bucket("NewBucket", { name: "b" }).pipe(
           renamedFrom("OldBucket"),
         );
         return {};
       }).pipe(makePlan);
 
-      // `OldBucket` keeps its row; `NewBucket` is a fresh create.
-      expect(plan.resources.OldBucket?.action).toEqual("noop");
-      expect(plan.resources.OldBucket?.state?.instanceId).toEqual(instanceId);
-      const node = plan.resources.NewBucket!;
-      expect(node.action).toEqual("create");
-      expect(node.renamedFrom).toBeUndefined();
+      // The rename claim wins the row: `NewBucket` migrates it...
+      const renamed = plan.resources.NewBucket!;
+      expect(renamed.action).toEqual("update");
+      expect(renamed.renamedFrom).toEqual(["OldBucket"]);
+      expect(renamed.state?.instanceId).toEqual(instanceId);
+      // ...and the reusing resource starts from scratch — it must NOT
+      // inherit the migrated resource's row (or physical resource).
+      const reuser = plan.resources.OldBucket!;
+      expect(reuser.action).toEqual("create");
+      expect(reuser.state).toBeUndefined();
       expect(Object.keys(plan.deletions)).toHaveLength(0);
     }),
   );
@@ -4480,7 +4489,7 @@ describe("renamed resources (renamedFrom)", () => {
       }).pipe(makePlan);
 
       const node = plan.resources["App/Site"]!;
-      expect(node.action).toEqual("noop");
+      expect(node.action).toEqual("update");
       expect(node.renamedFrom).toEqual(["App/Site/Worker"]);
       expect(node.state?.fqn).toEqual("App/Site");
       expect(node.state?.namespace).toEqual({ Id: "App" });
@@ -4505,7 +4514,7 @@ describe("renamed resources (renamedFrom)", () => {
       }).pipe(makePlan);
 
       const node = plan.resources["New/Thing"]!;
-      expect(node.action).toEqual("noop");
+      expect(node.action).toEqual("update");
       expect(node.renamedFrom).toEqual(["Thing"]);
       expect(node.state?.fqn).toEqual("New/Thing");
       expect(node.state?.instanceId).toEqual(instanceId);
@@ -4533,7 +4542,7 @@ describe("renamed resources (renamedFrom)", () => {
       }).pipe(makePlan);
 
       const node = plan.resources.NewBucket!;
-      expect(node.action).toEqual("noop");
+      expect(node.action).toEqual("update");
       // The migration source AND the same-instance leftover are both
       // collected — one apply drops them all.
       expect(node.renamedFrom).toEqual(["OldA", "OldB"]);
@@ -4560,11 +4569,12 @@ describe("renamed resources (renamedFrom)", () => {
       }).pipe(makePlan);
 
       const node = plan.resources.NewBucket!;
+      expect(node.action).toEqual("update");
       expect(node.renamedFrom).toEqual(["OldA"]);
       expect(node.state?.instanceId).toEqual(instanceId);
-      // The foreign row is a normal orphan — deleted in the SAME plan (the
-      // deletions guard compares against the claimant's PLANNED state, so
-      // the in-memory migration doesn't shield it).
+      // The foreign row is a normal orphan — deleted in the SAME plan (it
+      // never enters the migrated set, so the in-memory migration doesn't
+      // shield it).
       expect(plan.deletions.OldB?.action).toEqual("delete");
       expect(plan.deletions.OldA).toBeUndefined();
     }),
@@ -4599,12 +4609,11 @@ describe("renamed resources (renamedFrom)", () => {
   );
 
   test(
-    "a foreign-typed row at the NEW FQN does not block the migration",
+    "a foreign-typed row at the NEW FQN blocks the migration loudly",
     Effect.gen(function* () {
-      // A different resource type occupied `NewBucket` before this
-      // deploy's shuffle. It cannot be the Bucket's row, so the
-      // type-matching former row still migrates (and plans against the
-      // real predecessor's state, not the foreign type's).
+      // A different resource type's row occupies `NewBucket`. Migrating
+      // over it would silently abandon that row's cloud resource, so the
+      // plan fails with a clear remediation instead.
       yield* seed({
         NewBucket: {
           ...bucketRow("NewBucket", "f0re1gn0000000000000000000000000"),
@@ -4612,6 +4621,41 @@ describe("renamed resources (renamedFrom)", () => {
           attr: { name: "q", queueUrl: "https://test.queue.com/q" },
         },
         OldBucket: bucketRow("OldBucket"),
+      });
+
+      const exit = yield* Effect.gen(function* () {
+        yield* Bucket("NewBucket", { name: "b" }).pipe(
+          renamedFrom("OldBucket"),
+        );
+        return {};
+      }).pipe(makePlan, Effect.exit);
+
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isFailure(exit)) {
+        const die = exit.cause.reasons.find(Cause.isDieReason);
+        expect(String(die?.defect)).toContain(
+          "a state row of a different type ('Test.Queue') already occupies 'NewBucket'",
+        );
+      }
+    }),
+  );
+
+  test(
+    "a mid-replacement row migrates with its old-generation chain intact",
+    Effect.gen(function* () {
+      // The row is in `replaced` status: the new generation is live and
+      // the old generation is queued for garbage collection. The rename
+      // must carry the whole row — chain included — so GC still drains it.
+      yield* seed({
+        OldBucket: {
+          ...bucketRow("OldBucket"),
+          status: "replaced",
+          deleteFirst: false,
+          old: {
+            ...bucketRow("OldBucket", "01d6e7000000000000000000000000000"),
+            status: "created",
+          },
+        } as ResourceState,
       });
 
       const plan = yield* Effect.gen(function* () {
@@ -4622,10 +4666,13 @@ describe("renamed resources (renamedFrom)", () => {
       }).pipe(makePlan);
 
       const node = plan.resources.NewBucket!;
-      expect(node.action).toEqual("noop");
       expect(node.renamedFrom).toEqual(["OldBucket"]);
+      expect(node.state?.fqn).toEqual("NewBucket");
       expect(node.state?.instanceId).toEqual(instanceId);
-      expect(node.state?.resourceType).toEqual("Test.Bucket");
+      // The replacement backlog rides the migration.
+      expect((node.state as any).old?.instanceId).toEqual(
+        "01d6e7000000000000000000000000000",
+      );
       expect(Object.keys(plan.deletions)).toHaveLength(0);
     }),
   );

--- a/packages/alchemy/test/plan.test.ts
+++ b/packages/alchemy/test/plan.test.ts
@@ -4678,6 +4678,125 @@ describe("renamed resources (renamedFrom)", () => {
   );
 
   test(
+    "renamedFrom on a fresh resource (no rows anywhere) is inert",
+    Effect.gen(function* () {
+      // Every new StaticSite carries `renamedFrom(`${id}/Worker`)` forever,
+      // so a green-field deploy must behave exactly as if the decoration
+      // were absent: a plain create — and the cold-start adoption probe
+      // still runs (probe suppression only applies while a row is actually
+      // migrating away).
+      const reads: string[] = [];
+      const plan = yield* Effect.gen(function* () {
+        yield* TestResource("New", { string: "v" }).pipe(renamedFrom("Old"));
+        return {};
+      }).pipe(
+        makePlan,
+        Effect.provide(
+          Layer.succeed(TestResourceHooks, {
+            read: (id: string) =>
+              Effect.sync(() => {
+                reads.push(id);
+                return undefined;
+              }),
+          }),
+        ),
+      );
+
+      const node = plan.resources.New!;
+      expect(node.action).toEqual("create");
+      expect(node.renamedFrom).toBeUndefined();
+      expect(node.state).toBeUndefined();
+      // The state-loss recovery probe still ran.
+      expect(reads).toEqual(["New"]);
+      expect(Object.keys(plan.deletions)).toHaveLength(0);
+    }),
+  );
+
+  test(
+    "a rename combined with a replacement-triggering change plans a replace carrying the rename",
+    Effect.gen(function* () {
+      yield* seed({
+        Old: {
+          instanceId,
+          providerVersion: 0,
+          logicalId: "Old",
+          fqn: "Old",
+          namespace: undefined,
+          resourceType: "Test.TestResource",
+          status: "created",
+          props: { string: "v", replaceString: "a" },
+          attr: { string: "v", replaceString: "a" } as any,
+          bindings: [],
+          downstream: [],
+        },
+      });
+
+      const plan = yield* Effect.gen(function* () {
+        yield* TestResource("New", {
+          string: "v",
+          replaceString: "b",
+        }).pipe(renamedFrom("Old"));
+        return {};
+      }).pipe(makePlan);
+
+      // The replacement wins the action; the rename rides along so apply
+      // still moves the row (and the old-generation delete targets the
+      // migrated attrs under the new FQN).
+      const node = plan.resources.New!;
+      expect(node.action).toEqual("replace");
+      expect(node.renamedFrom).toEqual(["Old"]);
+      expect(node.state?.instanceId).toEqual(instanceId);
+      expect(Object.keys(plan.deletions)).toHaveLength(0);
+    }),
+  );
+
+  test(
+    "an interrupted-create row migrates and resumes the create under the new FQN",
+    Effect.gen(function* () {
+      // The pre-rename deploy crashed mid-create: the row is `creating`.
+      yield* seed({
+        OldBucket: {
+          ...bucketRow("OldBucket"),
+          status: "creating",
+        } as ResourceState,
+      });
+
+      const plan = yield* Effect.gen(function* () {
+        yield* Bucket("NewBucket", { name: "b" }).pipe(
+          renamedFrom("OldBucket"),
+        );
+        return {};
+      }).pipe(makePlan);
+
+      // Create resumes with the SAME instanceId under the new identity —
+      // deterministic physical names regenerate identically, so the
+      // half-created cloud resource is found rather than duplicated.
+      const node = plan.resources.NewBucket!;
+      expect(node.action).toEqual("create");
+      expect(node.renamedFrom).toEqual(["OldBucket"]);
+      expect(node.state?.instanceId).toEqual(instanceId);
+      expect(node.state?.fqn).toEqual("NewBucket");
+      expect(Object.keys(plan.deletions)).toHaveLength(0);
+    }),
+  );
+
+  test(
+    "a duplicated former id is collected once",
+    Effect.gen(function* () {
+      yield* seed({ OldBucket: bucketRow("OldBucket") });
+
+      const plan = yield* Effect.gen(function* () {
+        yield* Bucket("NewBucket", { name: "b" }).pipe(
+          renamedFrom("OldBucket", { fqn: "OldBucket" }),
+        );
+        return {};
+      }).pipe(makePlan);
+
+      expect(plan.resources.NewBucket?.renamedFrom).toEqual(["OldBucket"]);
+    }),
+  );
+
+  test(
     "two resources claiming the same former FQN fail the plan loudly",
     Effect.gen(function* () {
       const exit = yield* Effect.gen(function* () {

--- a/packages/alchemy/test/plan.test.ts
+++ b/packages/alchemy/test/plan.test.ts
@@ -4489,6 +4489,31 @@ describe("renamed resources (renamedFrom)", () => {
   );
 
   test(
+    "the absolute { fqn } form claims a former FQN across namespaces",
+    Effect.gen(function* () {
+      // The resource used to live at the ROOT of the stack; it moved into
+      // a namespace. A relative former id cannot express that (it would
+      // resolve inside the new namespace), so the absolute form is used.
+      yield* seed({ Thing: bucketRow("Thing") });
+
+      const plan = yield* Effect.gen(function* () {
+        yield* Bucket("Thing", { name: "b" }).pipe(
+          renamedFrom({ fqn: "Thing" }),
+          Namespace.push("New"),
+        );
+        return {};
+      }).pipe(makePlan);
+
+      const node = plan.resources["New/Thing"]!;
+      expect(node.action).toEqual("noop");
+      expect(node.renamedFrom).toEqual(["Thing"]);
+      expect(node.state?.fqn).toEqual("New/Thing");
+      expect(node.state?.instanceId).toEqual(instanceId);
+      expect(Object.keys(plan.deletions)).toHaveLength(0);
+    }),
+  );
+
+  test(
     "a rename chain with several same-instanceId leftovers is cleaned in one plan",
     Effect.gen(function* () {
       // A → B → C rename history with repeated partial failures: rows

--- a/packages/alchemy/test/plan.test.ts
+++ b/packages/alchemy/test/plan.test.ts
@@ -4797,6 +4797,65 @@ describe("renamed resources (renamedFrom)", () => {
   );
 
   test(
+    "a same-deploy rename shift (A→B while B→C) migrates both rows",
+    Effect.gen(function* () {
+      // Two existing resources shift names in ONE deploy: the resource at
+      // `A` becomes `B`, and the resource at `B` becomes `C`. Each row
+      // must follow ITS resource — B's resolution may not treat the row
+      // at `B` as its own, because C is claiming it.
+      const instanceB = "b0000000000000000000000000000000";
+      yield* seed({
+        A: bucketRow("A"),
+        B: bucketRow("B", instanceB),
+      });
+
+      const plan = yield* Effect.gen(function* () {
+        yield* Bucket("B", { name: "b" }).pipe(renamedFrom("A"));
+        yield* Bucket("C", { name: "b" }).pipe(renamedFrom("B"));
+        return {};
+      }).pipe(makePlan);
+
+      // C took B's row...
+      const c = plan.resources.C!;
+      expect(c.action).toEqual("update");
+      expect(c.renamedFrom).toEqual(["B"]);
+      expect(c.state?.instanceId).toEqual(instanceB);
+      // ...so B falls back to A's row (never a fresh create)...
+      const b = plan.resources.B!;
+      expect(b.action).toEqual("update");
+      expect(b.renamedFrom).toEqual(["A"]);
+      expect(b.state?.instanceId).toEqual(instanceId);
+      // ...and nothing is deleted.
+      expect(Object.keys(plan.deletions)).toHaveLength(0);
+    }),
+  );
+
+  test(
+    "a same-deploy rename swap (A⇄B) fails the plan loudly",
+    Effect.gen(function* () {
+      // Swapping two live resources' ids cannot be persisted safely (the
+      // two migrations would set and delete each other's rows); it must
+      // die as a rename cycle, never silently half-apply.
+      yield* seed({
+        A: bucketRow("A"),
+        B: bucketRow("B", "b0000000000000000000000000000000"),
+      });
+
+      const exit = yield* Effect.gen(function* () {
+        yield* Bucket("A", { name: "b" }).pipe(renamedFrom("B"));
+        yield* Bucket("B", { name: "b" }).pipe(renamedFrom("A"));
+        return {};
+      }).pipe(makePlan, Effect.exit);
+
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isFailure(exit)) {
+        const die = exit.cause.reasons.find(Cause.isDieReason);
+        expect(String(die?.defect)).toContain("cycle");
+      }
+    }),
+  );
+
+  test(
     "two resources claiming the same former FQN fail the plan loudly",
     Effect.gen(function* () {
       const exit = yield* Effect.gen(function* () {

--- a/packages/alchemy/test/plan.test.ts
+++ b/packages/alchemy/test/plan.test.ts
@@ -7,6 +7,7 @@ import * as Plan from "@/Plan";
 import * as Provider from "@/Provider";
 import { UnsatisfiedResourceCycle } from "@/Plan";
 import { remote } from "@/ProviderMode.ts";
+import { renamedFrom } from "@/Rename.ts";
 import type { ResourceBinding } from "@/Resource";
 import * as Stack from "@/Stack";
 import { Stage } from "@/Stage";
@@ -4332,6 +4333,158 @@ describe("upstream detection across nesting shapes", () => {
 
       // The cycle is tolerated AND the sibling dependency is still found.
       expect(plan.resources.A!.downstream).toContain("B");
+    }),
+  );
+});
+
+describe("renamed resources (renamedFrom)", () => {
+  const bucketRow = (
+    fqn: string,
+    rowInstanceId: string = instanceId,
+  ): ResourceState => ({
+    instanceId: rowInstanceId,
+    providerVersion: 0,
+    logicalId: parseFqnLogicalId(fqn),
+    fqn,
+    namespace: undefined,
+    resourceType: "Test.Bucket",
+    status: "created",
+    props: { name: "b" },
+    attr: { name: "b", bucketArn: `arn:test:bucket:${fqn}` },
+    bindings: [],
+    downstream: [],
+  });
+  const parseFqnLogicalId = (fqn: string) => fqn.split("/").pop()!;
+
+  test(
+    "a row at a former FQN plans as a noop at the new FQN, never a create+delete",
+    Effect.gen(function* () {
+      yield* seed({ OldBucket: bucketRow("OldBucket") });
+
+      const plan = yield* Effect.gen(function* () {
+        yield* Bucket("NewBucket", { name: "b" }).pipe(
+          renamedFrom("OldBucket"),
+        );
+        return {};
+      }).pipe(makePlan);
+
+      const node = plan.resources.NewBucket!;
+      expect(node.action).toEqual("noop");
+      expect(node.renamedFrom).toEqual("OldBucket");
+      // The row rides on the node under its NEW identity (apply persists
+      // the move before any lifecycle runs).
+      expect(node.state?.fqn).toEqual("NewBucket");
+      expect(node.state?.logicalId).toEqual("NewBucket");
+      expect(node.state?.instanceId).toEqual(instanceId);
+      // The former row is NOT an orphan.
+      expect(Object.keys(plan.deletions)).toHaveLength(0);
+    }),
+  );
+
+  test(
+    "the alias is ignored when the new FQN already has a row with a different instanceId",
+    Effect.gen(function* () {
+      yield* seed({
+        OldBucket: bucketRow("OldBucket", "0ld00000000000000000000000000000"),
+        NewBucket: bucketRow("NewBucket"),
+      });
+
+      const plan = yield* Effect.gen(function* () {
+        yield* Bucket("NewBucket", { name: "b" }).pipe(
+          renamedFrom("OldBucket"),
+        );
+        return {};
+      }).pipe(makePlan);
+
+      // The declared resource plans from its OWN row...
+      const node = plan.resources.NewBucket!;
+      expect(node.action).toEqual("noop");
+      expect(node.renamedFrom).toBeUndefined();
+      expect(node.state?.instanceId).toEqual(instanceId);
+      // ...and the former row is a distinct resource: a normal orphan.
+      expect(plan.deletions.OldBucket?.action).toEqual("delete");
+    }),
+  );
+
+  test(
+    "rows at both FQNs with the same instanceId are an in-flight migration, not an orphan",
+    Effect.gen(function* () {
+      // Simulates a crash between apply's `state.set` (new FQN) and
+      // `state.delete` (former FQN).
+      yield* seed({
+        OldBucket: bucketRow("OldBucket"),
+        NewBucket: bucketRow("NewBucket"),
+      });
+
+      const plan = yield* Effect.gen(function* () {
+        yield* Bucket("NewBucket", { name: "b" }).pipe(
+          renamedFrom("OldBucket"),
+        );
+        return {};
+      }).pipe(makePlan);
+
+      // The node plans from the new row and marks the leftover for
+      // state-only cleanup at apply; no delete of the physical resource.
+      const node = plan.resources.NewBucket!;
+      expect(node.action).toEqual("noop");
+      expect(node.renamedFrom).toEqual("OldBucket");
+      expect(Object.keys(plan.deletions)).toHaveLength(0);
+    }),
+  );
+
+  test(
+    "a former FQN that is still actively declared is not a rename",
+    Effect.gen(function* () {
+      yield* seed({ OldBucket: bucketRow("OldBucket") });
+
+      const plan = yield* Effect.gen(function* () {
+        yield* Bucket("OldBucket", { name: "b" });
+        yield* Bucket("NewBucket", { name: "b" }).pipe(
+          renamedFrom("OldBucket"),
+        );
+        return {};
+      }).pipe(makePlan);
+
+      // `OldBucket` keeps its row; `NewBucket` is a fresh create.
+      expect(plan.resources.OldBucket?.action).toEqual("noop");
+      expect(plan.resources.OldBucket?.state?.instanceId).toEqual(instanceId);
+      const node = plan.resources.NewBucket!;
+      expect(node.action).toEqual("create");
+      expect(node.renamedFrom).toBeUndefined();
+      expect(Object.keys(plan.deletions)).toHaveLength(0);
+    }),
+  );
+
+  test(
+    "former ids resolve against the ambient namespace (StaticSite's <id>/Worker → <id>)",
+    Effect.gen(function* () {
+      // The pre-rename shape: a `Worker` resource declared under the
+      // `App/Site` namespace chain.
+      yield* seed({
+        "App/Site/Worker": {
+          ...bucketRow("App/Site/Worker"),
+          namespace: { Id: "Site", Parent: { Id: "App" } },
+        },
+      });
+
+      const plan = yield* Effect.gen(function* () {
+        // The post-rename shape: the resource is `Site` itself, declared
+        // inside the same ambient namespace and claiming its former
+        // namespace-RELATIVE id — `renamedFrom("Site/Worker")` resolves to
+        // `App/Site/Worker` under `Namespace.push("App")`.
+        yield* Bucket("Site", { name: "b" }).pipe(
+          renamedFrom("Site/Worker"),
+          Namespace.push("App"),
+        );
+        return {};
+      }).pipe(makePlan);
+
+      const node = plan.resources["App/Site"]!;
+      expect(node.action).toEqual("noop");
+      expect(node.renamedFrom).toEqual("App/Site/Worker");
+      expect(node.state?.fqn).toEqual("App/Site");
+      expect(node.state?.namespace).toEqual({ Id: "App" });
+      expect(Object.keys(plan.deletions)).toHaveLength(0);
     }),
   );
 });

--- a/packages/alchemy/test/plan.test.ts
+++ b/packages/alchemy/test/plan.test.ts
@@ -4370,7 +4370,7 @@ describe("renamed resources (renamedFrom)", () => {
 
       const node = plan.resources.NewBucket!;
       expect(node.action).toEqual("noop");
-      expect(node.renamedFrom).toEqual("OldBucket");
+      expect(node.renamedFrom).toEqual(["OldBucket"]);
       // The row rides on the node under its NEW identity (apply persists
       // the move before any lifecycle runs).
       expect(node.state?.fqn).toEqual("NewBucket");
@@ -4427,7 +4427,7 @@ describe("renamed resources (renamedFrom)", () => {
       // state-only cleanup at apply; no delete of the physical resource.
       const node = plan.resources.NewBucket!;
       expect(node.action).toEqual("noop");
-      expect(node.renamedFrom).toEqual("OldBucket");
+      expect(node.renamedFrom).toEqual(["OldBucket"]);
       expect(Object.keys(plan.deletions)).toHaveLength(0);
     }),
   );
@@ -4481,10 +4481,112 @@ describe("renamed resources (renamedFrom)", () => {
 
       const node = plan.resources["App/Site"]!;
       expect(node.action).toEqual("noop");
-      expect(node.renamedFrom).toEqual("App/Site/Worker");
+      expect(node.renamedFrom).toEqual(["App/Site/Worker"]);
       expect(node.state?.fqn).toEqual("App/Site");
       expect(node.state?.namespace).toEqual({ Id: "App" });
       expect(Object.keys(plan.deletions)).toHaveLength(0);
+    }),
+  );
+
+  test(
+    "a rename chain with several same-instanceId leftovers is cleaned in one plan",
+    Effect.gen(function* () {
+      // A → B → C rename history with repeated partial failures: rows
+      // linger at BOTH former FQNs, all copies of the same row (migration
+      // preserves the instanceId).
+      yield* seed({
+        OldA: bucketRow("OldA"),
+        OldB: bucketRow("OldB"),
+      });
+
+      const plan = yield* Effect.gen(function* () {
+        // Most recent former id first.
+        yield* Bucket("NewBucket", { name: "b" }).pipe(
+          renamedFrom("OldA", "OldB"),
+        );
+        return {};
+      }).pipe(makePlan);
+
+      const node = plan.resources.NewBucket!;
+      expect(node.action).toEqual("noop");
+      // The migration source AND the same-instance leftover are both
+      // collected — one apply drops them all.
+      expect(node.renamedFrom).toEqual(["OldA", "OldB"]);
+      expect(node.state?.instanceId).toEqual(instanceId);
+      expect(Object.keys(plan.deletions)).toHaveLength(0);
+    }),
+  );
+
+  test(
+    "a foreign row at a later former FQN is orphan-deleted, not adopted",
+    Effect.gen(function* () {
+      // `OldA` is the real predecessor; `OldB` is someone else's row
+      // (different instanceId) that happens to sit at an older former FQN.
+      yield* seed({
+        OldA: bucketRow("OldA"),
+        OldB: bucketRow("OldB", "f0re1gn0000000000000000000000000"),
+      });
+
+      const plan = yield* Effect.gen(function* () {
+        yield* Bucket("NewBucket", { name: "b" }).pipe(
+          renamedFrom("OldA", "OldB"),
+        );
+        return {};
+      }).pipe(makePlan);
+
+      const node = plan.resources.NewBucket!;
+      expect(node.renamedFrom).toEqual(["OldA"]);
+      expect(node.state?.instanceId).toEqual(instanceId);
+      // The foreign row is a normal orphan — deleted in the SAME plan (the
+      // deletions guard compares against the claimant's PLANNED state, so
+      // the in-memory migration doesn't shield it).
+      expect(plan.deletions.OldB?.action).toEqual("delete");
+      expect(plan.deletions.OldA).toBeUndefined();
+    }),
+  );
+
+  test(
+    "a former row with a different resourceType is never migrated",
+    Effect.gen(function* () {
+      // The row at the former FQN was written by a DIFFERENT resource type
+      // — it cannot be this resource's row, whatever its FQN says.
+      yield* seed({
+        OldBucket: {
+          ...bucketRow("OldBucket"),
+          resourceType: "Test.Queue",
+          attr: { name: "b", queueUrl: "https://test.queue.com/b" },
+        },
+      });
+
+      const plan = yield* Effect.gen(function* () {
+        yield* Bucket("NewBucket", { name: "b" }).pipe(
+          renamedFrom("OldBucket"),
+        );
+        return {};
+      }).pipe(makePlan);
+
+      // Fresh create; the type-mismatched row is a normal orphan.
+      const node = plan.resources.NewBucket!;
+      expect(node.action).toEqual("create");
+      expect(node.renamedFrom).toBeUndefined();
+      expect(plan.deletions.OldBucket?.action).toEqual("delete");
+    }),
+  );
+
+  test(
+    "two resources claiming the same former FQN fail the plan loudly",
+    Effect.gen(function* () {
+      const exit = yield* Effect.gen(function* () {
+        yield* Bucket("A", { name: "a" }).pipe(renamedFrom("Shared"));
+        yield* Bucket("B", { name: "b" }).pipe(renamedFrom("Shared"));
+        return {};
+      }).pipe(makePlan, Effect.exit);
+
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isFailure(exit)) {
+        const die = exit.cause.reasons.find(Cause.isDieReason);
+        expect(String(die?.defect)).toContain("both claim former FQN 'Shared'");
+      }
     }),
   );
 });

--- a/packages/alchemy/test/plan.test.ts
+++ b/packages/alchemy/test/plan.test.ts
@@ -4599,6 +4599,38 @@ describe("renamed resources (renamedFrom)", () => {
   );
 
   test(
+    "a foreign-typed row at the NEW FQN does not block the migration",
+    Effect.gen(function* () {
+      // A different resource type occupied `NewBucket` before this
+      // deploy's shuffle. It cannot be the Bucket's row, so the
+      // type-matching former row still migrates (and plans against the
+      // real predecessor's state, not the foreign type's).
+      yield* seed({
+        NewBucket: {
+          ...bucketRow("NewBucket", "f0re1gn0000000000000000000000000"),
+          resourceType: "Test.Queue",
+          attr: { name: "q", queueUrl: "https://test.queue.com/q" },
+        },
+        OldBucket: bucketRow("OldBucket"),
+      });
+
+      const plan = yield* Effect.gen(function* () {
+        yield* Bucket("NewBucket", { name: "b" }).pipe(
+          renamedFrom("OldBucket"),
+        );
+        return {};
+      }).pipe(makePlan);
+
+      const node = plan.resources.NewBucket!;
+      expect(node.action).toEqual("noop");
+      expect(node.renamedFrom).toEqual(["OldBucket"]);
+      expect(node.state?.instanceId).toEqual(instanceId);
+      expect(node.state?.resourceType).toEqual("Test.Bucket");
+      expect(Object.keys(plan.deletions)).toHaveLength(0);
+    }),
+  );
+
+  test(
     "two resources claiming the same former FQN fail the plan loudly",
     Effect.gen(function* () {
       const exit = yield* Effect.gen(function* () {

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -416,6 +416,10 @@ export default defineConfig({
                   label: "Resources",
                   link: "/infrastructure-as-code/resource",
                 },
+                {
+                  label: "Renaming Resources",
+                  link: "/infrastructure-as-code/renaming",
+                },
                 { label: "Actions", link: "/infrastructure-as-code/action" },
                 {
                   label: "Inputs & Outputs",

--- a/website/src/content/docs/infrastructure-as-code/renaming.mdx
+++ b/website/src/content/docs/infrastructure-as-code/renaming.mdx
@@ -1,0 +1,172 @@
+---
+title: Renaming Resources
+description: Migrate a resource's state across a logical ID change instead of replacing it.
+---
+
+Changing a [logical ID](/infrastructure-as-code/resource#logical-id)
+normally plans a **replacement**: a new resource is created under the
+new ID and the old one — including its physical resource, data, and
+attachments — is deleted. When you actually just renamed the
+resource, declare the rename with `Alchemy.renamedFrom` and alchemy
+migrates the state row instead:
+
+```diff lang="typescript"
+-const bucket = yield* Cloudflare.R2.Bucket("Bucket");
++const bucket = yield* Cloudflare.R2.Bucket("Assets").pipe(
++  Alchemy.renamedFrom("Bucket"),
++);
+```
+
+The next deploy finds the state persisted under `Bucket`, moves it to
+`Assets`, and plans a single re-branding **update** — same instance
+ID, same physical name, nothing created or deleted in the cloud. The
+plan shows what's happening:
+
+```text
+Plan: 1 to update
+[Assets] update (renamed from Bucket)
+```
+
+Keep the decoration around; once no state row exists under the old
+ID it does nothing.
+
+## Namespaces
+
+A bare-string former id behaves exactly like the `id` argument: it
+resolves against the surrounding namespace (`Namespace.push`).
+Declared inside `Namespace.push("Site")`, `renamedFrom("Worker")`
+claims the former FQN `Site/Worker` — write the former id exactly
+as you would have written the `id` in the same position:
+
+```typescript
+// this Worker's FQN used to be `<id>/Worker`; now it is `<id>`
+// (what Cloudflare.Website.StaticSite does internally)
+yield* Worker(id, props).pipe(Alchemy.renamedFrom(`${id}/Worker`));
+```
+
+When a resource moved **between** namespaces, a relative id can't
+express the old location — pass the absolute form, the full FQN
+exactly as it appears in state:
+
+```typescript
+yield* Cloudflare.R2.Bucket("Assets").pipe(
+  Alchemy.renamedFrom({ fqn: "LegacySite/Assets" }),
+  Namespace.push("NewSite"),
+);
+```
+
+## Renamed more than once
+
+List every former id, **most recent first** — alchemy checks them in
+order and migrates from the first matching row:
+
+```typescript
+yield* Cloudflare.R2.Bucket("Assets").pipe(
+  Alchemy.renamedFrom("StaticAssets", "Bucket"),
+);
+```
+
+## Reusing the old ID
+
+The old ID can be reused by a **new** resource in the same deploy.
+The rename claim wins the state row — it's an explicit statement
+that the row was the renamed resource's — and the reusing resource
+is created fresh:
+
+```typescript
+// `Assets` keeps the physical resource previously known as
+// `Bucket`; this `Bucket` is a brand-new one.
+const assets = yield* Cloudflare.R2.Bucket("Assets").pipe(
+  Alchemy.renamedFrom("Bucket"),
+);
+const bucket = yield* Cloudflare.R2.Bucket("Bucket");
+```
+
+The migration deploy plans one **update** for the renamed resource
+(not a noop) — the reconcile re-brands the physical resource's
+ownership tags under the new logical ID, so the reused ID can never
+accidentally adopt the wrong cloud resource.
+
+## Safety semantics
+
+The migration is deliberately conservative.
+
+**Identity is proven, not assumed.** Only a migration ever copies an
+instance ID, so a leftover row from an interrupted move is provably
+a copy — it's dropped state-only, the physical resource untouched:
+
+```diff lang="typescript"
+-const bucket = yield* Cloudflare.R2.Bucket("Bucket");
++// a crashed deploy left rows at BOTH ids with the SAME instance id;
++// re-deploying drops the leftover copy — the cloud is never touched
++const bucket = yield* Cloudflare.R2.Bucket("Assets").pipe(
++  Alchemy.renamedFrom("Bucket"),
++);
+```
+
+A former row with a *different* instance ID is someone else's — the
+old name was reused after the rename shipped — so the alias is
+ignored and the row follows normal lifecycle rules:
+
+```diff lang="typescript"
+ // deployed long after the rename: `Bucket` is its own resource now,
+ // with its own instance id — `renamedFrom` never adopts it
+ const assets = yield* Cloudflare.R2.Bucket("Assets").pipe(
+   Alchemy.renamedFrom("Bucket"),
+ );
+ const bucket = yield* Cloudflare.R2.Bucket("Bucket");
+```
+
+**Types must match.** A former row written by a different resource
+type can't be this resource's state, whatever its FQN says — nothing
+migrates, and the orphaned row follows its own lifecycle:
+
+```diff lang="typescript"
+-const cache = yield* Cloudflare.KV.Namespace("Store");
++// the row at `Store` belongs to a KV.Namespace — it is never adopted;
++// `Assets` is created fresh and `Store` is a normal orphan delete
++const assets = yield* Cloudflare.R2.Bucket("Assets").pipe(
++  Alchemy.renamedFrom("Store"),
++);
+```
+
+And a different-typed row sitting at the *new* ID fails the plan —
+migrating over it would silently abandon its cloud resource:
+
+```diff lang="typescript"
+-const cache = yield* Cloudflare.KV.Namespace("Assets");
+-const bucket = yield* Cloudflare.R2.Bucket("Bucket");
++// ✗ a state row of a different type already occupies 'Assets' —
++//   delete or rename the KV namespace first, then re-deploy
++const bucket = yield* Cloudflare.R2.Bucket("Assets").pipe(
++  Alchemy.renamedFrom("Bucket"),
++);
+```
+
+**Ambiguity fails loudly.** Two resources claiming the same former
+ID fail instead of racing for the row:
+
+```typescript
+yield* Cloudflare.R2.Bucket("Assets").pipe(Alchemy.renamedFrom("Bucket"));
+yield* Cloudflare.R2.Bucket("Files").pipe(Alchemy.renamedFrom("Bucket"));
+// ✗ 'Assets' and 'Files' both claim former FQN 'Bucket'
+```
+
+**Shifts work.** Renames may pass through each other in one deploy —
+each row follows its resource, and pending replacement cleanup rides
+along:
+
+```typescript
+yield* Cloudflare.R2.Bucket("B").pipe(Alchemy.renamedFrom("A")); // row at A → B
+yield* Cloudflare.R2.Bucket("C").pipe(Alchemy.renamedFrom("B")); // row at B → C
+```
+
+**Swaps fail.** Exchanging two live IDs is a rename cycle — the two
+migrations would overwrite each other's rows — so the plan fails;
+rename through a temporary ID across two deploys instead:
+
+```typescript
+yield* Cloudflare.R2.Bucket("A").pipe(Alchemy.renamedFrom("B"));
+yield* Cloudflare.R2.Bucket("B").pipe(Alchemy.renamedFrom("A"));
+// ✗ rename cycle detected among ['A', 'B']
+```

--- a/website/src/content/docs/infrastructure-as-code/resource.mdx
+++ b/website/src/content/docs/infrastructure-as-code/resource.mdx
@@ -180,10 +180,9 @@ actually just renamed the resource, declare the rename with
 +);
 ```
 
-Same instance ID, same physical name, nothing created or deleted in
-the cloud. See [Renaming Resources](/infrastructure-as-code/renaming)
-for the full guide — namespaces and cross-namespace moves, multiple
-renames, reusing the old ID, and the safety semantics.
+The instance ID and physical name are preserved; nothing is created
+or deleted in the cloud. See
+[Renaming Resources](/infrastructure-as-code/renaming).
 
 ## Physical name
 

--- a/website/src/content/docs/infrastructure-as-code/resource.mdx
+++ b/website/src/content/docs/infrastructure-as-code/resource.mdx
@@ -225,10 +225,12 @@ yield* Cloudflare.R2.Bucket("Assets").pipe(
 
 The migration is deliberately conservative:
 
-- **Only unclaimed rows migrate.** If state already exists under the
-  new ID, the former ID is ignored — a row there is treated as a
-  different resource (e.g. a new resource reusing the old name) and
-  follows normal lifecycle rules.
+- **Only unclaimed rows migrate.** If state of the same resource
+  type already exists under the new ID, the former ID is ignored —
+  a row there is treated as a different resource (e.g. a new
+  resource reusing the old name) and follows normal lifecycle rules.
+  A row of a *different* type doesn't claim the ID: it can't be this
+  resource's state, so the type-matching former row still migrates.
 - **Identity is proven, not assumed.** Leftover rows from an
   interrupted migration are recognized by their instance ID and
   cleaned up state-only — the physical resource is never touched. A

--- a/website/src/content/docs/infrastructure-as-code/resource.mdx
+++ b/website/src/content/docs/infrastructure-as-code/resource.mdx
@@ -221,22 +221,42 @@ yield* Cloudflare.R2.Bucket("Assets").pipe(
 );
 ```
 
+### Reusing the old ID
+
+The old ID can be reused by a **new** resource in the same deploy.
+The rename claim wins the state row — it's an explicit statement
+that the row was the renamed resource's — and the reusing resource
+is created fresh:
+
+```typescript
+// `Assets` keeps the physical resource previously known as
+// `Bucket`; this `Bucket` is a brand-new one.
+const assets = yield* Cloudflare.R2.Bucket("Assets").pipe(
+  Alchemy.renamedFrom("Bucket"),
+);
+const bucket = yield* Cloudflare.R2.Bucket("Bucket");
+```
+
+The migration deploy plans one **update** for the renamed resource
+(not a noop) — the reconcile re-brands the physical resource's
+ownership tags under the new logical ID, so the reused ID can never
+accidentally adopt the wrong cloud resource. The plan output shows
+what's happening: `[Assets] update (renamed from Bucket)`.
+
 ### Safety semantics
 
 The migration is deliberately conservative:
 
-- **Only unclaimed rows migrate.** If state of the same resource
-  type already exists under the new ID, the former ID is ignored —
-  a row there is treated as a different resource (e.g. a new
-  resource reusing the old name) and follows normal lifecycle rules.
-  A row of a *different* type doesn't claim the ID: it can't be this
-  resource's state, so the type-matching former row still migrates.
 - **Identity is proven, not assumed.** Leftover rows from an
   interrupted migration are recognized by their instance ID and
   cleaned up state-only — the physical resource is never touched. A
-  row with a different instance ID is never adopted.
+  former row with a different instance ID (a resource that reused
+  the old name after the rename shipped) is never adopted and
+  follows normal lifecycle rules.
 - **Types must match.** A former row written by a different resource
-  type is never migrated, whatever its FQN says.
+  type is never migrated, whatever its FQN says. And a
+  different-typed row sitting at the *new* ID fails the plan loudly
+  — migrating over it would silently abandon its cloud resource.
 - **Ambiguity fails loudly.** Two resources claiming the same former
   ID fail the plan with an error instead of racing for the row.
 

--- a/website/src/content/docs/infrastructure-as-code/resource.mdx
+++ b/website/src/content/docs/infrastructure-as-code/resource.mdx
@@ -159,9 +159,84 @@ deploys:
   TypeScript class, move the file; as long as the logical ID stays
   the same, alchemy still recognizes it.
 - **Rename = replace** — change the logical ID and alchemy treats
-  it as a new resource (and deletes the old one on the next deploy).
+  it as a new resource (and deletes the old one on the next deploy)
+  — unless you declare the rename with
+  [`renamedFrom`](#renaming-a-resource).
 
 Logical IDs only need to be unique **within a stack**.
+
+## Renaming a resource
+
+Changing a logical ID normally plans a **replacement**: a new
+resource is created under the new ID and the old one — including
+its physical resource, data, and attachments — is deleted. When you
+actually just renamed the resource, declare the rename with
+`Alchemy.renamedFrom` and alchemy migrates the state row instead:
+
+```diff lang="typescript"
+-const bucket = yield* Cloudflare.R2.Bucket("Bucket");
++const bucket = yield* Cloudflare.R2.Bucket("Assets").pipe(
++  Alchemy.renamedFrom("Bucket"),
++);
+```
+
+The next deploy finds the state persisted under `Bucket`, moves it
+to `Assets`, and plans a **no-op** — same instance ID, same physical
+name, nothing created or deleted in the cloud. Keep the decoration
+around; once no state row exists under the old ID it does nothing.
+
+### Namespaces
+
+A bare-string former id behaves exactly like the `id` argument: it
+resolves against the surrounding namespace (`Namespace.push`).
+Declared inside `Namespace.push("Site")`, `renamedFrom("Worker")`
+claims the former FQN `Site/Worker` — write the former id exactly
+as you would have written the `id` in the same position:
+
+```typescript
+// this Worker's FQN used to be `<id>/Worker`; now it is `<id>`
+// (what Cloudflare.Website.StaticSite does internally)
+yield* Worker(id, props).pipe(Alchemy.renamedFrom(`${id}/Worker`));
+```
+
+When a resource moved **between** namespaces, a relative id can't
+express the old location — pass the absolute form, the full FQN
+exactly as it appears in state:
+
+```typescript
+yield* Cloudflare.R2.Bucket("Assets").pipe(
+  Alchemy.renamedFrom({ fqn: "LegacySite/Assets" }),
+  Namespace.push("NewSite"),
+);
+```
+
+### Renamed more than once
+
+List every former id, **most recent first** — alchemy checks them in
+order and migrates from the first matching row:
+
+```typescript
+yield* Cloudflare.R2.Bucket("Assets").pipe(
+  Alchemy.renamedFrom("StaticAssets", "Bucket"),
+);
+```
+
+### Safety semantics
+
+The migration is deliberately conservative:
+
+- **Only unclaimed rows migrate.** If state already exists under the
+  new ID, the former ID is ignored — a row there is treated as a
+  different resource (e.g. a new resource reusing the old name) and
+  follows normal lifecycle rules.
+- **Identity is proven, not assumed.** Leftover rows from an
+  interrupted migration are recognized by their instance ID and
+  cleaned up state-only — the physical resource is never touched. A
+  row with a different instance ID is never adopted.
+- **Types must match.** A former row written by a different resource
+  type is never migrated, whatever its FQN says.
+- **Ambiguity fails loudly.** Two resources claiming the same former
+  ID fail the plan with an error instead of racing for the row.
 
 ## Physical name
 

--- a/website/src/content/docs/infrastructure-as-code/resource.mdx
+++ b/website/src/content/docs/infrastructure-as-code/resource.mdx
@@ -245,47 +245,58 @@ what's happening: `[Assets] update (renamed from Bucket)`.
 
 ### Safety semantics
 
-The migration is deliberately conservative. The examples below all
-assume this rename:
-
-```typescript
-yield* Cloudflare.R2.Bucket("Assets").pipe(Alchemy.renamedFrom("Bucket"));
-```
+The migration is deliberately conservative.
 
 **Identity is proven, not assumed.** Only a migration ever copies an
 instance ID, so a leftover row from an interrupted move is provably
 a copy — it's dropped state-only, the physical resource untouched:
 
-```text
-state:  Bucket (instance a3f1)  +  Assets (instance a3f1)
-plan:   [Assets] update (renamed from Bucket)   ← drops the copy
+```diff lang="typescript"
+-const bucket = yield* Cloudflare.R2.Bucket("Bucket");
++// a crashed deploy left rows at BOTH ids with the SAME instance id;
++// re-deploying drops the leftover copy — the cloud is never touched
++const bucket = yield* Cloudflare.R2.Bucket("Assets").pipe(
++  Alchemy.renamedFrom("Bucket"),
++);
 ```
 
 A former row with a *different* instance ID is someone else's — the
-old name was reused after the rename shipped — and follows normal
-lifecycle rules:
+old name was reused after the rename shipped — so the alias is
+ignored and the row follows normal lifecycle rules:
 
-```text
-state:  Bucket (instance 9c2e)  +  Assets (instance a3f1)
-plan:   [Assets] noop            ← alias ignored
-        [Bucket] delete          ← normal orphan, if undeclared
+```diff lang="typescript"
+ // deployed long after the rename: `Bucket` is its own resource now,
+ // with its own instance id — `renamedFrom` never adopts it
+ const assets = yield* Cloudflare.R2.Bucket("Assets").pipe(
+   Alchemy.renamedFrom("Bucket"),
+ );
+ const bucket = yield* Cloudflare.R2.Bucket("Bucket");
 ```
 
 **Types must match.** A former row written by a different resource
-type can't be this resource's state, whatever its FQN says — it is
-never migrated:
+type can't be this resource's state, whatever its FQN says — nothing
+migrates, and the orphaned row follows its own lifecycle:
 
-```text
-state:  Bucket (a KV.Namespace row)
-plan:   [Assets] create          ← nothing to migrate
+```diff lang="typescript"
+-const cache = yield* Cloudflare.KV.Namespace("Store");
++// the row at `Store` belongs to a KV.Namespace — it is never adopted;
++// `Assets` is created fresh and `Store` is a normal orphan delete
++const assets = yield* Cloudflare.R2.Bucket("Assets").pipe(
++  Alchemy.renamedFrom("Store"),
++);
 ```
 
 And a different-typed row sitting at the *new* ID fails the plan —
 migrating over it would silently abandon its cloud resource:
 
-```text
-state:  Assets (a KV.Namespace row)  +  Bucket (an R2.Bucket row)
-plan:   ✗ a state row of a different type already occupies 'Assets'
+```diff lang="typescript"
+-const cache = yield* Cloudflare.KV.Namespace("Assets");
+-const bucket = yield* Cloudflare.R2.Bucket("Bucket");
++// ✗ a state row of a different type already occupies 'Assets' —
++//   delete or rename the KV namespace first, then re-deploy
++const bucket = yield* Cloudflare.R2.Bucket("Assets").pipe(
++  Alchemy.renamedFrom("Bucket"),
++);
 ```
 
 **Ambiguity fails loudly.** Two resources claiming the same former

--- a/website/src/content/docs/infrastructure-as-code/resource.mdx
+++ b/website/src/content/docs/infrastructure-as-code/resource.mdx
@@ -259,6 +259,11 @@ The migration is deliberately conservative:
   — migrating over it would silently abandon its cloud resource.
 - **Ambiguity fails loudly.** Two resources claiming the same former
   ID fail the plan with an error instead of racing for the row.
+- **Shifts work; swaps fail.** Renames may shift through each other
+  in one deploy (`A→B` while `B→C` — each row follows its resource,
+  and pending replacement cleanup rides along). A swap (`A ⇄ B`) is
+  a rename cycle and fails the plan — rename through a temporary ID
+  across two deploys instead.
 
 ## Physical name
 

--- a/website/src/content/docs/infrastructure-as-code/resource.mdx
+++ b/website/src/content/docs/infrastructure-as-code/resource.mdx
@@ -245,25 +245,76 @@ what's happening: `[Assets] update (renamed from Bucket)`.
 
 ### Safety semantics
 
-The migration is deliberately conservative:
+The migration is deliberately conservative. The examples below all
+assume this rename:
 
-- **Identity is proven, not assumed.** Leftover rows from an
-  interrupted migration are recognized by their instance ID and
-  cleaned up state-only — the physical resource is never touched. A
-  former row with a different instance ID (a resource that reused
-  the old name after the rename shipped) is never adopted and
-  follows normal lifecycle rules.
-- **Types must match.** A former row written by a different resource
-  type is never migrated, whatever its FQN says. And a
-  different-typed row sitting at the *new* ID fails the plan loudly
-  — migrating over it would silently abandon its cloud resource.
-- **Ambiguity fails loudly.** Two resources claiming the same former
-  ID fail the plan with an error instead of racing for the row.
-- **Shifts work; swaps fail.** Renames may shift through each other
-  in one deploy (`A→B` while `B→C` — each row follows its resource,
-  and pending replacement cleanup rides along). A swap (`A ⇄ B`) is
-  a rename cycle and fails the plan — rename through a temporary ID
-  across two deploys instead.
+```typescript
+yield* Cloudflare.R2.Bucket("Assets").pipe(Alchemy.renamedFrom("Bucket"));
+```
+
+**Identity is proven, not assumed.** Only a migration ever copies an
+instance ID, so a leftover row from an interrupted move is provably
+a copy — it's dropped state-only, the physical resource untouched:
+
+```text
+state:  Bucket (instance a3f1)  +  Assets (instance a3f1)
+plan:   [Assets] update (renamed from Bucket)   ← drops the copy
+```
+
+A former row with a *different* instance ID is someone else's — the
+old name was reused after the rename shipped — and follows normal
+lifecycle rules:
+
+```text
+state:  Bucket (instance 9c2e)  +  Assets (instance a3f1)
+plan:   [Assets] noop            ← alias ignored
+        [Bucket] delete          ← normal orphan, if undeclared
+```
+
+**Types must match.** A former row written by a different resource
+type can't be this resource's state, whatever its FQN says — it is
+never migrated:
+
+```text
+state:  Bucket (a KV.Namespace row)
+plan:   [Assets] create          ← nothing to migrate
+```
+
+And a different-typed row sitting at the *new* ID fails the plan —
+migrating over it would silently abandon its cloud resource:
+
+```text
+state:  Assets (a KV.Namespace row)  +  Bucket (an R2.Bucket row)
+plan:   ✗ a state row of a different type already occupies 'Assets'
+```
+
+**Ambiguity fails loudly.** Two resources claiming the same former
+ID fail instead of racing for the row:
+
+```typescript
+yield* Cloudflare.R2.Bucket("Assets").pipe(Alchemy.renamedFrom("Bucket"));
+yield* Cloudflare.R2.Bucket("Files").pipe(Alchemy.renamedFrom("Bucket"));
+// ✗ 'Assets' and 'Files' both claim former FQN 'Bucket'
+```
+
+**Shifts work.** Renames may pass through each other in one deploy —
+each row follows its resource, and pending replacement cleanup rides
+along:
+
+```typescript
+yield* Cloudflare.R2.Bucket("B").pipe(Alchemy.renamedFrom("A")); // row at A → B
+yield* Cloudflare.R2.Bucket("C").pipe(Alchemy.renamedFrom("B")); // row at B → C
+```
+
+**Swaps fail.** Exchanging two live IDs is a rename cycle — the two
+migrations would overwrite each other's rows — so the plan fails;
+rename through a temporary ID across two deploys instead:
+
+```typescript
+yield* Cloudflare.R2.Bucket("A").pipe(Alchemy.renamedFrom("B"));
+yield* Cloudflare.R2.Bucket("B").pipe(Alchemy.renamedFrom("A"));
+// ✗ rename cycle detected among ['A', 'B']
+```
 
 ## Physical name
 

--- a/website/src/content/docs/infrastructure-as-code/resource.mdx
+++ b/website/src/content/docs/infrastructure-as-code/resource.mdx
@@ -161,7 +161,7 @@ deploys:
 - **Rename = replace** — change the logical ID and alchemy treats
   it as a new resource (and deletes the old one on the next deploy)
   — unless you declare the rename with
-  [`renamedFrom`](#renaming-a-resource).
+  [`renamedFrom`](/infrastructure-as-code/renaming).
 
 Logical IDs only need to be unique **within a stack**.
 
@@ -180,152 +180,10 @@ actually just renamed the resource, declare the rename with
 +);
 ```
 
-The next deploy finds the state persisted under `Bucket`, moves it
-to `Assets`, and plans a **no-op** — same instance ID, same physical
-name, nothing created or deleted in the cloud. Keep the decoration
-around; once no state row exists under the old ID it does nothing.
-
-### Namespaces
-
-A bare-string former id behaves exactly like the `id` argument: it
-resolves against the surrounding namespace (`Namespace.push`).
-Declared inside `Namespace.push("Site")`, `renamedFrom("Worker")`
-claims the former FQN `Site/Worker` — write the former id exactly
-as you would have written the `id` in the same position:
-
-```typescript
-// this Worker's FQN used to be `<id>/Worker`; now it is `<id>`
-// (what Cloudflare.Website.StaticSite does internally)
-yield* Worker(id, props).pipe(Alchemy.renamedFrom(`${id}/Worker`));
-```
-
-When a resource moved **between** namespaces, a relative id can't
-express the old location — pass the absolute form, the full FQN
-exactly as it appears in state:
-
-```typescript
-yield* Cloudflare.R2.Bucket("Assets").pipe(
-  Alchemy.renamedFrom({ fqn: "LegacySite/Assets" }),
-  Namespace.push("NewSite"),
-);
-```
-
-### Renamed more than once
-
-List every former id, **most recent first** — alchemy checks them in
-order and migrates from the first matching row:
-
-```typescript
-yield* Cloudflare.R2.Bucket("Assets").pipe(
-  Alchemy.renamedFrom("StaticAssets", "Bucket"),
-);
-```
-
-### Reusing the old ID
-
-The old ID can be reused by a **new** resource in the same deploy.
-The rename claim wins the state row — it's an explicit statement
-that the row was the renamed resource's — and the reusing resource
-is created fresh:
-
-```typescript
-// `Assets` keeps the physical resource previously known as
-// `Bucket`; this `Bucket` is a brand-new one.
-const assets = yield* Cloudflare.R2.Bucket("Assets").pipe(
-  Alchemy.renamedFrom("Bucket"),
-);
-const bucket = yield* Cloudflare.R2.Bucket("Bucket");
-```
-
-The migration deploy plans one **update** for the renamed resource
-(not a noop) — the reconcile re-brands the physical resource's
-ownership tags under the new logical ID, so the reused ID can never
-accidentally adopt the wrong cloud resource. The plan output shows
-what's happening: `[Assets] update (renamed from Bucket)`.
-
-### Safety semantics
-
-The migration is deliberately conservative.
-
-**Identity is proven, not assumed.** Only a migration ever copies an
-instance ID, so a leftover row from an interrupted move is provably
-a copy — it's dropped state-only, the physical resource untouched:
-
-```diff lang="typescript"
--const bucket = yield* Cloudflare.R2.Bucket("Bucket");
-+// a crashed deploy left rows at BOTH ids with the SAME instance id;
-+// re-deploying drops the leftover copy — the cloud is never touched
-+const bucket = yield* Cloudflare.R2.Bucket("Assets").pipe(
-+  Alchemy.renamedFrom("Bucket"),
-+);
-```
-
-A former row with a *different* instance ID is someone else's — the
-old name was reused after the rename shipped — so the alias is
-ignored and the row follows normal lifecycle rules:
-
-```diff lang="typescript"
- // deployed long after the rename: `Bucket` is its own resource now,
- // with its own instance id — `renamedFrom` never adopts it
- const assets = yield* Cloudflare.R2.Bucket("Assets").pipe(
-   Alchemy.renamedFrom("Bucket"),
- );
- const bucket = yield* Cloudflare.R2.Bucket("Bucket");
-```
-
-**Types must match.** A former row written by a different resource
-type can't be this resource's state, whatever its FQN says — nothing
-migrates, and the orphaned row follows its own lifecycle:
-
-```diff lang="typescript"
--const cache = yield* Cloudflare.KV.Namespace("Store");
-+// the row at `Store` belongs to a KV.Namespace — it is never adopted;
-+// `Assets` is created fresh and `Store` is a normal orphan delete
-+const assets = yield* Cloudflare.R2.Bucket("Assets").pipe(
-+  Alchemy.renamedFrom("Store"),
-+);
-```
-
-And a different-typed row sitting at the *new* ID fails the plan —
-migrating over it would silently abandon its cloud resource:
-
-```diff lang="typescript"
--const cache = yield* Cloudflare.KV.Namespace("Assets");
--const bucket = yield* Cloudflare.R2.Bucket("Bucket");
-+// ✗ a state row of a different type already occupies 'Assets' —
-+//   delete or rename the KV namespace first, then re-deploy
-+const bucket = yield* Cloudflare.R2.Bucket("Assets").pipe(
-+  Alchemy.renamedFrom("Bucket"),
-+);
-```
-
-**Ambiguity fails loudly.** Two resources claiming the same former
-ID fail instead of racing for the row:
-
-```typescript
-yield* Cloudflare.R2.Bucket("Assets").pipe(Alchemy.renamedFrom("Bucket"));
-yield* Cloudflare.R2.Bucket("Files").pipe(Alchemy.renamedFrom("Bucket"));
-// ✗ 'Assets' and 'Files' both claim former FQN 'Bucket'
-```
-
-**Shifts work.** Renames may pass through each other in one deploy —
-each row follows its resource, and pending replacement cleanup rides
-along:
-
-```typescript
-yield* Cloudflare.R2.Bucket("B").pipe(Alchemy.renamedFrom("A")); // row at A → B
-yield* Cloudflare.R2.Bucket("C").pipe(Alchemy.renamedFrom("B")); // row at B → C
-```
-
-**Swaps fail.** Exchanging two live IDs is a rename cycle — the two
-migrations would overwrite each other's rows — so the plan fails;
-rename through a temporary ID across two deploys instead:
-
-```typescript
-yield* Cloudflare.R2.Bucket("A").pipe(Alchemy.renamedFrom("B"));
-yield* Cloudflare.R2.Bucket("B").pipe(Alchemy.renamedFrom("A"));
-// ✗ rename cycle detected among ['A', 'B']
-```
+Same instance ID, same physical name, nothing created or deleted in
+the cloud. See [Renaming Resources](/infrastructure-as-code/renaming)
+for the full guide — namespaces and cross-namespace moves, multiple
+renames, reusing the old ID, and the safety semantics.
 
 ## Physical name
 


### PR DESCRIPTION
Renaming a resource's logical id used to orphan its state row: the next deploy planned a create+delete replacement — new physical name, torn-down `workers.dev` URL, and a custom-domain handover that crashes at the "already attached to another Worker" guard. This is what took `alchemy.run` down when beta.68's StaticSite FQN flattening ([#1053](https://github.com/alchemy-run/alchemy/pull/1053)) met a pinned worker name.

`renamedFrom(...)` makes an FQN rename a first-class state migration:

```ts
// was `Worker("Website/Worker", ...)` in a previous release:
const worker = yield* Worker("Website", props).pipe(
  Alchemy.renamedFrom("Website/Worker"),
);
```

A bare-string former id resolves against the ambient namespace exactly like the resource's own `id`; `renamedFrom({ fqn: "Legacy/Thing" })` is absolute, for resources that moved between namespaces. Renamed more than once? List every former id, most recent first.

Semantics (`new` = row at the resource's FQN, `old` = row at a former FQN):

| new | old | outcome |
|---|---|---|
| — | row | migrate: the old row **is** the resource's state; apply moves it before any lifecycle op, and one **update** reconcile re-brands the physical resource under the new logical id (never a create) |
| row, same `instanceId` | row | interrupted migration: **all** same-instance leftovers dropped state-only in one apply; the physical resource is never touched |
| row, diff `instanceId` | row | someone else's row (old name reused after the rename shipped): ignored, normal orphan handling in the same deploy |
| row, diff `resourceType` | row | **fatal** — migrating over the foreign-typed row would silently abandon its cloud resource |
| any | row, diff `resourceType` | never migrated — cannot be this resource's row, whatever its FQN says |

The old id can be **reused by a new resource in the same deploy** — the rename claim wins the row and the reuser is created fresh. Its cold-start adoption probe is suppressed for that deploy (the migrated physical's tags still carry the old id and a tag-based `read` would adopt the wrong resource), and the forced re-branding update makes future probes safe:

```ts
yield* Bucket("Assets").pipe(Alchemy.renamedFrom("Bucket")); // keeps the physical
yield* Bucket("Bucket");                                     // brand new
```

Two resources claiming the same former FQN fail the plan loudly. Mid-replacement rows migrate with their old-generation GC chain intact. The plan output annotates migrations: `[Assets] update (renamed from Bucket)`.

Mechanics follow the cold-adoption precedent: plan stays side-effect-free (migrations are resolved up-front, in-memory), and apply persists the move first thing — commit at the new FQN, then delete the former rows, so an interruption reads as an in-flight migration and never as an orphan to delete.

`Cloudflare.Website.StaticSite` now declares `renamedFrom(`${id}/Worker`)`, so pre-beta.68 sites upgrade with a single re-branding update instead of a worker replacement — and beta.68 early adopters (already flat) are unaffected.

Documented under [Renaming a resource](https://alchemy.run/infrastructure-as-code/resource#renaming-a-resource) in `infrastructure-as-code/resource.mdx`.
