### PR TITLE
feat(aws/dynamodb): support multi-attribute GSI keys

### DIFF
--- a/packages/alchemy/src/AWS/DynamoDB/Table.ts
+++ b/packages/alchemy/src/AWS/DynamoDB/Table.ts
@@ -89,6 +89,10 @@ export type TableProps = {
   tableName?: string;
   /**
    * Partition key attribute name for the table.
+   *
+   * Base-table primary keys are always a single partition attribute plus an
+   * optional single sort attribute — DynamoDB supports multi-attribute keys
+   * only on global secondary indexes (see `globalSecondaryIndexes`).
    */
   partitionKey: string;
   /**
@@ -99,7 +103,20 @@ export type TableProps = {
    * Attribute definitions used by the primary key and any secondary indexes.
    */
   attributes: Record<string, ScalarAttributeType>;
+  /**
+   * Local secondary indexes, created with the table. LSI keys are always a
+   * single `HASH` element (the table's partition key) plus a single `RANGE`
+   * element. Changing this property replaces the table.
+   */
   localSecondaryIndexes?: DynamoDB.LocalSecondaryIndex[];
+  /**
+   * Global secondary indexes. A GSI's `KeySchema` may use multi-attribute
+   * keys: up to four `HASH` elements (hashed together as the composite
+   * partition key) and up to four `RANGE` elements (sorted and queried
+   * left-to-right, in declaration order). Element order is significant —
+   * reordering the attributes defines a different index and replaces the
+   * table. Every key attribute must appear in `attributes`.
+   */
   globalSecondaryIndexes?: DynamoDB.GlobalSecondaryIndex[];
   billingMode?: DynamoDB.BillingMode;
   deletionProtectionEnabled?: boolean;
@@ -234,6 +251,51 @@ export interface Table extends Resource<
  *     ],
  *     Projection: { ProjectionType: "ALL" },
  *   }],
