### PR TITLE
docs: Layer pages in the API reference generator + Better Auth hub

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,10 +182,32 @@ bun generate:api-reference   # -> website/src/content/docs/providers/{Cloud}/{Re
 
 This is the only doc generator that produces user-facing output. ([scripts/generate-api-reference.ts](./scripts/generate-api-reference.ts)) does the following:
 
-1. Discovers resource files in `packages/alchemy/src/{Cloud}/{Service}/`
+1. Discovers documented files across its configured source roots — `packages/alchemy/src/{Cloud}/{Service}/` plus flat single-provider packages like `packages/better-auth/src/` (mapped onto a synthetic provider directory, e.g. `BetterAuth/`)
 2. Parses TypeScript with `ts-morph`
-3. Extracts the resource-level summary plus `@section` / `@example` blocks from JSDoc
-4. Writes one markdown file per resource at `website/src/content/docs/providers/{Cloud}/{Resource}.md`
+3. Extracts the page-level summary plus `@section` / `@example` blocks from JSDoc on the export tagged `@resource`, `@binding`, or `@layer`
+4. Writes one markdown file per page at `website/src/content/docs/providers/{Provider}/{Name}.md`
+
+**Layer pages** (`@layer`) document exported Layer factories — the pluggable implementations of a Context service (e.g. better-auth's database layers). Alongside the shared tags, a Layer declares what it satisfies and needs:
+
+```typescript
+/**
+ * Neon database layer for Better Auth over Neon's serverless driver.
+ *
+ * @layer
+ * @provides BetterAuth.Database
+ * @peer @neondatabase/serverless
+ * @product Neon
+ *
+ * @section Connecting from a Worker or Lambda
+ * @example ...
+ */
+export const Neon = (url: ConnectionSource, options?: NeonOptions): Layer.Layer<Database> => ...
+```
+
+- `@provides <Service.Tag>` — the Context service tag(s) the Layer satisfies (repeatable)
+- `@peer <package>` — optional peer dependencies the Layer needs at runtime (repeatable)
+
+Both render as a metadata line under the page's `Source:` blockquote. Every Layer implementation should carry these annotations — a Layer without them is an undocumented integration surface.
 
 After editing JSDoc on a resource, run `bun generate:api-reference` to refresh the website docs.
 

--- a/scripts/generate-api-reference.ts
+++ b/scripts/generate-api-reference.ts
@@ -5,15 +5,47 @@ import { Node, Project, type SourceFile } from "ts-morph";
 
 const websiteRoot = path.join(import.meta.dir, "../website");
 
+interface SourceRoot {
+  /** Directory scanned for documented source files. */
+  srcRoot: string;
+  tsConfig: string;
+  /**
+   * Synthetic provider name for flat single-provider packages (their files
+   * sit directly at `srcRoot`); empty for the alchemy package, whose
+   * top-level directories ARE the providers.
+   */
+  providerPrefix: string;
+  /** Display prefix for the page's `Source:` line. */
+  sourceDisplayPrefix: string;
+}
+
 const config = {
-  srcRoot: path.join(import.meta.dir, "../packages/alchemy/src"),
   outRoot: path.join(websiteRoot, "src/content/docs/providers"),
-  tsConfig: path.join(import.meta.dir, "../packages/alchemy/tsconfig.json"),
+  roots: [
+    {
+      srcRoot: path.join(import.meta.dir, "../packages/alchemy/src"),
+      tsConfig: path.join(import.meta.dir, "../packages/alchemy/tsconfig.json"),
+      providerPrefix: "",
+      sourceDisplayPrefix: "src",
+    },
+    {
+      srcRoot: path.join(import.meta.dir, "../packages/better-auth/src"),
+      tsConfig: path.join(
+        import.meta.dir,
+        "../packages/better-auth/tsconfig.json",
+      ),
+      providerPrefix: "BetterAuth",
+      sourceDisplayPrefix: "packages/better-auth/src",
+    },
+  ] satisfies SourceRoot[],
 };
 
 interface FileEntry {
+  /** Output-relative path (provider-prefixed for flat packages). */
   relativePath: string;
   absolutePath: string;
+  /** Display path for the page's `Source:` blockquote. */
+  sourceDisplay: string;
 }
 
 interface ExampleBlock {
@@ -29,17 +61,47 @@ interface ExampleSection {
 
 interface PageDoc {
   title: string;
-  relativePath: string;
+  /** Display path for the `Source:` blockquote. */
+  sourceDisplay: string;
   summary: string;
   sections: ExampleSection[];
+  /** True for `@layer` pages — renders the Layer metadata line. */
+  isLayer: boolean;
+  /** Service tags the Layer provides (`@provides`). */
+  provides: string[];
+  /** Optional peer dependencies (`@peer`). */
+  peers: string[];
 }
 
 const normalizeSlashes = (value: string) => value.split(path.sep).join("/");
 
-async function discoverFiles(): Promise<FileEntry[]> {
+const isSourceFile = (baseName: string) =>
+  (baseName.endsWith(".ts") || baseName.endsWith(".tsx")) &&
+  !baseName.endsWith(".d.ts") &&
+  baseName !== "index.ts";
+
+async function discoverFiles(root: SourceRoot): Promise<FileEntry[]> {
   const entries: FileEntry[] = [];
 
-  const topLevelEntries = await fs.readdir(config.srcRoot, {
+  // Flat single-provider packages: every file under srcRoot belongs to the
+  // synthetic provider directory.
+  if (root.providerPrefix) {
+    const files = (await fs.readdir(root.srcRoot, {
+      recursive: true,
+    })) as string[];
+    for (const file of files) {
+      if (!isSourceFile(path.basename(file))) continue;
+      entries.push({
+        relativePath: path.join(root.providerPrefix, file),
+        absolutePath: path.join(root.srcRoot, file),
+        sourceDisplay: `${root.sourceDisplayPrefix}/${normalizeSlashes(file)}`,
+      });
+    }
+    entries.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+    return entries;
+  }
+
+  const topLevelEntries = await fs.readdir(root.srcRoot, {
     withFileTypes: true,
   });
   const dirs = topLevelEntries
@@ -47,7 +109,7 @@ async function discoverFiles(): Promise<FileEntry[]> {
     .map((entry) => entry.name);
 
   for (const dir of dirs) {
-    const dirPath = path.join(config.srcRoot, dir);
+    const dirPath = path.join(root.srcRoot, dir);
     let files: string[];
     try {
       files = (await fs.readdir(dirPath, { recursive: true })) as string[];
@@ -56,15 +118,13 @@ async function discoverFiles(): Promise<FileEntry[]> {
     }
 
     for (const file of files) {
-      const baseName = path.basename(file);
-      if (!baseName.endsWith(".ts") && !baseName.endsWith(".tsx")) continue;
-      if (baseName.endsWith(".d.ts")) continue;
-      if (baseName === "index.ts") continue;
+      if (!isSourceFile(path.basename(file))) continue;
 
       const relativePath = path.join(dir, file);
       entries.push({
         relativePath,
-        absolutePath: path.join(config.srcRoot, relativePath),
+        absolutePath: path.join(root.srcRoot, relativePath),
+        sourceDisplay: `${root.sourceDisplayPrefix}/${normalizeSlashes(relativePath)}`,
       });
     }
   }
@@ -97,6 +157,12 @@ interface ParsedJSDoc {
   sections: ExampleSection[];
   hasResourceTag: boolean;
   hasBindingTag: boolean;
+  /** `@layer` — a Layer factory providing a Context service. */
+  hasLayerTag: boolean;
+  /** `@provides <Service.Tag>` — service tags the Layer satisfies. */
+  provides: string[];
+  /** `@peer <package>` — optional peer dependencies the Layer needs. */
+  peers: string[];
   category: string;
   product: string;
 }
@@ -109,6 +175,9 @@ function parseJSDoc(node: Node): ParsedJSDoc {
       sections: [],
       hasResourceTag: false,
       hasBindingTag: false,
+      hasLayerTag: false,
+      provides: [],
+      peers: [],
       category: "",
       product: "",
     };
@@ -118,8 +187,11 @@ function parseJSDoc(node: Node): ParsedJSDoc {
 
   const summaryLines: string[] = [];
   const sections: ExampleSection[] = [];
+  const provides: string[] = [];
+  const peers: string[] = [];
   let hasResourceTag = false;
   let hasBindingTag = false;
+  let hasLayerTag = false;
   let category = "";
   let product = "";
   let sawTag = false;
@@ -167,6 +239,15 @@ function parseJSDoc(node: Node): ParsedJSDoc {
           break;
         case "binding":
           hasBindingTag = true;
+          break;
+        case "layer":
+          hasLayerTag = true;
+          break;
+        case "provides":
+          if (value) provides.push(value);
+          break;
+        case "peer":
+          if (value) peers.push(value);
           break;
         case "category":
         case "group":
@@ -216,6 +297,9 @@ function parseJSDoc(node: Node): ParsedJSDoc {
     sections,
     hasResourceTag,
     hasBindingTag,
+    hasLayerTag,
+    provides,
+    peers,
     category,
     product,
   };
@@ -284,7 +368,9 @@ function findTaggedPrimary(sourceFile: SourceFile): Primary | undefined {
 
   for (const node of candidates) {
     const doc = parseJSDoc(node);
-    if (!doc.hasResourceTag && !doc.hasBindingTag) continue;
+    if (!doc.hasResourceTag && !doc.hasBindingTag && !doc.hasLayerTag) {
+      continue;
+    }
     const name = declName(node);
     if (!name) continue;
     const category = doc.category;
@@ -314,7 +400,16 @@ function findTaggedPrimary(sourceFile: SourceFile): Primary | undefined {
       }
       if (!best && pd.summary) best = pd;
     }
-    return { name, doc: best ?? doc, category, product };
+    // Borrowed prose keeps the TAGGED declaration's kind + metadata.
+    const merged: ParsedJSDoc = {
+      ...(best ?? doc),
+      hasResourceTag: doc.hasResourceTag,
+      hasBindingTag: doc.hasBindingTag,
+      hasLayerTag: doc.hasLayerTag,
+      provides: doc.provides,
+      peers: doc.peers,
+    };
+    return { name, doc: merged, category, product };
   }
   return undefined;
 }
@@ -543,7 +638,6 @@ function renderPageBody(doc: PageDoc): string {
 }
 
 function renderPage(doc: PageDoc, resolve: LinkResolver): string {
-  const sourcePath = `src/${normalizeSlashes(doc.relativePath)}`;
   const description =
     stripLinkTags(firstParagraph(doc.summary)) ||
     `API reference for ${doc.title}`;
@@ -554,7 +648,24 @@ function renderPage(doc: PageDoc, resolve: LinkResolver): string {
     "---",
   ].join("\n");
 
-  const sourceBlock = `> **Source:** \`${sourcePath}\``;
+  const headerLines = [`> **Source:** \`${doc.sourceDisplay}\``];
+  if (doc.isLayer) {
+    const meta = ["**Kind:** Layer"];
+    if (doc.provides.length > 0) {
+      meta.push(
+        `**Provides:** ${doc.provides.map((tag) => `\`${tag}\``).join(", ")}`,
+      );
+    }
+    if (doc.peers.length > 0) {
+      meta.push(
+        `**Peer dependencies:** ${doc.peers
+          .map((peer) => `\`${peer}\``)
+          .join(", ")}`,
+      );
+    }
+    headerLines.push(`> ${meta.join(" · ")}`);
+  }
+  const sourceBlock = headerLines.join("\n");
   const body = linkifyMarkdown(renderPageBody(doc).trim(), resolve);
 
   if (body) {
@@ -731,14 +842,6 @@ function assertNoDuplicateSiblings(items: SidebarItem[], path: string[]) {
 }
 
 async function main() {
-  const entries = await discoverFiles();
-  console.log(`Discovered ${entries.length} source files.`);
-
-  const project = new Project({
-    tsConfigFilePath: config.tsConfig,
-    skipFileDependencyResolution: true,
-  });
-
   await fs.rm(config.outRoot, { recursive: true, force: true });
   await fs.mkdir(config.outRoot, { recursive: true });
 
@@ -748,68 +851,85 @@ async function main() {
   let written = 0;
   let skipped = 0;
 
-  for (const entry of entries) {
-    const sourceFile = project.getSourceFile(entry.absolutePath);
-    if (!sourceFile) {
-      console.warn(`  skipped (not in project): ${entry.relativePath}`);
-      skipped++;
-      continue;
-    }
+  for (const root of config.roots) {
+    const entries = await discoverFiles(root);
+    console.log(
+      `Discovered ${entries.length} source files in ${normalizeSlashes(
+        path.relative(path.join(import.meta.dir, ".."), root.srcRoot),
+      )}.`,
+    );
 
-    const primary = findTaggedPrimary(sourceFile);
-    if (!primary) {
-      skipped++;
-      continue;
-    }
-
-    // Only emit a page when there's actual documented content; a bare
-    // frontmatter + source link stub is noise.
-    if (!primary.doc.summary && primary.doc.sections.length === 0) {
-      skipped++;
-      continue;
-    }
-
-    // Mirror the source directory structure; name the page after the
-    // tagged declaration (e.g. Cloudflare.AI.Search/AiSearchInstance.md).
-    const relDir = path.dirname(entry.relativePath);
-    const outputRelative = path.join(relDir, `${primary.name}.md`);
-
-    const existing = seen.get(outputRelative);
-    if (existing) {
-      console.warn(
-        `  collision: ${outputRelative} from ${entry.relativePath} (already from ${existing})`,
-      );
-    }
-    seen.set(outputRelative, entry.relativePath);
-
-    const doc: PageDoc = {
-      title: primary.name,
-      relativePath: entry.relativePath,
-      summary: primary.doc.summary,
-      sections: primary.doc.sections,
-    };
-    pending.push({ outputRelative, doc });
-
-    let exportNames: string[] = [];
-    try {
-      exportNames = [...sourceFile.getExportedDeclarations().keys()];
-    } catch {
-      // Unresolvable re-exports — page-name resolution still applies.
-    }
-
-    const segments = normalizeSlashes(outputRelative).split("/");
-    pageEntries.push({
-      provider: segments[0] ?? "",
-      service: segments.length > 2 ? segments[1] : "",
-      resource: primary.name,
-      category: primary.category,
-      product: primary.product,
-      link: `/providers/${normalizeSlashes(outputRelative)
-        .replace(/\.md$/, "")
-        .toLowerCase()}`,
-      dir: normalizeSlashes(relDir),
-      exports: exportNames,
+    const project = new Project({
+      tsConfigFilePath: root.tsConfig,
+      skipFileDependencyResolution: true,
     });
+
+    for (const entry of entries) {
+      const sourceFile = project.getSourceFile(entry.absolutePath);
+      if (!sourceFile) {
+        console.warn(`  skipped (not in project): ${entry.relativePath}`);
+        skipped++;
+        continue;
+      }
+
+      const primary = findTaggedPrimary(sourceFile);
+      if (!primary) {
+        skipped++;
+        continue;
+      }
+
+      // Only emit a page when there's actual documented content; a bare
+      // frontmatter + source link stub is noise.
+      if (!primary.doc.summary && primary.doc.sections.length === 0) {
+        skipped++;
+        continue;
+      }
+
+      // Mirror the source directory structure; name the page after the
+      // tagged declaration (e.g. Cloudflare.AI.Search/AiSearchInstance.md).
+      const relDir = path.dirname(entry.relativePath);
+      const outputRelative = path.join(relDir, `${primary.name}.md`);
+
+      const existing = seen.get(outputRelative);
+      if (existing) {
+        console.warn(
+          `  collision: ${outputRelative} from ${entry.relativePath} (already from ${existing})`,
+        );
+      }
+      seen.set(outputRelative, entry.relativePath);
+
+      const doc: PageDoc = {
+        title: primary.name,
+        sourceDisplay: entry.sourceDisplay,
+        summary: primary.doc.summary,
+        sections: primary.doc.sections,
+        isLayer: primary.doc.hasLayerTag,
+        provides: primary.doc.provides,
+        peers: primary.doc.peers,
+      };
+      pending.push({ outputRelative, doc });
+
+      let exportNames: string[] = [];
+      try {
+        exportNames = [...sourceFile.getExportedDeclarations().keys()];
+      } catch {
+        // Unresolvable re-exports — page-name resolution still applies.
+      }
+
+      const segments = normalizeSlashes(outputRelative).split("/");
+      pageEntries.push({
+        provider: segments[0] ?? "",
+        service: segments.length > 2 ? segments[1] : "",
+        resource: primary.name,
+        category: primary.category,
+        product: primary.product,
+        link: `/providers/${normalizeSlashes(outputRelative)
+          .replace(/\.md$/, "")
+          .toLowerCase()}`,
+        dir: normalizeSlashes(relDir),
+        exports: exportNames,
+      });
+    }
   }
 
   // Second pass: render with `{@link}` resolution — the full page set must be

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -28,6 +28,7 @@ function providersSidebarEntry() {
       { label: "PlanetScale", link: "/planetscale" },
       { label: "Neon", link: "/neon" },
       { label: "Prisma", link: "/prisma" },
+      { label: "Better Auth", link: "/better-auth" },
       { label: "Axiom", link: "/axiom" },
       { label: "GitHub", link: "/github" },
       { label: "Docker", link: "/docker" },
@@ -1021,6 +1022,15 @@ export default defineConfig({
               ],
             },
             providerResourcesEntry("Prisma"),
+          ],
+        },
+        {
+          label: "Better Auth",
+          items: [
+            { label: "Overview", link: "/better-auth" },
+            { label: "Database layers", link: "/better-auth/database-layers" },
+            { label: "Migrations", link: "/better-auth/migrations" },
+            providerResourcesEntry("BetterAuth"),
           ],
         },
         {

--- a/website/src/components/ProviderDirectory.astro
+++ b/website/src/components/ProviderDirectory.astro
@@ -64,6 +64,10 @@ const HUBS: Record<string, { href: string; blurb: string }> = {
   },
   Neon: { href: "/neon", blurb: "Serverless Postgres with branches per PR" },
   Axiom: { href: "/axiom", blurb: "Logs, traces, dashboards, and monitors" },
+  BetterAuth: {
+    href: "/better-auth",
+    blurb: "Typed Better Auth with a database layer per platform",
+  },
   GitHub: { href: "/github", blurb: "Repos, secrets, and webhook events" },
   Docker: {
     href: "/docker",
@@ -85,7 +89,10 @@ const HUBS: Record<string, { href: string; blurb: string }> = {
 
 const BLURBS: Record<string, string> = {};
 
-const DISPLAY_LABELS: Record<string, string> = { Planetscale: "PlanetScale" };
+const DISPLAY_LABELS: Record<string, string> = {
+  Planetscale: "PlanetScale",
+  BetterAuth: "Better Auth",
+};
 
 const providers = generatedSidebar() ?? [];
 const cards = providers.map((p) => {

--- a/website/src/content/docs/better-auth/database-layers.mdx
+++ b/website/src/content/docs/better-auth/database-layers.mdx
@@ -1,0 +1,80 @@
+---
+title: Database layers
+description: One Layer per environment → database pair — HTTP and serverless drivers where they exist, TCP drivers as the fallback, all routed through alchemy's binding system.
+sidebar:
+  order: 1
+---
+
+`BetterAuth()` requires exactly one service: `BetterAuth.Database`.
+Platform layers provide it. Pick the optimal layer for your
+environment → database pair — HTTP/serverless transports where they
+exist, TCP drivers as the fallback:
+
+| Runtime | Database | Layer | Transport |
+| --- | --- | --- | --- |
+| Cloudflare Worker | D1 | [`CloudflareD1`](/providers/betterauth/cloudflared1) | native binding |
+| Worker / Lambda | Neon | [`Neon`](/providers/betterauth/neon) | serverless driver (WebSocket) |
+| AWS Lambda | Aurora | [`AuroraDataApi`](/providers/betterauth/auroradataapi) | RDS Data API (HTTPS, IAM) |
+| Cloudflare Worker | any TCP Postgres/MySQL | [`CloudflareHyperdrive`](/providers/betterauth/cloudflarehyperdrive) | pooled TCP via Hyperdrive |
+| anywhere with sockets | any Postgres | [`Postgres`](/providers/betterauth/postgres) | `pg` TCP |
+| anywhere with sockets | any MySQL | [`MySQL`](/providers/betterauth/mysql) | `mysql2` TCP |
+| bun (dev/tests) | local file | [`SQLite`](/providers/betterauth/sqlite) | `bun:sqlite` |
+| tests | in-memory | [`Memory`](/providers/betterauth/memory) | — |
+| bring-your-own | your Drizzle db | [`Drizzle`](/providers/betterauth/drizzle) | yours |
+
+## Layers are bindings
+
+Every layer routes runtime access through alchemy's binding system —
+never hand-wired environment variables:
+
+- **Native bindings** — `CloudflareD1` binds the D1 database to the
+  Worker; `CloudflareHyperdrive` binds the Hyperdrive connection;
+  `AuroraDataApi` grants the Lambda `rds-data:*` +
+  `secretsmanager:GetSecretValue` IAM through the `AWS.RDSData.*`
+  bindings.
+- **Environment Output bindings** — connection-string layers (`Neon`,
+  `Postgres`, `MySQL`) accept resource Outputs
+  (`project.connectionUri`, `role.connectionUrl`, ...); the value is
+  bound into the host environment at deploy and read back at runtime.
+
+Provide the layer on the impl effect that yields `BetterAuth`:
+
+```typescript
+Effect.gen(function* () {
+  const auth = yield* BetterAuth({ emailAndPassword: { enabled: true } });
+  return { fetch: /* ... */ };
+}).pipe(Effect.provide(CloudflareD1(AuthDb)));
+```
+
+When the layer needs a resource *attribute* (a connection string), build
+it with `Layer.unwrap` so it still composes at module scope:
+
+```typescript
+const AuthDatabase = Layer.unwrap(
+  Effect.map(AuthDb, (db) => NeonDatabase(db.connectionUri)),
+);
+```
+
+## Secondary storage
+
+Better Auth's optional `secondaryStorage` (sessions, rate limiting,
+OAuth state) is modeled as a second service, `BetterAuth.SecondaryStorage`,
+resolved only when a layer provides it. There is deliberately no
+Cloudflare KV implementation: Better Auth's guidance is a Redis-style
+store with strongly consistent reads and precise sub-minute TTLs, and
+KV's eventual consistency (plus its 60-second TTL floor) fights session
+reads and rate-limit counters. A Durable Object-backed layer is the
+right strongly-consistent Cloudflare option when one lands.
+
+## Choosing between Postgres options
+
+- **Neon** — use the [`Neon`](/providers/betterauth/neon) serverless
+  driver everywhere; no Hyperdrive or `pg` needed.
+- **Aurora from Lambda** — use
+  [`AuroraDataApi`](/providers/betterauth/auroradataapi); the Lambda
+  stays out of the VPC entirely.
+- **Any other Postgres from a Worker** — front it with
+  [`CloudflareHyperdrive`](/providers/betterauth/cloudflarehyperdrive).
+- **Everything else** — [`Postgres`](/providers/betterauth/postgres)
+  over `pg`. On Lambda, add `build: { install: ["pg"] }` so the
+  dynamically-imported driver ships with an npm layout.

--- a/website/src/content/docs/better-auth/index.mdx
+++ b/website/src/content/docs/better-auth/index.mdx
@@ -1,0 +1,121 @@
+---
+title: Better Auth
+description: Typed authentication as an Effect — one BetterAuth() call, a database Layer per platform, and schema migrations that run themselves at deploy.
+---
+
+[Better Auth](https://better-auth.com) is a framework-agnostic
+authentication library. `@alchemy.run/better-auth` wraps it in one
+Effect-native idea: `yield* BetterAuth(options)` gives you a fully-typed
+auth instance, and the database behind it is a Layer you pick per
+platform — D1, Neon, Aurora, Hyperdrive, plain Postgres/MySQL, SQLite,
+or your own Drizzle db.
+
+```typescript
+import { BetterAuth } from "@alchemy.run/better-auth";
+import { CloudflareD1 } from "@alchemy.run/better-auth/CloudflareD1";
+import * as Cloudflare from "alchemy/Cloudflare";
+
+export const AuthDb = Cloudflare.D1.Database("AuthDb");
+
+export default class Api extends Cloudflare.Worker<Api>()(
+  "Api",
+  { main: import.meta.url, compatibility: { flags: ["nodejs_compat"] } },
+  Effect.gen(function* () {
+    const auth = yield* BetterAuth({
+      basePath: "/auth",
+      emailAndPassword: { enabled: true },
+    });
+
+    return {
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        if (request.url.startsWith("/auth")) {
+          return yield* auth.fetch;
+        }
+        const session = yield* auth.getSession();
+        return yield* HttpServerResponse.json({ user: session?.user ?? null });
+      }),
+    };
+  }).pipe(Effect.provide(CloudflareD1(AuthDb))),
+) {}
+```
+
+Deploying this stack creates the D1 database, applies Better Auth's
+schema (an internal alchemy Action — see
+[Migrations](/better-auth/migrations)), provisions a stable signing
+secret, and serves sign-up/sign-in/session routes under `/auth/*`.
+
+## Typed end to end
+
+`BetterAuth(options)` preserves Better Auth's `Auth<Options>` generic:
+the plugins you pass surface as typed endpoints on `auth.api`, and
+session/user types flow from your options.
+
+```typescript
+import { anonymous } from "better-auth/plugins/anonymous";
+
+const auth = yield* BetterAuth({
+  emailAndPassword: { enabled: true },
+  plugins: [anonymous()],
+});
+
+// only exists because anonymous() is in the plugins — and it type-checks
+const result = yield* auth.api.signInAnonymous({});
+```
+
+Every `auth.api.*` endpoint is an Effect with a tagged
+`BetterAuthApiError` failure carrying the status key, numeric
+`statusCode`, JSON `body` (including the machine-readable `body.code`),
+and the response `Headers` — including the `set-cookie` values
+better-call normally hides on a symbol:
+
+```typescript
+const result = yield* auth.api
+  .signInEmail({ body: { email, password } })
+  .pipe(
+    Effect.catchTag("BetterAuthApiError", (error) =>
+      error.statusCode === 401
+        ? Effect.succeed(null)          // wrong credentials
+        : Effect.fail(error),
+    ),
+  );
+```
+
+`error.toResponse()` renders the failure exactly as Better Auth would
+have (status, JSON body, merged headers) for pass-through handlers.
+
+## The HTTP surface
+
+`auth.fetch` is an alchemy `HttpEffect` serving the whole Better Auth
+route tree — mount it under your `basePath`. It is host-portable: the
+same handler runs on Cloudflare Workers and AWS Lambda function URLs
+unchanged.
+
+`auth.getSession()` reads the session from the ambient request (or an
+explicit `Headers`), resolving `null` for anonymous requests — failures
+are real errors, never missing sessions.
+
+Anything the effectful surface doesn't cover is reachable through
+`auth.auth` — the raw per-execution `Auth` instance.
+
+## The signing secret
+
+`secret` defaults to an auto-provisioned `Alchemy.Random` resource:
+generated once, persisted in state, stable across deploys, and bound
+into the host environment as a secret. Override it with a literal, a
+`Redacted` value, or another resource's output accessor.
+
+## Execution scoping
+
+The Better Auth instance (and any database pool beneath it) is built
+once per execution — a Worker event or Lambda invocation — and released
+when the event settles. That is the only legal pooling shape on workerd,
+and it means Better Auth's background tasks drain through the event's
+`waitUntil` automatically.
+
+## Where to go next
+
+- [Database layers](/better-auth/database-layers) — pick the optimal
+  layer for your environment → database pair
+- [Migrations](/better-auth/migrations) — how deploy-time schema
+  migration works, and how to opt out

--- a/website/src/content/docs/better-auth/migrations.mdx
+++ b/website/src/content/docs/better-auth/migrations.mdx
@@ -1,0 +1,66 @@
+---
+title: Migrations
+description: Better Auth's schema is applied automatically at deploy by an internal alchemy Action — input-hash diffed, dead-code-eliminated from runtime bundles, opt-out with migrate false.
+sidebar:
+  order: 2
+---
+
+Better Auth owns its schema — tables for users, sessions, accounts,
+verifications, plus whatever your plugins add. With alchemy, applying
+that schema is part of `alchemy deploy`, not a separate CLI step.
+
+## How it works
+
+When a stack containing `BetterAuth()` is evaluated, the package
+registers an internal alchemy **Action** (`BetterAuth.Migrate`). Actions
+run only during apply — never at plan, and the migration code is
+dead-code-eliminated from deployed runtime bundles entirely.
+
+The Action's input is a hash of:
+
+- **the schema fingerprint** — derived from your options (plugins,
+  additional fields, model renames), so adding a plugin re-runs the
+  migration on the next deploy;
+- **the database identity** — a non-secret identifier from the layer
+  (a D1 `databaseId`, a digest of the connection string, cluster ARNs),
+  so pointing at a new database re-runs it too. Connection strings
+  themselves are never persisted to state.
+
+Unchanged input ⇒ the Action no-ops without touching the database.
+`--force` re-runs it. Migrations are additive and idempotent
+(`CREATE TABLE` / `ADD COLUMN` on what's missing), so re-running is
+always safe.
+
+The host Function/Worker depends on the migration through its
+environment, so first-deploy traffic cannot race the schema.
+
+## Per-layer transport
+
+Each layer supplies its own deploy-time connection:
+
+| Layer | Deploy-time migration path |
+| --- | --- |
+| `CloudflareD1` | D1 HTTP query API (or the local simulator under `alchemy dev`) |
+| `Neon` | serverless driver against the same connection string |
+| `AuroraDataApi` | RDS Data API with the stack's credentials |
+| `CloudflareHyperdrive` | the **origin** URL you pass as `migrate` (Hyperdrive's own string is runtime-only) |
+| `Postgres` / `MySQL` | the connection string (or a separate `migrate` source) |
+| `SQLite` | the same local file |
+| `Memory` / `Drizzle` | no migration — memory needs none; Drizzle schemas are user-owned |
+
+## Opting out
+
+```typescript
+const auth = yield* BetterAuth({
+  migrate: false,
+  emailAndPassword: { enabled: true },
+});
+```
+
+With `migrate: false` you own the schema — generate it with
+`npx @better-auth/cli generate` and apply it through your own migration
+flow (for Drizzle users that is the default and only mode).
+
+Multiple `BetterAuth` instances in one stack? Give each a distinct
+`id` — it suffixes the migration Action and the auto-provisioned secret
+so they don't collide.

--- a/website/src/docs-icons.ts
+++ b/website/src/docs-icons.ts
@@ -21,6 +21,7 @@ export const TAB_ICONS: Record<string, string | undefined> = {
   Neon: b("neon"),
   Prisma: b("prisma"),
   Axiom: l("activity"),
+  "Better Auth": l("key-round"),
   GitHub: b("github"),
   Docker: b("docker"),
   Kubernetes: b("kubernetes"),

--- a/website/src/docs-tabs.ts
+++ b/website/src/docs-tabs.ts
@@ -61,6 +61,14 @@ export const DOCS_TABS: DocsTab[] = [
     slot: "primary",
   },
   {
+    label: "Better Auth",
+    href: "/better-auth",
+    prefixes: ["/better-auth", "/providers/betterauth"],
+    slot: "more",
+    category: "Auth",
+    hint: "sessions · plugins · database layers",
+  },
+  {
     label: "Axiom",
     href: "/axiom",
     prefixes: ["/axiom", "/providers/axiom"],


### PR DESCRIPTION
Teaches the API-reference generator about **Layer pages** and wires Better Auth into the website — stacked on #1157, which carries the `@layer` annotations and the hand-written hub pages.

### Layer pages in the generator

Layers were a gap in the docs pipeline: resources (`@resource`) and bindings (`@binding`) generate pages, but the pluggable implementations of a Context service never did. New JSDoc vocabulary, one page per Layer:

```ts
/**
 * Neon database layer for Better Auth over Neon's serverless driver.
 *
 * @layer
 * @provides BetterAuth.Database
 * @peer @neondatabase/serverless
 * @product Neon
 *
 * @section Connecting from a Worker or Lambda
 * @example ...
 */
export const Neon = (url: ConnectionSource, options?: NeonOptions): Layer.Layer<Database> => ...
```

renders with a metadata line under the source link:

```
> **Source:** `packages/better-auth/src/Neon.ts`
> **Kind:** Layer · **Provides:** `BetterAuth.Database` · **Peer dependencies:** `@neondatabase/serverless`
```

### Multi-root discovery

The generator scanned only `packages/alchemy/src`, where top-level directories are providers. It now takes a list of source roots; flat single-provider packages map onto a synthetic provider directory:

```ts
roots: [
  { srcRoot: "packages/alchemy/src", providerPrefix: "" },
  { srcRoot: "packages/better-auth/src", providerPrefix: "BetterAuth" },
]
```

`bun docs:gen` now emits nine `providers/BetterAuth/*.md` Layer pages (AuroraDataApi, CloudflareD1, CloudflareHyperdrive, Drizzle, Memory, MySQL, Neon, Postgres, SQLite) alongside the existing 3,924.

### Better Auth in the nav

- "More ▾" dropdown gets an **Auth** heading with a **Better Auth** entry
- New sidebar hub: Overview → Database layers → Migrations → Resources (the generated Layer pages), backed by the hand-written pages from #1157
- Reference directory + provider list entries (`Better Auth` display label)

The `@layer`/`@provides`/`@peer` convention is documented in AGENTS.md — every Layer implementation should carry these annotations going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
