### PR TITLE
fix(cloudflare): flush event telemetry before settlement

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/DurableObjectBridge.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/DurableObjectBridge.ts
@@ -2,6 +2,7 @@ import type * as cf from "@cloudflare/workers-types";
 import type { DurableObject as DurableObjectClass } from "cloudflare:workers";
 
 import * as Cause from "effect/Cause";
+import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
@@ -9,7 +10,7 @@ import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
 
 import { HttpServerResponse } from "effect/unstable/http";
-import { buildEventTelemetry } from "../../Telemetry.ts";
+import { buildEventTelemetry, flushEventTelemetry } from "../../Telemetry.ts";
 import type {
   DurableObjectExport,
   DurableObjectShape,
@@ -129,6 +130,7 @@ export const makeDurableObjectBridge =
         ) => Promise<any>,
       ) {
         const scope = Scope.makeUnsafe();
+        let eventTelemetry = Context.empty();
 
         const { instance, services, context, telemetry } = await this.#instance;
 
@@ -142,11 +144,17 @@ export const makeDurableObjectBridge =
                 ),
                 Layer.succeed(Scope.Scope, scope),
                 // The configured telemetry exporters, attached to the *call*
-                // scope by `buildEventTelemetry` so buffered telemetry
-                // flushes when the scope closes into `waitUntil` below (the
-                // isolate scope never finalizes on workerd).
+                // scope by `buildEventTelemetry`. The captured Context is
+                // explicitly flushed before this call settles; ordinary scope
+                // finalizers close via `waitUntil`.
                 Layer.effectContext(
-                  buildEventTelemetry(context, scope, telemetry()),
+                  buildEventTelemetry(context, scope, telemetry()).pipe(
+                    Effect.tap((context) =>
+                      Effect.sync(() => {
+                        eventTelemetry = context;
+                      }),
+                    ),
+                  ),
                 ),
               ).pipe(
                 Layer.provideMerge(Layer.succeedContext(services)),
@@ -162,18 +170,20 @@ export const makeDurableObjectBridge =
                 ? Promise.resolve(exit.value)
                 : Promise.reject(Cause.squash(exit.cause)),
           )
