### PR TITLE
test(cloudflare/containers): deploy the #1321 container-binding shape

### DIFF
--- a/packages/alchemy/test/Cloudflare/Container/Container.test.ts
+++ b/packages/alchemy/test/Cloudflare/Container/Container.test.ts
@@ -9,6 +9,7 @@ import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
 import AsyncContainerStack from "./fixtures/async/stack.ts";
 import EffectfulStack from "./fixtures/effectful/stack.ts";
 import ExternalStack from "./fixtures/external/stack.ts";
+import InferredClassStack from "./fixtures/inferred/stack.ts";
 import { DEMO_PLAIN, DEMO_SECRET } from "./fixtures/remote/object.ts";
 import RemoteStack from "./fixtures/remote/stack.ts";
 
@@ -252,6 +253,44 @@ describe.concurrent.each([
         // The echo image reflects the request as JSON ("method" only appears
         // in a real echo response, never in an error page) — proof the
         // request went Worker → DO class → container port 8080 and back.
+        const hello = yield* fetchReady(new URL("/hello", url), "method");
+        expect(hello).toContain("method");
+      }).pipe(logLevel),
+      { timeout },
+    );
+  });
+  /**
+   * Issue #1321 — the same sid collision as above in the shape the
+   * Containers guide documents: `className` omitted, so the env key, the
+   * Container's logical id and the DO class are all one name
+   * (`Probe: Container("Probe", …)`). Deployed and driven over HTTP: the
+   * Worker must see a real namespace and reach the container through it.
+   */
+  describe("async container with inferred class name", () => {
+    const { test, beforeAll, afterAll, deploy, destroy } = make();
+    const stack = beforeAll(deploy(InferredClassStack), {
+      timeout: HOOK_TIMEOUT,
+    });
+    afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(InferredClassStack), {
+      timeout: HOOK_TIMEOUT,
+    });
+
+    test(
+      "binds the container class as a durable object namespace",
+      Effect.gen(function* () {
+        const { url } = yield* stack;
+
+        const body = yield* fetchReady(new URL("/binding", url), "kind");
+        expect(JSON.parse(body)).toEqual({ kind: "durable_object_namespace" });
+      }).pipe(logLevel),
+      { timeout },
+    );
+
+    test(
+      "serves through the container-backed DO class",
+      Effect.gen(function* () {
+        const { url } = yield* stack;
+
         const hello = yield* fetchReady(new URL("/hello", url), "method");
         expect(hello).toContain("method");
       }).pipe(logLevel),

--- a/packages/alchemy/test/Cloudflare/Container/fixtures/inferred/stack.ts
+++ b/packages/alchemy/test/Cloudflare/Container/fixtures/inferred/stack.ts
@@ -1,0 +1,36 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as Alchemy from "@/index.ts";
+import * as Effect from "effect/Effect";
+import * as path from "pathe";
+import type { Probe } from "./worker.ts";
+
+/**
+ * The "Bind on an async Worker" shape from the Containers guide, exactly as
+ * issue #1321 reported it: one name for the env key, the Container's logical
+ * id AND the Durable Object class — `className` omitted, so it defaults to
+ * the env key.
+ *
+ * Distinct from `fixtures/async` (which names a class that differs from the
+ * env key): with all three names equal there is nothing left to tell the
+ * Worker's `durable_object_namespace` binding and its `containers` metadata
+ * apart, so this is the shape that collapsed under one `sid` and lost the
+ * namespace binding (see "async container bound on env" in
+ * `Container.test.ts`).
+ */
+export const InferredClassWorker = Cloudflare.Worker("InferredClassWorker", {
+  main: path.resolve(import.meta.dirname, "worker.ts"),
+  env: {
+    Probe: Cloudflare.Container<Probe>("Probe", {
+      image: "mendhak/http-https-echo:latest",
+    }),
+  },
+});
+
+export default Alchemy.Stack(
+  "InferredClassContainerStack",
+  { providers: Cloudflare.providers(), state: Cloudflare.state() },
+  Effect.gen(function* () {
+    const worker = yield* InferredClassWorker;
+    return { url: worker.url.as<string>() };
+  }),
+);

--- a/packages/alchemy/test/Cloudflare/Container/fixtures/inferred/worker.ts
+++ b/packages/alchemy/test/Cloudflare/Container/fixtures/inferred/worker.ts
@@ -1,0 +1,39 @@
+import type * as Cloudflare from "@/Cloudflare";
+import { Container, getContainer } from "@cloudflare/containers";
+import type { InferredClassWorker } from "./stack.ts";
+
+/**
+ * Container-backed Durable Object class hosted by a plain async Worker. The
+ * class is named after the env key, so the stack omits `className` — the
+ * shape the Containers guide documents and the one issue #1321 reported.
+ */
+export class Probe extends Container {
+  defaultPort = 8080;
+}
+
+// InferEnv maps the Container binding to DurableObjectNamespace<Probe>, which
+// is what `getContainer` expects — a lost binding is a type error here too.
+type Env = Cloudflare.InferEnv<typeof InferredClassWorker>;
+
+export default {
+  async fetch(request: Request, env: Env) {
+    const url = new URL(request.url);
+    // What `env.Probe` actually IS at runtime: a namespace has `idFromName`;
+    // a Worker that lost the binding echoes the Container declaration it
+    // uploaded as json instead (`{"_id":"Effect","op":"alchemy/EffectClass"}`).
+    if (url.pathname === "/binding") {
+      const binding = env.Probe as unknown;
+      return Response.json({
+        kind:
+          typeof (binding as { idFromName?: unknown } | null)?.idFromName ===
+          "function"
+            ? "durable_object_namespace"
+            : JSON.stringify(binding),
+      });
+    }
+    if (url.pathname === "/hello") {
+      return getContainer(env.Probe, "default").fetch(request);
+    }
+    return new Response("ok");
+  },
+};


### PR DESCRIPTION
Closes #1321

[#1321](https://github.com/alchemy-run/alchemy/issues/1321) is the #953 symptom again — `getContainer(env.X, …)` dying with `idFromName is not a function` for a Container bound on an async Worker's `env`. The fix landed in #1271 (merged after the issue was filed; the reporter was on beta.74). This PR changes no behaviour; it pins the exact reported shape with a deployed fixture.

```ts
// fixtures/inferred/stack.ts — the "Bind on an async Worker" shape from the
// Containers guide: env key, logical id and DO class are all one name.
export const InferredClassWorker = Cloudflare.Worker("InferredClassWorker", {
  main: path.resolve(import.meta.dirname, "worker.ts"),
  env: { Probe: Cloudflare.Container<Probe>("Probe", { image: "…" }) },
});
```

The existing `fixtures/async` case names a class that differs from the env key. With `className` omitted there is nothing left to tell the Worker's `durable_object_namespace` binding and its `containers` metadata apart, so this is the shape that collapsed under one `sid` and lost the namespace binding.

Deployed in the dev/live matrix of `Container.test.ts` and driven over HTTP: `/binding` asserts `env.Probe` is a namespace, `/hello` round-trips Worker → DO class → container. Reverting the #1271 hunk fails it on a real deploy with the reporter's exact payload:

```
expected { kind: "{\"_id\":\"Effect\",\"op\":\"alchemy/EffectClass\"}" }
to equal { kind: "durable_object_namespace" }
```

### Not addressed

The issue's "Related friction" note — a deploy silently adopting the Worker as external with `env: {}` when `main` transitively imports a module Node can't load — is not reproduced. Nothing imports `main` under Node at plan time, and recovery-by-renaming points at a state/adoption interaction; it needs the reporter's state export to chase.
