### PR TITLE
test(aws): local dev HMR regression suite

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -414,6 +414,15 @@
         "effect": "catalog:",
       },
     },
+    "examples/aws-dev": {
+      "name": "aws-dev",
+      "version": "0.0.0",
+      "dependencies": {
+        "@effect/platform-node": "catalog:",
+        "alchemy": "workspace:*",
+        "effect": "catalog:",
+      },
+    },
     "examples/aws-ec2": {
       "name": "aws-ec2-example",
       "version": "0.0.0",
@@ -4172,6 +4181,8 @@
     "autoprefixer": ["autoprefixer@10.5.4", "", { "dependencies": { "browserslist": "^4.28.6", "caniuse-lite": "^1.0.30001806", "fraction.js": "^5.3.4", "picocolors": "^1.1.1", "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.1.0" }, "bin": { "autoprefixer": "bin/autoprefixer" } }, "sha512-MaU0U/za7N3r6brxD4YB/l4NSrFzLPlANv6wEuQVaIPlD3L4W9rFcQPbL/EilY9BHhHvhfcz3gInDLrEtWT4EA=="],
 
     "aws-bedrock-ai": ["aws-bedrock-ai@workspace:examples/aws-bedrock-ai"],
+
+    "aws-dev": ["aws-dev@workspace:examples/aws-dev"],
 
     "aws-ec2-example": ["aws-ec2-example@workspace:examples/aws-ec2"],
 

--- a/examples/aws-dev/alchemy.run.ts
+++ b/examples/aws-dev/alchemy.run.ts
@@ -1,0 +1,18 @@
+import * as Alchemy from "alchemy";
+import * as AWS from "alchemy/AWS";
+import * as Effect from "effect/Effect";
+import ApiFunction from "./src/ApiFunction.ts";
+
+export default Alchemy.Stack(
+  "aws-dev",
+  {
+    providers: AWS.providers(),
+    state: Alchemy.localState(),
+  },
+  Effect.gen(function* () {
+    const api = yield* ApiFunction;
+    return {
+      api: api.functionUrl,
+    };
+  }),
+);

--- a/examples/aws-dev/package.json
+++ b/examples/aws-dev/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "aws-dev",
+  "version": "0.0.0",
+  "private": true,
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
+    "directory": "examples/aws-dev"
+  },
+  "type": "module",
+  "scripts": {
+    "deploy": "alchemy deploy",
+    "dev": "alchemy dev",
+    "destroy": "alchemy destroy",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@effect/platform-node": "catalog:",
+    "alchemy": "workspace:*",
+    "effect": "catalog:"
+  }
+}

