### PR TITLE
fix(cli): require Effect platform peers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1520,8 +1520,6 @@
       },
       "optionalPeers": [
         "@aws/durable-execution-sdk-js",
-        "@effect/platform-bun",
-        "@effect/platform-node",
         "@effect/sql-mysql2",
         "@effect/sql-pg",
         "@vercel/nft",

--- a/packages/alchemy/package.json
+++ b/packages/alchemy/package.json
@@ -477,12 +477,6 @@
     "@aws/durable-execution-sdk-js": {
       "optional": true
     },
-    "@effect/platform-bun": {
-      "optional": true
-    },
-    "@effect/platform-node": {
-      "optional": true
-    },
     "@effect/sql-mysql2": {
       "optional": true
     },


### PR DESCRIPTION
`bunx alchemy@latest login --configure` currently crashes in a clean directory before the command can start:

```text
Cannot find module '@effect/platform-node/NodeServices'
```

### Root cause

Alchemy declares `@effect/platform-bun` and `@effect/platform-node` as peers, but also marks both peers optional. Package managers therefore omit them from an isolated `bunx` install.

They are not optional for the CLI:

- `Cloudflare/Workers/WorkerBridge.ts` statically imports `@effect/platform-node/NodeServices` while the CLI module graph loads.
- `Util/PlatformServices.ts` loads the matching Bun or Node runtime when the CLI starts.

This is why a project-local install that already includes both packages works, while standalone `bunx alchemy ...` fails. It also means fixing only the Node package would leave the Bun runtime unresolved once execution reaches `PlatformServices`.

### Change

Remove the two `peerDependenciesMeta.optional` entries. The packages remain peers, so applications can continue to provide and deduplicate compatible Effect versions; Bun/npm will now install them when Alchemy is used standalone.

This does not change Alchemy's public API, runtime selection, or provider behavior. It only makes the published dependency metadata match what the existing CLI imports already require.
