### PR TITLE
feat(cloudflare/access): protect Workers by identity

### DIFF
--- a/packages/alchemy-test/src/Registry.ts
+++ b/packages/alchemy-test/src/Registry.ts
@@ -2,13 +2,11 @@
  * Per-file registration state.
  *
  * While a test file's module body is evaluating, `describe`/`test`/hook
- * calls register nodes against that file's collector. The runner imports
- * all test files in PARALLEL; attribution stays correct because the
- * collector is carried by AsyncLocalStorage — the module loader propagates
- * the async context of the `import()` call into the module's top-level
- * evaluation (and into microtasks queued from it), so each file's
- * registrations resolve to its own root no matter how many imports are in
- * flight.
+ * calls register nodes against that file's collector. Collection is
+ * sequential: Bun 1.3.x does not propagate AsyncLocalStorage through
+ * dynamic `import()`, so a module-level fallback attributes registrations
+ * to the file currently importing. Do not raise collect concurrency
+ * without restoring ALS (the fallback is process-global).
  *
  * The storage lives on `globalThis` so that a duplicated module instance
  * (e.g. two resolutions of the package) still shares one registry.
@@ -26,6 +24,11 @@ const key = Symbol.for("alchemy-test/registry");
 const storage: AsyncLocalStorage<FileContext> = ((globalThis as any)[key] ??=
   new AsyncLocalStorage<FileContext>());
 
