### PR TITLE
docs(website): beta.73 release blog, local-emulator blog, per-cloud local dev pages

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -616,6 +616,10 @@ export default defineConfig({
             { label: "Overview", link: "/cloudflare" },
             { label: "Setup", link: "/cloudflare/setup" },
             {
+              label: "Local development",
+              link: "/cloudflare/local-development",
+            },
+            {
               label: "Tutorial",
               items: [{ autogenerate: { directory: "cloudflare/tutorial" } }],
             },
@@ -826,6 +830,7 @@ export default defineConfig({
           items: [
             { label: "Overview", link: "/aws" },
             { label: "Setup", link: "/aws/setup" },
+            { label: "Local development", link: "/aws/local-development" },
             {
               label: "Tutorial",
               items: [{ autogenerate: { directory: "aws/tutorial" } }],

--- a/website/src/content/docs/aws/local-development.mdx
+++ b/website/src/content/docs/aws/local-development.mdx
@@ -52,20 +52,39 @@ Each Lambda function executes in a local runtime container behind
 a working Function URL:
 
 ```typescript
-const api = yield* AWS.Lambda.Function("Api", { main: "./src/api.ts" });
-// http://b71ff5c0….lambda-url.us-east-1.localhost:4566/
+export default class Api extends AWS.Lambda.Function<Api>()(
+  "Api",
+  { main: import.meta.url, functionUrl: true },
+  Effect.gen(function* () {
+    const files = yield* AWS.S3.Bucket("Files");
+    const jobs = yield* AWS.SQS.Queue("Jobs");
+
+    const putObject = yield* AWS.S3.PutObject(files);
+    const sendMessage = yield* AWS.SQS.SendMessage(jobs);
+
+    return {
+      fetch: Effect.gen(function* () {
+        yield* putObject({ Key: "hello.txt", Body: "hello" });
+        yield* sendMessage({ MessageBody: "process hello.txt" });
+        return yield* HttpServerResponse.text("ok");
+      }).pipe(Effect.orDie),
+    };
+  }).pipe(
+    Effect.provide([AWS.S3.PutObjectHttp, AWS.SQS.SendMessageHttp]),
+  ),
+) {}
 ```
 
-Save `./src/api.ts` and the running function serves the new code
-in **~100–500ms** — no redeploy, no restart. The dev session
-watches your code's module graph, rebuilds, and swaps the code
-under the live Function URL.
+In dev, the function serves at a working local Function URL
+(`http://….lambda-url.us-east-1.localhost:4566/`), `putObject`
+lands in the local bucket, and `sendMessage` lands in the local
+queue. The SDK honors the standard `AWS_ENDPOINT_URL` environment
+override that the emulator injects into every dev container.
 
-Runtime bindings inside the function need zero wiring:
-`S3.putObject(...)` lands in the local bucket, `DynamoDB.getItem`
-reads the local table. The SDK honors the standard
-`AWS_ENDPOINT_URL` environment override that the emulator injects
-into every dev container.
+Save the file and the running function serves the new code in
+**~100–500ms** — no redeploy, no restart. The dev session watches
+your code's module graph, rebuilds, and swaps the code under the
+live Function URL.
 
 ## Websites run their own dev servers
 
@@ -92,15 +111,24 @@ ECS tasks and services run as real Docker containers, built and
 pushed through a local OCI registry:
 
 ```typescript
-const cluster = yield* AWS.ECS.Cluster("Cluster");
-
-// bundled Effect program — built into an image and running
-// as a container seconds later
-const api = yield* AWS.ECS.Task("Api", { main: "./src/api.ts", port: 8080 });
-
-// or your own Dockerfile
-const web = yield* AWS.ECS.Service("Web", { context: "./web", port: 3000 });
+// bundled Effect program — built into an image, pushed through
+// a local registry, running as a real container seconds later
+export default class Web extends AWS.ECS.Task<Web>()(
+  "Web",
+  { main: import.meta.url, port: 8080 },
+  Effect.gen(function* () {
+    return {
+      fetch: Effect.gen(function* () {
+        return HttpServerResponse.text("hello from a local container");
+      }),
+    };
+  }),
+) {}
 ```
+
+Bring-your-own-Dockerfile containers work too:
+`AWS.ECS.Service("Api", { context: "./api", port: 3000 })` builds
+your image and runs it the same way.
 
 The whole live pipeline runs unchanged: image build, `docker
 push`, task definitions, `RunTask`, and services that converge

--- a/website/src/content/docs/aws/local-development.mdx
+++ b/website/src/content/docs/aws/local-development.mdx
@@ -1,0 +1,190 @@
+---
+title: Local development
+description: alchemy dev runs your AWS stack on your machine — Lambda in Docker containers, local S3/DynamoDB/SQS, event sources firing, hot reload — with no AWS account or credentials required.
+---
+
+import Terminal from "../../../components/Terminal.astro";
+
+`alchemy dev` runs your AWS stack entirely on your machine — no
+AWS account, no credentials, no config. Lambda functions execute
+in Docker containers behind working Function URLs, websites run
+their frameworks' own dev servers with native HMR, ECS tasks run
+as real containers, and the surrounding services (S3, DynamoDB,
+SQS, SNS, EventBridge, and many more) are emulated locally. Code
+changes hot reload in ~100–500ms.
+
+```sh
+alchemy dev
+# no AWS credentials — using the local emulator
+```
+
+<Terminal content={`[g]✓[/g] [b]Files[/b] [d](AWS.S3.Bucket)[/d] [g]created[/g] [d](local)[/d]
+[g]✓[/g] [b]Users[/b] [d](AWS.DynamoDB.Table)[/d] [g]created[/g] [d](local)[/d]
+[g]✓[/g] [b]Jobs[/b] [d](AWS.SQS.Queue)[/d] [g]created[/g] [d](local)[/d]
+[g]✓[/g] [b]Api[/b] [d](AWS.Lambda.Function)[/d] [g]created[/g] [d](local → docker)[/d]
+[s2][d]• http://b71ff5c0….lambda-url.us-east-1.localhost:4566/[/d]
+
+[d]Watching for changes ...[/d]`} />
+
+## How it works
+
+Local AWS emulation is powered by
+[our fork](https://github.com/alchemy-run/floci) of
+[floci](https://floci.io), an MIT-licensed LocalStack-style
+emulator. The emulator starts automatically in Docker — one
+container (`alchemy-floci`) shared across projects and sessions —
+and your stack deploys into it in seconds. Resource identifiers
+carry the `dev:` marker and local endpoints
+(`localhost:4566`), which doubles as proof that no cloud call
+ran.
+
+We hold the emulator to the same bar as the real cloud: alchemy's
+live AWS test suites — the control-plane lifecycle tests and the
+data-plane binding tests that normally run against real AWS —
+also run against the emulator, and every fidelity gap they
+surface becomes a fix in the fork. See
+[Looping the Generation of Local Emulators](/blog/2026-08-20-generating-local-emulators)
+for how that loop works.
+
+## Lambda runs in containers
+
+Each Lambda function executes in a local runtime container behind
+a working Function URL:
+
+```typescript
+const api = yield* AWS.Lambda.Function("Api", { main: "./src/api.ts" });
+// http://b71ff5c0….lambda-url.us-east-1.localhost:4566/
+```
+
+Save `./src/api.ts` and the running function serves the new code
+in **~100–500ms** — no redeploy, no restart. The dev session
+watches your code's module graph, rebuilds, and swaps the code
+under the live Function URL.
+
+Runtime bindings inside the function need zero wiring:
+`S3.putObject(...)` lands in the local bucket, `DynamoDB.getItem`
+reads the local table. The SDK honors the standard
+`AWS_ENDPOINT_URL` environment override that the emulator injects
+into every dev container.
+
+## Websites run their own dev servers
+
+Every `AWS.Website.*` resource — Vite, Next.js, Astro, Nuxt,
+SvelteKit, Waku, Octane, StaticSite — runs its framework's own
+dev server under `alchemy dev`: native HMR, no cloud resources.
+The site's `url` is the local dev server's address:
+
+```typescript
+const site = yield* AWS.Website.Vite("Web");
+// dev:    site.url = http://localhost:5173 — Vite's own dev server, HMR included
+// deploy: site.url = the CloudFront distribution
+```
+
+The same stack deploys unchanged: `alchemy deploy` runs
+`vite build` and serves the output from S3 through CloudFront. For
+SSR frameworks, `server.environment` is delivered to the dev
+server's process env, so config reads work the same locally and
+deployed. See [AWS frontends](/aws/frontend/websites).
+
+## ECS tasks run as containers
+
+ECS tasks and services run as real Docker containers, built and
+pushed through a local OCI registry:
+
+```typescript
+const cluster = yield* AWS.ECS.Cluster("Cluster");
+
+// bundled Effect program — built into an image and running
+// as a container seconds later
+const api = yield* AWS.ECS.Task("Api", { main: "./src/api.ts", port: 8080 });
+
+// or your own Dockerfile
+const web = yield* AWS.ECS.Service("Web", { context: "./web", port: 3000 });
+```
+
+The whole live pipeline runs unchanged: image build, `docker
+push`, task definitions, `RunTask`, and services that converge
+exactly like AWS. Hot reload swaps a running container in ~6
+seconds — bundled tasks watch the deploy's exact module graph,
+Dockerfile tasks watch the build context, and services roll their
+tasks onto the new image revision. Emulated ALB listeners route
+to the local containers; each task is also reachable directly at
+its literal host port (`localhost:<port>`).
+
+## Event sources fire locally
+
+The glue between services works end to end in the emulator:
+SQS→Lambda event source mappings poll and deliver batches, S3
+notifications fire, EventBridge rules route, SNS subscriptions
+deliver, DynamoDB Streams pump changes, and EventBridge Scheduler
+schedules fire — so a `consumeQueueMessages` handler in a local
+Lambda drains a local queue exactly like it would in the cloud.
+
+## What's emulated
+
+Close to 40 services and over 200 resource types run against the
+local emulator in dev:
+
+| Category            | Services                                                                                                            |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Compute             | Lambda (functions, layers, versions, aliases, event source mappings, permissions), ECS, ECR, Batch, Auto Scaling, Application Auto Scaling |
+| APIs & delivery     | API Gateway (REST), API Gateway v2 (HTTP & WebSocket), AppSync, CloudFront (Distributions, Functions, KeyValueStore), WAFv2, ACM |
+| Storage & databases | S3, DynamoDB, RDS, Glue, Athena, S3 Vectors                                                                          |
+| Messaging & events  | SQS, SNS, EventBridge, Kinesis, Firehose, Pipes, Scheduler, Step Functions                                           |
+| Networking & DNS    | EC2 (VPCs, subnets, security groups, instances, …), ELBv2, Route 53, Cloud Map                                       |
+| Identity & security | IAM, Cognito, KMS, Secrets Manager                                                                                   |
+| Config & ops        | SSM Parameter Store, AppConfig, CloudWatch Logs, SES                                                                 |
+
+Resources without local emulation run against the real cloud in
+your personal [stage](/environments/stages) — a stack that mixes
+emulated and live-only resources just works.
+
+## Mix in the real cloud
+
+`Alchemy.remote()` opts any resource out of local emulation:
+
+```typescript
+// everything else is local; this one hits real AWS
+const secret = yield* AWS.SecretsManager.Secret("ProdSecret", { ... })
+  .pipe(Alchemy.remote());
+```
+
+If a remote resource needs credentials you don't have,
+`alchemy dev` tells you before touching anything:
+
+```text
+CredentialsRequired: 1 resource runs against the real cloud via Alchemy.remote():
+  - ProdSecret (AWS.SecretsManager.Secret)
+Run `alchemy login --profile <name>`, or set CI=1 to use environment credentials.
+```
+
+Switching a resource between local and live (or dev → deploy)
+plans a **replacement** — dev state never silently becomes cloud
+state. See
+[Local development](/environments/local-development) for the
+shared semantics.
+
+## Emulator management
+
+The emulator container outlives dev sessions — Docker is the
+supervisor, so there's nothing to babysit. Overrides when you
+want them:
+
+```sh
+ALCHEMY_FLOCI_IMAGE=floci:dev alchemy dev   # use your own emulator build
+```
+
+The default image is our patched release
+(`ghcr.io/alchemy-run/floci`).
+
+## Where next
+
+- [Local development](/environments/local-development) — the
+  shared `alchemy dev` concepts: hot reload, `Alchemy.remote()`,
+  and dev vs deploy semantics.
+- [AWS frontends](/aws/frontend/websites) — framework dev servers
+  under `alchemy dev`.
+- [Stages](/environments/stages) — how live-in-dev resources stay
+  isolated per developer.
+- [Local Providers](/infrastructure-as-code/local-provider) —
+  build the local implementation of a resource.

--- a/website/src/content/docs/blog/2026-08-20-beta-73.md
+++ b/website/src/content/docs/blog/2026-08-20-beta-73.md
@@ -93,9 +93,7 @@ export default class Api extends AWS.Lambda.Function<Api>()(
       }).pipe(Effect.orDie),
     };
   }).pipe(
-    Effect.provide(
-      Layer.mergeAll(AWS.S3.PutObjectHttp, AWS.SQS.SendMessageHttp),
-    ),
+    Effect.provide([AWS.S3.PutObjectHttp, AWS.SQS.SendMessageHttp]),
   ),
 ) {}
 ```
@@ -164,20 +162,29 @@ containers** on your machine, with hot reload
 ([#1185](https://github.com/alchemy-run/alchemy/pull/1185)):
 
 ```typescript
-const cluster = yield* AWS.ECS.Cluster("Cluster");
-
 // bundled Effect program — built into an image, pushed through
 // a local registry, running as a real container seconds later
-const api = yield* AWS.ECS.Task("Api", { main: "./src/api.ts", port: 8080 });
-
-// or your own Dockerfile
-const web = yield* AWS.ECS.Service("Web", { context: "./web", port: 3000 });
+export default class Web extends AWS.ECS.Task<Web>()(
+  "Web",
+  { main: import.meta.url, port: 8080 },
+  Effect.gen(function* () {
+    return {
+      fetch: Effect.gen(function* () {
+        return HttpServerResponse.text("hello from a local container");
+      }),
+    };
+  }),
+) {}
 ```
 
 ```text
 $ docker ps
-floci-ecs-…-api   Up 4 seconds   0.0.0.0:8080->8080/tcp
+floci-ecs-…-web   Up 4 seconds   0.0.0.0:8080->8080/tcp
 ```
+
+Bring-your-own-Dockerfile containers work too:
+`AWS.ECS.Service("Api", { context: "./api", port: 3000 })` builds
+your image and runs it the same way.
 
 The whole live pipeline runs unchanged against the emulator:
 image build, `docker push` through a real local OCI registry,

--- a/website/src/content/docs/blog/2026-08-20-beta-73.md
+++ b/website/src/content/docs/blog/2026-08-20-beta-73.md
@@ -75,36 +75,50 @@ bun alchemy dev
 ```
 
 ```typescript
-const files = yield* AWS.S3.Bucket("Files");
-const jobs = yield* AWS.SQS.Queue("Jobs");
-const users = yield* AWS.DynamoDB.Table("Users", {
-  partitionKey: "id",
-  attributes: { id: "S" },
-});
-const api = yield* AWS.Lambda.Function("Api", { main: "./src/api.ts" });
+export default class Api extends AWS.Lambda.Function<Api>()(
+  "Api",
+  { main: import.meta.url, functionUrl: true },
+  Effect.gen(function* () {
+    const files = yield* AWS.S3.Bucket("Files");
+    const jobs = yield* AWS.SQS.Queue("Jobs");
+
+    const putObject = yield* AWS.S3.PutObject(files);
+    const sendMessage = yield* AWS.SQS.SendMessage(jobs);
+
+    return {
+      fetch: Effect.gen(function* () {
+        yield* putObject({ Key: "hello.txt", Body: "hello" });
+        yield* sendMessage({ MessageBody: "process hello.txt" });
+        return yield* HttpServerResponse.text("ok");
+      }).pipe(Effect.orDie),
+    };
+  }).pipe(
+    Effect.provide(
+      Layer.mergeAll(AWS.S3.PutObjectHttp, AWS.SQS.SendMessageHttp),
+    ),
+  ),
+) {}
 ```
 
 ```text
 Api.functionUrl  http://b71ff5c0….lambda-url.us-east-1.localhost:4566/
 Jobs.queueUrl    http://localhost:4566/000000000000/jobs-dev-x7k2
-Users.tableArn   arn:aws:dynamodb:us-east-1:000000000000:table/users-dev-p3m9
+Files.bucketName files-dev-x7k2
 ```
 
 Everything runs locally on your machine: the Lambda executes in
 a Docker container behind a working Function URL, SQS→Lambda
 event source mappings pump messages, S3 notifications fire,
-EventBridge routes, and SNS subscriptions deliver. Runtime
-bindings inside your function need no configuration —
-`S3.putObject(...)` lands in the local bucket, because distilled
-honors the official SDKs' `AWS_ENDPOINT_URL` override that floci
-injects
+EventBridge routes, and SNS subscriptions deliver. The bindings
+need no configuration — `putObject` above lands in the local
+bucket, because distilled honors the official SDKs'
+`AWS_ENDPOINT_URL` override that floci injects
 ([#1192](https://github.com/alchemy-run/alchemy/pull/1192),
 [#1210](https://github.com/alchemy-run/alchemy/pull/1210)).
 
-Save `./src/api.ts` and the running function serves the new code
-in **~100–500ms** — no redeploy, no restart. The dev session
-watches your code, rebuilds, and swaps it under the live Function
-URL.
+Save the file and the running function serves the new code in
+**~100–500ms** — no redeploy, no restart. The dev session watches
+your code, rebuilds, and swaps it under the live Function URL.
 
 Mix in the real cloud per resource with `Alchemy.remote()`:
 

--- a/website/src/content/docs/blog/2026-08-20-beta-73.md
+++ b/website/src/content/docs/blog/2026-08-20-beta-73.md
@@ -1,0 +1,533 @@
+---
+title: 2.0.0-beta.73 - AWS Local Dev & Hetzner
+date: 2026-08-20T09:00:00Z
+category: release
+excerpt: v2.0.0-beta.73 brings alchemy dev to AWS — your Lambda, S3, DynamoDB, SQS, ECS, and website stack runs on your machine with hot reload and no credentials — adds a Hetzner Cloud provider with an Effect-native Service platform, deploys all six web frameworks to AWS (S3 + CloudFront + streaming Lambda), unifies SQL migrations into one Alchemy-owned format, protects Workers with Cloudflare Access, and makes removal policies persist.
+---
+
+beta.73 brings `alchemy dev` to AWS: your Lambda, S3, DynamoDB,
+SQS, ECS, and website stack runs **entirely on your machine** —
+no AWS account, no credentials, hot reload in ~100–500ms, and
+each website's framework runs its own dev server with native
+HMR. A new
+**Hetzner Cloud provider** ships 15 resources plus an
+Effect-native `Service` platform that deploys your program to a
+server over SSH. And the six web frameworks that landed on
+Cloudflare in beta.70 now deploy to **AWS** — S3 + CloudFront +
+streaming Lambda — with the same interface.
+
+This post covers beta.72 and beta.73 — beta.72 was a small
+dependency-fix release that didn't get its own notes.
+
+:::caution
+**Breaking changes**
+
+- **effect `>=4.0.0-rc.110` is the new minimum peer**
+  ([#1245](https://github.com/alchemy-run/alchemy/pull/1245)) —
+  effect has moved from beta to release candidates.
+- **`@alchemy.run/cloudflare-frameworks` is now
+  `@alchemy.run/frontend-frameworks`**
+  ([#1140](https://github.com/alchemy-run/alchemy/pull/1140),
+  [#1154](https://github.com/alchemy-run/alchemy/pull/1154)) —
+  the framework integrations serve every cloud now. Update your
+  devDependency.
+- **SQL migrations have one prop and one format**
+  ([#1226](https://github.com/alchemy-run/alchemy/pull/1226)).
+  `migrationsDir`/`migrationsTable` are replaced by a single
+  `migrations` prop, and history lives in `__alchemy_migrations`.
+  Databases previously migrated with drizzle-kit, Prisma, or
+  wrangler are converted automatically on the next deploy — see
+  [below](#one-migration-format-for-sql-databases).
+- **AWS website & Lambda surface renames**
+  ([#1158](https://github.com/alchemy-run/alchemy/pull/1158)):
+  `Lambda.Function`'s `url` prop is now `functionUrl`, the
+  website `router:` prop moved into `domain: { router }`,
+  `Website.Server`'s `port` moved to `dev: { port }`, and the
+  CloudFront default domain now serves alongside a custom domain
+  (opt out with `cloudfrontUrl: false`).
+- **`Worker.workerId` is now the immutable Worker ID**
+  ([#1228](https://github.com/alchemy-run/alchemy/pull/1228)) —
+  the hex script tag Access destinations key on, not a duplicate
+  of `workerName`. Old state heals itself on the next deploy.
+- **Destroying a non-empty R2 bucket now fails** instead of
+  silently deleting every object
+  ([#1253](https://github.com/alchemy-run/alchemy/pull/1253)) —
+  opt back in with `forceDestroy: true`. And a removed
+  `RemovalPolicy.retain()` now actually takes effect — see
+  [below](#removal-policies-persist).
+- **DynamoDB secondary indexes take typed keys**
+  ([#1216](https://github.com/alchemy-run/alchemy/pull/1216)) —
+  `partitionKey`/`sortKey` segments instead of the raw wire
+  `KeySchema` list. Existing state upgrades without a
+  replacement.
+:::
+
+## AWS local dev
+
+`alchemy dev` now runs your AWS stack on your machine
+([#1154](https://github.com/alchemy-run/alchemy/pull/1154)) using
+[our fork](https://github.com/alchemy-run/floci) of
+[floci](https://floci.io), an MIT LocalStack-style emulator. No
+stored profile, no env vars, no config — the emulator starts
+automatically in Docker (one shared `alchemy-floci` container
+across projects and sessions) and your stack deploys into it in
+seconds:
+
+```sh
+bun alchemy dev
+# no AWS credentials — using the local emulator
+```
+
+```typescript
+const files = yield* AWS.S3.Bucket("Files");
+const jobs = yield* AWS.SQS.Queue("Jobs");
+const users = yield* AWS.DynamoDB.Table("Users", {
+  partitionKey: "id",
+  attributes: { id: "S" },
+});
+const api = yield* AWS.Lambda.Function("Api", { main: "./src/api.ts" });
+```
+
+```text
+Api.functionUrl  http://b71ff5c0….lambda-url.us-east-1.localhost:4566/
+Jobs.queueUrl    http://localhost:4566/000000000000/jobs-dev-x7k2
+Users.tableArn   arn:aws:dynamodb:us-east-1:000000000000:table/users-dev-p3m9
+```
+
+Everything runs locally on your machine: the Lambda executes in
+a Docker container behind a working Function URL, SQS→Lambda
+event source mappings pump messages, S3 notifications fire,
+EventBridge routes, and SNS subscriptions deliver. Runtime
+bindings inside your function need no configuration —
+`S3.putObject(...)` lands in the local bucket, because distilled
+honors the official SDKs' `AWS_ENDPOINT_URL` override that floci
+injects
+([#1192](https://github.com/alchemy-run/alchemy/pull/1192),
+[#1210](https://github.com/alchemy-run/alchemy/pull/1210)).
+
+Save `./src/api.ts` and the running function serves the new code
+in **~100–500ms** — no redeploy, no restart. The dev session
+watches your code, rebuilds, and swaps it under the live Function
+URL.
+
+Mix in the real cloud per resource with `Alchemy.remote()`:
+
+```typescript
+// everything else is local; this one hits real AWS
+const secret = yield* AWS.SecretsManager.Secret("ProdSecret", { ... })
+  .pipe(Alchemy.remote());
+```
+
+If a remote resource needs credentials you don't have,
+`alchemy dev` tells you before touching anything, and switching a
+resource between local and live plans a **replacement** — dev
+state never silently becomes cloud state. Resources without local
+emulation run against the real cloud as before; stacks that mix
+the two work unchanged.
+
+Local emulation covers Lambda (hot reload, Function URLs, event
+source mappings), S3, DynamoDB, SQS, SNS, EventBridge, Secrets
+Manager, SSM, IAM, Cognito, Step Functions, Glue, ACM, and more.
+
+We forked floci so that alchemy's live AWS test suites — the
+control-plane lifecycle tests and the data-plane binding tests
+that normally run against real AWS — can run **against the
+emulator** and drive an agentic pipeline that patches it, the
+same loop we used to
+[grow the Cloudflare provider from 22 resources to 230](/blog/2026-07-02-cloudflare-resource-factory).
+See
+[Looping the Generation of Local Emulators](/blog/2026-08-20-generating-local-emulators).
+Every fidelity gap a test surfaces becomes a fix in the fork
+instead of a workaround in alchemy, and hundreds of live tests
+run green against the emulator across the dualized services
+([#1250](https://github.com/alchemy-run/alchemy/pull/1250)). The
+`examples/aws-dev` suite drives the real `alchemy dev` CLI end to
+end — bindings, queue consumers, and mid-session hot reloads
+([#1192](https://github.com/alchemy-run/alchemy/pull/1192)).
+
+Docs: [AWS local development](/aws/local-development).
+
+## ECS tasks run as local containers
+
+`alchemy dev` runs your ECS tasks and services as **real Docker
+containers** on your machine, with hot reload
+([#1185](https://github.com/alchemy-run/alchemy/pull/1185)):
+
+```typescript
+const cluster = yield* AWS.ECS.Cluster("Cluster");
+
+// bundled Effect program — built into an image, pushed through
+// a local registry, running as a real container seconds later
+const api = yield* AWS.ECS.Task("Api", { main: "./src/api.ts", port: 8080 });
+
+// or your own Dockerfile
+const web = yield* AWS.ECS.Service("Web", { context: "./web", port: 3000 });
+```
+
+```text
+$ docker ps
+floci-ecs-…-api   Up 4 seconds   0.0.0.0:8080->8080/tcp
+```
+
+The whole live pipeline runs unchanged against the emulator:
+image build, `docker push` through a real local OCI registry,
+task definitions, `RunTask`, and services that converge exactly
+like AWS. Save a file and the running container swaps in ~6
+seconds — bundled tasks watch the deploy's exact module graph,
+Dockerfile tasks watch the build context, and services roll
+their tasks onto the new image revision.
+
+An ECS dev stack is now **fully** local
+([#1210](https://github.com/alchemy-run/alchemy/pull/1210)): the
+VPC/subnet/ALB scaffolding and the event-source glue (SNS
+subscriptions, Lambda permissions, EventBridge, Scheduler) run
+against the emulator too — previously a dev apply could create a
+real VPC and ALB that could never route to local containers. The
+emulated ALB serves its listeners locally, so
+`aws ecs wait services-stable` and your load-balanced routes work
+without an AWS account.
+
+## Hetzner
+
+A new **Hetzner Cloud provider**
+([#1258](https://github.com/alchemy-run/alchemy/pull/1258)):
+Server, SshKey, Volume, VolumeAttachment, Network, Firewall,
+PlacementGroup, PrimaryIp, FloatingIp, FloatingIpAssignment,
+Certificate, LoadBalancer, Image, and DNS Zone + RecordSet. Auth
+is a single `HCLOUD_TOKEN` (or `alchemy login`).
+
+```typescript
+export const Key = Hetzner.SshKey("laptop", {
+  publicKey: "ssh-ed25519 AAAA… you@laptop",
+});
+
+export const Box = Hetzner.Server("box", {
+  serverType: "cpx12",
+  image: "ubuntu-24.04",
+  location: "nbg1",
+  sshKeys: [Key],
+});
+```
+
+`Hetzner.Service` is the Function/Worker analog for a server you
+own. Write an Effect program with a `fetch` handler; deploying
+bundles it, ships it to the server, and runs it under systemd
+with a readiness gate:
+
+```typescript
+export const Data = Hetzner.Volume("data", {
+  size: 40,
+  format: "ext4",
+  location: "nbg1",
+  server: Box,
+});
+
+export default class Api extends Hetzner.Service<Api>()(
+  "api",
+  { server: Box, main: import.meta.url, port: 3000 },
+  Effect.gen(function* () {
+    const disk = yield* Hetzner.MountVolume(Data, { path: "/var/lib/api" });
+    return {
+      fetch: Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const body = yield* fs.readFileString(`${disk.path}/hello.txt`);
+        return yield* HttpServerResponse.text(body);
+      }),
+    };
+  }).pipe(Effect.provide(Hetzner.MountVolumeLive)),
+) {}
+```
+
+Bindings follow the same capability model as AWS and Cloudflare:
+`MountVolume` formats, attaches, and mounts a Volume into the
+service, `Hetzner.Ssh(Box)` is a typed `exec`/`scp` client for a
+Server, and the DNS zone splits into least-privilege
+`ReadDns` / `WriteDns` / `ReadWriteDns` clients. Networking is a
+private Network, Firewall rules, and a LoadBalancer with managed
+TLS certificates:
+
+```typescript
+export const Lb = Hetzner.LoadBalancer("lb", {
+  location: "nbg1",
+  loadBalancerType: "lb11",
+  targets: [{ type: "server", server: Box, usePrivateIp: true }],
+  services: [
+    {
+      protocol: "https",
+      listenPort: 443,
+      destinationPort: 3000,
+      certificates: [Managed],
+      http: { redirectHttp: true },
+    },
+  ],
+});
+```
+
+Hetzner gets its own docs tab
+([#1260](https://github.com/alchemy-run/alchemy/pull/1260)): a
+setup guide, a four-part tutorial (server → service → volume →
+network + load balancer), and guides for servers, services,
+volumes, networking, and DNS.
+
+Docs: [Hetzner](/hetzner) ·
+[Tutorial](/hetzner/tutorial/part-1).
+
+## Web frameworks on AWS
+
+The full Website family — **Next.js, Astro, Nuxt, SvelteKit,
+Waku, and Octane** — now deploys to AWS
+([#1140](https://github.com/alchemy-run/alchemy/pull/1140)),
+mirroring the Cloudflare architecture: the framework server runs
+on a streaming Lambda Function URL, assets and prerendered pages
+live in a private S3 bucket, and a CloudFront Function routes
+each request at the edge via a KeyValueStore manifest.
+
+```typescript
+const site = yield* AWS.Website.Nextjs("Web", {
+  domain: { name: "app.example.com", hostedZoneId: zone.hostedZoneId },
+});
+```
+
+Next.js deploys the full OpenNext serverless topology — streaming
+server Lambda, image-optimization Lambda, SQS FIFO revalidation
+queue, DynamoDB tag cache, ISR cache bucket — with IAM wired
+through the binding channel. The others load your framework's own
+config natively; `output: "static"` Astro sites deploy
+assets-only with no Lambda at all.
+
+The interface is deliberately identical to Cloudflare's
+([#1158](https://github.com/alchemy-run/alchemy/pull/1158)): the
+same `{ name, aliases, redirects }` domain shape (standalone or
+through a shared `Router`), the same `dev` config, and the same
+`urls`/`url` output contract — custom domain first, CloudFront
+default last. Under `alchemy dev`, each framework's own dev
+server runs with native HMR and no cloud resources; every
+`cloudflare-website-*` example now has an `aws-website-*` mirror
+running the same app
+([#1189](https://github.com/alchemy-run/alchemy/pull/1189)).
+
+Docs: [AWS frontends](/aws/frontend/websites).
+
+## One migration format for SQL databases
+
+Alchemy's migration bookkeeping was an invented table shape
+incompatible with what drizzle-kit, Prisma, and wrangler actually
+maintain. There is now exactly **one** format, owned by Alchemy
+([#1226](https://github.com/alchemy-run/alchemy/pull/1226)):
+`__alchemy_migrations`, with one prop on every SQL database
+resource (D1, Neon, PlanetScale):
+
+```typescript
+const db = yield* Cloudflare.D1.Database("app-db", {
+  migrations: "./migrations", // or { dir, table } or a Drizzle.Schema
+});
+```
+
+A database previously migrated with drizzle-kit, Prisma, or
+wrangler is adopted on first deploy by a **one-way conversion**:
+the old tool's applied history is copied into Alchemy's table
+once, validated against your local migration files, and the old
+table is left frozen — never written, never dropped. Nothing
+replays. Passing a `Drizzle.Schema` resource as `migrations`
+orders generation before application in the same deploy.
+
+History validation is now strict — a recorded migration with no
+matching local file fails the deploy instead of passing silently.
+If you squashed and deleted old migration files, restore them
+before upgrading.
+
+Docs: [SQL](/sql).
+
+## Protect Workers with Access
+
+Support for
+[Workers protected by Access](https://blog.cloudflare.com/workers-protected-by-access/)
+([#1228](https://github.com/alchemy-run/alchemy/pull/1228)):
+declare policies inline on the Worker and alchemy manages the
+dedicated Access application for you —
+
+```typescript
+export default class Api extends Cloudflare.Worker<Api>()("Api", {
+  main: import.meta.url,
+  access: {
+    policies: [
+      { decision: "allow", include: [{ emailDomain: "example.com" }] },
+    ],
+  },
+}, /* ... */) {}
+```
+
+— or share one `Cloudflare.Access.Application` across several
+Workers (`access: App`), or protect **every current and future
+Worker in the account** with the `AllWorkers` destination.
+Enrollment goes through the binding contract, so removing the
+prop (or the Worker) un-enrolls it on the next reconcile.
+
+At runtime, `Cloudflare.Access.Context` reads the authenticated
+identity, and `dev: { access: { identity } }` stubs a logged-in
+user under `alchemy dev` so you can test the gated paths locally:
+
+```typescript
+fetch: Effect.gen(function* () {
+  const access = yield* Cloudflare.Access.Context;
+  const identity = yield* access.getIdentity(); // email, groups, idp…
+  return yield* HttpServerResponse.json({ email: identity?.email });
+}),
+```
+
+Docs:
+[Protect a Worker with Access](/cloudflare/security/access).
+
+## Removal policies persist
+
+`RemovalPolicy.retain()` added to an already-deployed resource
+never reached state — the policy is a decoration, not a prop, so
+the noop apply path skipped it, and a later rename or removal
+orphan-deleted the resource anyway. beta.73 persists the policy
+on the noop path
+([#1253](https://github.com/alchemy-run/alchemy/pull/1253)) and
+prints a note whenever a deploy flips one.
+
+Two behavior changes come with it, both protective. Destroying a
+non-empty R2 bucket now fails with `BucketNotEmpty` instead of
+silently emptying it first — the old behavior deleted 60k objects
+in the incident that motivated the fix. Opt disposable buckets
+back in explicitly:
+
+```typescript
+const cache = yield* Cloudflare.R2.Bucket("Cache", { forceDestroy: true });
+```
+
+And because the policy now actually persists, a `retain()` you
+*removed* from the code takes effect: the next removal deletes
+the resource for real. If anything depends on a retain that's no
+longer declared, put it back before deploying.
+
+Docs:
+[Resource lifecycle](/infrastructure-as-code/resource-lifecycle).
+
+## Prisma: object storage & locked Postgres state
+
+Three additions to the Prisma provider
+([#1061](https://github.com/alchemy-run/alchemy/pull/1061)) —
+thanks [Will Madden](https://github.com/wmadden)!
+
+- **Object storage** — `Prisma.Bucket` and `BucketAccessKey`
+  resources plus `ReadBucket`/`WriteBucket`/`ReadWriteBucket`
+  bindings; binding a bucket auto-creates a scoped access key and
+  wires endpoint + credentials into the host.
+- **`State/PostgresState`** — the first in-tree state backend
+  with real locking: per-stack advisory locks with holder
+  re-verification, on the `pg` dependency the repo already
+  carries.
+- **`Deployment.triggers`** — force a redeploy when an opaque
+  key/value changes (e.g. a rotated secret), fingerprinted and
+  persisted `Redacted` so no plaintext lands in state.
+
+## Also in this release
+
+- **Structured DNS record data**
+  ([#1257](https://github.com/alchemy-run/alchemy/pull/1257)) —
+  Cloudflare DNS records accept typed component objects for SVCB,
+  HTTPS, SRV, CAA, and friends via the same `content` prop, with
+  the shape discriminated by `type`. Thanks
+  [Arya Saatvik](https://github.com/aryasaatvik)! Adoption also
+  disambiguates records sharing `(name, type)` by
+  content/priority instead of clobbering the first match
+  ([#1264](https://github.com/alchemy-run/alchemy/pull/1264)).
+- **Worker versions carry static assets**
+  ([#1266](https://github.com/alchemy-run/alchemy/pull/1266)) — a
+  preview version can ship its own assets without touching the
+  parent deployment. Thanks
+  [Rahul Mishra](https://github.com/BlankParticle), who also
+  migrated the workspace to pnpm
+  ([#1214](https://github.com/alchemy-run/alchemy/pull/1214)),
+  bumped effect to rc.110
+  ([#1245](https://github.com/alchemy-run/alchemy/pull/1245)),
+  made process cleanup explicit and scoped
+  ([#1175](https://github.com/alchemy-run/alchemy/pull/1175)),
+  and improved platform runtime detection
+  ([#1197](https://github.com/alchemy-run/alchemy/pull/1197))!
+- **Nested Worker env plans converge**
+  ([#1273](https://github.com/alchemy-run/alchemy/pull/1273)) — a
+  Worker bound to an already-yielded Worker no longer plans
+  `update` forever on identical deploys. Thanks
+  [Odysseas Papadimas](https://github.com/odysseaspapadimas)!
+- **`alchemy dev` survives a broken save**
+  ([#1259](https://github.com/alchemy-run/alchemy/pull/1259)) — a
+  mid-edit save whose module evaluation throws now logs and waits
+  for the next change instead of killing the watch session.
+- **Env-bound strings deploy bare**
+  ([#1254](https://github.com/alchemy-run/alchemy/pull/1254)) — a
+  queue name no longer lands in its binding JSON-quoted, so the
+  dashboard and hand-written env reads see the real value.
+- **Dependency security bumps**
+  ([#1255](https://github.com/alchemy-run/alchemy/pull/1255)) —
+  the vulnerable `extract-zip` and libvips advisories are out of
+  the runtime's dependency closure.
+- **`Worker.domain` pins its zone**
+  ([#1241](https://github.com/alchemy-run/alchemy/pull/1241)) —
+  `zoneId`/`zone`/`zoneName` on `domain`, and unpinned hostnames
+  resolve by name instead of the first page of an account-wide
+  zone list. Thanks [Ben Snyder](https://github.com/benpsnyder)!
+- **`Cloudflare.Website.Foldkit`**
+  ([#1120](https://github.com/alchemy-run/alchemy/pull/1120)) and
+  **per-workflow step limits**
+  (`limits: { steps }`,
+  [#816](https://github.com/alchemy-run/alchemy/pull/816)) —
+  thanks [Filip Falcon](https://github.com/filipfalcon)!
+- **Pipelines streams bind to Workers**
+  ([#1176](https://github.com/alchemy-run/alchemy/pull/1176)) — a
+  stream in `env` becomes a real pipelines binding instead of
+  falling through to JSON. Thanks
+  [spinx](https://github.com/spinx)!
+- **DynamoDB multi-attribute GSI keys**
+  ([#1216](https://github.com/alchemy-run/alchemy/pull/1216)) —
+  GSI partition and sort keys composed of up to 4 attributes
+  each, with order-preserving diffs.
+- **RDS `DBParameterGroup.parameters`**
+  ([#1205](https://github.com/alchemy-run/alchemy/pull/1205)) —
+  engine settings reconciled against live user-modified values.
+  Thanks [skusez](https://github.com/skusez)!
+- **Lambda packaging fixes** — installed packages keep their file
+  modes and symlinks
+  ([#855](https://github.com/alchemy-run/alchemy/pull/855),
+  thanks [Joaquín Pérez](https://github.com/jperezrealini)!) and
+  nested `zipCode` archives are byte-deterministic across builds
+  ([#1211](https://github.com/alchemy-run/alchemy/pull/1211)).
+- **Astro forwards `prerenderEnvironment`**
+  ([#1242](https://github.com/alchemy-run/alchemy/pull/1242)) —
+  thanks [Maxwell Brown](https://github.com/IMax153)!
+- **The CLI honors `STAGE`**
+  ([#1244](https://github.com/alchemy-run/alchemy/pull/1244)) —
+  thanks [sethcarlton](https://github.com/sethcarlton)! And the
+  version check never suggests a downgrade
+  ([#1116](https://github.com/alchemy-run/alchemy/pull/1116)).
+- **`@effect/vitest` moves to devDependencies**
+  ([#1191](https://github.com/alchemy-run/alchemy/pull/1191)) —
+  installing alchemy no longer pulls a test toolchain (and its
+  esbuild peer conflicts) into your resolution. Thanks
+  [Kristóf Siket](https://github.com/kristof-siket)!
+- **A missing `.make` Layer names itself**
+  ([#1055](https://github.com/alchemy-run/alchemy/pull/1055)) —
+  yielding a bare-tag resource without its implementation Layer
+  dies with a `MissingImplementationError` explaining exactly
+  what to provide, instead of a `TypeError` deep in a provider.
+  Thanks [apostoli](https://github.com/apostolos-geyer)!
+- **Circular Worker layers typecheck**
+  ([#1199](https://github.com/alchemy-run/alchemy/pull/1199)) —
+  `Worker.make` no longer leaks the other Worker's tag into
+  `Layer.mergeAll` requirements. Thanks
+  [Patrik Duksin](https://github.com/patrikduksin)!
+
+## Where to go next
+
+- [AWS local development](/aws/local-development)
+- [Local development](/environments/local-development)
+- [Hetzner](/hetzner)
+- [Hetzner tutorial](/hetzner/tutorial/part-1)
+- [AWS frontends](/aws/frontend/websites)
+- [Protect a Worker with Access](/cloudflare/security/access)
+- [SQL](/sql)
+- [CHANGELOG](https://github.com/alchemy-run/alchemy/blob/main/CHANGELOG.md#v200-beta73)
+- [Compare v2.0.0-beta.71 → v2.0.0-beta.73](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.71...v2.0.0-beta.73)

--- a/website/src/content/docs/blog/2026-08-20-beta-73.md
+++ b/website/src/content/docs/blog/2026-08-20-beta-73.md
@@ -15,10 +15,6 @@ Effect-native `Service` platform that deploys your program to a
 server over SSH. And the six web frameworks that landed on
 Cloudflare in beta.70 now deploy to **AWS** — S3 + CloudFront +
 streaming Lambda — with the same interface.
-
-This post covers beta.72 and beta.73 — beta.72 was a small
-dependency-fix release that didn't get its own notes.
-
 :::caution
 **Breaking changes**
 

--- a/website/src/content/docs/blog/2026-08-20-beta-73.md
+++ b/website/src/content/docs/blog/2026-08-20-beta-73.md
@@ -298,26 +298,27 @@ Docs: [Hetzner](/hetzner) ·
 
 ## Web frameworks on AWS
 
-The full Website family — **Next.js, Astro, Nuxt, SvelteKit,
-Waku, and Octane** — now deploys to AWS
+The full Website family — plain **Vite** SPAs plus **Next.js,
+Astro, Nuxt, SvelteKit, Waku, and Octane** — now deploys to AWS
 ([#1140](https://github.com/alchemy-run/alchemy/pull/1140)),
-mirroring the Cloudflare architecture: the framework server runs
-on a streaming Lambda Function URL, assets and prerendered pages
-live in a private S3 bucket, and a CloudFront Function routes
-each request at the edge via a KeyValueStore manifest.
+mirroring the Cloudflare architecture: assets and prerendered
+pages live in a private S3 bucket, the framework server (when
+there is one) runs on a streaming Lambda Function URL, and a
+CloudFront Function routes each request at the edge via a
+KeyValueStore manifest.
 
 ```typescript
-const site = yield* AWS.Website.Nextjs("Web", {
+const site = yield* AWS.Website.Vite("Web", {
   domain: { name: "app.example.com", hostedZoneId: zone.hostedZoneId },
 });
 ```
 
-Next.js deploys the full OpenNext serverless topology — streaming
-server Lambda, image-optimization Lambda, SQS FIFO revalidation
-queue, DynamoDB tag cache, ISR cache bucket — with IAM wired
-through the binding channel. The others load your framework's own
-config natively; `output: "static"` Astro sites deploy
-assets-only with no Lambda at all.
+A Vite SPA deploys assets-only, with no Lambda at all. The SSR
+frameworks load your framework's own config natively; Next.js
+deploys the full OpenNext serverless topology — streaming server
+Lambda, image-optimization Lambda, SQS FIFO revalidation queue,
+DynamoDB tag cache, ISR cache bucket — with IAM wired through
+the binding channel.
 
 The interface is deliberately identical to Cloudflare's
 ([#1158](https://github.com/alchemy-run/alchemy/pull/1158)): the

--- a/website/src/content/docs/blog/2026-08-20-beta-73.md
+++ b/website/src/content/docs/blog/2026-08-20-beta-73.md
@@ -142,21 +142,21 @@ Local emulation covers Lambda (hot reload, Function URLs, event
 source mappings), S3, DynamoDB, SQS, SNS, EventBridge, Secrets
 Manager, SSM, IAM, Cognito, Step Functions, Glue, ACM, and more.
 
-We forked floci so that alchemy's live AWS test suites — the
-control-plane lifecycle tests and the data-plane binding tests
-that normally run against real AWS — can run **against the
-emulator** and drive an agentic pipeline that patches it, the
-same loop we used to
-[grow the Cloudflare provider from 22 resources to 230](/blog/2026-07-02-cloudflare-resource-factory).
-See
-[Looping the Generation of Local Emulators](/blog/2026-08-20-generating-local-emulators).
-Every fidelity gap a test surfaces becomes a fix in the fork
-instead of a workaround in alchemy, and hundreds of live tests
-run green against the emulator across the dualized services
+We forked floci so that alchemy's live AWS test suites, which
+normally run against real AWS, can run against the emulator and
+drive an agentic pipeline that patches it. Every fidelity gap a
+test surfaces becomes a fix in the fork instead of a workaround
+in alchemy, and hundreds of live tests now run green against the
+emulator
 ([#1250](https://github.com/alchemy-run/alchemy/pull/1250)). The
-`examples/aws-dev` suite drives the real `alchemy dev` CLI end to
-end — bindings, queue consumers, and mid-session hot reloads
+`examples/aws-dev` suite drives the real `alchemy dev` CLI end
+to end: bindings, queue consumers, and mid-session hot reloads
 ([#1192](https://github.com/alchemy-run/alchemy/pull/1192)).
+
+Alongside this release we published
+[Looping the Generation of Local Emulators](/blog/2026-08-20-generating-local-emulators),
+a dedicated post on the fork and the pipeline that drives it.
+Read that for the full story.
 
 Docs: [AWS local development](/aws/local-development).
 

--- a/website/src/content/docs/blog/2026-08-20-beta-73.md
+++ b/website/src/content/docs/blog/2026-08-20-beta-73.md
@@ -74,6 +74,9 @@ bun alchemy dev
 # no AWS credentials — using the local emulator
 ```
 
+Take a Lambda Function that owns a bucket and a queue and writes
+to both:
+
 ```typescript
 export default class Api extends AWS.Lambda.Function<Api>()(
   "Api",
@@ -97,6 +100,8 @@ export default class Api extends AWS.Lambda.Function<Api>()(
   ),
 ) {}
 ```
+
+The dev deploy's outputs all point at the emulator:
 
 ```text
 Api.functionUrl  http://b71ff5c0….lambda-url.us-east-1.localhost:4566/
@@ -176,6 +181,8 @@ export default class Web extends AWS.ECS.Task<Web>()(
   }),
 ) {}
 ```
+
+A dev deploy puts a real container on your machine:
 
 ```text
 $ docker ps

--- a/website/src/content/docs/blog/2026-08-20-beta-73.md
+++ b/website/src/content/docs/blog/2026-08-20-beta-73.md
@@ -344,7 +344,23 @@ resource (D1, Neon, PlanetScale):
 
 ```typescript
 const db = yield* Cloudflare.D1.Database("app-db", {
-  migrations: "./migrations", // or { dir, table } or a Drizzle.Schema
+  migrations: "./migrations", // or { dir, table }
+});
+```
+
+`Drizzle.Schema` plugs into the same prop. It diffs your
+TypeScript schema against the checked-in snapshot and generates
+SQL migrations on drift, and passing the resource itself orders
+generation before application in the same deploy:
+
+```typescript
+const schema = yield* Drizzle.Schema("AppSchema", {
+  schema: "./src/schema.ts",
+  dialect: "sqlite",
+});
+
+const db = yield* Cloudflare.D1.Database("app-db", {
+  migrations: schema,
 });
 ```
 
@@ -353,8 +369,7 @@ wrangler is adopted on first deploy by a **one-way conversion**:
 the old tool's applied history is copied into Alchemy's table
 once, validated against your local migration files, and the old
 table is left frozen — never written, never dropped. Nothing
-replays. Passing a `Drizzle.Schema` resource as `migrations`
-orders generation before application in the same deploy.
+replays.
 
 History validation is now strict — a recorded migration with no
 matching local file fails the deploy instead of passing silently.

--- a/website/src/content/docs/blog/2026-08-20-beta-73.md
+++ b/website/src/content/docs/blog/2026-08-20-beta-73.md
@@ -446,25 +446,17 @@ longer declared, put it back before deploying.
 Docs:
 [Resource lifecycle](/infrastructure-as-code/resource-lifecycle).
 
-## Prisma: object storage & locked Postgres state
-
-Three additions to the Prisma provider
-([#1061](https://github.com/alchemy-run/alchemy/pull/1061)) —
-thanks [Will Madden](https://github.com/wmadden)!
-
-- **Object storage** — `Prisma.Bucket` and `BucketAccessKey`
-  resources plus `ReadBucket`/`WriteBucket`/`ReadWriteBucket`
-  bindings; binding a bucket auto-creates a scoped access key and
-  wires endpoint + credentials into the host.
-- **`State/PostgresState`** — the first in-tree state backend
-  with real locking: per-stack advisory locks with holder
-  re-verification, on the `pg` dependency the repo already
-  carries.
-- **`Deployment.triggers`** — force a redeploy when an opaque
-  key/value changes (e.g. a rotated secret), fingerprinted and
-  persisted `Redacted` so no plaintext lands in state.
-
 ## Also in this release
+
+- **Prisma: object storage, locked Postgres state, and deploy
+  triggers**
+  ([#1061](https://github.com/alchemy-run/alchemy/pull/1061)) —
+  `Prisma.Bucket` + `BucketAccessKey` resources with
+  `ReadBucket`/`WriteBucket`/`ReadWriteBucket` bindings, a
+  `State/PostgresState` backend with per-stack advisory locks,
+  and `Deployment.triggers` to force a redeploy when an opaque
+  key/value (e.g. a rotated secret) changes. Thanks
+  [Will Madden](https://github.com/wmadden)!
 
 - **Structured DNS record data**
   ([#1257](https://github.com/alchemy-run/alchemy/pull/1257)) —

--- a/website/src/content/docs/blog/2026-08-20-generating-local-emulators.md
+++ b/website/src/content/docs/blog/2026-08-20-generating-local-emulators.md
@@ -31,23 +31,24 @@ stack runs on your machine with no AWS account and no
 credentials. It shipped in
 [2.0.0-beta.73](/blog/2026-08-20-beta-73).
 
-## The fork
+## We forked floci
 
 The emulator is [our fork](https://github.com/alchemy-run/floci)
 of [floci](https://floci.io), an MIT-licensed, LocalStack-style
-AWS emulator on the JVM. Our patches span about 30 services:
-Lambda's streaming Function URLs, ELBv2's ALB data plane,
-AppSync's Velocity template directives, EC2, IAM, SES, Cognito,
-Athena, event-source mappings. Every one of them exists because
-an alchemy test failed against the emulator after passing
-against AWS.
-
-We'd like to contribute these upstream. But the factory is a
+AWS emulator on the JVM. We forked because the factory is a
 fully automated fan-out, with fleets of agents producing fixes
-faster than any maintainer could reasonably review. Flooding the
-floci team with that maintenance burden isn't fair to them. It's
-easier to let alchemy's flywheel drive the emulator's
-development directly, and that requires a fork.
+faster than any maintainer could reasonably review. We'd like to
+contribute upstream, but flooding the floci team with that
+maintenance burden isn't fair to them. It's easier to let
+alchemy's flywheel drive the emulator's development directly,
+and that requires a fork.
+
+In this release our patches span about 30 services: Lambda's
+streaming Function URLs, ELBv2's ALB data plane, AppSync's
+Velocity template directives, EC2, IAM, SES, Cognito, Athena,
+event-source mappings. Every one of them exists because an
+alchemy test failed against the emulator after passing against
+AWS.
 
 The test harness has one switch:
 

--- a/website/src/content/docs/blog/2026-08-20-generating-local-emulators.md
+++ b/website/src/content/docs/blog/2026-08-20-generating-local-emulators.md
@@ -34,21 +34,25 @@ credentials. It shipped in
 ## We forked floci
 
 We [forked](https://github.com/alchemy-run/floci)
-[floci](https://floci.io), an MIT-licensed, LocalStack-style AWS
-emulator on the JVM, because the factory is a fully automated
-fan-out, with fleets of agents producing fixes faster than any
-maintainer could reasonably review. We'd like to contribute
-upstream, but flooding the floci team with that maintenance
-burden isn't fair to them. It's easier to let alchemy's flywheel
-drive the emulator's development directly, and that requires a
-fork.
+[floci](https://floci.io)'s AWS implementation because they've
+already laid a great foundation for local development but don't
+have full coverage. They're adding more every day, but we want
+to automate the emulator's development and push quickly for
+100%. In this version we focused on patching services floci
+already supported — **219 resources across ~39 services** — and
+added MicroVMs, a new service that is very important to alchemy.
 
-In this release our patches span about 30 services: Lambda's
-streaming Function URLs, ELBv2's ALB data plane, AppSync's
-Velocity template directives, EC2, IAM, SES, Cognito, Athena,
-event-source mappings. Every one of them exists because an
-alchemy test failed against the emulator after passing against
-AWS.
+The patches span about 30 services: Lambda's streaming Function
+URLs, ELBv2's ALB data plane, AppSync's Velocity template
+directives, EC2, IAM, SES, Cognito, Athena, event-source
+mappings. Every one of them exists because an alchemy test
+failed against the emulator after passing against AWS.
+
+We'd like to contribute these upstream, but the factory is a
+fully automated fan-out, with fleets of agents producing fixes
+faster than any maintainer could reasonably review. Flooding the
+floci team with that maintenance burden isn't fair to them. It's
+easier to let alchemy's flywheel drive the fork directly.
 
 The test harness has one switch:
 
@@ -59,11 +63,6 @@ pnpm test:aws:floci
 It runs the same test suite that normally runs against live AWS,
 except every call goes to floci instead. Nothing is mocked: each
 Lambda still cold-starts in its own Docker container.
-
-In beta.73 we focused on patching the services floci already
-supports: **219 resources across ~39 services** today. In the
-next release we'll push for 100% local emulation of every AWS
-service alchemy supports.
 
 ## One rule
 

--- a/website/src/content/docs/blog/2026-08-20-generating-local-emulators.md
+++ b/website/src/content/docs/blog/2026-08-20-generating-local-emulators.md
@@ -64,61 +64,31 @@ supports — **219 resources across ~39 services** today. In the
 next release we'll push for 100% local emulation of every AWS
 service alchemy supports.
 
-## The rule, inverted
+## One rule
 
-The SDK loop ran on one rule: agents never handle an unknown
-error in their own code — an unmatched error becomes an SDK
-patch. The emulator loop runs on the same rule pointed the other
-way: **never patch the consumer to tolerate the emulator.** A
-test that goes red under `ALCHEMY_TEST_DEV=1` is never fixed by
-loosening the test or special-casing alchemy's lifecycle code.
-The only permitted fix is in the fork.
+Every test must pass unchanged against both real AWS and floci.
+When a test goes red against the emulator, we never loosen the
+test or special-case alchemy — the fix goes in the fork, with a
+conformance test in the emulator's own suite.
 
-The invariant that keeps this honest: every test must pass
-unchanged against both real AWS and floci. The real cloud pins
-the tests, so the emulator can't drift toward them. The tests
-pin the emulator, so it can't drift from the cloud. When an
-agent fixes a fidelity bug, it also lands a conformance test
-inside the emulator's own suite — the fork's log is full of
-commits like `test(compat): align SES and ECS suite with AWS` —
-so the fix is pinned twice, once on each side of the boundary.
+For example: a live test asserts that a streaming Function URL
+delivers its first bytes before the handler finishes. floci
+buffered the stream, the test went red, the fix landed in the
+fork — and streaming now behaves the same locally as in
+`us-east-1`.
 
-One turn of the loop, concretely. Alchemy's Lambda suite
-asserts that a streaming Function URL delivers its first bytes
-before the invocation completes — a behavior a live test
-verified against AWS before floci was involved. Against the
-emulator, the response arrived only after the
-handler finished: floci's runtime API buffered the streaming
-POST to completion. The fix
-(`fix(lambda): resume streaming runtime POSTs so invokes
-complete at headers`) landed in the fork with a compat test, the
-alchemy suite reran, and streaming responses now behave
-identically on your laptop and in `us-east-1`.
+## Results
 
-## Convergence
+The first convergence run took the 13-service suite from **253
+failures to 33**, with **396 tests green** against the emulator.
+DynamoDB (105 tests), S3 (51), Step Functions (31), Cognito
+(19), and others are fully green.
 
-The first full convergence run took the combined 13-service
-suite from **253 failures to 33**, with **396 tests green**
-against the emulator. Running in isolation, entire services are
-fully green: DynamoDB (105 tests), S3 (51), Step Functions (31),
-Cognito (19), Glue (15), Secrets Manager (14), ACM (14),
-Application Auto Scaling (10), and more. Each remaining failure
-is either the next emulator fix or a documented platform gap.
-
-The result for users is
-[`alchemy dev` for AWS](/aws/local-development): Lambda
-executing in Docker containers behind working Function URLs, ECS
-tasks as real containers, SQS→Lambda event source mappings
-pumping messages, S3 notifications firing, EventBridge routing —
-with ~100–500ms hot reload and no credentials.
-
-A conformant emulator also makes the loop that built it cheaper:
-future generation waves can run their first iterations against
-floci — no rate limits,
-no eventual-consistency stalls measured in minutes, no leaked
-cloud resources to nuke between rounds — and graduate to the
-real cloud only to certify. The emulator, once produced by the
-tests, lowers the cost of producing everything else.
+The result is [`alchemy dev` for AWS](/aws/local-development) —
+and a cheaper factory: generation waves can now iterate against
+floci with no rate limits, no eventual-consistency stalls, and
+no leaked cloud resources, touching the real cloud only to
+certify.
 
 ## Three artifacts per cloud
 

--- a/website/src/content/docs/blog/2026-08-20-generating-local-emulators.md
+++ b/website/src/content/docs/blog/2026-08-20-generating-local-emulators.md
@@ -86,10 +86,12 @@ patch floci to support the operation. We're strict about this.
 
 ## Results
 
-The first convergence run took the 13-service suite from **253
-failures to 33**, with **396 tests green** against the emulator.
-DynamoDB (105 tests), S3 (51), Step Functions (31), Cognito
-(19), and others are fully green.
+When we first pointed the 13-service suite at floci, **253
+tests failed**. Agents patched the fork until **396 were
+green**. Several services now pass completely: DynamoDB (105
+tests), S3 (51), Step Functions (31), Cognito (19), and others.
+The 33 failures still open are the backlog for the 100% push
+next release.
 
 The result is [`alchemy dev` for AWS](/aws/local-development).
 It also makes the factory cheaper: generation waves can now

--- a/website/src/content/docs/blog/2026-08-20-generating-local-emulators.md
+++ b/website/src/content/docs/blog/2026-08-20-generating-local-emulators.md
@@ -37,8 +37,8 @@ We [forked](https://github.com/alchemy-run/floci)
 [floci](https://floci.io)'s AWS implementation because they've
 already laid a great foundation for local development but don't
 have full coverage. They're adding more every day, but we want
-to automate the emulator's development and push quickly for
-100%. In this version we focused on patching services floci
+to automate the emulator's development and will push for 100%
+next release. In this version we focused on patching services floci
 already supported — **219 resources across ~39 services** — and
 added MicroVMs, a new service that is very important to alchemy.
 

--- a/website/src/content/docs/blog/2026-08-20-generating-local-emulators.md
+++ b/website/src/content/docs/blog/2026-08-20-generating-local-emulators.md
@@ -1,7 +1,7 @@
 ---
 title: Looping the Generation of Local Emulators
 date: 2026-08-20T16:00:00Z
-excerpt: The live test suite that generates our IaC and SDKs is also an executable spec of the cloud. Point it at an emulator and every red test is a fidelity bug with a repro. One convergence run took AWS emulation from 253 failures to 396 green tests, and alchemy dev now runs your AWS stack with no AWS account.
+excerpt: The live test suite that generates our IaC and SDKs is also an executable spec of the cloud. Point it at an emulator and every red test is a fidelity bug with a repro. alchemy dev now emulates 219 resources across ~39 AWS services on your machine, with no AWS account.
 ---
 
 In [Looping the Generation of IaC and SDKs](/blog/2026-07-02-cloudflare-resource-factory)
@@ -38,9 +38,9 @@ We [forked](https://github.com/alchemy-run/floci)
 already laid a great foundation for local development but don't
 have full coverage. They're adding more every day, but we want
 to automate the emulator's development and will push for 100%
-next release. In this version we focused on patching services floci
-already supported — **219 resources across ~39 services** — and
-added MicroVMs, a new service that is very important to alchemy.
+next release. In this version we focused on patching services
+floci already supported, and added MicroVMs, a new service that
+is very important to alchemy.
 
 The patches span about 30 services: Lambda's streaming Function
 URLs, ELBv2's ALB data plane, AppSync's Velocity template
@@ -86,12 +86,11 @@ patch floci to support the operation. We're strict about this.
 
 ## Results
 
-When we first pointed the 13-service suite at floci, **253
-tests failed**. Agents patched the fork until **396 were
-green**. Several services now pass completely: DynamoDB (105
-tests), S3 (51), Step Functions (31), Cognito (19), and others.
-The 33 failures still open are the backlog for the 100% push
-next release.
+`alchemy dev` now emulates **219 resources across ~39 AWS
+services** locally, with **396 tests green** against the
+emulator. Several services pass their full live suite: DynamoDB
+(105 tests), S3 (51), Step Functions (31), Cognito (19), and
+others.
 
 The result is [`alchemy dev` for AWS](/aws/local-development).
 It also makes the factory cheaper: generation waves can now

--- a/website/src/content/docs/blog/2026-08-20-generating-local-emulators.md
+++ b/website/src/content/docs/blog/2026-08-20-generating-local-emulators.md
@@ -34,13 +34,19 @@ it shipped in [2.0.0-beta.73](/blog/2026-08-20-beta-73).
 
 The emulator is [our fork](https://github.com/alchemy-run/floci)
 of [floci](https://floci.io), an MIT-licensed, LocalStack-style
-AWS emulator on the JVM. We forked it so the factory can drive
-it: the fork is currently **92 commits ahead of upstream,
-touching about 30 services** — Lambda's streaming Function URLs,
-ELBv2's ALB data plane, AppSync's Velocity template directives,
-EC2, IAM, SES, Cognito, Athena, event-source mappings — and
-every one of those commits exists because an alchemy test failed
-against the emulator after passing against AWS.
+AWS emulator on the JVM. Our patches span about 30 services —
+Lambda's streaming Function URLs, ELBv2's ALB data plane,
+AppSync's Velocity template directives, EC2, IAM, SES, Cognito,
+Athena, event-source mappings — and every one of them exists
+because an alchemy test failed against the emulator after
+passing against AWS.
+
+We'd like to contribute these upstream. But the factory is a
+fully automated fan-out — fleets of agents producing fixes
+faster than any maintainer could reasonably review — and
+flooding the floci team with that maintenance burden isn't fair
+to them. It's easier to let alchemy's flywheel drive the
+emulator's development directly, and that requires a fork.
 
 Alchemy registers a local provider variant for every resource
 floci implements — **219 resources across ~39 services** today.

--- a/website/src/content/docs/blog/2026-08-20-generating-local-emulators.md
+++ b/website/src/content/docs/blog/2026-08-20-generating-local-emulators.md
@@ -13,40 +13,41 @@ product; the truthful SDK is the byproduct.
 
 The loop now has a second byproduct: a **local emulator**. What
 makes it possible is the tests, and they cover both halves of the
-cloud. The resource tests exercise the **control plane** — deploy
+cloud. The resource tests exercise the **control plane**: deploy
 a resource, verify it out-of-band against the raw API, mutate it,
 prove its destruction. The binding tests exercise the **data
-plane** — a deployed function actually calling `putObject`,
+plane**: a deployed function actually calling `putObject`,
 `getItem`, `sendMessage` against the resources bound to it.
 Together, thousands of them are an **executable specification of
-the cloud** — every consistency quirk, undocumented error code,
-and misused HTTP status the factory ever caught, pinned as an
+the cloud**. Every consistency quirk, undocumented error code,
+and misused HTTP status the factory ever caught is pinned as an
 assertion.
 
 An emulator has to satisfy the same specification. So we
 extended the factory: point the same suite at a local emulator,
 and every red test is a fidelity bug that arrives with its own
-reproduction. This is how `alchemy dev` for AWS works — your
-stack runs on your machine, no AWS account, no credentials — and
-it shipped in [2.0.0-beta.73](/blog/2026-08-20-beta-73).
+reproduction. This is how `alchemy dev` for AWS works. Your
+stack runs on your machine with no AWS account and no
+credentials. It shipped in
+[2.0.0-beta.73](/blog/2026-08-20-beta-73).
 
 ## The fork
 
 The emulator is [our fork](https://github.com/alchemy-run/floci)
 of [floci](https://floci.io), an MIT-licensed, LocalStack-style
-AWS emulator on the JVM. Our patches span about 30 services —
+AWS emulator on the JVM. Our patches span about 30 services:
 Lambda's streaming Function URLs, ELBv2's ALB data plane,
 AppSync's Velocity template directives, EC2, IAM, SES, Cognito,
-Athena, event-source mappings — and every one of them exists
-because an alchemy test failed against the emulator after
-passing against AWS.
+Athena, event-source mappings. Every one of them exists because
+an alchemy test failed against the emulator after passing
+against AWS.
 
 We'd like to contribute these upstream. But the factory is a
-fully automated fan-out — fleets of agents producing fixes
-faster than any maintainer could reasonably review — and
-flooding the floci team with that maintenance burden isn't fair
-to them. It's easier to let alchemy's flywheel drive the
-emulator's development directly, and that requires a fork.
+fully automated fan-out, with fleets of agents producing fixes
+faster than any maintainer could reasonably review. Flooding the
+floci team with that maintenance burden isn't fair to them. It's
+easier to let alchemy's flywheel drive the emulator's
+development directly, and that requires a fork.
 
 The test harness has one switch:
 
@@ -55,12 +56,11 @@ pnpm test:aws:floci
 ```
 
 It runs the same test suite that normally runs against live AWS,
-except every call — deploys and the tests' own verification
-reads — goes to floci instead. Nothing is mocked: each Lambda
-still cold-starts in its own Docker container.
+except every call goes to floci instead. Nothing is mocked: each
+Lambda still cold-starts in its own Docker container.
 
 In beta.73 we focused on patching the services floci already
-supports — **219 resources across ~39 services** today. In the
+supports: **219 resources across ~39 services** today. In the
 next release we'll push for 100% local emulation of every AWS
 service alchemy supports.
 
@@ -68,13 +68,13 @@ service alchemy supports.
 
 Every test must pass unchanged against both real AWS and floci.
 When a test goes red against the emulator, we never loosen the
-test or special-case alchemy — the fix goes in the fork, with a
+test or special-case alchemy. The fix goes in the fork, with a
 conformance test in the emulator's own suite.
 
 For example: a live test asserts that a streaming Function URL
 delivers its first bytes before the handler finishes. floci
 buffered the stream, the test went red, the fix landed in the
-fork — and streaming now behaves the same locally as in
+fork, and streaming now behaves the same locally as in
 `us-east-1`.
 
 ## Results
@@ -84,37 +84,37 @@ failures to 33**, with **396 tests green** against the emulator.
 DynamoDB (105 tests), S3 (51), Step Functions (31), Cognito
 (19), and others are fully green.
 
-The result is [`alchemy dev` for AWS](/aws/local-development) —
-and a cheaper factory: generation waves can now iterate against
-floci with no rate limits, no eventual-consistency stalls, and
-no leaked cloud resources, touching the real cloud only to
-certify.
+The result is [`alchemy dev` for AWS](/aws/local-development).
+It also makes the factory cheaper: generation waves can now
+iterate against floci with no rate limits, no
+eventual-consistency stalls, and no leaked cloud resources,
+touching the real cloud only to certify.
 
 ## Three artifacts per cloud
 
 The end state we're building toward is a flywheel that, for each
 cloud provider, produces three artifacts from one loop:
 
-1. **Infrastructure-as-Code** — typed resources and bindings in
+1. **Infrastructure-as-Code**: typed resources and bindings in
    Alchemy, with lifecycle logic whose error handling is
    verified against the live API.
-2. **A refined spec and Effect-native SDK** — distilled, where
+2. **A refined spec and Effect-native SDK**: distilled, where
    every behavior a live test observes becomes a typed patch to
    the provider's spec, compounding for every future consumer.
-3. **A local emulator** — held conformant to the same test suite
+3. **A local emulator**: held conformant to the same test suite
    that certifies the IaC, so `alchemy dev` is a faithful copy
    of `alchemy deploy`.
 
 Each artifact makes the others cheaper. The refined SDK types
 make lifecycle code generable. The lifecycle tests make the
-emulator convergeable. The emulator makes the tests — and your
-dev loop — free to run. And in the limit, the refined spec is
+emulator convergeable. The emulator makes the tests and your
+dev loop free to run. And in the limit, the refined spec is
 the substrate for all three: an emulator is just another
 consumer of a spec, and every patch that teaches the spec what
 the API really does is a piece of the emulator nobody has to
 hand-write.
 
-Cloudflare already runs this way — its Workers simulators are
+Cloudflare already runs this way: its Workers simulators are
 built on workerd itself and held to the same live suites. AWS
 now joins it. The next provider the factory brings up will ship
 all three artifacts together.

--- a/website/src/content/docs/blog/2026-08-20-generating-local-emulators.md
+++ b/website/src/content/docs/blog/2026-08-20-generating-local-emulators.md
@@ -90,7 +90,8 @@ patch floci to support the operation. We're strict about this.
 services** locally, with **396 tests green** against the
 emulator. Several services pass their full live suite: DynamoDB
 (105 tests), S3 (51), Step Functions (31), Cognito (19), and
-others.
+others. Next release we'll run the flywheel until the emulator
+conforms to 100% of what alchemy supports.
 
 The result is [`alchemy dev` for AWS](/aws/local-development).
 It also makes the factory cheaper: generation waves can now

--- a/website/src/content/docs/blog/2026-08-20-generating-local-emulators.md
+++ b/website/src/content/docs/blog/2026-08-20-generating-local-emulators.md
@@ -1,0 +1,152 @@
+---
+title: Looping the Generation of Local Emulators
+date: 2026-08-20T16:00:00Z
+excerpt: The live test suite that generates our IaC and SDKs is also an executable spec of the cloud. Point it at an emulator and every red test is a fidelity bug with a repro. One convergence run took AWS emulation from 253 failures to 396 green tests, and alchemy dev now runs your AWS stack with no AWS account.
+---
+
+In [Looping the Generation of IaC and SDKs](/blog/2026-07-02-cloudflare-resource-factory)
+we described the loop that builds Alchemy: fleets of AI agents
+write resources and their live tests, run them against the real
+cloud, and every API behavior the SDK's types don't capture
+becomes a typed patch to the generated SDK. The resource is the
+product; the truthful SDK is the byproduct.
+
+The loop now has a second byproduct: a **local emulator**. What
+makes it possible is the tests, and they cover both halves of the
+cloud. The resource tests exercise the **control plane** — deploy
+a resource, verify it out-of-band against the raw API, mutate it,
+prove its destruction. The binding tests exercise the **data
+plane** — a deployed function actually calling `putObject`,
+`getItem`, `sendMessage` against the resources bound to it.
+Together, thousands of them are an **executable specification of
+the cloud** — every consistency quirk, undocumented error code,
+and misused HTTP status the factory ever caught, pinned as an
+assertion.
+
+An emulator has to satisfy the same specification. So we
+extended the factory: point the same suite at a local emulator,
+and every red test is a fidelity bug that arrives with its own
+reproduction. This is how `alchemy dev` for AWS works — your
+stack runs on your machine, no AWS account, no credentials — and
+it shipped in [2.0.0-beta.73](/blog/2026-08-20-beta-73).
+
+## The fork
+
+The emulator is [our fork](https://github.com/alchemy-run/floci)
+of [floci](https://floci.io), an MIT-licensed, LocalStack-style
+AWS emulator on the JVM. We forked it so the factory can drive
+it: the fork is currently **92 commits ahead of upstream,
+touching about 30 services** — Lambda's streaming Function URLs,
+ELBv2's ALB data plane, AppSync's Velocity template directives,
+EC2, IAM, SES, Cognito, Athena, event-source mappings — and
+every one of those commits exists because an alchemy test failed
+against the emulator after passing against AWS.
+
+Alchemy registers a local provider variant for every resource
+floci implements — **219 resources across ~39 services** today.
+The test harness has one switch:
+
+```sh
+pnpm test:aws:floci   # ALCHEMY_TEST_DEV=1
+```
+
+It discovers the dualized services and reruns their **live**
+suites — the same files that run against real AWS — with local
+providers forced on. The harness pins everything to the
+emulator, not just the deploys: the out-of-band verification
+calls the tests make through
+[distilled](https://github.com/alchemy-run/distilled) are
+redirected too, so a test's every assertion runs against floci.
+A full run forks an RPC sidecar per test file and cold-starts a
+Docker container per Lambda.
+
+## The rule, inverted
+
+The SDK loop ran on one rule: agents never handle an unknown
+error in their own code — an unmatched error becomes an SDK
+patch. The emulator loop runs on the same rule pointed the other
+way: **never patch the consumer to tolerate the emulator.** A
+test that goes red under `ALCHEMY_TEST_DEV=1` is never fixed by
+loosening the test or special-casing alchemy's lifecycle code.
+The only permitted fix is in the fork.
+
+The invariant that keeps this honest: every test must pass
+unchanged against both real AWS and floci. The real cloud pins
+the tests, so the emulator can't drift toward them. The tests
+pin the emulator, so it can't drift from the cloud. When an
+agent fixes a fidelity bug, it also lands a conformance test
+inside the emulator's own suite — the fork's log is full of
+commits like `test(compat): align SES and ECS suite with AWS` —
+so the fix is pinned twice, once on each side of the boundary.
+
+One turn of the loop, concretely. Alchemy's Lambda suite
+asserts that a streaming Function URL delivers its first bytes
+before the invocation completes — a behavior a live test
+verified against AWS before floci was involved. Against the
+emulator, the response arrived only after the
+handler finished: floci's runtime API buffered the streaming
+POST to completion. The fix
+(`fix(lambda): resume streaming runtime POSTs so invokes
+complete at headers`) landed in the fork with a compat test, the
+alchemy suite reran, and streaming responses now behave
+identically on your laptop and in `us-east-1`.
+
+## Convergence
+
+The first full convergence run took the combined 13-service
+suite from **253 failures to 33**, with **396 tests green**
+against the emulator. Running in isolation, entire services are
+fully green: DynamoDB (105 tests), S3 (51), Step Functions (31),
+Cognito (19), Glue (15), Secrets Manager (14), ACM (14),
+Application Auto Scaling (10), and more. Each remaining failure
+is either the next emulator fix or a documented platform gap.
+
+The result for users is
+[`alchemy dev` for AWS](/aws/local-development): Lambda
+executing in Docker containers behind working Function URLs, ECS
+tasks as real containers, SQS→Lambda event source mappings
+pumping messages, S3 notifications firing, EventBridge routing —
+with ~100–500ms hot reload and no credentials.
+
+A conformant emulator also makes the loop that built it cheaper:
+future generation waves can run their first iterations against
+floci — no rate limits,
+no eventual-consistency stalls measured in minutes, no leaked
+cloud resources to nuke between rounds — and graduate to the
+real cloud only to certify. The emulator, once produced by the
+tests, lowers the cost of producing everything else.
+
+## Three artifacts per cloud
+
+The end state we're building toward is a flywheel that, for each
+cloud provider, produces three artifacts from one loop:
+
+1. **Infrastructure-as-Code** — typed resources and bindings in
+   Alchemy, with lifecycle logic whose error handling is
+   verified against the live API.
+2. **A refined spec and Effect-native SDK** — distilled, where
+   every behavior a live test observes becomes a typed patch to
+   the provider's spec, compounding for every future consumer.
+3. **A local emulator** — held conformant to the same test suite
+   that certifies the IaC, so `alchemy dev` is a faithful copy
+   of `alchemy deploy`.
+
+Each artifact makes the others cheaper. The refined SDK types
+make lifecycle code generable. The lifecycle tests make the
+emulator convergeable. The emulator makes the tests — and your
+dev loop — free to run. And in the limit, the refined spec is
+the substrate for all three: an emulator is just another
+consumer of a spec, and every patch that teaches the spec what
+the API really does is a piece of the emulator nobody has to
+hand-write.
+
+Cloudflare already runs this way — its Workers simulators are
+built on workerd itself and held to the same live suites. AWS
+now joins it. The next provider the factory brings up will ship
+all three artifacts together.
+
+- [2.0.0-beta.73 — the release AWS local dev shipped in](/blog/2026-08-20-beta-73)
+- [AWS local development](/aws/local-development)
+- [Looping the Generation of IaC and SDKs — the first post in this series](/blog/2026-07-02-cloudflare-resource-factory)
+- [alchemy-run/floci — the fork](https://github.com/alchemy-run/floci)
+- [distilled — the generated, patchable SDK](https://github.com/alchemy-run/distilled)

--- a/website/src/content/docs/blog/2026-08-20-generating-local-emulators.md
+++ b/website/src/content/docs/blog/2026-08-20-generating-local-emulators.md
@@ -33,15 +33,15 @@ credentials. It shipped in
 
 ## We forked floci
 
-The emulator is [our fork](https://github.com/alchemy-run/floci)
-of [floci](https://floci.io), an MIT-licensed, LocalStack-style
-AWS emulator on the JVM. We forked because the factory is a
-fully automated fan-out, with fleets of agents producing fixes
-faster than any maintainer could reasonably review. We'd like to
-contribute upstream, but flooding the floci team with that
-maintenance burden isn't fair to them. It's easier to let
-alchemy's flywheel drive the emulator's development directly,
-and that requires a fork.
+We [forked](https://github.com/alchemy-run/floci)
+[floci](https://floci.io), an MIT-licensed, LocalStack-style AWS
+emulator on the JVM, because the factory is a fully automated
+fan-out, with fleets of agents producing fixes faster than any
+maintainer could reasonably review. We'd like to contribute
+upstream, but flooding the floci team with that maintenance
+burden isn't fair to them. It's easier to let alchemy's flywheel
+drive the emulator's development directly, and that requires a
+fork.
 
 In this release our patches span about 30 services: Lambda's
 streaming Function URLs, ELBv2's ALB data plane, AppSync's

--- a/website/src/content/docs/blog/2026-08-20-generating-local-emulators.md
+++ b/website/src/content/docs/blog/2026-08-20-generating-local-emulators.md
@@ -80,6 +80,10 @@ buffered the stream, the test went red, the fix landed in the
 fork, and streaming now behaves the same locally as in
 `us-east-1`.
 
+The same goes for coverage gaps. Some operations in floci throw
+`UnsupportedOperation`. We never work around one in alchemy; we
+patch floci to support the operation. We're strict about this.
+
 ## Results
 
 The first convergence run took the 13-service suite from **253

--- a/website/src/content/docs/blog/2026-08-20-generating-local-emulators.md
+++ b/website/src/content/docs/blog/2026-08-20-generating-local-emulators.md
@@ -54,7 +54,10 @@ faster than any maintainer could reasonably review. Flooding the
 floci team with that maintenance burden isn't fair to them. It's
 easier to let alchemy's flywheel drive the fork directly.
 
-The test harness has one switch:
+## The flywheel
+
+What drives the fork is the test suite. The harness has one
+switch that points it at the emulator instead of live AWS:
 
 ```sh
 pnpm test:aws:floci
@@ -64,12 +67,12 @@ It runs the same test suite that normally runs against live AWS,
 except every call goes to floci instead. Nothing is mocked: each
 Lambda still cold-starts in its own Docker container.
 
-## One rule
-
-Every test must pass unchanged against both real AWS and floci.
-When a test goes red against the emulator, we never loosen the
-test or special-case alchemy. The fix goes in the fork, with a
-conformance test in the emulator's own suite.
+Agents run the suite and fix every red test. The fix always goes
+in the fork, never in alchemy: we don't loosen a test or
+special-case lifecycle code to tolerate the emulator, so the
+suite stays a single source of truth that both AWS and floci
+have to satisfy. Each fix lands with a conformance test in the
+emulator's own suite.
 
 For example: a live test asserts that a streaming Function URL
 delivers its first bytes before the handler finishes. floci

--- a/website/src/content/docs/blog/2026-08-20-generating-local-emulators.md
+++ b/website/src/content/docs/blog/2026-08-20-generating-local-emulators.md
@@ -48,23 +48,21 @@ flooding the floci team with that maintenance burden isn't fair
 to them. It's easier to let alchemy's flywheel drive the
 emulator's development directly, and that requires a fork.
 
-Alchemy registers a local provider variant for every resource
-floci implements — **219 resources across ~39 services** today.
 The test harness has one switch:
 
 ```sh
-pnpm test:aws:floci   # ALCHEMY_TEST_DEV=1
+pnpm test:aws:floci
 ```
 
-It discovers the dualized services and reruns their **live**
-suites — the same files that run against real AWS — with local
-providers forced on. The harness pins everything to the
-emulator, not just the deploys: the out-of-band verification
-calls the tests make through
-[distilled](https://github.com/alchemy-run/distilled) are
-redirected too, so a test's every assertion runs against floci.
-A full run forks an RPC sidecar per test file and cold-starts a
-Docker container per Lambda.
+It runs the same test suite that normally runs against live AWS,
+except every call — deploys and the tests' own verification
+reads — goes to floci instead. Nothing is mocked: each Lambda
+still cold-starts in its own Docker container.
+
+In beta.73 we focused on patching the services floci already
+supports — **219 resources across ~39 services** today. In the
+next release we'll push for 100% local emulation of every AWS
+service alchemy supports.
 
 ## The rule, inverted
 

--- a/website/src/content/docs/cloudflare/local-development.mdx
+++ b/website/src/content/docs/cloudflare/local-development.mdx
@@ -7,8 +7,9 @@ import Terminal from "../../../components/Terminal.astro";
 
 `alchemy dev` runs your Cloudflare stack on your machine. Workers
 execute in workerd — the same runtime used in production — with
-local simulators behind their bindings, and code changes hot
-reload in milliseconds.
+local simulators behind their bindings, websites run their
+frameworks' own dev servers with native HMR, containers run in
+Docker, and code changes hot reload in milliseconds.
 
 ```sh
 alchemy dev
@@ -24,15 +25,80 @@ alchemy dev
 ## Workers run in workerd
 
 Your Worker code executes in workerd with bindings wired to the
-local simulators, so binding behavior matches what you deploy.
-Durable Objects run inside the same workerd instance, cron
-triggers fire on their real schedule (and the
-miniflare-compatible `/cdn-cgi/handler/scheduled` route triggers
-them manually), and because everything is a local process you can
-attach a debugger, set breakpoints, and profile.
+local simulators, so binding behavior matches what you deploy:
+
+```typescript
+export const Cache = Cloudflare.KV.Namespace("Cache");
+
+export default class Api extends Cloudflare.Worker<Api>()(
+  "Api",
+  { main: import.meta.url },
+  Effect.gen(function* () {
+    const kv = yield* Cloudflare.KV.ReadWriteNamespace(Cache);
+    return {
+      fetch: Effect.gen(function* () {
+        yield* kv.put("greeting", "hello");
+        const value = yield* kv.get("greeting");
+        return yield* HttpServerResponse.text(value ?? "");
+      }).pipe(Effect.orDie),
+    };
+  }).pipe(Effect.provide(Cloudflare.KV.ReadWriteNamespaceBinding)),
+) {}
+```
+
+In dev, `kv.put` lands in a local KV simulator and the Worker
+serves at `http://localhost:<port>`. Durable Objects run inside
+the same workerd instance, cron triggers fire on their real
+schedule (and the miniflare-compatible
+`/cdn-cgi/handler/scheduled` route triggers them manually), and
+because everything is a local process you can attach a debugger,
+set breakpoints, and profile.
 
 A local resource's id is `dev:`-prefixed, which doubles as proof
 that no cloud call ran.
+
+## Websites run their own dev servers
+
+Every `Cloudflare.Website.*` resource — Vite, Next.js, Astro,
+Nuxt, SvelteKit, Waku, Octane, Foldkit, StaticSite — runs its
+framework's own dev server under `alchemy dev`: native HMR, no
+cloud resources. The site's `url` is the local dev server's
+address:
+
+```typescript
+const site = yield* Cloudflare.Website.Vite("Web");
+// dev:    site.url = http://localhost:5173 — Vite's own dev server, HMR included
+// deploy: site.url = the deployed site
+```
+
+See
+[Frontend frameworks](/cloudflare/frontend/frontends).
+
+## Containers run in Docker
+
+A `Cloudflare.Container` runs as a real Docker container on your
+machine, driven by its Durable Object in the local workerd:
+
+```typescript
+export class Sandbox extends Cloudflare.Container<
+  Sandbox,
+  { ping: () => Effect.Effect<string> }
+>()("Sandbox") {}
+
+export default Sandbox.make(
+  { main: import.meta.url },
+  Effect.gen(function* () {
+    return Sandbox.of({
+      ping: () => Effect.succeed("pong"),
+      fetch: Effect.succeed(HttpServerResponse.text("hello")),
+    });
+  }),
+);
+```
+
+All three image sources work locally: `main` (a bundled Effect
+program), `context` (your own Dockerfile), and `image` (a
+pre-built remote image).
 
 ## What's emulated
 

--- a/website/src/content/docs/cloudflare/local-development.mdx
+++ b/website/src/content/docs/cloudflare/local-development.mdx
@@ -1,0 +1,135 @@
+---
+title: Local development
+description: alchemy dev runs Workers in workerd with local simulators for KV, R2, D1, Queues, Hyperdrive, Workflows, Containers, and the Worker binding surface — browser rendering, images, email, cron, Stream, and more.
+---
+
+import Terminal from "../../../components/Terminal.astro";
+
+`alchemy dev` runs your Cloudflare stack on your machine. Workers
+execute in workerd — the same runtime used in production — with
+local simulators behind their bindings, and code changes hot
+reload in milliseconds.
+
+```sh
+alchemy dev
+```
+
+<Terminal content={`[g]✓[/g] [b]Bucket[/b] [d](Cloudflare.R2.Bucket)[/d] [g]created[/g] [d](local)[/d]
+[g]✓[/g] [b]DB[/b] [d](Cloudflare.D1.Database)[/d] [g]created[/g] [d](local)[/d]
+[g]✓[/g] [b]Worker[/b] [d](Cloudflare.Worker)[/d] [g]created[/g] [d](local → workerd)[/d]
+[s2][d]• http://localhost:1337[/d]
+
+[d]Watching for changes ...[/d]`} />
+
+## Workers run in workerd
+
+Your Worker code executes in workerd with bindings wired to the
+local simulators, so binding behavior matches what you deploy.
+Durable Objects run inside the same workerd instance, cron
+triggers fire on their real schedule (and the
+miniflare-compatible `/cdn-cgi/handler/scheduled` route triggers
+them manually), and because everything is a local process you can
+attach a debugger, set breakpoints, and profile.
+
+A local resource's id is `dev:`-prefixed, which doubles as proof
+that no cloud call ran.
+
+## What's emulated
+
+These resources ship a local provider and run as simulators in
+dev:
+
+| Resource                 | Local behavior                                                                    |
+| ------------------------ | --------------------------------------------------------------------------------- |
+| Workers                  | workerd, with hot reload and a `http://localhost:<port>` URL                       |
+| Durable Objects          | run inside the local workerd, including SQLite storage                             |
+| KV Namespaces            | local simulator; Node-side capability clients hit the same store                   |
+| R2 Buckets               | local simulator                                                                    |
+| D1 Databases             | local simulator; `migrations` and `importFiles` apply on every reconcile           |
+| Queues + consumers       | local broker with batching, retry, and dead-letter semantics                       |
+| Hyperdrive               | connects directly to your database                                                 |
+| Workflows                | run locally with real step semantics                                               |
+| Containers               | run as Docker containers on your machine                                           |
+| Secrets Store            | local store seeded with the real (Redacted-sourced) values                         |
+| Websites                 | the framework's own dev server (Vite, Astro, Next.js, Nuxt, SvelteKit, Waku, Octane, Foldkit, StaticSite) with native HMR |
+
+Worker-only bindings are simulated too:
+
+- **Email, both directions** — a `send_email` binding persists
+  messages as `.eml` files under `.alchemy/local/email`, and a
+  `POST` to `/cdn-cgi/handler/email` drives your `email()` handler
+  with accept, reject, and reply semantics.
+- **Browser Rendering** — `env.BROWSER` drives a locally-launched
+  headless Chrome over CDP; `@cloudflare/puppeteer` works
+  unchanged.
+- **Images** — `env.IMAGES` transforms run through sharp.
+- **Stream** — uploads land in a local video store.
+- **Tail consumers** — a local producer's trace events reach a
+  local tail Worker.
+- **Secret keys** — `secret_key` CryptoKey bindings boot locally.
+- **Access** — `dev: { access: { identity } }` stubs the
+  authenticated identity behind `ctx.access`, so gated paths are
+  testable without a login wall. See
+  [Protect a Worker with Access](/cloudflare/security/access).
+
+Resources whose provider has no local implementation (a Vectorize
+index, DNS records) deploy to the real cloud, into your personal
+[stage](/environments/stages), so a stack that mixes emulated and
+live-only resources just works.
+
+## Mix in the real cloud
+
+`Alchemy.remote()` opts any resource (or a whole scope) out of
+local emulation:
+
+```typescript
+// Effect-native Worker
+const browser = yield* Cloudflare.Browser("BROWSER").pipe(Alchemy.remote());
+
+// async Worker env
+env: { IMAGES: Cloudflare.Images.Images("IMAGES").pipe(Alchemy.remote()) }
+```
+
+Local and live compose into hybrid topologies. Pin a queue live
+and everything around it stays local — the local Worker produces
+real messages into the real queue, and its local consumer drains
+the same queue through a pull loop:
+
+```typescript
+// the queue is real, even in dev
+const Jobs = Cloudflare.Queues.Queue("Jobs").pipe(Alchemy.remote());
+```
+
+Your dev session sees the same traffic as staging — messages
+produced by deployed services or a teammate's session land in
+your local handler.
+
+Switching a resource between local and live (or dev → deploy)
+plans a **replacement** — dev state never silently becomes cloud
+state. See
+[Local development](/environments/local-development) for the
+shared semantics.
+
+## Custom port
+
+```typescript
+export default Cloudflare.Worker("Worker", {
+  main: import.meta.url,
+  dev: {
+    port: 3000,
+  },
+  // ...
+});
+```
+
+## Where next
+
+- [Local development](/environments/local-development) — the
+  shared `alchemy dev` concepts: hot reload, `Alchemy.remote()`,
+  and dev vs deploy semantics.
+- [Frontend frameworks](/cloudflare/frontend/frontends) —
+  framework dev servers under `alchemy dev`.
+- [Stages](/environments/stages) — how live-in-dev resources stay
+  isolated per developer.
+- [Local Providers](/infrastructure-as-code/local-provider) —
+  build the local implementation of a resource.

--- a/website/src/content/docs/environments/local-development.mdx
+++ b/website/src/content/docs/environments/local-development.mdx
@@ -1,15 +1,27 @@
 ---
 title: Local development
-description: How alchemy dev provides hot reloading, local workerd execution, and local emulation with per-resource opt-in to real cloud services.
+description: How alchemy dev provides hot reloading, local execution, and local emulation with per-resource opt-in to real cloud services.
 ---
 
 import Terminal from "../../../components/Terminal.astro";
 
-`alchemy dev` runs your stack on your machine. Workers execute in
-workerd, KV Namespaces, R2 Buckets, D1 Databases, and Queues are
-emulated locally, and code changes hot reload in milliseconds.
-`Alchemy.remote()` runs any resource against the real cloud when you
-need it.
+`alchemy dev` runs your stack on your machine. Your compute runs
+locally (Workers in workerd, Lambda and ECS in Docker
+containers), the services around it are emulated, and code
+changes hot reload in milliseconds. `Alchemy.remote()` runs any
+resource against the real cloud when you need it.
+
+This page covers the concepts shared by every cloud. For what
+each cloud emulates and how, see the dedicated guides:
+
+- **[Cloudflare local development](/cloudflare/local-development)**
+  — Workers in workerd; simulators for KV, R2, D1, Queues,
+  Hyperdrive, Workflows, Containers, and the Worker binding
+  surface (browser rendering, images, email, cron, Stream, …).
+- **[AWS local development](/aws/local-development)** — Lambda
+  and ECS in Docker containers with close to 40 emulated services
+  (S3, DynamoDB, SQS, SNS, EventBridge, API Gateway, …), no AWS
+  account required.
 
 ## How it works
 
@@ -26,21 +38,21 @@ alchemy dev
 
 Three things happen:
 
-1. **Emulatable services run locally** — KV Namespaces, R2 Buckets,
-   D1 Databases, and Queues are created as local simulators with
-   `dev:`-prefixed ids. No cloud calls. D1 applies `migrations`
-   and `importFiles` against the local database.
-2. **Workers run locally in workerd** — your code executes in
-   workerd, the same runtime used in production, with bindings wired
-   to the local simulators.
-3. **File changes hot reload** — edit your code and the Worker
-   rebuilds instantly.
+1. **Emulatable services run locally** — resources whose provider
+   ships a local implementation are created as local simulators
+   with `dev:`-prefixed ids. No cloud calls.
+2. **Your code runs locally** — Workers execute in workerd,
+   Lambda functions and ECS tasks in Docker containers, websites
+   on their framework's own dev server — with bindings wired to
+   the local simulators.
+3. **File changes hot reload** — edit your code and the running
+   compute swaps in the new code without a redeploy.
 
-Resources whose provider has no local implementation (a Hyperdrive,
-a Vectorize index) deploy to the real cloud, into your personal
-[stage](/environments/stages) (`dev_$USER` by default), so your loop
-never collides with teammates or prod. A stack that mixes emulated
-and live-only resources just works.
+Resources whose provider has no local implementation deploy to
+the real cloud, into your personal
+[stage](/environments/stages) (`dev_$USER` by default), so your
+loop never collides with teammates or prod. A stack that mixes
+emulated and live-only resources just works.
 
 ## Hot module reloading
 
@@ -65,64 +77,32 @@ deploy.
 
 ## Local by default, live on demand
 
-KV, R2, D1, and Queues ship a local provider. In dev they are
-simulators running inside workerd, the same runtime used in
-production, so binding behavior matches what you deploy. A local
-resource's id is `dev:`-prefixed, which doubles as proof that no
-cloud call ran.
+In dev, emulatable resources are simulators. A local resource's
+id is `dev:`-prefixed, which doubles as proof that no cloud call
+ran.
 
-The local simulators reach beyond Worker bindings. Node-side
-capability clients follow the same rule: a seed script in an
-[Action](/infrastructure-as-code/action) that writes to a `dev:` KV
-Namespace lands in the same local simulator your Worker reads.
+The local simulators reach beyond your compute's bindings.
+Node-side capability clients follow the same rule: a seed script
+in an [Action](/infrastructure-as-code/action) that writes to a
+`dev:` KV Namespace or S3 bucket lands in the same local
+simulator your Worker or Lambda reads.
 
 Every other resource runs live in dev automatically, and
-`Alchemy.remote()` (below) runs an emulatable resource against the
-real cloud when local fidelity isn't enough.
-
-Worker-only bindings are simulated too: a
-[`send_email` binding](/cloudflare/email/send-and-receive) persists
-messages as `.eml` files under `.alchemy/local/email` instead of
-delivering mail, Browser Rendering drives a locally-launched headless
-Chrome, Images transforms run through Sharp, and Stream uploads land
-in a local video store. Each of these opts out the same way as a
-resource — pipe the binding through `Alchemy.remote()` (below) to hit
-the real service from the dev loop:
-
-```typescript
-env: {
-  EMAIL: email, // Alchemy.remote() on the SendEmail descriptor
-  BROWSER: Cloudflare.Browser("BROWSER").pipe(Alchemy.remote()),
-}
-```
+`Alchemy.remote()` (below) runs an emulatable resource against
+the real cloud when local fidelity isn't enough.
 
 ## Debugging
 
-Because Workers run locally in workerd, you can attach a debugger:
+Because your code runs locally, you can attach a debugger:
 
 - Set breakpoints in your IDE
 - Inspect variables and call stacks
 - Profile performance
 
-## Resource adaptation
-
-Resources adapt their behavior in dev mode:
-
-- **Cloudflare Workers** — run locally in workerd with a cloud proxy
-  instead of deploying to the edge
-- **Vite dev servers** — integrate with Alchemy's dev server for
-  frontend hot reloading alongside your backend
-- **D1 Databases** — emulate locally, with `migrations` and
-  `importFiles` applied to the local database on every reconcile
-
-A resource emulates locally when its provider ships a local
-implementation; everything else is live in dev automatically. See
-[Local Providers](/infrastructure-as-code/local-provider) to build one.
-
 ## Running a resource live in dev
 
-`Alchemy.remote()` opts a resource out of local emulation — "run this live
-even in dev":
+`Alchemy.remote()` opts a resource out of local emulation — "run
+this live even in dev":
 
 ```typescript
 import * as Alchemy from "alchemy";
@@ -130,7 +110,9 @@ import * as Alchemy from "alchemy";
 const worker = yield* Worker("Api", { ... }).pipe(Alchemy.remote());
 ```
 
-During `alchemy deploy` the pin is a no-op — everything is live anyway.
+During `alchemy deploy` the pin is a no-op — everything is live
+anyway. If a remote resource needs credentials you don't have,
+`alchemy dev` tells you before touching anything.
 
 ### Opt out a whole scope
 
@@ -141,50 +123,41 @@ yield* Effect.gen(function* () {
 }).pipe(Alchemy.remote());
 ```
 
-The policy is ambient and captured at registration (like `adopt()`), so
-everything inside the scope runs live. Resources with no local emulation
-(a Hyperdrive, a Vectorize index) already run live in dev — `remote()` on
+The policy is ambient and captured at registration (like
+`adopt()`), so everything inside the scope runs live. Resources
+with no local emulation already run live in dev — `remote()` on
 them is a no-op.
 
-Queues support `remote()` in both directions: a local Worker binding a
-live queue produces real messages, and a local `queue()` handler drains
-the live queue through a pull consumer — with the usual local batching,
-retry, and dead-letter semantics.
+Local and live compose into hybrid topologies — a local Worker
+producing into a live queue whose local consumer drains it, or a
+local Lambda reading a live Secrets Manager secret. See the
+per-cloud guides for examples.
 
 ### Switching is a replacement
 
-When a resource moves between local and live — you deploy after a dev
-session, or add/remove `remote()` — it's planned as a **replacement**: the
-new instance is created live, and the local one (the workerd instance, the
-dev process) is torn down.
-
-## Custom port
-
-```typescript
-export default Cloudflare.Worker("Worker", {
-  main: import.meta.url,
-  dev: {
-    port: 3000,
-  },
-  // ...
-});
-```
+When a resource moves between local and live — you deploy after a
+dev session, or add/remove `remote()` — it's planned as a
+**replacement**: the new instance is created live, and the local
+one (the workerd instance, the Docker container, the dev process)
+is torn down. Dev state never silently becomes cloud state.
 
 ## Dev vs Deploy
 
-|                        | `alchemy dev`                          | `alchemy deploy`   |
-| ---------------------- | -------------------------------------- | ------------------ |
-| KV, R2, D1, Queues     | Local simulators (`remote()` for live) | Deployed to cloud  |
-| Everything else        | Deployed to cloud                      | Deployed to cloud  |
-| Application code       | Runs locally in workerd                | Deployed to cloud  |
-| File watching          | Hot reload on change                   | Manual redeploy    |
-| Debugging              | Attach local debugger                  | Tail logs          |
-| Speed                  | Milliseconds                           | Seconds to minutes |
+|                     | `alchemy dev`                            | `alchemy deploy`   |
+| ------------------- | ---------------------------------------- | ------------------ |
+| Emulatable services | Local simulators (`remote()` for live)   | Deployed to cloud  |
+| Everything else     | Deployed to cloud (personal stage)       | Deployed to cloud  |
+| Application code    | Runs locally (workerd, Docker)           | Deployed to cloud  |
+| File watching       | Hot reload on change                     | Manual redeploy    |
+| Debugging           | Attach local debugger                    | Tail logs          |
+| Speed               | Milliseconds                             | Seconds to minutes |
 
 To automate the deploy side, see the [CI guide](/environments/ci).
 
 ## Where next
 
+- [Cloudflare local development](/cloudflare/local-development) — what runs in workerd and which bindings are simulated.
+- [AWS local development](/aws/local-development) — the emulated AWS surface, Lambda/ECS containers, and zero-credential dev.
 - [CI](/environments/ci) — deploy the same stack from GitHub Actions with PR previews.
 - [Stages](/environments/stages) — how `dev_$USER`, `pr-42`, and `prod` stay isolated.
 - [Dev servers](/command/dev-servers) — run any framework dev server as a `Command.Dev` resource in the dev loop.


### PR DESCRIPTION
Release notes for beta.73 (covering beta.72), a follow-up blog on the floci fork, and dedicated local-development docs per cloud.

- **Blog: `2.0.0-beta.73 - AWS Local Dev & Hetzner`** — AWS local dev (Lambda in Docker, ECS containers, event sources, websites' own dev servers), the Hetzner provider + `Hetzner.Service`, web frameworks on AWS, unified SQL migrations, Workers protected by Access, removal-policy persistence, Prisma additions, and the long tail.
- **Blog: `Looping the Generation of Local Emulators`** — the floci fork as the factory's second byproduct: the control-plane and data-plane test suites as an executable spec, the inverted patch rule, convergence numbers, and the three-artifacts-per-cloud end state.
- **New docs: `/aws/local-development`** — how `alchemy dev` runs an AWS stack locally, `AWS.Website.Vite` dev servers, the emulated-service matrix, `Alchemy.remote()`, emulator management.
- **New docs: `/cloudflare/local-development`** — Workers in workerd and the local simulators per resource.
- **Reworked `/environments/local-development`** to be cloud-neutral, linking to the per-cloud pages; sidebar entries added for both.
