### PR TITLE
docs(cloudflare/website): frameworks load your config file — fix docs claiming otherwise

### DIFF
--- a/packages/alchemy/src/Cloudflare/Website/Astro.ts
+++ b/packages/alchemy/src/Cloudflare/Website/Astro.ts
@@ -52,9 +52,10 @@ export interface AstroProps<
   sessionKVBindingName?: string | false;
   /**
    * Serializable Astro config merged into the in-memory configuration.
-   * The project's `astro.config.*` file is NOT read — the integration is
-   * fully programmatic (the Cloudflare adapter, output target, and Vite
-   * environments are managed for you).
+   * The project's `astro.config.*` file loads natively; astro merges
+   * these options OVER it (scalars override the file). The Cloudflare
+   * adapter, output target, and Vite environments are managed for you —
+   * do not declare an `adapter` in the config file.
    */
   astro?: {
     /** The full URL the site deploys to (`Astro.site`). */
@@ -91,8 +92,8 @@ export interface AstroProps<
  * `Astro` runs Astro's programmatic build with a wrangler-free
  * Cloudflare adapter (`@alchemy.run/cloudflare-frameworks/astro`): server-rendered pages
  * execute in the Worker, prerendered pages and client assets deploy as
- * static assets — no `astro.config.*`, adapter setup, or Wrangler
- * configuration required.
+ * static assets. Your `astro.config.*` loads natively — no adapter
+ * setup or Wrangler configuration required.
  *
  * Input files are content-hashed (respecting `.gitignore` by default)
  * so unchanged projects skip the build and deploy entirely.
@@ -194,8 +195,15 @@ export interface AstroProps<
  * ```
  *
  * @section Astro Configuration
- * The integration is fully programmatic — your `astro.config.*` file is
- * not read. Common serializable options are exposed under `astro`.
+ * Your `astro.config.*` file loads natively — integrations, Vite
+ * plugins, and other non-serializable options work as usual. Common
+ * serializable options are exposed under `astro` for deploy-specific
+ * overrides; astro merges them OVER the config file (scalars override,
+ * arrays like `integrations` concatenate). The Cloudflare adapter is
+ * injected for you — declaring an `adapter` in the config file fails
+ * the build. `output` defaults to `"server"`, superseding a file-level
+ * `output`; opt into a fully prerendered site with
+ * `astro: { output: "static" }`.
  *
  * @example Setting the site URL and source directory
  * ```typescript

--- a/packages/alchemy/src/Cloudflare/Website/Nextjs.ts
+++ b/packages/alchemy/src/Cloudflare/Website/Nextjs.ts
@@ -38,6 +38,8 @@ export interface NextjsBuildOptions {
   configPath?: string;
   /**
    * The command the OpenNext pipeline runs to build the Next.js app.
+   * A `buildCommand` set in the project's `open-next.config.ts` takes
+   * precedence over this option.
    * @default "npx next build"
    */
   buildCommand?: string;

--- a/packages/alchemy/src/Cloudflare/Website/Nuxt.ts
+++ b/packages/alchemy/src/Cloudflare/Website/Nuxt.ts
@@ -59,8 +59,8 @@ export interface NuxtProps<
   memo?: MemoOptions;
   /**
    * Nuxt configuration overrides merged over the project's own
-   * `nuxt.config.ts` (the override wins). Unlike some siblings, the
-   * project's config file IS loaded natively — this is for
+   * `nuxt.config.ts` (the override wins). The project's config file is
+   * loaded natively — modules, layers, and all — so this is for
    * deploy-specific tweaks (`routeRules`, `runtimeConfig`, ...). Must be
    * JSON-serializable (it persists in state). Do not set `nitro.preset`
    * here — the Cloudflare deploy target owns the preset and a foreign

--- a/packages/alchemy/src/Cloudflare/Website/SvelteKit.ts
+++ b/packages/alchemy/src/Cloudflare/Website/SvelteKit.ts
@@ -33,12 +33,15 @@ export interface SvelteKitProps<
    */
   memo?: MemoOptions;
   /**
-   * SvelteKit configuration passed to the `sveltekit(config)` Vite plugin.
-   * Since kit v3 the configuration lives in memory (a `svelte.config.js` on
-   * disk is an upstream error), so this is the place for `alias`, `paths`,
-   * `prerender`, and the rest of the kit config surface. The `adapter`
-   * field is injected by Alchemy's wrangler-free Cloudflare adapter — do
-   * not set it here. Must be JSON-serializable (it persists in state).
+   * SvelteKit configuration overrides. A project-owned `vite.config.*`
+   * loads natively — its `sveltekit(...)` call is the primary config
+   * source — and these options are merged OVER it (the override wins).
+   * Without a config file, this is the whole kit config. Construction-time
+   * options (`preprocess`, `extensions`, `compilerOptions`, `vitePlugin`)
+   * only apply in the no-config-file case — put them in your own
+   * `sveltekit(...)` call otherwise. The `adapter` field is injected by
+   * Alchemy's wrangler-free Cloudflare adapter — do not set it here. Must
+   * be JSON-serializable (it persists in state).
    */
   kit?: Record<string, unknown>;
   /**
@@ -77,7 +80,9 @@ export interface SvelteKitProps<
  *
  * `SvelteKit` builds the app with SvelteKit's own Vite pipeline and a
  * wrangler-free in-memory Cloudflare adapter, then re-bundles the
- * Node-flavored server output for workerd — no `svelte.config.js`, no
+ * Node-flavored server output for workerd. A project-owned
+ * `vite.config.*` loads natively (its `sveltekit(...)` options apply) —
+ * no `svelte.config.js` (kit v3 dropped it), no
  * `@sveltejs/adapter-cloudflare`, no Wrangler configuration required.
  * Client assets and prerendered pages are deployed as Worker static
  * assets; dynamic routes are served by the generated Worker.
@@ -130,7 +135,9 @@ export interface SvelteKitProps<
  * ```
  *
  * @section Kit and Adapter Options
- * The kit config surface is passed in-memory via `kit`; the generated
+ * Kit options normally live in the `sveltekit(...)` call in your
+ * `vite.config.ts`, which loads natively; `kit` is a deploy-time
+ * override layer merged over them (the override wins). The generated
  * Cloudflare adapter is configured via `adapter`.
  *
  * @example SPA-style 404 fallback

--- a/packages/alchemy/src/Cloudflare/Website/Waku.ts
+++ b/packages/alchemy/src/Cloudflare/Website/Waku.ts
@@ -51,20 +51,25 @@ export interface WakuProps<
    */
   rootDir?: string;
   /**
-   * Waku source directory, relative to {@link rootDir}.
-   * @default "src"
+   * Waku source directory, relative to {@link rootDir}. Setting this
+   * overrides a `srcDir` in the project's `waku.config.*`.
+   * @default the project's `waku.config.*` value, or waku's own default (`"src"`)
    */
   srcDir?: string;
   /**
    * Waku build output directory, relative to {@link rootDir}. The server
    * bundle is read from `<distDir>/server` and the client assets from
-   * `<distDir>/public`.
-   * @default "dist"
+   * `<distDir>/public`. Setting this overrides a `distDir` in the
+   * project's `waku.config.*` — if your config file customizes `distDir`,
+   * mirror it here (or exclude it via `memo`) so the build output doesn't
+   * pollute the rebuild hash.
+   * @default the project's `waku.config.*` value, or waku's own default (`"dist"`)
    */
   distDir?: string;
   /**
-   * Base path the app is served under.
-   * @default "/"
+   * Base path the app is served under. Setting this overrides a
+   * `basePath` in the project's `waku.config.*`.
+   * @default the project's `waku.config.*` value, or waku's own default (`"/"`)
    */
   basePath?: string;
   /**
@@ -92,7 +97,12 @@ export interface WakuProps<
  * A Cloudflare Worker deployed from a [Waku](https://waku.gg) project.
  *
  * `Waku` builds the project programmatically — no `waku.config.ts` edits,
- * no Wrangler configuration, and no build command required. The RSC server
+ * no Wrangler configuration, and no build command required. A project's
+ * `waku.config.*` loads natively (same as waku's CLI) as the base config,
+ * with `srcDir`/`distDir`/`basePath` from this resource winning per key;
+ * `unstable_adapter` is owned by Alchemy and must not be set. Note that a
+ * standalone `vite.config.ts` is NOT loaded (same as waku's CLI) — Vite
+ * config belongs in `waku.config.*`'s `vite` field. The RSC server
  * bundle deploys as the Worker script and the client output (including
  * SSG-prerendered pages) deploys as static assets.
  *

--- a/packages/cloudflare-frameworks/src/nextjs/Nextjs.ts
+++ b/packages/cloudflare-frameworks/src/nextjs/Nextjs.ts
@@ -60,6 +60,8 @@ export interface NextjsFrameworkOptions {
         readonly configPath?: string | undefined;
         /**
          * The command the OpenNext pipeline runs to build the Next.js app.
+         * A `buildCommand` set in the project's `open-next.config.ts` takes
+         * precedence over this option.
          * @default "npx next build"
          */
         readonly buildCommand?: string | undefined;

--- a/packages/cloudflare-frameworks/src/nextjs/source.ts
+++ b/packages/cloudflare-frameworks/src/nextjs/source.ts
@@ -194,7 +194,11 @@ export interface NextjsSourceOptions {
   readonly memo?: NextjsMemoOptions | undefined;
   /** Path of the OpenNext config, relative to the project root. @default "open-next.config.ts" */
   readonly configPath?: string | undefined;
-  /** The command the OpenNext pipeline runs to build the Next.js app. @default "npx next build" */
+  /**
+   * The command the OpenNext pipeline runs to build the Next.js app. A
+   * `buildCommand` in the project's `open-next.config.ts` takes precedence.
+   * @default "npx next build"
+   */
   readonly buildCommand?: string | undefined;
   /** Skip the internal `next build` (reuse an existing `.next`). */
   readonly skipNextBuild?: boolean | undefined;

--- a/packages/cloudflare-frameworks/src/sveltekit/source.ts
+++ b/packages/cloudflare-frameworks/src/sveltekit/source.ts
@@ -195,8 +195,11 @@ export interface SvelteKitSourceOptions {
   /** Narrows the rebuild-detection input hash. */
   readonly memo?: SvelteKitMemoOptions | undefined;
   /**
-   * SvelteKit configuration passed to `sveltekit(config)` (kit v3 takes its
-   * config in-memory). Must be JSON-serializable — it persists in state.
+   * SvelteKit configuration overrides. With a project-owned
+   * `vite.config.*` (loaded natively), these merge over the options of the
+   * user's own `sveltekit(...)` call (integration wins); without one they
+   * are passed to `sveltekit(config)` wholesale. Must be JSON-serializable
+   * — it persists in state.
    */
   readonly kit?: Record<string, unknown> | undefined;
   /** Options for the wrangler-free Cloudflare adapter. */

--- a/website/src/content/docs/blog/2026-08-06-beta-70.md
+++ b/website/src/content/docs/blog/2026-08-06-beta-70.md
@@ -2,7 +2,7 @@
 title: 2.0.0-beta.70 - Web Frameworks & Full Local Dev
 date: 2026-08-06T09:00:00Z
 category: release
-excerpt: v2.0.0-beta.70 deploys Next.js, Astro, Nuxt, SvelteKit, Waku, and Octane to Cloudflare Workers with zero config files, completes local emulation in alchemy dev (browser rendering, images, email, cron, secrets, Stream, tail consumers), adds renamedFrom() state migration for logical ID renames, plan-time data sources, cluster-agnostic Kubernetes workloads, MySQL clients, and migrates every SDK to distilled v1.
+excerpt: v2.0.0-beta.70 deploys Next.js, Astro, Nuxt, SvelteKit, Waku, and Octane to Cloudflare Workers with zero Cloudflare-specific config, completes local emulation in alchemy dev (browser rendering, images, email, cron, secrets, Stream, tail consumers), adds renamedFrom() state migration for logical ID renames, plan-time data sources, cluster-agnostic Kubernetes workloads, MySQL clients, and migrates every SDK to distilled v1.
 ---
 
 beta.70 deploys **Next.js, Astro, Nuxt, SvelteKit, Waku, and
@@ -49,11 +49,13 @@ framework family:
 ([#1093](https://github.com/alchemy-run/alchemy/pull/1093)).
 
 Every resource builds your project programmatically — no wrangler
-binary, no `wrangler.json`, no adapter packages to install or
-config files to edit — and deploys it as a Worker: server bundle
-plus static assets. Builds are memoized by content-hashing the
-input files, so an unchanged project skips the build and deploy
-entirely.
+binary, no `wrangler.json`, no adapter packages to install — and
+deploys it as a Worker: server bundle plus static assets. Your
+framework's own config file (`astro.config.*`, `vite.config.ts`,
+`nuxt.config.ts`, ...) loads natively; Alchemy merges its
+Cloudflare config over it. Builds are memoized by content-hashing
+the input files, so an unchanged project skips the build and
+deploy entirely.
 
 ```typescript
 const site = yield* Cloudflare.Website.Nextjs("Site", {

--- a/website/src/content/docs/cloudflare/frontend/astro.mdx
+++ b/website/src/content/docs/cloudflare/frontend/astro.mdx
@@ -13,8 +13,8 @@ export const devDeps = "@alchemy.run/cloudflare-frameworks";
 project as a Cloudflare Worker. It runs Astro's programmatic build
 with a wrangler-free Cloudflare adapter: server-rendered pages
 execute in the Worker, prerendered pages and client assets deploy as
-static assets. There is no `astro.config.*` to write, no adapter to
-install into your config, and no Wrangler file.
+static assets. Your `astro.config.*` loads natively — there is no
+adapter to install into it and no Wrangler file to write.
 
 ## Install
 
@@ -40,10 +40,14 @@ so a dev dependency is enough:
 
 ## Configure Astro
 
-There is no framework config to write: the integration is fully
-programmatic, and your `astro.config.*` file is not read. Common
-serializable options are passed via the `astro` prop instead — see
-[Astro configuration](#astro-configuration) below for the details.
+Your `astro.config.*` file loads natively — integrations, Vite
+plugins, and any other non-serializable options work exactly as they
+do outside Alchemy. Alchemy merges a programmatic config *over* it:
+the Cloudflare adapter is injected for you (don't declare an
+`adapter` in your config — that fails the build with an actionable
+error), and options passed via the `astro` prop override the file's —
+see [Astro configuration](#astro-configuration) below for the
+details.
 
 ## Declare the Website
 
@@ -206,8 +210,12 @@ sites, since no Worker code runs at request time.
 
 ## Astro configuration
 
-Common serializable options from `astro.config.*` are exposed under
-the `astro` prop:
+Your `astro.config.*` is the primary place to configure Astro —
+integrations, Vite plugins, and every other option (serializable or
+not) work as usual. The `astro` prop exposes common serializable
+options for deploy-specific overrides; Astro merges them *over* the
+config file (scalars override, arrays like `integrations` and
+`vite.plugins` concatenate after the file's):
 
 ```typescript
 export const Website = Cloudflare.Website.Astro("Website", {
@@ -217,3 +225,13 @@ export const Website = Cloudflare.Website.Astro("Website", {
   },
 });
 ```
+
+Two options are managed for you regardless of the config file:
+
+- `adapter` — Alchemy injects its wrangler-free Cloudflare adapter.
+  Declaring an adapter in `astro.config.*` fails the build with an
+  actionable error.
+- `output` — Alchemy defaults it to `"server"` (superseding a
+  file-level `output`), so pages render on demand in the Worker.
+  Opt into a fully prerendered site with `astro: { output: "static" }`
+  on the resource.

--- a/website/src/content/docs/cloudflare/frontend/frontends.mdx
+++ b/website/src/content/docs/cloudflare/frontend/frontends.mdx
@@ -9,21 +9,26 @@ sidebar:
 Alchemy deploys frontends to Cloudflare with a family of
 `Cloudflare.Website` resources. Each one builds your project
 programmatically and deploys it as a Worker — server bundle plus
-static assets — with zero configuration files: no `wrangler.json`,
-no adapter setup.
+static assets — with no Cloudflare-specific configuration: no
+`wrangler.json`, no adapter setup. Your framework's own config file
+(`vite.config.ts`, `astro.config.*`, `nuxt.config.ts`, ...) loads
+natively; Alchemy layers its Cloudflare integration on top.
 
 - [`Vite`](/cloudflare/frontend/vite) — any pure-Vite app: SPAs and
   Vite-plugin frameworks like TanStack Start, React Router, Vue, and
-  SolidStart.
+  SolidStart; your `vite.config.ts` loads natively.
 - [`Astro`](/cloudflare/frontend/astro) — Astro sites, server-rendered
-  or fully static, with an auto-provisioned session KV namespace.
+  or fully static, with an auto-provisioned session KV namespace;
+  your `astro.config.*` loads natively.
 - [`Nextjs`](/cloudflare/frontend/nextjs) — Next.js apps built through
-  the OpenNext pipeline, with writable ISR on KV.
+  the OpenNext pipeline, with writable ISR on KV; your `next.config.*`
+  is honored as-is.
 - [`Nuxt`](/cloudflare/frontend/nuxt) — Nuxt apps built through
   nitro's `cloudflare_module` preset; your `nuxt.config.ts` loads
   natively.
 - [`SvelteKit`](/cloudflare/frontend/sveltekit) — SvelteKit apps with
-  a wrangler-free in-memory Cloudflare adapter.
+  a wrangler-free in-memory Cloudflare adapter; your `vite.config.ts`
+  loads natively.
 - [`Waku`](/cloudflare/frontend/waku) — Waku (React Server
   Components) apps.
 - [`Octane`](/cloudflare/frontend/octane) — OctaneJS fullstack apps

--- a/website/src/content/docs/cloudflare/frontend/nextjs.mdx
+++ b/website/src/content/docs/cloudflare/frontend/nextjs.mdx
@@ -44,10 +44,11 @@ They are only used at build time, so dev dependencies are enough:
 
 ## Configure OpenNext
 
-Your `next.config.*` stays untouched. OpenNext needs one config file
-next to it — the static-assets incremental cache is the
-zero-infrastructure default, where prerendered ISR pages serve their
-build-time payloads:
+Your `next.config.*` is loaded and honored as-is — the build runs a
+real `next build`, and Alchemy never rewrites the file. OpenNext
+needs one config file next to it — the static-assets incremental
+cache is the zero-infrastructure default, where prerendered ISR
+pages serve their build-time payloads:
 
 ```typescript
 // open-next.config.ts

--- a/website/src/content/docs/cloudflare/frontend/sveltekit.mdx
+++ b/website/src/content/docs/cloudflare/frontend/sveltekit.mdx
@@ -15,7 +15,8 @@ It builds the app with SvelteKit's own Vite pipeline and a
 wrangler-free in-memory Cloudflare adapter, then re-bundles the
 server output for workerd. Client assets and prerendered pages deploy
 as Worker static assets; dynamic routes are served by the generated
-Worker. There is no `svelte.config.js` to write, no
+Worker. Your `vite.config.ts` loads natively; there is no
+`svelte.config.js` to write (kit v3 dropped it), no
 `@sveltejs/adapter-cloudflare` to install, and no Wrangler file.
 
 ## Install
@@ -42,12 +43,15 @@ build time, so a dev dependency is enough:
 
 ## Configure SvelteKit
 
-There is no framework config to write. The resource drives
-SvelteKit's Vite pipeline programmatically and injects its own
-Cloudflare adapter, so a fresh SvelteKit project deploys as-is.
-Options that would normally live in `svelte.config.js` are passed via
-the `kit` prop instead — see
-[Kit and adapter options](#kit-and-adapter-options) below.
+Your project's `vite.config.ts` loads natively — your Vite plugins
+and the kit options in your `sveltekit(...)` call all apply as usual.
+Alchemy injects its own wrangler-free Cloudflare adapter (replacing
+any adapter you declare, with a warning), so a fresh SvelteKit
+project deploys as-is. Deploy-specific kit overrides can also be
+passed via the `kit` prop, which merges over your `sveltekit(...)`
+options — see [Kit and adapter options](#kit-and-adapter-options)
+below. A project without a `vite.config.*` works too: the resource
+falls back to a fully programmatic build.
 
 ## Declare the Website
 
@@ -158,9 +162,11 @@ export const load = async ({ platform }) => {
 
 ## Kit and adapter options
 
-Since kit v3 the configuration lives in memory — pass it via the
-`kit` prop instead of a `svelte.config.js`. The generated Cloudflare
-adapter is configured via `adapter`:
+Since kit v3 there is no `svelte.config.js` — kit options live in the
+`sveltekit(...)` call in your `vite.config.ts`, which loads natively.
+The `kit` prop is a deploy-time override layer merged over those
+options (the override wins). The generated Cloudflare adapter is
+configured via `adapter`:
 
 ```typescript
 export const Website = Cloudflare.Website.SvelteKit("Website", {
@@ -175,7 +181,13 @@ export const Website = Cloudflare.Website.SvelteKit("Website", {
 ```
 
 Don't set `kit.adapter` — Alchemy injects its own wrangler-free
-Cloudflare adapter.
+Cloudflare adapter (an adapter declared in your `sveltekit(...)` call
+is replaced with a warning).
+
+A few construction-time options (`preprocess`, `extensions`,
+`compilerOptions`, `vitePlugin`) can't be injected through the `kit`
+prop when your project has a `vite.config.*` — put those in your own
+`sveltekit(...)` call.
 
 ## Local dev
 

--- a/website/src/content/docs/cloudflare/frontend/waku.mdx
+++ b/website/src/content/docs/cloudflare/frontend/waku.mdx
@@ -13,8 +13,9 @@ export const devDeps = "@alchemy.run/cloudflare-frameworks";
 Cloudflare Worker. It builds the project programmatically: the React
 Server Components server bundle deploys as the Worker script, and the
 client output — including SSG-prerendered pages — deploys as static
-assets. There is no `waku.config.ts` to edit, no Wrangler file, and
-no build command to run.
+assets. No `waku.config.ts` edits are required — if you have one it
+loads natively — and there is no Wrangler file and no build command
+to run.
 
 ## Install
 
@@ -40,9 +41,18 @@ so a dev dependency is enough:
 
 ## Configure Waku
 
-There is no framework config to write: the resource builds the
-project programmatically, so a fresh Waku project deploys as-is —
-your `waku.config.ts` stays untouched.
+No framework config is required — a fresh Waku project deploys
+as-is. If your project has a `waku.config.ts`, Alchemy loads it
+natively (exactly as Waku's own CLI does) and uses it as the base
+config; options set on the resource (`srcDir`, `distDir`,
+`basePath`) merge over it. The one key Alchemy owns is
+`unstable_adapter` — setting it fails the build with an actionable
+error.
+
+:::note
+Vite configuration must live in `waku.config.ts`'s `vite` field —
+a standalone `vite.config.ts` is not loaded, same as Waku's own CLI.
+:::
 
 ## Declare the Website
 


### PR DESCRIPTION
The Astro guide claimed the opposite of what the code does:

```diff
-There is no framework config to write: the integration is fully
-programmatic, and your `astro.config.*` file is not read.
+Your `astro.config.*` file loads natively — integrations, Vite
+plugins, and any other non-serializable options work exactly as they
+do outside Alchemy. Alchemy merges a programmatic config *over* it.
```

The implementation leaves `configFile` to Astro's native discovery and merges the inline config over the file (pinned by `Astro.test.ts`: "The user's astro.config.* must load natively"). This lie caused a real user to conclude Alchemy couldn't deploy their Astro site with Vite plugins.

Audited every frontend doc and the corresponding JSDoc against the actual `configFile` handling in `cloudflare-frameworks`:

- **Astro** (`astro.mdx`, `Website/Astro.ts`) — config loads natively; documents the two real caveats: declaring an `adapter` in the file fails the build, and Alchemy's `output: "server"` default supersedes a file-level `output`.
- **SvelteKit** (`sveltekit.mdx`, `Website/SvelteKit.ts`, framework `source.ts`) — a project-owned `vite.config.ts` loads natively and its `sveltekit(...)` options are the primary config; the `kit` prop is an override layer, and construction-time options (`preprocess`, …) only apply in the no-config-file fallback. Docs predated the `UserConfig.ts` native-loading support.
- **Waku** (`waku.mdx`, `Website/Waku.ts`) — `waku.config.*` loads natively (file is base, props win per key); fixed `srcDir`/`distDir`/`basePath` `@default`s and added the framework-side `distDir` memo warning. Also documents the one genuine exception: a standalone `vite.config.ts` is **not** loaded (same as Waku's CLI).
- **Next.js** (`nextjs.mdx`, both `buildCommand` JSDoc copies) — "stays untouched" → "loaded and honored as-is"; documented that a `buildCommand` in `open-next.config.ts` takes precedence over the prop (`runner.mjs` uses `??=`).
- **Overview** (`frontends.mdx`) — "zero configuration files" → "no Cloudflare-specific configuration"; each framework bullet now states its config file loads natively.
- **Nuxt** (`Website/Nuxt.ts`) — was already correct; removed the now-wrong "unlike some siblings" contrast.

Vite-family pages (vite, vite-spa, vue, foldkit, tanstack-start, react-router, solidstart, octane) already correctly describe layering on top of the user's config — verified against `Sources/Vite.ts` (no `configFile` suppression) and left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
