### PR TITLE
fix(cloudflare/foldkit): upgrade foldkit and add a SSR Foldkit example

### DIFF
--- a/examples/cloudflare-foldkit-ssr/.gitignore
+++ b/examples/cloudflare-foldkit-ssr/.gitignore
@@ -1,0 +1,10 @@
+node_modules
+dist
+*.local
+*.tsbuildinfo
+.DS_Store
+
+# The root .gitignore excludes *.d.ts. These ambient declarations are source:
+# they reference vite/client for the CSS import and type the build id the
+# Foldkit plugin compiles in.
+!src/vite-env.d.ts

--- a/examples/cloudflare-foldkit-ssr/README.md
+++ b/examples/cloudflare-foldkit-ssr/README.md
@@ -1,0 +1,47 @@
+# cloudflare-foldkit-ssr
+
+A [Foldkit](https://foldkit.dev) app rendered on the server, deployed to Cloudflare with `Cloudflare.Website.Foldkit`.
+
+The sibling [`cloudflare-foldkit`](../cloudflare-foldkit) example is the client-only shape: it ships a template and the browser builds the page. This one renders each request at the edge and the browser adopts that markup, so the document a crawler reads already carries the page.
+
+## What makes it server-rendered
+
+- `src/entry.server.ts` exposes `renderPage(Request)`. It derives Flags from the request, renders through the same `view` the browser uses, and returns the markup plus the document's title.
+- `src/worker.ts` reads the built shell from the `ASSETS` binding, places the render into it with `Server.toResponse`, and answers asset misses and refused methods itself.
+- `src/entry.ts` calls `Runtime.hydrate` rather than `Runtime.run`, so the client adopts the served DOM instead of rebuilding it.
+- `alchemy.run.ts` turns the asset layer's page handling off so page requests actually reach the Worker.
+
+Load `/?count=7` and view source: the count is in the HTML before any JavaScript runs.
+
+## The two settings that matter
+
+```typescript
+assets: {
+  htmlHandling: "none",
+  notFoundHandling: "none",
+}
+```
+
+Both are load-bearing, and getting either wrong fails quietly — the site serves 200s carrying an empty document.
+
+`notFoundHandling: "none"` lets a request matching no file fall through to the Worker. Left at `"single-page-application"`, the asset layer answers every deep link with the unrendered template and the Worker is never reached.
+
+`htmlHandling: "none"` stops the asset layer resolving `/` to `/index.html` by itself, which would serve the template for the front page alone even after the first setting is right.
+
+Files are still served straight from the asset layer — only page requests reach the Worker.
+
+## The build id
+
+`renderToString` and `Runtime.hydrate` both require a build id, and hydration refuses a page whose id is not the running build's. `vite.config.ts` takes it from `FOLDKIT_BUILD_ID` and falls back to a fresh value, so a local build always has one. A real deployment should pass a value it already has, such as a commit or release tag, and give the client and server builds the same one. It is published in the page, so it must not be a secret.
+
+## A note on `alchemy dev`
+
+The Foldkit Vite plugin has an `ssr: { serverEntry }` option that serves rendered pages from the Vite dev server. This example deliberately does not set it: it loads the entry through `ssrLoadModule`, which needs a runnable `ssr` environment, and under `alchemy dev` that environment belongs to workerd. It is redundant here in any case — requests reach `src/worker.ts`, which renders through the same entry.
+
+## Commands
+
+```sh
+bun dev      # alchemy dev
+bun deploy   # alchemy deploy
+bun destroy  # alchemy destroy
+```

--- a/examples/cloudflare-foldkit-ssr/alchemy.run.ts
+++ b/examples/cloudflare-foldkit-ssr/alchemy.run.ts
@@ -1,0 +1,37 @@
+import * as Alchemy from "alchemy";
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+
+export default Alchemy.Stack(
+  "CloudflareFoldkitSsrExample",
+  {
+    providers: Cloudflare.providers(),
+    state: Cloudflare.state(),
+  },
+  Effect.gen(function* () {
+    const worker = yield* Cloudflare.Website.Foldkit("FoldkitSsr", {
+      // Rendering happens at the edge, so the deployment needs a Worker.
+      main: "src/worker.ts",
+      // Both settings are load-bearing, and getting either wrong fails
+      // quietly — the site serves 200s that carry an empty document.
+      //
+      // `notFoundHandling: "none"` lets a request that matches no file reach
+      // the Worker instead of being answered with the template.
+      // `htmlHandling: "none"` stops the asset layer resolving `/` to
+      // `/index.html` on its own, which would serve the unrendered template
+      // for the front page alone.
+      //
+      // Files still come straight from the asset layer; only page requests
+      // reach the Worker. `/index.html` keeps matching literally, which is
+      // where the Worker reads its shell from.
+      assets: {
+        htmlHandling: "none",
+        notFoundHandling: "none",
+      },
+    });
+
+    return {
+      url: worker.url,
+    };
+  }),
+);

--- a/examples/cloudflare-foldkit-ssr/index.html
+++ b/examples/cloudflare-foldkit-ssr/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Foldkit SSR on Cloudflare</title>
+    <link rel="stylesheet" href="/src/styles.css" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/entry.ts"></script>
+  </body>
+</html>

--- a/examples/cloudflare-foldkit-ssr/package.json
+++ b/examples/cloudflare-foldkit-ssr/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "cloudflare-foldkit-ssr",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "alchemy dev",
+    "build": "vite build",
+    "deploy": "alchemy deploy",
+    "destroy": "alchemy destroy",
+    "test": "bun test test/integ.test.ts"
+  },
+  "dependencies": {
+    "effect": "catalog:effect",
+    "foldkit": "catalog:frontend"
+  },
+  "devDependencies": {
+    "@foldkit/vite-plugin": "catalog:frontend",
+    "@types/node": "^24.12.0",
+    "alchemy": "workspace:*",
+    "typescript": "catalog:build",
+    "vite": "catalog:build"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
+    "directory": "examples/cloudflare-foldkit-ssr"
+  }
+}

