### PR TITLE
feat(cli)!: normalize default stage names

### DIFF
--- a/packages/alchemy/src/Cli/StageName.ts
+++ b/packages/alchemy/src/Cli/StageName.ts
@@ -1,0 +1,34 @@
+import { createHash } from "node:crypto";
+import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+import { base32 } from "../Util/base32.ts";
+
+const MAX_DEFAULT_STAGE_LENGTH = 32;
+const HASH_LENGTH = 6;
+const prefix = "dev-";
+const defaultUserPattern = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+
+export const StageNameSchema = Schema.String.check(
+  Schema.isPattern(/^[a-z0-9]+([-_a-z0-9]+)*$/i),
+);
+
+export const createDefaultStageName = Effect.fn(function* (user: string) {
+  const maxUserLength = MAX_DEFAULT_STAGE_LENGTH - prefix.length;
+  if (user.length <= maxUserLength && defaultUserPattern.test(user)) {
+    return `${prefix}${user}`;
+  }
+
+  const hash = yield* Effect.sync(() =>
+    base32(createHash("sha256").update(user).digest()).slice(0, HASH_LENGTH),
+  );
+  const slug = user
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  if (slug.length === 0) {
+    return `${prefix}${hash}`;
+  }
+  const maxSlugLength = maxUserLength - HASH_LENGTH - 1;
+  const truncated = slug.slice(0, maxSlugLength).replace(/-+$/g, "");
+  return `${prefix}${truncated}-${hash}`;
+});

--- a/packages/alchemy/src/Cli/commands/_shared.ts
+++ b/packages/alchemy/src/Cli/commands/_shared.ts
@@ -7,7 +7,6 @@ import * as Layer from "effect/Layer";
 import * as Logger from "effect/Logger";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
-import * as S from "effect/Schema";
 import * as Argument from "effect/unstable/cli/Argument";
 import * as CliError from "effect/unstable/cli/CliError";
 import * as Flag from "effect/unstable/cli/Flag";
@@ -36,16 +35,17 @@ import { recordCli } from "../../Telemetry/Metrics.ts";
 import { PromptCancelled } from "../../Util/Clank.ts";
 import { loadConfigProvider } from "../../Util/ConfigProvider.ts";
 import { fileLogger } from "../../Util/FileLogger.ts";
+import { createDefaultStageName, StageNameSchema } from "../StageName.ts";
 
 export const USER = Config.string("USER").pipe(
   Config.orElse(() => Config.string("USERNAME")),
   Config.withDefault("unknown"),
 );
 
