### PR TITLE
docs(blog): re-cut beta.73 release notes as beta.74 with the effect@rc dependency

### DIFF
--- a/website/src/content/docs/blog/2026-08-20-generating-local-emulators.md
+++ b/website/src/content/docs/blog/2026-08-20-generating-local-emulators.md
@@ -29,7 +29,7 @@ and every red test is a fidelity bug that arrives with its own
 reproduction. This is how `alchemy dev` for AWS works. Your
 stack runs on your machine with no AWS account and no
 credentials. It shipped in
-[2.0.0-beta.73](/blog/2026-08-20-beta-73).
+[2.0.0-beta.74](/blog/2026-08-21-beta-74).
 
 ## We forked floci
 
@@ -128,7 +128,7 @@ built on workerd itself and held to the same live suites. AWS
 now joins it. The next provider the factory brings up will ship
 all three artifacts together.
 
-- [2.0.0-beta.73 — the release AWS local dev shipped in](/blog/2026-08-20-beta-73)
+- [2.0.0-beta.74 — the release AWS local dev shipped in](/blog/2026-08-21-beta-74)
 - [AWS local development](/aws/local-development)
 - [Looping the Generation of IaC and SDKs — the first post in this series](/blog/2026-07-02-cloudflare-resource-factory)
 - [alchemy-run/floci — the fork](https://github.com/alchemy-run/floci)

--- a/website/src/content/docs/blog/2026-08-21-beta-74.md
+++ b/website/src/content/docs/blog/2026-08-21-beta-74.md
@@ -1,11 +1,11 @@
 ---
-title: 2.0.0-beta.73 - AWS Local Dev, Hetzner & Fly.io
-date: 2026-08-20T09:00:00Z
+title: 2.0.0-beta.74 - AWS Local Dev, Hetzner & Fly.io
+date: 2026-08-21T09:00:00Z
 category: release
-excerpt: v2.0.0-beta.73 brings alchemy dev to AWS — your Lambda, S3, DynamoDB, SQS, ECS, and website stack runs on your machine with hot reload and no credentials — adds Hetzner Cloud and Fly.io providers with Effect-native Service platforms, deploys all six web frameworks to AWS (S3 + CloudFront + streaming Lambda), unifies SQL migrations into one Alchemy-owned format, protects Workers with Cloudflare Access, and makes removal policies persist.
+excerpt: v2.0.0-beta.74 brings alchemy dev to AWS — your Lambda, S3, DynamoDB, SQS, ECS, and website stack runs on your machine with hot reload and no credentials — adds Hetzner Cloud and Fly.io providers with Effect-native Service platforms, deploys all six web frameworks to AWS (S3 + CloudFront + streaming Lambda), unifies SQL migrations into one Alchemy-owned format, protects Workers with Cloudflare Access, and makes removal policies persist.
 ---
 
-beta.73 brings `alchemy dev` to AWS: your Lambda, S3, DynamoDB,
+beta.74 brings `alchemy dev` to AWS: your Lambda, S3, DynamoDB,
 SQS, ECS, and website stack runs **entirely on your machine** —
 no AWS account, no credentials, hot reload in ~100–500ms, and
 each website's framework runs its own dev server with native
@@ -59,6 +59,18 @@ Lambda — with the same interface.
   `KeySchema` list. Existing state upgrades without a
   replacement.
 :::
+
+## alchemy depends on effect@rc
+
+effect 4.0 has moved from beta to release candidates, and alchemy
+now depends on effect's `rc` dist-tag
+([#1245](https://github.com/alchemy-run/alchemy/pull/1245)). The
+minimum peer is `>=4.0.0-rc.110`; install effect and the platform
+packages from the `rc` tag:
+
+```sh
+bun add alchemy@latest effect@rc @effect/platform-bun@rc @effect/platform-node@rc
+```
 
 ## AWS local dev
 
@@ -520,7 +532,7 @@ Docs:
 `RemovalPolicy.retain()` added to an already-deployed resource
 never reached state — the policy is a decoration, not a prop, so
 the noop apply path skipped it, and a later rename or removal
-orphan-deleted the resource anyway. beta.73 persists the policy
+orphan-deleted the resource anyway. beta.74 persists the policy
 on the noop path
 ([#1253](https://github.com/alchemy-run/alchemy/pull/1253)) and
 prints a note whenever a deploy flips one.
@@ -672,5 +684,5 @@ Docs:
 - [AWS frontends](/aws/frontend/websites)
 - [Protect a Worker with Access](/cloudflare/security/access)
 - [SQL](/sql)
-- [CHANGELOG](https://github.com/alchemy-run/alchemy/blob/main/CHANGELOG.md#v200-beta73)
-- [Compare v2.0.0-beta.71 → v2.0.0-beta.73](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.71...v2.0.0-beta.73)
+- [CHANGELOG](https://github.com/alchemy-run/alchemy/blob/main/CHANGELOG.md#v200-beta74)
+- [Compare v2.0.0-beta.71 → v2.0.0-beta.74](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.71...v2.0.0-beta.74)


### PR DESCRIPTION
Re-cut the beta.73 release notes as beta.74 — the release is going out as a hotfix under the bumped version.

- Renamed `2026-08-20-beta-73.md` to `2026-08-21-beta-74.md` and updated the title, excerpt, intro, and CHANGELOG/compare links to beta.74
- Added an "alchemy depends on effect@rc" section documenting the move to effect's release-candidate dist-tag:

```sh
bun add alchemy@latest effect@rc @effect/platform-bun@rc @effect/platform-node@rc
```

- Updated the two links in the local-emulators post that pointed at the old `/blog/2026-08-20-beta-73` slug
