### PR TITLE
fix(dev): route binding clients to the bound resource's data plane

### DIFF
--- a/examples/aws-dev/alchemy.run.ts
+++ b/examples/aws-dev/alchemy.run.ts
@@ -1,6 +1,8 @@
 import * as Alchemy from "alchemy";
 import * as AWS from "alchemy/AWS";
+import * as S3 from "alchemy/AWS/S3";
 import * as Effect from "effect/Effect";
+import * as Stream from "effect/Stream";
 import ApiFunction from "./src/ApiFunction.ts";
 
 export default Alchemy.Stack(
@@ -11,8 +13,40 @@ export default Alchemy.Stack(
   },
   Effect.gen(function* () {
     const api = yield* ApiFunction;
+
+    // Deploy-time Action data plane: seed an object into a bucket during
+    // apply and read it back, reporting which AWS account served the calls.
+    // Under `alchemy dev` the calls MUST land on the floci emulator — the
+    // dummy account id (000000000000) in the stack outputs is the proof.
+    // CLI-path counterpart of the harness regression in
+    // packages/alchemy/test/AWS/S3/Bucket.data-plane.test.ts.
+    const bucket = yield* S3.Bucket("SeedBucket", { forceDestroy: true });
+    const SeedObject = Alchemy.Action(
+      "SeedObject",
+      Effect.gen(function* () {
+        const putObject = yield* S3.PutObject(bucket);
+        const getObject = yield* S3.GetObject(bucket);
+        return Effect.fn(function* (input: { key: string; body: string }) {
+          const environment = yield* AWS.AWSEnvironment.current;
+          yield* putObject({ Key: input.key, Body: input.body });
+          const object = yield* getObject({ Key: input.key });
+          const text = yield* (
+            object.Body?.pipe(Stream.decodeText, Stream.mkString) ??
+              Effect.succeed("")
+          );
+          return { accountId: environment.accountId, text };
+        });
+      }).pipe(Effect.provide([S3.PutObjectHttp, S3.GetObjectHttp])),
+    );
+    const seeded = yield* SeedObject({
+      key: "seed.txt",
+      body: "seed-object-body-v1",
+    });
+
     return {
       api: api.functionUrl,
+      seedAccount: seeded.accountId,
+      seedText: seeded.text,
     };
   }),
 );

--- a/examples/aws-dev/test/dev.test.ts
+++ b/examples/aws-dev/test/dev.test.ts
@@ -26,6 +26,11 @@
  *   - DynamoDB Streams   → `/items` writes; the table stream + its
  *                          EventSourceMapping deliver the change record to
  *                          `consumeTableChanges`, read back by `/changes`
+ *   - Action data plane  → the deploy-time SeedObject Action put/gets an
+ *                          object through the S3 bindings inside the CLI
+ *                          process; the stack outputs carry the dummy
+ *                          account id (000000000000) proving the calls hit
+ *                          the emulator, not real AWS
  *   - HOT RELOAD         → rewriting src/marker.ts (no redeploy) must serve
  *                          the new marker; restoring it must swap back
  */
@@ -54,6 +59,21 @@ const markerSource = fs.readFileSync(markerPath, "utf8");
 // The whole suite needs docker (floci runs as a container).
 const dockerAvailable =
   spawnSync("docker", ["info"], { stdio: "ignore" }).status === 0;
+
+// Credential-free dev, deterministically: an isolated (unconfigured)
+// alchemy profile plus stripped AWS env credentials keep this suite
+// hermetic — it must pass on a machine with zero AWS configuration, and
+// must never touch a developer's real profile. (Action data-plane calls
+// are routed to the emulator per bound resource by the engine regardless
+// of ambient credentials — see Binding.Service's data-plane routing.)
+const devEnv: NodeJS.ProcessEnv = {
+  ...process.env,
+  ALCHEMY_PROFILE: "aws-dev-cli-test",
+};
+delete devEnv.AWS_ACCESS_KEY_ID;
+delete devEnv.AWS_SECRET_ACCESS_KEY;
+delete devEnv.AWS_SESSION_TOKEN;
+delete devEnv.AWS_PROFILE;
 
 let proc: ReturnType<typeof spawn> | undefined;
 let output = "";
