### PR TITLE
fix(cloudflare): keep local dev Worker ports stable across alchemy dev sessions

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -15,7 +15,7 @@ import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
 import * as Equal from "effect/Equal";
 import * as Exit from "effect/Exit";
-import type * as FileSystem from "effect/FileSystem";
+import * as FileSystem from "effect/FileSystem";
 import * as MutableHashMap from "effect/MutableHashMap";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
@@ -61,10 +61,14 @@ import {
 import { startViteChild } from "./ViteChild.ts";
 import { DEFAULT_DEV_PORT, type ViteChildConfig } from "./ViteChild.shared.ts";
 
-/** Local dev-server options (the worker-mode arm of `WorkerProps["dev"]`). */
-type DevServerOptions = Extract<WorkerProps["dev"], { mode?: "worker" }> & {
-  port: number;
-};
+/**
+ * Local dev-server options (the worker-mode arm of `WorkerProps["dev"]`).
+ * `port` stays `undefined` when the user didn't configure one — the sticky
+ * port assignment (see `startProxy`) resolves the effective port at serve
+ * time, so an implicit port never participates in config hashing or proxy
+ * reuse comparisons.
+ */
+type DevServerOptions = Extract<WorkerProps["dev"], { mode?: "worker" }>;
 
 // Hosts that bind every interface — the dev server is then reachable at
 // `localhost` *and* at each LAN address, like Vite's `--host` output.
@@ -109,6 +113,7 @@ export const LocalWorkerProvider = () =>
       const stack = yield* Stack;
       const storageDirectory = yield* localStorageDirectory;
       const path = yield* Path.Path;
+      const fs = yield* FileSystem.FileSystem;
       const localRuntimeState = yield* LocalRuntimeState;
       const workerProxy = yield* WorkerProxy.WorkerProxy;
       const cloudflareEnv = yield* CloudflareEnvironment;
@@ -192,15 +197,71 @@ export const LocalWorkerProvider = () =>
         return consumers;
       });
 
+      // Worker → dev-proxy port assignments from previous dev sessions,
+      // persisted one file per physical worker name under
+      // `.alchemy/local/worker-ports/` (the name is stable across sessions
+      // and unique across stacks/stages sharing the project's `.alchemy`;
+      // one file per worker keeps concurrent sessions from clobbering each
+      // other's assignments). Without a record, every worker without an
+      // explicit `dev.port` hunts up from `DEFAULT_DEV_PORT` in whatever
+      // order the workers happen to start — so a multi-worker stack
+      // reshuffles its worker↔port mapping on every `alchemy dev` session,
+      // breaking clients that hold on to a worker's URL. Recording each
+      // worker's actual port and preferring it on the next start keeps the
+      // mapping stable. Explicit `dev.port` (including `0` for a
+      // deliberately ephemeral port) always wins and is never recorded.
+      const portAssignmentsDirectory = path.join(
+        storageDirectory,
+        "worker-ports",
+      );
+      const portAssignmentFile = (workerName: string) =>
+        path.join(portAssignmentsDirectory, encodeURIComponent(workerName));
+      const recordedPort = Effect.fn(function* (workerName: string) {
+        const port = yield* fs
+          .readFileString(portAssignmentFile(workerName))
+          .pipe(
+            Effect.map((content) => Number(content.trim())),
+            Effect.orElseSucceed(() => Number.NaN),
+          );
+        return Number.isInteger(port) && port > 0 && port <= 65535
+          ? port
+          : undefined;
+      });
+      const recordPort = (workerName: string, port: number) =>
+        fs.makeDirectory(portAssignmentsDirectory, { recursive: true }).pipe(
+          Effect.andThen(
+            fs.writeFileString(portAssignmentFile(workerName), `${port}`),
+          ),
+          // Best-effort: a failed write only costs next session's port
+          // stability, it must not fail the serve.
+          Effect.catchCause((cause) =>
+            Effect.logDebug(
+              `Failed to record dev port assignment for ${workerName}`,
+              Cause.squash(cause),
+            ),
+          ),
+        );
+
       const startProxy = Effect.fn(function* (
         id: string,
+        workerName: string,
         serverOptions: DevServerOptions,
       ) {
         const scope = yield* Scope.fork(rootScope);
+        // Implicit port: prefer the port this worker served on in the
+        // previous dev session (recorded below); only a first-ever start
+        // hunts up from the default.
+        const port =
+          serverOptions.port ??
+          (yield* recordedPort(workerName)) ??
+          DEFAULT_DEV_PORT;
         const instance = yield* workerProxy
-          .serve(serverOptions)
+          .serve({ ...serverOptions, port })
           .pipe(Scope.provide(scope));
         proxyInstances.set(id, { serverOptions, instance, scope });
+        if (serverOptions.port === undefined) {
+          yield* recordPort(workerName, Number(instance.url.port));
+        }
         return instance;
       });
 
