### PR TITLE
fix(aws/dev): ECS Task/Service and Lambda Function declare the floci data plane

### DIFF
--- a/packages/alchemy/src/AWS/Providers.ts
+++ b/packages/alchemy/src/AWS/Providers.ts
@@ -22,7 +22,7 @@ import * as Command from "../Command/index.ts";
 import { DockerLive } from "../Docker/Docker.ts";
 import { KeyPair, KeyPairProvider } from "../KeyPair.ts";
 import * as ProviderLayer from "../Local/ProviderLayer.ts";
-import { flociDual } from "./Local/FlociServices.ts";
+import { flociDual, flociServices } from "./Local/FlociServices.ts";
 import * as Provider from "../Provider.ts";
 import { Random, RandomProvider } from "../Random.ts";
 import * as AccessAnalyzer from "./AccessAnalyzer/index.ts";
@@ -1288,14 +1288,21 @@ export const providers = () =>
           // Dual: live ECS in deploy, floci-emulated (RPC-sidecar-hosted,
           // hot-reloading real containers) in dev — see FlociServiceProvider
           // / FlociTaskProvider.
+          // Hand-written floci local providers still live on the floci data
+          // plane: declare it so deploy-time binding clients (Action bodies,
+          // plan-time `execute`) route to the emulator — and so a binding
+          // spanning a `flociDual` sibling (RunTask(cluster, task)) does not
+          // see "mixed data planes". Pinned by test/AWS/LocalDataPlane.test.ts.
           ProviderLayer.dual(ECS.Service, {
             live: () => ECS.ServiceProvider(),
             local: () => ECS.FlociServiceProvider(),
+            dataPlane: flociServices,
           }),
           flociDual(ECS.TaskDefinition, () => ECS.TaskDefinitionProvider()),
           ProviderLayer.dual(ECS.Task, {
             live: () => ECS.TaskProvider(),
             local: () => ECS.FlociTaskProvider(),
+            dataPlane: flociServices,
           }),
           EFS.AccessPointProvider(),
           EFS.FileSystemProvider(),
@@ -1425,6 +1432,7 @@ export const providers = () =>
           ProviderLayer.dual(Lambda.Function, {
             live: () => Lambda.FunctionProvider(),
             local: () => Lambda.FlociFunctionProvider(),
+            dataPlane: flociServices,
           }),
           flociDual(Lambda.LayerVersion, () => Lambda.LayerVersionProvider()),
           flociDual(Lambda.Version, () => Lambda.VersionProvider()),

--- a/packages/alchemy/src/Binding.ts
+++ b/packages/alchemy/src/Binding.ts
@@ -4,7 +4,7 @@ import type * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import type { Input } from "./Input.ts";
 import * as Output from "./Output.ts";
-import { resolveLocalDataPlane } from "./Provider.ts";
+import { describeDataPlane, type DataPlaneResolution } from "./Provider.ts";
 import { isResource, type ResourceLike } from "./Resource.ts";
 import { Self } from "./Self.ts";
 import { taggedFunction } from "./Util/effect.ts";
@@ -193,27 +193,51 @@ const routeClientDataPlane = (
     );
     if (resources.length === 0) return Effect.succeed(client);
     return Effect.gen(function* () {
-      const planes: (Layer.Layer<any, any, never> | undefined)[] = [];
+      const planes: DataPlaneResolution[] = [];
       for (const resource of resources) {
-        planes.push(yield* resolveLocalDataPlane(resource));
+        planes.push(yield* describeDataPlane(resource));
       }
-      const defined = [...new Set(planes.filter((p) => p !== undefined))];
-      if (defined.length === 0) return client;
-      if (defined.length > 1 || planes.some((p) => p === undefined)) {
+      const local = [
+        ...new Set(
+          planes.flatMap((p) => (p.kind === "local" ? [p.layer] : [])),
+        ),
+      ];
+      if (local.length === 0) return client;
+      if (local.length > 1 || planes.some((p) => p.kind !== "local")) {
+        // Say exactly where each resource lands: a dual provider that never
+        // registered a data plane is the usual culprit, and it would
+        // otherwise read as "live" — the report that sent a user chasing a
+        // `remote()` they never wrote.
+        const where = resources
+          .map((r, i) => `${r.FQN} → ${describeResolution(planes[i]!)}`)
+          .join("; ");
         return yield* Effect.die(
-          `Binding client spans mixed data planes: [${resources
-            .map((r) => r.FQN)
-            .join(
-              ", ",
-            )}] resolve to different targets (some local, some live). ` +
-            "A single API call cannot span the local emulator and the real " +
-            "cloud — make the bound resources' modes agree (e.g. pipe them " +
+          `Binding client spans mixed data planes: ${where}. A single API ` +
+            "call cannot span the local emulator and the real cloud. If a " +
+            "resource above is meant to be emulated, its provider must " +
+            "declare `dataPlane` on its ProviderLayer.dual registration; " +
+            "otherwise make the bound resources' modes agree (e.g. pipe them " +
             "all through Alchemy.remote(), or none).",
         );
       }
-      return wrapClientInvocations(client, defined[0]);
+      return wrapClientInvocations(client, local[0]!);
     });
   });
