### PR TITLE
feat(cloudflare)!: protect Workers with Access

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2072,7 +2072,7 @@
     },
     "workers": {
       "@cloudflare/unenv-preset": "^2.16.0",
-      "@cloudflare/workers-types": "^5.20260704.1",
+      "@cloudflare/workers-types": "^5.20260812.1",
       "miniflare": "^4.20260701.0",
       "unenv": "^2.0.0-rc.24",
       "workerd": "1.20260704.1",
@@ -3031,23 +3031,23 @@
 
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.43.0", "", {}, "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg=="],
 
-    "@opentui/core": ["@opentui/core@0.5.2", "", { "dependencies": { "bun-ffi-structs": "0.3.1", "diff": "9.0.0", "marked": "17.0.1", "string-width": "7.2.0", "strip-ansi": "7.1.2" }, "optionalDependencies": { "@opentui/core-darwin-arm64": "0.5.2", "@opentui/core-darwin-x64": "0.5.2", "@opentui/core-linux-arm64": "0.5.2", "@opentui/core-linux-arm64-musl": "0.5.2", "@opentui/core-linux-x64": "0.5.2", "@opentui/core-linux-x64-musl": "0.5.2", "@opentui/core-win32-arm64": "0.5.2", "@opentui/core-win32-x64": "0.5.2" }, "peerDependencies": { "web-tree-sitter": "0.25.10" } }, "sha512-GOuD0Mq1ylybq9eEX6L0TdYlfJ2zJVLGecuh6yEM8RpT9oMtR0f+gEWqGJsBN/ay+Y5TOCH9b3vePEcwOW01fg=="],
+    "@opentui/core": ["@opentui/core@0.5.3", "", { "dependencies": { "bun-ffi-structs": "0.3.1", "diff": "9.0.0", "marked": "17.0.1", "string-width": "7.2.0", "strip-ansi": "7.1.2" }, "optionalDependencies": { "@opentui/core-darwin-arm64": "0.5.3", "@opentui/core-darwin-x64": "0.5.3", "@opentui/core-linux-arm64": "0.5.3", "@opentui/core-linux-arm64-musl": "0.5.3", "@opentui/core-linux-x64": "0.5.3", "@opentui/core-linux-x64-musl": "0.5.3", "@opentui/core-win32-arm64": "0.5.3", "@opentui/core-win32-x64": "0.5.3" }, "peerDependencies": { "web-tree-sitter": "0.25.10" } }, "sha512-K8EQu44cx0rhnn3v3baCQW18Bpci3GltZayOwVpGGsbiAGL1WUYqwQjuaWsmS0c4dCa9rQ5xCEoHB1C4936nDg=="],
 
-    "@opentui/core-darwin-arm64": ["@opentui/core-darwin-arm64@0.5.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-fGi/RubZIhxcU8+M3GXNaBmEHqf127ZOnKmUTSp4ty2QdQ0kT4RTd+t91a/oyxrLZjjCmry0jXyquT0CZR1Byw=="],
+    "@opentui/core-darwin-arm64": ["@opentui/core-darwin-arm64@0.5.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-R39YeUqaMb/rH1h6G4MkB4MLVKIrRaUaXLfVqorZM4xgU5BxnfPetRk1vWR9vuLCvDwskg+kQ589kULw0o6AWA=="],
 
-    "@opentui/core-darwin-x64": ["@opentui/core-darwin-x64@0.5.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-ezFpB+5mQTd9BS4VvHOYEgQK6YxiYwVUmFb2sfTbJBnTqbOFP3Z/cdE5qNUHoeLQ01/nOs2dmUPcGyWxtMZIzw=="],
+    "@opentui/core-darwin-x64": ["@opentui/core-darwin-x64@0.5.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-1pmUas/chTVFGeiN19kaOx+5Xbte/DLhcgKyACwWO0M3+xE3z1v/6QGSyX6CoP5HBpmDroiX+JHv1ic/JlGd/g=="],
 
-    "@opentui/core-linux-arm64": ["@opentui/core-linux-arm64@0.5.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-9S53zkIkbwRb0iIv2thibK+IofpTCEz/c48rJNaBx3qDylaDcTA11k5oqt1gkFcOLernlqIcow8aMCNDnRYMAA=="],
+    "@opentui/core-linux-arm64": ["@opentui/core-linux-arm64@0.5.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nMo9Q9VIaQVdw2SNKlwIEWMmf3z+cI4jRdCkh36e2RU1FO7LrIBAEmV1ZuRp1CIFVGPkqCXIizCeckZHTr4yQ=="],
 
-    "@opentui/core-linux-arm64-musl": ["@opentui/core-linux-arm64-musl@0.5.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-s2DB6he7jgbBqWOHBAIV/p4X12mj+Hlk1pAEcwK36j2wg+L4nVVdWecUJm1xeJn6LJSRcaJYE29sA45w5b7B2g=="],
+    "@opentui/core-linux-arm64-musl": ["@opentui/core-linux-arm64-musl@0.5.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-QOYAxbbWrhYo27Cd6m0ATzpEx9YCAKAq82LgfUn0xu+VKXLNu+Q3hMNSVbG0SepUQQZil5rz228R9o9Cs8995w=="],
 
-    "@opentui/core-linux-x64": ["@opentui/core-linux-x64@0.5.2", "", { "os": "linux", "cpu": "x64" }, "sha512-HO0TWovqxo95hxFoTBx47MTP6pzzTW/QMoOIiD8jw0hkrn1DF8rSVPva0vLQMRer/drO9RpjyroFRNra7710og=="],
+    "@opentui/core-linux-x64": ["@opentui/core-linux-x64@0.5.3", "", { "os": "linux", "cpu": "x64" }, "sha512-hdAYLriLpTj3lvpMyL25GPBzvM2w/n2KCSbIwTmgS2F/dPZYCKJxHEETj2lCvtStSp7KuY8tkg3Xl5RAq1v7gA=="],
 
-    "@opentui/core-linux-x64-musl": ["@opentui/core-linux-x64-musl@0.5.2", "", { "os": "linux", "cpu": "x64" }, "sha512-zyuJaRGBRbUOABgf3nJ2Jk/NmD+gS2dQpJzC2ikr2OMqclPVk7gFbPTHW2s/A3SJH7D8d0PJ6wL2wzXWMUdrWQ=="],
+    "@opentui/core-linux-x64-musl": ["@opentui/core-linux-x64-musl@0.5.3", "", { "os": "linux", "cpu": "x64" }, "sha512-BkVIiPQ1TOf5/FfmIpf7DQU5rT/FO6ASW5R/o/wonI5Pdul7XiDCu86gzGyk1x5k9Sbh6GLeq1fe8/tPmI7IaA=="],
 
-    "@opentui/core-win32-arm64": ["@opentui/core-win32-arm64@0.5.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-J1QxYJqxyAO49RyocqZSoGWs5uszlYot8sInLasi6nUbjCFg4h7Kvh+64+gxE2i4LASeyvMRpAIYwblI6eMbtg=="],
+    "@opentui/core-win32-arm64": ["@opentui/core-win32-arm64@0.5.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-AjObTyZPU0xsK3Yk8GmhkboK6OcMoHBbydqYAybeHD4+v6axScSuZ3OEI9J05JJ9T7H2nZNky75tsdnjsvZJmg=="],
 
-    "@opentui/core-win32-x64": ["@opentui/core-win32-x64@0.5.2", "", { "os": "win32", "cpu": "x64" }, "sha512-9/F1Q19GdtkZ1jypa0dRP6v9SJHHc91XHs4ZSroamDeqSDyTaGu1bbWnKiC503gpNpQMY0mjOVg4g+WVJLdDig=="],
+    "@opentui/core-win32-x64": ["@opentui/core-win32-x64@0.5.3", "", { "os": "win32", "cpu": "x64" }, "sha512-e3nRlF2nSkLKCUPBF32OL9EDgtQDIh2pBo7tjhumpTyJ3qoNOa3us7DsM290Vw4xnakM6jpk9r9NzRf72CuMVg=="],
 
     "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
 
@@ -6549,13 +6549,13 @@
 
     "@actions/http-client/undici": ["undici@5.29.0", "", { "dependencies": { "@fastify/busboy": "^2.0.0" } }, "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg=="],
 
-    "@alchemy.run/cloudflare-runtime/@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260729.1", "", {}, "sha512-X5r/4y0gKMq/B72qkz/tEwNK4c3v2regT3to6Ia8qqC66E0+YIN/fU7x0JG6ej2rLxtU3TV3aVhfK9y8+jMMAw=="],
+    "@alchemy.run/cloudflare-runtime/@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260812.1", "", {}, "sha512-eG2aQdUWH8RYEubpBjUE98L2G57JYzGEcI8PgROTjt9YjunbEnPBHP4371Usj8v8pTWcXtbOmI+LRCXF4KhJgQ=="],
 
     "@alchemy.run/cloudflare-runtime/@types/node": ["@types/node@26.2.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg=="],
 
     "@alchemy.run/floci/@types/node": ["@types/node@26.2.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg=="],
 
-    "@alchemy.run/frontend-frameworks/@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260729.1", "", {}, "sha512-X5r/4y0gKMq/B72qkz/tEwNK4c3v2regT3to6Ia8qqC66E0+YIN/fU7x0JG6ej2rLxtU3TV3aVhfK9y8+jMMAw=="],
+    "@alchemy.run/frontend-frameworks/@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260812.1", "", {}, "sha512-eG2aQdUWH8RYEubpBjUE98L2G57JYzGEcI8PgROTjt9YjunbEnPBHP4371Usj8v8pTWcXtbOmI+LRCXF4KhJgQ=="],
 
     "@astrojs/check/chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
@@ -6729,27 +6729,27 @@
 
     "@effect/sql-d1/@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260729.1", "", {}, "sha512-X5r/4y0gKMq/B72qkz/tEwNK4c3v2regT3to6Ia8qqC66E0+YIN/fU7x0JG6ej2rLxtU3TV3aVhfK9y8+jMMAw=="],
 
-    "@fixtures/astro/@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260729.1", "", {}, "sha512-X5r/4y0gKMq/B72qkz/tEwNK4c3v2regT3to6Ia8qqC66E0+YIN/fU7x0JG6ej2rLxtU3TV3aVhfK9y8+jMMAw=="],
+    "@fixtures/astro/@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260812.1", "", {}, "sha512-eG2aQdUWH8RYEubpBjUE98L2G57JYzGEcI8PgROTjt9YjunbEnPBHP4371Usj8v8pTWcXtbOmI+LRCXF4KhJgQ=="],
 
-    "@fixtures/astro-ssr/@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260729.1", "", {}, "sha512-X5r/4y0gKMq/B72qkz/tEwNK4c3v2regT3to6Ia8qqC66E0+YIN/fU7x0JG6ej2rLxtU3TV3aVhfK9y8+jMMAw=="],
+    "@fixtures/astro-ssr/@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260812.1", "", {}, "sha512-eG2aQdUWH8RYEubpBjUE98L2G57JYzGEcI8PgROTjt9YjunbEnPBHP4371Usj8v8pTWcXtbOmI+LRCXF4KhJgQ=="],
 
-    "@fixtures/astro-static/@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260729.1", "", {}, "sha512-X5r/4y0gKMq/B72qkz/tEwNK4c3v2regT3to6Ia8qqC66E0+YIN/fU7x0JG6ej2rLxtU3TV3aVhfK9y8+jMMAw=="],
+    "@fixtures/astro-static/@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260812.1", "", {}, "sha512-eG2aQdUWH8RYEubpBjUE98L2G57JYzGEcI8PgROTjt9YjunbEnPBHP4371Usj8v8pTWcXtbOmI+LRCXF4KhJgQ=="],
 
-    "@fixtures/monorepo-workspace/@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260729.1", "", {}, "sha512-X5r/4y0gKMq/B72qkz/tEwNK4c3v2regT3to6Ia8qqC66E0+YIN/fU7x0JG6ej2rLxtU3TV3aVhfK9y8+jMMAw=="],
+    "@fixtures/monorepo-workspace/@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260812.1", "", {}, "sha512-eG2aQdUWH8RYEubpBjUE98L2G57JYzGEcI8PgROTjt9YjunbEnPBHP4371Usj8v8pTWcXtbOmI+LRCXF4KhJgQ=="],
 
     "@fixtures/nextjs/wrangler": ["wrangler@file:packages/frontend-frameworks/src/nextjs/wrangler-stub", {}],
 
     "@fixtures/nextjs-isr/wrangler": ["wrangler@file:packages/frontend-frameworks/src/nextjs/wrangler-stub", {}],
 
-    "@fixtures/nuxt/@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260729.1", "", {}, "sha512-X5r/4y0gKMq/B72qkz/tEwNK4c3v2regT3to6Ia8qqC66E0+YIN/fU7x0JG6ej2rLxtU3TV3aVhfK9y8+jMMAw=="],
+    "@fixtures/nuxt/@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260812.1", "", {}, "sha512-eG2aQdUWH8RYEubpBjUE98L2G57JYzGEcI8PgROTjt9YjunbEnPBHP4371Usj8v8pTWcXtbOmI+LRCXF4KhJgQ=="],
 
     "@fixtures/nuxt/@types/node": ["@types/node@24.13.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q=="],
 
-    "@fixtures/octane/@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260729.1", "", {}, "sha512-X5r/4y0gKMq/B72qkz/tEwNK4c3v2regT3to6Ia8qqC66E0+YIN/fU7x0JG6ej2rLxtU3TV3aVhfK9y8+jMMAw=="],
+    "@fixtures/octane/@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260812.1", "", {}, "sha512-eG2aQdUWH8RYEubpBjUE98L2G57JYzGEcI8PgROTjt9YjunbEnPBHP4371Usj8v8pTWcXtbOmI+LRCXF4KhJgQ=="],
 
     "@fixtures/octane/@types/node": ["@types/node@24.13.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q=="],
 
-    "@fixtures/react-router-rsc/@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260729.1", "", {}, "sha512-X5r/4y0gKMq/B72qkz/tEwNK4c3v2regT3to6Ia8qqC66E0+YIN/fU7x0JG6ej2rLxtU3TV3aVhfK9y8+jMMAw=="],
+    "@fixtures/react-router-rsc/@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260812.1", "", {}, "sha512-eG2aQdUWH8RYEubpBjUE98L2G57JYzGEcI8PgROTjt9YjunbEnPBHP4371Usj8v8pTWcXtbOmI+LRCXF4KhJgQ=="],
 
     "@fixtures/react-router-rsc/@types/node": ["@types/node@24.13.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q=="],
 
@@ -6761,21 +6761,21 @@
 
     "@fixtures/sveltekit-spa/@types/node": ["@types/node@24.13.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q=="],
 
-    "@fixtures/tanstack-start/@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260729.1", "", {}, "sha512-X5r/4y0gKMq/B72qkz/tEwNK4c3v2regT3to6Ia8qqC66E0+YIN/fU7x0JG6ej2rLxtU3TV3aVhfK9y8+jMMAw=="],
+    "@fixtures/tanstack-start/@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260812.1", "", {}, "sha512-eG2aQdUWH8RYEubpBjUE98L2G57JYzGEcI8PgROTjt9YjunbEnPBHP4371Usj8v8pTWcXtbOmI+LRCXF4KhJgQ=="],
 
     "@fixtures/tanstack-start/@types/node": ["@types/node@22.20.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q=="],
 
     "@fixtures/tanstack-start/@vitejs/plugin-react": ["@vitejs/plugin-react@5.2.0", "", { "dependencies": { "@babel/core": "^7.29.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-rc.3", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw=="],
 
-    "@fixtures/vocs/@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260729.1", "", {}, "sha512-X5r/4y0gKMq/B72qkz/tEwNK4c3v2regT3to6Ia8qqC66E0+YIN/fU7x0JG6ej2rLxtU3TV3aVhfK9y8+jMMAw=="],
+    "@fixtures/vocs/@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260812.1", "", {}, "sha512-eG2aQdUWH8RYEubpBjUE98L2G57JYzGEcI8PgROTjt9YjunbEnPBHP4371Usj8v8pTWcXtbOmI+LRCXF4KhJgQ=="],
 
     "@fixtures/vocs/@types/node": ["@types/node@24.13.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q=="],
 
-    "@fixtures/waku/@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260729.1", "", {}, "sha512-X5r/4y0gKMq/B72qkz/tEwNK4c3v2regT3to6Ia8qqC66E0+YIN/fU7x0JG6ej2rLxtU3TV3aVhfK9y8+jMMAw=="],
+    "@fixtures/waku/@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260812.1", "", {}, "sha512-eG2aQdUWH8RYEubpBjUE98L2G57JYzGEcI8PgROTjt9YjunbEnPBHP4371Usj8v8pTWcXtbOmI+LRCXF4KhJgQ=="],
 
     "@fixtures/waku/@types/node": ["@types/node@24.13.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q=="],
 
-    "@fixtures/waku-durable-objects/@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260729.1", "", {}, "sha512-X5r/4y0gKMq/B72qkz/tEwNK4c3v2regT3to6Ia8qqC66E0+YIN/fU7x0JG6ej2rLxtU3TV3aVhfK9y8+jMMAw=="],
+    "@fixtures/waku-durable-objects/@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260812.1", "", {}, "sha512-eG2aQdUWH8RYEubpBjUE98L2G57JYzGEcI8PgROTjt9YjunbEnPBHP4371Usj8v8pTWcXtbOmI+LRCXF4KhJgQ=="],
 
     "@fixtures/waku-durable-objects/@types/node": ["@types/node@24.13.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q=="],
 
@@ -7590,6 +7590,8 @@
     "website/typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "wrangler/@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.5.0", "", {}, "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg=="],
+
+    "wrangler/@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260812.1", "", {}, "sha512-eG2aQdUWH8RYEubpBjUE98L2G57JYzGEcI8PgROTjt9YjunbEnPBHP4371Usj8v8pTWcXtbOmI+LRCXF4KhJgQ=="],
 
     "wrangler/path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
 

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
       },
       "workers": {
         "@cloudflare/unenv-preset": "^2.16.0",
-        "@cloudflare/workers-types": "^5.20260704.1",
+        "@cloudflare/workers-types": "^5.20260812.1",
         "miniflare": "^4.20260701.0",
         "unenv": "^2.0.0-rc.24",
         "workerd": "1.20260704.1"

--- a/packages/alchemy/src/Cloudflare/Access/Application.ts
+++ b/packages/alchemy/src/Cloudflare/Access/Application.ts
@@ -49,10 +49,10 @@ export type ApplicationType =
  * - `via_mcp_server_portal` — routes via a managed MCP server portal.
  * - `worker` / `preview_worker` — a specific Cloudflare Worker's production
  *   traffic (custom domains, routes, `workers.dev`) or its version preview
- *   URLs, keyed by the Worker's immutable script id (its `scriptTag`
- *   attribute). Usually you don't write these by hand — set the `access`
- *   prop on the `Cloudflare.Worker` instead, and the Worker enrolls itself
- *   into the application.
+ *   URLs, keyed by the Worker's immutable ID (its `workerId` attribute).
+ *   Usually you don't write these by hand — set the `access` prop on the
+ *   `Cloudflare.Worker` instead, and the Worker enrolls itself into the
+ *   application.
  * - `all_workers` / `all_preview_workers` — every Worker on the account
  *   (including ones created later), production or preview traffic
  *   respectively. Hostname-level policies take precedence over Worker-level

--- a/packages/alchemy/src/Cloudflare/Access/Application.ts
+++ b/packages/alchemy/src/Cloudflare/Access/Application.ts
@@ -10,6 +10,12 @@ import { Resource } from "../../Resource.ts";
 import { arrayEquals } from "../../Util/equal.ts";
 import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
 import type { Providers } from "../Providers.ts";
+import type {
+  PolicyDecision,
+  PolicyExcludeRule,
+  PolicyRequireRule,
+  PolicyRule,
+} from "./Policy.ts";
 
 /**
  * Application type literal — every value Cloudflare's Access service
@@ -39,9 +45,10 @@ export type ApplicationType =
  * - `via_mcp_server_portal` — routes via a managed MCP server portal.
  * - `worker` / `preview_worker` — a specific Cloudflare Worker's production
  *   traffic (custom domains, routes, `workers.dev`) or its version preview
- *   URLs. `workerId` is the Worker's immutable script id — pass a deployed
- *   Worker's `scriptTag` attribute, or use the {@link Worker} /
- *   {@link WorkerPreview} helpers.
+ *   URLs, keyed by the Worker's immutable script id (its `scriptTag`
+ *   attribute). Usually you don't write these by hand — set the `access`
+ *   prop on the `Cloudflare.Worker` instead, and the Worker enrolls itself
+ *   into the application.
  * - `all_workers` / `all_preview_workers` — every Worker on the account
  *   (including ones created later), production or preview traffic
  *   respectively. Hostname-level policies take precedence over Worker-level
@@ -87,6 +94,42 @@ export interface OAuthConfiguration {
     /** Whether any loopback-address redirect URI is allowed. */
     allowAnyOnLoopback?: boolean;
   };
