### PR TITLE
fix(cloudflare/workers): preserve DO migration state after precreate

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -698,6 +698,60 @@ const getScriptSettings = (
     });
   });
 
+type ScriptSettingsRead = ReturnType<typeof getScriptSettings>;
+
+const isMissingScriptSettings = (error: Effect.Error<ScriptSettingsRead>) =>
+  error._tag === "WorkerNotFound" ||
+  error._tag === "WorkerHasNoVersions" ||
+  error._tag === "DispatchNamespaceScriptNotFound" ||
+  error._tag === "DispatchNamespaceNotFound";
+
+/**
+ * Observe the script state used to plan Durable Object migrations.
+ *
+ * A normal Worker is pre-created before reconcile. If that stub already
+ * exposed a Durable Object namespace, a transient missing-settings response
+ * cannot mean that the class is new: the precreate poll just proved it exists.
+ * Retry that observation and fail closed if it never converges. Treating the
+ * failed read as an absent Worker would emit `new_sqlite_classes` again and
+ * Cloudflare rejects the duplicate create migration.
+ *
+ * Workers for Platforms user workers skip precreate. With no previously
+ * observed Durable Object namespaces, a missing script is still a legitimate
+ * greenfield create and remains `undefined`.
+ *
+ * @internal
+ */
+export const observeWorkerSettingsForMigration = <R>(
+  read: Effect.Effect<
+    Effect.Success<ScriptSettingsRead>,
+    Effect.Error<ScriptSettingsRead>,
+    R
+  >,
+  observedDurableObjectClassNames: readonly string[],
+  retrySchedule: Schedule.Schedule<unknown, unknown, never> = Schedule.max([
+    Schedule.exponential(100),
+    Schedule.recurs(20),
+  ]),
+) =>
+  observedDurableObjectClassNames.length > 0
+    ? read.pipe(
+        Effect.retry({
+          while: isMissingScriptSettings,
+          schedule: retrySchedule,
+        }),
+      )
+    : read.pipe(
+        Effect.catchTag("WorkerNotFound", () => Effect.succeed(undefined)),
+        Effect.catchTag("WorkerHasNoVersions", () => Effect.succeed(undefined)),
+        Effect.catchTag("DispatchNamespaceScriptNotFound", () =>
+          Effect.succeed(undefined),
+        ),
+        Effect.catchTag("DispatchNamespaceNotFound", () =>
+          Effect.succeed(undefined),
+        ),
+      );
+
 /**
  * Deploy-time binding validation rejects an upload whose bindings
  * reference a resource Cloudflare can't see (each resource type has
@@ -3262,15 +3316,13 @@ export const LiveWorkerProvider = () =>
         // Read existing worker settings for migration tracking
         const oldSettings =
           existingSettings ??
-          (yield* workers
-            .getScriptScriptAndVersionSetting({
+          (yield* observeWorkerSettingsForMigration(
+            workers.getScriptScriptAndVersionSetting({
               accountId,
               scriptName: name,
-            })
-            .pipe(
-              Effect.map((s) => s as typeof s | undefined),
-              Effect.catch(() => Effect.succeed(undefined)),
-            ));
+            }),
+            Object.keys(output?.durableObjectNamespaces ?? {}),
+          ));
 
         const oldTags = Array.from(new Set(oldSettings?.tags ?? []));
         const oldBindings = oldSettings?.bindings ?? [];
@@ -5090,27 +5142,9 @@ export const LiveWorkerProvider = () =>
           // existing settings inform asset/migration decisions and let the
           // reconciler converge whether the worker is brand-new, adopted, or
           // an in-place update.
-          const existingSettings = yield* getScriptSettings(
-            accountId,
-            name,
-            dispatchNamespace,
-          ).pipe(
-            // After a pre-create stub (or under a busy account right after
-            // the first upload) the settings read can race the script
-            // registry and 404 with "has no versions". Treat it as "no
-            // existing settings" so reconcile proceeds to upload/converge.
-            // The dispatch-namespace endpoints raise
-            // `DispatchNamespaceScriptNotFound` / `DispatchNamespaceNotFound`.
-            Effect.catchTag("WorkerNotFound", () => Effect.succeed(undefined)),
-            Effect.catchTag("WorkerHasNoVersions", () =>
-              Effect.succeed(undefined),
-            ),
-            Effect.catchTag("DispatchNamespaceScriptNotFound", () =>
-              Effect.succeed(undefined),
-            ),
-            Effect.catchTag("DispatchNamespaceNotFound", () =>
-              Effect.succeed(undefined),
-            ),
+          const existingSettings = yield* observeWorkerSettingsForMigration(
+            getScriptSettings(accountId, name, dispatchNamespace),
+            Object.keys(output?.durableObjectNamespaces ?? {}),
           );
           yield* Effect.logInfo(
             `Cloudflare Worker reconcile: existing durable object tags ${JSON.stringify(

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -706,6 +706,15 @@ const isMissingScriptSettings = (error: Effect.Error<ScriptSettingsRead>) =>
   error._tag === "DispatchNamespaceScriptNotFound" ||
   error._tag === "DispatchNamespaceNotFound";
 
+/** @internal */
+export const getObservedHostedDurableObjectClassNames = (
+  durableObjectNamespaces: Readonly<Record<string, string>> | undefined,
+  hostedClassNames: ReadonlySet<string>,
+) =>
+  Object.keys(durableObjectNamespaces ?? {}).filter((className) =>
+    hostedClassNames.has(className),
+  );
+
 /**
  * Observe the script state used to plan Durable Object migrations.
  *
@@ -731,7 +740,7 @@ export const observeWorkerSettingsForMigration = <R>(
   observedDurableObjectClassNames: readonly string[],
   retrySchedule: Schedule.Schedule<unknown, unknown, never> = Schedule.max([
     Schedule.exponential(100),
-    Schedule.recurs(20),
+    Schedule.recurs(8),
   ]),
 ) =>
   observedDurableObjectClassNames.length > 0
@@ -3316,13 +3325,15 @@ export const LiveWorkerProvider = () =>
         // Read existing worker settings for migration tracking
         const oldSettings =
           existingSettings ??
-          (yield* observeWorkerSettingsForMigration(
-            workers.getScriptScriptAndVersionSetting({
+          (yield* workers
+            .getScriptScriptAndVersionSetting({
               accountId,
               scriptName: name,
-            }),
-            Object.keys(output?.durableObjectNamespaces ?? {}),
-          ));
+            })
+            .pipe(
+              Effect.map((s) => s as typeof s | undefined),
+              Effect.catch(() => Effect.succeed(undefined)),
+            ));
 
         const oldTags = Array.from(new Set(oldSettings?.tags ?? []));
         const oldBindings = oldSettings?.bindings ?? [];
@@ -5137,6 +5148,18 @@ export const LiveWorkerProvider = () =>
           );
 
           const dispatchNamespace = resolveNamespaceName(news.namespace);
+          const hostedDurableObjectClassNames = new Set([
+            ...durableObjects.map(({ className }) => className),
+            ...Object.entries(news.exports ?? {}).flatMap(
+              ([className, value]) =>
+                isDurableObjectExport(value) ? [className] : [],
+            ),
+          ]);
+          const observedHostedDurableObjectClassNames =
+            getObservedHostedDurableObjectClassNames(
+              output?.durableObjectNamespaces,
+              hostedDurableObjectClassNames,
+            );
           // Observe — fetch the script's current settings if it already exists.
           // `putWorker` is a true upsert against the Cloudflare API; the
           // existing settings inform asset/migration decisions and let the
@@ -5144,7 +5167,7 @@ export const LiveWorkerProvider = () =>
           // an in-place update.
           const existingSettings = yield* observeWorkerSettingsForMigration(
             getScriptSettings(accountId, name, dispatchNamespace),
-            Object.keys(output?.durableObjectNamespaces ?? {}),
+            observedHostedDurableObjectClassNames,
           );
           yield* Effect.logInfo(
             `Cloudflare Worker reconcile: existing durable object tags ${JSON.stringify(

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -698,69 +698,6 @@ const getScriptSettings = (
     });
   });
 
-type ScriptSettingsRead = ReturnType<typeof getScriptSettings>;
-
-const isMissingScriptSettings = (error: Effect.Error<ScriptSettingsRead>) =>
-  error._tag === "WorkerNotFound" ||
-  error._tag === "WorkerHasNoVersions" ||
-  error._tag === "DispatchNamespaceScriptNotFound" ||
-  error._tag === "DispatchNamespaceNotFound";
-
-/** @internal */
-export const getObservedHostedDurableObjectClassNames = (
-  durableObjectNamespaces: Readonly<Record<string, string>> | undefined,
-  hostedClassNames: ReadonlySet<string>,
-) =>
-  Object.keys(durableObjectNamespaces ?? {}).filter((className) =>
-    hostedClassNames.has(className),
-  );
-
-/**
- * Observe the script state used to plan Durable Object migrations.
- *
- * A normal Worker is pre-created before reconcile. If that stub already
- * exposed a Durable Object namespace, a transient missing-settings response
- * cannot mean that the class is new: the precreate poll just proved it exists.
- * Retry that observation and fail closed if it never converges. Treating the
- * failed read as an absent Worker would emit `new_sqlite_classes` again and
- * Cloudflare rejects the duplicate create migration.
- *
- * Workers for Platforms user workers skip precreate. With no previously
- * observed Durable Object namespaces, a missing script is still a legitimate
- * greenfield create and remains `undefined`.
- *
- * @internal
- */
-export const observeWorkerSettingsForMigration = <R>(
-  read: Effect.Effect<
-    Effect.Success<ScriptSettingsRead>,
-    Effect.Error<ScriptSettingsRead>,
-    R
-  >,
-  observedDurableObjectClassNames: readonly string[],
-  retrySchedule: Schedule.Schedule<unknown, unknown, never> = Schedule.max([
-    Schedule.exponential(100),
-    Schedule.recurs(8),
-  ]),
-) =>
-  observedDurableObjectClassNames.length > 0
-    ? read.pipe(
-        Effect.retry({
-          while: isMissingScriptSettings,
-          schedule: retrySchedule,
-        }),
-      )
-    : read.pipe(
-        Effect.catchTag("WorkerNotFound", () => Effect.succeed(undefined)),
-        Effect.catchTag("WorkerHasNoVersions", () => Effect.succeed(undefined)),
-        Effect.catchTag("DispatchNamespaceScriptNotFound", () =>
-          Effect.succeed(undefined),
-        ),
-        Effect.catchTag("DispatchNamespaceNotFound", () =>
-          Effect.succeed(undefined),
-        ),
-      );
-
 /**
  * Deploy-time binding validation rejects an upload whose bindings
  * reference a resource Cloudflare can't see (each resource type has
@@ -3335,7 +3272,11 @@ export const LiveWorkerProvider = () =>
               Effect.catch(() => Effect.succeed(undefined)),
             ));
 
-        const oldTags = Array.from(new Set(oldSettings?.tags ?? []));
+        const oldTags = selectWorkerMigrationTags(
+          oldSettings,
+          output?.tags,
+          olds === undefined,
+        );
         const oldBindings = oldSettings?.bindings ?? [];
 
         // Parse the DO logical-id→class mapping from script tags (packed
@@ -5148,26 +5089,32 @@ export const LiveWorkerProvider = () =>
           );
 
           const dispatchNamespace = resolveNamespaceName(news.namespace);
-          const hostedDurableObjectClassNames = new Set([
-            ...durableObjects.map(({ className }) => className),
-            ...Object.entries(news.exports ?? {}).flatMap(
-              ([className, value]) =>
-                isDurableObjectExport(value) ? [className] : [],
-            ),
-          ]);
-          const observedHostedDurableObjectClassNames =
-            getObservedHostedDurableObjectClassNames(
-              output?.durableObjectNamespaces,
-              hostedDurableObjectClassNames,
-            );
           // Observe — fetch the script's current settings if it already exists.
           // `putWorker` is a true upsert against the Cloudflare API; the
           // existing settings inform asset/migration decisions and let the
           // reconciler converge whether the worker is brand-new, adopted, or
           // an in-place update.
-          const existingSettings = yield* observeWorkerSettingsForMigration(
-            getScriptSettings(accountId, name, dispatchNamespace),
-            observedHostedDurableObjectClassNames,
+          const existingSettings = yield* getScriptSettings(
+            accountId,
+            name,
+            dispatchNamespace,
+          ).pipe(
+            // After a pre-create stub (or under a busy account right after
+            // the first upload) the settings read can race the script
+            // registry and 404 with "has no versions". Treat it as "no
+            // existing settings" so reconcile proceeds to upload/converge.
+            // The dispatch-namespace endpoints raise
+            // `DispatchNamespaceScriptNotFound` / `DispatchNamespaceNotFound`.
+            Effect.catchTag("WorkerNotFound", () => Effect.succeed(undefined)),
+            Effect.catchTag("WorkerHasNoVersions", () =>
+              Effect.succeed(undefined),
+            ),
+            Effect.catchTag("DispatchNamespaceScriptNotFound", () =>
+              Effect.succeed(undefined),
+            ),
+            Effect.catchTag("DispatchNamespaceNotFound", () =>
+              Effect.succeed(undefined),
+            ),
           );
           yield* Effect.logInfo(
             `Cloudflare Worker reconcile: existing durable object tags ${JSON.stringify(
@@ -5653,6 +5600,34 @@ export function getDurableObjectTagMap(tags: ReadonlyArray<string>) {
     }
   }
   return map;
+}
+
+/**
+ * Select the tags that describe the previous Durable Object migration state.
+ * Live settings are authoritative whenever they exist. During a create pass,
+ * a precreate stub may already have registered the classes even when its
+ * settings have not propagated yet, so its persisted tags are the fallback.
+ * Updates deliberately ignore cached tags when the Worker is missing so the
+ * normal upsert path can self-heal out-of-band deletion.
+ *
+ * @internal exported for unit testing.
+ */
+export function selectWorkerMigrationTags(
+  observedSettings:
+    | { readonly tags?: ReadonlyArray<string> | null }
+    | undefined,
+  precreatedTags: ReadonlyArray<string> | undefined,
+  isCreate: boolean,
+) {
+  return Array.from(
+    new Set(
+      observedSettings !== undefined
+        ? (observedSettings.tags ?? [])
+        : isCreate
+          ? (precreatedTags ?? [])
+          : [],
+    ),
+  );
 }
 
 const isDurableObjectTag = (tag: string) =>

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -3272,11 +3272,7 @@ export const LiveWorkerProvider = () =>
               Effect.catch(() => Effect.succeed(undefined)),
             ));
 
