### PR TITLE
fix(docker/container): configuration change does not result in update/replacement

### DIFF
--- a/packages/alchemy/src/Docker/Container.ts
+++ b/packages/alchemy/src/Docker/Container.ts
@@ -9,8 +9,11 @@ import * as Provider from "../Provider.ts";
 import { Resource } from "../Resource.ts";
 import { createInternalTags, hasAlchemyTags } from "../Tags.ts";
 import { toSeconds } from "../Util/Duration.ts";
+import { sha256Object } from "../Util/sha256.ts";
 import { Docker, dockerContextName, dockerPhysicalName } from "./Docker.ts";
 import type { Providers } from "./Providers.ts";
+
+const CREATE_CONFIG_HASH_LABEL = "alchemy::container-config";
 
 export interface ContainerProps {
   /** Image reference or Docker image resource. */
@@ -277,20 +280,29 @@ export const ContainerProvider = () =>
         );
       });
 
+      const inspect = (name: string, context?: string) =>
+        docker.container
+          .inspect(name, context)
+          .pipe(
+            Effect.catchReason(
+              "PlatformError",
+              "NotFound",
+              () => Effect.undefined,
+            ),
+          );
+
+      const remove = (name: string, context?: string) =>
+        docker.container.stop(name, context).pipe(
+          Effect.andThen(docker.container.remove(name, true, context)),
+          Effect.catchReason("PlatformError", "NotFound", () => Effect.void),
+        );
+
       return Container.Provider.of({
         list: () => Effect.succeed([]),
         read: Effect.fn(function* ({ id, instanceId, olds, output }) {
           const context = dockerContextName(olds.context);
           const name = yield* dockerPhysicalName(id, olds, instanceId);
-          const info = yield* docker.container
-            .inspect(name, context)
-            .pipe(
-              Effect.catchReason(
-                "PlatformError",
-                "NotFound",
-                () => Effect.undefined,
-              ),
-            );
+          const info = yield* inspect(name, context);
           if (!info) return undefined;
           // `olds.image` may be `undefined` when a `creating` row was
           // persisted before upstream Outputs resolved — fall back to the
@@ -342,52 +354,46 @@ export const ContainerProvider = () =>
         }) {
           const context = dockerContextName(news.context);
           const args = yield* makeCreateArgs(id, news, instanceId);
-          const oldContext = dockerContextName(olds?.context);
-          const oldArgs =
-            olds?.image === undefined
-              ? undefined
-              : yield* makeCreateArgs(id, olds, instanceId);
-          const inspect = (name: string, engineContext?: string) =>
-            docker.container
-              .inspect(name, engineContext)
-              .pipe(
-                Effect.catchReason(
-                  "PlatformError",
-                  "NotFound",
-                  () => Effect.undefined,
-                ),
-              );
-          const remove = (
-            container: Docker.Container,
-            engineContext?: string,
-          ) =>
-            docker.container.stop(container.Id, engineContext).pipe(
-              Effect.andThen(
-                docker.container.remove(container.Id, true, engineContext),
-              ),
-              Effect.catchReason(
-                "PlatformError",
-                "NotFound",
-                () => Effect.void,
-              ),
-            );
-
-          const live = yield* inspect(args.name, context);
+          const configHash = yield* sha256Object({
+            ...args,
+            imageId: normalizeImageId(news.image),
+          });
+          // Adoption has output but no olds. In that case the observed
+          // container already lives in the desired context.
+          const oldContext = olds ? dockerContextName(olds.context) : context;
+          const desiredLive = yield* inspect(args.name, context);
           const previous =
             output && (output.name !== args.name || oldContext !== context)
               ? yield* inspect(output.name, oldContext)
               : undefined;
           if (previous) {
-            yield* remove(previous, oldContext);
+            yield* remove(previous.Id, oldContext);
           }
+          const live =
+            desiredLive?.Id === previous?.Id ? undefined : desiredLive;
 
+          const oldArgs =
+            live?.Config.Labels?.[CREATE_CONFIG_HASH_LABEL] === undefined &&
+            olds !== undefined
+              ? yield* makeCreateArgs(
+                  id,
+                  {
+                    ...olds,
+                    image: olds.image ?? output?.imageRef ?? news.image,
+                  },
+                  instanceId,
+                )
+              : undefined;
           const recreate =
             live !== undefined &&
-            ((oldArgs !== undefined && !Equal.equals(oldArgs, args)) ||
-              normalizeImageId(olds?.image) !== normalizeImageId(news.image) ||
-              !matchesDesiredCreateConfiguration(live, args, news.image));
+            (live.Config.Labels?.[CREATE_CONFIG_HASH_LABEL] === undefined
+              ? (oldArgs !== undefined && !Equal.equals(oldArgs, args)) ||
+                normalizeImageId(olds?.image) !==
+                  normalizeImageId(news.image) ||
+                !matchesLegacyConfig(live, args, news.image)
+              : live.Config.Labels[CREATE_CONFIG_HASH_LABEL] !== configHash);
           if (recreate) {
-            yield* remove(live, context);
+            yield* remove(live.Id, context);
           }
 
           const current = recreate ? undefined : live;
@@ -396,7 +402,11 @@ export const ContainerProvider = () =>
             const { stdout: containerId } = yield* docker.container.create({
               ...args,
               context,
-              label: { ...args.label, ...internalTags },
+              label: {
+                ...args.label,
+                ...internalTags,
+                [CREATE_CONFIG_HASH_LABEL]: configHash,
+              },
             });
             yield* Effect.forEach(
               news.networks ?? [],
@@ -429,22 +439,7 @@ export const ContainerProvider = () =>
             );
         }),
         delete: Effect.fn(({ olds, output }) =>
-          docker.container
-            .stop(output.name, dockerContextName(olds.context))
-            .pipe(
-              Effect.andThen(
-                docker.container.remove(
-                  output.name,
-                  true,
-                  dockerContextName(olds.context),
-                ),
-              ),
-              Effect.catchReason(
-                "PlatformError",
-                "NotFound",
-                () => Effect.void,
-              ),
-            ),
+          remove(output.name, dockerContextName(olds.context)),
         ),
       });
     }),