+}
+
+/**
+ * An Access policy defined inline on (and owned by) an application: created
+ * with the application, updated in place, and deleted with it. Uses the same
+ * rule model as the reusable `Cloudflare.Access.Policy` resource.
+ */
+export interface InlineApplicationPolicy {
+  /** The action Access takes when a user matches this policy. */
+  decision: PolicyDecision;
+  /** Rules evaluated with OR — matching any one grants the policy. */
+  include: ReadonlyArray<PolicyRule>;
+  /** Rules evaluated with NOT — matching any one denies the policy. */
+  exclude?: ReadonlyArray<PolicyExcludeRule>;
+  /** Rules evaluated with AND — all must match. */
+  require?: ReadonlyArray<PolicyRequireRule>;
+  /** Display name. Cloudflare generates one when omitted. */
+  name?: string;
+  /** Execution order of this policy within the application. */
+  precedence?: number;
+  /** Session lifetime for this policy, e.g. `"24h"`, `"2h45m"`. */
+  sessionDuration?: string;
+  /** Require admin approval at the start of each session. */
+  approvalRequired?: boolean;
+  /** Administrators who can approve a temporary authentication request. */
+  approvalGroups?: ReadonlyArray<{
+    approvalsNeeded: number;
+    emailAddresses?: ReadonlyArray<string>;
+    emailListUuid?: string;
+  }>;
+  /** Serve the application in an isolated browser for matching users. */
+  isolationRequired?: boolean;
+  /** Require a login justification from matching users. */
+  purposeJustificationRequired?: boolean;
+  /** Custom message shown on the justification screen. */
+  purposeJustificationPrompt?: string;
 }
 
 export interface ApplicationProps {
@@ -164,23 +207,36 @@ export interface ApplicationProps {
    */
   tags?: string[];
   /**
-   * Reusable Access policies that gate access to this application, in
-   * ascending order of precedence. Author each policy with the
-   * `Cloudflare.Access.Policy` resource and pass the resource itself (or its
-   * `policyId`, or a bare policy UUID) here — Access applications no longer
-   * accept inline policy bodies in this provider.
+   * Access policies that gate access to this application, in ascending
+   * order of precedence.
    *
    * Each entry can be:
-   * - a deployed `Cloudflare.Access.Policy` (`policies: [allowTeam]`),
+   * - an **inline policy** owned by this application —
+   *   `{ decision, include, ... }` with the same rule model as
+   *   `Cloudflare.Access.Policy` (created, updated, and deleted with the
+   *   application; no separate resource needed),
+   * - a deployed reusable `Cloudflare.Access.Policy`
+   *   (`policies: [allowTeam]`),
    * - a policy id (`string`),
    * - `{ id, precedence? }`, or
    * - the same with per-application overrides (`approvalRequired`,
    *   `isolationRequired`, `purposeJustificationRequired`,
    *   `purposeJustificationPrompt`, `sessionDuration`, `approvalGroups`).
+   *
+   * Cloudflare treats inline and reusable policies as mutually exclusive on
+   * one application — mixing the two forms fails validation.
+   *
+   * @example
+   * ```ts
+   * policies: [
+   *   { decision: "allow", include: [{ emailDomain: { domain: "example.com" } }] },
+   * ]
+   * ```
    */
   policies?: ReadonlyArray<
     | string
     | { policyId: string }
+    | InlineApplicationPolicy
     | { id: string; precedence?: number }
     | {
         id: string;
@@ -232,11 +288,22 @@ export interface ApplicationAttributes {
   updatedAt: string | undefined;
 }
 
+/**
+ * Data other resources attach to an Access application via bindings.
+ * Workers enrolling themselves (the `access` prop on `Cloudflare.Worker`)
+ * push their `worker`/`preview_worker` destinations here; the application
+ * deploys with — and converges on — the union of its own `destinations`
+ * prop and every bound contribution.
+ */
+export interface ApplicationBinding {
+  destinations?: ApplicationDestination[];
+}
+
 export type Application = Resource<
   "Cloudflare.Access.Application",
   ApplicationProps,
   ApplicationAttributes,
-  never,
+  ApplicationBinding,
   Providers
 >;
 
@@ -291,23 +358,23 @@ export type Application = Resource<
  * ```
  *
  * @section Protecting Cloudflare Workers
- * @example Require Access on a specific Worker (production + previews)
+ * @example Require Access on a specific Worker
  * ```typescript
- * const api = yield* ApiWorker;
- *
- * const allowTeam = yield* Cloudflare.Access.Policy("AllowTeam", {
- *   decision: "allow",
- *   include: [{ emailDomain: { domain: "example.com" } }],
- * });
- *
- * yield* Cloudflare.Access.Application("ApiAccess", {
+ * // The application owns the policies (inline here — no separate Policy
+ * // resource needed); the Worker enrolls itself via its `access` prop,
+ * // covering its custom domains, routes, workers.dev URL, and version
+ * // preview URLs.
+ * const App = Cloudflare.Access.Application("TeamOnly", {
  *   type: "self_hosted",
- *   destinations: [
- *     Cloudflare.Access.Worker(api),        // production traffic
- *     Cloudflare.Access.WorkerPreview(api), // version preview URLs
+ *   policies: [
+ *     { decision: "allow", include: [{ emailDomain: { domain: "example.com" } }] },
  *   ],
- *   policies: [allowTeam],
  * });
+ *
+ * export default class Api extends Cloudflare.Worker<Api>()("Api", {
+ *   main: import.meta.url,
+ *   access: { application: App },
+ * }, /* ... *​/) {}
  * ```
  *
  * @example Require Access on every Worker in the account
@@ -321,7 +388,9 @@ export type Application = Resource<
  *     Cloudflare.Access.AllWorkers,         // production traffic of every Worker
  *     Cloudflare.Access.AllWorkerPreviews,  // every Worker's preview URLs
  *   ],
- *   policies: [allowTeam],
+ *   policies: [
+ *     { decision: "allow", include: [{ emailDomain: { domain: "example.com" } }] },
+ *   ],
  * });
  * ```
  *
@@ -472,18 +541,48 @@ export const ApplicationProvider = () =>
       return output?.applicationId ? attrs : Unowned(attrs);
     }),
 
-    reconcile: Effect.fn(function* ({ id, news, output }) {
+    reconcile: Effect.fn(function* ({ id, news, output, bindings }) {
       const { accountId } = yield* yield* CloudflareEnvironment;
 
       const resolvedName = yield* resolveName(id, news.name);
       const resolvedIdps = resolveAllowedIdps(news.allowedIdps);
       const resolvedPolicies = resolvePolicies(news.policies);
+      if (
+        resolvedPolicies !== undefined &&
+        resolvedPolicies.some(
+          (p) => typeof p !== "string" && isInlinePolicy(p),
+        ) &&
+        resolvedPolicies.some(
+          (p) => typeof p === "string" || !isInlinePolicy(p),
+        )
+      ) {
+        return yield* Effect.fail(
+          new Error(
+            "Cloudflare Access applications cannot mix inline policies with " +
+              "reusable policy references — use one form for the whole " +
+              "`policies` list.",
+          ),
+        );
+      }
       const body = buildMutableBody(
         news,
         resolvedName,
         resolvedIdps,
         resolvedPolicies,
       );
+      // Destinations contributed through the binding contract (e.g. Workers
+      // enrolling via their `access` prop) extend the declared ones. The
+      // engine dedupes and sid-sorts bindings, so the merged order is
+      // stable across deploys.
+      const boundDestinations = (bindings ?? []).flatMap(
+        (b) => (b.data.destinations ?? []) as ApplicationDestination[],
+      );
+      if (boundDestinations.length > 0) {
+        body.destinations = [
+          ...(body.destinations ?? []),
+          ...boundDestinations,
+        ];
+      }
 
       // 1. Observe
       let observed: ObservedApp | undefined;
@@ -564,7 +663,9 @@ export const ApplicationProvider = () =>
             autoRedirectToIdentity: body.autoRedirectToIdentity,
             appLauncherVisible: body.appLauncherVisible,
             tags: body.tags === undefined ? undefined : Array.from(body.tags),
-            policies: toRequestPolicies(body.policies),
+            policies: toRequestPolicies(
+              attachObservedPolicyIds(body.policies, observed.policies),
+            ),
             destinations:
               body.destinations === undefined
                 ? undefined
@@ -750,6 +851,18 @@ const observeById = (accountId: string, appId: string) =>
 interface ObservedPolicy {
   readonly id?: string;
   readonly precedence?: number;
+  /** false for application-owned (inline) policies, true for reusable. */
+  readonly reusable?: boolean;
+  readonly decision?: string;
+  readonly name?: string;
+  readonly include?: ReadonlyArray<unknown>;
+  readonly exclude?: ReadonlyArray<unknown>;
+  readonly require?: ReadonlyArray<unknown>;
+  readonly sessionDuration?: string;
+  readonly approvalRequired?: boolean;
+  readonly isolationRequired?: boolean;
+  readonly purposeJustificationRequired?: boolean;
+  readonly purposeJustificationPrompt?: string;
 }
 
 interface ObservedApp {
@@ -872,8 +985,21 @@ const narrowApp = (raw: {
 // correctly — no cast-to-Parameters needed.
 // ---------------------------------------------------------------------------
 
+/**
+ * Reconciler-side inline policy: `InlineApplicationPolicy` plus the optional
+ * `id` of the observed application-owned policy it updates in place (see
+ * `attachObservedPolicyIds`).
+ */
+interface InlineResolvedPolicy extends InlineApplicationPolicy {
+  id?: string;
+}
+
+const isInlinePolicy = (p: ResolvedPolicy): p is InlineResolvedPolicy =>
+  typeof p !== "string" && "decision" in p;
+
 type ResolvedPolicy =
   | string
+  | InlineResolvedPolicy
   | { id: string; precedence?: number }
   | {
       id: string;
@@ -890,16 +1016,13 @@ type ResolvedPolicy =
       }>;
     };
 
-// Distilled now types `policies` as `Array<refOrId> | Array<inlinePolicy>` —
-// a union at the array level. We only ever emit the references form, so
-// exclude the inline arm (discriminated by its required `decision` field)
-// to keep `Array<RequestPolicy>` assignable to distilled's first arm.
-type RequestPolicy = Exclude<
-  NonNullable<
-    zeroTrust.CreateAccessApplicationForAccountRequest["policies"]
-  >[number],
-  { decision: unknown }
->;
+// The self-hosted policies item union: references (id string / link /
+// per-app overrides) plus application-owned inline policies
+// (`InlineAccessPolicy`, added to distilled's model — the API docs only
+// carry the inline arm for infrastructure apps, but the live API accepts
+// it for self_hosted).
+type RequestPolicy =
+  zeroTrust.AccessApplicationsCreateForAccountRequestPoliciesSelfHostedApplicationItem;
 
 interface AppMutableBody {
   domain?: string;
@@ -915,11 +1038,46 @@ interface AppMutableBody {
   policies?: ReadonlyArray<ResolvedPolicy>;
 }
 
-const policyIdOf = (p: ResolvedPolicy): string =>
+const policyIdOf = (p: ResolvedPolicy): string | undefined =>
   typeof p === "string" ? p : p.id;
 
 const toRequestPolicy = (p: ResolvedPolicy): RequestPolicy => {
   if (typeof p === "string") return p;
+  if (isInlinePolicy(p)) {
+    return {
+      // `id` present when this inline body updates an observed
+      // application-owned policy in place (attachObservedPolicyIds).
+      id: p.id,
+      decision: p.decision,
+      include: Array.from(p.include) as zeroTrust.InlineAccessPolicy["include"],
+      exclude:
+        p.exclude === undefined
+          ? undefined
+          : (Array.from(p.exclude) as zeroTrust.InlineAccessPolicy["exclude"]),
+      require:
+        p.require === undefined
+          ? undefined
+          : (Array.from(p.require) as zeroTrust.InlineAccessPolicy["require"]),
+      name: p.name,
+      precedence: p.precedence,
+      sessionDuration: p.sessionDuration,
+      approvalRequired: p.approvalRequired,
+      approvalGroups:
+        p.approvalGroups === undefined
+          ? undefined
+          : p.approvalGroups.map((g) => ({
+              approvalsNeeded: g.approvalsNeeded,
+              emailAddresses:
+                g.emailAddresses === undefined
+                  ? undefined
+                  : Array.from(g.emailAddresses),
+              emailListUuid: g.emailListUuid,
+            })),
+      isolationRequired: p.isolationRequired,
+      purposeJustificationRequired: p.purposeJustificationRequired,
+      purposeJustificationPrompt: p.purposeJustificationPrompt,
+    } satisfies zeroTrust.InlineAccessPolicy;
+  }
   // The simple `{ id, precedence? }` form lacks the per-app override fields;
   // narrow once to a permissive view so we can copy them through uniformly.
   const rich = p as {
@@ -1154,6 +1312,67 @@ const policiesEq = (
   for (let i = 0; i < desired.length; i++) {
     const d = desired[i];
     const o = observed[i];
+    if (typeof d !== "string" && isInlinePolicy(d)) {
+      // Inline (application-owned) policy: compare the fields the caller
+      // set against the observed policy body. Cloudflare echoes rule
+      // objects structurally, so JSON equality is stable; getting this
+      // wrong is costly — a false inequality re-PUTs the policy list and
+      // id-less inline items would mint fresh policies every deploy.
+      if (o.reusable === true) return false;
+      if (d.decision !== o.decision) return false;
+      if (!jsonEq(d.include, (o.include ?? []) as typeof d.include)) {
+        return false;
+      }
+      if (
+        d.exclude !== undefined &&
+        !jsonEq(d.exclude, (o.exclude ?? []) as typeof d.exclude)
+      ) {
+        return false;
+      }
+      if (
+        d.require !== undefined &&
+        !jsonEq(d.require, (o.require ?? []) as typeof d.require)
+      ) {
+        return false;
+      }
+      if (d.name !== undefined && d.name !== o.name) return false;
+      if (
+        d.precedence !== undefined &&
+        o.precedence !== undefined &&
+        d.precedence !== o.precedence
+      ) {
+        return false;
+      }
+      if (
+        d.sessionDuration !== undefined &&
+        d.sessionDuration !== o.sessionDuration
+      ) {
+        return false;
+      }
+      if (
+        d.approvalRequired !== undefined &&
+        d.approvalRequired !== (o.approvalRequired ?? false)
+      ) {
+        return false;
+      }
+      if (
+        d.isolationRequired !== undefined &&
+        d.isolationRequired !== (o.isolationRequired ?? false)
+      ) {
+        return false;
+      }
+      if (
+        d.purposeJustificationRequired !== undefined &&
+        d.purposeJustificationRequired !==
+          (o.purposeJustificationRequired ?? false)
+      ) {
+        return false;
+      }
+      continue;
+    }
+    // Reference forms: an observed application-owned policy can never
+    // satisfy a reusable reference.
+    if (o.reusable === false) return false;
     if (policyIdOf(d) !== o.id) return false;
     if (typeof d !== "string") {
       if (
@@ -1167,6 +1386,33 @@ const policiesEq = (
   }
   return true;
 };
+
+/**
+ * Zip desired inline policies with the observed application-owned policies
+ * so an update PUT carries their ids and updates them in place — an id-less
+ * inline item in an update creates a brand-new policy (and drops the old
+ * one), churning policy ids on every deploy that touches any app field.
+ * Positional matching, guarded on `reusable === false` (never attach a
+ * reusable policy's id to an inline body — that would mutate the shared
+ * policy) and on a matching decision.
+ */
+const attachObservedPolicyIds = (
+  desired: ReadonlyArray<ResolvedPolicy> | undefined,
+  observed: ReadonlyArray<ObservedPolicy> | undefined,
+): ReadonlyArray<ResolvedPolicy> | undefined =>
+  desired === undefined || observed === undefined
+    ? desired
+    : desired.map((p, i) => {
+        const o = observed[i];
+        return typeof p !== "string" &&
+          isInlinePolicy(p) &&
+          p.id === undefined &&
+          o?.id !== undefined &&
+          o.reusable === false &&
+          o.decision === p.decision
+          ? { ...p, id: o.id }
+          : p;
+      });
 
 const bodyEqualsObserved = (
   desired: AppMutableBody,

--- a/packages/alchemy/src/Cloudflare/Access/Application.ts
+++ b/packages/alchemy/src/Cloudflare/Access/Application.ts
@@ -10,11 +10,15 @@ import { Resource } from "../../Resource.ts";
 import { arrayEquals } from "../../Util/equal.ts";
 import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
 import type { Providers } from "../Providers.ts";
-import type {
-  PolicyDecision,
-  PolicyExcludeRule,
-  PolicyRequireRule,
-  PolicyRule,
+import {
+  normalizePolicyRules,
+  type PolicyDecision,
+  type PolicyExcludeRule,
+  type PolicyExcludeRuleInput,
+  type PolicyRequireRule,
+  type PolicyRequireRuleInput,
+  type PolicyRule,
+  type PolicyRuleInput,
 } from "./Policy.ts";
 
 /**
@@ -105,11 +109,11 @@ export interface InlineApplicationPolicy {
   /** The action Access takes when a user matches this policy. */
   decision: PolicyDecision;
   /** Rules evaluated with OR — matching any one grants the policy. */
-  include: ReadonlyArray<PolicyRule>;
+  include: ReadonlyArray<PolicyRuleInput>;
   /** Rules evaluated with NOT — matching any one denies the policy. */
-  exclude?: ReadonlyArray<PolicyExcludeRule>;
+  exclude?: ReadonlyArray<PolicyExcludeRuleInput>;
   /** Rules evaluated with AND — all must match. */
-  require?: ReadonlyArray<PolicyRequireRule>;
+  require?: ReadonlyArray<PolicyRequireRuleInput>;
   /** Display name. Cloudflare generates one when omitted. */
   name?: string;
   /** Execution order of this policy within the application. */
@@ -229,7 +233,7 @@ export interface ApplicationProps {
    * @example
    * ```ts
    * policies: [
-   *   { decision: "allow", include: [{ emailDomain: { domain: "example.com" } }] },
+   *   { decision: "allow", include: [{ emailDomain: "example.com" }] },
    * ]
    * ```
    */
@@ -367,7 +371,7 @@ export type Application = Resource<
  * const App = Cloudflare.Access.Application("TeamOnly", {
  *   type: "self_hosted",
  *   policies: [
- *     { decision: "allow", include: [{ emailDomain: { domain: "example.com" } }] },
+ *     { decision: "allow", include: [{ emailDomain: "example.com" }] },
  *   ],
  * });
  *
@@ -389,7 +393,7 @@ export type Application = Resource<
  *     Cloudflare.Access.AllWorkerPreviews,  // every Worker's preview URLs
  *   ],
  *   policies: [
- *     { decision: "allow", include: [{ emailDomain: { domain: "example.com" } }] },
+ *     { decision: "allow", include: [{ emailDomain: "example.com" }] },
  *   ],
  * });
  * ```
@@ -1049,15 +1053,15 @@ const toRequestPolicy = (p: ResolvedPolicy): RequestPolicy => {
       // application-owned policy in place (attachObservedPolicyIds).
       id: p.id,
       decision: p.decision,
-      include: Array.from(p.include) as zeroTrust.InlineAccessPolicy["include"],
-      exclude:
-        p.exclude === undefined
-          ? undefined
-          : (Array.from(p.exclude) as zeroTrust.InlineAccessPolicy["exclude"]),
-      require:
-        p.require === undefined
-          ? undefined
-          : (Array.from(p.require) as zeroTrust.InlineAccessPolicy["require"]),
+      include: normalizePolicyRules(
+        p.include,
+      ) as zeroTrust.InlineAccessPolicy["include"],
+      exclude: normalizePolicyRules(
+        p.exclude,
+      ) as zeroTrust.InlineAccessPolicy["exclude"],
+      require: normalizePolicyRules(
+        p.require,
+      ) as zeroTrust.InlineAccessPolicy["require"],
       name: p.name,
       precedence: p.precedence,
       sessionDuration: p.sessionDuration,
@@ -1320,18 +1324,23 @@ const policiesEq = (
       // id-less inline items would mint fresh policies every deploy.
       if (o.reusable === true) return false;
       if (d.decision !== o.decision) return false;
-      if (!jsonEq(d.include, (o.include ?? []) as typeof d.include)) {
+      // Compare in wire shape: the caller may have used the scalar
+      // shorthand while Cloudflare echoes expanded rules.
+      const include = normalizePolicyRules(d.include);
+      if (!jsonEq(include, (o.include ?? []) as typeof include)) {
         return false;
       }
+      const exclude = normalizePolicyRules(d.exclude);
       if (
-        d.exclude !== undefined &&
-        !jsonEq(d.exclude, (o.exclude ?? []) as typeof d.exclude)
+        exclude !== undefined &&
+        !jsonEq(exclude, (o.exclude ?? []) as typeof exclude)
       ) {
         return false;
       }
+      const require = normalizePolicyRules(d.require);
       if (
-        d.require !== undefined &&
-        !jsonEq(d.require, (o.require ?? []) as typeof d.require)
+        require !== undefined &&
+        !jsonEq(require, (o.require ?? []) as typeof require)
       ) {
         return false;
       }

--- a/packages/alchemy/src/Cloudflare/Access/Application.ts
+++ b/packages/alchemy/src/Cloudflare/Access/Application.ts
@@ -6,7 +6,7 @@ import * as Stream from "effect/Stream";
 import { Unowned } from "../../AdoptPolicy.ts";
 import { createPhysicalName } from "../../PhysicalName.ts";
 import * as Provider from "../../Provider.ts";
-import { Resource } from "../../Resource.ts";
+import { isResourceOfType, Resource } from "../../Resource.ts";
 import { arrayEquals } from "../../Util/equal.ts";
 import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
 import type { Providers } from "../Providers.ts";
@@ -302,6 +302,9 @@ export interface ApplicationAttributes {
 export interface ApplicationBinding {
   destinations?: ApplicationDestination[];
 }
+
+export const isApplication = <T>(value: T): value is T & Application =>
+  isResourceOfType(value, "Cloudflare.Access.Application");
 
 export type Application = Resource<
   "Cloudflare.Access.Application",

--- a/packages/alchemy/src/Cloudflare/Access/Application.ts
+++ b/packages/alchemy/src/Cloudflare/Access/Application.ts
@@ -40,8 +40,8 @@ export type ApplicationType =
  * - `worker` / `preview_worker` — a specific Cloudflare Worker's production
  *   traffic (custom domains, routes, `workers.dev`) or its version preview
  *   URLs. `workerId` is the Worker's immutable script id — pass a deployed
- *   Worker's `scriptTag` attribute, or use the {@link worker} /
- *   {@link previewWorker} helpers.
+ *   Worker's `scriptTag` attribute, or use the {@link Worker} /
+ *   {@link WorkerPreview} helpers.
  * - `all_workers` / `all_preview_workers` — every Worker on the account
  *   (including ones created later), production or preview traffic
  *   respectively. Hostname-level policies take precedence over Worker-level
@@ -301,8 +301,8 @@ export type Application = Resource<
  * yield* Cloudflare.Access.Application("ApiAccess", {
  *   type: "self_hosted",
  *   destinations: [
- *     Cloudflare.Access.worker(api),        // production traffic
- *     Cloudflare.Access.previewWorker(api), // version preview URLs
+ *     Cloudflare.Access.Worker(api),        // production traffic
+ *     Cloudflare.Access.WorkerPreview(api), // version preview URLs
  *   ],
  *   policies: [allowTeam.policyId],
  * });
@@ -316,8 +316,8 @@ export type Application = Resource<
  * yield* Cloudflare.Access.Application("ProtectAllWorkers", {
  *   type: "self_hosted",
  *   destinations: [
- *     { type: "all_workers" },         // production traffic of every Worker
- *     { type: "all_preview_workers" }, // every Worker's preview URLs
+ *     Cloudflare.Access.AllWorkers,         // production traffic of every Worker
+ *     Cloudflare.Access.AllWorkerPreviews,  // every Worker's preview URLs
  *   ],
  *   policies: [allowTeam.policyId],
  * });

--- a/packages/alchemy/src/Cloudflare/Access/Application.ts
+++ b/packages/alchemy/src/Cloudflare/Access/Application.ts
@@ -30,13 +30,22 @@ export type ApplicationType =
 /**
  * A destination that this Access application protects.
  *
- * Cloudflare supports three destination flavours:
+ * Cloudflare supports these destination flavours:
  * - `public` — a public hostname/URI you own in Cloudflare (the legacy
  *   `domain` field on `ApplicationProps` covers the simple case).
  * - `private` — a hostname or CIDR reachable through a Cloudflare Tunnel.
  *   Traffic from WARP-enrolled devices is intercepted and forwarded
  *   through the tunnel; identity is enforced before forwarding.
  * - `via_mcp_server_portal` — routes via a managed MCP server portal.
+ * - `worker` / `preview_worker` — a specific Cloudflare Worker's production
+ *   traffic (custom domains, routes, `workers.dev`) or its version preview
+ *   URLs. `workerId` is the Worker's immutable script id — pass a deployed
+ *   Worker's `scriptTag` attribute, or use the {@link worker} /
+ *   {@link previewWorker} helpers.
+ * - `all_workers` / `all_preview_workers` — every Worker on the account
+ *   (including ones created later), production or preview traffic
+ *   respectively. Hostname-level policies take precedence over Worker-level
+ *   policies, which take precedence over these account-level policies.
  */
 export type ApplicationDestination =
   | { type: "public"; uri: string }
@@ -48,7 +57,11 @@ export type ApplicationDestination =
       portRange?: string;
       vnetId?: string;
     }
-  | { type: "via_mcp_server_portal"; mcpServerId: string };
+  | { type: "via_mcp_server_portal"; mcpServerId: string }
+  | { type: "worker"; workerId: string }
+  | { type: "preview_worker"; workerId: string }
+  | { type: "all_workers" }
+  | { type: "all_preview_workers" };
 
 /**
  * Configuration for an OAuth authorization flow managed by Cloudflare Access.
@@ -275,6 +288,41 @@ export type Application = Resource<
  * });
  * ```
  *
+ * @section Protecting Cloudflare Workers
+ * @example Require Access on a specific Worker (production + previews)
+ * ```typescript
+ * const api = yield* ApiWorker;
+ *
+ * const allowTeam = yield* Cloudflare.Access.Policy("AllowTeam", {
+ *   decision: "allow",
+ *   include: [{ emailDomain: { domain: "example.com" } }],
+ * });
+ *
+ * yield* Cloudflare.Access.Application("ApiAccess", {
+ *   type: "self_hosted",
+ *   destinations: [
+ *     Cloudflare.Access.worker(api),        // production traffic
+ *     Cloudflare.Access.previewWorker(api), // version preview URLs
+ *   ],
+ *   policies: [allowTeam.policyId],
+ * });
+ * ```
+ *
+ * @example Require Access on every Worker in the account
+ * ```typescript
+ * // Covers all current AND future Workers. Hostname-level policies beat
+ * // Worker-level policies, which beat this account-level policy — so an
+ * // individual Worker can still be opened up with its own application.
+ * yield* Cloudflare.Access.Application("ProtectAllWorkers", {
+ *   type: "self_hosted",
+ *   destinations: [
+ *     { type: "all_workers" },         // production traffic of every Worker
+ *     { type: "all_preview_workers" }, // every Worker's preview URLs
+ *   ],
+ *   policies: [allowTeam.policyId],
+ * });
+ * ```
+ *
  * @section Device-enrollment (warp)
  * @example WARP device-enrollment application
  * ```typescript
@@ -391,7 +439,13 @@ export const ApplicationProvider = () =>
       if (!observed?.id || !observed.aud || !observed.type) {
         return undefined;
       }
-      const domain = observed.domain ?? output?.domain ?? olds?.domain;
+      const domain =
+        observed.domain ??
+        output?.domain ??
+        olds?.domain ??
+        // Worker-destination apps (`worker`/`all_workers`/...) have no
+        // hostname; Cloudflare omits `domain` for them entirely.
+        (observed.destinations !== undefined ? "" : undefined);
       const name = observed.name ?? output?.name;
       if (domain === undefined || name === undefined) {
         return undefined;
@@ -672,11 +726,13 @@ const observeById = (accountId: string, appId: string) =>
     const r = yield* zeroTrust
       .getAccessApplicationForAccount({ accountId, appId })
       .pipe(
-        // Distilled only tags transport errors (Unauthorized,
-        // ServiceUnavailable, etc.); the live Cloudflare 404 surfaces as
-        // an untagged error. Swallow generically so observe falls through
-        // to recreate.
-        Effect.catch(() => Effect.succeed(undefined)),
+        // A missing application is typed (404 → AccessApplicationNotFound):
+        // observe falls through to recreate. Transient 403 back-pressure is
+        // retried; anything else is a real failure and propagates.
+        retryTransientAccessError,
+        Effect.catchTag("AccessApplicationNotFound", () =>
+          Effect.succeed(undefined),
+        ),
       );
     if (r === undefined) return undefined;
     return narrowApp(r as Parameters<typeof narrowApp>[0]);

--- a/packages/alchemy/src/Cloudflare/Access/Application.ts
+++ b/packages/alchemy/src/Cloudflare/Access/Application.ts
@@ -166,11 +166,12 @@ export interface ApplicationProps {
   /**
    * Reusable Access policies that gate access to this application, in
    * ascending order of precedence. Author each policy with the
-   * `Cloudflare.Access.Policy` resource and pass `policy.policyId` (or a bare
-   * policy UUID) here — Access applications no longer accept inline policy
-   * bodies in this provider.
+   * `Cloudflare.Access.Policy` resource and pass the resource itself (or its
+   * `policyId`, or a bare policy UUID) here — Access applications no longer
+   * accept inline policy bodies in this provider.
    *
    * Each entry can be:
+   * - a deployed `Cloudflare.Access.Policy` (`policies: [allowTeam]`),
    * - a policy id (`string`),
    * - `{ id, precedence? }`, or
    * - the same with per-application overrides (`approvalRequired`,
@@ -179,6 +180,7 @@ export interface ApplicationProps {
    */
   policies?: ReadonlyArray<
     | string
+    | { policyId: string }
     | { id: string; precedence?: number }
     | {
         id: string;
@@ -264,7 +266,7 @@ export type Application = Resource<
  *   type: "self_hosted",
  *   domain: "dashboard.example.com",
  *   sessionDuration: "24h",
- *   policies: [allowMyOrg.policyId],
+ *   policies: [allowMyOrg],
  * });
  * ```
  *
@@ -304,7 +306,7 @@ export type Application = Resource<
  *     Cloudflare.Access.Worker(api),        // production traffic
  *     Cloudflare.Access.WorkerPreview(api), // version preview URLs
  *   ],
- *   policies: [allowTeam.policyId],
+ *   policies: [allowTeam],
  * });
  * ```
  *
@@ -319,7 +321,7 @@ export type Application = Resource<
  *     Cloudflare.Access.AllWorkers,         // production traffic of every Worker
  *     Cloudflare.Access.AllWorkerPreviews,  // every Worker's preview URLs
  *   ],
- *   policies: [allowTeam.policyId],
+ *   policies: [allowTeam],
  * });
  * ```
  *
@@ -339,7 +341,7 @@ export type Application = Resource<
  *   allowedIdps: [googleIdpId],
  *   autoRedirectToIdentity: true,
  *   sessionDuration: "720h",
- *   policies: [allowCorp.policyId],
+ *   policies: [allowCorp],
  * });
  * ```
  *
@@ -364,7 +366,7 @@ export type Application = Resource<
  *   domain: "admin.example.com",
  *   allowedIdps: [googleIdpUuid],
  *   autoRedirectToIdentity: true,
- *   policies: [admins.policyId],
+ *   policies: [admins],
  * });
  * ```
  */
@@ -1023,9 +1025,13 @@ const resolvePolicies = (
 ): ReadonlyArray<ResolvedPolicy> | undefined =>
   policies === undefined
     ? undefined
-    : // Inputs are concrete strings here — the Plan layer resolved them
-      // before the reconciler ran.
-      (policies as ReadonlyArray<ResolvedPolicy>);
+    : // Inputs are concrete values here — the Plan layer resolved them
+      // before the reconciler ran. A whole `Access.Policy` resource resolves
+      // to its Attributes; normalize it to the bare policy id so everything
+      // downstream (diffing, request building) sees one shape.
+      (policies as ReadonlyArray<ResolvedPolicy | { policyId: string }>).map(
+        (p) => (typeof p !== "string" && "policyId" in p ? p.policyId : p),
+      );
 
 const buildMutableBody = (
   news: ApplicationProps,

--- a/packages/alchemy/src/Cloudflare/Access/Context.ts
+++ b/packages/alchemy/src/Cloudflare/Access/Context.ts
@@ -1,0 +1,37 @@
+import * as Effect from "effect/Effect";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
+import {
+  WorkerExecutionContext,
+  type WorkerExecutionContextAccess,
+} from "../Workers/Worker.ts";
+
+/**
+ * One-yield accessor for the current request's Cloudflare Access context
+ * (`ctx.access`) — sugar over `WorkerExecutionContext`:
+ *
+ * ```typescript
+ * fetch: Effect.gen(function* () {
+ *   const access = yield* Cloudflare.Access.Context;
+ *   if (access === undefined) {
+ *     return HttpServerResponse.text("Access required", { status: 403 });
+ *   }
+ *   const identity = yield* access.getIdentity();
+ *   return yield* HttpServerResponse.json({
+ *     aud: access.aud,
+ *     email: identity?.email,
+ *   });
+ * }),
+ * ```
+ *
+ * `undefined` when the request did not pass through Cloudflare Access (see
+ * `Cloudflare.Access.Application` with `worker` / `all_workers`
+ * destinations for turning enforcement on). Colored with
+ * {@link RuntimeContext}: it can be closed over during init but only *run*
+ * inside a request handler. Under `alchemy dev` the Worker's `dev.access`
+ * config simulates the authenticated state.
+ */
+export const Context: Effect.Effect<
+  WorkerExecutionContextAccess | undefined,
+  never,
+  RuntimeContext | WorkerExecutionContext
+> = WorkerExecutionContext.pipe(Effect.flatMap((ctx) => ctx.access));

--- a/packages/alchemy/src/Cloudflare/Access/Context.ts
+++ b/packages/alchemy/src/Cloudflare/Access/Context.ts
@@ -1,9 +1,7 @@
 import * as Effect from "effect/Effect";
 import type { RuntimeContext } from "../../RuntimeContext.ts";
-import {
-  WorkerExecutionContext,
-  type WorkerExecutionContextAccess,
-} from "../Workers/Worker.ts";
+import type { WorkerExecutionContextAccess } from "../Workers/WorkerAccess.ts";
+import { WorkerExecutionContext } from "../Workers/Worker.ts";
 
 /**
  * One-yield accessor for the current request's Cloudflare Access context

--- a/packages/alchemy/src/Cloudflare/Access/Policy.ts
+++ b/packages/alchemy/src/Cloudflare/Access/Policy.ts
@@ -36,6 +36,103 @@ export type PolicyRequireRule = NonNullable<
 >[number];
 
 /**
+ * Scalar shorthand for rule kinds with a single parameter (and bare names
+ * for the parameter-less kinds) — expanded to Cloudflare's wire shape by
+ * the providers, so both spellings are equivalent:
+ *
+ * ```ts
+ * include: [{ emailDomain: "example.com" }]   // { emailDomain: { domain: "example.com" } }
+ * include: [{ email: "sam@example.com" }]     // { email: { email: "sam@example.com" } }
+ * include: ["everyone"]                       // { everyone: {} }
+ * require: [{ geo: "US" }]                    // { geo: { countryCode: "US" } }
+ * ```
+ *
+ * Multi-parameter kinds (`gsuite`, `okta`, `saml`, `oidc`, `azureAD`,
+ * `githubOrganization`, `externalEvaluation`, `authContext`) keep their
+ * wire shape — there is no scalar to collapse them to.
+ */
+export type PolicyRuleShorthand =
+  | "everyone"
+  | "certificate"
+  | "anyValidServiceToken"
+  | { email: string }
+  | { emailDomain: string }
+  | { emailList: string }
+  | { ip: string }
+  | { ipList: string }
+  | { group: string }
+  | { loginMethod: string }
+  | { serviceToken: string }
+  | { geo: string }
+  | { authMethod: string }
+  | { devicePosture: string }
+  | { commonName: string }
+  | { linkedAppToken: string }
+  | { userRiskScore: string }
+  | { cloudflareAccountMember: string };
+
+/** A rule in either spelling: Cloudflare's wire shape or the scalar shorthand. */
+export type PolicyRuleInput = PolicyRule | PolicyRuleShorthand;
+export type PolicyExcludeRuleInput = PolicyExcludeRule | PolicyRuleShorthand;
+export type PolicyRequireRuleInput = PolicyRequireRule | PolicyRuleShorthand;
+
+/** Rule kind → its single parameter's (camelCase) member name. */
+const SCALAR_RULE_PARAMS: Record<string, string> = {
+  email: "email",
+  emailDomain: "domain",
+  emailList: "id",
+  ip: "ip",
+  ipList: "id",
+  group: "id",
+  loginMethod: "id",
+  serviceToken: "tokenId",
+  geo: "countryCode",
+  authMethod: "authMethod",
+  devicePosture: "integrationUid",
+  commonName: "commonName",
+  linkedAppToken: "appUid",
+  userRiskScore: "userRiskScore",
+  cloudflareAccountMember: "accountId",
+};
+
+/**
+ * Expand the scalar shorthand to Cloudflare's wire shape; wire-shaped rules
+ * pass through untouched.
+ */
+export const normalizePolicyRule = <Rule>(
+  rule: Rule | PolicyRuleShorthand,
+): Rule => {
+  if (typeof rule === "string") {
+    // "everyone" -> { everyone: {} }
+    return { [rule]: {} } as Rule;
+  }
+  const keys = Object.keys(rule as object);
+  if (keys.length === 1) {
+    const kind = keys[0];
+    const value = (rule as Record<string, unknown>)[kind];
+    const param = SCALAR_RULE_PARAMS[kind];
+    if (param !== undefined && (value === null || typeof value !== "object")) {
+      return { [kind]: { [param]: value } } as Rule;
+    }
+  }
+  return rule as Rule;
+};
+
+export function normalizePolicyRules<Rule>(
+  rules: ReadonlyArray<Rule | PolicyRuleShorthand>,
+): Rule[];
+export function normalizePolicyRules<Rule>(
+  rules: ReadonlyArray<Rule | PolicyRuleShorthand> | undefined,
+): Rule[] | undefined;
+export function normalizePolicyRules<Rule>(
+  rules: ReadonlyArray<Rule | PolicyRuleShorthand> | undefined,
+): Rule[] | undefined {
+  return rules === undefined
+    ? undefined
+    : rules.map((r) => normalizePolicyRule(r));
+}
+
+/**
  * Decision Cloudflare Access takes when a request matches this policy.
  *
  * - `"allow"` — admit the user.
@@ -70,17 +167,17 @@ export type PolicyProps = {
    * Rules combined with logical OR. A request must satisfy at least one
    * include rule for the policy to match. Required and must be non-empty.
    */
-  include: Policy.RuleGroup[];
+  include: PolicyRuleInput[];
   /**
    * Rules combined with logical NOT. A request matching any exclude rule is
    * rejected by the policy even if it satisfied an include rule.
    */
-  exclude?: PolicyExcludeRule[];
+  exclude?: PolicyExcludeRuleInput[];
   /**
    * Rules combined with logical AND. A request must satisfy every require
    * rule in addition to an include rule.
    */
-  require?: PolicyRequireRule[];
+  require?: PolicyRequireRuleInput[];
   /**
    * Duration of issued session tokens. Format: `300ms`, `2h45m`, etc. When
    * unset, applications using this policy fall back to their own configured
@@ -117,7 +214,7 @@ export declare namespace Policy {
    * gsuite, githubOrganization, okta, azureAD, saml, oidc, deviceCheck via
    * `devicePosture`, externalEvaluation, etc.).
    */
-  export type RuleGroup = PolicyRule;
+  export type RuleGroup = PolicyRuleInput;
 }
 
 export type Policy = Resource<
@@ -242,9 +339,9 @@ export const PolicyProvider = () =>
             accountId: acct,
             name,
             decision: news.decision,
-            include: news.include,
-            exclude: news.exclude,
-            require: news.require,
+            include: normalizePolicyRules(news.include),
+            exclude: normalizePolicyRules(news.exclude),
+            require: normalizePolicyRules(news.require),
             sessionDuration: news.sessionDuration,
             approvalRequired: news.approvalRequired,
             purposeJustificationRequired: news.purposeJustificationRequired,
@@ -270,9 +367,9 @@ export const PolicyProvider = () =>
           policyId: prior.id!,
           name,
           decision: news.decision,
-          include: news.include,
-          exclude: news.exclude,
-          require: news.require,
+          include: normalizePolicyRules(news.include),
+          exclude: normalizePolicyRules(news.exclude),
+          require: normalizePolicyRules(news.require),
           sessionDuration: news.sessionDuration,
           approvalRequired: news.approvalRequired,
           purposeJustificationRequired: news.purposeJustificationRequired,

--- a/packages/alchemy/src/Cloudflare/Access/WorkerDestination.ts
+++ b/packages/alchemy/src/Cloudflare/Access/WorkerDestination.ts
@@ -1,0 +1,66 @@
+import type { Output } from "../../Output.ts";
+import type { ApplicationDestination } from "./Application.ts";
+
+/**
+ * The slice of a deployed Worker the Access worker destinations need: its
+ * immutable script id (`scriptTag`). Structural so both the yielded Worker
+ * resource and hand-built shapes satisfy it.
+ */
+export interface AccessProtectableWorker {
+  scriptTag: Output<string | undefined>;
+}
+
+/**
+ * An {@link ApplicationDestination} whose `workerId` resolves from a deployed
+ * Worker's attributes. The discriminant stays a single literal so the
+ * destination matches its exact variant of the destination union.
+ */
+export interface WorkerApplicationDestination<
+  Type extends "worker" | "preview_worker",
+> {
+  type: Type;
+  workerId: Output<string>;
+}
+
+/**
+ * Destination covering a specific Worker's **production** traffic — custom
+ * domains, routes, and its `workers.dev` URL.
+ *
+ * ```typescript
+ * const api = yield* ApiWorker;
+ * yield* Cloudflare.Access.Application("ApiAccess", {
+ *   type: "self_hosted",
+ *   destinations: [Cloudflare.Access.worker(api)],
+ *   policies: [allowTeam.policyId],
+ * });
+ * ```
+ */
+export const worker = (
+  worker: AccessProtectableWorker,
+): WorkerApplicationDestination<"worker"> => ({
+  type: "worker",
+  // `scriptTag` is always present after a deploy of the Worker's own script;
+  // it is only absent for version workers, which are covered through their
+  // parent's tag instead.
+  workerId: worker.scriptTag.as<string>(),
+});
+
+/**
+ * Destination covering a specific Worker's **version preview URLs**
+ * (`<version>-<name>.<subdomain>.workers.dev`).
+ *
+ * ```typescript
+ * const api = yield* ApiWorker;
+ * yield* Cloudflare.Access.Application("ApiPreviewAccess", {
+ *   type: "self_hosted",
+ *   destinations: [Cloudflare.Access.previewWorker(api)],
+ *   policies: [allowTeam.policyId],
+ * });
+ * ```
+ */
+export const previewWorker = (
+  worker: AccessProtectableWorker,
+): WorkerApplicationDestination<"preview_worker"> => ({
+  type: "preview_worker",
+  workerId: worker.scriptTag.as<string>(),
+});

--- a/packages/alchemy/src/Cloudflare/Access/WorkerDestination.ts
+++ b/packages/alchemy/src/Cloudflare/Access/WorkerDestination.ts
@@ -1,73 +1,9 @@
-import type { Output } from "../../Output.ts";
-import type { ApplicationDestination } from "./Application.ts";
-
 /**
- * The slice of a deployed Worker the Access worker destinations need: its
- * immutable script id (`scriptTag`). Structural so both the yielded Worker
- * resource and hand-built shapes satisfy it.
+ * Account-wide Worker destinations for an Access application. Protecting a
+ * *specific* Worker is configured on the Worker itself (the `access` prop
+ * on `Cloudflare.Worker`), which enrolls it into an application by adding
+ * its `worker`/`preview_worker` destinations.
  */
-export interface AccessProtectableWorker {
-  scriptTag: Output<string | undefined>;
-}
-
-/**
- * An {@link ApplicationDestination} whose `workerId` resolves from a deployed
- * Worker's attributes. The discriminant stays a single literal so the
- * destination matches its exact variant of the destination union.
- */
-export interface WorkerApplicationDestination<
-  Type extends "worker" | "preview_worker",
-> {
-  type: Type;
-  workerId: Output<string>;
-}
-
-/**
- * Destination covering a specific Worker's **production** traffic — custom
- * domains, routes, and its `workers.dev` URL.
- *
- * Resolves the Worker's immutable script id (`scriptTag`) — the id the
- * Access API keys on. Note this is NOT the Worker's `workerId` attribute
- * (which carries the script *name*).
- *
- * ```typescript
- * const api = yield* ApiWorker;
- * yield* Cloudflare.Access.Application("ApiAccess", {
- *   type: "self_hosted",
- *   destinations: [Cloudflare.Access.Worker(api)],
- *   policies: [allowTeam],
- * });
- * ```
- */
-export const Worker = (
-  worker: AccessProtectableWorker,
-): WorkerApplicationDestination<"worker"> => ({
-  type: "worker",
-  // `scriptTag` is always present after a deploy of the Worker's own script;
-  // it is only absent for version workers, which are covered through their
-  // parent's tag instead.
-  workerId: worker.scriptTag.as<string>(),
-});
-
-/**
- * Destination covering a specific Worker's **version preview URLs**
- * (`<version>-<name>.<subdomain>.workers.dev`).
- *
- * ```typescript
- * const api = yield* ApiWorker;
- * yield* Cloudflare.Access.Application("ApiPreviewAccess", {
- *   type: "self_hosted",
- *   destinations: [Cloudflare.Access.WorkerPreview(api)],
- *   policies: [allowTeam],
- * });
- * ```
- */
-export const WorkerPreview = (
-  worker: AccessProtectableWorker,
-): WorkerApplicationDestination<"preview_worker"> => ({
-  type: "preview_worker",
-  workerId: worker.scriptTag.as<string>(),
-});
 
 /**
  * Destination covering the **production** traffic of every Worker on the

--- a/packages/alchemy/src/Cloudflare/Access/WorkerDestination.ts
+++ b/packages/alchemy/src/Cloudflare/Access/WorkerDestination.ts
@@ -26,16 +26,20 @@ export interface WorkerApplicationDestination<
  * Destination covering a specific Worker's **production** traffic — custom
  * domains, routes, and its `workers.dev` URL.
  *
+ * Resolves the Worker's immutable script id (`scriptTag`) — the id the
+ * Access API keys on. Note this is NOT the Worker's `workerId` attribute
+ * (which carries the script *name*).
+ *
  * ```typescript
  * const api = yield* ApiWorker;
  * yield* Cloudflare.Access.Application("ApiAccess", {
  *   type: "self_hosted",
- *   destinations: [Cloudflare.Access.worker(api)],
+ *   destinations: [Cloudflare.Access.Worker(api)],
  *   policies: [allowTeam.policyId],
  * });
  * ```
  */
-export const worker = (
+export const Worker = (
   worker: AccessProtectableWorker,
 ): WorkerApplicationDestination<"worker"> => ({
   type: "worker",
@@ -53,14 +57,47 @@ export const worker = (
  * const api = yield* ApiWorker;
  * yield* Cloudflare.Access.Application("ApiPreviewAccess", {
  *   type: "self_hosted",
- *   destinations: [Cloudflare.Access.previewWorker(api)],
+ *   destinations: [Cloudflare.Access.WorkerPreview(api)],
  *   policies: [allowTeam.policyId],
  * });
  * ```
  */
-export const previewWorker = (
+export const WorkerPreview = (
   worker: AccessProtectableWorker,
 ): WorkerApplicationDestination<"preview_worker"> => ({
   type: "preview_worker",
   workerId: worker.scriptTag.as<string>(),
 });
+
+/**
+ * Destination covering the **production** traffic of every Worker on the
+ * account — including Workers created later. Hostname-level policies take
+ * precedence over Worker-level policies, which take precedence over this
+ * account-level policy, so an individual Worker can still be opened up with
+ * its own application.
+ *
+ * ```typescript
+ * yield* Cloudflare.Access.Application("ProtectAllWorkers", {
+ *   type: "self_hosted",
+ *   destinations: [Cloudflare.Access.AllWorkers],
+ *   policies: [allowTeam.policyId],
+ * });
+ * ```
+ */
+export const AllWorkers: { type: "all_workers" } = { type: "all_workers" };
+
+/**
+ * Destination covering the **version preview URLs** of every Worker on the
+ * account — including Workers created later.
+ *
+ * ```typescript
+ * yield* Cloudflare.Access.Application("ProtectAllPreviews", {
+ *   type: "self_hosted",
+ *   destinations: [Cloudflare.Access.AllWorkerPreviews],
+ *   policies: [allowTeam.policyId],
+ * });
+ * ```
+ */
+export const AllWorkerPreviews: { type: "all_preview_workers" } = {
+  type: "all_preview_workers",
+};

--- a/packages/alchemy/src/Cloudflare/Access/WorkerDestination.ts
+++ b/packages/alchemy/src/Cloudflare/Access/WorkerDestination.ts
@@ -35,7 +35,7 @@ export interface WorkerApplicationDestination<
  * yield* Cloudflare.Access.Application("ApiAccess", {
  *   type: "self_hosted",
  *   destinations: [Cloudflare.Access.Worker(api)],
- *   policies: [allowTeam.policyId],
+ *   policies: [allowTeam],
  * });
  * ```
  */
@@ -58,7 +58,7 @@ export const Worker = (
  * yield* Cloudflare.Access.Application("ApiPreviewAccess", {
  *   type: "self_hosted",
  *   destinations: [Cloudflare.Access.WorkerPreview(api)],
- *   policies: [allowTeam.policyId],
+ *   policies: [allowTeam],
  * });
  * ```
  */
@@ -80,7 +80,7 @@ export const WorkerPreview = (
  * yield* Cloudflare.Access.Application("ProtectAllWorkers", {
  *   type: "self_hosted",
  *   destinations: [Cloudflare.Access.AllWorkers],
- *   policies: [allowTeam.policyId],
+ *   policies: [allowTeam],
  * });
  * ```
  */
@@ -94,7 +94,7 @@ export const AllWorkers: { type: "all_workers" } = { type: "all_workers" };
  * yield* Cloudflare.Access.Application("ProtectAllPreviews", {
  *   type: "self_hosted",
  *   destinations: [Cloudflare.Access.AllWorkerPreviews],
- *   policies: [allowTeam.policyId],
+ *   policies: [allowTeam],
  * });
  * ```
  */

--- a/packages/alchemy/src/Cloudflare/Access/index.ts
+++ b/packages/alchemy/src/Cloudflare/Access/index.ts
@@ -1,5 +1,6 @@
 export * from "../Access.ts";
 export * from "./Application.ts";
+export * from "./Context.ts";
 export * from "./Bookmark.ts";
 export * from "./Certificate.ts";
 export * from "./CustomPage.ts";
@@ -14,3 +15,4 @@ export * from "./Organization.ts";
 export * from "./Policy.ts";
 export * from "./ServiceToken.ts";
 export * from "./Tag.ts";
+export * from "./WorkerDestination.ts";

--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -1171,8 +1171,10 @@ export const LocalWorkerProvider = () =>
                   port: news.dev?.port ?? DEFAULT_DEV_PORT,
                 }).pipe(Effect.flatMap((proxy) => resolveLocalUrls(proxy.url)));
           return {
-            // No cloud script exists in dev — there is no immutable ID.
-            workerId: undefined,
+            // No cloud script exists in dev — fabricate a `dev:`-marked
+            // identity (the shared local-provider convention, and the
+            // legacy-row mode marker; see LOCAL_ID_PREFIX).
+            workerId: `dev:${name}`,
             workerName: name,
             namespace: undefined,
             logpush: undefined,
@@ -1205,7 +1207,7 @@ export const LocalWorkerProvider = () =>
             yield* closeWorkerd(id);
             const urls = config.dev.url ? [config.dev.url] : [];
             return {
-              workerId: undefined,
+              workerId: `dev:${config.name}`,
               workerName: config.name,
               namespace: undefined,
               logpush: undefined,
@@ -1274,7 +1276,7 @@ export const LocalWorkerProvider = () =>
           // are not served by this session, so they don't appear.
           const urls = yield* resolveLocalUrls(serverUrl);
           return {
-            workerId: undefined,
+            workerId: `dev:${config.name}`,
             workerName: config.name,
             namespace: undefined,
             logpush: undefined,

--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -517,11 +517,18 @@ export const LocalWorkerProvider = () =>
         selfUrl: string | undefined,
       ) {
         const { accountId } = yield* cloudflareEnv;
-        return yield* materializeRuntimeBindings(config, {
-          accountId,
-          selfUrl,
-          stack: { name: stack.name, stage: stack.stage },
-        });
+        return yield* materializeRuntimeBindings(
+          {
+            ...config,
+            devAccess:
+              config.dev.mode === "external" ? undefined : config.dev.access,
+          },
+          {
+            accountId,
+            selfUrl,
+            stack: { name: stack.name, stage: stack.stage },
+          },
+        );
       });
 
       // Latest successful serve per worker id, so runtime wiring changes
@@ -995,6 +1002,7 @@ export const LocalWorkerProvider = () =>
                         hasAssets: worker.hasAssets,
                         bindingDescriptors: worker.bindingDescriptors,
                         devRemote: worker.devRemote,
+                        devAccess: worker.dev.access,
                         durableObjectNamespaces: worker.durableObjectNamespaces,
                         workflows: worker.workflows,
                         hyperdrives: worker.hyperdrives,
@@ -1165,6 +1173,8 @@ export const LocalWorkerProvider = () =>
           return {
             workerId: name,
             workerName: name,
+            // No cloud script exists in dev — there is no immutable id.
+            scriptTag: undefined,
             namespace: undefined,
             logpush: undefined,
             url: urls[0],
@@ -1198,6 +1208,7 @@ export const LocalWorkerProvider = () =>
             return {
               workerId: config.name,
               workerName: config.name,
+              scriptTag: undefined,
               namespace: undefined,
               logpush: undefined,
               url: urls[0],
@@ -1267,6 +1278,7 @@ export const LocalWorkerProvider = () =>
           return {
             workerId: config.name,
             workerName: config.name,
+            scriptTag: undefined,
             namespace: undefined,
             logpush: undefined,
             url: urls[0],

--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -1171,10 +1171,9 @@ export const LocalWorkerProvider = () =>
                   port: news.dev?.port ?? DEFAULT_DEV_PORT,
                 }).pipe(Effect.flatMap((proxy) => resolveLocalUrls(proxy.url)));
           return {
-            workerId: name,
+            // No cloud script exists in dev — there is no immutable ID.
+            workerId: undefined,
             workerName: name,
-            // No cloud script exists in dev — there is no immutable id.
-            scriptTag: undefined,
             namespace: undefined,
             logpush: undefined,
             url: urls[0],
@@ -1206,9 +1205,8 @@ export const LocalWorkerProvider = () =>
             yield* closeWorkerd(id);
             const urls = config.dev.url ? [config.dev.url] : [];
             return {
-              workerId: config.name,
+              workerId: undefined,
               workerName: config.name,
-              scriptTag: undefined,
               namespace: undefined,
               logpush: undefined,
               url: urls[0],
@@ -1276,9 +1274,8 @@ export const LocalWorkerProvider = () =>
           // are not served by this session, so they don't appear.
           const urls = yield* resolveLocalUrls(serverUrl);
           return {
-            workerId: config.name,
+            workerId: undefined,
             workerName: config.name,
-            scriptTag: undefined,
             namespace: undefined,
             logpush: undefined,
             url: urls[0],

--- a/packages/alchemy/src/Cloudflare/Workers/RuntimeBindings.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/RuntimeBindings.ts
@@ -286,6 +286,12 @@ export const materializeRuntimeBindings = Effect.fn(function* (
     bindingDescriptors: WorkerBinding[];
     /** Binding name → opt-out of local emulation (`Alchemy.remote()`). */
     devRemote?: Record<string, boolean>;
+    /**
+     * Simulated Cloudflare Access config (`dev: { access: ... }`), lowered
+     * into the `ALCHEMY_DEV_ACCESS` env binding the worker bridge reads to
+     * serve `ctx.access` locally.
+     */
+    devAccess?: { aud?: string; identity?: Record<string, unknown> };
   },
   options: {
     accountId: string;
@@ -316,6 +322,9 @@ export const materializeRuntimeBindings = Effect.fn(function* (
           : Json.local(key, unredacted);
       }),
     ...(config.hasAssets ? [Assets.local("ASSETS")] : []),
+    ...(config.devAccess !== undefined
+      ? [Json.local("ALCHEMY_DEV_ACCESS", config.devAccess)]
+      : []),
   ];
   for (const descriptor of config.bindingDescriptors) {
     if (descriptor.type === "self_url") {

--- a/packages/alchemy/src/Cloudflare/Workers/ViteChild.shared.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/ViteChild.shared.ts
@@ -38,6 +38,8 @@ export interface ViteChildConfig {
     bindingDescriptors: WorkerBinding[];
     /** Binding name → opt-out of local emulation (`Alchemy.remote()`). */
     devRemote: Record<string, boolean>;
+    /** Simulated Cloudflare Access config (`dev: { access: ... }`). */
+    devAccess?: { aud?: string; identity?: Record<string, unknown> };
     durableObjectNamespaces: (DurableObjectNamespace & {
       uniqueKey: string;
     })[];

--- a/packages/alchemy/src/Cloudflare/Workers/ViteChildRunner.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/ViteChildRunner.ts
@@ -52,6 +52,7 @@ const program = Effect.scoped(
       hasAssets,
       bindingDescriptors,
       devRemote,
+      devAccess,
       ...runtimeWorker
     } = config.worker;
     const bindings = yield* materializeRuntimeBindings(
@@ -61,6 +62,7 @@ const program = Effect.scoped(
         hasAssets,
         bindingDescriptors,
         devRemote,
+        devAccess,
       },
       {
         accountId: config.accountId,

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -987,13 +987,16 @@ export interface WorkerProps<
          */
         cf?: Record<string, unknown>;
         /**
-         * Simulate Cloudflare Access locally (the alchemy equivalent of
-         * wrangler's `access.dev` config). When set, `ctx.access` is
-         * defined under `alchemy dev` with this audience and identity —
-         * letting you exercise identity-aware logic without deploying.
-         * Omit to simulate unauthenticated requests (`ctx.access` is
-         * `undefined`). Ignored on deploy: production `ctx.access` is
-         * populated by Cloudflare when the request passes through Access.
+         * Stub the authenticated Access state in local dev. In production,
+         * `ctx.access` is populated by Cloudflare's edge after a request
+         * passes the Access login wall — locally there is no edge and no
+         * login, so without this stub `ctx.access` is always `undefined`
+         * and identity-dependent code paths can't run. When set, every
+         * request served by `alchemy dev` behaves as if this one user had
+         * logged in: `ctx.access` carries the given audience and
+         * `getIdentity()` resolves the given identity. Omit to simulate
+         * unauthenticated requests. Inert on deploy — the deployed Worker
+         * always gets the real edge-populated `ctx.access`.
          */
         access?: {
           /**

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -650,46 +650,37 @@ export interface WorkerProps<
    */
   workersDev?: boolean | WorkersDevConfig;
   /**
-   * Protect this Worker with Cloudflare Access by enrolling it into an
-   * Access application. The application owns the policies (author them
-   * inline on the application or as `Cloudflare.Access.Policy` resources);
-   * the provider adds this Worker as a `worker` destination — and a
-   * `preview_worker` destination unless `previews: false` — covering its
-   * custom domains, routes, `workers.dev` URL, and version preview URLs.
-   * Removing the prop (or deleting the Worker) un-enrolls it.
+   * Protect this Worker with Cloudflare Access. Two forms:
+   *
+   * **Dedicated** — `{ policies, ... }` declares an Access application
+   * owned by this Worker (namespaced under it as `<Worker>/Access`),
+   * created, updated, and deleted with it:
+   * ```ts
+   * access: {
+   *   policies: [
+   *     { decision: "allow", include: [{ emailDomain: "example.com" }] },
+   *   ],
+   * }
+   * ```
+   *
+   * **Shared** — pass a `Cloudflare.Access.Application` directly to enroll
+   * into it. Access policies are application-wide: every enrolled Worker
+   * is gated by the same policy set:
+   * ```ts
+   * access: TeamOnly
+   * ```
+   *
+   * Either way the Worker's `worker` destination — and a `preview_worker`
+   * destination unless `previews: false` (dedicated form) — is pushed onto
+   * the application, covering custom domains, routes, the `workers.dev`
+   * URL, and version preview URLs. Removing the prop (or deleting the
+   * Worker) un-enrolls it.
    *
    * At runtime, read the authenticated identity from `ctx.access` via
    * `Cloudflare.Access.Context`; under `alchemy dev`, simulate it with
    * `dev: { access: ... }`. Also accepted by every `Cloudflare.Website.*`
    * framework. See the
    * [Protect a Worker with Access](/cloudflare/security/access) guide.
-   *
-   * @example
-   * ```ts
-   * // Dedicated application owned by this Worker (per-Worker policies):
-   * export default class Api extends Cloudflare.Worker<Api>()("Api", {
-   *   main: import.meta.url,
-   *   access: {
-   *     policies: [
-   *       { decision: "allow", include: [{ emailDomain: "example.com" }] },
-   *     ],
-   *   },
-   * }, ...) {}
-   *
-   * // Or enroll into a shared application (one policy set, many Workers —
-   * // note policies are application-wide):
-   * const App = Cloudflare.Access.Application("TeamOnly", {
-   *   type: "self_hosted",
-   *   policies: [
-   *     { decision: "allow", include: [{ emailDomain: "example.com" }] },
-   *   ],
-   * });
-   *
-   * export default class Api extends Cloudflare.Worker<Api>()("Api", {
-   *   main: import.meta.url,
-   *   access: App,
-   * }, ...) {}
-   * ```
    */
   access?: WorkerAccessConfig;
   /**
@@ -1434,7 +1425,10 @@ export const isSelf = (value: unknown): value is Self =>
  * `Cloudflare.Access.Context`. See the
  * [Protect a Worker with Access](/cloudflare/security/access) guide.
  *
- * @example Require a verified email domain
+ * @example Dedicated application — per-Worker policies
+ * The `{ policies }` form declares an Access application owned by this
+ * Worker (namespaced under it as `<Worker>/Access`), created, updated,
+ * and deleted with it:
  * ```typescript
  * export default Cloudflare.Worker(
  *   "Api",
@@ -1457,6 +1451,25 @@ export const isSelf = (value: unknown): value is Self =>
  *       }),
  *     };
  *   }),
+ * );
+ * ```
+ *
+ * @example Shared application — one policy set, many Workers
+ * Pass a `Cloudflare.Access.Application` directly to enroll into it.
+ * Access policies are application-wide: every enrolled Worker is gated
+ * by the same policy set.
+ * ```typescript
+ * const TeamOnly = Cloudflare.Access.Application("TeamOnly", {
+ *   type: "self_hosted",
+ *   policies: [
+ *     { decision: "allow", include: [{ emailDomain: "example.com" }] },
+ *   ],
+ * });
+ *
+ * export default Cloudflare.Worker(
+ *   "Api",
+ *   { main: import.meta.url, access: TeamOnly },
+ *   /* ... *​/
  * );
  * ```
  *

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -1139,11 +1139,13 @@ export type Worker<Bindings = any> = Resource<
      * value like `c81a2d22c29840ed9d61681a3270dbff`, shown as the Worker ID
      * in the dashboard and the identifier Access `worker` destinations key
      * on. Stable across every update; changes only when the script is
-     * replaced. For the script *name*, use {@link workerName}. `undefined`
-     * when no cloud script exists yet (`alchemy dev`, pre-create stubs) —
-     * a version worker carries its parent script's ID.
+     * replaced. For the script *name*, use {@link workerName}. A version
+     * worker carries its parent script's ID. Under `alchemy dev` there is
+     * no cloud script, so the local provider generates a `dev:`-prefixed
+     * ID instead (switching between dev and deploy replaces the resource,
+     * so the two identities never mix).
      */
-    workerId: string | undefined;
+    workerId: string;
     /** The script name, e.g. `"api"` — the classic API's identifier. */
     workerName: string;
     /**

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -843,7 +843,7 @@ export interface WorkerProps<
    *   main: import.meta.url,
    *   access: {
    *     policies: [
-   *       { decision: "allow", include: [{ emailDomain: { domain: "example.com" } }] },
+   *       { decision: "allow", include: [{ emailDomain: "example.com" }] },
    *     ],
    *   },
    * }, ...) {}
@@ -852,7 +852,7 @@ export interface WorkerProps<
    * const App = Cloudflare.Access.Application("TeamOnly", {
    *   type: "self_hosted",
    *   policies: [
-   *     { decision: "allow", include: [{ emailDomain: { domain: "example.com" } }] },
+   *     { decision: "allow", include: [{ emailDomain: "example.com" }] },
    *   ],
    * });
    *

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -1134,18 +1134,18 @@ export type Worker<Bindings = any> = Resource<
   WorkerTypeId,
   WorkerProps<Bindings>,
   {
-    workerId: string;
-    workerName: string;
     /**
-     * The immutable id Cloudflare assigns to this Worker's script (the
-     * script "tag" — shown as the Worker ID in the dashboard). This is the
-     * `workerId` a `Cloudflare.Access.Application` worker destination
-     * expects (see `Cloudflare.Access.worker(...)`). `undefined` for a
-     * version worker (protect its previews through the parent Worker) and
-     * for state persisted before this attribute existed (backfilled on the
-     * next deploy).
+     * The immutable ID Cloudflare assigns to this Worker's script — a hex
+     * value like `c81a2d22c29840ed9d61681a3270dbff`, shown as the Worker ID
+     * in the dashboard and the identifier Access `worker` destinations key
+     * on. Stable across every update; changes only when the script is
+     * replaced. For the script *name*, use {@link workerName}. `undefined`
+     * when no cloud script exists yet (`alchemy dev`, pre-create stubs) —
+     * a version worker carries its parent script's ID.
      */
-    scriptTag: string | undefined;
+    workerId: string | undefined;
+    /** The script name, e.g. `"api"` — the classic API's identifier. */
+    workerName: string;
     /**
      * The Workers for Platforms dispatch namespace this Worker was deployed
      * into, or `undefined` for a regular account-level Worker.

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -37,6 +37,7 @@ import type { DispatchNamespace } from "../WorkersForPlatforms/DispatchNamespace
 import type { WorkflowExport } from "../Workflows/Workflow.ts";
 import type { Reference as ZoneReference } from "../Zone/lookup.ts";
 import { type Assets, type AssetsProps } from "./Assets.ts";
+import type { Application } from "../Access/Application.ts";
 import { type DurableObjectExport } from "./DurableObject.ts";
 import { Request } from "./Request.ts";
 import type { ModuleRule } from "./Sources/Prebuilt.ts";
@@ -80,6 +81,25 @@ export interface WorkerExecutionContextCache {
   purge(
     options: cf.CachePurgeOptions,
   ): Effect.Effect<cf.CachePurgeResult, CachePurgeError, RuntimeContext>;
+}
+
+/**
+ * Enroll this Worker into a Cloudflare Access application (`access` prop).
+ * The application owns the policies; enrolling pushes this Worker's
+ * `worker` destination (and a `preview_worker` destination unless
+ * `previews: false`) onto the application through its binding contract, so
+ * the application deploys with — and converges on — the destinations of
+ * every enrolled Worker. Removing the prop (or the Worker) un-enrolls it
+ * on the application's next reconcile.
+ */
+export interface WorkerAccessConfig {
+  /** The `Cloudflare.Access.Application` to enroll into. */
+  application: Application;
+  /**
+   * Also protect the Worker's version preview URLs.
+   * @default true
+   */
+  previews?: boolean;
 }
 
 export class WorkerAccessIdentityError extends Data.TaggedError(
@@ -761,6 +781,35 @@ export interface WorkerProps<
    * @default true
    */
   workersDev?: boolean | WorkersDevConfig;
+  /**
+   * Protect this Worker with Cloudflare Access by enrolling it into an
+   * Access application. The application owns the policies (author them
+   * inline on the application or as `Cloudflare.Access.Policy` resources);
+   * the provider adds this Worker as a `worker` destination — and a
+   * `preview_worker` destination unless `previews: false` — covering its
+   * custom domains, routes, `workers.dev` URL, and version preview URLs.
+   * Removing the prop (or deleting the Worker) un-enrolls it.
+   *
+   * At runtime, read the authenticated identity from `ctx.access` via
+   * `Cloudflare.Access.Context`; under `alchemy dev`, simulate it with
+   * `dev: { access: ... }`.
+   *
+   * @example
+   * ```ts
+   * const App = Cloudflare.Access.Application("TeamOnly", {
+   *   type: "self_hosted",
+   *   policies: [
+   *     { decision: "allow", include: [{ emailDomain: { domain: "example.com" } }] },
+   *   ],
+   * });
+   *
+   * export default class Api extends Cloudflare.Worker<Api>()("Api", {
+   *   main: import.meta.url,
+   *   access: { application: App },
+   * }, ...) {}
+   * ```
+   */
+  access?: WorkerAccessConfig;
   /**
    * Static assets to serve. Can be:
    * - A string path to the assets directory

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -37,7 +37,12 @@ import type { DispatchNamespace } from "../WorkersForPlatforms/DispatchNamespace
 import type { WorkflowExport } from "../Workflows/Workflow.ts";
 import type { Reference as ZoneReference } from "../Zone/lookup.ts";
 import { type Assets, type AssetsProps } from "./Assets.ts";
-import type { Application, ApplicationProps } from "../Access/Application.ts";
+import {
+  resolveAccessContext,
+  type WorkerAccessConfig,
+  type WorkerAccessIdentity,
+  type WorkerExecutionContextAccess,
+} from "./WorkerAccess.ts";
 import { type DurableObjectExport } from "./DurableObject.ts";
 import { Request } from "./Request.ts";
 import type { ModuleRule } from "./Sources/Prebuilt.ts";
@@ -83,145 +88,6 @@ export interface WorkerExecutionContextCache {
   ): Effect.Effect<cf.CachePurgeResult, CachePurgeError, RuntimeContext>;
 }
 
-/**
- * Protect this Worker with Cloudflare Access (`access` prop). Two forms:
- *
- * - `{ application }` — enroll into a **shared** application (one policy
- *   set across several Workers).
- * - `{ policies }` — a **dedicated** application owned by this Worker,
- *   created/updated/deleted with it. Access configuration (policies,
- *   session duration, IdPs) lives on applications, so per-Worker
- *   configuration means a per-Worker application — this form declares one
- *   for you (logical id `<WorkerId>Access`).
- *
- * Either way, enrolling pushes this Worker's `worker` destination (and a
- * `preview_worker` destination unless `previews: false`) onto the
- * application through its binding contract, so the application deploys
- * with — and converges on — the destinations of every enrolled Worker.
- * Removing the prop (or the Worker) un-enrolls it on the application's
- * next reconcile.
- */
-export type WorkerAccessConfig =
-  | WorkerAccessEnrollment
-  | WorkerAccessApplication;
-
-/** Enroll this Worker into a shared Access application. */
-export interface WorkerAccessEnrollment {
-  /** The `Cloudflare.Access.Application` to enroll into. */
-  application: Application;
-  /**
-   * Also protect the Worker's version preview URLs.
-   * @default true
-   */
-  previews?: boolean;
-}
-
-/**
- * A dedicated Access application owned by this Worker — per-Worker
- * policies without declaring the application yourself.
- */
-export interface WorkerAccessApplication {
-  /**
-   * Policies gating access to this Worker — inline bodies, reusable
-   * `Cloudflare.Access.Policy` resources, or policy ids (see
-   * `ApplicationProps["policies"]`).
-   */
-  policies: NonNullable<ApplicationProps["policies"]>;
-  /** Display name for the application. Auto-generated when omitted. */
-  name?: string;
-  /** Session lifetime, e.g. `"24h"`. */
-  sessionDuration?: string;
-  /** Allowed identity-provider UUIDs. */
-  allowedIdps?: string[];
-  /** Skip the IdP picker when exactly one IdP is allowed. */
-  autoRedirectToIdentity?: boolean;
-  /** Show the application in the App Launcher dashboard. */
-  appLauncherVisible?: boolean;
-  /**
-   * Also protect the Worker's version preview URLs.
-   * @default true
-   */
-  previews?: boolean;
-}
-
-export class WorkerAccessIdentityError extends Data.TaggedError(
-  "WorkerAccessIdentityError",
-)<{
-  message: string;
-  cause?: unknown;
-}> {}
-
-/**
- * The identity Cloudflare Access authenticated for the current request,
- * as resolved by `ctx.access.getIdentity()`. Field names follow the wire
- * format of Access's identity payload (snake_case); identity providers can
- * attach additional fields, captured by the index signature.
- */
-export interface WorkerAccessIdentity {
-  /** The user's email address, if the identity provider supplies one. */
-  readonly email?: string;
-  /** The user's display name. */
-  readonly name?: string;
-  /** The user's unique identifier. */
-  readonly user_uuid?: string;
-  /** The Cloudflare account id the Access organization belongs to. */
-  readonly account_id?: string;
-  /** Login timestamp (Unix epoch seconds). */
-  readonly iat?: number;
-  /** The user's IP address at authentication time. */
-  readonly ip?: string;
-  /** Authentication methods used (e.g. `"pwd"`). */
-  readonly amr?: string[];
-  /** Identity-provider information. */
-  readonly idp?: { id: string; type: string };
-  /** Where the user authenticated from. */
-  readonly geo?: { country: string };
-  /** Group memberships from the identity provider. */
-  readonly groups?: Array<{ id: string; name: string; email?: string }>;
-  /** Device posture check results, keyed by check id. */
-  readonly devicePosture?: Record<string, unknown>;
-  /** True when the user connected via Cloudflare WARP. */
-  readonly is_warp?: boolean;
-  /** True when the user is authenticated via Cloudflare Gateway. */
-  readonly is_gateway?: boolean;
-  /** Service-token client id, when authenticated via a service token. */
-  readonly service_token_id?: string;
-  /** True when the request authenticated with a service token. */
-  readonly service_token_status?: boolean;
-  readonly [key: string]: unknown;
-}
-
-/**
- * Effect-native view of the Cloudflare Access runtime API on the execution
- * context (`ctx.access`). Present only when the request was admitted by a
- * Cloudflare Access policy (see `Cloudflare.Access.Application` with
- * `worker`/`all_workers` destinations), or when simulated locally via the
- * Worker's `dev.access` config.
- */
-export interface WorkerExecutionContextAccess {
-  /** The Access application audience (AUD) tag that admitted this request. */
-  readonly aud: string;
-  /**
-   * Resolve the authenticated identity — email, name, groups, device
-   * posture, etc. Resolves `undefined` when Access has no identity for the
-   * request (e.g. some service-token flows).
-   */
-  getIdentity(): Effect.Effect<
-    WorkerAccessIdentity | undefined,
-    WorkerAccessIdentityError,
-    RuntimeContext
-  >;
-}
-
-/**
- * The shape workerd exposes on `ctx.access` (typed locally — this package's
- * workers-types predates it) and that the local dev simulation mirrors.
- */
-interface RawAccessContext {
-  readonly aud: string;
-  getIdentity(): Promise<WorkerAccessIdentity | undefined>;
-}
-
 export class WorkerExecutionContext extends Context.Service<
   WorkerExecutionContext,
   {
@@ -260,52 +126,12 @@ export class WorkerExecutionContext extends Context.Service<
   }
 >()("Cloudflare.Workers.WorkerExecutionContext") {}
 
-const makeAccessContext = (
-  raw: RawAccessContext,
-): WorkerExecutionContextAccess => ({
-  aud: raw.aud,
-  getIdentity: () =>
-    Effect.tryPromise({
-      try: () => raw.getIdentity(),
-      catch: (cause) =>
-        new WorkerAccessIdentityError({
-          message:
-            cause instanceof Error
-              ? cause.message
-              : "Unknown Access identity resolution error",
-          cause,
-        }),
-    }),
-});
-
-/** The env key `dev.access` is lowered into by the local worker provider. */
-export const DEV_ACCESS_ENV_KEY = "ALCHEMY_DEV_ACCESS";
-
 export const fromExecutionContext = (
   ctx: cf.ExecutionContext,
   env?: Record<string, unknown>,
 ): WorkerExecutionContext["Service"] => ({
   raw: ctx,
-  access: Effect.sync(() => {
-    // Deployed behind Access: workerd populates ctx.access natively.
-    const native = (ctx as cf.ExecutionContext & { access?: RawAccessContext })
-      .access;
-    if (native !== undefined) {
-      return makeAccessContext(native);
-    }
-    // Local dev: the Worker's `dev.access` config is lowered into an env
-    // binding; absent config simulates an unauthenticated request.
-    const dev = env?.[DEV_ACCESS_ENV_KEY] as
-      | { aud?: string; identity?: WorkerAccessIdentity }
-      | undefined;
-    if (dev !== undefined) {
-      return {
-        aud: dev.aud ?? "dev",
-        getIdentity: () => Effect.succeed(dev.identity),
-      };
-    }
-    return undefined;
-  }),
+  access: Effect.sync(() => resolveAccessContext(ctx, env)),
   waitUntil: <A, E, R>(effect: Effect.Effect<A, E, R>) =>
     Effect.gen(function* () {
       const context = yield* Effect.context<R>();
@@ -834,7 +660,9 @@ export interface WorkerProps<
    *
    * At runtime, read the authenticated identity from `ctx.access` via
    * `Cloudflare.Access.Context`; under `alchemy dev`, simulate it with
-   * `dev: { access: ... }`.
+   * `dev: { access: ... }`. Also accepted by every `Cloudflare.Website.*`
+   * framework. See the
+   * [Protect a Worker with Access](/cloudflare/security/access) guide.
    *
    * @example
    * ```ts
@@ -1598,6 +1426,39 @@ export const isSelf = (value: unknown): value is Self =>
  * @resource
  * @product Workers
  * @category Workers & Compute
+ * @section Protect with Access
+ * Put Cloudflare Access in front of the Worker with the `access` prop —
+ * unauthenticated requests are redirected to your team's login page, and
+ * handlers read the authenticated identity from `ctx.access` via
+ * `Cloudflare.Access.Context`. See the
+ * [Protect a Worker with Access](/cloudflare/security/access) guide.
+ *
+ * @example Require a verified email domain
+ * ```typescript
+ * export default Cloudflare.Worker(
+ *   "Api",
+ *   {
+ *     main: import.meta.url,
+ *     access: {
+ *       policies: [
+ *         { decision: "allow", include: [{ emailDomain: "example.com" }] },
+ *       ],
+ *     },
+ *     // simulate the authenticated state under `alchemy dev`
+ *     dev: { access: { aud: "dev", identity: { email: "dev@example.com" } } },
+ *   },
+ *   Effect.gen(function* () {
+ *     return {
+ *       fetch: Effect.gen(function* () {
+ *         const access = yield* Cloudflare.Access.Context;
+ *         const identity = yield* access!.getIdentity();
+ *         return yield* HttpServerResponse.json({ email: identity?.email });
+ *       }),
+ *     };
+ *   }),
+ * );
+ * ```
+ *
  * @section Async Workers
  * You don't have to use Effect for your runtime code. If you create
  * a Worker resource with `main` pointing at a file but provide no

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -37,7 +37,7 @@ import type { DispatchNamespace } from "../WorkersForPlatforms/DispatchNamespace
 import type { WorkflowExport } from "../Workflows/Workflow.ts";
 import type { Reference as ZoneReference } from "../Zone/lookup.ts";
 import { type Assets, type AssetsProps } from "./Assets.ts";
-import type { Application } from "../Access/Application.ts";
+import type { Application, ApplicationProps } from "../Access/Application.ts";
 import { type DurableObjectExport } from "./DurableObject.ts";
 import { Request } from "./Request.ts";
 import type { ModuleRule } from "./Sources/Prebuilt.ts";
@@ -84,17 +84,59 @@ export interface WorkerExecutionContextCache {
 }
 
 /**
- * Enroll this Worker into a Cloudflare Access application (`access` prop).
- * The application owns the policies; enrolling pushes this Worker's
- * `worker` destination (and a `preview_worker` destination unless
- * `previews: false`) onto the application through its binding contract, so
- * the application deploys with — and converges on — the destinations of
- * every enrolled Worker. Removing the prop (or the Worker) un-enrolls it
- * on the application's next reconcile.
+ * Protect this Worker with Cloudflare Access (`access` prop). Two forms:
+ *
+ * - `{ application }` — enroll into a **shared** application (one policy
+ *   set across several Workers).
+ * - `{ policies }` — a **dedicated** application owned by this Worker,
+ *   created/updated/deleted with it. Access configuration (policies,
+ *   session duration, IdPs) lives on applications, so per-Worker
+ *   configuration means a per-Worker application — this form declares one
+ *   for you (logical id `<WorkerId>Access`).
+ *
+ * Either way, enrolling pushes this Worker's `worker` destination (and a
+ * `preview_worker` destination unless `previews: false`) onto the
+ * application through its binding contract, so the application deploys
+ * with — and converges on — the destinations of every enrolled Worker.
+ * Removing the prop (or the Worker) un-enrolls it on the application's
+ * next reconcile.
  */
-export interface WorkerAccessConfig {
+export type WorkerAccessConfig =
+  | WorkerAccessEnrollment
+  | WorkerAccessApplication;
+
+/** Enroll this Worker into a shared Access application. */
+export interface WorkerAccessEnrollment {
   /** The `Cloudflare.Access.Application` to enroll into. */
   application: Application;
+  /**
+   * Also protect the Worker's version preview URLs.
+   * @default true
+   */
+  previews?: boolean;
+}
+
+/**
+ * A dedicated Access application owned by this Worker — per-Worker
+ * policies without declaring the application yourself.
+ */
+export interface WorkerAccessApplication {
+  /**
+   * Policies gating access to this Worker — inline bodies, reusable
+   * `Cloudflare.Access.Policy` resources, or policy ids (see
+   * `ApplicationProps["policies"]`).
+   */
+  policies: NonNullable<ApplicationProps["policies"]>;
+  /** Display name for the application. Auto-generated when omitted. */
+  name?: string;
+  /** Session lifetime, e.g. `"24h"`. */
+  sessionDuration?: string;
+  /** Allowed identity-provider UUIDs. */
+  allowedIdps?: string[];
+  /** Skip the IdP picker when exactly one IdP is allowed. */
+  autoRedirectToIdentity?: boolean;
+  /** Show the application in the App Launcher dashboard. */
+  appLauncherVisible?: boolean;
   /**
    * Also protect the Worker's version preview URLs.
    * @default true
@@ -796,6 +838,17 @@ export interface WorkerProps<
    *
    * @example
    * ```ts
+   * // Dedicated application owned by this Worker (per-Worker policies):
+   * export default class Api extends Cloudflare.Worker<Api>()("Api", {
+   *   main: import.meta.url,
+   *   access: {
+   *     policies: [
+   *       { decision: "allow", include: [{ emailDomain: { domain: "example.com" } }] },
+   *     ],
+   *   },
+   * }, ...) {}
+   *
+   * // Or enroll into a shared application (one policy set, many Workers):
    * const App = Cloudflare.Access.Application("TeamOnly", {
    *   type: "self_hosted",
    *   policies: [

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -82,6 +82,84 @@ export interface WorkerExecutionContextCache {
   ): Effect.Effect<cf.CachePurgeResult, CachePurgeError, RuntimeContext>;
 }
 
+export class WorkerAccessIdentityError extends Data.TaggedError(
+  "WorkerAccessIdentityError",
+)<{
+  message: string;
+  cause?: unknown;
+}> {}
+
+/**
+ * The identity Cloudflare Access authenticated for the current request,
+ * as resolved by `ctx.access.getIdentity()`. Field names follow the wire
+ * format of Access's identity payload (snake_case); identity providers can
+ * attach additional fields, captured by the index signature.
+ */
+export interface WorkerAccessIdentity {
+  /** The user's email address, if the identity provider supplies one. */
+  readonly email?: string;
+  /** The user's display name. */
+  readonly name?: string;
+  /** The user's unique identifier. */
+  readonly user_uuid?: string;
+  /** The Cloudflare account id the Access organization belongs to. */
+  readonly account_id?: string;
+  /** Login timestamp (Unix epoch seconds). */
+  readonly iat?: number;
+  /** The user's IP address at authentication time. */
+  readonly ip?: string;
+  /** Authentication methods used (e.g. `"pwd"`). */
+  readonly amr?: string[];
+  /** Identity-provider information. */
+  readonly idp?: { id: string; type: string };
+  /** Where the user authenticated from. */
+  readonly geo?: { country: string };
+  /** Group memberships from the identity provider. */
+  readonly groups?: Array<{ id: string; name: string; email?: string }>;
+  /** Device posture check results, keyed by check id. */
+  readonly devicePosture?: Record<string, unknown>;
+  /** True when the user connected via Cloudflare WARP. */
+  readonly is_warp?: boolean;
+  /** True when the user is authenticated via Cloudflare Gateway. */
+  readonly is_gateway?: boolean;
+  /** Service-token client id, when authenticated via a service token. */
+  readonly service_token_id?: string;
+  /** True when the request authenticated with a service token. */
+  readonly service_token_status?: boolean;
+  readonly [key: string]: unknown;
+}
+
+/**
+ * Effect-native view of the Cloudflare Access runtime API on the execution
+ * context (`ctx.access`). Present only when the request was admitted by a
+ * Cloudflare Access policy (see `Cloudflare.Access.Application` with
+ * `worker`/`all_workers` destinations), or when simulated locally via the
+ * Worker's `dev.access` config.
+ */
+export interface WorkerExecutionContextAccess {
+  /** The Access application audience (AUD) tag that admitted this request. */
+  readonly aud: string;
+  /**
+   * Resolve the authenticated identity — email, name, groups, device
+   * posture, etc. Resolves `undefined` when Access has no identity for the
+   * request (e.g. some service-token flows).
+   */
+  getIdentity(): Effect.Effect<
+    WorkerAccessIdentity | undefined,
+    WorkerAccessIdentityError,
+    RuntimeContext
+  >;
+}
+
+/**
+ * The shape workerd exposes on `ctx.access` (typed locally — this package's
+ * workers-types predates it) and that the local dev simulation mirrors.
+ */
+interface RawAccessContext {
+  readonly aud: string;
+  getIdentity(): Promise<WorkerAccessIdentity | undefined>;
+}
+
 export class WorkerExecutionContext extends Context.Service<
   WorkerExecutionContext,
   {
@@ -104,16 +182,68 @@ export class WorkerExecutionContext extends Context.Service<
      */
     readonly cache: WorkerExecutionContextCache;
     /**
+     * The Cloudflare Access context for the current request (`ctx.access`),
+     * or `undefined` when the request did not pass through Access. Under
+     * `alchemy dev` the Worker's `dev.access` config simulates it.
+     */
+    readonly access: Effect.Effect<
+      WorkerExecutionContextAccess | undefined,
+      never,
+      RuntimeContext
+    >;
+    /**
      * The raw workerd ExecutionContext, for interop with async APIs.
      */
     readonly raw: cf.ExecutionContext;
   }
 >()("Cloudflare.Workers.WorkerExecutionContext") {}
 
+const makeAccessContext = (
+  raw: RawAccessContext,
+): WorkerExecutionContextAccess => ({
+  aud: raw.aud,
+  getIdentity: () =>
+    Effect.tryPromise({
+      try: () => raw.getIdentity(),
+      catch: (cause) =>
+        new WorkerAccessIdentityError({
+          message:
+            cause instanceof Error
+              ? cause.message
+              : "Unknown Access identity resolution error",
+          cause,
+        }),
+    }),
+});
+
+/** The env key `dev.access` is lowered into by the local worker provider. */
+export const DEV_ACCESS_ENV_KEY = "ALCHEMY_DEV_ACCESS";
+
 export const fromExecutionContext = (
   ctx: cf.ExecutionContext,
+  env?: Record<string, unknown>,
 ): WorkerExecutionContext["Service"] => ({
   raw: ctx,
+  access: Effect.sync(() => {
+    // Deployed behind Access: workerd populates ctx.access natively.
+    const native = (ctx as cf.ExecutionContext & { access?: RawAccessContext })
+      .access;
+    if (native !== undefined) {
+      return makeAccessContext(native);
+    }
+    // Local dev: the Worker's `dev.access` config is lowered into an env
+    // binding; absent config simulates an unauthenticated request.
+    const dev = env?.[DEV_ACCESS_ENV_KEY] as
+      | { aud?: string; identity?: WorkerAccessIdentity }
+      | undefined;
+    if (dev !== undefined) {
+      return {
+        aud: dev.aud ?? "dev",
+        getIdentity: () => Effect.succeed(dev.identity),
+      };
+    }
+    return undefined;
+  }),
   waitUntil: <A, E, R>(effect: Effect.Effect<A, E, R>) =>
     Effect.gen(function* () {
       const context = yield* Effect.context<R>();
@@ -176,6 +306,17 @@ export const deferredExecutionContext: WorkerExecutionContext["Service"] = {
       liveExecutionContext.pipe(
         Effect.flatMap((live) => live.cache.purge(options)),
       ) as Effect.Effect<cf.CachePurgeResult, CachePurgeError, RuntimeContext>,
+  },
+  // A getter so this module-level literal doesn't eagerly reference
+  // `liveExecutionContext` before its declaration below.
+  get access() {
+    return liveExecutionContext.pipe(
+      Effect.flatMap((live) => live.access),
+    ) as Effect.Effect<
+      WorkerExecutionContextAccess | undefined,
+      never,
+      RuntimeContext
+    >;
   },
 };
 
@@ -923,6 +1064,27 @@ export interface WorkerProps<
          * different edge location.
          */
         cf?: Record<string, unknown>;
+        /**
+         * Simulate Cloudflare Access locally (the alchemy equivalent of
+         * wrangler's `access.dev` config). When set, `ctx.access` is
+         * defined under `alchemy dev` with this audience and identity —
+         * letting you exercise identity-aware logic without deploying.
+         * Omit to simulate unauthenticated requests (`ctx.access` is
+         * `undefined`). Ignored on deploy: production `ctx.access` is
+         * populated by Cloudflare when the request passes through Access.
+         */
+        access?: {
+          /**
+           * Simulated Access application audience (AUD) tag.
+           * @default "dev"
+           */
+          aud?: string;
+          /**
+           * Simulated identity returned by `ctx.access.getIdentity()`,
+           * e.g. `{ email: "dev@example.com" }`.
+           */
+          identity?: WorkerAccessIdentity;
+        };
       }
     | {
         /**
@@ -1049,6 +1211,16 @@ export type Worker<Bindings = any> = Resource<
   {
     workerId: string;
     workerName: string;
+    /**
+     * The immutable id Cloudflare assigns to this Worker's script (the
+     * script "tag" — shown as the Worker ID in the dashboard). This is the
+     * `workerId` a `Cloudflare.Access.Application` worker destination
+     * expects (see `Cloudflare.Access.worker(...)`). `undefined` for a
+     * version worker (protect its previews through the parent Worker) and
+     * for state persisted before this attribute existed (backfilled on the
+     * next deploy).
+     */
+    scriptTag: string | undefined;
     /**
      * The Workers for Platforms dispatch namespace this Worker was deployed
      * into, or `undefined` for a regular account-level Worker.

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -676,7 +676,8 @@ export interface WorkerProps<
    *   },
    * }, ...) {}
    *
-   * // Or enroll into a shared application (one policy set, many Workers):
+   * // Or enroll into a shared application (one policy set, many Workers —
+   * // note policies are application-wide):
    * const App = Cloudflare.Access.Application("TeamOnly", {
    *   type: "self_hosted",
    *   policies: [
@@ -686,7 +687,7 @@ export interface WorkerProps<
    *
    * export default class Api extends Cloudflare.Worker<Api>()("Api", {
    *   main: import.meta.url,
-   *   access: { application: App },
+   *   access: App,
    * }, ...) {}
    * ```
    */

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerAccess.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerAccess.ts
@@ -1,0 +1,195 @@
+import type * as cf from "@cloudflare/workers-types";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
+import type { Application, ApplicationProps } from "../Access/Application.ts";
+
+/**
+ * Protect this Worker with Cloudflare Access (`access` prop). Two forms:
+ *
+ * - `{ application }` — enroll into a **shared** application (one policy
+ *   set across several Workers).
+ * - `{ policies }` — a **dedicated** application owned by this Worker,
+ *   created/updated/deleted with it. Access configuration (policies,
+ *   session duration, IdPs) lives on applications, so per-Worker
+ *   configuration means a per-Worker application — this form declares one
+ *   for you (logical id `<WorkerId>Access`).
+ *
+ * Either way, enrolling pushes this Worker's `worker` destination (and a
+ * `preview_worker` destination unless `previews: false`) onto the
+ * application through its binding contract, so the application deploys
+ * with — and converges on — the destinations of every enrolled Worker.
+ * Removing the prop (or the Worker) un-enrolls it on the application's
+ * next reconcile.
+ */
+export type WorkerAccessConfig =
+  | WorkerAccessEnrollment
+  | WorkerAccessApplication;
+
+/** Enroll this Worker into a shared Access application. */
+export interface WorkerAccessEnrollment {
+  /** The `Cloudflare.Access.Application` to enroll into. */
+  application: Application;
+  /**
+   * Also protect the Worker's version preview URLs.
+   * @default true
+   */
+  previews?: boolean;
+}
+
+/**
+ * A dedicated Access application owned by this Worker — per-Worker
+ * policies without declaring the application yourself.
+ */
+export interface WorkerAccessApplication {
+  /**
+   * Policies gating access to this Worker — inline bodies, reusable
+   * `Cloudflare.Access.Policy` resources, or policy ids (see
+   * `ApplicationProps["policies"]`).
+   */
+  policies: NonNullable<ApplicationProps["policies"]>;
+  /** Display name for the application. Auto-generated when omitted. */
+  name?: string;
+  /** Session lifetime, e.g. `"24h"`. */
+  sessionDuration?: string;
+  /** Allowed identity-provider UUIDs. */
+  allowedIdps?: string[];
+  /** Skip the IdP picker when exactly one IdP is allowed. */
+  autoRedirectToIdentity?: boolean;
+  /** Show the application in the App Launcher dashboard. */
+  appLauncherVisible?: boolean;
+  /**
+   * Also protect the Worker's version preview URLs.
+   * @default true
+   */
+  previews?: boolean;
+}
+
+export class WorkerAccessIdentityError extends Data.TaggedError(
+  "WorkerAccessIdentityError",
+)<{
+  message: string;
+  cause?: unknown;
+}> {}
+
+/**
+ * The identity Cloudflare Access authenticated for the current request,
+ * as resolved by `ctx.access.getIdentity()`. Field names follow the wire
+ * format of Access's identity payload (snake_case); identity providers can
+ * attach additional fields, captured by the index signature.
+ */
+export interface WorkerAccessIdentity {
+  /** The user's email address, if the identity provider supplies one. */
+  readonly email?: string;
+  /** The user's display name. */
+  readonly name?: string;
+  /** The user's unique identifier. */
+  readonly user_uuid?: string;
+  /** The Cloudflare account id the Access organization belongs to. */
+  readonly account_id?: string;
+  /** Login timestamp (Unix epoch seconds). */
+  readonly iat?: number;
+  /** The user's IP address at authentication time. */
+  readonly ip?: string;
+  /** Authentication methods used (e.g. `"pwd"`). */
+  readonly amr?: string[];
+  /** Identity-provider information. */
+  readonly idp?: { id: string; type: string };
+  /** Where the user authenticated from. */
+  readonly geo?: { country: string };
+  /** Group memberships from the identity provider. */
+  readonly groups?: Array<{ id: string; name: string; email?: string }>;
+  /** Device posture check results, keyed by check id. */
+  readonly devicePosture?: Record<string, unknown>;
+  /** True when the user connected via Cloudflare WARP. */
+  readonly is_warp?: boolean;
+  /** True when the user is authenticated via Cloudflare Gateway. */
+  readonly is_gateway?: boolean;
+  /** Service-token client id, when authenticated via a service token. */
+  readonly service_token_id?: string;
+  /** True when the request authenticated with a service token. */
+  readonly service_token_status?: boolean;
+  readonly [key: string]: unknown;
+}
+
+/**
+ * Effect-native view of the Cloudflare Access runtime API on the execution
+ * context (`ctx.access`). Present only when the request was admitted by a
+ * Cloudflare Access policy (see the `access` prop on `Cloudflare.Worker`),
+ * or when simulated locally via the Worker's `dev.access` config.
+ */
+export interface WorkerExecutionContextAccess {
+  /** The Access application audience (AUD) tag that admitted this request. */
+  readonly aud: string;
+  /**
+   * Resolve the authenticated identity — email, name, groups, device
+   * posture, etc. Resolves `undefined` when Access has no identity for the
+   * request (e.g. some service-token flows).
+   */
+  getIdentity(): Effect.Effect<
+    WorkerAccessIdentity | undefined,
+    WorkerAccessIdentityError,
+    RuntimeContext
+  >;
+}
+
+/**
+ * The shape workerd exposes on `ctx.access` (typed locally — this package's
+ * workers-types predates it) and that the local dev simulation mirrors.
+ */
+interface RawAccessContext {
+  readonly aud: string;
+  getIdentity(): Promise<WorkerAccessIdentity | undefined>;
+}
+
+const makeAccessContext = (
+  raw: RawAccessContext,
+): WorkerExecutionContextAccess => ({
+  aud: raw.aud,
+  getIdentity: () =>
+    Effect.tryPromise({
+      try: () => raw.getIdentity(),
+      catch: (cause) =>
+        new WorkerAccessIdentityError({
+          message:
+            cause instanceof Error
+              ? cause.message
+              : "Unknown Access identity resolution error",
+          cause,
+        }),
+    }),
+});
+
+/** The env key `dev.access` is lowered into by the local worker provider. */
+export const DEV_ACCESS_ENV_KEY = "ALCHEMY_DEV_ACCESS";
+
+/**
+ * Resolve the current request's Access context: workerd's native
+ * `ctx.access` when the request came through Cloudflare Access, the
+ * `dev.access` simulation under `alchemy dev`, and `undefined` (an
+ * unauthenticated request) otherwise. Backs the `access` member of the
+ * per-event `WorkerExecutionContext`.
+ */
+export const resolveAccessContext = (
+  ctx: cf.ExecutionContext,
+  env: Record<string, unknown> | undefined,
+): WorkerExecutionContextAccess | undefined => {
+  // Deployed behind Access: workerd populates ctx.access natively.
+  const native = (ctx as cf.ExecutionContext & { access?: RawAccessContext })
+    .access;
+  if (native !== undefined) {
+    return makeAccessContext(native);
+  }
+  // Local dev: the Worker's `dev.access` config is lowered into an env
+  // binding; absent config simulates an unauthenticated request.
+  const dev = env?.[DEV_ACCESS_ENV_KEY] as
+    | { aud?: string; identity?: WorkerAccessIdentity }
+    | undefined;
+  if (dev !== undefined) {
+    return {
+      aud: dev.aud ?? "dev",
+      getIdentity: () => Effect.succeed(dev.identity),
+    };
+  }
+  return undefined;
+};

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerAccess.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerAccess.ts
@@ -15,7 +15,7 @@ import type { Application, ApplicationProps } from "../Access/Application.ts";
  *   Worker, created/updated/deleted with it. Access configuration
  *   (policies, session duration, IdPs) lives on applications, so
  *   per-Worker configuration means a per-Worker application — this form
- *   declares one for you (logical id `<WorkerId>Access`).
+ *   declares one for you, namespaced under the Worker (`<Worker>/Access`).
  *
  * Either way, enrolling pushes this Worker's `worker` destination (and a
  * `preview_worker` destination unless `previews: false`) onto the

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerAccess.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerAccess.ts
@@ -7,13 +7,15 @@ import type { Application, ApplicationProps } from "../Access/Application.ts";
 /**
  * Protect this Worker with Cloudflare Access (`access` prop). Two forms:
  *
- * - `{ application }` — enroll into a **shared** application (one policy
- *   set across several Workers).
- * - `{ policies }` — a **dedicated** application owned by this Worker,
- *   created/updated/deleted with it. Access configuration (policies,
- *   session duration, IdPs) lives on applications, so per-Worker
- *   configuration means a per-Worker application — this form declares one
- *   for you (logical id `<WorkerId>Access`).
+ * - a `Cloudflare.Access.Application` — enroll into a **shared**
+ *   application (one policy set across several Workers). Note Access
+ *   policies are application-wide: every Worker enrolled in the
+ *   application is gated by the same policies.
+ * - `{ policies, ... }` — a **dedicated** application owned by this
+ *   Worker, created/updated/deleted with it. Access configuration
+ *   (policies, session duration, IdPs) lives on applications, so
+ *   per-Worker configuration means a per-Worker application — this form
+ *   declares one for you (logical id `<WorkerId>Access`).
  *
  * Either way, enrolling pushes this Worker's `worker` destination (and a
  * `preview_worker` destination unless `previews: false`) onto the
@@ -22,20 +24,7 @@ import type { Application, ApplicationProps } from "../Access/Application.ts";
  * Removing the prop (or the Worker) un-enrolls it on the application's
  * next reconcile.
  */
-export type WorkerAccessConfig =
-  | WorkerAccessEnrollment
-  | WorkerAccessApplication;
-
-/** Enroll this Worker into a shared Access application. */
-export interface WorkerAccessEnrollment {
-  /** The `Cloudflare.Access.Application` to enroll into. */
-  application: Application;
-  /**
-   * Also protect the Worker's version preview URLs.
-   * @default true
-   */
-  previews?: boolean;
-}
+export type WorkerAccessConfig = Application | WorkerAccessApplication;
 
 /**
  * A dedicated Access application owned by this Worker — per-Worker

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
@@ -5,6 +5,7 @@ import type { InputProps } from "../../Input.ts";
 import * as Output from "../../Output.ts";
 import type { ResourceBinding } from "../../Resource.ts";
 import { isYieldableEffectLike } from "../../Util/effect.ts";
+import type { Application } from "../Access/Application.ts";
 import { isAiGateway } from "../AI/Gateway.ts";
 import { isSearchInstance } from "../AI/SearchInstance.ts";
 import { isSearchNamespace } from "../AI/SearchNamespace.ts";
@@ -59,6 +60,43 @@ export const bindWorkerAsyncBindings = Effect.fn(function* (
   resource: Worker,
   props: InputProps<WorkerProps<WorkerBindingProps>>,
 ) {
+  // Access enrollment (`access` prop): push this Worker's
+  // `worker`/`preview_worker` destinations onto the application's binding
+  // contract. The application deploys with — and converges on — every
+  // enrolled Worker's destinations, including at create time, where
+  // Cloudflare requires a self-hosted app to be born with a domain or
+  // destinations.
+  if (props.access) {
+    const accessInput = props.access;
+    const access = (
+      isYieldableEffectLike(accessInput) && !Output.isOutput(accessInput)
+        ? yield* accessInput as Effect.Effect<unknown>
+        : accessInput
+    ) as { application: unknown; previews?: unknown };
+    // The application can be the declaration Effect (module-scope
+    // `const App = Cloudflare.Access.Application(...)`) or an
+    // already-yielded resource.
+    const application = (
+      isYieldableEffectLike(access.application) &&
+      !Output.isOutput(access.application)
+        ? yield* access.application as Effect.Effect<unknown>
+        : access.application
+    ) as Application;
+    const previews = access.previews !== false;
+    yield* application.bind(`access:${resource.FQN}`, {
+      destinations: [
+        { type: "worker", workerId: resource.scriptTag.as<string>() },
+        ...(previews
+          ? [
+              {
+                type: "preview_worker" as const,
+                workerId: resource.scriptTag.as<string>(),
+              },
+            ]
+          : []),
+      ],
+    });
+  }
   if (props.env) {
     for (const bindingName in props.env) {
       // @ts-expect-error

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
@@ -5,7 +5,7 @@ import type { InputProps } from "../../Input.ts";
 import * as Output from "../../Output.ts";
 import type { ResourceBinding } from "../../Resource.ts";
 import { isYieldableEffectLike } from "../../Util/effect.ts";
-import type { Application } from "../Access/Application.ts";
+import { Application } from "../Access/Application.ts";
 import { isAiGateway } from "../AI/Gateway.ts";
 import { isSearchInstance } from "../AI/SearchInstance.ts";
 import { isSearchNamespace } from "../AI/SearchNamespace.ts";
@@ -50,6 +50,7 @@ import {
   isSelfUrl,
   isWorker,
   type Worker,
+  type WorkerAccessConfig,
   type WorkerProps,
 } from "./Worker.ts";
 import type { WorkerBinding, WorkerBindingResource } from "./WorkerBinding.ts";
@@ -72,16 +73,28 @@ export const bindWorkerAsyncBindings = Effect.fn(function* (
       isYieldableEffectLike(accessInput) && !Output.isOutput(accessInput)
         ? yield* accessInput as Effect.Effect<unknown>
         : accessInput
-    ) as { application: unknown; previews?: unknown };
-    // The application can be the declaration Effect (module-scope
-    // `const App = Cloudflare.Access.Application(...)`) or an
-    // already-yielded resource.
-    const application = (
-      isYieldableEffectLike(access.application) &&
-      !Output.isOutput(access.application)
-        ? yield* access.application as Effect.Effect<unknown>
-        : access.application
-    ) as Application;
+    ) as InputProps<WorkerAccessConfig>;
+    const application =
+      "application" in access
+        ? // Shared form: the application can be the declaration Effect
+          // (module-scope `const App = Cloudflare.Access.Application(...)`)
+          // or an already-yielded resource.
+          ((isYieldableEffectLike(access.application) &&
+          !Output.isOutput(access.application)
+            ? yield* access.application as Effect.Effect<unknown>
+            : access.application) as Application)
+        : // Dedicated form: declare an application owned by this Worker —
+          // per-Worker Access configuration means a per-Worker application
+          // (Cloudflare attaches policies to applications, not Workers).
+          yield* Application(`${resource.LogicalId}Access`, {
+            type: "self_hosted",
+            name: access.name,
+            policies: access.policies,
+            sessionDuration: access.sessionDuration,
+            allowedIdps: access.allowedIdps,
+            autoRedirectToIdentity: access.autoRedirectToIdentity,
+            appLauncherVisible: access.appLauncherVisible,
+          });
     const previews = access.previews !== false;
     yield* application.bind(`access:${resource.FQN}`, {
       destinations: [

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
@@ -5,6 +5,7 @@ import type { InputProps } from "../../Input.ts";
 import * as Output from "../../Output.ts";
 import type { ResourceBinding } from "../../Resource.ts";
 import * as Namespace from "../../Namespace.ts";
+import { defaultProviderMode } from "../../ProviderMode.ts";
 import { isYieldableEffectLike } from "../../Util/effect.ts";
 import {
   Application,
@@ -72,7 +73,13 @@ export const bindWorkerAsyncBindings = Effect.fn(function* (
   // enrolled Worker's destinations, including at create time, where
   // Cloudflare requires a self-hosted app to be born with a domain or
   // destinations.
-  if (props.access) {
+  //
+  // Skipped when this Worker runs locally (`alchemy dev`): a local worker
+  // has no cloud script (no immutable ID to enroll), and Access cannot
+  // front a localhost URL — the `dev.access` stub covers the runtime
+  // instead. A Worker opted out via `Alchemy.remote()` enrolls normally.
+  const accessHostMode = resource.Mode ?? (yield* defaultProviderMode);
+  if (props.access && accessHostMode !== "local") {
     const accessInput = props.access;
     // The shared form is the application itself — as the module-scope
     // declaration Effect (`const App = Cloudflare.Access.Application(...)`)
@@ -101,12 +108,12 @@ export const bindWorkerAsyncBindings = Effect.fn(function* (
     const previews = isApplication(access) || access.previews !== false;
     yield* application.bind(`enroll:${resource.FQN}`, {
       destinations: [
-        { type: "worker", workerId: resource.scriptTag.as<string>() },
+        { type: "worker", workerId: resource.workerId.as<string>() },
         ...(previews
           ? [
               {
                 type: "preview_worker" as const,
-                workerId: resource.scriptTag.as<string>(),
+                workerId: resource.workerId.as<string>(),
               },
             ]
           : []),

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
@@ -108,12 +108,12 @@ export const bindWorkerAsyncBindings = Effect.fn(function* (
     const previews = isApplication(access) || access.previews !== false;
     yield* application.bind(`enroll:${resource.FQN}`, {
       destinations: [
-        { type: "worker", workerId: resource.workerId.as<string>() },
+        { type: "worker", workerId: resource.workerId },
         ...(previews
           ? [
               {
                 type: "preview_worker" as const,
-                workerId: resource.workerId.as<string>(),
+                workerId: resource.workerId,
               },
             ]
           : []),

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
@@ -5,7 +5,11 @@ import type { InputProps } from "../../Input.ts";
 import * as Output from "../../Output.ts";
 import type { ResourceBinding } from "../../Resource.ts";
 import { isYieldableEffectLike } from "../../Util/effect.ts";
-import { Application } from "../Access/Application.ts";
+import {
+  Application,
+  isApplication,
+  type Application as AccessApplication,
+} from "../Access/Application.ts";
 import { isAiGateway } from "../AI/Gateway.ts";
 import { isSearchInstance } from "../AI/SearchInstance.ts";
 import { isSearchNamespace } from "../AI/SearchNamespace.ts";
@@ -52,7 +56,7 @@ import {
   type Worker,
   type WorkerProps,
 } from "./Worker.ts";
-import type { WorkerAccessConfig } from "./WorkerAccess.ts";
+import type { WorkerAccessApplication } from "./WorkerAccess.ts";
 import type { WorkerBinding, WorkerBindingResource } from "./WorkerBinding.ts";
 import { isWorkerEntrypoint } from "./WorkerEntrypoint.ts";
 import { isWorkerLoader } from "./WorkerLoader.ts";
@@ -69,33 +73,30 @@ export const bindWorkerAsyncBindings = Effect.fn(function* (
   // destinations.
   if (props.access) {
     const accessInput = props.access;
+    // The shared form is the application itself — as the module-scope
+    // declaration Effect (`const App = Cloudflare.Access.Application(...)`)
+    // or an already-yielded resource. Resolve the yieldable spelling first,
+    // then discriminate.
     const access = (
       isYieldableEffectLike(accessInput) && !Output.isOutput(accessInput)
         ? yield* accessInput as Effect.Effect<unknown>
         : accessInput
-    ) as InputProps<WorkerAccessConfig>;
-    const application =
-      "application" in access
-        ? // Shared form: the application can be the declaration Effect
-          // (module-scope `const App = Cloudflare.Access.Application(...)`)
-          // or an already-yielded resource.
-          ((isYieldableEffectLike(access.application) &&
-          !Output.isOutput(access.application)
-            ? yield* access.application as Effect.Effect<unknown>
-            : access.application) as Application)
-        : // Dedicated form: declare an application owned by this Worker —
-          // per-Worker Access configuration means a per-Worker application
-          // (Cloudflare attaches policies to applications, not Workers).
-          yield* Application(`${resource.LogicalId}Access`, {
-            type: "self_hosted",
-            name: access.name,
-            policies: access.policies,
-            sessionDuration: access.sessionDuration,
-            allowedIdps: access.allowedIdps,
-            autoRedirectToIdentity: access.autoRedirectToIdentity,
-            appLauncherVisible: access.appLauncherVisible,
-          });
-    const previews = access.previews !== false;
+    ) as AccessApplication | InputProps<WorkerAccessApplication>;
+    const application = isApplication(access)
+      ? access
+      : // Dedicated form: declare an application owned by this Worker —
+        // per-Worker Access configuration means a per-Worker application
+        // (Cloudflare attaches policies to applications, not Workers).
+        yield* Application(`${resource.LogicalId}Access`, {
+          type: "self_hosted",
+          name: access.name,
+          policies: access.policies,
+          sessionDuration: access.sessionDuration,
+          allowedIdps: access.allowedIdps,
+          autoRedirectToIdentity: access.autoRedirectToIdentity,
+          appLauncherVisible: access.appLauncherVisible,
+        });
+    const previews = isApplication(access) || access.previews !== false;
     yield* application.bind(`access:${resource.FQN}`, {
       destinations: [
         { type: "worker", workerId: resource.scriptTag.as<string>() },

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
@@ -4,6 +4,7 @@ import type { Json } from "effect/Schema";
 import type { InputProps } from "../../Input.ts";
 import * as Output from "../../Output.ts";
 import type { ResourceBinding } from "../../Resource.ts";
+import * as Namespace from "../../Namespace.ts";
 import { isYieldableEffectLike } from "../../Util/effect.ts";
 import {
   Application,
@@ -86,8 +87,9 @@ export const bindWorkerAsyncBindings = Effect.fn(function* (
       ? access
       : // Dedicated form: declare an application owned by this Worker —
         // per-Worker Access configuration means a per-Worker application
-        // (Cloudflare attaches policies to applications, not Workers).
-        yield* Application(`${resource.LogicalId}Access`, {
+        // (Cloudflare attaches policies to applications, not Workers). It
+        // lives in the Worker's namespace: `<Worker>/Access`.
+        yield* Application("Access", {
           type: "self_hosted",
           name: access.name,
           policies: access.policies,
@@ -95,9 +97,9 @@ export const bindWorkerAsyncBindings = Effect.fn(function* (
           allowedIdps: access.allowedIdps,
           autoRedirectToIdentity: access.autoRedirectToIdentity,
           appLauncherVisible: access.appLauncherVisible,
-        });
+        }).pipe(Namespace.push(resource.LogicalId));
     const previews = isApplication(access) || access.previews !== false;
-    yield* application.bind(`access:${resource.FQN}`, {
+    yield* application.bind(`enroll:${resource.FQN}`, {
       destinations: [
         { type: "worker", workerId: resource.scriptTag.as<string>() },
         ...(previews

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
@@ -50,9 +50,9 @@ import {
   isSelfUrl,
   isWorker,
   type Worker,
-  type WorkerAccessConfig,
   type WorkerProps,
 } from "./Worker.ts";
+import type { WorkerAccessConfig } from "./WorkerAccess.ts";
 import type { WorkerBinding, WorkerBindingResource } from "./WorkerBinding.ts";
 import { isWorkerEntrypoint } from "./WorkerEntrypoint.ts";
 import { isWorkerLoader } from "./WorkerLoader.ts";

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerBridge.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerBridge.ts
@@ -81,6 +81,7 @@ export const makeWorkerBridge = (
       build: WorkerBuild,
     ) => readonly [Effect.Effect<any, any, any>, Context.Context<never>],
     ctx: cf.ExecutionContext,
+    env: Record<string, unknown> | undefined,
     onExit: (
       exit: Exit.Exit<any, any>,
       scope: Scope.Closeable,
@@ -103,7 +104,7 @@ export const makeWorkerBridge = (
               Layer.mergeAll(
                 Layer.succeed(
                   WorkerExecutionContext,
-                  fromExecutionContext(ctx),
+                  fromExecutionContext(ctx, env),
                 ),
                 Layer.succeed(Scope.Scope, scope),
                 // The configured telemetry exporters. Constructed as part
@@ -160,6 +161,7 @@ export const makeWorkerBridge = (
                 Context.Context<never>,
               ],
             this.ctx,
+            this.env,
             (exit) =>
               exit._tag === "Success"
                 ? Promise.resolve(exit.value)
@@ -203,6 +205,7 @@ export const makeWorkerBridge = (
                 ] as const;
               },
               this.ctx,
+              this.env,
               handleRpcExit,
             );
         },

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -2905,6 +2905,9 @@ export const LiveWorkerProvider = () =>
         return {
           workerId: parentName,
           workerName: parentName,
+          // A version worker never owns a script; protect its preview URLs
+          // through the parent Worker's scriptTag instead.
+          scriptTag: undefined,
           namespace: undefined,
           logpush: undefined,
           url: urls[0],
@@ -3459,7 +3462,12 @@ export const LiveWorkerProvider = () =>
         const rolloutTraffic = getSelfRolloutTraffic(news);
         let versionId: string | undefined;
         let deploymentId: string | undefined;
-        let worker: { id?: string | null; logpush?: boolean | null };
+        let worker: {
+          id?: string | null;
+          logpush?: boolean | null;
+          /** The immutable script id (Cloudflare's script "tag"). */
+          tag?: string | null;
+        };
         // A gradual rollout (`version.traffic` < 100) deploys through the
         // versions API instead of the full-cutover script PUT. That's only
         // possible when the script already has a live deployment to split
@@ -3618,6 +3626,7 @@ export const LiveWorkerProvider = () =>
           return {
             workerId: worker.id ?? name,
             workerName: name,
+            scriptTag: worker.tag ?? output?.scriptTag,
             namespace: dispatchNamespace,
             logpush: worker.logpush ?? undefined,
             url: undefined,
@@ -3865,6 +3874,10 @@ export const LiveWorkerProvider = () =>
         return {
           workerId: worker.id ?? name,
           workerName: name,
+          // The gradual-rollout branch deploys via the versions API (no
+          // script PUT response); the immutable tag is stable, so the cached
+          // value carries over.
+          scriptTag: worker.tag ?? output?.scriptTag,
           namespace: undefined,
           logpush: worker.logpush ?? undefined,
           url: urls[0],
@@ -4067,7 +4080,7 @@ export const LiveWorkerProvider = () =>
       });
 
       return Worker.Provider.of({
-        stables: ["workerId", "workerName"],
+        stables: ["workerId", "workerName", "scriptTag"],
         list: () =>
           Effect.gen(function* () {
             const { accountId } = yield* yield* CloudflareEnvironment;
@@ -4104,6 +4117,7 @@ export const LiveWorkerProvider = () =>
                               accountId,
                               workerId: script.id,
                               workerName: script.id,
+                              scriptTag: script.tag ?? undefined,
                               namespace: undefined,
                               logpush: script.logpush ?? undefined,
                               url: undefined,
@@ -4296,7 +4310,9 @@ export const LiveWorkerProvider = () =>
             // `workerId` is always stable across an update; seed it so it
             // survives now that `diff.stables` overrides `provider.stables`
             // rather than being merged with it.
-            const stables: string[] = ["workerId"];
+            // `workerId` and the immutable script tag are always stable
+            // across an update.
+            const stables: string[] = ["workerId", "scriptTag"];
             if (oldWorkerName === workerName) {
               stables.push("workerName");
             }
@@ -4370,6 +4386,7 @@ export const LiveWorkerProvider = () =>
             return {
               workerId: name,
               workerName: name,
+              scriptTag: undefined,
               namespace: undefined,
               logpush: undefined,
               url: undefined,
@@ -4397,6 +4414,9 @@ export const LiveWorkerProvider = () =>
             return {
               workerId: name,
               workerName: name,
+              // The placeholder upload's tag isn't captured; reconcile's
+              // full deploy records the real immutable id right after.
+              scriptTag: undefined,
               namespace:
                 typeof news.namespace === "string" ? news.namespace : undefined,
               logpush: undefined,
@@ -4594,6 +4614,9 @@ export const LiveWorkerProvider = () =>
           return {
             workerId: name,
             workerName: name,
+            // The placeholder upload's tag isn't captured; reconcile's full
+            // deploy records the real immutable id right after.
+            scriptTag: undefined,
             namespace: dispatchNamespace,
             logpush: existingSettings?.logpush ?? undefined,
             url: undefined,
@@ -4661,6 +4684,9 @@ export const LiveWorkerProvider = () =>
                 accountId,
                 workerId: workerName,
                 workerName,
+                // Not observable from the settings endpoint; carry the
+                // cached immutable id forward (backfilled by deploys).
+                scriptTag: output?.scriptTag,
                 namespace: dispatchNamespace,
                 logpush: settings.logpush ?? undefined,
                 url: undefined,
@@ -4788,6 +4814,9 @@ export const LiveWorkerProvider = () =>
               accountId,
               workerId: workerName,
               workerName,
+              // Not observable from the settings endpoint; carry the cached
+              // immutable id forward (backfilled by deploys).
+              scriptTag: output?.scriptTag,
               namespace: undefined,
               logpush: settings.logpush ?? undefined,
               url: urls[0],

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -4356,7 +4356,14 @@ export const LiveWorkerProvider = () =>
             oldWorkerName === workerName &&
             newDoClassNames.length === oldDoClassNames.length &&
             newDoClassNames.every((name, i) => name === oldDoClassNames[i]);
+          // Rows persisted by older releases carried the script *name* in
+          // `workerId` (interrupted precreates a provisional ""). Plan one
+          // update even when nothing else changed, so reconcile re-records
+          // the immutable Worker ID.
+          const legacyWorkerId =
+            cachedWorkerId(output.workerId, output.workerName) === undefined;
           if (
+            legacyWorkerId ||
             domainsChanged ||
             routesChanged ||
             cronsChanged ||
@@ -4370,11 +4377,11 @@ export const LiveWorkerProvider = () =>
               accountId,
             ))
           ) {
-            // `workerId` is always stable across an update; seed it so it
-            // survives now that `diff.stables` overrides `provider.stables`
-            // rather than being merged with it.
-            // The immutable script ID is always stable across an update.
-            const stables: string[] = ["workerId"];
+            // The immutable script ID is always stable across an update —
+            // except the healing update above, where its value is about to
+            // change from the legacy shape to the real ID (downstream
+            // consumers must see the fresh value).
+            const stables: string[] = legacyWorkerId ? [] : ["workerId"];
             if (oldWorkerName === workerName) {
               stables.push("workerName");
             }

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -703,6 +703,19 @@ const retryableScriptPut = (
  *
  * @internal
  */
+/**
+ * Resolve a script's immutable ID (Cloudflare's script "tag") by name.
+ * Neither the settings endpoints nor GET /content expose it, so scan the
+ * account's script listing lazily and stop at the first match.
+ */
+const findScriptTag = (accountId: string, scriptName: string) =>
+  workers.listScripts.items({ accountId }).pipe(
+    Stream.filter((script) => script.id === scriptName),
+    Stream.runHead,
+    Effect.map(Option.getOrUndefined),
+    Effect.map((script) => script?.tag ?? undefined),
+  );
+
 const putWorkerScript = (params: {
   accountId: string;
   scriptName: string;
@@ -2904,11 +2917,14 @@ export const LiveWorkerProvider = () =>
           ...(versionedUrl ? [versionedUrl] : []),
         ];
         return {
-          workerId: parentName,
+          // A version worker never owns a script — carry the *parent*
+          // script's immutable ID (its preview URLs are protected through
+          // the parent).
+          workerId:
+            output?.workerId !== undefined && output.workerId !== parentName
+              ? output.workerId
+              : yield* findScriptTag(accountId, parentName),
           workerName: parentName,
-          // A version worker never owns a script; protect its preview URLs
-          // through the parent Worker's scriptTag instead.
-          scriptTag: undefined,
           namespace: undefined,
           logpush: undefined,
           url: urls[0],
@@ -3625,9 +3641,10 @@ export const LiveWorkerProvider = () =>
         // reconciliation.
         if (dispatchNamespace) {
           return {
-            workerId: worker.id ?? name,
+            workerId:
+              worker.tag ??
+              (output?.workerId !== name ? output?.workerId : undefined),
             workerName: name,
-            scriptTag: worker.tag ?? output?.scriptTag,
             namespace: dispatchNamespace,
             logpush: worker.logpush ?? undefined,
             url: undefined,
@@ -3873,12 +3890,16 @@ export const LiveWorkerProvider = () =>
             ? yield* reconcileCrons(name, desiredCrons, previousCrons, session)
             : [];
         return {
-          workerId: worker.id ?? name,
+          // The immutable script ID. The gradual-rollout branch deploys via
+          // the versions API (no script PUT response), and rows persisted by
+          // older releases carried the script *name* here — both fall back
+          // to a lazy listing lookup.
+          workerId:
+            worker.tag ??
+            (output?.workerId !== undefined && output.workerId !== name
+              ? output.workerId
+              : yield* findScriptTag(accountId, name)),
           workerName: name,
-          // The gradual-rollout branch deploys via the versions API (no
-          // script PUT response); the immutable tag is stable, so the cached
-          // value carries over.
-          scriptTag: worker.tag ?? output?.scriptTag,
           namespace: undefined,
           logpush: worker.logpush ?? undefined,
           url: urls[0],
@@ -4081,7 +4102,7 @@ export const LiveWorkerProvider = () =>
       });
 
       return Worker.Provider.of({
-        stables: ["workerId", "workerName", "scriptTag"],
+        stables: ["workerId", "workerName"],
         list: () =>
           Effect.gen(function* () {
             const { accountId } = yield* yield* CloudflareEnvironment;
@@ -4116,9 +4137,8 @@ export const LiveWorkerProvider = () =>
                         ? [
                             {
                               accountId,
-                              workerId: script.id,
+                              workerId: script.tag ?? undefined,
                               workerName: script.id,
-                              scriptTag: script.tag ?? undefined,
                               namespace: undefined,
                               logpush: script.logpush ?? undefined,
                               url: undefined,
@@ -4311,9 +4331,8 @@ export const LiveWorkerProvider = () =>
             // `workerId` is always stable across an update; seed it so it
             // survives now that `diff.stables` overrides `provider.stables`
             // rather than being merged with it.
-            // `workerId` and the immutable script tag are always stable
-            // across an update.
-            const stables: string[] = ["workerId", "scriptTag"];
+            // The immutable script ID is always stable across an update.
+            const stables: string[] = ["workerId"];
             if (oldWorkerName === workerName) {
               stables.push("workerName");
             }
@@ -4385,9 +4404,8 @@ export const LiveWorkerProvider = () =>
               `Cloudflare Worker precreate: skipping stub for version worker ${id}`,
             );
             return {
-              workerId: name,
+              workerId: undefined,
               workerName: name,
-              scriptTag: undefined,
               namespace: undefined,
               logpush: undefined,
               url: undefined,
@@ -4413,11 +4431,8 @@ export const LiveWorkerProvider = () =>
               `Cloudflare Worker precreate: skipping stub for dispatch-namespace worker ${name}`,
             );
             return {
-              workerId: name,
+              workerId: undefined,
               workerName: name,
-              // The placeholder upload's tag isn't captured; reconcile's
-              // full deploy records the real immutable id right after.
-              scriptTag: undefined,
               namespace:
                 typeof news.namespace === "string" ? news.namespace : undefined,
               logpush: undefined,
@@ -4613,11 +4628,10 @@ export const LiveWorkerProvider = () =>
           }
 
           return {
-            workerId: name,
+            // The placeholder upload's tag isn't captured here; reconcile's
+            // full deploy records the immutable ID right after.
+            workerId: undefined,
             workerName: name,
-            // The placeholder upload's tag isn't captured; reconcile's full
-            // deploy records the real immutable id right after.
-            scriptTag: undefined,
             namespace: dispatchNamespace,
             logpush: existingSettings?.logpush ?? undefined,
             url: undefined,
@@ -4683,11 +4697,15 @@ export const LiveWorkerProvider = () =>
               );
               const attrs = {
                 accountId,
-                workerId: workerName,
-                workerName,
                 // Not observable from the settings endpoint; carry the
-                // cached immutable id forward (backfilled by deploys).
-                scriptTag: output?.scriptTag,
+                // cached immutable ID forward (rows persisted by older
+                // releases carried the script name — treat those as
+                // unknown; the next deploy heals them).
+                workerId:
+                  output?.workerId !== workerName
+                    ? output?.workerId
+                    : undefined,
+                workerName,
                 namespace: dispatchNamespace,
                 logpush: settings.logpush ?? undefined,
                 url: undefined,
@@ -4813,11 +4831,15 @@ export const LiveWorkerProvider = () =>
             );
             const attrs = {
               accountId,
-              workerId: workerName,
+              // The settings endpoint doesn't expose the immutable ID;
+              // reuse the cached value, falling back to a lazy listing
+              // lookup for unknown/legacy rows (older releases persisted
+              // the script *name* here) so adoption records the real ID.
+              workerId:
+                output?.workerId !== undefined && output.workerId !== workerName
+                  ? output.workerId
+                  : yield* findScriptTag(accountId, workerName),
               workerName,
-              // Not observable from the settings endpoint; carry the cached
-              // immutable id forward (backfilled by deploys).
-              scriptTag: output?.scriptTag,
               namespace: undefined,
               logpush: settings.logpush ?? undefined,
               url: urls[0],

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -704,16 +704,52 @@ const retryableScriptPut = (
  * @internal
  */
 /**
+ * A cached `workerId` attribute usable as the immutable script ID — rules
+ * out the legacy shape (older releases persisted the script *name*), the
+ * `dev:`-marked local identity, and the precreate stub's provisional `""`.
+ */
+const cachedWorkerId = (
+  value: string | undefined,
+  scriptName: string,
+): string | undefined =>
+  value !== undefined &&
+  value !== "" &&
+  value !== scriptName &&
+  !value.startsWith("dev:")
+    ? value
+    : undefined;
+
+export class ScriptTagNotFound extends Data.TaggedError("ScriptTagNotFound")<{
+  scriptName: string;
+  message: string;
+}> {}
+
+/**
  * Resolve a script's immutable ID (Cloudflare's script "tag") by name.
  * Neither the settings endpoints nor GET /content expose it, so scan the
- * account's script listing lazily and stop at the first match.
+ * account's script listing lazily and stop at the first match. The listing
+ * is eventually consistent, so a missing entry is retried briefly before
+ * failing.
  */
 const findScriptTag = (accountId: string, scriptName: string) =>
   workers.listScripts.items({ accountId }).pipe(
     Stream.filter((script) => script.id === scriptName),
     Stream.runHead,
     Effect.map(Option.getOrUndefined),
-    Effect.map((script) => script?.tag ?? undefined),
+    Effect.flatMap((script) =>
+      script?.tag != null
+        ? Effect.succeed(script.tag)
+        : Effect.fail(
+            new ScriptTagNotFound({
+              scriptName,
+              message: `Cloudflare Worker: could not resolve the immutable ID of script '${scriptName}' from the account listing`,
+            }),
+          ),
+    ),
+    Effect.retry({
+      while: (e) => e._tag === "ScriptTagNotFound",
+      schedule: Schedule.max([Schedule.spaced(2000), Schedule.recurs(3)]),
+    }),
   );
 
 const putWorkerScript = (params: {
@@ -2921,9 +2957,8 @@ export const LiveWorkerProvider = () =>
           // script's immutable ID (its preview URLs are protected through
           // the parent).
           workerId:
-            output?.workerId !== undefined && output.workerId !== parentName
-              ? output.workerId
-              : yield* findScriptTag(accountId, parentName),
+            cachedWorkerId(output?.workerId, parentName) ??
+            (yield* findScriptTag(accountId, parentName)),
           workerName: parentName,
           namespace: undefined,
           logpush: undefined,
@@ -3643,7 +3678,13 @@ export const LiveWorkerProvider = () =>
           return {
             workerId:
               worker.tag ??
-              (output?.workerId !== name ? output?.workerId : undefined),
+              cachedWorkerId(output?.workerId, name) ??
+              (yield* Effect.fail(
+                new ScriptTagNotFound({
+                  scriptName: name,
+                  message: `Cloudflare Worker: the dispatch-namespace upload for '${name}' did not return the script's immutable ID`,
+                }),
+              )),
             workerName: name,
             namespace: dispatchNamespace,
             logpush: worker.logpush ?? undefined,
@@ -3896,9 +3937,8 @@ export const LiveWorkerProvider = () =>
           // to a lazy listing lookup.
           workerId:
             worker.tag ??
-            (output?.workerId !== undefined && output.workerId !== name
-              ? output.workerId
-              : yield* findScriptTag(accountId, name)),
+            cachedWorkerId(output?.workerId, name) ??
+            (yield* findScriptTag(accountId, name)),
           workerName: name,
           namespace: undefined,
           logpush: worker.logpush ?? undefined,
@@ -4137,7 +4177,9 @@ export const LiveWorkerProvider = () =>
                         ? [
                             {
                               accountId,
-                              workerId: script.tag ?? undefined,
+                              // Practically always present; an empty value
+                              // is healed by the per-script read.
+                              workerId: script.tag ?? "",
                               workerName: script.id,
                               namespace: undefined,
                               logpush: script.logpush ?? undefined,
@@ -4404,7 +4446,10 @@ export const LiveWorkerProvider = () =>
               `Cloudflare Worker precreate: skipping stub for version worker ${id}`,
             );
             return {
-              workerId: undefined,
+              // Provisional: a version worker resolves its parent's
+              // immutable ID at reconcile — nothing observes this stub row
+              // (version workers have no circular bindings).
+              workerId: "",
               workerName: name,
               namespace: undefined,
               logpush: undefined,
@@ -4431,7 +4476,10 @@ export const LiveWorkerProvider = () =>
               `Cloudflare Worker precreate: skipping stub for dispatch-namespace worker ${name}`,
             );
             return {
-              workerId: undefined,
+              // Provisional: reconcile records the real immutable ID from
+              // the dispatch upload — nothing observes this stub row (user
+              // workers are dispatched by name, never bound circularly).
+              workerId: "",
               workerName: name,
               namespace:
                 typeof news.namespace === "string" ? news.namespace : undefined,
@@ -4527,6 +4575,7 @@ export const LiveWorkerProvider = () =>
             existingSettings?.bindings,
           );
 
+          let placeholder: { tag?: string | null } | undefined;
           if (existingSettings) {
             // Engine has already cleared this resource for write via
             // `read` + AdoptPolicy. Either we own it (matching tags) or
@@ -4544,7 +4593,7 @@ export const LiveWorkerProvider = () =>
                   `export class ${className} extends DurableObject {}`,
               )
               .join("\n")}`;
-            yield* putWorkerScript({
+            placeholder = yield* putWorkerScript({
               accountId,
               scriptName: name,
               dispatchNamespace,
@@ -4628,9 +4677,11 @@ export const LiveWorkerProvider = () =>
           }
 
           return {
-            // The placeholder upload's tag isn't captured here; reconcile's
-            // full deploy records the immutable ID right after.
-            workerId: undefined,
+            // The placeholder upload's tag (or, when adopting an existing
+            // script, the listing lookup); reconcile re-records it after
+            // the full deploy.
+            workerId:
+              placeholder?.tag ?? (yield* findScriptTag(accountId, name)),
             workerName: name,
             namespace: dispatchNamespace,
             logpush: existingSettings?.logpush ?? undefined,
@@ -4697,14 +4748,29 @@ export const LiveWorkerProvider = () =>
               );
               const attrs = {
                 accountId,
-                // Not observable from the settings endpoint; carry the
-                // cached immutable ID forward (rows persisted by older
-                // releases carried the script name — treat those as
-                // unknown; the next deploy heals them).
+                // Rows persisted by older releases carried the script name
+                // here — treat those as unknown and fetch the real ID from
+                // the dispatch-namespace script endpoint.
                 workerId:
-                  output?.workerId !== workerName
-                    ? output?.workerId
-                    : undefined,
+                  cachedWorkerId(output?.workerId, workerName) ??
+                  (yield* wfp
+                    .getDispatchNamespaceScript({
+                      accountId,
+                      dispatchNamespace,
+                      scriptName: workerName,
+                    })
+                    .pipe(
+                      Effect.flatMap((r) =>
+                        r.script?.tag != null
+                          ? Effect.succeed(r.script.tag)
+                          : Effect.fail(
+                              new ScriptTagNotFound({
+                                scriptName: workerName,
+                                message: `Cloudflare Worker: dispatch-namespace script '${workerName}' has no immutable ID in its metadata`,
+                              }),
+                            ),
+                      ),
+                    )),
                 workerName,
                 namespace: dispatchNamespace,
                 logpush: settings.logpush ?? undefined,
@@ -4836,9 +4902,8 @@ export const LiveWorkerProvider = () =>
               // lookup for unknown/legacy rows (older releases persisted
               // the script *name* here) so adoption records the real ID.
               workerId:
-                output?.workerId !== undefined && output.workerId !== workerName
-                  ? output.workerId
-                  : yield* findScriptTag(accountId, workerName),
+                cachedWorkerId(output?.workerId, workerName) ??
+                (yield* findScriptTag(accountId, workerName)),
               workerName,
               namespace: undefined,
               logpush: settings.logpush ?? undefined,

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -2632,6 +2632,7 @@ export const LiveWorkerProvider = () =>
             ["placement", news.placement],
             ["limits", news.limits],
             ["workersDev", news.workersDev],
+            ["access", news.access],
             ["vite", news.vite],
           ] as const
         ).flatMap(([key, value]) => (value !== undefined ? [key] : []));

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -719,19 +719,19 @@ const cachedWorkerId = (
     ? value
     : undefined;
 
-export class ScriptTagNotFound extends Data.TaggedError("ScriptTagNotFound")<{
+export class WorkerIdNotFound extends Data.TaggedError("WorkerIdNotFound")<{
   scriptName: string;
   message: string;
 }> {}
 
 /**
- * Resolve a script's immutable ID (Cloudflare's script "tag") by name.
- * Neither the settings endpoints nor GET /content expose it, so scan the
- * account's script listing lazily and stop at the first match. The listing
- * is eventually consistent, so a missing entry is retried briefly before
- * failing.
+ * Resolve a script's immutable Worker ID (carried as `tag` on Cloudflare's
+ * wire) by script name. Neither the settings endpoints nor GET /content
+ * expose it, so scan the account's script listing lazily and stop at the
+ * first match. The listing is eventually consistent, so a missing entry is
+ * retried briefly before failing.
  */
-const findScriptTag = (accountId: string, scriptName: string) =>
+const findWorkerId = (accountId: string, scriptName: string) =>
   workers.listScripts.items({ accountId }).pipe(
     Stream.filter((script) => script.id === scriptName),
     Stream.runHead,
@@ -740,14 +740,14 @@ const findScriptTag = (accountId: string, scriptName: string) =>
       script?.tag != null
         ? Effect.succeed(script.tag)
         : Effect.fail(
-            new ScriptTagNotFound({
+            new WorkerIdNotFound({
               scriptName,
               message: `Cloudflare Worker: could not resolve the immutable ID of script '${scriptName}' from the account listing`,
             }),
           ),
     ),
     Effect.retry({
-      while: (e) => e._tag === "ScriptTagNotFound",
+      while: (e) => e._tag === "WorkerIdNotFound",
       schedule: Schedule.max([Schedule.spaced(2000), Schedule.recurs(3)]),
     }),
   );
@@ -2958,7 +2958,7 @@ export const LiveWorkerProvider = () =>
           // the parent).
           workerId:
             cachedWorkerId(output?.workerId, parentName) ??
-            (yield* findScriptTag(accountId, parentName)),
+            (yield* findWorkerId(accountId, parentName)),
           workerName: parentName,
           namespace: undefined,
           logpush: undefined,
@@ -3680,7 +3680,7 @@ export const LiveWorkerProvider = () =>
               worker.tag ??
               cachedWorkerId(output?.workerId, name) ??
               (yield* Effect.fail(
-                new ScriptTagNotFound({
+                new WorkerIdNotFound({
                   scriptName: name,
                   message: `Cloudflare Worker: the dispatch-namespace upload for '${name}' did not return the script's immutable ID`,
                 }),
@@ -3938,7 +3938,7 @@ export const LiveWorkerProvider = () =>
           workerId:
             worker.tag ??
             cachedWorkerId(output?.workerId, name) ??
-            (yield* findScriptTag(accountId, name)),
+            (yield* findWorkerId(accountId, name)),
           workerName: name,
           namespace: undefined,
           logpush: worker.logpush ?? undefined,
@@ -4681,7 +4681,7 @@ export const LiveWorkerProvider = () =>
             // script, the listing lookup); reconcile re-records it after
             // the full deploy.
             workerId:
-              placeholder?.tag ?? (yield* findScriptTag(accountId, name)),
+              placeholder?.tag ?? (yield* findWorkerId(accountId, name)),
             workerName: name,
             namespace: dispatchNamespace,
             logpush: existingSettings?.logpush ?? undefined,
@@ -4764,7 +4764,7 @@ export const LiveWorkerProvider = () =>
                         r.script?.tag != null
                           ? Effect.succeed(r.script.tag)
                           : Effect.fail(
-                              new ScriptTagNotFound({
+                              new WorkerIdNotFound({
                                 scriptName: workerName,
                                 message: `Cloudflare Worker: dispatch-namespace script '${workerName}' has no immutable ID in its metadata`,
                               }),
@@ -4903,7 +4903,7 @@ export const LiveWorkerProvider = () =>
               // the script *name* here) so adoption records the real ID.
               workerId:
                 cachedWorkerId(output?.workerId, workerName) ??
-                (yield* findScriptTag(accountId, workerName)),
+                (yield* findWorkerId(accountId, workerName)),
               workerName,
               namespace: undefined,
               logpush: settings.logpush ?? undefined,

--- a/packages/alchemy/src/Cloudflare/Workers/index.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/index.ts
@@ -35,6 +35,7 @@ export * from "./VersionMetadata.ts";
 export * from "./VersionMetadataBinding.ts";
 export * from "./WebSocket.ts";
 export * from "./Worker.ts";
+export * from "./WorkerAccess.ts";
 export * from "./WorkerBinding.ts";
 export * from "./WorkerBridge.ts";
 export * from "./WorkerEntrypoint.ts";

--- a/packages/alchemy/test/Cloudflare/Access/Application.test.ts
+++ b/packages/alchemy/test/Cloudflare/Access/Application.test.ts
@@ -418,3 +418,143 @@ test.provider(
       yield* stack.destroy();
     }).pipe(logLevel),
 );
+
+/** Structural view of live application policies for inline-policy asserts. */
+interface LiveInlineApp {
+  policies?: ReadonlyArray<{
+    id?: string | null;
+    decision?: string | null;
+    name?: string | null;
+    reusable?: boolean | null;
+    sessionDuration?: string | null;
+    include?: ReadonlyArray<unknown> | null;
+    exclude?: ReadonlyArray<unknown> | null;
+    require?: ReadonlyArray<unknown> | null;
+  }> | null;
+}
+
+test.provider(
+  "inline policies: scalar shorthand, update in place, switch to reusable, no mixing",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const domain = `alchemy-test-inline-policies.${zoneName}`;
+      const makeApp = (
+        policies: Cloudflare.Access.ApplicationProps["policies"],
+      ) =>
+        Effect.gen(function* () {
+          yield* Cloudflare.Zone.Zone("TestZone", { name: zoneName }).pipe(
+            AdoptPolicy.adopt(true),
+          );
+          return yield* Cloudflare.Access.Application("InlinePolicyApp", {
+            type: "self_hosted",
+            domain,
+            policies,
+          });
+        });
+
+      // v1 — one inline policy via scalar shorthand.
+      const first = yield* stack.deploy(
+        makeApp([
+          {
+            decision: "allow",
+            name: "primary",
+            include: [{ emailDomain: "example.com" }],
+          },
+        ]),
+      );
+      const live1 = (yield* zeroTrust.getAccessApplicationForAccount({
+        accountId,
+        appId: first.applicationId,
+      })) as unknown as LiveInlineApp;
+      expect(live1.policies?.length).toBe(1);
+      expect(live1.policies![0].reusable).toBe(false);
+      // Shorthand expanded to the wire shape on the way out.
+      expect(live1.policies![0].include).toEqual([
+        { emailDomain: { domain: "example.com" } },
+      ]);
+      const inlineId = live1.policies![0].id;
+      expect(inlineId).toBeDefined();
+
+      // v2 — mutate the same inline policy: more shorthand kinds, exclude,
+      // require, session duration. The policy must update IN PLACE (same
+      // id) — an id-less inline item in the update PUT would mint a fresh
+      // policy.
+      yield* stack.deploy(
+        makeApp([
+          {
+            decision: "allow",
+            name: "primary",
+            include: [{ emailDomain: "example.com" }, "everyone"],
+            exclude: [{ email: "intern@example.com" }],
+            require: [{ geo: "US" }],
+            sessionDuration: "12h",
+          },
+        ]),
+      );
+      const live2 = (yield* zeroTrust.getAccessApplicationForAccount({
+        accountId,
+        appId: first.applicationId,
+      })) as unknown as LiveInlineApp;
+      expect(live2.policies?.length).toBe(1);
+      expect(live2.policies![0].id).toBe(inlineId);
+      expect(live2.policies![0].include).toEqual([
+        { emailDomain: { domain: "example.com" } },
+        { everyone: {} },
+      ]);
+      expect(live2.policies![0].exclude).toEqual([
+        { email: { email: "intern@example.com" } },
+      ]);
+      expect(live2.policies![0].require).toEqual([
+        { geo: { countryCode: "US" } },
+      ]);
+      expect(live2.policies![0].sessionDuration).toBe("12h");
+
+      // v3 — switch the application from inline to a reusable Policy
+      // resource (passed directly).
+      const reusableProgram = Effect.gen(function* () {
+        yield* Cloudflare.Zone.Zone("TestZone", { name: zoneName }).pipe(
+          AdoptPolicy.adopt(true),
+        );
+        const reusable = yield* Cloudflare.Access.Policy("InlineSwapPolicy", {
+          name: "Reusable for inline-swap test",
+          decision: "allow",
+          include: [{ emailDomain: "example.com" }],
+        });
+        const app = yield* Cloudflare.Access.Application("InlinePolicyApp", {
+          type: "self_hosted",
+          domain,
+          policies: [reusable],
+        });
+        return { app, reusable };
+      });
+      const { reusable } = yield* stack.deploy(reusableProgram);
+      const live3 = (yield* zeroTrust.getAccessApplicationForAccount({
+        accountId,
+        appId: first.applicationId,
+      })) as unknown as LiveInlineApp;
+      expect(live3.policies?.length).toBe(1);
+      expect(live3.policies![0].id).toBe(reusable.policyId);
+      expect(live3.policies![0].reusable).toBe(true);
+
+      // Mixing inline and reusable forms on one application fails fast.
+      const mixed = yield* stack
+        .deploy(
+          makeApp([
+            reusable.policyId,
+            {
+              decision: "allow",
+              include: [{ emailDomain: "example.com" }],
+            },
+          ]),
+        )
+        .pipe(Effect.flip);
+      expect(String(mixed)).toMatch(/mix/i);
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 300_000 },
+);

--- a/packages/alchemy/test/Cloudflare/Access/WorkerApplication.test.ts
+++ b/packages/alchemy/test/Cloudflare/Access/WorkerApplication.test.ts
@@ -99,7 +99,7 @@ test.provider(
               Cloudflare.Access.Worker(worker),
               Cloudflare.Access.WorkerPreview(worker),
             ],
-            policies: [policy.policyId],
+            policies: [policy],
           });
           return { worker, app, policy };
         }),

--- a/packages/alchemy/test/Cloudflare/Access/WorkerApplication.test.ts
+++ b/packages/alchemy/test/Cloudflare/Access/WorkerApplication.test.ts
@@ -9,6 +9,7 @@ import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
 import OwnedAccessWorker from "./fixtures/access-owned-worker.ts";
+import SecondAccessWorker from "./fixtures/access-worker-b.ts";
 import AccessProtectedWorker, { App } from "./fixtures/access-worker.ts";
 
 const { test } = Test.make({ providers: Cloudflare.providers() });
@@ -246,6 +247,76 @@ test.provider(
         "Access for alchemy owned-app test",
       );
       expect(appAfter).toBeUndefined();
+    }).pipe(logLevel),
+  { timeout: 300_000 },
+);
+
+test.provider(
+  "a shared application merges enrollments from multiple Workers",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      // Two Workers enroll into the SAME application — worker B with
+      // `previews: false` (production traffic only).
+      const both = Effect.gen(function* () {
+        const a = yield* AccessProtectedWorker;
+        const b = yield* SecondAccessWorker;
+        const app = yield* App;
+        return { a, b, app };
+      });
+      const { a, b, app } = yield* stack.deploy(both);
+
+      const live = (yield* zeroTrust.getAccessApplicationForAccount({
+        accountId,
+        appId: app.applicationId,
+      })) as unknown as LiveApp;
+      const workerDestinations = (live.destinations ?? []).filter(
+        (d) => d.workerId === a.scriptTag || d.workerId === b.scriptTag,
+      );
+      expect(workerDestinations).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ type: "worker", workerId: a.scriptTag }),
+          expect.objectContaining({
+            type: "preview_worker",
+            workerId: a.scriptTag,
+          }),
+          expect.objectContaining({ type: "worker", workerId: b.scriptTag }),
+        ]),
+      );
+      // previews: false — no preview destination for worker B.
+      expect(workerDestinations).toHaveLength(3);
+
+      // Un-enrollment without destroy: remove worker B from the stack —
+      // its binding contribution disappears and the application converges
+      // to worker A's destinations only.
+      const onlyA = Effect.gen(function* () {
+        const a = yield* AccessProtectedWorker;
+        const app = yield* App;
+        return { a, app };
+      });
+      yield* stack.deploy(onlyA);
+      const liveAfter = (yield* zeroTrust.getAccessApplicationForAccount({
+        accountId,
+        appId: app.applicationId,
+      })) as unknown as LiveApp;
+      const remaining = (liveAfter.destinations ?? []).filter(
+        (d) => d.workerId === a.scriptTag || d.workerId === b.scriptTag,
+      );
+      expect(remaining).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ type: "worker", workerId: a.scriptTag }),
+          expect.objectContaining({
+            type: "preview_worker",
+            workerId: a.scriptTag,
+          }),
+        ]),
+      );
+      expect(remaining).toHaveLength(2);
+
+      yield* stack.destroy();
     }).pipe(logLevel),
   { timeout: 300_000 },
 );

--- a/packages/alchemy/test/Cloudflare/Access/WorkerApplication.test.ts
+++ b/packages/alchemy/test/Cloudflare/Access/WorkerApplication.test.ts
@@ -96,8 +96,8 @@ test.provider(
             type: "self_hosted",
             name: "Access for alchemy worker-destination test",
             destinations: [
-              Cloudflare.Access.worker(worker),
-              Cloudflare.Access.previewWorker(worker),
+              Cloudflare.Access.Worker(worker),
+              Cloudflare.Access.WorkerPreview(worker),
             ],
             policies: [policy.policyId],
           });

--- a/packages/alchemy/test/Cloudflare/Access/WorkerApplication.test.ts
+++ b/packages/alchemy/test/Cloudflare/Access/WorkerApplication.test.ts
@@ -222,18 +222,10 @@ test.provider(
       expect(app!.policies?.length).toBe(1);
       expect(app!.policies![0].decision).toBe("allow");
       expect(app!.policies![0].reusable).toBe(false);
-      expect(app!.destinations).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            type: "worker",
-            workerId: worker.scriptTag,
-          }),
-          expect.objectContaining({
-            type: "preview_worker",
-            workerId: worker.scriptTag,
-          }),
-        ]),
-      );
+      // `previews: false` — production destination only.
+      expect(app!.destinations).toEqual([
+        expect.objectContaining({ type: "worker", workerId: worker.scriptTag }),
+      ]);
 
       // Unauthenticated requests are intercepted.
       const location = yield* expectAccessLoginRedirect(worker.url!);
@@ -259,8 +251,7 @@ test.provider(
 
       yield* stack.destroy();
 
-      // Two Workers enroll into the SAME application — worker B with
-      // `previews: false` (production traffic only).
+      // Two Workers enroll into the SAME application.
       const both = Effect.gen(function* () {
         const a = yield* AccessProtectedWorker;
         const b = yield* SecondAccessWorker;
@@ -284,10 +275,13 @@ test.provider(
             workerId: a.scriptTag,
           }),
           expect.objectContaining({ type: "worker", workerId: b.scriptTag }),
+          expect.objectContaining({
+            type: "preview_worker",
+            workerId: b.scriptTag,
+          }),
         ]),
       );
-      // previews: false — no preview destination for worker B.
-      expect(workerDestinations).toHaveLength(3);
+      expect(workerDestinations).toHaveLength(4);
 
       // Un-enrollment without destroy: remove worker B from the stack —
       // its binding contribution disappears and the application converges

--- a/packages/alchemy/test/Cloudflare/Access/WorkerApplication.test.ts
+++ b/packages/alchemy/test/Cloudflare/Access/WorkerApplication.test.ts
@@ -1,0 +1,168 @@
+import * as Cloudflare from "@/Cloudflare";
+import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
+import * as Test from "@/Test/Alchemy";
+import * as zeroTrust from "@distilled.cloud/cloudflare/zero-trust";
+import { expect } from "alchemy-test";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+import * as Schedule from "effect/Schedule";
+import AccessProtectedWorker from "./fixtures/access-worker.ts";
+
+const { test } = Test.make({ providers: Cloudflare.providers() });
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+class NotYetProtected extends Data.TaggedError("NotYetProtected")<{
+  status: number;
+  location: string | null;
+  bodyExcerpt: string;
+}> {}
+
+/**
+ * Probe `url` without following redirects until Cloudflare Access
+ * intercepts it — a 302 to the team's `cloudflareaccess.com` login page.
+ * Freshly-deployed workers.dev URLs 404/530 briefly and then serve the
+ * open worker until the Access policy propagates, so every non-intercepted
+ * response is retried.
+ */
+const expectAccessLoginRedirect = (url: string) =>
+  Effect.gen(function* () {
+    const probe = Effect.tryPromise({
+      try: async (signal) => {
+        const res = await fetch(url, {
+          signal,
+          redirect: "manual",
+          cache: "no-store",
+        });
+        const location = res.headers.get("location");
+        if (
+          res.status === 302 &&
+          location !== null &&
+          location.includes("cloudflareaccess.com")
+        ) {
+          return location;
+        }
+        const body = await res.text();
+        throw new NotYetProtected({
+          status: res.status,
+          location,
+          bodyExcerpt: body.slice(0, 200),
+        });
+      },
+      catch: (e) =>
+        e instanceof NotYetProtected
+          ? e
+          : new NotYetProtected({
+              status: 0,
+              location: null,
+              bodyExcerpt: e instanceof Error ? e.message : String(e),
+            }),
+    });
+    return yield* probe.pipe(
+      Effect.retry({
+        while: (e) => e._tag === "NotYetProtected",
+        schedule: Schedule.max([
+          Schedule.min([
+            Schedule.exponential("1 second", 1.5),
+            Schedule.spaced("5 seconds"),
+          ]),
+          Schedule.recurs(24),
+        ]),
+      }),
+    );
+  });
+
+test.provider(
+  "protect a Worker with worker + preview_worker destinations",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const { worker, app, policy } = yield* stack.deploy(
+        Effect.gen(function* () {
+          const worker = yield* AccessProtectedWorker;
+          const policy = yield* Cloudflare.Access.Policy("AllowExample", {
+            name: "Allow example.com (worker access test)",
+            decision: "allow",
+            include: [{ emailDomain: { domain: "example.com" } }],
+          });
+          const app = yield* Cloudflare.Access.Application("WorkerAccessApp", {
+            type: "self_hosted",
+            name: "Access for alchemy worker-destination test",
+            destinations: [
+              Cloudflare.Access.worker(worker),
+              Cloudflare.Access.previewWorker(worker),
+            ],
+            policies: [policy.policyId],
+          });
+          return { worker, app, policy };
+        }),
+      );
+
+      // The Worker exposes its immutable script id, and the Access app's
+      // destinations resolved to it.
+      expect(worker.scriptTag).toBeDefined();
+      expect(worker.scriptTag!.length).toBeGreaterThan(0);
+      expect(app.applicationId).toBeDefined();
+      expect(app.aud.length).toBeGreaterThan(0);
+      expect(policy.policyId.length).toBeGreaterThan(0);
+      expect(app.destinations).toEqual(
+        expect.arrayContaining([
+          { type: "worker", workerId: worker.scriptTag },
+          { type: "preview_worker", workerId: worker.scriptTag },
+        ]),
+      );
+
+      // Out-of-band: Cloudflare recorded the worker destinations.
+      const live = yield* zeroTrust.getAccessApplicationForAccount({
+        accountId,
+        appId: app.applicationId,
+      });
+      const liveDestinations = (
+        live as unknown as {
+          destinations?: ReadonlyArray<{
+            type?: string | null;
+            workerId?: string | null;
+          }> | null;
+        }
+      ).destinations;
+      expect(liveDestinations).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "worker",
+            workerId: worker.scriptTag,
+          }),
+          expect.objectContaining({
+            type: "preview_worker",
+            workerId: worker.scriptTag,
+          }),
+        ]),
+      );
+
+      // The workers.dev URL is now behind Access: an unauthenticated
+      // request is redirected to the Access login page instead of reaching
+      // the worker.
+      const location = yield* expectAccessLoginRedirect(worker.url!);
+      expect(location).toContain("cloudflareaccess.com");
+
+      yield* stack.destroy();
+
+      // The application is gone.
+      const liveAfter = yield* zeroTrust
+        .getAccessApplicationForAccount({ accountId, appId: app.applicationId })
+        .pipe(
+          Effect.map(() => "still-exists" as const),
+          Effect.catchTag("AccessApplicationNotFound", () =>
+            Effect.succeed("gone" as const),
+          ),
+        );
+      expect(liveAfter).toBe("gone");
+    }).pipe(logLevel),
+  { timeout: 300_000 },
+);

--- a/packages/alchemy/test/Cloudflare/Access/WorkerApplication.test.ts
+++ b/packages/alchemy/test/Cloudflare/Access/WorkerApplication.test.ts
@@ -124,12 +124,12 @@ test.provider(
       // The Worker enrolled itself: worker + preview destinations keyed by
       // its immutable script id, contributed through the application's
       // binding contract.
-      expect(worker.scriptTag).toBeDefined();
+      expect(worker.workerId).toBeDefined();
       expect(app.destinations).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
             type: "worker",
-            workerId: worker.scriptTag,
+            workerId: worker.workerId,
           }),
         ]),
       );
