### PR TITLE
feat: CliKit — a terminal UI layer for the CLI on @alchemy.run/sigil

### DIFF
--- a/packages/alchemy/package.json
+++ b/packages/alchemy/package.json
@@ -149,6 +149,12 @@
       "worker": "./src/Cli/InkCLI.tsx",
       "import": "./lib/Cli/InkCLI.js"
     },
+    "./Cli/CliKit": {
+      "types": "./lib/Cli/CliKit/index.d.ts",
+      "bun": "./src/Cli/CliKit/index.ts",
+      "worker": "./src/Cli/CliKit/index.ts",
+      "import": "./lib/Cli/CliKit/index.js"
+    },
     "./Cloudflare": {
       "types": "./lib/Cloudflare/index.d.ts",
       "bun": "./src/Cloudflare/index.ts",
@@ -416,6 +422,7 @@
     "@alchemy.run/cloudflare-runtime": "workspace:*",
     "@alchemy.run/floci": "workspace:*",
     "@alchemy.run/node-utils": "workspace:*",
+    "@alchemy.run/sigil": "0.0.0-alpha.5",
     "@aws-sdk/credential-providers": "catalog:aws",
     "@clack/prompts": "^1.7.0",
     "@distilled.cloud/aws": "workspace:*",
@@ -442,13 +449,14 @@
     "capnweb": "^0.6.1",
     "fast-glob": "catalog:cloudflare-runtime",
     "fast-xml-parser": "catalog:shared",
-    "ink": "^6.3.1",
+    "ink": "^7.0.2",
     "jszip": "^3.10.1",
     "libsodium-wrappers": "^0.8.3",
     "pathe": "catalog:tooling",
     "picomatch": "^4.0.4",
     "react": "^19.2.0",
     "rolldown": "catalog:build",
+    "string-width": "^8.2.2",
     "undici": "^7.16.0",
     "yaml": "catalog:shared"
   },

--- a/packages/alchemy/src/Cli/CliKit/CliKit.ts
+++ b/packages/alchemy/src/Cli/CliKit/CliKit.ts
@@ -1,0 +1,177 @@
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import type * as Scope from "effect/Scope";
+import type { NonInteractiveTerminal } from "./errors.ts";
+import type {
+  ConfirmOptions,
+  CycleSelectOptions,
+  AwaitExternalOptions,
+  MessageOptions,
+  InteractionError,
+  LiveViewHandle,
+  LiveViewOptions,
+  MenuOptions,
+  MultiSelectOptions,
+  PasswordInputOptions,
+  ProgressHandle,
+  ProgressOptions,
+  RenderOptions,
+  Screen,
+  SelectOptions,
+  CliKitCapabilities,
+  TextInputOptions,
+  View,
+} from "./types.ts";
+
+/** The sole injected owner of terminal rendering and input for a CLI process. */
+export class CliKit extends Context.Service<
+  CliKit,
+  {
+    readonly terminal: CliKitCapabilities;
+
+    readonly output: {
+      /** Append a completed layout to terminal scrollback/output. */
+      readonly print: (
+        view: View,
+        options?: RenderOptions,
+      ) => Effect.Effect<void>;
+
+      /** Render a layout without writing it. Useful for help, logs and snapshots. */
+      readonly format: (view: View, options?: RenderOptions) => string;
+
+      /** Effect form of `format`, useful when composing CLI programs. */
+      readonly render: (
+        view: View,
+        options?: RenderOptions,
+      ) => Effect.Effect<string>;
+
+      /** Append an arbitrary visual layout. Prefer the semantic methods for logs. */
+      readonly info: (message: string | MessageOptions) => Effect.Effect<void>;
+      readonly success: (
+        message: string | MessageOptions,
+      ) => Effect.Effect<void>;
+      readonly warning: (
+        message: string | MessageOptions,
+      ) => Effect.Effect<void>;
+      readonly error: (message: string | MessageOptions) => Effect.Effect<void>;
+    };
+
+    readonly prompt: {
+      readonly text: (
+        options: TextInputOptions,
+      ) => Effect.Effect<string, InteractionError>;
+      readonly password: (
+        options: PasswordInputOptions,
+      ) => Effect.Effect<string, InteractionError>;
+      readonly confirm: (
+        options: ConfirmOptions,
+      ) => Effect.Effect<boolean, InteractionError>;
+      readonly select: <Value>(
+        options: SelectOptions<Value>,
+      ) => Effect.Effect<Value, InteractionError>;
+      readonly multiSelect: <Value>(
+        options: MultiSelectOptions<Value>,
+      ) => Effect.Effect<ReadonlyArray<Value>, InteractionError>;
+      readonly cycle: <State>(
+        options: CycleSelectOptions<State>,
+      ) => Effect.Effect<ReadonlyArray<State>, InteractionError>;
+      readonly awaitExternal: (
+        options: AwaitExternalOptions,
+      ) => Effect.Effect<string, InteractionError>;
+
+      /**
+       * Display an application menu. Each invocation replaces the current app
+       * flow, so looping back to a menu clears any prompts shown since the last
+       * selection.
+       */
+      readonly menu: <Value>(
+        options: MenuOptions<Value>,
+      ) => Effect.Effect<Value, InteractionError>;
+
+      /** Run an arbitrary interactive screen in the service's single live region. */
+      readonly custom: <Value>(
+        screen: Screen<Value>,
+      ) => Effect.Effect<Value, InteractionError>;
+    };
+
+    /** Run a sequence of prompts as one owned interaction. */
+    readonly wizard: <A, E, R>(
+      effect: Effect.Effect<A, E, R>,
+    ) => Effect.Effect<A, E | NonInteractiveTerminal, R>;
+
+    /**
+     * Keep one renderer alive while an Effect drives menus, screens and prompt
+     * flows. The application is cleared and the renderer exits when it settles.
+     */
+    readonly application: <A, E, R>(
+      effect: Effect.Effect<A, E, R>,
+    ) => Effect.Effect<A, E | NonInteractiveTerminal, R>;
+
+    readonly live: {
+      /**
+       * Add a mutable row to the live region. The handle is idempotent, and
+       * the enclosing Scope closes it as a backstop so interruption can never
+       * leave an orphaned row keeping the renderer mounted.
+       */
+      readonly progress: (
+        options: ProgressOptions,
+      ) => Effect.Effect<ProgressHandle, never, Scope.Scope>;
+      /**
+       * Mount a live layout while the scope is open. The view is immutable —
+       * dynamic content flows through a caller-owned store (`LiveStore` +
+       * `useLiveStore`) that the view's component subscribes to.
+       */
+      readonly open: (
+        view: View,
+        options?: LiveViewOptions,
+      ) => Effect.Effect<LiveViewHandle, never, Scope.Scope>;
+    };
+
+    /** Run work behind a progress row and collapse it to a final status line. */
+    readonly task: <A, E, R>(
+      options: ProgressOptions,
+      effect: Effect.Effect<A, E, R>,
+    ) => Effect.Effect<A, E, R>;
+  }
+>()("Alchemy::CliKit") {}
+
+/** Effectful service accessors for code that must defer acquisition to use time. */
+export const accessors = {
+  output: {
+    info: (message: string | MessageOptions) =>
+      Effect.flatMap(CliKit, (service) => service.output.info(message)),
+    success: (message: string | MessageOptions) =>
+      Effect.flatMap(CliKit, (service) => service.output.success(message)),
+    warning: (message: string | MessageOptions) =>
+      Effect.flatMap(CliKit, (service) => service.output.warning(message)),
+    error: (message: string | MessageOptions) =>
+      Effect.flatMap(CliKit, (service) => service.output.error(message)),
+  },
+  prompt: {
+    text: (options: TextInputOptions) =>
+      Effect.flatMap(CliKit, (service) => service.prompt.text(options)),
+    password: (options: PasswordInputOptions) =>
+      Effect.flatMap(CliKit, (service) => service.prompt.password(options)),
+    confirm: (options: ConfirmOptions) =>
+      Effect.flatMap(CliKit, (service) => service.prompt.confirm(options)),
+    select: <Value>(options: SelectOptions<Value>) =>
+      Effect.flatMap(CliKit, (service) => service.prompt.select(options)),
+    multiSelect: <Value>(options: MultiSelectOptions<Value>) =>
+      Effect.flatMap(CliKit, (service) => service.prompt.multiSelect(options)),
+  },
+};
+
+const ApplicationPresentation = Context.Reference<"inline" | "alternate">(
+  "Alchemy::CliKit/ApplicationPresentation",
+  { defaultValue: () => "inline" },
+);
+
+/** Pipeable presentation modifiers for {@link CliKit.application}. */
+export const Application = {
+  alternate: <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+    effect.pipe(
+      Effect.provideService(ApplicationPresentation, "alternate" as const),
+    ),
+};
+
+export const applicationPresentation = ApplicationPresentation;

