### PR TITLE
feat(cloudflare/dns): support structured record data

### DIFF
--- a/packages/alchemy/src/Cloudflare/DNS/Record.ts
+++ b/packages/alchemy/src/Cloudflare/DNS/Record.ts
@@ -41,7 +41,15 @@ export type RecordType =
   | "URI"
   | (string & {});
 
-export interface RecordProps {
+/**
+ * Structured DNS record components accepted by Cloudflare.
+ *
+ * The applicable fields depend on the record {@link RecordType}. For example,
+ * `SVCB` and `HTTPS` records use `priority`, `target`, and `value`.
+ */
+export type RecordData = NonNullable<dns.CreateRecordRequest["data"]>;
+
+export interface RecordCommonProps {
   /**
    * Zone the record lives in. Stable — changing the zone triggers
    * replacement.
@@ -64,13 +72,6 @@ export interface RecordProps {
    * `diff` can compare without resolving an `Input`.
    */
   type: RecordType;
-  /**
-   * Record value. Interpretation depends on `type` — an A record's
-   * content is an IPv4, a CNAME's is a target hostname, etc.
-   *
-   * Mutable — patched in place.
-   */
-  content: string;
   /**
    * TTL in seconds (`60`–`86400`), or `"1"` for Cloudflare's "automatic"
    * setting. Must be `"1"` when `proxied` is `true`.
@@ -95,10 +96,41 @@ export interface RecordProps {
    */
   tags?: ReadonlyArray<string>;
   /**
-   * Priority — required for `MX` and `URI` records, ignored for others.
+   * Priority — required for `MX` and `URI` records. For structured record
+   * types such as `SVCB` and `HTTPS`, set `priority` inside {@link RecordData}.
    */
   priority?: number;
 }
+
+/**
+ * Input properties for a Cloudflare DNS record.
+ *
+ * Supply either a formatted `content` string or Cloudflare's structured
+ * `data` components. The two representations are mutually exclusive.
+ */
+export type RecordProps = RecordCommonProps &
+  (
+    | {
+        /**
+         * Formatted record value. Interpretation depends on `type` — an A
+         * record's content is an IPv4, a CNAME's is a target hostname, etc.
+         *
+         * Mutable — patched in place.
+         */
+        content: string;
+        data?: never;
+      }
+    | {
+        content?: never;
+        /**
+         * Structured record components. Required for record types such as
+         * `SVCB` and `HTTPS`, whose fields Cloudflare validates individually.
+         *
+         * Mutable — patched in place.
+         */
+        data: RecordData;
+      }
+  );
 
 export interface RecordAttributes {
   /** Cloudflare-assigned DNS record UUID. */
@@ -109,8 +141,10 @@ export interface RecordAttributes {
   name: string;
   /** Record type. */
   type: RecordType;
-  /** Resolved record value. */
-  content: string;
+  /** Formatted record value, when Cloudflare returns one. */
+  content: string | undefined;
+  /** Structured record components, when Cloudflare returns them. */
+  data: RecordData | undefined;
   /** Resolved TTL (Cloudflare echoes `1` for "automatic"). */
   ttl: number;
   /** Whether the record is proxied. */
@@ -173,6 +207,35 @@ export type Record = Resource<
  *   type: "A",
  *   content: "203.0.113.42",
  *   ttl: 300,
+ * });
+ * ```
+ *
+ * @section Structured service binding records
+ * @example SVCB record
+ * ```typescript
+ * yield* Cloudflare.DNS.Record("McpSvcb", {
+ *   zoneId: zone.zoneId,
+ *   name: "_mcp._agents.example.com",
+ *   type: "SVCB",
+ *   data: {
+ *     priority: 1,
+ *     target: "mcp.example.com.",
+ *     value: 'mandatory=alpn,port alpn="h2,h3" port="443"',
+ *   },
+ * });
+ * ```
+ *
+ * @example HTTPS record
+ * ```typescript
+ * yield* Cloudflare.DNS.Record("WebsiteHttps", {
+ *   zoneId: zone.zoneId,
+ *   name: "example.com",
+ *   type: "HTTPS",
+ *   data: {
+ *     priority: 1,
+ *     target: ".",
+ *     value: 'alpn="h2,h3"',
+ *   },
  * });
  * ```
  */
@@ -241,8 +304,7 @@ export const RecordProvider = () =>
     reconcile: Effect.fn(function* ({ news, output }) {
       // Inputs have been resolved to concrete strings by Plan.
       const zoneId = news.zoneId as string;
-      const content = news.content as string;
-      const body = buildMutableBody(news, content);
+      const body = buildMutableBody(news);
 
       // 1. Observe by cached id first.
       let observed: ObservedRecord | undefined;
@@ -274,6 +336,7 @@ export const RecordProvider = () =>
             name: body.name,
             type: body.type,
             content: body.content,
+            data: body.data,
             ttl: body.ttl,
             proxied: body.proxied,
             comment: body.comment,
@@ -340,6 +403,7 @@ export const RecordProvider = () =>
             name: body.name,
             type: body.type,
             content: body.content,
+            data: body.data,
             ttl: body.ttl,
             proxied: body.proxied,
             comment: body.comment,
@@ -356,12 +420,12 @@ export const RecordProvider = () =>
       if (
         !observed.id ||
         !observed.type ||
-        observed.content === undefined ||
+        (observed.content === undefined && observed.data === undefined) ||
         observed.ttl === undefined
       ) {
         return yield* Effect.fail(
           new Error(
-            "Cloudflare returned a DNS record without id/type/content/ttl",
+            "Cloudflare returned a DNS record without id/type/value/ttl",
           ),
         );
       }
@@ -371,6 +435,7 @@ export const RecordProvider = () =>
         name: observed.name ?? body.name,
         type: observed.type,
         content: observed.content,
+        data: observed.data,
         ttl: observed.ttl,
         proxied: observed.proxied ?? false,
         createdOn: observed.createdOn,
@@ -560,6 +625,7 @@ interface ObservedRecord {
   readonly comment?: string;
   readonly tags?: ReadonlyArray<string>;
   readonly priority?: number;
+  readonly data?: RecordData;
   readonly createdOn?: string;
   readonly modifiedOn?: string;
 }
@@ -577,6 +643,7 @@ const narrowRecord = (raw: {
   comment?: string | null;
   tags?: ReadonlyArray<string> | null;
   priority?: number | null;
+  data?: Readonly<{ [key: string]: unknown }> | null;
   createdOn?: string | null;
   modifiedOn?: string | null;
 }): ObservedRecord => ({
@@ -589,6 +656,7 @@ const narrowRecord = (raw: {
   comment: undef(raw.comment),
   tags: raw.tags == null ? undefined : (raw.tags as ReadonlyArray<string>),
   priority: undef(raw.priority),
+  data: normalizeRecordData(raw.data),
   createdOn: undef(raw.createdOn),
   modifiedOn: undef(raw.modifiedOn),
 });
@@ -601,7 +669,7 @@ const toAttributes = (
     !observed?.id ||
     !observed.name ||
     !observed.type ||
-    observed.content === undefined ||
+    (observed.content === undefined && observed.data === undefined) ||
     observed.ttl === undefined
   ) {
     return undefined;
@@ -612,6 +680,7 @@ const toAttributes = (
     name: observed.name,
     type: observed.type,
     content: observed.content,
+    data: observed.data,
     ttl: observed.ttl,
     proxied: observed.proxied ?? false,
     createdOn: observed.createdOn,
@@ -623,10 +692,9 @@ const toAttributes = (
 // Body construction
 // ---------------------------------------------------------------------------
 
-interface RecordMutableBody {
+interface RecordMutableBodyCommon {
   name: string;
   type: RecordType;
-  content: string;
   ttl: number;
   proxied?: boolean;
   comment?: string;
@@ -634,26 +702,30 @@ interface RecordMutableBody {
   priority?: number;
 }
 
-const buildMutableBody = (
-  news: RecordProps,
-  resolvedContent: string,
-): RecordMutableBody => ({
-  name: news.name,
-  type: news.type,
-  content: resolvedContent,
-  // Cloudflare rejects the string `"1"` even though distilled types
-  // it as `number | "1"`; the API wants numeric 1 for "automatic".
-  ttl:
-    news.ttl === undefined
-      ? 1
-      : news.ttl === ("1" as unknown)
+type RecordMutableBody = RecordMutableBodyCommon &
+  ({ content: string; data?: never } | { content?: never; data: RecordData });
+
+const buildMutableBody = (news: RecordProps): RecordMutableBody => {
+  const common: RecordMutableBodyCommon = {
+    name: news.name,
+    type: news.type,
+    // Cloudflare rejects the string `"1"` even though distilled types
+    // it as `number | "1"`; the API wants numeric 1 for "automatic".
+    ttl:
+      news.ttl === undefined
         ? 1
-        : (news.ttl as number),
-  proxied: news.proxied,
-  comment: news.comment,
-  tags: news.tags,
-  priority: news.priority,
-});
+        : news.ttl === ("1" as unknown)
+          ? 1
+          : (news.ttl as number),
+    proxied: news.proxied,
+    comment: news.comment,
+    tags: news.tags,
+    priority: news.priority,
+  };
+  return news.data === undefined
+    ? { ...common, content: news.content }
+    : { ...common, data: news.data };
+};
 
 // ---------------------------------------------------------------------------
 // Drift detection
@@ -663,7 +735,15 @@ const bodyEqualsObserved = (
   desired: RecordMutableBody,
   observed: ObservedRecord,
 ): boolean => {
-  if (desired.content !== observed.content) return false;
+  if (desired.content !== undefined && desired.content !== observed.content) {
+    return false;
+  }
+  if (
+    desired.data !== undefined &&
+    !recordDataEquals(desired.data, observed.data)
+  ) {
+    return false;
+  }
   // CF echoes ttl=1 for "automatic".
   if (desired.ttl !== observed.ttl) return false;
   if (
@@ -691,4 +771,35 @@ const bodyEqualsObserved = (
     return false;
   }
   return true;
+};
+
+const normalizeRecordData = (
+  data: Readonly<{ [key: string]: unknown }> | null | undefined,
+): RecordData | undefined => {
+  if (data == null) return undefined;
+  return Object.fromEntries(
+    Object.entries(data).filter(([, value]) => value != null),
+  ) as RecordData;
+};
+
+const recordDataEquals = (
+  desired: RecordData,
+  observed: RecordData | undefined,
+): boolean => {
+  if (observed === undefined) return false;
+  const desiredEntries = Object.entries(desired).filter(
+    ([, value]) => value != null,
+  );
+  const observedEntries = Object.entries(observed).filter(
+    ([, value]) => value != null,
+  );
+  return (
+    desiredEntries.length === observedEntries.length &&
+    desiredEntries.every(([key, value]) =>
+      observedEntries.some(
+        ([observedKey, observedValue]) =>
+          observedKey === key && observedValue === value,
+      ),
+    )
+  );
 };

--- a/packages/alchemy/src/Cloudflare/DNS/Record.ts
+++ b/packages/alchemy/src/Cloudflare/DNS/Record.ts
@@ -42,12 +42,26 @@ export type RecordType =
   | (string & {});
 
 /**
- * Structured DNS record components accepted by Cloudflare.
- *
- * The applicable fields depend on the record {@link RecordType}. For example,
- * `SVCB` and `HTTPS` records use `priority`, `target`, and `value`.
+ * Cloudflare's structured DNS record components, keyed by record type.
  */
-export type RecordData = NonNullable<dns.CreateRecordRequest["data"]>;
+export interface RecordDataByType {
+  CAA: dns.RecordsCreateRequestDataCAARecord;
+  CERT: dns.RecordsCreateRequestDataCERTRecord;
+  DNSKEY: dns.RecordsCreateRequestDataDNSKEYRecord;
+  DS: dns.RecordsCreateRequestDataDSRecord;
+  HTTPS: dns.RecordsCreateRequestDataHTTPSRecord;
+  LOC: dns.RecordsCreateRequestDataLOCRecord;
+  NAPTR: dns.RecordsCreateRequestDataNAPTRRecord;
+  SMIMEA: dns.RecordsCreateRequestDataSMIMEARecord;
+  SRV: dns.RecordsCreateRequestDataSRVRecord;
+  SSHFP: dns.RecordsCreateRequestDataSSHFPRecord;
+  SVCB: dns.RecordsCreateRequestDataHTTPSRecord;
+  TLSA: dns.RecordsCreateRequestDataSMIMEARecord;
+  URI: dns.RecordsCreateRequestDataURIRecord;
+}
+
+/** Structured DNS record components accepted by Cloudflare. */
+export type RecordData = RecordDataByType[keyof RecordDataByType];
 
 export interface RecordCommonProps {
   /**
@@ -65,13 +79,6 @@ export interface RecordCommonProps {
    * `string`) so it is statically knowable inside `diff`.
    */
   name: string;
-  /**
-   * Record type. Stable — changing triggers replacement.
-   *
-   * Declared as plain `string` (narrowed to {@link RecordType}) so
-   * `diff` can compare without resolving an `Input`.
-   */
-  type: RecordType;
   /**
    * TTL in seconds (`60`–`86400`), or `"1"` for Cloudflare's "automatic"
    * setting. Must be `"1"` when `proxied` is `true`.
@@ -95,42 +102,47 @@ export interface RecordCommonProps {
    * Custom tags shown in the dashboard. No effect on DNS responses.
    */
   tags?: ReadonlyArray<string>;
-  /**
-   * Priority — required for `MX` and `URI` records. For structured record
-   * types such as `SVCB` and `HTTPS`, set `priority` inside {@link RecordData}.
-   */
+}
+
+type StringRecordType = Exclude<RecordType, keyof RecordDataByType | "MX">;
+
+type StringRecordProps = {
+  /** Record type. Stable — changing triggers replacement. */
+  type: StringRecordType;
+  /** Formatted record value. Mutable — patched in place. */
+  content: string;
+  priority?: never;
+};
+
+interface MxRecordProps {
+  /** Record type. Stable — changing triggers replacement. */
+  type: "MX";
+  /** Mail server hostname. Mutable — patched in place. */
+  content: string;
+  /** Mail server priority; lower values are preferred. */
   priority?: number;
 }
 
-/**
- * Input properties for a Cloudflare DNS record.
- *
- * Supply either a formatted `content` string or Cloudflare's structured
- * `data` components. The two representations are mutually exclusive.
- */
+type StructuredRecordProps = {
+  [Type in keyof RecordDataByType]: {
+    /** Record type. Stable — changing triggers replacement. */
+    type: Type;
+    /**
+     * Record value as formatted DNS content or typed Cloudflare components.
+     * Mutable — patched in place.
+     */
+    content: string | RecordDataByType[Type];
+    /**
+     * Top-level priority, used by URI records. SRV, SVCB, and HTTPS put their
+     * priority inside structured `content`.
+     */
+    priority?: Type extends "URI" ? number : never;
+  };
+}[keyof RecordDataByType];
+
+/** Input properties for a Cloudflare DNS record. */
 export type RecordProps = RecordCommonProps &
-  (
-    | {
-        /**
-         * Formatted record value. Interpretation depends on `type` — an A
-         * record's content is an IPv4, a CNAME's is a target hostname, etc.
-         *
-         * Mutable — patched in place.
-         */
-        content: string;
-        data?: never;
-      }
-    | {
-        content?: never;
-        /**
-         * Structured record components. Required for record types such as
-         * `SVCB` and `HTTPS`, whose fields Cloudflare validates individually.
-         *
-         * Mutable — patched in place.
-         */
-        data: RecordData;
-      }
-  );
+  (StringRecordProps | MxRecordProps | StructuredRecordProps);
 
 export interface RecordAttributes {
   /** Cloudflare-assigned DNS record UUID. */
@@ -141,10 +153,10 @@ export interface RecordAttributes {
   name: string;
   /** Record type. */
   type: RecordType;
-  /** Formatted record value, when Cloudflare returns one. */
-  content: string | undefined;
+  /** Formatted record value returned by Cloudflare. */
+  content: string;
   /** Structured record components, when Cloudflare returns them. */
-  data: RecordData | undefined;
+  data?: RecordData;
   /** Resolved TTL (Cloudflare echoes `1` for "automatic"). */
   ttl: number;
   /** Whether the record is proxied. */
@@ -217,10 +229,10 @@ export type Record = Resource<
  *   zoneId: zone.zoneId,
  *   name: "_mcp._agents.example.com",
  *   type: "SVCB",
- *   data: {
+ *   content: {
  *     priority: 1,
  *     target: "mcp.example.com.",
- *     value: 'mandatory=alpn,port alpn="h2,h3" port="443"',
+ *     value: 'mandatory="alpn,port" alpn="h2,h3" port="443"',
  *   },
  * });
  * ```
@@ -231,7 +243,7 @@ export type Record = Resource<
  *   zoneId: zone.zoneId,
  *   name: "example.com",
  *   type: "HTTPS",
- *   data: {
+ *   content: {
  *     priority: 1,
  *     target: ".",
  *     value: 'alpn="h2,h3"',
@@ -319,7 +331,8 @@ export const RecordProvider = () =>
       let foundByScan = false;
       if (!observed) {
         const existing = yield* findByNameType(zoneId, news.name, news.type, {
-          content,
+          content: body.content,
+          data: body.data,
           priority: news.priority,
         });
         if (existing) {
@@ -330,52 +343,40 @@ export const RecordProvider = () =>
 
       // 3. Ensure.
       if (!observed) {
-        const created = yield* dns
-          .createRecord({
-            zoneId,
-            name: body.name,
-            type: body.type,
-            content: body.content,
-            data: body.data,
-            ttl: body.ttl,
-            proxied: body.proxied,
-            comment: body.comment,
-            tags: body.tags === undefined ? undefined : Array.from(body.tags),
-            priority: body.priority,
-          })
-          .pipe(
-            Effect.map(
-              (r) =>
-                ({
-                  record: narrowRecord(r as Parameters<typeof narrowRecord>[0]),
-                  raced: false,
-                }) as const,
-            ),
-            // A record with this `(name, type)` can already exist that the
-            // scan above missed — a leftover from an interrupted run, or a
-            // concurrent reconcile that won the create race. Cloudflare
-            // answers `An identical record already exists.`
-            // (`DnsRecordAlreadyExists`). Self-heal: re-scan and adopt the
-            // existing record instead of failing the deploy. Ownership was
-            // already gated by `read`/the adopt policy upstream.
-            Effect.catchTag("DnsRecordAlreadyExists", () =>
-              findByNameType(zoneId, news.name, news.type, {
-                content,
-                priority: news.priority,
-              }).pipe(
-                Effect.flatMap((existing) =>
-                  existing
-                    ? Effect.succeed({ record: existing, raced: true } as const)
-                    : Effect.fail(
-                        new Error(
-                          `Cloudflare reported an identical DNS record for ` +
-                            `(${news.name}, ${news.type}) but it could not be found`,
-                        ),
+        const created = yield* dns.createRecord({ zoneId, ...body }).pipe(
+          Effect.map(
+            (r) =>
+              ({
+                record: narrowRecord(r as Parameters<typeof narrowRecord>[0]),
+                raced: false,
+              }) as const,
+          ),
+          // A record with this `(name, type)` can already exist that the
+          // scan above missed — a leftover from an interrupted run, or a
+          // concurrent reconcile that won the create race. Cloudflare
+          // answers `An identical record already exists.`
+          // (`DnsRecordAlreadyExists`). Self-heal: re-scan and adopt the
+          // existing record instead of failing the deploy. Ownership was
+          // already gated by `read`/the adopt policy upstream.
+          Effect.catchTag("DnsRecordAlreadyExists", () =>
+            findByNameType(zoneId, news.name, news.type, {
+              content: body.content,
+              data: body.data,
+              priority: news.priority,
+            }).pipe(
+              Effect.flatMap((existing) =>
+                existing
+                  ? Effect.succeed({ record: existing, raced: true } as const)
+                  : Effect.fail(
+                      new Error(
+                        `Cloudflare reported an identical DNS record for ` +
+                          `(${news.name}, ${news.type}) but it could not be found`,
                       ),
-                ),
+                    ),
               ),
             ),
-          );
+          ),
+        );
         observed = created.record;
         // A raced/adopted record is treated like a scanned-existing one so
         // the sync step converges its mutable fields; a genuine fresh create
@@ -400,15 +401,7 @@ export const RecordProvider = () =>
           const updated = yield* dns.updateRecord({
             zoneId,
             dnsRecordId: observed.id,
-            name: body.name,
-            type: body.type,
-            content: body.content,
-            data: body.data,
-            ttl: body.ttl,
-            proxied: body.proxied,
-            comment: body.comment,
-            tags: body.tags === undefined ? undefined : Array.from(body.tags),
-            priority: body.priority,
+            ...body,
           });
           observed = narrowRecord(
             updated as Parameters<typeof narrowRecord>[0],
@@ -420,7 +413,7 @@ export const RecordProvider = () =>
       if (
         !observed.id ||
         !observed.type ||
-        (observed.content === undefined && observed.data === undefined) ||
+        observed.content === undefined ||
         observed.ttl === undefined
       ) {
         return yield* Effect.fail(
@@ -472,7 +465,13 @@ export const RecordProvider = () =>
       const type = output?.type ?? olds?.type;
       if (zoneId && name && type) {
         const observed = yield* findByNameType(zoneId, name, type, {
-          content: olds?.content ?? output?.content,
+          content:
+            typeof olds?.content === "string"
+              ? olds.content
+              : olds?.content === undefined
+                ? output?.content
+                : undefined,
+          data: typeof olds?.content === "object" ? olds.content : output?.data,
           priority: olds?.priority,
         });
         const attrs = toAttributes(observed, zoneId);
@@ -501,12 +500,13 @@ const observeById = (zoneId: string, dnsRecordId: string) =>
  */
 interface RecordMatch {
   readonly content?: string;
+  readonly data?: RecordData;
   readonly priority?: number;
 }
 
 /**
  * Raised when several DNS records share `(name, type)` and the declared
- * `content`/`priority` do not select exactly one of them — adoption must
+ * `content`/`data`/`priority` do not select exactly one of them — adoption must
  * never pick a record arbitrarily.
  */
 export class AmbiguousDnsRecordError extends Data.TaggedError(
@@ -518,6 +518,7 @@ export class AmbiguousDnsRecordError extends Data.TaggedError(
   readonly candidates: ReadonlyArray<{
     readonly id?: string;
     readonly content?: string;
+    readonly data?: RecordData;
     readonly priority?: number;
   }>;
   readonly message: string;
@@ -531,7 +532,7 @@ export class AmbiguousDnsRecordError extends Data.TaggedError(
 // `(name, type)` alone is NOT a unique identity — several records may share
 // it. A single candidate is returned as-is (preserving the adopt-then-modify
 // flow where the desired content differs from the live record). With multiple
-// candidates, the desired `content`/`priority` must select exactly one:
+// candidates, the desired record value/priority must select exactly one:
 //   - exactly one exact match -> that record
 //   - no exact match          -> `undefined` (a new sibling record is created)
 //   - several exact matches   -> fail with an actionable error
@@ -561,6 +562,8 @@ const findByNameType = (
         const narrowed = candidates.filter(
           (r) =>
             (match.content === undefined || r.content === match.content) &&
+            (match.data === undefined ||
+              recordDataEquals(match.data, r.data)) &&
             (match.priority === undefined || r.priority === match.priority),
         );
         if (narrowed.length === 1) return narrowed[0];
@@ -572,11 +575,12 @@ const findByNameType = (
           candidates: candidates.map((r) => ({
             id: r.id,
             content: r.content,
+            data: r.data,
             priority: r.priority,
           })),
           message:
             `Multiple DNS records in zone ${zoneId} match (name=${name}, ` +
-            `type=${type}) and the desired content/priority does not ` +
+            `type=${type}) and the desired record value/priority does not ` +
             `select exactly one. Set \`content\`` +
             (type === "MX" || type === "URI" ? " and `priority`" : "") +
             ` to exactly match the record this resource should adopt ` +
@@ -585,6 +589,9 @@ const findByNameType = (
               .map(
                 (r) =>
                   `  - id=${r.id} content=${JSON.stringify(r.content)}` +
+                  (r.data === undefined
+                    ? ""
+                    : ` data=${JSON.stringify(r.data)}`) +
                   (r.priority === undefined ? "" : ` priority=${r.priority}`),
               )
               .join("\n"),
@@ -669,7 +676,7 @@ const toAttributes = (
     !observed?.id ||
     !observed.name ||
     !observed.type ||
-    (observed.content === undefined && observed.data === undefined) ||
+    observed.content === undefined ||
     observed.ttl === undefined
   ) {
     return undefined;
@@ -698,7 +705,7 @@ interface RecordMutableBodyCommon {
   ttl: number;
   proxied?: boolean;
   comment?: string;
-  tags?: ReadonlyArray<string>;
+  tags?: string[];
   priority?: number;
 }
 
@@ -719,12 +726,12 @@ const buildMutableBody = (news: RecordProps): RecordMutableBody => {
           : (news.ttl as number),
     proxied: news.proxied,
     comment: news.comment,
-    tags: news.tags,
+    tags: news.tags === undefined ? undefined : Array.from(news.tags),
     priority: news.priority,
   };
-  return news.data === undefined
+  return typeof news.content === "string"
     ? { ...common, content: news.content }
-    : { ...common, data: news.data };
+    : { ...common, data: news.content };
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/alchemy/test/Cloudflare/Dns/DnsRecord.test.ts
+++ b/packages/alchemy/test/Cloudflare/Dns/DnsRecord.test.ts
@@ -47,7 +47,7 @@ const SVCB_DATA_V1 = {
 const SVCB_DATA_V2 = {
   priority: 1,
   target: `svc.${zoneName}.`,
-  value: 'mandatory=alpn,port alpn="h2,h3" port="8443"',
+  value: 'mandatory="alpn,port" alpn="h2,h3" port="8443"',
 } satisfies Cloudflare.DNS.RecordData;
 const resolveZoneId = Effect.gen(function* () {
   const { accountId } = yield* yield* CloudflareEnvironment;
@@ -166,13 +166,13 @@ test.provider(
             zoneId,
             name: NAME_SVCB,
             type: "SVCB",
-            data: SVCB_DATA_V1,
+            content: SVCB_DATA_V1,
           }).pipe(adopt(true));
         }),
       );
 
       expect(initial.type).toEqual("SVCB");
-      expect(initial.content).toBeUndefined();
+      expect(typeof initial.content).toEqual("string");
       expect(initial.data).toEqual(SVCB_DATA_V1);
 
       const created = yield* getRecord(zoneId, initial.recordId);
@@ -204,7 +204,7 @@ test.provider(
             zoneId,
             name: NAME_SVCB,
             type: "SVCB",
-            data: SVCB_DATA_V2,
+            content: SVCB_DATA_V2,
           }).pipe(adopt(true));
         }),
       );
@@ -243,7 +243,7 @@ test.provider(
             zoneId,
             name: NAME_HTTPS,
             type: "HTTPS",
-            data,
+            content: data,
           }).pipe(adopt(true));
         }),
       );
@@ -458,7 +458,7 @@ test.provider(
               zoneId,
               name: NAME_SVCB_ADOPT,
               type: "SVCB",
-              data: SVCB_DATA_V2,
+              content: SVCB_DATA_V2,
             });
           }),
         )
@@ -474,7 +474,7 @@ test.provider(
             zoneId,
             name: NAME_SVCB_ADOPT,
             type: "SVCB",
-            data: SVCB_DATA_V2,
+            content: SVCB_DATA_V2,
           }).pipe(adopt(true));
         }),
       );

--- a/packages/alchemy/test/Cloudflare/Dns/DnsRecord.test.ts
+++ b/packages/alchemy/test/Cloudflare/Dns/DnsRecord.test.ts
@@ -34,7 +34,21 @@ const NAME_ADOPT_RELATIVE_FQDN = `${NAME_ADOPT_RELATIVE}.${zoneName}`;
 const NAME_LIST = `alchemy-dnsrecord-list.${zoneName}`;
 const NAME_MX = `alchemy-dnsrecord-mx.${zoneName}`;
 const NAME_MX_AMBIG = `alchemy-dnsrecord-mx-ambig.${zoneName}`;
+const NAME_SVCB = `_alchemy-dnsrecord._tcp.${zoneName}`;
+const NAME_SVCB_ADOPT = `_alchemy-dnsrecord-adopt._tcp.${zoneName}`;
+const NAME_HTTPS = `alchemy-dnsrecord-https.${zoneName}`;
 
+const SVCB_DATA_V1 = {
+  priority: 1,
+  target: `svc.${zoneName}.`,
+  value: 'alpn="h2" port="443"',
+} satisfies Cloudflare.DNS.RecordData;
+
+const SVCB_DATA_V2 = {
+  priority: 1,
+  target: `svc.${zoneName}.`,
+  value: 'mandatory=alpn,port alpn="h2,h3" port="8443"',
+} satisfies Cloudflare.DNS.RecordData;
 const resolveZoneId = Effect.gen(function* () {
   const { accountId } = yield* yield* CloudflareEnvironment;
   const zone = yield* findZoneByName({ accountId, name: zoneName });
@@ -135,6 +149,118 @@ test.provider("create and delete an A record with default props", (stack) =>
     const gone = yield* findRecord(zoneId, NAME_DEFAULT, "A");
     expect(gone).toBeUndefined();
   }).pipe(logLevel),
+);
+
+test.provider(
+  "creates, lists, and updates an SVCB record from structured data",
+  (stack) =>
+    Effect.gen(function* () {
+      const zoneId = yield* resolveZoneId;
+
+      yield* stack.destroy();
+      yield* purgeRecords(zoneId, NAME_SVCB, "SVCB");
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.DNS.Record("StructuredSvcb", {
+            zoneId,
+            name: NAME_SVCB,
+            type: "SVCB",
+            data: SVCB_DATA_V1,
+          }).pipe(adopt(true));
+        }),
+      );
+
+      expect(initial.type).toEqual("SVCB");
+      expect(initial.content).toBeUndefined();
+      expect(initial.data).toEqual(SVCB_DATA_V1);
+
+      const created = yield* getRecord(zoneId, initial.recordId);
+      expect(created.type).toEqual("SVCB");
+      expect("data" in created ? created.data : undefined).toEqual(
+        SVCB_DATA_V1,
+      );
+
+      const provider = yield* Provider.findProvider(Cloudflare.DNS.Record);
+      const listed = (yield* provider.list()).find(
+        (record) => record.recordId === initial.recordId,
+      );
+      expect(listed?.data).toEqual(SVCB_DATA_V1);
+
+      // Introduce drift out of band, then change the desired data. Reconcile
+      // must compare against the observed components and patch in place.
+      yield* dns.updateRecord({
+        zoneId,
+        dnsRecordId: initial.recordId,
+        name: NAME_SVCB,
+        type: "SVCB",
+        ttl: 1,
+        data: { ...SVCB_DATA_V1, value: 'alpn="h3" port="9443"' },
+      });
+
+      const updated = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.DNS.Record("StructuredSvcb", {
+            zoneId,
+            name: NAME_SVCB,
+            type: "SVCB",
+            data: SVCB_DATA_V2,
+          }).pipe(adopt(true));
+        }),
+      );
+
+      expect(updated.recordId).toEqual(initial.recordId);
+      expect(updated.data).toEqual(SVCB_DATA_V2);
+
+      const live = yield* getRecord(zoneId, updated.recordId);
+      expect("data" in live ? live.data : undefined).toEqual(SVCB_DATA_V2);
+
+      yield* stack.destroy();
+
+      const gone = yield* findRecord(zoneId, NAME_SVCB, "SVCB");
+      expect(gone).toBeUndefined();
+    }).pipe(logLevel),
+  { timeout: 120_000 },
+);
+
+test.provider(
+  "creates and deletes an HTTPS record from structured data",
+  (stack) =>
+    Effect.gen(function* () {
+      const zoneId = yield* resolveZoneId;
+      const data = {
+        priority: 1,
+        target: ".",
+        value: 'alpn="h2,h3"',
+      } satisfies Cloudflare.DNS.RecordData;
+
+      yield* stack.destroy();
+      yield* purgeRecords(zoneId, NAME_HTTPS, "HTTPS");
+
+      const record = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.DNS.Record("StructuredHttps", {
+            zoneId,
+            name: NAME_HTTPS,
+            type: "HTTPS",
+            data,
+          }).pipe(adopt(true));
+        }),
+      );
+
+      expect(record.type).toEqual("HTTPS");
+      expect(record.data).toEqual(data);
+
+      const live = yield* getRecord(zoneId, record.recordId);
+      expect(live.type).toEqual("HTTPS");
+      expect("data" in live ? live.data : undefined).toEqual(data);
+
+      yield* stack.destroy();
+
+      const gone = yield* findRecord(zoneId, NAME_HTTPS, "HTTPS");
+      expect(gone).toBeUndefined();
+    }).pipe(logLevel),
+  { timeout: 120_000 },
 );
 
 test.provider("updating mutable fields patches in place", (stack) =>
@@ -306,6 +432,65 @@ test.provider(
       const gone = yield* findRecord(zoneId, NAME_ADOPT, "A");
       expect(gone).toBeUndefined();
     }).pipe(logLevel),
