### PR TITLE
fix(cloudflare): support assets in worker versions

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -508,10 +508,9 @@ export interface WorkerVersionAffinity {
  *   and the currently-live version keeps the remainder, instead of the
  *   default 100% cutover.
  *
- * A gradual rollout carries only what a version can: code, bindings,
- * compatibility settings, and cache configuration. Workers with static
- * assets cannot roll out gradually (the versions API cannot carry assets),
- * a deploy that changes Durable Object class migrations must go out at
+ * A gradual rollout carries only what a version can: code, static assets,
+ * bindings, compatibility settings, and cache configuration. A deploy that
+ * changes Durable Object class migrations must go out at
  * 100% (migrations cannot ride a rollout), and script-level settings
  * (tags, observability, limits, placement, logpush) keep their live
  * values until the next full deploy.
@@ -524,10 +523,10 @@ export interface WorkerVersionOptions {
    * locally-declared Worker — or a literal script name as an escape hatch.
    *
    * When set, this resource does not create a script of its own: it
-   * uploads a version (code + bindings + compatibility settings) to the
-   * parent's script. Script-level settings apply immediately to *all*
-   * versions of the parent, so they cannot be set on a version worker —
-   * `name`, `assets`, `namespace`, `crons`, `domain`, `routes`, `tags`,
+   * uploads a version (code + static assets + bindings + compatibility
+   * settings) to the parent's script. Script-level settings apply immediately
+   * to *all* versions of the parent, so they cannot be set on a version worker —
+   * `name`, `namespace`, `crons`, `domain`, `routes`, `tags`,
    * `logpush`, `observability`, `placement`, `limits`, and `subdomain` are
    * rejected, as are locally-hosted Durable Object or Workflow classes
    * (their migrations would mutate the parent).
@@ -1856,11 +1855,11 @@ export const isSelf = (value: unknown): value is Self =>
  * in `domains`. Because the aliased URL is known before the version
  * exists, `Worker.URL` works on version workers and resolves to it.
  *
- * A version carries code, bindings, and compatibility settings. Script-level
- * settings (routes, domains, crons, tags, observability, …) belong to the
- * parent and are rejected on version workers, as are locally-hosted Durable
- * Object or Workflow classes. Preview URLs require the parent's workers.dev
- * subdomain to be enabled (the default).
+ * A version carries code, static assets, bindings, and compatibility
+ * settings. Script-level settings (routes, domains, crons, tags,
+ * observability, …) belong to the parent and are rejected on version workers,
+ * as are locally-hosted Durable Object or Workflow classes. Preview URLs
+ * require the parent's workers.dev subdomain to be enabled (the default).
  *
  * **Example:** PR preview: a version of another stage's Worker
  * ```typescript

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -2735,7 +2735,6 @@ export const LiveWorkerProvider = () =>
         const forbidden = (
           [
             ["name", news.name],
-            ["assets", news.assets],
             ["namespace", news.namespace],
             ["crons", news.crons],
             ["tailConsumers", news.tailConsumers],
@@ -2846,12 +2845,13 @@ export const LiveWorkerProvider = () =>
         yield* Effect.logInfo(
           `Cloudflare Worker version: preparing bundle for ${parentName} (from ${id})`,
         );
-        const { bundle, hash: preparedHash } = yield* prepareAssetsAndBundle(
-          id,
-          parentName,
-          news,
-          { skipAssetsRead: true },
-        );
+        const {
+          assets,
+          bundle,
+          hash: preparedHash,
+        } = yield* prepareAssetsAndBundle(id, parentName, news, {
+          skipAssetsRead: false,
+        });
         const metadataHash = yield* resolveWorkerMetadataHash({
           props: news,
           bindings,
@@ -2881,6 +2881,25 @@ export const LiveWorkerProvider = () =>
                 : item,
           ),
         );
+        let metadataAssets:
+          | workers.CreateScriptVersionRequest["metadata"]["assets"]
+          | undefined;
+        if (assets) {
+          yield* Effect.logInfo(
+            `Cloudflare Worker version: uploading assets for ${parentName}`,
+          );
+          const { jwt } = yield* uploadAssets(
+            accountId,
+            parentName,
+            assets,
+            session,
+          );
+          metadataAssets = {
+            jwt,
+            config: mergeAssetsConfigFiles(assets.config, assets),
+          };
+          metadataBindings.push({ type: "assets", name: "ASSETS" });
+        }
         appendAlchemyAndEnvBindings(
           metadataBindings,
           news,
@@ -2895,6 +2914,7 @@ export const LiveWorkerProvider = () =>
             scriptName: parentName,
             metadata: {
               mainModule: bundle.main!,
+              assets: metadataAssets,
               bindings: metadataBindings,
               compatibilityDate: compatibility.date,
               compatibilityFlags: compatibility.flags,
@@ -3602,13 +3622,6 @@ export const LiveWorkerProvider = () =>
           output?.hash !== undefined &&
           !dispatchNamespace
         ) {
-          if (metadataAssets !== undefined) {
-            return yield* Effect.fail(
-              new WorkerVersionConfigError({
-                message: `Worker '${name}' has static assets, which the versions API cannot carry — gradual rollouts (version.traffic) are not supported for Workers with assets.`,
-              }),
-            );
-          }
           const migratedClasses = [
             ...migrations.newClasses,
             ...migrations.newSqliteClasses,
@@ -3632,7 +3645,9 @@ export const LiveWorkerProvider = () =>
               scriptName: name,
               metadata: {
                 mainModule: metadata.mainModule!,
+                assets: metadata.assets,
                 bindings: metadata.bindings,
+                keepAssets: metadata.keepAssets,
                 compatibilityDate: metadata.compatibilityDate,
                 compatibilityFlags: metadata.compatibilityFlags,
                 cacheOptions: metadata.cacheOptions,

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerVersion.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerVersion.test.ts
@@ -7,6 +7,7 @@ import * as workers from "@distilled.cloud/cloudflare/workers";
 import { describe, expect } from "alchemy-test";
 import * as Effect from "effect/Effect";
 import { MinimumLogLevel } from "effect/References";
+import * as pathe from "pathe";
 import { expectUrlContains } from "../Utils/Http.ts";
 import { waitForWorkerToBeDeleted } from "../Utils/Worker.ts";
 
@@ -150,6 +151,48 @@ describe.concurrent("Cloudflare.Worker version", () => {
         yield* waitForWorkerToBeDeleted(v3.parent.workerName, accountId);
       }).pipe(logLevel),
     { timeout: 300_000 },
+  );
+
+  test.provider(
+    "preview version carries its own static assets",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const { parent, preview } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const parent = yield* Cloudflare.Worker("AssetsVersionParent", {
+              script: script("assets-parent-marker"),
+            });
+            const preview = yield* Cloudflare.Worker("AssetsVersionPreview", {
+              script:
+                "export default { fetch(request, env) { return env.ASSETS.fetch(request); } };",
+              assets: {
+                directory: pathe.resolve(import.meta.dirname, "assets"),
+                runWorkerFirst: true,
+              },
+              version: { parent },
+            });
+            return { parent, preview };
+          }),
+        );
+
+        expect(preview.versionOf).toEqual(parent.workerName);
+        expect(preview.hash?.assets).toBeDefined();
+        yield* expectUrlContains(
+          new URL("/test.txt", preview.url!).toString(),
+          "This is a test file from assets.",
+          { label: "preview URL serves the version's static assets" },
+        );
+        yield* expectUrlContains(parent.url!, "assets-parent-marker", {
+          label: "preview assets leave the parent deployment untouched",
+        });
+
+        yield* stack.destroy();
+        const { accountId } = yield* yield* CloudflareEnvironment;
+        yield* waitForWorkerToBeDeleted(parent.workerName, accountId);
+      }).pipe(logLevel),
+    { timeout: 240_000 },
   );
 
   test.provider(


### PR DESCRIPTION
## Summary

- upload static assets when creating a preview version with `version.parent`
- carry asset metadata and `keepAssets` through gradual version rollouts
- remove the stale versions-API asset restriction and update Worker documentation
- add live coverage proving a preview serves version-specific assets without changing the parent deployment

## Verification

- `vp exec tsc -b`
- `vp exec oxlint packages/alchemy/src/Cloudflare/Workers/Worker.ts packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts packages/alchemy/test/Cloudflare/Workers/WorkerVersion.test.ts`
- `timeout 240 doppler run --project alchemy-v2 --config dev -- vpx bun@1.3.13 node_modules/alchemy-test/bin/alchemy-test.ts test/Cloudflare/Workers/WorkerVersion.test.ts --profile testing -t "preview version carries its own static assets" --timeout 120000` — 1 passed, 0 failed