### PR TITLE
feat(axiom): support dataset edge deployments

### DIFF
--- a/packages/alchemy/src/Axiom/Dataset.ts
+++ b/packages/alchemy/src/Axiom/Dataset.ts
@@ -25,6 +25,13 @@ export type DatasetProps = {
   /** Free-form description shown in the Axiom UI. */
   description?: string;
   /**
+   * Edge deployment where Axiom stores and processes the dataset's data.
+   * Defaults to the organization's default edge deployment.
+   *
+   * Cannot be changed after creation — triggers a replacement.
+   */
+  edgeDeployment?: string;
+  /**
    * Dataset kind. Defaults to `axiom:events:v1`.
    *
    * For OTEL pipelines, choose:
@@ -50,8 +57,13 @@ export type Dataset = Resource<
     kind: DatasetKind;
     description: string;
     created: string;
+    /** Edge deployment where the dataset's data is stored and processed. */
+    edgeDeployment: string;
+    /** Base URL for ingesting and querying data in the dataset's edge deployment. */
+    edgeDeploymentUrl: string;
+    /** Base URL for Axiom's centralized management API. */
     apiBaseUrl: string;
-    /** Root OTLP endpoint (`${apiBaseUrl}`). Most exporters auto-append the signal path. */
+    /** Root OTLP endpoint. Most exporters auto-append the signal path. */
     otelEndpoint: string;
     /** OTLP/HTTP traces endpoint. */
     otelTracesEndpoint: string;
@@ -76,11 +88,11 @@ export type Dataset = Resource<
  * the data is shown in the UI, and **cannot be changed** after creation
  * (changing it triggers a replacement, which deletes the data).
  *
- * Datasets expose Axiom's OTLP/HTTP endpoints (`otelTracesEndpoint`,
- * `otelLogsEndpoint`, `otelMetricsEndpoint`) as output attributes so you can
- * inject them into a Worker / Lambda's env vars for OpenTelemetry shipping.
- * The bearer token is **not** stored in resource state — supply
- * `Authorization: Bearer <AXIOM_TOKEN>` separately at runtime.
+ * Datasets expose their edge deployment and Axiom's OTLP/HTTP endpoints
+ * (`otelTracesEndpoint`, `otelLogsEndpoint`, `otelMetricsEndpoint`) as output
+ * attributes so you can inject them into a Worker / Lambda's env vars for
+ * OpenTelemetry shipping. The bearer token is **not** stored in resource state
+ * — supply `Authorization: Bearer <AXIOM_TOKEN>` separately at runtime.
  * @see https://axiom.co/docs/reference/datasets
  * @see https://axiom.co/docs/send-data/opentelemetry — OTLP endpoint reference
  *
@@ -153,18 +165,6 @@ const parseMarker = (
   return { stack: m[1], stage: m[2], id: m[3] };
 };
 
