### PR TITLE
feat(aws/website): Foldkit — client-only Vite SPAs on S3+CloudFront

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -586,6 +586,26 @@
         "typescript": "catalog:",
       },
     },
+    "examples/aws-website-foldkit": {
+      "name": "aws-website-foldkit",
+      "version": "0.0.0",
+      "dependencies": {
+        "effect": "catalog:",
+        "foldkit": "^0.137.0",
+      },
+      "devDependencies": {
+        "@alchemy.run/frontend-frameworks": "workspace:*",
+        "@distilled.cloud/aws": "catalog:",
+        "@effect/platform-node": "catalog:",
+        "@foldkit/vite-plugin": "^0.11.3",
+        "@tailwindcss/vite": "catalog:",
+        "@types/node": "^24.12.0",
+        "alchemy": "workspace:*",
+        "tailwindcss": "catalog:",
+        "typescript": "catalog:",
+        "vite": "catalog:",
+      },
+    },
     "examples/aws-website-nextjs": {
       "name": "aws-website-nextjs",
       "version": "0.0.0",
@@ -4246,6 +4266,8 @@
 
     "aws-website-astro": ["aws-website-astro@workspace:examples/aws-website-astro"],
 
+    "aws-website-foldkit": ["aws-website-foldkit@workspace:examples/aws-website-foldkit"],
+
     "aws-website-nextjs": ["aws-website-nextjs@workspace:examples/aws-website-nextjs"],
 
     "aws-website-nuxt": ["aws-website-nuxt@workspace:examples/aws-website-nuxt"],
@@ -7228,6 +7250,8 @@
 
     "astro/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
+    "aws-website-foldkit/@types/node": ["@types/node@24.13.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q=="],
+
     "aws-website-nextjs/typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "aws-website-nuxt/@types/node": ["@types/node@24.13.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q=="],
@@ -8413,6 +8437,8 @@
     "astro/sharp/@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.35.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog=="],
 
     "astro/sharp/@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.35.2", "", { "os": "win32", "cpu": "x64" }, "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ=="],
+
+    "aws-website-foldkit/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "aws-website-nuxt/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 

--- a/examples/aws-website-foldkit/alchemy.run.ts
+++ b/examples/aws-website-foldkit/alchemy.run.ts
@@ -1,0 +1,30 @@
+import * as Alchemy from "alchemy";
+import * as AWS from "alchemy/AWS";
+import * as Effect from "effect/Effect";
+
+export default Alchemy.Stack(
+  "AwsWebsiteFoldkitExample",
+  {
+    providers: AWS.providers(),
+    state: AWS.state(),
+  },
+  Effect.gen(function* () {
+    const site = yield* AWS.Website.Foldkit("Foldkit", {
+      // Only hash the files that affect the build, so unchanged sources
+      // skip the Vite build (and the deploy) entirely.
+      memo: {
+        include: [
+          "src/**",
+          "index.html",
+          "package.json",
+          "vite.config.ts",
+        ],
+      },
+      forceDestroy: true,
+    });
+
+    return {
+      url: site.url,
+    };
+  }),
+);

--- a/examples/aws-website-foldkit/index.html
+++ b/examples/aws-website-foldkit/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Foldkit on AWS</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./src/entry.ts"></script>
+  </body>
+</html>

--- a/examples/aws-website-foldkit/package.json
+++ b/examples/aws-website-foldkit/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cloudflare-foldkit",
+  "name": "aws-website-foldkit",
   "version": "0.0.0",
   "private": true,
   "type": "module",
@@ -16,6 +16,9 @@
     "foldkit": "^0.137.0"
   },
   "devDependencies": {
+    "@alchemy.run/frontend-frameworks": "workspace:*",
+    "@distilled.cloud/aws": "catalog:",
+    "@effect/platform-node": "catalog:",
     "@foldkit/vite-plugin": "^0.11.3",
     "@tailwindcss/vite": "catalog:",
     "@types/node": "^24.12.0",
@@ -27,6 +30,6 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/alchemy-run/alchemy.git",
-    "directory": "examples/cloudflare-foldkit"
+    "directory": "examples/aws-website-foldkit"
   }
 }

--- a/examples/aws-website-foldkit/src/entry.ts
+++ b/examples/aws-website-foldkit/src/entry.ts
@@ -1,0 +1,15 @@
+import "./styles.css";
+
+import { Runtime } from "foldkit";
+
+import { init, Message, Model, update, view } from "./main.ts";
+
+const application = Runtime.makeApplication({
+  Model,
+  init,
+  update,
+  view,
+  container: document.getElementById("root"),
+});
+
+Runtime.run(application);

--- a/examples/aws-website-foldkit/src/main.ts
+++ b/examples/aws-website-foldkit/src/main.ts
@@ -1,0 +1,83 @@
+import { Match as M, Schema as S } from "effect";
+import { Command, Runtime } from "foldkit";
+import type { Document, HtmlBuilder } from "foldkit/html";
+import { m } from "foldkit/message";
+
+// MODEL
+
+export const Model = S.Struct({ count: S.Number });
+export type Model = typeof Model.Type;
+
+// MESSAGE
+
+export const ClickedDecrement = m("ClickedDecrement");
+export const ClickedIncrement = m("ClickedIncrement");
+export const ClickedReset = m("ClickedReset");
+
+export const Message = S.Union([
+  ClickedDecrement,
+  ClickedIncrement,
+  ClickedReset,
+]);
+export type Message = typeof Message.Type;
+
+// UPDATE
+
+export const update = (
+  model: Model,
+  message: Message,
+): readonly [Model, ReadonlyArray<Command.Command<Message>>] =>
+  M.value(message).pipe(
+    M.withReturnType<
+      readonly [Model, ReadonlyArray<Command.Command<Message>>]
+    >(),
+    M.tagsExhaustive({
+      ClickedDecrement: () => [{ count: model.count - 1 }, []],
+      ClickedIncrement: () => [{ count: model.count + 1 }, []],
+      ClickedReset: () => [{ count: 0 }, []],
+    }),
+  );
+
+// INIT
+
+export const init: Runtime.ApplicationInit<Model, Message> = () => [
+  { count: 0 },
+  [],
+];
+
+// VIEW
+
+const buttonClass =
+  "rounded-lg bg-slate-800 px-4 py-2 font-semibold text-white hover:bg-slate-700";
+
+export const view = (model: Model, h: HtmlBuilder<Message>): Document => ({
+  title: `Counter: ${model.count}`,
+  body: h.div(
+    [
+      h.Id("app"),
+      h.Class(
+        "flex min-h-screen flex-col items-center justify-center gap-6 bg-slate-100",
+      ),
+    ],
+    [
+      h.p(
+        [h.Id("count"), h.Class("text-3xl font-bold text-slate-900")],
+        [model.count.toString()],
+      ),
+      h.div(
+        [h.Class("flex gap-3")],
+        [
+          h.button(
+            [h.OnClick(ClickedDecrement()), h.Class(buttonClass)],
+            ["-"],
+          ),
+          h.button([h.OnClick(ClickedReset()), h.Class(buttonClass)], ["Reset"]),
+          h.button(
+            [h.OnClick(ClickedIncrement()), h.Class(buttonClass)],
+            ["+"],
+          ),
+        ],
+      ),
+    ],
+  ),
+});

