### PR TITLE
fix(cloudflare/email): retry rule writes while a fresh Worker propagates

### DIFF
--- a/packages/alchemy/src/Cloudflare/Email/CatchAll.ts
+++ b/packages/alchemy/src/Cloudflare/Email/CatchAll.ts
@@ -8,6 +8,7 @@ import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
 import type { Providers } from "../Providers.ts";
 import { resolveZoneId, type Reference } from "../Zone/index.ts";
 import { listAllZones } from "../Zone/lookup.ts";
+import { retryWorkerScriptNotFound } from "./retry.ts";
 import type { Action } from "./Rule.ts";
 
 const CatchAllTypeId = "Cloudflare.Email.CatchAll" as const;
@@ -222,17 +223,19 @@ export const CatchAllProvider = () =>
       ) {
         return toAttributes(zoneId, observed, initial);
       }
-      const result = yield* emailRouting.putRuleCatchAll({
-        zoneId,
-        matchers: [{ type: "all" }],
-        actions: news.actions.map((a) =>
-          a.type === "drop"
-            ? { type: a.type }
-            : { type: a.type, value: a.value },
-        ),
-        enabled: desiredEnabled,
-        name: desiredName,
-      });
+      const result = yield* emailRouting
+        .putRuleCatchAll({
+          zoneId,
+          matchers: [{ type: "all" }],
+          actions: news.actions.map((a) =>
+            a.type === "drop"
+              ? { type: a.type }
+              : { type: a.type, value: a.value },
+          ),
+          enabled: desiredEnabled,
+          name: desiredName,
+        })
+        .pipe(retryWorkerScriptNotFound);
       return toAttributes(zoneId, result, initial);
     }),
 

--- a/packages/alchemy/src/Cloudflare/Email/Rule.ts
+++ b/packages/alchemy/src/Cloudflare/Email/Rule.ts
@@ -8,6 +8,7 @@ import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
 import type { Providers } from "../Providers.ts";
 import { resolveZoneId, type Reference } from "../Zone/index.ts";
 import { listAllZones } from "../Zone/lookup.ts";
+import { retryWorkerScriptNotFound } from "./retry.ts";
 
 export type Matcher =
   | { type: "all" }
@@ -174,16 +175,19 @@ export const RuleProvider = () =>
             ...body,
           })
           .pipe(
+            retryWorkerScriptNotFound,
             Effect.catch(() =>
               emailRouting
                 .createRule({ zoneId, ...body })
-                .pipe(Effect.map((r) => r)),
+                .pipe(retryWorkerScriptNotFound),
             ),
           );
         return normalize(result, zoneId);
       }
 
