### PR TITLE
fix(fly): unresolvable Postgres direct URI, dead code-change detection, in-network example migrations

### DIFF
--- a/examples/fly-postgres/src/api.ts
+++ b/examples/fly-postgres/src/api.ts
@@ -1,15 +1,20 @@
 import * as Drizzle from "alchemy/Drizzle/Postgres";
 import * as Fly from "alchemy/Fly";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import * as Effect from "effect/Effect";
 import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import { relations, Users } from "./schema.ts";
-import { API_PORT, Db, Site } from "./shared.ts";
+import { API_PORT, Db, MIGRATE_TOKEN, Site } from "./shared.ts";
 
 /**
  * HTTP Service that binds Managed Postgres via {@link Fly.ConnectPostgres}
  * and queries through Drizzle.
+ *
+ * Also exposes `POST /migrate`: MPG is only reachable on the org's private
+ * network, so DDL is applied through this in-network Service — the deploy
+ * (or test) posts the generated migration SQL here instead of connecting
+ * to the cluster directly.
  */
 export default class Api extends Fly.Service<Api>()(
   "Api",
@@ -19,17 +24,53 @@ export default class Api extends Fly.Service<Api>()(
     region: "iad",
     port: API_PORT,
     guest: { cpuKind: "shared", cpus: 1, memoryMb: 256 },
+    // `pg` is CommonJS — bundling it breaks `Client` under Rolldown's
+    // interop. Install it into the image so `@effect/sql-pg` /
+    // `Drizzle.Postgres` load it with Node's CJS semantics.
+    build: { install: ["pg"] },
   },
   Effect.gen(function* () {
     const conn = yield* Fly.ConnectPostgres(Db);
     const db = yield* Drizzle.Postgres(conn.connectionString, {
       relations,
     });
+    // DDL and other session-scoped statements need the direct
+    // (non-PgBouncer) connection.
+    const directDb = yield* Drizzle.Postgres(conn.directConnectionString);
 
     return {
       fetch: Effect.gen(function* () {
         const request = yield* HttpServerRequest;
         const path = new URL(request.url, "http://service").pathname;
+        if (path === "/migrate" && request.method === "POST") {
+          if (request.headers["x-migrate-token"] !== MIGRATE_TOKEN) {
+            return yield* HttpServerResponse.json(
+              { error: "unauthorized" },
+              { status: 401 },
+            );
+          }
+          // drizzle-kit emits one file per migration with statements
+          // separated by `--> statement-breakpoint`. Apply each statement,
+          // tolerating re-runs (the client retries through service warmup,
+          // so a statement may already have been applied).
+          const body = yield* request.text;
+          const statements = body
+            .split("--> statement-breakpoint")
+            .map((statement) => statement.trim())
+            .filter((statement) => statement.length > 0);
+          for (const statement of statements) {
+            yield* directDb.execute(sql.raw(statement)).pipe(
+              Effect.catch((error) =>
+                String(error).includes("already exists")
+                  ? Effect.void
+                  : Effect.fail(error),
+              ),
+            );
+          }
+          return yield* HttpServerResponse.json({
+            applied: statements.length,
+          });
+        }
         if (path === "/health") {
           const users = yield* db.select().from(Users);
           return yield* HttpServerResponse.json({

--- a/examples/fly-postgres/src/shared.ts
+++ b/examples/fly-postgres/src/shared.ts
@@ -1,32 +1,34 @@
 import * as Drizzle from "alchemy/Drizzle";
 import * as Fly from "alchemy/Fly";
-import * as Effect from "effect/Effect";
 
 export const API_PORT = 3000;
+
+/**
+ * Shared token for the fixture's `POST /migrate` route. Fly Managed
+ * Postgres is only reachable on the org's private network, so migrations
+ * are applied THROUGH the deployed Service (which is in-network) — the
+ * integ test reads the generated SQL locally and posts it here. A
+ * checked-in constant is fine for this throwaway demo database; real apps
+ * should use a deploy-time secret.
+ */
+export const MIGRATE_TOKEN = "fly-postgres-example-migrate";
 
 export const Site = Fly.App("Site", {
   enableSubdomains: true,
 });
 
 /**
- * Drizzle schema + Fly Managed Postgres. `migrations: schema` makes
- * `Drizzle.Schema` regenerate pending SQL, then `Fly.Postgres` applies
- * it on deploy.
+ * Drizzle schema generation. The generated SQL under `./migrations` is
+ * applied through the Api service's `/migrate` route (see api.ts) — MPG
+ * hostnames don't resolve outside the org's private network, so the
+ * in-network Service is the data plane for DDL too.
  */
 export const Schema = Drizzle.Schema("app-schema", {
   schema: "./src/schema.ts",
   out: "./migrations",
 });
 
-export const Db = Fly.Postgres(
-  "Db",
-  Effect.gen(function* () {
-    // Yield the schema so the cluster depends on it: Drizzle regenerates
-    // pending SQL first, then Fly.Postgres applies it.
-    const schema = yield* Schema;
-    return { region: "iad", migrations: schema };
-  }),
-);
+export const Db = Fly.Postgres("Db", { region: "iad" });
 
 export const PublicIp = Fly.IpAssignment("Shared", {
   app: Site,

--- a/examples/fly-postgres/test/integ.test.ts
+++ b/examples/fly-postgres/test/integ.test.ts
@@ -2,28 +2,20 @@ import * as Alchemy from "alchemy";
 import * as Drizzle from "alchemy/Drizzle";
 import * as Fly from "alchemy/Fly";
 import * as Test from "alchemy/Test/Bun";
-import { expect, test as bunTest } from "bun:test";
+import { expect } from "bun:test";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Schedule from "effect/Schedule";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import * as fs from "node:fs";
+import * as path from "node:path";
 import Stack from "../alchemy.run.ts";
 import type { User } from "../src/schema.ts";
+import { MIGRATE_TOKEN } from "../src/shared.ts";
 
 /** A `User` row as it arrives over JSON — `createdAt` is an ISO string. */
 type SerializedUser = Omit<User, "createdAt"> & { createdAt: string };
-
-/**
- * Fly Managed Postgres is only reachable on the org's PRIVATE network —
- * `direct.<hash>.flympg.net` does not resolve publicly. The stack applies
- * deploy-time Drizzle migrations from THIS process, so without a route (a
- * WireGuard peer, `fly mpg proxy`, or a machine on 6PN) the deploy fails
- * with `Fly.PostgresMigrationError: getaddrinfo ENOTFOUND`. Gate the whole
- * suite — deploy included — behind FLY_TEST_MPG=1 so a routed environment
- * runs the full lifecycle unchanged.
- */
-const hasMpgRoute = !!process.env.FLY_TEST_MPG;
 
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Layer.mergeAll(Fly.providers(), Drizzle.providers()),
@@ -31,57 +23,88 @@ const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   profile: process.env.ALCHEMY_PROFILE,
 });
 
-const fetchOk = (url: string) =>
+/**
+ * Generated migration SQL, in journal order. `Drizzle.Schema` writes these
+ * during the deploy in `beforeAll`, so read lazily inside the test.
+ */
+const readMigrationSql = (): string[] => {
+  const dir = path.resolve(import.meta.dirname, "..", "migrations");
+  return fs
+    .readdirSync(dir)
+    .filter((entry) => fs.existsSync(path.join(dir, entry, "migration.sql")))
+    .sort()
+    .map((entry) =>
+      fs.readFileSync(path.join(dir, entry, "migration.sql"), "utf8"),
+    );
+};
+
+/** Run a request, retrying non-200s through the fresh app's warmup. */
+const executeOk = (request: HttpClientRequest.HttpClientRequest) =>
   Effect.gen(function* () {
     const client = yield* HttpClient.HttpClient;
-    return yield* client.get(url).pipe(
+    return yield* client.execute(request).pipe(
       Effect.flatMap((res) =>
         res.status === 200
           ? Effect.succeed(res)
           : Effect.fail(new Error(`HTTP ${res.status}`)),
       ),
+      // Bounded (~90s): machine boot + route warmup. Never use unbounded
+      // exponential growth here — a genuinely broken route should surface
+      // well inside the test timeout.
       Effect.retry({
-        schedule: Schedule.exponential("500 millis"),
-        times: 20,
+        schedule: Schedule.spaced("2 seconds"),
+        times: 45,
       }),
     );
   });
 
-if (!hasMpgRoute) {
-  // Register ONLY the skip marker — no beforeAll, so nothing deploys.
-  bunTest.skip(
-    "Service connects to Managed Postgres through Drizzle (set FLY_TEST_MPG=1 in an environment routed to the MPG private network)",
-    () => {},
-  );
-} else {
-  const stack = beforeAll(deploy(Stack), { timeout: 300_000 });
+const stack = beforeAll(deploy(Stack), { timeout: 300_000 });
 
-  afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(Stack), {
-    timeout: 180_000,
-  });
+afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(Stack), {
+  timeout: 180_000,
+});
 
-  test(
-    "Service connects to Managed Postgres through Drizzle",
-    Effect.gen(function* () {
-      const out = yield* stack;
-      expect(out.clusterId).toBeString();
-      expect(out.region).toBe("iad");
-      expect(out.apiUrl).toBe(`https://${out.appName}.fly.dev`);
+test(
+  "Service connects to Managed Postgres through Drizzle",
+  Effect.gen(function* () {
+    const out = yield* stack;
+    expect(out.clusterId).toBeString();
+    expect(out.region).toBe("iad");
+    expect(out.apiUrl).toBe(`https://${out.appName}.fly.dev`);
 
-      const health = yield* fetchOk(`${out.apiUrl}/health`);
-      expect(health.status).toBe(200);
-      const body = (yield* health.json) as { ok: boolean; users: number };
-      expect(body.ok).toBe(true);
-      expect(body.users).toBeNumber();
-
-      const created = yield* HttpClient.execute(
-        HttpClientRequest.post(`${out.apiUrl}/users`),
+    // Apply the generated schema THROUGH the deployed Service. MPG is only
+    // reachable on the org's private network, so the in-network Service is
+    // the data plane for DDL too — the test never connects to the cluster
+    // directly. The `/migrate` route is idempotent, so warmup retries are
+    // safe.
+    const migrations = readMigrationSql();
+    expect(migrations.length).toBeGreaterThan(0);
+    for (const sqlText of migrations) {
+      const migrated = yield* executeOk(
+        HttpClientRequest.post(`${out.apiUrl}/migrate`).pipe(
+          HttpClientRequest.setHeader("x-migrate-token", MIGRATE_TOKEN),
+          HttpClientRequest.bodyText(sqlText),
+        ),
       );
-      expect(created.status).toBe(200);
-      const createdBody = (yield* created.json) as { user: SerializedUser[] };
-      expect(createdBody.user).toHaveLength(1);
-      expect(createdBody.user[0]?.id).toBeNumber();
-    }),
-    { timeout: 240_000 },
-  );
-}
+      const { applied } = (yield* migrated.json) as { applied: number };
+      expect(applied).toBeGreaterThan(0);
+    }
+
+    const health = yield* executeOk(
+      HttpClientRequest.get(`${out.apiUrl}/health`),
+    );
+    expect(health.status).toBe(200);
+    const body = (yield* health.json) as { ok: boolean; users: number };
+    expect(body.ok).toBe(true);
+    expect(body.users).toBeNumber();
+
+    const created = yield* HttpClient.execute(
+      HttpClientRequest.post(`${out.apiUrl}/users`),
+    );
+    expect(created.status).toBe(200);
+    const createdBody = (yield* created.json) as { user: SerializedUser[] };
+    expect(createdBody.user).toHaveLength(1);
+    expect(createdBody.user[0]?.id).toBeNumber();
+  }),
+  { timeout: 240_000 },
+);

--- a/packages/alchemy/src/Fly/Postgres.ts
+++ b/packages/alchemy/src/Fly/Postgres.ts
@@ -501,26 +501,25 @@ export const credentialsUri = (
 ): string | undefined => unwrapSensitive(credentials?.pgbouncer_uri);
 
 export const directUri = (
-  cluster: ManagedCluster | undefined,
+  _cluster: ManagedCluster | undefined,
   credentials: ClusterCredentials | undefined,
 ): string | undefined => {
-  const user = credentials?.user;
-  const password = unwrapSensitive(credentials?.password);
-  const dbname = credentials?.dbname;
-  const hash = cluster?.mpgd_cluster_id;
-  if (
-    user === undefined ||
-    user.length === 0 ||
-    password === undefined ||
-    password.length === 0 ||
-    dbname === undefined ||
-    dbname.length === 0 ||
-    hash === undefined ||
-    hash.length === 0
-  ) {
+  // Derive the direct host from the server-provided PgBouncer URI:
+  // `pgbouncer.<hash>.flympg.net` → `direct.<hash>.flympg.net`. The `<hash>`
+  // is the cluster's DNS hash, which is NOT any id the cluster API returns —
+  // `mpgd_cluster_id` is the `fly-mpg-…` cluster id, and a host synthesized
+  // from it does not resolve. Rewriting the observed pooled host is the only
+  // reliable derivation.
+  const pooled = unwrapSensitive(credentials?.pgbouncer_uri);
+  if (pooled === undefined || pooled.length === 0) return undefined;
+  try {
+    const url = new URL(pooled);
+    if (!url.hostname.startsWith("pgbouncer.")) return undefined;
+    url.hostname = url.hostname.replace(/^pgbouncer\./, "direct.");
+    return url.toString();
+  } catch {
     return undefined;
   }
-  return `postgres://${encodeURIComponent(user)}:${encodeURIComponent(password)}@direct.${hash}.flympg.net/${dbname}`;
 };
 
 const secretVersion = (

--- a/packages/alchemy/src/Fly/Service.ts
+++ b/packages/alchemy/src/Fly/Service.ts
@@ -39,6 +39,7 @@ import {
   toEnvRecord,
   type FlyBuildOptions,
   type FlyHostRuntimeContext,
+  type HostedProgramProps,
 } from "./hosted.ts";
 import { attachBucketSecrets } from "./Bucket.ts";
 import { attachPostgresSecrets } from "./Postgres.ts";
@@ -871,27 +872,48 @@ export const ServiceProvider = () =>
         nuke: { dependsOn: ["Fly.App"] },
 
         diff: Effect.fn(function* ({ id, news, output }) {
-          if (news === undefined || !isResolved(news)) return undefined;
-          if (output === undefined) return undefined;
-          const desiredAppName = appNameOf(news.app);
-          const appChanged =
-            desiredAppName !== undefined && desiredAppName !== output.appName;
-          const desiredName =
-            news.name !== undefined
-              ? sanitizeFlyAppName(news.name)
-              : output.name;
-          const nameChanged = desiredName !== output.name;
-          const desiredRegion = news.region ?? DEFAULT_REGION;
-          const regionChanged = desiredRegion !== output.region;
-          if (appChanged || nameChanged || regionChanged) {
-            return {
-              action: "replace" as const,
-              deleteFirst: nameChanged === false && appChanged === false,
-            };
+          if (news === undefined || output === undefined) return undefined;
+          if (isResolved(news)) {
+            const desiredAppName = appNameOf(news.app);
+            const appChanged =
+              desiredAppName !== undefined && desiredAppName !== output.appName;
+            const desiredName =
+              news.name !== undefined
+                ? sanitizeFlyAppName(news.name)
+                : output.name;
+            const nameChanged = desiredName !== output.name;
+            const desiredRegion = news.region ?? DEFAULT_REGION;
+            const regionChanged = desiredRegion !== output.region;
+            if (appChanged || nameChanged || regionChanged) {
+              return {
+                action: "replace" as const,
+                deleteFirst: nameChanged === false && appChanged === false,
+              };
+            }
           }
-          const hash = yield* hosted.hash(news);
-          if (hash !== output.code.hash) {
-            return { action: "update" as const };
+          // The code hash depends only on statically-known props (`main`,
+          // `build`, `image`, `port`). Never gate it on the WHOLE props
+          // being resolved: `app` is a resource reference that stays
+          // unresolved at diff time, so a whole-props guard makes
+          // code-only changes silently noop. By diff time the
+          // effect-config form has been evaluated, so the object view is
+          // safe to read.
+          const statics = news as Partial<
+            Pick<ServiceProps, "main" | "build" | "image" | "port">
+          >;
+          if (
+            isResolved({
+              main: statics.main,
+              build: statics.build,
+              image: statics.image,
+              port: statics.port,
+            }) &&
+            statics.main !== undefined
+          ) {
+            const hash = yield* hosted.hash(statics as HostedProgramProps);
+            if (hash !== output.code.hash) {
+              return { action: "update" as const };
+            }
           }
           return undefined;
         }),

--- a/packages/alchemy/src/Fly/Sprite.ts
+++ b/packages/alchemy/src/Fly/Sprite.ts
@@ -576,22 +576,32 @@ export const SpriteProvider = () =>
         stables: ["spriteId", "name"],
 
         diff: Effect.fn(function* ({ news, output }) {
-          if (news === undefined || !isResolved(news)) return undefined;
-          if (output === undefined) return undefined;
-          const desiredName =
-            news.name !== undefined
-              ? sanitizeFlyAppName(news.name)
-              : output.name;
-          if (desiredName !== output.name) {
-            return { action: "replace" as const };
+          if (news === undefined || output === undefined) return undefined;
+          if (isResolved(news)) {
+            const desiredName =
+              news.name !== undefined
+                ? sanitizeFlyAppName(news.name)
+                : output.name;
+            if (desiredName !== output.name) {
+              return { action: "replace" as const };
+            }
+            const desiredAuth = news.urlAuth ?? DEFAULT_URL_AUTH;
+            if (desiredAuth !== output.urlAuth) {
+              return { action: "update" as const };
+            }
           }
-          const desiredAuth = news.urlAuth ?? DEFAULT_URL_AUTH;
-          if (desiredAuth !== output.urlAuth) {
-            return { action: "update" as const };
-          }
-          const hash = yield* hosted.hash(news as HostedProgramProps);
-          if (hash !== output.code.hash) {
-            return { action: "update" as const };
+          // The code hash depends only on statically-known props — never
+          // gate it on the WHOLE props being resolved: an unresolved
+          // reference elsewhere in props would make code-only changes
+          // silently noop (see the same pattern in Service.ts). By diff
+          // time the effect-config form has been evaluated, so the object
+          // view is safe to read.
+          const statics = news as Partial<Pick<SpriteProps, "main" | "port">>;
+          if (isResolved({ main: statics.main, port: statics.port })) {
+            const hash = yield* hosted.hash(news as HostedProgramProps);
+            if (hash !== output.code.hash) {
+              return { action: "update" as const };
+            }
           }
           return undefined;
         }),


### PR DESCRIPTION
Un-skipping the fly-postgres example (follow-up to #1309, which gated it) surfaced three real bugs. The example now runs its full lifecycle unskipped: migrations are applied **through the deployed service** — the only place Fly Managed Postgres is actually reachable — and the test drives everything over HTTP.

### `Fly.Postgres.directUri` synthesized a hostname that never existed

The direct URI was built from `mpgd_cluster_id`, which is the `fly-mpg-…` cluster id — not the DNS hash. Observed on a live machine's env, the two hosts side by side:

```
FLY_POSTGRES_DB_DIRECT  postgres://…@direct.fly-mpg-a3228kasrtqjdfv2.flympg.net/fly-db   ← ENOTFOUND, everywhere
FLY_POSTGRES_DB_POOLED  postgresql://…@pgbouncer.z7y24odn8m1rgqd1.flympg.net/fly-db      ← works in-network
```

`directUri` now rewrites the server-provided pgbouncer host (`pgbouncer.<hash>` → `direct.<hash>`), the only reliable derivation.

### `Fly.Service` / `Fly.Sprite` never redeployed code-only changes

Both diffs gated their code-hash check behind `isResolved(news)` — but `news.app` is a resource reference that is never resolved at diff time, so the check was dead code and the engine's props-equality fallback noop'd every code-only edit:

```
# edit src/api.ts, deploy:
Plan: 5 to noop
[Api] noop        ← bundle content changed, nothing rolled out
```

The hash depends only on statically-known props (`main`, `build`, `image`, `port`), so it now runs against that subset regardless of unresolved references elsewhere. Replace checks (app/name/region) keep the whole-props guard.

### fly-postgres example: in-network migrations, unskipped test

- `Db` no longer uses laptop-side `migrations:` (MPG hostnames don't resolve outside the org's private network); the service exposes a token-guarded, idempotent `POST /migrate`, and the integ test posts the `Drizzle.Schema`-generated SQL through it before exercising `/health` and `/users`.
- `build: { install: ["pg"] }` on the service — CJS `pg` cannot be bundled (documented on `Fly.Service`), and without it every DB route defected with an empty 500. This was masked before because deploys always failed earlier at the laptop-side migrations.
- The `FLY_TEST_MPG` skip-gate from #1309 is removed; retries are bounded (spaced 2s × 45) instead of unbounded exponential growth.

Verified live: fly-postgres full lifecycle green (create → migrate-through-service → query → destroy, 11 expects), fly-service and fly-sprite green, `tsc -b` clean.
