### PR TITLE
fix(lambda): provide runtime services in packaged bootstraps

### DIFF
--- a/packages/alchemy/package.json
+++ b/packages/alchemy/package.json
@@ -89,6 +89,12 @@
       "worker": "./src/AWS/Endpoint.ts",
       "import": "./lib/AWS/Endpoint.js"
     },
+    "./AWS/Environment": {
+      "types": "./lib/AWS/Environment.d.ts",
+      "bun": "./src/AWS/Environment.ts",
+      "worker": "./src/AWS/Environment.ts",
+      "import": "./lib/AWS/Environment.js"
+    },
     "./AWS/Region": {
       "types": "./lib/AWS/Region.d.ts",
       "bun": "./src/AWS/Region.ts",
@@ -306,6 +312,12 @@
       "bun": "./src/Runtime.ts",
       "worker": "./src/Runtime.ts",
       "import": "./lib/Runtime.js"
+    },
+    "./Runtime/Bootstrap/*": {
+      "types": "./lib/Runtime/Bootstrap/*.d.ts",
+      "bun": "./src/Runtime/Bootstrap/*.ts",
+      "worker": "./src/Runtime/Bootstrap/*.ts",
+      "import": "./lib/Runtime/Bootstrap/*.js"
     },
     "./Process": {
       "types": "./lib/Process/index.d.ts",

--- a/packages/alchemy/src/AWS/Environment.ts
+++ b/packages/alchemy/src/AWS/Environment.ts
@@ -12,6 +12,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Result from "effect/Result";
+import * as Schema from "effect/Schema";
 import { AlchemyContext } from "../AlchemyContext.ts";
 import { getAuthProvider } from "../Auth/AuthProvider.ts";
 import { ALCHEMY_PROFILE, AlchemyProfile } from "../Auth/Profile.ts";
@@ -43,30 +44,25 @@ export class InvalidAWSServiceEndpoints extends Data.TaggedError(
   "AWS::Environment::InvalidServiceEndpoints",
 )<{ readonly message: string }> {}
 
+const ServiceEndpoints = Schema.Record(
+  Schema.NonEmptyString,
+  Schema.NonEmptyString,
+);
+
+const ServiceEndpointsInput = Schema.Union([
+  Schema.fromJsonString(ServiceEndpoints),
+  ServiceEndpoints,
+]);
+
 const decodeServiceEndpoints = (raw: unknown) =>
-  Effect.try({
-    try: () => {
-      const value: unknown = typeof raw === "string" ? JSON.parse(raw) : raw;
-      if (
-        typeof value !== "object" ||
-        value === null ||
-        Array.isArray(value) ||
-        Object.entries(value).some(
-          ([service, endpoint]) =>
-            service.length === 0 ||
-            typeof endpoint !== "string" ||
-            endpoint.length === 0,
-        )
-      ) {
-        throw new TypeError("expected a non-empty string endpoint record");
-      }
-      return value as Readonly<Record<string, string>>;
-    },
-    catch: () =>
-      new InvalidAWSServiceEndpoints({
-        message: `${AWS_SERVICE_ENDPOINTS_ENV_VAR} must contain a JSON object of non-empty service endpoints`,
-      }),
-  });
+  Schema.decodeUnknownEffect(ServiceEndpointsInput)(raw).pipe(
+    Effect.mapError(
+      () =>
+        new InvalidAWSServiceEndpoints({
+          message: `${AWS_SERVICE_ENDPOINTS_ENV_VAR} must contain a JSON object of non-empty service endpoints`,
+        }),
+    ),
+  );
 
 /** Service-specific AWS endpoints visible inside an application runtime. */
 export const AWS_SERVICE_ENDPOINTS = ConfigProvider.ConfigProvider.pipe(

--- a/packages/alchemy/src/AWS/Environment.ts
+++ b/packages/alchemy/src/AWS/Environment.ts
@@ -5,7 +5,6 @@ import type {
 import { Credentials } from "@distilled.cloud/aws/Credentials";
 import { Region } from "@distilled.cloud/aws/Region";
 import * as Config from "effect/Config";
-import * as ConfigProvider from "effect/ConfigProvider";
 import * as Context from "effect/Context";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
@@ -54,29 +53,19 @@ const ServiceEndpointsInput = Schema.Union([
   ServiceEndpoints,
 ]);
 
-const decodeServiceEndpoints = (raw: unknown) =>
-  Schema.decodeUnknownEffect(ServiceEndpointsInput)(raw).pipe(
-    Effect.mapError(
-      () =>
-        new InvalidAWSServiceEndpoints({
-          message: `${AWS_SERVICE_ENDPOINTS_ENV_VAR} must contain a JSON object of non-empty service endpoints`,
-        }),
-    ),
-  );
-
 /** Service-specific AWS endpoints visible inside an application runtime. */
-export const AWS_SERVICE_ENDPOINTS = ConfigProvider.ConfigProvider.pipe(
-  Effect.flatMap((provider) => provider.load([AWS_SERVICE_ENDPOINTS_ENV_VAR])),
-  Effect.flatMap((node) => {
-    if (node === undefined) return Effect.succeed(undefined);
-    return node._tag === "Value"
-      ? decodeServiceEndpoints(node.value)
-      : Effect.fail(
-          new InvalidAWSServiceEndpoints({
-            message: `${AWS_SERVICE_ENDPOINTS_ENV_VAR} must contain a JSON object of non-empty service endpoints`,
-          }),
-        );
-  }),
+export const AWS_SERVICE_ENDPOINTS = Config.schema(
+  ServiceEndpointsInput,
+  AWS_SERVICE_ENDPOINTS_ENV_VAR,
+).pipe(
+  Config.option,
+  Effect.mapError(
+    () =>
+      new InvalidAWSServiceEndpoints({
+        message: `${AWS_SERVICE_ENDPOINTS_ENV_VAR} must contain a JSON object of non-empty service endpoints`,
+      }),
+  ),
+  Effect.map(Option.getOrUndefined),
 );
 
 export type AccountID = string;

--- a/packages/alchemy/src/AWS/Environment.ts
+++ b/packages/alchemy/src/AWS/Environment.ts
@@ -2,7 +2,10 @@ import type {
   CredentialsError,
   ResolvedCredentials,
 } from "@distilled.cloud/aws/Credentials";
+import { Credentials } from "@distilled.cloud/aws/Credentials";
+import { Region } from "@distilled.cloud/aws/Region";
 import * as Config from "effect/Config";
+import * as ConfigProvider from "effect/ConfigProvider";
 import * as Context from "effect/Context";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
@@ -28,6 +31,57 @@ export const AWS_ACCOUNT_ID = Config.string("AWS_ACCOUNT_ID");
 export const AWS_ACCESS_KEY_ID = Config.string("AWS_ACCESS_KEY_ID");
 export const AWS_SECRET_ACCESS_KEY = Config.redacted("AWS_SECRET_ACCESS_KEY");
 export const AWS_SESSION_TOKEN = Config.redacted("AWS_SESSION_TOKEN");
+export const AWS_SERVICE_ENDPOINTS_ENV_VAR = "ALCHEMY_AWS_SERVICE_ENDPOINTS";
+
+/** Global AWS endpoint visible inside an application runtime. */
+export const AWS_ENDPOINT_URL = Config.string("AWS_ENDPOINT_URL").pipe(
+  Config.option,
+  Effect.map(Option.getOrUndefined),
+);
+
+export class InvalidAWSServiceEndpoints extends Data.TaggedError(
+  "AWS::Environment::InvalidServiceEndpoints",
+)<{ readonly message: string }> {}
+
+const decodeServiceEndpoints = (raw: unknown) =>
+  Effect.try({
+    try: () => {
+      const value: unknown = typeof raw === "string" ? JSON.parse(raw) : raw;
+      if (
+        typeof value !== "object" ||
+        value === null ||
+        Array.isArray(value) ||
+        Object.entries(value).some(
+          ([service, endpoint]) =>
+            service.length === 0 ||
+            typeof endpoint !== "string" ||
+            endpoint.length === 0,
+        )
+      ) {
+        throw new TypeError("expected a non-empty string endpoint record");
+      }
+      return value as Readonly<Record<string, string>>;
+    },
+    catch: () =>
+      new InvalidAWSServiceEndpoints({
+        message: `${AWS_SERVICE_ENDPOINTS_ENV_VAR} must contain a JSON object of non-empty service endpoints`,
+      }),
+  });
+
+/** Service-specific AWS endpoints visible inside an application runtime. */
+export const AWS_SERVICE_ENDPOINTS = ConfigProvider.ConfigProvider.pipe(
+  Effect.flatMap((provider) => provider.load([AWS_SERVICE_ENDPOINTS_ENV_VAR])),
+  Effect.flatMap((node) => {
+    if (node === undefined) return Effect.succeed(undefined);
+    return node._tag === "Value"
+      ? decodeServiceEndpoints(node.value)
+      : Effect.fail(
+          new InvalidAWSServiceEndpoints({
+            message: `${AWS_SERVICE_ENDPOINTS_ENV_VAR} must contain a JSON object of non-empty service endpoints`,
+          }),
+        );
+  }),
+);
 
 export type AccountID = string;
 export type RegionID = string;
@@ -54,6 +108,7 @@ export interface AWSEnvironmentShape {
   region: RegionID;
   credentials: Effect.Effect<ResolvedCredentials, CredentialsError>;
   endpoint?: string;
+  serviceEndpoints?: Readonly<Record<string, string>>;
   profile?: string;
 }
 
@@ -77,6 +132,35 @@ export class AWSEnvironment extends Context.Service<
 
 /** @see {@link AWSEnvironment.isLocalEmulator} */
 export const isLocalEmulator = AWSEnvironment.isLocalEmulator;
+
+/**
+ * Runtime-only AWS environment for generated Lambda entrypoints. It uses the
+ * process credentials and region installed by the bootstrap and never loads a
+ * profile, contacts metadata, or starts an emulator.
+ */
+export const Runtime = Layer.effect(
+  AWSEnvironment,
+  Effect.all({
+    accountId: Config.string("ALCHEMY_AWS_ACCOUNT_ID"),
+    credentials: Credentials,
+    endpoint: AWS_ENDPOINT_URL,
+    region: Region,
+    serviceEndpoints: AWS_SERVICE_ENDPOINTS,
+  }).pipe(
+    Effect.map(
+      ({ accountId, credentials, endpoint, region, serviceEndpoints }) =>
+        region.pipe(
+          Effect.map((region) => ({
+            accountId,
+            credentials,
+            endpoint,
+            region,
+            serviceEndpoints,
+          })),
+        ),
+    ),
+  ),
+);
 
 export const Default = Layer.effect(
   AWSEnvironment,

--- a/packages/alchemy/src/AWS/Lambda/Function.ts
+++ b/packages/alchemy/src/AWS/Lambda/Function.ts
@@ -43,7 +43,10 @@ import {
 import { sha256 } from "../../Util/sha256.ts";
 import { zipCode } from "../../Util/zip.ts";
 import { Assets } from "../Assets.ts";
-import { AWSEnvironment } from "../Environment.ts";
+import {
+  AWS_SERVICE_ENDPOINTS_ENV_VAR,
+  AWSEnvironment,
+} from "../Environment.ts";
 import * as IAM from "../IAM/index.ts";
 import type { PolicyStatement } from "../IAM/Policy.ts";
 import type { Providers } from "../Providers.ts";
@@ -1115,6 +1118,32 @@ export const Function: Platform<
   },
 });
 
+/** Environment identity captured by generated Lambda entrypoints. */
+export const resolveFunctionRuntimeEnv = Effect.gen(function* () {
+  const stack = yield* Stack;
+  const { accountId, serviceEndpoints } = yield* AWSEnvironment.current;
+  const serializedServiceEndpoints =
+    serviceEndpoints === undefined || Object.keys(serviceEndpoints).length === 0
+      ? undefined
+      : JSON.stringify(
+          Object.fromEntries(
+            Object.entries(serviceEndpoints).sort(([a], [b]) =>
+              a.localeCompare(b),
+            ),
+          ),
+        );
+
+  return {
+    ALCHEMY_AWS_ACCOUNT_ID: accountId,
+    ...(serializedServiceEndpoints === undefined
+      ? {}
+      : { [AWS_SERVICE_ENDPOINTS_ENV_VAR]: serializedServiceEndpoints }),
+    ALCHEMY_STACK_NAME: stack.name,
+    ALCHEMY_STAGE: stack.stage,
+    ALCHEMY_PHASE: "runtime",
+  };
+});
+
 export const FunctionProvider = () =>
   Provider.effect(
     Function,
@@ -1125,11 +1154,7 @@ export const FunctionProvider = () =>
       // provider's watch loop can rebuild the identical artifact.
       const { bundleCode } = yield* makeFunctionBundler;
       const functionImage = yield* makeFunctionImage;
-      const alchemyEnv = {
-        ALCHEMY_STACK_NAME: stack.name,
-        ALCHEMY_STAGE: stack.stage,
-        ALCHEMY_PHASE: "runtime",
-      };
+      const alchemyEnv = yield* resolveFunctionRuntimeEnv;
 
       const createFunctionName = (
         id: string,

--- a/packages/alchemy/src/Runtime/Bootstrap/Lambda.ts
+++ b/packages/alchemy/src/Runtime/Bootstrap/Lambda.ts
@@ -5,7 +5,6 @@
  * shim.
  */
 import * as Credentials from "@distilled.cloud/aws/Credentials";
-import * as Endpoint from "@distilled.cloud/aws/Endpoint";
 import * as Region from "@distilled.cloud/aws/Region";
 import { layer as nodeServicesLayer } from "@effect/platform-node/NodeServices";
 import * as ConfigProvider from "effect/ConfigProvider";
@@ -16,8 +15,11 @@ import * as Logger from "effect/Logger";
 import { MinimumLogLevel } from "effect/References";
 import * as Scope from "effect/Scope";
 import { layer as fetchHttpClientLayer } from "effect/unstable/http/FetchHttpClient";
+import { Runtime as AwsRuntimeEnvironment } from "../../AWS/Environment.ts";
+import * as AwsEndpoint from "../../AWS/Endpoint.ts";
 import { registerLambdaExtension } from "../../AWS/Lambda/RuntimeExtension.ts";
 import { reifyBoundConfigProvider } from "../../Runtime.ts";
+import { RuntimeContext } from "../../RuntimeContext.ts";
 import { entrypointLayer, entrypointTag, stackFromEnv } from "./Process.ts";
 
 /**
@@ -44,15 +46,20 @@ export const bootstrap = async (entrypoint: unknown): Promise<unknown> => {
     Logger.layer([Logger.consolePretty()]),
   );
 
+  const awsRuntime = Layer.mergeAll(Credentials.fromEnv(), Region.fromEnv());
+  const awsEnvironment = AwsRuntimeEnvironment.pipe(Layer.provide(awsRuntime));
+
   const entryLayer = entrypointLayer(entrypoint).pipe(
     Layer.provideMerge(stackFromEnv),
-    Layer.provideMerge(Credentials.fromEnv()),
-    Layer.provideMerge(Region.fromEnv()),
+    Layer.provideMerge(awsRuntime),
+    Layer.provideMerge(awsEnvironment),
     // AWS_ENDPOINT_URL is the LocalStack-standard override injected by local
     // emulators (floci) into the Lambda container — without it, runtime
     // bindings in `alchemy dev` would call REAL AWS with dummy credentials.
     // Resolves undefined when unset, so live deploys are unaffected.
-    Layer.provideMerge(Endpoint.fromEnv()),
+    Layer.provideMerge(
+      AwsEndpoint.fromEnvironment.pipe(Layer.provide(awsEnvironment)),
+    ),
     Layer.provideMerge(platform),
     Layer.provideMerge(
       Layer.succeed(
@@ -74,8 +81,12 @@ export const bootstrap = async (entrypoint: unknown): Promise<unknown> => {
   ).pipe(
     Effect.flatMap((context) =>
       entrypointTag.pipe(
-        Effect.flatMap((func) => func.RuntimeContext.exports),
-        Effect.flatMap((exports: any) => exports.handler),
+        Effect.flatMap((func) =>
+          func.RuntimeContext.exports.pipe(
+            Effect.flatMap((exports: any) => exports.handler),
+            Effect.provide(Layer.succeed(RuntimeContext, func.RuntimeContext)),
+          ),
+        ),
         Effect.provideContext(context),
       ),
     ),

--- a/packages/alchemy/test/AWS/Lambda/FunctionEnvironment.test.ts
+++ b/packages/alchemy/test/AWS/Lambda/FunctionEnvironment.test.ts
@@ -1,0 +1,39 @@
+import { resolveFunctionRuntimeEnv } from "@/AWS/Lambda/Function.ts";
+import { AWSEnvironment } from "@/AWS/Environment.ts";
+import { Stack, type StackSpec } from "@/Stack.ts";
+import { expect, it } from "alchemy-test";
+import * as Effect from "effect/Effect";
+
+it.effect("serializes runtime identity for packaged Lambdas", () =>
+  resolveFunctionRuntimeEnv.pipe(
+    Effect.tap((environment) =>
+      Effect.sync(() => {
+        expect(environment).toEqual({
+          ALCHEMY_AWS_ACCOUNT_ID: "123456789012",
+          ALCHEMY_AWS_SERVICE_ENDPOINTS: JSON.stringify({
+            ses: "http://ses.local",
+          }),
+          ALCHEMY_STACK_NAME: "example",
+          ALCHEMY_STAGE: "production",
+          ALCHEMY_PHASE: "runtime",
+        });
+      }),
+    ),
+    Effect.provideService(
+      AWSEnvironment,
+      Effect.succeed({
+        accountId: "123456789012",
+        region: "us-east-1",
+        credentials: Effect.die("not used"),
+        serviceEndpoints: { ses: "http://ses.local" },
+      }),
+    ),
+    Effect.provideService(Stack, {
+      name: "example",
+      stage: "production",
+      resources: {},
+      bindings: {},
+      actions: {},
+    } satisfies Omit<StackSpec, "output">),
+  ),
+);

--- a/packages/alchemy/test/AWS/ProviderOptions.test.ts
+++ b/packages/alchemy/test/AWS/ProviderOptions.test.ts
@@ -1,0 +1,130 @@
+import {
+  AWS_ENDPOINT_URL,
+  AWS_SERVICE_ENDPOINTS,
+  AWS_SERVICE_ENDPOINTS_ENV_VAR,
+  AWSEnvironment,
+  Runtime as AwsRuntime,
+} from "@/AWS/Environment.ts";
+import { Credentials } from "@distilled.cloud/aws/Credentials";
+import { Region } from "@distilled.cloud/aws/Region";
+import { describe, expect, it } from "alchemy-test";
+import * as ConfigProvider from "effect/ConfigProvider";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Redacted from "effect/Redacted";
+import * as Result from "effect/Result";
+
+describe("AWS runtime environment", () => {
+  it.effect("decodes global and service-specific endpoints", () =>
+    Effect.gen(function* () {
+      expect(yield* AWS_ENDPOINT_URL).toBe("http://global.local");
+      expect(yield* AWS_SERVICE_ENDPOINTS).toEqual({
+        ses: "http://ses.local",
+        sqs: "http://sqs.local",
+      });
+    }).pipe(
+      Effect.provideService(
+        ConfigProvider.ConfigProvider,
+        ConfigProvider.fromEnv({
+          env: {
+            AWS_ENDPOINT_URL: "http://global.local",
+            [AWS_SERVICE_ENDPOINTS_ENV_VAR]: JSON.stringify({
+              ses: "http://ses.local",
+              sqs: "http://sqs.local",
+            }),
+          },
+        }),
+      ),
+    ),
+  );
+
+  it.effect(
+    "accepts structured service endpoints from the runtime provider",
+    () =>
+      AWS_SERVICE_ENDPOINTS.pipe(
+        Effect.tap((endpoints) =>
+          Effect.sync(() =>
+            expect(endpoints).toEqual({
+              ses: "http://ses.local",
+            }),
+          ),
+        ),
+        Effect.provideService(
+          ConfigProvider.ConfigProvider,
+          ConfigProvider.make((path) =>
+            Effect.succeed(
+              path[0] === AWS_SERVICE_ENDPOINTS_ENV_VAR
+                ? ({
+                    _tag: "Value",
+                    value: { ses: "http://ses.local" },
+                  } as unknown as ConfigProvider.Node)
+                : undefined,
+            ),
+          ),
+        ),
+      ),
+  );
+
+  it.effect("rejects malformed service endpoint values", () =>
+    Effect.gen(function* () {
+      const result = yield* Effect.result(AWS_SERVICE_ENDPOINTS);
+      expect(Result.isFailure(result)).toBe(true);
+      if (Result.isFailure(result)) {
+        expect(result.failure._tag).toBe(
+          "AWS::Environment::InvalidServiceEndpoints",
+        );
+      }
+    }).pipe(
+      Effect.provideService(
+        ConfigProvider.ConfigProvider,
+        ConfigProvider.fromEnv({
+          env: { [AWS_SERVICE_ENDPOINTS_ENV_VAR]: '{"sqs":""}' },
+        }),
+      ),
+    ),
+  );
+
+  it.effect("reconstructs the runtime AWS environment", () =>
+    Effect.gen(function* () {
+      const environment = yield* AWSEnvironment.current;
+      expect(environment.accountId).toBe("123456789012");
+      expect(environment.region).toBe("us-east-1");
+      expect(environment.endpoint).toBe("http://floci:4566");
+      expect(environment.serviceEndpoints).toEqual({
+        ses: "http://ses.local",
+      });
+    }).pipe(
+      Effect.provide(
+        AwsRuntime.pipe(
+          Layer.provide(
+            Layer.mergeAll(
+              Layer.succeed(
+                Credentials,
+                Effect.succeed({
+                  accessKeyId: Redacted.make("access"),
+                  secretAccessKey: Redacted.make("secret"),
+                  sessionToken: undefined,
+                  region: "us-east-1",
+                }),
+              ),
+              Layer.succeed(Region, Effect.succeed("us-east-1")),
+            ),
+          ),
+          Layer.provide(
+            ConfigProvider.layer(
+              ConfigProvider.fromEnv({
+                env: {
+                  ALCHEMY_AWS_ACCOUNT_ID: "123456789012",
+                  AWS_ENDPOINT_URL: "http://floci:4566",
+                  [AWS_SERVICE_ENDPOINTS_ENV_VAR]: JSON.stringify({
+                    ses: "http://ses.local",
+                  }),
+                },
+              }),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+});

--- a/packages/alchemy/test/AWS/ProviderOptions.test.ts
+++ b/packages/alchemy/test/AWS/ProviderOptions.test.ts
@@ -51,16 +51,11 @@ describe("AWS runtime environment", () => {
         ),
         Effect.provideService(
           ConfigProvider.ConfigProvider,
-          ConfigProvider.make((path) =>
-            Effect.succeed(
-              path[0] === AWS_SERVICE_ENDPOINTS_ENV_VAR
-                ? ({
-                    _tag: "Value",
-                    value: { ses: "http://ses.local" },
-                  } as unknown as ConfigProvider.Node)
-                : undefined,
-            ),
-          ),
+          ConfigProvider.fromUnknown({
+            [AWS_SERVICE_ENDPOINTS_ENV_VAR]: {
+              ses: "http://ses.local",
+            },
+          }),
         ),
       ),
   );


### PR DESCRIPTION
## Summary

Packaged Lambda bootstraps now reconstruct the AWS runtime identity and handler context available during source execution. Service-specific endpoint configuration is preserved for consuming Effect layers without implying that every Distilled client automatically uses a service map.

## Runtime contract

```text
Alchemy AWS environment
  -> packaged Lambda environment
  -> Lambda bootstrap
  -> AWSEnvironment.Runtime + RuntimeContext
  -> consuming Effect layers
```

The bootstrap carries account, region, credentials, stack/stage/phase identity, and the optional `ALCHEMY_AWS_SERVICE_ENDPOINTS` record. The endpoint record accepts both its serialized JSON form and a reified runtime configuration value, with typed rejection of empty or malformed entries.

## Changes

- Reconstruct runtime AWS identity and handler-scoped context in packaged bootstraps.
- Preserve service-specific endpoint configuration across the packaging boundary.
- Decode endpoint configuration through `effect/Config` and `effect/Schema`.
- Keep endpoint selection at the consuming Effect layer boundary; generic per-service routing in Distilled remains a separate API concern.

## Validation

- Direct runtime probe: serialized JSON and structured endpoint records are accepted; an empty endpoint is rejected as `AWS::Environment::InvalidServiceEndpoints`.
- `git diff --check`.
- The focused local `alchemy-test` invocation is currently blocked by the existing runner collection error (`describe/test/hook called outside of a test file collection`); CI remains the authoritative suite.

## Scope

This changes packaged Lambda runtime reconstruction and endpoint configuration propagation only. It does not change Distilled's endpoint API or provider deployment behavior.