+ * });
+ * ```
+ *
+ * @example Multi-Attribute GSI Keys
+ * GSI partition and sort keys may be composed of up to four attributes each,
+ * indexing natural domain attributes directly instead of synthetic
+ * concatenated keys. Partition attributes are hashed together (queries must
+ * specify all of them with equality); sort attributes are queried
+ * left-to-right in declaration order.
+ * ```typescript
+ * const matches = yield* DynamoDB.Table("TournamentMatches", {
+ *   partitionKey: "matchId",
+ *   attributes: {
+ *     matchId: "S",
+ *     tournamentId: "S",
+ *     region: "S",
+ *     round: "S",
+ *   },
+ *   globalSecondaryIndexes: [{
+ *     IndexName: "TournamentRegionIndex",
+ *     KeySchema: [
+ *       { AttributeName: "tournamentId", KeyType: "HASH" },  // PK attribute 1
+ *       { AttributeName: "region", KeyType: "HASH" },        // PK attribute 2
+ *       { AttributeName: "round", KeyType: "RANGE" },        // SK attribute 1
+ *       { AttributeName: "matchId", KeyType: "RANGE" },      // SK attribute 2
+ *     ],
+ *     Projection: { ProjectionType: "ALL" },
+ *   }],
+ * });
+ *
+ * // init
+ * const query = yield* AWS.DynamoDB.Query(matches);
+ *
+ * // runtime: query with every partition attribute, then narrow the sort
+ * // attributes left-to-right
+ * const response = yield* query({
+ *   IndexName: "TournamentRegionIndex",
+ *   KeyConditionExpression:
+ *     "tournamentId = :t AND #r = :r AND round = :round",
+ *   ExpressionAttributeNames: { "#r": "region" },
+ *   ExpressionAttributeValues: {
+ *     ":t": { S: "WINTER2024" },
+ *     ":r": { S: "NA-EAST" },
+ *     ":round": { S: "SEMIFINALS" },
+ *   },
  * });
  * ```
  *
@@ -1205,14 +1267,25 @@ export const TableProvider = () =>
           (indexes ?? []).map((index) => [index.IndexName!, index]),
         ) as Record<string, T>;
 
-      const sortKeySchema = (
+      // KeySchema order is significant with multi-attribute keys: partition
+      // attributes are hashed together in declaration order and sort key
+      // attributes are queried left-to-right. Only the HASH/RANGE grouping is
+      // normalized (DescribeTable reports all HASH elements before all RANGE
+      // elements regardless of how the request interleaved them); the relative
+      // order within each group must be preserved — reordering attributes
+      // defines a different index.
+      const normalizeKeySchema = (
         keySchema: readonly DynamoDB.KeySchemaElement[] | undefined,
-      ) =>
-        [...(keySchema ?? [])].sort((a, b) =>
-          `${a.KeyType}:${a.AttributeName}`.localeCompare(
-            `${b.KeyType}:${b.AttributeName}`,
-          ),
-        );
+      ) => {
+        const elements = (keySchema ?? []).map((element) => ({
+          AttributeName: element.AttributeName,
+          KeyType: element.KeyType,
+        }));
+        return [
+          ...elements.filter((element) => element.KeyType === "HASH"),
+          ...elements.filter((element) => element.KeyType === "RANGE"),
+        ];
+      };
 
       const normalizeProjection = (
         projection: DynamoDB.Projection | undefined,
@@ -1225,8 +1298,8 @@ export const TableProvider = () =>
         left: DynamoDB.GlobalSecondaryIndex,
         right: DynamoDB.GlobalSecondaryIndex,
       ) =>
-        JSON.stringify(sortKeySchema(left.KeySchema)) ===
-          JSON.stringify(sortKeySchema(right.KeySchema)) &&
+        JSON.stringify(normalizeKeySchema(left.KeySchema)) ===
+          JSON.stringify(normalizeKeySchema(right.KeySchema)) &&
         JSON.stringify(normalizeProjection(left.Projection)) ===
           JSON.stringify(normalizeProjection(right.Projection));
 

--- a/packages/alchemy/src/AWS/DynamoDB/Table.ts
+++ b/packages/alchemy/src/AWS/DynamoDB/Table.ts
@@ -75,6 +75,58 @@ export interface KinesisStreamingDestination {
   approximateCreationDateTimePrecision?: DynamoDB.ApproximateCreationDateTimePrecision;
 }
 
+/**
+ * One or more attribute names forming an index key. DynamoDB's wire format
+ * flattens both key segments into a single ordered `KeySchema` list, but
+ * semantically a key is two ordered segments — this type captures one of
+ * them. Order is significant: partition attributes are hashed together in
+ * declaration order, and sort attributes are queried left-to-right.
+ */
+export type IndexKey = string | string[];
+
+export interface LocalSecondaryIndexProps {
+  /**
+   * Name of the index, unique within the table.
+   */
+  indexName: string;
+  /**
+   * Sort key attribute name. An LSI always shares the table's partition
+   * key, so only the sort key is declared; multi-attribute keys are not
+   * supported on LSIs.
+   */
+  sortKey: string;
+  /**
+   * Attributes projected from the table into the index.
+   */
+  projection: DynamoDB.Projection;
+}
+
+export interface GlobalSecondaryIndexProps {
+  /**
+   * Name of the index, unique within the table.
+   */
+  indexName: string;
+  /**
+   * Partition key attribute name(s). Up to four attributes may be listed;
+   * they are hashed together in declaration order and every one must be
+   * specified with an equality condition when querying the index.
+   */
+  partitionKey: IndexKey;
+  /**
+   * Optional sort key attribute name(s). Up to four attributes may be
+   * listed; items sort by each attribute in declaration order and queries
+   * narrow them left-to-right (no gaps, inequality last).
+   */
+  sortKey?: IndexKey;
+  /**
+   * Attributes projected from the table into the index.
+   */
+  projection: DynamoDB.Projection;
+  provisionedThroughput?: DynamoDB.ProvisionedThroughput;
+  onDemandThroughput?: DynamoDB.OnDemandThroughput;
+  warmThroughput?: DynamoDB.WarmThroughput;
+}
+
 export type TableProps = {
   /**
    * Name of the table. If omitted, Alchemy generates a deterministic physical
@@ -104,20 +156,19 @@ export type TableProps = {
    */
   attributes: Record<string, ScalarAttributeType>;
   /**
-   * Local secondary indexes, created with the table. LSI keys are always a
-   * single `HASH` element (the table's partition key) plus a single `RANGE`
-   * element. Changing this property replaces the table.
+   * Local secondary indexes, created with the table. An LSI always shares
+   * the table's partition key and declares a single sort key. Changing this
+   * property replaces the table.
    */
-  localSecondaryIndexes?: DynamoDB.LocalSecondaryIndex[];
+  localSecondaryIndexes?: LocalSecondaryIndexProps[];
   /**
-   * Global secondary indexes. A GSI's `KeySchema` may use multi-attribute
-   * keys: up to four `HASH` elements (hashed together as the composite
-   * partition key) and up to four `RANGE` elements (sorted and queried
-   * left-to-right, in declaration order). Element order is significant —
-   * reordering the attributes defines a different index and replaces the
-   * table. Every key attribute must appear in `attributes`.
+   * Global secondary indexes. GSIs support multi-attribute keys: up to four
+   * partition attributes (hashed together as the composite partition key)
+   * and up to four sort attributes (sorted and queried left-to-right).
+   * Attribute order is significant — reordering defines a different index
+   * and replaces the table. Every key attribute must appear in `attributes`.
    */
-  globalSecondaryIndexes?: DynamoDB.GlobalSecondaryIndex[];
+  globalSecondaryIndexes?: GlobalSecondaryIndexProps[];
   billingMode?: DynamoDB.BillingMode;
   deletionProtectionEnabled?: boolean;
   onDemandThroughput?: DynamoDB.OnDemandThroughput;
@@ -244,12 +295,10 @@ export interface Table extends Resource<
  *     gsi1sk: "S",
  *   },
  *   globalSecondaryIndexes: [{
- *     IndexName: "GSI1",
- *     KeySchema: [
- *       { AttributeName: "gsi1pk", KeyType: "HASH" },
- *       { AttributeName: "gsi1sk", KeyType: "RANGE" },
- *     ],
- *     Projection: { ProjectionType: "ALL" },
+ *     indexName: "GSI1",
+ *     partitionKey: "gsi1pk",
+ *     sortKey: "gsi1sk",
+ *     projection: { ProjectionType: "ALL" },
  *   }],
  * });
  * ```
