### PR TITLE
fix(cloudflare): strip unresolved input leaves from cold Worker adoption reads

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -18,12 +18,19 @@ import { Unowned } from "../../AdoptPolicy.ts";
 import * as Artifacts from "../../Artifacts.ts";
 import type { ScopedPlanStatusSession } from "../../Cli/Cli.ts";
 import { hashDirectory, type MemoOptions } from "../../Command/Memo.ts";
-import { havePropsChanged, isResolved, stripEffects } from "../../Diff.ts";
+import {
+  havePropsChanged,
+  isResolved,
+  stripEffects,
+  stripUnresolved,
+} from "../../Diff.ts";
+import type { Input } from "../../Input.ts";
 import * as ProviderLayer from "../../Local/ProviderLayer.ts";
 import * as Provider from "../../Provider.ts";
 import { type ResourceBinding } from "../../Resource.ts";
 import { Stack } from "../../Stack.ts";
 import { cachedFunction } from "../../Util/cached-function.ts";
+import { isPlainData } from "../../Util/data.ts";
 import { initialCwd } from "../../Util/Node.ts";
 import { sha256Object } from "../../Util/sha256.ts";
 import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
@@ -212,6 +219,77 @@ export const resolveVersionParentName = (
   if (typeof parent === "string") return parent;
   const workerName = (parent as { workerName?: unknown }).workerName;
   return typeof workerName === "string" ? workerName : undefined;
+};
+
+type WorkerReadInput = {
+  [K in keyof WorkerProps]?: Input<WorkerProps[K]>;
+};
+
+/**
+ * Project desired Worker props for a cold adoption read. Script name,
+ * dispatch namespace, and version parent determine which cloud resource is
+ * read, so each must already have a concrete identity. Other unresolved
+ * leaves, such as bindings in `env`, are safe to omit from the read.
+ *
+ * Domain, route, and cron props control optional observation calls. Keep each
+ * surface only when its complete declaration is resolved; reconcile performs
+ * the forced adoption update from the original desired props afterward.
+ *
+ * @internal exported for unit testing.
+ */
+export const resolveWorkerReadProps = (
+  news: Input<WorkerProps>,
+): Option.Option<WorkerProps> => {
+  if (!isPlainData(news) || Array.isArray(news)) return Option.none();
+  const desired = news as WorkerReadInput;
+
+  const name = desired.name;
+  if (name !== undefined && typeof name !== "string") return Option.none();
+
+  const namespace = desired.namespace;
+  let namespaceName: string | undefined;
+  if (namespace != null) {
+    if (
+      typeof namespace !== "string" &&
+      (!isPlainData(namespace) || Array.isArray(namespace))
+    ) {
+      return Option.none();
+    }
+    namespaceName = resolveNamespaceName(namespace);
+    if (typeof namespaceName !== "string") return Option.none();
+  }
+
+  const version = desired.version;
+  let parentName: string | undefined;
+  if (version != null) {
+    if (!isPlainData(version) || Array.isArray(version)) return Option.none();
+    const parent = version.parent;
+    if (parent != null) {
+      parentName =
+        typeof parent === "string"
+          ? parent
+          : isPlainData(parent) && !Array.isArray(parent)
+            ? typeof parent.workerName === "string"
+              ? parent.workerName
+              : undefined
+            : undefined;
+      if (parentName === undefined) return Option.none();
+    }
+  }
+
+  const projected = stripUnresolved(desired) as WorkerProps;
+  projected.name = name;
+  projected.namespace = namespaceName;
+  if (parentName === undefined) {
+    delete projected.version;
+  } else {
+    projected.version = { parent: parentName };
+  }
+  if (!isResolved(desired.domain)) delete projected.domain;
+  if (!isResolved(desired.routes)) delete projected.routes;
+  if (!isResolved(desired.crons)) delete projected.crons;
+
+  return Option.some(projected);
 };
 
 /**
@@ -4229,6 +4307,7 @@ export const LiveWorkerProvider = () =>
 
       return Worker.Provider.of({
         stables: ["workerId", "workerName"],
+        resolveReadProps: resolveWorkerReadProps,
         list: () =>
           Effect.gen(function* () {
             const { accountId } = yield* yield* CloudflareEnvironment;

--- a/packages/alchemy/src/Plan.ts
+++ b/packages/alchemy/src/Plan.ts
@@ -1165,13 +1165,10 @@ export const make = <A>(
             // update keeps the deploy idempotent: if cloud state already
             // matches news, the provider's update is a no-op write.
             //
-            // Skip the adoption probe entirely when `news` still contains
-            // unresolved upstream Outputs (e.g. a `streamArn` referencing
-            // a stream being created in the same plan). Calling `read` with
-            // an unresolved value would surface as `ParseError` from the
-            // SDK protocol layer. Resources whose props depend on
-            // not-yet-created upstreams cannot themselves be pre-existing
-            // — there's nothing to adopt.
+            // Providers may opt into cold reads with unresolved desired props
+            // by projecting them to a safe shape. The projection owns the
+            // provider-specific distinction between identity and unrelated
+            // inputs. Without one, unresolved props skip the probe as before.
             // A resource declared at a former FQN whose row just migrated
             // away is genuinely NEW by declaration — skip the probe. Its
             // predecessor's physical resource still carries tags branded
@@ -1180,10 +1177,25 @@ export const make = <A>(
             // and silently adopt the very resource that was renamed away.
             const reusesMigratedFqn = migratedRowFqns.has(fqn);
             let forceUpdateAfterAdoption = false;
+            const readProps =
+              oldState === undefined && provider.read && !reusesMigratedFqn
+                ? isResolved(news)
+                  ? Option.some(news)
+                  : (provider.resolveReadProps?.(news) ?? Option.none())
+                : Option.none();
+            if (Option.isSome(readProps) && !isResolved(readProps.value)) {
+              return yield* Effect.die(
+                new Error(
+                  `Provider '${resource.Type}' returned unresolved props from ` +
+                    `resolveReadProps for '${fqn}'. The hook must return fully ` +
+                    "resolved props or None.",
+                ),
+              );
+            }
             if (
               oldState === undefined &&
               provider.read &&
-              isResolved(news) &&
+              Option.isSome(readProps) &&
               !reusesMigratedFqn
             ) {
               const adoptInstanceId = yield* generateInstanceId();
@@ -1192,7 +1204,7 @@ export const make = <A>(
                   id,
                   fqn,
                   instanceId: adoptInstanceId,
-                  olds: news,
+                  olds: readProps.value,
                   output: undefined,
                 })
                 .pipe(providePlanScope(fqn, adoptInstanceId));

--- a/packages/alchemy/src/Provider.ts
+++ b/packages/alchemy/src/Provider.ts
@@ -242,6 +242,13 @@ export interface ProviderService<
     output: Res["Attributes"] | undefined; // current state -> synced state
   }): Effect.Effect<Res["Attributes"] | undefined, any, ReadReq>;
   /**
+   * Projects unresolved desired props into a safe, resolved shape for a cold
+   * adoption read. Return `None` when any physical-identity input needed by
+   * {@link read} is still unresolved. Providers without this hook retain the
+   * default behavior of skipping cold reads until all desired props resolve.
+   */
+  resolveReadProps?(news: Input<Props<Res>>): Option.Option<Props<Res>>;
+  /**
    * Properties that are always stable across any update.
    */
   stables?: Extract<keyof Res["Attributes"], string>[];

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerProvider.read-props.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerProvider.read-props.test.ts
@@ -1,0 +1,104 @@
+import { resolveWorkerReadProps } from "@/Cloudflare/Workers/WorkerProvider";
+import * as Output from "@/Output";
+import { describe, expect, test } from "alchemy-test";
+import * as Option from "effect/Option";
+
+// Cold adoption reads project desired props through
+// `resolveReadProps` before the provider's `read` runs. The projection
+// must never hand an unresolved leaf to the Cloudflare API, while keeping
+// every identity-determining field concrete.
+
+describe("resolveWorkerReadProps", () => {
+  test("passes fully resolved props through", () => {
+    const news = {
+      name: "my-worker",
+      env: { FOO: "bar" },
+      crons: ["* * * * *"],
+    };
+    const projected = resolveWorkerReadProps(news as any);
+    expect(Option.isSome(projected)).toBe(true);
+    expect((projected as any).value).toEqual({
+      name: "my-worker",
+      env: { FOO: "bar" },
+      crons: ["* * * * *"],
+    });
+  });
+
+  test("omits an unresolved leaf inside env", () => {
+    const projected = resolveWorkerReadProps({
+      name: "my-worker",
+      env: {
+        RESOLVED: "yes",
+        PENDING: Output.literal("later"),
+      },
+    } as any);
+    expect(Option.isSome(projected)).toBe(true);
+    const value = (projected as Option.Option<any>).value;
+    // The unresolved binding is stripped so the read payload stays plain
+    // data — an Output reaching the SDK protocol layer surfaces as
+    // ParseError.
+    expect(value.env.PENDING).toBeUndefined();
+    expect(value.env.RESOLVED).toBe("yes");
+  });
+
+  test("returns None when the script name is unresolved", () => {
+    const projected = resolveWorkerReadProps({
+      name: Output.literal("my-worker"),
+    } as any);
+    expect(Option.isNone(projected)).toBe(true);
+  });
+
+  test("resolves a DispatchNamespace resource to its name", () => {
+    const projected = resolveWorkerReadProps({
+      name: "my-worker",
+      namespace: { name: "outbound" },
+    } as any);
+    expect(Option.isSome(projected)).toBe(true);
+    expect((projected as any).value.namespace).toBe("outbound");
+  });
+
+  test("returns None when the dispatch namespace is unresolved", () => {
+    const projected = resolveWorkerReadProps({
+      name: "my-worker",
+      namespace: Output.literal("outbound"),
+    } as any);
+    expect(Option.isNone(projected)).toBe(true);
+  });
+
+  test("reduces version.parent to the parent script name", () => {
+    const byResource = resolveWorkerReadProps({
+      name: "versioned-worker",
+      version: { parent: { workerName: "parent" } },
+    } as any);
+    expect(Option.isSome(byResource)).toBe(true);
+    expect((byResource as any).value.version).toEqual({ parent: "parent" });
+
+    const byName = resolveWorkerReadProps({
+      name: "versioned-worker",
+      version: { parent: "parent" },
+    } as any);
+    expect((byName as any).value.version).toEqual({ parent: "parent" });
+  });
+
+  test("returns None when the version parent is unresolved", () => {
+    const projected = resolveWorkerReadProps({
+      name: "versioned-worker",
+      version: { parent: Output.literal("parent") },
+    } as any);
+    expect(Option.isNone(projected)).toBe(true);
+  });
+
+  test("keeps domain, routes, and crons only when fully resolved", () => {
+    const projected = resolveWorkerReadProps({
+      name: "my-worker",
+      domain: Output.literal("example.com"),
+      routes: [{ pattern: "example.com/*" }],
+      crons: ["* * * * *"],
+    } as any);
+    expect(Option.isSome(projected)).toBe(true);
+    const value = (projected as Option.Option<any>).value;
+    expect(value.domain).toBeUndefined();
+    expect(value.routes).toEqual([{ pattern: "example.com/*" }]);
+    expect(value.crons).toEqual(["* * * * *"]);
+  });
+});


### PR DESCRIPTION
A fresh `Cloudflare.Worker` whose props contain unresolved Outputs (resource-backed bindings resolved later in the same plan) skips the cold adoption read entirely, so an existing foreign script can be planned as `create` without any ownership check.

Fixes #1299.

- Add an optional `resolveReadProps` hook to `ProviderService`. `Plan.ts` calls it when desired props are unresolved and would otherwise skip the adoption probe; a projection that is still unresolved dies loudly instead of reaching the provider.
- The Cloudflare Worker provider projects cold-read props through `resolveWorkerReadProps`: identity fields (`name`, dispatch `namespace`, `version.parent`) must be concrete or the read returns `None`; other unresolved leaves (e.g. bindings in `env`) are stripped; unresolved `domain`/`routes`/`crons` surfaces are dropped since reconcile performs the forced adoption update from the original desired props afterward.

```diff
 const readProps =
   oldState === undefined && provider.read && !reusesMigratedFqn
     ? isResolved(news)
       ? Option.some(news)
       : (provider.resolveReadProps?.(news) ?? Option.none())
     : Option.none();
```