-          .finally(() =>
-            isScopeEjected(scope)
-              ? undefined
-              : this.ctx.waitUntil(
-                  // Match WorkerBridge: yield one macrotask so the
-                  // HttpMiddleware tracer's late span-end reaches the
-                  // telemetry exporter before the scope's flush finalizer.
-                  new Promise((resolve) => setTimeout(resolve, 0)).then(() =>
-                    Effect.runPromise(Scope.close(scope, Exit.void)),
-                  ),
+          .finally(() => {
+            if (isScopeEjected(scope)) return undefined;
+            // Match WorkerBridge: wait for the late HTTP span, flush its
+            // telemetry, then close ordinary call resources in the background.
+            return new Promise((resolve) => setTimeout(resolve, 0))
+              .then(() =>
+                Effect.runPromise(flushEventTelemetry(eventTelemetry)),
+              )
+              .then(() =>
+                this.ctx.waitUntil(
+                  Effect.runPromise(Scope.close(scope, Exit.void)),
                 ),
-          );
+              );
+          });
       }
 
       async fetch(request: Request): Promise<any> {

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerBridge.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerBridge.ts
@@ -19,7 +19,7 @@ import {
 } from "../../Runtime.ts";
 import { Self } from "../../Self.ts";
 import { Stack } from "../../Stack.ts";
-import { buildEventTelemetry } from "../../Telemetry.ts";
+import { buildEventTelemetry, flushEventTelemetry } from "../../Telemetry.ts";
 import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
 import cloudflare_workers from "./cloudflare_workers.ts";
 import { isScopeEjected } from "./HttpServer.ts";
@@ -88,6 +88,7 @@ export const makeWorkerBridge = (
     ) => T | Promise<T>,
   ): Promise<T> => {
     const scope = Scope.makeUnsafe();
+    let eventTelemetry = Context.empty();
     return build((promise) => ctx.waitUntil(promise as Promise<any>))
       .then(
         (built) => {
@@ -109,13 +110,22 @@ export const makeWorkerBridge = (
                 Layer.succeed(Scope.Scope, scope),
                 // The configured telemetry exporters. Constructed as part
                 // of this per-event layer, but `buildEventTelemetry`
-                // attaches their batching fibers and flush finalizers to
-                // the request `scope` (not this build's transient scope),
-                // so buffered telemetry flushes when the scope closes into
-                // `ctx.waitUntil` below — never on workerd's ephemeral
-                // isolate scope.
+                // attaches their batching fibers and finalizers to the
+                // request `scope` (not this build's transient scope). The
+                // captured Context is explicitly flushed before this event
+                // settles; ordinary scope finalizers close via `waitUntil`.
                 Layer.effectContext(
-                  buildEventTelemetry(built.context, scope, built.telemetry()),
+                  buildEventTelemetry(
+                    built.context,
+                    scope,
+                    built.telemetry(),
+                  ).pipe(
+                    Effect.tap((context) =>
+                      Effect.sync(() => {
+                        eventTelemetry = context;
+                      }),
+                    ),
+                  ),
                 ),
               ).pipe(
                 Layer.provideMerge(Layer.succeedContext(services)),
@@ -130,20 +140,18 @@ export const makeWorkerBridge = (
         (error) => Exit.die(error),
       )
       .then((exit) => onExit(exit, scope))
-      .finally(() =>
-        isScopeEjected(scope)
-          ? undefined
-          : ctx.waitUntil(
-              // The HttpMiddleware tracer ends the request's root span in a
-              // dispatcher task scheduled after the handler effect resolves.
-              // Yield one macrotask before closing the scope so that span
-              // reaches the telemetry exporter's buffer before the scope's
-              // flush finalizer runs.
-              new Promise((resolve) => setTimeout(resolve, 0)).then(() =>
-                Effect.runPromise(Scope.close(scope, Exit.void)),
-              ),
-            ),
-      );
+      .finally(() => {
+        if (isScopeEjected(scope)) return undefined;
+        // The HttpMiddleware tracer ends the request's root span in a
+        // dispatcher task scheduled after the handler effect resolves.
+        // Yield one macrotask, flush telemetry before the event settles, then
+        // close ordinary request resources in the background via waitUntil.
+        return new Promise((resolve) => setTimeout(resolve, 0))
+          .then(() => Effect.runPromise(flushEventTelemetry(eventTelemetry)))
+          .then(() =>
+            ctx.waitUntil(Effect.runPromise(Scope.close(scope, Exit.void))),
+          );
+      });
   };
   class WorkerBridge extends Base {
     constructor(

--- a/packages/alchemy/src/Telemetry.ts
+++ b/packages/alchemy/src/Telemetry.ts
@@ -42,9 +42,8 @@
  *
  * - the exporter's batching fiber runs inside the event's I/O context
  *   (required on workerd, where timers/fetches are pinned to the request),
- * - buffered spans/logs/metrics are flushed when the request scope
- *   finalizes — registered with `ctx.waitUntil`, so flushing never delays
- *   the response.
+ * - buffered spans/logs/metrics are flushed before the runtime event settles,
+ *   while ordinary request finalizers remain registered with `ctx.waitUntil`.
  */
 import * as Config from "effect/Config";
 import * as Context from "effect/Context";
@@ -56,6 +55,7 @@ import * as Result from "effect/Result";
 import type * as Scope from "effect/Scope";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import * as OtlpExporter from "effect/unstable/observability/OtlpExporter";
 import * as OtlpLogger from "effect/unstable/observability/OtlpLogger";
 import * as OtlpMetrics from "effect/unstable/observability/OtlpMetrics";
 import * as OtlpSerialization from "effect/unstable/observability/OtlpSerialization";
@@ -291,6 +291,7 @@ const fanoutClient = (
 
 const makeExporterLayer = (options?: {
   exportInterval?: Duration.Input;
+  shutdownTimeout?: Duration.Input;
 }): TelemetryLayer =>
   Layer.unwrap(
     Effect.gen(function* () {
@@ -337,6 +338,7 @@ const makeExporterLayer = (options?: {
             url: SENTINEL.traces,
             resource,
             exportInterval: options?.exportInterval,
+            shutdownTimeout: options?.shutdownTimeout,
           }),
         );
       }
@@ -347,6 +349,7 @@ const makeExporterLayer = (options?: {
             url: SENTINEL.logs,
             resource,
             exportInterval: options?.exportInterval,
+            shutdownTimeout: options?.shutdownTimeout,
           }),
         );
       }
@@ -357,6 +360,7 @@ const makeExporterLayer = (options?: {
             url: SENTINEL.metrics,
             resource,
             exportInterval: options?.exportInterval,
+            shutdownTimeout: options?.shutdownTimeout,
           }),
         );
       }
@@ -391,8 +395,11 @@ const makeExporterLayer = (options?: {
  * A malformed configuration degrades to `Layer.empty` with a warning
  * instead of failing the event.
  */
+const eventTelemetryFlushTimeout: Duration.Input = "3 seconds";
+
 const fromBoundConfig: TelemetryLayer = makeExporterLayer({
   exportInterval: "1 hour",
+  shutdownTimeout: eventTelemetryFlushTimeout,
 });
 
 /**
@@ -420,8 +427,8 @@ const reference = Telemetry;
 /**
  * Install a custom telemetry Layer (any Layer providing a `Tracer`,
  * loggers, and/or metric exporters). It is built once per event into the
- * event's request scope, so scoped exporters flush when the request scope
- * finalizes.
+ * event's request scope. Effect OTLP exporters are explicitly flushed before
+ * the runtime event settles; other scoped exporters finalize with the scope.
  *
  * Custom layers COMPOSE with the built-in OTLP destinations and with each
  * other: loggers and metric exporters merge; a custom `Tracer` (a single
@@ -613,7 +620,7 @@ const destinationsOutput = (
  * bindings) — url and header values accept resource Outputs, so exporter
  * config is wired from resources like any other binding. At runtime the
  * exporter reads the bound values back and ships traces, logs, and metrics
- * over OTLP/HTTP JSON, flushed as each event's scope closes.
+ * over OTLP/HTTP JSON before each event settles.
  *
  * Exporters COMPOSE: merge several `otlp` layers (or vendor sugar like
  * `Axiom.Telemetry`) and every destination receives the telemetry — spans
@@ -659,6 +666,22 @@ export const layerOtlp = (options: OtlpOptions): Layer.Layer<never> =>
   );
 
 /**
+ * Flush buffered OTLP event telemetry before the owning runtime event settles.
+ * Custom telemetry Layers without Effect's OTLP flusher are a no-op.
+ */
+export const flushEventTelemetry = (
+  context: Context.Context<never>,
+): Effect.Effect<void> => {
+  const flusher = Context.getOrUndefined(context, OtlpExporter.Flusher);
+  return flusher === undefined
+    ? Effect.void
+    : flusher.flush.pipe(
+        Effect.timeoutOption(eventTelemetryFlushTimeout),
+        Effect.asVoid,
+      );
+};
+
+/**
  * Build the configured {@link Telemetry} Layer into an event's request
  * scope, returning the Context of telemetry services to provide to the
  * event's handler effect.
@@ -666,9 +689,8 @@ export const layerOtlp = (options: OtlpOptions): Layer.Layer<never> =>
  * Called by the runtime bridges (Worker, Durable Object, Workflow, Lambda)
  * once per event. Building into the *request* scope — not the
  * never-finalized isolate scope — is what makes export work on workerd:
- * the batching fiber lives inside the event's I/O context and the final
- * flush runs from the scope's finalizer, which the bridges register with
- * `ctx.waitUntil`.
+ * the batching fiber lives inside the event's I/O context, and the bridges
+ * explicitly flush its buffers before allowing the event to settle.
  *
  * A failed build (bad user Layer, config error) degrades to an empty
  * Context with a warning instead of failing the event.

--- a/packages/alchemy/test/Cloudflare/Workers/Telemetry.local.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/Telemetry.local.test.ts
@@ -1,0 +1,116 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Test from "@/Test/Alchemy";
+import { createServer, type Server } from "node:http";
+import { expect } from "alchemy-test";
+import * as ConfigProvider from "effect/ConfigProvider";
+import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import OtelEventFlushWorker from "./fixtures/otel-event-flush-worker.ts";
+
+const { test } = Test.make({ providers: Cloudflare.providers(), dev: true });
+
+interface DelayedOtlpCollector {
+  readonly server: Server;
+  readonly url: string;
+  readonly completedRequests: { value: number };
+}
+
+/**
+ * Starts a local OTLP endpoint that only counts responses fully written to the
+ * client. The Node server is a test adapter for observing workerd cancellation.
+ */
+const startDelayedOtlpCollector = Effect.acquireRelease(
+  Effect.callback<DelayedOtlpCollector, Error>((resume) => {
+    const completedRequests = { value: 0 };
+    const server = createServer((request, response) => {
+      request.resume();
+      request.once("end", () => {
+        setTimeout(() => {
+          response.once("finish", () => {
+            completedRequests.value += 1;
+          });
+          response.writeHead(200, { "content-type": "application/json" });
+          response.end('{"partialSuccess":{}}');
+        }, 500);
+      });
+    });
+    const onError = (error: Error) => resume(Effect.fail(error));
+    server.once("error", onError);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", onError);
+      const address = server.address();
+      if (address === null || typeof address === "string") {
+        resume(
+          Effect.fail(new Error("OTLP test collector address unavailable")),
+        );
+        return;
+      }
+      resume(
+        Effect.succeed({
+          server,
+          completedRequests,
+          url: `http://127.0.0.1:${address.port}/v1/traces`,
+        }),
+      );
+    });
+    return Effect.sync(() => server.close());
+  }),
+  ({ server }) =>
+    Effect.callback<void, Error>((resume) => {
+      server.close((error) =>
+        resume(error === undefined ? Effect.void : Effect.fail(error)),
+      );
+    }).pipe(Effect.orDie),
+);
+
+test.provider(
+  "flushes Worker and Durable Object OTLP batches before local workerd stops",
+  (stack) =>
+    Effect.gen(function* () {
+      const collector = yield* startDelayedOtlpCollector;
+      const currentConfig = yield* ConfigProvider.ConfigProvider;
+      const deployment = yield* stack
+        .deploy(
+          Effect.gen(function* () {
+            const worker = yield* OtelEventFlushWorker;
+            return { url: worker.url };
+          }),
+        )
+        .pipe(
+          Effect.provideService(
+            ConfigProvider.ConfigProvider,
+            ConfigProvider.orElse(
+              ConfigProvider.fromUnknown({
+                OTLP_EVENT_FLUSH_URL: collector.url,
+              }),
+              currentConfig,
+            ),
+          ),
+        );
+
+      if (deployment.url === undefined) {
+        return yield* Effect.die(
+          "OTLP event flush test Worker URL unavailable",
+        );
+      }
+      const client = yield* HttpClient.HttpClient;
+      const response = yield* client.get(deployment.url);
+      expect(response.status).toBe(200);
+      expect(yield* response.text).toBe("worker-saw:durable-object-ok");
+
+      // No later event can inherit background work: stop workerd immediately
+      // after the sole trigger event settles.
+      yield* stack.destroy();
+
+      yield* Effect.sync(() => collector.completedRequests.value).pipe(
+        Effect.repeat({
+          schedule: Schedule.spaced("100 millis"),
+          until: (completed) => completed >= 2,
+          times: 30,
+        }),
+      );
+      expect(collector.completedRequests.value).toBe(2);
+    }),
+  { timeout: 120_000 },
+);

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/otel-event-flush-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/otel-event-flush-worker.ts
@@ -1,0 +1,55 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Telemetry from "@/Telemetry.ts";
+import * as Config from "effect/Config";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+/** Durable Object HTTP target whose event emits a child span. */
+export class OtelEventFlushTarget extends Cloudflare.DurableObject<OtelEventFlushTarget>()(
+  "OtelEventFlushTarget",
+  Effect.succeed(
+    Effect.succeed({
+      fetch: Effect.succeed(HttpServerResponse.text("durable-object-ok")).pipe(
+        Effect.withSpan("otel-event-flush.child"),
+      ),
+    }),
+  ),
+) {}
+
+/** Worker that emits one Worker and one Durable Object OTLP event batch. */
+export default class OtelEventFlushWorker extends Cloudflare.Worker<OtelEventFlushWorker>()(
+  "OtelEventFlushWorker",
+  {
+    main: import.meta.url,
+  },
+  Effect.gen(function* () {
+    const targetNamespace = yield* OtelEventFlushTarget;
+
+    return {
+      fetch: Effect.gen(function* () {
+        const targetClient = Cloudflare.toHttpClient(
+          targetNamespace.getByName("target"),
+        );
+        const response = yield* targetClient.execute(
+          HttpClientRequest.get("http://otel-event-flush-target/"),
+        );
+        return HttpServerResponse.text(`worker-saw:${yield* response.text}`);
+      }).pipe(Effect.orDie),
+    };
+  }).pipe(
+    Effect.provide(
+      Layer.unwrap(
+        Config.string("OTLP_EVENT_FLUSH_URL").pipe(
+          Effect.map((url) =>
+            Telemetry.layerOtlp({
+              traces: { url },
+              serviceName: "otel-event-flush-test",
+            }),
+          ),
+        ),
+      ),
+    ),
+  ),
+) {}


### PR DESCRIPTION
Flush event-scoped OTLP buffers before Worker and Durable Object promises settle, while keeping ordinary scope finalizers under `waitUntil`.

```ts
await flushEventTelemetry(eventTelemetry)
ctx.waitUntil(Effect.runPromise(Scope.close(scope, Exit.void)))
```

The bridge still yields one macrotask for Effect's late HTTP server span. Stream-ejected scopes keep their existing completion ownership.

Adds a real local-workerd regression that is red without the fix (`0` completed event batches) and green with it (`2` completed Worker/DO batches). Reproduction: https://github.com/dmmulroy/alchemy-workerd-otlp-flush-repro

Closes #1331.

Investigation and remediation guided by Dillon Mulroy ([@dmmulroy](https://github.com/dmmulroy)).