### PR TITLE
fix(release): fetch distilled submodule in the Publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,9 @@ jobs:
         with:
           ref: ${{ needs.build.outputs.sha }}
           fetch-depth: 0
+          # pnpm needs the distilled submodule (workspace member); the root
+          # `prepare` script also builds distilled/packages/cloudflare.
+          submodules: true
 
       - name: Setup pnpm, Node.js, Bun
         uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2


### PR DESCRIPTION
The Publish job failed at `pnpm install --frozen-lockfile` ([run 32514175029](https://github.com/alchemy-run/alchemy/actions/runs/32514175029/job/96873212022)) because its checkout doesn't fetch the `distilled` submodule, and the root `prepare` script builds it:

```
. prepare: error TS6053: File '.../distilled/packages/cloudflare/tsconfig.json' not found.
```

Add `submodules: true` to the Publish job checkout — same as the build job and every other workflow that runs `pnpm install`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
