### PR TITLE
feat(engine): force a subset of the stack

### DIFF
--- a/packages/alchemy/src/Action.ts
+++ b/packages/alchemy/src/Action.ts
@@ -1,9 +1,11 @@
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import type { Pipeable } from "effect/Pipeable";
 import { makeCaptureContext } from "./ActionRuntimeContext.ts";
 import { toFqn } from "./FQN.ts";
+import { ForcePolicy } from "./ForcePolicy.ts";
 import type { Input } from "./Input.ts";
 import { CurrentNamespace, type NamespaceNode } from "./Namespace.ts";
 import * as Output from "./Output.ts";
@@ -45,6 +47,14 @@ export interface ActionLike<
    * {@link RuntimeContext}. Empty when the Action captures nothing.
    */
   readonly Captures: Record<string, Output.Output>;
+  /**
+   * Per-action force policy captured from the ambient {@link ForcePolicy}
+   * at registration time (e.g. via `.pipe(force(true))`). `true` re-runs the
+   * body even when the input hash is unchanged; `false` pins the action as
+   * never-forced, overriding the run-level `--force`. `undefined` means no
+   * action-scoped override.
+   */
+  readonly Force: boolean | undefined;
   /** Resolved runner — populated by the init effect (if any). */
   readonly Run: (input: In) => Effect.Effect<Out, any, any>;
   /** @internal phantom */
@@ -288,6 +298,9 @@ const registerAction = <
       LogicalId: id,
       Input: input,
       Captures: captures,
+      Force: yield* Effect.serviceOption(ForcePolicy).pipe(
+        Effect.map(Option.getOrUndefined),
+      ),
       Run: run,
       Output: undefined as any,
     };

--- a/packages/alchemy/src/Cli/commands/_shared.ts
+++ b/packages/alchemy/src/Cli/commands/_shared.ts
@@ -11,6 +11,7 @@ import * as S from "effect/Schema";
 import * as Argument from "effect/unstable/cli/Argument";
 import * as CliError from "effect/unstable/cli/CliError";
 import * as Flag from "effect/unstable/cli/Flag";
