### PR TITLE
fix(cloudflare): pin Worker.domain zoneId and paginate listZones

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -338,7 +338,8 @@ export interface WorkerDomainConfig {
    * The canonical hostname (e.g. `"example.com"`). Attached to the Worker
    * as a Cloudflare custom domain — DNS record and edge certificate are
    * managed automatically. The Cloudflare zone is inferred from the
-   * hostname and must already exist in the account.
+   * hostname unless {@link zoneId}, {@link zone}, or {@link zoneName} is
+   * set. The zone must already exist in the account.
    *
    * When set, `https://<name>` is the Worker's primary `url` output.
    */
@@ -359,6 +360,23 @@ export interface WorkerDomainConfig {
    * `urls`.
    */
   redirects?: string[];
+  /**
+   * Cloudflare zone ID for every hostname in this config. Equivalent to
+   * Wrangler's `zone_id`. Wins over {@link zone} / {@link zoneName}.
+   * When omitted, each hostname's zone is looked up by name
+   * (`GET /zones?name=`), not by listing the account's first page of zones.
+   */
+  zoneId?: string;
+  /**
+   * Cloudflare zone name, e.g. `"example.com"`. Equivalent to Wrangler's
+   * `zone_name`.
+   */
+  zoneName?: string;
+  /**
+   * Zone reference — a zone ID, zone name, or `{ zoneId, name? }` object.
+   * Alternative to {@link zoneId} / {@link zoneName}.
+   */
+  zone?: ZoneReference;
 }
 
 export interface WorkerRouteConfig {
@@ -815,8 +833,9 @@ export interface WorkerProps<
   /**
    * The Worker's custom domain: one canonical hostname, plus optional
    * `aliases` that also serve the Worker and `redirects` that 301 to the
-   * canonical name. A bare string is shorthand for `{ name }`. The
-   * Cloudflare zone is inferred from each hostname — the zone must already
+   * canonical name. A bare string is shorthand for `{ name }`. Pin the
+   * zone with `zoneId` / `zone` / `zoneName` (same as {@link routes});
+   * otherwise each hostname is looked up by name. The zone must already
    * exist in the account.
    *
    * When set, `https://<name>` becomes the Worker's primary `url` output,
@@ -1079,7 +1098,12 @@ export type Worker<Bindings = any> = Resource<
      * when no custom domain is configured.
      */
     domain:
-      | { name: string; aliases: string[]; redirects: string[] }
+      | {
+          name: string;
+          aliases: string[];
+          redirects: string[];
+          zone?: ZoneReference;
+        }
       | undefined;
     tags: string[] | undefined;
     durableObjectNamespaces: Record<string, string>;
@@ -1632,6 +1656,7 @@ export const isSelf = (value: unknown): value is Self =>
  *   main: "./src/api.ts",
  *   domain: {
  *     name: "example.com",
+ *     zoneId: "<YOUR_ZONE_ID>",
  *     aliases: ["www.example.com"],
  *     redirects: ["old.example.com"], // 301 → https://example.com
  *   },

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -2,7 +2,6 @@ import * as durableObjectsApi from "@distilled.cloud/cloudflare/durable-objects"
 import * as rulesets from "@distilled.cloud/cloudflare/rulesets";
 import * as workers from "@distilled.cloud/cloudflare/workers";
 import * as wfp from "@distilled.cloud/cloudflare/workers-for-platforms";
-import * as zones from "@distilled.cloud/cloudflare/zones";
 import * as Config from "effect/Config";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
@@ -31,7 +30,10 @@ import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
 import { localRuntimeServices } from "../LocalRuntime.ts";
 import { detachQueueConsumersOfScript } from "../Queues/Consumer.ts";
 import { CloudflareLogs } from "../Logs.ts";
-import { resolveZoneId } from "../Zone/lookup.ts";
+import {
+  resolveZoneId,
+  type Reference as ZoneReference,
+} from "../Zone/lookup.ts";
 import {
   getAssetsPathPrefix,
   mergeAssetsConfigFiles,
@@ -473,7 +475,26 @@ export interface ResolvedWorkerDomain {
   name: string;
   aliases: string[];
   redirects: string[];
+  /** Pinned zone from props, when the caller set zoneId / zone / zoneName. */
+  zone?: ZoneReference;
 }
+
+/** Collapse Worker.domain zone pin fields to one {@link ZoneReference}. */
+export const resolveWorkerDomainZone = (
+  config:
+    | {
+        readonly zoneId?: string;
+        readonly zoneName?: string;
+        readonly zone?: ZoneReference;
+      }
+    | undefined,
+): ZoneReference | undefined => {
+  if (config === undefined) return undefined;
+  if (config.zoneId !== undefined) return config.zoneId;
+  if (config.zone !== undefined) return config.zone;
+  if (config.zoneName !== undefined) return config.zoneName;
+  return undefined;
+};
 
 // Convert non-ASCII hostnames (emoji, IDN, etc.) to punycode so the
 // Cloudflare API receives the form it stores domains in. `new URL(...)`
@@ -529,7 +550,10 @@ export const resolveWorkerDomain = (
         }),
       );
     }
