### PR TITLE
fix(dev): configured dev ports must not cascade on restart or be IPv6-shadowed on localhost

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/Sources/Vite.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Sources/Vite.ts
@@ -13,8 +13,9 @@ import {
   viteBuildOutputPlugin,
   type ViteBuildOutput,
 } from "../../../Bundle/Vite.ts";
+import { viteSupportsPortZero } from "@alchemy.run/cloudflare-runtime/core/internal/Port";
 import { hashDirectory, type MemoOptions } from "../../../Command/Memo.ts";
-import { initialCwd } from "../../../Util/Node.ts";
+import { findAvailablePort, initialCwd } from "../../../Util/Node.ts";
 import { sha256Object } from "../../../Util/sha256.ts";
 import { readAssets } from "../Assets.ts";
 import type { SourceDevHandle, SourceProvider } from "../Source.ts";
@@ -104,27 +105,48 @@ export const viteDev = (
   pluginOptions: CloudflareVitePluginOptions,
   serverOptions: vite.ServerOptions,
 ) =>
-  Effect.acquireRelease(
-    ConsoleService.consoleWith((console) =>
-      Effect.promise(async () => {
-        process.env[ALCHEMY_CLOUDFLARE_VITE_INJECTED] = "1";
-        const vite = await loadVite(rootDir);
-        const devServer = await vite.createServer({
-          root: rootDir,
-          define: getDefine(env),
-          plugins: [cloudflare(pluginOptions)],
-          server: serverOptions,
-          customLogger: makeViteLogger(console),
-        });
-        await devServer.listen();
-        return devServer;
-      }),
-    ),
-    (devServer) =>
-      Effect.promise(async () => {
-        await devServer.close();
-      }),
-  );
+  Effect.gen(function* () {
+    yield* Effect.sync(() => {
+      process.env[ALCHEMY_CLOUDFLARE_VITE_INJECTED] = "1";
+    });
+    const vite = yield* Effect.promise(() => loadVite(rootDir));
+    // `port: 0` is a true OS-assigned random port on Vite >= 8.2.1
+    // (vitejs/vite#23158); older Vite treats it as "no port given" and
+    // hunts upward from the 5173 default — colliding with (or
+    // IPv6-shadowing) user-facing dev ports. Substitute a probed
+    // ephemeral port there; `strictPort: false` handles the small
+    // probe→bind race by moving to the next ephemeral port.
+    const server =
+      serverOptions.port === 0 && !viteSupportsPortZero(vite.version)
+        ? {
+            ...serverOptions,
+            port: yield* findAvailablePort(
+              typeof serverOptions.host === "string"
+                ? serverOptions.host
+                : undefined,
+            ).pipe(Effect.orDie),
+          }
+        : serverOptions;
+    return yield* Effect.acquireRelease(
+      ConsoleService.consoleWith((console) =>
+        Effect.promise(async () => {
+          const devServer = await vite.createServer({
+            root: rootDir,
+            define: getDefine(env),
+            plugins: [cloudflare(pluginOptions)],
+            server,
+            customLogger: makeViteLogger(console),
+          });
+          await devServer.listen();
+          return devServer;
+        }),
+      ),
+      (devServer) =>
+        Effect.promise(async () => {
+          await devServer.close();
+        }),
+    );
+  });
 
 /**
  * Run a production Vite build in a child process rooted at the project

--- a/packages/alchemy/src/Cloudflare/Workers/ViteChildRunner.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/ViteChildRunner.ts
@@ -71,11 +71,11 @@ const program = Effect.scoped(
     );
     const source = config.source;
     const viteHost = "127.0.0.1";
-    // TODO(BlankParticle): replace this probe with `port: 0` once the Vite fix
-    // is released: https://github.com/vitejs/vite/pull/23158
-    // Vite currently treats `port: 0` as an absent value and falls back to
-    // its default port. Probe an ephemeral port ourselves until the fixed
-    // Vite release is available.
+    // TODO(vite>=8.2.1): replace this probe with `port: 0` — the Vite fix
+    // (https://github.com/vitejs/vite/pull/23158) shipped in Vite 8.2.1.
+    // Gated on the supported Vite floor: this runner drives the PROJECT's
+    // Vite install, and on older Vite `port: 0` is treated as absent and
+    // falls back to the 5173 default-port hunt.
     // `strictPort: false` still handles the small race between releasing the
     // probe socket and Vite binding the selected port.
     const vitePort = source ? undefined : yield* findAvailablePort(viteHost);

--- a/packages/alchemy/src/Cloudflare/Workers/ViteChildRunner.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/ViteChildRunner.ts
@@ -13,7 +13,6 @@ import {
 import { CloudflareAuth } from "../Auth/AuthProvider.ts";
 import * as Credentials from "../Credentials.ts";
 import * as RpcServerEnvironment from "../../Local/RpcServerEnvironment.ts";
-import { findAvailablePort } from "../../Util/Node.ts";
 import { PlatformServices, runMain } from "../../Util/PlatformServices.ts";
 import { materializeRuntimeBindings } from "./RuntimeBindings.ts";
 import { loadSource, SourceProviderError } from "./Source.ts";
@@ -71,14 +70,10 @@ const program = Effect.scoped(
     );
     const source = config.source;
     const viteHost = "127.0.0.1";
-    // TODO(vite>=8.2.1): replace this probe with `port: 0` — the Vite fix
-    // (https://github.com/vitejs/vite/pull/23158) shipped in Vite 8.2.1.
-    // Gated on the supported Vite floor: this runner drives the PROJECT's
-    // Vite install, and on older Vite `port: 0` is treated as absent and
-    // falls back to the 5173 default-port hunt.
-    // `strictPort: false` still handles the small race between releasing the
-    // probe socket and Vite binding the selected port.
-    const vitePort = source ? undefined : yield* findAvailablePort(viteHost);
+    // `viteDev` resolves `port: 0` per the loaded Vite: a true OS-assigned
+    // random port on Vite >= 8.2.1 (vitejs/vite#23158), a probed ephemeral
+    // port on older Vite.
+    const vitePort = source ? undefined : 0;
     const url = source
       ? yield* loadSource(source.descriptor).pipe(
           // `loadSource` is typed against the full `SourceServices` union

--- a/packages/cloudflare-frameworks/src/astro/Astro.ts
+++ b/packages/cloudflare-frameworks/src/astro/Astro.ts
@@ -274,7 +274,13 @@ export const make = <TargetConfig = unknown>(
           const root = yield* resolveRoot(devOptions?.root);
           const target = yield* resolveTarget(root);
           const astro = yield* loadAstro(root);
-          const config = makeConfig(root, target, { port: devOptions?.port });
+          // Vite (under Astro) treats `port: 0` as "no port given" and hunts
+          // upward from the default (4321), which can collide with (or
+          // IPv6-shadow) other dev servers' user-facing ports. Allocate a
+          // real ephemeral port instead.
+          const port =
+            devOptions?.port || (yield* FrameworkCore.findEphemeralPort());
+          const config = makeConfig(root, target, { port });
           const server = yield* Effect.acquireRelease(
             Effect.tryPromise({
               try: async () => await astro.dev(config),

--- a/packages/cloudflare-frameworks/src/astro/Astro.ts
+++ b/packages/cloudflare-frameworks/src/astro/Astro.ts
@@ -274,12 +274,28 @@ export const make = <TargetConfig = unknown>(
           const root = yield* resolveRoot(devOptions?.root);
           const target = yield* resolveTarget(root);
           const astro = yield* loadAstro(root);
-          // Vite (under Astro) treats `port: 0` as "no port given" and hunts
-          // upward from the default (4321), which can collide with (or
-          // IPv6-shadow) other dev servers' user-facing ports. Allocate a
-          // real ephemeral port instead.
-          const port =
-            devOptions?.port || (yield* FrameworkCore.findEphemeralPort());
+          // `port: 0` (true OS-assigned) when the Vite under Astro is
+          // >= 8.2.1, probed ephemeral port otherwise — see
+          // `resolveViteDevPort`. Astro's dev server runs on Astro's own
+          // Vite dependency, so the version is resolved from the astro
+          // package's directory, not the project root.
+          const viteVersion =
+            yield* FrameworkCore.resolveProjectPackageDirectory(
+              root,
+              "astro",
+            ).pipe(
+              Effect.flatMap((astroDirectory) =>
+                FrameworkCore.resolveInstalledPackageVersion(
+                  astroDirectory,
+                  "vite",
+                ),
+              ),
+              Effect.orElseSucceed(() => undefined),
+            );
+          const port = yield* FrameworkCore.resolveViteDevPort(
+            viteVersion,
+            devOptions?.port,
+          );
           const config = makeConfig(root, target, { port });
           const server = yield* Effect.acquireRelease(
             Effect.tryPromise({

--- a/packages/cloudflare-frameworks/src/core/DevPort.ts
+++ b/packages/cloudflare-frameworks/src/core/DevPort.ts
@@ -1,0 +1,57 @@
+import * as Effect from "effect/Effect";
+import * as NodeNet from "node:net";
+import { FrameworkError } from "./Framework.ts";
+
+/**
+ * Allocate a concrete ephemeral port for a framework dev server.
+ *
+ * Frameworks (and the listeners under them — Vite, listhen/get-port-please,
+ * `next dev`) treat `port: 0` as "no port given" and fall back to hunting
+ * upward from their well-known default (3000/4321/5173). Those defaults are
+ * exactly where users configure their `alchemy dev` proxy ports, so a
+ * framework child hunting from its default can land on — or IPv6-shadow —
+ * a port the user is browsing. Probing a real ephemeral port from the OS
+ * keeps dev servers out of user-visible port ranges entirely.
+ *
+ * The tiny probe→listen race is handled by the caller passing the port with
+ * non-strict semantics: on a genuine collision the framework moves to the
+ * next port, still in the ephemeral range.
+ */
+export const findEphemeralPort = (
+  host = "127.0.0.1",
+): Effect.Effect<number, FrameworkError> =>
+  Effect.callback<number, FrameworkError>((resume) => {
+    const server = NodeNet.createServer();
+    server.unref();
+    server.once("error", (error) =>
+      resume(
+        Effect.fail(
+          new FrameworkError({
+            message: "Failed to allocate an ephemeral dev-server port",
+            cause: error,
+          }),
+        ),
+      ),
+    );
+    server.listen({ port: 0, host, exclusive: true }, () => {
+      const address = server.address();
+      const port =
+        typeof address === "object" && address !== null
+          ? address.port
+          : undefined;
+      server.close(() => {
+        if (port !== undefined) {
+          resume(Effect.succeed(port));
+        } else {
+          resume(
+            Effect.fail(
+              new FrameworkError({
+                message: "Failed to allocate an ephemeral dev-server port",
+              }),
+            ),
+          );
+        }
+      });
+    });
+    return Effect.sync(() => server.close());
+  });

