### PR TITLE
docs: install alchemy@latest and effect@rc

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ One `ReadWriteBucket(Bucket)` call wires the binding, env var, and typed client 
 - **Same code, every stage.** Local dev, `plan` / `deploy`, smoke tests, and CI all share one mental model.
 
 ```sh
-bun add alchemy@next effect@next
+bun add alchemy@latest effect@next
 ```
 
 ## GitHub Action

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ One `ReadWriteBucket(Bucket)` call wires the binding, env var, and typed client 
 - **Same code, every stage.** Local dev, `plan` / `deploy`, smoke tests, and CI all share one mental model.
 
 ```sh
-bun add alchemy@latest effect@next
+bun add alchemy@latest effect@rc
 ```
 
 ## GitHub Action

--- a/website/src/content/docs/aws/setup.mdx
+++ b/website/src/content/docs/aws/setup.mdx
@@ -6,7 +6,7 @@ description: Install Alchemy and connect it to your AWS account — SSO, environ
 import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 import { effectVersion } from "../../../versions";
 
-export const pkgs = `"alchemy@next" "effect@${effectVersion}" "@effect/platform-bun@${effectVersion}" "@effect/platform-node@${effectVersion}"`;
+export const pkgs = `"alchemy@latest" "effect@${effectVersion}" "@effect/platform-bun@${effectVersion}" "@effect/platform-node@${effectVersion}"`;
 
 ## Prerequisites
 

--- a/website/src/content/docs/aws/tutorial/part-1.mdx
+++ b/website/src/content/docs/aws/tutorial/part-1.mdx
@@ -9,7 +9,7 @@ import Terminal from "../../../../components/Terminal.astro";
 import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 import { effectVersion } from "../../../../versions";
 
-export const pkgs = `"alchemy@next" "effect@${effectVersion}" "@effect/platform-bun@${effectVersion}" "@effect/platform-node@${effectVersion}"`;
+export const pkgs = `"alchemy@latest" "effect@${effectVersion}" "@effect/platform-bun@${effectVersion}" "@effect/platform-node@${effectVersion}"`;
 
 In this first part you'll install Alchemy and Effect, create a Stack
 with an AWS S3 Bucket, and deploy it — all in under five minutes.
@@ -41,7 +41,7 @@ Start with an empty directory and initialize a `package.json`:
 
 ## Install dependencies
 
-Install <code>alchemy@next</code> and <code>effect@{effectVersion}</code>:
+Install <code>alchemy@latest</code> and <code>effect@{effectVersion}</code>:
 
 <Tabs syncKey="pkgManager">
   <TabItem label="bun" icon="bun">

--- a/website/src/content/docs/blog/2026-08-20-generating-local-emulators.md
+++ b/website/src/content/docs/blog/2026-08-20-generating-local-emulators.md
@@ -29,7 +29,7 @@ and every red test is a fidelity bug that arrives with its own
 reproduction. This is how `alchemy dev` for AWS works. Your
 stack runs on your machine with no AWS account and no
 credentials. It shipped in
-[2.0.0-beta.73](/blog/2026-08-20-beta-73).
+[2.0.0-beta.74](/blog/2026-08-21-beta-74).
 
 ## We forked floci
 
@@ -128,7 +128,7 @@ built on workerd itself and held to the same live suites. AWS
 now joins it. The next provider the factory brings up will ship
 all three artifacts together.
 
