### PR TITLE
feat(cli/nuke): --local mode to clear locally emulated resources

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "logs:otel": "doppler run -c dev --project alchemy-v2 -- bun alchemy logs ./stacks/otel.ts",
     "logs:otel:prod": "bun logs:otel --profile prod --stage prod",
     "nuke": "bash scripts/nuke.sh",
+    "nuke:local": "bash scripts/nuke-local.sh",
     "opencode": "OPENCODE_EXPERIMENTAL_OXFMT=true opencode",
     "prepare": "husky && effect-tsgo patch && bun build:cloudflare-packages",
     "publish:packages": "pnpm publish --recursive --filter './packages/*' --access public",

--- a/packages/alchemy/src/Cli/commands/nuke.ts
+++ b/packages/alchemy/src/Cli/commands/nuke.ts
@@ -9,6 +9,7 @@ import { Command, Flag } from "effect/unstable/cli";
 import picomatch from "picomatch";
 
 import type { ProviderService } from "../../Provider.ts";
+import type { ProviderMode } from "../../ProviderMode.ts";
 import * as Clank from "../../Util/Clank.ts";
 import type { ScopedPlanStatusSession } from "../Cli.ts";
 import { isNonInteractive } from "../selectCli.ts";
@@ -96,9 +97,27 @@ const retriesFlag = Flag.integer("retries").pipe(
   Flag.withDefault(10),
 );
 
+const localFlag = Flag.boolean("local").pipe(
+  Flag.withDescription(
+    "Enumerate and delete LOCAL (emulated) resources instead of real cloud " +
+      "ones — the floci-emulated AWS account and the Cloudflare local " +
+      "runtime that `alchemy dev` provisions into. Only providers with a " +
+      "local implementation participate, so nothing in the real cloud is " +
+      "touched.",
+  ),
+  Flag.withDefault(false),
+);
+
 interface DiscoveredProvider {
   id: string;
-  provider: ProviderService;
+  /**
+   * Builds the provider service to enumerate/delete with. For the default
+   * (live) mode this is the service already registered in context; with
+   * `--local` it is the dual registration's lazily-built local variant, so
+   * only the providers actually selected pay for constructing the local
+   * runtime they emulate against (the floci container, workerd, ...).
+   */
+  resolve: Effect.Effect<ProviderService>;
 }
 
 const isProviderCollection = (
@@ -120,9 +139,18 @@ const hasListAndDelete = (value: unknown): value is ProviderService =>
  * {@link ProviderCollectionService}; we also pick up any directly-registered
  * provider whose key looks like a resource type. Only providers exposing a
  * `list` method are returned — policies and bindings are skipped.
+ *
+ * With `mode: "local"` only providers registered via `ProviderLayer.dual`
+ * (the ones carrying {@link ProviderService.modes}) are returned, resolving
+ * to their local variant — an AWS resource emulated by floci, a Cloudflare
+ * resource emulated by the local runtime. Mode-agnostic providers are
+ * deliberately dropped: they have a single implementation that talks to the
+ * real cloud, so including them would make `--local` delete live
+ * infrastructure.
  */
 const discoverProviders = (
   context: Context.Context<never>,
+  mode: ProviderMode,
 ): DiscoveredProvider[] => {
   // Resources opted out of teardown (`nuke.singleton` settings whose delete
   // only resets, or `nuke.skip` resources that can never be deleted) would be
@@ -151,7 +179,12 @@ const discoverProviders = (
     }
   }
   return [...out.entries()]
-    .map(([id, provider]) => ({ id, provider }))
+    .flatMap(([id, provider]): DiscoveredProvider[] => {
+      if (mode === "live") return [{ id, resolve: Effect.succeed(provider) }];
+      // No `modes` => mode-agnostic (single, live implementation).
+      const local = provider.modes?.local;
+      return local ? [{ id, resolve: local }] : [];
+    })
     .sort((a, b) => a.id.localeCompare(b.id));
 };
 