--- a/packages/cloudflare-frameworks/src/core/DevPort.ts
+++ b/packages/cloudflare-frameworks/src/core/DevPort.ts
@@ -3,15 +3,64 @@ import * as NodeNet from "node:net";
 import { FrameworkError } from "./Framework.ts";
 
 /**
- * Allocate a concrete ephemeral port for a framework dev server.
+ * Whether the given Vite version treats `server.port: 0` as a true
+ * OS-assigned random port (vitejs/vite#23158, shipped in Vite 8.2.1).
+ * Older Vite treats `0` as "no port given" and hunts upward from its 5173
+ * default.
  *
- * Vite < 8.2.1 treats `port: 0` as "no port given" and falls back to hunting
- * upward from its well-known default (5173, or the framework's own — 4321
- * for Astro). Those defaults are exactly where users configure their
- * `alchemy dev` proxy ports, so a framework child hunting from its default
- * can land on — or IPv6-shadow — a port the user is browsing. Probing a
- * real ephemeral port from the OS keeps dev servers out of user-visible
- * port ranges entirely.
+ * Framework core is deliberately platform-neutral (see the decoupling
+ * test), so this is a local definition — keep in sync with the copy in
+ * `@alchemy.run/cloudflare-runtime`'s `core/internal/Port.ts`, which
+ * serves that package's own Vite plugin consumers.
+ */
+export const viteSupportsPortZero = (
+  version: string | null | undefined,
+): boolean => {
+  if (typeof version !== "string") return false;
+  const match = /^(\d+)\.(\d+)\.(\d+)/.exec(version);
+  if (!match) return false;
+  const major = Number(match[1]);
+  const minor = Number(match[2]);
+  const patch = Number(match[3]);
+  return (
+    major > 8 || (major === 8 && (minor > 2 || (minor === 2 && patch >= 1)))
+  );
+};
+
+/**
+ * Resolve the port a Vite-based framework dev server should bind.
+ *
+ * - An explicitly configured port wins.
+ * - On Vite >= 8.2.1 (vitejs/vite#23158) `port: 0` is a true OS-assigned
+ *   random port — race-free at bind — so it is preferred whenever the
+ *   loaded Vite's `version` export says it's supported. Callers drive the
+ *   PROJECT's Vite install, so this is a runtime check, not a dependency
+ *   floor.
+ * - Older Vite treats `0` as "no port given" and hunts upward from its
+ *   well-known default (5173, or the framework's own — 4321 for Astro) —
+ *   exactly where users configure their `alchemy dev` proxy ports, so a
+ *   hunting dev server can land on (or IPv6-shadow) a port the user is
+ *   browsing. Fall back to {@link findEphemeralPort} there.
+ *
+ * TODO(vite>=8.2.1): delete the fallback (and `findEphemeralPort`) once
+ * the supported Vite floor reaches 8.2.1 in user projects. Nuxt's chain
+ * (nitro → listhen → get-port-please) already accepts `port: 0` — though
+ * it performs the same probe-and-release internally (`getRandomPort`).
+ * Next.js owns its listener and truly `listen(0)`s.
+ */
+export const resolveViteDevPort = (
+  viteVersion: string | null | undefined,
+  explicitPort?: number | undefined,
+): Effect.Effect<number, FrameworkError> =>
+  explicitPort
+    ? Effect.succeed(explicitPort)
+    : viteSupportsPortZero(viteVersion)
+      ? Effect.succeed(0)
+      : findEphemeralPort();
+
+/**
+ * Allocate a concrete ephemeral port for a framework dev server whose
+ * listener cannot take `port: 0` (see {@link resolveViteDevPort}).
  *
  * This is deliberately a hint, not a claim: the probe→listen window is a
  * TOCTOU race, so every caller passes the port with non-strict semantics
@@ -19,17 +68,6 @@ import { FrameworkError } from "./Framework.ts";
  * the ephemeral range) and wires the proxy to the URL the framework
  * REPORTS after binding, never to the probed number — a lost race can
  * shift a dev server by one port; it cannot serve the wrong app.
- *
- * TODO(vite>=8.2.1): vitejs/vite#23158 (shipped in Vite 8.2.1) makes
- * `port: 0` a true OS-assigned random port. Once the supported Vite floor
- * is >= 8.2.1 (the frameworks drive the PROJECT's Vite install, so this is
- * gated on what user projects run, not on our own dependency), the
- * Vite-based dev servers (SvelteKit, Waku, Octane, Astro, and the plain
- * Vite child in alchemy) should pass `port: 0` and this helper should be
- * deleted. Nuxt's chain (nitro → listhen → get-port-please) already
- * accepts `port: 0` — though it performs this same probe-and-release
- * internally (`getRandomPort`), so switching it is a simplification, not
- * a safety change. Next.js owns its listener and truly `listen(0)`s.
  */
 export const findEphemeralPort = (
   host = "127.0.0.1",

--- a/packages/cloudflare-frameworks/src/core/DevPort.ts
+++ b/packages/cloudflare-frameworks/src/core/DevPort.ts
@@ -5,17 +5,31 @@ import { FrameworkError } from "./Framework.ts";
 /**
  * Allocate a concrete ephemeral port for a framework dev server.
  *
- * Frameworks (and the listeners under them — Vite, listhen/get-port-please,
- * `next dev`) treat `port: 0` as "no port given" and fall back to hunting
- * upward from their well-known default (3000/4321/5173). Those defaults are
- * exactly where users configure their `alchemy dev` proxy ports, so a
- * framework child hunting from its default can land on — or IPv6-shadow —
- * a port the user is browsing. Probing a real ephemeral port from the OS
- * keeps dev servers out of user-visible port ranges entirely.
+ * Vite < 8.2.1 treats `port: 0` as "no port given" and falls back to hunting
+ * upward from its well-known default (5173, or the framework's own — 4321
+ * for Astro). Those defaults are exactly where users configure their
+ * `alchemy dev` proxy ports, so a framework child hunting from its default
+ * can land on — or IPv6-shadow — a port the user is browsing. Probing a
+ * real ephemeral port from the OS keeps dev servers out of user-visible
+ * port ranges entirely.
  *
- * The tiny probe→listen race is handled by the caller passing the port with
- * non-strict semantics: on a genuine collision the framework moves to the
- * next port, still in the ephemeral range.
+ * This is deliberately a hint, not a claim: the probe→listen window is a
+ * TOCTOU race, so every caller passes the port with non-strict semantics
+ * (on a genuine collision the framework moves to the next port, still in
+ * the ephemeral range) and wires the proxy to the URL the framework
+ * REPORTS after binding, never to the probed number — a lost race can
+ * shift a dev server by one port; it cannot serve the wrong app.
+ *
+ * TODO(vite>=8.2.1): vitejs/vite#23158 (shipped in Vite 8.2.1) makes
+ * `port: 0` a true OS-assigned random port. Once the supported Vite floor
+ * is >= 8.2.1 (the frameworks drive the PROJECT's Vite install, so this is
+ * gated on what user projects run, not on our own dependency), the
+ * Vite-based dev servers (SvelteKit, Waku, Octane, Astro, and the plain
+ * Vite child in alchemy) should pass `port: 0` and this helper should be
+ * deleted. Nuxt's chain (nitro → listhen → get-port-please) already
+ * accepts `port: 0` — though it performs this same probe-and-release
+ * internally (`getRandomPort`), so switching it is a simplification, not
+ * a safety change. Next.js owns its listener and truly `listen(0)`s.
  */
 export const findEphemeralPort = (
   host = "127.0.0.1",

--- a/packages/cloudflare-frameworks/src/core/Loader.ts
+++ b/packages/cloudflare-frameworks/src/core/Loader.ts
@@ -80,3 +80,27 @@ export const resolveProjectPackageDirectory = (
         cause,
       }),
   });