+import * as Primitive from "effect/unstable/cli/Primitive";
 import { pathToFileURL } from "node:url";
 
 import {
@@ -26,6 +27,7 @@ import {
 import { AwsAuth } from "../../AWS/AuthProvider.ts";
 import { AxiomAuth } from "../../Axiom/AuthProvider.ts";
 import { CloudflareAuth } from "../../Cloudflare/Auth/AuthProvider.ts";
+import type { ForceSelection } from "../../ForcePolicy.ts";
 import { GitHubAuth } from "../../GitHub/AuthProvider.ts";
 import { HetznerAuth } from "../../Hetzner/AuthProvider.ts";
 import { NeonAuth } from "../../Neon/AuthProvider.ts";
@@ -148,11 +150,71 @@ export const yes = Flag.boolean("yes").pipe(
   Flag.withDefault(false),
 );
 
-export const force = Flag.boolean("force").pipe(
+/**
+ * A flag the parser treats as a switch — a bare `--force` is legal and never
+ * swallows the following positional — but which also accepts an inline value
+ * (`--force=Seed,Api`).
+ *
+ * Effect's CLI has no first-class "optional value" flag: the parser decides
+ * whether to consume the next token by asking `Primitive.isBoolean`, which is
+ * a `_tag === "Boolean"` check, and an `=`-attached value is handed to the
+ * primitive's `parse` before that check runs. So a string primitive wearing
+ * the Boolean tag gets us both behaviors: `--force` parses the synthesized
+ * literal `"true"`, `--no-force` parses `"false"`, and `--force=A,B` parses
+ * `"A,B"`. `--force A,B` (space-separated) is NOT supported — that token
+ * stays positional, which is exactly what keeps `alchemy deploy --force
+ * main.ts` working.
+ *
+ * The three shapes are pinned by test/Cli/forceFlag.test.ts so a change to
+ * that internal contract fails loudly instead of silently.
+ */
+const optionalValuePrimitive: Primitive.Primitive<string> = Object.assign(
+  Object.create(Object.getPrototypeOf(Primitive.string)),
+  Primitive.string,
+  { _tag: "Boolean", parse: (value: string) => Effect.succeed(value) },
+);
+
+const optionalValueFlag = (name: string): Flag.Flag<string> => {
+  const flag = Flag.boolean(name);
+  return Object.assign(Object.create(Object.getPrototypeOf(flag)), flag, {
+    primitiveType: optionalValuePrimitive,
+  }) as unknown as Flag.Flag<string>;
+};
+
+const BOOLEAN_LITERALS: Record<string, boolean> = {
+  true: true,
+  "1": true,
+  y: true,
+  yes: true,
+  on: true,
+  false: false,
+  "0": false,
+  n: false,
+  no: false,
+  off: false,
+};
+
+/**
+ * Parse the raw `--force` value into a {@link ForceSelection}: the switch
+ * forms give a boolean, an inline value gives the comma-separated list.
+ */
+export const parseForceValue = (raw: string): ForceSelection => {
+  const literal = BOOLEAN_LITERALS[raw.trim().toLowerCase()];
+  if (literal !== undefined) return literal;
+  const ids = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  return ids.length > 0 ? ids : false;
+};
+
+export const force = optionalValueFlag("force").pipe(
   Flag.withDescription(
-    "Force updates for resources that would otherwise no-op",
+    "Re-run resources/actions that would otherwise no-op. " +
+      "Use --force=Seed,Api to force only those (logical ID or FQN).",
   ),
-  Flag.withDefault(false),
+  Flag.withDefault("false"),
+  Flag.map(parseForceValue),
 );
 
 export const script = Argument.file("main", {

--- a/packages/alchemy/src/Cli/commands/deploy.ts
+++ b/packages/alchemy/src/Cli/commands/deploy.ts
@@ -39,7 +39,14 @@ export const ExecStackOptions = Schema.Struct({
   envFile: Schema.OptionFromOptional(Schema.String),
   profile: Schema.optional(Schema.String),
   dryRun: Schema.optional(Schema.Boolean),
-  force: Schema.optional(Schema.Boolean),
+  /**
+   * `true` forces every node, an array forces just those logical IDs / FQNs
+   * (`--force=Seed,Api`). Encoded into `ALCHEMY_EXEC_OPTIONS` for the dev
+   * child process, so it has to survive a JSON round-trip.
+   */
+  force: Schema.optional(
+    Schema.Union([Schema.Boolean, Schema.Array(Schema.String)]),
+  ),
   yes: Schema.optional(Schema.Boolean),
   destroy: Schema.optional(Schema.Boolean),
   dev: Schema.optional(Schema.Boolean),
@@ -54,6 +61,9 @@ const stackSpanAttrs = (args: ExecStackOptions) => ({
   "alchemy.main": args.main,
   "alchemy.dry_run": !!args.dryRun,
   "alchemy.force": !!args.force,
+  "alchemy.force.selection": Array.isArray(args.force)
+    ? args.force.join(",")
+    : undefined,
   "alchemy.destroy": !!args.destroy,
   "alchemy.dev": !!args.dev,
   "alchemy.adopt": !!args.adopt,
@@ -237,6 +247,7 @@ export const destroyCommand = Command.make(
 export const planCommand = Command.make(
   "plan",
   {
+    force,
     main: script,
     envFile,
     stage,

--- a/packages/alchemy/src/Deploy.ts
+++ b/packages/alchemy/src/Deploy.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 import type * as Scope from "effect/Scope";
 import { AlchemyContext } from "./AlchemyContext.ts";
 import * as Apply from "./Apply.ts";
+import type { ForceSelection } from "./ForcePolicy.ts";
 import type { Input } from "./Input.ts";
 import * as Plan from "./Plan.ts";
 import { evalStack, type CompiledStack, type StackEffect } from "./Stack.ts";
@@ -20,7 +21,8 @@ export const deploy = <A>({
   dev?: boolean;
   /** See {@link evalStack} — when set, scoped resources outlive `deploy`. */
   scope?: Scope.Scope;
-  force?: boolean;
+  /** `true` forces every node; a list forces only those logical IDs / FQNs. */
+  force?: ForceSelection;
 }) =>
   evalStack(
     stack,

--- a/packages/alchemy/src/ForcePolicy.ts
+++ b/packages/alchemy/src/ForcePolicy.ts
@@ -1,0 +1,170 @@
+import * as Context from "effect/Context";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+
+/**
+ * Forcing re-runs a node that the engine would otherwise plan as a `noop`:
+ * a Resource's `reconcile` runs again against unchanged props, and an
+ * {@link Action}'s body runs again against an unchanged input hash.
+ *
+ * There are two ways to force, and they compose:
+ *
+ *   1. **Per declaration** — `.pipe(force(...))`, captured at registration
+ *      exactly like `adopt()` / `retain()` / `remote()` and stored on the
+ *      declaration as `Force`. Applies to every node declared inside the
+ *      piped effect, so it can decorate one resource or a whole scope.
+ *   2. **Per run** — the CLI's `--force` flag, either as a switch (force
+ *      everything) or with an explicit selection (`--force=Seed,Api`).
+ *
+ * A declaration-level policy always wins over the run-level selection, so
+ * `force(false)` is a genuine opt-out: `alchemy deploy --force` re-runs
+ * everything *except* nodes pinned with `force(false)`.
+ *
+ * Forcing never changes the *shape* of a plan — a node that would create,
+ * update, replace or delete does exactly that. It only upgrades `noop` to
+ * `update` (resources) or `run` (actions).
+ */
+export class ForcePolicy extends Context.Service<ForcePolicy, boolean>()(
+  "ForcePolicy",
+) {}
+
+/**
+ * The run-level force selection, as produced by the CLI's `--force` flag:
+ *
+ * - `false` — nothing is forced (the default).
+ * - `true` — every node is forced (`--force`).
+ * - `string[]` — only the named nodes are forced (`--force=Seed,Api`). Each
+ *   entry matches a **logical ID** (`Seed`) or a full **FQN**
+ *   (`Backend/Seed`).
+ */
+export type ForceSelection = boolean | ReadonlyArray<string>;
+
+/**
+ * Force the nodes declared inside the piped effect on every deploy, even
+ * when nothing about them changed.
+ *
+ * The common shape is a conditional force driven by config, which gives an
+ * on-demand re-run without the declaration ever leaving the stack:
+ *
+ * @example Re-seed on demand
+ * ```typescript
+ * const seed = yield* SeedDatabase({ url: db.url }).pipe(
+ *   force(yield* Config.boolean("SEED").pipe(Config.withDefault(false))),
+ * );
+ * ```
+ * ```sh
+ * alchemy dev            # seeds once, then noops
+ * SEED=1 alchemy dev     # re-seeds
+ * ```
+ *
+ * @example Opt one resource out of a `--force` run
+ * ```typescript
+ * const worker = yield* Worker("Api", { ... }).pipe(force(false));
+ * ```
+ *
+ * @param enabled `true` (the default) forces; `false` pins the node as
+ *   never-forced, overriding a run-level `--force`. May also be an `Effect`
+ *   producing the boolean.
+ */
+export const force: {
+  // Identity-typed so branded effect interfaces survive the pipe with their
+  // brand intact (same treatment as `remote()`).
+  (
+    enabled?: boolean,
+  ): <Eff extends Effect.Effect<any, any, any>>(effect: Eff) => Eff;
+  <R1 = never>(
+    enabled: Effect.Effect<boolean, never, R1>,
+  ): <A, E, R2 = never>(
+    effect: Effect.Effect<A, E, R2>,
+  ) => Effect.Effect<A, E, R1 | R2>;
+} = ((enabled: boolean | Effect.Effect<boolean, never, any> = true) =>
+  (eff: Effect.Effect<any, any, any>) =>
+    eff.pipe(
+      typeof enabled === "boolean"
+        ? Effect.provideService(ForcePolicy, enabled)
+        : Effect.provideServiceEffect(ForcePolicy, enabled),
+    )) as any;
+
+/** A node (resource or action) a force selection can name. */
+export interface ForceTarget {
+  readonly fqn: string;
+  readonly logicalId: string;
+}
+
+/**
+ * Does the run-level selection name this node? A selection entry matches
+ * either the logical ID or the full FQN.
+ */
+export const selects = (
+  selection: ForceSelection | undefined,
+  target: ForceTarget,
+): boolean =>
+  typeof selection === "boolean" || selection === undefined
+    ? !!selection
+    : selection.some(
+        (entry) => entry === target.logicalId || entry === target.fqn,
+      );
+
+/**
+ * Resolve whether a node is forced on this run. The declaration-level policy
+ * (`force(true)` / `force(false)`, captured as `Force` at registration) wins
+ * over the run-level selection.
+ */
+export const isForced = (
+  declared: boolean | undefined,
+  selection: ForceSelection | undefined,
+  target: ForceTarget,
+): boolean => declared ?? selects(selection, target);
+
+/**
+ * Raised (as a defect) when `--force=<ids>` names something the stack does
+ * not declare — almost always a typo, and silently forcing nothing is the
+ * worst possible outcome for a flag whose entire job is to make something
+ * run.
+ */
+export class UnknownForceTargetError extends Data.TaggedError(
+  "UnknownForceTarget",
+)<{
+  message: string;
+  /** The unmatched `--force=` entries. */
+  targets: ReadonlyArray<string>;
+  /** Every logical ID declared by the stack. */
+  available: ReadonlyArray<string>;
+}> {}
+
+/**
+ * The `--force=` entries that match no declared node. Empty for a boolean
+ * selection (nothing to typo).
+ */
+export const unmatched = (
+  selection: ForceSelection | undefined,
+  targets: Iterable<ForceTarget>,
+): string[] => {
+  if (typeof selection === "boolean" || selection === undefined) return [];
+  const known = new Set<string>();
+  for (const target of targets) {
+    known.add(target.logicalId);
+    known.add(target.fqn);
+  }
+  return selection.filter((entry) => !known.has(entry));
+};
+
+export const unknownForceTarget = (
+  targets: ReadonlyArray<string>,
+  available: ReadonlyArray<string>,
+) =>
+  new UnknownForceTargetError({
+    targets,
+    available,
+    message: [
+      `--force named ${targets.map((t) => `'${t}'`).join(", ")}, which ${
+        targets.length === 1
+          ? "is not a resource or action"
+          : "are not resources or actions"
+      } in this stack.`,
+      "",
+      `Available: ${available.length > 0 ? available.join(", ") : "(none)"}`,
+      "",
+      "Pass a logical ID (`--force=Seed`) or a fully-qualified name (`--force=Backend/Seed`).",
+    ].join("\n"),
+  });

--- a/packages/alchemy/src/Plan.ts
+++ b/packages/alchemy/src/Plan.ts
@@ -30,6 +30,12 @@ import {
   type UpdateDiff,
 } from "./Diff.ts";
 import { parseFqn } from "./FQN.ts";
+import {
+  isForced as resolveForced,
+  unknownForceTarget,
+  unmatched as unmatchedForceTargets,
+  type ForceSelection,
+} from "./ForcePolicy.ts";
 import { generateInstanceId, InstanceId } from "./InstanceId.ts";
 import * as Output from "./Output.ts";
 import {
@@ -286,7 +292,14 @@ export type Plan<Output = any> = {
 };
 
 export interface MakePlanOptions {
-  force?: boolean;
+  /**
+   * Which nodes to force (re-run even when nothing changed): `true` for the
+   * whole stack, or a list of logical IDs / FQNs to force just those. A
+   * declaration decorated with `force(...)` overrides this per node.
+   *
+   * @see {@link ForceSelection}
+   */
+  force?: ForceSelection;
 }
 
 export const make = <A>(
@@ -334,6 +347,44 @@ export const make = <A>(
         onSome: (c) => c.adopt,
       });
     });
+
+    // ── Forcing ──────────────────────────────────────────────────────────
+    //
+    // `--force` (the whole stack) or `--force=Seed,Api` (a selection), with
+    // a per-declaration `force(...)` decoration winning over both. An entry
+    // that names nothing is a typo — fail loudly rather than silently
+    // forcing nothing.
+    const forceSelection = options.force;
+    {
+      const targets = [
+        ...resources.map((r) => ({ fqn: r.FQN, logicalId: r.LogicalId })),
+        ...actions.map((a) => ({ fqn: a.FQN, logicalId: a.LogicalId })),
+      ];
+      const unknown = unmatchedForceTargets(forceSelection, targets);
+      if (unknown.length > 0) {
+        yield* Effect.die(
+          unknownForceTarget(
+            unknown,
+            [...new Set(targets.map((t) => t.logicalId))].sort(),
+          ),
+        );
+      }
+    }
+
+    /**
+     * Is this node forced on this run? `Force` is the declaration-level
+     * policy captured at registration (`.pipe(force(true))` /
+     * `.pipe(force(false))`); it wins over the run-level selection.
+     */
+    const isForced = (node: {
+      FQN: string;
+      LogicalId: string;
+      Force?: boolean | undefined;
+    }): boolean =>
+      resolveForced(node.Force, forceSelection, {
+        fqn: node.FQN,
+        logicalId: node.LogicalId,
+      });
 
     // The run-level default provider mode (`alchemy dev` → "local",
     // `alchemy deploy` → "live"). A resource-scoped `remote()` (captured on
@@ -702,7 +753,7 @@ export const make = <A>(
               // re-reconciled. Expose only the stable attributes and let
               // apply re-evaluate the rest against the forced reconcile's
               // fresh output.
-              if (options.force) {
+              if (isForced(resource)) {
                 return withStables(oldState?.attr);
               }
               if (
@@ -1407,7 +1458,7 @@ export const make = <A>(
                       } as UpdateDiff | NoopDiff),
                   ),
                   Effect.map((diff) =>
-                    options.force && diff.action === "noop"
+                    isForced(resource) && diff.action === "noop"
                       ? ({
                           action: "update",
                         } satisfies UpdateDiff)
@@ -1633,7 +1684,7 @@ export const make = <A>(
             const prior = oldState as ActionState | undefined;
             const sameInput =
               prior?.status === "ran" && prior.inputHash === inputHash;
-            if (sameInput && !options.force) {
+            if (sameInput && !isForced(action)) {
               return [
                 fqn,
                 {
@@ -1654,7 +1705,7 @@ export const make = <A>(
                 input: action.Input,
                 state: prior,
                 downstream,
-                forced: !!options.force,
+                forced: isForced(action),
               } satisfies ActionRun,
             ] as const;
           }),
@@ -1760,6 +1811,7 @@ export const make = <A>(
                   Type: persisted.actionType,
                   Input: persisted.input,
                   Captures: {},
+                  Force: undefined,
                   Run: () => undefined as any,
                   Output: undefined as any,
                 } satisfies ActionLike,
@@ -1846,6 +1898,7 @@ export const make = <A>(
                     Provider: Provider(resourceType),
                     RemovalPolicy: oldState.removalPolicy,
                     Adopt: undefined,
+                    Force: undefined,
                     RequiresImplementation: undefined,
                     Mode: oldState.providerMode,
                     FormerFqns: undefined,
@@ -1900,6 +1953,9 @@ export const make = <A>(
         "alchemy.stage": stack.stage,
         "alchemy.resources.count": Object.keys(stack.resources).length,
         "alchemy.force": !!options.force,
+        "alchemy.force.selection": Array.isArray(options.force)
+          ? options.force.join(",")
+          : undefined,
       },
     }),
   );

--- a/packages/alchemy/src/Resource.ts
+++ b/packages/alchemy/src/Resource.ts
@@ -5,6 +5,7 @@ import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import type { Pipeable } from "effect/Pipeable";
 import { AdoptPolicy } from "./AdoptPolicy.ts";
+import { ForcePolicy } from "./ForcePolicy.ts";
 import { toFqn } from "./FQN.ts";
 import type { Input, InputProps, PropsInput } from "./Input.ts";
 import { CurrentNamespace, type NamespaceNode } from "./Namespace.ts";
@@ -135,6 +136,14 @@ export interface ResourceLike<
    * resource-scoped override — the planner falls back to the stack/CLI default.
    */
   Adopt: boolean | undefined;
+  /**
+   * Per-resource force policy captured from the ambient {@link ForcePolicy}
+   * at registration time (e.g. via `.pipe(force(true))`). `true` re-runs
+   * `reconcile` even when nothing changed; `false` pins the resource as
+   * never-forced, overriding the run-level `--force`. `undefined` means no
+   * resource-scoped override — the planner falls back to the run selection.
+   */
+  Force: boolean | undefined;
   /**
    * Per-resource provider mode captured from the ambient
    * {@link ProviderModePolicy} at registration time. `"live"` when the
@@ -466,6 +475,9 @@ export function Resource<R extends ResourceLike>(
           Effect.map(Option.getOrElse(() => defaultRemovalPolicy)),
         ),
         Adopt: yield* Effect.serviceOption(AdoptPolicy).pipe(
+          Effect.map(Option.getOrUndefined),
+        ),
+        Force: yield* Effect.serviceOption(ForcePolicy).pipe(
           Effect.map(Option.getOrUndefined),
         ),
         Mode: ambientMode,

--- a/packages/alchemy/src/Sync.ts
+++ b/packages/alchemy/src/Sync.ts
@@ -474,6 +474,7 @@ export const plan = (stack: {
           Provider: Provider(persisted.resourceType),
           RemovalPolicy: persisted.removalPolicy,
           Adopt: undefined,
+          Force: undefined,
           RequiresImplementation: undefined,
           FormerFqns: undefined,
           Mode: persisted.providerMode,

--- a/packages/alchemy/src/index.ts
+++ b/packages/alchemy/src/index.ts
@@ -15,6 +15,8 @@ export {
 } from "./Binding.ts";
 export * from "./Destroy.ts";
 export * from "./Diff.ts";
+export { force } from "./ForcePolicy.ts";
+export * as ForcePolicy from "./ForcePolicy.ts";
 export * from "./Input.ts";
 export * from "./InstanceId.ts";
 export * from "./KeyPair.ts";

--- a/packages/alchemy/test/Cli/forceFlag.test.ts
+++ b/packages/alchemy/test/Cli/forceFlag.test.ts
@@ -1,0 +1,155 @@
+/**
+ * The `--force` flag's parser contract.
+ *
+ * `--force` is a switch that ALSO accepts an inline selection, which Effect's
+ * CLI has no first-class support for: `_shared.ts` builds it from a string
+ * primitive wearing the `Boolean` tag the parser dispatches on. That's an
+ * internal contract of `effect/unstable/cli`, so these tests pin every shape
+ * the flag has to keep supporting — an effect upgrade that changes the
+ * dispatch fails here instead of silently turning `alchemy deploy --force
+ * alchemy.run.ts` into "unknown file".
+ */
+import { force, parseForceValue } from "@/Cli/commands/_shared";
+import { ExecStackOptions } from "@/Cli/commands/deploy";
+import { PlatformServices } from "@/Util/PlatformServices";
+import { describe, expect, it, test } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import * as Argument from "effect/unstable/cli/Argument";
+import * as Command from "effect/unstable/cli/Command";
+import * as Schema from "effect/Schema";
+
+const parse = (
+  argv: ReadonlyArray<string>,
+): Effect.Effect<{ force: unknown; main: string }> =>
+  Effect.gen(function* () {
+    let parsed: { force: unknown; main: string } | undefined;
+    const command = Command.make(
+      "deploy",
+      {
+        force,
+        main: Argument.string("main").pipe(
+          Argument.withDefault("alchemy.run.ts"),
+        ),
+      },
+      (args) => Effect.sync(() => void (parsed = args as any)),
+    );
+    yield* Command.runWith(command, {
+      version: "test",
+      renderErrors: false,
+    })(argv);
+    return parsed!;
+  }).pipe(Effect.provide(PlatformServices), Effect.scoped) as Effect.Effect<{
+    force: unknown;
+    main: string;
+  }>;
+
+describe("--force parsing", () => {
+  it.effect("absent -> false", () =>
+    Effect.gen(function* () {
+      expect((yield* parse([])).force).toBe(false);
+    }),
+  );
+
+  it.effect("bare --force -> true (the whole stack)", () =>
+    Effect.gen(function* () {
+      expect((yield* parse(["--force"])).force).toBe(true);
+    }),
+  );
+
+  it.effect("--force=A,B -> the selection", () =>
+    Effect.gen(function* () {
+      expect((yield* parse(["--force=Seed,Api"])).force).toEqual([
+        "Seed",
+        "Api",
+      ]);
+    }),
+  );
+
+  it.effect("--force=A -> a one-entry selection, FQNs included", () =>
+    Effect.gen(function* () {
+      expect((yield* parse(["--force=Backend/Seed"])).force).toEqual([
+        "Backend/Seed",
+      ]);
+    }),
+  );
+
+  it.effect("bare --force never swallows the positional main", () =>
+    Effect.gen(function* () {
+      const args = yield* parse(["--force", "infra/app.ts"]);
+      expect(args.force).toBe(true);
+      expect(args.main).toBe("infra/app.ts");
+    }),
+  );
+
+  it.effect(
+    "the selection form composes with the positional main, either order",
+    () =>
+      Effect.gen(function* () {
+        expect(yield* parse(["--force=Seed", "infra/app.ts"])).toMatchObject({
+          force: ["Seed"],
+          main: "infra/app.ts",
+        });
+        expect(yield* parse(["infra/app.ts", "--force=Seed"])).toMatchObject({
+          force: ["Seed"],
+          main: "infra/app.ts",
+        });
+      }),
+  );
+
+  it.effect("--no-force and --force=false -> false", () =>
+    Effect.gen(function* () {
+      expect((yield* parse(["--no-force"])).force).toBe(false);
+      expect((yield* parse(["--force=false"])).force).toBe(false);
+      expect((yield* parse(["--force=true"])).force).toBe(true);
+    }),
+  );
+});
+
+describe("parseForceValue", () => {
+  test("boolean literals", () => {
+    expect(parseForceValue("true")).toBe(true);
+    expect(parseForceValue("yes")).toBe(true);
+    expect(parseForceValue("false")).toBe(false);
+    expect(parseForceValue("off")).toBe(false);
+  });
+
+  test("selections are trimmed and emptied entries dropped", () => {
+    expect(parseForceValue("Seed, Api ,")).toEqual(["Seed", "Api"]);
+    expect(parseForceValue(" , ")).toBe(false);
+  });
+});
+
+describe("ExecStackOptions", () => {
+  it.effect(
+    "a selection survives the JSON round-trip into the dev child process",
+    () =>
+      Effect.gen(function* () {
+        // `alchemy dev` re-execs itself with the options encoded into
+        // ALCHEMY_EXEC_OPTIONS, so the selection has to survive
+        // encode -> JSON -> decode intact.
+        const encoded = yield* Schema.encodeEffect(ExecStackOptions)({
+          main: "alchemy.run.ts",
+          stage: "dev",
+          force: ["Seed", "Backend/Api"],
+          dev: true,
+        } as any);
+        const decoded = Schema.decodeSync(ExecStackOptions)(
+          JSON.parse(JSON.stringify(encoded)),
+        );
+        expect(decoded.force).toEqual(["Seed", "Backend/Api"]);
+
+        const bool = Schema.decodeSync(ExecStackOptions)(
+          JSON.parse(
+            JSON.stringify(
+              yield* Schema.encodeEffect(ExecStackOptions)({
+                main: "alchemy.run.ts",
+                stage: "dev",
+                force: true,
+              } as any),
+            ),
+          ),
+        );
+        expect(bool.force).toBe(true);
+      }),
+  );
+});

--- a/packages/alchemy/test/force-selection.test.ts
+++ b/packages/alchemy/test/force-selection.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Forcing a subset of the stack.
+ *
+ * Two independent selectors, resolved in `Plan.make`:
+ *
+ *   - the RUN selection (`--force`, `--force=Seed,Api`) — `MakePlanOptions.force`
+ *   - the DECLARATION policy (`.pipe(force(...))`) — captured on the
+ *     resource/action at registration and authoritative over the run selection,
+ *     so `force(false)` is a real opt-out of a blanket `--force`.
+ *
+ * Forcing only ever upgrades a `noop` to an `update` (resources) or a `run`
+ * (actions); it never changes a create/replace/delete decision.
+ */
+import { Action } from "@/Action";
+import { apply } from "@/Apply";
+import { provideFreshArtifactStore } from "@/Artifacts";
+import { force } from "@/ForcePolicy";
+import * as Namespace from "@/Namespace";
+import * as Plan from "@/Plan";
+import * as Stack from "@/Stack";
+import { Stage } from "@/Stage";
+import { InMemoryService, State } from "@/State";
+import * as Test from "@/Test/Alchemy";
+import { describe, expect } from "alchemy-test";
+import * as Cause from "effect/Cause";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Layer from "effect/Layer";
+import { TestLayers, TestResource } from "./test.resources.ts";
+
+const { test } = Test.make({
+  providers: TestLayers(),
+  state: Layer.effect(
+    State,
+    Effect.sync(() => InMemoryService({})),
+  ),
+});
+
+const STAGE = "test";
+
+const makeHarness = (name: string) => {
+  const store: Record<string, Record<string, Record<string, any>>> = {};
+  const stateLayer = Layer.effect(
+    State,
+    Effect.sync(() => InMemoryService(store)),
+  );
+  const compile = (effect: Effect.Effect<any, any, any>) =>
+    (effect as Effect.Effect<any, any, never>).pipe(
+      Stack.make({
+        name,
+        providers: TestLayers() as Layer.Layer<any, never, any>,
+        state: stateLayer,
+      }),
+    );
+  const run = (
+    effect: Effect.Effect<any, any, any>,
+    options: Plan.MakePlanOptions | undefined,
+    then: (plan: any) => Effect.Effect<any, any, any>,
+  ) =>
+    compile(effect).pipe(
+      Effect.flatMap((compiled: any) =>
+        Plan.make(compiled, options).pipe(
+          Effect.flatMap(then),
+          Effect.provide(compiled.services),
+        ),
+      ),
+      Effect.provide(Layer.succeed(Stage, STAGE)),
+      provideFreshArtifactStore,
+    ) as unknown as Effect.Effect<any, any, never>;
+
+  return {
+    deploy: (
+      effect: Effect.Effect<any, any, any>,
+      options?: Plan.MakePlanOptions,
+    ) => run(effect, options, apply),
+    plan: (
+      effect: Effect.Effect<any, any, any>,
+      options?: Plan.MakePlanOptions,
+    ) => run(effect, options, Effect.succeed),
+  };
+};
+
+describe("run-level force selection", () => {
+  test(
+    "--force=<id> forces only the named resource",
+    Effect.gen(function* () {
+      const { deploy, plan } = makeHarness("force-one");
+      const program = Effect.gen(function* () {
+        yield* TestResource("Api", { string: "api" });
+        yield* TestResource("Seed", { string: "seed" });
+      });
+
+      yield* deploy(program);
+
+      const unforced: any = yield* plan(program);
+      expect(unforced.resources.Api.action).toBe("noop");
+      expect(unforced.resources.Seed.action).toBe("noop");
+
+      const forced: any = yield* plan(program, { force: ["Seed"] });
+      expect(forced.resources.Seed.action).toBe("update");
+      expect(forced.resources.Api.action).toBe("noop");
+    }),
+  );
+
+  test(
+    "a selection entry matches either the logical ID or the FQN",
+    Effect.gen(function* () {
+      const { deploy, plan } = makeHarness("force-fqn");
+      const program = Namespace.push(
+        "Backend",
+        Effect.gen(function* () {
+          yield* TestResource("Api", { string: "api" });
+          yield* TestResource("Seed", { string: "seed" });
+        }),
+      );
+
+      yield* deploy(program);
+
+      const byFqn: any = yield* plan(program, { force: ["Backend/Seed"] });
+      expect(byFqn.resources["Backend/Seed"].action).toBe("update");
+      expect(byFqn.resources["Backend/Api"].action).toBe("noop");
+
+      const byLogicalId: any = yield* plan(program, { force: ["Seed"] });
+      expect(byLogicalId.resources["Backend/Seed"].action).toBe("update");
+      expect(byLogicalId.resources["Backend/Api"].action).toBe("noop");
+    }),
+  );
+
+  test(
+    "--force=<unknown> dies instead of silently forcing nothing",
+    Effect.gen(function* () {
+      const { deploy, plan } = makeHarness("force-typo");
+      const program = Effect.gen(function* () {
+        yield* TestResource("Api", { string: "api" });
+      });
+      yield* deploy(program);
+
+      const exit = yield* Effect.exit(plan(program, { force: ["Ap"] }));
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isFailure(exit)) {
+        const err = Cause.squash(exit.cause) as any;
+        expect(err._tag).toBe("UnknownForceTarget");
+        expect(err.targets).toEqual(["Ap"]);
+        expect(err.available).toEqual(["Api"]);
+        expect(err.message).toContain("Available: Api");
+      }
+    }),
+  );
+
+  test(
+    "an empty selection forces nothing",
+    Effect.gen(function* () {
+      const { deploy, plan } = makeHarness("force-empty");
+      const program = Effect.gen(function* () {
+        yield* TestResource("Api", { string: "api" });
+      });
+      yield* deploy(program);
+
+      const p: any = yield* plan(program, { force: [] });
+      expect(p.resources.Api.action).toBe("noop");
+    }),
+  );
+
+  test(
+    "--force=<id> re-runs only the named action",
+    Effect.gen(function* () {
+      const { deploy, plan } = makeHarness("force-action-selection");
+      const Seed = Action("Seed", (_: { table: string }) =>
+        Effect.succeed({ rows: 1 }),
+      );
+      const Report = Action("Report", (_: { table: string }) =>
+        Effect.succeed({ rows: 2 }),
+      );
+      const program = Effect.gen(function* () {
+        yield* Seed({ table: "users" });
+        yield* Report({ table: "users" });
+      });
+
+      yield* deploy(program);
+
+      const unforced: any = yield* plan(program);
+      expect(unforced.actions.Seed.action).toBe("noop");
+
+      const forced: any = yield* plan(program, { force: ["Seed"] });
+      expect(forced.actions.Seed.action).toBe("run");
+      expect(forced.actions.Seed.forced).toBe(true);
+      expect(forced.actions.Report.action).toBe("noop");
+    }),
+  );
+});
+
+describe("force() decoration", () => {
+  test(
+    "force(true) on a declaration forces it with no CLI flag at all",
+    Effect.gen(function* () {
+      const { deploy, plan } = makeHarness("force-decoration");
+      const program = Effect.gen(function* () {
+        yield* TestResource("Api", { string: "api" });
+        yield* TestResource("Seed", { string: "seed" }).pipe(force(true));
+      });
+
+      yield* deploy(program);
+
+      const p: any = yield* plan(program);
+      expect(p.resources.Seed.action).toBe("update");
+      expect(p.resources.Api.action).toBe("noop");
+    }),
+  );
+
+  test(
+    "force(false) opts out of a blanket --force",
+    Effect.gen(function* () {
+      const { deploy, plan } = makeHarness("force-optout");
+      const program = Effect.gen(function* () {
+        yield* TestResource("Api", { string: "api" });
+        yield* TestResource("Pinned", { string: "pinned" }).pipe(force(false));
+      });
+
+      yield* deploy(program);
+
+      const p: any = yield* plan(program, { force: true });
+      expect(p.resources.Api.action).toBe("update");
+      expect(p.resources.Pinned.action).toBe("noop");
+    }),
+  );
+
+  test(
+    "force() decorates a whole scope",
+    Effect.gen(function* () {
+      const { deploy, plan } = makeHarness("force-scope");
+      const program = Effect.gen(function* () {
+        yield* Effect.gen(function* () {
+          yield* TestResource("Seed", { string: "seed" });
+          yield* TestResource("Migrate", { string: "migrate" });
+        }).pipe(force(true));
+        yield* TestResource("Api", { string: "api" });
+      });
+
+      yield* deploy(program);
+
+      const p: any = yield* plan(program);
+      expect(p.resources.Seed.action).toBe("update");
+      expect(p.resources.Migrate.action).toBe("update");
+      expect(p.resources.Api.action).toBe("noop");
+    }),
+  );
+
+  test(
+    "force(true) on an action re-runs its body against an unchanged input",
+    Effect.gen(function* () {
+      const { deploy, plan } = makeHarness("force-action-decoration");
+      let runs = 0;
+      const Seed = Action("Seed", (_: { table: string }) =>
+        Effect.sync(() => ({ rows: ++runs })),
+      );
+      const program = Effect.gen(function* () {
+        yield* Seed({ table: "users" }).pipe(force(true));
+      });
+
+      yield* deploy(program);
+      expect(runs).toBe(1);
+
+      const p: any = yield* plan(program);
+      expect(p.actions.Seed.action).toBe("run");
+      expect(p.actions.Seed.forced).toBe(true);
+
+      yield* deploy(program);
+      expect(runs).toBe(2);
+    }),
+  );
+
+  test(
+    "an undecorated action still noops on an unchanged input (control)",
+    Effect.gen(function* () {
+      const { deploy } = makeHarness("force-action-control");
+      let runs = 0;
+      const Seed = Action("Seed", (_: { table: string }) =>
+        Effect.sync(() => ({ rows: ++runs })),
+      );
+      const program = Effect.gen(function* () {
+        yield* Seed({ table: "users" });
+      });
+
+      yield* deploy(program);
+      yield* deploy(program);
+      expect(runs).toBe(1);
+    }),
+  );
+});

--- a/website/src/content/docs/cli/deploy.mdx
+++ b/website/src/content/docs/cli/deploy.mdx
@@ -51,12 +51,27 @@ When the plan contains no changes, the approval prompt is skipped automatically.
 | `--stage <name>`    | Stage to deploy to (defaults to `dev_$USER`)                                                                               |
 | `--yes`             | Skip the approval prompt                                                                                                   |
 | `--dry-run`         | Show the plan without applying (same as `alchemy plan`)                                                                    |
-| `--force`           | Force updates for resources that would otherwise no-op                                                                     |
+| `--force[=<ids>]`   | Re-run resources/actions that would otherwise no-op. `--force` for the whole stack, `--force=Seed,Api` for a selection      |
 | `--adopt`           | Adopt pre-existing cloud resources that conflict with this stack instead of failing. Useful for re-importing into a fresh state store. |
 | `--profile <name>`  | Auth profile to use (defaults to `default` or `$ALCHEMY_PROFILE`)                                                          |
 | `--env-file <path>` | Load environment variables from a file                                                                                     |
 
 How `--adopt` decides what to take over is covered in [Adopting Resources](/cli/adopting-resources).
+
+`--force` re-runs `reconcile` (and [Action](/infrastructure-as-code/action)
+bodies) that the plan would otherwise report as no-ops. Pass an inline,
+comma-separated value to force just part of the stack — each entry is a
+logical ID (`Seed`) or a fully-qualified name (`Backend/Seed`), and an
+entry matching nothing fails the plan:
+
+```sh
+alchemy deploy --force=Seed
+```
+
+Note the `=`: `--force Seed` would be read as `--force` plus a stack
+file named `Seed`. A declaration piped through
+[`force()`](/infrastructure-as-code/resource-lifecycle#forcing-a-re-run)
+overrides the flag either way.
 
 `--dry-run` runs the exact same code path as [`alchemy plan`](/cli/plan) — see that page for the plan output format.
 

--- a/website/src/content/docs/cli/dev.mdx
+++ b/website/src/content/docs/cli/dev.mdx
@@ -22,7 +22,7 @@ A failed apply keeps dev alive so healthy resources keep serving — fix the err
 | Option              | Description                                                        |
 | ------------------- | ------------------------------------------------------------------ |
 | `--stage <name>`    | Stage to use for dev (defaults to `dev_$USER`)                     |
-| `--force`           | Force updates for resources that would otherwise no-op             |
+| `--force[=<ids>]`   | Re-run resources/actions that would otherwise no-op (`--force=Seed`) |
 | `--profile <name>`  | Auth profile to use (defaults to `default` or `$ALCHEMY_PROFILE`)  |
 | `--env-file <path>` | Load environment variables from a file                             |
 | `[file]`            | Stack file to run (defaults to `alchemy.run.ts`)                   |
@@ -35,7 +35,14 @@ alchemy dev
 
 # Use a custom stage
 alchemy dev --stage dev
+
+# Re-run one resource or action on demand (e.g. re-seed a dev database)
+alchemy dev --force=Seed
 ```
+
+`--force=<ids>` takes logical IDs or fully-qualified names, so a
+`dev:seed` script can re-run just that node without redeploying the
+stack. See [Forcing a re-run](/infrastructure-as-code/resource-lifecycle#forcing-a-re-run).
 
 ## Where next
 

--- a/website/src/content/docs/cli/plan.mdx
+++ b/website/src/content/docs/cli/plan.mdx
@@ -26,6 +26,7 @@ made.
 | ------------------- | ----------------------------------------------------------------- |
 | `[file]`            | Stack file to plan (defaults to `alchemy.run.ts`)                 |
 | `--stage <name>`    | Stage to plan against (defaults to `dev_$USER`)                   |
+| `--force[=<ids>]`   | Preview a forced run — see [deploy](/cli/deploy#flags)            |
 | `--profile <name>`  | Auth profile to use (defaults to `default` or `$ALCHEMY_PROFILE`) |
 | `--env-file <path>` | Load environment variables from a file                            |
 

--- a/website/src/content/docs/infrastructure-as-code/action.mdx
+++ b/website/src/content/docs/infrastructure-as-code/action.mdx
@@ -166,7 +166,7 @@ An Action has only two terminal states:
 
 | Action | Symbol | When |
 | --- | --- | --- |
-| **run**  | `λ` | First time, or `inputHash` differs from the last persisted run, or `--force` is set |
+| **run**  | `λ` | First time, `inputHash` differs from the last persisted run, or the Action is [forced](#forcing-a-re-run) |
 | **skip** | `·` | Persisted `inputHash` matches the newly resolved input |
 
 There is no `replace` and no `delete`. When an Action is removed from the
@@ -182,10 +182,48 @@ differs means "run".
 ### Forcing a re-run
 
 ```sh
-alchemy deploy --force
+alchemy deploy --force        # every skip becomes a run
+alchemy deploy --force=Seed   # just this Action
 ```
 
-`--force` flips every `skip` to `run` at plan time, including actions.
+`--force` flips `skip` to `run` at plan time. With no value it forces
+the whole stack (resources included); with a comma-separated value it
+forces only the named nodes, each a logical ID (`Seed`) or a
+fully-qualified name (`Backend/Seed`). Naming something the stack does
+not declare fails the plan instead of quietly forcing nothing.
+
+The same works in dev, which is usually where an on-demand re-run is
+wanted:
+
+```json title="package.json"
+{
+  "scripts": {
+    "dev": "alchemy dev",
+    "dev:seed": "alchemy dev --force=Seed"
+  }
+}
+```
+
+An Action can also decide for itself, with the `force()` decoration:
+
+```typescript
+import { force } from "alchemy";
+import * as Config from "effect/Config";
+
+const seed = yield* Seed({ url: database.url }).pipe(
+  force(yield* Config.boolean("SEED").pipe(Config.withDefault(false))),
+);
+```
+
+```sh
+alchemy dev            # seeds once, then skips
+SEED=1 alchemy dev     # re-seeds
+```
+
+The decoration wins over the CLI flag, so `force(false)` pins an Action
+as never-forced even under a blanket `--force`. See
+[Forcing a re-run](/infrastructure-as-code/resource-lifecycle#forcing-a-re-run)
+for how the same decoration applies to Resources.
 
 ### Dependencies
 

--- a/website/src/content/docs/infrastructure-as-code/resource-lifecycle.mdx
+++ b/website/src/content/docs/infrastructure-as-code/resource-lifecycle.mdx
@@ -226,6 +226,50 @@ the `Unowned(attrs)` brand. The engine routes:
 See [Provider › read](/infrastructure-as-code/provider#read) for the implementation
 contract and [Adopting Resources](/cli/adopting-resources) for the CLI flag.
 
+## Forcing a re-run
+
+A resource whose props and bindings are unchanged plans as a
+**no-op**. Forcing upgrades that no-op to an `update`, so
+`reconcile` runs again and re-converges against real cloud state.
+Nothing else about the plan changes — a create stays a create, a
+replacement stays a replacement.
+
+Force a whole run from the CLI, or name what to force:
+
+```sh
+alchemy deploy --force            # every resource and action
+alchemy deploy --force=Seed       # just Seed
+alchemy deploy --force=Seed,Api   # a comma-separated selection
+```
+
+Each entry is a logical ID (`Seed`) or a fully-qualified name
+(`Backend/Seed`). An entry matching nothing fails the plan rather than
+silently forcing nothing.
+
+Force a single declaration instead by piping it through `force()`,
+which — like `retain()` and `adopt()` — applies to everything declared
+inside the piped effect:
+
+```typescript
+import { force } from "alchemy";
+
+Effect.gen(function* () {
+  // re-reconciled on every deploy
+  const bucket = yield* R2.Bucket("Uploads").pipe(force(true));
+
+  // ...and only when SEED is set
+  const seed = yield* SeedDatabase({ url: db.url }).pipe(
+    force(yield* Config.boolean("SEED").pipe(Config.withDefault(false))),
+  );
+
+  // never forced, not even by `--force`
+  const api = yield* Cloudflare.Worker("Api", { ... }).pipe(force(false));
+});
+```
+
+The declaration wins over the CLI, which makes `force(false)` a real
+opt-out of a blanket `--force`.
+
 ## Errors
 
 - **Retryable errors** (eventual consistency, dependency races) are


### PR DESCRIPTION
`--force` was all-or-nothing, so re-running one Action — a dev database seed, say — meant forcing the whole stack or duct-taping a changing input onto the declaration.

Two selectors, resolved per node in `Plan.make`.

### Run-level: `--force=<ids>`

```sh
alchemy deploy --force            # everything, unchanged
alchemy deploy --force=Seed,Api   # just these
alchemy dev --force=Backend/Seed  # logical ID or FQN
```

An entry that names nothing fails the plan (listing what's available) instead of silently forcing nothing. Available on `deploy`, `dev` and `plan`.

### Declaration-level: `force(...)`

Captured at registration like `adopt()` / `retain()` / `remote()`, so it decorates one node or a whole scope:

```ts
const seed = yield* Seed({ url: db.url }).pipe(
  force(yield* Config.boolean("SEED").pipe(Config.withDefault(false))),
);

const api = yield* Worker("Api", { ... }).pipe(force(false));
```

The declaration wins over the run selection, which makes `force(false)` a real opt-out of a blanket `--force`.

Forcing still only upgrades `noop` to `update` (resources) or `run` (actions) — creates, replacements and deletes are untouched.

### Notes for review

- **Back-compat on the flag.** Bare `--force` behaves exactly as before, including `alchemy deploy --force main.ts`. Effect's CLI has no optional-value flag — a boolean flag never takes a value, a string flag swallows the next positional — so `_shared.ts` builds `--force` from a string primitive wearing the `Boolean` tag the parser dispatches on. That's an internal contract of `effect/unstable/cli`, so `test/Cli/forceFlag.test.ts` pins every shape (bare, `=A,B`, `--no-force`, positional-not-swallowed, JSON round-trip into the dev child process); an effect upgrade that changes the dispatch fails there instead of quietly. Consequence: the selector must be `=`-attached — `--force Seed` reads `Seed` as the stack file.
- **Behavior change beyond the new flag.** Forcing is now resolved per node rather than as one global boolean, so in a forced run only the forced upstreams expose just their stable attrs to consumers (previously every resource did).
- Verified end-to-end through the real CLI against a local stack: `plan --force=Seed` reports `1 to update, 1 to noop`.

`test/force-selection.test.ts` (10 tests) covers selection, FQN matching, the typo failure, the decoration, the opt-out, scope decoration and actions. Existing plan/apply/action/force-stale-attrs suites (382 tests), `tsc -b`, and the website build's link + diff checks all pass.
