### PR TITLE
docs(website): readable text selection on dark code surfaces in light mode

### DIFF
--- a/website/src/styles/tokens.css
+++ b/website/src/styles/tokens.css
@@ -360,3 +360,15 @@ body.alc-root,
   background: var(--alc-accent-soft);
   color: var(--alc-fg-1);
 }
+
+/* Code surfaces stay dark walnut in BOTH themes, but the global selection
+   foreground follows the page (--alc-fg-1 is dark walnut in light mode) —
+   selecting code text would paint dark-on-dark. Pin selection inside code
+   surfaces to the dark-surface palette instead. */
+.expressive-code ::selection,
+.alc-term ::selection,
+.alc-code::selection,
+.alc-code ::selection {
+  background: #5c7a3e66; /* editor.selectionBackground from the walnut EC theme */
+  color: var(--alc-code-var);
+}


### PR DESCRIPTION
Selecting text in a code block in light mode rendered dark-on-dark and was unreadable. The global selection rule uses the page foreground, which is dark walnut in light mode — the same color as the code surface (code blocks stay dark walnut in both themes):

```css
::selection {
  background: var(--alc-accent-soft);
  color: var(--alc-fg-1); /* #2a2620 in light mode == the code-block bg */
}
```

Fix: pin selection inside dark code surfaces (`.expressive-code`, `.alc-term`, `.alc-code`) to the dark-surface palette, independent of page theme:

```css
.expressive-code ::selection,
.alc-term ::selection,
.alc-code::selection,
.alc-code ::selection {
  background: #5c7a3e66; /* editor.selectionBackground from the walnut EC theme */
  color: var(--alc-code-var);
}
```

`tokens.css` loads on both docs and marketing pages, so one rule covers all code surfaces. Verified in the dev server: light-mode code selection is now parchment on moss, dark mode and regular page-text selection are unchanged.