-    return { name, aliases, redirects };
+    const zone = resolveWorkerDomainZone(config);
+    return zone === undefined
+      ? { name, aliases, redirects }
+      : { name, aliases, redirects, zone };
   });
 
 const isWorkersDevHostname = (hostname: string) =>
@@ -585,12 +609,16 @@ export const stateWorkerDomain = (
           name?: unknown;
           aliases?: unknown[];
           redirects?: unknown[];
+          zone?: ZoneReference;
+          zoneId?: unknown;
+          zoneName?: unknown;
         } | null;
         domains?: unknown[];
       }
     | undefined;
   const domain = state?.domain;
   if (domain && typeof domain.name === "string") {
+    const zone = resolveWorkerDomainZone(domain);
     return {
       name: domain.name,
       aliases: (domain.aliases ?? []).filter(
@@ -599,6 +627,7 @@ export const stateWorkerDomain = (
       redirects: (domain.redirects ?? []).filter(
         (h): h is string => typeof h === "string",
       ),
+      ...(zone === undefined ? {} : { zone }),
     };
   }
   const legacy = stateCustomDomains(state?.domains);
@@ -1210,41 +1239,34 @@ export const LiveWorkerProvider = () =>
         });
 
       /**
-       * Infer the Cloudflare Zone ID for a given hostname by listing the
-       * account's zones and matching the hostname against each zone's name —
-       * walking up the DNS label hierarchy until a match is found.
+       * Resolve a hostname to a Cloudflare zone id. An explicit pin
+       * (`zoneId` / zone name / `{ zoneId }`) wins. Otherwise look the
+       * hostname up with {@link resolveZoneId} (`GET /zones?name=` per
+       * parent label) — never by listing the account's first page of zones.
        */
       const inferZoneIdForHostname = (
         hostname: string,
         zoneCache: Map<string, string>,
+        zone?: ZoneReference,
       ) =>
         Effect.gen(function* () {
-          const cached = zoneCache.get(hostname);
+          const cacheKey =
+            zone === undefined
+              ? hostname
+              : `${hostname}:${typeof zone === "string" ? zone : zone.zoneId}`;
+          const cached = zoneCache.get(cacheKey);
           if (cached) return cached;
-
-          const zoneList = yield* zones
-            .listZones({})
-            .pipe(Effect.map((response) => response.result ?? []));
-          for (const zone of zoneList) {
-            zoneCache.set(zone.name, zone.id);
-          }
-
-          const parts = hostname.split(".");
-          for (let i = 0; i < parts.length - 1; i++) {
-            const candidate = parts.slice(i).join(".");
-            const match = zoneList.find((z) => z.name === candidate);
-            if (match) {
-              zoneCache.set(hostname, match.id);
-              return match.id;
-            }
-          }
-          return yield* Effect.die(
-            `Could not infer Cloudflare Zone for hostname "${hostname}". ` +
-              "Ensure the parent zone exists in this account.",
-          );
+          const { accountId } = yield* yield* CloudflareEnvironment;
+          const zoneId = yield* resolveZoneId({ accountId, zone, hostname });
+          zoneCache.set(cacheKey, zoneId);
+          return zoneId;
         });
 