@@ -137,11 +137,11 @@ test.provider(
         expect.arrayContaining([
           expect.objectContaining({
             type: "worker",
-            workerId: worker.scriptTag,
+            workerId: worker.workerId,
           }),
           expect.objectContaining({
             type: "preview_worker",
-            workerId: worker.scriptTag,
+            workerId: worker.workerId,
           }),
         ]),
       );
@@ -163,7 +163,7 @@ test.provider(
       expect(liveAfter.policies![0].id).toBe(inlinePolicyId);
       expect(
         (liveAfter.destinations ?? []).filter(
-          (d) => d.workerId === worker.scriptTag,
+          (d) => d.workerId === worker.workerId,
         ),
       ).toHaveLength(2);
 
@@ -224,7 +224,7 @@ test.provider(
       expect(app!.policies![0].reusable).toBe(false);
       // `previews: false` — production destination only.
       expect(app!.destinations).toEqual([
-        expect.objectContaining({ type: "worker", workerId: worker.scriptTag }),
+        expect.objectContaining({ type: "worker", workerId: worker.workerId }),
       ]);
 
       // Unauthenticated requests are intercepted.
@@ -265,19 +265,19 @@ test.provider(
         appId: app.applicationId,
       })) as unknown as LiveApp;
       const workerDestinations = (live.destinations ?? []).filter(
-        (d) => d.workerId === a.scriptTag || d.workerId === b.scriptTag,
+        (d) => d.workerId === a.workerId || d.workerId === b.workerId,
       );
       expect(workerDestinations).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ type: "worker", workerId: a.scriptTag }),
