### PR TITLE
fix(cloudflare/dns): disambiguate DNS record adoption by content/priority

### DIFF
--- a/packages/alchemy/src/Cloudflare/DNS/Record.ts
+++ b/packages/alchemy/src/Cloudflare/DNS/Record.ts
@@ -138,6 +138,15 @@ export type Record = Resource<
  * set. This protects hand-edited records (especially the apex `A`/`AAAA`
  * and email DKIM/SPF records that the dashboard often manages) from
  * being clobbered.
+ *
+ * Several records may legitimately share `(name, type)` — MX fallbacks,
+ * multiple TXT records, round-robin A records. When the scan finds more
+ * than one candidate, the declared `content` (and `priority`) must match
+ * exactly one record; a record with no exact match is treated as missing
+ * (a new sibling record is created), and a still-ambiguous match fails
+ * with an error listing the candidates. To adopt one record out of such
+ * a set, declare its current `content`/`priority` verbatim first, then
+ * change them in a follow-up deploy.
  * @resource
  * @product DNS
  * @category Domains & DNS
@@ -246,7 +255,10 @@ export const RecordProvider = () =>
       //    behind the adopt policy before reconcile ever runs.
       let foundByScan = false;
       if (!observed) {
-        const existing = yield* findByNameType(zoneId, news.name, news.type);
+        const existing = yield* findByNameType(zoneId, news.name, news.type, {
+          content,
+          priority: news.priority,
+        });
         if (existing) {
           foundByScan = true;
           observed = existing;
@@ -283,7 +295,10 @@ export const RecordProvider = () =>
             // existing record instead of failing the deploy. Ownership was
             // already gated by `read`/the adopt policy upstream.
             Effect.catchTag("DnsRecordAlreadyExists", () =>
-              findByNameType(zoneId, news.name, news.type).pipe(
+              findByNameType(zoneId, news.name, news.type, {
+                content,
+                priority: news.priority,
+              }).pipe(
                 Effect.flatMap((existing) =>
                   existing
                     ? Effect.succeed({ record: existing, raced: true } as const)
@@ -382,12 +397,18 @@ export const RecordProvider = () =>
       // `(zoneId, name, type)` may already exist. DNS records carry no
       // ownership markers we can inspect, so we cannot prove we created
       // it — brand it `Unowned` so the engine refuses to take over
-      // unless `adopt` is set.
+      // unless `adopt` is set. Several records may legitimately share
+      // `(name, type)` (MX fallbacks, multiple TXT/A records) — the
+      // declared `content`/`priority` disambiguate which one this
+      // resource corresponds to.
       const zoneId = output?.zoneId ?? (olds?.zoneId as string | undefined);
       const name = output?.name ?? olds?.name;
       const type = output?.type ?? olds?.type;
       if (zoneId && name && type) {
-        const observed = yield* findByNameType(zoneId, name, type);
+        const observed = yield* findByNameType(zoneId, name, type, {
+          content: (olds?.content as string | undefined) ?? output?.content,
+          priority: olds?.priority as number | undefined,
+        });
         const attrs = toAttributes(observed, zoneId);
         if (attrs) return Unowned(attrs);
       }
@@ -407,27 +428,78 @@ const observeById = (zoneId: string, dnsRecordId: string) =>
     return narrowRecord(r as Parameters<typeof narrowRecord>[0]);
   });
 
+/**
+ * Property match used to disambiguate between several records sharing
+ * `(name, type)` — MX fallbacks, multiple TXT records, round-robin A
+ * records are all legitimate Cloudflare configurations.
+ */
+interface RecordMatch {
+  readonly content?: string;
+  readonly priority?: number;
+}
+
 // Locate an existing record by `(zoneId, name, type)`. Cloudflare accepts
 // relative names on writes but returns FQDNs on reads, so check the supplied
 // name first and then its zone-qualified form. Used both for the adoption path
 // and to surface a conflict when the caller hasn't opted into adoption.
-const findByNameType = (zoneId: string, name: string, type: RecordType) =>
-  findExactByNameType(zoneId, name, type).pipe(
+//
+// `(name, type)` alone is NOT a unique identity — several records may share
+// it. A single candidate is returned as-is (preserving the adopt-then-modify
+// flow where the desired content differs from the live record). With multiple
+// candidates, the desired `content`/`priority` must select exactly one:
+//   - exactly one exact match -> that record
+//   - no exact match          -> `undefined` (a new sibling record is created)
+//   - several exact matches   -> fail with an actionable error
+const findByNameType = (
+  zoneId: string,
+  name: string,
+  type: RecordType,
+  match: RecordMatch,
+) =>
+  listExactByNameType(zoneId, name, type).pipe(
     Effect.flatMap((found) => {
-      if (found) return Effect.succeed(found);
+      if (found.length > 0) return Effect.succeed(found);
 
       return zones.getZone({ zoneId }).pipe(
         Effect.flatMap((zone) => {
           const normalizedName = normalizeRecordName(name, zone.name);
           return normalizedName === name
-            ? Effect.succeed(undefined)
-            : findExactByNameType(zoneId, normalizedName, type);
+            ? Effect.succeed([] as ObservedRecord[])
+            : listExactByNameType(zoneId, normalizedName, type);
         }),
+      );
+    }),
+    Effect.flatMap((candidates) => {
+      if (candidates.length === 0) return Effect.succeed(undefined);
+      if (candidates.length === 1) return Effect.succeed(candidates[0]);
+      const narrowed = candidates.filter(
+        (r) =>
+          (match.content === undefined || r.content === match.content) &&
+          (match.priority === undefined || r.priority === match.priority),
+      );
+      if (narrowed.length === 1) return Effect.succeed(narrowed[0]);
+      if (narrowed.length === 0) return Effect.succeed(undefined);
+      return Effect.fail(
+        new Error(
+          `Multiple DNS records in zone ${zoneId} match (name=${name}, ` +
+            `type=${type}) and the desired content/priority does not ` +
+            `select exactly one. Set \`content\`` +
+            (type === "MX" || type === "URI" ? " and `priority`" : "") +
+            ` to exactly match the record this resource should adopt ` +
+            `(you can change it afterwards). Candidates:\n` +
+            candidates
+              .map(
+                (r) =>
+                  `  - id=${r.id} content=${JSON.stringify(r.content)}` +
+                  (r.priority === undefined ? "" : ` priority=${r.priority}`),
+              )
+              .join("\n"),
+        ),
       );
     }),
   );
 
-const findExactByNameType = (zoneId: string, name: string, type: RecordType) =>
+const listExactByNameType = (zoneId: string, name: string, type: RecordType) =>
   dns.listRecords
     .items({
       zoneId,
@@ -437,12 +509,9 @@ const findExactByNameType = (zoneId: string, name: string, type: RecordType) =>
     .pipe(
       Stream.runCollect,
       Effect.map((chunk) =>
-        Array.from(chunk).find((r) => r.name === name && r.type === type),
-      ),
-      Effect.map((found) =>
-        found === undefined
-          ? undefined
-          : narrowRecord(found as Parameters<typeof narrowRecord>[0]),
+        Array.from(chunk)
+          .filter((r) => r.name === name && r.type === type)
+          .map((r) => narrowRecord(r as Parameters<typeof narrowRecord>[0])),
       ),
     );
 

--- a/packages/alchemy/src/Cloudflare/DNS/Record.ts
+++ b/packages/alchemy/src/Cloudflare/DNS/Record.ts
@@ -1,5 +1,6 @@
 import * as dns from "@distilled.cloud/cloudflare/dns";
 import * as zones from "@distilled.cloud/cloudflare/zones";
+import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Stream from "effect/Stream";
 
@@ -401,13 +402,13 @@ export const RecordProvider = () =>
       // `(name, type)` (MX fallbacks, multiple TXT/A records) — the
       // declared `content`/`priority` disambiguate which one this
       // resource corresponds to.
-      const zoneId = output?.zoneId ?? (olds?.zoneId as string | undefined);
+      const zoneId = output?.zoneId ?? olds?.zoneId;
       const name = output?.name ?? olds?.name;
       const type = output?.type ?? olds?.type;
       if (zoneId && name && type) {
         const observed = yield* findByNameType(zoneId, name, type, {
-          content: (olds?.content as string | undefined) ?? output?.content,
-          priority: olds?.priority as number | undefined,
+          content: olds?.content ?? output?.content,
+          priority: olds?.priority,
         });
         const attrs = toAttributes(observed, zoneId);
         if (attrs) return Unowned(attrs);
@@ -437,6 +438,25 @@ interface RecordMatch {
   readonly content?: string;
   readonly priority?: number;
 }
+
+/**
+ * Raised when several DNS records share `(name, type)` and the declared
+ * `content`/`priority` do not select exactly one of them — adoption must
+ * never pick a record arbitrarily.
+ */
+export class AmbiguousDnsRecordError extends Data.TaggedError(
+  "AmbiguousDnsRecordError",
+)<{
+  readonly zoneId: string;
+  readonly name: string;
+  readonly type: RecordType;
+  readonly candidates: ReadonlyArray<{
+    readonly id?: string;
+    readonly content?: string;
+    readonly priority?: number;
+  }>;
+  readonly message: string;
+}> {}
 
 // Locate an existing record by `(zoneId, name, type)`. Cloudflare accepts
 // relative names on writes but returns FQDNs on reads, so check the supplied
@@ -469,19 +489,28 @@ const findByNameType = (
         }),
       );
     }),
-    Effect.flatMap((candidates) => {
-      if (candidates.length === 0) return Effect.succeed(undefined);
-      if (candidates.length === 1) return Effect.succeed(candidates[0]);
-      const narrowed = candidates.filter(
-        (r) =>
-          (match.content === undefined || r.content === match.content) &&
-          (match.priority === undefined || r.priority === match.priority),
-      );
-      if (narrowed.length === 1) return Effect.succeed(narrowed[0]);
-      if (narrowed.length === 0) return Effect.succeed(undefined);
-      return Effect.fail(
-        new Error(
-          `Multiple DNS records in zone ${zoneId} match (name=${name}, ` +
+    Effect.flatMap(
+      Effect.fn(function* (candidates) {
+        if (candidates.length === 0) return undefined;
+        if (candidates.length === 1) return candidates[0];
+        const narrowed = candidates.filter(
+          (r) =>
+            (match.content === undefined || r.content === match.content) &&
+            (match.priority === undefined || r.priority === match.priority),
+        );
+        if (narrowed.length === 1) return narrowed[0];
+        if (narrowed.length === 0) return undefined;
+        return yield* new AmbiguousDnsRecordError({
+          zoneId,
+          name,
+          type,
+          candidates: candidates.map((r) => ({
+            id: r.id,
+            content: r.content,
+            priority: r.priority,
+          })),
+          message:
+            `Multiple DNS records in zone ${zoneId} match (name=${name}, ` +
             `type=${type}) and the desired content/priority does not ` +
             `select exactly one. Set \`content\`` +
             (type === "MX" || type === "URI" ? " and `priority`" : "") +
@@ -494,9 +523,9 @@ const findByNameType = (
                   (r.priority === undefined ? "" : ` priority=${r.priority}`),
               )
               .join("\n"),
-        ),
-      );
-    }),
+        });
+      }),
+    ),
   );
 
 const listExactByNameType = (zoneId: string, name: string, type: RecordType) =>

--- a/packages/alchemy/test/Cloudflare/Dns/DnsRecord.test.ts
+++ b/packages/alchemy/test/Cloudflare/Dns/DnsRecord.test.ts
@@ -501,7 +501,7 @@ test.provider(
           Effect.as(undefined),
           Effect.catchCause((cause) => Effect.succeed(findError(cause))),
         );
-      expect(error).toBeDefined();
+      expect(error).toBeInstanceOf(Cloudflare.DNS.AmbiguousDnsRecordError);
       expect(String(error)).toContain("Multiple DNS records");
 
       yield* purgeRecords(zoneId, NAME_MX_AMBIG, "MX");

--- a/packages/alchemy/test/Cloudflare/Dns/DnsRecord.test.ts
+++ b/packages/alchemy/test/Cloudflare/Dns/DnsRecord.test.ts
@@ -32,6 +32,8 @@ const NAME_ADOPT = `alchemy-dnsrecord-adopt.${zoneName}`;
 const NAME_ADOPT_RELATIVE = "alchemy-dnsrecord-relative-adopt";
 const NAME_ADOPT_RELATIVE_FQDN = `${NAME_ADOPT_RELATIVE}.${zoneName}`;
 const NAME_LIST = `alchemy-dnsrecord-list.${zoneName}`;
+const NAME_MX = `alchemy-dnsrecord-mx.${zoneName}`;
+const NAME_MX_AMBIG = `alchemy-dnsrecord-mx-ambig.${zoneName}`;
 
 const resolveZoneId = Effect.gen(function* () {
   const { accountId } = yield* yield* CloudflareEnvironment;
@@ -345,6 +347,168 @@ test.provider(
     }).pipe(logLevel),
 );
 
+// Several records legitimately share `(name, type)` — e.g. a primary MX and
+// its fallback. Adoption must select the record whose `content`/`priority`
+// match the declaration exactly, never "the first match" (#1262).
+test.provider(
+  "adoption disambiguates records sharing (name, type) by content/priority",
+  (stack) =>
+    Effect.gen(function* () {
+      const zoneId = yield* resolveZoneId;
+
+      yield* stack.destroy();
+      yield* purgeRecords(zoneId, NAME_MX, "MX");
+
+      // Two pre-existing MX records for the same name — only content and
+      // priority tell them apart.
+      const prePrimary = yield* dns
+        .createRecord({
+          zoneId,
+          name: NAME_MX,
+          type: "MX",
+          content: `mx1.${zoneName}`,
+          priority: 1,
+          ttl: 1,
+        })
+        .pipe(
+          Effect.retry({
+            while: (e) => e._tag === "Forbidden",
+            schedule: forbiddenRetrySchedule,
+            times: 8,
+          }),
+        );
+      const preBackup = yield* dns.createRecord({
+        zoneId,
+        name: NAME_MX,
+        type: "MX",
+        content: `mx2.${zoneName}`,
+        priority: 10,
+        ttl: 1,
+      });
+
+      const { primary, backup } = yield* stack.deploy(
+        Effect.gen(function* () {
+          const primary = yield* Cloudflare.DNS.Record("PrimaryMx", {
+            zoneId,
+            name: NAME_MX,
+            type: "MX",
+            content: `mx1.${zoneName}`,
+            priority: 1,
+          }).pipe(adopt(true));
+          const backup = yield* Cloudflare.DNS.Record("BackupMx", {
+            zoneId,
+            name: NAME_MX,
+            type: "MX",
+            content: `mx2.${zoneName}`,
+            priority: 10,
+          }).pipe(adopt(true));
+          return { primary, backup };
+        }),
+      );
+
+      // Each logical resource adopted its own physical record.
+      expect(primary.recordId).toEqual(prePrimary.id);
+      expect(backup.recordId).toEqual(preBackup.id);
+      expect(primary.recordId).not.toEqual(backup.recordId);
+
+      // Adopt-then-modify: change the backup's priority; same physical id.
+      const changed = yield* stack.deploy(
+        Effect.gen(function* () {
+          const primary = yield* Cloudflare.DNS.Record("PrimaryMx", {
+            zoneId,
+            name: NAME_MX,
+            type: "MX",
+            content: `mx1.${zoneName}`,
+            priority: 1,
+          }).pipe(adopt(true));
+          const backup = yield* Cloudflare.DNS.Record("BackupMx", {
+            zoneId,
+            name: NAME_MX,
+            type: "MX",
+            content: `mx2.${zoneName}`,
+            priority: 20,
+          }).pipe(adopt(true));
+          return { primary, backup };
+        }),
+      );
+      expect(changed.backup.recordId).toEqual(preBackup.id);
+      const liveBackup = yield* getRecord(zoneId, changed.backup.recordId);
+      expect(
+        "priority" in liveBackup ? liveBackup.priority : undefined,
+      ).toEqual(20);
+      const livePrimary = yield* getRecord(zoneId, changed.primary.recordId);
+      expect(
+        "priority" in livePrimary ? livePrimary.priority : undefined,
+      ).toEqual(1);
+
+      yield* stack.destroy();
+
+      const leftovers = yield* listByNameType(zoneId, NAME_MX, "MX");
+      expect(leftovers).toEqual([]);
+    }).pipe(logLevel),
+);
+
+// When multiple candidates survive the content/priority filter, adoption must
+// fail with an actionable error instead of picking one arbitrarily.
+test.provider(
+  "adoption fails with an actionable error when the match stays ambiguous",
+  (stack) =>
+    Effect.gen(function* () {
+      const zoneId = yield* resolveZoneId;
+
+      yield* stack.destroy();
+      yield* purgeRecords(zoneId, NAME_MX_AMBIG, "MX");
+
+      // Same content on both records — only priority differs. A declaration
+      // without a priority cannot select one.
+      yield* dns
+        .createRecord({
+          zoneId,
+          name: NAME_MX_AMBIG,
+          type: "MX",
+          content: `mx.${zoneName}`,
+          priority: 1,
+          ttl: 1,
+        })
+        .pipe(
+          Effect.retry({
+            while: (e) => e._tag === "Forbidden",
+            schedule: forbiddenRetrySchedule,
+            times: 8,
+          }),
+        );
+      yield* dns.createRecord({
+        zoneId,
+        name: NAME_MX_AMBIG,
+        type: "MX",
+        content: `mx.${zoneName}`,
+        priority: 10,
+        ttl: 1,
+      });
+
+      const error = yield* stack
+        .deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.DNS.Record("AmbiguousMx", {
+              zoneId,
+              name: NAME_MX_AMBIG,
+              type: "MX",
+              content: `mx.${zoneName}`,
+            }).pipe(adopt(true));
+          }),
+        )
+        .pipe(
+          Effect.as(undefined),
+          Effect.catchCause((cause) => Effect.succeed(findError(cause))),
+        );
+      expect(error).toBeDefined();
+      expect(String(error)).toContain("Multiple DNS records");
+
+      yield* purgeRecords(zoneId, NAME_MX_AMBIG, "MX");
+      yield* stack.destroy();
+    }).pipe(logLevel),
+);
+
 // Canonical `list()` test (zone-scoped collection): `list()` enumerates every
 // zone via `listAllZones`, exhaustively paginates each zone's DNS records, and
 // hydrates them into the `read` Attributes shape. Deploy a record and assert it