-      const reconcileDomains = (scriptName: string, desired: string[]) =>
+      const reconcileDomains = (
+        scriptName: string,
+        desired: string[],
+        zone?: ZoneReference,
+      ) =>
         Effect.gen(function* () {
           const { accountId } = yield* yield* CloudflareEnvironment;
           // Always query the live state of domains attached to *this*
@@ -1336,7 +1358,11 @@ export const LiveWorkerProvider = () =>
               );
             }
 
-            const zoneId = yield* inferZoneIdForHostname(hostname, zoneCache);
+            const zoneId = yield* inferZoneIdForHostname(
+              hostname,
+              zoneCache,
+              zone,
+            );
             // Same eventual-consistency window as `setWorkerSubdomain`:
             // PUT /accounts/.../workers/domains right after `putScript`
             // can return `WorkerNotFound` until Cloudflare's script
@@ -3757,7 +3783,11 @@ export const LiveWorkerProvider = () =>
               ),
               Effect.catch(() => Effect.succeed([])),
             );
-          const reconciled = yield* reconcileDomains(name, desiredHostnames);
+          const reconciled = yield* reconcileDomains(
+            name,
+            desiredHostnames,
+            domainConfig?.zone,
+          );
           const zoneIdByHostname = new Map([
             ...liveBeforeReconcile,
             ...reconciled.map((d) => [d.hostname, d.zoneId] as const),
@@ -4195,7 +4225,12 @@ export const LiveWorkerProvider = () =>
           const domainKey = (d: ResolvedWorkerDomain | undefined) =>
             d === undefined
               ? ""
-              : JSON.stringify([d.name, d.aliases, [...d.redirects].sort()]);
+              : JSON.stringify([
+                  d.name,
+                  d.aliases,
+                  [...d.redirects].sort(),
+                  d.zone ?? null,
+                ]);
           // An omitted `domain` unmanages the surface (#942): reconcile
           // carries previously-observed custom domains forward in state, so
           // comparing the empty desired config against those would report a

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -479,22 +479,45 @@ export interface ResolvedWorkerDomain {
   zone?: ZoneReference;
 }
 
+const isZoneReference = (value: unknown): value is ZoneReference => {
+  if (typeof value === "string") return true;
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as { zoneId?: unknown; name?: unknown };
+  return (
+    typeof candidate.zoneId === "string" &&
+    (candidate.name === undefined || typeof candidate.name === "string")
+  );
+};
+
 /** Collapse Worker.domain zone pin fields to one {@link ZoneReference}. */
 export const resolveWorkerDomainZone = (
   config:
     | {
-        readonly zoneId?: string;
-        readonly zoneName?: string;
-        readonly zone?: ZoneReference;
+        readonly zoneId?: unknown;
+        readonly zoneName?: unknown;
+        readonly zone?: unknown;
       }
     | undefined,
 ): ZoneReference | undefined => {
   if (config === undefined) return undefined;
-  if (config.zoneId !== undefined) return config.zoneId;
-  if (config.zone !== undefined) return config.zone;
-  if (config.zoneName !== undefined) return config.zoneName;
+  if (typeof config.zoneId === "string") return config.zoneId;
+  if (isZoneReference(config.zone)) return config.zone;
+  if (typeof config.zoneName === "string") return config.zoneName;
   return undefined;
 };
+
+/** Whether an existing attachment must move to satisfy an explicit zone pin. */
+export const shouldRecreateWorkerDomainAttachment = (
+  liveZoneId: string,
+  desiredZoneId: string | undefined,
+): boolean => desiredZoneId !== undefined && liveZoneId !== desiredZoneId;
+
+// After deleting a custom-domain attachment, Cloudflare can briefly retain
+// ownership of the hostname and reject the replacement with code 100116.
+const workerDomainConflictSchedule = Schedule.max([
+  Schedule.spaced("2 seconds"),
+  Schedule.recurs(8),
+]);
 
 // Convert non-ASCII hostnames (emoji, IDN, etc.) to punycode so the
 // Cloudflare API receives the form it stores domains in. `new URL(...)`
@@ -1324,12 +1347,28 @@ export const LiveWorkerProvider = () =>
           // clear message rather than silently re-routing traffic.
           const attachDomain = Effect.fn(function* (hostname: string) {
             const live = liveByHostname.get(hostname);
-            if (live) {
+            const desiredZoneId =
+              zone === undefined
+                ? undefined
+                : yield* inferZoneIdForHostname(hostname, zoneCache, zone);
+            if (
+              live &&
+              !shouldRecreateWorkerDomainAttachment(live.zoneId, desiredZoneId)
+            ) {
               return {
                 hostname: live.hostname,
                 id: live.id,
                 zoneId: live.zoneId,
               };
+            }
+
+            if (live) {
+              // Cloudflare cannot change the zone of an existing custom
+              // domain in place. Delete only this still-desired attachment,
+              // then recreate it below with the explicitly requested zone.
+              yield* workers
+                .deleteDomain({ accountId, domainId: live.id })
+                .pipe(Effect.catchTag("DomainNotFound", () => Effect.void));
             }
 
             // Not attached to this Worker — but it could still belong
@@ -1358,11 +1397,9 @@ export const LiveWorkerProvider = () =>
               );
             }
 
-            const zoneId = yield* inferZoneIdForHostname(
-              hostname,
-              zoneCache,
-              zone,
-            );
+            const zoneId =
+              desiredZoneId ??
+              (yield* inferZoneIdForHostname(hostname, zoneCache));
             // Same eventual-consistency window as `setWorkerSubdomain`:
             // PUT /accounts/.../workers/domains right after `putScript`
             // can return `WorkerNotFound` until Cloudflare's script
@@ -1381,6 +1418,10 @@ export const LiveWorkerProvider = () =>
                     Schedule.exponential(200),
                     Schedule.recurs(15),
                   ]),
+                }),
+                Effect.retry({
+                  while: (error) => error._tag === "HostnameAlreadyInUse",
+                  schedule: workerDomainConflictSchedule,
                 }),
               );
             return {

--- a/packages/alchemy/src/Cloudflare/Zone/lookup.ts
+++ b/packages/alchemy/src/Cloudflare/Zone/lookup.ts
@@ -119,7 +119,8 @@ export const listAllZones = (
     ),
   );
 