--- a/examples/cloudflare-foldkit-ssr/src/entry.server.ts
+++ b/examples/cloudflare-foldkit-ssr/src/entry.server.ts
@@ -1,0 +1,30 @@
+import { Effect } from "effect";
+import { Server } from "foldkit/experimental";
+
+import { Flags, init, view } from "./main.ts";
+
+// THE SERVER ENTRY — one Web Request in, one delivery result out. The Worker
+// places the result into the HTML shell; nothing here knows who called it.
+// The same entry is what a build-time prerender would call.
+
+// The count comes off the query string purely so the render has something
+// request-shaped to do: `/?count=7` serves a 7 before any JavaScript runs.
+const flagsForRequest = (request: Request): Flags => {
+  const raw = new URL(request.url).searchParams.get("count");
+  const parsed = raw === null ? Number.NaN : Number(raw);
+  return { initialCount: Number.isFinite(parsed) ? parsed : 0 };
+};
+
+export const renderPage = (request: Request): Promise<Server.EntryResult> =>
+  Effect.runPromise(
+    Effect.gen(function* () {
+      const application = yield* Server.renderToString(
+        { Flags, init, view },
+        {
+          flags: flagsForRequest(request),
+          buildId: import.meta.env.FOLDKIT_BUILD_ID,
+        },
+      );
+      return Server.Rendered(application);
+    }),
+  );

--- a/examples/cloudflare-foldkit-ssr/src/entry.ts
+++ b/examples/cloudflare-foldkit-ssr/src/entry.ts
@@ -1,0 +1,21 @@
+import "./styles.css";
+
+import { Runtime } from "foldkit";
+
+import { Flags, init, Message, Model, update, view } from "./main.ts";
+
+const application = Runtime.makeApplication({
+  Model,
+  Flags,
+  init,
+  update,
+  view,
+  container: document.getElementById("root"),
+});
+
+// HYDRATE, not run: the document arrives already rendered, so the client
+// adopts that DOM instead of rebuilding it. The Flags the server used are
+// read back out of the page — `hydrate` takes no Flags producer of its own.
+// The build id is what makes adoption safe: hydration compares it against the
+// one the server stamped and refuses a page from another deployment.
+Runtime.hydrate(application, { buildId: import.meta.env.FOLDKIT_BUILD_ID });

--- a/examples/cloudflare-foldkit-ssr/src/main.ts
+++ b/examples/cloudflare-foldkit-ssr/src/main.ts
@@ -1,0 +1,82 @@
+import { Match as M, Schema as S } from "effect";
+import { Command } from "foldkit";
+import type { Document, HtmlBuilder } from "foldkit/html";
+import { m } from "foldkit/message";
+
+// MODEL
+
+export const Model = S.Struct({ count: S.Number });
+export type Model = typeof Model.Type;
+
+// FLAGS
+//
+// What the server knew when it rendered, and what the browser is handed back
+// so it can rebuild the same first Model. The server reads it from the
+// request; hydration decodes it from the page rather than guessing. Flags
+// ship in the HTML, so they are public — never put a secret here.
+
+export const Flags = S.Struct({ initialCount: S.Number });
+export type Flags = typeof Flags.Type;
+
+// MESSAGE
+
+export const ClickedDecrement = m("ClickedDecrement");
+export const ClickedIncrement = m("ClickedIncrement");
+export const ClickedReset = m("ClickedReset");
+
+export const Message = S.Union([
+  ClickedDecrement,
+  ClickedIncrement,
+  ClickedReset,
+]);
+export type Message = typeof Message.Type;
+
+// UPDATE
+
+export const update = (
+  model: Model,
+  message: Message,
+): readonly [Model, ReadonlyArray<Command.Command<Message>>] =>
+  M.value(message).pipe(
+    M.withReturnType<
+      readonly [Model, ReadonlyArray<Command.Command<Message>>]
+    >(),
+    M.tagsExhaustive({
+      ClickedDecrement: () => [{ count: model.count - 1 }, []],
+      ClickedIncrement: () => [{ count: model.count + 1 }, []],
+      ClickedReset: () => [{ count: 0 }, []],
+    }),
+  );
+
+// INIT
+//
+// Runs on the server to produce the rendered Model, then again in the browser
+// with the same Flags. Both sides must reach the same Model or hydration
+// rebuilds the tree it was supposed to adopt.
+
+export const init = (
+  flags: Flags,
+): readonly [Model, ReadonlyArray<Command.Command<Message>>] => [
+  { count: flags.initialCount },
+  [],
+];
+
+// VIEW
+
+export const view = (model: Model, h: HtmlBuilder<Message>): Document => ({
+  title: `Counter: ${model.count}`,
+  body: h.div(
+    [h.Id("app")],
+    [
+      h.p([h.Id("count")], [model.count.toString()]),
+      h.div(
+        [],
+        [
+          h.button([h.OnClick(ClickedDecrement())], ["-"]),
+          h.button([h.OnClick(ClickedReset())], ["Reset"]),
+          h.button([h.OnClick(ClickedIncrement())], ["+"]),
+        ],
+      ),
+    ],
+  ),
+});

--- a/examples/cloudflare-foldkit-ssr/src/styles.css
+++ b/examples/cloudflare-foldkit-ssr/src/styles.css
@@ -1,0 +1,4 @@
+body {
+  margin: 0;
+  font-family: ui-sans-serif, system-ui, sans-serif;
+}

