### PR TITLE
chore(cloudflare-runtime): bump internal isolate compatibility dates

### DIFF
--- a/packages/cloudflare-runtime/package.json
+++ b/packages/cloudflare-runtime/package.json
@@ -576,6 +576,12 @@
       "worker": "./src/core/globals/Storage.ts",
       "import": "./dist/core/node/globals/Storage.mjs"
     },
+    "./core/internal/constants": {
+      "types": "./dist/core/node/internal/constants.d.mts",
+      "bun": "./src/core/internal/constants.ts",
+      "worker": "./src/core/internal/constants.ts",
+      "import": "./dist/core/node/internal/constants.mjs"
+    },
     "./core/internal/internal-worker": {
       "types": "./dist/core/node/internal/internal-worker.d.mts",
       "bun": "./src/core/internal/internal-worker.ts",

--- a/packages/cloudflare-runtime/src/core/bindings/assets/Assets.ts
+++ b/packages/cloudflare-runtime/src/core/bindings/assets/Assets.ts
@@ -32,6 +32,13 @@ import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
+import * as Plugin from "../../Plugin.ts";
+import { PluginContext, type BindingHook } from "../../PluginContext.ts";
+import { ConfigError, SystemError } from "../../RuntimeError.shared.ts";
+import type { RuntimeWorker } from "../../RuntimeWorker.ts";
+import { INTERNAL_WORKER_COMPATIBILITY_DATE } from "../../internal/constants.ts";
+import { formatInternalWorkerModules } from "../../internal/internal-modules.ts";
+
 const AssetsKvWorker = {
   worker: () =>
     loadInternalWorker(
@@ -50,11 +57,6 @@ const RouterWorker = {
       "#cloudflare-runtime-core-worker/bindings/assets/router.worker",
     ),
 };
-import * as Plugin from "../../Plugin.ts";
-import { PluginContext, type BindingHook } from "../../PluginContext.ts";
-import { ConfigError, SystemError } from "../../RuntimeError.shared.ts";
-import type { RuntimeWorker } from "../../RuntimeWorker.ts";
-import { formatInternalWorkerModules } from "../../internal/internal-modules.ts";
 
 export class Assets extends Plugin.Service<Assets, { isConfigured: boolean }>()(
   "cloudflare-runtime/plugin/Assets",
@@ -312,8 +314,8 @@ export const AssetsLive = Layer.effect(
             {
               name: "assets:worker",
               worker: {
-                compatibilityDate: "2024-07-31",
-                compatibilityFlags: ["nodejs_compat", "enable_ctx_exports"],
+                compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
+                compatibilityFlags: ["nodejs_compat"],
                 bindings: [
                   {
                     name: "ASSETS_KV_NAMESPACE",
@@ -338,12 +340,8 @@ export const AssetsLive = Layer.effect(
             {
               name: "assets:router",
               worker: {
-                compatibilityDate: "2024-07-31",
-                compatibilityFlags: [
-                  "nodejs_compat",
-                  "no_nodejs_compat_v2",
-                  "enable_ctx_exports",
-                ],
+                compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
+                compatibilityFlags: ["nodejs_compat", "no_nodejs_compat_v2"],
                 bindings: [
                   {
                     name: "ASSET_WORKER",

--- a/packages/cloudflare-runtime/src/core/bindings/browser/Browser.ts
+++ b/packages/cloudflare-runtime/src/core/bindings/browser/Browser.ts
@@ -27,6 +27,7 @@ const BrowserWorker = {
 };
 import * as Loopback from "../../globals/Loopback.ts";
 import type * as LoopbackServer from "../../globals/LoopbackServer.ts";
+import { INTERNAL_WORKER_COMPATIBILITY_DATE } from "../../internal/constants.ts";
 import { formatInternalWorkerModules } from "../../internal/internal-modules.ts";
 import * as Plugin from "../../Plugin.ts";
 import type { BindingHook, PluginContext } from "../../PluginContext.ts";
@@ -174,7 +175,7 @@ export const BrowserLive = Layer.effect(
             const browserService: WorkerdConfig.Service = {
               name: SERVICE_BROWSER,
               worker: {
-                compatibilityDate: "2025-01-01",
+                compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
                 modules: formatInternalWorkerModules(
                   yield* Effect.promise(BrowserWorker.worker),
                 ),

--- a/packages/cloudflare-runtime/src/core/bindings/browser/Browser.ts
+++ b/packages/cloudflare-runtime/src/core/bindings/browser/Browser.ts
@@ -176,6 +176,7 @@ export const BrowserLive = Layer.effect(
               name: SERVICE_BROWSER,
               worker: {
                 compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
+                compatibilityFlags: ["web_socket_manual_reply_to_close"],
                 modules: formatInternalWorkerModules(
                   yield* Effect.promise(BrowserWorker.worker),
                 ),

--- a/packages/cloudflare-runtime/src/core/bindings/browser/Browser.ts
+++ b/packages/cloudflare-runtime/src/core/bindings/browser/Browser.ts
@@ -27,7 +27,6 @@ const BrowserWorker = {
 };
 import * as Loopback from "../../globals/Loopback.ts";
 import type * as LoopbackServer from "../../globals/LoopbackServer.ts";
-import { INTERNAL_WORKER_COMPATIBILITY_DATE } from "../../internal/constants.ts";
 import { formatInternalWorkerModules } from "../../internal/internal-modules.ts";
 import * as Plugin from "../../Plugin.ts";
 import type { BindingHook, PluginContext } from "../../PluginContext.ts";
@@ -175,8 +174,8 @@ export const BrowserLive = Layer.effect(
             const browserService: WorkerdConfig.Service = {
               name: SERVICE_BROWSER,
               worker: {
-                compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
-                compatibilityFlags: ["web_socket_manual_reply_to_close"],
+                // Stay pre-2026-04-07: CDP proxy hangs with auto-reply-to-close.
+                compatibilityDate: "2025-01-01",
                 modules: formatInternalWorkerModules(
                   yield* Effect.promise(BrowserWorker.worker),
                 ),

--- a/packages/cloudflare-runtime/src/core/bindings/browser/Browser.worker.ts
+++ b/packages/cloudflare-runtime/src/core/bindings/browser/Browser.worker.ts
@@ -34,6 +34,11 @@ function isClosed(ws: WebSocket | undefined): boolean {
   return !ws || ws.readyState === WebSocket.READY_STATE_CLOSED;
 }
 
+/** Half-open so CDP proxying can forward Close frames after auto-reply-to-close (2026-04-07). */
+function acceptProxyWebSocket(ws: WebSocket) {
+  ws.accept({ allowHalfOpen: true });
+}
+
 function chromeBaseUrl(wsEndpoint: string): string {
   const u = new URL(wsEndpoint.replace("ws://", "http://"));
   return `http://${u.host}`;
@@ -260,7 +265,7 @@ export class BrowserSession implements DurableObject {
     });
     assert(resp.webSocket !== null, "Expected a WebSocket response");
     this.chromeWs = resp.webSocket;
-    this.chromeWs.accept();
+    acceptProxyWebSocket(this.chromeWs);
     // Forward Chrome messages to whatever legacyServerWs is currently
     // connected. Set up once here so reconnects don't accumulate duplicate
     // listeners.
@@ -309,7 +314,7 @@ export class BrowserSession implements DurableObject {
     const webSocketPair = new WebSocketPair();
     const [client, server] = Object.values(webSocketPair);
 
-    server.accept();
+    acceptProxyWebSocket(server);
 
     server.addEventListener("message", (m) => {
       if (m.data === "ping") {
@@ -419,11 +424,11 @@ export class BrowserSession implements DurableObject {
 
     assert(response.webSocket !== null, "Expected a WebSocket response");
     const chrome = response.webSocket;
-    chrome.accept();
+    acceptProxyWebSocket(chrome);
 
     const webSocketPair = new WebSocketPair();
     const [client, server] = Object.values(webSocketPair);
-    server.accept();
+    acceptProxyWebSocket(server);
 
     const pair = { chrome, server };
     this.wss.push(pair);

--- a/packages/cloudflare-runtime/src/core/bindings/browser/Browser.worker.ts
+++ b/packages/cloudflare-runtime/src/core/bindings/browser/Browser.worker.ts
@@ -34,11 +34,6 @@ function isClosed(ws: WebSocket | undefined): boolean {
   return !ws || ws.readyState === WebSocket.READY_STATE_CLOSED;
 }
 
-/** Half-open so CDP proxying can forward Close frames after auto-reply-to-close (2026-04-07). */
-function acceptProxyWebSocket(ws: WebSocket) {
-  ws.accept({ allowHalfOpen: true });
-}
-
 function chromeBaseUrl(wsEndpoint: string): string {
   const u = new URL(wsEndpoint.replace("ws://", "http://"));
   return `http://${u.host}`;
@@ -265,7 +260,7 @@ export class BrowserSession implements DurableObject {
     });
     assert(resp.webSocket !== null, "Expected a WebSocket response");
     this.chromeWs = resp.webSocket;
-    acceptProxyWebSocket(this.chromeWs);
+    this.chromeWs.accept();
     // Forward Chrome messages to whatever legacyServerWs is currently
     // connected. Set up once here so reconnects don't accumulate duplicate
     // listeners.
@@ -314,7 +309,7 @@ export class BrowserSession implements DurableObject {
     const webSocketPair = new WebSocketPair();
     const [client, server] = Object.values(webSocketPair);
 
-    acceptProxyWebSocket(server);
+    server.accept();
 
     server.addEventListener("message", (m) => {
       if (m.data === "ping") {
@@ -424,11 +419,11 @@ export class BrowserSession implements DurableObject {
 
     assert(response.webSocket !== null, "Expected a WebSocket response");
     const chrome = response.webSocket;
-    acceptProxyWebSocket(chrome);
+    chrome.accept();
 
     const webSocketPair = new WebSocketPair();
     const [client, server] = Object.values(webSocketPair);
-    acceptProxyWebSocket(server);
+    server.accept();
 
     const pair = { chrome, server };
     this.wss.push(pair);

--- a/packages/cloudflare-runtime/src/core/bindings/cache/Cache.ts
+++ b/packages/cloudflare-runtime/src/core/bindings/cache/Cache.ts
@@ -10,6 +10,7 @@ const CacheWorker = {
     ),
 };
 import * as Storage from "../../globals/Storage.ts";
+import { INTERNAL_WORKER_COMPATIBILITY_DATE } from "../../internal/constants.ts";
 import { formatInternalWorkerModules } from "../../internal/internal-modules.ts";
 import * as Plugin from "../../Plugin.ts";
 import * as PluginContext from "../../PluginContext.ts";
@@ -89,7 +90,7 @@ export const CacheLive = Layer.effect(
             const cacheService: WorkerdConfig.Service = {
               name: SERVICE_CACHE,
               worker: {
-                compatibilityDate: "2025-01-01",
+                compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
                 modules: formatInternalWorkerModules(
                   yield* Effect.promise(CacheWorker.worker),
                 ),

--- a/packages/cloudflare-runtime/src/core/bindings/d1/D1.ts
+++ b/packages/cloudflare-runtime/src/core/bindings/d1/D1.ts
@@ -8,6 +8,7 @@ const D1Worker = {
     loadInternalWorker("#cloudflare-runtime-core-worker/bindings/d1/D1.worker"),
 };
 import * as Storage from "../../globals/Storage.ts";
+import { INTERNAL_WORKER_COMPATIBILITY_DATE } from "../../internal/constants.ts";
 import { formatInternalWorkerModules } from "../../internal/internal-modules.ts";
 import * as Plugin from "../../Plugin.ts";
 import type { BindingHook } from "../../PluginContext.ts";
@@ -95,7 +96,7 @@ export const D1Live = Layer.effect(
             const d1Service: WorkerdConfig.Service = {
               name: SERVICE_D1,
               worker: {
-                compatibilityDate: "2025-01-01",
+                compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
                 modules: formatInternalWorkerModules(
                   yield* Effect.promise(D1Worker.worker),
                 ),

--- a/packages/cloudflare-runtime/src/core/bindings/images/Images.ts
+++ b/packages/cloudflare-runtime/src/core/bindings/images/Images.ts
@@ -22,7 +22,10 @@ const ImagesStoreWorker = {
 import * as Loopback from "../../globals/Loopback.ts";
 import type * as LoopbackServer from "../../globals/LoopbackServer.ts";
 import * as Storage from "../../globals/Storage.ts";
-import { SOCKET_USER_ENTRY } from "../../internal/constants.ts";
+import {
+  INTERNAL_WORKER_COMPATIBILITY_DATE,
+  SOCKET_USER_ENTRY,
+} from "../../internal/constants.ts";
 import { formatInternalWorkerModules } from "../../internal/internal-modules.ts";
 import * as Plugin from "../../Plugin.ts";
 import { PluginContext, type BindingHook } from "../../PluginContext.ts";
@@ -167,7 +170,7 @@ export const ImagesLive = Layer.effect(
             const storeService: WorkerdConfig.Service = {
               name: SERVICE_IMAGES_STORE,
               worker: {
-                compatibilityDate: "2025-01-01",
+                compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
                 modules: formatInternalWorkerModules(
                   yield* Effect.promise(ImagesStoreWorker.worker),
                 ),
@@ -203,7 +206,7 @@ export const ImagesLive = Layer.effect(
             const imagesService: WorkerdConfig.Service = {
               name: SERVICE_IMAGES,
               worker: {
-                compatibilityDate: "2025-04-01",
+                compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
                 modules: formatInternalWorkerModules(
                   yield* Effect.promise(ImagesWorker.worker),
                 ),
@@ -226,7 +229,7 @@ export const ImagesLive = Layer.effect(
             const deliveryMiddleware: Plugin.Middleware = {
               name: "images:delivery",
               worker: {
-                compatibilityDate: "2025-01-01",
+                compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
                 modules: [
                   {
                     name: "images/delivery.worker.js",

--- a/packages/cloudflare-runtime/src/core/bindings/kv-namespace/KvNamespace.ts
+++ b/packages/cloudflare-runtime/src/core/bindings/kv-namespace/KvNamespace.ts
@@ -10,6 +10,7 @@ const KvNamespaceWorker = {
     ),
 };
 import * as Storage from "../../globals/Storage.ts";
+import { INTERNAL_WORKER_COMPATIBILITY_DATE } from "../../internal/constants.ts";
 import { formatInternalWorkerModules } from "../../internal/internal-modules.ts";
 import * as Plugin from "../../Plugin.ts";
 import type { BindingHook } from "../../PluginContext.ts";
@@ -103,7 +104,7 @@ export const KvNamespaceLive = Layer.effect(
             const kvService: WorkerdConfig.Service = {
               name: SERVICE_KV,
               worker: {
-                compatibilityDate: "2025-01-01",
+                compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
                 modules: formatInternalWorkerModules(
                   yield* Effect.promise(KvNamespaceWorker.worker),
                 ),

--- a/packages/cloudflare-runtime/src/core/bindings/queue/Queue.ts
+++ b/packages/cloudflare-runtime/src/core/bindings/queue/Queue.ts
@@ -15,7 +15,10 @@ const QueueShimForwardWorker = {
       "#cloudflare-runtime-core-worker/bindings/queue/QueueShimForward.worker",
     ),
 };
-import { SERVICE_USER_WORKER } from "../../internal/constants.ts";
+import {
+  INTERNAL_WORKER_COMPATIBILITY_DATE,
+  SERVICE_USER_WORKER,
+} from "../../internal/constants.ts";
 import { formatInternalWorkerModules } from "../../internal/internal-modules.ts";
 import * as Plugin from "../../Plugin.ts";
 import * as PluginContext from "../../PluginContext.ts";
@@ -34,8 +37,6 @@ import {
   BINDING_QUEUE_PRODUCERS,
   BINDING_QUEUE_USER_WORKER,
 } from "./QueueOptions.shared.ts";
-
-const BROKER_COMPATIBILITY_DATE = "2024-10-22";
 
 export class Queue extends Plugin.Service<
   Queue,
@@ -161,7 +162,7 @@ export const QueueLive = Layer.effect(
           return {
             name: queueServiceName(consumer.queueName),
             worker: {
-              compatibilityDate: BROKER_COMPATIBILITY_DATE,
+              compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
               compatibilityFlags: [
                 "experimental",
                 "service_binding_extra_handlers",
@@ -224,7 +225,7 @@ export const QueueLive = Layer.effect(
           return {
             name: remoteShimServiceName(props.binding),
             worker: {
-              compatibilityDate: BROKER_COMPATIBILITY_DATE,
+              compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
               modules: formatInternalWorkerModules(
                 yield* Effect.promise(QueueShimForwardWorker.worker),
               ),

--- a/packages/cloudflare-runtime/src/core/bindings/r2-bucket/R2Bucket.ts
+++ b/packages/cloudflare-runtime/src/core/bindings/r2-bucket/R2Bucket.ts
@@ -10,6 +10,7 @@ const R2BucketWorker = {
     ),
 };
 import * as Storage from "../../globals/Storage.ts";
+import { INTERNAL_WORKER_COMPATIBILITY_DATE } from "../../internal/constants.ts";
 import { formatInternalWorkerModules } from "../../internal/internal-modules.ts";
 import * as Plugin from "../../Plugin.ts";
 import type { BindingHook } from "../../PluginContext.ts";
@@ -103,7 +104,7 @@ export const R2BucketLive = Layer.effect(
             const r2Service: WorkerdConfig.Service = {
               name: SERVICE_R2,
               worker: {
-                compatibilityDate: "2025-01-01",
+                compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
                 // `node:crypto` is used to synchronously compute multipart etags
                 compatibilityFlags: ["nodejs_compat"],
                 modules: formatInternalWorkerModules(

--- a/packages/cloudflare-runtime/src/core/bindings/secrets-store/SecretsStore.ts
+++ b/packages/cloudflare-runtime/src/core/bindings/secrets-store/SecretsStore.ts
@@ -16,6 +16,7 @@ const SecretsStoreSecretWorker = {
     ),
 };
 import * as Storage from "../../globals/Storage.ts";
+import { INTERNAL_WORKER_COMPATIBILITY_DATE } from "../../internal/constants.ts";
 import { formatInternalWorkerModules } from "../../internal/internal-modules.ts";
 import * as Plugin from "../../Plugin.ts";
 import type { BindingHook } from "../../PluginContext.ts";
@@ -134,7 +135,7 @@ export const SecretsStoreLive = Layer.effect(
             const storeService: WorkerdConfig.Service = {
               name: SERVICE_SECRETS_STORE,
               worker: {
-                compatibilityDate: "2025-01-01",
+                compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
                 modules: formatInternalWorkerModules(
                   yield* Effect.promise(SecretsStoreStoreWorker.worker),
                 ),
@@ -174,7 +175,7 @@ export const SecretsStoreLive = Layer.effect(
             const secretService: WorkerdConfig.Service = {
               name: SERVICE_SECRETS_STORE_SECRET,
               worker: {
-                compatibilityDate: "2025-01-01",
+                compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
                 modules: formatInternalWorkerModules(
                   yield* Effect.promise(SecretsStoreSecretWorker.worker),
                 ),

--- a/packages/cloudflare-runtime/src/core/bindings/send-email/SendEmail.ts
+++ b/packages/cloudflare-runtime/src/core/bindings/send-email/SendEmail.ts
@@ -16,6 +16,7 @@ const SendEmailBindingWorker = {
     ),
 };
 import * as Storage from "../../globals/Storage.ts";
+import { INTERNAL_WORKER_COMPATIBILITY_DATE } from "../../internal/constants.ts";
 import {
   formatExtensionModule,
   formatInternalWorkerModules,
@@ -134,7 +135,7 @@ export const SendEmailLive = Layer.effect(
             const sendEmailService: WorkerdConfig.Service = {
               name: SERVICE_SEND_EMAIL,
               worker: {
-                compatibilityDate: "2025-03-17",
+                compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
                 modules: formatInternalWorkerModules(
                   yield* Effect.promise(SendEmailBindingWorker.worker),
                 ),

--- a/packages/cloudflare-runtime/src/core/bindings/stream/Stream.ts
+++ b/packages/cloudflare-runtime/src/core/bindings/stream/Stream.ts
@@ -12,7 +12,10 @@ const StreamWorker = {
 import * as Loopback from "../../globals/Loopback.ts";
 import type * as LoopbackServer from "../../globals/LoopbackServer.ts";
 import * as Storage from "../../globals/Storage.ts";
-import { SOCKET_USER_ENTRY } from "../../internal/constants.ts";
+import {
+  INTERNAL_WORKER_COMPATIBILITY_DATE,
+  SOCKET_USER_ENTRY,
+} from "../../internal/constants.ts";
 import { formatInternalWorkerModules } from "../../internal/internal-modules.ts";
 import * as Plugin from "../../Plugin.ts";
 import type { BindingHook, PluginContext } from "../../PluginContext.ts";
@@ -174,7 +177,7 @@ export const StreamLive = Layer.effect(
             const streamService: WorkerdConfig.Service = {
               name: SERVICE_STREAM,
               worker: {
-                compatibilityDate: "2026-03-23",
+                compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
                 modules: formatInternalWorkerModules(
                   yield* Effect.promise(StreamWorker.worker),
                 ),
@@ -219,7 +222,7 @@ export const StreamLive = Layer.effect(
                 {
                   name: "stream:router",
                   worker: {
-                    compatibilityDate: "2026-03-23",
+                    compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
                     modules: [
                       {
                         name: "stream/router.worker.js",

--- a/packages/cloudflare-runtime/src/core/bindings/workflows/Workflows.ts
+++ b/packages/cloudflare-runtime/src/core/bindings/workflows/Workflows.ts
@@ -16,7 +16,10 @@ const WorkflowsWrappedBindingWorker = {
     ),
 };
 import * as Storage from "../../globals/Storage.ts";
-import { SERVICE_USER_WORKER } from "../../internal/constants.ts";
+import {
+  INTERNAL_WORKER_COMPATIBILITY_DATE,
+  SERVICE_USER_WORKER,
+} from "../../internal/constants.ts";
 import {
   formatExtensionModule,
   formatInternalWorkerModules,
@@ -141,7 +144,7 @@ const makeEngineService = ({
 }): WorkerdConfig.Service => ({
   name: `workflows:${workflow.workflowName}`,
   worker: {
-    compatibilityDate: "2024-10-22",
+    compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
     compatibilityFlags: ["experimental", ...(compatibilityFlags ?? [])],
     modules,
     durableObjectNamespaces: [

--- a/packages/cloudflare-runtime/src/core/globals/Globals.ts
+++ b/packages/cloudflare-runtime/src/core/globals/Globals.ts
@@ -12,6 +12,7 @@ const EntryWorker = {
     loadInternalWorker("#cloudflare-runtime-core-worker/globals/entry.worker"),
 };
 import {
+  INTERNAL_WORKER_COMPATIBILITY_DATE,
   SERVICE_USER_WORKER,
   SOCKET_USER_ENTRY,
 } from "../internal/constants.ts";
@@ -155,7 +156,7 @@ export const GlobalsLive = Layer.effect(
             {
               name: "plugin:entry",
               worker: {
-                compatibilityDate: "2026-03-10",
+                compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
                 compatibilityFlags: [
                   "experimental",
                   "enable_request_signal",

--- a/packages/cloudflare-runtime/src/core/globals/Loopback.ts
+++ b/packages/cloudflare-runtime/src/core/globals/Loopback.ts
@@ -1,5 +1,6 @@
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import { INTERNAL_WORKER_COMPATIBILITY_DATE } from "../internal/constants.ts";
 import * as Plugin from "../Plugin.ts";
 import type * as WorkerdConfig from "../workerd/Config.ts";
 import { HEADER_CF_BLOB } from "./CfOptions.shared.ts";
@@ -34,7 +35,7 @@ export const LoopbackLive = Layer.effect(
         {
           name: "loopback:fetcher",
           worker: {
-            compatibilityDate: "2025-01-01",
+            compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
             modules: [
               {
                 name: "loopback/fetcher.worker.js",

--- a/packages/cloudflare-runtime/src/core/internal/constants.ts
+++ b/packages/cloudflare-runtime/src/core/internal/constants.ts
@@ -1,8 +1,8 @@
 export const SOCKET_USER_ENTRY = "user-entry";
 export const SERVICE_USER_WORKER = "user-worker";
 
-/** Newest date supported by catalog workerd 1.20260704.1. Used by internal isolates. */
-export const INTERNAL_WORKER_COMPATIBILITY_DATE = "2026-07-04";
+/** Newest date supported by catalog workerd 1.20260831.1. Used by internal isolates. */
+export const INTERNAL_WORKER_COMPATIBILITY_DATE = "2026-08-31";
 
 export const defaultDurableObjectUniqueKey = (
   scriptName: string,

--- a/packages/cloudflare-runtime/src/core/internal/constants.ts
+++ b/packages/cloudflare-runtime/src/core/internal/constants.ts
@@ -1,6 +1,9 @@
 export const SOCKET_USER_ENTRY = "user-entry";
 export const SERVICE_USER_WORKER = "user-worker";
 
+/** Newest date supported by catalog workerd 1.20260704.1. Used by internal isolates. */
+export const INTERNAL_WORKER_COMPATIBILITY_DATE = "2026-07-04";
+
 export const defaultDurableObjectUniqueKey = (
   scriptName: string,
   className: string,

--- a/packages/cloudflare-runtime/src/core/platform-proxy/PlatformProxy.ts
+++ b/packages/cloudflare-runtime/src/core/platform-proxy/PlatformProxy.ts
@@ -1,3 +1,4 @@
+import { INTERNAL_WORKER_COMPATIBILITY_DATE } from "../internal/constants.ts";
 import { loadInternalWorker } from "../internal/internal-worker.ts";
 /**
  * Node-side platform proxy: our reimplementation of wrangler's
@@ -78,7 +79,7 @@ export type {
   PlatformProxyCacheStorage,
 } from "./connect.ts";
 
-const DEFAULT_COMPATIBILITY_DATE = "2026-03-10";
+const DEFAULT_COMPATIBILITY_DATE = INTERNAL_WORKER_COMPATIBILITY_DATE;
 
 // ---------------------------------------------------------------------------
 // Public types

--- a/packages/cloudflare-runtime/src/core/proxy/WorkerProxy.ts
+++ b/packages/cloudflare-runtime/src/core/proxy/WorkerProxy.ts
@@ -11,6 +11,7 @@ const ProxyWorker = {
     ),
 };
 import * as Internet from "../globals/Internet.ts";
+import { INTERNAL_WORKER_COMPATIBILITY_DATE } from "../internal/constants.ts";
 import { formatInternalWorkerModules } from "../internal/internal-modules.ts";
 import * as Port from "../internal/Port.ts";
 import type { RuntimeError } from "../RuntimeError.shared.ts";
@@ -140,7 +141,7 @@ export const WorkerProxyLive = Layer.effect(
             {
               name: "proxy:worker",
               worker: {
-                compatibilityDate: "2026-03-10",
+                compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
                 modules,
                 bindings: [
                   {

--- a/packages/cloudflare-runtime/src/core/registry/RegistryProxy.ts
+++ b/packages/cloudflare-runtime/src/core/registry/RegistryProxy.ts
@@ -13,6 +13,7 @@ const RegistryProxyWorker = {
 };
 import {
   defaultDurableObjectUniqueKey,
+  INTERNAL_WORKER_COMPATIBILITY_DATE,
   SERVICE_USER_WORKER,
 } from "../internal/constants.ts";
 import { formatInternalWorkerModules } from "../internal/internal-modules.ts";
@@ -87,7 +88,7 @@ export const RegistryProxyLive = Layer.effect(
             const service: WorkerdConfig.Service = {
               name: SERVICE_REGISTRY_PROXY,
               worker: {
-                compatibilityDate: "2025-01-01",
+                compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
                 compatibilityFlags: ["service_binding_extra_handlers"],
                 modules: yield* registry
                   .read(subscribed)

--- a/packages/cloudflare-runtime/src/core/remote-bindings/RemoteBindings.ts
+++ b/packages/cloudflare-runtime/src/core/remote-bindings/RemoteBindings.ts
@@ -19,6 +19,7 @@ const OutboundWorker = {
     ),
 };
 import * as Loopback from "../globals/Loopback.ts";
+import { INTERNAL_WORKER_COMPATIBILITY_DATE } from "../internal/constants.ts";
 import { formatInternalWorkerModules } from "../internal/internal-modules.ts";
 import * as Plugin from "../Plugin.ts";
 import * as PluginContext from "../PluginContext.ts";
@@ -100,7 +101,7 @@ export const RemoteBindingsLive = Layer.effect(
       const outbound = {
         name: "remote-bindings:outbound",
         worker: {
-          compatibilityDate: "2026-03-10",
+          compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
           modules: outboundWorker,
           bindings: [
             {
@@ -129,7 +130,7 @@ export const RemoteBindingsLive = Layer.effect(
       const client = {
         name: "remote-bindings:client",
         worker: {
-          compatibilityDate: "2026-03-10",
+          compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
           modules: clientWorker,
           globalOutbound: { name: outbound.name },
         },

--- a/packages/cloudflare-runtime/src/core/remote-bindings/RemoteWorker.ts
+++ b/packages/cloudflare-runtime/src/core/remote-bindings/RemoteWorker.ts
@@ -14,6 +14,7 @@ const RemoteWorkerScript = {
       "#cloudflare-runtime-core-worker/remote-bindings/workers/remote.worker",
     ),
 };
+import { INTERNAL_WORKER_COMPATIBILITY_DATE } from "../internal/constants.ts";
 import type { ConfigError, SystemError } from "../RuntimeError.shared.ts";
 import { ApiError } from "../RuntimeError.shared.ts";
 import * as Access from "./Access.ts";
@@ -134,7 +135,7 @@ export const make: (
         cfPreviewUploadConfigToken,
         wranglerSessionConfig: { workersDev: true, minimalMode: true },
         metadata: {
-          compatibilityDate: "2025-04-28",
+          compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
           bindings: options.bindings,
           mainModule: files[0].name,
         },

--- a/packages/cloudflare-runtime/src/internal/workers-shared/workers/asset-worker/wrangler.jsonc
+++ b/packages/cloudflare-runtime/src/internal/workers-shared/workers/asset-worker/wrangler.jsonc
@@ -14,10 +14,10 @@
   "account_id": "0f1b8aa119a907021f659042f95ea9ba",
   "workers_dev": false,
   "main": "src/worker.ts",
-  "compatibility_date": "2024-07-31",
+  "compatibility_date": "2026-07-04",
   // nodejs_compat required when using @cloudflare/vitest-pool-workers
-  // enable_ctx_exports enables ctx.exports loopback for the AssetWorkerInner
-  "compatibility_flags": ["nodejs_compat", "enable_ctx_exports"],
+  // ctx.exports is default-on as of 2025-11-17
+  "compatibility_flags": ["nodejs_compat"],
   "unsafe": {
     "metadata": {
       "build_options": {
@@ -65,11 +65,7 @@
       "name": "asset-worker-staging",
       // enable_version_api is set per-environment (not top-level) because
       // the local workerd in vitest-pool-workers does not support it yet.
-      "compatibility_flags": [
-        "nodejs_compat",
-        "enable_ctx_exports",
-        "enable_version_api",
-      ],
+      "compatibility_flags": ["nodejs_compat", "enable_version_api"],
       "unsafe": {
         "metadata": {
           "build_options": {
@@ -116,11 +112,7 @@
     "fed-prod": {
       "name": "asset-worker-fed-prod",
       "account_id": "fca6c231dc1d1780777997c5bce5a5e3", // workers assets
-      "compatibility_flags": [
-        "nodejs_compat",
-        "enable_ctx_exports",
-        "enable_version_api",
-      ],
+      "compatibility_flags": ["nodejs_compat", "enable_version_api"],
       "vars": {
         "ENVIRONMENT": "fed-prod",
       },

--- a/packages/cloudflare-runtime/src/internal/workers-shared/workers/asset-worker/wrangler.jsonc
+++ b/packages/cloudflare-runtime/src/internal/workers-shared/workers/asset-worker/wrangler.jsonc
@@ -14,7 +14,7 @@
   "account_id": "0f1b8aa119a907021f659042f95ea9ba",
   "workers_dev": false,
   "main": "src/worker.ts",
-  "compatibility_date": "2026-07-04",
+  "compatibility_date": "2026-08-31",
   // nodejs_compat required when using @cloudflare/vitest-pool-workers
   // ctx.exports is default-on as of 2025-11-17
   "compatibility_flags": ["nodejs_compat"],

--- a/packages/cloudflare-runtime/src/internal/workers-shared/workers/router-worker/wrangler.jsonc
+++ b/packages/cloudflare-runtime/src/internal/workers-shared/workers/router-worker/wrangler.jsonc
@@ -14,7 +14,7 @@
   "account_id": "0f1b8aa119a907021f659042f95ea9ba",
   "workers_dev": false,
   "main": "src/worker.ts",
-  "compatibility_date": "2026-07-04",
+  "compatibility_date": "2026-08-31",
   // nodejs_compat required when using @cloudflare/vitest-pool-workers
   "compatibility_flags": ["nodejs_compat", "no_nodejs_compat_v2"],
   "version_metadata": {

--- a/packages/cloudflare-runtime/src/internal/workers-shared/workers/router-worker/wrangler.jsonc
+++ b/packages/cloudflare-runtime/src/internal/workers-shared/workers/router-worker/wrangler.jsonc
@@ -14,13 +14,9 @@
   "account_id": "0f1b8aa119a907021f659042f95ea9ba",
   "workers_dev": false,
   "main": "src/worker.ts",
-  "compatibility_date": "2024-07-31",
+  "compatibility_date": "2026-07-04",
   // nodejs_compat required when using @cloudflare/vitest-pool-workers
-  "compatibility_flags": [
-    "nodejs_compat",
-    "no_nodejs_compat_v2",
-    "enable_ctx_exports",
-  ],
+  "compatibility_flags": ["nodejs_compat", "no_nodejs_compat_v2"],
   "version_metadata": {
     "binding": "VERSION_METADATA",
   },

--- a/packages/cloudflare-runtime/src/internal/workflows-shared/wrangler.jsonc
+++ b/packages/cloudflare-runtime/src/internal/workflows-shared/wrangler.jsonc
@@ -3,7 +3,7 @@
 {
   "name": "workflows-shared-test",
   "main": "test/test-entry.ts",
-  "compatibility_date": "2026-07-04",
+  "compatibility_date": "2026-08-31",
   "durable_objects": {
     "bindings": [{ "name": "ENGINE", "class_name": "Engine" }],
   },

--- a/packages/cloudflare-runtime/src/internal/workflows-shared/wrangler.jsonc
+++ b/packages/cloudflare-runtime/src/internal/workflows-shared/wrangler.jsonc
@@ -3,8 +3,7 @@
 {
   "name": "workflows-shared-test",
   "main": "test/test-entry.ts",
-  "compatibility_date": "2025-02-04",
-  "compatibility_flags": ["enable_ctx_exports"],
+  "compatibility_date": "2026-07-04",
   "durable_objects": {
     "bindings": [{ "name": "ENGINE", "class_name": "Engine" }],
   },

--- a/packages/cloudflare-runtime/src/vite/assets/ViteAssets.ts
+++ b/packages/cloudflare-runtime/src/vite/assets/ViteAssets.ts
@@ -2,6 +2,7 @@
 // This file includes third-party code; see /THIRD_PARTY_LICENSES.md.
 import { loadInternalWorker } from "../../core/internal/internal-worker.ts";
 import * as Assets from "../../core/bindings/assets/Assets.ts";
+import { INTERNAL_WORKER_COMPATIBILITY_DATE } from "../../core/internal/constants.ts";
 import * as Loopback from "../../core/globals/Loopback.ts";
 import { PluginContext } from "../../core/PluginContext.ts";
 import * as Effect from "effect/Effect";
@@ -76,8 +77,8 @@ export const ViteAssetsLive = (viteDevServer: vite.ViteDevServer) =>
               {
                 name: "assets:worker",
                 worker: {
-                  compatibilityDate: "2024-07-31",
-                  compatibilityFlags: ["nodejs_compat", "enable_ctx_exports"],
+                  compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
+                  compatibilityFlags: ["nodejs_compat"],
                   bindings: [
                     {
                       name: "CONFIG",
@@ -106,12 +107,8 @@ export const ViteAssetsLive = (viteDevServer: vite.ViteDevServer) =>
               {
                 name: "assets:router",
                 worker: {
-                  compatibilityDate: "2024-07-31",
-                  compatibilityFlags: [
-                    "nodejs_compat",
-                    "no_nodejs_compat_v2",
-                    "enable_ctx_exports",
-                  ],
+                  compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
+                  compatibilityFlags: ["nodejs_compat", "no_nodejs_compat_v2"],
                   bindings: [
                     {
                       name: "ASSET_WORKER",

--- a/packages/cloudflare-runtime/src/vite/dev-server.ts
+++ b/packages/cloudflare-runtime/src/vite/dev-server.ts
@@ -1,3 +1,4 @@
+import { INTERNAL_WORKER_COMPATIBILITY_DATE } from "../core/internal/constants.ts";
 import { loadInternalWorker } from "../core/internal/internal-worker.ts";
 import type { ExportTypes } from "../rolldown/export-types.ts";
 import { EXPORT_TYPES_MODULE_ID } from "../rolldown/export-types.ts";
@@ -202,7 +203,8 @@ const serve = Effect.fn(function* <B extends BindingHooks = BindingHooks>(
   return yield* runtime.start({
     name,
     modules: yield* Effect.promise(() => makeWorkerModules(exportTypes)),
-    compatibilityDate: options.compatibilityDate ?? "2026-05-12",
+    compatibilityDate:
+      options.compatibilityDate ?? INTERNAL_WORKER_COMPATIBILITY_DATE,
     compatibilityFlags: options.compatibilityFlags ?? [],
     bindings: [
       UnsafeEval.local("__DISTILLED_UNSAFE_EVAL__"),

--- a/packages/cloudflare-runtime/src/vite/preview-server.ts
+++ b/packages/cloudflare-runtime/src/vite/preview-server.ts
@@ -1,3 +1,4 @@
+import { INTERNAL_WORKER_COMPATIBILITY_DATE } from "../core/internal/constants.ts";
 import type { BindingHooks, Module } from "../core/index.ts";
 import * as Runtime from "../core/Runtime.ts";
 import * as RuntimeServices from "../core/RuntimeServices.ts";
@@ -158,7 +159,8 @@ const serve = Effect.fn(function* (
   return yield* runtime.start({
     name: options.worker?.name ?? `vite-preview-${crypto.randomUUID()}`,
     modules,
-    compatibilityDate: options.compatibilityDate ?? "2026-05-12",
+    compatibilityDate:
+      options.compatibilityDate ?? INTERNAL_WORKER_COMPATIBILITY_DATE,
     compatibilityFlags: options.compatibilityFlags ?? [],
     bindings: options.worker?.bindings ?? [],
     durableObjectNamespaces: options.worker?.durableObjectNamespaces,

--- a/packages/cloudflare-runtime/tsdown.config.ts
+++ b/packages/cloudflare-runtime/tsdown.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, type UserConfig } from "tsdown";
+import { INTERNAL_WORKER_COMPATIBILITY_DATE } from "./src/core/internal/constants.ts";
 import {
   InternalWorkerExportPlugin,
   RuntimeSubpathExportPlugin,
@@ -31,7 +32,7 @@ const workerConfig = (
   // depth limit, so bridge through `unknown`.
   plugins: [
     cloudflare({
-      compatibilityDate: "2026-07-04",
+      compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
       compatibilityFlags: options.compatibilityFlags,
     }),
     InternalWorkerExportPlugin(),
@@ -123,7 +124,7 @@ export default defineConfig([
       mangle: false,
     },
     plugins: [
-      cloudflare({ compatibilityDate: "2026-07-04" }),
+      cloudflare({ compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE }),
       InternalWorkerExportPlugin(),
     ],
     deps: {

--- a/packages/cloudflare-runtime/tsdown.config.ts
+++ b/packages/cloudflare-runtime/tsdown.config.ts
@@ -31,7 +31,7 @@ const workerConfig = (
   // depth limit, so bridge through `unknown`.
   plugins: [
     cloudflare({
-      compatibilityDate: "2026-03-10",
+      compatibilityDate: "2026-07-04",
       compatibilityFlags: options.compatibilityFlags,
     }),
     InternalWorkerExportPlugin(),
@@ -123,7 +123,7 @@ export default defineConfig([
       mangle: false,
     },
     plugins: [
-      cloudflare({ compatibilityDate: "2026-03-10" }),
+      cloudflare({ compatibilityDate: "2026-07-04" }),
       InternalWorkerExportPlugin(),
     ],
     deps: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,8 +131,8 @@ catalogs:
       specifier: ^7.0.0 || ^8.0.0
       version: 8.2.1
     workerd:
-      specifier: 1.20260704.1
-      version: 1.20260704.1
+      specifier: 1.20260831.1
+      version: 1.20260831.1
     ws:
       specifier: ^8.21.0
       version: 8.21.3
@@ -2591,7 +2591,7 @@ importers:
         version: link:../../packages/frontend-frameworks
       '@cloudflare/unenv-preset':
         specifier: catalog:cloudflare-runtime
-        version: 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260722.1)
+        version: 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260831.1)
       '@types/node':
         specifier: ^24.12.0
         version: 24.13.3
@@ -5177,7 +5177,7 @@ importers:
         version: link:../../packages/frontend-frameworks
       '@cloudflare/unenv-preset':
         specifier: catalog:cloudflare-runtime
-        version: 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260722.1)
+        version: 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260831.1)
       '@cloudflare/workers-types':
         specifier: 5.20260812.1
         version: 5.20260812.1
@@ -5700,7 +5700,7 @@ importers:
         version: link:../node-utils
       '@cloudflare/unenv-preset':
         specifier: catalog:cloudflare-runtime
-        version: 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260704.1)
+        version: 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260831.1)
       '@distilled.cloud/cloudflare':
         specifier: workspace:*
         version: link:../../distilled/packages/cloudflare
@@ -5724,7 +5724,7 @@ importers:
         version: 2.0.0-rc.24
       workerd:
         specifier: catalog:cloudflare-runtime
-        version: 1.20260704.1
+        version: 1.20260831.1
       yauzl:
         specifier: catalog:cloudflare-runtime
         version: 3.4.0
@@ -6905,14 +6905,14 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-64@1.20260704.1':
-    resolution: {integrity: sha512-XO+vvdhhTNZSsIWCkZ+JaE/JrFUmQAB0H0y/sVkAf32xa2TYBRvFUMwjSqf6WxtlxcKPQvmbLfpO/UQ0l/q4eQ==}
+  '@cloudflare/workerd-darwin-64@1.20260722.1':
+    resolution: {integrity: sha512-vZOP8vIS3NwnuaO+gz0FZ7kIGeiO3bZmxV35Ph9zOXKSREhDFlH7wQ7mkCdhW3O4jnXsew+XT7b+DNEI2CcJGQ==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-64@1.20260722.1':
-    resolution: {integrity: sha512-vZOP8vIS3NwnuaO+gz0FZ7kIGeiO3bZmxV35Ph9zOXKSREhDFlH7wQ7mkCdhW3O4jnXsew+XT7b+DNEI2CcJGQ==}
+  '@cloudflare/workerd-darwin-64@1.20260831.1':
+    resolution: {integrity: sha512-oyZ8xhu+gYTvoxV/sn6NRmTHK95RhEO1Dk54/6oPb0Uu70w7ZeRoCjkJ5aNmfS8Vrkdu6+oL0HNg6EcC61uQ2Q==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
@@ -6923,14 +6923,14 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-arm64@1.20260704.1':
-    resolution: {integrity: sha512-6iI7nbOOO8PzEQ6UZVBZB/hv95m8jl0yvyjMuWrF5cJbiLb5zPw3KnpqvGi+aeOs2ZmUkc81i1FWKfXwLXzPRA==}
+  '@cloudflare/workerd-darwin-arm64@1.20260722.1':
+    resolution: {integrity: sha512-EmIQymihDq6WNdER4+LF8Qn80yqayBUpJ+tkOO7wmY8pmgfyXjIUFNXotl21AHovTeu2seR7HdVUgeN/BilCWw==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-arm64@1.20260722.1':
-    resolution: {integrity: sha512-EmIQymihDq6WNdER4+LF8Qn80yqayBUpJ+tkOO7wmY8pmgfyXjIUFNXotl21AHovTeu2seR7HdVUgeN/BilCWw==}
+  '@cloudflare/workerd-darwin-arm64@1.20260831.1':
+    resolution: {integrity: sha512-s6Go53KPnoXZ1sTGBZ3en3otfHDuMPJhiwXMYWU21JkJQkpoeRt6HFUwM0GPhK3YhXWm+8baGMvCGZYS/KA9eA==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
@@ -6941,14 +6941,14 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-64@1.20260704.1':
-    resolution: {integrity: sha512-3mT0YHtxT7eLjghu3hKSJDUQoz+AYv8FM43nLPYhM0YiHOxr8OlmvnCb2Lp7v/U3bwd3Gnx7WEqjSppR583mGg==}
+  '@cloudflare/workerd-linux-64@1.20260722.1':
+    resolution: {integrity: sha512-jvZ3k9fxcnEn04s80CgIYxQfpOyAiz/8qC42DP8EBa9tR27qWyg9wmm31zIobVlrgBZn/+8NfdP73avRGcQOjQ==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-64@1.20260722.1':
-    resolution: {integrity: sha512-jvZ3k9fxcnEn04s80CgIYxQfpOyAiz/8qC42DP8EBa9tR27qWyg9wmm31zIobVlrgBZn/+8NfdP73avRGcQOjQ==}
+  '@cloudflare/workerd-linux-64@1.20260831.1':
+    resolution: {integrity: sha512-WxNKBgjKgeYTolW3yl1Lt3Lu67UlxdeyzWYi9MIqrKBdyQcz+UNG36RevSBf8rv1sTWapRW234VX2keZ+wXapA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
@@ -6959,14 +6959,14 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-arm64@1.20260704.1':
-    resolution: {integrity: sha512-Opo7cPTPg4x0WwK+eZSDszCyFLKQkOGNCWxF005HRTJ5SJH8h0K9KyrC1k4LBwx3haXSVi+E1eGqo1gZ1Hmhkg==}
+  '@cloudflare/workerd-linux-arm64@1.20260722.1':
+    resolution: {integrity: sha512-BOSB55SMNdy+DA5uj2WirgiNanpHGis5PVvXH1wSfvjRKr4JGgWK+EZzxz0RFUo6QjjQQC/NimEzNZ7va7jmKg==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-arm64@1.20260722.1':
-    resolution: {integrity: sha512-BOSB55SMNdy+DA5uj2WirgiNanpHGis5PVvXH1wSfvjRKr4JGgWK+EZzxz0RFUo6QjjQQC/NimEzNZ7va7jmKg==}
+  '@cloudflare/workerd-linux-arm64@1.20260831.1':
+    resolution: {integrity: sha512-JTF9+9clUT3gaCq7Xnmd+Q/wEMaitpngSTOec/Ffb/r3xexA9XwNJVFSOKfk6q61flHGjAYJ4H9B7Mu5Qur49w==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
@@ -6977,14 +6977,14 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workerd-windows-64@1.20260704.1':
-    resolution: {integrity: sha512-a97Ecnzhy04x3U052VKPCNp863F7Wf00WY7Ga5P0SbtYvaO1PDzylsHrvFMPKeiDFcOwqiredawmJ+v6bhIgeQ==}
+  '@cloudflare/workerd-windows-64@1.20260722.1':
+    resolution: {integrity: sha512-sYM8YgUpKnRz2xjvdJLX1Ojzoi4MlA4gk8WTTExhGydjYB2UTs5NIbv0ZmpKgMoK9io3ixgmiW56ZnTbcWOdiA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workerd-windows-64@1.20260722.1':
-    resolution: {integrity: sha512-sYM8YgUpKnRz2xjvdJLX1Ojzoi4MlA4gk8WTTExhGydjYB2UTs5NIbv0ZmpKgMoK9io3ixgmiW56ZnTbcWOdiA==}
+  '@cloudflare/workerd-windows-64@1.20260831.1':
+    resolution: {integrity: sha512-do+KDYw0PABwsrKUQIccWBZB70kqKcADoSnvzJ8pvMaWUVB4qaCspEZYfm97WNdtY1wt8mlKYqIJyYUNOkTvQg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -18858,13 +18858,13 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
-  workerd@1.20260704.1:
-    resolution: {integrity: sha512-GDZ0jzIYDYfN7rCt/oFJv4BG3QJ+4IS2kfRvxEMY9VKIfPhzo63PH69Ir7ug8LfORCgCtmfkiQVXrqbot7pZTQ==}
+  workerd@1.20260722.1:
+    resolution: {integrity: sha512-NycKuc1x2onvsRfGGpM093vRlLFU2zHDAM0+APpccfg4+gZxDGCH27RmdDvkeBuoZyYqgLo3oAfF6re4mvC3vQ==}
     engines: {node: '>=16'}
     hasBin: true
 
-  workerd@1.20260722.1:
-    resolution: {integrity: sha512-NycKuc1x2onvsRfGGpM093vRlLFU2zHDAM0+APpccfg4+gZxDGCH27RmdDvkeBuoZyYqgLo3oAfF6re4mvC3vQ==}
+  workerd@1.20260831.1:
+    resolution: {integrity: sha512-A2LwrkBel/FnKABPfeBAMiL6v70+rugnunqQRfWsWZjlhsTZoBScWUVunMy/xLCGLjWCQL2zp39AVR6aO0jurQ==}
     engines: {node: '>=16'}
     hasBin: true
 
@@ -20464,17 +20464,17 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260317.1
 
-  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260704.1)':
-    dependencies:
-      unenv: 2.0.0-rc.24
-    optionalDependencies:
-      workerd: 1.20260704.1
-
   '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260722.1)':
     dependencies:
       unenv: 2.0.0-rc.24
     optionalDependencies:
       workerd: 1.20260722.1
+
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260831.1)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260831.1
 
   '@cloudflare/vitest-pool-workers@0.13.5(@cloudflare/workers-types@5.20260812.1)(@vitest/runner@4.1.10)(@vitest/snapshot@4.1.10)(vitest@4.1.10(@types/node@26.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))':
     dependencies:
@@ -20494,46 +20494,46 @@ snapshots:
   '@cloudflare/workerd-darwin-64@1.20260317.1':
     optional: true
 
-  '@cloudflare/workerd-darwin-64@1.20260704.1':
+  '@cloudflare/workerd-darwin-64@1.20260722.1':
     optional: true
 
-  '@cloudflare/workerd-darwin-64@1.20260722.1':
+  '@cloudflare/workerd-darwin-64@1.20260831.1':
     optional: true
 
   '@cloudflare/workerd-darwin-arm64@1.20260317.1':
     optional: true
 
-  '@cloudflare/workerd-darwin-arm64@1.20260704.1':
+  '@cloudflare/workerd-darwin-arm64@1.20260722.1':
     optional: true
 
-  '@cloudflare/workerd-darwin-arm64@1.20260722.1':
+  '@cloudflare/workerd-darwin-arm64@1.20260831.1':
     optional: true
 
   '@cloudflare/workerd-linux-64@1.20260317.1':
     optional: true
 
-  '@cloudflare/workerd-linux-64@1.20260704.1':
+  '@cloudflare/workerd-linux-64@1.20260722.1':
     optional: true
 
-  '@cloudflare/workerd-linux-64@1.20260722.1':
+  '@cloudflare/workerd-linux-64@1.20260831.1':
     optional: true
 
   '@cloudflare/workerd-linux-arm64@1.20260317.1':
     optional: true
 
-  '@cloudflare/workerd-linux-arm64@1.20260704.1':
+  '@cloudflare/workerd-linux-arm64@1.20260722.1':
     optional: true
 
-  '@cloudflare/workerd-linux-arm64@1.20260722.1':
+  '@cloudflare/workerd-linux-arm64@1.20260831.1':
     optional: true
 
   '@cloudflare/workerd-windows-64@1.20260317.1':
     optional: true
 
-  '@cloudflare/workerd-windows-64@1.20260704.1':
+  '@cloudflare/workerd-windows-64@1.20260722.1':
     optional: true
 
-  '@cloudflare/workerd-windows-64@1.20260722.1':
+  '@cloudflare/workerd-windows-64@1.20260831.1':
     optional: true
 
   '@cloudflare/workers-types@5.20260812.1': {}
@@ -36240,14 +36240,6 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260317.1
       '@cloudflare/workerd-windows-64': 1.20260317.1
 
-  workerd@1.20260704.1:
-    optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20260704.1
-      '@cloudflare/workerd-darwin-arm64': 1.20260704.1
-      '@cloudflare/workerd-linux-64': 1.20260704.1
-      '@cloudflare/workerd-linux-arm64': 1.20260704.1
-      '@cloudflare/workerd-windows-64': 1.20260704.1
-
   workerd@1.20260722.1:
     optionalDependencies:
       '@cloudflare/workerd-darwin-64': 1.20260722.1
@@ -36255,6 +36247,14 @@ snapshots:
       '@cloudflare/workerd-linux-64': 1.20260722.1
       '@cloudflare/workerd-linux-arm64': 1.20260722.1
       '@cloudflare/workerd-windows-64': 1.20260722.1
+
+  workerd@1.20260831.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260831.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260831.1
+      '@cloudflare/workerd-linux-64': 1.20260831.1
+      '@cloudflare/workerd-linux-arm64': 1.20260831.1
+      '@cloudflare/workerd-windows-64': 1.20260831.1
 
   wrangler@4.114.0(@cloudflare/workers-types@5.20260812.1):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -75,7 +75,7 @@ catalogs:
     toucan-js: 4.0.0
     unenv: ^2.0.0-rc.24
     vite: ^7.0.0 || ^8.0.0
-    workerd: 1.20260704.1
+    workerd: 1.20260831.1
     ws: ^8.21.0
     yauzl: ^3.4.0
   database:
@@ -187,3 +187,9 @@ minimumReleaseAgeExclude:
   - effect@4.0.0-rc.112
   - foldkit@0.148.2
   - '@solidjs/start@2.0.4'
+  - '@cloudflare/workerd-darwin-64@1.20260831.1'
+  - '@cloudflare/workerd-darwin-arm64@1.20260831.1'
+  - '@cloudflare/workerd-linux-64@1.20260831.1'
+  - '@cloudflare/workerd-linux-arm64@1.20260831.1'
+  - '@cloudflare/workerd-windows-64@1.20260831.1'
+  - workerd@1.20260831.1


### PR DESCRIPTION
Pin every internal workerd isolate and the Vite/platform-proxy defaults to `2026-08-31`, the newest date catalog `workerd` `1.20260831.1` supports.

```ts
export const INTERNAL_WORKER_COMPATIBILITY_DATE = "2026-08-31";
```

That constant now drives the queue broker, workflows engine, assets/router, KV, R2, D1, cache, secrets store, send-email, images, stream, loopback, entry, worker proxy, registry proxy, and remote-binding isolates.

`enable_ctx_exports` is omitted on the asset/router workers — it is default-on as of `2025-11-17`.

The browser isolate stays on `2025-01-01` until the CDP proxy can take the WebSocket auto-reply-to-close handshake (`2026-04-07`).