@@ -380,6 +544,21 @@ test.provider("list enumerates the deployed DNS record", (stack) =>
     yield* stack.destroy();
   }).pipe(logLevel),
 );
+
+/**
+ * Pull the first failure/defect value out of a Cause regardless of whether
+ * the engine raised it as a typed failure or a defect.
+ */
+const findError = (cause: Cause.Cause<unknown>): unknown =>
+  cause.reasons
+    .map((reason) =>
+      Cause.isFailReason(reason)
+        ? reason.error
+        : Cause.isDieReason(reason)
+          ? reason.defect
+          : undefined,
+    )
+    .find((value) => value !== undefined);
 
 /**
  * Pull the {@link OwnedBySomeoneElse} value out of a Cause regardless of


### PR DESCRIPTION
DNS record adoption looked up records by `(zoneId, name, type)` and took the first match. Several records legitimately share that key (MX fallbacks, multiple TXT/A records), so two Alchemy resources could adopt the same physical record and clobber each other.

`findByNameType` now collects **all** matches and, when more than one exists, the declared `content`/`priority` must select exactly one:

```ts
// both adopt their own physical record now — previously both matched the first MX
Cloudflare.DNS.Record("PrimaryMx", { zoneId, name, type: "MX", content: "mx1.example.com", priority: 1 });
Cloudflare.DNS.Record("BackupMx",  { zoneId, name, type: "MX", content: "mx2.example.com", priority: 10 });
```

```
- 1 candidate → returned as-is (preserves the adopt-then-modify flow)
->1 candidates, exactly one exact `content`/`priority` match → that record
->1 candidates, no exact match → treated as missing (a new sibling record is created)
->1 candidates, still ambiguous → fails with an error listing candidate ids/contents/priorities
```
Applies to the `read` adoption scan, the reconcile fallback scan, and the `DnsRecordAlreadyExists` self-heal path.

Fixes alchemy-run/alchemy#1262

🤖 Generated with [Claude Code](https://claude.com/claude-code)