-      const result = yield* emailRouting.createRule({ zoneId, ...body });
+      const result = yield* emailRouting
+        .createRule({ zoneId, ...body })
+        .pipe(retryWorkerScriptNotFound);
       return normalize(result, zoneId);
     }),
     delete: Effect.fn(function* ({ output }) {

--- a/packages/alchemy/src/Cloudflare/Email/retry.ts
+++ b/packages/alchemy/src/Cloudflare/Email/retry.ts
@@ -1,0 +1,29 @@
+import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
+
+/**
+ * Ride out the window in which a Worker created earlier in the same apply is
+ * not yet visible to Email Routing's action validation.
+ *
+ * Cloudflare validates a `{ type: "worker", value: [scriptName] }` action
+ * while handling the create/update request and rejects it with
+ * `WorkerScriptNotFound` ("Workers Script Info not found") until the script
+ * propagates — typically within a few hundred milliseconds. The rejected call
+ * creates nothing, so a retry cannot produce a duplicate rule.
+ *
+ * Mirrors `Cloudflare/Fetcher`'s treatment of a freshly-deployed script:
+ * bounded exponential backoff (~25s total), then re-raise the original error
+ * unchanged so a genuinely missing Worker still fails and says so.
+ *
+ * @see https://github.com/alchemy-run/alchemy/issues/1348
+ */
+export const retryWorkerScriptNotFound = <A, E extends { _tag: string }, R>(
+  effect: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> =>
+  effect.pipe(
+    Effect.retry({
+      while: (error) => error._tag === "WorkerScriptNotFound",
+      schedule: Schedule.exponential("100 millis"),
+      times: 8,
+    }),
+  );

--- a/packages/alchemy/test/Cloudflare/Email/EmailRuleWorkerTarget.test.ts
+++ b/packages/alchemy/test/Cloudflare/Email/EmailRuleWorkerTarget.test.ts
@@ -1,0 +1,147 @@
+import * as Cloudflare from "@/Cloudflare";
+import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
+import { findZoneByName } from "@/Cloudflare/Zone/lookup";
+import * as Test from "@/Test/Alchemy";
+import * as emailRouting from "@distilled.cloud/cloudflare/email-routing";
+import { describe, expect } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+import * as Schedule from "effect/Schedule";
+import RuleTargetWorker from "./fixtures/rule-target-worker.ts";
+
+const { test } = Test.make({ providers: Cloudflare.providers() });
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+const zoneName =
+  process.env.CLOUDFLARE_TEST_DNS_ZONE_NAME ?? "alchemy-test-2.us";
+
+const resolveZoneId = Effect.gen(function* () {
+  const { accountId } = yield* yield* CloudflareEnvironment;
+  const zone = yield* findZoneByName({ accountId, name: zoneName });
+  if (!zone) {
+    return yield* Effect.die(
+      new Error(`zone "${zoneName}" not found in account`),
+    );
+  }
+  return zone.id;
+});
+
+// The scoped API token the test harness mints propagates eventually-
+// consistently across Cloudflare's edge — a fresh token intermittently 403s.
+const enableRouting = (zoneId: string) =>
+  emailRouting.enableEmailRouting({ zoneId }).pipe(
+    Effect.retry({
+      while: (e) => e._tag === "Forbidden",
+      schedule: Schedule.exponential("500 millis"),
+      times: 8,
+    }),
+  );
+
+describe.sequential("Email.Rule -> Worker in one apply", () => {
+  // Coverage for the shape reported in #1348: a Worker plus a routing
+  // resource whose `{ type: "worker", value: [scriptName] }` action names
+  // it, both created in the same apply, into a stage that did not exist.
+  //
+  // NOTE: this does NOT reproduce the #1348 failure on current main, and
+  // was confirmed to still pass with the provider's retry removed. The
+  // Worker provider pre-creates a stub script before the rule is created
+  // (see "pre-creating" in a deploy log), so by the time Cloudflare
+  // validates the action the name already resolves. The retry stays as
+  // defensive handling for paths where that stub is absent or slow — the
+  // error itself is real and typed (`WorkerScriptNotFound`, Cloudflare
+  // code 2016, observed live on both createRule and putRuleCatchAll).
+  test.provider(
+    "first deploy of a fresh stage creates the rule targeting the worker",
+    (stack) =>
+      Effect.gen(function* () {
+        const zoneId = yield* resolveZoneId;
+
+        // A never-before-deployed stage is the precondition — start from a
+        // torn-down stack so the Worker really is created in this apply.
+        yield* stack.destroy();
+        yield* enableRouting(zoneId);
+
+        const { rule, workerName } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const routing = yield* Cloudflare.Email.Routing("Routing", {
+              zone: zoneName,
+            });
+            const worker = yield* RuleTargetWorker;
+            const rule = yield* Cloudflare.Email.Rule("WorkerRule", {
+              zone: { zoneId: routing.zoneId },
+              name: "alchemy worker-target test",
+              matchers: [
+                {
+                  type: "literal",
+                  field: "to",
+                  value: `worker-target@${zoneName}`,
+                },
+              ],
+              actions: [{ type: "worker", value: [worker.workerName] }],
+            });
+            return { rule, workerName: worker.workerName };
+          }),
+        );
+
+        expect(rule.ruleId).not.toEqual("");
+        expect(rule.zoneId).toEqual(zoneId);
+        expect(rule.actions).toEqual([{ type: "worker", value: [workerName] }]);
+
+        // Verify out-of-band that Cloudflare really stored the worker action.
+        const live = yield* emailRouting
+          .getRule({ zoneId, ruleIdentifier: rule.ruleId })
+          .pipe(
+            Effect.retry({
+              while: (e) => e._tag === "Forbidden",
+              schedule: Schedule.exponential("500 millis"),
+              times: 8,
+            }),
+          );
+        expect(live.actions?.[0]?.type).toEqual("worker");
+        expect(live.actions?.[0]?.value).toEqual([workerName]);
+
+        yield* stack.destroy();
+      }).pipe(logLevel),
+    { timeout: 180_000 },
+  );
+
+  // The catch-all rule takes a `worker` action through a different endpoint
+  // (`/rules/catch_all`) and hits the same validation window.
+  test.provider(
+    "catch-all pointed at a Worker created in the same apply",
+    (stack) =>
+      Effect.gen(function* () {
+        const zoneId = yield* resolveZoneId;
+
+        yield* stack.destroy();
+        yield* enableRouting(zoneId);
+
+        const { catchAll, workerName } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const routing = yield* Cloudflare.Email.Routing("Routing", {
+              zone: zoneName,
+            });
+            const worker = yield* RuleTargetWorker;
+            const catchAll = yield* Cloudflare.Email.CatchAll("CatchAll", {
+              zone: { zoneId: routing.zoneId },
+              name: "alchemy worker-target catch-all",
+              actions: [{ type: "worker", value: [worker.workerName] }],
+            });
+            return { catchAll, workerName: worker.workerName };
+          }),
+        );
+
+        expect(catchAll.zoneId).toEqual(zoneId);
+        expect(catchAll.actions).toEqual([
+          { type: "worker", value: [workerName] },
+        ]);
+
+        yield* stack.destroy();
+      }).pipe(logLevel),
+    { timeout: 180_000 },
+  );
+});