-const zoneNameCandidates = (hostname: string): string[] => {
+/** Hostname plus each parent label, longest first — used to infer a zone. */
+export const zoneNameCandidates = (hostname: string): string[] => {
   const parts = hostname.split(".");
   return parts.slice(0, -1).map((_, index) => parts.slice(index).join("."));
 };

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerProvider.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerProvider.test.ts
@@ -5,6 +5,7 @@ import {
   resolveWorkerDomain,
   resolveWorkerDomainZone,
   resolveWorkersDev,
+  shouldRecreateWorkerDomainAttachment,
   shouldObserveWorkerCrons,
   shouldObserveWorkerDomains,
   shouldObserveWorkerRoutes,
@@ -178,6 +179,18 @@ describe("WorkerProvider", () => {
         }),
       ).toEqual(zoneId);
     });
+
+    test("recreates an existing attachment only for a changed explicit zone", () => {
+      expect(shouldRecreateWorkerDomainAttachment("live-zone", undefined)).toBe(
+        false,
+      );
+      expect(
+        shouldRecreateWorkerDomainAttachment("live-zone", "live-zone"),
+      ).toBe(false);
+      expect(
+        shouldRecreateWorkerDomainAttachment("live-zone", "desired-zone"),
+      ).toBe(true);
+    });
   });
 
   describe("stateWorkerDomain", () => {
@@ -209,6 +222,22 @@ describe("WorkerProvider", () => {
         aliases: [],
         redirects: [],
         zone: "0123456789abcdef0123456789abcdef",
+      });
+      expect(
+        stateWorkerDomain({
+          domain: {
+            name: "app.example.com",
+            aliases: [],
+            redirects: [],
+            zoneId: 42,
+            zoneName: "example.com",
+          },
+        }),
+      ).toEqual({
+        name: "app.example.com",
+        aliases: [],
+        redirects: [],
+        zone: "example.com",
       });
     });
 

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerProvider.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerProvider.test.ts
@@ -3,6 +3,7 @@ import {
   getDurableObjectTagMap,
   normalizeStateDomains,
   resolveWorkerDomain,
+  resolveWorkerDomainZone,
   resolveWorkersDev,
   shouldObserveWorkerCrons,
   shouldObserveWorkerDomains,
@@ -144,6 +145,39 @@ describe("WorkerProvider", () => {
         expect(result.failure._tag).toEqual("WorkerDomainConfigError");
       }
     });