+);
+
+test.provider(
+  "adoption converges an existing structured SVCB record",
+  (stack) =>
+    Effect.gen(function* () {
+      const zoneId = yield* resolveZoneId;
+
+      yield* stack.destroy();
+      yield* purgeRecords(zoneId, NAME_SVCB_ADOPT, "SVCB");
+
+      const pre = yield* dns.createRecord({
+        zoneId,
+        name: NAME_SVCB_ADOPT,
+        type: "SVCB",
+        ttl: 1,
+        data: SVCB_DATA_V1,
+      });
+
+      const error = yield* stack
+        .deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.DNS.Record("AdoptedStructuredSvcb", {
+              zoneId,
+              name: NAME_SVCB_ADOPT,
+              type: "SVCB",
+              data: SVCB_DATA_V2,
+            });
+          }),
+        )
+        .pipe(
+          Effect.as(undefined),
+          Effect.catchCause((cause) => Effect.succeed(findOwnedError(cause))),
+        );
+      expect(error).toBeInstanceOf(OwnedBySomeoneElse);
+
+      const adopted = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.DNS.Record("AdoptedStructuredSvcb", {
+            zoneId,
+            name: NAME_SVCB_ADOPT,
+            type: "SVCB",
+            data: SVCB_DATA_V2,
+          }).pipe(adopt(true));
+        }),
+      );
+
+      expect(adopted.recordId).toEqual(pre.id);
+      expect(adopted.data).toEqual(SVCB_DATA_V2);
+
+      const live = yield* getRecord(zoneId, adopted.recordId);
+      expect("data" in live ? live.data : undefined).toEqual(SVCB_DATA_V2);
+
+      yield* stack.destroy();
+
+      const gone = yield* findRecord(zoneId, NAME_SVCB_ADOPT, "SVCB");
+      expect(gone).toBeUndefined();
+    }).pipe(logLevel),
+  { timeout: 120_000 },
 );
 
 test.provider(


### PR DESCRIPTION
## Summary

Allow Cloudflare DNS records to use typed structured record components while preserving the existing string-based `content` API. This enables component-based record types such as SVCB and HTTPS across create, update, readback, drift detection, adoption, and deletion.

Alchemy keeps a single semantic `content` property:

| Alchemy input | Cloudflare request |
| --- | --- |
| `content: string` | `content` |
| `content: RecordData` | `data` |

Structured values are sent directly as JSON objects in Cloudflare's `data` field; Alchemy does not JSON-stringify them.

## Usage

Existing string records remain unchanged:

```ts
yield* Cloudflare.DNS.Record("ApiRecord", {
  zoneId,
  name: "api.example.com",
  type: "A",
  content: "203.0.113.42",
});
```

Component-based records accept their record-specific structured shape:

```ts
yield* Cloudflare.DNS.Record("ServiceBinding", {
  zoneId,
  name: "_service._tcp.example.com",
  type: "SVCB",
  content: {
    priority: 1,
    target: "api.example.com.",
    value: 'mandatory="alpn,port" alpn="h2,h3" port="443"',
  },
});
```

The `type` discriminates the accepted content shape. String-only record types accept only strings, while component-based types accept either formatted string content or the corresponding structured object. Unknown or future Cloudflare record types remain supported with string content.

Priority follows Cloudflare's API model:

- MX and URI use top-level `priority`.
- SRV, SVCB, and HTTPS put `priority` inside structured `content`.
- Other record types do not expose top-level `priority`.

## Motivation

This limitation surfaced while publishing an SVCB record for [DNS-AID](https://datatracker.ietf.org/doc/html/draft-mozleywilliams-dnsop-dnsaid-02)-based MCP service discovery. The record allows compatible clients to discover a hosted MCP endpoint and its connection parameters from DNS:

```text
_mcp._agents.example.com
  -> mcp.example.com.
  -> HTTPS on port 443 using h2 or h3
```

Alchemy previously required formatted string `content` and always forwarded that field, along with the legacy top-level `priority`. Cloudflare rejected the SVCB request because it validates SVCB and HTTPS components through its structured `data` object:

```text
BadRequest: priority is a required data field.
```

This change adds generic structured DNS record support rather than DNS-AID-specific behavior. Distilled's generated request component types are mapped to their corresponding DNS record types, giving SVCB, HTTPS, SRV, CAA, CERT, DNSKEY, DS, LOC, NAPTR, SMIMEA, TLSA, SSHFP, and URI appropriately typed object content.

## Compatibility

- Existing string-based record declarations retain their current behavior.
- Unknown or future record types remain available through the string-content fallback.
- `RecordAttributes.content` remains Cloudflare's formatted string readback.
- Optional `RecordAttributes.data` provides structured readback when Cloudflare returns it.
- The existing top-level `priority` remains available where Cloudflare uses it: MX and URI.

## Validation

- `tsc -b --pretty false`
- `docs:gen`
- `docs:check`
- Formatting and diff checks
- Full live Cloudflare DNS suite against `alchemy-test-2.us` using Doppler `alchemy-v2/dev`
  - 13 test files, 45 tests: 38 passed, 7 entitlement-gated `todo`, 0 failed
  - Covers DNS records, structured SVCB/HTTPS lifecycles, adoption and ambiguity handling, DNSSEC, account and zone settings, runtime bindings, entitlement probes, internal views, and zone-transfer resources

Cloudflare canonicalizes some structured values on readback. For example, `mandatory=alpn,port` is returned as `mandatory="alpn,port"`; the examples and tests use the canonical form so subsequent deployments converge without repeated updates.
