### PR TITLE
fix(config): prefer process environment over dotenv defaults

### DIFF
--- a/packages/alchemy/src/Util/ConfigProvider.ts
+++ b/packages/alchemy/src/Util/ConfigProvider.ts
@@ -3,11 +3,6 @@ import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
 
-export const withDotEnvFallback = (
-  environment: ConfigProvider.ConfigProvider,
-  dotEnv: ConfigProvider.ConfigProvider,
-) => ConfigProvider.orElse(environment, dotEnv);
-
 export const loadConfigProvider = (envFile: Option.Option<string>) => {
   if (Option.isSome(envFile)) {
     return ConfigProvider.fromDotEnv({ path: envFile.value }).pipe(
@@ -22,7 +17,7 @@ export const loadConfigProvider = (envFile: Option.Option<string>) => {
     if (!exists) {
       return ConfigProvider.fromEnv();
     }
-    return withDotEnvFallback(
+    return ConfigProvider.orElse(
       ConfigProvider.fromEnv(),
       yield* ConfigProvider.fromDotEnv({ path: ".env" }),
     );

--- a/packages/alchemy/src/Util/ConfigProvider.ts
+++ b/packages/alchemy/src/Util/ConfigProvider.ts
@@ -3,6 +3,11 @@ import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
 
+export const withDotEnvFallback = (
+  environment: ConfigProvider.ConfigProvider,
+  dotEnv: ConfigProvider.ConfigProvider,
+) => ConfigProvider.orElse(environment, dotEnv);
+
 export const loadConfigProvider = (envFile: Option.Option<string>) => {
   if (Option.isSome(envFile)) {
     return ConfigProvider.fromDotEnv({ path: envFile.value }).pipe(
@@ -17,9 +22,9 @@ export const loadConfigProvider = (envFile: Option.Option<string>) => {
     if (!exists) {
       return ConfigProvider.fromEnv();
     }
-    return ConfigProvider.orElse(
-      yield* ConfigProvider.fromDotEnv({ path: ".env" }),
+    return withDotEnvFallback(
       ConfigProvider.fromEnv(),
+      yield* ConfigProvider.fromDotEnv({ path: ".env" }),
     );
   });
 };

--- a/packages/alchemy/test/AWS/AuthProvider.test.ts
+++ b/packages/alchemy/test/AWS/AuthProvider.test.ts
@@ -1,5 +1,6 @@
 import { applyEnvRegionOverride } from "@/AWS/AuthProvider.ts";
 import { loadConfigProvider } from "@/Util/ConfigProvider.ts";
+import { PlatformServices } from "@/Util/PlatformServices.ts";
 import { describe, expect, it } from "alchemy-test";
 import * as ConfigProvider from "effect/ConfigProvider";
 import * as Effect from "effect/Effect";
@@ -82,7 +83,7 @@ describe("applyEnvRegionOverride", () => {
             ),
           );
         }),
-      ),
+      ).pipe(Effect.provide(PlatformServices)),
     { exclusive: true },
   );
 });

--- a/packages/alchemy/test/AWS/AuthProvider.test.ts
+++ b/packages/alchemy/test/AWS/AuthProvider.test.ts
@@ -1,5 +1,4 @@
 import { applyEnvRegionOverride } from "@/AWS/AuthProvider.ts";
-import { withDotEnvFallback } from "@/Util/ConfigProvider.ts";
 import { describe, expect, it } from "alchemy-test";
 import * as ConfigProvider from "effect/ConfigProvider";
 import * as Effect from "effect/Effect";
