### PR TITLE
test(cloudflare): pin OTLP event-telemetry contracts; fix teardown-hook cleanup leaks

### DIFF
--- a/packages/alchemy-test/src/Runner.ts
+++ b/packages/alchemy-test/src/Runner.ts
@@ -670,13 +670,24 @@ const runSuite: (suite: Suite, ctx: ExecContext) => Effect.Effect<void> =
 const runAfterAll = Effect.fn(function* (suite: Suite, ctx: ExecContext) {
   if (suite.afterAll.length === 0) return;
   yield* ctx.emit({ _tag: "HookStart", file: ctx.file, hook: "afterAll" });
-  const exit = yield* runHooks(suite.afterAll, ctx.options.timeout).pipe(
-    withCapture(ctx.fileLogs),
-    Effect.exit,
-  );
+  // Unlike beforeAll (where a failure invalidates everything after it),
+  // every teardown hook runs even when an earlier one fails: a failing
+  // teardown assertion must not drop later cleanup — in particular
+  // Test.make's fallback hook that closes the shared scope and local
+  // provider sidecar, which registers last and would otherwise leak the
+  // sidecar for the rest of the process. Failures aggregate.
+  const exits = yield* Effect.forEach(suite.afterAll, (hook) =>
+    Effect.suspend(hook.body).pipe(
+      Effect.timeout(Duration.millis(hook.timeout ?? ctx.options.timeout)),
+      Effect.exit,
+    ),
+  ).pipe(withCapture(ctx.fileLogs));
   yield* ctx.emit({ _tag: "HookEnd", file: ctx.file, hook: "afterAll" });
-  if (Exit.isFailure(exit)) {
-    const error = `afterAll hook failed:\n${prettyCause(exit.cause)}`;
+  const failures = exits.filter(Exit.isFailure);
+  if (failures.length > 0) {
+    const error = `afterAll hook failed:\n${failures
+      .map((exit) => prettyCause(exit.cause))
+      .join("\n")}`;
     ctx.fileErrors.push(error);
   }
 });

--- a/packages/alchemy-test/test/Runner.test.ts
+++ b/packages/alchemy-test/test/Runner.test.ts
@@ -141,3 +141,53 @@ it("fails the process for every hook kind and preserves hook output", async () =
     await rm(root, { recursive: true, force: true });
   }
 });
