### PR TITLE
fix(cloudflare/containers): env vars and SQL database connections

### DIFF
--- a/packages/alchemy/src/Cloudflare/Containers/Container.ts
+++ b/packages/alchemy/src/Cloudflare/Containers/Container.ts
@@ -96,6 +96,42 @@ export type {
   RemoteContainerProps,
 };
 
+/**
+ * Props for an image-backed container declaration — either the plain props
+ * object, or an Effect that produces it.
+ *
+ * The Effect form is how a container reaches another resource's outputs. A
+ * class body is module scope, so there is nowhere to `yield*` a database,
+ * queue, or bucket; wrapping the props in `Effect.gen` moves the declaration
+ * into an Effect where sibling resources resolve normally and their
+ * attributes can be threaded into `env`:
+ *
+ * ```typescript
+ * export class Api extends Cloudflare.Container<Api>()(
+ *   "Api",
+ *   Effect.gen(function* () {
+ *     const { connection } = yield* Db;
+ *     return {
+ *       context: `${import.meta.dirname}/api`,
+ *       env: { DATABASE_URL: connection.databaseUrl },
+ *     };
+ *   }),
+ * ) {}
+ * ```
+ *
+ * A plain props object cannot do this: a module-scope resource declaration
+ * is an Effect, not a resolved handle, so `Db.connectionString` is
+ * `undefined` until something yields it.
+ */
+export type ImageContainerProps<Req = never> =
+  | InputProps<ExternalContainerProps>
+  | InputProps<RemoteContainerProps>
+  | Effect.Effect<
+      InputProps<ExternalContainerProps> | InputProps<RemoteContainerProps>,
+      Config.ConfigError,
+      Req
+    >;
+
 export type Container<Id extends string = string> = Named<Id> & {
   get running(): Effect.Effect<boolean, never, RuntimeContext>;
   start(
@@ -382,6 +418,72 @@ export type Container<Id extends string = string> = Named<Id> & {
  * );
  * ```
  *
+ * ### Environment Variables
+ * A container is a process, not a Worker: it has no bindings, so every
+ * piece of configuration reaches it through `env`. Each entry lands on
+ * the deployment and shows up in `process.env` inside the image —
+ * generated (`main`), built (`context`), or pre-built (`image`) alike.
+ * Wrap a secret in `Redacted` to keep it encrypted in state and out of
+ * plan output; the container still reads a plain string.
+ *
+ * **Example:** Plain and secret env values
+ * ```typescript
+ * export class Api extends Cloudflare.Container<Api>()("Api", {
+ *   context: `${import.meta.dirname}/api`,
+ *   ports: [{ name: "http", port: 8080 }],
+ *   env: {
+ *     PORT: "8080",
+ *     SESSION_KEY: Redacted.make(process.env.SESSION_KEY!),
+ *   },
+ * }) {}
+ * ```
+ *
+ * ### Props from Other Resources
+ * A class body is module scope, so there is nowhere to `yield*` the
+ * database, queue, or bucket whose output you need — and a bare
+ * declaration is an Effect, not a resolved handle, so
+ * `Uploads.bucketName` reads as `undefined`. Pass the props as an
+ * `Effect.gen` instead: inside it sibling resources resolve normally,
+ * and the reference orders the deploy.
+ *
+ * **Example:** Threading a sibling resource's output into `env`
+ * ```typescript
+ * export const Uploads = Cloudflare.R2.Bucket("Uploads");
+ *
+ * export class Api extends Cloudflare.Container<Api>()(
+ *   "Api",
+ *   Effect.gen(function* () {
+ *     const uploads = yield* Uploads;
+ *     return {
+ *       context: `${import.meta.dirname}/api`,
+ *       env: { BUCKET_NAME: uploads.bucketName },
+ *     };
+ *   }),
+ * ) {}
+ * ```
+ *
+ * A SQL database works the same way. Hyperdrive is a *Worker* binding
+ * (`Cloudflare.Hyperdrive.Connect` only resolves inside a deployed
+ * Worker, as does `Prisma.Connect`), so a container connects over TCP
+ * with the provider's **pooled** connection string instead.
+ *
+ * **Example:** Passing a pooled database URL to the container
+ * ```typescript
+ * export class Api extends Cloudflare.Container<Api>()(
+ *   "Api",
+ *   Effect.gen(function* () {
+ *     const { branch } = yield* Db;
+ *     return {
+ *       context: `${import.meta.dirname}/api`,
+ *       env: { DATABASE_URL: branch.pooledConnectionUri },
+ *     };
+ *   }),
+ * ) {}
+ * ```
+ *
+ * Start it with `Cloudflare.Containers.layer(Api, { enableInternet: true })`
+ * — without outbound networking the container never reaches the database.
+ *
  * ### Stack-level wiring
  * The `.make()` `export default` is the side-effect that registers
  * the container's runtime. It must be reachable from your
@@ -470,22 +572,15 @@ export type Container<Id extends string = string> = Named<Id> & {
  * @category Workers & Compute
  */
 export const Container: ResourceClassLike<ContainerApplication> & {
-  <DOShape = unknown, const Id extends string = string>(
+  <DOShape = unknown, const Id extends string = string, PropsReq = never>(
     id: Id,
-    props:
-      | InputProps<ExternalContainerProps>
-      | InputProps<RemoteContainerProps>,
-  ): Container.Decl<Container<Id>, {}, Id, never, DOShape>;
+    props: ImageContainerProps<PropsReq>,
+  ): Container.Decl<Container<Id>, {}, Id, PropsReq, DOShape>;
   <Self>(): {
-    <
-      const Id extends string,
-      Props extends
-        | InputProps<ExternalContainerProps>
-        | InputProps<RemoteContainerProps>,
-    >(
+    <const Id extends string, PropsReq = never>(
       id: Id,
-      props: Props,
-    ): Container.Decl<Self, {}, Id>;
+      props: ImageContainerProps<PropsReq>,
+    ): Container.Decl<Self, {}, Id, PropsReq>;
   };
   <Self, Shape>(): {
     <const Id extends string>(
@@ -530,8 +625,14 @@ export const Container: ResourceClassLike<ContainerApplication> & {
         // The Durable Object class name this container backs when bound on
         // an async Worker's `env` (see bindWorkerAsyncBindings). Defaults to
         // the binding name at bind time when no explicit `className` is set.
-        "~alchemy/Container/ClassName": (props as { className?: string })
-          ?.className,
+        // Effect-valued props cannot be read synchronously here, so carry
+        // the unresolved lookup and let `bindContainerClass` await it.
+        "~alchemy/Container/ClassName": Effect.isEffect(props)
+          ? Effect.map(
+              props as Effect.Effect<{ className?: string } | undefined>,
+              (resolved) => resolved?.className,
+            )
+          : (props as { className?: string })?.className,
         // yield* MyContainer.Application to get the ContainerApplication Resource Outputs
         Application: resource,
         of: (shape: any) => shape,
@@ -565,7 +666,10 @@ export declare namespace Container {
      * identifies an async-bindable Container declaration in a Worker's `env`
      * (see `bindWorkerAsyncBindings`).
      */
-    readonly "~alchemy/Container/ClassName": string | undefined;
+    readonly "~alchemy/Container/ClassName":
+      | string
+      | undefined
+      | Effect.Effect<string | undefined>;
     /**
      * The underlying {@link ContainerApplication} resource declaration —
      * `yield*` it to get the application's Output attributes.

--- a/packages/alchemy/src/Cloudflare/Containers/Container.ts
+++ b/packages/alchemy/src/Cloudflare/Containers/Container.ts
@@ -462,27 +462,55 @@ export type Container<Id extends string = string> = Named<Id> & {
  * ) {}
  * ```
  *
- * A SQL database works the same way. Hyperdrive is a *Worker* binding
- * (`Cloudflare.Hyperdrive.Connect` only resolves inside a deployed
- * Worker, as does `Prisma.Connect`), so a container connects over TCP
- * with the provider's **pooled** connection string instead.
+ * ### Database Connections
+ * An effectful (`main`) container runs your Effect program, so it
+ * resolves a database capability the same way a Worker does — you never
+ * name `DATABASE_URL`. The container has no bindings (it is a process,
+ * not a Worker), so `Prisma.Connect` writes the connection's outputs
+ * onto the deployment as environment variables and reads them back at
+ * runtime; the capability owns both ends.
  *
- * **Example:** Passing a pooled database URL to the container
+ * **Example:** Binding a Prisma connection inside the container runtime
  * ```typescript
- * export class Api extends Cloudflare.Container<Api>()(
- *   "Api",
+ * export default Api.make(
+ *   { main: import.meta.url },
  *   Effect.gen(function* () {
- *     const { branch } = yield* Db;
+ *     const db = yield* Prisma.Connect(Connection);
+ *     const sql = yield* SQL.Postgres({ url: db.databaseUrl });
+ *
+ *     return Api.of({
+ *       fetch: Effect.gen(function* () {
+ *         const users = yield* sql`SELECT * FROM users`;
+ *         return yield* HttpServerResponse.json(users);
+ *       }),
+ *     });
+ *   }).pipe(Effect.provide(Prisma.ConnectBinding)),
+ * );
+ * ```
+ *
+ * An image you brought yourself knows nothing about alchemy, so there is
+ * no capability to bind — name the variable and hand it the provider's
+ * **pooled** connection string.
+ *
+ * **Example:** Passing a pooled database URL to an arbitrary image
+ * ```typescript
+ * export class Web extends Cloudflare.Container<Web>()(
+ *   "Web",
+ *   Effect.gen(function* () {
+ *     const connection = yield* Connection;
  *     return {
- *       context: `${import.meta.dirname}/api`,
- *       env: { DATABASE_URL: branch.pooledConnectionUri },
+ *       context: `${import.meta.dirname}/web`,
+ *       env: { DATABASE_URL: connection.databaseUrl },
  *     };
  *   }),
  * ) {}
  * ```
  *
- * Start it with `Cloudflare.Containers.layer(Api, { enableInternet: true })`
- * — without outbound networking the container never reaches the database.
+ * Either way, start it with
+ * `Cloudflare.Containers.layer(Api, { enableInternet: true })` — without
+ * outbound networking the container never reaches the database.
+ * `Cloudflare.Hyperdrive.Connect` is the one that cannot work here: it
+ * *is* a workerd binding, so no container process can resolve it.
  *
  * ### Stack-level wiring
  * The `.make()` `export default` is the side-effect that registers

--- a/packages/alchemy/src/Cloudflare/Containers/ContainerBundle.ts
+++ b/packages/alchemy/src/Cloudflare/Containers/ContainerBundle.ts
@@ -40,13 +40,30 @@ import type { AnyContainerApplicationProps } from "./ContainerApplication.ts";
  * (mirroring the Worker runtime) so the container bootstrap can build
  * `CloudflareEnvironment` for HTTP capability bindings (R2/KV/Queue `*Http`).
  *
- * Explicit `props.environmentVariables` win on a name collision.
+ * `bindings` carries the resource's binding contract — the `{ env }` a
+ * `Binding.Service` attaches with ``host.bind`${resource}`({ env })`` when the
+ * container is the host (`Prisma.Connect`, and any other capability whose
+ * runtime config travels as environment variables). Bindings are resolved by
+ * the engine before `reconcile`, so they land here already evaluated. They are
+ * applied FIRST, at the lowest precedence: an explicitly declared `env` or
+ * `environmentVariables` entry always wins over a capability-injected one.
  */
 export const makeContainerEnv = (
   props: AnyContainerApplicationProps,
   accountId: string,
+  bindings: readonly {
+    data?: { env?: Record<string, any> } | undefined;
+  }[] = [],
 ) => {
   const env: Record<string, string | Redacted.Redacted<string>> = {};
+  for (const binding of bindings) {
+    for (const [name, value] of Object.entries(binding.data?.env ?? {})) {
+      if (Output.isOutput(value) || value === undefined) {
+        continue;
+      }
+      env[name] = value;
+    }
+  }
   for (const [name, value] of Object.entries(props.env ?? {})) {
     if (Output.isOutput(value) || value === undefined) {
       continue;

--- a/packages/alchemy/src/Cloudflare/Containers/ContainerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Containers/ContainerProvider.ts
@@ -533,6 +533,7 @@ export const LiveContainerProvider = () =>
       const createApplication = Effect.fn(function* ({
         id,
         news,
+        bindings,
         name,
         configuration,
         durableObjects,
@@ -540,6 +541,7 @@ export const LiveContainerProvider = () =>
       }: {
         id: string;
         news: AnyContainerApplicationProps;
+        bindings: ResourceBinding<ContainerApplication["Binding"]>[];
         name: string;
         configuration: ContainerApplication.Configuration;
         durableObjects:
@@ -579,6 +581,7 @@ export const LiveContainerProvider = () =>
           return yield* upsertApplication({
             id,
             news,
+            bindings,
             existing: toAttributes(existingByName),
             durableObjects,
             session,
@@ -604,6 +607,7 @@ export const LiveContainerProvider = () =>
           return yield* upsertApplication({
             id,
             news,
+            bindings,
             existing: toAttributes(existing),
             durableObjects,
             session,
@@ -642,6 +646,7 @@ export const LiveContainerProvider = () =>
                   return yield* upsertApplication({
                     id,
                     news,
+                    bindings,
                     existing: toAttributes(existing),
                     durableObjects,
                     session,
@@ -674,12 +679,14 @@ export const LiveContainerProvider = () =>
       const upsertApplication = Effect.fn(function* ({
         id,
         news,
+        bindings,
         existing,
         durableObjects,
         session,
       }: {
         id: string;
         news: AnyContainerApplicationProps;
+        bindings: ResourceBinding<ContainerApplication["Binding"]>[];
         existing: ContainerApplication["Attributes"];
         // The DO attachment to (re)create with if the "existing" application
         // turns out to be gone. Threaded through so the update→create fallback
@@ -692,7 +699,7 @@ export const LiveContainerProvider = () =>
         yield* Effect.logInfo(
           `Cloudflare Container update: preparing ${existing.applicationName}`,
         );
-        const env = makeContainerEnv(news, accountId);
+        const env = makeContainerEnv(news, accountId, bindings);
         const { build, imageRef, imageHash, dev } = yield* computeImage(
           id,
           news,
@@ -836,7 +843,7 @@ export const LiveContainerProvider = () =>
           const { imageHash, dev } = yield* computeImage(
             id,
             news,
-            makeContainerEnv(news, accountId),
+            makeContainerEnv(news, accountId, newBindings),
           );
           if (imageHash !== output.hash?.image || !deepEqual(dev, output.dev)) {
             return { action: "update" } as const;
@@ -865,6 +872,10 @@ export const LiveContainerProvider = () =>
           const result = yield* createApplication({
             id,
             news,
+            // Precreate runs before the engine resolves bindings (that is what
+            // breaks the worker <-> container cycle), so binding-injected env
+            // lands on the following reconcile.
+            bindings: [],
             name,
             configuration,
             durableObjects: undefined,
@@ -897,7 +908,7 @@ export const LiveContainerProvider = () =>
           );
           const durableObjects = yield* getDurableObjects(bindings);
           const { accountId } = yield* yield* CloudflareEnvironment;
-          const env = makeContainerEnv(news, accountId);
+          const env = makeContainerEnv(news, accountId, bindings);
           const { build, imageRef, imageHash, dev } = yield* computeImage(
             id,
             news,
@@ -964,6 +975,7 @@ export const LiveContainerProvider = () =>
                 return yield* upsertApplication({
                   id,
                   news,
+                  bindings,
                   existing: toAttributes(owner),
                   durableObjects,
                   session,
@@ -995,6 +1007,7 @@ export const LiveContainerProvider = () =>
             const result = yield* createApplication({
               id,
               news,
+              bindings,
               name,
               configuration,
               durableObjects,
@@ -1016,6 +1029,7 @@ export const LiveContainerProvider = () =>
             return yield* upsertApplication({
               id,
               news,
+              bindings,
               existing,
               durableObjects,
               session,
@@ -1030,6 +1044,7 @@ export const LiveContainerProvider = () =>
           const result = yield* createApplication({
             id,
             news,
+            bindings,
             name,
             configuration,
             durableObjects,

--- a/packages/alchemy/src/Cloudflare/Containers/LocalContainerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Containers/LocalContainerProvider.ts
@@ -5,6 +5,7 @@ import * as Redacted from "effect/Redacted";
 import * as Artifacts from "../../Artifacts.ts";
 import { hashDirectory } from "../../Command/Memo.ts";
 import { isResolved } from "../../Diff.ts";
+import type { ResourceBinding } from "../../Resource.ts";
 import * as RpcProvider from "../../Local/RpcProvider.ts";
 import { sha256Object } from "../../Util/sha256.ts";
 import { normalizeNulls } from "../../Util/stable.ts";
@@ -167,14 +168,16 @@ export const LocalContainerProvider = () =>
       const makeAttributes = Effect.fn(function* ({
         id,
         news,
+        bindings,
         output,
       }: {
         id: string;
         news: AnyContainerApplicationProps;
+        bindings: ResourceBinding<ContainerApplication["Binding"]>[];
         output: ContainerApplication["Attributes"] | undefined;
       }) {
         const { accountId } = yield* yield* CloudflareEnvironment;
-        const env = makeContainerEnv(news, accountId);
+        const env = makeContainerEnv(news, accountId, bindings);
         const { dev, hash } = yield* prepareImage(id, news);
         return {
           applicationId: output?.applicationId ?? generateLocalId(),
@@ -215,10 +218,17 @@ export const LocalContainerProvider = () =>
         // worker-hosted Durable Object namespace. Building the image here lets
         // the worker resolve `dev` without waiting on the container's reconcile.
         precreate: Effect.fn(function* ({ id, news }) {
-          return yield* makeAttributes({ id, news, output: undefined });
+          // Bindings are not resolved yet at precreate (that is what breaks
+          // the cycle); binding-injected env lands on the reconcile below.
+          return yield* makeAttributes({
+            id,
+            news,
+            bindings: [],
+            output: undefined,
+          });
         }),
-        reconcile: Effect.fn(function* ({ id, news, output }) {
-          return yield* makeAttributes({ id, news, output });
+        reconcile: Effect.fn(function* ({ id, news, bindings, output }) {
+          return yield* makeAttributes({ id, news, bindings, output });
         }),
         delete: Effect.fn(function* () {
           // Nothing to tear down: the build context lives under `.alchemy/tmp`

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
@@ -291,7 +291,14 @@ const bindContainerClass = Effect.fn(function* (
   bindingName: string,
   decl: Container.Decl.Any,
 ) {
-  const className = decl["~alchemy/Container/ClassName"] ?? bindingName;
+  // Effect-valued container props (the shape that threads a sibling
+  // resource's outputs into `env`) can only surface `className` here, once
+  // the props Effect runs.
+  const declaredClassName = decl["~alchemy/Container/ClassName"];
+  const className =
+    (Effect.isEffect(declaredClassName)
+      ? yield* declaredClassName
+      : declaredClassName) ?? bindingName;
   // Resolve the ContainerApplication resource declaration carried on the
   // class. An effectful (`main`) container has no application declaration of
   // its own here (it is created by its `.make()` Layer inside a Durable

--- a/packages/alchemy/src/Prisma/Connect.ts
+++ b/packages/alchemy/src/Prisma/Connect.ts
@@ -78,8 +78,9 @@ export interface ConnectClient {
 }
 
 /**
- * Bind a {@link Connection} to a Prisma Compute app, AWS Lambda Function, or
- * Cloudflare Worker and obtain the typed runtime client.
+ * Bind a {@link Connection} to a Prisma Compute app, AWS Lambda Function,
+ * Cloudflare Worker, or Cloudflare Container and obtain the typed runtime
+ * client.
  *
  * `Connect` is a single identifier that is simultaneously the binding's
  * Context tag, its type, and the callable —
@@ -107,6 +108,31 @@ export interface ConnectClient {
  *   }).pipe(Effect.provide(Prisma.ConnectBinding)),
  * );
  * ```
+ *
+ * **Example:** Use a connection inside a Cloudflare Container
+ * ```typescript
+ * export default Api.make(
+ *   { main: import.meta.url },
+ *   Effect.gen(function* () {
+ *     const db = yield* Prisma.Connect(connection);
+ *     const sql = yield* SQL.Postgres({ url: db.databaseUrl });
+ *
+ *     return Api.of({
+ *       fetch: Effect.gen(function* () {
+ *         const users = yield* sql`SELECT * FROM users`;
+ *         return yield* HttpServerResponse.json(users);
+ *       }),
+ *     });
+ *   }).pipe(Effect.provide(Prisma.ConnectBinding)),
+ * );
+ * ```
+ *
+ * A container is a real process with no workerd bindings, so the connection
+ * travels as plain environment variables — the same channel Prisma Compute
+ * and Lambda use. Start the container with
+ * `Cloudflare.Containers.layer(Api, { enableInternet: true })` so it can
+ * reach the database. (Hyperdrive, by contrast, is a workerd binding and is
+ * unavailable inside a container.)
  *
  * @binding
  */
@@ -183,10 +209,18 @@ type ConnectWorkerBindingHost = Resource<
   { bindings?: ConnectWorkerTextBinding[] }
 >;
 
+/**
+ * Hosts whose runtime configuration travels as plain environment variables:
+ * Prisma Compute, an AWS Lambda Function, and a Cloudflare Container. A
+ * container is a real process with no workerd bindings, so `env` is the only
+ * channel it has — the same contract the other two expose.
+ */
 const supportsConnectEnvBinding = (
   host: ResourceLike | undefined,
 ): host is ConnectEnvBindingHost =>
-  host?.Type === "Prisma.Compute" || host?.Type === "AWS.Lambda.Function";
+  host?.Type === "Prisma.Compute" ||
+  host?.Type === "AWS.Lambda.Function" ||
+  host?.Type === "Cloudflare.Container";
 
 const supportsConnectWorkerBinding = (
   host: ResourceLike | undefined,
@@ -376,7 +410,7 @@ export const ConnectBinding = Layer.effect(
         } else {
           return yield* Effect.die(
             new Error(
-              `Prisma.Connect supports Prisma.Compute, AWS.Lambda.Function, and Cloudflare.Worker runtimes, got '${host?.Type ?? "no host"}'`,
+              `Prisma.Connect supports Prisma.Compute, AWS.Lambda.Function, Cloudflare.Worker, and Cloudflare.Container runtimes, got '${host?.Type ?? "no host"}'`,
             ),
           );
         }

--- a/packages/alchemy/test/Cloudflare/Container/Container.test.ts
+++ b/packages/alchemy/test/Cloudflare/Container/Container.test.ts
@@ -88,6 +88,23 @@ describe.concurrent.each([
       { timeout },
     );
 
+    // A container is a real process — it has no workerd bindings, so a
+    // capability's only channel into it is the binding contract's `env`.
+    // The provider used to declare that contract and silently drop the
+    // values; this pins that a `Binding.Service`'s `host.bind({ env })`
+    // lands in the container's `process.env`, resolved Output and all.
+    // Same mechanism `Prisma.Connect` rides into a container.
+    test(
+      "a Binding.Service's bound env reaches the container",
+      Effect.gen(function* () {
+        const { url, bucketName } = yield* stack;
+
+        const body = yield* fetchReady(new URL("/bound-env", url), bucketName);
+        expect(JSON.parse(body)).toEqual({ value: bucketName });
+      }).pipe(logLevel),
+      { timeout },
+    );
+
     test(
       "RPC: reads an R2 object from inside the container",
       Effect.gen(function* () {

--- a/packages/alchemy/test/Cloudflare/Container/Container.test.ts
+++ b/packages/alchemy/test/Cloudflare/Container/Container.test.ts
@@ -8,6 +8,7 @@ import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
 import EffectfulStack from "./fixtures/effectful/stack.ts";
 import ExternalStack from "./fixtures/external/stack.ts";
+import { DEMO_PLAIN, DEMO_SECRET } from "./fixtures/remote/object.ts";
 import RemoteStack from "./fixtures/remote/stack.ts";
 
 describe.concurrent.each([
@@ -164,6 +165,27 @@ describe.concurrent.each([
 
         const hello = yield* fetchReady(new URL("/hello", url), "method");
         expect(hello).toContain("method");
+      }).pipe(logLevel),
+      { timeout },
+    );
+
+    // A pre-built image has no Effect runtime to inject config into, so `env`
+    // is the only channel: it lands as the ContainerApplication's
+    // `environmentVariables` and shows up as plain `process.env` entries
+    // inside the image. Covers all three value shapes — a literal, a
+    // `Redacted` (encrypted in state, plain in the container), and an Output
+    // resolved from a sibling resource (the canonical shape of a database
+    // connection string).
+    test(
+      "passes env — literal, Redacted, and sibling-resource Output — into the image",
+      Effect.gen(function* () {
+        const { url, bucketName } = yield* stack;
+        const body = yield* fetchReady(new URL("/hello", url), "DEMO_PLAIN");
+        const echoed = JSON.parse(body) as { env: Record<string, string> };
+
+        expect(echoed.env.DEMO_PLAIN).toBe(DEMO_PLAIN);
+        expect(echoed.env.DEMO_SECRET).toBe(DEMO_SECRET);
+        expect(echoed.env.DEMO_BUCKET).toBe(bucketName);
       }).pipe(logLevel),
       { timeout },
     );

--- a/packages/alchemy/test/Cloudflare/Container/fixtures/effectful/container.ts
+++ b/packages/alchemy/test/Cloudflare/Container/fixtures/effectful/container.ts
@@ -2,14 +2,18 @@ import * as Cloudflare from "@/Cloudflare";
 import * as Alchemy from "@/index.ts";
 import type { RuntimeContext } from "@/RuntimeContext.ts";
 import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
 import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import { ProbeEnv, ProbeEnvBinding } from "./env-binding.ts";
 import { Storage } from "./storage.ts";
 
 export class MyContainer extends Cloudflare.Container<
   MyContainer,
   {
     ping: () => Effect.Effect<string>;
+    /** The value a `Binding.Service` injected into the container's env. */
+    boundEnv: () => Effect.Effect<string | undefined, never, RuntimeContext>;
     /** Read an object's text body from R2 (or `null` when absent). */
     readObject: (
       key: string,
@@ -35,6 +39,11 @@ export default MyContainer.make(
       Alchemy.remote(),
     );
 
+    // A capability whose only deploy-time contribution is an env var. A
+    // container has no workerd bindings, so this is the channel every
+    // env-shaped capability (Prisma.Connect, …) reaches it through.
+    const boundEnv = yield* ProbeEnv(Storage);
+
     const read = (key: string) =>
       bucket.get(key).pipe(
         Effect.flatMap((object) =>
@@ -45,10 +54,14 @@ export default MyContainer.make(
 
     return {
       ping: () => Effect.succeed("pong"),
+      boundEnv: () => boundEnv,
       readObject: read,
       fetch: Effect.gen(function* () {
         const request = yield* HttpServerRequest;
         const url = new URL(request.url, "http://container");
+        if (url.pathname === "/bound-env") {
+          return yield* HttpServerResponse.json({ value: yield* boundEnv });
+        }
         if (url.pathname === "/health") {
           return yield* HttpServerResponse.json({ ok: true });
         }
@@ -60,5 +73,9 @@ export default MyContainer.make(
         return HttpServerResponse.text("hello from effectful container");
       }),
     };
-  }).pipe(Effect.provide(Cloudflare.R2.ReadWriteBucketHttp)),
+  }).pipe(
+    Effect.provide(
+      Layer.mergeAll(Cloudflare.R2.ReadWriteBucketHttp, ProbeEnvBinding),
+    ),
+  ),
 );

--- a/packages/alchemy/test/Cloudflare/Container/fixtures/effectful/env-binding.ts
+++ b/packages/alchemy/test/Cloudflare/Container/fixtures/effectful/env-binding.ts
@@ -1,0 +1,68 @@
+import * as Binding from "@/Binding.ts";
+import type { Bucket } from "@/Cloudflare/R2/Bucket.ts";
+import type { Resource, ResourceLike } from "@/Resource.ts";
+import type { RuntimeContext } from "@/RuntimeContext.ts";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+/**
+ * The env var the binding injects into whichever host it is provided on.
+ */
+export const PROBE_ENV_KEY = "ALCHEMY_TEST_BOUND_ENV";
+
+/**
+ * A minimal `Binding.Service` whose entire deploy-time contribution is an
+ * environment variable — the shape `Prisma.Connect` uses for a Prisma
+ * Compute app, a Lambda Function, and (as of this fixture's coverage) a
+ * Cloudflare Container.
+ *
+ * A container is a real process, so it has no workerd bindings: `env` is the
+ * only channel a capability has to reach it. This proves the container
+ * provider actually folds the binding contract's `env` into the deployed
+ * application's environment variables — it used to declare the contract and
+ * silently drop the values.
+ */
+export interface ProbeEnv extends Binding.Service<
+  ProbeEnv,
+  "Test.ProbeEnv",
+  (
+    bucket: Bucket,
+  ) => Effect.Effect<Effect.Effect<string | undefined, never, RuntimeContext>>
+> {}
+
+export const ProbeEnv = Binding.Service<ProbeEnv>("Test.ProbeEnv");
+
+type EnvBindingHost = Resource<
+  string,
+  object | undefined,
+  object,
+  { env?: Record<string, any> }
+>;
+
+const acceptsEnvBinding = (
+  host: ResourceLike | undefined,
+): host is EnvBindingHost => host?.Type === "Cloudflare.Container";
+
+export const ProbeEnvBinding = Layer.effect(
+  ProbeEnv,
+  Effect.succeed(
+    Effect.fn(function* (bucket: Bucket) {
+      if (!globalThis.__ALCHEMY_RUNTIME__) {
+        const host = yield* Binding.Host;
+        if (!acceptsEnvBinding(host)) {
+          return yield* Effect.die(
+            new Error(
+              `Test.ProbeEnv expects a Cloudflare.Container host, got '${host?.Type ?? "no host"}'`,
+            ),
+          );
+        }
+        // The value is an Output of a sibling resource's attribute, so this
+        // also pins that bound env survives Output resolution.
+        yield* host.bind`${bucket}`({
+          env: { [PROBE_ENV_KEY]: bucket.bucketName },
+        });
+      }
+      return Effect.sync(() => process.env[PROBE_ENV_KEY]);
+    }),
+  ),
+);

--- a/packages/alchemy/test/Cloudflare/Container/fixtures/effectful/object.ts
+++ b/packages/alchemy/test/Cloudflare/Container/fixtures/effectful/object.ts
@@ -28,6 +28,8 @@ export class Object extends Cloudflare.DurableObject<Object>()(
           bucket.put(key, value).pipe(Effect.asVoid),
         get: (key: string) => bucket.get(key),
         ping: () => container.ping(),
+        // The env var a `Binding.Service` injected into the container.
+        boundEnv: () => container.boundEnv(),
         // Read the object from inside the container over RPC.
         readObjectRpc: (key: string) => container.readObject(key),
         // Read the object from inside the container over its TCP port (fetch).

--- a/packages/alchemy/test/Cloudflare/Container/fixtures/effectful/stack.ts
+++ b/packages/alchemy/test/Cloudflare/Container/fixtures/effectful/stack.ts
@@ -2,6 +2,7 @@ import * as Cloudflare from "@/Cloudflare";
 import * as Alchemy from "@/index.ts";
 import * as Effect from "effect/Effect";
 import MyContainerLive from "./container.ts";
+import { Storage } from "./storage.ts";
 import Worker from "./worker.ts";
 
 export default Alchemy.Stack(
@@ -12,10 +13,12 @@ export default Alchemy.Stack(
   },
   Effect.gen(function* () {
     const worker = yield* Worker;
+    const storage = yield* Storage;
     // yield* MyContainer.Application
 
     return {
       url: worker.url.as<string>(),
+      bucketName: storage.bucketName,
     };
   }).pipe(Effect.provide(MyContainerLive)),
 );

--- a/packages/alchemy/test/Cloudflare/Container/fixtures/effectful/worker.ts
+++ b/packages/alchemy/test/Cloudflare/Container/fixtures/effectful/worker.ts
@@ -25,6 +25,12 @@ export default Cloudflare.Worker(
           return HttpServerResponse.text(pong);
         }
 
+        // The env var a `Binding.Service` bound onto the container.
+        if (url.pathname === "/bound-env") {
+          const value = yield* object.boundEnv();
+          return yield* HttpServerResponse.json({ value: value ?? null });
+        }
+
         // Seed R2 through the DO's native binding.
         if (request.method === "PUT" && url.pathname === "/seed") {
           const key = url.searchParams.get("key") ?? "";

--- a/packages/alchemy/test/Cloudflare/Container/fixtures/remote/object.ts
+++ b/packages/alchemy/test/Cloudflare/Container/fixtures/remote/object.ts
@@ -1,13 +1,38 @@
 import * as Cloudflare from "@/Cloudflare";
 import * as Effect from "effect/Effect";
+import * as Redacted from "effect/Redacted";
 import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+
+/**
+ * A sibling resource whose output is threaded into the container's `env`,
+ * proving that a pre-built image (no Effect bundling, no `.make()`) receives
+ * environment variables that resolve from other resources in the stack.
+ */
+export const EnvBucket = Cloudflare.R2.Bucket("RemoteContainerEnvBucket", {
+  forceDestroy: true,
+});
+
+/** Plain-text env value the container is expected to echo back verbatim. */
+export const DEMO_PLAIN = "hello-from-env";
+/** `Redacted` env value — encrypted in state, plain inside the container. */
+export const DEMO_SECRET = "sh-hh-its-a-secret";
 
 export class RemoteContainer extends Cloudflare.Container<RemoteContainer>()(
   "RemoteContainer",
-  {
-    image: "mendhak/http-https-echo:latest",
-    observability: { logs: { enabled: true } },
-  },
+  Effect.gen(function* () {
+    const bucket = yield* EnvBucket;
+    return {
+      image: "mendhak/http-https-echo:latest",
+      observability: { logs: { enabled: true } },
+      env: {
+        // Tells the echo image to include `process.env` in its JSON response.
+        ECHO_INCLUDE_ENV_VARS: "1",
+        DEMO_PLAIN,
+        DEMO_SECRET: Redacted.make(DEMO_SECRET),
+        DEMO_BUCKET: bucket.bucketName,
+      },
+    };
+  }),
 ) {}
 
 /**

--- a/packages/alchemy/test/Cloudflare/Container/fixtures/remote/stack.ts
+++ b/packages/alchemy/test/Cloudflare/Container/fixtures/remote/stack.ts
@@ -1,13 +1,15 @@
 import * as Cloudflare from "@/Cloudflare";
 import * as Alchemy from "@/index.ts";
 import * as Effect from "effect/Effect";
+import { EnvBucket } from "./object.ts";
 import RemoteContainerWorker from "./worker.ts";
 
 export default Alchemy.Stack(
   "RemoteContainerStack",
   { providers: Cloudflare.providers(), state: Cloudflare.state() },
   Effect.gen(function* () {
+    const bucket = yield* EnvBucket;
     const worker = yield* RemoteContainerWorker;
-    return { url: worker.url.as<string>() };
+    return { url: worker.url.as<string>(), bucketName: bucket.bucketName };
   }),
 );

--- a/website/src/content/docs/cloudflare/compute/containers.mdx
+++ b/website/src/content/docs/cloudflare/compute/containers.mdx
@@ -260,74 +260,37 @@ before the container application that reads its name.
 
 ## Connect to a SQL database
 
-Hyperdrive is a *Worker* binding — `Cloudflare.Hyperdrive.Connect`
-only resolves inside a deployed Worker, and the same is true of
-`Prisma.Connect`. A container has neither, so it connects to
-Postgres or MySQL the ordinary way: a connection string over TCP.
-
-Give it the provider's **pooled** endpoint (Neon's pgbouncer URI,
-PlanetScale's PSBouncer URL, Prisma's pooled connection string) —
-nothing else is pooling those connections on the container's behalf:
+An **effectful** (`main`) container runs your Effect program, so it
+resolves a database capability the same way a Worker does — declare
+the connection once, then bind it:
 
 ```typescript
 // src/Db.ts
-import * as Neon from "alchemy/Neon";
+import * as Prisma from "alchemy/Prisma";
 import * as Effect from "effect/Effect";
 
-export const Db = Effect.gen(function* () {
-  const project = yield* Neon.Project("app-db", { region: "aws-us-east-1" });
-  const branch = yield* Neon.Branch("app-branch", { project });
-  return { project, branch };
+export const Connection = Effect.gen(function* () {
+  const project = yield* Prisma.Project("app", {
+    createDatabase: false,
+    region: "us-east-1",
+  });
+  const postgres = yield* Prisma.Postgres("db", {
+    project,
+    region: "us-east-1",
+  });
+  return yield* Prisma.Connection("api", { database: postgres });
 });
 ```
 
 ```typescript
-// src/Api.ts
-import * as Cloudflare from "alchemy/Cloudflare";
-import * as Effect from "effect/Effect";
-import { Db } from "./Db.ts";
-
-export class Api extends Cloudflare.Container<Api>()(
-  "Api",
-  Effect.gen(function* () {
-    const { branch } = yield* Db;
-    return {
-      context: `${import.meta.dirname}/api`,
-      ports: [{ name: "http", port: 8080 }],
-      env: {
-        DATABASE_URL: branch.pooledConnectionUri,
-        PORT: "8080",
-      },
-    };
-  }),
-) {}
-```
-
-Your image reads `DATABASE_URL` with whatever client it already
-uses — `pg`, Prisma, Rails, Django. Nothing about the container is
-alchemy-specific; only the value's provenance is.
-
-Then start it with outbound networking, or the container never
-reaches the database at all:
-
-```typescript
-Effect.provide(Cloudflare.Containers.layer(Api, { enableInternet: true }))
-```
-
-A Worker fronting the same database still binds Hyperdrive — see
-[Hyperdrive](/cloudflare/data/hyperdrive). The two coexist: point
-Hyperdrive at the *direct* origin (it pools for the Worker) and the
-container at the pooled one.
-
-## Bind a capability into an effectful container
-
-Everything above is manual env plumbing, which is what an arbitrary
-image needs — it knows nothing about alchemy. An **effectful**
-(`main`) container runs your Effect program, so it can resolve
-capabilities the same way a Worker does:
-
-```typescript
 // src/Api.runtime.ts
+import * as Prisma from "alchemy/Prisma";
+import * as SQL from "alchemy/SQL/Postgres";
+import * as Effect from "effect/Effect";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import { Api } from "./Api.ts";
+import { Connection } from "./Db.ts";
+
 export default Api.make(
   { main: import.meta.url },
   Effect.gen(function* () {
@@ -344,22 +307,74 @@ export default Api.make(
 );
 ```
 
-The container never sees a binding: it is a process, not a Worker.
-What it gets is environment variables — the capability writes them
-at deploy time and reads them back at runtime, so you never name
-`DATABASE_URL` yourself.
+You never name `DATABASE_URL`. The container has no bindings — it is
+a process, not a Worker — so `Prisma.Connect` writes the connection's
+outputs onto the deployment as environment variables and reads them
+back at runtime. The capability owns both ends.
 
-That divides capabilities cleanly in two. A capability whose config
-travels as env vars works in a container: `Prisma.Connect`, and the
+Start it with outbound networking, or the container never reaches the
+database at all:
+
+```typescript
+Effect.provide(Cloudflare.Containers.layer(Api, { enableInternet: true }))
+```
+
+## Connect an arbitrary image to a database
+
+An image you brought yourself knows nothing about alchemy, so there
+is no capability to bind — you name the variable and hand it the
+connection string. Give it the provider's **pooled** endpoint
+(Prisma's `databaseUrl` already prefers it; on Neon it is
+`branch.pooledConnectionUri`, on PlanetScale `role.connectionUrlPooled`),
+since nothing else is pooling those connections on the container's
+behalf:
+
+```typescript
+// src/Web.ts
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import { Connection } from "./Db.ts";
+
+export class Web extends Cloudflare.Container<Web>()(
+  "Web",
+  Effect.gen(function* () {
+    const connection = yield* Connection;
+    return {
+      context: `${import.meta.dirname}/web`,
+      ports: [{ name: "http", port: 8080 }],
+      env: {
+        DATABASE_URL: connection.databaseUrl,
+        PORT: "8080",
+      },
+    };
+  }),
+) {}
+```
+
+Your image reads `DATABASE_URL` with whatever client it already
+uses — `pg`, Prisma, Rails, Django. Nothing about the container is
+alchemy-specific; only the value's provenance is.
+
+A Worker fronting the same database still binds Hyperdrive — see
+[Hyperdrive](/cloudflare/data/hyperdrive). The two coexist: point
+Hyperdrive at the *direct* origin (it pools for the Worker) and the
+container at the pooled one.
+
+## Which capabilities reach a container
+
+The split follows the transport. A capability whose config travels as
+environment variables works in a container: `Prisma.Connect`, and the
 token-scoped HTTP clients for
 [R2](/cloudflare/data/r2), [KV](/cloudflare/data/kv), and
 [Queues](/cloudflare/messaging/queues) —
 `Cloudflare.R2.ReadWriteBucketHttp` and friends, which mint a scoped
-API token instead of using a native binding. A capability that *is*
-a workerd binding cannot: `Cloudflare.Hyperdrive.Connect`,
-`Cloudflare.D1.QueryDatabase`, and every `*Binding` layer resolve
-against the Workers runtime, which no container process has. Use the
-`*Http` layer where one exists, and env vars otherwise.
+API token instead of using a native binding.
+
+A capability that *is* a workerd binding cannot:
+`Cloudflare.Hyperdrive.Connect`, `Cloudflare.D1.QueryDatabase`, and
+every `*Binding` layer resolve against the Workers runtime, which no
+container process has. Use the `*Http` layer where one exists, and
+environment variables otherwise.
 
 ## Bind on an async Worker
 

--- a/website/src/content/docs/cloudflare/compute/containers.mdx
+++ b/website/src/content/docs/cloudflare/compute/containers.mdx
@@ -200,6 +200,125 @@ for example a digest reference pushed by CI, like
 deploys the reference as-is and skips the docker pull and push
 entirely.
 
+## Configure the container with `env`
+
+A container is a process, not a Worker: it has no bindings, so every
+piece of configuration reaches it as an environment variable. `env`
+takes a plain map and lands each entry on the deployment, where the
+program reads it from `process.env` — the same for a generated
+(`main`) image, a `context` build, and a pre-built `image`:
+
+```typescript
+export class Api extends Cloudflare.Container<Api>()("Api", {
+  context: `${import.meta.dirname}/api`,
+  ports: [{ name: "http", port: 8080 }],
+  env: {
+    PORT: "8080",
+    LOG_LEVEL: "info",
+  },
+}) {}
+```
+
+Values are strings. Wrap a secret in `Redacted` and it stays
+encrypted in alchemy's state and out of plan output, while the
+container still reads a plain string:
+
+```typescript
+env: {
+  SESSION_KEY: Redacted.make(process.env.SESSION_KEY!),
+}
+```
+
+## Read another resource's outputs
+
+A class body is module scope, so there is nowhere to `yield*` the
+bucket, queue, or database whose output you need — and a bare
+declaration is an Effect, not a resolved handle, so
+`Uploads.bucketName` is `undefined` until something yields it. Pass
+the props as an `Effect.gen` instead; inside it, sibling resources
+resolve like anywhere else:
+
+```typescript
+import * as Effect from "effect/Effect";
+
+export const Uploads = Cloudflare.R2.Bucket("Uploads");
+
+export class Api extends Cloudflare.Container<Api>()(
+  "Api",
+  Effect.gen(function* () {
+    const uploads = yield* Uploads;
+    return {
+      context: `${import.meta.dirname}/api`,
+      env: { BUCKET_NAME: uploads.bucketName },
+    };
+  }),
+) {}
+```
+
+The reference is what orders the deploy: the bucket is created
+before the container application that reads its name.
+
+## Connect to a SQL database
+
+Hyperdrive is a *Worker* binding — `Cloudflare.Hyperdrive.Connect`
+only resolves inside a deployed Worker, and the same is true of
+`Prisma.Connect`. A container has neither, so it connects to
+Postgres or MySQL the ordinary way: a connection string over TCP.
+
+Give it the provider's **pooled** endpoint (Neon's pgbouncer URI,
+PlanetScale's PSBouncer URL, Prisma's pooled connection string) —
+nothing else is pooling those connections on the container's behalf:
+
+```typescript
+// src/Db.ts
+import * as Neon from "alchemy/Neon";
+import * as Effect from "effect/Effect";
+
+export const Db = Effect.gen(function* () {
+  const project = yield* Neon.Project("app-db", { region: "aws-us-east-1" });
+  const branch = yield* Neon.Branch("app-branch", { project });
+  return { project, branch };
+});
+```
+
+```typescript
+// src/Api.ts
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import { Db } from "./Db.ts";
+
+export class Api extends Cloudflare.Container<Api>()(
+  "Api",
+  Effect.gen(function* () {
+    const { branch } = yield* Db;
+    return {
+      context: `${import.meta.dirname}/api`,
+      ports: [{ name: "http", port: 8080 }],
+      env: {
+        DATABASE_URL: branch.pooledConnectionUri,
+        PORT: "8080",
+      },
+    };
+  }),
+) {}
+```
+
+Your image reads `DATABASE_URL` with whatever client it already
+uses — `pg`, Prisma, Rails, Django. Nothing about the container is
+alchemy-specific; only the value's provenance is.
+
+Then start it with outbound networking, or the container never
+reaches the database at all:
+
+```typescript
+Effect.provide(Cloudflare.Containers.layer(Api, { enableInternet: true }))
+```
+
+A Worker fronting the same database still binds Hyperdrive — see
+[Hyperdrive](/cloudflare/data/hyperdrive). The two coexist: point
+Hyperdrive at the *direct* origin (it pools for the Worker) and the
+container at the pooled one.
+
 ## Bind on an async Worker
 
 An async Worker can host a container-backed Durable Object class

--- a/website/src/content/docs/cloudflare/compute/containers.mdx
+++ b/website/src/content/docs/cloudflare/compute/containers.mdx
@@ -319,6 +319,48 @@ A Worker fronting the same database still binds Hyperdrive — see
 Hyperdrive at the *direct* origin (it pools for the Worker) and the
 container at the pooled one.
 
+## Bind a capability into an effectful container
+
+Everything above is manual env plumbing, which is what an arbitrary
+image needs — it knows nothing about alchemy. An **effectful**
+(`main`) container runs your Effect program, so it can resolve
+capabilities the same way a Worker does:
+
+```typescript
+// src/Api.runtime.ts
+export default Api.make(
+  { main: import.meta.url },
+  Effect.gen(function* () {
+    const db = yield* Prisma.Connect(Connection);
+    const sql = yield* SQL.Postgres({ url: db.databaseUrl });
+
+    return Api.of({
+      fetch: Effect.gen(function* () {
+        const users = yield* sql`SELECT * FROM users`;
+        return yield* HttpServerResponse.json(users);
+      }),
+    });
+  }).pipe(Effect.provide(Prisma.ConnectBinding)),
+);
+```
+
+The container never sees a binding: it is a process, not a Worker.
+What it gets is environment variables — the capability writes them
+at deploy time and reads them back at runtime, so you never name
+`DATABASE_URL` yourself.
+
+That divides capabilities cleanly in two. A capability whose config
+travels as env vars works in a container: `Prisma.Connect`, and the
+token-scoped HTTP clients for
+[R2](/cloudflare/data/r2), [KV](/cloudflare/data/kv), and
+[Queues](/cloudflare/messaging/queues) —
+`Cloudflare.R2.ReadWriteBucketHttp` and friends, which mint a scoped
+API token instead of using a native binding. A capability that *is*
+a workerd binding cannot: `Cloudflare.Hyperdrive.Connect`,
+`Cloudflare.D1.QueryDatabase`, and every `*Binding` layer resolve
+against the Workers runtime, which no container process has. Use the
+`*Http` layer where one exists, and env vars otherwise.
+
 ## Bind on an async Worker
 
 An async Worker can host a container-backed Durable Object class

--- a/website/src/content/docs/cloudflare/data/hyperdrive.mdx
+++ b/website/src/content/docs/cloudflare/data/hyperdrive.mdx
@@ -387,7 +387,10 @@ inside a deployed Worker — the binding resolves it at runtime — so
 anything else that talks to the database (CI jobs, a container,
 `psql` on your laptop) should connect to the pooled URI directly:
 `branch.pooledConnectionUri` on Neon, `role.connectionUrlPooled` on
-PlanetScale. Just don't do the reverse — `origin` deliberately
+PlanetScale. For a container that means passing the pooled URI in as
+an environment variable — see
+[Connect to a SQL database](/cloudflare/compute/containers#connect-to-a-sql-database).
+Just don't do the reverse — `origin` deliberately
 points Hyperdrive at the *direct* endpoint, because Hyperdrive
 already pools, and stacking it on top of the provider's pooler
 means two poolers fighting over the same connections.

--- a/website/src/content/docs/prisma/data/connections.mdx
+++ b/website/src/content/docs/prisma/data/connections.mdx
@@ -81,9 +81,9 @@ Accelerate-only database has no direct Postgres endpoint, so
 
 ## The Connect binding
 
-Inside a Prisma Compute app, AWS Lambda function, or Cloudflare
-Worker, `Prisma.Connect` resolves the bound connection at runtime as
-a typed client:
+Inside a Prisma Compute app, AWS Lambda function, Cloudflare Worker,
+or Cloudflare Container, `Prisma.Connect` resolves the bound
+connection at runtime as a typed client:
 
 ```typescript
 Effect.gen(function* () {
@@ -100,9 +100,16 @@ Effect.gen(function* () {
 ```
 
 At deploy time the binding carries the connection's outputs into the
-host's environment (env vars on Compute and Lambda, secret text
-bindings on Workers); at runtime `db.databaseUrl` and friends read
-them back as `Redacted` values.
+host's environment (env vars on Compute, Lambda, and Containers;
+secret text bindings on Workers); at runtime `db.databaseUrl` and
+friends read them back as `Redacted` values.
+
+A container is a real process with no workerd bindings, so env vars
+are its only channel — which is exactly why `Prisma.Connect` reaches
+it and `Cloudflare.Hyperdrive.Connect` does not. Start the container
+with `Cloudflare.Containers.layer(Api, { enableInternet: true })` so
+it can reach the database. See
+[Bind a capability into an effectful container](/cloudflare/compute/containers#bind-a-capability-into-an-effectful-container).
 
 ## Rotation
 


### PR DESCRIPTION
Fixes #1275

Cloudflare Containers have no bindings — every piece of configuration reaches them as an environment variable. Two things were broken, plus the docs that would have explained either.

### Binding-contract `env` was silently dropped

`ContainerApplication` declares `env` in its binding contract, but neither the live nor the local provider ever merged it. A `Binding.Service` doing this on a container was a no-op — the value never reached `process.env`:

```ts
yield* host.bind`${connection}`({ env: { DATABASE_URL: ... } })
```

`bindings` now threads through `makeContainerEnv` at lowest precedence, so an explicit `env` / `environmentVariables` entry still wins. Precreate has no bindings by design (that's what breaks the worker ↔ container cycle), so injected env lands on the following reconcile.

`Prisma.Connect` accepts a `Cloudflare.Container` host as a result — a container is a real process whose only config channel is env vars, the same contract Prisma Compute and Lambda expose. An effectful (`main`) container now binds a capability exactly like a Worker does:

```ts
// src/Api.ts — the class
export class Api extends Cloudflare.Container<Api, {}>()("Api") {}
```

```ts
// src/Api.runtime.ts — the runtime, bundled into the image
export default Api.make(
  { main: import.meta.url },
  Effect.gen(function* () {
    const db = yield* Prisma.Connect(Connection);
    const sql = yield* SQL.Postgres({ url: db.databaseUrl });

    return Api.of({
      fetch: Effect.gen(function* () {
        const users = yield* sql`SELECT * FROM users`;
        return yield* HttpServerResponse.json(users);
      }),
    });
  }).pipe(Effect.provide(Prisma.ConnectBinding)),
);
```

No `env` plumbing in the stack: `Prisma.Connect` binds the connection's outputs onto the ContainerApplication at deploy time and reads them back out of `process.env` at runtime. Start it with `Cloudflare.Containers.layer(Api, { enableInternet: true })` so it can reach the database.

Hyperdrive stays Worker-only — it *is* a workerd binding, so no container process can resolve it.

### Container props couldn't reference another resource

A class body is module scope, so there is nowhere to `yield*` the database whose connection string you need. Container props now also accept an `Effect`, the same shape `.make()` already took:

```ts
export class Api extends Cloudflare.Container<Api>()(
  "Api",
  Effect.gen(function* () {
    const { branch } = yield* Db;
    return {
      context: `${import.meta.dirname}/api`,
      env: { DATABASE_URL: branch.pooledConnectionUri },
    };
  }),
) {}
```

Before, `env: { DATABASE_URL: Db.connectionString }` silently deployed `undefined` — a module-scope declaration is an Effect, not a resolved handle. `className` now resolves from the props Effect in `bindContainerClass` instead of being read synchronously off the declaration.

### Docs

New sections in [Containers](https://alchemy.run/cloudflare/compute/containers):

- **Configure the container with `env`** — plain values and `Redacted` secrets, for `main` / `context` / `image` alike
- **Read another resource's outputs** — the `Effect.gen` props form and why it's needed
- **Connect to a SQL database** — leads with the effectful container yielding `Prisma.Connect`, plus `enableInternet: true`
- **Connect an arbitrary image to a database** — the hand-plumbed `env` form, for an image that knows nothing about alchemy
- **Which capabilities reach a container** — env-var capabilities (`Prisma.Connect`, the `*Http` clients for R2/KV/Queues) vs workerd bindings that can't (`Hyperdrive.Connect`, `D1.QueryDatabase`, every `*Binding` layer)

Same guidance on the `Container` and `Prisma.Connect` JSDoc; the Hyperdrive and Prisma Connections pages link across.

### Coverage

`Container.test.ts`, in both `dev: true` and `dev: false`:

- a pre-built (`image`) container receives all three env value shapes — literal, `Redacted`, and an Output resolved from a sibling R2 bucket
- a `Binding.Service`'s `host.bind({ env })` reaches an effectful container's `process.env`, Output resolution and all

The binding test was verified to fail without the provider fix.