--- a/packages/alchemy/test/Cloudflare/Email/EmailRuleWorkerTarget.test.ts
+++ b/packages/alchemy/test/Cloudflare/Email/EmailRuleWorkerTarget.test.ts
@@ -46,14 +46,17 @@ describe.sequential("Email.Rule -> Worker in one apply", () => {
   // resource whose `{ type: "worker", value: [scriptName] }` action names
   // it, both created in the same apply, into a stage that did not exist.
   //
-  // NOTE: this does NOT reproduce the #1348 failure on current main, and
-  // was confirmed to still pass with the provider's retry removed. The
-  // Worker provider pre-creates a stub script before the rule is created
-  // (see "pre-creating" in a deploy log), so by the time Cloudflare
-  // validates the action the name already resolves. The retry stays as
-  // defensive handling for paths where that stub is absent or slow — the
-  // error itself is real and typed (`WorkerScriptNotFound`, Cloudflare
-  // code 2016, observed live on both createRule and putRuleCatchAll).
+  // NOTE: this is a smoke test, NOT the regression guard for #1348. It was
+  // confirmed to still pass with the provider's retry removed — by us and
+  // independently by the reporter, who mutated the retry away and got three
+  // green runs. The Worker provider pre-creates a stub script before the
+  // rule is created (see "pre-creating" in a deploy log), so by the time
+  // Cloudflare validates the action the name already resolves.
+  //
+  // The retry itself is guarded deterministically in `retry.test.ts`, which
+  // injects the failure and does fail when the retry is removed. The error
+  // is real and typed (`WorkerScriptNotFound`, Cloudflare code 2016,
+  // observed live on both createRule and putRuleCatchAll).
   test.provider(
     "first deploy of a fresh stage creates the rule targeting the worker",
     (stack) =>

--- a/packages/alchemy/test/Cloudflare/Email/fixtures/rule-target-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Email/fixtures/rule-target-worker.ts
@@ -1,0 +1,20 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Effect from "effect/Effect";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+/**
+ * Minimal Worker that exists only to be named by an `Email.Rule` /
+ * `Email.CatchAll` `worker` action in the same apply — the shape that
+ * reproduces alchemy-run/alchemy#1348.
+ */
+export default class RuleTargetWorker extends Cloudflare.Worker<RuleTargetWorker>()(
+  "EmailRuleTargetWorker",
+  {
+    main: import.meta.url,
+  },
+  Effect.gen(function* () {
+    return {
+      fetch: Effect.succeed(HttpServerResponse.text("ok")),
+    };
+  }),
+) {}

--- a/packages/alchemy/test/Cloudflare/Email/retry.test.ts
+++ b/packages/alchemy/test/Cloudflare/Email/retry.test.ts
@@ -1,0 +1,88 @@
+import { retryWorkerScriptNotFound } from "@/Cloudflare/Email/retry";
+import { describe, expect, it } from "alchemy-test";
+import * as Effect from "effect/Effect";
+
+// Cloudflare rejects a rule whose `worker` action names a script it cannot see
+// yet with code 2016 / `WorkerScriptNotFound`. Distilled surfaces that as a
+// tagged error; only the tag matters to the retry, so a minimal stand-in keeps
+// this test free of the generated SDK.
+class WorkerScriptNotFound {
+  readonly _tag = "WorkerScriptNotFound";
+  constructor(readonly code = 2016) {}
+}
+class SomethingElse {
+  readonly _tag = "Conflict";
+}
+
+// Fails the first `failures` attempts with `error`, then succeeds.
+const flaky = <E>(failures: number, error: E) => {
+  let attempts = 0;
+  return {
+    attempts: () => attempts,
+    effect: Effect.suspend(() => {
+      attempts++;
+      return attempts <= failures ? Effect.fail(error) : Effect.succeed("ok");
+    }),
+  };
+};
+
+// The live suite (EmailRuleWorkerTarget.test.ts) cannot exercise this window —
+// the Worker provider pre-creates a stub script, so the name already resolves
+// by the time the rule is validated, and that suite passes with the retry
+// removed. These cases inject the failure instead, so they fail if the retry
+// regresses.
+//
+// `it.live` uses the real clock so the backoff actually elapses; the default
+// `it.effect` TestClock would never advance it.
+describe("retryWorkerScriptNotFound", () => {
+  it.live("retries while the script is not yet visible, then succeeds", () =>
+    Effect.gen(function* () {
+      const target = flaky(2, new WorkerScriptNotFound());
+
+      const result = yield* retryWorkerScriptNotFound(target.effect);
+
+      expect(result).toBe("ok");
+      // Two not-visible-yet failures plus the success.
+      expect(target.attempts()).toBe(3);
+    }),
+  );
+
+  it.live("does not retry an unrelated failure", () =>
+    Effect.gen(function* () {
+      const target = flaky(99, new SomethingElse());
+
+      const outcome = yield* Effect.result(
+        retryWorkerScriptNotFound(target.effect),
+      );
+
+      expect(outcome._tag).toBe("Failure");
+      // Attempted once and given up — no backoff burned on a permanent error.
+      expect(target.attempts()).toBe(1);
+    }),
+  );
+
+  it.live(
+    "gives up after a bounded budget and re-raises the original error",
+    () =>
+      Effect.gen(function* () {
+        const error = new WorkerScriptNotFound();
+        // Never recovers: a genuinely missing Worker must still fail and say so
+        // rather than hanging.
+        const target = flaky(Number.MAX_SAFE_INTEGER, error);
+
+        const outcome = yield* Effect.result(
+          retryWorkerScriptNotFound(target.effect),
+        );
+
+        expect(outcome._tag).toBe("Failure");
+        // The error surfaces unchanged, not wrapped in a retry-exhausted error.
+        if (outcome._tag === "Failure") {
+          expect(outcome.failure).toBe(error);
+        }
+        // `times: 8` — the initial attempt plus eight retries, and no more.
+        expect(target.attempts()).toBe(9);
+      }),
+    // ~25s of exponential backoff from 100ms, plus headroom.
+    { timeout: 60_000 },
+  );
+});


### PR DESCRIPTION
Cloudflare validates a rule's `{ type: "worker", value: [script] }` action while handling the write and rejects it until a freshly-uploaded script propagates. `createRule` declared no typed errors at all, so there was nothing to catch.

```ts
// before
export type CreateRuleError = CloudflareOpError;
// after
export type CreateRuleError = WorkerScriptNotFound | CloudflareOpError;
```

```ts
// Email/retry.ts — the shape Fetcher already uses for a fresh script
Effect.retry({
  while: (error) => error._tag === "WorkerScriptNotFound",
  schedule: Schedule.exponential("100 millis"),
  times: 8,
})
```

Applied to `createRule` / `updateRule` in `Email.Rule` and to `putRuleCatchAll` in `Email.CatchAll` — the catch-all takes a `worker` action through a different endpoint and hits the same validation. After the budget (~25s) the original error is re-raised unchanged, so a genuinely missing Worker still fails and says so.

Depends on alchemy-run/distilled#476, which adds the typed error and is picked up by the submodule bump here.

Closes #1348

### Observed live

The error is real and now tagged. Probed against the API directly — both endpoints return Cloudflare code **2016**:

```
createRule       -> WorkerScriptNotFound: Workers Script Info not found
putRuleCatchAll  -> WorkerScriptNotFound: Workers Script Info not found
```

The distilled matcher keys on `{ "code": 2016 }` rather than a status + message substring.

### The regression guard is `retry.test.ts`, not the live suite

`test/Cloudflare/Email/retry.test.ts` injects the failure rather than trying to race the real API, so it fails when the retry is removed:

| | retry as written | retry replaced with `effect` |
| --- | --- | --- |
| `EmailRuleWorkerTarget.test.ts` (live) | 2 passed | 2 passed |
| `retry.test.ts` (injected) | 3 passed | **2 failed** |

It covers retrying while `WorkerScriptNotFound` then succeeding (3 attempts), not retrying an unrelated tag (1 attempt), and re-raising the original error unchanged after the bounded budget (9 attempts = initial + `times: 8`).

### What this does not claim

**The reported failure does not reproduce on current `main`.** `test/Cloudflare/Email/EmailRuleWorkerTarget.test.ts` covers the reported shape — a Worker plus a rule, and a Worker plus a catch-all, each deployed into a torn-down stack so the Worker really is created in that apply — and it passes. It also passes with the retry removed, so it is a smoke test, not a regression guard, and the test says so.

#1348's reporter confirmed this independently on their own Email-Routing-capable account: they mutated the retry away and got three green runs, and verified from the deploy log that a never-before-deployed stage really is what runs. Credit to @xiaoyu2er — the deterministic test above exists because of that review.

The reason is visible in a deploy log: the Worker provider pre-creates a stub script before the rule is validated, so the name already resolves.

```
[EmailRuleTargetWorker] pre-creating      <- stub uploaded
[EmailRuleTargetWorker] creating          <- real upload
[WorkerRule] creating                     <- name already resolves
```

The reporter is on `2.0.0-beta.74`. The retry is kept as defensive handling for paths where that stub is absent or slow: it is free when it does not fire, and it only fires on a tag that means precisely "script not visible yet".

`getRule` also gains the already-defined `Forbidden` / `EmailRoutingRuleNotFound`, which it declared no errors for.

