### PR TITLE
fix(platform): skip absent optional config bindings

### DIFF
--- a/packages/alchemy/src/Platform.ts
+++ b/packages/alchemy/src/Platform.ts
@@ -43,6 +43,12 @@ export interface PlatformProps {
   isExternal?: boolean;
 }
 
+/** Synthetic Config nodes such as an absent `Config.option` have nothing to bind. */
+const isBindableRuntimeConfigNode = (
+  path: ReadonlyArray<unknown>,
+  value: unknown,
+): boolean => path.length > 0 && value !== undefined;
+
 /**
  * Provide the platform class's layer (`cls.make(props, impl)`) with a
  * lifetime that matches the phase.
@@ -569,14 +575,22 @@ export const Platform = <
                             path.map((p) => p.toString()).join("_"),
                           );
                           const node = yield* configProvider.load(path);
-                          if (phase === "plan" && node) {
+                          if (
+                            phase === "plan" &&
+                            node &&
+                            isBindableRuntimeConfigNode(path, node.value)
+                          ) {
                             // bind it to the RuntimeContext if running in plan phase
                             const output = Output.literal(
                               Redacted.make(node.value),
                             );
                             yield* ctx?.set(key, output) ?? Effect.void;
                             return node;
-                          } else if (phase === "runtime" && ctx) {
+                          } else if (
+                            phase === "runtime" &&
+                            ctx &&
+                            key.length > 0
+                          ) {
                             // retrieve from the RuntimeContext if running in runtime phase
                             const value =
                               yield* ctx.get<Redacted.Redacted<string>>(key);

--- a/packages/alchemy/test/PlatformConfigBindings.test.ts
+++ b/packages/alchemy/test/PlatformConfigBindings.test.ts
@@ -7,7 +7,7 @@ import { expect } from "alchemy-test";
 import * as Config from "effect/Config";
 import * as ConfigProvider from "effect/ConfigProvider";
 import * as Effect from "effect/Effect";
-import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
 
 interface ConfigHost extends Resource<
   "Test.ConfigHost",
@@ -46,7 +46,7 @@ const providers = Provider.succeed(ConfigHost, {
 const { test } = Test.make({ providers, state: inMemoryState() });
 
 test.provider(
-  "an absent optional Config does not create a synthetic runtime binding",
+  "an absent optional field skips synthetic binding and preserves concrete config bindings",
   (stack) =>
     Effect.gen(function* () {
       boundKeys.length = 0;
@@ -56,17 +56,28 @@ test.provider(
           "ConfigHost",
           {},
           Effect.gen(function* () {
-            const value = yield* Config.string(
-              "ALCHEMY_TEST_MISSING_OPTIONAL_CONFIG",
-            ).pipe(Config.option);
-            expect(Option.isNone(value)).toBe(true);
+            const optional = yield* Config.schema(
+              Schema.Struct({ maybe: Schema.optional(Schema.String) }),
+            );
+            expect(optional).toEqual({});
+
+            const concrete = yield* Config.string(
+              "ALCHEMY_TEST_PRESENT_CONFIG",
+            );
+            expect(concrete).toBe("present");
             return {};
           }),
         ),
       );
 
-      expect(boundKeys).toEqual([]);
+      expect(boundKeys).toEqual(["ALCHEMY_TEST_PRESENT_CONFIG"]);
     }).pipe(
-      Effect.provide(ConfigProvider.layer(ConfigProvider.fromUnknown({}))),
+      Effect.provide(
+        ConfigProvider.layer(
+          ConfigProvider.fromUnknown({
+            ALCHEMY_TEST_PRESENT_CONFIG: "present",
+          }),
+        ),
+      ),
     ),
 );

--- a/packages/alchemy/test/PlatformConfigBindings.test.ts
+++ b/packages/alchemy/test/PlatformConfigBindings.test.ts
@@ -1,0 +1,72 @@
+import { Platform } from "@/Platform.ts";
+import * as Provider from "@/Provider.ts";
+import type { Resource } from "@/Resource.ts";
+import { inMemoryState } from "@/State/index.ts";
+import * as Test from "@/Test/Alchemy.ts";
+import { expect } from "alchemy-test";
+import * as Config from "effect/Config";
+import * as ConfigProvider from "effect/ConfigProvider";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+
+interface ConfigHost extends Resource<
+  "Test.ConfigHost",
+  { env?: Record<string, unknown> },
+  { ready: true },
+  { env?: Record<string, unknown> }
+> {}
+
+const boundKeys: string[] = [];
+
+const ConfigHost: any = Platform<ConfigHost>("Test.ConfigHost", {
+  createRuntimeContext: (id) => ({
+    Type: "Test.ConfigHost",
+    id,
+    env: {},
+    set: (key) =>
+      Effect.sync(() => {
+        boundKeys.push(key);
+        return key;
+      }),
+    get: () => Effect.succeed(undefined),
+  }),
+});
+
+const providers = Provider.succeed(ConfigHost, {
+  list: () => Effect.succeed([]),
+  diff: Effect.fn(function* () {
+    return undefined;
+  }),
+  reconcile: Effect.fn(function* () {
+    return { ready: true as const };
+  }),
+  delete: Effect.fn(function* () {}),
+});
+
+const { test } = Test.make({ providers, state: inMemoryState() });
+
+test.provider(
+  "an absent optional Config does not create a synthetic runtime binding",
+  (stack) =>
+    Effect.gen(function* () {
+      boundKeys.length = 0;
+
+      yield* stack.deploy(
+        ConfigHost(
+          "ConfigHost",
+          {},
+          Effect.gen(function* () {
+            const value = yield* Config.string(
+              "ALCHEMY_TEST_MISSING_OPTIONAL_CONFIG",
+            ).pipe(Config.option);
+            expect(Option.isNone(value)).toBe(true);
+            return {};
+          }),
+        ),
+      );
+
+      expect(boundKeys).toEqual([]);
+    }).pipe(
+      Effect.provide(ConfigProvider.layer(ConfigProvider.fromUnknown({}))),
+    ),
+);


### PR DESCRIPTION
## Summary

Skip synthetic runtime bindings for optional configuration fields that are absent, while preserving bindings for concrete configuration values.

## Behavior

```text
Config.optional(absent)  -> no RuntimeContext binding
Config.string(present)   -> RuntimeContext binding remains
```

The plan phase now rejects empty paths and `undefined` values before publishing a binding. The runtime phase also ignores empty keys instead of attempting an invalid lookup.

## Validation

- `mise exec bun@1.3.13 -- bun node_modules/alchemy-test/bin/alchemy-test.ts --sequential test/PlatformConfigBindings.test.ts`
- Result: `0 failed | 1 passed`

## Scope

This only changes configuration binding publication; it does not alter required configuration resolution or runtime provider behavior.