--- a/examples/aws-website-foldkit/src/styles.css
+++ b/examples/aws-website-foldkit/src/styles.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/examples/aws-website-foldkit/test/dev.test.ts
+++ b/examples/aws-website-foldkit/test/dev.test.ts
@@ -1,0 +1,195 @@
+/**
+ * True `alchemy dev` end-to-end for the Foldkit site on AWS: spawns the
+ * REAL CLI (mirroring examples/aws-dev/test/dev.test.ts), which runs
+ * Vite's own dev server as the local `Website.Server` provider — no
+ * Lambda, no CloudFront, no S3; the only cloud touch is the state store.
+ *
+ * Coverage:
+ *   - stack output    → `url` is a local dev-server address (port is
+ *                       whatever Vite bound — never hard-coded)
+ *   - index HTML      → `/` serves the app shell (client-only SPA)
+ *   - SPA routing     → deep links serve the app shell
+ *   - HOT RELOAD      → editing index.html is served by Vite's HMR
+ *                       without a redeploy
+ */
+import { afterAll, expect, test } from "bun:test";
+import { spawn, spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const root = path.resolve(import.meta.dirname, "..");
+// Spawn the CLI entry directly (not through `bun run` / the cli.js
+// launcher) so signals hit the actual CLI process, whose scope teardown
+// kills the dev server and the provider sidecars.
+const alchemyBin = path.join(
+  root,
+  "node_modules",
+  "alchemy",
+  "bin",
+  "alchemy.ts",
+);
+// Isolated stage so this suite never fights integ.test.ts (same stack
+// name) over state rows.
+const STAGE = "dev-cli-test";
+
+// Hot-reload surface: the app shell. The test rewrites it in place with
+// the CLI running, then restores it.
+const pagePath = path.join(root, "index.html");
+const pageSource = fs.readFileSync(pagePath, "utf8");
+const MARKER = "Foldkit on AWS";
+const MARKER_V2 = "Foldkit on AWS [dev-v2]";
+
+let proc: ReturnType<typeof spawn> | undefined;
+let output = "";
+
+const pump = (stream: NodeJS.ReadableStream) => {
+  stream.on("data", (chunk: Buffer) => {
+    const text = chunk.toString();
+    output += text;
+    if (process.env.DEBUG) process.stderr.write(text);
+  });
+};
+
+/** Bounded poll for a (possibly async) producer to yield a value. */
+const pollUntil = async <T>(
+  what: string,
+  f: () => T | undefined | Promise<T | undefined>,
+  { tries = 30, delayMs = 1000 }: { tries?: number; delayMs?: number } = {},
+): Promise<T> => {
+  for (let i = 0; i < tries; i++) {
+    const value = await f();
+    if (value !== undefined) return value;
+    await Bun.sleep(delayMs);
+  }
+  throw new Error(
+    `Timed out waiting for ${what}.\n--- alchemy dev output (tail) ---\n${output.slice(-4000)}`,
+  );
+};
+
+/** Fetch with retries — the dev server takes a moment to start serving. */
+const fetchOk = async (
+  url: string | URL,
+  { tries = 30, delayMs = 1000 }: { tries?: number; delayMs?: number } = {},
+) => {
+  let last: Response | undefined;
+  for (let i = 0; i < tries; i++) {
+    try {
+      last = await fetch(url);
+      if (last.ok) return last;
+    } catch {
+      // dev server not listening yet
+    }
+    await Bun.sleep(delayMs);
+  }
+  throw new Error(
+    `GET ${url} never returned 2xx (last status: ${last?.status})`,
+  );
+};
+
+/** Extract the stack-output URL the CLI prints on stdout. */
+const outputUrl = () =>
+  output.match(/\burl:\s*['"]?(http[^\s'",]+)/)?.[1];
+
+afterAll(async () => {
+  // Always leave the repo tree clean, even on a mid-reload failure.
+  fs.writeFileSync(pagePath, pageSource);
+
+  if (proc?.pid) {
+    // Ctrl-C semantics: signal the whole PROCESS GROUP (the CLI, its
+    // `--watch` exec child, and the provider sidecars).
+    const killGroup = (signal: NodeJS.Signals) => {
+      try {
+        process.kill(-proc!.pid!, signal);
+      } catch {
+        // group already gone
+      }
+    };
+    const exited = new Promise((resolve) => proc!.once("exit", resolve));
+    killGroup("SIGINT");
+    await Promise.race([exited, Bun.sleep(15_000)]);
+    if (proc.exitCode === null && proc.signalCode === null) {
+      killGroup("SIGKILL");
+      await Promise.race([exited, Bun.sleep(5_000)]);
+    }
+  }
+  if (!process.env.NO_DESTROY) {
+    spawnSync("bun", [alchemyBin, "destroy", "--stage", STAGE, "--yes"], {
+      cwd: root,
+      stdio: "inherit",
+      timeout: 120_000,
+    });
+  }
+}, 180_000);
+
+test(
+  "alchemy dev serves the Foldkit site locally with hot reload",
+  async () => {
+    proc = spawn("bun", [alchemyBin, "dev", "--stage", STAGE], {
+      cwd: root,
+      // Own process group, so teardown can deliver Ctrl-C to the whole
+      // tree the way a terminal would.
+      detached: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    pump(proc.stdout!);
+    pump(proc.stderr!);
+
+    const url = await pollUntil("url in stack outputs", outputUrl, {
+      tries: 180,
+      delayMs: 1000,
+    });
+
+    // Dev identity: Vite's dev server, not CloudFront. The port is
+    // whatever Vite bound — only the URL captured from the CLI's stdout
+    // is authoritative.
+    expect(new URL(url).hostname).toBe("localhost");
+    expect(url).not.toContain("cloudfront.net");
+
+    // The app shell serves (client-only SPA — markup renders in the
+    // browser, so assert on the shell).
+    const home = await (await fetchOk(url)).text();
+    expect(home).toContain(MARKER);
+    expect(home).toContain('<div id="root">');
+
+    // Deep links serve the app shell too (client-side routing).
+    const deep = await (await fetchOk(new URL("/some/deep/link", url))).text();
+    expect(deep).toContain('<div id="root">');
+
+    // ── HOT RELOAD: rewrite the app shell with the CLI still running —
+    // Vite serves the new markup without a deploy ──
+    fs.writeFileSync(pagePath, pageSource.replace(MARKER, MARKER_V2));
+    await pollUntil(
+      "hot-reloaded page (v2 marker)",
+      async () => {
+        try {
+          const res = await fetch(url);
+          if (!res.ok) return undefined;
+          const html = await res.text();
+          return html.includes(MARKER_V2) ? true : undefined;
+        } catch {
+          return undefined; // mid-reload
+        }
+      },
+      { tries: 120, delayMs: 500 },
+    );
+
+    // Restore — the swap back is itself a second hot reload and leaves
+    // the checked-in tree clean.
+    fs.writeFileSync(pagePath, pageSource);
+    await pollUntil(
+      "restored page (v2 marker gone)",
+      async () => {
+        try {
+          const res = await fetch(url);
+          if (!res.ok) return undefined;
+          const html = await res.text();
+          return html.includes(MARKER_V2) ? undefined : true;
+        } catch {
+          return undefined; // mid-reload
+        }
+      },
+      { tries: 120, delayMs: 500 },
+    );
+  },
+  { timeout: 600_000 },
+);

--- a/examples/aws-website-foldkit/test/integ.test.ts
+++ b/examples/aws-website-foldkit/test/integ.test.ts
@@ -1,0 +1,122 @@
+import * as AWS from "alchemy/AWS";
+import * as Test from "alchemy/Test/Bun";
+import { expect } from "bun:test";
+import * as Console from "effect/Console";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
+import Stack from "../alchemy.run.ts";
+
+// A fresh CloudFront distribution can serve transient 404/5xx responses
+// while it propagates. `Test.getWhenReady` fails on that cold-start window
+// and retries until the site serves a real response.
+const { getWhenReady } = Test;
+
+class AssetNotReady extends Data.TaggedError("AssetNotReady")<{
+  body: string;
+}> {}
+
+// While the asset manifest and CloudFront edge caches are still
+// propagating, a 200 body can be stale — the status alone can't
+// distinguish "not yet" from "served", so retry until the body matches.
+const getBodyWhenReady = (url: string, expected: string) =>
+  Effect.gen(function* () {
+    const res = yield* getWhenReady(url);
+    expect(res.status).toBe(200);
+    const body = yield* res.text;
+    if (!body.includes(expected)) {
+      return yield* Effect.fail(new AssetNotReady({ body }));
+    }
+    return body;
+  }).pipe(
+    Effect.retry({
+      while: (error) => error instanceof AssetNotReady,
+      schedule: Schedule.max([
+        Schedule.min([
+          Schedule.exponential("500 millis"),
+          Schedule.spaced("3 seconds"),
+        ]),
+        Schedule.recurs(20),
+      ]),
+    }),
+  );
+
+const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
+  providers: AWS.providers(),
+  state: AWS.state(),
+  stage: "test",
+});
+
+// The first deploy runs the Vite build AND creates a CloudFront
+// distribution (~5-10 minutes), so give the hook far more headroom than
+// the default 120s.
+const stack = beforeAll(deploy(Stack).pipe(Effect.tap(Console.log)), {
+  timeout: 1_200_000,
+});
+// Deleting the CloudFront distribution takes several minutes too.
+afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(Stack), {
+  timeout: 1_200_000,
+});
+
+const base = Effect.map(stack, ({ url }) => {
+  if (!url) throw new Error("expected the site to expose a CloudFront url");
+  return String(url).replace(/\/+$/, "");
+});
+
+test(
+  "deploys and exposes a url",
+  Effect.gen(function* () {
+    const { url } = yield* stack;
+    expect(url).toBeString();
+  }),
+  { timeout: 180_000 },
+);
+
+test(
+  "serves the index HTML",
+  Effect.gen(function* () {
+    const url = yield* base;
+    const html = yield* getBodyWhenReady(url, '<div id="root">');
+    expect(html).toContain("Foldkit on AWS");
+  }),
+  { timeout: 180_000 },
+);
+
+test(
+  "serves the index page for deep links (SPA routing)",
+  Effect.gen(function* () {
+    const url = yield* base;
+    // Foldkit routes on the client: an unmatched path must serve
+    // index.html with a 200 so the app boots and its router takes over.
+    const html = yield* getBodyWhenReady(
+      `${url}/some/deep/link`,
+      '<div id="root">',
+    );
+    expect(html).toContain("Foldkit on AWS");
+  }),
+  { timeout: 180_000 },
+);
+
+test(
+  "compiles tailwind from vite.config.ts",
+  Effect.gen(function* () {
+    const url = yield* base;
+    // Foldkit is a client-only SPA — the markup renders in the browser, so
+    // assert on the compiled stylesheet Vite links from index.html instead
+    // of SSR output.
+    const html = yield* getBodyWhenReady(url, "stylesheet");
+    const link = html.match(
+      /<link[^>]*rel="stylesheet"[^>]*href="([^"]+)"[^>]*>/,
+    );
+    expect(link).not.toBeNull();
+    const href = link![1]!;
+    const cssUrl = href.startsWith("http")
+      ? href
+      : `${url}${href.startsWith("/") ? "" : "/"}${href}`;
+    // The compiled rule for a utility used in src/main.ts only exists if the
+    // @tailwindcss/vite plugin from the project's own vite.config.ts ran.
+    const css = yield* getBodyWhenReady(cssUrl, ".text-3xl");
+    expect(css).toContain(".text-3xl");
+  }),
+  { timeout: 180_000 },
+);