@@ -107,6 +127,10 @@ const fetchOk = async (
 const outputUrl = (key: string) =>
   output.match(new RegExp(`${key}:\\s*['"]?(http[^\\s'",]+)`))?.[1];
 
+/** Extract a plain (single-token) stack output value from stdout. */
+const outputValue = (key: string) =>
+  output.match(new RegExp(`${key}:\\s*['"]?([^\\s'",]+)`))?.[1];
+
 afterAll(async () => {
   // Always leave the repo tree clean, even on a mid-reload failure.
   fs.writeFileSync(markerPath, markerSource);
@@ -139,6 +163,7 @@ afterAll(async () => {
         cwd: root,
         stdio: "inherit",
         timeout: 120_000,
+        env: devEnv,
       },
     );
     if (destroyed.status !== 0) {
@@ -158,6 +183,7 @@ test.skipIf(!dockerAvailable)(
       // the way a terminal would.
       detached: true,
       stdio: ["ignore", "pipe", "pipe"],
+      env: devEnv,
     });
     pump(proc.stdout!);
     pump(proc.stderr!);
@@ -176,6 +202,19 @@ test.skipIf(!dockerAvailable)(
     // captured from the CLI's stdout is authoritative.
     expect(new URL(api).hostname).toEndWith("localhost");
     expect(api).not.toContain("amazonaws.com");
+
+    // Action data plane: the deploy-time SeedObject Action ran inside the
+    // CLI's exec process and put/get an object through the S3 bindings.
+    // The dummy account id proves the calls hit the emulator, not real
+    // AWS; the roundtripped body proves the put actually landed.
+    const seedAccount = await pollUntil("seedAccount in stack outputs", () =>
+      outputValue("seedAccount"),
+    );
+    expect(seedAccount).toBe("000000000000");
+    const seedText = await pollUntil("seedText in stack outputs", () =>
+      outputValue("seedText"),
+    );
+    expect(seedText).toBe("seed-object-body-v1");
 
     // Marker + env: the function reads MY_VARIABLE through effect/Config.
     const home = (await (await fetchOk(api)).json()) as {

--- a/packages/alchemy/src/AWS/Local/FlociServices.ts
+++ b/packages/alchemy/src/AWS/Local/FlociServices.ts
@@ -102,4 +102,8 @@ export const flociDual = <
   ProviderLayer.dual(cls, {
     live,
     local: () => provideProviderContext(live(), flociServices()),
+    // Registered as the resource's local data plane so deploy-time binding
+    // clients (Action bodies, plan-time `execute`) route their API calls to
+    // the emulator whenever the bound resource resolves to local mode.
+    dataPlane: flociServices,
   });

--- a/packages/alchemy/src/Binding.ts
+++ b/packages/alchemy/src/Binding.ts
@@ -1,9 +1,11 @@
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
+import type * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import type { Input } from "./Input.ts";
 import * as Output from "./Output.ts";
-import type { ResourceLike } from "./Resource.ts";
+import { resolveLocalDataPlane } from "./Provider.ts";
+import { isResource, type ResourceLike } from "./Resource.ts";
 import { Self } from "./Self.ts";
 import { taggedFunction } from "./Util/effect.ts";
 
@@ -124,7 +126,19 @@ export const Service = <
       Effect.all(
         args.map((arg) => (Effect.isEffect(arg) ? arg : Effect.succeed(arg))),
         { concurrency: "unbounded" },
-      ).pipe(Effect.flatMap((resolved) => f(...resolved))),
+      ).pipe(
+        Effect.flatMap((resolved) =>
+          f(...resolved).pipe(
+            // Deploy-time data-plane routing: the client's calls must target
+            // whatever data plane the bound resource actually lives on. In an
+            // `alchemy dev` run a local-mode resource exists only on the
+            // emulator, so invoking its client against the ambient (live)
+            // cloud environment would miss it — or worse, mutate the real
+            // cloud. See {@link routeClientDataPlane}.
+            Effect.flatMap((client) => routeClientDataPlane(resolved, client)),
+          ),
+        ),
+      ),
     );
   // Plan-time invoke (see the `execute` doc on `Service`): bind hostless —
   // `Binding.Host` is total and resolves `undefined`, so impls skip their
@@ -138,6 +152,105 @@ export const Service = <
       ) as Effect.Effect<any, never, any>,
     );
   return taggedFunction(tag as any, callable) as unknown as Self;
+};
+
+/**
+ * Route a binding client's invocations to the data plane its bound
+ * resource(s) actually live on.
+ *
+ * A dual-provider resource in an `alchemy dev` run resolves to its LOCAL
+ * provider (unless pinned live via `Alchemy.remote()`), so the physical
+ * resource exists only on the local emulator. A client invoked at deploy
+ * time — inside an {@link ../Action.ts Action} body or a plan-time
+ * {@link Service.execute} — would otherwise resolve the ambient (live)
+ * cloud environment and miss it, or mutate the real cloud. The bound
+ * resource's provider registers the emulator context as
+ * {@link ProviderService.localDataPlane} (e.g. AWS's `flociServices()`);
+ * this wrapper provides it *closest* around every invocation, so it wins
+ * over the ambient environment exactly like the local provider's lifecycle
+ * override does.
+ *
+ * Resolution happens once per bind, in the same context the bind step ran
+ * in (the Provider registry and `AlchemyContext` are ambient during stack
+ * evaluation and apply). At runtime inside a deployed Function/Worker there
+ * is no registry and no engine — the wrapper is skipped entirely.
+ */
+const routeClientDataPlane = (
+  resolvedArgs: readonly unknown[],
+  client: unknown,
+): Effect.Effect<any> =>
+  Effect.suspend(() => {
+    if (globalThis.__ALCHEMY_RUNTIME__) return Effect.succeed(client);
+    // Bind arguments are the capability's target resources by convention —
+    // scan the top level plus one array level (multi-resource bindings like
+    // ExecuteTransaction take tuples of resources).
+    const resources = resolvedArgs.flatMap((arg): ResourceLike[] =>
+      Array.isArray(arg)
+        ? arg.filter(isResource)
+        : isResource(arg)
+          ? [arg]
+          : [],
+    );
+    if (resources.length === 0) return Effect.succeed(client);
+    return Effect.gen(function* () {
+      const planes: (Layer.Layer<any, any, never> | undefined)[] = [];
+      for (const resource of resources) {
+        planes.push(yield* resolveLocalDataPlane(resource));
+      }
+      const defined = [...new Set(planes.filter((p) => p !== undefined))];
+      if (defined.length === 0) return client;
+      if (defined.length > 1 || planes.some((p) => p === undefined)) {
+        return yield* Effect.die(
+          `Binding client spans mixed data planes: [${resources
+            .map((r) => r.FQN)
+            .join(
+              ", ",
+            )}] resolve to different targets (some local, some live). ` +
+            "A single API call cannot span the local emulator and the real " +
+            "cloud — make the bound resources' modes agree (e.g. pipe them " +
+            "all through Alchemy.remote(), or none).",
+        );
+      }
+      return wrapClientInvocations(client, defined[0]);
+    });
+  });
+
+/**
+ * Wrap every invocation surface of a binding client so its returned Effects
+ * run with `layer` provided closest. Handles the client shapes bindings
+ * return: a callable (the common per-operation client), an object of
+ * methods/Effects (multi-method clients), or a bare Effect. Anything else
+ * passes through untouched. Proxies preserve identity, extra properties,
+ * and method names.
+ */
+const wrapClientInvocations = (
+  client: unknown,
+  layer: Layer.Layer<any, any, never>,
+): unknown => {
+  const provide = (value: unknown): unknown =>
+    Effect.isEffect(value)
+      ? Effect.provide(value as Effect.Effect<any, any, any>, layer)
+      : value;
+  if (Effect.isEffect(client)) return provide(client);
+  if (typeof client === "function") {
+    return new Proxy(client, {
+      apply: (target, thisArg, argArray) =>
+        provide(Reflect.apply(target, thisArg, argArray)),
+    });
+  }
+  if (typeof client === "object" && client !== null) {
+    return new Proxy(client, {
+      get: (target, prop, receiver) => {
+        const value = Reflect.get(target, prop, receiver);
+        if (typeof value === "function") {
+          return (...args: any[]) =>
+            provide(Reflect.apply(value, target, args));
+        }
+        return provide(value);
+      },
+    });
+  }
+  return client;
 };
 
 /**

--- a/packages/alchemy/src/Local/ProviderLayer.ts
+++ b/packages/alchemy/src/Local/ProviderLayer.ts
@@ -64,6 +64,17 @@ export const dual = <
   input: {
     live: () => LayerLive;
     local: () => LayerLocal;
+    /**
+     * Data-plane override context for the local mode — the layer of cloud
+     * environment services (endpoint, credentials, region) the local
+     * lifecycle variant runs under (e.g. AWS's `flociServices()`). Stamped
+     * onto the registered service as
+     * {@link ProviderService.localDataPlane} so `Binding.Service` clients
+     * can route deploy-time data-plane calls (Action bodies, plan-time
+     * `execute`) to the emulator when the bound resource resolves local.
+     * Pass a module-memoized layer reference.
+     */
+    dataPlane?: () => Layer.Layer<any, any, never>;
   },
 ): Layer.Layer<
   Layer.Success<LayerLive | LayerLocal>,
