### PR TITLE
fix(cloudflare/workflows): omit step-config keys with no value

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workflows/WorkflowBridge.ts
+++ b/packages/alchemy/src/Cloudflare/Workflows/WorkflowBridge.ts
@@ -166,7 +166,15 @@ export const wrapWorkflowStep = (step: any): WorkflowStep["Service"] => ({
                 output: context.output,
               }) as Effect.Effect<void>,
             ),
-          rollbackConfig: options.rollbackConfig,
+          // Scrubbed like the step's own config, and for the same reason: a
+          // rollback does not get a config of its own — `executeRollbacks`
+          // feeds this straight back through `ctx.do(target, config ?? {}, …)`,
+          // so it lands on the identical defaults-merge and the identical
+          // duration parse. This one arrives from the caller rather than being
+          // synthesized here, so it is a narrower door, but it is the same door
+          // — and it opens during rollback of an already-failing instance,
+          // where the crash is even harder to attribute.
+          rollbackConfig: definedStepConfig(options.rollbackConfig),
         }
       : undefined;
     return Effect.promise(() => {
@@ -189,9 +197,55 @@ export const wrapWorkflowStep = (step: any): WorkflowStep["Service"] => ({
     ),
 });
 
+/**
+ * A `WorkflowStepConfig` carrying only the keys that have a value — or
+ * `undefined` when none do, so the engine keeps every default it has.
+ *
+ * **A step config must never carry a key it has no value for.** The Workflows
+ * engine merges one over its own defaults by spread —
+ * `{ ...defaultConfig, ...stepConfig, retries: { ...defaultConfig.retries, ...stepConfig.retries } }`
+ * — and an own property whose value is `undefined` still wins a spread. So a
+ * config with `timeout: undefined` replaces the engine's `timeout: "10 minutes"`
+ * with `undefined`. The engine parses that with itty-time's
+ * `(e) => { if (!isNaN(+e)) return +e; e.match(/…/) … }`, and `+undefined` is
+ * `NaN`, so it reaches `.match` on `undefined` and throws
+ * `Cannot read properties of undefined (reading 'match')`.
+ *
+ * The symptom is badly disguised. That parse is the first statement of the
+ * step's `timeoutPromise`, which *races* the callback rather than gating it —
+ * so the step body runs and succeeds on every attempt, and the instance only
+ * errors afterwards, with a message naming nothing in the user's workflow. A
+ * step with `retries: { limit: 3 }` logs four successful bodies and then fails.
+ *
+ * `retries: undefined` happens to be survivable today, because the engine
+ * rebuilds `retries` from its defaults with an explicit key *after* the spread.
+ * It is the same mistake and is dropped for the same reason rather than relying
+ * on that.
+ *
+ * The guard is `=== undefined` rather than falsy so that a caller's `timeout: 0`
+ * is forwarded instead of dropped. The engine rejects `0` as invalid, which is a
+ * better answer than silently running the step under the 10-minute default.
+ */
+const definedStepConfig = (
+  config: WorkflowStepConfig | undefined,
+): WorkflowStepConfig | undefined => {
+  if (config === undefined) return undefined;
+  const defined: WorkflowStepConfig = {};
+  if (config.retries !== undefined) defined.retries = config.retries;
+  if (config.timeout !== undefined) defined.timeout = config.timeout;
+  return defined.retries === undefined && defined.timeout === undefined
+    ? undefined
+    : defined;
+};
+
+/**
+ * The step's own config. Built from the options bag rather than passed through,
+ * so this is where the `undefined` used to be synthesized: the old
+ * `{ retries: options.retries, timeout: options.timeout }` literal set both keys
+ * whether or not the caller gave both, which broke every step configured with
+ * retries alone.
+ */
 const toWorkflowStepConfig = (
   options: WorkflowTaskOptions<any, any, any>,
-): WorkflowStepConfig | undefined => {
-  if (!options.retries && !options.timeout) return undefined;
-  return { retries: options.retries, timeout: options.timeout };
-};
+): WorkflowStepConfig | undefined =>
+  definedStepConfig({ retries: options.retries, timeout: options.timeout });

--- a/packages/alchemy/test/Cloudflare/Workers/WorkflowBridge.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkflowBridge.test.ts
@@ -33,4 +33,95 @@ describe("WorkflowBridge", () => {
       }
     }),
   );
