### PR TITLE
fix(runtime): store unambiguous env strings bare instead of JSON-packing them

### DIFF
--- a/packages/alchemy/src/RuntimeContext.ts
+++ b/packages/alchemy/src/RuntimeContext.ts
@@ -74,8 +74,34 @@ export const isRedactedMarker = (value: unknown): value is RedactedMarker =>
   "value" in value;
 
 /**
+ * Returns true when {@link unpackEnvValue}'s `JSON.parse` would reinterpret
+ * the raw string as something other than itself — a number (`"123"`), a
+ * boolean, `null`, or a JSON document. Such strings must stay
+ * `JSON.stringify`-packed; everything else round-trips verbatim through the
+ * parse-failure fallback.
+ */
+const parsesAsJson = (value: string): boolean => {
+  try {
+    JSON.parse(value);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
  * Serialize a binding value for an env var: `Redacted` values are packed as
- * a {@link RedactedMarker}, everything else is plain `JSON.stringify`.
+ * a {@link RedactedMarker}, non-string values as JSON.
+ *
+ * A plain string is stored **verbatim** whenever `JSON.parse` would reject
+ * it — which is almost every real-world string (names, URLs, ids). Packing
+ * those too would put `"my-queue"` (quote characters included) on the wire,
+ * where anything that consumes the raw binding without going through
+ * {@link unpackEnvValue} — the Cloudflare dashboard, a hand-written env
+ * read, a queue-name comparison against `MessageBatch.queue` — sees the
+ * quoted form and mismatches (#1243). Only ambiguous strings (`"123"`,
+ * `"null"`, JSON documents) keep the pack so the read side can't
+ * reinterpret them.
  */
 export const packEnvValue = (value: unknown): string =>
   Redacted.isRedacted(value)
@@ -83,7 +109,9 @@ export const packEnvValue = (value: unknown): string =>
         _tag: "Redacted",
         value: Redacted.value(value),
       } satisfies RedactedMarker)
-    : JSON.stringify(value);
+    : typeof value === "string" && !parsesAsJson(value)
+      ? value
+      : JSON.stringify(value);
 
 /**
  * Like {@link packEnvValue}, but a `Redacted` input keeps its `Redacted`
@@ -102,8 +130,9 @@ export const packEnvValueKeepRedacted = (
 /**
  * Parse an env-var string produced by {@link packEnvValue} back into its
  * value: rebuild `Redacted` from the marker, return other JSON values
- * as-is, and fall back to the raw string for non-JSON input (e.g. an env
- * var the user set directly). `undefined` passes through.
+ * as-is, and fall back to the raw string for non-JSON input (a verbatim
+ * string from `packEnvValue`, or an env var the user set directly).
+ * `undefined` passes through.
  *
  * Runtime `get` accessors MUST feed this from the raw environment
  * (`process.env[key]` / the platform env object) — never through

--- a/packages/alchemy/test/Cloudflare/Queue/Queue.test.ts
+++ b/packages/alchemy/test/Cloudflare/Queue/Queue.test.ts
@@ -12,6 +12,9 @@ import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import ConsumerWorker from "./fixtures/dedicated-consumer-worker.ts";
+import ProducerWorker from "./fixtures/dedicated-producer-worker.ts";
 
 const { test } = Test.make({ providers: Cloudflare.providers() });
 
@@ -211,4 +214,81 @@ test.provider("suppresses deletion of a dev-only queue", (stack) =>
     });
     expect(persisted).toBeUndefined();
   }).pipe(logLevel),
+);
+
+/**
+ * Regression test for #1243 — producer and consumer split across two
+ * Workers, so the consuming Worker has no producer binding and learns its
+ * queue's name only from the `DedicatedQueue_queueName` env binding.
+ *
+ * Before the `packEnvValue` fix, that binding deployed as the JSON-packed
+ * `"the-name"` (quote characters on the wire): the raw-binding assertion
+ * below failed, and any consumer of the raw value — including the
+ * reporter's — could never match Cloudflare's bare `MessageBatch.queue`.
+ * The test pins both halves: the binding is the bare name, and the
+ * handler receives the message end-to-end.
+ */
+test.provider.skipIf(!!process.env.FAST)(
+  "dedicated consumer worker deploys a bare queue-name binding and receives messages",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const out = yield* stack.deploy(
+        Effect.gen(function* () {
+          const producer = yield* ProducerWorker;
+          const consumer = yield* ConsumerWorker;
+          return {
+            producer: producer.url.as<string>(),
+            consumer: consumer.url.as<string>(),
+          };
+        }),
+      );
+
+      const client = yield* HttpClient.HttpClient;
+      // Fresh workers.dev URLs 404 for a few seconds; retry through it.
+      const get = (url: string) =>
+        client.get(url).pipe(
+          Effect.flatMap((res) =>
+            res.status < 300
+              ? Effect.succeed(res)
+              : Effect.fail(new Error(`Worker not ready: ${res.status}`)),
+          ),
+          Effect.retry({
+            schedule: Schedule.max([
+              Schedule.min([
+                Schedule.exponential("500 millis"),
+                Schedule.spaced("3 seconds"),
+              ]),
+              Schedule.recurs(30),
+            ]),
+          }),
+          Effect.orDie,
+        );
+
+      // The raw env binding is the bare queue name — no quote characters
+      // on the wire (#1243: it deployed as `"the-name"`).
+      const binding = (yield* (yield* get(`${out.consumer}/binding`)).json) as {
+        queueName: string;
+      };
+      expect(binding.queueName).not.toMatch(/^"/);
+      expect(binding.queueName).toMatch(/queue/);
+
+      yield* get(`${out.producer}/send?text=dedicated`);
+
+      const received = yield* get(`${out.consumer}/received`).pipe(
+        Effect.flatMap((res) => res.json),
+        Effect.map((body) => (body as { bodies?: string[] })?.bodies ?? []),
+        Effect.repeat({
+          schedule: Schedule.spaced("2 seconds"),
+          until: (bodies) => bodies.includes("dedicated"),
+          times: 45,
+        }),
+        Effect.orDie,
+      );
+      expect(received).toContain("dedicated");
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 300_000 },
 );

