### PR TITLE
fix(aws/apprunner)!: reap the service's auto-created log groups on delete

### DIFF
--- a/packages/alchemy/src/AWS/AppRunner/Service.ts
+++ b/packages/alchemy/src/AWS/AppRunner/Service.ts
@@ -298,6 +298,22 @@ export interface ServiceProps extends PlatformProps {
    */
   kmsKeyArn?: string;
   /**
+   * Keep the CloudWatch log groups App Runner auto-creates for the service
+   * (`/aws/apprunner/{serviceName}/{serviceId}/application` and
+   * `.../service`) when the service is deleted.
+   *
+   * By default they are deleted along with the service — App Runner itself
+   * leaves them behind, so every deploy+destroy cycle would otherwise
+   * strand a pair. Set this when the logs must outlive the service (an
+   * incident post-mortem, a compliance retention window). The kept groups
+   * are inert: their names embed the service id, so no future service ever
+   * writes to them, and nothing but a manual delete (or
+   * `alchemy unsafe nuke`) removes them.
+   *
+   * @default false
+   */
+  retainLogGroups?: boolean;
+  /**
    * User-defined tags for the service.
    */
   tags?: Record<string, string>;
@@ -1687,7 +1703,7 @@ await Effect.runPromise(program).catch((err) => {
           return toAttrs(observed, platformAttributes);
         }),
 
-        delete: Effect.fn(function* ({ output }) {
+        delete: Effect.fn(function* ({ olds, output, force }) {
           // A service mid-operation rejects deletion with
           // InvalidStateException — wait (bounded) for it to settle first.
           const observed = yield* waitForSettled(output.serviceArn);
@@ -1768,11 +1784,19 @@ await Effect.runPromise(program).catch((err) => {
           // Last, because the reap can sit through App Runner's final log
           // flush: an interruption during that window must not strand the
           // repository or the roles, which cost money and block re-creates.
-          for (const logGroupName of logGroupNamesFor(
-            output.serviceName,
-            output.serviceId,
-          )) {
-            yield* reapLogGroup(logGroupName);
+          //
+          // `retainLogGroups` keeps them; account-wide teardown (`force`)
+          // overrides that opt-out, since nuke's contract is to leave
+          // nothing behind. Nuke also enumerates from the cloud, so `olds`
+          // carries Attributes rather than Props there and the flag reads
+          // as unset anyway.
+          if (!olds.retainLogGroups || force) {
+            for (const logGroupName of logGroupNamesFor(
+              output.serviceName,
+              output.serviceId,
+            )) {
+              yield* reapLogGroup(logGroupName);
+            }
           }
         }),
 

--- a/packages/alchemy/src/AWS/AppRunner/Service.ts
+++ b/packages/alchemy/src/AWS/AppRunner/Service.ts
@@ -1,4 +1,5 @@
 import * as apprunner from "@distilled.cloud/aws/apprunner";
+import * as logs from "@distilled.cloud/aws/cloudwatch-logs";
 import * as ecr from "@distilled.cloud/aws/ecr";
 import * as iam from "@distilled.cloud/aws/iam";
 import type { Region } from "@distilled.cloud/aws/Region";
@@ -785,6 +786,96 @@ const emptyPlatformAttributes: PlatformAttributes = {
   accessRoleName: undefined,
   codeHash: undefined,
 };
+
+/**
+ * The two CloudWatch log groups App Runner auto-creates for a service:
+ * `.../application` (the container's stdout/stderr) and `.../service`
+ * (App Runner's own deployment and health-check events).
+ *
+ * Both names embed the AWS-generated service id, so a pair belongs to
+ * exactly one service instance — it can never be shared with, or reused
+ * by, another service.
+ */
+const logGroupNamesFor = (serviceName: string, serviceId: string) => [
+  `/aws/apprunner/${serviceName}/${serviceId}/application`,
+  `/aws/apprunner/${serviceName}/${serviceId}/service`,
+];
+
+/**
+ * Delete one of a service's auto-created log groups, idempotently.
+ *
+ * `deleteService` does NOT remove them, so without this every
+ * deploy+destroy cycle strands a pair (matching how the Lambda and ECS
+ * providers reap `/aws/lambda/{name}` and their task log group).
+ *
+ * App Runner can flush a final batch of events after the service itself
+ * is gone, silently re-creating a just-deleted group, so the delete is
+ * followed by a bounded observe→delete convergence loop. A group that
+ * never reappears — the common case — costs a single extra describe.
+ * Reaping is auxiliary to an already-completed service deletion, so a
+ * group that survives the budget warns rather than failing the destroy.
+ */
+const reapLogGroup = Effect.fn(function* (logGroupName: string) {
+  const deleteGroup = logs.deleteLogGroup({ logGroupName }).pipe(
+    Effect.retry({
+      while: (error) =>
+        error._tag === "OperationAbortedException" ||
+        error._tag === "ServiceUnavailableException",
+      schedule: Schedule.max([
+        Schedule.exponential("250 millis"),
+        Schedule.recurs(6),
+      ]),
+    }),
+    Effect.catchTag("ResourceNotFoundException", () => Effect.void),
+    Effect.timeoutOrElse({
+      duration: "30 seconds",
+      orElse: () =>
+        Effect.logWarning(
+          `Timed out deleting App Runner log group ${logGroupName}`,
+        ),
+    }),
+  );
+
+  // A describe that cannot complete in time is not deletion proof —
+  // assume the group is still present and let the bounded loop converge.
+  const observeGroup = logs
+    .describeLogGroups({ logGroupNamePrefix: logGroupName, limit: 1 })
+    .pipe(
+      Effect.map((response) =>
+        (response.logGroups ?? []).some(
+          (group) => group.logGroupName === logGroupName,
+        ),
+      ),
+      Effect.timeoutOrElse({
+        duration: "15 seconds",
+        orElse: () =>
+          Effect.logWarning(
+            `Timed out observing App Runner log group ${logGroupName} — assuming still present`,
+          ).pipe(Effect.as(true)),
+      }),
+    );
+
+  yield* deleteGroup;
+
+  // Re-reaps at t=0s/5s/…/30s, each attempt idempotent.
+  const stillPresent = yield* Effect.gen(function* () {
+    const present = yield* observeGroup;
+    if (present) yield* deleteGroup;
+    return present;
+  }).pipe(
+    Effect.repeat({
+      schedule: Schedule.spaced("5 seconds"),
+      until: (present) => !present,
+      times: 6,
+    }),
+  );
+
+  if (stillPresent) {
+    yield* Effect.logWarning(
+      `App Runner log group ${logGroupName} kept reappearing after delete`,
+    );
+  }
+});
 
 export const ServiceProvider = () =>
   Provider.effect(
@@ -1672,6 +1763,16 @@ await Effect.runPromise(program).catch((err) => {
               .pipe(
                 Effect.catchTag("NoSuchEntityException", () => Effect.void),
               );
+          }
+
+          // Last, because the reap can sit through App Runner's final log
+          // flush: an interruption during that window must not strand the
+          // repository or the roles, which cost money and block re-creates.
+          for (const logGroupName of logGroupNamesFor(
+            output.serviceName,
+            output.serviceId,
+          )) {
+            yield* reapLogGroup(logGroupName);
           }
         }),
 

--- a/packages/alchemy/test/AWS/AppRunner/Bindings.test.ts
+++ b/packages/alchemy/test/AWS/AppRunner/Bindings.test.ts
@@ -12,6 +12,41 @@ import AppRunnerTestFunctionLive, {
 
 const { test } = Test.make({ providers: AWS.providers() });
 
+/**
+ * POST a fixture route and decode its JSON body.
+ *
+ * Each binding is granted by its OWN inline policy on the Lambda role, and
+ * those propagate independently — a call can be rejected for seconds after
+ * a sibling binding's call already works, so every route retries. On a
+ * non-200 the fixture's body (the rendered cause) goes into the failure
+ * message; decoding it blind used to surface as a TypeError on a missing
+ * field, which said nothing about what App Runner refused.
+ */
+const postJson = <T>(url: string) =>
+  HttpClient.execute(HttpClientRequest.post(url)).pipe(
+    Effect.flatMap((response) =>
+      response.text.pipe(
+        Effect.flatMap((body) =>
+          response.status === 200
+            ? Effect.try({
+                try: () => JSON.parse(body) as T,
+                catch: () =>
+                  new Error(`POST ${url} returned unparseable body: ${body}`),
+              })
+            : Effect.fail(
+                new Error(`POST ${url} returned ${response.status}: ${body}`),
+              ),
+        ),
+      ),
+    ),
+    Effect.retry({
+      schedule: Schedule.max([
+        Schedule.exponential("1 second"),
+        Schedule.recurs(8),
+      ]),
+    }),
+  );
+
 /** Poll the service status out-of-band until it settles to `expected`. */
 const waitForStatus = (serviceArn: string, expected: string) =>
   apprunner.describeService({ ServiceArn: serviceArn }).pipe(
@@ -124,39 +159,28 @@ test.provider.skipIf(!process.env.AWS_TEST_SLOW)(
       expect(customDomains.dnsTarget).toContain("awsapprunner.com");
 
       // PauseService: the service settles to PAUSED.
-      const paused = yield* HttpClient.execute(
-        HttpClientRequest.post(`${baseUrl}/pause`),
-      ).pipe(
-        Effect.flatMap((response) => response.json),
-        Effect.map(
-          (json) => json as { serviceArn: string; operationId?: string },
-        ),
-      );
+      const paused = yield* postJson<{
+        serviceArn: string;
+        operationId?: string;
+      }>(`${baseUrl}/pause`);
       expect(paused.serviceArn).toContain(
         ":service/alchemy-test-apprunner-bind/",
       );
       yield* waitForStatus(paused.serviceArn, "PAUSED");
 
       // ResumeService: the service settles back to RUNNING.
-      const resumed = yield* HttpClient.execute(
-        HttpClientRequest.post(`${baseUrl}/resume`),
-      ).pipe(
-        Effect.flatMap((response) => response.json),
-        Effect.map(
-          (json) => json as { serviceArn: string; operationId?: string },
-        ),
-      );
+      const resumed = yield* postJson<{
+        serviceArn: string;
+        operationId?: string;
+      }>(`${baseUrl}/resume`);
       expect(resumed.serviceArn).toBe(paused.serviceArn);
       yield* waitForStatus(paused.serviceArn, "RUNNING");
 
       // StartDeployment: returns an operation id; the deployment then shows
       // up in ListOperations. (The provider's delete waits for the service
       // to settle, so the in-flight deployment doesn't block destroy.)
-      const deployed = yield* HttpClient.execute(
-        HttpClientRequest.post(`${baseUrl}/deploy`),
-      ).pipe(
-        Effect.flatMap((response) => response.json),
-        Effect.map((json) => json as { operationId?: string }),
+      const deployed = yield* postJson<{ operationId?: string }>(
+        `${baseUrl}/deploy`,
       );
       expect(deployed.operationId).toBeTruthy();
 

--- a/packages/alchemy/test/AWS/AppRunner/Service.test.ts
+++ b/packages/alchemy/test/AWS/AppRunner/Service.test.ts
@@ -7,6 +7,12 @@ import { expect } from "alchemy-test";
 import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";
 import * as HttpClient from "effect/unstable/http/HttpClient";
+import {
+  awaitLogGroups,
+  deleteLogGroups,
+  logGroupNamesFor,
+  observeLogGroups,
+} from "./logGroups.ts";
 
 const { test } = Test.make({ providers: AWS.providers() });
 
@@ -160,6 +166,56 @@ test.provider.skipIf(!process.env.AWS_TEST_SLOW)(
       yield* stack.destroy();
       yield* assertServiceGone(service.serviceArn);
       yield* assertConfigGone("alchemy-test-svc-asc");
+    }),
+  // create (~3-5 min) + delete (~2-3 min), one sequential test.
+  { timeout: 900_000 },
+);
+
+// The `retainLogGroups` opt-out: destroying the service leaves the two
+// auto-created log groups in place. Uses the same public ECR gallery image
+// as the lifecycle test above (no access role, no Docker build) since all
+// this needs is a real service that has logged something.
+test.provider.skipIf(!process.env.AWS_TEST_SLOW)(
+  "retainLogGroups keeps the auto-created log groups after the service is destroyed",
+  (stack) =>
+    Effect.gen(function* () {
+      // Clean slate in case a previous run died mid-flight.
+      yield* stack.destroy();
+
+      const service = yield* stack.deploy(
+        Service("RetainedLogsService", {
+          serviceName: "alchemy-test-apprunner-retain-logs",
+          imageRepository: {
+            imageIdentifier:
+              "public.ecr.aws/aws-containers/hello-app-runner:latest",
+            imageRepositoryType: "ECR_PUBLIC",
+            port: "8000",
+          },
+          autoDeploymentsEnabled: false,
+          instanceConfiguration: { cpu: "256", memory: "512" },
+          retainLogGroups: true,
+        }),
+      );
+      expect(service.status).toBe("RUNNING");
+
+      const logGroupNames = logGroupNamesFor(
+        service.serviceName,
+        service.serviceId,
+      );
+      expect(yield* awaitLogGroups(logGroupNames)).toEqual([true, true]);
+
+      yield* stack.destroy();
+      yield* assertServiceGone(service.serviceArn);
+
+      // The service is gone but its logs are not: the provider honored the
+      // opt-out instead of reaping them.
+      expect(yield* observeLogGroups(logGroupNames)).toEqual([true, true]);
+
+      // Nothing owns them now that the state row is gone, so the test that
+      // asked for them to be retained is what cleans them up — a retained
+      // pair left here would leak into every later run's census.
+      yield* deleteLogGroups(logGroupNames);
+      expect(yield* observeLogGroups(logGroupNames)).toEqual([false, false]);
     }),
   // create (~3-5 min) + delete (~2-3 min), one sequential test.
   { timeout: 900_000 },

--- a/packages/alchemy/test/AWS/AppRunner/ServicePlatform.test.ts
+++ b/packages/alchemy/test/AWS/AppRunner/ServicePlatform.test.ts
@@ -1,6 +1,7 @@
 import * as AWS from "@/AWS";
 import * as Test from "@/Test/Alchemy";
 import * as apprunner from "@distilled.cloud/aws/apprunner";
+import * as logs from "@distilled.cloud/aws/cloudwatch-logs";
 import * as ecr from "@distilled.cloud/aws/ecr";
 import * as iam from "@distilled.cloud/aws/iam";
 import { expect } from "alchemy-test";
@@ -103,8 +104,30 @@ test.provider.skipIf(!process.env.AWS_TEST_SLOW)(
       );
       expect(later).toBeGreaterThan(first);
 
+      // App Runner auto-creates these two log groups for the service; they
+      // survive `deleteService`, so the provider reaps them explicitly.
+      const logGroupNames = [
+        `/aws/apprunner/${service.serviceName}/${service.serviceId}/application`,
+        `/aws/apprunner/${service.serviceName}/${service.serviceId}/service`,
+      ];
+      const observeLogGroups = Effect.forEach(logGroupNames, (logGroupName) =>
+        logs
+          .describeLogGroups({ logGroupNamePrefix: logGroupName, limit: 1 })
+          .pipe(
+            Effect.map((response) =>
+              (response.logGroups ?? []).some(
+                (group) => group.logGroupName === logGroupName,
+              ),
+            ),
+          ),
+      );
+      // Sanity check the names: a typo here would make the post-destroy
+      // assertion below pass vacuously.
+      expect(yield* observeLogGroups).toEqual([true, true]);
+
       // Destroy immediately — App Runner services bill while running — and
-      // verify zero leftovers: service, managed repository, and both roles.
+      // verify zero leftovers: service, managed repository, both roles, and
+      // both log groups.
       const { repositoryName, instanceRoleName, accessRoleName, serviceArn } =
         service;
       yield* stack.destroy();
@@ -130,6 +153,8 @@ test.provider.skipIf(!process.env.AWS_TEST_SLOW)(
         );
         expect(roleError._tag).toBe("NoSuchEntityException");
       }
+
+      expect(yield* observeLogGroups).toEqual([false, false]);
     }),
   // Docker build + push (~2-4 min) + create (~3-5 min) + delete (~2-3 min).
   { timeout: 1_200_000 },

--- a/packages/alchemy/test/AWS/AppRunner/ServicePlatform.test.ts
+++ b/packages/alchemy/test/AWS/AppRunner/ServicePlatform.test.ts
@@ -1,7 +1,6 @@
 import * as AWS from "@/AWS";
 import * as Test from "@/Test/Alchemy";
 import * as apprunner from "@distilled.cloud/aws/apprunner";
-import * as logs from "@distilled.cloud/aws/cloudwatch-logs";
 import * as ecr from "@distilled.cloud/aws/ecr";
 import * as iam from "@distilled.cloud/aws/iam";
 import { expect } from "alchemy-test";
@@ -9,6 +8,11 @@ import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import TestService from "./fixtures/service.ts";
+import {
+  awaitLogGroups,
+  logGroupNamesFor,
+  observeLogGroups,
+} from "./logGroups.ts";
 
 const { test } = Test.make({ providers: AWS.providers() });
 
@@ -106,24 +110,13 @@ test.provider.skipIf(!process.env.AWS_TEST_SLOW)(
 
       // App Runner auto-creates these two log groups for the service; they
       // survive `deleteService`, so the provider reaps them explicitly.
-      const logGroupNames = [
-        `/aws/apprunner/${service.serviceName}/${service.serviceId}/application`,
-        `/aws/apprunner/${service.serviceName}/${service.serviceId}/service`,
-      ];
-      const observeLogGroups = Effect.forEach(logGroupNames, (logGroupName) =>
-        logs
-          .describeLogGroups({ logGroupNamePrefix: logGroupName, limit: 1 })
-          .pipe(
-            Effect.map((response) =>
-              (response.logGroups ?? []).some(
-                (group) => group.logGroupName === logGroupName,
-              ),
-            ),
-          ),
+      // Asserting they exist FIRST keeps the post-destroy check below from
+      // passing vacuously on a wrong name.
+      const logGroupNames = logGroupNamesFor(
+        service.serviceName,
+        service.serviceId,
       );
-      // Sanity check the names: a typo here would make the post-destroy
-      // assertion below pass vacuously.
-      expect(yield* observeLogGroups).toEqual([true, true]);
+      expect(yield* awaitLogGroups(logGroupNames)).toEqual([true, true]);
 
       // Destroy immediately — App Runner services bill while running — and
       // verify zero leftovers: service, managed repository, both roles, and
@@ -154,7 +147,7 @@ test.provider.skipIf(!process.env.AWS_TEST_SLOW)(
         expect(roleError._tag).toBe("NoSuchEntityException");
       }
 
-      expect(yield* observeLogGroups).toEqual([false, false]);
+      expect(yield* observeLogGroups(logGroupNames)).toEqual([false, false]);
     }),
   // Docker build + push (~2-4 min) + create (~3-5 min) + delete (~2-3 min).
   { timeout: 1_200_000 },

--- a/packages/alchemy/test/AWS/AppRunner/fixtures/handler.ts
+++ b/packages/alchemy/test/AWS/AppRunner/fixtures/handler.ts
@@ -1,5 +1,6 @@
 import * as AppRunner from "@/AWS/AppRunner";
 import * as Lambda from "@/AWS/Lambda";
+import * as Cause from "effect/Cause";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -106,7 +107,20 @@ export default AppRunnerTestFunction.make(
           { error: "Not found", method: request.method, pathname },
           { status: 404 },
         );
-      }).pipe(Effect.orDie),
+      }).pipe(
+        // Render the failure into the response instead of dying: a binding
+        // that is rejected (an IAM grant that has not propagated yet, an
+        // InvalidStateException) otherwise reaches the test as an opaque
+        // Lambda 502, and the assertion blows up on a missing field rather
+        // than saying what App Runner actually refused.
+        Effect.catchCause((cause) =>
+          HttpServerResponse.json(
+            { error: Cause.pretty(cause) },
+            { status: 500 },
+          ),
+        ),
+        Effect.orDie,
+      ),
     };
   }).pipe(
     Effect.provide(

--- a/packages/alchemy/test/AWS/AppRunner/logGroups.ts
+++ b/packages/alchemy/test/AWS/AppRunner/logGroups.ts
@@ -1,0 +1,50 @@
+import * as logs from "@distilled.cloud/aws/cloudwatch-logs";
+import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
+
+/**
+ * The two CloudWatch log groups App Runner auto-creates for a service.
+ *
+ * Deliberately spelled out here rather than imported from the provider:
+ * a wrong format in the provider would make its reap miss the real groups,
+ * and only an independently-derived name catches that.
+ */
+export const logGroupNamesFor = (serviceName: string, serviceId: string) => [
+  `/aws/apprunner/${serviceName}/${serviceId}/application`,
+  `/aws/apprunner/${serviceName}/${serviceId}/service`,
+];
+
+/** Which of the given log groups currently exist, in order. */
+export const observeLogGroups = (logGroupNames: readonly string[]) =>
+  Effect.forEach(logGroupNames, (logGroupName) =>
+    logs
+      .describeLogGroups({ logGroupNamePrefix: logGroupName, limit: 1 })
+      .pipe(
+        Effect.map((response) =>
+          (response.logGroups ?? []).some(
+            (group) => group.logGroupName === logGroupName,
+          ),
+        ),
+      ),
+  );
+
+/**
+ * Wait until every group exists. App Runner creates them around the first
+ * deployment, which can lag the service reaching RUNNING by a few seconds.
+ */
+export const awaitLogGroups = (logGroupNames: readonly string[]) =>
+  observeLogGroups(logGroupNames).pipe(
+    Effect.repeat({
+      schedule: Schedule.spaced("5 seconds"),
+      until: (present) => present.every(Boolean),
+      times: 24,
+    }),
+  );
+
+/** Delete the groups out-of-band (cleanup for retained-log-group coverage). */
+export const deleteLogGroups = (logGroupNames: readonly string[]) =>
+  Effect.forEach(logGroupNames, (logGroupName) =>
+    logs
+      .deleteLogGroup({ logGroupName })
+      .pipe(Effect.catchTag("ResourceNotFoundException", () => Effect.void)),
+  );


### PR DESCRIPTION
App Runner auto-creates two CloudWatch log groups per service and `deleteService` leaves them behind, so every deploy+destroy cycle stranded a pair:

```
/aws/apprunner/<serviceName>/<serviceId>/application
/aws/apprunner/<serviceName>/<serviceId>/service
```

The provider's `delete` now reaps both, alongside the managed ECR repository and IAM roles it already cleaned up.

```ts
const logGroupNamesFor = (serviceName: string, serviceId: string) => [
  `/aws/apprunner/${serviceName}/${serviceId}/application`,
  `/aws/apprunner/${serviceName}/${serviceId}/service`,
];
```

### Why deleting is the default

Both names embed the AWS-generated service id, so a pair belongs to exactly one service instance — it can never be shared with, or reused by, another service, and once the service is gone nothing writes to it again. That matches how the Lambda provider reaps `/aws/lambda/<fn>` and the ECS provider reaps its task log group.

### Opting out

```ts
yield* Service("Api", {
  imageRepository: { /* … */ },
  retainLogGroups: true, // logs outlive the service
});
```

Read from `olds` in `delete`. Account-wide teardown (`alchemy unsafe nuke`, which passes `force`) overrides it — nuke's contract is to leave nothing behind, and it enumerates from the cloud so the flag reads as unset there anyway.

### Reap shape

`reapLogGroup` deletes (retrying `OperationAbortedException` / `ServiceUnavailableException`, swallowing `ResourceNotFoundException`, timeout-bounded), then converges with a bounded observe→delete loop — App Runner can flush a final batch of events after the service is gone and silently re-create a just-deleted group. A group that never reappears costs one extra describe. Unlike Lambda's version it warns rather than dying if a group survives the budget: reaping is auxiliary to an already-completed service delete, and failing there would strand the state row.

It runs last in `delete`, after the repository and both roles, so an interruption during the flush window cannot strand the resources that cost money.

### Tests

`ServicePlatform.test.ts`'s zero-leftover assertions now cover the log groups, asserting them present *before* destroy so a wrong name can't make the post-destroy check pass vacuously:

```ts
expect(yield* awaitLogGroups(logGroupNames)).toEqual([true, true]);
yield* stack.destroy();
// …service, ECR repo, both roles…
expect(yield* observeLogGroups(logGroupNames)).toEqual([false, false]);
```

`Service.test.ts` gains the opt-out case on the public ECR gallery image (no Docker build, no access role). It cleans up what it deliberately retained, so the pair doesn't leak into later runs:

```ts
yield* stack.destroy();
yield* assertServiceGone(service.serviceArn);
expect(yield* observeLogGroups(logGroupNames)).toEqual([true, true]);
yield* deleteLogGroups(logGroupNames);
```

Shared helpers live in `test/AWS/AppRunner/logGroups.ts`. They re-derive the name format rather than importing it from the provider — importing it would make a wrong format in the provider invisible to both tests.

Verified live (`AWS_TEST_SLOW=1 … --profile testing`): the full `test/AWS/AppRunner` suite green (9/9), then `Service.test.ts` + `ServicePlatform.test.ts` green (4/4) against the opt-out. Account census after both runs: zero App Runner services and zero `/aws/apprunner/*` log groups.

### Also: a pre-existing `Bindings.test.ts` flake

Surfaced while verifying (the suite passed only on its third body attempt). Reproduced with `--retry 0`:

```
TypeError: null is not an object (evaluating 'paused.serviceArn')
    at test/AWS/AppRunner/Bindings.test.ts:135:14
```

`/pause`, `/resume`, and `/deploy` decoded the response blind. Each binding is granted by its own inline policy on the Lambda role and those propagate independently — `ListOperations` already working says nothing about `PauseService` being live yet — so a call can be rejected seconds after a sibling binding's call succeeds. The read routes already retry for exactly this reason; the mutating ones did not. The fixture's `Effect.orDie` also turned the rejection into an opaque Lambda 502, so it surfaced as a TypeError on a missing field rather than naming what App Runner refused.

```ts
const paused = yield* postJson<{ serviceArn: string; operationId?: string }>(
  `${baseUrl}/pause`,
);
```

`postJson` requires a 200, retries on the same bounded schedule as the read routes, and puts the fixture's body in the failure message; the fixture renders the cause into a 500 JSON body instead of dying. Green on a fresh `--retry 0` run (566s).
