### PR TITLE
chore(turbo): cache generated package bin artifacts

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -15,6 +15,8 @@
         "**/dist/**",
         "lib/**",
         "**/lib/**",
+        "bin/**",
+        "**/bin/**",
         ".cache/**/*.tsbuildinfo",
         "**/.cache/**/*.tsbuildinfo"
       ]


### PR DESCRIPTION
## Summary

- include root and nested `bin/**` directories in Turbo build outputs
- ensure generated package CLI artifacts are restored on cache hits

## Context

The package preview workflow can hit the Turbo build cache before publishing. Without `bin/**` in the declared outputs, generated CLI files such as `bin/alchemy.js` and `bin/exec.js` are omitted from the restored package and therefore from the preview package.

## Verification

Verified through the PR package-preview workflow: the rebuilt preview contained the generated CLI files and deployed normally through `alchemy deploy`.