-const buildOtelAttrs = (apiBaseUrl: string, name: string) => {
-  const root = apiBaseUrl.replace(/\/$/, "");
-  return {
-    apiBaseUrl: root,
-    otelEndpoint: root,
-    otelTracesEndpoint: `${root}/v1/traces`,
-    otelLogsEndpoint: `${root}/v1/logs`,
-    otelMetricsEndpoint: `${root}/v1/metrics`,
-    otelHeaders: { "X-Axiom-Dataset": name } as Record<string, string>,
-  };
-};
-
 export const DatasetProvider = () =>
   Provider.effect(
     Dataset,
@@ -176,17 +176,37 @@ export const DatasetProvider = () =>
       const listDatasets = yield* Axiom.getDatasets;
       const del = yield* Axiom.deleteDataset;
 
-      const toAttrs = (dataset: Axiom.Dataset) => ({
-        id: dataset.id,
-        name: dataset.name,
-        kind: dataset.kind,
-        description: stripMarker(dataset.description),
-        created: dataset.created,
-        ...buildOtelAttrs(apiBaseUrl, dataset.name),
+      const toAttrs = Effect.fn(function* (dataset: Axiom.Dataset) {
+        if (!dataset.edgeDeployment || !dataset.edgeDeploymentUrl) {
+          return yield* Effect.fail(
+            new Error(
+              `Axiom dataset "${dataset.name}" is missing its edge deployment metadata`,
+            ),
+          );
+        }
+        const apiRoot = apiBaseUrl.replace(/\/$/, "");
+        const otelRoot = dataset.edgeDeploymentUrl.replace(/\/$/, "");
+        return {
+          id: dataset.id,
+          name: dataset.name,
+          kind: dataset.kind,
+          description: stripMarker(dataset.description),
+          created: dataset.created,
+          edgeDeployment: dataset.edgeDeployment,
+          edgeDeploymentUrl: dataset.edgeDeploymentUrl,
+          apiBaseUrl: apiRoot,
+          otelEndpoint: otelRoot,
+          otelTracesEndpoint: `${otelRoot}/v1/traces`,
+          otelLogsEndpoint: `${otelRoot}/v1/logs`,
+          otelMetricsEndpoint: `${otelRoot}/v1/metrics`,
+          otelHeaders: {
+            "X-Axiom-Dataset": dataset.name,
+          } as Record<string, string>,
+        };
       });
 
       return {
-        stables: ["id", "name", "kind"],
+        stables: ["id", "name", "kind", "edgeDeployment", "edgeDeploymentUrl"],
         // Enumerate every dataset in the org. Axiom exposes a single
         // account-wide `GET /v2/datasets` collection op (no pagination), so we
         // fetch it once and hydrate each row into the exact `read`/`toAttrs`
@@ -194,7 +214,7 @@ export const DatasetProvider = () =>
         list: () =>
           Effect.gen(function* () {
             const datasets = yield* listDatasets({});
-            return datasets.map(toAttrs);
+            return yield* Effect.forEach(datasets, toAttrs);
           }),
         diff: Effect.fn(function* ({ olds, news, output }) {
           if (!isResolved(news)) return undefined;
@@ -202,6 +222,13 @@ export const DatasetProvider = () =>
             return { action: "replace" } as const;
           }
           if (news.kind && output && news.kind !== output.kind) {
+            return { action: "replace" } as const;
+          }
+          if (
+            news.edgeDeployment &&
+            output &&
+            news.edgeDeployment !== output.edgeDeployment
+          ) {
             return { action: "replace" } as const;
           }
           if (
@@ -237,6 +264,7 @@ export const DatasetProvider = () =>
               create({
                 name: news.name,
                 description: augmentDescription(news.description, marker),
+                edgeDeployment: news.edgeDeployment,
                 kind: news.kind,
                 retentionDays: news.retentionDays,
                 useRetentionPeriod: news.useRetentionPeriod,
@@ -260,7 +288,7 @@ export const DatasetProvider = () =>
                   }),
               ),
             );
-            return toAttrs(current);
+            return yield* toAttrs(current);
           }
 
           // Sync — the dataset exists. Apply mutable aspects (description,
@@ -275,7 +303,7 @@ export const DatasetProvider = () =>
             current.retentionDays !== news.retentionDays ||
             current.useRetentionPeriod !== news.useRetentionPeriod;
           if (!needsSync) {
-            return toAttrs(current);
+            return yield* toAttrs(current);
           }
           const updated = yield* update({
             dataset_id: current.id,
@@ -283,7 +311,7 @@ export const DatasetProvider = () =>
             retentionDays: news.retentionDays,
             useRetentionPeriod: news.useRetentionPeriod,
           });
-          return toAttrs(updated);
+          return yield* toAttrs(updated);
         }),
         delete: Effect.fn(function* ({ output }) {
           yield* del({ dataset_id: output.id }).pipe(
@@ -305,7 +333,7 @@ export const DatasetProvider = () =>
             ownership.stack === stack.name &&
             ownership.stage === stage &&
             ownership.id === id;
-          const attrs = toAttrs(existing);
+          const attrs = yield* toAttrs(existing);
           return isOurs ? attrs : Unowned(attrs);
         }),
       };

--- a/packages/alchemy/test/Axiom/Dataset.test.ts
+++ b/packages/alchemy/test/Axiom/Dataset.test.ts
@@ -51,6 +51,11 @@ test.provider.skipIf(!hasAxiomCreds)(
       expect(found).toBeDefined();
       expect(found?.name).toEqual(DATASET_NAME);
       expect(found?.kind).toEqual(deployed.kind);
+      expect(found?.edgeDeployment).toEqual(deployed.edgeDeployment);
+      expect(found?.edgeDeploymentUrl).toEqual(deployed.edgeDeploymentUrl);
+      expect(found?.otelEndpoint).toEqual(
+        deployed.edgeDeploymentUrl.replace(/\/$/, ""),
+      );
       expect(found?.otelTracesEndpoint).toEqual(deployed.otelTracesEndpoint);
 
       yield* stack.destroy();


### PR DESCRIPTION
Axiom datasets now expose their edge placement, and Alchemy derives OTLP endpoints from Axiom's returned regional URL instead of the centralized management API.

```ts
const logs = yield* Axiom.Dataset("logs", {
  name: "my-app-logs",
  kind: "otel:logs:v1",
  edgeDeployment: "cloud.us-east-1.aws",
});

logs.edgeDeploymentUrl;
logs.otelLogsEndpoint;
```

Changing `edgeDeployment` replaces the dataset because Axiom does not support moving an existing dataset between edge deployments.
