### PR TITLE
docs(blog): beta.71 release notes

### DIFF
--- a/website/src/content/docs/blog/2026-08-12-beta-71.md
+++ b/website/src/content/docs/blog/2026-08-12-beta-71.md
@@ -1,0 +1,299 @@
+---
+title: 2.0.0-beta.71 - Effect beta.105 & Better Auth
+date: 2026-08-12T09:00:00Z
+category: release
+excerpt: v2.0.0-beta.71 moves to effect 4.0.0-beta.105 and drizzle 1.0.0-rc.5-ab785fc in lockstep (effect's TaggedErrorClass → TaggedError rename broke drizzle rc.4), gives @alchemy.run/better-auth an effectful API and a database Layer for every platform, lets Worker props be an Effect, and fixes the ways alchemy dev could serve the wrong app on a configured port.
+---
+
+Alchemy now runs on **effect 4.0.0-beta.105**, with
+**drizzle 1.0.0-rc.5-ab785fc** bumped in lockstep to survive
+effect's `TaggedErrorClass` → `TaggedError` rename. On top of that, `@alchemy.run/better-auth` gains an
+effectful API and a database Layer for every platform, Worker
+props can now be an Effect, and a batch of `alchemy dev` fixes
+makes configured ports, queue consumers, and pre-beta.66 state
+behave.
+
+:::caution
+**Breaking changes**
+
+- **effect `>=4.0.0-beta.105` is the new minimum peer**
+  ([#1132](https://github.com/alchemy-run/alchemy/pull/1132)).
+  effect renamed `Schema.TaggedErrorClass` to
+  `Schema.TaggedError`, so earlier betas can no longer resolve.
+  If you use Drizzle, upgrade `drizzle-orm`/`drizzle-kit` to
+  `1.0.0-rc.5-ab785fc` at the same time — see
+  [below](#effect-beta105-and-the-drizzle-rc5-lockstep).
+- **Drizzle backends move out of the `alchemy/Drizzle` barrel**
+  ([#1119](https://github.com/alchemy-run/alchemy/pull/1119)).
+  Import `alchemy/Drizzle/Postgres`, `alchemy/Drizzle/MySQL`, and
+  `alchemy/Drizzle/Cloudflare` (Durable Object) directly; the
+  barrel keeps `Schema`, `providers()`, `D1`, and the errors.
+- **`alchemy dev` now serves assets first** when
+  `assets.runWorkerFirst` is omitted
+  ([#1121](https://github.com/alchemy-run/alchemy/pull/1121)),
+  matching the deployed default. A worker that intercepts
+  asset-path requests in dev must opt in explicitly with
+  `assets: { runWorkerFirst: true }` — such apps already behaved
+  assets-first in production, so the old dev default was masking
+  a dev/prod divergence.
+:::
+
+## effect beta.105 and the drizzle rc.5 lockstep
+
+effect `4.0.0-beta.105` renamed `Schema.TaggedErrorClass` to
+`Schema.TaggedError`:
+
+```diff lang="typescript"
+-export class AuthError extends Schema.TaggedErrorClass<AuthError>()(
++export class AuthError extends Schema.TaggedError<AuthError>()(
+   "AuthError",
+   { message: Schema.String },
+ ) {}
+```
+
+drizzle-orm `1.0.0-rc.4` — which ships effect-native clients built
+on that API — broke against it, which pinned the entire dependency
+tree: you couldn't take the effect upgrade without breaking
+drizzle, and vice versa. Drizzle's `1.0.0-rc.5-ab785fc` release
+ships `TaggedError` natively, so beta.71 upgrades both in lockstep
+([#1132](https://github.com/alchemy-run/alchemy/pull/1132),
+[#1184](https://github.com/alchemy-run/alchemy/pull/1184)):
+
+```diff lang="json"
+-"effect": ">=4.0.0-beta.102",
+-"drizzle-orm": "1.0.0-rc.4",
+-"drizzle-kit": "1.0.0-rc.4",
++"effect": ">=4.0.0-beta.105",
++"drizzle-orm": "1.0.0-rc.5-ab785fc",
++"drizzle-kit": "1.0.0-rc.5-ab785fc",
+```
+
+When you upgrade, pin drizzle exactly — a `^1.0.0-rc.4` range can
+still hand you the rc.4 that breaks against effect beta.105.
+
+Alongside the version bump, the optional Drizzle drivers now load
+lazily ([#1119](https://github.com/alchemy-run/alchemy/pull/1119))
+— importing the Postgres or MySQL client no longer requires
+`@effect/sql-mysql2`/`@effect/sql-pg` to be installed unless you
+actually connect:
+
+```diff lang="typescript"
+-import * as Drizzle from "alchemy/Drizzle";
++import * as Drizzle from "alchemy/Drizzle/Postgres";
+ const db = yield* Drizzle.Postgres(conn.connectionString, { relations });
+```
+
+Docs: [SQL & Drizzle](/sql).
+
+## Better Auth: every database, effectful API
+
+`@alchemy.run/better-auth` now supports every storage backend and
+wraps Better Auth's async API in an effectful interface
+([#1157](https://github.com/alchemy-run/alchemy/pull/1157)):
+`yield* BetterAuth(options)` gives you a fully-typed auth
+instance, and the database is a Layer you pick per platform.
+Plugin typing flows end-to-end — every `auth.api.*` endpoint is an
+Effect with a tagged `BetterAuthApiError` — and schema migrations
+run automatically at deploy as an alchemy Action, input-hash
+diffed and tree-shaken out of runtime bundles.
+
+```typescript
+const auth = yield* BetterAuth({
+  basePath: "/auth",
+  emailAndPassword: { enabled: true },
+  plugins: [anonymous()], // auth.api.signInAnonymous is now typed
+});
+
+// serve the Better Auth routes on Workers and Lambda unchanged
+if (request.url.startsWith("/auth")) return yield* auth.fetch;
+
+// or call endpoints directly — typed errors, set-cookie preserved
+yield* auth.api.signInEmail({ body: { email, password } }).pipe(
+  Effect.catchTag("BetterAuthApiError", (e) => ...), // e.statusCode, e.body.code
+);
+```
+
+The database Layers cover every environment → target pair:
+`CloudflareD1` (native binding + migrations over the D1 HTTP API,
+local simulator included), `Neon` (serverless driver over
+WebSocket — no Hyperdrive, no `pg`), `AuroraDataApi` (SQL over
+HTTPS with IAM — no VPC attachment), `CloudflareHyperdrive`,
+generic `Postgres` and `MySQL` TCP fallbacks (PlanetScale, RDS,
+any connection string), `SQLite` for local dev, `Memory` for
+tests, and `Drizzle` to bring your own db via better-auth's
+official adapter.
+
+Because the database is a Layer, your auth code never changes —
+you swap the provided Layer. On D1:
+
+```typescript
+import { CloudflareD1 } from "@alchemy.run/better-auth/CloudflareD1";
+
+export const AuthDb = Cloudflare.D1.Database("AuthDb");
+
+export default class AuthWorker extends Cloudflare.Worker<AuthWorker>()(
+  "AuthWorker",
+  { main: import.meta.url },
+  Effect.gen(function* () {
+    const auth = yield* BetterAuth({ emailAndPassword: { enabled: true } });
+    return {
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        if (request.url.startsWith("/auth")) return yield* auth.fetch;
+        return HttpServerResponse.text("ok");
+      }),
+    };
+  }).pipe(Effect.provide(CloudflareD1(AuthDb))),
+) {}
+```
+
+Moving to PlanetScale Postgres is only a Layer swap — the
+`BetterAuth` program is untouched:
+
+```diff lang="typescript"
+-import { CloudflareD1 } from "@alchemy.run/better-auth/CloudflareD1";
++import { Postgres } from "@alchemy.run/better-auth/Postgres";
+
+-export const AuthDb = Cloudflare.D1.Database("AuthDb");
++export const AuthDb = Planetscale.PostgresDatabase("AuthDb");
++export const AuthRole = Planetscale.PostgresRole("AuthRole", { database: AuthDb });
++
++const AuthDatabase = Layer.unwrap(
++  Effect.map(AuthRole, (role) => Postgres(role.connectionUrl)),
++);
+
+ export default class AuthWorker extends Cloudflare.Worker<AuthWorker>()(
+   "AuthWorker",
+   { main: import.meta.url },
+   Effect.gen(function* () {
+     const auth = yield* BetterAuth({ emailAndPassword: { enabled: true } });
+     return {
+       fetch: ...,
+     };
+-  }).pipe(Effect.provide(CloudflareD1(AuthDb))),
++  }).pipe(Effect.provide(AuthDatabase)),
+ ) {}
+```
+
+The API reference also learned to document Layers as first-class
+pages ([#1159](https://github.com/alchemy-run/alchemy/pull/1159))
+— each database Layer gets its own generated page declaring what
+it provides and its peer dependencies.
+
+Docs: [Better Auth](/better-auth).
+
+## `alchemy dev` fixes
+
+A configured dev port could serve the wrong app
+([#1129](https://github.com/alchemy-run/alchemy/pull/1129)): the
+proxy bound only `127.0.0.1`, browsers prefer `::1`, and any
+framework dev server hunting from its default port could squat
+the IPv6 half of `localhost`:
+
+```sh
+proxy listening on 127.0.0.1:3000
+vite dev server binds [::1]:3000
+http://localhost:3000 → the wrong app
+```
+
+The proxy now owns its port on both address families, and a dev
+restart no longer cascades every configured port in the stack up
+by one.
+
+`Alchemy.remote()` bindings no longer go stale
+([#1139](https://github.com/alchemy-run/alchemy/pull/1139)) —
+Cloudflare's edge preview was pinning the remote-binding proxy to
+sessions pointing at destroyed resources, 400ing every proxied
+KV/R2/D1 call for up to 50 minutes.
+
+Framework production builds run in disposable child processes
+with `NODE_ENV=production` pinned
+([#1139](https://github.com/alchemy-run/alchemy/pull/1139),
+[#1178](https://github.com/alchemy-run/alchemy/pull/1178)), so
+user config and plugins can `chdir`, mutate `process.env`, or
+crash without taking the engine with them.
+
+And every local worker announces where it's serving as it comes
+up:
+
+```text
+[api-worker] ready at http://localhost:1337
+```
+
+## State from older versions recovers automatically
+
+Stacks that mixed `alchemy dev` and `alchemy deploy` on versions
+before beta.66 could end up with state the engine no longer knew
+how to handle — deploys and destroys failing forever with errors
+like:
+
+```text
+BadRequest: There is a malformed parameter in the request
+
+Cloudflare queue "jobs" already has a worker consumer for script
+"worker-t2po...", but this resource is configured for "worker-qwh3..."
+```
+
+beta.71 recognizes these situations and repairs them on your next
+run: old dev-mode state is routed to the local simulator instead
+of the real Cloudflare API
+([#1130](https://github.com/alchemy-run/alchemy/pull/1130)),
+resources deployed before beta.66 are properly replaced — not
+silently abandoned — when you run dev
+([#1110](https://github.com/alchemy-run/alchemy/pull/1110)), and
+queue/consumer wiring left behind by old runs is reattached or
+cleaned up
+([#1133](https://github.com/alchemy-run/alchemy/pull/1133)).
+
+## Also in this release
+
+- **Cloudflare tooling moves into the monorepo**
+  ([#1122](https://github.com/alchemy-run/alchemy/pull/1122)) —
+  the runtime and framework adapters are now
+  `@alchemy.run/cloudflare-runtime` and
+  `@alchemy.run/cloudflare-frameworks`, developed, tested, and
+  released with alchemy itself. Thanks
+  [Rahul Mishra](https://github.com/BlankParticle)!
+- **Queue consumers work on `Website.Vite` workers in dev**
+  ([#1113](https://github.com/alchemy-run/alchemy/pull/1113)) —
+  consumer wiring survives the Vite child's boot order, and
+  `send()` to a queue with no running consumer resolves instead
+  of hanging forever.
+- **Local queue consumers honor batch settings**
+  ([#1126](https://github.com/alchemy-run/alchemy/pull/1126)) —
+  `batchSize`/`maxWaitTimeMs` now map onto the local broker's
+  field names instead of being silently ignored.
+- **Asset serving fixes**
+  ([#1121](https://github.com/alchemy-run/alchemy/pull/1121)) —
+  the asset MIME table covers the full extension set (avif, webp,
+  woff2, … previously `application/octet-stream`), and asset
+  hashes include the extension so identical bodies under
+  different extensions keep distinct content types. One-time
+  effect: all assets re-upload on your next deploy.
+- **Docker containers receive their environment values**
+  ([#1118](https://github.com/alchemy-run/alchemy/pull/1118)) —
+  `environment` entries resolved empty inside the container,
+  breaking e.g. PostgreSQL bootstrap.
+- **InternetGateway detach rides out lingering ENIs**
+  ([#1125](https://github.com/alchemy-run/alchemy/pull/1125)) —
+  Fargate and Lambda ENIs can hold public IPs for 5–20 minutes
+  after their owner is deleted; the detach now waits them out
+  instead of leaving an IGW+VPC residue on destroy.
+- **Auto-generated names avoid reserved prefixes**
+  ([#1186](https://github.com/alchemy-run/alchemy/pull/1186)) —
+  stacks named `aws-*` produced physical names that Resource
+  Groups, S3 Tables, and S3 Vectors reject; colliding prefixes
+  are now escaped, and non-colliding names are byte-for-byte
+  unchanged.
+- **Dates persist correctly in state**
+  ([#1164](https://github.com/alchemy-run/alchemy/pull/1164)) —
+  a `Date`-typed prop used to serialize as `{}` in durable state
+  stores, churning a phantom update on every subsequent plan.
+
+## Where to go next
+
+- [Better Auth](/better-auth)
+- [SQL & Drizzle](/sql)
+- [Local development](/environments/local-development)
+- [CHANGELOG](https://github.com/alchemy-run/alchemy/blob/main/CHANGELOG.md#v200-beta71)
+- [Compare v2.0.0-beta.70 → v2.0.0-beta.71](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.70...v2.0.0-beta.71)


### PR DESCRIPTION
Release notes for v2.0.0-beta.71, covering everything since the v2.0.0-beta.70 tag.

- Headline: effect `4.0.0-beta.105` + drizzle `1.0.0-rc.5-ab785fc` in lockstep (effect's `TaggedErrorClass` → `TaggedError` rename broke drizzle rc.4) — #1132, #1184
- Better Auth: effectful API + a database Layer per platform, with a D1 → PlanetScale Postgres Layer-swap example — #1157, #1159
- Breaking changes called out up top: effect peer floor, `alchemy/Drizzle` subpath imports (#1119), assets-first dev routing (#1121)
- Worker props as an Effect (#1172), `alchemy dev` fixes (#1129, #1139, #1178), automatic recovery of state from older versions (#1110, #1130, #1133), and the long tail under "Also in this release"
