### PR TITLE
chore(ci): isolate website Astro caches

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -36,10 +36,10 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: website/node_modules/.astro
-          key: astro-${{ runner.os }}-${{ github.event.pull_request.number || 'main' }}-${{ github.sha }}
+          key: website-check-astro-${{ runner.os }}-${{ github.event.pull_request.number || 'main' }}-${{ github.sha }}
           restore-keys: |
-            astro-${{ runner.os }}-${{ github.event.pull_request.number || 'main' }}-
-            astro-${{ runner.os }}-main-
+            website-check-astro-${{ runner.os }}-${{ github.event.pull_request.number || 'main' }}-
+            website-check-astro-${{ runner.os }}-main-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -86,10 +86,10 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: website/node_modules/.astro
-          key: astro-${{ runner.os }}-${{ github.event.pull_request.number || 'main' }}-${{ github.sha }}
+          key: website-deploy-astro-${{ runner.os }}-${{ github.event.pull_request.number || 'main' }}-${{ github.sha }}
           restore-keys: |
-            astro-${{ runner.os }}-${{ github.event.pull_request.number || 'main' }}-
-            astro-${{ runner.os }}-main-
+            website-deploy-astro-${{ runner.os }}-${{ github.event.pull_request.number || 'main' }}-
+            website-deploy-astro-${{ runner.os }}-main-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary

- namespace the Website deploy Astro cache separately from the Check workflow
- keep each workflow’s PR/main restore chain within its own cache namespace

The two workflows previously published identical `astro-*` keys even though they can run different website builds, allowing one CI process to seed the other’s cache.

## Validation

- `git diff --check`
- parsed both workflow YAML files locally