### PR TITLE
docs: add Fly.io and the emulated CloudFront edge to the beta.73 blog

### DIFF
--- a/packages/alchemy/src/Fly/App.ts
+++ b/packages/alchemy/src/Fly/App.ts
@@ -72,16 +72,15 @@ export type App = Resource<
  * A Fly.App is a global namespace in your account. It contains Machines,
  * Services, Secrets, IPs, and certificates.
  *
- * @resource
  * @see https://fly.io/docs/machines/api/apps-resource/
  *
- * @section Create an App
+ * ### Create an App
  * Alchemy generates a unique name unless you pass one. `url` is
  * `https://{appName}.fly.dev`. Nothing answers there until a
  * {@link Service} or {@link Machine} publishes a proxy service and the App
  * has an {@link IpAssignment}.
  *
- * @example Generated name
+ * **Example:** Generated name
  * ```typescript
  * const site = yield* Fly.App("Site");
  * ```
@@ -91,10 +90,10 @@ export type App = Resource<
  * reclaimable.
  * :::
  *
- * @section A stable hostname
+ * ### A stable hostname
  * Pass `name` when you need a stable `fly.dev` hostname.
  *
- * @example Explicit name
+ * **Example:** Explicit name
  * ```typescript
  * const site = yield* Fly.App("Site", {
  *   name: "my-site",
@@ -106,10 +105,10 @@ export type App = Resource<
  * old App first, then creates the new one.
  * :::
  *
- * @section Organization
+ * ### Organization
  * Org defaults to the current token. Pass `orgSlug` to pin it.
  *
- * @example Pin an org
+ * **Example:** Pin an org
  * ```typescript
  * const site = yield* Fly.App("Site", {
  *   name: "my-site",
@@ -121,10 +120,10 @@ export type App = Resource<
  * The App is created in the new org. The old App is deleted.
  * :::
  *
- * @section Subdomains
+ * ### Subdomains
  * `enableSubdomains: true` turns on `*.{appName}.fly.dev`.
  *
- * @example Enable subdomains
+ * **Example:** Enable subdomains
  * ```typescript
  * const site = yield* Fly.App("Site", {
  *   name: "my-site",
@@ -136,10 +135,10 @@ export type App = Resource<
  * Flipping `enableSubdomains` later is ignored.
  * :::
  *
- * @section Isolated network
+ * ### Isolated network
  * `network` is an optional 6PN name.
  *
- * @example Custom network
+ * **Example:** Custom network
  * ```typescript
  * const site = yield* Fly.App("Site", {
  *   name: "my-site",
@@ -151,18 +150,20 @@ export type App = Resource<
  * The App is recreated on the new network.
  * :::
  *
- * @section Module-scope declarations
+ * ### Module-scope declarations
  * Declare the App once. Pass it into every child. Resource-valued props
  * accept the resource or an Effect producing it. Do not unwrap it just
  * to pass it along.
  *
- * @example Module-scope App
+ * **Example:** Module-scope App
  * ```typescript
  * // src/app.ts
  * import * as Fly from "alchemy/Fly";
  *
  * export const Site = Fly.App("Site");
  * ```
+ *
+ * @resource
  */
 export const App = Resource<App>("Fly.App");
 

--- a/packages/alchemy/src/Fly/Bucket.ts
+++ b/packages/alchemy/src/Fly/Bucket.ts
@@ -139,21 +139,20 @@ export type Bucket = Resource<
  * A Fly.Bucket is Tigris S3-compatible object storage, billed through
  * Fly. It is an org-scoped GraphQL add-on (`AddOnType` `tigris`).
  *
- * @resource
  * @see https://fly.io/docs/tigris/
  *
- * @section Create a Bucket
+ * ### Create a Bucket
  * Alchemy generates a unique name unless you pass one.
  *
- * @example Generated name
+ * **Example:** Generated name
  * ```typescript
  * const data = yield* Fly.Bucket("Data");
  * ```
  *
- * @section A stable name
+ * ### A stable name
  * Pass `name` when you need a stable Tigris bucket name.
  *
- * @example Explicit name
+ * **Example:** Explicit name
  * ```typescript
  * const data = yield* Fly.Bucket("Data", {
  *   name: "my-bucket",
@@ -165,10 +164,10 @@ export type Bucket = Resource<
  * deletes the old one.
  * :::
  *
- * @section Organization
+ * ### Organization
  * Org defaults to the current token. Pass `orgSlug` to pin it.
  *
- * @example Pin an org
+ * **Example:** Pin an org
  * ```typescript
  * const data = yield* Fly.Bucket("Data", {
  *   orgSlug: "my-org",
@@ -179,22 +178,22 @@ export type Bucket = Resource<
  * The bucket is created in the new org. The old bucket is deleted.
  * :::
  *
- * @section Public access
+ * ### Public access
  * Buckets are private by default. `public: true` serves objects
  * without credentials.
  *
- * @example Public bucket
+ * **Example:** Public bucket
  * ```typescript
  * const assets = yield* Fly.Bucket("Assets", {
  *   public: true,
  * });
  * ```
  *
- * @section Custom domain
+ * ### Custom domain
  * `domainName` sets `website.domain_name` on the add-on. Point a
  * CNAME at `{name}.t3.tigrisbucket.io`.
  *
- * @example Custom domain
+ * **Example:** Custom domain
  * ```typescript
  * const assets = yield* Fly.Bucket("Assets", {
  *   public: true,
@@ -202,12 +201,12 @@ export type Bucket = Resource<
  * });
  * ```
  *
- * @section Put and get objects
+ * ### Put and get objects
  * Tigris speaks the S3 API. Bind {@link PutObject} / {@link GetObject}
  * (and the other S3 object ops) in Service init. Alchemy injects the
  * Tigris endpoint and credentials; you never read `AWS_*` yourself.
  *
- * @example Put an object from a Service
+ * **Example:** Put an object from a Service
  * ```typescript
  * import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
  *
@@ -233,10 +232,10 @@ export type Bucket = Resource<
  * ) {}
  * ```
  *
- * @section Fly.Secret
+ * ### Fly.Secret
  * You can also set each key yourself with {@link Secret}.
  *
- * @example Manual secrets
+ * **Example:** Manual secrets
  * ```typescript
  * yield* Fly.Secret("BucketName", {
  *   app: Site,
@@ -244,6 +243,8 @@ export type Bucket = Resource<
  *   value: Data.bucketName,
  * });
  * ```
+ *
+ * @resource
  */
 export const Bucket = Resource<Bucket>("Fly.Bucket");
 

--- a/packages/alchemy/src/Fly/Certificate.ts
+++ b/packages/alchemy/src/Fly/Certificate.ts
@@ -108,14 +108,13 @@ export type Certificate = Resource<
  * ports. Fly's proxy terminates TLS on 443 once the certificate is
  * `configured`.
  *
- * @resource
  * @see https://fly.io/docs/machines/api/certificates-resource/
  *
- * @section ACME certificates
+ * ### ACME certificates
  * Request Let's Encrypt for a hostname. The Service does not change.
  * Yield the certificate in the Stack. Point DNS at the App.
  *
- * @example Let's Encrypt
+ * **Example:** Let's Encrypt
  * ```typescript
  * export const Www = Fly.Certificate("Www", {
  *   app: Site,
@@ -132,7 +131,7 @@ export type Certificate = Resource<
  * The certificate is created on the new App or with the new issuer.
  * :::
  *
- * @section DNS
+ * ### DNS
  * Point an A record at a `shared_v4` {@link IpAssignment} and an AAAA
  * at `v6`. Plus whatever `dnsRequirements` lists for the ACME
  * challenge. Alchemy re-checks via `checkAppCertificate` while
@@ -141,7 +140,7 @@ export type Certificate = Resource<
  * Observed attrs include `status`, `configured`, `acmeRequested`,
  * `dnsRequirements`, and `validation`.
  *
- * @example Yield next to a Service
+ * **Example:** Yield next to a Service
  * ```typescript
  * export default Alchemy.Stack(
  *   "MyApp",
@@ -161,12 +160,12 @@ export type Certificate = Resource<
  * );
  * ```
  *
- * @section Custom certificates
+ * ### Custom certificates
  * `"custom"` uploads `fullchain` and `privateKey`. Wrap the key with
  * `Redacted.make` so it never logs. Never stored in attributes.
  * Updating the PEM re-uploads in place.
  *
- * @example Upload a PEM
+ * **Example:** Upload a PEM
  * ```typescript
  * export const Www = Fly.Certificate("Www", {
  *   app: Site,
@@ -176,6 +175,8 @@ export type Certificate = Resource<
  *   privateKey: Redacted.make(key),
  * });
  * ```
+ *
+ * @resource
  */
 export const Certificate = Resource<Certificate>("Fly.Certificate");
 

--- a/packages/alchemy/src/Fly/Checkpoint.ts
+++ b/packages/alchemy/src/Fly/Checkpoint.ts
@@ -49,21 +49,20 @@ export interface CheckpointClient {
 /**
  * Checkpoint and restore a {@link Sprite} filesystem.
  *
- * @binding
  *
- * @section Create a checkpoint
+ * ### Create a checkpoint
  * Bind the client in init. Provide {@link CheckpointHttp}.
  *
- * @example Create
+ * **Example:** Create
  * ```typescript
  * const checkpoint = yield* Fly.Checkpoint(Box);
  * yield* checkpoint.create({ comment: "before deploy" });
  * ```
  *
- * @section Restore
+ * ### Restore
  * Restore rewinds the filesystem. Running processes stop.
  *
- * @example Restore v1
+ * **Example:** Restore v1
  * ```typescript
  * yield* checkpoint.restore("v1");
  * ```
@@ -71,6 +70,8 @@ export interface CheckpointClient {
  * :::caution[Restore is destructive]
  * The Sprite disk goes back to that checkpoint. Later writes are gone.
  * :::
+ *
+ * @binding
  */
 export interface Checkpoint extends Binding.Service<
   Checkpoint,

--- a/packages/alchemy/src/Fly/CheckpointHttp.ts
+++ b/packages/alchemy/src/Fly/CheckpointHttp.ts
@@ -10,17 +10,18 @@ import { makeHttpSpriteBinding } from "./SpriteHttp.ts";
  * HTTP implementation of {@link Checkpoint}. Provide it on the
  * {@link Sprite}, {@link Service}, or Action Effect.
  *
- * @layer
- * @provides Fly.Checkpoint
  *
- * @section Provide the layer
- * @example On a Sprite
+ * ### Provide the layer
+ * **Example:** On a Sprite
  * ```typescript
  * Effect.gen(function* () {
  *   const checkpoint = yield* Fly.Checkpoint(Box);
  *   // ...
  * }).pipe(Effect.provide(Fly.CheckpointHttp))
  * ```
+ *
+ * @layer
+ * @provides Fly.Checkpoint
  */
 export const CheckpointHttp = Layer.effect(
   Checkpoint,

--- a/packages/alchemy/src/Fly/ConnectPostgres.ts
+++ b/packages/alchemy/src/Fly/ConnectPostgres.ts
@@ -13,7 +13,7 @@ import type { Postgres } from "./Postgres.ts";
  * `ConnectPostgres` is the Context tag, the type, and the callable —
  * `yield* Fly.ConnectPostgres(Db)`. Provide {@link ConnectPostgresHttp}.
  *
- * @example Bind Postgres in a Service
+ * **Example:** Bind Postgres in a Service
  * ```typescript
  * import * as Drizzle from "alchemy/Drizzle/Postgres";
  *

--- a/packages/alchemy/src/Fly/ConnectPostgresHttp.ts
+++ b/packages/alchemy/src/Fly/ConnectPostgresHttp.ts
@@ -69,17 +69,18 @@ const firstUrl = (
  * runtime the client reads `process.env` (`FLY_POSTGRES_*`, then
  * Fly's `DATABASE_URL` secret).
  *
- * @layer
- * @provides Fly.ConnectPostgres
  *
- * @section Provide the layer
- * @example On a Service
+ * ### Provide the layer
+ * **Example:** On a Service
  * ```typescript
  * Effect.gen(function* () {
  *   const conn = yield* Fly.ConnectPostgres(Db);
  *   const db = yield* Drizzle.Postgres(conn.connectionString);
  * }).pipe(Effect.provide(Fly.ConnectPostgresHttp))
  * ```
+ *
+ * @layer
+ * @provides Fly.ConnectPostgres
  */
 export const ConnectPostgresHttp = Layer.effect(
   ConnectPostgres,

--- a/packages/alchemy/src/Fly/Decrypt.ts
+++ b/packages/alchemy/src/Fly/Decrypt.ts
@@ -21,13 +21,12 @@ export interface DecryptResult {
  * Decrypt with a Fly {@link SecretKey}. The App and key name are fixed
  * by `Decrypt(key)`.
  *
- * @binding
  *
- * @section Decrypt a payload
+ * ### Decrypt a payload
  * Provide {@link DecryptHttp}. Plaintext comes back `Redacted`. Unwrap
  * with `Redacted.value` only where you need the raw bytes.
  *
- * @example Decrypt
+ * **Example:** Decrypt
  * ```typescript
  * import * as Redacted from "effect/Redacted";
  *
@@ -36,16 +35,18 @@ export interface DecryptResult {
  * const bytes = Redacted.value(plaintext);
  * ```
  *
- * @section Associated data
+ * ### Associated data
  * `associatedData` must match the bytes passed to {@link Encrypt}.
  *
- * @example AEAD
+ * **Example:** AEAD
  * ```typescript
  * const { plaintext } = yield* decrypt({
  *   ciphertext,
  *   associatedData: nonce,
  * });
  * ```
+ *
+ * @binding
  */
 export interface Decrypt extends Binding.Service<
   Decrypt,

--- a/packages/alchemy/src/Fly/DecryptHttp.ts
+++ b/packages/alchemy/src/Fly/DecryptHttp.ts
@@ -18,17 +18,18 @@ import {
  * HTTP implementation of {@link Decrypt}. Provide it on the
  * {@link Service} or Action Effect.
  *
- * @layer
- * @provides Fly.Decrypt
  *
- * @section Provide the layer
- * @example On a Service
+ * ### Provide the layer
+ * **Example:** On a Service
  * ```typescript
  * Effect.gen(function* () {
  *   const decrypt = yield* Fly.Decrypt(Box);
  *   // ...
  * }).pipe(Effect.provide(Fly.DecryptHttp))
  * ```
+ *
+ * @layer
+ * @provides Fly.Decrypt
  */
 export const DecryptHttp = Layer.effect(
   Decrypt,

--- a/packages/alchemy/src/Fly/DeleteObject.ts
+++ b/packages/alchemy/src/Fly/DeleteObject.ts
@@ -15,14 +15,15 @@ export interface DeleteObjectRequest extends Omit<
  * Bind this operation to a {@link Bucket} in Service init. Provide
  * {@link DeleteObjectHttp}.
  *
- * @binding
  *
- * @section Deleting Objects
- * @example Delete an Object
+ * ### Deleting Objects
+ * **Example:** Delete an Object
  * ```typescript
  * const deleteObject = yield* Fly.DeleteObject(Data);
  * yield* deleteObject({ Key: "hello.txt" });
  * ```
+ *
+ * @binding
  */
 export interface DeleteObject extends Binding.Service<
   DeleteObject,

--- a/packages/alchemy/src/Fly/Encrypt.ts
+++ b/packages/alchemy/src/Fly/Encrypt.ts
@@ -19,13 +19,12 @@ export interface EncryptResult {
  * Encrypt with a Fly {@link SecretKey} (`nacl_box`, `nacl_secretbox`,
  * `xaes256gcm`, …). The App and key name are fixed by `Encrypt(key)`.
  *
- * @binding
  *
- * @section Encrypt a payload
+ * ### Encrypt a payload
  * Provide {@link EncryptHttp} on the Action or Service Effect. Fly
  * crypto ops need a KMS token. Org API tokens are typed `Forbidden`.
  *
- * @example Encrypt
+ * **Example:** Encrypt
  * ```typescript
  * const encrypt = yield* Fly.Encrypt(Box);
  * const { ciphertext } = yield* encrypt({
@@ -33,17 +32,19 @@ export interface EncryptResult {
  * });
  * ```
  *
- * @section Associated data
+ * ### Associated data
  * `associatedData` is optional AEAD associated data. {@link Decrypt}
  * must pass the same bytes.
  *
- * @example AEAD
+ * **Example:** AEAD
  * ```typescript
  * const { ciphertext } = yield* encrypt({
  *   plaintext: bytes,
  *   associatedData: nonce,
  * });
  * ```
+ *
+ * @binding
  */
 export interface Encrypt extends Binding.Service<
   Encrypt,

--- a/packages/alchemy/src/Fly/EncryptHttp.ts
+++ b/packages/alchemy/src/Fly/EncryptHttp.ts
@@ -17,17 +17,18 @@ import {
  * HTTP implementation of {@link Encrypt}. Provide it on the
  * {@link Service} or Action Effect.
  *
- * @layer
- * @provides Fly.Encrypt
  *
- * @section Provide the layer
- * @example On a Service
+ * ### Provide the layer
+ * **Example:** On a Service
  * ```typescript
  * Effect.gen(function* () {
  *   const encrypt = yield* Fly.Encrypt(Box);
  *   // ...
  * }).pipe(Effect.provide(Fly.EncryptHttp))
  * ```
+ *
+ * @layer
+ * @provides Fly.Encrypt
  */
 export const EncryptHttp = Layer.effect(
   Encrypt,

--- a/packages/alchemy/src/Fly/Exec.ts
+++ b/packages/alchemy/src/Fly/Exec.ts
@@ -25,17 +25,18 @@ export interface ExecRequest {
 /**
  * Run a command on a {@link Sprite} via `POST /sprites/{name}/exec`.
  *
- * @binding
  *
- * @section Exec a command
+ * ### Exec a command
  * Bind the client in init. Provide {@link ExecHttp}. The Sprite name
  * is fixed by `Exec(box)`.
  *
- * @example List files
+ * **Example:** List files
  * ```typescript
  * const exec = yield* Fly.Exec(Box);
  * const result = yield* exec({ cmd: ["ls", "-la"] });
  * ```
+ *
+ * @binding
  */
 export interface Exec extends Binding.Service<
   Exec,

--- a/packages/alchemy/src/Fly/ExecHttp.ts
+++ b/packages/alchemy/src/Fly/ExecHttp.ts
@@ -10,17 +10,18 @@ import { makeHttpSpriteBinding } from "./SpriteHttp.ts";
  * HTTP implementation of {@link Exec}. Provide it on the
  * {@link Sprite}, {@link Service}, or Action Effect.
  *
- * @layer
- * @provides Fly.Exec
  *
- * @section Provide the layer
- * @example On a Sprite
+ * ### Provide the layer
+ * **Example:** On a Sprite
  * ```typescript
  * Effect.gen(function* () {
  *   const exec = yield* Fly.Exec(Box);
  *   // ...
  * }).pipe(Effect.provide(Fly.ExecHttp))
  * ```
+ *
+ * @layer
+ * @provides Fly.Exec
  */
 export const ExecHttp = Layer.effect(
   Exec,

--- a/packages/alchemy/src/Fly/GetObject.ts
+++ b/packages/alchemy/src/Fly/GetObject.ts
@@ -12,10 +12,9 @@ export interface GetObjectRequest extends Omit<S3.GetObjectRequest, "Bucket"> {}
  * Bind this operation to a {@link Bucket} in Service init. Provide
  * {@link GetObjectHttp}.
  *
- * @binding
  *
- * @section Reading Objects
- * @example Read an Object and Decode Its Body
+ * ### Reading Objects
+ * **Example:** Read an Object and Decode Its Body
  * ```typescript
  * const getObject = yield* Fly.GetObject(Data);
  *
@@ -25,6 +24,8 @@ export interface GetObjectRequest extends Omit<S3.GetObjectRequest, "Bucket"> {}
  *   ),
  * );
  * ```
+ *
+ * @binding
  */
 export interface GetObject extends Binding.Service<
   GetObject,

--- a/packages/alchemy/src/Fly/GetSecret.ts
+++ b/packages/alchemy/src/Fly/GetSecret.ts
@@ -11,16 +11,15 @@ import type { Secret } from "./Secret.ts";
  * Fetch one Fly.io App secret. The App and name are fixed by
  * `GetSecret(secret)`. Calls take no `app_name`.
  *
- * @binding
  *
- * @section Read a secret
+ * ### Read a secret
  * Bind the client in init. Call it from `fetch` or an Action body.
  * Provide {@link GetSecretHttp}.
  *
  * Fly only returns plaintext from a Machine in the same App. From a
  * deploy-time Action you get metadata (name, digest, timestamps).
  *
- * @example GetSecret
+ * **Example:** GetSecret
  * ```typescript
  * export default class Api extends Fly.Service<Api>()(
  *   "Api",
@@ -37,6 +36,8 @@ import type { Secret } from "./Secret.ts";
  *   }).pipe(Effect.provide(Fly.GetSecretHttp)),
  * ) {}
  * ```
+ *
+ * @binding
  */
 export interface GetSecret extends Binding.Service<
   GetSecret,

--- a/packages/alchemy/src/Fly/GetSecretHttp.ts
+++ b/packages/alchemy/src/Fly/GetSecretHttp.ts
@@ -12,17 +12,18 @@ import { makeHttpSecretBinding } from "./SecretHttp.ts";
  * HTTP implementation of {@link GetSecret}. Provide it on the
  * {@link Service} or Action Effect.
  *
- * @layer
- * @provides Fly.GetSecret
  *
- * @section Provide the layer
- * @example On a Service
+ * ### Provide the layer
+ * **Example:** On a Service
  * ```typescript
  * Effect.gen(function* () {
  *   const get = yield* Fly.GetSecret(ApiToken);
  *   // ...
  * }).pipe(Effect.provide(Fly.GetSecretHttp))
  * ```
+ *
+ * @layer
+ * @provides Fly.GetSecret
  */
 export const GetSecretHttp = Layer.effect(
   GetSecret,

--- a/packages/alchemy/src/Fly/HeadObject.ts
+++ b/packages/alchemy/src/Fly/HeadObject.ts
@@ -15,14 +15,15 @@ export interface HeadObjectRequest extends Omit<
  * Bind this operation to a {@link Bucket} in Service init. Provide
  * {@link HeadObjectHttp}.
  *
- * @binding
  *
- * @section Inspecting Objects
- * @example Check an Object's Metadata
+ * ### Inspecting Objects
+ * **Example:** Check an Object's Metadata
  * ```typescript
  * const headObject = yield* Fly.HeadObject(Data);
  * const head = yield* headObject({ Key: "hello.txt" });
  * ```
+ *
+ * @binding
  */
 export interface HeadObject extends Binding.Service<
   HeadObject,

--- a/packages/alchemy/src/Fly/IpAssignment.ts
+++ b/packages/alchemy/src/Fly/IpAssignment.ts
@@ -100,14 +100,13 @@ const IpAssignmentResource = Resource<IpAssignment>("Fly.IpAssignment");
  *
  * Identity is the allocated `ip`. There is no in-place update.
  *
- * @resource
  * @see https://fly.io/docs/networking/services/
  *
- * @section Shared IPv4
+ * ### Shared IPv4
  * `shared_v4` is a shared Anycast IPv4. It is free. This is what you
  * want for fly.dev over IPv4. Yield it next to the Service.
  *
- * @example Allocate shared_v4
+ * **Example:** Allocate shared_v4
  * ```typescript
  * export const PublicIp = Fly.IpAssignment("Shared", {
  *   app: Site,
@@ -119,10 +118,10 @@ const IpAssignmentResource = Resource<IpAssignment>("Fly.IpAssignment");
  * A new address is allocated. The old one is released.
  * :::
  *
- * @section Dedicated IPv6
+ * ### Dedicated IPv6
  * `v6` is a dedicated IPv6. It is free.
  *
- * @example Allocate v6
+ * **Example:** Allocate v6
  * ```typescript
  * export const V6 = Fly.IpAssignment("V6", {
  *   app: Site,
@@ -130,11 +129,11 @@ const IpAssignmentResource = Resource<IpAssignment>("Fly.IpAssignment");
  * });
  * ```
  *
- * @section Dedicated IPv4
+ * ### Dedicated IPv4
  * `v4` is a billed dedicated IPv4. It may 400 if the org has no
  * quota. Prefer `shared_v4` or `v6` in tests.
  *
- * @example Allocate v4
+ * **Example:** Allocate v4
  * ```typescript
  * export const Dedicated = Fly.IpAssignment("Dedicated", {
  *   app: Site,
@@ -142,11 +141,11 @@ const IpAssignmentResource = Resource<IpAssignment>("Fly.IpAssignment");
  * });
  * ```
  *
- * @section Region
+ * ### Region
  * `region` pins a dedicated address. Shared Anycast ignores it. See
  * [Regions](/fly/compute/regions) for the list of codes.
  *
- * @example Dedicated IPv4 in iad
+ * **Example:** Dedicated IPv4 in iad
  * ```typescript
  * export const Dedicated = Fly.IpAssignment("Dedicated", {
  *   app: Site,
@@ -159,11 +158,11 @@ const IpAssignmentResource = Resource<IpAssignment>("Fly.IpAssignment");
  * A new address is allocated in the new region.
  * :::
  *
- * @section Service name
+ * ### Service name
  * `serviceName` binds the address to a Fly proxy service. Changing it
  * replaces the assignment.
  *
- * @example Bind to a named service
+ * **Example:** Bind to a named service
  * ```typescript
  * export const PublicIp = Fly.IpAssignment("Shared", {
  *   app: Site,
@@ -176,10 +175,10 @@ const IpAssignmentResource = Resource<IpAssignment>("Fly.IpAssignment");
  * A new address is allocated bound to the new service.
  * :::
  *
- * @section Isolated network
+ * ### Isolated network
  * `network` is an optional 6PN name. Create-only.
  *
- * @example Custom network
+ * **Example:** Custom network
  * ```typescript
  * export const Private = Fly.IpAssignment("Private", {
  *   app: Site,
@@ -192,11 +191,11 @@ const IpAssignmentResource = Resource<IpAssignment>("Fly.IpAssignment");
  * A new address is allocated on the new network.
  * :::
  *
- * @section Organization
+ * ### Organization
  * `orgSlug` defaults to the current token's org. It is not a
  * replacement key.
  *
- * @example Pin an org
+ * **Example:** Pin an org
  * ```typescript
  * export const PublicIp = Fly.IpAssignment("Shared", {
  *   app: Site,
@@ -205,11 +204,11 @@ const IpAssignmentResource = Resource<IpAssignment>("Fly.IpAssignment");
  * });
  * ```
  *
- * @section Yield with a Service
+ * ### Yield with a Service
  * Allocate the address on the same App as the Service. `api.url` is
  * `https://{appName}.fly.dev`.
  *
- * @example Stack outputs
+ * **Example:** Stack outputs
  * ```typescript
  * export default Alchemy.Stack(
  *   "MyApp",
@@ -221,6 +220,8 @@ const IpAssignmentResource = Resource<IpAssignment>("Fly.IpAssignment");
  *   }),
  * );
  * ```
+ *
+ * @resource
  */
 export const IpAssignment: typeof IpAssignmentResource = Object.assign(
   (

--- a/packages/alchemy/src/Fly/ListObjectsV2.ts
+++ b/packages/alchemy/src/Fly/ListObjectsV2.ts
@@ -15,14 +15,15 @@ export interface ListObjectsV2Request extends Omit<
  * Bind this operation to a {@link Bucket} in Service init. Provide
  * {@link ListObjectsV2Http}.
  *
- * @binding
  *
- * @section Listing Objects
- * @example List Objects Under a Prefix
+ * ### Listing Objects
+ * **Example:** List Objects Under a Prefix
  * ```typescript
  * const listObjects = yield* Fly.ListObjectsV2(Data);
  * const result = yield* listObjects({ Prefix: "jobs/", MaxKeys: 100 });
  * ```
+ *
+ * @binding
  */
 export interface ListObjectsV2 extends Binding.Service<
   ListObjectsV2,

--- a/packages/alchemy/src/Fly/ListSecrets.ts
+++ b/packages/alchemy/src/Fly/ListSecrets.ts
@@ -11,9 +11,8 @@ import type { App } from "./App.ts";
  * List Fly.io App secrets. Scoped to an {@link App}. Fly's list API
  * is `GET /apps/{app}/secrets`, not a single Secret.
  *
- * @binding
  *
- * @section List this App
+ * ### List this App
  * The App is fixed by `ListSecrets(app)`. Calls take no `app_name`.
  * Provide {@link ListSecretsHttp}.
  *
@@ -21,20 +20,20 @@ import type { App } from "./App.ts";
  * From a deploy-time Action you get metadata (name, digest,
  * timestamps).
  *
- * @example ListSecrets
+ * **Example:** ListSecrets
  * ```typescript
  * const list = yield* Fly.ListSecrets(Site);
  * const { secrets } = yield* list();
  * ```
  *
- * @section List another App
+ * ### List another App
  * From an Action, the org `FLY_API_TOKEN` can list any App in the
  * org. `ListSecrets(other)` is how you reach across Apps.
  *
  * From a Machine, deploy tokens are per-App. Mixing Apps on one host
  * shares one `FLY_API_TOKEN` and is not supported.
  *
- * @example Cross-app from an Action
+ * **Example:** Cross-app from an Action
  * ```typescript
  * const Seed = Alchemy.Action(
  *   "Seed",
@@ -48,6 +47,8 @@ import type { App } from "./App.ts";
  *   }).pipe(Effect.provide(Fly.ListSecretsHttp)),
  * );
  * ```
+ *
+ * @binding
  */
 export interface ListSecrets extends Binding.Service<
   ListSecrets,

--- a/packages/alchemy/src/Fly/ListSecretsHttp.ts
+++ b/packages/alchemy/src/Fly/ListSecretsHttp.ts
@@ -10,17 +10,18 @@ import { makeHttpAppBinding } from "./SecretHttp.ts";
  * HTTP implementation of {@link ListSecrets}. Provide it on the
  * {@link Service} or Action Effect.
  *
- * @layer
- * @provides Fly.ListSecrets
  *
- * @section Provide the layer
- * @example On an Action
+ * ### Provide the layer
+ * **Example:** On an Action
  * ```typescript
  * Effect.gen(function* () {
  *   const list = yield* Fly.ListSecrets(Site);
  *   // ...
  * }).pipe(Effect.provide(Fly.ListSecretsHttp))
  * ```
+ *
+ * @layer
+ * @provides Fly.ListSecrets
  */
 export const ListSecretsHttp = Layer.effect(
   ListSecrets,

--- a/packages/alchemy/src/Fly/Machine.ts
+++ b/packages/alchemy/src/Fly/Machine.ts
@@ -259,14 +259,13 @@ export type Machine = Resource<
  * effectful, supports bindings, and scales with `count`. Alchemy builds
  * and pushes the image. Use `Fly.Machine` when you already have an image.
  *
- * @resource
  * @see https://fly.io/docs/machines/api/machines-resource/
  *
- * @section Prefer a Service
+ * ### Prefer a Service
  * Declare a {@link Service} when you own the program. Alchemy bundles
  * `main`, builds `linux/amd64`, and pushes to `registry.fly.io`.
  *
- * @example Effect HTTP service
+ * **Example:** Effect HTTP service
  * ```typescript
  * export default class Api extends Fly.Service<Api>()(
  *   "Api",
@@ -279,11 +278,11 @@ export type Machine = Resource<
  * ) {}
  * ```
  *
- * @section Launch a Machine
+ * ### Launch a Machine
  * The parent is an {@link App}. Pin a region and an image. Guest
  * defaults to shared-cpu 1× / 256 MB. `image` updates in place.
  *
- * @example Nginx
+ * **Example:** Nginx
  * ```typescript
  * const web = yield* Fly.Machine("Web", {
  *   app: Site,
@@ -296,11 +295,11 @@ export type Machine = Resource<
  * The new App gets a new Machine. The old one is deleted.
  * :::
  *
- * @section A stable name
+ * ### A stable name
  * Machine names are unique per App. Omit `name` and Alchemy generates
  * one from the stack, stage, and logical ID.
  *
- * @example Explicit name
+ * **Example:** Explicit name
  * ```typescript
  * const web = yield* Fly.Machine("Web", {
  *   app: Site,
@@ -315,11 +314,11 @@ export type Machine = Resource<
  * deletes the old one.
  * :::
  *
- * @section Region
+ * ### Region
  * Fly Machines live in a region. Default is `iad`. See
  * [Regions](/fly/compute/regions) for the list of codes.
  *
- * @example Pin a region
+ * **Example:** Pin a region
  * ```typescript
  * const web = yield* Fly.Machine("Web", {
  *   app: Site,
@@ -332,11 +331,11 @@ export type Machine = Resource<
  * The Machine is created in the new region. The old one is deleted.
  * :::
  *
- * @section Guest size
+ * ### Guest size
  * `guest` is CPU kind, CPU count, and memory. Default is shared-cpu,
  * 1 CPU, 256 MB. Guest updates in place.
  *
- * @example Shared CPU
+ * **Example:** Shared CPU
  * ```typescript
  * const web = yield* Fly.Machine("Web", {
  *   app: Site,
@@ -346,11 +345,11 @@ export type Machine = Resource<
  * });
  * ```
  *
- * @section GPU
+ * ### GPU
  * Set `gpuKind` and `gpus` on `guest` when the Machine should have a
  * GPU.
  *
- * @example GPU guest
+ * **Example:** GPU guest
  * ```typescript
  * const worker = yield* Fly.Machine("Worker", {
  *   app: Site,
@@ -366,11 +365,11 @@ export type Machine = Resource<
  * });
  * ```
  *
- * @section Environment variables
+ * ### Environment variables
  * `env` is merged onto the Machine. Fly also injects App
  * {@link Secret} values as env vars unless the Machine skips secrets.
  *
- * @example Set env
+ * **Example:** Set env
  * ```typescript
  * const worker = yield* Fly.Machine("Worker", {
  *   app: Site,
@@ -380,7 +379,7 @@ export type Machine = Resource<
  * });
  * ```
  *
- * @section Publish a proxy service
+ * ### Publish a proxy service
  * `services` publishes ports on Fly's proxy. `{app}.fly.dev` over IPv4
  * still needs an {@link IpAssignment} on the parent App. `url` is
  * `https://{appName}.fly.dev` when a proxy service is configured.
@@ -392,7 +391,7 @@ export type Machine = Resource<
  * Omit `services` (or pass `[]`) for a process that should not be
  * reachable from the internet.
  *
- * @example HTTP on port 80
+ * **Example:** HTTP on port 80
  * ```typescript
  * const web = yield* Fly.Machine("Web", {
  *   app: Site,
@@ -411,7 +410,7 @@ export type Machine = Resource<
  * });
  * ```
  *
- * @section Autostart and autostop
+ * ### Autostart and autostop
  * `autostart` starts the Machine when a request arrives. `autostop` is
  * `"off"`, `"stop"`, `"suspend"`, or a boolean. `minMachinesRunning`
  * keeps that many Machines up for the service.
@@ -419,7 +418,7 @@ export type Machine = Resource<
  * Autostop only stops Machines that already exist. It does not mint
  * new ones. Yield more Machine resources to size the pool.
  *
- * @example Stop when idle
+ * **Example:** Stop when idle
  * ```typescript
  * const web = yield* Fly.Machine("Web", {
  *   app: Site,
@@ -438,7 +437,7 @@ export type Machine = Resource<
  * });
  * ```
  *
- * @section Scale up
+ * ### Scale up
  * Each Machine resource is one VM. Yield another Machine to add
  * capacity. Fly's proxy load-balances published `services` across
  * them.
@@ -446,7 +445,7 @@ export type Machine = Resource<
  * A {@link Service} still scales with `count`. That is one program,
  * many Machines.
  *
- * @example Two Machines
+ * **Example:** Two Machines
  * ```typescript
  * const web1 = yield* Fly.Machine("Web1", {
  *   app: Site,
@@ -475,10 +474,10 @@ export type Machine = Resource<
  * });
  * ```
  *
- * @section Scale down
+ * ### Scale down
  * Remove a Machine from the stack. The next deploy deletes it.
  *
- * @example Drop Web2
+ * **Example:** Drop Web2
  * ```diff
  *   const web1 = yield* Fly.Machine("Web1", {
  *     app: Site,
@@ -493,7 +492,7 @@ export type Machine = Resource<
  * - });
  * ```
  *
- * @section Attach a disk
+ * ### Attach a disk
  * Pass disks as `mounts`. Alchemy creates a Volume in the Machine's
  * app and region. A Volume attaches to one Machine. There is no
  * standalone Volume resource.
@@ -503,7 +502,7 @@ export type Machine = Resource<
  * See {@link MountVolume} for the full disk spec. From a Service,
  * prefer `MountVolume` so the path is part of the binding graph.
  *
- * @example Mount `/data`
+ * **Example:** Mount `/data`
  * ```typescript
  * const box = yield* Fly.Machine("Box", {
  *   app: Site,
@@ -513,11 +512,11 @@ export type Machine = Resource<
  * });
  * ```
  *
- * @section Init
+ * ### Init
  * `init` overrides `cmd`, `entrypoint`, `exec`, swap, and TTY. Updates
  * in place.
  *
- * @example Custom command
+ * **Example:** Custom command
  * ```typescript
  * const box = yield* Fly.Machine("Box", {
  *   app: Site,
@@ -527,12 +526,12 @@ export type Machine = Resource<
  * });
  * ```
  *
- * @section Restart policy
+ * ### Restart policy
  * `restart.policy` is `"no"`, `"always"`, `"on-failure"`, or
  * `"spot-price"`. `maxRetries` applies when the policy is
  * `"on-failure"`. Updates in place.
  *
- * @example Always restart
+ * **Example:** Always restart
  * ```typescript
  * const worker = yield* Fly.Machine("Worker", {
  *   app: Site,
@@ -542,11 +541,11 @@ export type Machine = Resource<
  * });
  * ```
  *
- * @section Destroy on exit
+ * ### Destroy on exit
  * `autoDestroy: true` tears the Machine down when its main process
  * exits. Default is `false`.
  *
- * @example One-shot Machine
+ * **Example:** One-shot Machine
  * ```typescript
  * const job = yield* Fly.Machine("Job", {
  *   app: Site,
@@ -557,12 +556,12 @@ export type Machine = Resource<
  * });
  * ```
  *
- * @section Skip launch
+ * ### Skip launch
  * `skipLaunch: true` creates or updates the config without starting
  * the Machine. Default is `false`. Reconcile otherwise waits until
  * the Machine is `started`.
  *
- * @example Config only
+ * **Example:** Config only
  * ```typescript
  * const web = yield* Fly.Machine("Web", {
  *   app: Site,
@@ -572,13 +571,13 @@ export type Machine = Resource<
  * });
  * ```
  *
- * @section Metadata
+ * ### Metadata
  * User keys on `metadata` merge with Alchemy ownership keys
  * (`alchemy.stack`, `alchemy.stage`, `alchemy.id`, `alchemy.type`,
  * `alchemy.replica`). Those ownership keys are always written so
  * `list()` can find owned Machines. Fly Apps have no labels.
  *
- * @example User metadata
+ * **Example:** User metadata
  * ```typescript
  * const web = yield* Fly.Machine("Web", {
  *   app: Site,
@@ -588,12 +587,12 @@ export type Machine = Resource<
  * });
  * ```
  *
- * @section Secrets version
+ * ### Secrets version
  * `minSecretsVersion` waits until the Machine has seen at least that
  * App secrets version. Use it after rotating a {@link Secret} if the
  * process must start with the new value.
  *
- * @example Wait for secrets
+ * **Example:** Wait for secrets
  * ```typescript
  * const web = yield* Fly.Machine("Web", {
  *   app: Site,
@@ -602,6 +601,8 @@ export type Machine = Resource<
  *   minSecretsVersion: 2,
  * });
  * ```
+ *
+ * @resource
  */
 export const Machine = Resource<Machine>("Fly.Machine");
 

--- a/packages/alchemy/src/Fly/MountVolume.ts
+++ b/packages/alchemy/src/Fly/MountVolume.ts
@@ -119,9 +119,8 @@ export interface ServiceBinding {
  * There is no standalone Volume resource. From a {@link Machine}, pass
  * `mounts: [{ path, sizeGb }]` instead.
  *
- * @binding
  *
- * @section Mount into a Service
+ * ### Mount into a Service
  * Yield `MountVolume` inside init. App and region come from the
  * parent Service. Provide {@link MountVolumeLive}. At runtime you get
  * `disk.path`.
@@ -129,7 +128,7 @@ export interface ServiceBinding {
  * A Volume attaches to one Machine. `count: 3` creates three Volumes
  * in one name-group, one per replica.
  *
- * @example Bind a path
+ * **Example:** Bind a path
  * ```typescript
  * export default class Api extends Fly.Service<Api>()(
  *   "Api",
@@ -147,19 +146,19 @@ export interface ServiceBinding {
  * ) {}
  * ```
  *
- * @section Grow a disk
+ * ### Grow a disk
  * `sizeGb` can grow in place via `extendVolume`. Fly cannot shrink a
  * Volume. Minimum size is 1 GB.
  *
- * @example 10 GB
+ * **Example:** 10 GB
  * ```typescript
  * const disk = yield* Fly.MountVolume({ path: "/data", sizeGb: 10 });
  * ```
  *
- * @section Encryption
+ * ### Encryption
  * `encrypted` encrypts the Volume at rest.
  *
- * @example Encrypted
+ * **Example:** Encrypted
  * ```typescript
  * const disk = yield* Fly.MountVolume({
  *   path: "/data",
@@ -172,10 +171,10 @@ export interface ServiceBinding {
  * Flipping `encrypted` later is ignored.
  * :::
  *
- * @section Filesystem
+ * ### Filesystem
  * `fstype` is the filesystem (`ext4`, …).
  *
- * @example ext4
+ * **Example:** ext4
  * ```typescript
  * const disk = yield* Fly.MountVolume({
  *   path: "/data",
@@ -188,12 +187,12 @@ export interface ServiceBinding {
  * Flipping `fstype` later is ignored.
  * :::
  *
- * @section Scheduled snapshots
+ * ### Scheduled snapshots
  * Scheduled snapshots default on (`autoBackupEnabled`).
  * `snapshotRetention` is days and updates in place. An on-demand
  * snapshot is {@link VolumeSnapshot}.
  *
- * @example Retention
+ * **Example:** Retention
  * ```typescript
  * const disk = yield* Fly.MountVolume({
  *   path: "/data",
@@ -203,10 +202,10 @@ export interface ServiceBinding {
  * });
  * ```
  *
- * @section Restore from a snapshot
+ * ### Restore from a snapshot
  * `snapshotId` restores into a new disk.
  *
- * @example snapshotId
+ * **Example:** snapshotId
  * ```typescript
  * const disk = yield* Fly.MountVolume({
  *   path: "/data",
@@ -219,10 +218,10 @@ export interface ServiceBinding {
  * Changing `snapshotId` later is ignored.
  * :::
  *
- * @section Fork a volume
+ * ### Fork a volume
  * `sourceVolumeId` forks from an existing Volume.
  *
- * @example sourceVolumeId
+ * **Example:** sourceVolumeId
  * ```typescript
  * const disk = yield* Fly.MountVolume({
  *   path: "/data",
@@ -235,10 +234,10 @@ export interface ServiceBinding {
  * Changing `sourceVolumeId` later is ignored.
  * :::
  *
- * @section Unique zone
+ * ### Unique zone
  * `requireUniqueZone` asks Fly to land the Volume in a unique zone.
  *
- * @example Unique zone
+ * **Example:** Unique zone
  * ```typescript
  * const disk = yield* Fly.MountVolume({
  *   path: "/data",
@@ -251,11 +250,11 @@ export interface ServiceBinding {
  * Flipping `requireUniqueZone` later is ignored.
  * :::
  *
- * @section Volume name
+ * ### Volume name
  * `name` is the Fly volume-group name. If omitted, a unique name is
  * generated from the host's logical ID and `path`.
  *
- * @example Named group
+ * **Example:** Named group
  * ```typescript
  * const disk = yield* Fly.MountVolume({
  *   path: "/data",
@@ -263,6 +262,8 @@ export interface ServiceBinding {
  *   name: "api_data",
  * });
  * ```
+ *
+ * @binding
  */
 export interface MountVolume extends Binding.Service<
   MountVolume,

--- a/packages/alchemy/src/Fly/Postgres.ts
+++ b/packages/alchemy/src/Fly/Postgres.ts
@@ -160,14 +160,13 @@ export type Postgres = Resource<
  * A Fly.Postgres is a Managed Postgres (MPG) cluster. It is billed.
  * Do not wrap unmanaged `fly postgres`.
  *
- * @resource
  * @see https://fly.io/docs/mpg/create-and-connect/
  *
- * @section Create a cluster
+ * ### Create a cluster
  * `region` is required. Alchemy generates a unique name unless you
  * pass one. Omit `name` in tests and CI.
  *
- * @example Generated name
+ * **Example:** Generated name
  * ```typescript
  * const db = yield* Fly.Postgres("Db", {
  *   region: "iad",
@@ -178,11 +177,11 @@ export type Postgres = Resource<
  * Managed Postgres is billed. Basic is about $38 per month.
  * :::
  *
- * @section Plan
+ * ### Plan
  * `plan` is the hardware size: `basic`, `starter`, `launch`,
  * `scale`, `performance`. Default is `basic`.
  *
- * @example Starter
+ * **Example:** Starter
  * ```typescript
  * const db = yield* Fly.Postgres("Db", {
  *   region: "iad",
@@ -194,11 +193,11 @@ export type Postgres = Resource<
  * Changing `plan` later is ignored. Fly has no cluster update API.
  * :::
  *
- * @section Region
+ * ### Region
  * The cluster is regional. An {@link App} is global. Pass `region`
  * on the cluster, not on the App.
  *
- * @example Pin a region
+ * **Example:** Pin a region
  * ```typescript
  * const db = yield* Fly.Postgres("Db", {
  *   region: "lhr",
@@ -210,10 +209,10 @@ export type Postgres = Resource<
  * deleted. Data is not copied.
  * :::
  *
- * @section Volume size
+ * ### Volume size
  * `volumeSizeGb` is the initial disk. Fly defaults to 10 GB.
  *
- * @example 20 GB
+ * **Example:** 20 GB
  * ```typescript
  * const db = yield* Fly.Postgres("Db", {
  *   region: "iad",
@@ -225,10 +224,10 @@ export type Postgres = Resource<
  * Changing `volumeSizeGb` later is ignored.
  * :::
  *
- * @section PostGIS
+ * ### PostGIS
  * `postgis: true` enables PostGIS at create.
  *
- * @example Enable PostGIS
+ * **Example:** Enable PostGIS
  * ```typescript
  * const db = yield* Fly.Postgres("Db", {
  *   region: "iad",
@@ -240,12 +239,12 @@ export type Postgres = Resource<
  * Flipping `postgis` later is ignored.
  * :::
  *
- * @section Connect from a Service
+ * ### Connect from a Service
  * Yield `ConnectPostgres` inside init. Provide
  * {@link ConnectPostgresHttp}. Pass `conn.connectionString` to
  * `Drizzle.Postgres` or `SQL.Postgres`.
  *
- * @example Bind and query
+ * **Example:** Bind and query
  * ```typescript
  * import * as Drizzle from "alchemy/Drizzle/Postgres";
  * import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
@@ -266,11 +265,11 @@ export type Postgres = Resource<
  * ) {}
  * ```
  *
- * @section Migrations
+ * ### Migrations
  * Pass a directory, `{ dir, table? }`, or a `Drizzle.Schema` resource.
  * Alchemy applies pending files on deploy over the direct URI.
  *
- * @example Directory
+ * **Example:** Directory
  * ```typescript
  * const db = yield* Fly.Postgres("Db", {
  *   region: "iad",
@@ -278,7 +277,7 @@ export type Postgres = Resource<
  * });
  * ```
  *
- * @example Drizzle.Schema
+ * **Example:** Drizzle.Schema
  * ```typescript
  * const schema = yield* Drizzle.Schema("app-schema", {
  *   schema: "./src/schema.ts",
@@ -290,6 +289,8 @@ export type Postgres = Resource<
  *   migrations: schema,
  * });
  * ```
+ *
+ * @resource
  */
 export const Postgres = Resource<Postgres>("Fly.Postgres");
 

--- a/packages/alchemy/src/Fly/PutObject.ts
+++ b/packages/alchemy/src/Fly/PutObject.ts
@@ -13,10 +13,9 @@ export interface PutObjectRequest extends Omit<S3.PutObjectRequest, "Bucket"> {}
  * bucket name, endpoint, and credentials are injected automatically.
  * Provide {@link PutObjectHttp}.
  *
- * @binding
  *
- * @section Writing Objects
- * @example Put an Object
+ * ### Writing Objects
+ * **Example:** Put an Object
  * ```typescript
  * const putObject = yield* Fly.PutObject(Data);
  *
@@ -26,6 +25,8 @@ export interface PutObjectRequest extends Omit<S3.PutObjectRequest, "Bucket"> {}
  *   ContentType: "text/plain",
  * });
  * ```
+ *
+ * @binding
  */
 export interface PutObject extends Binding.Service<
   PutObject,

--- a/packages/alchemy/src/Fly/ReadRedis.ts
+++ b/packages/alchemy/src/Fly/ReadRedis.ts
@@ -9,14 +9,15 @@ import type { Redis, RedisCommandError, RedisUrlMissing } from "./Redis.ts";
  * `ReadRedis` is the Context tag, the type, and the callable —
  * `yield* Fly.ReadRedis(Cache)`. Provide {@link ReadRedisHttp}.
  *
- * @binding
  *
- * @section Read
- * @example Get a key
+ * ### Read
+ * **Example:** Get a key
  * ```typescript
  * const cache = yield* Fly.ReadRedis(Cache);
  * const value = yield* cache.get("marker");
  * ```
+ *
+ * @binding
  */
 export interface ReadRedis extends Binding.Service<
   ReadRedis,

--- a/packages/alchemy/src/Fly/ReadWriteRedis.ts
+++ b/packages/alchemy/src/Fly/ReadWriteRedis.ts
@@ -10,15 +10,16 @@ import type { WriteRedisClient } from "./WriteRedis.ts";
  * `ReadWriteRedis` is the Context tag, the type, and the callable —
  * `yield* Fly.ReadWriteRedis(Cache)`. Provide {@link ReadWriteRedisHttp}.
  *
- * @binding
  *
- * @section Read and write
- * @example Round-trip a key
+ * ### Read and write
+ * **Example:** Round-trip a key
  * ```typescript
  * const cache = yield* Fly.ReadWriteRedis(Cache);
  * yield* cache.set("marker", "hello");
  * const value = yield* cache.get("marker");
  * ```
+ *
+ * @binding
  */
 export interface ReadWriteRedis extends Binding.Service<
   ReadWriteRedis,

--- a/packages/alchemy/src/Fly/Redis.ts
+++ b/packages/alchemy/src/Fly/Redis.ts
@@ -120,15 +120,14 @@ export type Redis = Resource<
  * uses it internally. Redis is not reachable from CI — drive it over
  * HTTP.
  *
- * @resource
  * @see https://fly.io/docs/upstash/redis/
  *
- * @section Create Redis
+ * ### Create Redis
  * Alchemy generates a unique name unless you pass one. Default region is
  * `iad`. Default plan is the cheapest `addOnPlans` row (free or
  * pay-as-you-go).
  *
- * @example Generated name
+ * **Example:** Generated name
  * ```typescript
  * const cache = yield* Fly.Redis("Cache");
  * ```
@@ -138,10 +137,10 @@ export type Redis = Resource<
  * reclaimable.
  * :::
  *
- * @section A stable name
+ * ### A stable name
  * Pass `name` when you want a stable Upstash database name.
  *
- * @example Explicit name
+ * **Example:** Explicit name
  * ```typescript
  * const cache = yield* Fly.Redis("Cache", {
  *   name: "my-cache",
@@ -159,11 +158,11 @@ export type Redis = Resource<
  * because the name cannot exist twice.
  * :::
  *
- * @section Bind from a Service
+ * ### Bind from a Service
  * Yield {@link ReadWriteRedis} (or {@link ReadRedis} / {@link WriteRedis})
  * in Service init. Provide the matching `*Http` layer.
  *
- * @example Read and write
+ * **Example:** Read and write
  * ```typescript
  * import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
  *
@@ -185,20 +184,20 @@ export type Redis = Resource<
  * ) {}
  * ```
  *
- * @section Eviction
+ * ### Eviction
  * Enable eviction for cache workloads. Updated in place.
  *
- * @example Eviction
+ * **Example:** Eviction
  * ```typescript
  * const cache = yield* Fly.Redis("Cache", {
  *   eviction: true,
  * });
  * ```
  *
- * @section Read replicas
+ * ### Read replicas
  * `readRegions` are extra replica regions. Updated in place.
  *
- * @example Replica region
+ * **Example:** Replica region
  * ```typescript
  * const cache = yield* Fly.Redis("Cache", {
  *   primaryRegion: "iad",
@@ -206,11 +205,11 @@ export type Redis = Resource<
  * });
  * ```
  *
- * @section Plan
+ * ### Plan
  * Omit `plan` for the cheapest listed plan. Pass a plan id or display
  * name to pin one. Fixed plans are billed.
  *
- * @example Pin pay-as-you-go
+ * **Example:** Pin pay-as-you-go
  * ```typescript
  * const cache = yield* Fly.Redis("Cache", {
  *   plan: "Pay-as-you-go",
@@ -221,6 +220,8 @@ export type Redis = Resource<
  * Fixed plans are billed monthly. Prefer omitting `plan` unless you
  * need a specific size.
  * :::
+ *
+ * @resource
  */
 export const Redis = Resource<Redis>("Fly.Redis");
 

--- a/packages/alchemy/src/Fly/Secret.ts
+++ b/packages/alchemy/src/Fly/Secret.ts
@@ -80,14 +80,13 @@ const SecretResource = Resource<Secret>("Fly.Secret");
  * time, yield `Config.redacted` instead. Do not pass `env: { ... }` on
  * a Service.
  *
- * @resource
  * @see https://fly.io/docs/apps/secrets/
  *
- * @section Config.redacted on a Service
+ * ### Config.redacted on a Service
  * Most secrets in a Service come from your `.env`. Yield
  * `Config.redacted` in init. Alchemy binds the value onto the Machine.
  *
- * @example Bind from .env
+ * **Example:** Bind from .env
  * ```typescript
  * import * as Config from "effect/Config";
  * import * as Redacted from "effect/Redacted";
@@ -108,12 +107,12 @@ const SecretResource = Resource<Secret>("Fly.Secret");
  * ) {}
  * ```
  *
- * @section Create a Secret
+ * ### Create a Secret
  * Wrap the value with `Redacted.make` so it is never logged. The
  * plaintext is never stored in attributes. Omit `name` and Alchemy
  * generates an ownership-stamped name.
  *
- * @example Generated name
+ * **Example:** Generated name
  * ```typescript
  * const dbUrl = yield* Fly.Secret("DatabaseUrl", {
  *   app: Site,
@@ -125,11 +124,11 @@ const SecretResource = Resource<Secret>("Fly.Secret");
  * The value is created on the new App. The old name is deleted.
  * :::
  *
- * @section Env-var name
+ * ### Env-var name
  * `name` is the env-var Machines see. It is stored as-is
  * (case-sensitive).
  *
- * @example Explicit name
+ * **Example:** Explicit name
  * ```typescript
  * export const ApiToken = Fly.Secret("ApiToken", {
  *   app: Site,
@@ -143,10 +142,10 @@ const SecretResource = Resource<Secret>("Fly.Secret");
  * deletes the old one.
  * :::
  *
- * @section Rotate the value
+ * ### Rotate the value
  * Updating `value` is in place via `updateSecrets`.
  *
- * @example New value
+ * **Example:** New value
  * ```typescript
  * export const ApiToken = Fly.Secret("ApiToken", {
  *   app: Site,
@@ -155,35 +154,35 @@ const SecretResource = Resource<Secret>("Fly.Secret");
  * });
  * ```
  *
- * @section Get a secret at runtime
+ * ### Get a secret at runtime
  * {@link GetSecret} is bound to one Secret. Provide
  * {@link GetSecretHttp}. Fly only returns plaintext from a Machine in
  * the same App. From a deploy-time Action you get metadata (name,
  * digest, timestamps).
  *
- * @example GetSecret
+ * **Example:** GetSecret
  * ```typescript
  * const get = yield* Fly.GetSecret(ApiToken);
  * const got = yield* get();
  * ```
  *
- * @section List secrets
+ * ### List secrets
  * {@link ListSecrets} is bound to an {@link App}. From an Action, the
  * org token can list any App in the org. From a Machine, deploy tokens
  * are per-App. Mixing Apps on one Machine shares one `FLY_API_TOKEN`
  * and is not supported.
  *
- * @example ListSecrets
+ * **Example:** ListSecrets
  * ```typescript
  * const list = yield* Fly.ListSecrets(Site);
  * const { secrets } = yield* list();
  * ```
  *
- * @section Write secrets
+ * ### Write secrets
  * {@link WriteSecret} creates, updates, and deletes by name. Provide
  * {@link WriteSecretHttp} on the Action or Service Effect.
  *
- * @example Rotate from an Action
+ * **Example:** Rotate from an Action
  * ```typescript
  * const Seed = Alchemy.Action(
  *   "Seed",
@@ -196,6 +195,8 @@ const SecretResource = Resource<Secret>("Fly.Secret");
  *   }).pipe(Effect.provide(Fly.WriteSecretHttp)),
  * );
  * ```
+ *
+ * @resource
  */
 export const Secret: typeof SecretResource = Object.assign(
   (

--- a/packages/alchemy/src/Fly/SecretKey.ts
+++ b/packages/alchemy/src/Fly/SecretKey.ts
@@ -67,99 +67,6 @@ export type SecretKey = Resource<
   Providers
 >;
 
-/**
- * A Fly.SecretKey is an App KMS key, not an env secret. Generate a
- * random key or set raw material. Private bytes never appear in
- * attributes.
- *
- * Use it at runtime with {@link Encrypt}, {@link Decrypt}, {@link Sign},
- * and {@link Verify}. Generate, set, and delete stay on this resource.
- *
- * @resource
- * @see https://docs.machines.dev/secrets/Secretkeys_list
- *
- * @section Generate a key
- * Omit `value` and Fly generates a key via `generateSecretKey`. `type`
- * is Fly's key type (`nacl_sign`, `nacl_box`, `nacl_secretbox`,
- * `hs256`, `hs384`, `hs512`, `xaes256gcm`, `nacl_auth`, `es256`, …).
- *
- * @example Signing key
- * ```typescript
- * export const Signing = Fly.SecretKey("Signing", {
- *   app: Site,
- *   type: "nacl_sign",
- * });
- * ```
- *
- * :::caution[Changing `app`, `name`, or `type` replaces the key]
- * The new key is created. The old one is deleted. Ciphertext from the
- * old key will not decrypt.
- * :::
- *
- * @section Set raw material
- * Pass `value` as bytes. The key is created or updated with
- * `setSecretKey`. Never persisted in state.
- *
- * @example HS256
- * ```typescript
- * const hmac = yield* Fly.SecretKey("Hmac", {
- *   app: Site,
- *   type: "hs256",
- *   value: hmacBytes,
- * });
- * ```
- *
- * @section Encrypt
- * Bind {@link Encrypt} to a box/secretbox/AEAD key. Provide
- * {@link EncryptHttp}. Optional `associatedData` is AEAD associated
- * data.
- *
- * Fly crypto ops need a KMS token. Org API tokens are typed
- * `Forbidden`. Encrypt and sign from a {@link Service}, not a laptop
- * Action.
- *
- * @example Encrypt a payload
- * ```typescript
- * const encrypt = yield* Fly.Encrypt(Box);
- * const { ciphertext } = yield* encrypt({
- *   plaintext: new TextEncoder().encode("attack at dawn"),
- * });
- * ```
- *
- * @section Decrypt
- * Bind {@link Decrypt} to the same key. Plaintext comes back
- * `Redacted`. Unwrap with `Redacted.value`. `associatedData` must
- * match encryption. Provide {@link DecryptHttp}.
- *
- * @example Decrypt a payload
- * ```typescript
- * const decrypt = yield* Fly.Decrypt(Box);
- * const { plaintext } = yield* decrypt({ ciphertext });
- * const bytes = Redacted.value(plaintext);
- * ```
- *
- * @section Sign
- * Bind {@link Sign} to a signing key (`nacl_sign`, `hs256`, `es256`,
- * …). The private key never leaves Fly KMS. Provide {@link SignHttp}.
- *
- * @example Sign a payload
- * ```typescript
- * const sign = yield* Fly.Sign(Signing);
- * const { signature } = yield* sign({
- *   plaintext: new TextEncoder().encode("release-manifest-v1"),
- * });
- * ```
- *
- * @section Verify
- * Bind {@link Verify} to the same key. A bad signature is a typed
- * error from the Machines API. Provide {@link VerifyHttp}.
- *
- * @example Verify a signature
- * ```typescript
- * const verify = yield* Fly.Verify(Signing);
- * const { valid } = yield* verify({ plaintext, signature });
- * ```
- */
 const resolveSecretKeyProps = (
   props: SecretKeyProps | Effect.Effect<SecretKeyProps, never, Providers>,
 ): Effect.Effect<SecretKeyProps, never, Providers> =>
@@ -174,6 +81,100 @@ const resolveSecretKeyProps = (
 
 const SecretKeyResource = Resource<SecretKey>("Fly.SecretKey");
 
+/**
+ * A Fly.SecretKey is an App KMS key, not an env secret. Generate a
+ * random key or set raw material. Private bytes never appear in
+ * attributes.
+ *
+ * Use it at runtime with {@link Encrypt}, {@link Decrypt}, {@link Sign},
+ * and {@link Verify}. Generate, set, and delete stay on this resource.
+ *
+ * @see https://docs.machines.dev/secrets/Secretkeys_list
+ *
+ * ### Generate a key
+ * Omit `value` and Fly generates a key via `generateSecretKey`. `type`
+ * is Fly's key type (`nacl_sign`, `nacl_box`, `nacl_secretbox`,
+ * `hs256`, `hs384`, `hs512`, `xaes256gcm`, `nacl_auth`, `es256`, …).
+ *
+ * **Example:** Signing key
+ * ```typescript
+ * export const Signing = Fly.SecretKey("Signing", {
+ *   app: Site,
+ *   type: "nacl_sign",
+ * });
+ * ```
+ *
+ * :::caution[Changing `app`, `name`, or `type` replaces the key]
+ * The new key is created. The old one is deleted. Ciphertext from the
+ * old key will not decrypt.
+ * :::
+ *
+ * ### Set raw material
+ * Pass `value` as bytes. The key is created or updated with
+ * `setSecretKey`. Never persisted in state.
+ *
+ * **Example:** HS256
+ * ```typescript
+ * const hmac = yield* Fly.SecretKey("Hmac", {
+ *   app: Site,
+ *   type: "hs256",
+ *   value: hmacBytes,
+ * });
+ * ```
+ *
+ * ### Encrypt
+ * Bind {@link Encrypt} to a box/secretbox/AEAD key. Provide
+ * {@link EncryptHttp}. Optional `associatedData` is AEAD associated
+ * data.
+ *
+ * Fly crypto ops need a KMS token. Org API tokens are typed
+ * `Forbidden`. Encrypt and sign from a {@link Service}, not a laptop
+ * Action.
+ *
+ * **Example:** Encrypt a payload
+ * ```typescript
+ * const encrypt = yield* Fly.Encrypt(Box);
+ * const { ciphertext } = yield* encrypt({
+ *   plaintext: new TextEncoder().encode("attack at dawn"),
+ * });
+ * ```
+ *
+ * ### Decrypt
+ * Bind {@link Decrypt} to the same key. Plaintext comes back
+ * `Redacted`. Unwrap with `Redacted.value`. `associatedData` must
+ * match encryption. Provide {@link DecryptHttp}.
+ *
+ * **Example:** Decrypt a payload
+ * ```typescript
+ * const decrypt = yield* Fly.Decrypt(Box);
+ * const { plaintext } = yield* decrypt({ ciphertext });
+ * const bytes = Redacted.value(plaintext);
+ * ```
+ *
+ * ### Sign
+ * Bind {@link Sign} to a signing key (`nacl_sign`, `hs256`, `es256`,
+ * …). The private key never leaves Fly KMS. Provide {@link SignHttp}.
+ *
+ * **Example:** Sign a payload
+ * ```typescript
+ * const sign = yield* Fly.Sign(Signing);
+ * const { signature } = yield* sign({
+ *   plaintext: new TextEncoder().encode("release-manifest-v1"),
+ * });
+ * ```
+ *
+ * ### Verify
+ * Bind {@link Verify} to the same key. A bad signature is a typed
+ * error from the Machines API. Provide {@link VerifyHttp}.
+ *
+ * **Example:** Verify a signature
+ * ```typescript
+ * const verify = yield* Fly.Verify(Signing);
+ * const { valid } = yield* verify({ plaintext, signature });
+ * ```
+ *
+ * @resource
+ */
 export const SecretKey: typeof SecretKeyResource = Object.assign(
   (
     id: string,

--- a/packages/alchemy/src/Fly/Service.ts
+++ b/packages/alchemy/src/Fly/Service.ts
@@ -192,10 +192,9 @@ export type ServiceRuntimeContext = FlyHostRuntimeContext;
  * A Service is an Effect program running in a Fly.io Machine. Set
  * `count` to scale it up or down. Several Services share one {@link App}.
  *
- * @resource
  * @see https://fly.io/docs/machines/api/machines-resource/
  *
- * @section Declare a Service
+ * ### Declare a Service
  * A Service is a class. Props describe the Machine. The Effect is the
  * program that runs on it.
  *
@@ -205,7 +204,7 @@ export type ServiceRuntimeContext = FlyHostRuntimeContext;
  * Docker image (default `oven/bun:1`), and pushes it to
  * `registry.fly.io/{app}:{id}-{hash}`.
  *
- * @example Class + App + main
+ * **Example:** Class + App + main
  * ```typescript
  * // src/api.ts
  * import * as Fly from "alchemy/Fly";
@@ -225,11 +224,11 @@ export type ServiceRuntimeContext = FlyHostRuntimeContext;
  * The new App gets a new replica set. The old Machines are deleted.
  * :::
  *
- * @section Serve HTTP with fetch
+ * ### Serve HTTP with fetch
  * Return `fetch` from the init Effect to boot an HTTP server. Omit
  * `fetch` for a background service.
  *
- * @example Hello
+ * **Example:** Hello
  * ```typescript
  * export default class Api extends Fly.Service<Api>()(
  *   "Api",
@@ -242,11 +241,11 @@ export type ServiceRuntimeContext = FlyHostRuntimeContext;
  * ) {}
  * ```
  *
- * @section Pin a region
+ * ### Pin a region
  * Fly Machines live in a region. Default is `iad`. See
  * [Regions](/fly/compute/regions) for the list of codes.
  *
- * @example Region
+ * **Example:** Region
  * ```typescript
  * export default class Api extends Fly.Service<Api>()(
  *   "Api",
@@ -264,11 +263,11 @@ export type ServiceRuntimeContext = FlyHostRuntimeContext;
  * deleted.
  * :::
  *
- * @section Set the port
+ * ### Set the port
  * `port` is the port the process listens on inside the Machine.
  * Alchemy writes it to `PORT`. Default is `3000`.
  *
- * @example Port 3000
+ * **Example:** Port 3000
  * ```typescript
  * export default class Api extends Fly.Service<Api>()(
  *   "Api",
@@ -281,13 +280,13 @@ export type ServiceRuntimeContext = FlyHostRuntimeContext;
  * ) {}
  * ```
  *
- * @section The public URL
+ * ### The public URL
  * Yield the Service in the Stack. `api.url` is
  * `https://{appName}.fly.dev`. Alchemy does not create this hostname.
  * It is the parent {@link App}'s fly.dev name. The Service does not
  * get its own URL.
  *
- * @example Stack output
+ * **Example:** Stack output
  * ```typescript
  * export default Alchemy.Stack(
  *   "MyApp",
@@ -307,11 +306,11 @@ export type ServiceRuntimeContext = FlyHostRuntimeContext;
  * one public Service on an App. Use `services: []` for workers.
  * :::
  *
- * @section Fly's proxy is the load balancer
+ * ### Fly's proxy is the load balancer
  * There is no LoadBalancer resource. Fly runs an Anycast proxy at
  * the edge.
  *
- * @example Published ports
+ * **Example:** Published ports
  * ```typescript
  * export default class Api extends Fly.Service<Api>()(
  *   "Api",
@@ -331,12 +330,12 @@ export type ServiceRuntimeContext = FlyHostRuntimeContext;
  * TLS on 443, picks one started Machine that published this service,
  * and forwards to `port` where `fetch` runs.
  *
- * @section An address so it answers
+ * ### An address so it answers
  * `{app}.fly.dev` does not answer over IPv4 until the App has an
  * {@link IpAssignment}. Allocate a shared Anycast IPv4 on the same
  * App and yield it next to the Service.
  *
- * @example shared_v4
+ * **Example:** shared_v4
  * ```typescript
  * export const PublicIp = Fly.IpAssignment("Shared", {
  *   app: Site,
@@ -352,13 +351,13 @@ export type ServiceRuntimeContext = FlyHostRuntimeContext;
  * });
  * ```
  *
- * @section Scale with count
+ * ### Scale with count
  * `count` is how many Machines to keep running. Default is `1`. They
  * all publish the same proxy service, so they all sit behind
  * `{app}.fly.dev`. Fly's proxy picks one Machine per request. Each
  * replica gets its own Volume from every {@link MountVolume} binding.
  *
- * @example Three replicas
+ * **Example:** Three replicas
  * ```typescript
  * export default class Api extends Fly.Service<Api>()(
  *   "Api",
@@ -371,7 +370,7 @@ export type ServiceRuntimeContext = FlyHostRuntimeContext;
  * ) {}
  * ```
  *
- * @section Config
+ * ### Config
  * Yield `Config` in init. Alchemy reads the value from the env of
  * whoever deploys and writes it onto the Machine. Do not pass
  * `env: { ... }` on a Service.
@@ -383,7 +382,7 @@ export type ServiceRuntimeContext = FlyHostRuntimeContext;
  * For a secret Fly should own and inject into every Machine on the
  * App, use {@link Secret}.
  *
- * @example Config.redacted
+ * **Example:** Config.redacted
  * ```typescript
  * import * as Config from "effect/Config";
  * import * as Redacted from "effect/Redacted";
@@ -404,12 +403,12 @@ export type ServiceRuntimeContext = FlyHostRuntimeContext;
  * ) {}
  * ```
  *
- * @section Mount a disk
+ * ### Mount a disk
  * Bind {@link MountVolume} inside init. App and region come from the
  * Service. `count: 3` creates three Volumes, one per replica. Provide
  * {@link MountVolumeLive}.
  *
- * @example Per-replica disk
+ * **Example:** Per-replica disk
  * ```typescript
  * export default class Api extends Fly.Service<Api>()(
  *   "Api",
@@ -427,12 +426,12 @@ export type ServiceRuntimeContext = FlyHostRuntimeContext;
  * ) {}
  * ```
  *
- * @section Guest size
+ * ### Guest size
  * `guest` is CPU kind, CPU count, and memory. Default is shared-cpu,
  * 1 CPU, 256 MB. Set `gpuKind` and `gpus` for a GPU. Guest updates in
  * place.
  *
- * @example Bigger guest
+ * **Example:** Bigger guest
  * ```typescript
  * export default class Api extends Fly.Service<Api>()(
  *   "Api",
@@ -451,11 +450,11 @@ export type ServiceRuntimeContext = FlyHostRuntimeContext;
  * ) {}
  * ```
  *
- * @section A stable name
+ * ### A stable name
  * Machine names are unique per App. Omit `name` and Alchemy generates
  * one from the stack, stage, and logical ID.
  *
- * @example Explicit name
+ * **Example:** Explicit name
  * ```typescript
  * export default class Api extends Fly.Service<Api>()(
  *   "Api",
@@ -473,11 +472,11 @@ export type ServiceRuntimeContext = FlyHostRuntimeContext;
  * deletes the old replica set.
  * :::
  *
- * @section Named export
+ * ### Named export
  * `handler` is the named export to load from `main`. Default is
  * `"default"`.
  *
- * @example Custom handler
+ * **Example:** Custom handler
  * ```typescript
  * export default class Api extends Fly.Service<Api>()(
  *   "Api",
@@ -490,12 +489,12 @@ export type ServiceRuntimeContext = FlyHostRuntimeContext;
  * ) {}
  * ```
  *
- * @section Base image
+ * ### Base image
  * `image` is the generated Dockerfile's `FROM`. Default is
  * `oven/bun:1`. It must still run bun. A content-hash change of
  * `main` updates the Machine in place.
  *
- * @example Override FROM
+ * **Example:** Override FROM
  * ```typescript
  * export default class Api extends Fly.Service<Api>()(
  *   "Api",
@@ -513,12 +512,12 @@ export type ServiceRuntimeContext = FlyHostRuntimeContext;
  * ) {}
  * ```
  *
- * @section Custom proxy services
+ * ### Custom proxy services
  * `services` defaults to HTTP 80 + HTTPS 443 toward `port`. Pass a
  * custom list to change handlers or autostop. Pass `[]` so Fly does
  * not publish a proxy.
  *
- * @example Unpublished process
+ * **Example:** Unpublished process
  * ```typescript
  * export default class Worker extends Fly.Service<Worker>()(
  *   "Worker",
@@ -529,11 +528,11 @@ export type ServiceRuntimeContext = FlyHostRuntimeContext;
  * ) {}
  * ```
  *
- * @section Background services
+ * ### Background services
  * Omit `port` and `fetch`. Pass `services: []`. Use `ServerHost.run`
  * for a long-running loop. If the process exits, Fly restarts it.
  *
- * @example ServerHost.run
+ * **Example:** ServerHost.run
  * ```typescript
  * import { ServerHost } from "alchemy/Server";
  *
@@ -552,12 +551,12 @@ export type ServiceRuntimeContext = FlyHostRuntimeContext;
  * ) {}
  * ```
  *
- * @section Bundle config
+ * ### Bundle config
  * `build` is Rolldown `input` / `output` overrides plus
  * pure-annotation options. Use it when `main` needs extra entry
  * points or externals.
  *
- * @example Externals
+ * **Example:** Externals
  * ```typescript
  * export default class Api extends Fly.Service<Api>()(
  *   "Api",
@@ -575,7 +574,7 @@ export type ServiceRuntimeContext = FlyHostRuntimeContext;
  * ) {}
  * ```
  *
- * @example Install `pg` unbundled
+ * **Example:** Install `pg` unbundled
  * `pg` is CommonJS. Rolldown's interop turns `Client` into a namespace.
  * Install it into the image so `@effect/sql-pg` / `Drizzle.Postgres` load
  * it with Node's CJS semantics — same `build.install` as Lambda.
@@ -601,11 +600,11 @@ export type ServiceRuntimeContext = FlyHostRuntimeContext;
  * ) {}
  * ```
  *
- * @section Multiple Services, one App
+ * ### Multiple Services, one App
  * Each Service has its own Machines, image, and lifecycle. Point
  * several at the same `app`.
  *
- * @example API and worker
+ * **Example:** API and worker
  * ```typescript
  * class Api extends Fly.Service<Api>()(
  *   "Api",
@@ -625,6 +624,8 @@ export type ServiceRuntimeContext = FlyHostRuntimeContext;
  *   }),
  * ) {}
  * ```
+ *
+ * @resource
  */
 export const Service: Platform<
   Service,

--- a/packages/alchemy/src/Fly/Sign.ts
+++ b/packages/alchemy/src/Fly/Sign.ts
@@ -17,19 +17,20 @@ export interface SignResult {
  * Sign with a Fly {@link SecretKey} (`nacl_sign`, `hs256`, `es256`,
  * …). The private key never leaves Fly KMS.
  *
- * @binding
  *
- * @section Sign a payload
+ * ### Sign a payload
  * The App and key name are fixed by `Sign(key)`. Provide
  * {@link SignHttp} on the Action or Service Effect.
  *
- * @example Sign
+ * **Example:** Sign
  * ```typescript
  * const sign = yield* Fly.Sign(Signing);
  * const { signature } = yield* sign({
  *   plaintext: new TextEncoder().encode("release-manifest-v1"),
  * });
  * ```
+ *
+ * @binding
  */
 export interface Sign extends Binding.Service<
   Sign,

--- a/packages/alchemy/src/Fly/SignHttp.ts
+++ b/packages/alchemy/src/Fly/SignHttp.ts
@@ -17,17 +17,18 @@ import { Sign, type SignRequest } from "./Sign.ts";
  * HTTP implementation of {@link Sign}. Provide it on the
  * {@link Service} or Action Effect.
  *
- * @layer
- * @provides Fly.Sign
  *
- * @section Provide the layer
- * @example On a Service
+ * ### Provide the layer
+ * **Example:** On a Service
  * ```typescript
  * Effect.gen(function* () {
  *   const sign = yield* Fly.Sign(Signing);
  *   // ...
  * }).pipe(Effect.provide(Fly.SignHttp))
  * ```
+ *
+ * @layer
+ * @provides Fly.Sign
  */
 export const SignHttp = Layer.effect(
   Sign,

--- a/packages/alchemy/src/Fly/Sprite.ts
+++ b/packages/alchemy/src/Fly/Sprite.ts
@@ -142,10 +142,9 @@ export type SpriteRuntimeContext = FlyHostRuntimeContext;
  * on demand. There is no parent {@link App}. Unlike a {@link Service},
  * Alchemy does not build a Docker image.
  *
- * @resource
  * @see https://sprites.dev/api/sprites
  *
- * @section Declare a Sprite
+ * ### Declare a Sprite
  * A Sprite is a class. Props describe the sandbox. The Effect is the
  * program that runs on it. There is no parent App.
  *
@@ -153,7 +152,7 @@ export type SpriteRuntimeContext = FlyHostRuntimeContext;
  * this file with Rolldown, writes it onto the Sprite, and runs it as
  * a Sprite service on {@link port}. Auth is `FLY_API_TOKEN`.
  *
- * @example Class + main
+ * **Example:** Class + main
  * ```typescript
  * export default class Box extends Fly.Sprite<Box>()(
  *   "Box",
@@ -164,11 +163,11 @@ export type SpriteRuntimeContext = FlyHostRuntimeContext;
  * ) {}
  * ```
  *
- * @section Serve HTTP with fetch
+ * ### Serve HTTP with fetch
  * Return `fetch` from the init Effect to boot an HTTP server. The
  * Sprite URL proxies to {@link port}.
  *
- * @example Hello
+ * **Example:** Hello
  * ```typescript
  * export default class Box extends Fly.Sprite<Box>()(
  *   "Box",
@@ -181,11 +180,11 @@ export type SpriteRuntimeContext = FlyHostRuntimeContext;
  * ) {}
  * ```
  *
- * @section The public URL
+ * ### The public URL
  * Yield the Sprite in the Stack. `box.url` is
  * `https://{name}-….sprites.app`.
  *
- * @example Stack output
+ * **Example:** Stack output
  * ```typescript
  * export default Alchemy.Stack(
  *   "MyApp",
@@ -197,11 +196,11 @@ export type SpriteRuntimeContext = FlyHostRuntimeContext;
  * );
  * ```
  *
- * @section URL auth
+ * ### URL auth
  * `urlAuth` is `public` or `sprite`. Default is `public` so `url`
  * answers without a Sprites token.
  *
- * @example Sprite-auth URL
+ * **Example:** Sprite-auth URL
  * ```typescript
  * export default class Box extends Fly.Sprite<Box>()(
  *   "Box",
@@ -219,14 +218,14 @@ export type SpriteRuntimeContext = FlyHostRuntimeContext;
  * `fetch` handler is reachable.
  * :::
  *
- * @section Config
+ * ### Config
  * Yield `Config` in init. Alchemy reads the value from the env of
  * whoever deploys and writes it onto the Sprite. Do not pass
  * `env: { ... }` on a Sprite.
  *
  * Yield `FileSystem.FileSystem` in init, never inside `fetch`.
  *
- * @example Config.redacted
+ * **Example:** Config.redacted
  * ```typescript
  * import * as Config from "effect/Config";
  * import * as FileSystem from "effect/FileSystem";
@@ -250,20 +249,20 @@ export type SpriteRuntimeContext = FlyHostRuntimeContext;
  * ) {}
  * ```
  *
- * @section Exec
+ * ### Exec
  * {@link Exec} runs a command on the Sprite. Provide {@link ExecHttp}.
  *
- * @example ls
+ * **Example:** ls
  * ```typescript
  * const exec = yield* Fly.Exec(Box);
  * const result = yield* exec({ cmd: ["ls", "-la"] });
  * ```
  *
- * @section Checkpoint
+ * ### Checkpoint
  * {@link Checkpoint} snapshots and restores the Sprite disk. Provide
  * {@link CheckpointHttp}.
  *
- * @example Create and restore
+ * **Example:** Create and restore
  * ```typescript
  * const checkpoint = yield* Fly.Checkpoint(Box);
  * yield* checkpoint.create({ comment: "before" });
@@ -274,11 +273,11 @@ export type SpriteRuntimeContext = FlyHostRuntimeContext;
  * The disk rewinds. Later writes are gone.
  * :::
  *
- * @section A stable name
+ * ### A stable name
  * Omit `name` and Alchemy generates one from the stack, stage, and
  * logical ID.
  *
- * @example Explicit name
+ * **Example:** Explicit name
  * ```typescript
  * export default class Box extends Fly.Sprite<Box>()(
  *   "Box",
@@ -296,11 +295,11 @@ export type SpriteRuntimeContext = FlyHostRuntimeContext;
  * deletes the old one.
  * :::
  *
- * @section Named export
+ * ### Named export
  * `handler` is the named export to load from `main`. Default is
  * `"default"`.
  *
- * @example Custom handler
+ * **Example:** Custom handler
  * ```typescript
  * export default class Box extends Fly.Sprite<Box>()(
  *   "Box",
@@ -312,6 +311,8 @@ export type SpriteRuntimeContext = FlyHostRuntimeContext;
  *   }),
  * ) {}
  * ```
+ *
+ * @resource
  */
 export const Sprite: Platform<
   Sprite,

--- a/packages/alchemy/src/Fly/Verify.ts
+++ b/packages/alchemy/src/Fly/Verify.ts
@@ -20,17 +20,18 @@ export interface VerifyResult {
  * Verify a signature with a Fly {@link SecretKey}. The App and key
  * name are fixed by `Verify(key)`.
  *
- * @binding
  *
- * @section Verify a signature
+ * ### Verify a signature
  * Provide {@link VerifyHttp}. A bad signature is a typed error from
  * the Machines API, not `valid: false`.
  *
- * @example Verify
+ * **Example:** Verify
  * ```typescript
  * const verify = yield* Fly.Verify(Signing);
  * const { valid } = yield* verify({ plaintext, signature });
  * ```
+ *
+ * @binding
  */
 export interface Verify extends Binding.Service<
   Verify,

--- a/packages/alchemy/src/Fly/VerifyHttp.ts
+++ b/packages/alchemy/src/Fly/VerifyHttp.ts
@@ -15,17 +15,18 @@ import { Verify, type VerifyRequest } from "./Verify.ts";
  * HTTP implementation of {@link Verify}. Provide it on the
  * {@link Service} or Action Effect.
  *
- * @layer
- * @provides Fly.Verify
  *
- * @section Provide the layer
- * @example On a Service
+ * ### Provide the layer
+ * **Example:** On a Service
  * ```typescript
  * Effect.gen(function* () {
  *   const verify = yield* Fly.Verify(Signing);
  *   // ...
  * }).pipe(Effect.provide(Fly.VerifyHttp))
  * ```
+ *
+ * @layer
+ * @provides Fly.Verify
  */
 export const VerifyHttp = Layer.effect(
   Verify,

--- a/packages/alchemy/src/Fly/VolumeSnapshot.ts
+++ b/packages/alchemy/src/Fly/VolumeSnapshot.ts
@@ -66,14 +66,13 @@ export type VolumeSnapshot = Resource<
  * subsequent list. Destroy is a no-op. Snapshots follow Volume
  * retention. `nuke` skips this type.
  *
- * @resource
  * @see https://fly.io/docs/machines/api/volumes-resource/
  *
- * @section Create a snapshot
+ * ### Create a snapshot
  * Point it at a Volume id from the parent {@link Machine} or
  * {@link Service} (`mounts[0].volumeId`).
  *
- * @example Snapshot a mounted disk
+ * **Example:** Snapshot a mounted disk
  * ```typescript
  * const box = yield* Fly.Machine("Box", {
  *   app: Site,
@@ -93,11 +92,11 @@ export type VolumeSnapshot = Resource<
  * It follows Volume `snapshot_retention`.
  * :::
  *
- * @section Restore
+ * ### Restore
  * Restore into a new disk with `snapshotId` on the mount. Create-only.
  * The new Machine gets a copy. The original Volume is unchanged.
  *
- * @example Restore onto a Machine
+ * **Example:** Restore onto a Machine
  * ```typescript
  * const restored = yield* Fly.Machine("Restored", {
  *   app: Site,
@@ -107,10 +106,10 @@ export type VolumeSnapshot = Resource<
  * });
  * ```
  *
- * @section Restore into a Service
+ * ### Restore into a Service
  * Pass `snapshotId` on {@link MountVolume}. Same create-only rule.
  *
- * @example Restore onto a Service
+ * **Example:** Restore onto a Service
  * ```typescript
  * export default class Api extends Fly.Service<Api>()(
  *   "Api",
@@ -127,6 +126,8 @@ export type VolumeSnapshot = Resource<
  *   }).pipe(Effect.provide(Fly.MountVolumeLive)),
  * ) {}
  * ```
+ *
+ * @resource
  */
 export const VolumeSnapshot = Resource<VolumeSnapshot>("Fly.VolumeSnapshot");
 

--- a/packages/alchemy/src/Fly/WriteRedis.ts
+++ b/packages/alchemy/src/Fly/WriteRedis.ts
@@ -9,14 +9,15 @@ import type { Redis, RedisCommandError, RedisUrlMissing } from "./Redis.ts";
  * `WriteRedis` is the Context tag, the type, and the callable —
  * `yield* Fly.WriteRedis(Cache)`. Provide {@link WriteRedisHttp}.
  *
- * @binding
  *
- * @section Write
- * @example Set a key
+ * ### Write
+ * **Example:** Set a key
  * ```typescript
  * const cache = yield* Fly.WriteRedis(Cache);
  * yield* cache.set("marker", "hello");
  * ```
+ *
+ * @binding
  */
 export interface WriteRedis extends Binding.Service<
   WriteRedis,

--- a/packages/alchemy/src/Fly/WriteSecret.ts
+++ b/packages/alchemy/src/Fly/WriteSecret.ts
@@ -20,13 +20,12 @@ import type { Secret } from "./Secret.ts";
  * mints an App deploy token. Inside an Action, the ambient
  * `FLY_API_TOKEN` is used.
  *
- * @binding
  *
- * @section Create
+ * ### Create
  * Bind the client in init. Provide {@link WriteSecretHttp}. Wrap
  * values with `Redacted.make`.
  *
- * @example Create a secret
+ * **Example:** Create a secret
  * ```typescript
  * const Seed = Alchemy.Action(
  *   "Seed",
@@ -40,21 +39,23 @@ import type { Secret } from "./Secret.ts";
  * );
  * ```
  *
- * @section Update
+ * ### Update
  * `update` rotates by name (batch of one).
  *
- * @example Rotate
+ * **Example:** Rotate
  * ```typescript
  * yield* secrets.update("API_KEY", Redacted.make("sk_live_rotated"));
  * ```
  *
- * @section Delete
+ * ### Delete
  * `delete` removes a secret by name.
  *
- * @example Delete
+ * **Example:** Delete
  * ```typescript
  * yield* secrets.delete("API_KEY");
  * ```
+ *
+ * @binding
  */
 export interface WriteSecret extends Binding.Service<
   WriteSecret,

--- a/packages/alchemy/src/Fly/WriteSecretHttp.ts
+++ b/packages/alchemy/src/Fly/WriteSecretHttp.ts
@@ -15,17 +15,18 @@ import { WriteSecret, type WriteSecretClient } from "./WriteSecret.ts";
  * HTTP implementation of {@link WriteSecret}. Provide it on the
  * {@link Service} or Action Effect.
  *
- * @layer
- * @provides Fly.WriteSecret
  *
- * @section Provide the layer
- * @example On an Action
+ * ### Provide the layer
+ * **Example:** On an Action
  * ```typescript
  * Effect.gen(function* () {
  *   const secrets = yield* Fly.WriteSecret(ApiToken);
  *   // ...
  * }).pipe(Effect.provide(Fly.WriteSecretHttp))
  * ```
+ *
+ * @layer
+ * @provides Fly.WriteSecret
  */
 export const WriteSecretHttp = Layer.effect(
   WriteSecret,

--- a/website/src/content/docs/blog/2026-08-20-beta-73.md
+++ b/website/src/content/docs/blog/2026-08-20-beta-73.md
@@ -1,8 +1,8 @@
 ---
-title: 2.0.0-beta.73 - AWS Local Dev & Hetzner
+title: 2.0.0-beta.73 - AWS Local Dev, Hetzner & Fly.io
 date: 2026-08-20T09:00:00Z
 category: release
-excerpt: v2.0.0-beta.73 brings alchemy dev to AWS — your Lambda, S3, DynamoDB, SQS, ECS, and website stack runs on your machine with hot reload and no credentials — adds a Hetzner Cloud provider with an Effect-native Service platform, deploys all six web frameworks to AWS (S3 + CloudFront + streaming Lambda), unifies SQL migrations into one Alchemy-owned format, protects Workers with Cloudflare Access, and makes removal policies persist.
+excerpt: v2.0.0-beta.73 brings alchemy dev to AWS — your Lambda, S3, DynamoDB, SQS, ECS, and website stack runs on your machine with hot reload and no credentials — adds Hetzner Cloud and Fly.io providers with Effect-native Service platforms, deploys all six web frameworks to AWS (S3 + CloudFront + streaming Lambda), unifies SQL migrations into one Alchemy-owned format, protects Workers with Cloudflare Access, and makes removal policies persist.
 ---
 
 beta.73 brings `alchemy dev` to AWS: your Lambda, S3, DynamoDB,
@@ -12,9 +12,11 @@ each website's framework runs its own dev server with native
 HMR. A new
 **Hetzner Cloud provider** ships 15 resources plus an
 Effect-native `Service` platform that deploys your program to a
-server over SSH. And the six web frameworks that landed on
-Cloudflare in beta.70 now deploy to **AWS** — S3 + CloudFront +
-streaming Lambda — with the same interface.
+server over SSH. A new **Fly.io provider** brings Machines,
+Services, Sprites, and managed Postgres, Redis, and Tigris object
+storage. And the six web frameworks that landed on Cloudflare in
+beta.70 now deploy to **AWS** — S3 + CloudFront + streaming
+Lambda — with the same interface.
 :::caution
 **Breaking changes**
 
@@ -141,6 +143,13 @@ the two work unchanged.
 Local emulation covers Lambda (hot reload, Function URLs, event
 source mappings), S3, DynamoDB, SQS, SNS, EventBridge, Secrets
 Manager, SSM, IAM, Cognito, Step Functions, Glue, ACM, and more.
+
+That includes the CloudFront edge: an `AWS.Website.Router`
+deploys into the emulator and serves requests on your machine.
+Its routing logic is a real CloudFront Function — floci executes
+it per request, it reads routes from the local KeyValueStore, and
+`cf.updateRequestOrigin()` forwards to local bucket and Function
+URL origins.
 
 We forked floci so that alchemy's live AWS test suites, which
 normally run against real AWS, can run against the emulator and
@@ -296,6 +305,94 @@ volumes, networking, and DNS.
 Docs: [Hetzner](/hetzner) ·
 [Tutorial](/hetzner/tutorial/part-1).
 
+## Fly.io
+
+A new **Fly.io provider**
+([#1261](https://github.com/alchemy-run/alchemy/pull/1261)): App,
+Machine, Service, Sprite, Volume + VolumeSnapshot, IpAssignment,
+Certificate, Secret, SecretKey, and managed data — Postgres,
+Upstash Redis, and Tigris object storage. Auth is a single
+`FLY_API_TOKEN`.
+
+`Fly.Service` is the Function/Worker analog: an always-on Effect
+program in a Fly Machine. Alchemy bundles `main`, builds a Docker
+image, pushes it, and Fly's Anycast proxy load-balances across
+`count` replicas:
+
+```typescript
+const Site = Fly.App("Site");
+
+const Db = Fly.Postgres("Db", {
+  region: "iad",
+  migrations: schema, // Drizzle.Schema, a directory, or { dir, table }
+});
+
+export default class Api extends Fly.Service<Api>()(
+  "Api",
+  { app: Site, main: import.meta.url, region: "iad", count: 3, port: 3000 },
+  Effect.gen(function* () {
+    const conn = yield* Fly.ConnectPostgres(Db);
+    const db = yield* Drizzle.Postgres(conn.connectionString);
+    return {
+      fetch: Effect.gen(function* () {
+        const rows = yield* db.select().from(users);
+        return HttpServerResponse.json({ rows });
+      }),
+    };
+  }).pipe(Effect.provide(Fly.ConnectPostgresHttp)),
+) {}
+```
+
+Upstash Redis and Tigris object storage bind the same way —
+`ReadRedis` / `WriteRedis` / `ReadWriteRedis` on a `Fly.Redis`,
+and S3-style `PutObject`/`GetObject` on a `Fly.Bucket`:
+
+```typescript
+const Cache = Fly.Redis("Cache"); // Upstash Redis
+const Data = Fly.Bucket("Data"); // Tigris object storage
+
+export default class Api extends Fly.Service<Api>()(
+  "Api",
+  { app: Site, main: import.meta.url, port: 3000 },
+  Effect.gen(function* () {
+    const cache = yield* Fly.ReadWriteRedis(Cache);
+    const putObject = yield* Fly.PutObject(Data);
+    return {
+      fetch: Effect.gen(function* () {
+        yield* putObject({ Key: "hello.txt", Body: "hello" });
+        yield* cache.set("last-write", "hello.txt");
+        return HttpServerResponse.text("ok");
+      }),
+    };
+  }).pipe(Effect.provide([Fly.ReadWriteRedisHttp, Fly.PutObjectHttp])),
+) {}
+```
+
+The rest of the surface follows the same capability model:
+`GetSecret`/`WriteSecret` on app secrets,
+`Encrypt`/`Decrypt`/`Sign`/`Verify` on a `SecretKey`, and
+`MountVolume` for disks. Already have an image? `Fly.Machine`
+runs it as one VM per resource — yield another to add capacity.
+
+`Fly.Sprite` deploys an Effect program onto a
+[Fly Sprite](https://fly.io/sprites) — a persistent Linux
+computer built for AI-agent workloads. It wakes on demand,
+hibernates when idle, and keeps its filesystem between wakes. No
+parent App, no Docker image: alchemy bundles `main` and writes it
+straight onto the Sprite:
+
+```typescript
+export default class Box extends Fly.Sprite<Box>()(
+  "Box",
+  { main: import.meta.url },
+  Effect.gen(function* () {
+    return { fetch: Effect.succeed(HttpServerResponse.text("hello")) };
+  }),
+) {}
+```
+
+Docs: [Fly.io](/fly) · [Tutorial](/fly/tutorial/part-1).
+
 ## Web frameworks on AWS
 
 The full Website family — plain **Vite** SPAs plus **Next.js,
@@ -448,6 +545,18 @@ Docs:
 
 ## Also in this release
 
+- **`nuke --local` clears the emulator**
+  ([#1287](https://github.com/alchemy-run/alchemy/pull/1287)) —
+  `alchemy unsafe nuke --local` enumerates and deletes through
+  each provider's **local** implementation (the floci-emulated
+  account, the Cloudflare local runtime), so wiping local state
+  is one command with no cloud credentials in reach.
+- **Hetzner init scripts compose with the bootstrap**
+  ([#1289](https://github.com/alchemy-run/alchemy/pull/1289)) —
+  `Hetzner.Server.userData` merges into a multipart cloud-init
+  document alongside alchemy's bootstrap instead of replacing it,
+  and changing it plans a replacement (cloud-init only runs on
+  first boot).
 - **Prisma: object storage, locked Postgres state, and deploy
   triggers**
   ([#1061](https://github.com/alchemy-run/alchemy/pull/1061)) —
@@ -558,6 +667,8 @@ Docs:
 - [Local development](/environments/local-development)
 - [Hetzner](/hetzner)
 - [Hetzner tutorial](/hetzner/tutorial/part-1)
+- [Fly.io](/fly)
+- [Fly.io tutorial](/fly/tutorial/part-1)
 - [AWS frontends](/aws/frontend/websites)
 - [Protect a Worker with Access](/cloudflare/security/access)
 - [SQL](/sql)

--- a/website/src/content/docs/fly/compute/services.mdx
+++ b/website/src/content/docs/fly/compute/services.mdx
@@ -135,11 +135,11 @@ export const PublicIp = Fly.IpAssignment("Shared", {
 ```
 
 ```diff lang="typescript"
-  Effect.gen(function* () {
-    const api = yield* Api;
-+    const ip = yield* PublicIp;
-    return { url: api.url, ip: ip.ip };
-  }),
+Effect.gen(function* () {
+  const api = yield* Api;
++  const ip = yield* PublicIp;
+  return { url: api.url, ip: ip.ip };
+}),
 ```
 
 ## Scale with `count`

--- a/website/src/content/docs/fly/networking.mdx
+++ b/website/src/content/docs/fly/networking.mdx
@@ -56,11 +56,11 @@ export const PublicIp = Fly.IpAssignment("Shared", {
 Yield it next to the Service.
 
 ```diff lang="typescript"
-  Effect.gen(function* () {
-    const api = yield* Api;
-+    const ip = yield* PublicIp;
-    return { url: api.url, ip: ip.ip };
-  }),
+Effect.gen(function* () {
+  const api = yield* Api;
++  const ip = yield* PublicIp;
+  return { url: api.url, ip: ip.ip };
+}),
 ```
 
 `v6` is free dedicated IPv6. `v4` is billed dedicated IPv4 and may

--- a/website/src/content/docs/fly/tutorial/part-3.mdx
+++ b/website/src/content/docs/fly/tutorial/part-3.mdx
@@ -90,22 +90,22 @@ Do not yield it per request.
 The Volume is a directory. Use `fs` from init:
 
 ```diff lang="typescript"
-      fetch: Effect.gen(function* () {
-        const request = yield* HttpServerRequest;
-        const url = new URL(request.url, "http://service");
-        if (url.pathname === "/health") {
-          return HttpServerResponse.json({ ok: true });
-        }
-+        const file = `${mount.path}${url.pathname}`;
+fetch: Effect.gen(function* () {
+  const request = yield* HttpServerRequest;
+  const url = new URL(request.url, "http://service");
+  if (url.pathname === "/health") {
+    return HttpServerResponse.json({ ok: true });
+  }
++  const file = `${mount.path}${url.pathname}`;
 +
-+        if (request.method === "PUT") {
-+          const body = yield* request.text;
-+          yield* fs.writeFileString(file, body).pipe(Effect.orDie);
-+          return HttpServerResponse.empty({ status: 204 });
-+        }
++  if (request.method === "PUT") {
++    const body = yield* request.text;
++    yield* fs.writeFileString(file, body).pipe(Effect.orDie);
++    return HttpServerResponse.empty({ status: 204 });
++  }
 +
-        return HttpServerResponse.text("Hello from Fly!");
-      }),
+  return HttpServerResponse.text("Hello from Fly!");
+}),
 ```
 
 ## Read files with `GET /:name`


### PR DESCRIPTION
Update the beta.73 release blog for the two features that landed after #1281, and fix the Fly docs issues the website build surfaced.

### Blog

- New **Fly.io** section ([#1261](https://github.com/alchemy-run/alchemy/pull/1261)): `Fly.Service` + `Fly.Postgres` example, a Redis + Tigris bindings example, `Fly.Sprite` framed as a persistent Linux computer for agent workloads ([fly.io/sprites](https://fly.io/sprites)). Title/intro/excerpt now mention Fly.io.
- AWS local dev: paragraph on the emulated CloudFront edge — `AWS.Website.Router` deploys into floci, its CloudFront Function executes per request against the local KeyValueStore, and `cf.updateRequestOrigin()` forwards to local origins.
- "Also in this release": `nuke --local` ([#1287](https://github.com/alchemy-run/alchemy/pull/1287)) and Hetzner init-script composition ([#1289](https://github.com/alchemy-run/alchemy/pull/1289)).

### Fly docs fixes

- `/providers/fly/secretkey` 404'd: the `@resource` JSDoc in `Fly/SecretKey.ts` was attached to the internal `resolveSecretKeyProps` helper instead of the exported `SecretKey`, so no page was generated. Moved it onto the export.
- `pnpm docs:fix-jsdoc` normalized the Fly sources still using the `@section`/`@example` tag layout.
- Rewrote three diff blocks (`fly/networking`, `fly/compute/services`, `fly/tutorial/part-3`) with flush context lines — indented context makes expressive-code dedent the block and render the `+` lines misaligned, which the build-output check rejects.

`pnpm docs:check` passes (4335 pages, links + diff indents).
