### PR TITLE
feat(hetzner/server): compose custom init scripts with the alchemy bootstrap

### DIFF
--- a/packages/alchemy/src/Hetzner/Server.ts
+++ b/packages/alchemy/src/Hetzner/Server.ts
@@ -140,7 +140,21 @@ export interface ServerProps {
    */
   placementGroup?: Ref<ServerPlacementGroup>;
   /**
-   * Cloud-Init user data (max 32 KiB). Applied only at create time.
+   * Cloud-init user data run on the Server's **first boot** — the place to
+   * install packages, write config files, or add users.
+   *
+   * Accepts a shell script (`#!/bin/bash …`), a `#cloud-config` document,
+   * or a bare shell snippet (a `#!/bin/bash` shebang is added for you).
+   * Alchemy combines it with its own bootstrap script (which preinstalls
+   * `bun` for `Hetzner.Service`) into a multipart cloud-init document, so
+   * both run — the bootstrap first. A document that already starts with a
+   * `Content-Type:` / `MIME-Version:` header is passed through untouched,
+   * taking over the whole payload including the bootstrap.
+   *
+   * Capped at 32 KiB (Hetzner's limit) after composition.
+   *
+   * Cloud-init only runs once, on first boot, so changing this replaces
+   * the Server.
    */
   userData?: string;
   /**
@@ -291,6 +305,35 @@ export type Server = Resource<
  * });
  * ```
  *
+ * ### Custom init script
+ * **Example:** Install packages on first boot
+ * ```typescript
+ * const server = yield* Hetzner.Server("web", {
+ *   serverType: "cpx12",
+ *   image: "ubuntu-24.04",
+ *   userData: `#!/bin/bash
+ * apt-get update
+ * DEBIAN_FRONTEND=noninteractive apt-get install -y nginx
+ * systemctl enable --now nginx`,
+ * });
+ * ```
+ *
+ * **Example:** cloud-config document
+ * ```typescript
+ * const server = yield* Hetzner.Server("web", {
+ *   serverType: "cpx12",
+ *   image: "ubuntu-24.04",
+ *   userData: `#cloud-config
+ * packages:
+ *   - nginx
+ *   - postgresql-client`,
+ * });
+ * ```
+ *
+ * `userData` is merged with Alchemy's own bootstrap script into a
+ * multipart cloud-init document, so both run. It is applied on first boot
+ * only — changing it replaces the Server.
+ *
  * @resource
  */
 export const Server = Resource<Server>("Hetzner.Server");
@@ -299,6 +342,18 @@ export class ServerNotResolved extends Data.TaggedError(
   "Hetzner.ServerNotResolved",
 )<{
   name: string;
+}> {}
+
+/**
+ * The composed cloud-init document (Alchemy's bootstrap plus the Server's
+ * `userData`) exceeds Hetzner's 32 KiB user-data limit.
+ */
+export class ServerUserDataTooLarge extends Data.TaggedError(
+  "Hetzner.ServerUserDataTooLarge",
+)<{
+  name: string;
+  bytes: number;
+  limit: number;
 }> {}
 
 type CloudServer = GetServerResponseServer | ListServersResponseServersItem;
@@ -402,6 +457,95 @@ if [ ! -x /root/.bun/bin/bun ]; then
   curl -fsSL https://bun.sh/install | bash || true
 fi
 `;
+
+/** Hetzner rejects user data larger than 32 KiB. */
+const MAX_USER_DATA_BYTES = 32 * 1024;
+
+const MIME_BOUNDARY = "==ALCHEMY==";
+
+/**
+ * Cloud-init dispatches on a document's first line. Anything unrecognized
+ * is treated as a shell script.
+ */
+const CLOUD_INIT_FORMATS: ReadonlyArray<readonly [string, string]> = [
+  ["#cloud-config", "text/cloud-config"],
+  ["#cloud-boothook", "text/cloud-boothook"],
+  ["#include", "text/x-include-url"],
+  ["#upstart-job", "text/upstart-job"],
+  ["#part-handler", "text/part-handler"],
+  ["#!", "text/x-shellscript"],
+];
+
+type UserDataPart = {
+  readonly contentType: string;
+  readonly body: string;
+};
+
+const classifyUserData = (doc: string): UserDataPart => {
+  const first = doc.split("\n", 1)[0]?.trim() ?? "";
+  for (const [prefix, contentType] of CLOUD_INIT_FORMATS) {
+    if (first.startsWith(prefix)) return { contentType, body: doc };
+  }
+  // A bare snippet (`apt-get install -y nginx`) is the common case —
+  // cloud-init needs a shebang before it will execute one.
+  return { contentType: "text/x-shellscript", body: `#!/bin/bash\n${doc}` };
+};
+
+/**
+ * Wrap the parts in a multipart cloud-init document. Parts are named
+ * `part-001`, `part-002`, … the way cloud-init names anonymous parts
+ * itself — scripts run in that (lexical) order, so the bootstrap goes
+ * first.
+ */
+const mimeMultipart = (parts: ReadonlyArray<UserDataPart>) =>
+  [
+    `Content-Type: multipart/mixed; boundary="${MIME_BOUNDARY}"`,
+    "MIME-Version: 1.0",
+    "",
+    ...parts.flatMap((part, index) => [
+      `--${MIME_BOUNDARY}`,
+      `Content-Type: ${part.contentType}; charset="utf-8"`,
+      "MIME-Version: 1.0",
+      `Content-Disposition: attachment; filename="part-${String(index + 1).padStart(3, "0")}"`,
+      "",
+      part.body.replace(/\n+$/, ""),
+    ]),
+    `--${MIME_BOUNDARY}--`,
+    "",
+  ].join("\n");
+
+/**
+ * Compose the cloud-init document sent at create: Alchemy's bootstrap
+ * script plus the caller's `userData`, if any.
+ */
+export const composeUserData = (userData: string | undefined): string => {
+  if (userData === undefined) return ALCHEMY_BOOTSTRAP;
+  const doc = userData.replace(/^\uFEFF/, "").replace(/^[\s\n]+/, "");
+  if (doc === "") return ALCHEMY_BOOTSTRAP;
+  // An explicit MIME document is passed through verbatim — the caller owns
+  // the whole payload, bootstrap included.
+  if (/^(content-type|mime-version):/i.test(doc)) return userData;
+  return mimeMultipart([
+    { contentType: "text/x-shellscript", body: ALCHEMY_BOOTSTRAP },
+    classifyUserData(doc),
+  ]);
+};
+
+const buildUserData = Effect.fn(function* (input: {
+  name: string;
+  userData: string | undefined;
+}) {
+  const doc = yield* Effect.sync(() => composeUserData(input.userData));
+  const bytes = yield* Effect.sync(() => Buffer.byteLength(doc, "utf8"));
+  if (bytes > MAX_USER_DATA_BYTES) {
+    return yield* new ServerUserDataTooLarge({
+      name: input.name,
+      bytes,
+      limit: MAX_USER_DATA_BYTES,
+    });
+  }
+  return doc;
+});
 
 const u32be = (n: number) => {
   const buf = Buffer.alloc(4);
@@ -761,9 +905,14 @@ export const ServerProvider = () =>
         );
       return items.map(toAttrs);
     }),