+
+/**
+ * Best-effort version of `packageName` as resolved from `fromDirectory`
+ * (`undefined` when unresolvable). Used to feature-detect a dependency of a
+ * project package — e.g. the Vite that Astro itself resolves — without
+ * loading the module.
+ */
+export const resolveInstalledPackageVersion = (
+  fromDirectory: string,
+  packageName: string,
+): Effect.Effect<string | undefined> =>
+  Effect.sync(() => {
+    try {
+      const require = createRequire(
+        NodePath.join(fromDirectory, "package.json"),
+      );
+      const pkg = require(`${packageName}/package.json`) as {
+        version?: unknown;
+      };
+      return typeof pkg.version === "string" ? pkg.version : undefined;
+    } catch {
+      return undefined;
+    }
+  });

--- a/packages/cloudflare-frameworks/src/core/index.ts
+++ b/packages/cloudflare-frameworks/src/core/index.ts
@@ -43,7 +43,7 @@ export type {
   DeployTargetServer,
   DeployTargetServices,
 } from "./DeployTarget.ts";
-export { findEphemeralPort } from "./DevPort.ts";
+export { findEphemeralPort, resolveViteDevPort } from "./DevPort.ts";
 export { Framework, FrameworkError } from "./Framework.ts";
 export type {
   FrameworkBuildOptions,
@@ -53,5 +53,6 @@ export type {
 export {
   loadProjectModule,
   ModuleLoadError,
+  resolveInstalledPackageVersion,
   resolveProjectPackageDirectory,
 } from "./Loader.ts";

--- a/packages/cloudflare-frameworks/src/core/index.ts
+++ b/packages/cloudflare-frameworks/src/core/index.ts
@@ -43,6 +43,7 @@ export type {
   DeployTargetServer,
   DeployTargetServices,
 } from "./DeployTarget.ts";
+export { findEphemeralPort } from "./DevPort.ts";
 export { Framework, FrameworkError } from "./Framework.ts";
 export type {
   FrameworkBuildOptions,

--- a/packages/cloudflare-frameworks/src/core/test/DevPort.test.ts
+++ b/packages/cloudflare-frameworks/src/core/test/DevPort.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { viteSupportsPortZero } from "../DevPort.ts";
+
+describe("viteSupportsPortZero", () => {
+  it("accepts 8.2.1 and later", () => {
+    expect(viteSupportsPortZero("8.2.1")).toBe(true);
+    expect(viteSupportsPortZero("8.2.2")).toBe(true);
+    expect(viteSupportsPortZero("8.3.0")).toBe(true);
+    expect(viteSupportsPortZero("9.0.0")).toBe(true);
+    expect(viteSupportsPortZero("9.0.0-beta.1")).toBe(true);
+  });
+
+  it("rejects versions before 8.2.1", () => {
+    expect(viteSupportsPortZero("8.2.0")).toBe(false);
+    expect(viteSupportsPortZero("8.1.9")).toBe(false);
+    expect(viteSupportsPortZero("7.2.6")).toBe(false);
+    expect(viteSupportsPortZero("6.0.0")).toBe(false);
+  });
+
+  it("rejects missing or malformed versions", () => {
+    expect(viteSupportsPortZero(undefined)).toBe(false);
+    expect(viteSupportsPortZero(null)).toBe(false);
+    expect(viteSupportsPortZero("")).toBe(false);
+    expect(viteSupportsPortZero("next")).toBe(false);
+  });
+});

--- a/packages/cloudflare-frameworks/src/nuxt/Nuxt.ts
+++ b/packages/cloudflare-frameworks/src/nuxt/Nuxt.ts
@@ -547,10 +547,12 @@ export const make: (
         ),
       );
     }
-    // `nuxt.server.listen` is listhen-backed, and listhen treats `0` as
-    // "no port given" — it hunts upward from 3000, colliding with (or
-    // IPv6-shadowing) user-facing `alchemy dev` proxy ports. Allocate a
-    // real ephemeral port instead.
+    // `nuxt.server.listen` is listhen-backed. listhen hunts upward from
+    // 3000 when NO port is given — colliding with (or IPv6-shadowing)
+    // user-facing `alchemy dev` proxy ports — while an explicit `port: 0`
+    // resolves to get-port-please's `getRandomPort`, the same
+    // probe-and-release `findEphemeralPort` does. Probe explicitly for
+    // uniformity with the Vite-based frameworks (see DevPort's TODO).
     const port =
       (devOptions?.port ?? options?.dev?.port) ||
       (yield* FrameworkCore.findEphemeralPort());

--- a/packages/cloudflare-frameworks/src/nuxt/Nuxt.ts
+++ b/packages/cloudflare-frameworks/src/nuxt/Nuxt.ts
@@ -547,7 +547,13 @@ export const make: (
         ),
       );
     }