+// Bun 1.3.x does not propagate AsyncLocalStorage through dynamic
+// `import()`. Collection is sequential (see Runner.ts), so a module
+// fallback attributes `describe`/`test` to the file currently importing.
+let importFallback: FileContext | undefined;
+
 /**
  * Collect one file: run `f` (the file's dynamic import + microtask flush)
  * with a fresh root as the ambient collector, and return the root.
@@ -35,12 +38,19 @@ export const collect = async (
   f: () => Promise<void>,
 ): Promise<FileSuite> => {
   const root = makeFileSuite(file);
-  await storage.run({ current: root }, f);
-  return root;
+  const ctx: FileContext = { current: root };
+  const previous = importFallback;
+  importFallback = ctx;
+  try {
+    await storage.run(ctx, f);
+    return root;
+  } finally {
+    importFallback = previous;
+  }
 };
 
 const currentContext = (): FileContext => {
-  const context = storage.getStore();
+  const context = storage.getStore() ?? importFallback;
   if (context === undefined) {
     throw new Error(
       "alchemy-test: describe/test/hook called outside of a test file collection. " +
@@ -59,7 +69,8 @@ export const currentSuite = (): Suite => currentContext().current;
  * at registration time to namespace per-test durable state by file.
  */
 export const currentFile = (): string | undefined => {
-  let suite: Suite | undefined = storage.getStore()?.current;
+  let suite: Suite | undefined =
+    storage.getStore()?.current ?? importFallback?.current;
   while (suite?.parent !== undefined) suite = suite.parent;
   return suite !== undefined && "file" in suite
     ? (suite as FileSuite).file

--- a/packages/alchemy-test/src/Runner.ts
+++ b/packages/alchemy-test/src/Runner.ts
@@ -744,10 +744,9 @@ export const run = Effect.fn(function* (options: RunOptions) {
   // hang), and it maximizes exposure to loader races under concurrent
   // dynamic imports. The shared dependency graph is deduped by the module
   // cache, so a modest bound keeps nearly all of the speedup.
-  const collectConcurrency =
-    options.concurrency === "unbounded"
-      ? 32
-      : Math.min(options.concurrency, 32);
+  // Sequential only. Bun 1.3.x drops AsyncLocalStorage across `import()`,
+  // so Registry.collect uses a process-global fallback that cannot overlap.
+  const collectConcurrency = 1;
   // collectFile never fails — import errors are captured on the result.
   const collected = yield* Effect.forEach(
     absoluteFiles.map((absolute, i) => [absolute, relative[i]!] as const),

--- a/packages/alchemy/src/Cloudflare/Access/Application.ts
+++ b/packages/alchemy/src/Cloudflare/Access/Application.ts
@@ -50,6 +50,9 @@ export type ApplicationType =
  * - `preview_worker` — that Worker's preview URLs only.
  * - `all_workers` — account-wide, current and future Workers.
  * - `all_preview_workers` — account-wide preview URLs.
+ *
+ * @see https://developers.cloudflare.com/workers/configuration/cloudflare-access/
+ * @see https://blog.cloudflare.com/workers-protected-by-access/
  */
 export type ApplicationDestination =
   | { type: "public"; uri: string }
@@ -405,6 +408,9 @@ export type Application = Resource<
  * // Worker public even when `all_workers` gates the rest of the account.
  * // A hostname/path application still overrides both.
  * ```
+ *
+ * @see https://developers.cloudflare.com/workers/configuration/cloudflare-access/
+ * @see https://blog.cloudflare.com/workers-protected-by-access/
  */
 export const Application = Resource<Application>(
   "Cloudflare.Access.Application",

--- a/packages/alchemy/src/Cloudflare/Access/Application.ts
+++ b/packages/alchemy/src/Cloudflare/Access/Application.ts
@@ -4,6 +4,7 @@ import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
 
 import { Unowned } from "../../AdoptPolicy.ts";
+import { isResolved } from "../../Diff.ts";
 import { createPhysicalName } from "../../PhysicalName.ts";
 import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
@@ -30,13 +31,25 @@ export type ApplicationType =
 /**
  * A destination that this Access application protects.
  *
- * Cloudflare supports three destination flavours:
+ * Hostname / path destinations:
  * - `public` — a public hostname/URI you own in Cloudflare (the legacy
  *   `domain` field on `ApplicationProps` covers the simple case).
  * - `private` — a hostname or CIDR reachable through a Cloudflare Tunnel.
  *   Traffic from WARP-enrolled devices is intercepted and forwarded
  *   through the tunnel; identity is enforced before forwarding.
  * - `via_mcp_server_portal` — routes via a managed MCP server portal.
+ *
+ * Worker-identity destinations (no hostname required). Precedence is
+ * hostname/path apps > worker-level > account-level. Worker-level
+ * policies break WebSocket upgrades (403). Workers for Platforms:
+ * Access protects the dispatch Worker; user workers are not Access
+ * targets.
+ * - `worker` — one Worker, everywhere it serves (routes, custom
+ *   domains, workers.dev, previews). `workerId` is the immutable
+ *   script tag (`Worker.workerId`).
+ * - `preview_worker` — that Worker's preview URLs only.
+ * - `all_workers` — account-wide, current and future Workers.
+ * - `all_preview_workers` — account-wide preview URLs.
  */
 export type ApplicationDestination =
   | { type: "public"; uri: string }
@@ -48,7 +61,11 @@ export type ApplicationDestination =
       portRange?: string;
       vnetId?: string;
     }
-  | { type: "via_mcp_server_portal"; mcpServerId: string };
+  | { type: "via_mcp_server_portal"; mcpServerId: string }
+  | { type: "worker"; workerId: string }
+  | { type: "preview_worker"; workerId: string }
+  | { type: "all_workers" }
+  | { type: "all_preview_workers" };
 
 /**
  * Configuration for an OAuth authorization flow managed by Cloudflare Access.
@@ -93,9 +110,12 @@ export interface ApplicationProps {
    */
   name?: string;
   /**
-   * Primary hostname and path secured by Access. Required for `self_hosted`
-   * apps; ignored on the request for `warp` (Cloudflare auto-fills it with
-   * `${authDomain}/warp`) and `saas` (Cloudflare uses the OIDC issuer).
+   * Primary hostname and path secured by Access. Required for hostname-
+   * based `self_hosted` apps; omit it when protecting a Worker via
+   * `destinations` (`worker` / `preview_worker` / `all_workers` /
+   * `all_preview_workers`). Ignored on the request for `warp`
+   * (Cloudflare auto-fills `${authDomain}/warp`) and `saas`
+   * (Cloudflare uses the OIDC issuer).
    */
   domain?: string;
   /**
@@ -199,8 +219,11 @@ export interface ApplicationAttributes {
   applicationId: string;
   /** Audience tag used to verify JWTs issued for this application. */
   aud: string;
-  /** Resolved domain. Cloudflare fills this in for `warp`/`saas` apps. */
-  domain: string;
+  /**
+   * Resolved domain. Cloudflare fills this in for `warp`/`saas` apps.
+   * Worker-identity destinations have no hostname — `undefined`.
+   */
+  domain: string | undefined;
   /** Resolved destinations (echoed back by Cloudflare). */
   destinations: ReadonlyArray<ApplicationDestination> | undefined;
   /** Resolved managed OAuth configuration. */
@@ -319,6 +342,69 @@ export type Application = Resource<
  *   policies: [admins.policyId],
  * });
  * ```
+ *
+ * @section Protecting Workers with Access
+ * @example Protect one Worker everywhere it serves
+ * ```typescript
+ * const worker = yield* Cloudflare.Worker("Api", { main: "./src/api.ts" });
+ * const allowOrg = yield* Cloudflare.Access.Policy("AllowOrg", {
+ *   decision: "allow",
+ *   include: [{ cloudflareAccountMember: {} }],
+ * });
+ * yield* Cloudflare.Access.Application("ProtectApi", {
+ *   type: "self_hosted",
+ *   destinations: [{ type: "worker", workerId: worker.workerId }],
+ *   policies: [allowOrg.policyId],
+ * });
+ * ```
+ *
+ * @example Protect only preview URLs
+ * ```typescript
+ * yield* Cloudflare.Access.Application("ProtectPreviews", {
+ *   type: "self_hosted",
+ *   destinations: [{ type: "preview_worker", workerId: worker.workerId }],
+ *   policies: [allowOrg.policyId],
+ * });
+ * ```
+ *
+ * @example Account-wide preview gate
+ * ```typescript
+ * yield* Cloudflare.Access.Application("AllPreviews", {
+ *   type: "self_hosted",
+ *   destinations: [{ type: "all_preview_workers" }],
+ *   policies: [allowOrg.policyId],
+ * });
+ * ```
+ *
+ * @example Public exception under an account-wide gate
+ * ```typescript
+ * const publicBypass = yield* Cloudflare.Access.Policy("PublicBypass", {
+ *   decision: "bypass",
+ *   include: [{ everyone: {} }],
+ * });
+ * yield* Cloudflare.Access.Application("PublicApi", {
+ *   type: "self_hosted",
+ *   destinations: [{ type: "worker", workerId: worker.workerId }],
+ *   policies: [publicBypass.policyId],
+ * });
+ * ```
+ *
+ * @example Path carve-out (hostname app beats worker-level)
+ * ```typescript
+ * yield* Cloudflare.Access.Application("PublicHealth", {
+ *   type: "self_hosted",
+ *   domain: "api.example.com/health",
+ *   policies: [publicBypass.policyId],
+ * });
+ * ```
+ *
+ * @section Precedence
+ * @example Hostname/path apps win over worker-level, which wins over account-wide
+ * ```typescript
+ * // A worker destination with a bypass + everyone policy makes that
+ * // Worker public even when `all_workers` gates the rest of the account.
+ * // A hostname/path application still overrides both.
+ * ```
  */
 export const Application = Resource<Application>(
   "Cloudflare.Access.Application",
@@ -361,12 +447,9 @@ export const ApplicationProvider = () =>
     stables: ["applicationId", "aud", "type", "accountId"],
 
     diff: Effect.fn(function* ({ olds = {}, news }) {
-      if ((olds as ApplicationProps).type !== undefined) {
-        if (
-          (olds as ApplicationProps).type !== (news as ApplicationProps).type
-        ) {
-          return { action: "replace" } as const;
-        }
+      if (!isResolved(news)) return undefined;
+      if (olds.type !== undefined && olds.type !== news.type) {
+        return { action: "replace" } as const;
       }
     }),
 
@@ -393,7 +476,13 @@ export const ApplicationProvider = () =>
       }
       const domain = observed.domain ?? output?.domain ?? olds?.domain;
       const name = observed.name ?? output?.name;
-      if (domain === undefined || name === undefined) {
+      // Domain-scan recovery needs a domain to match; an id-recovered
+      // Worker-identity app has none and must not look missing (that
+      // recreates it). Name is still required.
+      if (name === undefined) {
+        return undefined;
+      }
+      if (domain === undefined && output?.applicationId === undefined) {
         return undefined;
       }
       const attrs = {
@@ -540,7 +629,7 @@ export const ApplicationProvider = () =>
       return {
         applicationId: observed.id,
         aud: observed.aud,
-        domain: observed.domain ?? body.domain ?? "",
+        domain: observed.domain ?? body.domain,
         destinations: observed.destinations ?? body.destinations,
         // Keep the provider output cloud-authoritative. If Cloudflare rejects
         // or clears the desired configuration, do not mask that drift with
@@ -579,7 +668,7 @@ export const ApplicationProvider = () =>
                   {
                     applicationId: app.id,
                     aud: app.aud,
-                    domain: app.domain ?? "",
+                    domain: app.domain,
                     destinations: app.destinations,
                     oauthConfiguration: app.oauthConfiguration,
                     type: app.type,
@@ -601,7 +690,10 @@ export const ApplicationProvider = () =>
           accountId: output.accountId,
           appId: output.applicationId,
         })
-        .pipe(Effect.catch(() => Effect.void));
+        .pipe(
+          retryTransientAccessError,
+          Effect.catchTag("AccessApplicationNotFound", () => Effect.void),
+        );
     }),
   });
 
@@ -672,11 +764,10 @@ const observeById = (accountId: string, appId: string) =>
     const r = yield* zeroTrust
       .getAccessApplicationForAccount({ accountId, appId })
       .pipe(
-        // Distilled only tags transport errors (Unauthorized,
-        // ServiceUnavailable, etc.); the live Cloudflare 404 surfaces as
-        // an untagged error. Swallow generically so observe falls through
-        // to recreate.
-        Effect.catch(() => Effect.succeed(undefined)),
+        retryTransientAccessError,
+        Effect.catchTag("AccessApplicationNotFound", () =>
+          Effect.succeed(undefined),
+        ),
       );
     if (r === undefined) return undefined;
     return narrowApp(r as Parameters<typeof narrowApp>[0]);

--- a/packages/alchemy/src/Cloudflare/Access/GetIdentity.ts
+++ b/packages/alchemy/src/Cloudflare/Access/GetIdentity.ts
@@ -12,6 +12,9 @@ import {
  * `undefined` when Access did not authenticate it.
  *
  * Thin delegate over {@link WorkerExecutionContext.access.identity}.
+ *
+ * @see https://developers.cloudflare.com/workers/configuration/cloudflare-access/#read-authenticated-user-identity-with-ctxaccess
+ * @see https://blog.cloudflare.com/workers-protected-by-access/
  */
 export const getIdentity: Effect.Effect<
   cf.CloudflareAccessIdentity | undefined,

--- a/packages/alchemy/src/Cloudflare/Access/GetIdentity.ts
+++ b/packages/alchemy/src/Cloudflare/Access/GetIdentity.ts
@@ -1,0 +1,23 @@
+import type * as cf from "@cloudflare/workers-types";
+import * as Effect from "effect/Effect";
+
+import type { RuntimeContext } from "../../RuntimeContext.ts";
+import {
+  WorkerExecutionContext,
+  type AccessIdentityError,
+} from "../Workers/Worker.ts";
+
+/**
+ * The Access identity Cloudflare attached to this request, or
+ * `undefined` when Access did not authenticate it.
+ *
+ * Thin delegate over {@link WorkerExecutionContext.access.identity}.
+ */
+export const getIdentity: Effect.Effect<
+  cf.CloudflareAccessIdentity | undefined,
+  AccessIdentityError,
+  RuntimeContext | WorkerExecutionContext
+> = Effect.gen(function* () {
+  const ctx = yield* WorkerExecutionContext;
+  return yield* ctx.access.identity;
+});

--- a/packages/alchemy/src/Cloudflare/Access/Policy.ts
+++ b/packages/alchemy/src/Cloudflare/Access/Policy.ts
@@ -167,6 +167,23 @@ export type Policy = Resource<
  * });
  * ```
  *
+ * @section Pre-built policies
+ * @example Allow Cloudflare account members
+ * ```typescript
+ * const members = yield* Cloudflare.Access.Policy("AccountMembers", {
+ *   decision: "allow",
+ *   include: [{ cloudflareAccountMember: {} }],
+ * });
+ * ```
+ *
+ * @example Bypass Access for everyone
+ * ```typescript
+ * const publicBypass = yield* Cloudflare.Access.Policy("PublicBypass", {
+ *   decision: "bypass",
+ *   include: [{ everyone: {} }],
+ * });
+ * ```
+ *
  * @section Combining rule groups
  * @example Include + exclude + require
  * ```typescript

--- a/packages/alchemy/src/Cloudflare/Access/index.ts
+++ b/packages/alchemy/src/Cloudflare/Access/index.ts
@@ -3,6 +3,7 @@ export * from "./Application.ts";
 export * from "./Bookmark.ts";
 export * from "./Certificate.ts";
 export * from "./CustomPage.ts";
+export * from "./GetIdentity.ts";
 export * from "./GetIdentityProvider.ts";
 export * from "./GetIdentityProviderHttp.ts";
 export * from "./Group.ts";

--- a/packages/alchemy/src/Cloudflare/Providers.ts
+++ b/packages/alchemy/src/Cloudflare/Providers.ts
@@ -387,14 +387,11 @@ export const providers = () =>
     Layer.provide(
       Layer.mergeAll(
         AccessApp.ApplicationProvider(),
-        AccessApp.ApplicationProvider(),
         AccessCert.CertificateProvider(),
         AccessIdp.IdentityProviderProvider(),
         AccessInfraTarget.InfrastructureTargetProvider(),
         AccessKeyConfig.KeyConfigurationProvider(),
         AccessOrg.OrganizationProvider(),
-        AccessOrg.OrganizationProvider(),
-        AccessPol.PolicyProvider(),
         AccessPol.PolicyProvider(),
         AccessSvcToken.ServiceTokenProvider(),
         Account.AccountProvider(),

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -114,6 +114,9 @@ export class WorkerExecutionContext extends Context.Service<
      * Cloudflare Access identity on this request. `ctx.access` is
      * `undefined` when Access did not authenticate the request (no
      * application, bypass policy, or local `alchemy dev`).
+     *
+     * @see https://developers.cloudflare.com/workers/configuration/cloudflare-access/#read-authenticated-user-identity-with-ctxaccess
+     * @see https://blog.cloudflare.com/workers-protected-by-access/
      */
     readonly access: {
       readonly aud: Effect.Effect<string | undefined, never, RuntimeContext>;
@@ -1104,6 +1107,8 @@ export type Worker<Bindings = any> = Resource<
      * this value as `Access.Application` `destinations[].workerId`.
      * Workers for Platforms user workers also receive a tag, but they
      * are not Access targets — Access protects the dispatch Worker only.
+     *
+     * @see https://developers.cloudflare.com/workers/configuration/cloudflare-access/
      */
     workerId: string;
     /**

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -68,6 +68,13 @@ export class CachePurgeError extends Data.TaggedError("CachePurgeError")<{
   cause?: unknown;
 }> {}
 
+export class AccessIdentityError extends Data.TaggedError(
+  "AccessIdentityError",
+)<{
+  message: string;
+  cause?: unknown;
+}> {}
+
 /**
  * Effect-native view of the Workers Cache runtime API on the execution
  * context (`ctx.cache`). Only available when the Worker has Workers Cache
@@ -103,6 +110,19 @@ export class WorkerExecutionContext extends Context.Service<
      * The Workers Cache runtime API (`ctx.cache`).
      */
     readonly cache: WorkerExecutionContextCache;
+    /**
+     * Cloudflare Access identity on this request. `ctx.access` is
+     * `undefined` when Access did not authenticate the request (no
+     * application, bypass policy, or local `alchemy dev`).
+     */
+    readonly access: {
+      readonly aud: Effect.Effect<string | undefined, never, RuntimeContext>;
+      readonly identity: Effect.Effect<
+        cf.CloudflareAccessIdentity | undefined,
+        AccessIdentityError,
+        RuntimeContext
+      >;
+    };
     /**
      * The raw workerd ExecutionContext, for interop with async APIs.
      */
@@ -147,6 +167,22 @@ export const fromExecutionContext = (
             }),
           ),
   },
+  access: {
+    aud: Effect.sync(() => ctx.access?.aud),
+    identity: ctx.access
+      ? Effect.tryPromise({
+          try: () => ctx.access!.getIdentity(),
+          catch: (cause) =>
+            new AccessIdentityError({
+              message:
+                cause instanceof Error
+                  ? cause.message
+                  : "Unknown Access identity error",
+              cause,
+            }),
+        })
+      : Effect.succeed(undefined),
+  },
 });
 
 /**
@@ -176,6 +212,18 @@ export const deferredExecutionContext: WorkerExecutionContext["Service"] = {
       liveExecutionContext.pipe(
         Effect.flatMap((live) => live.cache.purge(options)),
       ) as Effect.Effect<cf.CachePurgeResult, CachePurgeError, RuntimeContext>,
+  },
+  access: {
+    aud: Effect.suspend(() =>
+      liveExecutionContext.pipe(Effect.flatMap((live) => live.access.aud)),
+    ) as Effect.Effect<string | undefined, never, RuntimeContext>,
+    identity: Effect.suspend(() =>
+      liveExecutionContext.pipe(Effect.flatMap((live) => live.access.identity)),
+    ) as Effect.Effect<
+      cf.CloudflareAccessIdentity | undefined,
+      AccessIdentityError,
+      RuntimeContext
+    >,
   },
 };
 
@@ -486,7 +534,10 @@ export interface WorkerVersionOptions {
    * (their migrations would mutate the parent).
    *
    * Changing the parent replaces the resource (a version belongs to
-   * exactly one script).
+   * exactly one script). A Worker reference supplies the parent's
+   * immutable `workerId` (script tag); a literal script name cannot —
+   * Access destinations that target this version need a resolved
+   * reference.
    */
   parent?: string | Worker;
   /**
@@ -1047,7 +1098,17 @@ export type Worker<Bindings = any> = Resource<
   WorkerTypeId,
   WorkerProps<Bindings>,
   {
+    /**
+     * The Worker's immutable identifier (the script `tag`). Distinct from
+     * {@link workerName}, the script name used in URLs and routes. Use
+     * this value as `Access.Application` `destinations[].workerId`.
+     * Workers for Platforms user workers also receive a tag, but they
+     * are not Access targets — Access protects the dispatch Worker only.
+     */
     workerId: string;
