### PR TITLE
fix(cli): keep alchemy dev alive when the stack module fails to load

### DIFF
--- a/packages/alchemy/src/Cli/commands/deploy.ts
+++ b/packages/alchemy/src/Cli/commands/deploy.ts
@@ -67,7 +67,7 @@ const adopt = Flag.boolean("adopt").pipe(
   Flag.withDefault(false),
 );
 
-export const execStack = Effect.fn(function* ({
+const runStack = Effect.fn(function* ({
   main,
   stage,
   envFile,
@@ -172,6 +172,31 @@ export const execStack = Effect.fn(function* ({
     }).pipe(Effect.provide(stack.services));
   }).pipe(Effect.provide(services));
 });
+
+// In dev, failures OUTSIDE the apply guard above must not exit the process
+// either: the user saves mid-edit states where importing the stack module
+// itself throws (missing export, module-evaluation crash), or planning fails
+// against the half-edited program. Those failures escape `runStack` before
+// the apply-level guard exists, and exiting here kills the `--watch` session
+// (oven-sh/bun#10983), so dev would stop reloading on subsequent saves. Log
+// the cause and park forever; the watcher restarts the run on the next file
+// change. Pure interruption (Ctrl-C / fiber kill) still propagates so dev
+// shuts down cleanly.
+export const devKeepAlive = <A, E, R>(
+  effect: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> =>
+  effect.pipe(
+    Effect.catchCause((cause) =>
+      Cause.hasInterruptsOnly(cause)
+        ? Effect.failCause(cause)
+        : Console.error(
+            `alchemy dev: run failed; waiting for the next file change to retry.\n${Cause.pretty(cause)}`,
+          ).pipe(Effect.andThen(Effect.never)),
+    ),
+  );
+
+export const execStack = (options: ExecStackOptions) =>
+  options.dev ? devKeepAlive(runStack(options)) : runStack(options);
 
 export const deployCommand = Command.make(
   "deploy",

--- a/packages/alchemy/test/Cli/devKeepAlive.test.ts
+++ b/packages/alchemy/test/Cli/devKeepAlive.test.ts
@@ -1,0 +1,79 @@
+import * as Cause from "effect/Cause";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as Option from "effect/Option";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "alchemy-test";
+import { importStack } from "../../src/Cli/commands/_shared";
+import { devKeepAlive } from "../../src/Cli/commands/deploy";
+import { PlatformServices } from "../../src/Util/PlatformServices";
+
+// `alchemy dev` runs under `--watch`: exiting the process on error cancels
+// the watch session, so a run wrapped in `devKeepAlive` must park (stay
+// alive for the watcher to restart) on ANY failure — typed error or defect —
+// while success and interruption pass through untouched.
+
+/** Resolves `true` when the effect is still running (parked) after the timeout. */
+const parks = <A, E>(effect: Effect.Effect<A, E>) =>
+  Effect.runPromise(
+    effect.pipe(Effect.timeoutOption("50 millis"), Effect.map(Option.isNone)),
+  );
+
+describe("devKeepAlive", () => {
+  test("passes success through untouched", () =>
+    expect(Effect.runPromise(devKeepAlive(Effect.succeed(42)))).resolves.toBe(
+      42,
+    ));
+
+  test("parks on a typed failure instead of exiting", () =>
+    expect(
+      parks(devKeepAlive(Effect.fail(new Error("plan failed")))),
+    ).resolves.toBe(true));
+
+  test("parks on a defect instead of exiting", () =>
+    expect(
+      parks(
+        devKeepAlive(Effect.die(new TypeError("undefined is not an object"))),
+      ),
+    ).resolves.toBe(true));
+
+  test("an interrupt-only cause propagates instead of parking", async () => {
+    const exit = await Effect.runPromiseExit(
+      devKeepAlive(Effect.failCause(Cause.interrupt())),
+    );
+    expect(exit._tag === "Failure" && Cause.hasInterruptsOnly(exit.cause)).toBe(
+      true,
+    );
+  });
+
+  test("interruption still tears down a parked run (Ctrl-C in dev)", () =>
+    expect(
+      Effect.runPromise(
+        Effect.gen(function* () {
+          const fiber = yield* Effect.forkChild(
+            devKeepAlive(Effect.die("apply failed")),
+          );
+          yield* Effect.sleep("20 millis");
+          yield* Fiber.interrupt(fiber);
+          return "shut down";
+        }),
+      ),
+    ).resolves.toBe("shut down"));
+
+  // The real-world crash: a mid-edit save makes the stack entrypoint throw at
+  // module evaluation, so `importStack`'s dynamic import rejects (a defect).
+  // Before the guard this crashed the exec process and killed the watch
+  // session; wrapped in `devKeepAlive` it must park until the next save.
+  test("a stack module that throws at evaluation parks instead of crashing", () =>
+    expect(
+      parks(
+        devKeepAlive(
+          importStack(
+            fileURLToPath(
+              import.meta.resolve("./fixtures/import-stack-throws.ts"),
+            ),
+          ).pipe(Effect.provide(PlatformServices)),
+        ),
+      ),
+    ).resolves.toBe(true));
+});

--- a/packages/alchemy/test/Cli/fixtures/import-stack-throws.ts
+++ b/packages/alchemy/test/Cli/fixtures/import-stack-throws.ts
@@ -1,0 +1,6 @@
+// Simulates a mid-edit save of a stack entrypoint: module evaluation throws
+// (e.g. dereferencing an export that no longer exists), so `import()` of this
+// file rejects. `alchemy dev` must survive this without exiting.
+const missing = undefined as unknown as { key: string };
+
+export default missing.key;


### PR DESCRIPTION
## What

Makes `alchemy dev` durable to runtime errors in the user's program: a save whose module evaluation throws now logs the failure and waits for the next file change instead of crashing the watch session.

## Why

The dev keep-alive guard only wrapped `apply`. A mid-edit save that breaks the stack entrypoint (e.g. importing a since-removed export, producing `TypeError: undefined is not an object` at module evaluation) rejected `importStack`'s dynamic `import()` as a defect, escaped the guard, and exited the exec process. Under `bun --watch` that cancels watch mode entirely (oven-sh/bun#10983), so dev stopped reloading on subsequent saves:

```
SyntaxError: Export named 'SessionContainerImage' not found in module '.../SandboxContainer.ts'.
ERROR (#2): TypeError: undefined is not an object (evaluating 'key.key')
    at Effect.fn (.../Cli/commands/deploy.ts:82:30)
```

## How

- Extracted the existing `execStack` body into `runStack` and added a `devKeepAlive` combinator that wraps the **entire** run when `dev: true`: any non-interrupt failure (import, plan, or apply-adjacent) prints its pretty cause and parks on `Effect.never` so the watcher restarts the run on the next save. Interrupt-only causes still propagate so Ctrl-C shuts dev down cleanly.
- The inner apply-level guard is unchanged — it additionally keeps the stack's services layer open so healthy local resources keep serving after a failed apply.

## Reviewer notes

- `execStack` changed from an `Effect.fn` to a plain `(options) => Effect` wrapper; `instrumentCommand` and all call sites (`deploy`/`destroy`/`plan`/`exec`) accept that shape unchanged.
- New tests in `packages/alchemy/test/Cli/devKeepAlive.test.ts` cover: success pass-through, parking on typed failures and defects, interrupt-only causes propagating, a parked run tearing down on interruption, and the real crash scenario via a fixture stack module that throws at evaluation.
- Verified: 35/35 Cli tests pass, `tsc -b` clean for src + tests, oxlint/oxfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)