### PR TITLE
feat(state): target a different account than the stack deploys into

### DIFF
--- a/packages/alchemy/src/AWS/Credentials.ts
+++ b/packages/alchemy/src/AWS/Credentials.ts
@@ -12,7 +12,10 @@ import * as Ref from "effect/Ref";
 import * as Schedule from "effect/Schedule";
 import * as Semaphore from "effect/Semaphore";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
-import { AWSEnvironment } from "./Environment.ts";
+import {
+  AWSEnvironment,
+  Default as DefaultEnvironment,
+} from "./Environment.ts";
 
 /**
  * Refresh assumed-role credentials this long before they actually expire, so a
@@ -199,3 +202,60 @@ export const fromAssumeRole = (options: {
       region: options.region,
     }),
   );
+
+/**
+ * An {@link AWSEnvironment} for another account, reached by assuming a role
+ * from the account the active Alchemy profile resolves to.
+ *
+ * Built for the cross-account state store — `AWS.state({ environment })`
+ * derives its credentials, region and endpoint from the environment it is
+ * given — but it is a plain `AWSEnvironment` layer and works anywhere one
+ * is accepted.
+ *
+ * The profile's credentials sign the `AssumeRole` call; the returned
+ * temporary credentials are cached and single-flighted until shortly
+ * before they expire (see {@link makeAssumeRoleResolver}).
+ *
+ * ```typescript
+ * AWS.state({
+ *   bucketName: "my-org-alchemy-state",
+ *   environment: AWS.assumeRoleEnvironment({
+ *     roleArn: "arn:aws:iam::111122223333:role/AlchemyState",
+ *     accountId: "111122223333",
+ *     region: "us-east-1",
+ *   }),
+ * })
+ * ```
+ */
+export const assumeRoleEnvironment = (options: {
+  /** ARN of the IAM Role to assume, in the target account. */
+  readonly roleArn: string;
+  /** Account the role lives in — reported as the environment's account. */
+  readonly accountId: string;
+  /** Region every API call made against this environment targets. */
+  readonly region: string;
+  /** STS role session name. @default "alchemy-state" */
+  readonly roleSessionName?: string;
+}) =>
+  Layer.effect(
+    AWSEnvironment,
+    Effect.gen(function* () {
+      // The surrounding (profile) environment supplies the long-lived
+      // credentials that sign `AssumeRole`.
+      const base = yield* AWSEnvironment;
+      const credentials = yield* makeAssumeRoleResolver({
+        roleArn: Effect.succeed(options.roleArn),
+        base: Layer.succeed(
+          Credentials,
+          Effect.flatMap(base, (env) => env.credentials),
+        ),
+        roleSessionName: options.roleSessionName ?? "alchemy-state",
+        region: options.region,
+      });
+      return Effect.succeed({
+        accountId: options.accountId,
+        region: options.region,
+        credentials,
+      });
+    }),
+  ).pipe(Layer.provide(DefaultEnvironment), Layer.orDie);

--- a/packages/alchemy/src/AWS/StateStore/State.ts
+++ b/packages/alchemy/src/AWS/StateStore/State.ts
@@ -3,6 +3,7 @@ import type { Region } from "@distilled.cloud/aws/Region";
 import * as s3 from "@distilled.cloud/aws/s3";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
 import type { HttpClient } from "effect/unstable/http/HttpClient";
@@ -62,38 +63,7 @@ export interface S3StateOptions {
    * @default `{ sseAlgorithm: "AES256" }`
    */
   encryption?: BucketEncryption;
-  /**
-   * AWS environment (account, region, credentials) that owns the state
-   * bucket. Everything the store talks to S3 with — credentials, region
-   * and endpoint — is derived from it.
-   *
-   * Defaults to the environment resolved from the active Alchemy profile,
-   * i.e. the same account the stack's resources deploy into. Pass a
-   * different environment to keep state in a separate account:
-   *
-   * ```typescript
-   * AWS.state({
-   *   bucketName: "my-org-alchemy-state",
-   *   environment: AWS.assumeRoleEnvironment({
-   *     roleArn: "arn:aws:iam::111122223333:role/AlchemyState",
-   *     accountId: "111122223333",
-   *     region: "us-east-1",
-   *   }),
-   * })
-   * ```
-   *
-   * The environment is provided privately to the state store, so a
-   * state-account environment never reaches the stack's providers.
-   */
-  environment?: AWSStateEnvironment;
 }
-
-/**
- * Layer shape accepted by {@link S3StateOptions.environment} — anything
- * that provides an {@link AWSEnvironment} out of the services a stack
- * already has.
- */
-export type AWSStateEnvironment = typeof DefaultEnvironment;
 
 /** Context required by the distilled S3 operations. */
 type S3Deps = Credentials | HttpClient | Region;
@@ -157,9 +127,11 @@ type S3Deps = Credentials | HttpClient | Region;
  * ```
  *
  * ### Keeping state in a different account
- * Pass an `environment` to store state in an account other than the one
- * the stack deploys into. Credentials, region and endpoint are all
- * derived from it, and it stays private to the state store.
+ * The store uses an {@link AWSEnvironment} from the surrounding context
+ * when one is provided, and falls back to the active Alchemy profile's
+ * environment otherwise. Pipe one in to keep state in another account —
+ * credentials, region and endpoint are all derived from it, so the
+ * environment is the only thing to provide.
  *
  * **Example:** State bucket in a dedicated account
  * ```typescript
