### PR TITLE
docs(kubernetes): dedicated Kubernetes docs hub

### DIFF
--- a/examples/kubernetes-local/README.md
+++ b/examples/kubernetes-local/README.md
@@ -1,0 +1,36 @@
+# Kubernetes (local cluster) Example
+
+The end state of the [Kubernetes tutorial](https://alchemy.run/kubernetes/tutorial/part-1)
+on any cluster your kubeconfig can reach — Docker Desktop, OrbStack, kind, k3s — with
+no cloud account and no container registry:
+
+- a `tutorial` Namespace, an `app-config` ConfigMap, and a Redis StatefulSet + Service,
+  all as `Kubernetes.Manifest`
+- an echo server as a `Kubernetes.Deployment` (pre-built `image:`), wired to the
+  ConfigMap and Redis through `env`
+- a one-shot `Kubernetes.Job` and a `Kubernetes.Job` with `schedule` (a CronJob)
+- the `podinfo` Helm chart as a `Kubernetes.HelmChart`, rendered with the local
+  `helm` CLI and applied as objects
+
+## Commands
+
+```sh
+bun install
+bun run --filter kubernetes-local-example deploy
+bun run --filter kubernetes-local-example destroy
+```
+
+`alchemy.run.ts` uses your kubeconfig's current context; pass
+`Kubernetes.KubeConfig({ context: "docker-desktop" })` to pin one. `helm` must be
+installed for the chart.
+
+## Try it
+
+```sh
+# Docker Desktop / OrbStack publish the LoadBalancer on localhost:
+curl "$url/hello"
+
+# kind / minikube have no LoadBalancer controller — port-forward instead:
+kubectl -n tutorial port-forward "svc/$deployment" 8080:8080 &
+curl localhost:8080/hello
+```

--- a/examples/kubernetes-local/alchemy.run.ts
+++ b/examples/kubernetes-local/alchemy.run.ts
@@ -1,0 +1,146 @@
+import * as Alchemy from "alchemy";
+import * as Kubernetes from "alchemy/Kubernetes";
+import * as Output from "alchemy/Output";
+import * as Effect from "effect/Effect";
+
+// Settings shared between the ConfigMap and the Deployment's env.
+const settings = {
+  LOG_LEVEL: "debug",
+  GREETING: "hello from alchemy",
+};
+
+// The end state of the Kubernetes tutorial (parts 1–4), on whichever
+// cluster your kubeconfig's current context points at: a Namespace,
+// a ConfigMap, a Redis StatefulSet + Service, an echo Deployment, a
+// one-shot Job, a CronJob, and a Helm chart — all pre-built images,
+// so no registry is needed.
+export default Alchemy.Stack(
+  "KubernetesLocalExample",
+  {
+    providers: Kubernetes.providers(),
+    state: Alchemy.localState(),
+  },
+  Effect.gen(function* () {
+    // Any cluster `kubectl` can reach. Pass `{ context: "..." }` to pin one.
+    const cluster = Kubernetes.KubeConfig();
+
+    const ns = yield* Kubernetes.Manifest("Namespace", {
+      cluster,
+      manifest: {
+        apiVersion: "v1",
+        kind: "Namespace",
+        metadata: { name: "tutorial" },
+      },
+    });
+
+    const config = yield* Kubernetes.Manifest("Config", {
+      cluster,
+      manifest: {
+        apiVersion: "v1",
+        kind: "ConfigMap",
+        metadata: { name: "app-config", namespace: ns.name },
+        data: settings,
+      },
+    });
+
+    const redis = yield* Kubernetes.Manifest("Redis", {
+      cluster,
+      manifest: {
+        apiVersion: "apps/v1",
+        kind: "StatefulSet",
+        metadata: { name: "redis", namespace: ns.name },
+        spec: {
+          serviceName: "redis",
+          replicas: 1,
+          selector: { matchLabels: { app: "redis" } },
+          template: {
+            metadata: { labels: { app: "redis" } },
+            spec: {
+              containers: [
+                {
+                  name: "redis",
+                  image: "redis:7",
+                  ports: [{ containerPort: 6379 }],
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    const redisService = yield* Kubernetes.Manifest("RedisService", {
+      cluster,
+      manifest: {
+        apiVersion: "v1",
+        kind: "Service",
+        metadata: { name: "redis", namespace: ns.name },
+        spec: {
+          type: "ClusterIP",
+          selector: { app: "redis" },
+          ports: [{ port: 6379, targetPort: 6379 }],
+        },
+      },
+    });
+
+    // A replicated server from a pre-built image. `LoadBalancer` (the
+    // default) populates `url` on clusters with an LB implementation
+    // (Docker Desktop, OrbStack); kind/minikube leave it undefined —
+    // use NodePort or `kubectl port-forward` there.
+    const echo = yield* Kubernetes.Deployment("Echo", {
+      cluster,
+      namespace: ns.name,
+      image: "mendhak/http-https-echo:33",
+      port: 8080,
+      replicas: 3,
+      env: {
+        ...settings,
+        CONFIG_MAP: config.name,
+        REDIS_URL: Output.interpolate`redis://${redisService.name}:6379`,
+      },
+    });
+
+    // Run-to-completion work.
+    const hello = yield* Kubernetes.Job("Hello", {
+      cluster,
+      namespace: ns.name,
+      image: "busybox:1.36",
+      command: ["sh", "-c"],
+      args: ["echo hello from a Job && sleep 2"],
+      backoffLimit: 1,
+      ttlSecondsAfterFinished: 300,
+    });
+
+    // ...and the same thing on a schedule (a CronJob).
+    const tick = yield* Kubernetes.Job("Tick", {
+      cluster,
+      namespace: ns.name,
+      image: "busybox:1.36",
+      command: ["sh", "-c", "date"],
+      schedule: "*/5 * * * *",
+    });
+
+    // A third-party Helm chart, rendered locally and applied as objects.
+    const podinfo = yield* Kubernetes.HelmChart("Podinfo", {
+      cluster,
+      chart: "podinfo",
+      repo: "https://stefanprodan.github.io/podinfo",
+      version: "6.14.1",
+      namespace: "podinfo",
+      createNamespace: true,
+      values: {
+        replicaCount: 2,
+        ui: { message: "hello from alchemy" },
+      },
+    });
+
+    return {
+      url: echo.url,
+      deployment: echo.deploymentName,
+      redis: redis.name,
+      job: hello.jobName,
+      cron: tick.jobName,
+      release: podinfo.releaseName,
+    };
+  }),
+);

--- a/examples/kubernetes-local/package.json
+++ b/examples/kubernetes-local/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "kubernetes-local-example",
+  "version": "0.0.0",
+  "private": true,
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/alchemy-run/alchemy.git",
+    "directory": "examples/kubernetes-local"
+  },
+  "scripts": {
+    "build": "tsc -b",
+    "deploy": "alchemy deploy",
+    "destroy": "alchemy destroy"
+  },
+  "dependencies": {
+    "@effect/platform-node": "catalog:effect",
+    "alchemy": "workspace:*",
+    "effect": "catalog:effect"
+  }
+}

--- a/examples/kubernetes-local/tsconfig.json
+++ b/examples/kubernetes-local/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["alchemy.run.ts", "src/**/*.ts"],
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "module": "Preserve",
+    "moduleResolution": "Bundler",
+    "target": "ESNext"
+  },
+  "references": [
+    {
+      "path": "../../packages/alchemy/tsconfig.json"
+    }
+  ]
+}

--- a/packages/alchemy/src/Kubernetes/HelmChart.ts
+++ b/packages/alchemy/src/Kubernetes/HelmChart.ts
@@ -206,7 +206,9 @@ const resolveReleaseName = (
   Effect.suspend(() => {
     if (news.releaseName) return Effect.succeed(news.releaseName);
     if (output?.releaseName) return Effect.succeed(output.releaseName);
-    return createPhysicalName({ id, lowercase: true });
+    // Helm caps release names at 53 characters (they prefix every object
+    // name the chart renders, which must stay a valid DNS label).
+    return createPhysicalName({ id, lowercase: true, maxLength: 53 });
   });
 
 /**

--- a/packages/alchemy/src/Kubernetes/internal/client.ts
+++ b/packages/alchemy/src/Kubernetes/internal/client.ts
@@ -324,7 +324,11 @@ export const deleteObject = Effect.fn(function* ({
       requestJson({
         transport,
         method: "DELETE",
-        path,
+        // The REST default propagation policy is per-kind — batch/v1 Jobs
+        // (and CronJobs) default to `Orphan`, which leaves their pods
+        // behind on delete. Ask for background cascading deletion the way
+        // `kubectl delete` does so dependents are garbage-collected.
+        path: `${path}?propagationPolicy=Background`,
       }),
     ),
     Effect.catchIf(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2424,6 +2424,18 @@ importers:
         specifier: 4.0.0-rc.110
         version: 4.0.0-rc.110
 
+  examples/kubernetes-local:
+    dependencies:
+      '@effect/platform-node':
+        specifier: catalog:effect
+        version: 4.0.0-rc.110(effect@4.0.0-rc.110)(redis@6.2.1)
+      alchemy:
+        specifier: workspace:*
+        version: link:../../packages/alchemy
+      effect:
+        specifier: 4.0.0-rc.110
+        version: 4.0.0-rc.110
+
   examples/monorepo-multi-stack/backend:
     dependencies:
       '@effect/platform-bun':

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -83,6 +83,9 @@
       "path": "./examples/aws-eks/tsconfig.json"
     },
     {
+      "path": "./examples/kubernetes-local/tsconfig.json"
+    },
+    {
       "path": "./examples/aws-bedrock-ai/tsconfig.json"
     },
     {

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -27,6 +27,7 @@ function providersSidebarEntry() {
       { label: "Cloudflare", link: "/cloudflare" },
       { label: "Hetzner", link: "/hetzner" },
       { label: "Fly", link: "/fly" },
+      { label: "Kubernetes", link: "/kubernetes" },
       { label: "PlanetScale", link: "/planetscale" },
       { label: "Neon", link: "/neon" },
       { label: "Prisma", link: "/prisma" },
@@ -1020,6 +1021,72 @@ export default defineConfig({
               items: [{ label: "IPs & certificates", link: "/fly/networking" }],
             },
             providerResourcesEntry("Fly"),
+          ],
+        },
+        {
+          label: "Kubernetes",
+          items: [
+            { label: "Overview", link: "/kubernetes" },
+            { label: "Setup", link: "/kubernetes/setup" },
+            {
+              label: "Tutorial",
+              items: [{ autogenerate: { directory: "kubernetes/tutorial" } }],
+            },
+            {
+              label: "Clusters",
+              items: [
+                {
+                  label: "Connecting",
+                  link: "/kubernetes/clusters/connecting",
+                },
+                { label: "Local clusters", link: "/kubernetes/clusters/local" },
+                { label: "Amazon EKS", link: "/kubernetes/clusters/eks" },
+              ],
+            },
+            {
+              label: "Workloads",
+              items: [
+                {
+                  label: "Deployments",
+                  link: "/kubernetes/workloads/deployments",
+                },
+                { label: "Jobs", link: "/kubernetes/workloads/jobs" },
+                {
+                  label: "Image sources",
+                  link: "/kubernetes/workloads/image-sources",
+                },
+                { label: "Bindings", link: "/kubernetes/workloads/bindings" },
+                {
+                  label: "Pod template",
+                  link: "/kubernetes/workloads/pod-template",
+                },
+              ],
+            },
+            {
+              label: "Objects",
+              items: [
+                { label: "Manifests", link: "/kubernetes/objects/manifests" },
+                { label: "Helm charts", link: "/kubernetes/objects/helm" },
+              ],
+            },
+            {
+              label: "Guides",
+              items: [
+                {
+                  label: "Exposing services",
+                  link: "/kubernetes/guides/exposing-services",
+                },
+                {
+                  label: "How apply works",
+                  link: "/kubernetes/guides/how-apply-works",
+                },
+                {
+                  label: "Cluster adapters",
+                  link: "/kubernetes/guides/cluster-adapters",
+                },
+              ],
+            },
+            providerResourcesEntry("Kubernetes"),
           ],
         },
         {

--- a/website/src/components/ProviderDirectory.astro
+++ b/website/src/components/ProviderDirectory.astro
@@ -66,6 +66,10 @@ const HUBS: Record<string, { href: string; blurb: string }> = {
     href: "/fly",
     blurb: "Machines, Services, Volumes, Secrets, and fly.dev on Fly.io",
   },
+  Kubernetes: {
+    href: "/kubernetes",
+    blurb: "Deployments, Jobs, Manifests, and Helm charts on any cluster",
+  },
   Planetscale: {
     href: "/planetscale",
     blurb: "Serverless MySQL & Postgres with branching workflows",

--- a/website/src/content/docs/aws/compute/choosing-a-runtime.mdx
+++ b/website/src/content/docs/aws/compute/choosing-a-runtime.mdx
@@ -77,15 +77,20 @@ load-balancer integration. Alchemy models it with:
 
 - [`Cluster`](/providers/aws/eks/cluster) — the control plane;
   `compute: "auto"` turns on Auto Mode with sensible defaults.
-- [`Deployment`](/providers/kubernetes/deployment) — a replicated
+- [`Deployment`](/kubernetes/workloads/deployments) — a replicated
   Kubernetes server (the Kubernetes analog of `AWS.ECS.Service`)
   with the same three image sources as ECS: a registry `image`, a
   Dockerfile `context`, or an inline Effect program via `main`.
-- [`Job`](/providers/kubernetes/job) — run-to-completion work, or a
+- [`Job`](/kubernetes/workloads/jobs) — run-to-completion work, or a
   `CronJob` when you set `schedule`.
-- [`Manifest`](/providers/kubernetes/manifest) and
-  [`HelmChart`](/providers/kubernetes/helmchart) — any raw Kubernetes
+- [`Manifest`](/kubernetes/objects/manifests) and
+  [`HelmChart`](/kubernetes/objects/helm) — any raw Kubernetes
   object or a rendered Helm chart, applied via server-side apply.
+
+The workloads are cluster-agnostic — the same program runs on any
+cluster your kubeconfig can reach; see the
+[Kubernetes hub](/kubernetes) for the workloads themselves and
+[Amazon EKS](/kubernetes/clusters/eks) for what the EKS adapter adds.
 
 Bindings work the same as on Lambda and ECS — env vars plus IAM
 policy statements, delivered through an EKS Pod Identity role —

--- a/website/src/content/docs/aws/compute/eks.mdx
+++ b/website/src/content/docs/aws/compute/eks.mdx
@@ -1,6 +1,6 @@
 ---
 title: EKS
-description: Stand up an EKS Auto Mode cluster on a Network and run containers on it — Deployments for servers, Jobs for run-to-completion work, Manifests for everything else. No YAML, no kubectl.
+description: Stand up an EKS Auto Mode cluster on a Network, grant access, install add-ons, and point the cluster-agnostic Kubernetes workloads at it. No YAML, no kubectl.
 ---
 
 **EKS** (Elastic Kubernetes Service) is AWS's managed Kubernetes:
@@ -27,15 +27,12 @@ Alchemy models these directly:
 [`Cluster`](/providers/aws/eks/cluster) with `compute: "auto"`
 stands up the control plane from a VPC, and the cluster-agnostic
 `alchemy/Kubernetes` workloads target it by passing the cluster
-resource as their `cluster` prop:
-[`Kubernetes.Deployment`](/providers/kubernetes/deployment)
-synthesizes a Kubernetes `Deployment` + `Service`;
-[`Kubernetes.Job`](/providers/kubernetes/job) a `Job` or `CronJob`;
-and [`Kubernetes.Manifest`](/providers/kubernetes/manifest) applies
-any raw Kubernetes object. The workloads live in the same TypeScript
-program as the cluster, with no YAML and no `kubectl apply` step —
-and the same workloads run on any other cluster your kubeconfig can
-reach (`Kubernetes.KubeConfig(...)`).
+resource as their `cluster` prop. This page covers the cluster —
+provisioning, access, add-ons, and HyperPod. Everything about the
+workloads themselves lives in the
+[Kubernetes hub](/kubernetes): what the EKS adapter adds on top of
+any other cluster is summarized on
+[Amazon EKS](/kubernetes/clusters/eks).
 
 The workload providers ship in `Kubernetes.providers()` — compose it
 with `AWS.providers()` in the Stack:
@@ -120,47 +117,17 @@ The deploying principal is bootstrapped as cluster admin
 Mode defaults), so these are for everyone (and everything) else that
 needs in.
 
-## Deploy a server
+## Run workloads on the cluster
 
-[`Kubernetes.Deployment`](/providers/kubernetes/deployment) is a
-replicated Kubernetes server — the Kubernetes analog of
-`AWS.ECS.Service`. It
-synthesizes a Kubernetes `Deployment` + `Service` (+
-`ServiceAccount`) and applies them via server-side apply, with the
-container image coming from exactly one of three sources flat on
-props: `image` (a registry reference, mirrored into ECR), `context`
-(build your own Dockerfile), or `main` (bundle an inline Effect
-program). The simplest form runs a remote image with no Effect
-runtime in the container:
-
-```typescript
-const echo = yield* Kubernetes.Deployment("EchoServer", {
-  cluster,
-  image: "registry.k8s.io/echoserver:1.10",
-  namespace: "default",
-  replicas: 2,
-  port: 8080,
-  serviceType: "LoadBalancer",
-});
-
-echo.url;            // LoadBalancer hostname (an NLB on Auto Mode)
-echo.deploymentName; // K8s-native attrs: deploymentName, serviceName, ...
-```
-
-`serviceType: "LoadBalancer"` provisions a cloud load balancer and
-exposes its hostname as `url`. Swap `image` for
-`context: "./legacy"` to build your own Dockerfile (`dockerfile` is
-a path, defaulting to `${context}/Dockerfile`).
-
-## Effect servers with bindings
-
-Pass `main: import.meta.url` and an init Effect and the program is
-bundled into a generated image instead — the same authoring model as
-[Lambda](/aws/compute/lambda). Bindings work identically too:
-`Deployment` accepts the same `{ env, policyStatements }` binding
-contract as a Lambda `Function`, so every AWS `Binding.Service`
-attaches environment variables to the Pod spec and IAM policy
-statements to a generated **Pod Identity role**:
+Pass the cluster resource as the `cluster` prop of any
+`alchemy/Kubernetes` workload. Because the target is an EKS cluster,
+the [`aws-eks` adapter](/kubernetes/clusters/eks#what-the-adapter-adds)
+adds what a plain kubeconfig cluster can't: authentication with your
+AWS credentials (no kubeconfig step), a per-workload **ECR
+repository** so `main:` and `context:` image sources work, and
+**Pod Identity** so AWS bindings land IAM policy statements on a
+generated role — the same `{ env, policyStatements }` contract as
+[Lambda](/aws/compute/lambda):
 
 ```typescript
 const api = yield* Kubernetes.Deployment(
@@ -176,101 +143,23 @@ const api = yield* Kubernetes.Deployment(
     };
   }).pipe(Effect.provide(AWS.DynamoDB.PutItemHttp)),
 );
+
+api.url; // internet-facing NLB hostname (EKS Auto Mode)
 ```
 
-Every Kubernetes workload on EKS gets Pod Identity as standard:
-Alchemy creates
-the IAM role, wires it to the workload's ServiceAccount with a
-[`PodIdentityAssociation`](/providers/aws/eks/podidentityassociation),
-and Pods resolve credentials through the EKS Pod Identity
-container-credentials chain — no OIDC provider or IRSA annotation
-ceremony. The tagged form
-(`class Api extends Kubernetes.Deployment<Api, Shape>()("Api") {}` +
-`Api.make(props, impl)`) works exactly as it does on Lambda and
-Cloudflare Workers.
+The same program runs against any other cluster by swapping
+`cluster`; the hub explains each workload in full:
 
-## Run-to-completion work with Job
-
-[`Kubernetes.Job`](/providers/kubernetes/job) runs a container to
-completion — the Kubernetes analog of `AWS.ECS.Task`. Same three image sources,
-same bindings and Pod Identity; an Effect impl returns `{ run }`
-instead of `{ fetch }`, executing to completion inside the Pod:
-
-```typescript
-const migrate = yield* Kubernetes.Job("DbMigrate", {
-  cluster,
-  image: "ghcr.io/acme/migrator:v3",
-  backoffLimit: 2,
-});
-```
-
-Set `schedule` (standard 5-field cron) and a Kubernetes `CronJob` is
-synthesized instead of a plain `Job`:
-
-```typescript
-const nightly = yield* Kubernetes.Job("NightlyBackfill", {
-  cluster,
-  main: import.meta.url,
-  schedule: "0 3 * * *",
-});
-```
-
-## Everything else is a Manifest
-
-[`Kubernetes.Manifest`](/providers/kubernetes/manifest) applies any
-raw Kubernetes object — StatefulSets, Namespaces, CRDs — via server-side apply.
-The manifest is a literal object, exactly as you would write it in
-YAML:
-
-```typescript
-const namespace = yield* Kubernetes.Manifest("DemoNamespace", {
-  cluster,
-  manifest: {
-    apiVersion: "v1",
-    kind: "Namespace",
-    metadata: { name: "demo" },
-  },
-});
-```
-
-There is no kubeconfig step: Alchemy authenticates to the cluster's
-API with your AWS credentials (a presigned STS token) and applies
-objects via **server-side apply** under the `alchemy` field manager,
-so deploys converge the live objects the same way the rest of your
-Stack converges cloud resources. Unknown kinds resolve through the
-Kubernetes API discovery endpoint, so CRDs work without any
-registration.
-
-## Install a Helm chart
-
-[`Kubernetes.HelmChart`](/providers/kubernetes/helmchart) renders a
-chart with the
-local `helm` CLI (`helm template` — install helm on your machine,
-like Docker for image builds) and applies the rendered objects
-through the same server-side-apply path as `Manifest`:
-
-```typescript
-const ingress = yield* Kubernetes.HelmChart("IngressNginx", {
-  cluster,
-  chart: "ingress-nginx",
-  repo: "https://kubernetes.github.io/ingress-nginx",
-  version: "4.11.2",
-  namespace: "ingress-nginx",
-  createNamespace: true,
-  values: {
-    controller: { replicaCount: 2 },
-  },
-});
-```
-
-`chart` also accepts `oci://` references and local chart directories,
-and `values` is a literal object — the same shape as a `values.yaml`
-file. Because the objects are applied (not `helm install`ed), Alchemy
-owns their lifecycle: drift is corrected on every deploy, objects
-that drop out of the render are pruned, and destroy deletes them —
-there is no in-cluster Helm release record. Charts that rely on
-install/upgrade hooks for correctness should be installed with Helm
-directly.
+- [Deployments](/kubernetes/workloads/deployments) — a replicated
+  server (the Kubernetes analog of `AWS.ECS.Service`): Deployment +
+  Service + ServiceAccount, `serviceType` and `url`, Effect servers.
+- [Jobs](/kubernetes/workloads/jobs) — run-to-completion work (the
+  analog of `AWS.ECS.Task`); set `schedule` for a CronJob.
+- [Bindings](/kubernetes/workloads/bindings#pod-identity-on-eks) —
+  how bindings become a Pod Identity role and pod environment.
+- [Manifests](/kubernetes/objects/manifests) and
+  [Helm charts](/kubernetes/objects/helm) — any raw object, and
+  charts rendered with `helm template` and applied as objects.
 
 ## Run on SageMaker HyperPod
 
@@ -333,6 +222,10 @@ surface.
 
 ## Where next
 
+- [Kubernetes hub](/kubernetes) — the workloads and objects you run
+  on this cluster, on any cluster.
+- [Amazon EKS in the Kubernetes hub](/kubernetes/clusters/eks) —
+  exactly what the EKS adapter adds (STS auth, Pod Identity, ECR).
 - [VPC & networking](/aws/networking) — what the `Network` helper
   builds under the cluster.
 - [HyperPod](/aws/compute/hyperpod) — run training fleets on this
@@ -340,7 +233,6 @@ surface.
 - [Choosing a runtime](/aws/compute/choosing-a-runtime) — when Lambda or ECS
   is the better fit than running your own Kubernetes workloads.
 - [`Cluster` reference](/providers/aws/eks/cluster),
-  [`Deployment` reference](/providers/kubernetes/deployment),
-  [`Job` reference](/providers/kubernetes/job),
-  [`Manifest` reference](/providers/kubernetes/manifest) — every prop
-  and attribute.
+  [`AccessEntry` reference](/providers/aws/eks/accessentry),
+  [`Addon` reference](/providers/aws/eks/addon) — every prop and
+  attribute.

--- a/website/src/content/docs/aws/compute/eks.mdx
+++ b/website/src/content/docs/aws/compute/eks.mdx
@@ -121,7 +121,7 @@ needs in.
 
 Pass the cluster resource as the `cluster` prop of any
 `alchemy/Kubernetes` workload. Because the target is an EKS cluster,
-the [`aws-eks` adapter](/kubernetes/clusters/eks#what-the-adapter-adds)
+the [`aws-eks` adapter](/kubernetes/clusters/eks#what-eks-adds)
 adds what a plain kubeconfig cluster can't: authentication with your
 AWS credentials (no kubeconfig step), a per-workload **ECR
 repository** so `main:` and `context:` image sources work, and

--- a/website/src/content/docs/aws/index.mdx
+++ b/website/src/content/docs/aws/index.mdx
@@ -101,7 +101,7 @@ Not sure which? See
 | Background jobs                       | [SQS](/aws/messaging/sqs) + Lambda                                                      |
 | Scheduled jobs                        | [EventBridge Scheduler](/aws/messaging/eventbridge) → Lambda                            |
 | A Postgres database                   | [RDS & Aurora](/aws/data/rds)                                                      |
-| Kubernetes workloads or Helm charts   | [EKS](/aws/compute/eks)                                                            |
+| Kubernetes workloads or Helm charts   | [EKS](/aws/compute/eks) + the [Kubernetes hub](/kubernetes)                        |
 | Object processing                     | [S3 events](/aws/messaging/s3-events)                                            |
 | Sending transactional email           | [SES sending](/aws/email/sending) — identity + `SendEmail` binding               |
 | Inbound email pipelines               | [SES email receiving](/aws/email/receiving) → S3 / SNS / Lambda                  |

--- a/website/src/content/docs/kubernetes/clusters/connecting.mdx
+++ b/website/src/content/docs/kubernetes/clusters/connecting.mdx
@@ -3,25 +3,15 @@ title: Connecting to a cluster
 description: The `cluster` prop explained — the serializable Connection every workload targets, `KubeConfig()` for anything kubectl can reach, raw token / client-cert / exec connections, and how the connection's `auth.kind` picks the adapter.
 ---
 
-Every `Kubernetes.*` resource has a `cluster` prop. It takes a
-**Connection**: plain data that says where the API server is and how
-to authenticate, or a resource that carries one. The `auth.kind`
-inside it picks the
-[cluster adapter](/kubernetes#what-the-cluster-adapter-gives-you),
-which decides whether a workload gets auth only or auth plus workload
-identity and a registry.
-
-You used `Kubernetes.KubeConfig()` in the tutorial and an
-`AWS.EKS.Cluster` in [Part 5](/kubernetes/tutorial/part-5). Both are
-Connections. The concrete cases are
-[local clusters](/kubernetes/clusters/local) and
-[EKS](/kubernetes/clusters/eks).
+Every `Kubernetes.*` resource has a `cluster` prop: a **Connection**
+(API server plus auth) or a resource carrying one. Its `auth.kind`
+picks the
+[cluster adapter](/kubernetes#what-the-cluster-adapter-gives-you).
 
 ## The Connection model
 
-A `Connection` is four fields. `auth` is a discriminated union keyed
-by `kind`. The built-in kinds are `kubeconfig`, `token`,
-`client-cert`, and `exec`; `alchemy/AWS` adds `aws-eks`.
+A `Connection` is four fields; `auth` is a discriminated union keyed
+by `kind`.
 
 ```typescript
 // The shape behind every `cluster` prop (alchemy/Kubernetes):
@@ -38,22 +28,9 @@ interface Connection {
 }
 ```
 
-`endpoint` is optional when the adapter can discover it: a
-kubeconfig file carries the server and the EKS adapter re-describes
-the cluster. `certificateAuthorityData` is base64 PEM, as a
-kubeconfig stores it.
-
-It is plain data on purpose. The workload provider resolves it at
-reconcile time and persists it on the workload's `connection`
-attribute, so `alchemy destroy` can reconnect after the cluster
-resource has left the program.
-
-The `cluster` prop is typed `ClusterLike`:
-`Connection | { connection: Connection }`. An
-[`AWS.EKS.Cluster`](/providers/aws/eks/cluster) exposes `connection`
-on its attributes, so you pass the whole resource and the
-[EKS adapter](/kubernetes/clusters/eks#what-the-adapter-adds) takes
-over.
+`cluster` is typed `ClusterLike`:
+`Connection | { connection: Connection }`, so an
+[`AWS.EKS.Cluster`](/providers/aws/eks/cluster) is passed whole.
 
 ```typescript
 // Both of these are a valid `cluster` (ClusterLike):
@@ -69,23 +46,14 @@ Effect.gen(function* () {
 });
 ```
 
-`auth` is the workload's cluster identity. Changing it replaces the
-workload. Changing only `endpoint` or the CA does not.
-
-:::note[Persisted with the workload]
-`alchemy state get` shows the resolved Connection on the workload's
-`connection` attribute ([Inspecting state](/cli/inspecting-state),
-[`Deployment` reference](/providers/kubernetes/deployment)). For
-`token` and `client-cert` that includes the credential itself.
-:::
+Changing `auth` replaces the workload; `endpoint` or the CA does not.
+The resolved Connection is persisted on the workload's `connection`
+attribute so `alchemy destroy` can reconnect.
 
 ## KubeConfig
 
-`Kubernetes.KubeConfig({ path?, context? })` is the "anything
-kubectl can reach" connection. It is a helper, not a resource: it
-returns `{ auth: { kind: "kubeconfig", path, context } }` and
-appears in no plan. Pass the context you enabled in
-[Setup](/kubernetes/setup#pick-a-cluster).
+`Kubernetes.KubeConfig({ path?, context? })` is the "anything kubectl
+can reach" connection: a helper, not a resource.
 
 ```typescript
 Effect.gen(function* () {
@@ -105,25 +73,9 @@ Effect.gen(function* () {
 });
 ```
 
-The file is the explicit `path`, else the first entry of
-`$KUBECONFIG` (only the first, unlike kubectl), else
-`~/.kube/config`. A leading `~` is expanded. The context is the
-explicit `context`, else the file's `current-context`. A missing
-file, context, cluster, or server fails with a typed
-`Kubernetes.KubeConfigError` naming the file.
-
-In a checked-in stack always pass `context`, so a teammate's
-`current-context` cannot retarget a deploy. The local context names
-are on
-[Local clusters](/kubernetes/clusters/local#which-local-cluster).
-
-From the cluster stanza the adapter reads `server`,
-`certificate-authority` or `certificate-authority-data`, and
-`insecure-skip-tls-verify`. From the user stanza it reads `token`,
-`tokenFile`, `client-certificate`/`client-key` (files or `-data`
-forms), and `exec` plugins. Exec plugins run per request and are
-cached until 30 seconds before their `expirationTimestamp`, or 60
-seconds when the plugin declares none.
+The file is `path`, else the first entry of `$KUBECONFIG`, else
+`~/.kube/config`; the context is `context`, else `current-context`.
+In a checked-in stack always pass `context`.
 
 ```typescript
 // Exec plugins declared in the file are honored — a GKE context via
@@ -132,43 +84,20 @@ seconds when the plugin declares none.
 const gke = Kubernetes.KubeConfig({ context: "gke_my-project_europe-west1_prod" });
 ```
 
-An explicit `endpoint`, `certificateAuthorityData`, or
-`insecureSkipTlsVerify` on the Connection overrides the file. Spread
-the helper's result and add the field. Not read from the file:
-`proxy-url`, `tls-server-name`, legacy `auth-provider` stanzas, and
-`impersonate*` settings. Those need an `exec` plugin or a raw kind.
-
-:::tip[Kubeconfig on EKS vs the EKS adapter]
-An `aws eks update-kubeconfig` context through `KubeConfig()` is
-auth only.
-[Targeting an EKS cluster](/kubernetes/clusters/eks#targeting-an-eks-cluster)
-covers how to get the full adapter.
-:::
+An `aws eks update-kubeconfig` context is auth only; see
+[Targeting an EKS cluster](/kubernetes/clusters/eks#targeting-an-eks-cluster).
 
 ## Token, client certificate, and exec
 
-The raw kinds are for when there is no kubeconfig file: CI with a
-service-account token, a connection built from another resource, a
-machine without `kubectl`. Three rules apply to all of them.
-
-`endpoint` is required. Without it the connect fails with
-`A 'token' Kubernetes connection requires an explicit endpoint (only
-kubeconfig-backed and managed-cloud connections can discover it)`,
-with your kind in the message.
-
-TLS is yours. Pass `certificateAuthorityData` (base64 PEM) or, for a
+No kubeconfig file involved. `endpoint` is required; pass
+`certificateAuthorityData` (base64 PEM) or, for a
 [self-signed local cluster](/kubernetes/clusters/local#which-local-cluster),
-`insecureSkipTlsVerify: true`. With neither, the platform trust
-store is used.
-
-Nothing else is read from disk or the environment.
+`insecureSkipTlsVerify: true`.
 
 ### token
 
-`{ kind: "token", token }` sends `Authorization: Bearer <token>` on
-every request. The classic case is a long-lived ServiceAccount token
-(a `kubernetes.io/service-account-token` Secret) for CI. Read it
-from config, never a literal.
+`{ kind: "token", token }` sends a bearer token. Read it from
+config, never a literal.
 
 ```typescript
 Effect.gen(function* () {
@@ -187,9 +116,8 @@ Effect.gen(function* () {
 
 ### client-cert
 
-`{ kind: "client-cert", certificate, key }`, both as PEM text, not
-base64. A kubeconfig's `-data` fields are decoded for you; here they
-are not. Requests use mutual TLS with no bearer header.
+`{ kind: "client-cert", certificate, key }`, both PEM text, not
+base64.
 
 ```typescript
 Effect.gen(function* () {
@@ -209,13 +137,8 @@ Effect.gen(function* () {
 
 ### exec
 
-`{ kind: "exec", command, args?, env? }` runs a
-`client.authentication.k8s.io` ExecCredential plugin with no
-kubeconfig involved. The plugin's `status.token` becomes the bearer
-token, or its `clientCertificateData`/`clientKeyData` the client
-certificate, cached like a plugin declared in a kubeconfig. A plugin
-that exits non-zero or returns malformed JSON fails with a typed
-`Kubernetes.ExecCredentialError` carrying the exit code and stderr.
+`{ kind: "exec", command, args?, env? }` runs an ExecCredential
+plugin; failures surface as `Kubernetes.ExecCredentialError`.
 
 ```typescript
 // EKS through the raw exec kind — auth only (see the EKS page for the
@@ -232,35 +155,17 @@ const cluster: Kubernetes.Connection = {
 };
 ```
 
-This reaches the same API server as the
-[EKS adapter](/kubernetes/clusters/eks#what-the-adapter-adds) and
-gets none of what it adds.
-
 :::caution[Credentials are persisted in state]
-A `token` or client `key` is stored on the workload's attributes so
-destroy can reconnect. Use a remote, access-controlled state store
-rather than a committed `.alchemy/` directory, or prefer `exec` and
-`kubeconfig`, which persist only how to mint a credential.
+A `token` or client `key` is stored in state, so use a remote state store or prefer `exec` and `kubeconfig`.
 :::
 
 ## How the adapter is chosen
 
-Every adapter is a Context service keyed
-`Kubernetes.ClusterAdapter/<auth kind>`. At reconcile, read, and
-delete time the workload provider looks up `connection.auth.kind` in
-the stack's composed provider layers, the same way resource providers
-are found by type. `Kubernetes.providers()` registers `kubeconfig`,
-`token`, `client-cert`, and `exec`. `AWS.providers()` registers
-`aws-eks`, the
-[EKS adapter](/kubernetes/clusters/eks#what-the-adapter-adds). What
-each adapter gives you is the
-[comparison table on the overview](/kubernetes#what-the-cluster-adapter-gives-you).
-
-Both layers register with `provideMerge`, so they must be merged
-into one `providers:` value, not one provided to the other. The
-[`Kubernetes.providers()` line from Setup](/kubernetes/setup#add-the-provider)
-covers every built-in kind. Targeting an `AWS.EKS.Cluster` means
-adding `AWS.providers()` alongside it.
+Adapters are Context services keyed by auth kind, looked up in the
+stack's providers. `Kubernetes.providers()` registers the four
+built-in kinds; `AWS.providers()` registers `aws-eks`, the
+[EKS adapter](/kubernetes/clusters/eks#what-the-adapter-adds). Merge
+both into one `providers:` value to target an `AWS.EKS.Cluster`.
 
 ```typescript
 // alchemy.run.ts — the providers layer decides which auth kinds resolve
@@ -277,10 +182,8 @@ export default Alchemy.Stack(
 );
 ```
 
-With only `Kubernetes.providers()` an `AWS.EKS.Cluster` target dies
-with this error.
+Without `AWS.providers()` an EKS target dies with:
 
-:::note[The error you'll see]
 ```text
 No Kubernetes cluster adapter is registered for auth kind 'aws-eks'.
 Add the provider layer that contributes it to the stack's providers —
@@ -289,21 +192,12 @@ e.g. 'aws-eks' ships with `AWS.providers()`; the built-in kinds
 `Kubernetes.providers()`. Compose multiple provider layers with
 `Layer.mergeAll(AWS.providers(), Kubernetes.providers())`.
 ```
-Change `providers: Kubernetes.providers()` to
-`providers: Layer.mergeAll(AWS.providers(), Kubernetes.providers())`.
-:::
 
-Beyond `connect`, an adapter can implement `identity`, `registry`,
-`bootstrap`, and `loadBalancerDefaults`. The
-[interface](/kubernetes/guides/cluster-adapters#the-interface) and
-[registering an auth kind](/kubernetes/guides/cluster-adapters#registering-an-auth-kind)
-are in the Cluster adapters guide.
+Adapters can also implement `identity`, `registry`, `bootstrap`, and
+`loadBalancerDefaults` ([interface](/kubernetes/guides/cluster-adapters#the-interface)).
 
 ## Where next
 
-- [Local clusters](/kubernetes/clusters/local) — which local cluster
-  to use, reaching a Service, and the registry-less limits.
-- [EKS](/kubernetes/clusters/eks) — what changes when `cluster` is
-  an `AWS.EKS.Cluster`.
-- [Cluster adapters](/kubernetes/guides/cluster-adapters) — add an
-  auth kind for GKE or AKS.
+- [Local clusters](/kubernetes/clusters/local)
+- [EKS](/kubernetes/clusters/eks)
+- [Cluster adapters](/kubernetes/guides/cluster-adapters)

--- a/website/src/content/docs/kubernetes/clusters/connecting.mdx
+++ b/website/src/content/docs/kubernetes/clusters/connecting.mdx
@@ -1,0 +1,309 @@
+---
+title: Connecting to a cluster
+description: The `cluster` prop explained — the serializable Connection every workload targets, `KubeConfig()` for anything kubectl can reach, raw token / client-cert / exec connections, and how the connection's `auth.kind` picks the adapter.
+---
+
+Every `Kubernetes.*` resource has a `cluster` prop. It takes a
+**Connection**: plain data that says where the API server is and how
+to authenticate, or a resource that carries one. The `auth.kind`
+inside it picks the
+[cluster adapter](/kubernetes#what-the-cluster-adapter-gives-you),
+which decides whether a workload gets auth only or auth plus workload
+identity and a registry.
+
+You used `Kubernetes.KubeConfig()` in the tutorial and an
+`AWS.EKS.Cluster` in [Part 5](/kubernetes/tutorial/part-5). Both are
+Connections. The concrete cases are
+[local clusters](/kubernetes/clusters/local) and
+[EKS](/kubernetes/clusters/eks).
+
+## The Connection model
+
+A `Connection` is four fields. `auth` is a discriminated union keyed
+by `kind`. The built-in kinds are `kubeconfig`, `token`,
+`client-cert`, and `exec`; `alchemy/AWS` adds `aws-eks`.
+
+```typescript
+// The shape behind every `cluster` prop (alchemy/Kubernetes):
+interface Connection {
+  endpoint?: string;                 // API server URL; optional when the adapter can discover it
+  certificateAuthorityData?: string; // base64 PEM bundle
+  insecureSkipTlsVerify?: boolean;   // self-signed local clusters
+  auth:                              // selects the adapter by `kind`
+    | { kind: "kubeconfig"; path?: string; context?: string }
+    | { kind: "token"; token: string }
+    | { kind: "client-cert"; certificate: string; key: string }
+    | { kind: "exec"; command: string; args?: string[]; env?: Record<string, string> }
+    | { kind: "aws-eks"; clusterName: string; region?: string }; // added by alchemy/AWS
+}
+```
+
+`endpoint` is optional when the adapter can discover it: a
+kubeconfig file carries the server and the EKS adapter re-describes
+the cluster. `certificateAuthorityData` is base64 PEM, as a
+kubeconfig stores it.
+
+It is plain data on purpose. The workload provider resolves it at
+reconcile time and persists it on the workload's `connection`
+attribute, so `alchemy destroy` can reconnect after the cluster
+resource has left the program.
+
+The `cluster` prop is typed `ClusterLike`:
+`Connection | { connection: Connection }`. An
+[`AWS.EKS.Cluster`](/providers/aws/eks/cluster) exposes `connection`
+on its attributes, so you pass the whole resource and the
+[EKS adapter](/kubernetes/clusters/eks#what-the-adapter-adds) takes
+over.
+
+```typescript
+// Both of these are a valid `cluster` (ClusterLike):
+Effect.gen(function* () {
+  // 1. a Connection — here built by the KubeConfig() helper
+  const local = Kubernetes.KubeConfig({ context: "docker-desktop" });
+
+  // 2. anything with a `.connection` attribute — a managed cluster resource
+  const eks = yield* AWS.EKS.Cluster("Cluster", { compute: "auto", /* ... */ });
+
+  yield* Kubernetes.Deployment("Api", { cluster: local, image: "ghcr.io/acme/api:v3" });
+  yield* Kubernetes.Deployment("ApiProd", { cluster: eks, image: "ghcr.io/acme/api:v3" });
+});
+```
+
+`auth` is the workload's cluster identity. Changing it replaces the
+workload. Changing only `endpoint` or the CA does not.
+
+:::note[Persisted with the workload]
+`alchemy state get` shows the resolved Connection on the workload's
+`connection` attribute ([Inspecting state](/cli/inspecting-state),
+[`Deployment` reference](/providers/kubernetes/deployment)). For
+`token` and `client-cert` that includes the credential itself.
+:::
+
+## KubeConfig
+
+`Kubernetes.KubeConfig({ path?, context? })` is the "anything
+kubectl can reach" connection. It is a helper, not a resource: it
+returns `{ auth: { kind: "kubeconfig", path, context } }` and
+appears in no plan. Pass the context you enabled in
+[Setup](/kubernetes/setup#pick-a-cluster).
+
+```typescript
+Effect.gen(function* () {
+  // default file + current-context: fine on a laptop, risky in a checked-in stack
+  const cluster = Kubernetes.KubeConfig();
+
+  // pin the context; path still resolves from $KUBECONFIG / ~/.kube/config
+  const staging = Kubernetes.KubeConfig({ context: "staging-eu" });
+
+  // a dedicated file (CI writes one from a secret, say)
+  const ci = Kubernetes.KubeConfig({ path: "./.kube/ci-config", context: "ci" });
+
+  yield* Kubernetes.Manifest("Namespace", {
+    cluster: staging,
+    manifest: { apiVersion: "v1", kind: "Namespace", metadata: { name: "demo" } },
+  });
+});
+```
+
+The file is the explicit `path`, else the first entry of
+`$KUBECONFIG` (only the first, unlike kubectl), else
+`~/.kube/config`. A leading `~` is expanded. The context is the
+explicit `context`, else the file's `current-context`. A missing
+file, context, cluster, or server fails with a typed
+`Kubernetes.KubeConfigError` naming the file.
+
+In a checked-in stack always pass `context`, so a teammate's
+`current-context` cannot retarget a deploy. The local context names
+are on
+[Local clusters](/kubernetes/clusters/local#which-local-cluster).
+
+From the cluster stanza the adapter reads `server`,
+`certificate-authority` or `certificate-authority-data`, and
+`insecure-skip-tls-verify`. From the user stanza it reads `token`,
+`tokenFile`, `client-certificate`/`client-key` (files or `-data`
+forms), and `exec` plugins. Exec plugins run per request and are
+cached until 30 seconds before their `expirationTimestamp`, or 60
+seconds when the plugin declares none.
+
+```typescript
+// Exec plugins declared in the file are honored — a GKE context via
+// gke-gcloud-auth-plugin, an AKS context via kubelogin, an EKS context via
+// `aws eks get-token` all work with no extra configuration:
+const gke = Kubernetes.KubeConfig({ context: "gke_my-project_europe-west1_prod" });
+```
+
+An explicit `endpoint`, `certificateAuthorityData`, or
+`insecureSkipTlsVerify` on the Connection overrides the file. Spread
+the helper's result and add the field. Not read from the file:
+`proxy-url`, `tls-server-name`, legacy `auth-provider` stanzas, and
+`impersonate*` settings. Those need an `exec` plugin or a raw kind.
+
+:::tip[Kubeconfig on EKS vs the EKS adapter]
+An `aws eks update-kubeconfig` context through `KubeConfig()` is
+auth only.
+[Targeting an EKS cluster](/kubernetes/clusters/eks#targeting-an-eks-cluster)
+covers how to get the full adapter.
+:::
+
+## Token, client certificate, and exec
+
+The raw kinds are for when there is no kubeconfig file: CI with a
+service-account token, a connection built from another resource, a
+machine without `kubectl`. Three rules apply to all of them.
+
+`endpoint` is required. Without it the connect fails with
+`A 'token' Kubernetes connection requires an explicit endpoint (only
+kubeconfig-backed and managed-cloud connections can discover it)`,
+with your kind in the message.
+
+TLS is yours. Pass `certificateAuthorityData` (base64 PEM) or, for a
+[self-signed local cluster](/kubernetes/clusters/local#which-local-cluster),
+`insecureSkipTlsVerify: true`. With neither, the platform trust
+store is used.
+
+Nothing else is read from disk or the environment.
+
+### token
+
+`{ kind: "token", token }` sends `Authorization: Bearer <token>` on
+every request. The classic case is a long-lived ServiceAccount token
+(a `kubernetes.io/service-account-token` Secret) for CI. Read it
+from config, never a literal.
+
+```typescript
+Effect.gen(function* () {
+  const token = yield* Config.string("KUBE_TOKEN");
+  const ca = yield* Config.string("KUBE_CA_DATA"); // base64 PEM, as in a kubeconfig
+
+  const cluster: Kubernetes.Connection = {
+    endpoint: "https://10.0.0.10:6443",
+    certificateAuthorityData: ca,
+    auth: { kind: "token", token },
+  };
+
+  yield* Kubernetes.Deployment("Api", { cluster, image: "ghcr.io/acme/api:v3", port: 8080 });
+});
+```
+
+### client-cert
+
+`{ kind: "client-cert", certificate, key }`, both as PEM text, not
+base64. A kubeconfig's `-data` fields are decoded for you; here they
+are not. Requests use mutual TLS with no bearer header.
+
+```typescript
+Effect.gen(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const cluster: Kubernetes.Connection = {
+    endpoint: "https://k3s.lan:6443",
+    insecureSkipTlsVerify: true, // self-signed server cert
+    auth: {
+      kind: "client-cert",
+      certificate: yield* fs.readFileString("./certs/client.crt"), // PEM
+      key: yield* fs.readFileString("./certs/client.key"),         // PEM
+    },
+  };
+  yield* Kubernetes.Job("Migrate", { cluster, image: "ghcr.io/acme/migrator:v3" });
+});
+```
+
+### exec
+
+`{ kind: "exec", command, args?, env? }` runs a
+`client.authentication.k8s.io` ExecCredential plugin with no
+kubeconfig involved. The plugin's `status.token` becomes the bearer
+token, or its `clientCertificateData`/`clientKeyData` the client
+certificate, cached like a plugin declared in a kubeconfig. A plugin
+that exits non-zero or returns malformed JSON fails with a typed
+`Kubernetes.ExecCredentialError` carrying the exit code and stderr.
+
+```typescript
+// EKS through the raw exec kind — auth only (see the EKS page for the
+// adapter that also gives you Pod Identity and ECR)
+const cluster: Kubernetes.Connection = {
+  endpoint: "https://ABC123.gr7.us-east-1.eks.amazonaws.com",
+  certificateAuthorityData: "LS0tLS1CRUdJTi...",
+  auth: {
+    kind: "exec",
+    command: "aws",
+    args: ["eks", "get-token", "--cluster-name", "prod", "--region", "us-east-1"],
+    env: { AWS_PROFILE: "prod" },
+  },
+};
+```
+
+This reaches the same API server as the
+[EKS adapter](/kubernetes/clusters/eks#what-the-adapter-adds) and
+gets none of what it adds.
+
+:::caution[Credentials are persisted in state]
+A `token` or client `key` is stored on the workload's attributes so
+destroy can reconnect. Use a remote, access-controlled state store
+rather than a committed `.alchemy/` directory, or prefer `exec` and
+`kubeconfig`, which persist only how to mint a credential.
+:::
+
+## How the adapter is chosen
+
+Every adapter is a Context service keyed
+`Kubernetes.ClusterAdapter/<auth kind>`. At reconcile, read, and
+delete time the workload provider looks up `connection.auth.kind` in
+the stack's composed provider layers, the same way resource providers
+are found by type. `Kubernetes.providers()` registers `kubeconfig`,
+`token`, `client-cert`, and `exec`. `AWS.providers()` registers
+`aws-eks`, the
+[EKS adapter](/kubernetes/clusters/eks#what-the-adapter-adds). What
+each adapter gives you is the
+[comparison table on the overview](/kubernetes#what-the-cluster-adapter-gives-you).
+
+Both layers register with `provideMerge`, so they must be merged
+into one `providers:` value, not one provided to the other. The
+[`Kubernetes.providers()` line from Setup](/kubernetes/setup#add-the-provider)
+covers every built-in kind. Targeting an `AWS.EKS.Cluster` means
+adding `AWS.providers()` alongside it.
+
+```typescript
+// alchemy.run.ts — the providers layer decides which auth kinds resolve
+export default Alchemy.Stack(
+  "MyApp",
+  {
+    // local / kubeconfig / token / client-cert / exec clusters:
+    providers: Kubernetes.providers(),
+    // targeting an AWS.EKS.Cluster (auth kind "aws-eks") as well:
+    // providers: Layer.mergeAll(AWS.providers(), Kubernetes.providers()),
+    state: Alchemy.localState(),
+  },
+  Effect.gen(function* () { /* ... */ }),
+);
+```
+
+With only `Kubernetes.providers()` an `AWS.EKS.Cluster` target dies
+with this error.
+
+:::note[The error you'll see]
+```text
+No Kubernetes cluster adapter is registered for auth kind 'aws-eks'.
+Add the provider layer that contributes it to the stack's providers —
+e.g. 'aws-eks' ships with `AWS.providers()`; the built-in kinds
+(kubeconfig, token, client-cert, exec) ship with
+`Kubernetes.providers()`. Compose multiple provider layers with
+`Layer.mergeAll(AWS.providers(), Kubernetes.providers())`.
+```
+Change `providers: Kubernetes.providers()` to
+`providers: Layer.mergeAll(AWS.providers(), Kubernetes.providers())`.
+:::
+
+Beyond `connect`, an adapter can implement `identity`, `registry`,
+`bootstrap`, and `loadBalancerDefaults`. The
+[interface](/kubernetes/guides/cluster-adapters#the-interface) and
+[registering an auth kind](/kubernetes/guides/cluster-adapters#registering-an-auth-kind)
+are in the Cluster adapters guide.
+
+## Where next
+
+- [Local clusters](/kubernetes/clusters/local) — which local cluster
+  to use, reaching a Service, and the registry-less limits.
+- [EKS](/kubernetes/clusters/eks) — what changes when `cluster` is
+  an `AWS.EKS.Cluster`.
+- [Cluster adapters](/kubernetes/guides/cluster-adapters) — add an
+  auth kind for GKE or AKS.

--- a/website/src/content/docs/kubernetes/clusters/connecting.mdx
+++ b/website/src/content/docs/kubernetes/clusters/connecting.mdx
@@ -1,44 +1,40 @@
 ---
 title: Connecting to a cluster
-description: The `cluster` prop explained — the serializable Connection every workload targets, `KubeConfig()` for anything kubectl can reach, raw token / client-cert / exec connections, and how the connection's `auth.kind` picks the adapter.
+description: Point a Kubernetes workload at a cluster using a kubeconfig context, a token, a client certificate, an exec plugin, or an EKS cluster.
 ---
 
-Every `Kubernetes.*` resource has a `cluster` prop: a **Connection**
-(API server plus auth) or a resource carrying one. Its `auth.kind`
-picks the
-[cluster adapter](/kubernetes#what-the-cluster-adapter-gives-you).
+Every `Kubernetes.*` resource takes a `cluster` prop: which cluster to
+deploy to and how to authenticate. Pass a kubeconfig context, a token,
+a client certificate, an exec plugin, or an EKS cluster.
 
-## The Connection model
+## What `cluster` accepts
 
-A `Connection` is four fields; `auth` is a discriminated union keyed
-by `kind`.
+`cluster` is a `Connection`: the API server plus one `auth` kind.
 
 ```typescript
-// The shape behind every `cluster` prop (alchemy/Kubernetes):
+// What `cluster` accepts (alchemy/Kubernetes):
 interface Connection {
-  endpoint?: string;                 // API server URL; optional when the adapter can discover it
+  endpoint?: string;                 // API server URL; not needed for kubeconfig or aws-eks
   certificateAuthorityData?: string; // base64 PEM bundle
   insecureSkipTlsVerify?: boolean;   // self-signed local clusters
-  auth:                              // selects the adapter by `kind`
+  auth:                              // pick one
     | { kind: "kubeconfig"; path?: string; context?: string }
     | { kind: "token"; token: string }
     | { kind: "client-cert"; certificate: string; key: string }
     | { kind: "exec"; command: string; args?: string[]; env?: Record<string, string> }
-    | { kind: "aws-eks"; clusterName: string; region?: string }; // added by alchemy/AWS
+    | { kind: "aws-eks"; clusterName: string; region?: string }; // from alchemy/AWS
 }
 ```
 
-`cluster` is typed `ClusterLike`:
-`Connection | { connection: Connection }`, so an
-[`AWS.EKS.Cluster`](/providers/aws/eks/cluster) is passed whole.
+You can also pass an [`AWS.EKS.Cluster`](/providers/aws/eks/cluster) directly.
 
 ```typescript
-// Both of these are a valid `cluster` (ClusterLike):
+// Both of these are a valid `cluster`:
 Effect.gen(function* () {
-  // 1. a Connection — here built by the KubeConfig() helper
+  // 1. a kubeconfig context
   const local = Kubernetes.KubeConfig({ context: "docker-desktop" });
 
-  // 2. anything with a `.connection` attribute — a managed cluster resource
+  // 2. an EKS cluster
   const eks = yield* AWS.EKS.Cluster("Cluster", { compute: "auto", /* ... */ });
 
   yield* Kubernetes.Deployment("Api", { cluster: local, image: "ghcr.io/acme/api:v3" });
@@ -46,24 +42,19 @@ Effect.gen(function* () {
 });
 ```
 
-Changing `auth` replaces the workload; `endpoint` or the CA does not.
-The resolved Connection is persisted on the workload's `connection`
-attribute so `alchemy destroy` can reconnect.
-
 ## KubeConfig
 
-`Kubernetes.KubeConfig({ path?, context? })` is the "anything kubectl
-can reach" connection: a helper, not a resource.
+`Kubernetes.KubeConfig()` connects to any cluster in your kubeconfig.
 
 ```typescript
 Effect.gen(function* () {
   // default file + current-context: fine on a laptop, risky in a checked-in stack
   const cluster = Kubernetes.KubeConfig();
 
-  // pin the context; path still resolves from $KUBECONFIG / ~/.kube/config
+  // pin the context; the file still comes from $KUBECONFIG or ~/.kube/config
   const staging = Kubernetes.KubeConfig({ context: "staging-eu" });
 
-  // a dedicated file (CI writes one from a secret, say)
+  // a dedicated file, e.g. one CI writes from a secret
   const ci = Kubernetes.KubeConfig({ path: "./.kube/ci-config", context: "ci" });
 
   yield* Kubernetes.Manifest("Namespace", {
@@ -73,31 +64,30 @@ Effect.gen(function* () {
 });
 ```
 
-The file is `path`, else the first entry of `$KUBECONFIG`, else
-`~/.kube/config`; the context is `context`, else `current-context`.
-In a checked-in stack always pass `context`.
+Without `path`, the file is the first entry of `$KUBECONFIG`, else
+`~/.kube/config`. Without `context`, it is the file's
+`current-context`. Always pass `context` in a checked-in stack so a
+teammate's current context never retargets a deploy.
 
 ```typescript
-// Exec plugins declared in the file are honored — a GKE context via
-// gke-gcloud-auth-plugin, an AKS context via kubelogin, an EKS context via
-// `aws eks get-token` all work with no extra configuration:
+// Exec plugins in the file just work (GKE, AKS, EKS), with no extra configuration:
 const gke = Kubernetes.KubeConfig({ context: "gke_my-project_europe-west1_prod" });
 ```
 
-An `aws eks update-kubeconfig` context is auth only; see
-[Targeting an EKS cluster](/kubernetes/clusters/eks#targeting-an-eks-cluster).
+An `aws eks update-kubeconfig` context only authenticates. For Pod
+Identity and ECR,
+[target the EKS cluster itself](/kubernetes/clusters/eks#targeting-an-eks-cluster).
 
 ## Token, client certificate, and exec
 
-No kubeconfig file involved. `endpoint` is required; pass
+These connect without a kubeconfig file. Set `endpoint`, plus either
 `certificateAuthorityData` (base64 PEM) or, for a
 [self-signed local cluster](/kubernetes/clusters/local#which-local-cluster),
 `insecureSkipTlsVerify: true`.
 
 ### token
 
-`{ kind: "token", token }` sends a bearer token. Read it from
-config, never a literal.
+Sends a bearer token. Read it from config, never paste a literal.
 
 ```typescript
 Effect.gen(function* () {
@@ -116,8 +106,7 @@ Effect.gen(function* () {
 
 ### client-cert
 
-`{ kind: "client-cert", certificate, key }`, both PEM text, not
-base64.
+Pass the certificate and key as PEM text, not base64.
 
 ```typescript
 Effect.gen(function* () {
@@ -137,12 +126,11 @@ Effect.gen(function* () {
 
 ### exec
 
-`{ kind: "exec", command, args?, env? }` runs an ExecCredential
-plugin; failures surface as `Kubernetes.ExecCredentialError`.
+Runs a credential plugin, the same way kubectl does. If the plugin
+fails you'll see `Kubernetes.ExecCredentialError`.
 
 ```typescript
-// EKS through the raw exec kind — auth only (see the EKS page for the
-// adapter that also gives you Pod Identity and ECR)
+// EKS through exec: auth only, no Pod Identity or ECR.
 const cluster: Kubernetes.Connection = {
   endpoint: "https://ABC123.gr7.us-east-1.eks.amazonaws.com",
   certificateAuthorityData: "LS0tLS1CRUdJTi...",
@@ -156,25 +144,23 @@ const cluster: Kubernetes.Connection = {
 ```
 
 :::caution[Credentials are persisted in state]
-A `token` or client `key` is stored in state, so use a remote state store or prefer `exec` and `kubeconfig`.
+A `token` or client `key` is stored in state. Use a remote state store, or prefer `exec` and `kubeconfig`.
 :::
 
-## How the adapter is chosen
+## Deploying to EKS
 
-Adapters are Context services keyed by auth kind, looked up in the
-stack's providers. `Kubernetes.providers()` registers the four
-built-in kinds; `AWS.providers()` registers `aws-eks`, the
-[EKS adapter](/kubernetes/clusters/eks#what-the-adapter-adds). Merge
-both into one `providers:` value to target an `AWS.EKS.Cluster`.
+`Kubernetes.providers()` handles `kubeconfig`, `token`, `client-cert`,
+and `exec`. To deploy to EKS (`aws-eks`), add `AWS.providers()` next
+to it.
 
 ```typescript
-// alchemy.run.ts — the providers layer decides which auth kinds resolve
+// alchemy.run.ts
 export default Alchemy.Stack(
   "MyApp",
   {
     // local / kubeconfig / token / client-cert / exec clusters:
     providers: Kubernetes.providers(),
-    // targeting an AWS.EKS.Cluster (auth kind "aws-eks") as well:
+    // to also target an AWS.EKS.Cluster (auth kind "aws-eks"):
     // providers: Layer.mergeAll(AWS.providers(), Kubernetes.providers()),
     state: Alchemy.localState(),
   },
@@ -182,7 +168,7 @@ export default Alchemy.Stack(
 );
 ```
 
-Without `AWS.providers()` an EKS target dies with:
+If you forget `AWS.providers()`, an EKS deploy fails with:
 
 ```text
 No Kubernetes cluster adapter is registered for auth kind 'aws-eks'.
@@ -193,11 +179,8 @@ e.g. 'aws-eks' ships with `AWS.providers()`; the built-in kinds
 `Layer.mergeAll(AWS.providers(), Kubernetes.providers())`.
 ```
 
-Adapters can also implement `identity`, `registry`, `bootstrap`, and
-`loadBalancerDefaults` ([interface](/kubernetes/guides/cluster-adapters#the-interface)).
-
 ## Where next
 
 - [Local clusters](/kubernetes/clusters/local)
 - [EKS](/kubernetes/clusters/eks)
-- [Cluster adapters](/kubernetes/guides/cluster-adapters)
+- [Cluster adapters](/kubernetes/guides/cluster-adapters) — add a cluster type of your own

--- a/website/src/content/docs/kubernetes/clusters/eks.mdx
+++ b/website/src/content/docs/kubernetes/clusters/eks.mdx
@@ -3,34 +3,18 @@ title: EKS
 description: What changes when `cluster` is an `AWS.EKS.Cluster` — SigV4 auth with no kubeconfig, a Pod Identity role per workload, a per-workload ECR repository that unlocks `main:` and `context:`, and Auto Mode load-balancer defaults.
 ---
 
-An `AWS.EKS.Cluster` carries a `connection` whose `auth.kind` is
-`aws-eks`, so the whole resource is a valid `cluster` (the
-`{ connection }` form of
-[`ClusterLike`](/kubernetes/clusters/connecting#the-connection-model)).
-That kind resolves to the adapter in `alchemy/AWS`, the only
-built-in adapter that adds workload identity and a registry on top
-of auth.
-
-Creating the cluster (`Network`, `Cluster` with `compute: "auto"`,
-`AccessEntry`, `Addon`, HyperPod) is the AWS tab's
-[EKS page](/aws/compute/eks). This page assumes you have one.
-[Tutorial part 5](/kubernetes/tutorial/part-5) moves the tutorial
-app onto EKS.
+An `AWS.EKS.Cluster` is a valid `cluster`: its `connection` has
+`auth.kind: "aws-eks"`, the only built-in adapter that adds workload
+identity and a registry on top of auth. Creating the cluster is the
+AWS tab's [EKS page](/aws/compute/eks).
 
 ## Targeting an EKS cluster
 
-The adapter lives in `AWS.providers()` and is looked up by auth
-kind, so the Stack needs both layers merged into one `providers:`
-value. With `Kubernetes.providers()` alone the deploy dies with the
-"no adapter registered" error
+The adapter lives in `AWS.providers()`, so merge it with
+`Kubernetes.providers()`
 ([How the adapter is chosen](/kubernetes/clusters/connecting#how-the-adapter-is-chosen)).
-
-Pass the resource when the cluster lives in the same program. For a
-cluster created elsewhere, write a raw `aws-eks` connection:
-`{ auth: { kind: "aws-eks", clusterName, region? } }`. `endpoint`
-and the CA are optional because the adapter re-describes the cluster
-(`eks:DescribeCluster`) when they are missing or stale. `region`
-defaults to the ambient AWS region.
+Pass the resource, or a raw `aws-eks` connection for a cluster
+created elsewhere.
 
 ```typescript
 // alchemy.run.ts
@@ -60,54 +44,28 @@ export default Alchemy.Stack(
 );
 ```
 
-The identity running `alchemy deploy` needs Kubernetes API access
-to the cluster, plus IAM, EKS, and ECR permissions for the role,
-association, and repository below. The creating principal is admin
-under the Auto Mode defaults; anyone else needs an `AccessEntry`
-([AWS page](/aws/compute/eks)). Every prop is in the
-[`Cluster` reference](/providers/aws/eks/cluster).
-
-:::note[Kubeconfig context vs the adapter]
-An `aws eks update-kubeconfig` context through
-[`KubeConfig()`](/kubernetes/clusters/connecting#kubeconfig) reaches
-the same API server but is auth only: no Pod Identity, no ECR,
-`image:` only.
-:::
+The deploying identity needs cluster API access plus IAM, EKS, and
+ECR permissions. An `aws eks update-kubeconfig` context through
+[`KubeConfig()`](/kubernetes/clusters/connecting#kubeconfig) is auth
+only.
 
 ## What the adapter adds
 
-A kubeconfig connection gives you `connect`. The `aws-eks` adapter
-implements all five hooks, the
-[overview's comparison table](/kubernetes#what-the-cluster-adapter-gives-you)
-expanded.
+`aws-eks` implements all five adapter hooks
+([comparison table](/kubernetes#what-the-cluster-adapter-gives-you)).
 
 ### Auth
 
-SigV4 bearer tokens, no kubeconfig. Each API request carries a
-token minted from the ambient AWS credentials: a presigned STS
-`GetCallerIdentity` URL encoded as `k8s-aws-v1.…` with a 60-second
-expiry, the same scheme as `aws eks get-token`. `endpoint` and
-`certificateAuthorityData` come from the connection when present and
-are re-described otherwise, which also covers EKS rotating the
-endpoint DNS when a cluster is recreated under the same name. A
-cluster that is gone or `DELETING` surfaces as a typed
-`Kubernetes.ClusterNotFoundError`, which `read` and `delete` treat
-as "everything in-cluster is already gone"
-([Destroy and a missing cluster](#destroy-and-a-missing-cluster)).
+SigV4 bearer tokens from the ambient AWS credentials, like
+`aws eks get-token`. A gone or `DELETING` cluster surfaces as
+`Kubernetes.ClusterNotFoundError`.
 
 ### Identity
 
-EKS Pod Identity for every workload. Per Deployment or Job the
-adapter creates an IAM role (`<id>-pod-role…`), an inline policy
-(`<id>-pod-policy…`) built from the workload's `policyStatements`
-bindings, and a
-[`PodIdentityAssociation`](/providers/aws/eks/podidentityassociation)
-tying the role to the workload's `namespace` and ServiceAccount. The
-result is the `identity` attribute. `identity.managedPolicyArns`
-adds managed policies to the role. The trust policy, the
-in-container credential chain, `AWS_REGION`, and what keys a
-replacement are on
-[Pod Identity on EKS](/kubernetes/workloads/bindings#pod-identity-on-eks).
+Per workload: an IAM role, an inline policy from its
+`policyStatements` bindings, and a `PodIdentityAssociation` to its
+ServiceAccount
+([Pod Identity on EKS](/kubernetes/workloads/bindings#pod-identity-on-eks)).
 
 ```typescript
 Effect.gen(function* () {
@@ -134,16 +92,11 @@ Effect.gen(function* () {
 
 ### Registry
 
-One private ECR repository per workload, named from the logical id
-(`<id>-repo…`, lowercased). All three image sources land in it:
-`main` bundled, `context` built, and a bare `image:` reference
-mirrored in (`docker pull`, tag, push) so nodes pull from ECR with
-IAM auth. Docker must be installed on the deploying machine,
-mirroring included. The result is the `registry` attribute and
-`imageUri`, the ECR reference the pod runs. The repository is
-deleted with the workload. How images are built is under
-[three sources](/kubernetes/workloads/image-sources#three-sources)
-and [architecture](/kubernetes/workloads/image-sources#architecture).
+One private ECR repository per workload; `main` is bundled,
+`context` built, and a bare `image:` mirrored into it. Docker must be
+installed on the deploying machine. This is what unlocks `main:` and
+`context:`
+([Registry requirement](/kubernetes/workloads/image-sources#registry-requirement)).
 
 ```typescript
 const web = yield* Kubernetes.Deployment("Web", {
@@ -155,28 +108,11 @@ web.imageUri;  // "<account>.dkr.ecr.<region>.amazonaws.com/<web-repo>:<content-
 web.registry;  // { kind: "aws-ecr", repositoryName, repositoryUri } | undefined
 ```
 
-:::tip[This is what unlocks main]
-The registry hook is why `{ fetch }` / `{ run }` and `context:` work
-here and die on a kubeconfig cluster. See
-[Registry requirement](/kubernetes/workloads/image-sources#registry-requirement).
-:::
-
 ### Load balancer defaults
 
-For `serviceType: "LoadBalancer"` on Auto Mode
-(`kubernetesNetworkConfig.elasticLoadBalancing.enabled`), the
-adapter sets `spec.loadBalancerClass: eks.amazonaws.com/nlb`,
-without which Auto Mode ignores the Service, and defaults
-`service.beta.kubernetes.io/aws-load-balancer-scheme` to
-`internet-facing`, because Auto Mode otherwise creates an internal
-NLB. User `serviceAnnotations` always win. The NLB listens on the
-Service `port`, so `url` is `http://<nlb-hostname>:<port>` unless
-the port is 80. The provider waits up to ~3 minutes for the hostname
-([Exposing it: serviceType and url](/kubernetes/workloads/deployments#exposing-it-servicetype-and-url)).
-Clusters without Auto Mode load balancing get no
-`loadBalancerClass` and rely on the AWS Load Balancer Controller's
-own annotations
-([Service types](/kubernetes/guides/exposing-services#service-types)).
+On Auto Mode the adapter sets `loadBalancerClass: eks.amazonaws.com/nlb`
+and defaults the scheme to `internet-facing`; your
+`serviceAnnotations` win.
 
 ```typescript
 const api = yield* Kubernetes.Deployment("Api", {
@@ -194,25 +130,12 @@ api.url; // "http://k8s-….elb.amazonaws.com:3000" once the NLB exists
 
 ## Destroy and a missing cluster
 
-Delete connects with the persisted connection. If the cluster is
-gone, `DELETING`, or unreachable, the in-cluster objects are skipped
-because they die with the cluster. The adapter-owned resources are
-still cleaned up: the `PodIdentityAssociation` (skipped when the
-cluster is gone), the IAM role with its inline policy, and the ECR
-repository, force-deleted with its images. The in-cluster side is
-under [delete order](/kubernetes/guides/how-apply-works#delete-order).
-
-A stack that owns both cluster and workloads destroys in one
-`alchemy destroy`. A stack targeting a shared cluster through a raw
-`aws-eks` connection removes only what it created. `read` on a
-missing cluster returns "gone", so the next plan shows the workloads
-as needing re-creation rather than erroring. Nothing else on the
-account is touched.
+If the cluster is gone or `DELETING`, delete skips the in-cluster
+objects but still removes the IAM role and ECR repository; `read`
+returns "gone", so the next plan re-creates the workloads.
 
 ## Where next
 
-- [Deployments](/kubernetes/workloads/deployments) — props, `url`,
-  the tagged form, `{ fetch }`.
+- [Deployments](/kubernetes/workloads/deployments)
 - [Pod Identity on EKS](/kubernetes/workloads/bindings#pod-identity-on-eks)
-  — how bindings become IAM on the pod role.
-- [EKS on the AWS tab](/aws/compute/eks) — provisioning the cluster.
+- [EKS on the AWS tab](/aws/compute/eks)

--- a/website/src/content/docs/kubernetes/clusters/eks.mdx
+++ b/website/src/content/docs/kubernetes/clusters/eks.mdx
@@ -1,0 +1,218 @@
+---
+title: EKS
+description: What changes when `cluster` is an `AWS.EKS.Cluster` — SigV4 auth with no kubeconfig, a Pod Identity role per workload, a per-workload ECR repository that unlocks `main:` and `context:`, and Auto Mode load-balancer defaults.
+---
+
+An `AWS.EKS.Cluster` carries a `connection` whose `auth.kind` is
+`aws-eks`, so the whole resource is a valid `cluster` (the
+`{ connection }` form of
+[`ClusterLike`](/kubernetes/clusters/connecting#the-connection-model)).
+That kind resolves to the adapter in `alchemy/AWS`, the only
+built-in adapter that adds workload identity and a registry on top
+of auth.
+
+Creating the cluster (`Network`, `Cluster` with `compute: "auto"`,
+`AccessEntry`, `Addon`, HyperPod) is the AWS tab's
+[EKS page](/aws/compute/eks). This page assumes you have one.
+[Tutorial part 5](/kubernetes/tutorial/part-5) moves the tutorial
+app onto EKS.
+
+## Targeting an EKS cluster
+
+The adapter lives in `AWS.providers()` and is looked up by auth
+kind, so the Stack needs both layers merged into one `providers:`
+value. With `Kubernetes.providers()` alone the deploy dies with the
+"no adapter registered" error
+([How the adapter is chosen](/kubernetes/clusters/connecting#how-the-adapter-is-chosen)).
+
+Pass the resource when the cluster lives in the same program. For a
+cluster created elsewhere, write a raw `aws-eks` connection:
+`{ auth: { kind: "aws-eks", clusterName, region? } }`. `endpoint`
+and the CA are optional because the adapter re-describes the cluster
+(`eks:DescribeCluster`) when they are missing or stale. `region`
+defaults to the ambient AWS region.
+
+```typescript
+// alchemy.run.ts
+export default Alchemy.Stack(
+  "MyApp",
+  {
+    providers: Layer.mergeAll(AWS.providers(), Kubernetes.providers()), // both: aws-eks lives in AWS.providers()
+    state: AWS.state(),
+  },
+  Effect.gen(function* () {
+    // (a) the cluster resource — see /aws/compute/eks for the Network + Cluster props
+    const network = yield* AWS.EC2.Network("Network", { /* see the AWS tab */ });
+    const cluster = yield* AWS.EKS.Cluster("Cluster", {
+      compute: "auto",
+      resourcesVpcConfig: { subnetIds: network.privateSubnetIds },
+    });
+
+    // (b) a cluster created elsewhere: name + region is enough, the adapter
+    //     re-describes it for endpoint + CA
+    const shared: Kubernetes.Connection = {
+      auth: { kind: "aws-eks", clusterName: "platform-prod", region: "eu-west-1" },
+    };
+
+    yield* Kubernetes.Deployment("Api", { cluster, main: import.meta.url, port: 3000 });
+    yield* Kubernetes.Job("Nightly", { cluster: shared, image: "ghcr.io/acme/report:v3", schedule: "0 3 * * *" });
+  }),
+);
+```
+
+The identity running `alchemy deploy` needs Kubernetes API access
+to the cluster, plus IAM, EKS, and ECR permissions for the role,
+association, and repository below. The creating principal is admin
+under the Auto Mode defaults; anyone else needs an `AccessEntry`
+([AWS page](/aws/compute/eks)). Every prop is in the
+[`Cluster` reference](/providers/aws/eks/cluster).
+
+:::note[Kubeconfig context vs the adapter]
+An `aws eks update-kubeconfig` context through
+[`KubeConfig()`](/kubernetes/clusters/connecting#kubeconfig) reaches
+the same API server but is auth only: no Pod Identity, no ECR,
+`image:` only.
+:::
+
+## What the adapter adds
+
+A kubeconfig connection gives you `connect`. The `aws-eks` adapter
+implements all five hooks, the
+[overview's comparison table](/kubernetes#what-the-cluster-adapter-gives-you)
+expanded.
+
+### Auth
+
+SigV4 bearer tokens, no kubeconfig. Each API request carries a
+token minted from the ambient AWS credentials: a presigned STS
+`GetCallerIdentity` URL encoded as `k8s-aws-v1.…` with a 60-second
+expiry, the same scheme as `aws eks get-token`. `endpoint` and
+`certificateAuthorityData` come from the connection when present and
+are re-described otherwise, which also covers EKS rotating the
+endpoint DNS when a cluster is recreated under the same name. A
+cluster that is gone or `DELETING` surfaces as a typed
+`Kubernetes.ClusterNotFoundError`, which `read` and `delete` treat
+as "everything in-cluster is already gone"
+([Destroy and a missing cluster](#destroy-and-a-missing-cluster)).
+
+### Identity
+
+EKS Pod Identity for every workload. Per Deployment or Job the
+adapter creates an IAM role (`<id>-pod-role…`), an inline policy
+(`<id>-pod-policy…`) built from the workload's `policyStatements`
+bindings, and a
+[`PodIdentityAssociation`](/providers/aws/eks/podidentityassociation)
+tying the role to the workload's `namespace` and ServiceAccount. The
+result is the `identity` attribute. `identity.managedPolicyArns`
+adds managed policies to the role. The trust policy, the
+in-container credential chain, `AWS_REGION`, and what keys a
+replacement are on
+[Pod Identity on EKS](/kubernetes/workloads/bindings#pod-identity-on-eks).
+
+```typescript
+Effect.gen(function* () {
+  const table = yield* AWS.DynamoDB.Table("Entries", { /* ... */ });
+
+  const api = yield* Kubernetes.Deployment(
+    "Api",
+    {
+      cluster,
+      main: import.meta.url,
+      port: 3000,
+      identity: { managedPolicyArns: ["arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess"] }, // see Pod Identity
+    },
+    Effect.gen(function* () {
+      const putItem = yield* AWS.DynamoDB.PutItem(table); // → policyStatements on the pod role
+      return { fetch: /* ... */ };
+    }).pipe(Effect.provide(AWS.DynamoDB.PutItemHttp)),
+  );
+
+  // what the adapter persisted:
+  api.identity; // { kind: "aws-pod-identity", roleArn, roleName, associationArn, associationId } | undefined
+});
+```
+
+### Registry
+
+One private ECR repository per workload, named from the logical id
+(`<id>-repo…`, lowercased). All three image sources land in it:
+`main` bundled, `context` built, and a bare `image:` reference
+mirrored in (`docker pull`, tag, push) so nodes pull from ECR with
+IAM auth. Docker must be installed on the deploying machine,
+mirroring included. The result is the `registry` attribute and
+`imageUri`, the ECR reference the pod runs. The repository is
+deleted with the workload. How images are built is under
+[three sources](/kubernetes/workloads/image-sources#three-sources)
+and [architecture](/kubernetes/workloads/image-sources#architecture).
+
+```typescript
+const web = yield* Kubernetes.Deployment("Web", {
+  cluster,
+  image: "public.ecr.aws/nginx/nginx:1.27", // mirrored into the workload's ECR repo, not pulled from public.ecr.aws by the nodes
+  port: 80,
+});
+web.imageUri;  // "<account>.dkr.ecr.<region>.amazonaws.com/<web-repo>:<content-hash>"
+web.registry;  // { kind: "aws-ecr", repositoryName, repositoryUri } | undefined
+```
+
+:::tip[This is what unlocks main]
+The registry hook is why `{ fetch }` / `{ run }` and `context:` work
+here and die on a kubeconfig cluster. See
+[Registry requirement](/kubernetes/workloads/image-sources#registry-requirement).
+:::
+
+### Load balancer defaults
+
+For `serviceType: "LoadBalancer"` on Auto Mode
+(`kubernetesNetworkConfig.elasticLoadBalancing.enabled`), the
+adapter sets `spec.loadBalancerClass: eks.amazonaws.com/nlb`,
+without which Auto Mode ignores the Service, and defaults
+`service.beta.kubernetes.io/aws-load-balancer-scheme` to
+`internet-facing`, because Auto Mode otherwise creates an internal
+NLB. User `serviceAnnotations` always win. The NLB listens on the
+Service `port`, so `url` is `http://<nlb-hostname>:<port>` unless
+the port is 80. The provider waits up to ~3 minutes for the hostname
+([Exposing it: serviceType and url](/kubernetes/workloads/deployments#exposing-it-servicetype-and-url)).
+Clusters without Auto Mode load balancing get no
+`loadBalancerClass` and rely on the AWS Load Balancer Controller's
+own annotations
+([Service types](/kubernetes/guides/exposing-services#service-types)).
+
+```typescript
+const api = yield* Kubernetes.Deployment("Api", {
+  cluster,
+  main: import.meta.url,
+  port: 3000,
+  serviceType: "LoadBalancer", // default
+  serviceAnnotations: {
+    // override the adapter's internet-facing default for a private API:
+    "service.beta.kubernetes.io/aws-load-balancer-scheme": "internal",
+  },
+});
+api.url; // "http://k8s-….elb.amazonaws.com:3000" once the NLB exists
+```
+
+## Destroy and a missing cluster
+
+Delete connects with the persisted connection. If the cluster is
+gone, `DELETING`, or unreachable, the in-cluster objects are skipped
+because they die with the cluster. The adapter-owned resources are
+still cleaned up: the `PodIdentityAssociation` (skipped when the
+cluster is gone), the IAM role with its inline policy, and the ECR
+repository, force-deleted with its images. The in-cluster side is
+under [delete order](/kubernetes/guides/how-apply-works#delete-order).
+
+A stack that owns both cluster and workloads destroys in one
+`alchemy destroy`. A stack targeting a shared cluster through a raw
+`aws-eks` connection removes only what it created. `read` on a
+missing cluster returns "gone", so the next plan shows the workloads
+as needing re-creation rather than erroring. Nothing else on the
+account is touched.
+
+## Where next
+
+- [Deployments](/kubernetes/workloads/deployments) — props, `url`,
+  the tagged form, `{ fetch }`.
+- [Pod Identity on EKS](/kubernetes/workloads/bindings#pod-identity-on-eks)
+  — how bindings become IAM on the pod role.
+- [EKS on the AWS tab](/aws/compute/eks) — provisioning the cluster.

--- a/website/src/content/docs/kubernetes/clusters/eks.mdx
+++ b/website/src/content/docs/kubernetes/clusters/eks.mdx
@@ -1,19 +1,16 @@
 ---
 title: EKS
-description: What changes when `cluster` is an `AWS.EKS.Cluster` — SigV4 auth with no kubeconfig, a Pod Identity role per workload, a per-workload ECR repository that unlocks `main:` and `context:`, and Auto Mode load-balancer defaults.
+description: Deploy Kubernetes workloads to an AWS EKS cluster with IAM auth, a Pod Identity role per workload, and an ECR repository so you can deploy your own code.
 ---
 
-An `AWS.EKS.Cluster` is a valid `cluster`: its `connection` has
-`auth.kind: "aws-eks"`, the only built-in adapter that adds workload
-identity and a registry on top of auth. Creating the cluster is the
-AWS tab's [EKS page](/aws/compute/eks).
+Pass an `AWS.EKS.Cluster` as `cluster` to get IAM auth, a Pod
+Identity role per workload, and an ECR repository for your images. To
+create one, see the AWS tab's [EKS page](/aws/compute/eks).
 
 ## Targeting an EKS cluster
 
-The adapter lives in `AWS.providers()`, so merge it with
-`Kubernetes.providers()`
-([How the adapter is chosen](/kubernetes/clusters/connecting#how-the-adapter-is-chosen)).
-Pass the resource, or a raw `aws-eks` connection for a cluster
+Add `AWS.providers()` next to `Kubernetes.providers()`.
+Pass the cluster resource, or an `aws-eks` connection for a cluster
 created elsewhere.
 
 ```typescript
@@ -21,7 +18,7 @@ created elsewhere.
 export default Alchemy.Stack(
   "MyApp",
   {
-    providers: Layer.mergeAll(AWS.providers(), Kubernetes.providers()), // both: aws-eks lives in AWS.providers()
+    providers: Layer.mergeAll(AWS.providers(), Kubernetes.providers()), // both: EKS needs AWS.providers()
     state: AWS.state(),
   },
   Effect.gen(function* () {
@@ -32,8 +29,7 @@ export default Alchemy.Stack(
       resourcesVpcConfig: { subnetIds: network.privateSubnetIds },
     });
 
-    // (b) a cluster created elsewhere: name + region is enough, the adapter
-    //     re-describes it for endpoint + CA
+    // (b) a cluster created elsewhere: name + region is enough
     const shared: Kubernetes.Connection = {
       auth: { kind: "aws-eks", clusterName: "platform-prod", region: "eu-west-1" },
     };
@@ -44,27 +40,25 @@ export default Alchemy.Stack(
 );
 ```
 
-The deploying identity needs cluster API access plus IAM, EKS, and
-ECR permissions. An `aws eks update-kubeconfig` context through
-[`KubeConfig()`](/kubernetes/clusters/connecting#kubeconfig) is auth
-only.
+Your AWS credentials need cluster API access plus IAM, EKS, and ECR
+permissions. An `aws eks update-kubeconfig` context through
+[`KubeConfig()`](/kubernetes/clusters/connecting#kubeconfig) only
+authenticates, with no Pod Identity or ECR.
 
-## What the adapter adds
+## What EKS adds
 
-`aws-eks` implements all five adapter hooks
-([comparison table](/kubernetes#what-the-cluster-adapter-gives-you)).
+On EKS you also get:
 
 ### Auth
 
-SigV4 bearer tokens from the ambient AWS credentials, like
-`aws eks get-token`. A gone or `DELETING` cluster surfaces as
-`Kubernetes.ClusterNotFoundError`.
+Your ambient AWS credentials sign you in, like `aws eks get-token`,
+with no kubeconfig. If the cluster is gone or `DELETING`, the deploy
+fails with `Kubernetes.ClusterNotFoundError`.
 
 ### Identity
 
-Per workload: an IAM role, an inline policy from its
-`policyStatements` bindings, and a `PodIdentityAssociation` to its
-ServiceAccount
+Each workload gets an IAM role, an inline policy built from its
+bindings, and a Pod Identity association to its ServiceAccount
 ([Pod Identity on EKS](/kubernetes/workloads/bindings#pod-identity-on-eks)).
 
 ```typescript
@@ -77,42 +71,40 @@ Effect.gen(function* () {
       cluster,
       main: import.meta.url,
       port: 3000,
-      identity: { managedPolicyArns: ["arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess"] }, // see Pod Identity
+      identity: { managedPolicyArns: ["arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess"] }, // extra managed policies on the pod's role
     },
     Effect.gen(function* () {
-      const putItem = yield* AWS.DynamoDB.PutItem(table); // → policyStatements on the pod role
+      const putItem = yield* AWS.DynamoDB.PutItem(table); // grants PutItem on the pod's role
       return { fetch: /* ... */ };
     }).pipe(Effect.provide(AWS.DynamoDB.PutItemHttp)),
   );
 
-  // what the adapter persisted:
+  // the role and association, once deployed:
   api.identity; // { kind: "aws-pod-identity", roleArn, roleName, associationArn, associationId } | undefined
 });
 ```
 
 ### Registry
 
-One private ECR repository per workload; `main` is bundled,
-`context` built, and a bare `image:` mirrored into it. Docker must be
-installed on the deploying machine. This is what unlocks `main:` and
-`context:`
-([Registry requirement](/kubernetes/workloads/image-sources#registry-requirement)).
+Each workload gets a private ECR repository. `main` is bundled,
+`context` is built, and `image:` is copied into it. Install Docker
+where you deploy from.
 
 ```typescript
 const web = yield* Kubernetes.Deployment("Web", {
   cluster,
-  image: "public.ecr.aws/nginx/nginx:1.27", // mirrored into the workload's ECR repo, not pulled from public.ecr.aws by the nodes
+  image: "public.ecr.aws/nginx/nginx:1.27", // copied into the workload's ECR repo; nodes pull from there
   port: 80,
 });
-web.imageUri;  // "<account>.dkr.ecr.<region>.amazonaws.com/<web-repo>:<content-hash>"
+web.imageUri;  // "<account>.dkr.ecr.<region>.amazonaws.com/<web-repo>:<tag>"
 web.registry;  // { kind: "aws-ecr", repositoryName, repositoryUri } | undefined
 ```
 
 ### Load balancer defaults
 
-On Auto Mode the adapter sets `loadBalancerClass: eks.amazonaws.com/nlb`
-and defaults the scheme to `internet-facing`; your
-`serviceAnnotations` win.
+On Auto Mode, `LoadBalancer` Services get
+`loadBalancerClass: eks.amazonaws.com/nlb` and an `internet-facing`
+scheme. Your `serviceAnnotations` override either.
 
 ```typescript
 const api = yield* Kubernetes.Deployment("Api", {
@@ -121,7 +113,7 @@ const api = yield* Kubernetes.Deployment("Api", {
   port: 3000,
   serviceType: "LoadBalancer", // default
   serviceAnnotations: {
-    // override the adapter's internet-facing default for a private API:
+    // make it private instead of internet-facing:
     "service.beta.kubernetes.io/aws-load-balancer-scheme": "internal",
   },
 });
@@ -130,9 +122,9 @@ api.url; // "http://k8s-….elb.amazonaws.com:3000" once the NLB exists
 
 ## Destroy and a missing cluster
 
-If the cluster is gone or `DELETING`, delete skips the in-cluster
-objects but still removes the IAM role and ECR repository; `read`
-returns "gone", so the next plan re-creates the workloads.
+If the cluster is gone or `DELETING`, `alchemy destroy` skips the
+in-cluster objects but still removes the IAM role and ECR repository;
+the next deploy re-creates the workloads.
 
 ## Where next
 

--- a/website/src/content/docs/kubernetes/clusters/local.mdx
+++ b/website/src/content/docs/kubernetes/clusters/local.mdx
@@ -1,0 +1,228 @@
+---
+title: Local clusters
+description: Run the Kubernetes workloads on Docker Desktop, OrbStack, kind, k3s, or minikube — which to pick, how to reach a Service without a cloud load balancer, and what "no managed registry" means for your images.
+---
+
+Pick a local cluster, reach a Service on it, run your own image.
+Every cluster here is a
+[`KubeConfig()` connection](/kubernetes/clusters/connecting#kubeconfig),
+so it is auth only. The only thing that changes is the two image
+sources that need a registry, covered at the end. If you have not
+deployed locally yet, start with
+[Tutorial part 1](/kubernetes/tutorial/part-1).
+
+## Which local cluster
+
+The tutorial assumes Docker Desktop or OrbStack.
+[Setup](/kubernetes/setup#pick-a-cluster) covers enabling one. This
+is the comparison.
+
+| Cluster        | Enable                                 | Context               | `LoadBalancer` Services                                              | Local image without a push                               |
+| -------------- | -------------------------------------- | --------------------- | -------------------------------------------------------------------- | -------------------------------------------------------- |
+| Docker Desktop | Settings → Kubernetes → Enable         | `docker-desktop`      | Yes, `url` is `http://localhost:<port>`                              | Yes, shared daemon                                       |
+| OrbStack       | Enable Kubernetes in settings          | `orbstack`            | Yes, `url` is `http://<ip>:<port>` on the OrbStack network           | Yes, shared daemon                                       |
+| kind           | `kind create cluster --name dev`       | `kind-dev`            | No, `url` stays `undefined` unless you install MetalLB or cloud-provider-kind | `kind load docker-image <ref> --name dev`       |
+| minikube       | `minikube start`                       | `minikube`            | Pending until `minikube tunnel` runs in another terminal             | `minikube image load <ref>`                              |
+| k3s / k3d      | Install k3s / `k3d cluster create dev` | `default` / `k3d-dev` | Yes, the bundled ServiceLB assigns the node IP                       | `k3s ctr images import` / `k3d image import <ref> -c dev` |
+
+A default `LoadBalancer` Deployment waits up to ~3 minutes for an
+address on a cluster that will never assign one. On kind the deploy
+still succeeds after the wait and returns `url: undefined`, with
+`kubectl get svc` showing `EXTERNAL-IP <pending>`. Set
+`serviceType: "ClusterIP"` on kind and minikube to skip the wait
+([Exposing it: serviceType and url](/kubernetes/workloads/deployments#exposing-it-servicetype-and-url)).
+
+```typescript
+Effect.gen(function* () {
+  // Pin the context so a teammate's `current-context` never retargets a deploy.
+  const cluster = Kubernetes.KubeConfig({ context: "docker-desktop" });
+  // kind:     Kubernetes.KubeConfig({ context: "kind-dev" })
+  // OrbStack: Kubernetes.KubeConfig({ context: "orbstack" })
+
+  const api = yield* Kubernetes.Deployment("Api", {
+    cluster,
+    image: "ghcr.io/acme/api:v3",
+    port: 8080,
+    // default LoadBalancer → url is http://localhost:8080 on Docker Desktop
+  });
+  return { url: api.url };
+});
+```
+
+:::tip[Self-signed API servers]
+The kubeconfig a local cluster writes carries its CA, so there is
+nothing to configure. Only a hand-written
+[raw connection](/kubernetes/clusters/connecting#token-client-certificate-and-exec)
+needs `insecureSkipTlsVerify: true`.
+:::
+
+## Reaching a Service
+
+Three ways to hit a Deployment on a laptop. Service types and
+Ingress in full are in the
+[Exposing services guide](/kubernetes/guides/exposing-services#service-types).
+
+### LoadBalancer
+
+The default, where the cluster supports it. On Docker Desktop,
+OrbStack, and k3s, `api.url` is the address to curl. Return it from
+the Stack so `alchemy deploy` prints it.
+
+### NodePort
+
+Works everywhere. The port is cluster-assigned (30000–32767) and
+not an attribute, because alchemy's Service spec sets only `port`
+and `targetPort`. Read it with
+`kubectl get svc <serviceName> -n <namespace>`. `url` is
+`undefined` for a `NodePort` Service. On Docker Desktop the node is
+`localhost`; on kind and minikube the node IP needs a port mapping
+or `minikube service`.
+`kubectl port-forward svc/<serviceName> 18080:8080` works too, so
+on a laptop you rarely need the node port.
+
+### ClusterIP and port-forward
+
+The dependable fallback on any cluster, and the right choice on kind
+and minikube.
+
+```typescript
+Effect.gen(function* () {
+  const cluster = Kubernetes.KubeConfig({ context: "kind-dev" });
+
+  const api = yield* Kubernetes.Deployment("Api", {
+    cluster,
+    image: "ghcr.io/acme/api:v3",
+    port: 8080,
+    serviceType: "ClusterIP", // no LB on kind: skip the 3-minute wait, url stays undefined
+  });
+
+  // api.serviceName / api.namespace are what you port-forward to:
+  return { service: api.serviceName, namespace: api.namespace };
+});
+```
+
+```sh
+kubectl port-forward -n default svc/myapp-api-dev-alex-k3m7p2q6r4s5t2v6 8080:8080   # svc/<api.serviceName>
+curl http://localhost:8080/
+```
+
+Without a `name` prop the Deployment, Service, and ServiceAccount
+share a generated base name, so port-forward to `api.serviceName`
+rather than a guess. The naming rules are under
+[What gets created](/kubernetes/workloads/deployments#what-gets-created).
+
+:::note[Ingress on a local cluster]
+ingress-nginx via `HelmChart` works on Docker Desktop and OrbStack
+exactly as in
+[the guide](/kubernetes/guides/exposing-services#ingress).
+:::
+
+## Registry-less limits
+
+`main:` and `context:` fail on every kubeconfig-backed cluster with
+the "this cluster has no managed image registry" error
+([Registry requirement](/kubernetes/workloads/image-sources#registry-requirement)).
+`image:` works, and the reference goes to the kubelet verbatim
+([the three sources](/kubernetes/workloads/image-sources#three-sources)).
+With no `main:` there is no `{ fetch }` or `{ run }`, so a local
+cluster binds through `env` only
+([env-only bindings](/kubernetes/workloads/bindings#env-only-bindings)).
+
+## Using your own images
+
+Build the image, make it pullable by the node, pass the reference as
+`image:`. The middle step depends on the cluster.
+
+### Shared daemon: Docker Desktop, OrbStack
+
+The node is your Docker daemon, so a locally built tag is already
+there. Build with `Docker.Image` from `alchemy/Docker`, with
+`Docker.providers()` merged into the Stack, and hand `imageRef` to
+the Deployment. A rebuild rolls the Deployment.
+
+```typescript
+// alchemy.run.ts
+export default Alchemy.Stack(
+  "MyApp",
+  {
+    providers: Layer.mergeAll(Docker.providers(), Kubernetes.providers()),
+    state: Alchemy.localState(),
+  },
+  Effect.gen(function* () {
+    const cluster = Kubernetes.KubeConfig({ context: "docker-desktop" });
+
+    // docker build ./api -t my-api:dev, through your active Docker context
+    const image = yield* Docker.Image("ApiImage", {
+      name: "my-api",
+      tag: "dev",
+      build: { context: "./api" },
+    });
+
+    const api = yield* Kubernetes.Deployment("Api", {
+      cluster,
+      image: image.imageRef, // "my-api:dev" — already in the node's image store
+      port: 8080,
+      // a non-:latest tag defaults imagePullPolicy to IfNotPresent, so the
+      // kubelet uses the local image instead of asking Docker Hub
+    });
+    return { url: api.url };
+  }),
+);
+```
+
+### Separate containerd: kind, minikube, k3d
+
+Build the same way, then load the tag into the cluster before
+deploying.
+
+```sh
+kind load docker-image my-api:dev --name dev
+minikube image load my-api:dev
+k3d image import my-api:dev -c dev
+```
+
+Loading is out of band. A rebuilt tag must be re-loaded or the
+kubelet keeps the old layers.
+
+### A local registry
+
+For teams or CI-like loops, run a registry container, push to it,
+and use the `localhost:5001/...` reference. kind documents a
+local-registry recipe of its own.
+
+```sh
+docker run -d -p 5001:5000 --name registry registry:2
+docker tag my-api:dev localhost:5001/my-api:dev
+docker push localhost:5001/my-api:dev
+```
+
+Then `image: "localhost:5001/my-api:dev"`. To push from the Stack,
+`Docker.Image` takes a `registry` block. See
+[Build and push](/docker/build-and-push).
+
+### The pull-policy gotcha
+
+Alchemy does not set `imagePullPolicy`, so the Kubernetes defaults
+apply. `:latest` or no tag means `Always`: the kubelet asks Docker
+Hub for a local-only image and fails with `ErrImagePull`. Any other
+tag means `IfNotPresent`. Use a real tag like `my-api:dev` or a git
+SHA. `IfNotPresent` on a `:latest` tag means restating the whole
+container, because `podTemplate.spec.containers` is an array and
+arrays replace wholesale. The shape is under
+[Container-level fields](/kubernetes/workloads/pod-template#container-level-fields).
+
+:::tip[Or let the cloud do it]
+On EKS the same `main:` and `context:` props build and push into a
+per-workload ECR repository with no registry setup. See
+[What the adapter adds](/kubernetes/clusters/eks#what-the-adapter-adds).
+:::
+
+## Where next
+
+- [EKS](/kubernetes/clusters/eks) — Pod Identity, ECR, and `main:`
+  without any of the above.
+- [Deployments](/kubernetes/workloads/deployments) — everything the
+  Deployment creates and every prop.
+- [Exposing services](/kubernetes/guides/exposing-services) —
+  Service types, Ingress, and Cloudflare Tunnel for a public
+  hostname on a local cluster.

--- a/website/src/content/docs/kubernetes/clusters/local.mdx
+++ b/website/src/content/docs/kubernetes/clusters/local.mdx
@@ -1,20 +1,19 @@
 ---
 title: Local clusters
-description: Run the Kubernetes workloads on Docker Desktop, OrbStack, kind, k3s, or minikube — which to pick, how to reach a Service without a cloud load balancer, and what "no managed registry" means for your images.
+description: Deploy Kubernetes workloads to Docker Desktop, OrbStack, kind, k3s, or minikube, reach a Service from your laptop, and use images you build locally.
 ---
 
-Every local cluster is a
-[`KubeConfig()` connection](/kubernetes/clusters/connecting#kubeconfig),
-so it is auth only; the only thing that changes is the two image
-sources that need a registry.
+Connect with
+[`KubeConfig()`](/kubernetes/clusters/connecting#kubeconfig).
+Everything works except `main:` and `context:`; use `image:`.
 
 ## Which local cluster
 
-Docker Desktop (`docker-desktop`), OrbStack (`orbstack`), and
-k3s/k3d (`default` / `k3d-dev`) assign `LoadBalancer` addresses.
-kind (`kind-dev`) and minikube (`minikube`) do not: a default
-Deployment waits ~3 minutes and returns `url: undefined`, so set
-`serviceType: "ClusterIP"` there.
+Docker Desktop (`docker-desktop`), OrbStack (`orbstack`), and k3s/k3d
+(`default` / `k3d-dev`) give `LoadBalancer` Services an address, so
+`api.url` works. kind (`kind-dev`) and minikube (`minikube`) don't: a
+default Deployment waits about 3 minutes and returns
+`url: undefined`, so set `serviceType: "ClusterIP"` there.
 
 ```typescript
 Effect.gen(function* () {
@@ -35,10 +34,9 @@ Effect.gen(function* () {
 
 ## Reaching a Service
 
-`LoadBalancer` (the default) gives you `api.url` where the cluster
-supports it. `NodePort` works everywhere, but the cluster-assigned
-port is not an attribute. `ClusterIP` plus port-forward is the
-dependable fallback and the right choice on kind and minikube
+`LoadBalancer` (the default) gives you `api.url` where supported.
+`NodePort` works everywhere, but you must look up the assigned port
+yourself. On kind and minikube use `ClusterIP` and port-forward
 ([Service types](/kubernetes/guides/exposing-services#service-types)).
 
 ```typescript
@@ -52,7 +50,7 @@ Effect.gen(function* () {
     serviceType: "ClusterIP", // no LB on kind: skip the 3-minute wait, url stays undefined
   });
 
-  // api.serviceName / api.namespace are what you port-forward to:
+  // port-forward to api.serviceName in api.namespace:
   return { service: api.serviceName, namespace: api.namespace };
 });
 ```
@@ -62,26 +60,23 @@ kubectl port-forward -n default svc/myapp-api-dev-alex-k3m7p2q6r4s5t2v6 8080:808
 curl http://localhost:8080/
 ```
 
-Port-forward to `api.serviceName`, not a guess: without a `name`
-prop the names are generated.
+Port-forward to `api.serviceName`: unless you pass `name`, the
+Service name is generated.
 
-## Registry-less limits
+## Limits without a registry
 
-`main:` and `context:` fail on every kubeconfig-backed cluster
-([Registry requirement](/kubernetes/workloads/image-sources#registry-requirement));
-`image:` works. With no `main:` there is no `{ fetch }` or `{ run }`,
-so bindings are
-[env only](/kubernetes/workloads/bindings#env-only-bindings).
+`main:` and `context:` fail on kubeconfig clusters; use `image:`.
+Bindings are [env only](/kubernetes/workloads/bindings#env-only-bindings).
 
 ## Using your own images
 
-Build the image, make it pullable by the node, pass the reference as
-`image:`.
+Build the image, make sure the node can pull it, and pass the
+reference as `image:`.
 
-### Shared daemon: Docker Desktop, OrbStack
+### Docker Desktop and OrbStack
 
-The node is your Docker daemon, so a `Docker.Image` build is already
-there; a rebuild rolls the Deployment.
+An image you build with `Docker.Image` is already on the node.
+Rebuilding it rolls the Deployment.
 
 ```typescript
 // alchemy.run.ts
@@ -105,22 +100,19 @@ export default Alchemy.Stack(
       cluster,
       image: image.imageRef, // "my-api:dev" — already in the node's image store
       port: 8080,
-      // a non-:latest tag defaults imagePullPolicy to IfNotPresent, so the
-      // kubelet uses the local image instead of asking Docker Hub
+      // use a real tag, not :latest
     });
     return { url: api.url };
   }),
 );
 ```
 
-Use a real tag: `:latest` means `imagePullPolicy: Always`, and the
-kubelet fails with `ErrImagePull` asking Docker Hub for a local-only
-image.
+Use a real tag; `:latest` fails with `ErrImagePull`.
 
-### Separate containerd: kind, minikube, k3d
+### kind, minikube, and k3d
 
-Load the tag into the cluster before deploying; a rebuilt tag must
-be re-loaded.
+Load the image into the cluster before you deploy, and again after
+every rebuild.
 
 ```sh
 kind load docker-image my-api:dev --name dev
@@ -130,7 +122,7 @@ k3d image import my-api:dev -c dev
 
 ### A local registry
 
-Or run a registry container, push to it, and use the
+Or run a registry container, push to it, and pass the
 `localhost:5001/...` reference as `image:`.
 
 ```sh

--- a/website/src/content/docs/kubernetes/clusters/local.mdx
+++ b/website/src/content/docs/kubernetes/clusters/local.mdx
@@ -3,34 +3,18 @@ title: Local clusters
 description: Run the Kubernetes workloads on Docker Desktop, OrbStack, kind, k3s, or minikube — which to pick, how to reach a Service without a cloud load balancer, and what "no managed registry" means for your images.
 ---
 
-Pick a local cluster, reach a Service on it, run your own image.
-Every cluster here is a
+Every local cluster is a
 [`KubeConfig()` connection](/kubernetes/clusters/connecting#kubeconfig),
-so it is auth only. The only thing that changes is the two image
-sources that need a registry, covered at the end. If you have not
-deployed locally yet, start with
-[Tutorial part 1](/kubernetes/tutorial/part-1).
+so it is auth only; the only thing that changes is the two image
+sources that need a registry.
 
 ## Which local cluster
 
-The tutorial assumes Docker Desktop or OrbStack.
-[Setup](/kubernetes/setup#pick-a-cluster) covers enabling one. This
-is the comparison.
-
-| Cluster        | Enable                                 | Context               | `LoadBalancer` Services                                              | Local image without a push                               |
-| -------------- | -------------------------------------- | --------------------- | -------------------------------------------------------------------- | -------------------------------------------------------- |
-| Docker Desktop | Settings → Kubernetes → Enable         | `docker-desktop`      | Yes, `url` is `http://localhost:<port>`                              | Yes, shared daemon                                       |
-| OrbStack       | Enable Kubernetes in settings          | `orbstack`            | Yes, `url` is `http://<ip>:<port>` on the OrbStack network           | Yes, shared daemon                                       |
-| kind           | `kind create cluster --name dev`       | `kind-dev`            | No, `url` stays `undefined` unless you install MetalLB or cloud-provider-kind | `kind load docker-image <ref> --name dev`       |
-| minikube       | `minikube start`                       | `minikube`            | Pending until `minikube tunnel` runs in another terminal             | `minikube image load <ref>`                              |
-| k3s / k3d      | Install k3s / `k3d cluster create dev` | `default` / `k3d-dev` | Yes, the bundled ServiceLB assigns the node IP                       | `k3s ctr images import` / `k3d image import <ref> -c dev` |
-
-A default `LoadBalancer` Deployment waits up to ~3 minutes for an
-address on a cluster that will never assign one. On kind the deploy
-still succeeds after the wait and returns `url: undefined`, with
-`kubectl get svc` showing `EXTERNAL-IP <pending>`. Set
-`serviceType: "ClusterIP"` on kind and minikube to skip the wait
-([Exposing it: serviceType and url](/kubernetes/workloads/deployments#exposing-it-servicetype-and-url)).
+Docker Desktop (`docker-desktop`), OrbStack (`orbstack`), and
+k3s/k3d (`default` / `k3d-dev`) assign `LoadBalancer` addresses.
+kind (`kind-dev`) and minikube (`minikube`) do not: a default
+Deployment waits ~3 minutes and returns `url: undefined`, so set
+`serviceType: "ClusterIP"` there.
 
 ```typescript
 Effect.gen(function* () {
@@ -49,41 +33,13 @@ Effect.gen(function* () {
 });
 ```
 
-:::tip[Self-signed API servers]
-The kubeconfig a local cluster writes carries its CA, so there is
-nothing to configure. Only a hand-written
-[raw connection](/kubernetes/clusters/connecting#token-client-certificate-and-exec)
-needs `insecureSkipTlsVerify: true`.
-:::
-
 ## Reaching a Service
 
-Three ways to hit a Deployment on a laptop. Service types and
-Ingress in full are in the
-[Exposing services guide](/kubernetes/guides/exposing-services#service-types).
-
-### LoadBalancer
-
-The default, where the cluster supports it. On Docker Desktop,
-OrbStack, and k3s, `api.url` is the address to curl. Return it from
-the Stack so `alchemy deploy` prints it.
-
-### NodePort
-
-Works everywhere. The port is cluster-assigned (30000–32767) and
-not an attribute, because alchemy's Service spec sets only `port`
-and `targetPort`. Read it with
-`kubectl get svc <serviceName> -n <namespace>`. `url` is
-`undefined` for a `NodePort` Service. On Docker Desktop the node is
-`localhost`; on kind and minikube the node IP needs a port mapping
-or `minikube service`.
-`kubectl port-forward svc/<serviceName> 18080:8080` works too, so
-on a laptop you rarely need the node port.
-
-### ClusterIP and port-forward
-
-The dependable fallback on any cluster, and the right choice on kind
-and minikube.
+`LoadBalancer` (the default) gives you `api.url` where the cluster
+supports it. `NodePort` works everywhere, but the cluster-assigned
+port is not an attribute. `ClusterIP` plus port-forward is the
+dependable fallback and the right choice on kind and minikube
+([Service types](/kubernetes/guides/exposing-services#service-types)).
 
 ```typescript
 Effect.gen(function* () {
@@ -106,39 +62,26 @@ kubectl port-forward -n default svc/myapp-api-dev-alex-k3m7p2q6r4s5t2v6 8080:808
 curl http://localhost:8080/
 ```
 
-Without a `name` prop the Deployment, Service, and ServiceAccount
-share a generated base name, so port-forward to `api.serviceName`
-rather than a guess. The naming rules are under
-[What gets created](/kubernetes/workloads/deployments#what-gets-created).
-
-:::note[Ingress on a local cluster]
-ingress-nginx via `HelmChart` works on Docker Desktop and OrbStack
-exactly as in
-[the guide](/kubernetes/guides/exposing-services#ingress).
-:::
+Port-forward to `api.serviceName`, not a guess: without a `name`
+prop the names are generated.
 
 ## Registry-less limits
 
-`main:` and `context:` fail on every kubeconfig-backed cluster with
-the "this cluster has no managed image registry" error
-([Registry requirement](/kubernetes/workloads/image-sources#registry-requirement)).
-`image:` works, and the reference goes to the kubelet verbatim
-([the three sources](/kubernetes/workloads/image-sources#three-sources)).
-With no `main:` there is no `{ fetch }` or `{ run }`, so a local
-cluster binds through `env` only
-([env-only bindings](/kubernetes/workloads/bindings#env-only-bindings)).
+`main:` and `context:` fail on every kubeconfig-backed cluster
+([Registry requirement](/kubernetes/workloads/image-sources#registry-requirement));
+`image:` works. With no `main:` there is no `{ fetch }` or `{ run }`,
+so bindings are
+[env only](/kubernetes/workloads/bindings#env-only-bindings).
 
 ## Using your own images
 
 Build the image, make it pullable by the node, pass the reference as
-`image:`. The middle step depends on the cluster.
+`image:`.
 
 ### Shared daemon: Docker Desktop, OrbStack
 
-The node is your Docker daemon, so a locally built tag is already
-there. Build with `Docker.Image` from `alchemy/Docker`, with
-`Docker.providers()` merged into the Stack, and hand `imageRef` to
-the Deployment. A rebuild rolls the Deployment.
+The node is your Docker daemon, so a `Docker.Image` build is already
+there; a rebuild rolls the Deployment.
 
 ```typescript
 // alchemy.run.ts
@@ -170,10 +113,14 @@ export default Alchemy.Stack(
 );
 ```
 
+Use a real tag: `:latest` means `imagePullPolicy: Always`, and the
+kubelet fails with `ErrImagePull` asking Docker Hub for a local-only
+image.
+
 ### Separate containerd: kind, minikube, k3d
 
-Build the same way, then load the tag into the cluster before
-deploying.
+Load the tag into the cluster before deploying; a rebuilt tag must
+be re-loaded.
 
 ```sh
 kind load docker-image my-api:dev --name dev
@@ -181,14 +128,10 @@ minikube image load my-api:dev
 k3d image import my-api:dev -c dev
 ```
 
-Loading is out of band. A rebuilt tag must be re-loaded or the
-kubelet keeps the old layers.
-
 ### A local registry
 
-For teams or CI-like loops, run a registry container, push to it,
-and use the `localhost:5001/...` reference. kind documents a
-local-registry recipe of its own.
+Or run a registry container, push to it, and use the
+`localhost:5001/...` reference as `image:`.
 
 ```sh
 docker run -d -p 5001:5000 --name registry registry:2
@@ -196,33 +139,8 @@ docker tag my-api:dev localhost:5001/my-api:dev
 docker push localhost:5001/my-api:dev
 ```
 
-Then `image: "localhost:5001/my-api:dev"`. To push from the Stack,
-`Docker.Image` takes a `registry` block. See
-[Build and push](/docker/build-and-push).
-
-### The pull-policy gotcha
-
-Alchemy does not set `imagePullPolicy`, so the Kubernetes defaults
-apply. `:latest` or no tag means `Always`: the kubelet asks Docker
-Hub for a local-only image and fails with `ErrImagePull`. Any other
-tag means `IfNotPresent`. Use a real tag like `my-api:dev` or a git
-SHA. `IfNotPresent` on a `:latest` tag means restating the whole
-container, because `podTemplate.spec.containers` is an array and
-arrays replace wholesale. The shape is under
-[Container-level fields](/kubernetes/workloads/pod-template#container-level-fields).
-
-:::tip[Or let the cloud do it]
-On EKS the same `main:` and `context:` props build and push into a
-per-workload ECR repository with no registry setup. See
-[What the adapter adds](/kubernetes/clusters/eks#what-the-adapter-adds).
-:::
-
 ## Where next
 
-- [EKS](/kubernetes/clusters/eks) — Pod Identity, ECR, and `main:`
-  without any of the above.
-- [Deployments](/kubernetes/workloads/deployments) — everything the
-  Deployment creates and every prop.
-- [Exposing services](/kubernetes/guides/exposing-services) —
-  Service types, Ingress, and Cloudflare Tunnel for a public
-  hostname on a local cluster.
+- [EKS](/kubernetes/clusters/eks) — `main:` with no registry setup
+- [Deployments](/kubernetes/workloads/deployments)
+- [Exposing services](/kubernetes/guides/exposing-services)

--- a/website/src/content/docs/kubernetes/guides/cluster-adapters.mdx
+++ b/website/src/content/docs/kubernetes/guides/cluster-adapters.mdx
@@ -1,23 +1,16 @@
 ---
 title: Cluster adapters
-description: The ClusterAdapter seam that makes Kubernetes workloads cluster-agnostic — the interface, how an auth kind is registered and found, and a worked sketch of a GKE adapter built on the exec credential path.
+description: The ClusterAdapter seam that makes Kubernetes workloads cluster-agnostic — the interface, how an auth kind is registered and found, and a sketch of a GKE adapter built on the exec credential path.
 ---
 
-The whole hub rests on one interface. A
-[`Connection`](/kubernetes/clusters/connecting#the-connection-model)
+A [`Connection`](/kubernetes/clusters/connecting#the-connection-model)
 is data. Its `auth.kind`
 [selects](/kubernetes/clusters/connecting#how-the-adapter-is-chosen)
 a `ClusterAdapterService` that talks to the API server and,
-optionally, gives workloads an identity and an image registry. The
-workload providers never import a platform. They call
-`findClusterAdapter(connection.auth.kind)` and use whatever members
-the adapter implements. Read this to add a platform (GKE, AKS, a
-corporate OIDC proxy) or to learn why `main:` only works on EKS
-today.
+optionally, gives workloads an identity and an image registry. Read
+this to add a platform (GKE, AKS, a corporate OIDC proxy).
 
 ## The interface
-
-The shape, as exported from `alchemy/Kubernetes`:
 
 ```typescript
 import type * as Kubernetes from "alchemy/Kubernetes";
@@ -58,104 +51,42 @@ interface ClusterAdapterService {
 }
 ```
 
-`connect` returns a `ClusterTransport`:
-`{ endpoint, certificateAuthorityData?, insecureSkipTlsVerify?, headers, clientCert? }`.
-`headers` is an Effect run once per API request, so short-lived
-tokens (STS presigns, exec plugins with an `expirationTimestamp`)
-are minted fresh. `connect` itself runs once per lifecycle operation.
-Exec-plugin results are cached per `(command, args, env)` until they
-expire, so a `headers` Effect that shells out is cheap. When the
-connection lacks `endpoint` or CA, discovery is the adapter's job:
-kubeconfig reads the file, EKS re-describes the cluster, and the
-[non-discovering built-ins](/kubernetes/clusters/connecting#token-client-certificate-and-exec)
-fail with "requires an explicit `endpoint`". Fail with
-`ClusterNotFoundError` (tag `Kubernetes.ClusterNotFoundError`) only
-when the cluster is definitively gone. `read` and `delete` treat it
-as everything in-cluster already gone. Any other error is transient:
-state is kept, the in-cluster delete is skipped, cloud-side cleanup
-still runs.
+`connect` is required. Its `ClusterTransport.headers` Effect runs
+once per API request, so short-lived tokens are minted fresh. Fail
+with `ClusterNotFoundError` only when the cluster is definitively
+gone; any other error is treated as transient.
 
-`identity` is called by Deployment and Job reconcile with
-`{ id, connection, namespace, serviceAccount, bindings, options, state, tags }`,
-where `options` is the workload's `identity` prop, and returns
-`{ env, serviceAccountAnnotations?, state }`. `env` is merged into
-the container (EKS injects `AWS_REGION`). `serviceAccountAnnotations`
-land on the synthesized ServiceAccount, the hook a GKE Workload
-Identity or Azure adapter needs. `state` is persisted on the
-workload's `identity` attribute and handed back next time as
-`Record<string, unknown>`, so narrow it and re-observe the cloud.
-Without `identity`, a binding carrying a non-`env` grant key such as
-`policyStatements` makes reconcile die. That is the mechanism behind
+`identity` receives the workload's bindings and returns
+`{ env, serviceAccountAnnotations?, state }`. Without it, a binding
+carrying `policyStatements` dies, the mechanism behind
 [env-only bindings](/kubernetes/workloads/bindings#env-only-bindings).
-What EKS provisions is under
-[Pod Identity on EKS](/kubernetes/workloads/bindings#pod-identity-on-eks).
-
-`registry.resolve` receives the image-source props (`main`,
-`handler`, `build`, `context`, `dockerfile`, `image`), the target
-`platform`, the `port`, the `bootstrap` entry generator, and a
-`session` for progress notes. It returns
-`{ imageUri, codeHash, state }`. `hash` is the plan-time twin `diff`
-uses to surface content drift without building. Without `registry`,
-an `image` reference passes through verbatim and `main` or `context`
-dies. That is the
+`registry.resolve` turns `main`, `context`, or `image` into
+`{ imageUri, codeHash, state }`; without it, `image` passes through
+verbatim and `main` or `context` dies, the
 [registry requirement](/kubernetes/workloads/image-sources#registry-requirement).
+`bootstrap` overrides the generated entry for `main` workloads.
+`loadBalancerDefaults` are spread under the user's
+`serviceAnnotations`
+([Service types](/kubernetes/guides/exposing-services#service-types)).
 
-`bootstrap` only matters for `main` workloads. It is the generated
-entry file
-[wrapped around the user's program](/kubernetes/workloads/image-sources#bundling-and-tree-shaking).
-The defaults serve `{ fetch }` on `PORT` and run `{ run }` to
-completion. EKS overrides both to add `Credentials.fromChain()` and
-`Region.fromEnv()` so Pod Identity's container-credentials endpoint
-resolves. Omit it unless the platform's credential chain needs
-in-process wiring.
-
-`loadBalancerDefaults` is consulted only by `Deployment` and only
-for `serviceType: "LoadBalancer"`. The result is spread under the
-user's `serviceAnnotations`, and `loadBalancerClass` goes to `spec`.
-EKS returns `eks.amazonaws.com/nlb` when the cluster reports Auto
-Mode load balancing, plus the internet-facing scheme annotation. How
-that surfaces to users is under
-[Service types](/kubernetes/guides/exposing-services#service-types).
-
-`AdapterLifecycleServices = InstanceId | Stack | Stage` are the only
-services an adapter method may require from the ambient context.
-`createPhysicalName` needs them, and they are per-resource, so never
-capture them at layer build. Everything else (cloud SDK clients,
-`FileSystem`, `ChildProcessSpawner`, `HttpClient`) is captured once
-with `yield* Effect.context<…>()` inside the `Layer.effect` and
-re-provided with `Effect.provideContext`. The EKS source says it in
-one line: "do not shadow InstanceId/Stack/Stage with the
-layer-captured context".
-
-What the providers call, in order:
-
-| Provider op | Calls                                                                                                                                                                     |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `diff`      | `registry.hash` (or the static `image`/`context` hash when absent)                                                                                                        |
-| `read`      | `connect` → GET the anchor object; `ClusterNotFoundError` means gone                                                                                                      |
-| `reconcile` | `connect` → `identity.reconcile` (if present; die when grants are bound and it is absent) → `registry.resolve` (or verbatim `image`) → build objects → `loadBalancerDefaults` (Deployment with `LoadBalancer` only) → apply |
-| `delete`    | `connect` (errors skip the in-cluster part) → delete objects → `identity.delete` → `registry.delete`                                                                     |
-
+`AdapterLifecycleServices = InstanceId | Stack | Stage` are
+per-resource, so never capture them at layer build; capture
+everything else once with `Effect.context` inside the `Layer.effect`.
 `Manifest` and `HelmChart` only use `connect`, so an auth-only
 adapter gives every resource except `main`/`context` images and
-cloud-grant bindings. That is the built-ins' column in the
-[overview table](/kubernetes#what-the-cluster-adapter-gives-you).
+cloud-grant bindings.
 
 ## Registering an auth kind
 
-`AuthRegistry` in `alchemy/Kubernetes/Connection` is an interface
-keyed by kind, extended by module augmentation, and `ConnectionAuth`
-is derived from it. A new kind makes `{ auth: { kind: "gke", … } }`
-valid on every workload's `cluster` prop with no change to the
-Kubernetes package.
+`AuthRegistry` in `alchemy/Kubernetes/Connection` is extended by
+module augmentation. A new kind makes `{ auth: { kind: "gke", … } }`
+valid on every workload's `cluster` prop.
 
 ### Augment `AuthRegistry`
 
-The descriptor is serializable identity, not credentials. It is
-[persisted on every workload's `connection` attribute](/kubernetes/clusters/connecting#the-connection-model),
-and its JSON decides whether a workload moved clusters. Endpoint and
-CA live on the `Connection`, not in `auth`, so they can rotate
-without replacing workloads.
+The descriptor is serializable identity, never credentials: it is
+[persisted on every workload](/kubernetes/clusters/connecting#the-connection-model)
+and its JSON decides whether a workload moved clusters.
 
 ```typescript
 // In-repo: relative path. External package: "alchemy/Kubernetes/Connection".
@@ -173,13 +104,8 @@ declare module "alchemy/Kubernetes/Connection" {
 
 ### Augment the state registries
 
-Optional, for adapters with `identity` or `registry`.
-`alchemy/Kubernetes/ClusterAdapter` exposes `IdentityStateRegistry`
-and `RegistryStateRegistry` for what the two persist,
-`WorkloadIdentityOptions` for cloud-specific `identity` prop fields,
-`WorkloadBindingContract` for a new grant channel like AWS's
-`policyStatements`, and `WorkloadServicesRegistry` for services the
-platform's bootstrap makes ambient. The EKS block is the template.
+Optional, for adapters with `identity` or `registry`. The EKS block
+is the template:
 
 ```typescript
 // packages/alchemy/src/AWS/EKS/KubernetesAdapter.ts
@@ -213,25 +139,14 @@ declare module "../../Kubernetes/ClusterAdapter.ts" {
 ### Build the layer
 
 `Kubernetes.ClusterAdapter("gke")` returns a Context service keyed
-`Kubernetes.ClusterAdapter/gke`, so any `findClusterAdapter("gke")`
-finds it. Use `Layer.effect` to capture dependencies once, return an
-object `satisfies ClusterAdapterService`, and die when
-`connection.auth.kind` is not yours. The engine never routes a
-foreign kind to you, so a mismatch is a programming error. A
-providers layer is `Layer<…, never, StackServices>`, and
-`StackServices` already includes `FileSystem`, `Path`, `HttpClient`,
-and `ChildProcessSpawner`, so an adapter may require those with no
-extra wiring. General provider scaffolding is under
-[Custom providers](/infrastructure-as-code/custom-provider).
+`Kubernetes.ClusterAdapter/gke`. Use `Layer.effect`, return an object
+`satisfies ClusterAdapterService`, and die when
+`connection.auth.kind` is not yours.
 
 ### Provide it into the Stack
 
-Adapters are looked up with `Effect.serviceOption`, not statically
-required, so they must be `provideMerge`d into the providers layer,
-never just `provide`d. In-repo, the cloud's `providers()` does
-`Layer.provideMerge(GkeKubernetesAdapter())`. Out of tree, merge it
-beside `Kubernetes.providers()`
-[where the Stack composes its providers](/kubernetes/setup#add-the-provider):
+Adapters are looked up with `Effect.serviceOption`, so merge the
+layer beside `Kubernetes.providers()`:
 
 ```typescript
 export default Alchemy.Stack(
@@ -258,39 +173,22 @@ export default Alchemy.Stack(
 );
 ```
 
-Skip this and `findClusterAdapter` dies with the message under
-[How the adapter is chosen](/kubernetes/clusters/connecting#how-the-adapter-is-chosen).
-
-### Stamp a connection on the cluster resource
-
-Optional. If the platform has a cluster resource, put a `connection`
-on its attributes so the whole resource satisfies `ClusterLike` and
-passes as `cluster` directly, the way
+Optionally, stamp a `connection` on the platform's cluster resource
+so it satisfies `ClusterLike` and passes as `cluster` directly, as
 [`AWS.EKS.Cluster`](/kubernetes/clusters/eks#what-the-adapter-adds)
-does with
-`eksConnectionOf({ clusterName, region, endpoint, certificateAuthorityData })`.
-Replacing the cluster then replaces the workloads, because `auth`
-changes only with the cluster name. Endpoint rotation is not a
-replacement.
+does.
 
 :::caution
-`auth` is persisted in plain state. Never put a secret in an
-`AuthRegistry` member. The built-in
-[`token` and `client-cert` kinds](/kubernetes/clusters/connecting#token-client-certificate-and-exec)
-are the documented exceptions. A cloud adapter derives credentials
-from the ambient environment, as `aws-eks` does.
+`auth` is persisted in plain state, so never put a secret in an `AuthRegistry` member.
 :::
 
 ## A GKE adapter sketch
 
-The smallest useful adapter: auth-only, exported API only, every
-identifier defined. The GKE API details and the compile have not
-been run against a live project. It discovers endpoint and CA from
-the GKE API with a `gcloud auth print-access-token` token, then
-delegates header minting to the built-in
+An auth-only adapter, not yet run against a live project. It
+discovers endpoint and CA from the GKE API, then delegates header
+minting to the built-in
 [`exec` adapter](/kubernetes/clusters/connecting#token-client-certificate-and-exec)
-with `gke-gcloud-auth-plugin` through `findClusterAdapter("exec")`.
-No ExecCredential protocol to re-implement.
+with `gke-gcloud-auth-plugin`:
 
 ```typescript
 import * as Kubernetes from "alchemy/Kubernetes";
@@ -432,81 +330,14 @@ export const GkeKubernetesAdapter = () =>
   );
 ```
 
-This gives every `Kubernetes.*` resource on GKE with `image:`
-sources and env-only bindings, the `kubeconfig` column of the
-[overview table](/kubernetes#what-the-cluster-adapter-gives-you),
-plus endpoint discovery so CI needs no kubeconfig file. The cluster
-identity is `{ project, location, clusterName }`. Change any of them
-and the workloads replace. The endpoint can be re-discovered at will.
-
-The sketch uses two credentials: a `gcloud` access token against
-`container.googleapis.com` for discovery only, and
-`gke-gcloud-auth-plugin` through the `exec` adapter for every object
-request. A production adapter would swap the shell-out for a
-google-auth library and cache the token until expiry. Without any
-adapter,
-[`Kubernetes.KubeConfig({ context: "gke_acme-prod_us-central1_main" })`](/kubernetes/clusters/connecting#kubeconfig)
-already honours the plugin. The adapter earns its keep through
-discovery and, later, identity and registry.
-
-`identity` for Workload Identity Federation would create a GCP
-service account per workload, return
-`serviceAccountAnnotations: { "iam.gke.io/gcp-service-account": email }`,
-persist `{ kind: "gke-workload-identity", email }`, and translate a
-new [binding contract](/kubernetes/workloads/bindings#the-binding-contract)
-channel such as `iamRoles` into IAM bindings. `registry` for
-Artifact Registry would reuse the Docker build-and-push machinery
-the EKS adapter gets from `makeImageSource` and mirror `image`
-references so the cluster pulls from one place. With both, `main:`
-and cloud-grant bindings
-[light up on GKE](/kubernetes/workloads/image-sources#registry-requirement)
-with no workload changes. `bootstrap` is probably unnecessary, since
-Application Default Credentials resolve through the metadata server
-inside the pod. Confirm that before relying on it. If a platform
-does need env-driven credential wiring, copy `makeEksServerBootstrap`
-and `makeEksJobBootstrap`.
-
-## Contributing an adapter
-
-An in-repo adapter mirrors the EKS layout. It lives at
-`packages/alchemy/src/{Cloud}/{Service}/KubernetesAdapter.ts`:
-augmentations at the top, `make{Cloud}Transport` and
-`{cloud}ConnectionOf` exported for the cluster resource, the
-`Layer.effect` at the bottom. The `Kubernetes/` package stays
-cloud-free. Register it with
-`Layer.provideMerge({Cloud}KubernetesAdapter())` in the cloud's
-`providers()`, stamp `connection` on the managed cluster resource's
-attributes, and list it in `stables`.
-
-State persisted by `identity` and `registry` is a hint. Re-read the
-cloud, per the
-[reconciler doctrine](/infrastructure-as-code/resource-lifecycle),
-and tolerate a missing cluster in `identity.delete` (EKS skips the
-association when the cluster is `DELETING`). Never cache
-`InstanceId`, `Stack`, or `Stage` at layer build, never return
-`ClusterNotFoundError` for a transient failure, never put
-credentials in `auth`.
-
-Tests are a transport unit test next to
-`test/Kubernetes/KubeConfig.test.ts` and live lifecycle tests behind
-an env gate like the EKS suite's `AWS_TEST_SLOW`, each starting and
-ending with `stack.destroy()`. `Kubernetes.KubeConfigError` and
-`Kubernetes.ExecCredentialError` are not re-exported from
-`alchemy/Kubernetes` today, so match on the tag string or export
-them first. For docs, add a row to the
-[overview's adapter table](/kubernetes#what-the-cluster-adapter-gives-you),
-a sentence to
-[How the adapter is chosen](/kubernetes/clusters/connecting#how-the-adapter-is-chosen),
-and JSDoc on the `AuthRegistry` member, the only user-facing type
-for the kind.
+This gives every `Kubernetes.*` resource on GKE with `image:` sources
+and env-only bindings. Adding `identity` (Workload Identity
+Federation via `serviceAccountAnnotations`) and `registry` (Artifact
+Registry) would light up `main:` and cloud-grant bindings with no
+workload changes.
 
 ## Where next
 
-- [Deployment reference](/providers/kubernetes/deployment) — the
-  generated reference for every `Kubernetes.*` resource starts here.
-- [EKS](/kubernetes/clusters/eks) — the reference adapter from the
-  user's side.
-- [Connecting to a cluster](/kubernetes/clusters/connecting) — the
-  connection model the adapter plugs into.
-- [Custom providers](/infrastructure-as-code/custom-provider) —
-  writing providers in general.
+- [EKS](/kubernetes/clusters/eks)
+- [Connecting to a cluster](/kubernetes/clusters/connecting)
+- [Custom providers](/infrastructure-as-code/custom-provider)

--- a/website/src/content/docs/kubernetes/guides/cluster-adapters.mdx
+++ b/website/src/content/docs/kubernetes/guides/cluster-adapters.mdx
@@ -1,14 +1,14 @@
 ---
 title: Cluster adapters
-description: The ClusterAdapter seam that makes Kubernetes workloads cluster-agnostic — the interface, how an auth kind is registered and found, and a sketch of a GKE adapter built on the exec credential path.
+description: Write a cluster adapter so Kubernetes workloads can target a new platform such as GKE or AKS.
 ---
 
-A [`Connection`](/kubernetes/clusters/connecting#the-connection-model)
-is data. Its `auth.kind`
-[selects](/kubernetes/clusters/connecting#how-the-adapter-is-chosen)
-a `ClusterAdapterService` that talks to the API server and,
-optionally, gives workloads an identity and an image registry. Read
-this to add a platform (GKE, AKS, a corporate OIDC proxy).
+A [`Connection`](/kubernetes/clusters/connecting#what-cluster-accepts)'s
+`auth.kind`
+[picks](/kubernetes/clusters/connecting#deploying-to-eks)
+the `ClusterAdapterService` that talks to the API server and,
+optionally, gives workloads an identity and an image registry. Write
+one to support a new platform (GKE, AKS, a corporate OIDC proxy).
 
 ## The interface
 
@@ -18,31 +18,31 @@ import type * as Kubernetes from "alchemy/Kubernetes";
 interface ClusterAdapterService {
   readonly kind: "Kubernetes.ClusterAdapter";
 
-  // REQUIRED — resolve endpoint/CA and a per-request header mint.
+  // REQUIRED: resolve endpoint/CA and mint headers per request.
   readonly connect: (
     connection: Kubernetes.Connection,
   ) => Effect.Effect<Kubernetes.ClusterTransport, Kubernetes.ClusterNotFoundError | Error>;
 
-  // OPTIONAL — workload identity (EKS Pod Identity).
+  // OPTIONAL: workload identity (EKS Pod Identity).
   readonly identity?: {
     readonly reconcile: (o: WorkloadIdentityReconcileOptions) => Effect.Effect<WorkloadIdentityResult, any, AdapterLifecycleServices>;
     readonly delete: (o: WorkloadIdentityDeleteOptions) => Effect.Effect<void, any, AdapterLifecycleServices>;
   };
 
-  // OPTIONAL — managed image registry (ECR).
+  // OPTIONAL: managed image registry (ECR).
   readonly registry?: {
     readonly resolve: (o: ImageRegistryResolveOptions) => Effect.Effect<ImageRegistryResult, any, AdapterLifecycleServices>;
     readonly hash: (o: ImageRegistryHashOptions) => Effect.Effect<string | undefined, any, AdapterLifecycleServices>;
     readonly delete: (o: ImageRegistryDeleteOptions) => Effect.Effect<void, any, AdapterLifecycleServices>;
   };
 
-  // OPTIONAL — platform-specific generated container entries for `main` workloads.
+  // OPTIONAL: platform-specific entry files for `main` workloads.
   readonly bootstrap?: {
     readonly server?: (handler: string) => (importPath: string) => string;
     readonly job?: (handler: string) => (importPath: string) => string;
   };
 
-  // OPTIONAL — defaults for `serviceType: "LoadBalancer"` Services.
+  // OPTIONAL: defaults for `serviceType: "LoadBalancer"` Services.
   readonly loadBalancerDefaults?: (o: { connection: Kubernetes.Connection }) => Effect.Effect<
     { loadBalancerClass?: string | undefined; annotations?: Record<string, string> },
     any,
@@ -51,45 +51,44 @@ interface ClusterAdapterService {
 }
 ```
 
-`connect` is required. Its `ClusterTransport.headers` Effect runs
-once per API request, so short-lived tokens are minted fresh. Fail
-with `ClusterNotFoundError` only when the cluster is definitively
-gone; any other error is treated as transient.
+Implement `connect`. Its `ClusterTransport.headers` Effect runs on
+every API request, so mint short-lived tokens there. Fail with
+`ClusterNotFoundError` only when the cluster is gone for good; any
+other error is treated as transient.
 
-`identity` receives the workload's bindings and returns
-`{ env, serviceAccountAnnotations?, state }`. Without it, a binding
-carrying `policyStatements` dies, the mechanism behind
-[env-only bindings](/kubernetes/workloads/bindings#env-only-bindings).
-`registry.resolve` turns `main`, `context`, or `image` into
-`{ imageUri, codeHash, state }`; without it, `image` passes through
-verbatim and `main` or `context` dies, the
-[registry requirement](/kubernetes/workloads/image-sources#registry-requirement).
-`bootstrap` overrides the generated entry for `main` workloads.
-`loadBalancerDefaults` are spread under the user's
-`serviceAnnotations`
+Add `identity` to give workloads a cloud identity: it receives the
+workload's bindings and returns
+`{ env, serviceAccountAnnotations?, state }`. Without it, bindings are
+[env-only](/kubernetes/workloads/bindings#env-only-bindings) and
+`policyStatements` fail the deploy. Add `registry` to support `main`
+and `context`: `resolve` turns any image source into
+`{ imageUri, codeHash, state }`. Without it, only `image` works,
+[verbatim](/kubernetes/workloads/image-sources#registry-requirement).
+`bootstrap` replaces the generated entry file for `main` workloads.
+`loadBalancerDefaults` go under the user's `serviceAnnotations`
 ([Service types](/kubernetes/guides/exposing-services#service-types)).
 
-`AdapterLifecycleServices = InstanceId | Stack | Stage` are
-per-resource, so never capture them at layer build; capture
-everything else once with `Effect.context` inside the `Layer.effect`.
-`Manifest` and `HelmChart` only use `connect`, so an auth-only
-adapter gives every resource except `main`/`context` images and
-cloud-grant bindings.
+`AdapterLifecycleServices` (`InstanceId | Stack | Stage`) are
+per-resource: don't capture them when you build the layer. Capture
+everything else once with `Effect.context` inside `Layer.effect`. An
+adapter with only `connect` supports every resource; you lose only
+`main`/`context` images and cloud-grant bindings.
 
 ## Registering an auth kind
 
-`AuthRegistry` in `alchemy/Kubernetes/Connection` is extended by
-module augmentation. A new kind makes `{ auth: { kind: "gke", … } }`
-valid on every workload's `cluster` prop.
+Add your kind to `AuthRegistry` in `alchemy/Kubernetes/Connection`
+with module augmentation. `{ auth: { kind: "gke", … } }` then
+type-checks on every workload's `cluster` prop.
 
 ### Augment `AuthRegistry`
 
-The descriptor is serializable identity, never credentials: it is
-[persisted on every workload](/kubernetes/clusters/connecting#the-connection-model)
-and its JSON decides whether a workload moved clusters.
+Put only what identifies the cluster in the descriptor, never
+credentials: it is
+[saved on every workload](/kubernetes/clusters/connecting#what-cluster-accepts),
+and changing it replaces the workload.
 
 ```typescript
-// In-repo: relative path. External package: "alchemy/Kubernetes/Connection".
+// In your package:
 declare module "alchemy/Kubernetes/Connection" {
   interface AuthRegistry {
     /** Authenticate against a GKE cluster with gke-gcloud-auth-plugin. */
@@ -104,11 +103,10 @@ declare module "alchemy/Kubernetes/Connection" {
 
 ### Augment the state registries
 
-Optional, for adapters with `identity` or `registry`. The EKS block
-is the template:
+Only if you add `identity` or `registry`. Copy the EKS block:
 
 ```typescript
-// packages/alchemy/src/AWS/EKS/KubernetesAdapter.ts
+// What the built-in EKS adapter declares
 declare module "../../Kubernetes/ClusterAdapter.ts" {
   interface IdentityStateRegistry {
     "aws-pod-identity": {
@@ -138,15 +136,13 @@ declare module "../../Kubernetes/ClusterAdapter.ts" {
 
 ### Build the layer
 
-`Kubernetes.ClusterAdapter("gke")` returns a Context service keyed
-`Kubernetes.ClusterAdapter/gke`. Use `Layer.effect`, return an object
-`satisfies ClusterAdapterService`, and die when
-`connection.auth.kind` is not yours.
+Build a `Layer.effect` for `Kubernetes.ClusterAdapter("gke")`.
+Return an object that `satisfies ClusterAdapterService`, and die if
+`connection.auth.kind` isn't yours.
 
 ### Provide it into the Stack
 
-Adapters are looked up with `Effect.serviceOption`, so merge the
-layer beside `Kubernetes.providers()`:
+Merge the layer beside `Kubernetes.providers()`:
 
 ```typescript
 export default Alchemy.Stack(
@@ -173,20 +169,19 @@ export default Alchemy.Stack(
 );
 ```
 
-Optionally, stamp a `connection` on the platform's cluster resource
-so it satisfies `ClusterLike` and passes as `cluster` directly, as
-[`AWS.EKS.Cluster`](/kubernetes/clusters/eks#what-the-adapter-adds)
+To let users pass a cluster resource as `cluster` directly, give it
+a `connection` attribute, as
+[`AWS.EKS.Cluster`](/kubernetes/clusters/eks#what-eks-adds)
 does.
 
 :::caution
-`auth` is persisted in plain state, so never put a secret in an `AuthRegistry` member.
+`auth` is saved in plain state. Never put a secret in an `AuthRegistry` member.
 :::
 
 ## A GKE adapter sketch
 
-An auth-only adapter, not yet run against a live project. It
-discovers endpoint and CA from the GKE API, then delegates header
-minting to the built-in
+An auth-only adapter. It looks up the endpoint and CA from the GKE
+API, then hands token minting to the built-in
 [`exec` adapter](/kubernetes/clusters/connecting#token-client-certificate-and-exec)
 with `gke-gcloud-auth-plugin`:
 
@@ -206,11 +201,7 @@ declare module "alchemy/Kubernetes/Connection" {
   }
 }
 
-/**
- * An access token for the GKE control-plane API, minted by the gcloud CLI the
- * user is already logged into — zero extra dependencies. Same spawn pattern as
- * the built-in exec-credential runner.
- */
+/** An access token for the GKE API from the gcloud CLI you're already logged into. */
 const gcloudAccessToken = Effect.gen(function* () {
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const { exitCode, stdout, stderr } = yield* ChildProcess.make(
@@ -247,7 +238,7 @@ const gcloudAccessToken = Effect.gen(function* () {
   return stdout.trim();
 });
 
-/** Describe the cluster through the GKE API; a 404 is a definitive "gone". */
+/** Look up the cluster in the GKE API; a 404 means it is gone. */
 const describeGkeCluster = Effect.fn(function* (auth: {
   project: string;
   location: string;
@@ -281,8 +272,7 @@ export const GkeKubernetesAdapter = () =>
   Layer.effect(
     Kubernetes.ClusterAdapter("gke"),
     Effect.gen(function* () {
-      // Capture deps ONCE at layer build; InstanceId/Stack/Stage stay ambient.
-      // Both services are in StackServices, so no extra wiring is needed.
+      // Capture dependencies once when the layer is built.
       const context = yield* Effect.context<
         HttpClient.HttpClient | ChildProcessSpawner.ChildProcessSpawner
       >();
@@ -295,7 +285,7 @@ export const GkeKubernetesAdapter = () =>
         }
         const auth = connection.auth;
 
-        // 1. Observe: discover endpoint/CA unless the connection already carries them.
+        // 1. Look up endpoint and CA unless the connection already has them.
         let { endpoint, certificateAuthorityData } = connection;
         if (!endpoint || !certificateAuthorityData) {
           const described = yield* describeGkeCluster(auth).pipe(
@@ -312,8 +302,8 @@ export const GkeKubernetesAdapter = () =>
           }
         }
 
-        // 2. Delegate per-request token minting to the built-in `exec` adapter
-        //    (ExecCredential protocol, cached until expirationTimestamp).
+        // 2. Let the built-in `exec` adapter mint tokens per request
+        //    (cached until expirationTimestamp).
         const exec = yield* Kubernetes.findClusterAdapter("exec");
         return yield* exec.connect({
           endpoint,
@@ -330,11 +320,11 @@ export const GkeKubernetesAdapter = () =>
   );
 ```
 
-This gives every `Kubernetes.*` resource on GKE with `image:` sources
-and env-only bindings. Adding `identity` (Workload Identity
+You now get every `Kubernetes.*` resource on GKE with `image:`
+sources and env-only bindings. Add `identity` (Workload Identity
 Federation via `serviceAccountAnnotations`) and `registry` (Artifact
-Registry) would light up `main:` and cloud-grant bindings with no
-workload changes.
+Registry) to unlock `main:` and cloud-grant bindings without changing
+any workload.
 
 ## Where next
 

--- a/website/src/content/docs/kubernetes/guides/cluster-adapters.mdx
+++ b/website/src/content/docs/kubernetes/guides/cluster-adapters.mdx
@@ -1,0 +1,512 @@
+---
+title: Cluster adapters
+description: The ClusterAdapter seam that makes Kubernetes workloads cluster-agnostic — the interface, how an auth kind is registered and found, and a worked sketch of a GKE adapter built on the exec credential path.
+---
+
+The whole hub rests on one interface. A
+[`Connection`](/kubernetes/clusters/connecting#the-connection-model)
+is data. Its `auth.kind`
+[selects](/kubernetes/clusters/connecting#how-the-adapter-is-chosen)
+a `ClusterAdapterService` that talks to the API server and,
+optionally, gives workloads an identity and an image registry. The
+workload providers never import a platform. They call
+`findClusterAdapter(connection.auth.kind)` and use whatever members
+the adapter implements. Read this to add a platform (GKE, AKS, a
+corporate OIDC proxy) or to learn why `main:` only works on EKS
+today.
+
+## The interface
+
+The shape, as exported from `alchemy/Kubernetes`:
+
+```typescript
+import type * as Kubernetes from "alchemy/Kubernetes";
+
+interface ClusterAdapterService {
+  readonly kind: "Kubernetes.ClusterAdapter";
+
+  // REQUIRED — resolve endpoint/CA and a per-request header mint.
+  readonly connect: (
+    connection: Kubernetes.Connection,
+  ) => Effect.Effect<Kubernetes.ClusterTransport, Kubernetes.ClusterNotFoundError | Error>;
+
+  // OPTIONAL — workload identity (EKS Pod Identity).
+  readonly identity?: {
+    readonly reconcile: (o: WorkloadIdentityReconcileOptions) => Effect.Effect<WorkloadIdentityResult, any, AdapterLifecycleServices>;
+    readonly delete: (o: WorkloadIdentityDeleteOptions) => Effect.Effect<void, any, AdapterLifecycleServices>;
+  };
+
+  // OPTIONAL — managed image registry (ECR).
+  readonly registry?: {
+    readonly resolve: (o: ImageRegistryResolveOptions) => Effect.Effect<ImageRegistryResult, any, AdapterLifecycleServices>;
+    readonly hash: (o: ImageRegistryHashOptions) => Effect.Effect<string | undefined, any, AdapterLifecycleServices>;
+    readonly delete: (o: ImageRegistryDeleteOptions) => Effect.Effect<void, any, AdapterLifecycleServices>;
+  };
+
+  // OPTIONAL — platform-specific generated container entries for `main` workloads.
+  readonly bootstrap?: {
+    readonly server?: (handler: string) => (importPath: string) => string;
+    readonly job?: (handler: string) => (importPath: string) => string;
+  };
+
+  // OPTIONAL — defaults for `serviceType: "LoadBalancer"` Services.
+  readonly loadBalancerDefaults?: (o: { connection: Kubernetes.Connection }) => Effect.Effect<
+    { loadBalancerClass?: string | undefined; annotations?: Record<string, string> },
+    any,
+    AdapterLifecycleServices
+  >;
+}
+```
+
+`connect` returns a `ClusterTransport`:
+`{ endpoint, certificateAuthorityData?, insecureSkipTlsVerify?, headers, clientCert? }`.
+`headers` is an Effect run once per API request, so short-lived
+tokens (STS presigns, exec plugins with an `expirationTimestamp`)
+are minted fresh. `connect` itself runs once per lifecycle operation.
+Exec-plugin results are cached per `(command, args, env)` until they
+expire, so a `headers` Effect that shells out is cheap. When the
+connection lacks `endpoint` or CA, discovery is the adapter's job:
+kubeconfig reads the file, EKS re-describes the cluster, and the
+[non-discovering built-ins](/kubernetes/clusters/connecting#token-client-certificate-and-exec)
+fail with "requires an explicit `endpoint`". Fail with
+`ClusterNotFoundError` (tag `Kubernetes.ClusterNotFoundError`) only
+when the cluster is definitively gone. `read` and `delete` treat it
+as everything in-cluster already gone. Any other error is transient:
+state is kept, the in-cluster delete is skipped, cloud-side cleanup
+still runs.
+
+`identity` is called by Deployment and Job reconcile with
+`{ id, connection, namespace, serviceAccount, bindings, options, state, tags }`,
+where `options` is the workload's `identity` prop, and returns
+`{ env, serviceAccountAnnotations?, state }`. `env` is merged into
+the container (EKS injects `AWS_REGION`). `serviceAccountAnnotations`
+land on the synthesized ServiceAccount, the hook a GKE Workload
+Identity or Azure adapter needs. `state` is persisted on the
+workload's `identity` attribute and handed back next time as
+`Record<string, unknown>`, so narrow it and re-observe the cloud.
+Without `identity`, a binding carrying a non-`env` grant key such as
+`policyStatements` makes reconcile die. That is the mechanism behind
+[env-only bindings](/kubernetes/workloads/bindings#env-only-bindings).
+What EKS provisions is under
+[Pod Identity on EKS](/kubernetes/workloads/bindings#pod-identity-on-eks).
+
+`registry.resolve` receives the image-source props (`main`,
+`handler`, `build`, `context`, `dockerfile`, `image`), the target
+`platform`, the `port`, the `bootstrap` entry generator, and a
+`session` for progress notes. It returns
+`{ imageUri, codeHash, state }`. `hash` is the plan-time twin `diff`
+uses to surface content drift without building. Without `registry`,
+an `image` reference passes through verbatim and `main` or `context`
+dies. That is the
+[registry requirement](/kubernetes/workloads/image-sources#registry-requirement).
+
+`bootstrap` only matters for `main` workloads. It is the generated
+entry file
+[wrapped around the user's program](/kubernetes/workloads/image-sources#bundling-and-tree-shaking).
+The defaults serve `{ fetch }` on `PORT` and run `{ run }` to
+completion. EKS overrides both to add `Credentials.fromChain()` and
+`Region.fromEnv()` so Pod Identity's container-credentials endpoint
+resolves. Omit it unless the platform's credential chain needs
+in-process wiring.
+
+`loadBalancerDefaults` is consulted only by `Deployment` and only
+for `serviceType: "LoadBalancer"`. The result is spread under the
+user's `serviceAnnotations`, and `loadBalancerClass` goes to `spec`.
+EKS returns `eks.amazonaws.com/nlb` when the cluster reports Auto
+Mode load balancing, plus the internet-facing scheme annotation. How
+that surfaces to users is under
+[Service types](/kubernetes/guides/exposing-services#service-types).
+
+`AdapterLifecycleServices = InstanceId | Stack | Stage` are the only
+services an adapter method may require from the ambient context.
+`createPhysicalName` needs them, and they are per-resource, so never
+capture them at layer build. Everything else (cloud SDK clients,
+`FileSystem`, `ChildProcessSpawner`, `HttpClient`) is captured once
+with `yield* Effect.context<…>()` inside the `Layer.effect` and
+re-provided with `Effect.provideContext`. The EKS source says it in
+one line: "do not shadow InstanceId/Stack/Stage with the
+layer-captured context".
+
+What the providers call, in order:
+
+| Provider op | Calls                                                                                                                                                                     |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `diff`      | `registry.hash` (or the static `image`/`context` hash when absent)                                                                                                        |
+| `read`      | `connect` → GET the anchor object; `ClusterNotFoundError` means gone                                                                                                      |
+| `reconcile` | `connect` → `identity.reconcile` (if present; die when grants are bound and it is absent) → `registry.resolve` (or verbatim `image`) → build objects → `loadBalancerDefaults` (Deployment with `LoadBalancer` only) → apply |
+| `delete`    | `connect` (errors skip the in-cluster part) → delete objects → `identity.delete` → `registry.delete`                                                                     |
+
+`Manifest` and `HelmChart` only use `connect`, so an auth-only
+adapter gives every resource except `main`/`context` images and
+cloud-grant bindings. That is the built-ins' column in the
+[overview table](/kubernetes#what-the-cluster-adapter-gives-you).
+
+## Registering an auth kind
+
+`AuthRegistry` in `alchemy/Kubernetes/Connection` is an interface
+keyed by kind, extended by module augmentation, and `ConnectionAuth`
+is derived from it. A new kind makes `{ auth: { kind: "gke", … } }`
+valid on every workload's `cluster` prop with no change to the
+Kubernetes package.
+
+### Augment `AuthRegistry`
+
+The descriptor is serializable identity, not credentials. It is
+[persisted on every workload's `connection` attribute](/kubernetes/clusters/connecting#the-connection-model),
+and its JSON decides whether a workload moved clusters. Endpoint and
+CA live on the `Connection`, not in `auth`, so they can rotate
+without replacing workloads.
+
+```typescript
+// In-repo: relative path. External package: "alchemy/Kubernetes/Connection".
+declare module "alchemy/Kubernetes/Connection" {
+  interface AuthRegistry {
+    /** Authenticate against a GKE cluster with gke-gcloud-auth-plugin. */
+    gke: {
+      project: string;
+      location: string; // region or zone
+      clusterName: string;
+    };
+  }
+}
+```
+
+### Augment the state registries
+
+Optional, for adapters with `identity` or `registry`.
+`alchemy/Kubernetes/ClusterAdapter` exposes `IdentityStateRegistry`
+and `RegistryStateRegistry` for what the two persist,
+`WorkloadIdentityOptions` for cloud-specific `identity` prop fields,
+`WorkloadBindingContract` for a new grant channel like AWS's
+`policyStatements`, and `WorkloadServicesRegistry` for services the
+platform's bootstrap makes ambient. The EKS block is the template.
+
+```typescript
+// packages/alchemy/src/AWS/EKS/KubernetesAdapter.ts
+declare module "../../Kubernetes/ClusterAdapter.ts" {
+  interface IdentityStateRegistry {
+    "aws-pod-identity": {
+      roleArn: string;
+      roleName: string;
+      associationArn: string;
+      associationId: string;
+    };
+  }
+  interface RegistryStateRegistry {
+    "aws-ecr": {
+      repositoryName: string;
+      repositoryUri: string;
+    };
+  }
+  interface WorkloadIdentityOptions {
+    managedPolicyArns?: string[];
+  }
+  interface WorkloadBindingContract {
+    policyStatements?: PolicyStatement[];
+  }
+  interface WorkloadServicesRegistry {
+    aws: Credentials | Region | AWSEnvironment;
+  }
+}
+```
+
+### Build the layer
+
+`Kubernetes.ClusterAdapter("gke")` returns a Context service keyed
+`Kubernetes.ClusterAdapter/gke`, so any `findClusterAdapter("gke")`
+finds it. Use `Layer.effect` to capture dependencies once, return an
+object `satisfies ClusterAdapterService`, and die when
+`connection.auth.kind` is not yours. The engine never routes a
+foreign kind to you, so a mismatch is a programming error. A
+providers layer is `Layer<…, never, StackServices>`, and
+`StackServices` already includes `FileSystem`, `Path`, `HttpClient`,
+and `ChildProcessSpawner`, so an adapter may require those with no
+extra wiring. General provider scaffolding is under
+[Custom providers](/infrastructure-as-code/custom-provider).
+
+### Provide it into the Stack
+
+Adapters are looked up with `Effect.serviceOption`, not statically
+required, so they must be `provideMerge`d into the providers layer,
+never just `provide`d. In-repo, the cloud's `providers()` does
+`Layer.provideMerge(GkeKubernetesAdapter())`. Out of tree, merge it
+beside `Kubernetes.providers()`
+[where the Stack composes its providers](/kubernetes/setup#add-the-provider):
+
+```typescript
+export default Alchemy.Stack(
+  "my-app",
+  {
+    providers: Layer.mergeAll(Kubernetes.providers(), GkeKubernetesAdapter()),
+    state: Alchemy.localState(),
+  },
+  Effect.gen(function* () {
+    const api = yield* Kubernetes.Deployment("Api", {
+      cluster: {
+        auth: {
+          kind: "gke",
+          project: "acme-prod",
+          location: "us-central1",
+          clusterName: "main",
+        },
+      },
+      image: "ghcr.io/acme/api:v3",
+      port: 8080,
+    });
+    return { url: api.url };
+  }),
+);
+```
+
+Skip this and `findClusterAdapter` dies with the message under
+[How the adapter is chosen](/kubernetes/clusters/connecting#how-the-adapter-is-chosen).
+
+### Stamp a connection on the cluster resource
+
+Optional. If the platform has a cluster resource, put a `connection`
+on its attributes so the whole resource satisfies `ClusterLike` and
+passes as `cluster` directly, the way
+[`AWS.EKS.Cluster`](/kubernetes/clusters/eks#what-the-adapter-adds)
+does with
+`eksConnectionOf({ clusterName, region, endpoint, certificateAuthorityData })`.
+Replacing the cluster then replaces the workloads, because `auth`
+changes only with the cluster name. Endpoint rotation is not a
+replacement.
+
+:::caution
+`auth` is persisted in plain state. Never put a secret in an
+`AuthRegistry` member. The built-in
+[`token` and `client-cert` kinds](/kubernetes/clusters/connecting#token-client-certificate-and-exec)
+are the documented exceptions. A cloud adapter derives credentials
+from the ambient environment, as `aws-eks` does.
+:::
+
+## A GKE adapter sketch
+
+The smallest useful adapter: auth-only, exported API only, every
+identifier defined. The GKE API details and the compile have not
+been run against a live project. It discovers endpoint and CA from
+the GKE API with a `gcloud auth print-access-token` token, then
+delegates header minting to the built-in
+[`exec` adapter](/kubernetes/clusters/connecting#token-client-certificate-and-exec)
+with `gke-gcloud-auth-plugin` through `findClusterAdapter("exec")`.
+No ExecCredential protocol to re-implement.
+
+```typescript
+import * as Kubernetes from "alchemy/Kubernetes";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Stream from "effect/Stream";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import * as ChildProcess from "effect/unstable/process/ChildProcess";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
+
+declare module "alchemy/Kubernetes/Connection" {
+  interface AuthRegistry {
+    gke: { project: string; location: string; clusterName: string };
+  }
+}
+
+/**
+ * An access token for the GKE control-plane API, minted by the gcloud CLI the
+ * user is already logged into — zero extra dependencies. Same spawn pattern as
+ * the built-in exec-credential runner.
+ */
+const gcloudAccessToken = Effect.gen(function* () {
+  const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+  const { exitCode, stdout, stderr } = yield* ChildProcess.make(
+    "gcloud",
+    ["auth", "print-access-token"],
+    {
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+      detached: false,
+      extendEnv: true,
+    },
+  ).pipe(
+    spawner.spawn,
+    Effect.flatMap((child) =>
+      Effect.all(
+        {
+          exitCode: child.exitCode,
+          stdout: child.stdout.pipe(Stream.decodeText, Stream.mkString),
+          stderr: child.stderr.pipe(Stream.decodeText, Stream.mkString),
+        },
+        { concurrency: "unbounded" },
+      ),
+    ),
+    Effect.scoped,
+  );
+  if (exitCode !== 0) {
+    return yield* Effect.fail(
+      new Error(
+        `gcloud auth print-access-token exited with ${String(exitCode)}: ${stderr.trim()}`,
+      ),
+    );
+  }
+  return stdout.trim();
+});
+
+/** Describe the cluster through the GKE API; a 404 is a definitive "gone". */
+const describeGkeCluster = Effect.fn(function* (auth: {
+  project: string;
+  location: string;
+  clusterName: string;
+}) {
+  const http = yield* HttpClient.HttpClient;
+  const accessToken = yield* gcloudAccessToken;
+  const res = yield* http.execute(
+    HttpClientRequest.get(
+      `https://container.googleapis.com/v1/projects/${auth.project}/locations/${auth.location}/clusters/${auth.clusterName}`,
+    ).pipe(HttpClientRequest.bearerToken(accessToken)),
+  );
+  if (res.status === 404) {
+    return yield* Effect.fail(
+      new Kubernetes.ClusterNotFoundError({
+        message: `GKE cluster '${auth.clusterName}' no longer exists`,
+      }),
+    );
+  }
+  const body = (yield* res.json) as {
+    endpoint?: string;
+    masterAuth?: { clusterCaCertificate?: string };
+  };
+  return {
+    endpoint: body.endpoint,
+    certificateAuthorityData: body.masterAuth?.clusterCaCertificate,
+  };
+});
+
+export const GkeKubernetesAdapter = () =>
+  Layer.effect(
+    Kubernetes.ClusterAdapter("gke"),
+    Effect.gen(function* () {
+      // Capture deps ONCE at layer build; InstanceId/Stack/Stage stay ambient.
+      // Both services are in StackServices, so no extra wiring is needed.
+      const context = yield* Effect.context<
+        HttpClient.HttpClient | ChildProcessSpawner.ChildProcessSpawner
+      >();
+
+      const connect = Effect.fn(function* (connection: Kubernetes.Connection) {
+        if (connection.auth.kind !== "gke") {
+          return yield* Effect.die(
+            new Error(`gke adapter received auth kind '${connection.auth.kind}'`),
+          );
+        }
+        const auth = connection.auth;
+
+        // 1. Observe: discover endpoint/CA unless the connection already carries them.
+        let { endpoint, certificateAuthorityData } = connection;
+        if (!endpoint || !certificateAuthorityData) {
+          const described = yield* describeGkeCluster(auth).pipe(
+            Effect.provideContext(context),
+          );
+          endpoint = described.endpoint ? `https://${described.endpoint}` : undefined;
+          certificateAuthorityData = described.certificateAuthorityData;
+          if (!endpoint || !certificateAuthorityData) {
+            return yield* Effect.fail(
+              new Error(
+                `GKE cluster '${auth.clusterName}' has no endpoint yet (still creating?)`,
+              ),
+            );
+          }
+        }
+
+        // 2. Delegate per-request token minting to the built-in `exec` adapter
+        //    (ExecCredential protocol, cached until expirationTimestamp).
+        const exec = yield* Kubernetes.findClusterAdapter("exec");
+        return yield* exec.connect({
+          endpoint,
+          certificateAuthorityData,
+          auth: { kind: "exec", command: "gke-gcloud-auth-plugin" },
+        });
+      });
+
+      return {
+        kind: "Kubernetes.ClusterAdapter" as const,
+        connect,
+      } satisfies Kubernetes.ClusterAdapterService;
+    }),
+  );
+```
+
+This gives every `Kubernetes.*` resource on GKE with `image:`
+sources and env-only bindings, the `kubeconfig` column of the
+[overview table](/kubernetes#what-the-cluster-adapter-gives-you),
+plus endpoint discovery so CI needs no kubeconfig file. The cluster
+identity is `{ project, location, clusterName }`. Change any of them
+and the workloads replace. The endpoint can be re-discovered at will.
+
+The sketch uses two credentials: a `gcloud` access token against
+`container.googleapis.com` for discovery only, and
+`gke-gcloud-auth-plugin` through the `exec` adapter for every object
+request. A production adapter would swap the shell-out for a
+google-auth library and cache the token until expiry. Without any
+adapter,
+[`Kubernetes.KubeConfig({ context: "gke_acme-prod_us-central1_main" })`](/kubernetes/clusters/connecting#kubeconfig)
+already honours the plugin. The adapter earns its keep through
+discovery and, later, identity and registry.
+
+`identity` for Workload Identity Federation would create a GCP
+service account per workload, return
+`serviceAccountAnnotations: { "iam.gke.io/gcp-service-account": email }`,
+persist `{ kind: "gke-workload-identity", email }`, and translate a
+new [binding contract](/kubernetes/workloads/bindings#the-binding-contract)
+channel such as `iamRoles` into IAM bindings. `registry` for
+Artifact Registry would reuse the Docker build-and-push machinery
+the EKS adapter gets from `makeImageSource` and mirror `image`
+references so the cluster pulls from one place. With both, `main:`
+and cloud-grant bindings
+[light up on GKE](/kubernetes/workloads/image-sources#registry-requirement)
+with no workload changes. `bootstrap` is probably unnecessary, since
+Application Default Credentials resolve through the metadata server
+inside the pod. Confirm that before relying on it. If a platform
+does need env-driven credential wiring, copy `makeEksServerBootstrap`
+and `makeEksJobBootstrap`.
+
+## Contributing an adapter
+
+An in-repo adapter mirrors the EKS layout. It lives at
+`packages/alchemy/src/{Cloud}/{Service}/KubernetesAdapter.ts`:
+augmentations at the top, `make{Cloud}Transport` and
+`{cloud}ConnectionOf` exported for the cluster resource, the
+`Layer.effect` at the bottom. The `Kubernetes/` package stays
+cloud-free. Register it with
+`Layer.provideMerge({Cloud}KubernetesAdapter())` in the cloud's
+`providers()`, stamp `connection` on the managed cluster resource's
+attributes, and list it in `stables`.
+
+State persisted by `identity` and `registry` is a hint. Re-read the
+cloud, per the
+[reconciler doctrine](/infrastructure-as-code/resource-lifecycle),
+and tolerate a missing cluster in `identity.delete` (EKS skips the
+association when the cluster is `DELETING`). Never cache
+`InstanceId`, `Stack`, or `Stage` at layer build, never return
+`ClusterNotFoundError` for a transient failure, never put
+credentials in `auth`.
+
+Tests are a transport unit test next to
+`test/Kubernetes/KubeConfig.test.ts` and live lifecycle tests behind
+an env gate like the EKS suite's `AWS_TEST_SLOW`, each starting and
+ending with `stack.destroy()`. `Kubernetes.KubeConfigError` and
+`Kubernetes.ExecCredentialError` are not re-exported from
+`alchemy/Kubernetes` today, so match on the tag string or export
+them first. For docs, add a row to the
+[overview's adapter table](/kubernetes#what-the-cluster-adapter-gives-you),
+a sentence to
+[How the adapter is chosen](/kubernetes/clusters/connecting#how-the-adapter-is-chosen),
+and JSDoc on the `AuthRegistry` member, the only user-facing type
+for the kind.
+
+## Where next
+
+- [Deployment reference](/providers/kubernetes/deployment) — the
+  generated reference for every `Kubernetes.*` resource starts here.
+- [EKS](/kubernetes/clusters/eks) — the reference adapter from the
+  user's side.
+- [Connecting to a cluster](/kubernetes/clusters/connecting) — the
+  connection model the adapter plugs into.
+- [Custom providers](/infrastructure-as-code/custom-provider) —
+  writing providers in general.

--- a/website/src/content/docs/kubernetes/guides/exposing-services.mdx
+++ b/website/src/content/docs/kubernetes/guides/exposing-services.mdx
@@ -1,39 +1,22 @@
 ---
 title: Exposing services
-description: Pick a Service type for a Deployment, tune the cloud load balancer with annotations, put an Ingress controller in front of many Deployments, or publish a private cluster through a Cloudflare Tunnel.
+description: Pick a Service type for a Deployment, tune the load balancer with annotations, front many Deployments with an Ingress controller, or publish a private cluster through a Cloudflare Tunnel.
 ---
 
-Every `Kubernetes.Deployment` gets a Service. What sits in front of it
-is up to you: one cloud load balancer per Deployment, one Ingress
-controller for all of them, or a Cloudflare Tunnel with no inbound
-path at all.
+Every `Kubernetes.Deployment` gets a Service. What fronts it is up to
+you: a cloud load balancer, an Ingress controller, or a Cloudflare
+Tunnel.
 
 ## Service types
 
-A Deployment
-[synthesizes one `v1/Service`](/kubernetes/workloads/deployments#what-gets-created)
-named after it. `spec.type` is `serviceType`, the selector is the
-merged labels, and the one port mapping is
-`{ port, targetPort: port, protocol: "TCP" }`, so the Service port is
-the container port.
-
-| `serviceType`            | What you get                                                                       | `url`                                                   | Reach for it when                                           |
-| ------------------------ | ---------------------------------------------------------------------------------- | ------------------------------------------------------- | ----------------------------------------------------------- |
-| `LoadBalancer` (default) | A cloud load balancer (an NLB on EKS Auto Mode); its address lands in `status.loadBalancer.ingress` | `http://<host>[:port]` once published; `undefined` if not within the bounded wait | One public service and the fastest path to a URL            |
-| `ClusterIP`              | A stable virtual IP and `<svc>.<ns>.svc.cluster.local`, reachable only in-cluster | Always `undefined`                                      | Anything behind an Ingress or a Tunnel; internal APIs; clusters with no LB |
-| `NodePort`               | `ClusterIP` plus a port on every node (30000–32767)                                | Always `undefined`                                      | Bare-metal or kind-style clusters where you front the nodes |
-
-The bounded wait, non-80 ports, and what `undefined` means are under
+`serviceType` is `LoadBalancer` (default, a cloud load balancer and a
+`url`), `ClusterIP` (in-cluster only, no `url`), or `NodePort`;
+details under
 [Exposing it: serviceType and url](/kubernetes/workloads/deployments#exposing-it-servicetype-and-url).
-What a local cluster does with `LoadBalancer` is on
-[Local clusters](/kubernetes/clusters/local#reaching-a-service).
 
-On `LoadBalancer`, the adapter's defaults are spread under your
-`serviceAnnotations`, so your keys win. Only the adapter can set
-`spec.loadBalancerClass`. The
-[EKS adapter](/kubernetes/clusters/eks#what-the-adapter-adds) sets
-`eks.amazonaws.com/nlb` on Auto Mode clusters plus the
-internet-facing scheme annotation.
+On `LoadBalancer`, the
+[adapter's defaults](/kubernetes/clusters/eks#what-the-adapter-adds)
+are spread under your `serviceAnnotations`, so your keys win:
 
 ```typescript
 // One public Deployment. On EKS the adapter adds
@@ -56,10 +39,7 @@ const api = yield* Kubernetes.Deployment("Api", {
 api.url; // "http://<nlb-hostname>:8080"
 ```
 
-The defaults only reach the Service the Deployment synthesizes. A
-Service from a `HelmChart` or a `Manifest` gets none, so on EKS Auto
-Mode you set the class and scheme yourself. The rest of this page
-uses the internal form:
+The rest of this page uses the internal form:
 
 ```typescript
 // Internal only: no cloud LB, no url. Reachable inside the cluster as
@@ -72,26 +52,12 @@ const api = yield* Kubernetes.Deployment("Api", {
 });
 ```
 
-`serviceType` and `serviceAnnotations` are documented on the
-[Deployment reference](/providers/kubernetes/deployment).
-
 ## Ingress
 
-One cloud load balancer per Deployment gets expensive fast. An
-Ingress controller is one load balancer in front of many `ClusterIP`
-Services, routed by host and path. Install it with
-`Kubernetes.HelmChart`, then declare routes with an `Ingress`
-Manifest.
-
-Install the chart with a
-[pinned `version`](/kubernetes/objects/helm#chart-sources) in its own
-namespace, either with `createNamespace: true` or a
-[Namespace Manifest](/kubernetes/objects/manifests#namespaces). On a
-local cluster the default [`values`](/kubernetes/objects/helm#values)
-are fine. On EKS Auto Mode the chart's Service is not the synthesized
-one, so the
-[adapter's NLB defaults](/kubernetes/clusters/eks#what-the-adapter-adds)
-do not reach it. Set the class and scheme in `values`:
+One Ingress controller fronts many `ClusterIP` Services. Install it
+with `Kubernetes.HelmChart`; on EKS Auto Mode set the LB class and
+scheme in `values`, since the adapter's defaults do not reach a
+chart's Service:
 
 ```typescript
 const ingressNginx = yield* Kubernetes.HelmChart("IngressNginx", {
@@ -117,20 +83,8 @@ const ingressNginx = yield* Kubernetes.HelmChart("IngressNginx", {
 });
 ```
 
-:::caution
-Some ingress-nginx versions ship admission-webhook Jobs annotated
-`helm.sh/hook`. Alchemy renders with `--no-hooks`, so they are never
-applied. See
-[what Helm does that Alchemy doesn't](/kubernetes/objects/helm#what-helm-does-that-alchemy-doesnt).
-:::
-
-Now the route. `Ingress` is
-[any object](/kubernetes/objects/manifests#any-object), resolved
-through API discovery. `ingressClassName: "nginx"` selects the
-controller. The backend is the Deployment's
-[`serviceName` and `port`](/kubernetes/workloads/deployments#what-gets-created)
-Outputs, so nothing drifts and the Ingress applies after the
-Deployment.
+Then the route, with the Deployment's `serviceName` and `port`
+Outputs as the backend:
 
 ```typescript
 const api = yield* Kubernetes.Deployment("Api", {
@@ -172,46 +126,20 @@ yield* Kubernetes.Manifest("ApiIngress", {
 });
 ```
 
-`api.url` is `undefined` on a `ClusterIP` Deployment. The public
-address belongs to the controller's Service, and `HelmChart`
-attributes carry references, not status, so read it from the cluster:
+The public address is the controller's Service; point DNS at it:
 
 ```sh
 kubectl -n ingress-nginx get svc ingress-nginx-controller
 ```
 
-Point DNS at that hostname. A Cloudflare DNS
-[`Record`](/cloudflare/networking/domains) does it from the same
-stack. On EKS Auto Mode the built-in ALB controller works too: an
-`IngressClass` whose `spec.controller` is `eks.amazonaws.com/alb`
-plus an `IngressClassParams` for the scheme, both plain Manifests.
-Check the EKS Auto Mode docs for the current `IngressClassParams`
-shape.
-
 ## Cloudflare Tunnel
 
-A [Tunnel](/cloudflare/networking/tunnel) needs no inbound path.
-`cloudflared` runs as a pod, dials out to Cloudflare, and forwards
-hostnames to in-cluster Service DNS names. That makes it the zero-LB
-path for local clusters and private EKS endpoints: no `LoadBalancer`
-support, no port-forward. The Tunnel, its `Configuration`, and the
-DNS CNAME are the Tunnel page's story. This section adds the
-Kubernetes half.
-
-The upstream for each hostname is
-`http://<serviceName>.<namespace>.svc.cluster.local:<port>`. Those
-parts are Outputs, so build the string with
-[`Output.interpolate`](/infrastructure-as-code/outputs#interpolate).
-A plain template literal does not resolve. The connector is a raw
-`Deployment` [Manifest](/kubernetes/objects/manifests#any-object)
-reading its token from a `Secret` through `envFrom`, which sidesteps
-the [arrays-replace rule](/kubernetes/workloads/pod-template#merge-rules)
-of `podTemplate`.
-
-`tunnel.token` is an `Output<Redacted<string>>` and
-[Manifest values are plain strings](/kubernetes/objects/manifests#secrets),
-so a `Redacted` in `stringData` is applied as the literal
-`<redacted>`. Unwrap it with `Output.map(tunnel.token, Redacted.value)`.
+A [Tunnel](/cloudflare/networking/tunnel) needs no inbound path:
+`cloudflared` runs as a pod, dials out, and forwards hostnames to
+in-cluster Service DNS names. Build the upstream with
+[`Output.interpolate`](/infrastructure-as-code/outputs#interpolate),
+and unwrap the token with `Output.map(tunnel.token, Redacted.value)`
+because [Manifest values are plain strings](/kubernetes/objects/manifests#secrets).
 
 ```typescript
 import * as Output from "alchemy/Output";
@@ -283,30 +211,17 @@ yield* Kubernetes.Manifest("Cloudflared", {
 });
 ```
 
-The `Configuration` rules are described under
-[Route hostnames with a Configuration](/cloudflare/networking/tunnel#route-hostnames-with-a-configuration).
-Finish with a proxied CNAME to the tunnel, shown under
-[Point DNS at the tunnel](/cloudflare/networking/tunnel#point-dns-at-the-tunnel).
+Finish with a
+[proxied CNAME](/cloudflare/networking/tunnel#point-dns-at-the-tunnel).
+Tunnel resources need `Cloudflare.providers()` merged beside
+`Kubernetes.providers()` in the Stack.
 
-:::caution[The token is in plan output and state]
-`Output.map(tunnel.token, Redacted.value)` makes the token a plain
-string. It shows in `alchemy plan` diffs and is persisted in state.
-Use a remote state store and rotate it by rotating the Tunnel. See
-[Secrets](/kubernetes/objects/manifests#secrets).
-:::
-
-:::note
-Tunnel resources need `Cloudflare.providers()` in the same Stack:
-`Layer.mergeAll(Cloudflare.providers(), Kubernetes.providers())`, as
-in [Add the provider](/kubernetes/setup#add-the-provider).
+:::caution
+The unwrapped token shows in `alchemy plan` diffs and is persisted in state, so use a remote state store.
 :::
 
 ## Where next
 
-- [How apply works](/kubernetes/guides/how-apply-works) — what
-  server-side apply and pruning mean for the objects you just created.
-- [Helm charts](/kubernetes/objects/helm) — the full HelmChart story.
-- [Tunnel](/cloudflare/networking/tunnel) — the Tunnel resources in
-  depth.
-- [Deployment reference](/providers/kubernetes/deployment) —
-  `serviceType` and `serviceAnnotations`.
+- [How apply works](/kubernetes/guides/how-apply-works)
+- [Helm charts](/kubernetes/objects/helm)
+- [Tunnel](/cloudflare/networking/tunnel)

--- a/website/src/content/docs/kubernetes/guides/exposing-services.mdx
+++ b/website/src/content/docs/kubernetes/guides/exposing-services.mdx
@@ -1,0 +1,312 @@
+---
+title: Exposing services
+description: Pick a Service type for a Deployment, tune the cloud load balancer with annotations, put an Ingress controller in front of many Deployments, or publish a private cluster through a Cloudflare Tunnel.
+---
+
+Every `Kubernetes.Deployment` gets a Service. What sits in front of it
+is up to you: one cloud load balancer per Deployment, one Ingress
+controller for all of them, or a Cloudflare Tunnel with no inbound
+path at all.
+
+## Service types
+
+A Deployment
+[synthesizes one `v1/Service`](/kubernetes/workloads/deployments#what-gets-created)
+named after it. `spec.type` is `serviceType`, the selector is the
+merged labels, and the one port mapping is
+`{ port, targetPort: port, protocol: "TCP" }`, so the Service port is
+the container port.
+
+| `serviceType`            | What you get                                                                       | `url`                                                   | Reach for it when                                           |
+| ------------------------ | ---------------------------------------------------------------------------------- | ------------------------------------------------------- | ----------------------------------------------------------- |
+| `LoadBalancer` (default) | A cloud load balancer (an NLB on EKS Auto Mode); its address lands in `status.loadBalancer.ingress` | `http://<host>[:port]` once published; `undefined` if not within the bounded wait | One public service and the fastest path to a URL            |
+| `ClusterIP`              | A stable virtual IP and `<svc>.<ns>.svc.cluster.local`, reachable only in-cluster | Always `undefined`                                      | Anything behind an Ingress or a Tunnel; internal APIs; clusters with no LB |
+| `NodePort`               | `ClusterIP` plus a port on every node (30000–32767)                                | Always `undefined`                                      | Bare-metal or kind-style clusters where you front the nodes |
+
+The bounded wait, non-80 ports, and what `undefined` means are under
+[Exposing it: serviceType and url](/kubernetes/workloads/deployments#exposing-it-servicetype-and-url).
+What a local cluster does with `LoadBalancer` is on
+[Local clusters](/kubernetes/clusters/local#reaching-a-service).
+
+On `LoadBalancer`, the adapter's defaults are spread under your
+`serviceAnnotations`, so your keys win. Only the adapter can set
+`spec.loadBalancerClass`. The
+[EKS adapter](/kubernetes/clusters/eks#what-the-adapter-adds) sets
+`eks.amazonaws.com/nlb` on Auto Mode clusters plus the
+internet-facing scheme annotation.
+
+```typescript
+// One public Deployment. On EKS the adapter adds
+//   metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-scheme"] = "internet-facing"
+//   spec.loadBalancerClass = "eks.amazonaws.com/nlb"   (Auto Mode clusters)
+// Your serviceAnnotations override the defaults key by key.
+const api = yield* Kubernetes.Deployment("Api", {
+  cluster,
+  image: "ghcr.io/acme/api:v3",
+  port: 8080,
+  serviceType: "LoadBalancer",
+  serviceAnnotations: {
+    // keep the NLB private to the VPC instead of the adapter's internet-facing default
+    "service.beta.kubernetes.io/aws-load-balancer-scheme": "internal",
+    // route straight to pod IPs instead of node ports
+    "service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "ip",
+  },
+});
+
+api.url; // "http://<nlb-hostname>:8080"
+```
+
+The defaults only reach the Service the Deployment synthesizes. A
+Service from a `HelmChart` or a `Manifest` gets none, so on EKS Auto
+Mode you set the class and scheme yourself. The rest of this page
+uses the internal form:
+
+```typescript
+// Internal only: no cloud LB, no url. Reachable inside the cluster as
+//   http://<api.serviceName>.<api.namespace>.svc.cluster.local:<api.port>
+const api = yield* Kubernetes.Deployment("Api", {
+  cluster,
+  image: "ghcr.io/acme/api:v3",
+  port: 8080,
+  serviceType: "ClusterIP",
+});
+```
+
+`serviceType` and `serviceAnnotations` are documented on the
+[Deployment reference](/providers/kubernetes/deployment).
+
+## Ingress
+
+One cloud load balancer per Deployment gets expensive fast. An
+Ingress controller is one load balancer in front of many `ClusterIP`
+Services, routed by host and path. Install it with
+`Kubernetes.HelmChart`, then declare routes with an `Ingress`
+Manifest.
+
+Install the chart with a
+[pinned `version`](/kubernetes/objects/helm#chart-sources) in its own
+namespace, either with `createNamespace: true` or a
+[Namespace Manifest](/kubernetes/objects/manifests#namespaces). On a
+local cluster the default [`values`](/kubernetes/objects/helm#values)
+are fine. On EKS Auto Mode the chart's Service is not the synthesized
+one, so the
+[adapter's NLB defaults](/kubernetes/clusters/eks#what-the-adapter-adds)
+do not reach it. Set the class and scheme in `values`:
+
+```typescript
+const ingressNginx = yield* Kubernetes.HelmChart("IngressNginx", {
+  cluster,
+  chart: "ingress-nginx",
+  repo: "https://kubernetes.github.io/ingress-nginx",
+  version: "4.13.9", // pin it — unpinned repo charts drift on every deploy
+  releaseName: "ingress-nginx", // names the objects ingress-nginx-*; default derives from stack/stage/id
+  namespace: "ingress-nginx",
+  createNamespace: true,
+  values: {
+    controller: {
+      // EKS Auto Mode only: the chart's Service is NOT the Deployment-synthesized
+      // one, so the adapter's NLB defaults do not apply — set them here.
+      service: {
+        loadBalancerClass: "eks.amazonaws.com/nlb",
+        annotations: {
+          "service.beta.kubernetes.io/aws-load-balancer-scheme": "internet-facing",
+        },
+      },
+    },
+  },
+});
+```
+
+:::caution
+Some ingress-nginx versions ship admission-webhook Jobs annotated
+`helm.sh/hook`. Alchemy renders with `--no-hooks`, so they are never
+applied. See
+[what Helm does that Alchemy doesn't](/kubernetes/objects/helm#what-helm-does-that-alchemy-doesnt).
+:::
+
+Now the route. `Ingress` is
+[any object](/kubernetes/objects/manifests#any-object), resolved
+through API discovery. `ingressClassName: "nginx"` selects the
+controller. The backend is the Deployment's
+[`serviceName` and `port`](/kubernetes/workloads/deployments#what-gets-created)
+Outputs, so nothing drifts and the Ingress applies after the
+Deployment.
+
+```typescript
+const api = yield* Kubernetes.Deployment("Api", {
+  cluster,
+  image: "ghcr.io/acme/api:v3",
+  port: 8080,
+  serviceType: "ClusterIP", // the Ingress controller is the only public entry point
+});
+
+yield* Kubernetes.Manifest("ApiIngress", {
+  cluster,
+  manifest: {
+    apiVersion: "networking.k8s.io/v1",
+    kind: "Ingress",
+    metadata: { name: "api", namespace: api.namespace },
+    spec: {
+      ingressClassName: "nginx",
+      rules: [
+        {
+          host: "api.example.com",
+          http: {
+            paths: [
+              {
+                path: "/",
+                pathType: "Prefix",
+                backend: {
+                  service: {
+                    name: api.serviceName, // Output → the Ingress depends on the Deployment
+                    port: { number: api.port },
+                  },
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+  },
+});
+```
+
+`api.url` is `undefined` on a `ClusterIP` Deployment. The public
+address belongs to the controller's Service, and `HelmChart`
+attributes carry references, not status, so read it from the cluster:
+
+```sh
+kubectl -n ingress-nginx get svc ingress-nginx-controller
+```
+
+Point DNS at that hostname. A Cloudflare DNS
+[`Record`](/cloudflare/networking/domains) does it from the same
+stack. On EKS Auto Mode the built-in ALB controller works too: an
+`IngressClass` whose `spec.controller` is `eks.amazonaws.com/alb`
+plus an `IngressClassParams` for the scheme, both plain Manifests.
+Check the EKS Auto Mode docs for the current `IngressClassParams`
+shape.
+
+## Cloudflare Tunnel
+
+A [Tunnel](/cloudflare/networking/tunnel) needs no inbound path.
+`cloudflared` runs as a pod, dials out to Cloudflare, and forwards
+hostnames to in-cluster Service DNS names. That makes it the zero-LB
+path for local clusters and private EKS endpoints: no `LoadBalancer`
+support, no port-forward. The Tunnel, its `Configuration`, and the
+DNS CNAME are the Tunnel page's story. This section adds the
+Kubernetes half.
+
+The upstream for each hostname is
+`http://<serviceName>.<namespace>.svc.cluster.local:<port>`. Those
+parts are Outputs, so build the string with
+[`Output.interpolate`](/infrastructure-as-code/outputs#interpolate).
+A plain template literal does not resolve. The connector is a raw
+`Deployment` [Manifest](/kubernetes/objects/manifests#any-object)
+reading its token from a `Secret` through `envFrom`, which sidesteps
+the [arrays-replace rule](/kubernetes/workloads/pod-template#merge-rules)
+of `podTemplate`.
+
+`tunnel.token` is an `Output<Redacted<string>>` and
+[Manifest values are plain strings](/kubernetes/objects/manifests#secrets),
+so a `Redacted` in `stringData` is applied as the literal
+`<redacted>`. Unwrap it with `Output.map(tunnel.token, Redacted.value)`.
+
+```typescript
+import * as Output from "alchemy/Output";
+import * as Redacted from "effect/Redacted";
+
+// Cloudflare side — see /cloudflare/networking/tunnel for the full story.
+const tunnel = yield* Cloudflare.Tunnel.Tunnel("ClusterTunnel");
+
+const api = yield* Kubernetes.Deployment("Api", {
+  cluster,
+  image: "ghcr.io/acme/api:v3",
+  port: 8080,
+  serviceType: "ClusterIP", // nothing public — the tunnel dials out
+});
+
+// Route a hostname to the in-cluster Service DNS name. serviceName/namespace/port
+// are Outputs, so the upstream string is built with Output.interpolate — a plain
+// template literal would not resolve.
+yield* Cloudflare.Tunnel.Configuration("ClusterIngress", {
+  tunnelId: tunnel.tunnelId,
+  ingress: [
+    {
+      hostname: "api.example.com",
+      service: Output.interpolate`http://${api.serviceName}.${api.namespace}.svc.cluster.local:${api.port}`,
+    },
+  ],
+});
+
+// Kubernetes side: the token as a Secret, the connector as a Deployment.
+const tunnelSecret = yield* Kubernetes.Manifest("TunnelToken", {
+  cluster,
+  manifest: {
+    apiVersion: "v1",
+    kind: "Secret",
+    metadata: { name: "cloudflared-token", namespace: "default" },
+    stringData: {
+      // Manifest values must be plain strings today (Redacted is not unwrapped
+      // before apply). Unwrapping on the Output means the token is visible in
+      // plan output and state — see the caution below.
+      TUNNEL_TOKEN: Output.map(tunnel.token, Redacted.value),
+    },
+  },
+});
+
+yield* Kubernetes.Manifest("Cloudflared", {
+  cluster,
+  manifest: {
+    apiVersion: "apps/v1",
+    kind: "Deployment",
+    metadata: { name: "cloudflared", namespace: "default" },
+    spec: {
+      replicas: 2, // two connectors = no single point of failure
+      selector: { matchLabels: { app: "cloudflared" } },
+      template: {
+        metadata: { labels: { app: "cloudflared" } },
+        spec: {
+          containers: [
+            {
+              name: "cloudflared",
+              image: "cloudflare/cloudflared:2026.8.2",
+              args: ["tunnel", "--no-autoupdate", "run"],
+              envFrom: [{ secretRef: { name: tunnelSecret.name } }], // Output → ordering
+            },
+          ],
+        },
+      },
+    },
+  },
+});
+```
+
+The `Configuration` rules are described under
+[Route hostnames with a Configuration](/cloudflare/networking/tunnel#route-hostnames-with-a-configuration).
+Finish with a proxied CNAME to the tunnel, shown under
+[Point DNS at the tunnel](/cloudflare/networking/tunnel#point-dns-at-the-tunnel).
+
+:::caution[The token is in plan output and state]
+`Output.map(tunnel.token, Redacted.value)` makes the token a plain
+string. It shows in `alchemy plan` diffs and is persisted in state.
+Use a remote state store and rotate it by rotating the Tunnel. See
+[Secrets](/kubernetes/objects/manifests#secrets).
+:::
+
+:::note
+Tunnel resources need `Cloudflare.providers()` in the same Stack:
+`Layer.mergeAll(Cloudflare.providers(), Kubernetes.providers())`, as
+in [Add the provider](/kubernetes/setup#add-the-provider).
+:::
+
+## Where next
+
+- [How apply works](/kubernetes/guides/how-apply-works) — what
+  server-side apply and pruning mean for the objects you just created.
+- [Helm charts](/kubernetes/objects/helm) — the full HelmChart story.
+- [Tunnel](/cloudflare/networking/tunnel) — the Tunnel resources in
+  depth.
+- [Deployment reference](/providers/kubernetes/deployment) —
+  `serviceType` and `serviceAnnotations`.

--- a/website/src/content/docs/kubernetes/guides/exposing-services.mdx
+++ b/website/src/content/docs/kubernetes/guides/exposing-services.mdx
@@ -1,35 +1,32 @@
 ---
 title: Exposing services
-description: Pick a Service type for a Deployment, tune the load balancer with annotations, front many Deployments with an Ingress controller, or publish a private cluster through a Cloudflare Tunnel.
+description: Put a Kubernetes Deployment behind a cloud load balancer, an Ingress controller, or a Cloudflare Tunnel.
 ---
 
-Every `Kubernetes.Deployment` gets a Service. What fronts it is up to
-you: a cloud load balancer, an Ingress controller, or a Cloudflare
-Tunnel.
+Every `Kubernetes.Deployment` gets a Service. Choose what fronts it: a
+cloud load balancer, an Ingress controller, or a Cloudflare Tunnel.
 
 ## Service types
 
-`serviceType` is `LoadBalancer` (default, a cloud load balancer and a
-`url`), `ClusterIP` (in-cluster only, no `url`), or `NodePort`;
-details under
+Set `serviceType` to `LoadBalancer` (default, a cloud load balancer and
+a `url`), `ClusterIP` (in-cluster only, no `url`), or `NodePort`. See
 [Exposing it: serviceType and url](/kubernetes/workloads/deployments#exposing-it-servicetype-and-url).
 
-On `LoadBalancer`, the
-[adapter's defaults](/kubernetes/clusters/eks#what-the-adapter-adds)
-are spread under your `serviceAnnotations`, so your keys win:
+On `LoadBalancer`, your `serviceAnnotations` override the cluster's
+[defaults](/kubernetes/clusters/eks#what-eks-adds) key by key:
 
 ```typescript
-// One public Deployment. On EKS the adapter adds
+// One public Deployment. On EKS you get these defaults:
 //   metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-scheme"] = "internet-facing"
 //   spec.loadBalancerClass = "eks.amazonaws.com/nlb"   (Auto Mode clusters)
-// Your serviceAnnotations override the defaults key by key.
+// Your serviceAnnotations override them key by key.
 const api = yield* Kubernetes.Deployment("Api", {
   cluster,
   image: "ghcr.io/acme/api:v3",
   port: 8080,
   serviceType: "LoadBalancer",
   serviceAnnotations: {
-    // keep the NLB private to the VPC instead of the adapter's internet-facing default
+    // keep the NLB private to the VPC instead of the internet-facing default
     "service.beta.kubernetes.io/aws-load-balancer-scheme": "internal",
     // route straight to pod IPs instead of node ports
     "service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "ip",
@@ -39,10 +36,10 @@ const api = yield* Kubernetes.Deployment("Api", {
 api.url; // "http://<nlb-hostname>:8080"
 ```
 
-The rest of this page uses the internal form:
+Behind an Ingress or a Tunnel, use `ClusterIP`:
 
 ```typescript
-// Internal only: no cloud LB, no url. Reachable inside the cluster as
+// Internal only: no cloud LB, no url. Reach it inside the cluster at
 //   http://<api.serviceName>.<api.namespace>.svc.cluster.local:<api.port>
 const api = yield* Kubernetes.Deployment("Api", {
   cluster,
@@ -54,24 +51,22 @@ const api = yield* Kubernetes.Deployment("Api", {
 
 ## Ingress
 
-One Ingress controller fronts many `ClusterIP` Services. Install it
-with `Kubernetes.HelmChart`; on EKS Auto Mode set the LB class and
-scheme in `values`, since the adapter's defaults do not reach a
-chart's Service:
+Install one Ingress controller with `Kubernetes.HelmChart` and put
+many `ClusterIP` Services behind it. On EKS Auto Mode, set the load
+balancer class and scheme in `values`:
 
 ```typescript
 const ingressNginx = yield* Kubernetes.HelmChart("IngressNginx", {
   cluster,
   chart: "ingress-nginx",
   repo: "https://kubernetes.github.io/ingress-nginx",
-  version: "4.13.9", // pin it — unpinned repo charts drift on every deploy
-  releaseName: "ingress-nginx", // names the objects ingress-nginx-*; default derives from stack/stage/id
+  version: "4.13.9", // pin the version
+  releaseName: "ingress-nginx", // names the objects ingress-nginx-*
   namespace: "ingress-nginx",
   createNamespace: true,
   values: {
     controller: {
-      // EKS Auto Mode only: the chart's Service is NOT the Deployment-synthesized
-      // one, so the adapter's NLB defaults do not apply — set them here.
+      // EKS Auto Mode only: the chart's Service gets no EKS defaults
       service: {
         loadBalancerClass: "eks.amazonaws.com/nlb",
         annotations: {
@@ -83,8 +78,8 @@ const ingressNginx = yield* Kubernetes.HelmChart("IngressNginx", {
 });
 ```
 
-Then the route, with the Deployment's `serviceName` and `port`
-Outputs as the backend:
+Add the route, with the Deployment's `serviceName` and `port` as the
+backend:
 
 ```typescript
 const api = yield* Kubernetes.Deployment("Api", {
@@ -112,7 +107,7 @@ yield* Kubernetes.Manifest("ApiIngress", {
                 pathType: "Prefix",
                 backend: {
                   service: {
-                    name: api.serviceName, // Output → the Ingress depends on the Deployment
+                    name: api.serviceName, // Output: the Ingress deploys after the Deployment
                     port: { number: api.port },
                   },
                 },
@@ -126,7 +121,7 @@ yield* Kubernetes.Manifest("ApiIngress", {
 });
 ```
 
-The public address is the controller's Service; point DNS at it:
+Point DNS at the controller's Service:
 
 ```sh
 kubectl -n ingress-nginx get svc ingress-nginx-controller
@@ -135,29 +130,29 @@ kubectl -n ingress-nginx get svc ingress-nginx-controller
 ## Cloudflare Tunnel
 
 A [Tunnel](/cloudflare/networking/tunnel) needs no inbound path:
-`cloudflared` runs as a pod, dials out, and forwards hostnames to
-in-cluster Service DNS names. Build the upstream with
-[`Output.interpolate`](/infrastructure-as-code/outputs#interpolate),
-and unwrap the token with `Output.map(tunnel.token, Redacted.value)`
-because [Manifest values are plain strings](/kubernetes/objects/manifests#secrets).
+`cloudflared` runs as a pod and dials out. Build the upstream URL with
+[`Output.interpolate`](/infrastructure-as-code/outputs#interpolate)
+and store the token in a
+[Secret](/kubernetes/objects/manifests#secrets) as a plain string with
+`Output.map(tunnel.token, Redacted.value)`.
 
 ```typescript
 import * as Output from "alchemy/Output";
 import * as Redacted from "effect/Redacted";
 
-// Cloudflare side — see /cloudflare/networking/tunnel for the full story.
+// Cloudflare side. See /cloudflare/networking/tunnel for the full setup.
 const tunnel = yield* Cloudflare.Tunnel.Tunnel("ClusterTunnel");
 
 const api = yield* Kubernetes.Deployment("Api", {
   cluster,
   image: "ghcr.io/acme/api:v3",
   port: 8080,
-  serviceType: "ClusterIP", // nothing public — the tunnel dials out
+  serviceType: "ClusterIP", // nothing public: the tunnel dials out
 });
 
-// Route a hostname to the in-cluster Service DNS name. serviceName/namespace/port
-// are Outputs, so the upstream string is built with Output.interpolate — a plain
-// template literal would not resolve.
+// Route a hostname to the in-cluster Service DNS name. serviceName, namespace
+// and port are Outputs, so build the string with Output.interpolate; a plain
+// template literal won't resolve.
 yield* Cloudflare.Tunnel.Configuration("ClusterIngress", {
   tunnelId: tunnel.tunnelId,
   ingress: [
@@ -176,9 +171,7 @@ const tunnelSecret = yield* Kubernetes.Manifest("TunnelToken", {
     kind: "Secret",
     metadata: { name: "cloudflared-token", namespace: "default" },
     stringData: {
-      // Manifest values must be plain strings today (Redacted is not unwrapped
-      // before apply). Unwrapping on the Output means the token is visible in
-      // plan output and state — see the caution below.
+      // unwrap the token; it is saved in state, so use a remote state store
       TUNNEL_TOKEN: Output.map(tunnel.token, Redacted.value),
     },
   },
@@ -191,7 +184,7 @@ yield* Kubernetes.Manifest("Cloudflared", {
     kind: "Deployment",
     metadata: { name: "cloudflared", namespace: "default" },
     spec: {
-      replicas: 2, // two connectors = no single point of failure
+      replicas: 2, // two connectors: no single point of failure
       selector: { matchLabels: { app: "cloudflared" } },
       template: {
         metadata: { labels: { app: "cloudflared" } },
@@ -201,7 +194,7 @@ yield* Kubernetes.Manifest("Cloudflared", {
               name: "cloudflared",
               image: "cloudflare/cloudflared:2026.8.2",
               args: ["tunnel", "--no-autoupdate", "run"],
-              envFrom: [{ secretRef: { name: tunnelSecret.name } }], // Output → ordering
+              envFrom: [{ secretRef: { name: tunnelSecret.name } }], // Output: deploys after the Secret
             },
           ],
         },
@@ -213,11 +206,11 @@ yield* Kubernetes.Manifest("Cloudflared", {
 
 Finish with a
 [proxied CNAME](/cloudflare/networking/tunnel#point-dns-at-the-tunnel).
-Tunnel resources need `Cloudflare.providers()` merged beside
-`Kubernetes.providers()` in the Stack.
+Add `Cloudflare.providers()` beside `Kubernetes.providers()` in the
+Stack.
 
 :::caution
-The unwrapped token shows in `alchemy plan` diffs and is persisted in state, so use a remote state store.
+The unwrapped token shows in `alchemy plan` diffs and is saved in state, so use a remote state store.
 :::
 
 ## Where next

--- a/website/src/content/docs/kubernetes/guides/how-apply-works.mdx
+++ b/website/src/content/docs/kubernetes/guides/how-apply-works.mdx
@@ -1,11 +1,11 @@
 ---
 title: How apply works
-description: Server-side apply under the alchemy field manager, how dropped objects are pruned and drift is corrected, what a field-manager conflict is, the order objects are deleted in, and how to debug it with kubectl.
+description: What an Alchemy deploy does to your Kubernetes objects and how to debug it with kubectl.
 ---
 
-Every `Kubernetes.*` resource ends in the same client: a server-side
-apply `PATCH` under the `alchemy` field manager with `force=true`,
-then a delete of whatever dropped out.
+Every `Kubernetes.*` resource applies its objects with server-side
+apply under the `alchemy` field manager, then deletes whatever
+dropped out.
 
 ## Server-side apply
 
@@ -19,41 +19,36 @@ Accept: application/json
 { "apiVersion": "apps/v1", "kind": "Deployment", "metadata": {...}, "spec": {...} }
 ```
 
-Uncommon kinds, including custom resources, are resolved through API
-discovery; `Kind 'X' not found in API group 'Y'` means the
+If you see `Kind 'X' not found in API group 'Y'`, the
 [CRD is not installed yet](/kubernetes/objects/manifests#custom-resources)
 or the `apiVersion` is wrong.
 
-Under `fieldManager=alchemy`, fields in the body become owned by
-`alchemy`, fields not in the body are left alone, and fields Alchemy
-applied last time but omits now are removed. Removing a key from a
-Manifest `spec` or from chart `values` really removes it from the
-object. `force=true` takes any contested field, so Alchemy never sees
-a 409 ([others do](#conflicts)).
+Alchemy owns every field it sends and leaves the rest alone. Remove a
+key from a Manifest `spec` or from chart `values` and it is removed
+from the object. `force=true` takes any field someone else owns; other
+tools get a [conflict](#conflicts) instead.
 
-Objects within one resource apply in rank order (Namespace, CRD,
+Objects in one resource apply in order: Namespace, CRD,
 ServiceAccount, ConfigMap and Secret, Service, workloads, then
-everything discovered), so a chart's custom resources always find
-their CRD. Declaring the same object twice is last-writer-wins.
+everything else. A chart's custom resources always find their CRD. If
+you declare the same object twice, the last one wins.
 
 ## Pruning and drift
 
-Each multi-object resource persists its object set keyed
-`apiVersion/kind/namespace/name`; keys missing from the next deploy
-are deleted first, in reverse rank order. That happens when a Helm
+An object that drops out of a resource is deleted on the next deploy,
+before anything is applied. That happens when a Helm
 [`values`](/kubernetes/objects/helm#values) change stops rendering an
 object, a [Job spec changes](/kubernetes/workloads/jobs#jobs), or
 `createNamespace` flips to `false`. A `Manifest` never prunes;
 changing its identity is a
 [replacement](/kubernetes/objects/manifests#any-object).
 
-Apply restates every owned field, so an out-of-band `kubectl scale`
-or `set image` is reverted the next time the resource reconciles,
-while fields Alchemy does not own survive. A resource reconciles only
-when the plan sees a prop or content-hash change:
+An out-of-band `kubectl scale` or `set image` is reverted the next
+time the resource applies; fields Alchemy never sent survive. A
+resource applies only when a prop or content hash changes:
 
 ```typescript
-// Deploy #1 — applies spec.replicas = 3 under manager "alchemy".
+// Deploy #1: applies spec.replicas = 3 under manager "alchemy".
 const api = yield* Kubernetes.Deployment("Api", {
   cluster,
   image: "ghcr.io/acme/api:v3",
@@ -62,26 +57,24 @@ const api = yield* Kubernetes.Deployment("Api", {
 
 // Someone runs: kubectl scale deploy/<api.deploymentName> --replicas=10
 //
-// `alchemy deploy` with NO prop change: the plan is a no-op for Api and replicas stay at 10.
-// `alchemy deploy` after ANY prop/hash change (new image tag, a label, an env var):
-// the apply re-asserts replicas = 3 and takes the field back from kubectl.
-// `alchemy deploy --force`: every resource reconciles even without a change —
-// the apply runs, replicas go back to 3.
+// `alchemy deploy` with NO prop change: Api is a no-op and replicas stay at 10.
+// `alchemy deploy` after ANY prop change (new image tag, a label, an env var):
+// replicas go back to 3 and the field is taken back from kubectl.
+// `alchemy deploy --force`: every resource applies even without a change;
+// replicas go back to 3.
 ```
 
-Field drift is fixed by [`alchemy deploy --force`](/cli/deploy).
-Existence drift is fixed by `alchemy sync`, which re-reads the object
-(`Manifest`), the ServiceAccount anchor (`Deployment`, `Job`), or
-only cluster reachability (`HelmChart`).
+To fix changed fields, run [`alchemy deploy --force`](/cli/deploy).
+If an object was deleted out of band, run `alchemy sync`.
 
 :::caution[HorizontalPodAutoscalers]
-`Deployment` always applies `spec.replicas`, so for an autoscaled workload write the Deployment as a [`Manifest`](/kubernetes/objects/manifests#any-object) and omit `spec.replicas`.
+`Deployment` always applies `spec.replicas`. For an autoscaled workload, write the Deployment as a [`Manifest`](/kubernetes/objects/manifests#any-object) and leave out `spec.replicas`.
 :::
 
 ## Conflicts
 
-Conflicts are what other server-side appliers see when they touch a
-field Alchemy owns:
+Other server-side appliers get a conflict when they touch a field
+Alchemy owns:
 
 ```
 $ kubectl apply --server-side -f deployment.yaml
@@ -90,40 +83,39 @@ Please review the fields above--they currently have other managers. Here
 are the ways you can resolve this warning: ...
 ```
 
-Don't co-manage; partition fields instead. A writer that only touches
-fields Alchemy never sends (an annotation, a field
-[left out of a Manifest](/kubernetes/objects/manifests#any-object))
-coexists indefinitely. `--force-conflicts` wins once; the next
-reconcile takes the field back. Client-side `kubectl apply`, `edit`,
-and `scale` never conflict and are reverted the same way.
+Don't share fields. Let other tools write only fields Alchemy never
+sends (an annotation, a field
+[left out of a Manifest](/kubernetes/objects/manifests#any-object)).
+`--force-conflicts` wins once; the next apply takes the field back.
+Client-side `kubectl apply`, `edit`, and `scale` never conflict and
+are reverted the same way.
 
-A Manifest matching an existing object adopts it by taking ownership
-of the fields it sends.
+A Manifest that matches an existing object takes it over, owning the
+fields it sends.
 
 ## Delete order
 
-Inside a resource, references are deleted in descending rank with
-`propagationPolicy=Background`; a 404 is success. Alchemy does not
-wait for deletion, so a Namespace can still be `Terminating` when
+Objects in a resource are deleted in reverse apply order; an object
+that is already gone counts as deleted. Alchemy doesn't wait, so a
+Namespace can still be `Terminating` when
 [`alchemy destroy`](/cli/destroy) returns.
 
-`Deployment` and `Job` then run the adapter's cloud-side cleanup
+`Deployment` and `Job` then clean up their cloud-side resources
 ([EKS](/kubernetes/clusters/eks#destroy-and-a-missing-cluster)).
-`HelmChart` with `includeCrds` deletes the CRDs last, cascading every
-custom resource of those kinds cluster-wide.
+`HelmChart` with `includeCrds` deletes the CRDs last, which deletes
+every custom resource of those kinds cluster-wide.
 
-Across the stack, deletes run in reverse dependency order, and
-dependencies exist only where Outputs flow: a workload whose
-`namespace` is `ns.name` goes before the Namespace; a literal
-`namespace: "apps"` may go in either order
+Across the stack, deletes run in reverse dependency order. Only
+Outputs create dependencies: a workload with `namespace: ns.name` is
+deleted before the Namespace; one with a literal `namespace: "apps"`
+may go in either order
 ([Namespaces](/kubernetes/objects/manifests#namespaces)).
 
 ## Debugging
 
-Apply failures are `KubernetesApiError`s formatted
-`PATCH <path> responded <status>: <body>`: `422` is schema
-validation, `404` means the kind does not exist on this cluster,
-`403` means the adapter's identity lacks RBAC.
+A failed apply reads `PATCH <path> responded <status>: <body>`. `422`
+is a schema error, `404` means the kind doesn't exist on this cluster,
+`403` means your identity lacks RBAC.
 
 ### See who owns what
 
@@ -131,8 +123,8 @@ validation, `404` means the kind does not exist on this cluster,
 kubectl -n default get deploy api -o yaml --show-managed-fields
 ```
 
-`manager: alchemy` with `operation: Apply` lists the fields Alchemy
-will re-assert.
+Look for `manager: alchemy` with `operation: Apply`: those are the
+fields Alchemy will take back.
 
 ### See what Alchemy remembers
 
@@ -140,7 +132,7 @@ will re-assert.
 alchemy state get --stack <stack> --stage <stage> --fqn Api
 ```
 
-The persisted references pruning and delete operate on.
+This lists the objects pruning and delete act on.
 
 ### Reproduce a render
 
@@ -149,7 +141,7 @@ helm template <release> <chart> --repo <repo> --version <v> \
   --namespace <ns> --include-crds --no-hooks -f values.yaml
 ```
 
-Alchemy's exact command;
+This is the exact command Alchemy runs;
 [hook-annotated objects](/kubernetes/objects/helm#what-helm-does-that-alchemy-doesnt)
 are dropped.
 

--- a/website/src/content/docs/kubernetes/guides/how-apply-works.mdx
+++ b/website/src/content/docs/kubernetes/guides/how-apply-works.mdx
@@ -1,21 +1,15 @@
 ---
 title: How apply works
-description: What Alchemy sends to the API server — server-side apply under the alchemy field manager, how dropped objects are pruned and drift is corrected, what a field-manager conflict is, the order objects are deleted in, and how to debug all of it with kubectl.
+description: Server-side apply under the alchemy field manager, how dropped objects are pruned and drift is corrected, what a field-manager conflict is, the order objects are deleted in, and how to debug it with kubectl.
 ---
 
-Every `Kubernetes.*` resource ends in the same client. It resolves
-the kind's REST path, `PATCH`es it as a server-side apply under the
-`alchemy` field manager with `force=true`, records the object
-references, and deletes whatever dropped out. Read this when
-something surprised you: a `kubectl scale` that got undone, an HPA
-fighting a Deployment, an object gone after a Helm value change, a
-Namespace stuck `Terminating` after `destroy`.
+Every `Kubernetes.*` resource ends in the same client: a server-side
+apply `PATCH` under the `alchemy` field manager with `force=true`,
+then a delete of whatever dropped out.
 
 ## Server-side apply
 
-Every object goes through one request. A Manifest's literal, the
-three objects a Deployment synthesizes, the two of a Job, every
-rendered chart object.
+Every object goes through one request:
 
 ```
 PATCH /apis/apps/v1/namespaces/default/deployments/api?fieldManager=alchemy&force=true
@@ -25,118 +19,38 @@ Accept: application/json
 { "apiVersion": "apps/v1", "kind": "Deployment", "metadata": {...}, "spec": {...} }
 ```
 
-The path comes from the kind. A static table covers the common kinds
-(Namespace, CustomResourceDefinition, ServiceAccount, ConfigMap,
-Secret, Service, Deployment, StatefulSet, DaemonSet, Job, CronJob,
-Pod). Anything else, including every custom resource, is resolved
-once per process through discovery at `/apis/<group>/<version>` or
-`/api/v1`. A Manifest of an unknown kind fails with
-`Kind 'X' not found in API group 'Y'`: the
+Uncommon kinds, including custom resources, are resolved through API
+discovery; `Kind 'X' not found in API group 'Y'` means the
 [CRD is not installed yet](/kubernetes/objects/manifests#custom-resources)
 or the `apiVersion` is wrong.
 
-`fieldManager=alchemy` makes Alchemy one manager among others. The
-API server records which manager last applied each field in
-`metadata.managedFields`. Fields in the body become owned by
-`alchemy`. Fields not in the body are left alone. Fields Alchemy
-applied last time but omits now are removed if Alchemy was their only
-owner. Removing a key from a Manifest `spec` or from chart `values`
-really removes it from the object.
+Under `fieldManager=alchemy`, fields in the body become owned by
+`alchemy`, fields not in the body are left alone, and fields Alchemy
+applied last time but omits now are removed. Removing a key from a
+Manifest `spec` or from chart `values` really removes it from the
+object. `force=true` takes any contested field, so Alchemy never sees
+a 409 ([others do](#conflicts)).
 
-`force=true` settles ownership. Where the server would answer
-`409 Conflict`, `force` takes the field instead, so Alchemy never
-sees a conflict ([others do](#conflicts)). Apply is a true upsert.
-No provider has a separate create path.
-
-What each resource applies is what it owns. `Manifest` applies your
-[literal object](/kubernetes/objects/manifests#any-object) and
-nothing more. `Deployment` applies its
-[three objects](/kubernetes/workloads/deployments#what-gets-created):
-the ServiceAccount, the `apps/v1/Deployment` with `spec.replicas`,
-`selector`, and a pod template of `serviceAccountName` plus one
-container (`image`, `command`, `args`, `ports`, `env`, `resources`)
-deep-merged with
-[`podTemplate`](/kubernetes/workloads/pod-template#merge-rules), and
-the Service (`type`, `loadBalancerClass` when the adapter sets it,
-`selector`, `ports`, `annotations`). `spec.replicas` is always
-applied, as `1` when omitted. `Job` applies the ServiceAccount plus a
-`batch/v1/Job` whose name embeds a hash of the spec, so a
-[spec change is a new Job](/kubernetes/workloads/jobs#jobs), or a
-`batch/v1/CronJob` under a stable name. `HelmChart` applies every
-object `helm template --no-hooks` rendered, with `namespace`
-injected where omitted, plus a `v1/Namespace` when `createNamespace`
-is set and the namespace is not `default`
-([lifecycle](/kubernetes/objects/helm#lifecycle)).
-
-Objects within one resource apply in rank chunks: Namespace (10),
-CustomResourceDefinition (15), ServiceAccount (20), ConfigMap and
-Secret (30), Service (40), Deployment, StatefulSet, DaemonSet (50),
-Job, CronJob, Pod (60), everything discovered (100). Chunks apply in
-order, objects within a chunk concurrently. A chart's custom
-resources always find their CRD, and an `Ingress` lands after its
-Service.
-
-Two retry loops can look like a hang. Transport errors retry every
-5 seconds up to 8 times. HTTP 5xx, 429, 401, and 403 retry every 6
-seconds up to 10 times, since a fresh managed cluster's access
-entries propagate asynchronously. Any other 4xx fails immediately
-with the server's message.
-
-:::note
-The `Content-Type` is `application/apply-patch+yaml` with a JSON
-body. JSON is valid YAML, and that is the server-side apply media
-type.
-:::
-
-:::caution
-Declaring the same object twice, in two Manifests or in a Manifest
-that duplicates a chart object, is silently last-writer-wins under
-one manager name, and deleting either resource deletes the object.
-One object, one resource.
-:::
+Objects within one resource apply in rank order (Namespace, CRD,
+ServiceAccount, ConfigMap and Secret, Service, workloads, then
+everything discovered), so a chart's custom resources always find
+their CRD. Declaring the same object twice is last-writer-wins.
 
 ## Pruning and drift
 
-Both come from one function, `reconcileObjects`. Every multi-object
-resource calls it with the objects it persisted last time and the
-objects it wants now. Each object is keyed
-`apiVersion/kind/namespace/name`, with `_cluster` standing in for
-cluster-scoped kinds. Keys in the previous set (the persisted
-`kubernetesObjects` or `objects` attribute) but not in the desired
-set are deleted first, in reverse rank order, 404 tolerated. The
-desired set is then applied in rank chunks and persisted as the next
-deploy's previous set.
+Each multi-object resource persists its object set keyed
+`apiVersion/kind/namespace/name`; keys missing from the next deploy
+are deleted first, in reverse rank order. That happens when a Helm
+[`values`](/kubernetes/objects/helm#values) change stops rendering an
+object, a [Job spec changes](/kubernetes/workloads/jobs#jobs), or
+`createNamespace` flips to `false`. A `Manifest` never prunes;
+changing its identity is a
+[replacement](/kubernetes/objects/manifests#any-object).
 
-A prune happens when a Helm [`values`](/kubernetes/objects/helm#values)
-change or `version` bump stops rendering an object, and when a chart
-moves an object to a new `apiVersion`. That is a different key, so
-the old path is deleted and the new one applied. A `Job` spec change
-prunes too: the new content-addressed Job is applied and the old one
-deleted, which is how
-[re-run on change](/kubernetes/workloads/jobs#jobs) works. Flipping
-`createNamespace` to `false` deletes the Namespace and everything in
-it. The [HelmChart lifecycle](/kubernetes/objects/helm#lifecycle)
-section carries the caution. A `Manifest` is one object and never
-prunes. Changing its `apiVersion`, `kind`, `name`, or `namespace` is a
-[replacement](/kubernetes/objects/manifests#any-object): the new
-object is created, then the old resource is deleted.
-
-Apply restates every owned field, so an out-of-band change to an
-owned field is reverted the next time the resource reconciles: a
-`kubectl scale`, a `kubectl set image`, a `kubectl edit` of the
-container env. Changes to fields Alchemy does not own survive: a
-`kubectl annotate`, the `restartedAt` annotation from
-`kubectl rollout restart`, anything under `status`.
-
-A resource reconciles only when the plan decides it changed. The
-engine diffs props, and the providers add content hashes. Deployment
-and Job hash the
-[image source](/kubernetes/workloads/image-sources#three-sources).
-HelmChart hashes chart, repo, version, values, flags, and the content
-of a local chart directory, which is why editing files under
-`context` or a chart directory shows up in
-[`alchemy plan`](/cli/plan). No change means no apply, and the drift
-stays.
+Apply restates every owned field, so an out-of-band `kubectl scale`
+or `set image` is reverted the next time the resource reconciles,
+while fields Alchemy does not own survive. A resource reconciles only
+when the plan sees a prop or content-hash change:
 
 ```typescript
 // Deploy #1 — applies spec.replicas = 3 under manager "alchemy".
@@ -156,42 +70,18 @@ const api = yield* Kubernetes.Deployment("Api", {
 ```
 
 Field drift is fixed by [`alchemy deploy --force`](/cli/deploy).
-Every resource reconciles and every apply restates its owned fields.
-There is no need to nudge a value or bump a version.
-
-Existence drift is fixed by `alchemy sync`. It calls each provider's
-`read` and compares with the persisted attributes. `--dry-run`
-reports `missing` and `drifted`, a real run recreates or reconciles.
-`Manifest` re-reads the object: 404 is `missing`, a different `uid`
-is `drifted`. `Deployment` and `Job` read the ServiceAccount as an
-existence anchor, so a deleted Deployment with a surviving
-ServiceAccount is not detected. `HelmChart` only checks that the
-cluster is reachable, so a hand-deleted chart object is invisible to
-`sync`. Use `alchemy deploy --force` to re-apply the render.
-
-A cluster that no longer exists (`ClusterNotFoundError`) reads as
-everything gone for all four resources. A cluster that is merely
-unreachable is caught by the `Deployment` and `Job` `read`, which
-keep persisted state. `Manifest` and `HelmChart` let the error
-propagate, so `sync` fails for those while syncing the rest. No
-resource is marked missing by an outage.
-
-`sync` detects existence, not field values. Field drift is only
-corrected by a reconcile.
+Existence drift is fixed by `alchemy sync`, which re-reads the object
+(`Manifest`), the ServiceAccount anchor (`Deployment`, `Job`), or
+only cluster reachability (`HelmChart`).
 
 :::caution[HorizontalPodAutoscalers]
-`Deployment` always applies `spec.replicas`, so the next reconcile
-(including `--force`) undoes what an HPA scaled. For an autoscaled
-workload, write the Deployment as a
-[`Manifest`](/kubernetes/objects/manifests#any-object) and omit
-`spec.replicas` so Alchemy never owns the field.
+`Deployment` always applies `spec.replicas`, so for an autoscaled workload write the Deployment as a [`Manifest`](/kubernetes/objects/manifests#any-object) and omit `spec.replicas`.
 :::
 
 ## Conflicts
 
-Every Alchemy apply is `force=true`, so Alchemy never receives a
-409. Conflicts are what other server-side appliers see when they
-touch a field Alchemy owns:
+Conflicts are what other server-side appliers see when they touch a
+field Alchemy owns:
 
 ```
 $ kubectl apply --server-side -f deployment.yaml
@@ -200,96 +90,40 @@ Please review the fields above--they currently have other managers. Here
 are the ways you can resolve this warning: ...
 ```
 
-Don't co-manage. If Alchemy declares the object, make the change in
-the program and deploy. If two managers must share an object,
-partition fields. Server-side apply lets each own different fields,
-so a writer that only touches fields Alchemy never sends (an extra
-annotation, a field you
-[leave out of a Manifest](/kubernetes/objects/manifests#any-object))
-coexists indefinitely. That is how cert-manager, an HPA with
-`spec.replicas` omitted, or a mesh injector runs beside Alchemy.
-`--force-conflicts` on their side wins once. The next Alchemy
-reconcile takes the field back.
+Don't co-manage; partition fields instead. A writer that only touches
+fields Alchemy never sends (an annotation, a field
+[left out of a Manifest](/kubernetes/objects/manifests#any-object))
+coexists indefinitely. `--force-conflicts` wins once; the next
+reconcile takes the field back. Client-side `kubectl apply`, `edit`,
+and `scale` never conflict and are reverted the same way.
 
-Two kinds of write never report a conflict. Client-side
-`kubectl apply` patches under `kubectl-client-side-apply`, and
-`kubectl edit`, `scale`, and `set` write under managers like
-`kubectl-edit`. None of them apply, so none are refused, and Alchemy
-reverts the
-[fields it owns](/kubernetes/workloads/deployments#what-gets-created)
-at the next reconcile. `--show-managed-fields` under
-[Debugging](#debugging) shows who owns what.
-
-Two stacks or stages declaring the same object both apply as
-`alchemy`. The last deploy wins and either `destroy` deletes the
-object. Generated names embed stack and stage, so the risk is an
-explicit `name` or `metadata.name` shared across stages.
-
-A Manifest that matches an object created with kubectl (same
-`apiVersion`, `kind`, `name`, and `namespace`) adopts it by taking
-ownership of the fields it sends. Fields that only exist in the old
-`last-applied-configuration` annotation remain until someone removes
-them. There is no import step.
+A Manifest matching an existing object adopts it by taking ownership
+of the fields it sends.
 
 ## Delete order
 
-Inside a resource, the persisted references are deleted sequentially
-in descending rank: discovered kinds and custom resources (100), Job,
-CronJob, Pod (60), Deployment, StatefulSet, DaemonSet (50), Service
-(40), ConfigMap and Secret (30), ServiceAccount (20),
-CustomResourceDefinition (15), Namespace (10). Each `DELETE` uses
-`propagationPolicy=Background`, like `kubectl delete`, so a Job's
-pods and a Deployment's ReplicaSets are garbage-collected instead of
-orphaned. A 404 is success, so delete is idempotent. Alchemy does not
-wait for deletion to finish, so a Namespace or a CRD with many
-instances can still be `Terminating` when
-[`alchemy destroy`](/cli/destroy) prints done.
+Inside a resource, references are deleted in descending rank with
+`propagationPolicy=Background`; a 404 is success. Alchemy does not
+wait for deletion, so a Namespace can still be `Terminating` when
+[`alchemy destroy`](/cli/destroy) returns.
 
-`Manifest` sends one `DELETE` and swallows any residual error, for
-example when the CRD was removed before its instance. `Deployment`
-and `Job` delete the in-cluster objects first, then run the adapter's
-cloud-side cleanup (`identity.delete`, then `registry.delete`). What
-that is on EKS is under
-[Destroy and a missing cluster](/kubernetes/clusters/eks#destroy-and-a-missing-cluster).
-`HelmChart` deletes all persisted `objects` in that order. With
-`includeCrds` (the default) the CRDs go last and cascade every custom
-resource of those kinds cluster-wide. The
-[lifecycle](/kubernetes/objects/helm#lifecycle) section owns the
-caution. `ClusterNotFoundError` means nothing in-cluster to delete
-for any resource. A merely unreachable cluster fails the `Manifest`
-and `HelmChart` delete. `Deployment` and `Job` skip the in-cluster
-part and still run the cloud-side cleanup.
+`Deployment` and `Job` then run the adapter's cloud-side cleanup
+([EKS](/kubernetes/clusters/eks#destroy-and-a-missing-cluster)).
+`HelmChart` with `includeCrds` deletes the CRDs last, cascading every
+custom resource of those kinds cluster-wide.
 
-Across the stack, the engine deletes in reverse dependency order, and
-dependencies exist only where Outputs flow. A workload whose
-`namespace` is the Namespace Manifest's `ns.name` Output is deleted
-before the Namespace. One that spells `namespace: "apps"` as a
-literal may go in either order. The Namespace cascade turns the later
-`DELETE`s into tolerated 404s, so `destroy` still succeeds. The
-wiring is under [Namespaces](/kubernetes/objects/manifests#namespaces).
-
-:::note
-`destroy` returning does not mean the Namespace is gone. Check
-`kubectl get ns` before re-creating one with the same name.
-:::
+Across the stack, deletes run in reverse dependency order, and
+dependencies exist only where Outputs flow: a workload whose
+`namespace` is `ns.name` goes before the Namespace; a literal
+`namespace: "apps"` may go in either order
+([Namespaces](/kubernetes/objects/manifests#namespaces)).
 
 ## Debugging
 
-Start with [`alchemy plan`](/cli/plan). It shows `update` with the
-changed props or `code.hash`, and `replace` when the cluster identity
-or namespace changed (Deployment, Job, Manifest) or the release name
-or namespace changed (HelmChart). No entry means nothing will be
-applied.
-
-Then read the error. Apply failures are `KubernetesApiError`s
-formatted `PATCH <path> responded <status>: <body>`, where the body
-is the server's `Status`. `422` is schema validation, see
-`details.causes[].field`. `404` on a discovery path means the kind or
-`apiVersion` does not exist on this cluster. `403` after the retries
-means the adapter's identity lacks RBAC. Transport errors surface as
-`Failed Kubernetes <method> <path>: …` after the bounded retries. A
-missing adapter dies with the message under
-[How the adapter is chosen](/kubernetes/clusters/connecting#how-the-adapter-is-chosen).
+Apply failures are `KubernetesApiError`s formatted
+`PATCH <path> responded <status>: <body>`: `422` is schema
+validation, `404` means the kind does not exist on this cluster,
+`403` means the adapter's identity lacks RBAC.
 
 ### See who owns what
 
@@ -297,58 +131,30 @@ missing adapter dies with the message under
 kubectl -n default get deploy api -o yaml --show-managed-fields
 ```
 
-Look for `manager: alchemy` with `operation: Apply`. The `f:` tree
-under it is the set of fields Alchemy will re-assert. Other entries
-are the other writers: `kube-controller-manager`,
-`kubectl-client-side-apply`, an HPA.
-
-### See what the cluster thinks
-
-`kubectl describe deploy` and `kubectl describe pod` show events:
-image pull errors on registry-less clusters (the
-[`image` reference is used verbatim](/kubernetes/workloads/image-sources#registry-requirement)),
-`FailedScheduling`, or a `LoadBalancer` Service with no
-`loadBalancerClass` on Auto Mode stuck at `<pending>`. When `url`
-came back `undefined`, read the Service directly:
-`kubectl get svc <name> -o jsonpath='{.status.loadBalancer.ingress}'`.
+`manager: alchemy` with `operation: Apply` lists the fields Alchemy
+will re-assert.
 
 ### See what Alchemy remembers
-
-The persisted `kubernetesObjects` and `objects` references are what
-pruning and delete operate on. Print them when an expected prune did
-not happen or a delete touched something unexpected:
 
 ```sh
 alchemy state get --stack <stack> --stage <stage> --fqn Api
 ```
 
-See [Inspecting state](/cli/inspecting-state). To compare existence,
-`alchemy sync --dry-run` lists `missing` and `drifted` per the `read`
-rules above. `alchemy sync` repairs existence, `alchemy deploy --force`
-repairs fields.
+The persisted references pruning and delete operate on.
 
 ### Reproduce a render
-
-For charts, run the same command Alchemy does to see which objects
-will be applied and which
-[hook-annotated ones were dropped](/kubernetes/objects/helm#what-helm-does-that-alchemy-doesnt):
 
 ```sh
 helm template <release> <chart> --repo <repo> --version <v> \
   --namespace <ns> --include-crds --no-hooks -f values.yaml
 ```
 
-:::tip
-`kubectl get <kind> -o yaml` hides `managedFields` since Kubernetes
-1.21. `--show-managed-fields` is required to see ownership.
-:::
+Alchemy's exact command;
+[hook-annotated objects](/kubernetes/objects/helm#what-helm-does-that-alchemy-doesnt)
+are dropped.
 
 ## Where next
 
-- [Cluster adapters](/kubernetes/guides/cluster-adapters) — the seam
-  that mints the auth headers on every request, and how to add a
-  platform.
-- [HelmChart lifecycle](/kubernetes/objects/helm#lifecycle) — the
-  chart lifecycle from the user's side.
-- [Manifests](/kubernetes/objects/manifests) — Manifests in full.
-- [`alchemy plan`](/cli/plan) — the plan command.
+- [Cluster adapters](/kubernetes/guides/cluster-adapters)
+- [HelmChart lifecycle](/kubernetes/objects/helm#lifecycle)
+- [Manifests](/kubernetes/objects/manifests)

--- a/website/src/content/docs/kubernetes/guides/how-apply-works.mdx
+++ b/website/src/content/docs/kubernetes/guides/how-apply-works.mdx
@@ -1,0 +1,354 @@
+---
+title: How apply works
+description: What Alchemy sends to the API server — server-side apply under the alchemy field manager, how dropped objects are pruned and drift is corrected, what a field-manager conflict is, the order objects are deleted in, and how to debug all of it with kubectl.
+---
+
+Every `Kubernetes.*` resource ends in the same client. It resolves
+the kind's REST path, `PATCH`es it as a server-side apply under the
+`alchemy` field manager with `force=true`, records the object
+references, and deletes whatever dropped out. Read this when
+something surprised you: a `kubectl scale` that got undone, an HPA
+fighting a Deployment, an object gone after a Helm value change, a
+Namespace stuck `Terminating` after `destroy`.
+
+## Server-side apply
+
+Every object goes through one request. A Manifest's literal, the
+three objects a Deployment synthesizes, the two of a Job, every
+rendered chart object.
+
+```
+PATCH /apis/apps/v1/namespaces/default/deployments/api?fieldManager=alchemy&force=true
+Content-Type: application/apply-patch+yaml
+Accept: application/json
+
+{ "apiVersion": "apps/v1", "kind": "Deployment", "metadata": {...}, "spec": {...} }
+```
+
+The path comes from the kind. A static table covers the common kinds
+(Namespace, CustomResourceDefinition, ServiceAccount, ConfigMap,
+Secret, Service, Deployment, StatefulSet, DaemonSet, Job, CronJob,
+Pod). Anything else, including every custom resource, is resolved
+once per process through discovery at `/apis/<group>/<version>` or
+`/api/v1`. A Manifest of an unknown kind fails with
+`Kind 'X' not found in API group 'Y'`: the
+[CRD is not installed yet](/kubernetes/objects/manifests#custom-resources)
+or the `apiVersion` is wrong.
+
+`fieldManager=alchemy` makes Alchemy one manager among others. The
+API server records which manager last applied each field in
+`metadata.managedFields`. Fields in the body become owned by
+`alchemy`. Fields not in the body are left alone. Fields Alchemy
+applied last time but omits now are removed if Alchemy was their only
+owner. Removing a key from a Manifest `spec` or from chart `values`
+really removes it from the object.
+
+`force=true` settles ownership. Where the server would answer
+`409 Conflict`, `force` takes the field instead, so Alchemy never
+sees a conflict ([others do](#conflicts)). Apply is a true upsert.
+No provider has a separate create path.
+
+What each resource applies is what it owns. `Manifest` applies your
+[literal object](/kubernetes/objects/manifests#any-object) and
+nothing more. `Deployment` applies its
+[three objects](/kubernetes/workloads/deployments#what-gets-created):
+the ServiceAccount, the `apps/v1/Deployment` with `spec.replicas`,
+`selector`, and a pod template of `serviceAccountName` plus one
+container (`image`, `command`, `args`, `ports`, `env`, `resources`)
+deep-merged with
+[`podTemplate`](/kubernetes/workloads/pod-template#merge-rules), and
+the Service (`type`, `loadBalancerClass` when the adapter sets it,
+`selector`, `ports`, `annotations`). `spec.replicas` is always
+applied, as `1` when omitted. `Job` applies the ServiceAccount plus a
+`batch/v1/Job` whose name embeds a hash of the spec, so a
+[spec change is a new Job](/kubernetes/workloads/jobs#jobs), or a
+`batch/v1/CronJob` under a stable name. `HelmChart` applies every
+object `helm template --no-hooks` rendered, with `namespace`
+injected where omitted, plus a `v1/Namespace` when `createNamespace`
+is set and the namespace is not `default`
+([lifecycle](/kubernetes/objects/helm#lifecycle)).
+
+Objects within one resource apply in rank chunks: Namespace (10),
+CustomResourceDefinition (15), ServiceAccount (20), ConfigMap and
+Secret (30), Service (40), Deployment, StatefulSet, DaemonSet (50),
+Job, CronJob, Pod (60), everything discovered (100). Chunks apply in
+order, objects within a chunk concurrently. A chart's custom
+resources always find their CRD, and an `Ingress` lands after its
+Service.
+
+Two retry loops can look like a hang. Transport errors retry every
+5 seconds up to 8 times. HTTP 5xx, 429, 401, and 403 retry every 6
+seconds up to 10 times, since a fresh managed cluster's access
+entries propagate asynchronously. Any other 4xx fails immediately
+with the server's message.
+
+:::note
+The `Content-Type` is `application/apply-patch+yaml` with a JSON
+body. JSON is valid YAML, and that is the server-side apply media
+type.
+:::
+
+:::caution
+Declaring the same object twice, in two Manifests or in a Manifest
+that duplicates a chart object, is silently last-writer-wins under
+one manager name, and deleting either resource deletes the object.
+One object, one resource.
+:::
+
+## Pruning and drift
+
+Both come from one function, `reconcileObjects`. Every multi-object
+resource calls it with the objects it persisted last time and the
+objects it wants now. Each object is keyed
+`apiVersion/kind/namespace/name`, with `_cluster` standing in for
+cluster-scoped kinds. Keys in the previous set (the persisted
+`kubernetesObjects` or `objects` attribute) but not in the desired
+set are deleted first, in reverse rank order, 404 tolerated. The
+desired set is then applied in rank chunks and persisted as the next
+deploy's previous set.
+
+A prune happens when a Helm [`values`](/kubernetes/objects/helm#values)
+change or `version` bump stops rendering an object, and when a chart
+moves an object to a new `apiVersion`. That is a different key, so
+the old path is deleted and the new one applied. A `Job` spec change
+prunes too: the new content-addressed Job is applied and the old one
+deleted, which is how
+[re-run on change](/kubernetes/workloads/jobs#jobs) works. Flipping
+`createNamespace` to `false` deletes the Namespace and everything in
+it. The [HelmChart lifecycle](/kubernetes/objects/helm#lifecycle)
+section carries the caution. A `Manifest` is one object and never
+prunes. Changing its `apiVersion`, `kind`, `name`, or `namespace` is a
+[replacement](/kubernetes/objects/manifests#any-object): the new
+object is created, then the old resource is deleted.
+
+Apply restates every owned field, so an out-of-band change to an
+owned field is reverted the next time the resource reconciles: a
+`kubectl scale`, a `kubectl set image`, a `kubectl edit` of the
+container env. Changes to fields Alchemy does not own survive: a
+`kubectl annotate`, the `restartedAt` annotation from
+`kubectl rollout restart`, anything under `status`.
+
+A resource reconciles only when the plan decides it changed. The
+engine diffs props, and the providers add content hashes. Deployment
+and Job hash the
+[image source](/kubernetes/workloads/image-sources#three-sources).
+HelmChart hashes chart, repo, version, values, flags, and the content
+of a local chart directory, which is why editing files under
+`context` or a chart directory shows up in
+[`alchemy plan`](/cli/plan). No change means no apply, and the drift
+stays.
+
+```typescript
+// Deploy #1 — applies spec.replicas = 3 under manager "alchemy".
+const api = yield* Kubernetes.Deployment("Api", {
+  cluster,
+  image: "ghcr.io/acme/api:v3",
+  replicas: 3,
+});
+
+// Someone runs: kubectl scale deploy/<api.deploymentName> --replicas=10
+//
+// `alchemy deploy` with NO prop change: the plan is a no-op for Api and replicas stay at 10.
+// `alchemy deploy` after ANY prop/hash change (new image tag, a label, an env var):
+// the apply re-asserts replicas = 3 and takes the field back from kubectl.
+// `alchemy deploy --force`: every resource reconciles even without a change —
+// the apply runs, replicas go back to 3.
+```
+
+Field drift is fixed by [`alchemy deploy --force`](/cli/deploy).
+Every resource reconciles and every apply restates its owned fields.
+There is no need to nudge a value or bump a version.
+
+Existence drift is fixed by `alchemy sync`. It calls each provider's
+`read` and compares with the persisted attributes. `--dry-run`
+reports `missing` and `drifted`, a real run recreates or reconciles.
+`Manifest` re-reads the object: 404 is `missing`, a different `uid`
+is `drifted`. `Deployment` and `Job` read the ServiceAccount as an
+existence anchor, so a deleted Deployment with a surviving
+ServiceAccount is not detected. `HelmChart` only checks that the
+cluster is reachable, so a hand-deleted chart object is invisible to
+`sync`. Use `alchemy deploy --force` to re-apply the render.
+
+A cluster that no longer exists (`ClusterNotFoundError`) reads as
+everything gone for all four resources. A cluster that is merely
+unreachable is caught by the `Deployment` and `Job` `read`, which
+keep persisted state. `Manifest` and `HelmChart` let the error
+propagate, so `sync` fails for those while syncing the rest. No
+resource is marked missing by an outage.
+
+`sync` detects existence, not field values. Field drift is only
+corrected by a reconcile.
+
+:::caution[HorizontalPodAutoscalers]
+`Deployment` always applies `spec.replicas`, so the next reconcile
+(including `--force`) undoes what an HPA scaled. For an autoscaled
+workload, write the Deployment as a
+[`Manifest`](/kubernetes/objects/manifests#any-object) and omit
+`spec.replicas` so Alchemy never owns the field.
+:::
+
+## Conflicts
+
+Every Alchemy apply is `force=true`, so Alchemy never receives a
+409. Conflicts are what other server-side appliers see when they
+touch a field Alchemy owns:
+
+```
+$ kubectl apply --server-side -f deployment.yaml
+error: Apply failed with 1 conflict: conflict with "alchemy": .spec.replicas
+Please review the fields above--they currently have other managers. Here
+are the ways you can resolve this warning: ...
+```
+
+Don't co-manage. If Alchemy declares the object, make the change in
+the program and deploy. If two managers must share an object,
+partition fields. Server-side apply lets each own different fields,
+so a writer that only touches fields Alchemy never sends (an extra
+annotation, a field you
+[leave out of a Manifest](/kubernetes/objects/manifests#any-object))
+coexists indefinitely. That is how cert-manager, an HPA with
+`spec.replicas` omitted, or a mesh injector runs beside Alchemy.
+`--force-conflicts` on their side wins once. The next Alchemy
+reconcile takes the field back.
+
+Two kinds of write never report a conflict. Client-side
+`kubectl apply` patches under `kubectl-client-side-apply`, and
+`kubectl edit`, `scale`, and `set` write under managers like
+`kubectl-edit`. None of them apply, so none are refused, and Alchemy
+reverts the
+[fields it owns](/kubernetes/workloads/deployments#what-gets-created)
+at the next reconcile. `--show-managed-fields` under
+[Debugging](#debugging) shows who owns what.
+
+Two stacks or stages declaring the same object both apply as
+`alchemy`. The last deploy wins and either `destroy` deletes the
+object. Generated names embed stack and stage, so the risk is an
+explicit `name` or `metadata.name` shared across stages.
+
+A Manifest that matches an object created with kubectl (same
+`apiVersion`, `kind`, `name`, and `namespace`) adopts it by taking
+ownership of the fields it sends. Fields that only exist in the old
+`last-applied-configuration` annotation remain until someone removes
+them. There is no import step.
+
+## Delete order
+
+Inside a resource, the persisted references are deleted sequentially
+in descending rank: discovered kinds and custom resources (100), Job,
+CronJob, Pod (60), Deployment, StatefulSet, DaemonSet (50), Service
+(40), ConfigMap and Secret (30), ServiceAccount (20),
+CustomResourceDefinition (15), Namespace (10). Each `DELETE` uses
+`propagationPolicy=Background`, like `kubectl delete`, so a Job's
+pods and a Deployment's ReplicaSets are garbage-collected instead of
+orphaned. A 404 is success, so delete is idempotent. Alchemy does not
+wait for deletion to finish, so a Namespace or a CRD with many
+instances can still be `Terminating` when
+[`alchemy destroy`](/cli/destroy) prints done.
+
+`Manifest` sends one `DELETE` and swallows any residual error, for
+example when the CRD was removed before its instance. `Deployment`
+and `Job` delete the in-cluster objects first, then run the adapter's
+cloud-side cleanup (`identity.delete`, then `registry.delete`). What
+that is on EKS is under
+[Destroy and a missing cluster](/kubernetes/clusters/eks#destroy-and-a-missing-cluster).
+`HelmChart` deletes all persisted `objects` in that order. With
+`includeCrds` (the default) the CRDs go last and cascade every custom
+resource of those kinds cluster-wide. The
+[lifecycle](/kubernetes/objects/helm#lifecycle) section owns the
+caution. `ClusterNotFoundError` means nothing in-cluster to delete
+for any resource. A merely unreachable cluster fails the `Manifest`
+and `HelmChart` delete. `Deployment` and `Job` skip the in-cluster
+part and still run the cloud-side cleanup.
+
+Across the stack, the engine deletes in reverse dependency order, and
+dependencies exist only where Outputs flow. A workload whose
+`namespace` is the Namespace Manifest's `ns.name` Output is deleted
+before the Namespace. One that spells `namespace: "apps"` as a
+literal may go in either order. The Namespace cascade turns the later
+`DELETE`s into tolerated 404s, so `destroy` still succeeds. The
+wiring is under [Namespaces](/kubernetes/objects/manifests#namespaces).
+
+:::note
+`destroy` returning does not mean the Namespace is gone. Check
+`kubectl get ns` before re-creating one with the same name.
+:::
+
+## Debugging
+
+Start with [`alchemy plan`](/cli/plan). It shows `update` with the
+changed props or `code.hash`, and `replace` when the cluster identity
+or namespace changed (Deployment, Job, Manifest) or the release name
+or namespace changed (HelmChart). No entry means nothing will be
+applied.
+
+Then read the error. Apply failures are `KubernetesApiError`s
+formatted `PATCH <path> responded <status>: <body>`, where the body
+is the server's `Status`. `422` is schema validation, see
+`details.causes[].field`. `404` on a discovery path means the kind or
+`apiVersion` does not exist on this cluster. `403` after the retries
+means the adapter's identity lacks RBAC. Transport errors surface as
+`Failed Kubernetes <method> <path>: …` after the bounded retries. A
+missing adapter dies with the message under
+[How the adapter is chosen](/kubernetes/clusters/connecting#how-the-adapter-is-chosen).
+
+### See who owns what
+
+```sh
+kubectl -n default get deploy api -o yaml --show-managed-fields
+```
+
+Look for `manager: alchemy` with `operation: Apply`. The `f:` tree
+under it is the set of fields Alchemy will re-assert. Other entries
+are the other writers: `kube-controller-manager`,
+`kubectl-client-side-apply`, an HPA.
+
+### See what the cluster thinks
+
+`kubectl describe deploy` and `kubectl describe pod` show events:
+image pull errors on registry-less clusters (the
+[`image` reference is used verbatim](/kubernetes/workloads/image-sources#registry-requirement)),
+`FailedScheduling`, or a `LoadBalancer` Service with no
+`loadBalancerClass` on Auto Mode stuck at `<pending>`. When `url`
+came back `undefined`, read the Service directly:
+`kubectl get svc <name> -o jsonpath='{.status.loadBalancer.ingress}'`.
+
+### See what Alchemy remembers
+
+The persisted `kubernetesObjects` and `objects` references are what
+pruning and delete operate on. Print them when an expected prune did
+not happen or a delete touched something unexpected:
+
+```sh
+alchemy state get --stack <stack> --stage <stage> --fqn Api
+```
+
+See [Inspecting state](/cli/inspecting-state). To compare existence,
+`alchemy sync --dry-run` lists `missing` and `drifted` per the `read`
+rules above. `alchemy sync` repairs existence, `alchemy deploy --force`
+repairs fields.
+
+### Reproduce a render
+
+For charts, run the same command Alchemy does to see which objects
+will be applied and which
+[hook-annotated ones were dropped](/kubernetes/objects/helm#what-helm-does-that-alchemy-doesnt):
+
+```sh
+helm template <release> <chart> --repo <repo> --version <v> \
+  --namespace <ns> --include-crds --no-hooks -f values.yaml
+```
+
+:::tip
+`kubectl get <kind> -o yaml` hides `managedFields` since Kubernetes
+1.21. `--show-managed-fields` is required to see ownership.
+:::
+
+## Where next
+
+- [Cluster adapters](/kubernetes/guides/cluster-adapters) — the seam
+  that mints the auth headers on every request, and how to add a
+  platform.
+- [HelmChart lifecycle](/kubernetes/objects/helm#lifecycle) — the
+  chart lifecycle from the user's side.
+- [Manifests](/kubernetes/objects/manifests) — Manifests in full.
+- [`alchemy plan`](/cli/plan) — the plan command.

--- a/website/src/content/docs/kubernetes/index.mdx
+++ b/website/src/content/docs/kubernetes/index.mdx
@@ -1,0 +1,138 @@
+---
+title: Kubernetes
+description: Run Deployments, Jobs, raw manifests, and Helm charts on any Kubernetes cluster from one typed program — a kubeconfig context, a raw connection, or a managed cluster like EKS — with the cluster's adapter deciding what you get for free.
+---
+
+An Alchemy app on Kubernetes is **workloads** plus **objects**.
+[`Kubernetes.Deployment`](/providers/kubernetes/deployment) runs a
+server, `Kubernetes.Job` runs to completion, `Kubernetes.Manifest`
+is any Kubernetes object, and `Kubernetes.HelmChart` is a rendered
+chart. Each one points at a cluster through its `cluster` prop.
+
+That value carries a
+[connection](/kubernetes/clusters/connecting#the-connection-model).
+Its `auth.kind` selects a **cluster adapter**, and the adapter decides
+what the workload gets for free: auth only, or auth plus workload
+identity plus a managed image registry.
+
+```typescript
+// alchemy.run.ts — inside the Stack's Effect.gen body
+const local = Kubernetes.KubeConfig({ context: "docker-desktop" }); // any cluster kubectl can reach
+// const cluster = yield* AWS.EKS.Cluster("Cluster", { compute: "auto", /* … */ }); // …or a managed one
+
+const web = yield* Kubernetes.Deployment("Web", {
+  cluster: local,                 // ← the only line that changes between clusters
+  image: "nginx:1.27",
+  port: 80,
+  replicas: 2,
+});
+
+return { url: web.url };          // LoadBalancer hostname once the cluster assigns one
+```
+
+`KubeConfig()` returns a plain connection and appears in no plan.
+`Deployment` synthesizes a Kubernetes Deployment plus a Service via
+server-side apply. Swap `cluster` for an `AWS.EKS.Cluster` and every
+other prop stays the same.
+
+New here? [Set up a project](/kubernetes/setup), then start the
+[tutorial](/kubernetes/tutorial/part-1). It runs on a local cluster
+and costs nothing.
+
+## What the cluster adapter gives you
+
+`Kubernetes.providers()` ships the auth-only adapters `kubeconfig`,
+`token`, `client-cert`, and `exec`. Managed-cloud adapters come from
+their provider layer and add identity and a registry. Today that is
+EKS (`aws-eks`, from `AWS.providers()`). The adapter is
+[selected by `auth.kind`](/kubernetes/clusters/connecting#how-the-adapter-is-chosen).
+
+| Capability | kubeconfig / token / client-cert / exec | [EKS (`aws-eks`)](/kubernetes/clusters/eks#what-the-adapter-adds) |
+| --- | --- | --- |
+| Auth | Whatever the kubeconfig says: static token, client cert, or exec plugin (`aws eks get-token`, `kubelogin`, `gke-gcloud-auth-plugin`). `token` / `client-cert` / `exec` need an [explicit `endpoint`](/kubernetes/clusters/connecting#token-client-certificate-and-exec) | SigV4/STS bearer tokens from your AWS credentials. Endpoint and CA discovered from the cluster |
+| `image:` (pre-built reference) | Used verbatim. The cluster pulls it | Mirrored into a per-workload ECR repository |
+| `main:` (bundled Effect program) / `context:` (your Dockerfile) | [Not available](/kubernetes/workloads/image-sources#registry-requirement). No registry to push to | Bundled / built and pushed to ECR |
+| Bindings | [`{ env }`](/kubernetes/workloads/bindings#the-binding-contract). Bind through environment variables | `{ env, policyStatements }`. Every AWS `Binding.Service` lands IAM statements on a generated [Pod Identity](/kubernetes/workloads/bindings#pod-identity-on-eks) role |
+| `url` from a `LoadBalancer` Service | Whatever the cluster's LB assigns. See [Local clusters](/kubernetes/clusters/local#reaching-a-service) | Internet-facing NLB via EKS Auto Mode (`loadBalancerClass` default) |
+| Providers in the Stack | `Kubernetes.providers()` | `Layer.mergeAll(AWS.providers(), Kubernetes.providers())` |
+| [Tools on the deploying machine](/kubernetes/setup#install) | `helm` only for `HelmChart` | Docker for every image source (`image` is pulled, tagged, and pushed), plus `helm` for `HelmChart` |
+
+Same four resources, different adapter underneath. That is why the
+tutorial runs on a local cluster and only its optional last part
+switches to EKS.
+
+:::note[EKS is one adapter, not the centre]
+Provisioning the cluster itself (Network, Cluster, AccessEntry, Addon,
+HyperPod) stays on the [AWS tab](/aws/compute/eks). This hub owns
+workloads and objects. Adapter internals live in
+[Cluster adapters](/kubernetes/guides/cluster-adapters#the-interface).
+:::
+
+## Clusters
+
+- **[Connecting](/kubernetes/clusters/connecting)**: the `Connection`
+  model, `KubeConfig()`, raw auth kinds, adapter selection.
+- **[Local clusters](/kubernetes/clusters/local)**: Docker Desktop,
+  OrbStack, kind, k3s. `LoadBalancer` behaviour and your own images.
+- **[EKS](/kubernetes/clusters/eks)**: STS auth, Pod Identity, ECR
+  mirroring, NLB defaults.
+
+## Workloads
+
+- **[Deployments](/kubernetes/workloads/deployments)**: a replicated
+  server, the analog of `AWS.ECS.Service`.
+  [Reference](/providers/kubernetes/deployment).
+- **[Jobs](/kubernetes/workloads/jobs)**: run-to-completion work, the
+  analog of `AWS.ECS.Task`. `schedule` makes a CronJob.
+  [Reference](/providers/kubernetes/job).
+- **[Image sources](/kubernetes/workloads/image-sources)**: one of
+  `image`, `context`, or `main`, and which clusters support which.
+- **[Bindings](/kubernetes/workloads/bindings)**: the
+  `{ env, policyStatements }` contract and Pod Identity.
+- **[Pod template](/kubernetes/workloads/pod-template)**: the
+  `podTemplate` escape hatch and its merge rules.
+
+## Objects
+
+- **[Manifests](/kubernetes/objects/manifests)**: any object as a
+  literal `{ apiVersion, kind, metadata, … }`. CRDs need no
+  registration. [Reference](/providers/kubernetes/manifest).
+- **[Helm charts](/kubernetes/objects/helm)**: `helm template`, then
+  apply. No in-cluster release, no hooks.
+  [Reference](/providers/kubernetes/helmchart).
+
+## Guides
+
+- **[Exposing services](/kubernetes/guides/exposing-services)**:
+  Service types, LB annotations, Ingress, Cloudflare Tunnel.
+- **[How apply works](/kubernetes/guides/how-apply-works)**:
+  server-side apply, drift, pruning, conflicts, delete order.
+- **[Cluster adapters](/kubernetes/guides/cluster-adapters)**: the
+  `ClusterAdapter` interface and registering a new `auth.kind`.
+
+## What are you building?
+
+| You're building | Reach for |
+| --- | --- |
+| An HTTP server from a pre-built image | [Deployment](/kubernetes/workloads/deployments#what-gets-created) with `image:`. Works on every cluster |
+| An Effect HTTP server, no Dockerfile | [Deployment](/kubernetes/workloads/deployments#effect-servers) with `main: import.meta.url` + `{ fetch }`. Needs a registry adapter ([EKS](/kubernetes/clusters/eks#what-the-adapter-adds)) |
+| A legacy app with its own Dockerfile | [Deployment](/kubernetes/workloads/deployments#what-gets-created) with `context:`. See [Image sources](/kubernetes/workloads/image-sources#three-sources) |
+| A one-off task (migration, seed) | [Job](/kubernetes/workloads/jobs#jobs) |
+| Something on a schedule | [Job](/kubernetes/workloads/jobs#cronjobs) with `schedule: "0 3 * * *"` |
+| A Namespace, ConfigMap, StatefulSet, CRD instance… | [Manifest](/kubernetes/objects/manifests#any-object) |
+| Secrets (ConfigMaps, Secrets as Manifests) | [Manifest](/kubernetes/objects/manifests#secrets) |
+| An off-the-shelf chart (ingress-nginx, podinfo, Karpenter) | [HelmChart](/kubernetes/objects/helm#chart-sources) |
+| AWS access from a Pod (S3, DynamoDB, SQS…) | Any AWS `Binding.Service` on a Deployment/Job. [Pod Identity](/kubernetes/workloads/bindings#pod-identity-on-eks) |
+| A public URL | `serviceType: "LoadBalancer"` → `url`. See [Exposing services](/kubernetes/guides/exposing-services#service-types) |
+| A domain + TLS in front of it | [Ingress](/kubernetes/guides/exposing-services#ingress) or [Cloudflare Tunnel](/kubernetes/guides/exposing-services#cloudflare-tunnel) |
+| GPU / spot / ARM placement | [podTemplate recipes](/kubernetes/workloads/pod-template#recipes) |
+| The EKS cluster itself | [`AWS.EKS.Cluster`](/aws/compute/eks) on the AWS tab |
+| A cluster Alchemy can't reach yet (GKE identity, AKS…) | `KubeConfig()` today ([Connecting](/kubernetes/clusters/connecting#kubeconfig)). Write an adapter for identity/registry ([Cluster adapters](/kubernetes/guides/cluster-adapters#registering-an-auth-kind)) |
+
+## Where next
+
+- [Setup](/kubernetes/setup): install, pick a cluster, plan your first
+  manifest.
+- [Tutorial](/kubernetes/tutorial/part-1): a Deployment, a Job,
+  manifests, and a Helm chart on a local cluster, then optionally EKS.
+- [Providers reference](/providers): generated API docs.

--- a/website/src/content/docs/kubernetes/index.mdx
+++ b/website/src/content/docs/kubernetes/index.mdx
@@ -1,19 +1,13 @@
 ---
 title: Kubernetes
-description: Run Deployments, Jobs, raw manifests, and Helm charts on any Kubernetes cluster from one typed program — a kubeconfig context, a raw connection, or a managed cluster like EKS — with the cluster's adapter deciding what you get for free.
+description: Run Deployments, Jobs, raw manifests, and Helm charts on any Kubernetes cluster from one typed program; the cluster's adapter decides what you get for free.
 ---
 
-An Alchemy app on Kubernetes is **workloads** plus **objects**.
 [`Kubernetes.Deployment`](/providers/kubernetes/deployment) runs a
-server, `Kubernetes.Job` runs to completion, `Kubernetes.Manifest`
-is any Kubernetes object, and `Kubernetes.HelmChart` is a rendered
-chart. Each one points at a cluster through its `cluster` prop.
-
-That value carries a
-[connection](/kubernetes/clusters/connecting#the-connection-model).
-Its `auth.kind` selects a **cluster adapter**, and the adapter decides
-what the workload gets for free: auth only, or auth plus workload
-identity plus a managed image registry.
+server, `Kubernetes.Job` runs to completion, `Kubernetes.Manifest` is
+any object, and `Kubernetes.HelmChart` is a rendered chart. Each points
+at a cluster through its `cluster` prop, whose `auth.kind` selects a
+[cluster adapter](/kubernetes/clusters/connecting#the-connection-model).
 
 ```typescript
 // alchemy.run.ts — inside the Stack's Effect.gen body
@@ -30,109 +24,62 @@ const web = yield* Kubernetes.Deployment("Web", {
 return { url: web.url };          // LoadBalancer hostname once the cluster assigns one
 ```
 
-`KubeConfig()` returns a plain connection and appears in no plan.
-`Deployment` synthesizes a Kubernetes Deployment plus a Service via
-server-side apply. Swap `cluster` for an `AWS.EKS.Cluster` and every
-other prop stays the same.
-
-New here? [Set up a project](/kubernetes/setup), then start the
-[tutorial](/kubernetes/tutorial/part-1). It runs on a local cluster
-and costs nothing.
-
 ## What the cluster adapter gives you
 
-`Kubernetes.providers()` ships the auth-only adapters `kubeconfig`,
-`token`, `client-cert`, and `exec`. Managed-cloud adapters come from
-their provider layer and add identity and a registry. Today that is
-EKS (`aws-eks`, from `AWS.providers()`). The adapter is
-[selected by `auth.kind`](/kubernetes/clusters/connecting#how-the-adapter-is-chosen).
+`Kubernetes.providers()` ships `kubeconfig`, `token`, `client-cert`, and
+`exec`; `AWS.providers()` adds `aws-eks`
+([selection](/kubernetes/clusters/connecting#how-the-adapter-is-chosen)).
 
-| Capability | kubeconfig / token / client-cert / exec | [EKS (`aws-eks`)](/kubernetes/clusters/eks#what-the-adapter-adds) |
+| | kubeconfig / token / client-cert / exec | [EKS](/kubernetes/clusters/eks#what-the-adapter-adds) |
 | --- | --- | --- |
-| Auth | Whatever the kubeconfig says: static token, client cert, or exec plugin (`aws eks get-token`, `kubelogin`, `gke-gcloud-auth-plugin`). `token` / `client-cert` / `exec` need an [explicit `endpoint`](/kubernetes/clusters/connecting#token-client-certificate-and-exec) | SigV4/STS bearer tokens from your AWS credentials. Endpoint and CA discovered from the cluster |
-| `image:` (pre-built reference) | Used verbatim. The cluster pulls it | Mirrored into a per-workload ECR repository |
-| `main:` (bundled Effect program) / `context:` (your Dockerfile) | [Not available](/kubernetes/workloads/image-sources#registry-requirement). No registry to push to | Bundled / built and pushed to ECR |
-| Bindings | [`{ env }`](/kubernetes/workloads/bindings#the-binding-contract). Bind through environment variables | `{ env, policyStatements }`. Every AWS `Binding.Service` lands IAM statements on a generated [Pod Identity](/kubernetes/workloads/bindings#pod-identity-on-eks) role |
-| `url` from a `LoadBalancer` Service | Whatever the cluster's LB assigns. See [Local clusters](/kubernetes/clusters/local#reaching-a-service) | Internet-facing NLB via EKS Auto Mode (`loadBalancerClass` default) |
-| Providers in the Stack | `Kubernetes.providers()` | `Layer.mergeAll(AWS.providers(), Kubernetes.providers())` |
-| [Tools on the deploying machine](/kubernetes/setup#install) | `helm` only for `HelmChart` | Docker for every image source (`image` is pulled, tagged, and pushed), plus `helm` for `HelmChart` |
+| Auth | Kubeconfig or [explicit `endpoint`](/kubernetes/clusters/connecting#token-client-certificate-and-exec) | SigV4/STS tokens |
+| `image:` | Used verbatim | Mirrored into ECR |
+| `main:` / `context:` | [Not available](/kubernetes/workloads/image-sources#registry-requirement) | Pushed to ECR |
+| Bindings | [`{ env }`](/kubernetes/workloads/bindings#the-binding-contract) | `{ env, policyStatements }` via [Pod Identity](/kubernetes/workloads/bindings#pod-identity-on-eks) |
 
-Same four resources, different adapter underneath. That is why the
-tutorial runs on a local cluster and only its optional last part
-switches to EKS.
-
-:::note[EKS is one adapter, not the centre]
-Provisioning the cluster itself (Network, Cluster, AccessEntry, Addon,
-HyperPod) stays on the [AWS tab](/aws/compute/eks). This hub owns
-workloads and objects. Adapter internals live in
-[Cluster adapters](/kubernetes/guides/cluster-adapters#the-interface).
+:::note
+The cluster itself is provisioned on the [AWS tab](/aws/compute/eks).
 :::
 
 ## Clusters
 
-- **[Connecting](/kubernetes/clusters/connecting)**: the `Connection`
-  model, `KubeConfig()`, raw auth kinds, adapter selection.
-- **[Local clusters](/kubernetes/clusters/local)**: Docker Desktop,
-  OrbStack, kind, k3s. `LoadBalancer` behaviour and your own images.
-- **[EKS](/kubernetes/clusters/eks)**: STS auth, Pod Identity, ECR
-  mirroring, NLB defaults.
+- [Connecting](/kubernetes/clusters/connecting)
+- [Local clusters](/kubernetes/clusters/local)
+- [EKS](/kubernetes/clusters/eks)
 
 ## Workloads
 
-- **[Deployments](/kubernetes/workloads/deployments)**: a replicated
-  server, the analog of `AWS.ECS.Service`.
-  [Reference](/providers/kubernetes/deployment).
-- **[Jobs](/kubernetes/workloads/jobs)**: run-to-completion work, the
-  analog of `AWS.ECS.Task`. `schedule` makes a CronJob.
-  [Reference](/providers/kubernetes/job).
-- **[Image sources](/kubernetes/workloads/image-sources)**: one of
-  `image`, `context`, or `main`, and which clusters support which.
-- **[Bindings](/kubernetes/workloads/bindings)**: the
-  `{ env, policyStatements }` contract and Pod Identity.
-- **[Pod template](/kubernetes/workloads/pod-template)**: the
-  `podTemplate` escape hatch and its merge rules.
+- [Deployments](/kubernetes/workloads/deployments) (≈ `AWS.ECS.Service`)
+- [Jobs](/kubernetes/workloads/jobs) (≈ `AWS.ECS.Task`)
+- [Image sources](/kubernetes/workloads/image-sources)
+- [Bindings](/kubernetes/workloads/bindings)
+- [Pod template](/kubernetes/workloads/pod-template)
 
 ## Objects
 
-- **[Manifests](/kubernetes/objects/manifests)**: any object as a
-  literal `{ apiVersion, kind, metadata, … }`. CRDs need no
-  registration. [Reference](/providers/kubernetes/manifest).
-- **[Helm charts](/kubernetes/objects/helm)**: `helm template`, then
-  apply. No in-cluster release, no hooks.
-  [Reference](/providers/kubernetes/helmchart).
+- [Manifests](/kubernetes/objects/manifests)
+- [Helm charts](/kubernetes/objects/helm)
 
 ## Guides
 
-- **[Exposing services](/kubernetes/guides/exposing-services)**:
-  Service types, LB annotations, Ingress, Cloudflare Tunnel.
-- **[How apply works](/kubernetes/guides/how-apply-works)**:
-  server-side apply, drift, pruning, conflicts, delete order.
-- **[Cluster adapters](/kubernetes/guides/cluster-adapters)**: the
-  `ClusterAdapter` interface and registering a new `auth.kind`.
+- [Exposing services](/kubernetes/guides/exposing-services)
+- [How apply works](/kubernetes/guides/how-apply-works)
+- [Cluster adapters](/kubernetes/guides/cluster-adapters)
 
 ## What are you building?
 
-| You're building | Reach for |
+| Building | Reach for |
 | --- | --- |
-| An HTTP server from a pre-built image | [Deployment](/kubernetes/workloads/deployments#what-gets-created) with `image:`. Works on every cluster |
-| An Effect HTTP server, no Dockerfile | [Deployment](/kubernetes/workloads/deployments#effect-servers) with `main: import.meta.url` + `{ fetch }`. Needs a registry adapter ([EKS](/kubernetes/clusters/eks#what-the-adapter-adds)) |
-| A legacy app with its own Dockerfile | [Deployment](/kubernetes/workloads/deployments#what-gets-created) with `context:`. See [Image sources](/kubernetes/workloads/image-sources#three-sources) |
-| A one-off task (migration, seed) | [Job](/kubernetes/workloads/jobs#jobs) |
-| Something on a schedule | [Job](/kubernetes/workloads/jobs#cronjobs) with `schedule: "0 3 * * *"` |
-| A Namespace, ConfigMap, StatefulSet, CRD instance… | [Manifest](/kubernetes/objects/manifests#any-object) |
-| Secrets (ConfigMaps, Secrets as Manifests) | [Manifest](/kubernetes/objects/manifests#secrets) |
-| An off-the-shelf chart (ingress-nginx, podinfo, Karpenter) | [HelmChart](/kubernetes/objects/helm#chart-sources) |
-| AWS access from a Pod (S3, DynamoDB, SQS…) | Any AWS `Binding.Service` on a Deployment/Job. [Pod Identity](/kubernetes/workloads/bindings#pod-identity-on-eks) |
-| A public URL | `serviceType: "LoadBalancer"` → `url`. See [Exposing services](/kubernetes/guides/exposing-services#service-types) |
-| A domain + TLS in front of it | [Ingress](/kubernetes/guides/exposing-services#ingress) or [Cloudflare Tunnel](/kubernetes/guides/exposing-services#cloudflare-tunnel) |
-| GPU / spot / ARM placement | [podTemplate recipes](/kubernetes/workloads/pod-template#recipes) |
-| The EKS cluster itself | [`AWS.EKS.Cluster`](/aws/compute/eks) on the AWS tab |
-| A cluster Alchemy can't reach yet (GKE identity, AKS…) | `KubeConfig()` today ([Connecting](/kubernetes/clusters/connecting#kubeconfig)). Write an adapter for identity/registry ([Cluster adapters](/kubernetes/guides/cluster-adapters#registering-an-auth-kind)) |
+| A server from a pre-built image | [Deployment](/kubernetes/workloads/deployments#what-gets-created) with `image:` |
+| An Effect server | [Deployment](/kubernetes/workloads/deployments#effect-servers) with `main:` (EKS only) |
+| A one-off or scheduled task | [Job](/kubernetes/workloads/jobs#jobs) / [CronJob](/kubernetes/workloads/jobs#cronjobs) |
+| Any other object | [Manifest](/kubernetes/objects/manifests#any-object) |
+| An off-the-shelf chart | [HelmChart](/kubernetes/objects/helm#chart-sources) |
+| AWS access from a Pod | [Pod Identity](/kubernetes/workloads/bindings#pod-identity-on-eks) |
+| A public URL | [Exposing services](/kubernetes/guides/exposing-services#service-types) |
 
 ## Where next
 
-- [Setup](/kubernetes/setup): install, pick a cluster, plan your first
-  manifest.
-- [Tutorial](/kubernetes/tutorial/part-1): a Deployment, a Job,
-  manifests, and a Helm chart on a local cluster, then optionally EKS.
-- [Providers reference](/providers): generated API docs.
+- [Setup](/kubernetes/setup)
+- [Tutorial](/kubernetes/tutorial/part-1)
+- [Providers reference](/providers)

--- a/website/src/content/docs/kubernetes/index.mdx
+++ b/website/src/content/docs/kubernetes/index.mdx
@@ -1,44 +1,43 @@
 ---
 title: Kubernetes
-description: Run Deployments, Jobs, raw manifests, and Helm charts on any Kubernetes cluster from one typed program; the cluster's adapter decides what you get for free.
+description: Deploy servers, jobs, manifests, and Helm charts to any Kubernetes cluster with Alchemy.
 ---
 
 [`Kubernetes.Deployment`](/providers/kubernetes/deployment) runs a
-server, `Kubernetes.Job` runs to completion, `Kubernetes.Manifest` is
-any object, and `Kubernetes.HelmChart` is a rendered chart. Each points
-at a cluster through its `cluster` prop, whose `auth.kind` selects a
-[cluster adapter](/kubernetes/clusters/connecting#the-connection-model).
+server, `Kubernetes.Job` runs a container to completion,
+`Kubernetes.Manifest` applies any object, and `Kubernetes.HelmChart`
+installs a chart. Point each at a cluster with its
+[`cluster` prop](/kubernetes/clusters/connecting#what-cluster-accepts).
 
 ```typescript
 // alchemy.run.ts — inside the Stack's Effect.gen body
-const local = Kubernetes.KubeConfig({ context: "docker-desktop" }); // any cluster kubectl can reach
-// const cluster = yield* AWS.EKS.Cluster("Cluster", { compute: "auto", /* … */ }); // …or a managed one
+const local = Kubernetes.KubeConfig({ context: "docker-desktop" }); // any context in your kubeconfig
+// const cluster = yield* AWS.EKS.Cluster("Cluster", { compute: "auto", /* … */ }); // …or an EKS cluster
 
 const web = yield* Kubernetes.Deployment("Web", {
-  cluster: local,                 // ← the only line that changes between clusters
+  cluster: local,                 // swap this to target another cluster
   image: "nginx:1.27",
   port: 80,
   replicas: 2,
 });
 
-return { url: web.url };          // LoadBalancer hostname once the cluster assigns one
+return { url: web.url };          // the LoadBalancer hostname, once the cluster assigns one
 ```
 
-## What the cluster adapter gives you
+## What each cluster supports
 
-`Kubernetes.providers()` ships `kubeconfig`, `token`, `client-cert`, and
-`exec`; `AWS.providers()` adds `aws-eks`
-([selection](/kubernetes/clusters/connecting#how-the-adapter-is-chosen)).
+Any cluster runs pre-built images. EKS also builds your own and gives
+Pods AWS access; add `AWS.providers()` beside `Kubernetes.providers()`.
 
-| | kubeconfig / token / client-cert / exec | [EKS](/kubernetes/clusters/eks#what-the-adapter-adds) |
+| | Any other cluster | [EKS](/kubernetes/clusters/eks#what-eks-adds) |
 | --- | --- | --- |
-| Auth | Kubeconfig or [explicit `endpoint`](/kubernetes/clusters/connecting#token-client-certificate-and-exec) | SigV4/STS tokens |
-| `image:` | Used verbatim | Mirrored into ECR |
-| `main:` / `context:` | [Not available](/kubernetes/workloads/image-sources#registry-requirement) | Pushed to ECR |
-| Bindings | [`{ env }`](/kubernetes/workloads/bindings#the-binding-contract) | `{ env, policyStatements }` via [Pod Identity](/kubernetes/workloads/bindings#pod-identity-on-eks) |
+| Auth | Kubeconfig, [token, cert, or exec](/kubernetes/clusters/connecting#token-client-certificate-and-exec) | Your AWS credentials |
+| `image:` | Used as-is | Copied to ECR |
+| `main:` / `context:` | [Not available](/kubernetes/workloads/image-sources#registry-requirement) | Built and pushed to ECR |
+| Bindings | [Env vars](/kubernetes/workloads/bindings#bind-a-resource) | Env vars + [Pod Identity](/kubernetes/workloads/bindings#pod-identity-on-eks) |
 
 :::note
-The cluster itself is provisioned on the [AWS tab](/aws/compute/eks).
+Create the EKS cluster on the [AWS tab](/aws/compute/eks).
 :::
 
 ## Clusters
@@ -49,8 +48,8 @@ The cluster itself is provisioned on the [AWS tab](/aws/compute/eks).
 
 ## Workloads
 
-- [Deployments](/kubernetes/workloads/deployments) (≈ `AWS.ECS.Service`)
-- [Jobs](/kubernetes/workloads/jobs) (≈ `AWS.ECS.Task`)
+- [Deployments](/kubernetes/workloads/deployments)
+- [Jobs](/kubernetes/workloads/jobs)
 - [Image sources](/kubernetes/workloads/image-sources)
 - [Bindings](/kubernetes/workloads/bindings)
 - [Pod template](/kubernetes/workloads/pod-template)
@@ -68,7 +67,7 @@ The cluster itself is provisioned on the [AWS tab](/aws/compute/eks).
 
 ## What are you building?
 
-| Building | Reach for |
+| Building | Use |
 | --- | --- |
 | A server from a pre-built image | [Deployment](/kubernetes/workloads/deployments#what-gets-created) with `image:` |
 | An Effect server | [Deployment](/kubernetes/workloads/deployments#effect-servers) with `main:` (EKS only) |

--- a/website/src/content/docs/kubernetes/objects/helm.mdx
+++ b/website/src/content/docs/kubernetes/objects/helm.mdx
@@ -1,27 +1,27 @@
 ---
 title: Helm charts
-description: Install a Helm chart from a repository, an OCI registry, or a local directory with Kubernetes.HelmChart — rendered locally with helm template, applied and owned by Alchemy, with no in-cluster release and no hooks.
+description: Install a Helm chart from a repository, an OCI registry, or a local directory with Kubernetes.HelmChart.
 ---
 
 [`Kubernetes.HelmChart`](/providers/kubernetes/helmchart) renders a
-chart locally with the `helm` CLI and applies the objects like a
-[Manifest](/kubernetes/objects/manifests#any-object). You need only
-the binary ([Setup](/kubernetes/setup#install)); `HELM_BIN` overrides
-its path.
+chart with the `helm` CLI on your machine and applies the objects like
+a [Manifest](/kubernetes/objects/manifests#any-object).
+[Install helm](/kubernetes/setup#install) first; set `HELM_BIN` to use
+a specific binary.
 
 ## Chart sources
 
-`chart` takes three forms: a repository chart name with `repo`, an
-`oci://` reference, or a local directory, which is content-hashed so a
-template edit shows as an update in `alchemy plan`.
+Set `chart` to a chart name with `repo`, an `oci://` reference, or a
+local directory. Edits to a local chart show as an update in
+`alchemy plan`.
 
 ```typescript
-// 1. Repository chart — repo URL is passed per render, no `helm repo add`.
+// 1. Repository chart: no `helm repo add` needed.
 const ingress = yield* Kubernetes.HelmChart("IngressNginx", {
   cluster,
   chart: "ingress-nginx",
   repo: "https://kubernetes.github.io/ingress-nginx",
-  version: "4.11.2", // pin it (see Values)
+  version: "4.11.2", // pin it
   namespace: "ingress-nginx",
   createNamespace: true,
 });
@@ -34,33 +34,31 @@ const karpenter = yield* Kubernetes.HelmChart("Karpenter", {
   namespace: "kube-system",
 });
 
-// 3. Local chart directory — content-hashed; template edits show in `plan`.
+// 3. Local chart directory: template edits show in `alchemy plan`.
 const app = yield* Kubernetes.HelmChart("App", {
   cluster,
   chart: "./charts/app",
   values: { image: { tag: "v1.2.3" } },
 });
 
-ingress.releaseName; // "<stack>-<id>-<stage>-<suffix>", lowercased, capped at 53 chars, unless you set releaseName
+ingress.releaseName; // generated from stack, stage, and id unless you set releaseName
 ingress.objects; // KubernetesObjectRef[] — every applied object
-ingress.code.hash; // hash of all render inputs (+ local chart files)
 ```
 
-Identity is the cluster, `releaseName`, and `namespace` (default
-`"default"`); changing any of those is a replace. Set `releaseName`
-when the chart names objects from `.Release.Name` and the names matter.
+Changing `releaseName` or `namespace` (default `"default"`) replaces
+the release. Set `releaseName` when the chart names objects after
+`.Release.Name` and you care about those names.
 
 ## Values
 
-`values` has exactly the shape of a `values.yaml`.
-[Outputs](/infrastructure-as-code/outputs) work anywhere inside it and
-order the chart after the referenced resource, like
-[`namespace: ns.name`](/kubernetes/objects/manifests#namespaces).
-Secret values follow the [Secret Manifest](/kubernetes/objects/manifests#secrets)
-rule: `Config.string`, never `Redacted`.
+`values` has the same shape as `values.yaml`. Put
+[outputs](/infrastructure-as-code/outputs) anywhere inside it and the
+chart deploys after the resource they come from, like
+[`namespace: ns.name`](/kubernetes/objects/manifests#namespaces). For
+secrets use `Config.string`, never `Redacted`
+([Secrets](/kubernetes/objects/manifests#secrets)).
 
-Pin `version`: the resource's hash contains only your inputs, so an
-unpinned chart can silently jump versions on an unrelated edit.
+Pin `version`. Without it, an unrelated edit can pull a newer chart.
 
 ```typescript
 const podinfo = yield* Kubernetes.HelmChart("Podinfo", {
@@ -68,10 +66,10 @@ const podinfo = yield* Kubernetes.HelmChart("Podinfo", {
   chart: "podinfo",
   repo: "https://stefanprodan.github.io/podinfo",
   version: "6.14.1", // bump this to upgrade; never leave it off
-  namespace: ns.name, // output → chart applies after the Namespace
+  namespace: ns.name, // deploys after the Namespace
   releaseName: "podinfo", // .Release.Name; default derives from stack/stage/id
   values: {
-    // === values.yaml
+    // same keys as values.yaml
     replicaCount: 2,
     ui: { color: "#34577c", message: "Deployed by Alchemy" },
     service: { type: "ClusterIP" },
@@ -82,27 +80,24 @@ const podinfo = yield* Kubernetes.HelmChart("Podinfo", {
 
 ## Lifecycle
 
-Every reconcile runs
-`helm template <releaseName> <chart> --namespace <ns> --no-hooks`
-locally, fills in `metadata.namespace` on namespaced objects that omit
-it, prunes objects that dropped out of the render since the last
-deploy (in reverse apply order), then
-[server-side applies](/kubernetes/guides/how-apply-works#server-side-apply)
-the rest in dependency rank order. A template error is a typed
-`HelmError` carrying helm's stderr.
+Each deploy runs
+`helm template <releaseName> <chart> --namespace <ns> --no-hooks` on
+your machine, sets `metadata.namespace` on objects that omit it,
+deletes objects that are no longer rendered, then
+[applies](/kubernetes/guides/how-apply-works#server-side-apply) the
+rest. If the template fails, you see helm's error output.
 
-Destroy deletes every ref in `objects` in reverse rank order. With
-`createNamespace: true` the Namespace is managed too, so destroy
-deletes it and everything in it; prefer a
-[Namespace Manifest](/kubernetes/objects/manifests#namespaces) when
-other resources share it. The full render is re-applied on any input
-change or `alchemy deploy --force`
-([pruning and drift](/kubernetes/guides/how-apply-works#pruning-and-drift)).
+`alchemy destroy` deletes every object in `objects`. With
+`createNamespace: true` it also deletes the Namespace and everything
+in it, so if other resources share the namespace, create it with a
+[Namespace Manifest](/kubernetes/objects/manifests#namespaces) instead.
+Any input change, or `alchemy deploy --force`, re-applies the whole
+chart and [corrects drift](/kubernetes/guides/how-apply-works#pruning-and-drift).
 
-:::caution[CRDs are part of the managed set by default]
-`includeCrds: true` deletes the chart's CRDs on destroy, taking every
+:::caution[CRDs are deleted on destroy]
+By default `alchemy destroy` deletes the chart's CRDs and every
 [custom resource](/kubernetes/objects/manifests#custom-resources) of
-that kind with them; set `includeCrds: false` if other stacks rely on them.
+those kinds. Set `includeCrds: false` if other stacks depend on them.
 :::
 
 ```typescript
@@ -112,27 +107,24 @@ const podinfo = yield* Kubernetes.HelmChart("Podinfo", {
   repo: "https://stefanprodan.github.io/podinfo",
   version: "6.14.1",
   namespace: ns.name,
-  includeCrds: false, // keep CRDs out of this stack's managed set
-  // Turning a template off drops its objects from the render; on the next
-  // deploy they are pruned (deleted first), then the rest is re-applied.
-  // Here the chart stops rendering its Service, so the deploy logs
-  // `Applying 2 objects from podinfo...` and the Service is pruned.
+  includeCrds: false, // don't apply or delete the chart's CRDs
+  // Disabling the Service removes it from the render. The next deploy
+  // deletes it first, then re-applies the rest and logs
+  // `Applying 2 objects from podinfo...`.
   values: { service: { enabled: false } },
 });
 ```
 
 ## What Helm does that Alchemy doesn't
 
-`HelmChart` is a template engine, not a package manager: no release
-record (`helm ls`, `helm rollback`, `helm test`), no `--wait`, and
-no hooks, which are neither executed nor applied. Express a hook's
-work as a [`Kubernetes.Job`](/kubernetes/workloads/jobs#jobs) you own.
+There is no Helm release in the cluster: `helm ls`, `helm rollback`,
+and `helm test` don't see it, deploy doesn't `--wait`, and hooks
+(`helm.sh/hook`) are neither applied nor run. Replace a hook with a
+[`Kubernetes.Job`](/kubernetes/workloads/jobs#jobs).
 
 ```typescript
-// A chart's pre-upgrade migration hook never runs under HelmChart.
-// Own the migration instead and order the chart after it: put the Job's
-// output in a harmless values key — the value doesn't matter, the reference
-// creates the edge (same idiom as `namespace: ns.name`).
+// The chart's pre-upgrade migration hook won't run. Run the migration as
+// a Job and reference its output from `values` so the chart deploys after it.
 const migrate = yield* Kubernetes.Job("Migrate", {
   cluster,
   image: "ghcr.io/acme/migrator:v3",
@@ -143,7 +135,7 @@ const app = yield* Kubernetes.HelmChart("App", {
   cluster,
   chart: "./charts/app",
   namespace: ns.name,
-  values: { migratedBy: migrate.jobName }, // ordering edge: chart applies after the Job
+  values: { migratedBy: migrate.jobName }, // chart deploys after the Job
 });
 ```
 

--- a/website/src/content/docs/kubernetes/objects/helm.mdx
+++ b/website/src/content/docs/kubernetes/objects/helm.mdx
@@ -4,20 +4,16 @@ description: Install a Helm chart from a repository, an OCI registry, or a local
 ---
 
 [`Kubernetes.HelmChart`](/providers/kubernetes/helmchart) renders a
-chart on your machine with the `helm` CLI and applies the objects the
-way a [Manifest](/kubernetes/objects/manifests#any-object) is
-applied. You need only the binary; see
-[Setup](/kubernetes/setup#install) for installing it. `HELM_BIN`
-overrides its path. A missing binary fails the deploy with
-`Failed to run 'helm': … install it (https://helm.sh/docs/intro/install/) or point HELM_BIN at the binary`.
+chart locally with the `helm` CLI and applies the objects like a
+[Manifest](/kubernetes/objects/manifests#any-object). You need only
+the binary ([Setup](/kubernetes/setup#install)); `HELM_BIN` overrides
+its path.
 
 ## Chart sources
 
-`chart` takes three forms. A repository chart name with `repo`
-becomes `--repo` on every render, with no `helm repo add` step. An
-`oci://` reference needs no `repo`. A local directory is any path on
-disk: `version` is ignored and the directory is content-hashed into
-`code.hash`, so a template edit shows as an update in `alchemy plan`.
+`chart` takes three forms: a repository chart name with `repo`, an
+`oci://` reference, or a local directory, which is content-hashed so a
+template edit shows as an update in `alchemy plan`.
 
 ```typescript
 // 1. Repository chart — repo URL is passed per render, no `helm repo add`.
@@ -50,44 +46,21 @@ ingress.objects; // KubernetesObjectRef[] — every applied object
 ingress.code.hash; // hash of all render inputs (+ local chart files)
 ```
 
-The chart's objects share one identity: the cluster, `releaseName`,
-and `namespace` (default `"default"`). Changing any of those is a
-replace. Changing `chart`, `repo`, `version`, `values`,
-`includeCrds`, `createNamespace`, or a local chart's contents is an
-update.
-
-The default `releaseName` derives from the stack, stage, and logical
-id, lowercased and capped at Helm's 53-character limit
-(`createPhysicalName({ maxLength: 53 })`), for example
-`kuberneteslocalexample-podinfgxktg4nyz5zvh4jz6du2ewxf`. Charts that
-name objects from `.Release.Name` then name them differently, so set
-`releaseName` when the names matter.
+Identity is the cluster, `releaseName`, and `namespace` (default
+`"default"`); changing any of those is a replace. Set `releaseName`
+when the chart names objects from `.Release.Name` and the names matter.
 
 ## Values
 
-`values` has exactly the shape of a `values.yaml`. It is written to a
-temporary `values.json` and passed as `--values`. An empty object
-passes nothing.
+`values` has exactly the shape of a `values.yaml`.
+[Outputs](/infrastructure-as-code/outputs) work anywhere inside it and
+order the chart after the referenced resource, like
+[`namespace: ns.name`](/kubernetes/objects/manifests#namespaces).
+Secret values follow the [Secret Manifest](/kubernetes/objects/manifests#secrets)
+rule: `Config.string`, never `Redacted`.
 
-[Outputs](/infrastructure-as-code/outputs) work anywhere inside
-`values` and order the chart after the referenced resource, the same
-way [`namespace: ns.name`](/kubernetes/objects/manifests#namespaces)
-does. Secret values follow the
-[Secret Manifest](/kubernetes/objects/manifests#secrets) rule:
-`Config.string`, never `Redacted`, which would render as
-`<redacted>`.
-
-Pin `version` for repository and OCI charts. Without it Helm resolves
-the latest chart at render time, but the resource's hash contains
-only your inputs, so an unchanged stack no-ops until an unrelated
-`values` edit re-renders and silently jumps versions. With a pin, an
-upgrade is a `version` bump and a visible object delta in the plan.
-
-`releaseName` feeds `.Release.Name` and `namespace` feeds
-`.Release.Namespace`, so templates render exactly as under
-`helm install`. When taking over objects Helm installed under a known
-name, set `releaseName` to match and read the ownership caution under
-[Lifecycle](#lifecycle) first.
+Pin `version`: the resource's hash contains only your inputs, so an
+unpinned chart can silently jump versions on an unrelated edit.
 
 ```typescript
 const podinfo = yield* Kubernetes.HelmChart("Podinfo", {
@@ -109,61 +82,27 @@ const podinfo = yield* Kubernetes.HelmChart("Podinfo", {
 
 ## Lifecycle
 
-Every reconcile runs the same sequence.
-
-Render runs
+Every reconcile runs
 `helm template <releaseName> <chart> --namespace <ns> --no-hooks`
-locally, plus `--repo`, `--version`, `--include-crds`, and `--values`
-as configured. The output is parsed as multi-document YAML. Every
-object must carry `apiVersion`, `kind`, and `metadata.name`;
-`generateName` alone fails the render because server-side apply
-needs a concrete name. A bad chart reference or template error is a
-typed `HelmError` carrying helm's stderr.
+locally, fills in `metadata.namespace` on namespaced objects that omit
+it, prunes objects that dropped out of the render since the last
+deploy (in reverse apply order), then
+[server-side applies](/kubernetes/guides/how-apply-works#server-side-apply)
+the rest in dependency rank order. A template error is a typed
+`HelmError` carrying helm's stderr.
 
-Charts routinely omit `metadata.namespace`. For each object without
-one the provider resolves the kind's scope, by static table or
-discovery as Manifest does, and sets `metadata.namespace` on
-namespaced kinds. Cluster-scoped kinds and objects with their own
-namespace pass through untouched. With `createNamespace: true` and a
-`namespace` other than `"default"`, a `v1/Namespace` object is
-prepended to the managed set, so it is owned and deleted on destroy.
-
-The previous deploy's `objects` attribute is compared with the new
-render by (`apiVersion`, `kind`, `namespace`, `name`). Anything that
-dropped out is deleted first, in reverse apply order. That is what
-happens when a value turns a template off.
-
-The desired objects are then
-[server-side applied](/kubernetes/guides/how-apply-works#server-side-apply)
-in dependency rank order: Namespaces and CRDs first, workloads later,
-discovered kinds last. The attributes record `connection`,
-`releaseName`, `namespace`, `chart`, `version`, `objects` (the prune
-baseline for the next deploy), and `code.hash`.
-
-Destroy deletes every ref in `objects` in reverse rank order: CRs
-before CRDs, workloads before Services and ConfigMaps, the Namespace
-last. 404s are ignored. If the cluster is gone the delete is a no-op.
-
-The whole render is re-applied on any input change or
-`alchemy deploy --force`, so manual edits to chart-managed fields are
-overwritten then. An unchanged stack no-ops, and refresh checks only
-that the cluster is reachable, not each object.
-[Pruning and drift](/kubernetes/guides/how-apply-works#pruning-and-drift)
-has the full model.
+Destroy deletes every ref in `objects` in reverse rank order. With
+`createNamespace: true` the Namespace is managed too, so destroy
+deletes it and everything in it; prefer a
+[Namespace Manifest](/kubernetes/objects/manifests#namespaces) when
+other resources share it. The full render is re-applied on any input
+change or `alchemy deploy --force`
+([pruning and drift](/kubernetes/guides/how-apply-works#pruning-and-drift)).
 
 :::caution[CRDs are part of the managed set by default]
-`includeCrds: true` applies the chart's `crds/` directory, so a CRD
-is re-applied on every reconcile and deleted on destroy, taking every
+`includeCrds: true` deletes the chart's CRDs on destroy, taking every
 [custom resource](/kubernetes/objects/manifests#custom-resources) of
-that kind with it. If other stacks or teams rely on the CRDs, set
-`includeCrds: false` and manage them separately.
-:::
-
-:::caution[`createNamespace: true` owns the Namespace]
-Destroy deletes it and everything else that lives there. When other
-resources share the namespace, prefer a
-[Namespace Manifest](/kubernetes/objects/manifests#namespaces) you
-control explicitly.
+that kind with them; set `includeCrds: false` if other stacks rely on them.
 :::
 
 ```typescript
@@ -184,28 +123,10 @@ const podinfo = yield* Kubernetes.HelmChart("Podinfo", {
 
 ## What Helm does that Alchemy doesn't
 
-`HelmChart` uses Helm as a template engine, not a package manager.
-
-| Helm (`helm install`) | `Kubernetes.HelmChart` | If you need it |
-| --- | --- | --- |
-| Writes a release record in the cluster; `helm ls`, `helm status`, `helm rollback` work | No release record. State is the `objects` attribute; rollback is redeploying the previous inputs | Install with Helm directly |
-| Runs lifecycle hooks (`helm.sh/hook`) with weights and delete policies | Rendered with `--no-hooks`, and hook-annotated objects are filtered by the parser, so they are neither executed nor applied | Install with Helm, or express the hook's work as a [`Kubernetes.Job`](/kubernetes/workloads/jobs#jobs) you own |
-| Three-way merge; never touches CRDs after install | Server-side apply against live state; CRDs managed by default | See the `includeCrds` caution under [Lifecycle](#lifecycle) |
-| `--create-namespace` creates but does not own the namespace | `createNamespace: true` owns it | See the `createNamespace` caution under [Lifecycle](#lifecycle) |
-| `helm test` | Not available (tests are hooks) | Run the test Pod as a `Kubernetes.Job` |
-| Waits for readiness with `--wait` | Returns once the API server accepts the objects | Check readiness out of band (`kubectl rollout status`) |
-
-If a chart's README says it relies on hooks, or you need
-`helm rollback`, use Helm. If you want the chart's objects in the
-same plan as your workloads, drift-corrected and pruned, use
-`HelmChart`. Hooks are excluded twice because a chart's `pre-delete`
-uninstall Job, applied as an ordinary object, would otherwise run on
-every deploy.
-
-Taking over objects a Helm release installed seizes their fields
-from the `helm` field manager; see
-[conflicts](/kubernetes/guides/how-apply-works#conflicts) for what
-`force` does there. Owning a hook's work yourself looks like this.
+`HelmChart` is a template engine, not a package manager: no release
+record (`helm ls`, `helm rollback`, `helm test`), no `--wait`, and
+no hooks, which are neither executed nor applied. Express a hook's
+work as a [`Kubernetes.Job`](/kubernetes/workloads/jobs#jobs) you own.
 
 ```typescript
 // A chart's pre-upgrade migration hook never runs under HelmChart.
@@ -226,46 +147,8 @@ const app = yield* Kubernetes.HelmChart("App", {
 });
 ```
 
-## Combining with Manifests and Deployments
-
-The API server accepts an Ingress whose class nobody has installed
-yet, so a chart-installed controller and the Ingress that uses it
-have no natural edge. To apply the Ingress only after the controller,
-carry a chart output in a harmless field, the
-[same idiom](/kubernetes/objects/manifests#namespaces) as
-`namespace: ns.name`.
-
-```typescript
-const route = yield* Kubernetes.Manifest("ApiIngress", {
-  cluster,
-  manifest: {
-    apiVersion: "networking.k8s.io/v1",
-    kind: "Ingress",
-    metadata: {
-      name: "api",
-      namespace: ns.name,
-      // Ordering edge: the value is irrelevant, the reference applies the
-      // Ingress after the ingress-nginx chart.
-      annotations: {
-        "alchemy.run/ingress-controller": ingressNginx.releaseName,
-      },
-    },
-    spec: { ingressClassName: "nginx", rules: [/* ... */] },
-  },
-});
-```
-
-The full controller, ClusterIP Deployment, and Ingress are in the
-[Ingress](/kubernetes/guides/exposing-services#ingress) section of
-the exposing-services guide.
-
 ## Where next
 
-- [Exposing services](/kubernetes/guides/exposing-services) — Service
-  types, LB annotations, Ingress, Cloudflare Tunnel.
+- [Exposing services](/kubernetes/guides/exposing-services)
 - [How apply works](/kubernetes/guides/how-apply-works#pruning-and-drift)
-  — field manager, pruning, drift, conflicts, delete order, debugging.
-- [Custom resources](/kubernetes/objects/manifests#custom-resources)
-  — the CRs that drive a chart-installed operator are Manifests.
-- [`HelmChart` reference](/providers/kubernetes/helmchart) — every
-  prop and attribute.
+- [`HelmChart` reference](/providers/kubernetes/helmchart)

--- a/website/src/content/docs/kubernetes/objects/helm.mdx
+++ b/website/src/content/docs/kubernetes/objects/helm.mdx
@@ -1,0 +1,271 @@
+---
+title: Helm charts
+description: Install a Helm chart from a repository, an OCI registry, or a local directory with Kubernetes.HelmChart — rendered locally with helm template, applied and owned by Alchemy, with no in-cluster release and no hooks.
+---
+
+[`Kubernetes.HelmChart`](/providers/kubernetes/helmchart) renders a
+chart on your machine with the `helm` CLI and applies the objects the
+way a [Manifest](/kubernetes/objects/manifests#any-object) is
+applied. You need only the binary; see
+[Setup](/kubernetes/setup#install) for installing it. `HELM_BIN`
+overrides its path. A missing binary fails the deploy with
+`Failed to run 'helm': … install it (https://helm.sh/docs/intro/install/) or point HELM_BIN at the binary`.
+
+## Chart sources
+
+`chart` takes three forms. A repository chart name with `repo`
+becomes `--repo` on every render, with no `helm repo add` step. An
+`oci://` reference needs no `repo`. A local directory is any path on
+disk: `version` is ignored and the directory is content-hashed into
+`code.hash`, so a template edit shows as an update in `alchemy plan`.
+
+```typescript
+// 1. Repository chart — repo URL is passed per render, no `helm repo add`.
+const ingress = yield* Kubernetes.HelmChart("IngressNginx", {
+  cluster,
+  chart: "ingress-nginx",
+  repo: "https://kubernetes.github.io/ingress-nginx",
+  version: "4.11.2", // pin it (see Values)
+  namespace: "ingress-nginx",
+  createNamespace: true,
+});
+
+// 2. OCI reference — no `repo`.
+const karpenter = yield* Kubernetes.HelmChart("Karpenter", {
+  cluster,
+  chart: "oci://public.ecr.aws/karpenter/karpenter",
+  version: "1.0.6",
+  namespace: "kube-system",
+});
+
+// 3. Local chart directory — content-hashed; template edits show in `plan`.
+const app = yield* Kubernetes.HelmChart("App", {
+  cluster,
+  chart: "./charts/app",
+  values: { image: { tag: "v1.2.3" } },
+});
+
+ingress.releaseName; // "<stack>-<id>-<stage>-<suffix>", lowercased, capped at 53 chars, unless you set releaseName
+ingress.objects; // KubernetesObjectRef[] — every applied object
+ingress.code.hash; // hash of all render inputs (+ local chart files)
+```
+
+The chart's objects share one identity: the cluster, `releaseName`,
+and `namespace` (default `"default"`). Changing any of those is a
+replace. Changing `chart`, `repo`, `version`, `values`,
+`includeCrds`, `createNamespace`, or a local chart's contents is an
+update.
+
+The default `releaseName` derives from the stack, stage, and logical
+id, lowercased and capped at Helm's 53-character limit
+(`createPhysicalName({ maxLength: 53 })`), for example
+`kuberneteslocalexample-podinfgxktg4nyz5zvh4jz6du2ewxf`. Charts that
+name objects from `.Release.Name` then name them differently, so set
+`releaseName` when the names matter.
+
+## Values
+
+`values` has exactly the shape of a `values.yaml`. It is written to a
+temporary `values.json` and passed as `--values`. An empty object
+passes nothing.
+
+[Outputs](/infrastructure-as-code/outputs) work anywhere inside
+`values` and order the chart after the referenced resource, the same
+way [`namespace: ns.name`](/kubernetes/objects/manifests#namespaces)
+does. Secret values follow the
+[Secret Manifest](/kubernetes/objects/manifests#secrets) rule:
+`Config.string`, never `Redacted`, which would render as
+`<redacted>`.
+
+Pin `version` for repository and OCI charts. Without it Helm resolves
+the latest chart at render time, but the resource's hash contains
+only your inputs, so an unchanged stack no-ops until an unrelated
+`values` edit re-renders and silently jumps versions. With a pin, an
+upgrade is a `version` bump and a visible object delta in the plan.
+
+`releaseName` feeds `.Release.Name` and `namespace` feeds
+`.Release.Namespace`, so templates render exactly as under
+`helm install`. When taking over objects Helm installed under a known
+name, set `releaseName` to match and read the ownership caution under
+[Lifecycle](#lifecycle) first.
+
+```typescript
+const podinfo = yield* Kubernetes.HelmChart("Podinfo", {
+  cluster,
+  chart: "podinfo",
+  repo: "https://stefanprodan.github.io/podinfo",
+  version: "6.14.1", // bump this to upgrade; never leave it off
+  namespace: ns.name, // output → chart applies after the Namespace
+  releaseName: "podinfo", // .Release.Name; default derives from stack/stage/id
+  values: {
+    // === values.yaml
+    replicaCount: 2,
+    ui: { color: "#34577c", message: "Deployed by Alchemy" },
+    service: { type: "ClusterIP" },
+    // Outputs are fine anywhere: e.g. backend: { url: api.url }
+  },
+});
+```
+
+## Lifecycle
+
+Every reconcile runs the same sequence.
+
+Render runs
+`helm template <releaseName> <chart> --namespace <ns> --no-hooks`
+locally, plus `--repo`, `--version`, `--include-crds`, and `--values`
+as configured. The output is parsed as multi-document YAML. Every
+object must carry `apiVersion`, `kind`, and `metadata.name`;
+`generateName` alone fails the render because server-side apply
+needs a concrete name. A bad chart reference or template error is a
+typed `HelmError` carrying helm's stderr.
+
+Charts routinely omit `metadata.namespace`. For each object without
+one the provider resolves the kind's scope, by static table or
+discovery as Manifest does, and sets `metadata.namespace` on
+namespaced kinds. Cluster-scoped kinds and objects with their own
+namespace pass through untouched. With `createNamespace: true` and a
+`namespace` other than `"default"`, a `v1/Namespace` object is
+prepended to the managed set, so it is owned and deleted on destroy.
+
+The previous deploy's `objects` attribute is compared with the new
+render by (`apiVersion`, `kind`, `namespace`, `name`). Anything that
+dropped out is deleted first, in reverse apply order. That is what
+happens when a value turns a template off.
+
+The desired objects are then
+[server-side applied](/kubernetes/guides/how-apply-works#server-side-apply)
+in dependency rank order: Namespaces and CRDs first, workloads later,
+discovered kinds last. The attributes record `connection`,
+`releaseName`, `namespace`, `chart`, `version`, `objects` (the prune
+baseline for the next deploy), and `code.hash`.
+
+Destroy deletes every ref in `objects` in reverse rank order: CRs
+before CRDs, workloads before Services and ConfigMaps, the Namespace
+last. 404s are ignored. If the cluster is gone the delete is a no-op.
+
+The whole render is re-applied on any input change or
+`alchemy deploy --force`, so manual edits to chart-managed fields are
+overwritten then. An unchanged stack no-ops, and refresh checks only
+that the cluster is reachable, not each object.
+[Pruning and drift](/kubernetes/guides/how-apply-works#pruning-and-drift)
+has the full model.
+
+:::caution[CRDs are part of the managed set by default]
+`includeCrds: true` applies the chart's `crds/` directory, so a CRD
+is re-applied on every reconcile and deleted on destroy, taking every
+[custom resource](/kubernetes/objects/manifests#custom-resources) of
+that kind with it. If other stacks or teams rely on the CRDs, set
+`includeCrds: false` and manage them separately.
+:::
+
+:::caution[`createNamespace: true` owns the Namespace]
+Destroy deletes it and everything else that lives there. When other
+resources share the namespace, prefer a
+[Namespace Manifest](/kubernetes/objects/manifests#namespaces) you
+control explicitly.
+:::
+
+```typescript
+const podinfo = yield* Kubernetes.HelmChart("Podinfo", {
+  cluster,
+  chart: "podinfo",
+  repo: "https://stefanprodan.github.io/podinfo",
+  version: "6.14.1",
+  namespace: ns.name,
+  includeCrds: false, // keep CRDs out of this stack's managed set
+  // Turning a template off drops its objects from the render; on the next
+  // deploy they are pruned (deleted first), then the rest is re-applied.
+  // Here the chart stops rendering its Service, so the deploy logs
+  // `Applying 2 objects from podinfo...` and the Service is pruned.
+  values: { service: { enabled: false } },
+});
+```
+
+## What Helm does that Alchemy doesn't
+
+`HelmChart` uses Helm as a template engine, not a package manager.
+
+| Helm (`helm install`) | `Kubernetes.HelmChart` | If you need it |
+| --- | --- | --- |
+| Writes a release record in the cluster; `helm ls`, `helm status`, `helm rollback` work | No release record. State is the `objects` attribute; rollback is redeploying the previous inputs | Install with Helm directly |
+| Runs lifecycle hooks (`helm.sh/hook`) with weights and delete policies | Rendered with `--no-hooks`, and hook-annotated objects are filtered by the parser, so they are neither executed nor applied | Install with Helm, or express the hook's work as a [`Kubernetes.Job`](/kubernetes/workloads/jobs#jobs) you own |
+| Three-way merge; never touches CRDs after install | Server-side apply against live state; CRDs managed by default | See the `includeCrds` caution under [Lifecycle](#lifecycle) |
+| `--create-namespace` creates but does not own the namespace | `createNamespace: true` owns it | See the `createNamespace` caution under [Lifecycle](#lifecycle) |
+| `helm test` | Not available (tests are hooks) | Run the test Pod as a `Kubernetes.Job` |
+| Waits for readiness with `--wait` | Returns once the API server accepts the objects | Check readiness out of band (`kubectl rollout status`) |
+
+If a chart's README says it relies on hooks, or you need
+`helm rollback`, use Helm. If you want the chart's objects in the
+same plan as your workloads, drift-corrected and pruned, use
+`HelmChart`. Hooks are excluded twice because a chart's `pre-delete`
+uninstall Job, applied as an ordinary object, would otherwise run on
+every deploy.
+
+Taking over objects a Helm release installed seizes their fields
+from the `helm` field manager; see
+[conflicts](/kubernetes/guides/how-apply-works#conflicts) for what
+`force` does there. Owning a hook's work yourself looks like this.
+
+```typescript
+// A chart's pre-upgrade migration hook never runs under HelmChart.
+// Own the migration instead and order the chart after it: put the Job's
+// output in a harmless values key — the value doesn't matter, the reference
+// creates the edge (same idiom as `namespace: ns.name`).
+const migrate = yield* Kubernetes.Job("Migrate", {
+  cluster,
+  image: "ghcr.io/acme/migrator:v3",
+  namespace: ns.name,
+});
+
+const app = yield* Kubernetes.HelmChart("App", {
+  cluster,
+  chart: "./charts/app",
+  namespace: ns.name,
+  values: { migratedBy: migrate.jobName }, // ordering edge: chart applies after the Job
+});
+```
+
+## Combining with Manifests and Deployments
+
+The API server accepts an Ingress whose class nobody has installed
+yet, so a chart-installed controller and the Ingress that uses it
+have no natural edge. To apply the Ingress only after the controller,
+carry a chart output in a harmless field, the
+[same idiom](/kubernetes/objects/manifests#namespaces) as
+`namespace: ns.name`.
+
+```typescript
+const route = yield* Kubernetes.Manifest("ApiIngress", {
+  cluster,
+  manifest: {
+    apiVersion: "networking.k8s.io/v1",
+    kind: "Ingress",
+    metadata: {
+      name: "api",
+      namespace: ns.name,
+      // Ordering edge: the value is irrelevant, the reference applies the
+      // Ingress after the ingress-nginx chart.
+      annotations: {
+        "alchemy.run/ingress-controller": ingressNginx.releaseName,
+      },
+    },
+    spec: { ingressClassName: "nginx", rules: [/* ... */] },
+  },
+});
+```
+
+The full controller, ClusterIP Deployment, and Ingress are in the
+[Ingress](/kubernetes/guides/exposing-services#ingress) section of
+the exposing-services guide.
+
+## Where next
+
+- [Exposing services](/kubernetes/guides/exposing-services) — Service
+  types, LB annotations, Ingress, Cloudflare Tunnel.
+- [How apply works](/kubernetes/guides/how-apply-works#pruning-and-drift)
+  — field manager, pruning, drift, conflicts, delete order, debugging.
+- [Custom resources](/kubernetes/objects/manifests#custom-resources)
+  — the CRs that drive a chart-installed operator are Manifests.
+- [`HelmChart` reference](/providers/kubernetes/helmchart) — every
+  prop and attribute.

--- a/website/src/content/docs/kubernetes/objects/manifests.mdx
+++ b/website/src/content/docs/kubernetes/objects/manifests.mdx
@@ -1,0 +1,361 @@
+---
+title: Manifests
+description: Apply any Kubernetes object — Namespaces, ConfigMaps, StatefulSets, Secrets, custom resources — as a literal object with Kubernetes.Manifest, and order workloads after it through outputs.
+---
+
+[`Kubernetes.Manifest`](/providers/kubernetes/manifest) applies any
+object that is not a `Deployment` or a `Job`. You write the object as
+a TypeScript literal with the same shape as its YAML. Alchemy applies
+it and owns it from then on.
+
+## Any object
+
+The `manifest` prop is the object itself: `apiVersion`, `kind`,
+`metadata`, then the kind's own fields. A StatefulSet is the usual
+"not a Deployment, not a Job" workload.
+
+```typescript
+// Inside the Stack's Effect.gen body; `cluster` is a
+// Kubernetes.KubeConfig(...) or a managed cluster resource.
+const redis = yield* Kubernetes.Manifest("Redis", {
+  cluster,
+  manifest: {
+    // Exactly what you'd write in YAML, as an object literal.
+    apiVersion: "apps/v1",
+    kind: "StatefulSet",
+    metadata: { name: "redis", namespace: "default" }, // name is REQUIRED
+    spec: {
+      serviceName: "redis",
+      replicas: 1,
+      selector: { matchLabels: { app: "redis" } },
+      template: {
+        metadata: { labels: { app: "redis" } },
+        spec: { containers: [{ name: "redis", image: "redis:7" }] },
+      },
+    },
+  },
+});
+
+redis.ref; // { apiVersion: "apps/v1", kind: "StatefulSet", name: "redis", namespace: "default" }
+redis.uid; // server-assigned UID (string | undefined)
+```
+
+The object was
+[server-side applied](/kubernetes/guides/how-apply-works#server-side-apply)
+under the field manager `alchemy`. One call creates it if it is
+missing and converges it if it already exists.
+
+`metadata.name` is required. Without it the provider fails with
+`Kubernetes.Manifest requires manifest.metadata.name (got <apiVersion>/<kind>)`.
+`generateName` is not supported because server-side apply addresses
+objects by a concrete name.
+
+The attributes are the object's identity (`apiVersion`, `kind`,
+`name`, `namespace`, with `namespace` undefined for cluster-scoped
+kinds), `ref` as that tuple in one value, `uid` when the API server
+returns one, and the cluster's
+[connection](/kubernetes/clusters/connecting#the-connection-model),
+persisted so destroy can reconnect without the original graph.
+
+An object's identity is (cluster, `apiVersion`, `kind`,
+`metadata.name`, `metadata.namespace`). Change any part and the plan
+shows a replace: the new object is applied, then the old one is
+deleted. Every other edit is an update that re-applies the object.
+The cluster counts by its auth descriptor, not its endpoint, so a
+managed cluster rotating its endpoint does not replace your objects.
+
+Refresh fetches the object by `ref` and checks existence only. A 404
+means the next deploy re-creates it. A vanished cluster
+(`Kubernetes.ClusterNotFoundError`) means the object is treated as
+gone. A hand-edited field on a live object is corrected the next
+time the Manifest reconciles or on `alchemy deploy --force`. See
+[pruning and drift](/kubernetes/guides/how-apply-works#pruning-and-drift).
+
+Destroy deletes the object. A 404 is ignored, and residual API errors
+are tolerated, for example when the CRD behind a custom resource was
+removed first.
+
+:::caution[Manifest does not adopt]
+There is no existence probe before the first apply. If an object with
+the same identity already exists, the apply takes over the fields you
+declare and `alchemy destroy` deletes the whole object. See
+[conflicts](/kubernetes/guides/how-apply-works#conflicts).
+:::
+
+The headless Service a StatefulSet needs is another Manifest next to
+it.
+
+```typescript
+const redisService = yield* Kubernetes.Manifest("RedisService", {
+  cluster,
+  manifest: {
+    apiVersion: "v1",
+    kind: "Service",
+    metadata: { name: "redis", namespace: "default" },
+    spec: {
+      clusterIP: "None", // headless: one DNS entry per pod
+      selector: { app: "redis" },
+      ports: [{ port: 6379 }],
+    },
+  },
+});
+```
+
+## Namespaces
+
+A Namespace is cluster-scoped, so it is a Manifest like any other. It
+is also the object almost every stack needs first. `Deployment`,
+`Job`, and namespaced Manifests all require their namespace to
+[already exist](/kubernetes/workloads/deployments#what-gets-created).
+Applying into a missing namespace fails with a 404.
+
+Namespaced kinds need `metadata.namespace`. Cluster-scoped kinds
+(Namespace, CustomResourceDefinition, ClusterRole) leave it off and
+get `namespace: undefined` back. A namespaced kind without one fails
+with `Kubernetes object <apiVersion>/<kind>/<name> requires a namespace`.
+`Manifest` does not default it to `default` the way `HelmChart`
+does, so write `namespace: "default"` when that is what you mean.
+
+Alchemy orders resources by the data that flows between them, not by
+declaration order. A bare string `namespace: "apps"` creates no edge
+to the Namespace manifest, so on a fresh deploy the Deployment can
+apply first. Reference the Namespace's `name` attribute instead and
+the Deployment deploys after it and is destroyed before it. When no
+field naturally carries an output, put it in a harmless one: a label
+on a Manifest, an unused `values` key on a HelmChart. The value does
+not matter, the reference creates the edge.
+
+:::tip[`namespace: ns.name`, not `namespace: "apps"`]
+The output reference is what creates the dependency edge. The value
+is identical.
+:::
+
+```typescript
+const ns = yield* Kubernetes.Manifest("AppsNamespace", {
+  cluster,
+  manifest: {
+    apiVersion: "v1",
+    kind: "Namespace", // cluster-scoped: no metadata.namespace
+    metadata: {
+      name: "apps",
+      labels: { "app.kubernetes.io/part-of": "my-app" },
+    },
+  },
+});
+
+ns.namespace; // undefined — cluster-scoped kinds have no namespace
+ns.name; // "apps"
+
+const config = yield* Kubernetes.Manifest("AppConfig", {
+  cluster,
+  manifest: {
+    apiVersion: "v1",
+    kind: "ConfigMap",
+    metadata: { name: "app-config", namespace: ns.name }, // depends on the Namespace
+    data: { LOG_LEVEL: "info" },
+  },
+});
+
+const api = yield* Kubernetes.Deployment("Api", {
+  cluster,
+  image: "ghcr.io/acme/api:1.4.0",
+  namespace: ns.name, // deploys after the Namespace exists; destroyed before it
+  env: { APP_CONFIG: config.name }, // any attr works as a dependency edge
+});
+```
+
+Deleting a Namespace deletes everything inside it. Never point a
+Namespace manifest at a namespace other tools own.
+
+## Custom resources
+
+`Manifest` accepts any `apiVersion` and `kind`. Core kinds are known
+statically. Anything else is discovered from the API server at apply
+time and cached for the rest of the process; the
+[server-side apply](/kubernetes/guides/how-apply-works#server-side-apply)
+guide covers both paths. A custom resource whose CRD is not installed
+fails with a typed `KubernetesApiError`, a 404 reading
+`Kind '<Kind>' not found in API group '<apiVersion>'`. Discovery is
+not retried, so the CRD must exist first. Carry the CRD's output into
+a label on the CR and Alchemy applies the CRD first and removes the
+CR first on destroy.
+
+```typescript
+const widgetCrd = yield* Kubernetes.Manifest("WidgetCrd", {
+  cluster,
+  manifest: {
+    apiVersion: "apiextensions.k8s.io/v1",
+    kind: "CustomResourceDefinition",
+    metadata: { name: "widgets.example.com" }, // cluster-scoped
+    spec: {
+      group: "example.com",
+      names: { kind: "Widget", plural: "widgets", singular: "widget" },
+      scope: "Namespaced",
+      versions: [
+        {
+          name: "v1",
+          served: true,
+          storage: true,
+          schema: {
+            openAPIV3Schema: {
+              type: "object",
+              properties: {
+                spec: {
+                  type: "object",
+                  properties: { size: { type: "integer" } },
+                },
+              },
+            },
+          },
+        },
+      ],
+    },
+  },
+});
+
+const widget = yield* Kubernetes.Manifest("Widget", {
+  cluster,
+  manifest: {
+    apiVersion: "example.com/v1", // resolved via /apis/example.com/v1 discovery
+    kind: "Widget",
+    metadata: {
+      name: "demo",
+      namespace: ns.name,
+      // Reference the CRD's output so the CR is applied after the CRD
+      // (and removed before it on destroy).
+      labels: { "example.com/definition": widgetCrd.name },
+    },
+    spec: { size: 3 },
+  },
+});
+```
+
+:::note
+Deleting a CRD deletes every custom resource of that kind
+cluster-wide. Keep a CRD manifest in the stack only if this stack
+owns the kind.
+:::
+
+:::caution[Eventual consistency]
+The API server registers a new CRD asynchronously (its `Established`
+condition). A CR that races it may hit the discovery 404 once on the
+first deploy. Re-running `alchemy deploy` converges.
+:::
+
+More often an operator already installed the CRD, such as
+cert-manager's `Certificate` or Argo's `Application`. Then the stack
+holds only the CR and discovery finds the kind on the cluster.
+Operators usually arrive as a
+[Helm chart](/kubernetes/objects/helm#values). When discovery or the
+apply fails, [debugging](/kubernetes/guides/how-apply-works#debugging)
+explains how to read the error.
+
+## Secrets
+
+A `Secret` is a Manifest with `stringData`. The API server
+base64-encodes it into `data` for you.
+
+Never inline the value in `alchemy.run.ts`. Read it from the deploy
+environment with `Config.string("DB_PASSWORD")`. `Config` values in
+props resolve at plan time, so the applied manifest carries the real
+value. It is sent to the API server over TLS and lands in etcd like
+any Secret applied with `kubectl`.
+
+:::note[Redacted is not unwrapped here]
+`Config.redacted(...)` and `Redacted.make(...)` are not supported
+inside `manifest` or Helm `values`. The cluster would receive the
+literal `<redacted>`. Use `Config.string`.
+:::
+
+```typescript
+import * as Config from "effect/Config";
+
+const dbSecret = yield* Kubernetes.Manifest("DbSecret", {
+  cluster,
+  manifest: {
+    apiVersion: "v1",
+    kind: "Secret",
+    metadata: { name: "db-credentials", namespace: ns.name },
+    type: "Opaque",
+    // stringData: the API server base64-encodes into `data` for you.
+    stringData: {
+      // Resolved from the deploy environment at plan time — never a literal.
+      // Config.string, not Config.redacted: Redacted is not unwrapped in `manifest`.
+      DB_PASSWORD: Config.string("DB_PASSWORD"),
+    },
+  },
+});
+
+// Consume it from a workload: `dbSecret.name` is the dependency edge; the
+// Secret is applied before the Deployment.
+const api = yield* Kubernetes.Deployment("Api", {
+  cluster,
+  image: "ghcr.io/acme/api:1.4.0",
+  namespace: ns.name,
+  env: { DB_SECRET_NAME: dbSecret.name },
+});
+```
+
+For `envFrom` or volume mounts see
+[container-level fields](/kubernetes/workloads/pod-template#container-level-fields).
+Container overrides in `podTemplate` replace the synthesized
+container wholesale and are only safe for `image:` sources. On EKS
+with AWS bindings you often need no Secret at all, because
+[Pod Identity](/kubernetes/workloads/bindings#pod-identity-on-eks)
+grants the access directly.
+
+:::caution[Secrets in state]
+The resolved `manifest` is written to state verbatim, plaintext
+included. Use a remote [state store](/state-store) and restrict who
+can read it. Rotate by changing the environment variable and
+redeploying. Pods still need a restart to pick up the new value.
+:::
+
+## Typing the manifest
+
+`manifest` is `KubernetesManifest`: `apiVersion`, `kind`, an optional
+`metadata` with `name`, `namespace`, `labels` and `annotations`, and
+`[key: string]: unknown` for the rest. It is loose on purpose so any
+kind is accepted and the API server validates the shape.
+
+Because props are deep `Input<T>`, any leaf can be an
+[output](/infrastructure-as-code/outputs) of another resource:
+`namespace: ns.name`, `data: { TABLE_NAME: table.tableName }`,
+`Output.interpolate` for composed strings. That is how you wire
+values and how you declare ordering. For editor help, write the
+literal with `satisfies` against a Kubernetes typings package. The
+literal keeps its narrow type and still satisfies
+`KubernetesManifest`.
+
+```typescript
+import type { V1StatefulSet } from "@kubernetes/client-node";
+
+const redisSpec = {
+  apiVersion: "apps/v1",
+  kind: "StatefulSet",
+  metadata: { name: "redis", namespace: ns.name },
+  spec: {
+    /* autocompleted */
+  },
+} satisfies V1StatefulSet; // compile-time shape check; runtime validation is the API server's
+
+const redis = yield* Kubernetes.Manifest("Redis", {
+  cluster,
+  manifest: redisSpec,
+});
+```
+
+A typo in `kind` or `apiVersion` is a discovery 404 at deploy time. A
+typo inside `spec` is a 422 from the API server. Both are covered
+under [debugging](/kubernetes/guides/how-apply-works#debugging).
+
+## Where next
+
+- [Helm charts](/kubernetes/objects/helm) — install whole charts with
+  `Kubernetes.HelmChart`; their objects take the same apply path.
+- [How apply works](/kubernetes/guides/how-apply-works#server-side-apply)
+  — the field manager, `force`, pruning, drift, and conflicts.
+- [Pod template recipes](/kubernetes/workloads/pod-template#recipes)
+  — mount these ConfigMaps and Secrets into a Deployment or Job.
+- [`Manifest` reference](/providers/kubernetes/manifest) — every
+  prop and attribute.

--- a/website/src/content/docs/kubernetes/objects/manifests.mdx
+++ b/website/src/content/docs/kubernetes/objects/manifests.mdx
@@ -1,11 +1,11 @@
 ---
 title: Manifests
-description: Apply any Kubernetes object — Namespaces, ConfigMaps, StatefulSets, Secrets, custom resources — as a literal object with Kubernetes.Manifest, and order workloads after it through outputs.
+description: Apply any Kubernetes object, including Namespaces, ConfigMaps, Secrets, and custom resources, with Kubernetes.Manifest.
 ---
 
-[`Kubernetes.Manifest`](/providers/kubernetes/manifest) applies any
-object that is not a `Deployment` or a `Job`, written as a literal with
-the same shape as its YAML.
+Use [`Kubernetes.Manifest`](/providers/kubernetes/manifest) for any
+object that isn't a `Deployment` or a `Job`. Write it exactly as you
+would in YAML.
 
 ## Any object
 
@@ -35,21 +35,17 @@ redis.ref; // { apiVersion: "apps/v1", kind: "StatefulSet", name: "redis", names
 redis.uid; // server-assigned UID (string | undefined)
 ```
 
-The object is
-[server-side applied](/kubernetes/guides/how-apply-works#server-side-apply)
-under the field manager `alchemy`. `metadata.name` is required;
-`generateName` is not supported.
+Set `metadata.name`; `generateName` isn't supported. Changing
+`apiVersion`, `kind`, `metadata.name`, or `metadata.namespace` replaces
+the object. `alchemy destroy` deletes it.
 
-Identity is (cluster, `apiVersion`, `kind`, `metadata.name`,
-`metadata.namespace`); changing any part is a replace. Destroy deletes
-the object and ignores a 404.
-
-:::caution[Manifest does not adopt]
-An existing object with the same identity is taken over and deleted by
-`alchemy destroy`; see [conflicts](/kubernetes/guides/how-apply-works#conflicts).
+:::caution[Existing objects are taken over]
+If the cluster already has an object with this name, Alchemy takes it
+over and `alchemy destroy` deletes it. See
+[conflicts](/kubernetes/guides/how-apply-works#conflicts).
 :::
 
-The headless Service a StatefulSet needs is another Manifest.
+Add the StatefulSet's headless Service as a second Manifest.
 
 ```typescript
 const redisService = yield* Kubernetes.Manifest("RedisService", {
@@ -69,14 +65,13 @@ const redisService = yield* Kubernetes.Manifest("RedisService", {
 
 ## Namespaces
 
-A Namespace is a cluster-scoped Manifest that `Deployment`, `Job`,
-and namespaced Manifests require to already exist. Namespaced kinds
-need `metadata.namespace`; `Manifest` does not default it.
+Create a Namespace as a Manifest. A `Deployment`, `Job`, or namespaced
+Manifest needs its namespace to exist before it deploys, and a
+namespaced Manifest must set `metadata.namespace`.
 
-Alchemy orders resources by the data that flows between them, not by
-declaration order: `namespace: ns.name` creates the edge, a bare
-`"apps"` does not. When no field carries an output, put it in a
-harmless one such as a label.
+To deploy something after the Namespace, reference `ns.name` in it. A
+plain `"apps"` string doesn't order them. If no field needs the value,
+put it in a label.
 
 ```typescript
 const ns = yield* Kubernetes.Manifest("AppsNamespace", {
@@ -99,7 +94,7 @@ const config = yield* Kubernetes.Manifest("AppConfig", {
   manifest: {
     apiVersion: "v1",
     kind: "ConfigMap",
-    metadata: { name: "app-config", namespace: ns.name }, // depends on the Namespace
+    metadata: { name: "app-config", namespace: ns.name }, // deploys after the Namespace
     data: { LOG_LEVEL: "info" },
   },
 });
@@ -108,7 +103,7 @@ const api = yield* Kubernetes.Deployment("Api", {
   cluster,
   image: "ghcr.io/acme/api:1.4.0",
   namespace: ns.name, // deploys after the Namespace exists; destroyed before it
-  env: { APP_CONFIG: config.name }, // any attr works as a dependency edge
+  env: { APP_CONFIG: config.name }, // any attribute orders the Deployment after the ConfigMap
 });
 ```
 
@@ -116,10 +111,8 @@ Deleting a Namespace deletes everything inside it.
 
 ## Custom resources
 
-Core kinds are known statically; anything else is discovered from the
-API server at apply time. A custom resource whose CRD is not installed
-fails with a 404, so reference the CRD's output from the CR to apply
-the CRD first.
+Reference the CRD's output from the custom resource so the CRD applies
+first; otherwise the deploy fails with a 404.
 
 ```typescript
 const widgetCrd = yield* Kubernetes.Manifest("WidgetCrd", {
@@ -157,13 +150,13 @@ const widgetCrd = yield* Kubernetes.Manifest("WidgetCrd", {
 const widget = yield* Kubernetes.Manifest("Widget", {
   cluster,
   manifest: {
-    apiVersion: "example.com/v1", // resolved via /apis/example.com/v1 discovery
+    apiVersion: "example.com/v1", // any kind the cluster serves works
     kind: "Widget",
     metadata: {
       name: "demo",
       namespace: ns.name,
-      // Reference the CRD's output so the CR is applied after the CRD
-      // (and removed before it on destroy).
+      // Reference the CRD so this applies after it
+      // (and is removed before it on destroy).
       labels: { "example.com/definition": widgetCrd.name },
     },
     spec: { size: 3 },
@@ -171,17 +164,17 @@ const widget = yield* Kubernetes.Manifest("Widget", {
 });
 ```
 
-Deleting a CRD deletes every custom resource of that kind
-cluster-wide. A CR that races a fresh CRD may hit the 404 once;
-re-running `alchemy deploy` converges. Operators usually arrive as a
+Deleting a CRD deletes every custom resource of that kind in the
+cluster. If a custom resource hits a 404 right after its CRD is
+created, run `alchemy deploy` again. Install operators with a
 [Helm chart](/kubernetes/objects/helm#values).
 
 ## Secrets
 
-A `Secret` is a Manifest with `stringData`. Read the value from the
-deploy environment with `Config.string`, never a literal.
-`Config.redacted` and `Redacted.make` are not unwrapped inside
-`manifest` or Helm `values`; the cluster would receive `<redacted>`.
+Write a `Secret` with `stringData` and read each value from your
+environment with `Config.string`. Don't use `Config.redacted` or
+`Redacted.make` inside `manifest` or Helm `values`: the cluster would
+receive the text `<redacted>`.
 
 ```typescript
 import * as Config from "effect/Config";
@@ -193,17 +186,16 @@ const dbSecret = yield* Kubernetes.Manifest("DbSecret", {
     kind: "Secret",
     metadata: { name: "db-credentials", namespace: ns.name },
     type: "Opaque",
-    // stringData: the API server base64-encodes into `data` for you.
+    // stringData: Kubernetes base64-encodes it into `data` for you.
     stringData: {
-      // Resolved from the deploy environment at plan time — never a literal.
-      // Config.string, not Config.redacted: Redacted is not unwrapped in `manifest`.
+      // Read from your environment at deploy time; don't paste the value.
+      // Use Config.string, not Config.redacted.
       DB_PASSWORD: Config.string("DB_PASSWORD"),
     },
   },
 });
 
-// Consume it from a workload: `dbSecret.name` is the dependency edge; the
-// Secret is applied before the Deployment.
+// Reference `dbSecret.name` from the workload so the Secret is applied first.
 const api = yield* Kubernetes.Deployment("Api", {
   cluster,
   image: "ghcr.io/acme/api:1.4.0",
@@ -212,8 +204,9 @@ const api = yield* Kubernetes.Deployment("Api", {
 });
 ```
 
-The resolved `manifest` is written to state in plaintext, so use a
-remote [state store](/state-store). For `envFrom` or volume mounts see
+The secret values are stored in plaintext in your state, so use a
+remote [state store](/state-store). To mount the Secret with `envFrom`
+or a volume, see
 [container-level fields](/kubernetes/workloads/pod-template#container-level-fields).
 
 ## Where next

--- a/website/src/content/docs/kubernetes/objects/manifests.mdx
+++ b/website/src/content/docs/kubernetes/objects/manifests.mdx
@@ -4,15 +4,10 @@ description: Apply any Kubernetes object — Namespaces, ConfigMaps, StatefulSet
 ---
 
 [`Kubernetes.Manifest`](/providers/kubernetes/manifest) applies any
-object that is not a `Deployment` or a `Job`. You write the object as
-a TypeScript literal with the same shape as its YAML. Alchemy applies
-it and owns it from then on.
+object that is not a `Deployment` or a `Job`, written as a literal with
+the same shape as its YAML.
 
 ## Any object
-
-The `manifest` prop is the object itself: `apiVersion`, `kind`,
-`metadata`, then the kind's own fields. A StatefulSet is the usual
-"not a Deployment, not a Job" workload.
 
 ```typescript
 // Inside the Stack's Effect.gen body; `cluster` is a
@@ -40,50 +35,21 @@ redis.ref; // { apiVersion: "apps/v1", kind: "StatefulSet", name: "redis", names
 redis.uid; // server-assigned UID (string | undefined)
 ```
 
-The object was
+The object is
 [server-side applied](/kubernetes/guides/how-apply-works#server-side-apply)
-under the field manager `alchemy`. One call creates it if it is
-missing and converges it if it already exists.
+under the field manager `alchemy`. `metadata.name` is required;
+`generateName` is not supported.
 
-`metadata.name` is required. Without it the provider fails with
-`Kubernetes.Manifest requires manifest.metadata.name (got <apiVersion>/<kind>)`.
-`generateName` is not supported because server-side apply addresses
-objects by a concrete name.
-
-The attributes are the object's identity (`apiVersion`, `kind`,
-`name`, `namespace`, with `namespace` undefined for cluster-scoped
-kinds), `ref` as that tuple in one value, `uid` when the API server
-returns one, and the cluster's
-[connection](/kubernetes/clusters/connecting#the-connection-model),
-persisted so destroy can reconnect without the original graph.
-
-An object's identity is (cluster, `apiVersion`, `kind`,
-`metadata.name`, `metadata.namespace`). Change any part and the plan
-shows a replace: the new object is applied, then the old one is
-deleted. Every other edit is an update that re-applies the object.
-The cluster counts by its auth descriptor, not its endpoint, so a
-managed cluster rotating its endpoint does not replace your objects.
-
-Refresh fetches the object by `ref` and checks existence only. A 404
-means the next deploy re-creates it. A vanished cluster
-(`Kubernetes.ClusterNotFoundError`) means the object is treated as
-gone. A hand-edited field on a live object is corrected the next
-time the Manifest reconciles or on `alchemy deploy --force`. See
-[pruning and drift](/kubernetes/guides/how-apply-works#pruning-and-drift).
-
-Destroy deletes the object. A 404 is ignored, and residual API errors
-are tolerated, for example when the CRD behind a custom resource was
-removed first.
+Identity is (cluster, `apiVersion`, `kind`, `metadata.name`,
+`metadata.namespace`); changing any part is a replace. Destroy deletes
+the object and ignores a 404.
 
 :::caution[Manifest does not adopt]
-There is no existence probe before the first apply. If an object with
-the same identity already exists, the apply takes over the fields you
-declare and `alchemy destroy` deletes the whole object. See
-[conflicts](/kubernetes/guides/how-apply-works#conflicts).
+An existing object with the same identity is taken over and deleted by
+`alchemy destroy`; see [conflicts](/kubernetes/guides/how-apply-works#conflicts).
 :::
 
-The headless Service a StatefulSet needs is another Manifest next to
-it.
+The headless Service a StatefulSet needs is another Manifest.
 
 ```typescript
 const redisService = yield* Kubernetes.Manifest("RedisService", {
@@ -103,32 +69,14 @@ const redisService = yield* Kubernetes.Manifest("RedisService", {
 
 ## Namespaces
 
-A Namespace is cluster-scoped, so it is a Manifest like any other. It
-is also the object almost every stack needs first. `Deployment`,
-`Job`, and namespaced Manifests all require their namespace to
-[already exist](/kubernetes/workloads/deployments#what-gets-created).
-Applying into a missing namespace fails with a 404.
-
-Namespaced kinds need `metadata.namespace`. Cluster-scoped kinds
-(Namespace, CustomResourceDefinition, ClusterRole) leave it off and
-get `namespace: undefined` back. A namespaced kind without one fails
-with `Kubernetes object <apiVersion>/<kind>/<name> requires a namespace`.
-`Manifest` does not default it to `default` the way `HelmChart`
-does, so write `namespace: "default"` when that is what you mean.
+A Namespace is a cluster-scoped Manifest that `Deployment`, `Job`,
+and namespaced Manifests require to already exist. Namespaced kinds
+need `metadata.namespace`; `Manifest` does not default it.
 
 Alchemy orders resources by the data that flows between them, not by
-declaration order. A bare string `namespace: "apps"` creates no edge
-to the Namespace manifest, so on a fresh deploy the Deployment can
-apply first. Reference the Namespace's `name` attribute instead and
-the Deployment deploys after it and is destroyed before it. When no
-field naturally carries an output, put it in a harmless one: a label
-on a Manifest, an unused `values` key on a HelmChart. The value does
-not matter, the reference creates the edge.
-
-:::tip[`namespace: ns.name`, not `namespace: "apps"`]
-The output reference is what creates the dependency edge. The value
-is identical.
-:::
+declaration order: `namespace: ns.name` creates the edge, a bare
+`"apps"` does not. When no field carries an output, put it in a
+harmless one such as a label.
 
 ```typescript
 const ns = yield* Kubernetes.Manifest("AppsNamespace", {
@@ -164,21 +112,14 @@ const api = yield* Kubernetes.Deployment("Api", {
 });
 ```
 
-Deleting a Namespace deletes everything inside it. Never point a
-Namespace manifest at a namespace other tools own.
+Deleting a Namespace deletes everything inside it.
 
 ## Custom resources
 
-`Manifest` accepts any `apiVersion` and `kind`. Core kinds are known
-statically. Anything else is discovered from the API server at apply
-time and cached for the rest of the process; the
-[server-side apply](/kubernetes/guides/how-apply-works#server-side-apply)
-guide covers both paths. A custom resource whose CRD is not installed
-fails with a typed `KubernetesApiError`, a 404 reading
-`Kind '<Kind>' not found in API group '<apiVersion>'`. Discovery is
-not retried, so the CRD must exist first. Carry the CRD's output into
-a label on the CR and Alchemy applies the CRD first and removes the
-CR first on destroy.
+Core kinds are known statically; anything else is discovered from the
+API server at apply time. A custom resource whose CRD is not installed
+fails with a 404, so reference the CRD's output from the CR to apply
+the CRD first.
 
 ```typescript
 const widgetCrd = yield* Kubernetes.Manifest("WidgetCrd", {
@@ -230,42 +171,17 @@ const widget = yield* Kubernetes.Manifest("Widget", {
 });
 ```
 
-:::note
 Deleting a CRD deletes every custom resource of that kind
-cluster-wide. Keep a CRD manifest in the stack only if this stack
-owns the kind.
-:::
-
-:::caution[Eventual consistency]
-The API server registers a new CRD asynchronously (its `Established`
-condition). A CR that races it may hit the discovery 404 once on the
-first deploy. Re-running `alchemy deploy` converges.
-:::
-
-More often an operator already installed the CRD, such as
-cert-manager's `Certificate` or Argo's `Application`. Then the stack
-holds only the CR and discovery finds the kind on the cluster.
-Operators usually arrive as a
-[Helm chart](/kubernetes/objects/helm#values). When discovery or the
-apply fails, [debugging](/kubernetes/guides/how-apply-works#debugging)
-explains how to read the error.
+cluster-wide. A CR that races a fresh CRD may hit the 404 once;
+re-running `alchemy deploy` converges. Operators usually arrive as a
+[Helm chart](/kubernetes/objects/helm#values).
 
 ## Secrets
 
-A `Secret` is a Manifest with `stringData`. The API server
-base64-encodes it into `data` for you.
-
-Never inline the value in `alchemy.run.ts`. Read it from the deploy
-environment with `Config.string("DB_PASSWORD")`. `Config` values in
-props resolve at plan time, so the applied manifest carries the real
-value. It is sent to the API server over TLS and lands in etcd like
-any Secret applied with `kubectl`.
-
-:::note[Redacted is not unwrapped here]
-`Config.redacted(...)` and `Redacted.make(...)` are not supported
-inside `manifest` or Helm `values`. The cluster would receive the
-literal `<redacted>`. Use `Config.string`.
-:::
+A `Secret` is a Manifest with `stringData`. Read the value from the
+deploy environment with `Config.string`, never a literal.
+`Config.redacted` and `Redacted.make` are not unwrapped inside
+`manifest` or Helm `values`; the cluster would receive `<redacted>`.
 
 ```typescript
 import * as Config from "effect/Config";
@@ -296,66 +212,12 @@ const api = yield* Kubernetes.Deployment("Api", {
 });
 ```
 
-For `envFrom` or volume mounts see
+The resolved `manifest` is written to state in plaintext, so use a
+remote [state store](/state-store). For `envFrom` or volume mounts see
 [container-level fields](/kubernetes/workloads/pod-template#container-level-fields).
-Container overrides in `podTemplate` replace the synthesized
-container wholesale and are only safe for `image:` sources. On EKS
-with AWS bindings you often need no Secret at all, because
-[Pod Identity](/kubernetes/workloads/bindings#pod-identity-on-eks)
-grants the access directly.
-
-:::caution[Secrets in state]
-The resolved `manifest` is written to state verbatim, plaintext
-included. Use a remote [state store](/state-store) and restrict who
-can read it. Rotate by changing the environment variable and
-redeploying. Pods still need a restart to pick up the new value.
-:::
-
-## Typing the manifest
-
-`manifest` is `KubernetesManifest`: `apiVersion`, `kind`, an optional
-`metadata` with `name`, `namespace`, `labels` and `annotations`, and
-`[key: string]: unknown` for the rest. It is loose on purpose so any
-kind is accepted and the API server validates the shape.
-
-Because props are deep `Input<T>`, any leaf can be an
-[output](/infrastructure-as-code/outputs) of another resource:
-`namespace: ns.name`, `data: { TABLE_NAME: table.tableName }`,
-`Output.interpolate` for composed strings. That is how you wire
-values and how you declare ordering. For editor help, write the
-literal with `satisfies` against a Kubernetes typings package. The
-literal keeps its narrow type and still satisfies
-`KubernetesManifest`.
-
-```typescript
-import type { V1StatefulSet } from "@kubernetes/client-node";
-
-const redisSpec = {
-  apiVersion: "apps/v1",
-  kind: "StatefulSet",
-  metadata: { name: "redis", namespace: ns.name },
-  spec: {
-    /* autocompleted */
-  },
-} satisfies V1StatefulSet; // compile-time shape check; runtime validation is the API server's
-
-const redis = yield* Kubernetes.Manifest("Redis", {
-  cluster,
-  manifest: redisSpec,
-});
-```
-
-A typo in `kind` or `apiVersion` is a discovery 404 at deploy time. A
-typo inside `spec` is a 422 from the API server. Both are covered
-under [debugging](/kubernetes/guides/how-apply-works#debugging).
 
 ## Where next
 
-- [Helm charts](/kubernetes/objects/helm) — install whole charts with
-  `Kubernetes.HelmChart`; their objects take the same apply path.
+- [Helm charts](/kubernetes/objects/helm)
 - [How apply works](/kubernetes/guides/how-apply-works#server-side-apply)
-  — the field manager, `force`, pruning, drift, and conflicts.
-- [Pod template recipes](/kubernetes/workloads/pod-template#recipes)
-  — mount these ConfigMaps and Secrets into a Deployment or Job.
-- [`Manifest` reference](/providers/kubernetes/manifest) — every
-  prop and attribute.
+- [`Manifest` reference](/providers/kubernetes/manifest)

--- a/website/src/content/docs/kubernetes/setup.mdx
+++ b/website/src/content/docs/kubernetes/setup.mdx
@@ -1,6 +1,6 @@
 ---
 title: Setup
-description: Install Alchemy, point it at a Kubernetes cluster, add Kubernetes.providers() to a Stack, and plan your first manifest.
+description: Install Alchemy, connect it to a Kubernetes cluster, and plan your first manifest.
 ---
 
 import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
@@ -9,10 +9,9 @@ import Terminal from "../../../components/Terminal.astro";
 
 export const pkgs = `"alchemy@latest" "effect@${effectVersion}" "@effect/platform-bun@${effectVersion}" "@effect/platform-node@${effectVersion}"`;
 
-You need [Bun](https://bun.sh) or Node.js 22+, a cluster your kubeconfig
-can reach, and `Kubernetes.providers()` in a Stack. There is no
-`alchemy login`; the built-in adapters read your kubeconfig like
-`kubectl` does.
+You need [Bun](https://bun.sh) or Node.js 22+ and a cluster `kubectl`
+can reach. Alchemy uses the same kubeconfig as `kubectl`; there is
+nothing to log in to.
 
 ## Create a project directory
 
@@ -48,9 +47,9 @@ can reach, and `Kubernetes.providers()` in a Stack. There is no
   </TabItem>
 </Tabs>
 
-[`Kubernetes.HelmChart`](/providers/kubernetes/helmchart) needs `helm`
-on `PATH` (or at `HELM_BIN`); EKS needs Docker for
-[every image source](/kubernetes/clusters/eks#what-the-adapter-adds).
+To deploy [Helm charts](/providers/kubernetes/helmchart), install
+`helm` (on `PATH`, or set `HELM_BIN`). To deploy to
+[EKS](/kubernetes/clusters/eks#what-eks-adds), install Docker.
 
 ```sh
 brew install helm   # macOS; other platforms: https://helm.sh/docs/intro/install/
@@ -58,17 +57,15 @@ brew install helm   # macOS; other platforms: https://helm.sh/docs/intro/install
 
 ## Pick a cluster
 
-Any cluster `kubectl` can reach works. Without a registry adapter such
-as EKS, workloads run pre-built `image:` references only
-([why](/kubernetes/workloads/image-sources#registry-requirement)).
+Any cluster `kubectl` can reach works. Use pre-built images (`image:`)
+everywhere except EKS, which can also build your own.
 
 <Tabs syncKey="cluster">
   <TabItem label="Local">
 
-Docker Desktop (Settings → Kubernetes → Enable, context
-`docker-desktop`) or OrbStack (context `orbstack`) is the easiest;
-`kind` and `k3s` also work
-([trade-offs](/kubernetes/clusters/local#which-local-cluster)).
+The easiest is Docker Desktop (Settings → Kubernetes → Enable; context
+`docker-desktop`) or OrbStack (context `orbstack`). `kind` and `k3s`
+also work ([compare them](/kubernetes/clusters/local#which-local-cluster)).
 
 ```sh
 kubectl config current-context   # e.g. docker-desktop
@@ -78,29 +75,29 @@ kubectl get nodes                 # one Ready node
   </TabItem>
   <TabItem label="EKS">
 
-Pass the `AWS.EKS.Cluster` resource as `cluster` for the full adapter;
-create it on the [AWS tab](/aws/compute/eks). A context from
-`aws eks update-kubeconfig` is auth-only
-([details](/kubernetes/clusters/eks#targeting-an-eks-cluster)).
+Pass an `AWS.EKS.Cluster` as `cluster` to get image builds and Pod
+Identity; create it on the [AWS tab](/aws/compute/eks). A context from
+`aws eks update-kubeconfig` gives auth only, no image builds or Pod
+Identity.
 
 ```typescript
-// full adapter: the resource IS the cluster value
+// an EKS cluster resource: image builds, ECR, and Pod Identity
 const cluster = yield* AWS.EKS.Cluster("Cluster", {
   compute: "auto",
   resourcesVpcConfig: { subnetIds: network.privateSubnetIds },
 });
 
-// auth-only: a context written by `aws eks update-kubeconfig`
+// auth only: an existing context from `aws eks update-kubeconfig`
 const existing = Kubernetes.KubeConfig({ context: "arn:aws:eks:us-east-1:123456789012:cluster/prod" });
 ```
 
   </TabItem>
   <TabItem label="Other managed cluster">
 
-Write a context with the provider's CLI
+Create a context with your provider's CLI
 (`gcloud container clusters get-credentials …`,
-`az aks get-credentials …`) and point `Kubernetes.KubeConfig({ context })`
-at it ([kubeconfig](/kubernetes/clusters/connecting#kubeconfig)).
+`az aks get-credentials …`), then pass its name to
+`Kubernetes.KubeConfig` ([kubeconfig](/kubernetes/clusters/connecting#kubeconfig)).
 
 ```typescript
 const gke = Kubernetes.KubeConfig({ context: "gke_my-proj_us-central1_prod" });
@@ -109,7 +106,7 @@ const gke = Kubernetes.KubeConfig({ context: "gke_my-proj_us-central1_prod" });
   </TabItem>
 </Tabs>
 
-## Add the provider
+## Create alchemy.run.ts
 
 ```typescript
 // alchemy.run.ts
@@ -120,7 +117,7 @@ import * as Effect from "effect/Effect";
 export default Alchemy.Stack(
   "MyApp",
   {
-    providers: Kubernetes.providers(),   // workload providers + kubeconfig/token/client-cert/exec adapters
+    providers: Kubernetes.providers(),
     state: Alchemy.localState(),
   },
   Effect.gen(function* () {
@@ -129,7 +126,7 @@ export default Alchemy.Stack(
 );
 ```
 
-EKS needs the AWS layer too, which ships the `aws-eks` adapter:
+To deploy to EKS, add `AWS.providers()` as well:
 
 ```diff lang="typescript"
 import * as Alchemy from "alchemy";
@@ -149,11 +146,12 @@ export default Alchemy.Stack(
 
 ## Verify
 
-Plan one [Namespace](/kubernetes/objects/manifests#namespaces) manifest.
+Add a [Namespace](/kubernetes/objects/manifests#namespaces) manifest
+and plan it.
 
 ```diff lang="typescript"
 Effect.gen(function* () {
-+  const cluster = Kubernetes.KubeConfig();   // current-context; pass { context: "..." } to pin one
++  const cluster = Kubernetes.KubeConfig();   // your current context; pass { context: "..." } for another
 +
 +  const ns = yield* Kubernetes.Manifest("DemoNamespace", {
 +    cluster,
@@ -187,9 +185,7 @@ Effect.gen(function* () {
 
 [g]+[/g] [b]DemoNamespace[/b] [d](Kubernetes.Manifest)[/d]`} />
 
-`plan` does not open a connection, so an unreachable context only
-surfaces on `deploy`. `KubeConfig()` is a
-[plain value](/kubernetes/clusters/connecting#the-connection-model), not a row.
+A wrong context fails on `deploy`, not on `plan`.
 
 :::tip[Round-trip it]
 
@@ -199,7 +195,7 @@ kubectl get namespace demo        # STATUS Active
 bun alchemy destroy
 ```
 
-Then delete the `DemoNamespace` block; part 1 starts from the empty Stack.
+Then remove the `DemoNamespace` block before you start the tutorial.
 :::
 
 ## Where next

--- a/website/src/content/docs/kubernetes/setup.mdx
+++ b/website/src/content/docs/kubernetes/setup.mdx
@@ -1,6 +1,6 @@
 ---
 title: Setup
-description: Install Alchemy, point it at a Kubernetes cluster — a local one, EKS, or any kubeconfig context — add Kubernetes.providers() to a Stack, and plan your first manifest.
+description: Install Alchemy, point it at a Kubernetes cluster, add Kubernetes.providers() to a Stack, and plan your first manifest.
 ---
 
 import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
@@ -9,19 +9,10 @@ import Terminal from "../../../components/Terminal.astro";
 
 export const pkgs = `"alchemy@latest" "effect@${effectVersion}" "@effect/platform-bun@${effectVersion}" "@effect/platform-node@${effectVersion}"`;
 
-You need the alchemy package, a cluster your kubeconfig can reach, and
-`Kubernetes.providers()` in a Stack. There is no `alchemy login`. The
-built-in adapters read your kubeconfig like `kubectl` does. Only a
-managed cluster resource (EKS) brings its own cloud credentials.
-
-## Prerequisites
-
-- [Bun](https://bun.sh) (recommended) or Node.js 22+
-- A cluster and a kubeconfig context that reaches it. A local one is
-  enough (see [Pick a cluster](#pick-a-cluster))
-- `kubectl`, used here to check the context and inspect results
-- `helm`, only for `Kubernetes.HelmChart`
-- Docker, only for EKS
+You need [Bun](https://bun.sh) or Node.js 22+, a cluster your kubeconfig
+can reach, and `Kubernetes.providers()` in a Stack. There is no
+`alchemy login`; the built-in adapters read your kubeconfig like
+`kubectl` does.
 
 ## Create a project directory
 
@@ -57,61 +48,40 @@ managed cluster resource (EKS) brings its own cloud credentials.
   </TabItem>
 </Tabs>
 
-### Helm
-
-Only [`Kubernetes.HelmChart`](/providers/kubernetes/helmchart) needs
-helm. It runs `helm template` on the deploying machine during `deploy`.
+[`Kubernetes.HelmChart`](/providers/kubernetes/helmchart) needs `helm`
+on `PATH` (or at `HELM_BIN`); EKS needs Docker for
+[every image source](/kubernetes/clusters/eks#what-the-adapter-adds).
 
 ```sh
 brew install helm   # macOS; other platforms: https://helm.sh/docs/intro/install/
 ```
 
-Alchemy runs `helm` from `PATH`, or the binary at `HELM_BIN`. Without
-it the first `HelmChart` deploy fails and says so.
-
-### Docker
-
-Only EKS needs Docker, for every image source. Even a pre-built
-`image:` is pulled, tagged, and pushed into the workload's
-[ECR repository](/kubernetes/clusters/eks#what-the-adapter-adds).
-Anything `docker ps` talks to works. `DOCKER_BIN` overrides the binary
-as on the [Docker setup page](/docker/setup).
-
 ## Pick a cluster
 
-Any cluster `kubectl` can reach works. Your choice picks a column of
-the [adapter table](/kubernetes#what-the-cluster-adapter-gives-you).
-A kubeconfig cluster has no registry, so workloads run pre-built
-`image:` references. `main:` and `context:` need a registry adapter
-such as EKS
+Any cluster `kubectl` can reach works. Without a registry adapter such
+as EKS, workloads run pre-built `image:` references only
 ([why](/kubernetes/workloads/image-sources#registry-requirement)).
 
 <Tabs syncKey="cluster">
   <TabItem label="Local">
 
 Docker Desktop (Settings → Kubernetes → Enable, context
-`docker-desktop`) or OrbStack (context `orbstack`) is the easiest.
-`kind` and `k3s` / `k3d` also work.
+`docker-desktop`) or OrbStack (context `orbstack`) is the easiest;
+`kind` and `k3s` also work
+([trade-offs](/kubernetes/clusters/local#which-local-cluster)).
 
 ```sh
 kubectl config current-context   # e.g. docker-desktop
 kubectl get nodes                 # one Ready node
 ```
 
-Alchemy reads the same file (`$KUBECONFIG`, else `~/.kube/config`)
-and the same `current-context`, unless you pass `context` to
-`Kubernetes.KubeConfig()`. Trade-offs between them are in
-[Which local cluster](/kubernetes/clusters/local#which-local-cluster).
-
   </TabItem>
   <TabItem label="EKS">
 
-Pass the `AWS.EKS.Cluster` resource as `cluster` for the full adapter
-([what it adds](/kubernetes/clusters/eks#what-the-adapter-adds)).
-Create the cluster on the [AWS tab](/aws/compute/eks) with credentials
-from [AWS setup](/aws/setup). An `aws eks update-kubeconfig` context
-through `KubeConfig()` is auth-only. See
-[Targeting an EKS cluster](/kubernetes/clusters/eks#targeting-an-eks-cluster).
+Pass the `AWS.EKS.Cluster` resource as `cluster` for the full adapter;
+create it on the [AWS tab](/aws/compute/eks). A context from
+`aws eks update-kubeconfig` is auth-only
+([details](/kubernetes/clusters/eks#targeting-an-eks-cluster)).
 
 ```typescript
 // full adapter: the resource IS the cluster value
@@ -127,33 +97,19 @@ const existing = Kubernetes.KubeConfig({ context: "arn:aws:eks:us-east-1:1234567
   </TabItem>
   <TabItem label="Other managed cluster">
 
-For GKE, AKS, DigitalOcean, on-prem, or anything else, write a context
-with the provider's CLI
+Write a context with the provider's CLI
 (`gcloud container clusters get-credentials …`,
-`az aks get-credentials …`,
-`doctl kubernetes cluster kubeconfig save …`) and point
-`Kubernetes.KubeConfig({ context })` at it. Exec plugins
-(`gke-gcloud-auth-plugin`, `kubelogin`) are honoured. See
-[kubeconfig](/kubernetes/clusters/connecting#kubeconfig). Without a
-kubeconfig file, a raw
-[token, client certificate, or exec](/kubernetes/clusters/connecting#token-client-certificate-and-exec)
-connection needs an explicit `endpoint`.
+`az aks get-credentials …`) and point `Kubernetes.KubeConfig({ context })`
+at it ([kubeconfig](/kubernetes/clusters/connecting#kubeconfig)).
 
 ```typescript
 const gke = Kubernetes.KubeConfig({ context: "gke_my-proj_us-central1_prod" });
 ```
 
-These are auth-only. Bind through env vars and run `image:` references
-your cluster can pull. To add identity and a registry, see
-[Cluster adapters](/kubernetes/guides/cluster-adapters#registering-an-auth-kind).
-
   </TabItem>
 </Tabs>
 
 ## Add the provider
-
-Create `alchemy.run.ts` with `Kubernetes.providers()` as `providers`
-and `Alchemy.localState()` as `state` (see [State Store](/state-store)).
 
 ```typescript
 // alchemy.run.ts
@@ -173,9 +129,7 @@ export default Alchemy.Stack(
 );
 ```
 
-`Kubernetes.providers()` registers the four workload providers and the
-four built-in adapters. Without it a `Kubernetes.*` resource does not
-type-check. EKS needs the AWS layer too.
+EKS needs the AWS layer too, which ships the `aws-eks` adapter:
 
 ```diff lang="typescript"
 import * as Alchemy from "alchemy";
@@ -193,15 +147,9 @@ export default Alchemy.Stack(
   },
 ```
 
-The `aws-eks` adapter ships in `AWS.providers()`. See
-[How the adapter is chosen](/kubernetes/clusters/connecting#how-the-adapter-is-chosen).
-
 ## Verify
 
-Add one [Namespace](/kubernetes/objects/manifests#namespaces) as a
-[`Kubernetes.Manifest`](/providers/kubernetes/manifest) and run
-`alchemy plan`. A Namespace is cluster-scoped, so nothing has to exist
-first.
+Plan one [Namespace](/kubernetes/objects/manifests#namespaces) manifest.
 
 ```diff lang="typescript"
 Effect.gen(function* () {
@@ -239,11 +187,9 @@ Effect.gen(function* () {
 
 [g]+[/g] [b]DemoNamespace[/b] [d](Kubernetes.Manifest)[/d]`} />
 
-The [plan](/cli/plan) proves the program type-checks and the providers
-layer is wired. It does not open a connection, so an unreachable
-context only surfaces on `deploy`. `cluster` is not a row because
-`KubeConfig()` returns a plain value, not a resource
-([the connection model](/kubernetes/clusters/connecting#the-connection-model)).
+`plan` does not open a connection, so an unreachable context only
+surfaces on `deploy`. `KubeConfig()` is a
+[plain value](/kubernetes/clusters/connecting#the-connection-model), not a row.
 
 :::tip[Round-trip it]
 
@@ -253,31 +199,11 @@ kubectl get namespace demo        # STATUS Active
 bun alchemy destroy
 ```
 
-`deploy` uses
-[server-side apply under the `alchemy` field manager](/kubernetes/guides/how-apply-works#server-side-apply).
-`destroy` deletes it. Once green, delete the `DemoNamespace` block.
-Part 1 starts from the empty Stack.
-:::
-
-## State storage
-
-Kubernetes has no state backend of its own. `Alchemy.localState()`
-keeps state under `.alchemy/`, fine for the tutorial and solo work.
-For a team, pass `AWS.state()` or `Cloudflare.state()`. See
-[State Store](/state-store).
-
-:::caution
-Workload attributes
-[persist the cluster connection](/kubernetes/clusters/connecting#the-connection-model),
-so a raw `token` ends up in state. Prefer a kubeconfig context or exec
-plugin, and a remote state store for shared stacks. Details on
-[token, client certificate, and exec](/kubernetes/clusters/connecting#token-client-certificate-and-exec).
+Then delete the `DemoNamespace` block; part 1 starts from the empty Stack.
 :::
 
 ## Where next
 
-- [Tutorial part 1](/kubernetes/tutorial/part-1): deploy from a
-  pre-built image, reach it, scale it, destroy it.
-- [Connecting to clusters](/kubernetes/clusters/connecting): the
-  `Connection` model and the auth kinds.
-- [Kubernetes overview](/kubernetes): the adapter table and the map.
+- [Tutorial part 1](/kubernetes/tutorial/part-1)
+- [Connecting to clusters](/kubernetes/clusters/connecting)
+- [State Store](/state-store)

--- a/website/src/content/docs/kubernetes/setup.mdx
+++ b/website/src/content/docs/kubernetes/setup.mdx
@@ -1,0 +1,283 @@
+---
+title: Setup
+description: Install Alchemy, point it at a Kubernetes cluster — a local one, EKS, or any kubeconfig context — add Kubernetes.providers() to a Stack, and plan your first manifest.
+---
+
+import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
+import { effectVersion } from "../../../versions";
+import Terminal from "../../../components/Terminal.astro";
+
+export const pkgs = `"alchemy@latest" "effect@${effectVersion}" "@effect/platform-bun@${effectVersion}" "@effect/platform-node@${effectVersion}"`;
+
+You need the alchemy package, a cluster your kubeconfig can reach, and
+`Kubernetes.providers()` in a Stack. There is no `alchemy login`. The
+built-in adapters read your kubeconfig like `kubectl` does. Only a
+managed cluster resource (EKS) brings its own cloud credentials.
+
+## Prerequisites
+
+- [Bun](https://bun.sh) (recommended) or Node.js 22+
+- A cluster and a kubeconfig context that reaches it. A local one is
+  enough (see [Pick a cluster](#pick-a-cluster))
+- `kubectl`, used here to check the context and inspect results
+- `helm`, only for `Kubernetes.HelmChart`
+- Docker, only for EKS
+
+## Create a project directory
+
+<Tabs syncKey="pkgManager">
+  <TabItem label="bun" icon="bun">
+    <Code code="mkdir my-app && cd my-app && bun init -y" lang="sh" />
+  </TabItem>
+  <TabItem label="npm" icon="npm">
+    <Code code="mkdir my-app && cd my-app && npm init -y" lang="sh" />
+  </TabItem>
+  <TabItem label="pnpm" icon="pnpm">
+    <Code code="mkdir my-app && cd my-app && pnpm init" lang="sh" />
+  </TabItem>
+  <TabItem label="yarn" icon="seti:yarn">
+    <Code code="mkdir my-app && cd my-app && yarn init -y" lang="sh" />
+  </TabItem>
+</Tabs>
+
+## Install
+
+<Tabs syncKey="pkgManager">
+  <TabItem label="bun" icon="bun">
+    <Code code={`bun add ${pkgs}`} lang="sh" />
+  </TabItem>
+  <TabItem label="npm" icon="npm">
+    <Code code={`npm install ${pkgs}`} lang="sh" />
+  </TabItem>
+  <TabItem label="pnpm" icon="pnpm">
+    <Code code={`pnpm add ${pkgs}`} lang="sh" />
+  </TabItem>
+  <TabItem label="yarn" icon="seti:yarn">
+    <Code code={`yarn add ${pkgs}`} lang="sh" />
+  </TabItem>
+</Tabs>
+
+### Helm
+
+Only [`Kubernetes.HelmChart`](/providers/kubernetes/helmchart) needs
+helm. It runs `helm template` on the deploying machine during `deploy`.
+
+```sh
+brew install helm   # macOS; other platforms: https://helm.sh/docs/intro/install/
+```
+
+Alchemy runs `helm` from `PATH`, or the binary at `HELM_BIN`. Without
+it the first `HelmChart` deploy fails and says so.
+
+### Docker
+
+Only EKS needs Docker, for every image source. Even a pre-built
+`image:` is pulled, tagged, and pushed into the workload's
+[ECR repository](/kubernetes/clusters/eks#what-the-adapter-adds).
+Anything `docker ps` talks to works. `DOCKER_BIN` overrides the binary
+as on the [Docker setup page](/docker/setup).
+
+## Pick a cluster
+
+Any cluster `kubectl` can reach works. Your choice picks a column of
+the [adapter table](/kubernetes#what-the-cluster-adapter-gives-you).
+A kubeconfig cluster has no registry, so workloads run pre-built
+`image:` references. `main:` and `context:` need a registry adapter
+such as EKS
+([why](/kubernetes/workloads/image-sources#registry-requirement)).
+
+<Tabs syncKey="cluster">
+  <TabItem label="Local">
+
+Docker Desktop (Settings → Kubernetes → Enable, context
+`docker-desktop`) or OrbStack (context `orbstack`) is the easiest.
+`kind` and `k3s` / `k3d` also work.
+
+```sh
+kubectl config current-context   # e.g. docker-desktop
+kubectl get nodes                 # one Ready node
+```
+
+Alchemy reads the same file (`$KUBECONFIG`, else `~/.kube/config`)
+and the same `current-context`, unless you pass `context` to
+`Kubernetes.KubeConfig()`. Trade-offs between them are in
+[Which local cluster](/kubernetes/clusters/local#which-local-cluster).
+
+  </TabItem>
+  <TabItem label="EKS">
+
+Pass the `AWS.EKS.Cluster` resource as `cluster` for the full adapter
+([what it adds](/kubernetes/clusters/eks#what-the-adapter-adds)).
+Create the cluster on the [AWS tab](/aws/compute/eks) with credentials
+from [AWS setup](/aws/setup). An `aws eks update-kubeconfig` context
+through `KubeConfig()` is auth-only. See
+[Targeting an EKS cluster](/kubernetes/clusters/eks#targeting-an-eks-cluster).
+
+```typescript
+// full adapter: the resource IS the cluster value
+const cluster = yield* AWS.EKS.Cluster("Cluster", {
+  compute: "auto",
+  resourcesVpcConfig: { subnetIds: network.privateSubnetIds },
+});
+
+// auth-only: a context written by `aws eks update-kubeconfig`
+const existing = Kubernetes.KubeConfig({ context: "arn:aws:eks:us-east-1:123456789012:cluster/prod" });
+```
+
+  </TabItem>
+  <TabItem label="Other managed cluster">
+
+For GKE, AKS, DigitalOcean, on-prem, or anything else, write a context
+with the provider's CLI
+(`gcloud container clusters get-credentials …`,
+`az aks get-credentials …`,
+`doctl kubernetes cluster kubeconfig save …`) and point
+`Kubernetes.KubeConfig({ context })` at it. Exec plugins
+(`gke-gcloud-auth-plugin`, `kubelogin`) are honoured. See
+[kubeconfig](/kubernetes/clusters/connecting#kubeconfig). Without a
+kubeconfig file, a raw
+[token, client certificate, or exec](/kubernetes/clusters/connecting#token-client-certificate-and-exec)
+connection needs an explicit `endpoint`.
+
+```typescript
+const gke = Kubernetes.KubeConfig({ context: "gke_my-proj_us-central1_prod" });
+```
+
+These are auth-only. Bind through env vars and run `image:` references
+your cluster can pull. To add identity and a registry, see
+[Cluster adapters](/kubernetes/guides/cluster-adapters#registering-an-auth-kind).
+
+  </TabItem>
+</Tabs>
+
+## Add the provider
+
+Create `alchemy.run.ts` with `Kubernetes.providers()` as `providers`
+and `Alchemy.localState()` as `state` (see [State Store](/state-store)).
+
+```typescript
+// alchemy.run.ts
+import * as Alchemy from "alchemy";
+import * as Kubernetes from "alchemy/Kubernetes";
+import * as Effect from "effect/Effect";
+
+export default Alchemy.Stack(
+  "MyApp",
+  {
+    providers: Kubernetes.providers(),   // workload providers + kubeconfig/token/client-cert/exec adapters
+    state: Alchemy.localState(),
+  },
+  Effect.gen(function* () {
+    // resources go here
+  }),
+);
+```
+
+`Kubernetes.providers()` registers the four workload providers and the
+four built-in adapters. Without it a `Kubernetes.*` resource does not
+type-check. EKS needs the AWS layer too.
+
+```diff lang="typescript"
+import * as Alchemy from "alchemy";
++import * as AWS from "alchemy/AWS";
+import * as Kubernetes from "alchemy/Kubernetes";
+import * as Effect from "effect/Effect";
++import * as Layer from "effect/Layer";
+
+export default Alchemy.Stack(
+  "MyApp",
+  {
+-    providers: Kubernetes.providers(),
++    providers: Layer.mergeAll(AWS.providers(), Kubernetes.providers()),
+    state: Alchemy.localState(),
+  },
+```
+
+The `aws-eks` adapter ships in `AWS.providers()`. See
+[How the adapter is chosen](/kubernetes/clusters/connecting#how-the-adapter-is-chosen).
+
+## Verify
+
+Add one [Namespace](/kubernetes/objects/manifests#namespaces) as a
+[`Kubernetes.Manifest`](/providers/kubernetes/manifest) and run
+`alchemy plan`. A Namespace is cluster-scoped, so nothing has to exist
+first.
+
+```diff lang="typescript"
+Effect.gen(function* () {
++  const cluster = Kubernetes.KubeConfig();   // current-context; pass { context: "..." } to pin one
++
++  const ns = yield* Kubernetes.Manifest("DemoNamespace", {
++    cluster,
++    manifest: {
++      apiVersion: "v1",
++      kind: "Namespace",
++      metadata: { name: "demo" },
++    },
++  });
++
++  return { namespace: ns.name };
+}),
+```
+
+<Tabs syncKey="pkgManager">
+  <TabItem label="bun" icon="bun">
+    <Code code="bun alchemy plan" lang="sh" />
+  </TabItem>
+  <TabItem label="npm" icon="npm">
+    <Code code="npm run alchemy plan" lang="sh" />
+  </TabItem>
+  <TabItem label="pnpm" icon="pnpm">
+    <Code code="pnpm alchemy plan" lang="sh" />
+  </TabItem>
+  <TabItem label="yarn" icon="seti:yarn">
+    <Code code="yarn alchemy plan" lang="sh" />
+  </TabItem>
+</Tabs>
+
+<Terminal content={`[u]Plan[/u]: [g]1 to create[/g]
+
+[g]+[/g] [b]DemoNamespace[/b] [d](Kubernetes.Manifest)[/d]`} />
+
+The [plan](/cli/plan) proves the program type-checks and the providers
+layer is wired. It does not open a connection, so an unreachable
+context only surfaces on `deploy`. `cluster` is not a row because
+`KubeConfig()` returns a plain value, not a resource
+([the connection model](/kubernetes/clusters/connecting#the-connection-model)).
+
+:::tip[Round-trip it]
+
+```sh
+bun alchemy deploy
+kubectl get namespace demo        # STATUS Active
+bun alchemy destroy
+```
+
+`deploy` uses
+[server-side apply under the `alchemy` field manager](/kubernetes/guides/how-apply-works#server-side-apply).
+`destroy` deletes it. Once green, delete the `DemoNamespace` block.
+Part 1 starts from the empty Stack.
+:::
+
+## State storage
+
+Kubernetes has no state backend of its own. `Alchemy.localState()`
+keeps state under `.alchemy/`, fine for the tutorial and solo work.
+For a team, pass `AWS.state()` or `Cloudflare.state()`. See
+[State Store](/state-store).
+
+:::caution
+Workload attributes
+[persist the cluster connection](/kubernetes/clusters/connecting#the-connection-model),
+so a raw `token` ends up in state. Prefer a kubeconfig context or exec
+plugin, and a remote state store for shared stacks. Details on
+[token, client certificate, and exec](/kubernetes/clusters/connecting#token-client-certificate-and-exec).
+:::
+
+## Where next
+
+- [Tutorial part 1](/kubernetes/tutorial/part-1): deploy from a
+  pre-built image, reach it, scale it, destroy it.
+- [Connecting to clusters](/kubernetes/clusters/connecting): the
+  `Connection` model and the auth kinds.
+- [Kubernetes overview](/kubernetes): the adapter table and the map.

--- a/website/src/content/docs/kubernetes/tutorial/part-1.mdx
+++ b/website/src/content/docs/kubernetes/tutorial/part-1.mdx
@@ -8,27 +8,22 @@ sidebar:
 import Terminal from "../../../../components/Terminal.astro";
 import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 
-Point a Stack at the local cluster you picked in Setup, deploy a
-pre-built image as a `Kubernetes.Deployment`, reach it, scale it,
-and tear it down. Nothing up to Part 4 costs money.
+Point a Stack at the local cluster from Setup, deploy a pre-built
+image as a `Kubernetes.Deployment`, reach it, scale it, tear it down.
 
 ## Prerequisites
 
-- [Bun](https://bun.sh) (recommended) or Node.js 22+
-- Alchemy installed. See [Setup](/kubernetes/setup#install)
-- A running local cluster listed by `kubectl config get-contexts`.
-  See [Pick a cluster](/kubernetes/setup#pick-a-cluster)
+- [Alchemy installed](/kubernetes/setup#install)
+- A [local cluster](/kubernetes/setup#pick-a-cluster) in
+  `kubectl config get-contexts`
 
-The steps assume Docker Desktop's `docker-desktop` context or
-OrbStack's `orbstack`. kind and minikube need the one change in
-[Choose how to reach it](#choose-how-to-reach-it).
+Steps assume the `docker-desktop` context; kind and minikube need
+[one change](#choose-how-to-reach-it).
 
 ## Create a project
 
-Continue in the project from Setup. Its `alchemy.run.ts` is the file
-the next four parts build on.
-
-Starting fresh? Create an empty project first:
+Continue in the Setup project, or start fresh and install as in
+[Setup](/kubernetes/setup#install):
 
 <Tabs syncKey="pkgManager">
   <TabItem label="bun" icon="bun">
@@ -45,12 +40,9 @@ Starting fresh? Create an empty project first:
   </TabItem>
 </Tabs>
 
-Then install alchemy and Effect as in [Setup](/kubernetes/setup#install).
-
 ## Create the Stack
 
-Start from the Setup `alchemy.run.ts` with the `DemoNamespace`
-verify resource removed:
+Start from the Setup `alchemy.run.ts` with `DemoNamespace` removed:
 
 ```typescript
 // alchemy.run.ts
@@ -70,17 +62,7 @@ export default Alchemy.Stack(
 );
 ```
 
-`Kubernetes.providers()` is the four workload providers plus the
-built-in cluster adapters from
-[Setup](/kubernetes/setup#add-the-provider). `Alchemy.localState()`
-keeps state on disk, which is fine for a solo tutorial. See
-[State Store](/state-store) for shared options. If you skipped
-Setup's destroy, expect an extra `1 to delete` row for
-`DemoNamespace` below.
-
 ## Point at your cluster
-
-Describe how to reach the cluster:
 
 ```diff lang="typescript"
 Effect.gen(function* () {
@@ -89,12 +71,9 @@ Effect.gen(function* () {
 ```
 
 [`KubeConfig`](/kubernetes/clusters/connecting#kubeconfig) is a plain
-helper, not a resource. No `yield*`, and it never shows up in a plan.
-Use whatever context name `kubectl config get-contexts` shows.
+helper, not a resource; use your context name.
 
 ## Add a Deployment
-
-Declare a Deployment running a pre-built echo image:
 
 ```diff lang="typescript"
 Effect.gen(function* () {
@@ -108,20 +87,12 @@ Effect.gen(function* () {
 }),
 ```
 
-One [`Kubernetes.Deployment`](/providers/kubernetes/deployment)
-synthesizes
-[three objects](/kubernetes/workloads/deployments#what-gets-created):
-a Deployment, a Service, and a ServiceAccount. `port` is both the
-container port and the Service port. The echo image listens on 8080
-and answers every request with a JSON copy of it.
-
-It has to be `image:` here. A kubeconfig cluster has
-[no managed image registry](/kubernetes/workloads/image-sources#registry-requirement),
-so Part 5 is where `main:` comes in.
+One resource synthesizes
+[three objects](/kubernetes/workloads/deployments#what-gets-created).
+It must be `image:`: a kubeconfig cluster has
+[no registry](/kubernetes/workloads/image-sources#registry-requirement).
 
 ## Choose how to reach it
-
-Make the Service type explicit:
 
 ```diff lang="typescript"
 const echo = yield* Kubernetes.Deployment("Echo", {
@@ -132,24 +103,16 @@ const echo = yield* Kubernetes.Deployment("Echo", {
 });
 ```
 
-`serviceType` picks the Service type. `LoadBalancer` is the default
-and is what fills the Deployment's
+`LoadBalancer` is the default and fills the Deployment's
 [`url`](/kubernetes/workloads/deployments#exposing-it-servicetype-and-url).
 
 :::note[No LoadBalancer on your cluster?]
-Docker Desktop and OrbStack publish LoadBalancer Services locally, so
-`url` resolves. kind and minikube do not. Use `serviceType: "NodePort"`
-or `ClusterIP` there, then
-`kubectl port-forward svc/<deployment output> 8080:8080` and curl
-`localhost:8080` wherever the steps use the `url`. Keeping the default
-on kind still deploys, but only after a ~3-minute wait, and `url` comes
-back `undefined`. See
-[Reaching a service](/kubernetes/clusters/local#reaching-a-service).
+kind and minikube have no LoadBalancer: use `serviceType: "NodePort"`
+and `kubectl port-forward` instead of `url`
+([Reaching a service](/kubernetes/clusters/local#reaching-a-service)).
 :::
 
 ## Return Stack outputs
-
-Return the values you will need:
 
 ```diff lang="typescript"
 const echo = yield* Kubernetes.Deployment("Echo", {
@@ -165,9 +128,7 @@ const echo = yield* Kubernetes.Deployment("Echo", {
 +};
 ```
 
-`url` is `http://<address>:8080`. The load balancer listens on the
-Service `port`, so a non-80 port is part of the URL.
-`deploymentName` is the generated object name for `kubectl`.
+`deploymentName` is the object name for `kubectl`.
 
 ## Deploy
 
@@ -199,35 +160,23 @@ Proceed?
 [s2]deployment: "myapp-echo-dev-alex-k3m7p2q6r4s5t2v6",
 }`} />
 
-One row, because the kubeconfig connection is not a resource. Behind
-it Alchemy applied the ServiceAccount, Service, and Deployment and
-waited for an address. "Applied" means
-[server-side apply](/kubernetes/guides/how-apply-works#server-side-apply)
-with the field manager `alchemy`. The first deploy pulls the image,
-so the pods take a few seconds.
+One row: the kubeconfig connection is not a resource.
 
 ## Try it out
-
-Hit the `url`:
 
 ```sh
 curl http://localhost:8080
 ```
 
-The response is a JSON document with the request and the pod's
-hostname under `os.hostname`. List the objects Alchemy owns:
+The pod's hostname is under `os.hostname`. List the objects Alchemy
+owns:
 
 ```sh
 kubectl get deployment,service,serviceaccount \
   -l app.kubernetes.io/name=myapp-echo-dev-alex-k3m7p2q6r4s5t2v6
 ```
 
-The `app.kubernetes.io/name` label is on every object and is the
-Service's selector.
-
 ## Scale it
-
-Run three replicas:
 
 ```diff lang="typescript"
 const echo = yield* Kubernetes.Deployment("Echo", {
@@ -248,16 +197,12 @@ Proceed?
 [d]Applied Kubernetes Deployment default/myapp-echo-dev-alex-k3m7p2q6r4s5t2v6[/d]
 [g]✓[/g] [b]Echo[/b] [d](Kubernetes.Deployment)[/d] [y]updated[/y]`} />
 
-`replicas` is mutable, so this is an in-place update, not a
-replacement. `kubectl get pods` shows three pods, and repeated curls
-return different `os.hostname` values. Updates re-apply the full
-object, so drift from `kubectl edit` is corrected on the next change
-or with `alchemy deploy --force`. See
-[pruning and drift](/kubernetes/guides/how-apply-works#pruning-and-drift).
+`replicas` is mutable, so this is an in-place update; repeated curls
+now return different hostnames.
 
 ## Deploy again
 
-Run `alchemy deploy` once more without editing anything:
+Deploy again without editing anything:
 
 <Terminal content={`[u]Plan[/u]: [d]no changes[/d]
 
@@ -265,9 +210,6 @@ Run `alchemy deploy` once more without editing anything:
 [s2]url: "http://localhost:8080",
 [s2]deployment: "myapp-echo-dev-alex-k3m7p2q6r4s5t2v6",
 }`} />
-
-Declare, deploy, and Alchemy diffs against what it deployed last
-time.
 
 ## Destroy
 
@@ -294,21 +236,10 @@ Proceed?
 ◉ Yes ○ No
 [r]✗[/r] [b]Echo[/b] [d](Kubernetes.Deployment)[/d] [r]deleted[/r]`} />
 
-The objects go in reverse apply order: Deployment, Service,
-ServiceAccount. State is cleared. Part 2 recreates `Echo` on its
-first deploy, so destroying now costs nothing.
-
-## Recap
-
-One resource made three objects reachable at a `url`. You updated it
-in place, ran a no-op deploy, and destroyed it. Part 2 adds
-`Kubernetes.Job` and turns it into a CronJob with one prop.
+Objects go in reverse apply order. Part 2 recreates `Echo`.
 
 ## Where next
 
-- [Part 2: Jobs and CronJobs](/kubernetes/tutorial/part-2) — run
-  something to completion, then on a schedule.
-- [Deployments](/kubernetes/workloads/deployments) — every prop and
-  attribute, the tagged form, Effect servers.
-- [Local clusters](/kubernetes/clusters/local) — which local cluster
-  to pick and how to reach services on each.
+- [Part 2: Jobs and CronJobs](/kubernetes/tutorial/part-2)
+- [Deployments](/kubernetes/workloads/deployments)
+- [Local clusters](/kubernetes/clusters/local)

--- a/website/src/content/docs/kubernetes/tutorial/part-1.mdx
+++ b/website/src/content/docs/kubernetes/tutorial/part-1.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Part 1: Your First Deployment"
-description: Point a Stack at your local cluster with Kubernetes.KubeConfig, deploy a pre-built image as a Kubernetes.Deployment, reach it, scale it, and tear it down.
+description: Deploy a pre-built image to your local cluster with Kubernetes.Deployment, reach it, scale it, and tear it down.
 sidebar:
   order: 1
 ---
@@ -8,8 +8,8 @@ sidebar:
 import Terminal from "../../../../components/Terminal.astro";
 import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 
-Point a Stack at the local cluster from Setup, deploy a pre-built
-image as a `Kubernetes.Deployment`, reach it, scale it, tear it down.
+Deploy a pre-built image to your local cluster, reach it from your
+laptop, scale it, and tear it down.
 
 ## Prerequisites
 
@@ -17,13 +17,14 @@ image as a `Kubernetes.Deployment`, reach it, scale it, tear it down.
 - A [local cluster](/kubernetes/setup#pick-a-cluster) in
   `kubectl config get-contexts`
 
-Steps assume the `docker-desktop` context; kind and minikube need
-[one change](#choose-how-to-reach-it).
+Replace `docker-desktop` with your context name. On kind or minikube,
+also set `serviceType` (see
+[Choose how to reach it](#choose-how-to-reach-it)).
 
 ## Create a project
 
-Continue in the Setup project, or start fresh and install as in
-[Setup](/kubernetes/setup#install):
+Keep using the Setup project, or start a new one and
+[install Alchemy](/kubernetes/setup#install):
 
 <Tabs syncKey="pkgManager">
   <TabItem label="bun" icon="bun">
@@ -42,7 +43,7 @@ Continue in the Setup project, or start fresh and install as in
 
 ## Create the Stack
 
-Start from the Setup `alchemy.run.ts` with `DemoNamespace` removed:
+Start with an empty Stack:
 
 ```typescript
 // alchemy.run.ts
@@ -70,8 +71,8 @@ Effect.gen(function* () {
 }),
 ```
 
-[`KubeConfig`](/kubernetes/clusters/connecting#kubeconfig) is a plain
-helper, not a resource; use your context name.
+[`KubeConfig`](/kubernetes/clusters/connecting#kubeconfig) connects to
+any cluster in your kubeconfig.
 
 ## Add a Deployment
 
@@ -87,10 +88,10 @@ Effect.gen(function* () {
 }),
 ```
 
-One resource synthesizes
-[three objects](/kubernetes/workloads/deployments#what-gets-created).
-It must be `image:`: a kubeconfig cluster has
-[no registry](/kubernetes/workloads/image-sources#registry-requirement).
+This creates a Deployment, a Service, and a
+[ServiceAccount](/kubernetes/workloads/deployments#what-gets-created).
+Use a pre-built image; local clusters
+[can't build images](/kubernetes/workloads/image-sources#registry-requirement).
 
 ## Choose how to reach it
 
@@ -103,12 +104,12 @@ const echo = yield* Kubernetes.Deployment("Echo", {
 });
 ```
 
-`LoadBalancer` is the default and fills the Deployment's
+`LoadBalancer` is the default and gives the Deployment a
 [`url`](/kubernetes/workloads/deployments#exposing-it-servicetype-and-url).
 
 :::note[No LoadBalancer on your cluster?]
-kind and minikube have no LoadBalancer: use `serviceType: "NodePort"`
-and `kubectl port-forward` instead of `url`
+On kind or minikube, set `serviceType: "NodePort"` and use
+`kubectl port-forward` instead of `url`
 ([Reaching a service](/kubernetes/clusters/local#reaching-a-service)).
 :::
 
@@ -128,7 +129,7 @@ const echo = yield* Kubernetes.Deployment("Echo", {
 +};
 ```
 
-`deploymentName` is the object name for `kubectl`.
+`deploymentName` is the name you pass to `kubectl`.
 
 ## Deploy
 
@@ -160,8 +161,6 @@ Proceed?
 [s2]deployment: "myapp-echo-dev-alex-k3m7p2q6r4s5t2v6",
 }`} />
 
-One row: the kubeconfig connection is not a resource.
-
 ## Try it out
 
 ```sh
@@ -169,7 +168,7 @@ curl http://localhost:8080
 ```
 
 The pod's hostname is under `os.hostname`. List the objects Alchemy
-owns:
+created:
 
 ```sh
 kubectl get deployment,service,serviceaccount \
@@ -197,8 +196,8 @@ Proceed?
 [d]Applied Kubernetes Deployment default/myapp-echo-dev-alex-k3m7p2q6r4s5t2v6[/d]
 [g]✓[/g] [b]Echo[/b] [d](Kubernetes.Deployment)[/d] [y]updated[/y]`} />
 
-`replicas` is mutable, so this is an in-place update; repeated curls
-now return different hostnames.
+The Deployment updates in place; repeated curls now return different
+hostnames.
 
 ## Deploy again
 
@@ -235,8 +234,6 @@ Deploy again without editing anything:
 Proceed?
 ◉ Yes ○ No
 [r]✗[/r] [b]Echo[/b] [d](Kubernetes.Deployment)[/d] [r]deleted[/r]`} />
-
-Objects go in reverse apply order. Part 2 recreates `Echo`.
 
 ## Where next
 

--- a/website/src/content/docs/kubernetes/tutorial/part-1.mdx
+++ b/website/src/content/docs/kubernetes/tutorial/part-1.mdx
@@ -1,0 +1,314 @@
+---
+title: "Part 1: Your First Deployment"
+description: Point a Stack at your local cluster with Kubernetes.KubeConfig, deploy a pre-built image as a Kubernetes.Deployment, reach it, scale it, and tear it down.
+sidebar:
+  order: 1
+---
+
+import Terminal from "../../../../components/Terminal.astro";
+import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
+
+Point a Stack at the local cluster you picked in Setup, deploy a
+pre-built image as a `Kubernetes.Deployment`, reach it, scale it,
+and tear it down. Nothing up to Part 4 costs money.
+
+## Prerequisites
+
+- [Bun](https://bun.sh) (recommended) or Node.js 22+
+- Alchemy installed. See [Setup](/kubernetes/setup#install)
+- A running local cluster listed by `kubectl config get-contexts`.
+  See [Pick a cluster](/kubernetes/setup#pick-a-cluster)
+
+The steps assume Docker Desktop's `docker-desktop` context or
+OrbStack's `orbstack`. kind and minikube need the one change in
+[Choose how to reach it](#choose-how-to-reach-it).
+
+## Create a project
+
+Continue in the project from Setup. Its `alchemy.run.ts` is the file
+the next four parts build on.
+
+Starting fresh? Create an empty project first:
+
+<Tabs syncKey="pkgManager">
+  <TabItem label="bun" icon="bun">
+    <Code code="mkdir my-app && cd my-app && bun init -y" lang="sh" />
+  </TabItem>
+  <TabItem label="npm" icon="npm">
+    <Code code="mkdir my-app && cd my-app && npm init -y" lang="sh" />
+  </TabItem>
+  <TabItem label="pnpm" icon="pnpm">
+    <Code code="mkdir my-app && cd my-app && pnpm init" lang="sh" />
+  </TabItem>
+  <TabItem label="yarn" icon="seti:yarn">
+    <Code code="mkdir my-app && cd my-app && yarn init -y" lang="sh" />
+  </TabItem>
+</Tabs>
+
+Then install alchemy and Effect as in [Setup](/kubernetes/setup#install).
+
+## Create the Stack
+
+Start from the Setup `alchemy.run.ts` with the `DemoNamespace`
+verify resource removed:
+
+```typescript
+// alchemy.run.ts
+import * as Alchemy from "alchemy";
+import * as Kubernetes from "alchemy/Kubernetes";
+import * as Effect from "effect/Effect";
+
+export default Alchemy.Stack(
+  "MyApp",
+  {
+    providers: Kubernetes.providers(),
+    state: Alchemy.localState(),
+  },
+  Effect.gen(function* () {
+    // resources go here
+  }),
+);
+```
+
+`Kubernetes.providers()` is the four workload providers plus the
+built-in cluster adapters from
+[Setup](/kubernetes/setup#add-the-provider). `Alchemy.localState()`
+keeps state on disk, which is fine for a solo tutorial. See
+[State Store](/state-store) for shared options. If you skipped
+Setup's destroy, expect an extra `1 to delete` row for
+`DemoNamespace` below.
+
+## Point at your cluster
+
+Describe how to reach the cluster:
+
+```diff lang="typescript"
+Effect.gen(function* () {
++  const cluster = Kubernetes.KubeConfig({ context: "docker-desktop" });
+}),
+```
+
+[`KubeConfig`](/kubernetes/clusters/connecting#kubeconfig) is a plain
+helper, not a resource. No `yield*`, and it never shows up in a plan.
+Use whatever context name `kubectl config get-contexts` shows.
+
+## Add a Deployment
+
+Declare a Deployment running a pre-built echo image:
+
+```diff lang="typescript"
+Effect.gen(function* () {
+  const cluster = Kubernetes.KubeConfig({ context: "docker-desktop" });
+
++  const echo = yield* Kubernetes.Deployment("Echo", {
++    cluster,
++    image: "mendhak/http-https-echo:33",
++    port: 8080,
++  });
+}),
+```
+
+One [`Kubernetes.Deployment`](/providers/kubernetes/deployment)
+synthesizes
+[three objects](/kubernetes/workloads/deployments#what-gets-created):
+a Deployment, a Service, and a ServiceAccount. `port` is both the
+container port and the Service port. The echo image listens on 8080
+and answers every request with a JSON copy of it.
+
+It has to be `image:` here. A kubeconfig cluster has
+[no managed image registry](/kubernetes/workloads/image-sources#registry-requirement),
+so Part 5 is where `main:` comes in.
+
+## Choose how to reach it
+
+Make the Service type explicit:
+
+```diff lang="typescript"
+const echo = yield* Kubernetes.Deployment("Echo", {
+  cluster,
+  image: "mendhak/http-https-echo:33",
+  port: 8080,
++  serviceType: "LoadBalancer",
+});
+```
+
+`serviceType` picks the Service type. `LoadBalancer` is the default
+and is what fills the Deployment's
+[`url`](/kubernetes/workloads/deployments#exposing-it-servicetype-and-url).
+
+:::note[No LoadBalancer on your cluster?]
+Docker Desktop and OrbStack publish LoadBalancer Services locally, so
+`url` resolves. kind and minikube do not. Use `serviceType: "NodePort"`
+or `ClusterIP` there, then
+`kubectl port-forward svc/<deployment output> 8080:8080` and curl
+`localhost:8080` wherever the steps use the `url`. Keeping the default
+on kind still deploys, but only after a ~3-minute wait, and `url` comes
+back `undefined`. See
+[Reaching a service](/kubernetes/clusters/local#reaching-a-service).
+:::
+
+## Return Stack outputs
+
+Return the values you will need:
+
+```diff lang="typescript"
+const echo = yield* Kubernetes.Deployment("Echo", {
+  cluster,
+  image: "mendhak/http-https-echo:33",
+  port: 8080,
+  serviceType: "LoadBalancer",
+});
+
++return {
++  url: echo.url,
++  deployment: echo.deploymentName,
++};
+```
+
+`url` is `http://<address>:8080`. The load balancer listens on the
+Service `port`, so a non-80 port is part of the URL.
+`deploymentName` is the generated object name for `kubectl`.
+
+## Deploy
+
+<Tabs syncKey="pkgManager">
+  <TabItem label="bun" icon="bun">
+    <Code code="bun alchemy deploy" lang="sh" />
+  </TabItem>
+  <TabItem label="npm" icon="npm">
+    <Code code="npm run alchemy deploy" lang="sh" />
+  </TabItem>
+  <TabItem label="pnpm" icon="pnpm">
+    <Code code="pnpm alchemy deploy" lang="sh" />
+  </TabItem>
+  <TabItem label="yarn" icon="seti:yarn">
+    <Code code="yarn alchemy deploy" lang="sh" />
+  </TabItem>
+</Tabs>
+
+<Terminal content={`[u]Plan[/u]: [g]1 to create[/g]
+
+[g]+[/g] [b]Echo[/b] [d](Kubernetes.Deployment)[/d]
+
+Proceed?
+◉ Yes ○ No
+[d]Applied Kubernetes Deployment default/myapp-echo-dev-alex-k3m7p2q6r4s5t2v6[/d]
+[g]✓[/g] [b]Echo[/b] [d](Kubernetes.Deployment)[/d] [g]created[/g]
+{
+[s2]url: "http://localhost:8080",
+[s2]deployment: "myapp-echo-dev-alex-k3m7p2q6r4s5t2v6",
+}`} />
+
+One row, because the kubeconfig connection is not a resource. Behind
+it Alchemy applied the ServiceAccount, Service, and Deployment and
+waited for an address. "Applied" means
+[server-side apply](/kubernetes/guides/how-apply-works#server-side-apply)
+with the field manager `alchemy`. The first deploy pulls the image,
+so the pods take a few seconds.
+
+## Try it out
+
+Hit the `url`:
+
+```sh
+curl http://localhost:8080
+```
+
+The response is a JSON document with the request and the pod's
+hostname under `os.hostname`. List the objects Alchemy owns:
+
+```sh
+kubectl get deployment,service,serviceaccount \
+  -l app.kubernetes.io/name=myapp-echo-dev-alex-k3m7p2q6r4s5t2v6
+```
+
+The `app.kubernetes.io/name` label is on every object and is the
+Service's selector.
+
+## Scale it
+
+Run three replicas:
+
+```diff lang="typescript"
+const echo = yield* Kubernetes.Deployment("Echo", {
+  cluster,
+  image: "mendhak/http-https-echo:33",
+  port: 8080,
+  serviceType: "LoadBalancer",
++  replicas: 3,
+});
+```
+
+<Terminal content={`[u]Plan[/u]: [y]1 to update[/y]
+
+[y]~[/y] [b]Echo[/b] [d](Kubernetes.Deployment)[/d]
+
+Proceed?
+◉ Yes ○ No
+[d]Applied Kubernetes Deployment default/myapp-echo-dev-alex-k3m7p2q6r4s5t2v6[/d]
+[g]✓[/g] [b]Echo[/b] [d](Kubernetes.Deployment)[/d] [y]updated[/y]`} />
+
+`replicas` is mutable, so this is an in-place update, not a
+replacement. `kubectl get pods` shows three pods, and repeated curls
+return different `os.hostname` values. Updates re-apply the full
+object, so drift from `kubectl edit` is corrected on the next change
+or with `alchemy deploy --force`. See
+[pruning and drift](/kubernetes/guides/how-apply-works#pruning-and-drift).
+
+## Deploy again
+
+Run `alchemy deploy` once more without editing anything:
+
+<Terminal content={`[u]Plan[/u]: [d]no changes[/d]
+
+{
+[s2]url: "http://localhost:8080",
+[s2]deployment: "myapp-echo-dev-alex-k3m7p2q6r4s5t2v6",
+}`} />
+
+Declare, deploy, and Alchemy diffs against what it deployed last
+time.
+
+## Destroy
+
+<Tabs syncKey="pkgManager">
+  <TabItem label="bun" icon="bun">
+    <Code code="bun alchemy destroy" lang="sh" />
+  </TabItem>
+  <TabItem label="npm" icon="npm">
+    <Code code="npm run alchemy destroy" lang="sh" />
+  </TabItem>
+  <TabItem label="pnpm" icon="pnpm">
+    <Code code="pnpm alchemy destroy" lang="sh" />
+  </TabItem>
+  <TabItem label="yarn" icon="seti:yarn">
+    <Code code="yarn alchemy destroy" lang="sh" />
+  </TabItem>
+</Tabs>
+
+<Terminal content={`[u]Plan[/u]: [r]1 to delete[/r]
+
+[r]-[/r] [b]Echo[/b] [d](Kubernetes.Deployment)[/d]
+
+Proceed?
+◉ Yes ○ No
+[r]✗[/r] [b]Echo[/b] [d](Kubernetes.Deployment)[/d] [r]deleted[/r]`} />
+
+The objects go in reverse apply order: Deployment, Service,
+ServiceAccount. State is cleared. Part 2 recreates `Echo` on its
+first deploy, so destroying now costs nothing.
+
+## Recap
+
+One resource made three objects reachable at a `url`. You updated it
+in place, ran a no-op deploy, and destroyed it. Part 2 adds
+`Kubernetes.Job` and turns it into a CronJob with one prop.
+
+## Where next
+
+- [Part 2: Jobs and CronJobs](/kubernetes/tutorial/part-2) — run
+  something to completion, then on a schedule.
+- [Deployments](/kubernetes/workloads/deployments) — every prop and
+  attribute, the tagged form, Effect servers.
+- [Local clusters](/kubernetes/clusters/local) — which local cluster
+  to pick and how to reach services on each.

--- a/website/src/content/docs/kubernetes/tutorial/part-2.mdx
+++ b/website/src/content/docs/kubernetes/tutorial/part-2.mdx
@@ -1,0 +1,236 @@
+---
+title: "Part 2: Jobs and CronJobs"
+description: Run a container to completion with Kubernetes.Job, control retries and cleanup with backoffLimit and ttlSecondsAfterFinished, then turn it into a CronJob with one schedule prop.
+sidebar:
+  order: 2
+---
+
+import Terminal from "../../../../components/Terminal.astro";
+import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
+
+[Part 1](/kubernetes/tutorial/part-1) deployed a long-running server.
+Now add a `Kubernetes.Job` that runs to completion, then retry it,
+clean it up, and schedule it. The Part 1 file carries over. If you
+destroyed it, the first deploy recreates `Echo`.
+
+## Add a Job
+
+Declare a Job below `Echo`:
+
+```diff lang="typescript"
+const echo = yield* Kubernetes.Deployment("Echo", {
+  cluster,
+  image: "mendhak/http-https-echo:33",
+  port: 8080,
+  serviceType: "LoadBalancer",
+  replicas: 3,
+});
+
++const hello = yield* Kubernetes.Job("Hello", {
++  cluster,
++  image: "busybox:1.36",
++  command: ["sh", "-c"],
++  args: ["echo hello from alchemy; date"],
++});
+```
+
+[`Kubernetes.Job`](/providers/kubernetes/job) is the analog of
+`AWS.ECS.Task`: a `batch/v1 Job` plus a `ServiceAccount` (see
+[Jobs](/kubernetes/workloads/jobs#jobs)). Kubernetes runs it the
+moment it is applied. `command` and `args` pass through verbatim.
+busybox has no entrypoint that exits, so we give it a shell line.
+
+## Expose the Job name
+
+Add the Job's name to the outputs:
+
+```diff lang="typescript"
+return {
+  url: echo.url,
+  deployment: echo.deploymentName,
++  job: hello.jobName,
+};
+```
+
+The generated name is `<base>-<8 hex chars>`. A one-shot Job's pod
+template is immutable, so Alchemy hashes the spec into the name. You
+need the exact name for `kubectl logs`.
+
+## Deploy and watch it run
+
+<Tabs syncKey="pkgManager">
+  <TabItem label="bun" icon="bun">
+    <Code code="bun alchemy deploy" lang="sh" />
+  </TabItem>
+  <TabItem label="npm" icon="npm">
+    <Code code="npm run alchemy deploy" lang="sh" />
+  </TabItem>
+  <TabItem label="pnpm" icon="pnpm">
+    <Code code="pnpm alchemy deploy" lang="sh" />
+  </TabItem>
+  <TabItem label="yarn" icon="seti:yarn">
+    <Code code="yarn alchemy deploy" lang="sh" />
+  </TabItem>
+</Tabs>
+
+<Terminal content={`[u]Plan[/u]: [g]2 to create[/g]
+
+[g]+[/g] [b]Echo[/b] [d](Kubernetes.Deployment)[/d]
+[g]+[/g] [b]Hello[/b] [d](Kubernetes.Job)[/d]
+
+Proceed?
+◉ Yes ○ No
+[g]✓[/g] [b]Echo[/b] [d](Kubernetes.Deployment)[/d] [g]created[/g]
+[g]✓[/g] [b]Hello[/b] [d](Kubernetes.Job)[/d] [g]created[/g]
+{
+[s2]url: "http://localhost:8080",
+[s2]deployment: "myapp-echo-dev-alex-k3m7p2q6r4s5t2v6",
+[s2]job: "myapp-hello-dev-alex-h6g5f4e3d2c7b2a4-3f9a1c2e",
+}`} />
+
+If `Echo` was still deployed, the plan is `1 to create`. Check on
+the Job:
+
+```sh
+kubectl get jobs
+```
+
+After a few seconds `COMPLETIONS` reads `1/1`. Read its output with
+the `job` output from the deploy:
+
+```sh
+kubectl logs job/myapp-hello-dev-alex-h6g5f4e3d2c7b2a4-3f9a1c2e
+```
+
+It prints `hello from alchemy` and the date. The deploy did not wait
+for completion. `Job` means "make sure this Job object exists", and
+Kubernetes runs it asynchronously.
+
+## Change the command and run it again
+
+Edit the shell line:
+
+```diff lang="typescript"
+const hello = yield* Kubernetes.Job("Hello", {
+  cluster,
+  image: "busybox:1.36",
+  command: ["sh", "-c"],
+-  args: ["echo hello from alchemy; date"],
++  args: ["echo hello again; date"],
+});
+```
+
+<Terminal content={`[u]Plan[/u]: [y]1 to update[/y]
+
+[y]~[/y] [b]Hello[/b] [d](Kubernetes.Job)[/d]
+
+Proceed?
+◉ Yes ○ No
+[g]✓[/g] [b]Hello[/b] [d](Kubernetes.Job)[/d] [y]updated[/y]`} />
+
+The name is content-addressed, so a changed spec is a new Job object
+with a new hash suffix, and it runs. The old one is
+[pruned](/kubernetes/guides/how-apply-works#pruning-and-drift) with
+its pods. Edit and deploy re-runs a one-shot Job, and the two edits
+below do the same.
+
+## Limit retries with backoffLimit
+
+Cap the retries:
+
+```diff lang="typescript"
+const hello = yield* Kubernetes.Job("Hello", {
+  cluster,
+  image: "busybox:1.36",
+  command: ["sh", "-c"],
+  args: ["echo hello again; date"],
++  backoffLimit: 1,
+});
+```
+
+`backoffLimit` is the Kubernetes field: retries before the Job is
+marked failed. The default of 6 retries a broken command for minutes.
+Swap `args` for `["exit 1"]` to watch it stop after two attempts.
+`restartPolicy` and the backoff curve are on
+[Jobs](/kubernetes/workloads/jobs#jobs).
+
+## Clean up finished Jobs with ttlSecondsAfterFinished
+
+Have finished Jobs delete themselves:
+
+```diff lang="typescript"
+const hello = yield* Kubernetes.Job("Hello", {
+  cluster,
+  image: "busybox:1.36",
+  command: ["sh", "-c"],
+  args: ["echo hello again; date"],
+  backoffLimit: 1,
++  ttlSecondsAfterFinished: 60,
+});
+```
+
+Finished Jobs and their pods stay around forever by default. The TTL
+controller deletes them this many seconds after completion. A
+TTL-collected Job does not look missing to Alchemy, so the next
+deploy is still `no changes`. See
+[Jobs](/kubernetes/workloads/jobs#jobs) for why.
+
+## Put it on a schedule
+
+Add a cron schedule and expose the resource's `kind`:
+
+```diff lang="typescript"
+const hello = yield* Kubernetes.Job("Hello", {
+  cluster,
+  image: "busybox:1.36",
+  command: ["sh", "-c"],
+  args: ["echo hello again; date"],
+  backoffLimit: 1,
+  ttlSecondsAfterFinished: 60,
++  schedule: "*/2 * * * *",
+});
+
+return {
+  url: echo.url,
+  deployment: echo.deploymentName,
+  job: hello.jobName,
++  kind: hello.kind,
+};
+```
+
+<Terminal content={`[u]Plan[/u]: [y]1 to update[/y]
+
+[y]~[/y] [b]Hello[/b] [d](Kubernetes.Job)[/d]
+
+Proceed?
+◉ Yes ○ No
+[g]✓[/g] [b]Hello[/b] [d](Kubernetes.Job)[/d] [y]updated[/y]
+{
+[s2]url: "http://localhost:8080",
+[s2]deployment: "myapp-echo-dev-alex-k3m7p2q6r4s5t2v6",
+[s2]job: "myapp-hello-dev-alex-h6g5f4e3d2c7b2a4",
+[s2]kind: "CronJob",
+}`} />
+
+A 5-field cron `schedule` makes the resource synthesize a `batch/v1`
+[`CronJob`](/kubernetes/workloads/jobs#cronjobs) around the same pod
+template. The `kind` output only shows the flip. Still `1 to update`:
+Alchemy prunes the Job and applies the CronJob, which is mutable and
+keeps a stable name. `kubectl get cronjobs` lists it, and within two
+minutes `kubectl get jobs` shows the first run. The TTL now applies
+to each run.
+
+## Recap
+
+`Hello` runs when applied and re-runs whenever its spec changes.
+`backoffLimit` and `ttlSecondsAfterFinished` pass straight through,
+and `schedule` turns the same resource into a CronJob in place. Part 3
+applies raw objects with `Kubernetes.Manifest` and wires their outputs
+into `Echo`.
+
+## Where next
+
+- [Part 3: Manifests](/kubernetes/tutorial/part-3) — namespaces,
+  config, and a StatefulSet.
+- [Jobs](/kubernetes/workloads/jobs) — the Effect `{ run }` form,
+  `restartPolicy`, and everything else about Jobs.

--- a/website/src/content/docs/kubernetes/tutorial/part-2.mdx
+++ b/website/src/content/docs/kubernetes/tutorial/part-2.mdx
@@ -8,14 +8,10 @@ sidebar:
 import Terminal from "../../../../components/Terminal.astro";
 import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 
-[Part 1](/kubernetes/tutorial/part-1) deployed a long-running server.
-Now add a `Kubernetes.Job` that runs to completion, then retry it,
-clean it up, and schedule it. The Part 1 file carries over. If you
-destroyed it, the first deploy recreates `Echo`.
+Add a `Kubernetes.Job` to the [Part 1](/kubernetes/tutorial/part-1)
+file, then retry it, clean it up, and schedule it.
 
 ## Add a Job
-
-Declare a Job below `Echo`:
 
 ```diff lang="typescript"
 const echo = yield* Kubernetes.Deployment("Echo", {
@@ -34,15 +30,11 @@ const echo = yield* Kubernetes.Deployment("Echo", {
 +});
 ```
 
-[`Kubernetes.Job`](/providers/kubernetes/job) is the analog of
-`AWS.ECS.Task`: a `batch/v1 Job` plus a `ServiceAccount` (see
-[Jobs](/kubernetes/workloads/jobs#jobs)). Kubernetes runs it the
-moment it is applied. `command` and `args` pass through verbatim.
-busybox has no entrypoint that exits, so we give it a shell line.
+A [`Kubernetes.Job`](/kubernetes/workloads/jobs#jobs) is a `batch/v1`
+Job plus a ServiceAccount. Kubernetes runs it the moment it is
+applied.
 
 ## Expose the Job name
-
-Add the Job's name to the outputs:
 
 ```diff lang="typescript"
 return {
@@ -52,9 +44,8 @@ return {
 };
 ```
 
-The generated name is `<base>-<8 hex chars>`. A one-shot Job's pod
-template is immutable, so Alchemy hashes the spec into the name. You
-need the exact name for `kubectl logs`.
+A Job's pod template is immutable, so Alchemy hashes the spec into
+the name.
 
 ## Deploy and watch it run
 
@@ -88,27 +79,19 @@ Proceed?
 [s2]job: "myapp-hello-dev-alex-h6g5f4e3d2c7b2a4-3f9a1c2e",
 }`} />
 
-If `Echo` was still deployed, the plan is `1 to create`. Check on
-the Job:
-
 ```sh
 kubectl get jobs
 ```
 
-After a few seconds `COMPLETIONS` reads `1/1`. Read its output with
-the `job` output from the deploy:
+After a few seconds `COMPLETIONS` reads `1/1`:
 
 ```sh
 kubectl logs job/myapp-hello-dev-alex-h6g5f4e3d2c7b2a4-3f9a1c2e
 ```
 
-It prints `hello from alchemy` and the date. The deploy did not wait
-for completion. `Job` means "make sure this Job object exists", and
-Kubernetes runs it asynchronously.
+The deploy does not wait for completion.
 
 ## Change the command and run it again
-
-Edit the shell line:
 
 ```diff lang="typescript"
 const hello = yield* Kubernetes.Job("Hello", {
@@ -128,15 +111,10 @@ Proceed?
 ◉ Yes ○ No
 [g]✓[/g] [b]Hello[/b] [d](Kubernetes.Job)[/d] [y]updated[/y]`} />
 
-The name is content-addressed, so a changed spec is a new Job object
-with a new hash suffix, and it runs. The old one is
-[pruned](/kubernetes/guides/how-apply-works#pruning-and-drift) with
-its pods. Edit and deploy re-runs a one-shot Job, and the two edits
-below do the same.
+A changed spec is a new Job, and it runs. The old one is
+[pruned](/kubernetes/guides/how-apply-works#pruning-and-drift).
 
 ## Limit retries with backoffLimit
-
-Cap the retries:
 
 ```diff lang="typescript"
 const hello = yield* Kubernetes.Job("Hello", {
@@ -148,15 +126,9 @@ const hello = yield* Kubernetes.Job("Hello", {
 });
 ```
 
-`backoffLimit` is the Kubernetes field: retries before the Job is
-marked failed. The default of 6 retries a broken command for minutes.
-Swap `args` for `["exit 1"]` to watch it stop after two attempts.
-`restartPolicy` and the backoff curve are on
-[Jobs](/kubernetes/workloads/jobs#jobs).
+Retries before the Job is marked failed; the default is 6.
 
 ## Clean up finished Jobs with ttlSecondsAfterFinished
-
-Have finished Jobs delete themselves:
 
 ```diff lang="typescript"
 const hello = yield* Kubernetes.Job("Hello", {
@@ -169,15 +141,10 @@ const hello = yield* Kubernetes.Job("Hello", {
 });
 ```
 
-Finished Jobs and their pods stay around forever by default. The TTL
-controller deletes them this many seconds after completion. A
-TTL-collected Job does not look missing to Alchemy, so the next
-deploy is still `no changes`. See
-[Jobs](/kubernetes/workloads/jobs#jobs) for why.
+Finished Jobs and their pods are deleted this many seconds after
+completion. The next deploy is still `no changes`.
 
 ## Put it on a schedule
-
-Add a cron schedule and expose the resource's `kind`:
 
 ```diff lang="typescript"
 const hello = yield* Kubernetes.Job("Hello", {
@@ -212,25 +179,11 @@ Proceed?
 [s2]kind: "CronJob",
 }`} />
 
-A 5-field cron `schedule` makes the resource synthesize a `batch/v1`
-[`CronJob`](/kubernetes/workloads/jobs#cronjobs) around the same pod
-template. The `kind` output only shows the flip. Still `1 to update`:
-Alchemy prunes the Job and applies the CronJob, which is mutable and
-keeps a stable name. `kubectl get cronjobs` lists it, and within two
-minutes `kubectl get jobs` shows the first run. The TTL now applies
-to each run.
-
-## Recap
-
-`Hello` runs when applied and re-runs whenever its spec changes.
-`backoffLimit` and `ttlSecondsAfterFinished` pass straight through,
-and `schedule` turns the same resource into a CronJob in place. Part 3
-applies raw objects with `Kubernetes.Manifest` and wires their outputs
-into `Echo`.
+A cron `schedule` makes the same resource a
+[`CronJob`](/kubernetes/workloads/jobs#cronjobs). Within two minutes
+`kubectl get jobs` shows the first run.
 
 ## Where next
 
-- [Part 3: Manifests](/kubernetes/tutorial/part-3) — namespaces,
-  config, and a StatefulSet.
-- [Jobs](/kubernetes/workloads/jobs) — the Effect `{ run }` form,
-  `restartPolicy`, and everything else about Jobs.
+- [Part 3: Manifests](/kubernetes/tutorial/part-3)
+- [Jobs](/kubernetes/workloads/jobs)

--- a/website/src/content/docs/kubernetes/tutorial/part-2.mdx
+++ b/website/src/content/docs/kubernetes/tutorial/part-2.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Part 2: Jobs and CronJobs"
-description: Run a container to completion with Kubernetes.Job, control retries and cleanup with backoffLimit and ttlSecondsAfterFinished, then turn it into a CronJob with one schedule prop.
+description: Run a container to completion with Kubernetes.Job, then turn it into a CronJob with a schedule.
 sidebar:
   order: 2
 ---
@@ -9,7 +9,7 @@ import Terminal from "../../../../components/Terminal.astro";
 import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 
 Add a `Kubernetes.Job` to the [Part 1](/kubernetes/tutorial/part-1)
-file, then retry it, clean it up, and schedule it.
+file, then limit retries, clean up, and schedule it.
 
 ## Add a Job
 
@@ -30,9 +30,8 @@ const echo = yield* Kubernetes.Deployment("Echo", {
 +});
 ```
 
-A [`Kubernetes.Job`](/kubernetes/workloads/jobs#jobs) is a `batch/v1`
-Job plus a ServiceAccount. Kubernetes runs it the moment it is
-applied.
+A [`Kubernetes.Job`](/kubernetes/workloads/jobs#jobs) runs a container
+to completion. It starts as soon as you deploy.
 
 ## Expose the Job name
 
@@ -44,8 +43,7 @@ return {
 };
 ```
 
-A Job's pod template is immutable, so Alchemy hashes the spec into
-the name.
+Each change to the Job gets a new name.
 
 ## Deploy and watch it run
 
@@ -89,7 +87,7 @@ After a few seconds `COMPLETIONS` reads `1/1`:
 kubectl logs job/myapp-hello-dev-alex-h6g5f4e3d2c7b2a4-3f9a1c2e
 ```
 
-The deploy does not wait for completion.
+Deploy doesn't wait for the Job to finish.
 
 ## Change the command and run it again
 
@@ -111,8 +109,8 @@ Proceed?
 ◉ Yes ○ No
 [g]✓[/g] [b]Hello[/b] [d](Kubernetes.Job)[/d] [y]updated[/y]`} />
 
-A changed spec is a new Job, and it runs. The old one is
-[pruned](/kubernetes/guides/how-apply-works#pruning-and-drift).
+A new Job runs under the new name. The old one is
+[removed](/kubernetes/guides/how-apply-works#pruning-and-drift).
 
 ## Limit retries with backoffLimit
 
@@ -142,7 +140,7 @@ const hello = yield* Kubernetes.Job("Hello", {
 ```
 
 Finished Jobs and their pods are deleted this many seconds after
-completion. The next deploy is still `no changes`.
+completion. A later deploy still reports `no changes`.
 
 ## Put it on a schedule
 
@@ -179,7 +177,7 @@ Proceed?
 [s2]kind: "CronJob",
 }`} />
 
-A cron `schedule` makes the same resource a
+Adding a `schedule` turns the Job into a
 [`CronJob`](/kubernetes/workloads/jobs#cronjobs). Within two minutes
 `kubectl get jobs` shows the first run.
 

--- a/website/src/content/docs/kubernetes/tutorial/part-3.mdx
+++ b/website/src/content/docs/kubernetes/tutorial/part-3.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Part 3: Manifests"
-description: Apply raw Kubernetes objects with Kubernetes.Manifest — a Namespace, a ConfigMap, and a Redis StatefulSet with a ClusterIP Service — and wire their outputs into the Deployment's namespace and env.
+description: Add a Namespace, a ConfigMap, and a Redis StatefulSet with Kubernetes.Manifest and pass their names into your Deployment.
 sidebar:
   order: 3
 ---
@@ -8,9 +8,9 @@ sidebar:
 import Terminal from "../../../../components/Terminal.astro";
 import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 
-Apply a Namespace, a ConfigMap, and a Redis StatefulSet as raw objects
-with `Kubernetes.Manifest`, and wire their outputs into `Echo`. Start
-from the [Part 2](/kubernetes/tutorial/part-2) file.
+Add a Namespace, a ConfigMap, and a Redis StatefulSet with
+`Kubernetes.Manifest`, and pass their names into `Echo`. Start from
+the [Part 2](/kubernetes/tutorial/part-2) file.
 
 ## Start clean
 
@@ -29,8 +29,7 @@ from the [Part 2](/kubernetes/tutorial/part-2) file.
   </TabItem>
 </Tabs>
 
-Moving a workload to a new namespace is a replacement, so start from
-a clean stack.
+Changing a workload's namespace replaces it.
 
 ## Add a Namespace
 
@@ -48,8 +47,8 @@ Effect.gen(function* () {
 +  });
 ```
 
-A [`Kubernetes.Manifest`](/kubernetes/objects/manifests#any-object) is
-one literal object of any `kind`, applied with server-side apply.
+A [`Kubernetes.Manifest`](/kubernetes/objects/manifests#any-object)
+applies any Kubernetes object you write as a literal.
 
 ## Move the workloads into it
 
@@ -75,8 +74,8 @@ const hello = yield* Kubernetes.Job("Hello", {
 });
 ```
 
-Passing `ns.name`, an [Output](/infrastructure-as-code/outputs),
-instead of `"tutorial"` is what orders the Namespace first.
+Pass `ns.name` (an [Output](/infrastructure-as-code/outputs)) rather
+than `"tutorial"` so the Namespace is created first.
 
 ## Add a ConfigMap
 
@@ -104,7 +103,7 @@ export default Alchemy.Stack(
 +    });
 ```
 
-Outputs work anywhere inside the literal.
+You can use Outputs anywhere in the manifest.
 
 ## Feed it into the Deployment
 
@@ -123,9 +122,8 @@ const echo = yield* Kubernetes.Deployment("Echo", {
 });
 ```
 
-A Manifest's attributes are the object's identity, not its contents,
-so `config.name` gives `"app-config"` while the values come from
-`settings`.
+`config.name` is `"app-config"`. Reuse `settings` for the values; a
+Manifest only exposes the object's name.
 
 ## Add Redis as a StatefulSet
 
@@ -157,7 +155,7 @@ const config = yield* Kubernetes.Manifest("Config", { /* ... */ });
 const echo = yield* Kubernetes.Deployment("Echo", { /* ... */ });
 ```
 
-Anything the two workload resources don't model is a Manifest.
+Use a Manifest for any object `Deployment` and `Job` don't cover.
 
 ## Give it a stable address
 
@@ -182,7 +180,7 @@ const echo = yield* Kubernetes.Deployment("Echo", { /* ... */ });
 ```
 
 A [ClusterIP](/kubernetes/guides/exposing-services#service-types)
-Service gives Redis the in-cluster DNS name `redis`.
+Service makes Redis reachable inside the cluster as `redis`.
 
 ## Hand the address to the Deployment
 
@@ -201,7 +199,8 @@ import * as Effect from "effect/Effect";
 ```
 
 [`Output.interpolate`](/infrastructure-as-code/outputs#interpolate)
-resolves after deploy and makes `Echo` depend on the Service.
+builds the URL from the Service name, so the Service is created
+before `Echo`.
 
 ## Deploy
 
@@ -244,8 +243,8 @@ Proceed?
 [s2]kind: "CronJob",
 }`} />
 
-The ✓ lines follow the graph: every edge came from a reference, none
-from `dependsOn`.
+Resources are created in the order your references require:
+Namespace first, `Echo` last.
 
 ```sh
 kubectl get all,configmap -n tutorial

--- a/website/src/content/docs/kubernetes/tutorial/part-3.mdx
+++ b/website/src/content/docs/kubernetes/tutorial/part-3.mdx
@@ -8,14 +8,11 @@ sidebar:
 import Terminal from "../../../../components/Terminal.astro";
 import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 
-A real app needs more than compute: namespaces, config, stateful
-services. Apply those as raw objects with `Kubernetes.Manifest` and
-wire what they produce into `Echo`. Start from the
-[Part 2](/kubernetes/tutorial/part-2) file.
+Apply a Namespace, a ConfigMap, and a Redis StatefulSet as raw objects
+with `Kubernetes.Manifest`, and wire their outputs into `Echo`. Start
+from the [Part 2](/kubernetes/tutorial/part-2) file.
 
 ## Start clean
-
-Tear down the Part 2 stack before editing:
 
 <Tabs syncKey="pkgManager">
   <TabItem label="bun" icon="bun">
@@ -32,13 +29,10 @@ Tear down the Part 2 stack before editing:
   </TabItem>
 </Tabs>
 
-The CronJob fires every two minutes, and moving a workload to a new
-namespace is a replacement on a live stack. Starting clean keeps this
-part's plan a simple list of creates.
+Moving a workload to a new namespace is a replacement, so start from
+a clean stack.
 
 ## Add a Namespace
-
-Declare a Namespace right after `cluster`:
 
 ```diff lang="typescript"
 Effect.gen(function* () {
@@ -54,18 +48,10 @@ Effect.gen(function* () {
 +  });
 ```
 
-A [`Kubernetes.Manifest`](/providers/kubernetes/manifest) is
-[one literal object](/kubernetes/objects/manifests#any-object), the
-same thing you would put in YAML, applied with server-side apply. Any
-`kind` works, built-in or CRD. `metadata.name` is required because
-apply addresses objects by name. A
-[Namespace](/kubernetes/objects/manifests#namespaces) is
-cluster-scoped, so `ns.namespace` is `undefined` and `ns.name` is
-`"tutorial"`.
+A [`Kubernetes.Manifest`](/kubernetes/objects/manifests#any-object) is
+one literal object of any `kind`, applied with server-side apply.
 
 ## Move the workloads into it
-
-Give both workloads the new namespace:
 
 ```diff lang="typescript"
 const echo = yield* Kubernetes.Deployment("Echo", {
@@ -89,15 +75,10 @@ const hello = yield* Kubernetes.Job("Hello", {
 });
 ```
 
-A workload's `namespace` must exist before it is applied. Passing
-`ns.name`, an [Output](/infrastructure-as-code/outputs), instead of
-`"tutorial"` is what orders the Namespace first. A bare string carries
-no edge. On a deployed stack, changing `namespace` is a replacement
-because cluster, namespace, and name are the workload's identity.
+Passing `ns.name`, an [Output](/infrastructure-as-code/outputs),
+instead of `"tutorial"` is what orders the Namespace first.
 
 ## Add a ConfigMap
-
-Keep the settings in a constant and apply them as a ConfigMap:
 
 ```diff lang="typescript"
 +const settings = {
@@ -123,13 +104,9 @@ export default Alchemy.Stack(
 +    });
 ```
 
-A ConfigMap's `data` is a string map, so keep it in a constant.
-`metadata.namespace: ns.name` is a reference too, so the ConfigMap
-lands after the Namespace. Outputs work anywhere inside the literal.
+Outputs work anywhere inside the literal.
 
 ## Feed it into the Deployment
-
-Pass the settings and the ConfigMap's name to `Echo` as env vars:
 
 ```diff lang="typescript"
 const echo = yield* Kubernetes.Deployment("Echo", {
@@ -146,17 +123,11 @@ const echo = yield* Kubernetes.Deployment("Echo", {
 });
 ```
 
-`env` becomes the container's environment. Strings go in verbatim,
-Outputs resolve at deploy time. A Manifest's attributes are the
-object's [identity](/kubernetes/objects/manifests#any-object), not its
-contents, so `config.name` gives `"app-config"` and an ordering edge
-while the values come from `settings`. To use `envFrom` instead,
-override the synthesized container with
-[container-level fields](/kubernetes/workloads/pod-template#container-level-fields).
+A Manifest's attributes are the object's identity, not its contents,
+so `config.name` gives `"app-config"` while the values come from
+`settings`.
 
 ## Add Redis as a StatefulSet
-
-Declare it after `config` and before `Echo`:
 
 ```diff lang="typescript"
 const config = yield* Kubernetes.Manifest("Config", { /* ... */ });
@@ -186,14 +157,9 @@ const config = yield* Kubernetes.Manifest("Config", { /* ... */ });
 const echo = yield* Kubernetes.Deployment("Echo", { /* ... */ });
 ```
 
-There is no `Kubernetes.StatefulSet` resource. Anything the two
-workload resources don't model is a Manifest, written as the API
-expects it. The API server validates the shape, so a typo in `spec`
-fails the deploy with the server's message.
+Anything the two workload resources don't model is a Manifest.
 
 ## Give it a stable address
-
-Put a ClusterIP Service between `redis` and `Echo`:
 
 ```diff lang="typescript"
 const redis = yield* Kubernetes.Manifest("Redis", { /* ... */ });
@@ -215,15 +181,10 @@ const redis = yield* Kubernetes.Manifest("Redis", { /* ... */ });
 const echo = yield* Kubernetes.Deployment("Echo", { /* ... */ });
 ```
 
-The Service gives Redis one stable in-cluster DNS name: `redis` from
-the same namespace, `redis.tutorial.svc` from anywhere. The
-StatefulSet's `serviceName: "redis"` names it. Nothing here is
-reachable from your laptop. That is the point of a
-[ClusterIP](/kubernetes/guides/exposing-services#service-types).
+A [ClusterIP](/kubernetes/guides/exposing-services#service-types)
+Service gives Redis the in-cluster DNS name `redis`.
 
 ## Hand the address to the Deployment
-
-Build the Redis URL from the Service's name:
 
 ```diff lang="typescript"
 import * as Alchemy from "alchemy";
@@ -239,12 +200,8 @@ import * as Effect from "effect/Effect";
   },
 ```
 
-`redisService.name` is not known until the Service is applied, so an
-ordinary template literal won't do.
 [`Output.interpolate`](/infrastructure-as-code/outputs#interpolate)
-resolves after deploy and makes `Echo` depend on the Service. The
-echo image won't connect to Redis. Part 5 replaces it with your own
-code that could.
+resolves after deploy and makes `Echo` depend on the Service.
 
 ## Deploy
 
@@ -287,38 +244,22 @@ Proceed?
 [s2]kind: "CronJob",
 }`} />
 
-The plan is alphabetical, but the ✓ lines show the graph: Namespace
-first, then Config, Redis, and RedisService, then the workloads. Every
-edge came from a reference, none from `dependsOn`. See what landed:
+The ✓ lines follow the graph: every edge came from a reference, none
+from `dependsOn`.
 
 ```sh
 kubectl get all,configmap -n tutorial
 ```
 
-And the environment `Echo`'s container received:
+Check the environment `Echo`'s container received:
 
 ```sh
 kubectl get deploy -n tutorial myapp-echo-dev-alex-k3m7p2q6r4s5t2v6 \
   -o jsonpath='{.spec.template.spec.containers[0].env}'
 ```
 
-`LOG_LEVEL`, `GREETING`, `CONFIG_MAP=app-config`, and
-`REDIS_URL=redis://redis:6379`, next to the `PORT` and `ALCHEMY_*`
-variables Alchemy adds to every workload.
-
-## Recap
-
-Four Manifests, `Echo` carrying the config and the Redis address in
-`env`, and every ordering edge derived from an Output. Part 4 installs
-a chart with `Kubernetes.HelmChart` and watches Alchemy prune what the
-chart stops rendering.
-
 ## Where next
 
-- [Part 4: Helm Charts](/kubernetes/tutorial/part-4) — render
-  podinfo, tune values, see pruning.
-- [Manifests](/kubernetes/objects/manifests) — CRDs, Secrets with
-  `Redacted`, ordering rules.
-- [Pod template](/kubernetes/workloads/pod-template) — the
-  `podTemplate` escape hatch when `env` and `resources` aren't
-  enough.
+- [Part 4: Helm Charts](/kubernetes/tutorial/part-4)
+- [Manifests](/kubernetes/objects/manifests)
+- [Pod template](/kubernetes/workloads/pod-template)

--- a/website/src/content/docs/kubernetes/tutorial/part-3.mdx
+++ b/website/src/content/docs/kubernetes/tutorial/part-3.mdx
@@ -1,0 +1,324 @@
+---
+title: "Part 3: Manifests"
+description: Apply raw Kubernetes objects with Kubernetes.Manifest — a Namespace, a ConfigMap, and a Redis StatefulSet with a ClusterIP Service — and wire their outputs into the Deployment's namespace and env.
+sidebar:
+  order: 3
+---
+
+import Terminal from "../../../../components/Terminal.astro";
+import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
+
+A real app needs more than compute: namespaces, config, stateful
+services. Apply those as raw objects with `Kubernetes.Manifest` and
+wire what they produce into `Echo`. Start from the
+[Part 2](/kubernetes/tutorial/part-2) file.
+
+## Start clean
+
+Tear down the Part 2 stack before editing:
+
+<Tabs syncKey="pkgManager">
+  <TabItem label="bun" icon="bun">
+    <Code code="bun alchemy destroy" lang="sh" />
+  </TabItem>
+  <TabItem label="npm" icon="npm">
+    <Code code="npm run alchemy destroy" lang="sh" />
+  </TabItem>
+  <TabItem label="pnpm" icon="pnpm">
+    <Code code="pnpm alchemy destroy" lang="sh" />
+  </TabItem>
+  <TabItem label="yarn" icon="seti:yarn">
+    <Code code="yarn alchemy destroy" lang="sh" />
+  </TabItem>
+</Tabs>
+
+The CronJob fires every two minutes, and moving a workload to a new
+namespace is a replacement on a live stack. Starting clean keeps this
+part's plan a simple list of creates.
+
+## Add a Namespace
+
+Declare a Namespace right after `cluster`:
+
+```diff lang="typescript"
+Effect.gen(function* () {
+  const cluster = Kubernetes.KubeConfig({ context: "docker-desktop" });
+
++  const ns = yield* Kubernetes.Manifest("Namespace", {
++    cluster,
++    manifest: {
++      apiVersion: "v1",
++      kind: "Namespace",
++      metadata: { name: "tutorial" },
++    },
++  });
+```
+
+A [`Kubernetes.Manifest`](/providers/kubernetes/manifest) is
+[one literal object](/kubernetes/objects/manifests#any-object), the
+same thing you would put in YAML, applied with server-side apply. Any
+`kind` works, built-in or CRD. `metadata.name` is required because
+apply addresses objects by name. A
+[Namespace](/kubernetes/objects/manifests#namespaces) is
+cluster-scoped, so `ns.namespace` is `undefined` and `ns.name` is
+`"tutorial"`.
+
+## Move the workloads into it
+
+Give both workloads the new namespace:
+
+```diff lang="typescript"
+const echo = yield* Kubernetes.Deployment("Echo", {
+  cluster,
++  namespace: ns.name,
+  image: "mendhak/http-https-echo:33",
+  port: 8080,
+  serviceType: "LoadBalancer",
+  replicas: 3,
+});
+
+const hello = yield* Kubernetes.Job("Hello", {
+  cluster,
++  namespace: ns.name,
+  image: "busybox:1.36",
+  command: ["sh", "-c"],
+  args: ["echo hello again; date"],
+  backoffLimit: 1,
+  ttlSecondsAfterFinished: 60,
+  schedule: "*/2 * * * *",
+});
+```
+
+A workload's `namespace` must exist before it is applied. Passing
+`ns.name`, an [Output](/infrastructure-as-code/outputs), instead of
+`"tutorial"` is what orders the Namespace first. A bare string carries
+no edge. On a deployed stack, changing `namespace` is a replacement
+because cluster, namespace, and name are the workload's identity.
+
+## Add a ConfigMap
+
+Keep the settings in a constant and apply them as a ConfigMap:
+
+```diff lang="typescript"
++const settings = {
++  LOG_LEVEL: "debug",
++  GREETING: "hello from part 3",
++};
+
+export default Alchemy.Stack(
+  // ...
+  Effect.gen(function* () {
+    const cluster = Kubernetes.KubeConfig({ context: "docker-desktop" });
+
+    const ns = yield* Kubernetes.Manifest("Namespace", { /* ... */ });
+
++    const config = yield* Kubernetes.Manifest("Config", {
++      cluster,
++      manifest: {
++        apiVersion: "v1",
++        kind: "ConfigMap",
++        metadata: { name: "app-config", namespace: ns.name },
++        data: settings,
++      },
++    });
+```
+
+A ConfigMap's `data` is a string map, so keep it in a constant.
+`metadata.namespace: ns.name` is a reference too, so the ConfigMap
+lands after the Namespace. Outputs work anywhere inside the literal.
+
+## Feed it into the Deployment
+
+Pass the settings and the ConfigMap's name to `Echo` as env vars:
+
+```diff lang="typescript"
+const echo = yield* Kubernetes.Deployment("Echo", {
+  cluster,
+  namespace: ns.name,
+  image: "mendhak/http-https-echo:33",
+  port: 8080,
+  serviceType: "LoadBalancer",
+  replicas: 3,
++  env: {
++    ...settings,
++    CONFIG_MAP: config.name,
++  },
+});
+```
+
+`env` becomes the container's environment. Strings go in verbatim,
+Outputs resolve at deploy time. A Manifest's attributes are the
+object's [identity](/kubernetes/objects/manifests#any-object), not its
+contents, so `config.name` gives `"app-config"` and an ordering edge
+while the values come from `settings`. To use `envFrom` instead,
+override the synthesized container with
+[container-level fields](/kubernetes/workloads/pod-template#container-level-fields).
+
+## Add Redis as a StatefulSet
+
+Declare it after `config` and before `Echo`:
+
+```diff lang="typescript"
+const config = yield* Kubernetes.Manifest("Config", { /* ... */ });
+
++const redis = yield* Kubernetes.Manifest("Redis", {
++  cluster,
++  manifest: {
++    apiVersion: "apps/v1",
++    kind: "StatefulSet",
++    metadata: { name: "redis", namespace: ns.name },
++    spec: {
++      serviceName: "redis",
++      replicas: 1,
++      selector: { matchLabels: { app: "redis" } },
++      template: {
++        metadata: { labels: { app: "redis" } },
++        spec: {
++          containers: [
++            { name: "redis", image: "redis:7", ports: [{ containerPort: 6379 }] },
++          ],
++        },
++      },
++    },
++  },
++});
+
+const echo = yield* Kubernetes.Deployment("Echo", { /* ... */ });
+```
+
+There is no `Kubernetes.StatefulSet` resource. Anything the two
+workload resources don't model is a Manifest, written as the API
+expects it. The API server validates the shape, so a typo in `spec`
+fails the deploy with the server's message.
+
+## Give it a stable address
+
+Put a ClusterIP Service between `redis` and `Echo`:
+
+```diff lang="typescript"
+const redis = yield* Kubernetes.Manifest("Redis", { /* ... */ });
+
++const redisService = yield* Kubernetes.Manifest("RedisService", {
++  cluster,
++  manifest: {
++    apiVersion: "v1",
++    kind: "Service",
++    metadata: { name: "redis", namespace: ns.name },
++    spec: {
++      type: "ClusterIP",
++      selector: { app: "redis" },
++      ports: [{ port: 6379, targetPort: 6379 }],
++    },
++  },
++});
+
+const echo = yield* Kubernetes.Deployment("Echo", { /* ... */ });
+```
+
+The Service gives Redis one stable in-cluster DNS name: `redis` from
+the same namespace, `redis.tutorial.svc` from anywhere. The
+StatefulSet's `serviceName: "redis"` names it. Nothing here is
+reachable from your laptop. That is the point of a
+[ClusterIP](/kubernetes/guides/exposing-services#service-types).
+
+## Hand the address to the Deployment
+
+Build the Redis URL from the Service's name:
+
+```diff lang="typescript"
+import * as Alchemy from "alchemy";
+import * as Kubernetes from "alchemy/Kubernetes";
++import * as Output from "alchemy/Output";
+import * as Effect from "effect/Effect";
+
+// ...
+  env: {
+    ...settings,
+    CONFIG_MAP: config.name,
++    REDIS_URL: Output.interpolate`redis://${redisService.name}:6379`,
+  },
+```
+
+`redisService.name` is not known until the Service is applied, so an
+ordinary template literal won't do.
+[`Output.interpolate`](/infrastructure-as-code/outputs#interpolate)
+resolves after deploy and makes `Echo` depend on the Service. The
+echo image won't connect to Redis. Part 5 replaces it with your own
+code that could.
+
+## Deploy
+
+<Tabs syncKey="pkgManager">
+  <TabItem label="bun" icon="bun">
+    <Code code="bun alchemy deploy" lang="sh" />
+  </TabItem>
+  <TabItem label="npm" icon="npm">
+    <Code code="npm run alchemy deploy" lang="sh" />
+  </TabItem>
+  <TabItem label="pnpm" icon="pnpm">
+    <Code code="pnpm alchemy deploy" lang="sh" />
+  </TabItem>
+  <TabItem label="yarn" icon="seti:yarn">
+    <Code code="yarn alchemy deploy" lang="sh" />
+  </TabItem>
+</Tabs>
+
+<Terminal content={`[u]Plan[/u]: [g]6 to create[/g]
+
+[g]+[/g] [b]Config[/b] [d](Kubernetes.Manifest)[/d]
+[g]+[/g] [b]Echo[/b] [d](Kubernetes.Deployment)[/d]
+[g]+[/g] [b]Hello[/b] [d](Kubernetes.Job)[/d]
+[g]+[/g] [b]Namespace[/b] [d](Kubernetes.Manifest)[/d]
+[g]+[/g] [b]Redis[/b] [d](Kubernetes.Manifest)[/d]
+[g]+[/g] [b]RedisService[/b] [d](Kubernetes.Manifest)[/d]
+
+Proceed?
+◉ Yes ○ No
+[g]✓[/g] [b]Namespace[/b] [d](Kubernetes.Manifest)[/d] [g]created[/g]
+[g]✓[/g] [b]Config[/b] [d](Kubernetes.Manifest)[/d] [g]created[/g]
+[g]✓[/g] [b]Redis[/b] [d](Kubernetes.Manifest)[/d] [g]created[/g]
+[g]✓[/g] [b]RedisService[/b] [d](Kubernetes.Manifest)[/d] [g]created[/g]
+[g]✓[/g] [b]Hello[/b] [d](Kubernetes.Job)[/d] [g]created[/g]
+[g]✓[/g] [b]Echo[/b] [d](Kubernetes.Deployment)[/d] [g]created[/g]
+{
+[s2]url: "http://localhost:8080",
+[s2]deployment: "myapp-echo-dev-alex-k3m7p2q6r4s5t2v6",
+[s2]job: "myapp-hello-dev-alex-h6g5f4e3d2c7b2a4",
+[s2]kind: "CronJob",
+}`} />
+
+The plan is alphabetical, but the ✓ lines show the graph: Namespace
+first, then Config, Redis, and RedisService, then the workloads. Every
+edge came from a reference, none from `dependsOn`. See what landed:
+
+```sh
+kubectl get all,configmap -n tutorial
+```
+
+And the environment `Echo`'s container received:
+
+```sh
+kubectl get deploy -n tutorial myapp-echo-dev-alex-k3m7p2q6r4s5t2v6 \
+  -o jsonpath='{.spec.template.spec.containers[0].env}'
+```
+
+`LOG_LEVEL`, `GREETING`, `CONFIG_MAP=app-config`, and
+`REDIS_URL=redis://redis:6379`, next to the `PORT` and `ALCHEMY_*`
+variables Alchemy adds to every workload.
+
+## Recap
+
+Four Manifests, `Echo` carrying the config and the Redis address in
+`env`, and every ordering edge derived from an Output. Part 4 installs
+a chart with `Kubernetes.HelmChart` and watches Alchemy prune what the
+chart stops rendering.
+
+## Where next
+
+- [Part 4: Helm Charts](/kubernetes/tutorial/part-4) — render
+  podinfo, tune values, see pruning.
+- [Manifests](/kubernetes/objects/manifests) — CRDs, Secrets with
+  `Redacted`, ordering rules.
+- [Pod template](/kubernetes/workloads/pod-template) — the
+  `podTemplate` escape hatch when `env` and `resources` aren't
+  enough.

--- a/website/src/content/docs/kubernetes/tutorial/part-4.mdx
+++ b/website/src/content/docs/kubernetes/tutorial/part-4.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Part 4: Helm Charts"
-description: Install the podinfo chart with Kubernetes.HelmChart, pin its version, tune values, own its namespace, and watch Alchemy prune objects the chart stops rendering.
+description: Install the podinfo Helm chart, pin its version, set values, and see objects removed when the chart stops rendering them.
 sidebar:
   order: 4
 ---
@@ -8,10 +8,10 @@ sidebar:
 import Terminal from "../../../../components/Terminal.astro";
 import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 
-Install a Helm chart with `Kubernetes.HelmChart`, tune its values, and
-watch Alchemy prune objects the chart stops rendering. Continue from
-[Part 3](/kubernetes/tutorial/part-3) with its stack deployed. `helm`
-must be on your `PATH` ([Setup](/kubernetes/setup#install)).
+Install a Helm chart, change its values, and remove objects by turning
+them off in the chart. Continue from
+[Part 3](/kubernetes/tutorial/part-3) with its stack deployed. You need
+`helm` on your `PATH` ([Setup](/kubernetes/setup#install)).
 
 ## Install podinfo
 
@@ -35,10 +35,10 @@ return {
 };
 ```
 
-Pin `version` or helm resolves the latest on every deploy
-([full props](/providers/kubernetes/helmchart)).
+Pin `version`, or every deploy picks up the newest release
+([all props](/providers/kubernetes/helmchart)).
 
-## Own the namespace with createNamespace
+## Create the namespace
 
 ```diff lang="typescript"
 const podinfo = yield* Kubernetes.HelmChart("Podinfo", {
@@ -51,8 +51,8 @@ const podinfo = yield* Kubernetes.HelmChart("Podinfo", {
 });
 ```
 
-The chart emits and [owns](/kubernetes/objects/helm#lifecycle) the
-`podinfo` Namespace, applied first and deleted with the rest.
+The chart creates the `podinfo` Namespace first and deletes it on
+destroy ([lifecycle](/kubernetes/objects/helm#lifecycle)).
 
 ## Deploy
 
@@ -88,15 +88,13 @@ Proceed?
 [s2]podinfoRelease: "myapp-podinfo-dev-alex-q2w3e4r5t6y7u2i3",
 }`} />
 
-The three rendered objects were
-[server-side applied](/kubernetes/guides/how-apply-works#server-side-apply)
-like Manifests.
+See the three objects:
 
 ```sh
 kubectl get all -n podinfo
 ```
 
-Port-forward to the Service, named after the release:
+Port-forward to the Service (named after the release) and call it:
 
 ```sh
 kubectl port-forward -n podinfo svc/myapp-podinfo-dev-alex-q2w3e4r5t6y7u2i3 9898:9898
@@ -120,13 +118,13 @@ const podinfo = yield* Kubernetes.HelmChart("Podinfo", {
 });
 ```
 
-[`values`](/kubernetes/objects/helm#values) is the chart's
-`values.yaml`. Deploy: the plan is `1 to update` and
+[`values`](/kubernetes/objects/helm#values) replaces the chart's
+`values.yaml`. Deploy again: the plan says `1 to update`, and
 `kubectl get deploy -n podinfo` shows `2/2`.
 
-## Turn an object off and watch it get pruned
+## Turn the Service off
 
-Stop the port-forward, then switch the Service off:
+Stop the port-forward, then disable the Service:
 
 ```diff lang="typescript"
 values: {
@@ -146,13 +144,13 @@ Proceed?
 [d]Applying 2 objects from podinfo...[/d]
 [g]✓[/g] [b]Podinfo[/b] [d](Kubernetes.HelmChart)[/d] [y]updated[/y]`} />
 
-Objects that leave the render are
-[pruned](/kubernetes/guides/how-apply-works#pruning-and-drift);
+The chart no longer renders the Service, so it gets
+[deleted](/kubernetes/guides/how-apply-works#pruning-and-drift).
 `kubectl get svc -n podinfo` is now empty.
 
 ## Put it back
 
-Delete the `service` line:
+Remove the `service` line and deploy:
 
 ```diff lang="typescript"
 values: {
@@ -172,13 +170,13 @@ Proceed?
 [d]Applying 3 objects from podinfo...[/d]
 [g]✓[/g] [b]Podinfo[/b] [d](Kubernetes.HelmChart)[/d] [y]updated[/y]`} />
 
-The Service re-enters the managed set.
+The Service is back.
 
-## What you didn't get from Helm
+## No Helm release
 
-`helm list -n podinfo` shows nothing: Helm only rendered, and hooks
-never run. See
-[What Helm does that Alchemy doesn't](/kubernetes/objects/helm#what-helm-does-that-alchemy-doesnt).
+`helm list -n podinfo` shows nothing: there is no Helm release, and
+chart hooks don't run
+([details](/kubernetes/objects/helm#what-helm-does-that-alchemy-doesnt)).
 
 ## Clean up
 
@@ -217,7 +215,7 @@ Proceed?
 [r]✗[/r] [b]RedisService[/b] [d](Kubernetes.Manifest)[/d] [r]deleted[/r]
 [r]✗[/r] [b]Namespace[/b] [d](Kubernetes.Manifest)[/d] [r]deleted[/r]`} />
 
-Dependents delete first, so the `tutorial` Namespace goes last.
+The `tutorial` Namespace goes last, after everything inside it.
 
 ## Where next
 

--- a/website/src/content/docs/kubernetes/tutorial/part-4.mdx
+++ b/website/src/content/docs/kubernetes/tutorial/part-4.mdx
@@ -8,21 +8,12 @@ sidebar:
 import Terminal from "../../../../components/Terminal.astro";
 import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 
-Most cluster software ships as Helm charts. Install one with
-`Kubernetes.HelmChart`, tune it from TypeScript, and see what it
-means for Alchemy to own the chart's objects. Continue from the
-[Part 3](/kubernetes/tutorial/part-3) file with its stack deployed.
-
-## Prerequisites
-
-`helm` must be on your `PATH`. `HelmChart` shells out to
-`helm template` on the deploying machine, the way image builds shell
-out to Docker (see [Setup](/kubernetes/setup#install)). No
-`helm repo add` is needed. The `repo` prop is passed on every render.
+Install a Helm chart with `Kubernetes.HelmChart`, tune its values, and
+watch Alchemy prune objects the chart stops rendering. Continue from
+[Part 3](/kubernetes/tutorial/part-3) with its stack deployed. `helm`
+must be on your `PATH` ([Setup](/kubernetes/setup#install)).
 
 ## Install podinfo
-
-Declare the chart after `Hello` and expose its release name:
 
 ```diff lang="typescript"
 const hello = yield* Kubernetes.Job("Hello", { /* ... */ });
@@ -44,18 +35,10 @@ return {
 };
 ```
 
-`chart` names the chart inside the repository at `repo`. OCI and
-local charts are on [Chart sources](/kubernetes/objects/helm#chart-sources).
-Pin `version`, or helm resolves the latest on every deploy and the
-objects drift. `namespace` is where the objects land. It doesn't
-exist yet, and the next step fixes that. `releaseName` defaults to a
-name from stack, stage, and logical id, and is the chart's
-`.Release.Name`. Full props are on the
-[`HelmChart` reference](/providers/kubernetes/helmchart).
+Pin `version` or helm resolves the latest on every deploy
+([full props](/providers/kubernetes/helmchart)).
 
 ## Own the namespace with createNamespace
-
-Have the chart resource create its own namespace:
 
 ```diff lang="typescript"
 const podinfo = yield* Kubernetes.HelmChart("Podinfo", {
@@ -68,10 +51,8 @@ const podinfo = yield* Kubernetes.HelmChart("Podinfo", {
 });
 ```
 
-A Namespace Manifest like Part 3 works too. `createNamespace` has the
-chart resource emit and [own](/kubernetes/objects/helm#lifecycle) the
-`podinfo` Namespace as its first object, applied before the rendered
-objects and deleted with them. It is a no-op for `namespace: "default"`.
+The chart emits and [owns](/kubernetes/objects/helm#lifecycle) the
+`podinfo` Namespace, applied first and deleted with the rest.
 
 ## Deploy
 
@@ -107,32 +88,22 @@ Proceed?
 [s2]podinfoRelease: "myapp-podinfo-dev-alex-q2w3e4r5t6y7u2i3",
 }`} />
 
-The render ran on your machine with `helm template --no-hooks`. The
-three objects, the Namespace plus the chart's Service and Deployment,
-were [server-side applied](/kubernetes/guides/how-apply-works#server-side-apply)
-like Manifests. Their refs are recorded on the `objects` attribute,
-which is what pruning and destroy work from. See what landed:
+The three rendered objects were
+[server-side applied](/kubernetes/guides/how-apply-works#server-side-apply)
+like Manifests.
 
 ```sh
 kubectl get all -n podinfo
 ```
 
-podinfo's Service is ClusterIP and named after the release, the
-`podinfoRelease` output. Port-forward to it:
+Port-forward to the Service, named after the release:
 
 ```sh
 kubectl port-forward -n podinfo svc/myapp-podinfo-dev-alex-q2w3e4r5t6y7u2i3 9898:9898
 curl localhost:9898
 ```
 
-podinfo answers with JSON describing itself. With a long stack or
-stage name the release name is capped at Helm's 53 characters and
-may drop `podinfo`, and the chart then names the Service
-`<release>-podinfo`. `kubectl get svc -n podinfo` shows it either way.
-
 ## Tune it with values
-
-Set the chart's values from TypeScript:
 
 ```diff lang="typescript"
 const podinfo = yield* Kubernetes.HelmChart("Podinfo", {
@@ -150,15 +121,12 @@ const podinfo = yield* Kubernetes.HelmChart("Podinfo", {
 ```
 
 [`values`](/kubernetes/objects/helm#values) is the chart's
-`values.yaml` as a TypeScript object. Deploy and the plan is
-`1 to update` because the chart's hash changed.
-`kubectl get deploy -n podinfo` shows `2/2`, and the port-forwarded
-JSON carries the new message. Unchanged objects are re-applied as
-no-ops.
+`values.yaml`. Deploy: the plan is `1 to update` and
+`kubectl get deploy -n podinfo` shows `2/2`.
 
 ## Turn an object off and watch it get pruned
 
-Stop the port-forward, then switch the chart's Service off:
+Stop the port-forward, then switch the Service off:
 
 ```diff lang="typescript"
 values: {
@@ -178,15 +146,13 @@ Proceed?
 [d]Applying 2 objects from podinfo...[/d]
 [g]✓[/g] [b]Podinfo[/b] [d](Kubernetes.HelmChart)[/d] [y]updated[/y]`} />
 
-`service.enabled` makes podinfo stop rendering its Service. The
-`Applying` note drops from 3 objects to 2, and
-`kubectl get svc -n podinfo` is empty. Objects that leave the render
-are [pruned](/kubernetes/guides/how-apply-works#pruning-and-drift),
-unlike `kubectl apply -f`.
+Objects that leave the render are
+[pruned](/kubernetes/guides/how-apply-works#pruning-and-drift);
+`kubectl get svc -n podinfo` is now empty.
 
 ## Put it back
 
-Delete the `service` line again:
+Delete the `service` line:
 
 ```diff lang="typescript"
 values: {
@@ -206,22 +172,13 @@ Proceed?
 [d]Applying 3 objects from podinfo...[/d]
 [g]✓[/g] [b]Podinfo[/b] [d](Kubernetes.HelmChart)[/d] [y]updated[/y]`} />
 
-Back to 3 objects, and `kubectl get svc -n podinfo` lists the Service
-again. An object that re-enters the render is added back to the
-managed set.
+The Service re-enters the managed set.
 
 ## What you didn't get from Helm
 
-`helm list -n podinfo` shows nothing. Helm only rendered, so there is
-no release record in the cluster. The chart's `templates/tests/` Pod
-never appeared in the object counts either, because the render runs
-with `--no-hooks`.
-
-:::note[Hooks and release records]
-Hook-annotated objects are never applied or executed. Charts that
-depend on lifecycle hooks should be installed with Helm directly. See
+`helm list -n podinfo` shows nothing: Helm only rendered, and hooks
+never run. See
 [What Helm does that Alchemy doesn't](/kubernetes/objects/helm#what-helm-does-that-alchemy-doesnt).
-:::
 
 ## Clean up
 
@@ -260,26 +217,10 @@ Proceed?
 [r]✗[/r] [b]RedisService[/b] [d](Kubernetes.Manifest)[/d] [r]deleted[/r]
 [r]✗[/r] [b]Namespace[/b] [d](Kubernetes.Manifest)[/d] [r]deleted[/r]`} />
 
-Within a resource, objects go in reverse apply order: the chart's
-Deployment and Service before its Namespace. Across resources,
-dependents go first, so the `tutorial` Namespace is last. `destroy`
-returns once the API server accepts the deletes, so `kubectl get ns`
-shows both namespaces `Terminating` for a while. Part 5 is optional
-and moves this program to a different cluster.
-
-## Recap
-
-One file deploys a Deployment, a CronJob, four Manifests, and a Helm
-chart, with values edits as ordinary updates and dropped objects
-pruned. Part 5 is optional: the same file on EKS, with `Echo` replaced
-by your own Effect code and an AWS binding.
+Dependents delete first, so the `tutorial` Namespace goes last.
 
 ## Where next
 
-- [Part 5: The Same Program on EKS](/kubernetes/tutorial/part-5) —
-  optional: the same program on EKS with `main:` and a DynamoDB
-  binding.
-- [Helm charts](/kubernetes/objects/helm) — OCI and local charts,
-  `includeCrds`, the full lifecycle.
-- [How apply works](/kubernetes/guides/how-apply-works) —
-  server-side apply, drift, pruning, conflicts, debugging.
+- [Part 5: The Same Program on EKS](/kubernetes/tutorial/part-5) — optional
+- [Helm charts](/kubernetes/objects/helm)
+- [How apply works](/kubernetes/guides/how-apply-works)

--- a/website/src/content/docs/kubernetes/tutorial/part-4.mdx
+++ b/website/src/content/docs/kubernetes/tutorial/part-4.mdx
@@ -1,0 +1,285 @@
+---
+title: "Part 4: Helm Charts"
+description: Install the podinfo chart with Kubernetes.HelmChart, pin its version, tune values, own its namespace, and watch Alchemy prune objects the chart stops rendering.
+sidebar:
+  order: 4
+---
+
+import Terminal from "../../../../components/Terminal.astro";
+import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
+
+Most cluster software ships as Helm charts. Install one with
+`Kubernetes.HelmChart`, tune it from TypeScript, and see what it
+means for Alchemy to own the chart's objects. Continue from the
+[Part 3](/kubernetes/tutorial/part-3) file with its stack deployed.
+
+## Prerequisites
+
+`helm` must be on your `PATH`. `HelmChart` shells out to
+`helm template` on the deploying machine, the way image builds shell
+out to Docker (see [Setup](/kubernetes/setup#install)). No
+`helm repo add` is needed. The `repo` prop is passed on every render.
+
+## Install podinfo
+
+Declare the chart after `Hello` and expose its release name:
+
+```diff lang="typescript"
+const hello = yield* Kubernetes.Job("Hello", { /* ... */ });
+
++const podinfo = yield* Kubernetes.HelmChart("Podinfo", {
++  cluster,
++  chart: "podinfo",
++  repo: "https://stefanprodan.github.io/podinfo",
++  version: "6.14.1",
++  namespace: "podinfo",
++});
+
+return {
+  url: echo.url,
+  deployment: echo.deploymentName,
+  job: hello.jobName,
+  kind: hello.kind,
++  podinfoRelease: podinfo.releaseName,
+};
+```
+
+`chart` names the chart inside the repository at `repo`. OCI and
+local charts are on [Chart sources](/kubernetes/objects/helm#chart-sources).
+Pin `version`, or helm resolves the latest on every deploy and the
+objects drift. `namespace` is where the objects land. It doesn't
+exist yet, and the next step fixes that. `releaseName` defaults to a
+name from stack, stage, and logical id, and is the chart's
+`.Release.Name`. Full props are on the
+[`HelmChart` reference](/providers/kubernetes/helmchart).
+
+## Own the namespace with createNamespace
+
+Have the chart resource create its own namespace:
+
+```diff lang="typescript"
+const podinfo = yield* Kubernetes.HelmChart("Podinfo", {
+  cluster,
+  chart: "podinfo",
+  repo: "https://stefanprodan.github.io/podinfo",
+  version: "6.14.1",
+  namespace: "podinfo",
++  createNamespace: true,
+});
+```
+
+A Namespace Manifest like Part 3 works too. `createNamespace` has the
+chart resource emit and [own](/kubernetes/objects/helm#lifecycle) the
+`podinfo` Namespace as its first object, applied before the rendered
+objects and deleted with them. It is a no-op for `namespace: "default"`.
+
+## Deploy
+
+<Tabs syncKey="pkgManager">
+  <TabItem label="bun" icon="bun">
+    <Code code="bun alchemy deploy" lang="sh" />
+  </TabItem>
+  <TabItem label="npm" icon="npm">
+    <Code code="npm run alchemy deploy" lang="sh" />
+  </TabItem>
+  <TabItem label="pnpm" icon="pnpm">
+    <Code code="pnpm alchemy deploy" lang="sh" />
+  </TabItem>
+  <TabItem label="yarn" icon="seti:yarn">
+    <Code code="yarn alchemy deploy" lang="sh" />
+  </TabItem>
+</Tabs>
+
+<Terminal content={`[u]Plan[/u]: [g]1 to create[/g]
+
+[g]+[/g] [b]Podinfo[/b] [d](Kubernetes.HelmChart)[/d]
+
+Proceed?
+◉ Yes ○ No
+[d]Rendering Helm chart podinfo@6.14.1...[/d]
+[d]Applying 3 objects from podinfo...[/d]
+[g]✓[/g] [b]Podinfo[/b] [d](Kubernetes.HelmChart)[/d] [g]created[/g]
+{
+[s2]url: "http://localhost:8080",
+[s2]deployment: "myapp-echo-dev-alex-k3m7p2q6r4s5t2v6",
+[s2]job: "myapp-hello-dev-alex-h6g5f4e3d2c7b2a4",
+[s2]kind: "CronJob",
+[s2]podinfoRelease: "myapp-podinfo-dev-alex-q2w3e4r5t6y7u2i3",
+}`} />
+
+The render ran on your machine with `helm template --no-hooks`. The
+three objects, the Namespace plus the chart's Service and Deployment,
+were [server-side applied](/kubernetes/guides/how-apply-works#server-side-apply)
+like Manifests. Their refs are recorded on the `objects` attribute,
+which is what pruning and destroy work from. See what landed:
+
+```sh
+kubectl get all -n podinfo
+```
+
+podinfo's Service is ClusterIP and named after the release, the
+`podinfoRelease` output. Port-forward to it:
+
+```sh
+kubectl port-forward -n podinfo svc/myapp-podinfo-dev-alex-q2w3e4r5t6y7u2i3 9898:9898
+curl localhost:9898
+```
+
+podinfo answers with JSON describing itself. With a long stack or
+stage name the release name is capped at Helm's 53 characters and
+may drop `podinfo`, and the chart then names the Service
+`<release>-podinfo`. `kubectl get svc -n podinfo` shows it either way.
+
+## Tune it with values
+
+Set the chart's values from TypeScript:
+
+```diff lang="typescript"
+const podinfo = yield* Kubernetes.HelmChart("Podinfo", {
+  cluster,
+  chart: "podinfo",
+  repo: "https://stefanprodan.github.io/podinfo",
+  version: "6.14.1",
+  namespace: "podinfo",
+  createNamespace: true,
++  values: {
++    replicaCount: 2,
++    ui: { message: "hello from alchemy" },
++  },
+});
+```
+
+[`values`](/kubernetes/objects/helm#values) is the chart's
+`values.yaml` as a TypeScript object. Deploy and the plan is
+`1 to update` because the chart's hash changed.
+`kubectl get deploy -n podinfo` shows `2/2`, and the port-forwarded
+JSON carries the new message. Unchanged objects are re-applied as
+no-ops.
+
+## Turn an object off and watch it get pruned
+
+Stop the port-forward, then switch the chart's Service off:
+
+```diff lang="typescript"
+values: {
+  replicaCount: 2,
+  ui: { message: "hello from alchemy" },
++  service: { enabled: false },
+},
+```
+
+<Terminal content={`[u]Plan[/u]: [y]1 to update[/y]
+
+[y]~[/y] [b]Podinfo[/b] [d](Kubernetes.HelmChart)[/d]
+
+Proceed?
+◉ Yes ○ No
+[d]Rendering Helm chart podinfo@6.14.1...[/d]
+[d]Applying 2 objects from podinfo...[/d]
+[g]✓[/g] [b]Podinfo[/b] [d](Kubernetes.HelmChart)[/d] [y]updated[/y]`} />
+
+`service.enabled` makes podinfo stop rendering its Service. The
+`Applying` note drops from 3 objects to 2, and
+`kubectl get svc -n podinfo` is empty. Objects that leave the render
+are [pruned](/kubernetes/guides/how-apply-works#pruning-and-drift),
+unlike `kubectl apply -f`.
+
+## Put it back
+
+Delete the `service` line again:
+
+```diff lang="typescript"
+values: {
+  replicaCount: 2,
+  ui: { message: "hello from alchemy" },
+-  service: { enabled: false },
+},
+```
+
+<Terminal content={`[u]Plan[/u]: [y]1 to update[/y]
+
+[y]~[/y] [b]Podinfo[/b] [d](Kubernetes.HelmChart)[/d]
+
+Proceed?
+◉ Yes ○ No
+[d]Rendering Helm chart podinfo@6.14.1...[/d]
+[d]Applying 3 objects from podinfo...[/d]
+[g]✓[/g] [b]Podinfo[/b] [d](Kubernetes.HelmChart)[/d] [y]updated[/y]`} />
+
+Back to 3 objects, and `kubectl get svc -n podinfo` lists the Service
+again. An object that re-enters the render is added back to the
+managed set.
+
+## What you didn't get from Helm
+
+`helm list -n podinfo` shows nothing. Helm only rendered, so there is
+no release record in the cluster. The chart's `templates/tests/` Pod
+never appeared in the object counts either, because the render runs
+with `--no-hooks`.
+
+:::note[Hooks and release records]
+Hook-annotated objects are never applied or executed. Charts that
+depend on lifecycle hooks should be installed with Helm directly. See
+[What Helm does that Alchemy doesn't](/kubernetes/objects/helm#what-helm-does-that-alchemy-doesnt).
+:::
+
+## Clean up
+
+<Tabs syncKey="pkgManager">
+  <TabItem label="bun" icon="bun">
+    <Code code="bun alchemy destroy" lang="sh" />
+  </TabItem>
+  <TabItem label="npm" icon="npm">
+    <Code code="npm run alchemy destroy" lang="sh" />
+  </TabItem>
+  <TabItem label="pnpm" icon="pnpm">
+    <Code code="pnpm alchemy destroy" lang="sh" />
+  </TabItem>
+  <TabItem label="yarn" icon="seti:yarn">
+    <Code code="yarn alchemy destroy" lang="sh" />
+  </TabItem>
+</Tabs>
+
+<Terminal content={`[u]Plan[/u]: [r]7 to delete[/r]
+
+[r]-[/r] [b]Config[/b] [d](Kubernetes.Manifest)[/d]
+[r]-[/r] [b]Echo[/b] [d](Kubernetes.Deployment)[/d]
+[r]-[/r] [b]Hello[/b] [d](Kubernetes.Job)[/d]
+[r]-[/r] [b]Namespace[/b] [d](Kubernetes.Manifest)[/d]
+[r]-[/r] [b]Podinfo[/b] [d](Kubernetes.HelmChart)[/d]
+[r]-[/r] [b]Redis[/b] [d](Kubernetes.Manifest)[/d]
+[r]-[/r] [b]RedisService[/b] [d](Kubernetes.Manifest)[/d]
+
+Proceed?
+◉ Yes ○ No
+[r]✗[/r] [b]Echo[/b] [d](Kubernetes.Deployment)[/d] [r]deleted[/r]
+[r]✗[/r] [b]Hello[/b] [d](Kubernetes.Job)[/d] [r]deleted[/r]
+[r]✗[/r] [b]Podinfo[/b] [d](Kubernetes.HelmChart)[/d] [r]deleted[/r]
+[r]✗[/r] [b]Config[/b] [d](Kubernetes.Manifest)[/d] [r]deleted[/r]
+[r]✗[/r] [b]Redis[/b] [d](Kubernetes.Manifest)[/d] [r]deleted[/r]
+[r]✗[/r] [b]RedisService[/b] [d](Kubernetes.Manifest)[/d] [r]deleted[/r]
+[r]✗[/r] [b]Namespace[/b] [d](Kubernetes.Manifest)[/d] [r]deleted[/r]`} />
+
+Within a resource, objects go in reverse apply order: the chart's
+Deployment and Service before its Namespace. Across resources,
+dependents go first, so the `tutorial` Namespace is last. `destroy`
+returns once the API server accepts the deletes, so `kubectl get ns`
+shows both namespaces `Terminating` for a while. Part 5 is optional
+and moves this program to a different cluster.
+
+## Recap
+
+One file deploys a Deployment, a CronJob, four Manifests, and a Helm
+chart, with values edits as ordinary updates and dropped objects
+pruned. Part 5 is optional: the same file on EKS, with `Echo` replaced
+by your own Effect code and an AWS binding.
+
+## Where next
+
+- [Part 5: The Same Program on EKS](/kubernetes/tutorial/part-5) —
+  optional: the same program on EKS with `main:` and a DynamoDB
+  binding.
+- [Helm charts](/kubernetes/objects/helm) — OCI and local charts,
+  `includeCrds`, the full lifecycle.
+- [How apply works](/kubernetes/guides/how-apply-works) —
+  server-side apply, drift, pruning, conflicts, debugging.

--- a/website/src/content/docs/kubernetes/tutorial/part-5.mdx
+++ b/website/src/content/docs/kubernetes/tutorial/part-5.mdx
@@ -8,33 +8,17 @@ sidebar:
 import Terminal from "../../../../components/Terminal.astro";
 import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 
-A kubeconfig cluster can deploy images but not build them, and pass
-env vars but not grant cloud permissions. Point the same file at EKS
-and the cluster adapter fills in both. Start from the
-[Part 4](/kubernetes/tutorial/part-4) file with the stack destroyed.
+On EKS the cluster adapter builds images and grants cloud permissions;
+a kubeconfig cluster can't. Start from
+[Part 4](/kubernetes/tutorial/part-4) with the stack destroyed. You
+need AWS credentials ([AWS Setup](/aws/setup)), Docker, and `helm`.
 
-:::caution[Costs and time]
-The EKS control plane, Auto Mode nodes, each `LoadBalancer` NLB, and
-the NAT gateway all bill hourly. Expect a few dollars for an
-afternoon. Cluster create and destroy each take 10–15 minutes.
-`alchemy destroy` at the end removes everything, including the
-cluster.
+:::caution[Costs]
+EKS, NLBs, and NAT bill hourly; cluster create and destroy each take
+10–15 minutes.
 :::
 
-## Prerequisites
-
-- AWS credentials in your environment. See [AWS Setup](/aws/setup)
-- Docker running. The adapter builds `main:` into an image and mirrors
-  `Hello`'s `busybox` image into ECR through it (see
-  [Image sources](/kubernetes/workloads/image-sources#three-sources))
-- `helm`, still needed for `Podinfo`
-
-`kubectl` access is optional. Alchemy talks to EKS directly, but
-`aws eks update-kubeconfig` works if you want to look around.
-
 ## Add the AWS providers
-
-Merge the AWS providers into the Stack:
 
 ```diff lang="typescript"
 // alchemy.run.ts
@@ -54,14 +38,12 @@ export default Alchemy.Stack(
   },
 ```
 
-`Kubernetes.providers()` ships the built-in adapters. The `aws-eks`
-adapter is registered by `AWS.providers()`, so EKS needs both layers.
-See [What the adapter adds](/kubernetes/clusters/eks#what-the-adapter-adds).
+`AWS.providers()` registers the `aws-eks`
+[adapter](/kubernetes/clusters/eks#what-the-adapter-adds).
 
 ## Move shared infrastructure to a module
 
-The Deployment you are about to write lives in its own file and needs
-the cluster and the namespace. Create `src/infra.ts`:
+Create `src/infra.ts`:
 
 ```typescript
 // src/infra.ts
@@ -101,7 +83,7 @@ export const Namespace = Effect.gen(function* () {
 });
 ```
 
-Then replace the inline Namespace in `alchemy.run.ts`:
+Then use it in `alchemy.run.ts`:
 
 ```diff lang="typescript"
 // alchemy.run.ts
@@ -124,17 +106,11 @@ import * as Layer from "effect/Layer";
 +    const ns = yield* Namespace;
 ```
 
-Module-scope declarations are memoized by logical id, so yielding
-`Cluster` or `Namespace` from two places converges on one resource.
-`compute: "auto"` is EKS Auto Mode. Network and
-[`Cluster`](/providers/aws/eks/cluster) props are on the
-[AWS EKS page](/aws/compute/eks#create-an-auto-mode-cluster). The
-`cluster` line is still kubeconfig for now, and `ns.name` keeps
-feeding the Part 3 resources.
+Module-scope declarations are memoized by logical id, so both files
+share one `Namespace`. Cluster props:
+[AWS EKS page](/aws/compute/eks#create-an-auto-mode-cluster).
 
 ## Swap the cluster
-
-Replace the kubeconfig connection with the EKS cluster:
 
 ```diff lang="typescript"
 import * as Effect from "effect/Effect";
@@ -148,10 +124,8 @@ import * as Layer from "effect/Layer";
 +    const cluster = yield* Cluster;
 ```
 
-Nothing else changes. `AWS.EKS.Cluster` carries a `connection` whose
-`auth.kind` is `"aws-eks"`, which is
-[how each resource finds the adapter](/kubernetes/clusters/connecting#how-the-adapter-is-chosen).
-Note the `yield*`: the cluster is a resource and gets a plan row.
+`AWS.EKS.Cluster` carries a connection with `auth.kind: "aws-eks"`,
+which is [how the adapter is chosen](/kubernetes/clusters/connecting#how-the-adapter-is-chosen).
 
 ## Write your own server
 
@@ -179,20 +153,17 @@ export default Kubernetes.Deployment(
 );
 ```
 
-This is the inline-Effect form: props, then an init Effect that
-returns the runtime API. The
-[tagged form](/kubernetes/workloads/deployments#the-tagged-form) is
-equivalent. `main: import.meta.url` makes this file the entrypoint.
-Alchemy [bundles it](/kubernetes/workloads/image-sources#bundling-and-tree-shaking)
-with rolldown, builds an image on `oven/bun:1`, and pushes it to a
-registry the adapter creates. A kubeconfig cluster
-[refused](/kubernetes/workloads/image-sources#registry-requirement)
-that step. [`fetch`](/kubernetes/workloads/deployments#effect-servers)
-is served on `port` by a Bun HTTP server.
+`main: import.meta.url` makes this file the entrypoint: Alchemy
+[bundles it](/kubernetes/workloads/image-sources#bundling-and-tree-shaking),
+builds an image, and pushes it to a
+[registry](/kubernetes/workloads/image-sources#registry-requirement)
+the adapter creates.
+[`fetch`](/kubernetes/workloads/deployments#effect-servers) is served
+on `port`.
 
 ## Add a DynamoDB table
 
-Append a table to `src/infra.ts`:
+Append to `src/infra.ts`:
 
 ```diff lang="typescript"
 // src/infra.ts
@@ -204,12 +175,7 @@ export const Cluster = Effect.gen(function* () { /* ... */ });
 +});
 ```
 
-An ordinary [AWS resource](/providers/aws/dynamodb/table) in the same
-program. It exists so the next step has something to bind.
-
 ## Bind the table
-
-Declare the bindings in the init Effect and provide their layers:
 
 ```diff lang="typescript"
 // src/api.ts
@@ -239,19 +205,13 @@ export default Kubernetes.Deployment(
 );
 ```
 
-`PutItem(Entries)` is a `Binding.Service`. At deploy it records
-`{ env, policyStatements }` on the Deployment: the table name and
-`dynamodb:PutItem` on that table (see
-[the binding contract](/kubernetes/workloads/bindings#the-binding-contract)).
-The EKS adapter turns `policyStatements` into a
-[Pod Identity](/kubernetes/workloads/bindings#pod-identity-on-eks)
-role on the ServiceAccount, so the pod gets credentials with no keys
-anywhere. The local cluster would have rejected this. It supports only
-[env-only bindings](/kubernetes/workloads/bindings#env-only-bindings).
+Each binding records
+[`env` and `policyStatements`](/kubernetes/workloads/bindings#the-binding-contract);
+the adapter turns the policy into a
+[Pod Identity](/kubernetes/workloads/bindings#pod-identity-on-eks) role,
+which a kubeconfig cluster [can't](/kubernetes/workloads/bindings#env-only-bindings).
 
 ## Use it in fetch
-
-Call the bound clients from the handler:
 
 ```diff lang="typescript"
 // src/api.ts
@@ -277,14 +237,11 @@ import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
     };
 ```
 
-`putItem` and `scan` are typed Effects that close over the env the
-binding set and sign with Pod Identity credentials. A `POST` writes
-one item and returns its id. Anything else returns the item count.
-Nothing in this handler knows it runs on Kubernetes.
+`putItem` and `scan` sign with Pod Identity credentials.
 
 ## Replace Echo with Api
 
-Swap the echo Deployment for your own in `alchemy.run.ts`:
+In `alchemy.run.ts`:
 
 ```diff lang="typescript"
 -import * as Output from "alchemy/Output";
@@ -321,14 +278,8 @@ import { Cluster, Namespace } from "./src/infra.ts";
     };
 ```
 
-Yielding `Api` registers the resource in the `tutorial` namespace.
-`Hello`, the Manifests, and `Podinfo` deploy to EKS unchanged. The
-Job's `image:` is [mirrored into ECR](/kubernetes/workloads/image-sources#three-sources)
-by the adapter, and the StatefulSet pulls `redis:7` directly. `Config`
-and `RedisService` stay owned even though `Api` doesn't read them. If
-a lint complains about unused `config` or `redisService`, make those
-two lines bare `yield*`. `identity` and `registry` are the two
-attributes only a managed adapter fills in.
+`Hello`, the Manifests, and `Podinfo` deploy to EKS unchanged;
+`identity` and `registry` are filled in only by a managed adapter.
 
 ## Deploy
 
@@ -389,15 +340,10 @@ Proceed?
 [s2]podinfoRelease: "myapp-podinfo-dev-alex-…",
 }`} />
 
-The `Api` row created an IAM role with the `dynamodb:PutItem` and
-`dynamodb:Scan` policy, a PodIdentityAssociation to the
-ServiceAccount, and an ECR repository, then bundled `src/api.ts`,
-built and pushed the image, applied the usual three objects, and
-waited for the NLB hostname. The role and repository have no plan
-rows. The [adapter](/kubernetes/clusters/eks#what-the-adapter-adds)
-provisions them inside the Deployment's lifecycle and deletes them
-with it. `url` carries port 3000 for the same reason Part 1 carried
-8080.
+The `Api` row also created an IAM role, PodIdentityAssociation, and
+ECR repository, managed by the
+[adapter](/kubernetes/clusters/eks#what-the-adapter-adds) inside the
+Deployment's lifecycle.
 
 ## Try it out
 
@@ -410,9 +356,7 @@ curl http://k8s-tutorial-myappapi-….elb.us-east-1.amazonaws.com:3000
 # → {"count":2}
 ```
 
-The pod wrote to DynamoDB with credentials from the Pod Identity
-agent on the node. The first request may take a few seconds while the
-NLB target registers. Retry if it times out.
+Retry if the first request times out.
 
 ## Ship a change
 
@@ -433,10 +377,8 @@ Proceed?
 ◉ Yes ○ No
 [g]✓[/g] [b]Api[/b] [d](Kubernetes.Deployment)[/d] [y]updated[/y]`} />
 
-The [bundle's](/kubernetes/workloads/image-sources#bundling-and-tree-shaking)
-hash changed, so Alchemy rebuilt, pushed a new tag, and applied the
-Deployment with the new `image`. A rolling update. The role,
-association, repository, Service, and ServiceAccount are untouched.
+The bundle hash changed, so Alchemy rebuilt, pushed a new tag, and
+rolled the Deployment.
 
 ## Destroy
 
@@ -471,29 +413,10 @@ association, repository, Service, and ServiceAccount are untouched.
 Proceed?
 ◉ Yes ○ No`} />
 
-Reverse dependency order: workloads with their roles and
-repositories, then the cluster (ten minutes or more), the table, and
-the network. The cluster and NAT gateway bill until this finishes.
-Let it complete and confirm in the AWS console that the cluster list
-is empty.
-
-## Recap
-
-One `cluster` line and `AWS.providers()` moved the file from Parts 1
-to 4 onto EKS. `Api` was bundled from `main` into ECR, its DynamoDB
-binding became a Pod Identity role, and the Job, Manifests, and chart
-deployed unchanged. One workload model, and the adapter decides what
-comes free.
+The cluster delete takes ten minutes or more.
 
 ## Where next
 
-- [Connecting to clusters](/kubernetes/clusters/connecting) — the
-  Connection model behind `KubeConfig()` and `AWS.EKS.Cluster`, every
-  auth kind, and adapter selection.
-- [Bindings](/kubernetes/workloads/bindings) — the binding contract,
-  Pod Identity details, and env-only binding on other clusters.
-- [EKS clusters](/kubernetes/clusters/eks) — everything the EKS
-  adapter adds, LB defaults, and where cluster provisioning docs
-  live.
-- [EKS on the AWS tab](/aws/compute/eks) — Network, Cluster,
-  AccessEntry, Addon, HyperPod.
+- [Connecting to clusters](/kubernetes/clusters/connecting)
+- [Bindings](/kubernetes/workloads/bindings)
+- [EKS clusters](/kubernetes/clusters/eks)

--- a/website/src/content/docs/kubernetes/tutorial/part-5.mdx
+++ b/website/src/content/docs/kubernetes/tutorial/part-5.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Part 5: The Same Program on EKS"
-description: Point the tutorial Stack at an AWS.EKS.Cluster, replace the pre-built image with your own Effect server bundled from main, bind a DynamoDB table, and see the Pod Identity role and ECR repository the adapter adds.
+description: Deploy the tutorial stack to an EKS cluster, replace the pre-built image with your own Effect server, and bind a DynamoDB table with Pod Identity.
 sidebar:
   order: 5
 ---
@@ -8,14 +8,14 @@ sidebar:
 import Terminal from "../../../../components/Terminal.astro";
 import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 
-On EKS the cluster adapter builds images and grants cloud permissions;
-a kubeconfig cluster can't. Start from
+Deploy the same stack to EKS, where Alchemy builds your image and
+grants AWS permissions to your pods. Start from
 [Part 4](/kubernetes/tutorial/part-4) with the stack destroyed. You
 need AWS credentials ([AWS Setup](/aws/setup)), Docker, and `helm`.
 
 :::caution[Costs]
-EKS, NLBs, and NAT bill hourly; cluster create and destroy each take
-10–15 minutes.
+EKS, load balancers, and NAT bill hourly; cluster create and destroy
+each take 10–15 minutes.
 :::
 
 ## Add the AWS providers
@@ -38,8 +38,8 @@ export default Alchemy.Stack(
   },
 ```
 
-`AWS.providers()` registers the `aws-eks`
-[adapter](/kubernetes/clusters/eks#what-the-adapter-adds).
+To deploy to EKS, add `AWS.providers()` next to
+`Kubernetes.providers()`.
 
 ## Move shared infrastructure to a module
 
@@ -69,7 +69,7 @@ export const Cluster = Effect.gen(function* () {
   });
 });
 
-// The Part 3 Namespace, unchanged — now shared by alchemy.run.ts and src/api.ts.
+// Shared with src/api.ts.
 export const Namespace = Effect.gen(function* () {
   const cluster = yield* Cluster;
   return yield* Kubernetes.Manifest("Namespace", {
@@ -106,9 +106,8 @@ import * as Layer from "effect/Layer";
 +    const ns = yield* Namespace;
 ```
 
-Module-scope declarations are memoized by logical id, so both files
-share one `Namespace`. Cluster props:
-[AWS EKS page](/aws/compute/eks#create-an-auto-mode-cluster).
+Both files share one `Namespace`. Cluster props:
+[AWS EKS](/aws/compute/eks#create-an-auto-mode-cluster).
 
 ## Swap the cluster
 
@@ -124,8 +123,7 @@ import * as Layer from "effect/Layer";
 +    const cluster = yield* Cluster;
 ```
 
-`AWS.EKS.Cluster` carries a connection with `auth.kind: "aws-eks"`,
-which is [how the adapter is chosen](/kubernetes/clusters/connecting#how-the-adapter-is-chosen).
+Every resource that takes `cluster` now deploys to EKS.
 
 ## Write your own server
 
@@ -153,13 +151,12 @@ export default Kubernetes.Deployment(
 );
 ```
 
-`main: import.meta.url` makes this file the entrypoint: Alchemy
+`main: import.meta.url` makes this file the entrypoint. Alchemy
 [bundles it](/kubernetes/workloads/image-sources#bundling-and-tree-shaking),
-builds an image, and pushes it to a
-[registry](/kubernetes/workloads/image-sources#registry-requirement)
-the adapter creates.
-[`fetch`](/kubernetes/workloads/deployments#effect-servers) is served
-on `port`.
+builds an image, and pushes it to
+[ECR](/kubernetes/workloads/image-sources#registry-requirement).
+[`fetch`](/kubernetes/workloads/deployments#effect-servers) answers
+every request on `port`.
 
 ## Add a DynamoDB table
 
@@ -205,11 +202,10 @@ export default Kubernetes.Deployment(
 );
 ```
 
-Each binding records
-[`env` and `policyStatements`](/kubernetes/workloads/bindings#the-binding-contract);
-the adapter turns the policy into a
-[Pod Identity](/kubernetes/workloads/bindings#pod-identity-on-eks) role,
-which a kubeconfig cluster [can't](/kubernetes/workloads/bindings#env-only-bindings).
+Each binding sets the table name in
+[env and grants IAM permissions](/kubernetes/workloads/bindings#bind-a-resource)
+through a [Pod Identity](/kubernetes/workloads/bindings#pod-identity-on-eks)
+role.
 
 ## Use it in fetch
 
@@ -237,7 +233,7 @@ import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
     };
 ```
 
-`putItem` and `scan` sign with Pod Identity credentials.
+`putItem` and `scan` use the pod's AWS credentials.
 
 ## Replace Echo with Api
 
@@ -278,8 +274,8 @@ import { Cluster, Namespace } from "./src/infra.ts";
     };
 ```
 
-`Hello`, the Manifests, and `Podinfo` deploy to EKS unchanged;
-`identity` and `registry` are filled in only by a managed adapter.
+`Hello`, the Manifests, and `Podinfo` need no changes. `identity` and
+`registry` are only set on EKS.
 
 ## Deploy
 
@@ -340,10 +336,9 @@ Proceed?
 [s2]podinfoRelease: "myapp-podinfo-dev-alex-…",
 }`} />
 
-The `Api` row also created an IAM role, PodIdentityAssociation, and
-ECR repository, managed by the
-[adapter](/kubernetes/clusters/eks#what-the-adapter-adds) inside the
-Deployment's lifecycle.
+`Api` also created an IAM role, a Pod Identity association, and an
+ECR repository. They are deleted with the Deployment
+([what EKS adds](/kubernetes/clusters/eks#what-eks-adds)).
 
 ## Try it out
 
@@ -377,8 +372,8 @@ Proceed?
 ◉ Yes ○ No
 [g]✓[/g] [b]Api[/b] [d](Kubernetes.Deployment)[/d] [y]updated[/y]`} />
 
-The bundle hash changed, so Alchemy rebuilt, pushed a new tag, and
-rolled the Deployment.
+Alchemy rebuilds the image, pushes a new tag, and rolls out the
+Deployment.
 
 ## Destroy
 
@@ -413,7 +408,7 @@ rolled the Deployment.
 Proceed?
 ◉ Yes ○ No`} />
 
-The cluster delete takes ten minutes or more.
+Deleting the cluster takes ten minutes or more.
 
 ## Where next
 

--- a/website/src/content/docs/kubernetes/tutorial/part-5.mdx
+++ b/website/src/content/docs/kubernetes/tutorial/part-5.mdx
@@ -1,0 +1,499 @@
+---
+title: "Part 5: The Same Program on EKS"
+description: Point the tutorial Stack at an AWS.EKS.Cluster, replace the pre-built image with your own Effect server bundled from main, bind a DynamoDB table, and see the Pod Identity role and ECR repository the adapter adds.
+sidebar:
+  order: 5
+---
+
+import Terminal from "../../../../components/Terminal.astro";
+import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
+
+A kubeconfig cluster can deploy images but not build them, and pass
+env vars but not grant cloud permissions. Point the same file at EKS
+and the cluster adapter fills in both. Start from the
+[Part 4](/kubernetes/tutorial/part-4) file with the stack destroyed.
+
+:::caution[Costs and time]
+The EKS control plane, Auto Mode nodes, each `LoadBalancer` NLB, and
+the NAT gateway all bill hourly. Expect a few dollars for an
+afternoon. Cluster create and destroy each take 10–15 minutes.
+`alchemy destroy` at the end removes everything, including the
+cluster.
+:::
+
+## Prerequisites
+
+- AWS credentials in your environment. See [AWS Setup](/aws/setup)
+- Docker running. The adapter builds `main:` into an image and mirrors
+  `Hello`'s `busybox` image into ECR through it (see
+  [Image sources](/kubernetes/workloads/image-sources#three-sources))
+- `helm`, still needed for `Podinfo`
+
+`kubectl` access is optional. Alchemy talks to EKS directly, but
+`aws eks update-kubeconfig` works if you want to look around.
+
+## Add the AWS providers
+
+Merge the AWS providers into the Stack:
+
+```diff lang="typescript"
+// alchemy.run.ts
+import * as Alchemy from "alchemy";
++import * as AWS from "alchemy/AWS";
+import * as Kubernetes from "alchemy/Kubernetes";
+import * as Output from "alchemy/Output";
+import * as Effect from "effect/Effect";
++import * as Layer from "effect/Layer";
+
+export default Alchemy.Stack(
+  "MyApp",
+  {
+-    providers: Kubernetes.providers(),
++    providers: Layer.mergeAll(AWS.providers(), Kubernetes.providers()),
+    state: Alchemy.localState(),
+  },
+```
+
+`Kubernetes.providers()` ships the built-in adapters. The `aws-eks`
+adapter is registered by `AWS.providers()`, so EKS needs both layers.
+See [What the adapter adds](/kubernetes/clusters/eks#what-the-adapter-adds).
+
+## Move shared infrastructure to a module
+
+The Deployment you are about to write lives in its own file and needs
+the cluster and the namespace. Create `src/infra.ts`:
+
+```typescript
+// src/infra.ts
+import * as AWS from "alchemy/AWS";
+import * as Kubernetes from "alchemy/Kubernetes";
+import * as Effect from "effect/Effect";
+
+export const Network = AWS.EC2.Network("Network", {
+  cidrBlock: "10.42.0.0/16",
+  availabilityZones: 2,
+  nat: "single",
+});
+
+export const Cluster = Effect.gen(function* () {
+  const network = yield* Network;
+  return yield* AWS.EKS.Cluster("Cluster", {
+    compute: "auto",
+    resourcesVpcConfig: {
+      subnetIds: network.privateSubnetIds,
+      endpointPublicAccess: true,
+      endpointPrivateAccess: true,
+    },
+  });
+});
+
+// The Part 3 Namespace, unchanged — now shared by alchemy.run.ts and src/api.ts.
+export const Namespace = Effect.gen(function* () {
+  const cluster = yield* Cluster;
+  return yield* Kubernetes.Manifest("Namespace", {
+    cluster,
+    manifest: {
+      apiVersion: "v1",
+      kind: "Namespace",
+      metadata: { name: "tutorial" },
+    },
+  });
+});
+```
+
+Then replace the inline Namespace in `alchemy.run.ts`:
+
+```diff lang="typescript"
+// alchemy.run.ts
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
++import { Namespace } from "./src/infra.ts";
+
+// ...
+  Effect.gen(function* () {
+    const cluster = Kubernetes.KubeConfig({ context: "docker-desktop" });
+
+-    const ns = yield* Kubernetes.Manifest("Namespace", {
+-      cluster,
+-      manifest: {
+-        apiVersion: "v1",
+-        kind: "Namespace",
+-        metadata: { name: "tutorial" },
+-      },
+-    });
++    const ns = yield* Namespace;
+```
+
+Module-scope declarations are memoized by logical id, so yielding
+`Cluster` or `Namespace` from two places converges on one resource.
+`compute: "auto"` is EKS Auto Mode. Network and
+[`Cluster`](/providers/aws/eks/cluster) props are on the
+[AWS EKS page](/aws/compute/eks#create-an-auto-mode-cluster). The
+`cluster` line is still kubeconfig for now, and `ns.name` keeps
+feeding the Part 3 resources.
+
+## Swap the cluster
+
+Replace the kubeconfig connection with the EKS cluster:
+
+```diff lang="typescript"
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+-import { Namespace } from "./src/infra.ts";
++import { Cluster, Namespace } from "./src/infra.ts";
+
+// ...
+  Effect.gen(function* () {
+-    const cluster = Kubernetes.KubeConfig({ context: "docker-desktop" });
++    const cluster = yield* Cluster;
+```
+
+Nothing else changes. `AWS.EKS.Cluster` carries a `connection` whose
+`auth.kind` is `"aws-eks"`, which is
+[how each resource finds the adapter](/kubernetes/clusters/connecting#how-the-adapter-is-chosen).
+Note the `yield*`: the cluster is a resource and gets a plan row.
+
+## Write your own server
+
+Create `src/api.ts`:
+
+```typescript
+// src/api.ts
+import * as Kubernetes from "alchemy/Kubernetes";
+import * as Effect from "effect/Effect";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import { Cluster, Namespace } from "./infra.ts";
+
+export default Kubernetes.Deployment(
+  "Api",
+  Effect.gen(function* () {
+    const cluster = yield* Cluster;
+    const ns = yield* Namespace;
+    return { cluster, namespace: ns.name, main: import.meta.url, port: 3000 };
+  }),
+  Effect.gen(function* () {
+    return {
+      fetch: Effect.succeed(HttpServerResponse.text("hello from EKS")),
+    };
+  }),
+);
+```
+
+This is the inline-Effect form: props, then an init Effect that
+returns the runtime API. The
+[tagged form](/kubernetes/workloads/deployments#the-tagged-form) is
+equivalent. `main: import.meta.url` makes this file the entrypoint.
+Alchemy [bundles it](/kubernetes/workloads/image-sources#bundling-and-tree-shaking)
+with rolldown, builds an image on `oven/bun:1`, and pushes it to a
+registry the adapter creates. A kubeconfig cluster
+[refused](/kubernetes/workloads/image-sources#registry-requirement)
+that step. [`fetch`](/kubernetes/workloads/deployments#effect-servers)
+is served on `port` by a Bun HTTP server.
+
+## Add a DynamoDB table
+
+Append a table to `src/infra.ts`:
+
+```diff lang="typescript"
+// src/infra.ts
+export const Cluster = Effect.gen(function* () { /* ... */ });
+
++export const Entries = AWS.DynamoDB.Table("Entries", {
++  partitionKey: "pk",
++  attributes: { pk: "S" },
++});
+```
+
+An ordinary [AWS resource](/providers/aws/dynamodb/table) in the same
+program. It exists so the next step has something to bind.
+
+## Bind the table
+
+Declare the bindings in the init Effect and provide their layers:
+
+```diff lang="typescript"
+// src/api.ts
++import * as AWS from "alchemy/AWS";
+import * as Kubernetes from "alchemy/Kubernetes";
+import * as Effect from "effect/Effect";
++import * as Layer from "effect/Layer";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+-import { Cluster, Namespace } from "./infra.ts";
++import { Cluster, Entries, Namespace } from "./infra.ts";
+
+export default Kubernetes.Deployment(
+  "Api",
+  Effect.gen(function* () { /* ... */ }),
+  Effect.gen(function* () {
++    const putItem = yield* AWS.DynamoDB.PutItem(Entries);
++    const scan = yield* AWS.DynamoDB.Scan(Entries);
+    return {
+      fetch: Effect.succeed(HttpServerResponse.text("hello from EKS")),
+    };
+-  }),
++  }).pipe(
++    Effect.provide(
++      Layer.mergeAll(AWS.DynamoDB.PutItemHttp, AWS.DynamoDB.ScanHttp),
++    ),
++  ),
+);
+```
+
+`PutItem(Entries)` is a `Binding.Service`. At deploy it records
+`{ env, policyStatements }` on the Deployment: the table name and
+`dynamodb:PutItem` on that table (see
+[the binding contract](/kubernetes/workloads/bindings#the-binding-contract)).
+The EKS adapter turns `policyStatements` into a
+[Pod Identity](/kubernetes/workloads/bindings#pod-identity-on-eks)
+role on the ServiceAccount, so the pod gets credentials with no keys
+anywhere. The local cluster would have rejected this. It supports only
+[env-only bindings](/kubernetes/workloads/bindings#env-only-bindings).
+
+## Use it in fetch
+
+Call the bound clients from the handler:
+
+```diff lang="typescript"
+// src/api.ts
+import * as Layer from "effect/Layer";
++import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+// ...
+    const putItem = yield* AWS.DynamoDB.PutItem(Entries);
+    const scan = yield* AWS.DynamoDB.Scan(Entries);
+    return {
+-      fetch: Effect.succeed(HttpServerResponse.text("hello from EKS")),
++      fetch: Effect.gen(function* () {
++        const request = yield* HttpServerRequest;
++        if (request.method === "POST") {
++          const id = yield* Effect.sync(() => crypto.randomUUID());
++          yield* putItem({ Item: { pk: { S: id } } });
++          return HttpServerResponse.json({ id });
++        }
++        const result = yield* scan({});
++        return HttpServerResponse.json({ count: result.Count ?? 0 });
++      }).pipe(Effect.orDie),
+    };
+```
+
+`putItem` and `scan` are typed Effects that close over the env the
+binding set and sign with Pod Identity credentials. A `POST` writes
+one item and returns its id. Anything else returns the item count.
+Nothing in this handler knows it runs on Kubernetes.
+
+## Replace Echo with Api
+
+Swap the echo Deployment for your own in `alchemy.run.ts`:
+
+```diff lang="typescript"
+-import * as Output from "alchemy/Output";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { Cluster, Namespace } from "./src/infra.ts";
++import Api from "./src/api.ts";
+
+// ...
+-    const echo = yield* Kubernetes.Deployment("Echo", {
+-      cluster,
+-      namespace: ns.name,
+-      image: "mendhak/http-https-echo:33",
+-      port: 8080,
+-      serviceType: "LoadBalancer",
+-      replicas: 3,
+-      env: {
+-        ...settings,
+-        CONFIG_MAP: config.name,
+-        REDIS_URL: Output.interpolate`redis://${redisService.name}:6379`,
+-      },
+-    });
++    const api = yield* Api;
+
+    return {
+-      url: echo.url,
+-      deployment: echo.deploymentName,
++      url: api.url,
++      identity: api.identity,
++      registry: api.registry,
+      job: hello.jobName,
+      kind: hello.kind,
+      podinfoRelease: podinfo.releaseName,
+    };
+```
+
+Yielding `Api` registers the resource in the `tutorial` namespace.
+`Hello`, the Manifests, and `Podinfo` deploy to EKS unchanged. The
+Job's `image:` is [mirrored into ECR](/kubernetes/workloads/image-sources#three-sources)
+by the adapter, and the StatefulSet pulls `redis:7` directly. `Config`
+and `RedisService` stay owned even though `Api` doesn't read them. If
+a lint complains about unused `config` or `redisService`, make those
+two lines bare `yield*`. `identity` and `registry` are the two
+attributes only a managed adapter fills in.
+
+## Deploy
+
+<Tabs syncKey="pkgManager">
+  <TabItem label="bun" icon="bun">
+    <Code code="bun alchemy deploy" lang="sh" />
+  </TabItem>
+  <TabItem label="npm" icon="npm">
+    <Code code="npm run alchemy deploy" lang="sh" />
+  </TabItem>
+  <TabItem label="pnpm" icon="pnpm">
+    <Code code="pnpm alchemy deploy" lang="sh" />
+  </TabItem>
+  <TabItem label="yarn" icon="seti:yarn">
+    <Code code="yarn alchemy deploy" lang="sh" />
+  </TabItem>
+</Tabs>
+
+<Terminal content={`[u]Plan[/u]: [g]10 to create[/g]
+
+[g]+[/g] [b]Api[/b] [d](Kubernetes.Deployment)[/d]
+[g]+[/g] [b]Cluster[/b] [d](AWS.EKS.Cluster)[/d]
+[g]+[/g] [b]Config[/b] [d](Kubernetes.Manifest)[/d]
+[g]+[/g] [b]Entries[/b] [d](AWS.DynamoDB.Table)[/d]
+[g]+[/g] [b]Hello[/b] [d](Kubernetes.Job)[/d]
+[g]+[/g] [b]Namespace[/b] [d](Kubernetes.Manifest)[/d]
+[g]+[/g] [b]Network[/b] [d](AWS.EC2.Network)[/d]
+[g]+[/g] [b]Podinfo[/b] [d](Kubernetes.HelmChart)[/d]
+[g]+[/g] [b]Redis[/b] [d](Kubernetes.Manifest)[/d]
+[g]+[/g] [b]RedisService[/b] [d](Kubernetes.Manifest)[/d]
+
+Proceed?
+◉ Yes ○ No
+[g]✓[/g] [b]Network[/b] [d](AWS.EC2.Network)[/d] [g]created[/g]
+[g]✓[/g] [b]Entries[/b] [d](AWS.DynamoDB.Table)[/d] [g]created[/g]
+[g]✓[/g] [b]Cluster[/b] [d](AWS.EKS.Cluster)[/d] [g]created[/g]
+[g]✓[/g] [b]Namespace[/b] [d](Kubernetes.Manifest)[/d] [g]created[/g]
+...
+[d]Bundling Api program...[/d]
+[d]Building container image 123456789012.dkr.ecr.us-east-1.amazonaws.com/myapp-api-dev-alex-…[/d]
+[g]✓[/g] [b]Api[/b] [d](Kubernetes.Deployment)[/d] [g]created[/g]
+{
+[s2]url: "http://k8s-tutorial-myappapi-….elb.us-east-1.amazonaws.com:3000",
+[s2]identity: {
+[s2][s2]kind: "aws-pod-identity",
+[s2][s2]roleArn: "arn:aws:iam::123456789012:role/myapp-api-dev-alex-…",
+[s2][s2]roleName: "myapp-api-dev-alex-…",
+[s2][s2]associationArn: "arn:aws:eks:us-east-1:123456789012:podidentityassociation/…",
+[s2][s2]associationId: "a-…",
+[s2]},
+[s2]registry: {
+[s2][s2]kind: "aws-ecr",
+[s2][s2]repositoryName: "myapp-api-dev-alex-…",
+[s2][s2]repositoryUri: "123456789012.dkr.ecr.us-east-1.amazonaws.com/myapp-api-dev-alex-…",
+[s2]},
+[s2]job: "myapp-hello-dev-alex-…",
+[s2]kind: "CronJob",
+[s2]podinfoRelease: "myapp-podinfo-dev-alex-…",
+}`} />
+
+The `Api` row created an IAM role with the `dynamodb:PutItem` and
+`dynamodb:Scan` policy, a PodIdentityAssociation to the
+ServiceAccount, and an ECR repository, then bundled `src/api.ts`,
+built and pushed the image, applied the usual three objects, and
+waited for the NLB hostname. The role and repository have no plan
+rows. The [adapter](/kubernetes/clusters/eks#what-the-adapter-adds)
+provisions them inside the Deployment's lifecycle and deletes them
+with it. `url` carries port 3000 for the same reason Part 1 carried
+8080.
+
+## Try it out
+
+Write two items, then count them:
+
+```sh
+curl -X POST http://k8s-tutorial-myappapi-….elb.us-east-1.amazonaws.com:3000
+curl -X POST http://k8s-tutorial-myappapi-….elb.us-east-1.amazonaws.com:3000
+curl http://k8s-tutorial-myappapi-….elb.us-east-1.amazonaws.com:3000
+# → {"count":2}
+```
+
+The pod wrote to DynamoDB with credentials from the Pod Identity
+agent on the node. The first request may take a few seconds while the
+NLB target registers. Retry if it times out.
+
+## Ship a change
+
+Edit the response and deploy again:
+
+```diff lang="typescript"
+// src/api.ts
+        const result = yield* scan({});
+-        return HttpServerResponse.json({ count: result.Count ?? 0 });
++        return HttpServerResponse.json({ count: result.Count ?? 0, source: "eks" });
+```
+
+<Terminal content={`[u]Plan[/u]: [y]1 to update[/y]
+
+[y]~[/y] [b]Api[/b] [d](Kubernetes.Deployment)[/d]
+
+Proceed?
+◉ Yes ○ No
+[g]✓[/g] [b]Api[/b] [d](Kubernetes.Deployment)[/d] [y]updated[/y]`} />
+
+The [bundle's](/kubernetes/workloads/image-sources#bundling-and-tree-shaking)
+hash changed, so Alchemy rebuilt, pushed a new tag, and applied the
+Deployment with the new `image`. A rolling update. The role,
+association, repository, Service, and ServiceAccount are untouched.
+
+## Destroy
+
+<Tabs syncKey="pkgManager">
+  <TabItem label="bun" icon="bun">
+    <Code code="bun alchemy destroy" lang="sh" />
+  </TabItem>
+  <TabItem label="npm" icon="npm">
+    <Code code="npm run alchemy destroy" lang="sh" />
+  </TabItem>
+  <TabItem label="pnpm" icon="pnpm">
+    <Code code="pnpm alchemy destroy" lang="sh" />
+  </TabItem>
+  <TabItem label="yarn" icon="seti:yarn">
+    <Code code="yarn alchemy destroy" lang="sh" />
+  </TabItem>
+</Tabs>
+
+<Terminal content={`[u]Plan[/u]: [r]10 to delete[/r]
+
+[r]-[/r] [b]Api[/b] [d](Kubernetes.Deployment)[/d]
+[r]-[/r] [b]Cluster[/b] [d](AWS.EKS.Cluster)[/d]
+[r]-[/r] [b]Config[/b] [d](Kubernetes.Manifest)[/d]
+[r]-[/r] [b]Entries[/b] [d](AWS.DynamoDB.Table)[/d]
+[r]-[/r] [b]Hello[/b] [d](Kubernetes.Job)[/d]
+[r]-[/r] [b]Namespace[/b] [d](Kubernetes.Manifest)[/d]
+[r]-[/r] [b]Network[/b] [d](AWS.EC2.Network)[/d]
+[r]-[/r] [b]Podinfo[/b] [d](Kubernetes.HelmChart)[/d]
+[r]-[/r] [b]Redis[/b] [d](Kubernetes.Manifest)[/d]
+[r]-[/r] [b]RedisService[/b] [d](Kubernetes.Manifest)[/d]
+
+Proceed?
+◉ Yes ○ No`} />
+
+Reverse dependency order: workloads with their roles and
+repositories, then the cluster (ten minutes or more), the table, and
+the network. The cluster and NAT gateway bill until this finishes.
+Let it complete and confirm in the AWS console that the cluster list
+is empty.
+
+## Recap
+
+One `cluster` line and `AWS.providers()` moved the file from Parts 1
+to 4 onto EKS. `Api` was bundled from `main` into ECR, its DynamoDB
+binding became a Pod Identity role, and the Job, Manifests, and chart
+deployed unchanged. One workload model, and the adapter decides what
+comes free.
+
+## Where next
+
+- [Connecting to clusters](/kubernetes/clusters/connecting) — the
+  Connection model behind `KubeConfig()` and `AWS.EKS.Cluster`, every
+  auth kind, and adapter selection.
+- [Bindings](/kubernetes/workloads/bindings) — the binding contract,
+  Pod Identity details, and env-only binding on other clusters.
+- [EKS clusters](/kubernetes/clusters/eks) — everything the EKS
+  adapter adds, LB defaults, and where cluster provisioning docs
+  live.
+- [EKS on the AWS tab](/aws/compute/eks) — Network, Cluster,
+  AccessEntry, Addon, HyperPod.

--- a/website/src/content/docs/kubernetes/workloads/bindings.mdx
+++ b/website/src/content/docs/kubernetes/workloads/bindings.mdx
@@ -3,8 +3,7 @@ title: Bindings
 description: How a Binding.Service lands on a Kubernetes workload — env vars on the pod spec everywhere, IAM on a Pod Identity role on EKS — and how to bind through plain env vars on clusters without an adapter.
 ---
 
-A `Kubernetes.Deployment` or `Kubernetes.Job` is a binding host with
-the same contract as `AWS.Lambda.Function` and `AWS.ECS.Task`. One
+A `Kubernetes.Deployment` or `Kubernetes.Job` is a binding host. One
 `yield* AWS.DynamoDB.PutItem(table)` in the init Effect becomes an env
 var on the pod spec and, on EKS, an IAM statement on a generated Pod
 Identity role.
@@ -14,8 +13,7 @@ Identity role.
 `WorkloadBindingContract` is `{ env?: Record<string, any> }`. The
 [EKS adapter](/kubernetes/clusters/eks#what-the-adapter-adds) adds
 `policyStatements?: PolicyStatement[]`, so every AWS `Binding.Service`
-works unchanged on a Kubernetes workload. The general model is
-[what one binding call records](/infrastructure-as-effects/binding#what-one-binding-call-does-at-deploy-time).
+works unchanged.
 
 ```typescript
 // Inside the Stack's Effect.gen body.
@@ -53,82 +51,27 @@ const api = yield* Kubernetes.Deployment(
 );
 ```
 
-The impl form is under
-[Effect servers](/kubernetes/workloads/deployments#effect-servers).
-Each `yield*` fed two channels.
-
-**The policy channel.** The `*Http` layer calls
-``host.bind`Allow(${host}, AWS.DynamoDB.PutItem(${table}))`({ policyStatements: [...] })``,
-guarded by `!globalThis.__ALCHEMY_RUNTIME__`. On EKS the statements
-become the Pod Identity role's inline policy.
-
-**The env channel.** Bindings with `data.env` are collected. Every
-`Output` the init Effect captures, such as `yield* table.tableName`
-inside the DynamoDB client, registers an env var through the host's
-`RuntimeContext`. Non-string values are JSON-encoded and the key is
-Alchemy-generated, so read through the client, not by name.
-
-Both land in the container `env` list with your own `env` prop, which
-wins on a shared key. The full precedence is under
-[What gets created](/kubernetes/workloads/deployments#what-gets-created).
-
-| Binding line       | Pod spec                                   | IAM (EKS)                                                                       |
-| ------------------ | ------------------------------------------ | ------------------------------------------------------------------------------- |
-| `PutItem(table)`   | env var with the table name (Alchemy key)  | `dynamodb:PutItem` on the table ARN, inline policy                              |
-| `GetObject(uploads)` | env var with the bucket name (Alchemy key) | `s3:GetObject` + `s3:GetObjectVersion` on `arn:…:uploads/*`, `s3:ListBucket` on the bucket |
-
-:::caution[PORT is just an env var]
-Setting `PORT` in `env` overrides the injected one but does not move
-`containerPort` or the Service port. Change the `port` prop instead.
-:::
-
-At boot the same init Effect runs inside the container. The
-`__ALCHEMY_RUNTIME__` guard skips `host.bind`, so only the client is
-built. See
-[the `__ALCHEMY_RUNTIME__` guard](/infrastructure-as-effects/phases#the-__alchemy_runtime__-guard).
+Each `yield*` records a policy statement on the host (guarded by
+`!globalThis.__ALCHEMY_RUNTIME__`, so at boot only the client is built)
+and registers every captured `Output` as an Alchemy-keyed env var:
+read through the client, not by name. Your `env` prop wins on a shared
+key.
 
 ## Pod Identity on EKS
 
-Every Deployment or Job on an `auth.kind: "aws-eks"` cluster gets
-workload identity, bindings or not. It is part of
-[what the EKS adapter adds](/kubernetes/clusters/eks#what-the-adapter-adds),
-and a [Job's `{ run }`](/kubernetes/workloads/jobs#effect-jobs) gets
-the same. The identity step runs on every deploy.
-
-The role is named from the logical id (`<id>-pod-role`, at most 64
-characters), trusts `pods.eks.amazonaws.com` for `sts:AssumeRole` and
-`sts:TagSession`, and carries Alchemy's internal tags. An existing
-role of that name is adopted only when it has those tags. Otherwise
-the deploy fails with "already exists and is not managed by alchemy".
-
-`identity.managedPolicyArns` are attached when the role is first
-created. That is how an external `image:` workload gets AWS access:
-it has no init Effect, and the SDK in the container uses the default
-credential chain.
-
+Every workload on an `auth.kind: "aws-eks"` cluster gets a role
+`<id>-pod-role` trusting `pods.eks.amazonaws.com`, bindings or not.
 Active bindings' `policyStatements` become one inline policy,
-`<id>-pod-policy`, each `Sid` sanitized to alphanumerics. When none
-remain the policy is deleted, so removing a binding removes its grant
-on the next deploy.
+`<id>-pod-policy`, re-synced every deploy. A
+[`PodIdentityAssociation`](/providers/aws/eks/podidentityassociation)
+keyed on the cluster, namespace, and generated ServiceAccount binds it,
+so changing `namespace` replaces the workload. Inside the container
+`Credentials.fromChain()` reads the Pod Identity endpoint and
+`AWS_REGION` is injected; nothing goes in `podTemplate`.
+`attrs.identity` is `undefined` off EKS.
 
-A [`PodIdentityAssociation`](/providers/aws/eks/podidentityassociation)
-keyed on the cluster, namespace, and the generated ServiceAccount
-binds the role to the workload. A changed role ARN is re-pointed in
-place. Changing `namespace` therefore replaces the workload.
-
-`AWS_REGION` is injected. EKS pods get none by default.
-
-Inside the container the bootstrap provides `Credentials.fromChain()`
-and `Region.fromEnv()`, so clients read the Pod Identity endpoint
-(`AWS_CONTAINER_CREDENTIALS_FULL_URI` plus the agent's token file).
-No static keys, no IRSA annotations, nothing in `podTemplate`.
-`Credentials | Region | AWSEnvironment` are ambient workload services,
-which is why the example above type-checks.
-
-`attrs.identity` is
-`{ kind: "aws-pod-identity", roleArn, roleName, associationArn, associationId }`
-on EKS and `undefined` elsewhere. It is stable, so `roleArn` is safe
-in a bucket policy or a KMS key policy.
+An `image:` workload has no init Effect, so grant it through
+`identity.managedPolicyArns`:
 
 ```typescript
 // External image, no init Effect — grant through managed policies.
@@ -146,47 +89,17 @@ worker.identity; // { kind: "aws-pod-identity", roleArn, roleName, associationAr
 worker.serviceAccountName; // the ServiceAccount the association is bound to
 ```
 
-On delete the association goes first (skipped when the cluster is
-gone or deleting), then inline policies, managed-policy detachments,
-and the role.
-
-:::note[Not separate plan rows]
-The role and association are reconciled inside the workload row.
-`alchemy plan` shows one row per workload, noted
-`Applied Kubernetes Deployment <namespace>/<name>`. Cluster
-provisioning lives on the [AWS EKS page](/aws/compute/eks).
-:::
-
 :::caution[managedPolicyArns is applied on first create only]
-Adding or removing an ARN once the role exists is silently ignored.
-Only the inline policy from bindings re-syncs every deploy. Replace
-the workload (change `namespace`) or grant through a binding instead.
+Changing the ARNs once the role exists is ignored; bind instead, or replace the workload.
 :::
 
 ## Env-only bindings
 
-A kubeconfig, token, client-cert, or exec cluster has no managed
-registry, so
+A registry-less cluster has
 [no `main`](/kubernetes/workloads/image-sources#registry-requirement),
-no init Effect, and nothing to bind. There is no identity step
-either. Point a binding-bearing impl at one and reconcile dies before
-touching the cluster:
-
-> `'Api': bindings carry cloud credential grants (policyStatements)
-> but this cluster's platform has no workload-identity adapter.
-> Target a managed cluster (e.g. AWS.EKS.Cluster) or bind through
-> environment variables instead.`
-
-"Bind through environment variables" means the `env` prop on an
-`image:` workload, fed from other resources' outputs.
-
-**Wire other objects' outputs.** Manifest attributes such as `name`
-and `namespace` are Outputs. Interpolate them into `env`. Numbers and
-objects are JSON-stringified. The StatefulSet and Service are plain
-[Manifests](/kubernetes/objects/manifests#any-object), and the image
-reached the cluster as
-[Using your own images](/kubernetes/clusters/local#using-your-own-images)
-describes.
+so nothing to bind and no identity step; a binding-bearing impl fails
+at reconcile. Feed the `env` prop of an `image:` workload from other
+resources' Outputs instead. Numbers and objects are JSON-stringified.
 
 ```typescript
 import * as Output from "alchemy/Output";
@@ -229,15 +142,12 @@ const api = yield* Kubernetes.Deployment("Api", {
 });
 ```
 
-**Secrets.** Never put secrets in `env`. It is plain text on the
-Deployment object. Create a `Secret` Manifest as
-[Secrets](/kubernetes/objects/manifests#secrets) describes and
-reference it with `valueFrom.secretKeyRef`. The `env` prop writes
-literals only, so `valueFrom` needs the
-[container-level override](/kubernetes/workloads/pod-template#container-level-fields).
-[Arrays replace](/kubernetes/workloads/pod-template#merge-rules), so
-the whole container is restated, which is only possible on an
-`image:` source.
+Never put secrets in `env`. Reference a
+[Secret Manifest](/kubernetes/objects/manifests#secrets) with
+`valueFrom.secretKeyRef`, which needs the
+[container-level override](/kubernetes/workloads/pod-template#container-level-fields);
+[arrays replace](/kubernetes/workloads/pod-template#merge-rules), so
+restate the whole container.
 
 ```typescript
 import * as Config from "effect/Config";
@@ -284,26 +194,11 @@ const api = yield* Kubernetes.Deployment("Api", {
 });
 ```
 
-**Consume from any language.** The names are the keys you wrote and
-the values are strings: `process.env.REDIS_HOST`,
-`os.environ["REDIS_HOST"]`, `std::env::var("REDIS_HOST")`. Parse
-JSON-encoded ones yourself. `ALCHEMY_STACK_NAME`, `ALCHEMY_STAGE`, and
-`ALCHEMY_PHASE` are present but ignorable.
-
-:::tip[ConfigMaps]
-Same pattern with `configMapKeyRef`, or pass the values straight into
-`env`. Tutorial part 3 does this.
-:::
-
 ## Runtime-only methods and RuntimeContext
 
-A binding's client runs only inside the pod. Its methods require
-`Alchemy.RuntimeContext`, which the bootstrap provides to `{ fetch }`
-and `{ run }` and the init Effect lacks. `yield* putItem(...)` in the
-init body is a type error. Inside `fetch` it compiles. Same rule as
-Lambda and Workers:
-[The types hold the boundary](/infrastructure-as-effects/layers#the-types-hold-the-boundary)
-and [Init vs runtime](/infrastructure-as-effects/phases#init-vs-runtime).
+A binding client's methods require `Alchemy.RuntimeContext`, which the
+bootstrap provides to `{ fetch }` and `{ run }` but not to the init
+Effect, so calling one at init is a type error.
 
 ```typescript
 Effect.gen(function* () {
@@ -320,11 +215,6 @@ Effect.gen(function* () {
 
 ## Where next
 
-- [Pod template](/kubernetes/workloads/pod-template) — merge rules
-  and recipes for the synthesized pod template.
-- [Secrets](/kubernetes/objects/manifests#secrets) — Secrets and
-  ConfigMaps as Manifests.
-- [What the adapter adds](/kubernetes/clusters/eks#what-the-adapter-adds)
-  — everything EKS adds beyond identity.
-- [Bindings](/infrastructure-as-effects/binding) — the binding model
-  across every Alchemy host.
+- [Pod template](/kubernetes/workloads/pod-template)
+- [Secrets](/kubernetes/objects/manifests#secrets)
+- [Bindings](/infrastructure-as-effects/binding)

--- a/website/src/content/docs/kubernetes/workloads/bindings.mdx
+++ b/website/src/content/docs/kubernetes/workloads/bindings.mdx
@@ -1,19 +1,18 @@
 ---
 title: Bindings
-description: How a Binding.Service lands on a Kubernetes workload — env vars on the pod spec everywhere, IAM on a Pod Identity role on EKS — and how to bind through plain env vars on clusters without an adapter.
+description: Give a Kubernetes Deployment or Job access to other resources with bindings, Pod Identity on EKS, or plain env vars on local clusters.
 ---
 
-A `Kubernetes.Deployment` or `Kubernetes.Job` is a binding host. One
-`yield* AWS.DynamoDB.PutItem(table)` in the init Effect becomes an env
-var on the pod spec and, on EKS, an IAM statement on a generated Pod
-Identity role.
+Bind a `Kubernetes.Deployment` or `Kubernetes.Job` to other resources.
+One
+`yield* AWS.DynamoDB.PutItem(table)` in the init Effect sets an env var
+on the pod and, on EKS, grants the permission to the pod's IAM role.
 
-## The binding contract
+## Bind a resource
 
-`WorkloadBindingContract` is `{ env?: Record<string, any> }`. The
-[EKS adapter](/kubernetes/clusters/eks#what-the-adapter-adds) adds
-`policyStatements?: PolicyStatement[]`, so every AWS `Binding.Service`
-works unchanged.
+A binding sets env vars on the pod. On
+[EKS](/kubernetes/clusters/eks#what-eks-adds) it also grants
+IAM permissions, so every AWS binding works unchanged.
 
 ```typescript
 // Inside the Stack's Effect.gen body.
@@ -28,11 +27,10 @@ const api = yield* Kubernetes.Deployment(
   "Api",
   { cluster, main: import.meta.url, port: 3000 },
   Effect.gen(function* () {
-    // Each yield* records one policy statement on the host and returns
-    // a typed client. Nothing is created here — the adapter does that
-    // on deploy.
-    const putItem = yield* AWS.DynamoDB.PutItem(table); // dynamodb:PutItem on table.tableArn
-    const getObject = yield* AWS.S3.GetObject(uploads); // s3:GetObject on ${bucketArn}/* (+ s3:ListBucket)
+    // Each yield* grants one permission and returns a client to call
+    // inside fetch.
+    const putItem = yield* AWS.DynamoDB.PutItem(table); // dynamodb:PutItem on the table
+    const getObject = yield* AWS.S3.GetObject(uploads); // s3:GetObject on the bucket's objects (+ s3:ListBucket)
 
     return {
       fetch: Effect.gen(function* () {
@@ -51,30 +49,24 @@ const api = yield* Kubernetes.Deployment(
 );
 ```
 
-Each `yield*` records a policy statement on the host (guarded by
-`!globalThis.__ALCHEMY_RUNTIME__`, so at boot only the client is built)
-and registers every captured `Output` as an Alchemy-keyed env var:
-read through the client, not by name. Your `env` prop wins on a shared
-key.
+Reach a bound resource through its client, not by reading its name
+from the environment. If your `env` prop sets the same key as a
+binding, your value wins.
 
 ## Pod Identity on EKS
 
-Every workload on an `auth.kind: "aws-eks"` cluster gets a role
-`<id>-pod-role` trusting `pods.eks.amazonaws.com`, bindings or not.
-Active bindings' `policyStatements` become one inline policy,
-`<id>-pod-policy`, re-synced every deploy. A
-[`PodIdentityAssociation`](/providers/aws/eks/podidentityassociation)
-keyed on the cluster, namespace, and generated ServiceAccount binds it,
-so changing `namespace` replaces the workload. Inside the container
-`Credentials.fromChain()` reads the Pod Identity endpoint and
-`AWS_REGION` is injected; nothing goes in `podTemplate`.
-`attrs.identity` is `undefined` off EKS.
+On EKS every workload gets an IAM role, `<id>-pod-role`, bound to its
+ServiceAccount, with or without bindings. Binding permissions go in
+the role's inline policy, `<id>-pod-policy`. AWS credentials and
+`AWS_REGION` are available inside the container; add nothing to
+`podTemplate`. Changing
+`namespace` replaces the workload. Off EKS, `identity` is `undefined`.
 
-An `image:` workload has no init Effect, so grant it through
+For an `image:` workload, grant permissions with
 `identity.managedPolicyArns`:
 
 ```typescript
-// External image, no init Effect — grant through managed policies.
+// Pre-built image: grant through managed policies.
 const worker = yield* Kubernetes.Deployment("Worker", {
   cluster,
   image: "ghcr.io/acme/worker:1.4",
@@ -86,7 +78,7 @@ const worker = yield* Kubernetes.Deployment("Worker", {
 });
 
 worker.identity; // { kind: "aws-pod-identity", roleArn, roleName, associationArn, associationId }
-worker.serviceAccountName; // the ServiceAccount the association is bound to
+worker.serviceAccountName; // the ServiceAccount the role is bound to
 ```
 
 :::caution[managedPolicyArns is applied on first create only]
@@ -95,11 +87,9 @@ Changing the ARNs once the role exists is ignored; bind instead, or replace the 
 
 ## Env-only bindings
 
-A registry-less cluster has
-[no `main`](/kubernetes/workloads/image-sources#registry-requirement),
-so nothing to bind and no identity step; a binding-bearing impl fails
-at reconcile. Feed the `env` prop of an `image:` workload from other
-resources' Outputs instead. Numbers and objects are JSON-stringified.
+On clusters other than EKS, pass values from other resources through
+the `env` prop of an `image:` workload. Numbers and objects are
+JSON-stringified.
 
 ```typescript
 import * as Output from "alchemy/Output";
@@ -132,7 +122,7 @@ const redisSvc = yield* Kubernetes.Manifest("RedisService", {
 
 const api = yield* Kubernetes.Deployment("Api", {
   cluster,
-  image: "ghcr.io/acme/api:v3", // the only image source on a registry-less cluster
+  image: "ghcr.io/acme/api:v3", // pre-built image
   port: 8080,
   env: {
     REDIS_HOST: Output.interpolate`${redisSvc.name}.${redisSvc.namespace}.svc.cluster.local`,
@@ -142,12 +132,12 @@ const api = yield* Kubernetes.Deployment("Api", {
 });
 ```
 
-Never put secrets in `env`. Reference a
-[Secret Manifest](/kubernetes/objects/manifests#secrets) with
-`valueFrom.secretKeyRef`, which needs the
-[container-level override](/kubernetes/workloads/pod-template#container-level-fields);
-[arrays replace](/kubernetes/workloads/pod-template#merge-rules), so
-restate the whole container.
+Never put secrets in `env`. Put them in a
+[Secret Manifest](/kubernetes/objects/manifests#secrets) and reference
+it with `valueFrom.secretKeyRef`. That is a
+[container-level field](/kubernetes/workloads/pod-template#container-level-fields),
+and [arrays replace](/kubernetes/workloads/pod-template#merge-rules),
+so restate the whole container.
 
 ```typescript
 import * as Config from "effect/Config";
@@ -158,7 +148,7 @@ const dbSecret = yield* Kubernetes.Manifest("DbSecret", {
     apiVersion: "v1",
     kind: "Secret",
     metadata: { name: "db-credentials", namespace: "default" },
-    // Resolved at plan time from the deploying shell's environment —
+    // Read from the shell that runs `alchemy deploy`;
     // never a literal in alchemy.run.ts.
     stringData: { password: Config.string("DB_PASSWORD") },
   },
@@ -171,7 +161,7 @@ const api = yield* Kubernetes.Deployment("Api", {
   env: { DB_HOST: "postgres.default.svc.cluster.local" },
   podTemplate: {
     spec: {
-      // Arrays REPLACE: restate the whole synthesized container.
+      // Restate the whole container.
       containers: [
         {
           name: "api",
@@ -194,16 +184,15 @@ const api = yield* Kubernetes.Deployment("Api", {
 });
 ```
 
-## Runtime-only methods and RuntimeContext
+## Calling a binding
 
-A binding client's methods require `Alchemy.RuntimeContext`, which the
-bootstrap provides to `{ fetch }` and `{ run }` but not to the init
-Effect, so calling one at init is a type error.
+Call a binding client inside `fetch` or `run`, not in the init Effect;
+at init it is a type error.
 
 ```typescript
 Effect.gen(function* () {
   const putItem = yield* AWS.DynamoDB.PutItem(table);
-  // yield* putItem({ ... })   ✗ RuntimeContext is not available at init
+  // yield* putItem({ ... })   ✗ not at init
   return {
     fetch: Effect.gen(function* () {
       yield* putItem({ Item: { pk: { S: "1" } } }); // ✓

--- a/website/src/content/docs/kubernetes/workloads/bindings.mdx
+++ b/website/src/content/docs/kubernetes/workloads/bindings.mdx
@@ -1,0 +1,330 @@
+---
+title: Bindings
+description: How a Binding.Service lands on a Kubernetes workload — env vars on the pod spec everywhere, IAM on a Pod Identity role on EKS — and how to bind through plain env vars on clusters without an adapter.
+---
+
+A `Kubernetes.Deployment` or `Kubernetes.Job` is a binding host with
+the same contract as `AWS.Lambda.Function` and `AWS.ECS.Task`. One
+`yield* AWS.DynamoDB.PutItem(table)` in the init Effect becomes an env
+var on the pod spec and, on EKS, an IAM statement on a generated Pod
+Identity role.
+
+## The binding contract
+
+`WorkloadBindingContract` is `{ env?: Record<string, any> }`. The
+[EKS adapter](/kubernetes/clusters/eks#what-the-adapter-adds) adds
+`policyStatements?: PolicyStatement[]`, so every AWS `Binding.Service`
+works unchanged on a Kubernetes workload. The general model is
+[what one binding call records](/infrastructure-as-effects/binding#what-one-binding-call-does-at-deploy-time).
+
+```typescript
+// Inside the Stack's Effect.gen body.
+// providers: Layer.mergeAll(AWS.providers(), Kubernetes.providers())
+const table = yield* AWS.DynamoDB.Table("Entries", {
+  partitionKey: "pk",
+  attributes: { pk: "S" },
+});
+const uploads = yield* AWS.S3.Bucket("Uploads", {});
+
+const api = yield* Kubernetes.Deployment(
+  "Api",
+  { cluster, main: import.meta.url, port: 3000 },
+  Effect.gen(function* () {
+    // Each yield* records one policy statement on the host and returns
+    // a typed client. Nothing is created here — the adapter does that
+    // on deploy.
+    const putItem = yield* AWS.DynamoDB.PutItem(table); // dynamodb:PutItem on table.tableArn
+    const getObject = yield* AWS.S3.GetObject(uploads); // s3:GetObject on ${bucketArn}/* (+ s3:ListBucket)
+
+    return {
+      fetch: Effect.gen(function* () {
+        yield* putItem({ Item: { pk: { S: "hello" } } });
+        const object = yield* getObject({ Key: "banner.png" });
+        return HttpServerResponse.text(
+          `banner is ${object.ContentLength} bytes`,
+        );
+      }).pipe(Effect.orDie),
+    };
+  }).pipe(
+    Effect.provide(
+      Layer.mergeAll(AWS.DynamoDB.PutItemHttp, AWS.S3.GetObjectHttp),
+    ),
+  ),
+);
+```
+
+The impl form is under
+[Effect servers](/kubernetes/workloads/deployments#effect-servers).
+Each `yield*` fed two channels.
+
+**The policy channel.** The `*Http` layer calls
+``host.bind`Allow(${host}, AWS.DynamoDB.PutItem(${table}))`({ policyStatements: [...] })``,
+guarded by `!globalThis.__ALCHEMY_RUNTIME__`. On EKS the statements
+become the Pod Identity role's inline policy.
+
+**The env channel.** Bindings with `data.env` are collected. Every
+`Output` the init Effect captures, such as `yield* table.tableName`
+inside the DynamoDB client, registers an env var through the host's
+`RuntimeContext`. Non-string values are JSON-encoded and the key is
+Alchemy-generated, so read through the client, not by name.
+
+Both land in the container `env` list with your own `env` prop, which
+wins on a shared key. The full precedence is under
+[What gets created](/kubernetes/workloads/deployments#what-gets-created).
+
+| Binding line       | Pod spec                                   | IAM (EKS)                                                                       |
+| ------------------ | ------------------------------------------ | ------------------------------------------------------------------------------- |
+| `PutItem(table)`   | env var with the table name (Alchemy key)  | `dynamodb:PutItem` on the table ARN, inline policy                              |
+| `GetObject(uploads)` | env var with the bucket name (Alchemy key) | `s3:GetObject` + `s3:GetObjectVersion` on `arn:…:uploads/*`, `s3:ListBucket` on the bucket |
+
+:::caution[PORT is just an env var]
+Setting `PORT` in `env` overrides the injected one but does not move
+`containerPort` or the Service port. Change the `port` prop instead.
+:::
+
+At boot the same init Effect runs inside the container. The
+`__ALCHEMY_RUNTIME__` guard skips `host.bind`, so only the client is
+built. See
+[the `__ALCHEMY_RUNTIME__` guard](/infrastructure-as-effects/phases#the-__alchemy_runtime__-guard).
+
+## Pod Identity on EKS
+
+Every Deployment or Job on an `auth.kind: "aws-eks"` cluster gets
+workload identity, bindings or not. It is part of
+[what the EKS adapter adds](/kubernetes/clusters/eks#what-the-adapter-adds),
+and a [Job's `{ run }`](/kubernetes/workloads/jobs#effect-jobs) gets
+the same. The identity step runs on every deploy.
+
+The role is named from the logical id (`<id>-pod-role`, at most 64
+characters), trusts `pods.eks.amazonaws.com` for `sts:AssumeRole` and
+`sts:TagSession`, and carries Alchemy's internal tags. An existing
+role of that name is adopted only when it has those tags. Otherwise
+the deploy fails with "already exists and is not managed by alchemy".
+
+`identity.managedPolicyArns` are attached when the role is first
+created. That is how an external `image:` workload gets AWS access:
+it has no init Effect, and the SDK in the container uses the default
+credential chain.
+
+Active bindings' `policyStatements` become one inline policy,
+`<id>-pod-policy`, each `Sid` sanitized to alphanumerics. When none
+remain the policy is deleted, so removing a binding removes its grant
+on the next deploy.
+
+A [`PodIdentityAssociation`](/providers/aws/eks/podidentityassociation)
+keyed on the cluster, namespace, and the generated ServiceAccount
+binds the role to the workload. A changed role ARN is re-pointed in
+place. Changing `namespace` therefore replaces the workload.
+
+`AWS_REGION` is injected. EKS pods get none by default.
+
+Inside the container the bootstrap provides `Credentials.fromChain()`
+and `Region.fromEnv()`, so clients read the Pod Identity endpoint
+(`AWS_CONTAINER_CREDENTIALS_FULL_URI` plus the agent's token file).
+No static keys, no IRSA annotations, nothing in `podTemplate`.
+`Credentials | Region | AWSEnvironment` are ambient workload services,
+which is why the example above type-checks.
+
+`attrs.identity` is
+`{ kind: "aws-pod-identity", roleArn, roleName, associationArn, associationId }`
+on EKS and `undefined` elsewhere. It is stable, so `roleArn` is safe
+in a bucket policy or a KMS key policy.
+
+```typescript
+// External image, no init Effect — grant through managed policies.
+const worker = yield* Kubernetes.Deployment("Worker", {
+  cluster,
+  image: "ghcr.io/acme/worker:1.4",
+  port: 8080,
+  serviceType: "ClusterIP",
+  identity: {
+    managedPolicyArns: ["arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"],
+  },
+});
+
+worker.identity; // { kind: "aws-pod-identity", roleArn, roleName, associationArn, associationId }
+worker.serviceAccountName; // the ServiceAccount the association is bound to
+```
+
+On delete the association goes first (skipped when the cluster is
+gone or deleting), then inline policies, managed-policy detachments,
+and the role.
+
+:::note[Not separate plan rows]
+The role and association are reconciled inside the workload row.
+`alchemy plan` shows one row per workload, noted
+`Applied Kubernetes Deployment <namespace>/<name>`. Cluster
+provisioning lives on the [AWS EKS page](/aws/compute/eks).
+:::
+
+:::caution[managedPolicyArns is applied on first create only]
+Adding or removing an ARN once the role exists is silently ignored.
+Only the inline policy from bindings re-syncs every deploy. Replace
+the workload (change `namespace`) or grant through a binding instead.
+:::
+
+## Env-only bindings
+
+A kubeconfig, token, client-cert, or exec cluster has no managed
+registry, so
+[no `main`](/kubernetes/workloads/image-sources#registry-requirement),
+no init Effect, and nothing to bind. There is no identity step
+either. Point a binding-bearing impl at one and reconcile dies before
+touching the cluster:
+
+> `'Api': bindings carry cloud credential grants (policyStatements)
+> but this cluster's platform has no workload-identity adapter.
+> Target a managed cluster (e.g. AWS.EKS.Cluster) or bind through
+> environment variables instead.`
+
+"Bind through environment variables" means the `env` prop on an
+`image:` workload, fed from other resources' outputs.
+
+**Wire other objects' outputs.** Manifest attributes such as `name`
+and `namespace` are Outputs. Interpolate them into `env`. Numbers and
+objects are JSON-stringified. The StatefulSet and Service are plain
+[Manifests](/kubernetes/objects/manifests#any-object), and the image
+reached the cluster as
+[Using your own images](/kubernetes/clusters/local#using-your-own-images)
+describes.
+
+```typescript
+import * as Output from "alchemy/Output";
+
+const redis = yield* Kubernetes.Manifest("Redis", {
+  cluster,
+  manifest: {
+    apiVersion: "apps/v1",
+    kind: "StatefulSet",
+    metadata: { name: "redis", namespace: "default" },
+    spec: {
+      serviceName: "redis",
+      selector: { matchLabels: { app: "redis" } },
+      template: {
+        metadata: { labels: { app: "redis" } },
+        spec: { containers: [{ name: "redis", image: "redis:7-alpine" }] },
+      },
+    },
+  },
+});
+const redisSvc = yield* Kubernetes.Manifest("RedisService", {
+  cluster,
+  manifest: {
+    apiVersion: "v1",
+    kind: "Service",
+    metadata: { name: "redis", namespace: "default" },
+    spec: { selector: { app: "redis" }, ports: [{ port: 6379 }] },
+  },
+});
+
+const api = yield* Kubernetes.Deployment("Api", {
+  cluster,
+  image: "ghcr.io/acme/api:v3", // the only image source on a registry-less cluster
+  port: 8080,
+  env: {
+    REDIS_HOST: Output.interpolate`${redisSvc.name}.${redisSvc.namespace}.svc.cluster.local`,
+    REDIS_PORT: 6379, // lands as the string "6379"
+    LOG_LEVEL: "info",
+  },
+});
+```
+
+**Secrets.** Never put secrets in `env`. It is plain text on the
+Deployment object. Create a `Secret` Manifest as
+[Secrets](/kubernetes/objects/manifests#secrets) describes and
+reference it with `valueFrom.secretKeyRef`. The `env` prop writes
+literals only, so `valueFrom` needs the
+[container-level override](/kubernetes/workloads/pod-template#container-level-fields).
+[Arrays replace](/kubernetes/workloads/pod-template#merge-rules), so
+the whole container is restated, which is only possible on an
+`image:` source.
+
+```typescript
+import * as Config from "effect/Config";
+
+const dbSecret = yield* Kubernetes.Manifest("DbSecret", {
+  cluster,
+  manifest: {
+    apiVersion: "v1",
+    kind: "Secret",
+    metadata: { name: "db-credentials", namespace: "default" },
+    // Resolved at plan time from the deploying shell's environment —
+    // never a literal in alchemy.run.ts.
+    stringData: { password: Config.string("DB_PASSWORD") },
+  },
+});
+
+const api = yield* Kubernetes.Deployment("Api", {
+  cluster,
+  image: "ghcr.io/acme/api:v3",
+  port: 8080,
+  env: { DB_HOST: "postgres.default.svc.cluster.local" },
+  podTemplate: {
+    spec: {
+      // Arrays REPLACE: restate the whole synthesized container.
+      containers: [
+        {
+          name: "api",
+          image: "ghcr.io/acme/api:v3",
+          ports: [{ containerPort: 8080 }],
+          env: [
+            { name: "PORT", value: "8080" },
+            { name: "DB_HOST", value: "postgres.default.svc.cluster.local" },
+            {
+              name: "DB_PASSWORD",
+              valueFrom: {
+                secretKeyRef: { name: dbSecret.name, key: "password" },
+              },
+            },
+          ],
+        },
+      ],
+    },
+  },
+});
+```
+
+**Consume from any language.** The names are the keys you wrote and
+the values are strings: `process.env.REDIS_HOST`,
+`os.environ["REDIS_HOST"]`, `std::env::var("REDIS_HOST")`. Parse
+JSON-encoded ones yourself. `ALCHEMY_STACK_NAME`, `ALCHEMY_STAGE`, and
+`ALCHEMY_PHASE` are present but ignorable.
+
+:::tip[ConfigMaps]
+Same pattern with `configMapKeyRef`, or pass the values straight into
+`env`. Tutorial part 3 does this.
+:::
+
+## Runtime-only methods and RuntimeContext
+
+A binding's client runs only inside the pod. Its methods require
+`Alchemy.RuntimeContext`, which the bootstrap provides to `{ fetch }`
+and `{ run }` and the init Effect lacks. `yield* putItem(...)` in the
+init body is a type error. Inside `fetch` it compiles. Same rule as
+Lambda and Workers:
+[The types hold the boundary](/infrastructure-as-effects/layers#the-types-hold-the-boundary)
+and [Init vs runtime](/infrastructure-as-effects/phases#init-vs-runtime).
+
+```typescript
+Effect.gen(function* () {
+  const putItem = yield* AWS.DynamoDB.PutItem(table);
+  // yield* putItem({ ... })   ✗ RuntimeContext is not available at init
+  return {
+    fetch: Effect.gen(function* () {
+      yield* putItem({ Item: { pk: { S: "1" } } }); // ✓
+      return HttpServerResponse.text("ok");
+    }),
+  };
+});
+```
+
+## Where next
+
+- [Pod template](/kubernetes/workloads/pod-template) — merge rules
+  and recipes for the synthesized pod template.
+- [Secrets](/kubernetes/objects/manifests#secrets) — Secrets and
+  ConfigMaps as Manifests.
+- [What the adapter adds](/kubernetes/clusters/eks#what-the-adapter-adds)
+  — everything EKS adds beyond identity.
+- [Bindings](/infrastructure-as-effects/binding) — the binding model
+  across every Alchemy host.

--- a/website/src/content/docs/kubernetes/workloads/deployments.mdx
+++ b/website/src/content/docs/kubernetes/workloads/deployments.mdx
@@ -1,13 +1,12 @@
 ---
 title: Deployments
-description: Run a replicated server on any cluster with Kubernetes.Deployment — what objects it creates, every prop by group, how serviceType and url work, Effect servers with fetch, the tagged form, and what updates in place versus replaces.
+description: Run a replicated server on any cluster with Kubernetes.Deployment — what it creates, serviceType and url, Effect servers with fetch, the tagged form, and what replaces.
 ---
 
 A [`Kubernetes.Deployment`](/providers/kubernetes/deployment) is a
-replicated server on any cluster, the Kubernetes analog of
-`AWS.ECS.Service`. Give it a cluster, an image source, and a port.
-It applies a `Deployment`, a `Service`, and a `ServiceAccount`, and
-hands back the Service's address.
+replicated server on any cluster. Give it a cluster, an image source,
+and a port; it applies a `Deployment`, a `Service`, and a
+`ServiceAccount`.
 
 ```typescript
 import * as Kubernetes from "alchemy/Kubernetes";
@@ -26,46 +25,15 @@ web.url;            // LoadBalancer address once assigned (string | undefined)
 web.deploymentName; // the Kubernetes object names are attributes too
 ```
 
-[`KubeConfig()`](/kubernetes/clusters/connecting#kubeconfig) returns
-a connection. `image` is
+`image` is
 [one of three image sources](/kubernetes/workloads/image-sources#three-sources).
 
 ## What gets created
 
-Three objects share one base name and one label set. The base name
-is `name` if set, otherwise the engine's physical name,
-`<stack>-<id>-<stage>-<16-character hash>`, lowercased with anything
-outside `[a-z0-9-]` replaced by `-`. The default stage `dev_<username>`
-becomes `dev-<username>`. `deploymentName`, `serviceName`, and
-`serviceAccountName` expose it. Don't hard-code that they are equal.
-
-Labels are `app.kubernetes.io/name: <baseName>` with your `labels`
-merged over it. The same map is the Deployment selector, the pod
-labels, and the Service selector.
-
-The container env is built in five layers. Later wins.
-
-1. binding env from each `Binding.Service`,
-2. adapter env (EKS injects `AWS_REGION`),
-3. `ALCHEMY_STACK_NAME`, `ALCHEMY_STAGE`, `ALCHEMY_PHASE=runtime`,
-4. `PORT`,
-5. your `env`.
-
-Non-string values are JSON-stringified. A `Kubernetes.Job` builds the
-same list minus `PORT`.
-
-Objects are applied ServiceAccount, then Service, then Deployment,
-each with
-[server-side apply](/kubernetes/guides/how-apply-works#server-side-apply)
-under the `alchemy` field manager.
-
-| Object           | Name       | Carries                                                              |
-| ---------------- | ---------- | -------------------------------------------------------------------- |
-| `ServiceAccount` | base name  | identity annotations from the cluster adapter, when it has identity   |
-| `Service`        | base name  | `type`, `ports` (`port` → `targetPort: port`), `selector`, annotations |
-| `Deployment`     | base name  | `replicas`, `selector`, the pod template (container, env, resources)  |
-
-The intro Deployment applies this:
+Three objects share one base name (`name`, or the engine's physical
+name lowercased) and one label set, `app.kubernetes.io/name` plus
+your `labels`. Container env, later wins: binding env, adapter env,
+`ALCHEMY_*`, `PORT`, your `env`.
 
 ```yaml
 # What `Kubernetes.Deployment("Web", { image: "nginx:1.27", port: 80, replicas: 2 })` applies
@@ -102,45 +70,19 @@ spec:
             - { name: PORT, value: "80" }
 ```
 
-On EKS the adapter provisions cloud resources beside these, recorded
-in `identity` and `registry`. See
+On EKS the adapter also provisions cloud resources, recorded in
+`identity` and `registry`. See
 [What the adapter adds](/kubernetes/clusters/eks#what-the-adapter-adds).
-
-Attributes: `connection`, `namespace`, `deploymentName`,
-`serviceName`, `serviceAccountName`, `port`, `imageUri`, `identity`,
-`registry`, `url`, `kubernetesObjects`, `code.hash`. The
-[`connection`](/kubernetes/clusters/connecting#the-connection-model)
-is persisted so `alchemy destroy` can reconnect.
 
 ## Props by group
 
 The [reference](/providers/kubernetes/deployment) lists every prop.
-This groups them by the question they answer.
-
-**Sizing.** `replicas` (default `1`) and `resources`, with `requests`
-and `limits` as `cpu` / `memory` strings. On EKS Auto Mode the
-requests drive node provisioning.
-
-**The container.** `command` overrides the entrypoint. `args` are the
-arguments. `env` wins over everything generated. `port` (default
-`3000`) is both the `containerPort` and the Service port.
-
-**Placement.** `namespace` (default `"default"`) must already exist.
-Declare it as a
-[Namespace manifest](/kubernetes/objects/manifests#namespaces) and
-pass its `name` attribute. `labels` merge over the name label and
-double as the Service selector. `podTemplate` is the deep-partial
-escape hatch. Objects merge, arrays and primitives replace. See the
-[merge rules](/kubernetes/workloads/pod-template#merge-rules).
-
-**Cloud.** `architecture` (`"amd64"` default, or `"arm64"`) is the
-platform the image is
-[built or mirrored for](/kubernetes/workloads/image-sources#architecture).
-`identity` holds adapter-specific workload-identity options. See
-[Pod Identity on EKS](/kubernetes/workloads/bindings#pod-identity-on-eks).
-`tags` go on adapter-owned cloud resources only. `name` overrides the
-base name. See [Updates and replacement](#updates-and-replacement)
-before changing it later.
+Sizing: `replicas`, `resources`. Container: `command`, `args`, `env`,
+`port` (default `3000`). Placement: `namespace` (must already exist —
+pass a [Namespace manifest](/kubernetes/objects/manifests#namespaces)'s
+`name`), `labels`,
+[`podTemplate`](/kubernetes/workloads/pod-template#merge-rules).
+Cloud: `architecture`, `identity`, `tags`, `name`.
 
 ```typescript
 const ns = yield* Kubernetes.Manifest("AppNamespace", {
@@ -168,33 +110,13 @@ const api = yield* Kubernetes.Deployment("Api", {
 });
 ```
 
-:::caution
-`namespace` must exist before the Deployment is applied. Pass
-`ns.name` from a `Kubernetes.Manifest`, not a bare string, so the
-dependency is in the graph.
-:::
-
 ## Exposing it: serviceType and url
 
-There is always a Service. `serviceType` picks its type. The default
-is `"LoadBalancer"`, not `kubectl`'s `ClusterIP`, which is why `url`
-works out of the box. With `"ClusterIP"` or `"NodePort"`, `url` is
-`undefined`.
-
-The load balancer listens on `port`, so `url` is `http://<hostname>`
-when `port` is 80 and `http://<hostname>:<port>` otherwise. An IP is
-used when the load balancer publishes one instead of a hostname.
-
-The provider polls `status.loadBalancer.ingress` every 5 seconds, up
-to 36 times. If there is still no address, the deploy succeeds and
-`url` is `undefined`. The next `alchemy deploy` fills it in.
-
-`serviceAnnotations` land on the Service. The adapter may add defaults
-underneath, on EKS per
-[What the adapter adds](/kubernetes/clusters/eks#what-the-adapter-adds),
-and yours win. Where the address resolves locally depends on the
-cluster. See
-[Reaching a service](/kubernetes/clusters/local#reaching-a-service).
+`serviceType` defaults to `"LoadBalancer"`, so `url` works out of the
+box; with `"ClusterIP"` or `"NodePort"` it is `undefined`. The
+provider waits about 3 minutes for an address; if none arrives, `url`
+stays `undefined` until the next deploy. Adapter defaults for
+`serviceAnnotations` go underneath yours.
 
 ```typescript
 const api = yield* Kubernetes.Deployment("Api", {
@@ -224,29 +146,15 @@ const worker = yield* Kubernetes.Deployment("Internal", {
 // Reach it from other pods as http://<serviceName>.<namespace>.svc:<port>
 ```
 
-:::note
-`url` is `string | undefined`. It is `undefined` for `ClusterIP` and
-`NodePort`, and may be `undefined` right after the first deploy of a
-`LoadBalancer` Service.
-:::
-
-NodePort, per-cloud annotations, and
-[Ingress](/kubernetes/guides/exposing-services#ingress) in front of a
-`ClusterIP` Service are covered in
+Ingress and per-cloud annotations:
 [Service types](/kubernetes/guides/exposing-services#service-types).
 
 ## Effect servers
 
-Write the server in Effect instead of shipping an image.
-`main: import.meta.url` is the bundle entrypoint. The third argument
-is the init Effect and returns `{ fetch }`. Alchemy bundles with
-rolldown, generates a Dockerfile (`FROM oven/bun:1` by default),
-builds and pushes the image, and serves `fetch` with a Bun HTTP server
-on `PORT`.
-
-`fetch` reads `HttpServerRequest` and returns an `HttpServerResponse`,
-both from `effect/unstable/http`. Its error channel must be `never`.
-Init runs once per pod. `fetch` runs per request.
+Pass `main: import.meta.url` and an init Effect that returns
+`{ fetch }`. Alchemy bundles it, builds and pushes an image, and
+serves `fetch` on `PORT`. Init runs once per pod; `fetch` runs per
+request and its error channel must be `never`.
 
 ```typescript
 import * as AWS from "alchemy/AWS";
@@ -279,7 +187,7 @@ const api = yield* Kubernetes.Deployment(
 ```
 
 The same call can be a module's `export default`, with `props` as an
-Effect that `yield*`s resources from a shared `infra.ts`.
+Effect.
 
 ```typescript
 // src/api.ts — the same call as a module default export.
@@ -300,29 +208,19 @@ export default Kubernetes.Deployment(
 const api = yield* Api;
 ```
 
-Every AWS `Binding.Service` works inside init as on Lambda. See
+Bindings resolve in init — see
 [The binding contract](/kubernetes/workloads/bindings#the-binding-contract).
-`handler` names the export to load (default `"default"`). `image`,
-`dockerfile`, and `context` become `main`'s environment modifiers
-under [Three sources](/kubernetes/workloads/image-sources#three-sources).
-`build` is under
-[Bundling and tree-shaking](/kubernetes/workloads/image-sources#bundling-and-tree-shaking).
 
 :::caution[`main` needs a managed registry]
-Today only the EKS adapter has one. On a kubeconfig cluster use
-`image:` with an
-[image you built yourself](/kubernetes/clusters/local#using-your-own-images).
-See [Registry requirement](/kubernetes/workloads/image-sources#registry-requirement).
+Today only the EKS adapter has one; on a kubeconfig cluster use
+`image:` (see [Registry requirement](/kubernetes/workloads/image-sources#registry-requirement)).
 :::
 
 ## The tagged form
 
-The tagged form gives the Stack a class you `yield*` by name, with
-typed members. `examples/aws-eks/src/Api.ts` uses it.
 `class Api extends Kubernetes.Deployment<Api, Shape>()("Api") {}`
-declares the identity. `Api.make(props, impl)` returns a Layer. The
-Stack provides the Layer and `yield*`s the class. `Shape` is optional.
-Members returned beyond `fetch` become part of the typed handle.
+declares the identity, `Api.make(props, impl)` returns a Layer, and
+the Stack provides the Layer and `yield*`s the class.
 
 ```typescript
 // src/api.ts
@@ -365,60 +263,18 @@ export default Alchemy.Stack(
 );
 ```
 
-The `providers` layer is the one from
-[Add the provider](/kubernetes/setup#add-the-provider). The same form
-works for a `Kubernetes.Job`. See
-[Effect jobs](/kubernetes/workloads/jobs#effect-jobs).
+The same form works for a
+[`Kubernetes.Job`](/kubernetes/workloads/jobs#effect-jobs).
 
 ## Updates and replacement
 
-Replacement happens in two cases: `cluster` changes identity, or
-`namespace` changes. Identity is the connection's `auth` descriptor
-per
-[The connection model](/kubernetes/clusters/connecting#the-connection-model).
-Rotating the endpoint or CA of the same cluster is not a replacement.
-Workload identity keys on cluster, namespace, and service account,
-which is why both force one.
-
-Everything else is an in-place update via server-side apply.
-Kubernetes rolls pods when the pod template changed. A Service-only
-change does not. Drift is covered in
-[Pruning and drift](/kubernetes/guides/how-apply-works#pruning-and-drift)
-and outside edits in
-[Conflicts](/kubernetes/guides/how-apply-works#conflicts).
-
-The plan re-hashes `main` bundles, `context` directories, and `image`
-references. A changed hash shows as an `update` against `code.hash`
-with no prop change. Edit the code and deploy.
-
-| Change                                             | Effect                                  |
-| -------------------------------------------------- | --------------------------------------- |
-| `cluster` identity, `namespace`                    | replace                                 |
-| `image`, `env`, `resources`, `command` / `args`, `port`, `podTemplate`, code edit under `main` / `context` | rolling update of pods |
-| `replicas`                                         | in-place scale, existing pods untouched |
-| `serviceType`, `serviceAnnotations`                | Service update, no pod restart          |
-
-:::note[`name` is sticky]
-Changing `name` on an existing Deployment does not rename its
-objects. The provider keeps the original `deploymentName`. A
-`Kubernetes.Job` does the opposite. See
-[Jobs → Updates and replacement](/kubernetes/workloads/jobs#updates-and-replacement).
-:::
-
-:::caution[Selector immutability]
-`labels` feed `spec.selector.matchLabels`, which is immutable on
-`apps/v1` Deployments, so changing `labels` on a live Deployment may
-be rejected. For pod-only labels set `podTemplate.metadata.labels`
-instead.
-:::
+Only a `cluster` identity change or a `namespace` change replaces;
+everything else is an in-place apply that rolls pods when the pod
+template changed. `name` is sticky and `labels` feed the immutable
+selector, so put pod-only labels in `podTemplate.metadata.labels`.
 
 ## Where next
 
-- [Jobs](/kubernetes/workloads/jobs) — run-to-completion and
-  scheduled work with `Kubernetes.Job`.
-- [Image sources](/kubernetes/workloads/image-sources) — `main` vs
-  `context` vs `image`, and why `main` needs a registry.
-- [Exposing services](/kubernetes/guides/exposing-services) —
-  Ingress, TLS, and per-cloud load-balancer annotations.
-- [`Deployment` reference](/providers/kubernetes/deployment) — every
-  prop and attribute.
+- [Jobs](/kubernetes/workloads/jobs)
+- [Image sources](/kubernetes/workloads/image-sources)
+- [`Deployment` reference](/providers/kubernetes/deployment)

--- a/website/src/content/docs/kubernetes/workloads/deployments.mdx
+++ b/website/src/content/docs/kubernetes/workloads/deployments.mdx
@@ -1,0 +1,424 @@
+---
+title: Deployments
+description: Run a replicated server on any cluster with Kubernetes.Deployment — what objects it creates, every prop by group, how serviceType and url work, Effect servers with fetch, the tagged form, and what updates in place versus replaces.
+---
+
+A [`Kubernetes.Deployment`](/providers/kubernetes/deployment) is a
+replicated server on any cluster, the Kubernetes analog of
+`AWS.ECS.Service`. Give it a cluster, an image source, and a port.
+It applies a `Deployment`, a `Service`, and a `ServiceAccount`, and
+hands back the Service's address.
+
+```typescript
+import * as Kubernetes from "alchemy/Kubernetes";
+
+// inside the Stack's Effect.gen body
+const local = Kubernetes.KubeConfig({ context: "docker-desktop" });
+
+const web = yield* Kubernetes.Deployment("Web", {
+  cluster: local,
+  image: "nginx:1.27", // pre-built image; used verbatim on a kubeconfig cluster
+  port: 80,
+  replicas: 2,
+});
+
+web.url;            // LoadBalancer address once assigned (string | undefined)
+web.deploymentName; // the Kubernetes object names are attributes too
+```
+
+[`KubeConfig()`](/kubernetes/clusters/connecting#kubeconfig) returns
+a connection. `image` is
+[one of three image sources](/kubernetes/workloads/image-sources#three-sources).
+
+## What gets created
+
+Three objects share one base name and one label set. The base name
+is `name` if set, otherwise the engine's physical name,
+`<stack>-<id>-<stage>-<16-character hash>`, lowercased with anything
+outside `[a-z0-9-]` replaced by `-`. The default stage `dev_<username>`
+becomes `dev-<username>`. `deploymentName`, `serviceName`, and
+`serviceAccountName` expose it. Don't hard-code that they are equal.
+
+Labels are `app.kubernetes.io/name: <baseName>` with your `labels`
+merged over it. The same map is the Deployment selector, the pod
+labels, and the Service selector.
+
+The container env is built in five layers. Later wins.
+
+1. binding env from each `Binding.Service`,
+2. adapter env (EKS injects `AWS_REGION`),
+3. `ALCHEMY_STACK_NAME`, `ALCHEMY_STAGE`, `ALCHEMY_PHASE=runtime`,
+4. `PORT`,
+5. your `env`.
+
+Non-string values are JSON-stringified. A `Kubernetes.Job` builds the
+same list minus `PORT`.
+
+Objects are applied ServiceAccount, then Service, then Deployment,
+each with
+[server-side apply](/kubernetes/guides/how-apply-works#server-side-apply)
+under the `alchemy` field manager.
+
+| Object           | Name       | Carries                                                              |
+| ---------------- | ---------- | -------------------------------------------------------------------- |
+| `ServiceAccount` | base name  | identity annotations from the cluster adapter, when it has identity   |
+| `Service`        | base name  | `type`, `ports` (`port` → `targetPort: port`), `selector`, annotations |
+| `Deployment`     | base name  | `replicas`, `selector`, the pod template (container, env, resources)  |
+
+The intro Deployment applies this:
+
+```yaml
+# What `Kubernetes.Deployment("Web", { image: "nginx:1.27", port: 80, replicas: 2 })` applies
+apiVersion: v1
+kind: ServiceAccount
+metadata: { name: myapp-web-dev-alex-a1b2c3d4e5f6g7h8, namespace: default, labels: { app.kubernetes.io/name: myapp-web-dev-alex-a1b2c3d4e5f6g7h8 } }
+---
+apiVersion: v1
+kind: Service
+metadata: { name: myapp-web-dev-alex-…, namespace: default, labels: { app.kubernetes.io/name: myapp-web-dev-alex-… } }
+spec:
+  type: LoadBalancer
+  selector: { app.kubernetes.io/name: myapp-web-dev-alex-… }
+  ports: [{ port: 80, targetPort: 80, protocol: TCP }]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: { name: myapp-web-dev-alex-…, namespace: default, labels: { app.kubernetes.io/name: myapp-web-dev-alex-… } }
+spec:
+  replicas: 2
+  selector: { matchLabels: { app.kubernetes.io/name: myapp-web-dev-alex-… } }
+  template:
+    metadata: { labels: { app.kubernetes.io/name: myapp-web-dev-alex-… } }
+    spec:
+      serviceAccountName: myapp-web-dev-alex-…
+      containers:
+        - name: myapp-web-dev-alex-…
+          image: nginx:1.27
+          ports: [{ containerPort: 80 }]
+          env:
+            - { name: ALCHEMY_STACK_NAME, value: MyApp }
+            - { name: ALCHEMY_STAGE, value: dev_alex }
+            - { name: ALCHEMY_PHASE, value: runtime }
+            - { name: PORT, value: "80" }
+```
+
+On EKS the adapter provisions cloud resources beside these, recorded
+in `identity` and `registry`. See
+[What the adapter adds](/kubernetes/clusters/eks#what-the-adapter-adds).
+
+Attributes: `connection`, `namespace`, `deploymentName`,
+`serviceName`, `serviceAccountName`, `port`, `imageUri`, `identity`,
+`registry`, `url`, `kubernetesObjects`, `code.hash`. The
+[`connection`](/kubernetes/clusters/connecting#the-connection-model)
+is persisted so `alchemy destroy` can reconnect.
+
+## Props by group
+
+The [reference](/providers/kubernetes/deployment) lists every prop.
+This groups them by the question they answer.
+
+**Sizing.** `replicas` (default `1`) and `resources`, with `requests`
+and `limits` as `cpu` / `memory` strings. On EKS Auto Mode the
+requests drive node provisioning.
+
+**The container.** `command` overrides the entrypoint. `args` are the
+arguments. `env` wins over everything generated. `port` (default
+`3000`) is both the `containerPort` and the Service port.
+
+**Placement.** `namespace` (default `"default"`) must already exist.
+Declare it as a
+[Namespace manifest](/kubernetes/objects/manifests#namespaces) and
+pass its `name` attribute. `labels` merge over the name label and
+double as the Service selector. `podTemplate` is the deep-partial
+escape hatch. Objects merge, arrays and primitives replace. See the
+[merge rules](/kubernetes/workloads/pod-template#merge-rules).
+
+**Cloud.** `architecture` (`"amd64"` default, or `"arm64"`) is the
+platform the image is
+[built or mirrored for](/kubernetes/workloads/image-sources#architecture).
+`identity` holds adapter-specific workload-identity options. See
+[Pod Identity on EKS](/kubernetes/workloads/bindings#pod-identity-on-eks).
+`tags` go on adapter-owned cloud resources only. `name` overrides the
+base name. See [Updates and replacement](#updates-and-replacement)
+before changing it later.
+
+```typescript
+const ns = yield* Kubernetes.Manifest("AppNamespace", {
+  cluster,
+  manifest: { apiVersion: "v1", kind: "Namespace", metadata: { name: "app" } },
+});
+
+const api = yield* Kubernetes.Deployment("Api", {
+  cluster,
+  image: "ghcr.io/acme/api:v3",
+  // sizing
+  replicas: 3,
+  resources: {
+    requests: { cpu: "100m", memory: "128Mi" },
+    limits: { cpu: "500m", memory: "256Mi" },
+  },
+  // the container
+  port: 8080,
+  args: ["--log-level", "info"],
+  env: { LOG_FORMAT: "json" },
+  // placement — the namespace must exist; referencing the Manifest's
+  // attribute (not the string "app") orders the deploy after it
+  namespace: ns.name,
+  labels: { "app.kubernetes.io/part-of": "acme" },
+});
+```
+
+:::caution
+`namespace` must exist before the Deployment is applied. Pass
+`ns.name` from a `Kubernetes.Manifest`, not a bare string, so the
+dependency is in the graph.
+:::
+
+## Exposing it: serviceType and url
+
+There is always a Service. `serviceType` picks its type. The default
+is `"LoadBalancer"`, not `kubectl`'s `ClusterIP`, which is why `url`
+works out of the box. With `"ClusterIP"` or `"NodePort"`, `url` is
+`undefined`.
+
+The load balancer listens on `port`, so `url` is `http://<hostname>`
+when `port` is 80 and `http://<hostname>:<port>` otherwise. An IP is
+used when the load balancer publishes one instead of a hostname.
+
+The provider polls `status.loadBalancer.ingress` every 5 seconds, up
+to 36 times. If there is still no address, the deploy succeeds and
+`url` is `undefined`. The next `alchemy deploy` fills it in.
+
+`serviceAnnotations` land on the Service. The adapter may add defaults
+underneath, on EKS per
+[What the adapter adds](/kubernetes/clusters/eks#what-the-adapter-adds),
+and yours win. Where the address resolves locally depends on the
+cluster. See
+[Reaching a service](/kubernetes/clusters/local#reaching-a-service).
+
+```typescript
+const api = yield* Kubernetes.Deployment("Api", {
+  cluster,
+  image: "ghcr.io/acme/api:v3",
+  port: 8080,
+  // default — provisions the cluster's cloud load balancer
+  serviceType: "LoadBalancer",
+  // annotations land on the Service; adapter defaults (EKS: internet-facing
+  // NLB) are applied underneath and yours win
+  serviceAnnotations: {
+    "service.beta.kubernetes.io/aws-load-balancer-scheme": "internal",
+  },
+});
+
+// http://<lb-hostname>:8080 — the Service port is the listener, so it's in the URL.
+// `undefined` if the load balancer hadn't published an address within ~3 minutes;
+// the next deploy fills it in.
+return { url: api.url };
+
+// In-cluster only: no load balancer, `url` is always undefined.
+const worker = yield* Kubernetes.Deployment("Internal", {
+  cluster,
+  image: "ghcr.io/acme/worker:v3",
+  serviceType: "ClusterIP",
+});
+// Reach it from other pods as http://<serviceName>.<namespace>.svc:<port>
+```
+
+:::note
+`url` is `string | undefined`. It is `undefined` for `ClusterIP` and
+`NodePort`, and may be `undefined` right after the first deploy of a
+`LoadBalancer` Service.
+:::
+
+NodePort, per-cloud annotations, and
+[Ingress](/kubernetes/guides/exposing-services#ingress) in front of a
+`ClusterIP` Service are covered in
+[Service types](/kubernetes/guides/exposing-services#service-types).
+
+## Effect servers
+
+Write the server in Effect instead of shipping an image.
+`main: import.meta.url` is the bundle entrypoint. The third argument
+is the init Effect and returns `{ fetch }`. Alchemy bundles with
+rolldown, generates a Dockerfile (`FROM oven/bun:1` by default),
+builds and pushes the image, and serves `fetch` with a Bun HTTP server
+on `PORT`.
+
+`fetch` reads `HttpServerRequest` and returns an `HttpServerResponse`,
+both from `effect/unstable/http`. Its error channel must be `never`.
+Init runs once per pod. `fetch` runs per request.
+
+```typescript
+import * as AWS from "alchemy/AWS";
+import * as Kubernetes from "alchemy/Kubernetes";
+import * as Effect from "effect/Effect";
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+// inside the Stack body (EKS — `main` needs the adapter's managed registry)
+const api = yield* Kubernetes.Deployment(
+  "Api",
+  { cluster, main: import.meta.url, port: 3000, replicas: 2 },
+  // init: runs once per pod at startup — resolve bindings, build clients
+  Effect.gen(function* () {
+    const getItem = yield* AWS.DynamoDB.GetItem(table);
+    return {
+      // fetch: runs per request, served by a Bun HTTP server on PORT
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        const url = new URL(request.url, "http://api");
+        if (url.pathname === "/health") {
+          return HttpServerResponse.text("ok");
+        }
+        const item = yield* getItem({ Key: { pk: { S: url.pathname } } });
+        return yield* HttpServerResponse.json(item.Item ?? null);
+      }).pipe(Effect.orDie), // the handler's error channel must be `never`
+    };
+  }).pipe(Effect.provide(AWS.DynamoDB.GetItemHttp)),
+);
+```
+
+The same call can be a module's `export default`, with `props` as an
+Effect that `yield*`s resources from a shared `infra.ts`.
+
+```typescript
+// src/api.ts — the same call as a module default export.
+// `props` is an Effect so it can reference resources declared in other modules.
+export default Kubernetes.Deployment(
+  "Api",
+  Effect.gen(function* () {
+    const cluster = yield* Cluster;          // from ./infra.ts
+    const ns = yield* AppNamespace;
+    return { cluster, main: import.meta.url, namespace: ns.name, port: 3000 };
+  }),
+  Effect.gen(function* () {
+    return { fetch: Effect.succeed(HttpServerResponse.text("ok")) };
+  }),
+);
+
+// alchemy.run.ts — `import Api from "./src/api.ts"` then, in the Stack body:
+const api = yield* Api;
+```
+
+Every AWS `Binding.Service` works inside init as on Lambda. See
+[The binding contract](/kubernetes/workloads/bindings#the-binding-contract).
+`handler` names the export to load (default `"default"`). `image`,
+`dockerfile`, and `context` become `main`'s environment modifiers
+under [Three sources](/kubernetes/workloads/image-sources#three-sources).
+`build` is under
+[Bundling and tree-shaking](/kubernetes/workloads/image-sources#bundling-and-tree-shaking).
+
+:::caution[`main` needs a managed registry]
+Today only the EKS adapter has one. On a kubeconfig cluster use
+`image:` with an
+[image you built yourself](/kubernetes/clusters/local#using-your-own-images).
+See [Registry requirement](/kubernetes/workloads/image-sources#registry-requirement).
+:::
+
+## The tagged form
+
+The tagged form gives the Stack a class you `yield*` by name, with
+typed members. `examples/aws-eks/src/Api.ts` uses it.
+`class Api extends Kubernetes.Deployment<Api, Shape>()("Api") {}`
+declares the identity. `Api.make(props, impl)` returns a Layer. The
+Stack provides the Layer and `yield*`s the class. `Shape` is optional.
+Members returned beyond `fetch` become part of the typed handle.
+
+```typescript
+// src/api.ts
+import * as Kubernetes from "alchemy/Kubernetes";
+import * as Effect from "effect/Effect";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import { Cluster, AppNamespace } from "./infra.ts";
+
+export class Api extends Kubernetes.Deployment<Api, {
+  health: () => Effect.Effect<string>;
+}>()("Api") {}
+
+export default Api.make(
+  // props can be an Effect so they can reference resources from other modules
+  Effect.gen(function* () {
+    const cluster = yield* Cluster;
+    const ns = yield* AppNamespace;
+    return { cluster, main: import.meta.url, namespace: ns.name, port: 3000 };
+  }),
+  Effect.gen(function* () {
+    return {
+      fetch: Effect.succeed(HttpServerResponse.text("ok")),
+      health: () => Effect.succeed("ok"),
+    };
+  }),
+);
+```
+
+```typescript
+// alchemy.run.ts — provide the Layer, yield the class
+import ApiLive, { Api } from "./src/api.ts";
+
+export default Alchemy.Stack(
+  "MyApp",
+  { providers: Layer.mergeAll(AWS.providers(), Kubernetes.providers()), state: Alchemy.localState() },
+  Effect.gen(function* () {
+    const api = yield* Api;
+    return { url: api.url };
+  }).pipe(Effect.provide(ApiLive)),
+);
+```
+
+The `providers` layer is the one from
+[Add the provider](/kubernetes/setup#add-the-provider). The same form
+works for a `Kubernetes.Job`. See
+[Effect jobs](/kubernetes/workloads/jobs#effect-jobs).
+
+## Updates and replacement
+
+Replacement happens in two cases: `cluster` changes identity, or
+`namespace` changes. Identity is the connection's `auth` descriptor
+per
+[The connection model](/kubernetes/clusters/connecting#the-connection-model).
+Rotating the endpoint or CA of the same cluster is not a replacement.
+Workload identity keys on cluster, namespace, and service account,
+which is why both force one.
+
+Everything else is an in-place update via server-side apply.
+Kubernetes rolls pods when the pod template changed. A Service-only
+change does not. Drift is covered in
+[Pruning and drift](/kubernetes/guides/how-apply-works#pruning-and-drift)
+and outside edits in
+[Conflicts](/kubernetes/guides/how-apply-works#conflicts).
+
+The plan re-hashes `main` bundles, `context` directories, and `image`
+references. A changed hash shows as an `update` against `code.hash`
+with no prop change. Edit the code and deploy.
+
+| Change                                             | Effect                                  |
+| -------------------------------------------------- | --------------------------------------- |
+| `cluster` identity, `namespace`                    | replace                                 |
+| `image`, `env`, `resources`, `command` / `args`, `port`, `podTemplate`, code edit under `main` / `context` | rolling update of pods |
+| `replicas`                                         | in-place scale, existing pods untouched |
+| `serviceType`, `serviceAnnotations`                | Service update, no pod restart          |
+
+:::note[`name` is sticky]
+Changing `name` on an existing Deployment does not rename its
+objects. The provider keeps the original `deploymentName`. A
+`Kubernetes.Job` does the opposite. See
+[Jobs → Updates and replacement](/kubernetes/workloads/jobs#updates-and-replacement).
+:::
+
+:::caution[Selector immutability]
+`labels` feed `spec.selector.matchLabels`, which is immutable on
+`apps/v1` Deployments, so changing `labels` on a live Deployment may
+be rejected. For pod-only labels set `podTemplate.metadata.labels`
+instead.
+:::
+
+## Where next
+
+- [Jobs](/kubernetes/workloads/jobs) — run-to-completion and
+  scheduled work with `Kubernetes.Job`.
+- [Image sources](/kubernetes/workloads/image-sources) — `main` vs
+  `context` vs `image`, and why `main` needs a registry.
+- [Exposing services](/kubernetes/guides/exposing-services) —
+  Ingress, TLS, and per-cloud load-balancer annotations.
+- [`Deployment` reference](/providers/kubernetes/deployment) — every
+  prop and attribute.

--- a/website/src/content/docs/kubernetes/workloads/deployments.mdx
+++ b/website/src/content/docs/kubernetes/workloads/deployments.mdx
@@ -1,12 +1,10 @@
 ---
 title: Deployments
-description: Run a replicated server on any cluster with Kubernetes.Deployment — what it creates, serviceType and url, Effect servers with fetch, the tagged form, and what replaces.
+description: Run a replicated server on any Kubernetes cluster with Kubernetes.Deployment and reach it through its url.
 ---
 
-A [`Kubernetes.Deployment`](/providers/kubernetes/deployment) is a
-replicated server on any cluster. Give it a cluster, an image source,
-and a port; it applies a `Deployment`, a `Service`, and a
-`ServiceAccount`.
+[`Kubernetes.Deployment`](/providers/kubernetes/deployment) runs a
+replicated server. Give it a cluster, an image, and a port.
 
 ```typescript
 import * as Kubernetes from "alchemy/Kubernetes";
@@ -16,13 +14,13 @@ const local = Kubernetes.KubeConfig({ context: "docker-desktop" });
 
 const web = yield* Kubernetes.Deployment("Web", {
   cluster: local,
-  image: "nginx:1.27", // pre-built image; used verbatim on a kubeconfig cluster
+  image: "nginx:1.27", // pre-built image; local clusters can't build one
   port: 80,
   replicas: 2,
 });
 
 web.url;            // LoadBalancer address once assigned (string | undefined)
-web.deploymentName; // the Kubernetes object names are attributes too
+web.deploymentName; // also serviceName and serviceAccountName
 ```
 
 `image` is
@@ -30,10 +28,10 @@ web.deploymentName; // the Kubernetes object names are attributes too
 
 ## What gets created
 
-Three objects share one base name (`name`, or the engine's physical
-name lowercased) and one label set, `app.kubernetes.io/name` plus
-your `labels`. Container env, later wins: binding env, adapter env,
-`ALCHEMY_*`, `PORT`, your `env`.
+This creates a `ServiceAccount`, a `Service`, and a `Deployment`. All
+three share one name (`name`, or a generated one) and the
+`app.kubernetes.io/name` label plus your `labels`. Your `env` wins over
+anything set for you (`ALCHEMY_*`, `PORT`, binding env).
 
 ```yaml
 # What `Kubernetes.Deployment("Web", { image: "nginx:1.27", port: 80, replicas: 2 })` applies
@@ -70,17 +68,16 @@ spec:
             - { name: PORT, value: "80" }
 ```
 
-On EKS the adapter also provisions cloud resources, recorded in
-`identity` and `registry`. See
-[What the adapter adds](/kubernetes/clusters/eks#what-the-adapter-adds).
+On EKS you also get an IAM role and an ECR repository, shown in
+`identity` and `registry` ([What EKS adds](/kubernetes/clusters/eks#what-eks-adds)).
 
 ## Props by group
 
-The [reference](/providers/kubernetes/deployment) lists every prop.
+Every prop is in the [reference](/providers/kubernetes/deployment).
 Sizing: `replicas`, `resources`. Container: `command`, `args`, `env`,
-`port` (default `3000`). Placement: `namespace` (must already exist —
-pass a [Namespace manifest](/kubernetes/objects/manifests#namespaces)'s
-`name`), `labels`,
+`port` (default `3000`). Placement: `namespace` (create it first with
+a [Namespace manifest](/kubernetes/objects/manifests#namespaces) and
+pass its `name`), `labels`,
 [`podTemplate`](/kubernetes/workloads/pod-template#merge-rules).
 Cloud: `architecture`, `identity`, `tags`, `name`.
 
@@ -103,8 +100,7 @@ const api = yield* Kubernetes.Deployment("Api", {
   port: 8080,
   args: ["--log-level", "info"],
   env: { LOG_FORMAT: "json" },
-  // placement — the namespace must exist; referencing the Manifest's
-  // attribute (not the string "app") orders the deploy after it
+  // placement — pass `ns.name`, not "app", so the namespace is created first
   namespace: ns.name,
   labels: { "app.kubernetes.io/part-of": "acme" },
 });
@@ -112,11 +108,10 @@ const api = yield* Kubernetes.Deployment("Api", {
 
 ## Exposing it: serviceType and url
 
-`serviceType` defaults to `"LoadBalancer"`, so `url` works out of the
-box; with `"ClusterIP"` or `"NodePort"` it is `undefined`. The
-provider waits about 3 minutes for an address; if none arrives, `url`
-stays `undefined` until the next deploy. Adapter defaults for
-`serviceAnnotations` go underneath yours.
+`serviceType` defaults to `"LoadBalancer"`, which gives you `url`.
+With `"ClusterIP"` or `"NodePort"` it is `undefined`. If no address
+arrives within about 3 minutes, `url` stays `undefined` until your
+next deploy. Your `serviceAnnotations` win over the cluster's defaults.
 
 ```typescript
 const api = yield* Kubernetes.Deployment("Api", {
@@ -125,16 +120,13 @@ const api = yield* Kubernetes.Deployment("Api", {
   port: 8080,
   // default — provisions the cluster's cloud load balancer
   serviceType: "LoadBalancer",
-  // annotations land on the Service; adapter defaults (EKS: internet-facing
-  // NLB) are applied underneath and yours win
+  // yours win over the cluster's defaults (EKS: internet-facing NLB)
   serviceAnnotations: {
     "service.beta.kubernetes.io/aws-load-balancer-scheme": "internal",
   },
 });
 
-// http://<lb-hostname>:8080 — the Service port is the listener, so it's in the URL.
-// `undefined` if the load balancer hadn't published an address within ~3 minutes;
-// the next deploy fills it in.
+// http://<lb-hostname>:8080, or undefined until the address arrives
 return { url: api.url };
 
 // In-cluster only: no load balancer, `url` is always undefined.
@@ -146,15 +138,15 @@ const worker = yield* Kubernetes.Deployment("Internal", {
 // Reach it from other pods as http://<serviceName>.<namespace>.svc:<port>
 ```
 
-Ingress and per-cloud annotations:
+For Ingress and per-cloud annotations, see
 [Service types](/kubernetes/guides/exposing-services#service-types).
 
 ## Effect servers
 
-Pass `main: import.meta.url` and an init Effect that returns
-`{ fetch }`. Alchemy bundles it, builds and pushes an image, and
-serves `fetch` on `PORT`. Init runs once per pod; `fetch` runs per
-request and its error channel must be `never`.
+To run your own code, pass `main: import.meta.url` and an Effect that
+returns `{ fetch }`. The outer Effect runs once per pod; `fetch` serves
+every request on `PORT` and must never fail, so end it with
+`Effect.orDie`.
 
 ```typescript
 import * as AWS from "alchemy/AWS";
@@ -163,15 +155,15 @@ import * as Effect from "effect/Effect";
 import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 
-// inside the Stack body (EKS — `main` needs the adapter's managed registry)
+// inside the Stack body (EKS only)
 const api = yield* Kubernetes.Deployment(
   "Api",
   { cluster, main: import.meta.url, port: 3000, replicas: 2 },
-  // init: runs once per pod at startup — resolve bindings, build clients
+  // runs once per pod at startup — resolve bindings, build clients
   Effect.gen(function* () {
     const getItem = yield* AWS.DynamoDB.GetItem(table);
     return {
-      // fetch: runs per request, served by a Bun HTTP server on PORT
+      // fetch: runs per request on PORT
       fetch: Effect.gen(function* () {
         const request = yield* HttpServerRequest;
         const url = new URL(request.url, "http://api");
@@ -180,14 +172,14 @@ const api = yield* Kubernetes.Deployment(
         }
         const item = yield* getItem({ Key: { pk: { S: url.pathname } } });
         return yield* HttpServerResponse.json(item.Item ?? null);
-      }).pipe(Effect.orDie), // the handler's error channel must be `never`
+      }).pipe(Effect.orDie), // fetch must never fail
     };
   }).pipe(Effect.provide(AWS.DynamoDB.GetItemHttp)),
 );
 ```
 
-The same call can be a module's `export default`, with `props` as an
-Effect.
+You can also put the Deployment in its own module and `export default`
+it, with `props` as an Effect.
 
 ```typescript
 // src/api.ts — the same call as a module default export.
@@ -208,19 +200,17 @@ export default Kubernetes.Deployment(
 const api = yield* Api;
 ```
 
-Bindings resolve in init — see
-[The binding contract](/kubernetes/workloads/bindings#the-binding-contract).
+To bind AWS resources, see [Bindings](/kubernetes/workloads/bindings).
 
-:::caution[`main` needs a managed registry]
-Today only the EKS adapter has one; on a kubeconfig cluster use
-`image:` (see [Registry requirement](/kubernetes/workloads/image-sources#registry-requirement)).
+:::caution[`main` works on EKS only]
+On other clusters use `image:` ([Registry requirement](/kubernetes/workloads/image-sources#registry-requirement)).
 :::
 
 ## The tagged form
 
-`class Api extends Kubernetes.Deployment<Api, Shape>()("Api") {}`
-declares the identity, `Api.make(props, impl)` returns a Layer, and
-the Stack provides the Layer and `yield*`s the class.
+Declare a class with `Kubernetes.Deployment<Api, Shape>()("Api")`,
+build its Layer with `Api.make(props, impl)`, then provide the Layer in
+the Stack and `yield*` the class.
 
 ```typescript
 // src/api.ts
@@ -268,10 +258,10 @@ The same form works for a
 
 ## Updates and replacement
 
-Only a `cluster` identity change or a `namespace` change replaces;
-everything else is an in-place apply that rolls pods when the pod
-template changed. `name` is sticky and `labels` feed the immutable
-selector, so put pod-only labels in `podTemplate.metadata.labels`.
+Changing `cluster` or `namespace` replaces the Deployment. Anything
+else updates in place, rolling pods when the pod template changes.
+`labels` can't change after create; put labels you'll edit later in
+`podTemplate.metadata.labels`.
 
 ## Where next
 

--- a/website/src/content/docs/kubernetes/workloads/image-sources.mdx
+++ b/website/src/content/docs/kubernetes/workloads/image-sources.mdx
@@ -3,10 +3,9 @@ title: Image sources
 description: Where a workload's container image comes from — main (bundle an Effect program), context (build your Dockerfile), or image (a pre-built reference) — why main and context need a cluster with a managed registry, and how bundling and tree-shaking work.
 ---
 
-Every workload needs a container image. One of three keys on the
-props says where it comes from. `image` and `context` describe an
-environment that runs as-is. `main` adds a bundled Effect program and
-can borrow either of the other two as its environment.
+Every workload needs a container image. One of three props says where
+it comes from: `image` (pre-built, runs as-is), `context` (your
+Dockerfile), or `main` (a bundled Effect program).
 
 ```typescript
 // 1. a pre-built image — the environment runs as-is
@@ -25,49 +24,29 @@ yield* Kubernetes.Deployment(
 );
 ```
 
-What `main` returns is `{ fetch }` for a
+`main` returns `{ fetch }` for a
 [Deployment](/kubernetes/workloads/deployments#effect-servers) and
-`{ run }` for a [Job](/kubernetes/workloads/jobs#effect-jobs). This
-page is about the image.
+`{ run }` for a [Job](/kubernetes/workloads/jobs#effect-jobs).
 
 ## Three sources
 
-`main` wins if present and the other keys become its environment
-modifiers. Otherwise `image`, otherwise `context` / `dockerfile`.
+`main` wins if present and the other keys become its environment.
+Otherwise `image`, otherwise `context`. Declare one.
 
-| Source                     | You provide                                                                                       | Alchemy does                                                                                    | Container runs                                                                 |
-| -------------------------- | ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| `image`                    | a registry reference (`nginx:1.27`, `ghcr.io/acme/api:v3`)                                        | on a managed registry: mirrors it (pull → tag → push); elsewhere: uses the reference verbatim    | the image's own entrypoint, plus your `command` / `args`                       |
-| `context` (+ `dockerfile`) | a build-context directory and a Dockerfile — a path (default `${context}/Dockerfile`) or inline content | `docker build` in your context, push to the managed registry                                | your Dockerfile's `CMD` / `ENTRYPOINT`                                          |
-| `main`                     | an entry module (`import.meta.url`) and an init Effect                                            | bundles with rolldown, generates a Dockerfile, builds and pushes                                | `bun /app/index.mjs` — the generated entry that serves `{ fetch }` or runs `{ run }` |
+**`image`** is a registry reference. A managed registry mirrors it;
+elsewhere it is used verbatim, so private registries need an
+`imagePullSecrets` [recipe](/kubernetes/workloads/pod-template#recipes).
 
-**`image`** is a reference the cluster can pull, or the deploying
-machine when mirroring. Mirrored private registries need docker
-credentials locally. Registry-less clusters need node pull access, an
-`imagePullSecrets` [recipe](/kubernetes/workloads/pod-template#recipes)
-in `podTemplate`. Pick what runs with
-[`command` / `args`](/kubernetes/workloads/deployments#props-by-group).
-The identity is the reference string plus platform.
+**`context` + `dockerfile`** runs `docker build` in your context.
+`dockerfile` is a path relative to the cwd (default
+`${context}/Dockerfile`) or `Docker.Dockerfile.inline` content, which
+has no context and no `COPY`. Your Dockerfile supplies `CMD` /
+`ENTRYPOINT`. Never interpolate secrets into it.
 
-**`context` + `dockerfile`** builds your own Dockerfile. `dockerfile`
-is a path relative to the cwd, not the context (default
-`${context}/Dockerfile`), or inline content built with an empty
-context, so no `COPY`. The Dockerfile must define its own `CMD` /
-`ENTRYPOINT`. Inline content uses the `Docker.Dockerfile.inline`
-tagged template and may interpolate `Output`s. Never interpolate
-secrets, they are baked into image layers. The identity is a hash of
-the context directory, the Dockerfile content, and the platform.
-
-**`main`** is the bundled Effect program. `handler` is the export to
-load (default `"default"`). `image` becomes the Dockerfile's `FROM`
-(default `oven/bun:1`) and must run bun. `dockerfile` (a path) +
-`context` is a two-stage build: your Dockerfile is built first, then
-the generated stage `FROM`s it. `dockerfile` (inline) replaces
-`FROM <image>` as the preamble, with no context and no `COPY`.
-`build` is covered under
-[Bundling and tree-shaking](#bundling-and-tree-shaking).
-
-The generated Dockerfile:
+**`main`** is bundled with rolldown and baked into a generated image.
+`image` is the `FROM` (default `oven/bun:1`, must run bun).
+`dockerfile` + `context` builds your Dockerfile first and `FROM`s it.
+Inline `dockerfile` replaces the preamble.
 
 ```dockerfile
 # the preamble: `FROM <image>` (default oven/bun:1), your inline
@@ -116,56 +95,24 @@ const tools = yield* Kubernetes.Job(
 );
 ```
 
-The per-source prop interfaces (`BundledDeploymentProps`,
-`DockerfileDeploymentProps`, `ImageDeploymentProps`, and their Job
-twins) are in the [Deployment](/providers/kubernetes/deployment) and
-[Job](/providers/kubernetes/job) references.
-
-:::note[Exactly one source]
-Declaring two sources (`image` + `context`, `image` + `dockerfile`,
-inline `dockerfile` + `context`) is rejected at plan time on clusters
-with a managed registry. On a registry-less cluster the first match
-in the order above is used and the rest are ignored. Declare one.
-:::
+Per-source prop interfaces: [Deployment](/providers/kubernetes/deployment),
+[Job](/providers/kubernetes/job).
 
 :::caution[Mutable tags]
-`acme/api:latest` is mirrored once. Pushing a new `latest` upstream
-changes nothing until the prop changes. Pin digests or version tags.
+`acme/api:latest` is mirrored once; pin digests or version tags.
 :::
 
 ## Registry requirement
 
 The cluster adapter,
 [selected by `auth.kind`](/kubernetes/clusters/connecting#how-the-adapter-is-chosen),
-decides which branch you are on. This is the detail behind the
-[adapter comparison table](/kubernetes#what-the-cluster-adapter-gives-you).
+decides. With a registry (today EKS → ECR) every source is built or
+mirrored and pushed under a content-hash tag (`code.hash`); an
+existing tag skips the work. Without one (`kubeconfig`, `token`,
+`client-cert`, `exec`) only `image` works, verbatim, and `main` or
+`context` fail the deploy:
 
-**The adapter has a registry** (today: EKS, backed by ECR). Every
-source goes through it. `main` is bundled, built, and pushed.
-`context` is built and pushed. `image` is pulled, tagged, and pushed,
-never used verbatim. The tag is the content hash, and an existing tag
-skips the build or mirror. On EKS it is one private ECR repository
-per workload, per
-[What the adapter adds](/kubernetes/clusters/eks#what-the-adapter-adds).
-`imageUri` is `<registry uri>:<hash>` and `registry` is the adapter's
-handle.
-
-**No registry** (`kubeconfig`, `token`, `client-cert`, `exec`). Only
-`image` works, placed in the pod spec verbatim. Alchemy pulls and
-pushes nothing. `main` and `context` fail the deploy with:
-
-> `'<id>': this cluster has no managed image registry, so 'main' and 'context' image sources cannot be built and pushed. Use a pre-built 'image' reference the cluster can pull, or target a cluster whose platform provides a registry (e.g. AWS.EKS → ECR).`
-
-Alchemy won't guess a registry or push to Docker Hub for you. A
-future GKE or AKS adapter supplies Artifact Registry or ACR through
-the same
-[`registry` slot](/kubernetes/guides/cluster-adapters#the-interface).
-
-Mirroring is platform-pinned on pull and push. A throttled pull fails
-after a few minutes instead of hanging. The push retries with backoff.
-The plan session's notes show it: `Bundling Api program...`,
-`Building container image <uri>...`, `Pulling container image nginx:1.27...`,
-`Pushed <uri>`.
+> `'<id>': this cluster has no managed image registry, so 'main' and 'context' image sources cannot be built and pushed. …`
 
 ```typescript
 // Registry-less cluster: only `image`, used verbatim — the nodes pull it.
@@ -189,33 +136,14 @@ web2.imageUri;  // "<ecr repository uri>:<content hash>" — the mirrored copy, 
 web2.registry;  // the adapter's registry handle (see Clusters → EKS → What the adapter adds)
 ```
 
-| I'm on…          | and I want…        | Do this                                                                                                                                     |
-| ---------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| a local cluster  | an Effect program  | build your own image from a Dockerfile and use `image:` ([Using your own images](/kubernetes/clusters/local#using-your-own-images)), or develop against EKS |
-| a local cluster  | a public image     | `image:` just works                                                                                                                         |
-| EKS              | anything           | all three sources work; expect Docker locally                                                                                               |
-
-:::caution[`main` and `context` need a managed registry]
-On `kubeconfig`, `token`, `client-cert`, and `exec` clusters the
-deploy fails with "this cluster has no managed image registry …".
-Use `image:` there. Today the only adapter with a registry is EKS.
-:::
-
-:::note[Docker on the deploying machine]
-With a registry adapter every source, including `image`, needs Docker
-running where you run `alchemy deploy`, because mirroring is a local
-pull and push. Registry-less `image:` needs no Docker. See
-[Install](/kubernetes/setup#install).
-:::
+With a registry adapter every source, `image` included, needs Docker
+running where you deploy. Registry-less `image:` needs none.
 
 ## Architecture
 
 `architecture: "amd64" | "arm64"` (default `"amd64"`) is the image
-platform for builds and mirrors. It must match the nodes. An arm64
-image on amd64 nodes fails with `exec format error` at pod start, not
-at deploy time. Flipping it rebuilds or re-mirrors and rolls the
-workload. Pair it with a `nodeSelector` on `kubernetes.io/arch`, a
-[recipe](/kubernetes/workloads/pod-template#recipes) in `podTemplate`.
+platform for builds and mirrors and must match the nodes; a mismatch
+fails with `exec format error` at pod start.
 
 ```typescript
 const api = yield* Kubernetes.Deployment(
@@ -230,64 +158,21 @@ const api = yield* Kubernetes.Deployment(
 );
 ```
 
-On registry-less clusters `architecture` only affects the content
-hash. Each node pulls the verbatim `image` for its own architecture,
-so multi-arch manifests just work.
-
-## What triggers a rebuild
-
-Each source has a content hash that becomes the image tag and the
-`code.hash` attribute. `main` hashes the rolldown bundle, the
-generated Dockerfile, the platform, and the two-stage environment if
-any. It is computed at plan time, so `alchemy plan` runs the bundler.
-`context` hashes every file under `context`, the Dockerfile text, and
-the platform. `image` hashes the reference string and the platform.
-
-A mismatch with `code.hash` shows as an `update` with no prop change,
-applied per the Deployment's
-[Updates and replacement](/kubernetes/workloads/deployments#updates-and-replacement).
-For a one-shot Job a new hash means the
-[Job re-runs](/kubernetes/workloads/jobs#jobs). Edit code, deploy.
-
-On a registry-less cluster a re-pushed mutable tag is invisible to
-`alchemy plan`. The node may or may not re-pull depending on its
-`imagePullPolicy`. Pin a digest or bump the tag, per the
-[mutable-tags caution](#three-sources).
-
-An existing tag in the registry skips the build and push, so a
-rollback to a previous hash is a tag lookup. `replicas`, `env`,
-`resources`, and `serviceType` do not rebuild, though they still roll
-pods where Kubernetes requires it.
+On registry-less clusters nodes pull the verbatim `image` for their
+own architecture.
 
 ## Bundling and tree-shaking
 
-`main` is bundled with rolldown: ESM, one `index.mjs` plus split
-chunks, `platform: "node"` with the `bun` export condition so
-`@effect/platform-bun` resolves its Bun implementations, `bun` and
-`bun:*` external, no minify and no sourcemap by default.
-`build.input` and `build.output` pass through to rolldown
-(`external`, `plugins`, `resolve`, `minify`, `sourcemap`).
+`main` is bundled with rolldown: ESM, `index.mjs` plus split chunks,
+`platform: "node"` with the `bun` export condition, `bun:*` external,
+no minify or sourcemap by default. `build.input` and `build.output`
+pass through to rolldown.
 
-Top-level call and `new` expressions in `effect`, `@effect/*`,
-`alchemy`, `@alchemy.run/*`, and `@distilled.cloud/*` get
-`/*#__PURE__*/` annotations, so unused parts are tree-shaken. Other
-packages are untouched unless listed. `build.pure.packages` adds
-names or picomatch globs (`replaceDefaults: true` replaces the
-defaults). `build: { pure: false }` disables the plugin.
-
-Listing a package annotates calls whose result is bound, which is
-safe anywhere. If the package also declares `"sideEffects": false`
-(or `[]`), discarded calls such as `router.on("/path", handler)` are
-marked pure too and dropped when unused. The defaults declare exactly
-that on purpose.
-
-`build.bundleAnalyzer: true` emits a bundle analysis report beside the
-output.
-
-This decides image size and cold start. `@distilled.cloud/aws` is
-large, and this keeps only the operations your
-[server](/kubernetes/workloads/deployments#effect-servers) or
-[job](/kubernetes/workloads/jobs#effect-jobs) calls.
+Top-level calls in `effect`, `@effect/*`, `alchemy`, `@alchemy.run/*`,
+and `@distilled.cloud/*` get `/*#__PURE__*/` annotations so unused
+parts are tree-shaken. `build.pure.packages` adds names or globs
+(`replaceDefaults: true` replaces the defaults); `build: { pure: false }`
+disables it. `build.bundleAnalyzer: true` emits a report.
 
 ```typescript
 const api = yield* Kubernetes.Deployment(
@@ -310,20 +195,11 @@ const api = yield* Kubernetes.Deployment(
 { main: import.meta.url, build: { pure: false } }
 ```
 
-:::caution
 Only list a package that declares `"sideEffects": false` if its
-modules really have no meaningful top-level side effects. Otherwise
-top-level registrations can be tree-shaken away.
-:::
+top-level calls really are side-effect free.
 
 ## Where next
 
-- [Bindings](/kubernetes/workloads/bindings) — env and Pod Identity
-  bindings inside a `main` program.
+- [Bindings](/kubernetes/workloads/bindings)
 - [Using your own images](/kubernetes/clusters/local#using-your-own-images)
-  — getting your own image onto a registry-less cluster.
 - [What the adapter adds](/kubernetes/clusters/eks#what-the-adapter-adds)
-  — the ECR repository the EKS adapter manages.
-- [`Deployment`](/providers/kubernetes/deployment) and
-  [`Job`](/providers/kubernetes/job) references — the per-source
-  prop interfaces.

--- a/website/src/content/docs/kubernetes/workloads/image-sources.mdx
+++ b/website/src/content/docs/kubernetes/workloads/image-sources.mdx
@@ -1,0 +1,329 @@
+---
+title: Image sources
+description: Where a workload's container image comes from — main (bundle an Effect program), context (build your Dockerfile), or image (a pre-built reference) — why main and context need a cluster with a managed registry, and how bundling and tree-shaking work.
+---
+
+Every workload needs a container image. One of three keys on the
+props says where it comes from. `image` and `context` describe an
+environment that runs as-is. `main` adds a bundled Effect program and
+can borrow either of the other two as its environment.
+
+```typescript
+// 1. a pre-built image — the environment runs as-is
+yield* Kubernetes.Deployment("Web", { cluster, image: "nginx:1.27", port: 80 });
+
+// 2. your own Dockerfile — built from ./legacy, runs its own CMD/ENTRYPOINT
+yield* Kubernetes.Deployment("Legacy", { cluster, context: "./legacy", port: 8080 });
+
+// 3. an Effect program — bundled, baked into a generated image, served on PORT
+yield* Kubernetes.Deployment(
+  "Api",
+  { cluster, main: import.meta.url, port: 3000 },
+  Effect.gen(function* () {
+    return { fetch: Effect.succeed(HttpServerResponse.text("ok")) };
+  }),
+);
+```
+
+What `main` returns is `{ fetch }` for a
+[Deployment](/kubernetes/workloads/deployments#effect-servers) and
+`{ run }` for a [Job](/kubernetes/workloads/jobs#effect-jobs). This
+page is about the image.
+
+## Three sources
+
+`main` wins if present and the other keys become its environment
+modifiers. Otherwise `image`, otherwise `context` / `dockerfile`.
+
+| Source                     | You provide                                                                                       | Alchemy does                                                                                    | Container runs                                                                 |
+| -------------------------- | ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `image`                    | a registry reference (`nginx:1.27`, `ghcr.io/acme/api:v3`)                                        | on a managed registry: mirrors it (pull → tag → push); elsewhere: uses the reference verbatim    | the image's own entrypoint, plus your `command` / `args`                       |
+| `context` (+ `dockerfile`) | a build-context directory and a Dockerfile — a path (default `${context}/Dockerfile`) or inline content | `docker build` in your context, push to the managed registry                                | your Dockerfile's `CMD` / `ENTRYPOINT`                                          |
+| `main`                     | an entry module (`import.meta.url`) and an init Effect                                            | bundles with rolldown, generates a Dockerfile, builds and pushes                                | `bun /app/index.mjs` — the generated entry that serves `{ fetch }` or runs `{ run }` |
+
+**`image`** is a reference the cluster can pull, or the deploying
+machine when mirroring. Mirrored private registries need docker
+credentials locally. Registry-less clusters need node pull access, an
+`imagePullSecrets` [recipe](/kubernetes/workloads/pod-template#recipes)
+in `podTemplate`. Pick what runs with
+[`command` / `args`](/kubernetes/workloads/deployments#props-by-group).
+The identity is the reference string plus platform.
+
+**`context` + `dockerfile`** builds your own Dockerfile. `dockerfile`
+is a path relative to the cwd, not the context (default
+`${context}/Dockerfile`), or inline content built with an empty
+context, so no `COPY`. The Dockerfile must define its own `CMD` /
+`ENTRYPOINT`. Inline content uses the `Docker.Dockerfile.inline`
+tagged template and may interpolate `Output`s. Never interpolate
+secrets, they are baked into image layers. The identity is a hash of
+the context directory, the Dockerfile content, and the platform.
+
+**`main`** is the bundled Effect program. `handler` is the export to
+load (default `"default"`). `image` becomes the Dockerfile's `FROM`
+(default `oven/bun:1`) and must run bun. `dockerfile` (a path) +
+`context` is a two-stage build: your Dockerfile is built first, then
+the generated stage `FROM`s it. `dockerfile` (inline) replaces
+`FROM <image>` as the preamble, with no context and no `COPY`.
+`build` is covered under
+[Bundling and tree-shaking](#bundling-and-tree-shaking).
+
+The generated Dockerfile:
+
+```dockerfile
+# the preamble: `FROM <image>` (default oven/bun:1), your inline
+# `dockerfile` content, or `FROM` the locally built two-stage env image
+FROM oven/bun:1
+WORKDIR /app
+COPY index.mjs /app/index.mjs
+# any split chunks rolldown emitted
+COPY *.js /app/
+# Deployments only — Jobs get neither line
+ENV PORT=3000
+EXPOSE 3000
+ENTRYPOINT ["bun", "/app/index.mjs"]
+```
+
+```typescript
+import * as Docker from "alchemy/Docker"; // Docker.Dockerfile.inline (used below)
+
+// `main` with a custom environment: a Debian-based bun image
+const api = yield* Kubernetes.Deployment(
+  "Api",
+  { cluster, main: import.meta.url, image: "oven/bun:1-debian", port: 3000 },
+  Effect.gen(function* () { /* ... */ }),
+);
+
+// `main` with a two-stage environment: your Dockerfile (apt-get install …)
+// is built first in ./env, then the bundle is layered on top of it
+const worker = yield* Kubernetes.Job(
+  "Render",
+  { cluster, main: import.meta.url, context: "./env", dockerfile: "./env/Dockerfile" },
+  Effect.gen(function* () { /* ... */ }),
+);
+
+// inline environment preamble (no local files — COPY is unsupported here)
+const tools = yield* Kubernetes.Job(
+  "Tools",
+  {
+    cluster,
+    main: import.meta.url,
+    dockerfile: Docker.Dockerfile.inline`
+      FROM oven/bun:1
+      RUN apt-get update && apt-get install -y ffmpeg
+    `,
+  },
+  Effect.gen(function* () { /* ... */ }),
+);
+```
+
+The per-source prop interfaces (`BundledDeploymentProps`,
+`DockerfileDeploymentProps`, `ImageDeploymentProps`, and their Job
+twins) are in the [Deployment](/providers/kubernetes/deployment) and
+[Job](/providers/kubernetes/job) references.
+
+:::note[Exactly one source]
+Declaring two sources (`image` + `context`, `image` + `dockerfile`,
+inline `dockerfile` + `context`) is rejected at plan time on clusters
+with a managed registry. On a registry-less cluster the first match
+in the order above is used and the rest are ignored. Declare one.
+:::
+
+:::caution[Mutable tags]
+`acme/api:latest` is mirrored once. Pushing a new `latest` upstream
+changes nothing until the prop changes. Pin digests or version tags.
+:::
+
+## Registry requirement
+
+The cluster adapter,
+[selected by `auth.kind`](/kubernetes/clusters/connecting#how-the-adapter-is-chosen),
+decides which branch you are on. This is the detail behind the
+[adapter comparison table](/kubernetes#what-the-cluster-adapter-gives-you).
+
+**The adapter has a registry** (today: EKS, backed by ECR). Every
+source goes through it. `main` is bundled, built, and pushed.
+`context` is built and pushed. `image` is pulled, tagged, and pushed,
+never used verbatim. The tag is the content hash, and an existing tag
+skips the build or mirror. On EKS it is one private ECR repository
+per workload, per
+[What the adapter adds](/kubernetes/clusters/eks#what-the-adapter-adds).
+`imageUri` is `<registry uri>:<hash>` and `registry` is the adapter's
+handle.
+
+**No registry** (`kubeconfig`, `token`, `client-cert`, `exec`). Only
+`image` works, placed in the pod spec verbatim. Alchemy pulls and
+pushes nothing. `main` and `context` fail the deploy with:
+
+> `'<id>': this cluster has no managed image registry, so 'main' and 'context' image sources cannot be built and pushed. Use a pre-built 'image' reference the cluster can pull, or target a cluster whose platform provides a registry (e.g. AWS.EKS → ECR).`
+
+Alchemy won't guess a registry or push to Docker Hub for you. A
+future GKE or AKS adapter supplies Artifact Registry or ACR through
+the same
+[`registry` slot](/kubernetes/guides/cluster-adapters#the-interface).
+
+Mirroring is platform-pinned on pull and push. A throttled pull fails
+after a few minutes instead of hanging. The push retries with backoff.
+The plan session's notes show it: `Bundling Api program...`,
+`Building container image <uri>...`, `Pulling container image nginx:1.27...`,
+`Pushed <uri>`.
+
+```typescript
+// Registry-less cluster: only `image`, used verbatim — the nodes pull it.
+const local = Kubernetes.KubeConfig({ context: "docker-desktop" });
+const web = yield* Kubernetes.Deployment("Web", {
+  cluster: local,
+  image: "ghcr.io/acme/web:1.4.2", // appears in the pod spec exactly like this
+  port: 8080,
+});
+web.imageUri;  // "ghcr.io/acme/web:1.4.2"
+web.registry;  // undefined
+
+// EKS: the same prop is mirrored into a per-workload ECR repository.
+const eks = yield* AWS.EKS.Cluster("Cluster", { compute: "auto", /* ... */ });
+const web2 = yield* Kubernetes.Deployment("Web", {
+  cluster: eks,
+  image: "ghcr.io/acme/web:1.4.2",
+  port: 8080,
+});
+web2.imageUri;  // "<ecr repository uri>:<content hash>" — the mirrored copy, not the ghcr ref
+web2.registry;  // the adapter's registry handle (see Clusters → EKS → What the adapter adds)
+```
+
+| I'm on…          | and I want…        | Do this                                                                                                                                     |
+| ---------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| a local cluster  | an Effect program  | build your own image from a Dockerfile and use `image:` ([Using your own images](/kubernetes/clusters/local#using-your-own-images)), or develop against EKS |
+| a local cluster  | a public image     | `image:` just works                                                                                                                         |
+| EKS              | anything           | all three sources work; expect Docker locally                                                                                               |
+
+:::caution[`main` and `context` need a managed registry]
+On `kubeconfig`, `token`, `client-cert`, and `exec` clusters the
+deploy fails with "this cluster has no managed image registry …".
+Use `image:` there. Today the only adapter with a registry is EKS.
+:::
+
+:::note[Docker on the deploying machine]
+With a registry adapter every source, including `image`, needs Docker
+running where you run `alchemy deploy`, because mirroring is a local
+pull and push. Registry-less `image:` needs no Docker. See
+[Install](/kubernetes/setup#install).
+:::
+
+## Architecture
+
+`architecture: "amd64" | "arm64"` (default `"amd64"`) is the image
+platform for builds and mirrors. It must match the nodes. An arm64
+image on amd64 nodes fails with `exec format error` at pod start, not
+at deploy time. Flipping it rebuilds or re-mirrors and rolls the
+workload. Pair it with a `nodeSelector` on `kubernetes.io/arch`, a
+[recipe](/kubernetes/workloads/pod-template#recipes) in `podTemplate`.
+
+```typescript
+const api = yield* Kubernetes.Deployment(
+  "Api",
+  {
+    cluster,
+    main: import.meta.url,
+    architecture: "arm64", // build + push a linux/arm64 image
+    podTemplate: { spec: { nodeSelector: { "kubernetes.io/arch": "arm64" } } },
+  },
+  Effect.gen(function* () { /* ... */ }),
+);
+```
+
+On registry-less clusters `architecture` only affects the content
+hash. Each node pulls the verbatim `image` for its own architecture,
+so multi-arch manifests just work.
+
+## What triggers a rebuild
+
+Each source has a content hash that becomes the image tag and the
+`code.hash` attribute. `main` hashes the rolldown bundle, the
+generated Dockerfile, the platform, and the two-stage environment if
+any. It is computed at plan time, so `alchemy plan` runs the bundler.
+`context` hashes every file under `context`, the Dockerfile text, and
+the platform. `image` hashes the reference string and the platform.
+
+A mismatch with `code.hash` shows as an `update` with no prop change,
+applied per the Deployment's
+[Updates and replacement](/kubernetes/workloads/deployments#updates-and-replacement).
+For a one-shot Job a new hash means the
+[Job re-runs](/kubernetes/workloads/jobs#jobs). Edit code, deploy.
+
+On a registry-less cluster a re-pushed mutable tag is invisible to
+`alchemy plan`. The node may or may not re-pull depending on its
+`imagePullPolicy`. Pin a digest or bump the tag, per the
+[mutable-tags caution](#three-sources).
+
+An existing tag in the registry skips the build and push, so a
+rollback to a previous hash is a tag lookup. `replicas`, `env`,
+`resources`, and `serviceType` do not rebuild, though they still roll
+pods where Kubernetes requires it.
+
+## Bundling and tree-shaking
+
+`main` is bundled with rolldown: ESM, one `index.mjs` plus split
+chunks, `platform: "node"` with the `bun` export condition so
+`@effect/platform-bun` resolves its Bun implementations, `bun` and
+`bun:*` external, no minify and no sourcemap by default.
+`build.input` and `build.output` pass through to rolldown
+(`external`, `plugins`, `resolve`, `minify`, `sourcemap`).
+
+Top-level call and `new` expressions in `effect`, `@effect/*`,
+`alchemy`, `@alchemy.run/*`, and `@distilled.cloud/*` get
+`/*#__PURE__*/` annotations, so unused parts are tree-shaken. Other
+packages are untouched unless listed. `build.pure.packages` adds
+names or picomatch globs (`replaceDefaults: true` replaces the
+defaults). `build: { pure: false }` disables the plugin.
+
+Listing a package annotates calls whose result is bound, which is
+safe anywhere. If the package also declares `"sideEffects": false`
+(or `[]`), discarded calls such as `router.on("/path", handler)` are
+marked pure too and dropped when unused. The defaults declare exactly
+that on purpose.
+
+`build.bundleAnalyzer: true` emits a bundle analysis report beside the
+output.
+
+This decides image size and cold start. `@distilled.cloud/aws` is
+large, and this keeps only the operations your
+[server](/kubernetes/workloads/deployments#effect-servers) or
+[job](/kubernetes/workloads/jobs#effect-jobs) calls.
+
+```typescript
+const api = yield* Kubernetes.Deployment(
+  "Api",
+  {
+    cluster,
+    main: import.meta.url,
+    build: {
+      // annotate your own packages in addition to the defaults
+      pure: { packages: ["@acme/*", "my-router"] },
+      // rolldown passthrough
+      output: { minify: true },
+      input: { external: ["sharp"] },
+    },
+  },
+  Effect.gen(function* () { /* ... */ }),
+);
+
+// disable pure annotations entirely (debugging a missing side effect)
+{ main: import.meta.url, build: { pure: false } }
+```
+
+:::caution
+Only list a package that declares `"sideEffects": false` if its
+modules really have no meaningful top-level side effects. Otherwise
+top-level registrations can be tree-shaken away.
+:::
+
+## Where next
+
+- [Bindings](/kubernetes/workloads/bindings) — env and Pod Identity
+  bindings inside a `main` program.
+- [Using your own images](/kubernetes/clusters/local#using-your-own-images)
+  — getting your own image onto a registry-less cluster.
+- [What the adapter adds](/kubernetes/clusters/eks#what-the-adapter-adds)
+  — the ECR repository the EKS adapter manages.
+- [`Deployment`](/providers/kubernetes/deployment) and
+  [`Job`](/providers/kubernetes/job) references — the per-source
+  prop interfaces.

--- a/website/src/content/docs/kubernetes/workloads/image-sources.mdx
+++ b/website/src/content/docs/kubernetes/workloads/image-sources.mdx
@@ -1,20 +1,20 @@
 ---
 title: Image sources
-description: Where a workload's container image comes from — main (bundle an Effect program), context (build your Dockerfile), or image (a pre-built reference) — why main and context need a cluster with a managed registry, and how bundling and tree-shaking work.
+description: Choose where a Deployment or Job gets its container image, from a pre-built image, your own Dockerfile, or a bundled Effect program.
 ---
 
-Every workload needs a container image. One of three props says where
-it comes from: `image` (pre-built, runs as-is), `context` (your
-Dockerfile), or `main` (a bundled Effect program).
+Every workload needs a container image. Set exactly one of `image`
+(pre-built), `context` (your Dockerfile), or `main` (an Effect program
+Alchemy bundles).
 
 ```typescript
-// 1. a pre-built image — the environment runs as-is
+// 1. a pre-built image, run as-is
 yield* Kubernetes.Deployment("Web", { cluster, image: "nginx:1.27", port: 80 });
 
-// 2. your own Dockerfile — built from ./legacy, runs its own CMD/ENTRYPOINT
+// 2. your own Dockerfile — built from ./legacy, runs its CMD/ENTRYPOINT
 yield* Kubernetes.Deployment("Legacy", { cluster, context: "./legacy", port: 8080 });
 
-// 3. an Effect program — bundled, baked into a generated image, served on PORT
+// 3. an Effect program, bundled into an image and served on PORT
 yield* Kubernetes.Deployment(
   "Api",
   { cluster, main: import.meta.url, port: 3000 },
@@ -30,31 +30,30 @@ yield* Kubernetes.Deployment(
 
 ## Three sources
 
-`main` wins if present and the other keys become its environment.
-Otherwise `image`, otherwise `context`. Declare one.
+If you set `main`, the other keys describe its base image.
 
-**`image`** is a registry reference. A managed registry mirrors it;
-elsewhere it is used verbatim, so private registries need an
+**`image`** is a registry reference. On EKS it is copied into ECR;
+elsewhere the nodes pull it as written, so a private registry needs an
 `imagePullSecrets` [recipe](/kubernetes/workloads/pod-template#recipes).
 
 **`context` + `dockerfile`** runs `docker build` in your context.
 `dockerfile` is a path relative to the cwd (default
 `${context}/Dockerfile`) or `Docker.Dockerfile.inline` content, which
-has no context and no `COPY`. Your Dockerfile supplies `CMD` /
+has no context and can't `COPY`. Your Dockerfile supplies `CMD` /
 `ENTRYPOINT`. Never interpolate secrets into it.
 
-**`main`** is bundled with rolldown and baked into a generated image.
-`image` is the `FROM` (default `oven/bun:1`, must run bun).
-`dockerfile` + `context` builds your Dockerfile first and `FROM`s it.
-Inline `dockerfile` replaces the preamble.
+**`main`** is bundled into a generated image. `image` is the `FROM`
+base (default `oven/bun:1`; must run bun). `dockerfile` + `context`
+builds your Dockerfile first and uses it as the base. An inline
+`dockerfile` replaces the opening lines.
 
 ```dockerfile
-# the preamble: `FROM <image>` (default oven/bun:1), your inline
-# `dockerfile` content, or `FROM` the locally built two-stage env image
+# base: `FROM <image>` (default oven/bun:1), your inline
+# `dockerfile`, or `FROM` your built Dockerfile
 FROM oven/bun:1
 WORKDIR /app
 COPY index.mjs /app/index.mjs
-# any split chunks rolldown emitted
+# extra bundle chunks
 COPY *.js /app/
 # Deployments only — Jobs get neither line
 ENV PORT=3000
@@ -65,22 +64,22 @@ ENTRYPOINT ["bun", "/app/index.mjs"]
 ```typescript
 import * as Docker from "alchemy/Docker"; // Docker.Dockerfile.inline (used below)
 
-// `main` with a custom environment: a Debian-based bun image
+// `main` on a different base image: Debian-based bun
 const api = yield* Kubernetes.Deployment(
   "Api",
   { cluster, main: import.meta.url, image: "oven/bun:1-debian", port: 3000 },
   Effect.gen(function* () { /* ... */ }),
 );
 
-// `main` with a two-stage environment: your Dockerfile (apt-get install …)
-// is built first in ./env, then the bundle is layered on top of it
+// `main` on your own Dockerfile: ./env/Dockerfile is built first,
+// then the bundle is added on top
 const worker = yield* Kubernetes.Job(
   "Render",
   { cluster, main: import.meta.url, context: "./env", dockerfile: "./env/Dockerfile" },
   Effect.gen(function* () { /* ... */ }),
 );
 
-// inline environment preamble (no local files — COPY is unsupported here)
+// inline base image (no local files, so no COPY)
 const tools = yield* Kubernetes.Job(
   "Tools",
   {
@@ -95,27 +94,24 @@ const tools = yield* Kubernetes.Job(
 );
 ```
 
-Per-source prop interfaces: [Deployment](/providers/kubernetes/deployment),
+Full prop list: [Deployment](/providers/kubernetes/deployment),
 [Job](/providers/kubernetes/job).
 
 :::caution[Mutable tags]
-`acme/api:latest` is mirrored once; pin digests or version tags.
+`acme/api:latest` is copied into ECR once; pin a version tag or digest.
 :::
 
 ## Registry requirement
 
-The cluster adapter,
-[selected by `auth.kind`](/kubernetes/clusters/connecting#how-the-adapter-is-chosen),
-decides. With a registry (today EKS → ECR) every source is built or
-mirrored and pushed under a content-hash tag (`code.hash`); an
-existing tag skips the work. Without one (`kubeconfig`, `token`,
-`client-cert`, `exec`) only `image` works, verbatim, and `main` or
-`context` fail the deploy:
+`main` and `context` build an image and push it to a registry, so they
+need a cluster with one (EKS). On EKS every source, `image` included,
+is pushed to ECR. On other clusters only `image` works, as written;
+`main` or `context` fail the deploy:
 
 > `'<id>': this cluster has no managed image registry, so 'main' and 'context' image sources cannot be built and pushed. …`
 
 ```typescript
-// Registry-less cluster: only `image`, used verbatim — the nodes pull it.
+// Local cluster: only `image`, used as written.
 const local = Kubernetes.KubeConfig({ context: "docker-desktop" });
 const web = yield* Kubernetes.Deployment("Web", {
   cluster: local,
@@ -125,25 +121,24 @@ const web = yield* Kubernetes.Deployment("Web", {
 web.imageUri;  // "ghcr.io/acme/web:1.4.2"
 web.registry;  // undefined
 
-// EKS: the same prop is mirrored into a per-workload ECR repository.
+// EKS: the same image is copied into ECR.
 const eks = yield* AWS.EKS.Cluster("Cluster", { compute: "auto", /* ... */ });
 const web2 = yield* Kubernetes.Deployment("Web", {
   cluster: eks,
   image: "ghcr.io/acme/web:1.4.2",
   port: 8080,
 });
-web2.imageUri;  // "<ecr repository uri>:<content hash>" — the mirrored copy, not the ghcr ref
-web2.registry;  // the adapter's registry handle (see Clusters → EKS → What the adapter adds)
+web2.imageUri;  // the ECR copy, not the ghcr ref
+web2.registry;  // { kind: "aws-ecr", repositoryName, repositoryUri }
 ```
 
-With a registry adapter every source, `image` included, needs Docker
-running where you deploy. Registry-less `image:` needs none.
+On EKS every source, `image` included, needs Docker running where you
+deploy. On other clusters `image:` needs no Docker.
 
 ## Architecture
 
-`architecture: "amd64" | "arm64"` (default `"amd64"`) is the image
-platform for builds and mirrors and must match the nodes; a mismatch
-fails with `exec format error` at pod start.
+Set `architecture: "amd64" | "arm64"` (default `"amd64"`) to match
+your nodes. A mismatch fails at pod start with `exec format error`.
 
 ```typescript
 const api = yield* Kubernetes.Deployment(
@@ -158,21 +153,18 @@ const api = yield* Kubernetes.Deployment(
 );
 ```
 
-On registry-less clusters nodes pull the verbatim `image` for their
-own architecture.
+On other clusters, nodes pull `image` for their own architecture.
 
 ## Bundling and tree-shaking
 
-`main` is bundled with rolldown: ESM, `index.mjs` plus split chunks,
-`platform: "node"` with the `bun` export condition, `bun:*` external,
-no minify or sourcemap by default. `build.input` and `build.output`
-pass through to rolldown.
+`main` is bundled with rolldown; `build.input` and `build.output`
+pass through to it. Minify and sourcemaps are off by default.
 
-Top-level calls in `effect`, `@effect/*`, `alchemy`, `@alchemy.run/*`,
-and `@distilled.cloud/*` get `/*#__PURE__*/` annotations so unused
-parts are tree-shaken. `build.pure.packages` adds names or globs
-(`replaceDefaults: true` replaces the defaults); `build: { pure: false }`
-disables it. `build.bundleAnalyzer: true` emits a report.
+Unused code from `effect`, `@effect/*`, `alchemy`, `@alchemy.run/*`,
+and `@distilled.cloud/*` is dropped. Add your own packages with
+`build.pure.packages` (`replaceDefaults: true` drops the defaults);
+`build: { pure: false }` turns it off. `build.bundleAnalyzer: true`
+writes a report.
 
 ```typescript
 const api = yield* Kubernetes.Deployment(
@@ -181,7 +173,7 @@ const api = yield* Kubernetes.Deployment(
     cluster,
     main: import.meta.url,
     build: {
-      // annotate your own packages in addition to the defaults
+      // also drop unused code from your own packages
       pure: { packages: ["@acme/*", "my-router"] },
       // rolldown passthrough
       output: { minify: true },
@@ -191,15 +183,14 @@ const api = yield* Kubernetes.Deployment(
   Effect.gen(function* () { /* ... */ }),
 );
 
-// disable pure annotations entirely (debugging a missing side effect)
+// keep all code (when a side effect goes missing)
 { main: import.meta.url, build: { pure: false } }
 ```
 
-Only list a package that declares `"sideEffects": false` if its
-top-level calls really are side-effect free.
+Only add a package whose top-level calls really are side-effect free.
 
 ## Where next
 
 - [Bindings](/kubernetes/workloads/bindings)
 - [Using your own images](/kubernetes/clusters/local#using-your-own-images)
-- [What the adapter adds](/kubernetes/clusters/eks#what-the-adapter-adds)
+- [What EKS adds](/kubernetes/clusters/eks#what-eks-adds)

--- a/website/src/content/docs/kubernetes/workloads/jobs.mdx
+++ b/website/src/content/docs/kubernetes/workloads/jobs.mdx
@@ -1,9 +1,9 @@
 ---
 title: Jobs
-description: Run-to-completion and scheduled work with Kubernetes.Job — retries, TTL, what a redeploy does, CronJobs via schedule, and Effect jobs that return run.
+description: Run a container to completion or on a cron schedule on any Kubernetes cluster with Kubernetes.Job.
 ---
 
-A [`Kubernetes.Job`](/providers/kubernetes/job) runs a container to
+[`Kubernetes.Job`](/providers/kubernetes/job) runs a container to
 completion. It takes the same `cluster`,
 [image sources](/kubernetes/workloads/image-sources#three-sources),
 and bindings as a Deployment, but has no Service and no `url`.
@@ -17,21 +17,20 @@ const migrate = yield* Kubernetes.Job("DbMigrate", {
   backoffLimit: 2,
 });
 
-migrate.jobName; // "<stack>-dbmigrate-<stage>-<suffix>-<8-char spec hash>"
+migrate.jobName; // generated; changes with every edit to the Job
 migrate.kind;    // "Job"
 ```
 
 ## Jobs
 
-A Job applies a `ServiceAccount` then a `batch/v1 Job`, named
+A Job creates a `ServiceAccount` and a `batch/v1 Job`, named
 [like a Deployment](/kubernetes/workloads/deployments#what-gets-created)
 with the same [props](/kubernetes/workloads/deployments#props-by-group).
-Applying it runs it; the deploy does not wait.
+The Job starts on deploy. Deploy doesn't wait for it to finish.
 
-The name carries a hash of the spec: an unchanged redeploy is a no-op,
-any spec change deletes the old Job and runs a new one (bump an env
-var to force a re-run). Set `ttlSecondsAfterFinished` on anything you
-deploy repeatedly.
+Redeploying with nothing changed does nothing. Any change deletes the
+old Job and runs a new one (bump an env var to force a re-run). Set
+`ttlSecondsAfterFinished` on anything you deploy repeatedly.
 
 ```typescript
 const backfill = yield* Kubernetes.Job("Backfill", {
@@ -43,14 +42,10 @@ const backfill = yield* Kubernetes.Job("Backfill", {
   restartPolicy: "Never",
   // give up after 3 retries (Kubernetes default is 6)
   backoffLimit: 3,
-  // garbage-collect the finished Job (and its pods) an hour after it ends
+  // clean up the finished Job (and its pods) an hour after it ends
   ttlSecondsAfterFinished: 3600,
   resources: { requests: { cpu: "250m", memory: "512Mi" } },
 });
-
-// Change `args` and deploy again: the old Job is deleted, a new
-// content-addressed Job is applied, and it runs. Deploying with nothing
-// changed is a no-op — the Job does not run twice.
 ```
 
 :::caution
@@ -60,9 +55,9 @@ A failed Job does not fail the deploy; see
 
 ## CronJobs
 
-Set `schedule` to a 5-field cron expression and Alchemy applies a
-`batch/v1 CronJob` instead, which updates in place and never runs on
-deploy. Fields without props (`concurrencyPolicy`, `timeZone`) need a
+Set `schedule` to a 5-field cron expression to get a `batch/v1 CronJob`
+instead. It updates in place and never runs on deploy. For fields
+without props (`concurrencyPolicy`, `timeZone`) write a
 [`Kubernetes.Manifest`](/kubernetes/objects/manifests#any-object).
 
 ```typescript
@@ -70,7 +65,7 @@ const nightly = yield* Kubernetes.Job("NightlyReport", {
   cluster,
   image: "ghcr.io/acme/tools:v3",
   args: ["report", "--yesterday"],
-  // 5-field cron → a CronJob is synthesized; runs at 03:00 cluster time
+  // 5-field cron → a CronJob; runs at 03:00 cluster time
   schedule: "0 3 * * *",
   // these apply to each run's Job
   backoffLimit: 1,
@@ -79,15 +74,13 @@ const nightly = yield* Kubernetes.Job("NightlyReport", {
 
 nightly.kind;     // "CronJob"
 nightly.schedule; // "0 3 * * *"
-// Editing `schedule` or the image updates the CronJob in place; nothing runs
-// until the next tick.
 ```
 
 ## Effect jobs
 
-Pass `main: import.meta.url` and an init Effect that returns
-`{ run }`. When `run` returns the process exits 0; a defect exits 1
-and counts against `backoffLimit`. Bindings resolve in init, as in
+To run your own code, pass `main: import.meta.url` and an Effect that
+returns `{ run }`. When `run` finishes the pod exits 0; a failure exits
+1 and counts against `backoffLimit`. Bindings work as in
 [Effect servers](/kubernetes/workloads/deployments#effect-servers).
 
 ```typescript
@@ -95,12 +88,12 @@ import * as AWS from "alchemy/AWS";
 import * as Kubernetes from "alchemy/Kubernetes";
 import * as Effect from "effect/Effect";
 
-// inside the Stack body (EKS — `main` needs the adapter's managed registry)
+// inside the Stack body (EKS only)
 const seed = yield* Kubernetes.Job(
   "SeedData",
   { cluster, main: import.meta.url, backoffLimit: 2, ttlSecondsAfterFinished: 600 },
   Effect.gen(function* () {
-    // init: bindings and clients
+    // runs once at startup: bindings and clients
     const putItem = yield* AWS.DynamoDB.PutItem(table);
     return {
       // run: executes to completion, then the pod exits 0
@@ -114,7 +107,7 @@ const seed = yield* Kubernetes.Job(
 ```
 
 The [tagged form](/kubernetes/workloads/deployments#the-tagged-form)
-works the same way, and `schedule` works with `main`.
+works too, and `schedule` works with `main`.
 
 ```typescript
 // src/backfill.ts — the tagged form (same shape as a tagged Deployment)
@@ -136,9 +129,8 @@ export default Backfill.make(
 );
 ```
 
-`main` needs a
-[managed registry](/kubernetes/workloads/image-sources#registry-requirement);
-on a kubeconfig cluster use `image:` with `command` / `args`.
+`main` works on [EKS only](/kubernetes/workloads/image-sources#registry-requirement).
+On other clusters use `image:` with `command` / `args`.
 
 ## Where next
 

--- a/website/src/content/docs/kubernetes/workloads/jobs.mdx
+++ b/website/src/content/docs/kubernetes/workloads/jobs.mdx
@@ -1,0 +1,252 @@
+---
+title: Jobs
+description: Run-to-completion and scheduled work with Kubernetes.Job — retries, TTL, what a redeploy does to a finished Job, CronJobs via schedule, and Effect jobs that return run.
+---
+
+A [`Kubernetes.Job`](/providers/kubernetes/job) runs a container to
+completion, the Kubernetes analog of `AWS.ECS.Task`. It takes the
+same `cluster`, the same
+[three image sources](/kubernetes/workloads/image-sources#three-sources),
+and the same bindings as a Deployment. There is no Service and no
+`url`. The pod exits when the work is done.
+
+```typescript
+// inside the Stack body
+const migrate = yield* Kubernetes.Job("DbMigrate", {
+  cluster,
+  image: "ghcr.io/acme/migrator:v3",
+  args: ["migrate", "--to", "latest"],
+  backoffLimit: 2,
+});
+
+migrate.jobName; // "<stack>-dbmigrate-<stage>-<suffix>-<8-char spec hash>"
+migrate.kind;    // "Job"
+```
+
+Applying a `batch/v1` Job starts it, so the Job runs on deploy. The
+deploy does not wait for it to finish. Objects follow the
+[same naming and label scheme](/kubernetes/workloads/deployments#what-gets-created)
+as a Deployment, with one twist in the Job's own name.
+
+## Jobs
+
+A Job resource applies a `ServiceAccount` then a `batch/v1 Job` with
+[server-side apply](/kubernetes/guides/how-apply-works#server-side-apply).
+The container env is a Deployment's minus `PORT`. See
+[What gets created](/kubernetes/workloads/deployments#what-gets-created).
+The shared props (`resources`, `env`, `namespace`, `labels`,
+`podTemplate`, `architecture`, `identity`, `tags`) are in
+[Props by group](/kubernetes/workloads/deployments#props-by-group).
+
+A Job's pod template is immutable, so Alchemy content-addresses
+one-shot Jobs. The name is the base name (truncated to 54 characters)
+plus 8 hex characters of a SHA-256 over `backoffLimit`,
+`ttlSecondsAfterFinished`, and the pod template. The ServiceAccount
+keeps the plain base name. Names cap at 63 characters because
+Kubernetes stamps the Job name into a pod label.
+
+A redeploy with no changes is a no-op. Any spec change (image, `args`,
+`env`, a binding's env, a `main` edit, `backoffLimit`) produces a new
+name. The old Job and its pods are deleted, the new one is applied,
+and it runs.
+
+`restartPolicy` (`"Never"` default, or `"OnFailure"`) is pod-level.
+With `Never` each failed attempt is a new pod and the failed one stays
+for `kubectl logs`. With `OnFailure` the container restarts in place.
+
+`backoffLimit` is the number of retries before the Job is `Failed`.
+Kubernetes defaults to 6, backing off 10s, 20s, 40s, capped at 6
+minutes.
+
+`ttlSecondsAfterFinished` is the seconds after success or failure
+before Kubernetes garbage-collects the Job and its pods. Unset means
+never. Set it on anything you deploy repeatedly. If TTL has already
+collected the Job and a later deploy reconciles an unchanged spec (a
+`tags` change, say), the same-named Job is re-created and runs again.
+
+`command` / `args` pick what the container does for `image` and
+`context` sources.
+
+```typescript
+const backfill = yield* Kubernetes.Job("Backfill", {
+  cluster,
+  image: "ghcr.io/acme/tools:v3",
+  command: ["node", "backfill.js"],
+  args: ["--since", "2026-01-01"],
+  // each failed attempt is a fresh pod; the failed pod stays for `kubectl logs`
+  restartPolicy: "Never",
+  // give up after 3 retries (Kubernetes default is 6)
+  backoffLimit: 3,
+  // garbage-collect the finished Job (and its pods) an hour after it ends
+  ttlSecondsAfterFinished: 3600,
+  resources: { requests: { cpu: "250m", memory: "512Mi" } },
+});
+
+// Change `args` and deploy again: the old Job is deleted, a new
+// content-addressed Job is applied, and it runs. Deploying with nothing
+// changed is a no-op — the Job does not run twice.
+```
+
+:::note[Re-running a Job]
+A Job re-runs exactly when its spec changes. To force a re-run, bump
+an env var (`env: { RUN: "2" }`).
+:::
+
+:::caution
+`alchemy deploy` returns as soon as the Job is applied. A failed Job
+does not fail the deploy. Check it with
+`kubectl get job <jobName> -n <namespace>` and
+`kubectl logs job/<jobName>`, or see
+[Debugging](/kubernetes/guides/how-apply-works#debugging).
+:::
+
+Attributes: `connection`, `namespace`, `kind` (`"Job"` or
+`"CronJob"`), `jobName`, `schedule`, `serviceAccountName`, `imageUri`,
+`identity`, `registry`, `kubernetesObjects`, `code.hash`. All are in
+the [reference](/providers/kubernetes/job).
+
+## CronJobs
+
+Set `schedule` to a 5-field cron expression and Alchemy synthesizes a
+`batch/v1 CronJob`. `kind` becomes `"CronJob"`. `backoffLimit`,
+`ttlSecondsAfterFinished`, `restartPolicy`, and the pod template go
+into `jobTemplate` unchanged.
+
+A CronJob is mutable, so it keeps the base name (truncated to 52
+characters) and updates in place. Nothing runs on deploy. Adding or
+removing `schedule` swaps the kind: the old object is deleted and the
+new kind applied. Removing it applies a one-shot Job, which runs.
+
+The cluster's controller manager interprets the expression, usually
+in UTC on managed clusters. `concurrencyPolicy`, `timeZone`,
+`startingDeadlineSeconds`, `successfulJobsHistoryLimit`, and
+`failedJobsHistoryLimit` have no props, and
+[`podTemplate`](/kubernetes/workloads/pod-template#merge-rules)
+reaches only the pod template inside `jobTemplate`. To set them,
+write the CronJob as a
+[`Kubernetes.Manifest`](/kubernetes/objects/manifests#any-object).
+
+Every tick creates a Job, so set `ttlSecondsAfterFinished`. Without
+it Kubernetes keeps the last 3 successful and 1 failed Job by default.
+
+```typescript
+const nightly = yield* Kubernetes.Job("NightlyReport", {
+  cluster,
+  image: "ghcr.io/acme/tools:v3",
+  args: ["report", "--yesterday"],
+  // 5-field cron → a CronJob is synthesized; runs at 03:00 cluster time
+  schedule: "0 3 * * *",
+  // these apply to each run's Job
+  backoffLimit: 1,
+  ttlSecondsAfterFinished: 86400,
+});
+
+nightly.kind;     // "CronJob"
+nightly.schedule; // "0 3 * * *"
+// Editing `schedule` or the image updates the CronJob in place; nothing runs
+// until the next tick.
+```
+
+:::note
+A CronJob never runs on deploy. A one-shot Job always does.
+:::
+
+## Effect jobs
+
+Pass `main: import.meta.url` and an init Effect that returns
+`{ run }`. `run` is an `Effect<void, never, …>`. When it returns, the
+process exits 0, so lingering sockets or timers can't keep the pod
+alive. A defect exits 1, a failed attempt against `backoffLimit`.
+
+Init runs before `run`, so resolve bindings there. Bindings work as in
+a Deployment. See
+[The binding contract](/kubernetes/workloads/bindings#the-binding-contract)
+and [Effect servers](/kubernetes/workloads/deployments#effect-servers).
+
+```typescript
+import * as AWS from "alchemy/AWS";
+import * as Kubernetes from "alchemy/Kubernetes";
+import * as Effect from "effect/Effect";
+
+// inside the Stack body (EKS — `main` needs the adapter's managed registry)
+const seed = yield* Kubernetes.Job(
+  "SeedData",
+  { cluster, main: import.meta.url, backoffLimit: 2, ttlSecondsAfterFinished: 600 },
+  Effect.gen(function* () {
+    // init: bindings and clients
+    const putItem = yield* AWS.DynamoDB.PutItem(table);
+    return {
+      // run: executes to completion, then the pod exits 0
+      run: Effect.gen(function* () {
+        yield* putItem({ Item: { pk: { S: "seed#1" }, message: { S: "hello" } } });
+        yield* Effect.log("seeded");
+      }).pipe(Effect.orDie), // a failure exits 1 → counts against backoffLimit
+    };
+  }).pipe(Effect.provide(AWS.DynamoDB.PutItemHttp)),
+);
+```
+
+The [tagged form](/kubernetes/workloads/deployments#the-tagged-form)
+works the same way. `schedule` works with `main` too.
+
+```typescript
+// src/backfill.ts — the tagged form (same shape as a tagged Deployment)
+export class Backfill extends Kubernetes.Job<Backfill, {
+  progress: () => Effect.Effect<number>;
+}>()("Backfill") {}
+
+export default Backfill.make(
+  Effect.gen(function* () {
+    const cluster = yield* Cluster;
+    return { cluster, main: import.meta.url, schedule: "0 3 * * *" }; // an Effect CronJob
+  }),
+  Effect.gen(function* () {
+    return {
+      run: Effect.log("backfilling…"),
+      progress: () => Effect.succeed(0),
+    };
+  }),
+);
+```
+
+:::caution[`main` needs a managed registry]
+Today only the EKS adapter has one. On a kubeconfig cluster use
+`image:` with `command` / `args`. See
+[Registry requirement](/kubernetes/workloads/image-sources#registry-requirement).
+:::
+
+## Updates and replacement
+
+Replacement happens on a `cluster` identity change or a `namespace`
+change, as in the Deployment's
+[Updates and replacement](/kubernetes/workloads/deployments#updates-and-replacement).
+Content drift in `main`, `context`, or `image` surfaces through
+`code.hash`.
+
+For a one-shot Job an update deletes the old Job, applies a new one,
+and runs it. For a CronJob it is an in-place edit. Removed objects are
+pruned per
+[Pruning and drift](/kubernetes/guides/how-apply-works#pruning-and-drift).
+
+`name` is not sticky. The base name is recomputed on every reconcile
+and only the ServiceAccount's name is kept, so changing `name` renames
+the Job or CronJob, and a renamed one-shot Job runs.
+
+| Change                                         | One-shot Job                              | CronJob                    |
+| ---------------------------------------------- | ----------------------------------------- | -------------------------- |
+| `cluster` identity, `namespace`                | replace                                   | replace                    |
+| image, `args`, `env`, `backoffLimit`, `podTemplate`, code edit | new content-addressed Job — runs | in-place edit, no run   |
+| `schedule` added / removed                     | Job deleted, CronJob created              | CronJob deleted, Job created — runs |
+| `name`                                         | renamed — runs                            | renamed, no run            |
+| nothing                                        | no-op, does not re-run                    | no-op                      |
+
+## Where next
+
+- [Image sources](/kubernetes/workloads/image-sources) — `main`,
+  `context`, `image`: which to use and why `main` needs a registry.
+- [Bindings](/kubernetes/workloads/bindings) — env and Pod Identity
+  bindings inside `run`.
+- [Manifests](/kubernetes/objects/manifests) — when you need CronJob
+  fields Alchemy doesn't expose.
+- [`Job` reference](/providers/kubernetes/job) — every prop and
+  attribute.

--- a/website/src/content/docs/kubernetes/workloads/jobs.mdx
+++ b/website/src/content/docs/kubernetes/workloads/jobs.mdx
@@ -1,14 +1,12 @@
 ---
 title: Jobs
-description: Run-to-completion and scheduled work with Kubernetes.Job — retries, TTL, what a redeploy does to a finished Job, CronJobs via schedule, and Effect jobs that return run.
+description: Run-to-completion and scheduled work with Kubernetes.Job — retries, TTL, what a redeploy does, CronJobs via schedule, and Effect jobs that return run.
 ---
 
 A [`Kubernetes.Job`](/providers/kubernetes/job) runs a container to
-completion, the Kubernetes analog of `AWS.ECS.Task`. It takes the
-same `cluster`, the same
-[three image sources](/kubernetes/workloads/image-sources#three-sources),
-and the same bindings as a Deployment. There is no Service and no
-`url`. The pod exits when the work is done.
+completion. It takes the same `cluster`,
+[image sources](/kubernetes/workloads/image-sources#three-sources),
+and bindings as a Deployment, but has no Service and no `url`.
 
 ```typescript
 // inside the Stack body
@@ -23,49 +21,17 @@ migrate.jobName; // "<stack>-dbmigrate-<stage>-<suffix>-<8-char spec hash>"
 migrate.kind;    // "Job"
 ```
 
-Applying a `batch/v1` Job starts it, so the Job runs on deploy. The
-deploy does not wait for it to finish. Objects follow the
-[same naming and label scheme](/kubernetes/workloads/deployments#what-gets-created)
-as a Deployment, with one twist in the Job's own name.
-
 ## Jobs
 
-A Job resource applies a `ServiceAccount` then a `batch/v1 Job` with
-[server-side apply](/kubernetes/guides/how-apply-works#server-side-apply).
-The container env is a Deployment's minus `PORT`. See
-[What gets created](/kubernetes/workloads/deployments#what-gets-created).
-The shared props (`resources`, `env`, `namespace`, `labels`,
-`podTemplate`, `architecture`, `identity`, `tags`) are in
-[Props by group](/kubernetes/workloads/deployments#props-by-group).
+A Job applies a `ServiceAccount` then a `batch/v1 Job`, named
+[like a Deployment](/kubernetes/workloads/deployments#what-gets-created)
+with the same [props](/kubernetes/workloads/deployments#props-by-group).
+Applying it runs it; the deploy does not wait.
 
-A Job's pod template is immutable, so Alchemy content-addresses
-one-shot Jobs. The name is the base name (truncated to 54 characters)
-plus 8 hex characters of a SHA-256 over `backoffLimit`,
-`ttlSecondsAfterFinished`, and the pod template. The ServiceAccount
-keeps the plain base name. Names cap at 63 characters because
-Kubernetes stamps the Job name into a pod label.
-
-A redeploy with no changes is a no-op. Any spec change (image, `args`,
-`env`, a binding's env, a `main` edit, `backoffLimit`) produces a new
-name. The old Job and its pods are deleted, the new one is applied,
-and it runs.
-
-`restartPolicy` (`"Never"` default, or `"OnFailure"`) is pod-level.
-With `Never` each failed attempt is a new pod and the failed one stays
-for `kubectl logs`. With `OnFailure` the container restarts in place.
-
-`backoffLimit` is the number of retries before the Job is `Failed`.
-Kubernetes defaults to 6, backing off 10s, 20s, 40s, capped at 6
-minutes.
-
-`ttlSecondsAfterFinished` is the seconds after success or failure
-before Kubernetes garbage-collects the Job and its pods. Unset means
-never. Set it on anything you deploy repeatedly. If TTL has already
-collected the Job and a later deploy reconciles an unchanged spec (a
-`tags` change, say), the same-named Job is re-created and runs again.
-
-`command` / `args` pick what the container does for `image` and
-`context` sources.
+The name carries a hash of the spec: an unchanged redeploy is a no-op,
+any spec change deletes the old Job and runs a new one (bump an env
+var to force a re-run). Set `ttlSecondsAfterFinished` on anything you
+deploy repeatedly.
 
 ```typescript
 const backfill = yield* Kubernetes.Job("Backfill", {
@@ -87,47 +53,17 @@ const backfill = yield* Kubernetes.Job("Backfill", {
 // changed is a no-op — the Job does not run twice.
 ```
 
-:::note[Re-running a Job]
-A Job re-runs exactly when its spec changes. To force a re-run, bump
-an env var (`env: { RUN: "2" }`).
-:::
-
 :::caution
-`alchemy deploy` returns as soon as the Job is applied. A failed Job
-does not fail the deploy. Check it with
-`kubectl get job <jobName> -n <namespace>` and
-`kubectl logs job/<jobName>`, or see
+A failed Job does not fail the deploy; see
 [Debugging](/kubernetes/guides/how-apply-works#debugging).
 :::
 
-Attributes: `connection`, `namespace`, `kind` (`"Job"` or
-`"CronJob"`), `jobName`, `schedule`, `serviceAccountName`, `imageUri`,
-`identity`, `registry`, `kubernetesObjects`, `code.hash`. All are in
-the [reference](/providers/kubernetes/job).
-
 ## CronJobs
 
-Set `schedule` to a 5-field cron expression and Alchemy synthesizes a
-`batch/v1 CronJob`. `kind` becomes `"CronJob"`. `backoffLimit`,
-`ttlSecondsAfterFinished`, `restartPolicy`, and the pod template go
-into `jobTemplate` unchanged.
-
-A CronJob is mutable, so it keeps the base name (truncated to 52
-characters) and updates in place. Nothing runs on deploy. Adding or
-removing `schedule` swaps the kind: the old object is deleted and the
-new kind applied. Removing it applies a one-shot Job, which runs.
-
-The cluster's controller manager interprets the expression, usually
-in UTC on managed clusters. `concurrencyPolicy`, `timeZone`,
-`startingDeadlineSeconds`, `successfulJobsHistoryLimit`, and
-`failedJobsHistoryLimit` have no props, and
-[`podTemplate`](/kubernetes/workloads/pod-template#merge-rules)
-reaches only the pod template inside `jobTemplate`. To set them,
-write the CronJob as a
+Set `schedule` to a 5-field cron expression and Alchemy applies a
+`batch/v1 CronJob` instead, which updates in place and never runs on
+deploy. Fields without props (`concurrencyPolicy`, `timeZone`) need a
 [`Kubernetes.Manifest`](/kubernetes/objects/manifests#any-object).
-
-Every tick creates a Job, so set `ttlSecondsAfterFinished`. Without
-it Kubernetes keeps the last 3 successful and 1 failed Job by default.
 
 ```typescript
 const nightly = yield* Kubernetes.Job("NightlyReport", {
@@ -147,21 +83,12 @@ nightly.schedule; // "0 3 * * *"
 // until the next tick.
 ```
 
-:::note
-A CronJob never runs on deploy. A one-shot Job always does.
-:::
-
 ## Effect jobs
 
 Pass `main: import.meta.url` and an init Effect that returns
-`{ run }`. `run` is an `Effect<void, never, …>`. When it returns, the
-process exits 0, so lingering sockets or timers can't keep the pod
-alive. A defect exits 1, a failed attempt against `backoffLimit`.
-
-Init runs before `run`, so resolve bindings there. Bindings work as in
-a Deployment. See
-[The binding contract](/kubernetes/workloads/bindings#the-binding-contract)
-and [Effect servers](/kubernetes/workloads/deployments#effect-servers).
+`{ run }`. When `run` returns the process exits 0; a defect exits 1
+and counts against `backoffLimit`. Bindings resolve in init, as in
+[Effect servers](/kubernetes/workloads/deployments#effect-servers).
 
 ```typescript
 import * as AWS from "alchemy/AWS";
@@ -187,7 +114,7 @@ const seed = yield* Kubernetes.Job(
 ```
 
 The [tagged form](/kubernetes/workloads/deployments#the-tagged-form)
-works the same way. `schedule` works with `main` too.
+works the same way, and `schedule` works with `main`.
 
 ```typescript
 // src/backfill.ts — the tagged form (same shape as a tagged Deployment)
@@ -209,44 +136,12 @@ export default Backfill.make(
 );
 ```
 
-:::caution[`main` needs a managed registry]
-Today only the EKS adapter has one. On a kubeconfig cluster use
-`image:` with `command` / `args`. See
-[Registry requirement](/kubernetes/workloads/image-sources#registry-requirement).
-:::
-
-## Updates and replacement
-
-Replacement happens on a `cluster` identity change or a `namespace`
-change, as in the Deployment's
-[Updates and replacement](/kubernetes/workloads/deployments#updates-and-replacement).
-Content drift in `main`, `context`, or `image` surfaces through
-`code.hash`.
-
-For a one-shot Job an update deletes the old Job, applies a new one,
-and runs it. For a CronJob it is an in-place edit. Removed objects are
-pruned per
-[Pruning and drift](/kubernetes/guides/how-apply-works#pruning-and-drift).
-
-`name` is not sticky. The base name is recomputed on every reconcile
-and only the ServiceAccount's name is kept, so changing `name` renames
-the Job or CronJob, and a renamed one-shot Job runs.
-
-| Change                                         | One-shot Job                              | CronJob                    |
-| ---------------------------------------------- | ----------------------------------------- | -------------------------- |
-| `cluster` identity, `namespace`                | replace                                   | replace                    |
-| image, `args`, `env`, `backoffLimit`, `podTemplate`, code edit | new content-addressed Job — runs | in-place edit, no run   |
-| `schedule` added / removed                     | Job deleted, CronJob created              | CronJob deleted, Job created — runs |
-| `name`                                         | renamed — runs                            | renamed, no run            |
-| nothing                                        | no-op, does not re-run                    | no-op                      |
+`main` needs a
+[managed registry](/kubernetes/workloads/image-sources#registry-requirement);
+on a kubeconfig cluster use `image:` with `command` / `args`.
 
 ## Where next
 
-- [Image sources](/kubernetes/workloads/image-sources) — `main`,
-  `context`, `image`: which to use and why `main` needs a registry.
-- [Bindings](/kubernetes/workloads/bindings) — env and Pod Identity
-  bindings inside `run`.
-- [Manifests](/kubernetes/objects/manifests) — when you need CronJob
-  fields Alchemy doesn't expose.
-- [`Job` reference](/providers/kubernetes/job) — every prop and
-  attribute.
+- [Image sources](/kubernetes/workloads/image-sources)
+- [Bindings](/kubernetes/workloads/bindings)
+- [`Job` reference](/providers/kubernetes/job)

--- a/website/src/content/docs/kubernetes/workloads/pod-template.mdx
+++ b/website/src/content/docs/kubernetes/workloads/pod-template.mdx
@@ -3,16 +3,14 @@ title: Pod template
 description: Tune the Pod template Alchemy synthesizes for a Deployment or Job with a deep-partial `podTemplate` — the merge rules, what they make easy, what they make dangerous, and recipes for the common knobs.
 ---
 
-`podTemplate` is the escape hatch for what the Deployment and Job
-props don't cover: a deep-partial `PodTemplateSpec` merged onto the
-one Alchemy synthesizes. Objects recurse, arrays and primitives
-replace. `containers` is an array, which is the one footgun.
+`podTemplate` is a deep-partial `PodTemplateSpec` merged onto the one
+Alchemy synthesizes for a Deployment or Job. Objects recurse, arrays
+and primitives replace.
 
 ## What Alchemy synthesizes
 
-This is the base your override merges onto. `command`, `args`,
-`resources`, `env`, and `port` already target the container, so
-reach for the prop first.
+`command`, `args`, `resources`, `env`, and `port` already target the
+container, so reach for the prop first.
 
 ```typescript
 // The base `podTemplate` the reconciler builds before your override is merged.
@@ -34,36 +32,15 @@ reach for the prop first.
 }
 ```
 
-The `env` list comes from
-[bindings](/kubernetes/workloads/bindings#the-binding-contract), the
-adapter, `ALCHEMY_*`, `PORT`, and your `env` prop, in the precedence
-[What gets created](/kubernetes/workloads/deployments#what-gets-created)
-owns. It is a plain `name`/`value` array inside `containers[0]`, so a
-container override must restate whatever it relies on.
-
-`labels` lands on `metadata.labels` and on the Deployment's selector.
-Labels under `podTemplate.metadata.labels` reach the pod only. A
-[Job](/kubernetes/workloads/jobs#jobs) adds `restartPolicy` and has
-no `ports` and no `PORT`. The same template serves `Job` and
-`CronJob`, so you never nest `jobTemplate`.
-
 The base has no `volumes`, `initContainers`, `tolerations`,
-`affinity`, `securityContext`, or `imagePullSecrets`, so adding them
-is clean.
+`affinity`, `securityContext`, or `imagePullSecrets`.
 
 ## Merge rules
 
-Objects merge recursively: `{ spec: { nodeSelector: { pool: "arm" } } }`
-adds one key under `spec`. Arrays replace wholesale, with no
-element-wise or by-name merge. Primitives replace:
-`spec.serviceAccountName: "other"` swaps the generated ServiceAccount,
-and on EKS that breaks
-[Pod Identity](/kubernetes/workloads/bindings#pod-identity-on-eks),
-whose association is keyed on the generated name.
-
-Keys absent from the base are simply set, so pod-level arrays
-(`volumes`, `tolerations`, `initContainers`, `imagePullSecrets`) are
-safe. `containers` is the one array the base already has.
+Objects merge recursively, arrays replace wholesale, primitives
+replace. `containers` is the one array the base already has.
+`spec.serviceAccountName` swaps the generated ServiceAccount and on
+EKS breaks [Pod Identity](/kubernetes/workloads/bindings#pod-identity-on-eks).
 
 ```typescript
 // ❌ Intent: add a readiness probe. Result: `containers` becomes this ONE
@@ -86,30 +63,18 @@ spec: {
 }
 ```
 
-:::caution[spec.containers replaces the synthesized container]
-Setting `spec.containers` means restating the whole container:
-`name`, `image`, `ports`, and every `env` entry you rely on. That is
-only possible with `image:` sources. With `main` or `context` the
-image URI is
-[computed at deploy time](/kubernetes/workloads/image-sources#three-sources),
-so write a `Manifest` instead (see below).
-:::
-
-`podTemplate` is a plain prop. A change is an in-place update through
-the same
-[server-side apply](/kubernetes/guides/how-apply-works#server-side-apply)
-path as everything else, which is where an invalid container is
-rejected. On a [Job](/kubernetes/workloads/jobs#jobs) it means a new
-run.
+A `podTemplate` change is an in-place
+[server-side apply](/kubernetes/guides/how-apply-works#server-side-apply),
+which is where an invalid container is rejected.
 
 ## Container-level fields
 
 Anything under `containers[0]` that is not a prop (probes,
-`volumeMounts`, `envFrom`, `valueFrom` env entries,
-`imagePullPolicy`, container `securityContext`, `lifecycle`, extra
-`ports`) needs the full-container override, which only works with
-[`image:` sources](/kubernetes/workloads/image-sources#three-sources).
-This is the canonical shape the recipes refer back to.
+`volumeMounts`, `envFrom`, `valueFrom`, `imagePullPolicy`, container
+`securityContext`) needs the full-container override. The image URI of
+`main` and `context` is
+[computed at deploy time](/kubernetes/workloads/image-sources#three-sources),
+so this only works with `image:`.
 
 ```typescript
 const api = yield* Kubernetes.Deployment("Api", {
@@ -133,32 +98,18 @@ const api = yield* Kubernetes.Deployment("Api", {
 });
 ```
 
-The override replaces the container the `env`, `resources`, and
-`command`/`args` props were written into, so those props are ignored
-for it. Restate them in the override. The
-[`secretKeyRef` example](/kubernetes/workloads/bindings#env-only-bindings),
-the re-tagged images under
-[Using your own images](/kubernetes/clusters/local#using-your-own-images),
-and `envFrom` for [Secrets](/kubernetes/objects/manifests#secrets)
-are all this one pattern.
+A `main:` Effect server has no probe today, so answer `/` quickly.
 
 :::tip
-If the override grows beyond a few lines, write the Deployment as a
-`Kubernetes.Manifest` instead (last section).
+If the override grows beyond a few lines, or you need container-level fields on `main:`, write a [`Kubernetes.Manifest`](/kubernetes/objects/manifests#any-object) instead.
 :::
 
 ## Recipes
 
-Each recipe is a `podTemplate` fragment on an `image:` or `main:`
-Deployment unless it says otherwise. Pod-level fields first, the ones
-that need the container override last.
-
 ### Tolerations and nodeSelector
 
-Both pod-level and absent from the base. Pair
-`nodeSelector: { "kubernetes.io/arch": "arm64" }` with the
-[`architecture: "arm64"`](/kubernetes/workloads/image-sources#architecture)
-prop so the image and the node agree.
+Pair `kubernetes.io/arch` with the
+[`architecture`](/kubernetes/workloads/image-sources#architecture) prop.
 
 ```typescript
 podTemplate: {
@@ -171,9 +122,7 @@ podTemplate: {
 
 ### Affinity and spread
 
-Both pod-level. `podAntiAffinity` needs a label it can name
-literally. The generated `app.kubernetes.io/name` is derived from the
-logical id, so add your own via `labels` and select on that.
+`podAntiAffinity` needs a literal label, so add one via `labels`.
 
 ```typescript
 labels: { app: "api" },
@@ -196,9 +145,9 @@ podTemplate: {
 
 ### Pod securityContext
 
-The pod-level `securityContext` merges cleanly. The container-level
-one (`capabilities`, `readOnlyRootFilesystem`) needs the
-[container override](#container-level-fields).
+Container-level `securityContext` (`capabilities`,
+`readOnlyRootFilesystem`) needs the
+[override](#container-level-fields) instead.
 
 ```typescript
 podTemplate: {
@@ -215,12 +164,8 @@ podTemplate: {
 
 ### imagePullSecrets
 
-For a registry-less cluster pulling a private `image:`. EKS does not
-need this for mirrored images. Create a `kubernetes.io/dockerconfigjson`
-Secret as a [Manifest](/kubernetes/objects/manifests#secrets) and
-reference it by name. The API server base64-encodes `stringData`, so
-read the docker config JSON from the deploy environment with
-`Config.string`.
+For a registry-less cluster pulling a private `image:`; EKS mirrors
+instead. The Secret is a [Manifest](/kubernetes/objects/manifests#secrets).
 
 ```typescript
 import * as Config from "effect/Config";
@@ -245,15 +190,10 @@ const api = yield* Kubernetes.Deployment("Api", {
 });
 ```
 
-Getting the image reachable from a local cluster is covered under
-[Using your own images](/kubernetes/clusters/local#using-your-own-images).
-
 ### Volumes: emptyDir and a PVC from a Manifest
 
-`spec.volumes` is pod-level and merges cleanly. `volumeMounts` is
-container-level and needs the override. The PVC is a
-[Manifest](/kubernetes/objects/manifests#any-object) whose `name`
-feeds `claimName`, so the Deployment deploys after the claim exists.
+`spec.volumes` merges cleanly; `volumeMounts` needs the override. The
+PVC is a [Manifest](/kubernetes/objects/manifests#any-object).
 
 ```typescript
 const data = yield* Kubernetes.Manifest("ApiData", {
@@ -290,17 +230,10 @@ const api = yield* Kubernetes.Deployment("Api", {
 });
 ```
 
-:::note
-A `ReadWriteOnce` PVC with `replicas > 1` leaves the extra replicas
-Pending on a multi-node cluster. That is Kubernetes, not Alchemy.
-:::
-
 ### Sidecar container
 
-Prefer a native sidecar: an `initContainers` entry with
-`restartPolicy: "Always"`. `initContainers` is absent from the base,
-so the main container is untouched and this works for `main:` and
-`context:` sources too.
+A native sidecar (Kubernetes 1.29+) leaves the main container
+untouched, so it works with `main:` and `context:` too.
 
 ```typescript
 podTemplate: {
@@ -316,27 +249,10 @@ podTemplate: {
 },
 ```
 
-Native sidecars need Kubernetes 1.29 or newer. Sharing the volume
-with the main container needs its `volumeMounts`, which brings back
-the override.
-
-### Readiness and liveness probes
-
-Container-level. The block under
-[Container-level fields](#container-level-fields) shows both.
-Without a `readinessProbe` the Service routes to the container as
-soon as it starts, so a slow-to-bind server eats connection errors.
-A `main:` Effect server has no probe today and no way to add one
-short of a Manifest, so answer `/` quickly. When `url` appears is
-under
-[Exposing it](/kubernetes/workloads/deployments#exposing-it-servicetype-and-url).
-
 ### imagePullPolicy
 
-Container-level, so full override. The case is a local cluster where
-you re-tag the same `image:` string or use `:latest`, which is where
-[Using your own images](/kubernetes/clusters/local#using-your-own-images)
-sends you. One new field. Everything else is restated.
+For a local cluster re-tagging the same `image:` string
+([Using your own images](/kubernetes/clusters/local#using-your-own-images)).
 
 ```typescript
 podTemplate: {
@@ -354,9 +270,9 @@ podTemplate: {
 
 ### envFrom a ConfigMap or Secret
 
-Container-level, so full override. Every key of a ConfigMap or
+Every key of a ConfigMap or
 [Secret Manifest](/kubernetes/objects/manifests#secrets) becomes an
-env var. The Manifest's `name` attribute is the reference.
+env var.
 
 ```typescript
 podTemplate: {
@@ -375,13 +291,9 @@ podTemplate: {
 },
 ```
 
-If the values are not secret, the `env` prop with `config.name`
-Outputs (tutorial part 3) needs no override.
-
 ### Annotations and grace period
 
-`metadata.annotations` and `spec.terminationGracePeriodSeconds` both
-merge cleanly. This is the smallest useful `podTemplate`.
+Both merge cleanly.
 
 ```typescript
 podTemplate: {
@@ -392,46 +304,8 @@ podTemplate: {
 },
 ```
 
-## When to write a Manifest instead
-
-Reach for [`Kubernetes.Manifest`](/kubernetes/objects/manifests#any-object)
-when you need container-level fields on a `main:` or `context:`
-source, when the override restates more than the props provide, when
-you need another kind (StatefulSet, DaemonSet), or when you need
-fields outside the template such as Deployment `strategy`,
-`minReadySeconds`, or Service internals beyond `serviceType` and
-`serviceAnnotations`.
-
-You give up everything
-[What gets created](/kubernetes/workloads/deployments#what-gets-created)
-lists: the Service and ServiceAccount, `url`, bindings and Pod
-Identity, image build and mirror. Mixing is normal. Tutorial part 3
-puts an `image:` Deployment next to a Manifest StatefulSet.
-
-```typescript
-// Same app as a Manifest: you own every field, Alchemy owns the lifecycle.
-const api = yield* Kubernetes.Manifest("Api", {
-  cluster,
-  manifest: {
-    apiVersion: "apps/v1",
-    kind: "Deployment",
-    metadata: { name: "api", namespace: "default" },
-    spec: {
-      replicas: 2,
-      strategy: { type: "RollingUpdate", rollingUpdate: { maxUnavailable: 0 } },
-      selector: { matchLabels: { app: "api" } },
-      template: { /* full PodTemplateSpec, no merge */ },
-    },
-  },
-});
-```
-
 ## Where next
 
-- [Manifests](/kubernetes/objects/manifests) — any object as a
-  resource, including the StatefulSets and DaemonSets `podTemplate`
-  can't express.
+- [Manifests](/kubernetes/objects/manifests)
 - [How apply works](/kubernetes/guides/how-apply-works#server-side-apply)
-  — how the merged template is applied and what happens on conflicts.
-- [`Deployment` reference](/providers/kubernetes/deployment) — every
-  prop and attribute.
+- [`Deployment` reference](/providers/kubernetes/deployment)

--- a/website/src/content/docs/kubernetes/workloads/pod-template.mdx
+++ b/website/src/content/docs/kubernetes/workloads/pod-template.mdx
@@ -1,0 +1,437 @@
+---
+title: Pod template
+description: Tune the Pod template Alchemy synthesizes for a Deployment or Job with a deep-partial `podTemplate` — the merge rules, what they make easy, what they make dangerous, and recipes for the common knobs.
+---
+
+`podTemplate` is the escape hatch for what the Deployment and Job
+props don't cover: a deep-partial `PodTemplateSpec` merged onto the
+one Alchemy synthesizes. Objects recurse, arrays and primitives
+replace. `containers` is an array, which is the one footgun.
+
+## What Alchemy synthesizes
+
+This is the base your override merges onto. `command`, `args`,
+`resources`, `env`, and `port` already target the container, so
+reach for the prop first.
+
+```typescript
+// The base `podTemplate` the reconciler builds before your override is merged.
+{
+  metadata: { labels: { "app.kubernetes.io/name": <name>, ...labels } },
+  spec: {
+    serviceAccountName: <name>,          // Job also: restartPolicy: "Never" | "OnFailure"
+    containers: [
+      {
+        name: <name>,
+        image: <resolved imageUri>,       // ECR URI on EKS; your `image` verbatim elsewhere
+        command, args,                    // from props
+        ports: [{ containerPort: port }], // Deployment only
+        env: [ /* name/value pairs — see Deployments → What gets created */ ],
+        resources,                        // from props
+      },
+    ],
+  },
+}
+```
+
+The `env` list comes from
+[bindings](/kubernetes/workloads/bindings#the-binding-contract), the
+adapter, `ALCHEMY_*`, `PORT`, and your `env` prop, in the precedence
+[What gets created](/kubernetes/workloads/deployments#what-gets-created)
+owns. It is a plain `name`/`value` array inside `containers[0]`, so a
+container override must restate whatever it relies on.
+
+`labels` lands on `metadata.labels` and on the Deployment's selector.
+Labels under `podTemplate.metadata.labels` reach the pod only. A
+[Job](/kubernetes/workloads/jobs#jobs) adds `restartPolicy` and has
+no `ports` and no `PORT`. The same template serves `Job` and
+`CronJob`, so you never nest `jobTemplate`.
+
+The base has no `volumes`, `initContainers`, `tolerations`,
+`affinity`, `securityContext`, or `imagePullSecrets`, so adding them
+is clean.
+
+## Merge rules
+
+Objects merge recursively: `{ spec: { nodeSelector: { pool: "arm" } } }`
+adds one key under `spec`. Arrays replace wholesale, with no
+element-wise or by-name merge. Primitives replace:
+`spec.serviceAccountName: "other"` swaps the generated ServiceAccount,
+and on EKS that breaks
+[Pod Identity](/kubernetes/workloads/bindings#pod-identity-on-eks),
+whose association is keyed on the generated name.
+
+Keys absent from the base are simply set, so pod-level arrays
+(`volumes`, `tolerations`, `initContainers`, `imagePullSecrets`) are
+safe. `containers` is the one array the base already has.
+
+```typescript
+// ❌ Intent: add a readiness probe. Result: `containers` becomes this ONE
+// object — no name, no image, no env. The API server rejects the apply
+// (a container needs `name` and `image`) and the deploy fails.
+podTemplate: {
+  spec: {
+    containers: [
+      { readinessProbe: { httpGet: { path: "/health", port: 3000 } } },
+    ],
+  },
+},
+```
+
+```typescript
+// What actually reaches the cluster for that override:
+spec: {
+  serviceAccountName: "api-…",
+  containers: [{ readinessProbe: { httpGet: { path: "/health", port: 3000 } } }],
+}
+```
+
+:::caution[spec.containers replaces the synthesized container]
+Setting `spec.containers` means restating the whole container:
+`name`, `image`, `ports`, and every `env` entry you rely on. That is
+only possible with `image:` sources. With `main` or `context` the
+image URI is
+[computed at deploy time](/kubernetes/workloads/image-sources#three-sources),
+so write a `Manifest` instead (see below).
+:::
+
+`podTemplate` is a plain prop. A change is an in-place update through
+the same
+[server-side apply](/kubernetes/guides/how-apply-works#server-side-apply)
+path as everything else, which is where an invalid container is
+rejected. On a [Job](/kubernetes/workloads/jobs#jobs) it means a new
+run.
+
+## Container-level fields
+
+Anything under `containers[0]` that is not a prop (probes,
+`volumeMounts`, `envFrom`, `valueFrom` env entries,
+`imagePullPolicy`, container `securityContext`, `lifecycle`, extra
+`ports`) needs the full-container override, which only works with
+[`image:` sources](/kubernetes/workloads/image-sources#three-sources).
+This is the canonical shape the recipes refer back to.
+
+```typescript
+const api = yield* Kubernetes.Deployment("Api", {
+  cluster,
+  image: "ghcr.io/acme/api:v3",
+  port: 8080,
+  podTemplate: {
+    spec: {
+      containers: [
+        {
+          name: "api",
+          image: "ghcr.io/acme/api:v3", // same string as `image`
+          ports: [{ containerPort: 8080 }],
+          env: [{ name: "PORT", value: "8080" }], // restate anything you need
+          readinessProbe: { httpGet: { path: "/health", port: 8080 }, periodSeconds: 5 },
+          livenessProbe: { httpGet: { path: "/health", port: 8080 }, initialDelaySeconds: 10 },
+        },
+      ],
+    },
+  },
+});
+```
+
+The override replaces the container the `env`, `resources`, and
+`command`/`args` props were written into, so those props are ignored
+for it. Restate them in the override. The
+[`secretKeyRef` example](/kubernetes/workloads/bindings#env-only-bindings),
+the re-tagged images under
+[Using your own images](/kubernetes/clusters/local#using-your-own-images),
+and `envFrom` for [Secrets](/kubernetes/objects/manifests#secrets)
+are all this one pattern.
+
+:::tip
+If the override grows beyond a few lines, write the Deployment as a
+`Kubernetes.Manifest` instead (last section).
+:::
+
+## Recipes
+
+Each recipe is a `podTemplate` fragment on an `image:` or `main:`
+Deployment unless it says otherwise. Pod-level fields first, the ones
+that need the container override last.
+
+### Tolerations and nodeSelector
+
+Both pod-level and absent from the base. Pair
+`nodeSelector: { "kubernetes.io/arch": "arm64" }` with the
+[`architecture: "arm64"`](/kubernetes/workloads/image-sources#architecture)
+prop so the image and the node agree.
+
+```typescript
+podTemplate: {
+  spec: {
+    tolerations: [{ key: "nvidia.com/gpu", operator: "Exists", effect: "NoSchedule" }],
+    nodeSelector: { "kubernetes.io/arch": "arm64", pool: "gpu" },
+  },
+},
+```
+
+### Affinity and spread
+
+Both pod-level. `podAntiAffinity` needs a label it can name
+literally. The generated `app.kubernetes.io/name` is derived from the
+logical id, so add your own via `labels` and select on that.
+
+```typescript
+labels: { app: "api" },
+podTemplate: {
+  spec: {
+    affinity: {
+      podAntiAffinity: {
+        preferredDuringSchedulingIgnoredDuringExecution: [{
+          weight: 100,
+          podAffinityTerm: {
+            labelSelector: { matchLabels: { app: "api" } },
+            topologyKey: "kubernetes.io/hostname",
+          },
+        }],
+      },
+    },
+  },
+},
+```
+
+### Pod securityContext
+
+The pod-level `securityContext` merges cleanly. The container-level
+one (`capabilities`, `readOnlyRootFilesystem`) needs the
+[container override](#container-level-fields).
+
+```typescript
+podTemplate: {
+  spec: {
+    securityContext: {
+      runAsNonRoot: true,
+      runAsUser: 1000,
+      fsGroup: 1000,
+      seccompProfile: { type: "RuntimeDefault" },
+    },
+  },
+},
+```
+
+### imagePullSecrets
+
+For a registry-less cluster pulling a private `image:`. EKS does not
+need this for mirrored images. Create a `kubernetes.io/dockerconfigjson`
+Secret as a [Manifest](/kubernetes/objects/manifests#secrets) and
+reference it by name. The API server base64-encodes `stringData`, so
+read the docker config JSON from the deploy environment with
+`Config.string`.
+
+```typescript
+import * as Config from "effect/Config";
+
+const pull = yield* Kubernetes.Manifest("GhcrPull", {
+  cluster,
+  manifest: {
+    apiVersion: "v1",
+    kind: "Secret",
+    metadata: { name: "ghcr-pull", namespace: "default" },
+    type: "kubernetes.io/dockerconfigjson",
+    // The contents of ~/.docker/config.json for the registry, from the env.
+    stringData: { ".dockerconfigjson": Config.string("GHCR_DOCKER_CONFIG_JSON") },
+  },
+});
+
+const api = yield* Kubernetes.Deployment("Api", {
+  cluster,
+  image: "ghcr.io/acme/private-api:v3",
+  port: 8080,
+  podTemplate: { spec: { imagePullSecrets: [{ name: pull.name }] } },
+});
+```
+
+Getting the image reachable from a local cluster is covered under
+[Using your own images](/kubernetes/clusters/local#using-your-own-images).
+
+### Volumes: emptyDir and a PVC from a Manifest
+
+`spec.volumes` is pod-level and merges cleanly. `volumeMounts` is
+container-level and needs the override. The PVC is a
+[Manifest](/kubernetes/objects/manifests#any-object) whose `name`
+feeds `claimName`, so the Deployment deploys after the claim exists.
+
+```typescript
+const data = yield* Kubernetes.Manifest("ApiData", {
+  cluster,
+  manifest: {
+    apiVersion: "v1",
+    kind: "PersistentVolumeClaim",
+    metadata: { name: "api-data", namespace: "default" },
+    spec: { accessModes: ["ReadWriteOnce"], resources: { requests: { storage: "10Gi" } } },
+  },
+});
+
+const api = yield* Kubernetes.Deployment("Api", {
+  cluster,
+  image: "ghcr.io/acme/api:v3",
+  port: 8080,
+  podTemplate: {
+    spec: {
+      volumes: [
+        { name: "scratch", emptyDir: {} },
+        { name: "data", persistentVolumeClaim: { claimName: data.name } },
+      ],
+      containers: [{ // full override — container-level mounts
+        name: "api",
+        image: "ghcr.io/acme/api:v3",
+        ports: [{ containerPort: 8080 }],
+        volumeMounts: [
+          { name: "scratch", mountPath: "/tmp/scratch" },
+          { name: "data", mountPath: "/var/lib/api" },
+        ],
+      }],
+    },
+  },
+});
+```
+
+:::note
+A `ReadWriteOnce` PVC with `replicas > 1` leaves the extra replicas
+Pending on a multi-node cluster. That is Kubernetes, not Alchemy.
+:::
+
+### Sidecar container
+
+Prefer a native sidecar: an `initContainers` entry with
+`restartPolicy: "Always"`. `initContainers` is absent from the base,
+so the main container is untouched and this works for `main:` and
+`context:` sources too.
+
+```typescript
+podTemplate: {
+  spec: {
+    initContainers: [{
+      name: "log-shipper",
+      image: "fluent/fluent-bit:3.1",
+      restartPolicy: "Always", // native sidecar: starts before, outlives the app container
+      volumeMounts: [{ name: "scratch", mountPath: "/var/log/app" }],
+    }],
+    volumes: [{ name: "scratch", emptyDir: {} }],
+  },
+},
+```
+
+Native sidecars need Kubernetes 1.29 or newer. Sharing the volume
+with the main container needs its `volumeMounts`, which brings back
+the override.
+
+### Readiness and liveness probes
+
+Container-level. The block under
+[Container-level fields](#container-level-fields) shows both.
+Without a `readinessProbe` the Service routes to the container as
+soon as it starts, so a slow-to-bind server eats connection errors.
+A `main:` Effect server has no probe today and no way to add one
+short of a Manifest, so answer `/` quickly. When `url` appears is
+under
+[Exposing it](/kubernetes/workloads/deployments#exposing-it-servicetype-and-url).
+
+### imagePullPolicy
+
+Container-level, so full override. The case is a local cluster where
+you re-tag the same `image:` string or use `:latest`, which is where
+[Using your own images](/kubernetes/clusters/local#using-your-own-images)
+sends you. One new field. Everything else is restated.
+
+```typescript
+podTemplate: {
+  spec: {
+    containers: [{
+      name: "api",
+      image: "my-api:dev", // same string as `image`
+      imagePullPolicy: "IfNotPresent", // the one field you came for
+      ports: [{ containerPort: 8080 }],
+      env: [{ name: "PORT", value: "8080" }],
+    }],
+  },
+},
+```
+
+### envFrom a ConfigMap or Secret
+
+Container-level, so full override. Every key of a ConfigMap or
+[Secret Manifest](/kubernetes/objects/manifests#secrets) becomes an
+env var. The Manifest's `name` attribute is the reference.
+
+```typescript
+podTemplate: {
+  spec: {
+    containers: [{
+      name: "api",
+      image: "ghcr.io/acme/api:v3",
+      ports: [{ containerPort: 8080 }],
+      env: [{ name: "PORT", value: "8080" }],
+      envFrom: [
+        { configMapRef: { name: config.name } },
+        { secretRef: { name: dbSecret.name } },
+      ],
+    }],
+  },
+},
+```
+
+If the values are not secret, the `env` prop with `config.name`
+Outputs (tutorial part 3) needs no override.
+
+### Annotations and grace period
+
+`metadata.annotations` and `spec.terminationGracePeriodSeconds` both
+merge cleanly. This is the smallest useful `podTemplate`.
+
+```typescript
+podTemplate: {
+  metadata: {
+    annotations: { "prometheus.io/scrape": "true", "prometheus.io/port": "3000" },
+  },
+  spec: { terminationGracePeriodSeconds: 30 },
+},
+```
+
+## When to write a Manifest instead
+
+Reach for [`Kubernetes.Manifest`](/kubernetes/objects/manifests#any-object)
+when you need container-level fields on a `main:` or `context:`
+source, when the override restates more than the props provide, when
+you need another kind (StatefulSet, DaemonSet), or when you need
+fields outside the template such as Deployment `strategy`,
+`minReadySeconds`, or Service internals beyond `serviceType` and
+`serviceAnnotations`.
+
+You give up everything
+[What gets created](/kubernetes/workloads/deployments#what-gets-created)
+lists: the Service and ServiceAccount, `url`, bindings and Pod
+Identity, image build and mirror. Mixing is normal. Tutorial part 3
+puts an `image:` Deployment next to a Manifest StatefulSet.
+
+```typescript
+// Same app as a Manifest: you own every field, Alchemy owns the lifecycle.
+const api = yield* Kubernetes.Manifest("Api", {
+  cluster,
+  manifest: {
+    apiVersion: "apps/v1",
+    kind: "Deployment",
+    metadata: { name: "api", namespace: "default" },
+    spec: {
+      replicas: 2,
+      strategy: { type: "RollingUpdate", rollingUpdate: { maxUnavailable: 0 } },
+      selector: { matchLabels: { app: "api" } },
+      template: { /* full PodTemplateSpec, no merge */ },
+    },
+  },
+});
+```
+
+## Where next
+
+- [Manifests](/kubernetes/objects/manifests) — any object as a
+  resource, including the StatefulSets and DaemonSets `podTemplate`
+  can't express.
+- [How apply works](/kubernetes/guides/how-apply-works#server-side-apply)
+  — how the merged template is applied and what happens on conflicts.
+- [`Deployment` reference](/providers/kubernetes/deployment) — every
+  prop and attribute.

--- a/website/src/content/docs/kubernetes/workloads/pod-template.mdx
+++ b/website/src/content/docs/kubernetes/workloads/pod-template.mdx
@@ -1,19 +1,19 @@
 ---
 title: Pod template
-description: Tune the Pod template Alchemy synthesizes for a Deployment or Job with a deep-partial `podTemplate` — the merge rules, what they make easy, what they make dangerous, and recipes for the common knobs.
+description: Customize the pod spec of a Kubernetes Deployment or Job with podTemplate, including merge rules, container overrides, and recipes for common settings.
 ---
 
-`podTemplate` is a deep-partial `PodTemplateSpec` merged onto the one
-Alchemy synthesizes for a Deployment or Job. Objects recurse, arrays
-and primitives replace.
+`podTemplate` is a partial `PodTemplateSpec` merged onto the default
+one for a Deployment or Job. Objects merge, arrays and primitives
+replace.
 
-## What Alchemy synthesizes
+## The default pod template
 
-`command`, `args`, `resources`, `env`, and `port` already target the
-container, so reach for the prop first.
+`command`, `args`, `resources`, `env`, and `port` already set the
+container, so use the prop when one exists.
 
 ```typescript
-// The base `podTemplate` the reconciler builds before your override is merged.
+// The pod template your `podTemplate` is merged onto.
 {
   metadata: { labels: { "app.kubernetes.io/name": <name>, ...labels } },
   spec: {
@@ -21,10 +21,10 @@ container, so reach for the prop first.
     containers: [
       {
         name: <name>,
-        image: <resolved imageUri>,       // ECR URI on EKS; your `image` verbatim elsewhere
+        image: <imageUri>,                // ECR URI on EKS; your `image` elsewhere
         command, args,                    // from props
         ports: [{ containerPort: port }], // Deployment only
-        env: [ /* name/value pairs — see Deployments → What gets created */ ],
+        env: [ /* ALCHEMY_*, PORT, your env */ ],
         resources,                        // from props
       },
     ],
@@ -32,20 +32,20 @@ container, so reach for the prop first.
 }
 ```
 
-The base has no `volumes`, `initContainers`, `tolerations`,
+The default has no `volumes`, `initContainers`, `tolerations`,
 `affinity`, `securityContext`, or `imagePullSecrets`.
 
 ## Merge rules
 
-Objects merge recursively, arrays replace wholesale, primitives
-replace. `containers` is the one array the base already has.
-`spec.serviceAccountName` swaps the generated ServiceAccount and on
-EKS breaks [Pod Identity](/kubernetes/workloads/bindings#pod-identity-on-eks).
+Objects merge recursively; arrays and primitives replace. `containers`
+is the one array the default already fills. Don't set
+`spec.serviceAccountName`: on EKS it breaks
+[Pod Identity](/kubernetes/workloads/bindings#pod-identity-on-eks).
 
 ```typescript
-// ❌ Intent: add a readiness probe. Result: `containers` becomes this ONE
-// object — no name, no image, no env. The API server rejects the apply
-// (a container needs `name` and `image`) and the deploy fails.
+// ❌ Adding a readiness probe like this replaces `containers` with this
+// ONE object: no name, no image, no env. The deploy fails because a
+// container needs `name` and `image`.
 podTemplate: {
   spec: {
     containers: [
@@ -56,25 +56,21 @@ podTemplate: {
 ```
 
 ```typescript
-// What actually reaches the cluster for that override:
+// What reaches the cluster for that override:
 spec: {
   serviceAccountName: "api-…",
   containers: [{ readinessProbe: { httpGet: { path: "/health", port: 3000 } } }],
 }
 ```
 
-A `podTemplate` change is an in-place
-[server-side apply](/kubernetes/guides/how-apply-works#server-side-apply),
-which is where an invalid container is rejected.
+Changing `podTemplate` updates the workload
+[in place](/kubernetes/guides/how-apply-works#server-side-apply).
 
 ## Container-level fields
 
-Anything under `containers[0]` that is not a prop (probes,
-`volumeMounts`, `envFrom`, `valueFrom`, `imagePullPolicy`, container
-`securityContext`) needs the full-container override. The image URI of
-`main` and `context` is
-[computed at deploy time](/kubernetes/workloads/image-sources#three-sources),
-so this only works with `image:`.
+Anything on the container that is not a prop (probes, `volumeMounts`,
+`envFrom`, `valueFrom`, `imagePullPolicy`, container `securityContext`)
+needs the full container override. Works with `image:` only.
 
 ```typescript
 const api = yield* Kubernetes.Deployment("Api", {
@@ -98,7 +94,7 @@ const api = yield* Kubernetes.Deployment("Api", {
 });
 ```
 
-A `main:` Effect server has no probe today, so answer `/` quickly.
+A `main:` Effect server gets no probe, so answer `/` quickly.
 
 :::tip
 If the override grows beyond a few lines, or you need container-level fields on `main:`, write a [`Kubernetes.Manifest`](/kubernetes/objects/manifests#any-object) instead.
@@ -108,7 +104,7 @@ If the override grows beyond a few lines, or you need container-level fields on 
 
 ### Tolerations and nodeSelector
 
-Pair `kubernetes.io/arch` with the
+Match `kubernetes.io/arch` to the
 [`architecture`](/kubernetes/workloads/image-sources#architecture) prop.
 
 ```typescript
@@ -122,7 +118,7 @@ podTemplate: {
 
 ### Affinity and spread
 
-`podAntiAffinity` needs a literal label, so add one via `labels`.
+`podAntiAffinity` needs a literal label, so add one with `labels`.
 
 ```typescript
 labels: { app: "api" },
@@ -147,7 +143,7 @@ podTemplate: {
 
 Container-level `securityContext` (`capabilities`,
 `readOnlyRootFilesystem`) needs the
-[override](#container-level-fields) instead.
+[container override](#container-level-fields).
 
 ```typescript
 podTemplate: {
@@ -164,8 +160,9 @@ podTemplate: {
 
 ### imagePullSecrets
 
-For a registry-less cluster pulling a private `image:`; EKS mirrors
-instead. The Secret is a [Manifest](/kubernetes/objects/manifests#secrets).
+Pull a private `image:` on a cluster without a registry (EKS doesn't
+need this). Create the Secret as a
+[Manifest](/kubernetes/objects/manifests#secrets).
 
 ```typescript
 import * as Config from "effect/Config";
@@ -177,7 +174,7 @@ const pull = yield* Kubernetes.Manifest("GhcrPull", {
     kind: "Secret",
     metadata: { name: "ghcr-pull", namespace: "default" },
     type: "kubernetes.io/dockerconfigjson",
-    // The contents of ~/.docker/config.json for the registry, from the env.
+    // The contents of ~/.docker/config.json for the registry, read from the env.
     stringData: { ".dockerconfigjson": Config.string("GHCR_DOCKER_CONFIG_JSON") },
   },
 });
@@ -192,8 +189,8 @@ const api = yield* Kubernetes.Deployment("Api", {
 
 ### Volumes: emptyDir and a PVC from a Manifest
 
-`spec.volumes` merges cleanly; `volumeMounts` needs the override. The
-PVC is a [Manifest](/kubernetes/objects/manifests#any-object).
+`spec.volumes` merges in; `volumeMounts` needs the container override.
+The PVC is a [Manifest](/kubernetes/objects/manifests#any-object).
 
 ```typescript
 const data = yield* Kubernetes.Manifest("ApiData", {
@@ -216,7 +213,7 @@ const api = yield* Kubernetes.Deployment("Api", {
         { name: "scratch", emptyDir: {} },
         { name: "data", persistentVolumeClaim: { claimName: data.name } },
       ],
-      containers: [{ // full override — container-level mounts
+      containers: [{ // full override: mounts are container-level
         name: "api",
         image: "ghcr.io/acme/api:v3",
         ports: [{ containerPort: 8080 }],
@@ -241,7 +238,7 @@ podTemplate: {
     initContainers: [{
       name: "log-shipper",
       image: "fluent/fluent-bit:3.1",
-      restartPolicy: "Always", // native sidecar: starts before, outlives the app container
+      restartPolicy: "Always", // native sidecar: starts before the app, stops after it
       volumeMounts: [{ name: "scratch", mountPath: "/var/log/app" }],
     }],
     volumes: [{ name: "scratch", emptyDir: {} }],
@@ -260,7 +257,7 @@ podTemplate: {
     containers: [{
       name: "api",
       image: "my-api:dev", // same string as `image`
-      imagePullPolicy: "IfNotPresent", // the one field you came for
+      imagePullPolicy: "IfNotPresent", // pull only if the node doesn't have it
       ports: [{ containerPort: 8080 }],
       env: [{ name: "PORT", value: "8080" }],
     }],
@@ -293,7 +290,7 @@ podTemplate: {
 
 ### Annotations and grace period
 
-Both merge cleanly.
+Both merge in.
 
 ```typescript
 podTemplate: {

--- a/website/src/docs-tabs.ts
+++ b/website/src/docs-tabs.ts
@@ -55,6 +55,12 @@ export const DOCS_TABS: DocsTab[] = [
     slot: "primary",
   },
   {
+    label: "Kubernetes",
+    href: "/kubernetes",
+    prefixes: ["/kubernetes", "/providers/kubernetes"],
+    slot: "primary",
+  },
+  {
     label: "PlanetScale",
     href: "/planetscale",
     prefixes: ["/planetscale", "/providers/planetscale"],


### PR DESCRIPTION
Kubernetes gets its own docs hub. The thesis: one workload model for any cluster — `Deployment`, `Job`, `Manifest`, `HelmChart` point at a kubeconfig context, a raw connection, or a managed cluster, and the cluster's adapter decides what comes for free (auth only, or auth + workload identity + image registry on EKS).

```
/kubernetes
├─ Overview · Setup
├─ Tutorial    part 1–4 on a local cluster (image:, Job/CronJob, Manifests, Helm), part 5 moves the same program to EKS
├─ Clusters    connecting · local clusters · Amazon EKS
├─ Workloads   deployments · jobs · image sources · bindings · pod template
├─ Objects     manifests · helm charts
├─ Guides      exposing services · how apply works · writing a cluster adapter
└─ Resources   generated reference
```

- New `Kubernetes` tab (`docs-tabs.ts`), sidebar group, and reference-directory card; `/providers/kubernetes/*` now belong to the hub tab instead of the bare Reference tab.
- `aws/compute/eks` keeps cluster provisioning (Network, Cluster, AccessEntry, Addon, HyperPod) and hands workloads off to the hub; `choosing-a-runtime` and the AWS index link the hub.
- `examples/kubernetes-local`: the tutorial's end state on any kubeconfig cluster, no registry needed.

Tutorial parts 1–4 were run end to end on a kind cluster. Two provider bugs surfaced and are fixed here:

```diff
 // Kubernetes/internal/client.ts — deleteObject
-        path,
+        // batch/v1 Jobs default to Orphan propagation, leaving pods behind
+        path: `${path}?propagationPolicy=Background`,
```

```diff
 // Kubernetes/HelmChart.ts — default releaseName
-    return createPhysicalName({ id, lowercase: true });
+    return createPhysicalName({ id, lowercase: true, maxLength: 53 });
```

Before the second fix, a stack named `KubernetesLocalExample` failed `helm template` with `release name … must not be longer than 53`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
