### PR TITLE
chore: fill in copyright owner in LICENSE appendix

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@ Apache License
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 FUNCTIONLESS CORP
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
The APPENDIX section of `LICENSE` still carries the Apache 2.0 template placeholders:

```
Copyright [yyyy] [name of copyright owner]
```

Replaces them with the actual owner:

```
Copyright 2026 FUNCTIONLESS CORP
```

Only that one line changes; the rest of the file is untouched.