-    diff: Effect.fn(function* ({ news, output }) {
+    diff: Effect.fn(function* ({ news, olds, output }) {
       if (!isResolved(news)) return undefined;
       if (output !== undefined) {
+        // Cloud-init runs once, on first boot — a changed init script can
+        // only take effect on a freshly provisioned Server.
+        if (news.userData !== olds?.userData) {
+          return { action: "replace" } as const;
+        }
         const location = news.location ?? DEFAULT_LOCATION;
         if (!sameRef(location, output.location, output.locationId)) {
           return { action: "replace" } as const;
@@ -812,7 +961,7 @@ export const ServerProvider = () =>
       const placementGroupId = numericId(news.placementGroup, ["id"]);
       const startAfterCreate = news.startAfterCreate ?? true;
       const desiredProtection = news.deleteProtection ?? false;
-      const userData = news.userData ?? ALCHEMY_BOOTSTRAP;
+      const userData = yield* buildUserData({ name, userData: news.userData });
 
       // Observe by id then desired name only. Do not fall back to
       // ownership labels — a create-first replacement still has the old

--- a/packages/alchemy/src/Hetzner/Server.ts
+++ b/packages/alchemy/src/Hetzner/Server.ts
@@ -446,16 +446,28 @@ const createServerName = (
     );
   });
 
+/**
+ * Preinstall Bun so `Hetzner.Service`'s first deploy does not have to.
+ * Mirrors the SSH-side install in `./hosted.ts` — Ubuntu images ship curl
+ * but not unzip, and bun's installer needs both. Never fails the boot:
+ * `hosted.ts` installs Bun over SSH if this did not manage to.
+ */
 const ALCHEMY_BOOTSTRAP = `#!/bin/bash
 set -uo pipefail
 export HOME=/root
-command -v curl >/dev/null 2>&1 || {
-  apt-get update
+export BUN_INSTALL=/root/.bun
+export PATH="/root/.bun/bin:$PATH"
+if ! command -v curl >/dev/null 2>&1 || ! command -v unzip >/dev/null 2>&1; then
+  apt-get update || true
   DEBIAN_FRONTEND=noninteractive apt-get install -y curl unzip ca-certificates || true
-}
-if [ ! -x /root/.bun/bin/bun ]; then
-  curl -fsSL https://bun.sh/install | bash || true
 fi
+if [ ! -x /root/.bun/bin/bun ]; then
+  for attempt in 1 2 3; do
+    curl -fsSL https://bun.sh/install | bash && break
+    sleep 5
+  done
+fi
+exit 0
 `;
 
 /** Hetzner rejects user data larger than 32 KiB. */

--- a/packages/alchemy/test/Hetzner/Server.test.ts
+++ b/packages/alchemy/test/Hetzner/Server.test.ts
@@ -4,6 +4,7 @@ import * as Test from "@/Test/Alchemy";
 import { Services } from "@distilled.cloud/hetzner";
 import { expect } from "alchemy-test";
 import * as Effect from "effect/Effect";
+import * as Redacted from "effect/Redacted";
 import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
 
@@ -26,6 +27,41 @@ const waitUntilGone = (id: number) =>
       times: 10,
     }),
   );
+
+test(
+  "composes user data with the alchemy bootstrap",
+  Effect.gen(function* () {
+    // No user data: the bootstrap script is sent as-is.
+    const bootstrap = Hetzner.composeUserData(undefined);
+    expect(bootstrap.startsWith("#!/bin/bash")).toBe(true);
+    expect(bootstrap).toContain("/root/.bun/bin/bun");
+
+    // A cloud-config document becomes the second part of a multipart
+    // cloud-init document, behind the bootstrap script.
+    const composed = Hetzner.composeUserData(
+      ["#cloud-config", "packages:", "  - nginx"].join("\n"),
+    );
+    expect(
+      composed.startsWith('Content-Type: multipart/mixed; boundary="'),
+    ).toBe(true);
+    expect(composed).toContain("Content-Type: text/x-shellscript");
+    expect(composed).toContain("Content-Type: text/cloud-config");
+    expect(composed).toContain("  - nginx");
+    expect(composed.indexOf("/root/.bun/bin/bun")).toBeLessThan(
+      composed.indexOf("#cloud-config"),
+    );
+
+    // A shell script keeps its shebang; a bare snippet gets one.
+    expect(Hetzner.composeUserData("#!/bin/sh\nid")).toContain("#!/bin/sh\nid");
+    expect(Hetzner.composeUserData("apt-get install -y nginx")).toContain(
+      "#!/bin/bash\napt-get install -y nginx",
+    );
+
+    // A caller-supplied MIME document owns the whole payload.
+    const raw = 'Content-Type: multipart/mixed; boundary="x"\n\n--x--\n';
+    expect(Hetzner.composeUserData(raw)).toEqual(raw);
+  }),
+);
 
 test.provider.skipIf(!hasHetznerCreds)(
   "create, update, and delete a server",
@@ -181,4 +217,77 @@ test.provider.skipIf(!hasHetznerCreds)(
       expect(gone).toEqual("gone");
     }).pipe(logLevel),
   { timeout: 180_000 },
+);
+
+test.provider.skipIf(!hasHetznerCreds)(
+  "runs a custom init script alongside the alchemy bootstrap",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const server = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Hetzner.Server("InitWeb", {
+            serverType: "cpx12",
+            image: "ubuntu-24.04",
+            location: "nbg1",
+            userData: [
+              "#!/bin/bash",
+              "echo alchemy-init-ok > /etc/alchemy-init-marker",
+            ].join("\n"),
+          });
+        }),
+      );
+
+      expect(server.ipv4).toEqual(expect.any(String));
+      expect(server.privateKey).toBeDefined();
+      const host = server.ipv4 ?? "";
+      const privateKey =
+        server.privateKey === undefined
+          ? ""
+          : Redacted.value(server.privateKey);
+
+      // Both cloud-init parts must have run: the user script (marker file)
+      // and Alchemy's bootstrap (bun). Probed as one command — the box is
+      // still booting when the create action completes.
+      const probe = yield* Effect.gen(function* () {
+        const ssh = yield* Hetzner.openSshClient({ host, privateKey });
+        const { stdout } = yield* ssh.exec(
+          "cat /etc/alchemy-init-marker && test -x /root/.bun/bin/bun && echo bun-ok",
+        );
+        return stdout;
+      }).pipe(
+        Effect.scoped,
+        Effect.retry({ schedule: Schedule.spaced("5 seconds"), times: 30 }),
+      );
+
+      expect(probe).toContain("alchemy-init-ok");
+      expect(probe).toContain("bun-ok");
+
+      // Cloud-init only runs on first boot, so a changed script replaces.
+      const replaced = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Hetzner.Server("InitWeb", {
+            serverType: "cpx12",
+            image: "ubuntu-24.04",
+            location: "nbg1",
+            userData: [
+              "#!/bin/bash",
+              "echo alchemy-init-v2 > /etc/alchemy-init-marker",
+            ].join("\n"),
+          });
+        }),
+      );
+
+      expect(replaced.id).not.toEqual(server.id);
+
+      const oldGone = yield* waitUntilGone(server.id);
+      expect(oldGone).toEqual("gone");
+
+      yield* stack.destroy();
+
+      const gone = yield* waitUntilGone(replaced.id);
+      expect(gone).toEqual("gone");
+    }).pipe(logLevel),
+  { timeout: 300_000 },
 );

