### PR TITLE
chore(docs): update prisma logo

### DIFF
--- a/website/src/docs-icons.ts
+++ b/website/src/docs-icons.ts
@@ -1,15 +1,30 @@
 /**
  * Icon resolution for the docs chrome (tab bar + sidebar group headings).
  *
- * Two sources, both 24×24 viewBox and theme-adaptive via `currentColor`:
+ * Three sources, all 24×24 viewBox and theme-adaptive via `currentColor`:
  * - lucide (stroke outlines) for generic concepts (tutorial, data, guides…)
  * - simple-icons (fill) for official provider brand marks (Cloudflare, AWS…)
+ * - custom (fill) for brand marks simple-icons has not caught up with yet
  */
 import { icons as lucide } from "@iconify-json/lucide";
 import { icons as brands } from "@iconify-json/simple-icons";
 
+/**
+ * Brand marks in the same body format simple-icons emits, for vendors whose
+ * upstream icon is stale. Delete an entry once simple-icons ships the new
+ * mark and move the call site back to `b()`.
+ */
+const custom: Record<string, string> = {
+  // Prisma's 2026 prism mark; simple-icons still ships the pre-2026 logo.
+  // Traced from the "Symbol" artwork in Prisma's brand kit (263×264), scaled
+  // uniformly and centred — the mark must not be stretched to fill the box.
+  prisma:
+    '<path fill="currentColor" d="M5.2578 8.4091L0.0455 13.6308V4.8636L4.8828 0.0095V0H13.6385L5.2578 8.4091Z M23.9545 8.3405L8.3231 24H0.0455V15.6572L15.6745 0H23.9545V8.3405Z M19.1078 24H10.3521L14.2685 20.0703L23.9546 10.3667V19.1364L19.1078 24Z"/>',
+};
+
 const l = (name: string): string | undefined => lucide.icons[name]?.body;
 const b = (name: string): string | undefined => brands.icons[name]?.body;
+const c = (name: string): string | undefined => custom[name];
 
 /** Tab bar icons, keyed by tab label (see docs-tabs.ts). */
 export const TAB_ICONS: Record<string, string | undefined> = {
@@ -21,7 +36,7 @@ export const TAB_ICONS: Record<string, string | undefined> = {
   Fly: b("flydotio"),
   PlanetScale: b("planetscale"),
   Neon: b("neon"),
-  Prisma: b("prisma"),
+  Prisma: c("prisma"),
   Axiom: l("activity"),
   "Better Auth": l("key-round"),
   GitHub: b("github"),
@@ -72,7 +87,7 @@ const GROUP_ICONS: Record<string, string | undefined> = {
   Neon: b("neon"),
   Planetscale: b("planetscale"),
   PlanetScale: b("planetscale"),
-  Prisma: b("prisma"),
+  Prisma: c("prisma"),
   Axiom: l("activity"),
   Docker: b("docker"),
   Kubernetes: b("kubernetes"),


### PR DESCRIPTION
Hey Alchemy team, we at Prisma are launching our new branding including logo. This is a little PR to update the Prisma logo to the new branding. Screenshots below:

<img width="362" height="198" alt="CleanShot 2026-08-25 at 00 40 35@2x" src="https://github.com/user-attachments/assets/f1c5b139-4f81-4ba4-9e46-c81571dc4a94" />
<img width="498" height="248" alt="CleanShot 2026-08-25 at 00 40 28@2x" src="https://github.com/user-attachments/assets/dab1561e-8010-4da5-a40e-6fbdcee5782e" />

Happy to adjust the approach if you prefer another way to apply a custom logo that isn't in the existing set.