### PR TITLE
chore(website): drop beta.75 links to unpublished frontend docs

### DIFF
--- a/website/src/content/docs/blog/2026-08-25-beta-75.md
+++ b/website/src/content/docs/blog/2026-08-25-beta-75.md
@@ -165,10 +165,7 @@ Each cloud has a matching example
 
 Docs:
 [Cloudflare](/cloudflare/frontend/frontends) ·
-[AWS](/aws/frontend/websites) ·
-[Fly](/fly/frontend/websites) ·
-[Hetzner](/hetzner/frontend/websites) ·
-[Railway](/railway/frontend/websites).
+[AWS](/aws/frontend/websites).
 
 ## Railway
 
@@ -816,9 +813,6 @@ const api = yield* AWS.Lambda.Function("ContainerApi", {
 - [Hetzner tutorial](/hetzner/tutorial/part-1)
 - [Cloudflare frontends](/cloudflare/frontend/frontends)
 - [AWS frontends](/aws/frontend/websites)
-- [Fly frontends](/fly/frontend/websites)
-- [Hetzner frontends](/hetzner/frontend/websites)
-- [Railway frontends](/railway/frontend/websites)
 - [AWS local development](/aws/local-development)
 - [Local development](/environments/local-development)
 - [Protect a Worker with Access](/cloudflare/security/access)


### PR DESCRIPTION
The Check job fails because the beta.75 post links to frontend docs that are not on main yet (`feat/container-websites`, #1351).

```diff
 Docs:
 [Cloudflare](/cloudflare/frontend/frontends) ·
-[AWS](/aws/frontend/websites) ·
-[Fly](/fly/frontend/websites) ·
-[Hetzner](/hetzner/frontend/websites) ·
-[Railway](/railway/frontend/websites).
+[AWS](/aws/frontend/websites).
```

Same three URLs dropped from **Where to go next**. Fly, Hetzner, and Railway still link to their hub pages.