--- a/examples/aws-dev/src/ApiFunction.ts
+++ b/examples/aws-dev/src/ApiFunction.ts
@@ -1,0 +1,132 @@
+import * as DynamoDB from "alchemy/AWS/DynamoDB";
+import * as Lambda from "alchemy/AWS/Lambda";
+import * as S3 from "alchemy/AWS/S3";
+import * as SQS from "alchemy/AWS/SQS";
+import * as Config from "effect/Config";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Stream from "effect/Stream";
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import { MARKER } from "./marker.ts";
+
+/**
+ * Kitchen-sink dev-mode Lambda: one Function owning an S3 bucket, a
+ * DynamoDB table, and an SQS queue, exercising each runtime binding over
+ * HTTP routes so `alchemy dev` can be driven end-to-end from a test.
+ *
+ * Routes:
+ *   - GET  /                  → marker + env (Config-provided MY_VARIABLE)
+ *   - GET  /s3                → PutObject/GetObject roundtrip
+ *   - GET  /dynamo            → PutItem/GetItem roundtrip
+ *   - POST /queue/send        → SendMessage over the binding
+ *   - GET  /queue/messages    → reads what the queue consumer recorded
+ *
+ * The queue consumer (`consumeQueueMessages`) runs on this same Function —
+ * the local broker (floci's event-source-mapping poller) invokes it with
+ * SQS batches, and it records each message into the table so the produce →
+ * consume path is observable over HTTP.
+ */
+export default class ApiFunction extends Lambda.Function<ApiFunction>()(
+  "ApiFunction",
+  {
+    main: import.meta.url,
+    functionUrl: true,
+    env: { MY_VARIABLE: "my-variable-abc123" },
+  },
+  Effect.gen(function* () {
+    // `/s3` writes into the bucket, so destroy must empty it first.
+    const bucket = yield* S3.Bucket("DevBucket", { forceDestroy: true });
+    const table = yield* DynamoDB.Table("MessagesTable", {
+      partitionKey: "id",
+      attributes: { id: "S" },
+    });
+    const queue = yield* SQS.Queue("DevQueue");
+
+    const getObject = yield* S3.GetObject(bucket);
+    const putObject = yield* S3.PutObject(bucket);
+    const getItem = yield* DynamoDB.GetItem(table);
+    const putItem = yield* DynamoDB.PutItem(table);
+    const sendMessage = yield* SQS.SendMessage(queue);
+
+    // Consume produced messages and record them into the table so the
+    // test can observe the produce → deliver → consume roundtrip.
+    yield* SQS.consumeQueueMessages(queue, (records) =>
+      records.pipe(
+        Stream.mapEffect((record) => {
+          const parsed = JSON.parse(record.body) as { id: string };
+          return putItem({
+            Item: {
+              id: { S: `msg:${parsed.id}` },
+              body: { S: record.body },
+            },
+          });
+        }),
+        Stream.runDrain,
+        Effect.orDie,
+      ),
+    );
+
+    return {
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        const url = new URL(request.originalUrl);
+
+        if (url.pathname === "/") {
+          const variable = yield* Config.string("MY_VARIABLE");
+          return yield* HttpServerResponse.json({ marker: MARKER, variable });
+        }
+
+        if (url.pathname === "/s3") {
+          yield* putObject({ Key: "hello.txt", Body: "hello from s3" });
+          const object = yield* getObject({ Key: "hello.txt" });
+          const text = yield* (object.Body?.pipe(
+            Stream.decodeText,
+            Stream.mkString,
+          ) ?? Effect.succeed(""));
+          return yield* HttpServerResponse.json({ text });
+        }
+
+        if (url.pathname === "/dynamo") {
+          yield* putItem({
+            Item: {
+              id: { S: "hello" },
+              content: { S: "hello from dynamo" },
+            },
+          });
+          const item = yield* getItem({ Key: { id: { S: "hello" } } });
+          return yield* HttpServerResponse.json({
+            text: item.Item?.content?.S ?? null,
+          });
+        }
+
+        if (url.pathname === "/queue/send" && request.method === "POST") {
+          const body = yield* request.text;
+          yield* sendMessage({ MessageBody: body });
+          return yield* HttpServerResponse.json({ sent: true });
+        }
+
+        if (url.pathname === "/queue/messages") {
+          const id = url.searchParams.get("id") ?? "";
+          const item = yield* getItem({ Key: { id: { S: `msg:${id}` } } });
+          return yield* HttpServerResponse.json({
+            body: item.Item?.body?.S ?? null,
+          });
+        }
+
+        return HttpServerResponse.text("Not found", { status: 404 });
+      }).pipe(Effect.orDie),
+    };
+  }).pipe(
+    Effect.provide(
+      Layer.mergeAll(
+        Lambda.QueueEventSource,
+        S3.GetObjectHttp,
+        S3.PutObjectHttp,
+        DynamoDB.GetItemHttp,
+        DynamoDB.PutItemHttp,
+        SQS.SendMessageHttp,
+      ),
+    ),
+  ),
+) {}

--- a/examples/aws-dev/src/marker.ts
+++ b/examples/aws-dev/src/marker.ts
@@ -1,0 +1,6 @@
+/**
+ * The CLI dev test (test/dev.test.ts) rewrites this value in place — with
+ * `alchemy dev` running — to prove the Lambda hot-swaps code without a
+ * redeploy, then restores it. The checked-in value is always `v1`.
+ */
+export const MARKER = "aws-dev-marker-v1";