--- a/examples/cloudflare-foldkit-ssr/src/vite-env.d.ts
+++ b/examples/cloudflare-foldkit-ssr/src/vite-env.d.ts
@@ -1,0 +1,16 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  /**
+   * The deployment this bundle belongs to, compiled in by
+   * `@foldkit/vite-plugin` from its `buildId` option or the
+   * `FOLDKIT_BUILD_ID` environment variable. Not optional: both entries
+   * require one, and `vite.config.ts` is what guarantees a build always has
+   * it.
+   */
+  readonly FOLDKIT_BUILD_ID: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/examples/cloudflare-foldkit-ssr/src/worker.ts
+++ b/examples/cloudflare-foldkit-ssr/src/worker.ts
@@ -1,0 +1,46 @@
+import { Server } from "foldkit/experimental";
+
+import { renderPage } from "./entry.server.ts";
+
+// Minimal binding shape, so the example needs no Workers type package.
+interface Env {
+  readonly ASSETS: { fetch(request: Request): Promise<Response> };
+}
+
+// THE SHELL — the BUILT index.html, read from the assets binding rather than
+// imported from source. The source template names `/src/entry.ts`; the built
+// one names the hashed bundle, and it is the only copy that cannot disagree
+// with what the browser will be asked to load.
+const shell = (env: Env, url: URL): Promise<string> =>
+  env.ASSETS.fetch(new Request(new URL("/index.html", url.origin))).then(
+    (response) => response.text(),
+  );
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    // A method the `Request` constructor rejects can never reach an entry, so
+    // it is refused here rather than becoming a 500 further in.
+    if (Server.isHostSettledMethod(request.method)) {
+      return new Response(null, {
+        status: Server.HOST_METHOD_ANSWERS.refusedStatus,
+        headers: { Allow: Server.HOST_METHOD_ANSWERS.allow },
+      });
+    }
+
+    // A request that matched no file is not automatically a page. Browsers
+    // ask for scripts and images with `Accept: */*`, which accepts HTML, so a
+    // hashed bundle that is no longer deployed would otherwise be answered
+    // with the shell at 200 — a stale client would read that as its own
+    // JavaScript. Classifying the miss answers it as the miss it is.
+    const classification = Server.classifyRequest(
+      request.url,
+      request.headers.get("sec-fetch-dest") ?? undefined,
+    );
+    if (classification !== "Page") {
+      return new Response("Not found", { status: 404 });
+    }
+
+    const url = new URL(request.url);
+    return Server.toResponse(await shell(env, url), await renderPage(request));
+  },
+};

--- a/examples/cloudflare-foldkit-ssr/test/integ.test.ts
+++ b/examples/cloudflare-foldkit-ssr/test/integ.test.ts
@@ -1,0 +1,119 @@
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Test from "alchemy/Test/Bun";
+import { expect } from "bun:test";
+import * as Console from "effect/Console";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
+import Stack from "../alchemy.run.ts";
+
+const { getWhenReady } = Test;
+
+class AssetNotReady extends Data.TaggedError("AssetNotReady")<{
+  body: string;
+}> {}
+
+// While the static-asset manifest is still propagating, Cloudflare can serve
+// placeholder content with a 200 — the status alone can't distinguish
+// "not yet" from "served", so retry until the body matches.
+const getBodyWhenReady = (url: string, expected: string) =>
+  Effect.gen(function* () {
+    const res = yield* getWhenReady(url);
+    expect(res.status).toBe(200);
+    const body = yield* res.text;
+    if (!body.includes(expected)) {
+      return yield* Effect.fail(new AssetNotReady({ body }));
+    }
+    return body;
+  }).pipe(
+    Effect.retry({
+      while: (error) => error instanceof AssetNotReady,
+      schedule: Schedule.max([
+        Schedule.min([
+          Schedule.exponential("500 millis"),
+          Schedule.spaced("3 seconds"),
+        ]),
+        Schedule.recurs(20),
+      ]),
+    }),
+  );
+
+const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
+  providers: Cloudflare.providers(),
+  state: Cloudflare.state(),
+  stage: "test",
+});
+
+// The first deploy runs the full Vite build, so give the hook more headroom
+// than the default 120s.
+const stack = beforeAll(deploy(Stack).pipe(Effect.tap(Console.log)), {
+  timeout: 600_000,
+});
+afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(Stack));
+
+const base = Effect.map(stack, ({ url }) => {
+  if (!url) throw new Error("expected the site to expose a workers.dev url");
+  return url.replace(/\/+$/, "");
+});
+
+test(
+  "deploys and exposes a url",
+  Effect.gen(function* () {
+    const { url } = yield* stack;
+    expect(url).toBeString();
+  }),
+  { timeout: 180_000 },
+);
+
+// The point of the example: the document carries the page. A client-only
+// deployment would answer with an empty `<div id="root">` here.
+test(
+  "serves markup rendered at the edge",
+  Effect.gen(function* () {
+    const url = yield* base;
+    const html = yield* getBodyWhenReady(url, 'id="count"');
+    expect(html).toContain(">0<");
+    // The title comes from the rendered Document, not from index.html.
+    expect(html).toContain("<title>Counter: 0</title>");
+  }),
+  { timeout: 180_000 },
+);
+
+// Flags are derived from the request, so a different request renders a
+// different page before any JavaScript runs.
+test(
+  "renders request-derived flags",
+  Effect.gen(function* () {
+    const url = yield* base;
+    const html = yield* getBodyWhenReady(`${url}/?count=7`, 'id="count"');
+    expect(html).toContain(">7<");
+    expect(html).toContain("<title>Counter: 7</title>");
+  }),
+  { timeout: 180_000 },
+);
+
+// Hydration compares the stamp before adopting any DOM, so a render without
+// one is a page no client can take over.
+test(
+  "stamps the handoff the client hydrates against",
+  Effect.gen(function* () {
+    const url = yield* base;
+    const html = yield* getBodyWhenReady(url, "data-foldkit-app");
+    expect(html).toContain("data-foldkit-build");
+    // The Flags the server used ride along for the client to decode.
+    expect(html).toContain("data-foldkit-flags");
+  }),
+  { timeout: 180_000 },
+);
+
+// A deep link has no file of its own, so it must reach the Worker and be
+// rendered — not be answered by the asset layer with the template.
+test(
+  "renders a path that matches no file",
+  Effect.gen(function* () {
+    const url = yield* base;
+    const html = yield* getBodyWhenReady(`${url}/anything`, 'id="count"');
+    expect(html).toContain("data-foldkit-app");
+  }),
+  { timeout: 180_000 },
+);