@@ -167,14 +139,15 @@ type S3Deps = Credentials | HttpClient | Region;
  *   "my-stack",
  *   {
  *     providers: AWS.providers(),
- *     state: AWS.state({
- *       bucketName: "my-org-alchemy-state",
- *       environment: AWS.assumeRoleEnvironment({
- *         roleArn: "arn:aws:iam::111122223333:role/AlchemyState",
- *         accountId: "111122223333",
- *         region: "us-east-1",
- *       }),
- *     }),
+ *     state: AWS.state({ bucketName: "my-org-alchemy-state" }).pipe(
+ *       Layer.provide(
+ *         AWS.assumeRoleEnvironment({
+ *           roleArn: "arn:aws:iam::111122223333:role/AlchemyState",
+ *           accountId: "111122223333",
+ *           region: "us-east-1",
+ *         }),
+ *       ),
+ *     ),
  *   },
  *   Effect.gen(function* () {
  *     // ...
@@ -186,23 +159,40 @@ type S3Deps = Credentials | HttpClient | Region;
  */
 export const state = (options: S3StateOptions = {}) =>
   s3State(options).pipe(
-    // `provide`, NOT `provideMerge`: the stack composes
-    // `providers.pipe(Layer.provideMerge(state))`, so anything merged here
-    // lands in the providers' build context. A custom (e.g. cross-account)
-    // environment leaking out that way would silently redirect every
-    // resource in the stack to the state account.
-    Layer.provide(options.environment ?? DefaultEnvironment),
+    Layer.provide(EnvironmentOrDefault),
     Layer.provideMerge(AwsAuth),
     Layer.provideMerge(CredentialsStoreLive),
     Layer.orDie,
   );
 
 /**
- * The S3 state store with its {@link AWSEnvironment} left **open**.
+ * The {@link AWSEnvironment} the state store runs against: whatever the
+ * surrounding context provides, or the profile-derived default.
  *
- * {@link state} is this layer with the profile-derived environment
- * provided; use this directly when you want to supply the environment
- * yourself and keep full control of how it is built:
+ * `Effect.serviceOption` does not contribute to the layer's requirements,
+ * so {@link state} still satisfies the stack's `state` slot
+ * (`Layer<State, never, StackServices>`) while remaining pipe-able:
+ * `AWS.state().pipe(Layer.provide(myEnvironment))` builds `myEnvironment`
+ * into this layer's context, where the lookup finds it.
+ *
+ * Nothing is *merged* out either way — the environment stays private to
+ * the store, so an account meant for state never reaches the stack's
+ * providers.
+ */
+const EnvironmentOrDefault = Layer.unwrap(
+  Effect.map(Effect.serviceOption(AWSEnvironment), (environment) =>
+    Option.match(environment, {
+      onNone: () => DefaultEnvironment,
+      onSome: (env) => Layer.succeed(AWSEnvironment, env),
+    }),
+  ),
+);
+
+/**
+ * The S3 state store with its {@link AWSEnvironment} left **required**
+ * rather than optional — the same store as {@link state}, minus the
+ * profile fallback, for callers who want the type to demand an
+ * environment instead of silently defaulting.
  *
  * ```typescript
  * AWS.s3State({ bucketName: "my-org-alchemy-state" }).pipe(

--- a/packages/alchemy/src/AWS/StateStore/State.ts
+++ b/packages/alchemy/src/AWS/StateStore/State.ts
@@ -62,7 +62,38 @@ export interface S3StateOptions {
    * @default `{ sseAlgorithm: "AES256" }`
    */
   encryption?: BucketEncryption;
+  /**
+   * AWS environment (account, region, credentials) that owns the state
+   * bucket. Everything the store talks to S3 with — credentials, region
+   * and endpoint — is derived from it.
+   *
+   * Defaults to the environment resolved from the active Alchemy profile,
+   * i.e. the same account the stack's resources deploy into. Pass a
+   * different environment to keep state in a separate account:
+   *
+   * ```typescript
+   * AWS.state({
+   *   bucketName: "my-org-alchemy-state",
+   *   environment: AWS.assumeRoleEnvironment({
+   *     roleArn: "arn:aws:iam::111122223333:role/AlchemyState",
+   *     accountId: "111122223333",
+   *     region: "us-east-1",
+   *   }),
+   * })
+   * ```
+   *
+   * The environment is provided privately to the state store, so a
+   * state-account environment never reaches the stack's providers.
+   */
+  environment?: AWSStateEnvironment;
 }
+
+/**
+ * Layer shape accepted by {@link S3StateOptions.environment} — anything
+ * that provides an {@link AWSEnvironment} out of the services a stack
+ * already has.
+ */
+export type AWSStateEnvironment = typeof DefaultEnvironment;
 
 /** Context required by the distilled S3 operations. */
 type S3Deps = Credentials | HttpClient | Region;
@@ -125,9 +156,65 @@ type S3Deps = Credentials | HttpClient | Region;
  * );
  * ```
  *
+ * ### Keeping state in a different account
+ * Pass an `environment` to store state in an account other than the one
+ * the stack deploys into. Credentials, region and endpoint are all
+ * derived from it, and it stays private to the state store.
+ *
+ * **Example:** State bucket in a dedicated account
+ * ```typescript
+ * const Stack = Alchemy.Stack(
+ *   "my-stack",
+ *   {
+ *     providers: AWS.providers(),
+ *     state: AWS.state({
+ *       bucketName: "my-org-alchemy-state",
+ *       environment: AWS.assumeRoleEnvironment({
+ *         roleArn: "arn:aws:iam::111122223333:role/AlchemyState",
+ *         accountId: "111122223333",
+ *         region: "us-east-1",
+ *       }),
+ *     }),
+ *   },
+ *   Effect.gen(function* () {
+ *     // ...
+ *   }),
+ * );
+ * ```
+ *
  * @resource
  */
 export const state = (options: S3StateOptions = {}) =>
+  s3State(options).pipe(
+    // `provide`, NOT `provideMerge`: the stack composes
+    // `providers.pipe(Layer.provideMerge(state))`, so anything merged here
+    // lands in the providers' build context. A custom (e.g. cross-account)
+    // environment leaking out that way would silently redirect every
+    // resource in the stack to the state account.
+    Layer.provide(options.environment ?? DefaultEnvironment),
+    Layer.provideMerge(AwsAuth),
+    Layer.provideMerge(CredentialsStoreLive),
+    Layer.orDie,
+  );
+
+/**
+ * The S3 state store with its {@link AWSEnvironment} left **open**.
+ *
+ * {@link state} is this layer with the profile-derived environment
+ * provided; use this directly when you want to supply the environment
+ * yourself and keep full control of how it is built:
+ *
+ * ```typescript
+ * AWS.s3State({ bucketName: "my-org-alchemy-state" }).pipe(
+ *   Layer.provide(myEnvironment),
+ *   Layer.orDie,
+ * )
+ * ```
+ *
+ * `Region`, `Credentials` and `Endpoint` are derived from the environment
+ * internally, so an environment layer is the only thing to provide.
+ */
+export const s3State = (options: S3StateOptions = {}) =>
   Layer.effect(
     State,
     Effect.gen(function* () {
@@ -142,13 +229,9 @@ export const state = (options: S3StateOptions = {}) =>
       return yield* Effect.cached(make);
     }),
   ).pipe(
-    Layer.provideMerge(AwsRegion.fromEnvironment),
-    Layer.provideMerge(AwsCredentials.fromEnvironment),
-    Layer.provideMerge(Endpoint.fromEnvironment),
-    Layer.provideMerge(DefaultEnvironment),
-    Layer.provideMerge(AwsAuth),
-    Layer.provideMerge(CredentialsStoreLive),
-    Layer.orDie,
+    Layer.provide(AwsRegion.fromEnvironment),
+    Layer.provide(AwsCredentials.fromEnvironment),
+    Layer.provide(Endpoint.fromEnvironment),
   );
 
 /**

--- a/packages/alchemy/src/AWS/index.ts
+++ b/packages/alchemy/src/AWS/index.ts
@@ -1,6 +1,13 @@
 export * from "./Arn.ts";
 export * from "./Assets.ts";
 export * from "./Bootstrap.ts";
+// Credential *constructors* only — the module's `Credentials` re-export
+// would collide with the service tag exported by the provider barrel.
+export {
+  assumeRoleEnvironment,
+  fromAssumeRole,
+  makeAssumeRoleResolver,
+} from "./Credentials.ts";
 export * from "./Environment.ts";
 export * from "./Providers.ts";
 export * from "./StateStore/index.ts";

--- a/packages/alchemy/src/Cloudflare/CloudflareEnvironment.ts
+++ b/packages/alchemy/src/Cloudflare/CloudflareEnvironment.ts
@@ -3,6 +3,7 @@ import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as Redacted from "effect/Redacted";
 import { getAuthProvider } from "../Auth/AuthProvider.ts";
 import { ALCHEMY_PROFILE, AlchemyProfile } from "../Auth/Profile.ts";
 import {
@@ -29,6 +30,32 @@ export const fromEnv = () =>
         Config.map(Option.getOrUndefined),
       );
       return { account: accountId } as any;
+    }),
+  );
+
+/**
+ * A fixed environment for an explicit account + API token, bypassing the
+ * Alchemy profile entirely.
+ *
+ * Used to point part of a stack at a different Cloudflare account than the
+ * one it deploys into — most commonly a dedicated state-store account via
+ * `Cloudflare.state({ accountId, apiToken })`. Pair it with a matching
+ * `Credentials` layer (`Credentials.fromApiToken`): the account and the
+ * token that can authenticate against it always travel together.
+ */
+export const ofApiToken = (options: {
+  readonly accountId: string;
+  readonly apiToken: string | Redacted.Redacted<string>;
+}) =>
+  Layer.succeed(
+    CloudflareEnvironment,
+    Effect.succeed<CloudflareResolvedCredentials>({
+      type: "apiToken",
+      apiToken: Redacted.isRedacted(options.apiToken)
+        ? options.apiToken
+        : Redacted.make(options.apiToken),
+      accountId: options.accountId,
+      source: { type: "env", details: "explicit apiToken" },
     }),
   );
 

--- a/packages/alchemy/src/Cloudflare/Credentials.ts
+++ b/packages/alchemy/src/Cloudflare/Credentials.ts
@@ -20,7 +20,11 @@ import {
   type CloudflareResolvedCredentials,
 } from "./Auth/AuthProvider.ts";
 
-export { Credentials, fromEnv } from "@distilled.cloud/cloudflare/Credentials";
+export {
+  Credentials,
+  fromApiToken,
+  fromEnv,
+} from "@distilled.cloud/cloudflare/Credentials";
 
 declare module "@distilled.cloud/cloudflare/Credentials" {
   interface Credentials {

--- a/packages/alchemy/src/Cloudflare/Providers.ts
+++ b/packages/alchemy/src/Cloudflare/Providers.ts
@@ -1,5 +1,6 @@
 import { Retry } from "@distilled.cloud/cloudflare";
 import * as Layer from "effect/Layer";
+import * as Redacted from "effect/Redacted";
 import { CredentialsStoreLive } from "../Auth/Credentials.ts";
 import { ProfileLive } from "../Auth/Profile.ts";
 import * as Command from "../Command/index.ts";
@@ -134,8 +135,11 @@ export type ProviderRequirements = Layer.Services<ReturnType<typeof providers>>;
 
 /**
  * Cloudflare providers, bindings, and credentials for Worker-based stacks.
+ *
+ * `options` selects the account and credentials every provider operation
+ * runs against; omitted, they come from the active Alchemy profile.
  */
-export const providers = () =>
+export const providers = (options: CloudflareApiOptions = {}) =>
   Layer.effect(
     Providers,
     Provider.collection([
@@ -684,9 +688,34 @@ export const providers = () =>
     // local provider composes it into its `ProviderLayer.dual` local thunk,
     // so workerd machinery only builds when a local variant is actually
     // demanded (dev runs, or deleting a local-mode row during deploy).
-    Layer.provideMerge(CloudflareApiLive()),
+    Layer.provideMerge(CloudflareApiLive(options)),
     Layer.orDie,
   );
+
+/**
+ * Which Cloudflare account an effect tree talks to, and how it
+ * authenticates. Defaults everywhere to the active Alchemy profile.
+ *
+ * Accepted by {@link providers} and by the Cloudflare state store, so a
+ * stack can deploy into one account while its state lives in another.
+ */
+export interface CloudflareApiOptions {
+  /**
+   * Cloudflare account every API call targets. Pair it with `apiToken`;
+   * on its own it is ignored, because a token minted for another account
+   * cannot authenticate against it.
+   */
+  readonly accountId?: string;
+  /**
+   * API token to authenticate with, instead of the active Alchemy
+   * profile's credentials.
+   */
+  readonly apiToken?: string | Redacted.Redacted<string>;
+  /** Full override of the credentials layer. Wins over `apiToken`. */
+  readonly credentials?: Layer.Layer<Credentials.Credentials>;
+  /** Full override of the account environment. Wins over `accountId`. */
+  readonly environment?: Layer.Layer<CloudflareEnvironment.CloudflareEnvironment>;
+}
 
 /**
  * The foundation every effect tree that talks to the Cloudflare API
@@ -710,10 +739,35 @@ export const providers = () =>
  * under load) are now tagged retryable at the source in the SDK's
  * global error map, so `makeDefault`'s transient detection covers
  * them.
+ *
+ * Both halves that decide *which account* is talked to — the credentials
+ * and the account environment — are overridable, which is how the state
+ * store is pointed at an account other than the one a stack deploys into
+ * (see {@link ../Cloudflare/StateStore/State.ts state}). Unlike AWS, a
+ * Cloudflare account and its API token are resolved independently, so
+ * both must be replaced together; passing `accountId` + `apiToken` does
+ * that in one step.
  */
-export const CloudflareApiLive = () =>
-  Credentials.fromAuthProvider().pipe(
-    Layer.provideMerge(CloudflareEnvironment.fromProfile()),
+export const CloudflareApiLive = (options: CloudflareApiOptions = {}) =>
+  (
+    options.credentials ??
+    (options.apiToken !== undefined
+      ? Credentials.fromApiToken({
+          apiToken: Redacted.isRedacted(options.apiToken)
+            ? Redacted.value(options.apiToken)
+            : options.apiToken,
+        })
+      : Credentials.fromAuthProvider())
+  ).pipe(
+    Layer.provideMerge(
+      options.environment ??
+        (options.accountId !== undefined && options.apiToken !== undefined
+          ? CloudflareEnvironment.ofApiToken({
+              accountId: options.accountId,
+              apiToken: options.apiToken,
+            })
+          : CloudflareEnvironment.fromProfile()),
+    ),
     Layer.provideMerge(CloudflareAuth),
     Layer.provideMerge(Access.AccessLive),
     Layer.provideMerge(ProfileLive),

--- a/packages/alchemy/src/Cloudflare/Providers.ts
+++ b/packages/alchemy/src/Cloudflare/Providers.ts
@@ -1,5 +1,7 @@
 import { Retry } from "@distilled.cloud/cloudflare";
+import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import * as Redacted from "effect/Redacted";
 import { CredentialsStoreLive } from "../Auth/Credentials.ts";
 import { ProfileLive } from "../Auth/Profile.ts";
@@ -718,6 +720,55 @@ export interface CloudflareApiOptions {
 }
 
 /**
+ * Credentials for {@link CloudflareApiLive}: explicit options first, then
+ * whatever the surrounding context provides, then the Alchemy profile.
+ *
+ * The context lookup is `Effect.serviceOption`, so it adds nothing to the
+ * layer's requirements — `providers()` / `state()` keep their current
+ * types while becoming pipe-able.
+ */
+const credentialsFor = (options: CloudflareApiOptions) =>
+  options.credentials ??
+  (options.apiToken !== undefined
+    ? Credentials.fromApiToken({
+        apiToken: Redacted.isRedacted(options.apiToken)
+          ? Redacted.value(options.apiToken)
+          : options.apiToken,
+      })
+    : Layer.unwrap(
+        Effect.map(
+          Effect.serviceOption(Credentials.Credentials),
+          Option.match({
+            onNone: () => Credentials.fromAuthProvider(),
+            onSome: (credentials) =>
+              Layer.succeed(Credentials.Credentials, credentials),
+          }),
+        ),
+      ));
+
+/** The account half of {@link credentialsFor}, same precedence. */
+const environmentFor = (options: CloudflareApiOptions) =>
+  options.environment ??
+  (options.accountId !== undefined && options.apiToken !== undefined
+    ? CloudflareEnvironment.ofApiToken({
+        accountId: options.accountId,
+        apiToken: options.apiToken,
+      })
+    : Layer.unwrap(
+        Effect.map(
+          Effect.serviceOption(CloudflareEnvironment.CloudflareEnvironment),
+          Option.match({
+            onNone: () => CloudflareEnvironment.fromProfile(),
+            onSome: (environment) =>
+              Layer.succeed(
+                CloudflareEnvironment.CloudflareEnvironment,
+                environment,
+              ),
+          }),
+        ),
+      ));
+
+/**
  * The foundation every effect tree that talks to the Cloudflare API
  * shares — credentials resolved through the Alchemy auth provider,
  * account environment, Access, profile + credential store — plus a
@@ -741,33 +792,23 @@ export interface CloudflareApiOptions {
  * them.
  *
  * Both halves that decide *which account* is talked to — the credentials
- * and the account environment — are overridable, which is how the state
- * store is pointed at an account other than the one a stack deploys into
- * (see {@link ../Cloudflare/StateStore/State.ts state}). Unlike AWS, a
- * Cloudflare account and its API token are resolved independently, so
- * both must be replaced together; passing `accountId` + `apiToken` does
- * that in one step.
+ * and the account environment — fall back to the surrounding context
+ * before the profile, so piping either in redirects everything built on
+ * top of this foundation:
+ *
+ * ```typescript
+ * Cloudflare.state().pipe(
+ *   Layer.provide(Cloudflare.CloudflareApiLive({ accountId, apiToken })),
+ * )
+ * ```
+ *
+ * Unlike AWS, a Cloudflare account and the token that authenticates
+ * against it are resolved independently, so both have to be replaced
+ * together; `accountId` + `apiToken` does that in one step.
  */
 export const CloudflareApiLive = (options: CloudflareApiOptions = {}) =>
-  (
-    options.credentials ??
-    (options.apiToken !== undefined
-      ? Credentials.fromApiToken({
-          apiToken: Redacted.isRedacted(options.apiToken)
-            ? Redacted.value(options.apiToken)
-            : options.apiToken,
-        })
-      : Credentials.fromAuthProvider())
-  ).pipe(
-    Layer.provideMerge(
-      options.environment ??
-        (options.accountId !== undefined && options.apiToken !== undefined
-          ? CloudflareEnvironment.ofApiToken({
-              accountId: options.accountId,
-              apiToken: options.apiToken,
-            })
-          : CloudflareEnvironment.fromProfile()),
-    ),
+  credentialsFor(options).pipe(
+    Layer.provideMerge(environmentFor(options)),
     Layer.provideMerge(CloudflareAuth),
     Layer.provideMerge(Access.AccessLive),
     Layer.provideMerge(ProfileLive),

--- a/packages/alchemy/src/Cloudflare/StateStore/State.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/State.ts
@@ -54,28 +54,7 @@ import {
 
 const CI = Config.boolean("CI").pipe(Config.withDefault(false));
 
-export type CloudflareStateOptions = Cloudflare.CloudflareApiOptions;
-
-/**
- * State store backed by a Worker + Durable Object deployed to your
- * Cloudflare account.
- *
- * By default it uses the account the active Alchemy profile resolves to —
- * the same one `Cloudflare.providers()` deploys into. Pass `accountId` +
- * `apiToken` (or explicit `credentials` / `environment` layers) to keep
- * state in a different account:
- *
- * ```typescript
- * state: Cloudflare.state({
- *   accountId: process.env.STATE_CLOUDFLARE_ACCOUNT_ID!,
- *   apiToken: process.env.STATE_CLOUDFLARE_API_TOKEN!,
- * }),
- * ```
- *
- * The foundation is provided privately, so a state-account token never
- * reaches the stack's providers.
- */
-export const state = (options: CloudflareStateOptions = {}) =>
+export const state = () =>
   Layer.effect(
     State,
     Effect.gen(function* () {
@@ -101,7 +80,6 @@ export const state = (options: CloudflareStateOptions = {}) =>
             profileName,
             isCI,
             force: false,
-            api: options,
           });
         }
 
@@ -124,7 +102,6 @@ export const state = (options: CloudflareStateOptions = {}) =>
                 }));
               if (shouldDeploy) {
                 return yield* bootstrap({
-                  ...options,
                   workerName: scriptName,
                   profile: profileName,
                 });
@@ -148,7 +125,6 @@ export const state = (options: CloudflareStateOptions = {}) =>
                 stage: scriptName,
                 state: httpState,
                 force: false,
-                api: options,
               });
               return yield* makeCloudflareStateStore(stateStoreOptions);
             });
@@ -232,7 +208,7 @@ export const state = (options: CloudflareStateOptions = {}) =>
           );
         } else if (autoUpdateStateStore) {
           // `--yes`: deploy the missing state store automatically (also in CI).
-          return yield* bootstrap(options);
+          return yield* bootstrap();
         } else if (isCI) {
           return yield* Effect.die(
             new AuthError({
@@ -246,7 +222,7 @@ export const state = (options: CloudflareStateOptions = {}) =>
           }).pipe(
             Effect.flatMap((shouldDeploy) =>
               shouldDeploy
-                ? bootstrap(options)
+                ? bootstrap()
                 : Effect.die(new Clank.PromptCancelled()),
             ),
           );
@@ -262,13 +238,12 @@ export const state = (options: CloudflareStateOptions = {}) =>
     // policy the init-time subdomain/script/secrets probes run on the
     // SDK default and give up early under Cloudflare rate limiting.
     // `provide` (not `provideMerge`) so the distilled Retry tag stays
-    // out of this layer's public type — and so a state-account override
-    // never reaches the stack's providers.
-    Layer.provide(Cloudflare.CloudflareApiLive(options)),
+    // out of this layer's public type.
+    Layer.provide(Cloudflare.CloudflareApiLive()),
     Layer.orDie,
   );
 
-export interface BootstrapOptions extends Cloudflare.CloudflareApiOptions {
+export interface BootstrapOptions {
   /** @default "alchemy-state-store" */
   workerName?: string;
   /** @default false */
@@ -303,7 +278,6 @@ export const bootstrap = (options: BootstrapOptions = {}) =>
         profileName,
         isCI,
         force,
-        api: options,
       }).pipe(
         Effect.tap(() =>
           Clank.success(`Cloudflare State Store '${scriptName}' is ready.`),
@@ -354,7 +328,6 @@ export const bootstrap = (options: BootstrapOptions = {}) =>
             stage: scriptName,
             state: httpState,
             force,
-            api: options,
           }),
         );
       } else {
@@ -367,7 +340,6 @@ export const bootstrap = (options: BootstrapOptions = {}) =>
         profileName,
         isCI,
         force,
-        api: options,
       }).pipe(
         Effect.tap(() =>
           Clank.success(`Cloudflare State Store '${scriptName}' is ready.`),
@@ -508,17 +480,10 @@ const deployStateStore = ({
   stage,
   state,
   force,
-  api,
 }: {
   stage: string;
   state: StateService;
   force?: boolean;
-  /**
-   * Account the state-store Worker itself is deployed into. Must match the
-   * account the store's API calls use, or bootstrap would create the Worker
-   * in one account and then probe for it in another.
-   */
-  api?: Cloudflare.CloudflareApiOptions;
 }) =>
   Effect.gen(function* () {
     yield* annotateAccountHash();
@@ -531,10 +496,7 @@ const deployStateStore = ({
       stack: Alchemy.Stack(
         "CloudflareStateStore",
         {
-          providers: Layer.mergeAll(
-            Cloudflare.providers(api ?? {}),
-            RandomProvider(),
-          ),
+          providers: Layer.mergeAll(Cloudflare.providers(), RandomProvider()),
           state: stateLayer,
         },
         Effect.gen(function* () {
@@ -589,13 +551,11 @@ const deployWithLocalState = ({
   isCI,
   force,
   profileName,
-  api,
 }: {
   scriptName: string;
   isCI: boolean;
   force: boolean;
   profileName: string;
-  api?: Cloudflare.CloudflareApiOptions;
 }) =>
   Effect.gen(function* () {
     const localState = yield* makeLocalState();
@@ -605,7 +565,6 @@ const deployWithLocalState = ({
       stage: localStage,
       state: localState,
       force,
-      api,
     });
 
     const { url } = yield* loginWithCloudflare(profileName, force);

--- a/packages/alchemy/src/Cloudflare/StateStore/State.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/State.ts
@@ -54,7 +54,28 @@ import {
 
 const CI = Config.boolean("CI").pipe(Config.withDefault(false));
 
-export const state = () =>
+export type CloudflareStateOptions = Cloudflare.CloudflareApiOptions;
+
+/**
+ * State store backed by a Worker + Durable Object deployed to your
+ * Cloudflare account.
+ *
+ * By default it uses the account the active Alchemy profile resolves to —
+ * the same one `Cloudflare.providers()` deploys into. Pass `accountId` +
+ * `apiToken` (or explicit `credentials` / `environment` layers) to keep
+ * state in a different account:
+ *
+ * ```typescript
+ * state: Cloudflare.state({
+ *   accountId: process.env.STATE_CLOUDFLARE_ACCOUNT_ID!,
+ *   apiToken: process.env.STATE_CLOUDFLARE_API_TOKEN!,
+ * }),
+ * ```
+ *
+ * The foundation is provided privately, so a state-account token never
+ * reaches the stack's providers.
+ */
+export const state = (options: CloudflareStateOptions = {}) =>
   Layer.effect(
     State,
     Effect.gen(function* () {
@@ -80,6 +101,7 @@ export const state = () =>
             profileName,
             isCI,
             force: false,
+            api: options,
           });
         }
 
@@ -102,6 +124,7 @@ export const state = () =>
                 }));
               if (shouldDeploy) {
                 return yield* bootstrap({
+                  ...options,
                   workerName: scriptName,
                   profile: profileName,
                 });
@@ -125,6 +148,7 @@ export const state = () =>
                 stage: scriptName,
                 state: httpState,
                 force: false,
+                api: options,
               });
               return yield* makeCloudflareStateStore(stateStoreOptions);
             });
@@ -208,7 +232,7 @@ export const state = () =>
           );
         } else if (autoUpdateStateStore) {
           // `--yes`: deploy the missing state store automatically (also in CI).
-          return yield* bootstrap();
+          return yield* bootstrap(options);
         } else if (isCI) {
           return yield* Effect.die(
             new AuthError({
@@ -222,7 +246,7 @@ export const state = () =>
           }).pipe(
             Effect.flatMap((shouldDeploy) =>
               shouldDeploy
-                ? bootstrap()
+                ? bootstrap(options)
                 : Effect.die(new Clank.PromptCancelled()),
             ),
           );
@@ -238,12 +262,13 @@ export const state = () =>
     // policy the init-time subdomain/script/secrets probes run on the
     // SDK default and give up early under Cloudflare rate limiting.
     // `provide` (not `provideMerge`) so the distilled Retry tag stays
-    // out of this layer's public type.
-    Layer.provide(Cloudflare.CloudflareApiLive()),
+    // out of this layer's public type — and so a state-account override
+    // never reaches the stack's providers.
+    Layer.provide(Cloudflare.CloudflareApiLive(options)),
     Layer.orDie,
   );
 
-export interface BootstrapOptions {
+export interface BootstrapOptions extends Cloudflare.CloudflareApiOptions {
   /** @default "alchemy-state-store" */
   workerName?: string;
   /** @default false */
@@ -278,6 +303,7 @@ export const bootstrap = (options: BootstrapOptions = {}) =>
         profileName,
         isCI,
         force,
+        api: options,
       }).pipe(
         Effect.tap(() =>
           Clank.success(`Cloudflare State Store '${scriptName}' is ready.`),
@@ -328,6 +354,7 @@ export const bootstrap = (options: BootstrapOptions = {}) =>
             stage: scriptName,
             state: httpState,
             force,
+            api: options,
           }),
         );
       } else {
@@ -340,6 +367,7 @@ export const bootstrap = (options: BootstrapOptions = {}) =>
         profileName,
         isCI,
         force,
+        api: options,
       }).pipe(
         Effect.tap(() =>
           Clank.success(`Cloudflare State Store '${scriptName}' is ready.`),
@@ -480,10 +508,17 @@ const deployStateStore = ({
   stage,
   state,
   force,
+  api,
 }: {
   stage: string;
   state: StateService;
   force?: boolean;
+  /**
+   * Account the state-store Worker itself is deployed into. Must match the
+   * account the store's API calls use, or bootstrap would create the Worker
+   * in one account and then probe for it in another.
+   */
+  api?: Cloudflare.CloudflareApiOptions;
 }) =>
   Effect.gen(function* () {
     yield* annotateAccountHash();
@@ -496,7 +531,10 @@ const deployStateStore = ({
       stack: Alchemy.Stack(
         "CloudflareStateStore",
         {
-          providers: Layer.mergeAll(Cloudflare.providers(), RandomProvider()),
+          providers: Layer.mergeAll(
+            Cloudflare.providers(api ?? {}),
+            RandomProvider(),
+          ),
           state: stateLayer,
         },
         Effect.gen(function* () {
@@ -551,11 +589,13 @@ const deployWithLocalState = ({
   isCI,
   force,
   profileName,
+  api,
 }: {
   scriptName: string;
   isCI: boolean;
   force: boolean;
   profileName: string;
+  api?: Cloudflare.CloudflareApiOptions;
 }) =>
   Effect.gen(function* () {
     const localState = yield* makeLocalState();
@@ -565,6 +605,7 @@ const deployWithLocalState = ({
       stage: localStage,
       state: localState,
       force,
+      api,
     });
 
     const { url } = yield* loginWithCloudflare(profileName, force);

--- a/packages/alchemy/test/State/StateStoreEnvironment.test.ts
+++ b/packages/alchemy/test/State/StateStoreEnvironment.test.ts
@@ -1,4 +1,5 @@
 import { CredentialsStore } from "@/Auth/Credentials.ts";
+import { ProfileLive } from "@/Auth/Profile.ts";
 import { AWSEnvironment } from "@/AWS/Environment.ts";
 import { s3State, state as s3StateStore } from "@/AWS/StateStore/State.ts";
 import * as CloudflareCredentials from "@/Cloudflare/Credentials.ts";
@@ -86,24 +87,46 @@ const capturingHttpClient = (captured: CapturedRequest[]) =>
     );
   });
 
+/**
+ * Services a stack would normally supply around a state store. `state()`
+ * still *types* as needing the profile (the fallback branch is part of
+ * its type even when the piped-in environment wins), so tests supply it
+ * even though the fallback never builds here.
+ */
+const TestServices = Layer.mergeAll(PlatformServices, ProfileLive);
+
+/** Drive one state op through the given store layer. */
+const listThrough = <R>(layer: Layer.Layer<State, never, R>) =>
+  Effect.result(
+    Effect.gen(function* () {
+      const state = yield* yield* State;
+      return yield* state.list({ stack: "app", stage: "dev" });
+    }).pipe(Effect.provide(layer)),
+  );
+
+/** Assert a captured request went to the state account, in its region. */
+const expectStateAccountRequest = (request: CapturedRequest) => {
+  expect(request.url).toContain(STATE_BUCKET);
+  expect(request.url).toContain(`s3.${STATE_REGION}.amazonaws.com`);
+  // SigV4 credential scope proves the provided credentials signed it.
+  expect(request.authorization).toContain(`Credential=${STATE_ACCESS_KEY}/`);
+  expect(request.authorization).toContain(`/${STATE_REGION}/s3/aws4_request`);
+};
+
 describe("AWS S3 state store environment", () => {
   it.effect(
-    "signs and addresses its calls with the environment it was given",
+    "signs and addresses its calls with an environment piped into `state`",
     () =>
       Effect.gen(function* () {
         const captured: CapturedRequest[] = [];
 
-        const store = yield* Effect.result(
-          Effect.gen(function* () {
-            const state = yield* yield* State;
-            return yield* state.list({ stack: "app", stage: "dev" });
-          }).pipe(
-            Effect.provide(
-              s3State({ bucketName: STATE_BUCKET }).pipe(
-                Layer.provide(stateAccountEnvironment),
-                Layer.provide(capturingHttpClient(captured)),
-              ),
-            ),
+        // The headline: `AWS.state()` declares no environment requirement
+        // (it must satisfy the stack's `state` slot), but an environment
+        // piped in still wins over the profile default.
+        const store = yield* listThrough(
+          s3StateStore({ bucketName: STATE_BUCKET }).pipe(
+            Layer.provide(stateAccountEnvironment),
+            Layer.provide(capturingHttpClient(captured)),
           ),
         );
 
@@ -111,41 +134,45 @@ describe("AWS S3 state store environment", () => {
         // which account/region/credentials it failed against.
         expect(Result.isFailure(store)).toBe(true);
         expect(captured.length).toBeGreaterThan(0);
-
-        const first = captured[0]!;
-        // Region and bucket come from the provided environment, not from
-        // the ambient profile.
-        expect(first.url).toContain(STATE_BUCKET);
-        expect(first.url).toContain(`s3.${STATE_REGION}.amazonaws.com`);
-        // SigV4 credential scope proves the provided credentials signed it.
-        expect(first.authorization).toContain(
-          `Credential=${STATE_ACCESS_KEY}/`,
-        );
-        expect(first.authorization).toContain(
-          `/${STATE_REGION}/s3/aws4_request`,
-        );
-      }),
+        expectStateAccountRequest(captured[0]!);
+      }).pipe(Effect.provide(TestServices)),
     { timeout: 30_000 },
   );
 
-  it.effect("keeps that environment private to the state store", () =>
+  it.effect("`s3State` takes the environment as a hard requirement", () =>
+    Effect.gen(function* () {
+      const captured: CapturedRequest[] = [];
+
+      const store = yield* listThrough(
+        s3State({ bucketName: STATE_BUCKET }).pipe(
+          Layer.provide(stateAccountEnvironment),
+          Layer.provide(capturingHttpClient(captured)),
+        ),
+      );
+
+      expect(Result.isFailure(store)).toBe(true);
+      expect(captured.length).toBeGreaterThan(0);
+      expectStateAccountRequest(captured[0]!);
+    }),
+  );
+
+  it.effect("keeps the piped-in environment private to the state store", () =>
     Effect.gen(function* () {
       // Mirrors how `Alchemy.Stack` composes the two layers:
-      // `providers.pipe(Layer.provideMerge(state))`. If the state layer
-      // merged its environment out, `providers` would build against the
-      // state account.
+      // `providers.pipe(Layer.provideMerge(state))`. The state store reads
+      // the environment but never merges one out, so a providers-shaped
+      // layer built on top of it does not inherit the state account.
       const composed = ProvidersProbe.layer.pipe(
         Layer.provideMerge(
-          s3StateStore({
-            bucketName: STATE_BUCKET,
-            environment: stateAccountEnvironment,
-          }),
+          s3StateStore({ bucketName: STATE_BUCKET }).pipe(
+            Layer.provide(stateAccountEnvironment),
+          ),
         ),
       );
 
       const probe = yield* Effect.provide(ProvidersProbe, composed);
       expect(probe.sawEnvironment).toBe(false);
-    }).pipe(Effect.provide(PlatformServices)),
+    }).pipe(Effect.provide(TestServices)),
   );
 });
 

--- a/packages/alchemy/test/State/StateStoreEnvironment.test.ts
+++ b/packages/alchemy/test/State/StateStoreEnvironment.test.ts
@@ -1,0 +1,213 @@
+import { CredentialsStore } from "@/Auth/Credentials.ts";
+import { AWSEnvironment } from "@/AWS/Environment.ts";
+import { s3State, state as s3StateStore } from "@/AWS/StateStore/State.ts";
+import * as CloudflareCredentials from "@/Cloudflare/Credentials.ts";
+import * as CloudflareEnvironment from "@/Cloudflare/CloudflareEnvironment.ts";
+import { State } from "@/State/State.ts";
+import { PlatformServices } from "@/Util/PlatformServices";
+import { describe, expect, it } from "alchemy-test";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Redacted from "effect/Redacted";
+import * as Result from "effect/Result";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+
+/**
+ * A state store may live in a different account than the resources a
+ * stack deploys — the state bucket in a locked-down "state" account, the
+ * workloads anywhere else. These tests pin the two halves of that
+ * contract, hermetically (no sockets, no cloud):
+ *
+ * 1. the environment handed to the store is what actually signs and
+ *    addresses its API calls, and
+ * 2. it stays private to the store. The stack composes
+ *    `providers.pipe(Layer.provideMerge(state))`, so a state-account
+ *    environment that leaked out of the state layer would silently
+ *    redirect every resource in the stack into the state account.
+ */
+
+const STATE_ACCOUNT = "111122223333";
+const STATE_REGION = "eu-west-2";
+const STATE_ACCESS_KEY = "AKIAEXAMPLESTATEACCT";
+const STATE_BUCKET = "cross-account-alchemy-state";
+
+/** An `AWSEnvironment` for the state account — no profile, no STS. */
+const stateAccountEnvironment = Layer.succeed(
+  AWSEnvironment,
+  Effect.succeed({
+    accountId: STATE_ACCOUNT,
+    region: STATE_REGION,
+    credentials: Effect.succeed({
+      accessKeyId: Redacted.make(STATE_ACCESS_KEY),
+      secretAccessKey: Redacted.make("secret-access-key"),
+      region: STATE_REGION,
+    }),
+  }),
+);
+
+/** Minimal fetch signature — Bun's `typeof fetch` also demands `preconnect`. */
+type FetchStub = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+
+const stubHttpClient = (stub: FetchStub) =>
+  FetchHttpClient.layer.pipe(
+    Layer.provide(
+      Layer.succeed(FetchHttpClient.Fetch, stub as typeof globalThis.fetch),
+    ),
+  );
+
+interface CapturedRequest {
+  readonly url: string;
+  readonly authorization: string;
+}
+
+/**
+ * Capture every request and answer 403 — a terminal S3 error, so the
+ * store fails fast on its first call instead of retrying or needing a
+ * full fixture of XML responses. The request itself is the assertion
+ * subject.
+ */
+const capturingHttpClient = (captured: CapturedRequest[]) =>
+  stubHttpClient((input, init) => {
+    const url = input instanceof Request ? input.url : input.toString();
+    const headers = new Headers(
+      input instanceof Request ? input.headers : init?.headers,
+    );
+    captured.push({ url, authorization: headers.get("authorization") ?? "" });
+    return Promise.resolve(
+      new Response(
+        `<?xml version="1.0" encoding="UTF-8"?><Error><Code>AccessDenied</Code><Message>Access Denied</Message></Error>`,
+        { status: 403, headers: { "content-type": "application/xml" } },
+      ),
+    );
+  });
+
+describe("AWS S3 state store environment", () => {
+  it.effect(
+    "signs and addresses its calls with the environment it was given",
+    () =>
+      Effect.gen(function* () {
+        const captured: CapturedRequest[] = [];
+
+        const store = yield* Effect.result(
+          Effect.gen(function* () {
+            const state = yield* yield* State;
+            return yield* state.list({ stack: "app", stage: "dev" });
+          }).pipe(
+            Effect.provide(
+              s3State({ bucketName: STATE_BUCKET }).pipe(
+                Layer.provide(stateAccountEnvironment),
+                Layer.provide(capturingHttpClient(captured)),
+              ),
+            ),
+          ),
+        );
+
+        // The stub denies everything, so the op fails — what matters is
+        // which account/region/credentials it failed against.
+        expect(Result.isFailure(store)).toBe(true);
+        expect(captured.length).toBeGreaterThan(0);
+
+        const first = captured[0]!;
+        // Region and bucket come from the provided environment, not from
+        // the ambient profile.
+        expect(first.url).toContain(STATE_BUCKET);
+        expect(first.url).toContain(`s3.${STATE_REGION}.amazonaws.com`);
+        // SigV4 credential scope proves the provided credentials signed it.
+        expect(first.authorization).toContain(
+          `Credential=${STATE_ACCESS_KEY}/`,
+        );
+        expect(first.authorization).toContain(
+          `/${STATE_REGION}/s3/aws4_request`,
+        );
+      }),
+    { timeout: 30_000 },
+  );
+
+  it.effect("keeps that environment private to the state store", () =>
+    Effect.gen(function* () {
+      // Mirrors how `Alchemy.Stack` composes the two layers:
+      // `providers.pipe(Layer.provideMerge(state))`. If the state layer
+      // merged its environment out, `providers` would build against the
+      // state account.
+      const composed = ProvidersProbe.layer.pipe(
+        Layer.provideMerge(
+          s3StateStore({
+            bucketName: STATE_BUCKET,
+            environment: stateAccountEnvironment,
+          }),
+        ),
+      );
+
+      const probe = yield* Effect.provide(ProvidersProbe, composed);
+      expect(probe.sawEnvironment).toBe(false);
+    }).pipe(Effect.provide(PlatformServices)),
+  );
+});
+
+/**
+ * Stands in for the `providers` layer: records whether an
+ * {@link AWSEnvironment} was visible in the context it was built with.
+ */
+class ProvidersProbe extends Context.Service<
+  ProvidersProbe,
+  { readonly sawEnvironment: boolean }
+>()("test/ProvidersProbe") {
+  static readonly layer = Layer.effect(
+    ProvidersProbe,
+    Effect.map(Effect.serviceOption(AWSEnvironment), (environment) => ({
+      sawEnvironment: Option.isSome(environment),
+    })),
+  );
+}
+
+describe("Cloudflare state store environment", () => {
+  it.effect("resolves the account and token it was given", () =>
+    Effect.gen(function* () {
+      const environment =
+        yield* yield* CloudflareEnvironment.CloudflareEnvironment;
+      expect(environment.accountId).toBe("cf-state-account");
+      expect(environment.type).toBe("apiToken");
+
+      const credentials = yield* yield* CloudflareCredentials.Credentials;
+      expect(credentials.type).toBe("apiToken");
+      if (credentials.type === "apiToken") {
+        expect(Redacted.value(credentials.apiToken)).toBe("cf-state-token");
+      }
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          CloudflareEnvironment.ofApiToken({
+            accountId: "cf-state-account",
+            apiToken: "cf-state-token",
+          }),
+          CloudflareCredentials.fromApiToken({ apiToken: "cf-state-token" }),
+        ),
+      ),
+    ),
+  );
+
+  it.effect("is not resolved from the profile when overridden", () =>
+    Effect.gen(function* () {
+      // No profile, no credential store, no auth provider in context: if
+      // the override did not take, building this layer would demand them.
+      const environment =
+        yield* yield* CloudflareEnvironment.CloudflareEnvironment;
+      expect(environment.accountId).toBe("cf-state-account");
+      expect(yield* Effect.serviceOption(CredentialsStore)).toEqual(
+        Option.none(),
+      );
+    }).pipe(
+      Effect.provide(
+        CloudflareEnvironment.ofApiToken({
+          accountId: "cf-state-account",
+          apiToken: "cf-state-token",
+        }),
+      ),
+    ),
+  );
+});

--- a/website/src/content/docs/state-store/index.mdx
+++ b/website/src/content/docs/state-store/index.mdx
@@ -161,27 +161,35 @@ state: AWS.state({
 
 By default a state store talks to the same account the stack deploys
 into — both are resolved from the active Alchemy profile. Both
-cloud-backed stores accept an override, so state can live somewhere
-else: a locked-down state account, or one shared team account while each
-developer deploys into their own.
+cloud-backed stores look for an account in their surrounding context
+first, so piping one in moves state somewhere else: a locked-down state
+account, or one shared team account while each developer deploys into
+their own.
 
 ### AWS
 
 ```typescript
