### PR TITLE
fix(release): keep validator logs out of GITHUB_OUTPUT

### DIFF
--- a/scripts/release/prepare.ts
+++ b/scripts/release/prepare.ts
@@ -119,7 +119,10 @@ await writeFile(
 );
 
 await $`pnpm install --lockfile-only`.cwd(root).quiet();
-await $`bun validate:publish-packages`.cwd(root);
+// stdout is piped into $GITHUB_OUTPUT by the workflow, so keep subcommand
+// logs on stderr — only the key=value lines below may reach stdout.
+const validation = await $`bun validate:publish-packages`.cwd(root).quiet();
+console.error(validation.stdout.toString().trimEnd());
 
 const tag = forceLatest
   ? "latest"


### PR DESCRIPTION
The Release workflow's `Prepare release` step pipes `prepare.ts` stdout into `$GITHUB_OUTPUT`, so the validator's log line broke output parsing and failed the run ([run 32513416735](https://github.com/alchemy-run/alchemy/actions/runs/32513416735/job/96869531848)):

```
##[error]Unable to process file command 'output' successfully.
##[error]Invalid format 'Validated 7 publishable packages at 2.0.0-beta.73'
```

Run the validator quiet and re-emit its output on stderr, so only the `version=`/`channel=`/`tag=` lines reach stdout:

```diff
-await $`bun validate:publish-packages`.cwd(root);
+const validation = await $`bun validate:publish-packages`.cwd(root).quiet();
+console.error(validation.stdout.toString().trimEnd());
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
