### PR TITLE
docs(fly): flatten the Fly resources sidebar

### DIFF
--- a/packages/alchemy/src/Fly/ConnectPostgres.ts
+++ b/packages/alchemy/src/Fly/ConnectPostgres.ts
@@ -26,8 +26,6 @@ import type { Postgres } from "./Postgres.ts";
  * ```
  *
  * @binding
- * @product Fly
- * @category Storage & Databases
  */
 export interface ConnectPostgres extends Binding.Service<
   ConnectPostgres,


### PR DESCRIPTION
The Fly provider's sidebar rendered a redundant `Storage & Databases > Fly` subtree containing only `ConnectPostgres`, next to an otherwise flat resource list. Cause: `ConnectPostgres` was the only Fly export tagged with `@product` / `@category`, so the sidebar generator built a category→product subtree for that one binding.

```diff
  * @binding
- * @product Fly
- * @category Storage & Databases
  */
```

`pnpm docs:gen` now emits a flat Fly Resources group (App, Bucket, …, ConnectPostgres, …) with no nested subgroups; the regenerated sidebar/markdown are gitignored build outputs.