-        const oldTags = selectWorkerMigrationTags(
-          oldSettings,
-          output?.tags,
-          olds === undefined,
-        );
+        const oldTags = Array.from(new Set(oldSettings?.tags ?? []));
         const oldBindings = oldSettings?.bindings ?? [];
 
         // Parse the DO logical-id→class mapping from script tags (packed
@@ -3478,16 +3474,16 @@ export const LiveWorkerProvider = () =>
               previousClassName = observed.className;
             }
           }
-          // A class new to this script is a host move when the declaration
-          // says so: `transferredFrom` lists the former host(s) — moves
-          // are always declared, never inferred, because a class deleted
-          // on one worker and created on another is otherwise ambiguous
-          // between "move the data" and "delete + fresh namespace". The
-          // declared source must be observed to still host the namespace;
-          // otherwise (fresh stage, transfer already completed) fall
-          // through to a plain create.
-          const fromScript = !previousClassName
-            ? dispatchNamespace
+          if (!previousClassName) {
+            // A class new to this script is a host move when the declaration
+            // says so: `transferredFrom` lists the former host(s) — moves
+            // are always declared, never inferred, because a class deleted
+            // on one worker and created on another is otherwise ambiguous
+            // between "move the data" and "delete + fresh namespace". The
+            // declared source must be observed to still host the namespace;
+            // otherwise (fresh stage, transfer already completed) fall
+            // through to a plain create.
+            const fromScript = dispatchNamespace
               ? undefined
               : yield* resolveTransferSource({
                   accountId,
@@ -3499,16 +3495,28 @@ export const LiveWorkerProvider = () =>
                     name,
                   ),
                   observedNamespaces,
-                })
-            : undefined;
-          const migration = planDurableObjectClassMigration({
-            previousClassName,
-            className: binding.className,
-            fromScript,
-          });
-          newSqliteClasses.push(...migration.newSqliteClasses);
-          renamedClasses.push(...migration.renamedClasses);
-          transferredClasses.push(...migration.transferredClasses);
+                });
+            if (fromScript !== undefined) {
+              // Data-preserving move: ship Cloudflare's
+              // `transferred_classes` migration instead of creating a
+              // fresh class.
+              transferredClasses.push({
+                from: binding.className,
+                fromScript,
+                to: binding.className,
+              });
+              continue;
+            }
+            // Default all new Durable Object classes to SQLite. Cloudflare
+            // recommends SQLite for new namespaces, and container-backed
+            // Durable Objects require it.
+            newSqliteClasses.push(binding.className);
+          } else if (previousClassName !== binding.className) {
+            renamedClasses.push({
+              from: previousClassName,
+              to: binding.className,
+            });
+          }
         }
 
         yield* Effect.logInfo(
@@ -5089,10 +5097,26 @@ export const LiveWorkerProvider = () =>
           ).pipe(
             // After a pre-create stub (or under a busy account right after
             // the first upload) the settings read can race the script
-            // registry and 404 with "has no versions". Treat it as "no
-            // existing settings" so reconcile proceeds to upload/converge.
-            // The dispatch-namespace endpoints raise
+            // registry and 404 with "has no versions". When we already hold
+            // attributes for this script, that 404 is far more likely the
+            // race than a deleted worker, so wait briefly for the registry
+            // before concluding there are no existing settings — planning
+            // the stub's Durable Object classes as new again is rejected by
+            // Cloudflare. A worker that really is gone falls through to the
+            // upsert below. The dispatch-namespace endpoints raise
             // `DispatchNamespaceScriptNotFound` / `DispatchNamespaceNotFound`.
+            Effect.retry({
+              while: (error) =>
+                output !== undefined &&
+                (error._tag === "WorkerNotFound" ||
+                  error._tag === "WorkerHasNoVersions" ||
+                  error._tag === "DispatchNamespaceScriptNotFound" ||
+                  error._tag === "DispatchNamespaceNotFound"),
+              schedule: Schedule.max([
+                Schedule.exponential(250),
+                Schedule.recurs(6),
+              ]),
+            }),
             Effect.catchTag("WorkerNotFound", () => Effect.succeed(undefined)),
             Effect.catchTag("WorkerHasNoVersions", () =>
               Effect.succeed(undefined),
@@ -5588,60 +5612,6 @@ export function getDurableObjectTagMap(tags: ReadonlyArray<string>) {
     }
   }
   return map;
-}
-
-/**
- * Select the tags that describe the previous Durable Object migration state.
- * Live settings are authoritative whenever they exist. During a create pass,
- * a precreate stub may already have registered the classes even when its
- * settings have not propagated yet, so its persisted tags are the fallback.
- * Updates deliberately ignore cached tags when the Worker is missing so the
- * normal upsert path can self-heal out-of-band deletion.
- *
- * @internal exported for unit testing.
- */
-export function selectWorkerMigrationTags(
-  observedSettings:
-    | { readonly tags?: ReadonlyArray<string> | null }
-    | undefined,
-  precreatedTags: ReadonlyArray<string> | undefined,
-  isCreate: boolean,
-) {
-  return Array.from(
-    new Set(
-      observedSettings !== undefined
-        ? (observedSettings.tags ?? [])
-        : isCreate
-          ? (precreatedTags ?? [])
-          : [],
-    ),
-  );
-}
-
-/** @internal exported for unit testing. */
-export function planDurableObjectClassMigration({
-  previousClassName,
-  className,
-  fromScript,
-}: {
-  previousClassName: string | undefined;
-  className: string;
-  fromScript?: string;
-}) {
-  return {
-    newSqliteClasses:
-      previousClassName === undefined && fromScript === undefined
-        ? [className]
-        : [],
-    renamedClasses:
-      previousClassName !== undefined && previousClassName !== className
-        ? [{ from: previousClassName, to: className }]
-        : [],
-    transferredClasses:
-      previousClassName === undefined && fromScript !== undefined
-        ? [{ from: className, fromScript, to: className }]
-        : [],
-  };
 }
 
 const isDurableObjectTag = (tag: string) =>

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -3478,9 +3478,14 @@ export const LiveWorkerProvider = () =>
               previousClassName = observed.className;
             }
           }
