### PR TITLE
chore(scripts): stop test:examples status repaint leaking rows into scrollback

### DIFF
--- a/scripts/test-examples.ts
+++ b/scripts/test-examples.ts
@@ -49,43 +49,87 @@ const elapsedSeconds = (state: TaskState): string => {
 
 const makeStatusRenderer = (states: readonly TaskState[]) => {
   const interactive = process.stdout.isTTY === true;
-  let renderedLines = 0;
+  let renderedRows = 0;
 
-  const lines = () => [
-    "Example tests",
-    ...states.map((state) => {
-      const icon =
-        state.status === "ok"
-          ? "ok"
-          : state.status === "failed"
-            ? "failed"
-            : state.status;
-      const exit =
-        state.exitCode === undefined || state.exitCode === 0
-          ? ""
-          : ` exit ${state.exitCode ?? "signal"}`;
-      return `  ${icon.padEnd(7)} ${state.label} ${elapsedSeconds(state)}${exit}`;
-    }),
-  ];
+  const taskLine = (state: TaskState) => {
+    const icon =
+      state.status === "ok"
+        ? "ok"
+        : state.status === "failed"
+          ? "failed"
+          : state.status;
+    const exit =
+      state.exitCode === undefined || state.exitCode === 0
+        ? ""
+        : ` exit ${state.exitCode ?? "signal"}`;
+    return `  ${icon.padEnd(7)} ${state.label} ${elapsedSeconds(state)}${exit}`;
+  };
+
+  // Physical rows a line occupies once the terminal wraps it.
+  const rowsFor = (line: string) => {
+    const columns = process.stdout.columns || 80;
+    return Math.max(1, Math.ceil(line.length / columns));
+  };
+  const rowsForAll = (output: readonly string[]) =>
+    output.reduce((total, line) => total + rowsFor(line), 0);
+
+  const fullLines = () => ["Example tests", ...states.map(taskLine)];
+
+  // The in-place repaint moves the cursor up with `\x1b[NF`, which cannot
+  // climb above the top of the viewport: if a paint is taller than the
+  // terminal (or lines wrap), the write scrolls and every repaint leaks its
+  // topmost rows into scrollback. Keep each paint strictly shorter than the
+  // viewport by collapsing finished tasks into the header once space runs
+  // out (`+ 1` accounts for the cursor parking on the row below the paint).
+  const lines = () => {
+    const rows = process.stdout.rows || 24;
+    const full = fullLines();
+    if (rowsForAll(full) + 1 <= rows) {
+      return full;
+    }
+    const done = states.filter((state) => state.status === "ok").length;
+    const active = states.filter((state) => state.status !== "ok");
+    const header = `Example tests (${done}/${states.length} ok)`;
+    const activeLines = active.map(taskLine);
+    let shown = activeLines.length;
+    const fits = (count: number) => {
+      const overflow = count < activeLines.length ? 1 : 0;
+      return (
+        rowsForAll([header, ...activeLines.slice(0, count)]) + overflow + 1 <=
+        rows
+      );
+    };
+    while (shown > 0 && !fits(shown)) {
+      shown--;
+    }
+    return shown === activeLines.length
+      ? [header, ...activeLines]
+      : [
+          header,
+          ...activeLines.slice(0, shown),
+          `  … ${activeLines.length - shown} more`,
+        ];
+  };
 
   return {
     render() {
       if (!interactive) {
         return;
       }
-      if (renderedLines > 0) {
-        process.stdout.write(`\x1b[${renderedLines}F\x1b[J`);
+      if (renderedRows > 0) {
+        process.stdout.write(`\x1b[${renderedRows}F\x1b[J`);
       }
       const output = lines();
       process.stdout.write(`${output.join("\n")}\n`);
-      renderedLines = output.length;
+      renderedRows = rowsForAll(output);
     },
     finish() {
-      if (interactive) {
-        this.render();
-        return;
+      if (interactive && renderedRows > 0) {
+        process.stdout.write(`\x1b[${renderedRows}F\x1b[J`);
+        renderedRows = 0;
       }
-      for (const line of lines()) {
+      // Always end with the full table (the live view may be compacted).
+      for (const line of fullLines()) {
         console.log(line);
       }
     },


### PR DESCRIPTION
Fixes the endless `Example tests` spam when running `test:examples` in a terminal shorter than the status table.

The live table repaints in place with `\x1b[NF` (cursor up N lines), which can't move above the top of the viewport. #1178 grew the example list to 17, making the paint (header + 17 rows + cursor line) taller than typical panes — each repaint scrolled, the cursor-up clamped at the top, and the repaint's topmost rows leaked into scrollback once per render. Wrapped lines in narrow panes leak the same way.

The renderer now measures physical rows (accounting for line wrapping via `stdout.columns`) and collapses finished tasks into the header whenever the full table wouldn't fit the viewport:

```
Example tests (9/17 ok)
  running ./examples/cloudflare-website-nextjs 38s
  running ./examples/aws-lambda 21s
  … 6 more
```

A paint is now never taller than the viewport, so it never scrolls and never leaks. The final summary still prints the full table.

Verified with a fake-TTY simulation across viewports (18×120 — the reporting case, 10×120, 24×40 narrow-wrap, 5×80, 50×200): no paint ever exceeds the viewport at any phase of the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