--- a/packages/alchemy/src/Cli/CliKit/SigilRuntime.tsx
+++ b/packages/alchemy/src/Cli/CliKit/SigilRuntime.tsx
@@ -1,0 +1,879 @@
+/** @jsxImportSource react */
+import { stripVTControlCharacters } from "node:util";
+import * as Cause from "effect/Cause";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Semaphore from "effect/Semaphore";
+import type * as Scope from "effect/Scope";
+import { Box, render, renderToString, Static } from "@alchemy.run/sigil";
+import { type ReactNode, useSyncExternalStore } from "react";
+import { Spinner, Status } from "./components/Feedback.tsx";
+import { CliEnvironment } from "./components/Environment.tsx";
+import { useTerminalInput } from "./components/Interactive.tsx";
+import { LiveStore, useLiveStore } from "./components/Live.tsx";
+import { CancelledPrompt } from "./components/Transcript.tsx";
+import { Text } from "./components/Typography.tsx";
+import { NonInteractiveTerminal, TerminalCancelled } from "./errors.ts";
+import {
+  confirmScreen,
+  cycleSelectScreen,
+  awaitExternalScreen,
+  menuScreen,
+  multiSelectScreen,
+  passwordScreen,
+  selectScreen,
+  textScreen,
+} from "./screens.tsx";
+import { applicationPresentation, CliKit } from "./CliKit.ts";
+import type {
+  ProgressHandle,
+  ProgressOptions,
+  RenderOptions,
+  Screen,
+  MenuOptions,
+  CliKitCapabilities,
+  CliKitOptions,
+  InteractionError,
+  LiveViewHandle,
+  LiveViewOptions,
+  View,
+} from "./types.ts";
+
+const InApplication = Context.Reference<boolean>(
+  "Alchemy::CliKit/InApplication",
+  { defaultValue: () => false },
+);
+
+/**
+ * One rendered block. Views are immutable once mounted — dynamic content
+ * flows through caller-owned stores (`LiveStore` + `useLiveStore`) that the
+ * view component subscribes to, never through the runtime.
+ */
+interface Item {
+  readonly key: number;
+  readonly view: View;
+  readonly placement?: LiveViewOptions["placement"];
+}
+
+const normalizeView = (view: View): View => {
+  if (
+    typeof view === "string" ||
+    typeof view === "number" ||
+    typeof view === "bigint"
+  ) {
+    return <Text>{String(view)}</Text>;
+  }
+  // Contract: an array of primitives renders as ONE Text line with the
+  // elements concatenated (no separator) — matching how React renders
+  // adjacent text children. Callers wanting separators must join themselves.
+  if (
+    Array.isArray(view) &&
+    view.every(
+      (item) =>
+        item === null ||
+        item === undefined ||
+        typeof item === "boolean" ||
+        typeof item === "string" ||
+        typeof item === "number" ||
+        typeof item === "bigint",
+    )
+  ) {
+    return (
+      <Text>
+        {view
+          .filter(
+            (item) =>
+              item !== null && item !== undefined && typeof item !== "boolean",
+          )
+          .map(String)
+          .join("")}
+      </Text>
+    );
+  }
+  return view;
+};
+
+interface StoreState {
+  readonly staticItems: Item[];
+  readonly transcript: ReadonlyArray<Item>;
+  readonly live: ReadonlyArray<Item>;
+  readonly active?: Item;
+}
+
+/**
+ * The single external store the React root syncs from. It only tracks WHICH
+ * blocks are mounted and in what region (static scrollback, in-application
+ * transcript, live region, active prompt) — block content never changes
+ * after mount, so there is no update surface here.
+ */
+class TerminalStore {
+  private state: StoreState = { staticItems: [], transcript: [], live: [] };
+  private readonly listeners = new Set<() => void>();
+  private nextKey = 0;
+
+  readonly subscribe = (listener: () => void) => {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  };
+  readonly snapshot = () => this.state;
+
+  private commit(state: StoreState) {
+    this.state = state;
+    for (const listener of this.listeners) listener();
+  }
+
+  alloc() {
+    return this.nextKey++;
+  }
+
+  append(view: View) {
+    this.commit({
+      ...this.state,
+      transcript: [...this.state.transcript, { key: this.alloc(), view }],
+    });
+  }
+
+  appendStatic(view: View) {
+    this.commit({
+      ...this.state,
+      staticItems: [...this.state.staticItems, { key: this.alloc(), view }],
+    });
+  }
+
+  addLive(
+    key: number,
+    view: View,
+    placement: LiveViewOptions["placement"] = "afterTranscript",
+  ) {
+    this.commit({
+      ...this.state,
+      live: [...this.state.live, { key, view, placement }],
+    });
+  }
+
+  removeLive(key: number) {
+    this.commit({
+      ...this.state,
+      live: this.state.live.filter((entry) => entry.key !== key),
+    });
+  }
+
+  /**
+   * Move a live block into scrollback (its component renders one final time
+   * from its store's final state). No-op when the row was already cleared.
+   */
+  completeLive(key: number, destination: "staticItems" | "transcript") {
+    const item = this.state.live.find((entry) => entry.key === key);
+    if (item === undefined) return;
+    this.commit({
+      ...this.state,
+      [destination]: [
+        ...this.state[destination],
+        { key: this.alloc(), view: item.view },
+      ],
+      live: this.state.live.filter((entry) => entry.key !== key),
+    });
+  }
+
+  activate(view: View) {
+    this.commit({ ...this.state, active: { key: this.alloc(), view } });
+  }
+
+  deactivate() {
+    if (this.state.active !== undefined)
+      this.commit({ ...this.state, active: undefined });
+  }
+
+  clear() {
+    this.commit({ ...this.state, transcript: [], live: [] });
+  }
+
+  clearStatic() {
+    if (this.state.staticItems.length > 0) {
+      this.commit({ ...this.state, staticItems: [] });
+    }
+  }
+
+  clearTranscript() {
+    if (this.state.transcript.length > 0) {
+      this.commit({ ...this.state, transcript: [] });
+    }
+  }
+
+  get idle() {
+    return this.state.active === undefined && this.state.live.length === 0;
+  }
+}
+
+/**
+ * Always-on Ctrl+C handler wrapped around every screen by `run`. Screens no
+ * longer need their own Ctrl+C wiring (a screen that forgot it used to make
+ * the CLI unkillable, since Sigil runs with `exitOnCtrlC: false` in raw mode);
+ * they only handle Escape, whose semantics differ per screen.
+ */
+type ScreenCancelGuardProps = {
+  readonly onCancel: () => void;
+  readonly children?: ReactNode;
+};
+
+function ScreenCancelGuard({ onCancel, children }: ScreenCancelGuardProps) {
+  useTerminalInput(
+    (input, key) => {
+      if (key.ctrl && input === "c") onCancel();
+    },
+    { active: true },
+  );
+  return <>{children}</>;
+}
+
+type ItemViewProps = { readonly item: Item };
+
+function ItemView({ item }: ItemViewProps) {
+  return <Box flexDirection="column">{item.view}</Box>;
+}
+
+type TerminalRootProps = {
+  readonly store: TerminalStore;
+  readonly onInterrupt: () => void;
+};
+
+function TerminalRoot({ store, onInterrupt }: TerminalRootProps) {
+  const state = useSyncExternalStore(store.subscribe, store.snapshot);
+  useTerminalInput(
+    (input, key) => {
+      if (key.ctrl && input === "c") onInterrupt();
+    },
+    { active: state.active === undefined },
+  );
+  const beforeTranscript = state.live.filter(
+    (item) => item.placement === "beforeTranscript",
+  );
+  const afterTranscript = state.live.filter(
+    (item) => item.placement !== "beforeTranscript",
+  );
+  return (
+    <Box flexDirection="column">
+      <Static items={state.staticItems}>
+        {(item) => <ItemView key={item.key} item={item} />}
+      </Static>
+      {beforeTranscript.map((item) => (
+        <ItemView key={item.key} item={item} />
+      ))}
+      {state.transcript.map((item) => (
+        <ItemView key={item.key} item={item} />
+      ))}
+      {afterTranscript.map((item) => (
+        <ItemView key={item.key} item={item} />
+      ))}
+      {state.active === undefined ? null : (
+        <Box marginTop={state.transcript.length > 0 ? 1 : 0}>
+          <ItemView key={state.active.key} item={state.active} />
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+const formatStaticView = (
+  view: ReactNode,
+  options: RenderOptions,
+  capabilities: CliKitCapabilities,
+): string => {
+  const colors = options.colors ?? capabilities.colors;
+  // The renderer and the components must agree on the width: components size
+  // themselves from the environment's `columns`, so an explicit render width
+  // has to flow into the capabilities too, not only into renderToString.
+  const columns = options.columns ?? capabilities.columns;
+  const output = renderToString(
+    <CliEnvironment capabilities={{ ...capabilities, colors, columns }}>
+      {view}
+    </CliEnvironment>,
+    { columns },
+  ).replace(/[\s\n]+$/, "");
+  return colors ? output : stripVTControlCharacters(output);
+};
+
+/** Progress rows are ordinary live views over a runtime-owned store. */
+interface ProgressState {
+  readonly options: ProgressOptions;
+  readonly final?: {
+    readonly variant: "success" | "error";
+    readonly message?: string;
+  };
+}
+
+type ProgressViewProps = {
+  readonly store: LiveStore<ProgressState>;
+};
+
+function ProgressView({ store }: ProgressViewProps) {
+  const state = useLiveStore(store);
+  return state.final === undefined ? (
+    <Spinner label={state.options.label} detail={state.options.detail} />
+  ) : (
+    <Status variant={state.final.variant}>
+      {state.final.message ?? state.options.label}
+    </Status>
+  );
+}
+
+export interface CliKitRuntime {
+  readonly service: CliKit["Service"];
+  readonly dispose: () => Promise<void>;
+}
+
+export const makeRuntime = (
+  options: CliKitOptions,
+  capabilities: CliKitCapabilities,
+): CliKitRuntime => {
+  const stdin = options.stdin ?? process.stdin;
+  const stdout = options.stdout ?? process.stdout;
+  const stderr = options.stderr ?? process.stderr;
+  const onInterrupt =
+    options.onInterrupt ?? (() => process.kill(process.pid, "SIGINT"));
+  const store = new TerminalStore();
+  const rendererGate = Semaphore.makeUnsafe(1);
+  const promptGate = Semaphore.makeUnsafe(1);
+
+  interface Mounted {
+    readonly ink: ReturnType<typeof render>;
+    readonly alternate: boolean;
+    /** Settles when the instance exits; render crashes are routed out, never rethrown. */
+    exit: Promise<void>;
+  }
+  let mounted: Mounted | undefined;
+  let unmounting: Promise<void> | undefined;
+  let applicationMounted = false;
+  let disposed = false;
+  let flushDirectStdio: (() => void) | undefined;
+  /**
+   * Fails the active interaction when a screen component throws during
+   * render. Without this the prompt's callback would never resume and the
+   * CLI would hang with a dead renderer.
+   */
+  let failActive: ((error: unknown) => void) | undefined;
+
+  const mount = async (alternateScreen = false): Promise<void> => {
+    // Never overlap a new Sigil root with one that is still tearing down —
+    // Sigil keys instances by stdout and two live roots corrupt the output.
+    while (unmounting !== undefined) await unmounting;
+    if (disposed || mounted !== undefined) return;
+    const captureDirectStdio = options.captureConsole !== false;
+    // Process output lives in the renderer's Static zone above every inline
+    // view. Adding a static row commits it to scrollback and naturally moves
+    // the live UI down, avoiding log-update's erase/restore path and its
+    // render artifacts. `patchConsole: "stdio"` captures console, Node
+    // warnings, and direct stream writes from tools such as Floci (the
+    // renderer's own frames go through passthrough facades and bypass the
+    // capture); `onCapturedOutput` takes ownership of each raw chunk so the
+    // Static transcript renders it instead of the built-in splicing. The
+    // renderer restores console and stream writes itself on unmount.
+    const buffers = { stdout: "", stderr: "" };
+    const appendLines = (stream: keyof typeof buffers, data: string) => {
+      const parts = `${buffers[stream]}${data}`.split(/\r?\n/);
+      buffers[stream] = parts.pop() ?? "";
+      for (const line of parts) store.appendStatic(<Text>{line || " "}</Text>);
+    };
+    const ink = render(
+      <CliEnvironment capabilities={capabilities} observeWindow>
+        <TerminalRoot store={store} onInterrupt={onInterrupt} />
+      </CliEnvironment>,
+      {
+        stdin,
+        stdout,
+        stderr,
+        exitOnCtrlC: false,
+        interactive: capabilities.input,
+        alternateScreen: alternateScreen,
+        ...(captureDirectStdio
+          ? {
+              patchConsole: "stdio" as const,
+              onCapturedOutput: (stream: "stdout" | "stderr", data: string) => {
+                appendLines(stream, data);
+                return true;
+              },
+            }
+          : { patchConsole: false as const }),
+      },
+    );
+    const current: Mounted = {
+      ink,
+      alternate: alternateScreen,
+      exit: Promise.resolve(),
+    };
+    // Capture the exit promise at mount time: Sigil registers its process
+    // `beforeExit` listener on the first `waitUntilExit()` call and `unmount`
+    // only removes a listener that already exists, so waiting only after
+    // unmount leaks one process listener per mount cycle. A rejection means a
+    // component threw during render — Sigil has already unmounted itself, so
+    // drop the dead instance and surface the error instead of hanging.
+    current.exit = ink.waitUntilExit().then(
+      () => undefined,
+      (error: unknown) => {
+        if (mounted === current) mounted = undefined;
+        if (failActive !== undefined) failActive(error);
+        else stderr.write(`CliKit renderer error: ${String(error)}\n`);
+      },
+    );
+    mounted = current;
+
+    // Flush any partial captured line into the Static transcript — called
+    // at unmount so trailing output without a newline still lands.
+    if (captureDirectStdio) {
+      flushDirectStdio = () => {
+        for (const stream of ["stdout", "stderr"] as const) {
+          if (buffers[stream] !== "") {
+            store.appendStatic(<Text>{buffers[stream]}</Text>);
+            buffers[stream] = "";
+          }
+        }
+      };
+    }
+  };
+
+  const ensureMounted = () => Effect.promise(() => mount());
+
+  const waitForRender = () =>
+    mounted?.ink.waitUntilRenderFlush().catch(() => undefined) ??
+    Promise.resolve();
+
+  /**
+   * Tear down the renderer. Total (never rejects) and re-validated across its
+   * awaits: output printed or live views opened while the final frame flushes
+   * abort the teardown instead of being destroyed with it. `force` skips the
+   * re-validation for dispose and presentation switches.
+   */
+  const unmount = (force = false): Promise<void> => {
+    if (unmounting !== undefined) return unmounting;
+    const current = mounted;
+    if (current === undefined) return Promise.resolve();
+    unmounting = (async () => {
+      try {
+        flushDirectStdio?.();
+        // Drain: keep flushing until no new static output arrives between
+        // flushes, so a `print` racing the teardown reaches the terminal.
+        let staticCount;
+        do {
+          staticCount = store.snapshot().staticItems.length;
+          await current.ink.waitUntilRenderFlush();
+        } while (store.snapshot().staticItems.length !== staticCount);
+        // Re-validate: a prompt or live view may have re-armed the renderer
+        // while the frame flushed. Their output would be destroyed by the
+        // teardown, so leave the instance mounted for them instead.
+        if (!force && (applicationMounted || !store.idle)) return;
+        mounted = undefined;
+        flushDirectStdio = undefined;
+        // unmount restores the patched console and stream writes.
+        current.ink.unmount();
+        await current.exit;
+        current.ink.cleanup();
+        // Static output has been handed off to the terminal. Do not replay
+        // it when a later live session mounts a fresh Sigil root.
+        store.clearStatic();
+      } catch {
+        // Teardown must be total: a crashed instance still ends up unmounted
+        // with console/stream patches restored.
+        if (mounted === current) mounted = undefined;
+        flushDirectStdio = undefined;
+        try {
+          current.ink.unmount();
+        } catch {
+          // Already unmounted (or unmount itself is what threw above).
+        }
+      }
+    })().finally(() => {
+      unmounting = undefined;
+    });
+    return unmounting;
+  };
+
+  const releaseIfIdle = () =>
+    Effect.suspend(() =>
+      applicationMounted || !store.idle
+        ? Effect.void
+        : Effect.promise(() => unmount()),
+    );
+
+  const formatView = (view: View, renderOptions: RenderOptions = {}) =>
+    formatStaticView(normalizeView(view), renderOptions, {
+      ...capabilities,
+      // Re-read the width at render time — the boot-time snapshot goes stale
+      // the moment the user resizes the terminal.
+      columns: stdout.columns ?? capabilities.columns,
+    });
+
+  const renderView = (view: View, renderOptions: RenderOptions = {}) =>
+    Effect.sync(() => formatView(view, renderOptions));
+
+  const print = (view: View, renderOptions: RenderOptions = {}) =>
+    Effect.gen(function* () {
+      const inApplication = yield* InApplication;
+      view = normalizeView(view);
+      if (inApplication) {
+        yield* Effect.sync(() => store.append(view));
+      } else if (mounted !== undefined) {
+        yield* Effect.sync(() => store.appendStatic(view));
+      } else {
+        const output = yield* renderView(view, renderOptions);
+        if (output !== "")
+          yield* Effect.sync(() => stdout.write(`${output}\n`));
+      }
+    });
+
+  const messageOptions = (
+    message: string | { message: string; detail?: string },
+  ) => (typeof message === "string" ? { message } : message);
+
+  const log =
+    (variant: "info" | "success" | "warning" | "error") =>
+    (message: string | { message: string; detail?: string }) => {
+      const options = messageOptions(message);
+      return print(
+        <Status variant={variant} detail={options.detail}>
+          {options.message}
+        </Status>,
+      );
+    };
+
+  const run = <Value,>(screen: Screen<Value>) => {
+    if (!capabilities.input) {
+      return Effect.fail(
+        new NonInteractiveTerminal({
+          operation: screen.name,
+          message: `Cannot run ${screen.name} without an interactive terminal. Provide the equivalent command flags instead.`,
+        }),
+      );
+    }
+    return Effect.gen(function* () {
+      const inApplication = yield* InApplication;
+      const interaction = promptGate.withPermits(1)(
+        Effect.gen(function* () {
+          let completedView: View | undefined;
+          return yield* Effect.callback<Value, TerminalCancelled>((resume) => {
+            let settled = false;
+            const finish = (
+              result: Effect.Effect<Value, TerminalCancelled>,
+              resultView?: View,
+            ) => {
+              if (settled) return;
+              settled = true;
+              failActive = undefined;
+              store.deactivate();
+              if (resultView !== undefined) {
+                if (inApplication) store.append(normalizeView(resultView));
+                else completedView = resultView;
+              }
+              resume(result);
+            };
+            const cancel = () =>
+              finish(
+                Effect.fail(new TerminalCancelled()),
+                <CancelledPrompt message={screen.name} />,
+              );
+            // A screen that throws during render unmounts Sigil with the error;
+            // without this hook the callback would never resume and the CLI
+            // would hang forever on a dead renderer.
+            failActive = (error) => finish(Effect.die(error));
+            store.activate(
+              <ScreenCancelGuard onCancel={cancel}>
+                {screen.render({
+                  submit: (value, summary) =>
+                    finish(Effect.succeed(value), summary),
+                  cancel,
+                })}
+              </ScreenCancelGuard>,
+            );
+            void mount();
+            // Interruption cleanup: deactivate the screen and let the caller's
+            // finalizers release the renderer.
+            return Effect.sync(() => {
+              if (!settled) {
+                settled = true;
+                failActive = undefined;
+                store.deactivate();
+              }
+            });
+          }).pipe(
+            Effect.ensuring(
+              Effect.suspend(() =>
+                inApplication
+                  ? Effect.void
+                  : releaseIfIdle().pipe(
+                      Effect.andThen(
+                        completedView === undefined
+                          ? Effect.void
+                          : print(completedView),
+                      ),
+                    ),
+              ),
+            ),
+          );
+        }),
+      );
+      return yield* inApplication
+        ? interaction
+        : rendererGate.withPermits(1)(interaction);
+    });
+  };
+
+  const menu = <Value,>(
+    options: MenuOptions<Value>,
+  ): Effect.Effect<Value, InteractionError> =>
+    Effect.gen(function* () {
+      if (yield* InApplication) yield* Effect.sync(() => store.clear());
+      return yield* run(menuScreen(options));
+    });
+
+  const app = <A, E, R>(
+    effect: Effect.Effect<A, E, R>,
+  ): Effect.Effect<A, E | NonInteractiveTerminal, R> =>
+    !capabilities.input
+      ? Effect.fail(
+          new NonInteractiveTerminal({
+            operation: "application",
+            message:
+              "Cannot run a CLI application without terminal input. Provide the equivalent command flags instead.",
+          }),
+        )
+      : Effect.gen(function* () {
+          if (yield* InApplication) return yield* effect;
+          const presentation = yield* applicationPresentation;
+          const alternate =
+            presentation === "alternate" && capabilities.alternateScreen;
+          return yield* rendererGate.withPermits(1)(
+            Effect.acquireUseRelease(
+              Effect.promise(async () => {
+                applicationMounted = true;
+                store.clear();
+                // Sigil cannot change `alternateScreen` on a live instance: if
+                // an inline renderer (say an earlier progress row) is still
+                // mounted with the wrong presentation, remount with the
+                // requested one instead of silently ignoring it.
+                if (mounted !== undefined && mounted.alternate !== alternate) {
+                  await unmount(true);
+                }
+                await mount(alternate);
+              }),
+              () => effect.pipe(Effect.provideService(InApplication, true)),
+              () =>
+                Effect.promise(async () => {
+                  applicationMounted = false;
+                  store.clear();
+                  // Let the empty frame replace the application, then erase
+                  // that frame explicitly. Unmount can now restore terminal
+                  // modes without leaving the empty frame's newline behind.
+                  const current = mounted;
+                  if (current !== undefined) {
+                    await current.ink.waitUntilRenderFlush();
+                    current.ink.clear();
+                  }
+                  await unmount();
+                }),
+            ),
+          );
+        });
+
+  // A wizard owns the renderer when invoked standalone and reuses the
+  // current application renderer when nested. Prompt serialization remains
+  // centralized in `run`, so nested profile/OAuth flows suspend cleanly.
+  const wizard = <A, E, R>(
+    effect: Effect.Effect<A, E, R>,
+  ): Effect.Effect<A, E | NonInteractiveTerminal, R> =>
+    Effect.gen(function* () {
+      if (!(yield* InApplication)) return yield* app(effect);
+      return yield* effect.pipe(
+        Effect.ensuring(Effect.sync(() => store.clearTranscript())),
+      );
+    });
+
+  const makeLive = (
+    initial: View,
+    options: LiveViewOptions = {},
+  ): Effect.Effect<LiveViewHandle> =>
+    Effect.gen(function* () {
+      if (!capabilities.input) {
+        yield* print(initial);
+        return { close: Effect.void };
+      }
+      const inApplication = yield* InApplication;
+      const key = store.alloc();
+      let closed = false;
+      yield* Effect.sync(() =>
+        store.addLive(key, normalizeView(initial), options.placement),
+      );
+      yield* ensureMounted();
+      return {
+        close: Effect.suspend(() => {
+          if (closed) return Effect.void;
+          closed = true;
+          // removeLive/completeLive no-op when the row was already cleared
+          // by a menu loop or application boundary.
+          if (options.persistOnClose)
+            store.completeLive(
+              key,
+              inApplication ? "transcript" : "staticItems",
+            );
+          else store.removeLive(key);
+          return Effect.promise(waitForRender).pipe(
+            Effect.andThen(releaseIfIdle()),
+          );
+        }),
+      };
+    });
+
+  /**
+   * Scope-bound: the enclosing scope closes the view as a backstop, so an
+   * interrupted caller can never leave an orphaned row keeping the renderer
+   * mounted (and the process alive) forever.
+   */
+  const live = (
+    initial: View,
+    options: LiveViewOptions = {},
+  ): Effect.Effect<LiveViewHandle, never, Scope.Scope> =>
+    Effect.acquireRelease(makeLive(initial, options), (handle) => handle.close);
+
+  /**
+   * A progress row is just a live view over a runtime-owned store — the
+   * handle mutates the store, React re-renders. Settling swaps the store to
+   * its final state and commits the block to scrollback.
+   */
+  const makeProgress = (
+    initial: ProgressOptions,
+  ): Effect.Effect<ProgressHandle> =>
+    Effect.gen(function* () {
+      const dynamic =
+        capabilities.input && ((yield* InApplication) || stdout.isTTY === true);
+      if (!dynamic) {
+        let current = initial;
+        let closed = false;
+        yield* print(
+          <Status variant="info" detail={initial.detail}>
+            {initial.label}
+          </Status>,
+        );
+        const settle = (variant: "success" | "error", message?: string) =>
+          Effect.suspend(() => {
+            if (closed) return Effect.void;
+            closed = true;
+            return print(
+              <Status variant={variant}>{message ?? current.label}</Status>,
+            );
+          });
+        return {
+          update: (next) =>
+            Effect.sync(() => {
+              if (!closed) current = next;
+            }),
+          succeed: (message) => settle("success", message),
+          fail: (message) => settle("error", message),
+          close: Effect.sync(() => {
+            closed = true;
+          }),
+        } satisfies ProgressHandle;
+      }
+      const inApplication = yield* InApplication;
+      const progressStore = new LiveStore<ProgressState>({ options: initial });
+      const key = store.alloc();
+      yield* Effect.sync(() =>
+        store.addLive(key, <ProgressView store={progressStore} />),
+      );
+      yield* ensureMounted();
+      let settled = false;
+      const finishRow = (persist: boolean) =>
+        Effect.suspend(() => {
+          if (settled) return Effect.void;
+          settled = true;
+          // completeLive/removeLive no-op when the row was already cleared
+          // by a menu loop or application boundary.
+          if (persist)
+            store.completeLive(
+              key,
+              inApplication ? "transcript" : "staticItems",
+            );
+          else store.removeLive(key);
+          return Effect.promise(waitForRender).pipe(
+            Effect.andThen(releaseIfIdle()),
+          );
+        });
+      const settle = (variant: "success" | "error", message?: string) =>
+        Effect.suspend(() => {
+          if (settled) return Effect.void;
+          progressStore.update((state) => ({
+            ...state,
+            final: { variant, message },
+          }));
+          return finishRow(true);
+        });
+      return {
+        update: (next) =>
+          Effect.sync(() => {
+            if (!settled) progressStore.set({ options: next });
+          }),
+        succeed: (message) => settle("success", message),
+        fail: (message) => settle("error", message),
+        // An unsettled close abandons the row rather than committing it.
+        close: finishRow(false),
+      } satisfies ProgressHandle;
+    });
+
+  const progress = (
+    initial: ProgressOptions,
+  ): Effect.Effect<ProgressHandle, never, Scope.Scope> =>
+    Effect.acquireRelease(makeProgress(initial), (handle) => handle.close);
+
+  const service: CliKit["Service"] = {
+    terminal: capabilities,
+    output: {
+      print,
+      format: formatView,
+      render: renderView,
+      info: log("info"),
+      success: log("success"),
+      warning: log("warning"),
+      error: log("error"),
+    },
+    prompt: {
+      text: (inputOptions) => run(textScreen(inputOptions)),
+      password: (inputOptions) => run(passwordScreen(inputOptions)),
+      confirm: (confirmOptions) => run(confirmScreen(confirmOptions)),
+      select: (selectOptions) => run(selectScreen(selectOptions)),
+      multiSelect: (selectOptions) => run(multiSelectScreen(selectOptions)),
+      cycle: (selectOptions) => run(cycleSelectScreen(selectOptions)),
+      awaitExternal: (externalOptions) =>
+        run(awaitExternalScreen(externalOptions)),
+      menu,
+      custom: run,
+    },
+    wizard,
+    application: app,
+    live: { progress, open: live },
+    task: (taskOptions, effect) =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const handle = yield* progress(taskOptions);
+          return yield* effect.pipe(
+            Effect.onExit((exit) =>
+              Exit.isSuccess(exit)
+                ? handle.succeed()
+                : // Interruption (Ctrl+C) is not a failure — remove the row
+                  // instead of painting a red error status.
+                  Cause.hasInterruptsOnly(exit.cause)
+                  ? handle.close
+                  : handle.fail(),
+            ),
+          );
+        }),
+      ),
+  };
+
+  return {
+    service,
+    dispose: async () => {
+      // After dispose the runtime must never mount again; force teardown even
+      // if stray live rows were leaked.
+      disposed = true;
+      await unmount(true);
+    },
+  };
+};

--- a/packages/alchemy/src/Cli/CliKit/components.ts
+++ b/packages/alchemy/src/Cli/CliKit/components.ts
@@ -1,0 +1,69 @@
+/**
+ * Composable terminal layouts and interaction widgets.
+ *
+ * This is a separate entrypoint from `alchemy/Cli/CliKit` so importing the
+ * injectable service does not eagerly load React, Sigil or Yoga.
+ */
+export {
+  CliEnvironment,
+  useBorderStyle,
+  useCliEnvironment,
+  useGlyphs,
+  useKeyGlyphs,
+} from "./components/Environment.tsx";
+export {
+  Box,
+  Gutter,
+  Heading,
+  Row,
+  SectionHeading,
+  Stack,
+  Viewport,
+  type BoxProps,
+  type RowProps,
+  type StackProps,
+} from "./components/Layout.tsx";
+export {
+  Link,
+  Text,
+  type TextProps,
+  type TextTone,
+} from "./components/Typography.tsx";
+export {
+  Alert,
+  KeyBar,
+  ProgressBar,
+  Spinner,
+  SpinnerGlyph,
+  Status,
+  Tabs,
+  Toast,
+  type AlertProps,
+  type StatusProps,
+  type ToastProps,
+} from "./components/Feedback.tsx";
+export { DescriptionList, type DescriptionItem } from "./components/Data.tsx";
+export {
+  BooleanChoice,
+  CycleList,
+  InlineConfirm,
+  PromptFrame,
+  TextField,
+  useCycleNavigation,
+  useTerminalInput,
+  useTerminalPaste,
+  useTerminalSize,
+  type CycleListProps,
+  type PromptFrameProps,
+  type TerminalKey,
+  type TextFieldProps,
+} from "./components/Interactive.tsx";
+export { AnsweredPrompt, CancelledPrompt } from "./components/Transcript.tsx";
+export {
+  LiveStore,
+  ProgressGroup,
+  TaskRow,
+  useLiveStore,
+  type ProgressGroupRow,
+  type TaskRowProps,
+} from "./components/Live.tsx";

--- a/packages/alchemy/src/Cli/CliKit/components/Data.tsx
+++ b/packages/alchemy/src/Cli/CliKit/components/Data.tsx
@@ -1,0 +1,37 @@
+/** @jsxImportSource react */
+import type { ReactNode } from "react";
+import { Box } from "./Layout.tsx";
+import { Text } from "./Typography.tsx";
+
+export interface DescriptionItem {
+  readonly label: ReactNode;
+  readonly value: ReactNode;
+}
+
+type DescriptionListProps = {
+  readonly items: ReadonlyArray<DescriptionItem>;
+  readonly labelWidth?: number;
+  /** Put values on their own line when horizontal space must not truncate them. */
+  readonly stacked?: boolean;
+};
+
+export function DescriptionList({
+  items,
+  labelWidth = 16,
+  stacked = false,
+}: DescriptionListProps) {
+  return (
+    <Box flexDirection="column" gap={stacked ? 1 : 0}>
+      {items.map((item, index) => (
+        <Box key={index} flexDirection={stacked ? "column" : "row"}>
+          <Box width={stacked ? undefined : labelWidth} paddingRight={1}>
+            <Text tone="muted">{item.label}</Text>
+          </Box>
+          <Box paddingLeft={stacked ? 1 : 0}>
+            <Text>{item.value}</Text>
+          </Box>
+        </Box>
+      ))}
+    </Box>
+  );
+}

--- a/packages/alchemy/src/Cli/CliKit/components/Environment.tsx
+++ b/packages/alchemy/src/Cli/CliKit/components/Environment.tsx
@@ -1,0 +1,86 @@
+/** @jsxImportSource react */
+import { useWindowSize } from "@alchemy.run/sigil";
+import { createContext, type ReactNode, useContext, useMemo } from "react";
+import type { CliKitCapabilities } from "../types.ts";
+import { glyphsFor, theme, type KeyHint } from "../theme.ts";
+
+const defaults: CliKitCapabilities = {
+  input: false,
+  columns: 80,
+  rows: 24,
+  colors: false,
+  unicode: true,
+  alternateScreen: false,
+};
+
+const EnvironmentContext = createContext<CliKitCapabilities>(defaults);
+
+/**
+ * Resize-following variant, split out so the static renderer (`renderToString`
+ * for every print/format) never attaches a `resize` listener to stdout.
+ */
+type ObservingEnvironmentProps = {
+  readonly capabilities: CliKitCapabilities;
+  readonly children?: ReactNode;
+};
+
+function ObservingEnvironment({
+  capabilities,
+  children,
+}: ObservingEnvironmentProps) {
+  const window = useWindowSize();
+  const environment = useMemo(
+    () => ({ ...capabilities, columns: window.columns, rows: window.rows }),
+    [capabilities, window.columns, window.rows],
+  );
+  return (
+    <EnvironmentContext.Provider value={environment}>
+      {children}
+    </EnvironmentContext.Provider>
+  );
+}
+
+type CliEnvironmentProps = {
+  readonly capabilities: CliKitCapabilities;
+  /** Follow Sigil's terminal resize subscription for a live renderer. */
+  readonly observeWindow?: boolean;
+  readonly children?: ReactNode;
+};
+
+export function CliEnvironment({
+  capabilities,
+  observeWindow = false,
+  children,
+}: CliEnvironmentProps) {
+  return observeWindow ? (
+    <ObservingEnvironment capabilities={capabilities}>
+      {children}
+    </ObservingEnvironment>
+  ) : (
+    <EnvironmentContext.Provider value={capabilities}>
+      {children}
+    </EnvironmentContext.Provider>
+  );
+}
+
+export const useCliEnvironment = () => useContext(EnvironmentContext);
+
+export const useGlyphs = () => glyphsFor(useCliEnvironment().unicode);
+
+/** Border style matching the terminal's Unicode capability. */
+export const useBorderStyle = () =>
+  useCliEnvironment().unicode ? ("single" as const) : ("classic" as const);
+
+const asciiKeyHint: KeyHint = {
+  enter: "enter",
+  upDown: "up/down",
+  leftRight: "left/right",
+  escape: "esc",
+  space: "space",
+  tab: "tab",
+  yesNo: "y/n",
+};
+
+/** Key-hint labels for `KeyBar` footers, honoring the ASCII fallback. */
+export const useKeyGlyphs = (): KeyHint =>
+  useCliEnvironment().unicode ? theme.keyHint : asciiKeyHint;

--- a/packages/alchemy/src/Cli/CliKit/components/Feedback.tsx
+++ b/packages/alchemy/src/Cli/CliKit/components/Feedback.tsx
@@ -1,0 +1,257 @@
+/** @jsxImportSource react */
+import { useAnimation } from "@alchemy.run/sigil";
+import type { ReactNode } from "react";
+import { statusColor, theme, type StatusVariant } from "../theme.ts";
+import {
+  useBorderStyle,
+  useCliEnvironment,
+  useGlyphs,
+} from "./Environment.tsx";
+import { Box } from "./Layout.tsx";
+import { Text } from "./Typography.tsx";
+
+export interface StatusProps {
+  readonly variant?: StatusVariant;
+  readonly children?: ReactNode;
+  readonly detail?: ReactNode;
+}
+
+export function Status({ variant = "info", children, detail }: StatusProps) {
+  const glyphs = useGlyphs();
+  return (
+    <Box gap={1} flexWrap="wrap">
+      <Text color={statusColor(variant)}>{glyphs[variant]}</Text>
+      <Text color={variant === "error" ? statusColor(variant) : undefined}>
+        {children}
+      </Text>
+      {detail === undefined ? null : <Text tone="muted">· {detail}</Text>}
+    </Box>
+  );
+}
+
+export type ToastProps = StatusProps;
+
+/** Short-lived application notice with enough space to remain visually distinct. */
+export function Toast({ variant = "info", children, detail }: ToastProps) {
+  const borderStyle = useBorderStyle();
+  return (
+    <Box
+      paddingY={1}
+      paddingLeft={1}
+      borderStyle={borderStyle}
+      borderLeft
+      borderRight={false}
+      borderTop={false}
+      borderBottom={false}
+      borderColor={statusColor(variant)}
+    >
+      <Status variant={variant} detail={detail}>
+        {children}
+      </Status>
+    </Box>
+  );
+}
+
+export interface AlertProps extends StatusProps {
+  readonly title?: ReactNode;
+}
+
+export function Alert({
+  variant = "info",
+  title,
+  children,
+  detail,
+}: AlertProps) {
+  const borderStyle = useBorderStyle();
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle={borderStyle}
+      borderLeft
+      borderRight={false}
+      borderTop={false}
+      borderBottom={false}
+      borderColor={statusColor(variant)}
+      paddingLeft={1}
+    >
+      <Box gap={1} alignItems="center">
+        <Text
+          bold
+          color={theme.color.onAccent}
+          backgroundColor={statusColor(variant)}
+        >
+          {` ${variant.toUpperCase()} `}
+        </Text>
+        {title === undefined ? null : <Text bold>{title}</Text>}
+        {detail === undefined ? null : <Text tone="muted">· {detail}</Text>}
+      </Box>
+      <Box paddingLeft={1}>
+        <Text>{children}</Text>
+      </Box>
+    </Box>
+  );
+}
+
+type KeyBarProps = {
+  readonly keys: ReadonlyArray<readonly [key: string, label: string]>;
+  readonly marginTop?: number;
+};
+
+export function KeyBar({ keys, marginTop = 1 }: KeyBarProps) {
+  return (
+    <Box width="100%" flexWrap="wrap" marginTop={marginTop} paddingLeft={2}>
+      {keys.map(([key, label], index) => (
+        <Box key={`${key}:${label}`}>
+          {index === 0 ? null : <Text tone="muted"> • </Text>}
+          <Text>
+            <Text bold color={theme.color.success}>
+              {key}
+            </Text>
+            <Text tone="muted"> {label}</Text>
+          </Text>
+        </Box>
+      ))}
+    </Box>
+  );
+}
+
+const SPINNER_FRAMES = [
+  "⠋",
+  "⠙",
+  "⠹",
+  "⠸",
+  "⠼",
+  "⠴",
+  "⠦",
+  "⠧",
+  "⠇",
+  "⠏",
+] as const;
+const ASCII_SPINNER_FRAMES = ["-", "\\", "|", "/"] as const;
+
+export const useSpinnerFrame = (): string => {
+  const { unicode } = useCliEnvironment();
+  const frames = unicode ? SPINNER_FRAMES : ASCII_SPINNER_FRAMES;
+  const { frame } = useAnimation({ interval: 80 });
+  return frames[frame % frames.length] ?? ASCII_SPINNER_FRAMES[0];
+};
+
+/**
+ * Spinner-as-status-icon: one animated frame, colorable so it can stand in
+ * for a status glyph in trees and progress rows.
+ */
+type SpinnerGlyphProps = { readonly color?: string };
+
+export function SpinnerGlyph({ color }: SpinnerGlyphProps) {
+  return <Text color={color ?? theme.color.info}>{useSpinnerFrame()}</Text>;
+}
+
+type SpinnerProps = {
+  readonly label: ReactNode;
+  readonly detail?: ReactNode;
+};
+
+export function Spinner({ label, detail }: SpinnerProps) {
+  return (
+    <Box gap={1}>
+      <SpinnerGlyph />
+      <Text>{label}</Text>
+      {detail === undefined ? null : <Text tone="muted">{detail}</Text>}
+    </Box>
+  );
+}
+
+type ProgressBarProps = {
+  /** Completion ratio. Values outside 0..1 are clamped. */
+  readonly value: number;
+  readonly width?: number;
+  readonly showPercent?: boolean;
+  readonly label?: ReactNode;
+  readonly detail?: ReactNode;
+  readonly variant?: StatusVariant;
+};
+
+export function ProgressBar({
+  value,
+  width = 24,
+  showPercent = true,
+  label,
+  detail,
+  variant = "success",
+}: ProgressBarProps) {
+  const { unicode } = useCliEnvironment();
+  const ratio = Math.max(0, Math.min(1, value));
+  const cells = Math.max(1, Math.floor(width));
+  const filled = Math.round(cells * ratio);
+  return (
+    <Box
+      gap={1}
+      aria-role="progressbar"
+      aria-label={`${Math.round(ratio * 100)}%`}
+      aria-state={{ busy: ratio < 1 }}
+    >
+      <Text>
+        <Text color={statusColor(variant)}>
+          {(unicode ? "█" : "#").repeat(filled)}
+        </Text>
+        <Text tone="muted">{(unicode ? "░" : ".").repeat(cells - filled)}</Text>
+      </Text>
+      {showPercent ? (
+        <Text tone="muted">{`${Math.round(ratio * 100)}%`.padStart(4)}</Text>
+      ) : null}
+      {label === undefined ? null : <Text>{label}</Text>}
+      {detail === undefined ? null : <Text tone="muted">{detail}</Text>}
+    </Box>
+  );
+}
+
+type TabsProps = {
+  readonly tabs: ReadonlyArray<{
+    readonly id: string;
+    readonly label: string;
+    readonly marked?: boolean;
+  }>;
+  readonly active: string;
+};
+
+export function Tabs({ tabs, active }: TabsProps) {
+  const glyphs = useGlyphs();
+  return (
+    <Box
+      width="100%"
+      gap={1}
+      paddingLeft={2}
+      marginBottom={1}
+      aria-role="tablist"
+    >
+      {tabs.map((tab) => {
+        const selected = tab.id === active;
+        return (
+          <Box
+            key={tab.id}
+            paddingX={1}
+            backgroundColor={selected ? theme.color.accent : undefined}
+            aria-role="tab"
+            aria-label={tab.label}
+            aria-state={{ selected }}
+          >
+            <Text
+              bold={selected}
+              color={selected ? theme.color.onAccent : undefined}
+              dimColor={!selected}
+            >
+              {tab.marked ? (
+                <Text
+                  color={selected ? theme.color.onAccent : theme.color.brand}
+                >
+                  {glyphs.selected}{" "}
+                </Text>
+              ) : null}
+              {tab.label}
+            </Text>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}

--- a/packages/alchemy/src/Cli/CliKit/components/Interactive.tsx
+++ b/packages/alchemy/src/Cli/CliKit/components/Interactive.tsx
@@ -1,0 +1,993 @@
+/** @jsxImportSource react */
+import {
+  measureElement,
+  useCursor,
+  useInput,
+  usePaste,
+  useStdout,
+  type DOMElement,
+} from "@alchemy.run/sigil";
+import {
+  type JSX,
+  type ReactNode,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import stringWidth from "string-width";
+import type { Choice, CycleChoice } from "../types.ts";
+import { theme } from "../theme.ts";
+import { copyToClipboard, truncate } from "../terminal.ts";
+import {
+  useBorderStyle,
+  useCliEnvironment,
+  useGlyphs,
+  useKeyGlyphs,
+} from "./Environment.tsx";
+import { KeyBar, Spinner } from "./Feedback.tsx";
+import { Box } from "./Layout.tsx";
+import { Link, Text } from "./Typography.tsx";
+
+export interface TerminalKey {
+  readonly up: boolean;
+  readonly down: boolean;
+  readonly left: boolean;
+  readonly right: boolean;
+  readonly home: boolean;
+  readonly end: boolean;
+  readonly pageUp: boolean;
+  readonly pageDown: boolean;
+  readonly enter: boolean;
+  readonly escape: boolean;
+  readonly backspace: boolean;
+  readonly delete: boolean;
+  readonly tab: boolean;
+  readonly shift: boolean;
+  readonly ctrl: boolean;
+  readonly meta: boolean;
+}
+
+/** Backend facade for custom screens; callers never need to import Sigil. */
+export const useTerminalInput = (
+  handler: (input: string, key: TerminalKey) => void,
+  options?: { readonly active?: boolean },
+) => {
+  return useInput(
+    (input, key) =>
+      handler(input, {
+        up: key.upArrow,
+        down: key.downArrow,
+        left: key.leftArrow,
+        right: key.rightArrow,
+        home: key.home,
+        end: key.end,
+        pageUp: key.pageUp,
+        pageDown: key.pageDown,
+        enter: key.return,
+        escape: key.escape,
+        backspace: key.backspace,
+        delete: key.delete,
+        tab: key.tab,
+        shift: key.shift,
+        ctrl: key.ctrl,
+        meta: key.meta,
+      }),
+    { isActive: options?.active ?? true },
+  );
+};
+
+/** Bracketed-paste input scoped the same way as {@link useTerminalInput}. */
+export const useTerminalPaste = (
+  handler: (text: string) => void,
+  options?: { readonly active?: boolean },
+) => {
+  usePaste(handler, { isActive: options?.active ?? true });
+};
+
+export const useTerminalSize = () => {
+  const { columns, rows } = useCliEnvironment();
+  return { columns, rows };
+};
+
+export const useListNavigation = (length: number, initialIndex = 0) => {
+  const [cursor, setCursor] = useState(initialIndex);
+  const clamped = Math.max(0, Math.min(cursor, Math.max(0, length - 1)));
+  const move = (delta: number) =>
+    setCursor((current) => {
+      if (length === 0) return 0;
+      // Clamp before wrapping: after a filter shrinks the list the raw state
+      // can point past the end, and wrapping from there jumps arbitrarily.
+      const base = Math.max(0, Math.min(current, length - 1));
+      return (((base + delta) % length) + length) % length;
+    });
+  return { cursor: clamped, move, setCursor } as const;
+};
+
+/** Step `delta` rows from `cursor`, wrapping and skipping disabled rows. */
+export const moveSkippingDisabled = (
+  disabled: ReadonlyArray<boolean>,
+  cursor: number,
+  delta: number,
+): number => {
+  const length = disabled.length;
+  if (length === 0) return 0;
+  for (let offset = 1; offset <= length; offset++) {
+    const next = (((cursor + delta * offset) % length) + length) % length;
+    if (!disabled[next]) return next;
+  }
+  return cursor;
+};
+
+/**
+ * Jump to `target` (clamped, no wrap), settling on the nearest enabled row in
+ * the jump direction and falling back to the other direction. Used for
+ * Home/End and PageUp/PageDown in list prompts.
+ */
+export const jumpSkippingDisabled = (
+  disabled: ReadonlyArray<boolean>,
+  cursor: number,
+  target: number,
+): number => {
+  const clamped = Math.max(0, Math.min(disabled.length - 1, target));
+  if (!disabled[clamped]) return clamped;
+  const direction = clamped >= cursor ? 1 : -1;
+  for (
+    let next = clamped + direction;
+    next >= 0 && next < disabled.length;
+    next += direction
+  ) {
+    if (!disabled[next]) return next;
+  }
+  for (
+    let next = clamped - direction;
+    next >= 0 && next < disabled.length;
+    next -= direction
+  ) {
+    if (!disabled[next]) return next;
+  }
+  return cursor;
+};
+
+export interface MenuProps<Value> {
+  readonly choices: ReadonlyArray<Choice<Value>>;
+  readonly cursor: number;
+  readonly selected?: ReadonlySet<number>;
+  readonly visibleCount?: number;
+  readonly empty?: string;
+  readonly descriptionPlacement?: "below" | "inline";
+}
+
+/** Pure menu presentation used by select prompts and custom applications. */
+export function Menu<Value>({
+  choices,
+  cursor,
+  selected,
+  visibleCount = 12,
+  empty = "No choices.",
+  descriptionPlacement = "inline",
+}: MenuProps<Value>): JSX.Element {
+  const glyphs = useGlyphs();
+  const borderStyle = useBorderStyle();
+  if (choices.length === 0) return <Text tone="muted">{empty}</Text>;
+  // Overflow indicators (and a sticky heading) render outside the window;
+  // reserve their rows so the widget stays within the requested height.
+  const count = Math.max(
+    1,
+    choices.length > visibleCount ? visibleCount - 2 : visibleCount,
+  );
+  const start = Math.max(
+    0,
+    Math.min(cursor - Math.floor(count / 2), choices.length - count),
+  );
+  const end = Math.min(choices.length, start + count);
+  const stickyIndex =
+    start === 0
+      ? -1
+      : choices.findLastIndex(
+          (choice, index) => index < start && choice.sticky,
+        );
+  const visible = [
+    ...(stickyIndex === -1 ? [] : [stickyIndex]),
+    ...Array.from({ length: end - start }, (_, offset) => start + offset),
+  ];
+  return (
+    <Box
+      flexDirection="column"
+      aria-role="listbox"
+      aria-state={{ multiselectable: selected !== undefined }}
+    >
+      {start > 0 ? (
+        <Text tone="muted">
+          {" "}
+          {glyphs.overflowUp} {start} more
+        </Text>
+      ) : null}
+      {visible.map((index) => {
+        const choice = choices[index];
+        if (choice === undefined) return null;
+        const focused = index === cursor;
+        const checked = selected?.has(index);
+        const disabled =
+          choice.disabled !== undefined && choice.disabled !== false;
+        const previous = choices[index - 1];
+        const showGroup =
+          choice.group !== undefined &&
+          (index === start || previous?.group !== choice.group);
+        return (
+          <Box
+            key={index}
+            flexDirection="column"
+            marginTop={showGroup && index !== visible[0] ? 1 : 0}
+          >
+            {showGroup ? (
+              <Text bold tone="muted">
+                {choice.group.toUpperCase()}
+              </Text>
+            ) : null}
+            <Box
+              gap={1}
+              paddingRight={1}
+              paddingLeft={(choice.indent ?? 0) + (focused ? 1 : 2)}
+              borderStyle={borderStyle}
+              borderLeft={focused}
+              borderRight={false}
+              borderTop={false}
+              borderBottom={false}
+              borderColor={theme.color.accent}
+              aria-role="option"
+              aria-label={choice.label}
+              aria-state={{
+                disabled,
+                selected: selected === undefined ? focused : checked,
+              }}
+            >
+              {selected === undefined ? null : (
+                <Text
+                  color={checked ? theme.color.success : theme.color.muted}
+                  dimColor={disabled}
+                >
+                  {checked ? glyphs.checked : glyphs.unchecked}
+                </Text>
+              )}
+              <Box
+                flexDirection={
+                  descriptionPlacement === "inline" ? "row" : "column"
+                }
+                flexGrow={1}
+                gap={descriptionPlacement === "inline" ? 1 : 0}
+              >
+                <Text
+                  bold={focused || choice.sticky || checked}
+                  color={
+                    focused
+                      ? theme.color.accentBright
+                      : choice.tone === "info"
+                        ? theme.color.info
+                        : undefined
+                  }
+                  dimColor={disabled}
+                >
+                  {choice.label}
+                </Text>
+                {choice.description === undefined ? null : (
+                  <Text tone="muted" wrap="truncate-end">
+                    {descriptionPlacement === "inline" ? "· " : ""}
+                    {choice.description}
+                  </Text>
+                )}
+              </Box>
+              {typeof choice.disabled === "string" ? (
+                <Text tone="muted">{choice.disabled}</Text>
+              ) : null}
+            </Box>
+          </Box>
+        );
+      })}
+      {end < choices.length ? (
+        <Text tone="muted">
+          {" "}
+          {glyphs.overflowDown} {choices.length - end} more
+        </Text>
+      ) : null}
+    </Box>
+  );
+}
+
+export interface TextFieldProps {
+  readonly placeholder?: string;
+  readonly initialValue?: string;
+  readonly value?: string;
+  readonly mask?: string;
+  readonly onSubmit: (value: string) => void;
+  readonly onChange?: (value: string) => void;
+  readonly onCancel?: () => void;
+  readonly active?: boolean;
+  readonly ariaLabel?: string;
+}
+
+const graphemeSegmenter = new Intl.Segmenter();
+
+/**
+ * Split into user-perceived characters so cursor movement and deletion never
+ * land inside a surrogate pair or emoji cluster.
+ */
+const toGraphemes = (value: string): ReadonlyArray<string> =>
+  Array.from(graphemeSegmenter.segment(value), (segment) => segment.segment);
+
+/**
+ * Normalize text before inserting it into a single-line field. Sigil reports
+ * bracketed paste separately, but pasted content can still contain newlines,
+ * tabs or other control characters that do not belong in the value.
+ */
+export const sanitizeTextInsert = (input: string): string =>
+  // eslint-disable-next-line no-control-regex
+  input.replace(/[\u0000-\u001f\u007f]/g, "");
+
+/** Readline-style whitespace word boundary to the left of `cursor`. */
+const wordBoundaryLeft = (
+  chars: ReadonlyArray<string>,
+  cursor: number,
+): number => {
+  let index = cursor;
+  while (index > 0 && chars[index - 1] === " ") index--;
+  while (index > 0 && chars[index - 1] !== " ") index--;
+  return index;
+};
+
+/** Readline-style whitespace word boundary to the right of `cursor`. */
+const wordBoundaryRight = (
+  chars: ReadonlyArray<string>,
+  cursor: number,
+): number => {
+  let index = cursor;
+  while (index < chars.length && chars[index] === " ") index++;
+  while (index < chars.length && chars[index] !== " ") index++;
+  return index;
+};
+
+/**
+ * Horizontal scroll window for a single-line field: which grapheme range fits
+ * in `avail` display cells while keeping the cursor visible. One cell is
+ * reserved for the cursor sitting past the last character.
+ */
+const visibleWindow = (
+  chars: ReadonlyArray<string>,
+  cursor: number,
+  avail: number,
+): { readonly start: number; readonly end: number } => {
+  const budget = Math.max(1, avail - 1);
+  const widths = chars.map((char) => stringWidth(char));
+  let before = 0;
+  for (let index = 0; index < cursor; index++) before += widths[index] ?? 0;
+  let start = 0;
+  if (before > budget) {
+    // Scrolled: pin the cursor near the right edge of the window.
+    let used = 0;
+    while (start < cursor && before - used > budget) {
+      used += widths[start] ?? 0;
+      start++;
+    }
+  }
+  let end = start;
+  let total = 0;
+  while (end < chars.length && total + (widths[end] ?? 0) <= budget) {
+    total += widths[end] ?? 0;
+    end++;
+  }
+  return { start, end };
+};
+
+/**
+ * Single-line editor with insertion, deletion, home/end, word-wise movement
+ * and the common readline kill bindings (Ctrl+U/K/W, Alt+Backspace). Long
+ * values scroll horizontally instead of wrapping, so the terminal cursor
+ * always sits on the field's own row.
+ */
+export function TextField({
+  placeholder,
+  initialValue = "",
+  value: controlledValue,
+  mask,
+  onSubmit,
+  onChange,
+  onCancel,
+  active,
+  ariaLabel,
+}: TextFieldProps) {
+  // Prompts are serialized by the CliKit runtime, so an enabled field owns
+  // the input stream outright — no Sigil focus negotiation. (Coupling this to
+  // useFocus({autoFocus}) silently disabled the field whenever any other
+  // focusable was already mounted.)
+  const inputActive = active ?? true;
+  const [internalValue, setInternalValue] = useState(initialValue);
+  const value = controlledValue ?? internalValue;
+  const chars = toGraphemes(value);
+  const [cursor, setCursor] = useState(
+    () => toGraphemes(controlledValue ?? initialValue).length,
+  );
+  const fieldRef = useRef<DOMElement>(null);
+  const [metrics, setMetrics] = useState({ x: 0, y: 0, measured: false });
+  const { setCursorPosition } = useCursor();
+  const { columns } = useCliEnvironment();
+  useEffect(() => {
+    setCursor((current) => Math.min(current, toGraphemes(value).length));
+  }, [value]);
+  const update = (nextChars: ReadonlyArray<string>, nextCursor: number) => {
+    const next = nextChars.join("");
+    if (controlledValue === undefined) setInternalValue(next);
+    setCursor(Math.max(0, Math.min(nextChars.length, nextCursor)));
+    onChange?.(next);
+  };
+  useTerminalInput(
+    (input, key) => {
+      if (key.enter) onSubmit(value);
+      else if (key.escape) onCancel?.();
+      else if (key.left)
+        setCursor(
+          key.ctrl || key.meta
+            ? wordBoundaryLeft(chars, cursor)
+            : Math.max(0, cursor - 1),
+        );
+      else if (key.right)
+        setCursor(
+          key.ctrl || key.meta
+            ? wordBoundaryRight(chars, cursor)
+            : Math.min(chars.length, cursor + 1),
+        );
+      // Sigil distinguishes physical Backspace from Delete.
+      else if (key.backspace && cursor > 0) {
+        const target = key.meta ? wordBoundaryLeft(chars, cursor) : cursor - 1;
+        update([...chars.slice(0, target), ...chars.slice(cursor)], target);
+      } else if (key.delete && cursor < chars.length)
+        update([...chars.slice(0, cursor), ...chars.slice(cursor + 1)], cursor);
+      else if (key.ctrl && input === "d" && cursor < chars.length)
+        update([...chars.slice(0, cursor), ...chars.slice(cursor + 1)], cursor);
+      else if (key.ctrl && input === "w" && cursor > 0) {
+        const target = wordBoundaryLeft(chars, cursor);
+        update([...chars.slice(0, target), ...chars.slice(cursor)], target);
+      } else if (key.ctrl && input === "u") update(chars.slice(cursor), 0);
+      else if (key.ctrl && input === "k")
+        update(chars.slice(0, cursor), cursor);
+      else if (key.home || (key.ctrl && input === "a")) setCursor(0);
+      else if (key.end || (key.ctrl && input === "e")) setCursor(chars.length);
+      else if (key.meta && input === "b")
+        setCursor(wordBoundaryLeft(chars, cursor));
+      else if (key.meta && input === "f")
+        setCursor(wordBoundaryRight(chars, cursor));
+      else if (!key.ctrl && !key.meta && !key.tab) {
+        const inserted = toGraphemes(sanitizeTextInsert(input));
+        if (inserted.length > 0) {
+          update(
+            [...chars.slice(0, cursor), ...inserted, ...chars.slice(cursor)],
+            cursor + inserted.length,
+          );
+        }
+      }
+    },
+    { active: inputActive },
+  );
+  useTerminalPaste(
+    (pasted) => {
+      const inserted = toGraphemes(sanitizeTextInsert(pasted));
+      if (inserted.length === 0) return;
+      update(
+        [...chars.slice(0, cursor), ...inserted, ...chars.slice(cursor)],
+        cursor + inserted.length,
+      );
+    },
+    { active: inputActive },
+  );
+  const shownChars = mask === undefined ? chars : chars.map(() => mask);
+  // Available width = terminal width minus the field's left offset. The box's
+  // own measured width is useless here: it shrinks to its content (flexGrow
+  // only affects height in a column parent), so using it collapses the scroll
+  // window to whatever is currently typed.
+  const avail = Math.max(4, columns - (metrics.measured ? metrics.x : 0) - 1);
+  const { start, end } = visibleWindow(shownChars, cursor, avail);
+  const display =
+    shownChars.length === 0
+      ? (placeholder ?? " ")
+      : `${shownChars.slice(start, end).join("")}${
+          cursor === shownChars.length ? " " : ""
+        }`;
+  // Cursor placement must happen DURING render: useCursor only records the
+  // position in a ref and propagates it to the renderer from an insertion
+  // effect, which runs BEFORE layout effects in the same commit. Setting the
+  // position from a layout effect therefore paints every frame with the
+  // previous keystroke's cursor (off by one while typing and erasing). The
+  // ref write is render-safe — propagation is commit-gated, so abandoned
+  // concurrent renders never reach the terminal.
+  setCursorPosition(
+    inputActive && metrics.measured
+      ? {
+          x: metrics.x + stringWidth(shownChars.slice(start, cursor).join("")),
+          y: metrics.y,
+        }
+      : undefined,
+  );
+  // Measuring stays post-layout: the Box ref only exists after mutation.
+  // A metrics change re-renders, which re-runs the render-time cursor
+  // placement above with the fresh offsets.
+  useLayoutEffect(() => {
+    if (fieldRef.current === null) return;
+    const { x, y } = measureElement(fieldRef.current);
+    setMetrics((current) =>
+      current.measured && current.x === x && current.y === y
+        ? current
+        : { x, y, measured: true },
+    );
+  });
+  return (
+    <Box ref={fieldRef} aria-role="textbox" aria-label={ariaLabel}>
+      <Text
+        tone={shownChars.length === 0 ? "muted" : "default"}
+        wrap="truncate-end"
+      >
+        {display}
+      </Text>
+    </Box>
+  );
+}
+
+export interface CycleListProps<State> {
+  readonly choices: ReadonlyArray<CycleChoice<State>>;
+  readonly cursor: number;
+  readonly indices: ReadonlyArray<number>;
+  readonly visibleCount?: number;
+}
+
+const stateColor = (
+  variant: CycleChoice<unknown>["states"][number]["variant"],
+) =>
+  variant === undefined || variant === "neutral"
+    ? undefined
+    : theme.color[variant === "error" ? "danger" : variant];
+
+export function CycleList<State>({
+  choices,
+  cursor,
+  indices,
+  visibleCount = 12,
+}: CycleListProps<State>) {
+  const glyphs = useGlyphs();
+  const borderStyle = useBorderStyle();
+  const count = Math.max(
+    1,
+    choices.length > visibleCount ? visibleCount - 2 : visibleCount,
+  );
+  const start = Math.max(
+    0,
+    Math.min(cursor - Math.floor(count / 2), choices.length - count),
+  );
+  const end = Math.min(choices.length, start + count);
+  return (
+    <Box flexDirection="column">
+      {start > 0 ? (
+        <Text tone="muted">
+          {" "}
+          {glyphs.overflowUp} {start} more
+        </Text>
+      ) : null}
+      {choices.slice(start, end).map((choice, offset) => {
+        const index = start + offset;
+        const state = choice.states[indices[index] ?? 0];
+        const focused = index === cursor;
+        const color = stateColor(state?.variant);
+        return (
+          <Box
+            key={index}
+            gap={1}
+            paddingRight={1}
+            paddingLeft={focused ? 1 : 2}
+            borderStyle={borderStyle}
+            borderLeft={focused}
+            borderRight={false}
+            borderTop={false}
+            borderBottom={false}
+            borderColor={theme.color.accent}
+          >
+            <Text color={color} dimColor={color === undefined}>
+              {state?.icon ?? glyphs.bullet}
+            </Text>
+            <Text
+              bold={focused}
+              color={focused ? theme.color.accentBright : undefined}
+            >
+              {choice.label}
+            </Text>
+            {state?.label === undefined ? null : (
+              <Text color={color}>{state.label}</Text>
+            )}
+            {choice.description === undefined ? null : (
+              <Text tone="muted">· {choice.description}</Text>
+            )}
+          </Box>
+        );
+      })}
+      {end < choices.length ? (
+        <Text tone="muted">
+          {" "}
+          {glyphs.overflowDown} {choices.length - end} more
+        </Text>
+      ) : null}
+    </Box>
+  );
+}
+
+export const useCycleNavigation = (stateCounts: ReadonlyArray<number>) => {
+  const { cursor, move, setCursor } = useListNavigation(stateCounts.length);
+  const [indices, setIndices] = useState<ReadonlyArray<number>>(() =>
+    stateCounts.map(() => 0),
+  );
+  const cycle = (delta: number) =>
+    setIndices((current) =>
+      current.map((value, index) => {
+        if (index !== cursor) return value;
+        const count = stateCounts[index] ?? 0;
+        return count <= 0 ? 0 : (value + delta + count) % count;
+      }),
+    );
+  return { cursor, indices, move, setCursor, cycle } as const;
+};
+
+export interface ExternalWaitProps {
+  readonly message: string;
+  readonly waitingLabel: string;
+  readonly url?: string;
+  readonly code?: string;
+  readonly openFailed?: boolean;
+  readonly onOpen?: () => Promise<void>;
+  readonly allowManualInput?: boolean;
+  readonly inputLabel?: string;
+  readonly placeholder?: string;
+  readonly validate?: (value: string) => string | Error | undefined;
+  readonly onSubmit: (value: string) => void;
+  readonly onCancel: () => void;
+}
+
+/**
+ * Yes/no keyboard handling shared by `InlineConfirm` and the confirm prompt
+ * screen: arrows/tab toggle, Enter commits, y/n answer directly.
+ */
+export const useConfirmKeys = ({
+  initialValue = false,
+  active,
+  onSubmit,
+  onCancel,
+}: {
+  readonly initialValue?: boolean;
+  readonly active?: boolean;
+  readonly onSubmit: (value: boolean) => void;
+  readonly onCancel?: () => void;
+}): boolean => {
+  const [value, setValue] = useState(initialValue);
+  useTerminalInput(
+    (input, key) => {
+      if (key.escape) onCancel?.();
+      else if (key.left || key.right || key.tab || key.up || key.down)
+        setValue((current) => !current);
+      else if (key.enter) onSubmit(value);
+      else if (key.ctrl || key.meta) return;
+      else if (input.toLowerCase() === "y") onSubmit(true);
+      else if (input.toLowerCase() === "n") onSubmit(false);
+    },
+    { active: active ?? true },
+  );
+  return value;
+};
+
+type InlineConfirmProps = {
+  readonly message: string;
+  readonly initialValue?: boolean;
+  readonly active?: boolean;
+  readonly onSubmit: (value: boolean) => void;
+  readonly onCancel?: () => void;
+};
+
+export function InlineConfirm({
+  message,
+  initialValue = false,
+  active,
+  onSubmit,
+  onCancel,
+}: InlineConfirmProps) {
+  const keys = useKeyGlyphs();
+  const value = useConfirmKeys({ initialValue, active, onSubmit, onCancel });
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Text bold color={theme.color.accent}>
+        {message}
+      </Text>
+      <BooleanChoice value={value} />
+      <KeyBar
+        keys={[
+          [keys.yesNo, "choose"],
+          [keys.enter, "confirm"],
+          [keys.escape, "cancel"],
+        ]}
+      />
+    </Box>
+  );
+}
+
+type BooleanChoiceProps = { readonly value: boolean };
+
+export function BooleanChoice({ value }: BooleanChoiceProps) {
+  return (
+    <Box gap={1} paddingLeft={1} aria-role="radiogroup">
+      <Box
+        backgroundColor={value ? theme.color.accent : undefined}
+        aria-role="radio"
+        aria-label="Yes"
+        aria-state={{ checked: value }}
+      >
+        <Text bold={value} color={value ? theme.color.onAccent : undefined}>
+          {value ? "[Yes]" : "Yes"}
+        </Text>
+      </Box>
+      <Box
+        backgroundColor={!value ? theme.color.accent : undefined}
+        aria-role="radio"
+        aria-label="No"
+        aria-state={{ checked: !value }}
+      >
+        <Text bold={!value} color={!value ? theme.color.onAccent : undefined}>
+          {!value ? "[No]" : "No"}
+        </Text>
+      </Box>
+    </Box>
+  );
+}
+
+/** Browser/OAuth waiting screen with URL controls and manual-entry fallback. */
+export function ExternalWait({
+  message,
+  waitingLabel,
+  url,
+  code,
+  openFailed = false,
+  onOpen,
+  allowManualInput = true,
+  inputLabel,
+  placeholder,
+  validate,
+  onSubmit,
+  onCancel,
+}: ExternalWaitProps) {
+  const { stdout } = useStdout();
+  const glyphs = useGlyphs();
+  const keyGlyphs = useKeyGlyphs();
+  const [manual, setManual] = useState(false);
+  const [showFull, setShowFull] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [browserFailed, setBrowserFailed] = useState(openFailed);
+  const [error, setError] = useState<string>();
+  const copiedTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
+  useEffect(
+    () => () => {
+      clearTimeout(copiedTimer.current);
+    },
+    [],
+  );
+  const { columns } = useTerminalSize();
+  // Ctrl+C is handled centrally by the screen runner (SigilRuntime.run).
+  useTerminalInput((input, key) => {
+    if (manual) {
+      if (key.escape) {
+        setError(undefined);
+        setManual(false);
+      }
+      return;
+    }
+    const shortcut = input.toLowerCase();
+    if (key.enter && allowManualInput) setManual(true);
+    else if (key.escape) onCancel();
+    // Ctrl+C must fall through to the runner's cancel guard, not copy the URL.
+    else if (key.ctrl || key.meta) return;
+    else if (shortcut === "u") setShowFull((current) => !current);
+    else if (shortcut === "o" && onOpen !== undefined) {
+      setBrowserFailed(false);
+      void onOpen().catch(() => setBrowserFailed(true));
+    } else if (shortcut === "c" && (code ?? url) !== undefined) {
+      copyToClipboard(code ?? url!, stdout ?? process.stdout);
+      setCopied(true);
+      clearTimeout(copiedTimer.current);
+      copiedTimer.current = setTimeout(() => setCopied(false), 2000);
+    }
+  });
+  if (manual) {
+    const manualInputLabel =
+      inputLabel ?? "Paste the authorization code or callback URL";
+    return (
+      <PromptFrame
+        message={manualInputLabel}
+        layout="inline"
+        error={error}
+        keys={[
+          [keyGlyphs.enter, "confirm"],
+          [keyGlyphs.escape, "back to waiting"],
+        ]}
+      >
+        <TextField
+          placeholder={placeholder}
+          ariaLabel={manualInputLabel}
+          onCancel={() => {
+            setError(undefined);
+            setManual(false);
+          }}
+          onChange={() => setError(undefined)}
+          onSubmit={(value) => {
+            const problem = validate?.(value);
+            if (problem !== undefined) {
+              setError(problem instanceof Error ? problem.message : problem);
+            } else {
+              onSubmit(value);
+            }
+          }}
+        />
+      </PromptFrame>
+    );
+  }
+  return (
+    <PromptFrame
+      message={message}
+      keys={[
+        ...(allowManualInput
+          ? ([[keyGlyphs.enter, "enter code manually"]] as const)
+          : []),
+        ...(url === undefined
+          ? []
+          : ([
+              ...(onOpen === undefined
+                ? []
+                : ([["o", "open browser"]] as const)),
+              [
+                "c",
+                copied
+                  ? `${glyphs.success} copied`
+                  : code === undefined
+                    ? "copy URL"
+                    : "copy code",
+              ],
+              ["u", showFull ? "collapse URL" : "full URL"],
+            ] as const)),
+        [keyGlyphs.escape, "cancel"],
+      ]}
+    >
+      <Box flexDirection="column" gap={1}>
+        <Spinner label={waitingLabel} />
+        {code === undefined ? null : (
+          <Box gap={1}>
+            <Text tone="muted">Code</Text>
+            <Text bold color={theme.color.accentBright}>
+              {code}
+            </Text>
+          </Box>
+        )}
+        {browserFailed ? (
+          <Text tone="warning">
+            {glyphs.warning} Could not open the browser. Copy and open the URL
+            manually.
+          </Text>
+        ) : null}
+        {url === undefined ? null : (
+          <Link href={url}>
+            {showFull ? url : truncate(url, Math.max(24, columns - 8))}
+          </Link>
+        )}
+      </Box>
+    </PromptFrame>
+  );
+}
+
+export type PromptFrameProps = {
+  readonly message: string;
+  readonly description?: ReactNode;
+  readonly children: JSX.Element;
+  readonly layout?: "inline" | "stacked";
+  readonly error?: string;
+  readonly keys?: ReadonlyArray<readonly [string, string]>;
+};
+
+export function PromptFrame({
+  message,
+  description,
+  children,
+  layout = "stacked",
+  error,
+  keys,
+}: PromptFrameProps) {
+  const glyphs = useGlyphs();
+  const borderStyle = useBorderStyle();
+  const heading = (
+    <Text>
+      <Text color={theme.color.brand}>{glyphs.active}</Text>{" "}
+      <Text bold>{message}</Text>
+    </Text>
+  );
+  return (
+    <Box flexDirection="column">
+      {layout === "inline" ? (
+        <Box flexDirection="column" paddingLeft={1}>
+          <Box gap={1}>
+            <Text bold>{message}:</Text>
+            <Box flexGrow={1}>{children}</Box>
+          </Box>
+          {description === undefined ? null : (
+            <Box paddingLeft={2}>
+              <Text tone="muted">{description}</Text>
+            </Box>
+          )}
+        </Box>
+      ) : (
+        <>
+          {heading}
+          {description === undefined ? null : (
+            <Box paddingLeft={2}>
+              <Text tone="muted">{description}</Text>
+            </Box>
+          )}
+          <Box
+            marginTop={1}
+            paddingLeft={1}
+            flexDirection="column"
+            borderStyle={borderStyle}
+            borderLeft
+            borderRight={false}
+            borderTop={false}
+            borderBottom={false}
+            borderColor={theme.color.accent}
+          >
+            {children}
+          </Box>
+        </>
+      )}
+      {error === undefined ? null : (
+        <Box marginTop={1} paddingLeft={2}>
+          <Text color={theme.color.danger}>
+            {glyphs.error} {error}
+          </Text>
+        </Box>
+      )}
+      {keys === undefined ? null : (
+        <Box paddingLeft={1}>
+          <KeyBar keys={keys} />
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+export const filterChoices = <Value,>(
+  choices: ReadonlyArray<Choice<Value>>,
+  query: string,
+) => {
+  const normalized = query.trim().toLowerCase();
+  const indexed = choices.map((choice, index) => ({ choice, index }));
+  return normalized === ""
+    ? indexed
+    : indexed.filter(({ choice }) =>
+        `${choice.group ?? ""} ${choice.label} ${choice.description ?? ""}`
+          .toLowerCase()
+          .includes(normalized),
+      );
+};
+
+/** Stable selected-index set for multiselect widgets. */
+export const useSelectedChoices = <Value,>(
+  choices: ReadonlyArray<Choice<Value>>,
+  initialValues: ReadonlyArray<Value>,
+) => {
+  return useState<ReadonlySet<number>>(
+    () =>
+      new Set(
+        initialValues.flatMap((value) => {
+          const index = choices.findIndex((choice) => choice.value === value);
+          return index === -1 || choices[index]?.disabled ? [] : [index];
+        }),
+      ),
+  );
+};

--- a/packages/alchemy/src/Cli/CliKit/components/Layout.tsx
+++ b/packages/alchemy/src/Cli/CliKit/components/Layout.tsx
@@ -1,0 +1,191 @@
+/** @jsxImportSource react */
+import { Box as SigilBox, type DOMElement } from "@alchemy.run/sigil";
+import {
+  forwardRef,
+  type ComponentProps,
+  type ForwardRefExoticComponent,
+  type PropsWithoutRef,
+  type ReactNode,
+  type RefAttributes,
+} from "react";
+import { theme } from "../theme.ts";
+import { useCliEnvironment, useGlyphs } from "./Environment.tsx";
+import { Text } from "./Typography.tsx";
+
+export type BoxProps = ComponentProps<typeof SigilBox>;
+
+/** Theme-aware Sigil container used by CliKit layouts. */
+export const Box: ForwardRefExoticComponent<
+  PropsWithoutRef<BoxProps> & RefAttributes<DOMElement>
+> = forwardRef<DOMElement, BoxProps>(function Box(props, ref) {
+  const { colors } = useCliEnvironment();
+  const {
+    borderColor: _borderColor,
+    borderTopColor: _borderTopColor,
+    borderBottomColor: _borderBottomColor,
+    borderLeftColor: _borderLeftColor,
+    borderRightColor: _borderRightColor,
+    borderBackgroundColor: _borderBackgroundColor,
+    borderTopBackgroundColor: _borderTopBackgroundColor,
+    borderBottomBackgroundColor: _borderBottomBackgroundColor,
+    borderLeftBackgroundColor: _borderLeftBackgroundColor,
+    borderRightBackgroundColor: _borderRightBackgroundColor,
+    backgroundColor: _backgroundColor,
+    borderDimColor: _borderDimColor,
+    borderTopDimColor: _borderTopDimColor,
+    borderBottomDimColor: _borderBottomDimColor,
+    borderLeftDimColor: _borderLeftDimColor,
+    borderRightDimColor: _borderRightDimColor,
+    ...colorless
+  } = props;
+  return <SigilBox {...(colors ? props : colorless)} ref={ref} />;
+});
+
+export interface StackProps extends Omit<BoxProps, "flexDirection"> {
+  readonly gap?: number;
+}
+
+/** Vertical layout primitive. */
+export function Stack({ children, gap = 0, ...props }: StackProps) {
+  return (
+    <Box flexDirection="column" gap={gap} {...props}>
+      {children}
+    </Box>
+  );
+}
+
+export interface RowProps extends Omit<
+  BoxProps,
+  "flexDirection" | "alignItems" | "justifyContent"
+> {
+  readonly gap?: number;
+  readonly align?: "flex-start" | "center" | "flex-end";
+  readonly justify?:
+    | "flex-start"
+    | "center"
+    | "flex-end"
+    | "space-between"
+    | "space-around";
+}
+
+/** Horizontal layout primitive. */
+export function Row({
+  children,
+  gap = 1,
+  align = "flex-start",
+  justify = "flex-start",
+  ...props
+}: RowProps) {
+  return (
+    <Box
+      flexDirection="row"
+      gap={gap}
+      alignItems={align}
+      justifyContent={justify}
+      {...props}
+    >
+      {children}
+    </Box>
+  );
+}
+
+type HeadingProps = {
+  readonly children?: ReactNode;
+  /** Set false to drop the section glyph prefix (e.g. help-screen headings). */
+  readonly glyph?: boolean;
+};
+
+export function Heading({ children, glyph = true }: HeadingProps) {
+  const glyphs = useGlyphs();
+  return (
+    <Box>
+      <Text
+        bold
+        color={theme.color.onAccent}
+        backgroundColor={theme.color.accent}
+      >
+        {" "}
+        {glyph ? `${glyphs.section} ` : null}
+        {children}{" "}
+      </Text>
+    </Box>
+  );
+}
+
+type SectionHeadingProps = {
+  readonly children?: ReactNode;
+  readonly annotation?: ReactNode;
+};
+
+export function SectionHeading({ children, annotation }: SectionHeadingProps) {
+  return (
+    <Text>
+      <Text
+        bold
+        color={theme.color.onAccent}
+        backgroundColor={theme.color.accent}
+      >
+        {" "}
+        {children}{" "}
+      </Text>
+      {annotation === undefined ? null : (
+        <Text tone="muted"> · {annotation}</Text>
+      )}
+    </Text>
+  );
+}
+
+type GutterProps = {
+  readonly depth?: number;
+  readonly children?: ReactNode;
+};
+
+export function Gutter({ depth = 1, children }: GutterProps) {
+  return (
+    <Box paddingLeft={Math.max(0, depth) * 2}>
+      <Box flexDirection="column" flexGrow={1}>
+        {children}
+      </Box>
+    </Box>
+  );
+}
+
+/** Windowed list keeping `cursor` centered; each item renders as a block. */
+type ViewportProps<Item> = {
+  readonly items: ReadonlyArray<Item>;
+  readonly cursor?: number;
+  readonly height: number;
+  readonly renderItem: (item: Item, index: number) => ReactNode;
+  readonly getKey: (item: Item, index: number) => string;
+  readonly empty?: ReactNode;
+};
+
+export function Viewport<Item>({
+  items,
+  cursor = 0,
+  height,
+  renderItem,
+  getKey,
+  empty,
+}: ViewportProps<Item>) {
+  if (items.length === 0) return <>{empty}</>;
+  const count = Math.max(1, height);
+  const selected = Math.max(0, Math.min(cursor, items.length - 1));
+  const start = Math.max(
+    0,
+    Math.min(selected - Math.floor(count / 2), items.length - count),
+  );
+  const end = Math.min(items.length, start + count);
+  return (
+    <Stack>
+      {items.slice(start, end).map((item, offset) => {
+        const index = start + offset;
+        return (
+          <Box key={getKey(item, index)} flexDirection="column">
+            {renderItem(item, index)}
+          </Box>
+        );
+      })}
+    </Stack>
+  );
+}

--- a/packages/alchemy/src/Cli/CliKit/components/Live.tsx
+++ b/packages/alchemy/src/Cli/CliKit/components/Live.tsx
@@ -1,0 +1,129 @@
+/** @jsxImportSource react */
+import type { ReactNode } from "react";
+import { useSyncExternalStore } from "react";
+import { useGlyphs } from "./Environment.tsx";
+import { ProgressBar, SpinnerGlyph } from "./Feedback.tsx";
+import { Box, Row, Stack } from "./Layout.tsx";
+import { Text } from "./Typography.tsx";
+
+export interface TaskRowProps {
+  /** Status glyph. Ignored while `spinning`; defaults to the bullet glyph. */
+  readonly icon?: string;
+  /** Color for the glyph (and the spinner while `spinning`). */
+  readonly iconColor?: string;
+  /** Render an animated spinner frame in the glyph slot. */
+  readonly spinning?: boolean;
+  readonly label: ReactNode;
+  /** Muted annotation directly after the label. */
+  readonly detail?: ReactNode;
+  /** Indentation in 2-space units. */
+  readonly depth?: number;
+  /** Extra trailing cells (status labels, chips). */
+  readonly children?: ReactNode;
+}
+
+/**
+ * The one status row shape shared by TaskTree and the plan/apply views:
+ * glyph-or-spinner, bold label, muted detail, then any trailing cells.
+ */
+export function TaskRow({
+  icon,
+  iconColor,
+  spinning = false,
+  label,
+  detail,
+  depth = 0,
+  children,
+}: TaskRowProps) {
+  const glyphs = useGlyphs();
+  return (
+    <Row gap={1} paddingLeft={depth * 2}>
+      {spinning ? (
+        <SpinnerGlyph color={iconColor} />
+      ) : (
+        <Text color={iconColor}>{icon ?? glyphs.bullet}</Text>
+      )}
+      <Text bold={depth === 0}>{label}</Text>
+      {detail === undefined ? null : <Text tone="muted">· {detail}</Text>}
+      {children}
+    </Row>
+  );
+}
+
+export interface ProgressGroupRow {
+  readonly id: string;
+  readonly label: ReactNode;
+  readonly completed: number;
+  readonly total: number;
+  readonly failed?: number;
+  readonly detail?: ReactNode;
+}
+
+type ProgressGroupProps = {
+  readonly rows: ReadonlyArray<ProgressGroupRow>;
+  readonly width?: number;
+  /** Fixed label column (truncated) so the count cells align across rows. */
+  readonly labelWidth?: number;
+};
+
+export function ProgressGroup({
+  rows,
+  width = 20,
+  labelWidth,
+}: ProgressGroupProps) {
+  return (
+    <Stack>
+      {rows.map((row) => {
+        const complete = row.total > 0 && row.completed >= row.total;
+        const variant = row.failed ? "error" : complete ? "success" : "info";
+        return (
+          <Row key={row.id}>
+            <ProgressBar
+              value={row.total <= 0 ? 0 : row.completed / row.total}
+              width={width}
+              showPercent={false}
+              variant={variant}
+            />
+            {labelWidth === undefined ? (
+              <Text>{row.label}</Text>
+            ) : (
+              <Box width={labelWidth} flexShrink={0}>
+                <Text wrap="truncate-end">{row.label}</Text>
+              </Box>
+            )}
+            <Text bold tone={variant === "error" ? "danger" : variant}>
+              {row.completed}/{row.total}
+            </Text>
+            {row.failed ? (
+              <Text tone="danger">({row.failed} failed)</Text>
+            ) : null}
+            {row.detail === undefined ? null : (
+              <Text tone="muted">{row.detail}</Text>
+            )}
+          </Row>
+        );
+      })}
+    </Stack>
+  );
+}
+
+export class LiveStore<Value> {
+  private value: Value;
+  private readonly listeners = new Set<() => void>();
+  constructor(initial: Value) {
+    this.value = initial;
+  }
+  readonly subscribe = (listener: () => void) => {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  };
+  readonly snapshot = () => this.value;
+  readonly set = (value: Value) => {
+    this.value = value;
+    for (const listener of this.listeners) listener();
+  };
+  readonly update = (f: (value: Value) => Value) => this.set(f(this.value));
+}
+
+export const useLiveStore = <Value,>(store: LiveStore<Value>): Value =>
+  useSyncExternalStore(store.subscribe, store.snapshot);

--- a/packages/alchemy/src/Cli/CliKit/components/Transcript.tsx
+++ b/packages/alchemy/src/Cli/CliKit/components/Transcript.tsx
@@ -1,0 +1,42 @@
+/** @jsxImportSource react */
+import { useGlyphs } from "./Environment.tsx";
+import { Stack } from "./Layout.tsx";
+import { Text } from "./Typography.tsx";
+
+type AnsweredPromptProps = {
+  readonly message: string;
+  readonly answer: string;
+  readonly below?: boolean;
+};
+
+export function AnsweredPrompt({
+  message,
+  answer,
+  below = false,
+}: AnsweredPromptProps) {
+  const glyphs = useGlyphs();
+  return below ? (
+    <Stack>
+      <Text>
+        <Text tone="success">{glyphs.success}</Text> {message}
+      </Text>
+      <Text tone="muted"> {answer}</Text>
+    </Stack>
+  ) : (
+    <Text>
+      <Text tone="success">{glyphs.success}</Text> {message}{" "}
+      <Text tone="muted">· {answer}</Text>
+    </Text>
+  );
+}
+
+type CancelledPromptProps = { readonly message: string };
+
+export function CancelledPrompt({ message }: CancelledPromptProps) {
+  const glyphs = useGlyphs();
+  return (
+    <Text tone="muted">
+      <Text tone="danger">{glyphs.error}</Text> {message} cancelled
+    </Text>
+  );
+}

--- a/packages/alchemy/src/Cli/CliKit/components/Typography.tsx
+++ b/packages/alchemy/src/Cli/CliKit/components/Typography.tsx
@@ -1,0 +1,83 @@
+/** @jsxImportSource react */
+import {
+  Hyperlink as SigilHyperlink,
+  Text as SigilText,
+} from "@alchemy.run/sigil";
+import type { ComponentProps } from "react";
+import { theme } from "../theme.ts";
+import { useCliEnvironment } from "./Environment.tsx";
+
+export type TextTone =
+  | "default"
+  | "muted"
+  | "emphasis"
+  | "brand"
+  | "accent"
+  | "info"
+  | "success"
+  | "warning"
+  | "danger";
+
+export interface TextProps extends Omit<
+  ComponentProps<typeof SigilText>,
+  "color"
+> {
+  readonly tone?: TextTone;
+  readonly color?: string;
+}
+
+/** CliKit typography primitive. Consumers never import Sigil directly. */
+export function Text({
+  tone = "default",
+  color,
+  backgroundColor,
+  bold,
+  dimColor,
+  italic,
+  underline,
+  strikethrough,
+  inverse,
+  ...props
+}: TextProps) {
+  const { colors } = useCliEnvironment();
+  return (
+    <SigilText
+      {...props}
+      color={
+        colors
+          ? (color ??
+            (tone === "default" || tone === "muted"
+              ? undefined
+              : theme.color[tone]))
+          : undefined
+      }
+      backgroundColor={colors ? backgroundColor : undefined}
+      bold={colors ? bold : undefined}
+      dimColor={colors ? (dimColor ?? tone === "muted") : undefined}
+      italic={colors ? italic : undefined}
+      underline={colors ? underline : undefined}
+      strikethrough={colors ? strikethrough : undefined}
+      inverse={colors ? inverse : undefined}
+    />
+  );
+}
+
+type LinkProps = {
+  readonly href: string;
+  readonly children?: string;
+};
+
+export function Link({ href, children }: LinkProps) {
+  const { colors } = useCliEnvironment();
+  const label = children ?? href;
+  return (
+    <SigilHyperlink
+      url={href}
+      fallback={label !== href}
+      color={colors ? theme.color.info : undefined}
+      underline={colors || undefined}
+    >
+      {label}
+    </SigilHyperlink>
+  );
+}

--- a/packages/alchemy/src/Cli/CliKit/errors.ts
+++ b/packages/alchemy/src/Cli/CliKit/errors.ts
@@ -1,0 +1,18 @@
+import * as Data from "effect/Data";
+
+/** The user dismissed the active terminal interaction. */
+export class TerminalCancelled extends Data.TaggedError("TerminalCancelled") {}
+
+/** An interactive operation was requested without an interactive terminal. */
+export class NonInteractiveTerminal extends Data.TaggedError(
+  "NonInteractiveTerminal",
+)<{
+  readonly operation: string;
+  readonly message: string;
+}> {}
+
+/** The platform's browser launcher exited unsuccessfully. */
+export class BrowserOpenFailed extends Data.TaggedError("BrowserOpenFailed")<{
+  readonly command: string;
+  readonly exitCode: number;
+}> {}

--- a/packages/alchemy/src/Cli/CliKit/index.ts
+++ b/packages/alchemy/src/Cli/CliKit/index.ts
@@ -1,0 +1,47 @@
+export { accessors, Application, CliKit } from "./CliKit.ts";
+export { layer } from "./layer.ts";
+export { openUrl } from "./openUrl.ts";
+export {
+  BrowserOpenFailed,
+  NonInteractiveTerminal,
+  TerminalCancelled,
+} from "./errors.ts";
+export { glyphsFor, theme, type GlyphName } from "./theme.ts";
+export {
+  ANSI_BOLD,
+  ANSI_DIM,
+  ANSI_RESET,
+  ansiFg,
+  colorsEnabled,
+  hyperlink,
+  linePrefix,
+  paint,
+  pipedColorEnv,
+  stripAnsi,
+  truncate,
+  unicodeEnabled,
+} from "./terminal.ts";
+export {
+  Screen,
+  type Choice,
+  type AwaitExternalOptions,
+  type ConfirmOptions,
+  type CycleChoice,
+  type CycleSelectOptions,
+  type InteractionError,
+  type LiveViewHandle,
+  type LiveViewOptions,
+  type MenuOptions,
+  type MessageOptions,
+  type MultiSelectOptions,
+  type PasswordInputOptions,
+  type ProgressHandle,
+  type ProgressOptions,
+  type RenderOptions,
+  type ScreenController,
+  type SelectOptions,
+  type CliKitCapabilities,
+  type CliKitOptions,
+  type TextInputOptions,
+  type View,
+} from "./types.ts";

--- a/packages/alchemy/src/Cli/CliKit/layer.ts
+++ b/packages/alchemy/src/Cli/CliKit/layer.ts
@@ -1,0 +1,45 @@
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { detectCapabilities } from "@alchemy.run/sigil/capabilities";
+import { isNonInteractive } from "../../Util/interactive.ts";
+import { CliKit } from "./CliKit.ts";
+import type { CliKitCapabilities, CliKitOptions } from "./types.ts";
+
+const resolveCapabilities = (options: CliKitOptions): CliKitCapabilities => {
+  const stdout = options.stdout ?? process.stdout;
+  const stdin = options.stdin ?? process.stdin;
+  const detected = detectCapabilities({ stdout });
+  const input =
+    options.input ??
+    (stdin.isTTY === true && stdout.isTTY === true && !isNonInteractive());
+  return {
+    input,
+    columns: detected.size.columns,
+    rows: detected.size.rows,
+    colors: options.colors ?? detected.supports.color,
+    unicode: options.unicode ?? detected.supports.unicode,
+    alternateScreen: detected.supports.alternateScreen,
+  };
+};
+
+// One shared import promise per process. Concurrent dynamic imports of the
+// same module (e.g. two test files building this layer at once) can race in
+// bun and hand one caller a partially-evaluated namespace, which throws a
+// TDZ ReferenceError on `makeRuntime`; funneling every build through a
+// single import() sidesteps the race.
+let sigilRuntime: Promise<typeof import("./SigilRuntime.tsx")> | undefined;
+const loadSigilRuntime = () => (sigilRuntime ??= import("./SigilRuntime.tsx"));
+
+/** Provides one terminal runtime for the enclosing scope. */
+export const layer = (options: CliKitOptions = {}) =>
+  Layer.effect(
+    CliKit,
+    Effect.acquireRelease(
+      Effect.promise(async () => {
+        const capabilities = resolveCapabilities(options);
+        const { makeRuntime } = await loadSigilRuntime();
+        return makeRuntime(options, capabilities);
+      }),
+      ({ dispose }) => Effect.promise(dispose),
+    ).pipe(Effect.map(({ service }) => service)),
+  );

--- a/packages/alchemy/src/Cli/CliKit/openUrl.ts
+++ b/packages/alchemy/src/Cli/CliKit/openUrl.ts
@@ -1,0 +1,33 @@
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import { ChildProcess } from "effect/unstable/process";
+import { BrowserOpenFailed } from "./errors.ts";
+
+/**
+ * Open a URL in the platform's default browser without invoking a shell.
+ *
+ * Fails with {@link BrowserOpenFailed} when the launcher exits non-zero (e.g.
+ * `xdg-open` with no handler installed). Some `xdg-open` configurations block
+ * until the browser itself exits — a launcher still running after a short
+ * grace period is treated as a successful launch rather than awaited.
+ */
+export const openUrl = (url: string) =>
+  Effect.gen(function* () {
+    const [command, args] =
+      process.platform === "win32"
+        ? (["rundll32.exe", ["url.dll,FileProtocolHandler", url]] as const)
+        : process.platform === "darwin"
+          ? (["open", [url]] as const)
+          : (["xdg-open", [url]] as const);
+    const handle = yield* ChildProcess.make(command, [...args], {
+      shell: false,
+    });
+    const exitCode = yield* handle.exitCode.pipe(
+      Effect.timeoutOption("3 seconds"),
+    );
+    if (Option.isSome(exitCode) && exitCode.value !== 0) {
+      return yield* Effect.fail(
+        new BrowserOpenFailed({ command, exitCode: exitCode.value }),
+      );
+    }
+  }).pipe(Effect.scoped);

--- a/packages/alchemy/src/Cli/CliKit/screens.tsx
+++ b/packages/alchemy/src/Cli/CliKit/screens.tsx
@@ -1,0 +1,736 @@
+/** @jsxImportSource react */
+import { type ReactNode, useEffect, useMemo, useState } from "react";
+import type {
+  ConfirmOptions,
+  CycleSelectOptions,
+  AwaitExternalOptions,
+  MenuOptions,
+  MultiSelectOptions,
+  PasswordInputOptions,
+  Screen,
+  ScreenController,
+  SelectOptions,
+  TextInputOptions,
+} from "./types.ts";
+import { theme } from "./theme.ts";
+import { useGlyphs, useKeyGlyphs } from "./components/Environment.tsx";
+import { Alert } from "./components/Feedback.tsx";
+import {
+  BooleanChoice,
+  filterChoices,
+  CycleList,
+  ExternalWait,
+  jumpSkippingDisabled,
+  Menu,
+  moveSkippingDisabled,
+  PromptFrame,
+  sanitizeTextInsert,
+  TextField,
+  useConfirmKeys,
+  useListNavigation,
+  useSelectedChoices,
+  useTerminalInput,
+  useTerminalPaste,
+  useTerminalSize,
+  useCycleNavigation,
+  type TerminalKey,
+} from "./components/Interactive.tsx";
+import { Box } from "./components/Layout.tsx";
+import { AnsweredPrompt } from "./components/Transcript.tsx";
+import { Text } from "./components/Typography.tsx";
+
+const errorMessage = (value: string | Error | undefined) =>
+  value instanceof Error ? value.message : value;
+
+const answerText = (value: string, maskGlyph?: string) => {
+  if (maskGlyph !== undefined) {
+    return maskGlyph.repeat(Math.min(value.length, 12));
+  }
+  return value || "(empty)";
+};
+
+/**
+ * Escape-to-cancel for standard prompts. Ctrl+C is handled centrally by the
+ * screen runner (SigilRuntime.run), so screens only wire Escape semantics.
+ */
+const useCancel = (cancel: () => void) =>
+  useTerminalInput((_input, key) => {
+    if (key.escape) cancel();
+  });
+
+/** One `Screen` factory shape shared by the non-generic prompt screens. */
+const screen =
+  <Options, Value>(
+    name: string,
+    Component: (
+      props: { readonly options: Options } & ScreenController<Value>,
+    ) => ReactNode,
+  ) =>
+  (options: Options): Screen<Value> => ({
+    name,
+    render: (controller) => <Component options={options} {...controller} />,
+  });
+
+/**
+ * Scaffolding shared by the select and multi-select prompts: cursor state
+ * clamped onto enabled rows, the navigation key ladder (arrows, `j`/`k` when
+ * not searchable, Home/End, PageUp/PageDown), Escape-clears-filter-then-
+ * cancels, filter editing, and bracketed paste into the filter. Callers run
+ * their own submit/toggle keys first and delegate the rest to `handleKey`.
+ */
+const useChoiceList = ({
+  disabled,
+  searchable,
+  visibleCount,
+  query,
+  setQuery,
+  onCancel,
+  initialCursor = 0,
+}: {
+  readonly disabled: ReadonlyArray<boolean>;
+  readonly searchable: boolean;
+  readonly visibleCount: number;
+  readonly query: string;
+  readonly setQuery: (query: string) => void;
+  readonly onCancel: () => void;
+  readonly initialCursor?: number;
+}) => {
+  const { cursor, setCursor } = useListNavigation(
+    disabled.length,
+    initialCursor,
+  );
+  useEffect(() => {
+    setCursor((current) => {
+      if (disabled.length === 0) return 0;
+      const clamped = Math.min(current, disabled.length - 1);
+      if (!disabled[clamped]) return clamped;
+      const enabled = disabled.findIndex((value) => !value);
+      return enabled === -1 ? clamped : enabled;
+    });
+  }, [disabled, setCursor]);
+  const page = Math.max(1, visibleCount);
+  const resetFilter = (next: string) => {
+    setQuery(next);
+    setCursor(0);
+  };
+  /** Returns true when the keystroke was consumed. */
+  const handleKey = (input: string, key: TerminalKey): boolean => {
+    const plain = !key.ctrl && !key.meta;
+    if (key.up || (!searchable && plain && input === "k"))
+      setCursor(moveSkippingDisabled(disabled, cursor, -1));
+    else if (key.down || (!searchable && plain && input === "j"))
+      setCursor(moveSkippingDisabled(disabled, cursor, 1));
+    else if (key.home) setCursor(jumpSkippingDisabled(disabled, cursor, 0));
+    else if (key.end)
+      setCursor(jumpSkippingDisabled(disabled, cursor, disabled.length - 1));
+    else if (key.pageUp)
+      setCursor(jumpSkippingDisabled(disabled, cursor, cursor - page));
+    else if (key.pageDown)
+      setCursor(jumpSkippingDisabled(disabled, cursor, cursor + page));
+    else if (key.escape) {
+      // An active filter absorbs the first Escape; the second cancels.
+      if (query !== "") resetFilter("");
+      else onCancel();
+    } else if (searchable && (key.backspace || key.delete))
+      resetFilter(query.slice(0, -1));
+    else if (searchable && plain && !key.tab) {
+      const typed = sanitizeTextInsert(input);
+      if (typed.length === 0) return false;
+      resetFilter(query + typed);
+    } else return false;
+    return true;
+  };
+  useTerminalPaste(
+    (pasted) => {
+      const typed = sanitizeTextInsert(pasted);
+      if (typed.length > 0) resetFilter(query + typed);
+    },
+    { active: searchable },
+  );
+  return { cursor, setCursor, handleKey } as const;
+};
+
+type TextPromptProps = {
+  readonly options: TextInputOptions | PasswordInputOptions;
+  readonly mask?: boolean;
+  readonly submit: (value: string, summary?: ReactNode) => void;
+  readonly cancel: () => void;
+};
+
+function TextPrompt({ options, mask, submit, cancel }: TextPromptProps) {
+  const glyphs = useGlyphs();
+  const keys = useKeyGlyphs();
+  const maskGlyph = mask ? glyphs.mask : undefined;
+  const [error, setError] = useState<string>();
+  useCancel(cancel);
+  const complete = (raw: string) => {
+    const value =
+      raw === "" &&
+      "defaultValue" in options &&
+      options.defaultValue !== undefined
+        ? options.defaultValue
+        : raw;
+    const problem = errorMessage(options.validate?.(value));
+    if (problem !== undefined) setError(problem);
+    else
+      submit(
+        value,
+        <AnsweredPrompt
+          message={options.message}
+          answer={answerText(value, maskGlyph)}
+        />,
+      );
+  };
+  return (
+    <PromptFrame
+      message={options.message}
+      description={options.description}
+      layout={options.layout ?? "inline"}
+      error={error}
+      keys={[
+        [keys.enter, "confirm"],
+        [keys.escape, "cancel"],
+      ]}
+    >
+      <TextField
+        // A default is the value Enter will submit, so show it in the empty
+        // field when the caller did not supply more specific hint text.
+        // Keep it a placeholder (rather than initialValue) so the first
+        // keystroke starts a replacement instead of appending to the default.
+        placeholder={
+          options.placeholder ??
+          ("defaultValue" in options ? options.defaultValue : undefined)
+        }
+        initialValue={
+          "initialValue" in options ? options.initialValue : undefined
+        }
+        mask={maskGlyph}
+        ariaLabel={options.message}
+        onChange={() => setError(undefined)}
+        onSubmit={complete}
+      />
+    </PromptFrame>
+  );
+}
+
+export const textScreen = screen<TextInputOptions, string>(
+  "text input",
+  TextPrompt,
+);
+
+export const passwordScreen = screen<PasswordInputOptions, string>(
+  "password input",
+  (props) => <TextPrompt {...props} mask />,
+);
+
+type SelectPromptProps<Value> = {
+  readonly options: SelectOptions<Value>;
+  readonly submit: (value: Value, summary?: ReactNode) => void;
+  readonly cancel: () => void;
+  readonly summary?: boolean;
+  readonly header?: ReactNode;
+  readonly footer?: ReactNode;
+  readonly escapeLabel?: string;
+};
+
+function SelectPrompt<Value>({
+  options,
+  submit,
+  cancel,
+  summary = true,
+  header,
+  footer,
+  escapeLabel = "cancel",
+}: SelectPromptProps<Value>) {
+  const keys = useKeyGlyphs();
+  const { rows } = useTerminalSize();
+  const visibleCount =
+    options.visibleCount ?? Math.max(3, Math.min(16, rows - 8));
+  const searchable = options.searchable === true;
+  const [query, setQuery] = useState("");
+  const filtered = useMemo(
+    () =>
+      searchable
+        ? filterChoices(options.options, query)
+        : options.options.map((choice, index) => ({ choice, index })),
+    [options.options, query, searchable],
+  );
+  const initialOriginalIndex = options.options.findIndex(
+    (choice) => choice.value === options.initialValue,
+  );
+  const initialIndex = filtered.findIndex(
+    ({ index }) => index === initialOriginalIndex,
+  );
+  const firstEnabled = filtered.findIndex(({ choice }) => !choice.disabled);
+  const disabled = useMemo(
+    () =>
+      filtered.map(
+        ({ choice }) =>
+          choice.disabled !== undefined && choice.disabled !== false,
+      ),
+    [filtered],
+  );
+  const { cursor, handleKey } = useChoiceList({
+    disabled,
+    searchable,
+    visibleCount,
+    query,
+    setQuery,
+    onCancel: cancel,
+    initialCursor:
+      initialIndex !== -1 && !filtered[initialIndex]?.choice.disabled
+        ? initialIndex
+        : Math.max(0, firstEnabled),
+  });
+  useTerminalInput((input, key) => {
+    if (key.enter) {
+      const choice = filtered[cursor]?.choice;
+      if (choice !== undefined && !choice.disabled) {
+        submit(
+          choice.value,
+          summary ? (
+            <AnsweredPrompt message={options.message} answer={choice.label} />
+          ) : undefined,
+        );
+      }
+      return;
+    }
+    handleKey(input, key);
+  });
+  return (
+    <Box flexDirection="column" gap={1}>
+      {header}
+      <PromptFrame
+        message={options.message}
+        keys={[
+          [keys.upDown, "navigate"],
+          [keys.enter, "select"],
+          [keys.escape, query === "" ? escapeLabel : "clear filter"],
+        ]}
+      >
+        <Box flexDirection="column" gap={searchable ? 1 : 0}>
+          {searchable ? (
+            <Text tone="muted">
+              filter · <Text color={theme.color.info}>{query || "all"}</Text>
+            </Text>
+          ) : null}
+          <Menu
+            choices={filtered.map(({ choice }) => choice)}
+            cursor={cursor}
+            visibleCount={visibleCount}
+            empty="No matching choices."
+            descriptionPlacement={options.descriptionPlacement}
+          />
+        </Box>
+      </PromptFrame>
+      {footer}
+    </Box>
+  );
+}
+
+export const selectScreen = <Value,>(
+  options: SelectOptions<Value>,
+): Screen<Value> => ({
+  name: "selection",
+  render: ({ submit, cancel }) => (
+    <SelectPrompt options={options} submit={submit} cancel={cancel} />
+  ),
+});
+
+export const menuScreen = <Value,>(
+  options: MenuOptions<Value>,
+): Screen<Value> => {
+  const hasBack = Object.hasOwn(options, "back");
+  return {
+    name: "menu",
+    render: ({ submit, cancel }) => (
+      <SelectPrompt
+        options={options}
+        submit={submit}
+        cancel={() => (hasBack ? submit(options.back as Value) : cancel())}
+        summary={false}
+        header={options.header}
+        footer={options.footer}
+        escapeLabel={hasBack ? "back" : "exit"}
+      />
+    ),
+  };
+};
+
+type MultiSelectPromptProps<Value> = {
+  readonly options: MultiSelectOptions<Value>;
+  readonly submit: (value: ReadonlyArray<Value>, summary?: ReactNode) => void;
+  readonly cancel: () => void;
+};
+
+function MultiSelectPrompt<Value>({
+  options,
+  submit,
+  cancel,
+}: MultiSelectPromptProps<Value>) {
+  const keys = useKeyGlyphs();
+  const { rows } = useTerminalSize();
+  const visibleCount =
+    options.visibleCount ?? Math.max(3, Math.min(16, rows - 10));
+  const searchable = options.searchable === true;
+  const [query, setQuery] = useState("");
+  const filtered = useMemo(
+    () =>
+      searchable
+        ? filterChoices(options.options, query)
+        : options.options.map((choice, index) => ({ choice, index })),
+    [options.options, searchable, query],
+  );
+  const listRows = useMemo(() => {
+    const result: Array<
+      | {
+          readonly type: "group";
+          readonly label: string;
+          readonly indices: number[];
+        }
+      | {
+          readonly type: "choice";
+          readonly choice: (typeof filtered)[number]["choice"];
+          readonly index: number;
+          readonly nested: boolean;
+        }
+    > = [];
+    // Each contiguous run of a group gets its own header owning exactly the
+    // run's rows — a group split by ungrouped entries must not produce two
+    // headers that both toggle the whole group.
+    let currentGroup: string | undefined;
+    let currentHeader: { indices: number[] } | undefined;
+    for (const entry of filtered) {
+      const group = entry.choice.group;
+      if (group === undefined) {
+        currentHeader = undefined;
+      } else if (group !== currentGroup || currentHeader === undefined) {
+        const header = {
+          type: "group" as const,
+          label: group,
+          indices: [] as number[],
+        };
+        result.push(header);
+        currentHeader = header;
+      }
+      currentGroup = group;
+      if (group !== undefined && currentHeader !== undefined) {
+        currentHeader.indices.push(entry.index);
+      }
+      result.push({
+        type: "choice",
+        choice: entry.choice,
+        index: entry.index,
+        nested: group !== undefined,
+      });
+    }
+    return result;
+  }, [filtered]);
+  const [selected, setSelected] = useSelectedChoices(
+    options.options,
+    options.initialValues ?? [],
+  );
+  const [error, setError] = useState<string>();
+  const disabled = useMemo(
+    () =>
+      listRows.map((row) =>
+        row.type === "choice"
+          ? row.choice.disabled !== undefined && row.choice.disabled !== false
+          : row.indices.every((index) =>
+              Boolean(options.options[index]?.disabled),
+            ),
+      ),
+    [listRows, options.options],
+  );
+  const { cursor, handleKey } = useChoiceList({
+    disabled,
+    searchable,
+    visibleCount,
+    query,
+    setQuery,
+    onCancel: cancel,
+  });
+  useTerminalInput((input, key) => {
+    if (key.ctrl && input === "a") {
+      const enabledVisible = filtered.flatMap(({ choice, index }) =>
+        choice.disabled !== undefined && choice.disabled !== false
+          ? []
+          : [index],
+      );
+      if (enabledVisible.length === 0) return;
+      setSelected((current) => {
+        const next = new Set(current);
+        const allSelected = enabledVisible.every((index) => next.has(index));
+        for (const index of enabledVisible) {
+          if (allSelected) next.delete(index);
+          else next.add(index);
+        }
+        return next;
+      });
+      setError(undefined);
+    } else if (input === " " && !key.ctrl && !key.meta) {
+      const row = listRows[cursor];
+      if (row === undefined) return;
+      const indices =
+        row.type === "group"
+          ? row.indices.filter((index) => !options.options[index]?.disabled)
+          : row.choice.disabled
+            ? []
+            : [row.index];
+      if (indices.length === 0) return;
+      setSelected((current) => {
+        const next = new Set(current);
+        const allSelected = indices.every((index) => next.has(index));
+        for (const index of indices) {
+          if (allSelected) next.delete(index);
+          else next.add(index);
+        }
+        return next;
+      });
+      setError(undefined);
+    } else if (key.enter) {
+      if (options.required && selected.size === 0) {
+        setError("Select at least one option.");
+        return;
+      }
+      const values = options.options.flatMap((choice, index) =>
+        selected.has(index) ? [choice.value] : [],
+      );
+      const labels = options.options.flatMap((choice, index) =>
+        selected.has(index) ? [choice.label] : [],
+      );
+      submit(
+        values,
+        <AnsweredPrompt
+          message={options.message}
+          answer={labels.length === 0 ? "none" : labels.join(", ")}
+        />,
+      );
+    } else if (handleKey(input, key)) {
+      setError(undefined);
+    }
+  });
+  const visibleChoices = listRows.map((row) =>
+    row.type === "group"
+      ? {
+          value: row,
+          label: row.label,
+          sticky: true,
+          tone: "info" as const,
+        }
+      : {
+          ...row.choice,
+          value: row,
+          group: undefined,
+          indent: row.nested ? 2 : row.choice.indent,
+        },
+  );
+  const visibleSelected = new Set(
+    listRows.flatMap((row, visibleIndex) => {
+      if (row.type !== "group") {
+        return selected.has(row.index) ? [visibleIndex] : [];
+      }
+      // Match the toggle semantics: disabled children are excluded there, so
+      // they must not keep a fully-toggled group from rendering as selected.
+      const toggleable = row.indices.filter(
+        (index) => !options.options[index]?.disabled,
+      );
+      return toggleable.length > 0 &&
+        toggleable.every((index) => selected.has(index))
+        ? [visibleIndex]
+        : [];
+    }),
+  );
+  return (
+    <PromptFrame
+      message={options.message}
+      error={error}
+      keys={[
+        [keys.upDown, "navigate"],
+        [keys.space, "toggle"],
+        ["ctrl+a", "toggle all"],
+        [keys.enter, "confirm"],
+        [keys.escape, query === "" ? "cancel" : "clear filter"],
+      ]}
+    >
+      <Box flexDirection="column" gap={searchable ? 1 : 0}>
+        {searchable ? (
+          <Text tone="muted">
+            filter · <Text color={theme.color.info}>{query || "all"}</Text>
+            {" · "}
+            {selected.size} selected
+          </Text>
+        ) : (
+          <Text tone="muted">{selected.size} selected</Text>
+        )}
+        <Menu<(typeof listRows)[number]>
+          choices={visibleChoices}
+          cursor={cursor}
+          selected={visibleSelected}
+          visibleCount={visibleCount}
+          empty="No matching choices."
+          descriptionPlacement={options.descriptionPlacement}
+        />
+      </Box>
+    </PromptFrame>
+  );
+}
+
+export const multiSelectScreen = <Value,>(
+  options: MultiSelectOptions<Value>,
+): Screen<ReadonlyArray<Value>> => ({
+  name: "multiple selection",
+  render: ({ submit, cancel }) => (
+    <MultiSelectPrompt options={options} submit={submit} cancel={cancel} />
+  ),
+});
+
+type CycleSelectPromptProps<State> = {
+  readonly options: CycleSelectOptions<State>;
+  readonly submit: (value: ReadonlyArray<State>, summary?: ReactNode) => void;
+  readonly cancel: () => void;
+};
+
+function CycleSelectPrompt<State>({
+  options,
+  submit,
+  cancel,
+}: CycleSelectPromptProps<State>) {
+  const keys = useKeyGlyphs();
+  const { rows } = useTerminalSize();
+  const visibleCount =
+    options.visibleCount ?? Math.max(3, Math.min(16, rows - 8));
+  const navigation = useCycleNavigation(
+    options.options.map((choice) => choice.states.length),
+  );
+  const [unchanged, setUnchanged] = useState(false);
+  useCancel(cancel);
+  const last = Math.max(0, options.options.length - 1);
+  const page = Math.max(1, visibleCount);
+  useTerminalInput((input, key) => {
+    const plain = !key.ctrl && !key.meta;
+    if (key.up || (plain && input === "k")) navigation.move(-1);
+    else if (key.down || (plain && input === "j")) navigation.move(1);
+    else if (key.home) navigation.setCursor(0);
+    else if (key.end) navigation.setCursor(last);
+    else if (key.pageUp)
+      navigation.setCursor(Math.max(0, navigation.cursor - page));
+    else if (key.pageDown)
+      navigation.setCursor(Math.min(last, navigation.cursor + page));
+    else if ((plain && input === " ") || key.right) {
+      navigation.cycle(1);
+      setUnchanged(false);
+    } else if (key.left) {
+      navigation.cycle(-1);
+      setUnchanged(false);
+    } else if (key.enter) {
+      if (
+        options.requireChange &&
+        navigation.indices.every((index) => index === 0)
+      ) {
+        setUnchanged(true);
+        return;
+      }
+      const values = options.options.flatMap((choice, index) => {
+        const state = choice.states[navigation.indices[index] ?? 0];
+        return state === undefined ? [] : [state.value];
+      });
+      const changed = options.options.flatMap((choice, index) => {
+        if ((navigation.indices[index] ?? 0) === 0) return [];
+        const state = choice.states[navigation.indices[index] ?? 0];
+        return state === undefined
+          ? []
+          : [`${choice.label}: ${state.label ?? "changed"}`];
+      });
+      submit(
+        values,
+        <AnsweredPrompt
+          message={options.message}
+          answer={changed.length === 0 ? "no changes" : changed.join(", ")}
+        />,
+      );
+    }
+  });
+  return (
+    <PromptFrame
+      message={options.message}
+      keys={[
+        [keys.upDown, "navigate"],
+        [keys.space, "change"],
+        [keys.enter, options.requireChange ? "apply" : "confirm"],
+        [keys.escape, options.requireChange ? "back" : "cancel"],
+      ]}
+    >
+      <Box flexDirection="column">
+        <CycleList
+          choices={options.options}
+          cursor={navigation.cursor}
+          indices={navigation.indices}
+          visibleCount={visibleCount}
+        />
+        {unchanged ? (
+          <Alert variant="warning" title="No changes to apply">
+            {options.unchangedMessage ??
+              "Press Space to change a selection, or Esc to go back."}
+          </Alert>
+        ) : null}
+      </Box>
+    </PromptFrame>
+  );
+}
+
+export const cycleSelectScreen = <State,>(
+  options: CycleSelectOptions<State>,
+): Screen<ReadonlyArray<State>> => ({
+  name: "cycle selection",
+  render: ({ submit, cancel }) => (
+    <CycleSelectPrompt options={options} submit={submit} cancel={cancel} />
+  ),
+});
+
+export const awaitExternalScreen = screen<AwaitExternalOptions, string>(
+  "external authorization",
+  ({ options, submit, cancel }) => (
+    <ExternalWait {...options} onSubmit={submit} onCancel={cancel} />
+  ),
+);
+
+type ConfirmPromptProps = {
+  readonly options: ConfirmOptions;
+  readonly submit: (value: boolean, summary?: ReactNode) => void;
+  readonly cancel: () => void;
+};
+
+function ConfirmPrompt({ options, submit, cancel }: ConfirmPromptProps) {
+  const keys = useKeyGlyphs();
+  const complete = (answer: boolean) =>
+    submit(
+      answer,
+      <AnsweredPrompt
+        message={options.message}
+        answer={answer ? "yes" : "no"}
+      />,
+    );
+  const value = useConfirmKeys({
+    initialValue: options.initialValue ?? true,
+    onSubmit: complete,
+    onCancel: cancel,
+  });
+  return (
+    <PromptFrame
+      message={options.message}
+      keys={[
+        [keys.yesNo, "choose"],
+        [keys.enter, "confirm"],
+        [keys.escape, "cancel"],
+      ]}
+    >
+      <BooleanChoice value={value} />
+    </PromptFrame>
+  );
+}
+
+export const confirmScreen = screen<ConfirmOptions, boolean>(
+  "confirmation",
+  ConfirmPrompt,
+);

--- a/packages/alchemy/src/Cli/CliKit/terminal.ts
+++ b/packages/alchemy/src/Cli/CliKit/terminal.ts
@@ -1,0 +1,102 @@
+/** Terminal-emulator features shared by CliKit components. */
+import { stripVTControlCharacters } from "node:util";
+import {
+  detectColorLevel,
+  detectUnicodeSupport,
+} from "@alchemy.run/sigil/capabilities";
+import stringWidth from "string-width";
+import { glyphsFor, theme } from "./theme.ts";
+
+const ATTRIBUTION_COLORS = [
+  theme.color.accent,
+  theme.color.info,
+  theme.color.warning,
+  theme.color.accentBright,
+  theme.color.muted,
+  theme.color.success,
+] as const;
+
+const sourceColor = (id: string): string => {
+  let hash = 0;
+  for (let index = 0; index < id.length; index++) {
+    hash = (hash * 31 + id.charCodeAt(index)) | 0;
+  }
+  return ATTRIBUTION_COLORS[Math.abs(hash) % ATTRIBUTION_COLORS.length];
+};
+
+export const ANSI_RESET = "\u001B[0m";
+export const ANSI_BOLD = "\u001B[1m";
+export const ANSI_DIM = "\u001B[2m";
+
+/** Truecolor foreground escape for raw, non-layout output. */
+export const ansiFg = (hex: string) => {
+  const red = Number.parseInt(hex.slice(1, 3), 16);
+  const green = Number.parseInt(hex.slice(3, 5), 16);
+  const blue = Number.parseInt(hex.slice(5, 7), 16);
+  return `\u001B[38;2;${red};${green};${blue}m`;
+};
+
+/**
+ * The canonical color-support decision, shared by raw terminal strings and
+ * CliKit capability detection so the two can never disagree.
+ */
+export const colorsEnabled = (
+  stream: Pick<NodeJS.WriteStream, "isTTY"> = process.stdout,
+): boolean => detectColorLevel(stream) > 0;
+
+/** The canonical Unicode-support decision for raw terminal strings. */
+export const unicodeEnabled = detectUnicodeSupport;
+
+/** Environment override for child processes whose piped output returns here. */
+export const pipedColorEnv = (): Record<string, string> =>
+  colorsEnabled() ? { FORCE_COLOR: process.env.FORCE_COLOR ?? "1" } : {};
+
+export const paint = (code: string, value: string): string =>
+  colorsEnabled() ? `${code}${value}${ANSI_RESET}` : value;
+
+export const stripAnsi = (value: string): string =>
+  stripVTControlCharacters(value);
+
+/** Stable source prefix for interleaved dev-server and worker output. */
+export const linePrefix = (
+  id: string,
+  options: { readonly colors?: boolean; readonly unicode?: boolean } = {},
+) => {
+  const colors = options.colors ?? colorsEnabled();
+  const divider = glyphsFor(options.unicode ?? unicodeEnabled()).bar;
+  return colors
+    ? `${ansiFg(sourceColor(id))}${id}${ANSI_RESET} ${divider}`
+    : `${id} ${divider}`;
+};
+
+export const hyperlink = (text: string, url: string): string =>
+  `\u001B]8;;${url}\u0007${text}\u001B]8;;\u0007`;
+
+export const copyToClipboard = (
+  text: string,
+  stdout: Pick<NodeJS.WriteStream, "write"> = process.stdout,
+): void => {
+  const payload = Buffer.from(text).toString("base64");
+  let sequence = `\u001B]52;c;${payload}\u0007`;
+  if (process.env.TMUX !== undefined) {
+    sequence = `\u001BPtmux;${sequence.replaceAll("\u001B", "\u001B\u001B")}\u001B\\`;
+  }
+  stdout.write(sequence);
+};
+
+const truncateSegmenter = new Intl.Segmenter();
+
+/** Display-width-aware truncation (wide CJK/emoji count by rendered cells). */
+export const truncate = (value: string, width: number): string => {
+  const max = Math.max(4, width);
+  if (stringWidth(value) <= max) return value;
+  let total = 0;
+  let kept = "";
+  for (const { segment } of truncateSegmenter.segment(value)) {
+    const segmentWidth = stringWidth(segment);
+    if (total + segmentWidth > max - 1) break;
+    total += segmentWidth;
+    kept += segment;
+  }
+  return `${kept}…`;
+};

--- a/packages/alchemy/src/Cli/CliKit/theme.ts
+++ b/packages/alchemy/src/Cli/CliKit/theme.ts
@@ -1,0 +1,99 @@
+export const theme = {
+  color: {
+    /**
+     * Brand terracotta — the yantra bindu (see website/src/brand/yantra.ts,
+     * dark-theme `dot`). Marks brand identity: the logo dot, the wordmark
+     * bullet, active-profile markers. Never used for errors — that is
+     * `danger`'s job.
+     */
+    brand: "#e28a5b",
+    accent: "#acd17b",
+    accentBright: "#c5e49b",
+    accentMuted: "#587044",
+    success: "#9acb69",
+    warning: "#efb85a",
+    danger: "#e1735b",
+    info: "#75bfd0",
+    /** Reserved for non-text decoration (borders, gutter bars, idle glyphs). Muted TEXT uses `tone="muted"`. */
+    muted: "#8f887c",
+    surface: "#36332e",
+    onSurface: "#f5f0e6",
+    onAccent: "#14110d",
+    /** High-emphasis foreground text (headings, command names). */
+    emphasis: "#f5f0e6",
+  },
+  glyph: {
+    section: "●",
+    active: "›",
+    success: "✓",
+    warning: "!",
+    error: "×",
+    info: "•",
+    pointer: "›",
+    selected: "◆",
+    unselected: "·",
+    checked: "✓",
+    unchecked: "·",
+    add: "+",
+    edit: "✎",
+    refresh: "↻",
+    delete: "−",
+    replace: "↔",
+    run: "▶",
+    bar: "┊",
+    mask: "•",
+    bullet: "·",
+    overflowUp: "↑",
+    overflowDown: "↓",
+  },
+  /**
+   * Key-hint labels for KeyBar footers. Resolve through `useKeyGlyphs()`
+   * (components/Environment.tsx) so ASCII terminals get readable fallbacks
+   * instead of mojibake.
+   */
+  keyHint: {
+    enter: "↩",
+    upDown: "↑/↓",
+    leftRight: "←/→",
+    escape: "esc",
+    space: "space",
+    tab: "tab",
+    yesNo: "y/n",
+  },
+} as const;
+
+export type KeyHint = { readonly [Key in keyof typeof theme.keyHint]: string };
+export type GlyphName = keyof typeof theme.glyph;
+
+export const asciiGlyphs: { readonly [Key in GlyphName]: string } = {
+  section: "@",
+  active: ">",
+  success: "+",
+  warning: "!",
+  error: "x",
+  info: "i",
+  pointer: ">",
+  selected: "*",
+  unselected: ".",
+  checked: "x",
+  unchecked: ".",
+  add: "+",
+  edit: "~",
+  refresh: "r",
+  delete: "-",
+  replace: "~",
+  run: ">",
+  bar: ":",
+  mask: "*",
+  bullet: ".",
+  overflowUp: "^",
+  overflowDown: "v",
+};
+
+export const glyphsFor = (unicode: boolean) =>
+  unicode ? theme.glyph : asciiGlyphs;
+
+export type StatusVariant = "info" | "success" | "warning" | "error";
+
+export const statusColor = (variant: StatusVariant): string =>
+  variant === "error" ? theme.color.danger : theme.color[variant];

--- a/packages/alchemy/src/Cli/CliKit/types.ts
+++ b/packages/alchemy/src/Cli/CliKit/types.ts
@@ -1,0 +1,210 @@
+import type * as Effect from "effect/Effect";
+import type { ReactNode } from "react";
+import type { NonInteractiveTerminal, TerminalCancelled } from "./errors.ts";
+
+/** A composable CLI layout. Views are inert; only CliKit renders them. */
+export type View = ReactNode;
+
+export interface CliKitCapabilities {
+  /** Whether this process has usable terminal input for prompts and apps. */
+  readonly input: boolean;
+  readonly columns: number;
+  readonly rows: number;
+  readonly colors: boolean;
+  readonly unicode: boolean;
+  /** Whether full-screen applications may use the terminal's alternate buffer. */
+  readonly alternateScreen: boolean;
+}
+
+export interface RenderOptions {
+  readonly columns?: number;
+  readonly colors?: boolean;
+}
+
+export interface Choice<Value> {
+  readonly value: Value;
+  readonly label: string;
+  /** Optional section heading shared by adjacent choices. */
+  readonly group?: string;
+  /** Indent the entire rendered row, including its selection indicator. */
+  readonly indent?: number;
+  /** Keep this row visible as the heading for following rows while scrolling. */
+  readonly sticky?: boolean;
+  /** Visually distinguish structural rows from ordinary choices. */
+  readonly tone?: "info";
+  readonly description?: string;
+  readonly disabled?: boolean | string;
+}
+
+export interface MessageOptions {
+  readonly message: string;
+  readonly detail?: string;
+}
+
+export interface TextInputOptions {
+  readonly message: string;
+  /** Secondary guidance rendered beneath the field in muted text. */
+  readonly description?: string;
+  /** Place the editable field beside the message or beneath it. @default "inline" */
+  readonly layout?: "inline" | "stacked";
+  readonly placeholder?: string;
+  readonly initialValue?: string;
+  readonly defaultValue?: string;
+  readonly validate?: (value: string) => string | Error | undefined;
+}
+
+export interface PasswordInputOptions extends Omit<
+  TextInputOptions,
+  "initialValue" | "defaultValue"
+> {}
+
+export interface ConfirmOptions {
+  readonly message: string;
+  readonly initialValue?: boolean;
+}
+
+export interface SelectOptions<Value> {
+  readonly message: string;
+  readonly options: ReadonlyArray<Choice<Value>>;
+  readonly initialValue?: Value;
+  readonly visibleCount?: number;
+  /** Allow typing to filter choices by label and description. */
+  readonly searchable?: boolean;
+  /** Place descriptions beside labels instead of on a second line. */
+  readonly descriptionPlacement?: "below" | "inline";
+}
+
+export interface MultiSelectOptions<Value> extends Omit<
+  SelectOptions<Value>,
+  "initialValue"
+> {
+  readonly initialValues?: ReadonlyArray<Value>;
+  readonly required?: boolean;
+}
+
+export interface CycleChoice<State> {
+  readonly label: string;
+  readonly description?: string;
+  readonly states: ReadonlyArray<{
+    readonly value: State;
+    readonly label?: string;
+    readonly icon?: string;
+    readonly variant?:
+      | "neutral"
+      | "accent"
+      | "info"
+      | "success"
+      | "warning"
+      | "error";
+  }>;
+}
+
+export interface CycleSelectOptions<State> {
+  readonly message: string;
+  readonly options: ReadonlyArray<CycleChoice<State>>;
+  readonly visibleCount?: number;
+  /** Keep the prompt open when Enter is pressed without changing any row. */
+  readonly requireChange?: boolean;
+  readonly unchangedMessage?: string;
+}
+
+export interface AwaitExternalOptions {
+  readonly message: string;
+  readonly waitingLabel: string;
+  readonly url?: string;
+  /** Short code the user must enter on the authorization page. */
+  readonly code?: string;
+  readonly openFailed?: boolean;
+  /** Open the authorization URL again from the waiting screen. */
+  readonly onOpen?: () => Promise<void>;
+  /** Allow Enter to switch to manual code entry. @default true */
+  readonly allowManualInput?: boolean;
+  readonly inputLabel?: string;
+  readonly placeholder?: string;
+  readonly validate?: (value: string) => string | Error | undefined;
+}
+
+/** A navigable application menu. Selecting an item does not commit output. */
+export interface MenuOptions<Value> extends SelectOptions<Value> {
+  readonly header?: View;
+  readonly footer?: View;
+  /**
+   * Value returned by Escape. Without it, Escape cancels the application.
+   * `undefined` is a valid back value when it is part of `Value`; presence of
+   * the property, rather than its value, determines whether a back target
+   * exists.
+   */
+  readonly back?: Value;
+}
+
+export interface ScreenController<Value> {
+  readonly submit: (value: Value, summary?: View) => void;
+  readonly cancel: () => void;
+}
+
+/**
+ * A custom interactive scene. The scene owns its local component state while
+ * CliKit owns input streams, serialization, rendering and teardown.
+ */
+export interface Screen<Value> {
+  readonly name: string;
+  readonly render: (controller: ScreenController<Value>) => View;
+}
+
+export const Screen = {
+  make: <Value>(
+    name: string,
+    render: (controller: ScreenController<Value>) => View,
+  ): Screen<Value> => ({ name, render }),
+};
+
+export interface ProgressOptions {
+  readonly label: string;
+  readonly detail?: string;
+}
+
+/**
+ * Handle for a live progress row. Acquired within a `Scope`: the enclosing
+ * scope's close is a release backstop, so an interrupted fiber can never leave
+ * an orphaned row pinning the renderer. Settling early via `succeed`/`fail`/
+ * `close` is the normal path; every settle operation is idempotent.
+ */
+export interface ProgressHandle {
+  readonly update: (options: ProgressOptions) => Effect.Effect<void>;
+  readonly succeed: (message?: string) => Effect.Effect<void>;
+  readonly fail: (message?: string) => Effect.Effect<void>;
+  readonly close: Effect.Effect<void>;
+}
+
+/**
+ * A mounted live view. The view itself is immutable — dynamic content flows
+ * through a caller-owned store that its component subscribes to — so the
+ * handle only controls the block's lifetime. Scope-bound the same way as
+ * {@link ProgressHandle}; `close` settles early and is idempotent.
+ */
+export interface LiveViewHandle {
+  readonly close: Effect.Effect<void>;
+}
+
+export interface LiveViewOptions {
+  /** Place an application shell/header before completed prompt output. */
+  readonly placement?: "beforeTranscript" | "afterTranscript";
+  /** Commit the final view to the static transcript when it closes. */
+  readonly persistOnClose?: boolean;
+}
+
+export type InteractionError = TerminalCancelled | NonInteractiveTerminal;
+
+export interface CliKitOptions {
+  readonly stdin?: NodeJS.ReadStream;
+  readonly stdout?: NodeJS.WriteStream;
+  readonly stderr?: NodeJS.WriteStream;
+  /** Override automatic TTY input detection. Primarily useful for tests. */
+  readonly input?: boolean;
+  readonly colors?: boolean;
+  readonly unicode?: boolean;
+  /** Capture console output while the interactive renderer owns the tty. */
+  readonly captureConsole?: boolean;
+  /** Handle Ctrl-C received while raw-mode rendering has no active prompt. */
+  readonly onInterrupt?: () => void;
+}

--- a/packages/alchemy/src/Cli/ModeTag.ts
+++ b/packages/alchemy/src/Cli/ModeTag.ts
@@ -1,7 +1,7 @@
 import type { ProviderMode } from "../ProviderMode.ts";
 
 /**
- * Pure formatting shared by the plan/deploy renderers (Ink TUI +
+ * Pure formatting shared by the plan/deploy renderers (Sigil TUI +
  * non-interactive LoggingCli) for the local-vs-live provider-mode
  * indicator on a resource row.
  *

--- a/packages/alchemy/src/Cli/exec.ts
+++ b/packages/alchemy/src/Cli/exec.ts
@@ -16,7 +16,7 @@ import { selectCli } from "./selectCli.ts";
 
 // `alchemy dev` is a long-running session whose primary output is the log
 // stream (worker starts, cron fires, request logs) interleaved with
-// re-applies on file change. Ink's insertion model stacks inserted lines
+// re-applies on file change. Sigil's insertion model stacks inserted lines
 // ABOVE the animated region, so runtime logs end up above the plan/apply
 // output in scrollback. Append-only chronological rendering is the correct
 // model for a dev server (plan → status → logs, strictly in order), so dev

--- a/packages/alchemy/src/Local/RpcSpawner.ts
+++ b/packages/alchemy/src/Local/RpcSpawner.ts
@@ -72,7 +72,7 @@ export const make = Effect.fn(function* ({
 
   // Sidecar output hub. During `alchemy dev` this process (the outer dev
   // command) shares the tty with the exec child, and the exec child owns the
-  // repainting progress renderer (Ink patches its `console`). Printing
+  // repainting progress renderer (Sigil patches its `console`). Printing
   // sidecar lines RAW from here interleaves with the renderer's repaints and
   // corrupts the region (stacked/duplicated frames). So: when an exec child
   // is subscribed via the /logs endpoint, hand lines to it and let it print
@@ -192,7 +192,7 @@ export const make = Effect.fn(function* ({
       const request = yield* HttpServerRequest;
       if (request.url.startsWith(LOGS_PATH)) {
         // Long-lived NDJSON stream of sidecar output. The subscriber (exec
-        // child) prints these lines through its own console, which the Ink
+        // child) prints these lines through its own console, which the Sigil
         // renderer patches — inserting them above the progress region
         // instead of tearing it. Client disconnect interrupts the stream
         // and unregisters the subscriber.
@@ -265,7 +265,7 @@ const parseSidecarLogLine = (raw: string): SidecarLogLine | undefined => {
 /**
  * Pull sidecar output from the spawner (the outer `alchemy dev` process)
  * into THIS process's Console. The exec child owns the terminal renderer —
- * Ink patches its `console`, so lines printed here are inserted cleanly
+ * Sigil patches its `console`, so lines printed here are inserted cleanly
  * above the repainting progress region instead of racing it on the shared
  * tty. Forks in the ambient scope and never fails: when no spawner is
  * configured (`ALCHEMY_RPC_SPAWNER_URL` absent — plain deploy/destroy) it is

--- a/packages/alchemy/src/Util/interactive.ts
+++ b/packages/alchemy/src/Util/interactive.ts
@@ -3,20 +3,26 @@
  * coding agent, CI runner, test runner, or anything else that won't render an
  * interactive TUI / prompt well.
  *
- * Two callers rely on this:
- *  - `Cli/selectCli.ts` uses it to pick `LoggingCli` over the Ink TUI.
- *  - `Auth/Profile.ts` uses it to refuse to launch an interactive credential
- *    configure flow (and thus avoid acquiring an auth lockfile) when there's
- *    no TTY to drive the prompts.
+ * This is the process-level source of truth used by CliKit capability
+ * detection, auth configuration guards, and spawned-command stdin policy.
  *
  * Kept in `Util` (rather than `Cli`) so `Auth` can depend on it without
  * pulling in the CLI layer.
  */
 export const isNonInteractive = (): boolean => {
   const env = process.env;
+  // An explicit CLI flag beats every env-based heuristic. Checked via argv
+  // because capability detection runs while the CLI's service layers are
+  // built, before the command parser has produced flag values. Only scan up
+  // to a `--` separator so a positional argument that happens to be the
+  // literal text "--no-input" is not mistaken for the flag.
+  const separator = process.argv.indexOf("--");
+  const flagArgs =
+    separator === -1 ? process.argv : process.argv.slice(0, separator);
+  if (flagArgs.includes("--no-input")) return true;
   if (env.ALCHEMY_PLAIN === "1" || env.ALCHEMY_NO_TUI === "1") return true;
   if (env.ALCHEMY_TUI === "1") return false;
-  if (!process.stdout.isTTY) return true;
+  if (!process.stdin.isTTY || !process.stdout.isTTY) return true;
   if (env.CI) return true;
   // Known coding-agent env vars. These are best-effort — the isTTY check
   // above already catches most cases since agents typically pipe stdout.

--- a/packages/alchemy/test/Cli/CliKit.test.tsx
+++ b/packages/alchemy/test/Cli/CliKit.test.tsx
@@ -1,0 +1,1003 @@
+/** @jsxImportSource react */
+import { PassThrough } from "node:stream";
+import {
+  NonInteractiveTerminal,
+  Application,
+  Screen,
+  TerminalCancelled,
+  CliKit,
+  hyperlink,
+  stripAnsi,
+  layer as cliKitLayer,
+} from "@/Cli/CliKit/index.ts";
+import {
+  AnsweredPrompt,
+  Alert,
+  DescriptionList,
+  Heading,
+  LiveStore,
+  ProgressGroup,
+  SectionHeading,
+  Status,
+  Tabs,
+  TaskRow,
+  Text,
+  TextField,
+  useLiveStore,
+} from "@/Cli/CliKit/components.ts";
+import { makeRuntime } from "@/Cli/CliKit/SigilRuntime.tsx";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Fiber from "effect/Fiber";
+import { expect, it } from "alchemy-test";
+
+class CaptureStream extends PassThrough {
+  readonly columns = 80;
+  readonly rows = 24;
+  output = "";
+
+  constructor(readonly isTTY = false) {
+    super();
+    this.on("data", (chunk) => {
+      this.output += chunk.toString();
+    });
+  }
+
+  waitFor(text: string): Promise<void> {
+    if (this.output.includes(text)) return Promise.resolve();
+    return new Promise((resolve) => {
+      const onData = () => {
+        if (!this.output.includes(text)) return;
+        this.off("data", onData);
+        resolve();
+      };
+      this.on("data", onData);
+    });
+  }
+}
+
+class InputStream extends PassThrough {
+  readonly isTTY = true;
+  isRaw = false;
+  private resolveReady: (() => void) | undefined;
+  readonly ready = new Promise<void>((resolve) => {
+    this.resolveReady = resolve;
+  });
+
+  setRawMode(mode: boolean) {
+    this.isRaw = mode;
+    if (mode) this.resolveReady?.();
+    return this;
+  }
+
+  ref() {
+    return this;
+  }
+
+  unref() {
+    return this;
+  }
+}
+
+const makeStatic = () => {
+  const stdout = new CaptureStream();
+  const runtime = makeRuntime(
+    {
+      input: false,
+      // SAFETY: CaptureStream implements the writable stream surface consumed by Sigil.
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      captureConsole: false,
+    },
+    {
+      input: false,
+      columns: stdout.columns,
+      rows: stdout.rows,
+      colors: false,
+      unicode: true,
+      alternateScreen: false,
+    },
+  );
+  return { ...runtime, stdout };
+};
+
+/**
+ * Scoped variant of `makeStatic` for tests that mount a persistent renderer.
+ * Disposal runs as a finalizer, so a failing test never leaks a Sigil
+ * instance.
+ */
+const makeLive = (
+  overrides: {
+    readonly stdin?: InputStream;
+    readonly captureConsole?: boolean;
+    readonly input?: boolean;
+    readonly unicode?: boolean;
+  } = {},
+) => {
+  const input = overrides.input ?? true;
+  return Effect.acquireRelease(
+    Effect.sync(() => {
+      const stdout = new CaptureStream(input);
+      const stderr = new CaptureStream(input);
+      // Interactive runtimes need a raw-mode-capable stdin: with a real
+      // process.stdin pipe Sigil's useInput throws during commit, which now
+      // surfaces as a renderer error instead of being silently swallowed.
+      const stdin = overrides.stdin ?? (input ? new InputStream() : undefined);
+      const runtime = makeRuntime(
+        {
+          input,
+          // SAFETY: InputStream implements the raw readable stream surface consumed by Sigil.
+          stdin: stdin as unknown as NodeJS.ReadStream | undefined,
+          // SAFETY: CaptureStream implements the writable stream surface consumed by Sigil.
+          stdout: stdout as unknown as NodeJS.WriteStream,
+          // SAFETY: CaptureStream implements the writable stream surface consumed by Sigil.
+          stderr: stderr as unknown as NodeJS.WriteStream,
+          captureConsole: overrides.captureConsole ?? false,
+        },
+        {
+          input,
+          columns: stdout.columns,
+          rows: stdout.rows,
+          colors: false,
+          unicode: overrides.unicode ?? true,
+          alternateScreen: input,
+        },
+      );
+      return { ...runtime, stdout, stderr };
+    }),
+    ({ dispose }) => Effect.promise(dispose),
+  );
+};
+
+it.effect("renders the built-in layout components without writing", () =>
+  Effect.gen(function* () {
+    const { service, stdout } = makeStatic();
+    const rendered = yield* service.output.render(
+      <>
+        <SectionHeading annotation="active">Profile</SectionHeading>
+        <DescriptionList
+          items={[
+            { label: "Name", value: "production" },
+            { label: "Status", value: "ready" },
+          ]}
+        />
+      </>,
+    );
+
+    expect(rendered).toContain("Profile");
+    expect(rendered).toContain("production");
+    expect(rendered).toContain("ready");
+    expect(stdout.output).toBe("");
+  }),
+);
+
+it.effect("preserves zero in primitive-array views", () =>
+  Effect.gen(function* () {
+    const { service } = makeStatic();
+    const rendered = yield* service.output.render(["count: ", 0, false, null]);
+
+    expect(rendered).toBe("count: 0");
+  }),
+);
+
+it.effect("prints headings and data views through one service", () =>
+  Effect.gen(function* () {
+    const { service, stdout } = makeStatic();
+    yield* service.output.print(<Heading>Deployments</Heading>);
+    yield* service.output.print(
+      <DescriptionList
+        items={[
+          { label: "api", value: "ready" },
+          { label: "worker", value: "updating" },
+        ]}
+      />,
+    );
+
+    expect(stdout.output).toContain("Deployments");
+    expect(stdout.output).toContain("worker");
+    expect(stdout.output).toContain("updating");
+  }),
+);
+
+it.effect("fails input operations when no terminal input is available", () =>
+  Effect.gen(function* () {
+    const { service } = makeStatic();
+    const failure = yield* service.prompt
+      .select({
+        message: "Choose",
+        options: [{ label: "One", value: 1 }],
+      })
+      .pipe(Effect.flip);
+
+    expect(failure).toBeInstanceOf(NonInteractiveTerminal);
+    if (failure instanceof NonInteractiveTerminal) {
+      expect(failure.operation).toBe("selection");
+    }
+
+    const cycleFailure = yield* service.prompt
+      .cycle({ message: "Change", options: [] })
+      .pipe(Effect.flip);
+    const externalFailure = yield* service.prompt
+      .awaitExternal({
+        message: "Authorize",
+        waitingLabel: "Waiting",
+        inputLabel: "Enter code",
+      })
+      .pipe(Effect.flip);
+    expect(cycleFailure).toBeInstanceOf(NonInteractiveTerminal);
+    if (cycleFailure instanceof NonInteractiveTerminal) {
+      expect(cycleFailure.operation).toBe("cycle selection");
+    }
+    expect(externalFailure).toBeInstanceOf(NonInteractiveTerminal);
+    if (externalFailure instanceof NonInteractiveTerminal) {
+      expect(externalFailure.operation).toBe("external authorization");
+    }
+  }),
+);
+
+it.effect("progress handles are updateable and settle only once", () =>
+  Effect.gen(function* () {
+    const { service, stdout } = makeStatic();
+    const progress = yield* service.live.progress({ label: "Deploying" });
+    yield* progress.update({ label: "Uploading", detail: "2/3" });
+    yield* progress.succeed("Deployed");
+    yield* progress.fail("must not print");
+
+    expect(stdout.output).toContain("Deploying");
+    expect(stdout.output).toContain("Deployed");
+    expect(stdout.output).not.toContain("must not print");
+  }),
+);
+
+/** Live views are immutable; dynamic content flows through caller stores. */
+const LiveLabel = ({ store }: { readonly store: LiveStore<string> }) => (
+  <Text>{useLiveStore(store)}</Text>
+);
+
+it.effect("tears down store-driven live views idempotently", () =>
+  Effect.gen(function* () {
+    const { service, stdout } = yield* makeLive();
+
+    const store = new LiveStore("Scanning");
+    const live = yield* service.live.open(<LiveLabel store={store} />);
+    yield* Effect.sync(() => store.set("Deleting"));
+    yield* live.close;
+    yield* live.close;
+
+    expect(stdout.output).toContain("\u001B[?25h");
+  }),
+);
+
+it.effect("does not let one closing view tear down a newer live view", () =>
+  Effect.gen(function* () {
+    const { service, stdout } = yield* makeLive();
+
+    const first = yield* service.live.open(<Text>first</Text>);
+    const closing = yield* first.close.pipe(Effect.forkChild);
+    const store = new LiveStore("second");
+    const second = yield* service.live.open(<LiveLabel store={store} />, {
+      persistOnClose: true,
+    });
+    yield* Fiber.join(closing);
+    yield* Effect.sync(() => store.set("second updated"));
+    yield* second.close;
+
+    expect(stdout.output).toContain("second updated");
+  }),
+);
+
+interface OrderingCase {
+  readonly name: string;
+  readonly captureConsole: boolean;
+  readonly emit: (service: CliKit["Service"]) => Effect.Effect<void>;
+  readonly verify: (output: string) => void;
+}
+
+const orderingCases: ReadonlyArray<OrderingCase> = [
+  {
+    name: "commits persistent live views to the static transcript",
+    captureConsole: false,
+    emit: () => Effect.void,
+    verify: (output) => {
+      expect(output).toContain("Deployed");
+      expect(output.slice(output.lastIndexOf("Deployed"))).not.toContain(
+        "\u001B[2K",
+      );
+      expect(output).toContain("\u001B[?25h");
+    },
+  },
+  {
+    name: "keeps captured logs static and ordered before completed live views",
+    captureConsole: true,
+    emit: () => Effect.sync(() => console.log("runtime ready")),
+    verify: (output) => {
+      expect(output.match(/runtime ready/g)?.length).toBe(1);
+      expect(output.indexOf("runtime ready")).toBeLessThan(
+        output.lastIndexOf("Deployed"),
+      );
+    },
+  },
+  {
+    name: "orders semantic output through the active renderer",
+    captureConsole: false,
+    emit: (service) => service.output.info("runtime ready"),
+    verify: (output) => {
+      expect(output.indexOf("runtime ready")).toBeLessThan(
+        output.lastIndexOf("Deployed"),
+      );
+    },
+  },
+];
+
+it.effect.each(orderingCases)("$name", ({ captureConsole, emit, verify }) =>
+  Effect.gen(function* () {
+    const { service, stdout } = yield* makeLive({ captureConsole });
+
+    const store = new LiveStore("Deploying");
+    const live = yield* service.live.open(<LiveLabel store={store} />, {
+      persistOnClose: true,
+    });
+    yield* emit(service);
+    yield* Effect.sync(() => store.set("Deployed"));
+    yield* live.close;
+
+    verify(stdout.output);
+  }),
+);
+
+it.effect("commits stdio above active Sigil views", () =>
+  Effect.gen(function* () {
+    const { service, stdout, stderr } = yield* makeLive({
+      captureConsole: true,
+    });
+    const store = new LiveStore("Resolving credentials");
+    const live = yield* service.live.open(<LiveLabel store={store} />, {
+      persistOnClose: true,
+    });
+
+    yield* Effect.sync(() => {
+      stdout.write("floci stdout\n");
+      stderr.write("node warning\n");
+      store.set("Credentials resolved");
+    });
+    yield* live.close;
+
+    expect(stdout.output).toContain("floci stdout");
+    expect(stdout.output).toContain("node warning");
+    expect(stderr.output).not.toContain("node warning");
+    expect(stdout.output).toContain("Credentials resolved");
+    expect(stdout.output.lastIndexOf("node warning")).toBeLessThan(
+      stdout.output.lastIndexOf("Credentials resolved"),
+    );
+  }),
+);
+
+it.effect("progress settles into success and failure status output", () =>
+  Effect.gen(function* () {
+    const { service, stdout } = makeStatic();
+    yield* Effect.scoped(
+      Effect.gen(function* () {
+        const first = yield* service.live.progress({
+          label: "Resolve credentials",
+        });
+        yield* first.succeed();
+        const second = yield* service.live.progress({
+          label: "Apply resource",
+        });
+        yield* second.fail();
+      }),
+    );
+
+    expect(stdout.output).toContain("Resolve credentials");
+    expect(stdout.output).toContain("Apply resource");
+    expect(stdout.output).toContain("✓");
+    expect(stdout.output).toContain("×");
+  }),
+);
+
+it.effect("task collapses success and failure into status output", () =>
+  Effect.gen(function* () {
+    const { service, stdout } = makeStatic();
+    yield* service.task(
+      { label: "Resolve credentials" },
+      Effect.succeed("credentials"),
+    );
+    yield* service
+      .task({ label: "Apply resource" }, Effect.fail("nope"))
+      .pipe(Effect.ignore);
+
+    expect(stdout.output).toContain("Resolve credentials");
+    expect(stdout.output).toContain("Apply resource");
+    expect(stdout.output).toContain("✓");
+    expect(stdout.output).toContain("×");
+  }),
+);
+
+it.effect("status output composes as a normal view", () =>
+  Effect.gen(function* () {
+    const { service } = makeStatic();
+    const rendered = yield* service.output.render(
+      <Status variant="warning" detail="retrying">
+        API unavailable
+      </Status>,
+    );
+    expect(rendered).toContain("API unavailable");
+    expect(rendered).toContain("retrying");
+  }),
+);
+
+it.effect("uses ASCII fallbacks when Unicode is unavailable", () =>
+  Effect.gen(function* () {
+    const { service } = yield* makeLive({ input: false, unicode: false });
+    const rendered = yield* service.output.render(
+      <>
+        <Heading>Deploy</Heading>
+        <Status variant="success">Complete</Status>
+      </>,
+    );
+    expect(rendered).toContain("@ Deploy");
+    expect(rendered).toContain("+ Complete");
+    expect(rendered).not.toContain("✓");
+  }),
+);
+
+it("strips terminal colors and hyperlinks", () => {
+  expect(
+    stripAnsi(`\u001B[31mred\u001B[0m ${hyperlink("docs", "https://x")}`),
+  ).toBe("red docs");
+});
+
+it.effect("runs interactive components inside the owned session", () =>
+  Effect.gen(function* () {
+    const { service, stdout } = yield* makeLive();
+
+    const result = yield* service.prompt.custom(
+      Screen.make("test screen", ({ submit }) => {
+        queueMicrotask(() => submit("completed", <Status>Done</Status>));
+        return <Status>Working</Status>;
+      }),
+    );
+    expect(result).toBe("completed");
+    expect(stdout.output).toContain("Done");
+  }),
+);
+
+it.effect("restores the terminal after an alternate-screen interaction", () =>
+  Effect.gen(function* () {
+    const { service, stdout } = yield* makeLive();
+
+    yield* service
+      .application(
+        service.prompt.custom(
+          Screen.make("full screen", ({ submit }) => {
+            queueMicrotask(() => submit(undefined));
+            return <Status>Browsing</Status>;
+          }),
+        ),
+      )
+      .pipe(Application.alternate);
+
+    expect(stdout.output).toContain("\u001B[?1049h");
+    expect(stdout.output).toContain("\u001B[?1049l");
+    expect(stdout.output.indexOf("\u001B[?1049h")).toBeLessThan(
+      stdout.output.indexOf("\u001B[?1049l"),
+    );
+  }),
+);
+
+it.effect("treats the terminal DEL byte as text-field backspace", () =>
+  Effect.gen(function* () {
+    const stdin = new InputStream();
+    const { service } = yield* makeLive({ stdin });
+
+    const fiber = yield* service.prompt
+      .custom(
+        Screen.make("backspace", ({ submit }) => (
+          <TextField initialValue="abc" onChange={submit} onSubmit={submit} />
+        )),
+      )
+      .pipe(Effect.forkChild);
+    yield* Effect.promise(() => stdin.ready);
+    yield* Effect.sync(() => stdin.write("\x7f"));
+    const result = yield* Fiber.join(fiber);
+
+    expect(result).toBe("ab");
+  }),
+);
+
+/** Let a written stdin chunk flow through Sigil's input pipeline. */
+const settleInput = Effect.yieldNow.pipe(Effect.repeat({ times: 2 }));
+
+it.effect("strips control characters from pasted text-field input", () =>
+  Effect.gen(function* () {
+    const stdin = new InputStream();
+    const { service } = yield* makeLive({ stdin });
+
+    const fiber = yield* service.prompt
+      .custom(
+        Screen.make("paste", ({ submit }) => <TextField onSubmit={submit} />),
+      )
+      .pipe(Effect.forkChild);
+    yield* Effect.promise(() => stdin.ready);
+    // A paste arrives as one chunk; embedded newlines/tabs must not survive.
+    yield* Effect.sync(() => stdin.write("to\tken\r\n123"));
+    yield* settleInput;
+    yield* Effect.sync(() => stdin.write("\r"));
+    const result = yield* Fiber.join(fiber);
+
+    expect(result).toBe("token123");
+  }),
+);
+
+it.effect("shows the whole typed value while width remains available", () =>
+  Effect.gen(function* () {
+    const stdin = new InputStream();
+    const { service, stdout } = yield* makeLive({ stdin });
+
+    const fiber = yield* service.prompt
+      .text({ message: "New profile name" })
+      .pipe(Effect.forkChild);
+    yield* Effect.promise(() => stdin.ready);
+    // Regression: the field's box used to shrink to its content, so the
+    // measured "available" width collapsed to the minimum and the value
+    // scrolled after ~4 characters despite a mostly-empty row.
+    yield* Effect.sync(() => stdin.write("my-longer-profile-name"));
+    yield* Effect.promise(() => stdout.waitFor("my-longer-profile-name"));
+    expect(stdout.output).toContain("my-longer-profile-name");
+    yield* Effect.sync(() => stdin.write("\r"));
+    const result = yield* Fiber.join(fiber);
+
+    expect(result).toBe("my-longer-profile-name");
+  }),
+);
+
+it.effect("shows a text prompt default before it is accepted", () =>
+  Effect.gen(function* () {
+    const stdin = new InputStream();
+    const { service, stdout } = yield* makeLive({ stdin });
+
+    const fiber = yield* service.prompt
+      .text({
+        message: "Emulator endpoint",
+        defaultValue: "http://localhost:4566",
+      })
+      .pipe(Effect.forkChild);
+    yield* Effect.promise(() => stdin.ready);
+    yield* Effect.promise(() => stdout.waitFor("http://localhost:4566"));
+    yield* Effect.sync(() => stdin.write("\r"));
+
+    expect(yield* Fiber.join(fiber)).toBe("http://localhost:4566");
+  }),
+);
+
+it.effect("deletes a whole emoji grapheme on backspace", () =>
+  Effect.gen(function* () {
+    const stdin = new InputStream();
+    const { service } = yield* makeLive({ stdin });
+
+    const fiber = yield* service.prompt
+      .custom(
+        Screen.make("grapheme", ({ submit }) => (
+          <TextField initialValue="a👍" onChange={submit} onSubmit={submit} />
+        )),
+      )
+      .pipe(Effect.forkChild);
+    yield* Effect.promise(() => stdin.ready);
+    yield* Effect.sync(() => stdin.write("\x7f"));
+    const result = yield* Fiber.join(fiber);
+
+    expect(result).toBe("a");
+  }),
+);
+
+it.effect("erases the multi-select filter with the terminal DEL byte", () =>
+  Effect.gen(function* () {
+    const stdin = new InputStream();
+    const { service } = yield* makeLive({ stdin });
+
+    const fiber = yield* service.prompt
+      .multiSelect({
+        message: "pick",
+        options: [
+          { value: "alpha", label: "alpha" },
+          { value: "beta", label: "beta" },
+        ],
+      })
+      .pipe(Effect.forkChild);
+    yield* Effect.promise(() => stdin.ready);
+    // Filter to nothing, erase the filter with DEL, then toggle + confirm.
+    yield* Effect.sync(() => stdin.write("z"));
+    yield* settleInput;
+    yield* Effect.sync(() => stdin.write("\x7f"));
+    yield* settleInput;
+    yield* Effect.sync(() => stdin.write(" "));
+    yield* settleInput;
+    yield* Effect.sync(() => stdin.write("\r"));
+    const result = yield* Fiber.join(fiber);
+
+    expect(result).toEqual(["alpha"]);
+  }),
+);
+
+it.effect("filters searchable selects without stealing Enter", () =>
+  Effect.gen(function* () {
+    const stdin = new InputStream();
+    const { service } = yield* makeLive({ stdin });
+
+    const fiber = yield* service.prompt
+      .select({
+        message: "pick",
+        searchable: true,
+        options: [
+          { value: "alpha", label: "alpha" },
+          { value: "beta", label: "beta" },
+        ],
+      })
+      .pipe(Effect.forkChild);
+    yield* Effect.promise(() => stdin.ready);
+    yield* Effect.sync(() => stdin.write("bet"));
+    yield* settleInput;
+    yield* Effect.sync(() => stdin.write("\r"));
+    const result = yield* Fiber.join(fiber);
+
+    expect(result).toBe("beta");
+  }),
+);
+
+it.effect("keeps required cycle edits open until something changes", () =>
+  Effect.gen(function* () {
+    const stdin = new InputStream();
+    const { service } = yield* makeLive({ stdin });
+
+    const fiber = yield* service.prompt
+      .cycle({
+        message: "Manage accounts",
+        requireChange: true,
+        options: [
+          {
+            label: "Cloudflare",
+            states: [
+              { value: "keep", label: "keep" },
+              { value: "remove", label: "remove" },
+            ],
+          },
+        ],
+      })
+      .pipe(Effect.forkChild);
+    yield* Effect.promise(() => stdin.ready);
+    yield* Effect.sync(() => stdin.write("\r"));
+    yield* settleInput;
+    expect(fiber.pollUnsafe()).toBe(undefined);
+
+    yield* Effect.sync(() => stdin.write(" "));
+    yield* settleInput;
+    yield* Effect.sync(() => stdin.write("\r"));
+    const result = yield* Fiber.join(fiber);
+    expect(result).toEqual(["remove"]);
+  }),
+);
+
+it.effect("reopens browser authorization from the waiting screen", () =>
+  Effect.gen(function* () {
+    const stdin = new InputStream();
+    const { service } = yield* makeLive({ stdin });
+    let opened = 0;
+
+    const fiber = yield* service.prompt
+      .awaitExternal({
+        message: "Authorize",
+        waitingLabel: "Waiting",
+        url: "https://example.com/authorize",
+        inputLabel: "Enter code",
+        onOpen: async () => {
+          opened += 1;
+        },
+      })
+      .pipe(Effect.forkChild);
+    yield* Effect.promise(() => stdin.ready);
+    yield* Effect.sync(() => stdin.write("o"));
+    yield* settleInput;
+    expect(opened).toBe(1);
+
+    yield* Effect.sync(() => stdin.write("\r"));
+    yield* settleInput;
+    yield* Effect.sync(() => stdin.write("code"));
+    yield* settleInput;
+    yield* Effect.sync(() => stdin.write("\r"));
+    const result = yield* Fiber.join(fiber);
+    expect(result).toBe("code");
+  }),
+);
+
+it.effect("toggles every visible multi-select choice on ctrl+a", () =>
+  Effect.gen(function* () {
+    const stdin = new InputStream();
+    const { service } = yield* makeLive({ stdin });
+
+    const fiber = yield* service.prompt
+      .multiSelect({
+        message: "pick",
+        options: [
+          { value: "alpha", label: "alpha" },
+          { value: "beta", label: "beta" },
+          { value: "gamma", label: "gamma", disabled: true },
+        ],
+      })
+      .pipe(Effect.forkChild);
+    yield* Effect.promise(() => stdin.ready);
+    yield* Effect.sync(() => stdin.write("\x01"));
+    yield* settleInput;
+    yield* Effect.sync(() => stdin.write("\r"));
+    const result = yield* Fiber.join(fiber);
+
+    expect(result).toEqual(["alpha", "beta"]);
+  }),
+);
+
+it.effect("returns an explicit undefined menu back target on Escape", () =>
+  Effect.gen(function* () {
+    const stdin = new InputStream();
+    const { service } = yield* makeLive({ stdin });
+
+    const fiber = yield* service.prompt
+      .menu<string | undefined>({
+        message: "pick",
+        back: undefined,
+        options: [{ value: "alpha", label: "alpha" }],
+      })
+      .pipe(Effect.forkChild);
+    yield* Effect.promise(() => stdin.ready);
+    yield* Effect.sync(() => stdin.write("\x1b"));
+    const result = yield* Fiber.join(fiber);
+
+    expect(result).toBe(undefined);
+  }),
+);
+
+it.effect("cleans up a cancelled standalone prompt", () =>
+  Effect.gen(function* () {
+    const { service, stdout } = yield* makeLive();
+
+    const failure = yield* service.prompt
+      .custom(
+        Screen.make("cancel test", ({ cancel }) => {
+          queueMicrotask(cancel);
+          return <Status>Waiting</Status>;
+        }),
+      )
+      .pipe(Effect.flip);
+
+    expect(failure).toBeInstanceOf(TerminalCancelled);
+    expect(stdout.output).toContain("cancel test cancelled");
+  }),
+);
+
+it.effect("releases the renderer when a running prompt is interrupted", () =>
+  Effect.gen(function* () {
+    const stdin = new InputStream();
+    const { service } = yield* makeLive({ stdin });
+
+    const fiber = yield* service.prompt
+      .custom(Screen.make("interrupted", () => <Status>Waiting</Status>))
+      .pipe(Effect.forkChild);
+    yield* Effect.promise(() => stdin.ready);
+    yield* Fiber.interrupt(fiber);
+
+    // The interrupted prompt must have released the renderer and the prompt
+    // gate for the next interaction.
+    const result = yield* service.prompt.custom(
+      Screen.make("after interruption", ({ submit }) => {
+        queueMicrotask(() => submit("ok"));
+        return <Status>After</Status>;
+      }),
+    );
+    expect(result).toBe("ok");
+  }),
+);
+
+it.effect("closes leaked live handles when their scope closes", () =>
+  Effect.gen(function* () {
+    const { service, stdout } = yield* makeLive();
+
+    yield* Effect.scoped(
+      Effect.gen(function* () {
+        yield* service.live.open(<Text>Leaky</Text>);
+        // Deliberately no close — the enclosing scope must release the row
+        // and unmount the renderer.
+      }),
+    );
+
+    expect(stdout.output).toContain("[?25h");
+  }),
+);
+
+it.effect("fails the active prompt when a screen throws during render", () =>
+  Effect.gen(function* () {
+    const { service } = yield* makeLive();
+    const Broken = (): never => {
+      throw new Error("screen render boom");
+    };
+
+    // Without exit observation this would hang forever: the screen's
+    // submit/cancel can never run once the renderer has crashed.
+    const exit = yield* service.prompt
+      .custom(Screen.make("broken screen", () => <Broken />))
+      .pipe(Effect.exit);
+
+    expect(Exit.isFailure(exit)).toBe(true);
+  }),
+);
+
+it.effect("cancels a screen with no cancel wiring on ctrl+c", () =>
+  Effect.gen(function* () {
+    const stdin = new InputStream();
+    const { service, stdout } = yield* makeLive({ stdin });
+
+    // The screen never touches the controller — the centralized handler in
+    // the runtime must still turn Ctrl+C into a cancellation.
+    const fiber = yield* service.prompt
+      .custom(Screen.make("no cancel wiring", () => <Status>Waiting</Status>))
+      .pipe(Effect.flip, Effect.forkChild);
+    yield* Effect.promise(() => stdin.ready);
+    yield* Effect.sync(() => stdin.write("\x03"));
+    const failure = yield* Fiber.join(fiber);
+
+    expect(failure).toBeInstanceOf(TerminalCancelled);
+    expect(stdout.output).toContain("no cancel wiring cancelled");
+  }),
+);
+
+it.effect("keeps one renderer alive for an Effect-driven application", () =>
+  Effect.gen(function* () {
+    const { service } = yield* makeLive();
+
+    const result = yield* service.application(
+      Effect.gen(function* () {
+        const action = yield* service.prompt.custom(
+          Screen.make("main menu", ({ submit }) => {
+            queueMicrotask(() => submit("add"));
+            return <Status>Main menu</Status>;
+          }),
+        );
+        const name = yield* service.wizard(
+          service.prompt.custom(
+            Screen.make("auth flow", ({ submit }) => {
+              queueMicrotask(() =>
+                submit("cloudflare", <Status>Profile name</Status>),
+              );
+              return <Status>Cloudflare auth</Status>;
+            }),
+          ),
+        );
+        const done = yield* service.prompt.custom(
+          Screen.make("returned menu", ({ submit }) => {
+            queueMicrotask(() => submit(true));
+            return <Status>Returned menu</Status>;
+          }),
+        );
+        return { action, name, done };
+      }),
+    );
+
+    expect(result).toEqual({
+      action: "add",
+      name: "cloudflare",
+      done: true,
+    });
+  }),
+);
+
+it.effect("provides CliKit once as a scoped injectable service", () => {
+  const stdout = new CaptureStream();
+  return Effect.gen(function* () {
+    const capabilities = yield* CliKit.useSync((cli) => cli.terminal);
+    const cli = yield* CliKit;
+    yield* cli.output.print("Injected");
+
+    expect(capabilities.input).toBe(false);
+    expect(capabilities.colors).toBe(false);
+    expect(stdout.output).toContain("Injected");
+  }).pipe(
+    Effect.provide(
+      cliKitLayer({
+        input: false,
+        stdout: stdout as unknown as NodeJS.WriteStream,
+        captureConsole: false,
+      }),
+    ),
+  );
+});
+
+it.effect("uses append-only progress when input is disabled on a TTY", () => {
+  const stdout = new CaptureStream(true);
+  return Effect.gen(function* () {
+    const cli = yield* CliKit;
+    const progress = yield* cli.live.progress({ label: "Deploying" });
+    yield* progress.update({ label: "Uploading" });
+    yield* progress.succeed("Deployed");
+
+    expect(cli.terminal.input).toBe(false);
+    expect(stdout.output).toContain("Deploying\n");
+    expect(stdout.output).toContain("Deployed\n");
+    expect(stdout.output).not.toContain("\u001B[");
+  }).pipe(
+    Effect.provide(
+      cliKitLayer({
+        input: false,
+        stdout: stdout as unknown as NodeJS.WriteStream,
+        captureConsole: false,
+      }),
+    ),
+  );
+});
+
+it.effect(
+  "renders the same semantic and component output without terminal input",
+  () =>
+    Effect.gen(function* () {
+      const { service, stdout } = yield* makeLive({
+        input: false,
+        unicode: false,
+      });
+
+      yield* service.output.info("Resolving credentials");
+      yield* service.output.success({
+        message: "Authenticated",
+        detail: "cloudflare",
+      });
+      yield* service.output.warning("Token expires soon");
+      yield* service.output.error("Authentication failed");
+      yield* service.output.print(
+        <Alert variant="warning" title="Attention">
+          Manual action required
+        </Alert>,
+      );
+      yield* service.output.print(<Status>React output</Status>);
+
+      expect(stdout.output).toContain("Resolving credentials\n");
+      expect(stdout.output).toContain("Authenticated");
+      expect(stdout.output).toContain("cloudflare");
+      expect(stdout.output).toContain("Token expires soon");
+      expect(stdout.output).toContain("Authentication failed");
+      expect(stdout.output).toContain("Attention");
+      expect(stdout.output).toContain("Manual action required");
+      expect(stdout.output).toContain("React output");
+    }),
+);
+
+it.effect(
+  "renders application, transcript, live-work, and data primitives together",
+  () =>
+    Effect.gen(function* () {
+      const { service } = makeStatic();
+      const rendered = yield* service.output.render(
+        <>
+          <Tabs
+            tabs={[
+              { id: "dev", label: "dev" },
+              { id: "prod", label: "prod", marked: true },
+            ]}
+            active="prod"
+          />
+          <AnsweredPrompt message="Account" answer="production" />
+          <TaskRow spinning label="stack" />
+          <TaskRow icon="+" label="worker" depth={1} />
+          <ProgressGroup
+            rows={[
+              {
+                id: "providers",
+                label: "providers",
+                completed: 2,
+                total: 4,
+              },
+            ]}
+          />
+          <Status>q quit</Status>
+        </>,
+      );
+
+      expect(rendered).toContain("prod");
+      expect(rendered).toContain("production");
+      expect(rendered).toContain("worker");
+      expect(rendered).toContain("2/4");
+    }),
+);

--- a/packages/alchemy/tsconfig.json
+++ b/packages/alchemy/tsconfig.json
@@ -12,9 +12,7 @@
     "paths": {
       "@/*": ["./src/*"]
     },
-    // Solid is the default JSX runtime in this package; React files opt in per-file.
     "jsx": "react-jsx",
-    "jsxImportSource": "@opentui/solid",
     "lib": ["DOM", "DOM.Iterable", "ES2023"],
     "plugins": [
       {

--- a/packages/alchemy/tsconfig.test.json
+++ b/packages/alchemy/tsconfig.test.json
@@ -12,8 +12,8 @@
     "test/Cloudflare/Website/fixtures/nuxt-app",
     "test/AWS/Website/fixtures/nuxt-app",
     "test/Cloudflare/Website/fixtures/nuxt-spa-app",
-    // Octane fixture: `.tsx` components use octane's JSX runtime, which
-    // conflicts with this package's default `@opentui/solid` jsxImportSource.
+    // Octane fixture: `.tsx` components use octane's JSX runtime, not
+    // the react-jsx runtime this package compiles with.
     "test/Cloudflare/Website/fixtures/octane-app",
     "test/Cloudflare/Website/fixtures/octane-spa-app",
     "test/AWS/Website/fixtures/octane-app",
@@ -42,9 +42,7 @@
     "paths": {
       "@/*": ["./src/*"]
     },
-    // Solid is the default JSX runtime in this package; React files opt in per-file.
     "jsx": "react-jsx",
-    "jsxImportSource": "@opentui/solid",
     "lib": ["DOM", "DOM.Iterable", "ES2023"]
   },
   "references": [

--- a/patches/ink@7.1.1.patch
+++ b/patches/ink@7.1.1.patch
@@ -1,0 +1,118 @@
+diff --git a/build/ink.js b/build/ink.js
+index 0082666b281ec2db77b875d6b8460bcc19a59ce7..966c9f5ca908974643a87b2f13b2d1f90017cd52 100644
+--- a/build/ink.js
++++ b/build/ink.js
+@@ -95,7 +95,13 @@ const shouldClearTerminalForFrame = ({ isTty, viewportRows, previousOutputHeight
+     const wasOverflowing = previousOutputHeight > viewportRows;
+     const isOverflowing = nextOutputHeight > viewportRows;
+     const isFullscreen = nextOutputHeight >= viewportRows;
+-    const isLeavingFullscreen = wasFullscreen && nextOutputHeight < viewportRows;
++    // Only a frame that actually OVERFLOWED the viewport needs the full
++    // clear when shrinking back to inline — its top rows live above the top
++    // margin where incremental erase cannot reach. A frame that exactly
++    // filled the viewport is erasable in place; clearing the terminal for it
++    // destroys the user's scrollback for no benefit (and rapid height
++    // resizes routinely produce transient exactly-fullscreen frames).
++    const isLeavingFullscreen = wasOverflowing && nextOutputHeight < viewportRows;
+     const shouldClearOnUnmount = isUnmounting && wasFullscreen;
+     if (isWindowsConsole && (wasFullscreen || isFullscreen)) {
+         return true;
+@@ -155,6 +161,7 @@ export default class Ink {
+     lastOutputToRender;
+     lastOutputHeight;
+     lastTerminalWidth;
++    lastTerminalHeight;
+     container;
+     rootNode;
+     // This variable is used only in debug mode to store full static output
+@@ -244,6 +251,7 @@ export default class Ink {
+         this.lastOutputToRender = '';
+         this.lastOutputHeight = 0;
+         this.lastTerminalWidth = getWindowSize(this.options.stdout).columns;
++        this.lastTerminalHeight = getWindowSize(this.options.stdout).rows;
+         // This variable is used only in debug mode to store full static output
+         // so that it's rerendered every time, not just new static parts, like in non-debug mode
+         this.fullStaticOutput = '';
+@@ -278,16 +286,32 @@ export default class Ink {
+     }
+     resized = () => {
+         const currentWidth = getWindowSize(this.options.stdout).columns;
+-        if (currentWidth < this.lastTerminalWidth) {
+-            // We clear the screen when decreasing terminal width to prevent duplicate overlapping re-renders.
++        const currentHeight = getWindowSize(this.options.stdout).rows;
++        // A width decrease rewraps lines and any height change moves content
++        // through scrollback, so the incremental render state no longer
++        // matches the screen. Erase what is still visible and force the next
++        // render to be a full rewrite instead of an incremental diff that
++        // would skip "unchanged" lines over stale screen content.
++        if (currentWidth < this.lastTerminalWidth ||
++            currentHeight !== this.lastTerminalHeight) {
++            // `log.clear()` erases the full previous frame line count from
++            // the cursor upward — after a height grow that also covers frame
++            // lines the emulator pulled back from scrollback, so no extra
++            // erase is needed for them.
+             this.log.clear();
+             this.lastOutput = '';
+             this.lastOutputToRender = '';
++            // Also forget the previous frame height: it described a frame
++            // that no longer exists on screen, and letting it flow into
++            // shouldClearTerminalForFrame would trigger a scrollback-erasing
++            // clearTerminal on a height shrink.
++            this.lastOutputHeight = 0;
+         }
+         this.calculateLayout();
+         dom.emitLayoutListeners(this.rootNode);
+         this.onRender();
+         this.lastTerminalWidth = currentWidth;
++        this.lastTerminalHeight = currentHeight;
+     };
+     resolveExitPromise = () => { };
+     rejectExitPromise = () => { };
+@@ -751,6 +775,17 @@ export default class Ink {
+         // Detect fullscreen: output fills or exceeds terminal height.
+         // Only apply when writing to a real TTY — piped output always gets trailing newlines.
+         const viewportRows = isTty ? getWindowSize(this.options.stdout).rows : 24;
++        // Clamp the frame to the viewport, keeping its bottom rows. Rows above
++        // the top margin cannot be updated or erased in place, and the
++        // historical fallback for such frames — a full clearTerminal including
++        // an ESC[3J scrollback erase — destroys the user's scrollback on every
++        // overflowing update. A frame taller than the terminal is unreadable
++        // anyway; components size themselves from useWindowSize to avoid it.
++        if (isTty && outputHeight > viewportRows) {
++            const lines = output.split('\n');
++            output = lines.slice(lines.length - viewportRows).join('\n');
++            outputHeight = viewportRows;
++        }
+         const isFullscreen = isTty && outputHeight >= viewportRows;
+         const outputToRender = isFullscreen ? output : output + '\n';
+         const shouldClearTerminal = shouldClearTerminalForFrame({
+diff --git a/build/log-update.js b/build/log-update.js
+index cdb5fc41f158304c4c4f230a765065ab1fe0a2f7..3487abac2c855c4439ff9ddd378ee5ed944c6773 100644
+--- a/build/log-update.js
++++ b/build/log-update.js
+@@ -156,6 +156,25 @@ const createIncremental = (stream, { showCursor = false } = {}) => {
+             previousLines = nextLines;
+             return true;
+         }
++        // A frame that grew may need rows past the bottom margin. The
++        // incremental walk moves over unchanged lines with cursorNextLine,
++        // which clamps at the bottom margin instead of scrolling (only a
++        // line feed scrolls), so a grown frame that reaches the bottom
++        // desynchronizes the tracked cursor position from the terminal.
++        // Rewrite the whole frame instead — every line is emitted with a
++        // newline, which scrolls correctly at the bottom.
++        if (visibleCount > previousVisible) {
++            const cursorSuffix = buildCursorSuffix(visibleCount, activeCursor);
++            stream.write(returnPrefix +
++                ansiEscapes.eraseLines(previousLines.length) +
++                str +
++                cursorSuffix);
++            cursorWasShown = activeCursor !== undefined;
++            previousCursorPosition = activeCursor ? { ...activeCursor } : undefined;
++            previousOutput = str;
++            previousLines = nextLines;
++            return true;
++        }
+         const hasTrailingNewline = str.endsWith('\n');
+         // We aggregate all chunks for incremental rendering into a buffer, and then write them to stdout at the end.
+         const buffer = [];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -378,6 +378,7 @@ overrides:
 
 patchedDependencies:
   '@astrojs/starlight@0.41.7': 7ab76e506900e9b0f934039b4b3f797fdf6ea76e9668891402a75ef46dd79b8c
+  ink@7.1.1: 9e22acbdbb668fee48e5ce9ed62a37a2f7360ce014575016f60c914421bd0810
   starlight-blog@0.28.0: 7b6e57367fab3517e0cfd5e4d0da3459ac1430bf4b6036cf03002c978602c23b
 
 importers:
@@ -5312,6 +5313,9 @@ importers:
       '@alchemy.run/node-utils':
         specifier: workspace:*
         version: link:../node-utils
+      '@alchemy.run/sigil':
+        specifier: 0.0.0-alpha.5
+        version: 0.0.0-alpha.5(@types/react@19.2.18)(react-devtools-core@7.0.1)(react@19.2.8)
       '@aws-sdk/credential-providers':
         specifier: catalog:aws
         version: 3.1095.0
@@ -5403,8 +5407,8 @@ importers:
         specifier: catalog:shared
         version: 5.10.1
       ink:
-        specifier: ^6.3.1
-        version: 6.8.0(@types/react@19.2.18)(react-devtools-core@7.0.1)(react@19.2.8)
+        specifier: ^7.0.2
+        version: 7.1.1(patch_hash=9e22acbdbb668fee48e5ce9ed62a37a2f7360ce014575016f60c914421bd0810)(@types/react@19.2.18)(react-devtools-core@7.0.1)(react@19.2.8)
       jszip:
         specifier: ^3.10.1
         version: 3.10.1
@@ -5423,6 +5427,9 @@ importers:
       rolldown:
         specifier: 1.2.5
         version: 1.2.5
+      string-width:
+        specifier: ^8.2.2
+        version: 8.2.2
       undici:
         specifier: ^7.16.0
         version: 7.29.0
@@ -6029,9 +6036,22 @@ packages:
   '@actions/io@1.1.3':
     resolution: {integrity: sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==}
 
-  '@alcalzone/ansi-tokenize@0.2.5':
-    resolution: {integrity: sha512-3NX/MpTdroi0aKz134A6RC2Gb2iXVECN4QaAXnvCIxxIm3C3AVB1mkUe8NaaiyvOpDfsrqWhYtj+Q6a62RrTsw==}
+  '@alcalzone/ansi-tokenize@0.3.0':
+    resolution: {integrity: sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA==}
     engines: {node: '>=18'}
+
+  '@alchemy.run/sigil@0.0.0-alpha.5':
+    resolution: {integrity: sha512-meY3ccl6PO2Hw4bbhTwmdQHTJJ22b2KXey+U6HDotHGNMeyDi5Vu5d4O44vbqOONNRzpTg8AQCaqXgA5RcuAgw==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      '@types/react': '>=19.2.0'
+      react: '>=19.2.0'
+      react-devtools-core: '>=6.1.2'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react-devtools-core:
+        optional: true
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -13265,17 +13285,17 @@ packages:
   clean-set@1.1.2:
     resolution: {integrity: sha512-cA8uCj0qSoG9e0kevyOWXwPaELRPVg5Pxp6WskLMwerx257Zfnh8Nl0JBH59d7wQzij2CK7qEfJQK3RjuKKIug==}
 
-  cli-boxes@3.0.0:
-    resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
-    engines: {node: '>=10'}
+  cli-boxes@4.0.1:
+    resolution: {integrity: sha512-5IOn+jcCEHEraYolBPs/sT4BxYCe2nHg374OPiItB1O96KZFseS2gthU4twyYzeDcFew4DaUM/xwc5BQf08JJw==}
+    engines: {node: '>=18.20 <19 || >=20.10'}
 
   cli-cursor@4.0.0:
     resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  cli-truncate@5.2.0:
-    resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
-    engines: {node: '>=20'}
+  cli-truncate@6.1.1:
+    resolution: {integrity: sha512-06p9vyLahLa4zkGcgsGxU6iEkSOiuI4fhCH6Emhe2lPAcoUv73n72DnODsnHA+5wwXGnV0n9M9/qOQJSjYhFhw==}
+    engines: {node: '>=22'}
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
@@ -14810,12 +14830,12 @@ packages:
     resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
-  ink@6.8.0:
-    resolution: {integrity: sha512-sbl1RdLOgkO9isK42WCZlJCFN9hb++sX9dsklOvfd1YQ3bQ2AiFu12Q6tFlr0HvEUvzraJntQCCpfEoUe9DSzA==}
-    engines: {node: '>=20'}
+  ink@7.1.1:
+    resolution: {integrity: sha512-Y43xxa1ZSPvpmfLHcN5o+OdP8Rf8ykkNJEuKYOUNZKT8wXVNLFTtEm1nSDMQkfBH+YANF4Xuu0hhZ4ejqAtN2w==}
+    engines: {node: '>=22'}
     peerDependencies:
-      '@types/react': '>=19.0.0'
-      react: '>=19.0.0'
+      '@types/react': '>=19.2.0'
+      react: '>=19.2.0'
       react-devtools-core: '>=6.1.2'
     peerDependenciesMeta:
       '@types/react':
@@ -17322,9 +17342,9 @@ packages:
     resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
     engines: {node: '>=14.16'}
 
-  slice-ansi@8.0.0:
-    resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
-    engines: {node: '>=20'}
+  slice-ansi@9.0.0:
+    resolution: {integrity: sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA==}
+    engines: {node: '>=22'}
 
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
@@ -19119,10 +19139,19 @@ snapshots:
 
   '@actions/io@1.1.3': {}
 
-  '@alcalzone/ansi-tokenize@0.2.5':
+  '@alcalzone/ansi-tokenize@0.3.0':
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
+
+  '@alchemy.run/sigil@0.0.0-alpha.5(@types/react@19.2.18)(react-devtools-core@7.0.1)(react@19.2.8)':
+    dependencies:
+      react: 19.2.8
+      react-reconciler: 0.33.0(react@19.2.8)
+      scheduler: 0.27.0
+    optionalDependencies:
+      '@types/react': 19.2.18
+      react-devtools-core: 7.0.1
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -28319,15 +28348,15 @@ snapshots:
 
   clean-set@1.1.2: {}
 
-  cli-boxes@3.0.0: {}
+  cli-boxes@4.0.1: {}
 
   cli-cursor@4.0.0:
     dependencies:
       restore-cursor: 4.0.0
 
-  cli-truncate@5.2.0:
+  cli-truncate@6.1.1:
     dependencies:
-      slice-ansi: 8.0.0
+      slice-ansi: 9.0.0
       string-width: 8.2.2
 
   client-only@0.0.1: {}
@@ -30020,16 +30049,16 @@ snapshots:
 
   ini@4.1.1: {}
 
-  ink@6.8.0(@types/react@19.2.18)(react-devtools-core@7.0.1)(react@19.2.8):
+  ink@7.1.1(patch_hash=9e22acbdbb668fee48e5ce9ed62a37a2f7360ce014575016f60c914421bd0810)(@types/react@19.2.18)(react-devtools-core@7.0.1)(react@19.2.8):
     dependencies:
-      '@alcalzone/ansi-tokenize': 0.2.5
+      '@alcalzone/ansi-tokenize': 0.3.0
       ansi-escapes: 7.3.0
       ansi-styles: 6.2.3
       auto-bind: 5.0.1
       chalk: 5.6.2
-      cli-boxes: 3.0.0
+      cli-boxes: 4.0.1
       cli-cursor: 4.0.0
-      cli-truncate: 5.2.0
+      cli-truncate: 6.1.1
       code-excerpt: 4.0.0
       es-toolkit: 1.50.0
       indent-string: 5.0.0
@@ -30039,13 +30068,13 @@ snapshots:
       react-reconciler: 0.33.0(react@19.2.8)
       scheduler: 0.27.0
       signal-exit: 3.0.7
-      slice-ansi: 8.0.0
+      slice-ansi: 9.0.0
       stack-utils: 2.0.6
       string-width: 8.2.2
       terminal-size: 4.0.1
       type-fest: 5.8.0
       widest-line: 6.0.0
-      wrap-ansi: 9.0.2
+      wrap-ansi: 10.0.0
       ws: 8.21.3
       yoga-layout: 3.2.1
     optionalDependencies:
@@ -33949,7 +33978,7 @@ snapshots:
 
   slash@5.1.0: {}
 
-  slice-ansi@8.0.0:
+  slice-ansi@9.0.0:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -171,9 +171,11 @@ overrides:
   drizzle-orm: 1.0.0-rc.5-ab785fc
   rolldown: 1.2.5
 patchedDependencies:
+  ink@7.1.1: patches/ink@7.1.1.patch
   "@astrojs/starlight@0.41.7": patches/@astrojs%2Fstarlight@0.41.7.patch
   starlight-blog@0.28.0: patches/starlight-blog@0.28.0.patch
 minimumReleaseAgeExclude:
+  - '@alchemy.run/sigil@0.0.0-alpha.5'
   - '@effect/atom-react@4.0.0-rc.112'
   - '@effect/platform-bun@4.0.0-rc.112'
   - '@effect/platform-node-shared@4.0.0-rc.112'


### PR DESCRIPTION
Bottom of stack #1236: `feat/clikit` → `feat/profile` → `feat/cli-overhaul`.

This PR introduces **CliKit**, the shared terminal UI service used by the two PRs above for prompts, progress, semantic output, and full-screen applications. It is built on [`@alchemy.run/sigil`](https://npmx.dev/package/@alchemy.run/sigil), our renderer fork.

### What lands here

- One scoped `CliKit` service, provided once at the CLI root.
- A lazily imported `SigilRuntime`, so non-interactive commands do not eagerly load React or the renderer.
- Typed non-interactive and cancellation failures instead of hanging on unavailable input.
- Serialized prompt sessions, interruption-safe live views, and one renderer root per output stream.
- Prompt primitives for text, secrets, confirmation, selection, menus, browser authorization, and custom screens.
- Scope-owned progress, task, transcript, application, and alternate-screen lifecycles.
- Theme-aware layout, typography, feedback, data, and interactive components with Unicode/ASCII fallbacks.
- Sigil-owned stdio capture so logs and direct output remain ordered around active live regions.
- Capability detection for TTY input, color, Unicode, size, alternate screen, and `--no-input`.

The implementation and public terminology consistently use **Sigil**: `SigilRuntime`, Sigil component aliases, loader names, comments, and tests. The obsolete Ink patch is removed later in the stack when the legacy renderer is deleted.

### Stack boundary

- #1234 consumes CliKit for profiles and authentication.
- #1235 moves every remaining CLI surface onto CliKit, deletes the legacy renderer and Clack, and introduces the final `SigilCli` root view.

The focused CliKit suite exercises real rendering through fake streams, including ordering, resize behavior, prompts, cancellation, interruption, renderer failures, full-screen sessions, and teardown.
