### PR TITLE
fix(cloudflare/workers): preserve adoption checks with unresolved bindings

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -18,12 +18,19 @@ import { Unowned } from "../../AdoptPolicy.ts";
 import * as Artifacts from "../../Artifacts.ts";
 import type { ScopedPlanStatusSession } from "../../Cli/Cli.ts";
 import { hashDirectory, type MemoOptions } from "../../Command/Memo.ts";
-import { havePropsChanged, isResolved, stripEffects } from "../../Diff.ts";
+import {
+  havePropsChanged,
+  isResolved,
+  stripEffects,
+  stripUnresolved,
+} from "../../Diff.ts";
+import type { Input } from "../../Input.ts";
 import * as ProviderLayer from "../../Local/ProviderLayer.ts";
 import * as Provider from "../../Provider.ts";
 import { type ResourceBinding } from "../../Resource.ts";
 import { Stack } from "../../Stack.ts";
 import { cachedFunction } from "../../Util/cached-function.ts";
+import { isPlainData } from "../../Util/data.ts";
 import { initialCwd } from "../../Util/Node.ts";
 import { sha256Object } from "../../Util/sha256.ts";
 import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
@@ -212,6 +219,77 @@ export const resolveVersionParentName = (
   if (typeof parent === "string") return parent;
   const workerName = (parent as { workerName?: unknown }).workerName;
   return typeof workerName === "string" ? workerName : undefined;
+};
+
+type WorkerReadInput = {
+  [K in keyof WorkerProps]?: Input<WorkerProps[K]>;
+};
+
+/**
+ * Project desired Worker props for a cold adoption read. Script name,
+ * dispatch namespace, and version parent determine which cloud resource is
+ * read, so each must already have a concrete identity. Other unresolved
+ * leaves, such as bindings in `env`, are safe to omit from the read.
+ *
+ * Domain, route, and cron props control optional observation calls. Keep each
+ * surface only when its complete declaration is resolved; reconcile performs
+ * the forced adoption update from the original desired props afterward.
+ *
+ * @internal exported for unit testing.
+ */
+export const resolveWorkerReadProps = (
+  news: Input<WorkerProps>,
+): Option.Option<WorkerProps> => {
+  if (!isPlainData(news) || Array.isArray(news)) return Option.none();
+  const desired = news as WorkerReadInput;
+
+  const name = desired.name;
+  if (name !== undefined && typeof name !== "string") return Option.none();
+
+  const namespace = desired.namespace;
+  let namespaceName: string | undefined;
+  if (namespace != null) {
+    if (
+      typeof namespace !== "string" &&
+      (!isPlainData(namespace) || Array.isArray(namespace))
+    ) {
+      return Option.none();
+    }
+    namespaceName = resolveNamespaceName(namespace);
+    if (typeof namespaceName !== "string") return Option.none();
+  }
+
+  const version = desired.version;
+  let parentName: string | undefined;
+  if (version != null) {
+    if (!isPlainData(version) || Array.isArray(version)) return Option.none();
+    const parent = version.parent;
+    if (parent != null) {
+      parentName =
+        typeof parent === "string"
+          ? parent
+          : isPlainData(parent) && !Array.isArray(parent)
+            ? typeof parent.workerName === "string"
+              ? parent.workerName
+              : undefined
+            : undefined;
+      if (parentName === undefined) return Option.none();
+    }
+  }
+
+  const projected = stripUnresolved(desired) as WorkerProps;
+  projected.name = name;
+  projected.namespace = namespaceName;
+  if (parentName === undefined) {
+    delete projected.version;
+  } else {
+    projected.version = { parent: parentName };
+  }
+  if (!isResolved(desired.domain)) delete projected.domain;
+  if (!isResolved(desired.routes)) delete projected.routes;
+  if (!isResolved(desired.crons)) delete projected.crons;
+
+  return Option.some(projected);
 };
 
 /**
@@ -4229,6 +4307,7 @@ export const LiveWorkerProvider = () =>
 
       return Worker.Provider.of({
         stables: ["workerId", "workerName"],
+        resolveReadProps: resolveWorkerReadProps,
         list: () =>
           Effect.gen(function* () {
             const { accountId } = yield* yield* CloudflareEnvironment;

--- a/packages/alchemy/src/Plan.ts
+++ b/packages/alchemy/src/Plan.ts
@@ -1165,13 +1165,10 @@ export const make = <A>(
             // update keeps the deploy idempotent: if cloud state already
             // matches news, the provider's update is a no-op write.
             //
-            // Skip the adoption probe entirely when `news` still contains
-            // unresolved upstream Outputs (e.g. a `streamArn` referencing
-            // a stream being created in the same plan). Calling `read` with
-            // an unresolved value would surface as `ParseError` from the
-            // SDK protocol layer. Resources whose props depend on
-            // not-yet-created upstreams cannot themselves be pre-existing
-            // — there's nothing to adopt.
+            // Providers may opt into cold reads with unresolved desired props
+            // by projecting them to a safe shape. The projection owns the
+            // provider-specific distinction between identity and unrelated
+            // inputs. Without one, unresolved props skip the probe as before.
             // A resource declared at a former FQN whose row just migrated
             // away is genuinely NEW by declaration — skip the probe. Its
             // predecessor's physical resource still carries tags branded
@@ -1180,10 +1177,25 @@ export const make = <A>(
             // and silently adopt the very resource that was renamed away.
             const reusesMigratedFqn = migratedRowFqns.has(fqn);
             let forceUpdateAfterAdoption = false;
+            const readProps =
+              oldState === undefined && provider.read && !reusesMigratedFqn
+                ? isResolved(news)
+                  ? Option.some(news)
+                  : (provider.resolveReadProps?.(news) ?? Option.none())
+                : Option.none();
+            if (Option.isSome(readProps) && !isResolved(readProps.value)) {
+              return yield* Effect.die(
+                new Error(
+                  `Provider '${resource.Type}' returned unresolved props from ` +
+                    `resolveReadProps for '${fqn}'. The hook must return fully ` +
+                    "resolved props or None.",
+                ),
+              );
+            }
             if (
               oldState === undefined &&
               provider.read &&
-              isResolved(news) &&
+              Option.isSome(readProps) &&
               !reusesMigratedFqn
             ) {
               const adoptInstanceId = yield* generateInstanceId();
@@ -1192,7 +1204,7 @@ export const make = <A>(
                   id,
                   fqn,
                   instanceId: adoptInstanceId,
-                  olds: news,
+                  olds: readProps.value,
                   output: undefined,
                 })
                 .pipe(providePlanScope(fqn, adoptInstanceId));

--- a/packages/alchemy/src/Provider.ts
+++ b/packages/alchemy/src/Provider.ts
@@ -242,6 +242,13 @@ export interface ProviderService<
     output: Res["Attributes"] | undefined; // current state -> synced state
   }): Effect.Effect<Res["Attributes"] | undefined, any, ReadReq>;
   /**
+   * Projects unresolved desired props into a safe, resolved shape for a cold
+   * adoption read. Return `None` when any physical-identity input needed by
+   * {@link read} is still unresolved. Providers without this hook retain the
+   * default behavior of skipping cold reads until all desired props resolve.
+   */
+  resolveReadProps?(news: Input<Props<Res>>): Option.Option<Props<Res>>;
+  /**
    * Properties that are always stable across any update.
    */
   stables?: Extract<keyof Res["Attributes"], string>[];

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerProvider.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerProvider.test.ts
@@ -2,6 +2,7 @@ import {
   encodeDurableObjectTags,
   getDurableObjectTagMap,
   normalizeStateDomains,
+  resolveWorkerReadProps,
   resolveWorkerDomain,
   resolveWorkerDomainZone,
   resolveWorkersDev,
@@ -12,11 +13,89 @@ import {
   stateCustomDomains,
   stateWorkerDomain,
 } from "@/Cloudflare/Workers/WorkerProvider";
+import type { WorkerProps } from "@/Cloudflare/Workers/Worker";
+import { isResolved } from "@/Diff";
+import * as Output from "@/Output";
 import { describe, expect, test } from "alchemy-test";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import * as Result from "effect/Result";
 
 describe("WorkerProvider", () => {
+  describe("resolveWorkerReadProps", () => {
+    test("keeps an explicit name while stripping an unresolved env binding", () => {
+      const result = resolveWorkerReadProps({
+        name: "existing-worker",
+        env: { DATABASE: Output.literal("database-id") },
+        domain: "app.example.com",
+        routes: [{ pattern: "app.example.com/*" }],
+        crons: ["0 * * * *"],
+      });
+
+      expect(Option.isSome(result)).toBe(true);
+      if (Option.isSome(result)) {
+        expect(isResolved(result.value)).toBe(true);
+        expect(result.value.name).toBe("existing-worker");
+        expect(result.value.env?.DATABASE).toBeUndefined();
+        expect(result.value.domain).toBe("app.example.com");
+        expect(result.value.routes).toEqual([{ pattern: "app.example.com/*" }]);
+        expect(result.value.crons).toEqual(["0 * * * *"]);
+      }
+    });
+
+    test("projects resolved namespace and version parent identities", () => {
+      const namespace = resolveWorkerReadProps({
+        name: "user-worker",
+        namespace: "customer-workers",
+      });
+      const version = resolveWorkerReadProps({
+        version: { parent: "parent-worker" },
+      });
+
+      expect(Option.isSome(namespace)).toBe(true);
+      expect(Option.isSome(version)).toBe(true);
+      if (Option.isSome(namespace)) {
+        expect(namespace.value.namespace).toBe("customer-workers");
+      }
+      if (Option.isSome(version)) {
+        expect(version.value.version).toEqual({ parent: "parent-worker" });
+      }
+    });
+
+    test("returns None when a Worker identity input is unresolved", () => {
+      const unresolved = Output.literal("unresolved");
+      const results = [
+        resolveWorkerReadProps({ name: unresolved }),
+        resolveWorkerReadProps({ namespace: unresolved }),
+        resolveWorkerReadProps({
+          namespace: {
+            name: unresolved,
+          } as unknown as WorkerProps["namespace"],
+        }),
+        resolveWorkerReadProps({ version: { parent: unresolved } }),
+      ];
+
+      expect(results.every(Option.isNone)).toBe(true);
+    });
+
+    test("omits unresolved optional observation surfaces", () => {
+      const unresolved = Output.literal("unresolved");
+      const result = resolveWorkerReadProps({
+        name: "existing-worker",
+        domain: unresolved,
+        routes: [{ pattern: unresolved }],
+        crons: [unresolved],
+      });
+
+      expect(Option.isSome(result)).toBe(true);
+      if (Option.isSome(result)) {
+        expect(result.value.domain).toBeUndefined();
+        expect(result.value.routes).toBeUndefined();
+        expect(result.value.crons).toBeUndefined();
+      }
+    });
+  });
+
   describe("normalizeStateDomains", () => {
     // Worker state has gone through three generations: <= beta.44 stored each
     // custom domain as a `{ id, hostname, zoneId }` object; beta.45 – beta.57

--- a/packages/alchemy/test/plan.test.ts
+++ b/packages/alchemy/test/plan.test.ts
@@ -2983,13 +2983,20 @@ describe("engine-level adoption", () => {
       readHook?: (
         id: string,
       ) => Effect.Effect<TestResource["Attributes"] | undefined, any>;
+      resolveReadProps?: (
+        news: Input<TestResourceProps>,
+      ) => Option.Option<TestResourceProps>;
     },
   ): Effect.Effect<Plan.Plan<A>, any, State> =>
     Effect.gen(function* () {
       const { name, stage } = yield* resolveStackId;
-      const hooksLayer = opts.readHook
-        ? Layer.succeed(TestResourceHooks, { read: opts.readHook })
-        : Layer.empty;
+      const hooksLayer =
+        opts.readHook || opts.resolveReadProps
+          ? Layer.succeed(TestResourceHooks, {
+              read: opts.readHook,
+              resolveReadProps: opts.resolveReadProps,
+            })
+          : Layer.empty;
       const adoptLayer =
         opts.adopt === undefined
           ? Layer.empty
@@ -3312,6 +3319,158 @@ describe("engine-level adoption", () => {
         const reason = exit.cause.reasons.find(Cause.isFailReason);
         expect((reason?.error as any)?._tag).toBe("OwnedBySomeoneElse");
         expect((reason?.error as any)?.resourceType).toBe("Test.TestResource");
+      }
+    }),
+  );
+
+  test(
+    "providers without a read projection skip unresolved cold reads",
+    Effect.gen(function* () {
+      let read = false;
+      const plan = yield* makeAdoptPlan(
+        Effect.gen(function* () {
+          const upstream = yield* TestResource("Upstream", { string: "up" });
+          yield* TestResource("Unresolved", { string: upstream.string });
+        }),
+        {
+          readHook: (id) =>
+            Effect.sync(() => {
+              if (id === "Unresolved") read = true;
+              return undefined;
+            }),
+        },
+      );
+
+      expect(read).toBe(false);
+      expect(plan.resources.Unresolved!.action).toBe("create");
+    }),
+  );
+
+  test(
+    "projected read props permit ownership rejection and adoption",
+    Effect.gen(function* () {
+      const program = Effect.gen(function* () {
+        const upstream = yield* TestResource("Upstream", { string: "up" });
+        yield* TestResource("Projected", {
+          replaceString: "existing-worker",
+          string: upstream.string,
+        });
+      });
+      const readHook = (id: string) =>
+        id === "Projected"
+          ? Effect.succeed(Unowned(ownedAttrs))
+          : Effect.succeed(undefined);
+      const resolveReadProps = (news: Input<TestResourceProps>) => {
+        const desired = news as { replaceString?: Input<string> };
+        return desired.replaceString === "existing-worker"
+          ? Option.some({ replaceString: desired.replaceString })
+          : Option.none();
+      };
+
+      const rejected = yield* makeAdoptPlan(program, {
+        adopt: false,
+        readHook,
+        resolveReadProps,
+      }).pipe(Effect.exit);
+      expect(Exit.isFailure(rejected)).toBe(true);
+      if (Exit.isFailure(rejected)) {
+        const reason = rejected.cause.reasons.find(Cause.isFailReason);
+        expect((reason?.error as any)?._tag).toBe("OwnedBySomeoneElse");
+      }
+
+      const plan = yield* makeAdoptPlan(program, {
+        adopt: true,
+        readHook,
+        resolveReadProps,
+      });
+      expect(plan.resources.Projected).toMatchObject({
+        action: "update",
+        adopting: true,
+        state: { status: "created" },
+      });
+      expect(plan.resources.Upstream!.action).toBe("create");
+    }),
+  );
+
+  test(
+    "a read projection returning None skips the cold read",
+    Effect.gen(function* () {
+      const plan = yield* makeAdoptPlan(
+        Effect.gen(function* () {
+          const upstream = yield* TestResource("Upstream", { string: "up" });
+          yield* TestResource("Fresh", { replaceString: upstream.string });
+        }),
+        {
+          readHook: (id) =>
+            id === "Fresh"
+              ? Effect.die(new Error("read should not run"))
+              : Effect.succeed(undefined),
+          resolveReadProps: () => Option.none(),
+        },
+      );
+
+      expect(plan.resources.Fresh!.action).toBe("create");
+      expect(plan.resources.Fresh!.state).toBeUndefined();
+    }),
+  );
+
+  test(
+    "projected cold-read errors remain fatal",
+    Effect.gen(function* () {
+      const readError = new Error("read failed");
+      const exit = yield* makeAdoptPlan(
+        Effect.gen(function* () {
+          const upstream = yield* TestResource("Upstream", { string: "up" });
+          yield* TestResource("Broken", { string: upstream.string });
+        }),
+        {
+          readHook: (id) =>
+            id === "Broken"
+              ? Effect.fail(readError)
+              : Effect.succeed(undefined),
+          resolveReadProps: () => Option.some({}),
+        },
+      ).pipe(Effect.exit);
+
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isFailure(exit)) {
+        const reason = exit.cause.reasons.find(Cause.isFailReason);
+        expect(reason?.error).toBe(readError);
+      }
+    }),
+  );
+
+  test(
+    "an unresolved Some projection fails closed before read",
+    Effect.gen(function* () {
+      let read = false;
+      const exit = yield* makeAdoptPlan(
+        Effect.gen(function* () {
+          const upstream = yield* TestResource("Upstream", { string: "up" });
+          yield* TestResource("InvalidProjection", {
+            string: upstream.string,
+          });
+        }),
+        {
+          readHook: (id) =>
+            Effect.sync(() => {
+              if (id === "InvalidProjection") read = true;
+              return undefined;
+            }),
+          resolveReadProps: () =>
+            Option.some({
+              string: Output.literal("still-unresolved"),
+            } as unknown as TestResourceProps),
+        },
+      ).pipe(Effect.exit);
+
+      expect(read).toBe(false);
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isFailure(exit)) {
+        const reason = exit.cause.reasons.find(Cause.isDieReason);
+        expect(String(reason?.defect)).toContain(
+          "returned unresolved props from resolveReadProps",
+        );
       }
     }),
   );

--- a/packages/alchemy/test/test.resources.ts
+++ b/packages/alchemy/test/test.resources.ts
@@ -2,6 +2,7 @@ import { Unowned } from "@/AdoptPolicy";
 import { AlchemyContext } from "@/AlchemyContext.ts";
 import { Artifacts } from "@/Artifacts";
 import { isResolved } from "@/Diff.ts";
+import type { Input } from "@/Input.ts";
 import * as ProviderLayer from "@/Local/ProviderLayer.ts";
 import * as Provider from "@/Provider.ts";
 import { LOCAL_ID_PREFIX, type ProviderMode } from "@/ProviderMode.ts";
@@ -362,6 +363,9 @@ export class TestResourceHooks extends Context.Service<
     read?: (
       id: string,
     ) => Effect.Effect<TestResource["Attributes"] | undefined, any>;
+    resolveReadProps?: (
+      news: Input<TestResourceProps>,
+    ) => Option.Option<TestResourceProps>;
   }
 >()("TestResourceHooks") {}
 
@@ -371,7 +375,13 @@ export const testResourceProvider = () =>
   Provider.effect(
     TestResource,
     Effect.gen(function* () {
+      const hooks = Option.getOrUndefined(
+        yield* Effect.serviceOption(TestResourceHooks),
+      );
       return {
+        ...(hooks?.resolveReadProps
+          ? { resolveReadProps: hooks.resolveReadProps }
+          : undefined),
         list: () => Effect.succeed([]),
         read: Effect.fn(function* ({ id, output }) {
           const hooks = Option.getOrUndefined(


### PR DESCRIPTION
## TL;DR

A fresh Worker with resource-backed `env` bindings skipped its ownership read and planned `create`, allowing reconcile to upsert an existing foreign script without `AdoptPolicy`. This adds provider-owned read projections so Workers can probe a resolved physical identity while unresolved non-identity bindings remain deferred.

**Files to review (6, +359 / -13):**

| File | Why |
|---|---|
| `packages/alchemy/src/Plan.ts` *(start here)* | Applies projections only during unresolved cold-adoption reads and validates that projected props are fully resolved. |
| `packages/alchemy/src/Provider.ts` | Defines the optional provider projection contract. |
| `packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts` | Projects Worker identity and safe observation inputs without resolving bindings. |
| `packages/alchemy/test/plan.test.ts` | Covers ownership rejection, explicit adoption, default behavior, read failures, and invalid projections. |
| `packages/alchemy/test/Cloudflare/Workers/WorkerProvider.test.ts` | Covers Worker name, namespace, version-parent, and optional observation inputs. |
| `packages/alchemy/test/test.resources.ts` | Exposes the provider hook to planner lifecycle tests. |

## Why

Before this change, an existing Worker named `www` with fresh D1, Images, Email, and secret bindings produced:

```text
Plan: 1 to create
[Website] create
[Website/EMAIL] create
[Website/IMAGES] create
[Website/TURNSTILE_SECRET_KEY] create
[Website/WAITLIST_DB] create
```

The unresolved bindings made the complete desired props fail `isResolved`, so planning skipped `provider.read`. Worker precreate and reconcile later resolved the explicit name and could overwrite the foreign script through the normal upsert path.

## How

1. Providers may opt into unresolved cold reads by projecting desired props to the resolved subset their `read` operation needs.
2. Planning rejects any `Some` projection that still contains unresolved values, and provider read errors propagate unchanged.
3. The Worker provider requires concrete script-name, dispatch-namespace, and version-parent identities. It strips unresolved bindings and omits optional domain, route, or cron observation surfaces only when those declarations are unresolved.

## Reviewer notes

- **Existing providers keep the old gate.** Providers without `resolveReadProps` still skip cold reads whenever desired props are unresolved.
- **Identity stays fail-closed.** An unresolved Worker name, nested namespace name, or version parent returns `None`; the planner never guesses a physical resource.
- **Reconcile keeps full desired props.** The projection is read-only. Adoption still forces an update using the original desired configuration and bindings.
- **No read-error fallback.** Authentication, permission, schema, and API failures stop planning instead of degrading to create.

## Tests

- `pnpm exec tsc -b`
- `timeout 240 pnpm test test/plan.test.ts --profile testing` — 163 passed
- `timeout 240 pnpm test test/Cloudflare/Workers/WorkerProvider.test.ts --profile testing` — 44 passed
- `pnpm lint:providers`
- `pnpm format:check`

No live Cloudflare test was run. Generic planner lifecycle tests and Worker projection tests cover the ownership and provider-specific halves independently.

## Links

- Closes #1299