-          // A class new to this script is a host move only when the
-          // declaration names a source that still owns its namespace.
-          // Otherwise it is a plain SQLite-backed create.
+          // A class new to this script is a host move when the declaration
+          // says so: `transferredFrom` lists the former host(s) — moves
+          // are always declared, never inferred, because a class deleted
+          // on one worker and created on another is otherwise ambiguous
+          // between "move the data" and "delete + fresh namespace". The
+          // declared source must be observed to still host the namespace;
+          // otherwise (fresh stage, transfer already completed) fall
+          // through to a plain create.
           const fromScript = !previousClassName
             ? dispatchNamespace
               ? undefined

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -3478,16 +3478,11 @@ export const LiveWorkerProvider = () =>
               previousClassName = observed.className;
             }
           }
-          if (!previousClassName) {
-            // A class new to this script is a host move when the declaration
-            // says so: `transferredFrom` lists the former host(s) — moves
-            // are always declared, never inferred, because a class deleted
-            // on one worker and created on another is otherwise ambiguous
-            // between "move the data" and "delete + fresh namespace". The
-            // declared source must be observed to still host the namespace;
-            // otherwise (fresh stage, transfer already completed) fall
-            // through to a plain create.
-            const fromScript = dispatchNamespace
+          // A class new to this script is a host move only when the
+          // declaration names a source that still owns its namespace.
+          // Otherwise it is a plain SQLite-backed create.
+          const fromScript = !previousClassName
+            ? dispatchNamespace
               ? undefined
               : yield* resolveTransferSource({
                   accountId,
@@ -3499,28 +3494,16 @@ export const LiveWorkerProvider = () =>
                     name,
                   ),
                   observedNamespaces,
-                });
-            if (fromScript !== undefined) {
-              // Data-preserving move: ship Cloudflare's
-              // `transferred_classes` migration instead of creating a
-              // fresh class.
-              transferredClasses.push({
-                from: binding.className,
-                fromScript,
-                to: binding.className,
-              });
-              continue;
-            }
-            // Default all new Durable Object classes to SQLite. Cloudflare
-            // recommends SQLite for new namespaces, and container-backed
-            // Durable Objects require it.
-            newSqliteClasses.push(binding.className);
-          } else if (previousClassName !== binding.className) {
-            renamedClasses.push({
-              from: previousClassName,
-              to: binding.className,
-            });
-          }
+                })
+            : undefined;
+          const migration = planDurableObjectClassMigration({
+            previousClassName,
+            className: binding.className,
+            fromScript,
+          });
+          newSqliteClasses.push(...migration.newSqliteClasses);
+          renamedClasses.push(...migration.renamedClasses);
+          transferredClasses.push(...migration.transferredClasses);
         }
 
         yield* Effect.logInfo(
@@ -5628,6 +5611,32 @@ export function selectWorkerMigrationTags(
           : [],
     ),
   );
