### PR TITLE
fix(cloudflare-runtime): keep module-runner export-types detection alive with ctx.waitUntil

### DIFF
--- a/packages/cloudflare-runtime/src/vite/module-runner/module-runner.worker.ts
+++ b/packages/cloudflare-runtime/src/vite/module-runner/module-runner.worker.ts
@@ -93,7 +93,14 @@ export class ModuleRunnerDO extends DurableObject<Env> {
     this.webSockets.set(environmentName, server);
     server.addEventListener("message", ({ data }) => {
       if (isRequestExportTypes(data)) {
-        void this.reportExportTypes(environmentName);
+        // Not awaited (the listener itself cannot be async), but this must still
+        // keep the Durable Object alive until it settles: workerd ties I/O to the
+        // event that's currently being handled, and a plain fire-and-forget call
+        // here can end up running `reportExportTypes`'s own `import()` calls (and
+        // whatever async work module evaluation triggers) after this message
+        // event is considered done, throwing "Disallowed operation called within
+        // global scope" for whatever I/O happens next.
+        this.ctx.waitUntil(this.reportExportTypes(environmentName));
       }
     });
     return new Response(null, { status: 101, webSocket: client });


### PR DESCRIPTION
When you run a Vite dev server, there's a piece that checks what a Worker file exports so it can wire things up correctly. That check runs in the background  and it starts the check but doesn't wait for it to finish before moving on.

The problem: if the check is still running by the time the runtime considers "that request" done, whatever the check tries to do next has nowhere left to run, and it crashes with `Uncaught Error: Disallowed operation called within global scope`.

The fix: tell the runtime to keep things alive until the check actually finishes (`ctx.waitUntil`), instead of firing it and walking away. Same fix already used elsewhere in this codebase for the exact same situation (`workflows-shared/binding.ts`).