+
+  it.effect("only sends step-config keys that have a value", () =>
+    Effect.gen(function* () {
+      // The Workflows engine merges a step config over its own defaults by
+      // spread, and an own property whose value is `undefined` still wins a
+      // spread. So a config carrying `timeout: undefined` erased the engine's
+      // `timeout: "10 minutes"`, which it then parsed with itty-time's
+      // `e.match(/…/)` and died on — from the step's timeout race rather than
+      // from the body, so the body succeeded on every attempt and the instance
+      // errored afterwards naming nothing the user wrote.
+      //
+      // Assert on key PRESENCE, not on value: `toEqual({ retries })` passes for
+      // `{ retries, timeout: undefined }`, which is precisely the bug.
+      const seen: Array<Record<string, unknown> | undefined> = [];
+      const step = wrapWorkflowStep({
+        do: (_name: string, second: unknown) => {
+          // `step.do` is overloaded — the config is only present when the
+          // second argument is not the callback.
+          seen.push(
+            typeof second === "function"
+              ? undefined
+              : (second as Record<string, unknown>),
+          );
+          return Promise.resolve("done");
+        },
+      });
+
+      const retries = { limit: 2, delay: "1 second" };
+      const effect = Effect.succeed("done");
+      yield* step.do({ name: "retries-only", effect, retries });
+      yield* step.do({ name: "timeout-only", effect, timeout: "30 seconds" });
+      yield* step.do({ name: "both", effect, retries, timeout: "30 seconds" });
+      yield* step.do({ name: "neither", effect });
+
+      const [retriesOnly, timeoutOnly, both, neither] = seen;
+
+      expect("retries" in retriesOnly!).toBe(true);
+      expect("timeout" in retriesOnly!).toBe(false);
+
+      expect("timeout" in timeoutOnly!).toBe(true);
+      expect("retries" in timeoutOnly!).toBe(false);
+
+      expect("retries" in both!).toBe(true);
+      expect("timeout" in both!).toBe(true);
+
+      // Neither configured: no config argument at all, so the engine keeps
+      // every default it has.
+      expect(neither).toBeUndefined();
+    }),
+  );
+
+  it.effect("scrubs rollbackConfig the same way", () =>
+    Effect.gen(function* () {
+      // A rollback does not get a config path of its own: `executeRollbacks`
+      // feeds `rollbackConfig` straight back through
+      // `ctx.do(target, config ?? {}, …)`, so it lands on the same
+      // defaults-merge and the same duration parse as any other step. Unlike
+      // the step's own config this one arrives from the caller, so it only
+      // detonates for someone building it programmatically — and it does so
+      // while rolling back an already-failing instance, which is worse to read.
+      let rollback: { rollbackConfig?: Record<string, unknown> } | undefined;
+      const step = wrapWorkflowStep({
+        do: (
+          _name: string,
+          _config: unknown,
+          _callback: unknown,
+          fourth: unknown,
+        ) => {
+          rollback = fourth as { rollbackConfig?: Record<string, unknown> };
+          return Promise.resolve("done");
+        },
+      });
+
+      yield* step.do({
+        name: "with-rollback",
+        effect: Effect.succeed("done"),
+        retries: { limit: 2, delay: "1 second" },
+        rollback: () => Effect.void,
+        // `timeout: undefined` type-checks against `timeout?: string | number`,
+        // so `{ retries, timeout: someConfig.timeout }` compiles and used to
+        // reach the engine intact.
+        rollbackConfig: {
+          retries: { limit: 1, delay: "1 second" },
+          timeout: undefined,
+        },
+      });
+
+      expect("retries" in rollback!.rollbackConfig!).toBe(true);
+      expect("timeout" in rollback!.rollbackConfig!).toBe(false);
+    }),
+  );
 });

--- a/packages/alchemy/test/Cloudflare/Workflows/Workflow.local.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workflows/Workflow.local.test.ts
@@ -33,6 +33,8 @@ interface WorkflowStatus {
   status: string;
   output?: {
     greeting: string;
+    retriedOk: boolean;
+    boundedOk: boolean;
     workflowName: string;
     instanceId: string;
   };
@@ -170,6 +172,15 @@ test.provider(
       expect(status.output?.greeting).toBe("Hello, world!");
       expect(status.output?.instanceId).toBe(instanceId);
 
+      // The fixture's partially-configured steps ran. Before
+      // `toWorkflowStepConfig` stopped emitting keys it had no value for, the
+      // `retry-only` step clobbered the engine's default `timeout` with
+      // `undefined` and this instance ended `errored` with
+      // `Cannot read properties of undefined (reading 'match')`.
+      expect(status.error).toBeFalsy();
+      expect(status.output?.retriedOk).toBe(true);
+      expect(status.output?.boundedOk).toBe(true);
+
       yield* stack.destroy();
     }).pipe(logLevel),
   { timeout: 120_000 },
