### PR TITLE
fix(test): use local providers in actions when local is forced

### DIFF
--- a/packages/alchemy/src/Test/Core.ts
+++ b/packages/alchemy/src/Test/Core.ts
@@ -530,11 +530,12 @@ export const scratchStack = <ROut>(
       ? Layer.succeed(State.State, State.InMemoryService({}))
       : Layer.provide(State.localState(), PlatformServices);
 
-  // `withProviders` already pins test-body distilled to Floci, but the stack
-  // *program* is composed under `AWS.providers()`'s live Endpoint. Dual
-  // providers still hit Floci in lifecycle ops; user-program distilled
-  // (e.g. ECS Service `findHostedZoneId`) would otherwise query real AWS.
-  const pinProgramToFloci = <A, E, R>(
+  // `withProviders` already pins the test body to Floci, but the stack program
+  // and its later plan/apply phase run under `AWS.providers()`'s live services.
+  // Pin both phases separately: Actions execute during apply, after the stack
+  // program has finished. This override must be inside `compiled.services` so
+  // Effect's closest-layer precedence selects Floci for Action data-plane calls.
+  const pinToFloci = <A, E, R>(
     effect: Effect.Effect<A, E, R>,
   ): Effect.Effect<A, E, R> =>
     Option.getOrElse(alchemyTestDevOverride(), () => false)
@@ -542,15 +543,14 @@ export const scratchStack = <ROut>(
       : effect;
 
   const buildAndApply = (effect: Effect.Effect<any, any, any>) =>
-    (pinProgramToFloci(effect) as Effect.Effect<any, any, never>).pipe(
+    (pinToFloci(effect) as Effect.Effect<any, any, never>).pipe(
       makeStack({
         name: stackName,
         providers: options.providers,
         state: stateLayer,
       } as any) as any,
       Effect.flatMap((compiled: any) =>
-        Plan.make(compiled).pipe(
-          Effect.flatMap(apply),
+        pinToFloci(Plan.make(compiled).pipe(Effect.flatMap(apply))).pipe(
           Effect.provide(compiled.services),
         ),
       ),
@@ -559,14 +559,14 @@ export const scratchStack = <ROut>(
     );
 
   const buildPlan = (effect: Effect.Effect<any, any, any>) =>
-    (pinProgramToFloci(effect) as Effect.Effect<any, any, never>).pipe(
+    (pinToFloci(effect) as Effect.Effect<any, any, never>).pipe(
       makeStack({
         name: stackName,
         providers: options.providers,
         state: stateLayer,
       } as any) as any,
       Effect.flatMap((compiled: any) =>
-        Plan.make(compiled).pipe(Effect.provide(compiled.services)),
+        pinToFloci(Plan.make(compiled)).pipe(Effect.provide(compiled.services)),
       ),
       Effect.provide(Layer.succeed(Stage, stage)),
       provideFreshArtifactStore,

--- a/packages/alchemy/src/Test/Core.ts
+++ b/packages/alchemy/src/Test/Core.ts
@@ -1,5 +1,6 @@
 /** @effect-diagnostics anyUnknownInErrorContext:off */
 
+import * as Floci from "@alchemy.run/floci";
 import * as Config from "effect/Config";
 import { ConfigProvider } from "effect/ConfigProvider";
 import * as Context from "effect/Context";
@@ -11,7 +12,6 @@ import * as Scope from "effect/Scope";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
-import * as Floci from "@alchemy.run/floci";
 
 import { DEFAULT_LOCAL_ENDPOINT } from "../AWS/AuthProvider.ts";
 import { flociServices } from "../AWS/Local/FlociServices.ts";
@@ -28,6 +28,7 @@ import { destroy as _destroy } from "../Destroy.ts";
 import type { Input } from "../Input.ts";
 import * as RpcProviderProxy from "../Local/RpcProviderProxy.ts";
 import * as RpcSpawner from "../Local/RpcSpawner.ts";
+import { ALCHEMY_DEV } from "../Phase.ts";
 import * as Plan from "../Plan.ts";
 import {
   type CompiledStack,
@@ -39,7 +40,6 @@ import {
 import { Stage } from "../Stage.ts";
 import * as State from "../State/index.ts";
 import { TelemetryLive } from "../Telemetry/Layer.ts";
-import { ALCHEMY_DEV } from "../Phase.ts";
 import { loadConfigProvider } from "../Util/ConfigProvider.ts";
 import { PlatformServices } from "../Util/PlatformServices.ts";
 
@@ -550,7 +550,9 @@ export const scratchStack = <ROut>(
         state: stateLayer,
       } as any) as any,
       Effect.flatMap((compiled: any) =>
-        pinToFloci(Plan.make(compiled).pipe(Effect.flatMap(apply))).pipe(
+        Plan.make(compiled).pipe(
+          Effect.flatMap(apply),
+          pinToFloci,
           Effect.provide(compiled.services),
         ),
       ),

--- a/packages/alchemy/test/AWS/S3/Bucket.data-plane.test.ts
+++ b/packages/alchemy/test/AWS/S3/Bucket.data-plane.test.ts
@@ -1,13 +1,34 @@
+import { Action } from "@/Action";
 import * as AWS from "@/AWS";
-import { Bucket } from "@/AWS/S3";
+import { AWSEnvironment } from "@/AWS/Environment.ts";
+import { Bucket, PutObject, PutObjectHttp } from "@/AWS/S3";
 import * as Test from "@/Test/Alchemy";
 import * as S3 from "@distilled.cloud/aws/s3";
 import { expect } from "alchemy-test";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
 import * as Schedule from "effect/Schedule";
 
 const { test } = Test.make({ providers: AWS.providers() });
+
+// The Floci sweep must override even a configured live AWS environment. This
+// sentinel makes the Action regression independent of local profiles.
+const forceLocal = process.env.ALCHEMY_TEST_DEV === "1";
+const actionProviders = forceLocal
+  ? Layer.merge(
+      AWS.providers(),
+      Layer.succeed(
+        AWSEnvironment,
+        Effect.succeed({
+          accountId: "111111111111",
+          region: "us-east-1",
+          credentials: Effect.die("live credentials must not be used"),
+        }),
+      ),
+    )
+  : AWS.providers();
+const { test: actionTest } = Test.make({ providers: actionProviders });
 
 const deployTestBucket = (stack: Test.ScratchStack) =>
   Effect.gen(function* () {
@@ -23,6 +44,48 @@ const deployTestBucket = (stack: Test.ScratchStack) =>
       }),
     );
   });
+
+actionTest.provider("Action - uses the configured S3 data plane", (stack) =>
+  Effect.gen(function* () {
+    yield* stack.destroy();
+
+    const output = yield* stack.deploy(
+      Effect.gen(function* () {
+        const bucket = yield* Bucket("ActionDataPlaneBucket", {
+          forceDestroy: true,
+        });
+        const PutWithAction = Action(
+          "PutWithAction",
+          Effect.gen(function* () {
+            const putObject = yield* PutObject(bucket);
+            return () =>
+              Effect.gen(function* () {
+                const environment = yield* AWSEnvironment.current;
+                if (forceLocal && environment.accountId !== "000000000000") {
+                  return { accountId: environment.accountId };
+                }
+                const result = yield* putObject({
+                  Key: "action.txt",
+                  Body: "hello from Action",
+                });
+                return {
+                  accountId: environment.accountId,
+                  etag: result.ETag,
+                };
+              });
+          }).pipe(Effect.provide(PutObjectHttp)),
+        );
+        return yield* PutWithAction({});
+      }),
+    );
+
+    expect(output.etag).toBeDefined();
+    if (forceLocal) {
+      expect(output.accountId).toBe("000000000000");
+    }
+    yield* stack.destroy();
+  }),
+);
 
 test.provider("listObjectsV2 - list objects in bucket", (stack) =>
   Effect.gen(function* () {


### PR DESCRIPTION
## Summary

- Keep the Floci AWS override active during stack plan/apply.
- Ensure AWS data-plane calls inside `Action` use Floci when `ALCHEMY_TEST_DEV=1`.
- Add an S3 `PutObject` regression test with a sentinel live AWS environment.

## Root cause

`scratchStack` applied the Floci override to the test body and initial stack program, but `Action.Run` executes later during `Plan.make → apply` under `compiled.services`. The closer live AWS layer could therefore win, causing data-plane calls inside Actions to target real AWS while resource lifecycle operations remained local.

## Testing

- Focused Action/S3 regression test
- Full S3 Floci data-plane test suite: 10/10 passing
- Workspace TypeScript build
- Formatting and `git diff --check`