### PR TITLE
perf(tsconfig): fix IDE language-server hangs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -50,12 +50,27 @@
     "packages/alchemy/bin/**/*.js*": true,
     "packages/alchemy/bin/**/*.d*": true
   },
+  // The client watcher feeds the tsgo LSP (workspace/didChangeWatchedFiles);
+  // every unexcluded change storm forces a session-snapshot clone + program
+  // update (8-18s on the alchemy projects). Exclude everything that is not a
+  // program input: agent worktrees (.claude is ~69GB incl. nested
+  // node_modules), vendored submodules, test logs/tmp bundles, and installs.
   "files.watcherExclude": {
-    "**/distilled/**": true
+    "**/distilled/**": true,
+    "**/.claude/**": true,
+    "**/.vendor/**": true,
+    "**/.alchemy/**": true,
+    "**/node_modules/**": true,
+    "**/.git/**": true
   },
   "search.exclude": {
-    "**/distilled/**": true
+    "**/distilled/**": true,
+    "**/.claude/**": true,
+    "**/.vendor/**": true,
+    "**/.alchemy/**": true
   },
+  // Keep the 200MB generated distilled surface out of the auto-import index.
+  "typescript.preferences.autoImportFileExcludePatterns": ["**/distilled/**"],
   "[typescript]": {
     "editor.indentSize": 2,
     "editor.defaultFormatter": "oxc.oxc-vscode"

--- a/packages/alchemy/src/Cloudflare/Providers.ts
+++ b/packages/alchemy/src/Cloudflare/Providers.ts
@@ -1,4 +1,4 @@
-import * as Retry from "@distilled.cloud/cloudflare/Retry";
+import { Retry } from "@distilled.cloud/cloudflare";
 import * as Layer from "effect/Layer";
 import { CredentialsStoreLive } from "../Auth/Credentials.ts";
 import { ProfileLive } from "../Auth/Profile.ts";

--- a/packages/alchemy/src/Cloudflare/Providers.ts
+++ b/packages/alchemy/src/Cloudflare/Providers.ts
@@ -1,4 +1,4 @@
-import { Retry } from "@distilled.cloud/cloudflare";
+import * as Retry from "@distilled.cloud/cloudflare/Retry";
 import * as Layer from "effect/Layer";
 import { CredentialsStoreLive } from "../Auth/Credentials.ts";
 import { ProfileLive } from "../Auth/Profile.ts";

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -565,7 +565,10 @@ export interface WorkerVersionOptions {
 }
 
 export interface WorkerProps<
-  Bindings extends WorkerBindingProps = any,
+  // PERF: unconstrained for the same reason as `Worker<Bindings>` above —
+  // the `extends WorkerBindingProps` proof is expensive for generic mapped
+  // types and the call-site overloads already constrain user input.
+  Bindings = any,
   Assets extends WorkerAssetsConfig | undefined =
     | WorkerAssetsConfig
     | undefined,
@@ -1033,7 +1036,14 @@ export interface ViteOptions {
   };
 }
 
