### PR TITLE
chore: make distilled worktree bootstrap resilient

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -8,4 +8,6 @@ common_dir="$(git rev-parse --path-format=absolute --git-common-dir)"
 # needs bootstrapping when Git has just created (or switched) a linked worktree.
 [ "$git_dir" != "$common_dir" ] || exit 0
 
-exec bun scripts/bootstrap-distilled-worktree.ts
+bun scripts/bootstrap-distilled-worktree.ts >/dev/null 2>&1 || true
+
+exit 0

--- a/scripts/bootstrap-distilled-worktree.ts
+++ b/scripts/bootstrap-distilled-worktree.ts
@@ -72,9 +72,21 @@ const objectExists =
     sharedRepository,
   )) !== undefined;
 
+let checkoutCommit = desiredCommit;
 if (!objectExists) {
   console.log(`Fetching distilled commit ${desiredCommit}...`);
-  await git(["fetch", "origin", desiredCommit], sharedRepository, false);
+  const fetchedCommit = await tryGit(
+    ["fetch", "origin", desiredCommit],
+    sharedRepository,
+  );
+
+  if (fetchedCommit === undefined) {
+    console.warn(
+      `Could not fetch distilled commit ${desiredCommit}; falling back to origin/main.`,
+    );
+    await git(["fetch", "origin", "main"], sharedRepository, false);
+    checkoutCommit = await git(["rev-parse", "FETCH_HEAD"], sharedRepository);
+  }
 }
 
 if (existsSync(checkout)) {
@@ -98,7 +110,7 @@ if (existsSync(checkout)) {
       ["symbolic-ref", "--short", "-q", "HEAD"],
       checkout,
     );
-    if (currentCommit === desiredCommit) {
+    if (currentCommit === checkoutCommit) {
       if (
         desiredBranch !== undefined &&
         currentBranch !== desiredBranch &&
@@ -106,7 +118,7 @@ if (existsSync(checkout)) {
       ) {
         // Same commit, wrong (or detached) HEAD — just move the branch over.
         await git(
-          ["checkout", "-B", desiredBranch, desiredCommit],
+          ["checkout", "-B", desiredBranch, checkoutCommit],
           checkout,
           false,
         );
@@ -116,23 +128,23 @@ if (existsSync(checkout)) {
 
     if ((await git(["status", "--porcelain"], checkout)) !== "") {
       console.error(
-        `Cannot update distilled to ${desiredCommit}: ${checkout} has uncommitted changes.`,
+        `Cannot update distilled to ${checkoutCommit}: ${checkout} has uncommitted changes.`,
       );
       process.exit(1);
     }
 
-    console.log(`Updating distilled to ${desiredCommit}...`);
+    console.log(`Updating distilled to ${checkoutCommit}...`);
     if (
       desiredBranch !== undefined &&
       (currentBranch === desiredBranch || !(await branchInUseElsewhere()))
     ) {
       await git(
-        ["checkout", "-B", desiredBranch, desiredCommit],
+        ["checkout", "-B", desiredBranch, checkoutCommit],
         checkout,
         false,
       );
     } else {
-      await git(["checkout", "--detach", desiredCommit], checkout, false);
+      await git(["checkout", "--detach", checkoutCommit], checkout, false);
     }
     process.exit(0);
   }
@@ -147,11 +159,11 @@ if (existsSync(checkout)) {
   rmdirSync(checkout);
 }
 
-console.log(`Creating distilled worktree at ${desiredCommit}...`);
+console.log(`Creating distilled worktree at ${checkoutCommit}...`);
 await git(
   desiredBranch !== undefined && !(await branchInUseElsewhere())
-    ? ["worktree", "add", "-B", desiredBranch, checkout, desiredCommit]
-    : ["worktree", "add", "--detach", checkout, desiredCommit],
+    ? ["worktree", "add", "-B", desiredBranch, checkout, checkoutCommit]
+    : ["worktree", "add", "--detach", checkout, checkoutCommit],
   sharedRepository,
   false,
 );


### PR DESCRIPTION
## What happened

Creating a T3 Code thread in a new worktree started failing and returning the UI to the original thread. Retrying then produced a duplicate-thread error and left orphaned Git worktrees behind.

The repository post-checkout hook synchronously bootstraps a matching `distilled` worktree. When the parent commit referenced a distilled gitlink object that was not available locally, the bootstrap attempted to fetch that exact SHA. GitHub may reject direct SHA fetches with `upload-pack: not our ref`, even when the desired commit is associated with repository history. The hook propagated that failure through `git worktree add`. T3 then attempted to roll back the parent worktree, but the partially created nested distilled worktree made cleanup incomplete.

## What changed

- Try to use or fetch the exact distilled gitlink commit first.
- If the exact SHA cannot be fetched, fetch `origin/main` and create the matching distilled branch from `FETCH_HEAD`.
- Use the resolved checkout commit consistently when creating or updating the distilled worktree.
- Make the Husky hook silent and fail-soft so an optional distilled bootstrap failure cannot invalidate creation of the parent worktree.
- Advance the distilled gitlink to current main, including the merged `.turbo/` ignore fix.

## Verification

Tested both successful exact-commit bootstrap and a deliberately unavailable gitlink SHA. The unavailable SHA falls back to distilled main, mirrors the parent branch name, and leaves the parent worktree creation successful.