### PR TITLE
fix(cloudflare/containers): fail the dev container image build when docker does

### DIFF
--- a/packages/cloudflare-runtime/src/core/Docker.ts
+++ b/packages/cloudflare-runtime/src/core/Docker.ts
@@ -107,6 +107,27 @@ export const toPullRef = (imageUri: string) =>
   imageUri.replace(/:[^@/]+(?=@sha256:)/, "");
 
 /**
+ * Stderr signatures of a docker CLI that cannot run our build. Image builds
+ * use BuildKit flags (`--load`, `--provenance=false`), which a CLI without
+ * the buildx plugin rejects outright. Its stderr names the flag rather than
+ * the missing component, and several distros package the two separately
+ * (Arch/CachyOS `docker` vs `docker-buildx`, Debian `docker.io` vs
+ * `docker-buildx`), so this is a first-run trap rather than a broken setup.
+ */
+const BUILDKIT_MISSING_MARKERS = [
+  "unknown flag: --load",
+  "unknown flag: --provenance",
+  "'buildx' is not a docker command",
+  "buildx component is missing",
+];
+
+/** Names the missing buildx plugin when docker's own stderr only names the flag. */
+export const buildFailureHint = (stderr: string): string | undefined =>
+  BUILDKIT_MISSING_MARKERS.some((marker) => stderr.includes(marker))
+    ? "This docker CLI has no BuildKit (buildx) plugin, which building container images requires. Install it and retry — e.g. `pacman -S docker-buildx` (Arch/CachyOS), `apt install docker-buildx` (Debian/Ubuntu), or Docker Desktop, which bundles it."
+    : undefined;
+
+/**
  * Matches a loopback host (`localhost`, `127.0.0.1`, `0.0.0.0`, `[::1]`)
  * where it denotes a connection target inside an env value: at the start of
  * the value, after a `scheme://` (with optional userinfo), after `=` (DSN
@@ -364,6 +385,25 @@ export const DockerLive = Layer.effect(
         Effect.scoped,
       );
 
+    /**
+     * `run` resolves with the command's exit code instead of failing on it
+     * (some callers, e.g. `inspect`, treat a non-zero exit as a legitimate
+     * "not present" answer). Every command whose failure actually matters
+     * therefore has to check the code itself: without this, a `docker build`
+     * that exits 1 is indistinguishable from a successful build, the image
+     * is never created, and the only symptom the user ever sees is workerd
+     * reporting `Container exited while waiting for port <port>` on a loop.
+     */
+    const ensureExitZero = <E>(
+      result: { exitCode: number; stdout: string; stderr: string },
+      onNonZero: (result: {
+        exitCode: number;
+        stdout: string;
+        stderr: string;
+      }) => E,
+    ): Effect.Effect<void, E> =>
+      result.exitCode === 0 ? Effect.void : Effect.fail(onNonZero(result));
+
     const pull = ({ imageUri }: ContainerImage.Pull) =>
       run(["pull", toPullRef(imageUri), "--platform", "linux/amd64"]).pipe(
         Effect.mapError(
@@ -505,7 +545,6 @@ export const DockerLive = Layer.effect(
             ),
           ).pipe(
             Effect.withLogSpan(`docker: build ${tag}`),
-            Effect.asVoid,
             Effect.mapError(
               (cause) =>
                 new SystemError({
@@ -513,6 +552,18 @@ export const DockerLive = Layer.effect(
                   message: `Failed to build image "${tag}".`,
                   cause,
                 }),
+            ),
+            Effect.flatMap((result) =>
+              ensureExitZero(
+                result,
+                ({ exitCode, stdout, stderr }) =>
+                  new SystemError({
+                    subtag: "DockerBuildFailed",
+                    message: `Failed to build image "${tag}".`,
+                    hint: buildFailureHint(stderr),
+                    detail: { bin, tag, exitCode, stdout, stderr },
+                  }),
+              ),
             ),
           );
         }),
@@ -527,6 +578,24 @@ export const DockerLive = Layer.effect(
                     message: `Failed to tag image "${image.imageUri}" as "${tag}".`,
                     cause,
                   }),
+              ),
+              Effect.flatMap((result) =>
+                ensureExitZero(
+                  result,
+                  ({ exitCode, stdout, stderr }) =>
+                    new SystemError({
+                      subtag: "DockerTagFailed",
+                      message: `Failed to tag image "${image.imageUri}" as "${tag}".`,
+                      detail: {
+                        bin,
+                        imageUri: image.imageUri,
+                        tag,
+                        exitCode,
+                        stdout,
+                        stderr,
+                      },
+                    }),
+                ),
               ),
             ),
           ),

--- a/packages/cloudflare-runtime/src/core/test/Docker.test.ts
+++ b/packages/cloudflare-runtime/src/core/test/Docker.test.ts
@@ -6,6 +6,7 @@ import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 import {
+  buildFailureHint,
   CONTAINER_LOOPBACK_ALIAS,
   Docker,
   DockerLive,
@@ -364,3 +365,115 @@ layer(Layer.provide(DockerLive, Layer.merge(NodeServices.layer, absent.layer)))(
     );
   },
 );