--- a/examples/aws-dev/test/dev.test.ts
+++ b/examples/aws-dev/test/dev.test.ts
@@ -1,0 +1,253 @@
+/**
+ * True `alchemy dev` end-to-end for AWS: spawns the REAL CLI and drives
+ * every local binding over HTTP against the floci emulator.
+ *
+ * This is a different code path from the `Test.make({ dev: true })` harness
+ * suites under packages/alchemy/test/AWS — the harness mirrors the RPC
+ * sidecar topology, but only this test covers the CLI itself: arg parsing,
+ * the `bin/exec` child under `--watch`, the `ALCHEMY_RPC_SPAWNER_URL`
+ * handshake, and provider sidecars whose lifetime is tied to the CLI
+ * process (the #1007 bug class, mirrored from
+ * examples/cloudflare-dev/test/dev.test.ts).
+ *
+ * Coverage, all against floci (no cloud credentials, no cloud resources):
+ *   - Function URL       → `/` serves through the emulator's URL proxy
+ *   - env vars           → `/` echoes MY_VARIABLE via effect/Config
+ *   - S3 binding         → `/s3` PutObject/GetObject roundtrip
+ *   - DynamoDB binding   → `/dynamo` PutItem/GetItem roundtrip
+ *   - SQS + consumer     → `/queue/send` produces; floci's ESM poller
+ *                          delivers to `consumeQueueMessages`, which records
+ *                          into the table read back by `/queue/messages`
+ *   - HOT RELOAD         → rewriting src/marker.ts (no redeploy) must serve
+ *                          the new marker; restoring it must swap back
+ */
+import { afterAll, expect, test } from "bun:test";
+import { spawn, spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const root = path.resolve(import.meta.dirname, "..");
+// Spawn the CLI entry directly (not through `bun run` / the cli.js
+// launcher) so signals hit the actual CLI process, whose scope teardown
+// kills the exec child and the provider sidecars.
+const alchemyBin = path.join(
+  root,
+  "node_modules",
+  "alchemy",
+  "bin",
+  "alchemy.ts",
+);
+// Isolated stage so this suite never fights other local runs over state.
+const STAGE = "dev-cli-test";
+
+const markerPath = path.join(root, "src", "marker.ts");
+const markerSource = fs.readFileSync(markerPath, "utf8");
+
+// The whole suite needs docker (floci runs as a container).
+const dockerAvailable =
+  spawnSync("docker", ["info"], { stdio: "ignore" }).status === 0;
+
+let proc: ReturnType<typeof spawn> | undefined;
+let output = "";
+
+const pump = (stream: NodeJS.ReadableStream) => {
+  stream.on("data", (chunk: Buffer) => {
+    const text = chunk.toString();
+    output += text;
+    if (process.env.DEBUG) process.stderr.write(text);
+  });
+};
+
+/** Bounded poll for a (possibly async) producer to yield a value. */
+const pollUntil = async <T>(
+  what: string,
+  f: () => T | undefined | Promise<T | undefined>,
+  { tries = 30, delayMs = 1000 }: { tries?: number; delayMs?: number } = {},
+): Promise<T> => {
+  for (let i = 0; i < tries; i++) {
+    const value = await f();
+    if (value !== undefined) return value;
+    await Bun.sleep(delayMs);
+  }
+  throw new Error(
+    `Timed out waiting for ${what}.\n--- alchemy dev output (tail) ---\n${output.slice(-4000)}`,
+  );
+};
+
+/** Fetch with retries — the emulator's URL proxy takes a moment to serve. */
+const fetchOk = async (
+  url: string | URL,
+  init?: RequestInit,
+  { tries = 20, delayMs = 500 }: { tries?: number; delayMs?: number } = {},
+) => {
+  let last: Response | undefined;
+  for (let i = 0; i < tries; i++) {
+    try {
+      last = await fetch(url, init);
+      if (last.ok) return last;
+    } catch {
+      // proxy not listening yet
+    }
+    await Bun.sleep(delayMs);
+  }
+  throw new Error(
+    `${init?.method ?? "GET"} ${url} never returned 2xx (last status: ${last?.status})`,
+  );
+};
+
+/** Extract the api URL from the stack outputs the CLI prints on stdout. */
+const outputUrl = (key: string) =>
+  output.match(new RegExp(`${key}:\\s*['"]?(http[^\\s'",]+)`))?.[1];
+
+afterAll(async () => {
+  // Always leave the repo tree clean, even on a mid-reload failure.
+  fs.writeFileSync(markerPath, markerSource);
+
+  if (proc?.pid) {
+    // Ctrl-C semantics: signal the whole PROCESS GROUP (the CLI, its
+    // `--watch` exec child, and the provider sidecars). Signaling only the
+    // CLI process orphans the exec child, which then keeps the stack's
+    // state locked and blocks the destroy below.
+    const killGroup = (signal: NodeJS.Signals) => {
+      try {
+        process.kill(-proc!.pid!, signal);
+      } catch {
+        // group already gone
+      }
+    };
+    const exited = new Promise((resolve) => proc!.once("exit", resolve));
+    killGroup("SIGINT");
+    await Promise.race([exited, Bun.sleep(15_000)]);
+    if (proc.exitCode === null && proc.signalCode === null) {
+      killGroup("SIGKILL");
+      await Promise.race([exited, Bun.sleep(5_000)]);
+    }
+  }
+  if (!process.env.NO_DESTROY && dockerAvailable) {
+    spawnSync("bun", [alchemyBin, "destroy", "--stage", STAGE, "--yes"], {
+      cwd: root,
+      stdio: "inherit",
+      timeout: 120_000,
+    });
+  }
+}, 180_000);
+
+test.skipIf(!dockerAvailable)(
+  "alchemy dev serves every local AWS binding end-to-end with hot reload",
+  async () => {
+    proc = spawn("bun", [alchemyBin, "dev", "--stage", STAGE], {
+      cwd: root,
+      // Own process group, so teardown can deliver Ctrl-C to the whole tree
+      // the way a terminal would.
+      detached: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    pump(proc.stdout!);
+    pump(proc.stderr!);
+
+    // The first dev deploy may pull the floci image, provision the local
+    // data plane, and package the function before printing stack outputs.
+    const api = await pollUntil(
+      "api url in stack outputs",
+      () => outputUrl("api"),
+      { tries: 300, delayMs: 1000 },
+    );
+
+    // Dev identity: the function URL is served by the emulator, not AWS.
+    expect(api).toContain("localhost:4566");
+
+    // Marker + env: the function reads MY_VARIABLE through effect/Config.
+    const home = (await (await fetchOk(api)).json()) as {
+      marker: string;
+      variable: string;
+    };
+    expect(home.marker).toBe("aws-dev-marker-v1");
+    expect(home.variable).toBe("my-variable-abc123");
+
+    // S3 binding: put/get roundtrip against the emulator.
+    const s3 = (await (await fetchOk(new URL("/s3", api))).json()) as {
+      text: string;
+    };
+    expect(s3.text).toBe("hello from s3");
+
+    // DynamoDB binding: put/get roundtrip against the emulator.
+    const dynamo = (await (await fetchOk(new URL("/dynamo", api))).json()) as {
+      text: string | null;
+    };
+    expect(dynamo.text).toBe("hello from dynamo");
+
+    // SQS: produce over the binding; floci's event-source-mapping poller
+    // delivers to the consumer, which records into the table.
+    const message = { id: crypto.randomUUID(), text: "hello from alchemy dev" };
+    await fetchOk(new URL("/queue/send", api), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(message),
+    });
+    const received = await pollUntil(
+      "queue message to be consumed",
+      async () => {
+        const res = await fetch(
+          new URL(`/queue/messages?id=${message.id}`, api),
+        );
+        if (!res.ok) return undefined;
+        const { body } = (await res.json()) as { body: string | null };
+        return body ?? undefined;
+      },
+      { tries: 60, delayMs: 500 },
+    );
+    expect(JSON.parse(received)).toEqual(message);
+
+    // ── HOT RELOAD: rewrite src/marker.ts with the CLI still running. The
+    // `--watch` exec child re-runs, the dev provider hot-swaps the function
+    // code in floci, and the SAME url serves the new marker — no deploy ──
+    fs.writeFileSync(
+      markerPath,
+      markerSource.replace("aws-dev-marker-v1", "aws-dev-marker-v2"),
+    );
+    await pollUntil(
+      "hot-swapped marker v2",
+      async () => {
+        try {
+          const res = await fetch(api);
+          if (!res.ok) return undefined;
+          const { marker } = (await res.json()) as { marker: string };
+          return marker === "aws-dev-marker-v2" ? marker : undefined;
+        } catch {
+          return undefined; // mid-swap
+        }
+      },
+      { tries: 240, delayMs: 500 },
+    );
+
+    // Bindings survived the reload: the table still holds the consumed
+    // message and the S3 roundtrip still works.
+    const afterReload = (await (
+      await fetchOk(new URL(`/queue/messages?id=${message.id}`, api))
+    ).json()) as { body: string | null };
+    expect(afterReload.body).toBe(JSON.stringify(message));
+    const s3After = (await (await fetchOk(new URL("/s3", api))).json()) as {
+      text: string;
+    };
+    expect(s3After.text).toBe("hello from s3");
+
+    // Restore the marker — the swap back is itself a second hot reload,
+    // and leaves the checked-in tree clean.
+    fs.writeFileSync(markerPath, markerSource);
+    await pollUntil(
+      "restored marker v1",
+      async () => {
+        try {
+          const res = await fetch(api);
+          if (!res.ok) return undefined;
+          const { marker } = (await res.json()) as { marker: string };
+          return marker === "aws-dev-marker-v1" ? marker : undefined;
+        } catch {
+          return undefined; // mid-swap
+        }
+      },
+      { tries: 240, delayMs: 500 },
+    );
+  },
+  { timeout: 600_000 },
+);

--- a/examples/aws-dev/tsconfig.json
+++ b/examples/aws-dev/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["alchemy.run.ts", "src/**/*.ts", "test/**/*.ts"],
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "module": "Preserve",
+    "moduleResolution": "Bundler",
+    "target": "ESNext"
+  },
+  "references": [
+    {
+      "path": "../../packages/alchemy/tsconfig.json"
+    }
+  ]
+}

