### PR TITLE
fix(bundle): make zipCode archives deterministic

### DIFF
--- a/packages/alchemy/src/Util/zip.ts
+++ b/packages/alchemy/src/Util/zip.ts
@@ -1,4 +1,5 @@
 import * as Effect from "effect/Effect";
+import type JSZip from "jszip";
 
 export interface ZipFile {
   path: string;
@@ -10,28 +11,46 @@ export interface ZipFile {
   mode?: number;
 }
 
+const archiveDate = new Date("1980-01-01T00:00:00.000Z");
+
+/**
+ * Generate the archive bytes deterministically. Nested paths make JSZip
+ * synthesize the intermediate folder entries, and those are stamped with
+ * `new Date()` rather than the per-file date the entries were added with.
+ * Left alone, two archives built from identical bytes seconds apart differ —
+ * which reads downstream as a content change.
+ */
+const generateDeterministic = (zip: JSZip) =>
+  Effect.gen(function* () {
+    yield* Effect.sync(() => {
+      for (const entry of Object.values(zip.files)) {
+        entry.date = archiveDate;
+      }
+    });
+    return yield* Effect.promise(() =>
+      zip.generateAsync({
+        type: "nodebuffer",
+        compression: "DEFLATE",
+        platform: "UNIX",
+      }),
+    );
+  });
+
 export const zipCode = Effect.fn(function* (
   content: string | Uint8Array<ArrayBufferLike>,
   files?: ReadonlyArray<ZipFile>,
 ) {
   // Create a zip buffer in memory
   const zip = new (yield* Effect.promise(() => import("jszip"))).default();
-  const date = new Date("1980-01-01T00:00:00.000Z");
-  zip.file("index.mjs", content, { date });
+  zip.file("index.mjs", content, { date: archiveDate });
   for (const file of files ?? []) {
     zip.file(file.path, file.content, {
-      date,
+      date: archiveDate,
       unixPermissions: file.mode,
     });
   }
 
-  return yield* Effect.promise(() =>
-    zip.generateAsync({
-      type: "nodebuffer",
-      compression: "DEFLATE",
-      platform: "UNIX",
-    }),
-  );
+  return yield* generateDeterministic(zip);
 });
 
 /**
@@ -42,28 +61,12 @@ export const zipCode = Effect.fn(function* (
 export const zipFiles = Effect.fn(function* (files: ReadonlyArray<ZipFile>) {
   // Create a zip buffer in memory
   const zip = new (yield* Effect.promise(() => import("jszip"))).default();
-  const date = new Date("1980-01-01T00:00:00.000Z");
   for (const file of [...files].sort((a, b) => (a.path < b.path ? -1 : 1))) {
     zip.file(file.path, file.content, {
-      date,
+      date: archiveDate,
       unixPermissions: file.mode,
     });
   }
-  // Nested paths make JSZip synthesize the intermediate folder entries, and
-  // those are stamped with `new Date()` rather than the per-file `date`
-  // above. Left alone, two archives built from identical bytes seconds apart
-  // differ — which reads downstream as a content change.
-  yield* Effect.sync(() => {
-    for (const entry of Object.values(zip.files)) {
-      entry.date = date;
-    }
-  });
 
-  return yield* Effect.promise(() =>
-    zip.generateAsync({
-      type: "nodebuffer",
-      compression: "DEFLATE",
-      platform: "UNIX",
-    }),
-  );
+  return yield* generateDeterministic(zip);
 });

--- a/packages/alchemy/test/zip.test.ts
+++ b/packages/alchemy/test/zip.test.ts
@@ -21,3 +21,29 @@ test("zipCode is deterministic for identical inputs", async () => {
   await new Promise((resolve) => setTimeout(resolve, 1100));
   expect(await hash()).toBe(first);
 });
+
+// Nested paths make JSZip synthesize intermediate folder entries; those must
+// carry the fixed archive date or the bytes differ across builds.
+test("zipCode is deterministic for nested package paths", async () => {
+  const build = () =>
+    Effect.runPromise(
+      zipCode("export default 1", [
+        {
+          path: "node_modules/uuid/package.json",
+          content: JSON.stringify({ name: "uuid" }),
+        },
+      ]),
+    );
+
+  const first = await build();
+  const zip = await (await import("jszip")).default.loadAsync(first);
+  for (const entry of Object.values(zip.files)) {
+    expect(entry.date.toISOString()).toBe("1980-01-01T00:00:00.000Z");
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, 1100));
+  const second = await build();
+  expect(await Effect.runPromise(sha256(second))).toBe(
+    await Effect.runPromise(sha256(first)),
+  );
+});


### PR DESCRIPTION
`zipCode` archives with nested paths (Lambda `build.install` packages) were byte-different on every build: JSZip synthesizes the intermediate folder entries and stamps them with `new Date()` instead of the fixed archive date. `zipFiles` already normalized those entries; `zipCode` never got the fix, so every build churned the content-addressed S3 asset key (function diffs are driven by the install identity hash, so no spurious updates — just a fresh multi-MB asset upload per deploy).

```ts
// shared by zipCode and zipFiles before generateAsync
for (const entry of Object.values(zip.files)) {
  entry.date = archiveDate;
}
```

The existing determinism test only used a flat path, which is why it never caught this; added a nested-path case that pins both the entry dates and byte-equality across builds (verified red without the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