+}
+
+/** @internal exported for unit testing. */
+export function planDurableObjectClassMigration({
+  previousClassName,
+  className,
+  fromScript,
+}: {
+  previousClassName: string | undefined;
+  className: string;
+  fromScript?: string;
+}) {
+  return {
+    newSqliteClasses:
+      previousClassName === undefined && fromScript === undefined
+        ? [className]
+        : [],
+    renamedClasses:
+      previousClassName !== undefined && previousClassName !== className
+        ? [{ from: previousClassName, to: className }]
+        : [],
+    transferredClasses:
+      previousClassName === undefined && fromScript !== undefined
+        ? [{ from: className, fromScript, to: className }]
+        : [],
+  };
 }
 
 const isDurableObjectTag = (tag: string) =>

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -5097,13 +5097,12 @@ export const LiveWorkerProvider = () =>
           ).pipe(
             // After a pre-create stub (or under a busy account right after
             // the first upload) the settings read can race the script
-            // registry and 404 with "has no versions". When we already hold
-            // attributes for this script, that 404 is far more likely the
-            // race than a deleted worker, so wait briefly for the registry
-            // before concluding there are no existing settings — planning
-            // the stub's Durable Object classes as new again is rejected by
-            // Cloudflare. A worker that really is gone falls through to the
-            // upsert below. The dispatch-namespace endpoints raise
+            // registry and 404 with "has no versions". If we already hold
+            // attributes for this script, wait briefly for the registry:
+            // planning the stub's Durable Object classes as new again is
+            // rejected by Cloudflare. A worker that really is gone still
+            // falls through to the upsert below. The dispatch-namespace
+            // endpoints raise
             // `DispatchNamespaceScriptNotFound` / `DispatchNamespaceNotFound`.
             Effect.retry({
               while: (error) =>

--- a/packages/alchemy/test/Cloudflare/Workers/DurableObjectPrecreateRace.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/DurableObjectPrecreateRace.test.ts
@@ -7,14 +7,10 @@ import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import { expectUrlContains } from "../Utils/Http.ts";
 
 /**
- * A Worker hosting a Durable Object is pre-created as a stub that already
- * registers the class. Reconcile then reads the script settings to learn
- * which classes exist; under load that read can 404 "has no versions" even
- * though precreate just observed the class. The deploy used to send
- * `new_sqlite_classes` for the class a second time, which Cloudflare rejects.
- *
- * Everything below runs against the real API except the settings reads
- * after precreate has observed the namespace: the next two answer 404.
+ * Precreate registers a Worker's Durable Object classes, then reconcile's
+ * settings read can 404 "has no versions" and the deploy re-sends
+ * `new_sqlite_classes`, which Cloudflare rejects. Everything here hits the
+ * real API except those two reads.
  */
 
 const settingsPath = /\/workers\/scripts\/[^/]+\/settings$/;

--- a/packages/alchemy/test/Cloudflare/Workers/DurableObjectPrecreateRace.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/DurableObjectPrecreateRace.test.ts
@@ -1,0 +1,108 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Test from "@/Test/Alchemy";
+import { expect } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import { expectUrlContains } from "../Utils/Http.ts";
+
+/**
+ * A Worker hosting a Durable Object is pre-created as a stub that already
+ * registers the class. Reconcile then reads the script settings to learn
+ * which classes exist; under load that read can 404 "has no versions" even
+ * though precreate just observed the class. The deploy used to send
+ * `new_sqlite_classes` for the class a second time, which Cloudflare rejects.
+ *
+ * Everything below runs against the real API except the settings reads
+ * after precreate has observed the namespace: the next two answer 404.
+ */
+
+const settingsPath = /\/workers\/scripts\/[^/]+\/settings$/;
+
+const race = { observed: false, injected: 0 };
+
+const noVersions = () =>
+  new Response(
+    JSON.stringify({
+      success: false,
+      errors: [{ code: 10007, message: "Worker has no versions" }],
+      messages: [],
+      result: null,
+    }),
+    { status: 404, headers: { "content-type": "application/json" } },
+  );
+
+const racingFetch: typeof fetch = async (input, init) => {
+  const request = input instanceof Request ? input : new Request(input, init);
+  if (
+    request.method !== "GET" ||
+    !settingsPath.test(new URL(request.url).pathname)
+  ) {
+    return fetch(input, init);
+  }
+  if (race.observed && race.injected < 2) {
+    race.injected++;
+    return noVersions();
+  }
+  const response = await fetch(input, init);
+  if (
+    response.status === 200 &&
+    (await response.clone().text()).includes('"namespace_id"')
+  ) {
+    race.observed = true;
+  }
+  return response;
+};
+
+const { test } = Test.make({
+  providers: Cloudflare.providers().pipe(
+    Layer.provideMerge(
+      Layer.fresh(FetchHttpClient.layer).pipe(
+        Layer.provide(Layer.succeed(FetchHttpClient.Fetch, racingFetch)),
+      ),
+    ),
+  ),
+});
+
+const script = `import { DurableObject } from "cloudflare:workers";
+export class Counter extends DurableObject {
+  async increment() {
+    const next = ((await this.ctx.storage.get("count")) ?? 0) + 1;
+    await this.ctx.storage.put("count", next);
+    return next;
+  }
+}
+export default {
+  async fetch(request, env) {
+    const value = await env.Counter.getByName("shared").increment();
+    return new Response("count=" + value);
+  },
+};`;
+
+test.provider(
+  "deploy survives a settings read that races the precreated durable object",
+  (stack) =>
+    Effect.gen(function* () {
+      race.observed = false;
+      race.injected = 0;
+      yield* stack.destroy();
+
+      const { worker } = yield* stack.deploy(
+        Effect.gen(function* () {
+          return {
+            worker: yield* Cloudflare.Worker("do-precreate-race", {
+              script,
+              env: { Counter: Cloudflare.DurableObject("Counter") },
+            }),
+          };
+        }),
+      );
+
+      expect(race.injected).toBe(2);
+      expect(Object.keys(worker.durableObjectNamespaces)).toEqual(["Counter"]);
+      yield* expectUrlContains(worker.url!, "count=");
+
+      yield* stack.destroy();
+    }),
+  { timeout: 180_000 },
+);

--- a/packages/alchemy/test/Cloudflare/Workers/DurableObjectPrecreateRace.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/DurableObjectPrecreateRace.test.ts
@@ -28,7 +28,10 @@ const noVersions = () =>
     { status: 404, headers: { "content-type": "application/json" } },
   );
 
-const racingFetch: typeof fetch = async (input, init) => {
+const racingFetch = async (
+  input: Parameters<typeof fetch>[0],
+  init?: Parameters<typeof fetch>[1],
+) => {
   const request = input instanceof Request ? input : new Request(input, init);
   if (
     request.method !== "GET" ||
@@ -54,7 +57,12 @@ const { test } = Test.make({
   providers: Cloudflare.providers().pipe(
     Layer.provideMerge(
       Layer.fresh(FetchHttpClient.layer).pipe(
-        Layer.provide(Layer.succeed(FetchHttpClient.Fetch, racingFetch)),
+        Layer.provide(
+          Layer.succeed(
+            FetchHttpClient.Fetch,
+            racingFetch as typeof globalThis.fetch,
+          ),
+        ),
       ),
     ),
   ),

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerProvider.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerProvider.test.ts
@@ -1,5 +1,6 @@
 import {
   encodeDurableObjectTags,
+  getObservedHostedDurableObjectClassNames,
   getDurableObjectTagMap,
   normalizeStateDomains,
   observeWorkerSettingsForMigration,
@@ -13,7 +14,6 @@ import {
   stateCustomDomains,
   stateWorkerDomain,
 } from "@/Cloudflare/Workers/WorkerProvider";
-import { CloudflareRateLimited } from "@distilled.cloud/cloudflare/Errors";
 import * as workers from "@distilled.cloud/cloudflare/workers";
 import { describe, expect, test } from "alchemy-test";
 import * as Effect from "effect/Effect";
@@ -23,6 +23,18 @@ import * as Schedule from "effect/Schedule";
 
 describe("WorkerProvider", () => {
   describe("observeWorkerSettingsForMigration", () => {
+    test("uses only namespaces for classes hosted by this Worker", () => {
+      expect(
+        getObservedHostedDurableObjectClassNames(
+          {
+            ForeignClass: "foreign-namespace-id",
+            SeatConnector: "hosted-namespace-id",
+          },
+          new Set(["SeatConnector"]),
+        ),
+      ).toEqual(["SeatConnector"]);
+    });
+
     test.effect(
       "retries a missing-settings race after precreate proved the DO exists",
       () =>
@@ -103,27 +115,6 @@ describe("WorkerProvider", () => {
             expect(result.failure._tag).toBe("WorkerHasNoVersions");
           }
         }),
-    );
-
-    test.effect("never turns an observation failure into a new migration", () =>
-      Effect.gen(function* () {
-        const result = yield* Effect.result(
-          observeWorkerSettingsForMigration(
-            Effect.fail(
-              new CloudflareRateLimited({
-                status: 429,
-                errors: [{ code: 10000, message: "rate limited" }],
-              }),
-            ),
-            [],
-          ),
-        );
-
-        expect(Result.isFailure(result)).toBe(true);
-        if (Result.isFailure(result)) {
-          expect(result.failure._tag).toBe("CloudflareRateLimited");
-        }
-      }),
     );
   });
 

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerProvider.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerProvider.test.ts
@@ -2,6 +2,7 @@ import {
   encodeDurableObjectTags,
   getDurableObjectTagMap,
   normalizeStateDomains,
+  observeWorkerSettingsForMigration,
   resolveWorkerDomain,
   resolveWorkerDomainZone,
   resolveWorkersDev,
@@ -12,11 +13,120 @@ import {
   stateCustomDomains,
   stateWorkerDomain,
 } from "@/Cloudflare/Workers/WorkerProvider";
+import { CloudflareRateLimited } from "@distilled.cloud/cloudflare/Errors";
+import * as workers from "@distilled.cloud/cloudflare/workers";
 import { describe, expect, test } from "alchemy-test";
 import * as Effect from "effect/Effect";
+import * as Ref from "effect/Ref";
 import * as Result from "effect/Result";
+import * as Schedule from "effect/Schedule";
 
 describe("WorkerProvider", () => {
+  describe("observeWorkerSettingsForMigration", () => {
+    test.effect(
+      "retries a missing-settings race after precreate proved the DO exists",
+      () =>
+        Effect.gen(function* () {
+          const attempts = yield* Ref.make(0);
+          const observed = {
+            tags: ["alchemy:dos:SeatConnector=SeatConnector"],
+            bindings: [
+              {
+                type: "durable_object_namespace" as const,
+                name: "SeatConnector",
+                className: "SeatConnector",
+                namespaceId: "namespace-id",
+              },
+            ],
+          } satisfies workers.GetScriptScriptAndVersionSettingResponse;
+          const read = Ref.updateAndGet(attempts, (count) => count + 1).pipe(
+            Effect.flatMap((attempt) =>
+              attempt === 1
+                ? Effect.fail(
+                    new workers.WorkerHasNoVersions({
+                      code: 10007,
+                      message: "Worker has no versions",
+                    }),
+                  )
+                : Effect.succeed(observed),
+            ),
+          );
+
+          const settings = yield* observeWorkerSettingsForMigration(
+            read,
+            ["SeatConnector"],
+            Schedule.recurs(1),
+          );
+
+          expect(settings).toBe(observed);
+          expect(yield* Ref.get(attempts)).toBe(2);
+        }),
+    );
+
+    test.effect(
+      "keeps a missing script as a greenfield create without a precreated DO",
+      () =>
+        Effect.gen(function* () {
+          const settings = yield* observeWorkerSettingsForMigration(
+            Effect.fail(
+              new workers.WorkerNotFound({
+                code: 10007,
+                message: "Worker not found",
+              }),
+            ),
+            [],
+          );
+
+          expect(settings).toBeUndefined();
+        }),
+    );
+
+    test.effect(
+      "fails closed when settings stay missing after a precreated DO",
+      () =>
+        Effect.gen(function* () {
+          const result = yield* Effect.result(
+            observeWorkerSettingsForMigration(
+              Effect.fail(
+                new workers.WorkerHasNoVersions({
+                  code: 10007,
+                  message: "Worker has no versions",
+                }),
+              ),
+              ["SeatConnector"],
+              Schedule.recurs(0),
+            ),
+          );
+
+          expect(Result.isFailure(result)).toBe(true);
+          if (Result.isFailure(result)) {
+            expect(result.failure._tag).toBe("WorkerHasNoVersions");
+          }
+        }),
+    );
+
+    test.effect("never turns an observation failure into a new migration", () =>
+      Effect.gen(function* () {
+        const result = yield* Effect.result(
+          observeWorkerSettingsForMigration(
+            Effect.fail(
+              new CloudflareRateLimited({
+                status: 429,
+                errors: [{ code: 10000, message: "rate limited" }],
+              }),
+            ),
+            [],
+          ),
+        );
+
+        expect(Result.isFailure(result)).toBe(true);
+        if (Result.isFailure(result)) {
+          expect(result.failure._tag).toBe("CloudflareRateLimited");
+        }
+      }),
+    );
+  });
+
   describe("normalizeStateDomains", () => {
     // Worker state has gone through three generations: <= beta.44 stored each
     // custom domain as a `{ id, hostname, zoneId }` object; beta.45 – beta.57

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerProvider.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerProvider.test.ts
@@ -1,9 +1,7 @@
 import {
   encodeDurableObjectTags,
-  getObservedHostedDurableObjectClassNames,
   getDurableObjectTagMap,
   normalizeStateDomains,
-  observeWorkerSettingsForMigration,
   resolveWorkerDomain,
   resolveWorkerDomainZone,
   resolveWorkersDev,
@@ -11,111 +9,41 @@ import {
   shouldObserveWorkerCrons,
   shouldObserveWorkerDomains,
   shouldObserveWorkerRoutes,
+  selectWorkerMigrationTags,
   stateCustomDomains,
   stateWorkerDomain,
 } from "@/Cloudflare/Workers/WorkerProvider";
-import * as workers from "@distilled.cloud/cloudflare/workers";
 import { describe, expect, test } from "alchemy-test";
 import * as Effect from "effect/Effect";
-import * as Ref from "effect/Ref";
 import * as Result from "effect/Result";
-import * as Schedule from "effect/Schedule";
 
 describe("WorkerProvider", () => {
-  describe("observeWorkerSettingsForMigration", () => {
-    test("uses only namespaces for classes hosted by this Worker", () => {
-      expect(
-        getObservedHostedDurableObjectClassNames(
-          {
-            ForeignClass: "foreign-namespace-id",
-            SeatConnector: "hosted-namespace-id",
-          },
-          new Set(["SeatConnector"]),
-        ),
-      ).toEqual(["SeatConnector"]);
+  describe("selectWorkerMigrationTags", () => {
+    const precreatedTags = ["alchemy:dos:SeatConnector=SeatConnector"];
+
+    test("prevents a duplicate create migration when precreate settings are missing", () => {
+      const tags = selectWorkerMigrationTags(undefined, precreatedTags, true);
+
+      expect(getDurableObjectTagMap(tags)).toEqual({
+        SeatConnector: "SeatConnector",
+      });
     });
 
-    test.effect(
-      "retries a missing-settings race after precreate proved the DO exists",
-      () =>
-        Effect.gen(function* () {
-          const attempts = yield* Ref.make(0);
-          const observed = {
-            tags: ["alchemy:dos:SeatConnector=SeatConnector"],
-            bindings: [
-              {
-                type: "durable_object_namespace" as const,
-                name: "SeatConnector",
-                className: "SeatConnector",
-                namespaceId: "namespace-id",
-              },
-            ],
-          } satisfies workers.GetScriptScriptAndVersionSettingResponse;
-          const read = Ref.updateAndGet(attempts, (count) => count + 1).pipe(
-            Effect.flatMap((attempt) =>
-              attempt === 1
-                ? Effect.fail(
-                    new workers.WorkerHasNoVersions({
-                      code: 10007,
-                      message: "Worker has no versions",
-                    }),
-                  )
-                : Effect.succeed(observed),
-            ),
-          );
+    test("keeps observed settings authoritative during create", () => {
+      const tags = selectWorkerMigrationTags(
+        { tags: [] },
+        precreatedTags,
+        true,
+      );
 
-          const settings = yield* observeWorkerSettingsForMigration(
-            read,
-            ["SeatConnector"],
-            Schedule.recurs(1),
-          );
+      expect(tags).toEqual([]);
+    });
 
-          expect(settings).toBe(observed);
-          expect(yield* Ref.get(attempts)).toBe(2);
-        }),
-    );
+    test("ignores cached tags on update when settings are missing", () => {
+      const tags = selectWorkerMigrationTags(undefined, precreatedTags, false);
 
-    test.effect(
-      "keeps a missing script as a greenfield create without a precreated DO",
-      () =>
-        Effect.gen(function* () {
-          const settings = yield* observeWorkerSettingsForMigration(
-            Effect.fail(
-              new workers.WorkerNotFound({
-                code: 10007,
-                message: "Worker not found",
-              }),
-            ),
-            [],
-          );
-
-          expect(settings).toBeUndefined();
-        }),
-    );
-
-    test.effect(
-      "fails closed when settings stay missing after a precreated DO",
-      () =>
-        Effect.gen(function* () {
-          const result = yield* Effect.result(
-            observeWorkerSettingsForMigration(
-              Effect.fail(
-                new workers.WorkerHasNoVersions({
-                  code: 10007,
-                  message: "Worker has no versions",
-                }),
-              ),
-              ["SeatConnector"],
-              Schedule.recurs(0),
-            ),
-          );
-
-          expect(Result.isFailure(result)).toBe(true);
-          if (Result.isFailure(result)) {
-            expect(result.failure._tag).toBe("WorkerHasNoVersions");
-          }
-        }),
-    );
+      expect(tags).toEqual([]);
+    });
   });
 
   describe("normalizeStateDomains", () => {

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerProvider.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerProvider.test.ts
@@ -2,6 +2,7 @@ import {
   encodeDurableObjectTags,
   getDurableObjectTagMap,
   normalizeStateDomains,
+  planDurableObjectClassMigration,
   resolveWorkerDomain,
   resolveWorkerDomainZone,
   resolveWorkersDev,
@@ -19,13 +20,21 @@ import * as Result from "effect/Result";
 
 describe("WorkerProvider", () => {
   describe("selectWorkerMigrationTags", () => {
-    const precreatedTags = ["alchemy:dos:SeatConnector=SeatConnector"];
+    const precreatedTags = [
+      "alchemy:dos:ExampleDurableObject=ExampleDurableObject",
+    ];
 
     test("prevents a duplicate create migration when precreate settings are missing", () => {
       const tags = selectWorkerMigrationTags(undefined, precreatedTags, true);
+      const previousClassNames = getDurableObjectTagMap(tags);
+      const migration = planDurableObjectClassMigration({
+        previousClassName: previousClassNames.ExampleDurableObject,
+        className: "ExampleDurableObject",
+      });
 
-      expect(getDurableObjectTagMap(tags)).toEqual({
-        SeatConnector: "SeatConnector",
+      expect(migration.newSqliteClasses).toEqual([]);
+      expect(previousClassNames).toEqual({
+        ExampleDurableObject: "ExampleDurableObject",
       });
     });
 
@@ -43,6 +52,46 @@ describe("WorkerProvider", () => {
       const tags = selectWorkerMigrationTags(undefined, precreatedTags, false);
 
       expect(tags).toEqual([]);
+    });
+
+    test("classifies new, renamed, and transferred classes", () => {
+      expect(
+        planDurableObjectClassMigration({
+          previousClassName: undefined,
+          className: "NewClass",
+        }),
+      ).toEqual({
+        newSqliteClasses: ["NewClass"],
+        renamedClasses: [],
+        transferredClasses: [],
+      });
+      expect(
+        planDurableObjectClassMigration({
+          previousClassName: "OldClass",
+          className: "RenamedClass",
+        }),
+      ).toEqual({
+        newSqliteClasses: [],
+        renamedClasses: [{ from: "OldClass", to: "RenamedClass" }],
+        transferredClasses: [],
+      });
+      expect(
+        planDurableObjectClassMigration({
+          previousClassName: undefined,
+          className: "MovedClass",
+          fromScript: "former-host",
+        }),
+      ).toEqual({
+        newSqliteClasses: [],
+        renamedClasses: [],
+        transferredClasses: [
+          {
+            from: "MovedClass",
+            fromScript: "former-host",
+            to: "MovedClass",
+          },
+        ],
+      });
     });
   });
 

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerProvider.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerProvider.test.ts
@@ -2,7 +2,6 @@ import {
   encodeDurableObjectTags,
   getDurableObjectTagMap,
   normalizeStateDomains,
-  planDurableObjectClassMigration,
   resolveWorkerDomain,
   resolveWorkerDomainZone,
   resolveWorkersDev,
@@ -10,7 +9,6 @@ import {
   shouldObserveWorkerCrons,
   shouldObserveWorkerDomains,
   shouldObserveWorkerRoutes,
-  selectWorkerMigrationTags,
   stateCustomDomains,
   stateWorkerDomain,
 } from "@/Cloudflare/Workers/WorkerProvider";
@@ -19,82 +17,6 @@ import * as Effect from "effect/Effect";
 import * as Result from "effect/Result";
 
 describe("WorkerProvider", () => {
-  describe("selectWorkerMigrationTags", () => {
-    const precreatedTags = [
-      "alchemy:dos:ExampleDurableObject=ExampleDurableObject",
-    ];
-
-    test("prevents a duplicate create migration when precreate settings are missing", () => {
-      const tags = selectWorkerMigrationTags(undefined, precreatedTags, true);
-      const previousClassNames = getDurableObjectTagMap(tags);
-      const migration = planDurableObjectClassMigration({
-        previousClassName: previousClassNames.ExampleDurableObject,
-        className: "ExampleDurableObject",
-      });
-
-      expect(migration.newSqliteClasses).toEqual([]);
-      expect(previousClassNames).toEqual({
-        ExampleDurableObject: "ExampleDurableObject",
-      });
-    });
-
-    test("keeps observed settings authoritative during create", () => {
-      const tags = selectWorkerMigrationTags(
-        { tags: [] },
-        precreatedTags,
-        true,
-      );
-
-      expect(tags).toEqual([]);
-    });
-
-    test("ignores cached tags on update when settings are missing", () => {
-      const tags = selectWorkerMigrationTags(undefined, precreatedTags, false);
-
-      expect(tags).toEqual([]);
-    });
-
-    test("classifies new, renamed, and transferred classes", () => {
-      expect(
-        planDurableObjectClassMigration({
-          previousClassName: undefined,
-          className: "NewClass",
-        }),
-      ).toEqual({
-        newSqliteClasses: ["NewClass"],
-        renamedClasses: [],
-        transferredClasses: [],
-      });
-      expect(
-        planDurableObjectClassMigration({
-          previousClassName: "OldClass",
-          className: "RenamedClass",
-        }),
-      ).toEqual({
-        newSqliteClasses: [],
-        renamedClasses: [{ from: "OldClass", to: "RenamedClass" }],
-        transferredClasses: [],
-      });
-      expect(
-        planDurableObjectClassMigration({
-          previousClassName: undefined,
-          className: "MovedClass",
-          fromScript: "former-host",
-        }),
-      ).toEqual({
-        newSqliteClasses: [],
-        renamedClasses: [],
-        transferredClasses: [
-          {
-            from: "MovedClass",
-            fromScript: "former-host",
-            to: "MovedClass",
-          },
-        ],
-      });
-    });
-  });
-
   describe("normalizeStateDomains", () => {
     // Worker state has gone through three generations: <= beta.44 stored each
     // custom domain as a `{ id, hostname, zoneId }` object; beta.45 – beta.57


### PR DESCRIPTION
Fixes #1296.

Precreate uploads a stub that registers a Worker's Durable Object classes, then reconcile reads the script settings to learn which classes already exist. Under load that read can 404 "has no versions" even though precreate just observed the class, so migration planning sent `new_sqlite_classes` for the same class again:

```text
Cannot apply new-sqlite-class migration to class 'Counter' that is already depended on by existing Durable Objects
```

When attributes for the script are already held, retry the read briefly before concluding there are no existing settings:

```ts
Effect.retry({
  while: (error) =>
    output !== undefined &&
    (error._tag === "WorkerNotFound" ||
      error._tag === "WorkerHasNoVersions" ||
      error._tag === "DispatchNamespaceScriptNotFound" ||
      error._tag === "DispatchNamespaceNotFound"),
  schedule: Schedule.max([Schedule.exponential(250), Schedule.recurs(6)]),
}),
```

A worker that really is gone still falls through to the upsert after ~16s, so out-of-band deletion self-heals as before.

`DurableObjectPrecreateRace.test.ts` deploys a Durable Object Worker against the real API and answers the two settings reads after precreate with 404 "has no versions".