+          expect.objectContaining({ type: "worker", workerId: a.workerId }),
           expect.objectContaining({
             type: "preview_worker",
-            workerId: a.scriptTag,
+            workerId: a.workerId,
           }),
-          expect.objectContaining({ type: "worker", workerId: b.scriptTag }),
+          expect.objectContaining({ type: "worker", workerId: b.workerId }),
           expect.objectContaining({
             type: "preview_worker",
-            workerId: b.scriptTag,
+            workerId: b.workerId,
           }),
         ]),
       );
@@ -297,14 +297,14 @@ test.provider(
         appId: app.applicationId,
       })) as unknown as LiveApp;
       const remaining = (liveAfter.destinations ?? []).filter(
-        (d) => d.workerId === a.scriptTag || d.workerId === b.scriptTag,
+        (d) => d.workerId === a.workerId || d.workerId === b.workerId,
       );
       expect(remaining).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ type: "worker", workerId: a.scriptTag }),
+          expect.objectContaining({ type: "worker", workerId: a.workerId }),
           expect.objectContaining({
             type: "preview_worker",
-            workerId: a.scriptTag,
+            workerId: a.workerId,
           }),
         ]),
       );

--- a/packages/alchemy/test/Cloudflare/Access/WorkerApplication.test.ts
+++ b/packages/alchemy/test/Cloudflare/Access/WorkerApplication.test.ts
@@ -7,6 +7,8 @@ import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
+import * as Stream from "effect/Stream";
+import OwnedAccessWorker from "./fixtures/access-owned-worker.ts";
 import AccessProtectedWorker, { App } from "./fixtures/access-worker.ts";
 
 const { test } = Test.make({ providers: Cloudflare.providers() });
