### PR TITLE
fix(docker/container): report assigned host ports, support extra hosts, stop disconnecting foreign networks

### DIFF
--- a/packages/alchemy/src/Docker/Container.ts
+++ b/packages/alchemy/src/Docker/Container.ts
@@ -45,6 +45,13 @@ export interface ContainerProps {
   stopTimeout?: Duration.Input;
   /** Networks to connect after create. */
   networks?: Container.NetworkMapping[];
+  /**
+   * Extra `/etc/hosts` entries, each `hostname:address`. Docker's
+   * `host-gateway` alias resolves to the host machine, so
+   * `"host.docker.internal:host-gateway"` reaches services listening on the
+   * developer's machine from inside the container.
+   */
+  extraHosts?: string[];
   /** Remove the container when it exits. @default false */
   removeOnExit?: boolean;
   /** Start the container after creation/reconciliation. @default false */
@@ -174,6 +181,32 @@ export interface Container extends Resource<
  * const runtime = yield* Docker.inspectContainer(postgresName);
  * ```
  *
+ * ### Host Access
+ * **Example:** Reach a service on the developer's machine
+ * ```typescript
+ * const api = yield* Docker.Container("api", {
+ *   image: "ghcr.io/acme/api:latest",
+ *   // `host-gateway` resolves to the host machine, so a database listening
+ *   // on the developer's loopback is reachable from inside the container.
+ *   extraHosts: ["host.docker.internal:host-gateway"],
+ *   environment: {
+ *     DATABASE_URL: "postgres://postgres@host.docker.internal:5432/app",
+ *   },
+ *   start: true,
+ * });
+ * ```
+ *
+ * **Example:** Publish on any free host port
+ * ```typescript
+ * const api = yield* Docker.Container("api", {
+ *   image: "ghcr.io/acme/api:latest",
+ *   // `external: 0` lets Docker choose; the assigned port is reported back.
+ *   ports: [{ external: 0, internal: 3000 }],
+ *   start: true,
+ * });
+ * const hostPort = api.ports["3000/tcp"];
+ * ```
+ *
  * ### Traefik
  * **Example:** Route a container through Traefik
  * ```typescript
@@ -235,11 +268,11 @@ export const ContainerProvider = () =>
       const reconcileNetworks = Effect.fn(function* (
         live: Docker.Container,
         news: ContainerProps,
+        olds: ContainerProps | undefined,
       ) {
         const context = dockerContextName(news.context);
         const connect = new Map<string, Container.NetworkMapping>();
         const disconnect = new Set<string>();
-        const noop = new Set<string>();
         for (const network of news.networks ?? []) {
           const entry = live.NetworkSettings.Networks?.[network.name];
           if (!entry) {
@@ -249,13 +282,20 @@ export const ContainerProvider = () =>
           ) {
             connect.set(network.name, network);
             disconnect.add(network.name);
-          } else {
-            noop.add(network.name);
           }
         }
-        for (const key of Object.keys(live.NetworkSettings.Networks ?? {})) {
-          if (!noop.has(key)) {
-            disconnect.add(key);
+        // Only networks alchemy itself attached are alchemy's to detach, and
+        // `olds.networks` is the sole record of which those are — the live
+        // container cannot say who connected a network. Sweeping every live
+        // network instead tore off the default `bridge` and anything a user,
+        // compose file, or another tool had attached out of band (#1386).
+        const desired = new Set((news.networks ?? []).map((n) => n.name));
+        for (const network of olds?.networks ?? []) {
+          if (
+            !desired.has(network.name) &&
+            live.NetworkSettings.Networks?.[network.name]
+          ) {
+            disconnect.add(network.name);
           }
         }
         yield* Effect.forEach(
@@ -333,7 +373,7 @@ export const ContainerProvider = () =>
             return { action: "update" as const };
           }
         }),
-        reconcile: Effect.fn(function* ({ id, instanceId, news }) {
+        reconcile: Effect.fn(function* ({ id, instanceId, news, olds }) {
           const context = dockerContextName(news.context);
           const args = yield* makeCreateArgs(id, news, instanceId);
           const live = yield* docker.container
@@ -347,7 +387,7 @@ export const ContainerProvider = () =>
             );
 
           if (live) {
-            yield* reconcileNetworks(live, news);
+            yield* reconcileNetworks(live, news, olds);
             if (news.start && live.State.Status !== "running") {
               yield* docker.container.start(live.Id, context);
             } else if (!news.start && live.State.Status === "running") {
@@ -419,10 +459,17 @@ const makeCreateArgs = (id: string, news: ContainerProps, instanceId: string) =>
         volume: news.volumes?.map(
           (v) => `${v.hostPath}:${v.containerPath}${v.readOnly ? ":ro" : ""}`,
         ),
-        p: news.ports?.map(
-          (port) =>
-            `${port.external}:${port.internal}/${port.protocol ?? "tcp"}`,
-        ),
+        p: news.ports?.map((port) => {
+          const target = `${port.internal}/${port.protocol ?? "tcp"}`;
+          // `external: 0` means "any free host port". Docker spells that as a
+          // bare container port (`-p 80/tcp`); `-p 0:80/tcp` instead asks for
+          // host port 0 literally, which the daemon accepts and then reports
+          // back as 0.
+          return isRandomHostPort(port.external)
+            ? target
+            : `${port.external}:${target}`;
+        }),
+        "add-host": news.extraHosts,
         restart: news.restart ?? "no",
         label: news.labels,
         "stop-timeout": toSeconds(news.stopTimeout)?.toString(),
@@ -463,16 +510,50 @@ const toContainerAttributes = (
   status: info.State.Status,
   createdAt: Date.parse(info.Created) || Date.now(),
   imageRef,
-  ports: Object.fromEntries(
-    Object.entries({
-      ...info.NetworkSettings.Ports,
-      ...info.HostConfig.PortBindings,
-    }).flatMap(([internal, bindings]) => {
-      if (!bindings?.[0]?.HostPort) return [];
-      return [[internal, Number.parseInt(bindings[0].HostPort, 10)]];
-    }),
-  ),
+  ports: toPortAttributes(info),
 });
+
+/** First binding that carries a real (non-zero) host port. */
+const boundHostPort = (
+  bindings: ReadonlyArray<{ HostPort?: string }> | null | undefined,
+): number | undefined => {
+  for (const binding of bindings ?? []) {
+    if (!binding.HostPort) continue;
+    const port = Number.parseInt(binding.HostPort, 10);
+    if (Number.isInteger(port) && port > 0) return port;
+  }
+  return undefined;
+};
+
+/**
+ * `HostConfig.PortBindings` is what was *requested*, `NetworkSettings.Ports`
+ * what Docker actually *assigned* — so the assignment wins wherever both
+ * exist. A container published with `external: 0` (or any random-publish
+ * mapping) has no requested host port at all, and reading the request over
+ * the assignment reported 0 instead of the port the container is reachable
+ * on. The request is still the fallback: a created-but-not-yet-started
+ * container has empty `NetworkSettings.Ports`.
+ */
+const toPortAttributes = (info: Docker.Container): Record<string, number> => {
+  const ports: Record<string, number> = {};
+  for (const [internal, bindings] of Object.entries(
+    info.HostConfig.PortBindings ?? {},
+  )) {
+    const port = boundHostPort(bindings);
+    if (port !== undefined) ports[internal] = port;
+  }
+  for (const [internal, bindings] of Object.entries(
+    info.NetworkSettings.Ports ?? {},
+  )) {
+    const port = boundHostPort(bindings);
+    if (port !== undefined) ports[internal] = port;
+  }
+  return ports;
+};
+
+/** `external: 0` / `"0"` asks Docker to pick any free host port. */
+const isRandomHostPort = (external: number | string): boolean =>
+  Number.parseInt(String(external), 10) === 0;
 
 const normalizeEnvironment = (
   environment: Record<string, string | Redacted.Redacted<string>> | undefined,

--- a/packages/alchemy/src/Docker/Docker.ts
+++ b/packages/alchemy/src/Docker/Docker.ts
@@ -51,6 +51,8 @@ export class Docker extends Context.Service<
         "health-start-interval": string | undefined;
         "stop-timeout": string | undefined;
         p: Array<string> | undefined;
+        /** `--add-host` entries, each `hostname:address`. */
+        "add-host"?: Array<string> | undefined;
         command: Array<string> | undefined;
         label?: Record<string, string>;
         context?: string;
@@ -397,6 +399,7 @@ export declare namespace Docker {
         Array<{ HostIp: string; HostPort: string }> | null
       > | null;
       Binds: string[] | null;
+      ExtraHosts: string[] | null;
       RestartPolicy: {
         Name: string;
         MaximumRetryCount: number;

--- a/packages/alchemy/test/Docker/Container.test.ts
+++ b/packages/alchemy/test/Docker/Container.test.ts
@@ -401,4 +401,107 @@ describe("Docker.Container", { concurrent: false }, () => {
       expect(health?.StartPeriod).toBe(1_000_000_000);
     }),
   );
+  test.provider(
+    "reports the host port Docker assigned to a random publish (#1388)",
+    (stack) =>
+      Effect.gen(function* () {
+        const docker = yield* Docker.Docker;
+        const container = yield* stack.deploy(
+          Docker.Container("random-port-container", {
+            image: "nginx:alpine",
+            // `external: 0` = "any free host port".
+            ports: [{ external: 0, internal: 80 }],
+            start: true,
+          }),
+        );
+
+        // Before the fix this was 0: the create arg asked for host port 0
+        // literally, and the requested binding was then reported over the
+        // assigned one.
+        const assigned = container.ports["80/tcp"];
+        expect(assigned).toBeGreaterThan(0);
+
+        // …and it is the port the container is actually published on.
+        const runtime = yield* docker.container.inspect(container.name);
+        expect(runtime?.NetworkSettings.Ports?.["80/tcp"]).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ HostPort: `${assigned}` }),
+          ]),
+        );
+      }),
+  );
+
+  test.provider("forwards extra hosts to the container (#1387)", (stack) =>
+    Effect.gen(function* () {
+      const docker = yield* Docker.Docker;
+      const container = yield* stack.deploy(
+        Docker.Container("extra-hosts-container", {
+          image: "nginx:alpine",
+          extraHosts: [
+            "host.docker.internal:host-gateway",
+            "db.internal:10.1.2.3",
+          ],
+          start: true,
+        }),
+      );
+
+      const runtime = yield* docker.container.inspect(container.name);
+      expect(runtime?.HostConfig.ExtraHosts).toEqual(
+        expect.arrayContaining([
+          "host.docker.internal:host-gateway",
+          "db.internal:10.1.2.3",
+        ]),
+      );
+    }),
+  );
+
+  test.provider(
+    "disconnects only the networks alchemy connected (#1386)",
+    (stack) =>
+      Effect.gen(function* () {
+        const docker = yield* Docker.Docker;
+        const foreign = "alchemy-test-foreign-network";
+
+        const deploy = (attach: boolean) =>
+          stack.deploy(
+            Effect.gen(function* () {
+              const network = yield* Docker.Network("managed-network");
+              const container = yield* Docker.Container("managed-container", {
+                image: "nginx:alpine",
+                networks: attach ? [{ name: network.name }] : [],
+              });
+              return { container, network };
+            }),
+          );
+
+        const first = yield* deploy(true);
+
+        // A network alchemy never connected the container to — the case a
+        // user, compose file, or another tool creates.
+        yield* docker.network
+          .create({ name: foreign, driver: "bridge" })
+          .pipe(Effect.ignore);
+        yield* Effect.addFinalizer(() =>
+          docker.network.remove(foreign).pipe(Effect.ignore),
+        );
+        yield* docker.network.connect({
+          network: foreign,
+          container: first.container.name,
+        });
+
+        // Drop the managed network from the desired state.
+        const second = yield* deploy(false);
+        expect(second.container.id).toBe(first.container.id);
+
+        const info = yield* docker.container.inspect(second.container.name);
+        const attached = Object.keys(info?.NetworkSettings.Networks ?? {});
+        // Ours goes…
+        expect(attached).not.toContain(first.network.name);
+        // …the foreign one and Docker's own default stay. Before the fix the
+        // reconciler swept every live network and tore off both.
+        expect(attached).toContain(foreign);
+        expect(attached).toContain("bridge");
+      }),
+    { timeout: 240_000 },
+  );
 });


### PR DESCRIPTION
Three independent `Docker.Container` bugs, each with a regression test that fails without its fix.

### Assigned host port reported as 0 (#1388)

`external: 0` means "any free host port". The create arg asked for host port 0 literally, and `toContainerAttributes` then overlaid the *requested* bindings on top of the *assigned* ones:

```diff
-p: news.ports?.map((port) => `${port.external}:${port.internal}/${port.protocol ?? "tcp"}`)
+// `-p 80/tcp` (random publish), not `-p 0:80/tcp`
+p: news.ports?.map((port) => isRandomHostPort(port.external) ? target : `${port.external}:${target}`)

-ports: { ...info.NetworkSettings.Ports, ...info.HostConfig.PortBindings }  // request wins
+ports: toPortAttributes(info)                                             // assignment wins
```

The request stays the fallback — a created-but-not-started container has empty `NetworkSettings.Ports`.

Before: `expected 0 to be greater than 0`.

### No way to set extra hosts (#1387)

Added `extraHosts?: string[]`, forwarded as `--add-host`:

```ts
Docker.Container("api", {
  image: "ghcr.io/acme/api:latest",
  extraHosts: ["host.docker.internal:host-gateway"],
});
```

Before: `expected null to equal ArrayContaining [ "host.docker.internal:host-gateway" ]`.

### Reconciliation disconnected foreign networks (#1386)

Removals were derived from every *live* network, so anything alchemy had not connected was torn off — including Docker's default `bridge`. They now come from `olds.networks`, the only record of what alchemy itself attached; the live container cannot say who connected a network.

Before, after dropping one managed network, the container was left with **no networks at all**: `expected [ ] to contain "alchemy-test-foreign-network"`.
