### PR TITLE
docs(hetzner): docs hub, setup guide, tutorial, and guides

### DIFF
--- a/packages/alchemy/src/Hetzner/ReadDns.ts
+++ b/packages/alchemy/src/Hetzner/ReadDns.ts
@@ -18,8 +18,6 @@ import type { Zone } from "./Zone.ts";
  * zone id. Provide {@link ReadDnsHttp} on the Action / Function Effect.
  *
  * @binding
- * @product DNS
- * @category Domains & DNS
  *
  * @section Reading RRSets at runtime
  * @example List and get RRSets from an Action

--- a/packages/alchemy/src/Hetzner/ReadWriteDns.ts
+++ b/packages/alchemy/src/Hetzner/ReadWriteDns.ts
@@ -13,8 +13,6 @@ import { type WriteDnsClient } from "./WriteDns.ts";
  * {@link ReadWriteDnsHttp} on the Action / Function Effect.
  *
  * @binding
- * @product DNS
- * @category Domains & DNS
  *
  * @section Managing RRSets at runtime
  * @example Full CRUD from an Action

--- a/packages/alchemy/src/Hetzner/WriteDns.ts
+++ b/packages/alchemy/src/Hetzner/WriteDns.ts
@@ -45,8 +45,6 @@ import type { Zone } from "./Zone.ts";
  * see the change. Poll with {@link waitForZoneAction}.
  *
  * @binding
- * @product DNS
- * @category Domains & DNS
  *
  * @section Mutating RRSets at runtime
  * @example Create, replace records, and delete from an Action