-state: AWS.state({
-  bucketName: "my-org-alchemy-state",
-  environment: AWS.assumeRoleEnvironment({
-    roleArn: "arn:aws:iam::111122223333:role/AlchemyState",
-    accountId: "111122223333",
-    region: "us-east-1",
-  }),
-}),
+state: AWS.state({ bucketName: "my-org-alchemy-state" }).pipe(
+  Layer.provide(
+    AWS.assumeRoleEnvironment({
+      roleArn: "arn:aws:iam::111122223333:role/AlchemyState",
+      accountId: "111122223333",
+      region: "us-east-1",
+    }),
+  ),
+),
 ```
+
+`AWS.state()` declares no environment requirement — it has to satisfy
+the stack's `state` slot, which only permits services a stack already
+has — so it resolves an `AWSEnvironment` from its context if one is
+there and falls back to the profile if not. That is why the layer is
+pipe-able even though its type says nothing about it.
 
 The profile's credentials sign the `AssumeRole` call; the temporary
 credentials it returns are cached and single-flighted until shortly
 before they expire. Region, credentials and endpoint are all derived
-from the environment, so it is the only thing to pass.
+from the environment, so it is the only thing to pipe in.
 
 In the state account, the role needs object permissions on the bucket
 plus the bucket-level settings the store reconciles on every run:
@@ -190,10 +198,10 @@ plus the bucket-level settings the store reconciles on every run:
 `s3:GetBucketPublicAccessBlock`, `s3:PutBucketPublicAccessBlock`,
 `s3:GetBucketOwnershipControls` and `s3:PutBucketOwnershipControls`.
 
-`environment` takes any `Layer<AWSEnvironment>` — static keys, a
-different STS chain, a local emulator. For full control over how the
-store itself is assembled, `AWS.s3State()` is the same store with its
-environment left open:
+Any `Layer<AWSEnvironment>` works — static keys, a different STS chain, a
+local emulator. If you would rather the type demand an environment than
+silently fall back to the profile, `AWS.s3State()` is the same store with
+the environment as a hard requirement:
 
 ```typescript
 state: AWS.s3State({ bucketName: "my-org-alchemy-state" }).pipe(
@@ -205,33 +213,43 @@ state: AWS.s3State({ bucketName: "my-org-alchemy-state" }).pipe(
 ### Cloudflare
 
 ```typescript
-state: Cloudflare.state({
-  accountId: process.env.STATE_CLOUDFLARE_ACCOUNT_ID!,
-  apiToken: process.env.STATE_CLOUDFLARE_API_TOKEN!,
-}),
+state: Cloudflare.state().pipe(
+  Layer.provide(
+    Cloudflare.CloudflareApiLive({
+      accountId: process.env.STATE_CLOUDFLARE_ACCOUNT_ID!,
+      apiToken: process.env.STATE_CLOUDFLARE_API_TOKEN!,
+    }),
+  ),
+),
 ```
 
 A Cloudflare account and the token that authenticates against it are
-resolved independently, so unlike AWS both have to be given together —
-an account id on its own is ignored. The state-store Worker and its
-Secrets Store secrets then bootstrap into that account instead of the
-profile's. Pass `credentials` / `environment` layers instead if you want
-to build them yourself.
+resolved independently, so unlike AWS both have to travel together — an
+account id on its own is ignored. `CloudflareApiLive` also accepts
+`credentials` / `environment` layers if you want to build them yourself.
 
-`Cloudflare.providers()` accepts the same options, so a stack can also
-deploy its *resources* into a non-default account.
+The state-store Worker and its Secrets Store secrets bootstrap into
+whichever account the store resolves, so the store and the infrastructure
+backing it never split across accounts.
+
+`Cloudflare.providers()` resolves its account the same way, so a stack
+can also deploy its *resources* into a non-default account.
 
 ### Everything else
 
 The Postgres and HTTP stores are already explicit — `postgresState({ url })`
 writes wherever the URL points, with no profile involved.
 
-### The override stays private
+### What the store does and doesn't share
 
-In every case the environment is provided *privately* to the state
-store. A stack composes its providers on top of its state layer, so an
-override that leaked out would silently redirect every resource in the
-stack into the state account. Providers keep using the profile.
+The account is read from context, never merged back out. A stack builds
+its providers on top of its state layer, so a state account that leaked
+out of the state store would silently redirect every resource in the
+stack into it.
+
+The flip side: piping an account in at the *stack* level rather than onto
+the state layer puts it in scope for both. Attach it to the state layer,
+as above, when you want it to apply to state alone.
 
 ## Postgres state store
 

--- a/website/src/content/docs/state-store/index.mdx
+++ b/website/src/content/docs/state-store/index.mdx
@@ -118,6 +118,121 @@ you want a dedicated store per Cloudflare account or per team:
 state: Cloudflare.state({ workerName: "alchemy-state-store-team-a" }),
 ```
 
+## AWS S3 state store
+
+`AWS.state()` persists state as JSON objects in an S3 bucket, laid out
+exactly like the local store's file tree:
+
+```
+s3://{bucket}/{prefix}{stack}/{stage}/{fqn}.json
+```
+
+```typescript
+Alchemy.Stack(
+  "MyApp",
+  {
+    providers: AWS.providers(),
+    state: AWS.state(),
+  },
+  Effect.gen(function* () {
+    // ...
+  }),
+);
+```
+
+The bucket is created on first use — an account-regional bucket named
+`alchemy-state-{accountId}-{region}-an` by default — and versioning,
+default encryption, public-access-block and ownership controls are
+reconciled on every run, so out-of-band drift converges back. Pass
+`bucketName`, `prefix` or `encryption` to customize it:
+
+```typescript
+state: AWS.state({
+  bucketName: "my-company-state",
+  prefix: "alchemy",
+  encryption: {
+    sseAlgorithm: "aws:kms",
+    kmsMasterKeyId: "alias/alchemy-state",
+  },
+}),
+```
+
+## Keeping state in a different account
+
+By default a state store talks to the same account the stack deploys
+into — both are resolved from the active Alchemy profile. Both
+cloud-backed stores accept an override, so state can live somewhere
+else: a locked-down state account, or one shared team account while each
+developer deploys into their own.
+
+### AWS
+
+```typescript
+state: AWS.state({
+  bucketName: "my-org-alchemy-state",
+  environment: AWS.assumeRoleEnvironment({
+    roleArn: "arn:aws:iam::111122223333:role/AlchemyState",
+    accountId: "111122223333",
+    region: "us-east-1",
+  }),
+}),
+```
+
+The profile's credentials sign the `AssumeRole` call; the temporary
+credentials it returns are cached and single-flighted until shortly
+before they expire. Region, credentials and endpoint are all derived
+from the environment, so it is the only thing to pass.
+
+In the state account, the role needs object permissions on the bucket
+plus the bucket-level settings the store reconciles on every run:
+`s3:GetBucketVersioning`, `s3:PutBucketVersioning`,
+`s3:GetEncryptionConfiguration`, `s3:PutEncryptionConfiguration`,
+`s3:GetBucketPublicAccessBlock`, `s3:PutBucketPublicAccessBlock`,
+`s3:GetBucketOwnershipControls` and `s3:PutBucketOwnershipControls`.
+
+`environment` takes any `Layer<AWSEnvironment>` — static keys, a
+different STS chain, a local emulator. For full control over how the
+store itself is assembled, `AWS.s3State()` is the same store with its
+environment left open:
+
+```typescript
+state: AWS.s3State({ bucketName: "my-org-alchemy-state" }).pipe(
+  Layer.provide(myEnvironment),
+  Layer.orDie,
+),
+```
+
+### Cloudflare
+
+```typescript
+state: Cloudflare.state({
+  accountId: process.env.STATE_CLOUDFLARE_ACCOUNT_ID!,
+  apiToken: process.env.STATE_CLOUDFLARE_API_TOKEN!,
+}),
+```
+
+A Cloudflare account and the token that authenticates against it are
+resolved independently, so unlike AWS both have to be given together —
+an account id on its own is ignored. The state-store Worker and its
+Secrets Store secrets then bootstrap into that account instead of the
+profile's. Pass `credentials` / `environment` layers instead if you want
+to build them yourself.
+
+`Cloudflare.providers()` accepts the same options, so a stack can also
+deploy its *resources* into a non-default account.
+
+### Everything else
+
+The Postgres and HTTP stores are already explicit — `postgresState({ url })`
+writes wherever the URL points, with no profile involved.
+
+### The override stays private
+
+In every case the environment is provided *privately* to the state
+store. A stack composes its providers on top of its state layer, so an
+override that leaked out would silently redirect every resource in the
+stack into the state account. Providers keep using the profile.
+
 ## Postgres state store
 
 `postgresState()` persists state in a Postgres database you already run, and it locks: each `(stack, stage)` holds a session advisory lock for the duration of a run, so two concurrent deploys of the same stage cannot interleave.


### PR DESCRIPTION
State stores baked in the account they talked to. `AWS.state()` provided its own credentials, region and environment internally, so an outer `AWS.state().pipe(Layer.provide(myEnvironment))` type-checked and silently did nothing. Both cloud-backed stores now resolve the account from their surrounding context, falling back to the Alchemy profile, so piping one in works:

```ts
state: AWS.state({ bucketName: "my-org-alchemy-state" }).pipe(
  Layer.provide(
    AWS.assumeRoleEnvironment({
      roleArn: "arn:aws:iam::111122223333:role/AlchemyState",
      accountId: "111122223333",
      region: "us-east-1",
    }),
  ),
),
```

```ts
state: Cloudflare.state().pipe(
  Layer.provide(Cloudflare.CloudflareApiLive({ accountId, apiToken })),
),
```

### Why a context lookup rather than an option

The stack's slot is `state: Layer.Layer<State, never, StackServices>`, and `StackServices` has no `AWSEnvironment`/`Credentials` in it, so a state store cannot leave them as declared requirements — it has to close over them. `Effect.serviceOption` doesn't contribute to `R`, so the store can prefer an environment from context while still fitting the slot:

```ts
const EnvironmentOrDefault = Layer.unwrap(
  Effect.map(Effect.serviceOption(AWSEnvironment), (environment) =>
    Option.match(environment, {
      onNone: () => DefaultEnvironment,
      onSome: (env) => Layer.succeed(AWSEnvironment, env),
    }),
  ),
);
```

`Layer.provide` builds the piped layer into the store's build context, which is where that lookup runs — so the pipe reaches it even though the type never mentions it.

### What changed

- `AWS.state()` resolves `AWSEnvironment` from context, else the profile. `Region`, `Credentials` and `Endpoint` are derived from it internally, so the environment is the only thing to pipe.
- `AWS.s3State()` — the same store with the environment as a hard requirement, for callers who want the type to demand one instead of falling back.
- `AWS.assumeRoleEnvironment({ roleArn, accountId, region })` — an `AWSEnvironment` for another account, reached by assuming a role signed with the profile's credentials, cached and single-flighted by the existing `makeAssumeRoleResolver`.
- `Cloudflare.CloudflareApiLive` resolves both halves (credentials and account environment) the same way: explicit options, then context, then profile. `providers()` takes the same options.
- The Cloudflare state store is otherwise untouched: its bootstrap deploy inherits the resolved account from the init context, so the state Worker and its Secrets Store secrets land in the account the store then talks to.
- `CloudflareEnvironment.ofApiToken()`, plus a `fromApiToken` re-export from `Cloudflare/Credentials.ts`.
- Postgres and HTTP stores already take connection details explicitly; unchanged.

The environment is read, never merged back out:

```diff
-    Layer.provideMerge(DefaultEnvironment),
+    Layer.provide(EnvironmentOrDefault),
```

A stack composes `providers.pipe(Layer.provideMerge(state))`, so anything the state layer merges lands in the providers' build context — an account meant for state would silently redirect every resource in the stack. `AWS.providers()` self-provides the same credentials/region/endpoint chain, so nothing downstream depended on the old merge.

`test/State/StateStoreEnvironment.test.ts` covers the AWS side hermetically (stubbed `fetch`, no cloud): a piped-in environment is what signs and addresses the store's S3 calls, `s3State` behaves the same with the environment required, and a providers-shaped layer composed on top of the state layer does not see the state account.