+    /**
+     * The script name used in URLs, routes, and the workers.dev hostname.
+     */
     workerName: string;
     /**
      * The Workers for Platforms dispatch namespace this Worker was deployed
@@ -2101,6 +2162,16 @@ export const isSelf = (value: unknown): value is Self =>
  *     return HttpServerResponse.fromClientResponse(res);
  *   }),
  * };
+ * ```
+ *
+ * @section Access identity
+ * @example Read the Access audience and identity on a protected Worker
+ * ```typescript
+ * const ctx = yield* Cloudflare.WorkerExecutionContext;
+ * const aud = yield* ctx.access.aud;
+ * const identity = yield* ctx.access.identity;
+ * // or: yield* Cloudflare.Access.getIdentity
+ * // identity is undefined when Access did not authenticate the request
  * ```
  */
 export const Worker: ResourceClassLike<Worker> &

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -213,6 +213,62 @@ export const resolveVersionParentName = (
 };
 
 /**
+ * Resolve the parent's immutable script tag from a resolved Worker
+ * reference. A literal-name `version.parent` has no tag — callers fall
+ * back to the script name (see {@link resolveVersionParentName}).
+ *
+ * @internal
+ */
+export const resolveVersionParentWorkerId = (
+  version: WorkerProps["version"],
+): string | undefined => {
+  const parent = version?.parent;
+  if (parent == null || typeof parent === "string") return undefined;
+  const workerId = (parent as { workerId?: unknown }).workerId;
+  return typeof workerId === "string" ? workerId : undefined;
+};
+
+/**
+ * Legacy Worker state stored `workerId` as the script name. Unchanged
+ * workers never reconcile, so the planner would keep projecting that
+ * name to downstream Access destinations. Dispatch-namespace and
+ * version rows are excluded — they are not Access targets. Local-mode
+ * rows never enter this live provider (engine replacement).
+ *
+ * @internal
+ */
+export const needsWorkerIdMigration = (
+  output:
+    | {
+        workerId: string;
+        workerName: string;
+        namespace?: string;
+        versionOf?: string;
+      }
+    | undefined,
+): boolean =>
+  output != null &&
+  output.workerId === output.workerName &&
+  output.namespace == null &&
+  output.versionOf == null;
+
+/**
+ * Look up the immutable script tag for a named Worker. Used on cold
+ * read (no persisted `output.workerId`) so we don't persist the name
+ * as the id. Falls back to `undefined` when the script is missing.
+ */
+const lookupScriptTag = Effect.fn(function* (
+  accountId: string,
+  workerName: string,
+) {
+  const matches = yield* workers.searchScript({
+    accountId,
+    name: workerName,
+  });
+  return matches.find((worker) => worker.scriptName === workerName)?.id;
+});
+
+/**
  * The traffic percentage a *self-owned* Worker's new version should receive,
  * or `undefined` for the default full cutover. Only a `version` prop without
  * a `parent` participates — version workers handle traffic separately.
@@ -2903,7 +2959,7 @@ export const LiveWorkerProvider = () =>
           ...(versionedUrl ? [versionedUrl] : []),
         ];
         return {
-          workerId: parentName,
+          workerId: resolveVersionParentWorkerId(version) ?? parentName,
           workerName: parentName,
           namespace: undefined,
           logpush: undefined,
@@ -3459,7 +3515,11 @@ export const LiveWorkerProvider = () =>
         const rolloutTraffic = getSelfRolloutTraffic(news);
         let versionId: string | undefined;
         let deploymentId: string | undefined;
-        let worker: { id?: string | null; logpush?: boolean | null };
+        let worker: {
+          id?: string | null;
+          tag?: string | null;
+          logpush?: boolean | null;
+        };
         // A gradual rollout (`version.traffic` < 100) deploys through the
         // versions API instead of the full-cutover script PUT. That's only
         // possible when the script already has a live deployment to split
@@ -3548,7 +3608,14 @@ export const LiveWorkerProvider = () =>
               message: news.version?.message,
             });
           }
-          worker = { id: name, logpush: existingSettings.logpush };
+          worker = {
+            id: name,
+            tag:
+              output?.workerId !== undefined && output.workerId !== name
+                ? output.workerId
+                : yield* lookupScriptTag(accountId, name),
+            logpush: existingSettings.logpush,
+          };
         } else {
           if (rolloutTraffic !== undefined) {
             // First deploy of this script (or a pre-create placeholder is
@@ -3613,10 +3680,11 @@ export const LiveWorkerProvider = () =>
         // Workers for Platforms user workers are invoked via dynamic dispatch,
         // never routed directly — they have no workers.dev subdomain, custom
         // domains, zone routes, or cron triggers. Skip all of that
-        // reconciliation.
+        // reconciliation. They still receive an immutable script tag, but
+        // they are not Access targets (Access protects the dispatch Worker).
         if (dispatchNamespace) {
           return {
-            workerId: worker.id ?? name,
+            workerId: worker.tag ?? name,
             workerName: name,
             namespace: dispatchNamespace,
             logpush: worker.logpush ?? undefined,
@@ -3863,7 +3931,7 @@ export const LiveWorkerProvider = () =>
             ? yield* reconcileCrons(name, desiredCrons, previousCrons, session)
             : [];
         return {
-          workerId: worker.id ?? name,
+          workerId: worker.tag ?? name,
           workerName: name,
           namespace: undefined,
           logpush: worker.logpush ?? undefined,
@@ -4102,7 +4170,7 @@ export const LiveWorkerProvider = () =>
                         ? [
                             {
                               accountId,
-                              workerId: script.id,
+                              workerId: script.tag ?? script.id,
                               workerName: script.id,
                               namespace: undefined,
                               logpush: script.logpush ?? undefined,
@@ -4187,6 +4255,10 @@ export const LiveWorkerProvider = () =>
           if (!output) {
             return;
           }
+          const migrateWorkerId =
+            needsWorkerIdMigration(output) &&
+            !newIsVersion &&
+            newNamespace == null;
           // Compare the full domain config — name, aliases (ordered: they
           // drive `urls` order), and redirects — against persisted state
           // (with legacy `domains`-list state migrated on the fly).
@@ -4279,7 +4351,23 @@ export const LiveWorkerProvider = () =>
             oldWorkerName === workerName &&
             newDoClassNames.length === oldDoClassNames.length &&
             newDoClassNames.every((name, i) => name === oldDoClassNames[i]);
+          // `workerId` is always stable across an update; seed it so it
+          // survives now that `diff.stables` overrides `provider.stables`
+          // rather than being merged with it. Legacy rows that stored the
+          // script name as `workerId` omit it so reconcile can persist the
+          // immutable tag.
+          const stables: string[] = migrateWorkerId ? [] : ["workerId"];
+          if (oldWorkerName === workerName) {
+            stables.push("workerName");
+          }
+          if (urlStable) {
+            stables.push("url");
+          }
+          if (doNamespacesStable) {
+            stables.push("durableObjectNamespaces");
+          }
           if (
+            migrateWorkerId ||
             domainsChanged ||
             routesChanged ||
             cronsChanged ||
@@ -4293,19 +4381,6 @@ export const LiveWorkerProvider = () =>
               accountId,
             ))
           ) {
-            // `workerId` is always stable across an update; seed it so it
-            // survives now that `diff.stables` overrides `provider.stables`
-            // rather than being merged with it.
-            const stables: string[] = ["workerId"];
-            if (oldWorkerName === workerName) {
-              stables.push("workerName");
-            }
-            if (urlStable) {
-              stables.push("url");
-            }
-            if (doNamespacesStable) {
-              stables.push("durableObjectNamespaces");
-            }
             return {
               action: "update",
               stables: stables.length > 0 ? stables : undefined,
@@ -4659,7 +4734,10 @@ export const LiveWorkerProvider = () =>
               );
               const attrs = {
                 accountId,
-                workerId: workerName,
+                workerId:
+                  output?.workerId ??
+                  (yield* lookupScriptTag(accountId, workerName)) ??
+                  workerName,
                 workerName,
                 namespace: dispatchNamespace,
                 logpush: settings.logpush ?? undefined,
@@ -4786,7 +4864,10 @@ export const LiveWorkerProvider = () =>
             );
             const attrs = {
               accountId,
-              workerId: workerName,
+              workerId:
+                output?.workerId ??
+                (yield* lookupScriptTag(accountId, workerName)) ??
+                workerName,
               workerName,
               namespace: undefined,
               logpush: settings.logpush ?? undefined,

--- a/packages/alchemy/test/Cloudflare/Access/Application.test.ts
+++ b/packages/alchemy/test/Cloudflare/Access/Application.test.ts
@@ -169,7 +169,7 @@ test.provider(
 
       expect(app.type).toEqual("warp");
       // Cloudflare derives the warp domain as `${authDomain}/warp`.
-      expect(app.domain.endsWith("/warp")).toBe(true);
+      expect(app.domain?.endsWith("/warp")).toBe(true);
 
       yield* stack.destroy();
     }).pipe(logLevel),

--- a/packages/alchemy/test/Cloudflare/Access/WorkerProtection.test.ts
+++ b/packages/alchemy/test/Cloudflare/Access/WorkerProtection.test.ts
@@ -1,0 +1,485 @@
+import * as Cloudflare from "@/Cloudflare";
+import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
+import * as Test from "@/Test/Alchemy";
+import * as zeroTrust from "@distilled.cloud/cloudflare/zero-trust";
+import { describe, expect, test as unitTest } from "alchemy-test";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+import * as Redacted from "effect/Redacted";
+import * as Schedule from "effect/Schedule";
+import * as Stream from "effect/Stream";
+import ProtectedWorker, { fixtureBody } from "./fixtures/protected-worker.ts";
+
+const { test } = Test.make({ providers: Cloudflare.providers() });
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+const previewScript = `export default { fetch() { return new Response("${fixtureBody}"); } };`;
+
+class AccessProbeFailed extends Data.TaggedError("AccessProbeFailed")<{
+  message: string;
+}> {}
+
+const fetchManual = (url: string, headers?: Record<string, string>) =>
+  Effect.tryPromise(async (signal) => {
+    const res = await fetch(url, {
+      signal,
+      redirect: "manual",
+      cache: "no-store",
+      headers: {
+        "cache-control": "no-cache",
+        ...(headers ?? {}),
+      },
+    });
+    const location = res.headers.get("location") ?? undefined;
+    const body = await res.text();
+    return { status: res.status, location, body };
+  });
+
+const isAccessRedirect = (res: {
+  status: number;
+  location: string | undefined;
+}) =>
+  (res.status === 302 || res.status === 301) &&
+  (res.location?.includes(".cloudflareaccess.com") ?? false);
+
+const pollUntil = <A>(
+  effect: Effect.Effect<A, unknown>,
+  until: (value: A) => boolean,
+) =>
+  effect.pipe(
+    Effect.flatMap((value) =>
+      until(value)
+        ? Effect.succeed(value)
+        : Effect.fail(
+            new AccessProbeFailed({
+              message: `probe not ready: ${JSON.stringify(value).slice(0, 300)}`,
+            }),
+          ),
+    ),
+    Effect.retry({
+      while: (e): boolean => e._tag === "AccessProbeFailed",
+      schedule: Schedule.max([
+        Schedule.min([
+          Schedule.exponential("1 second"),
+          Schedule.spaced("5 seconds"),
+        ]),
+        Schedule.recurs(18),
+      ]),
+    }),
+  );
+
+const expectAccessRedirect = (url: string) =>
+  pollUntil(fetchManual(url), isAccessRedirect);
+
+const expectFixtureBody = (url: string, headers?: Record<string, string>) =>
+  pollUntil(
+    fetchManual(url, headers),
+    (res) => res.status === 200 && res.body.includes(fixtureBody),
+  );
+
+const liveDestinations = (accountId: string, appId: string) =>
+  zeroTrust
+    .getAccessApplicationForAccount({ accountId, appId })
+    .pipe(
+      Effect.map(
+        (app) =>
+          (app as { destinations?: ReadonlyArray<unknown> | null })
+            .destinations ?? [],
+      ),
+    );
+
+test.provider(
+  "typed not-found: get/delete of a missing Access application",
+  () =>
+    Effect.gen(function* () {
+      const { accountId } = yield* yield* CloudflareEnvironment;
+      const missing = "00000000-0000-4000-8000-000000000000";
+      const get = yield* zeroTrust
+        .getAccessApplicationForAccount({
+          accountId,
+          appId: missing,
+        })
+        .pipe(Effect.result);
+      expect(get._tag).toEqual("Failure");
+      if (get._tag === "Failure") {
+        expect(get.failure._tag).toEqual("AccessApplicationNotFound");
+      }
+      const del = yield* zeroTrust
+        .deleteAccessApplicationForAccount({
+          accountId,
+          appId: missing,
+        })
+        .pipe(Effect.result);
+      expect(del._tag).toEqual("Failure");
+      if (del._tag === "Failure") {
+        expect(del.failure._tag).toEqual("AccessApplicationNotFound");
+      }
+    }).pipe(logLevel),
+  { timeout: 60_000 },
+);
+
+test.provider(
+  "T1: worker destination → preview_worker → destroy (fixture-body oracle)",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* yield* CloudflareEnvironment;
+      yield* stack.destroy();
+
+      const v1 = yield* stack.deploy(
+        Effect.gen(function* () {
+          const parent = yield* ProtectedWorker;
+          const preview = yield* Cloudflare.Worker("ProtectedPreview", {
+            script: previewScript,
+            version: { parent },
+          });
+          const policy = yield* Cloudflare.Access.Policy("ProtectAllow", {
+            name: "Allow example.com",
+            decision: "allow",
+            include: [{ emailDomain: { domain: "example.com" } }],
+          });
+          const app = yield* Cloudflare.Access.Application("ProtectWorker", {
+            type: "self_hosted",
+            destinations: [{ type: "worker", workerId: parent.workerId }],
+            policies: [policy.policyId],
+          });
+          return { parent, preview, app, policy };
+        }),
+      );
+
+      expect(v1.parent.workerId).not.toEqual(v1.parent.workerName);
+      expect(v1.app.domain).toBeUndefined();
+
+      const sent = [{ type: "worker", workerId: v1.parent.workerId }];
+      const echoed = yield* liveDestinations(accountId, v1.app.applicationId);
+      // P2 — destination drift: if this fails, Cloudflare reorders/enriches
+      // and bodyEqualsObserved needs a shared canonicalDestinations().
+      expect(echoed).toEqual(sent);
+
+      yield* expectAccessRedirect(v1.parent.url!);
+      yield* expectAccessRedirect(v1.preview.url!);
+
+      const v2 = yield* stack.deploy(
+        Effect.gen(function* () {
+          const parent = yield* ProtectedWorker;
+          const preview = yield* Cloudflare.Worker("ProtectedPreview", {
+            script: previewScript,
+            version: { parent },
+          });
+          const policy = yield* Cloudflare.Access.Policy("ProtectAllow", {
+            name: "Allow example.com",
+            decision: "allow",
+            include: [{ emailDomain: { domain: "example.com" } }],
+          });
+          const app = yield* Cloudflare.Access.Application("ProtectWorker", {
+            type: "self_hosted",
+            destinations: [
+              { type: "preview_worker", workerId: parent.workerId },
+            ],
+            policies: [policy.policyId],
+          });
+          return { parent, preview, app };
+        }),
+      );
+
+      expect(v2.app.applicationId).toEqual(v1.app.applicationId);
+      expect(v2.app.aud).toEqual(v1.app.aud);
+      expect(yield* liveDestinations(accountId, v2.app.applicationId)).toEqual([
+        { type: "preview_worker", workerId: v2.parent.workerId },
+      ]);
+
+      yield* expectFixtureBody(v2.parent.url!);
+      yield* expectAccessRedirect(v2.preview.url!);
+
+      // Drop the Access app only — the Worker stays so both URLs should
+      // serve the fixture body again.
+      const v3 = yield* stack.deploy(
+        Effect.gen(function* () {
+          const parent = yield* ProtectedWorker;
+          const preview = yield* Cloudflare.Worker("ProtectedPreview", {
+            script: previewScript,
+            version: { parent },
+          });
+          yield* Cloudflare.Access.Policy("ProtectAllow", {
+            name: "Allow example.com",
+            decision: "allow",
+            include: [{ emailDomain: { domain: "example.com" } }],
+          });
+          return { parent, preview };
+        }),
+      );
+
+      yield* expectFixtureBody(v3.parent.url!);
+      yield* expectFixtureBody(v3.preview.url!);
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 180_000 },
+);
+
+test.provider(
+  "T2: allow (redirect) then bypass+everyone (unique body, anonymous)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const enforced = yield* stack.deploy(
+        Effect.gen(function* () {
+          const worker = yield* ProtectedWorker;
+          const policy = yield* Cloudflare.Access.Policy("EnforceAllow", {
+            name: "Allow example.com",
+            decision: "allow",
+            include: [{ emailDomain: { domain: "example.com" } }],
+          });
+          const app = yield* Cloudflare.Access.Application("PublicException", {
+            type: "self_hosted",
+            destinations: [{ type: "worker", workerId: worker.workerId }],
+            policies: [policy.policyId],
+          });
+          return { worker, app };
+        }),
+      );
+
+      yield* expectAccessRedirect(enforced.worker.url!);
+
+      const bypassed = yield* stack.deploy(
+        Effect.gen(function* () {
+          const worker = yield* ProtectedWorker;
+          const policy = yield* Cloudflare.Access.Policy("PublicBypass", {
+            name: "Bypass everyone",
+            decision: "bypass",
+            include: [{ everyone: {} }],
+          });
+          const app = yield* Cloudflare.Access.Application("PublicException", {
+            type: "self_hosted",
+            destinations: [{ type: "worker", workerId: worker.workerId }],
+            policies: [policy.policyId],
+          });
+          return { worker, app };
+        }),
+      );
+
+      expect(bypassed.app.applicationId).toEqual(enforced.app.applicationId);
+      yield* expectFixtureBody(bypassed.worker.url!);
+      // Bypass still goes through Access (aud is present) but there is
+      // no user identity — that is distinct from "Access did not run".
+      const whoami = yield* pollUntil(
+        fetchManual(`${bypassed.worker.url}/whoami`),
+        (res) => res.status === 200 && res.body.includes('"aud"'),
+      );
+      const identity = JSON.parse(whoami.body) as {
+        aud: string | null;
+        email: string | null;
+      };
+      expect(identity.email).toBeNull();
+      expect(identity.aud).toEqual(bypassed.app.aud);
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 180_000 },
+);
+
+test.provider(
+  "T3: service-token identity reaches the fixture body",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const deployed = yield* stack.deploy(
+        Effect.gen(function* () {
+          const worker = yield* ProtectedWorker;
+          const token = yield* Cloudflare.Access.ServiceToken("ProtectToken", {
+            name: "alchemy-access-worker-protect",
+          });
+          const policy = yield* Cloudflare.Access.Policy("ServiceAuth", {
+            name: "Service auth",
+            decision: "non_identity",
+            include: [{ serviceToken: { tokenId: token.serviceTokenId } }],
+          });
+          const app = yield* Cloudflare.Access.Application("TokenApp", {
+            type: "self_hosted",
+            destinations: [{ type: "worker", workerId: worker.workerId }],
+            policies: [policy.policyId],
+          });
+          return { worker, token, app };
+        }),
+      );
+
+      // Service Auth (`non_identity`) has no IdP login: an unauthenticated
+      // request is denied (403 Access error page), not redirected.
+      const denied = yield* pollUntil(
+        fetchManual(deployed.worker.url!),
+        (res) => res.status === 403 && res.body.includes("Cloudflare Access"),
+      );
+      expect(denied.status).toEqual(403);
+
+      const secret = deployed.token.clientSecret;
+      expect(secret).toBeDefined();
+      const headers = {
+        "CF-Access-Client-ID": deployed.token.clientId,
+        "CF-Access-Client-Secret": Redacted.value(secret!),
+      };
+      yield* expectFixtureBody(deployed.worker.url!, headers);
+
+      const whoami = yield* pollUntil(
+        fetchManual(`${deployed.worker.url}/whoami`, headers),
+        (res) => res.status === 200 && !res.body.includes("anonymous"),
+      );
+      const identity = JSON.parse(whoami.body) as {
+        aud: string | null;
+        email: string | null;
+        name: string | null;
+        userUuid: string | null;
+        accountId: string | null;
+      };
+      // Service tokens carry no user email. The Access JWT audience is
+      // the application `aud`; user identity fields stay empty.
+      expect(identity.email).toBeNull();
+      expect(identity.aud).toEqual(deployed.app.aud);
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 180_000 },
+);
+
+test.provider(
+  "T4 / P1: duplicate worker-destination create is rejected (no silent clone)",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* yield* CloudflareEnvironment;
+      yield* stack.destroy();
+
+      const deployed = yield* stack.deploy(
+        Effect.gen(function* () {
+          const worker = yield* ProtectedWorker;
+          const policy = yield* Cloudflare.Access.Policy("DupAllow", {
+            name: "Allow example.com",
+            decision: "allow",
+            include: [{ emailDomain: { domain: "example.com" } }],
+          });
+          const app = yield* Cloudflare.Access.Application("DupApp", {
+            type: "self_hosted",
+            destinations: [{ type: "worker", workerId: worker.workerId }],
+            policies: [policy.policyId],
+          });
+          return { worker, app, policy };
+        }),
+      );
+
+      const duplicate = yield* zeroTrust
+        .createAccessApplicationForAccount({
+          accountId,
+          type: "self_hosted",
+          name: "alchemy-dup-worker-dest",
+          destinations: [
+            { type: "worker", workerId: deployed.worker.workerId },
+          ],
+          policies: [deployed.policy.policyId],
+        })
+        .pipe(Effect.result);
+
+      // P1 — a silent duplicate would require destination-set recovery.
+      // A conflict must be a typed tag (not Forbidden: that is entitlement).
+      if (duplicate._tag === "Success") {
+        return yield* Effect.fail(
+          new AccessProbeFailed({
+            message:
+              "P1: Cloudflare accepted a second app on the same worker destination — implement destination-set recovery",
+          }),
+        );
+      }
+      expect(duplicate.failure._tag).toEqual("AccessDestinationConflict");
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 180_000 },
+);
+
+unitTest("worker-identity destinations are schema-covered (ungated)", () => {
+  const destinations: Cloudflare.Access.ApplicationDestination[] = [
+    { type: "worker", workerId: "script-tag" },
+    { type: "preview_worker", workerId: "script-tag" },
+    { type: "all_workers" },
+    { type: "all_preview_workers" },
+  ];
+  expect(destinations.map((d) => d.type)).toEqual([
+    "worker",
+    "preview_worker",
+    "all_workers",
+    "all_preview_workers",
+  ]);
+});
+
+const accountWideEnabled =
+  process.env.CLOUDFLARE_TEST_ACCESS_ACCOUNT_WIDE === "1";
+
+describe.skipIf(!accountWideEnabled)("account-wide Access (env-gated)", () => {
+  test.provider(
+    "T5: all_preview_workers with preflight and immediate teardown",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+
+        const existing = yield* zeroTrust.listAccessApplicationsForAccount
+          .items({ accountId })
+          .pipe(
+            Stream.runCollect,
+            Effect.map((chunk) =>
+              Array.from(chunk).filter((app) =>
+                (
+                  (app as { destinations?: ReadonlyArray<{ type?: string }> })
+                    .destinations ?? []
+                ).some(
+                  (d) =>
+                    d.type === "all_preview_workers" ||
+                    d.type === "all_workers",
+                ),
+              ),
+            ),
+          );
+        if (existing.length > 0) {
+          return yield* Effect.fail(
+            new AccessProbeFailed({
+              message: `refusing to touch ${existing.length} pre-existing account-wide Access app(s)`,
+            }),
+          );
+        }
+
+        yield* stack.destroy();
+
+        yield* Effect.gen(function* () {
+          const deployed = yield* stack.deploy(
+            Effect.gen(function* () {
+              const parent = yield* ProtectedWorker;
+              const preview = yield* Cloudflare.Worker("AccountWidePreview", {
+                script: previewScript,
+                version: { parent },
+              });
+              const policy = yield* Cloudflare.Access.Policy(
+                "AccountWideAllow",
+                {
+                  name: "Allow example.com",
+                  decision: "allow",
+                  include: [{ emailDomain: { domain: "example.com" } }],
+                },
+              );
+              const app = yield* Cloudflare.Access.Application("AllPreviews", {
+                type: "self_hosted",
+                destinations: [{ type: "all_preview_workers" }],
+                policies: [policy.policyId],
+              });
+              return { parent, preview, app };
+            }),
+          );
+
+          yield* expectFixtureBody(deployed.parent.url!);
+          yield* expectAccessRedirect(deployed.preview.url!);
+        }).pipe(Effect.ensuring(stack.destroy()));
+      }).pipe(logLevel),
+    { timeout: 180_000 },
+  );
+});

--- a/packages/alchemy/test/Cloudflare/Access/fixtures/protected-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Access/fixtures/protected-worker.ts
@@ -1,0 +1,43 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Effect from "effect/Effect";
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+/** Unique body used as the T1/T2/T3 success oracle — never a bare 200. */
+export const fixtureBody = "alchemy-access-protected-worker-body";
+
+export default class ProtectedWorker extends Cloudflare.Worker<ProtectedWorker>()(
+  "ProtectedWorker",
+  {
+    main: import.meta.url,
+  },
+  Effect.gen(function* () {
+    return {
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        if (request.url.startsWith("/whoami")) {
+          const ctx = yield* Cloudflare.WorkerExecutionContext;
+          const aud = yield* ctx.access.aud;
+          const identity = yield* ctx.access.identity.pipe(
+            Effect.catchTag("AccessIdentityError", () =>
+              Effect.succeed(undefined),
+            ),
+          );
+          // Service Auth has an aud but no user identity. Bypass / no
+          // Access leaves both undefined.
+          if (aud === undefined && identity === undefined) {
+            return HttpServerResponse.text("anonymous");
+          }
+          return yield* HttpServerResponse.json({
+            aud: aud ?? null,
+            email: identity?.email ?? null,
+            name: identity?.name ?? null,
+            userUuid: identity?.user_uuid ?? null,
+            accountId: identity?.account_id ?? null,
+          });
+        }
+        return HttpServerResponse.text(fixtureBody);
+      }),
+    };
+  }),
+) {}