@@ -176,6 +178,74 @@ test.provider(
           ),
         );
       expect(gone).toBe("gone");
+    }).pipe(logLevel),
+  { timeout: 300_000 },
+);
+
+/** Find a live application by its exact display name, or undefined. */
+const findAppByName = (accountId: string, name: string) =>
+  zeroTrust.listAccessApplicationsForAccount.pages({ accountId }).pipe(
+    Stream.runCollect,
+    Effect.map((chunk) =>
+      Array.from(chunk)
+        .flatMap((page) => page.result ?? [])
+        .map(
+          (raw) => raw as unknown as LiveApp & { id?: string; name?: string },
+        )
+        .find((app) => app.name === name),
+    ),
+  );
+
+test.provider(
+  "access.policies declares a dedicated application owned by the Worker",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const { worker } = yield* stack.deploy(
+        Effect.gen(function* () {
+          const worker = yield* OwnedAccessWorker;
+          return { worker };
+        }),
+      );
+
+      // The dedicated application exists with the inline policy and this
+      // Worker's destinations — declared entirely from the `access` prop.
+      const app = yield* findAppByName(
+        accountId,
+        "Access for alchemy owned-app test",
+      );
+      expect(app).toBeDefined();
+      expect(app!.policies?.length).toBe(1);
+      expect(app!.policies![0].decision).toBe("allow");
+      expect(app!.policies![0].reusable).toBe(false);
+      expect(app!.destinations).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "worker",
+            workerId: worker.scriptTag,
+          }),
+          expect.objectContaining({
+            type: "preview_worker",
+            workerId: worker.scriptTag,
+          }),
+        ]),
+      );
+
+      // Unauthenticated requests are intercepted.
+      const location = yield* expectAccessLoginRedirect(worker.url!);
+      expect(location).toContain("cloudflareaccess.com");
+
+      yield* stack.destroy();
+
+      // The dedicated application is deleted with the Worker's stack.
+      const appAfter = yield* findAppByName(
+        accountId,
+        "Access for alchemy owned-app test",
+      );
+      expect(appAfter).toBeUndefined();
     }).pipe(logLevel),
   { timeout: 300_000 },
 );

