### PR TITLE
fix(astro): forward prerender environment

### DIFF
--- a/packages/alchemy/src/Cloudflare/Website/Astro.ts
+++ b/packages/alchemy/src/Cloudflare/Website/Astro.ts
@@ -51,6 +51,12 @@ export interface AstroProps<
    */
   sessionKVBindingName?: string | false;
   /**
+   * Runtime used to prerender static pages. `"workerd"` renders them in the
+   * production Worker runtime; `"node"` uses Astro's stock Node prerenderer.
+   * @default "workerd"
+   */
+  prerenderEnvironment?: "workerd" | "node";
+  /**
    * Serializable Astro config merged into the in-memory configuration.
    * The project's `astro.config.*` file loads natively; astro merges
    * these options OVER it (scalars override the file). The Cloudflare
@@ -304,6 +310,7 @@ export const Astro: {
                 // source provider can skip its session-driver wiring on
                 // opt-out.
                 sessionKVBindingName: props.sessionKVBindingName,
+                prerenderEnvironment: props.prerenderEnvironment,
                 // Server output is the documented default: astro's own
                 // zero-config default is `"static"`, which would prerender
                 // every page at build time inside workerd — where the

--- a/packages/alchemy/test/Cloudflare/Website/PropSurface.test.ts
+++ b/packages/alchemy/test/Cloudflare/Website/PropSurface.test.ts
@@ -59,6 +59,19 @@ describe("Website prop surfaces", () => {
         source: { provider: "x", options: {} },
       }),
     () =>
+      Cloudflare.Website.Astro("A", {
+        prerenderEnvironment: "node",
+      }),
+    () =>
+      Cloudflare.Website.Astro("A", {
+        prerenderEnvironment: "workerd",
+      }),
+    () =>
+      Cloudflare.Website.Astro("A", {
+        // @ts-expect-error only workerd and node are supported
+        prerenderEnvironment: "bun",
+      }),
+    () =>
       Cloudflare.Website.Nextjs("X", {
         // @ts-expect-error `script` is owned by the source dispatch
         script: "export default {}",

--- a/packages/alchemy/test/Cloudflare/Website/StaticSiteNamespace.test.ts
+++ b/packages/alchemy/test/Cloudflare/Website/StaticSiteNamespace.test.ts
@@ -100,3 +100,22 @@ test(
     expect(keys).toEqual(["Cache", "Site"]);
   }),
 );
+
+test(
+  "Astro forwards the prerender environment to its source provider",
+  Effect.gen(function* () {
+    const resources = yield* compile(
+      Cloudflare.Website.Astro("Astro", {
+        prerenderEnvironment: "node",
+        sessionKVBindingName: false,
+      }),
+    );
+    expect(resources["Astro"]?.Props.source).toMatchObject({
+      provider: "@alchemy.run/frontend-frameworks/astro/source",
+      devMode: "server",
+      options: {
+        prerenderEnvironment: "node",
+      },
+    });
+  }),
+);

--- a/packages/frontend-frameworks/src/astro/source.ts
+++ b/packages/frontend-frameworks/src/astro/source.ts
@@ -223,6 +223,11 @@ export interface AstroSourceOptions {
    */
   readonly sessionDevKV?: boolean;
   /**
+   * Runtime used to prerender static pages.
+   * @default "workerd"
+   */
+  readonly prerenderEnvironment?: "workerd" | "node";
+  /**
    * JSON-serializable subset of Astro config merged into the in-memory
    * `AstroInlineConfig`. The project's `astro.config.*` file loads
    * natively; astro merges this inline overlay OVER it (scalars here
@@ -836,6 +841,7 @@ export interface AstroBuildChildConfig {
   readonly sessionKVBindingName: string | undefined;
   readonly sessions: boolean | undefined;
   readonly sessionDevKV: boolean | undefined;
+  readonly prerenderEnvironment: "workerd" | "node" | undefined;
   readonly astro: AstroSourceOptions["astro"];
 }
 
@@ -860,6 +866,7 @@ export const buildInChild = (config: AstroBuildChildConfig) =>
             sessionKVBindingName: config.sessionKVBindingName,
             sessions: config.sessions,
             sessionDevKV: config.sessionDevKV,
+            prerenderEnvironment: config.prerenderEnvironment,
           }),
           astro: config.astro,
         }),
@@ -889,6 +896,7 @@ const makeAstroSourceProvider = (
             sessionKVBindingName: options.sessionKVBindingName,
             sessions: options.sessions,
             sessionDevKV: options.sessionDevKV,
+            prerenderEnvironment: options.prerenderEnvironment,
           }),
           astro: options.astro,
         }),
@@ -914,6 +922,7 @@ const makeAstroSourceProvider = (
             sessionKVBindingName: options.sessionKVBindingName,
             sessions: options.sessions,
             sessionDevKV: options.sessionDevKV,
+            prerenderEnvironment: options.prerenderEnvironment,
             astro: options.astro,
           } satisfies AstroBuildChildConfig,
         }).pipe(

--- a/packages/frontend-frameworks/src/astro/test/Astro.test.ts
+++ b/packages/frontend-frameworks/src/astro/test/Astro.test.ts
@@ -101,10 +101,12 @@ describe("cloudflare target module", () => {
     const worker = { compatibilityDate: "2026-03-10" };
     const target = cloudflareTarget({
       worker,
+      prerenderEnvironment: "node",
       sessionKVBindingName: "MY_SESSION",
     });
     expect(target.config).toEqual({
       worker,
+      prerenderEnvironment: "node",
       sessionKVBindingName: "MY_SESSION",
     });
     const integration = target.integration();


### PR DESCRIPTION
## Summary
- expose `prerenderEnvironment` on `Cloudflare.Website.Astro`
- forward the option through the serialized source descriptor to dev and production Astro targets
- cover the public type surface and source descriptor forwarding

## Testing
- `bun run test:astro` in `packages/frontend-frameworks`
- `bun alchemy-test test/Cloudflare/Website/StaticSiteNamespace.test.ts` in `packages/alchemy`
- `bun run typecheck` in `packages/frontend-frameworks`
- `bun tsc -b`
- `bunx tsc --noEmit -p tsconfig.test.json` in `packages/alchemy`