--- a/packages/alchemy/test/AWS/Website/Astro.local.test.ts
+++ b/packages/alchemy/test/AWS/Website/Astro.local.test.ts
@@ -2,6 +2,8 @@ import * as AWS from "@/AWS";
 import * as Test from "@/Test/Alchemy";
 import { describe, expect } from "alchemy-test";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
 import * as pathe from "pathe";
 import { cloneFixture } from "../../Cloudflare/Utils/Fixture.ts";
 import { expectUrlContains } from "../../Cloudflare/Utils/Http.ts";
@@ -29,6 +31,9 @@ describe("AWS.Website.Astro local", () => {
     "dev runs Astro's own dev server with no cloud resources",
     (stack) =>
       Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+
         yield* stack.destroy();
 
         const rootDir = yield* cloneFixture(fixtureDir, {
@@ -74,6 +79,25 @@ describe("AWS.Website.Astro local", () => {
         );
         yield* expectUrlContains(`${url}/api/hello?echo=dev`, "dev", {
           label: "API route query echo (dev)",
+        });
+
+        // ── HMR: edit the API route in place. The stack is NOT re-applied —
+        // astro's dev rebuild must pick the change up and serve it through
+        // the same URL ───────────────────────────────────────────────────
+        const helloPath = path.join(rootDir, "src/pages/api/hello.ts");
+        const hello = yield* fs.readFileString(helloPath);
+        yield* fs.writeFileString(
+          helloPath,
+          hello.replace("ASTRO_AWS_API_MARKER", "ASTRO_AWS_API_MARKER_V2"),
+        );
+        yield* expectUrlContains(
+          `${url}/api/hello?echo=dev`,
+          "ASTRO_AWS_API_MARKER_V2",
+          { timeout: "90 seconds", label: "API route after HMR edit" },
+        );
+        // The route still round-trips its query after the reload.
+        yield* expectUrlContains(`${url}/api/hello?echo=post-hmr`, "post-hmr", {
+          label: "API route query echo after HMR edit",
         });
 
         yield* stack.destroy();

--- a/packages/alchemy/test/AWS/Website/Nextjs.local.test.ts
+++ b/packages/alchemy/test/AWS/Website/Nextjs.local.test.ts
@@ -2,6 +2,8 @@ import * as AWS from "@/AWS";
 import * as Test from "@/Test/Alchemy";
 import { describe, expect } from "alchemy-test";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
 import { spawn } from "node:child_process";
 import * as pathe from "pathe";
 import { cloneFixture } from "../../Cloudflare/Utils/Fixture.ts";
@@ -62,6 +64,9 @@ describe("AWS.Website.Nextjs local", () => {
     "dev runs Next's own dev server with no cloud resources",
     (stack) =>
       Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+
         yield* stack.destroy();
 
         // Clone OUTSIDE the repo (OS temp dir): an in-workspace clone makes
@@ -114,6 +119,25 @@ describe("AWS.Website.Nextjs local", () => {
         );
         yield* expectUrlContains(`${url}/api/hello?echo=dev`, "dev", {
           label: "API route query echo (dev)",
+        });
+
+        // ── HMR: edit the App Router route in place. The stack is NOT
+        // re-applied — next dev must recompile the route and serve it
+        // through the same URL ───────────────────────────────────────────
+        const routePath = path.join(rootDir, "app/api/hello/route.ts");
+        const route = yield* fs.readFileString(routePath);
+        yield* fs.writeFileString(
+          routePath,
+          route.replace("NEXTJS_AWS_API_MARKER", "NEXTJS_AWS_API_MARKER_V2"),
+        );
+        yield* expectUrlContains(
+          `${url}/api/hello?echo=dev`,
+          "NEXTJS_AWS_API_MARKER_V2",
+          { timeout: "120 seconds", label: "API route after HMR edit" },
+        );
+        // The route still round-trips its query after the recompile.
+        yield* expectUrlContains(`${url}/api/hello?echo=post-hmr`, "post-hmr", {
+          label: "API route query echo after HMR edit",
         });
 
         yield* stack.destroy();

--- a/packages/alchemy/test/AWS/Website/Nuxt.local.test.ts
+++ b/packages/alchemy/test/AWS/Website/Nuxt.local.test.ts
@@ -2,6 +2,8 @@ import * as AWS from "@/AWS";
 import * as Test from "@/Test/Alchemy";
 import { describe, expect } from "alchemy-test";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
 import * as pathe from "pathe";
 import { cloneFixture } from "../../Cloudflare/Utils/Fixture.ts";
 import { expectUrlContains } from "../../Cloudflare/Utils/Http.ts";
@@ -30,6 +32,9 @@ describe("AWS.Website.Nuxt local", () => {
     "dev runs Nuxt's own dev server with no cloud resources",
     (stack) =>
       Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+
         yield* stack.destroy();
 
         const rootDir = yield* cloneFixture(fixtureDir, {
@@ -84,6 +89,27 @@ describe("AWS.Website.Nuxt local", () => {
           "NUXT_AWS_API_MARKER",
           { label: "API route (dev)" },
         );
+
+        // ── HMR: edit the API route in place. The stack is NOT re-applied —
+        // nitro's dev rebuild must pick the change up and serve it through
+        // the same URL ───────────────────────────────────────────────────
+        const helloPath = path.join(rootDir, "server/api/hello.ts");
+        const hello = yield* fs.readFileString(helloPath);
+        yield* fs.writeFileString(
+          helloPath,
+          hello.replace("NUXT_AWS_API_MARKER", "NUXT_AWS_API_MARKER_V2"),
+        );
+        yield* expectUrlContains(
+          `${url}/api/hello?echo=dev`,
+          "NUXT_AWS_API_MARKER_V2",
+          { timeout: "90 seconds", label: "API route after HMR edit" },
+        );
+        // server.environment survived the dev rebuild — the injected env
+        // still reaches SSR after the reload (dev/live parity holds across
+        // hot updates, not just at boot).
+        yield* expectUrlContains(`${url}/`, "env:nuxt-aws-dev-env-marker", {
+          label: "server.environment after HMR edit",
+        });
 
         yield* stack.destroy();
       }),

--- a/packages/alchemy/test/AWS/Website/Octane.local.test.ts
+++ b/packages/alchemy/test/AWS/Website/Octane.local.test.ts
@@ -2,6 +2,8 @@ import * as AWS from "@/AWS";
 import * as Test from "@/Test/Alchemy";
 import { describe, expect } from "alchemy-test";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
 import * as pathe from "pathe";
 import { cloneFixture } from "../../Cloudflare/Utils/Fixture.ts";
 import { expectUrlContains } from "../../Cloudflare/Utils/Http.ts";
@@ -32,6 +34,9 @@ describe("AWS.Website.Octane local", () => {
     "dev runs Octane's own dev server with no cloud resources",
     (stack) =>
       Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+
         yield* stack.destroy();
 
         const rootDir = yield* cloneFixture(fixtureDir, {
@@ -75,6 +80,27 @@ describe("AWS.Website.Octane local", () => {
         yield* expectUrlContains(`${url}/api/hello?echo=dev`, "dev", {
           label: "API route query echo (dev)",
         });
+
+        // ── HMR: edit the page component in place. The stack is NOT
+        // re-applied — Octane's Vite dev server must hot-update the module
+        // and serve the new marker through the same URL ──────────────────
+        const appPath = path.join(rootDir, "src/App.tsx");
+        const app = yield* fs.readFileString(appPath);
+        yield* fs.writeFileString(
+          appPath,
+          app.replace("OCTANE_AWS_PAGE_MARKER", "OCTANE_AWS_PAGE_MARKER_V2"),
+        );
+        yield* expectUrlContains(`${url}/`, "OCTANE_AWS_PAGE_MARKER_V2", {
+          timeout: "90 seconds",
+          label: "SSR page after HMR edit",
+        });
+        // The API route (octane.config.ts server route) survived the
+        // client-module hot update.
+        yield* expectUrlContains(
+          `${url}/api/hello?echo=post-hmr`,
+          "OCTANE_AWS_API_MARKER",
+          { label: "API route after HMR edit" },
+        );
 
         yield* stack.destroy();
       }),

--- a/packages/alchemy/test/AWS/Website/StaticSite.local.test.ts
+++ b/packages/alchemy/test/AWS/Website/StaticSite.local.test.ts
@@ -101,6 +101,25 @@ describe("AWS.Website.StaticSite local", () => {
           },
         );
 
+        // ── Live edit: rewrite the content in place. The stack is NOT
+        // re-applied — the external dev server reads from disk per request,
+        // so the very next fetch must serve the new content ──────────────
+        const editedMarker = "aws-staticsite-dev-command-marker-v2";
+        yield* fs.writeFileString(
+          path.join(cwd, "site", "index.html"),
+          htmlPage(editedMarker),
+        );
+        yield* expectUrlContains(`${url}/`, editedMarker, {
+          timeout: "30 seconds",
+          label: "dev.command index after live edit",
+        });
+        // `dev.env` still reaches the (unchanged, long-lived) child.
+        yield* expectUrlContains(
+          `${url}/__dev-env`,
+          "aws-staticsite-dev-env-marker",
+          { label: "dev.command env passthrough after live edit" },
+        );
+
         yield* stack.destroy();
       }),
     { timeout: 300_000 },

--- a/packages/alchemy/test/AWS/Website/SvelteKit.local.test.ts
+++ b/packages/alchemy/test/AWS/Website/SvelteKit.local.test.ts
@@ -2,6 +2,8 @@ import * as AWS from "@/AWS";
 import * as Test from "@/Test/Alchemy";
 import { describe, expect } from "alchemy-test";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
 import * as pathe from "pathe";
 import { cloneFixture } from "../../Cloudflare/Utils/Fixture.ts";
 import { expectUrlContains } from "../../Cloudflare/Utils/Http.ts";
@@ -28,6 +30,9 @@ describe("AWS.Website.SvelteKit local", () => {
     "dev runs SvelteKit's own dev server with no cloud resources",
     (stack) =>
       Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+
         yield* stack.destroy();
 
         const rootDir = yield* cloneFixture(fixtureDir, {
@@ -68,6 +73,28 @@ describe("AWS.Website.SvelteKit local", () => {
         );
         yield* expectUrlContains(`${url}/api/hello?echo=dev`, "dev", {
           label: "API route query echo (dev)",
+        });
+
+        // ── HMR: edit the API route in place. The stack is NOT re-applied —
+        // the kit/vite dev rebuild must pick the change up and serve it
+        // through the same URL ───────────────────────────────────────────
+        const helloPath = path.join(rootDir, "src/routes/api/hello/+server.ts");
+        const hello = yield* fs.readFileString(helloPath);
+        yield* fs.writeFileString(
+          helloPath,
+          hello.replace(
+            "SVELTEKIT_AWS_API_MARKER",
+            "SVELTEKIT_AWS_API_MARKER_V2",
+          ),
+        );
+        yield* expectUrlContains(
+          `${url}/api/hello?echo=dev`,
+          "SVELTEKIT_AWS_API_MARKER_V2",
+          { timeout: "90 seconds", label: "API route after HMR edit" },
+        );
+        // The route still round-trips its query after the reload.
+        yield* expectUrlContains(`${url}/api/hello?echo=post-hmr`, "post-hmr", {
+          label: "API route query echo after HMR edit",
         });
 
         yield* stack.destroy();

--- a/packages/alchemy/test/AWS/Website/Waku.local.test.ts
+++ b/packages/alchemy/test/AWS/Website/Waku.local.test.ts
@@ -2,6 +2,8 @@ import * as AWS from "@/AWS";
 import * as Test from "@/Test/Alchemy";
 import { describe, expect } from "alchemy-test";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
 import * as pathe from "pathe";
 import { cloneFixture } from "../../Cloudflare/Utils/Fixture.ts";
 import { expectUrlContains } from "../../Cloudflare/Utils/Http.ts";
@@ -29,6 +31,9 @@ describe("AWS.Website.Waku local", () => {
     "dev runs Waku's own dev server with no cloud resources",
     (stack) =>
       Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+
         yield* stack.destroy();
 
         const rootDir = yield* cloneFixture(fixtureDir, {
@@ -71,6 +76,25 @@ describe("AWS.Website.Waku local", () => {
         );
         yield* expectUrlContains(`${url}/echo?echo=dev`, "dev", {
           label: "API route query echo (dev)",
+        });
+
+        // ── HMR: edit the API route in place. The stack is NOT re-applied —
+        // waku's vite dev rebuild must pick the change up and serve it
+        // through the same URL ───────────────────────────────────────────
+        const echoPath = path.join(rootDir, "src/pages/_api/echo.ts");
+        const echo = yield* fs.readFileString(echoPath);
+        yield* fs.writeFileString(
+          echoPath,
+          echo.replaceAll("WAKU_AWS_API_MARKER", "WAKU_AWS_API_MARKER_V2"),
+        );
+        yield* expectUrlContains(
+          `${url}/echo?echo=dev`,
+          "WAKU_AWS_API_MARKER_V2",
+          { timeout: "90 seconds", label: "API route after HMR edit" },
+        );
+        // The route still round-trips its query after the reload.
+        yield* expectUrlContains(`${url}/echo?echo=post-hmr`, "post-hmr", {
+          label: "API route query echo after HMR edit",
         });
 
         yield* stack.destroy();

--- a/scripts/test-examples.ts
+++ b/scripts/test-examples.ts
@@ -15,6 +15,7 @@ const examples = [
   "./examples/cloudflare-website-nuxt",
   "./examples/cloudflare-website-sveltekit",
   "./examples/cloudflare-website-waku",
+  "./examples/aws-dev",
   "./examples/aws-lambda",
   "./examples/aws-website-astro",
   "./examples/aws-website-nextjs",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -83,6 +83,9 @@
       "path": "./examples/aws-lambda-rpc/tsconfig.json"
     },
     {
+      "path": "./examples/aws-dev/tsconfig.json"
+    },
+    {
       "path": "./examples/aws-lambda/tsconfig.json"
     },
     {


### PR DESCRIPTION
Regression coverage for AWS local dev HMR, mirroring what `examples/cloudflare-dev` pins for Cloudflare.

### `examples/aws-dev` — the real CLI, end to end

```sh
cd examples/aws-dev
bun run dev   # zero AWS credentials required — everything runs in the local emulator
```

The suite spawns the actual `alchemy dev` binary (not the test harness) and drives every binding over HTTP:

```
api: "http://<id>.lambda-url.us-east-1.localhost:4566/"
```

- `GET /` → marker + `MY_VARIABLE` via `effect/Config`
- `GET /s3` → `PutObject`/`GetObject` roundtrip
- `GET /dynamo` → `PutItem`/`GetItem` roundtrip
- `POST /queue/send` → `SendMessage`; floci's event-source-mapping poller delivers to `consumeQueueMessages`, which records into the table read back by `/queue/messages`
- **hot reload**: rewrite `src/marker.ts` with the CLI still running — the same URL serves the new marker without a deploy; restoring it is a second reload

This is the code path `Test.make({ dev: true })` can't reach: CLI arg parsing, the `--watch` exec child, sidecar lifetimes (the #1007 bug class).

### Website HMR blocks in all 7 AWS local suites

Astro, Next.js, Nuxt, SvelteKit, Waku, Octane, StaticSite — each now edits its cloned fixture mid-session and polls the same URL until the dev server serves the change:

```ts
yield* fs.writeFileString(
  helloPath,
  hello.replace("NUXT_AWS_API_MARKER", "NUXT_AWS_API_MARKER_V2"),
);
yield* expectUrlContains(`${url}/api/hello?echo=dev`, "NUXT_AWS_API_MARKER_V2", {
  timeout: "90 seconds",
  label: "API route after HMR edit",
});
```

The stack is never re-applied — the framework's own dev rebuild must pick the edit up, and env passthrough / sibling routes are re-asserted after the reload.

### Fix: runtime bindings inside dev Lambdas targeted real AWS

The new suite immediately caught a real bug: alchemy's runtime bindings (`S3.GetObject`, `DynamoDB.PutItem`, …) executing *inside* a dev-mode Lambda container ignored the emulator and signed requests against `amazonaws.com`:

```
UnknownAwsError: The AWS Access Key Id you provided does not exist in our records.
```

distilled's endpoint resolution now honors the official SDKs' env override — `AWS_ENDPOINT_URL_<SERVICE>`, then `AWS_ENDPOINT_URL`, only when no `Endpoint` service is provided — so any code running inside an emulated runtime (Lambda and ECS) targets the emulator with zero wiring. Presigned S3 URLs honor the same override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
