### PR TITLE
docs(blog): beta.75 — Railway, Fly, Hetzner & websites

### DIFF
--- a/website/src/content/docs/aws/local-development.mdx
+++ b/website/src/content/docs/aws/local-development.mdx
@@ -42,9 +42,7 @@ We hold the emulator to the same bar as the real cloud: alchemy's
 live AWS test suites — the control-plane lifecycle tests and the
 data-plane binding tests that normally run against real AWS —
 also run against the emulator, and every fidelity gap they
-surface becomes a fix in the fork. See
-[Looping the Generation of Local Emulators](/blog/2026-08-20-generating-local-emulators)
-for how that loop works.
+surface becomes a fix in the fork.
 
 ## Lambda runs in containers
 

--- a/website/src/content/docs/blog/2026-08-20-generating-local-emulators.md
+++ b/website/src/content/docs/blog/2026-08-20-generating-local-emulators.md
@@ -1,6 +1,7 @@
 ---
 title: Looping the Generation of Local Emulators
 date: 2026-08-20T16:00:00Z
+draft: true
 excerpt: The live test suite that generates our IaC and SDKs is also an executable spec of the cloud. Point it at an emulator and every red test is a fidelity bug with a repro. alchemy dev now emulates 219 resources across ~39 AWS services on your machine, with no AWS account.
 ---
 
@@ -29,7 +30,7 @@ and every red test is a fidelity bug that arrives with its own
 reproduction. This is how `alchemy dev` for AWS works. Your
 stack runs on your machine with no AWS account and no
 credentials. It shipped in
-[2.0.0-beta.74](/blog/2026-08-21-beta-74).
+[2.0.0-beta.75](/blog/2026-08-25-beta-75).
 
 ## We forked floci
 
@@ -128,7 +129,7 @@ built on workerd itself and held to the same live suites. AWS
 now joins it. The next provider the factory brings up will ship
 all three artifacts together.
 
