### PR TITLE
fix(kubernetes): exclude Helm lifecycle hooks from HelmChart's managed objects

### DIFF
--- a/packages/alchemy/src/Kubernetes/HelmChart.ts
+++ b/packages/alchemy/src/Kubernetes/HelmChart.ts
@@ -125,9 +125,11 @@ export interface HelmChart extends Resource<
  * target `cluster` can be a managed cluster resource (e.g.
  * `AWS.EKS.Cluster`) or any cluster your kubeconfig can reach.
  *
- * Helm install/upgrade hooks are not executed (objects are applied, not
- * `helm install`ed); charts that depend on hooks for correctness should be
- * installed with Helm directly.
+ * Helm lifecycle hooks (`helm.sh/hook`-annotated objects: install/upgrade/
+ * delete hooks, tests) are neither executed nor applied — the chart is
+ * rendered with `--no-hooks`, so they never enter the managed-object graph.
+ * Charts that depend on hooks for correctness should be installed with Helm
+ * directly.
  * ### Installing a Chart
  * **Example:** Chart from a repository
  * ```typescript

--- a/packages/alchemy/src/Kubernetes/internal/helm.ts
+++ b/packages/alchemy/src/Kubernetes/internal/helm.ts
@@ -55,10 +55,12 @@ export interface RenderHelmChartOptions {
 }
 
 /**
- * Render a chart with `helm template` and parse the multi-document YAML
- * output into object definitions. Every rendered object must carry
- * `apiVersion`, `kind`, and `metadata.name` (server-side apply needs a
- * name; `generateName`-only objects are rejected with a clear error).
+ * Render a chart with `helm template --no-hooks` and parse the
+ * multi-document YAML output into object definitions. Every rendered object
+ * must carry `apiVersion`, `kind`, and `metadata.name` (server-side apply
+ * needs a name; `generateName`-only objects are rejected with a clear
+ * error). Helm lifecycle hooks are excluded from the result (see
+ * {@link isHelmHook}).
  */
 export const renderHelmChart = Effect.fn(function* (
   options: RenderHelmChartOptions,
@@ -74,6 +76,11 @@ export const renderHelmChart = Effect.fn(function* (
     options.chart,
     "--namespace",
     options.namespace,
+    // Helm lifecycle hooks (`helm.sh/hook`) only make sense under Helm's own
+    // release events; HelmChart server-side applies the render and does not
+    // implement hook timing/weights/delete policies, so a hook (e.g. a
+    // pre-delete uninstall Job) must never enter the managed-object graph.
+    "--no-hooks",
   ];
   if (options.repo !== undefined) {
     args.push("--repo", options.repo);
@@ -135,7 +142,21 @@ export const renderHelmChart = Effect.fn(function* (
   return yield* parseRenderedManifests(options.chart, result.stdout);
 });
 
-/** Parse `helm template` output (multi-document YAML) into definitions. */
+/**
+ * Whether a rendered object is a Helm lifecycle hook (`helm.sh/hook`
+ * annotation). Hooks are executed by Helm at release events (pre-install,
+ * pre-delete, test, …); HelmChart has no release and no hook lifecycle, so
+ * they are filtered out rather than applied as ordinary objects.
+ */
+export const isHelmHook = (object: KubernetesObjectDefinition): boolean =>
+  typeof object.metadata.annotations?.["helm.sh/hook"] === "string";
+
+/**
+ * Parse `helm template` output (multi-document YAML) into definitions.
+ * Hook-annotated objects are dropped — `renderHelmChart` already passes
+ * `--no-hooks`, but the parser enforces the invariant independently of the
+ * helm CLI's behavior.
+ */
 export const parseRenderedManifests = (
   chart: string,
   rendered: string,
@@ -190,7 +211,9 @@ export const parseRenderedManifests = (
           }),
         );
       }
-      objects.push(object as KubernetesObjectDefinition);
+      const definition = object as KubernetesObjectDefinition;
+      if (isHelmHook(definition)) continue;
+      objects.push(definition);
     }
     return objects;
   });

--- a/packages/alchemy/test/Kubernetes/HelmChart.test.ts
+++ b/packages/alchemy/test/Kubernetes/HelmChart.test.ts
@@ -11,7 +11,6 @@ import { expect, layer } from "alchemy-test";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Result from "effect/Result";
-import { spawnSync } from "node:child_process";
 
 const testOptions = {
   providers: Layer.mergeAll(AWS.providers(), Kubernetes.providers()),
@@ -19,99 +18,89 @@ const testOptions = {
 const { test } = Test.make(testOptions);
 
 // Rendering shells out to the local helm CLI (like Docker for image
-// builds); skip the render tests on machines without it.
-const isHelmReady =
-  spawnSync("helm", ["version"], { stdio: "ignore" }).status === 0;
-
+// builds) — `helm` must be installed on the machine running this suite.
 const chartDir = `${import.meta.dirname}/fixtures/chart`;
 
 const describe = layer(NodeServices.layer);
 
 describe("renderHelmChart (local fixture)", (it) => {
-  it.effect.skipIf(!isHelmReady)(
-    "renders values, release name, and namespace",
-    () =>
-      Effect.gen(function* () {
-        const objects = yield* renderHelmChart({
-          chart: chartDir,
-          releaseName: "probe",
-          namespace: "demo",
-          values: { message: "hello-from-values" },
-        });
-        expect(objects).toHaveLength(1);
-        const configMap = objects[0]! as unknown as {
-          kind: string;
-          metadata: { name: string };
-          data: Record<string, string>;
-        };
-        expect(configMap.kind).toBe("ConfigMap");
-        expect(configMap.metadata.name).toBe("probe-config");
-        expect(configMap.data.message).toBe("hello-from-values");
-        expect(configMap.data.release).toBe("probe");
-        expect(configMap.data.namespace).toBe("demo");
-      }),
+  it.effect("renders values, release name, and namespace", () =>
+    Effect.gen(function* () {
+      const objects = yield* renderHelmChart({
+        chart: chartDir,
+        releaseName: "probe",
+        namespace: "demo",
+        values: { message: "hello-from-values" },
+      });
+      expect(objects).toHaveLength(1);
+      const configMap = objects[0]! as unknown as {
+        kind: string;
+        metadata: { name: string };
+        data: Record<string, string>;
+      };
+      expect(configMap.kind).toBe("ConfigMap");
+      expect(configMap.metadata.name).toBe("probe-config");
+      expect(configMap.data.message).toBe("hello-from-values");
+      expect(configMap.data.release).toBe("probe");
+      expect(configMap.data.namespace).toBe("demo");
+    }),
   );
 
-  it.effect.skipIf(!isHelmReady)(
-    "values toggle conditional templates on and off",
-    () =>
-      Effect.gen(function* () {
-        const withoutSecond = yield* renderHelmChart({
-          chart: chartDir,
-          releaseName: "probe",
-          namespace: "demo",
-        });
-        expect(withoutSecond).toHaveLength(1);
+  it.effect("values toggle conditional templates on and off", () =>
+    Effect.gen(function* () {
+      const withoutSecond = yield* renderHelmChart({
+        chart: chartDir,
+        releaseName: "probe",
+        namespace: "demo",
+      });
+      expect(withoutSecond).toHaveLength(1);
 
-        const withSecond = yield* renderHelmChart({
-          chart: chartDir,
-          releaseName: "probe",
-          namespace: "demo",
-          values: { secondConfigMap: { enabled: true } },
-        });
-        expect(withSecond).toHaveLength(2);
-        expect(withSecond.map((object) => object.metadata.name).sort()).toEqual(
-          ["probe-config", "probe-second"],
-        );
-      }),
+      const withSecond = yield* renderHelmChart({
+        chart: chartDir,
+        releaseName: "probe",
+        namespace: "demo",
+        values: { secondConfigMap: { enabled: true } },
+      });
+      expect(withSecond).toHaveLength(2);
+      expect(withSecond.map((object) => object.metadata.name).sort()).toEqual([
+        "probe-config",
+        "probe-second",
+      ]);
+    }),
   );
 
   // Regression for #1312: the fixture chart ships a `helm.sh/hook: pre-delete`
   // Job. HelmChart has no Helm release and no hook lifecycle, so the hook
   // must never enter the managed-object graph (where it would be created and
   // reconciled like an ordinary workload on every deploy).
-  it.effect.skipIf(!isHelmReady)(
-    "excludes Helm lifecycle hooks from the render",
-    () =>
-      Effect.gen(function* () {
-        const objects = yield* renderHelmChart({
-          chart: chartDir,
-          releaseName: "probe",
-          namespace: "demo",
-        });
-        expect(objects.map((object) => object.kind)).not.toContain("Job");
-        expect(objects.map((object) => object.metadata.name)).toEqual([
-          "probe-config",
-        ]);
-      }),
+  it.effect("excludes Helm lifecycle hooks from the render", () =>
+    Effect.gen(function* () {
+      const objects = yield* renderHelmChart({
+        chart: chartDir,
+        releaseName: "probe",
+        namespace: "demo",
+      });
+      expect(objects.map((object) => object.kind)).not.toContain("Job");
+      expect(objects.map((object) => object.metadata.name)).toEqual([
+        "probe-config",
+      ]);
+    }),
   );
 
-  it.effect.skipIf(!isHelmReady)(
-    "a bad chart reference fails with a typed HelmError",
-    () =>
-      Effect.gen(function* () {
-        const result = yield* Effect.result(
-          renderHelmChart({
-            chart: `${chartDir}-does-not-exist`,
-            releaseName: "probe",
-            namespace: "demo",
-          }),
-        );
-        expect(Result.isFailure(result)).toBe(true);
-        if (Result.isFailure(result)) {
-          expect(result.failure._tag).toBe("HelmError");
-        }
-      }),
+  it.effect("a bad chart reference fails with a typed HelmError", () =>
+    Effect.gen(function* () {
+      const result = yield* Effect.result(
+        renderHelmChart({
+          chart: `${chartDir}-does-not-exist`,
+          releaseName: "probe",
+          namespace: "demo",
+        }),
+      );
+      expect(Result.isFailure(result)).toBe(true);
+      if (Result.isFailure(result)) {
+        expect(result.failure._tag).toBe("HelmError");
+      }
+    }),
   );
 });
 

--- a/packages/alchemy/test/Kubernetes/HelmChart.test.ts
+++ b/packages/alchemy/test/Kubernetes/HelmChart.test.ts
@@ -76,6 +76,26 @@ describe("renderHelmChart (local fixture)", (it) => {
       }),
   );
 
+  // Regression for #1312: the fixture chart ships a `helm.sh/hook: pre-delete`
+  // Job. HelmChart has no Helm release and no hook lifecycle, so the hook
+  // must never enter the managed-object graph (where it would be created and
+  // reconciled like an ordinary workload on every deploy).
+  it.effect.skipIf(!isHelmReady)(
+    "excludes Helm lifecycle hooks from the render",
+    () =>
+      Effect.gen(function* () {
+        const objects = yield* renderHelmChart({
+          chart: chartDir,
+          releaseName: "probe",
+          namespace: "demo",
+        });
+        expect(objects.map((object) => object.kind)).not.toContain("Job");
+        expect(objects.map((object) => object.metadata.name)).toEqual([
+          "probe-config",
+        ]);
+      }),
+  );
+
   it.effect.skipIf(!isHelmReady)(
     "a bad chart reference fails with a typed HelmError",
     () =>
@@ -113,6 +133,37 @@ metadata:
       expect(objects).toHaveLength(1);
       expect(objects[0]?.kind).toBe("ConfigMap");
       expect(objects[0]?.metadata.name).toBe("example");
+    }),
+  );
+
+  it.effect("excludes helm.sh/hook-annotated objects (#1312)", () =>
+    Effect.gen(function* () {
+      const objects = yield* parseRenderedManifests(
+        "example",
+        `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ordinary
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uninstall-hook
+  annotations:
+    helm.sh/hook: pre-delete
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: smoke-test
+  annotations:
+    "helm.sh/hook": test
+`,
+      );
+
+      expect(objects.map((object) => object.metadata.name)).toEqual([
+        "ordinary",
+      ]);
     }),
   );
 

--- a/packages/alchemy/test/Kubernetes/fixtures/chart/templates/uninstall-hook.yaml
+++ b/packages/alchemy/test/Kubernetes/fixtures/chart/templates/uninstall-hook.yaml
@@ -1,0 +1,15 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-uninstall-hook
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: uninstall
+          image: busybox
+          command: ["sh", "-c", "echo uninstall"]


### PR DESCRIPTION
`helm template` emits `helm.sh/hook`-annotated objects, and `parseRenderedManifests` passed them into the server-side-apply graph — so a chart's `pre-delete` uninstall Job (or `test` Pod) was created and reconciled as an ordinary workload on every deploy, even though `HelmChart` implements no hook lifecycle (timing, weights, delete policies).

Fixed at both layers:

```diff
   const args = [
     "template",
     options.releaseName,
     options.chart,
     "--namespace",
     options.namespace,
+    "--no-hooks",
   ];
```

```ts
export const isHelmHook = (object: KubernetesObjectDefinition): boolean =>
  typeof object.metadata.annotations?.["helm.sh/hook"] === "string";

// parseRenderedManifests
const definition = object as KubernetesObjectDefinition;
if (isHelmHook(definition)) continue;
```

The parser filter keeps the invariant independent of the helm CLI's behavior and is what the unit test pins. The fixture chart gains a `pre-delete` hook Job so the `renderHelmChart` test also covers the `--no-hooks` path. `HelmChart` JSDoc now says hooks are excluded, not just unexecuted.

Closes #1312

🤖 Generated with [Claude Code](https://claude.com/claude-code)
