### PR TITLE
chore: publish Hetzner in PR package previews

### DIFF
--- a/.github/workflows/pr-package.yml
+++ b/.github/workflows/pr-package.yml
@@ -73,6 +73,7 @@ jobs:
               { "dir": "distilled/packages/aws",         "name": "@distilled.cloud/aws",               "group": "Distilled", "submodule": true },
               { "dir": "distilled/packages/axiom",       "name": "@distilled.cloud/axiom",             "group": "Distilled", "submodule": true },
               { "dir": "distilled/packages/cloudflare",  "name": "@distilled.cloud/cloudflare",        "group": "Distilled", "submodule": true },
+              { "dir": "distilled/packages/hetzner",     "name": "@distilled.cloud/hetzner",           "group": "Distilled", "submodule": true },
               { "dir": "distilled/packages/neon",        "name": "@distilled.cloud/neon",              "group": "Distilled", "submodule": true },
               { "dir": "distilled/packages/planetscale", "name": "@distilled.cloud/planetscale",       "group": "Distilled", "submodule": true }
             ]

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:clean:shallow": "bun clean:shallow . && bun run build",
     "build:cloudflare-packages": "bun tsc -b distilled/packages/cloudflare/tsconfig.json && turbo run build --filter=@alchemy.run/cloudflare-runtime --filter=@alchemy.run/frontend-frameworks --filter=@alchemy.run/cloudflare-test-tools",
     "build:packages": "bun tsc -b && pnpm --filter './packages/*' build",
-    "build:pr-packages": "turbo run build --filter=alchemy --filter=@alchemy.run/better-auth --filter=@alchemy.run/cloudflare-runtime --filter=@alchemy.run/frontend-frameworks --filter=@alchemy.run/pr-package --filter=@distilled.cloud/core --filter=@distilled.cloud/aws --filter=@distilled.cloud/axiom --filter=@distilled.cloud/cloudflare --filter=@distilled.cloud/neon --filter=@distilled.cloud/planetscale",
+    "build:pr-packages": "turbo run build --filter=alchemy --filter=@alchemy.run/better-auth --filter=@alchemy.run/cloudflare-runtime --filter=@alchemy.run/frontend-frameworks --filter=@alchemy.run/pr-package --filter=@distilled.cloud/core --filter=@distilled.cloud/aws --filter=@distilled.cloud/axiom --filter=@distilled.cloud/cloudflare --filter=@distilled.cloud/hetzner --filter=@distilled.cloud/neon --filter=@distilled.cloud/planetscale",
     "clean": "git clean -fqdx -e .env",
     "clean:shallow": "rm -rf alchemy/*.tgz && bun tsc -b --clean",
     "clear:state": "alchemy state clear ./stacks/nuke.ts",


### PR DESCRIPTION
## Summary

- build `@distilled.cloud/hetzner` in the PR-package workflow
- publish its preview tarball and include its install URL alongside the other Distilled packages
- complete the workspace dependency closure for the published `alchemy` preview package

## Problem

Installing an Alchemy PR preview failed because `alchemy` depends on `@distilled.cloud/hetzner` via `workspace:*`, but Hetzner was absent from the preview package list. The packed dependency therefore resolved to the unpublished registry version and failed with:

```text
No version matching "1.0.0-rc.4" found for specifier "@distilled.cloud/hetzner"
```

## Validation

- reproduced the failure from the current PR-preview URL
- built `@distilled.cloud/hetzner` and its core dependency successfully
- verified the configured PR-preview package set has a complete workspace dependency closure (14 packages)
- `git diff --check`