### PR TITLE
feat(cli): add a --detailed flag to show property changes in "alchemy plan" and "alchemy deploy"

### DIFF
--- a/packages/alchemy/src/Apply.ts
+++ b/packages/alchemy/src/Apply.ts
@@ -24,6 +24,7 @@ import {
   makeScopedArtifacts,
 } from "./Artifacts.ts";
 import {
+  type PlanDisplayOptions,
   type PlanStatusSession,
   type ScopedPlanStatusSession,
   Cli,
@@ -89,6 +90,10 @@ export type AppliedPlan<P extends Plan> = {
     : Simplify<P["resources"][id]["resource"]["attr"]>;
 };
 
+export interface ApplyOptions {
+  planDisplay?: PlanDisplayOptions;
+}
+
 interface ResourceTracker {
   output: any;
   props: any;
@@ -148,6 +153,7 @@ const instrumentLifecycle =
 
 export const apply = <P extends Plan>(
   plan: P,
+  options: ApplyOptions = {},
 ): Effect.Effect<
   Input.Resolve<P["output"]>,
   | Output.InvalidReferenceError
@@ -176,7 +182,7 @@ export const apply = <P extends Plan>(
     }
 
     const cli = yield* Cli;
-    const session = yield* cli.startApplySession(plan);
+    const session = yield* cli.startApplySession(plan, options.planDisplay);
     const state = yield* yield* State;
     const stack = yield* Stack;
     const stage = yield* Stage;

--- a/packages/alchemy/src/Cli/Cli.ts
+++ b/packages/alchemy/src/Cli/Cli.ts
@@ -12,11 +12,22 @@ export interface ScopedPlanStatusSession extends PlanStatusSession {
   note: (note: string) => Effect.Effect<void>;
 }
 
+export interface PlanDisplayOptions {
+  detailed?: boolean;
+}
+
 export interface CLIService {
-  approvePlan: <P extends Plan>(plan: P) => Effect.Effect<boolean>;
-  displayPlan: <P extends Plan>(plan: P) => Effect.Effect<void>;
+  approvePlan: <P extends Plan>(
+    plan: P,
+    options?: PlanDisplayOptions,
+  ) => Effect.Effect<boolean>;
+  displayPlan: <P extends Plan>(
+    plan: P,
+    options?: PlanDisplayOptions,
+  ) => Effect.Effect<void>;
   startApplySession: <P extends Plan>(
     plan: P,
+    options?: PlanDisplayOptions,
   ) => Effect.Effect<PlanStatusSession>;
 }
 

--- a/packages/alchemy/src/Cli/LoggingCli.ts
+++ b/packages/alchemy/src/Cli/LoggingCli.ts
@@ -2,9 +2,20 @@ import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import type { CRUD, Plan } from "../Plan.ts";
-import { Cli } from "./Cli.ts";
+import { Cli, type PlanDisplayOptions } from "./Cli.ts";
 import type { ApplyEvent, ApplyStatus } from "./Event.ts";
 import { formatModeNote } from "./ModeTag.ts";
+import {
+  diffDeclaredProperties,
+  fitCreatedPropertyValue,
+  fitPropertyChangeValues,
+  formatPropertyPath,
+  propertyDiffLayout,
+  toFormattedPropertyChange,
+  type FormattedPropertyChange,
+  type PropertyChange,
+  type PropertyValue,
+} from "./PropertyDiff.ts";
 
 const ESC = "\x1b[";
 const RESET = `${ESC}0m`;
@@ -68,8 +79,16 @@ const modeSuffix = (options: Parameters<typeof formatModeNote>[0]): string => {
   return note ? ` ${dim(`(${note})`)}` : "";
 };
 
-/** Exported for unit tests — pure plan-preview rendering. */
-export const formatPlanLines = (plan: Plan): string[] => {
+export interface PlanRenderOptions extends PlanDisplayOptions {
+  // The terminal width only affects inline versus stacked detail rows.
+  columns?: number;
+}
+
+/** Build the static plan lines used by CI, piped output, and plain terminals. */
+export const formatPlanLines = (
+  plan: Plan,
+  options: PlanRenderOptions = {},
+): string[] => {
   const items = [
     ...Object.values(plan.resources),
     ...Object.values(plan.deletions),
@@ -88,8 +107,14 @@ export const formatPlanLines = (plan: Plan): string[] => {
   const sorted = [...items].sort((a, b) =>
     a.resource.LogicalId.localeCompare(b.resource.LogicalId),
   );
+  // Compact remains the default product output; --detailed opts into props.
+  const detailed = options.detailed ?? false;
   const lines = [`${bold("Plan:")} ${summary}`];
-  for (const item of sorted) {
+  // Blank resource blocks improve scanning only in detailed mode; compact
+  // deliberately keeps its previous dense output byte-for-byte.
+  if (detailed) lines.push("");
+  for (const [index, item] of sorted.entries()) {
+    if (detailed && index > 0) lines.push("");
     const action = actionColor[item.action](item.action);
     const mode = modeSuffix({
       mode: item.mode,
@@ -107,6 +132,15 @@ export const formatPlanLines = (plan: Plan): string[] => {
         ? ` ${dim(`(renamed from ${item.renamedFrom.join(", ")})`)}`
         : "";
     lines.push(`${tag(item.resource.LogicalId)} ${action}${mode}${renamed}`);
+    if (detailed) {
+      // A resource row stays the heading; declared property rows sit below it.
+      lines.push(
+        ...formatDetailedPropertyLines(
+          item,
+          options.columns ?? process.stdout.columns ?? 120,
+        ),
+      );
+    }
     for (const binding of item.bindings) {
       if (binding.action === "noop") continue;
       const bindingAction = actionColor[binding.action](binding.action);
@@ -118,24 +152,153 @@ export const formatPlanLines = (plan: Plan): string[] => {
   return lines;
 };
 
+const formatDetailedPropertyLines = (item: CRUD, columns: number): string[] => {
+  // v1 explains create/update/replace inputs; delete and noop stay compact.
+  if (item.action === "delete" || item.action === "noop") return [];
+
+  // Create compares against no prior declaration. Updates and replacements
+  // compare persisted declared props with the newly desired props.
+  const changes = diffDeclaredProperties(
+    item.action === "create" ? {} : item.state.props,
+    item.props,
+  );
+  // Actions can originate outside props, so say so instead of inventing rows.
+  if (changes.length === 0) {
+    return [
+      `  ${dim(item.action === "create" ? "no declared properties" : "no declared property changes")}`,
+    ];
+  }
+  // Creates only have desired values, so `+ path value` is clearer than an
+  // artificial `(not set) -> value` pair on every line.
+  if (item.action === "create") {
+    return formatCreatedPropertyLines(changes, columns);
+  }
+  // Wide terminals render `old -> new`; narrow terminals stack both values.
+  const layout = propertyDiffLayout(
+    changes.map(toFormattedPropertyChange),
+    columns,
+  );
+  return formatPropertyChanges(changes, layout);
+};
+
+const formatCreatedPropertyLines = (
+  changes: PropertyChange[],
+  columns: number,
+): string[] => {
+  // Every declared create leaf is a green addition beneath its resource.
+  return changes.map(toFormattedPropertyChange).map((row) => {
+    const value = fitCreatedPropertyValue(row, columns);
+    return `  ${green("+")} ${bold(formatPropertyPath(row.path))}  ${colorPropertyValue(value, row.afterValue, green)}`;
+  });
+};
+
+const formatPropertyChanges = (
+  changes: PropertyChange[],
+  layout: ReturnType<typeof propertyDiffLayout>,
+): string[] => {
+  // Both terminal layouts consume the same semantic PropertyChange rows.
+  const rows = changes.map(toFormattedPropertyChange);
+  return layout
+    ? formatInlinePropertyChanges(rows, layout)
+    : rows.flatMap(formatStackedPropertyChange);
+};
+
+const formatInlinePropertyChanges = (
+  rows: FormattedPropertyChange[],
+  layout: NonNullable<ReturnType<typeof propertyDiffLayout>>,
+): string[] =>
+  // Example: `~ memorySize  512 -> 1024` on a sufficiently wide terminal.
+  rows.map((row) => {
+    const symbol = colorPropertySymbol(row.kind);
+    const path = bold(formatPropertyPath(row.path));
+    const values = fitPropertyChangeValues(row, layout);
+    const before = colorPropertyValue(
+      values.before,
+      row.beforeValue,
+      row.kind === "remove" || row.kind === "update" ? red : dim,
+    );
+    const after = colorPropertyValue(
+      values.after,
+      row.afterValue,
+      row.kind === "add" || row.kind === "update" ? green : dim,
+    );
+    return `  ${symbol} ${path}  ${before}${dim(" → ")}${after}`;
+  });
+
+const formatStackedPropertyChange = (
+  row: FormattedPropertyChange,
+): string[] => {
+  // Keep before/after readable when one terminal line is too short.
+  const symbol = colorPropertySymbol(row.kind);
+  const before = colorPropertyValue(
+    row.before,
+    row.beforeValue,
+    row.kind === "remove" || row.kind === "update" ? red : dim,
+  );
+  const after = colorPropertyValue(
+    row.after,
+    row.afterValue,
+    row.kind === "add" || row.kind === "update" ? green : dim,
+  );
+  return [
+    `  ${symbol} ${bold(row.path)}`,
+    `      ${dim("├─ before")}  ${before}`,
+    `      ${dim("└─ after ")}  ${after}`,
+  ];
+};
+
+const colorPropertySymbol = (kind: FormattedPropertyChange["kind"]): string =>
+  // Match resource-plan language: green add, red remove, yellow update.
+  kind === "add" ? green("+") : kind === "remove" ? red("-") : yellow("~");
+
+const colorPropertyValue = (
+  value: string,
+  propertyValue: PropertyValue | undefined,
+  fallback: (value: string) => string,
+): string => {
+  // Semantic placeholders keep distinct colors even when no literal exists:
+  // secrets are magenta; deferred/computed values are cyan.
+  if (!propertyValue) return yellow(value);
+  switch (propertyValue.kind) {
+    case "redacted":
+      return magenta(value);
+    case "known-after-apply":
+    case "computed":
+      return cyan(value);
+    default:
+      return fallback(value);
+  }
+};
+
+/** Line-oriented CLI for CI, agents, pipes, and plain terminal output. */
 export const LoggingCli = Layer.succeed(
   Cli,
   Cli.of({
-    approvePlan: (plan) =>
+    approvePlan: (plan, options) =>
       Effect.gen(function* () {
-        for (const line of formatPlanLines(plan)) yield* Console.log(line);
+        // Non-interactive deploy still previews the plan, but cannot answer the
+        // approval prompt and therefore refuses to apply without --yes.
+        for (const line of formatPlanLines(plan, options)) {
+          yield* Console.log(line);
+        }
         yield* Console.log(
           `\n${yellow("Non-interactive terminal detected.")} Pass ${bold("--yes")} to approve, or set ${bold("ALCHEMY_TUI=1")} for the interactive UI.`,
         );
         return false;
       }),
-    displayPlan: (plan) =>
+    displayPlan: (plan, options) =>
       Effect.gen(function* () {
-        for (const line of formatPlanLines(plan)) yield* Console.log(line);
+        // `alchemy plan` ends after printing this read-only preview.
+        for (const line of formatPlanLines(plan, options)) {
+          yield* Console.log(line);
+        }
       }),
-    startApplySession: (plan) =>
+    startApplySession: (plan, options) =>
       Effect.gen(function* () {
-        for (const line of formatPlanLines(plan)) yield* Console.log(line);
+        // Approved deploys print the same preview before streaming apply events.
+        for (const line of formatPlanLines(plan, options)) {
+          yield* Console.log(line);
+        }
         yield* Console.log("");
 
         const counts = { ok: 0, fail: 0 };

--- a/packages/alchemy/src/Cli/NamespaceTree.ts
+++ b/packages/alchemy/src/Cli/NamespaceTree.ts
@@ -6,6 +6,7 @@ import type {
   ActionDelete,
 } from "../Plan.ts";
 import type { ProviderMode } from "../ProviderMode.ts";
+import { diffDeclaredProperties, type PropertyChange } from "./PropertyDiff.ts";
 
 export interface TreeBinding {
   sid: string;
@@ -128,14 +129,24 @@ export interface FlattenedItem {
    * old generation was created with (always differs from `providerMode`).
    */
   fromProviderMode?: ProviderMode;
+  /**
+   * Declared properties carried to detailed create/update/replace renderers.
+   * An empty array is meaningful because the action may originate outside
+   * declared props, or a create may declare none.
+   */
+  propertyChanges?: PropertyChange[];
+}
+
+export interface FlattenTreeOptions {
+  includePropertyChanges?: boolean;
 }
 
 export function flattenTree(
   node: TreeNode,
-  depth = 0,
-  result: FlattenedItem[] = [],
+  options: FlattenTreeOptions = {},
 ): FlattenedItem[] {
-  flattenNamespace(node, depth, result);
+  const result: FlattenedItem[] = [];
+  flattenNamespace(node, 0, result, options);
   return result;
 }
 
@@ -143,6 +154,7 @@ const flattenNamespace = (
   node: TreeNode,
   depth: number,
   result: FlattenedItem[],
+  options: FlattenTreeOptions,
 ) => {
   const sortedResources = [...node.resources].sort((a, b) =>
     a.resource.LogicalId.localeCompare(b.resource.LogicalId),
@@ -166,7 +178,7 @@ const flattenNamespace = (
       action: deriveNamespaceAction(child),
       hasChildren: true,
     });
-    flattenNamespace(child, depth + 1, result);
+    flattenNamespace(child, depth + 1, result, options);
   }
 
   for (const resource of sortedResources) {
@@ -187,6 +199,16 @@ const flattenNamespace = (
         resource.state.providerMode !== resource.mode
           ? resource.state.providerMode
           : undefined,
+      propertyChanges:
+        options.includePropertyChanges &&
+        (resource.action === "create" ||
+          resource.action === "update" ||
+          resource.action === "replace")
+          ? diffDeclaredProperties(
+              resource.action === "create" ? {} : resource.state.props,
+              resource.props,
+            )
+          : undefined,
     });
     for (const binding of [...resource.bindings].sort((a, b) =>
       a.sid.localeCompare(b.sid),
@@ -201,7 +223,7 @@ const flattenNamespace = (
       });
     }
     if (childNamespace) {
-      flattenNamespace(childNamespace, depth + 1, result);
+      flattenNamespace(childNamespace, depth + 1, result, options);
     }
   }
 

--- a/packages/alchemy/src/Cli/PropertyDiff.ts
+++ b/packages/alchemy/src/Cli/PropertyDiff.ts
@@ -1,0 +1,392 @@
+import * as Effect from "effect/Effect";
+import * as Redacted from "effect/Redacted";
+import { deepEqual, havePropsChanged } from "../Diff.ts";
+import * as Output from "../Output.ts";
+import { isPlainData } from "../Util/data.ts";
+
+const DEFAULT_MAX_VALUE_LENGTH = 120;
+// Engine equality treats {} like { x: undefined }, but [] differs from
+// [undefined]. Separate sentinels preserve object-key and array-index absence.
+const MISSING = Symbol("missing property");
+const OMITTED_PROPERTY = Symbol("omitted property");
+
+export type PropertyValue =
+  | {
+      kind: "literal";
+      value: string | number | boolean | null;
+      truncated?: true;
+    }
+  | { kind: "undefined" }
+  | { kind: "redacted" }
+  | { kind: "known-after-apply" }
+  | { kind: "computed" }
+  | { kind: "collection"; collection: "array" | "object" }
+  | { kind: "opaque" };
+
+export interface PropertyChange {
+  kind: "add" | "remove" | "update";
+  path: string;
+  before?: PropertyValue;
+  after?: PropertyValue;
+}
+
+export interface PropertyDiffOptions {
+  maxValueLength?: number;
+}
+
+export interface FormattedPropertyChange {
+  kind: "add" | "remove" | "update";
+  path: string;
+  before: string;
+  after: string;
+  beforeValue?: PropertyValue;
+  afterValue?: PropertyValue;
+}
+
+export interface PropertyDiffLayout {
+  columns: number;
+}
+
+export const NOT_SET_PROPERTY_VALUE = "(not set)";
+export const MIN_INLINE_PROPERTY_DIFF_COLUMNS = 96;
+
+/**
+ * Diff previously persisted declared input props against the currently
+ * desired input props already carried by a plan node. This is not a live
+ * cloud-drift comparison. The walk is limited to plain data and never
+ * evaluates deferred values.
+ */
+export const diffDeclaredProperties = (
+  oldProps: unknown,
+  newProps: unknown,
+  options: PropertyDiffOptions = {},
+): PropertyChange[] => {
+  const maxValueLength = Math.max(
+    0,
+    options.maxValueLength ?? DEFAULT_MAX_VALUE_LENGTH,
+  );
+  const changes: PropertyChange[] = [];
+  // Track current ancestor paths instead of all visited objects: cycles stop
+  // safely, while shared objects are still diffed at every declared path.
+  const oldAncestors = new WeakSet<object>();
+  const newAncestors = new WeakSet<object>();
+
+  const record = (change: PropertyChange) => changes.push(change);
+
+  const walk = (oldValue: unknown, newValue: unknown, path: string): void => {
+    // Keep the two absence kinds separate until equality is decided: a missing
+    // object key and an out-of-range array index do not serialize the same way.
+    const oldMissing = oldValue === MISSING;
+    const newMissing = newValue === MISSING;
+    const oldOmitted = oldValue === OMITTED_PROPERTY;
+    const newOmitted = newValue === OMITTED_PROPERTY;
+    // Example: {} -> { x: undefined } is not a declared change, while the
+    // equivalent array case is handled below as an added index.
+    if (
+      (oldOmitted && (newOmitted || newValue === undefined)) ||
+      (newOmitted && oldValue === undefined) ||
+      (oldMissing && newMissing)
+    ) {
+      return;
+    }
+    // From here both sentinels mean "not set" for add/remove classification.
+    const oldAbsent = oldMissing || oldOmitted;
+    const newAbsent = newMissing || newOmitted;
+    // Only arrays and plain objects are safe to recurse into. Date, Effect,
+    // Output, SDK objects, and class instances remain leaves.
+    const oldPlain = !oldAbsent && isPlainData(oldValue);
+    const newPlain = !newAbsent && isPlainData(newValue);
+    // Example: value.self = value must stop at self instead of producing
+    // self.self.self forever.
+    const oldCycle = oldPlain && oldAncestors.has(oldValue as object);
+    const newCycle = newPlain && newAncestors.has(newValue as object);
+    // Matching cycles cannot contain a serializable child difference here.
+    if (oldCycle && newCycle) return;
+    // If only one side cycles, report that path opaquely rather than walking an
+    // unsafe structure or pretending both sides match.
+    if (oldCycle || newCycle) {
+      record(makeChange(oldValue, newValue, path, maxValueLength));
+      return;
+    }
+    // Example: 512 -> 512 stops here. Equal plain containers still need a walk
+    // so a nested Output or Redacted value is classified at its declared path.
+    if (
+      !oldAbsent &&
+      !newAbsent &&
+      !oldPlain &&
+      !newPlain &&
+      valuesEqual(oldValue, newValue)
+    ) {
+      return;
+    }
+    // Arrays pair with arrays and objects with objects. A change from [] to {}
+    // is one container update, not a comparison between indexes and keys.
+    const sameCollectionKind =
+      oldPlain &&
+      newPlain &&
+      Array.isArray(oldValue) === Array.isArray(newValue);
+
+    // When a container is added or removed, walk its children so { a: 1 }
+    // becomes a change at a instead of an unhelpful change at the whole object.
+    if (
+      (sameCollectionKind || oldAbsent || newAbsent) &&
+      (oldPlain || newPlain)
+    ) {
+      const collection = (oldPlain ? oldValue : newValue) as
+        | Record<string, unknown>
+        | unknown[];
+      if (oldPlain) oldAncestors.add(oldValue as object);
+      if (newPlain) newAncestors.add(newValue as object);
+      // An added/removed container may contain only undefined-equivalent
+      // leaves. Report the container if its walk produces no child changes.
+      try {
+        if (Array.isArray(collection)) {
+          // Arrays intentionally diff by index; move/LCS inference is out of scope.
+          const oldArray = Array.isArray(oldValue) ? oldValue : [];
+          const newArray = Array.isArray(newValue) ? newValue : [];
+          const length = Math.max(oldArray.length, newArray.length);
+          const before = changes.length;
+          // An empty added array has no child index that could carry its change.
+          if (length === 0 && (oldAbsent || newAbsent)) {
+            record(makeChange(oldValue, newValue, path, maxValueLength));
+            return;
+          }
+          // Example: ["a"] -> ["a", "b"] compares [0], then adds [1].
+          for (let index = 0; index < length; index++) {
+            walk(
+              index < oldArray.length ? oldArray[index] : MISSING,
+              index < newArray.length ? newArray[index] : MISSING,
+              appendIndex(path, index),
+            );
+          }
+          // Example: adding [undefined] has a real array slot even if walking
+          // its value produced no scalar change.
+          if ((oldAbsent || newAbsent) && changes.length === before) {
+            record(makeChange(oldValue, newValue, path, maxValueLength));
+          }
+          return;
+        }
+
+        const oldRecord = oldPlain ? (oldValue as Record<string, unknown>) : {};
+        const newRecord = newPlain ? (newValue as Record<string, unknown>) : {};
+        // The sorted key union makes { b: 1, a: 2 } render as a then b,
+        // independently of construction or insertion order.
+        const keys = [
+          ...new Set([...Object.keys(oldRecord), ...Object.keys(newRecord)]),
+        ].sort(compareStrings);
+        const before = changes.length;
+        // An empty added object has no child key that could carry its change.
+        if (keys.length === 0 && (oldAbsent || newAbsent)) {
+          record(makeChange(oldValue, newValue, path, maxValueLength));
+          return;
+        }
+        // Example: { env: { MODE: "dev" } } builds the path env.MODE.
+        for (const key of keys) {
+          walk(
+            Object.hasOwn(oldRecord, key) ? oldRecord[key] : OMITTED_PROPERTY,
+            Object.hasOwn(newRecord, key) ? newRecord[key] : OMITTED_PROPERTY,
+            appendKey(path, key),
+          );
+        }
+        // Example: adding { config: { x: undefined } } still adds config as an
+        // empty serialized object, even though x itself is omission-equivalent.
+        if ((oldAbsent || newAbsent) && changes.length === before) {
+          record(makeChange(oldValue, newValue, path, maxValueLength));
+        }
+        return;
+      } finally {
+        if (oldPlain) oldAncestors.delete(oldValue as object);
+        if (newPlain) newAncestors.delete(newValue as object);
+      }
+    }
+
+    // Scalars, opaque leaves, and collection-type changes end as one row here.
+    record(makeChange(oldValue, newValue, path, maxValueLength));
+  };
+
+  walk(oldProps ?? {}, newProps ?? {}, "");
+  return changes;
+};
+
+export const formatPropertyValue = (value: PropertyValue): string => {
+  switch (value.kind) {
+    case "literal":
+      return typeof value.value === "string"
+        ? JSON.stringify(value.value) + (value.truncated ? "…" : "")
+        : String(value.value);
+    case "undefined":
+      return "undefined";
+    case "redacted":
+      return "(redacted)";
+    case "known-after-apply":
+      return "(known after apply)";
+    case "computed":
+      return "(computed)";
+    case "collection":
+      return value.collection === "array" ? "[…]" : "{…}";
+    case "opaque":
+      return "(opaque)";
+  }
+};
+
+export const toFormattedPropertyChange = (
+  change: PropertyChange,
+): FormattedPropertyChange => ({
+  kind: change.kind,
+  path: change.path,
+  before: change.before
+    ? formatPropertyValue(change.before)
+    : NOT_SET_PROPERTY_VALUE,
+  after: change.after
+    ? formatPropertyValue(change.after)
+    : NOT_SET_PROPERTY_VALUE,
+  beforeValue: change.before,
+  afterValue: change.after,
+});
+
+export const propertyDiffLayout = (
+  changes: FormattedPropertyChange[],
+  columns: number,
+): PropertyDiffLayout | undefined => {
+  // Example: wide terminals show `old -> new` inline; narrow terminals return
+  // no layout so the caller can stack the two values on separate lines.
+  if (columns < MIN_INLINE_PROPERTY_DIFF_COLUMNS || changes.length === 0) {
+    return undefined;
+  }
+  return { columns };
+};
+
+export const formatPropertyPath = (path: string): string =>
+  truncatePropertyCell(path, 36);
+
+export const fitPropertyChangeValues = (
+  change: FormattedPropertyChange,
+  layout: PropertyDiffLayout,
+): { before: string; after: string } => {
+  const valueColumns =
+    layout.columns - formatPropertyPath(change.path).length - 6;
+  const beforeWidth = Math.min(
+    48,
+    Math.max(1, Math.floor((valueColumns - 3) / 2)),
+  );
+  const before = truncatePropertyCell(change.before, beforeWidth);
+  const after = truncatePropertyCell(
+    change.after,
+    Math.max(1, valueColumns - before.length - 3),
+  );
+  return { before, after };
+};
+
+export const fitCreatedPropertyValue = (
+  change: FormattedPropertyChange,
+  columns: number,
+): string =>
+  truncatePropertyCell(
+    change.after,
+    Math.max(1, columns - formatPropertyPath(change.path).length - 6),
+  );
+
+const truncatePropertyCell = (value: string, width: number): string =>
+  value.length > width ? `${value.slice(0, Math.max(0, width - 1))}…` : value;
+
+const makeChange = (
+  oldValue: unknown,
+  newValue: unknown,
+  path: string,
+  maxValueLength: number,
+): PropertyChange => {
+  const oldMissing = oldValue === MISSING || oldValue === OMITTED_PROPERTY;
+  const newMissing = newValue === MISSING || newValue === OMITTED_PROPERTY;
+  // Example: missing -> 1 is add, 1 -> missing is remove, and 1 -> 2 is update.
+  return {
+    kind: oldMissing ? "add" : newMissing ? "remove" : "update",
+    path: path || "(root)",
+    before: oldMissing ? undefined : toPropertyValue(oldValue, maxValueLength),
+    after: newMissing ? undefined : toPropertyValue(newValue, maxValueLength),
+  };
+};
+
+const valuesEqual = (oldValue: unknown, newValue: unknown): boolean => {
+  if (Output.isExpr(oldValue) || Output.isExpr(newValue)) {
+    // Example: "old-id" -> resource.id stays changed and renders as
+    // known-after-apply. Reuse the engine rule without resolving the Output.
+    return (
+      oldValue === newValue &&
+      !havePropsChanged(
+        { value: oldValue } as Record<string, unknown>,
+        { value: newValue } as Record<string, unknown>,
+      )
+    );
+  }
+  if (
+    Effect.isEffect(oldValue) ||
+    Effect.isEffect(newValue) ||
+    typeof oldValue === "function" ||
+    typeof newValue === "function"
+  ) {
+    // Example: two references to the same callback are unchanged; different
+    // callbacks are opaque changes. Neither callback or Effect is executed.
+    return oldValue === newValue;
+  }
+  if (typeof oldValue === "bigint" || typeof newValue === "bigint") {
+    // Example: 1n -> 2n must compare safely because JSON.stringify rejects BigInt.
+    return oldValue === newValue;
+  }
+  // Scalars and safe leaves use the engine's existing equality semantics.
+  return deepEqual(oldValue, newValue);
+};
+
+const toPropertyValue = (
+  value: unknown,
+  maxValueLength: number,
+): PropertyValue => {
+  // Order is security-sensitive: redact first, then recognize Outputs before
+  // Effects because Output expressions are yieldable Effects.
+  if (Redacted.isRedacted(value)) return { kind: "redacted" };
+  if (Output.isExpr(value)) return { kind: "known-after-apply" };
+  if (Effect.isEffect(value) || typeof value === "function") {
+    return { kind: "computed" };
+  }
+  if (value === undefined) return { kind: "undefined" };
+  if (
+    value === null ||
+    typeof value === "boolean" ||
+    typeof value === "number"
+  ) {
+    return { kind: "literal", value };
+  }
+  if (typeof value === "string") {
+    // Keep the complete change list, but bound an individual value such as a
+    // large policy document so one row cannot dominate the terminal.
+    return value.length > maxValueLength
+      ? {
+          kind: "literal",
+          value: value.slice(0, maxValueLength),
+          truncated: true,
+        }
+      : { kind: "literal", value };
+  }
+  if (isPlainData(value)) {
+    return {
+      kind: "collection",
+      collection: Array.isArray(value) ? "array" : "object",
+    };
+  }
+  return { kind: "opaque" };
+};
+
+const appendIndex = (path: string, index: number): string =>
+  `${path}[${index}]`;
+
+const appendKey = (path: string, key: string): string => {
+  // Example: env.MODE uses dots, while env["feature.flag"] quotes a key whose
+  // punctuation would otherwise make the path ambiguous.
+  const segment = /^[A-Za-z_$][\w$]*$/.test(key)
+    ? key
+    : `[${JSON.stringify(key)}]`;
+  if (!path) return segment;
+  return segment.startsWith("[") ? `${path}${segment}` : `${path}.${segment}`;
+};
+
+const compareStrings = (a: string, b: string): number =>
+  a < b ? -1 : a > b ? 1 : 0;

--- a/packages/alchemy/src/Cli/commands/deploy.ts
+++ b/packages/alchemy/src/Cli/commands/deploy.ts
@@ -44,6 +44,7 @@ export const ExecStackOptions = Schema.Struct({
   destroy: Schema.optional(Schema.Boolean),
   dev: Schema.optional(Schema.Boolean),
   adopt: Schema.optional(Schema.Boolean),
+  detailed: Schema.optional(Schema.Boolean),
 });
 export type ExecStackOptions = typeof ExecStackOptions.Type;
 export type ExecStackOptionsEncoded = typeof ExecStackOptions.Encoded;
@@ -67,6 +68,13 @@ const adopt = Flag.boolean("adopt").pipe(
   Flag.withDefault(false),
 );
 
+const detailed = Flag.boolean("detailed").pipe(
+  Flag.withDescription(
+    "Show declared property changes for updates and replacements",
+  ),
+  Flag.withDefault(false),
+);
+
 const runStack = Effect.fn(function* ({
   main,
   stage,
@@ -78,6 +86,7 @@ const runStack = Effect.fn(function* ({
   destroy = false,
   dev = false,
   adopt = false,
+  detailed = false,
 }: ExecStackOptions) {
   const stackEffect = yield* importStack(main);
 
@@ -125,7 +134,7 @@ const runStack = Effect.fn(function* ({
         ? yield* Plan.destroy(stack)
         : yield* Plan.make(stack, { force });
       if (dryRun) {
-        yield* cli.displayPlan(updatePlan);
+        yield* cli.displayPlan(updatePlan, { detailed });
       } else {
         const hasChanges =
           Object.keys(updatePlan.deletions).length > 0 ||
@@ -135,7 +144,7 @@ const runStack = Effect.fn(function* ({
               node.bindings.some((b) => b.action !== "noop"),
           );
         if (!yes && hasChanges) {
-          const approved = yield* cli.approvePlan(updatePlan);
+          const approved = yield* cli.approvePlan(updatePlan, { detailed });
           if (!approved) {
             return;
           }
@@ -149,7 +158,7 @@ const runStack = Effect.fn(function* ({
         // and the rest of the stack keeps serving, but re-propagate a pure
         // interruption (Ctrl-C / fiber kill) so dev still shuts down cleanly.
         const applyPlan = dev
-          ? apply(updatePlan).pipe(
+          ? apply(updatePlan, { planDisplay: { detailed } }).pipe(
               Effect.catchCause((cause) =>
                 Cause.hasInterruptsOnly(cause)
                   ? Effect.failCause(cause)
@@ -158,7 +167,7 @@ const runStack = Effect.fn(function* ({
                     ).pipe(Effect.as(undefined)),
               ),
             )
-          : apply(updatePlan);
+          : apply(updatePlan, { planDisplay: { detailed } });
         const outputs = yield* applyPlan;
 
         if (outputs !== undefined) {
@@ -209,6 +218,7 @@ export const deployCommand = Command.make(
     yes,
     profile,
     adopt,
+    detailed,
   },
   instrumentCommand("deploy", stackSpanAttrs)(execStack),
 );
@@ -241,6 +251,7 @@ export const planCommand = Command.make(
     envFile,
     stage,
     profile,
+    detailed,
   },
   instrumentCommand(
     "plan",

--- a/packages/alchemy/src/Cli/tui/InkCLI.tsx
+++ b/packages/alchemy/src/Cli/tui/InkCLI.tsx
@@ -3,7 +3,11 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import { render } from "ink";
 import type { Plan } from "../../Plan.ts";
-import { type PlanStatusSession, Cli } from "../Cli.ts";
+import {
+  type PlanDisplayOptions,
+  type PlanStatusSession,
+  Cli,
+} from "../Cli.ts";
 import type { ApplyEvent } from "../Event.ts";
 import { ApprovePlan } from "./components/ApprovePlan.tsx";
 import { Plan as PlanComponent } from "./components/Plan.tsx";
@@ -19,22 +23,37 @@ export const inkCLI = () =>
     }),
   );
 
-const approvePlan = Effect.fn(function* <P extends Plan>(plan: P) {
+const approvePlan = Effect.fn(function* <P extends Plan>(
+  plan: P,
+  options: PlanDisplayOptions = {},
+) {
   let approved = false;
   const { waitUntilExit } = render(
-    <ApprovePlan plan={plan} approve={(a) => (approved = a)} />,
+    <ApprovePlan
+      plan={plan}
+      detailed={options.detailed}
+      approve={(a) => (approved = a)}
+    />,
   );
   yield* Effect.promise(waitUntilExit);
   return approved;
 });
 
-const displayPlan = <P extends Plan>(plan: P): Effect.Effect<void> =>
+const displayPlan = <P extends Plan>(
+  plan: P,
+  options: PlanDisplayOptions = {},
+): Effect.Effect<void> =>
   Effect.sync(() => {
-    const { unmount } = render(<PlanComponent plan={plan} />);
+    const { unmount } = render(
+      <PlanComponent plan={plan} detailed={options.detailed} />,
+    );
     unmount();
   });
 
-const startApplySession = Effect.fn(function* <P extends Plan>(plan: P) {
+const startApplySession = Effect.fn(function* <P extends Plan>(
+  plan: P,
+  options: PlanDisplayOptions = {},
+) {
   // Print the plan preview once into scrollback before mounting the
   // animated progress region (mirrors LoggingCli, which prints the plan
   // lines at session start — `alchemy dev`/`--yes` runs never call
@@ -43,7 +62,7 @@ const startApplySession = Effect.fn(function* <P extends Plan>(plan: P) {
   // releases the Ink instance for PlanProgress; forwarded runtime logs then
   // insert BETWEEN the preview and the live region instead of piling above
   // the entire transcript.
-  yield* displayPlan(plan);
+  yield* displayPlan(plan, options);
   const listeners = new Set<(event: ApplyEvent) => void>();
   const { unmount } = render(
     <PlanProgress

--- a/packages/alchemy/src/Cli/tui/components/ApprovePlan.tsx
+++ b/packages/alchemy/src/Cli/tui/components/ApprovePlan.tsx
@@ -8,11 +8,12 @@ import { Plan } from "./Plan.tsx";
 
 export interface ApprovePlanProps {
   plan: AlchemyPlan;
+  detailed?: boolean;
   approve: (result: boolean) => void;
 }
 
 export function ApprovePlan(props: ApprovePlanProps): JSX.Element {
-  const { plan, approve } = props;
+  const { plan, detailed = false, approve } = props;
   const [selected, setSelected] = useState(0);
   const { exit } = useApp();
 
@@ -27,7 +28,7 @@ export function ApprovePlan(props: ApprovePlanProps): JSX.Element {
 
   return (
     <Box flexDirection="column">
-      <Plan plan={plan} />
+      <Plan plan={plan} detailed={detailed} />
       <Box marginTop={1}>
         <Text>Proceed?</Text>
       </Box>

--- a/packages/alchemy/src/Cli/tui/components/Plan.tsx
+++ b/packages/alchemy/src/Cli/tui/components/Plan.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource react */
 import { useMemo, type JSX } from "react";
 
-import { Box, Text } from "ink";
+import { Box, Text, useStdout } from "ink";
 import type {
   Plan as AlchemyPlan,
   BindingAction,
@@ -16,11 +16,24 @@ import {
   type ActionVerb,
 } from "../../NamespaceTree.ts";
 import { formatModeNote } from "../../ModeTag.ts";
+import {
+  fitCreatedPropertyValue,
+  fitPropertyChangeValues,
+  formatPropertyPath,
+  propertyDiffLayout,
+  toFormattedPropertyChange,
+  type FormattedPropertyChange,
+  type PropertyChange,
+  type PropertyValue,
+} from "../../PropertyDiff.ts";
 
 export interface PlanProps {
   plan: AlchemyPlan;
+  detailed?: boolean;
 }
-export function Plan({ plan }: PlanProps): JSX.Element {
+export function Plan({ plan, detailed = false }: PlanProps): JSX.Element {
+  const { stdout } = useStdout();
+  const terminalColumns = stdout.columns ?? 120;
   const items = useMemo(
     () =>
       [
@@ -40,9 +53,8 @@ export function Plan({ plan }: PlanProps): JSX.Element {
 
   const flatItems = useMemo(() => {
     const tree = buildNamespaceTree(items, taskItems);
-    return flattenTree(tree);
-  }, [items, taskItems]);
-
+    return flattenTree(tree, { includePropertyChanges: detailed });
+  }, [detailed, items, taskItems]);
   if (items.length === 0 && taskItems.length === 0) {
     return <Text color="gray">No changes planned</Text>;
   }
@@ -96,7 +108,7 @@ export function Plan({ plan }: PlanProps): JSX.Element {
         )}
       </Box>
       <Box flexDirection="column" marginTop={1}>
-        {flatItems.map((item) => {
+        {flatItems.map((item, index) => {
           const indent = "  ".repeat(item.depth);
           const color = getActionColor(item.action);
           const icon = getActionIcon(item.action);
@@ -152,32 +164,94 @@ export function Plan({ plan }: PlanProps): JSX.Element {
             priorMode: item.fromProviderMode,
             defaultMode: plan.defaultMode,
           });
+          const resourceRowProps = {
+            indent,
+            color,
+            icon,
+            id: item.id,
+            resourceType: item.resourceType,
+            bindingCount: item.bindingCount,
+            modeNote,
+          };
+          if (!detailed) {
+            return <ResourceRow key={key} {...resourceRowProps} />;
+          }
+
+          const propertyColumns = Math.max(0, terminalColumns - indent.length);
+          const propertyLayout =
+            item.action !== "create" && item.propertyChanges?.length
+              ? propertyDiffLayout(
+                  item.propertyChanges.map(toFormattedPropertyChange),
+                  propertyColumns,
+                )
+              : undefined;
           return (
-            <Box key={key} flexDirection="row">
-              <Text>{indent}</Text>
-              <Box width={2}>
-                <Text color={color}>{icon} </Text>
-              </Box>
-              <Box>
-                <Text bold>{item.id}</Text>
-              </Box>
-              <Box marginLeft={1}>
-                <Text color="blackBright">({item.resourceType})</Text>
-              </Box>
-              {modeNote && (
-                <Box marginLeft={1}>
-                  <Text color="blackBright">({modeNote})</Text>
-                </Box>
+            <Box key={key} flexDirection="column" marginTop={index > 0 ? 1 : 0}>
+              <ResourceRow {...resourceRowProps} />
+              {item.propertyChanges?.length === 0 && (
+                <Text color="gray">
+                  {`${indent}  `}
+                  {item.action === "create"
+                    ? "no declared properties"
+                    : "no declared property changes"}
+                </Text>
               )}
-              {item.bindingCount !== undefined && item.bindingCount > 0 && (
-                <Box marginLeft={1}>
-                  <Text color="cyan">({item.bindingCount} bindings)</Text>
-                </Box>
+              {item.propertyChanges && item.propertyChanges.length > 0 && (
+                <PropertyChanges
+                  changes={item.propertyChanges}
+                  indent={`${indent}  `}
+                  layout={propertyLayout}
+                  columns={propertyColumns}
+                  created={item.action === "create"}
+                />
               )}
             </Box>
           );
         })}
       </Box>
+    </Box>
+  );
+}
+
+function ResourceRow({
+  indent,
+  color,
+  icon,
+  id,
+  resourceType,
+  bindingCount,
+  modeNote,
+}: {
+  indent: string;
+  color: Color;
+  icon: string;
+  id: string;
+  resourceType?: string;
+  bindingCount?: number;
+  modeNote?: string;
+}): JSX.Element {
+  return (
+    <Box flexDirection="row">
+      <Text>{indent}</Text>
+      <Box width={2}>
+        <Text color={color}>{icon} </Text>
+      </Box>
+      <Box>
+        <Text bold>{id}</Text>
+      </Box>
+      <Box marginLeft={1}>
+        <Text color="blackBright">({resourceType})</Text>
+      </Box>
+      {modeNote && (
+        <Box marginLeft={1}>
+          <Text color="blackBright">({modeNote})</Text>
+        </Box>
+      )}
+      {bindingCount !== undefined && bindingCount > 0 && (
+        <Box marginLeft={1}>
+          <Text color="cyan">({bindingCount} bindings)</Text>
+        </Box>
+      )}
     </Box>
   );
 }
@@ -209,3 +283,133 @@ const getActionIcon = (action: AnyAction): string =>
   })[action] ?? "?";
 
 const actionColor = (action: CRUD["action"]): Color => getActionColor(action);
+
+function PropertyChanges({
+  changes,
+  indent,
+  layout,
+  columns,
+  created,
+}: {
+  changes: PropertyChange[];
+  indent: string;
+  layout: ReturnType<typeof propertyDiffLayout>;
+  columns: number;
+  created: boolean;
+}): JSX.Element {
+  const rows = changes.map(toFormattedPropertyChange);
+
+  if (created) {
+    return (
+      <>
+        {rows.map((row) => (
+          <Text key={`${row.kind}/${row.path}`}>
+            {indent}
+            <Text color="green">+</Text>{" "}
+            <Text bold>{formatPropertyPath(row.path)}</Text>
+            {"  "}
+            <PropertyValueText
+              text={fitCreatedPropertyValue(row, columns)}
+              value={row.afterValue}
+              fallbackColor="green"
+            />
+          </Text>
+        ))}
+      </>
+    );
+  }
+
+  if (!layout) {
+    return (
+      <>
+        {rows.flatMap((row) => [
+          <Text key={`${row.kind}/${row.path}`}>
+            {indent}
+            <Text color={propertyChangeColor(row.kind)}>
+              {propertyChangeSymbol(row.kind)}
+            </Text>{" "}
+            <Text bold>{row.path}</Text>
+          </Text>,
+          <Text key={`${row.kind}/${row.path}/before`}>
+            {indent} <Text color="gray">├─ before</Text>
+            {"  "}
+            <PropertyValueText
+              text={row.before}
+              value={row.beforeValue}
+              fallbackColor={beforeColor(row.kind)}
+            />
+          </Text>,
+          <Text key={`${row.kind}/${row.path}/after`}>
+            {indent} <Text color="gray">└─ after </Text>
+            {"  "}
+            <PropertyValueText
+              text={row.after}
+              value={row.afterValue}
+              fallbackColor={afterColor(row.kind)}
+            />
+          </Text>,
+        ])}
+      </>
+    );
+  }
+
+  return (
+    <>
+      {rows.map((row) => {
+        const values = fitPropertyChangeValues(row, layout);
+        return (
+          <Text key={`${row.kind}/${row.path}`}>
+            {indent}
+            <Text color={propertyChangeColor(row.kind)}>
+              {propertyChangeSymbol(row.kind)}
+            </Text>{" "}
+            <Text bold>{formatPropertyPath(row.path)}</Text>
+            {"  "}
+            <PropertyValueText
+              text={values.before}
+              value={row.beforeValue}
+              fallbackColor={beforeColor(row.kind)}
+            />
+            <Text color="gray"> → </Text>
+            <PropertyValueText
+              text={values.after}
+              value={row.afterValue}
+              fallbackColor={afterColor(row.kind)}
+            />
+          </Text>
+        );
+      })}
+    </>
+  );
+}
+
+const propertyChangeSymbol = (kind: FormattedPropertyChange["kind"]): string =>
+  kind === "add" ? "+" : kind === "remove" ? "-" : "~";
+
+const propertyChangeColor = (kind: FormattedPropertyChange["kind"]): Color =>
+  kind === "add" ? "green" : kind === "remove" ? "red" : "yellow";
+
+const beforeColor = (kind: FormattedPropertyChange["kind"]): Color =>
+  kind === "add" ? "gray" : "red";
+
+const afterColor = (kind: FormattedPropertyChange["kind"]): Color =>
+  kind === "remove" ? "gray" : "green";
+
+function PropertyValueText({
+  text,
+  value,
+  fallbackColor,
+}: {
+  text: string;
+  value: PropertyValue | undefined;
+  fallbackColor: Color;
+}): JSX.Element {
+  const color: Color = !value
+    ? "yellow"
+    : value.kind === "redacted"
+      ? "magenta"
+      : value.kind === "known-after-apply" || value.kind === "computed"
+        ? "cyan"
+        : fallbackColor;
+  return <Text color={color}>{text}</Text>;
+}

--- a/packages/alchemy/test/Cli/LoggingCli.test.ts
+++ b/packages/alchemy/test/Cli/LoggingCli.test.ts
@@ -1,0 +1,160 @@
+import { formatPlanLines } from "@/Cli/LoggingCli.ts";
+import * as Output from "@/Output.ts";
+import { describe, expect, test } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import * as Redacted from "effect/Redacted";
+import {
+  createNode,
+  deleteNode,
+  planWith,
+  replaceNode,
+  updateNode,
+} from "./PlanTestNodes.ts";
+
+describe("formatPlanLines", () => {
+  test("keeps the existing compact output unchanged by default", () => {
+    const lines = formatPlanLines(
+      planWith([
+        updateNode({ value: "old" }, { value: "new" }, "First"),
+        replaceNode({ engine: "v1" }, { engine: "v2" }, "Second"),
+      ]),
+    );
+
+    expect(lines).toEqual([
+      "Plan: 1 to update, 1 to replace",
+      "[First] update",
+      "[Second] replace",
+    ]);
+  });
+
+  test("shows property details for an update", () => {
+    const lines = formatPlanLines(
+      planWith([
+        updateNode(
+          { compatibilityDate: "2026-01-01" },
+          { compatibilityDate: "2026-08-19" },
+        ),
+      ]),
+      { detailed: true },
+    );
+    const row = lines.find((line) => line.includes("compatibilityDate"));
+    expect(row).toContain('"2026-01-01" → "2026-08-19"');
+    expect(lines.join("\n")).not.toContain("PROPERTY");
+    expect(lines.join("\n")).not.toContain("│");
+  });
+
+  test("shows explicit before and after values for additions and removals", () => {
+    const lines = formatPlanLines(
+      planWith([updateNode({ removed: "old" }, { added: "new" })]),
+      { detailed: true },
+    );
+    expect(lines.find((line) => line.includes("added"))).toContain(
+      '(not set) → "new"',
+    );
+    expect(lines.find((line) => line.includes("removed"))).toContain(
+      '"old" → (not set)',
+    );
+  });
+
+  test("uses a stacked before and after layout in narrow terminals", () => {
+    const lines = formatPlanLines(
+      planWith([updateNode({ port: 80 }, { port: 443 })]),
+      { detailed: true, columns: 80 },
+    );
+    expect(lines).toContain("  ~ port");
+    expect(lines).toContain("      ├─ before  80");
+    expect(lines).toContain("      └─ after   443");
+  });
+
+  test("starts values directly after each property path", () => {
+    const lines = formatPlanLines(
+      planWith([
+        updateNode(
+          { short: "a", mediumPath: "m" },
+          { short: "b", mediumPath: "n" },
+          "First",
+        ),
+        updateNode(
+          { muchLongerProperty: "before" },
+          { muchLongerProperty: "after" },
+          "Second",
+        ),
+      ]),
+      { detailed: true, columns: 160 },
+    );
+    const rows = ["short", "mediumPath", "muchLongerProperty"].map((path) =>
+      lines.find((line) => line.includes(path))!,
+    );
+    expect(rows[0]).toContain('short  "a"');
+    expect(rows[1]).toContain('mediumPath  "m"');
+    expect(rows[0].indexOf('"a"')).not.toBe(rows[1].indexOf('"m"'));
+    expect(rows[2].indexOf('"before"')).toBeGreaterThan(rows[0].indexOf('"a"'));
+    expect(Math.max(...rows.map((row) => row.length))).toBeLessThan(60);
+    expect(lines.filter((line) => line === "")).toHaveLength(2);
+  });
+
+  test("is honest when update and replace have no declared property changes", () => {
+    const lines = formatPlanLines(
+      planWith([
+        updateNode({ name: "same" }, { name: "same" }, "UpdateWorker"),
+        replaceNode({ name: "same" }, { name: "same" }, "ReplaceWorker"),
+      ]),
+      { detailed: true },
+    );
+    expect(lines.filter((line) => line.includes("no declared"))).toEqual([
+      "  no declared property changes",
+      "  no declared property changes",
+    ]);
+  });
+
+  test("keeps create and delete rows compact by default", () => {
+    const plan = planWith(
+      [createNode({ createdOnly: true })],
+      [deleteNode({ deletedOnly: true }, "OldWorker")],
+    );
+    const lines = formatPlanLines(plan);
+    expect(lines).toEqual([
+      "Plan: 1 to create, 1 to delete",
+      "[OldWorker] delete",
+      "[Worker] create",
+    ]);
+    expect(lines.join("\n")).not.toContain("createdOnly");
+    expect(lines.join("\n")).not.toContain("deletedOnly");
+  });
+
+  test("shows safe declared properties for a detailed create", () => {
+    let outputEvaluated = false;
+    let effectExecuted = false;
+    const plan = planWith(
+      [
+        createNode({
+          endpoint: Output.fromEffect(
+            Effect.sync(() => {
+              outputEvaluated = true;
+              return "resolved-output";
+            }),
+          ),
+          handler: Effect.sync(() => {
+            effectExecuted = true;
+            return "computed-handler";
+          }),
+          name: "worker",
+          token: Redacted.make("secret-token"),
+        }),
+      ],
+      [deleteNode({ deletedOnly: true }, "OldWorker")],
+    );
+    const output = formatPlanLines(plan, { detailed: true }).join("\n");
+
+    expect(output).toContain("+ endpoint  (known after apply)");
+    expect(output).toContain("+ handler  (computed)");
+    expect(output).toContain('+ name  "worker"');
+    expect(output).toContain("+ token  (redacted)");
+    expect(output).not.toContain("(not set)");
+    expect(output).not.toContain("deletedOnly");
+    expect(output).not.toContain("secret-token");
+    expect(output).not.toContain("resolved-output");
+    expect(outputEvaluated).toBe(false);
+    expect(effectExecuted).toBe(false);
+  });
+});

--- a/packages/alchemy/test/Cli/MultiCloudPlanPropertyDiff.test.ts
+++ b/packages/alchemy/test/Cli/MultiCloudPlanPropertyDiff.test.ts
@@ -1,0 +1,643 @@
+import * as Alchemy from "alchemy";
+import { havePropsChanged, isResolved } from "alchemy/Diff";
+import * as Provider from "alchemy/Provider";
+import type { ResourceClass } from "alchemy/Resource";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+import * as Redacted from "effect/Redacted";
+import { fileURLToPath } from "node:url";
+
+const currentFile = fileURLToPath(import.meta.url);
+const isStackProcess = process.env.MULTI_CLOUD_FIXTURE_MODE === "stack";
+
+// -----------------------------------------------------------------------------
+// Lifecycle test
+// -----------------------------------------------------------------------------
+
+async function registerLifecycleTest(): Promise<void> {
+  const [{ exec }, NodeServices, { describe, expect, test }, { ChildProcess }] =
+    await Promise.all([
+      import("@/Util/exec.ts"),
+      import("@effect/platform-node/NodeServices"),
+      import("alchemy-test"),
+      import("effect/unstable/process"),
+    ]);
+
+  describe("alchemy plan property details", () => {
+    test.effect(
+      "runs the local deploy → plan → cleanup user flow",
+      () =>
+        Effect.gen(function* () {
+          const { exitCode, stdout, stderr } = yield* exec(
+            ChildProcess.make(process.execPath, [currentFile], {
+              shell: false,
+            }),
+          ).pipe(Effect.scoped);
+
+          expect(stderr).toBe("");
+          expect(stdout).toContain("Step 1/3: deploy baseline stack");
+          expect(stdout).toContain("Step 2/3: plan updated stack");
+          expect(stdout).toContain(
+            "✔ compact and detailed plans verified for 20 resources",
+          );
+          expect(stdout).toContain("Step 3/3: remove disposable local state");
+          expect(stdout).toContain("✔ temporary runtime and state removed");
+          expect(exitCode).toBe(0);
+        }).pipe(Effect.provide(NodeServices.layer)),
+      { timeout: 30_000 },
+    );
+  });
+}
+
+// -----------------------------------------------------------------------------
+// Directly runnable local user flow
+// -----------------------------------------------------------------------------
+
+function runLifecycle(verbose: boolean) {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const packageRoot = path.resolve(path.dirname(currentFile), "../..");
+    const cli = path.join(packageRoot, "bin/alchemy.ts");
+
+    return yield* Effect.acquireUseRelease(
+      fs.makeTempDirectory({ prefix: "alchemy-plan-diff-flow-" }),
+      (runtime) =>
+        Effect.gen(function* () {
+          const dotAlchemy = path.join(runtime, ".alchemy");
+          yield* fs.makeDirectory(dotAlchemy, { recursive: true });
+          // Suppress the CLI's periodic npm lookup so this local lifecycle stays hermetic.
+          yield* fs.writeFileString(
+            path.join(dotAlchemy, "version-check.json"),
+            JSON.stringify({ checkedAt: 9_999_999_999_999 }),
+          );
+
+          yield* Effect.sync(() =>
+            console.log("Step 1/3: deploy baseline stack"),
+          );
+          const created = yield* Effect.tryPromise(() =>
+            runCli(
+              cli,
+              runtime,
+              ["deploy", "--yes", "--detailed"],
+              "baseline",
+              verbose,
+            ),
+          );
+          if (!verbose) {
+            yield* Effect.sync(() => verifyDetailedCreate(created));
+          }
+          yield* verifyPersistedState(runtime);
+          yield* Effect.sync(() =>
+            console.log("✔ created and persisted 20 local resources"),
+          );
+
+          yield* Effect.sync(() =>
+            console.log("\nStep 2/3: plan updated stack"),
+          );
+          const compact = yield* Effect.tryPromise(() =>
+            runCli(cli, runtime, ["plan"], "updated", verbose),
+          );
+          if (!verbose) {
+            yield* Effect.sync(() => verifyCompactPlan(compact));
+          }
+
+          const detailed = yield* Effect.tryPromise(() =>
+            runCli(cli, runtime, ["plan", "--detailed"], "updated", verbose),
+          );
+          if (!verbose) {
+            yield* Effect.sync(() => verifyDetailedPlan(detailed));
+          }
+          yield* Effect.sync(() =>
+            console.log(
+              "✔ compact and detailed plans verified for 20 resources",
+            ),
+          );
+        }),
+      (runtime) =>
+        Effect.gen(function* () {
+          yield* Effect.sync(() =>
+            console.log("\nStep 3/3: remove disposable local state"),
+          );
+          yield* fs.remove(runtime, { recursive: true, force: true });
+          yield* Effect.sync(() =>
+            console.log("✔ temporary runtime and state removed"),
+          );
+        }),
+    );
+  });
+}
+
+async function runCli(
+  cli: string,
+  runtime: string,
+  command:
+    | ["plan"]
+    | ["plan", "--detailed"]
+    | ["deploy", "--yes", "--detailed"],
+  revision: "baseline" | "updated",
+  interactive: boolean,
+): Promise<string> {
+  const arguments_ = [
+    process.execPath,
+    cli,
+    command[0],
+    currentFile,
+    "--stage",
+    "acceptance",
+    ...command.slice(1),
+  ];
+  const environment: Record<string, string | undefined> = {
+    ...process.env,
+    MULTI_CLOUD_FIXTURE_MODE: "stack",
+    MULTI_CLOUD_REVISION: revision,
+  };
+
+  if (interactive) {
+    delete environment.ALCHEMY_PLAIN;
+    delete environment.ALCHEMY_NO_TUI;
+    delete environment.CI;
+    console.log(`\n$ ${displayCommand(command)}\n`);
+
+    const child = Bun.spawn(arguments_, {
+      cwd: runtime,
+      env: environment,
+      stdin: "inherit",
+      stdout: "inherit",
+      stderr: "inherit",
+    });
+    const exitCode = await child.exited;
+    if (exitCode !== 0) {
+      throw new Error(`${command.join(" ")} exited with ${exitCode}`);
+    }
+    return "";
+  }
+
+  const child = Bun.spawn(arguments_, {
+    cwd: runtime,
+    env: {
+      ...environment,
+      ALCHEMY_PLAIN: "1",
+      CI: "1",
+    },
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+  if (exitCode !== 0) {
+    process.stderr.write(stderr);
+    throw new Error(`${command.join(" ")} exited with ${exitCode}`);
+  }
+  if (stderr !== "") {
+    throw new Error(`${command.join(" ")} wrote to stderr:\n${stderr}`);
+  }
+  return stdout;
+}
+
+function displayCommand(
+  command:
+    | ["plan"]
+    | ["plan", "--detailed"]
+    | ["deploy", "--yes", "--detailed"],
+): string {
+  return command[0] === "deploy"
+    ? "alchemy deploy --detailed --yes"
+    : `alchemy ${command.join(" ")}`;
+}
+
+function verifyDetailedCreate(output: string): void {
+  const expected = [
+    "Plan: 20 to create",
+    "[ApiFunction] create",
+    "environment.API_TOKEN  (redacted)",
+    'handler  "src/api.handler"',
+    "[EdgeWorker] create",
+    'compatibilityDate  "2026-01-01"',
+    "[Network] create",
+    'tags.Environment  "staging"',
+  ];
+  const missing = expected.filter((value) => !output.includes(value));
+  if (missing.length > 0 || output.includes("(not set)")) {
+    throw new Error(
+      `Detailed create rendered the wrong properties:\n${missing.join("\n")}`,
+    );
+  }
+  verifyNoLeaks(output);
+}
+
+function verifyPersistedState(runtime: string) {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const stateDirectory = path.join(
+      runtime,
+      ".alchemy",
+      "state",
+      "MultiCloudPlanPropertyDiff",
+      "acceptance",
+    );
+    const resourceStates = (yield* fs.readDirectory(stateDirectory)).filter(
+      (file) => file.endsWith(".json") && file !== "__stack_output__.json",
+    );
+    if (resourceStates.length !== 20) {
+      return yield* Effect.fail(
+        new Error(
+          `Expected 20 persisted resource states, got ${resourceStates.length}`,
+        ),
+      );
+    }
+  });
+}
+
+function verifyCompactPlan(output: string): void {
+  const resourceRows = changedResourceRows(output);
+  if (resourceRows.length !== 20) {
+    throw new Error(
+      `Expected 20 compact resource rows, got ${resourceRows.length}`,
+    );
+  }
+  if (
+    !output.includes("Plan: 16 to update, 4 to replace") ||
+    output.includes("compatibilityDate") ||
+    output.includes("known after apply")
+  ) {
+    throw new Error("Compact lifecycle plan rendered the wrong detail level");
+  }
+  verifyNoLeaks(output);
+}
+
+function verifyDetailedPlan(output: string): void {
+  const resourceRows = changedResourceRows(output);
+  if (resourceRows.length !== 20) {
+    throw new Error(
+      `Expected 20 detailed resource rows, got ${resourceRows.length}`,
+    );
+  }
+
+  const expected = [
+    "[EdgeWorker] update",
+    'compatibilityDate  "2026-01-01" → "2026-08-19"',
+    "vars.SESSION_KEY  (redacted) → (redacted)",
+    "[NatGateway] replace",
+    'allocationId  "eipalloc-staging" → "eipalloc-production"',
+    "[PrivateRoutes] update",
+    "routes[0].natGatewayId",
+    "(known after apply)",
+    "[RdsPrimary] replace",
+    "monitoringRoleArn  null → (not set)",
+    "[SessionDurableObject] replace",
+    "[AssetsBucket] replace",
+    "[ApiDnsRecord] update",
+    "ttl  (not set) → 60",
+  ];
+  const missing = expected.filter((value) => !output.includes(value));
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing expected multi-cloud output:\n${missing.join("\n")}`,
+    );
+  }
+  verifyNoLeaks(output);
+}
+
+function changedResourceRows(output: string): string[] {
+  return output
+    .split("\n")
+    .filter((line) => /^\[[^\]]+\] (update|replace)$/.test(line));
+}
+
+function verifyNoLeaks(output: string): void {
+  const forbidden = [
+    "staging-api-token",
+    "production-api-token",
+    "staging-session-key",
+    "production-session-key",
+    "simulated Lambda handler must not execute during plan",
+  ].filter((value) => output.includes(value));
+  if (forbidden.length > 0) {
+    throw new Error(
+      `Sensitive or computed values leaked: ${forbidden.join(", ")}`,
+    );
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Local multi-cloud stack fixture
+// -----------------------------------------------------------------------------
+
+type Props = Record<string, unknown>;
+type Attributes = { id: string; arn: string };
+type SimulatedResource<Type extends string> = Alchemy.Resource<
+  Type,
+  Props,
+  Attributes
+>;
+
+const simulated = <const Type extends string>(type: Type) =>
+  Alchemy.Resource<SimulatedResource<Type>>(type);
+
+const Vpc = simulated("AWS.EC2.VPC");
+const InternetGateway = simulated("AWS.EC2.InternetGateway");
+const PublicSubnet = simulated("AWS.EC2.Subnet.Public");
+const PrivateSubnet = simulated("AWS.EC2.Subnet.Private");
+const NatGateway = simulated("AWS.EC2.NatGateway");
+const RouteTable = simulated("AWS.EC2.RouteTable");
+const SecurityGroup = simulated("AWS.EC2.SecurityGroup");
+const Ec2Instance = simulated("AWS.EC2.Instance");
+const EcsCluster = simulated("AWS.ECS.Cluster");
+const EcsService = simulated("AWS.ECS.Service");
+const EksCluster = simulated("AWS.EKS.Cluster");
+const RdsInstance = simulated("AWS.RDS.DBInstance");
+const AuroraCluster = simulated("AWS.RDS.DBCluster");
+const LambdaFunction = simulated("AWS.Lambda.Function");
+const IamRole = simulated("AWS.IAM.Role");
+const Worker = simulated("Cloudflare.Worker");
+const DurableObject = simulated("Cloudflare.DurableObject");
+const KvNamespace = simulated("Cloudflare.KV.Namespace");
+const R2Bucket = simulated("Cloudflare.R2.Bucket");
+const DnsRecord = simulated("Cloudflare.DNS.Record");
+
+const replacements = new Set([
+  "NatGateway",
+  "RdsPrimary",
+  "SessionDurableObject",
+  "AssetsBucket",
+]);
+
+// Resource names are representative only; providers and state stay local and
+// never contact AWS or Cloudflare.
+const providerFor = <const Type extends string>(
+  resource: ResourceClass<SimulatedResource<Type>>,
+) =>
+  Provider.succeed(resource, {
+    list: () => Effect.succeed([]),
+    diff: ({ id, olds, news }) =>
+      Effect.succeed(
+        isResolved(news) && !havePropsChanged(olds, news)
+          ? ({ action: "noop" } as const)
+          : replacements.has(id)
+            ? ({ action: "replace" } as const)
+            : ({ action: "update", stables: ["id", "arn"] } as const),
+      ),
+    reconcile: ({ id }) =>
+      Effect.succeed({ id: `${id}-id`, arn: `arn:simulated:${id}` }),
+    delete: () => Effect.void,
+  });
+
+const providers = Layer.mergeAll(
+  providerFor(Vpc),
+  providerFor(InternetGateway),
+  providerFor(PublicSubnet),
+  providerFor(PrivateSubnet),
+  providerFor(NatGateway),
+  providerFor(RouteTable),
+  providerFor(SecurityGroup),
+  providerFor(Ec2Instance),
+  providerFor(EcsCluster),
+  providerFor(EcsService),
+  providerFor(EksCluster),
+  providerFor(RdsInstance),
+  providerFor(AuroraCluster),
+  providerFor(LambdaFunction),
+  providerFor(IamRole),
+  providerFor(Worker),
+  providerFor(DurableObject),
+  providerFor(KvNamespace),
+  providerFor(R2Bucket),
+  providerFor(DnsRecord),
+);
+
+const revision = process.env.MULTI_CLOUD_REVISION ?? "updated";
+if (revision !== "baseline" && revision !== "updated") {
+  throw new Error(`Unknown MULTI_CLOUD_REVISION '${revision}'`);
+}
+const updated = revision === "updated";
+const choose = <T>(baseline: T, next: T): T => (updated ? next : baseline);
+
+export default Alchemy.Stack(
+  "MultiCloudPlanPropertyDiff",
+  {
+    providers,
+    state: Alchemy.localState(),
+  },
+  Effect.gen(function* () {
+    const vpc = yield* Vpc("Network", {
+      cidrBlock: "10.0.0.0/16",
+      enableDnsHostnames: true,
+      tags: {
+        Environment: choose("staging", "production"),
+        Owner: "platform",
+        ...(updated ? { CostCenter: "core" } : {}),
+      },
+    });
+    yield* InternetGateway("InternetGateway", {
+      vpcId: vpc.id,
+      tags: { Environment: choose("staging", "production") },
+    });
+    const publicSubnet = yield* PublicSubnet("PublicSubnet", {
+      vpcId: vpc.id,
+      cidrBlock: "10.0.1.0/24",
+      mapPublicIpOnLaunch: !updated,
+      tags: { Tier: "public", Environment: choose("staging", "production") },
+    });
+    const privateSubnet = yield* PrivateSubnet("PrivateSubnet", {
+      vpcId: vpc.id,
+      cidrBlock: "10.0.10.0/24",
+      mapPublicIpOnLaunch: false,
+      tags: {
+        Tier: "private",
+        Environment: choose("staging", "production"),
+        ...(updated ? { DataClassification: "confidential" } : {}),
+      },
+    });
+    const nat = yield* NatGateway("NatGateway", {
+      subnetId: publicSubnet.id,
+      allocationId: choose("eipalloc-staging", "eipalloc-production"),
+      connectivityType: "public",
+    });
+    yield* RouteTable("PrivateRoutes", {
+      vpcId: vpc.id,
+      routes: [
+        { destinationCidrBlock: "0.0.0.0/0", natGatewayId: nat.id },
+        ...(updated
+          ? [
+              {
+                destinationCidrBlock: "10.20.0.0/16",
+                transitGatewayId: "tgw-production",
+              },
+            ]
+          : []),
+      ],
+    });
+    const securityGroup = yield* SecurityGroup("ApplicationSecurityGroup", {
+      vpcId: vpc.id,
+      ingress: [
+        {
+          protocol: "tcp",
+          fromPort: choose(80, 443),
+          toPort: choose(80, 443),
+          cidrBlocks: ["10.0.0.0/16"],
+        },
+        ...(updated
+          ? [
+              {
+                protocol: "tcp",
+                fromPort: 22,
+                toPort: 22,
+                cidrBlocks: ["10.99.0.0/16"],
+              },
+            ]
+          : []),
+      ],
+      egress: [{ protocol: "-1", cidrBlocks: ["0.0.0.0/0"] }],
+    });
+    yield* Ec2Instance("Bastion", {
+      subnetId: publicSubnet.id,
+      securityGroupIds: [securityGroup.id],
+      instanceType: choose("t3.small", "t3.medium"),
+      detailedMonitoring: updated,
+    });
+    const ecsCluster = yield* EcsCluster("ApplicationCluster", {
+      name: choose("application-staging", "application-production"),
+      containerInsights: choose("disabled", "enabled"),
+    });
+    yield* EcsService("ApiService", {
+      clusterArn: ecsCluster.arn,
+      desiredCount: choose(2, 4),
+      deployment: {
+        minimumHealthyPercent: choose(50, 100),
+        maximumPercent: 200,
+      },
+    });
+    yield* EksCluster("KubernetesCluster", {
+      version: choose("1.31", "1.32"),
+      subnetIds: [publicSubnet.id, privateSubnet.id],
+      endpointPrivateAccess: updated,
+    });
+    yield* RdsInstance("RdsPrimary", {
+      engine: "postgres",
+      engineVersion: choose("15.7", "16.3"),
+      instanceClass: choose("db.t4g.medium", "db.r7g.large"),
+      multiAz: updated,
+      ...(updated ? {} : { monitoringRoleArn: null }),
+    });
+    yield* AuroraCluster("AuroraCluster", {
+      engine: "aurora-postgresql",
+      engineMode: "provisioned",
+      backupRetentionPeriod: choose(7, 14),
+      serverlessV2Scaling: {
+        minCapacity: choose(0.5, 1),
+        maxCapacity: choose(4, 16),
+      },
+    });
+    yield* LambdaFunction("ApiFunction", {
+      memorySize: choose(512, 1024),
+      timeout: choose(15, 30),
+      handler: updated
+        ? Effect.die(
+            new Error("simulated Lambda handler must not execute during plan"),
+          )
+        : "src/api.handler",
+      environment: {
+        LOG_LEVEL: choose("info", "warn"),
+        API_TOKEN: Redacted.make(
+          choose("staging-api-token", "production-api-token"),
+        ),
+      },
+    });
+    yield* IamRole("ApplicationRole", {
+      path: "/application/",
+      managedPolicyArns: [
+        "arn:aws:iam::aws:policy/ReadOnlyAccess",
+        ...(updated
+          ? ["arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"]
+          : []),
+      ],
+      inlinePolicy: {
+        Statement: [
+          {
+            Effect: "Allow",
+            Action: updated
+              ? ["s3:GetObject", "s3:PutObject"]
+              : ["s3:GetObject"],
+            Resource: "arn:aws:s3:::assets/*",
+          },
+          ...(updated
+            ? [
+                {
+                  Effect: "Allow",
+                  Action: ["sqs:SendMessage"],
+                  Resource: "arn:aws:sqs:eu-central-1:123456789012:jobs",
+                },
+              ]
+            : []),
+        ],
+      },
+    });
+    yield* Worker("EdgeWorker", {
+      compatibilityDate: choose("2026-01-01", "2026-08-19"),
+      compatibilityFlags: [
+        "nodejs_compat",
+        ...(updated ? ["streams_enable_constructors"] : []),
+      ],
+      vars: {
+        ORIGIN: choose(
+          "https://staging.example.com",
+          "https://api.example.com",
+        ),
+        SESSION_KEY: Redacted.make(
+          choose("staging-session-key", "production-session-key"),
+        ),
+      },
+    });
+    yield* DurableObject("SessionDurableObject", {
+      className: choose("SessionV1", "SessionV2"),
+      sqlite: updated,
+      migrationTag: choose("v1", "v2"),
+    });
+    yield* KvNamespace("EdgeConfig", {
+      title: choose("edge-config-staging", "edge-config-production"),
+    });
+    yield* R2Bucket("AssetsBucket", {
+      name: choose("assets-staging", "assets-production"),
+      jurisdiction: choose("default", "eu"),
+      storageClass: choose("Standard", "InfrequentAccess"),
+    });
+    yield* DnsRecord("ApiDnsRecord", {
+      zoneId: "zone-example",
+      name: "api.example.com",
+      type: "CNAME",
+      content: choose(
+        "staging.example.workers.dev",
+        "production.example.workers.dev",
+      ),
+      proxied: true,
+      ...(updated ? { ttl: 60 } : {}),
+    });
+  }),
+);
+
+if (import.meta.main) {
+  const arguments_ = process.argv.slice(2);
+  if (arguments_.some((argument) => argument !== "--verbose")) {
+    console.error(`Usage: bun ${currentFile} [--verbose]`);
+    process.exit(1);
+  }
+  const verbose = arguments_.includes("--verbose");
+  if (verbose && !process.stdout.isTTY) {
+    console.error("--verbose requires an interactive terminal (TTY)");
+    process.exit(1);
+  }
+  const NodeServices = await import("@effect/platform-node/NodeServices");
+  await Effect.runPromise(
+    runLifecycle(verbose).pipe(Effect.provide(NodeServices.layer)),
+  );
+} else if (!isStackProcess) {
+  await registerLifecycleTest();
+}

--- a/packages/alchemy/test/Cli/MultiCloudPlanPropertyDiff.test.ts
+++ b/packages/alchemy/test/Cli/MultiCloudPlanPropertyDiff.test.ts
@@ -7,6 +7,7 @@ import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 import * as Redacted from "effect/Redacted";
+import { createInterface } from "node:readline/promises";
 import { fileURLToPath } from "node:url";
 
 const currentFile = fileURLToPath(import.meta.url);
@@ -93,6 +94,10 @@ function runLifecycle(verbose: boolean) {
           yield* Effect.sync(() =>
             console.log("✔ created and persisted 20 local resources"),
           );
+          yield* pauseForReview(
+            verbose,
+            "Press Enter to show the compact update plan...",
+          );
 
           yield* Effect.sync(() =>
             console.log("\nStep 2/3: plan updated stack"),
@@ -103,6 +108,10 @@ function runLifecycle(verbose: boolean) {
           if (!verbose) {
             yield* Effect.sync(() => verifyCompactPlan(compact));
           }
+          yield* pauseForReview(
+            verbose,
+            "Press Enter to show the detailed update plan...",
+          );
 
           const detailed = yield* Effect.tryPromise(() =>
             runCli(cli, runtime, ["plan", "--detailed"], "updated", verbose),
@@ -114,6 +123,10 @@ function runLifecycle(verbose: boolean) {
             console.log(
               "✔ compact and detailed plans verified for 20 resources",
             ),
+          );
+          yield* pauseForReview(
+            verbose,
+            "Press Enter to remove the temporary state and exit...",
           );
         }),
       (runtime) =>
@@ -129,6 +142,21 @@ function runLifecycle(verbose: boolean) {
     );
   });
 }
+
+const pauseForReview = (enabled: boolean, message: string) =>
+  enabled
+    ? Effect.promise(async () => {
+        const readline = createInterface({
+          input: process.stdin,
+          output: process.stdout,
+        });
+        try {
+          await readline.question(`\n${message}`);
+        } finally {
+          readline.close();
+        }
+      })
+    : Effect.void;
 
 async function runCli(
   cli: string,

--- a/packages/alchemy/test/Cli/NamespaceTree.test.ts
+++ b/packages/alchemy/test/Cli/NamespaceTree.test.ts
@@ -1,0 +1,63 @@
+import { buildNamespaceTree, flattenTree } from "@/Cli/NamespaceTree.ts";
+import { describe, expect, test } from "alchemy-test";
+import { createNode, replaceNode, updateNode } from "./PlanTestNodes.ts";
+
+describe("NamespaceTree property changes", () => {
+  test("does not attach property changes in compact mode", () => {
+    const resource = updateNode(
+      { config: { retries: 2 } },
+      { config: { retries: 3 } },
+      "Api",
+    );
+
+    const item = flattenTree(buildNamespaceTree([resource])).find(
+      (item) => item.type === "resource",
+    );
+    expect(item?.propertyChanges).toBeUndefined();
+  });
+
+  test("carries update property changes into the flattened TUI model", () => {
+    const resource = updateNode(
+      { config: { retries: 2 } },
+      { config: { retries: 3 } },
+      "Api",
+    );
+
+    const item = flattenTree(buildNamespaceTree([resource]), {
+      includePropertyChanges: true,
+    }).find((item) => item.type === "resource");
+    expect(item?.propertyChanges).toEqual([
+      {
+        kind: "update",
+        path: "config.retries",
+        before: { kind: "literal", value: 2 },
+        after: { kind: "literal", value: 3 },
+      },
+    ]);
+  });
+
+  test("carries declared create properties into the flattened TUI model", () => {
+    const resource = createNode({ config: { region: "eu-central-1" } }, "Api");
+
+    const item = flattenTree(buildNamespaceTree([resource]), {
+      includePropertyChanges: true,
+    }).find((item) => item.type === "resource");
+    expect(item?.propertyChanges).toEqual([
+      {
+        kind: "add",
+        path: "config.region",
+        before: undefined,
+        after: { kind: "literal", value: "eu-central-1" },
+      },
+    ]);
+  });
+
+  test("carries an empty detailed diff for non-property replacements", () => {
+    const resource = replaceNode({ name: "same" }, { name: "same" });
+
+    const item = flattenTree(buildNamespaceTree([resource]), {
+      includePropertyChanges: true,
+    }).find((item) => item.type === "resource");
+    expect(item?.propertyChanges).toEqual([]);
+  });
+});

--- a/packages/alchemy/test/Cli/PlanTestNodes.ts
+++ b/packages/alchemy/test/Cli/PlanTestNodes.ts
@@ -1,0 +1,102 @@
+import type { Apply, Create, Delete, Plan, Replace, Update } from "@/Plan.ts";
+import type { ProviderService } from "@/Provider.ts";
+import type { ResourceLike } from "@/Resource.ts";
+import type { CreatedResourceState } from "@/State/index.ts";
+import * as Effect from "effect/Effect";
+
+const provider: ProviderService<ResourceLike> = {
+  list: () => Effect.succeed([]),
+  reconcile: () => Effect.succeed({}),
+  delete: () => Effect.void,
+};
+
+const resource = (id: string, props: object): ResourceLike => ({
+  Namespace: undefined,
+  FQN: id,
+  Type: "Test.Resource",
+  LogicalId: id,
+  Props: props,
+  RemovalPolicy: "destroy",
+  Adopt: undefined,
+  Mode: undefined,
+  RequiresImplementation: undefined,
+  FormerFqns: undefined,
+  Attributes: {},
+  Binding: undefined,
+  Providers: undefined,
+});
+
+const state = (id: string, props: object): CreatedResourceState => ({
+  resourceType: "Test.Resource",
+  namespace: undefined,
+  fqn: id,
+  logicalId: id,
+  instanceId: `test-${id}`,
+  providerVersion: 0,
+  status: "created",
+  downstream: [],
+  bindings: [],
+  props,
+  attr: {},
+  removalPolicy: "destroy",
+});
+
+const baseNode = (id: string, props: object) => ({
+  resource: resource(id, props),
+  provider,
+  mode: undefined,
+  downstream: [],
+  bindings: [],
+});
+
+export const updateNode = (
+  olds: object,
+  news: object,
+  id = "Worker",
+): Update => ({
+  ...baseNode(id, news),
+  action: "update",
+  props: news,
+  state: state(id, olds),
+});
+
+export const createNode = (props: object, id = "Worker"): Create => ({
+  ...baseNode(id, props),
+  action: "create",
+  props,
+  state: undefined,
+});
+
+export const replaceNode = (
+  olds: object,
+  news: object,
+  id = "Worker",
+): Replace => ({
+  ...baseNode(id, news),
+  action: "replace",
+  props: news,
+  state: state(id, olds),
+  deleteFirst: false,
+});
+
+export const deleteNode = (props: object, id = "Worker"): Delete => ({
+  ...baseNode(id, props),
+  action: "delete",
+  state: state(id, props),
+});
+
+export const planWith = (
+  resources: Apply[] = [],
+  deletions: Delete[] = [],
+): Plan<undefined> => ({
+  resources: Object.fromEntries(
+    resources.map((node) => [node.resource.FQN, node]),
+  ),
+  deletions: Object.fromEntries(
+    deletions.map((node) => [node.resource.FQN, node]),
+  ),
+  actions: {},
+  actionDeletions: {},
+  output: undefined,
+  cycleMembers: new Set<string>(),
+});

--- a/packages/alchemy/test/Cli/PropertyDiff.test.ts
+++ b/packages/alchemy/test/Cli/PropertyDiff.test.ts
@@ -1,0 +1,277 @@
+import {
+  diffDeclaredProperties,
+  formatPropertyValue,
+  type PropertyChange,
+} from "@/Cli/PropertyDiff.ts";
+import * as Output from "@/Output.ts";
+import { describe, expect, test } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import * as Redacted from "effect/Redacted";
+
+const concreteChanges = (changes: PropertyChange[]): PropertyChange[] =>
+  changes;
+
+describe("diffDeclaredProperties", () => {
+  const cases = [
+    {
+      name: "scalar update",
+      olds: { enabled: false },
+      news: { enabled: true },
+      expected: [{ kind: "update", path: "enabled" }],
+    },
+    {
+      name: "property create and delete",
+      olds: { removed: "old" },
+      news: { added: "new" },
+      expected: [
+        { kind: "add", path: "added" },
+        { kind: "remove", path: "removed" },
+      ],
+    },
+    {
+      name: "nested path",
+      olds: { server: { ports: [80, 443] } },
+      news: { server: { ports: [80, 8443] } },
+      expected: [{ kind: "update", path: "server.ports[1]" }],
+    },
+  ] as const;
+
+  for (const { name, olds, news, expected } of cases) {
+    test(name, () => {
+      expect(
+        concreteChanges(diffDeclaredProperties(olds, news)).map(
+          ({ kind, path }) => ({ kind, path }),
+        ),
+      ).toEqual(expected);
+    });
+  }
+
+  test("identical props return no changes", () => {
+    expect(
+      diffDeclaredProperties(
+        { nested: { value: 1 }, array: ["a", "b"] },
+        { array: ["a", "b"], nested: { value: 1 } },
+      ),
+    ).toEqual([]);
+  });
+
+  test("Redacted values never expose their contents", () => {
+    const changes = diffDeclaredProperties(
+      { token: Redacted.make("old-secret") },
+      { token: Redacted.make("new-secret") },
+    );
+    expect(changes).toEqual([
+      {
+        kind: "update",
+        path: "token",
+        before: { kind: "redacted" },
+        after: { kind: "redacted" },
+      },
+    ]);
+    const rendered = JSON.stringify(changes);
+    expect(rendered).not.toContain("old-secret");
+    expect(rendered).not.toContain("new-secret");
+  });
+
+  test("nested and unchanged Redacted values stay hidden", () => {
+    const unchanged = Redacted.make("unchanged-secret");
+    const changes = diffDeclaredProperties(
+      { auth: { tokens: [Redacted.make("old-nested-secret"), unchanged] } },
+      { auth: { tokens: [Redacted.make("new-nested-secret"), unchanged] } },
+    );
+    expect(changes).toEqual([
+      {
+        kind: "update",
+        path: "auth.tokens[0]",
+        before: { kind: "redacted" },
+        after: { kind: "redacted" },
+      },
+    ]);
+    expect(JSON.stringify(changes)).not.toMatch(
+      /nested-secret|unchanged-secret/,
+    );
+  });
+
+  test("Outputs are not evaluated and are marked known after apply", () => {
+    let evaluated = false;
+    const output = Output.fromEffect(
+      Effect.sync(() => {
+        evaluated = true;
+        return "resolved";
+      }),
+    );
+    const changes = diffDeclaredProperties(
+      { endpoint: "https://old.example.com" },
+      { endpoint: output },
+    );
+    expect(evaluated).toBe(false);
+    expect(changes).toEqual([
+      {
+        kind: "update",
+        path: "endpoint",
+        before: { kind: "literal", value: "https://old.example.com" },
+        after: { kind: "known-after-apply" },
+      },
+    ]);
+  });
+
+  test("Effects are not executed and are marked computed", () => {
+    let executed = false;
+    const effect = Effect.sync(() => {
+      executed = true;
+      return "computed";
+    });
+    const changes = diffDeclaredProperties({}, { handler: effect });
+    expect(executed).toBe(false);
+    expect(changes).toEqual([
+      {
+        kind: "add",
+        path: "handler",
+        after: { kind: "computed" },
+      },
+    ]);
+  });
+
+  test("functions are not executed and are marked computed", () => {
+    let executed = false;
+    const fn = () => {
+      executed = true;
+      return "computed";
+    };
+    const changes = diffDeclaredProperties({}, { handler: fn });
+    expect(executed).toBe(false);
+    expect(changes).toEqual([
+      {
+        kind: "add",
+        path: "handler",
+        after: { kind: "computed" },
+      },
+    ]);
+  });
+
+  test("matches engine equality for omitted and undefined values", () => {
+    const hole = Array(1);
+    expect(diffDeclaredProperties({}, { value: undefined })).toEqual([]);
+    expect(diffDeclaredProperties({ value: undefined }, {})).toEqual([]);
+    expect(
+      diffDeclaredProperties({ values: hole }, { values: [undefined] }),
+    ).toEqual([]);
+    expect(
+      diffDeclaredProperties({ values: [] }, { values: [undefined] }),
+    ).toEqual([
+      {
+        kind: "add",
+        path: "values[0]",
+        after: { kind: "undefined" },
+      },
+    ]);
+  });
+
+  test("keeps an added container whose only child is undefined", () => {
+    expect(
+      diffDeclaredProperties({}, { settings: { value: undefined } }),
+    ).toEqual([
+      {
+        kind: "add",
+        path: "settings",
+        after: { kind: "collection", collection: "object" },
+      },
+    ]);
+  });
+
+  test("renders nullish and collection type changes explicitly", () => {
+    expect(
+      diffDeclaredProperties(
+        { optional: null, shape: "literal" },
+        { optional: undefined, shape: [] },
+      ),
+    ).toEqual([
+      {
+        kind: "update",
+        path: "optional",
+        before: { kind: "literal", value: null },
+        after: { kind: "undefined" },
+      },
+      {
+        kind: "update",
+        path: "shape",
+        before: { kind: "literal", value: "literal" },
+        after: { kind: "collection", collection: "array" },
+      },
+    ]);
+  });
+
+  test("compares bigint leaves without throwing", () => {
+    expect(diffDeclaredProperties({ size: 1n }, { size: 2n })).toEqual([
+      {
+        kind: "update",
+        path: "size",
+        before: { kind: "opaque" },
+        after: { kind: "opaque" },
+      },
+    ]);
+    expect(diffDeclaredProperties({ size: 1n }, { size: 1n })).toEqual([]);
+  });
+
+  test("documents array insertions as index changes", () => {
+    expect(
+      concreteChanges(
+        diffDeclaredProperties(
+          { regions: ["fra", "iad"] },
+          { regions: ["lhr", "fra", "iad"] },
+        ),
+      ).map(({ kind, path }) => ({ kind, path })),
+    ).toEqual([
+      { kind: "update", path: "regions[0]" },
+      { kind: "update", path: "regions[1]" },
+      { kind: "add", path: "regions[2]" },
+    ]);
+  });
+
+  test("sorts object paths deterministically", () => {
+    const paths = concreteChanges(
+      diffDeclaredProperties({}, { zebra: 1, alpha: 2, middle: 3 }),
+    ).map((change) => change.path);
+    expect(paths).toEqual(["alpha", "middle", "zebra"]);
+  });
+
+  test("returns every declared change without a count cap", () => {
+    const news = Object.fromEntries(
+      Array.from({ length: 105 }, (_, index) => [
+        `property${String(index).padStart(3, "0")}`,
+        index,
+      ]),
+    );
+    const changes = diffDeclaredProperties({}, news);
+    expect(changes).toHaveLength(105);
+    expect(changes[104].path).toBe("property104");
+  });
+
+  test("truncates long display values", () => {
+    const [change] = diffDeclaredProperties(
+      { value: "short" },
+      { value: "abcdefgh" },
+      { maxValueLength: 4 },
+    );
+    expect(change.kind).toBe("update");
+    if (change.kind !== "update") return;
+    expect(change.after).toEqual({
+      kind: "literal",
+      value: "abcd",
+      truncated: true,
+    });
+    expect(formatPropertyValue(change.after!)).toBe('"abcd"…');
+  });
+
+  test("terminates on cyclic plain data", () => {
+    const oldValue: Record<string, unknown> = { name: "old" };
+    const newValue: Record<string, unknown> = { name: "new" };
+    oldValue.self = oldValue;
+    newValue.self = newValue;
+    expect(
+      concreteChanges(
+        diffDeclaredProperties({ value: oldValue }, { value: newValue }),
+      ).map((change) => change.path),
+    ).toEqual(["value.name"]);
+  });
+});

--- a/website/src/content/docs/cli/deploy.mdx
+++ b/website/src/content/docs/cli/deploy.mdx
@@ -45,20 +45,25 @@ When the plan contains no changes, the approval prompt is skipped automatically.
 
 ## Flags
 
-| Option              | Description                                                                                                                |
-| ------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `[file]`            | Stack file to deploy (defaults to `alchemy.run.ts`)                                                                        |
-| `--stage <name>`    | Stage to deploy to (defaults to `dev_$USER`)                                                                               |
-| `--yes`             | Skip the approval prompt                                                                                                   |
-| `--dry-run`         | Show the plan without applying (same as `alchemy plan`)                                                                    |
-| `--force`           | Force updates for resources that would otherwise no-op                                                                     |
+| Option              | Description                                                                                                                            |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `[file]`            | Stack file to deploy (defaults to `alchemy.run.ts`)                                                                                    |
+| `--stage <name>`    | Stage to deploy to (defaults to `dev_$USER`)                                                                                           |
+| `--yes`             | Skip the approval prompt                                                                                                               |
+| `--dry-run`         | Show the plan without applying (same as `alchemy plan`)                                                                                |
+| `--detailed`        | Show declared property changes in the plan                                                                                             |
+| `--force`           | Force updates for resources that would otherwise no-op                                                                                 |
 | `--adopt`           | Adopt pre-existing cloud resources that conflict with this stack instead of failing. Useful for re-importing into a fresh state store. |
-| `--profile <name>`  | Auth profile to use (defaults to `default` or `$ALCHEMY_PROFILE`)                                                          |
-| `--env-file <path>` | Load environment variables from a file                                                                                     |
+| `--profile <name>`  | Auth profile to use (defaults to `default` or `$ALCHEMY_PROFILE`)                                                                      |
+| `--env-file <path>` | Load environment variables from a file                                                                                                 |
 
 How `--adopt` decides what to take over is covered in [Adopting Resources](/cli/adopting-resources).
 
 `--dry-run` runs the exact same code path as [`alchemy plan`](/cli/plan) — see that page for the plan output format.
+
+`--detailed` shows desired declared properties for creates and declared changes
+for updates and replacements. It works with the approval prompt, `--yes`, and
+`--dry-run`.
 
 ## Examples
 
@@ -74,6 +79,9 @@ alchemy deploy stacks/github.ts
 
 # Preview what would change
 alchemy deploy --dry-run
+
+# Show property changes before approving the deploy
+alchemy deploy --detailed
 
 # Re-import existing cloud resources into a fresh state store
 alchemy deploy --adopt

--- a/website/src/content/docs/cli/plan.mdx
+++ b/website/src/content/docs/cli/plan.mdx
@@ -20,6 +20,38 @@ The plan uses `+` for creates, `~` for updates, `-` for deletes,
 and `•` for no-ops. No approval prompt is shown and no changes are
 made.
 
+## Detailed property changes
+
+Pass `--detailed` to show declared properties for creates and declared property
+changes for updates and replacements:
+
+```sh
+alchemy plan --detailed
+```
+
+<Terminal content={`[u]Plan[/u]: [g]1 to create[/g], [y]2 to update[/y]
+
+[g]+[/g] [b]EventsQueue[/b] [d](AWS.SQS.Queue)[/d]
+[s2][g]+[/g] [b]fifo[/b]  [g]true[/g]
+[s2][g]+[/g] [b]visibilityTimeout[/b]  [g]"30 seconds"[/g]
+
+[y]~[/y] [b]OrderHandler[/b] [d](AWS.Lambda.Function)[/d]
+[s2][y]~[/y] [b]memorySize[/b]  [r]512[/r] → [g]1024[/g]
+[s2][y]~[/y] [b]env.QUEUE_URL[/b]  [r]"https://sqs.../old-events"[/r] → [c](known after apply)[/c]
+[s2][y]~[/y] [b]env.API_TOKEN[/b]  [d](redacted)[/d] → [d](redacted)[/d]
+
+[y]~[/y] [b]ProductionDatabase[/b] [d](AWS.RDS.DBInstance)[/d]
+[s2][y]~[/y] [b]engineVersion[/b]  [r]"15.7"[/r] → [g]"16.3"[/g]
+[s2][y]~[/y] [b]dbInstanceClass[/b]  [r]"db.t4g.medium"[/r] → [g]"db.r7g.large"[/g]
+[s2][y]~[/y] [b]multiAZ[/b]  [r]false[/r] → [g]true[/g]`} />
+
+For creates, the indented lines show the desired declared input properties. For
+updates and replacements, they compare previously persisted declared input
+properties with the currently desired ones. They are not a live-cloud drift
+diff; no cloud values are fetched for these property lines. Unknown outputs are
+shown as `(known after apply)`, computed values are shown as `(computed)`, and
+secrets remain redacted. Deletes stay compact.
+
 ## Flags
 
 | Option              | Description                                                       |
@@ -28,6 +60,7 @@ made.
 | `--stage <name>`    | Stage to plan against (defaults to `dev_$USER`)                   |
 | `--profile <name>`  | Auth profile to use (defaults to `default` or `$ALCHEMY_PROFILE`) |
 | `--env-file <path>` | Load environment variables from a file                            |
+| `--detailed`        | Show declared properties for creates, updates, and replacements   |
 
 ## Where next
 


### PR DESCRIPTION
> [!NOTE]
> This needs to be changed after PR #1235 to add on to the CLI overhaul from Blank. I dont know what/if you guys are planning everything else in the property diff direction that does not comply with my proposal. This is just how I thought it could fit in :)  

### Reason I would like this to be added

We want to migrate to alchemy from using Terraform and we like seeing the planned changes more detailed.

### What changes

This adds an opt-in `--detailed` view to `alchemy plan` and `alchemy deploy`:

```sh
alchemy plan --detailed
alchemy deploy --detailed
```

The default output stays compact:

<img width="980" height="744" alt="plan-compact-default" src="https://github.com/user-attachments/assets/b1c3a000-a0b5-428f-b611-a9c1a889bf94" />

With `--detailed`, the same plan includes the declared property changes:

<img width="1112" height="1440" alt="plan-detailed-update" src="https://github.com/user-attachments/assets/df35efa8-b302-48f8-8c10-d158fd9aee6a" />

### Why a flag

Basically everything stays the same, except the user wants to opt in into more detailed output.

### What the detailed view shows

- creates show the inputs declared in the stack
- updates and replacements show additions, removals, and changed values
- deletes stay compact

The diff compares persisted `state.props` with the desired `props` already in the plan. It explains changes to declared inputs, not live cloud drift.

The Logging CLI and Ink UI share one structured `PropertyChange` result. Paths are sorted, arrays are compared by index, and rendering never evaluates a value:

- secrets stay `(redacted)`
- Outputs become `(known after apply)`
- raw Effects and functions become `(computed)`

I tried aligned tables, fixed columns, and always-stacked values along the way. Inline `old → new` rows were the easiest to scan at normal widths, with a stacked before/after layout only when the terminal gets narrow.

### Create previews

Detailed creates show every declared input already present in the plan, including unresolved inputs represented as Outputs.

They cannot list future provider-generated fields such as an ARN, queue URL, or database endpoint. Those values are not in `props` yet, so the preview shows what Alchemy actually knows instead of guessing the rest. 

Supporting a Terraform-style list of future computed fields would need a separate provider preview contract as far as I understood the that part of the repo.

<img width="980" height="1034" alt="plan-detailed-create" src="https://github.com/user-attachments/assets/23c15a7e-2fb5-4d17-8e0f-84efc27c1427" />


### Try it locally (that test was primarily for local development to test different look and feels; idk if that should be merged tbh)
The test deploys a stack (against not real cloud, just the state will be created) with detailed deploy, then plans an normal update in step 2 and then plans a detailed update in step 3 so you can see these 3 versions.

```sh
cd packages/alchemy
bun test/Cli/MultiCloudPlanPropertyDiff.test.ts --verbose
```

### More examples

Redacted and deferred values:

<img width="980" height="1440" alt="plan-detailed-security-deferred" src="https://github.com/user-attachments/assets/00fbde5b-ba78-4fd0-9caf-f32cee55e102" />

At narrower widths, before and after values move onto separate lines:

<img width="980" height="1005" alt="plan-detailed-update-narrow" src="https://github.com/user-attachments/assets/d24580ad-e712-4041-afa3-1ea472f23de0" />
<img width="980" height="628" alt="plan-detailed-output-narrow" src="https://github.com/user-attachments/assets/fc438ff7-7657-4925-8aed-67533aac07d7" />

`alchemy deploy --detailed` shows the same preview before the existing approval prompt. The flag changes the preview, not the deploy flow.

<img width="980" height="715" alt="deploy-detailed-approval" src="https://github.com/user-attachments/assets/ef27e12e-818f-4b20-b901-f6f7852f983f" />


