### PR TITLE
fix(cloudflare/workers): converge nested yielded-resource env plans

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -989,13 +989,8 @@ type MetadataHashValue =
  * values contribute by value, not by reference identity, so two
  * independently-constructed secrets with the same contents hash identically.
  *
- * Effects are dropped, never executed: resource-typed `env` entries (Worker
- * effect-classes, R2 buckets, Provider/Context tags, ...) are all Effects
- * whose evaluation requires plan-phase context that is not available inside
- * lifecycle operations (running one here fails with `Service not found:
- * Cloudflare.Worker`). Their deploy-time identity is already captured by the
- * resolved `bindings` data hashed alongside `env`, so skipping them loses no
- * change-detection.
+ * Effects are dropped, never executed: evaluating one here may require
+ * plan-phase context that is not available inside lifecycle operations.
  */
 const resolveMetadataHashValue = (
   value: unknown,
@@ -1053,8 +1048,8 @@ const resolveMetadataHashValue = (
 /**
  * The deploy-time metadata surface of a Worker whose changes must trigger an
  * update but that never touch the bundle/vite/asset-content hashes:
- * compatibility, env literals, bindings, asset routing config, cache,
- * limits, logpush, observability, placement, subdomain, and tags. See #745.
+ * compatibility, env/bindings, asset routing config, cache, limits, logpush,
+ * observability, placement, subdomain, and tags. See #745.
  */
 interface WorkerMetadataHashInput {
   readonly props: WorkerProps;
@@ -1105,7 +1100,12 @@ const resolveWorkerMetadataHash = ({
     selfUrl,
     stack: { name: stack.name, stage: stack.stage },
     compatibility: getCompatibility(props),
-    env: props.env,
+    // Every `env` entry is lowered into binding data by
+    // `bindWorkerAsyncBindings`, including literals and VITE_ values. Hash only
+    // that canonical wire representation. Resource-backed env values can be
+    // materialized as different attribute projections between reconcile and a
+    // later plan; hashing props.env as well would turn those irrelevant shape
+    // differences into perpetual updates.
     bindings: bindings.map((binding) => ({
       sid: binding.sid,
       data: binding.data,
@@ -4472,42 +4472,39 @@ export const LiveWorkerProvider = () =>
               stables: stables.length > 0 ? stables : undefined,
             };
           }
-          // Machine-local source locations (`main`, `assets.directory`,
-          // `vite.rootDir`) name WHERE the source lives; their deploy-relevant
-          // effect is fully captured by the content hashes `hasChanged` just
-          // compared (bundle, asset content, vite input — all deliberately
-          // path-independent). Left alone, the engine's raw-props fallback
-          // would still flag a relocated checkout (CI runner ↔ laptop, temp
-          // build dirs) as changed forever. When the ONLY residual raw-prop
-          // difference is such a path, suppress the fallback with an explicit
-          // noop; any other residual difference still falls through to the
-          // engine's conservative comparison, so props outside the hashed
-          // metadata surface keep deploying (#745). Guarded on resolved
-          // bindings — without them the metadata hash was skipped above and
-          // the raw-props fallback is the only net for metadata edits.
+          // Machine-local source paths and resource-backed `env` values have
+          // already been compared by their content hashes and canonical
+          // binding data. Ignore those representations in the raw fallback so
+          // checkout paths and resource attribute projections do not force
+          // perpetual updates (#745).
           if (Array.isArray(newBindings)) {
-            const normalizeSourcePaths = (props: WorkerProps) => ({
-              ...props,
-              ...(props.main !== undefined ? { main: "<source>" } : undefined),
-              ...(props.assets
-                ? {
-                    assets: {
-                      ...(typeof props.assets === "string"
-                        ? undefined
-                        : props.assets),
-                      directory: "<source>",
-                    },
-                  }
-                : undefined),
-              ...(props.vite
-                ? { vite: { ...props.vite, rootDir: "<source>" } }
-                : undefined),
-            });
+            const normalizeComparedProps = (props: WorkerProps) => {
+              const { env: _env, ...rest } = props;
+              return {
+                ...rest,
+                ...(props.main !== undefined
+                  ? { main: "<source>" }
+                  : undefined),
+                ...(props.assets
+                  ? {
+                      assets: {
+                        ...(typeof props.assets === "string"
+                          ? undefined
+                          : props.assets),
+                        directory: "<source>",
+                      },
+                    }
+                  : undefined),
+                ...(props.vite
+                  ? { vite: { ...props.vite, rootDir: "<source>" } }
+                  : undefined),
+              };
+            };
             if (
               olds !== undefined &&
               !havePropsChanged(
-                normalizeSourcePaths(olds),
-                normalizeSourcePaths(news),
+                normalizeComparedProps(olds),
+                normalizeComparedProps(news),
               )
             ) {
               return { action: "noop" };

--- a/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
@@ -1036,6 +1036,98 @@ describe.concurrent("Cloudflare.Worker", () => {
     { timeout: 360_000 },
   );
 
+  // #1272 regression, remaining #874 case: an already-yielded Worker is
+  // plain resource attributes rather than an Effect-valued tag. In a binding
+  // chain, plan and apply may materialize different stable/full projections
+  // of those attributes, but both describe the same service binding and must
+  // converge.
+  // Switching the actual target must still update the caller and land in
+  // Cloudflare.
+  test.provider(
+    "nested yielded worker resources in env converge to noop plans",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+
+        yield* stack.destroy();
+
+        const program = (selected: "A" | "B") =>
+          Effect.gen(function* () {
+            const targetB = yield* Cloudflare.Worker("YieldedEnvTargetB", {
+              main,
+            });
+            const targetA = yield* Cloudflare.Worker("YieldedEnvTargetA", {
+              main,
+              env: { UPSTREAM: targetB },
+            });
+            const caller = yield* Cloudflare.Worker("YieldedEnvCaller", {
+              main,
+              env: { TARGET: selected === "A" ? targetA : targetB },
+            });
+            return { targetA, targetB, caller };
+          });
+
+        const actionOf = (plan: any, logicalId: string) =>
+          (Object.values(plan.resources) as any[]).find(
+            (node: any) => node.resource.LogicalId === logicalId,
+          )?.action;
+
+        const deployedA = yield* stack.deploy(program("A"));
+        const bindingTarget = Effect.fn(function* (callerName: string) {
+          const settings = yield* workers.getScriptScriptAndVersionSetting({
+            accountId,
+            scriptName: callerName,
+          });
+          return settings.bindings?.find(
+            (binding) =>
+              binding.type === "service" && binding.name === "TARGET",
+          );
+        });
+        expect(yield* bindingTarget(deployedA.caller.workerName)).toEqual(
+          expect.objectContaining({
+            type: "service",
+            name: "TARGET",
+            service: deployedA.targetA.workerName,
+          }),
+        );
+
+        const stableA = yield* stack.plan(program("A"));
+        expect(actionOf(stableA, "YieldedEnvTargetA")).toBe("noop");
+        expect(actionOf(stableA, "YieldedEnvTargetB")).toBe("noop");
+        expect(actionOf(stableA, "YieldedEnvCaller")).toBe("noop");
+
+        const switchPlan = yield* stack.plan(program("B"));
+        expect(actionOf(switchPlan, "YieldedEnvTargetA")).toBe("noop");
+        expect(actionOf(switchPlan, "YieldedEnvTargetB")).toBe("noop");
+        expect(actionOf(switchPlan, "YieldedEnvCaller")).toBe("update");
+
+        const deployedB = yield* stack.deploy(program("B"));
+        expect(yield* bindingTarget(deployedB.caller.workerName)).toEqual(
+          expect.objectContaining({
+            type: "service",
+            name: "TARGET",
+            service: deployedB.targetB.workerName,
+          }),
+        );
+
+        const stableB = yield* stack.plan(program("B"));
+        expect(actionOf(stableB, "YieldedEnvTargetA")).toBe("noop");
+        expect(actionOf(stableB, "YieldedEnvTargetB")).toBe("noop");
+        expect(actionOf(stableB, "YieldedEnvCaller")).toBe("noop");
+
+        yield* stack.destroy();
+        yield* Effect.all(
+          [
+            deployedB.caller.workerName,
+            deployedB.targetA.workerName,
+            deployedB.targetB.workerName,
+          ].map((name) => waitForWorkerToBeDeleted(name, accountId)),
+          { concurrency: "unbounded" },
+        );
+      }).pipe(logLevel),
+    { timeout: 360_000 },
+  );
+
   // The full circular case from the #874 report: A and B each bind the
   // OTHER's tag in env. The tags keep the dependency on the binding channel
   // (precreate stubs + converge pass) — a cycle the props channel cannot


### PR DESCRIPTION
Fixes #1272. Follow-up to #874 and #890.

#890 made Effect-valued Worker tags in `env` converge. A nested graph of already-yielded Worker resources can still plan its downstream consumer as `update` forever:

```ts
const upstream = yield* Cloudflare.Worker("Upstream", { main });
const target = yield* Cloudflare.Worker("Target", {
  main,
  env: { UPSTREAM: upstream },
});
yield* Cloudflare.Worker("Caller", {
  main,
  env: { TARGET: target },
});
```

The live service bindings deploy correctly. On an identical subsequent plan, `Upstream` and `Target` are `noop`, while `Caller` is `update`.

Plan and reconcile/state persistence can materialize stable/full projections of the intermediate Worker's attributes. Two comparisons treat that irrelevant shape difference as deployable configuration:

1. the Worker metadata hash includes raw `props.env` as well as canonical resolved binding data;
2. the final raw-props fallback compares `olds.env` and `news.env` again.

The fix uses resolved bindings as the deploy-relevant `env` representation:

- remove raw `props.env` from `resolveWorkerMetadataHash`; every env entry is already lowered by `bindWorkerAsyncBindings`;
- omit `env` from the final props fallback only when `newBindings` is resolved;
- retain comparison of every other prop and the existing source-path normalization.

Actual binding changes remain visible in the canonical metadata hash.

### Regression test

Following the `test.provider` convention requested during #747 review, the regression exercises the public resource lifecycle:

1. deploy target B, target A bound to B, and a caller bound to A;
2. verify Cloudflare received the caller's service binding to A;
3. plan the identical graph and assert all three Workers are `noop`;
4. switch the caller from A to B and assert only the caller plans `update`;
5. deploy and verify the live service binding now targets B;
6. plan again and assert all three Workers converge to `noop`.

Red on unpatched `main`:

```text
AssertionError: expected "update" to be "noop"
```

The failing assertion is the downstream caller's first identical post-deploy plan.

Green with the fix:

```text
Tests: 0 failed | 1 passed
```

### Validation

```text
Focused live regression:      passed (60.1s)
WorkerProvider unit suite:    40 passed
WorkerSource suite:           6 passed
oxfmt / git diff --check:     passed
oxlint:                       no errors (3 pre-existing warnings)
Effect diagnostics:           0 errors
```

A full local `tsc -b` was killed by the 15 GiB/no-swap host. Repository CI should run the complete typecheck.

### Application validation

The original beta.72 provider reports the downstream Worker as `update` on every unchanged plan. With the fix and state representing the post-migration hash:

```text
Plan: 11 to noop
```

No application cloud resources were mutated.

### Migration

Existing Workers with `env` will plan one update because their stored metadata hash includes raw `env`. The update persists the canonical hash; subsequent plans converge. This is the same self-healing migration pattern used when #747 introduced `hash.metadata`.

### Files

- `packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts`
- `packages/alchemy/test/Cloudflare/Workers/Worker.test.ts`
