### PR TITLE
feat(cloudflare-runtime): opt-in workerd inspector via WORKERD_INSPECTOR_WORKER

### DIFF
--- a/packages/cloudflare-runtime/src/core/Runtime.ts
+++ b/packages/cloudflare-runtime/src/core/Runtime.ts
@@ -209,6 +209,16 @@ export const RuntimeLive = Layer.effect(
             concurrency: "unbounded",
           },
         );
+        // Debug facility: expose workerd's V8 inspector (the Chrome DevTools
+        // protocol) for one worker. `WORKERD_INSPECTOR_WORKER=<worker name>`
+        // selects it; `WORKERD_INSPECTOR_ADDR` overrides the default listen
+        // address. Scoped to a single named worker because every worker runs
+        // in its own workerd process, so an unconditional fixed address
+        // would collide across them.
+        const inspectorAddr =
+          process.env.WORKERD_INSPECTOR_WORKER === worker.name
+            ? (process.env.WORKERD_INSPECTOR_ADDR ?? "127.0.0.1:9229")
+            : undefined;
         const ports = yield* workerd.serve(
           {
             sockets: [
@@ -260,6 +270,9 @@ export const RuntimeLive = Layer.effect(
           },
           {
             "debug-port": "127.0.0.1:0",
+            ...(inspectorAddr
+              ? { "inspector-addr": inspectorAddr }
+              : undefined),
             ...(worker.logging?.verbose ? { verbose: true } : undefined),
           },
           { onOutput: worker.logging?.onOutput },


### PR DESCRIPTION
workerd's `--inspector-addr` exposes the Chrome DevTools protocol for the isolate — headless CPU profiling of the JS and wasm running in a dev worker, no browser attached. `Workerd.serve` already counts an `--inspector-addr` listener in its control-socket handshake, but nothing passes the flag, so a dev-session worker cannot be profiled today.

This adds an env-gated debug facility in the spirit of `WORKERD_DUMP_CONFIG`:

```sh
WORKERD_INSPECTOR_WORKER=my-worker alchemy dev
# then: curl http://127.0.0.1:9229/json  →  attach CDP, Profiler.start/stop
```

`WORKERD_INSPECTOR_ADDR` overrides the default `127.0.0.1:9229`. Scoped to one named worker because every worker runs in its own workerd process — an unconditional fixed address would collide across a multi-worker session. Unset, the serve args are unchanged.

A typed per-worker option (alongside `logging`) would be the fuller shape; the env gate works from any consumer without an API change.
