### PR TITLE
chore: check out distilled worktree on the parent worktree's branch

### DIFF
--- a/scripts/bootstrap-distilled-worktree.ts
+++ b/scripts/bootstrap-distilled-worktree.ts
@@ -1,27 +1,32 @@
+import { $ } from "bun";
 import { existsSync, readdirSync, rmdirSync } from "node:fs";
 import { resolve } from "node:path";
-import { spawnSync } from "node:child_process";
 
-function git(args: string[], cwd: string, capture = true) {
-  const result = spawnSync("git", args, {
-    cwd,
-    encoding: "utf8",
-    stdio: capture ? "pipe" : "inherit",
-  });
+async function git(args: string[], cwd: string, capture = true) {
+  const command = $`git ${args}`.cwd(cwd).nothrow();
+  const result = capture ? await command.quiet() : await command;
 
-  if (result.status !== 0) {
+  if (result.exitCode !== 0) {
     if (capture) {
       process.stderr.write(result.stderr);
     }
-    process.exit(result.status ?? 1);
+    process.exit(result.exitCode);
   }
 
-  return result.stdout?.trim() ?? "";
+  return result.text().trim();
 }
 
-const root = git(["rev-parse", "--show-toplevel"], process.cwd());
-const gitDir = git(["rev-parse", "--path-format=absolute", "--git-dir"], root);
-const commonDir = git(
+async function tryGit(args: string[], cwd: string) {
+  const result = await $`git ${args}`.cwd(cwd).quiet().nothrow();
+  return result.exitCode === 0 ? result.text().trim() : undefined;
+}
+
+const root = await git(["rev-parse", "--show-toplevel"], process.cwd());
+const gitDir = await git(
+  ["rev-parse", "--path-format=absolute", "--git-dir"],
+  root,
+);
+const commonDir = await git(
   ["rev-parse", "--path-format=absolute", "--git-common-dir"],
   root,
 );
@@ -31,9 +36,27 @@ if (gitDir === commonDir) {
   process.exit(0);
 }
 
-const desiredCommit = git(["rev-parse", "HEAD:distilled"], root);
+const desiredCommit = await git(["rev-parse", "HEAD:distilled"], root);
 const sharedRepository = resolve(commonDir, "modules/distilled");
 const checkout = resolve(root, "distilled");
+
+// Mirror the parent worktree's branch onto the distilled worktree so it isn't
+// left on a dangling detached HEAD. A detached parent stays detached.
+const desiredBranch = await tryGit(
+  ["symbolic-ref", "--short", "-q", "HEAD"],
+  root,
+);
+
+async function branchInUseElsewhere(): Promise<boolean> {
+  const list = await tryGit(
+    ["worktree", "list", "--porcelain"],
+    sharedRepository,
+  );
+  return (
+    list !== undefined &&
+    list.split("\n").includes(`branch refs/heads/${desiredBranch}`)
+  );
+}
 
 if (!existsSync(sharedRepository)) {
   console.error(
@@ -44,40 +67,54 @@ if (!existsSync(sharedRepository)) {
 }
 
 const objectExists =
-  spawnSync("git", ["cat-file", "-e", `${desiredCommit}^{commit}`], {
-    cwd: sharedRepository,
-    stdio: "ignore",
-  }).status === 0;
+  (await tryGit(
+    ["cat-file", "-e", `${desiredCommit}^{commit}`],
+    sharedRepository,
+  )) !== undefined;
 
 if (!objectExists) {
   console.log(`Fetching distilled commit ${desiredCommit}...`);
-  git(["fetch", "origin", desiredCommit], sharedRepository, false);
+  await git(["fetch", "origin", desiredCommit], sharedRepository, false);
 }
 
 if (existsSync(checkout)) {
-  const checkoutMetadata = resolve(checkout, ".git");
-  const checkoutGitDir = existsSync(checkoutMetadata)
-    ? spawnSync(
-        "git",
+  const checkoutGitDir = existsSync(resolve(checkout, ".git"))
+    ? await tryGit(
         ["rev-parse", "--path-format=absolute", "--git-common-dir"],
-        { cwd: checkout, encoding: "utf8", stdio: "pipe" },
+        checkout,
       )
     : undefined;
 
-  if (checkoutGitDir?.status === 0) {
-    if (checkoutGitDir.stdout.trim() !== sharedRepository) {
+  if (checkoutGitDir !== undefined) {
+    if (checkoutGitDir !== sharedRepository) {
       console.error(
         `Cannot bootstrap distilled: ${checkout} belongs to a different Git repository.`,
       );
       process.exit(1);
     }
 
-    const currentCommit = git(["rev-parse", "HEAD"], checkout);
+    const currentCommit = await git(["rev-parse", "HEAD"], checkout);
+    const currentBranch = await tryGit(
+      ["symbolic-ref", "--short", "-q", "HEAD"],
+      checkout,
+    );
     if (currentCommit === desiredCommit) {
+      if (
+        desiredBranch !== undefined &&
+        currentBranch !== desiredBranch &&
+        !(await branchInUseElsewhere())
+      ) {
+        // Same commit, wrong (or detached) HEAD — just move the branch over.
+        await git(
+          ["checkout", "-B", desiredBranch, desiredCommit],
+          checkout,
+          false,
+        );
+      }
       process.exit(0);
     }
 
-    if (git(["status", "--porcelain"], checkout) !== "") {
+    if ((await git(["status", "--porcelain"], checkout)) !== "") {
       console.error(
         `Cannot update distilled to ${desiredCommit}: ${checkout} has uncommitted changes.`,
       );
@@ -85,7 +122,18 @@ if (existsSync(checkout)) {
     }
 
     console.log(`Updating distilled to ${desiredCommit}...`);
-    git(["checkout", "--detach", desiredCommit], checkout, false);
+    if (
+      desiredBranch !== undefined &&
+      (currentBranch === desiredBranch || !(await branchInUseElsewhere()))
+    ) {
+      await git(
+        ["checkout", "-B", desiredBranch, desiredCommit],
+        checkout,
+        false,
+      );
+    } else {
+      await git(["checkout", "--detach", desiredCommit], checkout, false);
+    }
     process.exit(0);
   }
 
@@ -100,8 +148,10 @@ if (existsSync(checkout)) {
 }
 
 console.log(`Creating distilled worktree at ${desiredCommit}...`);
-git(
-  ["worktree", "add", "--detach", checkout, desiredCommit],
+await git(
+  desiredBranch !== undefined && !(await branchInUseElsewhere())
+    ? ["worktree", "add", "-B", desiredBranch, checkout, desiredCommit]
+    : ["worktree", "add", "--detach", checkout, desiredCommit],
   sharedRepository,
   false,
 );


### PR DESCRIPTION
The post-checkout bootstrap created the distilled worktree with `--detach`, leaving every linked worktree's distilled checkout on a dangling detached HEAD. It now mirrors the parent worktree's branch:

```diff
-git worktree add --detach distilled <commit>
+git worktree add -B <parent-branch> distilled <commit>
```

- Falls back to detached when the parent is itself detached, or when the branch is already checked out by another distilled worktree (git refuses to check out one branch twice).
- Re-running the hook heals an existing detached checkout: same commit but wrong/detached HEAD now does a `checkout -B` instead of exiting early.
- Ported the script from `spawnSync` to Bun's `$` shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
