### PR TITLE
chore: fix Cloudflare runtime package dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1596,7 +1596,7 @@
       "version": "2.0.0-beta.71",
       "dependencies": {
         "@alchemy.run/cloudflare-runtime": "workspace:*",
-        "@distilled.cloud/cloudflare": "catalog:",
+        "@distilled.cloud/cloudflare": "workspace:*",
         "@effect/platform-node": "catalog:effect",
         "esbuild": "catalog:cloudflare",
         "fast-glob": "catalog:cloudflare",
@@ -1653,6 +1653,7 @@
         "@alchemy.run/node-utils": "catalog:",
         "@cloudflare/unenv-preset": "catalog:workers",
         "@puppeteer/browsers": "catalog:cloudflare",
+        "capnp-es": "catalog:cloudflare",
         "magic-string": "catalog:cloudflare",
         "sharp": "catalog:cloudflare",
         "unenv": "catalog:workers",
@@ -1667,7 +1668,6 @@
         "@types/http-cache-semantics": "catalog:cloudflare",
         "@types/node": "catalog:",
         "@types/ws": "catalog:cloudflare",
-        "capnp-es": "catalog:cloudflare",
         "capnweb": "catalog:cloudflare",
         "heap-js": "catalog:cloudflare",
         "http-cache-semantics": "catalog:cloudflare",
@@ -1683,7 +1683,7 @@
         "ws": "catalog:cloudflare",
       },
       "peerDependencies": {
-        "@distilled.cloud/cloudflare": "catalog:",
+        "@distilled.cloud/cloudflare": "workspace:*",
         "@effect/platform-bun": "catalog:effect",
         "@effect/platform-node": "catalog:effect",
         "effect": "catalog:effect",

--- a/packages/cloudflare-frameworks/package.json
+++ b/packages/cloudflare-frameworks/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@alchemy.run/cloudflare-runtime": "workspace:*",
-    "@distilled.cloud/cloudflare": "catalog:",
+    "@distilled.cloud/cloudflare": "workspace:*",
     "@effect/platform-node": "catalog:effect",
     "esbuild": "catalog:cloudflare",
     "fast-glob": "catalog:cloudflare",

--- a/packages/cloudflare-runtime/package.json
+++ b/packages/cloudflare-runtime/package.json
@@ -45,6 +45,7 @@
     "@alchemy.run/node-utils": "catalog:",
     "@cloudflare/unenv-preset": "catalog:workers",
     "@puppeteer/browsers": "catalog:cloudflare",
+    "capnp-es": "catalog:cloudflare",
     "magic-string": "catalog:cloudflare",
     "sharp": "catalog:cloudflare",
     "unenv": "catalog:workers",
@@ -59,7 +60,6 @@
     "@types/http-cache-semantics": "catalog:cloudflare",
     "@types/node": "catalog:",
     "@types/ws": "catalog:cloudflare",
-    "capnp-es": "catalog:cloudflare",
     "capnweb": "catalog:cloudflare",
     "http-cache-semantics": "catalog:cloudflare",
     "heap-js": "catalog:cloudflare",
@@ -75,7 +75,7 @@
     "ws": "catalog:cloudflare"
   },
   "peerDependencies": {
-    "@distilled.cloud/cloudflare": "catalog:",
+    "@distilled.cloud/cloudflare": "workspace:*",
     "@effect/platform-bun": "catalog:effect",
     "@effect/platform-node": "catalog:effect",
     "effect": "catalog:effect",


### PR DESCRIPTION
## What broke

`@alchemy.run/cloudflare-runtime@2.0.0-beta.71` had two packaging problems:

1. Its Bun exports point directly at TypeScript source files that import `capnp-es` at runtime, but `capnp-es` was listed only in `devDependencies`. The compiled distribution inlines it, which hid the mismatch until a Bun consumer selected the source export.
2. `@distilled.cloud/cloudflare` was declared as `catalog:`. The current release action rewrites explicit `workspace:*` dependencies to concrete versions before packing, but it cannot see that this catalog entry maps to a workspace package. Bun resolves the catalog only during packing and emitted the peer as `workspace:*`, leaving an invalid protocol in beta.71.

## Fix

- Move `capnp-es` from `devDependencies` to production `dependencies`.
- Declare `@distilled.cloud/cloudflare` explicitly as `workspace:*` in both `@alchemy.run/cloudflare-runtime` and `@alchemy.run/cloudflare-frameworks`. This lets the existing release action recognize it before `bun pm pack` and replace it with the installed Distilled version.

The shared Actions release tooling should separately learn to resolve catalog-backed workspace dependencies and reject tarballs that retain `workspace:` or `catalog:` protocols. Until then, the explicit workspace declarations avoid the catalog blind spot.

## Verification

- `vp install`
- Cloudflare runtime, frameworks, and test-tools builds completed successfully.
- Confirmed the pinned release action iterates `dependencies`, `devDependencies`, `peerDependencies`, and `optionalDependencies`, rewriting explicit `workspace:*` values before invoking `bun pm pack`.
- Against this checkout, that logic resolves both Cloudflare package declarations from `workspace:*` to installed `@distilled.cloud/cloudflare@1.0.0-rc.4`.
- Previously inspected concrete manifests pack with `1.0.0-rc.4`, and the runtime tarball includes `capnp-es` in production dependencies.