### PR TITLE
test(release): check pnpm peer graph

### DIFF
--- a/.github/workflows/pr-package.yml
+++ b/.github/workflows/pr-package.yml
@@ -69,6 +69,34 @@ jobs:
             ]
           pr-package-token: ${{ secrets.PR_PACKAGE_TOKEN }}
 
+      - name: Check pnpm peer graph
+        if: fromJson(steps.publish.outputs.plan).packages[0] != null
+        env:
+          PLAN: ${{ steps.publish.outputs.plan }}
+        run: |
+          set -euo pipefail
+
+          PACKAGE_URL=$(jq -r '
+            . as $plan
+            | .packages[]
+            | select(.name == "alchemy")
+            | "https://\($plan.install_host)/\(.install)/\(.commit)"
+          ' <<< "$PLAN")
+
+          if [ -z "$PACKAGE_URL" ]; then
+            echo "alchemy was not selected for this publication"
+            exit 0
+          fi
+
+          TEMP_DIR=$(mktemp -d)
+          trap 'rm -rf "$TEMP_DIR"' EXIT
+          cd "$TEMP_DIR"
+
+          bunx pnpm@11.21.0 init
+          bunx pnpm@11.21.0 config set blockExoticSubdeps false --location project
+          bunx pnpm@11.21.0 add --ignore-scripts "$PACKAGE_URL"
+          bunx pnpm@11.21.0 peers check
+
       - name: Generate bot token
         if: >-
           github.event_name == 'pull_request' &&


### PR DESCRIPTION
Prevent #1149 from recurring by installing the just-published `alchemy` PR package with pnpm 11.21.0 and failing when its peer graph is inconsistent.

The check follows the same package URLs emitted by the PR-package workflow, disables pnpm's exotic-subdependency block only for those trusted preview URLs, and ignores install scripts.

This covers the published-manifest boundary that workspace installs and the Bun lockfile cannot expose. The current `main` preview resolves a coherent Effect beta.106 and Distilled rc.3 graph.