--- a/examples/cloudflare-foldkit-ssr/tsconfig.json
+++ b/examples/cloudflare-foldkit-ssr/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["alchemy.run.ts", "vite.config.ts", "src"],
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "module": "Preserve",
+    "moduleResolution": "Bundler",
+    "target": "ESNext",
+    "lib": ["ESNext", "DOM"]
+  }
+}

--- a/examples/cloudflare-foldkit-ssr/vite.config.ts
+++ b/examples/cloudflare-foldkit-ssr/vite.config.ts
@@ -1,0 +1,24 @@
+import { foldkit } from "@foldkit/vite-plugin";
+import { defineConfig } from "vite";
+
+// The deployment this build belongs to. The server stamps it on the rendered
+// root and the client carries the same value, so hydration can refuse a page
+// from a different deployment before adopting its DOM. A hydratable render
+// fails without one, so a build must always have it: CI supplies a real
+// per-deployment value and a local build falls back to a fresh one rather
+// than a constant, which would make a stale page look current.
+const buildId =
+  process.env.FOLDKIT_BUILD_ID ?? `local-${Date.now().toString(36)}`;
+
+export default defineConfig({
+  // NOTE: the plugin's `ssr: { serverEntry }` option is deliberately NOT set.
+  // It serves rendered pages from the Vite dev server by loading the entry
+  // through `ssrLoadModule`, which requires a runnable `ssr` environment —
+  // and under `alchemy dev` that environment belongs to workerd, which is not
+  // runnable. It is also redundant here: requests reach `src/worker.ts`,
+  // which renders through the same entry.
+  plugins: [foldkit({ buildId })],
+  optimizeDeps: {
+    entries: ["src/entry.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,8 +197,8 @@ catalogs:
       specifier: 1.0.3
       version: 1.0.3
     '@foldkit/vite-plugin':
-      specifier: ^0.15.0
-      version: 0.15.0
+      specifier: ^0.16.1
+      version: 0.16.1
     '@octanejs/adapter-cloudflare':
       specifier: 0.0.12
       version: 0.0.12
@@ -245,8 +245,8 @@ catalogs:
       specifier: 7.2.0
       version: 7.2.0
     foldkit:
-      specifier: ^0.147.0
-      version: 0.147.0
+      specifier: ^0.148.2
+      version: 0.148.2
     hono:
       specifier: ^4.12.14
       version: 4.12.33
@@ -298,7 +298,7 @@ catalogs:
   shared:
     '@opentui/core':
       specifier: latest
-      version: 0.5.4
+      version: 0.5.6
     fast-xml-parser:
       specifier: ^5.3.4
       version: 5.10.1
@@ -1542,11 +1542,11 @@ importers:
         version: 4.0.0-rc.110
       foldkit:
         specifier: catalog:frontend
-        version: 0.147.0(effect@4.0.0-rc.110)
+        version: 0.148.2(effect@4.0.0-rc.110)
     devDependencies:
       '@foldkit/vite-plugin':
         specifier: catalog:frontend
-        version: 0.15.0(effect@4.0.0-rc.110)(foldkit@0.147.0(effect@4.0.0-rc.110))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 0.16.1(effect@4.0.0-rc.110)(foldkit@0.148.2(effect@4.0.0-rc.110))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       '@tailwindcss/vite':
         specifier: catalog:frontend
         version: 4.3.3(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -1559,6 +1559,31 @@ importers:
       tailwindcss:
         specifier: catalog:frontend
         version: 4.3.3
+      typescript:
+        specifier: catalog:build
+        version: 7.0.2
+      vite:
+        specifier: catalog:build
+        version: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
+
+  examples/cloudflare-foldkit-ssr:
+    dependencies:
+      effect:
+        specifier: 4.0.0-rc.110
+        version: 4.0.0-rc.110
+      foldkit:
+        specifier: catalog:frontend
+        version: 0.148.2(effect@4.0.0-rc.110)
+    devDependencies:
+      '@foldkit/vite-plugin':
+        specifier: catalog:frontend
+        version: 0.16.1(effect@4.0.0-rc.110)(foldkit@0.148.2(effect@4.0.0-rc.110))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+      '@types/node':
+        specifier: ^24.12.0
+        version: 24.13.3
+      alchemy:
+        specifier: workspace:*
+        version: link:../../packages/alchemy
       typescript:
         specifier: catalog:build
         version: 7.0.2
@@ -3056,7 +3081,7 @@ importers:
         version: 4.3.3(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       '@tanstack/react-devtools':
         specifier: latest
-        version: 0.10.11(@neodrag/core@3.0.0-next.11)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(csstype@3.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(solid-js@1.9.15)
+        version: 0.10.12(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(csstype@3.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(solid-js@1.9.15)
       '@tanstack/react-router':
         specifier: latest
         version: 1.170.31(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -3105,7 +3130,7 @@ importers:
         version: 0.5.20(tailwindcss@4.3.3)
       '@tanstack/devtools-vite':
         specifier: latest
-        version: 0.8.4(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 0.8.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       '@types/node':
         specifier: ^22.10.2
         version: 22.20.1
@@ -3448,7 +3473,7 @@ importers:
         version: 4.0.0-rc.110(effect@4.0.0-rc.110)
       '@foldkit/vite-plugin':
         specifier: catalog:frontend
-        version: 0.15.0(effect@4.0.0-rc.110)(foldkit@0.147.0(effect@4.0.0-rc.110))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 0.16.1(effect@4.0.0-rc.110)(foldkit@0.148.2(effect@4.0.0-rc.110))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       '@octanejs/adapter-cloudflare':
         specifier: catalog:frontend
         version: 0.0.12(@octanejs/app-core@0.0.18(octane@0.1.22(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))))
@@ -3517,7 +3542,7 @@ importers:
         version: 4.0.0-rc.110
       foldkit:
         specifier: catalog:frontend
-        version: 0.147.0(effect@4.0.0-rc.110)
+        version: 0.148.2(effect@4.0.0-rc.110)
       hono:
         specifier: catalog:frontend
         version: 4.12.33
@@ -3598,7 +3623,7 @@ importers:
         version: 4.0.0-rc.110(effect@4.0.0-rc.110)
       '@opentui/core':
         specifier: catalog:shared
-        version: 0.5.4(typescript@7.0.2)(web-tree-sitter@0.25.10)
+        version: 0.5.6(typescript@7.0.2)(web-tree-sitter@0.25.10)
       effect:
         specifier: 4.0.0-rc.110
         version: 4.0.0-rc.110
@@ -6150,13 +6175,12 @@ packages:
   '@floating-ui/vue@1.1.9':
     resolution: {integrity: sha512-BfNqNW6KA83Nexspgb9DZuz578R7HT8MZw1CfK9I6Ah4QReNWEJsXWHN+SdmOVLNGmTPDi+fDT535Df5PzMLbQ==}
 
-  '@foldkit/vite-plugin@0.15.0':
-    resolution: {integrity: sha512-H0+sdhSn43GaNeIaZuf8/uZT1wBcIIuva/75wqKWLHdqA6lcp6LbKm8GhwCi+IuqSVyB6hkaq+c3ll6lAIgxqA==}
-    engines: {node: '>=18.0.0'}
-    deprecated: Server-rendering security fixes are available in @foldkit/vite-plugin@0.16.0 with foldkit@0.148.0. Safe for SPA use; upgrade if you use the plugin's ssr option.
+  '@foldkit/vite-plugin@0.16.1':
+    resolution: {integrity: sha512-zYbiQbYPRh32jSeocJEKVwsbrL1xD3IKZDBPbE1Dvq4s6LOMWbqbJmON781SVwVJ9cFp0Wh6AITNGsH8GLvccA==}
+    engines: {node: '>=20.19.0'}
     peerDependencies:
       effect: 4.0.0-rc.110
-      foldkit: ^0
+      foldkit: '>=0.148.0'
       vite: ^7.0.0 || ^8.0.0
 
   '@headlessui/tailwindcss@0.2.2':
@@ -7300,50 +7324,50 @@ packages:
     resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
     engines: {node: '>=14'}
 
-  '@opentui/core-darwin-arm64@0.5.4':
-    resolution: {integrity: sha512-oETbn6tg/0g+mOvGXy3iot+1Zv7CGr65U1lRaPJ7kpsKGnOxftCpDD1qA0I6eQwfPJa9k7h9D/9yGB3IbweGcg==}
+  '@opentui/core-darwin-arm64@0.5.6':
+    resolution: {integrity: sha512-g/OOSSXuFlpLOhLHm8w8MsMh1oGVYlQ7QuW8l6oqG9KIkOg4hkYN5eFnpe6Px1p6cNCw5NOC+198WwdcKhQncg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@opentui/core-darwin-x64@0.5.4':
-    resolution: {integrity: sha512-TIeqCNfAV8xvNAv6oVBYsoGBz/p8CxcYm668OQIeBPUO+irqbQ72vJJa/SwFZrUEAHFmsDELaB6y80oHU5Jm6g==}
+  '@opentui/core-darwin-x64@0.5.6':
+    resolution: {integrity: sha512-4+z7/CaV27u9JpdooMa6oRIpLwsaA5j1a2xz7Xzm8oWhakeKGZnW0wUJAfStn/sks3NK5tUpF+eKHa9oawGiEw==}
     cpu: [x64]
     os: [darwin]
 
-  '@opentui/core-linux-arm64-musl@0.5.4':
-    resolution: {integrity: sha512-8vFWd1dsPZj9fHQKlsGHue3ukp7MRjTSpmIrdneIruOcoK2etccHfd6bqIo4FcNr+HA0eI2FP4ZIL9xhE3r9/w==}
+  '@opentui/core-linux-arm64-musl@0.5.6':
+    resolution: {integrity: sha512-cMdxhADkuJW0Nkn7pTB43q5Djg4Ch5i3hlC4iLOVkbOgvckKqz8xJHdl7fuqVs8g5LaadGBmZqdlFKjXIMKl2g==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@opentui/core-linux-arm64@0.5.4':
-    resolution: {integrity: sha512-UrOsX3D5BOO9TI30WvRwEK/lyPPhY75+LwSqeRRe8SV2ON+Ez5QqY4oryTyYC6+yNahTJufz34n0YgwnQaxTNA==}
+  '@opentui/core-linux-arm64@0.5.6':
+    resolution: {integrity: sha512-RAiRmosbg7DH4+ZuXRMjEmQmDAWhcRpuQKQ6bGL76nUd6wl/CufBiD7il/FQMQyUGzmQQH0Hu+pVQLz+kAkNJw==}
     cpu: [arm64]
     os: [linux]
 
-  '@opentui/core-linux-x64-musl@0.5.4':
-    resolution: {integrity: sha512-YYREqUB3v5K0qWij3A5YWzJkkVXp/EqIiuHZKsAjrUAY/0+Bp8Hn0baLvvvkuklpG9whW+GfwIeUsmp4fxqmCA==}
+  '@opentui/core-linux-x64-musl@0.5.6':
+    resolution: {integrity: sha512-vb5mn1i1s8/3lp03O6lX3190eN+iVCZxXOl9qCO5BTCXWtFztyIkp5YDad3/20SptcOHcLPKDiRGWNmSkYBrkQ==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@opentui/core-linux-x64@0.5.4':
-    resolution: {integrity: sha512-1RXzSl6d347O7mUXviXFWlFFyILr7qsVt4jwD3k0UiKtENeEDNi+glM1bKHbXwCdQjfA835QgFA2mbILybK+aQ==}
+  '@opentui/core-linux-x64@0.5.6':
+    resolution: {integrity: sha512-gzlNauPg5UT5UnWiSIlONRwKnkNA6fjN8SyRGlT3SGvcAox+vT2WeP6TwoJSM6pq5H5MF/tlY+REIqc/ZMGJtQ==}
     cpu: [x64]
     os: [linux]
 
-  '@opentui/core-win32-arm64@0.5.4':
-    resolution: {integrity: sha512-F9sB6suPJmwkLF2MwKEC+OtwP6cn5QspIm4MCh2hmu3mVqSz9GDpYID1X3sAh9/V79EVocqiOSqI3KeCTRouKQ==}
+  '@opentui/core-win32-arm64@0.5.6':
+    resolution: {integrity: sha512-FTSpFrNyuh4k2Z3+KeLVLlryFpe89ZyQcqBE0XcmtgiU3RlXuoMPSj2TtRekukR/FaWw9toDBfWokiQjOJGjrA==}
     cpu: [arm64]
     os: [win32]
 
-  '@opentui/core-win32-x64@0.5.4':
-    resolution: {integrity: sha512-2/6dPPPJ9xL/bWz9jh+lZeV2g/tbxZ9N4FBIqwhnqSfIYy5jOnscsPZpcN4X6PstfJAo2yf0Ebk/tLTOzOS6TQ==}
+  '@opentui/core-win32-x64@0.5.6':
+    resolution: {integrity: sha512-rWplkCuHX0OxVi7bO8dAVPttzPpCgmz6Bsu1XCm4ErPAhZOofRd5FbeW2+pC71AbLOKicSwI7lQ4mhGCNaweaA==}
     cpu: [x64]
     os: [win32]
 
-  '@opentui/core@0.5.4':
-    resolution: {integrity: sha512-czcJKQ72QhTWvu1eWfKg4EPN1GLLND6cP9MOhDyqYzCdIZgxQSJVWYzz6c4/CQGOu/qQLRyce2y1efVu4lgQ0w==}
+  '@opentui/core@0.5.6':
+    resolution: {integrity: sha512-e38H1VceXoSSOEYmhUeHDE3F3LHXn/sFEZ6NhbXkbYdrkdV+1MMTgEkGZJ9I5fHhBlJdGJ1LDTPw8V0ZSUXSyQ==}
     peerDependencies:
       web-tree-sitter: 0.25.10
 
@@ -9286,8 +9310,8 @@ packages:
   '@takumi-rs/wasm@0.62.8':
     resolution: {integrity: sha512-V3L4LMoa1hqUxYel+j2oaIYhx7TdfSI/5iStU+7sTDru3o0gwJxw923jG66/F+lLSPGeY4rmYejcJCJN5VfpBA==}
 
-  '@tanstack/devtools-bundler-core@0.1.2':
-    resolution: {integrity: sha512-vU92j/k1oLJ0BEz+lDf/95As8rCmDDkkDk8H6/BUdJ8PtmSyfS2bx4xTbd7QjsTqfIzwcQEBFPUjXYgNKZrRPw==}
+  '@tanstack/devtools-bundler-core@0.1.3':
+    resolution: {integrity: sha512-F0tlxIyfFqXkZ1mJP1EjtkiSeJA+ztXY2AYOHf7r4goCIEAOp86N9PFJ/yv8vu1TnmxGS6vKsZCS3Kyls9xQQA==}
     engines: {node: '>=18'}
 
   '@tanstack/devtools-client@0.0.8':
@@ -9309,15 +9333,15 @@ packages:
     peerDependencies:
       solid-js: '>=1.9.7'
 
-  '@tanstack/devtools-vite@0.8.4':
-    resolution: {integrity: sha512-8Rq0Tb9v3atTJtgNVyHWHkZWsnv/QdBCPhSD6Ia+MyfImgtHQMWrMEc7BT3cUVA0M+BH/YXSuBxkiOx5vlGCmQ==}
+  '@tanstack/devtools-vite@0.8.5':
+    resolution: {integrity: sha512-xaifCEmiwwzizlbp973oISXNsnmuU/BugLa66gryAZaPJJ/qo1kJd2DxY5X960eHwmyIS3SN0KYrL3/aRhucmA==}
     engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  '@tanstack/devtools@0.14.1':
-    resolution: {integrity: sha512-OURovHbCJNOMHtSHRvJtLMdP32Q7y04m8iGgHmtTAYIpUiqRaRXAZ4Y87odpQKToUOYXCOjXiEREbYJoCB2dQQ==}
+  '@tanstack/devtools@0.14.2':
+    resolution: {integrity: sha512-8FVVmDU+x3iEwrl5rtbIhud8gwp9eSXPlhs36SCV59yAtXmheFFvLqLAUXpfIU79sZVBg3LLTy2VlTIXaWbaBw==}
     engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
@@ -9336,8 +9360,8 @@ packages:
   '@tanstack/query-core@5.101.4':
     resolution: {integrity: sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw==}
 
-  '@tanstack/react-devtools@0.10.11':
-    resolution: {integrity: sha512-kMt61UiKj820XAVoLr0zvRXLa3XACLim8EzoiBOQmVJ/z6MHXCWL4q9TlXsmxHN0H26oI3tmRLArxo6s0kASeA==}
+  '@tanstack/react-devtools@0.10.12':
+    resolution: {integrity: sha512-dgoz7TFm97Izo/D34z91PD0h+ufk+eBmoN9OgRHJlj/c7Ol5xpIP7bqLBNByjgt5paRE2eSu5AQHV92Ul+G6iw==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/react': '>=16.8'
@@ -12247,10 +12271,9 @@ packages:
   focus-trap@7.8.0:
     resolution: {integrity: sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==}
 
-  foldkit@0.147.0:
-    resolution: {integrity: sha512-RCyvuRjEXiMP62XCO5A+ati2kb+Na+HOQeTmDJU8dbtWuqHrU+0jSbWos4GPaxshOJ/V1kxP9X8nj63cBXu7Dw==}
-    engines: {node: '>=18.0.0'}
-    deprecated: Server-rendering security fixes are available in foldkit@0.148.0. Safe for SPA use; upgrade if you use foldkit/experimental/server.
+  foldkit@0.148.2:
+    resolution: {integrity: sha512-Bf735uDqbKU1jSUAMgkV1aMUEf5X+4ljsfQFkylgowOSKqTSEY0NYgrsAKiFSFkW3G2ReF1qyX61lBdbItYxnQ==}
+    engines: {node: '>=20.19.0'}
     peerDependencies:
       effect: 4.0.0-rc.110
 
@@ -19357,10 +19380,10 @@ snapshots:
       - '@vue/composition-api'
       - vue
 
-  '@foldkit/vite-plugin@0.15.0(effect@4.0.0-rc.110)(foldkit@0.147.0(effect@4.0.0-rc.110))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))':
+  '@foldkit/vite-plugin@0.16.1(effect@4.0.0-rc.110)(foldkit@0.148.2(effect@4.0.0-rc.110))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))':
     dependencies:
       effect: 4.0.0-rc.110
-      foldkit: 0.147.0(effect@4.0.0-rc.110)
+      foldkit: 0.148.2(effect@4.0.0-rc.110)
       magic-string: 0.30.21
       vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
       ws: 8.21.3
@@ -19368,10 +19391,10 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@foldkit/vite-plugin@0.15.0(effect@4.0.0-rc.110)(foldkit@0.147.0(effect@4.0.0-rc.110))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))':
+  '@foldkit/vite-plugin@0.16.1(effect@4.0.0-rc.110)(foldkit@0.148.2(effect@4.0.0-rc.110))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))':
     dependencies:
       effect: 4.0.0-rc.110
-      foldkit: 0.147.0(effect@4.0.0-rc.110)
+      foldkit: 0.148.2(effect@4.0.0-rc.110)
       magic-string: 0.30.21
       vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
       ws: 8.21.3
@@ -21171,31 +21194,31 @@ snapshots:
 
   '@opentelemetry/semantic-conventions@1.43.0': {}
 
-  '@opentui/core-darwin-arm64@0.5.4':
+  '@opentui/core-darwin-arm64@0.5.6':
     optional: true
 
-  '@opentui/core-darwin-x64@0.5.4':
+  '@opentui/core-darwin-x64@0.5.6':
     optional: true
 
-  '@opentui/core-linux-arm64-musl@0.5.4':
+  '@opentui/core-linux-arm64-musl@0.5.6':
     optional: true
 
-  '@opentui/core-linux-arm64@0.5.4':
+  '@opentui/core-linux-arm64@0.5.6':
     optional: true
 
-  '@opentui/core-linux-x64-musl@0.5.4':
+  '@opentui/core-linux-x64-musl@0.5.6':
     optional: true
 
-  '@opentui/core-linux-x64@0.5.4':
+  '@opentui/core-linux-x64@0.5.6':
     optional: true
 
-  '@opentui/core-win32-arm64@0.5.4':
+  '@opentui/core-win32-arm64@0.5.6':
     optional: true
 
-  '@opentui/core-win32-x64@0.5.4':
+  '@opentui/core-win32-x64@0.5.6':
     optional: true
 
-  '@opentui/core@0.5.4(typescript@7.0.2)(web-tree-sitter@0.25.10)':
+  '@opentui/core@0.5.6(typescript@7.0.2)(web-tree-sitter@0.25.10)':
     dependencies:
       bun-ffi-structs: 0.3.1(typescript@7.0.2)
       diff: 9.0.0
@@ -21204,14 +21227,14 @@ snapshots:
       strip-ansi: 7.1.2
       web-tree-sitter: 0.25.10
     optionalDependencies:
-      '@opentui/core-darwin-arm64': 0.5.4
-      '@opentui/core-darwin-x64': 0.5.4
-      '@opentui/core-linux-arm64': 0.5.4
-      '@opentui/core-linux-arm64-musl': 0.5.4
-      '@opentui/core-linux-x64': 0.5.4
-      '@opentui/core-linux-x64-musl': 0.5.4
-      '@opentui/core-win32-arm64': 0.5.4
-      '@opentui/core-win32-x64': 0.5.4
+      '@opentui/core-darwin-arm64': 0.5.6
+      '@opentui/core-darwin-x64': 0.5.6
+      '@opentui/core-linux-arm64': 0.5.6
+      '@opentui/core-linux-arm64-musl': 0.5.6
+      '@opentui/core-linux-x64': 0.5.6
+      '@opentui/core-linux-x64-musl': 0.5.6
+      '@opentui/core-win32-arm64': 0.5.6
+      '@opentui/core-win32-x64': 0.5.6
     transitivePeerDependencies:
       - typescript
 
@@ -23367,7 +23390,7 @@ snapshots:
 
   '@takumi-rs/wasm@0.62.8': {}
 
-  '@tanstack/devtools-bundler-core@0.1.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)':
+  '@tanstack/devtools-bundler-core@0.1.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)':
     dependencies:
       '@tanstack/devtools-client': 0.0.8
       '@tanstack/devtools-event-bus': 0.4.3
@@ -23404,9 +23427,9 @@ snapshots:
     transitivePeerDependencies:
       - csstype
 
-  '@tanstack/devtools-vite@0.8.4(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))':
+  '@tanstack/devtools-vite@0.8.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))':
     dependencies:
-      '@tanstack/devtools-bundler-core': 0.1.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)
+      '@tanstack/devtools-bundler-core': 0.1.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)
       '@tanstack/devtools-client': 0.0.8
       '@tanstack/devtools-event-bus': 0.4.3
       chalk: 5.6.2
@@ -23417,8 +23440,9 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@tanstack/devtools@0.14.1(@neodrag/core@3.0.0-next.11)(csstype@3.2.3)(solid-js@1.9.15)':
+  '@tanstack/devtools@0.14.2(csstype@3.2.3)(solid-js@1.9.15)':
     dependencies:
+      '@neodrag/core': 3.0.0-next.11
       '@neodrag/solid': 3.0.0-next.11(@neodrag/core@3.0.0-next.11)(solid-js@1.9.15)
       '@solid-primitives/event-listener': 2.4.6(solid-js@1.9.15)
       '@solid-primitives/keyboard': 1.3.7(solid-js@1.9.15)
@@ -23430,7 +23454,6 @@ snapshots:
       goober: 2.1.19(csstype@3.2.3)
       solid-js: 1.9.15
     transitivePeerDependencies:
-      - '@neodrag/core'
       - bufferutil
       - csstype
       - utf-8-validate
@@ -23453,15 +23476,14 @@ snapshots:
 
   '@tanstack/query-core@5.101.4': {}
 
-  '@tanstack/react-devtools@0.10.11(@neodrag/core@3.0.0-next.11)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(csstype@3.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(solid-js@1.9.15)':
+  '@tanstack/react-devtools@0.10.12(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(csstype@3.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(solid-js@1.9.15)':
     dependencies:
-      '@tanstack/devtools': 0.14.1(@neodrag/core@3.0.0-next.11)(csstype@3.2.3)(solid-js@1.9.15)
+      '@tanstack/devtools': 0.14.2(csstype@3.2.3)(solid-js@1.9.15)
       '@types/react': 19.2.18
       '@types/react-dom': 19.2.4(@types/react@19.2.18)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
     transitivePeerDependencies:
-      - '@neodrag/core'
       - bufferutil
       - csstype
       - solid-js
@@ -27583,7 +27605,7 @@ snapshots:
     dependencies:
       tabbable: 6.5.0
 
-  foldkit@0.147.0(effect@4.0.0-rc.110):
+  foldkit@0.148.2(effect@4.0.0-rc.110):
     dependencies:
       effect: 4.0.0-rc.110
       parse5: 8.0.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -102,7 +102,7 @@ catalogs:
   frontend:
     "@astrojs/internal-helpers": 0.10.1
     "@astrojs/underscore-redirects": 1.0.3
-    "@foldkit/vite-plugin": ^0.15.0
+    "@foldkit/vite-plugin": ^0.16.1
     "@octanejs/adapter-cloudflare": 0.0.12
     "@octanejs/vite-plugin": 0.1.22
     "@opennextjs/aws": 4.1.0
@@ -119,7 +119,7 @@ catalogs:
     "@vitejs/plugin-react": ^6.0.2
     "@vitejs/plugin-rsc": ^0.5.27
     astro: 7.2.0
-    foldkit: ^0.147.0
+    foldkit: ^0.148.2
     hono: ^4.12.14
     next: 16.2.10
     nitropack: 2.13.4
@@ -177,6 +177,6 @@ minimumReleaseAgeExclude:
   - '@effect/sql-pg@4.0.0-rc.110'
   - '@effect/sql-sqlite-do@4.0.0-rc.110'
   - '@effect/vitest@4.0.0-rc.110'
-  - '@foldkit/vite-plugin@0.15.0'
+  - '@foldkit/vite-plugin@0.16.1'
   - effect@4.0.0-rc.110
-  - foldkit@0.147.0
+  - foldkit@0.148.2

--- a/scripts/test-examples.ts
+++ b/scripts/test-examples.ts
@@ -9,6 +9,7 @@ const examples = [
   "./examples/cloudflare-vue",
   "./examples/cloudflare-solidstart",
   "./examples/cloudflare-foldkit",
+  "./examples/cloudflare-foldkit-ssr",
   "./examples/cloudflare-octane",
   "./examples/cloudflare-website-astro",
   "./examples/cloudflare-website-nextjs",


### PR DESCRIPTION
## Why

`examples/cloudflare-foldkit` is the client-only shape. Foldkit's docs are explicit that server rendering is not a different kind of application:

> SSG and SSR are delivery policies, not separate Foldkit application types.

So the server-rendered shape is a different *deployment* of the same kind of app — and it needs asset routing the client-only one does not. Nothing in the repo showed it.

Companion to #1313, but independent: this example passes explicit `assets`, so it behaves the same before or after that change.

## What the example covers

The parts with no counterpart in a client-only deployment:

- **`src/entry.server.ts`** — `renderPage(Request)`, deriving Flags from the request and rendering through the same `view` the browser uses.
- **`src/worker.ts`** — reads the built shell from the `ASSETS` binding, places the render into it with `Server.toResponse`, and answers refused methods and asset misses itself. It reads the *built* `index.html`, not the source template: the source names `/src/entry.ts` while the built one names the hashed bundle, and only the latter can't disagree with what the browser is asked to load.
- **`src/entry.ts`** — `Runtime.hydrate` rather than `Runtime.run`.
- **`vite.config.ts`** — the build id both entries require.
- **`alchemy.run.ts`** — `htmlHandling: "none"` + `notFoundHandling: "none"`, with a comment on why each is load-bearing.

Flags come off the query string, so `/?count=7` visibly renders a 7 before any JavaScript runs. That gives the integration test something only a server render can produce.

## Catalog bump

`foldkit ^0.147.0 → ^0.148.2` and `@foldkit/vite-plugin ^0.15.0 → ^0.16.1`, which must move together (0.16.x peers `foldkit >= 0.148.0`).

0.148.0 is where `renderToString` takes a `buildId` and `Runtime.hydrate` stops accepting a bare `hydrate(application)` — deliberately, because an absent id is indistinguishable from a page served before build ids existed. Writing a new example against 0.147's pre-`buildId` API would ship the shape upstream had just removed as unsafe.

Both catalog consumers — `examples/cloudflare-foldkit` and the `packages/alchemy` test fixture, where foldkit is a devDependency only — are client-only apps on `Runtime.run` and are unaffected.

## One note for reviewers

The Foldkit Vite plugin's `ssr: { serverEntry }` option is deliberately **not** set. It serves rendered pages from the Vite dev server by loading the entry through `ssrLoadModule`, which requires a runnable `ssr` environment — and under `alchemy dev` that environment is workerd's, which is not runnable. Setting it makes every page request 500 with `ssrLoadModule requires the 'ssr' environment to be a runnable environment`. It is redundant here regardless: requests reach `src/worker.ts`, which renders through the same entry. This is called out in the example's README and in `vite.config.ts` so nobody adds it back.

## Verification

`tsc --noEmit` clean, `oxfmt --check` clean, and `vite build` produces a client bundle with the build id compiled in. The integration test deploys against real Cloudflare and I have not run it.