### PR TITLE
chore(ci): set node version explicitly

### DIFF
--- a/.github/workflows/pr-package.yml
+++ b/.github/workflows/pr-package.yml
@@ -30,6 +30,7 @@ jobs:
 
       - uses: alchemy-run/actions/actions/setup@ab9b8d7a9e09390ba578b85373dcac972bf3edc4 # actions#10
         with:
+          node-version: "24"
           bun-version: "1.3.13"
 
       - name: Install Distilled dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,7 @@ jobs:
       # The bun workspace includes `distilled/packages/*` from the
       # distilled submodule, so consumer checkouts must fetch it.
       submodules: "true"
+      node-version: "24"
       version: ${{ inputs.version }}
       force-latest: ${{ inputs.force-latest }}
       repo: alchemy-run/alchemy

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -30,6 +30,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
+  NODE_VERSION: "24"
   STAGE: ${{ github.event_name == 'pull_request' && format('pr-{0}',
     github.event.number) || (github.event_name == 'workflow_dispatch' ||
     startsWith(github.event.head_commit.message, 'chore(release):')) && 'prod' ||
@@ -71,8 +72,10 @@ jobs:
           client-id: ${{ secrets.ALCHEMY_VERSION_BOT_ID }}
           private-key: ${{ secrets.ALCHEMY_VERSION_BOT_PRIVATE_KEY }}
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+      - uses: alchemy-run/actions/actions/setup@ab9b8d7a9e09390ba578b85373dcac972bf3edc4 # actions#10
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          install: "false"
 
       - name: Restore Astro build cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -120,8 +123,10 @@ jobs:
           client-id: ${{ secrets.ALCHEMY_VERSION_BOT_ID }}
           private-key: ${{ secrets.ALCHEMY_VERSION_BOT_PRIVATE_KEY }}
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+      - uses: alchemy-run/actions/actions/setup@ab9b8d7a9e09390ba578b85373dcac972bf3edc4 # actions#10
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          install: "false"
 
       - name: Install Doppler CLI
         uses: dopplerhq/cli-action@4819d808ab99e5cde19a0637a16536a4038fad73 # v4


### PR DESCRIPTION
## Summary

- explicitly configure Node 24 across CI workflows
- use the pinned `alchemy-run/actions/actions/setup` action in both website jobs
- pass Node 24 explicitly to the shared setup and release workflows
- preserve the website Astro cache ordering by disabling the setup action’s automatic install
- keep the existing explicit Node 24 configuration in check and Cloudflare-tools CI

## Why set Node when CI uses Bun?

Bun is the package manager and primary script runner, but package scripts can still execute CLIs through their Node shebang. In this case Turbo launched `tsdown`, whose executable uses `#!/usr/bin/env node`, so it inherited the Blacksmith image’s ambient Node runtime rather than Bun.

That means the Node version remains part of the effective CI toolchain even though installs and top-level scripts use Bun. Setting it explicitly makes CI reproducible and prevents runner-image defaults from changing how nested tooling executes.

The shared setup action accepts `node-version`, passes it to its pinned `actions/setup-node`, and then configures Bun. The website jobs set `install: "false"` so their existing cache restore still happens before `bun install`.

## Issue

The website deployment started failing after moving from GitHub-hosted runners to Blacksmith: https://github.com/alchemy-run/alchemy/actions/runs/31430572959/job/93592722093

The Blacksmith image exposed an older default Node runtime. `tsdown@0.22.14` could not use native TypeScript config loading, first failing because its optional `unrun` loader was absent. A labeled preview with `unrun` installed got further and then failed on the unsupported `Promise.withResolvers` API, confirming that the underlying issue was the Node runtime rather than a missing application dependency.

Node 24 supports native TypeScript loading and tsdown’s required runtime APIs, so no `unrun` dependency or build-script workaround is needed.

## Verification

- `deploy-website` is applied so Blacksmith exercises the original prepare/build/deploy path
- all Bun-based CI workflows now select Node 24 explicitly through pinned actions or explicit reusable-workflow inputs