### PR TITLE
fix(planetscale): env overrides for OAuth client + redirect URI

### DIFF
--- a/packages/alchemy/src/Planetscale/OAuthClient.ts
+++ b/packages/alchemy/src/Planetscale/OAuthClient.ts
@@ -41,12 +41,45 @@ export interface Authorization {
  * {@link OAUTH_REDIRECT_URI}. Scopes are configured on the application
  * itself, not requested per-authorization. Rotate by registering a new
  * secret and cutting a release.
+ *
+ * All three values (client id, client secret, redirect URI) can be
+ * overridden via `ALCHEMY_PLANETSCALE_OAUTH_CLIENT_ID` /
+ * `ALCHEMY_PLANETSCALE_OAUTH_CLIENT_SECRET` /
+ * `ALCHEMY_PLANETSCALE_OAUTH_REDIRECT_URI` to point the CLI at a
+ * self-registered PlanetScale OAuth application.
  */
-export const OAUTH_CLIENT_ID = "pscale_app_aa12e3938baebb788aac443f66e422da";
-export const OAUTH_CLIENT_SECRET =
-  "pscale_app_secret_yyZ3Q8oe99GP9_yA5wrA5er6RuN6Lz9dC66Bj1OJzpg";
+const env = (key: string, fallback: string): string => {
+  const value = process.env[key];
+  return value !== undefined && value !== "" ? value : fallback;
+};
 
-export const OAUTH_REDIRECT_URI = "https://alchemy.run/auth/callback";
+export const OAUTH_CLIENT_ID = env(
+  "ALCHEMY_PLANETSCALE_OAUTH_CLIENT_ID",
+  "pscale_app_aa12e3938baebb788aac443f66e422da",
+);
+export const OAUTH_CLIENT_SECRET = env(
+  "ALCHEMY_PLANETSCALE_OAUTH_CLIENT_SECRET",
+  "pscale_app_secret_yyZ3Q8oe99GP9_yA5wrA5er6RuN6Lz9dC66Bj1OJzpg",
+);
+
+/**
+ * PlanetScale validates `redirect_uri` against the OAuth application's
+ * registered redirect URIs with an **exact string match** at the authorize
+ * step, before consent. If the registration drifts from this constant the
+ * user sees `invalid redirect uri` and no code is ever issued (#1166).
+ * Note the live page 307s to `/auth/callback/` (trailing slash) — the
+ * registered URI must match what the CLI sends, not the canonical URL.
+ *
+ * Override with `ALCHEMY_PLANETSCALE_OAUTH_REDIRECT_URI` (together with the
+ * client id/secret overrides above) to use a self-registered PlanetScale
+ * OAuth application. Registering `http://localhost:9976/auth/callback` and
+ * setting it as the override skips the hosted relay entirely — the CLI's
+ * loopback server receives the callback directly.
+ */
+export const OAUTH_REDIRECT_URI = env(
+  "ALCHEMY_PLANETSCALE_OAUTH_REDIRECT_URI",
+  "https://alchemy.run/auth/callback",
+);
 export const OAUTH_LOCAL_CALLBACK_URI = "http://localhost:9976/auth/callback";
 export const OAUTH_ENDPOINTS = {
   // PlanetScale's own .well-known OAuth discovery doc declares this as

--- a/packages/alchemy/src/Planetscale/OAuthClient.ts
+++ b/packages/alchemy/src/Planetscale/OAuthClient.ts
@@ -62,25 +62,31 @@ export const OAUTH_CLIENT_SECRET = env(
   "pscale_app_secret_yyZ3Q8oe99GP9_yA5wrA5er6RuN6Lz9dC66Bj1OJzpg",
 );
 
+export const OAUTH_LOCAL_CALLBACK_URI = "http://localhost:9976/auth/callback";
+
 /**
  * PlanetScale validates `redirect_uri` against the OAuth application's
  * registered redirect URIs with an **exact string match** at the authorize
- * step, before consent. If the registration drifts from this constant the
- * user sees `invalid redirect uri` and no code is ever issued (#1166).
- * Note the live page 307s to `/auth/callback/` (trailing slash) — the
- * registered URI must match what the CLI sends, not the canonical URL.
+ * step, before consent — a mismatch shows `invalid redirect uri` and no
+ * code is ever issued.
  *
- * Override with `ALCHEMY_PLANETSCALE_OAUTH_REDIRECT_URI` (together with the
- * client id/secret overrides above) to use a self-registered PlanetScale
- * OAuth application. Registering `http://localhost:9976/auth/callback` and
- * setting it as the override skips the hosted relay entirely — the CLI's
- * loopback server receives the callback directly.
+ * The app's registered Redirect URI must be exactly this value, with no
+ * trailing slash — the live relay page 307s to `/auth/callback/`, but the
+ * registered value must match what the CLI *sends*, not the canonical URL.
+ * #962 switched this constant from the loopback URI to the hosted relay
+ * while the app registration still listed only the loopback URI, which
+ * broke PlanetScale login with `invalid redirect uri` until the
+ * registration was updated to match (#1166). If these ever drift again,
+ * that error at the authorize step (before consent) is the symptom.
+ *
+ * Override with `ALCHEMY_PLANETSCALE_OAUTH_REDIRECT_URI` (together with
+ * the client id/secret overrides above) to use a self-registered
+ * PlanetScale OAuth application.
  */
 export const OAUTH_REDIRECT_URI = env(
   "ALCHEMY_PLANETSCALE_OAUTH_REDIRECT_URI",
   "https://alchemy.run/auth/callback",
 );
-export const OAUTH_LOCAL_CALLBACK_URI = "http://localhost:9976/auth/callback";
 export const OAUTH_ENDPOINTS = {
   // PlanetScale's own .well-known OAuth discovery doc declares this as
   // the authorization_endpoint — NOT auth.planetscale.com/oauth/authorize

--- a/website/src/pages/auth/callback.astro
+++ b/website/src/pages/auth/callback.astro
@@ -36,7 +36,7 @@ import Auth from "../../layouts/Auth.astro";
 
   const showManual = () => {
     connecting.textContent = error
-      ? "Cloudflare did not authorize the request."
+      ? "The provider did not authorize the request."
       : "Couldn't connect to your local Alchemy process.";
     if (!code || !state) return;
     codeBox.textContent = `${code}#${state}`;


### PR DESCRIPTION
PlanetScale OAuth login fails with `invalid redirect uri` at the authorize step (#1166).

Root cause (confirmed against the app's dashboard settings): [#962](https://github.com/alchemy-run/alchemy/pull/962) switched the CLI's `redirect_uri` from `http://localhost:9976/auth/callback` to the hosted relay `https://alchemy.run/auth/callback`, but the PlanetScale OAuth app (`pscale_app_aa12e393...`) still had only the loopback URI registered. PlanetScale exact-matches `redirect_uri` before consent, so no code was ever issued. Cloudflare was unaffected because its app registration was updated.

The fix is registering exactly `https://alchemy.run/auth/callback` (no trailing slash) as the app's Redirect URI — done dashboard-side, no release required. This PR captures what the code can:

- Document the exact-match requirement, the #1166 drift, and the trailing-slash foot-gun (the live relay page 307s to `/auth/callback/`; the registration must match what the CLI sends, not the canonical URL) on the `OAUTH_REDIRECT_URI` constant.
- Make the OAuth app values overridable for self-registered PlanetScale OAuth applications:

```ts
export const OAUTH_CLIENT_ID = env(
  "ALCHEMY_PLANETSCALE_OAUTH_CLIENT_ID",
  "pscale_app_aa12e3938baebb788aac443f66e422da",
);
// likewise ALCHEMY_PLANETSCALE_OAUTH_CLIENT_SECRET and
// ALCHEMY_PLANETSCALE_OAUTH_REDIRECT_URI
```

- Relay page error copy said "Cloudflare did not authorize the request." for all providers — now provider-neutral.

Closes #1166 (fixed by the redirect URI re-registration; verified alongside this PR).
