### PR TITLE
fix(cloudflare): don't let the dev registry freeze when fs.watch fails

### DIFF
--- a/packages/alchemy/test/Cloudflare/Queues/ProducerServiceBinding.local.test.ts
+++ b/packages/alchemy/test/Cloudflare/Queues/ProducerServiceBinding.local.test.ts
@@ -1,0 +1,95 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Test from "@/Test/Alchemy";
+import { expect } from "alchemy-test";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+import * as Schedule from "effect/Schedule";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as pathe from "pathe";
+
+const { test } = Test.make({
+  providers: Cloudflare.providers(),
+  dev: true,
+});
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+class WorkerNotReady extends Data.TaggedError("WorkerNotReady")<{
+  status: number;
+}> {}
+
+const getReady = (url: string) =>
+  Effect.gen(function* () {
+    const client = yield* HttpClient.HttpClient;
+    return yield* client.get(url).pipe(
+      Effect.flatMap((res) =>
+        res.status === 200
+          ? Effect.succeed(res)
+          : Effect.fail(new WorkerNotReady({ status: res.status })),
+      ),
+      Effect.retry({
+        while: (error) => error instanceof WorkerNotReady,
+        schedule: Schedule.exponential("250 millis"),
+        times: 20,
+      }),
+    );
+  }).pipe(Effect.orDie);
+
+/**
+ * A producer binding for a queue nothing consumes makes the worker subscribe
+ * to the dev registry (it has to find whichever instance consumes the queue),
+ * which in turn gives it a registry-proxy service it would not otherwise
+ * have. That must not disturb how OTHER workers reach it: the caller's
+ * service binding resolves the target through the same registry.
+ *
+ * Both workers run in this process here, so this covers the in-process wiring
+ * only — the cross-process path (`alchemy dev` runs a Vite website's workerd
+ * in a child process) is pinned by the registry's own tests.
+ */
+test.provider(
+  "service binding reaches a worker that produces to an unconsumed queue",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const deployed = yield* stack.deploy(
+        Effect.gen(function* () {
+          const queue = yield* Cloudflare.Queues.Queue("ProducerOnlyQueue");
+          const target = yield* Cloudflare.Worker("producer-target", {
+            main: pathe.resolve(
+              import.meta.dirname,
+              "fixtures/producer-target-worker.ts",
+            ),
+            env: { QUEUE: queue },
+          });
+          const caller = yield* Cloudflare.Worker("producer-caller", {
+            main: pathe.resolve(
+              import.meta.dirname,
+              "fixtures/producer-caller-worker.ts",
+            ),
+            env: { BACKEND: target },
+          });
+          return { target, caller };
+        }),
+      );
+
+      expect(deployed.caller.url).toMatch(/^http:\/\/localhost:\d+$/);
+
+      const direct = yield* getReady(`${deployed.target.url}/ping`).pipe(
+        Effect.flatMap((res) => res.text),
+      );
+      expect(direct).toBe("pong from target");
+
+      const viaBinding = yield* getReady(
+        `${deployed.caller.url}/via-binding`,
+      ).pipe(Effect.flatMap((res) => res.text));
+      expect(viaBinding).toBe("200:pong from target");
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 120_000 },
+);

--- a/packages/alchemy/test/Cloudflare/Queues/fixtures/producer-caller-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Queues/fixtures/producer-caller-worker.ts
@@ -1,0 +1,18 @@
+/// <reference types="@cloudflare/workers-types" />
+
+/** Caller worker: forwards to the target through its service binding. */
+export default {
+  async fetch(request: Request, env: { BACKEND: Service }): Promise<Response> {
+    const url = new URL(request.url);
+    if (url.pathname === "/via-binding") {
+      try {
+        const res = await env.BACKEND.fetch(new Request("http://backend/ping"));
+        return new Response(`${res.status}:${await res.text()}`);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return new Response(`caller failed: ${message}`, { status: 500 });
+      }
+    }
+    return new Response("caller up");
+  },
+};