@@ -458,7 +453,10 @@ const normalizeImageId = (image: Container.Image | undefined) =>
 
 type CreateArgs = Parameters<Docker["Service"]["container"]["create"]>[0];
 
-const matchesDesiredCreateConfiguration = (
+// Containers created before config hashes were introduced are compared using
+// the fields Docker reports without image-default normalization. A subsequent
+// create stamps the complete resolved configuration hash.
+const matchesLegacyConfig = (
   live: Docker.Container,
   desired: CreateArgs,
   image: Container.Image,
@@ -470,93 +468,52 @@ const matchesDesiredCreateConfiguration = (
     Equal.equals(live.Config.Cmd, desired.command)) &&
   Object.entries(desired.env ?? {}).every(([key, value]) =>
     live.Config.Env?.includes(`${key}=${value}`),
-  ) &&
-  Equal.equals(
-    [...(live.HostConfig.Binds ?? [])].sort(),
-    [...(desired.volume ?? [])].sort(),
-  ) &&
-  Equal.equals(
-    Object.entries(live.HostConfig.PortBindings ?? {})
-      .flatMap(([internal, bindings]) =>
-        (bindings ?? []).map((binding) => `${binding.HostPort}:${internal}`),
-      )
-      .sort(),
-    [...(desired.p ?? [])].sort(),
-  ) &&
-  live.HostConfig.RestartPolicy.Name === desired.restart &&
-  live.HostConfig.AutoRemove === desired.rm &&
-  Object.entries(desired.label ?? {}).every(
-    ([key, value]) => live.Config.Labels?.[key] === value,
-  ) &&
-  (desired["stop-timeout"] === undefined ||
-    live.Config.StopTimeout === Number(desired["stop-timeout"])) &&
-  matchesDesiredHealthcheck(live.Config.Healthcheck, desired);
-
-const matchesDesiredHealthcheck = (
-  live: Docker.Container["Config"]["Healthcheck"],
-  desired: CreateArgs,
-) => {
-  if (desired["health-cmd"] === undefined) return true;
-  return (
-    Equal.equals(live?.Test, ["CMD-SHELL", desired["health-cmd"]]) &&
-    (desired["health-interval"] === undefined ||
-      live?.Interval === parseDockerDuration(desired["health-interval"])) &&
-    (desired["health-timeout"] === undefined ||
-      live?.Timeout === parseDockerDuration(desired["health-timeout"])) &&
-    live?.Retries === desired["health-retries"] &&
-    (desired["health-start-period"] === undefined ||
-      live?.StartPeriod ===
-        parseDockerDuration(desired["health-start-period"])) &&
-    (desired["health-start-interval"] === undefined ||
-      live?.StartInterval ===
-        parseDockerDuration(desired["health-start-interval"]))
   );
-};
-
-const parseDockerDuration = (duration: string | undefined) =>
-  duration?.endsWith("ns") ? Number(duration.slice(0, -2)) : undefined;
 
 const makeCreateArgs = (id: string, news: ContainerProps, instanceId: string) =>
   dockerPhysicalName(id, news, instanceId).pipe(
-    Effect.map((name): CreateArgs => ({
-      name,
-      image: normalizeImageRef(news.image),
-      command: news.command,
-      env: normalizeEnvironment(news.environment),
-      volume: news.volumes?.map(
-        (v) => `${v.hostPath}:${v.containerPath}${v.readOnly ? ":ro" : ""}`,
-      ),
-      p: news.ports?.map(
-        (port) => `${port.external}:${port.internal}/${port.protocol ?? "tcp"}`,
-      ),
-      restart: news.restart ?? "no",
-      label: news.labels,
-      "stop-timeout": toSeconds(news.stopTimeout)?.toString(),
-      rm: news.removeOnExit ?? false,
-      ...(news.healthcheck
-        ? {
-            "health-cmd": Array.isArray(news.healthcheck.cmd)
-              ? news.healthcheck.cmd.join(" ")
-              : news.healthcheck.cmd,
-            "health-interval": normalizeDuration(news.healthcheck.interval),
-            "health-timeout": normalizeDuration(news.healthcheck.timeout),
-            "health-retries": news.healthcheck.retries ?? 0,
-            "health-start-period": normalizeDuration(
-              news.healthcheck.startPeriod,
-            ),
-            "health-start-interval": normalizeDuration(
-              news.healthcheck.startInterval,
-            ),
-          }
-        : {
-            "health-cmd": undefined,
-            "health-interval": undefined,
-            "health-timeout": undefined,
-            "health-retries": undefined,
-            "health-start-period": undefined,
-            "health-start-interval": undefined,
-          }),
-    })),
+    Effect.map(
+      (name): Parameters<Docker["Service"]["container"]["create"]>[0] => ({
+        name,
+        image: normalizeImageRef(news.image),
+        command: news.command,
+        env: normalizeEnvironment(news.environment),
+        volume: news.volumes?.map(
+          (v) => `${v.hostPath}:${v.containerPath}${v.readOnly ? ":ro" : ""}`,
+        ),
+        p: news.ports?.map(
+          (port) =>
+            `${port.external}:${port.internal}/${port.protocol ?? "tcp"}`,
+        ),
+        restart: news.restart ?? "no",
+        label: news.labels,
+        "stop-timeout": toSeconds(news.stopTimeout)?.toString(),
+        rm: news.removeOnExit ?? false,
+        ...(news.healthcheck
+          ? {
+              "health-cmd": Array.isArray(news.healthcheck.cmd)
+                ? news.healthcheck.cmd.join(" ")
+                : news.healthcheck.cmd,
+              "health-interval": normalizeDuration(news.healthcheck.interval),
+              "health-timeout": normalizeDuration(news.healthcheck.timeout),
+              "health-retries": news.healthcheck.retries ?? 0,
+              "health-start-period": normalizeDuration(
+                news.healthcheck.startPeriod,
+              ),
+              "health-start-interval": normalizeDuration(
+                news.healthcheck.startInterval,
+              ),
+            }
+          : {
+              "health-cmd": undefined,
+              "health-interval": undefined,
+              "health-timeout": undefined,
+              "health-retries": undefined,
+              "health-start-period": undefined,
+              "health-start-interval": undefined,
+            }),
+      }),
+    ),
   );
 
 const toContainerAttributes = (

--- a/packages/alchemy/src/Docker/Container.ts
+++ b/packages/alchemy/src/Docker/Container.ts
@@ -62,7 +62,7 @@ export declare namespace Container {
     | "removing"
     | "exited"
     | "dead";
-  type Image = string | { imageRef: string };
+  type Image = string | { imageRef: string; imageId?: string };
   interface PortMapping {
     /** External port on the host. */
     external: number | string;
@@ -333,55 +333,100 @@ export const ContainerProvider = () =>
             return { action: "update" as const };
           }
         }),
-        reconcile: Effect.fn(function* ({ id, instanceId, news }) {
+        reconcile: Effect.fn(function* ({
+          id,
+          instanceId,
+          news,
+          olds,
+          output,
+        }) {
           const context = dockerContextName(news.context);
           const args = yield* makeCreateArgs(id, news, instanceId);
-          const live = yield* docker.container
-            .inspect(args.name, context)
-            .pipe(
+          const oldContext = dockerContextName(olds?.context);
+          const oldArgs =
+            olds?.image === undefined
+              ? undefined
+              : yield* makeCreateArgs(id, olds, instanceId);
+          const inspect = (name: string, engineContext?: string) =>
+            docker.container
+              .inspect(name, engineContext)
+              .pipe(
+                Effect.catchReason(
+                  "PlatformError",
+                  "NotFound",
+                  () => Effect.undefined,
+                ),
+              );
+          const remove = (
+            container: Docker.Container,
+            engineContext?: string,
+          ) =>
+            docker.container.stop(container.Id, engineContext).pipe(
+              Effect.andThen(
+                docker.container.remove(container.Id, true, engineContext),
+              ),
               Effect.catchReason(
                 "PlatformError",
                 "NotFound",
-                () => Effect.undefined,
+                () => Effect.void,
               ),
             );
 
-          if (live) {
-            yield* reconcileNetworks(live, news);
-            if (news.start && live.State.Status !== "running") {
-              yield* docker.container.start(live.Id, context);
-            } else if (!news.start && live.State.Status === "running") {
-              yield* docker.container.stop(live.Id, context);
-            }
-            return yield* docker.container
-              .inspect(live.Id, context)
-              .pipe(
-                Effect.map((info) => toContainerAttributes(info, args.image)),
-              );
+          const live = yield* inspect(args.name, context);
+          const previous =
+            output && (output.name !== args.name || oldContext !== context)
+              ? yield* inspect(output.name, oldContext)
+              : undefined;
+          if (previous) {
+            yield* remove(previous, oldContext);
           }
 
-          const internalTags = yield* createInternalTags(id);
-          const { stdout: containerId } = yield* docker.container.create({
-            ...args,
-            context,
-            label: { ...args.label, ...internalTags },
-          });
-          yield* Effect.forEach(
-            news.networks ?? [],
-            (network) =>
-              docker.network.connect({
-                network: network.name,
-                container: containerId,
-                alias: network.aliases,
-                context,
-              }),
-            { concurrency: "unbounded" },
-          );
-          if (news.start) {
-            yield* docker.container.start(containerId, context);
+          const recreate =
+            live !== undefined &&
+            ((oldArgs !== undefined && !Equal.equals(oldArgs, args)) ||
+              normalizeImageId(olds?.image) !== normalizeImageId(news.image) ||
+              !matchesDesiredCreateConfiguration(live, args, news.image));
+          if (recreate) {
+            yield* remove(live, context);
           }
-          const info = yield* docker.container.inspect(containerId, context);
-          return toContainerAttributes(info, args.image);
+
+          const current = recreate ? undefined : live;
+          if (!current) {
+            const internalTags = yield* createInternalTags(id);
+            const { stdout: containerId } = yield* docker.container.create({
+              ...args,
+              context,
+              label: { ...args.label, ...internalTags },
+            });
+            yield* Effect.forEach(
+              news.networks ?? [],
+              (network) =>
+                docker.network.connect({
+                  network: network.name,
+                  container: containerId,
+                  alias: network.aliases,
+                  context,
+                }),
+              { concurrency: "unbounded" },
+            );
+            if (news.start) {
+              yield* docker.container.start(containerId, context);
+            }
+            const info = yield* docker.container.inspect(containerId, context);
+            return toContainerAttributes(info, args.image);
+          }
+
+          yield* reconcileNetworks(current, news);
+          if (news.start && current.State.Status !== "running") {
+            yield* docker.container.start(current.Id, context);
+          } else if (!news.start && current.State.Status === "running") {
+            yield* docker.container.stop(current.Id, context);
+          }
+          return yield* docker.container
+            .inspect(current.Id, context)
+            .pipe(
+              Effect.map((info) => toContainerAttributes(info, args.image)),
+            );
         }),
         delete: Effect.fn(({ olds, output }) =>
           docker.container
@@ -408,50 +453,110 @@ export const ContainerProvider = () =>
 const normalizeImageRef = (image: Container.Image): string =>
   typeof image === "string" ? image : image.imageRef;
 
+const normalizeImageId = (image: Container.Image | undefined) =>
+  typeof image === "string" ? undefined : image?.imageId;
+
+type CreateArgs = Parameters<Docker["Service"]["container"]["create"]>[0];
+
+const matchesDesiredCreateConfiguration = (
+  live: Docker.Container,
+  desired: CreateArgs,
+  image: Container.Image,
+) =>
+  (normalizeImageId(image)
+    ? live.Image === normalizeImageId(image)
+    : live.Config.Image === desired.image) &&
+  (desired.command === undefined ||
+    Equal.equals(live.Config.Cmd, desired.command)) &&
+  Object.entries(desired.env ?? {}).every(([key, value]) =>
+    live.Config.Env?.includes(`${key}=${value}`),
+  ) &&
+  Equal.equals(
+    [...(live.HostConfig.Binds ?? [])].sort(),
+    [...(desired.volume ?? [])].sort(),
+  ) &&
+  Equal.equals(
+    Object.entries(live.HostConfig.PortBindings ?? {})
+      .flatMap(([internal, bindings]) =>
+        (bindings ?? []).map((binding) => `${binding.HostPort}:${internal}`),
+      )
+      .sort(),
+    [...(desired.p ?? [])].sort(),
+  ) &&
+  live.HostConfig.RestartPolicy.Name === desired.restart &&
+  live.HostConfig.AutoRemove === desired.rm &&
+  Object.entries(desired.label ?? {}).every(
+    ([key, value]) => live.Config.Labels?.[key] === value,
+  ) &&
+  (desired["stop-timeout"] === undefined ||
+    live.Config.StopTimeout === Number(desired["stop-timeout"])) &&
+  matchesDesiredHealthcheck(live.Config.Healthcheck, desired);
+
+const matchesDesiredHealthcheck = (
+  live: Docker.Container["Config"]["Healthcheck"],
+  desired: CreateArgs,
+) => {
+  if (desired["health-cmd"] === undefined) return true;
+  return (
+    Equal.equals(live?.Test, ["CMD-SHELL", desired["health-cmd"]]) &&
+    (desired["health-interval"] === undefined ||
+      live?.Interval === parseDockerDuration(desired["health-interval"])) &&
+    (desired["health-timeout"] === undefined ||
+      live?.Timeout === parseDockerDuration(desired["health-timeout"])) &&
+    live?.Retries === desired["health-retries"] &&
+    (desired["health-start-period"] === undefined ||
+      live?.StartPeriod ===
+        parseDockerDuration(desired["health-start-period"])) &&
+    (desired["health-start-interval"] === undefined ||
+      live?.StartInterval ===
+        parseDockerDuration(desired["health-start-interval"]))
+  );
+};
+
+const parseDockerDuration = (duration: string | undefined) =>
+  duration?.endsWith("ns") ? Number(duration.slice(0, -2)) : undefined;
+
 const makeCreateArgs = (id: string, news: ContainerProps, instanceId: string) =>
   dockerPhysicalName(id, news, instanceId).pipe(
-    Effect.map(
-      (name): Parameters<Docker["Service"]["container"]["create"]>[0] => ({
-        name,
-        image: normalizeImageRef(news.image),
-        command: news.command,
-        env: normalizeEnvironment(news.environment),
-        volume: news.volumes?.map(
-          (v) => `${v.hostPath}:${v.containerPath}${v.readOnly ? ":ro" : ""}`,
-        ),
-        p: news.ports?.map(
-          (port) =>
-            `${port.external}:${port.internal}/${port.protocol ?? "tcp"}`,
-        ),
-        restart: news.restart ?? "no",
-        label: news.labels,
-        "stop-timeout": toSeconds(news.stopTimeout)?.toString(),
-        rm: news.removeOnExit ?? false,
-        ...(news.healthcheck
-          ? {
-              "health-cmd": Array.isArray(news.healthcheck.cmd)
-                ? news.healthcheck.cmd.join(" ")
-                : news.healthcheck.cmd,
-              "health-interval": normalizeDuration(news.healthcheck.interval),
-              "health-timeout": normalizeDuration(news.healthcheck.timeout),
-              "health-retries": news.healthcheck.retries ?? 0,
-              "health-start-period": normalizeDuration(
-                news.healthcheck.startPeriod,
-              ),
-              "health-start-interval": normalizeDuration(
-                news.healthcheck.startInterval,
-              ),
-            }
-          : {
-              "health-cmd": undefined,
-              "health-interval": undefined,
-              "health-timeout": undefined,
-              "health-retries": undefined,
-              "health-start-period": undefined,
-              "health-start-interval": undefined,
-            }),
-      }),
-    ),
+    Effect.map((name): CreateArgs => ({
+      name,
+      image: normalizeImageRef(news.image),
+      command: news.command,
+      env: normalizeEnvironment(news.environment),
+      volume: news.volumes?.map(
+        (v) => `${v.hostPath}:${v.containerPath}${v.readOnly ? ":ro" : ""}`,
+      ),
+      p: news.ports?.map(
+        (port) => `${port.external}:${port.internal}/${port.protocol ?? "tcp"}`,
+      ),
+      restart: news.restart ?? "no",
+      label: news.labels,
+      "stop-timeout": toSeconds(news.stopTimeout)?.toString(),
+      rm: news.removeOnExit ?? false,
+      ...(news.healthcheck
+        ? {
+            "health-cmd": Array.isArray(news.healthcheck.cmd)
+              ? news.healthcheck.cmd.join(" ")
+              : news.healthcheck.cmd,
+            "health-interval": normalizeDuration(news.healthcheck.interval),
+            "health-timeout": normalizeDuration(news.healthcheck.timeout),
+            "health-retries": news.healthcheck.retries ?? 0,
+            "health-start-period": normalizeDuration(
+              news.healthcheck.startPeriod,
+            ),
+            "health-start-interval": normalizeDuration(
+              news.healthcheck.startInterval,
+            ),
+          }
+        : {
+            "health-cmd": undefined,
+            "health-interval": undefined,
+            "health-timeout": undefined,
+            "health-retries": undefined,
+            "health-start-period": undefined,
+            "health-start-interval": undefined,
+          }),
+    })),
   );
 
 const toContainerAttributes = (

--- a/packages/alchemy/src/Docker/Docker.ts
+++ b/packages/alchemy/src/Docker/Docker.ts
@@ -373,6 +373,7 @@ export declare namespace Docker {
 
   export interface Container {
     Id: string;
+    Image: string;
     Name?: string;
     State: { Status: ContainerStatus };
     Created: string;

--- a/packages/alchemy/test/Docker/Container.test.ts
+++ b/packages/alchemy/test/Docker/Container.test.ts
@@ -1,4 +1,5 @@
 import * as Docker from "@/Docker";
+import { Action } from "@/Action";
 import * as Provider from "@/Provider";
 import {
   inMemoryState,
@@ -9,6 +10,8 @@ import {
 import * as Test from "@/Test/Alchemy";
 import { describe, expect } from "alchemy-test";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
 import * as Redacted from "effect/Redacted";
 import { findAvailablePort } from "./Runtime.ts";
 
@@ -176,6 +179,106 @@ describe("Docker.Container", { concurrent: false }, () => {
       );
       expect(info.Config.StopTimeout).toBe(600);
     }),
+  );
+
+  test.provider(
+    "recreates a container when an Action-backed environment value changes",
+    (stack) =>
+      Effect.gen(function* () {
+        const docker = yield* Docker.Docker;
+        const Environment = Action(
+          "ContainerEnvironment",
+          (input: { value: string }) => Effect.succeed(input.value),
+        );
+        const deployWithEnvironment = (value: string) =>
+          stack.deploy(
+            Effect.gen(function* () {
+              const environment = yield* Environment({ value });
+              return yield* Docker.Container("action-env-container", {
+                image: "nginx:alpine",
+                environment: { VALUE: environment },
+                start: false,
+              });
+            }),
+          );
+
+        const first = yield* deployWithEnvironment("first");
+        const second = yield* deployWithEnvironment("second");
+
+        expect(second.id).not.toBe(first.id);
+        const info = yield* docker.container.inspect(second.name);
+        expect(info.Config.Env).toContain("VALUE=second");
+        expect(info.Config.Env).not.toContain("VALUE=first");
+      }),
+  );
+
+  test.provider(
+    "recreates a container when a Docker image is rebuilt with the same ref",
+    (stack) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const docker = yield* Docker.Docker;
+        const root = yield* fs.makeTempDirectoryScoped({
+          prefix: "alchemy-container-image-",
+        });
+        const deploy = () =>
+          stack.deploy(
+            Effect.gen(function* () {
+              const image = yield* Docker.Image("container-image", {
+                build: { context: root },
+              });
+              const container = yield* Docker.Container(
+                "rebuilt-image-container",
+                {
+                  image,
+                  start: false,
+                },
+              );
+              return { container, image };
+            }),
+          );
+
+        yield* fs.writeFileString(
+          path.join(root, "Dockerfile"),
+          "FROM nginx:alpine\nLABEL alchemy.generation=first\n",
+        );
+        const first = yield* deploy();
+        yield* fs.writeFileString(
+          path.join(root, "Dockerfile"),
+          "FROM nginx:alpine\nLABEL alchemy.generation=second\n",
+        );
+        const second = yield* deploy();
+
+        expect(second.image.imageRef).toBe(first.image.imageRef);
+        expect(second.image.imageId).not.toBe(first.image.imageId);
+        expect(second.container.id).not.toBe(first.container.id);
+        const info = yield* docker.container.inspect(second.container.name);
+        expect(info.Image).toBe(second.image.imageId);
+      }),
+    { timeout: 240_000 },
+  );
+
+  test.provider(
+    "updates start state without replacing the container",
+    (stack) =>
+      Effect.gen(function* () {
+        const first = yield* stack.deploy(
+          Docker.Container("started-container", {
+            image: "nginx:alpine",
+            start: false,
+          }),
+        );
+        const second = yield* stack.deploy(
+          Docker.Container("started-container", {
+            image: "nginx:alpine",
+            start: true,
+          }),
+        );
+
+        expect(second.id).toBe(first.id);
+        expect(second.status).toBe("running");
+      }),
   );
 
   test.provider(

--- a/packages/alchemy/test/Docker/Container.test.ts
+++ b/packages/alchemy/test/Docker/Container.test.ts
@@ -256,7 +256,55 @@ describe("Docker.Container", { concurrent: false }, () => {
         const info = yield* docker.container.inspect(second.container.name);
         expect(info.Image).toBe(second.image.imageId);
       }),
-    { timeout: 240_000 },
+    { timeout: 120_000 },
+  );
+
+  test.provider(
+    "adopts a container from a named context without removing it",
+    (stack) =>
+      Effect.gen(function* () {
+        const docker = yield* Docker.Docker;
+        const context = "alchemy-test-container-adoption";
+        const name = "alchemy-test-adopted-container";
+        const { stdout: host } = yield* docker.run([
+          "context",
+          "inspect",
+          "--format",
+          "{{.Endpoints.docker.Host}}",
+        ]);
+
+        yield* docker.context.remove(context, true).pipe(Effect.ignore);
+        yield* docker.context.create({
+          name: context,
+          docker: `host=${host.trim()}`,
+        });
+        yield* Effect.addFinalizer(() =>
+          docker.context.remove(context, true).pipe(Effect.ignore),
+        );
+        yield* docker.container.remove(name, true, context).pipe(Effect.ignore);
+        const { stdout: id } = yield* docker.run([
+          "--context",
+          context,
+          "container",
+          "create",
+          "--name",
+          name,
+          "nginx:alpine",
+        ]);
+        yield* Effect.addFinalizer(() =>
+          docker.container.remove(name, true, context).pipe(Effect.ignore),
+        );
+
+        const adopted = yield* stack.deploy(
+          Docker.Container("adopted-container", {
+            name,
+            image: "nginx:alpine",
+            context,
+          }),
+        );
+
+        expect(adopted.id).toBe(id);
+      }),
   );
 
   test.provider(
@@ -309,6 +357,36 @@ describe("Docker.Container", { concurrent: false }, () => {
           info?.NetworkSettings.Networks?.[second.network.name]?.Aliases ?? [];
         expect(aliases).toContain("new-alias");
         expect(aliases).not.toContain("old-alias");
+      }),
+  );
+
+  test.provider(
+    "updates networks without replacing a container with a host-bound port",
+    (stack) =>
+      Effect.gen(function* () {
+        const hostPort = yield* findAvailablePort();
+        const deployWithAlias = (alias: string) =>
+          stack.deploy(
+            Effect.gen(function* () {
+              const network = yield* Docker.Network("host-port-network");
+              const container = yield* Docker.Container("host-port-container", {
+                image: "nginx:alpine",
+                ports: [
+                  {
+                    external: `127.0.0.1:${hostPort}`,
+                    internal: 80,
+                  },
+                ],
+                networks: [{ name: network.name, aliases: [alias] }],
+              });
+              return { container, network };
+            }),
+          );
+
+        const first = yield* deployWithAlias("old-alias");
+        const second = yield* deployWithAlias("new-alias");
+
+        expect(second.container.id).toBe(first.container.id);
       }),
   );
 
@@ -403,7 +481,7 @@ describe("Docker.Container", { concurrent: false }, () => {
 
         yield* stack.destroy();
       }),
-    { timeout: 240_000 },
+    { timeout: 120_000 },
   );
 
   test.provider(
@@ -441,7 +519,33 @@ describe("Docker.Container", { concurrent: false }, () => {
 
         yield* stack.destroy();
       }),
-    { timeout: 240_000 },
+    { timeout: 120_000 },
+  );
+
+  test.provider(
+    "reconciles removed environment after a creating-state image prop is lost",
+    (stack) =>
+      Effect.gen(function* () {
+        const docker = yield* Docker.Docker;
+        const first = yield* stack.deploy(
+          Docker.Container("lost-image-env-container", {
+            image: "nginx:alpine",
+            environment: { OLD_VALUE: "present" },
+          }),
+        );
+
+        yield* wedgeContainerRow(stack);
+
+        const second = yield* stack.deploy(
+          Docker.Container("lost-image-env-container", {
+            image: "nginx:alpine",
+          }),
+        );
+        const info = yield* docker.container.inspect(second.name);
+
+        expect(second.id).not.toBe(first.id);
+        expect(info.Config.Env).not.toContain("OLD_VALUE=present");
+      }),
   );
 
   test.provider(


### PR DESCRIPTION
### Problem

`Docker.Container` can report a successful update without applying the resolved configuration to Docker.

When a container prop depends on an `Action` or another resource output, `Container.diff` cannot compare it during planning because the new props are still unresolved. The planner schedules an update, but the old reconciler only synchronized networks and start state. Create-time settings such as environment variables, commands, ports, volumes, labels, restart policy, and health checks could remain unchanged while Alchemy persisted the new props.

A related case occurs when `Docker.Image` rebuilds an image under the same tag. The `imageRef` remains unchanged even though the `imageId` changes, so a dependent container could continue using the old image.

### Fix

- Hash the fully resolved Docker create arguments together with the managed image ID and stamp newly created containers with that internal configuration hash.
- During reconcile, recreate a container when its applied hash differs from the desired hash.
- Keep a narrow compatibility path for containers created before the hash label existed, so upgrades and adoption do not replace otherwise matching containers.
- Treat adoption as already being in the desired Docker context, avoiding cleanup against the active/default context.
- Remove the previous container when a resolved name or context changes, including when two contexts point to the same engine.
- Continue applying network and start-state changes in place so those updates preserve the container ID.

The regression coverage includes Action-backed environment updates, same-ref image rebuilds, named-context adoption, host-bound ports during network-only updates, creating-state recovery with removed environment values, and start/network updates that must preserve the container.