@@ -119,6 +130,7 @@ export const dual = <
         ...defaultService,
         mode: defaultMode,
         modes,
+        localDataPlane: input.dataPlane,
       } satisfies ProviderService<R>);
     }),
   ) as any;

--- a/packages/alchemy/src/Provider.ts
+++ b/packages/alchemy/src/Provider.ts
@@ -10,7 +10,7 @@ import type { Diff } from "./Diff.ts";
 import type { Input } from "./Input.ts";
 import type { InstanceId } from "./InstanceId.ts";
 import type { Platform } from "./Platform.ts";
-import type { ProviderMode } from "./ProviderMode.ts";
+import { defaultProviderMode, type ProviderMode } from "./ProviderMode.ts";
 import type {
   ResourceBinding,
   ResourceClass,
@@ -133,6 +133,22 @@ export interface ProviderService<
    * even during a live deploy (and vice versa).
    */
   modes?: { readonly [M in ProviderMode]: Effect.Effect<ProviderService<Res>> };
+  /**
+   * Data-plane override context for this provider's **local** mode: a layer
+   * of cloud environment services (endpoint, credentials, region,
+   * environment) that points data-plane API calls at the local emulator —
+   * the same override the local lifecycle variant runs under (e.g. AWS's
+   * `flociServices()`).
+   *
+   * Set by `ProviderLayer.dual` registrations that pass `dataPlane`.
+   * Consumed by `Binding.Service`'s client wrapper (via
+   * {@link resolveLocalDataPlane}) so deploy-time binding invocations —
+   * inside an `Action` body or a plan-time `execute` — target whatever
+   * data plane the bound resource actually lives on: a local-mode resource
+   * routes to the emulator while an `Alchemy.remote()` resource keeps
+   * hitting the real cloud. Pass a module-memoized layer reference.
+   */
+  localDataPlane?: () => Layer.Layer<any, any, never>;
   /**
    * Account-wide teardown (`alchemy unsafe nuke`) behaviour. Providers whose
    * resources can't meaningfully be deleted opt out here so nuke doesn't
@@ -594,6 +610,34 @@ export const providerForMode = <R extends ResourceLike>(
   mode !== undefined && service.modes !== undefined
     ? service.modes[mode]
     : Effect.succeed(service);
+
+/**
+ * Resolve the data-plane override layer for a resource, or `undefined` when
+ * its data plane is the real cloud:
+ *
+ * - no provider registered in context (bare runtime, unit tests) → live;
+ * - mode-agnostic provider (no `modes`) → live even in dev;
+ * - dual provider without a registered {@link ProviderService.localDataPlane}
+ *   → live (nothing to route to);
+ * - otherwise the resource's effective mode decides — its registration-
+ *   captured {@link ResourceLike.Mode} (`Alchemy.remote()` → `"live"`) or
+ *   the run default (`alchemy dev` → `"local"`), the same resolution
+ *   `Plan.make` applies to lifecycle operations.
+ */
+export const resolveLocalDataPlane = (resource: {
+  readonly Type: string;
+  readonly Mode?: ProviderMode | undefined;
+}): Effect.Effect<Layer.Layer<any, any, never> | undefined> =>
+  Effect.gen(function* () {
+    const found = yield* tryFindProviderByType(resource.Type);
+    if (Option.isNone(found)) return undefined;
+    const provider = found.value;
+    if (provider.modes === undefined || provider.localDataPlane === undefined) {
+      return undefined;
+    }
+    const mode = resource.Mode ?? (yield* defaultProviderMode);
+    return mode === "local" ? provider.localDataPlane() : undefined;
+  });
 
 export const findProviderByType: {
   <R extends ResourceLike>(

--- a/packages/alchemy/src/Test/Core.ts
+++ b/packages/alchemy/src/Test/Core.ts
@@ -530,11 +530,12 @@ export const scratchStack = <ROut>(
       ? Layer.succeed(State.State, State.InMemoryService({}))
       : Layer.provide(State.localState(), PlatformServices);
 
-  // `withProviders` already pins test-body distilled to Floci, but the stack
-  // *program* is composed under `AWS.providers()`'s live Endpoint. Dual
-  // providers still hit Floci in lifecycle ops; user-program distilled
-  // (e.g. ECS Service `findHostedZoneId`) would otherwise query real AWS.
-  const pinProgramToFloci = <A, E, R>(
+  // `withProviders` already pins the test body to Floci, but the stack program
+  // and its later plan/apply phase run under `AWS.providers()`'s live services.
+  // Pin both phases separately: Actions execute during apply, after the stack
+  // program has finished. This override must be inside `compiled.services` so
+  // Effect's closest-layer precedence selects Floci for Action data-plane calls.
+  const pinToFloci = <A, E, R>(
     effect: Effect.Effect<A, E, R>,
   ): Effect.Effect<A, E, R> =>
     Option.getOrElse(alchemyTestDevOverride(), () => false)
@@ -542,15 +543,14 @@ export const scratchStack = <ROut>(
       : effect;
 
   const buildAndApply = (effect: Effect.Effect<any, any, any>) =>
-    (pinProgramToFloci(effect) as Effect.Effect<any, any, never>).pipe(
+    (pinToFloci(effect) as Effect.Effect<any, any, never>).pipe(
       makeStack({
         name: stackName,
         providers: options.providers,
         state: stateLayer,
       } as any) as any,
       Effect.flatMap((compiled: any) =>
-        Plan.make(compiled).pipe(
-          Effect.flatMap(apply),
+        pinToFloci(Plan.make(compiled).pipe(Effect.flatMap(apply))).pipe(
           Effect.provide(compiled.services),
         ),
       ),
@@ -559,14 +559,14 @@ export const scratchStack = <ROut>(
     );
 
   const buildPlan = (effect: Effect.Effect<any, any, any>) =>
-    (pinProgramToFloci(effect) as Effect.Effect<any, any, never>).pipe(
+    (pinToFloci(effect) as Effect.Effect<any, any, never>).pipe(
       makeStack({
         name: stackName,
         providers: options.providers,
         state: stateLayer,
       } as any) as any,
       Effect.flatMap((compiled: any) =>
-        Plan.make(compiled).pipe(Effect.provide(compiled.services)),
+        pinToFloci(Plan.make(compiled)).pipe(Effect.provide(compiled.services)),
       ),
       Effect.provide(Layer.succeed(Stage, stage)),
       provideFreshArtifactStore,

--- a/packages/alchemy/src/Test/Core.ts
+++ b/packages/alchemy/src/Test/Core.ts
@@ -1,5 +1,6 @@
 /** @effect-diagnostics anyUnknownInErrorContext:off */
 
+import * as Floci from "@alchemy.run/floci";
 import * as Config from "effect/Config";
 import { ConfigProvider } from "effect/ConfigProvider";
 import * as Context from "effect/Context";
@@ -11,7 +12,6 @@ import * as Scope from "effect/Scope";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
-import * as Floci from "@alchemy.run/floci";
 
 import { DEFAULT_LOCAL_ENDPOINT } from "../AWS/AuthProvider.ts";
 import { flociServices } from "../AWS/Local/FlociServices.ts";
@@ -28,6 +28,7 @@ import { destroy as _destroy } from "../Destroy.ts";
 import type { Input } from "../Input.ts";
 import * as RpcProviderProxy from "../Local/RpcProviderProxy.ts";
 import * as RpcSpawner from "../Local/RpcSpawner.ts";
+import { ALCHEMY_DEV } from "../Phase.ts";
 import * as Plan from "../Plan.ts";
 import {
   type CompiledStack,
@@ -39,7 +40,6 @@ import {
 import { Stage } from "../Stage.ts";
 import * as State from "../State/index.ts";
 import { TelemetryLive } from "../Telemetry/Layer.ts";
-import { ALCHEMY_DEV } from "../Phase.ts";
 import { loadConfigProvider } from "../Util/ConfigProvider.ts";
 import { PlatformServices } from "../Util/PlatformServices.ts";
 
@@ -550,7 +550,9 @@ export const scratchStack = <ROut>(
         state: stateLayer,
       } as any) as any,
       Effect.flatMap((compiled: any) =>
-        pinToFloci(Plan.make(compiled).pipe(Effect.flatMap(apply))).pipe(
+        Plan.make(compiled).pipe(
+          Effect.flatMap(apply),
+          pinToFloci,
           Effect.provide(compiled.services),
         ),
       ),

--- a/packages/alchemy/test/AWS/S3/Bucket.data-plane.test.ts
+++ b/packages/alchemy/test/AWS/S3/Bucket.data-plane.test.ts
@@ -1,13 +1,34 @@
+import { Action } from "@/Action";
 import * as AWS from "@/AWS";
-import { Bucket } from "@/AWS/S3";
+import { AWSEnvironment } from "@/AWS/Environment.ts";
+import { Bucket, PutObject, PutObjectHttp } from "@/AWS/S3";
 import * as Test from "@/Test/Alchemy";
 import * as S3 from "@distilled.cloud/aws/s3";
 import { expect } from "alchemy-test";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
 import * as Schedule from "effect/Schedule";
 
 const { test } = Test.make({ providers: AWS.providers() });
+
+// The Floci sweep must override even a configured live AWS environment. This
+// sentinel makes the Action regression independent of local profiles.
+const forceLocal = process.env.ALCHEMY_TEST_DEV === "1";
+const actionProviders = forceLocal
+  ? Layer.merge(
+      AWS.providers(),
+      Layer.succeed(
+        AWSEnvironment,
+        Effect.succeed({
+          accountId: "111111111111",
+          region: "us-east-1",
+          credentials: Effect.die("live credentials must not be used"),
+        }),
+      ),
+    )
+  : AWS.providers();
+const { test: actionTest } = Test.make({ providers: actionProviders });
 
 const deployTestBucket = (stack: Test.ScratchStack) =>
   Effect.gen(function* () {
@@ -23,6 +44,48 @@ const deployTestBucket = (stack: Test.ScratchStack) =>
       }),
     );
   });
+
+actionTest.provider("Action - uses the configured S3 data plane", (stack) =>
+  Effect.gen(function* () {
+    yield* stack.destroy();
+
+    const output = yield* stack.deploy(
+      Effect.gen(function* () {
+        const bucket = yield* Bucket("ActionDataPlaneBucket", {
+          forceDestroy: true,
+        });
+        const PutWithAction = Action(
+          "PutWithAction",
+          Effect.gen(function* () {
+            const putObject = yield* PutObject(bucket);
+            return () =>
+              Effect.gen(function* () {
+                const environment = yield* AWSEnvironment.current;
+                if (forceLocal && environment.accountId !== "000000000000") {
+                  return { accountId: environment.accountId };
+                }
+                const result = yield* putObject({
+                  Key: "action.txt",
+                  Body: "hello from Action",
+                });
+                return {
+                  accountId: environment.accountId,
+                  etag: result.ETag,
+                };
+              });
+          }).pipe(Effect.provide(PutObjectHttp)),
+        );
+        return yield* PutWithAction({});
+      }),
+    );
+
+    expect(output.etag).toBeDefined();
+    if (forceLocal) {
+      expect(output.accountId).toBe("000000000000");
+    }
+    yield* stack.destroy();
+  }),
+);
 
 test.provider("listObjectsV2 - list objects in bucket", (stack) =>
   Effect.gen(function* () {

--- a/packages/alchemy/test/AWS/S3/Bucket.data-plane.test.ts
+++ b/packages/alchemy/test/AWS/S3/Bucket.data-plane.test.ts
@@ -1,7 +1,9 @@
 import { Action } from "@/Action";
 import * as AWS from "@/AWS";
 import { AWSEnvironment } from "@/AWS/Environment.ts";
+import { flociServices } from "@/AWS/Local/FlociServices.ts";
 import { Bucket, PutObject, PutObjectHttp } from "@/AWS/S3";
+import { remote } from "@/ProviderMode.ts";
 import * as Test from "@/Test/Alchemy";
 import * as S3 from "@distilled.cloud/aws/s3";
 import { expect } from "alchemy-test";
@@ -44,6 +46,107 @@ const deployTestBucket = (stack: Test.ScratchStack) =>
       }),
     );
   });
+
+// The PRODUCTION dev path: plain `dev: true` (no ALCHEMY_TEST_DEV sweep), so
+// the ambient AWS environment stays whatever the profile resolves — live
+// credentials under `--profile testing`. Binding clients invoked inside an
+// Action must route per bound resource regardless: a local-mode bucket's
+// calls land on the floci emulator, an `Alchemy.remote()` bucket's calls
+// land on the real cloud. Skipped under the sweep, which pins the whole
+// process to floci and would make the live-vs-local distinction vacuous.
+const { test: devTest } = Test.make({ providers: AWS.providers(), dev: true });
+const inSweep = process.env.ALCHEMY_TEST_DEV === "1";
+
+devTest.provider.skipIf(inSweep)(
+  "dev Action routes to the local bucket's emulator data plane",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const output = yield* stack.deploy(
+        Effect.gen(function* () {
+          const bucket = yield* Bucket("DevLocalActionBucket", {
+            forceDestroy: true,
+          });
+          const PutLocal = Action(
+            "PutLocalObject",
+            Effect.gen(function* () {
+              const putObject = yield* PutObject(bucket);
+              return () =>
+                Effect.gen(function* () {
+                  const result = yield* putObject({
+                    Key: "local.txt",
+                    Body: "routed to the emulator",
+                  });
+                  return { etag: result.ETag };
+                });
+            }).pipe(Effect.provide(PutObjectHttp)),
+          );
+          return { bucketName: bucket.bucketName, put: yield* PutLocal({}) };
+        }),
+      );
+      expect(output.put.etag).toBeDefined();
+
+      // The object landed on the emulator...
+      const local = yield* S3.headObject({
+        Bucket: output.bucketName,
+        Key: "local.txt",
+      }).pipe(Effect.provide(flociServices()));
+      expect(local.ETag).toBe(output.put.etag);
+
+      // ...and the bucket never existed on the real cloud (the test body's
+      // ambient SDK is the live `testing` environment).
+      const live = yield* S3.headBucket({ Bucket: output.bucketName }).pipe(
+        Effect.map(() => "found" as const),
+        Effect.catchTag("NotFound", () => Effect.succeed("not-found" as const)),
+      );
+      expect(live).toBe("not-found");
+
+      yield* stack.destroy();
+    }),
+);
+
+devTest.provider.skipIf(inSweep)(
+  "dev Action on a remote() bucket targets the real cloud",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const output = yield* stack.deploy(
+        Effect.gen(function* () {
+          const bucket = yield* Bucket("DevRemoteActionBucket", {
+            forceDestroy: true,
+          }).pipe(remote());
+          const PutRemote = Action(
+            "PutRemoteObject",
+            Effect.gen(function* () {
+              const putObject = yield* PutObject(bucket);
+              return () =>
+                Effect.gen(function* () {
+                  const result = yield* putObject({
+                    Key: "remote.txt",
+                    Body: "landed on real AWS",
+                  });
+                  return { etag: result.ETag };
+                });
+            }).pipe(Effect.provide(PutObjectHttp)),
+          );
+          return { bucketName: bucket.bucketName, put: yield* PutRemote({}) };
+        }),
+      );
+      expect(output.put.etag).toBeDefined();
+
+      // Out-of-band via the live SDK: the write landed on the real bucket.
+      const live = yield* S3.headObject({
+        Bucket: output.bucketName,
+        Key: "remote.txt",
+      });
+      expect(live.ETag).toBe(output.put.etag);
+
+      yield* stack.destroy();
+      yield* assertBucketDeleted(output.bucketName);
+    }),
+);
 
 actionTest.provider("Action - uses the configured S3 data plane", (stack) =>
   Effect.gen(function* () {

--- a/website/src/content/docs/infrastructure-as-code/local-provider.mdx
+++ b/website/src/content/docs/infrastructure-as-code/local-provider.mdx
@@ -41,6 +41,27 @@ export const WorkerProvider = () =>
 **lazily** — e.g. the local provider is only constructed during a deploy
 if it has an instance to tear down.
 
+### Route deploy-time data-plane calls: `dataPlane`
+
+Binding clients can be invoked at deploy time — inside an `Action` body or
+a plan-time `execute` — and their API calls must target whatever data
+plane the bound resource actually lives on. Pass the local mode's
+environment override (endpoint, credentials, region — the same layer the
+local lifecycle runs under) as `dataPlane`:
+
+```typescript
+ProviderLayer.dual(Bucket, {
+  live: () => BucketProvider(),
+  local: () => provideProviderContext(BucketProvider(), flociServices()),
+  dataPlane: flociServices,
+});
+```
+
+With it registered, a client bound to a local-mode resource is routed to
+the emulator even when the ambient profile carries live credentials, while
+a client bound to an `Alchemy.remote()` resource keeps hitting the real
+cloud — per bound resource, within the same Action.
+
 ### Compose local deps inside the thunk
 
 Mode-specific dependency layers (`workerd`, Docker) go inside the `local`


### PR DESCRIPTION
In `alchemy dev`, a binding client invoked at deploy time — inside an `Action` body or a plan-time `execute` — resolved the *ambient* cloud environment, not the environment of the resource it was bound to. With a configured live profile, an Action's `putObject` on a locally-emulated bucket would hit real AWS (missing the bucket, or worse, mutating the real cloud).

Binding clients now route per bound resource: a local-mode resource's calls land on the emulator, an `Alchemy.remote()` resource's calls land on the real cloud — within the same Action.

- `ProviderLayer.dual` accepts a `dataPlane` thunk — the local mode's environment override layer, stamped onto the registered service as `ProviderService.localDataPlane`. AWS's `flociDual` passes `flociServices`, so every floci-dual resource gets routing for free.

```ts
ProviderLayer.dual(cls, {
  live,
  local: () => provideProviderContext(live(), flociServices()),
  dataPlane: flociServices,
});
```

- `Binding.Service`'s callable resolves the bound resources' data plane once per bind (`resource.Mode ?? defaultProviderMode`, the same resolution `Plan.make` applies to lifecycle ops) and wraps the returned client so each invocation runs with that plane's environment provided closest. Skipped at runtime inside deployed Functions/Workers; a binding spanning mixed planes dies with an explicit error.

```ts
// dev run, live credentials ambient:
const bucket = yield* Bucket("Local", {});                    // → emulator
const real = yield* Bucket("Real", {}).pipe(Alchemy.remote()); // → real AWS
// an Action using PutObject(bucket) and PutObject(real) routes each call correctly
```

- Regression tests in `Bucket.data-plane.test.ts` run under plain `Test.make({ dev: true })` with live credentials ambient: the local-bucket Action's object lands on floci and the bucket never exists on real AWS; the `remote()` Action's object lands on real AWS and tears down cleanly.
- The `aws-dev` example gains a deploy-time `SeedObject` Action, and its CLI e2e (`test/dev.test.ts`) asserts the seed landed on the emulator (`seedAccount: 000000000000`) through the real `alchemy dev` binary, on an isolated credential-free profile.

Raw distilled SDK calls inside an Action still follow the ambient environment — there is no bound resource to route by; bindings are the sanctioned capability surface. Cloudflare's dual providers can adopt the same `dataPlane` hook when needed.

Supersedes #1306 — thanks @Vicentesan for the root-cause analysis; this PR includes that harness fix and regression test (authorship preserved) and extends the fix to the production `alchemy dev` path.