@@ -357,6 +390,7 @@ const nukeCommand = Command.make(
     include: includeFlag,
     exclude: excludeFlag,
     filter: filterFlag,
+    local: localFlag,
   },
   instrumentCommand("unsafe.nuke", (a: { profile: string; main: string }) => ({
     "alchemy.profile": a.profile,
@@ -376,6 +410,7 @@ const nukeCommand = Command.make(
       include,
       exclude,
       filter,
+      local,
     }) {
       // DEBUG=1 routes provider logs to the console (instead of the
       // .alchemy/log/out file) at Debug level and disables the TUI so the
@@ -395,7 +430,11 @@ const nukeCommand = Command.make(
         extra: Layer.succeed(MinimumLogLevel, debug ? "Debug" : "Info"),
       });
 
-      const discovered = discoverProviders(context as Context.Context<never>);
+      const mode: ProviderMode = local ? "local" : "live";
+      const discovered = discoverProviders(
+        context as Context.Context<never>,
+        mode,
+      );
 
       const matchInclude =
         include.length > 0 ? picomatch([...include]) : () => true;
@@ -405,8 +444,19 @@ const nukeCommand = Command.make(
         (p) => matchInclude(p.id) && !matchExclude(p.id),
       );
 
+      if (local) {
+        yield* Console.log(
+          `Local mode: ${selected.length} emulated provider(s). ` +
+            "Real cloud resources are never touched.",
+        );
+      }
+
       if (selected.length === 0) {
-        yield* Console.log("No providers match the given --include/--exclude.");
+        yield* Console.log(
+          local
+            ? "No local providers match the given --include/--exclude."
+            : "No providers match the given --include/--exclude.",
+        );
         return;
       }
 
@@ -427,11 +477,21 @@ const nukeCommand = Command.make(
         scanUI ? Effect.sync(() => scanUI.emit(event)) : Effect.void;
 
       const listed = yield* Effect.all(
-        selected.map(({ id, provider }) =>
+        selected.map(({ id, resolve }) =>
           Effect.gen(function* () {
             yield* emitScan({ kind: "start", id });
-            const attrs = yield* provider.list().pipe(
-              Effect.timeout(`${timeout} seconds`),
+            // Resolving is a no-op in live mode; in local mode it builds the
+            // provider's local variant (and, on first use, whatever runtime
+            // it emulates against). Both it and the listing are guarded, so
+            // a provider whose local runtime can't start is skipped with a
+            // logged warning instead of aborting the whole run.
+            const scanned = yield* Effect.gen(function* () {
+              const provider = yield* resolve;
+              const attrs = yield* provider
+                .list()
+                .pipe(Effect.timeout(`${timeout} seconds`));
+              return { provider, attrs };
+            }).pipe(
               // Log inside the provided scope so the failure lands in the
               // stack's file logger (.alchemy/log/out), then swallow it so a
               // single broken/slow provider doesn't abort the whole scan.
@@ -440,11 +500,11 @@ const nukeCommand = Command.make(
               ),
               Effect.provide(context),
               Effect.matchCause({
-                onSuccess: (attrs: unknown[]) => attrs,
-                onFailure: () => [] as unknown[],
+                onSuccess: (scanned) => scanned,
+                onFailure: () => undefined,
               }),
             );
-            const items = attrs.map((raw) => {
+            const items = (scanned?.attrs ?? []).map((raw) => {
               const attr = (raw ?? {}) as Record<string, unknown>;
               return {
                 attr,
@@ -457,7 +517,7 @@ const nukeCommand = Command.make(
               id,
               count: items.filter((i) => !i.spared).length,
             });
-            return { id, provider, items };
+            return { id, provider: scanned?.provider, items };
           }),
         ),
         { concurrency },
@@ -470,13 +530,17 @@ const nukeCommand = Command.make(
 
       // ---- Filter phase ------------------------------------------------
       const candidates = listed.flatMap(({ id, provider, items }) =>
-        items.map(({ attr, name, spared }) => ({
-          id,
-          provider,
-          attr,
-          name,
-          spared,
-        })),
+        // `provider` is only undefined when the scan failed, in which case
+        // `items` is empty and nothing is emitted.
+        provider === undefined
+          ? []
+          : items.map(({ attr, name, spared }) => ({
+              id,
+              provider,
+              attr,
+              name,
+              spared,
+            })),
       );
 
       const targets = candidates.filter((c) => !c.spared);
@@ -535,7 +599,8 @@ const nukeCommand = Command.make(
         ? true
         : yield* Clank.confirm({
             message:
-              `Permanently DELETE ${targets.length} resource(s)? ` +
+              `Permanently DELETE ${targets.length} ` +
+              `${local ? "locally emulated " : ""}resource(s)? ` +
               `This cannot be undone.`,
             initialValue: false,
           });
@@ -802,7 +867,9 @@ const nukeCommand = Command.make(
   Command.unlisted,
   Command.withDescription(
     "Enumerate every live resource across the stack's providers and delete " +
-      "them. DESTRUCTIVE — use --include/--exclude/--filter to scope it.",
+      "them. DESTRUCTIVE — use --include/--exclude/--filter to scope it. " +
+      "Pass --local to target locally emulated resources (floci, the " +
+      "Cloudflare local runtime) instead of the real cloud.",
   ),
 );
 

--- a/scripts/nuke-local.sh
+++ b/scripts/nuke-local.sh
@@ -1,0 +1,43 @@
+# Clears the floci local emulator: enumerates every LOCALLY EMULATED AWS
+# resource (`--local`) and deletes it. Only providers registered with both a
+# live and a local implementation participate, so the real cloud is never
+# touched and no cloud credentials are needed.
+#
+# `--include 'AWS.*'` keeps the run to floci. Drop it to also sweep the
+# Cloudflare local runtime (workerd instances alive in this process — always
+# empty from a fresh CLI invocation, so it just costs a build).
+#
+# --- What is spared, and why -----------------------------------------------
+#
+# The emulator, like a real account, has always-present singletons. Deleting
+# them either fails or is a no-op that re-enumerates on the next run, so a
+# run would never converge to "nothing to delete":
+#
+#   AWS.ApiGateway.Account   account-level settings object; get-account always
+#                            answers, so it lists forever
+#   AwsDataCatalog           Athena's built-in catalog (delete is rejected)
+#   default                  the Scheduler schedule group, the RDS DB subnet
+#                            group, and friends — recreated by the emulator
+#
+# AWS.EC2.SecurityGroupRule is excluded because of a floci bug: deleting a
+# security group leaves its rules behind in DescribeSecurityGroupRules, and
+# those orphans can never be revoked (RevokeSecurityGroupIngress fails with
+# InvalidGroup.NotFound because the group is gone). They accumulate and make
+# every run report ~80 rules to delete that "succeed" and come straight back.
+# Deleting the group already removes the rules functionally; only the listing
+# is dirty. Reproduce with:
+#   aws --endpoint-url http://localhost:4566 ec2 describe-security-group-rules
+#
+# floci's own internals are spared for the same convergence reason:
+#   floci-*                    the emulator's internal buckets (Athena results, ...)
+#   awslambda-us-east-1-tasks  the emulator's Lambda task store
+bun alchemy unsafe nuke ./stacks/nuke.ts \
+  --local \
+  --include 'AWS.*' \
+  --exclude 'AWS.ApiGateway.Account' \
+  --exclude 'AWS.EC2.SecurityGroupRule' \
+  --concurrency 32 \
+  --timeout 60 \
+  --filter '["default", "AwsDataCatalog", "primary", "Default", "DefaultConfiguration"].includes(resource.LogicalId)' \
+  --filter 'resource.Type === "AWS.S3.Bucket" && (String(resource.bucketName).startsWith("floci-") || String(resource.bucketName) === "awslambda-us-east-1-tasks")' \
+  "$@"

--- a/website/src/content/docs/aws/local-development.mdx
+++ b/website/src/content/docs/aws/local-development.mdx
@@ -205,6 +205,18 @@ ALCHEMY_FLOCI_IMAGE=floci:dev alchemy dev   # use your own emulator build
 The default image is our patched release
 (`ghcr.io/alchemy-run/floci`).
 
+To wipe everything inside the emulator without recreating the
+container, point [`nuke`](/cli/nuke) at the local providers:
+
+```sh
+bun alchemy unsafe nuke --local --include 'AWS.*'
+```
+
+`--local` enumerates and deletes through each provider's local
+implementation, so it only ever sees emulated resources — no
+cloud credentials are involved and nothing in a real AWS account
+can be touched.
+
 ## Where next
 
 - [Local development](/environments/local-development) — the

--- a/website/src/content/docs/cli/nuke.mdx
+++ b/website/src/content/docs/cli/nuke.mdx
@@ -28,6 +28,19 @@ The state store is never read or written: enumeration is live cloud state only. 
 - Resources whose `delete` keeps failing — reported at the end of the run.
 - Anything owned by providers not registered in the stack file.
 
+## Local mode
+
+`--local` flips the command over to the **local** implementations of your providers — the floci-emulated AWS account and the Cloudflare local runtime that [`alchemy dev`](/cli/dev) provisions into — instead of the real cloud.
+
+```sh
+# clear everything floci is holding
+bun alchemy unsafe nuke --local --include 'AWS.*'
+```
+
+Only providers registered with both a live and a local implementation participate; mode-agnostic providers (a single implementation, which always talks to the real cloud) are dropped at discovery. That's what makes `--local` safe: there is no code path by which it reaches live infrastructure, and it needs no cloud credentials.
+
+Each selected provider's local variant is built lazily, as it is scanned, so `--include` also scopes which local runtimes get constructed. A local variant that fails to build is reported as a scan failure and contributes 0 resources, exactly like a failing `list`.
+
 ## Scoping the blast radius
 
 `--include` and `--exclude` take provider-ID globs (picomatch, e.g. `'Cloudflare.*'`), are repeatable, and `--exclude` is applied after `--include`.
@@ -72,6 +85,7 @@ Deletion runs in passes: each pass attempts every remaining resource, failures a
 | `--include <glob>`    | Glob of provider IDs to include (e.g. `'Cloudflare.*'` or `'Cloudflare.Worker'`). Repeatable; when omitted, every provider is included.                                |
 | `--exclude <glob>`    | Glob of provider IDs to exclude (applied after `--include`). Repeatable.                                                                                               |
 | `--filter <expr>`     | JavaScript expression evaluated with `resource` in scope. Any resource for which an expression is truthy is **spared**. Repeatable.                                    |
+| `--local`             | Enumerate and delete LOCAL (emulated) resources instead of real cloud ones. Only providers with a local implementation participate.                                    |
 
 ## Debugging
 
@@ -79,6 +93,7 @@ Deletion runs in passes: each pass attempts every remaining resource, failures a
 
 ## Where next
 
+- [AWS local development](/aws/local-development) — the floci emulator `--local` clears
 - [destroy](/cli/destroy) — the stack-scoped, state-driven teardown you usually want
 - [Inspecting State](/cli/inspecting-state) — clear the stale state entries nuke leaves behind
 - [State Store](/state-store) — why nuke bypasses it entirely


### PR DESCRIPTION
`nuke` can now target the **local** implementations of your providers — the floci-emulated AWS account, the Cloudflare local runtime — instead of the real cloud, so clearing floci is one command.

```sh
bun alchemy unsafe nuke --local --include 'AWS.*'
pnpm nuke:local   # the repo's floci sweep
```

Discovery resolves `ProviderLayer.dual`'s `modes.local` instead of the registered service:

```diff lang="typescript"
  return [...out.entries()]
-   .map(([id, provider]) => ({ id, provider }))
+   .flatMap(([id, provider]): DiscoveredProvider[] => {
+     if (mode === "live") return [{ id, resolve: Effect.succeed(provider) }];
+     // No `modes` => mode-agnostic (single, live implementation).
+     const local = provider.modes?.local;
+     return local ? [{ id, resolve: local }] : [];
+   })
    .sort((a, b) => a.id.localeCompare(b.id));
```

Mode-agnostic providers are dropped: a single implementation always talks to the real cloud, so including them would make `--local` delete live infrastructure. That leaves no code path from `--local` to live state, and the run needs no cloud credentials.

Local variants resolve lazily *inside* the scan, so `--include` also scopes which local runtimes get constructed (an AWS-only run never builds workerd), and a variant that fails to build is logged as a scan failure contributing 0 resources rather than aborting the run.

### `pnpm nuke:local`

`scripts/nuke-local.sh` sweeps floci and converges to `Nothing to delete` on the second run. Getting there needed two spares:

- **Emulator singletons** that always re-list — the ApiGateway account settings, Athena's `AwsDataCatalog`, the `default` scheduler group and RDS subnet group, floci's own buckets.
- **`AWS.EC2.SecurityGroupRule`**, because of a floci bug: deleting a security group leaves its rules in `DescribeSecurityGroupRules`, and those orphans can never be revoked —

  ```
  $ aws --endpoint-url http://localhost:4566 ec2 revoke-security-group-ingress \
      --group-id sg-79a62527ca0f9fda0 --security-group-rule-ids sgr-2d68e41ad76834b74
  An error occurred (InvalidGroup.NotFound) … The security group 'sg-79a62527ca0f9fda0' does not exist
  ```

  Real AWS cascades rules on `DeleteSecurityGroup`; floci doesn't, so they accumulate (29 rules against 1 surviving group locally) and every run reported ~80 rules "deleted" that came straight back. Deleting the group already removes them functionally — only the listing is dirty. Worth fixing upstream in floci.

### Verified against a live floci

- Full AWS local scan: 869 emulated resources enumerated in 3.5s, matching `curl localhost:4566` exactly
- Delete path: a throwaway bucket deleted while the other 8 were spared by `--filter`
- `pnpm nuke:local --yes` run to completion, then twice more → `0 resource(s) to delete` both times
- Runs with no `--profile` and no cloud credentials
