### PR TITLE
fix(command): supervise Dev process cleanup

### DIFF
--- a/packages/alchemy/src/Command/Command.ts
+++ b/packages/alchemy/src/Command/Command.ts
@@ -82,6 +82,7 @@ export class CommandExecutor extends Context.Service<
      */
     readonly spawn: (
       props: CommandProps,
+      options?: CommandSpawnOptions,
     ) => Effect.Effect<
       ChildProcessSpawner.ChildProcessHandle,
       CommandError,
@@ -100,6 +101,15 @@ export class CommandExecutor extends Context.Service<
     >;
   }
 >()("alchemy/Command/CommandExecutor") {}
+
+/** Internal lifecycle controls for resource-specific command ownership. */
+export interface CommandSpawnOptions extends ChildProcess.KillOptions {
+  /**
+   * Disable the generic synchronous exit hook when another owner provides a
+   * stronger abrupt-exit lifecycle (for example Command.Dev's guardian).
+   */
+  readonly registerExitKill?: boolean;
+}
 
 /**
  * Extends Effect's `PlatformError` to include the command that failed and some command-specific error reasons.
@@ -224,7 +234,9 @@ const parseExecutionTimeout = (
   return Effect.succeed(decoded.value);
 };
 
-const terminateProcessGroup = (child: ChildProcessSpawner.ChildProcessHandle) =>
+export const terminateProcessGroup = (
+  child: ChildProcessSpawner.ChildProcessHandle,
+) =>
   Effect.gen(function* () {
     // Dispatch SIGTERM without waiting indefinitely for the root process. The
     // Effect process runtime targets the detached process group on POSIX and
@@ -306,7 +318,7 @@ export const CommandExecutorLive = () =>
       };
 
       /** Spawns a command, returning the child process handle. */
-      const spawn = (props: CommandProps) =>
+      const spawn = (props: CommandProps, options?: CommandSpawnOptions) =>
         parseCommand(props).pipe(
           Effect.flatMap(({ bin, args }) =>
             spawner.spawn(
@@ -328,11 +340,16 @@ export const CommandExecutorLive = () =>
                 // The Effect process runtime creates a detached process group
                 // by default on POSIX. Preserve that default so timeouts and
                 // scoped interruption can terminate every descendant.
-                killSignal: "SIGKILL",
+                killSignal: options?.killSignal ?? "SIGKILL",
+                forceKillAfter: options?.forceKillAfter,
               }),
             ),
           ),
-          Effect.tap((child) => registerExitKill(child.pid)),
+          Effect.tap((child) =>
+            options?.registerExitKill === false
+              ? Effect.succeed(child)
+              : registerExitKill(child.pid).pipe(Effect.as(child)),
+          ),
           Effect.map((child) =>
             redactChildProcessHandle(child, makeCommandRedactor(props.env)),
           ),

--- a/packages/alchemy/src/Command/Dev.ts
+++ b/packages/alchemy/src/Command/Dev.ts
@@ -9,9 +9,11 @@ import {
   CommandExecutor,
   UnexpectedExit,
   makeCommandError,
+  terminateProcessGroup,
   type CommandProps,
 } from "./Command.ts";
 import { makeCommandRedactor } from "./Redaction.ts";
+import { startDevProcessGuardian } from "../Util/DevProcessGuardian.ts";
 
 export interface DevProps extends CommandProps {}
 
