### PR TITLE
feat(kubernetes): direct image strategy for Deployment (skip the managed-registry mirror)

### DIFF
--- a/packages/alchemy/src/Kubernetes/Deployment.ts
+++ b/packages/alchemy/src/Kubernetes/Deployment.ts
@@ -45,6 +45,7 @@ import {
   connectionIdentity,
   connectionOfOutput,
   deepMerge,
+  imageSourceKind,
   imagePlatformOf,
   makeServerBootstrap,
   resolveWorkloadImage,
@@ -200,6 +201,13 @@ export interface ImageDeploymentProps extends DeploymentPropsBase {
    * reference is used verbatim.
    */
   image: string;
+  /**
+   * How the image is delivered on clusters with a managed registry.
+   * `"mirror"` copies it into that registry; `"direct"` uses the supplied
+   * reference verbatim and requires the cluster to be able to pull it.
+   * @default "mirror"
+   */
+  imageStrategy?: "mirror" | "direct";
 }
 
 export type DeploymentProps =
@@ -450,6 +458,37 @@ const retryUntilServiceReady = <A, E, R>(
 const isNotFound = (error: unknown): error is KubernetesApiError =>
   error instanceof KubernetesApiError && error.statusCode === 404;
 
+interface ObservedDeployment {
+  metadata?: { generation?: number };
+  spec?: { replicas?: number; progressDeadlineSeconds?: number };
+  status?: {
+    observedGeneration?: number;
+    replicas?: number;
+    updatedReplicas?: number;
+    availableReplicas?: number;
+  };
+}
+
+/** Kubernetes' completed-rollout conditions, exposed for unit testing. */
+export const isDeploymentRolloutComplete = (
+  deployment: ObservedDeployment,
+): boolean => {
+  const generation = deployment.metadata?.generation;
+  const desired = deployment.spec?.replicas ?? 1;
+  const status = deployment.status;
+  return (
+    generation !== undefined &&
+    (status?.observedGeneration ?? -1) >= generation &&
+    (status?.updatedReplicas ?? 0) === desired &&
+    (status?.replicas ?? 0) === desired &&
+    (status?.availableReplicas ?? 0) === desired
+  );
+};
+
+class DeploymentRolloutPending extends Data.TaggedError(
+  "Kubernetes.DeploymentRolloutPending",
+) {}
+
 export const DeploymentProvider = () =>
   Provider.effect(
     Deployment,
@@ -468,6 +507,42 @@ export const DeploymentProvider = () =>
           : createPhysicalName({ id, maxLength: 200, lowercase: true }).pipe(
               Effect.map((name) => name.replaceAll(/[^a-z0-9-]/g, "-")),
             );
+
+      const stableAttributes: Array<keyof Deployment["Attributes"]> = [
+        "connection",
+        "namespace",
+        "serviceAccountName",
+        "deploymentName",
+        "serviceName",
+        "identity",
+        "registry",
+      ];
+
+      const waitForDeploymentRollout = (
+        transport: ClusterTransport,
+        deployment: KubernetesObjectDefinition,
+      ) => {
+        const deadlineSeconds =
+          (deployment.spec as { progressDeadlineSeconds?: number })
+            .progressDeadlineSeconds ?? 600;
+        return readObject({
+          transport,
+          object: toKubernetesObjectRef(deployment),
+        }).pipe(
+          Effect.flatMap((observed) =>
+            isDeploymentRolloutComplete(observed as ObservedDeployment)
+              ? Effect.succeed(observed)
+              : Effect.fail(new DeploymentRolloutPending()),
+          ),
+          Effect.retry({
+            while: (error) => error instanceof DeploymentRolloutPending,
+            schedule: Schedule.max([
+              Schedule.spaced("5 seconds"),
+              Schedule.recurs(Math.ceil(deadlineSeconds / 5)),
+            ]),
+          }),
+        );
+      };
 
       // Read a LoadBalancer Service's assigned hostname (bounded wait).
       const waitForLoadBalancer = (
@@ -499,15 +574,7 @@ export const DeploymentProvider = () =>
         );
 
       return {
-        stables: [
-          "connection",
-          "namespace",
-          "serviceAccountName",
-          "deploymentName",
-          "serviceName",
-          "identity",
-          "registry",
-        ],
+        stables: stableAttributes,
         // A Deployment's identity spans in-cluster Kubernetes objects plus
         // adapter-owned cloud resources (identity role, image repository).
         // There is no single enumeration that faithfully reconstructs that
@@ -539,6 +606,25 @@ export const DeploymentProvider = () =>
           ) {
             return { action: "replace" } as const;
           }
+          const oldSource = olds as WorkloadImageSource;
+          const newSource = news as WorkloadImageSource;
+          const oldImageStrategy =
+            imageSourceKind(oldSource) === "image"
+              ? ((olds as ImageDeploymentProps).imageStrategy ?? "mirror")
+              : undefined;
+          const newImageStrategy =
+            imageSourceKind(newSource) === "image"
+              ? ((news as ImageDeploymentProps).imageStrategy ?? "mirror")
+              : undefined;
+          if (oldImageStrategy !== newImageStrategy) {
+            return {
+              action: "update",
+              // Registry ownership changes across direct/mirror transitions.
+              stables: stableAttributes.filter(
+                (attribute) => attribute !== "registry",
+              ),
+            } as const;
+          }
           // Content drift: the props don't change when files under a build
           // context (or the bundled program) do, so surface hash drift as
           // an update.
@@ -549,6 +635,10 @@ export const DeploymentProvider = () =>
             const hash = yield* workloadImageHash({
               adapter,
               source,
+              imageStrategy:
+                imageSourceKind(source) === "image"
+                  ? (news as ImageDeploymentProps).imageStrategy
+                  : undefined,
               platform: imagePlatformOf(news.architecture),
               port: news.port ?? 3000,
               isExternal: news.isExternal,
@@ -647,10 +737,20 @@ export const DeploymentProvider = () =>
           // registry adapter (pre-built `image` refs pass through verbatim
           // on registry-less clusters).
           const source = news as WorkloadImageSource;
+          const previousRegistryState =
+            (output?.registry as Record<string, unknown> | undefined) ??
+            (typeof (output as Record<string, unknown> | undefined)
+              ?.repositoryName === "string"
+              ? (output as unknown as Record<string, unknown>)
+              : undefined);
           const resolved = yield* resolveWorkloadImage({
             adapter,
             id,
             source,
+            imageStrategy:
+              imageSourceKind(source) === "image"
+                ? (news as ImageDeploymentProps).imageStrategy
+                : undefined,
             platform: imagePlatformOf(news.architecture),
             port,
             isExternal: news.isExternal,
@@ -658,9 +758,7 @@ export const DeploymentProvider = () =>
               source.handler ?? "default",
             ),
             tags,
-            state:
-              (output?.registry as Record<string, unknown> | undefined) ??
-              (output as Record<string, unknown> | undefined),
+            state: previousRegistryState,
             session,
           });
 
@@ -778,6 +876,14 @@ export const DeploymentProvider = () =>
           yield* session.note(
             `Applied Kubernetes Deployment ${namespace}/${baseName}`,
           );
+
+          if (resolved.cleanupState !== undefined && adapter.registry) {
+            yield* waitForDeploymentRollout(transport, deploymentObject);
+            yield* adapter.registry.delete({ state: resolved.cleanupState });
+            yield* session.note(
+              `Removed previous managed image registry for ${namespace}/${baseName}`,
+            );
+          }
 
           // Resolve the LoadBalancer URL if applicable. The cloud listener
           // is the Service `port` (Kubernetes maps `spec.ports[].port` 1:1

--- a/packages/alchemy/src/Kubernetes/internal/workload.ts
+++ b/packages/alchemy/src/Kubernetes/internal/workload.ts
@@ -13,6 +13,7 @@ import type { ResourceBinding } from "../../Resource.ts";
 import { Self } from "../../Self.ts";
 import { sha256Object } from "../../Util/sha256.ts";
 import type {
+  AdapterLifecycleServices,
   ClusterAdapterService,
   IdentityState,
   RegistryState,
@@ -220,6 +221,8 @@ export interface ResolveWorkloadImageOptions {
   adapter: ClusterAdapterService;
   id: string;
   source: WorkloadImageSource;
+  /** Deployment-only delivery strategy for a pre-built image. */
+  imageStrategy?: "mirror" | "direct";
   platform: string;
   port?: number | undefined;
   isExternal?: boolean | undefined;
@@ -230,6 +233,14 @@ export interface ResolveWorkloadImageOptions {
   session: { note: (message: string) => Effect.Effect<void> };
 }
 
+export interface ResolvedWorkloadImage {
+  imageUri: string;
+  codeHash: string;
+  state: RegistryState | undefined;
+  /** Previous managed-registry state to delete after the new image is live. */
+  cleanupState: Record<string, unknown> | undefined;
+}
+
 /**
  * Resolve the container image for a workload: through the cluster
  * adapter's managed registry when it has one (build/mirror + push), or —
@@ -238,10 +249,28 @@ export interface ResolveWorkloadImageOptions {
  */
 export const resolveWorkloadImage = Effect.fn(function* (
   options: ResolveWorkloadImageOptions,
-) {
+): Effect.fn.Return<
+  ResolvedWorkloadImage,
+  any,
+  AdapterLifecycleServices | FileSystem.FileSystem | Path.Path
+> {
   const { adapter, source } = options;
+  const kind = imageSourceKind(source);
+  if (kind === "image" && options.imageStrategy === "direct") {
+    const codeHash = (yield* computeStaticWorkloadImageHash(
+      source,
+      options.platform,
+    ))!;
+    return {
+      imageUri: source.image!,
+      codeHash,
+      state: undefined,
+      cleanupState: adapter.registry === undefined ? undefined : options.state,
+    };
+  }
+
   if (adapter.registry !== undefined) {
-    return yield* adapter.registry.resolve({
+    const resolved = yield* adapter.registry.resolve({
       id: options.id,
       source,
       platform: options.platform,
@@ -252,9 +281,9 @@ export const resolveWorkloadImage = Effect.fn(function* (
       state: options.state,
       session: options.session,
     });
+    return { ...resolved, cleanupState: undefined };
   }
 
-  const kind = imageSourceKind(source);
   if (kind === "image") {
     const codeHash = (yield* computeStaticWorkloadImageHash(
       source,
@@ -264,6 +293,7 @@ export const resolveWorkloadImage = Effect.fn(function* (
       imageUri: source.image!,
       codeHash,
       state: undefined,
+      cleanupState: undefined,
     };
   }
 
@@ -281,11 +311,22 @@ export const resolveWorkloadImage = Effect.fn(function* (
 export const workloadImageHash = Effect.fn(function* (options: {
   adapter: ClusterAdapterService;
   source: WorkloadImageSource;
+  /** Deployment-only delivery strategy for a pre-built image. */
+  imageStrategy?: "mirror" | "direct";
   platform: string;
   port?: number | undefined;
   isExternal?: boolean | undefined;
   bootstrap: (importPath: string) => string;
 }) {
+  if (
+    imageSourceKind(options.source) === "image" &&
+    options.imageStrategy === "direct"
+  ) {
+    return yield* computeStaticWorkloadImageHash(
+      options.source,
+      options.platform,
+    );
+  }
   if (options.adapter.registry !== undefined) {
     return yield* options.adapter.registry.hash({
       source: options.source,

--- a/packages/alchemy/test/Kubernetes/Deployment.test.ts
+++ b/packages/alchemy/test/Kubernetes/Deployment.test.ts
@@ -2,15 +2,27 @@ import * as AWS from "@/AWS";
 import { Network } from "@/AWS/EC2/Network.ts";
 import { Cluster } from "@/AWS/EKS/Cluster.ts";
 import { makeEksTransport } from "@/AWS/EKS/KubernetesAdapter.ts";
+import { InstanceId } from "@/InstanceId.ts";
 import * as Kubernetes from "@/Kubernetes";
+import type { ClusterAdapterService } from "@/Kubernetes/ClusterAdapter.ts";
+import { isDeploymentRolloutComplete } from "@/Kubernetes/Deployment.ts";
 import { readObject } from "@/Kubernetes/internal/client.ts";
+import {
+  resolveWorkloadImage,
+  workloadImageHash,
+} from "@/Kubernetes/internal/workload.ts";
 import * as Core from "@/Test/Core";
 import * as Provider from "@/Provider";
+import { Stack, type StackSpec } from "@/Stack.ts";
+import { Stage } from "@/Stage.ts";
 import * as Test from "@/Test/Alchemy";
 import * as dynamodb from "@distilled.cloud/aws/dynamodb";
-import { describe, expect } from "alchemy-test";
+import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
+import { describe, expect, it } from "alchemy-test";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
 import * as Schedule from "effect/Schedule";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import EksHostApi from "./fixtures/deployment.ts";
@@ -19,6 +31,172 @@ const testOptions = {
   providers: Layer.mergeAll(AWS.providers(), Kubernetes.providers()),
 };
 const { test, beforeAll, afterAll } = Test.make(testOptions);
+
+const unitStack: Omit<StackSpec, "output"> = {
+  name: "kubernetes-deployment-test",
+  stage: "test",
+  resources: {},
+  bindings: {},
+  actions: {},
+};
+
+const adapterLifecycleLayer = Layer.mergeAll(
+  NodeFileSystem.layer,
+  Path.layer,
+  Layer.succeed(Stack, unitStack),
+  Layer.succeed(Stage, unitStack.stage),
+  Layer.succeed(InstanceId, "0123456789abcdef0123456789abcdef"),
+);
+
+const provideAdapterLifecycle = <A, E>(
+  effect: Effect.Effect<
+    A,
+    E,
+    Stack | Stage | InstanceId | FileSystem.FileSystem | Path.Path
+  >,
+) => effect.pipe(Effect.provide(adapterLifecycleLayer));
+
+const checkImageStrategyTypeSurface = () => {
+  const cluster = undefined as unknown as Kubernetes.ClusterLike;
+  const imageProps: Kubernetes.ImageDeploymentProps = {
+    cluster,
+    image: "registry.example.test/cache:v1",
+    imageStrategy: "direct",
+  };
+  const bundledProps: Kubernetes.BundledDeploymentProps = {
+    cluster,
+    main: import.meta.url,
+    // @ts-expect-error direct delivery only applies to pre-built images
+    imageStrategy: "direct",
+  };
+  return { imageProps, bundledProps };
+};
+void checkImageStrategyTypeSurface;
+
+const makeRegistryAdapter = (calls: string[]): ClusterAdapterService => ({
+  kind: "Kubernetes.ClusterAdapter",
+  connect: () => Effect.die(new Error("not used")),
+  registry: {
+    resolve: () =>
+      Effect.sync(() => {
+        calls.push("resolve");
+        return {
+          imageUri: "managed.example.test/repository:latest",
+          codeHash: "managed-hash",
+          state: { kind: "aws-ecr", repositoryName: "repository" },
+        } as any;
+      }),
+    hash: () =>
+      Effect.sync(() => {
+        calls.push("hash");
+        return "managed-hash";
+      }),
+    delete: () => Effect.void,
+  },
+});
+
+const imageOptions = (adapter: ClusterAdapterService, source: any) => ({
+  adapter,
+  id: "ImageStrategyTest",
+  source,
+  platform: "linux/amd64",
+  bootstrap: () => "",
+  tags: {},
+  state: { kind: "aws-ecr", repositoryName: "previous-repository" },
+  session: { note: () => Effect.void },
+});
+
+describe("Kubernetes Deployment image strategy", () => {
+  it.effect("mirrors pre-built images by default", () =>
+    provideAdapterLifecycle(
+      Effect.gen(function* () {
+        const calls: string[] = [];
+        const resolved = yield* resolveWorkloadImage(
+          imageOptions(makeRegistryAdapter(calls), {
+            image: "registry.example.test/cache:v1",
+          }),
+        );
+        expect(calls).toEqual(["resolve"]);
+        expect(resolved.imageUri).toBe(
+          "managed.example.test/repository:latest",
+        );
+        expect(resolved.cleanupState).toBeUndefined();
+      }),
+    ),
+  );
+
+  it.effect(
+    "uses a pre-built image directly without invoking the registry",
+    () =>
+      provideAdapterLifecycle(
+        Effect.gen(function* () {
+          const calls: string[] = [];
+          const previous = {
+            kind: "aws-ecr",
+            repositoryName: "previous-repository",
+          };
+          const resolved = yield* resolveWorkloadImage({
+            ...imageOptions(makeRegistryAdapter(calls), {
+              image: "registry.example.test/cache@sha256:abc",
+            }),
+            imageStrategy: "direct",
+            state: previous,
+          });
+          expect(calls).toEqual([]);
+          expect(resolved.imageUri).toBe(
+            "registry.example.test/cache@sha256:abc",
+          );
+          expect(resolved.state).toBeUndefined();
+          expect(resolved.cleanupState).toEqual(previous);
+        }),
+      ),
+  );
+
+  it.effect("hashes direct images without invoking the managed registry", () =>
+    provideAdapterLifecycle(
+      Effect.gen(function* () {
+        const calls: string[] = [];
+        const hash = yield* workloadImageHash({
+          adapter: makeRegistryAdapter(calls),
+          source: {
+            image: "registry.example.test/cache:v2",
+          },
+          imageStrategy: "direct",
+          platform: "linux/amd64",
+          bootstrap: () => "",
+        });
+        expect(hash).toMatch(/^[a-f0-9]{16}$/);
+        expect(calls).toEqual([]);
+      }),
+    ),
+  );
+
+  it("recognizes only a fully completed Kubernetes rollout", () => {
+    const complete = {
+      metadata: { generation: 4 },
+      spec: { replicas: 2 },
+      status: {
+        observedGeneration: 4,
+        replicas: 2,
+        updatedReplicas: 2,
+        availableReplicas: 2,
+      },
+    };
+    expect(isDeploymentRolloutComplete(complete)).toBe(true);
+    expect(
+      isDeploymentRolloutComplete({
+        ...complete,
+        status: { ...complete.status, replicas: 3 },
+      }),
+    ).toBe(false);
+    expect(
+      isDeploymentRolloutComplete({
+        ...complete,
+        status: { ...complete.status, observedGeneration: 3 },
+      }),
+    ).toBe(false);
+  });
+});
 
 // Ungated probe: `Deployment` is a composite host (in-cluster
 // Deployment/Service plus adapter-owned cloud resources — ECR repo,


### PR DESCRIPTION
## What

Adds `imageStrategy?: "mirror" | "direct"` to `Kubernetes.Deployment`'s `ImageDeploymentProps`:

```ts
yield* Kubernetes.Deployment("api", {
  cluster,
  image: "europe-west4-docker.pkg.dev/my-project/apps/api@sha256:…",
  imageStrategy: "direct",
});
```

- `"mirror"` (**default**, unchanged behaviour) — the image is copied into the cluster adapter's managed registry (ECR on EKS) and the pod pulls the mirrored copy.
- `"direct"` — the supplied reference is used verbatim; the registry adapter is never invoked.

## Why

`Kubernetes.Deployment` currently routes *every* image source through the platform's managed registry whenever the adapter has one, including a pre-built `image` reference. Today the pass-through path only exists for registry-*less* clusters (`resolveWorkloadImage`'s `adapter.registry === undefined` branch).

That means an image that already lives in a registry the cluster can pull from — a repo-wide Artifact Registry, an internal Harbor, a public base image, an image built by a CI pipeline that already pushed it — gets mirrored purely to satisfy the API. The cost is a managed repository per deployment, a duplicate copy of every layer, and a pull/push of the whole image on each deploy. For large ML/CUDA images that is tens of gigabytes of pointless traffic and storage.

`"direct"` lets the caller say "the cluster can already pull this", and the deployment just references it.

## How it stays backwards-compatible

- The prop is optional and defaults to `"mirror"`, so the resolved image, hash, and persisted registry state of every existing deployment are byte-identical.
- It is only accepted on `ImageDeploymentProps`. `main` / `context` sources are unchanged and still require a managed registry — a `@ts-expect-error` test pins that.
- The registry-less-cluster pass-through path is untouched.

### Retiring the old repository on a mirror → direct switch

Flipping an existing deployment to `"direct"` orphans the managed repository it used to own. `resolveWorkloadImage` therefore returns the previous registry state as `cleanupState`, and the reconciler deletes it **after** `waitForDeploymentRollout` confirms the new pods are up — so the mirrored image stays pullable until nothing references it. `diff` returns `action: "update"` with `registry` removed from `stables` for that transition, since registry ownership legitimately changes.

`isDeploymentRolloutComplete` implements Kubernetes' completed-rollout conditions (`observedGeneration >= generation` and `replicas == updatedReplicas == availableReplicas == spec.replicas`) and is exported so it can be unit-tested without a cluster.

## Tests

`packages/alchemy/test/Kubernetes/Deployment.test.ts`, using a fake `ClusterAdapterService` whose registry records every call:

- **mirrors pre-built images by default** — no `imageStrategy` ⇒ `registry.resolve` is called and its `imageUri` wins; `cleanupState` is `undefined`.
- **uses a pre-built image directly without invoking the registry** — `"direct"` ⇒ zero registry calls, `imageUri` is the supplied reference, `state` is `undefined`, and the previously persisted registry state comes back as `cleanupState`.
- **hashes direct images without invoking the managed registry** — the plan-time `workloadImageHash` path also bypasses `registry.hash`.
- **recognizes only a fully completed Kubernetes rollout** — `isDeploymentRolloutComplete` against complete, under-replicated, and stale-generation statuses.
- A compile-time surface check asserting `imageStrategy` is accepted on `ImageDeploymentProps` and rejected on `BundledDeploymentProps`.

```
$ cd packages/alchemy && bun alchemy-test test/Kubernetes/
Tests: 0 failed | 17 passed | 2 skipped (5 files)
```
(the 2 skipped are the pre-existing live-AWS E2E cases)

```
$ bun tsc -b packages/alchemy/tsconfig.test.json
```
No new diagnostics — the single remaining error (`AWS/DynamoDB/Table.ts:779`) reproduces identically on `main` at `bee6451a2`.

`bunx oxfmt --check packages/alchemy/{src,test}/Kubernetes` is clean.

## Follow-up (not in this PR)

`Kubernetes.Job` shares `resolveWorkloadImage` / `workloadImageHash` and has the same `ImageJobProps` shape, so the same option is a natural extension there. It is left out here because a Job has no rollout to gate the old-repository cleanup on, and that deserves its own decision. The plumbing in `internal/workload.ts` is platform-neutral and ready for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
