### PR TITLE
fix(cloudflare/workers): paginate zone inference for domains and routes

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -2,7 +2,6 @@ import * as durableObjectsApi from "@distilled.cloud/cloudflare/durable-objects"
 import * as rulesets from "@distilled.cloud/cloudflare/rulesets";
 import * as workers from "@distilled.cloud/cloudflare/workers";
 import * as wfp from "@distilled.cloud/cloudflare/workers-for-platforms";
-import * as zones from "@distilled.cloud/cloudflare/zones";
 import * as Config from "effect/Config";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
@@ -31,7 +30,7 @@ import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
 import { localRuntimeServices } from "../LocalRuntime.ts";
 import { detachQueueConsumersOfScript } from "../Queues/Consumer.ts";
 import { CloudflareLogs } from "../Logs.ts";
-import { resolveZoneId } from "../Zone/lookup.ts";
+import { findZoneByName, resolveZoneId } from "../Zone/lookup.ts";
 import {
   getAssetsPathPrefix,
   mergeAssetsConfigFiles,
@@ -1073,7 +1072,6 @@ export const LiveWorkerProvider = () =>
       // const putDomain = yield* workers.putDomain;
       // const listDomains = yield* workers.listDomains;
       // const deleteDomain = yield* workers.deleteDomain;
-      // const listZones = yield* zones.listZones;
       const telemetry = yield* CloudflareLogs;
 
       // Account subdomain is invariant for the life of a provider layer —
@@ -1210,9 +1208,20 @@ export const LiveWorkerProvider = () =>
         });
 
       /**
-       * Infer the Cloudflare Zone ID for a given hostname by listing the
-       * account's zones and matching the hostname against each zone's name —
-       * walking up the DNS label hierarchy until a match is found.
+       * Infer the Cloudflare Zone ID for a given hostname by walking up the
+       * DNS label hierarchy and asking Cloudflare for each candidate zone
+       * name until one matches.
+       *
+       * Deliberately an exact-name lookup per candidate rather than listing
+       * the account's zones: `GET /zones` pages at 20 by default, so any
+       * account with more zones than that would silently fail to resolve the
+       * ones past the first page. The lookup is also scoped to `accountId`,
+       * so a token with access to several accounts can't match a zone the
+       * Worker's account doesn't own.
+       *
+       * `zoneCache` memoizes both the resolved hostname and the zone name it
+       * resolved through, so sibling hostnames on the same zone (`api.x.com`,
+       * `app.x.com`) cost one request in total.
        */
       const inferZoneIdForHostname = (
         hostname: string,
@@ -1222,20 +1231,20 @@ export const LiveWorkerProvider = () =>
           const cached = zoneCache.get(hostname);
           if (cached) return cached;
 
-          const zoneList = yield* zones
-            .listZones({})
-            .pipe(Effect.map((response) => response.result ?? []));
-          for (const zone of zoneList) {
-            zoneCache.set(zone.name, zone.id);
-          }
+          const { accountId } = yield* yield* CloudflareEnvironment;
 
           const parts = hostname.split(".");
           for (let i = 0; i < parts.length - 1; i++) {
             const candidate = parts.slice(i).join(".");
-            const match = zoneList.find((z) => z.name === candidate);
-            if (match) {
-              zoneCache.set(hostname, match.id);
-              return match.id;
+            const hit =
+              zoneCache.get(candidate) ??
+              (yield* findZoneByName({ accountId, name: candidate }).pipe(
+                Effect.map((zone) => zone?.id),
+              ));
+            if (hit) {
+              zoneCache.set(candidate, hit);
+              zoneCache.set(hostname, hit);
+              return hit;
             }
           }
           return yield* Effect.die(

--- a/packages/alchemy/test/Cloudflare/Workers/ZonePaging.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/ZonePaging.test.ts
@@ -1,0 +1,137 @@
+import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Test from "@/Test/Alchemy";
+import * as workers from "@distilled.cloud/cloudflare/workers";
+import * as zones from "@distilled.cloud/cloudflare/zones";
+import { expect } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
+import * as Stream from "effect/Stream";
+import * as pathe from "pathe";
+
+/**
+ * Regression coverage for zone inference on accounts with more zones than
+ * Cloudflare's default `per_page` (20).
+ *
+ * The Worker provider used to infer a custom domain's zone from a single
+ * unpaginated `GET /zones`, so any zone past the first page was invisible and
+ * the deploy died with "Could not infer Cloudflare Zone for hostname".
+ *
+ * Only an account with >20 zones can exercise this, so the file is gated on
+ * `CLOUDFLARE_TEST_MANY_ZONES_PROFILE` naming the profile
+ * (`~/.alchemy/profiles.json`) for such an account. Unset — as on CI and the
+ * standard `testing` run — every test here skips and no credentials resolve.
+ */
+const PROFILE = process.env.CLOUDFLARE_TEST_MANY_ZONES_PROFILE;
+
+const { test } = Test.make({
+  providers: Cloudflare.providers(),
+  profile: PROFILE,
+});
+
+const main = pathe.resolve(import.meta.dirname, "fixtures/worker.ts");
+
+// Deterministic per-user hostname — never derived from Date.now().
+const subdomain = `zone-paging-${process.env.PULL_REQUEST ?? process.env.USER}`;
+
+/**
+ * The zone the old code could not see: present in the exhaustive paged
+ * listing, absent from the single default-page response. Computed rather than
+ * hardcoded so it stays correct as the account's zone set changes. An explicit
+ * `CLOUDFLARE_TEST_MANY_ZONES_ZONE_NAME` wins — auto-selection can otherwise
+ * land on a production zone.
+ */
+const zoneBeyondFirstPage = Effect.gen(function* () {
+  const { accountId } = yield* yield* CloudflareEnvironment;
+
+  const all = yield* zones.listZones.pages({ account: { id: accountId } }).pipe(
+    Stream.runCollect,
+    Effect.map((chunk) =>
+      Array.from(chunk).flatMap((page) => page.result ?? []),
+    ),
+  );
+
+  const override = process.env.CLOUDFLARE_TEST_MANY_ZONES_ZONE_NAME;
+  if (override) {
+    const named = all.find((zone) => zone.name === override);
+    if (!named) {
+      return yield* Effect.die(
+        new Error(`zone "${override}" not found in account ${accountId}`),
+      );
+    }
+    return { total: all.length, firstPageSize: all.length, zone: named };
+  }
+
+  // The exact request the buggy provider made — whatever Cloudflare returns
+  // here is the set that inference used to be limited to.
+  const firstPage = yield* zones
+    .listZones({ account: { id: accountId } })
+    .pipe(Effect.map((r) => new Set((r.result ?? []).map((z) => z.id))));
+
+  return {
+    total: all.length,
+    firstPageSize: firstPage.size,
+    // Only an active zone can take a Worker custom domain.
+    zone: all.find((z) => !firstPage.has(z.id) && z.status === "active"),
+  };
+});
+
+const transientRetrySchedule = Schedule.exponential("500 millis");
+
+const findAttachment = (hostname: string) =>
+  Effect.gen(function* () {
+    const { accountId } = yield* yield* CloudflareEnvironment;
+    return yield* workers.listDomains({ accountId, hostname }).pipe(
+      Effect.map((r) => (r.result ?? []).find((d) => d.hostname === hostname)),
+      Effect.retry({
+        while: (e) => e._tag === "TooManyRequests",
+        schedule: transientRetrySchedule,
+        times: 8,
+      }),
+    );
+  });
+
+test.provider.skipIf(!PROFILE)(
+  "infers the zone for a hostname past the first page of GET /zones",
+  (stack) =>
+    Effect.gen(function* () {
+      const { total, firstPageSize, zone } = yield* zoneBeyondFirstPage;
+      yield* Effect.log(
+        `account has ${total} zones, ${firstPageSize} on the first page`,
+      );
+      if (!zone) {
+        // ≤ one page of zones (or none of the overflow is active) — this
+        // account cannot reproduce the bug, so there is nothing to assert.
+        yield* Effect.log("no active zone past the first page — skipping");
+        return;
+      }
+      yield* Effect.log(`inferring against zone ${zone.name} (${zone.id})`);
+
+      const hostname = `${subdomain}.${zone.name}`;
+
+      yield* stack.destroy();
+
+      yield* Effect.gen(function* () {
+        const worker = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.Worker("ZonePagingWorker", {
+              main,
+              workersDev: false,
+              compatibility: { date: "2024-01-01" },
+              domain: hostname,
+            });
+          }),
+        );
+
+        expect(worker.urls).toEqual([`https://${hostname}`]);
+
+        // The assertion that fails pre-fix: inference resolved the hostname
+        // to its real zone instead of dying with "Could not infer Cloudflare
+        // Zone for hostname".
+        const attachment = yield* findAttachment(hostname);
+        expect(attachment?.zoneId).toEqual(zone.id);
+        expect(attachment?.service).toEqual(worker.workerName);
+      }).pipe(Effect.ensuring(stack.destroy().pipe(Effect.ignore)));
+    }),
+  { timeout: 120_000 },
+);


### PR DESCRIPTION
Worker custom domains and routes infer their zone from `GET /zones`, which Cloudflare pages at 20 by default. On an account with more zones, every zone past the first page is invisible to inference and the deploy dies:

```
Could not infer Cloudflare Zone for hostname "app.example.com".
Ensure the parent zone exists in this account.
```

The listing was also unscoped, so a token with access to several accounts could match a zone the Worker's account doesn't own.

Replaced with the exact-name walk already backing the explicit `zone` prop:

```diff
-const zoneList = yield* zones.listZones({})
-const match = zoneList.find((z) => z.name === candidate)
+const hit =
+  zoneCache.get(candidate) ??
+  (yield* findZoneByName({ accountId, name: candidate }))
```

Request count now tracks the hostname's label count instead of the account's zone count, and the cache memoizes the matched zone name, so sibling hostnames on one zone (`api.x.com`, `app.x.com`) cost a single lookup.

`ZonePaging.test.ts` covers it, gated on `CLOUDFLARE_TEST_MANY_ZONES_PROFILE` naming a profile whose account has more than one page of zones. It picks the target by diffing the exhaustive paged listing against the default single-page response, so it stays valid as the account's zone set changes, and no-ops on accounts that can't reproduce.