--- a/packages/alchemy/test/Cloudflare/Access/WorkerApplication.test.ts
+++ b/packages/alchemy/test/Cloudflare/Access/WorkerApplication.test.ts
@@ -7,7 +7,7 @@ import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
-import AccessProtectedWorker from "./fixtures/access-worker.ts";
+import AccessProtectedWorker, { App } from "./fixtures/access-worker.ts";
 
 const { test } = Test.make({ providers: Cloudflare.providers() });
 
@@ -76,63 +76,61 @@ const expectAccessLoginRedirect = (url: string) =>
     );
   });
 
+/** Structural view of the live application for out-of-band assertions. */
+interface LiveApp {
+  destinations?: ReadonlyArray<{
+    type?: string | null;
+    workerId?: string | null;
+  }> | null;
+  policies?: ReadonlyArray<{
+    id?: string | null;
+    decision?: string | null;
+    reusable?: boolean | null;
+  }> | null;
+}
+
 test.provider(
-  "protect a Worker with worker + preview_worker destinations",
+  "the access prop enrolls a Worker into an Access application with inline policies",
   (stack) =>
     Effect.gen(function* () {
       const { accountId } = yield* yield* CloudflareEnvironment;
 
       yield* stack.destroy();
 
-      const { worker, app, policy } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const worker = yield* AccessProtectedWorker;
-          const policy = yield* Cloudflare.Access.Policy("AllowExample", {
-            name: "Allow example.com (worker access test)",
-            decision: "allow",
-            include: [{ emailDomain: { domain: "example.com" } }],
-          });
-          const app = yield* Cloudflare.Access.Application("WorkerAccessApp", {
-            type: "self_hosted",
-            name: "Access for alchemy worker-destination test",
-            destinations: [
-              Cloudflare.Access.Worker(worker),
-              Cloudflare.Access.WorkerPreview(worker),
-            ],
-            policies: [policy],
-          });
-          return { worker, app, policy };
-        }),
-      );
+      const deployStack = Effect.gen(function* () {
+        const worker = yield* AccessProtectedWorker;
+        const app = yield* App;
+        return { worker, app };
+      });
 