--- a/packages/alchemy/test/Cloudflare/Queue/fixtures/dedicated-consumer-queue.ts
+++ b/packages/alchemy/test/Cloudflare/Queue/fixtures/dedicated-consumer-queue.ts
@@ -1,0 +1,8 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+
+/**
+ * The queue shared by the dedicated producer and consumer Workers of
+ * `DedicatedConsumer.test.ts`. Declared in its own module so each Worker
+ * fixture stays a single-default-export `main` bundle.
+ */
+export const DedicatedQueue = Cloudflare.Queues.Queue("DedicatedQueue");

--- a/packages/alchemy/test/Cloudflare/Queue/fixtures/dedicated-consumer-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Queue/fixtures/dedicated-consumer-worker.ts
@@ -1,0 +1,71 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Effect from "effect/Effect";
+import * as Stream from "effect/Stream";
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import { DedicatedQueue } from "./dedicated-consumer-queue.ts";
+
+/** Records the bodies the queue handler observed, so the test can poll them. */
+export class Inbox extends Cloudflare.DurableObject<Inbox>()(
+  "DedicatedInbox",
+  Effect.gen(function* () {
+    return Effect.gen(function* () {
+      const state = yield* Cloudflare.DurableObjectState;
+      const bodies = (yield* state.storage.get<string[]>("bodies")) ?? [];
+      return {
+        record: Effect.fn(function* (body: string) {
+          bodies.push(body);
+          yield* state.storage.put("bodies", bodies);
+        }),
+        snapshot: () => Effect.succeed({ bodies }),
+      };
+    });
+  }),
+) {}
+
+/**
+ * A Worker that ONLY consumes — it never binds the queue as a producer, so
+ * the queue's name reaches it exclusively through the
+ * `DedicatedQueue_queueName` env binding that `consumeQueueMessages` reads
+ * to scope its handler. This is the topology of #1243.
+ *
+ * `GET /binding` returns that binding RAW from `WorkerEnvironment` (not
+ * through the unpacking `ctx.get` accessor) so the test can pin the wire
+ * format Cloudflare actually stores.
+ */
+export default class ConsumerWorker extends Cloudflare.Worker<ConsumerWorker>()(
+  "dedicated-consumer-worker",
+  { main: import.meta.url },
+  Effect.gen(function* () {
+    const inbox = yield* Inbox;
+    const queue = yield* DedicatedQueue;
+    const env = yield* Cloudflare.WorkerEnvironment;
+
+    yield* Cloudflare.Queues.consumeQueueMessages<{ text: string }>(
+      queue,
+      (stream) =>
+        Stream.runForEach(stream, (msg) =>
+          inbox.getByName("default").record(msg.body.text),
+        ),
+    );
+
+    return {
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        const url = new URL(request.url, "http://x");
+        if (url.pathname === "/binding") {
+          return yield* HttpServerResponse.json({
+            queueName: (env as Record<string, unknown>)
+              .DedicatedQueue_queueName,
+          });
+        }
+        if (url.pathname === "/received") {
+          return yield* HttpServerResponse.json(
+            yield* inbox.getByName("default").snapshot(),
+          );
+        }
+        return HttpServerResponse.text("Not Found", { status: 404 });
+      }),
+    };
+  }).pipe(Effect.provide(Cloudflare.Queues.EventSourceLive)),
+) {}

