### PR TITLE
feat(aws/cognito): add emailConfiguration to UserPool for SES-backed email delivery

### DIFF
--- a/packages/alchemy/src/AWS/Cognito/UserPool.ts
+++ b/packages/alchemy/src/AWS/Cognito/UserPool.ts
@@ -219,6 +219,47 @@ export interface UserPoolCustomEmailSender {
 }
 
 /**
+ * How the user pool delivers its email messages (verification codes, OTPs,
+ * invitations): either Cognito's built-in, rate-limited delivery
+ * (`COGNITO_DEFAULT`) or your own verified Amazon SES identity
+ * (`DEVELOPER`). With `DEVELOPER`, the SES identity's policy must grant
+ * `cognito-idp.amazonaws.com` permission to send
+ * (`SES.EmailIdentityPolicy`).
+ */
+export interface UserPoolEmailConfiguration {
+  /**
+   * Which sending account delivers the pool's email. `COGNITO_DEFAULT`
+   * uses Cognito's built-in delivery (limited daily volume);
+   * `DEVELOPER` sends through your own SES identity (`sourceArn`
+   * required) at your SES quota.
+   * @default "COGNITO_DEFAULT"
+   */
+  emailSendingAccount?: "COGNITO_DEFAULT" | "DEVELOPER";
+  /**
+   * ARN of a verified SES email identity (address or domain) in a
+   * supported region. Required when `emailSendingAccount` is `DEVELOPER`;
+   * with `COGNITO_DEFAULT` it customizes the FROM address while Cognito
+   * still handles delivery.
+   */
+  sourceArn?: string;
+  /**
+   * The FROM address, either bare (`no-reply@example.com`) or with a
+   * friendly display name (`"My App <no-reply@example.com>"`). Must be
+   * covered by the `sourceArn` identity.
+   */
+  from?: string;
+  /**
+   * The destination for replies to the pool's messages.
+   */
+  replyToEmailAddress?: string;
+  /**
+   * Name of an SES configuration set applied to email sent by the pool
+   * (event publishing, IP pool selection). `DEVELOPER` only.
+   */
+  configurationSet?: string;
+}
+
+/**
  * An account recovery mechanism with its priority (1 is highest).
  */
 export interface UserPoolRecoveryMechanism {
@@ -323,6 +364,14 @@ export interface UserPoolProps {
    */
   customEmailSender?: UserPoolCustomEmailSender;
   /**
+   * How the pool delivers its email messages: Cognito's built-in delivery
+   * (`COGNITO_DEFAULT`, the service default) or a verified SES identity
+   * (`DEVELOPER`) — no custom sender Lambda required. When omitted, an
+   * observed email configuration is preserved rather than reset to the
+   * service default.
+   */
+  emailConfiguration?: UserPoolEmailConfiguration;
+  /**
    * ARN of the symmetric KMS key Cognito uses to encrypt the codes it
    * passes to the custom sender function(s) (`LambdaConfig.KMSKeyID`).
    * The principal running the deploy must hold `kms:CreateGrant` on the
@@ -391,6 +440,38 @@ export interface UserPool extends Resource<
  *     { name: "tenantId", mutable: false },
  *     { name: "plan", attributeDataType: "String" },
  *   ],
+ * });
+ * ```
+ *
+ * ### Sending Email Through SES
+ * **Example:** OTP and Verification Email from a Verified SES Identity
+ * ```typescript
+ * const identity = yield* SES.EmailIdentity("Sender", {
+ *   emailIdentity: "mail.example.com",
+ * });
+ * // allow Cognito to send through the identity
+ * yield* SES.EmailIdentityPolicy("CognitoSend", {
+ *   emailIdentity: identity.emailIdentity,
+ *   policyName: "cognito",
+ *   policy: {
+ *     Version: "2012-10-17",
+ *     Statement: [{
+ *       Effect: "Allow",
+ *       Principal: { Service: "cognito-idp.amazonaws.com" },
+ *       Action: ["ses:SendEmail", "ses:SendRawEmail"],
+ *       Resource: identity.identityArn,
+ *     }],
+ *   },
+ * });
+ * const pool = yield* Cognito.UserPool("Users", {
+ *   usernameAttributes: ["email"],
+ *   autoVerifiedAttributes: ["email"],
+ *   emailConfiguration: {
+ *     emailSendingAccount: "DEVELOPER",
+ *     sourceArn: identity.identityArn,
+ *     from: "My App <no-reply@mail.example.com>",
+ *     replyToEmailAddress: "support@example.com",
+ *   },
  * });
  * ```
  *
@@ -485,6 +566,32 @@ const toWireSignInPolicy = (policy: UserPoolSignInPolicy | undefined) =>
     ? undefined
     : { AllowedFirstAuthFactors: policy.allowedFirstAuthFactors };
 
+const toWireEmailConfiguration = (
+  config: UserPoolEmailConfiguration | undefined,
+): cip.EmailConfigurationType | undefined =>
+  config === undefined
+    ? undefined
+    : {
+        EmailSendingAccount: config.emailSendingAccount ?? "COGNITO_DEFAULT",
+        SourceArn: config.sourceArn,
+        From: config.from,
+        ReplyToEmailAddress: config.replyToEmailAddress,
+        ConfigurationSet: config.configurationSet,
+      };
+
+/** Observed/desired email configuration with the service default filled in,
+ * for order- and absence-insensitive comparison (`JSON.stringify` drops the
+ * `undefined` members on both sides). */
+const normalizedEmailConfiguration = (
+  config: cip.EmailConfigurationType | undefined,
+) => ({
+  emailSendingAccount: config?.EmailSendingAccount ?? "COGNITO_DEFAULT",
+  sourceArn: config?.SourceArn,
+  from: config?.From,
+  replyToEmailAddress: config?.ReplyToEmailAddress,
+  configurationSet: config?.ConfigurationSet,
+});
+
 const toWireCustomEmailSender = (
   sender: UserPoolCustomEmailSender | undefined,
 ): cip.CustomEmailLambdaVersionConfigType | undefined =>
@@ -513,17 +620,25 @@ const validateProps = (props: UserPoolProps) =>
             "customEmailSender requires kmsKeyId — Cognito encrypts the codes it passes to the custom sender with that KMS key",
         }),
       )
