### PR TITLE
feat(kubernetes): Image.ref for verbatim Deployment images

### DIFF
--- a/packages/alchemy/src/AWS/ECR/Image.ts
+++ b/packages/alchemy/src/AWS/ECR/Image.ts
@@ -13,6 +13,7 @@ import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
 import { createInternalTags } from "../../Tags.ts";
 import type { Providers } from "../Providers.ts";
+import type { BundledImageSource } from "./ImageSource.ts";
 
 /**
  * Docker login credentials for the account's private ECR registry, in the
@@ -95,7 +96,7 @@ export const buildAndPushEcrImage = Effect.fn(function* (
   return options.imageUri;
 });
 
-export interface ImageProps {
+interface ImagePropsBase {
   /**
    * URI of the target ECR repository, e.g. `repository.repositoryUri` from an
    * `ECR.Repository`. When omitted, the Image auto-creates (and owns) a
@@ -103,6 +104,17 @@ export interface ImageProps {
    * repository is force-deleted when the Image is destroyed.
    */
   repositoryUri?: string;
+  /**
+   * Target platform for the image build. Fargate defaults to X86_64, so the
+   * default pins `linux/amd64` — without it an image built on an ARM64 host
+   * (e.g. Apple Silicon) is rejected at task start.
+   * @default "linux/amd64"
+   */
+  platform?: string;
+}
+
+/** Build the image from a local Dockerfile and context. */
+export interface DockerfileImageProps extends ImagePropsBase {
   /**
    * Docker build context directory. Every file under the context (plus the
    * Dockerfile, platform, and build args) participates in the content hash
@@ -116,17 +128,21 @@ export interface ImageProps {
    */
   dockerfile?: string;
   /**
-   * Target platform for the image build. Fargate defaults to X86_64, so the
-   * default pins `linux/amd64` — without it an image built on an ARM64 host
-   * (e.g. Apple Silicon) is rejected at task start.
-   * @default "linux/amd64"
-   */
-  platform?: string;
-  /**
    * Docker build arguments (`--build-arg`).
    */
   buildArgs?: Record<string, string>;
 }
+
+/**
+ * Bundle an Effect program (`main`) into a generated image and push it
+ * to ECR. The same source shape as `AWS.ECS.Task` / `Kubernetes.Deployment`.
+ */
+export interface BundledImageProps extends ImagePropsBase, BundledImageSource {}
+
+export type ImageProps = DockerfileImageProps | BundledImageProps;
+
+const isBundledImageProps = (props: ImageProps): props is BundledImageProps =>
+  "main" in props && typeof props.main === "string";
 
 export interface Image extends Resource<
   "AWS.ECR.Image",
@@ -150,13 +166,13 @@ export interface Image extends Resource<
 > {}
 
 /**
- * A Docker image built from a local context and pushed to a private Amazon
- * ECR repository.
+ * A container image pushed to a private Amazon ECR repository.
  *
- * The image is identified by a content hash over the build context,
- * Dockerfile, platform, and build args. Reconcile rebuilds and pushes only
- * when that hash changes — a content change produces a new tag and digest on
- * the same resource, so replacement is never needed.
+ * Exactly one source: `context` (your Dockerfile) or `main` (bundle an
+ * Effect program). The image is identified by a content hash of that
+ * source. Reconcile rebuilds and pushes only when the hash changes — a
+ * content change produces a new tag and digest on the same resource, so
+ * replacement is never needed.
  *
  * @resource
  * @section Building Images
@@ -196,6 +212,20 @@ export interface Image extends Resource<
  *   sidecars: [{ name: "proxy", image: image.imageUri, essential: false }],
  * });
  * ```
+ *
+ * @section Bundling an Effect program
+ * @example Explicit repository + image, then a Kubernetes Deployment
+ * ```typescript
+ * const repository = yield* AWS.ECR.Repository("ApiRepository", {});
+ * const apiImage = yield* AWS.ECR.Image("ApiImage", {
+ *   repositoryUri: repository.repositoryUri,
+ *   main: import.meta.url,
+ * });
+ * const api = yield* Kubernetes.Deployment("Api", {
+ *   cluster,
+ *   image: apiImage,
+ * });
+ * ```
  */
 export const Image = Resource<Image>("AWS.ECR.Image");
 
@@ -218,7 +248,16 @@ export const ImageProvider = () =>
           lowercase: true,
         });
 
