### PR TITLE
feat(cloudflare/r2): enable the r2.dev managed domain on Bucket

### DIFF
--- a/packages/alchemy/src/Cloudflare/R2/Bucket.ts
+++ b/packages/alchemy/src/Cloudflare/R2/Bucket.ts
@@ -160,6 +160,18 @@ export type BucketProps = {
    */
   domains?: BucketCustomDomain[];
   /**
+   * Whether the bucket is publicly readable at Cloudflare's managed
+   * `r2.dev` domain. Cloudflare's default is off; omit or pass `false`
+   * to disable it.
+   *
+   * Once enabled, the hostname is reported on `publicDomain`. This
+   * endpoint is rate-limited and intended for non-production use — use
+   * `domains` for production public access.
+   *
+   * @default false
+   */
+  publicAccess?: boolean;
+  /**
    * Object lifecycle rules applied to the bucket. Pass an empty array (or
    * omit) to clear all lifecycle rules. See the Cloudflare R2 docs for
    * supported transitions.
@@ -203,6 +215,12 @@ export type Bucket = Resource<
     domains: Bucket.CustomDomain[];
     lifecycleRules: Bucket.LifecycleRule[];
     cors: Bucket.CorsRule[];
+    /**
+     * Hostname of the bucket's Cloudflare-managed `r2.dev` domain.
+     * Set only while `publicAccess` is enabled; `undefined` when
+     * disabled (the domain still exists but serves 401).
+     */
+    publicDomain: string | undefined;
   },
   never,
   Cloudflare.Providers
@@ -296,6 +314,28 @@ export type Bucket = Resource<
  *       minTLS: "1.2",
  *     },
  *   ],