@@ -237,6 +248,8 @@ test.provider(
         Effect.retry({ schedule: Schedule.spaced("3 seconds"), times: 2 }),
       );
       expect(status.output?.greeting).toBe("Hello, world!");
+      expect(status.output?.retriedOk).toBe(true);
+      expect(status.output?.boundedOk).toBe(true);
 
       yield* stack.destroy();
 

--- a/packages/alchemy/test/Cloudflare/Workflows/fixtures/test-workflow.ts
+++ b/packages/alchemy/test/Cloudflare/Workflows/fixtures/test-workflow.ts
@@ -7,6 +7,9 @@ import * as Effect from "effect/Effect";
  * Minimal durable body: one named `task`, a short `sleep`, and event
  * metadata in the result — enough to prove the workflow engine (local
  * workerd emulation or real Cloudflare) actually ran the instance.
+ *
+ * The two partially-configured steps are a regression guard, not filler. See
+ * `retry-only` below.
  */
 export default class LocalTestWorkflow extends Cloudflare.Workflow<LocalTestWorkflow>()(
   "LocalTestWorkflow",
@@ -19,10 +22,48 @@ export default class LocalTestWorkflow extends Cloudflare.Workflow<LocalTestWork
         Effect.succeed({ text: `Hello, ${input.value}!` }),
       );
 
+      /**
+       * `retries` with no `timeout` — the case that used to break every
+       * workflow that set a retry policy.
+       *
+       * `toWorkflowStepConfig` emitted `{ retries, timeout: options.timeout }`
+       * unconditionally, so this step arrived at the engine carrying an own
+       * `timeout` property whose value was `undefined`. The engine merges a step
+       * config over its defaults by spread, and an own `undefined` still wins a
+       * spread, so its `timeout: "10 minutes"` became `undefined` — which it
+       * then parsed with itty-time's `e.match(/…/)` and died on with
+       * `Cannot read properties of undefined (reading 'match')`.
+       *
+       * Nothing about that failure points here. The parse runs in the step's
+       * timeout race rather than gating the body, so the body succeeds on every
+       * attempt and the instance errors only afterwards, naming a file the user
+       * never wrote. Every pre-existing fixture passed both options or neither,
+       * which is precisely why it shipped.
+       */
+      const retried = yield* Cloudflare.Workflows.task(
+        "retry-only",
+        Effect.succeed({ ok: true }),
+        { retries: { limit: 2, delay: "1 second" } },
+      );
+
+      /**
+       * The mirror: `timeout` with no `retries`. Survivable even before the fix,
+       * because the engine rebuilds `retries` from its defaults with an explicit
+       * key *after* the spread — but it was the same mistake, and pinning it
+       * stops the asymmetry from being re-introduced as a "harmless" shortcut.
+       */
+      const bounded = yield* Cloudflare.Workflows.task(
+        "timeout-only",
+        Effect.succeed({ ok: true }),
+        { timeout: "30 seconds" },
+      );
+
       yield* Cloudflare.Workflows.sleep("cooldown", "1 second");
 
       return {
         greeting: greeted.text,
+        retriedOk: retried.ok,
+        boundedOk: bounded.ok,
         workflowName: event.workflowName,
         instanceId: event.instanceId,
       };


### PR DESCRIPTION
Omit undefined `retries` and `timeout` keys before passing task and rollback configuration to Cloudflare Workflows. This preserves the engine defaults instead of overriding them with `undefined`.

```ts
yield* Cloudflare.task("process", processItem, {
  retries: { limit: 3, delay: "1 second" },
});
```

A retries-only configuration previously passed `timeout: undefined`, causing the engine to fail with `Cannot read properties of undefined (reading 'match')`. The same normalization applies to `rollbackConfig`; explicit values, including `timeout: 0`, retain native validation behavior.