@@ -270,14 +319,10 @@ export interface Table extends Resource<
  *     round: "S",
  *   },
  *   globalSecondaryIndexes: [{
- *     IndexName: "TournamentRegionIndex",
- *     KeySchema: [
- *       { AttributeName: "tournamentId", KeyType: "HASH" },  // PK attribute 1
- *       { AttributeName: "region", KeyType: "HASH" },        // PK attribute 2
- *       { AttributeName: "round", KeyType: "RANGE" },        // SK attribute 1
- *       { AttributeName: "matchId", KeyType: "RANGE" },      // SK attribute 2
- *     ],
- *     Projection: { ProjectionType: "ALL" },
+ *     indexName: "TournamentRegionIndex",
+ *     partitionKey: ["tournamentId", "region"],
+ *     sortKey: ["round", "matchId"],
+ *     projection: { ProjectionType: "ALL" },
  *   }],
  * });
  *
@@ -418,6 +463,79 @@ export const TableProvider = () =>
             ]
           : []),
       ];
+
+      const toKeyAttributeNames = (key: IndexKey | undefined) =>
+        key === undefined ? [] : typeof key === "string" ? [key] : key;
+
+      // AWS's wire format flattens an index key into one ordered KeySchema
+      // list and validates that all HASH elements precede all RANGE
+      // elements; deriving the list from the two typed segments makes the
+      // invalid orderings unrepresentable in props.
+      const toIndexKeySchema = (
+        partitionKey: IndexKey,
+        sortKey: IndexKey | undefined,
+      ): DynamoDB.KeySchemaElement[] => [
+        ...toKeyAttributeNames(partitionKey).map((name) => ({
+          AttributeName: name,
+          KeyType: "HASH" as const,
+        })),
+        ...toKeyAttributeNames(sortKey).map((name) => ({
+          AttributeName: name,
+          KeyType: "RANGE" as const,
+        })),
+      ];
+
+      // Pre-typed-props state may persist index props in the legacy wire
+      // shape ({ IndexName, KeySchema, ... }). Tolerate it when converting
+      // `olds` so upgrading alchemy never plans a spurious table
+      // replacement over a shape-only difference.
+      const isLegacyWireIndex = (
+        index: unknown,
+      ): index is DynamoDB.GlobalSecondaryIndex =>
+        typeof index === "object" && index !== null && "KeySchema" in index;
+
+      const toWireGlobalSecondaryIndex = (
+        index: GlobalSecondaryIndexProps,
+      ): DynamoDB.GlobalSecondaryIndex =>
+        isLegacyWireIndex(index)
+          ? index
+          : {
+              IndexName: index.indexName,
+              KeySchema: toIndexKeySchema(index.partitionKey, index.sortKey),
+              Projection: index.projection,
+              ProvisionedThroughput: index.provisionedThroughput,
+              OnDemandThroughput: index.onDemandThroughput,
+              WarmThroughput: index.warmThroughput,
+            };
+
+      const toWireLocalSecondaryIndex = (
+        tablePartitionKey: string,
+        index: LocalSecondaryIndexProps,
+      ): DynamoDB.LocalSecondaryIndex =>
+        isLegacyWireIndex(index)
+          ? index
+          : {
+              IndexName: index.indexName,
+              KeySchema: toIndexKeySchema(tablePartitionKey, index.sortKey),
+              Projection: index.projection,
+            };
+
+      const toWireGlobalSecondaryIndexes = (
+        indexes: readonly GlobalSecondaryIndexProps[] | undefined,
+      ) =>
+        indexes === undefined || indexes.length === 0
+          ? undefined
+          : indexes.map(toWireGlobalSecondaryIndex);
+
+      const toWireLocalSecondaryIndexes = (
+        tablePartitionKey: string,
+        indexes: readonly LocalSecondaryIndexProps[] | undefined,
+      ) =>
+        indexes === undefined || indexes.length === 0
+          ? undefined
+          : indexes.map((index) =>
+              toWireLocalSecondaryIndex(tablePartitionKey, index),
+            );
 
       const toAttributeDefinitions = (
         attrs: Record<string, ScalarAttributeType>,
@@ -1538,17 +1656,32 @@ export const TableProvider = () =>
               return replace;
             }
           }
+          // Compare secondary indexes in the wire shape so legacy state
+          // (persisted before the typed index props) diffs cleanly against
+          // the new prop shape.
           if (
             havePropsChanged(
-              { localSecondaryIndexes: olds.localSecondaryIndexes ?? [] },
-              { localSecondaryIndexes: news.localSecondaryIndexes ?? [] },
+              {
+                localSecondaryIndexes:
+                  toWireLocalSecondaryIndexes(
+                    olds.partitionKey,
+                    olds.localSecondaryIndexes,
+                  ) ?? [],
+              },
+              {
+                localSecondaryIndexes:
+                  toWireLocalSecondaryIndexes(
+                    news.partitionKey,
+                    news.localSecondaryIndexes,
+                  ) ?? [],
+              },
             )
           ) {
             return replace;
           }
           const { requiresReplacement } = diffGlobalSecondaryIndexes(
-            olds.globalSecondaryIndexes,
-            news.globalSecondaryIndexes,
+            toWireGlobalSecondaryIndexes(olds.globalSecondaryIndexes),
+            toWireGlobalSecondaryIndexes(news.globalSecondaryIndexes),
           );
           if (requiresReplacement) {
             return replace;
@@ -1587,8 +1720,13 @@ export const TableProvider = () =>
                 TableClass: news.tableClass,
                 KeySchema: toKeySchema(news),
                 AttributeDefinitions: toAttributeDefinitions(news.attributes),
-                LocalSecondaryIndexes: news.localSecondaryIndexes,
-                GlobalSecondaryIndexes: news.globalSecondaryIndexes,
+                LocalSecondaryIndexes: toWireLocalSecondaryIndexes(
+                  news.partitionKey,
+                  news.localSecondaryIndexes,
+                ),
+                GlobalSecondaryIndexes: toWireGlobalSecondaryIndexes(
+                  news.globalSecondaryIndexes,
+                ),
                 BillingMode: news.billingMode ?? "PAY_PER_REQUEST",
                 SSESpecification: news.sseSpecification,
                 StreamSpecification: desiredStreamSpecification,
@@ -1618,7 +1756,7 @@ export const TableProvider = () =>
               yield* waitForGlobalSecondaryIndexesStable(
                 session,
                 tableName,
-                news.globalSecondaryIndexes?.map((index) => index.IndexName) ??
+                news.globalSecondaryIndexes?.map((index) => index.indexName) ??
                   [],
               );
             }
