### PR TITLE
fix(ci): bump actions pin — dist-tag moves now survive OIDC-only auth

### DIFF
--- a/.github/workflows/pr-package.yml
+++ b/.github/workflows/pr-package.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   pr-package:
-    uses: alchemy-run/actions/.github/workflows/pr-package.yml@7353f5e478ca98f88a03400b91cd96707711de64 # main
+    uses: alchemy-run/actions/.github/workflows/pr-package.yml@2ba4aab624950338968f1598bdfe34804244a77a # main
     with:
       # The bun workspace includes `distilled/packages/*` from the
       # distilled submodule, so the publish jobs must check it out.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ permissions:
 
 jobs:
   release:
-    uses: alchemy-run/actions/.github/workflows/release.yml@7353f5e478ca98f88a03400b91cd96707711de64 # main
+    uses: alchemy-run/actions/.github/workflows/release.yml@2ba4aab624950338968f1598bdfe34804244a77a # main
     with:
       # The bun workspace includes `distilled/packages/*` from the
       # distilled submodule, so consumer checkouts must fetch it.


### PR DESCRIPTION
## Summary

Picks up [alchemy-run/actions#7](https://github.com/alchemy-run/actions/pull/7), fixing the failure in [release run #200](https://github.com/alchemy-run/alchemy/actions/runs/31073219472).

What happened: npm OIDC trusted publishing only covers `npm publish`, not `npm dist-tag add` ([npm/cli#8547](https://github.com/npm/cli/issues/8547)). With force-latest, the previous script published `alchemy@2.0.0-beta.69` under `next`, then failed E401 trying to add `latest` — killing wave-1 and skipping wave-2, so `@alchemy.run/better-auth` and `@alchemy.run/pr-package` never published beta.69. Current tags: `latest=2.0.0-beta.68`, `next=2.0.0-beta.69`.

With the new pin, force-latest publishes under `latest` directly (OIDC-covered) and moves `next` as a follow-up that uses the optional `NPM_TOKEN` secret, or emits a workflow warning with the manual command when the secret is absent — the release no longer fails either way.

## Follow-up for maintainers

- [ ] Add an `NPM_TOKEN` repo secret (granular access token, read/write on `alchemy`, `@alchemy.run/better-auth`, `@alchemy.run/pr-package`) so `next` moves automatically; `secrets: inherit` already passes it through
- [ ] Either repair beta.69 by hand (`npm dist-tag add alchemy@2.0.0-beta.69 latest`) or just cut the next release after merging — it will supersede beta.69 on both tags (note: better-auth/pr-package have no beta.69 on npm)

Made with [Cursor](https://cursor.com)