-- [2.0.0-beta.74 — the release AWS local dev shipped in](/blog/2026-08-21-beta-74)
+- [2.0.0-beta.75 — the release AWS local dev shipped in](/blog/2026-08-25-beta-75)
 - [AWS local development](/aws/local-development)
 - [Looping the Generation of IaC and SDKs — the first post in this series](/blog/2026-07-02-cloudflare-resource-factory)
 - [alchemy-run/floci — the fork](https://github.com/alchemy-run/floci)

--- a/website/src/content/docs/blog/2026-08-25-beta-75.md
+++ b/website/src/content/docs/blog/2026-08-25-beta-75.md
@@ -5,8 +5,8 @@ category: release
 excerpt: v2.0.0-beta.75 ships Railway alongside Fly.io and Hetzner, deploys the same website frameworks to Cloudflare, AWS, Hetzner, Railway, and Fly, and brings alchemy dev to AWS — Lambda, S3, DynamoDB, SQS, ECS, EC2, and websites on your machine with no credentials.
 ---
 
-beta.75 ships three container clouds — **Railway, Fly.io, and
-Hetzner** — each with an Effect-native `Service` platform. The
+beta.75 ships **Railway, Fly.io, and Hetzner** — each with an
+Effect-native `Service` platform. The
 same website call now deploys to all three plus **Cloudflare and
 AWS**: Vite, Astro, Next.js, Nuxt, SvelteKit, Waku, Octane,
 Foldkit, and StaticSite, with one props vocabulary.

--- a/website/src/content/docs/blog/2026-08-25-beta-75.md
+++ b/website/src/content/docs/blog/2026-08-25-beta-75.md
@@ -1,27 +1,28 @@
 ---
-title: 2.0.0-beta.74 - AWS Local Dev, Hetzner & Fly.io
-date: 2026-08-21T09:00:00Z
+title: 2.0.0-beta.75 - Railway, Fly, Hetzner & Websites
+date: 2026-08-25T09:00:00Z
 category: release
-excerpt: v2.0.0-beta.74 brings alchemy dev to AWS — your Lambda, S3, DynamoDB, SQS, ECS, and website stack runs on your machine with hot reload and no credentials — adds Hetzner Cloud and Fly.io providers with Effect-native Service platforms, deploys all six web frameworks to AWS (S3 + CloudFront + streaming Lambda), unifies SQL migrations into one Alchemy-owned format, protects Workers with Cloudflare Access, and makes removal policies persist.
+excerpt: v2.0.0-beta.75 ships Railway alongside Fly.io and Hetzner, deploys the same website frameworks to Cloudflare, AWS, Hetzner, Railway, and Fly, and brings alchemy dev to AWS — Lambda, S3, DynamoDB, SQS, ECS, EC2, and websites on your machine with no credentials.
 ---
 
-beta.74 brings `alchemy dev` to AWS: your Lambda, S3, DynamoDB,
-SQS, ECS, and website stack runs **entirely on your machine** —
-no AWS account, no credentials, hot reload in ~100–500ms, and
-each website's framework runs its own dev server with native
-HMR. A new
-**Hetzner Cloud provider** ships 15 resources plus an
-Effect-native `Service` platform that deploys your program to a
-server over SSH. A new **Fly.io provider** brings Machines,
-Services, Sprites, and managed Postgres, Redis, and Tigris object
-storage. And the six web frameworks that landed on Cloudflare in
-beta.70 now deploy to **AWS** — S3 + CloudFront + streaming
-Lambda — with the same interface.
+beta.75 ships three container clouds — **Railway, Fly.io, and
+Hetzner** — each with an Effect-native `Service` platform. The
+same website call now deploys to all three plus **Cloudflare and
+AWS**: Vite, Astro, Next.js, Nuxt, SvelteKit, Waku, Octane,
+Foldkit, and StaticSite, with one props vocabulary.
+`alchemy dev` runs your AWS Lambda, S3, DynamoDB, SQS, ECS,
+EC2, and website stack **on your machine** — no account, no
+credentials, hot reload. SQL migrations have one format,
+Workers can sit behind Access, and removal policies persist.
+
+This post covers beta.72 through beta.75.
+
 :::caution
 **Breaking changes**
 
-- **effect `>=4.0.0-rc.110` is the new minimum peer**
-  ([#1245](https://github.com/alchemy-run/alchemy/pull/1245)) —
+- **effect `>=4.0.0-rc.111` is the new minimum peer**
+  ([#1245](https://github.com/alchemy-run/alchemy/pull/1245),
+  [#1318](https://github.com/alchemy-run/alchemy/pull/1318)) —
   effect has moved from beta to release candidates.
 - **`@alchemy.run/cloudflare-frameworks` is now
   `@alchemy.run/frontend-frameworks`**
@@ -29,6 +30,21 @@ Lambda — with the same interface.
   [#1154](https://github.com/alchemy-run/alchemy/pull/1154)) —
   the framework integrations serve every cloud now. Update your
   devDependency.
+- **Website props are one vocabulary**
+  ([#1353](https://github.com/alchemy-run/alchemy/pull/1353),
+  [#1351](https://github.com/alchemy-run/alchemy/pull/1351),
+  [#1158](https://github.com/alchemy-run/alchemy/pull/1158)).
+  Flat deploy props, the framework's own config file, and a
+  JSON-serializable override bag (`astro:`, `vite:`, `nuxt:`,
+  `waku:`, `kit:`). AWS's `server: { env, memorySize, … }` bag
+  is gone — those fields are top-level. Cloudflare's mirrored
+  framework fields (`site`, `base`, `srcDir`, `spa`, …) move
+  into the bag and `assets.notFoundHandling`.
+  `StaticSite.environment` is `build.env`. Custom domains are
+  `domain: { name, aliases?, redirects? }` (or a bare hostname);
+  the zone is inferred from the hostname. Lambda's `url` prop is
+  `functionUrl`; `Website.Server`'s `port` moved to
+  `dev: { port }`.
 - **SQL migrations have one prop and one format**
   ([#1226](https://github.com/alchemy-run/alchemy/pull/1226)).
   `migrationsDir`/`migrationsTable` are replaced by a single
@@ -36,13 +52,6 @@ Lambda — with the same interface.
   Databases previously migrated with drizzle-kit, Prisma, or
   wrangler are converted automatically on the next deploy — see
   [below](#one-migration-format-for-sql-databases).
-- **AWS website & Lambda surface renames**
-  ([#1158](https://github.com/alchemy-run/alchemy/pull/1158)):
-  `Lambda.Function`'s `url` prop is now `functionUrl`, the
-  website `router:` prop moved into `domain: { router }`,
-  `Website.Server`'s `port` moved to `dev: { port }`, and the
-  CloudFront default domain now serves alongside a custom domain
-  (opt out with `cloudfrontUrl: false`).
 - **`Worker.workerId` is now the immutable Worker ID**
   ([#1228](https://github.com/alchemy-run/alchemy/pull/1228)) —
   the hex script tag Access destinations key on, not a duplicate
@@ -64,173 +73,139 @@ Lambda — with the same interface.
 
 effect 4.0 has moved from beta to release candidates, and alchemy
 now depends on effect's `rc` dist-tag
-([#1245](https://github.com/alchemy-run/alchemy/pull/1245)). The
-minimum peer is `>=4.0.0-rc.110`; install effect and the platform
+([#1245](https://github.com/alchemy-run/alchemy/pull/1245),
+[#1318](https://github.com/alchemy-run/alchemy/pull/1318)). The
+minimum peer is `>=4.0.0-rc.111`; install effect and the platform
 packages from the `rc` tag:
 
 ```sh
 bun add alchemy@latest effect@rc @effect/platform-bun@rc @effect/platform-node@rc
 ```
 
-## AWS local dev
+## Websites on five clouds
 
-`alchemy dev` now runs your AWS stack on your machine
-([#1154](https://github.com/alchemy-run/alchemy/pull/1154)) using
-[our fork](https://github.com/alchemy-run/floci) of
-[floci](https://floci.io), an MIT LocalStack-style emulator. No
-stored profile, no env vars, no config — the emulator starts
-automatically in Docker (one shared `alchemy-floci` container
-across projects and sessions) and your stack deploys into it in
-seconds:
+The Website family now deploys to **Cloudflare, AWS, Hetzner,
+Railway, and Fly** with one props vocabulary
+([#1140](https://github.com/alchemy-run/alchemy/pull/1140),
+[#1353](https://github.com/alchemy-run/alchemy/pull/1353),
+[#1351](https://github.com/alchemy-run/alchemy/pull/1351)):
 
-```sh
-bun alchemy dev
-# no AWS credentials — using the local emulator
-```
-
-Take a Lambda Function that owns a bucket and a queue and writes
-to both:
+1. **Flat deploy props** — `rootDir`, `env`, `memo`, `assets`,
+   `dev`, plus the platform half.
+2. **The framework's own config file**, loaded natively —
+   plugins and all.
+3. **A per-framework override bag** (`astro:`, `vite:`,
+   `nuxt:`, `waku:`, `kit:`) merged *over* the file for values
+   that vary per stage or come from other resources' `Output`s.
 
 ```typescript
-export default class Api extends AWS.Lambda.Function<Api>()(
+const site = yield* Cloudflare.Website.Astro("Blog", {
+  rootDir: "./apps/blog",
+  env: { API_BASE: api.url },
+  astro: { site: `https://${stage}.example.com`, output: "server" },
+  domain: "blog.example.com",
+});
+```
+
+Swap the namespace: `AWS.Website.Astro`, `Fly.Website.Astro`,
+`Railway.Website.Astro`, `Hetzner.Website.Astro` (pass `zone`
+when you set `domain`). Zone inference on Cloudflare and AWS
+walks the hostname; pin it with `zone` / `hostedZoneId` when
+several could match.
+
+`alchemy dev` is the framework's own server on every cloud —
+native HMR, no cloud resources. Live topology is what changes:
+
+- **Cloudflare** — Worker + static assets
+- **AWS** — private S3 + CloudFront Function router + streaming
+  Lambda. Next.js is the full OpenNext topology (streaming
+  server, image-optimization Lambda, SQS FIFO revalidation,
+  DynamoDB tag cache, ISR bucket)
+- **Fly** — one Service (Machine) + Tigris for hashed client
+  assets + ACME if `domain` is set
+- **Hetzner** — a systemd unit on a Server (auto-created `cpx12`
+  in `fsn1` if you omit `server`) + an A record
+- **Railway** — a Service from a generated Dockerfile, CDN on
+  the Service, `CustomDomain` if `domain` is set
+
+Next.js on Fly, Hetzner, and Railway is `next build` plus a
+long-running Node server, not OpenNext. React Router, SolidStart,
+and TanStack Start stay on Cloudflare (`Website.Vite`) and AWS
+(dedicated composites).
+
+Frameworks on all five: **Vite, Foldkit, Astro, Next.js, Nuxt,
+SvelteKit, Waku, Octane, StaticSite**. Vocs on Cloudflare, Fly,
+Hetzner, and Railway. Each cloud has a matching example
+(`examples/{cloudflare,aws,fly,hetzner,railway}-website-{framework}`).
+
+Docs:
+[Cloudflare](/cloudflare/frontend/frontends) ·
+[AWS](/aws/frontend/websites) ·
+[Fly](/fly/frontend/websites) ·
+[Hetzner](/hetzner/frontend/websites) ·
+[Railway](/railway/frontend/websites).
+
+## Railway
+
+A new **Railway provider**
+([#1295](https://github.com/alchemy-run/alchemy/pull/1295)):
+Project, Service, Function, Postgres, MySQL, Mongo, Redis,
+Bucket, Volume, Variable, CustomDomain, TcpProxy, and
+PrivateNetwork. Auth is `RAILWAY_API_TOKEN` or `alchemy login`.
+
+A Project is the parent. `Railway.Service` is the
+Function/Worker analog: an Effect program in a container.
+Alchemy bundles `main`, builds a Docker image, and pushes it to
+a registry Railway can pull (GHCR or Docker Hub — Railway has
+no private registry of its own):
+
+```typescript
+const Site = Railway.Project("Site");
+
+const Db = Railway.Postgres("Db", { project: Site });
+
+export default class Api extends Railway.Service<Api>()(
   "Api",
-  { main: import.meta.url, functionUrl: true },
+  {
+    project: Site,
+    main: import.meta.url,
+    registry: "ghcr.io/acme",
+    build: { install: ["pg"] },
+  },
   Effect.gen(function* () {
-    const files = yield* AWS.S3.Bucket("Files");
-    const jobs = yield* AWS.SQS.Queue("Jobs");
-
-    const putObject = yield* AWS.S3.PutObject(files);
-    const sendMessage = yield* AWS.SQS.SendMessage(jobs);
-
+    const conn = yield* Railway.ConnectPostgres(Db);
+    const db = yield* Drizzle.Postgres(conn.connectionString);
     return {
       fetch: Effect.gen(function* () {
-        yield* putObject({ Key: "hello.txt", Body: "hello" });
-        yield* sendMessage({ MessageBody: "process hello.txt" });
-        return yield* HttpServerResponse.text("ok");
-      }).pipe(Effect.orDie),
+        const rows = yield* db.select().from(users);
+        return HttpServerResponse.json({ rows });
+      }),
     };
-  }).pipe(
-    Effect.provide([AWS.S3.PutObjectHttp, AWS.SQS.SendMessageHttp]),
-  ),
+  }).pipe(Effect.provide(Railway.ConnectPostgresHttp)),
 ) {}
 ```
 
-The dev deploy's outputs all point at the emulator:
+`api.url` is `https://{name}.up.railway.app`. Redis and S3-style
+Buckets bind the same way — `ReadWriteRedis` on a `Railway.Redis`,
+`PutObject`/`GetObject` on a `Railway.Bucket`. Pass `image` for
+a public tag (`hashicorp/http-echo`) or `repo` for GitHub;
+`healthcheck` / `cronSchedule` match Railway IaC.
 
-```text
-Api.functionUrl  http://b71ff5c0….lambda-url.us-east-1.localhost:4566/
-Jobs.queueUrl    http://localhost:4566/000000000000/jobs-dev-x7k2
-Files.bucketName files-dev-x7k2
-```
-
-Everything runs locally on your machine: the Lambda executes in
-a Docker container behind a working Function URL, SQS→Lambda
-event source mappings pump messages, S3 notifications fire,
-EventBridge routes, and SNS subscriptions deliver. The bindings
-need no configuration — `putObject` above lands in the local
-bucket, because distilled honors the official SDKs'
-`AWS_ENDPOINT_URL` override that floci injects
-([#1192](https://github.com/alchemy-run/alchemy/pull/1192),
-[#1210](https://github.com/alchemy-run/alchemy/pull/1210)).
-
-Save the file and the running function serves the new code in
-**~100–500ms** — no redeploy, no restart. The dev session watches
-your code, rebuilds, and swaps it under the live Function URL.
-
-Mix in the real cloud per resource with `Alchemy.remote()`:
+`Railway.Function` is the canvas runtime: a single TypeScript
+file on Bun. No Docker. No registry. Cap is 96KB. Distinct from
+`Service({ main, registry })`:
 
 ```typescript
-// everything else is local; this one hits real AWS
-const secret = yield* AWS.SecretsManager.Secret("ProdSecret", { ... })
-  .pipe(Alchemy.remote());
-```
-
-If a remote resource needs credentials you don't have,
-`alchemy dev` tells you before touching anything, and switching a
-resource between local and live plans a **replacement** — dev
-state never silently becomes cloud state. Resources without local
-emulation run against the real cloud as before; stacks that mix
-the two work unchanged.
-
-Local emulation covers Lambda (hot reload, Function URLs, event
-source mappings), S3, DynamoDB, SQS, SNS, EventBridge, Secrets
-Manager, SSM, IAM, Cognito, Step Functions, Glue, ACM, and more.
-
-That includes the CloudFront edge: an `AWS.Website.Router`
-deploys into the emulator and serves requests on your machine.
-Its routing logic is a real CloudFront Function — floci executes
-it per request, it reads routes from the local KeyValueStore, and
-`cf.updateRequestOrigin()` forwards to local bucket and Function
-URL origins.
-
-We forked floci so that alchemy's live AWS test suites, which
-normally run against real AWS, can run against the emulator and
-drive an agentic pipeline that patches it. Every fidelity gap a
-test surfaces becomes a fix in the fork instead of a workaround
-in alchemy, and hundreds of live tests now run green against the
-emulator
-([#1250](https://github.com/alchemy-run/alchemy/pull/1250)). The
-`examples/aws-dev` suite drives the real `alchemy dev` CLI end
-to end: bindings, queue consumers, and mid-session hot reloads
-([#1192](https://github.com/alchemy-run/alchemy/pull/1192)).
-
-Alongside this release we published
-[Looping the Generation of Local Emulators](/blog/2026-08-20-generating-local-emulators),
-a dedicated post on the fork and the pipeline that drives it.
-Read that for the full story.
-
-Docs: [AWS local development](/aws/local-development).
-
-## ECS tasks run as local containers
-
-`alchemy dev` runs your ECS tasks and services as **real Docker
-containers** on your machine, with hot reload
-([#1185](https://github.com/alchemy-run/alchemy/pull/1185)):
-
-```typescript
-// bundled Effect program — built into an image, pushed through
-// a local registry, running as a real container seconds later
-export default class Web extends AWS.ECS.Task<Web>()(
-  "Web",
-  { main: import.meta.url, port: 8080 },
+export default class Ping extends Railway.Function<Ping>()(
+  "Ping",
+  { project: Site, main: import.meta.url },
   Effect.gen(function* () {
-    return {
-      fetch: Effect.gen(function* () {
-        return HttpServerResponse.text("hello from a local container");
-      }),
-    };
+    return { fetch: Effect.succeed(HttpServerResponse.text("ok")) };
   }),
 ) {}
 ```
 
-A dev deploy puts a real container on your machine:
-
-```text
-$ docker ps
-floci-ecs-…-web   Up 4 seconds   0.0.0.0:8080->8080/tcp
-```
-
-Bring-your-own-Dockerfile containers work too:
-`AWS.ECS.Service("Api", { context: "./api", port: 3000 })` builds
-your image and runs it the same way.
-
-The whole live pipeline runs unchanged against the emulator:
-image build, `docker push` through a real local OCI registry,
-task definitions, `RunTask`, and services that converge exactly
-like AWS. Save a file and the running container swaps in ~6
-seconds — bundled tasks watch the deploy's exact module graph,
-Dockerfile tasks watch the build context, and services roll
-their tasks onto the new image revision.
-
-An ECS dev stack is now **fully** local
-([#1210](https://github.com/alchemy-run/alchemy/pull/1210)): the
-VPC/subnet/ALB scaffolding and the event-source glue (SNS
-subscriptions, Lambda permissions, EventBridge, Scheduler) run
-against the emulator too — previously a dev apply could create a
-real VPC and ALB that could never route to local containers. The
-emulated ALB serves its listeners locally, so
-`aws ecs wait services-stable` and your load-balanced routes work
-without an AWS account.
+Docs: [Railway](/railway) · [Tutorial](/railway/tutorial/part-1).
 
 ## Hetzner
 
@@ -405,42 +380,162 @@ export default class Box extends Fly.Sprite<Box>()(
 
 Docs: [Fly.io](/fly) · [Tutorial](/fly/tutorial/part-1).
 
-## Web frameworks on AWS
+## AWS local dev
 
-The full Website family — plain **Vite** SPAs plus **Next.js,
-Astro, Nuxt, SvelteKit, Waku, and Octane** — now deploys to AWS
-([#1140](https://github.com/alchemy-run/alchemy/pull/1140)),
-mirroring the Cloudflare architecture: assets and prerendered
-pages live in a private S3 bucket, the framework server (when
-there is one) runs on a streaming Lambda Function URL, and a
-CloudFront Function routes each request at the edge via a
-KeyValueStore manifest.
+`alchemy dev` now runs your AWS stack on your machine
+([#1154](https://github.com/alchemy-run/alchemy/pull/1154)) using
+[our fork](https://github.com/alchemy-run/floci) of
+[floci](https://floci.io), an MIT LocalStack-style emulator. No
+stored profile, no env vars, no config — the emulator starts
+automatically in Docker (one shared `alchemy-floci` container
+across projects and sessions) and your stack deploys into it in
+seconds:
 
-```typescript
-const site = yield* AWS.Website.Vite("Web", {
-  domain: { name: "app.example.com", hostedZoneId: zone.hostedZoneId },
-});
+```sh
+bun alchemy dev
+# no AWS credentials — using the local emulator
 ```
 
-A Vite SPA deploys assets-only, with no Lambda at all. The SSR
-frameworks load your framework's own config natively; Next.js
-deploys the full OpenNext serverless topology — streaming server
-Lambda, image-optimization Lambda, SQS FIFO revalidation queue,
-DynamoDB tag cache, ISR cache bucket — with IAM wired through
-the binding channel.
+Take a Lambda Function that owns a bucket and a queue and writes
+to both:
 
-The interface is deliberately identical to Cloudflare's
-([#1158](https://github.com/alchemy-run/alchemy/pull/1158)): the
-same `{ name, aliases, redirects }` domain shape (standalone or
-through a shared `Router`), the same `dev` config, and the same
-`urls`/`url` output contract — custom domain first, CloudFront
-default last. Under `alchemy dev`, each framework's own dev
-server runs with native HMR and no cloud resources; every
-`cloudflare-website-*` example now has an `aws-website-*` mirror
-running the same app
-([#1189](https://github.com/alchemy-run/alchemy/pull/1189)).
+```typescript
+export default class Api extends AWS.Lambda.Function<Api>()(
+  "Api",
+  { main: import.meta.url, functionUrl: true },
+  Effect.gen(function* () {
+    const files = yield* AWS.S3.Bucket("Files");
+    const jobs = yield* AWS.SQS.Queue("Jobs");
 
-Docs: [AWS frontends](/aws/frontend/websites).
+    const putObject = yield* AWS.S3.PutObject(files);
+    const sendMessage = yield* AWS.SQS.SendMessage(jobs);
+
+    return {
+      fetch: Effect.gen(function* () {
+        yield* putObject({ Key: "hello.txt", Body: "hello" });
+        yield* sendMessage({ MessageBody: "process hello.txt" });
+        return yield* HttpServerResponse.text("ok");
+      }).pipe(Effect.orDie),
+    };
+  }).pipe(
+    Effect.provide([AWS.S3.PutObjectHttp, AWS.SQS.SendMessageHttp]),
+  ),
+) {}
+```
+
+The dev deploy's outputs all point at the emulator:
+
+```text
+Api.functionUrl  http://b71ff5c0….lambda-url.us-east-1.localhost:4566/
+Jobs.queueUrl    http://localhost:4566/000000000000/jobs-dev-x7k2
+Files.bucketName files-dev-x7k2
+```
+
+Everything runs locally on your machine: the Lambda executes in
+a Docker container behind a working Function URL, SQS→Lambda
+event source mappings pump messages, S3 notifications fire,
+EventBridge routes, and SNS subscriptions deliver. The bindings
+need no configuration — `putObject` above lands in the local
+bucket, because distilled honors the official SDKs'
+`AWS_ENDPOINT_URL` override that floci injects
+([#1192](https://github.com/alchemy-run/alchemy/pull/1192),
+[#1210](https://github.com/alchemy-run/alchemy/pull/1210)).
+
+Save the file and the running function serves the new code in
+**~100–500ms** — no redeploy, no restart. The dev session watches
+your code, rebuilds, and swaps it under the live Function URL.
+
+Mix in the real cloud per resource with `Alchemy.remote()`:
+
+```typescript
+// everything else is local; this one hits real AWS
+const secret = yield* AWS.SecretsManager.Secret("ProdSecret", { ... })
+  .pipe(Alchemy.remote());
+```
+
+If a remote resource needs credentials you don't have,
+`alchemy dev` tells you before touching anything, and switching a
+resource between local and live plans a **replacement** — dev
+state never silently becomes cloud state. Resources without local
+emulation run against the real cloud as before; stacks that mix
+the two work unchanged.
+
+Local emulation covers Lambda (hot reload, Function URLs, event
+source mappings), S3, DynamoDB, SQS, SNS, EventBridge, Secrets
+Manager, SSM, IAM, Cognito, Step Functions, Glue, ACM, and more.
+
+That includes the CloudFront edge: an `AWS.Website.Router`
+deploys into the emulator and serves requests on your machine.
+Its routing logic is a real CloudFront Function — floci executes
+it per request, it reads routes from the local KeyValueStore, and
+`cf.updateRequestOrigin()` forwards to local bucket and Function
+URL origins.
+
+We forked floci so that alchemy's live AWS test suites, which
+normally run against real AWS, can run against the emulator and
+drive an agentic pipeline that patches it. Every fidelity gap a
+test surfaces becomes a fix in the fork instead of a workaround
+in alchemy, and hundreds of live tests now run green against the
+emulator
+([#1250](https://github.com/alchemy-run/alchemy/pull/1250)). The
+`examples/aws-dev` suite drives the real `alchemy dev` CLI end
+to end: bindings, queue consumers, and mid-session hot reloads
+([#1192](https://github.com/alchemy-run/alchemy/pull/1192)).
+
+Docs: [AWS local development](/aws/local-development).
+
+## Local ECS, EC2, and MicroVMs
+
+`alchemy dev` runs ECS tasks and services as **real Docker
+containers** on your machine, with hot reload
+([#1185](https://github.com/alchemy-run/alchemy/pull/1185),
+[#1335](https://github.com/alchemy-run/alchemy/pull/1335)):
+
+```typescript
+export default class Web extends AWS.ECS.Task<Web>()(
+  "Web",
+  { main: import.meta.url, port: 8080 },
+  Effect.gen(function* () {
+    return {
+      fetch: Effect.gen(function* () {
+        return HttpServerResponse.text("hello from a local container");
+      }),
+    };
+  }),
+) {}
+```
+
+A dev deploy puts a real container on your machine:
+
+```text
+$ docker ps
+floci-ecs-…-web   Up 4 seconds   0.0.0.0:8080->8080/tcp
+```
+
+Bring-your-own-Dockerfile containers work too:
+`AWS.ECS.Service("Api", { context: "./api", port: 3000 })` builds
+your image and runs it the same way. Save a file and the running
+container swaps in ~6 seconds. Prop-driven updates (an inline
+`dockerfile`, a new env var) roll too — not just file edits.
+
+The whole live pipeline runs unchanged against the emulator:
+image build, `docker push` through a real local OCI registry,
+task definitions, `RunTask`, and services that converge exactly
+like AWS. VPC/subnet/ALB scaffolding and event-source glue (SNS
+subscriptions, Lambda permissions, EventBridge, Scheduler) run
+against the emulator too
+([#1210](https://github.com/alchemy-run/alchemy/pull/1210)) —
+previously a dev apply could create a real VPC and ALB that
+could never route to local containers.
+
+The same watch loop covers **EC2 hosted instances** (in-place
+bundle + reboot, same address) and **Lambda MicroVMs** (host-side
+`docker build` with real layer caching — image edits serve in
+~14s instead of a cold ~60s rebuild). Plan-time lookups
+(`getAmi`, AZ discovery) resolve against the emulator in dev, so
+you don't need AWS credentials just to plan.
+
+Docs: [AWS local development](/aws/local-development).
 
 ## One migration format for SQL databases
 
@@ -532,7 +627,7 @@ Docs:
 `RemovalPolicy.retain()` added to an already-deployed resource
 never reached state — the policy is a decoration, not a prop, so
 the noop apply path skipped it, and a later rename or removal
-orphan-deleted the resource anyway. beta.74 persists the policy
+orphan-deleted the resource anyway. beta.75 persists the policy
 on the noop path
 ([#1253](https://github.com/alchemy-run/alchemy/pull/1253)) and
 prints a note whenever a deploy flips one.
@@ -557,6 +652,35 @@ Docs:
 
 ## Also in this release
 
+- **Lambda Docker Functions**
+  ([#1077](https://github.com/alchemy-run/alchemy/pull/1077)) —
+  `AWS.Lambda.Function` deploys a container image: build from a
+  Dockerfile into a managed ECR repo, or point `image.uri` at an
+  existing tag or digest. Zip XOR image at the type level.
+  Thanks [Simon Westerlund](https://github.com/westerlund)!
+- **`Cloudflare.Website.Vocs`**
+  ([#1278](https://github.com/alchemy-run/alchemy/pull/1278)) —
+  first-class Vocs docs sites, also on Fly, Hetzner, and Railway.
+- **Isolated installs bundle**
+  ([#1324](https://github.com/alchemy-run/alchemy/pull/1324)) —
+  generated entries are shims over real
+  `alchemy/Runtime/Bootstrap/*` modules, so bun
+  `--linker=isolated` and pnpm no longer leave Effect programs
+  crashing at boot with `Cannot find module`.
+- **Axiom dataset edge deployments**
+  ([#1361](https://github.com/alchemy-run/alchemy/pull/1361)) —
+  `edgeDeployment` on `Axiom.Dataset`; OTLP endpoints derive
+  from Axiom's regional URL. Thanks
+  [Aman Varshney](https://github.com/AmanVarshney01)!
+- **Cognito email OTP, CustomEmailSender, and KMS**
+  ([#1323](https://github.com/alchemy-run/alchemy/pull/1323)) —
+  on `UserPool`.
+- **PlanetScale Metal SKUs**
+  ([#1319](https://github.com/alchemy-run/alchemy/pull/1319)) —
+  on `PostgresClusterSize`.
+- **`r2.dev` managed domain**
+  ([#1329](https://github.com/alchemy-run/alchemy/pull/1329)) —
+  enable it on `Cloudflare.R2.Bucket`.
 - **`nuke --local` clears the emulator**
   ([#1287](https://github.com/alchemy-run/alchemy/pull/1287)) —
   `alchemy unsafe nuke --local` enumerates and deletes through
@@ -578,7 +702,6 @@ Docs:
   and `Deployment.triggers` to force a redeploy when an opaque
   key/value (e.g. a rotated secret) changes. Thanks
   [Will Madden](https://github.com/wmadden)!
-
 - **Structured DNS record data**
   ([#1257](https://github.com/alchemy-run/alchemy/pull/1257)) —
   Cloudflare DNS records accept typed component objects for SVCB,
@@ -595,12 +718,18 @@ Docs:
   [Rahul Mishra](https://github.com/BlankParticle), who also
   migrated the workspace to pnpm
   ([#1214](https://github.com/alchemy-run/alchemy/pull/1214)),
-  bumped effect to rc.110
-  ([#1245](https://github.com/alchemy-run/alchemy/pull/1245)),
+  bumped effect to rc.110 then rc.111
+  ([#1245](https://github.com/alchemy-run/alchemy/pull/1245),
+  [#1318](https://github.com/alchemy-run/alchemy/pull/1318)),
   made process cleanup explicit and scoped
   ([#1175](https://github.com/alchemy-run/alchemy/pull/1175)),
   and improved platform runtime detection
   ([#1197](https://github.com/alchemy-run/alchemy/pull/1197))!
+- **Cloudflare Containers reach host services in dev**
+  ([#1344](https://github.com/alchemy-run/alchemy/pull/1344),
+  [#1335](https://github.com/alchemy-run/alchemy/pull/1335)) —
+  loopback env URLs rewrite to the docker host, and container
+  images hot-reload on context/Dockerfile/prop changes.
 - **Nested Worker env plans converge**
   ([#1273](https://github.com/alchemy-run/alchemy/pull/1273)) — a
   Worker bound to an already-yielded Worker no longer plans
@@ -614,6 +743,13 @@ Docs:
   ([#1254](https://github.com/alchemy-run/alchemy/pull/1254)) — a
   queue name no longer lands in its binding JSON-quoted, so the
   dashboard and hand-written env reads see the real value.
+- **App Runner reaps auto-created log groups on delete**
+  ([#1327](https://github.com/alchemy-run/alchemy/pull/1327)).
+- **SvelteKit 3 config shape**
+  ([#1347](https://github.com/alchemy-run/alchemy/pull/1347)) —
+  `@sveltejs/kit@3.0.0-next.21+`.
+- **Process env wins over dotenv defaults**
+  ([#1355](https://github.com/alchemy-run/alchemy/pull/1355)).
 - **Dependency security bumps**
   ([#1255](https://github.com/alchemy-run/alchemy/pull/1255)) —
   the vulnerable `extract-zip` and libvips advisories are out of
@@ -675,14 +811,20 @@ Docs:
 
 ## Where to go next
 
-- [AWS local development](/aws/local-development)
-- [Local development](/environments/local-development)
-- [Hetzner](/hetzner)
-- [Hetzner tutorial](/hetzner/tutorial/part-1)
+- [Railway](/railway)
+- [Railway tutorial](/railway/tutorial/part-1)
 - [Fly.io](/fly)
 - [Fly.io tutorial](/fly/tutorial/part-1)
+- [Hetzner](/hetzner)
+- [Hetzner tutorial](/hetzner/tutorial/part-1)
+- [Cloudflare frontends](/cloudflare/frontend/frontends)
 - [AWS frontends](/aws/frontend/websites)
+- [Fly frontends](/fly/frontend/websites)
+- [Hetzner frontends](/hetzner/frontend/websites)
+- [Railway frontends](/railway/frontend/websites)
+- [AWS local development](/aws/local-development)
+- [Local development](/environments/local-development)
 - [Protect a Worker with Access](/cloudflare/security/access)
 - [SQL](/sql)
-- [CHANGELOG](https://github.com/alchemy-run/alchemy/blob/main/CHANGELOG.md#v200-beta74)
-- [Compare v2.0.0-beta.71 → v2.0.0-beta.74](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.71...v2.0.0-beta.74)
+- [CHANGELOG](https://github.com/alchemy-run/alchemy/blob/main/CHANGELOG.md)
+- [Compare v2.0.0-beta.71 → main](https://github.com/alchemy-run/alchemy/compare/v2.0.0-beta.71...main)

--- a/website/src/content/docs/blog/2026-08-25-beta-75.md
+++ b/website/src/content/docs/blog/2026-08-25-beta-75.md
@@ -429,21 +429,15 @@ Docs: [Fly.io](/fly) · [Tutorial](/fly/tutorial/part-1).
 ## AWS local dev
 
 `alchemy dev` now runs your AWS stack on your machine
-([#1154](https://github.com/alchemy-run/alchemy/pull/1154)) using
-[our fork](https://github.com/alchemy-run/floci) of
-[floci](https://floci.io), an MIT LocalStack-style emulator. No
-stored profile, no env vars, no config — the emulator starts
-automatically in Docker (one shared `alchemy-floci` container
-across projects and sessions) and your stack deploys into it in
-seconds:
+([#1154](https://github.com/alchemy-run/alchemy/pull/1154)). No
+account, no credentials:
 
 ```sh
 bun alchemy dev
-# no AWS credentials — using the local emulator
 ```
 
-Take a Lambda Function that owns a bucket and a queue and writes
-to both:
+Same program as production. A Function that writes to a bucket
+and a queue:
 
 ```typescript
 export default class Api extends AWS.Lambda.Function<Api>()(
@@ -469,7 +463,7 @@ export default class Api extends AWS.Lambda.Function<Api>()(
 ) {}
 ```
 
-The dev deploy's outputs all point at the emulator:
+hits local endpoints:
 
 ```text
 Api.functionUrl  http://b71ff5c0….lambda-url.us-east-1.localhost:4566/
@@ -477,63 +471,25 @@ Jobs.queueUrl    http://localhost:4566/000000000000/jobs-dev-x7k2
 Files.bucketName files-dev-x7k2
 ```
 
-Everything runs locally on your machine: the Lambda executes in
-a Docker container behind a working Function URL, SQS→Lambda
-event source mappings pump messages, S3 notifications fire,
-EventBridge routes, and SNS subscriptions deliver. The bindings
-need no configuration — `putObject` above lands in the local
-bucket, because distilled honors the official SDKs'
-`AWS_ENDPOINT_URL` override that floci injects
-([#1192](https://github.com/alchemy-run/alchemy/pull/1192),
-[#1210](https://github.com/alchemy-run/alchemy/pull/1210)).
+Save the file and the Function serves the new code in
+**~100–500ms**. `putObject` lands in the local bucket; queue
+consumers fire; websites run their own dev servers.
 
-Save the file and the running function serves the new code in
-**~100–500ms** — no redeploy, no restart. The dev session watches
-your code, rebuilds, and swaps it under the live Function URL.
-
-Mix in the real cloud per resource with `Alchemy.remote()`:
+Opt a resource onto the real cloud with `Alchemy.remote()`:
 
 ```typescript
-// everything else is local; this one hits real AWS
 const secret = yield* AWS.SecretsManager.Secret("ProdSecret", { ... })
   .pipe(Alchemy.remote());
 ```
 
-If a remote resource needs credentials you don't have,
-`alchemy dev` tells you before touching anything, and switching a
-resource between local and live plans a **replacement** — dev
-state never silently becomes cloud state. Resources without local
-emulation run against the real cloud as before; stacks that mix
-the two work unchanged.
-
-Local emulation covers Lambda (hot reload, Function URLs, event
-source mappings), S3, DynamoDB, SQS, SNS, EventBridge, Secrets
-Manager, SSM, IAM, Cognito, Step Functions, Glue, ACM, and more.
-
-That includes the CloudFront edge: an `AWS.Website.Router`
-deploys into the emulator and serves requests on your machine.
-Its routing logic is a real CloudFront Function — floci executes
-it per request, it reads routes from the local KeyValueStore, and
-`cf.updateRequestOrigin()` forwards to local bucket and Function
-URL origins.
-
-We forked floci so that alchemy's live AWS test suites, which
-normally run against real AWS, can run against the emulator and
-drive an agentic pipeline that patches it. Every fidelity gap a
-test surfaces becomes a fix in the fork instead of a workaround
-in alchemy, and hundreds of live tests now run green against the
-emulator
-([#1250](https://github.com/alchemy-run/alchemy/pull/1250)). The
-`examples/aws-dev` suite drives the real `alchemy dev` CLI end
-to end: bindings, queue consumers, and mid-session hot reloads
-([#1192](https://github.com/alchemy-run/alchemy/pull/1192)).
+Switching local ↔ live plans a **replacement**, so dev state
+never silently becomes cloud state.
 
 Docs: [AWS local development](/aws/local-development).
 
 ## Local ECS, EC2, and MicroVMs
 
-`alchemy dev` runs ECS tasks and services as **real Docker
-containers** on your machine, with hot reload
+`alchemy dev` runs ECS tasks the same way
 ([#1185](https://github.com/alchemy-run/alchemy/pull/1185),
 [#1335](https://github.com/alchemy-run/alchemy/pull/1335)):
 
@@ -543,43 +499,21 @@ export default class Web extends AWS.ECS.Task<Web>()(
   { main: import.meta.url, port: 8080 },
   Effect.gen(function* () {
     return {
-      fetch: Effect.gen(function* () {
-        return HttpServerResponse.text("hello from a local container");
-      }),
+      fetch: Effect.succeed(HttpServerResponse.text("hello")),
     };
   }),
 ) {}
 ```
-
-A dev deploy puts a real container on your machine:
 
 ```text
 $ docker ps
 floci-ecs-…-web   Up 4 seconds   0.0.0.0:8080->8080/tcp
 ```
 
-Bring-your-own-Dockerfile containers work too:
-`AWS.ECS.Service("Api", { context: "./api", port: 3000 })` builds
-your image and runs it the same way. Save a file and the running
-container swaps in ~6 seconds. Prop-driven updates (an inline
-`dockerfile`, a new env var) roll too — not just file edits.
-
-The whole live pipeline runs unchanged against the emulator:
-image build, `docker push` through a real local OCI registry,
-task definitions, `RunTask`, and services that converge exactly
-like AWS. VPC/subnet/ALB scaffolding and event-source glue (SNS
-subscriptions, Lambda permissions, EventBridge, Scheduler) run
-against the emulator too
-([#1210](https://github.com/alchemy-run/alchemy/pull/1210)) —
-previously a dev apply could create a real VPC and ALB that
-could never route to local containers.
-
-The same watch loop covers **EC2 hosted instances** (in-place
-bundle + reboot, same address) and **Lambda MicroVMs** (host-side
-`docker build` with real layer caching — image edits serve in
-~14s instead of a cold ~60s rebuild). Plan-time lookups
-(`getAmi`, AZ discovery) resolve against the emulator in dev, so
-you don't need AWS credentials just to plan.
+Save a file and the container swaps in ~6 seconds. A Dockerfile
+context works too:
+`AWS.ECS.Service("Api", { context: "./api", port: 3000 })`.
+EC2 instances and Lambda MicroVMs hot-reload on the same loop.
 
 Docs: [AWS local development](/aws/local-development).
 

--- a/website/src/content/docs/blog/2026-08-25-beta-75.md
+++ b/website/src/content/docs/blog/2026-08-25-beta-75.md
@@ -33,18 +33,13 @@ This post covers beta.72 through beta.75.
 - **Website props are one vocabulary**
   ([#1353](https://github.com/alchemy-run/alchemy/pull/1353),
   [#1351](https://github.com/alchemy-run/alchemy/pull/1351),
-  [#1158](https://github.com/alchemy-run/alchemy/pull/1158)).
-  Flat deploy props, the framework's own config file, and a
-  JSON-serializable override bag (`astro:`, `vite:`, `nuxt:`,
-  `waku:`, `kit:`). AWS's `server: { env, memorySize, … }` bag
-  is gone — those fields are top-level. Cloudflare's mirrored
-  framework fields (`site`, `base`, `srcDir`, `spa`, …) move
-  into the bag and `assets.notFoundHandling`.
-  `StaticSite.environment` is `build.env`. Custom domains are
-  `domain: { name, aliases?, redirects? }` (or a bare hostname);
-  the zone is inferred from the hostname. Lambda's `url` prop is
-  `functionUrl`; `Website.Server`'s `port` moved to
-  `dev: { port }`.
+  [#1158](https://github.com/alchemy-run/alchemy/pull/1158)) —
+  AWS's `server:` bag is gone, Cloudflare's mirrored framework
+  fields move into `astro:` / `waku:` /
+  `assets.notFoundHandling`, `StaticSite.environment` is
+  `build.env`. Lambda's `url` is `functionUrl`;
+  `Website.Server`'s `port` is `dev: { port }`. See
+  [below](#websites-on-five-clouds).
 - **SQL migrations have one prop and one format**
   ([#1226](https://github.com/alchemy-run/alchemy/pull/1226)).
   `migrationsDir`/`migrationsTable` are replaced by a single
@@ -85,18 +80,12 @@ bun add alchemy@latest effect@rc @effect/platform-bun@rc @effect/platform-node@r
 ## Websites on five clouds
 
 The Website family now deploys to **Cloudflare, AWS, Hetzner,
-Railway, and Fly** with one props vocabulary
+Railway, and Fly**
 ([#1140](https://github.com/alchemy-run/alchemy/pull/1140),
 [#1353](https://github.com/alchemy-run/alchemy/pull/1353),
-[#1351](https://github.com/alchemy-run/alchemy/pull/1351)):
-
-1. **Flat deploy props** — `rootDir`, `env`, `memo`, `assets`,
-   `dev`, plus the platform half.
-2. **The framework's own config file**, loaded natively —
-   plugins and all.
-3. **A per-framework override bag** (`astro:`, `vite:`,
-   `nuxt:`, `waku:`, `kit:`) merged *over* the file for values
-   that vary per stage or come from other resources' `Output`s.
+[#1351](https://github.com/alchemy-run/alchemy/pull/1351)).
+Your `astro.config.*` loads natively. Stage-varying values go in
+the `astro:` bag. Change the namespace to change the cloud:
 
 ```typescript
 const site = yield* Cloudflare.Website.Astro("Blog", {
@@ -107,35 +96,71 @@ const site = yield* Cloudflare.Website.Astro("Blog", {
 });
 ```
 
-Swap the namespace: `AWS.Website.Astro`, `Fly.Website.Astro`,
-`Railway.Website.Astro`, `Hetzner.Website.Astro` (pass `zone`
-when you set `domain`). Zone inference on Cloudflare and AWS
-walks the hostname; pin it with `zone` / `hostedZoneId` when
-several could match.
+```diff lang="typescript"
+-const site = yield* Cloudflare.Website.Astro("Blog", {
++const site = yield* Fly.Website.Astro("Blog", {
+   rootDir: "./apps/blog",
+   env: { API_BASE: api.url },
+   astro: { site: `https://${stage}.example.com`, output: "server" },
+   domain: "blog.example.com",
+ });
+```
+
+`AWS.Website.Astro` and `Railway.Website.Astro` take the same
+props. Hetzner adds the DNS `zone` when you set `domain`:
+
+```typescript
+const site = yield* Hetzner.Website.Astro("Blog", {
+  rootDir: "./apps/blog",
+  env: { API_BASE: api.url },
+  astro: { site: `https://${stage}.example.com`, output: "server" },
+  domain: "blog.example.com",
+  zone,
+});
+```
 
 `alchemy dev` is the framework's own server on every cloud —
-native HMR, no cloud resources. Live topology is what changes:
+native HMR, no cloud resources. A Vite SPA is the same shape,
+assets-only on AWS (no Lambda):
 
-- **Cloudflare** — Worker + static assets
-- **AWS** — private S3 + CloudFront Function router + streaming
-  Lambda. Next.js is the full OpenNext topology (streaming
-  server, image-optimization Lambda, SQS FIFO revalidation,
-  DynamoDB tag cache, ISR bucket)
-- **Fly** — one Service (Machine) + Tigris for hashed client
-  assets + ACME if `domain` is set
-- **Hetzner** — a systemd unit on a Server (auto-created `cpx12`
-  in `fsn1` if you omit `server`) + an A record
-- **Railway** — a Service from a generated Dockerfile, CDN on
-  the Service, `CustomDomain` if `domain` is set
+```typescript
+const site = yield* AWS.Website.Vite("Web", {
+  domain: "app.example.com",
+});
+```
 
-Next.js on Fly, Hetzner, and Railway is `next build` plus a
-long-running Node server, not OpenNext. React Router, SolidStart,
-and TanStack Start stay on Cloudflare (`Website.Vite`) and AWS
-(dedicated composites).
+Next.js is the same call. Cloudflare and AWS run OpenNext;
+Fly, Hetzner, and Railway run `next build` and a Node server:
 
-Frameworks on all five: **Vite, Foldkit, Astro, Next.js, Nuxt,
-SvelteKit, Waku, Octane, StaticSite**. Vocs on Cloudflare, Fly,
-Hetzner, and Railway. Each cloud has a matching example
+```typescript
+const site = yield* Fly.Website.Nextjs("Site", {
+  rootDir: "./apps/web",
+  env: { DATABASE_URL: db.connectionUri },
+  domain: "app.example.com",
+});
+```
+
+AWS's old `server:` bag is now flat props:
+
+```diff lang="typescript"
+ const site = yield* AWS.Website.Astro("Blog", {
+-  server: {
+-    memorySize: 1024,
+-    environment: { API_URL: api.url },
+-  },
++  memorySize: 1024,
++  env: { API_URL: api.url },
+   astro: { site: `https://${stage}.example.com` },
+   domain: "blog.example.com",
+ });
+```
+
+`Vite`, `Foldkit`, `Astro`, `Nextjs`, `Nuxt`, `SvelteKit`,
+`Waku`, `Octane`, and `StaticSite` on all five.
+`Cloudflare.Website.Vocs` also lands on Fly, Hetzner, and
+Railway. React Router, SolidStart, and TanStack Start stay on
+Cloudflare (`Website.Vite`) and AWS (dedicated composites).
+Each cloud has a matching example
 (`examples/{cloudflare,aws,fly,hetzner,railway}-website-{framework}`).
 
 Docs:
@@ -186,10 +211,31 @@ export default class Api extends Railway.Service<Api>()(
 ```
 
 `api.url` is `https://{name}.up.railway.app`. Redis and S3-style
-Buckets bind the same way — `ReadWriteRedis` on a `Railway.Redis`,
-`PutObject`/`GetObject` on a `Railway.Bucket`. Pass `image` for
-a public tag (`hashicorp/http-echo`) or `repo` for GitHub;
-`healthcheck` / `cronSchedule` match Railway IaC.
+Buckets bind the same way:
+
+```typescript
+const Cache = Railway.Redis("Cache", { project: Site });
+const Data = Railway.Bucket("Data", { project: Site });
+
+export default class Api extends Railway.Service<Api>()(
+  "Api",
+  { project: Site, main: import.meta.url, registry: "ghcr.io/acme" },
+  Effect.gen(function* () {
+    const cache = yield* Railway.ReadWriteRedis(Cache);
+    const putObject = yield* Railway.PutObject(Data);
+    return {
+      fetch: Effect.gen(function* () {
+        yield* putObject({ Key: "hello.txt", Body: "hello" });
+        yield* cache.set("last-write", "hello.txt");
+        return HttpServerResponse.text("ok");
+      }),
+    };
+  }).pipe(Effect.provide([Railway.ReadWriteRedisHttp, Railway.PutObjectHttp])),
+) {}
+```
+
+Pass `image` for a public tag (`hashicorp/http-echo`) or `repo`
+for GitHub; `healthcheck` / `cronSchedule` match Railway IaC.
 
 `Railway.Function` is the canvas runtime: a single TypeScript
 file on Bun. No Docker. No registry. Cap is 96KB. Distinct from
@@ -650,14 +696,25 @@ longer declared, put it back before deploying.
 Docs:
 [Resource lifecycle](/infrastructure-as-code/resource-lifecycle).
 
+## Lambda Docker Functions
+
+`AWS.Lambda.Function` deploys a container image
+([#1077](https://github.com/alchemy-run/alchemy/pull/1077)).
+Build from a Dockerfile into a managed ECR repo, or point
+`image.uri` at an existing tag or digest. Zip XOR image at the
+type level — mixing `main` with `image` is a compile error.
+Thanks [Simon Westerlund](https://github.com/westerlund)!
+
+```typescript
+const api = yield* AWS.Lambda.Function("ContainerApi", {
+  image: { context: "./lambda", dockerfile: "Dockerfile" },
+  architecture: "arm64",
+  functionUrl: true,
+});
+```
+
 ## Also in this release
 
-- **Lambda Docker Functions**
-  ([#1077](https://github.com/alchemy-run/alchemy/pull/1077)) —
-  `AWS.Lambda.Function` deploys a container image: build from a
-  Dockerfile into a managed ECR repo, or point `image.uri` at an
-  existing tag or digest. Zip XOR image at the type level.
-  Thanks [Simon Westerlund](https://github.com/westerlund)!
 - **`Cloudflare.Website.Vocs`**
   ([#1278](https://github.com/alchemy-run/alchemy/pull/1278)) —
   first-class Vocs docs sites, also on Fly, Hetzner, and Railway.

--- a/website/src/content/docs/blog/2026-08-25-beta-75.md
+++ b/website/src/content/docs/blog/2026-08-25-beta-75.md
@@ -487,11 +487,12 @@ never silently becomes cloud state.
 
 Docs: [AWS local development](/aws/local-development).
 
-## Local ECS, EC2, and MicroVMs
+## Local ECS and MicroVMs
 
-`alchemy dev` runs ECS tasks the same way
+`alchemy dev` runs ECS tasks and Lambda MicroVMs the same way
 ([#1185](https://github.com/alchemy-run/alchemy/pull/1185),
-[#1335](https://github.com/alchemy-run/alchemy/pull/1335)):
+[#1335](https://github.com/alchemy-run/alchemy/pull/1335)) — same
+program, two runtimes:
 
 ```typescript
 export default class Web extends AWS.ECS.Task<Web>()(
@@ -505,15 +506,20 @@ export default class Web extends AWS.ECS.Task<Web>()(
 ) {}
 ```
 
-```text
-$ docker ps
-floci-ecs-…-web   Up 4 seconds   0.0.0.0:8080->8080/tcp
+```typescript
+export default class Box extends AWS.Lambda.MicrovmImage<Box>()(
+  "Box",
+  { main: import.meta.url },
+  Effect.gen(function* () {
+    return {
+      fetch: Effect.succeed(HttpServerResponse.text("hello")),
+    };
+  }),
+) {}
 ```
 
-Save a file and the container swaps in ~6 seconds. A Dockerfile
-context works too:
-`AWS.ECS.Service("Api", { context: "./api", port: 3000 })`.
-EC2 instances and Lambda MicroVMs hot-reload on the same loop.
+Save a file and both reload. EC2 instances that host an Effect
+program do too.
 
 Docs: [AWS local development](/aws/local-development).
 


### PR DESCRIPTION
Rebrand the unannounced beta.74 notes to beta.75 and fold in Railway, five-cloud Website deployments, and the rest of main.

```ts
const site = yield* Cloudflare.Website.Astro("Blog", {
  rootDir: "./apps/blog",
  env: { API_BASE: api.url },
  astro: { site: `https://${stage}.example.com` },
  domain: "blog.example.com",
});
// same call: AWS | Fly | Hetzner | Railway
```

- Announce Railway with Fly and Hetzner
- One Website props vocabulary across Cloudflare, AWS, Hetzner, Railway, and Fly
- Draft *Looping the Generation of Local Emulators* until AWS local coverage is complete
