### PR TITLE
fix(cloudflare): route asset upload sessions to the dispatch-namespace endpoint

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/Assets.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Assets.ts
@@ -1,4 +1,5 @@
 import * as workers from "@distilled.cloud/cloudflare/workers";
+import * as wfp from "@distilled.cloud/cloudflare/workers-for-platforms";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
@@ -428,10 +429,10 @@ export const uploadAssets = Effect.fn(function* (
   workerName: string,
   assets: AssetReadResult,
   { note }: ScopedPlanStatusSession,
+  dispatchNamespace?: string,
 ) {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
-  const createScriptAssetUpload = yield* workers.createScriptAssetUpload;
   const createAssetUpload = yield* workers.createAssetUpload;
 
   // Manifest keys are the paths Cloudflare *serves*, so they carry the
@@ -463,11 +464,18 @@ export const uploadAssets = Effect.fn(function* (
   // the completion JWT directly.
   const runSession = Effect.fn(function* () {
     yield* note("Checking assets...");
-    const session = yield* createScriptAssetUpload({
-      accountId,
-      scriptName: workerName,
-      manifest: assets.manifest,
-    });
+    const session = dispatchNamespace
+      ? yield* wfp.createDispatchNamespaceScriptAssetUpload({
+          accountId,
+          dispatchNamespace,
+          scriptName: workerName,
+          manifest: assets.manifest,
+        })
+      : yield* workers.createScriptAssetUpload({
+          accountId,
+          scriptName: workerName,
+          manifest: assets.manifest,
+        });
     if (!session.buckets?.length) {
       if (!session.jwt) {
         return yield* new AssetUploadSessionError({

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -3234,6 +3234,7 @@ export const LiveWorkerProvider = () =>
               name,
               assets,
               session,
+              dispatchNamespace,
             );
             metadataAssets = {
               jwt,

--- a/packages/alchemy/test/Cloudflare/WorkersForPlatforms/DispatchNamespace.test.ts
+++ b/packages/alchemy/test/Cloudflare/WorkersForPlatforms/DispatchNamespace.test.ts
@@ -6,6 +6,8 @@ import * as Test from "@/Test/Alchemy";
 import * as wfp from "@distilled.cloud/cloudflare/workers-for-platforms";
 import { expect } from "alchemy-test";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
 import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
 
@@ -176,6 +178,93 @@ test.provider(
       yield* expectNamespaceGone(accountId, namespaceName);
     }).pipe(logLevel),
   { timeout: 120_000 },
+);
+
+const assetsNamespaceName = "alchemy-wfp-assets-test-ns";
+
+// Read-after-create: a just-uploaded script can briefly 404 (or come back
+// with `script: null`) from the out-of-band read — poll (bounded) until the
+// script is visible with `has_assets` set.
+const expectScriptWithAssets = (
+  accountId: string,
+  namespace: string,
+  scriptName: string,
+) =>
+  poll({
+    description: "namespace script is visible with assets",
+    effect: getScript(accountId, namespace, scriptName).pipe(
+      Effect.map((response) => response.script),
+      Effect.catchTag(
+        ["DispatchNamespaceNotFound", "DispatchNamespaceScriptNotFound"],
+        () => Effect.succeed(null),
+      ),
+    ),
+    predicate: (script) => script?.id === scriptName && !!script.hasAssets,
+    schedule: Schedule.max([
+      Schedule.exponential("500 millis"),
+      Schedule.recurs(10),
+    ]),
+  });
+
+// One program deploying the namespace and a user Worker with static assets
+// into it. The Worker's props reference the namespace's output name, so the
+// engine orders the Worker last on deploy (and first on destroy).
+const assetsProgram = (assetsDir: string) =>
+  Effect.gen(function* () {
+    const namespace = yield* Cloudflare.WorkersForPlatforms.DispatchNamespace(
+      "AssetsNs",
+      { name: assetsNamespaceName },
+    );
+    const worker = yield* Cloudflare.Worker("WfpAssetsWorker", {
+      namespace: namespace.name,
+      script: `export default { fetch: () => new Response("ok") };`,
+      assets: assetsDir,
+    });
+    return { namespace, worker };
+  });
+
+// The asset upload session must be created on the dispatch-namespace
+// endpoint — an account-level session's JWT is scoped to the wrong script
+// identity and the namespaced script PUT rejects it, on both the fresh
+// deploy and the changed-asset redeploy.
+test.provider(
+  "uploads assets for a Worker deployed into a dispatch namespace",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* yield* CloudflareEnvironment;
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+
+      yield* stack.destroy();
+
+      const dir = yield* fs.makeTempDirectory({
+        prefix: "alchemy-wfp-assets-",
+      });
+      yield* fs.writeFileString(
+        path.join(dir, "index.html"),
+        "<html><body>alchemy-wfp-assets-index</body></html>",
+      );
+
+      const initial = yield* stack.deploy(assetsProgram(dir));
+      const workerName = initial.worker.workerName;
+
+      yield* expectScriptWithAssets(accountId, assetsNamespaceName, workerName);
+
+      yield* fs.writeFileString(
+        path.join(dir, "index.html"),
+        "<html><body>alchemy-wfp-assets-index-v2</body></html>",
+      );
+      const updated = yield* stack.deploy(assetsProgram(dir));
+      expect(updated.worker.workerName).toEqual(workerName);
+
+      yield* expectScriptWithAssets(accountId, assetsNamespaceName, workerName);
+
+      yield* stack.destroy();
+
+      yield* expectScriptGone(accountId, assetsNamespaceName, workerName);
+      yield* expectNamespaceGone(accountId, assetsNamespaceName);
+    }).pipe(logLevel),
+  { timeout: 240_000 },
 );
 
 test.provider(


### PR DESCRIPTION
Asset upload sessions for Workers deployed into a dispatch namespace were created on the account-level endpoint, so the completion JWT comes back scoped to the wrong script identity and the namespaced script PUT is rejected (400 on a new script, 500 on an existing one).

`uploadAssets` now takes the namespace and picks the endpoint the same way the namespace-aware helpers in `WorkerProvider` already do (`putWorkerScript`, `getScriptSettings`, `deleteWorkerScript`):

```ts
const session = dispatchNamespace
  ? yield* wfp.createDispatchNamespaceScriptAssetUpload({
      accountId,
      dispatchNamespace,
      scriptName: workerName,
      manifest: assets.manifest,
    })
  : yield* workers.createScriptAssetUpload({
      accountId,
      scriptName: workerName,
      manifest: assets.manifest,
    });
```

The version-upload call site is unchanged: namespaced scripts have no versions API and the provider already rejects `version` + `namespace`.

We run this change in production as a patch over `2.0.0-beta.72` (Workers for Platforms platform publishing sites into a dispatch namespace, static assets + prebuilt SSR workers); with it, `Worker` with `namespace` and `assets` deploys end to end.
