### PR TITLE
docs(blog): move beta.68 release post to beta.70, add renamedFrom()

### DIFF
--- a/website/src/content/docs/blog/2026-08-06-beta-70.md
+++ b/website/src/content/docs/blog/2026-08-06-beta-70.md
@@ -1,11 +1,11 @@
 ---
-title: 2.0.0-beta.68 - Web Frameworks & Full Local Dev
-date: 2026-08-06T01:00:00Z
+title: 2.0.0-beta.70 - Web Frameworks & Full Local Dev
+date: 2026-08-06T09:00:00Z
 category: release
-excerpt: v2.0.0-beta.68 deploys Next.js, Astro, Nuxt, SvelteKit, Waku, and Octane to Cloudflare Workers with zero config files, completes local emulation in alchemy dev (browser rendering, images, email, cron, secrets, Stream, tail consumers), adds plan-time data sources, cluster-agnostic Kubernetes workloads, MySQL clients, and migrates every SDK to distilled v1.
+excerpt: v2.0.0-beta.70 deploys Next.js, Astro, Nuxt, SvelteKit, Waku, and Octane to Cloudflare Workers with zero config files, completes local emulation in alchemy dev (browser rendering, images, email, cron, secrets, Stream, tail consumers), adds renamedFrom() state migration for logical ID renames, plan-time data sources, cluster-agnostic Kubernetes workloads, MySQL clients, and migrates every SDK to distilled v1.
 ---
 
-beta.68 deploys **Next.js, Astro, Nuxt, SvelteKit, Waku, and
+beta.70 deploys **Next.js, Astro, Nuxt, SvelteKit, Waku, and
 Octane** to Cloudflare Workers — programmatic builds, no
 `wrangler.json`, no adapter config. And `alchemy dev` now emulates
 effectively the entire Cloudflare surface locally: browser
@@ -15,22 +15,23 @@ release also adds plan-time data sources, moves Kubernetes
 workloads out of EKS into a cluster-agnostic namespace, and
 migrates every SDK to distilled v1.
 
-This post also folds in beta.67, a small fix release that didn't
-get its own notes.
+This post covers beta.67 through beta.70 — beta.67 was a small
+fix release that didn't get its own notes, and beta.68/beta.69
+are superseded by beta.70.
 
 :::caution
-**Breaking change**
+**Behavior change**
 
 `Cloudflare.Website.StaticSite` no longer duplicates `env`
 resources into its own namespace
 ([#1053](https://github.com/alchemy-run/alchemy/pull/1053)) — a
 shared KV namespace passed as `env` used to register a second
 physical copy at `<site-id>/…`. As part of the fix, the site's
-Worker moves from the `<id>/Worker` FQN to `<id>`, so on your
-first redeploy the Worker is recreated under a new physical name
-(and a new `workers.dev` subdomain). Custom domains re-attach to
-the new Worker automatically. Thanks
-[apostoli](https://github.com/apostolos-geyer)!
+Worker moves from the `<id>/Worker` FQN to `<id>` — and thanks to
+the new [`renamedFrom()`](#rename-resources-with-renamedfrom)
+support, its state migrates in place on your next deploy: same
+physical name, same `workers.dev` subdomain, nothing recreated.
+Thanks [apostoli](https://github.com/apostolos-geyer)!
 :::
 
 ## The Website family: six new frameworks
@@ -145,7 +146,7 @@ Docs: [Frontend frameworks](/cloudflare/frontend/frontends).
 
 ## `alchemy dev` covers the whole surface
 
-beta.66 emulated KV, R2, D1, and Queues locally. beta.68 finishes
+beta.66 emulated KV, R2, D1, and Queues locally. beta.70 finishes
 the campaign
 ([#1039](https://github.com/alchemy-run/alchemy/pull/1039)) —
 miniflare parity and beyond:
@@ -234,6 +235,41 @@ its worker name, so interleaved logs from several sites stay
 readable. The work also surfaced an upstream Vite bug in
 `server.port` handling, fixed in
 [vitejs/vite#23158](https://github.com/vitejs/vite/pull/23158).
+
+## Rename resources with `renamedFrom()`
+
+Changing a resource's logical ID used to plan a **replacement** —
+a new resource created under the new ID, the old one (and its
+data) deleted. `Alchemy.renamedFrom`
+([#1108](https://github.com/alchemy-run/alchemy/pull/1108))
+declares the id(s) a resource was previously registered under, and
+the engine migrates the persisted state row instead:
+
+```diff lang="typescript"
+-const bucket = yield* Cloudflare.R2.Bucket("Bucket");
++const bucket = yield* Cloudflare.R2.Bucket("Assets").pipe(
++  Alchemy.renamedFrom("Bucket"),
++);
+```
+
+The next deploy plans a single re-branding update — same instance
+ID, same physical name, nothing created or deleted in the cloud:
+
+```text
+Plan: 1 to update
+[Assets] update (renamed from Bucket)
+```
+
+A bare string resolves against the ambient namespace exactly like
+the `id` argument; `{ fqn: "..." }` addresses a move between
+namespaces; listing several former ids covers rename chains. The
+migration is deliberately conservative — types must match,
+ambiguous claims and rename cycles fail the plan, and a leftover
+row from an interrupted move is dropped state-only, never touching
+the cloud. This is what lets the StaticSite fix above migrate
+`<id>/Worker` → `<id>` without replacing your Worker.
+
+Docs: [Renaming Resources](/infrastructure-as-code/renaming).
 
 ## Data sources: plan-time `execute`
 
@@ -495,8 +531,9 @@ build: {
 
 - [Frontend frameworks](/cloudflare/frontend/frontends)
 - [Local development](/environments/local-development)
+- [Renaming Resources](/infrastructure-as-code/renaming)
 - [Bindings](/infrastructure-as-effects/binding)
 - [EKS & Kubernetes](/aws/compute/eks)
 - [SQL](/sql)
-- [CHANGELOG](https://github.com/alchemy-run/alchemy/blob/main/CHANGELOG.md#v200-beta68)
-- [Compare v2.0.0-beta.66 → v2.0.0-beta.68](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.66...v2.0.0-beta.68)
+- [CHANGELOG](https://github.com/alchemy-run/alchemy/blob/main/CHANGELOG.md#v200-beta70)
+- [Compare v2.0.0-beta.66 → v2.0.0-beta.70](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.66...v2.0.0-beta.70)


### PR DESCRIPTION
beta.68 and beta.69 had regressions, so the release post moves to beta.70 — the version users should actually install. Renamed `2026-08-06-beta-68.md` → `2026-08-06-beta-70.md` and updated the version references, CHANGELOG anchor, and compare link.

Content changes on top of the retitle:

- New section covering `Alchemy.renamedFrom()` ([#1108](https://github.com/alchemy-run/alchemy/pull/1108), landed in beta.69) — state-row migration across logical ID renames, with a link to the new `/infrastructure-as-code/renaming` docs page.

```diff
-const bucket = yield* Cloudflare.R2.Bucket("Bucket");
+const bucket = yield* Cloudflare.R2.Bucket("Assets").pipe(
+  Alchemy.renamedFrom("Bucket"),
+);
```

- The StaticSite `:::caution` is downgraded from "Breaking change" to "Behavior change": #1108 pipes the site's Worker through ``renamedFrom(`${id}/Worker`)``, so the FQN move from #1053 now migrates state in place — no recreated Worker, no new `workers.dev` subdomain.
- Intro now reads "This post covers beta.67 through beta.70", noting beta.68/69 are superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