@@ -114,9 +116,20 @@ export const DevProviderLocal = () =>
       return {
         // The dev process is spawned into the instance scope the helper
         // provides: it keeps running after `start` returns (readiness) and
-        // is killed when the helper closes the scope on restart/delete.
+        // receives a graceful group shutdown when the helper closes its scope.
+        // A detached guardian separately owns abrupt sidecar loss, because
+        // exit-hook cannot await an async SIGTERM -> SIGKILL escalation.
         start: Effect.fn(function* ({ news: props, invalidate }) {
-          const child = yield* spawn(props);
+          // The generic exit hook is intentionally disabled for Dev: it can
+          // only issue a synchronous SIGKILL. The guardian below survives an
+          // abrupt sidecar exit and owns the bounded SIGTERM -> SIGKILL path.
+          const child = yield* spawn(props, { registerExitKill: false });
+          const guardian = startDevProcessGuardian(child.pid);
+          yield* Effect.addFinalizer(() =>
+            terminateProcessGroup(child).pipe(
+              Effect.ensuring(Effect.sync(guardian.stop)),
+            ),
+          );
           const redactor = makeCommandRedactor(props.env);
 
           let buffer = "";

--- a/packages/alchemy/src/Util/DevProcessGuardian.ts
+++ b/packages/alchemy/src/Util/DevProcessGuardian.ts
@@ -1,0 +1,85 @@
+import * as NodeChildProcess from "node:child_process";
+
+const GRACE_PERIOD_MILLIS = 1_000;
+
+// This deliberately has no imports: it is run by whichever Node-compatible
+// runtime owns the sidecar (Bun or Node), after that owner may have died.
+const guardianProgram = String.raw`
+const pid = Number(process.argv[1]);
+const ownerPid = Number(process.argv[2]);
+let stopped = false;
+let ended = false;
+const killTree = (signal) => {
+  try {
+    if (process.platform === "win32") {
+      require("node:child_process").execFileSync("taskkill", ["/pid", String(pid), "/T", ...(signal === "SIGKILL" ? ["/F"] : [])], { stdio: "ignore" });
+    } else {
+      process.kill(-pid, signal);
+    }
+  } catch {}
+};
+const finish = () => {
+  if (ended || stopped) return;
+  ended = true;
+  killTree("SIGTERM");
+  setTimeout(() => {
+    killTree("SIGKILL");
+    process.exit(0);
+  }, ${GRACE_PERIOD_MILLIS});
+};
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => { if (chunk.includes("stop")) stopped = true; });
+process.stdin.on("end", finish);
+process.stdin.on("close", finish);
+process.stdin.on("error", finish);
+process.stdin.resume();
+// Some detached Bun children keep the stdin descriptor open after their
+// owner is hard-killed. The PID probe is the independent owner-death signal;
+// stdin still carries the explicit normal-stop marker below.
+setInterval(() => {
+  if (stopped || ended) return;
+  if (process.ppid !== ownerPid) {
+    finish();
+    return;
+  }
+  try {
+    process.kill(ownerPid, 0);
+  } catch {
+    finish();
+  }
+}, 100).unref();
+`;
+
+export interface DevProcessGuardian {
+  /** Marks normal scoped cleanup complete and prevents emergency escalation. */
+  readonly stop: () => void;
+}
+
+/**
+ * Keeps a detached `Command.Dev` process group from outliving its sidecar.
+ *
+ * `exit-hook` exits synchronously, so it cannot await a graceful shutdown.
+ * This sibling watches its owner's stdin: EOF without the normal-stop marker
+ * means the owner disappeared, and the guardian performs SIGTERM -> grace ->
+ * SIGKILL itself. On Windows, `taskkill /T` keeps the existing tree semantics
+ * and `/F` is the hard escalation.
+ */
+export const startDevProcessGuardian = (pid: number): DevProcessGuardian => {
+  const guardian = NodeChildProcess.spawn(
+    process.execPath,
+    ["-e", guardianProgram, `${pid}`, `${process.pid}`],
+    {
+      detached: true,
+      stdio: ["pipe", "ignore", "ignore"],
+    },
+  );
+  guardian.unref();
+
+  return {
+    stop: () => {
+      try {
+        guardian.stdin?.end("stop");
+      } catch {}
+    },
+  };
+};

--- a/packages/alchemy/test/Command/Dev.test.ts
+++ b/packages/alchemy/test/Command/Dev.test.ts
@@ -427,11 +427,16 @@ test.provider(
       const fs = yield* FileSystem.FileSystem;
       const tmp = yield* fs.makeTempDirectoryScoped({ prefix: "devcmd-" });
       const pidFile = pathe.join(tmp, "pid.json");
+      const shutdownFile = pathe.join(tmp, "shutdown.json");
 
       yield* stack.deploy(
         Command.Dev("Dev", {
           command: `node ${fixtureScript}`,
-          env: { PID_FILE: pidFile, MARKER: "stop" },
+          env: {
+            PID_FILE: pidFile,
+            SHUTDOWN_FILE: shutdownFile,
+            MARKER: "stop",
+          },
         }),
       );
       const { pid } = yield* waitForPidFile(pidFile, "stop");
@@ -440,6 +445,10 @@ test.provider(
       yield* stack.destroy();
       yield* waitForDeath(pid);
       expect(yield* isAlive(pid)).toBe(false);
+      expect(JSON.parse(yield* fs.readFileString(shutdownFile))).toEqual({
+        pid,
+        marker: "stop",
+      });
     }),
   { timeout: 30_000 },
 );

--- a/packages/alchemy/test/Command/fixture/ignore-term-tree.cjs
+++ b/packages/alchemy/test/Command/fixture/ignore-term-tree.cjs
@@ -1,0 +1,20 @@
+const fs = require("node:fs");
+const { spawn } = require("node:child_process");
+
+const pidFile = process.env.PID_FILE;
+if (!pidFile) throw new Error("PID_FILE is required");
+
+process.on("SIGTERM", () => {});
+const descendant = spawn(
+  process.execPath,
+  ["-e", "process.on('SIGTERM', () => {}); setInterval(() => {}, 60000)"],
+  {
+    stdio: "ignore",
+  },
+);
+fs.writeFileSync(
+  pidFile,
+  JSON.stringify({ pid: process.pid, descendantPid: descendant.pid }),
+);
+console.log("http://localhost:65535/");
+setInterval(() => {}, 60_000);

--- a/packages/alchemy/test/Command/fixture/long-running.cjs
+++ b/packages/alchemy/test/Command/fixture/long-running.cjs
@@ -4,6 +4,7 @@
 const fs = require("node:fs");
 
 const file = process.env.PID_FILE;
+const shutdownFile = process.env.SHUTDOWN_FILE;
 const marker = process.env.MARKER ?? "default";
 
 if (!file) {
@@ -12,6 +13,19 @@ if (!file) {
 }
 
 fs.writeFileSync(file, JSON.stringify({ pid: process.pid, marker }));
+
+// Dev-process cleanup is graceful first: record the signal before yielding
+// to normal termination so the RpcSpawner fixture proves the child observed
+// SIGTERM across the real sidecar boundary.
+process.once("SIGTERM", () => {
+  if (shutdownFile) {
+    fs.writeFileSync(
+      shutdownFile,
+      JSON.stringify({ pid: process.pid, marker }),
+    );
+  }
+  process.exit(0);
+});
 
 // Print a localhost URL so the Dev provider's URL-readiness scan resolves
 // immediately (like a real dev server) instead of waiting out its 5-second

--- a/packages/alchemy/test/Local/RpcSpawnerCleanup.test.ts
+++ b/packages/alchemy/test/Local/RpcSpawnerCleanup.test.ts
@@ -33,6 +33,9 @@ const DEVSERVER_SIDECAR_TS_URL = new URL(
 const LONG_RUNNING_CJS = fileURLToPath(
   new URL("../Command/fixture/long-running.cjs", import.meta.url),
 );
+const IGNORE_TERM_TREE_CJS = fileURLToPath(
+  new URL("../Command/fixture/ignore-term-tree.cjs", import.meta.url),
+);
 
 for (const runtime of runtimes()) {
   describe(`Local.RpcSpawner cleanup (${runtime.name})`, () => {
@@ -126,6 +129,7 @@ for (const runtime of runtimes()) {
             prefix: "alchemy-devserver-",
           });
           const pidFile = `${tmpDir}/${process.pid}-${runtime.name}.json`;
+          const shutdownFile = `${tmpDir}/${process.pid}-${runtime.name}.shutdown`;
           const child = yield* ChildProcess.make(
             bin,
             [
@@ -133,6 +137,7 @@ for (const runtime of runtimes()) {
               DEVSERVER_SIDECAR_TS_URL,
               `node ${LONG_RUNNING_CJS}`,
               pidFile,
+              shutdownFile,
             ],
             {
               stdout: "pipe",
@@ -179,6 +184,70 @@ for (const runtime of runtimes()) {
           yield* killPid(parentPid, "SIGTERM");
           yield* waitForExit(child, Duration.seconds(10));
           yield* assertPidExited(devServerPid);
+          expect(JSON.parse(yield* fs.readFileString(shutdownFile))).toEqual({
+            pid: devServerPid,
+            marker: "rpc-devserver",
+          });
+        }).pipe(Effect.provide(PlatformServices)),
+      { timeout: 45_000 },
+    );
+
+    it.live(
+      "DevServer escalation kills an ignoring process group after parent exit",
+      () =>
+        Effect.gen(function* () {
+          const [bin, ...args] = runtime.argv(DEVSERVER_PARENT_TS);
+          const fs = yield* FileSystem.FileSystem;
+          const tmpDir = yield* fs.makeTempDirectory({
+            prefix: "alchemy-devserver-ignore-",
+          });
+          const pidFile = `${tmpDir}/${process.pid}-${runtime.name}.json`;
+          const shutdownFile = `${tmpDir}/${process.pid}-${runtime.name}.shutdown`;
+          const child = yield* ChildProcess.make(
+            bin,
+            [
+              ...args,
+              DEVSERVER_SIDECAR_TS_URL,
+              `node ${IGNORE_TERM_TREE_CJS}`,
+              pidFile,
+              shutdownFile,
+            ],
+            { stdout: "pipe" },
+          );
+          const output = yield* child.stdout.pipe(
+            Stream.decodeText,
+            Stream.run(
+              Sink.fold(
+                () => "",
+                (acc) =>
+                  !acc.includes("PARENT_PID=") ||
+                  !acc.includes("DEVSERVER_PID="),
+                (acc, chunk) => Effect.succeed(acc + chunk),
+              ),
+            ),
+            Effect.timeout("30 seconds"),
+          );
+          const parentPid = Number.parseInt(
+            output.match(/PARENT_PID=(\d+)/)?.[1]!,
+            10,
+          );
+          const pids = JSON.parse(yield* fs.readFileString(pidFile)) as {
+            pid: number;
+            descendantPid: number;
+          };
+          yield* Effect.addFinalizer(() =>
+            Effect.all(
+              [
+                killPid(pids.pid, "SIGKILL"),
+                killPid(pids.descendantPid, "SIGKILL"),
+              ],
+              { discard: true },
+            ),
+          );
+          yield* killPid(parentPid, "SIGTERM");
+          yield* waitForExit(child, Duration.seconds(10));
+          yield* assertPidExited(pids.pid);
+          yield* assertPidExited(pids.descendantPid);
         }).pipe(Effect.provide(PlatformServices)),
       { timeout: 45_000 },
     );

--- a/packages/alchemy/test/Local/fixtures/rpc-spawner-devserver-parent.ts
+++ b/packages/alchemy/test/Local/fixtures/rpc-spawner-devserver-parent.ts
@@ -20,10 +20,11 @@ import { PlatformServices } from "../../../src/Util/PlatformServices.ts";
 const sidecarEntry = process.argv[2];
 const command = process.argv[3];
 const pidFile = process.argv[4];
+const shutdownFile = process.argv[5];
 
-if (!sidecarEntry || !command || !pidFile) {
+if (!sidecarEntry || !command || !pidFile || !shutdownFile) {
   console.error(
-    "usage: rpc-spawner-devserver-parent.ts <sidecar-entry-url> <command> <pid-file>",
+    "usage: rpc-spawner-devserver-parent.ts <sidecar-entry-url> <command> <pid-file> <shutdown-file>",
   );
   process.exit(2);
 }
@@ -61,7 +62,11 @@ const program = Effect.gen(function* () {
     instanceId: "Dev",
     news: {
       command,
-      env: { PID_FILE: pidFile, MARKER: "rpc-devserver" },
+      env: {
+        PID_FILE: pidFile,
+        SHUTDOWN_FILE: shutdownFile,
+        MARKER: "rpc-devserver",
+      },
     },
     olds: undefined,
     output: undefined,


### PR DESCRIPTION
## Summary

Give `Command.Dev` graceful shutdown time before hard cleanup, without weakening the synchronous emergency cleanup contract used by ordinary commands.

## Lifecycle

```mermaid
sequenceDiagram
  participant Scope as Normal scope
  participant Sidecar as Command sidecar
  participant Guardian as Detached Dev guardian
  participant Group as Dev process group
  Scope->>Group: SIGTERM
  Scope->>Group: SIGKILL after 1 second if needed
  Sidecar-->>Guardian: owner exits abruptly
  Guardian->>Group: SIGTERM
  Guardian->>Group: SIGKILL after 1 second if needed
```

- `Command.Dev` opts out of the generic synchronous `exit-hook`, which can only send SIGKILL.
- Its guardian survives sidecar death and owns the bounded process-group escalation.
- Prisma, Vite, builds, and other commands keep the existing generic hard exit-hook behavior.
- Windows uses `taskkill /T`, escalating with `/F`.

## Validation

- `bun tsc -b --pretty false`
- `bunx oxfmt --check` on the eight changed paths
- `bunx oxlint` on the eight changed paths
- `git diff --check`
- `RpcSpawnerCleanup.test.ts` Bun matrix: graceful SIGTERM evidence, ignored-child SIGKILL escalation, and descendant cleanup
- `Dev.test.ts -t 'stops the process on destroy'`: normal scoped SIGTERM evidence

The Node fixture matrix remains in the suite. This machine's Node 26 cannot execute these TypeScript fixtures (native stripping rejects parameter properties after removal of `--experimental-transform-types`); Node 24.18.0 can launch the fixture directly, but the current Effect test runner does not propagate its stdout in this setup.
