### PR TITLE
chroe(deps): restore release age and exempt astro packages

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,6 +1,11 @@
 [install]
-minimumReleaseAge = 0
+minimumReleaseAge = 259200
 minimumReleaseAgeExcludes = [
+  "astro",
+  "@astrojs/check",
+  "@astrojs/mdx",
+  "@astrojs/react",
+  "@astrojs/starlight",
   "@opentui/core",
   "@opentui/core-darwin-arm64",
   "@opentui/core-darwin-x64",


### PR DESCRIPTION
## Summary

- restore Bun's 72-hour minimum package release age
- exempt the Astro packages managed by `@astrojs/upgrade`
- keep the release-age safeguard enabled for all other dependencies

## Verification

- `vp install --frozen-lockfile`
- `git diff --check`