--- a/scripts/generate-api-reference.ts
+++ b/scripts/generate-api-reference.ts
@@ -727,6 +727,12 @@ function orderedKeys(keys: string[], order: string[]): string[] {
  * Grouping is by resolved product LABEL (`@product`, falling back to the
  * service dir name), not by directory: two directories declaring the same
  * product merge into one group instead of rendering duplicate siblings.
+ *
+ * A group that would hold exactly one page named the same as the group
+ * (a flat provider dir where the label falls back to the resource name,
+ * e.g. "Certificate > Certificate") carries no information — collapse it
+ * to a plain leaf. Genuine single-page products keep their folder (the
+ * label differs, e.g. Cloudflare's "D1 > Database").
  */
 function buildServiceItems(pages: PageEntry[]): SidebarItem[] {
   const byLabelKey = new Map<string, PageEntry[]>();
@@ -737,6 +743,13 @@ function buildServiceItems(pages: PageEntry[]): SidebarItem[] {
   }
   const items: SidebarItem[] = [];
   for (const [label, productPages] of byLabelKey) {
+    if (
+      productPages.length === 1 &&
+      productPages[0].resource === label
+    ) {
+      items.push({ label, link: productPages[0].link });
+      continue;
+    }
     items.push({
       label,
       collapsed: true,

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -25,6 +25,7 @@ function providersSidebarEntry() {
     items: [
       { label: "AWS", link: "/aws" },
       { label: "Cloudflare", link: "/cloudflare" },
+      { label: "Hetzner", link: "/hetzner" },
       { label: "PlanetScale", link: "/planetscale" },
       { label: "Neon", link: "/neon" },
       { label: "Prisma", link: "/prisma" },
@@ -947,6 +948,36 @@ export default defineConfig({
               ],
             },
             providerResourcesEntry("AWS"),
+          ],
+        },
+        {
+          label: "Hetzner",
+          items: [
+            { label: "Overview", link: "/hetzner" },
+            { label: "Setup", link: "/hetzner/setup" },
+            {
+              label: "Tutorial",
+              items: [{ autogenerate: { directory: "hetzner/tutorial" } }],
+            },
+            {
+              label: "Compute",
+              items: [
+                { label: "Servers", link: "/hetzner/compute/servers" },
+                { label: "Services", link: "/hetzner/compute/services" },
+              ],
+            },
+            {
+              label: "Data",
+              items: [{ label: "Volumes", link: "/hetzner/data/volumes" }],
+            },
+            {
+              label: "Networking",
+              items: [
+                { label: "Networking", link: "/hetzner/networking" },
+                { label: "DNS", link: "/hetzner/networking/dns" },
+              ],
+            },
+            providerResourcesEntry("Hetzner"),
           ],
         },
         {

--- a/website/src/components/ProviderDirectory.astro
+++ b/website/src/components/ProviderDirectory.astro
@@ -58,6 +58,10 @@ const HUBS: Record<string, { href: string; blurb: string }> = {
     href: "/aws",
     blurb: "Lambda, ECS, EKS, EC2, DynamoDB, S3, SQS, Kinesis",
   },
+  Hetzner: {
+    href: "/hetzner",
+    blurb: "Servers running Services over SSH, Volumes, Load Balancers, DNS",
+  },
   Planetscale: {
     href: "/planetscale",
     blurb: "Serverless MySQL & Postgres with branching workflows",

--- a/website/src/content/docs/hetzner/compute/servers.mdx
+++ b/website/src/content/docs/hetzner/compute/servers.mdx
@@ -1,0 +1,165 @@
+---
+title: Servers
+description: Launch Hetzner Cloud Servers with Alchemy — SSH keys and typed SSH access, cloud-init, networks, volumes, snapshots, and placement groups.
+---
+
+A [`Server`](/providers/hetzner/server) is a Hetzner Cloud VM: pick
+a size, an OS image, and a location, and it boots in about ten
+seconds, billed by the hour. It's both a raw compute primitive and
+the host that [Services](/hetzner/compute/services) deploy onto.
+
+## Launch a server
+
+The minimal server is a type, an image, and a location:
+
+```typescript
+const server = yield* Hetzner.Server("box", {
+  serverType: "cx22",
+  image: "ubuntu-24.04",
+  location: "nbg1",
+});
+```
+
+All three are create-only — changing any of them **replaces** the
+server. The resolved resource exposes `ipv4`, `ipv6`, `serverId`,
+`status`, and the rest of the observed state — see the
+[`Server` reference](/providers/hetzner/server).
+
+To discover what's available, use the catalog helpers — each
+accepts a name or numeric id and fails with a typed
+`CatalogNotFound` if it doesn't exist:
+
+```typescript
+const serverType = yield* Hetzner.findServerType("cx22");
+const image = yield* Hetzner.findImage("ubuntu-24.04");
+const location = yield* Hetzner.findLocation("nbg1");
+```
+
+## SSH keys
+
+Register your public key as an [`SshKey`](/providers/hetzner/sshkey)
+and inject it at create time:
+
+```typescript
+const key = yield* Hetzner.SshKey("laptop", {
+  publicKey: "ssh-ed25519 AAAA... you@laptop",
+});
+
+const server = yield* Hetzner.Server("box", {
+  serverType: "cx22",
+  image: "ubuntu-24.04",
+  sshKeys: [key],
+});
+```
+
+Hetzner applies injected keys only when the server is provisioned —
+changing `sshKeys` later doesn't touch a live server.
+
+Separately from your keys, Alchemy generates a **deploy key** for
+every server it creates and injects it at boot. That key (persisted
+redacted in state) is how [`Hetzner.Ssh`](#run-commands-over-ssh)
+and [`Hetzner.Service`](/hetzner/compute/services) reach the box
+with zero SSH configuration on your side.
+
+## Run commands over SSH
+
+The `Ssh` binding gives you typed `exec`/`scp` against any managed
+server, from deploy-time Effects like
+[Actions](/infrastructure-as-code/action):
+
+```typescript
+const ssh = yield* Hetzner.Ssh(server);
+
+const { stdout } = yield* ssh.exec("uname -a");
+yield* ssh.scp("./assets.tar.gz", "/opt/app/assets.tar.gz");
+```
+
+`exec` returns `{ stdout, stderr, code }` and **fails** with a typed
+`Hetzner.SshError` on a non-zero exit. `scp` accepts a local path or
+a `Uint8Array` and creates the remote directory if needed. Both use
+the server's deploy key and the `root` user by default; pass
+`{ user, privateKey }` to override.
+
+## Cloud-init
+
+`userData` runs at first boot (create-only, max 32 KiB):
+
+```typescript
+const server = yield* Hetzner.Server("box", {
+  serverType: "cx22",
+  image: "ubuntu-24.04",
+  userData: `#cloud-config
+packages:
+  - postgresql
+`,
+});
+```
+
+:::caution
+When you omit `userData`, Alchemy installs its own bootstrap that
+pre-installs [Bun](https://bun.sh) for
+[Services](/hetzner/compute/services). Providing your own `userData`
+replaces that bootstrap — Services still work (the first deploy
+installs Bun over SSH), it's just slower.
+:::
+
+## Attach infrastructure
+
+Networks, firewalls, volumes, and a placement group are all props —
+each accepts the resource directly (yielded or module-scope) and is
+kept in sync on update:
+
+```typescript
+const server = yield* Hetzner.Server("box", {
+  serverType: "cx22",
+  image: "ubuntu-24.04",
+  networks: [network],
+  firewalls: [firewall],
+  volumes: [volume],
+  placementGroup: group,
+});
+```
+
+See [Networking](/hetzner/networking) for networks, firewalls, and
+load balancers, and [Volumes](/hetzner/data/volumes) for storage.
+
+## Placement groups
+
+A [`PlacementGroup`](/providers/hetzner/placementgroup) of type
+`spread` guarantees its members run on distinct physical hosts —
+cheap insurance for redundant pairs:
+
+```typescript
+const spread = yield* Hetzner.PlacementGroup("spread", {
+  type: "spread",
+});
+
+const a = yield* Hetzner.Server("a", { /* ... */ placementGroup: spread });
+const b = yield* Hetzner.Server("b", { /* ... */ placementGroup: spread });
+```
+
+## Snapshots
+
+[`Image`](/providers/hetzner/image) captures a server's disk as a
+snapshot (or converts an existing backup):
+
+```typescript
+const golden = yield* Hetzner.Image("golden", {
+  server,
+  type: "snapshot",
+  description: "app image v1",
+});
+```
+
+Boot new servers from it by passing the image to another Server's
+`image` prop.
+
+## Where next
+
+- [Services](/hetzner/compute/services) — deploy code to the server
+  as a supervised systemd unit.
+- [Volumes](/hetzner/data/volumes) — durable block storage.
+- [Networking](/hetzner/networking) — private networks, firewalls,
+  load balancers, stable IPs.
+- [`Server` reference](/providers/hetzner/server) — every prop and
+  attribute.

--- a/website/src/content/docs/hetzner/compute/services.mdx
+++ b/website/src/content/docs/hetzner/compute/services.mdx
@@ -1,0 +1,201 @@
+---
+title: Services
+description: Deploy Effect programs to Hetzner Servers as supervised systemd units — HTTP handlers, background workers, env & config, updates, and logs.
+---
+
+A [`Service`](/providers/hetzner/service) is your code on a
+[Server](/hetzner/compute/servers): an Effect program that Alchemy
+bundles with Rolldown, copies over SSH, and runs under systemd with
+`Restart=always`. You never write a unit file, a Dockerfile, or a
+deploy script — and several Services can share one Server.
+
+## Declare a Service
+
+A Service is a class with an infrastructure definition and a runtime
+implementation:
+
+```typescript
+// src/api.ts
+import * as Hetzner from "alchemy/Hetzner";
+import * as Effect from "effect/Effect";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import { Box } from "./server.ts";
+
+export default class Api extends Hetzner.Service<Api>()(
+  "Api",
+  { server: Box, main: import.meta.url, port: 3000 },
+  Effect.gen(function* () {
+    return {
+      fetch: Effect.succeed(HttpServerResponse.text("hello")),
+    };
+  }),
+) {}
+```
+
+- `server` — the machine to run on (a `Hetzner.Server`, yielded or
+  module-scope). Changing it **replaces** the Service.
+- `main: import.meta.url` — this file is the bundle entrypoint.
+- `port` — written to the `PORT` env var and used to build the
+  `url` attribute (`http://<server-ipv4>:<port>`). Default `3000`.
+- `fetch` — returning it from the init Effect boots an HTTP server
+  on that port; omit it for a [background service](#background-services).
+
+The resolved resource exposes `url`, `port`, `unitName`, `serverId`,
+and the bundle's `code.hash`.
+
+## What a deploy does
+
+One SSH session, using the Server's Alchemy-managed deploy key:
+
+1. Bundle `main` with Rolldown into a single ESM file (a generated
+   bootstrap wires up the Bun HTTP server, logging, and config from
+   the environment).
+2. Attach and mount any [bound Volumes](/hetzner/data/volumes).
+3. Unpack the bundle to `/opt/<unitName>/`, write the env file, and
+   install the systemd unit:
+
+   ```ini
+   [Service]
+   WorkingDirectory=/opt/<unitName>
+   EnvironmentFile=-/opt/<unitName>/env
+   ExecStart=/root/.bun/bin/bun --no-install /opt/<unitName>/index.mjs
+   Restart=always
+   RestartSec=5
+   ```
+
+4. `systemctl enable --now`, restart, and wait for the unit to be
+   active — and, when a `port` is declared, for
+   `http://127.0.0.1:<port>/health` to answer.
+
+On later deploys Alchemy compares the bundle's content hash against
+what's deployed: unchanged code is a no-op; changed code is copied
+up and the unit restarted, a few seconds end to end.
+
+:::caution[The `/health` route is load-bearing]
+A Service that declares a `port` **must serve `/health`** — the
+deploy polls it and fails (dumping the unit's journal into the
+output) if it never answers. Keep it trivial:
+
+```typescript
+if (url.pathname === "/health") {
+  return HttpServerResponse.json({ ok: true });
+}
+```
+:::
+
+## Reachability
+
+The `url` is the Server's public IP and the Service's port —
+there's no proxy in between. A fresh Hetzner server has no firewall
+(every port open); once you apply a
+[`Firewall`](/hetzner/networking#firewalls), inbound is default-deny
+and you choose who reaches the port. For a stable front door with
+health checks and TLS, put a
+[Load Balancer](/hetzner/networking#load-balancer) in front and
+allow the port only from the private network.
+
+## Environment & config
+
+Pass static values with `env`; read them at runtime through Effect's
+`Config` (the runtime's `ConfigProvider` is backed by the process
+environment):
+
+```typescript
+import * as Config from "effect/Config";
+
+export default class Api extends Hetzner.Service<Api>()(
+  "Api",
+  {
+    server: Box,
+    main: import.meta.url,
+    port: 3000,
+    env: { GREETING: "hello" },
+  },
+  Effect.gen(function* () {
+    const greeting = yield* Config.string("GREETING");
+    // ...
+  }),
+) {}
+```
+
+Alchemy also injects `PORT` (when `port` is set) and the stack
+metadata (`ALCHEMY_STACK_NAME`, `ALCHEMY_STAGE`). Values from
+bindings are merged first, so your `env` wins on conflict. See
+[Secrets & Config](/environments/secrets) for handling secret
+values.
+
+## Background services
+
+Omit `port`/`fetch` and use `ServerHost.run` to register a
+long-running loop — a worker, a queue consumer, a cron-ish daemon:
+
+```typescript
+// src/worker.ts
+import * as Hetzner from "alchemy/Hetzner";
+import { ServerHost } from "alchemy/Server";
+import * as Effect from "effect/Effect";
+
+export default class Worker extends Hetzner.Service<Worker>()(
+  "Worker",
+  { server: Box, main: import.meta.url },
+  Effect.gen(function* () {
+    const host = yield* ServerHost;
+
+    yield* host.run(
+      Effect.gen(function* () {
+        // do work forever
+        return yield* Effect.never;
+      }).pipe(Effect.orDie),
+    );
+  }),
+) {}
+```
+
+systemd still supervises the process — if your loop exits or
+crashes, the unit restarts after 5 seconds.
+
+## Multiple Services, one Server
+
+Each Service is its own unit with its own bundle, env file, and
+lifecycle. Point several at the same `server` and share resources
+between them — two Services mounting the same Volume at the same
+path is one attach and one mount:
+
+```typescript
+// Api serves what Worker writes — same Box, same Volume
+class Api extends Hetzner.Service<Api>()(
+  "Api",
+  { server: Box, main: import.meta.url, port: 3000 },
+  /* mounts Data at /data, serves files */
+) {}
+
+class Worker extends Hetzner.Service<Worker>()(
+  "Worker",
+  { server: Box, main: import.meta.url },
+  /* mounts Data at /data, writes files */
+) {}
+```
+
+## Logs
+
+Service logs go to the systemd journal. `alchemy logs`/`alchemy
+tail` don't support Hetzner Services yet — read them over SSH:
+
+```sh
+ssh root@<server-ip> journalctl -u <unitName> -f
+```
+
+The unit name is the Service's `unitName` output (surface it as a
+stack output to keep it handy). Failed deploys already print the
+last 80 journal lines.
+
+## Where next
+
+- [Tutorial part 2](/hetzner/tutorial/part-2) — build up a Service
+  step by step.
+- [Volumes](/hetzner/data/volumes) — persistent storage via the
+  `MountVolume` binding.
+- [Networking](/hetzner/networking) — firewalls and load balancers
+  in front of your Service.
+- [`Service` reference](/providers/hetzner/service) — every prop
+  and attribute.

--- a/website/src/content/docs/hetzner/data/volumes.mdx
+++ b/website/src/content/docs/hetzner/data/volumes.mdx
@@ -1,0 +1,102 @@
+---
+title: Volumes
+description: Durable network block storage for Hetzner Servers — attach with props or VolumeAttachment, mount into Services with the MountVolume binding.
+---
+
+A [`Volume`](/providers/hetzner/volume) is Hetzner's network block
+storage: a durable disk (10 GB minimum) with its own lifecycle,
+attachable to one Server at a time in the same location. Servers
+come and go; Volumes keep the data.
+
+## Create a Volume
+
+```typescript
+import * as Hetzner from "alchemy/Hetzner";
+
+export const Data = Hetzner.Volume("data", {
+  size: 10,
+  format: "ext4",
+  location: "nbg1",
+});
+```
+
+`size` is in GB and can **grow in place** on a later deploy —
+shrinking is impossible. `format` (`ext4` or `xfs`) and `location`
+are create-only: changing either **replaces the Volume and destroys
+its data**. The location must match the Server's.
+
+## Mount into a Service (recommended)
+
+The `MountVolume` binding is the highest-level path: inside a
+[Service](/hetzner/compute/services)'s init, bind the Volume to a
+path and use it as a plain directory at runtime. Pass the `Data`
+declaration directly — no yielding required:
+
+```typescript
+export default class Api extends Hetzner.Service<Api>()(
+  "Api",
+  { server: Box, main: import.meta.url, port: 3000 },
+  Effect.gen(function* () {
+    const mount = yield* Hetzner.MountVolume(Data, { path: "/data" });
+
+    return {
+      fetch: Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const text = yield* fs.readFileString(`${mount.path}/hello.txt`);
+        // ...
+      }),
+    };
+  }).pipe(Effect.provide(Hetzner.MountVolumeLive)),
+) {}
+```
+
+At deploy time the binding attaches the Volume to the Service's
+Server, creates the directory, mounts the device, and appends an
+`/etc/fstab` entry (`defaults,nofail`) so the mount survives
+reboots. At runtime it hands you the resolved `mount.path` and
+`mount.device`. Every step is idempotent, and two Services binding
+the same `(volume, path)` on the same Server share one attach and
+one mount.
+
+If the Server is ever replaced, the Volume is detached from the old
+machine and re-attached to the new one on the next deploy — the
+data rides along.
+
+## Attach without a Service
+
+For servers that manage their own filesystems, attach declaratively
+instead. Either from the Volume side:
+
+```typescript
+export const Data = Hetzner.Volume("data", {
+  size: 10,
+  location: "nbg1",
+  server: Box,
+  automount: true,
+});
+```
+
+Or as a standalone
+[`VolumeAttachment`](/providers/hetzner/volumeattachment) — useful
+when the Volume and Server are declared far apart:
+
+```typescript
+yield* Hetzner.VolumeAttachment("data-on-box", {
+  volume: Data,
+  server: Box,
+  automount: true,
+});
+```
+
+With `automount: true` Hetzner mounts the disk under
+`/mnt/HC_Volume_<id>`; otherwise mount `volume.linuxDevice`
+yourself (e.g. via cloud-init or `Hetzner.Ssh`).
+
+## Where next
+
+- [Tutorial part 3](/hetzner/tutorial/part-3) — mount a Volume into
+  a Service step by step.
+- [Services](/hetzner/compute/services) — the platform doing the
+  mounting.
+- [`Volume` reference](/providers/hetzner/volume) — every prop and
+  attribute.

--- a/website/src/content/docs/hetzner/index.mdx
+++ b/website/src/content/docs/hetzner/index.mdx
@@ -1,0 +1,75 @@
+---
+title: Hetzner
+description: Build applications on Hetzner Cloud with Alchemy — Servers running your Effect programs as Services, plus volumes, networks, firewalls, load balancers, and DNS, all in one typed program.
+---
+
+An Alchemy app on Hetzner is one or more **Servers** — real VMs,
+booted in seconds and billed by the hour — running your Effect
+programs as **Services**: bundled with rolldown, copied over SSH, and
+supervised by systemd. No Dockerfile, no ansible, no hand-written
+unit files. Around them you declare the rest of the platform —
+volumes, private networks, firewalls, load balancers, and DNS — in
+the same TypeScript program.
+
+New here? [Set up your project and API token](/hetzner/setup), then
+start the [tutorial](/hetzner/tutorial/part-1).
+
+## Compute
+
+- **[Servers](/hetzner/compute/servers)** — the VM: pick a
+  `serverType`, an `image`, and a `location`; attach SSH keys,
+  networks, firewalls, volumes, and placement groups. Alchemy injects
+  a deploy key so it can reach every server it manages.
+- **[Services](/hetzner/compute/services)** — your code on a Server.
+  An HTTP `fetch` handler (or a background process) deployed as a
+  systemd unit; N Services can share one Server.
+- **[SSH](/hetzner/compute/servers#run-commands-over-ssh)** — typed
+  `exec`/`scp` against any managed Server, usable from deploy-time
+  Effects.
+- **Images & snapshots** — snapshot a Server with `Hetzner.Image`,
+  look up stock images with `Hetzner.findImage`.
+
+## Storage
+
+- **[Volumes](/hetzner/data/volumes)** — network block storage
+  attached to a Server. Mount one into a Service with the
+  `MountVolume` binding and read/write it like a local directory.
+
+## Networking
+
+- **[Networks, Firewalls & Load Balancers](/hetzner/networking)** —
+  private networks with subnets, stateful firewall rules applied to
+  servers, and managed load balancers with health checks and TLS
+  certificates.
+- **Floating & Primary IPs** — stable public addresses that survive
+  server replacement.
+
+## DNS
+
+- **[Zones & records](/hetzner/networking/dns)** — Hetzner DNS zones
+  and record sets as resources, plus `ReadDns`/`WriteDns` bindings
+  for querying and mutating records from deploy-time Effects.
+
+## What are you building?
+
+| You're building                    | Reach for                                                                                                    |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| An HTTP API on a VM                | [Server](/hetzner/compute/servers) + [Service](/hetzner/compute/services)                                      |
+| A background worker / daemon       | [Service](/hetzner/compute/services) with `host.run(...)` — no port, no HTTP                                   |
+| Persistent state on disk           | [Volume + MountVolume](/hetzner/data/volumes)                                                                  |
+| A load-balanced, TLS-terminated app | [Load Balancer + Certificate](/hetzner/networking#load-balancer)                                              |
+| Servers talking privately          | [Network](/hetzner/networking#private-networks) + `usePrivateIp` targets                                       |
+| Locking down public access         | [Firewall](/hetzner/networking#firewalls)                                                                      |
+| Your own domain                    | [Zone + RecordSet](/hetzner/networking/dns)                                                                    |
+| A stable IP across replacements    | Primary IP / Floating IP — see [Networking](/hetzner/networking#floating--primary-ips)                         |
+| Golden images                      | `Hetzner.Image` snapshots — see [Servers](/hetzner/compute/servers#snapshots)                                   |
+
+## Where next
+
+- [Setup](/hetzner/setup) — create a Hetzner project, generate an
+  API token, and connect alchemy.
+- [Tutorial](/hetzner/tutorial/part-1) — from empty directory to a
+  Server running an HTTP Service with a mounted Volume and a
+  firewall.
+- [Providers reference](/providers) — generated API docs for every
+  Hetzner resource Alchemy ships.

--- a/website/src/content/docs/hetzner/networking/dns.mdx
+++ b/website/src/content/docs/hetzner/networking/dns.mdx
@@ -1,0 +1,128 @@
+---
+title: DNS
+description: Hetzner Cloud DNS with Alchemy — Zones and RecordSets as resources, plus ReadDns/WriteDns bindings for querying and mutating records from Effects.
+---
+
+Hetzner Cloud DNS is part of the same project and the same
+`HCLOUD_TOKEN` as your servers — no separate account, console, or
+token. Alchemy models it two ways: **resources** (`Zone`,
+`RecordSet`) for records that belong to your stack, and **bindings**
+(`ReadDns`/`WriteDns`) for code that queries or mutates records
+dynamically.
+
+## Zones
+
+A [`Zone`](/providers/hetzner/zone) is an apex domain you own —
+`name` must be a real registrable domain (no subdomains, no
+trailing dot):
+
+```typescript
+import * as Hetzner from "alchemy/Hetzner";
+
+export const Dns = Hetzner.Zone("dns", {
+  name: "example.com",
+  ttl: 300,
+});
+```
+
+Changing `name` replaces the Zone. The resolved resource exposes
+`assignedNameservers` — set those at your registrar to delegate the
+domain — plus `delegationStatus` to check whether that's done.
+
+## RecordSets
+
+A [`RecordSet`](/providers/hetzner/recordset) is one `(name, type)`
+pair and **all** of its records. Values accept resource outputs, so
+pointing your domain at a Load Balancer is a reference, not a
+copy-pasted IP:
+
+```typescript
+const www = yield* Hetzner.RecordSet("www", {
+  zone: Dns,
+  name: "www",
+  type: "A",
+  ttl: 300,
+  records: [{ value: lb.ipv4.as<string>() }],
+});
+```
+
+`name` is relative to the zone (`@` for the apex). Changing `zone`,
+`name`, or `type` replaces the RecordSet; `records` and `ttl`
+update in place. Because a RecordSet owns the whole `(name, type)`
+pair, keep each pair in exactly one resource.
+
+## Query & mutate from Effects
+
+For DNS that isn't part of the declared stack — health-dependent
+records, dynamic entries, lookups — bind a typed client to a zone.
+Three bindings, each with a matching layer:
+
+| Binding | Layer | Client |
+| --- | --- | --- |
+| `Hetzner.ReadDns(zone)` | `Hetzner.ReadDnsHttp` | `getRecordSet`, `listRecordSets` |
+| `Hetzner.WriteDns(zone)` | `Hetzner.WriteDnsHttp` | `createRecordSet`, `setRecordSetRecords`, `addRecordSetRecords`, `removeRecordSetRecords`, `updateRecordSet`, `deleteRecordSet`, `changeRecordSetTtl`, … |
+| `Hetzner.ReadWriteDns(zone)` | `Hetzner.ReadWriteDnsHttp` | both |
+
+The zone is fixed when you bind — pass the Zone declaration
+directly, and calls never pass a zone id:
+
+```typescript
+import * as Alchemy from "alchemy";
+import * as Hetzner from "alchemy/Hetzner";
+import * as Effect from "effect/Effect";
+import { Dns } from "./dns.ts";
+
+const SyncRecords = Alchemy.Action(
+  "SyncRecords",
+  Effect.gen(function* () {
+    const dns = yield* Hetzner.ReadWriteDns(Dns);
+
+    return Effect.fn(function* () {
+      const listed = yield* dns.listRecordSets({ type: ["A"] });
+
+      const { action } = yield* dns.setRecordSetRecords("api", "A", {
+        records: [{ value: "203.0.113.20" }],
+      });
+      yield* Hetzner.waitForZoneAction(action);
+    });
+  }).pipe(Effect.provide(Hetzner.ReadWriteDnsHttp)),
+);
+```
+
+:::caution[DNS mutations are asynchronous]
+Every mutating RRSet call returns an `action` that Hetzner applies
+in the background — a read right after may not see the change.
+Always `yield* Hetzner.waitForZoneAction(action)` before depending
+on the result. (Zone actions have their own API namespace — use
+`waitForZoneAction`, not the compute `waitForAction`.)
+:::
+
+Writes also require your `HCLOUD_TOKEN` to be a **Read & Write**
+token — a read-only token fails mutations with a typed `Forbidden`.
+
+## Put it together: a domain on your Load Balancer
+
+```typescript
+const cert = yield* Hetzner.Certificate("cert", {
+  type: "managed",
+  domainNames: ["example.com", "www.example.com"],
+});
+
+yield* Hetzner.RecordSet("apex", {
+  zone: Dns,
+  name: "@",
+  type: "A",
+  records: [{ value: lb.ipv4.as<string>() }],
+});
+```
+
+The managed [Certificate](/hetzner/networking#tls-termination) is
+issued via this same DNS, so the Zone must exist (and be delegated)
+first — Alchemy orders that for you through the references.
+
+## Where next
+
+- [Networking](/hetzner/networking) — the Load Balancer these
+  records usually point at.
+- [`Zone`](/providers/hetzner/zone) and
+  [`RecordSet`](/providers/hetzner/recordset) references.

--- a/website/src/content/docs/hetzner/networking/index.mdx
+++ b/website/src/content/docs/hetzner/networking/index.mdx
@@ -1,0 +1,176 @@
+---
+title: Networking
+description: Private networks, default-deny firewalls, managed load balancers with TLS, and stable Floating & Primary IPs for Hetzner Cloud.
+---
+
+The networking toolkit around your
+[Servers](/hetzner/compute/servers): private **Networks** for
+east-west traffic, **Firewalls** to close the public interface,
+**Load Balancers** as the health-checked (and TLS-terminated) front
+door, and **Floating/Primary IPs** for addresses that outlive any
+one machine.
+
+## Private networks
+
+A [`Network`](/providers/hetzner/network) is an RFC1918 range with
+subnets per network zone (`eu-central`, `us-east`, `us-west`,
+`ap-southeast`). Attach Servers via their `networks` prop:
+
+```typescript
+import * as Hetzner from "alchemy/Hetzner";
+
+export const Net = Hetzner.Network("net", {
+  ipRange: "10.0.0.0/16",
+  subnets: [
+    { type: "cloud", networkZone: "eu-central", ipRange: "10.0.1.0/24" },
+  ],
+});
+
+export const Box = Hetzner.Server("box", {
+  serverType: "cx22",
+  image: "ubuntu-24.04",
+  location: "nbg1",
+  networks: [Net],
+});
+```
+
+Traffic inside the network never touches the public interface —
+which is what lets a [Firewall](#firewalls) close the public app
+port entirely while a [Load Balancer](#load-balancer) still reaches
+the Server over its private IP. The `ipRange` can be extended in
+place; shrinking it replaces the network.
+
+## Firewalls
+
+A [`Firewall`](/providers/hetzner/firewall) is a named rule set
+applied to servers' public interfaces. Once applied it is
+**default-deny inbound** (outbound stays open) — only what a rule
+allows gets through:
+
+```typescript
+export const Wall = Hetzner.Firewall("wall", {
+  applyTo: [Box],
+  rules: [
+    {
+      direction: "in",
+      protocol: "tcp",
+      port: "22",
+      sourceIps: ["0.0.0.0/0", "::/0"],
+      description: "ssh",
+    },
+    {
+      direction: "in",
+      protocol: "tcp",
+      port: "3000",
+      sourceIps: ["10.0.0.0/16"],
+      description: "app, private net only",
+    },
+  ],
+});
+```
+
+`port` takes a single port (`"443"`) or a range (`"1024-5000"`).
+Everything about a firewall — name, rules, targets — updates in
+place; nothing replaces.
+
+## Load Balancer
+
+A [`LoadBalancer`](/providers/hetzner/loadbalancer) fronts one or
+more servers with health-checked forwarding. Target servers over
+their private IP so the public port can stay closed:
+
+```typescript
+export const Edge = Hetzner.LoadBalancer("edge", {
+  location: "nbg1",
+  loadBalancerType: "lb11",
+  networks: [Net],
+  algorithm: "round_robin",
+  targets: [{ type: "server", server: Box, usePrivateIp: true }],
+  services: [
+    {
+      protocol: "http",
+      listenPort: 80,
+      destinationPort: 3000,
+      healthCheck: {
+        protocol: "http",
+        port: 3000,
+        interval: 3,
+        timeout: 2,
+        retries: 2,
+        http: { path: "/health" },
+      },
+    },
+  ],
+});
+```
+
+Each entry in `services` is one listener, keyed by `listenPort`.
+The resolved LB exposes `ipv4`/`ipv6`. The `loadBalancerType`
+(`lb11`, `lb21`, …) upgrades in place but can't downgrade; changing
+`location` replaces.
+
+### TLS termination
+
+Terminate HTTPS at the LB with a
+[`Certificate`](/providers/hetzner/certificate). A **managed**
+certificate is issued by Let's Encrypt — its domains must be zones
+in [Hetzner DNS](/hetzner/networking/dns):
+
+```typescript
+const cert = yield* Hetzner.Certificate("cert", {
+  type: "managed",
+  domainNames: ["example.com", "www.example.com"],
+});
+
+const lb = yield* Hetzner.LoadBalancer("edge", {
+  // ...
+  services: [
+    {
+      protocol: "https",
+      listenPort: 443,
+      destinationPort: 3000,
+      certificates: [cert],
+      http: { redirectHttp: true },
+    },
+  ],
+});
+```
+
+`redirectHttp: true` makes the LB answer port 80 with a redirect to
+HTTPS. Bring-your-own PEM works too: `type: "uploaded"` with
+`certificate` and `privateKey`.
+
+## Floating & Primary IPs
+
+Servers get ephemeral public IPs by default — replace the server,
+lose the address. Two resources decouple addresses from machines:
+
+- A [`PrimaryIp`](/providers/hetzner/primaryip) is the address a
+  server boots with. Declaring it as its own resource keeps it
+  alive independent of any server.
+- A [`FloatingIp`](/providers/hetzner/floatingip) can be re-pointed
+  at any server in its home location at any time — the classic
+  failover/blue-green address.
+
+```typescript
+const float = yield* Hetzner.FloatingIp("float", {
+  type: "ipv4",
+  homeLocation: "nbg1",
+});
+
+yield* Hetzner.FloatingIpAssignment("float-on-box", {
+  floatingIp: float,
+  server: Box,
+});
+```
+
+Re-deploying the assignment with a different `server` moves the
+address in place — no replacement, no DNS change.
+
+## Where next
+
+- [Tutorial part 4](/hetzner/tutorial/part-4) — wire a Network,
+  Firewall, and Load Balancer around a live Service.
+- [DNS](/hetzner/networking/dns) — point your domain at the LB.
+- [Providers reference](/providers) — every prop and attribute of
+  the resources above.

--- a/website/src/content/docs/hetzner/setup.mdx
+++ b/website/src/content/docs/hetzner/setup.mdx
@@ -1,0 +1,138 @@
+---
+title: Setup
+description: Install Alchemy and connect it to Hetzner Cloud — create a project, generate an API token, and store it in a profile.
+---
+
+import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
+import { effectVersion } from "../../../versions";
+
+export const pkgs = `"alchemy@next" "effect@${effectVersion}" "@effect/platform-bun@${effectVersion}" "@effect/platform-node@${effectVersion}"`;
+
+Everything you need before deploying to Hetzner Cloud: the alchemy
+package, a Hetzner project, and an API token stored in a profile.
+
+## Prerequisites
+
+- [Bun](https://bun.sh) (recommended) or Node.js 22+
+- A [Hetzner Cloud](https://console.hetzner.com) account
+
+## Create a Hetzner project
+
+Everything in Hetzner Cloud — servers, volumes, networks, tokens —
+lives inside a **project**. In the
+[Hetzner Cloud Console](https://console.hetzner.com):
+
+1. Click **+ New project**.
+2. Give it a name (e.g. `my-app`) and open it.
+
+One project per app (or per environment) is a good default: API
+tokens are scoped to a single project, so separate projects give you
+hard isolation between apps.
+
+## Generate an API token
+
+Inside the project:
+
+1. Go to **Security** → **API tokens**.
+2. Click **Generate API token**.
+3. Give it a description (e.g. `alchemy`) and select
+   **Read & Write** — Alchemy needs write access to create resources.
+4. Copy the token — Hetzner shows it **only once**.
+
+## Create a project directory
+
+<Tabs syncKey="pkgManager">
+  <TabItem label="bun" icon="bun">
+    <Code code="mkdir my-app && cd my-app && bun init -y" lang="sh" />
+  </TabItem>
+  <TabItem label="npm" icon="npm">
+    <Code code="mkdir my-app && cd my-app && npm init -y" lang="sh" />
+  </TabItem>
+  <TabItem label="pnpm" icon="pnpm">
+    <Code code="mkdir my-app && cd my-app && pnpm init" lang="sh" />
+  </TabItem>
+  <TabItem label="yarn" icon="seti:yarn">
+    <Code code="mkdir my-app && cd my-app && yarn init -y" lang="sh" />
+  </TabItem>
+</Tabs>
+
+## Install
+
+<Tabs syncKey="pkgManager">
+  <TabItem label="bun" icon="bun">
+    <Code code={`bun add ${pkgs}`} lang="sh" />
+  </TabItem>
+  <TabItem label="npm" icon="npm">
+    <Code code={`npm install ${pkgs}`} lang="sh" />
+  </TabItem>
+  <TabItem label="pnpm" icon="pnpm">
+    <Code code={`pnpm add ${pkgs}`} lang="sh" />
+  </TabItem>
+  <TabItem label="yarn" icon="seti:yarn">
+    <Code code={`yarn add ${pkgs}`} lang="sh" />
+  </TabItem>
+</Tabs>
+
+## Connect alchemy to Hetzner
+
+There is no separate credentials step. The first time you run
+`alchemy deploy` (or `plan`, `dev`, `destroy`) on a stack that uses
+`Hetzner.providers()`, alchemy walks you through an interactive
+login with two options:
+
+- **API Token** — paste the token you generated above. It's
+  verified against the Hetzner API and saved under
+  `~/.alchemy/credentials/<profile>/`.
+- **Environment Variables** — reads `HCLOUD_TOKEN` from the
+  environment on every run (plus an optional `HCLOUD_ENDPOINT` to
+  override the API base URL). This is the method for CI — when
+  alchemy detects `CI=true` it skips the prompt and uses the
+  environment automatically.
+
+Either choice is saved to your **`default`**
+[profile](/environments/profiles) and reused on every subsequent
+command.
+
+To re-run the setup later (e.g. to rotate the token, or configure a
+separate `prod` profile):
+
+```sh
+alchemy login --configure
+alchemy login --profile prod --configure
+```
+
+Inspect what's stored (secrets are redacted):
+
+```sh
+alchemy profile show
+```
+
+:::note[No SSH key setup required]
+`Hetzner.Service` deploys your code to a Server over SSH, but you
+don't need to create or upload an SSH key for that — alchemy
+generates a dedicated deploy key for each Server it creates and
+injects it at boot. Adding your own `Hetzner.SshKey` is only for
+*your* interactive `ssh` access.
+:::
+
+## State storage
+
+Hetzner has no object-storage state backend of its own, so pick one
+of:
+
+- **`Alchemy.localState()`** — state on disk under `.alchemy/` next
+  to your code. Zero setup; right for solo projects and trying
+  things out.
+- **A cloud state store** — if you also use Cloudflare or AWS, pass
+  `Cloudflare.state()` or `AWS.state()` so state is shared with
+  your team and CI. See [State Store](/state-store).
+
+State for a Hetzner stack includes each Server's deploy SSH key
+(stored redacted), so for shared or production stacks prefer a
+remote state store over files on one laptop.
+
+## Next steps
+
+- [Tutorial part 1](/hetzner/tutorial/part-1) — deploy your first
+  Server.
+- [Hetzner overview](/hetzner) — the map of resources and guides.

--- a/website/src/content/docs/hetzner/tutorial/part-1.mdx
+++ b/website/src/content/docs/hetzner/tutorial/part-1.mdx
@@ -1,0 +1,324 @@
+---
+title: "Part 1: Your First Server"
+description: Install Alchemy, create a Stack with a Hetzner Server, and deploy it.
+sidebar:
+  order: 1
+---
+
+import Terminal from "../../../../components/Terminal.astro";
+import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
+import { effectVersion } from "../../../../versions";
+
+export const pkgs = `"alchemy@next" "effect@${effectVersion}" "@effect/platform-bun@${effectVersion}" "@effect/platform-node@${effectVersion}"`;
+
+In this first part you'll install Alchemy and Effect, create a Stack
+with a Hetzner Cloud Server, deploy it, and SSH in — all in under
+five minutes.
+
+## Prerequisites
+
+- [Bun](https://bun.sh) (recommended) or Node.js 22+
+- A Hetzner project and an API token — see [Setup](/hetzner/setup)
+  if you haven't created those yet
+
+:::note[Costs]
+Hetzner bills servers by the hour. The `cx22` used in this tutorial
+costs about €4/month — a few cents for the time it takes to finish
+all four parts. `alchemy destroy` tears everything down when you're
+done.
+:::
+
+## Create a project
+
+Start with an empty directory and initialize a `package.json`:
+
+<Tabs syncKey="pkgManager">
+  <TabItem label="bun" icon="bun">
+    <Code code="mkdir my-app && cd my-app && bun init -y" lang="sh" />
+  </TabItem>
+  <TabItem label="npm" icon="npm">
+    <Code code="mkdir my-app && cd my-app && npm init -y" lang="sh" />
+  </TabItem>
+  <TabItem label="pnpm" icon="pnpm">
+    <Code code="mkdir my-app && cd my-app && pnpm init" lang="sh" />
+  </TabItem>
+  <TabItem label="yarn" icon="seti:yarn">
+    <Code code="mkdir my-app && cd my-app && yarn init -y" lang="sh" />
+  </TabItem>
+</Tabs>
+
+## Install dependencies
+
+Install <code>alchemy@next</code> and <code>effect@{effectVersion}</code>:
+
+<Tabs syncKey="pkgManager">
+  <TabItem label="bun" icon="bun">
+    <Code code={`bun add ${pkgs}`} lang="sh" />
+  </TabItem>
+  <TabItem label="npm" icon="npm">
+    <Code code={`npm install ${pkgs}`} lang="sh" />
+  </TabItem>
+  <TabItem label="pnpm" icon="pnpm">
+    <Code code={`pnpm add ${pkgs}`} lang="sh" />
+  </TabItem>
+  <TabItem label="yarn" icon="seti:yarn">
+    <Code code={`yarn add ${pkgs}`} lang="sh" />
+  </TabItem>
+</Tabs>
+
+## Create the Stack
+
+Every Alchemy program starts with a `Stack` — a collection of
+Resources managed by Providers with state tracked between deploys.
+
+Create an `alchemy.run.ts` file:
+
+```typescript
+// alchemy.run.ts
+import * as Alchemy from "alchemy";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+export default Alchemy.Stack(
+  "MyApp",
+  {
+  // @error: ts(2345) Argument of type '{ providers: Layer.Layer<never, never, never>; }' is not assignable to parameter of type 'StackProps<never>'.
+  // @error:   Property 'state' is missing in type '{ providers: Layer.Layer<never, never, never>; }' but required in type 'StackProps<never>'.
+    providers: Layer.empty,
+  },
+  Effect.gen(function* () {
+    // we'll add resources here next
+  }),
+);
+```
+
+TypeScript is unhappy: the `state` property is required. Every Stack
+needs a **state store** so Alchemy can persist resource state between
+deploys and compute diffs against your infrastructure.
+
+## Configure state
+
+Hetzner has no state backend of its own, so we'll keep state on disk
+with `Alchemy.localState()` — it writes to `.alchemy/` next to your
+code, no setup required:
+
+```diff lang="typescript"
+// alchemy.run.ts
+import * as Alchemy from "alchemy";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+export default Alchemy.Stack(
+  "MyApp",
+  {
+    providers: Layer.empty,
++    state: Alchemy.localState(),
+  },
+  Effect.gen(function* () {
+    // we'll add resources here next
+  }),
+);
+```
+
+:::note[Other state stores]
+Local state is perfect for a solo project. When you need state your
+team and CI can share, swap in `Cloudflare.state()` or `AWS.state()`
+— see [State Store](/state-store).
+:::
+
+## Add a Server
+
+Resources represent cloud infrastructure. Each resource is
+`yield*`-ed inside the Stack's Effect generator.
+
+Let's declare a Server — Hetzner's virtual machine — and observe the
+type error:
+
+```diff lang="typescript"
+// alchemy.run.ts
+import * as Alchemy from "alchemy";
++import * as Hetzner from "alchemy/Hetzner";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+export default Alchemy.Stack(
+  "MyApp",
+  {
+    providers: Layer.empty,
+    // @error: ts(2322) Type 'Layer<never, never, never>' is not assignable to type 'Layer<NoInfer<Providers>, never, StackServices>'.
+    // @error:   Type 'Providers' is not assignable to type 'never'.
+    state: Alchemy.localState(),
+  },
+  Effect.gen(function* () {
++    const server = yield* Hetzner.Server("box", {
++      serverType: "cx22",
++      image: "ubuntu-24.04",
++      location: "nbg1",
++    });
+  }),
+);
+```
+
+The props map directly onto Hetzner's console: `serverType` is the
+size (`cx22` = 2 vCPU / 4 GB), `image` is the OS, and `location` is
+the datacenter (`nbg1` is Nuremberg; `fsn1`, `hel1`, `ash`, `hil`,
+and `sin` also exist).
+
+TypeScript is telling us that `Layer.empty` doesn't provide
+`Hetzner.Providers` — the layer required by `Server`.
+
+## Fix the Providers
+
+Replace `Layer.empty` with `Hetzner.providers()` to resolve the type
+error:
+
+```diff lang="typescript"
+// alchemy.run.ts
+import * as Alchemy from "alchemy";
+import * as Hetzner from "alchemy/Hetzner";
+import * as Effect from "effect/Effect";
+-import * as Layer from "effect/Layer";
+
+export default Alchemy.Stack(
+  "MyApp",
+  {
++    providers: Hetzner.providers(),
+    state: Alchemy.localState(),
+  },
+  Effect.gen(function* () {
+    const server = yield* Hetzner.Server("box", {
+      serverType: "cx22",
+      image: "ubuntu-24.04",
+      location: "nbg1",
+    });
+  }),
+);
+```
+
+Now the program type-checks. The providers layer tells Alchemy how to
+talk to the Hetzner Cloud API, and the type system ensures you never
+forget to wire it up.
+
+## Add your SSH key
+
+The server will boot without one, but registering your public key
+lets you SSH straight in (and stops Hetzner emailing you a root
+password). Declare an `SshKey` and pass it to the server:
+
+```diff lang="typescript"
+Effect.gen(function* () {
++  const key = yield* Hetzner.SshKey("laptop", {
++    publicKey: "ssh-ed25519 AAAA... you@laptop",
++  });
+
+  const server = yield* Hetzner.Server("box", {
+    serverType: "cx22",
+    image: "ubuntu-24.04",
+    location: "nbg1",
++    sshKeys: [key],
+  });
+}),
+```
+
+Paste your own key from `~/.ssh/id_ed25519.pub` (create one with
+`ssh-keygen -t ed25519` if you don't have it). Passing the resolved
+`key` to `sshKeys` is your first **resource reference** — Alchemy
+sees the dependency and orders the deploy so the key exists before
+the server boots.
+
+## Return Stack outputs
+
+Stack outputs let you see important values after a deploy. Return an
+object from the generator to expose the server's public addresses:
+
+```diff lang="typescript"
+  const server = yield* Hetzner.Server("box", {
+    serverType: "cx22",
+    image: "ubuntu-24.04",
+    location: "nbg1",
+    sshKeys: [key],
+  });
+
++  return {
++    ipv4: server.ipv4,
++    ipv6: server.ipv6,
++  };
+}),
+```
+
+## Deploy
+
+Run `alchemy deploy` to create the key and the server:
+
+<Tabs syncKey="pkgManager">
+  <TabItem label="bun" icon="bun">
+    <Code code="bun alchemy deploy" lang="sh" />
+  </TabItem>
+  <TabItem label="npm" icon="npm">
+    <Code code="npm run alchemy deploy" lang="sh" />
+  </TabItem>
+  <TabItem label="pnpm" icon="pnpm">
+    <Code code="pnpm alchemy deploy" lang="sh" />
+  </TabItem>
+  <TabItem label="yarn" icon="seti:yarn">
+    <Code code="yarn alchemy deploy" lang="sh" />
+  </TabItem>
+</Tabs>
+
+The first time you deploy, Alchemy prompts for Hetzner credentials —
+paste the API token you generated in [Setup](/hetzner/setup). The
+token is verified and saved to your **`default`**
+[profile](/environments/profiles), so you won't be asked again.
+
+<Terminal content={`[u]Plan[/u]: [g]2 to create[/g]
+
+[g]+[/g] [b]laptop[/b] [d](Hetzner.SshKey)[/d]
+[g]+[/g] [b]box[/b] [d](Hetzner.Server)[/d]
+
+Proceed?
+◉ Yes ○ No
+[g]✓[/g] [b]laptop[/b] [d](Hetzner.SshKey)[/d] [g]created[/g]
+[g]✓[/g] [b]box[/b] [d](Hetzner.Server)[/d] [g]created[/g]
+{
+[s2]ipv4: "203.0.113.10",
+[s2]ipv6: "2001:db8::1",
+}`} />
+
+Alchemy shows a plan, asks for confirmation, creates both resources,
+and prints the stack outputs. A Hetzner server boots in about ten
+seconds.
+
+## Verify it worked
+
+The server is listed in your project in the
+[Hetzner Cloud Console](https://console.hetzner.com), and you can SSH
+straight in:
+
+```sh
+ssh root@203.0.113.10
+```
+
+Run `alchemy deploy` again. Because nothing changed, both resources
+show as no-ops:
+
+<Terminal content={`[u]Plan[/u]: [d]no changes[/d]
+
+{
+[s2]ipv4: "203.0.113.10",
+[s2]ipv6: "2001:db8::1",
+}`} />
+
+This is the core loop — declare resources in code, deploy, and
+Alchemy figures out what changed.
+
+## Recap
+
+You now have:
+
+- An `alchemy.run.ts` with a Stack, an SSH key, and a Server
+- A live VM running Ubuntu in Nuremberg, booted in seconds
+- Stack outputs showing its public IPv4 and IPv6 addresses
+
+In [Part 2](/hetzner/tutorial/part-2), you'll deploy code to this
+server — a `Hetzner.Service` that serves HTTP without you ever
+writing a systemd unit or a Dockerfile.

--- a/website/src/content/docs/hetzner/tutorial/part-2.mdx
+++ b/website/src/content/docs/hetzner/tutorial/part-2.mdx
@@ -1,0 +1,305 @@
+---
+title: "Part 2: Deploy a Service"
+description: Bundle an Effect HTTP server, deploy it to your Hetzner Server as a systemd unit, and serve requests on a public URL.
+sidebar:
+  order: 2
+---
+
+import Terminal from "../../../../components/Terminal.astro";
+import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
+
+In [Part 1](/hetzner/tutorial/part-1) you deployed a Server. Now
+you'll put code on it: a `Hetzner.Service` — an Effect program that
+Alchemy bundles, copies over SSH, and runs as a systemd unit. No
+Dockerfile, no unit files, no scp scripts.
+
+## Move the Server to a module
+
+So far the resources live inside the Stack's generator. To let other
+files reference them, declare them at **module scope** instead — a
+resource declared this way is an Effect you can import and `yield*`
+anywhere. Create `src/server.ts` and move the key and Server from
+Part 1 into it:
+
+```typescript
+// src/server.ts
+import * as Hetzner from "alchemy/Hetzner";
+
+export const Key = Hetzner.SshKey("laptop", {
+  publicKey: "ssh-ed25519 AAAA... you@laptop",
+});
+
+export const Box = Hetzner.Server("box", {
+  serverType: "cx22",
+  image: "ubuntu-24.04",
+  location: "nbg1",
+  sshKeys: [Key],
+});
+```
+
+Notice `sshKeys: [Key]` passes the declaration directly, without
+yielding — resource-valued props accept the resource or an Effect
+producing it. The logical ids are still `laptop` and `box`, so
+Alchemy recognizes them as the same resources you deployed in
+Part 1 — moving declarations between files doesn't recreate
+anything.
+
+## Update the Stack
+
+Import the Server and yield it from the Stack:
+
+```diff lang="typescript"
+// alchemy.run.ts
+import * as Alchemy from "alchemy";
+import * as Hetzner from "alchemy/Hetzner";
+import * as Effect from "effect/Effect";
++import { Box } from "./src/server.ts";
+
+export default Alchemy.Stack(
+  "MyApp",
+  {
+    providers: Hetzner.providers(),
+    state: Alchemy.localState(),
+  },
+  Effect.gen(function* () {
+-    const key = yield* Hetzner.SshKey("laptop", {
+-      publicKey: "ssh-ed25519 AAAA... you@laptop",
+-    });
+-
+-    const server = yield* Hetzner.Server("box", {
+-      serverType: "cx22",
+-      image: "ubuntu-24.04",
+-      location: "nbg1",
+-      sshKeys: [key],
+-    });
++    const server = yield* Box;
+
+    return {
+      ipv4: server.ipv4,
+      ipv6: server.ipv6,
+    };
+  }),
+);
+```
+
+The key is still part of the graph — it's registered when the
+Server's `sshKeys` reference resolves.
+
+## Create the Service file
+
+A Service in Alchemy is a class — it has both an infrastructure
+definition and a runtime implementation expressed as an Effect.
+Create `src/api.ts` with the smallest possible declaration:
+
+```typescript
+// src/api.ts
+import * as Hetzner from "alchemy/Hetzner";
+import * as Effect from "effect/Effect";
+import { Box } from "./server.ts";
+
+export default class Api extends Hetzner.Service<Api>()(
+  "Api",
+  { server: Box, main: import.meta.url },
+  Effect.gen(function* () {
+    return {};
+  }),
+) {}
+```
+
+The `<Api>` type argument plus the empty `()` is a one-time bit of
+ceremony — it lets TypeScript reason about `Api` as a typed handle.
+`server: Box` says which machine this Service runs on, and
+`main: import.meta.url` tells Alchemy this same file is the bundle
+entrypoint: at deploy time it's bundled with Rolldown and shipped to
+the Server.
+
+## Serve HTTP with `fetch`
+
+Add a `fetch` field — Alchemy treats anything returned from the
+`Effect.gen` block as the runtime API, and `fetch` specifically is
+wired to an HTTP server listening on the Service's port:
+
+```diff lang="typescript"
+// src/api.ts
+import * as Hetzner from "alchemy/Hetzner";
+import * as Effect from "effect/Effect";
++import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import { Box } from "./server.ts";
+
+export default class Api extends Hetzner.Service<Api>()(
+  "Api",
+  { server: Box, main: import.meta.url },
+  Effect.gen(function* () {
+-    return {};
++    return {
++      fetch: Effect.succeed(HttpServerResponse.text("Hello from Hetzner!")),
++    };
+  }),
+) {}
+```
+
+`HttpServerResponse` is the same `effect/unstable/http` API used on
+every other Alchemy runtime — the handler you write here would run
+unchanged on Cloudflare Workers or AWS Lambda.
+
+:::note
+Notice the "Effect returning an Effect" pattern. The outer generator
+is the **Init phase** — it runs at deploy time and at process
+startup. The inner `fetch` generator is the **Runtime phase** — it
+runs per request.
+:::
+
+## Set the port
+
+Give the Service an explicit port so we know where to reach it:
+
+```diff lang="typescript"
+export default class Api extends Hetzner.Service<Api>()(
+  "Api",
+-  { server: Box, main: import.meta.url },
++  { server: Box, main: import.meta.url, port: 3000 },
+```
+
+The port is written to the process environment as `PORT` and used to
+build the Service's `url` attribute (`http://<server-ipv4>:<port>`).
+
+## Add a health route
+
+When a Service declares a `port`, the deploy doesn't just start the
+unit and hope — it polls `http://127.0.0.1:<port>/health` on the
+Server until it answers, and fails the deploy (with the unit's
+journal in the output) if it never does. Add the route:
+
+```diff lang="typescript"
+// src/api.ts
++import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+// ...
+    return {
+-      fetch: Effect.succeed(HttpServerResponse.text("Hello from Hetzner!")),
++      fetch: Effect.gen(function* () {
++        const request = yield* HttpServerRequest;
++        const url = new URL(request.url, "http://service");
++        if (url.pathname === "/health") {
++          return HttpServerResponse.json({ ok: true });
++        }
++        return HttpServerResponse.text("Hello from Hetzner!");
++      }),
+    };
+```
+
+## Wire the Service into the Stack
+
+The `Api` class is just a typed identifier — yielding it inside the
+Stack's Effect is what registers the resource and starts the deploy:
+
+```diff lang="typescript"
+// alchemy.run.ts
+import * as Alchemy from "alchemy";
+import * as Hetzner from "alchemy/Hetzner";
+import * as Effect from "effect/Effect";
++import Api from "./src/api.ts";
+import { Box } from "./src/server.ts";
+
+export default Alchemy.Stack(
+  "MyApp",
+  {
+    providers: Hetzner.providers(),
+    state: Alchemy.localState(),
+  },
+  Effect.gen(function* () {
+    const server = yield* Box;
++    const api = yield* Api;
+
+    return {
+      ipv4: server.ipv4,
+-      ipv6: server.ipv6,
++      url: api.url,
+    };
+  }),
+);
+```
+
+Yielding `Api` returns the resolved Service outputs — the systemd
+unit name, the port, and the public `url` we surface from the Stack.
+
+## Deploy
+
+<Tabs syncKey="pkgManager">
+  <TabItem label="bun" icon="bun">
+    <Code code="bun alchemy deploy" lang="sh" />
+  </TabItem>
+  <TabItem label="npm" icon="npm">
+    <Code code="npm run alchemy deploy" lang="sh" />
+  </TabItem>
+  <TabItem label="pnpm" icon="pnpm">
+    <Code code="pnpm alchemy deploy" lang="sh" />
+  </TabItem>
+  <TabItem label="yarn" icon="seti:yarn">
+    <Code code="yarn alchemy deploy" lang="sh" />
+  </TabItem>
+</Tabs>
+
+<Terminal content={`[u]Plan[/u]: [g]1 to create[/g]
+
+[g]+[/g] [b]Api[/b] [d](Hetzner.Service)[/d]
+[d]•[/d] [b]box[/b] [d](Hetzner.Server)[/d]
+
+Proceed?
+◉ Yes ○ No
+[g]✓[/g] [b]Api[/b] [d](Hetzner.Service)[/d] [g]created[/g]
+{
+[s2]ipv4: "203.0.113.10",
+[s2]url: "http://203.0.113.10:3000",
+}`} />
+
+A lot just happened over one SSH connection:
+
+1. `src/api.ts` was bundled with Rolldown into a single ESM file.
+2. Alchemy connected to the Server using the **deploy key** it
+   injected when the Server was created — no SSH configuration on
+   your side.
+3. It unpacked the bundle to `/opt/<unit>/` and wrote an
+   `EnvironmentFile` with `PORT` and the stack metadata. The
+   [Bun](https://bun.sh) runtime is already there — Alchemy's
+   cloud-init bootstrap installed it when the Server was created.
+4. It wrote a systemd unit (`Restart=always`), enabled it, and
+   waited for `/health` to answer.
+
+## Try it out
+
+```sh
+curl http://203.0.113.10:3000
+# → Hello from Hetzner!
+```
+
+The port is reachable because a fresh Hetzner server has **no
+firewall** — every port is open until you apply one. In
+[Part 4](/hetzner/tutorial/part-4) we'll lock this down.
+
+## Ship a change
+
+Edit the greeting in `src/api.ts` and deploy again:
+
+<Terminal content={`[u]Plan[/u]: [y]1 to update[/y]
+
+[y]~[/y] [b]Api[/b] [d](Hetzner.Service)[/d]
+
+Proceed?
+◉ Yes ○ No
+[g]✓[/g] [b]Api[/b] [d](Hetzner.Service)[/d] [y]updated[/y]`} />
+
+Alchemy hashes the bundle: if your code didn't change, the Service
+is a no-op; if it did, the new bundle is copied up and the unit
+restarted — a few seconds end to end.
+
+## Recap
+
+You now have:
+
+- An HTTP Service running on your Server as a systemd unit, with
+  `Restart=always` supervision
+- A public URL serving requests, verified healthy at deploy time
+- A code-hash-based update loop — edit, deploy, restarted
+
+In [Part 3](/hetzner/tutorial/part-3), you'll attach a Volume and
+persist data across deploys.

--- a/website/src/content/docs/hetzner/tutorial/part-3.mdx
+++ b/website/src/content/docs/hetzner/tutorial/part-3.mdx
@@ -1,0 +1,207 @@
+---
+title: "Part 3: Persist Data with a Volume"
+description: Attach a Hetzner Volume, mount it into your Service with the MountVolume binding, and store files that survive deploys.
+sidebar:
+  order: 3
+---
+
+import Terminal from "../../../../components/Terminal.astro";
+import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
+
+Your Service from [Part 2](/hetzner/tutorial/part-2) is stateless —
+anything it writes to the Server's root disk dies with the Server.
+In this part you'll attach a **Volume** — Hetzner's network block
+storage — and mount it into the Service so files survive deploys and
+even Server replacement.
+
+## Declare a Volume
+
+Add a Volume next to the Server in `src/server.ts`:
+
+```diff lang="typescript"
+// src/server.ts
+import * as Hetzner from "alchemy/Hetzner";
+
+export const Key = Hetzner.SshKey("laptop", { /* ... */ });
+
+export const Box = Hetzner.Server("box", {
+  serverType: "cx22",
+  image: "ubuntu-24.04",
+  location: "nbg1",
+  sshKeys: [Key],
+});
+
++export const Data = Hetzner.Volume("data", {
++  size: 10,
++  format: "ext4",
++  location: "nbg1",
++});
+```
+
+`size` is in GB (10 is the minimum), and the `location` must match
+the Server's — volumes attach over the local network. Note what's
+*not* here: no `server` prop. The Service will claim it instead.
+
+## Mount it into the Service
+
+Inside the Service's init, bind the Volume with
+`Hetzner.MountVolume` — pass the declaration directly, no yielding
+required:
+
+```diff lang="typescript"
+// src/api.ts
+import * as Hetzner from "alchemy/Hetzner";
+import * as Effect from "effect/Effect";
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+-import { Box } from "./server.ts";
++import { Box, Data } from "./server.ts";
+
+export default class Api extends Hetzner.Service<Api>()(
+  "Api",
+  { server: Box, main: import.meta.url, port: 3000 },
+  Effect.gen(function* () {
++    const mount = yield* Hetzner.MountVolume(Data, { path: "/data" });
+
+    return {
+      fetch: /* ... */,
+    };
+  }),
+) {}
+```
+
+`MountVolume` is a **binding**: at deploy time it tells the Service
+"attach this Volume to my Server and mount it at `/data`", and at
+runtime it hands you the resolved `mount.path` and `mount.device`.
+
+## Provide the binding layer
+
+Bindings declare a capability; layers implement it. Provide
+`MountVolumeLive` on the Service's init Effect:
+
+```diff lang="typescript"
+  Effect.gen(function* () {
+    const mount = yield* Hetzner.MountVolume(Data, { path: "/data" });
+
+    return {
+      fetch: /* ... */,
+    };
+-  }),
++  }).pipe(Effect.provide(Hetzner.MountVolumeLive)),
+) {}
+```
+
+## Write files with `PUT /:name`
+
+Now use the mount from the handler. The runtime provides Effect's
+`FileSystem` service, so the Volume is just a directory:
+
+```diff lang="typescript"
+// src/api.ts
++import * as FileSystem from "effect/FileSystem";
+// ...
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        const url = new URL(request.url, "http://service");
+        if (url.pathname === "/health") {
+          return HttpServerResponse.json({ ok: true });
+        }
++        const fs = yield* FileSystem.FileSystem;
++        const file = `${mount.path}${url.pathname}`;
++
++        if (request.method === "PUT") {
++          const body = yield* request.text;
++          yield* fs.writeFileString(file, body).pipe(Effect.orDie);
++          return HttpServerResponse.empty({ status: 204 });
++        }
++
+        return HttpServerResponse.text("Hello from Hetzner!");
+      }),
+```
+
+## Read files with `GET /:name`
+
+Add the read branch, turning a missing file into a 404:
+
+```diff lang="typescript"
+if (request.method === "PUT") {
+  const body = yield* request.text;
+  yield* fs.writeFileString(file, body).pipe(Effect.orDie);
+  return HttpServerResponse.empty({ status: 204 });
+}
+
++if (request.method === "GET") {
++  const text = yield* fs.readFileString(file).pipe(
++    Effect.catchAll(() => Effect.succeed(undefined)),
++  );
++  if (text === undefined) {
++    return HttpServerResponse.text("Not found", { status: 404 });
++  }
++  return HttpServerResponse.text(text);
++}
+
+return HttpServerResponse.text("Hello from Hetzner!");
+```
+
+## Deploy
+
+<Tabs syncKey="pkgManager">
+  <TabItem label="bun" icon="bun">
+    <Code code="bun alchemy deploy" lang="sh" />
+  </TabItem>
+  <TabItem label="npm" icon="npm">
+    <Code code="npm run alchemy deploy" lang="sh" />
+  </TabItem>
+  <TabItem label="pnpm" icon="pnpm">
+    <Code code="pnpm alchemy deploy" lang="sh" />
+  </TabItem>
+  <TabItem label="yarn" icon="seti:yarn">
+    <Code code="yarn alchemy deploy" lang="sh" />
+  </TabItem>
+</Tabs>
+
+<Terminal content={`[u]Plan[/u]: [g]1 to create[/g], [y]1 to update[/y]
+
+[g]+[/g] [b]data[/b] [d](Hetzner.Volume)[/d]
+[y]~[/y] [b]Api[/b] [d](Hetzner.Service)[/d]
+
+Proceed?
+◉ Yes ○ No
+[g]✓[/g] [b]data[/b] [d](Hetzner.Volume)[/d] [g]created[/g]
+[g]✓[/g] [b]Api[/b] [d](Hetzner.Service)[/d] [y]updated[/y]`} />
+
+During the Service's deploy, Alchemy attaches the Volume to the
+Server, then (over the same SSH session) creates `/data`, mounts the
+device, and adds an `/etc/fstab` entry so the mount survives
+reboots. Every step is idempotent — two Services mounting the same
+`(volume, path)` share one attach and one mount.
+
+## Try it out
+
+```sh
+# Store a file on the Volume
+curl -X PUT http://203.0.113.10:3000/hello.txt -d 'Hello, Volume!'
+
+# Read it back
+curl http://203.0.113.10:3000/hello.txt
+# → Hello, Volume!
+```
+
+Ship another code change and deploy — the file is still there. The
+Volume is a separate resource with its own lifecycle: even if the
+Server is replaced, the Volume re-attaches to the new machine on the
+next deploy.
+
+## Recap
+
+You now have:
+
+- A 10 GB Volume attached to your Server and mounted at `/data`,
+  with an fstab entry for reboots
+- A Service reading and writing it through Effect's `FileSystem` —
+  no SDK, just files
+- Data that outlives deploys and Server replacement
+
+In [Part 4](/hetzner/tutorial/part-4), you'll put a firewall in
+front of the Server and a managed Load Balancer in front of the
+Service.

--- a/website/src/content/docs/hetzner/tutorial/part-4.mdx
+++ b/website/src/content/docs/hetzner/tutorial/part-4.mdx
@@ -1,0 +1,260 @@
+---
+title: "Part 4: Networking & Load Balancing"
+description: Put your Service behind a managed Load Balancer on a private network, and lock the Server down with a Firewall.
+sidebar:
+  order: 4
+---
+
+import Terminal from "../../../../components/Terminal.astro";
+import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
+
+Right now your Service is served straight off the Server's public
+IP, and every port on the Server is open to the internet. In this
+final part you'll make it production-shaped: a **private Network**
+between the machines, a managed **Load Balancer** in front, and a
+**Firewall** that closes the app port to everyone but the LB.
+
+:::note[Costs]
+The `lb11` Load Balancer costs about €5.39/month, billed hourly like
+everything else. The [cleanup step](#clean-up) at the end tears it
+all down.
+:::
+
+## Create a private Network
+
+Add a Network to `src/server.ts` and attach the Server to it:
+
+```diff lang="typescript"
+// src/server.ts
+import * as Hetzner from "alchemy/Hetzner";
+
++export const Net = Hetzner.Network("net", {
++  ipRange: "10.0.0.0/16",
++  subnets: [
++    { type: "cloud", networkZone: "eu-central", ipRange: "10.0.1.0/24" },
++  ],
++});
+
+export const Box = Hetzner.Server("box", {
+  serverType: "cx22",
+  image: "ubuntu-24.04",
+  location: "nbg1",
+  sshKeys: [Key],
++  networks: [Net],
+});
+
+export const Data = Hetzner.Volume("data", { /* ... */ });
+```
+
+`nbg1` lives in the `eu-central` network zone. Passing `Net` — a
+module-scope resource declaration — directly in `networks` is
+enough: resource-valued props accept the resource or an Effect
+producing it, and Alchemy resolves the reference and orders the
+deploy.
+
+## Add a Load Balancer
+
+Declare the Load Balancer in `src/server.ts`, targeting the Server
+over its **private** IP:
+
+```diff lang="typescript"
+// src/server.ts
++export const Edge = Hetzner.LoadBalancer("edge", {
++  location: "nbg1",
++  loadBalancerType: "lb11",
++  networks: [Net],
++  targets: [{ type: "server", server: Box, usePrivateIp: true }],
++  services: [
++    {
++      protocol: "http",
++      listenPort: 80,
++      destinationPort: 3000,
++      healthCheck: {
++        protocol: "http",
++        port: 3000,
++        interval: 3,
++        timeout: 2,
++        retries: 2,
++        http: { path: "/health" },
++      },
++    },
++  ],
++});
+```
+
+The LB listens on port 80 and forwards to port 3000 on the Server,
+reaching it through the private Network (`usePrivateIp: true`). Its
+health check polls the same `/health` route the deploy already
+uses — an unhealthy Service is pulled out of rotation automatically.
+
+## Lock down the Server
+
+With traffic flowing through the private network, close the public
+app port. Apply a Firewall to the Server that allows SSH from
+anywhere but port 3000 only from inside the Network:
+
+```diff lang="typescript"
+// src/server.ts
++export const Wall = Hetzner.Firewall("wall", {
++  applyTo: [Box],
++  rules: [
++    {
++      direction: "in",
++      protocol: "tcp",
++      port: "22",
++      sourceIps: ["0.0.0.0/0", "::/0"],
++      description: "ssh",
++    },
++    {
++      direction: "in",
++      protocol: "tcp",
++      port: "3000",
++      sourceIps: ["10.0.0.0/16"],
++      description: "api via private net",
++    },
++  ],
++});
+```
+
+A Hetzner Firewall is default-deny for inbound traffic: once
+applied, only what a rule allows gets through. Outbound stays open.
+
+## Surface the Load Balancer URL
+
+Yield the new resources from the Stack and output the LB address
+instead of the Server's:
+
+```diff lang="typescript"
+// alchemy.run.ts
+import * as Alchemy from "alchemy";
+import * as Hetzner from "alchemy/Hetzner";
++import * as Output from "alchemy/Output";
+import * as Effect from "effect/Effect";
+import Api from "./src/api.ts";
+-import { Box } from "./src/server.ts";
++import { Box, Edge, Wall } from "./src/server.ts";
+
+// ...
+  Effect.gen(function* () {
+    const server = yield* Box;
++    const lb = yield* Edge;
++    yield* Wall;
+    const api = yield* Api;
+
+    return {
+      ipv4: server.ipv4,
+-      url: api.url,
++      url: Output.interpolate`http://${lb.ipv4}`,
+    };
+  }),
+```
+
+`Output.interpolate` builds a string from resource outputs — the
+LB's IP isn't known until it's created, so the template resolves
+after deploy.
+
+## Deploy
+
+<Tabs syncKey="pkgManager">
+  <TabItem label="bun" icon="bun">
+    <Code code="bun alchemy deploy" lang="sh" />
+  </TabItem>
+  <TabItem label="npm" icon="npm">
+    <Code code="npm run alchemy deploy" lang="sh" />
+  </TabItem>
+  <TabItem label="pnpm" icon="pnpm">
+    <Code code="pnpm alchemy deploy" lang="sh" />
+  </TabItem>
+  <TabItem label="yarn" icon="seti:yarn">
+    <Code code="yarn alchemy deploy" lang="sh" />
+  </TabItem>
+</Tabs>
+
+<Terminal content={`[u]Plan[/u]: [g]3 to create[/g], [y]1 to update[/y]
+
+[g]+[/g] [b]net[/b] [d](Hetzner.Network)[/d]
+[g]+[/g] [b]edge[/b] [d](Hetzner.LoadBalancer)[/d]
+[g]+[/g] [b]wall[/b] [d](Hetzner.Firewall)[/d]
+[y]~[/y] [b]box[/b] [d](Hetzner.Server)[/d]
+
+Proceed?
+◉ Yes ○ No
+[g]✓[/g] [b]net[/b] [d](Hetzner.Network)[/d] [g]created[/g]
+[g]✓[/g] [b]box[/b] [d](Hetzner.Server)[/d] [y]updated[/y]
+[g]✓[/g] [b]edge[/b] [d](Hetzner.LoadBalancer)[/d] [g]created[/g]
+[g]✓[/g] [b]wall[/b] [d](Hetzner.Firewall)[/d] [g]created[/g]
+{
+[s2]ipv4: "203.0.113.10",
+[s2]url: "http://198.51.100.7",
+}`} />
+
+## Try it out
+
+The app now answers on the Load Balancer:
+
+```sh
+curl http://198.51.100.7/hello.txt
+# → Hello, Volume!
+```
+
+And the direct route is gone — the Firewall drops it:
+
+```sh
+curl --max-time 5 http://203.0.113.10:3000/hello.txt
+# → curl: (28) Connection timed out
+```
+
+:::tip[Your own domain?]
+Hetzner DNS is part of the provider too: declare a `Hetzner.Zone`
+and a `Hetzner.RecordSet` pointing at `lb.ipv4`, and add a managed
+`Hetzner.Certificate` to terminate TLS on the Load Balancer. See
+[DNS](/hetzner/networking/dns) and
+[Networking](/hetzner/networking#load-balancer).
+:::
+
+## Clean up
+
+You're done — tear everything down so the hourly billing stops:
+
+<Tabs syncKey="pkgManager">
+  <TabItem label="bun" icon="bun">
+    <Code code="bun alchemy destroy" lang="sh" />
+  </TabItem>
+  <TabItem label="npm" icon="npm">
+    <Code code="npm run alchemy destroy" lang="sh" />
+  </TabItem>
+  <TabItem label="pnpm" icon="pnpm">
+    <Code code="pnpm alchemy destroy" lang="sh" />
+  </TabItem>
+  <TabItem label="yarn" icon="seti:yarn">
+    <Code code="yarn alchemy destroy" lang="sh" />
+  </TabItem>
+</Tabs>
+
+Alchemy deletes everything in reverse dependency order — Service,
+Load Balancer, Firewall, Volume, Server, Network, SSH key.
+
+## Recap
+
+Over four parts you built a complete, production-shaped deployment:
+
+- A Server provisioned in seconds, with an Alchemy-managed deploy
+  key
+- An HTTP Service bundled, shipped over SSH, and supervised by
+  systemd — updated only when its code hash changes
+- A Volume mounted at `/data` whose contents outlive deploys
+- A private Network, a health-checked Load Balancer, and a
+  default-deny Firewall
+
+## Where next
+
+- [Services](/hetzner/compute/services) — background workers,
+  environment variables, multiple Services per Server.
+- [Servers](/hetzner/compute/servers) — SSH access, snapshots,
+  placement groups, cloud-init.
+- [DNS](/hetzner/networking/dns) — zones and records for your own
+  domain.
+- [Testing](/testing) — deploy this stack from an integration test
+  and drive it over HTTP.
+- [CI](/environments/ci) — run `alchemy deploy` from GitHub Actions
+  with `HCLOUD_TOKEN`.

--- a/website/src/docs-icons.ts
+++ b/website/src/docs-icons.ts
@@ -17,6 +17,7 @@ export const TAB_ICONS: Record<string, string | undefined> = {
   CLI: l("square-terminal"),
   Cloudflare: b("cloudflare"),
   AWS: b("amazonwebservices"),
+  Hetzner: b("hetzner"),
   PlanetScale: b("planetscale"),
   Neon: b("neon"),
   Prisma: b("prisma"),
@@ -64,6 +65,7 @@ const GROUP_ICONS: Record<string, string | undefined> = {
   // Reference tab: provider groups get their official brand marks.
   AWS: b("amazonwebservices"),
   Cloudflare: b("cloudflare"),
+  Hetzner: b("hetzner"),
   GitHub: b("github"),
   Neon: b("neon"),
   Planetscale: b("planetscale"),

--- a/website/src/docs-tabs.ts
+++ b/website/src/docs-tabs.ts
@@ -43,6 +43,12 @@ export const DOCS_TABS: DocsTab[] = [
     slot: "primary",
   },
   {
+    label: "Hetzner",
+    href: "/hetzner",
+    prefixes: ["/hetzner", "/providers/hetzner"],
+    slot: "primary",
+  },
+  {
     label: "PlanetScale",
     href: "/planetscale",
     prefixes: ["/planetscale", "/providers/planetscale"],

--- a/website/src/pages/index.mdx
+++ b/website/src/pages/index.mdx
@@ -141,6 +141,7 @@ export const P99Alarm = AWS.CloudWatch.Alarm("p99Latency", {
   </div>
   <div class="alc-cloud-chips">
     <span class="alc-cloud-chips__label">Also</span>
+    <a class="alc-cloud-chip" href="/hetzner">Hetzner</a>
     <a class="alc-cloud-chip" href="/planetscale">PlanetScale</a>
     <a class="alc-cloud-chip" href="/neon">Neon</a>
     <a class="alc-cloud-chip" href="/axiom">Axiom</a>


### PR DESCRIPTION
Dedicated docs for the Hetzner provider ([#1258](https://github.com/alchemy-run/alchemy-effect/pull/1258)): a full docs hub mirroring the AWS/Cloudflare skeleton, registered as a primary docs tab.

- **Overview + Setup** — create a Hetzner project, generate a Read & Write API token, `alchemy login` (stored token or `HCLOUD_TOKEN`; CI auto-selects env), state-store guidance (`Alchemy.localState()` default).
- **Tutorial (4 parts)** — Server + SshKey → deploy a `Hetzner.Service` (including the deploy's `/health` readiness gate) → Volume + `MountVolume` → private Network + Load Balancer + Firewall, ending with `alchemy destroy`.
- **Guides** — Servers (SSH keys, deploy key, `Hetzner.Ssh`, cloud-init caveat, snapshots), Services (systemd deploy mechanics, env/Config, background workers via `ServerHost.run`, `journalctl` logs), Volumes, Networking (firewalls, LB + TLS, Floating/Primary IPs), DNS (Zone/RecordSet, Read/Write bindings, `waitForZoneAction`).

Snippets follow the declaration-reference DX — module scope never yields, and declarations pass straight into bindings/props:

```ts
export const Data = Hetzner.Volume("data", { size: 10, format: "ext4", location: "nbg1" });

// inside the Service impl
const mount = yield* Hetzner.MountVolume(Data, { path: "/data" });
```

### Flattened Resources sidebar

The generated reference tree rendered redundant single-child groups (`Certificate > Certificate`, and `Domains & DNS > DNS > ReadDns` three deep). `buildServiceItems` now collapses a group holding exactly one page named the same as the group into a plain link (also fixes Prisma's `App > App` nesting; AWS/Cloudflare had zero such groups and are unchanged), and the Hetzner DNS bindings drop their `@product`/`@category` tags so the provider renders as a flat 21-entry list like Docker.

Verified with `bun run docs:check` (4,264 pages, link + diff-indent checks pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