--- a/packages/alchemy/test/Cloudflare/Queue/fixtures/dedicated-producer-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Queue/fixtures/dedicated-producer-worker.ts
@@ -1,0 +1,30 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Effect from "effect/Effect";
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import { DedicatedQueue } from "./dedicated-consumer-queue.ts";
+
+/** Produces to the queue consumed by `dedicated-consumer-worker.ts`. */
+export default class ProducerWorker extends Cloudflare.Worker<ProducerWorker>()(
+  "dedicated-producer-worker",
+  { main: import.meta.url },
+  Effect.gen(function* () {
+    const queue = yield* Cloudflare.Queues.WriteQueue(yield* DedicatedQueue);
+    return {
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        const url = new URL(request.url, "http://x");
+        if (url.pathname === "/send") {
+          yield* queue
+            .send({ text: url.searchParams.get("text") ?? "hello" })
+            .pipe(Effect.orDie);
+          return yield* HttpServerResponse.json(
+            { sent: true },
+            { status: 202 },
+          );
+        }
+        return HttpServerResponse.text("Not Found", { status: 404 });
+      }),
+    };
+  }).pipe(Effect.provide(Cloudflare.Queues.WriteQueueBinding)),
+) {}

--- a/packages/alchemy/test/RuntimeContext.test.ts
+++ b/packages/alchemy/test/RuntimeContext.test.ts
@@ -1,0 +1,84 @@
+import {
+  packEnvValue,
+  packEnvValueKeepRedacted,
+  unpackEnvValue,
+} from "@/RuntimeContext.ts";
+import { describe, expect, it } from "alchemy-test";
+import * as Redacted from "effect/Redacted";
+
+describe("packEnvValue / unpackEnvValue", () => {
+  it("stores a plain string verbatim (no quote characters on the wire)", () => {
+    // #1243: a queue name must reach the env binding bare so raw readers
+    // (dashboard, MessageBatch.queue comparisons) see the real name.
+    expect(packEnvValue("my-queue")).toBe("my-queue");
+    expect(packEnvValue("https://example.com/a?b=c")).toBe(
+      "https://example.com/a?b=c",
+    );
+  });
+
+  it("keeps ambiguous strings packed so the read side can't reinterpret them", () => {
+    // These would JSON.parse into a different value if stored bare.
+    for (const s of [
+      "123",
+      "-4.5",
+      "null",
+      "true",
+      '"quoted"',
+      '{"a":1}',
+      "[1]",
+    ]) {
+      expect(packEnvValue(s)).toBe(JSON.stringify(s));
+      expect(unpackEnvValue(packEnvValue(s))).toBe(s);
+    }
+  });
+
+  it("round-trips every string exactly", () => {
+    for (const s of [
+      "my-queue",
+      "",
+      " ",
+      "123",
+      "null",
+      "Infinity",
+      '"unterminated',
+      "{not json",
+      "line\nbreak",
+    ]) {
+      expect(unpackEnvValue(packEnvValue(s))).toBe(s);
+    }
+  });
+
+  it("round-trips non-string JSON values", () => {
+    expect(unpackEnvValue(packEnvValue(8080))).toBe(8080);
+    expect(unpackEnvValue(packEnvValue(true))).toBe(true);
+    expect(unpackEnvValue(packEnvValue({ a: [1, "x"] }))).toEqual({
+      a: [1, "x"],
+    });
+  });
+
+  it("round-trips Redacted through the marker", () => {
+    const out = unpackEnvValue<Redacted.Redacted<string>>(
+      packEnvValue(Redacted.make("s3cret")),
+    );
+    expect(Redacted.isRedacted(out)).toBe(true);
+    expect(Redacted.value(out!)).toBe("s3cret");
+  });
+
+  it("packEnvValueKeepRedacted keeps the wrapper outside the packed string", () => {
+    const packed = packEnvValueKeepRedacted(Redacted.make("s3cret"));
+    expect(Redacted.isRedacted(packed)).toBe(true);
+    const inner = Redacted.value(packed as Redacted.Redacted<string>);
+    const out = unpackEnvValue<Redacted.Redacted<string>>(inner);
+    expect(Redacted.isRedacted(out)).toBe(true);
+    expect(Redacted.value(out!)).toBe("s3cret");
+    // Non-Redacted values stay plain strings.
+    expect(packEnvValueKeepRedacted("my-queue")).toBe("my-queue");
+  });
+
+  it("unpackEnvValue passes through raw env vars a user set directly", () => {
+    expect(unpackEnvValue("my-queue")).toBe("my-queue");
+    expect(unpackEnvValue(undefined)).toBeUndefined();
+    // A user-set raw numeric env var still parses — unchanged behavior.
+    expect(unpackEnvValue("123")).toBe(123);
+  });
+});