-export const STAGE = Config.string("STAGE").pipe(
+export const STAGE = Config.schema(StageNameSchema, "STAGE").pipe(
   Config.option,
-  (a) => a,
   Effect.map(Option.getOrUndefined),
+  Effect.mapError((cause) => new CliError.UserError({ cause })),
 );
 
 /**
@@ -100,32 +100,23 @@ export const handleCancellation = <A, E, R>(self: Effect.Effect<A, E, R>) =>
   );
 
 export const stage = Flag.string("stage").pipe(
-  Flag.withSchema(S.String.check(S.isPattern(/^[a-z0-9]+([-_a-z0-9]+)*$/gi))),
-  Flag.withDescription("Stage to deploy to, defaults to dev_${USER}"),
+  Flag.withSchema(StageNameSchema),
+  Flag.withDescription("Stage to deploy to, defaults to dev-$USER"),
   Flag.optional,
   Flag.map(Option.getOrUndefined),
   Flag.mapEffect(
-    Effect.fn(function* (stage) {
-      if (stage) {
-        return stage;
+    Effect.fn(function* (flag) {
+      if (flag !== undefined) {
+        return flag;
       }
-      return yield* STAGE.pipe(
-        Effect.catch(() =>
-          Effect.fail(
-            new CliError.MissingOption({
-              option: "stage",
-            }),
-          ),
-        ),
-        Effect.flatMap((s) =>
-          s === undefined
-            ? USER.pipe(
-                Effect.map((user) => `dev_${user}`),
-                Effect.catch(() => Effect.succeed("unknown")),
-              )
-            : Effect.succeed(s),
-        ),
+      const configured = yield* STAGE;
+      if (configured !== undefined) {
+        return configured;
+      }
+      const user = yield* USER.pipe(
+        Effect.catch(() => Effect.succeed("unknown")),
       );
+      return yield* createDefaultStageName(user);
     }),
   ),
 );

--- a/packages/alchemy/test/Cli/StageEnvironment.test.ts
+++ b/packages/alchemy/test/Cli/StageEnvironment.test.ts
@@ -5,30 +5,100 @@ import * as ConfigProvider from "effect/ConfigProvider";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 
-const TestEnv = Layer.mergeAll(
-  PlatformServices,
-  ConfigProvider.layer(
-    ConfigProvider.fromEnv({ env: { STAGE: "production", USER: "name" } }),
-  ),
-);
-
-describe("STAGE environment variable", () => {
-  test.effect("takes precedence over the user default", () =>
-    Effect.gen(function* () {
-      const [, selected] = yield* stage.parse({ arguments: [], flags: {} });
-
-      expect(selected).toBe("production");
-    }).pipe(Effect.provide(TestEnv)),
+const testEnv = (env: Record<string, string>) =>
+  Layer.mergeAll(
+    PlatformServices,
+    ConfigProvider.layer(ConfigProvider.fromEnv({ env })),
   );
 
-  test.effect("yields to an explicit --stage flag", () =>
+const parseStage = (env: Record<string, string>, flag?: string) =>
+  stage
+    .parse({
+      arguments: [],
+      flags: flag === undefined ? {} : { stage: [flag] },
+    })
+    .pipe(Effect.provide(testEnv(env)));
+
+describe("stage", () => {
+  test.effect("STAGE takes precedence over the user default", () =>
     Effect.gen(function* () {
-      const [, selected] = yield* stage.parse({
-        arguments: [],
-        flags: { stage: ["preview"] },
+      const [, selected] = yield* parseStage({
+        STAGE: "Production_STAGE",
+        USER: "name",
       });
 
-      expect(selected).toBe("preview");
-    }).pipe(Effect.provide(TestEnv)),
+      expect(selected).toBe("Production_STAGE");
+    }),
+  );
+
+  test.effect("--stage takes precedence over STAGE", () =>
+    Effect.gen(function* () {
+      const [, selected] = yield* parseStage(
+        { STAGE: "Production_STAGE", USER: "name" },
+        "Preview_STAGE",
+      );
+
+      expect(selected).toBe("Preview_STAGE");
+    }),
+  );
+
+  test.effect("does not validate STAGE when --stage is set", () =>
+    Effect.gen(function* () {
+      const [, selected] = yield* parseStage(
+        { STAGE: "../production", USER: "name" },
+        "Preview_STAGE",
+      );
+
+      expect(selected).toBe("Preview_STAGE");
+    }),
+  );
+
+  test.effect("rejects an invalid --stage", () =>
+    Effect.gen(function* () {
+      const error = yield* Effect.flip(parseStage({}, "../preview"));
+
+      expect(error._tag).toBe("InvalidValue");
+      if (error._tag === "InvalidValue") {
+        expect(error.option).toBe("stage");
+      }
+    }),
+  );
+
+  test.effect("rejects an invalid STAGE", () =>
+    Effect.gen(function* () {
+      const error = yield* Effect.flip(parseStage({ STAGE: "../production" }));
+
+      expect(error._tag).toBe("UserError");
+      if (error._tag === "UserError") {
+        expect(String(error.cause)).toContain("STAGE");
+      }
+    }),
+  );
+
+  test.effect("uses USER before USERNAME for the default", () =>
+    Effect.gen(function* () {
+      const [, selected] = yield* parseStage({
+        USER: "User Name",
+        USERNAME: "windows-user",
+      });
+
+      expect(selected).toBe("dev-user-name-vfu5at");
+    }),
+  );
+
+  test.effect("falls back to USERNAME for the default", () =>
+    Effect.gen(function* () {
+      const [, selected] = yield* parseStage({ USERNAME: "windows-user" });
+
+      expect(selected).toBe("dev-windows-user");
+    }),
+  );
+
+  test.effect("falls back to unknown when no user name is available", () =>
+    Effect.gen(function* () {
+      const [, selected] = yield* parseStage({});
+
+      expect(selected).toBe("dev-unknown");
+    }),
   );
 });

--- a/packages/alchemy/test/Cli/StageName.test.ts
+++ b/packages/alchemy/test/Cli/StageName.test.ts
@@ -1,0 +1,53 @@
+import { createDefaultStageName } from "@/Cli/StageName.ts";
+import { describe, expect, test } from "alchemy-test";
+import * as Effect from "effect/Effect";
+
+describe("createDefaultStageName", () => {
+  test.effect("keeps an already normalized user name readable", () =>
+    Effect.gen(function* () {
+      expect(yield* createDefaultStageName("user")).toBe("dev-user");
+      expect(yield* createDefaultStageName("123user")).toBe("dev-123user");
+    }),
+  );
+
+  test.effect("gives normalized user names stable, distinct identities", () =>
+    Effect.gen(function* () {
+      expect(yield* createDefaultStageName("User Name")).toBe(
+        "dev-user-name-vfu5at",
+      );
+      expect(yield* createDefaultStageName("user_name")).toBe(
+        "dev-user-name-fygq4a",
+      );
+    }),
+  );
+
+  test.effect("uses only the hash when the user name has no slug", () =>
+    Effect.gen(function* () {
+      expect(yield* createDefaultStageName("___")).toBe("dev-xwrfcv");
+    }),
+  );
+
+  test.effect("hashes only after the default stage length limit", () =>
+    Effect.gen(function* () {
+      expect(yield* createDefaultStageName("a".repeat(28))).toBe(
+        `dev-${"a".repeat(28)}`,
+      );
+      expect(yield* createDefaultStageName("a".repeat(29))).toBe(
+        `dev-${"a".repeat(21)}-nej4tr`,
+      );
+    }),
+  );
+
+  test.effect(
+    "distinguishes long user names with the same truncated slug",
+    () =>
+      Effect.gen(function* () {
+        expect(yield* createDefaultStageName(`user-${"a".repeat(60)}`)).toBe(
+          `dev-user-${"a".repeat(16)}-rvgpjw`,
+        );
+        expect(yield* createDefaultStageName(`user_${"a".repeat(60)}`)).toBe(
+          `dev-user-${"a".repeat(16)}-wyjsu6`,
+        );
+      }),
+  );
+});

--- a/website/src/content/docs/aws/tutorial/part-3.mdx
+++ b/website/src/content/docs/aws/tutorial/part-3.mdx
@@ -91,7 +91,7 @@ skips unchanged resources.
 
 :::note[Which stage do tests deploy to?]
 The test harness defaults to a stage named `test`, separate from the
-`dev_<user>` stage your `alchemy deploy` runs target — so tests never
+`dev-$USER` stage your `alchemy deploy` runs target — so tests never
 clobber your working deployment. More on stages in
 [Part 4](/aws/tutorial/part-4).
 :::

--- a/website/src/content/docs/aws/tutorial/part-4.mdx
+++ b/website/src/content/docs/aws/tutorial/part-4.mdx
@@ -17,14 +17,14 @@ the infrastructure.
 ## The default stage
 
 You've been using stages all along. If you don't pass `--stage`,
-Alchemy deploys to **`dev_$USER`** (e.g. `dev_sam`):
+Alchemy deploys to **`dev-$USER`** (e.g. `dev-sam`):
 
 ```sh
 $ whoami
 sam
 
 $ bun alchemy deploy
-# deploys to stage `dev_sam`
+# deploys to stage `dev-sam`
 ```
 
 Each developer on your team automatically gets a personal sandbox
@@ -32,8 +32,8 @@ without any config. The resolution order is:
 
 1. `--stage <name>` flag
 2. `$STAGE` environment variable
-3. `dev_${USER}` (or `dev_${USERNAME}` on Windows)
-4. `dev_unknown` if no user is set
+3. `dev-$USER` (or `dev-$USERNAME` on Windows)
+4. `dev-unknown` if no user name is available
 
 ## Deploy a second stage
 
@@ -58,7 +58,7 @@ Proceed?
 
 Everything is created fresh — a new bucket, a new function, a new
 Function URL — because `staging` has never been deployed before.
-Your `dev_sam` deployment is untouched.
+Your `dev-sam` deployment is untouched.
 
 ## How stages isolate
 
@@ -67,7 +67,7 @@ Each stage gets its own:
 - **State** — the persisted record of what's deployed, kept
   separately per stage in the `AWS.state()` S3 bucket
 - **Physical names** — `myapp-prod-bucket-7d4e` vs
-  `myapp-dev_sam-bucket-9b2c`; the stage is baked into every
+  `myapp-dev-sam-bucket-9b2c`; the stage is baked into every
   generated resource name
 - **Logs and metrics** — scoped per deployed function
 
@@ -80,7 +80,8 @@ alchemy deploy --stage pr-42
 alchemy destroy --stage pr-42   # only removes pr-42 resources
 ```
 
-Stage names must match `[a-z0-9][-_a-z0-9]*`.
+Values passed through `--stage` or `$STAGE` are kept as written and
+validated case-insensitively against `[a-z0-9][-_a-z0-9]*`.
 
 ## Configure per stage
 
@@ -162,7 +163,7 @@ alchemy deploy --stage pr-42 --profile default
 
 You now have:
 
-- A personal `dev_<user>` stage that every plain `alchemy deploy`
+- A personal `dev-$USER` stage that every plain `alchemy deploy`
   targets
 - A `staging` stage deployed (and destroyed) with `--stage`
 - Per-stage Lambda memory via `Stack.useSync`

--- a/website/src/content/docs/cli/deploy.mdx
+++ b/website/src/content/docs/cli/deploy.mdx
@@ -48,7 +48,7 @@ When the plan contains no changes, the approval prompt is skipped automatically.
 | Option              | Description                                                                                                                |
 | ------------------- | -------------------------------------------------------------------------------------------------------------------------- |
 | `[file]`            | Stack file to deploy (defaults to `alchemy.run.ts`)                                                                        |
-| `--stage <name>`    | Stage to deploy to (defaults to `dev_$USER`)                                                                               |
+| `--stage <name>`    | Stage to deploy to (defaults to `dev-$USER`)                                                                               |
 | `--yes`             | Skip the approval prompt                                                                                                   |
 | `--dry-run`         | Show the plan without applying (same as `alchemy plan`)                                                                    |
 | `--force`           | Force updates for resources that would otherwise no-op                                                                     |

--- a/website/src/content/docs/cli/destroy.mdx
+++ b/website/src/content/docs/cli/destroy.mdx
@@ -28,7 +28,7 @@ Proceed?
 | Option              | Description                                                       |
 | ------------------- | ----------------------------------------------------------------- |
 | `[file]`            | Stack file to destroy (defaults to `alchemy.run.ts`)              |
-| `--stage <name>`    | Stage to destroy (defaults to `dev_$USER`)                        |
+| `--stage <name>`    | Stage to destroy (defaults to `dev-$USER`)                        |
 | `--yes`             | Skip the approval prompt                                          |
 | `--dry-run`         | Show what would be deleted without actually deleting              |
 | `--profile <name>`  | Auth profile to use (defaults to `default` or `$ALCHEMY_PROFILE`) |

--- a/website/src/content/docs/cli/dev.mdx
+++ b/website/src/content/docs/cli/dev.mdx
@@ -21,7 +21,7 @@ A failed apply keeps dev alive so healthy resources keep serving — fix the err
 
 | Option              | Description                                                        |
 | ------------------- | ------------------------------------------------------------------ |
-| `--stage <name>`    | Stage to use for dev (defaults to `dev_$USER`)                     |
+| `--stage <name>`    | Stage to use for dev (defaults to `dev-$USER`)                     |
 | `--force`           | Force updates for resources that would otherwise no-op             |
 | `--profile <name>`  | Auth profile to use (defaults to `default` or `$ALCHEMY_PROFILE`)  |
 | `--env-file <path>` | Load environment variables from a file                             |

--- a/website/src/content/docs/cli/index.mdx
+++ b/website/src/content/docs/cli/index.mdx
@@ -37,7 +37,7 @@ Each command has its own page: [deploy](/cli/deploy), [plan](/cli/plan), [destro
 
 | Option              | Description                                                                                                                              |
 | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `--stage <name>`    | Stage to target. Falls back to the `stage` env config, then `dev_$USER`. Must match `[a-z0-9]+([-_a-z0-9]+)*` (case-insensitive).        |
+| `--stage <name>`    | Stage to target. Falls back to `$STAGE`, then `dev-$USER`. Must match `[a-z0-9]+([-_a-z0-9]+)*` (case-insensitive).        |
 | `--profile <name>`  | Auth profile from `~/.alchemy/profiles.json`. Defaults to `default` or `$ALCHEMY_PROFILE`.                                                |
 | `--env-file <path>` | File to load environment variables from. Defaults to `.env`.                                                                             |
 | `--yes`             | Yes to all prompts.                                                                                                                       |

--- a/website/src/content/docs/cli/inspecting-state.mdx
+++ b/website/src/content/docs/cli/inspecting-state.mdx
@@ -12,7 +12,7 @@ bun alchemy state tree
 ```
 
 <Terminal content={`AlchemyEffectWebsite
-├─ dev_sam
+├─ dev-sam
 │  ├─ Bucket
 │  └─ Worker
 └─ prod
@@ -38,7 +38,7 @@ bun alchemy state stages --stack myapp
 Lists every stage recorded under `myapp`.
 
 ```sh
-bun alchemy state resources --stack myapp --stage dev_sam
+bun alchemy state resources --stack myapp --stage dev-sam
 ```
 
 Prints the FQNs tracked under that stack/stage — the addresses
@@ -57,14 +57,14 @@ single JSON document to filter locally — see
 ## Debugging a bad diff
 
 ```sh
-bun alchemy state get --stack myapp --stage dev_sam --fqn Bucket
+bun alchemy state get --stack myapp --stage dev-sam --fqn Bucket
 ```
 
 This is the persisted props/attrs the planner diffs against — see
 [state](/cli/state) for the output encoding. Compare it with what
 `alchemy plan` says it wants to change. Three usual causes:
 
-**Wrong stage.** `--stage` defaults to `dev_$USER` (e.g. `dev_sam`),
+**Wrong stage.** `--stage` defaults to `dev-$USER` (e.g. `dev-sam`),
 so a plan that "wants to create everything" often just means you're
 looking at a stage you never deployed. Run
 `state stages --stack myapp` and confirm which stage actually has

--- a/website/src/content/docs/cli/logs.mdx
+++ b/website/src/content/docs/cli/logs.mdx
@@ -19,7 +19,7 @@ Resources must be deployed and their provider must implement log fetching; if no
 
 | Option              | Description                                                                                    |
 | ------------------- | ---------------------------------------------------------------------------------------------- |
-| `--stage <name>`    | Stage to fetch logs from (defaults to `dev_$USER`)                                             |
+| `--stage <name>`    | Stage to fetch logs from (defaults to `dev-$USER`)                                             |
 | `--filter <ids>`    | Comma-separated logical resource IDs to include                                                |
 | `--limit <n>`       | Number of log entries to fetch (default: 100)                                                  |
 | `--since <time>`    | Fetch logs since this time — a duration (`30m`, `1h`, `2d`; units `s`/`m`/`h`/`d`) or ISO date |

--- a/website/src/content/docs/cli/plan.mdx
+++ b/website/src/content/docs/cli/plan.mdx
@@ -25,7 +25,7 @@ made.
 | Option              | Description                                                       |
 | ------------------- | ----------------------------------------------------------------- |
 | `[file]`            | Stack file to plan (defaults to `alchemy.run.ts`)                 |
-| `--stage <name>`    | Stage to plan against (defaults to `dev_$USER`)                   |
+| `--stage <name>`    | Stage to plan against (defaults to `dev-$USER`)                   |
 | `--profile <name>`  | Auth profile to use (defaults to `default` or `$ALCHEMY_PROFILE`) |
 | `--env-file <path>` | Load environment variables from a file                            |
 

--- a/website/src/content/docs/cli/tail.mdx
+++ b/website/src/content/docs/cli/tail.mdx
@@ -27,7 +27,7 @@ Only deployed resources whose provider implements tailing are streamed; if none 
 
 | Option              | Description                                                         |
 | ------------------- | ------------------------------------------------------------------- |
-| `--stage <name>`    | Stage to tail (defaults to `dev_$USER`)                             |
+| `--stage <name>`    | Stage to tail (defaults to `dev-$USER`)                             |
 | `--filter <ids>`    | Comma-separated logical resource IDs to include (e.g. `Worker,Api`) |
 | `--profile <name>`  | Auth profile to use (defaults to `default` or `$ALCHEMY_PROFILE`)   |
 | `--env-file <path>` | Load environment variables from a file                              |

--- a/website/src/content/docs/environments/local-development.mdx
+++ b/website/src/content/docs/environments/local-development.mdx
@@ -38,7 +38,7 @@ Three things happen:
 
 Resources whose provider has no local implementation (a Hyperdrive,
 a Vectorize index) deploy to the real cloud, into your personal
-[stage](/environments/stages) (`dev_$USER` by default), so your loop
+[stage](/environments/stages) (`dev-$USER` by default), so your loop
 never collides with teammates or prod. A stack that mixes emulated
 and live-only resources just works.
 
@@ -186,6 +186,6 @@ To automate the deploy side, see the [CI guide](/environments/ci).
 ## Where next
 
 - [CI](/environments/ci) — deploy the same stack from GitHub Actions with PR previews.
-- [Stages](/environments/stages) — how `dev_$USER`, `pr-42`, and `prod` stay isolated.
+- [Stages](/environments/stages) — how `dev-$USER`, `pr-42`, and `prod` stay isolated.
 - [Dev servers](/command/dev-servers) — run any framework dev server as a `Command.Dev` resource in the dev loop.
 - [Local Providers](/infrastructure-as-code/local-provider) — build the local implementation of a resource.

--- a/website/src/content/docs/environments/stages.mdx
+++ b/website/src/content/docs/environments/stages.mdx
@@ -1,6 +1,6 @@
 ---
 title: Stages
-description: Stages are isolated instances of a Stack — dev_sam, staging, prod, pr-42 — each with their own state and physical names.
+description: Stages are isolated instances of a Stack — dev-sam, staging, prod, pr-42 — each with their own state and physical names.
 sidebar:
   hidden: true
 ---
@@ -13,8 +13,8 @@ dedicated environment — all from one program.
 
 ## The default stage
 
-If you don't pass `--stage`, alchemy uses **`dev_$USER`** (e.g.
-`dev_sam`). Each developer on your team automatically gets a
+If you don't pass `--stage`, alchemy uses **`dev-$USER`** (e.g.
+`dev-sam`). Each developer on your team automatically gets a
 personal stage without any config.
 
 ```sh
@@ -22,27 +22,39 @@ $ whoami
 sam
 
 $ alchemy deploy
-# deploys to stage `dev_sam`
+# deploys to stage `dev-sam`
 ```
 
 The resolution order is:
 
 1. `--stage <name>` flag
 2. `$STAGE` environment variable
-3. `dev_${USER}` (or `dev_${USERNAME}` on Windows)
-4. `dev_unknown` if no user is set
+3. `dev-$USER` (or `dev-$USERNAME` on Windows)
+4. `dev-unknown` if no user name is available
+
+The default derived from `$USER` or `$USERNAME` is normalized to lowercase
+letters, numbers, and hyphens. Alchemy adds a stable hash when it changes or
+shortens the user name:
+
+```text
+sam      → dev-sam
+sam-name → dev-sam-name
+Sam Name → dev-sam-name-xoyvem
+sam_name → dev-sam-name-osa47f
+```
+
+Values passed through `--stage` or `$STAGE` are kept as written. They are
+validated case-insensitively against `[a-z0-9][-_a-z0-9]*`.
 
 ## Common stage patterns
 
 | Stage             | Purpose                                  |
 | ----------------- | ---------------------------------------- |
-| `dev_<user>`      | Per-developer sandbox (default)          |
+| `dev-<user>`      | Per-developer sandbox (default)          |
 | `pr-<n>`          | Per-pull-request preview environment     |
 | `staging`         | Shared pre-production                    |
 | `prod`            | Production                               |
 | `dev`             | Shared development                       |
-
-Stage names must match `[a-z0-9][-_a-z0-9]*`.
 
 ```sh
 alchemy deploy --stage prod
@@ -56,15 +68,15 @@ Each stage gets its own:
 
 - **State file** — the persisted record of what's deployed
 - **Physical names** — `myapp-prod-bucket-abc123` vs
-  `myapp-dev_sam-bucket-9b2c`
+  `myapp-dev-sam-bucket-9b2c`
 - **Logs and metrics** — scoped per deployed function/worker
 
 Because of this, deploying or destroying one stage **never touches**
 another:
 
 ```sh
-$ alchemy deploy --stage dev_sam     # -> myapp-dev_sam-photos-a3f1
-$ alchemy deploy --stage pr-147      # -> myapp-pr_147-photos-9b2c
+$ alchemy deploy --stage dev-sam     # -> myapp-dev-sam-photos-a3f1
+$ alchemy deploy --stage pr-147      # -> myapp-pr-147-photos-9b2c
 $ alchemy deploy --stage prod        # -> myapp-prod-photos-7d4e
 
 $ alchemy destroy --stage pr-147     # only removes pr-147 resources

--- a/website/src/content/docs/infrastructure-as-code/stack.mdx
+++ b/website/src/content/docs/infrastructure-as-code/stack.mdx
@@ -118,14 +118,14 @@ The CLI renders them after every successful deploy:
 ## Stages
 
 Every deploy targets a **stage** — an isolated instance of the stack
-like `dev_sam`, `staging`, or `prod`. The stage defaults to
-`dev_$USER`, so each developer gets their own environment
+like `dev-sam`, `staging`, or `prod`. The stage defaults to
+`dev-$USER`, so each developer gets their own environment
 automatically. State and physical names are namespaced by stage.
 
 ```sh
 # Each stage = its own state file + its own physical names.
-$ alchemy deploy --stage dev_sam     # -> myapp-dev_sam-photos-a3f1
-$ alchemy deploy --stage pr-147      # -> myapp-pr_147-photos-9b2c
+$ alchemy deploy --stage dev-sam     # -> myapp-dev-sam-photos-a3f1
+$ alchemy deploy --stage pr-147      # -> myapp-pr-147-photos-9b2c
 $ alchemy deploy --stage prod        # -> myapp-prod-photos-7d4e
 
 # Three independent deployments. Destroying one
@@ -148,7 +148,7 @@ import * as Console from "effect/Console";
 Effect.gen(function* () {
   const stack = yield* Stack;
   yield* Console.log(stack.name); // "MyApp"
-  yield* Console.log(stack.stage); // "dev_sam"
+  yield* Console.log(stack.stage); // "dev-sam"
 
   const queue = yield* SQS.Queue("Jobs").pipe(
     RemovalPolicy.retain(stack.stage === "prod"),

--- a/website/src/content/docs/state-store/index.mdx
+++ b/website/src/content/docs/state-store/index.mdx
@@ -33,7 +33,7 @@ By default, state is stored on disk in the `.alchemy/` directory:
 .alchemy/
   state/
     MyApp/
-      dev_sam/
+      dev-sam/
         Bucket.json
         Worker.json
 ```
@@ -45,7 +45,7 @@ echo ".alchemy/" >> .gitignore
 ```
 
 Local state works for solo development. Each developer gets their own
-state via their default stage (`dev_$USER`).
+state via their default stage (`dev-$USER`).
 
 ## Remote state
 

--- a/website/src/content/docs/what-is-alchemy.mdx
+++ b/website/src/content/docs/what-is-alchemy.mdx
@@ -158,7 +158,7 @@ deploy targets a **stage** — an isolated environment like `dev`,
 `prod`, or `pr-42`:
 
 ```sh
-alchemy deploy              # deploys to dev_$USER by default
+alchemy deploy              # deploys to dev-$USER by default
 alchemy deploy --stage prod # deploys to prod
 ```
 


### PR DESCRIPTION
**BREAKING:** Default stages now use `dev-<safe-user>` instead of `dev_<user>`. User names that require normalization or truncation get a deterministic hash to avoid collisions.

To target an existing `dev_<user>` deployment, pass the old stage explicitly. Explicit `--stage` and `STAGE` values are used as-is.