-      // The Worker exposes its immutable script id, and the Access app's
-      // destinations resolved to it.
-      expect(worker.scriptTag).toBeDefined();
-      expect(worker.scriptTag!.length).toBeGreaterThan(0);
+      const { worker, app } = yield* stack.deploy(deployStack);
+
+      // The application carries the inline (application-owned) policy.
       expect(app.applicationId).toBeDefined();
       expect(app.aud.length).toBeGreaterThan(0);
-      expect(policy.policyId.length).toBeGreaterThan(0);
-      expect(app.destinations).toEqual(
-        expect.arrayContaining([
-          { type: "worker", workerId: worker.scriptTag },
-          { type: "preview_worker", workerId: worker.scriptTag },
-        ]),
-      );
-
-      // Out-of-band: Cloudflare recorded the worker destinations.
-      const live = yield* zeroTrust.getAccessApplicationForAccount({
+      const live = (yield* zeroTrust.getAccessApplicationForAccount({
         accountId,
         appId: app.applicationId,
-      });
-      const liveDestinations = (
-        live as unknown as {
-          destinations?: ReadonlyArray<{
-            type?: string | null;
-            workerId?: string | null;
-          }> | null;
-        }
-      ).destinations;
-      expect(liveDestinations).toEqual(
+      })) as unknown as LiveApp;
+      expect(live.policies?.length).toBe(1);
+      expect(live.policies![0].decision).toBe("allow");
+      expect(live.policies![0].reusable).toBe(false);
+      const inlinePolicyId = live.policies![0].id;
+      expect(inlinePolicyId).toBeDefined();
+
+      // The Worker enrolled itself: worker + preview destinations keyed by
+      // its immutable script id, contributed through the application's
+      // binding contract.
+      expect(worker.scriptTag).toBeDefined();
+      expect(app.destinations).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "worker",
+            workerId: worker.scriptTag,
+          }),
+        ]),
+      );
+      expect(live.destinations).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
             type: "worker",
@@ -145,16 +143,31 @@ test.provider(
         ]),
       );
 
-      // The workers.dev URL is now behind Access: an unauthenticated
-      // request is redirected to the Access login page instead of reaching
-      // the worker.
+      // Unauthenticated requests are redirected to the Access login page
+      // instead of reaching the worker.
       const location = yield* expectAccessLoginRedirect(worker.url!);
       expect(location).toContain("cloudflareaccess.com");
 
+      // Idempotence: a second deploy must not churn the inline policy (an
+      // id-less inline item in an update PUT would mint a fresh policy) or
+      // duplicate the destinations.
+      yield* stack.deploy(deployStack);
+      const liveAfter = (yield* zeroTrust.getAccessApplicationForAccount({
+        accountId,
+        appId: app.applicationId,
+      })) as unknown as LiveApp;
+      expect(liveAfter.policies?.length).toBe(1);
+      expect(liveAfter.policies![0].id).toBe(inlinePolicyId);
+      expect(
+        (liveAfter.destinations ?? []).filter(
+          (d) => d.workerId === worker.scriptTag,
+        ),
+      ).toHaveLength(2);
+
       yield* stack.destroy();
 
-      // The application is gone.
-      const liveAfter = yield* zeroTrust
+      // The application (and its inline policy with it) is gone.
+      const gone = yield* zeroTrust
         .getAccessApplicationForAccount({ accountId, appId: app.applicationId })
         .pipe(
           Effect.map(() => "still-exists" as const),
@@ -162,7 +175,7 @@ test.provider(
             Effect.succeed("gone" as const),
           ),
         );
-      expect(liveAfter).toBe("gone");
+      expect(gone).toBe("gone");
     }).pipe(logLevel),
   { timeout: 300_000 },
 );