### PR DESCRIPTION
Fixes #1243 at the source: env-bound strings no longer reach the wire JSON-quoted.

`RuntimeContext.packEnvValue` JSON-stringified **every** env-bound value, so a queue name landed in its `plain_text` binding as `"my-queue"` — quote characters included. The Effect runtime's `ctx.get` unpacks on read, but any consumer of the raw binding (the dashboard, a hand-written env read, a queue-name comparison against `MessageBatch.queue`) sees the quoted form and mismatches.

A plain string is now stored **verbatim** whenever `JSON.parse` would reject it — which is almost every real-world string:

```ts
export const packEnvValue = (value: unknown): string =>
  Redacted.isRedacted(value)
    ? JSON.stringify({ _tag: "Redacted", value: Redacted.value(value) })
    : typeof value === "string" && !parsesAsJson(value)
      ? value
      : JSON.stringify(value);
```

- `"my-queue"` → wire `my-queue` (bare)
- `"123"`, `"null"`, `'{"a":1}'` → still packed, so `unpackEnvValue`'s `JSON.parse` can't reinterpret them
- `Redacted` markers and non-string values unchanged

No read-side changes: `unpackEnvValue` (and `reifyEnvString`) already fall back to the raw string when `JSON.parse` fails, on every shipped runtime version — so bare values written by a new deploy read correctly under an old bundled runtime, and old packed values read correctly under the new one.

Verified live: the `${LogicalId}_queueName` binding deploys bare and the queue round-trip (producer → Cloudflare dispatch → `consumeQueueMessages` handler → DO) delivers. `test/Cloudflare/Queue`, `test/Cloudflare/Queues`, `WorkerEnv`, `Secret`, and `Server/Process` suites are green; `test/RuntimeContext.test.ts` pins the pack/unpack round-trip for every value shape.

### Regression test

The regression test in `test/Cloudflare/Queue/Queue.test.ts` deploys the issue's exact topology — a producer Worker and a consumer-only Worker whose queue name arrives solely through the `DedicatedQueue_queueName` env binding — reads that binding raw off `WorkerEnvironment`, and asserts it is the bare name before driving a message end-to-end through the DO-backed inbox. Verified red-without/green-with:

```
# with packEnvValue reverted to main
AssertionError: NOT: expected "\"cloudflare-queue-dedicatedconsumer-dedi…\"" to match /^"/
# with the fix
✓ dedicated consumer worker deploys a bare queue-name binding and receives messages (27.6s)
```