-    const port = devOptions?.port ?? options?.dev?.port ?? 0;
+    // `nuxt.server.listen` is listhen-backed, and listhen treats `0` as
+    // "no port given" — it hunts upward from 3000, colliding with (or
+    // IPv6-shadowing) user-facing `alchemy dev` proxy ports. Allocate a
+    // real ephemeral port instead.
+    const port =
+      (devOptions?.port ?? options?.dev?.port) ||
+      (yield* FrameworkCore.findEphemeralPort());
     const listener = yield* Effect.acquireRelease(
       Effect.tryPromise({
         try: () => server.listen(port),

--- a/packages/cloudflare-frameworks/src/octane/Octane.ts
+++ b/packages/cloudflare-frameworks/src/octane/Octane.ts
@@ -42,6 +42,7 @@ export interface ResolvedOctaneConfigSlice {
 
 /** The structural slice of the project's `vite` module this package drives. */
 export interface OctaneViteModule {
+  readonly version?: string;
   readonly build: (config: Record<string, unknown>) => Promise<unknown>;
   readonly createServer: (
     config: Record<string, unknown>,
@@ -299,12 +300,12 @@ export const make: (
   const dev: Framework["Service"]["dev"] = Effect.fn(function* (devOptions) {
     const root = devOptions?.root ?? baseRoot;
     const vite = yield* loadVite(root);
-    // Vite treats `port: 0` as "no port given" and hunts upward from its
-    // default (5173), which can collide with (or IPv6-shadow) other dev
-    // servers' user-facing ports. Allocate a real ephemeral port instead.
-    const port =
-      (devOptions?.port ?? options?.dev?.port) ||
-      (yield* FrameworkCore.findEphemeralPort());
+    // `port: 0` (true OS-assigned) on Vite >= 8.2.1, probed ephemeral port
+    // on older Vite — see `resolveViteDevPort`.
+    const port = yield* FrameworkCore.resolveViteDevPort(
+      vite.version,
+      devOptions?.port ?? options?.dev?.port,
+    );
 
     const server = yield* Effect.acquireRelease(
       Effect.tryPromise({

--- a/packages/cloudflare-frameworks/src/octane/Octane.ts
+++ b/packages/cloudflare-frameworks/src/octane/Octane.ts
@@ -299,7 +299,12 @@ export const make: (
   const dev: Framework["Service"]["dev"] = Effect.fn(function* (devOptions) {
     const root = devOptions?.root ?? baseRoot;
     const vite = yield* loadVite(root);
-    const port = devOptions?.port ?? options?.dev?.port ?? 0;
+    // Vite treats `port: 0` as "no port given" and hunts upward from its
+    // default (5173), which can collide with (or IPv6-shadow) other dev
+    // servers' user-facing ports. Allocate a real ephemeral port instead.
+    const port =
+      (devOptions?.port ?? options?.dev?.port) ||
+      (yield* FrameworkCore.findEphemeralPort());
 
     const server = yield* Effect.acquireRelease(
       Effect.tryPromise({

--- a/packages/cloudflare-frameworks/src/sveltekit/SvelteKit.ts
+++ b/packages/cloudflare-frameworks/src/sveltekit/SvelteKit.ts
@@ -588,7 +588,12 @@ export const make: (
     );
     const vite = yield* loadVite(root);
     const config = yield* resolveViteConfig(root, adapter);
-    const port = devOptions?.port ?? options?.dev?.port;
+    // Without an explicit port Vite hunts upward from its default (5173),
+    // which can collide with (or IPv6-shadow) other dev servers'
+    // user-facing ports. Allocate a real ephemeral port instead.
+    const port =
+      (devOptions?.port ?? options?.dev?.port) ||
+      (yield* FrameworkCore.findEphemeralPort());
 
     const server = yield* Effect.acquireRelease(
       Effect.tryPromise({
@@ -597,7 +602,7 @@ export const make: (
             ...config,
             server: {
               ...config.server,
-              ...(port !== undefined ? { port } : undefined),
+              port,
             },
           });
           return await server.listen();

--- a/packages/cloudflare-frameworks/src/sveltekit/SvelteKit.ts
+++ b/packages/cloudflare-frameworks/src/sveltekit/SvelteKit.ts
@@ -588,12 +588,12 @@ export const make: (
     );
     const vite = yield* loadVite(root);
     const config = yield* resolveViteConfig(root, adapter);
-    // Without an explicit port Vite hunts upward from its default (5173),
-    // which can collide with (or IPv6-shadow) other dev servers'
-    // user-facing ports. Allocate a real ephemeral port instead.
-    const port =
-      (devOptions?.port ?? options?.dev?.port) ||
-      (yield* FrameworkCore.findEphemeralPort());
+    // `port: 0` (true OS-assigned) on Vite >= 8.2.1, probed ephemeral port
+    // on older Vite — see `resolveViteDevPort`.
+    const port = yield* FrameworkCore.resolveViteDevPort(
+      vite.version,
+      devOptions?.port ?? options?.dev?.port,
+    );
 
     const server = yield* Effect.acquireRelease(
       Effect.tryPromise({

--- a/packages/cloudflare-frameworks/src/waku/Waku.ts
+++ b/packages/cloudflare-frameworks/src/waku/Waku.ts
@@ -791,14 +791,15 @@ export const make = (
             process.env.NODE_ENV = INITIAL_NODE_ENV ?? "development";
           });
           const wakuConfig = yield* makeConfig(project, root, hooks);
-          // Vite treats `port: 0` as "no port given" and hunts upward from
-          // its default (5173), which can collide with (or IPv6-shadow)
-          // other dev servers' user-facing ports. Allocate a real ephemeral
-          // port instead; keep strictPort off so a probe race just moves to
-          // the next ephemeral port.
+          // `port: 0` (true OS-assigned) on Vite >= 8.2.1, probed ephemeral
+          // port on older Vite — see `resolveViteDevPort`. strictPort stays
+          // off for allocated ports so a probe race just moves to the next
+          // ephemeral port.
           const explicitPort = devOptions?.port || options?.port;
-          const port =
-            explicitPort || (yield* FrameworkCore.findEphemeralPort());
+          const port = yield* FrameworkCore.resolveViteDevPort(
+            project.vite.version,
+            explicitPort,
+          );
           const server = yield* Effect.acquireRelease(
             Effect.tryPromise({
               try: async () => {

--- a/packages/cloudflare-frameworks/src/waku/Waku.ts
+++ b/packages/cloudflare-frameworks/src/waku/Waku.ts
@@ -791,7 +791,14 @@ export const make = (
             process.env.NODE_ENV = INITIAL_NODE_ENV ?? "development";
           });
           const wakuConfig = yield* makeConfig(project, root, hooks);
-          const port = devOptions?.port ?? options?.port;
+          // Vite treats `port: 0` as "no port given" and hunts upward from
+          // its default (5173), which can collide with (or IPv6-shadow)
+          // other dev servers' user-facing ports. Allocate a real ephemeral
+          // port instead; keep strictPort off so a probe race just moves to
+          // the next ephemeral port.
+          const explicitPort = devOptions?.port || options?.port;
+          const port =
+            explicitPort || (yield* FrameworkCore.findEphemeralPort());
           const server = yield* Effect.acquireRelease(
             Effect.tryPromise({
               try: async () => {
@@ -801,14 +808,7 @@ export const make = (
                   plugins: [
                     project.vitePlugins.unstable_combinedPlugins(wakuConfig),
                   ],
-                  ...(port !== undefined
-                    ? {
-                        server: {
-                          port,
-                          strictPort: devOptions?.port !== undefined,
-                        },
-                      }
-                    : undefined),
+                  server: { port, strictPort: !!explicitPort },
                 });
                 return await server.listen();
               },

--- a/packages/cloudflare-runtime/package.json
+++ b/packages/cloudflare-runtime/package.json
@@ -581,6 +581,12 @@
       "worker": "./src/core/internal/internal-worker.ts",
       "import": "./dist/core/node/internal/internal-worker.mjs"
     },
+    "./core/internal/Port": {
+      "types": "./dist/core/node/internal/Port.d.mts",
+      "bun": "./src/core/internal/Port.ts",
+      "worker": "./src/core/internal/Port.ts",
+      "import": "./dist/core/node/internal/Port.mjs"
+    },
     "./core/platform-proxy": {
       "types": "./dist/core/node/platform-proxy/index.d.mts",
       "bun": "./src/core/platform-proxy/index.ts",

--- a/packages/cloudflare-runtime/src/core/internal/Port.ts
+++ b/packages/cloudflare-runtime/src/core/internal/Port.ts
@@ -1,5 +1,6 @@
 import * as Cache from "effect/Cache";
 import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
 import * as Semaphore from "effect/Semaphore";
 import * as NodeNet from "node:net";
 import * as NodeOs from "node:os";
@@ -79,6 +80,18 @@ export interface Ports {
    */
   readonly check: (port: number) => Effect.Effect<number, ConfigError>;
   /**
+   * Waits for a specific port to become available (uncached probes on a
+   * short interval), reserving it on success. Fails with `AddressInUse`
+   * when the grace window elapses — or immediately when the port is
+   * reserved by this process group, since the holder won't release it.
+   *
+   * This is the allocator for user-configured ports: a dev-session restart
+   * races the previous session's teardown, and without a grace window the
+   * configured port silently drifts — cascading every configured port in
+   * the stack up by one in nondeterministic order.
+   */
+  readonly waitFor: (port: number) => Effect.Effect<number, ConfigError>;
+  /**
    * Marks a port as occupied for the lifetime of the cache, preventing it from being assigned to another worker.
    * Note that this is best-effort; the caller should include retry logic to handle race conditions.
    */
@@ -115,6 +128,13 @@ interface PortsOptions {
  * cleanly for everyone else.
  */
 const RESERVATION_TTL_MS = 30_000;
+/**
+ * Grace window for `waitFor`: ~3s of 250ms probes. A killed dev session
+ * releases its listeners well within this; a genuinely-occupied port only
+ * delays that one worker's startup by the window before falling back.
+ */
+const WAIT_FOR_INTERVAL = "250 millis";
+const WAIT_FOR_ATTEMPTS = 12;
 const globalSearchLock = Semaphore.makeUnsafe(1);
 const globalReservations = new Map<number, number>();
 const isReserved = (port: number) => {
@@ -222,6 +242,10 @@ export const make = (options: PortsOptions) =>
         }),
       );
     }, searchLock.withPermits(1));
+    // Uncached availability probe across all local hosts — `waitFor` polls
+    // with it, so the 30s negative cache must not poison the retries.
+    const probe = (port: number) =>
+      Effect.forEach(HOSTS, (host) => bind(port, host)).pipe(Effect.as(port));
     return {
       find: Effect.fn(function* (port) {
         if (port === 0) {
@@ -232,6 +256,22 @@ export const make = (options: PortsOptions) =>
         }
         return yield* search(port);
       }),
+      waitFor: (port) =>
+        Effect.suspend(() =>
+          // Reserved in-process (at entry or mid-wait): the holder keeps it
+          // for the cache lifetime, so waiting cannot succeed (e.g. two
+          // workers configured the same port) — fail and let the caller
+          // fall back. The retry predicate re-checks so a reservation
+          // arriving during the grace window also stops the wait.
+          isReserved(port) ? Effect.fail(addressInUseError(port)) : probe(port),
+        ).pipe(
+          Effect.retry({
+            while: (): boolean => !isReserved(port),
+            schedule: Schedule.spaced(WAIT_FOR_INTERVAL),
+            times: WAIT_FOR_ATTEMPTS,
+          }),
+          Effect.tap(() => reserve(port)),
+        ),
       check: (port) =>
         Effect.suspend(() =>
           isReserved(port)

--- a/packages/cloudflare-runtime/src/core/internal/Port.ts
+++ b/packages/cloudflare-runtime/src/core/internal/Port.ts
@@ -9,6 +9,30 @@ import { ConfigError, SystemError } from "../RuntimeError.shared.ts";
 export const MAX_PORT = 65535;
 
 /**
+ * Whether the given Vite version treats `server.port: 0` as a true
+ * OS-assigned random port (vitejs/vite#23158, shipped in Vite 8.2.1).
+ * Older Vite treats `0` as "no port given" and hunts upward from its 5173
+ * default — colliding with (or IPv6-shadowing) user-facing dev ports.
+ *
+ * Callers drive the PROJECT's Vite install, so this is a runtime check on
+ * the loaded module's `version` export: prefer `port: 0` (race-free at
+ * bind) when supported, fall back to an ephemeral-port probe otherwise.
+ */
+export const viteSupportsPortZero = (
+  version: string | null | undefined,
+): boolean => {
+  if (typeof version !== "string") return false;
+  const match = /^(\d+)\.(\d+)\.(\d+)/.exec(version);
+  if (!match) return false;
+  const major = Number(match[1]);
+  const minor = Number(match[2]);
+  const patch = Number(match[3]);
+  return (
+    major > 8 || (major === 8 && (minor > 2 || (minor === 2 && patch >= 1)))
+  );
+};
+
+/**
  * Upper bound on how many candidate ports `find` scans past the requested
  * starting port. An unbounded scan (up to `MAX_PORT`) multiplied by the
  * per-port availability probes is a socket storm: on Windows CI, where an

--- a/packages/cloudflare-runtime/src/core/proxy/WorkerProxy.ts
+++ b/packages/cloudflare-runtime/src/core/proxy/WorkerProxy.ts
@@ -3,6 +3,7 @@ import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import type * as Scope from "effect/Scope";
+import * as NodeNet from "node:net";
 const ProxyWorker = {
   worker: () =>
     loadInternalWorker(
@@ -60,6 +61,23 @@ export const WorkerProxyLive = Layer.effect(
     const internet = yield* Internet.Internet;
     const ports = yield* Port.make({ cache: true });
 
+    // `localhost` resolves to BOTH 127.0.0.1 and ::1, and browsers prefer
+    // IPv6. A proxy bound only on 127.0.0.1 leaves `[::1]:port` free for any
+    // other process (e.g. a framework dev server hunting from its default
+    // port) to claim — after which `http://localhost:port` silently serves
+    // that other process instead of (or interleaved with) the proxy. When
+    // serving on the loopback default, bind an additional `[::1]` socket so
+    // the proxy owns its port on both address families. Machines without an
+    // IPv6 loopback are detected once and skip the extra socket.
+    const ipv6Loopback = yield* Effect.callback<boolean>((resume) => {
+      const server = NodeNet.createServer();
+      server.once("error", () => resume(Effect.succeed(false)));
+      server.listen({ port: 0, host: "::1", exclusive: true }, () =>
+        server.close(() => resume(Effect.succeed(true))),
+      );
+      return Effect.sync(() => server.close());
+    });
+
     const normalizeOptions = Effect.fnUntraced(function* (
       options: ServeOptions,
     ) {
@@ -69,9 +87,22 @@ export const WorkerProxyLive = Layer.effect(
         port:
           options.port && options.strictPort
             ? yield* ports.check(options.port)
-            : yield* ports.find(options.port ?? 0),
+            : options.port
+              ? // A configured (non-strict) port: a dev-session restart races
+                // the previous session's teardown, and an instant fallback
+                // would silently shift every configured port in the stack up
+                // by one in nondeterministic order — serving the wrong app on
+                // the ports the user knows. Wait out the teardown before
+                // falling back to the hunt (the caller warns on drift).
+                yield* ports
+                  .waitFor(options.port)
+                  .pipe(Effect.catch(() => ports.find(options.port!)))
+              : yield* ports.find(0),
         host,
         strictPort,
+        // Dual-bind only for the loopback default — an explicit host is
+        // served verbatim.
+        ipv6: options.host === undefined && ipv6Loopback,
         token: crypto.randomUUID(),
       };
     });
@@ -82,7 +113,7 @@ export const WorkerProxyLive = Layer.effect(
       formatInternalWorkerModules,
     );
 
-    const serve = ({ host, port, token }: ResolvedOptions) =>
+    const serve = ({ host, port, token, ipv6 }: ResolvedOptions) =>
       workerd
         .serve({
           sockets: [
@@ -91,6 +122,19 @@ export const WorkerProxyLive = Layer.effect(
               address: `${host}:${port}`,
               service: { name: "proxy:worker" },
             },
+            // The IPv6 half of `localhost` (see `ipv6Loopback` above). The
+            // port was probed across both families by `ports.find`/`check`,
+            // so this bind only fails on a genuine race — handled by
+            // `serveWithRetry` like any other collision.
+            ...(ipv6
+              ? [
+                  {
+                    name: "http-ipv6",
+                    address: `[::1]:${port}`,
+                    service: { name: "proxy:worker" },
+                  },
+                ]
+              : []),
           ],
           services: [
             {
@@ -154,6 +198,15 @@ export const WorkerProxyLive = Layer.effect(
       serve: Effect.fn("WorkerProxy.serve")(function* (options = {}) {
         const resolved = yield* normalizeOptions(options);
         const url = yield* serveWithRetry(resolved);
+        if (
+          options.port !== undefined &&
+          options.port !== 0 &&
+          Number(url.port) !== options.port
+        ) {
+          yield* Effect.logWarning(
+            `Port ${options.port} is in use by another process; serving on ${url.port} instead. Stop the other process, pick a different port, or set \`strictPort: true\` to fail instead.`,
+          );
+        }
         return {
           url,
           set: Effect.fn("WorkerProxyInstance.set")(function* (upstream) {

--- a/packages/cloudflare-runtime/src/core/test/internal/Port.test.ts
+++ b/packages/cloudflare-runtime/src/core/test/internal/Port.test.ts
@@ -74,3 +74,27 @@ describe("Port.isUnsupportedHostError", () => {
     ).toBe(false);
   });
 });
+
+describe("Port.viteSupportsPortZero", () => {
+  it("accepts 8.2.1 and later", () => {
+    expect(Port.viteSupportsPortZero("8.2.1")).toBe(true);
+    expect(Port.viteSupportsPortZero("8.2.2")).toBe(true);
+    expect(Port.viteSupportsPortZero("8.3.0")).toBe(true);
+    expect(Port.viteSupportsPortZero("9.0.0")).toBe(true);
+    expect(Port.viteSupportsPortZero("9.0.0-beta.1")).toBe(true);
+  });
+
+  it("rejects versions before 8.2.1", () => {
+    expect(Port.viteSupportsPortZero("8.2.0")).toBe(false);
+    expect(Port.viteSupportsPortZero("8.1.9")).toBe(false);
+    expect(Port.viteSupportsPortZero("7.2.6")).toBe(false);
+    expect(Port.viteSupportsPortZero("6.0.0")).toBe(false);
+  });
+
+  it("rejects missing or malformed versions", () => {
+    expect(Port.viteSupportsPortZero(undefined)).toBe(false);
+    expect(Port.viteSupportsPortZero(null)).toBe(false);
+    expect(Port.viteSupportsPortZero("")).toBe(false);
+    expect(Port.viteSupportsPortZero("next")).toBe(false);
+  });
+});

--- a/packages/cloudflare-runtime/src/core/test/proxy/WorkerProxy.test.ts
+++ b/packages/cloudflare-runtime/src/core/test/proxy/WorkerProxy.test.ts
@@ -414,19 +414,65 @@ layer(services, { excludeTestServices: true })((it) => {
     () =>
       Effect.gen(function* () {
         const proxy = yield* WorkerProxy.WorkerProxy;
-        const base = yield* PortHelpers.find(0);
 
         // Simulate a dev restart racing the old session's teardown: the old
         // session still holds the middle configured port when the new
         // session's proxies start. Without a grace window the middle worker
         // silently drifts onto a neighbor's configured port — serving the
         // wrong app on a port the user knows.
-        const stale = yield* Effect.forkChild(
-          Effect.scoped(
-            Effect.gen(function* () {
-              yield* PortHelpers.occupy(base + 1);
-              yield* Effect.sleep("750 millis");
-            }),
+        //
+        // The suite runs many port tests concurrently, so a freshly probed
+        // port's neighbors may already be taken — stage the trio by
+        // retrying until the "stale" listener actually binds base + 1 and
+        // base + 2 probes free.
+        const tryBind = (port: number) =>
+          Effect.callback<NodeNet.Server | undefined>((resume) => {
+            const server = NodeNet.createServer();
+            server.once("error", () => resume(Effect.succeed(undefined)));
+            server.listen({ port, exclusive: true }, () =>
+              resume(Effect.succeed(server)),
+            );
+            return Effect.sync(() => server.close());
+          });
+        let base!: number;
+        let stale!: NodeNet.Server;
+        for (let attempt = 0; ; attempt++) {
+          const candidate = yield* PortHelpers.find(0);
+          const staleCandidate = yield* tryBind(candidate + 1);
+          if (staleCandidate !== undefined) {
+            const neighbor = yield* tryBind(candidate + 2);
+            if (neighbor !== undefined) {
+              yield* Effect.callback<void>((resume) =>
+                neighbor.close(() => resume(Effect.void)),
+              );
+              base = candidate;
+              stale = staleCandidate;
+              break;
+            }
+            yield* Effect.callback<void>((resume) =>
+              staleCandidate.close(() => resume(Effect.void)),
+            );
+          }
+          if (attempt >= 9) {
+            return yield* Effect.die(
+              "could not stage a stale listener on a free port trio",
+            );
+          }
+        }
+        // The finalizer makes the close idempotent if the test fails early.
+        yield* Effect.addFinalizer(() =>
+          Effect.callback<void>((resume) =>
+            stale.close(() => resume(Effect.void)),
+          ),
+        );
+        // The "old session" releases the port mid-grace-window.
+        yield* Effect.forkChild(
+          Effect.sleep("750 millis").pipe(
+            Effect.andThen(
+              Effect.callback<void>((resume) =>
+                stale.close(() => resume(Effect.void)),
+              ),
+            ),
           ),
         );
 
@@ -438,7 +484,6 @@ layer(services, { excludeTestServices: true })((it) => {
           ],
           { concurrency: "unbounded" },
         );
-        yield* Fiber.join(stale);
 
         expect(Number(a.url.port)).toBe(base);
         expect(Number(b.url.port)).toBe(base + 1);

--- a/packages/cloudflare-runtime/src/core/test/proxy/WorkerProxy.test.ts
+++ b/packages/cloudflare-runtime/src/core/test/proxy/WorkerProxy.test.ts
@@ -3,6 +3,7 @@ import { assert, expect, layer } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
+import * as NodeNet from "node:net";
 import * as Internet from "../../globals/Internet.ts";
 import * as WorkerProxy from "../../proxy/WorkerProxy.ts";
 import { ConfigError } from "../../RuntimeError.shared.ts";
@@ -362,6 +363,86 @@ layer(services, { excludeTestServices: true })((it) => {
           .pipe(Effect.flip);
         assert(error instanceof ConfigError);
         expect(Workerd.isAddressInUseError(error)).toBe(true);
+      }),
+  );
+
+  it.effect(
+    "owns its port on the IPv6 loopback so localhost cannot be shadowed",
+    () =>
+      Effect.gen(function* () {
+        const proxy = yield* WorkerProxy.WorkerProxy;
+        const upstream = yield* serveUpstream(HTTP_WORKER);
+        const instance = yield* proxy.serve();
+        yield* instance.set(upstream);
+        const port = Number(instance.url.port);
+
+        // `localhost` resolves to both 127.0.0.1 and ::1 (and browsers prefer
+        // ::1). A proxy holding only the IPv4 half leaves `[::1]:port` free
+        // for another dev server to claim, silently splitting the port's
+        // traffic between two apps. The proxy must answer on both halves...
+        const viaV6 = yield* Effect.promise(() =>
+          fetch(`http://[::1]:${port}/echo`, {
+            method: "POST",
+            body: "v6",
+          }).then((res) => res.text()),
+        );
+        expect(viaV6).toBe("echo:v6");
+
+        // ...and a squatter's bind on the IPv6 half must fail.
+        const squat = yield* Effect.callback<string>((resume) => {
+          const server = NodeNet.createServer();
+          server.once("error", (error) =>
+            resume(
+              Effect.succeed(
+                typeof error === "object" && error !== null && "code" in error
+                  ? String(error.code)
+                  : "error",
+              ),
+            ),
+          );
+          server.listen({ port, host: "::1", exclusive: true }, () =>
+            server.close(() => resume(Effect.succeed("BOUND"))),
+          );
+          return Effect.sync(() => server.close());
+        });
+        expect(squat).toBe("EADDRINUSE");
+      }),
+  );
+
+  it.effect(
+    "waits out a previous session's teardown instead of shifting configured ports",
+    () =>
+      Effect.gen(function* () {
+        const proxy = yield* WorkerProxy.WorkerProxy;
+        const base = yield* PortHelpers.find(0);
+
+        // Simulate a dev restart racing the old session's teardown: the old
+        // session still holds the middle configured port when the new
+        // session's proxies start. Without a grace window the middle worker
+        // silently drifts onto a neighbor's configured port — serving the
+        // wrong app on a port the user knows.
+        const stale = yield* Effect.forkChild(
+          Effect.scoped(
+            Effect.gen(function* () {
+              yield* PortHelpers.occupy(base + 1);
+              yield* Effect.sleep("750 millis");
+            }),
+          ),
+        );
+
+        const [a, b, c] = yield* Effect.all(
+          [
+            proxy.serve({ port: base }),
+            proxy.serve({ port: base + 1 }),
+            proxy.serve({ port: base + 2 }),
+          ],
+          { concurrency: "unbounded" },
+        );
+        yield* Fiber.join(stale);
+
+        expect(Number(a.url.port)).toBe(base);
+        expect(Number(b.url.port)).toBe(base + 1);
+        expect(Number(c.url.port)).toBe(base + 2);
       }),
   );
 


### PR DESCRIPTION
Fixes two ways `alchemy dev` can serve the wrong app on a configured dev port (reported with a backend + three frontends on ports 3000–3002, where one port intermittently served a different frontend — persisting across dev restarts until the terminal was killed). Ports [cloudflare-tools#112](https://github.com/alchemy-run/cloudflare-tools/pull/112) onto the integrated monorepo layout from #1122.

### 1. Dev servers can shadow proxy ports on the IPv6 half of `localhost`

`localhost` resolves to both `127.0.0.1` and `::1`, and browsers prefer `::1`. The proxy bound only `127.0.0.1`, so any dev server hunting from its framework default (listhen/Nuxt: 3000, Vite: 5173, Astro: 4321) saw the proxy's port as free on the IPv6 side, bound it there, and silently received that port's `localhost` traffic — or interleaved with the proxy within one page load (HTML from one app, assets 404ing on the other). Reproduced on macOS:

```
proxy listening on 127.0.0.1:39871
availability check of the port with no host says: FREE
second server (no host): BOUND on wildcard
fetch http://localhost:39871 → WRONG APP (::1)
fetch http://127.0.0.1:39871 → right app
```

- **`WorkerProxy`**: bind an additional `[::1]` socket when serving on the loopback default, so the proxy owns its port on both address families (skipped on machines without an IPv6 loopback; a bind race falls into the existing retry). Warn when a requested non-strict port is taken and the proxy drifts — previously silent.

```ts
sockets: [
  { name: "http", address: `${host}:${port}`, ... },
  ...(ipv6 ? [{ name: "http-ipv6", address: `[::1]:${port}`, ... }] : []),
]
```

- **`cloudflare-frameworks`**: new `FrameworkCore.findEphemeralPort()`; the Nuxt, Astro, SvelteKit, Waku, and Octane dev servers now allocate a real OS ephemeral port instead of passing `port: 0` (treated as "absent" → default-port hunt through user-facing ranges). Next.js already listened on a caller-owned `port ?? 0` server and needed no change.

### 2. Configured ports silently cascade on dev restart

A dev-session restart races the previous session's listener teardown. The proxy allocator fell back instantly (`ports.find(port)` hunts upward), so one lingering old listener shifts every configured port in the stack up by one — in nondeterministic order, letting a neighbor land on a port the user knows as a different app.

- **`Ports.waitFor(port)`**: uncached probes of the exact configured port on a 250ms interval for ~3s before falling back to the hunt. In-process reservations fail fast (two workers configured the same port — waiting can't cure that).

### Confirmed against the original report's repro

[isakgustavsen/tiff-alchemy](https://github.com/isakgustavsen/tiff-alchemy) (backend + three TanStack Start frontends on ports 3000–3002, alchemy 2.0.0-beta.64) reproduces the cross-wire on first boot: the three in-process Vite servers all defaulted to port 5173 on host `localhost`, and two of them "won" it on different address families —

```
bun 99752  127.0.0.1:5173   ← FestivalFriend's vite server
bun 99752  [::1]:5173       ← Admin's vite server, same port
bun 99752  [::1]:5174       ← Preorder
```

— so both reported `http://localhost:5173/`, and Admin's proxy (port 3000) served FestivalFriend. alchemy ≥ 2.0.0-beta.68 (#1076 + #1090: vite children on explicit `127.0.0.1` + probed ephemeral ports) already removes that instance — verified by re-running the same repro on beta.69, where each port serves the correct app. This PR closes the remaining classes: framework dev servers that pick their own `localhost` ports, any third-party process squatting the IPv6 half of a proxy port, and the configured-port cascade on dev restart.

New regression tests: the proxy answers on `[::1]:port` and a squatter's bind on the IPv6 half fails `EADDRINUSE`; three proxies requesting `p, p+1, p+2` while a stale listener holds `p+1` for 750ms each end up on exactly their requested port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
