### PR TITLE
fix(website): SEO, noindex, canonical, nosnippet & more

### DIFF
--- a/scripts/generate-api-reference.ts
+++ b/scripts/generate-api-reference.ts
@@ -679,6 +679,19 @@ function renderPage(doc: PageDoc, resolve: LinkResolver): string {
     "---",
     `title: ${yamlString(doc.title)}`,
     `description: ${yamlString(description)}`,
+    // Generated reference pages are ~4k near-identical one-paragraph +
+    // one-snippet stubs (92% of the site). Indexed as separate documents
+    // they read as programmatic thin content, dilute crawl budget, and are
+    // what surfaces as "random" search results instead of the hub and
+    // guide pages. Keep them navigable and crawlable (`follow`) but out of
+    // search indexes; the sitemap integration drops any page carrying this
+    // meta. Revisit once pages are consolidated per service / carry real
+    // prose — this is the only line to change.
+    "head:",
+    "  - tag: meta",
+    "    attrs:",
+    "      name: robots",
+    '      content: "noindex, follow"',
     "---",
   ].join("\n");
 

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -358,7 +358,9 @@ export default defineConfig({
       filter: (page) =>
         !page.endsWith(".html") &&
         !page.endsWith(".md") &&
-        !page.endsWith(".mdx"),
+        !page.endsWith(".mdx") &&
+        // OAuth device-flow landing pages — `noindex` in `Auth.astro`.
+        !page.includes("/auth/"),
     }),
     starlight({
       title: "Alchemy",

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -360,7 +360,10 @@ export default defineConfig({
         !page.endsWith(".md") &&
         !page.endsWith(".mdx") &&
         // OAuth device-flow landing pages — `noindex` in `Auth.astro`.
-        !page.includes("/auth/"),
+        !page.includes("/auth/") &&
+        // starlight-blog's paginated listings (`/blog/2/`, …) — thin pages
+        // that only repeat post excerpts; the posts themselves are listed.
+        !/\/blog\/\d+\/?$/.test(page),
     }),
     starlight({
       title: "Alchemy",

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -137,6 +137,60 @@ function copyMarkdownSources() {
 }
 
 /**
+ * Pages that opt out of search indexing (`<meta name="robots" content="noindex…">`,
+ * set per page via Starlight `head` frontmatter, `Auth.astro`, or the
+ * reference generator) must not be advertised in the sitemap either — a
+ * sitemap entry is an explicit "please index this". Instead of maintaining a
+ * parallel path list in the sitemap filter, scan the rendered HTML once and
+ * let the filter consult the result. Runs in `astro:build:done` before the
+ * sitemap integration (Astro runs hooks in registration order), so it must
+ * be listed ahead of `sitemap()` in `integrations`.
+ */
+const noindexPaths = new Set();
+function collectNoindexPages() {
+  // Attribute order varies by emitter (Starlight `head`, hand-written
+  // layouts), so match either order.
+  const noindexRegex =
+    /<meta\b(?=[^>]*\bname="robots")(?=[^>]*\bcontent="[^"]*noindex)/i;
+  return {
+    name: "collect-noindex-pages",
+    hooks: {
+      "astro:build:done": async ({ dir, logger }) => {
+        const outDir = fileURLToPath(dir);
+        // Sequential on purpose: ~4.4k pages, and fanning the reads out
+        // holds every page's HTML in memory at once on top of an already
+        // heavy build heap.
+        /** @param {string} d */
+        async function walk(d) {
+          const entries = await fs.readdir(d, { withFileTypes: true });
+          for (const e of entries) {
+            const full = path.join(d, e.name);
+            if (e.isDirectory()) {
+              await walk(full);
+              continue;
+            }
+            if (!e.isFile() || !e.name.endsWith(".html")) continue;
+            const html = await fs.readFile(full, "utf8");
+            if (!noindexRegex.test(html)) continue;
+            // dist/foo/bar/index.html -> /foo/bar/ (sitemap URLs carry the
+            // trailing slash); dist/foo.html -> /foo.html
+            let rel =
+              "/" + path.relative(outDir, full).split(path.sep).join("/");
+            if (rel.endsWith("/index.html"))
+              rel = rel.slice(0, -"index.html".length);
+            noindexPaths.add(rel);
+          }
+        }
+        await walk(outDir);
+        logger.info(
+          `${noindexPaths.size} noindex page(s) excluded from the sitemap`,
+        );
+      },
+    },
+  };
+}
+
+/**
  * Build-output checks — one pass over every rendered HTML page:
  *
  * 1. Case-sensitive internal-link check: validates every internal
@@ -354,13 +408,15 @@ export default defineConfig({
     pagefindIgnoreNoise(),
     copyMarkdownSources(),
     buildOutputChecks(),
+    collectNoindexPages(),
     sitemap({
       filter: (page) =>
         !page.endsWith(".html") &&
         !page.endsWith(".md") &&
         !page.endsWith(".mdx") &&
-        // OAuth device-flow landing pages — `noindex` in `Auth.astro`.
-        !page.includes("/auth/") &&
+        // Anything rendered with a `noindex` robots meta: `/auth/*`, and the
+        // example-less API reference stubs (see `collectNoindexPages`).
+        !noindexPaths.has(new URL(page).pathname) &&
         // starlight-blog's paginated listings (`/blog/2/`, …) — thin pages
         // that only repeat post excerpts; the posts themselves are listed.
         !/\/blog\/\d+\/?$/.test(page),

--- a/website/public/robots.txt
+++ b/website/public/robots.txt
@@ -1,0 +1,5 @@
+# https://alchemy.run — full site is crawlable.
+User-agent: *
+Allow: /
+
+Sitemap: https://alchemy.run/sitemap-index.xml

--- a/website/src/components/DAG.astro
+++ b/website/src/components/DAG.astro
@@ -278,7 +278,7 @@ const buildEdges = (): Edge[] =>
 const edgeShapes = buildEdges();
 ---
 
-<figure class="alc-dag not-content">
+<figure class="alc-dag not-content" data-nosnippet>
   <svg
     class="alc-dag__svg"
     viewBox={`0 0 ${W} ${H}`}

--- a/website/src/components/LoopDiagram.astro
+++ b/website/src/components/LoopDiagram.astro
@@ -15,7 +15,7 @@
  */
 ---
 
-<figure class="alc-loop">
+<figure class="alc-loop" data-nosnippet>
   <svg
     class="alc-loop__svg"
     viewBox="0 0 760 250"

--- a/website/src/components/StructuredData.astro
+++ b/website/src/components/StructuredData.astro
@@ -1,0 +1,46 @@
+---
+/**
+ * Schema.org JSON-LD for the site: an `Organization` (with `sameAs` pointing
+ * at our social profiles so search engines link them to the brand) and the
+ * `WebSite` it publishes. Emitted on every page — marketing and docs — so the
+ * knowledge-panel signals don't depend on which URL gets crawled first.
+ *
+ * URLs are always built against `Astro.site` (the canonical origin), never
+ * the request host, so mirrors and previews describe production.
+ */
+const site = Astro.site ?? new URL("https://alchemy.run");
+const organizationId = new URL("/#organization", site).href;
+
+const SOCIAL_PROFILES = {
+  github: "https://github.com/alchemy-run/alchemy",
+  x: "https://x.com/alchemy_run",
+  discord: "https://discord.gg/jwKw8dBJdN",
+  npm: "https://www.npmjs.com/package/alchemy",
+} as const;
+
+const organization = {
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "@id": organizationId,
+  name: "Alchemy",
+  url: site.href,
+  logo: new URL("/alchemy-logo-512-white-bg.png", site).href,
+  sameAs: Object.values(SOCIAL_PROFILES),
+};
+
+const website = {
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "@id": new URL("/#website", site).href,
+  name: "Alchemy",
+  url: site.href,
+  publisher: { "@id": organizationId },
+};
+
+// `</script` inside a JSON string would end the block early; escape `<`.
+const json = (value: unknown) =>
+  JSON.stringify(value).replaceAll("<", "\\u003c");
+---
+
+<script is:inline type="application/ld+json" set:html={json(organization)} />
+<script is:inline type="application/ld+json" set:html={json(website)} />

--- a/website/src/components/Terminal.astro
+++ b/website/src/components/Terminal.astro
@@ -30,7 +30,7 @@ const html = content
   .replace(/\[s4\]/g, '    ');
 ---
 
-<div class="terminal not-content">
+<div class="terminal not-content" data-nosnippet>
   <div class="terminal-header">
     <span class="terminal-dot" style="background:#ff5f57"></span>
     <span class="terminal-dot" style="background:#febc2e"></span>

--- a/website/src/components/marketing-islands/AsyncTabs.tsx
+++ b/website/src/components/marketing-islands/AsyncTabs.tsx
@@ -49,7 +49,7 @@ export default function AsyncTabs({ panels }: { panels: Panel[] }) {
   const html = panels.map((p) => highlightTS(p.code));
 
   return (
-    <div ref={wrapRef} className="async-tabs">
+    <div ref={wrapRef} className="async-tabs" data-nosnippet="">
       <div className="async-tabs__chrome">
         <div className="async-tabs__header">
           <span

--- a/website/src/components/marketing-islands/BindingsToIAM.tsx
+++ b/website/src/components/marketing-islands/BindingsToIAM.tsx
@@ -138,7 +138,7 @@ export default function BindingsToIAM() {
   }, []);
 
   return (
-    <div ref={wrapRef} className="bindings-iam">
+    <div ref={wrapRef} className="bindings-iam" data-nosnippet="">
       {/* LEFT — Lambda code */}
       <div className="alc-code-block bindings-iam__code">
         <div className="alc-code-block__header">

--- a/website/src/components/marketing-islands/BrowserHotReload.tsx
+++ b/website/src/components/marketing-islands/BrowserHotReload.tsx
@@ -252,7 +252,8 @@ function BrowserChrome({
   style?: CSSProperties;
 }) {
   return (
-    <div className="bhr-browser" style={style}>
+    // Simulated browser chrome — decoration, kept out of search snippets.
+    <div className="bhr-browser" style={style} data-nosnippet>
       <div className="bhr-browser__header">
         <span
           className="alc-code-block__dot"

--- a/website/src/components/marketing-islands/BrowserHotReload.tsx
+++ b/website/src/components/marketing-islands/BrowserHotReload.tsx
@@ -253,7 +253,7 @@ function BrowserChrome({
 }) {
   return (
     // Simulated browser chrome — decoration, kept out of search snippets.
-    <div className="bhr-browser" style={style} data-nosnippet>
+    <div className="bhr-browser" style={style} data-nosnippet="">
       <div className="bhr-browser__header">
         <span
           className="alc-code-block__dot"

--- a/website/src/components/marketing-islands/CopyForAgent.tsx
+++ b/website/src/components/marketing-islands/CopyForAgent.tsx
@@ -26,7 +26,7 @@ export default function CopyForAgent() {
   };
 
   return (
-    <div className="alc-copy-agent">
+    <div className="alc-copy-agent" data-nosnippet="">
       <code className="alc-copy-agent__text">{PROMPT}</code>
       <button
         type="button"

--- a/website/src/components/marketing-islands/EffectPilledShowcase.tsx
+++ b/website/src/components/marketing-islands/EffectPilledShowcase.tsx
@@ -261,7 +261,7 @@ export default function EffectPilledShowcase() {
   const splitKey = tab;
 
   return (
-    <div ref={wrapRef} className="eff-showcase">
+    <div ref={wrapRef} className="eff-showcase" data-nosnippet="">
       <div className="eff-showcase__chrome">
         <div className="eff-showcase__header">
           <span

--- a/website/src/components/marketing-islands/HeroCta.tsx
+++ b/website/src/components/marketing-islands/HeroCta.tsx
@@ -28,7 +28,7 @@ export default function HeroCta() {
             Tutorial
           </a>
         </div>
-        <div className="hero-cta__line">
+        <div className="hero-cta__line" data-nosnippet="">
           <span>
             <span aria-hidden>🤖</span> Using a coding agent?
           </span>
@@ -75,7 +75,9 @@ function CopyCard() {
           {copied ? <CheckIcon /> : <CopyIcon />}
         </span>
       </span>
-      <code className="hero-cta__prompt-code">{PROMPT}</code>
+      <code className="hero-cta__prompt-code" data-nosnippet="">
+        {PROMPT}
+      </code>
     </button>
   );
 }

--- a/website/src/components/marketing-islands/OutputGraphAnim.tsx
+++ b/website/src/components/marketing-islands/OutputGraphAnim.tsx
@@ -131,7 +131,7 @@ export default function OutputGraphAnim() {
   );
 
   return (
-    <div ref={wrapRef} className="output-anim-grid">
+    <div ref={wrapRef} className="output-anim-grid" data-nosnippet="">
       {/* LEFT — code panel with progressive highlight */}
       <div className="alc-code-block">
         <div className="alc-code-block__header">

--- a/website/src/components/marketing-islands/PRLifecycle.tsx
+++ b/website/src/components/marketing-islands/PRLifecycle.tsx
@@ -150,7 +150,7 @@ export default function PRLifecycle() {
             : "DESTROY";
 
   return (
-    <div className="pr-lc">
+    <div className="pr-lc" data-nosnippet="">
       <ol className="pr-lc__timeline" aria-label="PR lifecycle">
         {PHASES.map((p, i) => {
           const activeIdx = PHASES.findIndex((x) => x.id === phase);

--- a/website/src/components/marketing-islands/ServiceLayerSwap.tsx
+++ b/website/src/components/marketing-islands/ServiceLayerSwap.tsx
@@ -182,7 +182,7 @@ export default function ServiceLayerSwap() {
   const active = IMPLS[idx]!;
 
   return (
-    <div ref={wrapRef} className="service-swap-grid">
+    <div ref={wrapRef} className="service-swap-grid" data-nosnippet="">
       {/* LEFT — code: Worker that consumes Sessions, Layer name swaps */}
       <div className="alc-code-block">
         <div className="alc-code-block__header">

--- a/website/src/components/marketing-islands/_terminal.tsx
+++ b/website/src/components/marketing-islands/_terminal.tsx
@@ -111,7 +111,10 @@ export function TermChrome({
     );
   }
   return (
-    <div className="alc-term not-content">
+    // `data-nosnippet`: the simulated terminal is decoration, not prose. Left
+    // visible to crawlers it leaks into Google-generated snippets as chrome
+    // fragments ("~/my-appDEV", "○localhost:1337/ HMR").
+    <div className="alc-term not-content" data-nosnippet>
       <div className="alc-term__header">
         <span
           className="alc-code-block__dot"

--- a/website/src/components/marketing-islands/_terminal.tsx
+++ b/website/src/components/marketing-islands/_terminal.tsx
@@ -114,7 +114,7 @@ export function TermChrome({
     // `data-nosnippet`: the simulated terminal is decoration, not prose. Left
     // visible to crawlers it leaks into Google-generated snippets as chrome
     // fragments ("~/my-appDEV", "○localhost:1337/ HMR").
-    <div className="alc-term not-content" data-nosnippet>
+    <div className="alc-term not-content" data-nosnippet="">
       <div className="alc-term__header">
         <span
           className="alc-code-block__dot"

--- a/website/src/components/starlight/Head.astro
+++ b/website/src/components/starlight/Head.astro
@@ -13,6 +13,7 @@
 import Default from "@astrojs/starlight/components/Head.astro";
 import PostHog from "../analytics/PostHog.astro";
 import BrandIcons from "../../brand/Icons.astro";
+import StructuredData from "../StructuredData.astro";
 
 // Starlight injects route data via Astro.locals at runtime; the public
 // types aren't ambient-declared in this project, so we cast through any.
@@ -38,7 +39,11 @@ const ogImage = new URL(`/og/${ogSlug}.png`, Astro.site);
 
 {/* Twitter / X */}
 <meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:site" content="@alchemy_run" />
 <meta name="twitter:image" content={ogImage.href} />
+
+{/* Organization (sameAs → social profiles) + WebSite JSON-LD. */}
+<StructuredData />
 
 <PostHog />
 

--- a/website/src/layouts/Auth.astro
+++ b/website/src/layouts/Auth.astro
@@ -28,6 +28,8 @@ const {
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <ThemeProvider />
     <title>{title} — Alchemy</title>
+    {/* OAuth device-flow landing pages: no standalone content worth indexing. */}
+    <meta name="robots" content="noindex, follow" />
     <BrandIcons />
   </head>
   <body class="alc-auth-body">

--- a/website/src/layouts/Marketing.astro
+++ b/website/src/layouts/Marketing.astro
@@ -7,6 +7,7 @@ import Footer from "../components/marketing/Footer.astro";
 import PostHog from "../components/analytics/PostHog.astro";
 import ThemeProvider from "../components/ThemeProvider.astro";
 import BrandIcons from "../brand/Icons.astro";
+import StructuredData from "../components/StructuredData.astro";
 
 interface Props {
   title?: string;
@@ -72,9 +73,12 @@ const canonical = new URL(Astro.url.pathname, Astro.site);
 
     {/* Twitter / X */}
     <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@alchemy_run" />
     <meta name="twitter:title" content={title} />
     {description && <meta name="twitter:description" content={description} />}
     <meta name="twitter:image" content={ogImage.href} />
+
+    <StructuredData />
 
     <PostHog />
   </head>

--- a/website/src/pages/index.mdx
+++ b/website/src/pages/index.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../layouts/Marketing.astro
 title: "Alchemy — zero to production. TypeScript IaC on Effect."
-description: "Alchemy is the IaC tool that's actually TypeScript. Stand up your whole cloud in one program, type-check the IAM, hot-reload it locally, run tests against the real cloud, preview every PR, and ship dashboards & alarms in the same file."
+description: "Alchemy is the IaC tool that is actually TypeScript: one type-safe program for your whole cloud, hot-reloaded locally, tested against real infrastructure."
 ---
 
 import Section from "../components/marketing/Section.astro";

--- a/website/src/worker.ts
+++ b/website/src/worker.ts
@@ -16,18 +16,30 @@ interface HTMLRewriterElement {
 }
 
 /**
- * Astro bakes absolute URLs into `<meta property="og:image">`,
- * `og:url`, `twitter:image`, and `<link rel="canonical">` at build time
- * using the `site` config (`https://alchemy.run`). PR previews and
- * custom domains then advertise OG / canonical URLs that point back at
- * the canonical host — so a Slack/Twitter unfurl of a preview URL
- * fetches the *production* card, not the one for the page being
- * shared.
+ * `https://alchemy.run` is the one indexable origin. Every other host this
+ * worker answers on — `main.alchemy.run`, PR previews on `*.workers.dev`,
+ * future aliases — is a mirror of the same build:
  *
- * Rewrite those tags at the edge to match the request's actual host so
- * each deployment unfurls itself.
+ * - `<link rel="canonical">` is baked at build time against `site` and is left
+ *   alone, so mirrors point search engines back at production.
+ * - Every mirror response carries `X-Robots-Tag: noindex` and its `robots.txt`
+ *   advertises no sitemap, so a mirror URL that leaks (a PR comment, a shared
+ *   link) never becomes a duplicate search result.
+ * - `og:*` / `twitter:*` card URLs ARE rewritten to the request host, so a
+ *   Slack/X unfurl of a preview URL shows that preview's card, not
+ *   production's.
  */
 const CANONICAL_HOST = "alchemy.run";
+const CANONICAL_ORIGIN = `https://${CANONICAL_HOST}`;
+
+/**
+ * The v1 docs moved to their own host. v1-era URLs (`/docs/...`, and the
+ * pre-hub `/guides/...` / `/providers/...` / `/concepts/...` trees) are still
+ * in search indexes; instead of 404ing them we probe v1 and 301 when it has
+ * the page.
+ */
+const V1_ORIGIN = "https://v1.alchemy.run";
+const V1_PREFIXES = ["/docs/", "/guides/", "/providers/", "/concepts/"];
 
 /**
  * 301s for the docs restructure (guides/tutorials moved into per-cloud hubs).
@@ -228,12 +240,22 @@ const resolveRedirect = (url: URL): string | undefined => {
 
 export default {
   fetch: async (request: Request, env: WorkerEnv) => {
-    const redirect = resolveRedirect(new URL(request.url));
+    const url = new URL(request.url);
+    const canonical = url.host === CANONICAL_HOST;
+    const redirect = resolveRedirect(url);
     if (redirect !== undefined) {
       return Response.redirect(new URL(redirect, request.url), 301);
     }
+    if (url.pathname === "/robots.txt" && !canonical) {
+      return new Response(MIRROR_ROBOTS_TXT, {
+        headers: {
+          "content-type": "text/plain; charset=utf-8",
+          "x-robots-tag": "noindex",
+        },
+      });
+    }
     if (request.method === "GET" && prefersMarkdown(request)) {
-      const mdUrl = toMarkdownUrl(new URL(request.url)).toString();
+      const mdUrl = toMarkdownUrl(url).toString();
       const res = await env.ASSETS.fetch(new Request(mdUrl, request));
       // Astro's asset server labels `.md` as `application/octet-stream`, which
       // agents treat as a binary download instead of rendering. Force the
@@ -241,19 +263,38 @@ export default {
       if (res.status !== 404)
         return withoutIndexing(
           withContentType(res, "text/markdown; charset=utf-8"),
+          url,
+          canonical,
         );
     }
     const res = await env.ASSETS.fetch(request);
+    if (res.status === 404 && request.method === "GET") {
+      const v1 = await resolveV1Fallback(url);
+      if (v1 !== undefined) return Response.redirect(v1, 301);
+    }
     return withoutIndexing(
       withUtf8Charset(
         await rewriteAgentTextOrigin(
           request,
-          rewriteCanonicalHost(request, res),
+          rewriteSocialCardHost(request, res),
         ),
       ),
+      url,
+      canonical,
     );
   },
 };
+
+/**
+ * Served as `robots.txt` on every non-canonical host. Crawlable on purpose:
+ * a `Disallow` would stop crawlers from ever seeing the `noindex` header, and
+ * a blocked URL can still be indexed by URL alone. No `Sitemap:` line, so the
+ * mirror never advertises itself.
+ */
+const MIRROR_ROBOTS_TXT = `# Mirror of https://${CANONICAL_HOST} — every response is noindex.
+User-agent: *
+Allow: /
+`;
 
 /**
  * Every page is mirrored as raw markdown (`/getting-started.md`, or the same
@@ -264,27 +305,54 @@ export default {
  * kind of agent-facing text.
  *
  * Keep them crawlable (so the directive is actually seen) but out of the index.
+ * On a non-canonical host *everything* is noindex — the HTML included.
  */
-const withoutIndexing = (res: Response): Response => {
+const withoutIndexing = (
+  res: Response,
+  url: URL,
+  canonicalHost: boolean,
+): Response => {
   const ct = res.headers.get("content-type") ?? "";
-  if (!ct.includes("text/markdown") && !ct.includes("text/plain")) return res;
+  const agentText =
+    url.pathname.endsWith(".md") ||
+    ct.includes("text/markdown") ||
+    ct.includes("text/plain");
+  if (canonicalHost && !agentText) return res;
   const next = new Response(res.body, res);
   next.headers.set("x-robots-tag", "noindex");
   return next;
 };
 
 /**
- * `llms.txt` / `llms-full.txt` / `robots.txt` are generated at build time with
- * absolute canonical URLs, so a PR preview would hand agents an index — and
- * crawlers a sitemap — that points back at production. Rewrite the baked origin
- * to the request's own origin — the same treatment `rewriteCanonicalHost` gives
- * HTML meta tags.
+ * v1-era URL that still resolves on the v1 docs host, or `undefined`. Only
+ * consulted after production 404s, so the extra HEAD subrequest is confined
+ * to dead links.
  */
-const AGENT_TEXT_PATHS = new Set([
-  "/llms.txt",
-  "/llms-full.txt",
-  "/robots.txt",
-]);
+const resolveV1Fallback = async (url: URL): Promise<string | undefined> => {
+  const pathname = url.pathname.replace(/\/$/, "");
+  if (pathname.endsWith(".md")) return undefined;
+  if (!V1_PREFIXES.some((prefix) => `${pathname}/`.startsWith(prefix))) {
+    return undefined;
+  }
+  const v1Path = pathname.startsWith("/docs/")
+    ? pathname.slice("/docs".length)
+    : pathname;
+  const target = `${V1_ORIGIN}${v1Path}${url.search}`;
+  try {
+    const probe = await fetch(target, { method: "HEAD", redirect: "follow" });
+    return probe.ok ? target : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * `llms.txt` / `llms-full.txt` are generated at build time with absolute
+ * canonical URLs, so a PR preview would hand agents an index that points back
+ * at production. Rewrite the baked origin to the request's own origin — the
+ * same treatment `rewriteSocialCardHost` gives the OG tags.
+ */
+const AGENT_TEXT_PATHS = new Set(["/llms.txt", "/llms-full.txt"]);
 
 const rewriteAgentTextOrigin = async (
   request: Request,
@@ -299,7 +367,7 @@ const rewriteAgentTextOrigin = async (
     return res;
   }
   const body = (await res.text()).replaceAll(
-    `https://${CANONICAL_HOST}/`,
+    `${CANONICAL_ORIGIN}/`,
     `${reqUrl.origin}/`,
   );
   return new Response(body, res);
@@ -323,19 +391,21 @@ const withContentType = (res: Response, contentType: string): Response => {
   return next;
 };
 
-const rewriteCanonicalHost = (request: Request, res: Response): Response => {
+/**
+ * Astro bakes absolute URLs into `og:image`, `og:url`, and `twitter:image`
+ * using the `site` config. Rewrite those to the request's host so each
+ * deployment unfurls itself. `<link rel="canonical">` is deliberately NOT
+ * rewritten — it must keep pointing at production on every mirror.
+ */
+const rewriteSocialCardHost = (request: Request, res: Response): Response => {
   const ct = res.headers.get("content-type") ?? "";
   if (!ct.includes("text/html")) return res;
   const reqUrl = new URL(request.url);
   if (reqUrl.host === CANONICAL_HOST) return res;
 
-  class HostRewriter {
-    attr: "content" | "href";
-    constructor(attr: "content" | "href") {
-      this.attr = attr;
-    }
+  const content = {
     element(el: HTMLRewriterElement) {
-      const value = el.getAttribute(this.attr);
+      const value = el.getAttribute("content");
       if (!value) return;
       let u: URL;
       try {
@@ -346,18 +416,14 @@ const rewriteCanonicalHost = (request: Request, res: Response): Response => {
       if (u.host !== CANONICAL_HOST) return;
       u.protocol = reqUrl.protocol;
       u.host = reqUrl.host;
-      el.setAttribute(this.attr, u.toString());
-    }
-  }
-
-  const content = new HostRewriter("content");
-  const href = new HostRewriter("href");
+      el.setAttribute("content", u.toString());
+    },
+  };
 
   return new HTMLRewriter()
     .on('meta[property="og:image"]', content)
     .on('meta[property="og:url"]', content)
     .on('meta[name="twitter:image"]', content)
-    .on('link[rel="canonical"]', href)
     .transform(res);
 };
 

--- a/website/src/worker.ts
+++ b/website/src/worker.ts
@@ -239,28 +239,60 @@ export default {
       // agents treat as a binary download instead of rendering. Force the
       // correct text type + charset since this branch only ever serves markdown.
       if (res.status !== 404)
-        return withContentType(res, "text/markdown; charset=utf-8");
+        return withoutIndexing(
+          withContentType(res, "text/markdown; charset=utf-8"),
+        );
     }
     const res = await env.ASSETS.fetch(request);
-    return withUtf8Charset(
-      await rewriteLlmsTxtOrigin(request, rewriteCanonicalHost(request, res)),
+    return withoutIndexing(
+      withUtf8Charset(
+        await rewriteAgentTextOrigin(
+          request,
+          rewriteCanonicalHost(request, res),
+        ),
+      ),
     );
   },
 };
 
 /**
- * `llms.txt` / `llms-full.txt` are generated at build time with absolute
- * canonical URLs, so a PR preview would hand agents an index that points back
- * at production. Rewrite the baked origin to the request's own origin — the
- * same treatment `rewriteCanonicalHost` gives HTML meta tags.
+ * Every page is mirrored as raw markdown (`/getting-started.md`, or the same
+ * URL requested with `Accept: text/markdown`) for agents. Search engines crawl
+ * those mirrors too and index them as separate documents — duplicating the HTML
+ * page and surfacing raw MDX (`import { Tabs } from "@astrojs/starlight/..."`)
+ * as the search result's snippet. `llms.txt` / `llms-full.txt` are the same
+ * kind of agent-facing text.
+ *
+ * Keep them crawlable (so the directive is actually seen) but out of the index.
  */
-const rewriteLlmsTxtOrigin = async (
+const withoutIndexing = (res: Response): Response => {
+  const ct = res.headers.get("content-type") ?? "";
+  if (!ct.includes("text/markdown") && !ct.includes("text/plain")) return res;
+  const next = new Response(res.body, res);
+  next.headers.set("x-robots-tag", "noindex");
+  return next;
+};
+
+/**
+ * `llms.txt` / `llms-full.txt` / `robots.txt` are generated at build time with
+ * absolute canonical URLs, so a PR preview would hand agents an index — and
+ * crawlers a sitemap — that points back at production. Rewrite the baked origin
+ * to the request's own origin — the same treatment `rewriteCanonicalHost` gives
+ * HTML meta tags.
+ */
+const AGENT_TEXT_PATHS = new Set([
+  "/llms.txt",
+  "/llms-full.txt",
+  "/robots.txt",
+]);
+
+const rewriteAgentTextOrigin = async (
   request: Request,
   res: Response,
 ): Promise<Response> => {
   const reqUrl = new URL(request.url);
   if (
-    (reqUrl.pathname !== "/llms.txt" && reqUrl.pathname !== "/llms-full.txt") ||
+    !AGENT_TEXT_PATHS.has(reqUrl.pathname) ||
     reqUrl.host === CANONICAL_HOST ||
     !res.ok
   ) {


### PR DESCRIPTION
SEO pass. Google Search Console has been surfacing non-content (terminal chrome, the copy-for-agent prompt, raw `.md` mirrors, mirror hosts) as results and snippets.

### One indexable origin

`https://alchemy.run` is canonical. Every other host the worker answers on — `main.alchemy.run`, PR previews, future aliases — is a mirror:

```ts
// src/worker.ts — on any non-canonical host
X-Robots-Tag: noindex            // every response
<link rel="canonical">           // left pointing at https://alchemy.run (no longer rewritten)
robots.txt                       // Allow: /, no Sitemap: line
og:url / og:image / twitter:image // still rewritten so previews unfurl themselves
```

Before this, `main.alchemy.run/getting-started/` declared itself canonical and was fully indexable.

### robots.txt + markdown mirrors

`alchemy.run/robots.txt` was serving only Cloudflare's content-signals block — no `Sitemap:`. Now `website/public/robots.txt` advertises the sitemap.

`.md` mirrors (`/getting-started.md`, `Accept: text/markdown`) and `llms*.txt` get `X-Robots-Tag: noindex` — crawlable so the directive is seen, out of the index. DuckDuckGo/Google were listing `alchemy.run/guides/cloudflare.md` with `import { Tabs, TabItem } from '@astrojs/starlight/components';` as the snippet.

### v1-era URLs

`/docs/getting-started`, `/docs/providers/aws-control/…`, `/guides/cloudflare` are still indexed and 404 on prod. On a prod 404 under `/docs/`, `/guides/`, `/providers/`, `/concepts/` the worker HEADs `v1.alchemy.run` and 301s there when it has the page.

### `data-nosnippet`

On every simulated terminal / browser / diagram island on the homepage, the docs `Terminal`, `DAG`, `LoopDiagram` figures, and both SSR'd copies of the 2.8 KB copy-for-agent prompt. Live snippet before: `Learn more →. ‹›↻. ○localhost:1337/ HMR. ~/my-appDEV.`

### Generated reference pages are `noindex, follow`

`/providers/**` is 4,070 of the site's 4,412 pages (AWS alone 3,584), each a one-paragraph summary plus one snippet. Indexed individually they read as programmatic thin content and are what surfaces as "random" results instead of the hub/guide pages. The generator now emits:

```yaml
head:
  - tag: meta
    attrs: { name: robots, content: "noindex, follow" }
```

Still navigable, still crawled (`follow`), still in Pagefind. `follow` keeps link equity flowing to the hub pages. Lifting it later is one line in `scripts/generate-api-reference.ts`.

The sitemap no longer needs a hand-maintained exclusion list: a `collectNoindexPages` integration scans the build output for a `noindex` robots meta and the sitemap filter drops those URLs — covers the reference pages and `/auth/*` alike.

### Structured data

`Organization` (`sameAs` → GitHub, X, Discord, npm) + `WebSite` JSON-LD and `twitter:site` on every page (`src/components/StructuredData.astro`).

### Also

- `/auth/*` pages `noindex, follow` and out of the sitemap
- blog pagination pages (`/blog/2/`…) out of the sitemap
- homepage description 254 → 154 chars

🤖 Generated with [Claude Code](https://claude.com/claude-code)