+
+    test("carries zoneId / zone / zoneName pins", () => {
+      const zoneId = "0123456789abcdef0123456789abcdef";
+      expect(
+        resolve({
+          name: "app.example.com",
+          zoneId,
+        }),
+      ).toEqual({
+        name: "app.example.com",
+        aliases: [],
+        redirects: [],
+        zone: zoneId,
+      });
+      expect(
+        resolve({
+          name: "app.example.com",
+          zoneName: "example.com",
+        }),
+      ).toEqual({
+        name: "app.example.com",
+        aliases: [],
+        redirects: [],
+        zone: "example.com",
+      });
+      expect(
+        resolveWorkerDomainZone({
+          zoneId,
+          zoneName: "ignored.com",
+          zone: "also-ignored.com",
+        }),
+      ).toEqual(zoneId);
+    });
   });
 
   describe("stateWorkerDomain", () => {
@@ -160,6 +194,21 @@ describe("WorkerProvider", () => {
         name: "app.example.com",
         aliases: ["www.example.com"],
         redirects: ["old.example.com"],
+      });
+      expect(
+        stateWorkerDomain({
+          domain: {
+            name: "app.example.com",
+            aliases: [],
+            redirects: [],
+            zoneId: "0123456789abcdef0123456789abcdef",
+          },
+        }),
+      ).toEqual({
+        name: "app.example.com",
+        aliases: [],
+        redirects: [],
+        zone: "0123456789abcdef0123456789abcdef",
       });
     });
 

--- a/packages/alchemy/test/Cloudflare/Zone/lookup.test.ts
+++ b/packages/alchemy/test/Cloudflare/Zone/lookup.test.ts
@@ -3,10 +3,20 @@ import {
   resolveZoneId,
   zoneNameCandidates,
 } from "@/Cloudflare/Zone/lookup.ts";