--- a/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
@@ -1567,6 +1567,17 @@ describe.concurrent("Cloudflare.Worker", () => {
       expect(found?.workerId).toEqual(worker.workerId);
       expect(found?.accountId).toEqual(accountId);
 
+      // workerId is the immutable script tag, not the script name. Pin the
+      // equality chain: persist (putScript.tag) === list (script.tag) ===
+      // Beta GET (id). If this ever fails, switch the source to Beta GET.
+      const beta = yield* workers.getBetaWorker({
+        accountId,
+        workerId: worker.workerName,
+      });
+      expect(worker.workerId).toEqual(beta.id);
+      expect(found?.workerId).toEqual(beta.id);
+      expect(worker.workerId).not.toEqual(worker.workerName);
+
       yield* stack.destroy();
       yield* waitForWorkerToBeDeleted(worker.workerName, accountId);
     }).pipe(logLevel),

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerProvider.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerProvider.test.ts
@@ -1,7 +1,9 @@
 import {
   encodeDurableObjectTags,
   getDurableObjectTagMap,
+  needsWorkerIdMigration,
   normalizeStateDomains,
+  resolveVersionParentWorkerId,
   resolveWorkerDomain,
   resolveWorkersDev,
   shouldObserveWorkerCrons,
@@ -451,6 +453,63 @@ describe("WorkerProvider", () => {
 
     test("observes when prior state has crons (e.g. Effect-native cron())", () => {
       expect(shouldObserveWorkerCrons({}, { crons: ["0 * * * *"] })).toBe(true);
+    });
+  });
+
+  describe("needsWorkerIdMigration", () => {
+    test("legacy-shaped output (workerId === workerName) needs an update", () => {
+      expect(
+        needsWorkerIdMigration({
+          workerId: "my-worker",
+          workerName: "my-worker",
+        }),
+      ).toBe(true);
+    });
+
+    test("a persisted script tag is already migrated", () => {
+      expect(
+        needsWorkerIdMigration({
+          workerId: "5a1b2c3d4e5f6789",
+          workerName: "my-worker",
+        }),
+      ).toBe(false);
+    });
+
+    test("dispatch-namespace and version rows are excluded", () => {
+      expect(
+        needsWorkerIdMigration({
+          workerId: "my-worker",
+          workerName: "my-worker",
+          namespace: "customers",
+        }),
+      ).toBe(false);
+      expect(
+        needsWorkerIdMigration({
+          workerId: "my-worker",
+          workerName: "my-worker",
+          versionOf: "parent-worker",
+        }),
+      ).toBe(false);
+    });
+
+    test("missing output is not a migration", () => {
+      expect(needsWorkerIdMigration(undefined)).toBe(false);
+    });
+  });
+
+  describe("resolveVersionParentWorkerId", () => {
+    test("a resolved Worker reference supplies the parent's tag", () => {
+      expect(
+        resolveVersionParentWorkerId({
+          parent: { workerId: "tag-abc", workerName: "parent" } as never,
+        }),
+      ).toEqual("tag-abc");
+    });
+
+    test("a literal-name parent cannot supply a tag", () => {
+      expect(
+        resolveVersionParentWorkerId({ parent: "parent-script" }),
+      ).toBeUndefined();
     });
   });
 });

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -788,6 +788,10 @@ export default defineConfig({
                   link: "/cloudflare/security/secrets-store",
                 },
                 { label: "Turnstile", link: "/cloudflare/security/turnstile" },
+                {
+                  label: "Access on Workers",
+                  link: "/cloudflare/security/access-workers",
+                },
               ],
             },
             {

--- a/website/src/content/docs/cloudflare/security/access-workers.mdx
+++ b/website/src/content/docs/cloudflare/security/access-workers.mdx
@@ -8,7 +8,10 @@ sidebar:
 Cloudflare Access can protect a Worker by **identity**, not just by
 hostname. An Access application with a worker destination covers
 every URL that Worker serves — routes, custom domains, `workers.dev`,
-and preview URLs — without listing those hostnames.
+and preview URLs — without listing those hostnames. See Cloudflare's
+[Access for Workers docs](https://developers.cloudflare.com/workers/configuration/cloudflare-access/)
+and the
+[launch post](https://blog.cloudflare.com/workers-protected-by-access/).
 
 ## Three-tier model
 
@@ -90,3 +93,11 @@ workers in a dispatch namespace are not Access targets.
 
 Under `alchemy dev`, `ctx.access` is absent and `identity` resolves
 `undefined`. Local simulation is a planned follow-up.
+
+## Related
+
+- [Cloudflare Access for Workers](https://developers.cloudflare.com/workers/configuration/cloudflare-access/)
+  — destination types, hierarchy, WebSocket limitation, and
+  `ctx.access`.
+- [Workers protected by Access](https://blog.cloudflare.com/workers-protected-by-access/)
+  — launch post for attaching Access to a Worker or the whole account.

--- a/website/src/content/docs/cloudflare/security/access-workers.mdx
+++ b/website/src/content/docs/cloudflare/security/access-workers.mdx
@@ -1,0 +1,92 @@
+---
+title: Protect Workers with Access
+description: Attach Cloudflare Access to a Worker by identity — one Worker, its previews, or every preview in the account — and read the authenticated identity at runtime.
+sidebar:
+  order: 24
+---
+
+Cloudflare Access can protect a Worker by **identity**, not just by
+hostname. An Access application with a worker destination covers
+every URL that Worker serves — routes, custom domains, `workers.dev`,
+and preview URLs — without listing those hostnames.
+
+## Three-tier model
+
+| Destination | What it protects |
+|---|---|
+| `{ type: "worker", workerId }` | One Worker, everywhere it serves |
+| `{ type: "preview_worker", workerId }` | That Worker's preview URLs only |
+| `{ type: "all_workers" }` | Every Worker in the account, including future ones |
+| `{ type: "all_preview_workers" }` | Every preview URL in the account |
+
+`workerId` is the Worker's immutable script tag (`worker.workerId`),
+not the script name (`worker.workerName`).
+
+## Precedence
+
+Hostname/path applications win over worker-level applications, which
+win over account-wide ones. A worker-level app with a reusable
+`bypass` + `everyone` policy makes that Worker public under an
+account-wide gate. A hostname/path app still overrides both.
+
+## Protect one Worker
+
+```typescript
+const worker = yield* Cloudflare.Worker("Api", { main: "./src/api.ts" });
+
+const allowOrg = yield* Cloudflare.Access.Policy("AllowOrg", {
+  decision: "allow",
+  include: [{ cloudflareAccountMember: {} }],
+});
+
+yield* Cloudflare.Access.Application("ProtectApi", {
+  type: "self_hosted",
+  destinations: [{ type: "worker", workerId: worker.workerId }],
+  policies: [allowOrg.policyId],
+});
+```
+
+## Public exception
+
+```typescript
+const publicBypass = yield* Cloudflare.Access.Policy("PublicBypass", {
+  decision: "bypass",
+  include: [{ everyone: {} }],
+});
+
+yield* Cloudflare.Access.Application("PublicApi", {
+  type: "self_hosted",
+  destinations: [{ type: "worker", workerId: worker.workerId }],
+  policies: [publicBypass.policyId],
+});
+```
+
+Dashboard one-click Access uses the same reusable-policy model.
+Inline policies are not supported.
+
+## Identity at runtime
+
+```typescript
+const ctx = yield* Cloudflare.WorkerExecutionContext;
+const aud = yield* ctx.access.aud;
+const identity = yield* ctx.access.identity;
+// or: yield* Cloudflare.Access.getIdentity
+```
+
+`ctx.access` is `undefined` when Access did not authenticate the
+request. `identity` is then `undefined`. A rejected lookup is
+`AccessIdentityError`.
+
+The raw workerd API is still on `ctx.raw.access` (`aud` and
+`getIdentity()`).
+
+:::caution
+Worker-level Access policies reject WebSocket upgrades with 403.
+Use a hostname/path application if the Worker serves WebSockets.
+:::
+
+Workers for Platforms: Access protects the **dispatch Worker**. User
+workers in a dispatch namespace are not Access targets.
+
+Under `alchemy dev`, `ctx.access` is absent and `identity` resolves
+`undefined`. Local simulation is a planned follow-up.


### PR DESCRIPTION
Closes #1225. Protect a Worker with Cloudflare Access by identity — one Worker, its previews, or every Worker / preview in the account — and read the authenticated identity at runtime.

This is the feature from the [Access for Workers docs](https://developers.cloudflare.com/workers/configuration/cloudflare-access/) and the [launch post](https://blog.cloudflare.com/workers-protected-by-access/). #1225 asked for the destination union; this PR also wires the control plane, the script-tag identity, and `ctx.access`.

```ts
const worker = yield* Cloudflare.Worker("Api", { main: "./src/api.ts" });
const allowOrg = yield* Cloudflare.Access.Policy("AllowOrg", {
  decision: "allow",
  include: [{ cloudflareAccountMember: {} }],
});
yield* Cloudflare.Access.Application("ProtectApi", {
  type: "self_hosted",
  destinations: [{ type: "worker", workerId: worker.workerId }],
  policies: [allowOrg.policyId],
});
```

`worker.workerId` is the immutable script `tag`, not the script name. Cloudflare's `worker_id` field is that tag.

```ts
export type ApplicationDestination =
  | { type: "public"; uri: string }
  | { type: "private"; /* … */ }
  | { type: "via_mcp_server_portal"; mcpServerId: string }
  | { type: "worker"; workerId: string }
  | { type: "preview_worker"; workerId: string }
  | { type: "all_workers" }
  | { type: "all_preview_workers" };
```

```ts
const ctx = yield* Cloudflare.WorkerExecutionContext;
const aud = yield* ctx.access.aud;
const identity = yield* ctx.access.identity;
// or: yield* Cloudflare.Access.getIdentity
```

Depends on [alchemy-run/distilled#458](https://github.com/alchemy-run/distilled/pull/458) for `AccessApplicationNotFound` and `AccessDestinationConflict`. Draft until that merges and this PR retargets the submodule pin to the merge SHA.

A second application for the same worker destination is rejected (`AccessDestinationConflict`) — no steal/adopt. Cloudflare echoes destinations faithfully; we do not invent a `domain`.

Account-wide `all_workers` / `all_preview_workers` live tests stay behind `CLOUDFLARE_TEST_ACCESS_ACCOUNT_WIDE=1`. Local `alchemy dev` simulation of `ctx.access` is a follow-up.

Guide: `website/src/content/docs/cloudflare/security/access-workers.mdx`.