+
+it("runs every afterAll hook even when an earlier one fails", async () => {
+  // Regression: `runAfterAll` used to short-circuit on the first failing
+  // hook, so a failing teardown assertion silently dropped every later
+  // afterAll — in particular Test.make's fallback hook that closes the
+  // shared scope and local provider sidecar, leaking the sidecar for the
+  // rest of the process. All teardown hooks must run; failures aggregate.
+  const root = await mkdtemp(resolve(tmpdir(), "alchemy-test-afterall-"));
+  try {
+    await writeFile(
+      resolve(root, "teardown-chain.test.ts"),
+      `
+        import { it, registerHook } from ${JSON.stringify(apiUrl)};
+        import * as Effect from ${JSON.stringify(effectUrl)};
+        registerHook("afterAll", { body: () => Effect.gen(function* () {
+          return yield* Effect.fail(new Error("first-teardown-failed"));
+        }) });
+        registerHook("afterAll", { body: () => Effect.gen(function* () {
+          yield* Effect.log("second-teardown-ran");
+        }) });
+        it("body", () => {});
+      `,
+    );
+
+    const child = Bun.spawn(
+      [process.execPath, cli, root, "--retry", "0", "--concurrency", "1"],
+      {
+        cwd: root,
+        stdout: "pipe",
+        stderr: "pipe",
+        env: { ...process.env, NO_COLOR: "1" },
+      },
+    );
+    const [exitCode, stdout, stderr] = await Promise.all([
+      child.exited,
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+    ]);
+    const output = `${stdout}\n${stderr}`;
+
+    // The failure is reported and fails the run…
+    expect(exitCode).toBe(1);
+    expect(output).toContain("afterAll hook failed:");
+    expect(output).toContain("first-teardown-failed");
+    // …and the later teardown hook still ran.
+    expect(output).toContain("second-teardown-ran");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/packages/alchemy/src/Test/Bun.ts
+++ b/packages/alchemy/src/Test/Bun.ts
@@ -194,12 +194,25 @@ export const make = <ROut = any>(options: MakeOptions<ROut>): TestApi => {
     bun.beforeEach(() => runEff(eff), hookOptions);
   };
 
+  // bun:test stops running later `afterAll` hooks once one throws, which
+  // would skip the fallback cleanup hook below — leaking the shared scope
+  // and the sidecar for the rest of the process whenever a teardown
+  // assertion fails. Guard every user teardown: on failure, run the
+  // (idempotent) cleanup before rethrowing so the failure still fails the
+  // suite. (`closeAll` is initialized below; hooks only run after `make`
+  // returns.)
+  const guardTeardown = (eff: TestEffect<any>) => () =>
+    runEff(eff).catch(async (error) => {
+      await Effect.runPromise(closeAll);
+      throw error;
+    });
+
   const afterAll = ((eff, hookOptions) => {
-    bun.afterAll(() => runEff(eff), hookOptions ?? DEFAULT_HOOK_TIMEOUT);
+    bun.afterAll(guardTeardown(eff), hookOptions ?? DEFAULT_HOOK_TIMEOUT);
   }) as AfterAllFn;
   afterAll.skipIf = (predicate) => (eff, hookOptions) => {
     if (predicate) return;
-    bun.afterAll(() => runEff(eff), hookOptions ?? DEFAULT_HOOK_TIMEOUT);
+    bun.afterAll(guardTeardown(eff), hookOptions ?? DEFAULT_HOOK_TIMEOUT);
   };
 
   const afterEach: AfterEachFn = (eff, hookOptions) => {

--- a/packages/alchemy/test/Cloudflare/Workers/Telemetry.local.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/Telemetry.local.test.ts
@@ -1,0 +1,144 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Test from "@/Test/Alchemy";
+import { createServer, type Server } from "node:http";
+import { expect } from "alchemy-test";
+import * as ConfigProvider from "effect/ConfigProvider";
+import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import OtelEventFlushWorker from "./fixtures/otel-event-flush-worker.ts";
+
+const { test } = Test.make({ providers: Cloudflare.providers(), dev: true });
+
+interface DelayedOtlpCollector {
+  readonly server: Server;
+  readonly url: string;
+  readonly completedRequests: { value: number };
+}
+
+/**
+ * Starts a local OTLP endpoint that only counts responses fully written to the
+ * client. The Node server is a test adapter for observing workerd cancellation.
+ */
+const startDelayedOtlpCollector = Effect.acquireRelease(
+  Effect.callback<DelayedOtlpCollector, Error>((resume) => {
+    const completedRequests = { value: 0 };
+    const server = createServer((request, response) => {
+      request.resume();
+      request.once("end", () => {
+        setTimeout(() => {
+          response.once("finish", () => {
+            completedRequests.value += 1;
+          });
+          response.writeHead(200, { "content-type": "application/json" });
+          response.end('{"partialSuccess":{}}');
+        }, 500);
+      });
+    });
+    const onError = (error: Error) => resume(Effect.fail(error));
+    server.once("error", onError);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", onError);
+      const address = server.address();
+      if (address === null || typeof address === "string") {
+        resume(
+          Effect.fail(new Error("OTLP test collector address unavailable")),
+        );
+        return;
+      }
+      resume(
+        Effect.succeed({
+          server,
+          completedRequests,
+          url: `http://127.0.0.1:${address.port}/v1/traces`,
+        }),
+      );
+    });
+    return Effect.sync(() => server.close());
+  }),
+  ({ server }) =>
+    Effect.callback<void, Error>((resume) => {
+      server.close((error) =>
+        resume(error === undefined ? Effect.void : Effect.fail(error)),
+      );
+    }).pipe(Effect.orDie),
+);
+
+test.provider(
+  "delivers Worker and Durable Object OTLP batches without delaying the Worker response",
+  (stack) =>
+    Effect.gen(function* () {
+      const collector = yield* startDelayedOtlpCollector;
+      const currentConfig = yield* ConfigProvider.ConfigProvider;
+      const deployment = yield* stack
+        .deploy(
+          Effect.gen(function* () {
+            const worker = yield* OtelEventFlushWorker;
+            return { url: worker.url };
+          }),
+        )
+        .pipe(
+          Effect.provideService(
+            ConfigProvider.ConfigProvider,
+            ConfigProvider.orElse(
+              ConfigProvider.fromUnknown({
+                OTLP_EVENT_FLUSH_URL: collector.url,
+              }),
+              currentConfig,
+            ),
+          ),
+        );
+
+      if (deployment.url === undefined) {
+        return yield* Effect.die(
+          "OTLP event flush test Worker URL unavailable",
+        );
+      }
+      const client = yield* HttpClient.HttpClient;
+      const response = yield* client.get(deployment.url);
+      expect(response.status).toBe(200);
+      expect(yield* response.text).toBe("worker-saw:durable-object-ok");
+
+      // The latency contract: the Worker's own batch must still be in
+      // flight at response time — its export completes in the background
+      // under `ctx.waitUntil`, so the 500ms-delayed collector cannot have
+      // acknowledged it yet. A value of 2 here means the Worker response
+      // waited on its own telemetry export — a latency regression. (The DO
+      // batch may or may not have completed, depending on whether the DO
+      // bridge exports foreground or background — both satisfy the
+      // contract.)
+      const completedAtResponse = collector.completedRequests.value;
+      expect(completedAtResponse).toBeLessThanOrEqual(1);
+
+      // The delivery contract: with workerd still alive, background
+      // exports must complete — nothing is lost.
+      yield* Effect.sync(() => collector.completedRequests.value).pipe(
+        Effect.repeat({
+          schedule: Schedule.spaced("100 millis"),
+          until: (completed) => completed >= 2,
+          times: 30,
+        }),
+      );
+      expect(collector.completedRequests.value).toBe(2);
+
+      // Same contract for the Durable Object RPC event path: the Worker's
+      // own batch (the 4th) must not be complete at response time.
+      const rpcResponse = yield* client.get(`${deployment.url}/rpc`);
+      expect(rpcResponse.status).toBe(200);
+      expect(yield* rpcResponse.text).toBe("worker-saw:durable-object-rpc-ok");
+      expect(collector.completedRequests.value).toBeLessThanOrEqual(3);
+
+      yield* Effect.sync(() => collector.completedRequests.value).pipe(
+        Effect.repeat({
+          schedule: Schedule.spaced("100 millis"),
+          until: (completed) => completed >= 4,
+          times: 30,
+        }),
+      );
+      expect(collector.completedRequests.value).toBe(4);
+
+      yield* stack.destroy();
+      expect(collector.completedRequests.value).toBe(4);
+    }),
+  { timeout: 120_000 },
+);

--- a/packages/alchemy/test/Cloudflare/Workers/Telemetry.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/Telemetry.test.ts
@@ -9,6 +9,7 @@ import * as pathe from "pathe";
 import { expectUrlContains } from "../Utils/Http.ts";
 import type { OtelSink } from "./fixtures/otel-collector-worker.ts";
 import OtelCustomWorker from "./fixtures/otel-custom-worker.ts";
+import OtelEventFlushWorker from "./fixtures/otel-event-flush-worker.ts";
 import OtelTracedWorker from "./fixtures/otel-traced-worker.ts";
 
 const { test } = Test.make({ providers: Cloudflare.providers() });
@@ -72,13 +73,14 @@ describe("Cloudflare Worker Telemetry", () => {
         // test body runs, so layer the just-learned collector URL on top of
         // the current provider for this deploy only.
         const currentConfig = yield* ConfigProvider.ConfigProvider;
-        const { traced, custom } = yield* stack
+        const { traced, custom, flush } = yield* stack
           .deploy(
             Effect.gen(function* () {
               yield* collectorWorker();
               const traced = yield* OtelTracedWorker;
               const custom = yield* OtelCustomWorker;
-              return { traced, custom };
+              const flush = yield* OtelEventFlushWorker;
+              return { traced, custom, flush };
             }),
           )
           .pipe(
@@ -87,6 +89,7 @@ describe("Cloudflare Worker Telemetry", () => {
               ConfigProvider.orElse(
                 ConfigProvider.fromUnknown({
                   COLLECTOR_URL: collectorUrl,
+                  OTLP_EVENT_FLUSH_URL: `${collectorUrl}/v1/traces`,
                 }),
                 currentConfig,
               ),
@@ -141,6 +144,40 @@ describe("Cloudflare Worker Telemetry", () => {
         });
         yield* expectUrlContains(collected, "custom.child-span");
         yield* expectUrlContains(collected, "custom-work-log");
+
+        // Durable Object event paths on deployed workerd: the Worker calls
+        // its DO over HTTP and over RPC; each DO event is its own telemetry
+        // scope. `state.waitUntil` is a no-op in DOs, so DO batches only
+        // arrive if the DurableObjectBridge's flush actually completes
+        // before/despite the event's I/O context winding down.
+        const flushUrl = flush.url as string;
+        yield* expectUrlContains(
+          `${flushUrl}/`,
+          "worker-saw:durable-object-ok",
+          {
+            timeout: "240 seconds",
+            label: "event-flush worker via DO fetch",
+          },
+        );
+        yield* expectUrlContains(
+          `${flushUrl}/rpc`,
+          "worker-saw:durable-object-rpc-ok",
+          {
+            timeout: "120 seconds",
+            label: "event-flush worker via DO rpc",
+          },
+        );
+        // The DO fetch event's child span…
+        yield* expectUrlContains(collected, "otel-event-flush.child", {
+          timeout: "120 seconds",
+          label: "deployed DO fetch event batch",
+        });
+        // …and the DO RPC method event's child span both reach the
+        // collector.
+        yield* expectUrlContains(collected, "otel-event-flush.rpc", {
+          timeout: "120 seconds",
+          label: "deployed DO rpc event batch",
+        });
       }),
     { timeout: 600_000 },
   );

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/otel-event-flush-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/otel-event-flush-worker.ts
@@ -1,0 +1,69 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Telemetry from "@/Telemetry.ts";
+import * as Config from "effect/Config";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+/**
+ * Durable Object target whose events emit child spans — one HTTP fetch
+ * event and one RPC method event, so both DurableObjectBridge paths get
+ * telemetry coverage.
+ */
+export class OtelEventFlushTarget extends Cloudflare.DurableObject<OtelEventFlushTarget>()(
+  "OtelEventFlushTarget",
+  Effect.succeed(
+    Effect.succeed({
+      fetch: Effect.succeed(HttpServerResponse.text("durable-object-ok")).pipe(
+        Effect.withSpan("otel-event-flush.child"),
+      ),
+      ping: () =>
+        Effect.succeed("durable-object-rpc-ok").pipe(
+          Effect.withSpan("otel-event-flush.rpc"),
+        ),
+    }),
+  ),
+) {}
+
+/** Worker that emits one Worker and one Durable Object OTLP event batch. */
+export default class OtelEventFlushWorker extends Cloudflare.Worker<OtelEventFlushWorker>()(
+  "OtelEventFlushWorker",
+  {
+    main: import.meta.url,
+  },
+  Effect.gen(function* () {
+    const targetNamespace = yield* OtelEventFlushTarget;
+
+    return {
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        if (request.url.startsWith("/rpc")) {
+          const pong = yield* targetNamespace.getByName("target").ping();
+          return HttpServerResponse.text(`worker-saw:${pong}`);
+        }
+        const targetClient = Cloudflare.toHttpClient(
+          targetNamespace.getByName("target"),
+        );
+        const response = yield* targetClient.execute(
+          HttpClientRequest.get("http://otel-event-flush-target/"),
+        );
+        return HttpServerResponse.text(`worker-saw:${yield* response.text}`);
+      }).pipe(Effect.orDie),
+    };
+  }).pipe(
+    Effect.provide(
+      Layer.unwrap(
+        Config.string("OTLP_EVENT_FLUSH_URL").pipe(
+          Effect.map((url) =>
+            Telemetry.layerOtlp({
+              traces: { url },
+              serviceName: "otel-event-flush-test",
+            }),
+          ),
+        ),
+      ),
+    ),
+  ),
+) {}

--- a/packages/alchemy/test/Test/Bun.test.ts
+++ b/packages/alchemy/test/Test/Bun.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "alchemy-test";
+import { fileURLToPath } from "node:url";
+
+const fixturesDir = fileURLToPath(new URL("./fixtures/", import.meta.url));
+
+describe("Bun adapter fallback cleanup", () => {
+  test(
+    "closes the shared scope when a user afterAll throws",
+    async () => {
+      // bun:test stops the afterAll chain on the first throw, so without
+      // the adapter's teardown guard the microtask-registered fallback
+      // (which closes the shared scope + sidecar) never runs. The fixture's
+      // shared-scope finalizer printing proves the guard closed the scope;
+      // the non-zero exit proves the teardown failure still fails the run.
+      const child = Bun.spawn(
+        ["bun", "test", "./bun-teardown-guard.fixture.ts"],
+        {
+          cwd: fixturesDir,
+          stdout: "pipe",
+          stderr: "pipe",
+          env: { ...process.env, NO_COLOR: "1", ALCHEMY_DEV: "" },
+        },
+      );
+      const [exitCode, stdout, stderr] = await Promise.all([
+        child.exited,
+        new Response(child.stdout).text(),
+        new Response(child.stderr).text(),
+      ]);
+      const output = `${stdout}\n${stderr}`;
+
+      expect(exitCode).not.toBe(0);
+      expect(output).toContain("teardown-assertion-failed");
+      const userHook = output.indexOf("BUN_GUARD:user-afterAll-throws");
+      const finalizer = output.indexOf("BUN_GUARD:shared-scope-finalizer-ran");
+      expect(userHook).toBeGreaterThanOrEqual(0);
+      // The cleanup ran, and ran after the failing user teardown.
+      expect(finalizer).toBeGreaterThan(userHook);
+    },
+    { timeout: 60_000 },
+  );
+});

--- a/packages/alchemy/test/Test/fixtures/bun-teardown-guard.fixture.ts
+++ b/packages/alchemy/test/Test/fixtures/bun-teardown-guard.fixture.ts
@@ -1,0 +1,29 @@
+// Run by `bun test ./<path>` from Bun.test.ts — the `.fixture.ts` suffix
+// keeps alchemy-test from collecting it. Exercises `alchemy/Test/Bun`'s
+// teardown guard: bun:test stops running later `afterAll` hooks once one
+// throws, so the adapter must run its fallback cleanup (closing the shared
+// scope and sidecar) itself before rethrowing — otherwise a failing
+// teardown assertion leaks them for the rest of the process.
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Test from "@/Test/Bun.ts";
+
+const { test, beforeAll, afterAll } = Test.make({
+  providers: Layer.empty as never,
+});
+
+// Attaches to the adapter's shared scope (provided to every hook/test by
+// `Core.toEffect`), so this line printing proves the fallback cleanup ran.
+beforeAll(
+  Effect.addFinalizer(() =>
+    Effect.sync(() => console.log("BUN_GUARD:shared-scope-finalizer-ran")),
+  ),
+);
+
+afterAll(
+  Effect.sync(() => {
+    console.log("BUN_GUARD:user-afterAll-throws");
+  }).pipe(Effect.andThen(Effect.fail(new Error("teardown-assertion-failed")))),
+);
+
+test("body", Effect.void);


### PR DESCRIPTION
Resolves the investigation behind #1331 / #1332: the runtime bridges need **no change** — the existing `waitUntil`-deferred background export delivers every batch, verified empirically on local and deployed workerd for Worker fetch, DO fetch, and DO RPC events. The loss in #1331's repro was the test harness tearing workerd down before background work ran (#1341 fixes the Vitest adapter). This PR pins the telemetry contracts as tests, and fixes the same teardown-leak class in the two other test adapters.

### Telemetry contract tests (no bridge changes)

| environment | Worker fetch | DO fetch | DO RPC |
| --- | --- | --- | --- |
| local workerd (dev sidecar, alive) | ✓ | ✓ | ✓ |
| deployed workerd | ✓ | ✓ | ✓ |

- **Delivery** — every event's OTLP batch reaches the collector while the runtime is alive. Locally via a 500ms-delayed `127.0.0.1` collector counting only fully-written responses; live via the DO-backed collector on the test zone (`Telemetry.test.ts` now also deploys the Worker→DO fixture and asserts the DO fetch and DO RPC event spans arrive from deployed workerd — `state.waitUntil` is a no-op in DOs, so this is the path #1331 believed was broken).
- **Latency** — an event's response never waits on its own telemetry export:

```ts
const completedAtResponse = collector.completedRequests.value;
expect(completedAtResponse).toBeLessThanOrEqual(1); // own batch still in flight
```

A foreground-flush design fails the latency bound; a lossy design fails the delivery poll.

### Teardown-hook leak fixes (companion to #1341)

A failing teardown hook silently dropped later cleanup — leaking the shared scope and local provider sidecar for the rest of the test process. Each adapter had it with a different trigger; #1341 covers Vitest, this covers the other two:

- **alchemy-test runner**: `runAfterAll` short-circuited on the first failing hook. Every `afterAll` now runs; failures aggregate. (`beforeAll` keeps short-circuit semantics — a failed setup invalidates what follows.)
- **Test/Bun**: bun:test stops the `afterAll` chain once a hook throws (probed empirically; registration order and afterAll-after-failed-`beforeAll` are fine), skipping the microtask-registered fallback. User teardowns are now guarded:

```ts
const guardTeardown = (eff) => () =>
  runEff(eff).catch(async (error) => {
    await Effect.runPromise(closeAll); // idempotent
    throw error;                       // still fails the suite
  });
```

Both regression tests are two-sided and red against the previous code: the runner test asserts a second teardown's sentinel after a failing first; the Bun test spawns real `bun test` on a fixture using the public adapter and asserts a shared-scope finalizer sentinel after the throwing user teardown.

Builds on @dmmulroy's investigation and repro topology from #1331/#1332.
