### PR TITLE
chore(ci): never suggest a downgrade in the version check

### DIFF
--- a/packages/alchemy/src/Cli/checkVersion.ts
+++ b/packages/alchemy/src/Cli/checkVersion.ts
@@ -25,23 +25,67 @@ interface VersionCheckCache {
   distTags?: Record<string, string>;
 }
 
+const parseVersion = (v: string) => {
+  const [core = "", pre] = v.split("-", 2);
+  return {
+    core: core.split(".").map(Number),
+    pre:
+      pre === undefined
+        ? []
+        : pre.split(".").map((id) => (/^\d+$/.test(id) ? Number(id) : id)),
+  };
+};
+
+/**
+ * Semver precedence (semver.org §11): negative when a < b, positive when
+ * a > b. Enough of the spec for registry versions — numeric core, dotted
+ * prerelease identifiers, release > prerelease.
+ */
+const compareVersions = (a: string, b: string): number => {
+  const pa = parseVersion(a);
+  const pb = parseVersion(b);
+  for (let i = 0; i < 3; i++) {
+    const d = (pa.core[i] ?? 0) - (pb.core[i] ?? 0);
+    if (d !== 0) return d;
+  }
+  // A release outranks any prerelease of the same core.
+  if (pa.pre.length === 0 || pb.pre.length === 0) {
+    return pb.pre.length - pa.pre.length;
+  }
+  for (let i = 0; i < Math.max(pa.pre.length, pb.pre.length); i++) {
+    const x = pa.pre[i];
+    const y = pb.pre[i];
+    if (x === undefined) return -1;
+    if (y === undefined) return 1;
+    if (x === y) continue;
+    if (typeof x === "number" && typeof y === "number") return x - y;
+    // Numeric identifiers rank below alphanumeric ones.
+    if (typeof x === "number") return -1;
+    if (typeof y === "number") return 1;
+    return x < y ? -1 : 1;
+  }
+  return 0;
+};
+
 /**
  * Pick the dist-tag matching the current channel. For pre-release versions
- * like `2.0.0-beta.33`, npm's `latest` tag points at the most recent stable
- * release — not the newest beta — so we match the prerelease identifier
- * (`beta`, `next`, etc.), falling back through `next` → `latest`.
+ * like `2.0.0-beta.33`, we match the prerelease identifier (`beta`, `next`,
+ * etc.), falling back through `next` → `latest`. Because our releases can
+ * force prereleases onto `latest`, it may run ahead of the channel tag —
+ * in that case offer `latest` instead of the channel pick.
  */
 const pickDistTag = (
   current: string,
   distTags: Record<string, string>,
 ): string | undefined => {
   const pre = current.split("-", 2)[1];
-  if (pre) {
-    const id = pre.split(".")[0];
-    if (id && distTags[id]) return distTags[id];
-    if (distTags.next) return distTags.next;
-  }
-  return distTags.latest;
+  if (!pre) return distTags.latest;
+  const id = pre.split(".")[0];
+  const channelPick = (id && distTags[id]) || distTags.next;
+  const { latest } = distTags;
+  if (channelPick === undefined) return latest;
+  if (latest === undefined) return channelPick;
+  return compareVersions(latest, channelPick) > 0 ? latest : channelPick;
 };
 
 const readCache = Effect.fn(
@@ -123,7 +167,10 @@ export const checkLatestVersion = Effect.gen(function* () {
 
   const current = packageJson.version;
   const latest = pickDistTag(current, distTags);
-  if (latest === undefined || latest === current) return;
+  // Strictly newer only: a dist-tag pointing at (or behind) the installed
+  // version — e.g. a stale `next` after a force-latest release — must not
+  // prompt a "downgrade".
+  if (latest === undefined || compareVersions(latest, current) <= 0) return;
 
   const installCmd =
     typeof process !== "undefined" && (process as any).versions?.bun
@@ -140,4 +187,4 @@ export const checkLatestVersion = Effect.gen(function* () {
 }).pipe(Effect.catch(() => Effect.void));
 
 // Exported for tests.
-export const _internal = { pickDistTag };
+export const _internal = { pickDistTag, compareVersions };

--- a/packages/alchemy/test/Cli/checkVersion.test.ts
+++ b/packages/alchemy/test/Cli/checkVersion.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "alchemy-test";
 
 import { _internal } from "../../src/Cli/checkVersion";
 
-const { pickDistTag } = _internal;
+const { pickDistTag, compareVersions } = _internal;
 
 describe("pickDistTag", () => {
   // Real shape returned by https://registry.npmjs.org/-/package/alchemy/dist-tags
@@ -34,5 +34,44 @@ describe("pickDistTag", () => {
 
   test("falls back to latest when no prerelease channel exists", () => {
     expect(pickDistTag("2.0.0-beta.30", { latest: "0.93.7" })).toBe("0.93.7");
+  });
+
+  test("offers latest when it runs ahead of the channel tag (force-latest releases)", () => {
+    // Regression: a force-latest beta release left `next` stranded behind
+    // `latest` (latest=beta.68, next=beta.67).
+    expect(
+      pickDistTag("2.0.0-beta.67", {
+        latest: "2.0.0-beta.68",
+        next: "2.0.0-beta.67",
+      }),
+    ).toBe("2.0.0-beta.68");
+  });
+});
+
+describe("compareVersions", () => {
+  test("orders prerelease numbers numerically, not lexically", () => {
+    expect(compareVersions("2.0.0-beta.68", "2.0.0-beta.67")).toBeGreaterThan(
+      0,
+    );
+    expect(compareVersions("2.0.0-beta.9", "2.0.0-beta.10")).toBeLessThan(0);
+  });
+
+  test("release outranks its prereleases", () => {
+    expect(compareVersions("2.0.0", "2.0.0-rc.1")).toBeGreaterThan(0);
+    expect(compareVersions("2.0.0-rc.1", "2.0.0")).toBeLessThan(0);
+  });
+
+  test("core versions compare numerically", () => {
+    expect(compareVersions("0.93.7", "0.93.6")).toBeGreaterThan(0);
+    expect(compareVersions("0.93.7", "2.0.0-beta.1")).toBeLessThan(0);
+  });
+
+  test("equal versions compare as 0 (stale tag must not warn)", () => {
+    expect(compareVersions("2.0.0-beta.68", "2.0.0-beta.68")).toBe(0);
+  });
+
+  test("alphanumeric prerelease identifiers rank above numeric ones", () => {
+    expect(compareVersions("2.0.0-rc.1", "2.0.0-beta.99")).toBeGreaterThan(0);
+    expect(compareVersions("2.0.0-beta.1", "2.0.0-1")).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary

A user deploying on `2.0.0-beta.68` was told:

> alchemy 2.0.0-beta.67 is available (you're on 2.0.0-beta.68). Run `pnpm add alchemy@2.0.0-beta.67` to upgrade.

`checkLatestVersion` compared the picked dist-tag against the installed version with `!==`, so *any* drift — including a tag pointing at an older version — triggered the upgrade prompt. The drift itself came from the release pipeline (fixed in [alchemy-run/actions#6](https://github.com/alchemy-run/actions/pull/6) / [#7](https://github.com/alchemy-run/actions/pull/7)), but the CLI should be robust to it regardless.

Changes to `checkVersion.ts`:

- Add a small semver precedence comparator (numeric core, dotted prerelease identifiers, release > prerelease) — no new dependency.
- Warn only when the picked version is **strictly newer** than the installed one.
- In `pickDistTag`, offer `latest` when it runs ahead of the channel pick: our releases force prereleases onto `latest`, so `latest` can legitimately lead `next` (that was exactly the beta.68/beta.67 state).

All existing `pickDistTag` test expectations are unchanged; new tests cover the incident scenario and the comparator (numeric prerelease ordering, release vs prerelease, equal versions).

## Test plan

- [x] Standalone run of the pure functions: 16/16 cases pass, including the 5 pre-existing expectations
- [ ] CI: `packages/alchemy/test/Cli/checkVersion.test.ts`

Made with [Cursor](https://cursor.com)