--- a/examples/aws-website-foldkit/tsconfig.json
+++ b/examples/aws-website-foldkit/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["alchemy.run.ts", "vite.config.ts", "src", "test"],
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "module": "Preserve",
+    "moduleResolution": "Bundler",
+    "target": "ESNext",
+    "lib": ["ESNext", "DOM"]
+  }
+}

--- a/examples/aws-website-foldkit/vite.config.ts
+++ b/examples/aws-website-foldkit/vite.config.ts
@@ -1,0 +1,10 @@
+import { foldkit } from "@foldkit/vite-plugin";
+import tailwindcss from "@tailwindcss/vite";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [foldkit(), tailwindcss()],
+  optimizeDeps: {
+    entries: ["src/entry.ts"],
+  },
+});

--- a/examples/cloudflare-foldkit/test/dev.test.ts
+++ b/examples/cloudflare-foldkit/test/dev.test.ts
@@ -1,0 +1,191 @@
+/**
+ * True `alchemy dev` end-to-end for the Foldkit site on Cloudflare: spawns
+ * the REAL CLI (mirroring examples/cloudflare-dev/test/dev.test.ts). The
+ * worker's Vite source runs `vite createServer` with the injected
+ * Cloudflare plugin (workerd inside the Vite pipeline) behind the stable
+ * WorkerProxy URL — native Vite HMR, no deploy.
+ *
+ * Coverage:
+ *   - stack output    → `url` is the local WorkerProxy address (port is
+ *                       whatever was bound — never hard-coded)
+ *   - index HTML      → `/` serves the app shell (client-only SPA)
+ *   - HOT RELOAD      → editing index.html is served by Vite's HMR
+ *                       without a redeploy
+ */
+import { afterAll, expect, test } from "bun:test";
+import { spawn, spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const root = path.resolve(import.meta.dirname, "..");
+// Spawn the CLI entry directly (not through `bun run` / the cli.js
+// launcher) so signals hit the actual CLI process, whose scope teardown
+// kills the vite child and the provider sidecars.
+const alchemyBin = path.join(
+  root,
+  "node_modules",
+  "alchemy",
+  "bin",
+  "alchemy.ts",
+);
+// Isolated stage so this suite never fights integ.test.ts (same stack
+// name) over state rows.
+const STAGE = "dev-cli-test";
+
+// Hot-reload surface: the app shell. The test rewrites it in place with
+// the CLI running, then restores it.
+const pagePath = path.join(root, "index.html");
+const pageSource = fs.readFileSync(pagePath, "utf8");
+const MARKER = "Foldkit on Cloudflare";
+const MARKER_V2 = "Foldkit on Cloudflare [dev-v2]";
+
+let proc: ReturnType<typeof spawn> | undefined;
+let output = "";
+
+const pump = (stream: NodeJS.ReadableStream) => {
+  stream.on("data", (chunk: Buffer) => {
+    const text = chunk.toString();
+    output += text;
+    if (process.env.DEBUG) process.stderr.write(text);
+  });
+};
+
+/** Bounded poll for a (possibly async) producer to yield a value. */
+const pollUntil = async <T>(
+  what: string,
+  f: () => T | undefined | Promise<T | undefined>,
+  { tries = 30, delayMs = 1000 }: { tries?: number; delayMs?: number } = {},
+): Promise<T> => {
+  for (let i = 0; i < tries; i++) {
+    const value = await f();
+    if (value !== undefined) return value;
+    await Bun.sleep(delayMs);
+  }
+  throw new Error(
+    `Timed out waiting for ${what}.\n--- alchemy dev output (tail) ---\n${output.slice(-4000)}`,
+  );
+};
+
+/** Fetch with retries — fresh workerd takes a moment to start serving. */
+const fetchOk = async (
+  url: string | URL,
+  { tries = 30, delayMs = 1000 }: { tries?: number; delayMs?: number } = {},
+) => {
+  let last: Response | undefined;
+  for (let i = 0; i < tries; i++) {
+    try {
+      last = await fetch(url);
+      if (last.ok) return last;
+    } catch {
+      // proxy not listening yet
+    }
+    await Bun.sleep(delayMs);
+  }
+  throw new Error(
+    `GET ${url} never returned 2xx (last status: ${last?.status})`,
+  );
+};
+
+/** Extract the stack-output URL the CLI prints on stdout. */
+const outputUrl = () =>
+  output.match(/\burl:\s*['"]?(http[^\s'",]+)/)?.[1];
+
+afterAll(async () => {
+  // Always leave the repo tree clean, even on a mid-reload failure.
+  fs.writeFileSync(pagePath, pageSource);
+
+  if (proc?.pid) {
+    // Ctrl-C semantics: signal the whole PROCESS GROUP (the CLI, its
+    // `--watch` exec child, and the provider sidecars).
+    const killGroup = (signal: NodeJS.Signals) => {
+      try {
+        process.kill(-proc!.pid!, signal);
+      } catch {
+        // group already gone
+      }
+    };
+    const exited = new Promise((resolve) => proc!.once("exit", resolve));
+    killGroup("SIGINT");
+    await Promise.race([exited, Bun.sleep(15_000)]);
+    if (proc.exitCode === null && proc.signalCode === null) {
+      killGroup("SIGKILL");
+      await Promise.race([exited, Bun.sleep(5_000)]);
+    }
+  }
+  if (!process.env.NO_DESTROY) {
+    spawnSync("bun", [alchemyBin, "destroy", "--stage", STAGE, "--yes"], {
+      cwd: root,
+      stdio: "inherit",
+      timeout: 120_000,
+    });
+  }
+}, 180_000);
+
+test(
+  "alchemy dev serves the Foldkit site locally with hot reload",
+  async () => {
+    proc = spawn("bun", [alchemyBin, "dev", "--stage", STAGE], {
+      cwd: root,
+      // Own process group, so teardown can deliver Ctrl-C to the whole
+      // tree the way a terminal would.
+      detached: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    pump(proc.stdout!);
+    pump(proc.stderr!);
+
+    const url = await pollUntil("url in stack outputs", outputUrl, {
+      tries: 180,
+      delayMs: 1000,
+    });
+
+    // Dev identity: the local WorkerProxy, not workers.dev. The port is
+    // whatever was bound — only the URL captured from the CLI's stdout is
+    // authoritative.
+    expect(new URL(url).hostname).toBe("localhost");
+    expect(url).not.toContain("workers.dev");
+
+    // The app shell serves through the vite pipeline (client-only SPA —
+    // markup renders in the browser, so assert on the shell).
+    const home = await (await fetchOk(url)).text();
+    expect(home).toContain(MARKER);
+    expect(home).toContain('<div id="root">');
+
+    // ── HOT RELOAD: rewrite the app shell with the CLI still running —
+    // Vite serves the new markup without a deploy ──
+    fs.writeFileSync(pagePath, pageSource.replace(MARKER, MARKER_V2));
+    await pollUntil(
+      "hot-reloaded page (v2 marker)",
+      async () => {
+        try {
+          const res = await fetch(url);
+          if (!res.ok) return undefined;
+          const html = await res.text();
+          return html.includes(MARKER_V2) ? true : undefined;
+        } catch {
+          return undefined; // mid-reload
+        }
+      },
+      { tries: 120, delayMs: 500 },
+    );
+
+    // Restore — the swap back is itself a second hot reload and leaves
+    // the checked-in tree clean.
+    fs.writeFileSync(pagePath, pageSource);
+    await pollUntil(
+      "restored page (v2 marker gone)",
+      async () => {
+        try {
+          const res = await fetch(url);
+          if (!res.ok) return undefined;
+          const html = await res.text();
+          return html.includes(MARKER_V2) ? undefined : true;
+        } catch {
+          return undefined; // mid-reload
+        }
+      },
+      { tries: 120, delayMs: 500 },
+    );
+  },
+  { timeout: 600_000 },
+);

--- a/packages/alchemy/src/AWS/Website/Foldkit.ts
+++ b/packages/alchemy/src/AWS/Website/Foldkit.ts
@@ -1,0 +1,113 @@
+import * as Namespace from "../../Namespace.ts";
+import { makeFrameworkSite, type FrameworkSiteProps } from "./FrameworkSite.ts";
+
+/** The framework-integration package that drives the client-only Vite build. */
+export const VITE_FRAMEWORK_SPECIFIER = "@alchemy.run/frontend-frameworks/vite";
+
+/** The AWS deploy target for the client-only Vite build. */
+export const VITE_AWS_TARGET_SPECIFIER =
+  "@alchemy.run/frontend-frameworks/vite/aws";
+
+export interface FoldkitProps extends FrameworkSiteProps {
+  /**
+   * Serve the built error page for requests that match no uploaded file
+   * instead of the SPA index fallback. Setting this implies `spa: false`
+   * unless `spa` is set explicitly.
+   */
+  errorPage?: string;
+  /**
+   * Answer misses with the index page (200) instead of a 404, so deep
+   * links boot the app and the Foldkit router takes over.
+   * @default true
+   */
+  spa?: boolean;
+}
+
+/**
+ * Deploy a [Foldkit](https://foldkit.dev) application to AWS: static
+ * assets in S3 behind a CloudFront distribution (or attached to a shared
+ * `AWS.Website.Router`).
+ *
+ * Foldkit apps are client-only Vite projects, so `Foldkit` drives the
+ * project's own `vite build` — the Foldkit Vite plugin in the app's
+ * `vite.config.ts` runs as-is — and deploys the client output as static
+ * assets. No server function is created; the deployment is assets-only.
+ *
+ * The build runs through `@alchemy.run/frontend-frameworks/vite` (the
+ * client-only Vite integration) — the package must be installed in your
+ * project.
+ *
+ * Foldkit apps route on the client, so unmatched paths serve `index.html`
+ * by default (`spa: true`) and the Foldkit router takes over.
+ *
+ * During `alchemy dev` the site is Vite's own dev server (native HMR) and
+ * no cloud resources are declared; `Alchemy.remote()` opts back into the
+ * full live deployment.
+ *
+ * @resource
+ * @section Deploying a Foldkit App
+ * A single call builds the project and deploys the client output as
+ * static assets — no configuration required.
+ *
+ * @example Foldkit app
+ * ```typescript
+ * const site = yield* AWS.Website.Foldkit("Website");
+ * ```
+ *
+ * @example Foldkit project in a subdirectory
+ * ```typescript
+ * const site = yield* AWS.Website.Foldkit("Website", {
+ *   rootDir: "applications/web",
+ * });
+ * ```
+ *
+ * @section Custom Domain
+ * @example Serve the site at a Route 53 domain
+ * ```typescript
+ * const site = yield* AWS.Website.Foldkit("Website", {
+ *   domain: {
+ *     name: "app.example.com",
+ *     hostedZoneId: zone.hostedZoneId,
+ *   },
+ * });
+ * ```
+ *
+ * @section Single-Page Application Routing
+ * Unmatched paths serve `index.html` by default so deep links boot the
+ * app and the Foldkit router resolves the route. A site that ships real
+ * 404 content can opt out.
+ *
+ * @example Serving a real 404 page
+ * ```typescript
+ * const site = yield* AWS.Website.Foldkit("Website", {
+ *   spa: false,
+ *   errorPage: "404.html",
+ * });
+ * ```
+ *
+ * @section Custom Rebuild Scope
+ * By default, every non-gitignored file is hashed to decide whether a
+ * rebuild is needed. Use `memo` to narrow the scope when your project
+ * has large directories that don't affect the build output.
+ *
+ * @example Narrowing the memo scope
+ * ```typescript
+ * const site = yield* AWS.Website.Foldkit("Website", {
+ *   memo: {
+ *     include: ["src/**", "public/**", "index.html", "package.json"],
+ *   },
+ * });
+ * ```
+ */
+export const Foldkit = (id: string, props: FoldkitProps = {}) =>
+  makeFrameworkSite(id, props, {
+    name: "Foldkit",
+    framework: VITE_FRAMEWORK_SPECIFIER,
+    target: VITE_AWS_TARGET_SPECIFIER,
+    // Assets-only: a Foldkit build produces no server code. SPA fallback
+    // is the default (client-side router); an explicit errorPage opts out.
+    static: {
+      spa: props.spa ?? props.errorPage === undefined,
+      errorPage: props.errorPage,
+    },
+  }).pipe(Namespace.push(id));

--- a/packages/alchemy/src/AWS/Website/index.ts
+++ b/packages/alchemy/src/AWS/Website/index.ts
@@ -1,5 +1,6 @@
 export * from "./AssetDeployment.ts";
 export * from "./Astro.ts";
+export * from "./Foldkit.ts";
 export * from "./FrameworkSite.ts";
 export * from "./Nextjs.ts";
 export * from "./Nuxt.ts";

--- a/packages/frontend-frameworks/package.json
+++ b/packages/frontend-frameworks/package.json
@@ -272,6 +272,18 @@
       "worker": "./dist/sveltekit/source.js",
       "import": "./dist/sveltekit/source.js"
     },
+    "./vite": {
+      "types": "./dist/vite/index.d.ts",
+      "bun": "./dist/vite/index.js",
+      "worker": "./dist/vite/index.js",
+      "import": "./dist/vite/index.js"
+    },
+    "./vite/aws": {
+      "types": "./dist/vite/aws.d.ts",
+      "bun": "./dist/vite/aws.js",
+      "worker": "./dist/vite/aws.js",
+      "import": "./dist/vite/aws.js"
+    },
     "./waku": {
       "types": "./dist/waku/index.d.ts",
       "bun": "./dist/waku/index.js",

--- a/packages/frontend-frameworks/src/vite/Vite.ts
+++ b/packages/frontend-frameworks/src/vite/Vite.ts
@@ -1,0 +1,243 @@
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+import * as Schedule from "effect/Schedule";
+import * as FrameworkCore from "../core/index.ts";
+import {
+  Framework,
+  FrameworkError,
+  type DeployTarget,
+  type DeployTargetInput,
+} from "../core/index.ts";
+
+/** The structural slice of the project's `vite` module this package drives. */
+export interface ViteModule {
+  readonly version?: string;
+  readonly build: (config: Record<string, unknown>) => Promise<unknown>;
+  readonly resolveConfig: (
+    config: Record<string, unknown>,
+    command: "build" | "serve",
+  ) => Promise<ResolvedViteConfigSlice>;
+  readonly createServer: (
+    config: Record<string, unknown>,
+  ) => Promise<ViteDevServer>;
+}
+
+/** The structural slice of a resolved Vite config this package reads. */
+export interface ResolvedViteConfigSlice {
+  readonly root: string;
+  readonly build: { readonly outDir: string };
+}
+
+/** The structural slice of a Vite dev server this package reads. */
+export interface ViteDevServer {
+  readonly listen: () => Promise<unknown>;
+  readonly close: () => Promise<void>;
+  readonly resolvedUrls?:
+    | { readonly local: ReadonlyArray<string> }
+    | null
+    | undefined;
+}
+
+/**
+ * A deploy target for a client-only Vite build. The generic `DeployTarget`
+ * seams are all a static build needs — assets-only output has no
+ * platform-specific server code, so most targets are pure markers.
+ */
+export type ViteTargetInput = DeployTargetInput<DeployTarget, unknown>;
+
+export interface ViteFrameworkOptions {
+  /**
+   * Project root (the directory containing `vite.config.ts`).
+   * @default process.cwd()
+   */
+  readonly root?: string | undefined;
+  /**
+   * The deploy target the build is produced for. Accepts a target value, a
+   * `(config) => target` factory, or a module specifier string. Optional —
+   * a client-only build has no platform-specific output, so the target's
+   * only seams are the wholesale `build` takeover and the `finish` pass.
+   */
+  readonly target?: ViteTargetInput | undefined;
+  readonly dev?:
+    | {
+        /** Default dev-server port (overridden by `FrameworkDevOptions.port`). */
+        readonly port?: number | undefined;
+      }
+    | undefined;
+}
+
+const fail = (message: string, cause?: unknown) =>
+  new FrameworkError({ framework: "vite", message, cause });
+
+/**
+ * Build the `Framework` service implementation for a client-only Vite
+ * project (a plain SPA — [Foldkit](https://foldkit.dev) apps, vanilla Vite
+ * templates, anything whose production output is static files).
+ *
+ * - `build` drives the PROJECT's own Vite install programmatically: one
+ *   `vite build` with the project's own `vite.config.*` (plugins included)
+ *   is the whole pipeline. The `BuildOutput` is assets-only: the resolved
+ *   `build.outDir` becomes `clientDirectory` and `serverModules` is
+ *   `undefined` — no server code is produced or deployed.
+ * - `dev` runs Vite's own dev server programmatically (native HMR),
+ *   scoped — closing the Scope closes the server.
+ *
+ * This module is target-agnostic; a target (when provided) only
+ * contributes the generic `build` takeover / `finish` seams.
+ */
+export const make: (
+  options?: ViteFrameworkOptions,
+) => Effect.Effect<
+  Framework["Service"],
+  never,
+  FileSystem.FileSystem | Path.Path
+> = Effect.fnUntraced(function* (options?: ViteFrameworkOptions) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const baseRoot = options?.root ?? (yield* Effect.sync(() => process.cwd()));
+
+  const resolveTarget = (root: string) =>
+    options?.target === undefined
+      ? Effect.succeed(undefined)
+      : FrameworkCore.resolveDeployTarget<DeployTarget, unknown>(
+          root,
+          options.target,
+          {},
+        ).pipe(Effect.mapError((error) => fail(error.message, error.cause)));
+
+  const loadVite = (root: string) =>
+    FrameworkCore.loadProjectModule<ViteModule>(root, "vite").pipe(
+      Effect.mapError((error) =>
+        fail("Failed to load the project's Vite install", error.cause),
+      ),
+    );
+
+  const build: Framework["Service"]["build"] = Effect.fn(
+    function* (buildOptions) {
+      const root = buildOptions?.root ?? baseRoot;
+      const target = yield* resolveTarget(root);
+      const targetContext = { root, framework: "vite" };
+
+      // Wholesale build takeover (targets that own the entire pipeline).
+      if (target?.build !== undefined) {
+        return yield* target.build(targetContext).pipe(
+          Effect.mapError((error) => fail(error.message, error.cause)),
+          Effect.provideService(FileSystem.FileSystem, fs),
+          Effect.provideService(Path.Path, path),
+        );
+      }
+
+      // The project's own vite.config.* (plugins included) drives the
+      // entire production pipeline inside this one call.
+      const vite = yield* loadVite(root);
+      yield* Effect.tryPromise({
+        try: async () => await vite.build({ root, logLevel: "warn" }),
+        catch: (error) => fail("Failed to build", error),
+      });
+
+      // Read the resolved outDir from the project's own config rather than
+      // assuming `dist`.
+      const resolved = yield* Effect.tryPromise({
+        try: async () =>
+          await vite.resolveConfig({ root, logLevel: "warn" }, "build"),
+        catch: (error) =>
+          fail("Failed to resolve the project's Vite config", error),
+      });
+      const outDir = path.resolve(resolved.root, resolved.build.outDir);
+      if (!(yield* fs.exists(outDir).pipe(Effect.orElseSucceed(() => false)))) {
+        return yield* Effect.fail(
+          fail(`The Vite build produced no output directory at ${outDir}`),
+        );
+      }
+
+      const output: FrameworkCore.BuildOutput = {
+        distDirectory: outDir,
+        clientDirectory: outDir,
+        serverModules: undefined,
+        externalWorkspaces: new Set<string>(),
+      };
+
+      // The finishing-pass seam (none needed for a static build — the
+      // contract is honored for targets that do post-process).
+      return yield* FrameworkCore.applyDeployTargetFinish(
+        target,
+        output,
+        targetContext,
+      ).pipe(
+        Effect.mapError((error) => fail(error.message, error.cause)),
+        Effect.provideService(FileSystem.FileSystem, fs),
+        Effect.provideService(Path.Path, path),
+      );
+    },
+  );
+
+  const dev: Framework["Service"]["dev"] = Effect.fn(function* (devOptions) {
+    const root = devOptions?.root ?? baseRoot;
+    const vite = yield* loadVite(root);
+    // `port: 0` (true OS-assigned) on Vite >= 8.2.1, probed ephemeral port
+    // on older Vite — see `resolveViteDevPort`.
+    const port = yield* FrameworkCore.resolveViteDevPort(
+      vite.version,
+      devOptions?.port ?? options?.dev?.port,
+    );
+    const host = devOptions?.host;
+
+    const server = yield* Effect.acquireRelease(
+      Effect.tryPromise({
+        try: async () => {
+          const server = await vite.createServer({
+            root,
+            server: {
+              port,
+              ...(host !== undefined ? { host } : undefined),
+            },
+          });
+          await server.listen();
+          return server;
+        },
+        catch: (error) => fail("Failed to start the Vite dev server", error),
+      }),
+      (server) =>
+        Effect.promise(async () => {
+          try {
+            await server.close();
+          } catch {
+            // teardown is best-effort
+          }
+        }),
+    );
+
+    const url = server.resolvedUrls?.local[0];
+    if (url === undefined) {
+      return yield* Effect.fail(fail("Could not determine the dev server URL"));
+    }
+
+    // Bounded readiness probe: any HTTP response counts (vite serves
+    // lazily; we only need the listener to answer).
+    yield* Effect.tryPromise({
+      try: async () => {
+        const response = await fetch(url, { redirect: "manual" });
+        await response.arrayBuffer().catch(() => {});
+      },
+      catch: (error) => fail("The dev server did not become reachable", error),
+    }).pipe(
+      Effect.retry({ schedule: Schedule.spaced("250 millis"), times: 40 }),
+    );
+
+    return { url };
+  });
+
+  return Framework.of({ build, dev });
+});
+
+/**
+ * A `Layer` providing framework-core's `Framework` service for a client-only
+ * Vite project — the fully-typed entrypoint for `e2e.config.ts` (harness
+ * form 4) and alchemy's website composites.
+ */
+export const layer = (
+  options?: ViteFrameworkOptions,
+): Layer.Layer<Framework, never, FileSystem.FileSystem | Path.Path> =>
+  Layer.effect(Framework, make(options));

--- a/packages/frontend-frameworks/src/vite/aws.ts
+++ b/packages/frontend-frameworks/src/vite/aws.ts
@@ -1,0 +1,16 @@
+/**
+ * `@alchemy.run/frontend-frameworks/vite/aws` — the AWS deploy target for
+ * the client-only Vite integration.
+ *
+ * A client-only Vite build is assets-only: there is no server code to
+ * bundle, adapt, or post-process, so this target is a pure marker — the
+ * built output deploys as-is to S3 behind CloudFront
+ * (`AWS.Website.Foldkit` / `makeKvSite`).
+ */
+import { makeDeployTarget, type DeployTarget } from "../core/index.ts";
+
+/** Build the AWS deploy target for a client-only Vite build. */
+export const target = (config: unknown = {}): DeployTarget =>
+  makeDeployTarget({ platform: "aws", config });
+
+export default target;

--- a/packages/frontend-frameworks/src/vite/index.ts
+++ b/packages/frontend-frameworks/src/vite/index.ts
@@ -1,0 +1,42 @@
+/**
+ * `@alchemy.run/frontend-frameworks/vite` — client-only Vite integration
+ * implementing framework-core's `Framework` service: one `vite build` with
+ * the project's own `vite.config.*` is the whole pipeline, and the output
+ * is assets-only (no server modules). [Foldkit](https://foldkit.dev) apps
+ * and plain Vite SPAs deploy through this integration.
+ *
+ * The optional deploy target (e.g.
+ * `@alchemy.run/frontend-frameworks/vite/aws`) is a pure marker for static
+ * builds — only the generic `build` takeover / `finish` seams apply.
+ *
+ * The default export is the e2e-harness factory contract: a
+ * `(options) => Layer<Framework>` function. Use {@link layer} directly for
+ * the fully-typed path.
+ */
+import type * as FileSystem from "effect/FileSystem";
+import type * as Layer from "effect/Layer";
+import type * as Path from "effect/Path";
+import type { Framework } from "../core/index.ts";
+import { layer } from "./Vite.ts";
+
+export {
+  layer,
+  make,
+  type ResolvedViteConfigSlice,
+  type ViteDevServer,
+  type ViteFrameworkOptions,
+  type ViteModule,
+  type ViteTargetInput,
+} from "./Vite.ts";
+
+/**
+ * The e2e-harness factory contract
+ * (`framework: "@alchemy.run/frontend-frameworks/vite"` in `e2e.config.ts`).
+ */
+const factory = (): Layer.Layer<
+  Framework,
+  never,
+  FileSystem.FileSystem | Path.Path
+> => layer();
+
+export default factory;

--- a/packages/frontend-frameworks/tsdown.config.ts
+++ b/packages/frontend-frameworks/tsdown.config.ts
@@ -32,6 +32,8 @@ export default defineConfig([
       "octane/source": "src/octane/source.ts",
       "sveltekit/index": "src/sveltekit/index.ts",
       "sveltekit/aws": "src/sveltekit/aws.ts",
+      "vite/index": "src/vite/index.ts",
+      "vite/aws": "src/vite/aws.ts",
       "sveltekit/cloudflare": "src/sveltekit/cloudflare.ts",
       "sveltekit/source": "src/sveltekit/source.ts",
       "waku/index": "src/waku/index.ts",

--- a/scripts/test-examples.ts
+++ b/scripts/test-examples.ts
@@ -19,6 +19,7 @@ const examples = [
   "./examples/aws-ecs",
   "./examples/aws-lambda",
   "./examples/aws-website-astro",
+  "./examples/aws-website-foldkit",
   "./examples/aws-website-nextjs",
   "./examples/aws-website-nuxt",
   "./examples/aws-website-sveltekit",

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -852,8 +852,10 @@ export default defineConfig({
                   link: "/aws/frontend/websites",
                 },
                 { label: "Astro", link: "/aws/frontend/astro" },
+                { label: "Foldkit", link: "/aws/frontend/foldkit" },
                 { label: "Next.js", link: "/aws/frontend/nextjs" },
                 { label: "Nuxt", link: "/aws/frontend/nuxt" },
+                { label: "Octane", link: "/aws/frontend/octane" },
                 {
                   label: "Static sites",
                   link: "/aws/frontend/static-site",

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -145,7 +145,7 @@ A linear five-part walkthrough from zero to a tested, locally-developed, CI-depl
 - [Full-stack TanStack Start + RPC + Drizzle](https://alchemy.run/cloudflare/frontend/full-stack-tanstack-rpc-drizzle) — Build a reactive full-stack app on Cloudflare — a TanStack Start UI that drives an Effect RPC backend over Drizzle and Neon Postgres, with browser state wired through Effect 4's native atom RPC.
 - [React Router](https://alchemy.run/cloudflare/frontend/react-router) — Deploy React Router v7 — including React Server Components — to Cloudflare with Cloudflare.Website.Vite and viteEnvironments.
 - [Vue](https://alchemy.run/cloudflare/frontend/vue) — Deploy a Vue single-page app to Cloudflare with the Vite resource — one declaration, no Wrangler config.
-- [Foldkit](https://alchemy.run/cloudflare/frontend/foldkit) — Deploy a Foldkit app to Cloudflare with the Vite resource — one declaration, no Wrangler config.
+- [Foldkit](https://alchemy.run/cloudflare/frontend/foldkit) — Deploy a Foldkit app to Cloudflare with the Foldkit resource — one declaration, no Wrangler config.
 - [SolidStart](https://alchemy.run/cloudflare/frontend/solidstart) — Deploy SolidStart to Cloudflare with Cloudflare.Website.Vite — plus the hand-rolled SolidJS SSR variant for full control over the server entry.
 - [Astro](https://alchemy.run/cloudflare/frontend/astro) — Deploy an Astro site to Cloudflare Workers with Cloudflare.Website.Astro — SSR in the Worker, prerendered pages as static assets, sessions backed by an auto-provisioned KV namespace.
 - [Next.js](https://alchemy.run/cloudflare/frontend/nextjs) — Deploy a Next.js app to Cloudflare Workers with Cloudflare.Website.Nextjs — the OpenNext pipeline, writable ISR, and wrangler-free local dev.
@@ -239,8 +239,15 @@ A linear five-part walkthrough from zero to a tested, CI-deployed AWS project. E
 
 ## AWS — Frontend
 
-- [Deploy a static site](https://alchemy.run/aws/frontend/static-site) — Ship a static site to S3 + CloudFront with AWS.Website.StaticSite — build-step support, Router composition, and cache invalidation on deploy.
-- [Websites](https://alchemy.run/aws/frontend/websites) — Deploy static sites and Vite apps to S3 and CloudFront as a single StaticSite resource.
+- [Websites](https://alchemy.run/aws/frontend/websites) — Deploy Astro, Next.js, Nuxt, SvelteKit, Waku, Octane, Foldkit, or any static build to AWS with first-class Website resources.
+- [Static sites](https://alchemy.run/aws/frontend/static-site) — Ship a static site to S3 + CloudFront with AWS.Website.StaticSite — build-step support, Router composition, and cache invalidation on deploy.
+- [Next.js](https://alchemy.run/aws/frontend/nextjs) — Deploy a Next.js app to AWS with AWS.Website.Nextjs — the OpenNext serverless topology with streaming SSR, image optimization, and ISR wiring, plus next dev under alchemy dev.
+- [Nuxt](https://alchemy.run/aws/frontend/nuxt) — Deploy a Nuxt app to AWS with AWS.Website.Nuxt — nitro's aws-lambda preset on a streaming Lambda Function URL, S3 assets behind CloudFront, and Nuxt's own dev server under alchemy dev.
+- [Astro](https://alchemy.run/aws/frontend/astro) — Deploy an Astro app to AWS with AWS.Website.Astro — SSR on a streaming Lambda Function URL, static output on S3 + CloudFront, and Astro's own dev server under alchemy dev.
+- [SvelteKit](https://alchemy.run/aws/frontend/sveltekit) — Deploy a SvelteKit app to AWS with AWS.Website.SvelteKit — SSR on a streaming Lambda Function URL, assets and prerendered pages on S3 + CloudFront, and Kit's own dev server under alchemy dev.
+- [Waku](https://alchemy.run/aws/frontend/waku) — Deploy a Waku app to AWS with AWS.Website.Waku — RSC server on a streaming Lambda Function URL, SSG pages and assets on S3 + CloudFront, and Waku's own dev server under alchemy dev.
+- [Octane](https://alchemy.run/aws/frontend/octane) — Deploy an OctaneJS app to AWS with AWS.Website.Octane — SSR on a streaming Lambda Function URL, assets on S3 + CloudFront, and Octane's own Vite dev server under alchemy dev.
+- [Foldkit](https://alchemy.run/aws/frontend/foldkit) — Deploy a Foldkit app to AWS with AWS.Website.Foldkit — the client-only Vite build on S3 + CloudFront, SPA deep links at the edge, and Vite's own dev server under alchemy dev.
 
 ## AWS — APIs
 
@@ -363,4 +370,4 @@ Cloud-agnostic local process primitives — memoized builds, one-off commands, a
 
 Per-resource API reference, generated from JSDoc on the source `.ts` files via `bun generate:api-reference`. Each page documents the resource's input properties (with types, defaults, and constraints), output attributes, and Quick Reference / Examples sections derived from `@section` / `@example` JSDoc tags.
 
-The per-resource pages are indexed in [llms-full.txt](https://alchemy.run/llms-full.txt), which repeats this entire file plus one link per resource. Warning: it is large (~855 KB) — only fetch it when you need to locate a specific resource's reference page.
+The per-resource pages are indexed in [llms-full.txt](https://alchemy.run/llms-full.txt), which repeats this entire file plus one link per resource. Warning: it is large (~862 KB) — only fetch it when you need to locate a specific resource's reference page.

--- a/website/src/content/docs/aws/frontend/foldkit.mdx
+++ b/website/src/content/docs/aws/frontend/foldkit.mdx
@@ -1,0 +1,199 @@
+---
+title: Foldkit
+description: Deploy a Foldkit app to AWS with AWS.Website.Foldkit — the client-only Vite build on S3 + CloudFront, SPA deep links at the edge, and Vite's own dev server under alchemy dev.
+sidebar:
+  order: 15
+---
+
+import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
+
+export const devDeps = "@alchemy.run/frontend-frameworks";
+
+[Foldkit](https://foldkit.dev) is an Elm-architecture frontend
+framework built on Effect. Its apps are client-only Vite projects —
+the Foldkit Vite plugin only adds HMR and devtools wiring — so
+`AWS.Website.Foldkit` deploys them with a single declaration: no
+build command, no output directory, no CDK, no CloudFormation.
+
+The deployment is assets-only: Alchemy runs your project's own
+`vite build` and uploads the client output to a private S3 bucket
+served through CloudFront. No Lambda is created. Client-side routing
+is assumed, so deep links fall back to `index.html` without you
+configuring anything.
+
+## Install
+
+The build integration is not bundled with alchemy. Install
+`@alchemy.run/frontend-frameworks`; the resource loads its `/vite`
+and `/vite/aws` exports from your project at deploy time. It is only
+used at build time, so a dev dependency is enough:
+
+<Tabs syncKey="pkgManager">
+  <TabItem label="bun" icon="bun">
+    <Code code={`bun add -d ${devDeps}`} lang="sh" />
+  </TabItem>
+  <TabItem label="npm" icon="npm">
+    <Code code={`npm install -D ${devDeps}`} lang="sh" />
+  </TabItem>
+  <TabItem label="pnpm" icon="pnpm">
+    <Code code={`pnpm add -D ${devDeps}`} lang="sh" />
+  </TabItem>
+  <TabItem label="yarn" icon="seti:yarn">
+    <Code code={`yarn add -D ${devDeps}`} lang="sh" />
+  </TabItem>
+</Tabs>
+
+## Configure Vite
+
+Your Vite config stays what Foldkit's setup gives you:
+
+```typescript
+// vite.config.ts
+import { foldkit } from "@foldkit/vite-plugin";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [foldkit()],
+  optimizeDeps: {
+    entries: ["src/entry.ts"],
+  },
+});
+```
+
+Alchemy runs Vite programmatically on the project root with this
+config as-is — the Foldkit plugin and the rest of your setup are
+preserved, and nothing platform-specific is injected. The build's
+output is plain static files.
+
+:::note[Pinned Effect versions]
+Foldkit pins its `effect` peer dependency to an exact version.
+Alchemy runs your app's own Vite build with your app's own
+`node_modules`, so that pin is between Foldkit and your package
+manager — Alchemy imposes no Effect version on your frontend.
+:::
+
+## Declare the Website
+
+Declare the site as a module-level const (rather than inline in the
+Stack):
+
+```typescript
+// alchemy.run.ts
+import * as AWS from "alchemy/AWS";
+
+export const Website = AWS.Website.Foldkit("Foldkit");
+```
+
+For an app in a subdirectory of a monorepo, point `rootDir` at it:
+
+```typescript
+export const Website = AWS.Website.Foldkit("Foldkit", {
+  rootDir: "applications/web",
+});
+```
+
+## Add it to the Stack
+
+Yield the site from your Stack and return its URL — see
+[examples/aws-website-foldkit](https://github.com/alchemy-run/alchemy/tree/main/examples/aws-website-foldkit)
+for the checked-in example:
+
+```typescript
+// alchemy.run.ts
+import * as Alchemy from "alchemy";
+import * as Effect from "effect/Effect";
+
+export default Alchemy.Stack(
+  "AwsWebsiteFoldkitExample",
+  {
+    providers: AWS.providers(),
+    state: AWS.state(),
+  },
+  Effect.gen(function* () {
+    const site = yield* Website;
+
+    return {
+      url: site.url,
+    };
+  }),
+);
+```
+
+Alchemy builds the client assets and serves them from CloudFront at
+the returned `url`.
+
+## Deep links
+
+A Foldkit app that uses URL routing (`Runtime.makeApplication` with
+`route`, `onUrlRequest`, and `onUrlChange`) resolves routes on the
+client, so a deep link like `/counter/42` arrives at the edge as a
+request for a file that doesn't exist.
+
+`Foldkit` answers unmatched paths with the index page (200) by
+default — the Foldkit runtime resolves the route once the app boots.
+A Foldkit app that ships a real 404 page can opt out:
+
+```typescript
+export const Website = AWS.Website.Foldkit("Foldkit", {
+  spa: false,
+  errorPage: "404.html",
+});
+```
+
+## Environment variables
+
+A Foldkit SPA has no server, so anything it needs from the
+environment is baked into the bundle at build time by Vite's own
+[env handling](https://vite.dev/guide/env-and-mode): `VITE_`-prefixed
+variables from the build's process environment and the project's
+`.env` files are inlined as `import.meta.env.VITE_*`.
+
+Type them for your Foldkit code with Vite's standard `ImportMetaEnv`
+augmentation:
+
+```typescript
+// src/vite-env.d.ts
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_URL: string;
+}
+```
+
+Anything dynamic — values that come from other resources in your
+Stack — must come from a route the app fetches at runtime instead;
+compose an API behind the same domain with a
+[`Router`](/aws/frontend/static-site#compose-sites-with-a-router).
+
+## Custom domain
+
+```typescript
+export const Website = AWS.Website.Foldkit("Foldkit", {
+  domain: {
+    name: "app.example.com",
+    hostedZoneId: zone.hostedZoneId,
+  },
+});
+```
+
+Alchemy provisions the ACM certificate and the Route 53 alias
+records. To serve the app next to an API (or other sites) on one
+CloudFront distribution, attach it to a shared
+[`Router`](/aws/frontend/static-site#compose-sites-with-a-router)
+with `domain: { router }`.
+
+## Local dev
+
+`alchemy dev` runs the app's own Vite dev server, so Foldkit's HMR
+with state preservation and its devtools wiring work unchanged.
+`site.url` is the local address and no AWS resources are created;
+wrap the site in `Alchemy.remote()` to deploy the real infrastructure
+even during dev.
+
+Pin the dev server's address when several apps run in one Stack:
+
+```typescript
+export const Website = AWS.Website.Foldkit("Foldkit", {
+  dev: { host: "127.0.0.1", port: 5180, strictPort: true },
+});
+```

--- a/website/src/content/docs/aws/frontend/websites.mdx
+++ b/website/src/content/docs/aws/frontend/websites.mdx
@@ -1,6 +1,6 @@
 ---
 title: Websites
-description: Deploy Astro, Next.js, Nuxt, SvelteKit, Waku, Octane, or any static build to AWS with first-class Website resources.
+description: Deploy Astro, Next.js, Nuxt, SvelteKit, Waku, Octane, Foldkit, or any static build to AWS with first-class Website resources.
 sidebar:
   label: Overview
   order: 1
@@ -32,6 +32,9 @@ integration on top.
   apps.
 - [`Octane`](/aws/frontend/octane) — OctaneJS fullstack apps built
   through your own `vite build` with the AWS marker adapter.
+- [`Foldkit`](/aws/frontend/foldkit) — Foldkit apps (client-only Vite
+  SPAs) built through your own `vite build` and deployed assets-only,
+  with SPA deep links handled at the edge.
 - [`StaticSite`](/aws/frontend/static-site) — any directory of files,
   optionally produced by a build command, for static generators like
   Zola and Hugo or pre-built SPAs.
@@ -58,6 +61,7 @@ the full live deployment.
 | SvelteKit | `SvelteKit` | [SvelteKit](/aws/frontend/sveltekit) |
 | Waku | `Waku` | [Waku](/aws/frontend/waku) |
 | OctaneJS (fullstack) | `Octane` | [Octane](/aws/frontend/octane) |
+| Foldkit | `Foldkit` | [Foldkit](/aws/frontend/foldkit) |
 | Vite SPA (any build) | `StaticSite` | [Static sites](/aws/frontend/static-site) |
 | Zola, Hugo, or any static generator | `StaticSite` | [Static sites](/aws/frontend/static-site) |
 
@@ -70,9 +74,9 @@ way.
 ## How to choose
 
 Use the resource named after your framework. `Astro`, `Nextjs`,
-`Nuxt`, `SvelteKit`, `Waku`, and `Octane` each drive their
-framework's own programmatic build and know its output layout, config
-surface, and dev server.
+`Nuxt`, `SvelteKit`, `Waku`, `Octane`, and `Foldkit` each drive
+their framework's own programmatic build and know its output layout,
+config surface, and dev server.
 
 Use `StaticSite` when the output is plain files — a pre-built SPA, or
 an arbitrary build command that emits a directory (Zola, Hugo, or any
@@ -92,7 +96,8 @@ minutes to create, and each custom domain can only attach to one.
   [Nuxt](/aws/frontend/nuxt),
   [SvelteKit](/aws/frontend/sveltekit),
   [Waku](/aws/frontend/waku),
-  [Octane](/aws/frontend/octane).
+  [Octane](/aws/frontend/octane),
+  [Foldkit](/aws/frontend/foldkit).
 - [`StaticSite` reference](/providers/aws/website/staticsite) and
   [`Router` reference](/providers/aws/website/router) — every prop
   and attribute.


### PR DESCRIPTION
Brings Foldkit to AWS (mirroring `Cloudflare.Website.Foldkit` from #1120) and completes the foldkit examples' test coverage so `test:examples` runs both `dev.test.ts` and `integ.test.ts` for every AWS and Cloudflare example.

### `@alchemy.run/frontend-frameworks/vite`

A generic client-only Vite integration (Foldkit apps, plain Vite SPAs) implementing framework-core's `Framework` contract:

```ts
// build: one `vite build` with the project's own vite.config.* is the whole
// pipeline; the resolved outDir becomes an assets-only BuildOutput
// (serverModules: undefined). dev: vite's own dev server, native HMR.
export const make: (options?: ViteFrameworkOptions) => Effect<Framework["Service"], ...>
```

Plus `/vite/aws`, a pure-marker deploy target (a static build has no platform-specific server code — only the generic `build` takeover / `finish` seams apply).

### `AWS.Website.Foldkit`

An assets-only `makeFrameworkSite` composite — S3 + CloudFront (or a shared `Router`), **no Lambda**, SPA index fallback by default so deep links boot the client router (`errorPage` opts out):

```ts
const site = yield* AWS.Website.Foldkit("Website");
// alchemy dev → vite dev server (HMR), no cloud resources
// alchemy deploy → vite build → S3 assets behind CloudFront
```

### Tests

- `examples/aws-website-foldkit` (new, added to `scripts/test-examples.ts`): `dev.test.ts` drives the real CLI — vite dev server URL from stdout, app shell, SPA deep links, hot-reload roundtrip; `integ.test.ts` deploys live — index HTML, SPA deep-link routing through CloudFront, compiled tailwind from the project's own `vite.config.ts`.
- `examples/cloudflare-foldkit`: new `dev.test.ts` (real CLI through the WorkerProxy + vite/workerd pipeline, HMR roundtrip), and the `test` script un-pinned from `test/integ.test.ts` so both suites run under `test:examples`.

Full `ALCHEMY_PROFILE=testing bun test:examples` is green — all 25 examples (~10.5 min wall), including every dev + integ suite on both clouds.

### Docs

`/aws/frontend/foldkit` — mirrors the Cloudflare Foldkit guide adapted for AWS (assets-only S3+CloudFront, SPA deep links, Vite env inlining, custom domain / Router composition, `alchemy dev`). Foldkit added to the AWS Websites overview + sidebar (with the previously missing Octane sidebar entry). The `AWS.Website.Foldkit` API reference generates from the resource JSDoc; full website build passes.