@@ -1680,7 +1818,7 @@ export const TableProvider = () =>
               state.table.GlobalSecondaryIndexes as
                 | readonly DynamoDB.GlobalSecondaryIndex[]
                 | undefined,
-              news.globalSecondaryIndexes,
+              toWireGlobalSecondaryIndexes(news.globalSecondaryIndexes),
             );
 
           for (const globalSecondaryIndexUpdate of globalSecondaryIndexUpdates) {
@@ -1702,7 +1840,7 @@ export const TableProvider = () =>
 
           if (globalSecondaryIndexUpdates.length > 0) {
             const expectedNames =
-              news.globalSecondaryIndexes?.map((index) => index.IndexName) ??
+              news.globalSecondaryIndexes?.map((index) => index.indexName) ??
               [];
             yield* session.note(
               `Table ${tableName}: waiting for GSIs to stabilize (${expectedNames.join(", ") || "none"})`,

--- a/packages/alchemy/src/AWS/Website/Nextjs.ts
+++ b/packages/alchemy/src/AWS/Website/Nextjs.ts
@@ -277,12 +277,10 @@ export const Nextjs = Effect.fn("AWS.Website.Nextjs")(
       attributes: { tag: "S", path: "S", revalidatedAt: "N" },
       globalSecondaryIndexes: [
         {
-          IndexName: "revalidate",
-          KeySchema: [
-            { AttributeName: "path", KeyType: "HASH" },
-            { AttributeName: "revalidatedAt", KeyType: "RANGE" },
-          ],
-          Projection: { ProjectionType: "ALL" },
+          indexName: "revalidate",
+          partitionKey: "path",
+          sortKey: "revalidatedAt",
+          projection: { ProjectionType: "ALL" },
         },
       ],
       billingMode: "PAY_PER_REQUEST",

--- a/packages/alchemy/test/AWS/DynamoDB/Bindings.test.ts
+++ b/packages/alchemy/test/AWS/DynamoDB/Bindings.test.ts
@@ -613,6 +613,80 @@ describe("DynamoDB Bindings", () => {
         expect((response as any).items.length).toBe(2);
       }),
     );
+
+    test.provider(
+      "queries the multi-attribute-key GSI by composite partition key",
+      (_stack) =>
+        Effect.gen(function* () {
+          // Items carry natural attributes — the GSI indexes them without
+          // synthetic concatenated keys. The third item differs only in
+          // `subcategory`, so the composite partition key must exclude it.
+          const items = [
+            {
+              pk: "multi-query#1",
+              sk: "item1",
+              category: "electronics",
+              subcategory: "audio",
+              rank: "featured",
+            },
+            {
+              pk: "multi-query#2",
+              sk: "item2",
+              category: "electronics",
+              subcategory: "audio",
+              rank: "standard",
+            },
+            {
+              pk: "multi-query#3",
+              sk: "item3",
+              category: "electronics",
+              subcategory: "video",
+              rank: "featured",
+            },
+          ];
+          yield* Effect.forEach(items, (item) =>
+            send(
+              HttpClientRequest.bodyJsonUnsafe(
+                HttpClientRequest.post(`${baseUrl}/put`),
+                item,
+              ),
+            ),
+          );
+
+          // Both HASH attributes must be equality conditions; poll through
+          // the GSI's asynchronous propagation.
+          const byPartition = yield* Effect.gen(function* () {
+            const r = yield* HttpClient.get(
+              `${baseUrl}/query-multi?category=electronics&subcategory=audio`,
+            ).pipe(Effect.flatMap((r) => r.json));
+            if ((r as any).count !== 2) {
+              return yield* Effect.fail(new QueryNotConsistent());
+            }
+            return r;
+          }).pipe(
+            Effect.retry({
+              while: (e) => e._tag === "QueryNotConsistent",
+              schedule: Schedule.max([
+                Schedule.fixed("500 millis"),
+                Schedule.recurs(30),
+              ]),
+            }),
+          );
+          expect((byPartition as any).count).toBe(2);
+          expect(
+            ((byPartition as any).items as any[])
+              .map((item) => item.pk.S)
+              .sort(),
+          ).toEqual(["multi-query#1", "multi-query#2"]);
+
+          // Narrow by the first RANGE attribute (left-to-right).
+          const byRank = yield* HttpClient.get(
+            `${baseUrl}/query-multi?category=electronics&subcategory=audio&rank=featured`,
+          ).pipe(Effect.flatMap((r) => r.json));
+          expect((byRank as any).count).toBe(1);
+          expect((byRank as any).items[0].pk.S).toBe("multi-query#1");
+        }),
+    );
   });
 
   describe("ListTables", () => {

--- a/packages/alchemy/test/AWS/DynamoDB/Table.test.ts
+++ b/packages/alchemy/test/AWS/DynamoDB/Table.test.ts
@@ -511,21 +511,18 @@ describe.skipIf(!!process.env.FAST)("AWS.DynamoDB.Table", () => {
               },
               localSecondaryIndexes: [
                 {
-                  IndexName: "lsi-by-sk",
-                  KeySchema: [
-                    { AttributeName: "pk", KeyType: "HASH" },
-                    { AttributeName: "sk", KeyType: "RANGE" },
-                  ],
-                  Projection: {
+                  indexName: "lsi-by-sk",
+                  sortKey: "sk",
+                  projection: {
                     ProjectionType: "ALL",
                   },
                 },
               ],
               globalSecondaryIndexes: [
                 {
-                  IndexName: "gsi-by-lookup",
-                  KeySchema: [{ AttributeName: "gsi1pk", KeyType: "HASH" }],
-                  Projection: {
+                  indexName: "gsi-by-lookup",
+                  partitionKey: "gsi1pk",
+                  projection: {
                     ProjectionType: "ALL",
                   },
                 },
@@ -595,14 +592,10 @@ describe.skipIf(!!process.env.FAST)("AWS.DynamoDB.Table", () => {
             },
             globalSecondaryIndexes: [
               {
-                IndexName: "TournamentRegionIndex",
-                KeySchema: [
-                  { AttributeName: "tournamentId", KeyType: "HASH" },
-                  { AttributeName: "region", KeyType: "HASH" },
-                  { AttributeName: "round", KeyType: "RANGE" },
-                  { AttributeName: "matchId", KeyType: "RANGE" },
-                ],
-                Projection: { ProjectionType: "ALL" },
+                indexName: "TournamentRegionIndex",
+                partitionKey: ["tournamentId", "region"],
+                sortKey: ["round", "matchId"],
+                projection: { ProjectionType: "ALL" },
               },
             ],
           });
@@ -708,9 +701,7 @@ describe.skipIf(!!process.env.FAST)("AWS.DynamoDB.Table", () => {
         yield* logTestStep("starting multi-attribute GSI reorder test");
         yield* stack.destroy();
 
-        const makeTable = (
-          keySchema: { AttributeName: string; KeyType: "HASH" | "RANGE" }[],
-        ) =>
+        const makeTable = (sortKey: string[]) =>
           Effect.gen(function* () {
             return yield* Table("ReorderedMultiAttrKeyTable", {
               partitionKey: "id",
@@ -721,34 +712,23 @@ describe.skipIf(!!process.env.FAST)("AWS.DynamoDB.Table", () => {
               },
               globalSecondaryIndexes: [
                 {
-                  IndexName: "CategoryIndex",
-                  KeySchema: keySchema,
-                  Projection: { ProjectionType: "KEYS_ONLY" },
+                  indexName: "CategoryIndex",
+                  partitionKey: "category",
+                  sortKey,
+                  projection: { ProjectionType: "KEYS_ONLY" },
                 },
               ],
             });
           });
 
         yield* logTestStep("deploying table with ordered sort attributes");
-        const original = yield* stack.deploy(
-          makeTable([
-            { AttributeName: "category", KeyType: "HASH" },
-            { AttributeName: "subcategory", KeyType: "RANGE" },
-            { AttributeName: "id", KeyType: "RANGE" },
-          ]),
-        );
+        const original = yield* stack.deploy(makeTable(["subcategory", "id"]));
 
-        // Swapping the two RANGE attributes defines a different index
+        // Swapping the two sort attributes defines a different index
         // (sort attributes are queried left-to-right in declaration order),
         // so the deploy must replace the table, not no-op.
         yield* logTestStep("reordering sort attributes (expect replacement)");
-        const replaced = yield* stack.deploy(
-          makeTable([
-            { AttributeName: "category", KeyType: "HASH" },
-            { AttributeName: "id", KeyType: "RANGE" },
-            { AttributeName: "subcategory", KeyType: "RANGE" },
-          ]),
-        );
+        const replaced = yield* stack.deploy(makeTable(["id", "subcategory"]));
         expect(replaced.tableName).not.toEqual(original.tableName);
 
         const replacedTable = yield* expectTableIndexes(replaced.tableName, {
@@ -812,9 +792,9 @@ describe.skipIf(!!process.env.FAST)("AWS.DynamoDB.Table", () => {
               },
               globalSecondaryIndexes: [
                 {
-                  IndexName: "gsi-by-lookup-1",
-                  KeySchema: [{ AttributeName: "gsi1pk", KeyType: "HASH" }],
-                  Projection: {
+                  indexName: "gsi-by-lookup-1",
+                  partitionKey: "gsi1pk",
+                  projection: {
                     ProjectionType: "ALL",
                   },
                 },
@@ -863,16 +843,16 @@ describe.skipIf(!!process.env.FAST)("AWS.DynamoDB.Table", () => {
               },
               globalSecondaryIndexes: [
                 {
-                  IndexName: "gsi-by-lookup-1",
-                  KeySchema: [{ AttributeName: "gsi1pk", KeyType: "HASH" }],
-                  Projection: {
+                  indexName: "gsi-by-lookup-1",
+                  partitionKey: "gsi1pk",
+                  projection: {
                     ProjectionType: "ALL",
                   },
                 },
                 {
-                  IndexName: "gsi-by-lookup-2",
-                  KeySchema: [{ AttributeName: "gsi2pk", KeyType: "HASH" }],
-                  Projection: {
+                  indexName: "gsi-by-lookup-2",
+                  partitionKey: "gsi2pk",
+                  projection: {
                     ProjectionType: "ALL",
                   },
                 },
@@ -900,9 +880,9 @@ describe.skipIf(!!process.env.FAST)("AWS.DynamoDB.Table", () => {
               },
               globalSecondaryIndexes: [
                 {
-                  IndexName: "gsi-by-lookup-2",
-                  KeySchema: [{ AttributeName: "gsi2pk", KeyType: "HASH" }],
-                  Projection: {
+                  indexName: "gsi-by-lookup-2",
+                  partitionKey: "gsi2pk",
+                  projection: {
                     ProjectionType: "ALL",
                   },
                 },
@@ -983,12 +963,9 @@ describe.skipIf(!!process.env.FAST)("AWS.DynamoDB.Table", () => {
               },
               localSecondaryIndexes: [
                 {
-                  IndexName: "lsi-by-sk",
-                  KeySchema: [
-                    { AttributeName: "pk", KeyType: "HASH" },
-                    { AttributeName: "sk", KeyType: "RANGE" },
-                  ],
-                  Projection: {
+                  indexName: "lsi-by-sk",
+                  sortKey: "sk",
+                  projection: {
                     ProjectionType: "ALL",
                   },
                 },

--- a/packages/alchemy/test/AWS/DynamoDB/Table.test.ts
+++ b/packages/alchemy/test/AWS/DynamoDB/Table.test.ts
@@ -577,6 +577,199 @@ describe.skipIf(!!process.env.FAST)("AWS.DynamoDB.Table", () => {
     { timeout: 180_000 },
   );
 
+  test.provider(
+    "create table with multi-attribute GSI keys and query them",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* logTestStep("starting multi-attribute GSI key test");
+        yield* stack.destroy();
+
+        const multiAttrTable = Effect.gen(function* () {
+          return yield* Table("MultiAttrKeyTable", {
+            partitionKey: "matchId",
+            attributes: {
+              matchId: "S",
+              tournamentId: "S",
+              region: "S",
+              round: "S",
+            },
+            globalSecondaryIndexes: [
+              {
+                IndexName: "TournamentRegionIndex",
+                KeySchema: [
+                  { AttributeName: "tournamentId", KeyType: "HASH" },
+                  { AttributeName: "region", KeyType: "HASH" },
+                  { AttributeName: "round", KeyType: "RANGE" },
+                  { AttributeName: "matchId", KeyType: "RANGE" },
+                ],
+                Projection: { ProjectionType: "ALL" },
+              },
+            ],
+          });
+        });
+
+        yield* logTestStep("deploying table with multi-attribute GSI keys");
+        const table = yield* stack.deploy(multiAttrTable);
+
+        const actualTable = yield* expectTableIndexes(table.tableName, {
+          local: [],
+          global: ["TournamentRegionIndex"],
+        });
+
+        // The composite key's element order is significant — DescribeTable
+        // must report the HASH attributes then the RANGE attributes in
+        // declaration order.
+        expect(
+          actualTable?.GlobalSecondaryIndexes?.[0]?.KeySchema?.map(
+            (element) => [element.AttributeName, element.KeyType],
+          ),
+        ).toEqual([
+          ["tournamentId", "HASH"],
+          ["region", "HASH"],
+          ["round", "RANGE"],
+          ["matchId", "RANGE"],
+        ]);
+
+        yield* logTestStep("writing items with natural attributes");
+        const matches = [
+          { matchId: "match-001", region: "NA-EAST", round: "FINALS" },
+          { matchId: "match-002", region: "NA-EAST", round: "SEMIFINALS" },
+          { matchId: "match-003", region: "NA-WEST", round: "FINALS" },
+        ];
+        yield* Effect.forEach(matches, (match) =>
+          DynamoDB.putItem({
+            TableName: table.tableName,
+            Item: {
+              matchId: { S: match.matchId },
+              tournamentId: { S: "WINTER2024" },
+              region: { S: match.region },
+              round: { S: match.round },
+            },
+          }),
+        );
+
+        // Query with every partition attribute (equality on both HASH
+        // elements), retried through GSI propagation.
+        yield* logTestStep("querying GSI by composite partition key");
+        const byRegion = yield* DynamoDB.query({
+          TableName: table.tableName,
+          IndexName: "TournamentRegionIndex",
+          KeyConditionExpression: "tournamentId = :t AND #r = :r",
+          ExpressionAttributeNames: { "#r": "region" },
+          ExpressionAttributeValues: {
+            ":t": { S: "WINTER2024" },
+            ":r": { S: "NA-EAST" },
+          },
+        }).pipe(
+          Effect.repeat({
+            schedule: Schedule.max([
+              Schedule.fixed("2 seconds"),
+              Schedule.recurs(30),
+            ]),
+            until: (response) => (response.Count ?? 0) === 2,
+          }),
+        );
+        expect(byRegion.Count).toEqual(2);
+
+        // Narrow by the first sort key attribute (left-to-right).
+        const byRound = yield* DynamoDB.query({
+          TableName: table.tableName,
+          IndexName: "TournamentRegionIndex",
+          KeyConditionExpression:
+            "tournamentId = :t AND #r = :r AND round = :round",
+          ExpressionAttributeNames: { "#r": "region" },
+          ExpressionAttributeValues: {
+            ":t": { S: "WINTER2024" },
+            ":r": { S: "NA-EAST" },
+            ":round": { S: "SEMIFINALS" },
+          },
+        });
+        expect(byRound.Count).toEqual(1);
+        expect(byRound.Items?.[0]?.matchId).toEqual({ S: "match-002" });
+
+        // An identical redeploy must be a no-op — the order-sensitive GSI
+        // diff must not see a phantom change in the multi-attribute schema.
+        yield* logTestStep("redeploying unchanged table (expect no-op)");
+        const unchanged = yield* stack.deploy(multiAttrTable);
+        expect(unchanged.tableName).toEqual(table.tableName);
+        expect(unchanged.tableId).toEqual(table.tableId);
+
+        yield* logTestStep("destroying multi-attribute GSI table");
+        yield* stack.destroy();
+        yield* assertTableIsDeleted(table.tableName);
+      }),
+    { timeout: 240_000 },
+  );
+
+  test.provider(
+    "reordering multi-attribute GSI key attributes replaces the table",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* logTestStep("starting multi-attribute GSI reorder test");
+        yield* stack.destroy();
+
+        const makeTable = (
+          keySchema: { AttributeName: string; KeyType: "HASH" | "RANGE" }[],
+        ) =>
+          Effect.gen(function* () {
+            return yield* Table("ReorderedMultiAttrKeyTable", {
+              partitionKey: "id",
+              attributes: {
+                id: "S",
+                category: "S",
+                subcategory: "S",
+              },
+              globalSecondaryIndexes: [
+                {
+                  IndexName: "CategoryIndex",
+                  KeySchema: keySchema,
+                  Projection: { ProjectionType: "KEYS_ONLY" },
+                },
+              ],
+            });
+          });
+
+        yield* logTestStep("deploying table with ordered sort attributes");
+        const original = yield* stack.deploy(
+          makeTable([
+            { AttributeName: "category", KeyType: "HASH" },
+            { AttributeName: "subcategory", KeyType: "RANGE" },
+            { AttributeName: "id", KeyType: "RANGE" },
+          ]),
+        );
+
+        // Swapping the two RANGE attributes defines a different index
+        // (sort attributes are queried left-to-right in declaration order),
+        // so the deploy must replace the table, not no-op.
+        yield* logTestStep("reordering sort attributes (expect replacement)");
+        const replaced = yield* stack.deploy(
+          makeTable([
+            { AttributeName: "category", KeyType: "HASH" },
+            { AttributeName: "id", KeyType: "RANGE" },
+            { AttributeName: "subcategory", KeyType: "RANGE" },
+          ]),
+        );
+        expect(replaced.tableName).not.toEqual(original.tableName);
+
+        const replacedTable = yield* expectTableIndexes(replaced.tableName, {
+          local: [],
+          global: ["CategoryIndex"],
+        });
+        expect(
+          replacedTable?.GlobalSecondaryIndexes?.[0]?.KeySchema?.map(
+            (element) => element.AttributeName,
+          ),
+        ).toEqual(["category", "id", "subcategory"]);
+
+        yield* assertTableIsDeleted(original.tableName);
+
+        yield* logTestStep("destroying reordered multi-attribute GSI table");
+        yield* stack.destroy();
+        yield* assertTableIsDeleted(replaced.tableName);
+      }),
+    { timeout: 300_000 },
+  );
+
   // it's super slow because GSIs are awfully slow to create
   test.provider.skip(
     "update global secondary indexes across multiple deploys",

--- a/packages/alchemy/test/AWS/DynamoDB/handler.ts
+++ b/packages/alchemy/test/AWS/DynamoDB/handler.ts
@@ -31,17 +31,13 @@ export default DynamoDBTestFunction.make(
       },
       globalSecondaryIndexes: [
         {
-          // Multi-attribute keys: composite HASH (category + subcategory)
-          // and composite RANGE (rank + sk). Sparse — only items written
-          // with all four attributes appear in the index.
-          IndexName: "MultiAttrIndex",
-          KeySchema: [
-            { AttributeName: "category", KeyType: "HASH" },
-            { AttributeName: "subcategory", KeyType: "HASH" },
-            { AttributeName: "rank", KeyType: "RANGE" },
-            { AttributeName: "sk", KeyType: "RANGE" },
-          ],
-          Projection: { ProjectionType: "ALL" },
+          // Multi-attribute keys: composite partition key (category +
+          // subcategory) and composite sort key (rank + sk). Sparse — only
+          // items written with all four attributes appear in the index.
+          indexName: "MultiAttrIndex",
+          partitionKey: ["category", "subcategory"],
+          sortKey: ["rank", "sk"],
+          projection: { ProjectionType: "ALL" },
         },
       ],
     });

--- a/packages/alchemy/test/AWS/DynamoDB/handler.ts
+++ b/packages/alchemy/test/AWS/DynamoDB/handler.ts
@@ -22,7 +22,28 @@ export default DynamoDBTestFunction.make(
     const sourceTable = yield* DynamoDB.Table("TestTable", {
       partitionKey: "pk",
       sortKey: "sk",
-      attributes: { pk: "S", sk: "S" },
+      attributes: {
+        pk: "S",
+        sk: "S",
+        category: "S",
+        subcategory: "S",
+        rank: "S",
+      },
+      globalSecondaryIndexes: [
+        {
+          // Multi-attribute keys: composite HASH (category + subcategory)
+          // and composite RANGE (rank + sk). Sparse — only items written
+          // with all four attributes appear in the index.
+          IndexName: "MultiAttrIndex",
+          KeySchema: [
+            { AttributeName: "category", KeyType: "HASH" },
+            { AttributeName: "subcategory", KeyType: "HASH" },
+            { AttributeName: "rank", KeyType: "RANGE" },
+            { AttributeName: "sk", KeyType: "RANGE" },
+          ],
+          Projection: { ProjectionType: "ALL" },
+        },
+      ],
     });
     const restoreTargetTable = yield* DynamoDB.Table("RestoreTargetTable", {
       partitionKey: "pk",
@@ -89,12 +110,22 @@ export default DynamoDBTestFunction.make(
             pk: string;
             sk: string;
             data?: string;
+            category?: string;
+            subcategory?: string;
+            rank?: string;
           };
           const result = yield* putItem({
             Item: {
               pk: { S: body.pk },
               sk: { S: body.sk },
               ...(body.data ? { data: { S: body.data } } : {}),
+              // Natural attributes indexed by the multi-attribute-key GSI —
+              // no synthetic concatenated keys.
+              ...(body.category ? { category: { S: body.category } } : {}),
+              ...(body.subcategory
+                ? { subcategory: { S: body.subcategory } }
+                : {}),
+              ...(body.rank ? { rank: { S: body.rank } } : {}),
             },
           });
           return yield* HttpServerResponse.json({ success: true, result });
@@ -308,6 +339,39 @@ export default DynamoDBTestFunction.make(
           const result = yield* query({
             KeyConditionExpression: "pk = :pk",
             ExpressionAttributeValues: { ":pk": { S: pk } },
+          });
+          return yield* HttpServerResponse.json({
+            items: result.Items,
+            count: result.Count,
+          });
+        }
+
+        if (request.method === "GET" && pathname === "/query-multi") {
+          const category = url.searchParams.get("category");
+          const subcategory = url.searchParams.get("subcategory");
+          const rank = url.searchParams.get("rank");
+          if (!category || !subcategory) {
+            return HttpServerResponse.text("Missing category or subcategory", {
+              status: 400,
+            });
+          }
+          // Multi-attribute-key GSI query: every partition attribute must be
+          // an equality condition; sort attributes narrow left-to-right.
+          const result = yield* query({
+            IndexName: "MultiAttrIndex",
+            KeyConditionExpression: rank
+              ? "#c = :c AND #s = :s AND #r = :r"
+              : "#c = :c AND #s = :s",
+            ExpressionAttributeNames: {
+              "#c": "category",
+              "#s": "subcategory",
+              ...(rank ? { "#r": "rank" } : {}),
+            },
+            ExpressionAttributeValues: {
+              ":c": { S: category },
+              ":s": { S: subcategory },
+              ...(rank ? { ":r": { S: rank } } : {}),
+            },
           });
           return yield* HttpServerResponse.json({
             items: result.Items,


### PR DESCRIPTION
Support DynamoDB's [multi-attribute GSI keys](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GSI.DesignPattern.MultiAttributeKeys.html) (Nov 2025): GSI partition and sort keys composed of up to 4 attributes each. GSI-only — base-table primary keys and LSIs remain single-attribute, so the base-table props already match what AWS permits there.

Secondary-index props are now typed `partitionKey`/`sortKey` segments instead of the raw wire `KeySchema` list (breaking change):

```ts
globalSecondaryIndexes: [{
  indexName: "TournamentRegionIndex",
  partitionKey: ["tournamentId", "region"], // hashed together, ≤4, order-significant
  sortKey: ["round", "matchId"],            // queried left-to-right, ≤4
  projection: { ProjectionType: "ALL" },
}],
localSecondaryIndexes: [{
  indexName: "lsi-by-sk",
  sortKey: "sk",                            // LSI partition key is always the table's
  projection: { ProjectionType: "ALL" },
}]
```

AWS's flat `KeySchema` array is a wire-compat artifact: `CreateTable` validation enforces that it is really two contiguous ordered segments (probed live — `The first KeySchemaElement is not a HASH key type`, `All HASH key attributes must precede RANGE key attributes in the KeySchema`, `The KeySchema exceeds the maximum allowed number of HASH key attributes`). The typed props declare those segments directly and the provider derives the flat list, making RANGE-first / interleaved schemas unrepresentable. Diff compares in the wire shape and tolerates legacy wire-shaped `olds` from pre-upgrade state, so upgrading never plans a spurious (data-losing) table replacement.

The GSI diff also had a real bug for multi-attribute keys: it alphabetically sorted `KeySchema` before comparing, erasing the order that is now semantic — a reorder would have silently no-opped. It now normalizes only the HASH/RANGE grouping and preserves relative order within each segment, so reordering key attributes correctly replaces the table.

- Prop JSDoc + a "Multi-Attribute GSI Keys" example on `Table` (API reference regenerated).
- Live tests, green against real AWS: create/describe-order/query (composite partition key + left-to-right sort narrowing) + unchanged-redeploy no-op, and reorder-of-sort-attributes triggers table replacement.
- End-to-end runtime coverage through the effectful Lambda fixture: the shared Bindings table carries a multi-attribute-key GSI, `/put` writes the natural attributes, and a new `/query-multi` route queries the index through the deployed Lambda's `Query` binding (full 25-test Bindings suite green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