-- [2.0.0-beta.73 — the release AWS local dev shipped in](/blog/2026-08-20-beta-73)
+- [2.0.0-beta.74 — the release AWS local dev shipped in](/blog/2026-08-21-beta-74)
 - [AWS local development](/aws/local-development)
 - [Looping the Generation of IaC and SDKs — the first post in this series](/blog/2026-07-02-cloudflare-resource-factory)
 - [alchemy-run/floci — the fork](https://github.com/alchemy-run/floci)

--- a/website/src/content/docs/blog/2026-08-21-beta-74.md
+++ b/website/src/content/docs/blog/2026-08-21-beta-74.md
@@ -1,11 +1,11 @@
 ---
-title: 2.0.0-beta.73 - AWS Local Dev, Hetzner & Fly.io
-date: 2026-08-20T09:00:00Z
+title: 2.0.0-beta.74 - AWS Local Dev, Hetzner & Fly.io
+date: 2026-08-21T09:00:00Z
 category: release
-excerpt: v2.0.0-beta.73 brings alchemy dev to AWS — your Lambda, S3, DynamoDB, SQS, ECS, and website stack runs on your machine with hot reload and no credentials — adds Hetzner Cloud and Fly.io providers with Effect-native Service platforms, deploys all six web frameworks to AWS (S3 + CloudFront + streaming Lambda), unifies SQL migrations into one Alchemy-owned format, protects Workers with Cloudflare Access, and makes removal policies persist.
+excerpt: v2.0.0-beta.74 brings alchemy dev to AWS — your Lambda, S3, DynamoDB, SQS, ECS, and website stack runs on your machine with hot reload and no credentials — adds Hetzner Cloud and Fly.io providers with Effect-native Service platforms, deploys all six web frameworks to AWS (S3 + CloudFront + streaming Lambda), unifies SQL migrations into one Alchemy-owned format, protects Workers with Cloudflare Access, and makes removal policies persist.
 ---
 
-beta.73 brings `alchemy dev` to AWS: your Lambda, S3, DynamoDB,
+beta.74 brings `alchemy dev` to AWS: your Lambda, S3, DynamoDB,
 SQS, ECS, and website stack runs **entirely on your machine** —
 no AWS account, no credentials, hot reload in ~100–500ms, and
 each website's framework runs its own dev server with native
@@ -59,6 +59,18 @@ Lambda — with the same interface.
   `KeySchema` list. Existing state upgrades without a
   replacement.
 :::
+
+## alchemy depends on effect@rc
+
+effect 4.0 has moved from beta to release candidates, and alchemy
+now depends on effect's `rc` dist-tag
+([#1245](https://github.com/alchemy-run/alchemy/pull/1245)). The
+minimum peer is `>=4.0.0-rc.110`; install effect and the platform
+packages from the `rc` tag:
+
+```sh
+bun add alchemy@latest effect@rc @effect/platform-bun@rc @effect/platform-node@rc
+```
 
 ## AWS local dev
 
@@ -520,7 +532,7 @@ Docs:
 `RemovalPolicy.retain()` added to an already-deployed resource
 never reached state — the policy is a decoration, not a prop, so
 the noop apply path skipped it, and a later rename or removal
-orphan-deleted the resource anyway. beta.73 persists the policy
+orphan-deleted the resource anyway. beta.74 persists the policy
 on the noop path
 ([#1253](https://github.com/alchemy-run/alchemy/pull/1253)) and
 prints a note whenever a deploy flips one.
@@ -672,5 +684,5 @@ Docs:
 - [AWS frontends](/aws/frontend/websites)
 - [Protect a Worker with Access](/cloudflare/security/access)
 - [SQL](/sql)
-- [CHANGELOG](https://github.com/alchemy-run/alchemy/blob/main/CHANGELOG.md#v200-beta73)
-- [Compare v2.0.0-beta.71 → v2.0.0-beta.73](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.71...v2.0.0-beta.73)
+- [CHANGELOG](https://github.com/alchemy-run/alchemy/blob/main/CHANGELOG.md#v200-beta74)
+- [Compare v2.0.0-beta.71 → v2.0.0-beta.74](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.71...v2.0.0-beta.74)

--- a/website/src/content/docs/cloudflare/setup.mdx
+++ b/website/src/content/docs/cloudflare/setup.mdx
@@ -6,14 +6,14 @@ description: Install Alchemy, create a Cloudflare account, and connect the two â
 import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 import { effectVersion } from "../../../versions";
 
-export const pkgs = `"alchemy@next" "effect@${effectVersion}" "@effect/platform-bun@${effectVersion}" "@effect/platform-node@${effectVersion}"`;
+export const pkgs = `"alchemy@latest" "effect@${effectVersion}" "@effect/platform-bun@${effectVersion}" "@effect/platform-node@${effectVersion}"`;
 
 Everything you need before deploying to Cloudflare: the alchemy
 package, a Cloudflare account, and stored credentials.
 
 ## Install
 
-Install <code>alchemy@next</code> and <code>effect@{effectVersion}</code>
+Install <code>alchemy@latest</code> and <code>effect@{effectVersion}</code>
 in your project:
 
 <Tabs syncKey="pkgManager">

--- a/website/src/content/docs/cloudflare/tutorial/part-1.mdx
+++ b/website/src/content/docs/cloudflare/tutorial/part-1.mdx
@@ -10,7 +10,7 @@ import StateStoreBootstrap from "../../../../components/marketing-islands/StateS
 import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 import { effectVersion } from "../../../../versions";
 
-export const pkgs = `"alchemy@next" "effect@${effectVersion}" "@effect/platform-bun@${effectVersion}" "@effect/platform-node@${effectVersion}"`;
+export const pkgs = `"alchemy@latest" "effect@${effectVersion}" "@effect/platform-bun@${effectVersion}" "@effect/platform-node@${effectVersion}"`;
 
 In this first part you'll install Alchemy and Effect, create a Stack
 with a Cloudflare R2 Bucket, and deploy it — all in under five
@@ -42,7 +42,7 @@ Start with an empty directory and initialize a `package.json`:
 
 ## Install dependencies
 
-Install <code>alchemy@next</code> and <code>effect@{effectVersion}</code>:
+Install <code>alchemy@latest</code> and <code>effect@{effectVersion}</code>:
 
 <Tabs syncKey="pkgManager">
   <TabItem label="bun" icon="bun">

--- a/website/src/content/docs/fly/setup.mdx
+++ b/website/src/content/docs/fly/setup.mdx
@@ -6,7 +6,7 @@ description: Create a Fly org, generate an API token, and store it in a profile.
 import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 import { effectVersion } from "../../../versions";
 
-export const pkgs = `"alchemy@next" "effect@${effectVersion}" "@effect/platform-bun@${effectVersion}" "@effect/platform-node@${effectVersion}"`;
+export const pkgs = `"alchemy@latest" "effect@${effectVersion}" "@effect/platform-bun@${effectVersion}" "@effect/platform-node@${effectVersion}"`;
 
 Everything you need before deploying to Fly.io: the alchemy package,
 a Fly organization, and an API token stored in a profile.

--- a/website/src/content/docs/fly/tutorial/part-1.mdx
+++ b/website/src/content/docs/fly/tutorial/part-1.mdx
@@ -9,7 +9,7 @@ import Terminal from "../../../../components/Terminal.astro";
 import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 import { effectVersion } from "../../../../versions";
 
-export const pkgs = `"alchemy@next" "effect@${effectVersion}" "@effect/platform-bun@${effectVersion}" "@effect/platform-node@${effectVersion}"`;
+export const pkgs = `"alchemy@latest" "effect@${effectVersion}" "@effect/platform-bun@${effectVersion}" "@effect/platform-node@${effectVersion}"`;
 
 Install Alchemy and Effect, create a Stack with a Fly App, and
 deploy it. An App is the parent for Machines, Services, Secrets,
@@ -48,7 +48,7 @@ Start with an empty directory and initialize a `package.json`:
 
 ## Install dependencies
 
-Install <code>alchemy@next</code> and <code>effect@{effectVersion}</code>:
+Install <code>alchemy@latest</code> and <code>effect@{effectVersion}</code>:
 
 <Tabs syncKey="pkgManager">
   <TabItem label="bun" icon="bun">

--- a/website/src/content/docs/getting-started.mdx
+++ b/website/src/content/docs/getting-started.mdx
@@ -7,7 +7,7 @@ import Terminal from "../../components/Terminal.astro";
 import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 import { effectVersion } from "../../versions";
 
-export const pkgs = `"alchemy@next" "effect@${effectVersion}" "@effect/platform-bun@${effectVersion}" "@effect/platform-node@${effectVersion}"`;
+export const pkgs = `"alchemy@latest" "effect@${effectVersion}" "@effect/platform-bun@${effectVersion}" "@effect/platform-node@${effectVersion}"`;
 
 ## Prerequisites
 

--- a/website/src/content/docs/hetzner/setup.mdx
+++ b/website/src/content/docs/hetzner/setup.mdx
@@ -6,7 +6,7 @@ description: Install Alchemy and connect it to Hetzner Cloud — create a projec
 import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 import { effectVersion } from "../../../versions";
 
-export const pkgs = `"alchemy@next" "effect@${effectVersion}" "@effect/platform-bun@${effectVersion}" "@effect/platform-node@${effectVersion}"`;
+export const pkgs = `"alchemy@latest" "effect@${effectVersion}" "@effect/platform-bun@${effectVersion}" "@effect/platform-node@${effectVersion}"`;
 
 Everything you need before deploying to Hetzner Cloud: the alchemy
 package, a Hetzner project, and an API token stored in a profile.

--- a/website/src/content/docs/hetzner/tutorial/part-1.mdx
+++ b/website/src/content/docs/hetzner/tutorial/part-1.mdx
@@ -9,7 +9,7 @@ import Terminal from "../../../../components/Terminal.astro";
 import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 import { effectVersion } from "../../../../versions";
 
-export const pkgs = `"alchemy@next" "effect@${effectVersion}" "@effect/platform-bun@${effectVersion}" "@effect/platform-node@${effectVersion}"`;
+export const pkgs = `"alchemy@latest" "effect@${effectVersion}" "@effect/platform-bun@${effectVersion}" "@effect/platform-node@${effectVersion}"`;
 
 In this first part you'll install Alchemy and Effect, create a Stack
 with a Hetzner Cloud Server, deploy it, and SSH in — all in under
@@ -49,7 +49,7 @@ Start with an empty directory and initialize a `package.json`:
 
 ## Install dependencies
 
-Install <code>alchemy@next</code> and <code>effect@{effectVersion}</code>:
+Install <code>alchemy@latest</code> and <code>effect@{effectVersion}</code>:
 
 <Tabs syncKey="pkgManager">
   <TabItem label="bun" icon="bun">

--- a/website/src/versions.ts
+++ b/website/src/versions.ts
@@ -1,10 +1,6 @@
-import workspaceYaml from "../../pnpm-workspace.yaml?raw";
 import alchemyPkg from "../../packages/alchemy/package.json" with { type: "json" };
-import { parse } from "yaml";
-
-const workspace = parse(workspaceYaml) as {
-  catalogs: { effect: { effect: string } };
-};
 
 export const alchemyVersion = alchemyPkg.version;
-export const effectVersion = workspace.catalogs.effect.effect;
+// effect's npm dist-tag for the 4.0 release candidates (effect@rc,
+// @effect/platform-bun@rc, @effect/platform-node@rc).
+export const effectVersion = "rc";


### PR DESCRIPTION
Point doc install commands at the public dist-tags — `alchemy@latest` (stable releases now publish to `latest`) and `effect@rc` (effect 4.0 release candidates) — and re-cut the beta.73 release notes as beta.74 for the hotfix.

- Replaced every `alchemy@next` across the website docs (getting-started, all provider setup pages, and tutorial part-1 pages) and the README with `alchemy@latest`
- `website/src/versions.ts` now exports the `rc` dist-tag instead of the pinned catalog version, so docs render `effect@rc`, `@effect/platform-bun@rc`, `@effect/platform-node@rc`

```diff
-export const effectVersion = workspace.catalogs.effect.effect; // 4.0.0-rc.110
+export const effectVersion = "rc";
```

- Renamed the release post to `2026-08-21-beta-74.md`, updated all version references to beta.74, added an "alchemy depends on effect@rc" section with the install command, and fixed the links from the local-emulators post

No `@alchemy.run/*@next` references existed, so only the `alchemy` package needed the latest-tag change.
