### PR TITLE
feat(vite): self-deduplicating Cloudflare plugin — no more env-var guard in vite configs

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/Sources/Vite.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Sources/Vite.ts
@@ -96,6 +96,13 @@ const makeViteLogger = (console: ConsoleService.Console): vite.Logger => {
  * race a save/restore. A process that ran an Alchemy build never also
  * runs a standalone (non-Alchemy) Vite build, so the flag staying set is
  * correct for the process lifetime.
+ *
+ * DEPRECATED as a user-facing guard: the plugin is now self-deduplicating
+ * (`injected: true` on the orchestrated instance; a config-file instance
+ * detects it via its `apply` clause and stands down), so configs can
+ * declare `cloudflare({...})` unguarded. The variable is still set for
+ * configs that guard on it — their ternary yields `null`, which is
+ * equally correct.
  */
 const ALCHEMY_CLOUDFLARE_VITE_INJECTED = "ALCHEMY_CLOUDFLARE_VITE_INJECTED";
 
@@ -133,7 +140,7 @@ export const viteDev = (
           const devServer = await vite.createServer({
             root: rootDir,
             define: getDefine(env),
-            plugins: [cloudflare(pluginOptions)],
+            plugins: [cloudflare({ ...pluginOptions, injected: true })],
             server,
             customLogger: makeViteLogger(console),
           });
@@ -216,7 +223,10 @@ export const viteBuildInProcess = (
         {
           root: rootDir,
           define: getDefine(env),
-          plugins: [cloudflare(pluginOptions), outputPlugin.plugin],
+          plugins: [
+            cloudflare({ ...pluginOptions, injected: true }),
+            outputPlugin.plugin,
+          ],
           customLogger: makeViteLogger(console),
           // Disables the NATIVE rolldown progress reporter ("transforming…",
           // "rendering chunks…", "computing gzip size…"): it prints from

--- a/packages/alchemy/test/Cloudflare/Website/vite-fixture/vite.config.ts
+++ b/packages/alchemy/test/Cloudflare/Website/vite-fixture/vite.config.ts
@@ -1,3 +1,4 @@
+import cloudflare from "@alchemy.run/cloudflare-runtime/vite";
 import { defineConfig } from "vite";
 
 // `Cloudflare.Website.Vite` declares an `ssr` environment but doesn't set a
@@ -7,6 +8,12 @@ import { defineConfig } from "vite";
 // build at our minimal worker entry so the cloudflare-vite-plugin can
 // wrap it into the worker bundle.
 export default defineConfig({
+  // Deliberately UNGUARDED (no ALCHEMY_CLOUDFLARE_VITE_INJECTED ternary):
+  // the plugin an app declares for standalone `vite build`/`vite dev` must
+  // stand down by itself when alchemy injects its orchestrated instance —
+  // this fixture pins that self-deduplication end to end (a second active
+  // instance would boot a bindings-less workerd and fail these suites).
+  plugins: [cloudflare({ main: "./src/worker.ts" })],
   environments: {
     ssr: {
       build: {

--- a/packages/cloudflare-frameworks/src/astro/integration.ts
+++ b/packages/cloudflare-frameworks/src/astro/integration.ts
@@ -373,12 +373,16 @@ export function distilledCloudflare(
             ? withDevSessionKv(options.vite, sessionKVBindingName)
             : options.vite;
 
-        const cloudflarePlugins = cloudflareVitePlugin(
-          makeIntegrationPluginOptions(viteOptions, {
+        const cloudflarePlugins = cloudflareVitePlugin({
+          ...makeIntegrationPluginOptions(viteOptions, {
             prerenderEnvironment,
             command,
           }),
-        ) as Array<vite.Plugin>;
+          // This integration owns the plugin for the whole Astro run — a
+          // `cloudflare({...})` the app's own vite config declares (for
+          // standalone builds) stands down against this instance.
+          injected: true,
+        }) as Array<vite.Plugin>;
 
         // Same trick as upstream (astro#16332): `build`/`sync` run type
         // generation, which creates a temporary Vite server and fires

--- a/packages/cloudflare-frameworks/src/waku/cloudflare.ts
+++ b/packages/cloudflare-frameworks/src/waku/cloudflare.ts
@@ -129,13 +129,17 @@ export const makeWakuCloudflareTarget = (
       }),
     vitePlugins: (context) =>
       Effect.sync(() => [
-        cloudflareVitePlugin(
-          makeWakuPluginOptions({
+        cloudflareVitePlugin({
+          ...makeWakuPluginOptions({
             root: context.root,
             wakuDirectory: context.wakuDirectory,
             pluginOptions: config,
           }),
-        ),
+          // The target owns the plugin for the whole Waku run — a
+          // `cloudflare({...})` the app's own vite config declares (for
+          // standalone builds) stands down against this instance.
+          injected: true,
+        }),
       ]),
   });
 

--- a/packages/cloudflare-runtime/src/vite/plugin.ts
+++ b/packages/cloudflare-runtime/src/vite/plugin.ts
@@ -48,12 +48,61 @@ export interface CloudflareVitePluginOptions<
   >;
   context?: Context.Context<RuntimeServices>;
   dev?: CloudflareVitePluginDevOptions;
+  /**
+   * Marks this instance as injected by an orchestrator (Alchemy's
+   * dev/build runs, a framework integration) that supplies the fully
+   * resolved worker options. A NON-injected instance — the one an app's
+   * own `vite.config.ts` declares so plain `vite build`/`vite dev` work
+   * without the orchestrator — stands down automatically when an injected
+   * instance is present in the same config (see the `apply` guard below),
+   * so configs no longer need the `ALCHEMY_CLOUDFLARE_VITE_INJECTED`
+   * env-var ternary.
+   *
+   * @internal
+   */
+  injected?: boolean;
 }
+
+/**
+ * Marker property stamped on every plugin object of an injected instance.
+ *
+ * Detection goes through the config's plugin OBJECTS (not module state):
+ * the orchestrator's instance and the config-file instance may come from
+ * different copies of this module (the app's `node_modules` vs the
+ * orchestrator's), so a module-level flag would not be shared between
+ * them. A well-known property on the plugin objects travels with the
+ * config regardless of which copy created them.
+ */
+const INJECTED_MARKER = "__alchemyCloudflareInjected";
+
+/**
+ * Whether an injected Cloudflare plugin instance is present in a config's
+ * plugin tree. Async entries are ignored: the orchestrators always pass
+ * their instance as a plain array in the inline config, so an injected
+ * instance is never behind a Promise.
+ */
+const hasInjectedInstance = (option: vite.PluginOption): boolean => {
+  if (Array.isArray(option)) return option.some(hasInjectedInstance);
+  return (
+    typeof option === "object" && option !== null && INJECTED_MARKER in option
+  );
+};
+
+/** Evaluate a plugin's original `apply` clause (absent means always). */
+const originalApplies = (
+  apply: vite.Plugin["apply"],
+  config: vite.UserConfig,
+  env: vite.ConfigEnv,
+): boolean => {
+  if (apply === undefined) return true;
+  if (typeof apply === "function") return apply(config, env);
+  return apply === env.command;
+};
 
 export default function cloudflareVitePlugin(
   options: CloudflareVitePluginOptions = {},
 ): vite.PluginOption {
-  return [
+  const plugins = [
     optionsPlugin.vite(options),
     cloudflareExternalsPlugin.vite(options),
     nodejsAlsPlugin.vite(options),
@@ -75,4 +124,21 @@ export default function cloudflareVitePlugin(
     // family) and resolve to `null`; filter them out so integrations that
     // post-process the returned plugins don't have to handle sparse entries.
   ].filter((plugin): plugin is vite.Plugin => plugin !== null);
+  if (options.injected) {
+    for (const plugin of plugins) {
+      Object.defineProperty(plugin, INJECTED_MARKER, { value: true });
+    }
+  } else {
+    // Self-deduplication: Vite evaluates `apply` BEFORE a plugin enters the
+    // pipeline, so a standing-down instance runs no hooks, boots no
+    // workerd, and never appears in `configResolved.plugins` — the
+    // name-based cross-plugin lookups can only find the injected instance.
+    for (const plugin of plugins) {
+      const apply = plugin.apply;
+      plugin.apply = (config, env) =>
+        !hasInjectedInstance(config.plugins ?? []) &&
+        originalApplies(apply, config, env);
+    }
+  }
+  return plugins;
 }

--- a/packages/cloudflare-runtime/src/vite/test/plugin-dedup.test.ts
+++ b/packages/cloudflare-runtime/src/vite/test/plugin-dedup.test.ts
@@ -1,0 +1,101 @@
+import * as vite from "vite";
+import { describe, expect, it } from "vitest";
+import cloudflareVitePlugin from "../plugin.ts";
+
+const asPlugins = (option: vite.PluginOption): Array<vite.Plugin> =>
+  option as Array<vite.Plugin>;
+
+const SERVE_ENV: vite.ConfigEnv = { command: "serve", mode: "development" };
+
+describe("cloudflare vite plugin self-deduplication", () => {
+  it("a config-file instance stands down when an injected instance is present", () => {
+    const configFile = asPlugins(cloudflareVitePlugin());
+    const injected = asPlugins(cloudflareVitePlugin({ injected: true }));
+    const config: vite.UserConfig = { plugins: [configFile, injected] };
+
+    for (const plugin of configFile) {
+      expect(plugin.apply, `${plugin.name} has an apply guard`).toBeTypeOf(
+        "function",
+      );
+      expect(
+        (plugin.apply as (c: vite.UserConfig, e: vite.ConfigEnv) => boolean)(
+          config,
+          SERVE_ENV,
+        ),
+        `${plugin.name} stands down`,
+      ).toBe(false);
+    }
+  });
+
+  it("a config-file instance stays active without an injected instance", () => {
+    const configFile = asPlugins(cloudflareVitePlugin());
+    const config: vite.UserConfig = { plugins: [configFile] };
+
+    for (const plugin of configFile) {
+      expect(
+        (plugin.apply as (c: vite.UserConfig, e: vite.ConfigEnv) => boolean)(
+          config,
+          SERVE_ENV,
+        ),
+        `${plugin.name} applies standalone`,
+      ).toBe(true);
+    }
+  });
+
+  it("detects the injected instance through nested plugin arrays", () => {
+    const configFile = asPlugins(cloudflareVitePlugin());
+    const injected = asPlugins(cloudflareVitePlugin({ injected: true }));
+    // Framework configs commonly nest plugin arrays several levels deep.
+    const config: vite.UserConfig = { plugins: [[configFile], [[injected]]] };
+
+    expect(
+      (
+        configFile[0]!.apply as (
+          c: vite.UserConfig,
+          e: vite.ConfigEnv,
+        ) => boolean
+      )(config, SERVE_ENV),
+    ).toBe(false);
+  });
+
+  it("resolves to exactly one active plugin stack when both instances are configured", async () => {
+    const config = await vite.resolveConfig(
+      {
+        configFile: false,
+        logLevel: "silent",
+        // The app's own (unguarded) instance first — the shape of a config
+        // file declaring `cloudflare({...})` while alchemy injects its own
+        // via the inline config.
+        plugins: [
+          cloudflareVitePlugin(),
+          cloudflareVitePlugin({ injected: true }),
+        ],
+      },
+      "serve",
+    );
+    const optionsInstances = config.plugins.filter(
+      (plugin) => plugin.name === "distilled-cloudflare:options",
+    );
+    expect(optionsInstances).toHaveLength(1);
+    const devInstances = config.plugins.filter(
+      (plugin) => plugin.name === "distilled-cloudflare:dev",
+    );
+    expect(devInstances).toHaveLength(1);
+  });
+
+  it("resolves the standalone instance when nothing is injected", async () => {
+    const config = await vite.resolveConfig(
+      {
+        configFile: false,
+        logLevel: "silent",
+        plugins: [cloudflareVitePlugin()],
+      },
+      "serve",
+    );
+    expect(
+      config.plugins.filter(
+        (plugin) => plugin.name === "distilled-cloudflare:options",
+      ),
+    ).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Follow-up to #1129: the Cloudflare Vite plugin now deduplicates itself, so apps that also build standalone can declare it unguarded — the `ALCHEMY_CLOUDFLARE_VITE_INJECTED` env-var ternary is no longer needed.

```diff
  // vite.config.ts
- process.env.ALCHEMY_CLOUDFLARE_VITE_INJECTED === "1" ? null : cloudflare({ ... })
+ cloudflare({ ... })
```

Orchestrated call sites (alchemy's `viteDev`/`viteBuild`, the Astro integration, the Waku cloudflare target) pass `injected: true`, which stamps a marker property on that instance's plugin objects. A non-injected instance carries an `apply` clause that scans the merged config's plugin tree for the marker and stands down:

```ts
plugin.apply = (config, env) =>
  !hasInjectedInstance(config.plugins ?? []) && originalApplies(apply, config, env);
```

Why this shape:

- Vite evaluates `apply` **before** a plugin enters the pipeline — a standing-down instance runs no hooks, boots no workerd, and never appears in `configResolved.plugins`, so the name-based cross-plugin lookups (`distilled-cloudflare:options`) can only find the injected instance.
- Detection rides on the plugin **objects**, not module state: the orchestrator's instance and the config-file instance may come from different copies of the module (app `node_modules` vs orchestrator's), so a module-level flag would not be shared between them.
- The env var is still set for existing configs that guard on it — their ternary yields `null`, which is equally correct. It's now documented as deprecated for new configs.

Coverage: unit + `vite.resolveConfig` integration tests assert exactly one active plugin stack in every combination (`plugin-dedup.test.ts`), and the Website vite fixture's `vite.config.ts` now declares the plugin **unguarded** — the `Vite`, `Vite.local`, and `ViteRoutePrefix` suites (18 tests) only pass if the config-file instance stands down in both dev and live builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
