### PR TITLE
chore(ci): restore release changelog and Discord notifications

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,9 @@ permissions:
   contents: write
   id-token: write
 
+env:
+  ALCHEMY_REPO: alchemy-run/alchemy
+
 jobs:
   build:
     name: Build and pack
@@ -89,6 +92,7 @@ jobs:
         env:
           VERSION: ${{ steps.release.outputs.version }}
           CHANNEL: ${{ steps.release.outputs.channel }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: bash scripts/release/commit.sh
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -141,7 +145,15 @@ jobs:
       - name: Create GitHub release
         if: needs.build.outputs.channel != 'tag'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
           VERSION: ${{ needs.build.outputs.version }}
           CHANNEL: ${{ needs.build.outputs.channel }}
         run: bun scripts/release/github-release.ts "v${VERSION}" "$CHANNEL"
+
+      - name: Notify Discord
+        if: needs.build.outputs.channel != 'tag'
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          VERSION: ${{ needs.build.outputs.version }}
+          CHANNEL: ${{ needs.build.outputs.channel }}
+        run: bun scripts/release/discord-notify.ts "v${VERSION}" "$CHANNEL"

--- a/scripts/release/changelog.ts
+++ b/scripts/release/changelog.ts
@@ -1,0 +1,92 @@
+/**
+ * changelogithub's `generate()`, minus the 1 MB ceiling.
+ *
+ * Upstream reads the commit range with `execSync`, whose default `maxBuffer`
+ * is 1 MB. `git log … --name-status` prints every changed path of every
+ * commit in the range, so a release spanning a large diff blows past that and
+ * the process is killed:
+ *
+ *   error: spawnSync /bin/sh ENOBUFS (stdout or stderr buffer reached
+ *   maxBuffer size limit)
+ *
+ * It is not a pathological case — one repo-wide refactor in the range is
+ * enough, and the release then fails at the tagging step having already
+ * bumped versions.
+ *
+ * `generate()` is `getGitDiff → parseCommits → resolveAuthors → markdown`,
+ * and changelogithub exports every piece except the first. So this reads the
+ * log itself, streaming, and hands the result to the same parser — no
+ * reimplementation of the changelog format, and no fork.
+ */
+import type { ChangelogOptions, Commit } from "changelogithub";
+import {
+  generateMarkdown,
+  parseCommits,
+  resolveAuthors,
+  resolveConfig,
+} from "changelogithub";
+
+interface RawGitCommit {
+  message: string;
+  body: string;
+  shortHash: string;
+  author: { name: string; email: string };
+}
+
+/**
+ * The same command and parsing as changelogen's `getGitDiff`, read through a
+ * pipe instead of a fixed buffer. Kept byte-compatible with upstream: the
+ * `----` record separator and `|`-delimited header are what `parseCommits`
+ * expects.
+ */
+export const getGitDiff = async (
+  from: string | undefined,
+  to = "HEAD",
+): Promise<RawGitCommit[]> => {
+  const proc = Bun.spawn(
+    [
+      "git",
+      "--no-pager",
+      "log",
+      `${from ? `${from}...` : ""}${to}`,
+      "--pretty=----%n%s|%h|%an|%ae%n%b",
+      "--name-status",
+    ],
+    { stdout: "pipe", stderr: "pipe" },
+  );
+  const [raw, err, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (exitCode !== 0) {
+    throw new Error(`git log ${from ?? ""}...${to} failed: ${err.trim()}`);
+  }
+  return raw
+    .trim()
+    .split("----\n")
+    .splice(1)
+    .map((line) => {
+      const [firstLine, ..._body] = line.split("\n");
+      const [message, shortHash, authorName, authorEmail] = (
+        firstLine ?? ""
+      ).split("|");
+      return {
+        message: message ?? "",
+        shortHash: shortHash ?? "",
+        author: { name: authorName ?? "", email: authorEmail ?? "" },
+        body: _body.join("\n"),
+      };
+    });
+};
+
+/** Drop-in for changelogithub's `generate`. */
+export const generate = async (options: ChangelogOptions) => {
+  const config = await resolveConfig(options);
+  const commits: Commit[] = parseCommits(
+    (await getGitDiff(config.from, config.to)) as never,
+    config,
+  );
+  if (config.contributors) await resolveAuthors(commits, config);
+  return { config, commits, md: generateMarkdown(commits, config) };
+};

--- a/scripts/release/commit.sh
+++ b/scripts/release/commit.sh
@@ -9,8 +9,9 @@ fi
 tag="v${VERSION}"
 git config user.email "alchemy-version-bot[bot]@users.noreply.github.com"
 git config user.name "alchemy-version-bot[bot]"
+bun scripts/release/release-notes.ts "$tag"
 mapfile -t package_jsons < <(jq -r '.[] | "\(.dir)/package.json"' release-packages.json)
-git add "${package_jsons[@]}" pnpm-lock.yaml
+git add "${package_jsons[@]}" pnpm-lock.yaml CHANGELOG.md
 if ! git diff --cached --quiet; then
   git commit -m "chore(release): ${VERSION}"
 fi

--- a/scripts/release/config.ts
+++ b/scripts/release/config.ts
@@ -1,0 +1,100 @@
+/**
+ * Shared config for the release scripts. Read from env vars set by the
+ * reusable workflow so the same scripts work for every consumer.
+ *
+ * ALCHEMY_PUBLISHABLE_DIRS   JSON array of package dirs (relative to repo root)
+ * ALCHEMY_PUBLISHABLE_NAMES  JSON array of npm names (parallel to dirs)
+ * ALCHEMY_CURRENT_VERSION    Anchor for prerelease bumps (e.g. "2.0.0")
+ * ALCHEMY_REPO               `<owner>/<repo>` for changelog/release-note URLs
+ * GITHUB_OUTPUT              GitHub Actions output file (used by output())
+ */
+import { appendFileSync } from "node:fs";
+
+export type Package = {
+  dir: string;
+  name: string;
+  project: string;
+  install: string;
+  runner: string;
+  artifact: string;
+};
+
+export type PrPackagePlan = {
+  packages: Package[];
+  publishable_names: string[];
+  tags: string[];
+  dependency_tag: string;
+  short: string;
+  install_host: string;
+};
+
+export function fail(message: string): never {
+  console.error(message);
+  process.exit(1);
+}
+
+export function required(name: string): string {
+  const v = process.env[name];
+  if (!v || !v.trim()) {
+    fail(`Required env var ${name} is unset or empty`);
+  }
+  return v.trim();
+}
+
+export function output(name: string, value: unknown): void {
+  const encoded = typeof value === "string" ? value : JSON.stringify(value);
+  appendFileSync(required("GITHUB_OUTPUT"), `${name}=${encoded}\n`);
+}
+
+export function jsonArray<T>(name: string, value: string): T[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch (e) {
+    fail(`${name} is not valid JSON: ${(e as Error).message}`);
+  }
+  if (!Array.isArray(parsed)) {
+    fail(`${name} must be a JSON array`);
+  }
+  return parsed as T[];
+}
+
+function parseJsonArray(name: string, value: string): string[] {
+  const parsed = jsonArray<unknown>(name, value);
+  if (!parsed.every((x) => typeof x === "string" && x.trim().length > 0)) {
+    fail(`${name} must be a JSON array of non-empty strings`);
+  }
+  return parsed as string[];
+}
+
+export function publishableDirs(): string[] {
+  return parseJsonArray(
+    "ALCHEMY_PUBLISHABLE_DIRS",
+    required("ALCHEMY_PUBLISHABLE_DIRS"),
+  );
+}
+
+export function publishableNames(): string[] {
+  return parseJsonArray(
+    "ALCHEMY_PUBLISHABLE_NAMES",
+    required("ALCHEMY_PUBLISHABLE_NAMES"),
+  );
+}
+
+export function currentVersion(): string {
+  const v = required("ALCHEMY_CURRENT_VERSION");
+  if (!/^\d+\.\d+\.\d+$/.test(v)) {
+    console.error(`ALCHEMY_CURRENT_VERSION must be x.y.z (got: ${v})`);
+    process.exit(1);
+  }
+  return v;
+}
+
+export function repo(): string {
+  const r = required("ALCHEMY_REPO");
+  if (!/^[\w.-]+\/[\w.-]+$/.test(r)) {
+    console.error(`ALCHEMY_REPO must be <owner>/<repo> (got: ${r})`);
+    process.exit(1);
+  }
+  return r;
+}

--- a/scripts/release/discord-body.ts
+++ b/scripts/release/discord-body.ts
@@ -1,0 +1,56 @@
+/**
+ * Transform a CHANGELOG.md entry body (written for GitHub Releases, which
+ * render HTML) into text suitable for a Discord embed description.
+ *
+ * Discord renders neither HTML entities nor the `<samp>` tag, and only
+ * honors `#`, `##`, and `###` headings. The CHANGELOG entries produced by
+ * `render.ts` / `changelogithub` use:
+ *
+ *   - `&nbsp;` sequences to visually indent `###`/`#####` headings and
+ *     author/PR separators (`&nbsp;-&nbsp;`)
+ *   - `<samp>(hash)</samp>` to render commit-hash links in small caps
+ *   - A trailing `#####` "View changes on GitHub" line
+ *
+ * This converts those into plain-text / markdown equivalents.
+ */
+export function toDiscordBody(rawBody: string): string {
+  return (
+    rawBody
+      .replace(/&nbsp;/g, " ")
+      .replace(/<\/?samp>/g, "`")
+      // Collapse the long indent that the GitHub-flavored headings use.
+      .replace(/^(#{1,6})\s+/gm, "$1 ")
+      // Discord only renders #, ##, ### as headings; drop deeper levels so
+      // lines like "##### View changes on GitHub" become plain text.
+      .replace(/^#{4,6}\s+/gm, "")
+      // Strip any other stray HTML tags just in case.
+      .replace(/<\/?[a-z][^>]*>/gi, "")
+  );
+}
+
+/**
+ * Extract the body for a single `## <tag>` entry out of a CHANGELOG.md
+ * string. Stops at the `---` separator that `release-notes.ts` inserts
+ * between entries, or at the next `## ` heading if the separator is
+ * missing. Returns `undefined` if the tag isn't present.
+ */
+export function extractTagBody(
+  changelog: string,
+  tag: string,
+): string | undefined {
+  const heading = `## ${tag}\n`;
+  const start = changelog.indexOf(heading);
+  if (start === -1) return undefined;
+  const after = changelog.slice(start + heading.length);
+  const sepIdx = after.indexOf("\n---\n");
+  const nextHeadingIdx = after.indexOf("\n## ");
+  const end =
+    sepIdx === -1
+      ? nextHeadingIdx === -1
+        ? after.length
+        : nextHeadingIdx
+      : nextHeadingIdx === -1
+        ? sepIdx
+        : Math.min(sepIdx, nextHeadingIdx);
+  return after.slice(0, end).trim();
+}

--- a/scripts/release/discord-notify.ts
+++ b/scripts/release/discord-notify.ts
@@ -1,0 +1,107 @@
+#!/usr/bin/env bun
+/**
+ * Post a release announcement to Discord as a single embed. The body is
+ * read verbatim from the CHANGELOG.md entry the release-notes step just
+ * wrote, so Discord matches the GitHub Release copy exactly.
+ *
+ * The webhook posts under `<RepoName> Releases` (e.g. "Alchemy-Effect
+ * Releases", "Distilled Releases"). The embed title uses the first
+ * hyphen-segment of the repo name as the project prefix
+ * (alchemy-effect → "Alchemy", distilled → "Distilled") and omits the
+ * channel suffix for stable `release` channel so you don't get
+ * "...(release) released" doubling up.
+ *
+ *   alchemy-effect + beta → Alchemy v2.0.0-beta.42 (beta) released
+ *   distilled + release  → Distilled v0.21.3 released
+ *
+ * Reads DISCORD_WEBHOOK from the environment. Silently no-ops if unset.
+ *
+ * Usage: bun discord-notify.ts <tag> <release|beta|alpha|tag>
+ *
+ * Reads ALCHEMY_REPO for the GitHub repo to link to.
+ */
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { repo } from "./config.ts";
+import { extractTagBody, toDiscordBody } from "./discord-body.ts";
+
+const EMBED_DESCRIPTION_LIMIT = 4096;
+
+const tag = process.argv[2];
+const channel = process.argv[3];
+if (!tag || !channel) {
+  console.error("Usage: bun discord-notify.ts <tag> <channel>");
+  process.exit(1);
+}
+
+const webhook = process.env.DISCORD_WEBHOOK;
+if (!webhook) {
+  console.log("DISCORD_WEBHOOK not set, skipping Discord notification");
+  process.exit(0);
+}
+
+const REPO = repo();
+const repoSlug = REPO.split("/")[1]!;
+const capitalize = (s: string) =>
+  s.length === 0 ? s : s[0]!.toUpperCase() + s.slice(1);
+// "alchemy-effect" -> "Alchemy-Effect"
+const fullRepoName = repoSlug.split("-").map(capitalize).join("-");
+// "alchemy-effect" -> "Alchemy"
+const projectName = capitalize(repoSlug.split("-")[0]!);
+const botName = `${fullRepoName} Releases`;
+const titleChannel = channel === "release" ? "" : ` (${channel})`;
+const title = `${projectName} ${tag}${titleChannel} released`;
+
+const changelogPath = join(process.cwd(), "CHANGELOG.md");
+const changelog = await readFile(changelogPath, "utf-8");
+const rawBody = extractTagBody(changelog, tag);
+if (rawBody === undefined) {
+  console.error(`CHANGELOG.md has no entry for ${tag}`);
+  process.exit(1);
+}
+
+const body = toDiscordBody(rawBody);
+
+const releaseUrl = `https://github.com/${REPO}/releases/tag/${tag}`;
+const footer = `\n\n[Full release notes →](${releaseUrl})`;
+// Discord embed descriptions cap at 4096 chars. If the rendered body
+// plus the footer would overflow, truncate the body to fit and prepend
+// a notice line so the reader knows there's more on GitHub. We cut at
+// the last newline before the budget so we never slice mid-bullet, then
+// fall back to a hard slice if no newline lands in range.
+const truncationNotice =
+  "_Release notes truncated — see the full changelog on GitHub._\n\n";
+let description = `${body}${footer}`;
+if (description.length > EMBED_DESCRIPTION_LIMIT) {
+  const budget =
+    EMBED_DESCRIPTION_LIMIT - footer.length - truncationNotice.length;
+  let cut = body.lastIndexOf("\n", budget);
+  if (cut < budget / 2) cut = budget; // no convenient newline — hard cut
+  const truncated = body.slice(0, cut).trimEnd();
+  description = `${truncationNotice}${truncated}${footer}`;
+  console.log(
+    `Changelog body (${body.length} chars) exceeded Discord limit; truncated to ${truncated.length} chars and linked to GitHub for the full notes.`,
+  );
+}
+
+const res = await fetch(webhook, {
+  method: "POST",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify({
+    username: botName,
+    embeds: [
+      {
+        title,
+        url: releaseUrl,
+        description,
+      },
+    ],
+    allowed_mentions: { parse: [] },
+  }),
+});
+
+if (!res.ok) {
+  console.error(`Discord webhook failed: ${res.status} ${await res.text()}`);
+  process.exit(1);
+}
+console.log(`Posted Discord release notification for ${tag}`);

--- a/scripts/release/github-release.ts
+++ b/scripts/release/github-release.ts
@@ -1,50 +1,135 @@
+#!/usr/bin/env bun
+/**
+ * Create a GitHub release for a tag, with channel-aware prerelease/latest flags.
+ *
+ * GitHub's API does not allow a release to be both `prerelease=true` and
+ * `latest=true`. To show an alpha/beta as "Latest" when no stable release
+ * exists yet, we publish it with `prerelease=false` — a masquerade. This
+ * script compensates on the next release: if the currently-latest release
+ * has a pre-release-style tag and prerelease=false, we flip it back to
+ * `prerelease=true` before publishing the new one. That keeps the latest
+ * badge where the user wants it without leaving stale "stable" markers on
+ * alpha/beta tags.
+ *
+ * Channel → flags on the new release:
+ *   release        prerelease=false, latest=true
+ *   beta|alpha|rc  if any true-stable release exists: prerelease=true, latest=false
+ *                  else:                              prerelease=false, latest=true (masquerade)
+ *   tag            prerelease=true, latest=false (always)
+ *
+ * Usage: bun github-release.ts <tag> <release|beta|alpha|tag>
+ *
+ * Reads ALCHEMY_REPO for the GitHub repo to query commit history from.
+ */
 import { $ } from "bun";
+import { generate } from "./changelog.ts";
+import { repo } from "./config.ts";
 
-const [tag, channel] = process.argv.slice(2);
-if (!tag || !channel)
-  throw new Error("Usage: github-release.ts <tag> <channel>");
-if ((await $`gh release view ${tag}`.nothrow().quiet()).exitCode === 0)
-  process.exit(0);
+type Channel = "release" | "beta" | "alpha" | "rc" | "tag";
+const CHANNELS: readonly Channel[] = ["release", "beta", "alpha", "rc", "tag"];
 
-const stable = channel === "release";
-let latest = stable;
-let prerelease = !stable;
-if (!stable) {
-  const releases =
-    await $`gh release list --limit 500 --json tagName,isPrerelease`.json();
-  const hasStable = releases.some(
-    (release: { tagName: string; isPrerelease: boolean }) =>
-      /^v?\d+\.\d+\.\d+$/.test(release.tagName) && !release.isPrerelease,
+function isStableTag(tag: string): boolean {
+  return /^v?\d+\.\d+\.\d+$/.test(tag);
+}
+
+const tag = process.argv[2];
+const channel = process.argv[3] as Channel | undefined;
+if (!tag || !channel || !CHANNELS.includes(channel)) {
+  console.error(
+    "Usage: bun github-release.ts <tag> <release|beta|alpha|rc|tag>",
   );
-  latest = !hasStable;
-  prerelease = hasStable;
+  process.exit(1);
+}
+
+const view = await $`gh release view ${tag}`.nothrow().quiet();
+if (view.exitCode === 0) {
+  console.log(`Release ${tag} already exists on GitHub, skipping`);
+  process.exit(0);
+}
+
+let prerelease: boolean;
+let latest: boolean;
+if (channel === "release") {
+  prerelease = false;
+  latest = true;
+} else if (channel === "tag") {
+  prerelease = true;
+  latest = false;
+} else {
+  const list = await $`gh release list --limit 500 --json tagName,isPrerelease`
+    .nothrow()
+    .quiet();
+  let hasStable = false;
+  if (list.exitCode === 0) {
+    const raw = list.stdout.toString().trim();
+    const releases = raw
+      ? (JSON.parse(raw) as Array<{ tagName: string; isPrerelease: boolean }>)
+      : [];
+    hasStable = releases.some((r) => isStableTag(r.tagName) && !r.isPrerelease);
+  }
+  if (hasStable) {
+    prerelease = true;
+    latest = false;
+  } else {
+    prerelease = false;
+    latest = true;
+    console.log(
+      "No true-stable release exists; publishing this prerelease with prerelease=false so it can be marked latest.",
+    );
+  }
 }
 
 if (latest) {
-  const result = await $`gh release view --latest --json tagName,isPrerelease`
+  const cur = await $`gh release view --latest --json tagName,isPrerelease`
     .nothrow()
     .quiet();
-  const current =
-    result.exitCode === 0 ? JSON.parse(result.stdout.toString()) : undefined;
-  if (
-    current &&
-    current.tagName !== tag &&
-    !/^v?\d+\.\d+\.\d+$/.test(current.tagName) &&
-    !current.isPrerelease
-  ) {
-    await $`gh release edit ${current.tagName} --prerelease=true --latest=false`;
+  if (cur.exitCode === 0) {
+    const raw = cur.stdout.toString().trim();
+    if (raw) {
+      const current = JSON.parse(raw) as {
+        tagName: string;
+        isPrerelease: boolean;
+      };
+      if (
+        current.tagName !== tag &&
+        !isStableTag(current.tagName) &&
+        !current.isPrerelease
+      ) {
+        console.log(
+          `Demoting previous masquerading latest ${current.tagName}: prerelease=false → true`,
+        );
+        await $`gh release edit ${current.tagName} --prerelease=true --latest=false`;
+      }
+    }
   }
 }
+
+const prev = await $`git describe --tags --abbrev=0 ${`${tag}^`}`
+  .nothrow()
+  .quiet();
+const from = prev.exitCode === 0 ? prev.stdout.toString().trim() : undefined;
+
+console.log(
+  `Generating release notes for ${tag}${from ? ` from ${from}` : ""}`,
+);
+const { md } = await generate({
+  from,
+  to: tag,
+  emoji: true,
+  contributors: true,
+  repo: repo(),
+});
 
 const args = [
   "release",
   "create",
   tag,
-  "--verify-tag",
-  "--generate-notes",
   "--title",
   tag,
-  `--latest=${latest}`,
+  "--notes",
+  md,
+  `--latest=${latest ? "true" : "false"}`,
 ];
 if (prerelease) args.push("--prerelease");
+
 await $`gh ${args}`;

--- a/scripts/release/release-notes.ts
+++ b/scripts/release/release-notes.ts
@@ -1,0 +1,48 @@
+#!/usr/bin/env bun
+/**
+ * Prepend release notes for a tag to CHANGELOG.md. Idempotent: if the tag
+ * already appears as a heading in CHANGELOG.md, does nothing.
+ *
+ * Usage: bun release-notes.ts v2.0.0-beta.13
+ *
+ * Reads ALCHEMY_REPO for the GitHub repo to query commits/authors from.
+ */
+import { $ } from "bun";
+import { generate } from "./changelog.ts";
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { repo } from "./config.ts";
+import { renderMarkdown } from "./render.ts";
+
+const tag = process.argv[2];
+if (!tag) {
+  console.error("Usage: bun release-notes.ts <tag>");
+  process.exit(1);
+}
+
+const changelogPath = join(process.cwd(), "CHANGELOG.md");
+const existing = await readFile(changelogPath, "utf-8").catch((e) => {
+  if ((e as NodeJS.ErrnoException).code === "ENOENT") return "";
+  throw e;
+});
+if (existing.includes(`## ${tag}\n`)) {
+  console.log(`${tag} already in CHANGELOG.md, skipping`);
+  process.exit(0);
+}
+
+const tagExists =
+  (await $`git rev-parse --verify ${`refs/tags/${tag}`}`.nothrow().quiet())
+    .exitCode === 0;
+const toRev = tagExists ? tag : "HEAD";
+
+console.log(`Generating release notes for ${tag} (using ${toRev})`);
+const { commits, config } = await generate({
+  to: toRev,
+  emoji: true,
+  contributors: true,
+  repo: repo(),
+});
+
+const md = renderMarkdown(commits, config);
+
+await writeFile(changelogPath, `## ${tag}\n\n${md}\n\n---\n\n${existing}`);

--- a/scripts/release/render.ts
+++ b/scripts/release/render.ts
@@ -1,0 +1,239 @@
+/**
+ * Custom markdown renderer for changelogithub-parsed commits.
+ *
+ * Mirrors the output of changelogithub's built-in generator but groups
+ * conventional-commit scopes hierarchically by splitting on `/`. For
+ * example commits like `fix(aws/lambda): ...`, `fix(aws/s3): ...` and
+ * `fix(aws): ...` render as nested categories under a shared `**aws**`
+ * top-level scope rather than as three unrelated flat groups.
+ *
+ * Line-level formatting (authors, PR/issue links, `<samp>` hash tags,
+ * `&nbsp;` spacing) is kept byte-compatible with changelogithub so output
+ * for single-segment scopes is identical to the upstream renderer.
+ */
+import type { ChangelogOptions, Commit } from "changelogithub";
+
+export type RenderConfig = Required<
+  Pick<
+    ChangelogOptions,
+    | "titles"
+    | "types"
+    | "capitalize"
+    | "emoji"
+    | "baseUrl"
+    | "repo"
+    | "from"
+    | "to"
+  >
+> & {
+  scopeMap?: Record<string, string>;
+};
+
+const emojisRE =
+  /([\u2700-\u27BF\uE000-\uF8FF\u2011-\u26FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|\uD83E[\uDD10-\uDDFF])/g;
+
+export function renderMarkdown(
+  commits: Commit[],
+  config: RenderConfig,
+): string {
+  const lines: string[] = [];
+  const [breaking, rest] = partition(commits, (c) => c.isBreaking);
+
+  if (config.titles?.breakingChanges) {
+    lines.push(
+      ...renderSection(breaking, config.titles.breakingChanges, config),
+    );
+  }
+
+  const byType = groupBy(rest, (c) => c.type);
+  for (const type of Object.keys(config.types)) {
+    const items = byType[type] || [];
+    lines.push(...renderSection(items, config.types[type].title, config));
+  }
+
+  if (!lines.length) lines.push("*No significant changes*");
+
+  const url = `https://${config.baseUrl}/${config.repo}/compare/${config.from}...${config.to}`;
+  lines.push(
+    "",
+    `##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](${url})`,
+  );
+
+  return lines.join("\n").trim();
+}
+
+interface Node {
+  commits: Commit[];
+  children: Record<string, Node>;
+}
+
+function makeNode(): Node {
+  return { commits: [], children: {} };
+}
+
+function renderSection(
+  commits: Commit[],
+  sectionName: string,
+  config: RenderConfig,
+): string[] {
+  if (!commits.length) return [];
+  const out: string[] = ["", formatTitle(sectionName, config), ""];
+
+  // Build a tree keyed by the `/`-separated scope segments. Commits attach
+  // to the deepest node that matches their scope exactly.
+  const root = makeNode();
+  for (const commit of commits) {
+    const scope = (commit.scope ?? "").trim();
+    const mapped = config.scopeMap?.[scope] ?? scope;
+    const segments = mapped
+      ? mapped
+          .split("/")
+          .map((s) => s.trim())
+          .filter(Boolean)
+      : [];
+    let node = root;
+    for (const seg of segments) {
+      node.children[seg] ??= makeNode();
+      node = node.children[seg];
+    }
+    node.commits.push(commit);
+  }
+
+  out.push(...renderNode(root, 0, config));
+  return out;
+}
+
+function renderNode(node: Node, depth: number, config: RenderConfig): string[] {
+  const lines: string[] = [];
+  const pad = "  ".repeat(depth);
+
+  // Reverse to match changelogithub's ordering: commits come out of git log
+  // newest-first, and the upstream renderer flips them so the oldest entry
+  // in the range appears at the top of each bucket.
+  for (const commit of [...node.commits].reverse()) {
+    lines.push(`${pad}- ${formatLine(commit, config)}`);
+  }
+
+  const childNames = Object.keys(node.children).sort();
+
+  // Match changelogithub's `group: true` default: within a given level, if
+  // ANY sibling scope has more than a single inline-able commit (either
+  // multiple commits or further sub-scopes), force every sibling to render
+  // with a header. This keeps visual alignment consistent and is what the
+  // existing CHANGELOG.md entries already use, so it avoids regressing
+  // historical release-notes style.
+  const forceHeaders = childNames.some((name) => {
+    const child = node.children[name];
+    return countCommits(child) > 1 || Object.keys(child.children).length > 0;
+  });
+
+  for (const name of childNames) {
+    const child = node.children[name];
+    const label = `**${name}**`;
+
+    const childCommitCount = countCommits(child);
+    const hasGrandchildren = Object.keys(child.children).length > 0;
+
+    // Collapse inline only when NO sibling wants a header and this child is
+    // a single-commit leaf. Otherwise emit the header + nested bullets.
+    if (!forceHeaders && childCommitCount === 1 && !hasGrandchildren) {
+      const [commit] = child.commits;
+      lines.push(`${pad}- ${label}: ${formatLine(commit, config)}`);
+      continue;
+    }
+
+    lines.push(`${pad}- ${label}:`);
+    lines.push(...renderNode(child, depth + 1, config));
+  }
+
+  return lines;
+}
+
+function countCommits(node: Node): number {
+  let n = node.commits.length;
+  for (const child of Object.values(node.children)) n += countCommits(child);
+  return n;
+}
+
+function formatTitle(name: string, config: RenderConfig): string {
+  if (!config.emoji) name = name.replace(emojisRE, "");
+  return `### &nbsp;&nbsp;&nbsp;${name.trim()}`;
+}
+
+function formatLine(commit: Commit, config: RenderConfig): string {
+  const prRefs = formatReferences(commit.references, config, "issues");
+  const hashRefs = formatReferences(commit.references, config, "hash");
+  const authorNames = [
+    ...new Set(
+      (commit.resolvedAuthors ?? []).map((a) =>
+        a.login ? `@${a.login}` : `**${a.name}**`,
+      ),
+    ),
+  ];
+  const authors = joinWithAnd(authorNames).trim();
+  const authorStr = authors ? `by ${authors}` : "";
+  let refs = [authorStr, prRefs, hashRefs]
+    .filter((s) => s && s.trim())
+    .join(" ");
+  if (refs) refs = `&nbsp;-&nbsp; ${refs}`;
+  const description = config.capitalize
+    ? capitalize(commit.description)
+    : commit.description;
+  return [description, refs].filter((s) => s && s.trim()).join(" ");
+}
+
+function formatReferences(
+  references: Commit["references"],
+  config: RenderConfig,
+  kind: "issues" | "hash",
+): string {
+  const baseUrl = config.baseUrl;
+  const repo = config.repo;
+  const refs = references
+    .filter((r) =>
+      kind === "issues"
+        ? r.type === "issue" || r.type === "pull-request"
+        : r.type === "hash",
+    )
+    .map((ref) => {
+      if (!repo) return ref.value;
+      if (ref.type === "pull-request" || ref.type === "issue") {
+        return `https://${baseUrl}/${repo}/issues/${ref.value.slice(1)}`;
+      }
+      return `[<samp>(${ref.value.slice(0, 5)})</samp>](https://${baseUrl}/${repo}/commit/${ref.value})`;
+    });
+  const joined = joinWithAnd(refs).trim();
+  if (kind === "issues") return joined ? `in ${joined}` : "";
+  return joined;
+}
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function joinWithAnd(
+  array: string[],
+  glue = ", ",
+  finalGlue = " and ",
+): string {
+  if (!array || array.length === 0) return "";
+  if (array.length === 1) return array[0];
+  if (array.length === 2) return array.join(finalGlue);
+  return `${array.slice(0, -1).join(glue)}${finalGlue}${array.slice(-1)}`;
+}
+
+function partition<T>(items: T[], pred: (item: T) => boolean): [T[], T[]] {
+  const yes: T[] = [];
+  const no: T[] = [];
+  for (const item of items) (pred(item) ? yes : no).push(item);
+  return [yes, no];
+}
+
+function groupBy<T>(items: T[], key: (item: T) => string): Record<string, T[]> {
+  const out: Record<string, T[]> = {};
+  for (const item of items) {
+    const k = key(item);
+    (out[k] ??= []).push(item);
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

- restore the release scripts from the shared `alchemy-run/actions` workflow used before the pnpm migration
- generate and commit the established hierarchical `CHANGELOG.md` entry before tagging
- create GitHub releases with the restored channel-aware release generator
- post the generated changelog entry to Discord through `DISCORD_WEBHOOK_URL`
- adapt the restored scripts to the current Alchemy repository name, token environment, and formatter

## Validation

- `vp install --frozen-lockfile --ignore-scripts`
- `vpx oxfmt --check .github/workflows/release.yml scripts/release/{config.ts,changelog.ts,render.ts,release-notes.ts,discord-body.ts,discord-notify.ts,github-release.ts}`
- `vpx oxlint scripts/release/{config.ts,changelog.ts,render.ts,release-notes.ts,discord-body.ts,discord-notify.ts,github-release.ts}`
- local changelog-generation smoke test over 53 commits
- local extraction and Discord markdown conversion against `v2.0.0-beta.72`
- notifier no-webhook path exits cleanly

Distilled is intentionally excluded from this PR.