@@ -47,7 +46,7 @@ describe("applyEnvRegionOverride", () => {
     }).pipe(
       Effect.provide(
         ConfigProvider.layer(
-          withDotEnvFallback(
+          ConfigProvider.orElse(
             ConfigProvider.fromEnv({ env: { AWS_REGION: "us-east-1" } }),
             ConfigProvider.fromEnv({ env: { AWS_REGION: "ap-south-1" } }),
           ),

--- a/packages/alchemy/test/AWS/AuthProvider.test.ts
+++ b/packages/alchemy/test/AWS/AuthProvider.test.ts
@@ -1,7 +1,11 @@
 import { applyEnvRegionOverride } from "@/AWS/AuthProvider.ts";
+import { loadConfigProvider } from "@/Util/ConfigProvider.ts";
 import { describe, expect, it } from "alchemy-test";
 import * as ConfigProvider from "effect/ConfigProvider";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Option from "effect/Option";
+import * as Path from "effect/Path";
 
 const withEnv = (env: Record<string, string>) =>
   Effect.provide(ConfigProvider.layer(ConfigProvider.fromEnv({ env })));
@@ -35,23 +39,50 @@ describe("applyEnvRegionOverride", () => {
     }).pipe(withEnv({})),
   );
 
-  it.effect("selected environment overrides the default dotenv region", () =>
-    Effect.gen(function* () {
-      const creds = yield* applyEnvRegionOverride({
-        accountId: "654654387918",
-        region: "us-west-2",
-      });
-      expect(creds.region).toBe("us-east-1");
-      expect(creds.accountId).toBe("654654387918");
-    }).pipe(
-      Effect.provide(
-        ConfigProvider.layer(
-          ConfigProvider.orElse(
-            ConfigProvider.fromEnv({ env: { AWS_REGION: "us-east-1" } }),
-            ConfigProvider.fromEnv({ env: { AWS_REGION: "ap-south-1" } }),
-          ),
-        ),
+  it.effect(
+    "process environment overrides the default dotenv region",
+    () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const tempDir = yield* fs.makeTempDirectoryScoped({
+            prefix: "alchemy-config-provider-",
+          });
+          yield* fs.writeFileString(
+            path.join(tempDir, ".env"),
+            "AWS_REGION=ap-south-1\n",
+          );
+
+          const originalCwd = process.cwd();
+          const originalRegion = process.env.AWS_REGION;
+          yield* Effect.gen(function* () {
+            yield* Effect.sync(() => {
+              process.chdir(tempDir);
+              process.env.AWS_REGION = "us-east-1";
+            });
+
+            const configProvider = yield* loadConfigProvider(Option.none());
+            const creds = yield* applyEnvRegionOverride({
+              accountId: "654654387918",
+              region: "us-west-2",
+            }).pipe(Effect.provide(ConfigProvider.layer(configProvider)));
+            expect(creds.region).toBe("us-east-1");
+            expect(creds.accountId).toBe("654654387918");
+          }).pipe(
+            Effect.ensuring(
+              Effect.sync(() => {
+                process.chdir(originalCwd);
+                if (originalRegion === undefined) {
+                  delete process.env.AWS_REGION;
+                } else {
+                  process.env.AWS_REGION = originalRegion;
+                }
+              }),
+            ),
+          );
+        }),
       ),
-    ),
+    { exclusive: true },
   );
 });

--- a/packages/alchemy/test/AWS/AuthProvider.test.ts
+++ b/packages/alchemy/test/AWS/AuthProvider.test.ts
@@ -1,4 +1,5 @@
 import { applyEnvRegionOverride } from "@/AWS/AuthProvider.ts";
+import { withDotEnvFallback } from "@/Util/ConfigProvider.ts";
 import { describe, expect, it } from "alchemy-test";
 import * as ConfigProvider from "effect/ConfigProvider";
 import * as Effect from "effect/Effect";
@@ -33,5 +34,25 @@ describe("applyEnvRegionOverride", () => {
       const creds = yield* applyEnvRegionOverride(profileCreds);
       expect(creds.region).toBe("us-west-2");
     }).pipe(withEnv({})),
+  );
+
+  it.effect("selected environment overrides the default dotenv region", () =>
+    Effect.gen(function* () {
+      const creds = yield* applyEnvRegionOverride({
+        accountId: "654654387918",
+        region: "us-west-2",
+      });
+      expect(creds.region).toBe("us-east-1");
+      expect(creds.accountId).toBe("654654387918");
+    }).pipe(
+      Effect.provide(
+        ConfigProvider.layer(
+          withDotEnvFallback(
+            ConfigProvider.fromEnv({ env: { AWS_REGION: "us-east-1" } }),
+            ConfigProvider.fromEnv({ env: { AWS_REGION: "ap-south-1" } }),
+          ),
+        ),
+      ),
+    ),
   );
 });


### PR DESCRIPTION
## Summary

Make explicit process environment variables take precedence over values loaded from the default `.env` file.

## Resolution order

```text
process environment  ->  default .env fallback
```

`loadConfigProvider` now tries `ConfigProvider.fromEnv()` before `ConfigProvider.fromDotEnv({ path: ".env" })`, so a checked-in or local dotenv default cannot shadow an explicitly supplied process value.

## Validation

- `mise exec bun@1.3.13 -- bun node_modules/alchemy-test/bin/alchemy-test.ts --sequential test/AWS/AuthProvider.test.ts`
- Result: `0 failed | 4 passed`
- The regression uses an isolated temporary `.env`, sets `AWS_REGION` in the process environment, and restores the working directory and environment afterward.

## Scope

This preserves the existing dotenv fallback and changes only precedence when both sources provide a value.