-      const resolveBuildPaths = Effect.fn(function* (props: ImageProps) {
+      // Dynamic import: ImageSource.ts imports buildAndPushEcrImage from
+      // this file. A static import here would be a module-init cycle.
+      const { makeImageSource, makeBunBootstrap } = yield* Effect.promise(
+        () => import("./ImageSource.ts"),
+      );
+      const imageSource = yield* makeImageSource;
+
+      const resolveBuildPaths = Effect.fn(function* (
+        props: DockerfileImageProps,
+      ) {
         const context = path.resolve(props.context);
         const dockerfile = props.dockerfile
           ? path.isAbsolute(props.dockerfile)
@@ -243,7 +282,9 @@ export const ImageProvider = () =>
       // the target platform, and the build args. Absolute paths deliberately
       // do NOT participate, so relocating an identical context (e.g. a temp
       // dir) produces the same tag.
-      const hashBuildInputs = Effect.fn(function* (props: ImageProps) {
+      const hashBuildInputs = Effect.fn(function* (
+        props: DockerfileImageProps,
+      ) {
         const { context, dockerfile } = yield* resolveBuildPaths(props);
         const hasher = yield* Effect.sync(() => crypto.createHash("sha256"));
         yield* Effect.sync(() =>
@@ -349,8 +390,14 @@ export const ImageProvider = () =>
         // new tag + digest on the same resource.
         diff: Effect.fn(function* ({ news, output }) {
           if (!isResolved(news) || !output) return undefined;
-          const hash = yield* hashBuildInputs(news);
-          if (hash !== output.imageTag) {
+          const hash = isBundledImageProps(news)
+            ? yield* imageSource.hash({
+                source: news,
+                platform: news.platform ?? "linux/amd64",
+                bootstrap: makeBunBootstrap(news.handler ?? "default"),
+              })
+            : yield* hashBuildInputs(news);
+          if (hash !== undefined && hash !== output.imageTag) {
             return { action: "update" } as const;
           }
         }),
@@ -375,6 +422,37 @@ export const ImageProvider = () =>
               );
               return { repositoryName, repositoryUri, ownsRepository: true };
             });
+
+          if (isBundledImageProps(news)) {
+            const resolved = yield* imageSource.resolve({
+              id,
+              source: news,
+              repositoryName,
+              repositoryUri,
+              platform: news.platform ?? "linux/amd64",
+              bootstrap: makeBunBootstrap(news.handler ?? "default"),
+              session,
+            });
+            const pushed = yield* describeImage(
+              resolved.repositoryName,
+              resolved.codeHash,
+            );
+            if (!pushed?.imageDigest) {
+              return yield* Effect.fail(
+                new Error(
+                  `Image ${resolved.imageUri} not found in ECR after push`,
+                ),
+              );
+            }
+            return {
+              imageUri: resolved.imageUri,
+              digest: pushed.imageDigest,
+              repositoryUri: resolved.repositoryUri,
+              repositoryName: resolved.repositoryName,
+              imageTag: resolved.codeHash,
+              ownsRepository,
+            };
+          }
 
           const { context, dockerfile } = yield* resolveBuildPaths(news);
           const imageTag = yield* hashBuildInputs(news);

--- a/packages/alchemy/src/AWS/ECR/index.ts
+++ b/packages/alchemy/src/AWS/ECR/index.ts
@@ -38,6 +38,8 @@ export {
   Image,
   ImageProvider,
   type EcrRegistryCredentials,
+  type BundledImageProps,
+  type DockerfileImageProps,
   type ImageProps,
 } from "./Image.ts";
 export {

--- a/packages/alchemy/src/Kubernetes/ClusterAdapter.ts
+++ b/packages/alchemy/src/Kubernetes/ClusterAdapter.ts
@@ -37,6 +37,7 @@ import type { InlineDockerfile } from "../Docker/Dockerfile.ts";
 import type { Stack } from "../Stack.ts";
 import type { Stage } from "../Stage.ts";
 import type { Connection } from "./Connection.ts";
+import type { ImageValue } from "./Image.ts";
 
 /**
  * Per-resource engine services ambient inside every provider lifecycle
@@ -157,7 +158,9 @@ export type WorkloadServices =
 /**
  * The image-source shape shared by every workload: exactly one of `main`
  * (bundle an inline Effect program), `context`/`dockerfile` (build the
- * user's Dockerfile), or `image` (a pre-built registry reference).
+ * user's Dockerfile), or `image` (a pre-built registry reference — a
+ * string is mirrored on EKS; {@link Image.ref} / `{ imageUri }` are used
+ * verbatim).
  * Structurally mirrors the AWS container platforms' source props.
  */
 export interface WorkloadImageSource {
@@ -173,7 +176,11 @@ export interface WorkloadImageSource {
   build?: Bundle.BundleConfig;
   context?: string;
   dockerfile?: string | InlineDockerfile;
-  image?: string;
+  /**
+   * Pre-built image. A `string` is mirrored into the managed registry on
+   * EKS; {@link Image.ref} or `{ imageUri }` is used verbatim.
+   */
+  image?: string | ImageValue;
 }
 
 export interface WorkloadIdentityReconcileOptions {

--- a/packages/alchemy/src/Kubernetes/Deployment.ts
+++ b/packages/alchemy/src/Kubernetes/Deployment.ts
@@ -40,15 +40,18 @@ import {
   type KubernetesObjectDefinition,
   type KubernetesObjectRef,
 } from "./internal/objects.ts";
+import type { ImageValue } from "./Image.ts";
 import {
   collectBindingEnv,
   connectionIdentity,
   connectionOfOutput,
   deepMerge,
   imagePlatformOf,
+  imageSourceKind,
   makeServerBootstrap,
   resolveWorkloadImage,
   tryConnectionOf,
+  usesManagedRegistry,
   workloadImageHash,
 } from "./internal/workload.ts";
 import type { Providers } from "./Providers.ts";
@@ -195,11 +198,17 @@ export interface DockerfileDeploymentProps extends DeploymentPropsBase {
 /** Run a pre-built registry image. */
 export interface ImageDeploymentProps extends DeploymentPropsBase {
   /**
-   * A pre-built image reference, e.g. `nginx:1.27`. On clusters with a
-   * managed registry (EKS) the image is mirrored into it; elsewhere the
-   * reference is used verbatim.
+   * A pre-built image.
+   *
+   * - `string` — on EKS, mirrored into a per-deployment ECR repository
+   *   (existing behaviour). On registry-less clusters the string is used
+   *   verbatim.
+   * - {@link Image.ref} — used verbatim; the cluster must be able to pull
+   *   it. Does not invoke the managed registry.
+   * - `{ imageUri }` — a produced image resource (e.g. `AWS.ECR.Image`).
+   *   Same as {@link Image.ref}: the uri is written onto the pod spec.
    */
-  image: string;
+  image: string | ImageValue;
 }
 
 export type DeploymentProps =
@@ -294,6 +303,25 @@ export interface DeploymentRuntimeContext extends HostRuntimeContext {
  * });
  * nginx.url;            // LB URL, e.g. "http://k8s-….elb.amazonaws.com"
  * nginx.deploymentName; // K8s-native attrs
+ * ```
+ *
+ * @example Pull a pre-built image directly (skip the EKS mirror)
+ * ```typescript
+ * const cache = yield* Kubernetes.Deployment("Cache", {
+ *   cluster,
+ *   image: Kubernetes.Image.ref(
+ *     "2956….dkr.ecr.us-east-1.amazonaws.com/apps@sha256:…",
+ *   ),
+ * });
+ * ```
+ *
+ * @example Run an image produced by AWS.ECR.Image
+ * ```typescript
+ * const apiImage = yield* AWS.ECR.Image("ApiImage", { context: "./api" });
+ * const api = yield* Kubernetes.Deployment("Api", {
+ *   cluster,
+ *   image: apiImage,
+ * });
  * ```
  *
  * @example Any cluster via kubeconfig
@@ -450,6 +478,37 @@ const retryUntilServiceReady = <A, E, R>(
 const isNotFound = (error: unknown): error is KubernetesApiError =>
   error instanceof KubernetesApiError && error.statusCode === 404;
 
+interface ObservedDeployment {
+  metadata?: { generation?: number };
+  spec?: { replicas?: number; progressDeadlineSeconds?: number };
+  status?: {
+    observedGeneration?: number;
+    replicas?: number;
+    updatedReplicas?: number;
+    availableReplicas?: number;
+  };
+}
+
+/** Kubernetes' completed-rollout conditions, exposed for unit testing. */
+export const isDeploymentRolloutComplete = (
+  deployment: ObservedDeployment,
+): boolean => {
+  const generation = deployment.metadata?.generation;
+  const desired = deployment.spec?.replicas ?? 1;
+  const status = deployment.status;
+  return (
+    generation !== undefined &&
+    (status?.observedGeneration ?? -1) >= generation &&
+    (status?.updatedReplicas ?? 0) === desired &&
+    (status?.replicas ?? 0) === desired &&
+    (status?.availableReplicas ?? 0) === desired
+  );
+};
+
+class DeploymentRolloutPending extends Data.TaggedError(
+  "Kubernetes.DeploymentRolloutPending",
+) {}
+
 export const DeploymentProvider = () =>
   Provider.effect(
     Deployment,
@@ -498,16 +557,44 @@ export const DeploymentProvider = () =>
           ),
         );
 
+      const stableAttributes: Array<keyof Deployment["Attributes"]> = [
+        "connection",
+        "namespace",
+        "serviceAccountName",
+        "deploymentName",
+        "serviceName",
+        "identity",
+        "registry",
+      ];
+
+      const waitForDeploymentRollout = (
+        transport: ClusterTransport,
+        deployment: KubernetesObjectDefinition,
+      ) => {
+        const deadlineSeconds =
+          (deployment.spec as { progressDeadlineSeconds?: number })
+            .progressDeadlineSeconds ?? 600;
+        return readObject({
+          transport,
+          object: toKubernetesObjectRef(deployment),
+        }).pipe(
+          Effect.flatMap((observed) =>
+            isDeploymentRolloutComplete(observed as ObservedDeployment)
+              ? Effect.succeed(observed)
+              : Effect.fail(new DeploymentRolloutPending()),
+          ),
+          Effect.retry({
+            while: (error) => error instanceof DeploymentRolloutPending,
+            schedule: Schedule.max([
+              Schedule.spaced("5 seconds"),
+              Schedule.recurs(Math.ceil(deadlineSeconds / 5)),
+            ]),
+          }),
+        );
+      };
+
       return {
-        stables: [
-          "connection",
-          "namespace",
-          "serviceAccountName",
-          "deploymentName",
-          "serviceName",
-          "identity",
-          "registry",
-        ],
+        stables: stableAttributes,
         // A Deployment's identity spans in-cluster Kubernetes objects plus
         // adapter-owned cloud resources (identity role, image repository).
         // There is no single enumeration that faithfully reconstructs that
@@ -538,6 +625,21 @@ export const DeploymentProvider = () =>
             (olds.namespace ?? "default") !== (news.namespace ?? "default")
           ) {
             return { action: "replace" } as const;
+          }
+          const oldSource = olds as WorkloadImageSource;
+          const newSource = news as WorkloadImageSource;
+          if (
+            imageSourceKind(oldSource) !== undefined &&
+            usesManagedRegistry(oldSource) !== usesManagedRegistry(newSource)
+          ) {
+            return {
+              action: "update",
+              // Registry ownership changes when a mirrored string becomes
+              // Image.ref / { imageUri }, or the reverse.
+              stables: stableAttributes.filter(
+                (attribute) => attribute !== "registry",
+              ),
+            } as const;
           }
           // Content drift: the props don't change when files under a build
           // context (or the bundled program) do, so surface hash drift as
@@ -778,6 +880,14 @@ export const DeploymentProvider = () =>
           yield* session.note(
             `Applied Kubernetes Deployment ${namespace}/${baseName}`,
           );
+
+          if (resolved.cleanupState !== undefined && adapter.registry) {
+            yield* waitForDeploymentRollout(transport, deploymentObject);
+            yield* adapter.registry.delete({ state: resolved.cleanupState });
+            yield* session.note(
+              `Removed previous managed image registry for ${namespace}/${baseName}`,
+            );
+          }
 
           // Resolve the LoadBalancer URL if applicable. The cloud listener
           // is the Service `port` (Kubernetes maps `spec.ports[].port` 1:1

--- a/packages/alchemy/src/Kubernetes/Deployment.ts
+++ b/packages/alchemy/src/Kubernetes/Deployment.ts
@@ -280,7 +280,9 @@ export interface DeploymentRuntimeContext extends HostRuntimeContext {
  * cluster's platform adapter — workload identity and a container image
  * from exactly one of three sources flat on props: `main` (bundle an
  * inline Effect program), `context` (build your own Dockerfile), or
- * `image` (a pre-built registry reference). On `AWS.EKS.Cluster` targets
+ * `image` (a pre-built registry reference — a string is mirrored into
+ * ECR on EKS; {@link Image.ref} or `{ imageUri }` is used verbatim).
+ * On `AWS.EKS.Cluster` targets
  * it accepts the same `{ env, policyStatements }` host binding contract as
  * `AWS.Lambda.Function` and `AWS.ECS.Task`: every AWS `Binding.Service`
  * (S3, DynamoDB, SQS, …) attaches env vars to the pod spec and IAM policy

--- a/packages/alchemy/src/Kubernetes/Deployment.ts
+++ b/packages/alchemy/src/Kubernetes/Deployment.ts
@@ -326,6 +326,19 @@ export interface DeploymentRuntimeContext extends HostRuntimeContext {
  * });
  * ```
  *
+ * @example Bundle an Effect program as an explicit ECR image
+ * ```typescript
+ * const repository = yield* AWS.ECR.Repository("ApiRepository", {});
+ * const apiImage = yield* AWS.ECR.Image("ApiImage", {
+ *   repositoryUri: repository.repositoryUri,
+ *   main: import.meta.url,
+ * });
+ * const api = yield* Kubernetes.Deployment("Api", {
+ *   cluster,
+ *   image: apiImage,
+ * });
+ * ```
+ *
  * @example Any cluster via kubeconfig
  * ```typescript
  * const local = Kubernetes.KubeConfig({ context: "kind-dev" });

--- a/packages/alchemy/src/Kubernetes/Image.ts
+++ b/packages/alchemy/src/Kubernetes/Image.ts
@@ -1,0 +1,84 @@
+/**
+ * Typed container-image values for Kubernetes workloads.
+ *
+ * A bare `image: string` on {@link Deployment} / {@link Job} still means
+ * "mirror into the cluster's managed registry" on EKS (existing
+ * behaviour). {@link Image.ref} is the lift that says the opposite: use
+ * this registry reference verbatim. A produced image resource (anything
+ * with `imageUri`, e.g. {@link AWS.ECR.Image}) is the same direct path
+ * without a wrapper.
+ *
+ * Build, bundle, and mirror stay on those image resources — they are
+ * lifecycles, not constructors.
+ */
+import type { Input } from "../Input.ts";
+
+export const ImageRefTypeId = "Kubernetes.Image.Ref" as const;
+
+/**
+ * A pre-built registry reference used verbatim on the pod spec.
+ * The cluster must already be able to pull it; Alchemy does not copy it
+ * into the managed registry.
+ */
+export interface Ref {
+  readonly _tag: typeof ImageRefTypeId;
+  readonly ref: Input<string>;
+}
+
+/**
+ * A produced image (e.g. `AWS.ECR.Image`). The workload writes
+ * `imageUri` onto the pod and never invokes the cluster registry adapter.
+ */
+export interface Produced {
+  readonly imageUri: Input<string>;
+}
+
+/** Values that skip the managed-registry mirror. */
+export type ImageValue = Ref | Produced;
+
+export const isRef = (value: unknown): value is Ref =>
+  typeof value === "object" &&
+  value !== null &&
+  (value as { _tag?: unknown })._tag === ImageRefTypeId;
+
+export const isProduced = (value: unknown): value is Produced =>
+  typeof value === "object" &&
+  value !== null &&
+  !isRef(value) &&
+  "imageUri" in value;
+
+/** True when `image` is a direct pull spec, not a string to be mirrored. */
+export const isDirectImage = (value: unknown): boolean =>
+  isRef(value) || isProduced(value);
+
+/**
+ * The resolved registry reference for a direct image, or `undefined` when
+ * `value` is not direct or its inner `Input` has not resolved to a string.
+ */
+export const directPullSpec = (value: unknown): string | undefined => {
+  if (isRef(value)) {
+    return typeof value.ref === "string" ? value.ref : undefined;
+  }
+  if (isProduced(value)) {
+    return typeof value.imageUri === "string" ? value.imageUri : undefined;
+  }
+  return undefined;
+};
+
+/**
+ * Lift a pre-built registry reference into a typed image that Deployment
+ * and Job will use verbatim.
+ *
+ * @example
+ * ```typescript
+ * image: Image.ref("2956….dkr.ecr.us-east-1.amazonaws.com/apps@sha256:…")
+ * image: Image.ref(other.imageUri)
+ * ```
+ */
+export const Image = {
+  ref: (ref: Input<string>): Ref => ({
+    _tag: ImageRefTypeId,
+    ref,
+  }),
+  isRef,
+};

--- a/packages/alchemy/src/Kubernetes/Job.ts
+++ b/packages/alchemy/src/Kubernetes/Job.ts
@@ -269,7 +269,9 @@ export interface JobRuntimeContext extends HostRuntimeContext {
  * target cluster's platform adapter — workload identity and a container
  * image from exactly one of three sources flat on props: `main` (bundle an
  * inline Effect program whose impl returns `{ run }`), `context` (build
- * your own Dockerfile), or `image` (a pre-built registry reference). On
+ * your own Dockerfile), or `image` (a pre-built registry reference — a
+ * string is mirrored into ECR on EKS; {@link Image.ref} or `{ imageUri }`
+ * is used verbatim). On
  * `AWS.EKS.Cluster` targets, bindings attach env vars to the pod and IAM
  * policy statements to a generated pod-identity role, exactly like
  * `Kubernetes.Deployment`.
@@ -281,6 +283,14 @@ export interface JobRuntimeContext extends HostRuntimeContext {
  *   cluster,
  *   image: "ghcr.io/acme/migrator:v3",
  *   backoffLimit: 2,
+ * });
+ * ```
+ *
+ * @example Pull a pre-built image directly (skip the EKS mirror)
+ * ```typescript
+ * const migrate = yield* Kubernetes.Job("DbMigrate", {
+ *   cluster,
+ *   image: Kubernetes.Image.ref("ghcr.io/acme/migrator@sha256:…"),
  * });
  * ```
  *

--- a/packages/alchemy/src/Kubernetes/Job.ts
+++ b/packages/alchemy/src/Kubernetes/Job.ts
@@ -44,15 +44,18 @@ import type {
   KubernetesObjectDefinition,
   KubernetesObjectRef,
 } from "./internal/objects.ts";
+import type { ImageValue } from "./Image.ts";
 import {
   collectBindingEnv,
   connectionIdentity,
   connectionOfOutput,
   deepMerge,
   imagePlatformOf,
+  imageSourceKind,
   makeJobBootstrap,
   resolveWorkloadImage,
   tryConnectionOf,
+  usesManagedRegistry,
   workloadImageHash,
 } from "./internal/workload.ts";
 import type { Providers } from "./Providers.ts";
@@ -190,11 +193,10 @@ export interface DockerfileJobProps extends JobPropsBase {
 /** Run a pre-built registry image. */
 export interface ImageJobProps extends JobPropsBase {
   /**
-   * A pre-built image reference, e.g. `ghcr.io/acme/migrator:v3`. On
-   * clusters with a managed registry (EKS) the image is mirrored into it;
-   * elsewhere the reference is used verbatim.
+   * A pre-built image. A `string` is mirrored into the managed registry
+   * on EKS; {@link Image.ref} or `{ imageUri }` is used verbatim.
    */
-  image: string;
+  image: string | ImageValue;
 }
 
 export type JobProps = BundledJobProps | DockerfileJobProps | ImageJobProps;
@@ -429,14 +431,16 @@ export const JobProvider = () =>
               Effect.map((name) => name.replaceAll(/[^a-z0-9-]/g, "-")),
             );
 
+      const stableAttributes: Array<keyof Job["Attributes"]> = [
+        "connection",
+        "namespace",
+        "serviceAccountName",
+        "identity",
+        "registry",
+      ];
+
       return {
-        stables: [
-          "connection",
-          "namespace",
-          "serviceAccountName",
-          "identity",
-          "registry",
-        ],
+        stables: stableAttributes,
         // A Job's identity spans in-cluster Kubernetes objects plus
         // adapter-owned cloud resources — no single enumeration
         // reconstructs the composite, so enumeration is empty; `read`
@@ -458,6 +462,19 @@ export const JobProvider = () =>
             (olds.namespace ?? "default") !== (news.namespace ?? "default")
           ) {
             return { action: "replace" } as const;
+          }
+          const oldSource = olds as WorkloadImageSource;
+          const newSource = news as WorkloadImageSource;
+          if (
+            imageSourceKind(oldSource) !== undefined &&
+            usesManagedRegistry(oldSource) !== usesManagedRegistry(newSource)
+          ) {
+            return {
+              action: "update",
+              stables: stableAttributes.filter(
+                (attribute) => attribute !== "registry",
+              ),
+            } as const;
           }
           // Content drift (see Deployment).
           const connection = tryConnectionOf(news.cluster);

--- a/packages/alchemy/src/Kubernetes/index.ts
+++ b/packages/alchemy/src/Kubernetes/index.ts
@@ -3,6 +3,17 @@ export * from "./ClusterAdapter.ts";
 export * from "./Connection.ts";
 export * from "./Deployment.ts";
 export * from "./HelmChart.ts";
+export {
+  Image,
+  ImageRefTypeId,
+  directPullSpec,
+  isDirectImage,
+  isProduced,
+  isRef,
+  type ImageValue,
+  type Produced,
+  type Ref,
+} from "./Image.ts";
 export * from "./Job.ts";
 export * from "./Manifest.ts";
 export * from "./Providers.ts";

--- a/packages/alchemy/src/Kubernetes/internal/workload.ts
+++ b/packages/alchemy/src/Kubernetes/internal/workload.ts
@@ -13,6 +13,7 @@ import type { ResourceBinding } from "../../Resource.ts";
 import { Self } from "../../Self.ts";
 import { sha256Object } from "../../Util/sha256.ts";
 import type {
+  AdapterLifecycleServices,
   ClusterAdapterService,
   IdentityState,
   RegistryState,
@@ -20,6 +21,7 @@ import type {
   WorkloadImageSource,
 } from "../ClusterAdapter.ts";
 import type { ClusterLike, Connection, ConnectionAuth } from "../Connection.ts";
+import { directPullSpec, isDirectImage } from "../Image.ts";
 
 /**
  * Structural deep merge: objects merge recursively; arrays and primitives
@@ -168,6 +170,29 @@ export const imageSourceKind = (
         : undefined;
 
 /**
+ * True when this source goes through the cluster adapter's managed
+ * registry (ECR on EKS). `main` / `context` always do; a pre-built
+ * `image` string does; {@link Image.ref} and `{ imageUri }` do not.
+ */
+export const usesManagedRegistry = (source: WorkloadImageSource): boolean => {
+  const kind = imageSourceKind(source);
+  if (kind === "main" || kind === "context") return true;
+  if (kind === "image") return !isDirectImage(source.image);
+  return false;
+};
+
+/** Resolved pull spec for a pre-built image source, if one is known. */
+export const imagePullSpec = (
+  source: WorkloadImageSource,
+): string | undefined => {
+  if (imageSourceKind(source) !== "image" || source.image === undefined) {
+    return undefined;
+  }
+  if (typeof source.image === "string") return source.image;
+  return directPullSpec(source.image);
+};
+
+/**
  * Content hash for image sources whose identity is computable without a
  * bundler: `image` (the ref + platform) and `context` (the build-context
  * directory + Dockerfile content + platform). `main` returns `undefined`
@@ -179,10 +204,9 @@ export const computeStaticWorkloadImageHash = Effect.fn(function* (
 ) {
   const kind = imageSourceKind(source);
   if (kind === "image") {
-    return (yield* sha256Object({ image: source.image!, platform })).slice(
-      0,
-      16,
-    );
+    const spec = imagePullSpec(source);
+    if (spec === undefined) return undefined;
+    return (yield* sha256Object({ image: spec, platform })).slice(0, 16);
   }
   if (kind === "context") {
     if (
@@ -230,18 +254,62 @@ export interface ResolveWorkloadImageOptions {
   session: { note: (message: string) => Effect.Effect<void> };
 }
 
+export interface ResolvedWorkloadImage {
+  imageUri: string;
+  codeHash: string;
+  state: RegistryState | undefined;
+  /** Previous managed-registry state to delete after the new image is live. */
+  cleanupState: Record<string, unknown> | undefined;
+}
+
+const resolveDirectImage = Effect.fn(function* (
+  options: ResolveWorkloadImageOptions,
+) {
+  const spec = imagePullSpec(options.source);
+  if (spec === undefined) {
+    return yield* Effect.die(
+      new Error(
+        `'${options.id}': direct image did not resolve to a registry ` +
+          "reference. Pass Image.ref(...) or a resource with a string " +
+          "`imageUri` (Outputs must be resolved at deploy time).",
+      ),
+    );
+  }
+  const codeHash = (yield* computeStaticWorkloadImageHash(
+    options.source,
+    options.platform,
+  ))!;
+  return {
+    imageUri: spec,
+    codeHash,
+    state: undefined,
+    cleanupState:
+      options.adapter.registry === undefined ? undefined : options.state,
+  } satisfies ResolvedWorkloadImage;
+});
+
 /**
- * Resolve the container image for a workload: through the cluster
- * adapter's managed registry when it has one (build/mirror + push), or —
- * on registry-less clusters — pass a pre-built `image` reference through
- * verbatim. `main`/`context` sources require a managed registry.
+ * Resolve the container image for a workload.
+ *
+ * A pre-built {@link Image.ref} or `{ imageUri }` is used verbatim and
+ * never invokes the managed registry. A bare `image: string` is still
+ * mirrored when the cluster adapter has a registry (EKS → ECR) — the
+ * existing default. `main` / `context` always require a managed registry.
  */
 export const resolveWorkloadImage = Effect.fn(function* (
   options: ResolveWorkloadImageOptions,
-) {
+): Effect.fn.Return<
+  ResolvedWorkloadImage,
+  any,
+  AdapterLifecycleServices | FileSystem.FileSystem | Path.Path
+> {
   const { adapter, source } = options;
+  if (imageSourceKind(source) === "image" && isDirectImage(source.image)) {
+    return yield* resolveDirectImage(options);
+  }
+
   if (adapter.registry !== undefined) {
-    return yield* adapter.registry.resolve({
+    const resolved = yield* adapter.registry.resolve({
       id: options.id,
       source,
       platform: options.platform,
@@ -252,19 +320,12 @@ export const resolveWorkloadImage = Effect.fn(function* (
       state: options.state,
       session: options.session,
     });
+    return { ...resolved, cleanupState: undefined };
   }
 
   const kind = imageSourceKind(source);
   if (kind === "image") {
-    const codeHash = (yield* computeStaticWorkloadImageHash(
-      source,
-      options.platform,
-    ))!;
-    return {
-      imageUri: source.image!,
-      codeHash,
-      state: undefined,
-    };
+    return yield* resolveDirectImage(options);
   }
 
   return yield* Effect.die(
@@ -286,6 +347,15 @@ export const workloadImageHash = Effect.fn(function* (options: {
   isExternal?: boolean | undefined;
   bootstrap: (importPath: string) => string;
 }) {
+  if (
+    imageSourceKind(options.source) === "image" &&
+    isDirectImage(options.source.image)
+  ) {
+    return yield* computeStaticWorkloadImageHash(
+      options.source,
+      options.platform,
+    );
+  }
   if (options.adapter.registry !== undefined) {
     return yield* options.adapter.registry.hash({
       source: options.source,

--- a/packages/alchemy/test/Kubernetes/Image.test.ts
+++ b/packages/alchemy/test/Kubernetes/Image.test.ts
@@ -1,0 +1,213 @@
+import { InstanceId } from "@/InstanceId.ts";
+import * as Kubernetes from "@/Kubernetes";
+import type { ClusterAdapterService } from "@/Kubernetes/ClusterAdapter.ts";
+import { isDeploymentRolloutComplete } from "@/Kubernetes/Deployment.ts";
+import {
+  resolveWorkloadImage,
+  usesManagedRegistry,
+  workloadImageHash,
+} from "@/Kubernetes/internal/workload.ts";
+import { Stack, type StackSpec } from "@/Stack.ts";
+import { Stage } from "@/Stage.ts";
+import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
+import { describe, expect, it } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+
+const unitStack: Omit<StackSpec, "output"> = {
+  name: "kubernetes-image-test",
+  stage: "test",
+  resources: {},
+  bindings: {},
+  actions: {},
+};
+
+const adapterLifecycleLayer = Layer.mergeAll(
+  NodeFileSystem.layer,
+  Path.layer,
+  Layer.succeed(Stack, unitStack),
+  Layer.succeed(Stage, unitStack.stage),
+  Layer.succeed(InstanceId, "0123456789abcdef0123456789abcdef"),
+);
+
+const provideAdapterLifecycle = <A, E>(
+  effect: Effect.Effect<
+    A,
+    E,
+    Stack | Stage | InstanceId | FileSystem.FileSystem | Path.Path
+  >,
+) => effect.pipe(Effect.provide(adapterLifecycleLayer));
+
+const checkImageTypeSurface = () => {
+  const cluster = undefined as unknown as Kubernetes.ClusterLike;
+  const stringProps: Kubernetes.ImageDeploymentProps = {
+    cluster,
+    image: "registry.example.test/cache:v1",
+  };
+  const refProps: Kubernetes.ImageDeploymentProps = {
+    cluster,
+    image: Kubernetes.Image.ref("registry.example.test/cache@sha256:abc"),
+  };
+  const producedProps: Kubernetes.ImageDeploymentProps = {
+    cluster,
+    image: { imageUri: "2956.dkr.ecr.us-east-1.amazonaws.com/apps:hash" },
+  };
+  const bundledProps: Kubernetes.BundledDeploymentProps = {
+    cluster,
+    main: import.meta.url,
+    image: "oven/bun:1",
+  };
+  return { stringProps, refProps, producedProps, bundledProps };
+};
+void checkImageTypeSurface;
+
+const makeRegistryAdapter = (calls: string[]): ClusterAdapterService => ({
+  kind: "Kubernetes.ClusterAdapter",
+  connect: () => Effect.die(new Error("not used")),
+  registry: {
+    resolve: () =>
+      Effect.sync(() => {
+        calls.push("resolve");
+        return {
+          imageUri: "managed.example.test/repository:latest",
+          codeHash: "managed-hash",
+          state: { kind: "aws-ecr", repositoryName: "repository" },
+        } as any;
+      }),
+    hash: () =>
+      Effect.sync(() => {
+        calls.push("hash");
+        return "managed-hash";
+      }),
+    delete: () => Effect.void,
+  },
+});
+
+const imageOptions = (adapter: ClusterAdapterService, source: any) => ({
+  adapter,
+  id: "ImageRefTest",
+  source,
+  platform: "linux/amd64",
+  bootstrap: () => "",
+  tags: {},
+  state: { kind: "aws-ecr", repositoryName: "previous-repository" },
+  session: { note: () => Effect.void },
+});
+
+describe("Kubernetes.Image.ref", () => {
+  it.effect(
+    "mirrors a pre-built image string through the managed registry",
+    () =>
+      provideAdapterLifecycle(
+        Effect.gen(function* () {
+          const calls: string[] = [];
+          const source = { image: "registry.example.test/cache:v1" };
+          expect(usesManagedRegistry(source)).toBe(true);
+          const resolved = yield* resolveWorkloadImage(
+            imageOptions(makeRegistryAdapter(calls), source),
+          );
+          expect(calls).toEqual(["resolve"]);
+          expect(resolved.imageUri).toBe(
+            "managed.example.test/repository:latest",
+          );
+          expect(resolved.cleanupState).toBeUndefined();
+        }),
+      ),
+  );
+
+  it.effect("uses Image.ref verbatim without invoking the registry", () =>
+    provideAdapterLifecycle(
+      Effect.gen(function* () {
+        const calls: string[] = [];
+        const previous = {
+          kind: "aws-ecr",
+          repositoryName: "previous-repository",
+        };
+        const source = {
+          image: Kubernetes.Image.ref("registry.example.test/cache@sha256:abc"),
+        };
+        expect(usesManagedRegistry(source)).toBe(false);
+        const resolved = yield* resolveWorkloadImage({
+          ...imageOptions(makeRegistryAdapter(calls), source),
+          state: previous,
+        });
+        expect(calls).toEqual([]);
+        expect(resolved.imageUri).toBe(
+          "registry.example.test/cache@sha256:abc",
+        );
+        expect(resolved.state).toBeUndefined();
+        expect(resolved.cleanupState).toEqual(previous);
+      }),
+    ),
+  );
+
+  it.effect(
+    "uses a produced imageUri verbatim without invoking the registry",
+    () =>
+      provideAdapterLifecycle(
+        Effect.gen(function* () {
+          const calls: string[] = [];
+          const source = {
+            image: {
+              imageUri: "2956.dkr.ecr.us-east-1.amazonaws.com/apps@sha256:def",
+            },
+          };
+          expect(usesManagedRegistry(source)).toBe(false);
+          const resolved = yield* resolveWorkloadImage(
+            imageOptions(makeRegistryAdapter(calls), source),
+          );
+          expect(calls).toEqual([]);
+          expect(resolved.imageUri).toBe(
+            "2956.dkr.ecr.us-east-1.amazonaws.com/apps@sha256:def",
+          );
+          expect(resolved.state).toBeUndefined();
+        }),
+      ),
+  );
+
+  it.effect("hashes Image.ref without invoking the managed registry", () =>
+    provideAdapterLifecycle(
+      Effect.gen(function* () {
+        const calls: string[] = [];
+        const hash = yield* workloadImageHash({
+          adapter: makeRegistryAdapter(calls),
+          source: {
+            image: Kubernetes.Image.ref("registry.example.test/cache:v2"),
+          },
+          platform: "linux/amd64",
+          bootstrap: () => "",
+        });
+        expect(hash).toMatch(/^[a-f0-9]{16}$/);
+        expect(calls).toEqual([]);
+      }),
+    ),
+  );
+
+  it("recognizes only a fully completed Kubernetes rollout", () => {
+    const complete = {
+      metadata: { generation: 4 },
+      spec: { replicas: 2 },
+      status: {
+        observedGeneration: 4,
+        replicas: 2,
+        updatedReplicas: 2,
+        availableReplicas: 2,
+      },
+    };
+    expect(isDeploymentRolloutComplete(complete)).toBe(true);
+    expect(
+      isDeploymentRolloutComplete({
+        ...complete,
+        status: { ...complete.status, replicas: 3 },
+      }),
+    ).toBe(false);
+    expect(
+      isDeploymentRolloutComplete({
+        ...complete,
+        status: { ...complete.status, observedGeneration: 3 },
+      }),
+    ).toBe(false);
+  });
+});

--- a/website/src/content/docs/aws/compute/choosing-a-runtime.mdx
+++ b/website/src/content/docs/aws/compute/choosing-a-runtime.mdx
@@ -79,8 +79,10 @@ load-balancer integration. Alchemy models it with:
   `compute: "auto"` turns on Auto Mode with sensible defaults.
 - [`Deployment`](/providers/kubernetes/deployment) — a replicated
   Kubernetes server (the Kubernetes analog of `AWS.ECS.Service`)
-  with the same three image sources as ECS: a registry `image`, a
-  Dockerfile `context`, or an inline Effect program via `main`.
+  with the same three image sources as ECS: a registry `image`
+  (mirrored into ECR, or `Image.ref` / `{ imageUri }` to pull
+  as-is), a Dockerfile `context`, or an inline Effect program via
+  `main`.
 - [`Job`](/providers/kubernetes/job) — run-to-completion work, or a
   `CronJob` when you set `schedule`.
 - [`Manifest`](/providers/kubernetes/manifest) and

--- a/website/src/content/docs/aws/compute/eks.mdx
+++ b/website/src/content/docs/aws/compute/eks.mdx
@@ -175,7 +175,10 @@ bundled into a generated image instead — the same authoring model as
 `Deployment` accepts the same `{ env, policyStatements }` binding
 contract as a Lambda `Function`, so every AWS `Binding.Service`
 attaches environment variables to the Pod spec and IAM policy
-statements to a generated **Pod Identity role**:
+statements to a generated **Pod Identity role**.
+
+The compact form lets Deployment own the bundle and the per-workload
+ECR repository:
 
 ```typescript
 const api = yield* Kubernetes.Deployment(
@@ -191,6 +194,25 @@ const api = yield* Kubernetes.Deployment(
     };
   }).pipe(Effect.provide(AWS.DynamoDB.PutItemHttp)),
 );
+```
+
+To own the repository and the image as their own resources, bundle
+`main` on `AWS.ECR.Image` and pass the result into Deployment.
+The image is not mirrored again — Deployment writes `apiImage.imageUri`
+onto the pod:
+
+```typescript
+const repository = yield* AWS.ECR.Repository("ApiRepository", {});
+const apiImage = yield* AWS.ECR.Image("ApiImage", {
+  repositoryUri: repository.repositoryUri,
+  main: import.meta.url,
+});
+const api = yield* Kubernetes.Deployment("Api", {
+  cluster,
+  image: apiImage,
+  port: 3000,
+  replicas: 2,
+});
 ```
 
 Every Kubernetes workload on EKS gets Pod Identity as standard:

--- a/website/src/content/docs/aws/compute/eks.mdx
+++ b/website/src/content/docs/aws/compute/eks.mdx
@@ -128,15 +128,18 @@ replicated Kubernetes server — the Kubernetes analog of
 synthesizes a Kubernetes `Deployment` + `Service` (+
 `ServiceAccount`) and applies them via server-side apply, with the
 container image coming from exactly one of three sources flat on
-props: `image` (a registry reference, mirrored into ECR), `context`
+props: `image` (a pre-built registry reference), `context`
 (build your own Dockerfile), or `main` (bundle an inline Effect
 program). The simplest form runs a remote image with no Effect
-runtime in the container:
+runtime in the container. A bare string is **mirrored into a
+per-deployment ECR repository** so the nodes pull over IAM; wrap
+the same string in `Kubernetes.Image.ref(...)` to skip the copy
+when the cluster can already pull it:
 
 ```typescript
 const echo = yield* Kubernetes.Deployment("EchoServer", {
   cluster,
-  image: "registry.k8s.io/echoserver:1.10",
+  image: "registry.k8s.io/echoserver:1.10", // mirrored into ECR
   namespace: "default",
   replicas: 2,
   port: 8080,
@@ -145,6 +148,18 @@ const echo = yield* Kubernetes.Deployment("EchoServer", {
 
 echo.url;            // LoadBalancer hostname (an NLB on Auto Mode)
 echo.deploymentName; // K8s-native attrs: deploymentName, serviceName, ...
+
+// Already in a registry the nodes can pull — no extra ECR repo.
+const cache = yield* Kubernetes.Deployment("Cache", {
+  cluster,
+  image: Kubernetes.Image.ref(
+    "123456789012.dkr.ecr.us-east-1.amazonaws.com/apps@sha256:…",
+  ),
+});
+
+// Or pass a produced image resource (AWS.ECR.Image) — same direct path.
+const apiImage = yield* AWS.ECR.Image("ApiImage", { context: "./api" });
+const api = yield* Kubernetes.Deployment("Api", { cluster, image: apiImage });
 ```
 
 `serviceType: "LoadBalancer"` provisions a cloud load balancer and
@@ -192,7 +207,9 @@ Cloudflare Workers.
 ## Run-to-completion work with Job
 
 [`Kubernetes.Job`](/providers/kubernetes/job) runs a container to
-completion — the Kubernetes analog of `AWS.ECS.Task`. Same three image sources,
+completion — the Kubernetes analog of `AWS.ECS.Task`. Same three image sources
+(a bare `image` string still mirrors into ECR; `Image.ref` / `{ imageUri }`
+pull as-is),
 same bindings and Pod Identity; an Effect impl returns `{ run }`
 instead of `{ fetch }`, executing to completion inside the Pod:
 


### PR DESCRIPTION
## What

Adds `Kubernetes.Image.ref` — the only new wrapper — so a pre-built registry reference can be placed on a `Kubernetes.Deployment` / `Kubernetes.Job` **verbatim**, without copying it through the EKS managed registry.

```ts
yield* Kubernetes.Deployment("Cache", {
  cluster,
  image: Kubernetes.Image.ref(
    "2956….dkr.ecr.us-east-1.amazonaws.com/apps@sha256:…",
  ),
});
```

A produced image resource (anything with `imageUri`, e.g. `AWS.ECR.Image`) is accepted the same way, with no wrapper:

```ts
const apiImage = yield* AWS.ECR.Image("ApiImage", { context: "./api" });
yield* Kubernetes.Deployment("Api", { cluster, image: apiImage });
```

Build, bundle, and mirror stay on **existing resources and their props**. They are not new `Image.*` constructors — those are lifecycles, not type lifts.

Supersedes #1098 (and the closed re-roll #1207). Those added `imageStrategy: "direct"`, which never shipped. This PR does not include that flag.

## Why

On EKS, `Kubernetes.Deployment` routes every `image: string` through the cluster adapter's managed ECR repo: pull on the deploy host, push a per-deployment copy, point the pod at the copy. That is the right default when the cluster should only pull IAM-authenticated ECR. It is the wrong path when the image already lives in a registry the nodes can pull (a shared ECR repo, a digest pushed by CI, an in-cluster pull-through cache).

The missing capability is not "a strategy enum on Deployment". It is a typed value that means **this string is already a pull spec**. `Image.ref` is that lift. `Docker.RemoteImage` cannot express it: it still `docker pull`s on the deploy host.

## Design

Three stages, only one of which needed a new type:

| Stage | Where it lives |
|---|---|
| **Produce** (bundle / Dockerfile / already-built digest) | `main` / `context` on Deployment (unchanged), or `AWS.ECR.Image` (`main` or `context`) / `Docker.Image` |
| **Publish** (land bytes in a pullable registry) | `AWS.ECR.Image` (and the existing EKS adapter mirror for a bare `image: string`) |
| **Run** | Deployment / Job write a pull spec onto the pod |

`image` on `ImageDeploymentProps` / `ImageJobProps` is now:

```ts
image: string | Image.Ref | { imageUri: Input<string> }
```

- `string` — **unchanged EKS behaviour**: mirror into the per-workload ECR repo.
- `Image.ref(ref)` — tagged `{ _tag: "Kubernetes.Image.Ref", ref }`. Used verbatim. Accepts `Input<string>` so `Output`s keep their dependency edge. Structural tag, not a branded string — same reason as `Dockerfile.inline`: brands die in state and cannot wrap `Output<string>`.
- `{ imageUri }` — a produced image resource. Same direct path.

`main` and `context` are unchanged. They still require a managed registry.

Switching an existing EKS deployment from a mirrored `image: string` to `Image.ref` / `{ imageUri }` retires the old ECR repo **after** the new rollout is complete (`replicas == updatedReplicas == availableReplicas` and `observedGeneration >= generation`), so the mirrored image stays pullable until nothing references it. `registry` is dropped from `stables` for that transition.

## Before / after

### Pre-built image the cluster can already pull

```ts
// before — EKS always mirrored this, even when the digest was already in ECR
yield* Kubernetes.Deployment("Cache", {
  cluster,
  image: "2956….dkr.ecr.us-east-1.amazonaws.com/apps@sha256:…",
});

// after — skip the mirror; pod pulls the digest you named
yield* Kubernetes.Deployment("Cache", {
  cluster,
  image: Kubernetes.Image.ref(
    "2956….dkr.ecr.us-east-1.amazonaws.com/apps@sha256:…",
  ),
});
```

### Image produced by an existing resource

```ts
// before — Deployment owned build+push via `context` (still valid)
yield* Kubernetes.Deployment("Api", {
  cluster,
  context: "./api",
});

// after — preferred: produce on the image resource, run the result
const apiImage = yield* AWS.ECR.Image("ApiImage", { context: "./api" });
yield* Kubernetes.Deployment("Api", { cluster, image: apiImage });
```

### Bundle an Effect program

```ts
// compact — still valid: Deployment owns the bundle and the per-workload ECR repo
yield* Kubernetes.Deployment("Api", {
  cluster,
  main: import.meta.url,
});

// explicit — produce on named resources, then run the result (not remirrored)
const repository = yield* AWS.ECR.Repository("ApiRepository", {});
const apiImage = yield* AWS.ECR.Image("ApiImage", {
  repositoryUri: repository.repositoryUri,
  main: import.meta.url,
});
yield* Kubernetes.Deployment("Api", { cluster, image: apiImage });
```

### Mirror a public image into ECR (existing EKS default)

```ts
// unchanged — a bare string still mirrors on EKS
yield* Kubernetes.Deployment("Nginx", {
  cluster,
  image: "nginx:1.27",
});
```

## Backwards compatibility (EKS)

Only EKS is in scope. `imageStrategy` never shipped, so there is nothing to migrate.

| Existing EKS program | This PR |
|---|---|
| `{ image: "nginx:1.27" }` | Still mirrors into per-deployment ECR. Same resolved image, hash, and persisted `registry` state. |
| `{ main: import.meta.url }` | Unchanged. Still bundled and pushed through the adapter registry. |
| `{ context: "./app" }` | Unchanged. Still built and pushed through the adapter registry. |
| `{ image: Image.ref("…") }` | New. Direct pull; no registry adapter call. |
| `{ image: ecrImage }` | New. Direct pull of `ecrImage.imageUri`. |

A first deploy of an existing stack that still uses `image: string` / `main` / `context` is a no-op relative to current main.

## Tests

`packages/alchemy/test/Kubernetes/Image.test.ts`, against a fake `ClusterAdapterService` whose registry records every call:

- **mirrors a pre-built image string** — no `Image.ref` ⇒ `registry.resolve` is called and its `imageUri` wins; `cleanupState` is `undefined`.
- **uses `Image.ref` verbatim** — zero registry calls; `imageUri` is the supplied reference; previously persisted registry state comes back as `cleanupState`.
- **uses a produced `imageUri` verbatim** — same direct path for `{ imageUri }`.
- **hashes `Image.ref` without the managed registry** — plan-time `workloadImageHash` also bypasses `registry.hash`.
- **recognizes only a fully completed Kubernetes rollout** — `isDeploymentRolloutComplete` against complete, under-replicated, and stale-generation statuses.
- A compile-time surface check that `ImageDeploymentProps.image` accepts `string`, `Image.ref(...)`, and `{ imageUri }`, and that bundled `image` is still the `FROM` string.

```
$ cd packages/alchemy && bun alchemy-test test/Kubernetes/Image.test.ts test/Kubernetes/HelmChart.test.ts
Tests: 0 failed | 12 passed (2 files)
```

## Out of scope

- Extending `AWS.ECR.Image` with `image` (mirror a public ref). `main` and `context` are supported; a bare `image: string` on Deployment still mirrors.
- `Kubernetes.Job` registry cleanup after a mirror → `Image.ref` switch (no rollout to gate it on). Job accepts the same `image` union; leftover ECR from a switch is not deleted automatically.
- GKE / registry-less clusters: a pre-built `image` string was already pass-through. No compatibility work.