--- a/website/src/content/docs/hetzner/compute/servers.mdx
+++ b/website/src/content/docs/hetzner/compute/servers.mdx
@@ -82,7 +82,8 @@ the server's deploy key and the `root` user by default; pass
 
 ## Cloud-init
 
-`userData` runs at first boot (create-only, max 32 KiB):
+`userData` runs on the server's first boot — the place to install
+packages, write config files, or add users:
 
 ```typescript
 const server = yield* Hetzner.Server("box", {
@@ -95,12 +96,36 @@ packages:
 });
 ```
 
+A shell script works too, and so does a bare snippet — Alchemy adds the
+`#!/bin/bash` shebang cloud-init needs to execute one:
+
+```typescript
+const server = yield* Hetzner.Server("box", {
+  serverType: "cx22",
+  image: "ubuntu-24.04",
+  userData: `#!/bin/bash
+apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get install -y nginx
+systemctl enable --now nginx
+`,
+});
+```
+
+Alchemy has its own bootstrap script that pre-installs
+[Bun](https://bun.sh) for [Services](/hetzner/compute/services). Your
+`userData` does not replace it: the two are combined into a multipart
+cloud-init document and both run, Alchemy's first. To take over the
+whole payload, bootstrap included, pass a document that already starts
+with a `Content-Type:` header.
+
+The composed document is capped at 32 KiB (Hetzner's limit) — over that,
+the deploy fails with `Hetzner.ServerUserDataTooLarge`.
+
 :::caution
-When you omit `userData`, Alchemy installs its own bootstrap that
-pre-installs [Bun](https://bun.sh) for
-[Services](/hetzner/compute/services). Providing your own `userData`
-replaces that bootstrap — Services still work (the first deploy
-installs Bun over SSH), it's just slower.
+Cloud-init only runs once, on first boot, so **changing `userData`
+replaces the server**. Plan for it the way you would an `image` or
+`serverType` change: the new server is created, dependents are pointed
+at it, then the old one is deleted.
 :::
 
 ## Attach infrastructure


### PR DESCRIPTION
`Hetzner.Server`'s `userData` replaced Alchemy's bootstrap script rather than composing with it, so a custom init script silently dropped the Bun preinstall that `Hetzner.Service` depends on. Changing it afterwards was also a silent no-op — cloud-init only runs on first boot, and `diff` planned no replacement.

Both are now merged into a multipart cloud-init document, bootstrap first:

```ts
const server = yield* Hetzner.Server("web", {
  serverType: "cpx12",
  image: "ubuntu-24.04",
  userData: `#!/bin/bash
apt-get update
DEBIAN_FRONTEND=noninteractive apt-get install -y nginx
systemctl enable --now nginx`,
});
```

- Accepts a shell script, a `#cloud-config` document, `#include` / `#cloud-boothook` / `#part-handler`, or a bare snippet (a `#!/bin/bash` shebang is added so cloud-init will execute it).
- A document starting with `Content-Type:` / `MIME-Version:` passes through verbatim — the caller takes over the whole payload, bootstrap included.
- Over 32 KiB after composition fails with a typed `Hetzner.ServerUserDataTooLarge` instead of a Hetzner API rejection.

```diff
-    diff: Effect.fn(function* ({ news, output }) {
+    diff: Effect.fn(function* ({ news, olds, output }) {
       if (!isResolved(news)) return undefined;
       if (output !== undefined) {
+        // Cloud-init runs once, on first boot — a changed init script can
+        // only take effect on a freshly provisioned Server.
+        if (news.userData !== olds?.userData) {
+          return { action: "replace" } as const;
+        }
```

Matches how Terraform's `hcloud_server` treats `user_data`, and is the only way a new init script can actually take effect.

### Bootstrap fix

Running the new live test surfaced a pre-existing bug: the cloud-init bootstrap only installed packages when `curl` was missing, but Ubuntu images ship curl and *not* unzip — so bun's installer died with `error: unzip is required to install bun`. The preinstall has never worked; `hosted.ts` reinstalling bun over SSH masked it.

```diff
-command -v curl >/dev/null 2>&1 || {
-  apt-get update
-  DEBIAN_FRONTEND=noninteractive apt-get install -y curl unzip ca-certificates || true
-}
+if ! command -v curl >/dev/null 2>&1 || ! command -v unzip >/dev/null 2>&1; then
+  apt-get update || true
+  DEBIAN_FRONTEND=noninteractive apt-get install -y curl unzip ca-certificates || true
+fi
```

Now matches the SSH-side install in `hosted.ts` (both binaries checked, `BUN_INSTALL` set, retried, `exit 0` so a failed preinstall never dirties the boot).