+ * });
+ * ```
+ *
+ * ### Public Development URL
+ *
+ * Enable Cloudflare's managed `r2.dev` domain so objects are publicly
+ * readable without attaching a custom domain. The hostname is reported
+ * on `publicDomain`. This endpoint is rate-limited and intended for
+ * non-production use — use `domains` for production public access.
+ *
+ * **Example:** Enable public access at r2.dev
+ * ```typescript
+ * const bucket = yield* Cloudflare.R2.Bucket("MyBucket", {
+ *   publicAccess: true,
+ * });
+ * // objects are at https://${bucket.publicDomain}/<key>
+ * ```
+ *
+ * **Example:** Disable public access
+ * ```typescript
+ * const bucket = yield* Cloudflare.R2.Bucket("MyBucket", {
+ *   publicAccess: false,
  * });
  * ```
  *
@@ -714,6 +754,77 @@ export const ProviderLive = () =>
           return applied.sort((a, b) => a.domain.localeCompare(b.domain));
         });
 
+      const listManagedDomain = Effect.fn(function* (
+        bucketName: string,
+        jurisdiction: Bucket.Jurisdiction,
+        options?: { retryMissing?: boolean },
+      ) {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+        const fetch = r2.listBucketDomainManageds({
+          accountId,
+          bucketName,
+          jurisdiction,
+        });
+        return yield* (
+          options?.retryMissing === false
+            ? fetch
+            : fetch.pipe(
+                Effect.retry({
+                  while: (e) => e._tag === "NoSuchBucket",
+                  schedule: r2BucketEndpointConsistencySchedule,
+                }),
+              )
+        ).pipe(
+          // The hostname exists whether or not public access is on; a
+          // disabled domain serves 401, so only report it while enabled.
+          Effect.map((response) =>
+            response.enabled ? response.domain : undefined,
+          ),
+          Effect.catchTag("NoSuchBucket", () => Effect.succeed(undefined)),
+        );
+      });
+
+      const reconcileManagedDomain = (
+        bucketName: string,
+        jurisdiction: Bucket.Jurisdiction,
+        desired: boolean,
+      ) =>
+        Effect.gen(function* () {
+          const { accountId } = yield* yield* CloudflareEnvironment;
+          const observed = yield* r2
+            .listBucketDomainManageds({
+              accountId,
+              bucketName,
+              jurisdiction,
+            })
+            .pipe(
+              Effect.retry({
+                while: (e) => e._tag === "NoSuchBucket",
+                schedule: r2BucketEndpointConsistencySchedule,
+              }),
+            );
+
+          if (observed.enabled === desired) {
+            return desired ? observed.domain : undefined;
+          }
+
+          const updated = yield* r2
+            .putBucketDomainManaged({
+              accountId,
+              bucketName,
+              enabled: desired,
+              jurisdiction,
+            })
+            .pipe(
+              Effect.retry({
+                while: (e) => e._tag === "NoSuchBucket",
+                schedule: r2BucketEndpointConsistencySchedule,
+              }),
+            );
+
+          return updated.enabled ? updated.domain : undefined;
+        });
+
       // R2's `listBuckets` is not modelled as paginated by distilled and its
       // response omits a continuation cursor, so paginate exhaustively with the
       // `startAfter` query param: keep fetching full pages (capped at 1000)
@@ -907,47 +1018,51 @@ export const ProviderLive = () =>
               buckets,
               (bucket) =>
                 Effect.gen(function* () {
-                  // The three hydration reads are independent — issue them
+                  // The hydration reads are independent — issue them
                   // concurrently so each bucket costs one round-trip of wall
-                  // clock instead of three (a large leaked-bucket census can
+                  // clock instead of four (a large leaked-bucket census can
                   // otherwise blow the nuke scan's per-provider timeout).
-                  const [domains, lifecycleRules, cors] = yield* Effect.all(
-                    [
-                      listCustomDomains(bucket.name, bucket.jurisdiction, {
-                        retryMissing: false,
-                      }).pipe(Effect.map((d) => d ?? [])),
-                      r2
-                        .getBucketLifecycle({
-                          accountId,
-                          bucketName: bucket.name,
-                          jurisdiction: bucket.jurisdiction,
-                        })
-                        .pipe(
-                          Effect.map((observed) =>
-                            (observed.rules ?? []).map(toLifecycleRule),
+                  const [domains, lifecycleRules, cors, publicDomain] =
+                    yield* Effect.all(
+                      [
+                        listCustomDomains(bucket.name, bucket.jurisdiction, {
+                          retryMissing: false,
+                        }).pipe(Effect.map((d) => d ?? [])),
+                        r2
+                          .getBucketLifecycle({
+                            accountId,
+                            bucketName: bucket.name,
+                            jurisdiction: bucket.jurisdiction,
+                          })
+                          .pipe(
+                            Effect.map((observed) =>
+                              (observed.rules ?? []).map(toLifecycleRule),
+                            ),
+                            Effect.catchTag("NoSuchBucket", () =>
+                              Effect.succeed([] as Bucket.LifecycleRule[]),
+                            ),
                           ),
-                          Effect.catchTag("NoSuchBucket", () =>
-                            Effect.succeed([] as Bucket.LifecycleRule[]),
+                        r2
+                          .getBucketCors({
+                            accountId,
+                            bucketName: bucket.name,
+                            jurisdiction: bucket.jurisdiction,
+                          })
+                          .pipe(
+                            Effect.map((observed) =>
+                              (observed.rules ?? []).map(toCorsRule),
+                            ),
+                            Effect.catchTag(
+                              ["NoSuchBucket", "NoCorsConfiguration"],
+                              () => Effect.succeed([] as Bucket.CorsRule[]),
+                            ),
                           ),
-                        ),
-                      r2
-                        .getBucketCors({
-                          accountId,
-                          bucketName: bucket.name,
-                          jurisdiction: bucket.jurisdiction,
-                        })
-                        .pipe(
-                          Effect.map((observed) =>
-                            (observed.rules ?? []).map(toCorsRule),
-                          ),
-                          Effect.catchTag(
-                            ["NoSuchBucket", "NoCorsConfiguration"],
-                            () => Effect.succeed([] as Bucket.CorsRule[]),
-                          ),
-                        ),
-                    ] as const,
-                    { concurrency: 3 },
-                  );
+                        listManagedDomain(bucket.name, bucket.jurisdiction, {
+                          retryMissing: false,
+                        }),
+                      ] as const,
+                      { concurrency: 4 },
+                    );
                   return {
                     bucketName: bucket.name,
                     storageClass: bucket.storageClass,
@@ -957,6 +1072,7 @@ export const ProviderLive = () =>
                     domains,
                     lifecycleRules,
                     cors,
+                    publicDomain,
                   };
                 }).pipe(
                   // The custom-domain endpoint intermittently 500s ("Failed to
@@ -978,6 +1094,7 @@ export const ProviderLive = () =>
                       domains: [] as Bucket.CustomDomain[],
                       lifecycleRules: [] as Bucket.LifecycleRule[],
                       cors: [] as Bucket.CorsRule[],
+                      publicDomain: undefined,
                     }),
                   ),
                 ),
@@ -1023,6 +1140,9 @@ export const ProviderLive = () =>
             return { action: "update" } as const;
           }
           if (!deepEqual(olds.cors, news.cors)) {
+            return { action: "update" } as const;
+          }
+          if ((olds.publicAccess ?? false) !== (news.publicAccess ?? false)) {
             return { action: "update" } as const;
           }
         }),
@@ -1139,11 +1259,18 @@ export const ProviderLive = () =>
             news.cors ?? [],
           );
 
+          const publicDomain = yield* reconcileManagedDomain(
+            attrs.bucketName,
+            attrs.jurisdiction,
+            news.publicAccess ?? false,
+          );
+
           return {
             ...attrs,
             domains,
             lifecycleRules,
             cors,
+            publicDomain,
           };
         }),
         delete: Effect.fn(function* ({ olds = {}, output, force }) {
@@ -1213,6 +1340,7 @@ export const ProviderLive = () =>
                 domains: output?.domains ?? [],
                 lifecycleRules: output?.lifecycleRules ?? [],
                 cors: output?.cors ?? [],
+                publicDomain: output?.publicDomain,
               })),
               Effect.catchTag("NoSuchBucket", () => Effect.succeed(undefined)),
             );
@@ -1229,8 +1357,9 @@ export const ProviderLive = () =>
  * opaque id — the name IS the identity — so the `dev:` marker rides on the
  * name (a `:` can never appear in a real R2 bucket name).
  *
- * Custom domains, lifecycle rules, and CORS are deploy-side concerns with
- * no local behavior; the local attributes report them empty.
+ * Custom domains, lifecycle rules, CORS, and the managed r2.dev domain
+ * are deploy-side concerns with no local behavior; the local attributes
+ * report them empty.
  */
 export const ProviderLocal = () =>
   Provider.succeed(Bucket, {
@@ -1259,6 +1388,7 @@ export const ProviderLocal = () =>
         domains: [],
         lifecycleRules: [],
         cors: [],
+        publicDomain: undefined,
       };
     }),
     delete: Effect.fn(function* () {

--- a/packages/alchemy/test/Cloudflare/R2/Bucket.test.ts
+++ b/packages/alchemy/test/Cloudflare/R2/Bucket.test.ts
@@ -822,14 +822,24 @@ test.provider("managed r2.dev domain converges drift and adoption", (stack) =>
 
     yield* stack.destroy();
 
+    // Pin the physical name on every deploy so adding `name` cannot be
+    // what schedules the update — same shape as the CORS drift case
+    // above. A PR/user suffix keeps concurrent runs from colliding.
+    const suffix = (process.env.PULL_REQUEST ?? process.env.USER ?? "local")
+      .toLowerCase()
+      .replace(/[^a-z0-9]/g, "")
+      .slice(0, 24);
+    const bucketName = `alchemy-test-r2-pub-drift-${suffix}`;
+
     const initial = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* Cloudflare.R2.Bucket("DriftPublicBucket", {
           forceDestroy: true,
+          name: bucketName,
+          publicAccess: false,
         });
       }),
     );
-    const bucketName = initial.bucketName;
     expect(initial.publicDomain).toBeUndefined();
 
     // Drift: enable the managed domain out of band.
@@ -839,16 +849,22 @@ test.provider("managed r2.dev domain converges drift and adoption", (stack) =>
       enabled: true,
     });
 
-    // Re-deploy without publicAccess. Reconcile diffs desired against
-    // observed cloud state, so the leaked enable is turned back off.
+    // Re-deploy with publicAccess still false. The storage-class change
+    // is what makes Plan run reconcile (unchanged props skip it); the
+    // managed-domain sync must still disable the leaked enable because
+    // it diffs desired against *observed* cloud state, not olds.
     const repaired = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* Cloudflare.R2.Bucket("DriftPublicBucket", {
           forceDestroy: true,
           name: bucketName,
+          publicAccess: false,
+          storageClass: "InfrequentAccess",
         });
       }),
     );
+    expect(repaired.bucketName).toEqual(bucketName);
+    expect(repaired.storageClass).toEqual("InfrequentAccess");
     expect(repaired.publicDomain).toBeUndefined();
 
     const afterRepair = yield* r2.listBucketDomainManageds({

--- a/packages/alchemy/test/Cloudflare/R2/Bucket.test.ts
+++ b/packages/alchemy/test/Cloudflare/R2/Bucket.test.ts
@@ -54,6 +54,7 @@ test.provider("create and delete bucket with default props", (stack) =>
     expect(bucket.bucketName).toBeDefined();
     expect(bucket.storageClass).toEqual("Standard");
     expect(bucket.jurisdiction).toEqual("default");
+    expect(bucket.publicDomain).toBeUndefined();
 
     const actualBucket = yield* getBucketWhenReady(
       bucket.bucketName,
@@ -766,6 +767,181 @@ test.provider("cors is applied to the new bucket on replacement", (stack) =>
   }).pipe(logLevel),
 );
 
+test.provider("managed r2.dev domain is enabled and disabled", (stack) =>
+  Effect.gen(function* () {
+    const { accountId } = yield* yield* CloudflareEnvironment;
+
+    yield* stack.destroy();
+
+    const initial = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* Cloudflare.R2.Bucket("PublicBucket", {
+          forceDestroy: true,
+          publicAccess: true,
+        });
+      }),
+    );
+
+    expect(initial.publicDomain).toBeDefined();
+    expect(initial.publicDomain).toMatch(/\.r2\.dev$/);
+
+    const enabled = yield* r2.listBucketDomainManageds({
+      accountId,
+      bucketName: initial.bucketName,
+    });
+    expect(enabled.enabled).toEqual(true);
+    expect(enabled.domain).toEqual(initial.publicDomain);
+
+    const disabled = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* Cloudflare.R2.Bucket("PublicBucket", {
+          forceDestroy: true,
+          publicAccess: false,
+        });
+      }),
+    );
+
+    expect(disabled.bucketName).toEqual(initial.bucketName);
+    expect(disabled.publicDomain).toBeUndefined();
+
+    const observed = yield* r2.listBucketDomainManageds({
+      accountId,
+      bucketName: initial.bucketName,
+    });
+    expect(observed.enabled).toEqual(false);
+    expect(observed.domain).toEqual(enabled.domain);
+
+    yield* stack.destroy();
+    yield* waitForBucketToBeDeleted(initial.bucketName, accountId);
+  }).pipe(logLevel),
+);
+
+test.provider("managed r2.dev domain converges drift and adoption", (stack) =>
+  Effect.gen(function* () {
+    const { accountId } = yield* yield* CloudflareEnvironment;
+
+    yield* stack.destroy();
+
+    const initial = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* Cloudflare.R2.Bucket("DriftPublicBucket", {
+          forceDestroy: true,
+        });
+      }),
+    );
+    const bucketName = initial.bucketName;
+    expect(initial.publicDomain).toBeUndefined();
+
+    // Drift: enable the managed domain out of band.
+    yield* r2.putBucketDomainManaged({
+      accountId,
+      bucketName,
+      enabled: true,
+    });
+
+    // Re-deploy without publicAccess. Reconcile diffs desired against
+    // observed cloud state, so the leaked enable is turned back off.
+    const repaired = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* Cloudflare.R2.Bucket("DriftPublicBucket", {
+          forceDestroy: true,
+          name: bucketName,
+        });
+      }),
+    );
+    expect(repaired.publicDomain).toBeUndefined();
+
+    const afterRepair = yield* r2.listBucketDomainManageds({
+      accountId,
+      bucketName,
+    });
+    expect(afterRepair.enabled).toEqual(false);
+
+    // Adoption: re-enable out of band, wipe local state, then adopt
+    // with publicAccess: true (output defined, olds undefined).
+    yield* r2.putBucketDomainManaged({
+      accountId,
+      bucketName,
+      enabled: true,
+    });
+    yield* Effect.gen(function* () {
+      const state = yield* yield* State;
+      yield* state.delete({
+        stack: stack.name,
+        stage: "test",
+        fqn: "DriftPublicBucket",
+      });
+    }).pipe(Effect.provide(stack.state));
+
+    const adopted = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* Cloudflare.R2.Bucket("DriftPublicBucket", {
+          forceDestroy: true,
+          name: bucketName,
+          publicAccess: true,
+        });
+      }),
+    );
+    expect(adopted.bucketName).toEqual(bucketName);
+    expect(adopted.publicDomain).toMatch(/\.r2\.dev$/);
+
+    const converged = yield* r2.listBucketDomainManageds({
+      accountId,
+      bucketName,
+    });
+    expect(converged.enabled).toEqual(true);
+    expect(converged.domain).toEqual(adopted.publicDomain);
+
+    yield* stack.destroy();
+    yield* waitForBucketToBeDeleted(bucketName, accountId);
+  }).pipe(logLevel),
+);
+
+test.provider("managed r2.dev domain is applied on replacement", (stack) =>
+  Effect.gen(function* () {
+    const { accountId } = yield* yield* CloudflareEnvironment;
+
+    yield* stack.destroy();
+
+    const initial = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* Cloudflare.R2.Bucket("ReplacePublicBucket", {
+          forceDestroy: true,
+          publicAccess: true,
+        });
+      }),
+    );
+    const oldName = initial.bucketName;
+    // Flip the first character so the replacement name is unique and
+    // stays within R2's 63-char limit regardless of the original length.
+    const newName = `x${oldName.slice(1)}`;
+
+    const replaced = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* Cloudflare.R2.Bucket("ReplacePublicBucket", {
+          forceDestroy: true,
+          name: newName,
+          publicAccess: true,
+        });
+      }),
+    );
+    expect(replaced.bucketName).toEqual(newName);
+    expect(replaced.publicDomain).toMatch(/\.r2\.dev$/);
+
+    const replacedDomain = yield* r2.listBucketDomainManageds({
+      accountId,
+      bucketName: newName,
+    });
+    expect(replacedDomain.enabled).toEqual(true);
+    expect(replacedDomain.domain).toEqual(replaced.publicDomain);
+
+    yield* waitForBucketToBeDeleted(oldName, accountId);
+
+    yield* stack.destroy();
+    yield* waitForBucketToBeDeleted(newName, accountId);
+  }).pipe(logLevel),
+);
+
 // R2 bucket creates are eventually consistent — a read immediately after
 // deploy can briefly return NoSuchBucket until the bucket propagates.
 const getBucketWhenReady = Effect.fn(function* (
@@ -990,6 +1166,7 @@ const stubbedOutput = {
   domains: [],
   lifecycleRules: [],
   cors: [],
+  publicDomain: undefined,
 };
 
 /** `DELETE .../r2/buckets/{name}/objects` — the request that wipes data. */

--- a/website/src/content/docs/cloudflare/data/r2.mdx
+++ b/website/src/content/docs/cloudflare/data/r2.mdx
@@ -125,6 +125,24 @@ Your runtime code depends only on the capability
 (`ReadBucket(Bucket)` etc.) — swapping the implementation layer
 doesn't touch the handlers.
 
+## Public development URL
+
+Buckets are private by default. Set `publicAccess: true` to serve
+objects from Cloudflare's managed `r2.dev` domain — useful for
+preview stacks and anywhere a signed S3 URL or a custom domain
+isn't an option. The hostname lands on `publicDomain`:
+
+```typescript
+const bucket = yield* Cloudflare.R2.Bucket("Assets", {
+  publicAccess: true,
+});
+// https://pub-….r2.dev/photo.jpg
+```
+
+This endpoint is rate-limited and intended for non-production use.
+For production traffic, attach a hostname you control with
+`domains`.
+
 ## Destroying a bucket
 
 R2 refuses to delete a bucket that still has objects in it, and


### PR DESCRIPTION
`Cloudflare.R2.Bucket` can now enable Cloudflare's managed `r2.dev` domain and report the hostname. The distilled SDK already shipped `listBucketDomainManageds` / `putBucketDomainManaged`; the resource never called them.

```ts
const bucket = yield* Cloudflare.R2.Bucket("Assets", {
  publicAccess: true,
});
// objects are at https://${bucket.publicDomain}/<key>
```

- `publicAccess` defaults to `false`, matching Cloudflare
- `publicDomain` is the `r2.dev` hostname while enabled, `undefined` while disabled (a disabled domain serves 401)
- Reconcile observes live managed-domain state and PUTs only on drift
- Delete does not disable the domain — it goes away with the bucket
- The local/dev provider reports `publicDomain: undefined` (no `r2.dev` in the simulator)

Closes #1328
