### PR TITLE
chore(test): bound every stage of the flaky workerd shutdown test

### DIFF
--- a/packages/cloudflare-runtime/src/core/test/Workerd.test.ts
+++ b/packages/cloudflare-runtime/src/core/test/Workerd.test.ts
@@ -195,6 +195,14 @@ layer(services)((it) => {
     { timeout: 30_000 },
   );
 
+  // Every stage of this test is individually bounded. It used to hang for
+  // the full 60s test timeout on loaded ubuntu CI runners (~3 of 8 main
+  // runs) because the two unbounded waits — serve's listen-message race and
+  // the un-timeboxed fetch — could wedge under full-suite parallel load,
+  // and a vitest timeout interrupt wedges the shared layer runtime, so both
+  // retries died instantly ("All fibers interrupted without error"). With
+  // per-stage bounds a load blip surfaces as a fast, typed failure naming
+  // the stage, which vitest's CI retry budget can actually absorb.
   it.effect(
     "shuts down workerd when its scope closes",
     () =>
@@ -202,42 +210,54 @@ layer(services)((it) => {
         let port = 0;
         yield* Effect.gen(function* () {
           const workerd = yield* Workerd.Workerd;
-          const ports = yield* workerd.serve({
-            sockets: [
-              {
-                name: "http",
-                address: "127.0.0.1:0",
-                service: { name: "test" },
-              },
-            ],
-            services: [
-              {
-                name: "test",
-                worker: {
-                  compatibilityDate: "2026-03-10",
-                  modules: [
-                    {
-                      name: "main.js",
-                      esModule:
-                        "export default { fetch: () => new Response('ok') };",
-                    },
-                  ],
+          const ports = yield* workerd
+            .serve({
+              sockets: [
+                {
+                  name: "http",
+                  address: "127.0.0.1:0",
+                  service: { name: "test" },
                 },
-              },
-            ],
-          });
+              ],
+              services: [
+                {
+                  name: "test",
+                  worker: {
+                    compatibilityDate: "2026-03-10",
+                    modules: [
+                      {
+                        name: "main.js",
+                        esModule:
+                          "export default { fetch: () => new Response('ok') };",
+                      },
+                    ],
+                  },
+                },
+              ],
+            })
+            .pipe(Effect.timeout(20_000));
           port = ports.http;
+          // Workerd has reported its listener, so connect succeeds; the
+          // bound covers a slow first-request isolate compile under load.
           const response = yield* Effect.promise(() =>
-            fetch(`http://127.0.0.1:${port}/`),
+            fetch(`http://127.0.0.1:${port}/`, {
+              signal: AbortSignal.timeout(10_000),
+            }),
           );
           expect(yield* Effect.promise(() => response.text())).toBe("ok");
         }).pipe(Effect.scoped);
 
-        // Wait until we can bind to the port ourselves. Closing the scope
-        // kills workerd, but the OS releases the listener a moment after the
-        // process exits — a single immediate probe races that on loaded CI
-        // runners (observed on macos-latest), so retry briefly (bounded).
-        const free = yield* PortHelpers.check(port).pipe(
+        // Prove shutdown by LISTENING on exactly the address workerd held.
+        // (`PortHelpers.check` sweeps seven hosts — 0.0.0.0, ::, localhost,
+        // … — any of which a concurrently-running test project can occupy
+        // at this port number, failing the probe for reasons unrelated to
+        // workerd.) Closing the scope kills workerd, but the OS releases
+        // the listener a moment after the process exits — a single
+        // immediate probe races that on loaded CI runners (observed on
+        // macos-latest), so retry briefly (bounded).
+        const free = yield* PortHelpers.occupy(port, "127.0.0.1").pipe(
+          Effect.scoped,
+          Effect.catchDefect(Effect.fail),
           Effect.retry({ schedule: Schedule.spaced("250 millis"), times: 40 }),
           Effect.exit,
         );

--- a/packages/cloudflare-runtime/src/core/test/Workerd.test.ts
+++ b/packages/cloudflare-runtime/src/core/test/Workerd.test.ts
@@ -5,6 +5,7 @@ import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
 import * as Predicate from "effect/Predicate";
 import * as Schedule from "effect/Schedule";
+import * as NodeNet from "node:net";
 import * as Workerd from "../workerd/Workerd.ts";
 import * as PortHelpers from "./helpers/port.ts";
 
@@ -265,6 +266,116 @@ layer(services)((it) => {
       }),
     { timeout: 60_000 },
   );
+  // Pins the invariant the shutdown test's de-flake relies on: a TYPED
+  // failure leaves the shared layer runtime healthy, so a vitest retry gets
+  // a real, working attempt. (An external timeout interrupt used to wedge
+  // the runtime — "All fibers interrupted without error" — making both CI
+  // retries dead-on-arrival.) Attempt 1 fails on purpose the way a bounded
+  // stage fails; attempt 2 must be able to run the full serve → fetch →
+  // shutdown round-trip.
+  let wedgeAttempts = 0;
+  it.effect(
+    "a typed failure leaves the runtime healthy, so a retry gets a real attempt",
+    () =>
+      Effect.gen(function* () {
+        wedgeAttempts += 1;
+        if (wedgeAttempts === 1) {
+          return yield* Effect.fail(
+            new Error("simulated transient wedge (attempt 1)"),
+          );
+        }
+        const workerd = yield* Workerd.Workerd;
+        const ports = yield* workerd
+          .serve({
+            sockets: [
+              {
+                name: "http",
+                address: "127.0.0.1:0",
+                service: { name: "test" },
+              },
+            ],
+            services: [
+              {
+                name: "test",
+                worker: {
+                  compatibilityDate: "2026-03-10",
+                  modules: [
+                    {
+                      name: "main.js",
+                      esModule:
+                        "export default { fetch: () => new Response('retried') };",
+                    },
+                  ],
+                },
+              },
+            ],
+          })
+          .pipe(Effect.timeout(20_000));
+        const response = yield* Effect.promise(() =>
+          fetch(`http://127.0.0.1:${ports.http}/`, {
+            signal: AbortSignal.timeout(10_000),
+          }),
+        );
+        expect(yield* Effect.promise(() => response.text())).toBe("retried");
+      }),
+    { timeout: 60_000, retry: 2 },
+  );
+
+  // Pins the persistent-wedge failure mode: against a server that accepts
+  // connections but never responds (the shape of the CI wedge — workerd's
+  // listener was up, the first response never came), the bounded fetch
+  // fails FAST with a typed TimeoutError instead of hanging until the test
+  // timeout kills the fiber. The server tracks and destroys its sockets on
+  // release — `server.close` alone waits for the aborted connection's
+  // server-side socket and never fires its callback.
+  const silentServer = Effect.acquireRelease(
+    Effect.callback<{
+      port: number;
+      server: NodeNet.Server;
+      sockets: Set<NodeNet.Socket>;
+    }>((resume) => {
+      const sockets = new Set<NodeNet.Socket>();
+      const server = NodeNet.createServer((socket) => {
+        sockets.add(socket);
+        socket.once("close", () => sockets.delete(socket));
+      });
+      server.once("error", (error) => resume(Effect.die(error)));
+      server.listen({ port: 0, host: "127.0.0.1", exclusive: true }, () =>
+        resume(
+          Effect.succeed({
+            server,
+            sockets,
+            port: (server.address() as NodeNet.AddressInfo).port,
+          }),
+        ),
+      );
+    }),
+    ({ server, sockets }) =>
+      Effect.callback<void>((resume) => {
+        for (const socket of sockets) socket.destroy();
+        server.close(() => resume(Effect.void));
+      }),
+  );
+
+  it.effect(
+    "a wedged first request fails fast with a typed abort, not a hang",
+    () =>
+      Effect.gen(function* () {
+        const silent = yield* silentServer;
+        const started = Date.now();
+        const exit = yield* Effect.tryPromise(() =>
+          fetch(`http://127.0.0.1:${silent.port}/`, {
+            signal: AbortSignal.timeout(1_000),
+          }),
+        ).pipe(Effect.exit);
+        const elapsed = Date.now() - started;
+        assert(Exit.isFailure(exit));
+        expect(String(exit.cause)).toMatch(/timeout/i);
+        expect(elapsed).toBeLessThan(10_000);
+      }),
+    { timeout: 30_000 },
+  );
+
   it.effect(
     "starts many workers concurrently",
     () =>


### PR DESCRIPTION
The workerd shutdown test ("shuts down workerd when its scope closes") hung for its full 60s timeout on loaded ubuntu runners in ~3 of the last 8 main runs of cloudflare-tools.yml (e.g. run 31541434645). Every CI failure is a timeout — never an assertion — and the "(retry x2)" attempts died instantly with "All fibers interrupted without error": a vitest timeout interrupt wedges the shared `@effect/vitest` layer runtime, so the CI retry budget never got a real attempt.

The hang lived in the test's two unbounded waits, not the (already bounded) port poll:

- `workerd.serve` — waits indefinitely on the control-fd listen-message race
- the `fetch` against the served worker — no timeout at all

Both are now bounded, so a load blip becomes a fast, typed failure naming the stage — which vitest's `retry: 2` can actually absorb:

```ts
const ports = yield* workerd.serve({...}).pipe(Effect.timeout(20_000));
const response = yield* Effect.promise(() =>
  fetch(`http://127.0.0.1:${port}/`, { signal: AbortSignal.timeout(10_000) }),
);
```

The shutdown probe also stops depending on unrelated processes: `PortHelpers.check` sweeps seven hosts (`0.0.0.0`, `::`, `localhost`, …), any of which a concurrently-running test project can occupy at that port number under `fileParallelism`. The test now proves shutdown by listening on exactly the address workerd held:

```ts
const free = yield* PortHelpers.occupy(port, "127.0.0.1").pipe(
  Effect.scoped,
  Effect.catchDefect(Effect.fail),
  Effect.retry({ schedule: Schedule.spaced("250 millis"), times: 40 }),
  Effect.exit,
);
```

Both outcomes are pinned by deterministic tests so the de-flake can't silently regress:

- **transient wedge → retry passes**: a test fails attempt 1 on purpose (the way a bounded stage fails) and attempt 2 must complete a full serve → fetch round-trip, proving a typed failure leaves the layer runtime healthy and the retry is real — it reports `✓ … (retry x1)`
- **persistent wedge → fast typed failure**: against a server that accepts but never responds (the CI wedge shape), the bounded fetch fails in ~1s with a typed `TimeoutError` instead of hanging to the test timeout

No product code changes — `Workerd.serve` semantics are untouched. If the wedge recurs on CI it now surfaces as a flaky-passed test whose logged first-attempt error names the wedged stage — turning CI into the diagnostic harness for the underlying (likely workerd-first-request) root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