+
+const describeResolution = (plane: DataPlaneResolution): string => {
+  switch (plane.kind) {
+    case "local":
+      return "local emulator";
+    case "live":
+      return "real cloud (live mode)";
+    case "undeclared":
+      return `real cloud (its provider ${plane.providerType} is dual-mode but registers no local data plane)`;
+    case "agnostic":
+      return "real cloud (mode-agnostic provider)";
+    case "unregistered":
+      return "real cloud (no provider registered)";
+  }
+};
 
 /**
  * Wrap every invocation surface of a binding client so its returned Effects

--- a/packages/alchemy/src/Provider.ts
+++ b/packages/alchemy/src/Provider.ts
@@ -612,32 +612,65 @@ export const providerForMode = <R extends ResourceLike>(
     : Effect.succeed(service);
 
 /**
- * Resolve the data-plane override layer for a resource, or `undefined` when
- * its data plane is the real cloud:
+ * Why a resource's deploy-time binding clients target the data plane they
+ * do — see {@link describeDataPlane}.
  *
- * - no provider registered in context (bare runtime, unit tests) → live;
- * - mode-agnostic provider (no `modes`) → live even in dev;
- * - dual provider without a registered {@link ProviderService.localDataPlane}
- *   → live (nothing to route to);
- * - otherwise the resource's effective mode decides — its registration-
- *   captured {@link ResourceLike.Mode} (`Alchemy.remote()` → `"live"`) or
- *   the run default (`alchemy dev` → `"local"`), the same resolution
- *   `Plan.make` applies to lifecycle operations.
+ * - `local` — the resource runs on its provider's local emulator; `layer`
+ *   is the override to provide closest around every client call.
+ * - `live` — the resource targets the real cloud: either pinned there
+ *   (`Alchemy.remote()`) or the run is a plain deploy.
+ * - `undeclared` — the resource resolves to local mode, but its provider
+ *   is a dual registration without a {@link ProviderService.localDataPlane}
+ *   (a process-hosted local variant with no API to route to, or a missing
+ *   `dataPlane` on a hand-written `ProviderLayer.dual`). Clients fall back
+ *   to the real cloud — reported by name so the two are never confused.
+ * - `agnostic` — the provider is mode-agnostic (plain registration); its
+ *   resources live on the real cloud even in dev.
+ * - `unregistered` — no provider in context (bare runtime, unit tests).
+ */
+export type DataPlaneResolution =
+  | { readonly kind: "local"; readonly layer: Layer.Layer<any, any, never> }
+  | { readonly kind: "live" }
+  | { readonly kind: "undeclared"; readonly providerType: string }
+  | { readonly kind: "agnostic" }
+  | { readonly kind: "unregistered" };
+
+/**
+ * Resolve where a resource's deploy-time binding clients should be routed:
+ * its registration-captured {@link ResourceLike.Mode} (`Alchemy.remote()`
+ * → `"live"`) or the run default (`alchemy dev` → `"local"`) — the same
+ * resolution `Plan.make` applies to lifecycle operations — combined with
+ * whether the provider registered a local data plane at all.
+ */
+export const describeDataPlane = (resource: {
+  readonly Type: string;
+  readonly Mode?: ProviderMode | undefined;
+}): Effect.Effect<DataPlaneResolution> =>
+  Effect.gen(function* () {
+    const found = yield* tryFindProviderByType(resource.Type);
+    if (Option.isNone(found)) return { kind: "unregistered" as const };
+    const provider = found.value;
+    if (provider.modes === undefined) return { kind: "agnostic" as const };
+    const mode = resource.Mode ?? (yield* defaultProviderMode);
+    if (mode !== "local") return { kind: "live" as const };
+    if (provider.localDataPlane === undefined) {
+      return { kind: "undeclared" as const, providerType: resource.Type };
+    }
+    return { kind: "local" as const, layer: provider.localDataPlane() };
+  });
+
+/**
+ * The data-plane override layer for a resource, or `undefined` when its
+ * clients target the real cloud for any reason (see
+ * {@link describeDataPlane} for which).
  */
 export const resolveLocalDataPlane = (resource: {
   readonly Type: string;
   readonly Mode?: ProviderMode | undefined;
 }): Effect.Effect<Layer.Layer<any, any, never> | undefined> =>
