### PR TITLE
fix(cloudflare): type circular Worker layers

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -2118,7 +2118,9 @@ export const Worker: ResourceClassLike<Worker> &
         Self | Extract<Deps, Container.Application<any>> | Providers
       > &
         Named<Id> & {
-          new (_: never): MakeShape<Shape, WorkerShape> & Named<Id> & Tag;
+          new (
+            _: never,
+          ): MakeShape<Shape, WorkerShape> & Named<Id> & Tag<WorkerTypeId>;
           of(shape: Shape & WorkerShape): MakeShape<Shape, WorkerShape>;
           make<PropsReq = never, InitReq = never>(
             props:
@@ -2130,7 +2132,10 @@ export const Worker: ResourceClassLike<Worker> &
             never,
             | Extract<Deps, Container.Application<any>>
             | Providers
-            | Exclude<InitReq, Self | WorkerServices>
+            | Exclude<
+                PropsReq | InitReq,
+                Self | WorkerServices | Tag<WorkerTypeId>
+              >
           >;
         };
     };
@@ -2156,7 +2161,7 @@ export const Worker: ResourceClassLike<Worker> &
         Extract<Req, Container.Application<any>> | Providers | PropsReq
       > &
         Named<Id> & {
-          new (): MakeShape<Shape, WorkerShape> & Named<Id> & Tag;
+          new (): MakeShape<Shape, WorkerShape> & Named<Id> & Tag<WorkerTypeId>;
         };
       /**
        * Class form without an implementation — an external Worker (a plain
@@ -2176,7 +2181,7 @@ export const Worker: ResourceClassLike<Worker> &
           | Effect.Effect<InputProps<WorkerProps>, ConfigError, Req>,
       ): Effect.Effect<Worker & Rpc<{}>, never, Req | Providers> &
         Named<Id> & {
-          new (): Named<Id> & Tag;
+          new (): Named<Id> & Tag<WorkerTypeId>;
         };
     };
     <

--- a/packages/alchemy/test/Cloudflare/Workers/CircularBindings.types.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/CircularBindings.types.ts
@@ -1,0 +1,86 @@
+import * as Cloudflare from "@/Cloudflare";
+import type { Tag } from "@/Named";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+class A extends Cloudflare.Worker<A, { work: () => Effect.Effect<string> }>()(
+  "A",
+) {}
+
+class B extends Cloudflare.Worker<B, { work: () => Effect.Effect<string> }>()(
+  "B",
+) {}
+
+const ALive = A.make(
+  { main: import.meta.url },
+  Effect.gen(function* () {
+    const b = yield* Cloudflare.Workers.bindWorker(B);
+    return {
+      fetch: Effect.gen(function* () {
+        return HttpServerResponse.text(yield* b.work());
+      }),
+      work: () => Effect.succeed("A handled its half"),
+    };
+  }),
+);
+
+const BLive = B.make(
+  { main: import.meta.url },
+  Effect.gen(function* () {
+    const a = yield* Cloudflare.Workers.bindWorker(A);
+    return {
+      fetch: Effect.gen(function* () {
+        return HttpServerResponse.text(yield* a.work());
+      }),
+      work: () => Effect.succeed("B handled its half"),
+    };
+  }),
+);
+
+const program = Effect.gen(function* () {
+  const a = yield* A;
+  const b = yield* B;
+  return { aUrl: a.url, bUrl: b.url };
+}).pipe(Effect.provide(Layer.mergeAll(ALive, BLive)));
+
+type RequirementsOf<T> =
+  T extends Effect.Effect<unknown, unknown, infer Req> ? Req : never;
+type LayerRequirementsOf<T> =
+  T extends Layer.Layer<infer _A, infer _E, infer Req> ? Req : never;
+type Assert<T extends true> = T;
+
+type _CircularWorkersAreProvided = Assert<
+  Extract<RequirementsOf<typeof program>, A | B> extends never ? true : false
+>;
+
+class UserService extends Context.Service<UserService, {}>()(
+  "test/UserService",
+) {}
+
+class OtherResource
+  extends Context.Service<OtherResource, {}>()("test/OtherResource")
+  implements Tag<"Test.Resource">
+{
+  declare readonly "~alchemy/Tag": "Test.Resource";
+}
+
+const RequirementsLive = A.make(
+  Effect.gen(function* () {
+    yield* UserService;
+    yield* OtherResource;
+    return { main: import.meta.url };
+  }),
+  Effect.succeed({
+    work: () => Effect.succeed("done"),
+  }),
+);
+
+type _PreservesNonWorkerRequirements = Assert<
+  UserService | OtherResource extends LayerRequirementsOf<
+    typeof RequirementsLive
+  >
+    ? true
+    : false
+>;


### PR DESCRIPTION
## Summary

- type Worker class instances as `Tag<WorkerTypeId>` instead of the broad `Tag`
- remove only Worker resource tags from `Worker.make` layer requirements, allowing circular Worker layers to compose with `Layer.mergeAll`
- restore `PropsReq` propagation while preserving user services and non-Worker resource tags
- add a regression typetest matching the circular-bindings guide's `A.make` / `B.make` example

## Diagnosis

`bindWorker(B)` correctly adds B's Worker Tag to A's init requirements. Alchemy resolves that dependency through its deferred resource graph, but the `Worker.make` return type exposed it as an ordinary Effect Layer input. In a circular pair, each layer therefore required the other layer's output, leaving `A | B` in the Stack requirements and triggering Effect's `layerMergeAllWithDependencies` diagnostic.

Excluding the broad `Tag` type would also erase unrelated Alchemy resource requirements. This change brands Worker classes with `Tag<WorkerTypeId>` and excludes only that function-resource tag. The typetest verifies that ordinary Context services and a non-Worker resource tag still flow through the layer requirements.

## Checks

- `bunx oxfmt --check packages/alchemy/src/Cloudflare/Workers/Worker.ts packages/alchemy/test/Cloudflare/Workers/CircularBindings.types.ts`
- `git diff --check`
- isolated TypeScript project: both new assertions pass; the only compiler error is the pre-existing `packages/alchemy/src/AWS/StepFunctions/Asl/Program.ts:102` TS2352 cast error

No runtime behavior, RPC transport, dependency version, or generated documentation changed. The existing circular-bindings guide is already accurate.