-export type Worker<Bindings extends WorkerBindings = any> = Resource<
+// PERF: deliberately NOT `Bindings extends WorkerBindings`. The constraint
+// forced the checker to prove the generic `NormalizedBindings<...>` mapped
+// type assignable to the ~30-member `WorkerBindingResource` union at every
+// `Worker<...>` instantiation — a single 28s structural relation that was 45%
+// of the whole program's check time. Input is already constrained at the
+// call boundary (`Bindings extends WorkerBindingProps`), so this type
+// argument is only ever produced from validated shapes.
+export type Worker<Bindings = any> = Resource<
   WorkerTypeId,
   WorkerProps<Bindings>,
   {

--- a/packages/alchemy/tsconfig.json
+++ b/packages/alchemy/tsconfig.json
@@ -1,11 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
-  "include": [
-    "src/**/*.ts",
-    "src/**/*.tsx",
-    "src/**/*.json",
-    "src/Cloudflare/DnsFirewall/Firewall"
-  ],
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
   "compilerOptions": {
     "composite": true,
     "noEmit": false,
@@ -26,6 +21,9 @@
         "name": "@effect/language-service",
         // enable this to get effect diangostics in tsc
         "diagnostics": false,
+        // Unbounded type printing on hover renders megabyte strings for
+        // Effect-scale types (base also sets noErrorTruncation); cap it.
+        "quickinfoMaximumLength": 2000,
         "ignoreEffectErrorsInTscExitCode": true,
         "ignoreEffectWarningsInTscExitCode": true,
         "ignoreEffectSuggestionsInTscExitCode": true,

--- a/scripts/analyze-type-trace.ts
+++ b/scripts/analyze-type-trace.ts
@@ -1,0 +1,271 @@
+/**
+ * Attribute TypeScript check time and type creation to their source —
+ * "which types are making the checker slow, and whose fault are they?"
+ *
+ * The workspace compiler is tsgo (TS 7), which does NOT support
+ * `--generateTrace`, so traces are produced with Strada (TS 5.x) used purely
+ * as a measurement instrument against the same project:
+ *
+ * ```sh
+ * # 1. generate a trace (~2.5 min, ~12GB RAM for packages/alchemy)
+ * bunx --package typescript@5.9 tsc \
+ *   -p packages/alchemy/tsconfig.json \
+ *   --noEmit --incremental false --composite false \
+ *   --generateTrace /tmp/tstrace
+ *
+ * # 2. attribute it
+ * bun scripts/analyze-type-trace.ts /tmp/tstrace
+ * ```
+ *
+ * Reports, from `trace.json` + a streaming pass over `types.json`:
+ *   - check self-time per bucket (src/AWS, src/Cloudflare, core, distilled
+ *     lib, effect, node_modules, TS libs) and the top files
+ *   - top-level `structuredTypeRelatedTo` relation pairs by time — this is
+ *     what exposed the 28.4s `Worker<NormalizedBindings<...>>` vs
+ *     `WorkerBindingResource` constraint proof (45% of all check time)
+ *   - locationless union/intersection types attributed to their first
+ *     member's origin, and the top symbols by types created
+ *
+ * NOTE: `npx @typescript/analyze-trace` is complementary (per-file hot-spot
+ * drill-downs from trace.json) but crashes with "Invalid string length" when
+ * given an Effect-scale types.json — this script streams it instead.
+ * types.json can exceed 1GB; the stream pass takes ~1 min.
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as readline from "node:readline";
+
+const traceDir = process.argv[2];
+if (!traceDir) {
+  console.error("usage: bun scripts/analyze-type-trace.ts <traceDir>");
+  process.exit(1);
+}
+
+const BUCKETS = [
+  "(unknown)",
+  "packages/alchemy/src/AWS",
+  "packages/alchemy/src/Cloudflare",
+  "packages/alchemy/src (core)",
+  "distilled/*/lib",
+  "node_modules/effect",
+  "other node_modules",
+  "typescript libs",
+  "other",
+] as const;
+
+// Match by path segment rather than a repo-root prefix so the script works no
+// matter which checkout produced the trace. Strada lowercases paths on macOS.
+function bucketIdOf(p: string | undefined): number {
+  if (!p) return 0;
+  const lower = p.toLowerCase();
+  if (lower.includes("node_modules/effect/")) return 5;
+  if (lower.includes("node_modules/typescript/lib/")) return 7;
+  if (lower.includes("node_modules/")) return 6;
+  if (lower.includes("packages/alchemy/src/aws/")) return 1;
+  if (lower.includes("packages/alchemy/src/cloudflare/")) return 2;
+  if (lower.includes("packages/alchemy/src/")) return 3;
+  if (/distilled\/packages\/[^/]+\//.test(lower)) return 4;
+  return 8;
+}
+
+// Strip the absolute prefix before the first recognizable repo-relative
+// segment, purely for display.
+const rel = (p: string | undefined) => {
+  if (!p) return "?";
+  const m = p.match(/(?:packages|distilled|node_modules|examples|scripts)\/.*$/);
+  return m ? m[0] : p;
+};
+
+// ---------- trace.json: check self-time + top-level relation pairs ----------
+interface TraceEvent {
+  name?: string;
+  ph?: string;
+  ts: number;
+  dur?: number;
+  args?: { path?: string; sourceId?: number; targetId?: number };
+}
+
+const trace: TraceEvent[] = JSON.parse(
+  fs.readFileSync(path.join(traceDir, "trace.json"), "utf8"),
+);
+
+const stack: { p: string | undefined; start: number; child: number }[] = [];
+const fileSelf = new Map<string, number>();
+let totalCheck = 0;
+const relEvents: TraceEvent[] = [];
+for (const ev of trace) {
+  if (!ev?.name) continue;
+  if (ev.name === "checkSourceFile") {
+    if (ev.ph === "B") {
+      stack.push({ p: ev.args?.path, start: ev.ts, child: 0 });
+    } else if (ev.ph === "E" && stack.length) {
+      const f = stack.pop()!;
+      const dur = ev.ts - f.start;
+      const self = dur - f.child;
+      if (stack.length) stack[stack.length - 1].child += dur;
+      fileSelf.set(f.p ?? "?", (fileSelf.get(f.p ?? "?") ?? 0) + self);
+      totalCheck += self;
+    }
+  } else if (ev.name === "structuredTypeRelatedTo" && ev.ph === "X") {
+    relEvents.push(ev);
+  }
+}
+
+// Keep only top-level relation intervals (not nested inside a prior one).
+relEvents.sort((a, b) => a.ts - b.ts);
+let coverEnd = -1;
+const pairTime = new Map<string, number>();
+let topLevelRelTotal = 0;
+const neededIds = new Set<number>();
+for (const ev of relEvents) {
+  if (ev.ts >= coverEnd) {
+    topLevelRelTotal += ev.dur ?? 0;
+    coverEnd = ev.ts + (ev.dur ?? 0);
+    const k = `${ev.args!.sourceId}->${ev.args!.targetId}`;
+    pairTime.set(k, (pairTime.get(k) ?? 0) + (ev.dur ?? 0));
+    neededIds.add(ev.args!.sourceId!);
+    neededIds.add(ev.args!.targetId!);
+  }
+}
+const topPairs = [...pairTime.entries()].sort((a, b) => b[1] - a[1]).slice(0, 25);
+
+const out: string[] = [];
+out.push(
+  `== checkSourceFile self-time: ${(totalCheck / 1e6).toFixed(1)}s over ${fileSelf.size} files ==`,
+  "",
+  "== Check self-time by bucket ==",
+);
+const bucketTime = new Map<string, number>();
+for (const [p, us] of fileSelf) {
+  const b = BUCKETS[bucketIdOf(p)];
+  bucketTime.set(b, (bucketTime.get(b) ?? 0) + us);
+}
+for (const [b, us] of [...bucketTime.entries()].sort((a, b) => b[1] - a[1])) {
+  out.push(
+    `${(us / 1000).toFixed(0).padStart(9)} ms  ${((us / totalCheck) * 100).toFixed(1).padStart(5)}%  ${b}`,
+  );
+}
+out.push("", "== Top 30 files by check self-time ==");
+for (const [p, us] of [...fileSelf.entries()].sort((a, b) => b[1] - a[1]).slice(0, 30)) {
+  out.push(`${(us / 1000).toFixed(0).padStart(9)} ms  ${rel(p)}`);
+}
+out.push(
+  "",
+  `== Top-level structuredTypeRelatedTo total: ${(topLevelRelTotal / 1e6).toFixed(1)}s ==`,
+);
+
+// ---------- types.json: streamed attribution ----------
+interface TypeDescriptor {
+  id: number;
+  symbolName?: string;
+  firstDeclaration?: { path?: string; start?: { line: number } };
+  location?: { path?: string; line?: number };
+  intersectionTypes?: number[];
+  unionTypes?: number[];
+  flags?: string[];
+}
+
+const typesPath = path.join(traceDir, "types.json");
+const rl = readline.createInterface({
+  input: fs.createReadStream(typesPath, { encoding: "utf8", highWaterMark: 1 << 22 }),
+  crlfDelay: Infinity,
+});
+
+const MAX = 16_000_000;
+const bucketById = new Uint8Array(MAX);
+const idInfo = new Map<
+  number,
+  { sym?: string; path?: string; line?: number; flags?: string }
+>();
+const compositeByBucket = new Map<string, number>();
+const symCount = new Map<string, number>();
+const locatedByBucket = new Map<string, number>();
+let total = 0;
+
+for await (let line of rl) {
+  line = line.trim();
+  if (line === "[" || line === "]" || line === "") continue;
+  if (line.startsWith("[")) line = line.slice(1);
+  if (line.endsWith(",")) line = line.slice(0, -1);
+  if (line[0] !== "{") continue;
+  let t: TypeDescriptor;
+  try {
+    t = JSON.parse(line);
+  } catch {
+    continue;
+  }
+  total++;
+  const decl = t.firstDeclaration ?? t.location;
+  const p = decl && ("path" in decl ? decl.path : undefined);
+  const lineNo =
+    decl && ("start" in decl && decl.start ? decl.start.line : (decl as { line?: number }).line);
+  let b = 0;
+  if (p) {
+    b = bucketIdOf(p);
+    locatedByBucket.set(BUCKETS[b], (locatedByBucket.get(BUCKETS[b]) ?? 0) + 1);
+    if (t.symbolName) {
+      const key = `${t.symbolName} @ ${rel(p)}:${lineNo}`;
+      symCount.set(key, (symCount.get(key) ?? 0) + 1);
+    }
+  } else {
+    const members = t.intersectionTypes ?? t.unionTypes;
+    if (members) {
+      // Attribute a locationless composite to its first non-lib member.
+      for (const m of members) {
+        if (m > 0 && m < MAX && bucketById[m] !== 0 && bucketById[m] !== 7) {
+          b = bucketById[m];
+          break;
+        }
+      }
+      if (b === 0) {
+        for (const m of members) {
+          if (m > 0 && m < MAX && bucketById[m] !== 0) {
+            b = bucketById[m];
+            break;
+          }
+        }
+      }
+      const bn = BUCKETS[b] + (t.intersectionTypes ? " [intersection]" : " [union]");
+      compositeByBucket.set(bn, (compositeByBucket.get(bn) ?? 0) + 1);
+    }
+  }
+  if (t.id < MAX) bucketById[t.id] = b;
+  if (neededIds.has(t.id)) {
+    idInfo.set(t.id, {
+      sym: t.symbolName,
+      path: p,
+      line: lineNo,
+      flags: t.flags?.join("|"),
+    });
+  }
+  if (total % 1_000_000 === 0) process.stderr.write(`  ...streamed ${total} types\n`);
+}
+
+out.push("", `== ${total} types total; located types by bucket ==`);
+for (const [b, c] of [...locatedByBucket.entries()].sort((a, b) => b[1] - a[1])) {
+  out.push(`${String(c).padStart(9)}  ${b}`);
+}
+out.push("", "== Locationless union/intersection types by first member's bucket ==");
+for (const [b, c] of [...compositeByBucket.entries()].sort((a, b) => b[1] - a[1])) {
+  out.push(`${String(c).padStart(9)}  ${b}`);
+}
+out.push("", "== Top 30 symbols by types created ==");
+for (const [k, c] of [...symCount.entries()].sort((a, b) => b[1] - a[1]).slice(0, 30)) {
+  out.push(`${String(c).padStart(9)}  ${k}`);
+}
+out.push("", "== Top 25 top-level relation pairs by time ==");
+const fmt = (id: number) => {
+  const i = idInfo.get(id);
+  if (!i) return `#${id}`;
+  const loc = i.path ? `${rel(i.path)}:${i.line}` : i.flags;
+  return `${i.sym ?? "(anon)"} [${i.flags}] ${loc}`;
+};
+for (const [k, us] of topPairs) {
+  const [s, tg] = k.split("->").map(Number);
+  out.push(`${(us / 1000).toFixed(0).padStart(8)} ms  ${fmt(s)}`, `             -> ${fmt(tg)}`);
+}
+
+const outPath = path.join(traceDir, "attribution.txt");
+fs.writeFileSync(outPath, `${out.join("\n")}\n`);
+console.log(out.join("\n"));
+console.error(`\nwritten to ${outPath}`);

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,5 +1,19 @@
 {
   "exclude": ["node_modules", "dist", "vendor"],
+  // For `tsc -b -w` / classic-tsserver editors (the Cursor/tsgo LSP watches via
+  // the client, gated by .vscode/settings.json `files.watcherExclude`).
+  "watchOptions": {
+    "watchFile": "useFsEvents",
+    "watchDirectory": "useFsEvents",
+    "excludeDirectories": [
+      "**/node_modules",
+      "**/.git",
+      "**/.claude",
+      "**/.vendor",
+      "**/.alchemy",
+      "**/dist"
+    ]
+  },
   "compilerOptions": {
     "types": ["bun"],
     // Enable latest features
@@ -28,6 +42,11 @@
     // builds with `noCheck: true` and gates its own typechecking in its
     // own CI, so re-checking its sources from here buys nothing.
     "disableSourceOfProjectReferenceRedirect": true,
+    // Don't eagerly load every referenced composite project into the language
+    // server on find-all-references/rename — with 6 distilled projects and ~36
+    // examples in the solution, eager loading is a multi-GB memory spike.
+    // Editor-only; no effect on `tsc -b`.
+    "disableReferencedProjectLoad": true,
     "noFallthroughCasesInSwitch": true,
     // Some stricter flags (disabled by default)
     "noUnusedLocals": false,


### PR DESCRIPTION
Fix the hanging TypeScript language server. Cursor's tsgo LSP rebuilds the dirty project's whole program (10,060 files, ~10GB, 13.7M symbols) behind every LSP request, and its logs showed the rebuilds being triggered constantly by file-watch storms from directories that are not program inputs.

- `.vscode/settings.json`: `files.watcherExclude`/`search.exclude` for `.claude/**` (agent worktrees with their own node_modules), `.vendor/**`, `.alchemy/**`, `node_modules/**`; keep distilled out of the auto-import index

```jsonc
"files.watcherExclude": {
  "**/distilled/**": true,
  "**/.claude/**": true,
  "**/.vendor/**": true,
  "**/.alchemy/**": true,
  "**/node_modules/**": true,
  "**/.git/**": true
}
```

- `tsconfig.base.json`: `disableReferencedProjectLoad: true` (editor-only — stops find-all-refs from loading all 6 distilled projects + 36 examples) and `watchOptions.excludeDirectories` for `tsc -b -w`
- `packages/alchemy/tsconfig.json`: remove dead include entries (`src/Cloudflare/DnsFirewall/Firewall` doesn't exist, `src/**/*.json` matches nothing); cap Effect LS hover printing with `quickinfoMaximumLength: 2000`

Full `tsc -p packages/alchemy/tsconfig.json` check passes.

A companion change in the distilled repo (independent, no ordering requirement) turns off `declarationMap` so go-to-definition lands in `lib/*.d.ts` instead of loading the multi-MB generated source projects into the language server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
