### PR TITLE
chore(ci): bump alchemy-run/actions pin for the force-latest dist-tag fix

### DIFF
--- a/.github/workflows/pr-package.yml
+++ b/.github/workflows/pr-package.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   pr-package:
-    uses: alchemy-run/actions/.github/workflows/pr-package.yml@45c20065c654cb378d02a707427405a1ad9ac3f3 # main
+    uses: alchemy-run/actions/.github/workflows/pr-package.yml@7353f5e478ca98f88a03400b91cd96707711de64 # main
     with:
       # The bun workspace includes `distilled/packages/*` from the
       # distilled submodule, so the publish jobs must check it out.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ permissions:
 
 jobs:
   release:
-    uses: alchemy-run/actions/.github/workflows/release.yml@45c20065c654cb378d02a707427405a1ad9ac3f3 # main
+    uses: alchemy-run/actions/.github/workflows/release.yml@7353f5e478ca98f88a03400b91cd96707711de64 # main
     with:
       # The bun workspace includes `distilled/packages/*` from the
       # distilled submodule, so consumer checkouts must fetch it.


### PR DESCRIPTION
## Summary

Bumps the pinned `alchemy-run/actions` ref (both `release.yml` and `pr-package.yml`) to pick up [alchemy-run/actions#6](https://github.com/alchemy-run/actions/pull/6).

Our release workflow runs with `force-latest: true` by default, and the old publish script tagged force-latest publishes with `latest` **only** — the channel tag never moved. Every default beta release therefore left `next` stranded on the previous beta. Current npm state: `latest=2.0.0-beta.68`, `next=2.0.0-beta.67`, which makes the CLI version check tell beta.68 users to "upgrade" to beta.67.

With the fix, force-latest is additive: a beta publish always moves `next`, then adds `latest` on top, so both tags track the newest release.

Note: the stale tag on npm can be repaired immediately (without waiting for the next release) via:

```
npm dist-tag add alchemy@2.0.0-beta.68 next
```

## Test plan

- [ ] Next release run: confirm `npm view alchemy dist-tags` shows `next` and `latest` on the same new version

Made with [Cursor](https://cursor.com)