### PR TITLE
test(cloudflare): decouple native-binding coverage from token minting

### DIFF
--- a/packages/alchemy/test/Cloudflare/KV/Binding.test.ts
+++ b/packages/alchemy/test/Cloudflare/KV/Binding.test.ts
@@ -241,20 +241,36 @@ const exercise = (label: string, base: string) =>
     yield* expectMissing(base, k("v"));
   });
 
+/** Write through `writeBase`, read it back (and observe the delete) through `readBase`. */
+const crossWorker = (label: string, writeBase: string, readBase: string) =>
+  Effect.gen(function* () {
+    const key = `${label}-key`;
+    expect((yield* put(writeBase, key, `${label}-value`)).status).toBe(200);
+    expect(yield* expectValue(readBase, key, `${label}-value`)).toBe(
+      `${label}-value`,
+    );
+    yield* del(writeBase, key);
+    yield* expectMissing(readBase, key);
+  });
+
+const url = (u: unknown) => {
+  expect(u).toBeTypeOf("string");
+  return u as string;
+};
+
 /**
- * Deploys six Workers that all bind one shared KV namespace — read /
- * write / read-write, each over the native Worker binding
- * (`*NamespaceBinding`) and over a scoped HTTP API token
- * (`*NamespaceHttp`) — then drives them over `fetch`:
+ * Deploys three Workers that all bind one shared KV namespace — read /
+ * write / read-write — over the native Worker binding
+ * (`*NamespaceBinding`), then drives them over `fetch`:
  *
  * - the read-write worker exercises the entire client surface by itself
- *   (every read + write method), once per transport;
+ *   (every read + write method);
  * - the split Read/Write workers prove the separate bindings agree on
  *   the namespace: write through Write, read back through Read, delete
  *   through Write, observe gone through Read.
  */
 test.provider.skipIf(!!process.env.FAST)(
-  "KV read/write/read-write bindings over binding + http",
+  "KV read/write/read-write bindings over the native binding",
   (stack) =>
     Effect.gen(function* () {
       yield* stack.destroy();
@@ -264,13 +280,53 @@ test.provider.skipIf(!!process.env.FAST)(
           const readBinding = yield* ReadBindingWorker;
           const writeBinding = yield* WriteBindingWorker;
           const readWriteBinding = yield* ReadWriteBindingWorker;
-          const readHttp = yield* ReadHttpWorker;
-          const writeHttp = yield* WriteHttpWorker;
-          const readWriteHttp = yield* ReadWriteHttpWorker;
           return {
             readBinding: readBinding.url,
             writeBinding: writeBinding.url,
             readWriteBinding: readWriteBinding.url,
+          };
+        }),
+      );
+
+      yield* exercise("rw-bind", url(out.readWriteBinding));
+      yield* crossWorker("bind", url(out.writeBinding), url(out.readBinding));
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 300_000 },
+);
+
+/**
+ * The same matrix over the `*NamespaceHttp` clients.
+ *
+ * Gated: the `*NamespaceHttp` layers mint a scoped `AccountApiToken`, and
+ * Cloudflare OAuth credentials have no token-creation scope at all — the
+ * deploy fails at token creation with:
+ *
+ *     Unauthorized: Unauthorized to access requested resource
+ *       at AccountApiToken.ts (provider.create)
+ *
+ * Deployed separately from the native-binding test above so that minting
+ * the token cannot take down binding coverage that needs no token.
+ *
+ * Set `CLOUDFLARE_TEST_API_TOKENS=1` with an API-token credential that is
+ * permitted to create account tokens. Matches the gate on the
+ * `UserApiToken` lifecycle tests (`CLOUDFLARE_TEST_USER_TOKENS`).
+ */
+test.provider.skipIf(
+  !!process.env.FAST || !process.env.CLOUDFLARE_TEST_API_TOKENS,
+)(
+  "KV read/write/read-write bindings over a scoped HTTP token",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const out = yield* stack.deploy(
+        Effect.gen(function* () {
+          const readHttp = yield* ReadHttpWorker;
+          const writeHttp = yield* WriteHttpWorker;
+          const readWriteHttp = yield* ReadWriteHttpWorker;
+          return {
             readHttp: readHttp.url,
             writeHttp: writeHttp.url,
             readWriteHttp: readWriteHttp.url,
@@ -278,34 +334,7 @@ test.provider.skipIf(!!process.env.FAST)(
         }),
       );
 
-      const url = (u: unknown) => {
-        expect(u).toBeTypeOf("string");
-        return u as string;
-      };
-
-      // ── Full client surface through a single read-write worker ──
-      yield* exercise("rw-bind", url(out.readWriteBinding));
       yield* exercise("rw-http", url(out.readWriteHttp));
-
-      // ── Split Read/Write bindings agree on the shared namespace ──
-      const crossWorker = (
-        label: string,
-        writeBase: string,
-        readBase: string,
-      ) =>
-        Effect.gen(function* () {
-          const key = `${label}-key`;
-          expect((yield* put(writeBase, key, `${label}-value`)).status).toBe(
-            200,
-          );
-          expect(yield* expectValue(readBase, key, `${label}-value`)).toBe(
-            `${label}-value`,
-          );
-          yield* del(writeBase, key);
-          yield* expectMissing(readBase, key);
-        });
-
-      yield* crossWorker("bind", url(out.writeBinding), url(out.readBinding));
       yield* crossWorker("http", url(out.writeHttp), url(out.readHttp));
 
       yield* stack.destroy();

--- a/packages/alchemy/test/Cloudflare/Queue/Binding.test.ts
+++ b/packages/alchemy/test/Cloudflare/Queue/Binding.test.ts
@@ -52,17 +52,34 @@ const post = (base: string, path: string, body?: string) => {
 };
 
 /**
- * Cloudflare Queue is producer-only at the binding layer, so there is
- * no Read/ReadWrite split — only a Write producer. This deploys two
- * Workers that both bind one shared queue (native Worker binding and
- * scoped HTTP API token), then drives every {@link WriteQueueClient}
- * method over `fetch` — `send` and `sendBatch`, each in its JSON and
- * `text` content-type form — and asserts the producer accepts the
- * messages (202), proving the binding/token are wired and reach the
- * real queue.
+ * Drive every {@link WriteQueueClient} method over `fetch` — `send` and
+ * `sendBatch`, each in its JSON and `text` content-type form — and assert
+ * the producer accepts the messages (202), proving the binding/token are
+ * wired and reach the real queue.
+ *
+ * Cloudflare Queue is producer-only at the binding layer, so there is no
+ * Read/ReadWrite split — only a Write producer.
+ *
+ * The two implementations deploy separately on purpose. The HTTP producer
+ * mints a scoped `AccountApiToken`, which the native binding does not need;
+ * sharing one deploy meant a credential that cannot mint tokens lost the
+ * native-binding coverage too, rather than just the half it actually gates.
  */
+const exercise = (base: string, label: string) =>
+  Effect.gen(function* () {
+    expect((yield* post(base, "/send", `${label}-json`)).status).toBe(202);
+    expect((yield* post(base, "/send-text", `${label}-text`)).status).toBe(202);
+    expect((yield* post(base, "/sendBatch")).status).toBe(202);
+    expect((yield* post(base, "/sendBatch-text")).status).toBe(202);
+  });
+
+const url = (u: unknown) => {
+  expect(u).toBeTypeOf("string");
+  return u as string;
+};
+
 test.provider(
-  "Queue write producer over binding + http",
+  "Queue write producer over the native binding",
   (stack) =>
     Effect.gen(function* () {
       yield* stack.destroy();
@@ -70,36 +87,42 @@ test.provider(
       const out = yield* stack.deploy(
         Effect.gen(function* () {
           const writeBinding = yield* WriteBindingWorker;
-          const writeHttp = yield* WriteHttpWorker;
-          return {
-            writeBinding: writeBinding.url,
-            writeHttp: writeHttp.url,
-          };
+          return { writeBinding: writeBinding.url };
         }),
       );
 
-      const url = (u: unknown) => {
-        expect(u).toBeTypeOf("string");
-        return u as string;
-      };
-
-      // Drive the full producer surface (send + sendBatch, json + text)
-      // against one base url.
-      const exercise = (base: string, label: string) =>
-        Effect.gen(function* () {
-          expect((yield* post(base, "/send", `${label}-json`)).status).toBe(
-            202,
-          );
-          expect(
-            (yield* post(base, "/send-text", `${label}-text`)).status,
-          ).toBe(202);
-          expect((yield* post(base, "/sendBatch")).status).toBe(202);
-          expect((yield* post(base, "/sendBatch-text")).status).toBe(202);
-        });
-
-      // ── Native binding producer ──
       yield* exercise(url(out.writeBinding), "binding");
-      // ── HTTP token producer ──
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 240_000 },
+);
+
+/**
+ * Gated: the `WriteQueueHttp` layer mints a scoped `AccountApiToken`, and
+ * Cloudflare OAuth credentials have no token-creation scope at all — the
+ * deploy fails at token creation with:
+ *
+ *     Unauthorized: Unauthorized to access requested resource
+ *       at AccountApiToken.ts (provider.create)
+ *
+ * Set `CLOUDFLARE_TEST_API_TOKENS=1` with an API-token credential that is
+ * permitted to create account tokens. Matches the gate on the
+ * `UserApiToken` lifecycle tests (`CLOUDFLARE_TEST_USER_TOKENS`).
+ */
+test.provider.skipIf(!process.env.CLOUDFLARE_TEST_API_TOKENS)(
+  "Queue write producer over a scoped HTTP token",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const out = yield* stack.deploy(
+        Effect.gen(function* () {
+          const writeHttp = yield* WriteHttpWorker;
+          return { writeHttp: writeHttp.url };
+        }),
+      );
+
       yield* exercise(url(out.writeHttp), "http");
 
       yield* stack.destroy();

--- a/packages/alchemy/test/Cloudflare/R2/Binding.test.ts
+++ b/packages/alchemy/test/Cloudflare/R2/Binding.test.ts
@@ -1,6 +1,6 @@
 import * as Cloudflare from "@/Cloudflare";
 import * as Test from "@/Test/Alchemy";
-import { expect } from "alchemy-test";
+import { describe, expect } from "alchemy-test";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import { MinimumLogLevel } from "effect/References";
@@ -8,6 +8,7 @@ import * as Schedule from "effect/Schedule";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
 import type * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
+import HttpStack from "./fixtures/stack-http.ts";
 import Stack from "./fixtures/stack.ts";
 
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
@@ -227,66 +228,86 @@ const exercise = (
   });
 
 /**
- * Deploys six Workers that all bind one shared R2 bucket — read /
- * write / read-write, each over the native Worker binding
- * (`*BucketBinding`) and over a scoped HTTP API token (`*BucketHttp`)
- * — via {@link Stack}, then drives each binding flavor over `fetch` in
- * its own test:
+ * Deploys three Workers that all bind one shared R2 bucket — read /
+ * write / read-write — over the native Worker binding
+ * (`*BucketBinding`), via {@link Stack}, then drives each flavor over
+ * `fetch`:
  *
  * - write through the Write worker, read it back through the Read
  *   worker (cross-worker, proving both halves agree on the bucket);
  * - round-trip a key through the ReadWrite worker by itself.
- *
- * The stack lives in `fixtures/stack.ts` so it can also be inspected
- * directly, e.g. `alchemy tail --stage test ./test/Cloudflare/R2/fixtures/stack.ts`.
  */
-const stack = beforeAll(deploy(Stack), { timeout: HOOK_TIMEOUT });
-afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(Stack), {
-  timeout: HOOK_TIMEOUT,
+describe("native binding", () => {
+  const stack = beforeAll(deploy(Stack), { timeout: HOOK_TIMEOUT });
+  afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(Stack), {
+    timeout: HOOK_TIMEOUT,
+  });
+
+  test(
+    "write + read across separate workers",
+    Effect.gen(function* () {
+      const out = yield* stack;
+      yield* exercise("bind", out.writeBinding, out.readBinding, true);
+    }).pipe(logLevel),
+    { timeout: TEST_TIMEOUT },
+  );
+
+  test(
+    "read-write round-trip in one worker",
+    Effect.gen(function* () {
+      const out = yield* stack;
+      yield* exercise(
+        "rw-bind",
+        out.readWriteBinding,
+        out.readWriteBinding,
+        true,
+      );
+    }).pipe(logLevel),
+    { timeout: TEST_TIMEOUT },
+  );
 });
 
-// ── Native Worker binding ── write through the Write worker, read back through
-// the Read worker (cross-worker, proving both halves agree on the bucket).
-test(
-  "native binding: write + read across separate workers",
-  Effect.gen(function* () {
-    const out = yield* stack;
-    yield* exercise("bind", out.writeBinding, out.readBinding, true);
-  }).pipe(logLevel),
-  { timeout: TEST_TIMEOUT },
-);
+/**
+ * The same matrix over the `*BucketHttp` clients (multipart is
+ * unsupported over the HTTP API, so it is skipped here).
+ *
+ * Gated: the `*BucketHttp` layers mint a scoped `AccountApiToken`, and
+ * Cloudflare OAuth credentials have no token-creation scope at all — the
+ * deploy fails at token creation with:
+ *
+ *     Unauthorized: Unauthorized to access requested resource
+ *       at AccountApiToken.ts (provider.create)
+ *
+ * The gate is on the `describe` rather than the individual tests so the
+ * suite's `beforeAll` never runs: the runner skips a suite's hooks when
+ * every test below it is skipped, which is what keeps the token mint out
+ * of the native-binding path above.
+ *
+ * Set `CLOUDFLARE_TEST_API_TOKENS=1` with an API-token credential that is
+ * permitted to create account tokens. Matches the gate on the
+ * `UserApiToken` lifecycle tests (`CLOUDFLARE_TEST_USER_TOKENS`).
+ */
+describe.skipIf(!process.env.CLOUDFLARE_TEST_API_TOKENS)("http token", () => {
+  const stack = beforeAll(deploy(HttpStack), { timeout: HOOK_TIMEOUT });
+  afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(HttpStack), {
+    timeout: HOOK_TIMEOUT,
+  });
 
-// The ReadWrite worker round-trips a key by itself over the native binding.
-test(
-  "native binding: read-write round-trip in one worker",
-  Effect.gen(function* () {
-    const out = yield* stack;
-    yield* exercise(
-      "rw-bind",
-      out.readWriteBinding,
-      out.readWriteBinding,
-      true,
-    );
-  }).pipe(logLevel),
-  { timeout: TEST_TIMEOUT },
-);
+  test(
+    "write + read across separate workers",
+    Effect.gen(function* () {
+      const out = yield* stack;
+      yield* exercise("http", out.writeHttp, out.readHttp, false);
+    }).pipe(logLevel),
+    { timeout: TEST_TIMEOUT },
+  );
 
-// ── Scoped HTTP API token ── same matrix over the `*BucketHttp` clients
-// (multipart is unsupported over the HTTP API, so it is skipped here).
-test(
-  "http token: write + read across separate workers",
-  Effect.gen(function* () {
-    const out = yield* stack;
-    yield* exercise("http", out.writeHttp, out.readHttp, false);
-  }).pipe(logLevel),
-  { timeout: TEST_TIMEOUT },
-);
-
-test(
-  "http token: read-write round-trip in one worker",
-  Effect.gen(function* () {
-    const out = yield* stack;
-    yield* exercise("rw-http", out.readWriteHttp, out.readWriteHttp, false);
-  }).pipe(logLevel),
-  { timeout: TEST_TIMEOUT },
-);
+  test(
+    "read-write round-trip in one worker",
+    Effect.gen(function* () {
+      const out = yield* stack;
+      yield* exercise("rw-http", out.readWriteHttp, out.readWriteHttp, false);
+    }).pipe(logLevel),
+    { timeout: TEST_TIMEOUT },
+  );
+});

--- a/packages/alchemy/test/Cloudflare/R2/fixtures/stack-http.ts
+++ b/packages/alchemy/test/Cloudflare/R2/fixtures/stack-http.ts
@@ -1,0 +1,34 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as Alchemy from "@/index.ts";
+import * as Effect from "effect/Effect";
+import ReadHttpWorker from "./read-http.ts";
+import ReadWriteHttpWorker from "./readwrite-http.ts";
+import WriteHttpWorker from "./write-http.ts";
+
+/**
+ * Deploys the three Workers that reach one shared R2 bucket over a
+ * **scoped HTTP API token** (`*BucketHttp`) — read / write /
+ * read-write.
+ *
+ * Kept apart from the native-binding stack ({@link ./stack.ts}) so that
+ * minting the `AccountApiToken` these workers depend on cannot take down
+ * binding coverage that needs no token at all. Inspect directly with:
+ *
+ * ```sh
+ * alchemy tail --stage test ./test/Cloudflare/R2/fixtures/stack-http.ts
+ * ```
+ */
+export default Alchemy.Stack(
+  "R2BindingHttpStack",
+  { providers: Cloudflare.providers(), state: Cloudflare.state() },
+  Effect.gen(function* () {
+    const readHttp = yield* ReadHttpWorker;
+    const writeHttp = yield* WriteHttpWorker;
+    const readWriteHttp = yield* ReadWriteHttpWorker;
+    return {
+      readHttp: readHttp.url.as<string>(),
+      writeHttp: writeHttp.url.as<string>(),
+      readWriteHttp: readWriteHttp.url.as<string>(),
+    };
+  }),
+);

--- a/packages/alchemy/test/Cloudflare/R2/fixtures/stack.ts
+++ b/packages/alchemy/test/Cloudflare/R2/fixtures/stack.ts
@@ -2,21 +2,22 @@ import * as Cloudflare from "@/Cloudflare";
 import * as Alchemy from "@/index.ts";
 import * as Effect from "effect/Effect";
 import ReadBindingWorker from "./read-binding.ts";
-import ReadHttpWorker from "./read-http.ts";
 import ReadWriteBindingWorker from "./readwrite-binding.ts";
-import ReadWriteHttpWorker from "./readwrite-http.ts";
 import WriteBindingWorker from "./write-binding.ts";
-import WriteHttpWorker from "./write-http.ts";
 
 /**
- * Deploys six Workers that all bind one shared R2 bucket — read / write /
- * read-write, each over the native Worker binding (`*BucketBinding`) and over a
- * scoped HTTP API token (`*BucketHttp`). Extracted into its own stack file so
- * it can be deployed by the test suite AND inspected directly, e.g.
+ * Deploys the three Workers that reach one shared R2 bucket over the
+ * **native Worker binding** (`*BucketBinding`) — read / write /
+ * read-write. Extracted into its own stack file so it can be deployed
+ * by the test suite AND inspected directly, e.g.
  *
  * ```sh
  * alchemy tail --stage test ./test/Cloudflare/R2/fixtures/stack.ts
  * ```
+ *
+ * The HTTP-token half lives in a separate stack ({@link ./stack-http.ts})
+ * because deploying it mints an `AccountApiToken`, which not every
+ * credential is permitted to do — see the gate in `../Binding.test.ts`.
  */
 export default Alchemy.Stack(
   "R2BindingStack",
@@ -25,16 +26,10 @@ export default Alchemy.Stack(
     const readBinding = yield* ReadBindingWorker;
     const writeBinding = yield* WriteBindingWorker;
     const readWriteBinding = yield* ReadWriteBindingWorker;
-    const readHttp = yield* ReadHttpWorker;
-    const writeHttp = yield* WriteHttpWorker;
-    const readWriteHttp = yield* ReadWriteHttpWorker;
     return {
       readBinding: readBinding.url.as<string>(),
       writeBinding: writeBinding.url.as<string>(),
       readWriteBinding: readWriteBinding.url.as<string>(),
-      readHttp: readHttp.url.as<string>(),
-      writeHttp: writeHttp.url.as<string>(),
-      readWriteHttp: readWriteHttp.url.as<string>(),
     };
   }),
 );


### PR DESCRIPTION
Three Cloudflare binding suites deployed their native-binding workers and their HTTP-token workers in a single stack. The `*Http` layers mint a scoped `AccountApiToken`, so a credential without token-creation permission failed the whole deploy — taking down the native-binding coverage, which needs no token:

```
Unauthorized: Unauthorized to access requested resource
  at AccountApiToken.ts (provider.create)
```

Cloudflare OAuth credentials have no token-creation scope at all, so this is not recoverable by re-authorizing. On `--profile alchemy-testing` it meant zero coverage of the R2, KV, and Queue native bindings, presenting as a red suite rather than a gap.

Each suite now deploys the two transports separately and gates only the HTTP half.

Queue and KV split their `test.provider` in two:

```diff
-test.provider("Queue write producer over binding + http", (stack) =>
-  // one deploy: WriteBindingWorker + WriteHttpWorker
+test.provider("Queue write producer over the native binding", (stack) =>
+  // deploys WriteBindingWorker only — no token needed
+
+test.provider.skipIf(!process.env.CLOUDFLARE_TEST_API_TOKENS)(
+  "Queue write producer over a scoped HTTP token", (stack) =>
+  // deploys WriteHttpWorker only
```

R2 uses a shared `beforeAll`, so it splits `fixtures/stack.ts` into a binding stack plus a new `fixtures/stack-http.ts` and gates at the `describe`:

```diff
+describe("native binding", () => {
+  const stack = beforeAll(deploy(Stack), { timeout: HOOK_TIMEOUT });
+
+describe.skipIf(!process.env.CLOUDFLARE_TEST_API_TOKENS)("http token", () => {
+  const stack = beforeAll(deploy(HttpStack), { timeout: HOOK_TIMEOUT });
```

The gate sits on the `describe` rather than the individual tests so the suite's `beforeAll` never runs at all — `runSuite` skips a suite's hooks when every test below it is skipped (`alchemy-test/src/Runner.ts`). Both stacks stay independently inspectable via `alchemy tail`.

The env var matches `CLOUDFLARE_TEST_USER_TOKENS` on the `UserApiToken` lifecycle tests, and each skip comment records the exact error per the entitlement-gating convention.

### Result

| suite | before | after |
| --- | --- | --- |
| `test/Cloudflare/Queue` | 24 passed, 1 failed | 25 passed, 1 gated |
| `R2/Binding` + `KV/Binding` | 0 passed, 5 failed | 3 passed, 3 gated |

The native-binding cases are coverage that was previously lost entirely, not failures that were re-labelled. Confirmed the gates are not inert: with `CLOUDFLARE_TEST_API_TOKENS=1` the HTTP tests run and reach the recorded token-creation error.
