### PR TITLE
feat(drizzle): extract alchemy/Drizzle into @alchemy.run/drizzle

### DIFF
--- a/.github/workflows/pr-package.yml
+++ b/.github/workflows/pr-package.yml
@@ -57,6 +57,7 @@ jobs:
             [
               { "dir": "packages/alchemy",               "name": "alchemy",                            "group": "Alchemy" },
               { "dir": "packages/better-auth",           "name": "@alchemy.run/better-auth",           "group": "Alchemy" },
+              { "dir": "packages/drizzle",               "name": "@alchemy.run/drizzle",              "group": "Alchemy" },
               { "dir": "packages/cloudflare-runtime",    "name": "@alchemy.run/cloudflare-runtime",    "group": "Alchemy" },
               { "dir": "packages/cloudflare-frameworks", "name": "@alchemy.run/cloudflare-frameworks", "group": "Alchemy" },
               { "dir": "packages/pr-package",            "name": "@alchemy.run/pr-package",            "group": "Alchemy" },

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,7 @@ jobs:
         [
           { "dir": "packages/alchemy",            "name": "alchemy",                         "runner": "ubuntu-22-large" },
           { "dir": "packages/better-auth",        "name": "@alchemy.run/better-auth",        "runner": "ubuntu-22-large" },
+          { "dir": "packages/drizzle",            "name": "@alchemy.run/drizzle",            "runner": "ubuntu-22-large" },
           { "dir": "packages/cloudflare-runtime", "name": "@alchemy.run/cloudflare-runtime", "runner": "ubuntu-22-large" },
           { "dir": "packages/cloudflare-frameworks",         "name": "@alchemy.run/cloudflare-frameworks",         "runner": "ubuntu-22-large" },
           { "dir": "packages/pr-package",         "name": "@alchemy.run/pr-package",         "runner": "ubuntu-22-large" }

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "alchemy-monorepo",
       "devDependencies": {
+        "@alchemy.run/drizzle": "workspace:*",
         "@alchemy.run/pr-package": "workspace:*",
         "@ark/attest": "^0.56.0",
         "@cloudflare/puppeteer": "^1.1.0",
@@ -504,6 +505,7 @@
       "name": "cloudflare-d1-drizzle",
       "version": "0.0.0",
       "dependencies": {
+        "@alchemy.run/drizzle": "workspace:*",
         "@cloudflare/workers-types": "catalog:",
         "@effect/platform-bun": "catalog:",
         "@effect/platform-node": "catalog:",
@@ -578,6 +580,7 @@
       "name": "cloudflare-neon-drizzle",
       "version": "0.0.0",
       "dependencies": {
+        "@alchemy.run/drizzle": "workspace:*",
         "@cloudflare/workers-types": "catalog:",
         "@effect/platform-bun": "catalog:",
         "@effect/platform-node": "catalog:",
@@ -608,6 +611,7 @@
       "name": "cloudflare-planetscale-mysql-drizzle",
       "version": "0.0.0",
       "dependencies": {
+        "@alchemy.run/drizzle": "workspace:*",
         "@cloudflare/workers-types": "catalog:",
         "@effect/platform-bun": "catalog:",
         "@effect/platform-node": "catalog:",
@@ -625,6 +629,7 @@
       "name": "cloudflare-planetscale-postgres-drizzle",
       "version": "0.0.0",
       "dependencies": {
+        "@alchemy.run/drizzle": "workspace:*",
         "@cloudflare/workers-types": "catalog:",
         "@effect/platform-bun": "catalog:",
         "@effect/platform-node": "catalog:",
@@ -730,6 +735,7 @@
       "name": "cloudflare-tanstack-rpc-drizzle-example",
       "version": "0.0.0",
       "dependencies": {
+        "@alchemy.run/drizzle": "workspace:*",
         "@effect/atom-react": "catalog:",
         "@effect/platform-bun": "catalog:",
         "@effect/platform-node": "catalog:",
@@ -1356,7 +1362,6 @@
         "@distilled.cloud/neon": "workspace:*",
         "@distilled.cloud/planetscale": "workspace:*",
         "@effect/sql-d1": "catalog:",
-        "@effect/sql-sqlite-do": "catalog:",
         "@effect/vitest": "catalog:",
         "@libsql/client": "catalog:",
         "@octokit/rest": "^22.0.1",
@@ -1412,6 +1417,8 @@
         "alchemy-test": "workspace:*",
         "astro": "catalog:frameworks",
         "better-auth": "catalog:",
+        "drizzle-kit": "catalog:",
+        "drizzle-orm": "catalog:",
         "effect": "catalog:",
         "foldkit": "catalog:fixtures",
         "hono": "catalog:frameworks",
@@ -1446,8 +1453,6 @@
         "@effect/sql-mysql2": "catalog:",
         "@effect/sql-pg": "catalog:",
         "@vercel/nft": "^1.10.2",
-        "drizzle-kit": "catalog:",
-        "drizzle-orm": "catalog:",
         "effect": "catalog:",
         "mongodb": "^6.10.0",
         "mysql2": "^3.15.3",
@@ -1462,8 +1467,6 @@
         "@effect/sql-mysql2",
         "@effect/sql-pg",
         "@vercel/nft",
-        "drizzle-kit",
-        "drizzle-orm",
         "mongodb",
         "mysql2",
         "pg",
@@ -1619,6 +1622,31 @@
         "rolldown": "catalog:",
         "vite": "catalog:",
       },
+    },
+    "packages/drizzle": {
+      "name": "@alchemy.run/drizzle",
+      "version": "2.0.0-beta.70",
+      "dependencies": {
+        "@effect/sql-d1": "catalog:",
+        "@effect/sql-sqlite-do": "catalog:",
+        "alchemy": "workspace:*",
+      },
+      "peerDependencies": {
+        "@effect/sql-mysql2": "catalog:",
+        "@effect/sql-pg": "catalog:",
+        "drizzle-kit": "catalog:",
+        "drizzle-orm": "catalog:",
+        "effect": "catalog:",
+        "mysql2": "^3.15.3",
+        "pg": "^8.13.0",
+      },
+      "optionalPeers": [
+        "@effect/sql-mysql2",
+        "@effect/sql-pg",
+        "drizzle-kit",
+        "mysql2",
+        "pg",
+      ],
     },
     "packages/pr-package": {
       "name": "@alchemy.run/pr-package",
@@ -1829,6 +1857,8 @@
     "@alchemy.run/cloudflare-runtime": ["@alchemy.run/cloudflare-runtime@workspace:packages/cloudflare-runtime"],
 
     "@alchemy.run/cloudflare-test-tools": ["@alchemy.run/cloudflare-test-tools@workspace:packages/cloudflare-test-tools"],
+
+    "@alchemy.run/drizzle": ["@alchemy.run/drizzle@workspace:packages/drizzle"],
 
     "@alchemy.run/node-utils": ["@alchemy.run/node-utils@0.0.5", "", {}, "sha512-5agdhQxWBodxa5hDRyjnpx91RTU3g+qd5fxYB7uNDCaOzB0XC47UU/KHR6zf6jhz/NXf61gJS+vhYwn8NHeRoQ=="],
 

--- a/examples/cloudflare-d1-drizzle/alchemy.run.ts
+++ b/examples/cloudflare-d1-drizzle/alchemy.run.ts
@@ -1,6 +1,6 @@
 import * as Alchemy from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
-import * as Drizzle from "alchemy/Drizzle";
+import * as Drizzle from "@alchemy.run/drizzle";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 

--- a/examples/cloudflare-d1-drizzle/package.json
+++ b/examples/cloudflare-d1-drizzle/package.json
@@ -16,6 +16,7 @@
     "test": "bun test"
   },
   "dependencies": {
+    "@alchemy.run/drizzle": "workspace:*",
     "@cloudflare/workers-types": "catalog:",
     "@effect/platform-bun": "catalog:",
     "@effect/platform-node": "catalog:",

--- a/examples/cloudflare-d1-drizzle/src/Api.ts
+++ b/examples/cloudflare-d1-drizzle/src/Api.ts
@@ -1,5 +1,5 @@
 import * as Cloudflare from "alchemy/Cloudflare";
-import * as Drizzle from "alchemy/Drizzle";
+import * as Drizzle from "@alchemy.run/drizzle";
 import { eq } from "drizzle-orm";
 import * as Effect from "effect/Effect";
 import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";

--- a/examples/cloudflare-d1-drizzle/src/Db.ts
+++ b/examples/cloudflare-d1-drizzle/src/Db.ts
@@ -1,5 +1,5 @@
 import * as Cloudflare from "alchemy/Cloudflare";
-import * as Drizzle from "alchemy/Drizzle";
+import * as Drizzle from "@alchemy.run/drizzle";
 import * as Effect from "effect/Effect";
 
 /**

--- a/examples/cloudflare-d1-drizzle/test/integ.test.ts
+++ b/examples/cloudflare-d1-drizzle/test/integ.test.ts
@@ -1,6 +1,6 @@
 import * as Alchemy from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
-import * as Drizzle from "alchemy/Drizzle";
+import * as Drizzle from "@alchemy.run/drizzle";
 import * as Test from "alchemy/Test/Bun";
 import { expect } from "bun:test";
 import * as Effect from "effect/Effect";

--- a/examples/cloudflare-neon-drizzle/alchemy.run.ts
+++ b/examples/cloudflare-neon-drizzle/alchemy.run.ts
@@ -1,6 +1,6 @@
 import * as Alchemy from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
-import * as Drizzle from "alchemy/Drizzle";
+import * as Drizzle from "@alchemy.run/drizzle";
 import * as Neon from "alchemy/Neon";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";

--- a/examples/cloudflare-neon-drizzle/package.json
+++ b/examples/cloudflare-neon-drizzle/package.json
@@ -16,6 +16,7 @@
     "test": "bun test"
   },
   "dependencies": {
+    "@alchemy.run/drizzle": "workspace:*",
     "@cloudflare/workers-types": "catalog:",
     "@effect/platform-bun": "catalog:",
     "@effect/platform-node": "catalog:",

--- a/examples/cloudflare-neon-drizzle/src/Api.ts
+++ b/examples/cloudflare-neon-drizzle/src/Api.ts
@@ -1,5 +1,5 @@
 import * as Cloudflare from "alchemy/Cloudflare";
-import * as Drizzle from "alchemy/Drizzle/Postgres";
+import * as Drizzle from "@alchemy.run/drizzle/Postgres";
 import { eq } from "drizzle-orm";
 import { Layer } from "effect";
 import * as Effect from "effect/Effect";

--- a/examples/cloudflare-neon-drizzle/src/Db.ts
+++ b/examples/cloudflare-neon-drizzle/src/Db.ts
@@ -1,6 +1,6 @@
 import * as Alchemy from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
-import * as Drizzle from "alchemy/Drizzle";
+import * as Drizzle from "@alchemy.run/drizzle";
 import * as Neon from "alchemy/Neon";
 import * as Effect from "effect/Effect";
 

--- a/examples/cloudflare-neon-drizzle/test/integ.test.ts
+++ b/examples/cloudflare-neon-drizzle/test/integ.test.ts
@@ -1,6 +1,6 @@
 import * as Alchemy from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
-import * as Drizzle from "alchemy/Drizzle";
+import * as Drizzle from "@alchemy.run/drizzle";
 import * as Neon from "alchemy/Neon";
 import * as Test from "alchemy/Test/Bun";
 import { expect } from "bun:test";

--- a/examples/cloudflare-planetscale-mysql-drizzle/alchemy.run.ts
+++ b/examples/cloudflare-planetscale-mysql-drizzle/alchemy.run.ts
@@ -1,6 +1,6 @@
 import * as Alchemy from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
-import * as Drizzle from "alchemy/Drizzle";
+import * as Drizzle from "@alchemy.run/drizzle";
 import * as Planetscale from "alchemy/Planetscale";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";

--- a/examples/cloudflare-planetscale-mysql-drizzle/package.json
+++ b/examples/cloudflare-planetscale-mysql-drizzle/package.json
@@ -17,6 +17,7 @@
     "test": "bun test"
   },
   "dependencies": {
+    "@alchemy.run/drizzle": "workspace:*",
     "@cloudflare/workers-types": "catalog:",
     "@effect/platform-bun": "catalog:",
     "@effect/platform-node": "catalog:",

--- a/examples/cloudflare-planetscale-mysql-drizzle/src/Api.ts
+++ b/examples/cloudflare-planetscale-mysql-drizzle/src/Api.ts
@@ -1,5 +1,5 @@
 import * as Cloudflare from "alchemy/Cloudflare";
-import * as Drizzle from "alchemy/Drizzle/MySQL";
+import * as Drizzle from "@alchemy.run/drizzle/MySQL";
 import { eq } from "drizzle-orm";
 import { Layer } from "effect";
 import * as Effect from "effect/Effect";

--- a/examples/cloudflare-planetscale-mysql-drizzle/src/Db.ts
+++ b/examples/cloudflare-planetscale-mysql-drizzle/src/Db.ts
@@ -1,6 +1,6 @@
 import * as Alchemy from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
-import * as Drizzle from "alchemy/Drizzle";
+import * as Drizzle from "@alchemy.run/drizzle";
 import * as Planetscale from "alchemy/Planetscale";
 import * as Effect from "effect/Effect";
 

--- a/examples/cloudflare-planetscale-postgres-drizzle/alchemy.run.ts
+++ b/examples/cloudflare-planetscale-postgres-drizzle/alchemy.run.ts
@@ -1,6 +1,6 @@
 import * as Alchemy from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
-import * as Drizzle from "alchemy/Drizzle";
+import * as Drizzle from "@alchemy.run/drizzle";
 import * as Planetscale from "alchemy/Planetscale";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";

--- a/examples/cloudflare-planetscale-postgres-drizzle/package.json
+++ b/examples/cloudflare-planetscale-postgres-drizzle/package.json
@@ -16,6 +16,7 @@
     "test": "bun test"
   },
   "dependencies": {
+    "@alchemy.run/drizzle": "workspace:*",
     "@cloudflare/workers-types": "catalog:",
     "@effect/platform-bun": "catalog:",
     "@effect/platform-node": "catalog:",

--- a/examples/cloudflare-planetscale-postgres-drizzle/src/Api.ts
+++ b/examples/cloudflare-planetscale-postgres-drizzle/src/Api.ts
@@ -1,5 +1,5 @@
 import * as Cloudflare from "alchemy/Cloudflare";
-import * as Drizzle from "alchemy/Drizzle/Postgres";
+import * as Drizzle from "@alchemy.run/drizzle/Postgres";
 import { eq } from "drizzle-orm";
 import { Layer } from "effect";
 import * as Effect from "effect/Effect";

--- a/examples/cloudflare-planetscale-postgres-drizzle/src/Db.ts
+++ b/examples/cloudflare-planetscale-postgres-drizzle/src/Db.ts
@@ -1,6 +1,6 @@
 import * as Alchemy from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
-import * as Drizzle from "alchemy/Drizzle";
+import * as Drizzle from "@alchemy.run/drizzle";
 import * as Planetscale from "alchemy/Planetscale";
 import * as Effect from "effect/Effect";
 

--- a/examples/cloudflare-planetscale-postgres-drizzle/test/integ.test.ts
+++ b/examples/cloudflare-planetscale-postgres-drizzle/test/integ.test.ts
@@ -1,6 +1,6 @@
 import * as Alchemy from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
-import * as Drizzle from "alchemy/Drizzle";
+import * as Drizzle from "@alchemy.run/drizzle";
 import * as Planetscale from "alchemy/Planetscale";
 import * as Test from "alchemy/Test/Bun";
 import { expect } from "bun:test";

--- a/examples/cloudflare-tanstack-rpc-drizzle/alchemy.run.ts
+++ b/examples/cloudflare-tanstack-rpc-drizzle/alchemy.run.ts
@@ -1,6 +1,6 @@
 import * as Alchemy from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
-import * as Drizzle from "alchemy/Drizzle";
+import * as Drizzle from "@alchemy.run/drizzle";
 import * as Neon from "alchemy/Neon";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";

--- a/examples/cloudflare-tanstack-rpc-drizzle/package.json
+++ b/examples/cloudflare-tanstack-rpc-drizzle/package.json
@@ -18,6 +18,7 @@
     "test": "bun test"
   },
   "dependencies": {
+    "@alchemy.run/drizzle": "workspace:*",
     "@effect/atom-react": "catalog:",
     "@effect/platform-bun": "catalog:",
     "@effect/platform-node": "catalog:",

--- a/examples/cloudflare-tanstack-rpc-drizzle/src/backend/api.ts
+++ b/examples/cloudflare-tanstack-rpc-drizzle/src/backend/api.ts
@@ -1,5 +1,5 @@
 import * as Cloudflare from "alchemy/Cloudflare";
-import * as Drizzle from "alchemy/Drizzle/Postgres";
+import * as Drizzle from "@alchemy.run/drizzle/Postgres";
 import { eq } from "drizzle-orm";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";

--- a/examples/cloudflare-tanstack-rpc-drizzle/src/backend/database.ts
+++ b/examples/cloudflare-tanstack-rpc-drizzle/src/backend/database.ts
@@ -1,6 +1,6 @@
 import * as Alchemy from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
-import * as Drizzle from "alchemy/Drizzle";
+import * as Drizzle from "@alchemy.run/drizzle";
 import * as Neon from "alchemy/Neon";
 import * as Effect from "effect/Effect";
 

--- a/examples/cloudflare-tanstack-rpc-drizzle/test/integ.test.ts
+++ b/examples/cloudflare-tanstack-rpc-drizzle/test/integ.test.ts
@@ -1,6 +1,6 @@
 import * as Alchemy from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
-import * as Drizzle from "alchemy/Drizzle";
+import * as Drizzle from "@alchemy.run/drizzle";
 import * as Neon from "alchemy/Neon";
 import * as Test from "alchemy/Test/Bun";
 import { describe, expect } from "bun:test";

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build:clean": "bun clean . && bun i && bun run build && bun download:env",
     "build:cloudflare-packages": "bun tsc -b distilled/packages/cloudflare/tsconfig.json && turbo run build --filter=@alchemy.run/cloudflare-runtime --filter=@alchemy.run/cloudflare-frameworks --filter=@alchemy.run/cloudflare-test-tools",
     "build:packages": "bun tsc -b && bun run --filter './packages/*' build",
-    "build:pr-packages": "turbo run build --filter=alchemy --filter=@alchemy.run/better-auth --filter=@alchemy.run/cloudflare-runtime --filter=@alchemy.run/cloudflare-frameworks --filter=@alchemy.run/pr-package --filter=@distilled.cloud/core --filter=@distilled.cloud/aws --filter=@distilled.cloud/axiom --filter=@distilled.cloud/cloudflare --filter=@distilled.cloud/neon --filter=@distilled.cloud/planetscale",
+    "build:pr-packages": "turbo run build --filter=alchemy --filter=@alchemy.run/better-auth --filter=@alchemy.run/drizzle --filter=@alchemy.run/cloudflare-runtime --filter=@alchemy.run/cloudflare-frameworks --filter=@alchemy.run/pr-package --filter=@distilled.cloud/core --filter=@distilled.cloud/aws --filter=@distilled.cloud/axiom --filter=@distilled.cloud/cloudflare --filter=@distilled.cloud/neon --filter=@distilled.cloud/planetscale",
     "build": "bun tsc -b && bun run --filter ./website --filter './packages/*' build && bun lint:providers",
     "clean:shallow": "rm -rf alchemy/*.tgz && bun tsc -b --clean",
     "clean": "git clean -fqdx -e .env",
@@ -206,6 +206,7 @@
     }
   },
   "devDependencies": {
+    "@alchemy.run/drizzle": "workspace:*",
     "@alchemy.run/pr-package": "workspace:*",
     "@ark/attest": "^0.56.0",
     "@cloudflare/puppeteer": "^1.1.0",

--- a/packages/alchemy/package.json
+++ b/packages/alchemy/package.json
@@ -172,17 +172,11 @@
       "worker": "./src/Cloudflare/*/index.ts",
       "import": "./lib/Cloudflare/*/index.js"
     },
-    "./Drizzle": {
-      "types": "./lib/Drizzle/index.d.ts",
-      "bun": "./src/Drizzle/index.ts",
-      "worker": "./src/Drizzle/index.ts",
-      "import": "./lib/Drizzle/index.js"
-    },
-    "./Drizzle/*": {
-      "types": "./lib/Drizzle/*.d.ts",
-      "bun": "./src/Drizzle/*.ts",
-      "worker": "./src/Drizzle/*.ts",
-      "import": "./lib/Drizzle/*.js"
+    "./Cloudflare/Workers/*": {
+      "types": "./lib/Cloudflare/Workers/*.d.ts",
+      "bun": "./src/Cloudflare/Workers/*.ts",
+      "worker": "./src/Cloudflare/Workers/*.ts",
+      "import": "./lib/Cloudflare/Workers/*.js"
     },
     "./Axiom": {
       "types": "./lib/Axiom/index.d.ts",
@@ -373,7 +367,6 @@
     "@distilled.cloud/neon": "workspace:*",
     "@distilled.cloud/planetscale": "workspace:*",
     "@effect/sql-d1": "catalog:",
-    "@effect/sql-sqlite-do": "catalog:",
     "@effect/vitest": "catalog:",
     "@libsql/client": "catalog:",
     "@octokit/rest": "^22.0.1",
@@ -429,6 +422,8 @@
     "alchemy-test": "workspace:*",
     "astro": "catalog:frameworks",
     "better-auth": "catalog:",
+    "drizzle-kit": "catalog:",
+    "drizzle-orm": "catalog:",
     "effect": "catalog:",
     "foldkit": "catalog:fixtures",
     "hono": "catalog:frameworks",
@@ -463,8 +458,6 @@
     "@effect/sql-mysql2": "catalog:",
     "@effect/sql-pg": "catalog:",
     "@vercel/nft": "^1.10.2",
-    "drizzle-kit": "catalog:",
-    "drizzle-orm": "catalog:",
     "effect": "catalog:",
     "mongodb": "^6.10.0",
     "mysql2": "^3.15.3",
@@ -489,12 +482,6 @@
       "optional": true
     },
     "@vercel/nft": {
-      "optional": true
-    },
-    "drizzle-kit": {
-      "optional": true
-    },
-    "drizzle-orm": {
       "optional": true
     },
     "mongodb": {

--- a/packages/alchemy/test/AWS/DSQL/fixtures/drizzle-handler.ts
+++ b/packages/alchemy/test/AWS/DSQL/fixtures/drizzle-handler.ts
@@ -1,6 +1,6 @@
 import * as DSQL from "@/AWS/DSQL";
 import * as Lambda from "@/AWS/Lambda";
-import * as Drizzle from "@/Drizzle/Postgres.ts";
+import * as Drizzle from "@alchemy.run/drizzle/Postgres";
 import { eq, sql } from "drizzle-orm";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";

--- a/packages/alchemy/test/AWS/RDSData/drizzle-iam-handler.ts
+++ b/packages/alchemy/test/AWS/RDSData/drizzle-iam-handler.ts
@@ -1,6 +1,6 @@
 import * as Lambda from "@/AWS/Lambda";
 import * as RDS from "@/AWS/RDS";
-import * as Drizzle from "@/Drizzle/Postgres.ts";
+import * as Drizzle from "@alchemy.run/drizzle/Postgres";
 import { sql } from "drizzle-orm";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";

--- a/packages/alchemy/test/Cloudflare/D1/Drizzle.test.ts
+++ b/packages/alchemy/test/Cloudflare/D1/Drizzle.test.ts
@@ -1,5 +1,5 @@
 import * as Cloudflare from "@/Cloudflare";
-import * as Drizzle from "@/Drizzle";
+import * as Drizzle from "@alchemy.run/drizzle";
 import * as Test from "@/Test/Alchemy";
 import { expect } from "alchemy-test";
 import * as Data from "effect/Data";

--- a/packages/alchemy/test/Cloudflare/D1/fixtures/drizzle-database.ts
+++ b/packages/alchemy/test/Cloudflare/D1/fixtures/drizzle-database.ts
@@ -1,5 +1,5 @@
 import * as Cloudflare from "@/Cloudflare/index.ts";
-import * as Drizzle from "@/Drizzle/index.ts";
+import * as Drizzle from "@alchemy.run/drizzle";
 import * as Effect from "effect/Effect";
 
 /**

--- a/packages/alchemy/test/Cloudflare/D1/fixtures/drizzle-stack.ts
+++ b/packages/alchemy/test/Cloudflare/D1/fixtures/drizzle-stack.ts
@@ -1,5 +1,5 @@
 import * as Cloudflare from "@/Cloudflare";
-import * as Drizzle from "@/Drizzle";
+import * as Drizzle from "@alchemy.run/drizzle";
 import * as Alchemy from "@/index";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";

--- a/packages/alchemy/test/Cloudflare/D1/fixtures/drizzle-worker.ts
+++ b/packages/alchemy/test/Cloudflare/D1/fixtures/drizzle-worker.ts
@@ -1,5 +1,5 @@
 import * as Cloudflare from "@/Cloudflare/index.ts";
-import * as Drizzle from "@/Drizzle/index.ts";
+import * as Drizzle from "@alchemy.run/drizzle";
 import * as SQL from "@/SQL/D1.ts";
 import * as Effect from "effect/Effect";
 import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/drizzle-do/object.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/drizzle-do/object.ts
@@ -1,5 +1,5 @@
 import * as Cloudflare from "@/Cloudflare";
-import * as Drizzle from "@/Drizzle/Cloudflare.ts";
+import * as Drizzle from "@alchemy.run/drizzle/Cloudflare";
 import { sql } from "drizzle-orm";
 import * as Effect from "effect/Effect";
 // The exact artifacts `drizzle-kit generate` emits for

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/drizzle-workflow/worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/drizzle-workflow/worker.ts
@@ -1,5 +1,5 @@
 import * as Cloudflare from "@/Cloudflare/index.ts";
-import * as Drizzle from "@/Drizzle/Postgres.ts";
+import * as Drizzle from "@alchemy.run/drizzle/Postgres";
 import { eq } from "drizzle-orm";
 import * as Effect from "effect/Effect";
 import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/drizzle-workflow/workflow.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/drizzle-workflow/workflow.ts
@@ -1,5 +1,5 @@
 import * as Cloudflare from "@/Cloudflare/index.ts";
-import * as Drizzle from "@/Drizzle/Postgres.ts";
+import * as Drizzle from "@alchemy.run/drizzle/Postgres";
 import { eq } from "drizzle-orm";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";

--- a/packages/alchemy/test/Drizzle/Schema.test.ts
+++ b/packages/alchemy/test/Drizzle/Schema.test.ts
@@ -1,4 +1,4 @@
-import * as Drizzle from "@/Drizzle";
+import * as Drizzle from "@alchemy.run/drizzle";
 import * as Provider from "@/Provider";
 import * as Stack from "@/Stack";
 import { State } from "@/State";

--- a/packages/alchemy/test/Planetscale/MySQL/fixtures/hyperdrive-worker.ts
+++ b/packages/alchemy/test/Planetscale/MySQL/fixtures/hyperdrive-worker.ts
@@ -1,5 +1,5 @@
 import * as Cloudflare from "@/Cloudflare/index.ts";
-import * as Drizzle from "@/Drizzle/MySQL.ts";
+import * as Drizzle from "@alchemy.run/drizzle/MySQL";
 import { eq } from "drizzle-orm";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";

--- a/packages/alchemy/test/Planetscale/Postgres/fixtures/hyperdrive-worker.ts
+++ b/packages/alchemy/test/Planetscale/Postgres/fixtures/hyperdrive-worker.ts
@@ -1,5 +1,5 @@
 import * as Cloudflare from "@/Cloudflare/index.ts";
-import * as Drizzle from "@/Drizzle/Postgres.ts";
+import * as Drizzle from "@alchemy.run/drizzle/Postgres";
 import { eq } from "drizzle-orm";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";

--- a/packages/alchemy/tsconfig.test.json
+++ b/packages/alchemy/tsconfig.test.json
@@ -39,6 +39,9 @@
       "path": "../alchemy-test/tsconfig.json"
     },
     {
+      "path": "../drizzle/tsconfig.json"
+    },
+    {
       "path": "./tsconfig.bin.json"
     }
   ]

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -1,0 +1,79 @@
+{
+  "name": "@alchemy.run/drizzle",
+  "version": "2.0.0-beta.70",
+  "description": "Drizzle ORM integration for Alchemy.",
+  "homepage": "https://alchemy.run",
+  "license": "Apache-2.0",
+  "author": "Sam Goodwin <sam@alchemy.run>",
+  "keywords": [
+    "alchemy",
+    "drizzle",
+    "effect",
+    "infrastructure-as-code"
+  ],
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
+    "directory": "packages/drizzle"
+  },
+  "bugs": {
+    "url": "https://github.com/alchemy-run/alchemy/issues"
+  },
+  "files": [
+    "lib",
+    "src"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsc -b"
+  },
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "bun": "./src/index.ts",
+      "worker": "./src/index.ts",
+      "import": "./lib/index.js"
+    },
+    "./*": {
+      "types": "./lib/*.d.ts",
+      "bun": "./src/*.ts",
+      "worker": "./src/*.ts",
+      "import": "./lib/*.js"
+    }
+  },
+  "dependencies": {
+    "@effect/sql-d1": "catalog:",
+    "@effect/sql-sqlite-do": "catalog:",
+    "alchemy": "workspace:*"
+  },
+  "peerDependencies": {
+    "@effect/sql-mysql2": "catalog:",
+    "@effect/sql-pg": "catalog:",
+    "drizzle-kit": "catalog:",
+    "drizzle-orm": "catalog:",
+    "effect": "catalog:",
+    "mysql2": "^3.15.3",
+    "pg": "^8.13.0"
+  },
+  "peerDependenciesMeta": {
+    "@effect/sql-mysql2": {
+      "optional": true
+    },
+    "@effect/sql-pg": {
+      "optional": true
+    },
+    "drizzle-kit": {
+      "optional": true
+    },
+    "mysql2": {
+      "optional": true
+    },
+    "pg": {
+      "optional": true
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/drizzle/src/Cloudflare.ts
+++ b/packages/drizzle/src/Cloudflare.ts
@@ -4,7 +4,7 @@ import * as SQLiteDoDrizzle from "drizzle-orm/effect-sqlite-do";
 import { migrate } from "drizzle-orm/effect-sqlite-do/migrator";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
-import { DurableObjectState } from "../Cloudflare/Workers/DurableObjectState.ts";
+import { DurableObjectState } from "alchemy/Cloudflare/Workers/DurableObjectState";
 
 /**
  * Migrations for {@link DurableObject} — the shape of the `migrations.js`
@@ -69,7 +69,7 @@ export interface DurableObjectConfig<
  * ```
  *
  * ```typescript
- * import * as Drizzle from "alchemy/Drizzle/Cloudflare";
+ * import * as Drizzle from "@alchemy.run/drizzle/Cloudflare";
  * import migrations from "./drizzle/migrations.js";
  * import { posts, relations, users } from "./schema.ts";
  *

--- a/packages/drizzle/src/D1.ts
+++ b/packages/drizzle/src/D1.ts
@@ -4,9 +4,9 @@ import type { EffectSQLiteD1Database } from "drizzle-orm/effect-d1";
 import * as SQLiteD1Drizzle from "drizzle-orm/effect-d1";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
-import type { D1DatabaseSource } from "../SQL/D1.ts";
-import { makeExecutionMemo } from "../Runtime/ExecutionMemo.ts";
-import { proxyChain } from "../Util/proxy-chain.ts";
+import { makeExecutionMemo } from "alchemy/Runtime/ExecutionMemo";
+import type { D1DatabaseSource } from "alchemy/SQL/D1";
+import { proxyChain } from "alchemy/Util/proxy-chain";
 
 /**
  * Open a Drizzle database over a Cloudflare D1 binding using the

--- a/packages/drizzle/src/MySQL.ts
+++ b/packages/drizzle/src/MySQL.ts
@@ -1,5 +1,5 @@
 // `@effect/sql-mysql2` (and mysql2 underneath) are optional peers — value
-// imports are deferred to first use so `alchemy/Drizzle` resolves without
+// imports are deferred to first use so `@alchemy.run/drizzle` resolves without
 // them installed.
 import type * as MysqlClient from "@effect/sql-mysql2/MysqlClient";
 import type { AnyRelations, EmptyRelations } from "drizzle-orm";
@@ -8,9 +8,9 @@ import type { EffectDrizzleMySqlConfig } from "drizzle-orm/mysql-core/effect/uti
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import type * as Redacted from "effect/Redacted";
-import { makeExecutionMemo } from "../Runtime/ExecutionMemo.ts";
-import type { MySQLConfig } from "../SQL/MySQL.ts";
-import { proxyChain } from "../Util/proxy-chain.ts";
+import { makeExecutionMemo } from "alchemy/Runtime/ExecutionMemo";
+import type { MySQLConfig } from "alchemy/SQL/MySQL";
+import { proxyChain } from "alchemy/Util/proxy-chain";
 
 /**
  * Open a Drizzle/MySQL database from a connection URL using the
@@ -62,7 +62,7 @@ export const MySQL = <
             Promise.all([
               import("@effect/sql-mysql2/MysqlClient"),
               import("drizzle-orm/effect-mysql2"),
-              import("../SQL/MySQL.ts"),
+              import("alchemy/SQL/MySQL"),
             ]),
           );
         const { client, ...drizzleConfig } = config ?? {};

--- a/packages/drizzle/src/Postgres.ts
+++ b/packages/drizzle/src/Postgres.ts
@@ -1,5 +1,5 @@
 // `@effect/sql-pg` (and pg underneath) are optional peers — value imports
-// are deferred to first use so `alchemy/Drizzle` resolves without them
+// are deferred to first use so `@alchemy.run/drizzle` resolves without them
 // installed.
 import type * as PgClient from "@effect/sql-pg/PgClient";
 import type { AnyRelations, EmptyRelations } from "drizzle-orm";
@@ -8,8 +8,8 @@ import type { EffectDrizzlePgConfig } from "drizzle-orm/pg-core/effect/utils";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import type * as Redacted from "effect/Redacted";
-import { makeExecutionMemo } from "../Runtime/ExecutionMemo.ts";
-import { proxyChain } from "../Util/proxy-chain.ts";
+import { makeExecutionMemo } from "alchemy/Runtime/ExecutionMemo";
+import { proxyChain } from "alchemy/Util/proxy-chain";
 
 /**
  * Open a Drizzle/Postgres database from a connection URL using the

--- a/packages/drizzle/src/Providers.ts
+++ b/packages/drizzle/src/Providers.ts
@@ -1,5 +1,5 @@
 import * as Layer from "effect/Layer";
-import * as Provider from "../Provider.ts";
+import * as Provider from "alchemy/Provider";
 import { Schema, SchemaProvider } from "./Schema.ts";
 
 export class Providers extends Provider.ProviderCollection<Providers>()(
@@ -17,7 +17,7 @@ export type ProviderRequirements = Layer.Services<ReturnType<typeof providers>>;
  * ```typescript
  * import * as Alchemy from "alchemy";
  * import * as Cloudflare from "alchemy/Cloudflare";
- * import * as Drizzle from "alchemy/Drizzle";
+ * import * as Drizzle from "@alchemy.run/drizzle";
  * import * as Neon from "alchemy/Neon";
  * import * as Effect from "effect/Effect";
  * import * as Layer from "effect/Layer";

--- a/packages/drizzle/src/Schema.ts
+++ b/packages/drizzle/src/Schema.ts
@@ -4,11 +4,11 @@ import * as Path from "effect/Path";
 import type { PlatformError } from "effect/PlatformError";
 import { ChildProcess } from "effect/unstable/process";
 import * as crypto from "node:crypto";
-import * as Artifacts from "../Artifacts.ts";
-import { isResolved } from "../Diff.ts";
-import * as Provider from "../Provider.ts";
-import { Resource } from "../Resource.ts";
-import { exec } from "../Util/exec.ts";
+import * as Artifacts from "alchemy/Artifacts";
+import { isResolved } from "alchemy/Diff";
+import * as Provider from "alchemy/Provider";
+import { Resource } from "alchemy/Resource";
+import { exec } from "alchemy/Util/exec";
 import type { Providers } from "./Providers.ts";
 
 export type Dialect = "postgres" | "mysql" | "sqlite";

--- a/packages/drizzle/src/index.ts
+++ b/packages/drizzle/src/index.ts
@@ -16,4 +16,4 @@ export * from "./Schema.ts";
 // (`@effect/sql-mysql2`/`mysql2`, `@effect/sql-pg`/`pg`) are optional peer
 // dependencies, and keeping them out of the barrel keeps them out of every
 // non-user's module graph. Import them via their subpaths instead:
-// `alchemy/Drizzle/MySQL`, `alchemy/Drizzle/Postgres`.
+// `@alchemy.run/drizzle/MySQL`, `@alchemy.run/drizzle/Postgres`.

--- a/packages/drizzle/tsconfig.json
+++ b/packages/drizzle/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*.ts"],
+  "compilerOptions": {
+    "composite": true,
+    "noEmit": false,
+    "outDir": "./lib",
+    "rootDir": "./src"
+  },
+  "references": [
+    {
+      "path": "../alchemy/tsconfig.json"
+    }
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -52,6 +52,9 @@
       "path": "./packages/better-auth/tsconfig.json"
     },
     {
+      "path": "./packages/drizzle/tsconfig.json"
+    },
+    {
       "path": "./packages/pr-package/tsconfig.json"
     },
     // TODO(sam): fix by upgrading starlight to ^0.39.2

--- a/website/src/content/docs/cloudflare/data/branch-from-shared-database.mdx
+++ b/website/src/content/docs/cloudflare/data/branch-from-shared-database.mdx
@@ -31,7 +31,7 @@ unconditionally creates its own `Neon.Project`:
 ```typescript
 // src/Db.ts
 import * as Cloudflare from "alchemy/Cloudflare";
-import * as Drizzle from "alchemy/Drizzle";
+import * as Drizzle from "@alchemy.run/drizzle";
 import * as Neon from "alchemy/Neon";
 import * as Effect from "effect/Effect";
 
@@ -73,7 +73,7 @@ to every stack effect:
 ```diff lang="typescript"
 +import * as Alchemy from "alchemy";
  import * as Cloudflare from "alchemy/Cloudflare";
- import * as Drizzle from "alchemy/Drizzle";
+ import * as Drizzle from "@alchemy.run/drizzle";
  import * as Neon from "alchemy/Neon";
  import * as Effect from "effect/Effect";
 
@@ -146,7 +146,7 @@ without paying for a whole Postgres cluster.
 // src/Db.ts
 import * as Alchemy from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
-import * as Drizzle from "alchemy/Drizzle";
+import * as Drizzle from "@alchemy.run/drizzle";
 import * as Neon from "alchemy/Neon";
 import * as Effect from "effect/Effect";
 

--- a/website/src/content/docs/cloudflare/data/d1-drizzle.mdx
+++ b/website/src/content/docs/cloudflare/data/d1-drizzle.mdx
@@ -5,7 +5,7 @@ description: Manage your Drizzle schema as a resource, apply migrations to D1 on
 
 import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 
-export const drizzleDeps = `drizzle-orm@^1.0.0-rc.4 @effect/sql-d1`;
+export const drizzleDeps = `@alchemy.run/drizzle drizzle-orm@^1.0.0-rc.4 @effect/sql-d1`;
 export const drizzleDevDeps = `drizzle-kit@^1.0.0-rc.4`;
 
 D1 is serverless SQLite, so Drizzle needs no connection string, no
@@ -92,7 +92,7 @@ SQL.
 ```diff lang="typescript"
 // alchemy.run.ts
 import * as Cloudflare from "alchemy/Cloudflare";
-+import * as Drizzle from "alchemy/Drizzle";
++import * as Drizzle from "@alchemy.run/drizzle";
 +import * as Layer from "effect/Layer";
 
 export default Alchemy.Stack(
@@ -117,7 +117,7 @@ no separate `drizzle-kit generate` step in CI:
 ```typescript
 // src/Db.ts
 import * as Cloudflare from "alchemy/Cloudflare";
-import * as Drizzle from "alchemy/Drizzle";
+import * as Drizzle from "@alchemy.run/drizzle";
 import * as Effect from "effect/Effect";
 
 export const Database = Effect.gen(function* () {
@@ -150,7 +150,7 @@ directly:
 ```typescript
 // src/Api.ts
 import * as Cloudflare from "alchemy/Cloudflare";
-import * as Drizzle from "alchemy/Drizzle";
+import * as Drizzle from "@alchemy.run/drizzle";
 import * as Effect from "effect/Effect";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import { Database } from "./Db.ts";

--- a/website/src/content/docs/cloudflare/data/drizzle.mdx
+++ b/website/src/content/docs/cloudflare/data/drizzle.mdx
@@ -5,7 +5,7 @@ description: Replace raw pg with Drizzle's effect-postgres integration, manage y
 
 import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 
-export const drizzleDeps = `drizzle-orm@^1.0.0-rc.4 @effect/sql-pg pg`;
+export const drizzleDeps = `@alchemy.run/drizzle drizzle-orm@^1.0.0-rc.4 @effect/sql-pg pg`;
 export const drizzleDevDeps = `drizzle-kit@^1.0.0-rc.4 @types/pg`;
 export const mysqlDeps = `@effect/sql-mysql2 mysql2`;
 
@@ -65,7 +65,7 @@ export const Posts = pgTable("posts", {
 ```diff lang="typescript"
 // alchemy.run.ts
 import * as Cloudflare from "alchemy/Cloudflare";
-+import * as Drizzle from "alchemy/Drizzle";
++import * as Drizzle from "@alchemy.run/drizzle";
 import * as Neon from "alchemy/Neon";
 import * as Layer from "effect/Layer";
 
@@ -114,7 +114,7 @@ branch resource each deploy:
 ```diff lang="typescript"
 // src/Db.ts
 import * as Cloudflare from "alchemy/Cloudflare";
-+import * as Drizzle from "alchemy/Drizzle";
++import * as Drizzle from "@alchemy.run/drizzle";
 import * as Neon from "alchemy/Neon";
 import * as Effect from "effect/Effect";
 
@@ -159,7 +159,7 @@ wrappers around queries:
 ```typescript
 // src/Api.ts
 import * as Cloudflare from "alchemy/Cloudflare";
-import * as Drizzle from "alchemy/Drizzle/Postgres";
+import * as Drizzle from "@alchemy.run/drizzle/Postgres";
 import * as Effect from "effect/Effect";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import { Hyperdrive } from "./Db.ts";
@@ -322,7 +322,7 @@ Register `Planetscale.providers()` alongside the Drizzle provider:
 ```diff lang="typescript"
 // alchemy.run.ts
 import * as Cloudflare from "alchemy/Cloudflare";
-import * as Drizzle from "alchemy/Drizzle";
+import * as Drizzle from "@alchemy.run/drizzle";
 -import * as Neon from "alchemy/Neon";
 +import * as Planetscale from "alchemy/Planetscale";
 import * as Layer from "effect/Layer";
@@ -344,7 +344,7 @@ pending migrations transactionally on every deploy:
 ```typescript
 // src/Db.ts
 import * as Cloudflare from "alchemy/Cloudflare";
-import * as Drizzle from "alchemy/Drizzle";
+import * as Drizzle from "@alchemy.run/drizzle";
 import * as Planetscale from "alchemy/Planetscale";
 import * as Effect from "effect/Effect";
 
@@ -442,7 +442,7 @@ uses the MySQL resource trio — database, branch, and a
 ```typescript
 // src/Db.ts
 import * as Cloudflare from "alchemy/Cloudflare";
-import * as Drizzle from "alchemy/Drizzle";
+import * as Drizzle from "@alchemy.run/drizzle";
 import * as Planetscale from "alchemy/Planetscale";
 import * as Effect from "effect/Effect";
 
@@ -493,7 +493,7 @@ At runtime, `Drizzle.MySQL` is the drop-in sibling of
 ```typescript
 // src/Api.ts
 import * as Cloudflare from "alchemy/Cloudflare";
-import * as Drizzle from "alchemy/Drizzle/MySQL";
+import * as Drizzle from "@alchemy.run/drizzle/MySQL";
 import * as Effect from "effect/Effect";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import { Hyperdrive } from "./Db.ts";

--- a/website/src/content/docs/cloudflare/data/shared-database.mdx
+++ b/website/src/content/docs/cloudflare/data/shared-database.mdx
@@ -29,7 +29,7 @@ project — wasteful for short-lived PR previews:
 ```typescript
 // src/Db.ts
 import * as Alchemy from "alchemy";
-import * as Drizzle from "alchemy/Drizzle";
+import * as Drizzle from "@alchemy.run/drizzle";
 import * as Neon from "alchemy/Neon";
 import * as Effect from "effect/Effect";
 
@@ -137,7 +137,7 @@ copy-on-write and free; projects aren't.
 ```typescript
 // src/Db.ts
 import * as Alchemy from "alchemy";
-import * as Drizzle from "alchemy/Drizzle";
+import * as Drizzle from "@alchemy.run/drizzle";
 import * as Neon from "alchemy/Neon";
 import * as Effect from "effect/Effect";
 

--- a/website/src/content/docs/cloudflare/frontend/full-stack-tanstack-rpc-drizzle.mdx
+++ b/website/src/content/docs/cloudflare/frontend/full-stack-tanstack-rpc-drizzle.mdx
@@ -122,7 +122,7 @@ Worker reaches Postgres through Cloudflare's connection pooler:
 // src/backend/database.ts
 import * as Alchemy from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
-import * as Drizzle from "alchemy/Drizzle";
+import * as Drizzle from "@alchemy.run/drizzle";
 import * as Neon from "alchemy/Neon";
 import * as Effect from "effect/Effect";
 
@@ -187,7 +187,7 @@ we raise inside the `flatMap` stays a normal, typed failure the client can catch
 ```typescript
 // src/backend/api.ts
 import * as Cloudflare from "alchemy/Cloudflare";
-import * as Drizzle from "alchemy/Drizzle/Postgres";
+import * as Drizzle from "@alchemy.run/drizzle/Postgres";
 import { eq } from "drizzle-orm";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -280,7 +280,7 @@ resource into an SSR Worker (see [Frontend frameworks](/cloudflare/frontend/fron
 // alchemy.run.ts
 import * as Alchemy from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
-import * as Drizzle from "alchemy/Drizzle";
+import * as Drizzle from "@alchemy.run/drizzle";
 import * as Neon from "alchemy/Neon";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";

--- a/website/src/content/docs/neon/guides/drizzle.mdx
+++ b/website/src/content/docs/neon/guides/drizzle.mdx
@@ -17,7 +17,7 @@ next to Neon's in your stack config:
 
 ```typescript
 // alchemy.run.ts
-import * as Drizzle from "alchemy/Drizzle";
+import * as Drizzle from "@alchemy.run/drizzle";
 import * as Neon from "alchemy/Neon";
 import * as Layer from "effect/Layer";
 
@@ -33,7 +33,7 @@ Point `Drizzle.Schema` at your schema module and the directory
 where migrations should land:
 
 ```typescript
-import * as Drizzle from "alchemy/Drizzle";
+import * as Drizzle from "@alchemy.run/drizzle";
 
 const schema = yield* Drizzle.Schema("app-schema", {
   schema: "./src/schema.ts",

--- a/website/src/content/docs/planetscale/guides/drizzle.mdx
+++ b/website/src/content/docs/planetscale/guides/drizzle.mdx
@@ -40,7 +40,7 @@ alongside PlanetScale's:
 ```typescript
 // alchemy.run.ts
 import * as Cloudflare from "alchemy/Cloudflare";
-import * as Drizzle from "alchemy/Drizzle";
+import * as Drizzle from "@alchemy.run/drizzle";
 import * as Planetscale from "alchemy/Planetscale";
 import * as Layer from "effect/Layer";
 

--- a/website/src/content/docs/prisma/guides/cloudflare-workers.mdx
+++ b/website/src/content/docs/prisma/guides/cloudflare-workers.mdx
@@ -8,7 +8,7 @@ from the same resources:
 
 ```typescript
 import * as Cloudflare from "alchemy/Cloudflare";
-import * as Drizzle from "alchemy/Drizzle/Postgres";
+import * as Drizzle from "@alchemy.run/drizzle/Postgres";
 import * as Prisma from "alchemy/Prisma";
 import * as SQL from "alchemy/SQL/Postgres";
 import * as Effect from "effect/Effect";

--- a/website/src/content/docs/project-structure/file-layout.mdx
+++ b/website/src/content/docs/project-structure/file-layout.mdx
@@ -105,7 +105,7 @@ Resources that change together share a file:
 
 ```typescript
 // src/Db.ts
-import * as Drizzle from "alchemy/Drizzle";
+import * as Drizzle from "@alchemy.run/drizzle";
 import * as Neon from "alchemy/Neon";
 import * as Effect from "effect/Effect";
 
@@ -177,7 +177,7 @@ With the units in `src/`, the root file shrinks to wiring:
 // alchemy.run.ts
 import * as Alchemy from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
-import * as Drizzle from "alchemy/Drizzle";
+import * as Drizzle from "@alchemy.run/drizzle";
 import * as Neon from "alchemy/Neon";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";

--- a/website/src/content/docs/sql/drizzle/d1.mdx
+++ b/website/src/content/docs/sql/drizzle/d1.mdx
@@ -5,7 +5,7 @@ description: Drizzle on Cloudflare D1 — declare the schema, generate and apply
 
 import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 
-export const deps = `drizzle-orm @effect/sql-d1`;
+export const deps = `@alchemy.run/drizzle drizzle-orm @effect/sql-d1`;
 export const devDeps = `drizzle-kit`;
 
 Drizzle on D1, end to end: a schema module, a `Drizzle.Schema`
@@ -71,7 +71,7 @@ first, apply second, in one `alchemy deploy`:
 ```typescript
 // src/db.ts
 import * as Cloudflare from "alchemy/Cloudflare";
-import * as Drizzle from "alchemy/Drizzle";
+import * as Drizzle from "@alchemy.run/drizzle";
 import * as Effect from "effect/Effect";
 
 export const Database = Effect.gen(function* () {
@@ -100,7 +100,7 @@ client to `Drizzle.D1`:
 ```typescript
 // src/api.ts
 import * as Cloudflare from "alchemy/Cloudflare";
-import * as Drizzle from "alchemy/Drizzle";
+import * as Drizzle from "@alchemy.run/drizzle";
 import * as Effect from "effect/Effect";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import { Database } from "./db.ts";

--- a/website/src/content/docs/sql/drizzle/migrations.mdx
+++ b/website/src/content/docs/sql/drizzle/migrations.mdx
@@ -115,7 +115,7 @@ Object. Commit it and hand it to `Drizzle.DurableObject`, along with
 the `relations`:
 
 ```typescript
-import * as Drizzle from "alchemy/Drizzle/Cloudflare";
+import * as Drizzle from "@alchemy.run/drizzle/Cloudflare";
 import migrations from "./drizzle/migrations.js";
 import { posts, relations, users } from "./schema.ts";
 
@@ -136,7 +136,7 @@ export class Users extends Cloudflare.DurableObject<Users>()(
 ) {}
 ```
 
-`Drizzle.DurableObject` (from `alchemy/Drizzle/Cloudflare`) opens
+`Drizzle.DurableObject` (from `@alchemy.run/drizzle/Cloudflare`) opens
 drizzle over the instance's own SQLite storage using the
 `drizzle-orm/effect-sqlite-do` integration — the
 same effect-native query surface as [`Drizzle.D1`](/sql/drizzle/d1)

--- a/website/src/content/docs/sql/drizzle/mysql.mdx
+++ b/website/src/content/docs/sql/drizzle/mysql.mdx
@@ -5,7 +5,7 @@ description: Drizzle on MySQL — declare the schema, generate and apply migrati
 
 import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 
-export const deps = `drizzle-orm @effect/sql-mysql2 mysql2`;
+export const deps = `@alchemy.run/drizzle drizzle-orm @effect/sql-mysql2 mysql2`;
 export const devDeps = `drizzle-kit`;
 
 Drizzle on MySQL, end to end: a schema module, a `Drizzle.Schema`
@@ -71,7 +71,7 @@ second, in one `alchemy deploy`. On PlanetScale:
 ```typescript
 // src/db.ts
 import * as Cloudflare from "alchemy/Cloudflare";
-import * as Drizzle from "alchemy/Drizzle";
+import * as Drizzle from "@alchemy.run/drizzle";
 import * as Planetscale from "alchemy/Planetscale";
 import * as Effect from "effect/Effect";
 
@@ -122,7 +122,7 @@ connection string:
 ```typescript
 // src/api.ts
 import * as Cloudflare from "alchemy/Cloudflare";
-import * as Drizzle from "alchemy/Drizzle/MySQL";
+import * as Drizzle from "@alchemy.run/drizzle/MySQL";
 import * as Effect from "effect/Effect";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import { Hyperdrive } from "./db.ts";

--- a/website/src/content/docs/sql/drizzle/postgres.mdx
+++ b/website/src/content/docs/sql/drizzle/postgres.mdx
@@ -5,7 +5,7 @@ description: Drizzle on Postgres — declare the schema, generate and apply migr
 
 import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 
-export const deps = `drizzle-orm @effect/sql-pg pg`;
+export const deps = `@alchemy.run/drizzle drizzle-orm @effect/sql-pg pg`;
 export const devDeps = `drizzle-kit`;
 
 Drizzle on Postgres, end to end: a schema module, a `Drizzle.Schema`
@@ -72,7 +72,7 @@ first, apply second, in one `alchemy deploy`. On Neon:
 ```typescript
 // src/db.ts
 import * as Cloudflare from "alchemy/Cloudflare";
-import * as Drizzle from "alchemy/Drizzle";
+import * as Drizzle from "@alchemy.run/drizzle";
 import * as Neon from "alchemy/Neon";
 import * as Effect from "effect/Effect";
 
@@ -112,7 +112,7 @@ its connection string:
 ```typescript
 // src/api.ts
 import * as Cloudflare from "alchemy/Cloudflare";
-import * as Drizzle from "alchemy/Drizzle/Postgres";
+import * as Drizzle from "@alchemy.run/drizzle/Postgres";
 import * as Effect from "effect/Effect";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import { Hyperdrive } from "./db.ts";

--- a/website/src/content/docs/sql/index.mdx
+++ b/website/src/content/docs/sql/index.mdx
@@ -25,19 +25,19 @@ everything else.
 typed errors, no ORM — one subpath per backend (`alchemy/SQL/D1`,
 `alchemy/SQL/Postgres`, `alchemy/SQL/MySQL`), so you only load the
 driver you use.
-`alchemy/Drizzle` is the ORM sibling: a typed schema and relational
+`@alchemy.run/drizzle` is the ORM sibling: a typed schema and relational
 queries. `Drizzle.Schema`, `Drizzle.providers()`, and `Drizzle.D1`
-come from the `alchemy/Drizzle` entry; the Postgres and MySQL
-clients live on their own subpaths (`alchemy/Drizzle/Postgres`,
-`alchemy/Drizzle/MySQL`) so their drivers only load when you use
+come from the `@alchemy.run/drizzle` entry; the Postgres and MySQL
+clients live on their own subpaths (`@alchemy.run/drizzle/Postgres`,
+`@alchemy.run/drizzle/MySQL`) so their drivers only load when you use
 them, and the Durable Object client lives at
-`alchemy/Drizzle/Cloudflare`. Both wrap the same
+`@alchemy.run/drizzle/Cloudflare`. Both wrap the same
 [`@effect/sql`](https://effect.website) drivers and share one
 lifecycle.
 
 ```typescript
 import * as SQL from "alchemy/SQL/D1";
-import * as Drizzle from "alchemy/Drizzle";
+import * as Drizzle from "@alchemy.run/drizzle";
 
 // Raw effect-sql — tagged-template queries, typed errors
 const sql = yield* SQL.D1(d1);

--- a/website/src/content/docs/testing/testing-a-stack.mdx
+++ b/website/src/content/docs/testing/testing-a-stack.mdx
@@ -12,7 +12,7 @@ Configure Providers and state once per file — `Test.make` returns everything t
 ```typescript
 import * as Alchemy from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
-import * as Drizzle from "alchemy/Drizzle";
+import * as Drizzle from "@alchemy.run/drizzle";
 import * as Neon from "alchemy/Neon";
 import * as Test from "alchemy/Test/Bun";
 import { expect } from "bun:test";


### PR DESCRIPTION
Extract the Drizzle integration into its own package, `@alchemy.run/drizzle` (`packages/drizzle`), so `drizzle-orm` / `drizzle-kit` are off the `alchemy` package's critical path.

```diff
-import * as Drizzle from "alchemy/Drizzle";
-import * as DrizzlePg from "alchemy/Drizzle/Postgres";
+import * as Drizzle from "@alchemy.run/drizzle";
+import * as DrizzlePg from "@alchemy.run/drizzle/Postgres";
```

- The moved sources (`Schema`, `Providers`, `Postgres`, `MySQL`, `D1`, `Cloudflare`) now import alchemy internals via public subpaths (`alchemy/Provider`, `alchemy/Runtime/ExecutionMemo`, `alchemy/SQL/D1`, …). Same export shape as before: barrel + `./Postgres` / `./MySQL` / `./Cloudflare` subpaths, `bun`/`worker`/`import`/`types` conditions.
- `alchemy` drops the `./Drizzle` exports, the `drizzle-kit` / `drizzle-orm` peers, and `@effect/sql-sqlite-do` (Drizzle-only); the new package takes `@effect/sql-d1` + `@effect/sql-sqlite-do` as deps, `drizzle-orm` as a required peer, and `drizzle-kit` / `@effect/sql-pg` / `@effect/sql-mysql2` / `pg` / `mysql2` as optional peers.
- `alchemy` gains a `./Cloudflare/Workers/*` export pattern (like the existing `./AWS/Lambda/*`) so `Drizzle.DurableObject` can import `DurableObjectState` as a single module instead of the whole Cloudflare barrel.
- Tests stay in `packages/alchemy/test` and import the new package. The dep lives in the workspace **root's** devDependencies: a devDep on `alchemy` itself would make `alchemy ⇄ @alchemy.run/drizzle` a package cycle that turbo hard-errors on.
- Wired into root tsconfig references, `build:pr-packages`, and the `release.yml` / `pr-package.yml` matrices; the five drizzle examples and all guide docs updated to the new package (blog posts left as historical record).

Verified: `bun tsc -b` clean; `test/Drizzle` (8/8), live `test/Cloudflare/D1/Drizzle.test.ts`, and live `test/Cloudflare/Workers/DrizzleDurableObjectMigrations.test.ts` pass — the latter two exercise worker bundling through the new package's `worker` export condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
