### PR TITLE
feat(cloudflare): named state stores and monotonic version guard

### DIFF
--- a/packages/alchemy/src/Cloudflare/StateStore/Api.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/Api.ts
@@ -17,10 +17,11 @@ import {
 import { ReadSecret } from "../SecretsStore/ReadSecret.ts";
 import { ReadSecretBinding } from "../SecretsStore/ReadSecretBinding.ts";
 import { Worker } from "../Workers/Worker.ts";
+import { StateStoreWorkerName } from "./Names.ts";
 import Store from "./Store.ts";
 import { AuthToken } from "./Token.ts";
 
-export const STATE_STORE_SCRIPT_NAME = "alchemy-state-store" as const;
+export { STATE_STORE_SCRIPT_NAME } from "./Names.ts";
 
 /**
  * Version of the deployed Cloudflare State Store worker contract.
@@ -100,15 +101,22 @@ export const STATE_STORE_VERSION = 7 as const;
  */
 export default Worker(
   "Api",
-  {
-    name: STATE_STORE_SCRIPT_NAME,
-    main: import.meta.url,
-    workersDev: true,
-    compatibility: {
-      flags: ["nodejs_compat"],
-      date: "2026-03-17",
-    },
-  },
+  // Effect-valued props: the worker's physical name resolves from the
+  // `StateStoreWorkerName` reference so `Cloudflare.state({ workerName })`
+  // and `bootstrap({ workerName })` can deploy independent named stores.
+  // Un-provided (including inside the deployed bundle, where the name is
+  // irrelevant) it defaults to `alchemy-state-store`.
+  Effect.gen(function* () {
+    return {
+      name: yield* StateStoreWorkerName,
+      main: import.meta.url,
+      workersDev: true,
+      compatibility: {
+        flags: ["nodejs_compat"] as string[],
+        date: "2026-03-17",
+      },
+    };
+  }),
   Effect.gen(function* () {
     const remoteSecret = yield* ReadSecret(AuthToken);
     const store = yield* Store;

--- a/packages/alchemy/src/Cloudflare/StateStore/CredentialsFile.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/CredentialsFile.ts
@@ -13,6 +13,17 @@ import type { HttpStateStoreCredentials } from "../../State/HttpStateStore.ts";
 export const CREDENTIALS_FILE = "cloudflare-state-store";
 
 /**
+ * Per-store credentials cache file. The default store keeps the
+ * historical {@link CREDENTIALS_FILE} name; named stores (see
+ * `Cloudflare.state({ workerName })`) each get their own file so two
+ * stores never share a cached `{ url, authToken }` pair.
+ */
+export const stateStoreCredentialsFile = (workerName: string) =>
+  workerName === "alchemy-state-store"
+    ? CREDENTIALS_FILE
+    : `${CREDENTIALS_FILE}-${workerName}`;
+
+/**
  * On-disk shape of the cached Cloudflare state-store credentials.
  *
  * Extends the generic {@link HttpStateStoreCredentials} (`{ url, authToken }`)

--- a/packages/alchemy/src/Cloudflare/StateStore/Names.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/Names.ts
@@ -1,0 +1,57 @@
+import * as Context from "effect/Context";
+
+/**
+ * Default name of the state-store Worker deployed by
+ * `Cloudflare.state()` / `alchemy bootstrap cloudflare`.
+ */
+export const STATE_STORE_SCRIPT_NAME = "alchemy-state-store" as const;
+
+/**
+ * The physical name of the state-store Worker for the current
+ * deploy, as a `Context.Reference` so it can flow from
+ * `Cloudflare.state({ workerName })` (or `bootstrap({ workerName })`)
+ * into the state-store stack — the Worker resource in `Api.ts` and
+ * the Secrets Store secrets in `Token.ts` — without those modules
+ * taking constructor parameters (their default exports must stay
+ * statically analyzable for the worker bundler).
+ *
+ * The default keeps every un-parameterized consumer (including the
+ * re-evaluated module inside the deployed worker bundle, where the
+ * name is irrelevant) on the historical `alchemy-state-store`
+ * identity.
+ */
+export const StateStoreWorkerName = Context.Reference<string>(
+  "Alchemy/Cloudflare/StateStoreWorkerName",
+  { defaultValue: () => STATE_STORE_SCRIPT_NAME },
+);
+
+/**
+ * Cloudflare Secrets Store secret names only allow `[A-Za-z0-9_]`.
+ * Worker names allow dashes, so fold anything else to `_` when a
+ * worker name is embedded in a secret name.
+ */
+const sanitizeSecretName = (name: string) =>
+  name.replace(/[^A-Za-z0-9_]/g, "_");
+
+/**
+ * Per-store name of the bearer-token secret in the account Secrets
+ * Store. The default store keeps the historical un-suffixed name so
+ * existing deployments keep resolving their secret; named stores get
+ * a suffixed name so each store has its own credential authority —
+ * one store's bearer token must never authenticate against another.
+ */
+export const authTokenSecretName = (workerName: string) =>
+  workerName === STATE_STORE_SCRIPT_NAME
+    ? "AlchemyStateStoreToken"
+    : `AlchemyStateStoreToken_${sanitizeSecretName(workerName)}`;
+
+/**
+ * Per-store name of the state-encryption-key secret. Same suffixing
+ * rule as {@link authTokenSecretName}: each store encrypts its state
+ * with its own key, so credentials for one store cannot decrypt
+ * another store's state.
+ */
+export const encryptionKeySecretName = (workerName: string) =>
+  workerName === STATE_STORE_SCRIPT_NAME
+    ? "AlchemyStateStoreEncryptionKey"
+    : `AlchemyStateStoreEncryptionKey_${sanitizeSecretName(workerName)}`;

--- a/packages/alchemy/src/Cloudflare/StateStore/State.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/State.ts
@@ -39,27 +39,113 @@ import * as Clank from "../../Util/Clank.ts";
 import * as Access from "../Access.ts";
 import * as CloudflareEnvironment from "../CloudflareEnvironment.ts";
 import { EdgeSessionError, createEdgeSession } from "../EdgeSession.ts";
-import Api, { STATE_STORE_SCRIPT_NAME, STATE_STORE_VERSION } from "./Api.ts";
+import Api, { STATE_STORE_VERSION } from "./Api.ts";
 import {
-  CREDENTIALS_FILE,
   type StoredStateStoreCredentials,
   isStateStoreCredentialsStale,
+  stateStoreCredentialsFile,
 } from "./CredentialsFile.ts";
 import {
-  AuthToken,
-  AuthTokenSecretName,
-  EncryptionKeySecretName,
-  TokenValue,
-} from "./Token.ts";
+  STATE_STORE_SCRIPT_NAME,
+  StateStoreWorkerName,
+  authTokenSecretName,
+  encryptionKeySecretName,
+} from "./Names.ts";
+import { AuthToken, TokenValue } from "./Token.ts";
 
 const CI = Config.boolean("CI").pipe(Config.withDefault(false));
 
-export const state = () =>
+export interface StateStoreOptions {
+  /**
+   * Physical name of the state-store Worker. Defaults to the shared
+   * account-wide `alchemy-state-store`. Pass a distinct name to
+   * deploy and attach to a dedicated store — its Worker, Durable
+   * Object state, bearer-token secret, encryption-key secret, and
+   * cached credentials are all keyed by this name, so two stores on
+   * one account never share credential authority or upgrade lockstep.
+   *
+   * @default "alchemy-state-store"
+   */
+  workerName?: string;
+}
+
+/**
+ * The state store deployed by a newer alchemy CLI than this one. This
+ * client must never downgrade shared state infrastructure — not even
+ * with `--yes` — so `state()` fails closed. Upgrade this project's
+ * `alchemy` dependency, or point it at a dedicated store via
+ * `Cloudflare.state({ workerName })`.
+ */
+export class StateStoreClientTooOldError extends Error {
+  readonly _tag = "StateStoreClientTooOldError";
+  constructor(
+    readonly scriptName: string,
+    readonly expected: number,
+    readonly observed: number,
+  ) {
+    super(
+      `Cloudflare State Store '${scriptName}' was deployed by a newer version of alchemy ` +
+        `(store contract v${observed}, this client expects v${expected}). ` +
+        `Refusing to downgrade shared state infrastructure. ` +
+        `Upgrade this project's 'alchemy' dependency, or isolate it with ` +
+        `Cloudflare.state({ workerName: "..." }).`,
+    );
+  }
+}
+
+/**
+ * How the deployed store's contract version relates to this client's:
+ *
+ * - `match` — attach as-is.
+ * - `missing` — no functioning store; deploy it.
+ * - `store-older` — the store is older and compatible to upgrade; the
+ *   client may upgrade it (with confirmation or `--yes`).
+ * - `store-newer` — the store was deployed by a newer client; this
+ *   client must fail closed before mutating anything. `--yes` cannot
+ *   override this; only an explicit `bootstrap --force` can downgrade.
+ *
+ * @internal exported for unit testing.
+ */
+export type StoreVersionStatus =
+  | "match"
+  | "missing"
+  | "store-older"
+  | "store-newer";
+
+/** @internal exported for unit testing. */
+export const classifyStoreVersion = (
+  expected: number,
+  observed: number | undefined,
+): StoreVersionStatus =>
+  observed === undefined
+    ? "missing"
+    : observed === expected
+      ? "match"
+      : observed < expected
+        ? "store-older"
+        : "store-newer";
+
+/**
+ * Cloudflare-backed state store Layer.
+ *
+ * With no options, attaches to (bootstrapping if needed) the shared
+ * account-wide `alchemy-state-store` Worker. Pass `workerName` to use a
+ * dedicated store — its Worker, Durable Object state, secrets, and cached
+ * credentials are all independent of the default store, so separate
+ * projects can upgrade their alchemy dependency (and therefore their
+ * state-store contract version) independently:
+ *
+ * ```typescript
+ * state: Cloudflare.state({ workerName: "alchemy-state-store-team-a" }),
+ * ```
+ */
+export const state = (options: StateStoreOptions = {}) =>
   Layer.effect(
     State,
     Effect.gen(function* () {
       const isCI = yield* CI;
-      const scriptName = STATE_STORE_SCRIPT_NAME;
+      const scriptName = options.workerName ?? STATE_STORE_SCRIPT_NAME;
+      const credentialsFile = stateStoreCredentialsFile(scriptName);
       const profileName = yield* ALCHEMY_PROFILE;
       const localStage = `${profileName}_${scriptName}`;
       const credStore = yield* CredentialsStore;
@@ -91,10 +177,13 @@ export const state = () =>
           authToken: string;
         }) =>
           Effect.gen(function* () {
-            const { matches, expected, observed } =
-              yield* checkStateStoreVersion(url);
+            const { expected, observed } = yield* checkStateStoreVersion(
+              url,
+              scriptName,
+            );
+            const status = classifyStoreVersion(expected, observed);
 
-            if (observed === undefined) {
+            if (status === "missing") {
               const shouldDeploy =
                 autoUpdateStateStore ||
                 (yield* Clank.confirm({
@@ -110,19 +199,32 @@ export const state = () =>
               }
             }
 
+            if (status === "store-newer") {
+              // Fail closed BEFORE touching credentials or prompting:
+              // an older client must never downgrade a newer store,
+              // and `--yes` cannot authorize it (#1194).
+              return yield* Effect.die(
+                new StateStoreClientTooOldError(
+                  scriptName,
+                  expected,
+                  observed!,
+                ),
+              );
+            }
+
             const httpState = yield* ensureAccess({ url, authToken });
-            if (matches) {
+            if (status === "match") {
               return httpState;
             }
 
-            // The store is out of date. Upgrade it in place.
+            // The store is older than this client. Upgrade it in place.
             const upgrade = Effect.gen(function* () {
               yield* Clank.info(
                 `Cloudflare State Store '${scriptName}' is out of date ` +
                   `(expected v${expected}, observed v${observed ?? "unknown"}); upgrading...`,
               );
               const stateStoreOptions = yield* deployStateStore({
-                stage: scriptName,
+                scriptName,
                 state: httpState,
                 force: false,
               });
@@ -163,7 +265,11 @@ export const state = () =>
               yield* Clank.info(
                 `Cloudflare State store authentication failed, refreshing credentials...`,
               );
-              const credentials = yield* loginWithCloudflare(profileName, true);
+              const credentials = yield* loginWithCloudflare(
+                profileName,
+                true,
+                scriptName,
+              );
               if (!(yield* checkHttpStateStoreAuth(credentials))) {
                 return yield* Effect.die(
                   new AuthError({
@@ -181,7 +287,7 @@ export const state = () =>
 
         const credentials = yield* credStore.read<StoredStateStoreCredentials>(
           profileName,
-          CREDENTIALS_FILE,
+          credentialsFile,
         );
         if (credentials) {
           // The cached `url`/`authToken` are minted per-account (the `url`
@@ -196,19 +302,22 @@ export const state = () =>
                 `Cloudflare account; re-deriving for the current account.`,
             );
             yield* credStore
-              .delete(profileName, CREDENTIALS_FILE)
+              .delete(profileName, credentialsFile)
               .pipe(Effect.ignore);
           } else {
             return yield* ensureLatest(credentials);
           }
         }
-        if (yield* isStateStoreServing(accountId)) {
+        if (yield* isStateStoreServing(accountId, scriptName)) {
           return yield* ensureLatest(
-            yield* loginWithCloudflare(profileName, false),
+            yield* loginWithCloudflare(profileName, false, scriptName),
           );
         } else if (autoUpdateStateStore) {
           // `--yes`: deploy the missing state store automatically (also in CI).
-          return yield* bootstrap();
+          return yield* bootstrap({
+            workerName: scriptName,
+            profile: profileName,
+          });
         } else if (isCI) {
           return yield* Effect.die(
             new AuthError({
@@ -217,12 +326,11 @@ export const state = () =>
           );
         } else {
           return yield* Clank.confirm({
-            message:
-              "Cloudflare State Store not found. Do you want to deploy it?",
+            message: `Cloudflare State Store '${scriptName}' not found. Do you want to deploy it?`,
           }).pipe(
             Effect.flatMap((shouldDeploy) =>
               shouldDeploy
-                ? bootstrap()
+                ? bootstrap({ workerName: scriptName, profile: profileName })
                 : Effect.die(new Clank.PromptCancelled()),
             ),
           );
@@ -286,7 +394,7 @@ export const bootstrap = (options: BootstrapOptions = {}) =>
     }
     const { accountId } =
       yield* yield* CloudflareEnvironment.CloudflareEnvironment;
-    if (yield* isStateStoreServing(accountId)) {
+    if (yield* isStateStoreServing(accountId, scriptName)) {
       // this is a regular update, let's check if it needs an update and refresh credentials
       if (!force) {
         yield* Clank.info(
@@ -298,6 +406,7 @@ export const bootstrap = (options: BootstrapOptions = {}) =>
         profileName,
         // force refresh during
         true,
+        scriptName,
       );
       const { url, authToken } = credentials;
       if (!isCI) {
@@ -305,15 +414,32 @@ export const bootstrap = (options: BootstrapOptions = {}) =>
         const store = yield* CredentialsStore;
         yield* store.write<StoredStateStoreCredentials>(
           profileName,
-          CREDENTIALS_FILE,
+          stateStoreCredentialsFile(scriptName),
           credentials,
         );
       }
-      const { matches, expected, observed } =
-        yield* checkStateStoreVersion(url);
+      const { expected, observed } = yield* checkStateStoreVersion(
+        url,
+        scriptName,
+      );
+      const status = classifyStoreVersion(expected, observed);
+      if (status === "store-newer" && !force) {
+        // Downgrading shared state infrastructure requires the explicit
+        // operator command (`alchemy bootstrap cloudflare --force`);
+        // an ordinary bootstrap of an older client fails closed (#1194).
+        return yield* Effect.die(
+          new StateStoreClientTooOldError(scriptName, expected, observed!),
+        );
+      }
       const httpState = yield* makeCloudflareStateStore({ url, authToken });
-      if (!matches || force) {
-        if (matches && force) {
+      if (status !== "match" || force) {
+        if (status === "store-newer") {
+          yield* Clank.info(
+            `Cloudflare State Store '${scriptName}' was deployed by a newer ` +
+              `client (store v${observed}, this client v${expected}); ` +
+              `--force DOWNGRADES it to v${expected}.`,
+          );
+        } else if (status === "match" && force) {
           yield* Clank.info(
             `Cloudflare State Store '${scriptName}' is up to date; force redeploying...`,
           );
@@ -325,7 +451,7 @@ export const bootstrap = (options: BootstrapOptions = {}) =>
         }
         return yield* makeCloudflareStateStore(
           yield* deployStateStore({
-            stage: scriptName,
+            scriptName,
             state: httpState,
             force,
           }),
@@ -405,9 +531,11 @@ export const teardownStateStore = (options: TeardownOptions = {}) =>
     );
 
     // 2. Delete the secrets the state store created, plus any now-empty store.
+    // Secret names are per-store (suffixed with the worker name for named
+    // stores), so tearing down one store never deletes another's secrets.
     const ourSecretNames = new Set<string>([
-      AuthTokenSecretName,
-      EncryptionKeySecretName,
+      authTokenSecretName(scriptName),
+      encryptionKeySecretName(scriptName),
     ]);
     const stores = yield* SecretsStore.listStores.items({ accountId }).pipe(
       Stream.runCollect,
@@ -463,7 +591,9 @@ export const teardownStateStore = (options: TeardownOptions = {}) =>
 
     // 3. Drop the locally cached state-store credentials for this profile.
     const credStore = yield* CredentialsStore;
-    yield* credStore.delete(profileName, CREDENTIALS_FILE).pipe(Effect.ignore);
+    yield* credStore
+      .delete(profileName, stateStoreCredentialsFile(scriptName))
+      .pipe(Effect.ignore);
 
     yield* Clank.success(`Cloudflare State Store '${scriptName}' torn down.`);
   }).pipe(
@@ -477,11 +607,15 @@ export const teardownStateStore = (options: TeardownOptions = {}) =>
   );
 
 const deployStateStore = ({
-  stage,
+  scriptName,
+  stage = scriptName,
   state,
   force,
 }: {
-  stage: string;
+  /** Physical name of the state-store Worker (and its secrets). */
+  scriptName: string;
+  /** Stack stage; defaults to the script name. */
+  stage?: string;
   state: StateService;
   force?: boolean;
 }) =>
@@ -511,7 +645,11 @@ const deployStateStore = ({
             url: api.url.as<string>(),
             authToken: token.text.pipe(Output.map(Redacted.value)),
           };
-        }),
+        }).pipe(
+          // Resolve the Worker's physical name (and the per-store secret
+          // names in Token.ts) from the configured store identity.
+          Effect.provideService(StateStoreWorkerName, scriptName),
+        ),
       ),
     }).pipe(
       // The Cloudflare State Store is account-level infrastructure that
@@ -524,7 +662,7 @@ const deployStateStore = ({
       Effect.provide(stateLayer),
     );
 
-    yield* writeCredentials(url, authToken);
+    yield* writeCredentials(url, authToken, scriptName);
 
     // Cloudflare's worker upload is eventually consistent: the deploy
     // call returns as soon as the script upload is accepted, but the
@@ -535,7 +673,7 @@ const deployStateStore = ({
     // adoption) end up talking to the old worker and may either
     // observe stale data or trip the staleness check and recurse into
     // another redeploy.
-    yield* waitForStateStoreVersion(url);
+    yield* waitForStateStoreVersion(url, scriptName);
     return { url, authToken };
   }).pipe(
     Effect.withSpan("state_store.deploy", {
@@ -562,12 +700,13 @@ const deployWithLocalState = ({
     const localStage = `${profileName}_${scriptName}`;
     const remoteStage = scriptName;
     const { authToken } = yield* deployStateStore({
+      scriptName,
       stage: localStage,
       state: localState,
       force,
     });
 
-    const { url } = yield* loginWithCloudflare(profileName, force);
+    const { url } = yield* loginWithCloudflare(profileName, force, scriptName);
     const httpState = yield* makeCloudflareStateStore({ url, authToken });
 
     yield* hoistBootstrapStack({
@@ -716,10 +855,15 @@ const hoistBootstrapStack = Effect.fn(function* ({
  * `CloudflareEnvironment`, `Credentials`, `HttpClient`, and
  * `FileSystem`.
  */
-export const loginWithCloudflare = (profileName: string, force: boolean) =>
+export const loginWithCloudflare = (
+  profileName: string,
+  force: boolean,
+  scriptName: string = STATE_STORE_SCRIPT_NAME,
+) =>
   Effect.gen(function* () {
     const credStore = yield* CredentialsStore;
     const isCI = yield* CI;
+    const credentialsFile = stateStoreCredentialsFile(scriptName);
     const { accountId } =
       yield* yield* CloudflareEnvironment.CloudflareEnvironment;
 
@@ -727,7 +871,7 @@ export const loginWithCloudflare = (profileName: string, force: boolean) =>
       // try and read from the cached credentials first if not forcing (force will always refresh)
       const credentials = yield* credStore.read<StoredStateStoreCredentials>(
         profileName,
-        CREDENTIALS_FILE,
+        credentialsFile,
       );
       // Ignore a cache minted for a different account (or a legacy file with
       // no `accountId`) — reusing it would hand back the wrong account's
@@ -755,9 +899,9 @@ export const loginWithCloudflare = (profileName: string, force: boolean) =>
 
     // 2. Fetch the auth-token from Secrets Store with a temporary edge-preview worker
     const authToken = yield* readSecretViaEdge(
-      STATE_STORE_SCRIPT_NAME,
+      scriptName,
       store.id,
-      AuthTokenSecretName,
+      authTokenSecretName(scriptName),
     ).pipe(
       Effect.retry({
         while: (error) =>
@@ -777,13 +921,13 @@ export const loginWithCloudflare = (profileName: string, force: boolean) =>
 
     // 3. Derive the deployed worker URL.
     const { subdomain } = yield* workers.getSubdomain({ accountId });
-    const url = `https://${STATE_STORE_SCRIPT_NAME}.${subdomain}.workers.dev`;
+    const url = `https://${scriptName}.${subdomain}.workers.dev`;
 
     if (!isCI) {
       // 4. Persist credentials. The profile entry is managed by
       //    `loadOrConfigure` when this is invoked through `configure`.
       yield* credStore
-        .write<StoredStateStoreCredentials>(profileName, CREDENTIALS_FILE, {
+        .write<StoredStateStoreCredentials>(profileName, credentialsFile, {
           url,
           authToken: authToken.trim(),
           accountId,
@@ -821,12 +965,12 @@ export const loginWithCloudflare = (profileName: string, force: boolean) =>
     Effect.withSpan("state_store.login", {
       attributes: {
         "alchemy.state_store.op": "login",
-        "alchemy.state_store.script_name": STATE_STORE_SCRIPT_NAME,
+        "alchemy.state_store.script_name": scriptName,
       },
     }),
   );
 
-const isStateStoreAvailable = (scriptName: string = "alchemy-state-store") =>
+const isStateStoreAvailable = (scriptName: string) =>
   Effect.gen(function* () {
     // otherwise, the remote one might exist
     const { accountId } =
@@ -847,18 +991,18 @@ const isStateStoreAvailable = (scriptName: string = "alchemy-state-store") =>
  * verified by checking the /version endpoint
  *
  */
-const isStateStoreServing = (accountId: string) =>
+const isStateStoreServing = (accountId: string, scriptName: string) =>
   Effect.gen(function* () {
     const url = yield* workers.getSubdomain({ accountId }).pipe(
       Effect.map(({ subdomain }) =>
         subdomain
-          ? `https://${STATE_STORE_SCRIPT_NAME}.${subdomain}.workers.dev`
+          ? `https://${scriptName}.${subdomain}.workers.dev`
           : undefined,
       ),
       Effect.catch(() => Effect.succeed(undefined)),
     );
     if (url === undefined) return false;
-    const { observed } = yield* checkStateStoreVersion(url);
+    const { observed } = yield* checkStateStoreVersion(url, scriptName);
     return observed !== undefined;
   });
 
@@ -891,9 +1035,12 @@ class StateStoreVersionNotReady extends Error {
   }
 }
 
-const waitForStateStoreVersion = (url: string) =>
+const waitForStateStoreVersion = (url: string, scriptName: string) =>
   Effect.gen(function* () {
-    const { matches, expected, observed } = yield* checkStateStoreVersion(url);
+    const { matches, expected, observed } = yield* checkStateStoreVersion(
+      url,
+      scriptName,
+    );
     if (!matches) {
       return yield* Effect.fail(
         new StateStoreVersionNotReady(expected, observed),
@@ -919,12 +1066,10 @@ const waitForStateStoreVersion = (url: string) =>
     }),
   );
 
-const checkStateStoreVersion = (url: string) =>
+const checkStateStoreVersion = (url: string, scriptName: string) =>
   Effect.gen(function* () {
     const client = yield* HttpApiClient.make(StateApi, { baseUrl: url });
-    const isAvailable = yield* Effect.cached(
-      isStateStoreAvailable(STATE_STORE_SCRIPT_NAME),
-    );
+    const isAvailable = yield* Effect.cached(isStateStoreAvailable(scriptName));
     // The /version route may 404 transiently after a fresh deploy
     // while Cloudflare propagates the new script to the edge, and may
     // also surface transport-level blips on cold workers.dev hosts.
@@ -1054,7 +1199,7 @@ const readSecretViaEdge = (
     }),
   );
 
-const writeCredentials = (url: string, authToken: string) =>
+const writeCredentials = (url: string, authToken: string, scriptName: string) =>
   Effect.gen(function* () {
     const profileName = yield* ALCHEMY_PROFILE;
     const credStore = yield* CredentialsStore;
@@ -1062,7 +1207,7 @@ const writeCredentials = (url: string, authToken: string) =>
       yield* yield* CloudflareEnvironment.CloudflareEnvironment;
     yield* credStore.write<StoredStateStoreCredentials>(
       profileName,
-      CREDENTIALS_FILE,
+      stateStoreCredentialsFile(scriptName),
       {
         url,
         authToken,

--- a/packages/alchemy/src/Cloudflare/StateStore/Token.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/Token.ts
@@ -1,7 +1,12 @@
-import { Random } from "../../Random.ts";
 import * as Effect from "effect/Effect";
+import { Random } from "../../Random.ts";
 import * as Secret from "../SecretsStore/Secret.ts";
 import { Store as SecretsStore } from "../SecretsStore/SecretsStore.ts";
+import {
+  StateStoreWorkerName,
+  authTokenSecretName,
+  encryptionKeySecretName,
+} from "./Names.ts";
 
 /**
  * The account-wide Secrets Store that backs every secret used by the
@@ -18,7 +23,10 @@ export const Store = SecretsStore("StateStoreSecrets");
 export const TokenValue = Random("StateStoreAuthTokenValue");
 
 /**
- * The name of the secret in the Cloudflare Secrets Store that contains the bearer token.
+ * The name of the secret in the Cloudflare Secrets Store that contains the
+ * bearer token for the *default* state store. Named stores
+ * (`Cloudflare.state({ workerName })`) suffix this with the worker name —
+ * see {@link authTokenSecretName}.
  */
 export const AuthTokenSecretName = "AlchemyStateStoreToken" as const;
 
@@ -27,12 +35,17 @@ export const AuthTokenSecretName = "AlchemyStateStoreToken" as const;
  * store worker. The value comes from {@link TokenValue} and lives in
  * the account-wide Cloudflare Secrets Store so it can be bound into
  * the worker without bundling the raw string.
+ *
+ * The secret's *name* is derived from {@link StateStoreWorkerName} so
+ * each named state store owns its own bearer token; the logical id
+ * stays fixed (the worker reads the binding by logical id).
  */
 export const AuthToken = Effect.gen(function* () {
   const store = yield* Store;
   const random = yield* TokenValue;
+  const workerName = yield* StateStoreWorkerName;
   return yield* Secret.Secret(AuthTokenSecretName, {
-    name: AuthTokenSecretName,
+    name: authTokenSecretName(workerName),
     store,
     value: random.text,
   });
@@ -48,6 +61,11 @@ export const EncryptionKeyValue = Random("StateStoreEncryptionKeyValue", {
   bytes: 32,
 });
 
+/**
+ * The name of the encryption-key secret for the *default* state store.
+ * Named stores suffix this with the worker name — see
+ * {@link encryptionKeySecretName}.
+ */
 export const EncryptionKeySecretName =
   "AlchemyStateStoreEncryptionKey" as const;
 
@@ -56,12 +74,17 @@ export const EncryptionKeySecretName =
  * Cloudflare's Secrets Store; the Durable Object binds to it at
  * runtime to derive an AES-CTR `CryptoKey` via Web Crypto's
  * `subtle.importKey`.
+ *
+ * Like {@link AuthToken}, the secret name is per-store while the
+ * logical id stays fixed, so each named store encrypts its state with
+ * its own key.
  */
 export const EncryptionKey = Effect.gen(function* () {
   const store = yield* Store;
   const random = yield* EncryptionKeyValue;
+  const workerName = yield* StateStoreWorkerName;
   return yield* Secret.Secret("StateStoreEncryptionKey", {
-    name: EncryptionKeySecretName,
+    name: encryptionKeySecretName(workerName),
     store,
     value: random.text,
   });

--- a/packages/alchemy/src/Cloudflare/StateStore/index.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/index.ts
@@ -1,1 +1,12 @@
-export { bootstrap, state, type BootstrapOptions } from "./State.ts";
+export { StateStoreWorkerName, STATE_STORE_SCRIPT_NAME } from "./Names.ts";
+export {
+  bootstrap,
+  classifyStoreVersion,
+  state,
+  StateStoreClientTooOldError,
+  teardownStateStore,
+  type BootstrapOptions,
+  type StateStoreOptions,
+  type StoreVersionStatus,
+  type TeardownOptions,
+} from "./State.ts";

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -2210,14 +2210,17 @@ export const Worker: ResourceClassLike<Worker> &
         | WorkerServices
         | Container.Application<any>
         | PlatformServices,
+      PropsReq = never,
     >(
       id: string,
-      props: InputProps<WorkerProps>,
+      props:
+        | InputProps<WorkerProps>
+        | Effect.Effect<InputProps<WorkerProps>, ConfigError, PropsReq>,
       impl: Effect.Effect<Shape, ConfigError, Req>,
     ): Effect.Effect<
       Worker & Rpc<Shape>,
       never,
-      Extract<Req, Container.Application<any>> | Providers
+      Extract<Req, Container.Application<any>> | Providers | PropsReq
     > &
       Named<Id>;
     /**

--- a/packages/alchemy/test/Cloudflare/StateStore/NamedStore.test.ts
+++ b/packages/alchemy/test/Cloudflare/StateStore/NamedStore.test.ts
@@ -1,0 +1,153 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as CloudflareEnvironment from "@/Cloudflare/CloudflareEnvironment.ts";
+import {
+  authTokenSecretName,
+  encryptionKeySecretName,
+} from "@/Cloudflare/StateStore/Names.ts";
+import * as Test from "@/Test/Alchemy";
+import * as SecretsStore from "@distilled.cloud/cloudflare/secrets-store";
+import * as workers from "@distilled.cloud/cloudflare/workers";
+import { describe, expect } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Stream from "effect/Stream";
+
+/**
+ * Live coexistence coverage for named state stores (#912): a
+ * `workerName`-selected store must have its own Worker, Durable Object
+ * state, bearer-token secret, and encryption-key secret — and neither
+ * the named store's bootstrap/teardown nor the default store's
+ * bootstrap may touch the other.
+ *
+ * The tests are one sequence: bootstrap the named store, prove the
+ * stores don't see each other's state, then tear the named store down
+ * and prove the default store survived.
+ */
+
+const NAMED = "alchemy-state-store-e2e";
+const STACK = "NamedStoreE2E";
+const STAGE = "e2e";
+const FQN = "NamedStoreE2E/scope/resource-a";
+
+const { test } = Test.make({
+  providers: Cloudflare.providers(),
+});
+
+const sampleState = {
+  kind: "resource" as const,
+  resourceType: "Test.Resource",
+  namespace: undefined,
+  fqn: FQN,
+  logicalId: "resource-a",
+  instanceId: "inst-a",
+  providerVersion: 1,
+  status: "created" as const,
+  downstream: [],
+  bindings: [],
+  props: { hello: "named-store" },
+  attr: { id: "inst-a" },
+};
+
+const accountId = Effect.gen(function* () {
+  const { accountId } =
+    yield* yield* CloudflareEnvironment.CloudflareEnvironment;
+  return accountId;
+});
+
+const scriptExists = (scriptName: string) =>
+  Effect.gen(function* () {
+    const account = yield* accountId;
+    return yield* workers
+      .getScriptSetting({ accountId: account, scriptName })
+      .pipe(
+        Effect.map(() => true),
+        Effect.catchTag(["WorkerNotFound", "InvalidRoute"], () =>
+          Effect.succeed(false),
+        ),
+      );
+  });
+
+const listSecretNames = Effect.gen(function* () {
+  const account = yield* accountId;
+  const store = yield* SecretsStore.listStores
+    .items({ accountId: account })
+    .pipe(Stream.runHead, Effect.map(Option.getOrUndefined));
+  if (!store) return [];
+  return yield* SecretsStore.listStoreSecrets
+    .items({ accountId: account, storeId: store.id })
+    .pipe(
+      Stream.runCollect,
+      Effect.map((chunk) => Array.from(chunk).map((s) => s.name)),
+    );
+});
+
+describe.sequential("NamedStore", () => {
+  test.provider.skipIf(!!process.env.FAST)(
+    "bootstrap({ workerName }) deploys a dedicated store and serves state",
+    () =>
+      Effect.gen(function* () {
+        const named = yield* Cloudflare.bootstrap({ workerName: NAMED });
+
+        // The named store serves its own state roundtrip.
+        yield* named.deleteStack({ stack: STACK });
+        yield* named.set({
+          stack: STACK,
+          stage: STAGE,
+          fqn: FQN,
+          value: sampleState,
+        });
+        const got = yield* named.get({ stack: STACK, stage: STAGE, fqn: FQN });
+        expect(got).toBeDefined();
+        expect((got as any).props).toEqual({ hello: "named-store" });
+
+        // Out-of-band: the named store is its own physical Worker, and its
+        // secrets are per-store (suffixed) names in the account Secrets Store.
+        expect(yield* scriptExists(NAMED)).toBe(true);
+        const secretNames = yield* listSecretNames;
+        expect(secretNames).toContain(authTokenSecretName(NAMED));
+        expect(secretNames).toContain(encryptionKeySecretName(NAMED));
+      }),
+    { timeout: 420_000 },
+  );
+
+  test.provider.skipIf(!!process.env.FAST)(
+    "the default store and the named store cannot see each other's state",
+    () =>
+      Effect.gen(function* () {
+        // Attaching to the default store (bootstrap without a name adopts the
+        // existing deployment) must not surface the named store's stack...
+        const def = yield* Cloudflare.bootstrap({});
+        const fqns = yield* def.list({ stack: STACK, stage: STAGE });
+        expect(fqns).not.toContain(FQN);
+
+        // ...and must not have redeployed or mutated the named store: its
+        // Worker still exists and still serves the state written above.
+        expect(yield* scriptExists(NAMED)).toBe(true);
+        const named = yield* Cloudflare.bootstrap({ workerName: NAMED });
+        const got = yield* named.get({ stack: STACK, stage: STAGE, fqn: FQN });
+        expect(got).toBeDefined();
+        expect((got as any).props).toEqual({ hello: "named-store" });
+      }),
+    { timeout: 300_000 },
+  );
+
+  test.provider.skipIf(!!process.env.FAST)(
+    "teardown of the named store leaves the default store untouched",
+    () =>
+      Effect.gen(function* () {
+        yield* Cloudflare.teardownStateStore({ workerName: NAMED });
+
+        // The named store's Worker and secrets are gone...
+        expect(yield* scriptExists(NAMED)).toBe(false);
+        const secretNames = yield* listSecretNames;
+        expect(secretNames).not.toContain(authTokenSecretName(NAMED));
+        expect(secretNames).not.toContain(encryptionKeySecretName(NAMED));
+
+        // ...while the default store's Worker and secrets survive.
+        expect(yield* scriptExists("alchemy-state-store")).toBe(true);
+        expect(secretNames).toContain("AlchemyStateStoreToken");
+        expect(secretNames).toContain("AlchemyStateStoreEncryptionKey");
+      }),
+    { timeout: 180_000 },
+  );
+});

--- a/packages/alchemy/test/Cloudflare/StateStore/Names.test.ts
+++ b/packages/alchemy/test/Cloudflare/StateStore/Names.test.ts
@@ -1,0 +1,70 @@
+import { stateStoreCredentialsFile } from "@/Cloudflare/StateStore/CredentialsFile.ts";
+import {
+  STATE_STORE_SCRIPT_NAME,
+  authTokenSecretName,
+  encryptionKeySecretName,
+} from "@/Cloudflare/StateStore/Names.ts";
+import { classifyStoreVersion } from "@/Cloudflare/StateStore/State.ts";
+import { describe, expect, it } from "alchemy-test";
+
+/**
+ * Pure coverage for the per-store identity derivation (#912) and the
+ * monotonic version classification (#1194). No cloud access.
+ */
+
+describe("classifyStoreVersion", () => {
+  it("matches when the deployed store equals the client contract", () => {
+    expect(classifyStoreVersion(7, 7)).toBe("match");
+  });
+
+  it("is missing when no version could be observed", () => {
+    expect(classifyStoreVersion(7, undefined)).toBe("missing");
+  });
+
+  it("is store-older when the deployed store predates the client (upgradable)", () => {
+    expect(classifyStoreVersion(7, 5)).toBe("store-older");
+    expect(classifyStoreVersion(7, 6)).toBe("store-older");
+  });
+
+  it("is store-newer when the deployed store postdates the client (fail closed)", () => {
+    expect(classifyStoreVersion(5, 7)).toBe("store-newer");
+    expect(classifyStoreVersion(7, 8)).toBe("store-newer");
+  });
+});
+
+describe("per-store identities", () => {
+  it("the default store keeps its historical identities", () => {
+    expect(authTokenSecretName(STATE_STORE_SCRIPT_NAME)).toBe(
+      "AlchemyStateStoreToken",
+    );
+    expect(encryptionKeySecretName(STATE_STORE_SCRIPT_NAME)).toBe(
+      "AlchemyStateStoreEncryptionKey",
+    );
+    expect(stateStoreCredentialsFile(STATE_STORE_SCRIPT_NAME)).toBe(
+      "cloudflare-state-store",
+    );
+  });
+
+  it("named stores get suffixed identities", () => {
+    expect(authTokenSecretName("alchemy-state-store-team-a")).toBe(
+      "AlchemyStateStoreToken_alchemy_state_store_team_a",
+    );
+    expect(encryptionKeySecretName("alchemy-state-store-team-a")).toBe(
+      "AlchemyStateStoreEncryptionKey_alchemy_state_store_team_a",
+    );
+    expect(stateStoreCredentialsFile("alchemy-state-store-team-a")).toBe(
+      "cloudflare-state-store-alchemy-state-store-team-a",
+    );
+  });
+
+  it("two named stores never share a secret or credential identity", () => {
+    const a = "alchemy-state-store-team-a";
+    const b = "alchemy-state-store-team-b";
+    expect(authTokenSecretName(a)).not.toBe(authTokenSecretName(b));
+    expect(encryptionKeySecretName(a)).not.toBe(encryptionKeySecretName(b));
+    expect(stateStoreCredentialsFile(a)).not.toBe(stateStoreCredentialsFile(b));
+    expect(authTokenSecretName(a)).not.toBe(
+      authTokenSecretName(STATE_STORE_SCRIPT_NAME),
+    );
+  });
+});

--- a/website/src/content/docs/state-store/index.mdx
+++ b/website/src/content/docs/state-store/index.mdx
@@ -108,15 +108,52 @@ CI, set `CI=true`; the credentials are resolved from the Secrets
 Store on every run via a short-lived edge-preview Worker, so nothing
 needs to be persisted to disk.
 
-### Customizing the worker name
+### Named state stores
 
-By default the state-store Worker is named `alchemy-state-store`.
-Pass `workerName` to use a separate state store — for example, when
-you want a dedicated store per Cloudflare account or per team:
+By default the state-store Worker is named `alchemy-state-store` and
+is a single account-wide service: every stack that uses
+`Cloudflare.state()` on the account shares its Worker, credentials,
+and contract version. Pass `workerName` to use a dedicated store
+instead — for example one per team, or to isolate projects that
+upgrade their `alchemy` dependency on different schedules:
 
 ```typescript
 state: Cloudflare.state({ workerName: "alchemy-state-store-team-a" }),
 ```
+
+A named store is fully independent of the default one:
+
+- its own Worker (and Durable Object state) under the given name
+- its own bearer-token and encryption-key secrets
+  (`AlchemyStateStoreToken_<name>` /
+  `AlchemyStateStoreEncryptionKey_<name>`), so one store's
+  credentials can never read or decrypt another store's state
+- its own credentials cache file
+  (`cloudflare-state-store-<name>.json`)
+
+Bootstrap, upgrade, and teardown of a named store never touch any
+other store on the account. The CLI commands accept the same name:
+
+```bash
+alchemy cloudflare bootstrap --worker-name alchemy-state-store-team-a
+```
+
+### Version upgrades
+
+Each Alchemy release pins the state-store contract version it
+expects and probes the deployed Worker's `/version` on startup:
+
+- **store matches** — attach and continue.
+- **store is older** — Alchemy asks to upgrade it in place (`--yes`
+  accepts automatically; CI fails with instructions instead of
+  prompting). Upgrading a shared store affects every stack using it,
+  so projects that can't upgrade in lockstep should use a named
+  store.
+- **store is newer** — the store was deployed by a newer Alchemy
+  release. The older client **fails closed** before touching
+  anything; `--yes` cannot authorize a downgrade. The only way to
+  downgrade a store is the explicit operator command
+  `alchemy cloudflare bootstrap --force`.
 
 ## State and lifecycle
 


### PR DESCRIPTION
Closes #912, closes #1194.

### Named state stores (#912)

`Cloudflare.state({ workerName })` now works end to end:

```ts
state: Cloudflare.state({ workerName: "alchemy-state-store-team-a" }),
```

The worker name flows through a `Context.Reference` (`StateStoreWorkerName`, default `alchemy-state-store`) into the state-store stack, so `Api.ts` can stay a static `export default Worker(...)` — its props are now an Effect that resolves the name from context:

```ts
export default Worker(
  "Api",
  Effect.gen(function* () {
    return { name: yield* StateStoreWorkerName, main: import.meta.url, ... };
  }),
  ...
);
```

`deployStateStore` provides the reference on the stack body; inside the deployed bundle the reference falls back to its default, where the name is irrelevant.

Everything the issue listed as only partially propagated is now keyed by the selected store:

- physical Worker identity, serving probe, `/version` check, and workers.dev URL derivation
- login (`readSecretViaEdge` targets the named worker and its suffixed secret)
- credentials cache: `cloudflare-state-store-<name>.json` per store
- secrets: `AlchemyStateStoreToken_<name>` / `AlchemyStateStoreEncryptionKey_<name>` (default store keeps the historical un-suffixed names; logical ids stay fixed since the worker binds by logical id) — so one store's bearer token can't authenticate against, nor its key decrypt, another store's state
- `bootstrap({ workerName })` and `teardownStateStore({ workerName })` only touch their own store's worker, secrets, and credential cache

### Monotonic version guard (#1194)

`checkStateStoreVersion` results are classified as `match | missing | store-older | store-newer`:

- `store-older` keeps the existing upgrade flow (prompt, `--yes`, CI error).
- `store-newer` fails closed with `StateStoreClientTooOldError` **before** any mutation — `--yes` cannot authorize a downgrade. The only downgrade path is the explicit operator command `alchemy cloudflare bootstrap --force`.

### Tests

- `Names.test.ts` — pure coverage of the version classification and per-store identity derivation.
- `NamedStore.test.ts` — live: bootstraps a named store on the testing account, proves state roundtrip, proves the default and named stores can't see each other's state and don't redeploy each other, then tears the named store down and verifies the default store's worker and secrets survive. All green against the real API; the default-store `State.test.ts` suite (18 tests) also passes unchanged.
