### PR TITLE
fix(cloudflare/queues): map consumer settings to the local broker's field names

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -36,6 +36,7 @@ import {
   LocalRuntimeState,
   localStorageDirectory,
 } from "../LocalRuntime.ts";
+import type { ConsumerSettings } from "../Queues/Consumer.ts";
 import type { WorkerAssetsConfig, WorkerProps } from "../Workers/Worker.ts";
 import { readAssetsConfigFiles } from "./Assets.ts";
 import { getCompatibility } from "./Compatibility.ts";
@@ -126,6 +127,25 @@ export const LocalWorkerProvider = () =>
         }
       >();
 
+      // ConsumerSettings speaks the Cloudflare API's dialect (batchSize,
+      // maxWaitTimeMs in milliseconds); the runtime's QueueConsumer speaks
+      // wrangler's (maxBatchSize, maxBatchTimeout in seconds). Map
+      // explicitly — a spread silently drops the mismatched fields.
+      const toRuntimeConsumerSettings = (
+        settings: ConsumerSettings | undefined,
+      ): Pick<
+        RuntimeQueueConsumer,
+        "maxBatchSize" | "maxBatchTimeout" | "maxRetries" | "retryDelay"
+      > => ({
+        maxBatchSize: settings?.batchSize,
+        maxBatchTimeout:
+          settings?.maxWaitTimeMs !== undefined
+            ? settings.maxWaitTimeMs / 1000
+            : undefined,
+        maxRetries: settings?.maxRetries,
+        retryDelay: settings?.retryDelay,
+      });
+
       const getQueueConsumers = Effect.fn(function* (scriptName: string) {
         const consumers: RuntimeQueueConsumer[] = [];
         for (const consumer of MutableHashMap.values(
@@ -146,7 +166,7 @@ export const LocalWorkerProvider = () =>
               consumers.push({
                 queueName: consumer.queueName,
                 deadLetterQueue: consumer.deadLetterQueue,
-                ...consumer.settings,
+                ...toRuntimeConsumerSettings(consumer.settings),
                 pull: {
                   queueId: consumer.queueId,
                   accountId: consumer.accountId,
@@ -162,7 +182,7 @@ export const LocalWorkerProvider = () =>
               consumers.push({
                 queueName: queue.queueName,
                 deadLetterQueue: consumer.deadLetterQueue,
-                ...consumer.settings,
+                ...toRuntimeConsumerSettings(consumer.settings),
               });
             } else {
               return yield* Effect.die(`Queue ${consumer.queueId} not found`);

--- a/packages/alchemy/test/Cloudflare/Queues/Queue.local.test.ts
+++ b/packages/alchemy/test/Cloudflare/Queues/Queue.local.test.ts
@@ -116,6 +116,71 @@ test.provider(
 );
 
 /**
+ * Consumer `settings` reach the local broker with the field names and units
+ * the runtime expects (`batchSize` → `maxBatchSize`, `maxWaitTimeMs` (ms) →
+ * `maxBatchTimeout` (s)). With `batchSize: 2` and a 2s wait, five quick
+ * sends must arrive in batches of at most 2 — under the broker's defaults
+ * (batch of 5, 1s flush) they'd land as one batch of 5. The trailing
+ * single-message batch flushing within the poll window pins the ms→s
+ * conversion: an unconverted 2000 would stall it for over half an hour.
+ */
+test.provider(
+  "local consumer settings control broker batch size and flush timeout",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const deployed = yield* stack.deploy(
+        Effect.gen(function* () {
+          const queue = yield* Cloudflare.Queues.Queue("BatchSettingsQueue");
+          const worker = yield* Cloudflare.Worker("queue-batch-local-worker", {
+            main: pathe.resolve(
+              import.meta.dirname,
+              "fixtures/queue-local-worker.ts",
+            ),
+            env: { QUEUE: queue },
+          });
+          yield* Cloudflare.Queues.Consumer("BatchSettingsConsumer", {
+            queueId: queue.queueId,
+            scriptName: worker.workerName,
+            settings: { batchSize: 2, maxWaitTimeMs: 2000 },
+          });
+          return { queue, worker };
+        }),
+      );
+
+      expect(deployed.queue.queueId).toMatch(/^dev:/);
+
+      for (let i = 0; i < 5; i++) {
+        yield* getJsonReady(`${deployed.worker.url}/send?text=batch-${i}`);
+      }
+
+      // All five arrive: two full batches immediately, the leftover after
+      // the 2s flush timeout.
+      const received = yield* getJsonReady(
+        `${deployed.worker.url}/received`,
+      ).pipe(
+        Effect.map((body) => (body as { received: string[] }).received),
+        Effect.repeat({
+          schedule: Schedule.spaced("500 millis"),
+          until: (received) => received.length >= 5,
+          times: 30,
+        }),
+      );
+      expect(received.length).toBe(5);
+
+      const { batches } = (yield* getJsonReady(
+        `${deployed.worker.url}/batches`,
+      )) as { batches: number[] };
+      expect(Math.max(...batches)).toBe(2);
+      expect(batches.reduce((a, b) => a + b, 0)).toBe(5);
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 120_000 },
+);
+
+/**
  * Regression test for #988: a consumer configured with a dead-letter queue
  * that the worker does not itself consume. The DLQ binding resolves through
  * the local runtime's registry proxy; the worker previously failed to start

--- a/packages/alchemy/test/Cloudflare/Queues/fixtures/queue-local-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Queues/fixtures/queue-local-worker.ts
@@ -16,6 +16,7 @@ interface MessageLike {
 }
 
 const received: string[] = [];
+const batches: number[] = [];
 
 export default {
   fetch: async (request: Request, env: Env) => {
@@ -39,9 +40,13 @@ export default {
     if (url.pathname === "/received") {
       return Response.json({ received });
     }
+    if (url.pathname === "/batches") {
+      return Response.json({ batches });
+    }
     return new Response("not found", { status: 404 });
   },
   queue: async (batch: { messages: MessageLike[] }) => {
+    batches.push(batch.messages.length);
     for (const message of batch.messages) {
       received.push(String(message.body));
     }


### PR DESCRIPTION
In local dev, `getQueueConsumers` spread `ConsumerSettings` straight into the runtime's `QueueConsumer`, but the two speak different dialects — `batchSize`/`maxWaitTimeMs` (ms) vs `maxBatchSize`/`maxBatchTimeout` (seconds) — so the local broker silently ignored configured batch settings and ran on its defaults (batch of 5, 1s flush).

```ts
// before: batchSize/maxWaitTimeMs vanish into unknown fields
...consumer.settings,

// after: explicit mapping, ms → s
maxBatchSize: settings?.batchSize,
maxBatchTimeout: settings?.maxWaitTimeMs !== undefined
  ? settings.maxWaitTimeMs / 1000
  : undefined,
```

The conversion also matters for validity: the runtime rejects `maxBatchTimeout` outside 0–60 seconds, so a raw ms value would fail worker startup.

New test in `Queue.local.test.ts` deploys a consumer with `batchSize: 2, maxWaitTimeMs: 2000`, sends 5 messages, and asserts delivery in batches of at most 2 with the leftover flushing on the 2s timeout — it fails against the old spread (one batch of 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
