### PR TITLE
feat(website): deploy PR previews as worker versions

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -94,9 +94,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # Secrets (Cloudflare credentials, etc.) are injected by
-      # `doppler run` from the `alchemy-v2` project — `prod` config on
-      # main, `dev` config everywhere else.
+      # Main/prod use the production account; PR stages use the test account.
       - name: Deploy
         working-directory: website
         run: bun alchemy deploy --stage "$STAGE" --yes
@@ -106,6 +104,17 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ (env.STAGE == 'main' || env.STAGE == 'prod') && secrets.PROD_CLOUDFLARE_ACCOUNT_ID || secrets.TEST_CLOUDFLARE_ACCOUNT_ID }}
           BUILD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           GITHUB_TOKEN: ${{ steps.bot-token.outputs.token }}
+
+      # PR builds upload zero-traffic versions of this Worker. Refresh the
+      # parent from merged main using the same test account as PR previews.
+      - name: Deploy preview parent
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        working-directory: website
+        run: bun alchemy deploy --stage preview-base --yes
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.TEST_CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.TEST_CLOUDFLARE_ACCOUNT_ID }}
+          BUILD_SHA: ${{ github.sha }}
 
   cleanup:
     name: Cleanup

--- a/website/alchemy.run.ts
+++ b/website/alchemy.run.ts
@@ -9,39 +9,52 @@ export type WorkerEnv = Cloudflare.InferEnv<typeof Website>;
 
 const Website = Cloudflare.Website.StaticSite(
   "Website",
-  Alchemy.Stack.useSync(
-    (stack) =>
-      ({
-        command: "bun run build",
-        main: "./src/worker.ts",
-        outdir: "dist",
-        workersDev: stack.stage === "prod" ? false : undefined,
-        domain:
-          stack.stage === "prod"
-            ? { name: "alchemy.run", redirects: ["v2.alchemy.run"] }
-            : stack.stage === "main"
-              ? { name: "main.alchemy.run" }
+  Effect.gen(function* () {
+    const stack = yield* Alchemy.Stack;
+    const previewParent = stack.stage.startsWith("pr-")
+      ? yield* Cloudflare.Worker.ref("Website", { stage: "preview-base" })
+      : undefined;
+
+    return {
+      command: "bun run build",
+      main: "./src/worker.ts",
+      outdir: "dist",
+      version: previewParent
+        ? {
+            parent: previewParent,
+            alias: stack.stage,
+            message: process.env.PULL_REQUEST
+              ? `PR #${process.env.PULL_REQUEST}`
               : undefined,
-        memo: {
-          include: [
-            "src/**",
-            "astro.config.mjs",
-            "package.json",
-            "plugins/**",
-            "public/**",
-            "scripts/**",
-            "../bun.lock",
-          ],
-        },
-        compatibility: {
-          date: "2026-04-02",
-          flags: ["nodejs_compat"],
-        },
-        assets: {
-          runWorkerFirst: true,
-        },
-      }) satisfies Cloudflare.Website.StaticSiteProps<{}>,
-  ),
+          }
+        : undefined,
+      workersDev: stack.stage === "prod" ? false : undefined,
+      domain:
+        stack.stage === "prod"
+          ? { name: "alchemy.run", redirects: ["v2.alchemy.run"] }
+          : stack.stage === "main"
+            ? { name: "main.alchemy.run" }
+            : undefined,
+      memo: {
+        include: [
+          "src/**",
+          "astro.config.mjs",
+          "package.json",
+          "plugins/**",
+          "public/**",
+          "scripts/**",
+          "../bun.lock",
+        ],
+      },
+      compatibility: {
+        date: "2026-04-02",
+        flags: ["nodejs_compat"],
+      },
+      assets: {
+        runWorkerFirst: true,
+      },
+    } satisfies Cloudflare.Website.StaticSiteProps<{}>;
+  }),
 );
 
 export default Alchemy.Stack(


### PR DESCRIPTION
## Summary

- upload `pr-*` website stages as zero-traffic versions of a permanent `preview-base` Worker instead of creating one Worker script per PR
- refresh `preview-base` from merged `main` in the existing deploy job using the same test-account GitHub secrets as PR previews
- use the PR stage as a stable, short preview alias while preserving the existing preview comment and cleanup lifecycle

## Verification

- `vp exec tsc -b`
- workflow YAML parsed successfully
- `timeout 240 vpr build` from `website/` — 4,262 pages built; link and diff-indent checks passed

## Stack

Depends on #1266, which adds static-asset support to Worker versions and passed its focused Doppler-backed live test.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>