### PR TITLE
docs(website): capitalize Alchemy in browser tab titles

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -373,7 +373,7 @@ export default defineConfig({
         !page.endsWith(".mdx"),
     }),
     starlight({
-      title: "alchemy",
+      title: "Alchemy",
       favicon: "/favicon.svg",
       customCss: ["./src/styles/global.css", "./src/styles/custom.css"],
       components: {

--- a/website/src/layouts/Marketing.astro
+++ b/website/src/layouts/Marketing.astro
@@ -29,7 +29,7 @@ interface Props {
 
 const props = Astro.props;
 const fm = props.frontmatter ?? {};
-const title = props.title ?? fm.title ?? "alchemy";
+const title = props.title ?? fm.title ?? "Alchemy";
 const description = props.description ?? fm.description;
 const image = props.image ?? fm.image;
 

--- a/website/src/pages/index.mdx
+++ b/website/src/pages/index.mdx
@@ -1,6 +1,6 @@
 ---
 layout: ../layouts/Marketing.astro
-title: "alchemy — zero to production. TypeScript IaC on Effect."
+title: "Alchemy — zero to production. TypeScript IaC on Effect."
 description: "Alchemy is the IaC tool that's actually TypeScript. Stand up your whole cloud in one program, type-check the IAM, hot-reload it locally, run tests against the real cloud, preview every PR, and ship dashboards & alarms in the same file."
 ---
 

--- a/website/src/pages/privacy.mdx
+++ b/website/src/pages/privacy.mdx
@@ -1,6 +1,6 @@
 ---
 layout: ../layouts/Marketing.astro
-title: "Privacy & Telemetry — alchemy"
+title: "Privacy & Telemetry — Alchemy"
 description: What data the Alchemy CLI and Cloudflare State Store collect, where it goes, and how to opt out.
 ---
 import "../styles/privacy.css";


### PR DESCRIPTION
Capitalize "Alchemy" in browser tab titles.

```diff
-      title: "alchemy",
+      title: "Alchemy",
```

- Starlight site title (`APIs | Alchemy`)
- Homepage frontmatter (`Alchemy — zero to production…`)
- Privacy page frontmatter and the `Marketing.astro` title fallback

Visible wordmarks and CLI command references stay lowercase.