+import { Credentials } from "@distilled.cloud/cloudflare/Credentials";
 import { describe, expect, test } from "alchemy-test";
 import * as Effect from "effect/Effect";
 
 describe("Cloudflare zone lookup", () => {
+  const withoutCredentials = <A, E>(effect: Effect.Effect<A, E, Credentials>) =>
+    effect.pipe(
+      Effect.provideService(
+        Credentials,
+        Effect.die("explicit zone IDs must not resolve credentials"),
+      ),
+      Effect.runSync,
+    );
+
   test("zoneNameCandidates walks hostname labels longest-first", () => {
     expect(zoneNameCandidates("app.example.com")).toEqual([
       "app.example.com",
@@ -25,7 +35,7 @@ describe("Cloudflare zone lookup", () => {
     const zoneId = "0123456789abcdef0123456789abcdef";
     expect(isId(zoneId)).toBe(true);
     expect(
-      Effect.runSync(
+      withoutCredentials(
         resolveZoneId({
           accountId: "account",
           zone: zoneId,
@@ -34,7 +44,7 @@ describe("Cloudflare zone lookup", () => {
       ),
     ).toEqual(zoneId);
     expect(
-      Effect.runSync(
+      withoutCredentials(
         resolveZoneId({
           accountId: "account",
           zone: { zoneId, name: "example.com" },

--- a/packages/alchemy/test/Cloudflare/Zone/lookup.test.ts
+++ b/packages/alchemy/test/Cloudflare/Zone/lookup.test.ts
@@ -1,0 +1,46 @@
+import {
+  isId,
+  resolveZoneId,
+  zoneNameCandidates,
+} from "@/Cloudflare/Zone/lookup.ts";
+import { describe, expect, test } from "alchemy-test";
+import * as Effect from "effect/Effect";
+
+describe("Cloudflare zone lookup", () => {
+  test("zoneNameCandidates walks hostname labels longest-first", () => {
+    expect(zoneNameCandidates("app.example.com")).toEqual([
+      "app.example.com",
+      "example.com",
+    ]);
+    expect(zoneNameCandidates("a.b.c.example.com")).toEqual([
+      "a.b.c.example.com",
+      "b.c.example.com",
+      "c.example.com",
+      "example.com",
+    ]);
+    expect(zoneNameCandidates("example.com")).toEqual(["example.com"]);
+  });
+
+  test("resolveZoneId returns an explicit zone id without listing zones", () => {
+    const zoneId = "0123456789abcdef0123456789abcdef";
+    expect(isId(zoneId)).toBe(true);
+    expect(
+      Effect.runSync(
+        resolveZoneId({
+          accountId: "account",
+          zone: zoneId,
+          hostname: "app.example.com",
+        }),
+      ),
+    ).toEqual(zoneId);
+    expect(
+      Effect.runSync(
+        resolveZoneId({
+          accountId: "account",
+          zone: { zoneId, name: "example.com" },
+          hostname: "app.example.com",
+        }),
+      ),
+    ).toEqual(zoneId);
+  });
+});


### PR DESCRIPTION
Closes [#1240](https://github.com/alchemy-run/alchemy/issues/1240).

`Worker.routes` can pin a zone (`zoneId` / `zone` / `zoneName`) and, when it does, looks the zone up with `resolveZoneId` (`GET /zones?account.id=&name=`). `Worker.domain` could not pin a zone. Attach inferred the zone by listing the account's zones **once** (`listZones({})`) and walking DNS labels against that first page.

Cloudflare paginates zone lists (default 20). An account with more zones than one page can fail to attach, or attach to the wrong parent if a suffix match is on page 1 and the real zone is not. The rest of the Cloudflare provider already has the right helpers (`findZoneByName`, `listZones.pages`, `resolveZoneId`). Domain attach was the leftover caller.

This is attach-time **zone selection**. It is not [#942](https://github.com/alchemy-run/alchemy/issues/942) (omitted `domain` used to delete this Worker's attachments — already fixed: omit unmanages, `null` detaches). Reconcile still lists domains for **this script** only; it does not walk other Workers on the same zone.

```ts
// before — first page of every zone in the token's view
zones.listZones({})

// after — same path routes already use
resolveZoneId({ accountId, zone, hostname })
```

```ts
domain: {
  name: "app.example.com",
  zoneId: "...", // or zone / zoneName; omit to infer by hostname
  aliases: ["www.example.com"],
}
```

An explicit pin never lists zones. Unpinned hostnames walk parent labels with a named lookup, not an account-wide list.

Not in this PR: binding inheritance, omit-`domain` semantics, a second Worker-domain resource, or adopting a hostname owned by another Worker.