@@ -214,16 +275,20 @@ export const LocalWorkerProvider = () =>
 
       const maybeStartProxy = Effect.fn(function* (
         id: string,
+        workerName: string,
         serverOptions: DevServerOptions,
       ) {
         const existing = proxyInstances.get(id);
         if (existing) {
+          // Compared on the *requested* options — an implicit port is
+          // `undefined` on both sides regardless of which port the running
+          // proxy landed on, so sticky assignment never restarts a proxy.
           if (Equal.equals(existing.serverOptions, serverOptions)) {
             return existing.instance;
           }
           yield* stopProxy(id);
         }
-        return yield* startProxy(id, serverOptions);
+        return yield* startProxy(id, workerName, serverOptions);
       });
 
       const toRuntimeModules = Effect.fn(function* (
@@ -410,9 +475,11 @@ export const LocalWorkerProvider = () =>
             : {
                 ...props.dev,
                 mode: "worker" as const,
-                // This is the default. Vite and cloudflare-runtime will retry
-                // if unavailable, unless `strictPort` is true.
-                port: props.dev?.port ?? DEFAULT_DEV_PORT,
+                // Deliberately no port default here: an implicit port is
+                // resolved at serve time (`startProxy`) from the recorded
+                // assignment of the previous dev session, and must stay out
+                // of the hashed config so sticky assignment never restarts
+                // the instance.
               };
         return {
           id,
@@ -835,7 +902,11 @@ export const LocalWorkerProvider = () =>
 
       const runWorker = Effect.fn(function* (worker: RunnableWorkerConfig) {
         const start = Date.now();
-        const proxy = yield* maybeStartProxy(worker.id, worker.dev);
+        const proxy = yield* maybeStartProxy(
+          worker.id,
+          worker.name,
+          worker.dev,
+        );
         // Inline `script` workers bypass the bundler entirely — the string
         // IS the module (mirroring the deploy path, which uploads it as a
         // single `main.js`). There is nothing to watch: script changes flow
@@ -901,7 +972,11 @@ export const LocalWorkerProvider = () =>
 
       const runAssetsOnly = Effect.fn(function* (worker: RunnableWorkerConfig) {
         const start = Date.now();
-        const proxy = yield* maybeStartProxy(worker.id, worker.dev);
+        const proxy = yield* maybeStartProxy(
+          worker.id,
+          worker.name,
+          worker.dev,
+        );
         yield* serveWith(worker, assetsOnlyBundle, proxy);
         yield* Effect.log(
           `[${worker.id}] Started in ${Math.round(Date.now() - start)}ms`,
@@ -1075,7 +1150,11 @@ export const LocalWorkerProvider = () =>
         invalidate: Effect.Effect<void>,
         source?: NonNullable<ViteChildConfig["source"]>,
       ) {
-        const proxy = yield* maybeStartProxy(worker.id, worker.dev);
+        const proxy = yield* maybeStartProxy(
+          worker.id,
+          worker.name,
+          worker.dev,
+        );
         yield* serveVite({ worker, rootDir, invalidate, source, proxy });
         return proxy.url;
       });
@@ -1088,7 +1167,11 @@ export const LocalWorkerProvider = () =>
       //   bundle is served through the same make-before-break `serveWith`
       //   path the built-in bundler uses.
       const runSource = Effect.fn(function* (worker: RunnableWorkerConfig) {
-        const proxy = yield* maybeStartProxy(worker.id, worker.dev);
+        const proxy = yield* maybeStartProxy(
+          worker.id,
+          worker.name,
+          worker.dev,
+        );
         // Queue requests until the source's first output is served —
         // whether that's the first workerd serve (bundle mode) or the dev
         // server URL (server mode).
@@ -1165,10 +1248,9 @@ export const LocalWorkerProvider = () =>
             news.dev?.mode === "external"
               ? // news.dev.url may be an unresolved output; avoid trying to resolve it here.
                 []
-              : yield* maybeStartProxy(id, {
+              : yield* maybeStartProxy(id, name, {
                   ...news.dev,
                   mode: "worker" as const,
-                  port: news.dev?.port ?? DEFAULT_DEV_PORT,
                 }).pipe(Effect.flatMap((proxy) => resolveLocalUrls(proxy.url)));
           return {
             // No cloud script exists in dev — fabricate a `dev:`-marked
@@ -1232,7 +1314,7 @@ export const LocalWorkerProvider = () =>
             config.bindingDescriptors.some((b) => b.type === "self_url") ||
             Object.values(config.env ?? {}).some(isSelfUrl);
           const selfUrl = needsSelfUrl
-            ? (yield* maybeStartProxy(id, config.dev)).url
+            ? (yield* maybeStartProxy(id, config.name, config.dev)).url
                 .toString()
                 .replace(/\/$/, "")
             : undefined;

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -980,7 +980,14 @@ export interface WorkerProps<
         /**
          * Port the local dev server listens on. If the port is unavailable,
          * the next free port is used unless {@link strictPort} is `true`.
-         * @default 1337
+         *
+         * When omitted, the port is **sticky**: the port this Worker served
+         * on in the previous `alchemy dev` session is reused (recorded under
+         * `.alchemy/local/worker-ports/`), so every Worker in the stack
+         * keeps a stable URL across sessions. A first-ever start hunts up
+         * from `1337`. Pass `0` for a fresh OS-assigned port on every
+         * session.
+         * @default the previous session's port, or 1337
          */
         port?: number;
         /**

--- a/packages/alchemy/test/Cloudflare/Workers/DevPorts.local.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/DevPorts.local.test.ts
@@ -1,0 +1,140 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Test from "@/Test/Alchemy";
+import { expect } from "alchemy-test";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import { MinimumLogLevel } from "effect/References";
+import * as Schedule from "effect/Schedule";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+
+const { test } = Test.make({
+  providers: Cloudflare.providers(),
+  dev: true,
+});
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+class WorkerNotReady extends Data.TaggedError("WorkerNotReady")<{
+  status: number;
+}> {}
+
+const getJsonReady = (url: string) =>
+  Effect.gen(function* () {
+    const client = yield* HttpClient.HttpClient;
+    const res = yield* client.get(url).pipe(
+      Effect.flatMap((res) =>
+        res.status === 200
+          ? Effect.succeed(res)
+          : Effect.fail(new WorkerNotReady({ status: res.status })),
+      ),
+      Effect.retry({
+        while: (e): e is WorkerNotReady => e instanceof WorkerNotReady,
+        schedule: Schedule.max([
+          Schedule.min([
+            Schedule.exponential("500 millis"),
+            Schedule.spaced("2 seconds"),
+          ]),
+          Schedule.recurs(10),
+        ]),
+      }),
+    );
+    return yield* res.json;
+  }).pipe(Effect.orDie);
+
+const script = `export default {
+  async fetch() {
+    return Response.json({ ok: true });
+  },
+};`;
+
+// One file per worker name under `.alchemy/local/worker-ports/` — the
+// persisted port assignment the local Worker provider records (see
+// LocalWorkerProvider's `recordPort`).
+const portAssignmentFile = (workerName: string) =>
+  Effect.gen(function* () {
+    const path = yield* Path.Path;
+    return path.join(
+      process.cwd(),
+      ".alchemy",
+      "local",
+      "worker-ports",
+      encodeURIComponent(workerName),
+    );
+  });
+
+const readAssignment = (workerName: string) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const file = yield* portAssignmentFile(workerName);
+    return yield* fs.readFileString(file).pipe(
+      Effect.map((content) => Number(content.trim())),
+      Effect.orElseSucceed(() => undefined),
+    );
+  });
+
+const seedAssignment = (workerName: string, port: number) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const file = yield* portAssignmentFile(workerName);
+    yield* fs.makeDirectory(path.dirname(file), { recursive: true });
+    yield* fs.writeFileString(file, `${port}`);
+  });
+
+// An implicit dev port would otherwise be assigned by hunting up from 1337
+// in nondeterministic start order, reshuffling every worker's URL between
+// dev sessions. The provider records each worker's actual port and prefers
+// it on the next start — this test simulates "the next session" by seeding
+// the recorded assignment before the worker's first start.
+const STICKY_WORKER = "dev-ports-sticky-a";
+const FRESH_WORKER = "dev-ports-fresh-b";
+// Arbitrary, far outside the 1337-onward hunt range shared with other
+// suites' workers.
+const SEEDED_PORT = 42871;
+
+test.provider(
+  "implicit dev ports are recorded and reused across sessions",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+      yield* seedAssignment(STICKY_WORKER, SEEDED_PORT);
+
+      const deployed = yield* stack.deploy(
+        Effect.gen(function* () {
+          return {
+            sticky: yield* Cloudflare.Worker("sticky-worker", {
+              name: STICKY_WORKER,
+              script,
+            }),
+            fresh: yield* Cloudflare.Worker("fresh-worker", {
+              name: FRESH_WORKER,
+              script,
+            }),
+          };
+        }),
+      );
+
+      // The seeded assignment wins over the default-port hunt — proof a
+      // recorded port from a previous session pins the worker's URL.
+      expect(deployed.sticky.url).toBe(`http://localhost:${SEEDED_PORT}`);
+      const body = (yield* getJsonReady(deployed.sticky.url!)) as {
+        ok: boolean;
+      };
+      expect(body.ok).toBe(true);
+
+      // The fresh worker hunted a port and recorded it for the next
+      // session.
+      expect(deployed.fresh.url).toMatch(/^http:\/\/localhost:\d+$/);
+      const freshPort = Number(new URL(deployed.fresh.url!).port);
+      expect(yield* readAssignment(FRESH_WORKER)).toBe(freshPort);
+      expect(yield* readAssignment(STICKY_WORKER)).toBe(SEEDED_PORT);
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 120_000 },
+);

--- a/packages/cloudflare-runtime/src/core/internal/Port.ts
+++ b/packages/cloudflare-runtime/src/core/internal/Port.ts
@@ -120,6 +120,14 @@ export interface Ports {
    * Note that this is best-effort; the caller should include retry logic to handle race conditions.
    */
   readonly reserve: (port: number) => Effect.Effect<void>;
+  /**
+   * Drops the reservation taken by `find`/`check`/`waitFor` once the
+   * listener that held the port is gone. Without this, a server stopped and
+   * re-requested within the reservation TTL (e.g. a dev worker deleted and
+   * re-created, or a same-process serve retry) observes its own stale
+   * reservation and silently drifts to the next port.
+   */
+  readonly release: (port: number) => Effect.Effect<void>;
 }
 
 const HOSTS: Set<string> = new Set([
@@ -309,5 +317,13 @@ export const make = (options: PortsOptions) =>
               ),
         ),
       reserve,
+      release: (port) =>
+        Effect.sync(() => {
+          globalReservations.delete(port);
+        }).pipe(
+          // Also drop the negative cache entry so the next `find`/`check`
+          // re-probes instead of treating the port as taken for up to 30s.
+          Effect.andThen(Cache.invalidate(cache, port)),
+        ),
     } as Ports;
   });

--- a/packages/cloudflare-runtime/src/core/proxy/WorkerProxy.ts
+++ b/packages/cloudflare-runtime/src/core/proxy/WorkerProxy.ts
@@ -198,6 +198,11 @@ export const WorkerProxyLive = Layer.effect(
       serve: Effect.fn("WorkerProxy.serve")(function* (options = {}) {
         const resolved = yield* normalizeOptions(options);
         const url = yield* serveWithRetry(resolved);
+        // The reservation taken while probing outlives the listener by its
+        // TTL — release it when the proxy's scope closes so the same port
+        // can be re-requested immediately (a deleted-and-recreated dev
+        // worker would otherwise silently drift to the next port).
+        yield* Effect.addFinalizer(() => ports.release(Number(url.port)));
         if (
           options.port !== undefined &&
           options.port !== 0 &&

--- a/packages/cloudflare-runtime/src/core/test/proxy/WorkerProxy.test.ts
+++ b/packages/cloudflare-runtime/src/core/test/proxy/WorkerProxy.test.ts
@@ -1,8 +1,10 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, expect, layer } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
+import * as Scope from "effect/Scope";
 import * as NodeNet from "node:net";
 import * as Internet from "../../globals/Internet.ts";
 import * as WorkerProxy from "../../proxy/WorkerProxy.ts";
@@ -363,6 +365,27 @@ layer(services, { excludeTestServices: true })((it) => {
           .pipe(Effect.flip);
         assert(error instanceof ConfigError);
         expect(Workerd.isAddressInUseError(error)).toBe(true);
+      }),
+  );
+
+  it.effect(
+    "releases its port reservation on close so the port can be re-requested immediately",
+    () =>
+      Effect.gen(function* () {
+        const proxy = yield* WorkerProxy.WorkerProxy;
+        const port = yield* PortHelpers.find(0);
+
+        const scope = yield* Scope.make();
+        const first = yield* proxy.serve({ port }).pipe(Scope.provide(scope));
+        expect(Number(first.url.port)).toBe(port);
+        yield* Scope.close(scope, Exit.void);
+
+        // Without the release, the reservation taken while probing lingers
+        // for its TTL after the listener is gone, and a re-request for the
+        // same port (a deleted-and-recreated dev worker) silently drifts to
+        // the next port.
+        const second = yield* proxy.serve({ port });
+        expect(Number(second.url.port)).toBe(port);
       }),
   );
 


### PR DESCRIPTION
Workers without an explicit `dev.port` all hunt up from `1337`, and hunt order is whatever order the proxies happen to start in — nondeterministic across concurrent reconciles. A multi-worker stack therefore reshuffles its worker↔port mapping on every `alchemy dev` session, and clients holding a worker's URL hit the wrong worker (404s, failed WebSocket connects).

### Sticky implicit ports

`LocalWorkerProvider` now records each worker's actual dev-proxy port (one file per physical worker name, so concurrent sessions can't clobber each other's entries) and prefers it on the next start:

```
.alchemy/local/worker-ports/<worker-name>   # contains e.g. "1341"
```

- Explicit `dev.port` always wins and is never recorded; `dev.port: 0` still gets a fresh ephemeral port per session.
- The implicit port stays out of the hashed config and the proxy-reuse comparison, so sticky assignment never restarts an instance or a running proxy.

```diff
 const startProxy = Effect.fn(function* (id, workerName, serverOptions) {
   const scope = yield* Scope.fork(rootScope);
+  const port =
+    serverOptions.port ?? (yield* recordedPort(workerName)) ?? DEFAULT_DEV_PORT;
   const instance = yield* workerProxy
-    .serve(serverOptions)
+    .serve({ ...serverOptions, port })
     .pipe(Scope.provide(scope));
   proxyInstances.set(id, { serverOptions, instance, scope });
+  if (serverOptions.port === undefined) {
+    yield* recordPort(workerName, Number(instance.url.port));
+  }
   return instance;
 });
```

### Release port reservations on proxy teardown

A stopped proxy's port reservation lingered for its 30s TTL, so a worker deleted and re-created (or any same-process re-request of the port) silently drifted to the next port even though the port was free. `WorkerProxy.serve` now releases the reservation when its scope closes (`Ports.release` drops the global reservation and invalidates the negative probe cache). The new runtime test fails without this.

### Tests

- `test/Cloudflare/Workers/DevPorts.local.test.ts` — seeds a recorded assignment (simulating a previous session) and asserts the worker serves on exactly that port; asserts a fresh worker's hunted port is recorded.
- `WorkerProxy.test.ts` — "releases its port reservation on close so the port can be re-requested immediately".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
