### PR TITLE
fix(cloudflare): expose Worker URLs during precreate

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -1403,6 +1403,27 @@ export const LiveWorkerProvider = () =>
         return `https://${version.versionId.slice(0, 8)}-${scriptName}.${accountSubdomain}.workers.dev`;
       });
 
+      const computeStableWorkerUrls = Effect.fn(function* (params: {
+        scriptName: string;
+        workersDev: ResolvedWorkersDev;
+        domain: ResolvedWorkerDomain | undefined;
+      }) {
+        const { workersDev, domain, scriptName } = params;
+        const urls: string[] = [];
+        if (domain) {
+          urls.push(
+            `https://${domain.name}`,
+            ...domain.aliases.map((hostname) => `https://${hostname}`),
+          );
+        }
+        if (workersDev.enabled) {
+          const { accountId } = yield* yield* CloudflareEnvironment;
+          const accountSubdomain = yield* getAccountSubdomain(accountId);
+          urls.push(`https://${scriptName}.${accountSubdomain}.workers.dev`);
+        }
+        return urls;
+      });
+
       /**
        * Assemble every URL a deployed, script-owning Worker serves at, most
        * significant first — the first entry becomes the `url` attribute:
@@ -1428,36 +1449,25 @@ export const LiveWorkerProvider = () =>
         uploadedVersionAlias?: string;
       }) {
         const { workersDev, domain, scriptName } = params;
-        const urls: string[] = [];
-        if (domain) {
-          urls.push(
-            `https://${domain.name}`,
-            ...domain.aliases.map((hostname) => `https://${hostname}`),
-          );
-        }
-        if (workersDev.enabled || workersDev.previewsEnabled) {
+        const urls = yield* computeStableWorkerUrls(params);
+        if (workersDev.previewsEnabled) {
           const { accountId } = yield* yield* CloudflareEnvironment;
           const accountSubdomain = yield* getAccountSubdomain(accountId);
-          if (workersDev.enabled) {
-            urls.push(`https://${scriptName}.${accountSubdomain}.workers.dev`);
-          }
-          if (workersDev.previewsEnabled) {
-            if (params.uploadedVersionId !== undefined) {
-              if (params.uploadedVersionAlias !== undefined) {
-                urls.push(
-                  `https://${params.uploadedVersionAlias}-${scriptName}.${accountSubdomain}.workers.dev`,
-                );
-              }
+          if (params.uploadedVersionId !== undefined) {
+            if (params.uploadedVersionAlias !== undefined) {
               urls.push(
-                `https://${params.uploadedVersionId.split("-")[0]}-${scriptName}.${accountSubdomain}.workers.dev`,
+                `https://${params.uploadedVersionAlias}-${scriptName}.${accountSubdomain}.workers.dev`,
               );
-            } else if (!workersDev.enabled) {
-              const previewUrl = yield* getPreviewUrl(
-                scriptName,
-                accountSubdomain,
-              );
-              if (previewUrl) urls.push(previewUrl);
             }
+            urls.push(
+              `https://${params.uploadedVersionId.split("-")[0]}-${scriptName}.${accountSubdomain}.workers.dev`,
+            );
+          } else if (!workersDev.enabled) {
+            const previewUrl = yield* getPreviewUrl(
+              scriptName,
+              accountSubdomain,
+            );
+            if (previewUrl) urls.push(previewUrl);
           }
         }
         return urls;
@@ -4591,17 +4601,33 @@ export const LiveWorkerProvider = () =>
               ));
           }
 
+          const urlProps = {
+            domain: news.domain,
+            workersDev: news.workersDev,
+          };
+          const hasResolvedUrlProps = isResolved(urlProps);
+          const domain = hasResolvedUrlProps
+            ? yield* resolveWorkerDomain(urlProps.domain)
+            : undefined;
+          const urls = hasResolvedUrlProps
+            ? yield* computeStableWorkerUrls({
+                scriptName: name,
+                workersDev: resolveWorkersDev(urlProps.workersDev),
+                domain,
+              })
+            : [];
+
           return {
             workerId: name,
             workerName: name,
             namespace: dispatchNamespace,
             logpush: existingSettings?.logpush ?? undefined,
-            url: undefined,
+            url: urls[0],
             tags: existingSettings?.tags ?? tags,
             durableObjectNamespaces,
             accountId,
-            urls: [],
-            domain: undefined,
+            urls,
+            domain,
             routes: [],
             crons: [],
           } satisfies Worker["Attributes"];

--- a/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
@@ -1171,6 +1171,72 @@ describe.concurrent("Cloudflare.Worker", () => {
     { timeout: 360_000 },
   );
 
+  test.provider(
+    "circular Worker URL bindings deploy and converge",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+
+        yield* stack.destroy();
+
+        const program = () =>
+          Effect.gen(function* () {
+            const a = yield* Cloudflare.Worker("CircularUrlA", { main });
+            const b = yield* Cloudflare.Worker("CircularUrlB", { main });
+            yield* a.bind`B_URL`({
+              bindings: [
+                {
+                  type: "plain_text",
+                  name: "B_URL",
+                  text: b.url.as<string>(),
+                },
+              ],
+            });
+            yield* b.bind`A_URL`({
+              bindings: [
+                {
+                  type: "plain_text",
+                  name: "A_URL",
+                  text: a.url.as<string>(),
+                },
+              ],
+            });
+            return { a, b };
+          });
+
+        const deployed = yield* stack.deploy(program());
+        for (const [worker, name, peerUrl] of [
+          [deployed.a, "B_URL", deployed.b.url],
+          [deployed.b, "A_URL", deployed.a.url],
+        ] as const) {
+          const settings = yield* workers.getScriptScriptAndVersionSetting({
+            accountId,
+            scriptName: worker.workerName,
+          });
+          expect(settings.bindings).toContainEqual(
+            expect.objectContaining({
+              type: "plain_text",
+              name,
+              text: peerUrl,
+            }),
+          );
+        }
+
+        const settled = yield* stack.plan(program());
+        for (const logicalId of ["CircularUrlA", "CircularUrlB"]) {
+          const node = (Object.values(settled.resources) as any[]).find(
+            (candidate) => candidate.resource.LogicalId === logicalId,
+          );
+          expect(node?.action).toBe("noop");
+        }
+
+        yield* stack.destroy();
+        yield* waitForWorkerToBeDeleted(deployed.a.workerName, accountId);
+        yield* waitForWorkerToBeDeleted(deployed.b.workerName, accountId);
+      }).pipe(logLevel),
+    { timeout: 360_000 },
+  );
+
   // Effect-valued env entries are stripped from the props comparison (#874),
   // so change detection for them rides entirely on the evaluated binding
   // data. This test guards that channel: when only the VALUE an env Effect


### PR DESCRIPTION
Worker URL outputs were unavailable during precreate, so circular URL bindings resolved to `undefined` on the first deployment.

For example, a web Worker can depend on the server URL while the server depends on the web URL for CORS:

```ts
const server = yield* Cloudflare.Worker("Server", {
  main: "./server.ts",
});

const web = yield* Cloudflare.Website.Astro("Web", {
  env: {
    PUBLIC_SERVER_URL: server.url.as<string>(),
  },
});

yield* server.bind`CORS_ORIGIN`({
  bindings: [
    {
      type: "plain_text",
      name: "CORS_ORIGIN",
      text: web.url.as<string>(),
    },
  ],
});
```

The deferred `bind` call registers the back edge after both resources have been declared. Populate deterministic custom-domain and `workers.dev` URLs in the precreate result so Alchemy can resolve this cycle. Preview URLs remain deferred until Cloudflare creates the corresponding version.