--- a/packages/alchemy/test/Cloudflare/Access/fixtures/access-owned-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Access/fixtures/access-owned-worker.ts
@@ -13,6 +13,8 @@ export default class OwnedAccessWorker extends Cloudflare.Worker<OwnedAccessWork
     main: import.meta.url,
     access: {
       name: "Access for alchemy owned-app test",
+      // Production traffic only — preview URLs stay open.
+      previews: false,
       policies: [
         {
           decision: "allow",

--- a/packages/alchemy/test/Cloudflare/Access/fixtures/access-owned-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Access/fixtures/access-owned-worker.ts
@@ -16,7 +16,7 @@ export default class OwnedAccessWorker extends Cloudflare.Worker<OwnedAccessWork
       policies: [
         {
           decision: "allow",
-          include: [{ emailDomain: { domain: "example.com" } }],
+          include: [{ emailDomain: "example.com" }],
         },
       ],
     },

--- a/packages/alchemy/test/Cloudflare/Access/fixtures/access-owned-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Access/fixtures/access-owned-worker.ts
@@ -5,7 +5,8 @@ import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 /**
  * Worker protected by a **dedicated** Access application declared through
  * the `access.policies` form — no Application resource in sight. The
- * application is auto-declared with logical id `OwnedAccessWorkerAccess`.
+ * application is auto-declared in the Worker's namespace
+ * (`OwnedAccessWorker/Access`).
  */
 export default class OwnedAccessWorker extends Cloudflare.Worker<OwnedAccessWorker>()(
   "OwnedAccessWorker",

--- a/packages/alchemy/test/Cloudflare/Access/fixtures/access-owned-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Access/fixtures/access-owned-worker.ts
@@ -1,0 +1,35 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Effect from "effect/Effect";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+/**
+ * Worker protected by a **dedicated** Access application declared through
+ * the `access.policies` form — no Application resource in sight. The
+ * application is auto-declared with logical id `OwnedAccessWorkerAccess`.
+ */
+export default class OwnedAccessWorker extends Cloudflare.Worker<OwnedAccessWorker>()(
+  "OwnedAccessWorker",
+  {
+    main: import.meta.url,
+    access: {
+      name: "Access for alchemy owned-app test",
+      policies: [
+        {
+          decision: "allow",
+          include: [{ emailDomain: { domain: "example.com" } }],
+        },
+      ],
+    },
+  },
+  Effect.gen(function* () {
+    return {
+      fetch: Effect.gen(function* () {
+        const access = yield* Cloudflare.Access.Context;
+        return yield* HttpServerResponse.json({
+          marker: "alchemy-access-owned-open",
+          authenticated: access !== undefined,
+        });
+      }),
+    };
+  }),
+) {}

--- a/packages/alchemy/test/Cloudflare/Access/fixtures/access-worker-b.ts
+++ b/packages/alchemy/test/Cloudflare/Access/fixtures/access-worker-b.ts
@@ -5,14 +5,14 @@ import { App } from "./access-worker.ts";
 
 /**
  * Second Worker enrolling into the SAME shared application as
- * `access-worker.ts`, with `previews: false` — production traffic only.
- * Pins the many-Workers-one-application merge through the binding contract.
+ * `access-worker.ts`. Pins the many-Workers-one-application merge through
+ * the binding contract.
  */
 export default class SecondAccessWorker extends Cloudflare.Worker<SecondAccessWorker>()(
   "SecondAccessWorker",
   {
     main: import.meta.url,
-    access: { application: App, previews: false },
+    access: App,
   },
   Effect.gen(function* () {
     return {

--- a/packages/alchemy/test/Cloudflare/Access/fixtures/access-worker-b.ts
+++ b/packages/alchemy/test/Cloudflare/Access/fixtures/access-worker-b.ts
@@ -1,0 +1,28 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Effect from "effect/Effect";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import { App } from "./access-worker.ts";
+
+/**
+ * Second Worker enrolling into the SAME shared application as
+ * `access-worker.ts`, with `previews: false` — production traffic only.
+ * Pins the many-Workers-one-application merge through the binding contract.
+ */
+export default class SecondAccessWorker extends Cloudflare.Worker<SecondAccessWorker>()(
+  "SecondAccessWorker",
+  {
+    main: import.meta.url,
+    access: { application: App, previews: false },
+  },
+  Effect.gen(function* () {
+    return {
+      fetch: Effect.gen(function* () {
+        const access = yield* Cloudflare.Access.Context;
+        return yield* HttpServerResponse.json({
+          marker: "alchemy-access-worker-b-open",
+          authenticated: access !== undefined,
+        });
+      }),
+    };
+  }),
+) {}

--- a/packages/alchemy/test/Cloudflare/Access/fixtures/access-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Access/fixtures/access-worker.ts
@@ -12,7 +12,7 @@ export const App = Cloudflare.Access.Application("WorkerAccessApp", {
   policies: [
     {
       decision: "allow",
-      include: [{ emailDomain: { domain: "example.com" } }],
+      include: [{ emailDomain: "example.com" }],
     },
   ],
 });

--- a/packages/alchemy/test/Cloudflare/Access/fixtures/access-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Access/fixtures/access-worker.ts
@@ -27,7 +27,7 @@ export default class AccessProtectedWorker extends Cloudflare.Worker<AccessProte
   "AccessProtectedWorker",
   {
     main: import.meta.url,
-    access: { application: App },
+    access: App,
   },
   Effect.gen(function* () {
     return {

--- a/packages/alchemy/test/Cloudflare/Access/fixtures/access-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Access/fixtures/access-worker.ts
@@ -1,0 +1,33 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Effect from "effect/Effect";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+/**
+ * Minimal worker for the Access worker-destination test. Serves a marker
+ * body plus the request's `ctx.access` view, so the test can distinguish
+ * "worker answered directly" from "Access intercepted the request".
+ */
+export default class AccessProtectedWorker extends Cloudflare.Worker<AccessProtectedWorker>()(
+  "AccessProtectedWorker",
+  {
+    main: import.meta.url,
+  },
+  Effect.gen(function* () {
+    const exec = yield* Cloudflare.WorkerExecutionContext;
+    return {
+      fetch: Effect.gen(function* () {
+        const access = yield* exec.access;
+        const identity =
+          access === undefined
+            ? undefined
+            : yield* access.getIdentity().pipe(Effect.orDie);
+        return yield* HttpServerResponse.json({
+          marker: "alchemy-access-worker-open",
+          authenticated: access !== undefined,
+          aud: access?.aud,
+          email: identity?.email,
+        });
+      }),
+    };
+  }),
+) {}

--- a/packages/alchemy/test/Cloudflare/Access/fixtures/access-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Access/fixtures/access-worker.ts
@@ -3,20 +3,36 @@ import * as Effect from "effect/Effect";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 
 /**
- * Minimal worker for the Access worker-destination test. Serves a marker
- * body plus the request's `ctx.access` view, so the test can distinguish
- * "worker answered directly" from "Access intercepted the request".
+ * The Access application this Worker enrolls into — policies authored
+ * inline (application-owned), no separate Policy resource.
+ */
+export const App = Cloudflare.Access.Application("WorkerAccessApp", {
+  type: "self_hosted",
+  name: "Access for alchemy worker-enrollment test",
+  policies: [
+    {
+      decision: "allow",
+      include: [{ emailDomain: { domain: "example.com" } }],
+    },
+  ],
+});
+
+/**
+ * Worker protected by Access via the `access` prop: the provider enrolls it
+ * into {@link App} (worker + preview destinations). The fetch handler
+ * serves a marker body plus its `ctx.access` view, so the test can
+ * distinguish "worker answered directly" from "Access intercepted".
  */
 export default class AccessProtectedWorker extends Cloudflare.Worker<AccessProtectedWorker>()(
   "AccessProtectedWorker",
   {
     main: import.meta.url,
+    access: { application: App },
   },
   Effect.gen(function* () {
-    const exec = yield* Cloudflare.WorkerExecutionContext;
     return {
       fetch: Effect.gen(function* () {
-        const access = yield* exec.access;
+        const access = yield* Cloudflare.Access.Context;
         const identity =
           access === undefined
             ? undefined

--- a/packages/alchemy/test/Cloudflare/Website/WebsiteAccess.types.ts
+++ b/packages/alchemy/test/Cloudflare/Website/WebsiteAccess.types.ts
@@ -1,0 +1,39 @@
+/**
+ * Type-level pin: the `access` prop is part of the shared Worker props and
+ * must stay accepted by every `Cloudflare.Website.*` framework — a future
+ * addition to a framework's `Omit<WorkerProps, ...>` list must not silently
+ * drop it. Compile-only; never executed.
+ */
+import * as Cloudflare from "@/Cloudflare";
+import * as Effect from "effect/Effect";
+
+const App = Cloudflare.Access.Application("TypesApp", {
+  type: "self_hosted",
+  policies: [{ decision: "allow", include: [{ emailDomain: "example.com" }] }],
+});
+
+// The shared-application form: props are Input-wrapped, so the declaration
+// Effect is accepted directly.
+const access = { application: App, previews: false };
+
+const dedicated = {
+  policies: [
+    { decision: "allow" as const, include: [{ emailDomain: "example.com" }] },
+  ],
+};
+
+export const websites = Effect.gen(function* () {
+  yield* Cloudflare.Website.Astro("AstroSite", { access });
+  yield* Cloudflare.Website.Vite("ViteSite", { access: dedicated });
+  yield* Cloudflare.Website.Nextjs("NextSite", { access });
+  yield* Cloudflare.Website.Nuxt("NuxtSite", { access });
+  yield* Cloudflare.Website.SvelteKit("SvelteSite", { access });
+  yield* Cloudflare.Website.Waku("WakuSite", { access });
+  yield* Cloudflare.Website.Octane("OctaneSite", { access });
+  yield* Cloudflare.Website.Foldkit("FoldkitSite", { access });
+  yield* Cloudflare.Website.StaticSite("StaticSite", {
+    command: "bun run build",
+    outdir: "dist",
+    access,
+  });
+});

--- a/packages/alchemy/test/Cloudflare/Website/WebsiteAccess.types.ts
+++ b/packages/alchemy/test/Cloudflare/Website/WebsiteAccess.types.ts
@@ -12,9 +12,9 @@ const App = Cloudflare.Access.Application("TypesApp", {
   policies: [{ decision: "allow", include: [{ emailDomain: "example.com" }] }],
 });
 
-// The shared-application form: props are Input-wrapped, so the declaration
-// Effect is accepted directly.
-const access = { application: App, previews: false };
+// The shared-application form is the application itself — props are
+// Input-wrapped, so the declaration Effect is accepted directly.
+const access = App;
 
 const dedicated = {
   policies: [

--- a/packages/alchemy/test/Cloudflare/Workers/AccessContext.local.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/AccessContext.local.test.ts
@@ -77,8 +77,10 @@ test.provider("dev.access simulates ctx.access locally", (stack) =>
     // deploy ran.
     expect(deployed.authed.url).toMatch(/^http:\/\/localhost:\d+$/);
     expect(deployed.anon.url).toMatch(/^http:\/\/localhost:\d+$/);
-    // No cloud script exists in dev — there is no immutable Worker ID.
-    expect(deployed.authed.workerId).toBeUndefined();
+    // No cloud script exists in dev — the local provider fabricates a
+    // `dev:`-marked identity (mode switches replace the resource, so the
+    // two identities never mix).
+    expect(deployed.authed.workerId).toMatch(/^dev:/);
 
     const authed = yield* getJsonReady(deployed.authed.url!);
     expect(authed).toEqual({

--- a/packages/alchemy/test/Cloudflare/Workers/AccessContext.local.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/AccessContext.local.test.ts
@@ -77,6 +77,8 @@ test.provider("dev.access simulates ctx.access locally", (stack) =>
     // deploy ran.
     expect(deployed.authed.url).toMatch(/^http:\/\/localhost:\d+$/);
     expect(deployed.anon.url).toMatch(/^http:\/\/localhost:\d+$/);
+    // No cloud script exists in dev — there is no immutable Worker ID.
+    expect(deployed.authed.workerId).toBeUndefined();
 
     const authed = yield* getJsonReady(deployed.authed.url!);
     expect(authed).toEqual({

--- a/packages/alchemy/test/Cloudflare/Workers/AccessContext.local.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/AccessContext.local.test.ts
@@ -1,0 +1,94 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Test from "@/Test/Alchemy";
+import { expect } from "alchemy-test";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+import * as Schedule from "effect/Schedule";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import AnonAccessWorker from "./fixtures/access-context/anon-worker.ts";
+import AuthedAccessWorker from "./fixtures/access-context/authed-worker.ts";
+
+// `dev: true` runs local providers behind the RPC sidecar proxy by default,
+// matching the process topology of the real `alchemy dev` command.
+const { test } = Test.make({
+  providers: Cloudflare.providers(),
+  dev: true,
+});
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+class WorkerNotReady extends Data.TaggedError("WorkerNotReady")<{
+  status: number;
+  body: string;
+}> {}
+
+/** GET a route, retrying until the freshly started workerd serves a 200. */
+const getJsonReady = (url: string) =>
+  Effect.gen(function* () {
+    const client = yield* HttpClient.HttpClient;
+    const res = yield* client.get(url).pipe(
+      Effect.flatMap((res) =>
+        res.status === 200
+          ? Effect.succeed(res)
+          : res.text.pipe(
+              Effect.flatMap((body) =>
+                Effect.fail(new WorkerNotReady({ status: res.status, body })),
+              ),
+            ),
+      ),
+      Effect.retry({
+        while: (e): e is WorkerNotReady => e instanceof WorkerNotReady,
+        schedule: Schedule.max([
+          Schedule.min([
+            Schedule.exponential("500 millis"),
+            Schedule.spaced("2 seconds"),
+          ]),
+          Schedule.recurs(10),
+        ]),
+      }),
+    );
+    return (yield* res.json) as Record<string, unknown>;
+  }).pipe(Effect.orDie);
+
+/**
+ * Pins the `dev.access` simulation of `ctx.access` (the alchemy equivalent
+ * of wrangler's `access.dev` config): a worker with `dev.access` sees a
+ * defined `ctx.access` carrying the configured aud, and `getIdentity()`
+ * resolves the configured identity — while a worker without the config sees
+ * `ctx.access === undefined` (unauthenticated).
+ */
+test.provider("dev.access simulates ctx.access locally", (stack) =>
+  Effect.gen(function* () {
+    yield* stack.destroy();
+
+    const deployed = yield* stack.deploy(
+      Effect.gen(function* () {
+        const authed = yield* AuthedAccessWorker;
+        const anon = yield* AnonAccessWorker;
+        return { authed, anon };
+      }),
+    );
+
+    // Dev markers: both workers serve from the local dev proxy — no cloud
+    // deploy ran.
+    expect(deployed.authed.url).toMatch(/^http:\/\/localhost:\d+$/);
+    expect(deployed.anon.url).toMatch(/^http:\/\/localhost:\d+$/);
+
+    const authed = yield* getJsonReady(deployed.authed.url!);
+    expect(authed).toEqual({
+      authenticated: true,
+      aud: "test-aud",
+      email: "dev@alchemy.test",
+      groups: [{ id: "g1", name: "devs" }],
+    });
+
+    const anon = yield* getJsonReady(deployed.anon.url!);
+    expect(anon).toEqual({ authenticated: false });
+
+    yield* stack.destroy();
+  }).pipe(logLevel),
+);

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerId.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerId.test.ts
@@ -1,0 +1,201 @@
+import * as Cloudflare from "@/Cloudflare";
+import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
+import { isResourceState, State, type ResourceState } from "@/State";
+import * as Test from "@/Test/Alchemy";
+import * as workers from "@distilled.cloud/cloudflare/workers";
+import { expect } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import { MinimumLogLevel } from "effect/References";
+import * as Stream from "effect/Stream";
+
+const { test } = Test.make({ providers: Cloudflare.providers() });
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+const script = (marker: string) => `
+export default {
+  async fetch() {
+    return new Response(${JSON.stringify(marker)});
+  }
+}`;
+
+const HEX_ID = /^[0-9a-f]{32}$/;
+
+/** The live script's tag straight from the account's script listing. */
+const liveScriptTag = (accountId: string, scriptName: string) =>
+  workers.listScripts.items({ accountId }).pipe(
+    Stream.filter((s) => s.id === scriptName),
+    Stream.runHead,
+    Effect.map(Option.getOrUndefined),
+    Effect.map((s) => s?.tag ?? undefined),
+  );
+
+test.provider(
+  "workerId is the immutable script ID and survives updates",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const deployWith = (marker: string) =>
+        stack.deploy(Cloudflare.Worker("IdWorker", { script: script(marker) }));
+
+      const v1 = yield* deployWith("v1");
+      // The immutable hex ID — decisively not the script name.
+      expect(v1.workerId).toMatch(HEX_ID);
+      expect(v1.workerId).not.toEqual(v1.workerName);
+      // It is exactly what Cloudflare reports as the script's tag.
+      expect(yield* liveScriptTag(accountId, v1.workerName)).toEqual(
+        v1.workerId,
+      );
+
+      // A code update keeps both identifiers.
+      const v2 = yield* deployWith("v2");
+      expect(v2.workerId).toEqual(v1.workerId);
+      expect(v2.workerName).toEqual(v1.workerName);
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 240_000 },
+);
+
+test.provider(
+  "legacy state carrying the script name in workerId heals on the next update",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const deployWith = (marker: string) =>
+        stack.deploy(
+          Cloudflare.Worker("LegacyIdWorker", { script: script(marker) }),
+        );
+
+      const v1 = yield* deployWith("v1");
+      const realId = v1.workerId;
+      expect(realId).toMatch(HEX_ID);
+
+      // Rewrite the persisted row into the pre-rename shape: older betas
+      // stored the script *name* in `workerId`.
+      const state = yield* yield* State;
+      const stage = "test"; // scratch stacks default to the "test" stage
+      const fqns = yield* state.list({ stack: stack.name, stage });
+      const rows = yield* Effect.forEach(fqns, (fqn) =>
+        state
+          .get({ stack: stack.name, stage, fqn })
+          .pipe(Effect.map((row) => ({ fqn, row }))),
+      );
+      const workerRow = rows.find(
+        (r): r is { fqn: string; row: ResourceState } =>
+          isResourceState(r.row) && r.row.resourceType === "Cloudflare.Worker",
+      );
+      if (!workerRow) {
+        return yield* Effect.die(new Error("no Worker state row after deploy"));
+      }
+      const attr = workerRow.row.attr as { workerId?: string } | undefined;
+      expect(attr?.workerId).toEqual(realId);
+      yield* state.set({
+        stack: stack.name,
+        stage,
+        fqn: workerRow.fqn,
+        value: {
+          ...workerRow.row,
+          attr: { ...(attr ?? {}), workerId: v1.workerName },
+        },
+      });
+
+      // The next update must not trust the legacy value: reconcile records
+      // the real immutable ID again (from the upload response).
+      const v2 = yield* deployWith("v2");
+      expect(v2.workerId).toEqual(realId);
+      expect(v2.workerId).not.toEqual(v2.workerName);
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 240_000 },
+);
+
+test.provider(
+  "state loss: adoption re-records the same immutable ID",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      // A deterministic name: with auto-generated names, state loss mints a
+      // fresh instance id (and so a fresh script) — adoption is only
+      // meaningful when the physical name is stable.
+      const deploy = () =>
+        stack.deploy(
+          Cloudflare.Worker("AdoptIdWorker", {
+            name: "alchemy-test-workerid-adopt",
+            script: script("v1"),
+          }),
+        );
+
+      const v1 = yield* deploy();
+      expect(v1.workerId).toMatch(HEX_ID);
+
+      // Simulate state loss: the script lives on in Cloudflare, but the
+      // engine has no row for it.
+      const state = yield* yield* State;
+      const stage = "test";
+      const fqns = yield* state.list({ stack: stack.name, stage });
+      const rows = yield* Effect.forEach(fqns, (fqn) =>
+        state
+          .get({ stack: stack.name, stage, fqn })
+          .pipe(Effect.map((row) => ({ fqn, row }))),
+      );
+      const workerRow = rows.find(
+        (r) =>
+          isResourceState(r.row) && r.row.resourceType === "Cloudflare.Worker",
+      );
+      if (!workerRow) {
+        return yield* Effect.die(new Error("no Worker state row after deploy"));
+      }
+      yield* state.delete({ stack: stack.name, stage, fqn: workerRow.fqn });
+
+      // The re-deploy upserts the same script — same name, same immutable
+      // ID (proof the script was adopted, not replaced).
+      const readopted = yield* deploy();
+      expect(readopted.workerName).toEqual(v1.workerName);
+      expect(readopted.workerId).toEqual(v1.workerId);
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 240_000 },
+);
+
+test.provider(
+  "a version worker carries its parent script's workerId",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const { parent, preview } = yield* stack.deploy(
+        Effect.gen(function* () {
+          const parent = yield* Cloudflare.Worker("IdVersionParent", {
+            script: script("parent"),
+          });
+          const preview = yield* Cloudflare.Worker("IdVersionPreview", {
+            script: script("preview"),
+            version: { parent, message: "workerId test" },
+          });
+          return { parent, preview };
+        }),
+      );
+
+      expect(parent.workerId).toMatch(HEX_ID);
+      // The version worker owns no script of its own — it carries the
+      // parent's immutable ID (resolved through the listing lookup), so
+      // Access preview destinations protect its preview URLs.
+      expect(preview.workerId).toEqual(parent.workerId);
+      expect(preview.versionOf).toEqual(parent.workerName);
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 240_000 },
+);

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerId.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerId.test.ts
@@ -65,7 +65,7 @@ test.provider(
 );
 
 test.provider(
-  "legacy state carrying the script name in workerId heals on the next update",
+  "legacy state carrying the script name in workerId heals on a no-change redeploy",
   (stack) =>
     Effect.gen(function* () {
       yield* stack.destroy();
@@ -108,11 +108,12 @@ test.provider(
         },
       });
 
-      // The next update must not trust the legacy value: reconcile records
+      // A NO-CHANGE redeploy must heal: diff detects the legacy shape and
+      // plans an update even though no prop changed, and reconcile records
       // the real immutable ID again (from the upload response).
-      const v2 = yield* deployWith("v2");
-      expect(v2.workerId).toEqual(realId);
-      expect(v2.workerId).not.toEqual(v2.workerName);
+      const healed = yield* deployWith("v1");
+      expect(healed.workerId).toEqual(realId);
+      expect(healed.workerId).not.toEqual(healed.workerName);
 
       yield* stack.destroy();
     }).pipe(logLevel),

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/access-context/anon-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/access-context/anon-worker.ts
@@ -1,0 +1,26 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Effect from "effect/Effect";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+/**
+ * Worker without `dev.access`: under `alchemy dev`, `ctx.access` is
+ * `undefined`, simulating an unauthenticated request.
+ */
+export default class AnonAccessWorker extends Cloudflare.Worker<AnonAccessWorker>()(
+  "AnonAccessWorker",
+  {
+    main: import.meta.url,
+  },
+  Effect.gen(function* () {
+    return {
+      fetch: Effect.gen(function* () {
+        // The one-yield accessor (vs. authed-worker.ts, which pins the
+        // `WorkerExecutionContext.access` surface).
+        const access = yield* Cloudflare.Access.Context;
+        return yield* HttpServerResponse.json({
+          authenticated: access !== undefined,
+        });
+      }),
+    };
+  }),
+) {}

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/access-context/authed-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/access-context/authed-worker.ts
@@ -1,0 +1,42 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Effect from "effect/Effect";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+/**
+ * Worker with a simulated Cloudflare Access identity (`dev.access`): under
+ * `alchemy dev`, `ctx.access` is defined and `getIdentity()` resolves the
+ * configured identity.
+ */
+export default class AuthedAccessWorker extends Cloudflare.Worker<AuthedAccessWorker>()(
+  "AuthedAccessWorker",
+  {
+    main: import.meta.url,
+    dev: {
+      access: {
+        aud: "test-aud",
+        identity: {
+          email: "dev@alchemy.test",
+          groups: [{ id: "g1", name: "devs" }],
+        },
+      },
+    },
+  },
+  Effect.gen(function* () {
+    const exec = yield* Cloudflare.WorkerExecutionContext;
+    return {
+      fetch: Effect.gen(function* () {
+        const access = yield* exec.access;
+        if (access === undefined) {
+          return yield* HttpServerResponse.json({ authenticated: false });
+        }
+        const identity = yield* access.getIdentity().pipe(Effect.orDie);
+        return yield* HttpServerResponse.json({
+          authenticated: true,
+          aud: access.aud,
+          email: identity?.email,
+          groups: identity?.groups,
+        });
+      }),
+    };
+  }),
+) {}

--- a/packages/cloudflare-runtime/src/core/bindings/hyperdrive/hyperdrive-binding.worker.ts
+++ b/packages/cloudflare-runtime/src/core/bindings/hyperdrive/hyperdrive-binding.worker.ts
@@ -17,5 +17,10 @@ export default function makeBinding(env: { ORIGIN: HyperdriveOrigin }) {
     password: env.ORIGIN.password,
     host: env.ORIGIN.host,
     port: env.ORIGIN.port,
+    // Production Hyperdrive exposes a synthetic IPv4 literal for drivers that
+    // reject hostnames; locally the origin host is directly connectable, so
+    // it doubles as the "ip" (drivers pass it back into connect(), which
+    // accepts hostnames).
+    ip: env.ORIGIN.host,
   } satisfies Hyperdrive;
 }

--- a/packages/cloudflare-runtime/src/core/bindings/workflows/wrapped-binding.worker.ts
+++ b/packages/cloudflare-runtime/src/core/bindings/workflows/wrapped-binding.worker.ts
@@ -33,6 +33,10 @@ class WorkflowImpl implements Workflow {
     });
   }
 
+  async deleteBatch(instanceIds: string[]): Promise<WorkflowBatchDeleteResult> {
+    return this.binding.deleteBatch(instanceIds);
+  }
+
   async unsafeGetBindingName(): Promise<string> {
     return this.binding.unsafeGetBindingName();
   }
@@ -130,6 +134,15 @@ class InstanceImpl implements WorkflowInstance {
   }): Promise<void> {
     using instance = await this.getInstance();
     await instance.sendEvent(args);
+  }
+
+  public async delete(): Promise<void> {
+    using instance = await this.getInstance();
+    // Structural call: whether the ambient WorkflowInstance type in this
+    // program carries `delete` depends on which workers-types copy wins
+    // (vitest-pool-workers bundles an older one), but the runtime handle
+    // (WorkflowHandle) always implements it.
+    await (instance as unknown as { delete(): Promise<void> }).delete();
   }
 }
 

--- a/packages/cloudflare-runtime/src/internal/workflows-shared/binding.ts
+++ b/packages/cloudflare-runtime/src/internal/workflows-shared/binding.ts
@@ -235,6 +235,33 @@ export class WorkflowBinding extends WorkerEntrypoint<Env> {
     );
   }
 
+  public async deleteBatch(
+    instanceIds: string[],
+  ): Promise<WorkflowBatchDeleteResult> {
+    if (instanceIds.length > 100) {
+      throw new WorkflowError(
+        "deleteBatch is limited to 100 instances at a time",
+      );
+    }
+    const deleted: { id: string }[] = [];
+    const errors: { id: string; code: number; message: string }[] = [];
+    for (const id of new Set(instanceIds)) {
+      try {
+        const handle = (await this.get(id)) as WorkflowHandle;
+        await handle.delete();
+        deleted.push({ id });
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        errors.push({
+          id,
+          code: message.startsWith("instance.not_found") ? 404 : 400,
+          message,
+        });
+      }
+    }
+    return { deleted, errors };
+  }
+
   public async unsafeGetBindingName(): Promise<string> {
     // async because of rpc
     return this.env.BINDING_NAME;
@@ -453,5 +480,26 @@ export class WorkflowHandle extends RpcTarget implements WorkflowInstance {
       type: args.type,
       timestamp: new Date(),
     });
+  }
+
+  public async delete(): Promise<void> {
+    const { status } = await this.status();
+    if (
+      status !== "complete" &&
+      status !== "errored" &&
+      status !== "terminated"
+    ) {
+      throw new Error(
+        "instance.not_terminal: only instances in a terminal state (complete, errored, terminated) can be deleted",
+      );
+    }
+    try {
+      // Wiping the engine DO's storage makes a subsequent `get(id)` report
+      // instance.not_found — the local equivalent of deleting the record.
+      await this.stub.unsafeAbort("instance.deleted");
+    } catch {
+      // unsafeAbort aborts the DO out from under its own RPC channel, which
+      // may reject the call after the storage wipe already happened.
+    }
   }
 }

--- a/website/src/content/docs/cloudflare/index.mdx
+++ b/website/src/content/docs/cloudflare/index.mdx
@@ -62,6 +62,9 @@ New here? [Set up your account](/cloudflare/setup), then start the
 
 - [Secrets & env](/cloudflare/security/secrets-env) — bind `.env` values and
   secrets into your Workers.
+- [Protect a Worker with Access](/cloudflare/security/access) — put a login
+  wall in front of a Worker and read the authenticated identity from
+  `ctx.access`.
 
 ## What are you building?
 

--- a/website/src/content/docs/cloudflare/security/access.mdx
+++ b/website/src/content/docs/cloudflare/security/access.mdx
@@ -1,0 +1,214 @@
+---
+title: Protect a Worker with Access
+description: Put Cloudflare Access in front of a Worker with the access prop — per-Worker policies, shared applications, ctx.access identity at runtime, and a local dev simulation.
+sidebar:
+  order: 20
+---
+
+Cloudflare Access puts a login wall in front of your Worker — covering
+its custom domains, routes, `workers.dev` URL, and version preview
+URLs — and hands your code the authenticated identity at runtime. In
+alchemy this is a property of the Worker: set the `access` prop.
+
+## Protect a Worker
+
+The simplest form declares the policies right on the Worker. Alchemy
+creates a dedicated Access application for it (Cloudflare attaches
+policies to *applications*, so per-Worker policies mean a per-Worker
+application — it is created, updated, and deleted with the Worker):
+
+```typescript
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+export default Cloudflare.Worker(
+  "Api",
+  {
+    main: import.meta.url,
+    access: {
+      policies: [
+        { decision: "allow", include: [{ emailDomain: "example.com" }] },
+      ],
+    },
+  },
+  Effect.gen(function* () {
+    return {
+      fetch: Effect.gen(function* () {
+        return HttpServerResponse.text("team only");
+      }),
+    };
+  }),
+);
+```
+
+Unauthenticated requests are redirected to your team's Access login
+page before they ever reach the Worker. Anyone with a verified
+`@example.com` email gets through.
+
+## Read who's calling
+
+Once a request passes Access, the identity is available from
+`ctx.access` — one yield away via `Cloudflare.Access.Context`:
+
+```typescript
+fetch: Effect.gen(function* () {
+  const access = yield* Cloudflare.Access.Context;
+  if (access === undefined) {
+    return HttpServerResponse.text("Access required", { status: 403 });
+  }
+  const identity = yield* access.getIdentity();
+  return yield* HttpServerResponse.json({
+    aud: access.aud,
+    email: identity?.email,
+    groups: identity?.groups,
+  });
+}),
+```
+
+`access` is `undefined` when the request did not come through
+Cloudflare Access (for example a route you deliberately left open).
+`getIdentity()` resolves the user's email, name, groups, identity
+provider, device posture, and service-token fields.
+
+## Test locally
+
+`alchemy dev` can simulate the authenticated state — the equivalent of
+wrangler's `access.dev` config. Add `dev.access` and `ctx.access`
+serves that identity locally:
+
+```typescript
+export default Cloudflare.Worker(
+  "Api",
+  {
+    main: import.meta.url,
+    access: {
+      policies: [
+        { decision: "allow", include: [{ emailDomain: "example.com" }] },
+      ],
+    },
+    dev: {
+      access: {
+        aud: "dev",
+        identity: { email: "dev@example.com" },
+      },
+    },
+  },
+  /* ... */
+);
+```
+
+Remove the `dev.access` block to simulate unauthenticated requests
+(`Cloudflare.Access.Context` yields `undefined`), so both branches of
+your handler are exercisable without deploying. The block has no
+effect on a real deploy.
+
+## Writing policy rules
+
+Rules use Cloudflare's own shapes, with a scalar shorthand for the
+single-parameter kinds — both spellings are equivalent:
+
+```typescript
+policies: [
+  {
+    decision: "allow",
+    include: [
+      { emailDomain: "example.com" },   // { emailDomain: { domain: "example.com" } }
+      { email: "sam@partner.com" },     // { email: { email: "sam@partner.com" } }
+    ],
+    exclude: [{ email: "intern@example.com" }],
+    require: [{ geo: "US" }],           // { geo: { countryCode: "US" } }
+    sessionDuration: "12h",
+  },
+]
+```
+
+`include` rules combine with OR, `require` with AND, `exclude` with
+NOT. Parameter-less kinds collapse to bare strings (`"everyone"`,
+`"certificate"`, `"anyValidServiceToken"`); multi-parameter kinds
+(`gsuite`, `okta`, `saml`, `oidc`, `azureAD`, `githubOrganization`,
+...) keep Cloudflare's wire shape, so anything in the
+[Access policy docs](https://developers.cloudflare.com/cloudflare-one/policies/access/)
+pastes in directly.
+
+## Share one application across Workers
+
+When several Workers should sit behind the same policy set, declare
+the application once and enroll each Worker into it:
+
+```typescript
+import * as Cloudflare from "alchemy/Cloudflare";
+
+export const TeamOnly = Cloudflare.Access.Application("TeamOnly", {
+  type: "self_hosted",
+  policies: [
+    { decision: "allow", include: [{ emailDomain: "example.com" }] },
+  ],
+});
+```
+
+```typescript
+import { TeamOnly } from "./stack.ts";
+
+export default Cloudflare.Worker(
+  "Api",
+  {
+    main: import.meta.url,
+    access: { application: TeamOnly },
+  },
+  /* ... */
+);
+```
+
+Each enrolled Worker contributes its destinations to the application
+through the engine's binding contract, so the application always
+converges on exactly the set of currently-enrolled Workers — removing
+the `access` prop (or the Worker itself) un-enrolls it on the next
+deploy.
+
+Set `previews: false` on either form to protect production traffic
+only, leaving version preview URLs open.
+
+## Protect every Worker on the account
+
+An account-level application covers all current **and future**
+Workers. Hostname policies beat Worker policies beat account policies,
+so an individual Worker can still be opened up (or locked down
+tighter) with its own application:
+
+```typescript
+yield* Cloudflare.Access.Application("ProtectAllWorkers", {
+  type: "self_hosted",
+  destinations: [
+    Cloudflare.Access.AllWorkers,
+    Cloudflare.Access.AllWorkerPreviews,
+  ],
+  policies: [
+    { decision: "allow", include: [{ emailDomain: "example.com" }] },
+  ],
+});
+```
+
+## Websites too
+
+`access` is part of the shared Worker props, so every
+`Cloudflare.Website.*` framework accepts it unchanged:
+
+```typescript
+const app = yield* Cloudflare.Website.Astro("Docs", {
+  access: {
+    policies: [
+      { decision: "allow", include: [{ emailDomain: "example.com" }] },
+    ],
+  },
+});
+```
+
+## See also
+
+- [Application API reference](/providers/cloudflare/access/application)
+- [Policy API reference](/providers/cloudflare/access/policy)
+- [Worker API reference](/providers/cloudflare/workers/worker)
+- [Secrets & env](/cloudflare/security/secrets-env) — for service-to-service
+  auth without a human login, pair Access service tokens with policies
+  using `serviceToken` / `"anyValidServiceToken"` rules.

--- a/website/src/content/docs/cloudflare/security/access.mdx
+++ b/website/src/content/docs/cloudflare/security/access.mdx
@@ -154,7 +154,7 @@ export default Cloudflare.Worker(
   "Api",
   {
     main: import.meta.url,
-    access: { application: TeamOnly },
+    access: TeamOnly,
   },
   /* ... */
 );
@@ -164,10 +164,12 @@ Each enrolled Worker contributes its destinations to the application
 through the engine's binding contract, so the application always
 converges on exactly the set of currently-enrolled Workers — removing
 the `access` prop (or the Worker itself) un-enrolls it on the next
-deploy.
+deploy. Keep in mind Access policies are **application-wide**: every
+Worker enrolled in `TeamOnly` is gated by the same policy set. For
+per-Worker rules, use the dedicated `{ policies }` form above.
 
-Set `previews: false` on either form to protect production traffic
-only, leaving version preview URLs open.
+On the dedicated form, set `previews: false` to protect production
+traffic only, leaving version preview URLs open.
 
 ## Protect every Worker on the account
 

--- a/website/src/content/docs/cloudflare/security/access.mdx
+++ b/website/src/content/docs/cloudflare/security/access.mdx
@@ -10,13 +10,18 @@ its custom domains, routes, `workers.dev` URL, and version preview
 URLs — and hands your code the authenticated identity at runtime. In
 alchemy this is a property of the Worker: set the `access` prop.
 
-## Protect a Worker
+The prop has two forms — a **dedicated application** owned by the
+Worker (`access: { policies }`) for per-Worker rules, and a **shared
+application** (`access: App`) when several Workers sit behind one
+policy set. Each has its own section below.
+
+## Dedicated application (per-Worker policies)
 
 The simplest form declares the policies right on the Worker. Alchemy
 creates a dedicated Access application for it (Cloudflare attaches
 policies to *applications*, so per-Worker policies mean a per-Worker
 application — created, updated, and deleted with the Worker, and
-namespaced under it in the plan as `Api/Access`):
+namespaced under it as `Api/Access`):
 
 ```typescript
 import * as Cloudflare from "alchemy/Cloudflare";
@@ -132,10 +137,10 @@ NOT. Parameter-less kinds collapse to bare strings (`"everyone"`,
 [Access policy docs](https://developers.cloudflare.com/cloudflare-one/policies/access/)
 pastes in directly.
 
-## Share one application across Workers
+## Shared application (one policy set, many Workers)
 
 When several Workers should sit behind the same policy set, declare
-the application once and enroll each Worker into it:
+the application once and pass it to each Worker directly:
 
 ```typescript
 import * as Cloudflare from "alchemy/Cloudflare";

--- a/website/src/content/docs/cloudflare/security/access.mdx
+++ b/website/src/content/docs/cloudflare/security/access.mdx
@@ -15,7 +15,8 @@ alchemy this is a property of the Worker: set the `access` prop.
 The simplest form declares the policies right on the Worker. Alchemy
 creates a dedicated Access application for it (Cloudflare attaches
 policies to *applications*, so per-Worker policies mean a per-Worker
-application — it is created, updated, and deleted with the Worker):
+application — created, updated, and deleted with the Worker, and
+namespaced under it in the plan as `Api/Access`):
 
 ```typescript
 import * as Cloudflare from "alchemy/Cloudflare";

--- a/website/src/content/docs/cloudflare/security/access.mdx
+++ b/website/src/content/docs/cloudflare/security/access.mdx
@@ -79,9 +79,15 @@ provider, device posture, and service-token fields.
 
 ## Test locally
 
-`alchemy dev` can simulate the authenticated state — the equivalent of
-wrangler's `access.dev` config. Add `dev.access` and `ctx.access`
-serves that identity locally:
+In production, `ctx.access` is populated by Cloudflare's edge after a
+request passes the Access login wall. Under `alchemy dev` your Worker
+runs in local workerd — there is no edge and no login — so `ctx.access`
+would always be `undefined` and the authenticated branch of your
+handler could never run locally.
+
+`dev.access` stubs that state: when set, every local request behaves
+as if this one user had logged in — `ctx.access` carries the given
+`aud` and `getIdentity()` resolves the given identity:
 
 ```typescript
 export default Cloudflare.Worker(
@@ -106,8 +112,10 @@ export default Cloudflare.Worker(
 
 Remove the `dev.access` block to simulate unauthenticated requests
 (`Cloudflare.Access.Context` yields `undefined`), so both branches of
-your handler are exercisable without deploying. The block has no
-effect on a real deploy.
+your handler are exercisable without deploying. Changing the block
+restarts the dev server with the new identity. It is inert on deploy:
+the deployed Worker always gets the real edge-populated `ctx.access`,
+never the stub.
 
 ## Writing policy rules
 


### PR DESCRIPTION
> [!CAUTION]
> **Breaking:** the Worker's `workerId` attribute is now the **immutable Worker ID** (the hex script "tag" — the dashboard's Worker ID, what Access destinations key on), always a `string` — under `alchemy dev` the local provider generates a `dev:`-marked ID (mode switches replace the resource, so the identities never mix). It previously duplicated `workerName` (the script *name*); use `workerName` for the name. State persisted by older betas is healed automatically on the next deploy — `diff` detects the legacy shape and plans an update even when nothing else changed — pinned by a dedicated live suite ([WorkerId.test.ts](https://github.com/alchemy-run/alchemy/blob/claude/cloudflare-workers-access-5ce8a1/packages/alchemy/test/Cloudflare/Workers/WorkerId.test.ts)): tag matches the live listing, survives updates, legacy-shaped rows heal on the next update, state-loss adoption preserves the ID, and a version worker carries its parent's.

Support for [Workers protected by Access](https://blog.cloudflare.com/workers-protected-by-access/): enable Access on one Worker or the whole account, author policies inline, read the authenticated identity from `ctx.access`, and test it all in local dev.

### Protect a Worker

Access is configured on the Worker. The zero-ceremony form declares a **dedicated application owned by the Worker** (Cloudflare attaches policies to applications, so per-Worker policies mean a per-Worker application — alchemy declares it for you, created/updated/deleted with the Worker):

```ts
export default class Api extends Cloudflare.Worker<Api>()("Api", {
  main: import.meta.url,
  access: {
    policies: [
      { decision: "allow", include: [{ emailDomain: "example.com" }] },
    ],
    // previews: false to leave preview URLs open; sessionDuration,
    // allowedIdps, autoRedirectToIdentity, appLauncherVisible pass through
  },
}, /* ... */) {}
```

To share one application (one policy set) across several Workers, declare it and pass it directly — note Access policies are application-wide, so every enrolled Worker is gated by the same set:

```ts
const App = Cloudflare.Access.Application("TeamOnly", {
  type: "self_hosted",
  policies: [
    { decision: "allow", include: [{ emailDomain: "example.com" }] },
  ],
});

export default class Api extends Cloudflare.Worker<Api>()("Api", {
  main: import.meta.url,
  access: App,
}, /* ... */) {}
```

Enrollment rides the engine's binding contract: the Worker pushes its `worker`/`preview_worker` destinations (keyed by its immutable script ID) onto the application, which deploys with — and converges on — the destinations of every enrolled Worker. That ordering matters: Cloudflare requires a self-hosted app to be *born* with destinations, and it makes un-enrollment engine-driven — remove the prop (or the Worker) and the application's next reconcile drops the destinations. No `workerId` plumbing ever appears in user code.

### Protect every Worker in the account

Covers all current **and future** Workers. Hostname policies beat Worker policies beat this account-level policy, so an individual Worker can still be opened up with its own application:

```ts
yield* Cloudflare.Access.Application("ProtectAllWorkers", {
  type: "self_hosted",
  destinations: [Cloudflare.Access.AllWorkers, Cloudflare.Access.AllWorkerPreviews],
  policies: [
    { decision: "allow", include: [{ emailDomain: "example.com" }] },
  ],
});
```

`policies` also accepts reusable `Cloudflare.Access.Policy` resources directly (`policies: [allowTeam]`), their ids, or per-app override objects — inline and reusable forms are mutually exclusive per application (Cloudflare rule, validated with a clear error).

Rules use Cloudflare's wire shapes (types derived from distilled, so every rule kind is available and stays current), with a scalar shorthand for the single-parameter kinds — both spellings are equivalent:

```ts
include: [{ emailDomain: "example.com" }]  // ⇢ { emailDomain: { domain: "example.com" } }
include: [{ email: "sam@example.com" }]    // ⇢ { email: { email: "sam@example.com" } }
include: ["everyone"]                      // ⇢ { everyone: {} }
require: [{ geo: "US" }]                   // ⇢ { geo: { countryCode: "US" } }
```

### See who's calling from `ctx.access`

`Cloudflare.Access.Context` is a one-yield accessor over the new `WorkerExecutionContext.access` member — `RuntimeContext`-colored like `ctx.cache`, `undefined` when the request didn't pass through Access:

```ts
fetch: Effect.gen(function* () {
  const access = yield* Cloudflare.Access.Context;
  if (access === undefined) {
    return HttpServerResponse.text("Access required", { status: 403 });
  }
  const identity = yield* access.getIdentity(); // email, name, groups, idp, ...
  return yield* HttpServerResponse.json({ aud: access.aud, email: identity?.email });
}),
```

### Test in local dev

Locally there is no edge and no login wall, so `ctx.access` would always be `undefined`. `dev.access` stubs the authenticated state — every local request behaves as if this user had logged in; omit the block to simulate unauthenticated requests. Inert on deploy:

```ts
export default class Api extends Cloudflare.Worker<Api>()("Api", {
  main: import.meta.url,
  access: App,
  dev: {
    access: {
      aud: "dev-aud",
      identity: { email: "dev@example.com" },
    },
  },
}, /* ... */) {}
```

### Docs & Websites

- New guide: [Protect a Worker with Access](https://github.com/alchemy-run/alchemy/blob/claude/cloudflare-workers-access-5ce8a1/website/src/content/docs/cloudflare/security/access.mdx) (`/cloudflare/security/access`) — both `access` forms, `ctx.access`, the dev simulation, rule shorthand, and account-wide protection; linked from the Cloudflare index and from a new "Protect with Access" section on the generated Worker reference page.
- `access` is part of the shared Worker props, so every `Cloudflare.Website.*` framework (Astro, Vite, Next.js, Nuxt, SvelteKit, Waku, Octane, Foldkit, StaticSite) accepts it unchanged — pinned by a compile-only types test so a framework's `Omit<WorkerProps, ...>` can never silently drop it.
- Worker-access runtime/config code lives in its own `Workers/WorkerAccess.ts` module rather than growing `Worker.ts`.

### Implementation notes

- Inline policies are typed in distilled (`InlineAccessPolicy` added to the self-hosted policy item unions — the API docs only model the inline arm for infrastructure apps, but the live API accepts it for `self_hosted`). Updates attach observed application-owned policy ids positionally so redeploys update policies in place instead of minting fresh ones — pinned by an idempotence assertion in the live test.
- distilled also gains a typed `AccessApplicationNotFound` (404) on `getAccessApplicationForAccount`; `observeById` and cleanup verification catch the tag instead of swallowing errors generically. (Submodule bump.)
- `@cloudflare/workers-types` bumped to `^5.20260812.1` for the worker-side packages (ships the native `ctx.access` typings); the local Workflow/Hyperdrive simulators implement the new required `WorkflowInstance.delete` / `Workflow.deleteBatch` / `Hyperdrive.ip` APIs. The default catalog stays on v4: v5's global entrypoint declares Node-compat globals that collide with `@types/bun` across the alchemy/examples programs — that migration is a separate follow-up.

Verified live across 9 tests: inline policy update-in-place (same policy id after rule mutation), shorthand expansion asserted on the wire echo, inline ⇄ reusable form switching, mixed-forms refusal, two Workers merging onto one shared application (`previews: false` respected), un-enrollment by removing a Worker from the stack, plus the original flows: [WorkerApplication.test.ts](https://github.com/alchemy-run/alchemy/blob/claude/cloudflare-workers-access-5ce8a1/packages/alchemy/test/Cloudflare/Access/WorkerApplication.test.ts) deploys both forms (dedicated `access.policies` app and shared enrollment), confirms the recorded destinations, observes the unauthenticated 302 to the Access login page, redeploys to pin idempotence (same policy id, no duplicate destinations), and verifies teardown via the typed 404. [AccessContext.local.test.ts](https://github.com/alchemy-run/alchemy/blob/claude/cloudflare-workers-access-5ce8a1/packages/alchemy/test/Cloudflare/Workers/AccessContext.local.test.ts) pins the `dev.access` simulation through the RPC-sidecar dev topology.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