-  Effect.gen(function* () {
-    const found = yield* tryFindProviderByType(resource.Type);
-    if (Option.isNone(found)) return undefined;
-    const provider = found.value;
-    if (provider.modes === undefined || provider.localDataPlane === undefined) {
-      return undefined;
-    }
-    const mode = resource.Mode ?? (yield* defaultProviderMode);
-    return mode === "local" ? provider.localDataPlane() : undefined;
-  });
+  describeDataPlane(resource).pipe(
+    Effect.map((plane) => (plane.kind === "local" ? plane.layer : undefined)),
+  );
 
 export const findProviderByType: {
   <R extends ResourceLike>(

--- a/packages/alchemy/test/AWS/Local/EcsDataPlane.local.test.ts
+++ b/packages/alchemy/test/AWS/Local/EcsDataPlane.local.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Dev-mode data-plane routing for the hand-written floci providers.
+ *
+ * `ECS.Cluster` is a `flociDual` (which declares the floci emulator as the
+ * resource's local data plane), while `ECS.Task` / `ECS.Service` /
+ * `Lambda.Function` are hand-written `ProviderLayer.dual` registrations
+ * whose local variants ALSO run on floci. If those don't declare the data
+ * plane, a binding that spans both kinds — `RunTask(cluster, task)` — sees
+ * one resource routed to the emulator and the other to nothing, and dies at
+ * bind time with "Binding client spans mixed data planes", before anything
+ * is provisioned. Reported with exactly this four-line program:
+ *
+ *   const cluster = yield* AWS.ECS.Cluster("Cluster")
+ *   const task = yield* AWS.ECS.Task("Task", { image: "busybox:stable", command: ["true"] })
+ *   yield* AWS.ECS.RunTask(cluster, task)
+ *
+ * Requires Docker (floci runs as a container); skipped when unavailable.
+ */
+import { Action } from "@/Action";
+import * as AWS from "@/AWS";
+import * as Test from "@/Test/Alchemy";
+import { expect } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import { dockerAvailable } from "./fixtures/raw.ts";
+
+const { test } = Test.make({ providers: AWS.providers(), dev: true });
+
+/** The emulator runs task containers on THIS machine. */
+const hostRuntimePlatform = {
+  cpuArchitecture:
+    process.arch === "arm64" ? ("ARM64" as const) : ("X86_64" as const),
+  operatingSystemFamily: "LINUX" as const,
+};
+
+test.provider.skipIf(!dockerAvailable)(
+  "RunTask(cluster, task) binds in dev and routes the launch to floci",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const outputs = yield* stack.deploy(
+        Effect.gen(function* () {
+          const cluster = yield* AWS.ECS.Cluster("DataPlaneCluster");
+          const task = yield* AWS.ECS.Task("DataPlaneTask", {
+            image: "busybox:stable",
+            command: ["true"],
+            cpu: 256,
+            memory: 512,
+            requiresCompatibilities: ["EC2"],
+            runtimePlatform: hostRuntimePlatform,
+          });
+
+          // The deploy-time client path (#1308): an Action binds
+          // RunTask(cluster, task) — this bind is where the data-plane check
+          // runs — and launches the task. Its call must land on the
+          // emulator, not the real cloud.
+          const Launch = Action(
+            "LaunchDataPlaneTask",
+            Effect.gen(function* () {
+              const runTask = yield* AWS.ECS.RunTask(cluster, task);
+              return () =>
+                runTask({ launchType: "EC2", count: 1 }).pipe(
+                  Effect.map((response) => ({
+                    taskArn: response.tasks?.[0]?.taskArn,
+                    failures: response.failures ?? [],
+                  })),
+                );
+            }),
+          );
+          return {
+            clusterArn: cluster.clusterArn,
+            launched: yield* Launch({}),
+          };
+        }).pipe(Effect.provide(AWS.ECS.RunTaskHttp)),
+      );
+
+      // Emulator-shaped identity: the live cloud can never mint these.
+      expect(outputs.clusterArn).toContain(":000000000000:");
+      expect(outputs.launched.failures).toEqual([]);
+      expect(outputs.launched.taskArn).toContain(":000000000000:");
+
+      yield* stack.destroy();
+    }),
+  { timeout: 300_000 },
+);

--- a/packages/alchemy/test/AWS/LocalDataPlane.test.ts
+++ b/packages/alchemy/test/AWS/LocalDataPlane.test.ts
@@ -1,0 +1,62 @@
+import * as AWS from "@/AWS";
+import type { ProviderService } from "@/Provider";
+import * as Test from "@/Test/Alchemy";
+import { expect } from "alchemy-test";
+import * as Effect from "effect/Effect";
+
+const { test } = Test.make({ providers: AWS.providers() });
+
+/**
+ * Dual-mode AWS providers whose LOCAL variant is a process on this machine
+ * (a dev server), not the floci emulator. They have no emulator API for a
+ * binding client to route to, so `resolveLocalDataPlane` deliberately falls
+ * back to the real cloud for them (see Provider.ts). Every other AWS dual
+ * runs on floci and must say so.
+ */
+const PROCESS_HOSTED = new Set(["Command.Dev", "AWS.Website.Server"]);
+
+/**
+ * Every floci-backed dual provider must declare the emulator as its
+ * {@link ProviderService.localDataPlane}. A dual that doesn't is a silent
+ * hole in `alchemy dev`: a deploy-time binding client bound to it (an
+ * Action body, a plan-time `execute`) is left unrouted — a single-resource
+ * binding such as `InvokeFunction(fn)` then targets the real cloud, and a
+ * binding spanning a declaring sibling (`RunTask(cluster, task)`) dies with
+ * "Binding client spans mixed data planes" (the reported bug; its e2e is
+ * test/AWS/Local/EcsDataPlane.local.test.ts).
+ *
+ * `flociDual` declares it for you; the hand-written floci providers
+ * (`ProviderLayer.dual` with a `Floci*Provider` local) have to say so
+ * explicitly — this walks the registry and pins that they all do.
+ */
+test.provider(
+  "every floci-backed dual AWS provider declares its local data plane",
+  () =>
+    Effect.gen(function* () {
+      const context = yield* Effect.context<never>();
+      const missing: string[] = [];
+      let duals = 0;
+      for (const [key, value] of context.mapUnsafe) {
+        const entry = value as Partial<ProviderService> & {
+          kind?: string;
+          providers?: Record<string, ProviderService>;
+        };
+        // Providers live in context either as individual `Provider` tags or
+        // inside a `ProviderCollection` keyed by resource type.
+        const candidates: [string, Partial<ProviderService>][] =
+          entry.kind === "ProviderCollection" && entry.providers
+            ? Object.entries(entry.providers)
+            : typeof entry.reconcile === "function"
+              ? [[String(key), entry]]
+              : [];
+        for (const [type, service] of candidates) {
+          if (service.modes === undefined || PROCESS_HOSTED.has(type)) continue;
+          duals += 1;
+          if (service.localDataPlane === undefined) missing.push(type);
+        }
+      }
+      // Sanity: the registry was actually walked (hundreds of duals).
+      expect(duals).toBeGreaterThan(100);
+      expect(missing).toEqual([]);
+    }),
+);


### PR DESCRIPTION
In an `alchemy dev` run this four-line program died before provisioning anything:

```ts
const cluster = yield* AWS.ECS.Cluster("Cluster");
const task = yield* AWS.ECS.Task("Task", { image: "busybox:stable", command: ["true"] });
yield* AWS.ECS.RunTask(cluster, task);
```

```
Binding client spans mixed data planes: [Cluster, Task] resolve to different targets (some local, some live).
```

Nothing was live. `ECS.Cluster` is a `flociDual`, which registers `dataPlane: flociServices`; `ECS.Task`, `ECS.Service` and `Lambda.Function` are hand-written `ProviderLayer.dual` registrations over the floci providers that never declared a data plane, so `resolveLocalDataPlane` returned `undefined` for them — and the #1308 check can't tell "undeclared" from "live". The single-resource case is worse: `InvokeFunction(fn)` in a dev Action didn't die, it was left unrouted and silently called the real cloud.

```diff
  ProviderLayer.dual(ECS.Task, {
    live: () => ECS.TaskProvider(),
    local: () => ECS.FlociTaskProvider(),
+   dataPlane: flociServices,
  }),
```

Same for `ECS.Service` and `Lambda.Function`.

The mixed-plane error now says where each resource lands and why, via a new `describeDataPlane`:

```
Binding client spans mixed data planes: DataPlaneCluster → local emulator; DataPlaneTask → real cloud (its provider AWS.ECS.Task is dual-mode but registers no local data plane). …
```

### Tests

- `test/AWS/Local/EcsDataPlane.local.test.ts` — the report, end to end in dev: an Action binds `RunTask(cluster, task)` and launches the task; the task ARN must be emulator-shaped. Fails on `main` with the exact reported message.
- `test/AWS/LocalDataPlane.test.ts` — walks the provider registry and pins that every floci-backed dual declares its data plane (names `AWS.ECS.Service`, `AWS.ECS.Task`, `AWS.Lambda.Function` on `main`). `Command.Dev` / `AWS.Website.Server` are the documented exception: process-hosted locals with no emulator API.

Why existing tests missed it: #1308's only routing test is on `S3.Bucket` (a `flociDual`, which declares the plane automatically), and the ECS dev suites drive floci over raw HTTP rather than through the `RunTask` binding, so the bind step never ran in dev for a hand-written dual.

Green: `test/AWS/Local`, `test/AWS/S3/Bucket.data-plane.test.ts`, `test/provider-mode.test.ts`, the two new suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