+
+/**
+ * Spawner whose `docker <verb>` exits non-zero with `stderr`, so the tests
+ * below can assert that a failing docker command is reported rather than
+ * mistaken for a successful one.
+ */
+const makeFailingStub = (verb: string, stderr: string, exitCode = 1) =>
+  Layer.succeed(
+    ChildProcessSpawner.ChildProcessSpawner,
+    ChildProcessSpawner.make((command) => {
+      const fails =
+        command._tag === "StandardCommand" && command.args[0] === verb;
+      return Effect.succeed(
+        ChildProcessSpawner.makeHandle({
+          pid: ChildProcessSpawner.ProcessId(1),
+          exitCode: Effect.succeed(
+            ChildProcessSpawner.ExitCode(fails ? exitCode : 0),
+          ),
+          isRunning: Effect.succeed(false),
+          kill: () => Effect.void,
+          stdin: Sink.drain,
+          stdout: Stream.empty,
+          stderr: fails
+            ? Stream.make(new TextEncoder().encode(stderr))
+            : Stream.empty,
+          all: Stream.empty,
+          getInputFd: () => Sink.drain,
+          getOutputFd: () => Stream.empty,
+          unref: Effect.succeed(Effect.void),
+        }),
+      );
+    }),
+  );
+
+describe("buildFailureHint", () => {
+  it("names the buildx plugin when docker only names the flag", () => {
+    expect(buildFailureHint("unknown flag: --load")).toContain("buildx");
+  });
+
+  it("stays silent for ordinary build failures", () => {
+    expect(
+      buildFailureHint("ERROR: failed to solve: dockerfile parse error"),
+    ).toBeUndefined();
+  });
+});
+
+/**
+ * `run` reports a non-zero exit in its success channel, so a command whose
+ * failure matters has to check it. When `build` did not, a failed
+ * `docker build` looked like a success: no image was ever created and the
+ * only symptom was workerd looping on `Container exited while waiting for
+ * port 8080`, with the actual docker error absent from the logs entirely.
+ */
+layer(
+  Layer.provide(
+    DockerLive,
+    Layer.merge(
+      NodeServices.layer,
+      makeFailingStub("build", "unknown flag: --load"),
+    ),
+  ),
+)((it) => {
+  it.effect("build fails when docker build exits non-zero", () =>
+    Effect.gen(function* () {
+      const docker = yield* Docker;
+      const result = yield* Effect.result(
+        docker.build("alchemy-test:latest", {
+          dockerfile: `${import.meta.dirname}/fixtures/Dockerfile.build-failure`,
+        }),
+      );
+      expect(result._tag).toBe("Failure");
+      if (result._tag !== "Failure") return;
+      const error = result.failure as {
+        subtag: string;
+        hint?: string;
+        detail?: { exitCode: number; stderr: string };
+      };
+      expect(error.subtag).toBe("DockerBuildFailed");
+      // The docker output the user needs is carried, not discarded.
+      expect(error.detail?.exitCode).toBe(1);
+      expect(error.detail?.stderr).toContain("unknown flag: --load");
+      expect(error.hint).toContain("buildx");
+    }),
+  );
+});
+
+layer(
+  Layer.provide(
+    DockerLive,
+    Layer.merge(
+      NodeServices.layer,
+      makeFailingStub("tag", "Error response from daemon: no such image"),
+    ),
+  ),
+)((it) => {
+  it.effect("pull fails when the follow-up docker tag exits non-zero", () =>
+    Effect.gen(function* () {
+      const docker = yield* Docker;
+      const result = yield* Effect.result(
+        docker.pull("alchemy-test:latest", { imageUri: PINNED }),
+      );
+      expect(result._tag).toBe("Failure");
+      if (result._tag !== "Failure") return;
+      const error = result.failure as {
+        subtag: string;
+        detail?: { stderr: string };
+      };
+      expect(error.subtag).toBe("DockerTagFailed");
+      expect(error.detail?.stderr).toContain("no such image");
+    }),
+  );
+});

--- a/packages/cloudflare-runtime/src/core/test/fixtures/Dockerfile.build-failure
+++ b/packages/cloudflare-runtime/src/core/test/fixtures/Dockerfile.build-failure
@@ -1,0 +1,1 @@
+FROM scratch


### PR DESCRIPTION
A failed `docker build` was reported as a successful one, so `alchemy dev` never told anyone the image build had failed.

`run` resolves with the command's exit code rather than failing on it — `inspect` relies on that to read a non-zero exit as "not present". `pull` checks the code explicitly; `build` discarded the whole result:

```diff
   ).pipe(
     Effect.withLogSpan(`docker: build ${tag}`),
-    Effect.asVoid,
     Effect.mapError((cause) => new SystemError({ subtag: "DockerBuildFailed", ... })),
+    Effect.flatMap((result) =>
+      ensureExitZero(result, ({ exitCode, stdout, stderr }) =>
+        new SystemError({ subtag: "DockerBuildFailed", hint: buildFailureHint(stderr),
+          detail: { bin, tag, exitCode, stdout, stderr } })),
+    ),
   );
```

With the build "succeeding", no image existed, the container create failed, and the only thing the user ever saw was workerd retrying:

```
Error: Container exited while waiting for port 8080
Error: Container exited while waiting for port 8080
```

Docker's actual error appeared nowhere — `grep -c "Failed to build\|DockerBuildFailed" <test log>` returned `0`, and the word `build` did not occur in the log at all.

The follow-up `docker tag` inside `pull` had the same hole.

### Buildx hint

Image builds pass `--load` and `--provenance=false`, which require the buildx plugin. Distros package it separately (Arch/CachyOS `docker` vs `docker-buildx`, Debian `docker.io` vs `docker-buildx`), and docker's stderr names only the flag:

```
unknown flag: --load
```

That stderr is now matched to a hint naming the plugin to install, so a first-run Linux setup says what is missing rather than what is syntactically wrong.