-    : props.tier === "LITE" &&
-        (props.signInPolicy?.allowedFirstAuthFactors ?? []).some((factor) =>
-          PASSWORDLESS_AUTH_FACTORS.includes(factor),
-        )
+    : props.emailConfiguration?.emailSendingAccount === "DEVELOPER" &&
+        props.emailConfiguration.sourceArn === undefined
       ? Effect.fail(
           new InvalidUserPoolConfiguration({
             reason:
-              "passwordless first-auth factors (EMAIL_OTP / SMS_OTP / WEB_AUTHN) require the ESSENTIALS or PLUS tier, not LITE",
+              "emailConfiguration with emailSendingAccount DEVELOPER requires sourceArn — the ARN of the verified SES identity Cognito sends from",
           }),
         )
-      : Effect.void;
+      : props.tier === "LITE" &&
+          (props.signInPolicy?.allowedFirstAuthFactors ?? []).some((factor) =>
+            PASSWORDLESS_AUTH_FACTORS.includes(factor),
+          )
+        ? Effect.fail(
+            new InvalidUserPoolConfiguration({
+              reason:
+                "passwordless first-auth factors (EMAIL_OTP / SMS_OTP / WEB_AUTHN) require the ESSENTIALS or PLUS tier, not LITE",
+            }),
+          )
+        : Effect.void;
 
 const tagRecordOf = (
   tags: { [key: string]: string | undefined } | undefined,
@@ -709,6 +824,13 @@ export const UserPoolProvider = () =>
             : toWireSignInPolicy(news.signInPolicy);
         return {
           LambdaConfig: lambdaConfig,
+          // updateUserPool resets an omitted EmailConfiguration to the
+          // service default — echo the OBSERVED configuration back when the
+          // prop is undefined so unrelated updates never clear it.
+          EmailConfiguration:
+            news.emailConfiguration === undefined
+              ? observed.EmailConfiguration
+              : toWireEmailConfiguration(news.emailConfiguration),
           Policies:
             PasswordPolicy === undefined && SignInPolicy === undefined
               ? undefined
@@ -841,6 +963,19 @@ export const UserPoolProvider = () =>
         if (
           (news.mfaConfiguration ?? "OFF") !==
           (observed.MfaConfiguration ?? "OFF")
+        ) {
+          return true;
+        }
+        if (
+          news.emailConfiguration !== undefined &&
+          JSON.stringify(
+            normalizedEmailConfiguration(
+              toWireEmailConfiguration(news.emailConfiguration),
+            ),
+          ) !==
+            JSON.stringify(
+              normalizedEmailConfiguration(observed.EmailConfiguration),
+            )
         ) {
           return true;
         }
@@ -988,6 +1123,9 @@ export const UserPoolProvider = () =>
                 DeletionProtection: news.deletionProtection
                   ? "ACTIVE"
                   : "INACTIVE",
+                EmailConfiguration: toWireEmailConfiguration(
+                  news.emailConfiguration,
+                ),
                 UsernameAttributes: news.usernameAttributes,
                 AliasAttributes: news.aliasAttributes,
                 AutoVerifiedAttributes: news.autoVerifiedAttributes,

--- a/packages/alchemy/test/AWS/Cognito/UserPool.test.ts
+++ b/packages/alchemy/test/AWS/Cognito/UserPool.test.ts
@@ -278,6 +278,82 @@ test.provider(
   { timeout: 180_000 },
 );
 
+// UpdateUserPool resets any field omitted from its body to the service
+// default — an unrelated update must echo the observed EmailConfiguration
+// back rather than clear it.
+test.provider(
+  "email configuration is set, survives unrelated updates, and converges",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const pool = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* UserPool("EmailPool", {
+            autoVerifiedAttributes: ["email"],
+            emailConfiguration: {
+              replyToEmailAddress: "support@example.com",
+            },
+          });
+        }),
+      );
+
+      const describe = () =>
+        cip
+          .describeUserPool({ UserPoolId: pool.userPoolId })
+          .pipe(Effect.map((r) => r.UserPool!));
+
+      const created = yield* describe();
+      expect(created.EmailConfiguration?.EmailSendingAccount).toBe(
+        "COGNITO_DEFAULT",
+      );
+      expect(created.EmailConfiguration?.ReplyToEmailAddress).toBe(
+        "support@example.com",
+      );
+
+      // an unrelated update that OMITS emailConfiguration must preserve the
+      // observed configuration (updateUserPool would otherwise reset it)
+      const updated = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* UserPool("EmailPool", {
+            autoVerifiedAttributes: ["email"],
+            passwordPolicy: { minimumLength: 12 },
+          });
+        }),
+      );
+      expect(updated.userPoolId).toBe(pool.userPoolId);
+      const afterUnrelated = yield* describe();
+      expect(afterUnrelated.Policies?.PasswordPolicy?.MinimumLength).toBe(12);
+      expect(afterUnrelated.EmailConfiguration?.ReplyToEmailAddress).toBe(
+        "support@example.com",
+      );
+
+      // changing the declared configuration converges
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* UserPool("EmailPool", {
+            autoVerifiedAttributes: ["email"],
+            passwordPolicy: { minimumLength: 12 },
+            emailConfiguration: {
+              replyToEmailAddress: "help@example.com",
+            },
+          });
+        }),
+      );
+      const afterChange = yield* describe();
+      expect(afterChange.EmailConfiguration?.ReplyToEmailAddress).toBe(
+        "help@example.com",
+      );
+      expect(afterChange.EmailConfiguration?.EmailSendingAccount).toBe(
+        "COGNITO_DEFAULT",
+      );
+
+      yield* stack.destroy();
+      yield* assertPoolDeleted(pool.userPoolId);
+    }),
+  { timeout: 120_000 },
+);
+
 test.provider(
   "customEmailSender without kmsKeyId and passwordless factors on LITE fail early",
   (stack) =>
@@ -314,6 +390,17 @@ test.provider(
         )
         .pipe(Effect.exit);
       expect(failureTag(liteOtp)).toBe("InvalidUserPoolConfiguration");
+
+      const developerWithoutSource = yield* stack
+        .deploy(
+          UserPool("InvalidPool", {
+            emailConfiguration: { emailSendingAccount: "DEVELOPER" },
+          }),
+        )
+        .pipe(Effect.exit);
+      expect(failureTag(developerWithoutSource)).toBe(
+        "InvalidUserPoolConfiguration",
+      );
 
       // nothing was created — the validation runs before any API call
       yield* stack.destroy();


### PR DESCRIPTION
Let a Cognito user pool send its verification/OTP email through a verified SES identity natively — no `customEmailSender` Lambda required.

```ts
const identity = yield* SES.EmailIdentity("Sender", { emailIdentity: "example.com" });
// SES.EmailIdentityPolicy grants cognito-idp.amazonaws.com ses:SendEmail on the identity

const pool = yield* Cognito.UserPool("Users", {
  usernameAttributes: ["email"],
  autoVerifiedAttributes: ["email"],
  emailConfiguration: {
    emailSendingAccount: "DEVELOPER",
    sourceArn: identity.identityArn,
    from: "Example <no-reply@example.com>",
    replyToEmailAddress: "support@example.com",
  },
});
```

- Models the Cognito `EmailConfiguration` wire shape: `emailSendingAccount` (`"COGNITO_DEFAULT" | "DEVELOPER"`), `sourceArn`, `from`, `replyToEmailAddress`, `configurationSet`
- `UpdateUserPool` resets omitted fields to service defaults, so the reconciler echoes the **observed** `EmailConfiguration` back when the prop is undefined — an unrelated update (e.g. password policy) never clears an SES-backed configuration; drift compares normalized desired vs observed with the `COGNITO_DEFAULT` default filled in on both sides
- `DEVELOPER` without `sourceArn` fails early with the typed `InvalidUserPoolConfiguration` before any API call