--- a/packages/alchemy/test/Cloudflare/Queues/fixtures/producer-target-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Queues/fixtures/producer-target-worker.ts
@@ -1,0 +1,20 @@
+/// <reference types="@cloudflare/workers-types" />
+
+/**
+ * Target worker: holds a queue PRODUCER binding for a queue nothing
+ * consumes, and serves plain HTTP. Reached both directly and through a
+ * caller's service binding.
+ */
+interface Env {
+  QUEUE: { send(body: unknown): Promise<void> };
+}
+
+export default {
+  fetch: async (request: Request, _env: Env) => {
+    const url = new URL(request.url);
+    if (url.pathname === "/ping") {
+      return new Response("pong from target");
+    }
+    return new Response("target up");
+  },
+};

--- a/packages/cloudflare-runtime/src/core/registry/Registry.ts
+++ b/packages/cloudflare-runtime/src/core/registry/Registry.ts
@@ -1,5 +1,6 @@
 import * as Context from "effect/Context";
 import * as DateTime from "effect/DateTime";
+import type * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
@@ -48,6 +49,20 @@ export class Registry extends Context.Service<
 >()("cloudflare-runtime/registry/Registry") {}
 
 const STALE_AFTER_MS = 300_000;
+
+/**
+ * How often the registry re-reads its directory when a filesystem watcher is
+ * running. The watcher is the fast path; this is the safety net for the
+ * events it drops.
+ */
+const WATCHED_POLL_INTERVAL = "1 second";
+
+/**
+ * How often the registry re-reads its directory when no watcher is running
+ * (Windows, or a watcher that died) — the only discovery signal, so it runs
+ * hot.
+ */
+const UNWATCHED_POLL_INTERVAL = "100 millis";
 
 export const RegistryLive = Layer.effect(
   Registry,
@@ -115,11 +130,21 @@ export const RegistryLive = Layer.effect(
     const refresh = readAll.pipe(
       Effect.flatMap((newValue) => SubscriptionRef.set(ref, newValue)),
       updateLock.withPermits(1),
+      // A snapshot that fails (the directory was removed out from under us,
+      // a transient EMFILE, ...) must not tear down the refresh loop — the
+      // next tick reads again.
+      Effect.catchCause((cause) =>
+        Effect.logDebug("Failed to refresh the registry", cause),
+      ),
     );
+
+    const poll = (interval: Duration.Input) =>
+      Stream.fromEffect(refresh).pipe(Stream.repeat(Schedule.spaced(interval)));
 
     // The `fileSystemSupportsWatcher` flag is set to false on Windows and true everywhere else.
     // The flag can be overridden using a ConfigProvider, e.g. for testing.
-    // If the watcher is not supported, we fall back to polling every 100ms.
+    // Without a watcher, polling is the only discovery signal; with one, it
+    // still runs underneath as a safety net (see the comments below).
     yield* (
       (yield* System.fileSystemSupportsWatcher)
         ? fs.watch(directory).pipe(
@@ -130,8 +155,27 @@ export const RegistryLive = Layer.effect(
             // watcher-triggered read cannot be overwritten by an older one.
             Stream.merge(Stream.succeed(undefined)),
             Stream.mapEffect(() => refresh),
+            Stream.catchCause((cause) =>
+              // The watcher died (inotify limits, an unmounted directory).
+              // Polling is now the only signal, so switch to the unwatched
+              // rate rather than leaving the registry frozen.
+              Stream.fromEffect(
+                Effect.logDebug(
+                  "The registry filesystem watcher stopped; polling instead",
+                  cause,
+                ),
+              ).pipe(Stream.merge(poll(UNWATCHED_POLL_INTERVAL))),
+            ),
+            // `fs.watch` is best-effort even while it is alive: virtualised
+            // and network filesystems (WSL drive mounts, containers, NFS)
+            // drop events. A registry that stops seeing writes is invisible
+            // — a worker in one process never learns that a worker in
+            // another process came up, and its service bindings answer
+            // "worker not found" for the rest of the session — so keep a
+            // slow poll running underneath as a safety net.
+            Stream.merge(poll(WATCHED_POLL_INTERVAL)),
           )
-        : Stream.fromEffect(refresh).pipe(Stream.repeat(Schedule.spaced(100)))
+        : poll(UNWATCHED_POLL_INTERVAL)
     ).pipe(Stream.runDrain, Effect.forkScoped);
 
     return Registry.of({
@@ -142,7 +186,14 @@ export const RegistryLive = Layer.effect(
       subscribe: (subscribers) =>
         SubscriptionRef.changes(ref).pipe(
           Stream.map(pickSubscriberServices(subscribers)),
-          Stream.changes,
+          // Compare by value, not by reference: every snapshot builds a fresh
+          // map, and the ref is re-set on each poll tick and each heartbeat
+          // `utimes`, so `Stream.changes` (reference equality on plain
+          // objects) would report a change every time and push an identical
+          // target map to every subscriber's proxy.
+          Stream.changesWith(
+            (left, right) => JSON.stringify(left) === JSON.stringify(right),
+          ),
         ),
       write: (entry) => {
         const entryPath = path.join(

--- a/packages/cloudflare-runtime/src/core/registry/Registry.ts
+++ b/packages/cloudflare-runtime/src/core/registry/Registry.ts
@@ -1,3 +1,4 @@
+import type * as Cause from "effect/Cause";
 import * as Context from "effect/Context";
 import * as DateTime from "effect/DateTime";
 import type * as Duration from "effect/Duration";
@@ -141,6 +142,19 @@ export const RegistryLive = Layer.effect(
     const poll = (interval: Duration.Input) =>
       Stream.fromEffect(refresh).pipe(Stream.repeat(Schedule.spaced(interval)));
 
+    // The watcher stopped delivering events, so polling is the only signal
+    // left — switch to the unwatched rate. A registry that stops refreshing
+    // is otherwise invisible: a worker in one process never learns that a
+    // worker in another process came up, and its service bindings answer
+    // "worker not found" for the rest of the session.
+    const watcherStopped = (reason: string, cause?: Cause.Cause<unknown>) =>
+      Stream.fromEffect(
+        Effect.logDebug(
+          `The registry filesystem watcher ${reason}; polling instead`,
+          cause,
+        ),
+      ).pipe(Stream.merge(poll(UNWATCHED_POLL_INTERVAL)));
+
     // The `fileSystemSupportsWatcher` flag is set to false on Windows and true everywhere else.
     // The flag can be overridden using a ConfigProvider, e.g. for testing.
     // Without a watcher, polling is the only discovery signal; with one, it
@@ -155,24 +169,17 @@ export const RegistryLive = Layer.effect(
             // watcher-triggered read cannot be overwritten by an older one.
             Stream.merge(Stream.succeed(undefined)),
             Stream.mapEffect(() => refresh),
-            Stream.catchCause((cause) =>
-              // The watcher died (inotify limits, an unmounted directory).
-              // Polling is now the only signal, so switch to the unwatched
-              // rate rather than leaving the registry frozen.
-              Stream.fromEffect(
-                Effect.logDebug(
-                  "The registry filesystem watcher stopped; polling instead",
-                  cause,
-                ),
-              ).pipe(Stream.merge(poll(UNWATCHED_POLL_INTERVAL))),
-            ),
-            // `fs.watch` is best-effort even while it is alive: virtualised
-            // and network filesystems (WSL drive mounts, containers, NFS)
-            // drop events. A registry that stops seeing writes is invisible
-            // — a worker in one process never learns that a worker in
-            // another process came up, and its service bindings answer
-            // "worker not found" for the rest of the session — so keep a
-            // slow poll running underneath as a safety net.
+            // An `fs.watch` handle that closes ENDS this stream rather than
+            // failing it, so a dead watcher is indistinguishable from an idle
+            // one: `runDrain` completes, the forked fiber retires, and the
+            // registry silently stops refreshing. That is the shape of the
+            // freeze, not just the error case below.
+            Stream.concat(Stream.suspend(() => watcherStopped("ended"))),
+            Stream.catchCause((cause) => watcherStopped("failed", cause)),
+            // `fs.watch` is best-effort even while it is alive: platforms and
+            // filesystems differ in which events they deliver, and some drop
+            // them under load. Keep a slow poll running underneath so
+            // discovery is eventually consistent whatever the watcher does.
             Stream.merge(poll(WATCHED_POLL_INTERVAL)),
           )
         : poll(UNWATCHED_POLL_INTERVAL)

--- a/packages/cloudflare-runtime/src/core/registry/RegistryProxy.ts
+++ b/packages/cloudflare-runtime/src/core/registry/RegistryProxy.ts
@@ -1,6 +1,7 @@
 import { loadInternalWorker } from "../internal/internal-worker.ts";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
 import * as HttpBody from "effect/unstable/http/HttpBody";
 import * as HttpClient from "effect/unstable/http/HttpClient";
@@ -169,9 +170,29 @@ export const RegistryProxyLive = Layer.effect(
                   }
                   yield* registry.subscribe(subscribed).pipe(
                     Stream.runForEach((targets) =>
-                      http.post(`http://127.0.0.1:${proxyPort}/`, {
-                        body: HttpBody.jsonUnsafe(targets),
-                      }),
+                      http
+                        .post(`http://127.0.0.1:${proxyPort}/`, {
+                          body: HttpBody.jsonUnsafe(targets),
+                        })
+                        .pipe(
+                          Effect.retry({
+                            schedule: Schedule.exponential("50 millis"),
+                            times: 5,
+                          }),
+                          // A push that still fails must NOT kill the
+                          // subscription: this fiber is the only thing that
+                          // keeps the proxy's target map current, and a dead
+                          // one freezes this worker's view of every other
+                          // worker for the rest of the session. Each push
+                          // carries the full map, so the next registry change
+                          // recovers whatever this one dropped.
+                          Effect.catchCause((cause) =>
+                            Effect.logDebug(
+                              "Failed to push registry targets to the proxy",
+                              cause,
+                            ),
+                          ),
+                        ),
                     ),
                     Effect.forkScoped,
                   );

--- a/packages/cloudflare-runtime/src/core/test/registry/Registry.test.ts
+++ b/packages/cloudflare-runtime/src/core/test/registry/Registry.test.ts
@@ -235,14 +235,17 @@ describe.each(watcherModes)(
   },
 );
 
-// The filesystem watcher is best-effort: `fs.watch` fails outright when the
-// platform runs out of watches (inotify limits on Linux/WSL) or the directory
-// is unmounted, and it silently drops events on virtualised and network
-// filesystems. A registry that stops refreshing is invisible — a worker in one
-// process never learns that a worker in another process came up, and its
-// service bindings answer "worker not found" for the rest of the session — so
-// discovery must not depend on the watcher alone.
-describe("Registry (broken filesystem watcher)", () => {
+// The filesystem watcher is best-effort, and it stops in two shapes: the
+// stream FAILS (`fs.watch` rejected outright — inotify limits, an unmounted
+// directory) or it ENDS (the handle closed), which is indistinguishable from
+// an idle watcher. Either way a registry that stops refreshing is invisible —
+// a worker in one process never learns that a worker in another process came
+// up, and its service bindings answer "worker not found" for the rest of the
+// session — so discovery must not depend on the watcher alone.
+describe.each([
+  ["fails", () => Stream.die(new Error("inotify watch limit reached"))],
+  ["ends", () => Stream.empty],
+] as const)("Registry (watcher %s)", (label, watch) => {
   const services = Registry.RegistryLive.pipe(
     Layer.provideMerge(Paths.PathsLive),
     Layer.provide(configProvider({ fileSystemSupportsWatcher: true })),
@@ -250,10 +253,7 @@ describe("Registry (broken filesystem watcher)", () => {
       Layer.effect(
         FileSystem.FileSystem,
         Effect.map(FileSystem.FileSystem, (fs) =>
-          FileSystem.FileSystem.of({
-            ...fs,
-            watch: () => Stream.die(new Error("inotify watch limit reached")),
-          }),
+          FileSystem.FileSystem.of({ ...fs, watch }),
         ),
       ).pipe(Layer.provide(NodeServices.layer)),
     ),
@@ -267,7 +267,7 @@ describe("Registry (broken filesystem watcher)", () => {
       const directory = yield* Paths.state("alchemy", "registry");
       yield* Registry.Registry;
 
-      const scriptName = "test-worker-broken-watcher";
+      const scriptName = `test-worker-watcher-${label}`;
       // Another process registering a worker is just a file appearing in the
       // directory — this registry never sees the `write` call, so a re-read of
       // the directory is the only way it can discover the entry.

--- a/packages/cloudflare-runtime/src/core/test/registry/Registry.test.ts
+++ b/packages/cloudflare-runtime/src/core/test/registry/Registry.test.ts
@@ -235,6 +235,54 @@ describe.each(watcherModes)(
   },
 );
 
+// The filesystem watcher is best-effort: `fs.watch` fails outright when the
+// platform runs out of watches (inotify limits on Linux/WSL) or the directory
+// is unmounted, and it silently drops events on virtualised and network
+// filesystems. A registry that stops refreshing is invisible — a worker in one
+// process never learns that a worker in another process came up, and its
+// service bindings answer "worker not found" for the rest of the session — so
+// discovery must not depend on the watcher alone.
+describe("Registry (broken filesystem watcher)", () => {
+  const services = Registry.RegistryLive.pipe(
+    Layer.provideMerge(Paths.PathsLive),
+    Layer.provide(configProvider({ fileSystemSupportsWatcher: true })),
+    Layer.provideMerge(
+      Layer.effect(
+        FileSystem.FileSystem,
+        Effect.map(FileSystem.FileSystem, (fs) =>
+          FileSystem.FileSystem.of({
+            ...fs,
+            watch: () => Stream.die(new Error("inotify watch limit reached")),
+          }),
+        ),
+      ).pipe(Layer.provide(NodeServices.layer)),
+    ),
+    Layer.provideMerge(NodeServices.layer),
+  );
+
+  it.live("resolves entries registered by another process", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const directory = yield* Paths.state("alchemy", "registry");
+      yield* Registry.Registry;
+
+      const scriptName = "test-worker-broken-watcher";
+      // Another process registering a worker is just a file appearing in the
+      // directory — this registry never sees the `write` call, so a re-read of
+      // the directory is the only way it can discover the entry.
+      yield* fs.writeFileString(
+        path.join(directory, `${scriptName}.json`),
+        JSON.stringify(registryEntry(scriptName)),
+      );
+
+      yield* waitForRegistryEntry(subscriberEntry(scriptName), {
+        toBeDefined: true,
+      }).pipe(Effect.timeout("10 seconds"));
+    }).pipe(Effect.provide(services)),
+  );
+});
+
 const registryEntry = (scriptName: string): RegistryEntry => ({
   scriptName,
   debugPortAddress: "127.0.0.1:12345",


### PR DESCRIPTION
Fixes a user report ([repro](https://github.com/LordCoughmann/alchemy-writequeue-binding-repro)) where adding a Queue producer binding to a Worker made a `Website.Vite` Worker's service binding to it fail with `503 Worker "<backend>" not found`, while direct requests to the same Worker kept working. Confirmed fixed by the reporter on both the minimal repro and their real app.

`alchemy dev` runs a Vite website's workerd in a **different process** from a plain Worker's, so the two find each other only through the on-disk dev registry (`~/.local/state/alchemy/registry`). Each process refreshed its in-memory view of that directory from `fs.watch` alone — one snapshot at startup, then watcher events forever after:

```ts
// Registry.ts, before
yield* (
  supportsWatcher
    ? fs.watch(directory).pipe(/* … */, Stream.mapEffect(() => refresh))
    : Stream.fromEffect(refresh).pipe(Stream.repeat(Schedule.spaced(100)))
).pipe(Stream.runDrain, Effect.forkScoped)
```

That single signal is load-bearing and it can stop in two shapes. It can **fail**, and it can **end** — a closed `fs.watch` handle calls `Queue.endUnsafe`, so the stream completes normally, `runDrain` returns, the forked fiber retires, and the registry stops refreshing with nothing logged and no error anywhere. From the outside the two are identical: the website's frozen snapshot never gains the backend, and its service binding answers "not found" for the rest of the session.

The Queue is only the trigger. A producer binding for a queue **nothing consumes** makes the Worker subscribe to the registry for a `queue-consumer` target, which is what gives it a registry-proxy worker to build and boot before it registers itself. That pushes its registration past the website's snapshot. Without the queue it registers earlier, the snapshot happens to contain it, and everything looks fine.

### The fix

- Poll the registry directory (1s) as a safety net alongside the watcher, and drop to the unwatched rate (100ms) if the watcher stops — whether it failed or ended.
- Log which of the two happened, so a frozen registry is diagnosable next time instead of silent.
- Don't let a failed snapshot or a failed target-map push tear down the loops that keep discovery current — each push carries the full map, so the next change recovers whatever one dropped.
- `subscribe` dedupes by value, so polling doesn't push identical target maps to every proxy.

```ts
// Registry.ts, after
fs.watch(directory).pipe(
  /* … */,
  Stream.concat(Stream.suspend(() => watcherStopped("ended"))),
  Stream.catchCause((cause) => watcherStopped("failed", cause)),
  Stream.merge(poll(WATCHED_POLL_INTERVAL)),
)
```

`Registry (watcher fails)` / `Registry (watcher ends)` inject a `FileSystem` whose `watch` does each, then register a worker the way another process does (a file appearing in the directory). Both time out before this change and pass after.

### On the root cause

Worth being straight about what is and isn't established. This change is verified against the failure *mode*, by injecting a stopped watcher — I never reproduced the reporter's environment. Their repro runs clean on macOS at `2.0.0-beta.72`, which is why the Queue looked like the culprit rather than the timing shift it causes.

The reporter has since ruled out both environmental guesses in the original version of this description: their project is on the native WSL filesystem, not `/mnt/c`, and their inotify limits are healthy (`max_user_watches: 524288`, `max_user_instances: 128`, and raising the latter changes nothing). So **why** their watcher stops delivering is still unknown — the "ends" path above is the leading candidate precisely because it needs no error and leaves no trace. The fix stands either way: a registry whose only refresh signal is a best-effort watcher is wrong regardless of which platform quirk trips it.

### For @LordCoughmann, if you're up for one more datapoint

This would tell us whether `fs.watch` delivers events at all on your box. Save as `watch-probe.mjs`, run `node watch-probe.mjs` in WSL:

```js
import fs from "node:fs";
import os from "node:os";
import path from "node:path";

const dir = process.env.XDG_STATE_HOME
  ? path.join(process.env.XDG_STATE_HOME, "alchemy", "registry")
  : path.join(os.homedir(), ".local", "state", "alchemy", "registry");
fs.mkdirSync(dir, { recursive: true });
console.log("watching", dir);

let events = 0;
const w = fs.watch(dir, (event, name) => {
  events++;
  console.log("event:", event, name);
});
w.on("error", (e) => console.log("WATCHER ERROR:", e.message));
w.on("close", () => console.log("WATCHER CLOSED"));

const probe = path.join(dir, "watch-probe.json");
setTimeout(() => fs.writeFileSync(probe, "{}"), 500);
setTimeout(() => fs.writeFileSync(probe, '{"n":2}'), 1500);
setTimeout(() => {
  fs.rmSync(probe, { force: true });
  w.close();
  console.log(events > 0 ? `OK: ${events} events` : "BROKEN: 0 events delivered");
  process.exit(events > 0 ? 0 : 1);
}, 3000);
```

`BROKEN: 0 events` or a `WATCHER CLOSED` before the end confirms it. `OK: 2 events` means the watcher is fine in isolation and something in the dev session is stopping it — also useful to know, and a reason to look elsewhere. Either result is a real answer; no rush, the fix doesn't depend on it.
