### PR TITLE
chore(test): correct llms.txt marker in Vocs live test

### DIFF
--- a/packages/alchemy/test/Cloudflare/Website/Vocs.test.ts
+++ b/packages/alchemy/test/Cloudflare/Website/Vocs.test.ts
@@ -99,10 +99,14 @@ describe.concurrent("Vocs", () => {
             label: "Vocs public asset",
           },
         );
-        yield* expectUrlContains(`${site1.url!}/llms.txt`, "Alchemy Vocs", {
-          timeout: "60 seconds",
-          label: "Vocs generated llms asset",
-        });
+        yield* expectUrlContains(
+          `${site1.url!}/llms.txt`,
+          "Alchemy with Vocs",
+          {
+            timeout: "60 seconds",
+            label: "Vocs generated llms asset",
+          },
+        );
 
         const site2 = yield* deploy();
         expect(site2.hash?.input).toEqual(site1.hash?.input);


### PR DESCRIPTION
The Vocs live test asserted that `/llms.txt` contains `"Alchemy Vocs"`, but the fixture at `examples/cloudflare-website-vocs` generates it from the site title `"Alchemy with Vocs"` — the substring never occurs, so the assertion polled until its 60s timeout and the test could never pass.

```diff
-yield* expectUrlContains(`${site1.url!}/llms.txt`, "Alchemy Vocs", {
+yield* expectUrlContains(`${site1.url!}/llms.txt`, "Alchemy with Vocs", {
```

This matches the example's own integ test (`examples/cloudflare-website-vocs/test/integ.test.ts`). Verified with a live run: `pnpm test test/Cloudflare/Website/Vocs.test.ts --profile testing` passes (55.8s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
